### PR TITLE
:core:data — DirectGeminiClient (BYOK) implementing InsightGenerator

### DIFF
--- a/core/data/src/main/kotlin/com/adaptweather/core/data/insight/DirectGeminiClient.kt
+++ b/core/data/src/main/kotlin/com/adaptweather/core/data/insight/DirectGeminiClient.kt
@@ -1,0 +1,76 @@
+package com.adaptweather.core.data.insight
+
+import com.adaptweather.core.domain.repository.InsightGenerator
+import com.adaptweather.core.domain.usecase.Prompt
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.URLProtocol
+import io.ktor.http.contentType
+import io.ktor.http.path
+
+internal const val GEMINI_HOST = "generativelanguage.googleapis.com"
+internal const val GEMINI_API_VERSION = "v1beta"
+internal const val DEFAULT_GEMINI_MODEL = "gemini-2.5-flash"
+
+/**
+ * BYOK Gemini client: the user's key is read from [keyProvider] (Tink-encrypted
+ * DataStore in production) and sent on every call as `x-goog-api-key`. The key
+ * never leaves the device.
+ *
+ * `temperature = 0.4` keeps outputs neutral but not robotic; `maxOutputTokens = 100`
+ * caps cost per call and the system instruction caps it to a single 25-word sentence.
+ *
+ * Thrown errors propagate to the caller (typically a WorkManager worker, which
+ * decides whether to retry on network failures or skip the day on auth failures).
+ */
+class DirectGeminiClient(
+    private val httpClient: HttpClient,
+    private val keyProvider: KeyProvider,
+    private val model: String = DEFAULT_GEMINI_MODEL,
+    private val temperature: Double = 0.4,
+    private val maxOutputTokens: Int = 100,
+) : InsightGenerator {
+
+    override suspend fun generate(prompt: Prompt): String {
+        val key = keyProvider.get().also {
+            if (it.isBlank()) throw MissingApiKeyException()
+        }
+
+        val response: GenerateContentResponse = httpClient.post {
+            url {
+                protocol = URLProtocol.HTTPS
+                host = GEMINI_HOST
+                path(GEMINI_API_VERSION, "models", "$model:generateContent")
+            }
+            header("x-goog-api-key", key)
+            contentType(ContentType.Application.Json)
+            setBody(
+                GenerateContentRequest(
+                    systemInstruction = SystemInstruction(parts = listOf(Part(prompt.systemInstruction))),
+                    contents = listOf(Content(role = "user", parts = listOf(Part(prompt.userMessage)))),
+                    generationConfig = GenerationConfig(
+                        temperature = temperature,
+                        maxOutputTokens = maxOutputTokens,
+                    ),
+                ),
+            )
+        }.body()
+
+        response.promptFeedback?.blockReason?.let {
+            throw GeminiBlockedException("Prompt blocked: $it")
+        }
+
+        return response.candidates.firstOrNull()
+            ?.content?.parts?.firstOrNull()
+            ?.text
+            ?: throw GeminiEmptyResponseException()
+    }
+}
+
+class GeminiEmptyResponseException : IllegalStateException("Gemini returned no text")
+
+class GeminiBlockedException(message: String) : IllegalStateException(message)

--- a/core/data/src/main/kotlin/com/adaptweather/core/data/insight/GeminiDto.kt
+++ b/core/data/src/main/kotlin/com/adaptweather/core/data/insight/GeminiDto.kt
@@ -1,0 +1,47 @@
+package com.adaptweather.core.data.insight
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Wire types for `generativelanguage.googleapis.com/v1beta/models/{model}:generateContent`.
+ * Field names match Gemini's REST API (camelCase) so kotlinx.serialization needs no
+ * `@SerialName` overrides.
+ */
+@Serializable
+internal data class GenerateContentRequest(
+    val systemInstruction: SystemInstruction,
+    val contents: List<Content>,
+    val generationConfig: GenerationConfig,
+)
+
+@Serializable
+internal data class SystemInstruction(val parts: List<Part>)
+
+@Serializable
+internal data class Content(val role: String, val parts: List<Part>)
+
+@Serializable
+internal data class Part(val text: String)
+
+@Serializable
+internal data class GenerationConfig(
+    val temperature: Double,
+    val maxOutputTokens: Int,
+)
+
+@Serializable
+internal data class GenerateContentResponse(
+    val candidates: List<Candidate> = emptyList(),
+    val promptFeedback: PromptFeedback? = null,
+)
+
+@Serializable
+internal data class Candidate(
+    val content: Content? = null,
+    val finishReason: String? = null,
+)
+
+@Serializable
+internal data class PromptFeedback(
+    val blockReason: String? = null,
+)

--- a/core/data/src/main/kotlin/com/adaptweather/core/data/insight/KeyProvider.kt
+++ b/core/data/src/main/kotlin/com/adaptweather/core/data/insight/KeyProvider.kt
@@ -1,0 +1,15 @@
+package com.adaptweather.core.data.insight
+
+/**
+ * Source of the user's Gemini API key. Implemented by the storage layer in :app
+ * (Tink-encrypted DataStore for v1's BYOK path) and faked in tests.
+ *
+ * Suspend so the implementation may read encrypted storage off the main thread
+ * without exposing thread-affinity to callers.
+ */
+interface KeyProvider {
+    suspend fun get(): String
+}
+
+/** Thrown when no API key has been configured by the user. */
+class MissingApiKeyException : IllegalStateException("Gemini API key has not been configured")

--- a/core/data/src/test/kotlin/com/adaptweather/core/data/insight/DirectGeminiClientTest.kt
+++ b/core/data/src/test/kotlin/com/adaptweather/core/data/insight/DirectGeminiClientTest.kt
@@ -1,0 +1,162 @@
+package com.adaptweather.core.data.insight
+
+import com.adaptweather.core.domain.usecase.Prompt
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.HttpRequestData
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.utils.io.ByteReadChannel
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Test
+
+class DirectGeminiClientTest {
+    private val prompt = Prompt(
+        systemInstruction = "Write one short sentence.",
+        userMessage = "Yesterday: cool. Today: warm. Compare and advise.",
+    )
+
+    private fun mockClient(
+        responseBody: String,
+        captureRequest: (HttpRequestData) -> Unit = {},
+    ): HttpClient {
+        val engine = MockEngine { request ->
+            captureRequest(request)
+            respond(
+                content = ByteReadChannel(responseBody),
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+        return HttpClient(engine) {
+            install(ContentNegotiation) {
+                json(Json { ignoreUnknownKeys = true })
+            }
+        }
+    }
+
+    private class FakeKeyProvider(private val key: String) : KeyProvider {
+        override suspend fun get() = key
+    }
+
+    @Test
+    fun `posts to expected gemini endpoint with key header and json body`() = runTest {
+        var captured: HttpRequestData? = null
+        val client = DirectGeminiClient(
+            httpClient = mockClient(SUCCESS_BODY) { captured = it },
+            keyProvider = FakeKeyProvider("test-key"),
+        )
+
+        client.generate(prompt)
+
+        val req = checkNotNull(captured)
+        req.url.host shouldBe GEMINI_HOST
+        req.url.encodedPath shouldBe "/v1beta/models/gemini-2.5-flash:generateContent"
+        req.headers["x-goog-api-key"] shouldBe "test-key"
+        req.body.contentType.toString().shouldContain("application/json")
+    }
+
+    @Test
+    fun `request body carries system instruction, user message, and generation config`() = runTest {
+        var capturedBody: String? = null
+        val client = DirectGeminiClient(
+            httpClient = mockClient(SUCCESS_BODY) {
+                capturedBody = (it.body as io.ktor.http.content.OutgoingContent.ByteArrayContent)
+                    .bytes()
+                    .toString(Charsets.UTF_8)
+            },
+            keyProvider = FakeKeyProvider("test-key"),
+        )
+
+        client.generate(prompt)
+
+        val body = checkNotNull(capturedBody)
+        body.shouldContain("\"systemInstruction\"")
+        body.shouldContain("Write one short sentence.")
+        body.shouldContain("Yesterday: cool. Today: warm. Compare and advise.")
+        body.shouldContain("\"role\":\"user\"")
+        body.shouldContain("\"temperature\":0.4")
+        body.shouldContain("\"maxOutputTokens\":100")
+    }
+
+    @Test
+    fun `extracts the text from the first candidate`() = runTest {
+        val client = DirectGeminiClient(
+            httpClient = mockClient(SUCCESS_BODY),
+            keyProvider = FakeKeyProvider("test-key"),
+        )
+
+        client.generate(prompt) shouldBe "Warmer than yesterday — go without a jumper."
+    }
+
+    @Test
+    fun `throws MissingApiKeyException when key is blank`() = runTest {
+        val client = DirectGeminiClient(
+            httpClient = mockClient(SUCCESS_BODY),
+            keyProvider = FakeKeyProvider("   "),
+        )
+
+        shouldThrow<MissingApiKeyException> { client.generate(prompt) }
+    }
+
+    @Test
+    fun `throws GeminiEmptyResponseException when no candidates returned`() = runTest {
+        val client = DirectGeminiClient(
+            httpClient = mockClient("""{"candidates":[]}"""),
+            keyProvider = FakeKeyProvider("test-key"),
+        )
+
+        shouldThrow<GeminiEmptyResponseException> { client.generate(prompt) }
+    }
+
+    @Test
+    fun `throws GeminiBlockedException when promptFeedback indicates a block`() = runTest {
+        val client = DirectGeminiClient(
+            httpClient = mockClient("""{"promptFeedback":{"blockReason":"SAFETY"}}"""),
+            keyProvider = FakeKeyProvider("test-key"),
+        )
+
+        val ex = shouldThrow<GeminiBlockedException> { client.generate(prompt) }
+        ex.message!!.shouldContain("SAFETY")
+    }
+
+    @Test
+    fun `honors model override`() = runTest {
+        var captured: HttpRequestData? = null
+        val client = DirectGeminiClient(
+            httpClient = mockClient(SUCCESS_BODY) { captured = it },
+            keyProvider = FakeKeyProvider("test-key"),
+            model = "gemini-2.5-pro",
+        )
+
+        client.generate(prompt)
+
+        captured!!.url.encodedPath shouldBe "/v1beta/models/gemini-2.5-pro:generateContent"
+    }
+
+    private companion object {
+        const val SUCCESS_BODY = """
+            {
+              "candidates": [
+                {
+                  "content": {
+                    "role": "model",
+                    "parts": [
+                      {"text": "Warmer than yesterday — go without a jumper."}
+                    ]
+                  },
+                  "finishReason": "STOP"
+                }
+              ]
+            }
+        """
+    }
+}


### PR DESCRIPTION
## Summary

Completes the Gemini half of `:core:data`. `DirectGeminiClient` implements `InsightGenerator` from `:core:domain` and calls the Gemini REST API with the user's BYOK key.

- `KeyProvider` interface — production impl will be Tink-encrypted DataStore in `:app`; tests fake it
- `DirectGeminiClient` posts to `/v1beta/models/{model}:generateContent` with the key in `x-goog-api-key`. Default model `gemini-2.5-flash`, temperature `0.4`, `maxOutputTokens=100` (sentence is already capped at 25 words by the system instruction)
- Typed errors: `MissingApiKeyException`, `GeminiBlockedException` (safety/policy block via `promptFeedback`), `GeminiEmptyResponseException`
- DTOs match Gemini's camelCase wire format

The whole `GenerateDailyInsight` use case can now be wired end-to-end with `OpenMeteoClient + DirectGeminiClient` once `:app` lands.

## Test plan

- [x] MockEngine asserts endpoint URL, `x-goog-api-key` header, JSON body shape (`systemInstruction`, `contents` with `role: user`, `generationConfig` with `temperature` and `maxOutputTokens`)
- [x] Extracts text from first candidate
- [x] Each error path (`blank key`, `no candidates`, `blocked`)
- [x] Model override flows through to URL
- [x] All 39 unit tests across `:core:domain` and `:core:data` green locally
- [ ] CI green
- [ ] Follow-up: `:core:storage` (Tink + DataStore) impl of `KeyProvider`, then `:app` to plumb everything together

https://claude.ai/code/session_01VftWR7DyaaVXHnovkuQwge

---
_Generated by [Claude Code](https://claude.ai/code/session_01VftWR7DyaaVXHnovkuQwge)_