### PR TITLE
:app — SettingsViewModel + minimal SettingsScreen (Compose)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -67,6 +67,9 @@ dependencies {
 
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
+    implementation(libs.androidx.lifecycle.runtime.compose)
+    implementation(libs.androidx.lifecycle.viewmodel.compose)
+    implementation(libs.androidx.lifecycle.viewmodel.ktx)
     implementation(libs.androidx.activity.compose)
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.compose.ui)

--- a/app/src/main/kotlin/com/adaptweather/AdaptWeatherApplication.kt
+++ b/app/src/main/kotlin/com/adaptweather/AdaptWeatherApplication.kt
@@ -1,5 +1,14 @@
 package com.adaptweather
 
 import android.app.Application
+import com.adaptweather.data.SecureKeyStore
+import com.adaptweather.data.SettingsRepository
 
-class AdaptWeatherApplication : Application()
+/**
+ * Lightweight DI: lazy singletons for repositories that depend on Android Context.
+ * Will move to Hilt once we have more than a handful of consumers.
+ */
+class AdaptWeatherApplication : Application() {
+    val secureKeyStore: SecureKeyStore by lazy { SecureKeyStore.create(this) }
+    val settingsRepository: SettingsRepository by lazy { SettingsRepository.create(this) }
+}

--- a/app/src/main/kotlin/com/adaptweather/MainActivity.kt
+++ b/app/src/main/kotlin/com/adaptweather/MainActivity.kt
@@ -3,53 +3,34 @@ package com.adaptweather
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.adaptweather.ui.settings.SettingsScreen
+import com.adaptweather.ui.settings.SettingsViewModel
 import com.adaptweather.ui.theme.AdaptWeatherTheme
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        val app = application as AdaptWeatherApplication
         setContent {
             AdaptWeatherTheme {
                 Surface(
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background,
                 ) {
-                    PlaceholderHome()
+                    val viewModel: SettingsViewModel = viewModel(
+                        factory = SettingsViewModel.Factory(
+                            settingsRepository = app.settingsRepository,
+                            keyStore = app.secureKeyStore,
+                        ),
+                    )
+                    SettingsScreen(viewModel = viewModel)
                 }
             }
         }
-    }
-}
-
-@Composable
-private fun PlaceholderHome() {
-    Box(
-        modifier = Modifier.fillMaxSize().padding(24.dp),
-        contentAlignment = Alignment.Center,
-    ) {
-        Text(
-            text = stringResource(R.string.placeholder_home_message),
-            style = MaterialTheme.typography.bodyLarge,
-        )
-    }
-}
-
-@Preview(showBackground = true)
-@Composable
-private fun PlaceholderHomePreview() {
-    AdaptWeatherTheme {
-        PlaceholderHome()
     }
 }

--- a/app/src/main/kotlin/com/adaptweather/ui/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/adaptweather/ui/settings/SettingsScreen.kt
@@ -1,0 +1,233 @@
+package com.adaptweather.ui.settings
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.adaptweather.R
+import com.adaptweather.core.domain.model.DeliveryMode
+import com.adaptweather.core.domain.model.DistanceUnit
+import com.adaptweather.core.domain.model.TemperatureUnit
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SettingsScreen(viewModel: SettingsViewModel) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(title = { Text(stringResource(R.string.settings_title)) })
+        },
+    ) { padding ->
+        SettingsContent(
+            state = state,
+            padding = padding,
+            onSetApiKey = viewModel::setApiKey,
+            onClearApiKey = viewModel::clearApiKey,
+            onSetDeliveryMode = viewModel::setDeliveryMode,
+            onSetTemperatureUnit = viewModel::setTemperatureUnit,
+            onSetDistanceUnit = viewModel::setDistanceUnit,
+        )
+    }
+}
+
+@Composable
+private fun SettingsContent(
+    state: SettingsState,
+    padding: PaddingValues,
+    onSetApiKey: (String) -> Unit,
+    onClearApiKey: () -> Unit,
+    onSetDeliveryMode: (DeliveryMode) -> Unit,
+    onSetTemperatureUnit: (TemperatureUnit) -> Unit,
+    onSetDistanceUnit: (DistanceUnit) -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(padding)
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        ApiKeyCard(
+            configured = state.apiKeyConfigured,
+            onSave = onSetApiKey,
+            onClear = onClearApiKey,
+        )
+        DeliveryModeCard(state.deliveryMode, onSetDeliveryMode)
+        TemperatureUnitCard(state.temperatureUnit, onSetTemperatureUnit)
+        DistanceUnitCard(state.distanceUnit, onSetDistanceUnit)
+    }
+}
+
+@Composable
+private fun SectionCard(title: String, content: @Composable () -> Unit) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Text(text = title, style = MaterialTheme.typography.titleMedium)
+            content()
+        }
+    }
+}
+
+@Composable
+private fun ApiKeyCard(
+    configured: Boolean,
+    onSave: (String) -> Unit,
+    onClear: () -> Unit,
+) {
+    SectionCard(title = stringResource(R.string.settings_api_key_title)) {
+        Text(
+            text = if (configured) {
+                stringResource(R.string.settings_api_key_status_set)
+            } else {
+                stringResource(R.string.settings_api_key_status_unset)
+            },
+            style = MaterialTheme.typography.bodyMedium,
+        )
+
+        var input by remember { mutableStateOf("") }
+        OutlinedTextField(
+            value = input,
+            onValueChange = { input = it },
+            singleLine = true,
+            visualTransformation = if (input.isEmpty()) VisualTransformation.None else PasswordVisualTransformation(),
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+            placeholder = { Text(stringResource(R.string.settings_api_key_placeholder)) },
+            modifier = Modifier.fillMaxWidth(),
+        )
+
+        Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            Button(
+                onClick = {
+                    if (input.isNotBlank()) {
+                        onSave(input)
+                        input = ""
+                    }
+                },
+                enabled = input.isNotBlank(),
+                modifier = Modifier.fillMaxWidth(),
+            ) { Text(stringResource(R.string.settings_api_key_save)) }
+
+            if (configured) {
+                TextButton(
+                    onClick = onClear,
+                    modifier = Modifier.fillMaxWidth(),
+                ) { Text(stringResource(R.string.settings_api_key_clear)) }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DeliveryModeCard(
+    selected: DeliveryMode,
+    onSelect: (DeliveryMode) -> Unit,
+) {
+    SectionCard(title = stringResource(R.string.settings_delivery_title)) {
+        DeliveryMode.entries.forEach { mode ->
+            RadioRow(
+                label = stringResource(deliveryModeLabel(mode)),
+                selected = mode == selected,
+                onSelect = { onSelect(mode) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun TemperatureUnitCard(
+    selected: TemperatureUnit,
+    onSelect: (TemperatureUnit) -> Unit,
+) {
+    SectionCard(title = stringResource(R.string.settings_temperature_unit_title)) {
+        TemperatureUnit.entries.forEach { unit ->
+            RadioRow(
+                label = stringResource(temperatureUnitLabel(unit)),
+                selected = unit == selected,
+                onSelect = { onSelect(unit) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun DistanceUnitCard(
+    selected: DistanceUnit,
+    onSelect: (DistanceUnit) -> Unit,
+) {
+    SectionCard(title = stringResource(R.string.settings_distance_unit_title)) {
+        DistanceUnit.entries.forEach { unit ->
+            RadioRow(
+                label = stringResource(distanceUnitLabel(unit)),
+                selected = unit == selected,
+                onSelect = { onSelect(unit) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun RadioRow(
+    label: String,
+    selected: Boolean,
+    onSelect: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        RadioButton(selected = selected, onClick = onSelect)
+        Text(text = label, modifier = Modifier.padding(start = 8.dp))
+    }
+}
+
+private fun deliveryModeLabel(mode: DeliveryMode): Int = when (mode) {
+    DeliveryMode.NOTIFICATION_ONLY -> R.string.settings_delivery_notification_only
+    DeliveryMode.TTS_ONLY -> R.string.settings_delivery_tts_only
+    DeliveryMode.NOTIFICATION_AND_TTS -> R.string.settings_delivery_notification_and_tts
+}
+
+private fun temperatureUnitLabel(unit: TemperatureUnit): Int = when (unit) {
+    TemperatureUnit.CELSIUS -> R.string.settings_temperature_unit_celsius
+    TemperatureUnit.FAHRENHEIT -> R.string.settings_temperature_unit_fahrenheit
+}
+
+private fun distanceUnitLabel(unit: DistanceUnit): Int = when (unit) {
+    DistanceUnit.KILOMETERS -> R.string.settings_distance_unit_kilometers
+    DistanceUnit.MILES -> R.string.settings_distance_unit_miles
+}

--- a/app/src/main/kotlin/com/adaptweather/ui/settings/SettingsState.kt
+++ b/app/src/main/kotlin/com/adaptweather/ui/settings/SettingsState.kt
@@ -1,0 +1,16 @@
+package com.adaptweather.ui.settings
+
+import com.adaptweather.core.domain.model.DeliveryMode
+import com.adaptweather.core.domain.model.DistanceUnit
+import com.adaptweather.core.domain.model.TemperatureUnit
+
+/**
+ * What [SettingsScreen] needs to render. Settings that are not yet user-editable
+ * (schedule, wardrobe rules) are intentionally absent and will land in follow-up PRs.
+ */
+data class SettingsState(
+    val deliveryMode: DeliveryMode = DeliveryMode.NOTIFICATION_ONLY,
+    val temperatureUnit: TemperatureUnit = TemperatureUnit.CELSIUS,
+    val distanceUnit: DistanceUnit = DistanceUnit.KILOMETERS,
+    val apiKeyConfigured: Boolean = false,
+)

--- a/app/src/main/kotlin/com/adaptweather/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/adaptweather/ui/settings/SettingsViewModel.kt
@@ -1,0 +1,83 @@
+package com.adaptweather.ui.settings
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.adaptweather.core.domain.model.DeliveryMode
+import com.adaptweather.core.domain.model.DistanceUnit
+import com.adaptweather.core.domain.model.TemperatureUnit
+import com.adaptweather.data.SecureKeyStore
+import com.adaptweather.data.SettingsRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+class SettingsViewModel(
+    private val settingsRepository: SettingsRepository,
+    private val keyStore: SecureKeyStore,
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(SettingsState())
+    val state: StateFlow<SettingsState> = _state.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            settingsRepository.preferences.collect { prefs ->
+                _state.update {
+                    it.copy(
+                        deliveryMode = prefs.deliveryMode,
+                        temperatureUnit = prefs.temperatureUnit,
+                        distanceUnit = prefs.distanceUnit,
+                    )
+                }
+            }
+        }
+        viewModelScope.launch { refreshApiKeyStatus() }
+    }
+
+    fun setApiKey(key: String) {
+        viewModelScope.launch {
+            keyStore.set(key.trim())
+            refreshApiKeyStatus()
+        }
+    }
+
+    fun clearApiKey() {
+        viewModelScope.launch {
+            keyStore.clear()
+            refreshApiKeyStatus()
+        }
+    }
+
+    fun setDeliveryMode(mode: DeliveryMode) {
+        viewModelScope.launch { settingsRepository.setDeliveryMode(mode) }
+    }
+
+    fun setTemperatureUnit(unit: TemperatureUnit) {
+        viewModelScope.launch { settingsRepository.setUnits(unit, _state.value.distanceUnit) }
+    }
+
+    fun setDistanceUnit(unit: DistanceUnit) {
+        viewModelScope.launch { settingsRepository.setUnits(_state.value.temperatureUnit, unit) }
+    }
+
+    private suspend fun refreshApiKeyStatus() {
+        val configured = runCatching { keyStore.get().isNotBlank() }.getOrDefault(false)
+        _state.update { it.copy(apiKeyConfigured = configured) }
+    }
+
+    class Factory(
+        private val settingsRepository: SettingsRepository,
+        private val keyStore: SecureKeyStore,
+    ) : ViewModelProvider.Factory {
+        @Suppress("UNCHECKED_CAST")
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            require(modelClass.isAssignableFrom(SettingsViewModel::class.java)) {
+                "Unknown ViewModel: ${modelClass.name}"
+            }
+            return SettingsViewModel(settingsRepository, keyStore) as T
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,26 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">AdaptWeather</string>
-    <string name="placeholder_home_message">AdaptWeather — your daily weather difference, every morning.</string>
+
+    <string name="settings_title">Settings</string>
+
+    <string name="settings_api_key_title">Gemini API key</string>
+    <string name="settings_api_key_status_set">A key is configured. The key is encrypted at rest using the Android Keystore.</string>
+    <string name="settings_api_key_status_unset">No key configured. The daily insight needs a Gemini API key from aistudio.google.com.</string>
+    <string name="settings_api_key_placeholder">Paste your API key</string>
+    <string name="settings_api_key_save">Save key</string>
+    <string name="settings_api_key_clear">Clear stored key</string>
+
+    <string name="settings_delivery_title">How to deliver the daily insight</string>
+    <string name="settings_delivery_notification_only">Notification only</string>
+    <string name="settings_delivery_tts_only">Spoken aloud only</string>
+    <string name="settings_delivery_notification_and_tts">Notification and spoken aloud</string>
+
+    <string name="settings_temperature_unit_title">Temperature unit</string>
+    <string name="settings_temperature_unit_celsius">Celsius (°C)</string>
+    <string name="settings_temperature_unit_fahrenheit">Fahrenheit (°F)</string>
+
+    <string name="settings_distance_unit_title">Distance unit</string>
+    <string name="settings_distance_unit_kilometers">Kilometres</string>
+    <string name="settings_distance_unit_miles">Miles</string>
 </resources>

--- a/app/src/test/kotlin/com/adaptweather/data/SecureKeyStoreTest.kt
+++ b/app/src/test/kotlin/com/adaptweather/data/SecureKeyStoreTest.kt
@@ -9,14 +9,21 @@ import com.adaptweather.core.data.insight.MissingApiKeyException
 import com.google.crypto.tink.Aead
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.io.File
 import java.nio.file.Path
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class SecureKeyStoreTest {
     @TempDir lateinit var tempDir: Path
 
@@ -25,10 +32,20 @@ class SecureKeyStoreTest {
 
     @BeforeEach
     fun setUp() {
+        // The :app module ships kotlinx-coroutines-android transitively (via lifecycle).
+        // In unit tests, AndroidDispatcherFactory tries to call Looper.getMainLooper(),
+        // which is unmocked and throws. Setting a test Main dispatcher up front shadows
+        // that lookup so DataStore's internal coroutines run cleanly.
+        Dispatchers.setMain(UnconfinedTestDispatcher())
         dataStore = PreferenceDataStoreFactory.create(
             produceFile = { File(tempDir.toFile(), "secure_key.preferences_pb") },
         )
         subject = SecureKeyStore(aead = ReversibleFakeAead, dataStore = dataStore)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        Dispatchers.resetMain()
     }
 
     @Test

--- a/app/src/test/kotlin/com/adaptweather/data/SettingsRepositoryTest.kt
+++ b/app/src/test/kotlin/com/adaptweather/data/SettingsRepositoryTest.kt
@@ -15,8 +15,14 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
@@ -26,6 +32,7 @@ import java.time.DayOfWeek
 import java.time.LocalTime
 import java.time.ZoneId
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class SettingsRepositoryTest {
     @TempDir lateinit var tempDir: Path
 
@@ -35,6 +42,9 @@ class SettingsRepositoryTest {
 
     @BeforeEach
     fun setUp() {
+        // See SecureKeyStoreTest.setUp for why we install a test Main dispatcher even
+        // though this class doesn't directly read Dispatchers.Main.
+        Dispatchers.setMain(UnconfinedTestDispatcher())
         dataStore = PreferenceDataStoreFactory.create(
             produceFile = { File(tempDir.toFile(), "settings.preferences_pb") },
         )
@@ -42,6 +52,11 @@ class SettingsRepositoryTest {
             dataStore = dataStore,
             zoneIdProvider = { zone },
         )
+    }
+
+    @AfterEach
+    fun tearDown() {
+        Dispatchers.resetMain()
     }
 
     @Test

--- a/app/src/test/kotlin/com/adaptweather/ui/settings/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/com/adaptweather/ui/settings/SettingsViewModelTest.kt
@@ -1,0 +1,108 @@
+package com.adaptweather.ui.settings
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import com.adaptweather.core.domain.model.DeliveryMode
+import com.adaptweather.core.domain.model.DistanceUnit
+import com.adaptweather.core.domain.model.TemperatureUnit
+import com.adaptweather.data.SecureKeyStore
+import com.adaptweather.data.SettingsRepository
+import com.google.crypto.tink.Aead
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.nio.file.Path
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SettingsViewModelTest {
+    @TempDir lateinit var tempDir: Path
+
+    private val dispatcher = UnconfinedTestDispatcher()
+    private lateinit var settingsDataStore: DataStore<Preferences>
+    private lateinit var keyDataStore: DataStore<Preferences>
+    private lateinit var settingsRepository: SettingsRepository
+    private lateinit var keyStore: SecureKeyStore
+    private lateinit var subject: SettingsViewModel
+
+    @BeforeEach
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+        settingsDataStore = PreferenceDataStoreFactory.create(
+            produceFile = { File(tempDir.toFile(), "settings.preferences_pb") },
+        )
+        keyDataStore = PreferenceDataStoreFactory.create(
+            produceFile = { File(tempDir.toFile(), "key.preferences_pb") },
+        )
+        settingsRepository = SettingsRepository(settingsDataStore)
+        keyStore = SecureKeyStore(IdentityFakeAead, keyDataStore)
+        subject = SettingsViewModel(settingsRepository, keyStore)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `initial state reflects repository defaults`() = runTest {
+        val state = subject.state.value
+        state.deliveryMode shouldBe DeliveryMode.NOTIFICATION_ONLY
+        state.temperatureUnit shouldBe TemperatureUnit.CELSIUS
+        state.distanceUnit shouldBe DistanceUnit.KILOMETERS
+        state.apiKeyConfigured shouldBe false
+    }
+
+    @Test
+    fun `setApiKey persists to keystore and updates state`() = runTest {
+        subject.setApiKey("AIzaSyTestKeyValue")
+        subject.state.value.apiKeyConfigured shouldBe true
+        keyStore.get() shouldBe "AIzaSyTestKeyValue"
+    }
+
+    @Test
+    fun `setApiKey trims whitespace`() = runTest {
+        subject.setApiKey("   AIzaSyKey   ")
+        keyStore.get() shouldBe "AIzaSyKey"
+    }
+
+    @Test
+    fun `clearApiKey removes the stored key and updates state`() = runTest {
+        subject.setApiKey("AIzaSyKey")
+        subject.clearApiKey()
+        subject.state.value.apiKeyConfigured shouldBe false
+    }
+
+    @Test
+    fun `setDeliveryMode persists`() = runTest {
+        subject.setDeliveryMode(DeliveryMode.NOTIFICATION_AND_TTS)
+        subject.state.value.deliveryMode shouldBe DeliveryMode.NOTIFICATION_AND_TTS
+        settingsRepository.preferences.first().deliveryMode shouldBe DeliveryMode.NOTIFICATION_AND_TTS
+    }
+
+    @Test
+    fun `setTemperatureUnit and setDistanceUnit persist independently`() = runTest {
+        subject.setTemperatureUnit(TemperatureUnit.FAHRENHEIT)
+        subject.setDistanceUnit(DistanceUnit.MILES)
+
+        val state = subject.state.value
+        state.temperatureUnit shouldBe TemperatureUnit.FAHRENHEIT
+        state.distanceUnit shouldBe DistanceUnit.MILES
+    }
+}
+
+/** Pass-through AEAD: encrypt/decrypt are identity. Sufficient for round-trip tests. */
+private object IdentityFakeAead : Aead {
+    override fun encrypt(plaintext: ByteArray, associatedData: ByteArray?): ByteArray = plaintext
+    override fun decrypt(ciphertext: ByteArray, associatedData: ByteArray?): ByteArray = ciphertext
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,9 @@ datastore = "1.1.1"
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycle" }
+androidx-lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "lifecycle" }
+androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycle" }
+androidx-lifecycle-viewmodel-ktx = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-ktx", version.ref = "lifecycle" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
 androidx-compose-ui = { group = "androidx.compose.ui", name = "ui" }


### PR DESCRIPTION
## Summary

First user-visible screen. Replaces the placeholder home with a Settings screen wired to `SettingsRepository` and `SecureKeyStore`.

**`SettingsViewModel`**
- `StateFlow<SettingsState>` combines repo + keystore status
- `setApiKey` / `clearApiKey` write through `SecureKeyStore`
- `setDeliveryMode`, `setTemperatureUnit`, `setDistanceUnit` write through `SettingsRepository`
- `Factory` lets `viewModel { ... }` build it without Hilt

**`SettingsScreen`** — three Compose cards:
- **Gemini API key** — masked `OutlinedTextField`, Save / Clear buttons, status line that reflects whether a key is currently encrypted at rest
- **Delivery mode** — radios for `NOTIFICATION_ONLY` / `TTS_ONLY` / `NOTIFICATION_AND_TTS`
- **Temperature + distance units** — radios

**DI** — `AdaptWeatherApplication` holds lazy `SecureKeyStore` + `SettingsRepository` singletons; Hilt deferred until there are more consumers.

**Out of scope (follow-ups)**
- Schedule editor (needs a time picker + day-of-week chips)
- Wardrobe rules editor (needs a list editor)
- Permission UX (will land alongside the notification + alarm work)
- About / privacy

## Test plan

- [x] `SettingsViewModelTest` — initial state defaults, `setApiKey` round-trip, whitespace trimming, `clearApiKey`, `setDeliveryMode`, `setTemperatureUnit` + `setDistanceUnit` independent persistence
- [x] All strings externalized to `strings.xml` for v2 localization
- [ ] CI green
- [ ] Sideload APK on phone, set a test Gemini key, change delivery mode, confirm round-trip across process kill (DataStore persistence)

https://claude.ai/code/session_01VftWR7DyaaVXHnovkuQwge

---
_Generated by [Claude Code](https://claude.ai/code/session_01VftWR7DyaaVXHnovkuQwge)_