### PR TITLE
:app — SecureKeyStore (Tink + DataStore) implementing KeyProvider

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         id: gradle
         run: |
           set -o pipefail
-          ./gradlew :core:domain:test :core:data:test --stacktrace --info 2>&1 | tee /tmp/jvm-tests.log
+          ./gradlew :core:domain:test :core:data:test :app:testDebugUnitTest --stacktrace --info 2>&1 | tee /tmp/jvm-tests.log
 
       - name: Post tail of gradle log on failure
         if: failure() && github.event_name == 'pull_request'

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -52,6 +52,12 @@ android {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
         }
     }
+
+    testOptions {
+        unitTests.all {
+            it.useJUnitPlatform()
+        }
+    }
 }
 
 dependencies {
@@ -69,11 +75,24 @@ dependencies {
 
     implementation(libs.kotlinx.coroutines.core)
 
+    // Encrypted on-device storage of the user's Gemini API key.
+    // Tink wraps an Android-Keystore master key around a Tink AEAD keyset; ciphertext
+    // is persisted in DataStore Preferences. EncryptedSharedPreferences is deprecated.
+    implementation(libs.tink.android)
+    implementation(libs.androidx.datastore.preferences)
+
     // Ktor with the OkHttp engine for production HTTP. Tests in :core:data use MockEngine,
     // so the engine choice is :app's concern.
     implementation(libs.ktor.client.core)
     implementation(libs.ktor.client.okhttp)
     implementation(libs.ktor.client.content.negotiation)
     implementation(libs.ktor.serialization.kotlinx.json)
+
+    testImplementation(platform("org.junit:junit-bom:5.11.3"))
+    testImplementation(libs.junit.jupiter.api)
+    testRuntimeOnly(libs.junit.jupiter.engine)
+    testImplementation(libs.kotest.assertions.core)
+    testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.androidx.datastore.preferences.core)
 }
 

--- a/app/src/main/kotlin/com/adaptweather/data/SecureKeyStore.kt
+++ b/app/src/main/kotlin/com/adaptweather/data/SecureKeyStore.kt
@@ -27,7 +27,13 @@ import java.util.Base64
  * 1.1.0-alpha07 — Tink + DataStore is its modern replacement.
  *
  * Constructor takes an [Aead] and a [DataStore] so the class is unit-testable with
- * a fake AEAD and an in-memory DataStore. Production callers use [SecureKeyStore.create].
+ * a fake AEAD and a test DataStore (e.g. temp-file-backed via PreferenceDataStoreFactory).
+ * Production callers use [SecureKeyStore.create].
+ *
+ * `get()` reports any decode or decrypt failure as [MissingApiKeyException] and clears
+ * the stored value. This handles the Keystore master key rotating (factory reset,
+ * device-to-device transfer that doesn't preserve hardware-backed keys, etc.) by asking
+ * the user to re-enter their key, rather than looping on a corrupt ciphertext.
  */
 class SecureKeyStore(
     private val aead: Aead,
@@ -37,8 +43,15 @@ class SecureKeyStore(
     override suspend fun get(): String {
         val ciphertextB64 = dataStore.data.map { it[GEMINI_KEY] }.first()
             ?: throw MissingApiKeyException()
-        val ciphertext = Base64.getDecoder().decode(ciphertextB64)
-        return aead.decrypt(ciphertext, AAD).toString(Charsets.UTF_8)
+        return try {
+            val ciphertext = Base64.getDecoder().decode(ciphertextB64)
+            aead.decrypt(ciphertext, AAD).toString(Charsets.UTF_8)
+        } catch (_: Exception) {
+            // Corrupt ciphertext or unrecoverable Keystore state — drop the bad value so
+            // the next attempt prompts the user to re-enter their key cleanly.
+            clear()
+            throw MissingApiKeyException()
+        }
     }
 
     suspend fun set(key: String) {

--- a/app/src/main/kotlin/com/adaptweather/data/SecureKeyStore.kt
+++ b/app/src/main/kotlin/com/adaptweather/data/SecureKeyStore.kt
@@ -1,0 +1,76 @@
+package com.adaptweather.data
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import com.adaptweather.core.data.insight.KeyProvider
+import com.adaptweather.core.data.insight.MissingApiKeyException
+import com.google.crypto.tink.Aead
+import com.google.crypto.tink.KeyTemplates
+import com.google.crypto.tink.aead.AeadConfig
+import com.google.crypto.tink.integration.android.AndroidKeysetManager
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import java.util.Base64
+
+/**
+ * Encrypted on-device storage of the user's Gemini API key.
+ *
+ * The key is encrypted with a Tink AEAD primitive whose keyset is itself encrypted
+ * by an Android-Keystore master key — so the secret material never appears in
+ * SharedPreferences in plaintext. Ciphertext is persisted in DataStore Preferences.
+ *
+ * EncryptedSharedPreferences is deprecated as of androidx.security:security-crypto
+ * 1.1.0-alpha07 — Tink + DataStore is its modern replacement.
+ *
+ * Constructor takes an [Aead] and a [DataStore] so the class is unit-testable with
+ * a fake AEAD and an in-memory DataStore. Production callers use [SecureKeyStore.create].
+ */
+class SecureKeyStore(
+    private val aead: Aead,
+    private val dataStore: DataStore<Preferences>,
+) : KeyProvider {
+
+    override suspend fun get(): String {
+        val ciphertextB64 = dataStore.data.map { it[GEMINI_KEY] }.first()
+            ?: throw MissingApiKeyException()
+        val ciphertext = Base64.getDecoder().decode(ciphertextB64)
+        return aead.decrypt(ciphertext, AAD).toString(Charsets.UTF_8)
+    }
+
+    suspend fun set(key: String) {
+        val ciphertext = aead.encrypt(key.toByteArray(Charsets.UTF_8), AAD)
+        val ciphertextB64 = Base64.getEncoder().encodeToString(ciphertext)
+        dataStore.edit { it[GEMINI_KEY] = ciphertextB64 }
+    }
+
+    suspend fun clear() {
+        dataStore.edit { it.remove(GEMINI_KEY) }
+    }
+
+    companion object {
+        private val GEMINI_KEY = stringPreferencesKey("gemini_api_key_v1")
+        private val AAD = "adaptweather:gemini_api_key:v1".toByteArray(Charsets.UTF_8)
+
+        private const val MASTER_KEY_URI = "android-keystore://adaptweather_master_key"
+        private const val KEYSET_PREFS = "adaptweather_master_prefs"
+        private const val KEYSET_NAME = "adaptweather_master_keyset"
+
+        fun create(context: Context): SecureKeyStore {
+            AeadConfig.register()
+            val aead: Aead = AndroidKeysetManager.Builder()
+                .withSharedPref(context, KEYSET_NAME, KEYSET_PREFS)
+                .withKeyTemplate(KeyTemplates.get("AES256_GCM"))
+                .withMasterKeyUri(MASTER_KEY_URI)
+                .build()
+                .keysetHandle
+                .getPrimitive(Aead::class.java)
+            return SecureKeyStore(aead, context.secureKeyDataStore)
+        }
+    }
+}
+
+private val Context.secureKeyDataStore: DataStore<Preferences> by preferencesDataStore(name = "secure_key_store")

--- a/app/src/test/kotlin/com/adaptweather/data/SecureKeyStoreTest.kt
+++ b/app/src/test/kotlin/com/adaptweather/data/SecureKeyStoreTest.kt
@@ -3,6 +3,8 @@ package com.adaptweather.data
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
 import com.adaptweather.core.data.insight.MissingApiKeyException
 import com.google.crypto.tink.Aead
 import io.kotest.assertions.throwables.shouldThrow
@@ -62,12 +64,30 @@ class SecureKeyStoreTest {
         val plaintext = "AIzaSyVerySecretValue"
         subject.set(plaintext)
 
-        val storedB64 = dataStore.data.first().asMap().values.single() as String
+        val storedB64 = dataStore.data.first()[GEMINI_KEY_PREFERENCE]
         // ReversibleFakeAead reverses the bytes, so the stored value must be a
         // base64 string that decodes to the reversed plaintext — confirming we
         // pass through the AEAD before persisting.
         storedB64 shouldBe java.util.Base64.getEncoder()
             .encodeToString(plaintext.toByteArray(Charsets.UTF_8).reversedArray())
+    }
+
+    @Test
+    fun `corrupt ciphertext is cleared and reported as MissingApiKeyException`() = runTest {
+        // Simulate a Keystore master-key rotation: the stored ciphertext is no longer
+        // decodeable. The store should drop the bad value and tell callers there's no key.
+        dataStore.edit { it[GEMINI_KEY_PREFERENCE] = "@@@not-valid-base64@@@" }
+
+        shouldThrow<MissingApiKeyException> { subject.get() }
+
+        // And subsequent reads no longer see the corrupt value.
+        dataStore.data.first()[GEMINI_KEY_PREFERENCE] shouldBe null
+    }
+
+    private companion object {
+        // Mirrors SecureKeyStore.GEMINI_KEY (private). Kept in sync deliberately so the
+        // test can assert against the on-disk preference name.
+        val GEMINI_KEY_PREFERENCE = stringPreferencesKey("gemini_api_key_v1")
     }
 }
 

--- a/app/src/test/kotlin/com/adaptweather/data/SecureKeyStoreTest.kt
+++ b/app/src/test/kotlin/com/adaptweather/data/SecureKeyStoreTest.kt
@@ -1,0 +1,85 @@
+package com.adaptweather.data
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import com.adaptweather.core.data.insight.MissingApiKeyException
+import com.google.crypto.tink.Aead
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.nio.file.Path
+
+class SecureKeyStoreTest {
+    @TempDir lateinit var tempDir: Path
+
+    private lateinit var dataStore: DataStore<Preferences>
+    private lateinit var subject: SecureKeyStore
+
+    @BeforeEach
+    fun setUp() {
+        dataStore = PreferenceDataStoreFactory.create(
+            produceFile = { File(tempDir.toFile(), "secure_key.preferences_pb") },
+        )
+        subject = SecureKeyStore(aead = ReversibleFakeAead, dataStore = dataStore)
+    }
+
+    @Test
+    fun `set then get returns the same key`() = runTest {
+        subject.set("AIzaSyExampleKeyValue123")
+
+        subject.get() shouldBe "AIzaSyExampleKeyValue123"
+    }
+
+    @Test
+    fun `get without prior set throws MissingApiKeyException`() = runTest {
+        shouldThrow<MissingApiKeyException> { subject.get() }
+    }
+
+    @Test
+    fun `clear removes the key`() = runTest {
+        subject.set("AIzaSyExampleKeyValue123")
+        subject.clear()
+
+        shouldThrow<MissingApiKeyException> { subject.get() }
+    }
+
+    @Test
+    fun `set replaces the previous key`() = runTest {
+        subject.set("first")
+        subject.set("second")
+
+        subject.get() shouldBe "second"
+    }
+
+    @Test
+    fun `stored ciphertext is not the plaintext key`() = runTest {
+        val plaintext = "AIzaSyVerySecretValue"
+        subject.set(plaintext)
+
+        val storedB64 = dataStore.data.first().asMap().values.single() as String
+        // ReversibleFakeAead reverses the bytes, so the stored value must be a
+        // base64 string that decodes to the reversed plaintext — confirming we
+        // pass through the AEAD before persisting.
+        storedB64 shouldBe java.util.Base64.getEncoder()
+            .encodeToString(plaintext.toByteArray(Charsets.UTF_8).reversedArray())
+    }
+}
+
+/**
+ * Test-only AEAD: encrypt = reverse the bytes; decrypt = reverse again.
+ * Round-trip semantics are sufficient for SecureKeyStore's contract; we don't
+ * test cryptographic strength here (Tink's own tests cover that).
+ */
+private object ReversibleFakeAead : Aead {
+    override fun encrypt(plaintext: ByteArray, associatedData: ByteArray?): ByteArray =
+        plaintext.reversedArray()
+
+    override fun decrypt(ciphertext: ByteArray, associatedData: ByteArray?): ByteArray =
+        ciphertext.reversedArray()
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,8 @@ turbine = "1.2.0"
 coroutines = "1.9.0"
 ktor = "3.0.2"
 serialization = "1.7.3"
+tink = "1.15.0"
+datastore = "1.1.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -42,6 +44,11 @@ ktor-client-logging = { group = "io.ktor", name = "ktor-client-logging", version
 ktor-client-mock = { group = "io.ktor", name = "ktor-client-mock", version.ref = "ktor" }
 ktor-serialization-kotlinx-json = { group = "io.ktor", name = "ktor-serialization-kotlinx-json", version.ref = "ktor" }
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "serialization" }
+
+tink-android = { group = "com.google.crypto.tink", name = "tink-android", version.ref = "tink" }
+
+androidx-datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastore" }
+androidx-datastore-preferences-core = { group = "androidx.datastore", name = "datastore-preferences-core", version.ref = "datastore" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary

Encrypted on-device storage for the user's Gemini API key — the production implementation of `KeyProvider` from `:core:data`.

- **Tink** binds an AES-256-GCM AEAD keyset to an Android Keystore master key (`android-keystore://adaptweather_master_key`) — the secret material itself never appears anywhere in plaintext.
- **DataStore Preferences** persists the resulting ciphertext (base64 of `aead.encrypt(key, AAD)`).
- `EncryptedSharedPreferences` (deprecated since `androidx.security:security-crypto:1.1.0-alpha07`) is intentionally not used.
- `SecureKeyStore` constructor takes `Aead` + `DataStore<Preferences>` so it's unit-testable; `SecureKeyStore.create(context)` is the production factory that wires up Tink + Keystore.

CI now also runs `:app:testDebugUnitTest`.

## Test plan

- [x] Unit tests with a reversible fake `Aead` and an in-memory `PreferenceDataStore` (pure JVM, no Robolectric needed):
  - set then get round-trips
  - get without set throws `MissingApiKeyException`
  - clear removes the key
  - set replaces previous value
  - stored ciphertext is base64 of the AEAD output (not plaintext)
- [ ] CI green
- [ ] Follow-up: `SettingsRepository` (DataStore-backed `UserPreferences`), then `SettingsScreen` Compose UI, then alarm/worker/notification

https://claude.ai/code/session_01VftWR7DyaaVXHnovkuQwge

---
_Generated by [Claude Code](https://claude.ai/code/session_01VftWR7DyaaVXHnovkuQwge)_