### PR TITLE
:core:data — OpenMeteoClient (free, key-less weather)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,8 @@ jobs:
         with:
           cache-read-only: ${{ github.ref != 'refs/heads/main' }}
 
-      - name: Run :core:domain tests
-        run: ./gradlew :core:domain:test --stacktrace
+      - name: Run unit tests
+        run: ./gradlew :core:domain:test :core:data:test --stacktrace
 
       - name: Upload test reports
         if: always()

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -1,0 +1,33 @@
+plugins {
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.kotlin.serialization)
+}
+
+kotlin {
+    jvmToolchain(21)
+}
+
+dependencies {
+    implementation(project(":core:domain"))
+    implementation(libs.kotlinx.coroutines.core)
+    implementation(libs.kotlinx.serialization.json)
+    implementation(libs.ktor.client.core)
+    implementation(libs.ktor.client.content.negotiation)
+    implementation(libs.ktor.serialization.kotlinx.json)
+
+    testImplementation(platform("org.junit:junit-bom:5.11.3"))
+    testImplementation(libs.junit.jupiter.api)
+    testImplementation(libs.junit.jupiter.params)
+    testRuntimeOnly(libs.junit.jupiter.engine)
+    testImplementation(libs.kotest.assertions.core)
+    testImplementation(libs.mockk)
+    testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.ktor.client.mock)
+}
+
+tasks.withType<Test>().configureEach {
+    useJUnitPlatform()
+    testLogging {
+        events("passed", "skipped", "failed")
+    }
+}

--- a/core/data/src/main/kotlin/com/adaptweather/core/data/weather/OpenMeteoClient.kt
+++ b/core/data/src/main/kotlin/com/adaptweather/core/data/weather/OpenMeteoClient.kt
@@ -1,0 +1,45 @@
+package com.adaptweather.core.data.weather
+
+import com.adaptweather.core.domain.model.Location
+import com.adaptweather.core.domain.repository.ForecastBundle
+import com.adaptweather.core.domain.repository.WeatherRepository
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import io.ktor.client.request.parameter
+import io.ktor.http.URLProtocol
+import io.ktor.http.path
+
+internal const val OPEN_METEO_HOST = "api.open-meteo.com"
+
+/**
+ * Open-Meteo `forecast` endpoint with past_days=1&forecast_days=1, returning yesterday's
+ * actuals plus today's forecast in one call. Free, key-less. Free-tier soft cap is 10k
+ * requests/day; this app makes one call per device per day.
+ */
+class OpenMeteoClient(private val httpClient: HttpClient) : WeatherRepository {
+    override suspend fun fetchForecast(location: Location): ForecastBundle {
+        val response: OpenMeteoResponse = httpClient.get {
+            url {
+                protocol = URLProtocol.HTTPS
+                host = OPEN_METEO_HOST
+                path("v1", "forecast")
+            }
+            parameter("latitude", location.latitude)
+            parameter("longitude", location.longitude)
+            parameter("past_days", 1)
+            parameter("forecast_days", 1)
+            parameter("timezone", "auto")
+            parameter(
+                "daily",
+                "temperature_2m_min,temperature_2m_max,precipitation_probability_max,precipitation_sum,weather_code",
+            )
+            parameter(
+                "hourly",
+                "temperature_2m,precipitation_probability,weather_code",
+            )
+        }.body()
+
+        return OpenMeteoMapper.toBundle(response)
+    }
+}

--- a/core/data/src/main/kotlin/com/adaptweather/core/data/weather/OpenMeteoDto.kt
+++ b/core/data/src/main/kotlin/com/adaptweather/core/data/weather/OpenMeteoDto.kt
@@ -1,0 +1,36 @@
+package com.adaptweather.core.data.weather
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Wire types for the Open-Meteo `forecast` endpoint with `past_days=1&forecast_days=1`.
+ * Daily index 0 is yesterday, index 1 is today. Hourly spans both days.
+ *
+ * Open-Meteo emits null inside the array when a value is unavailable for a given hour;
+ * the parser must tolerate this.
+ */
+@Serializable
+internal data class OpenMeteoResponse(
+    @SerialName("timezone") val timezone: String,
+    @SerialName("daily") val daily: DailyData,
+    @SerialName("hourly") val hourly: HourlyData,
+)
+
+@Serializable
+internal data class DailyData(
+    @SerialName("time") val time: List<String>,
+    @SerialName("temperature_2m_min") val temperatureMin: List<Double?>,
+    @SerialName("temperature_2m_max") val temperatureMax: List<Double?>,
+    @SerialName("precipitation_probability_max") val precipitationProbabilityMax: List<Int?>,
+    @SerialName("precipitation_sum") val precipitationSum: List<Double?>,
+    @SerialName("weather_code") val weatherCode: List<Int?>,
+)
+
+@Serializable
+internal data class HourlyData(
+    @SerialName("time") val time: List<String>,
+    @SerialName("temperature_2m") val temperature: List<Double?>,
+    @SerialName("precipitation_probability") val precipitationProbability: List<Int?>,
+    @SerialName("weather_code") val weatherCode: List<Int?>,
+)

--- a/core/data/src/main/kotlin/com/adaptweather/core/data/weather/OpenMeteoMapper.kt
+++ b/core/data/src/main/kotlin/com/adaptweather/core/data/weather/OpenMeteoMapper.kt
@@ -1,0 +1,57 @@
+package com.adaptweather.core.data.weather
+
+import com.adaptweather.core.domain.model.DailyForecast
+import com.adaptweather.core.domain.model.HourlyForecast
+import com.adaptweather.core.domain.repository.ForecastBundle
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+
+/**
+ * Maps an [OpenMeteoResponse] (queried with past_days=1&forecast_days=1) into a
+ * [ForecastBundle]. Index 0 in the daily arrays is yesterday, index 1 is today.
+ * The hourly stream covers both days; we only attach today's hours to the today
+ * forecast (yesterday's hourlies are not needed by the prompt).
+ */
+internal object OpenMeteoMapper {
+    fun toBundle(response: OpenMeteoResponse): ForecastBundle {
+        require(response.daily.time.size >= 2) {
+            "Open-Meteo response must include 2 daily entries (yesterday + today); got ${response.daily.time.size}"
+        }
+
+        val yesterdayDate = LocalDate.parse(response.daily.time[0])
+        val todayDate = LocalDate.parse(response.daily.time[1])
+
+        val yesterday = response.daily.toForecast(index = 0, date = yesterdayDate, hourly = emptyList())
+        val todayHourly = response.hourly.forDate(todayDate)
+        val today = response.daily.toForecast(index = 1, date = todayDate, hourly = todayHourly)
+
+        return ForecastBundle(today = today, yesterday = yesterday)
+    }
+
+    private fun DailyData.toForecast(index: Int, date: LocalDate, hourly: List<HourlyForecast>): DailyForecast =
+        DailyForecast(
+            date = date,
+            temperatureMinC = temperatureMin[index] ?: 0.0,
+            temperatureMaxC = temperatureMax[index] ?: 0.0,
+            precipitationProbabilityMaxPct = (precipitationProbabilityMax[index] ?: 0).toDouble(),
+            precipitationMmTotal = precipitationSum[index] ?: 0.0,
+            condition = WmoCodeMapper.map(weatherCode[index]),
+            hourly = hourly,
+        )
+
+    private fun HourlyData.forDate(date: LocalDate): List<HourlyForecast> {
+        val out = ArrayList<HourlyForecast>(24)
+        for (i in time.indices) {
+            val ts = LocalDateTime.parse(time[i])
+            if (ts.toLocalDate() != date) continue
+            out += HourlyForecast(
+                time = LocalTime.of(ts.hour, ts.minute),
+                temperatureC = temperature[i] ?: 0.0,
+                precipitationProbabilityPct = (precipitationProbability[i] ?: 0).toDouble(),
+                condition = WmoCodeMapper.map(weatherCode[i]),
+            )
+        }
+        return out
+    }
+}

--- a/core/data/src/main/kotlin/com/adaptweather/core/data/weather/WmoCodeMapper.kt
+++ b/core/data/src/main/kotlin/com/adaptweather/core/data/weather/WmoCodeMapper.kt
@@ -1,0 +1,22 @@
+package com.adaptweather.core.data.weather
+
+import com.adaptweather.core.domain.model.WeatherCondition
+
+/**
+ * WMO weather interpretation code → coarse [WeatherCondition] bucket.
+ * Reference: https://open-meteo.com/en/docs (search "WMO Weather interpretation codes").
+ */
+internal object WmoCodeMapper {
+    fun map(code: Int?): WeatherCondition = when (code) {
+        null -> WeatherCondition.UNKNOWN
+        0, 1 -> WeatherCondition.CLEAR
+        2 -> WeatherCondition.PARTLY_CLOUDY
+        3 -> WeatherCondition.CLOUDY
+        45, 48 -> WeatherCondition.FOG
+        51, 53, 55, 56, 57 -> WeatherCondition.DRIZZLE
+        61, 63, 65, 66, 67, 80, 81, 82 -> WeatherCondition.RAIN
+        71, 73, 75, 77, 85, 86 -> WeatherCondition.SNOW
+        95, 96, 99 -> WeatherCondition.THUNDERSTORM
+        else -> WeatherCondition.UNKNOWN
+    }
+}

--- a/core/data/src/test/kotlin/com/adaptweather/core/data/weather/OpenMeteoClientTest.kt
+++ b/core/data/src/test/kotlin/com/adaptweather/core/data/weather/OpenMeteoClientTest.kt
@@ -1,0 +1,92 @@
+package com.adaptweather.core.data.weather
+
+import com.adaptweather.core.domain.model.Location
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldContainAll
+import io.kotest.matchers.shouldBe
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.HttpRequestData
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.utils.io.ByteReadChannel
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Test
+
+class OpenMeteoClientTest {
+    private val london = Location(latitude = 51.5074, longitude = -0.1278, displayName = "London")
+
+    private fun fixtureBytes(): ByteReadChannel {
+        val text = checkNotNull(javaClass.getResourceAsStream("/openmeteo_london.json")) {
+            "fixture missing"
+        }.bufferedReader().readText()
+        return ByteReadChannel(text)
+    }
+
+    private fun mockClient(captureRequest: (HttpRequestData) -> Unit): HttpClient {
+        val engine = MockEngine { request ->
+            captureRequest(request)
+            respond(
+                content = fixtureBytes(),
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+        return HttpClient(engine) {
+            install(ContentNegotiation) {
+                json(Json { ignoreUnknownKeys = true })
+            }
+        }
+    }
+
+    @Test
+    fun `request hits open-meteo with required parameters`() = runTest {
+        var captured: HttpRequestData? = null
+        val client = OpenMeteoClient(mockClient { captured = it })
+
+        client.fetchForecast(london)
+
+        val req = checkNotNull(captured)
+        req.url.host shouldBe OPEN_METEO_HOST
+        req.url.encodedPath shouldBe "/v1/forecast"
+
+        val params = req.url.parameters
+        params["latitude"] shouldBe "51.5074"
+        params["longitude"] shouldBe "-0.1278"
+        params["past_days"] shouldBe "1"
+        params["forecast_days"] shouldBe "1"
+        params["timezone"] shouldBe "auto"
+
+        val daily = checkNotNull(params["daily"]).split(",")
+        daily.shouldContainAll(
+            listOf(
+                "temperature_2m_min",
+                "temperature_2m_max",
+                "precipitation_probability_max",
+                "precipitation_sum",
+                "weather_code",
+            ),
+        )
+
+        val hourly = checkNotNull(params["hourly"]).split(",")
+        hourly.shouldContain("temperature_2m")
+        hourly.shouldContain("precipitation_probability")
+        hourly.shouldContain("weather_code")
+    }
+
+    @Test
+    fun `parses fixture into a forecast bundle`() = runTest {
+        val client = OpenMeteoClient(mockClient { })
+
+        val bundle = client.fetchForecast(london)
+
+        bundle.yesterday.temperatureMaxC shouldBe 18.0
+        bundle.today.temperatureMaxC shouldBe 24.0
+        bundle.today.hourly.size shouldBe 8
+    }
+}

--- a/core/data/src/test/kotlin/com/adaptweather/core/data/weather/OpenMeteoMapperTest.kt
+++ b/core/data/src/test/kotlin/com/adaptweather/core/data/weather/OpenMeteoMapperTest.kt
@@ -1,0 +1,127 @@
+package com.adaptweather.core.data.weather
+
+import com.adaptweather.core.domain.model.WeatherCondition
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.time.LocalTime
+
+class OpenMeteoMapperTest {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private fun loadFixture(): OpenMeteoResponse {
+        val text = checkNotNull(javaClass.getResourceAsStream("/openmeteo_london.json")) {
+            "fixture missing"
+        }.bufferedReader().readText()
+        return json.decodeFromString(text)
+    }
+
+    @Test
+    fun `bundle preserves yesterday and today dates`() {
+        val bundle = OpenMeteoMapper.toBundle(loadFixture())
+
+        bundle.yesterday.date shouldBe LocalDate.of(2026, 4, 24)
+        bundle.today.date shouldBe LocalDate.of(2026, 4, 25)
+    }
+
+    @Test
+    fun `yesterday daily values are mapped`() {
+        val y = OpenMeteoMapper.toBundle(loadFixture()).yesterday
+
+        y.temperatureMinC shouldBe 12.0
+        y.temperatureMaxC shouldBe 18.0
+        y.precipitationProbabilityMaxPct shouldBe 5.0
+        y.precipitationMmTotal shouldBe 0.0
+        y.condition shouldBe WeatherCondition.PARTLY_CLOUDY
+        y.hourly shouldBe emptyList()
+    }
+
+    @Test
+    fun `today daily values are mapped`() {
+        val t = OpenMeteoMapper.toBundle(loadFixture()).today
+
+        t.temperatureMinC shouldBe 16.0
+        t.temperatureMaxC shouldBe 24.0
+        t.precipitationProbabilityMaxPct shouldBe 60.0
+        t.precipitationMmTotal shouldBe 4.5
+        t.condition shouldBe WeatherCondition.RAIN
+    }
+
+    @Test
+    fun `today hourly is filtered to today's date only`() {
+        val t = OpenMeteoMapper.toBundle(loadFixture()).today
+
+        // Fixture has 2 hours on 2026-04-24 + 8 hours on 2026-04-25.
+        t.hourly shouldHaveSize 8
+        t.hourly.first().time shouldBe LocalTime.of(0, 0)
+        t.hourly.last().time shouldBe LocalTime.of(21, 0)
+    }
+
+    @Test
+    fun `peak rain hour is preserved for downstream BuildPrompt`() {
+        val t = OpenMeteoMapper.toBundle(loadFixture()).today
+
+        val peak = t.hourly.maxByOrNull { it.precipitationProbabilityPct }
+        peak shouldNotBe null
+        peak!!.time shouldBe LocalTime.of(15, 0)
+        peak.precipitationProbabilityPct shouldBe 60.0
+        peak.condition shouldBe WeatherCondition.RAIN
+    }
+
+    @Test
+    fun `null temperatures and probabilities are tolerated as zero`() {
+        val sparse = OpenMeteoResponse(
+            timezone = "UTC",
+            daily = DailyData(
+                time = listOf("2026-04-24", "2026-04-25"),
+                temperatureMin = listOf(null, 16.0),
+                temperatureMax = listOf(null, 24.0),
+                precipitationProbabilityMax = listOf(null, null),
+                precipitationSum = listOf(null, 4.5),
+                weatherCode = listOf(null, 63),
+            ),
+            hourly = HourlyData(
+                time = listOf("2026-04-25T15:00"),
+                temperature = listOf(null),
+                precipitationProbability = listOf(null),
+                weatherCode = listOf(null),
+            ),
+        )
+
+        val bundle = OpenMeteoMapper.toBundle(sparse)
+
+        bundle.yesterday.temperatureMinC shouldBe 0.0
+        bundle.yesterday.temperatureMaxC shouldBe 0.0
+        bundle.yesterday.precipitationProbabilityMaxPct shouldBe 0.0
+        bundle.yesterday.condition shouldBe WeatherCondition.UNKNOWN
+        bundle.today.precipitationProbabilityMaxPct shouldBe 0.0
+        bundle.today.hourly.single().temperatureC shouldBe 0.0
+        bundle.today.hourly.single().condition shouldBe WeatherCondition.UNKNOWN
+    }
+
+    @Test
+    fun `rejects responses missing two daily entries`() {
+        val short = OpenMeteoResponse(
+            timezone = "UTC",
+            daily = DailyData(
+                time = listOf("2026-04-25"),
+                temperatureMin = listOf(16.0),
+                temperatureMax = listOf(24.0),
+                precipitationProbabilityMax = listOf(60),
+                precipitationSum = listOf(4.5),
+                weatherCode = listOf(63),
+            ),
+            hourly = HourlyData(emptyList(), emptyList(), emptyList(), emptyList()),
+        )
+
+        try {
+            OpenMeteoMapper.toBundle(short)
+            error("expected IllegalArgumentException")
+        } catch (expected: IllegalArgumentException) {
+            // ok
+        }
+    }
+}

--- a/core/data/src/test/kotlin/com/adaptweather/core/data/weather/WmoCodeMapperTest.kt
+++ b/core/data/src/test/kotlin/com/adaptweather/core/data/weather/WmoCodeMapperTest.kt
@@ -1,0 +1,43 @@
+package com.adaptweather.core.data.weather
+
+import com.adaptweather.core.domain.model.WeatherCondition
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+
+class WmoCodeMapperTest {
+    @ParameterizedTest
+    @CsvSource(
+        "0, CLEAR",
+        "1, CLEAR",
+        "2, PARTLY_CLOUDY",
+        "3, CLOUDY",
+        "45, FOG",
+        "48, FOG",
+        "51, DRIZZLE",
+        "55, DRIZZLE",
+        "57, DRIZZLE",
+        "61, RAIN",
+        "63, RAIN",
+        "65, RAIN",
+        "80, RAIN",
+        "82, RAIN",
+        "71, SNOW",
+        "75, SNOW",
+        "85, SNOW",
+        "95, THUNDERSTORM",
+        "96, THUNDERSTORM",
+        "99, THUNDERSTORM",
+        "100, UNKNOWN",
+        "-1, UNKNOWN",
+    )
+    fun `maps known WMO codes`(code: Int, expected: WeatherCondition) {
+        WmoCodeMapper.map(code) shouldBe expected
+    }
+
+    @Test
+    fun `null code maps to UNKNOWN`() {
+        WmoCodeMapper.map(null) shouldBe WeatherCondition.UNKNOWN
+    }
+}

--- a/core/data/src/test/resources/openmeteo_london.json
+++ b/core/data/src/test/resources/openmeteo_london.json
@@ -1,0 +1,40 @@
+{
+  "latitude": 51.5074,
+  "longitude": -0.1278,
+  "timezone": "Europe/London",
+  "timezone_abbreviation": "BST",
+  "utc_offset_seconds": 3600,
+  "daily_units": {
+    "time": "iso8601",
+    "temperature_2m_min": "°C",
+    "temperature_2m_max": "°C",
+    "precipitation_probability_max": "%",
+    "precipitation_sum": "mm",
+    "weather_code": "wmo code"
+  },
+  "daily": {
+    "time": ["2026-04-24", "2026-04-25"],
+    "temperature_2m_min": [12.0, 16.0],
+    "temperature_2m_max": [18.0, 24.0],
+    "precipitation_probability_max": [5, 60],
+    "precipitation_sum": [0.0, 4.5],
+    "weather_code": [2, 63]
+  },
+  "hourly_units": {
+    "time": "iso8601",
+    "temperature_2m": "°C",
+    "precipitation_probability": "%",
+    "weather_code": "wmo code"
+  },
+  "hourly": {
+    "time": [
+      "2026-04-24T22:00", "2026-04-24T23:00",
+      "2026-04-25T00:00", "2026-04-25T03:00", "2026-04-25T06:00",
+      "2026-04-25T09:00", "2026-04-25T12:00", "2026-04-25T15:00",
+      "2026-04-25T18:00", "2026-04-25T21:00"
+    ],
+    "temperature_2m": [13.0, 12.5, 12.0, 13.0, 16.0, 18.0, 22.0, 22.0, 19.0, 17.0],
+    "precipitation_probability": [0, 0, 0, 0, 5, 10, 30, 60, 30, 5],
+    "weather_code": [2, 2, 2, 2, 2, 2, 3, 63, 51, 2]
+  }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,8 @@ mockk = "1.13.13"
 kotest = "5.9.1"
 turbine = "1.2.0"
 coroutines = "1.9.0"
+ktor = "3.0.2"
+serialization = "1.7.3"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -32,6 +34,14 @@ mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
 kotest-assertions-core = { group = "io.kotest", name = "kotest-assertions-core", version.ref = "kotest" }
 turbine = { group = "app.cash.turbine", name = "turbine", version.ref = "turbine" }
 
+ktor-client-core = { group = "io.ktor", name = "ktor-client-core", version.ref = "ktor" }
+ktor-client-cio = { group = "io.ktor", name = "ktor-client-cio", version.ref = "ktor" }
+ktor-client-content-negotiation = { group = "io.ktor", name = "ktor-client-content-negotiation", version.ref = "ktor" }
+ktor-client-logging = { group = "io.ktor", name = "ktor-client-logging", version.ref = "ktor" }
+ktor-client-mock = { group = "io.ktor", name = "ktor-client-mock", version.ref = "ktor" }
+ktor-serialization-kotlinx-json = { group = "io.ktor", name = "ktor-serialization-kotlinx-json", version.ref = "ktor" }
+kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "serialization" }
+
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 android-library = { id = "com.android.library", version.ref = "agp" }
@@ -39,3 +49,4 @@ kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -25,3 +25,4 @@ dependencyResolutionManagement {
 rootProject.name = "adaptweather"
 
 include(":core:domain")
+include(":core:data")


### PR DESCRIPTION
## Summary

New `:core:data` module (pure Kotlin JVM, KMP-shaped) wraps Open-Meteo's `forecast` endpoint with `past_days=1&forecast_days=1` to return yesterday's actuals + today's forecast in a single call. No API key required.

- `OpenMeteoClient` implements `WeatherRepository` from `:core:domain`
- `WmoCodeMapper` translates WMO weather-interpretation codes to the coarse `WeatherCondition` enum
- `OpenMeteoMapper` builds the `ForecastBundle` and filters hourly data to today only
- Tolerates `null` values inside response arrays (Open-Meteo emits null when a value is unavailable)
- CI now runs `:core:domain:test` and `:core:data:test`

## Test plan

- [x] `WmoCodeMapper` parameterized over the documented WMO code ranges
- [x] `OpenMeteoMapper` golden-file test against a recorded London fixture (`openmeteo_london.json`)
- [x] `OpenMeteoClient` MockEngine test asserts request shape (lat/lon, past_days, daily/hourly fields) and parses the bundle
- [x] All tests green locally
- [ ] CI green
- [ ] Follow-up: `DirectGeminiClient` (BYOK) implementing `InsightGenerator`

https://claude.ai/code/session_01VftWR7DyaaVXHnovkuQwge

---
_Generated by [Claude Code](https://claude.ai/code/session_01VftWR7DyaaVXHnovkuQwge)_