### PR TITLE
:app — notification channel + InsightNotifier + permission helper

### DIFF
--- a/app/src/main/kotlin/com/adaptweather/AdaptWeatherApplication.kt
+++ b/app/src/main/kotlin/com/adaptweather/AdaptWeatherApplication.kt
@@ -3,6 +3,8 @@ package com.adaptweather
 import android.app.Application
 import com.adaptweather.data.SecureKeyStore
 import com.adaptweather.data.SettingsRepository
+import com.adaptweather.notification.InsightNotifier
+import com.adaptweather.notification.NotificationChannelRegistrar
 
 /**
  * Lightweight DI: lazy singletons for repositories that depend on Android Context.
@@ -11,4 +13,10 @@ import com.adaptweather.data.SettingsRepository
 class AdaptWeatherApplication : Application() {
     val secureKeyStore: SecureKeyStore by lazy { SecureKeyStore.create(this) }
     val settingsRepository: SettingsRepository by lazy { SettingsRepository.create(this) }
+    val insightNotifier: InsightNotifier by lazy { InsightNotifier(this) }
+
+    override fun onCreate() {
+        super.onCreate()
+        NotificationChannelRegistrar.register(this)
+    }
 }

--- a/app/src/main/kotlin/com/adaptweather/notification/InsightNotifier.kt
+++ b/app/src/main/kotlin/com/adaptweather/notification/InsightNotifier.kt
@@ -1,0 +1,64 @@
+package com.adaptweather.notification
+
+import android.Manifest
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.core.content.ContextCompat
+import com.adaptweather.MainActivity
+import com.adaptweather.R
+import com.adaptweather.core.domain.model.Insight
+
+/**
+ * Posts the daily insight as a system notification. Tapping the notification opens
+ * MainActivity. POST_NOTIFICATIONS is checked before posting; on Android 13+ a missing
+ * permission silently no-ops (the worker keeps the cached insight; the user will see it
+ * in-app the next time they open the app).
+ */
+class InsightNotifier(private val context: Context) {
+
+    fun notify(insight: Insight) {
+        if (!hasPostNotificationPermission()) return
+
+        val tapIntent = Intent(context, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
+        }
+        val pendingIntent = PendingIntent.getActivity(
+            context,
+            REQUEST_OPEN_APP,
+            tapIntent,
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+        )
+
+        val notification = NotificationCompat.Builder(context, CHANNEL_DAILY_INSIGHT)
+            .setSmallIcon(R.drawable.ic_notification_insight)
+            .setContentTitle(context.getString(R.string.notification_daily_insight_title))
+            .setContentText(insight.summary)
+            .setStyle(NotificationCompat.BigTextStyle().bigText(insight.summary))
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
+            .setAutoCancel(true)
+            .setContentIntent(pendingIntent)
+            .setCategory(NotificationCompat.CATEGORY_REMINDER)
+            .build()
+
+        NotificationManagerCompat.from(context).notify(NOTIFICATION_ID_DAILY_INSIGHT, notification)
+    }
+
+    private fun hasPostNotificationPermission(): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return true
+        return ContextCompat.checkSelfPermission(
+            context,
+            Manifest.permission.POST_NOTIFICATIONS,
+        ) == PackageManager.PERMISSION_GRANTED
+    }
+
+    companion object {
+        const val NOTIFICATION_ID_DAILY_INSIGHT = 1001
+        private const val REQUEST_OPEN_APP = 100
+    }
+}

--- a/app/src/main/kotlin/com/adaptweather/notification/NotificationChannelRegistrar.kt
+++ b/app/src/main/kotlin/com/adaptweather/notification/NotificationChannelRegistrar.kt
@@ -1,0 +1,38 @@
+package com.adaptweather.notification
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import androidx.core.content.getSystemService
+import com.adaptweather.R
+
+/**
+ * Channel IDs are stable identifiers persisted by the system; renaming or deleting one
+ * is a user-visible change. Bump the suffix when channel semantics change.
+ */
+internal const val CHANNEL_DAILY_INSIGHT = "daily_insight_v1"
+
+/**
+ * Registers the notification channel(s) used by the app. Idempotent — safe to call from
+ * Application.onCreate on every cold start.
+ *
+ * The daily-insight channel is high-importance because the user explicitly opted in to a
+ * morning notification, and the OS otherwise groups it silently if a lower importance is used.
+ */
+object NotificationChannelRegistrar {
+    fun register(context: Context) {
+        val manager = context.getSystemService<NotificationManager>() ?: return
+
+        val channel = NotificationChannel(
+            CHANNEL_DAILY_INSIGHT,
+            context.getString(R.string.notification_channel_daily_insight_name),
+            NotificationManager.IMPORTANCE_HIGH,
+        ).apply {
+            description = context.getString(R.string.notification_channel_daily_insight_description)
+            setShowBadge(true)
+            lockscreenVisibility = android.app.Notification.VISIBILITY_PUBLIC
+        }
+
+        manager.createNotificationChannel(channel)
+    }
+}

--- a/app/src/main/kotlin/com/adaptweather/notification/NotificationPermission.kt
+++ b/app/src/main/kotlin/com/adaptweather/notification/NotificationPermission.kt
@@ -1,0 +1,26 @@
+package com.adaptweather.notification
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.core.content.ContextCompat
+
+/**
+ * Helper for the runtime POST_NOTIFICATIONS permission introduced in Android 13. Versions
+ * below that grant notification posting implicitly, so we report `granted = true` there.
+ */
+object NotificationPermission {
+    fun isRequired(): Boolean = Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
+
+    fun isGranted(context: Context): Boolean {
+        if (!isRequired()) return true
+        return ContextCompat.checkSelfPermission(
+            context,
+            Manifest.permission.POST_NOTIFICATIONS,
+        ) == PackageManager.PERMISSION_GRANTED
+    }
+
+    /** The permission string callers feed into ActivityResultContracts.RequestPermission. */
+    val MANIFEST_PERMISSION: String = Manifest.permission.POST_NOTIFICATIONS
+}

--- a/app/src/main/res/drawable/ic_notification_insight.xml
+++ b/app/src/main/res/drawable/ic_notification_insight.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Notification icons must be silhouetted: white-on-transparent. The system applies the
+    accent / channel colour at runtime. A simple sun-and-cloud glyph keeps it recognisable
+    at small status-bar sizes.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M12,5 m-3,0 a3,3 0 1,0 6,0 a3,3 0 1,0 -6,0" />
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M8,18 c-2,0 -3.5,-1.5 -3.5,-3.5 c0,-2 1.5,-3.5 3.5,-3.5 c0.3,-2 2,-3.5 4,-3.5 c2,0 3.7,1.5 4,3.5 c1.5,0.3 2.5,1.5 2.5,3.5 c0,2 -1.5,3.5 -3.5,3.5 z" />
+</vector>

--- a/app/src/main/res/drawable/ic_notification_insight.xml
+++ b/app/src/main/res/drawable/ic_notification_insight.xml
@@ -8,8 +8,7 @@
     android:width="24dp"
     android:height="24dp"
     android:viewportWidth="24"
-    android:viewportHeight="24"
-    android:tint="?attr/colorControlNormal">
+    android:viewportHeight="24">
     <path
         android:fillColor="#FFFFFF"
         android:pathData="M12,5 m-3,0 a3,3 0 1,0 6,0 a3,3 0 1,0 -6,0" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -23,4 +23,8 @@
     <string name="settings_distance_unit_title">Distance unit</string>
     <string name="settings_distance_unit_kilometers">Kilometres</string>
     <string name="settings_distance_unit_miles">Miles</string>
+
+    <string name="notification_channel_daily_insight_name">Daily insight</string>
+    <string name="notification_channel_daily_insight_description">The morning weather summary you opted in to.</string>
+    <string name="notification_daily_insight_title">Today\'s weather</string>
 </resources>


### PR DESCRIPTION
## Summary

Foundation for the daily-insight notification flow. The Worker landing in a follow-up PR will call `insightNotifier.notify(insight)` once Gemini returns.

- **`NotificationChannelRegistrar`** — registers a high-importance channel `daily_insight_v1` with `VISIBILITY_PUBLIC` so the insight is readable on a lock screen. Channel ID is suffixed `v1`; bump on semantic changes (channels are user-visible system state).
- **`InsightNotifier`** — builds a `NotificationCompat` with `BigTextStyle`, a small silhouette icon, and a content intent that opens `MainActivity`. Silently no-ops when `POST_NOTIFICATIONS` is denied (Worker keeps the cached `Insight`, user sees it in-app on next launch).
- **`NotificationPermission`** — small helper exposing `isRequired` / `isGranted(context)` / `MANIFEST_PERMISSION` for the Settings prompt that lands later.
- **`Application.onCreate`** registers the channel on every cold start; `createNotificationChannel` is idempotent.
- **`ic_notification_insight.xml`** — silhouette sun-and-cloud vector for the status-bar icon.

## Test plan

- [x] All existing JVM tests still pass on local + CI
- [x] Channel + notifier are largely Android-API ceremony; no useful unit-test surface. Maestro/Firebase Test Lab flows in a follow-up will exercise the channel registration + post path end-to-end.
- [ ] CI green
- [ ] Sideload, install, confirm the channel shows up under Settings → Apps → AdaptWeather → Notifications
- [ ] Follow-ups: Settings UX for the permission grant, alarm + WorkManager + boot receiver + `FetchAndNotifyWorker`, then TTS

https://claude.ai/code/session_01VftWR7DyaaVXHnovkuQwge

---
_Generated by [Claude Code](https://claude.ai/code/session_01VftWR7DyaaVXHnovkuQwge)_