### PR TITLE
:app — SettingsRepository (DataStore-backed UserPreferences)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,11 +50,18 @@ jobs:
         with:
           script: |
             const fs = require('fs');
+            const path = '/tmp/jvm-tests.log';
             let body = '_(no log captured)_';
             try {
-              const log = fs.readFileSync('/tmp/jvm-tests.log', 'utf8');
-              const tail = log.split('\n').slice(-200).join('\n');
-              body = '<!-- ci-jvm-tests --> JVM unit tests failed. Last 200 lines:\n\n```\n' + tail + '\n```';
+              const log = fs.readFileSync(path, 'utf8');
+              const lines = log.split('\n');
+              const errorLines = lines.filter(l =>
+                /^(e:|w:| {2}error:|FAILURE:|\* What went wrong:|Caused by:|Compilation error)/.test(l)
+              ).slice(0, 80);
+              const tail = lines.slice(-300).join('\n');
+              body = '<!-- ci-jvm-tests --> JVM unit tests failed.\n\n' +
+                '### Likely error lines\n```\n' + (errorLines.join('\n') || '(none matched)') + '\n```\n' +
+                '### Last 300 lines\n```\n' + tail + '\n```';
             } catch (e) {
               body = 'JVM unit tests failed before gradle started: ' + e.message;
             }
@@ -115,8 +122,14 @@ jobs:
             let body = '_(no log captured)_';
             try {
               const log = fs.readFileSync('/tmp/android-build.log', 'utf8');
-              const tail = log.split('\n').slice(-200).join('\n');
-              body = '<!-- ci-android-build --> Android debug build failed. Last 200 lines:\n\n```\n' + tail + '\n```';
+              const lines = log.split('\n');
+              const errorLines = lines.filter(l =>
+                /^(e:|w:| {2}error:|FAILURE:|\* What went wrong:|Caused by:|Compilation error)/.test(l)
+              ).slice(0, 80);
+              const tail = lines.slice(-300).join('\n');
+              body = '<!-- ci-android-build --> Android debug build failed.\n\n' +
+                '### Likely error lines\n```\n' + (errorLines.join('\n') || '(none matched)') + '\n```\n' +
+                '### Last 300 lines\n```\n' + tail + '\n```';
             } catch (e) {
               body = 'Android debug build failed before gradle started: ' + e.message;
             }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
+    alias(libs.plugins.kotlin.serialization)
 }
 
 android {
@@ -80,6 +81,7 @@ dependencies {
     // is persisted in DataStore Preferences. EncryptedSharedPreferences is deprecated.
     implementation(libs.tink.android)
     implementation(libs.androidx.datastore.preferences)
+    implementation(libs.kotlinx.serialization.json)
 
     // Ktor with the OkHttp engine for production HTTP. Tests in :core:data use MockEngine,
     // so the engine choice is :app's concern.

--- a/app/src/main/kotlin/com/adaptweather/data/SettingsRepository.kt
+++ b/app/src/main/kotlin/com/adaptweather/data/SettingsRepository.kt
@@ -15,6 +15,8 @@ import com.adaptweather.core.domain.model.UserPreferences
 import com.adaptweather.core.domain.model.WardrobeRule
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import java.time.DayOfWeek
 import java.time.LocalTime

--- a/app/src/main/kotlin/com/adaptweather/data/SettingsRepository.kt
+++ b/app/src/main/kotlin/com/adaptweather/data/SettingsRepository.kt
@@ -1,0 +1,112 @@
+package com.adaptweather.data
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.core.stringSetPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import com.adaptweather.core.domain.model.DeliveryMode
+import com.adaptweather.core.domain.model.DistanceUnit
+import com.adaptweather.core.domain.model.Schedule
+import com.adaptweather.core.domain.model.TemperatureUnit
+import com.adaptweather.core.domain.model.UserPreferences
+import com.adaptweather.core.domain.model.WardrobeRule
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlinx.serialization.json.Json
+import java.time.DayOfWeek
+import java.time.LocalTime
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+
+/**
+ * Persists [UserPreferences] in DataStore Preferences.
+ *
+ * `Schedule.zoneId` is intentionally NOT persisted — it's resolved from
+ * [zoneIdProvider] (defaulting to the current system zone) every time the flow
+ * emits. This way, if the user travels or DST flips, the next read picks up the
+ * correct zone without us having to migrate stored data.
+ *
+ * Constructor takes the [DataStore] for unit-test injection;
+ * [SettingsRepository.create] is the production factory.
+ */
+class SettingsRepository(
+    private val dataStore: DataStore<Preferences>,
+    private val zoneIdProvider: () -> ZoneId = { ZoneId.systemDefault() },
+    private val json: Json = Json { ignoreUnknownKeys = true },
+) {
+    val preferences: Flow<UserPreferences> = dataStore.data.map { prefs -> prefs.toUserPreferences() }
+
+    suspend fun setSchedule(time: LocalTime, days: Set<DayOfWeek>) {
+        require(days.isNotEmpty()) { "Schedule must include at least one day" }
+        dataStore.edit { prefs ->
+            prefs[SCHEDULE_TIME] = TIME_FORMAT.format(time)
+            prefs[SCHEDULE_DAYS] = days.map { it.name }.toSet()
+        }
+    }
+
+    suspend fun setDeliveryMode(mode: DeliveryMode) {
+        dataStore.edit { it[DELIVERY_MODE] = mode.name }
+    }
+
+    suspend fun setUnits(temperature: TemperatureUnit, distance: DistanceUnit) {
+        dataStore.edit { prefs ->
+            prefs[TEMPERATURE_UNIT] = temperature.name
+            prefs[DISTANCE_UNIT] = distance.name
+        }
+    }
+
+    suspend fun setWardrobeRules(rules: List<WardrobeRule>) {
+        dataStore.edit { it[WARDROBE_RULES] = json.encodeToString(rules.map { rule -> rule.toDto() }) }
+    }
+
+    private fun Preferences.toUserPreferences(): UserPreferences {
+        val time = this[SCHEDULE_TIME]?.let { LocalTime.parse(it, TIME_FORMAT) }
+            ?: DEFAULT_TIME
+        val days = this[SCHEDULE_DAYS]?.mapNotNull { runCatching { DayOfWeek.valueOf(it) }.getOrNull() }
+            ?.toSet()
+            ?.takeIf { it.isNotEmpty() }
+            ?: Schedule.EVERY_DAY
+        val deliveryMode = this[DELIVERY_MODE]?.let { runCatching { DeliveryMode.valueOf(it) }.getOrNull() }
+            ?: DeliveryMode.NOTIFICATION_ONLY
+        val temperatureUnit = this[TEMPERATURE_UNIT]?.let { runCatching { TemperatureUnit.valueOf(it) }.getOrNull() }
+            ?: TemperatureUnit.CELSIUS
+        val distanceUnit = this[DISTANCE_UNIT]?.let { runCatching { DistanceUnit.valueOf(it) }.getOrNull() }
+            ?: DistanceUnit.KILOMETERS
+        val rules = parseRules(this[WARDROBE_RULES])
+
+        return UserPreferences(
+            schedule = Schedule(time = time, days = days, zoneId = zoneIdProvider()),
+            deliveryMode = deliveryMode,
+            temperatureUnit = temperatureUnit,
+            distanceUnit = distanceUnit,
+            wardrobeRules = rules,
+        )
+    }
+
+    private fun parseRules(raw: String?): List<WardrobeRule> {
+        if (raw.isNullOrBlank()) return WardrobeRule.DEFAULTS
+        return runCatching {
+            json.decodeFromString<List<WardrobeRuleDto>>(raw).map { it.toDomain() }
+        }.getOrDefault(WardrobeRule.DEFAULTS)
+    }
+
+    companion object {
+        private val SCHEDULE_TIME = stringPreferencesKey("schedule_time_hhmm")
+        private val SCHEDULE_DAYS = stringSetPreferencesKey("schedule_days")
+        private val DELIVERY_MODE = stringPreferencesKey("delivery_mode")
+        private val TEMPERATURE_UNIT = stringPreferencesKey("temperature_unit")
+        private val DISTANCE_UNIT = stringPreferencesKey("distance_unit")
+        private val WARDROBE_RULES = stringPreferencesKey("wardrobe_rules_json")
+
+        private val TIME_FORMAT: DateTimeFormatter = DateTimeFormatter.ofPattern("HH:mm")
+        private val DEFAULT_TIME: LocalTime = LocalTime.of(7, 0)
+
+        fun create(context: Context): SettingsRepository =
+            SettingsRepository(context.settingsDataStore)
+    }
+}
+
+private val Context.settingsDataStore: DataStore<Preferences> by preferencesDataStore(name = "settings")

--- a/app/src/main/kotlin/com/adaptweather/data/WardrobeRuleDto.kt
+++ b/app/src/main/kotlin/com/adaptweather/data/WardrobeRuleDto.kt
@@ -1,0 +1,44 @@
+package com.adaptweather.data
+
+import com.adaptweather.core.domain.model.WardrobeRule
+import kotlinx.serialization.Serializable
+
+/**
+ * On-disk representation of a [WardrobeRule]. The domain type uses a sealed interface
+ * for [WardrobeRule.Condition], which is awkward to serialize directly — this DTO
+ * flattens it to (type, value) and round-trips through [toDomain] / [toDto].
+ *
+ * `type` strings are intentionally non-camelCase so they're stable identifiers in JSON
+ * even if class names are renamed.
+ */
+@Serializable
+internal data class WardrobeRuleDto(
+    val item: String,
+    val type: String,
+    val value: Double,
+) {
+    fun toDomain(): WardrobeRule = WardrobeRule(
+        item = item,
+        condition = when (type) {
+            TYPE_TEMP_BELOW -> WardrobeRule.TemperatureBelow(value)
+            TYPE_TEMP_ABOVE -> WardrobeRule.TemperatureAbove(value)
+            TYPE_PRECIP_ABOVE -> WardrobeRule.PrecipitationProbabilityAbove(value)
+            else -> error("Unknown wardrobe rule type: $type")
+        },
+    )
+
+    companion object {
+        const val TYPE_TEMP_BELOW = "temp_below"
+        const val TYPE_TEMP_ABOVE = "temp_above"
+        const val TYPE_PRECIP_ABOVE = "precip_above"
+    }
+}
+
+internal fun WardrobeRule.toDto(): WardrobeRuleDto = when (val c = condition) {
+    is WardrobeRule.TemperatureBelow ->
+        WardrobeRuleDto(item, WardrobeRuleDto.TYPE_TEMP_BELOW, c.celsius)
+    is WardrobeRule.TemperatureAbove ->
+        WardrobeRuleDto(item, WardrobeRuleDto.TYPE_TEMP_ABOVE, c.celsius)
+    is WardrobeRule.PrecipitationProbabilityAbove ->
+        WardrobeRuleDto(item, WardrobeRuleDto.TYPE_PRECIP_ABOVE, c.percent)
+}

--- a/app/src/test/kotlin/com/adaptweather/data/SettingsRepositoryTest.kt
+++ b/app/src/test/kotlin/com/adaptweather/data/SettingsRepositoryTest.kt
@@ -1,0 +1,149 @@
+package com.adaptweather.data
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.core.stringSetPreferencesKey
+import com.adaptweather.core.domain.model.DeliveryMode
+import com.adaptweather.core.domain.model.DistanceUnit
+import com.adaptweather.core.domain.model.Schedule
+import com.adaptweather.core.domain.model.TemperatureUnit
+import com.adaptweather.core.domain.model.WardrobeRule
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.nio.file.Path
+import java.time.DayOfWeek
+import java.time.LocalTime
+import java.time.ZoneId
+
+class SettingsRepositoryTest {
+    @TempDir lateinit var tempDir: Path
+
+    private val zone: ZoneId = ZoneId.of("Europe/London")
+    private lateinit var dataStore: DataStore<Preferences>
+    private lateinit var subject: SettingsRepository
+
+    @BeforeEach
+    fun setUp() {
+        dataStore = PreferenceDataStoreFactory.create(
+            produceFile = { File(tempDir.toFile(), "settings.preferences_pb") },
+        )
+        subject = SettingsRepository(
+            dataStore = dataStore,
+            zoneIdProvider = { zone },
+        )
+    }
+
+    @Test
+    fun `defaults are returned when nothing is stored`() = runTest {
+        val prefs = subject.preferences.first()
+
+        prefs.schedule.time shouldBe LocalTime.of(7, 0)
+        prefs.schedule.days shouldBe Schedule.EVERY_DAY
+        prefs.schedule.zoneId shouldBe zone
+        prefs.deliveryMode shouldBe DeliveryMode.NOTIFICATION_ONLY
+        prefs.temperatureUnit shouldBe TemperatureUnit.CELSIUS
+        prefs.distanceUnit shouldBe DistanceUnit.KILOMETERS
+        prefs.wardrobeRules shouldBe WardrobeRule.DEFAULTS
+    }
+
+    @Test
+    fun `setSchedule round-trips time and days`() = runTest {
+        subject.setSchedule(
+            time = LocalTime.of(6, 30),
+            days = setOf(DayOfWeek.MONDAY, DayOfWeek.WEDNESDAY, DayOfWeek.FRIDAY),
+        )
+
+        val prefs = subject.preferences.first()
+        prefs.schedule.time shouldBe LocalTime.of(6, 30)
+        prefs.schedule.days.shouldContainExactlyInAnyOrder(DayOfWeek.MONDAY, DayOfWeek.WEDNESDAY, DayOfWeek.FRIDAY)
+    }
+
+    @Test
+    fun `setSchedule rejects empty days`() = runTest {
+        shouldThrow<IllegalArgumentException> {
+            subject.setSchedule(LocalTime.of(7, 0), emptySet())
+        }
+    }
+
+    @Test
+    fun `setDeliveryMode round-trips`() = runTest {
+        subject.setDeliveryMode(DeliveryMode.NOTIFICATION_AND_TTS)
+
+        subject.preferences.first().deliveryMode shouldBe DeliveryMode.NOTIFICATION_AND_TTS
+    }
+
+    @Test
+    fun `setUnits round-trips both`() = runTest {
+        subject.setUnits(TemperatureUnit.FAHRENHEIT, DistanceUnit.MILES)
+
+        val prefs = subject.preferences.first()
+        prefs.temperatureUnit shouldBe TemperatureUnit.FAHRENHEIT
+        prefs.distanceUnit shouldBe DistanceUnit.MILES
+    }
+
+    @Test
+    fun `setWardrobeRules round-trips all three condition types`() = runTest {
+        val rules = listOf(
+            WardrobeRule("hat", WardrobeRule.TemperatureBelow(5.0)),
+            WardrobeRule("shorts", WardrobeRule.TemperatureAbove(28.5)),
+            WardrobeRule("brolly", WardrobeRule.PrecipitationProbabilityAbove(40.0)),
+        )
+
+        subject.setWardrobeRules(rules)
+
+        subject.preferences.first().wardrobeRules shouldContainExactly rules
+    }
+
+    @Test
+    fun `setWardrobeRules with empty list persists empty list, not defaults`() = runTest {
+        subject.setWardrobeRules(emptyList())
+
+        subject.preferences.first().wardrobeRules shouldBe emptyList()
+    }
+
+    @Test
+    fun `corrupt wardrobe rules JSON falls back to defaults`() = runTest {
+        dataStore.edit {
+            it[stringPreferencesKey("wardrobe_rules_json")] = "{not valid json["
+        }
+
+        subject.preferences.first().wardrobeRules shouldBe WardrobeRule.DEFAULTS
+    }
+
+    @Test
+    fun `unknown enum names fall back to defaults`() = runTest {
+        dataStore.edit { prefs ->
+            prefs[stringPreferencesKey("delivery_mode")] = "UNKNOWN_MODE"
+            prefs[stringPreferencesKey("temperature_unit")] = "KELVIN"
+            prefs[stringSetPreferencesKey("schedule_days")] = setOf("FUNDAY")
+        }
+
+        val prefs = subject.preferences.first()
+        prefs.deliveryMode shouldBe DeliveryMode.NOTIFICATION_ONLY
+        prefs.temperatureUnit shouldBe TemperatureUnit.CELSIUS
+        prefs.schedule.days shouldBe Schedule.EVERY_DAY
+    }
+
+    @Test
+    fun `zoneId is resolved fresh on each emission`() = runTest {
+        val zones = mutableListOf(ZoneId.of("UTC"), ZoneId.of("America/New_York"))
+        val rotating = SettingsRepository(
+            dataStore = dataStore,
+            zoneIdProvider = { zones.removeAt(0) },
+        )
+
+        rotating.preferences.first().schedule.zoneId shouldBe ZoneId.of("UTC")
+        rotating.preferences.first().schedule.zoneId shouldBe ZoneId.of("America/New_York")
+    }
+}


### PR DESCRIPTION
## Summary

DataStore-backed persistence for `UserPreferences` — schedule (time + days), delivery mode, units, and wardrobe rules.

- **`WardrobeRuleDto`** flattens `WardrobeRule.Condition` (sealed) into a `(type, value)` tuple for a stable JSON shape independent of class renames
- **`SettingsRepository`** exposes a `Flow<UserPreferences>` and per-section setters
- **Schedule.zoneId is intentionally not persisted** — resolved from `zoneIdProvider` (defaults to `ZoneId.systemDefault()`) on every emission, so travelling and DST changes are picked up without data migration
- **Resilience**: corrupt JSON, unknown enum names, and empty day sets fall back to defaults rather than crashing
- Constructor takes `DataStore<Preferences>` for unit-test injection; `SettingsRepository.create(context)` is the production factory

## Test plan

- [x] Defaults (when nothing stored) → `Schedule.default`, `NOTIFICATION_ONLY`, `CELSIUS`, `KILOMETERS`, `WardrobeRule.DEFAULTS`
- [x] Each setter round-trips
- [x] All three rule condition types (`TempBelow`, `TempAbove`, `PrecipAbove`) survive JSON round-trip
- [x] `setSchedule(empty days)` rejected
- [x] `setWardrobeRules(emptyList())` persists empty (not defaults)
- [x] Corrupt JSON in `wardrobe_rules_json` → falls back to `DEFAULTS`
- [x] Unknown enum names → fall back to defaults
- [x] zoneId is resolved fresh on each emission (rotating provider test)
- [ ] CI green
- [ ] Follow-up: `SettingsScreen` + `ViewModel` (Compose UI), then alarm/worker/notification

https://claude.ai/code/session_01VftWR7DyaaVXHnovkuQwge

---
_Generated by [Claude Code](https://claude.ai/code/session_01VftWR7DyaaVXHnovkuQwge)_