### PR TITLE
fix(:app): SettingsViewModel temperature/distance unit race

### DIFF
--- a/app/src/main/kotlin/com/adaptweather/data/SettingsRepository.kt
+++ b/app/src/main/kotlin/com/adaptweather/data/SettingsRepository.kt
@@ -53,11 +53,12 @@ class SettingsRepository(
         dataStore.edit { it[DELIVERY_MODE] = mode.name }
     }
 
-    suspend fun setUnits(temperature: TemperatureUnit, distance: DistanceUnit) {
-        dataStore.edit { prefs ->
-            prefs[TEMPERATURE_UNIT] = temperature.name
-            prefs[DISTANCE_UNIT] = distance.name
-        }
+    suspend fun setTemperatureUnit(unit: TemperatureUnit) {
+        dataStore.edit { it[TEMPERATURE_UNIT] = unit.name }
+    }
+
+    suspend fun setDistanceUnit(unit: DistanceUnit) {
+        dataStore.edit { it[DISTANCE_UNIT] = unit.name }
     }
 
     suspend fun setWardrobeRules(rules: List<WardrobeRule>) {

--- a/app/src/main/kotlin/com/adaptweather/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/adaptweather/ui/settings/SettingsViewModel.kt
@@ -56,11 +56,11 @@ class SettingsViewModel(
     }
 
     fun setTemperatureUnit(unit: TemperatureUnit) {
-        viewModelScope.launch { settingsRepository.setUnits(unit, _state.value.distanceUnit) }
+        viewModelScope.launch { settingsRepository.setTemperatureUnit(unit) }
     }
 
     fun setDistanceUnit(unit: DistanceUnit) {
-        viewModelScope.launch { settingsRepository.setUnits(_state.value.temperatureUnit, unit) }
+        viewModelScope.launch { settingsRepository.setDistanceUnit(unit) }
     }
 
     private suspend fun refreshApiKeyStatus() {

--- a/app/src/test/kotlin/com/adaptweather/data/SettingsRepositoryTest.kt
+++ b/app/src/test/kotlin/com/adaptweather/data/SettingsRepositoryTest.kt
@@ -100,7 +100,8 @@ class SettingsRepositoryTest {
 
     @Test
     fun `setUnits round-trips both`() = runTest {
-        subject.setUnits(TemperatureUnit.FAHRENHEIT, DistanceUnit.MILES)
+        subject.setTemperatureUnit(TemperatureUnit.FAHRENHEIT)
+        subject.setDistanceUnit(DistanceUnit.MILES)
 
         val prefs = subject.preferences.first()
         prefs.temperatureUnit shouldBe TemperatureUnit.FAHRENHEIT

--- a/app/src/test/kotlin/com/adaptweather/ui/settings/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/com/adaptweather/ui/settings/SettingsViewModelTest.kt
@@ -56,37 +56,41 @@ class SettingsViewModelTest {
 
     @Test
     fun `initial state reflects repository defaults`() = runTest {
-        val state = subject.state.value
-        state.deliveryMode shouldBe DeliveryMode.NOTIFICATION_ONLY
+        // The initial MutableStateFlow value matches our defaults; await the first
+        // collector emission so anything from DataStore that disagreed would surface here.
+        val state = subject.state.first {
+            !it.apiKeyConfigured && it.deliveryMode == DeliveryMode.NOTIFICATION_ONLY
+        }
         state.temperatureUnit shouldBe TemperatureUnit.CELSIUS
         state.distanceUnit shouldBe DistanceUnit.KILOMETERS
-        state.apiKeyConfigured shouldBe false
     }
 
     @Test
     fun `setApiKey persists to keystore and updates state`() = runTest {
         subject.setApiKey("AIzaSyTestKeyValue")
-        subject.state.value.apiKeyConfigured shouldBe true
+        subject.state.first { it.apiKeyConfigured }
         keyStore.get() shouldBe "AIzaSyTestKeyValue"
     }
 
     @Test
     fun `setApiKey trims whitespace`() = runTest {
         subject.setApiKey("   AIzaSyKey   ")
+        subject.state.first { it.apiKeyConfigured }
         keyStore.get() shouldBe "AIzaSyKey"
     }
 
     @Test
     fun `clearApiKey removes the stored key and updates state`() = runTest {
         subject.setApiKey("AIzaSyKey")
+        subject.state.first { it.apiKeyConfigured }
         subject.clearApiKey()
-        subject.state.value.apiKeyConfigured shouldBe false
+        subject.state.first { !it.apiKeyConfigured }
     }
 
     @Test
     fun `setDeliveryMode persists`() = runTest {
         subject.setDeliveryMode(DeliveryMode.NOTIFICATION_AND_TTS)
-        subject.state.value.deliveryMode shouldBe DeliveryMode.NOTIFICATION_AND_TTS
+        subject.state.first { it.deliveryMode == DeliveryMode.NOTIFICATION_AND_TTS }
         settingsRepository.preferences.first().deliveryMode shouldBe DeliveryMode.NOTIFICATION_AND_TTS
     }
 
@@ -95,7 +99,9 @@ class SettingsViewModelTest {
         subject.setTemperatureUnit(TemperatureUnit.FAHRENHEIT)
         subject.setDistanceUnit(DistanceUnit.MILES)
 
-        val state = subject.state.value
+        val state = subject.state.first {
+            it.temperatureUnit == TemperatureUnit.FAHRENHEIT && it.distanceUnit == DistanceUnit.MILES
+        }
         state.temperatureUnit shouldBe TemperatureUnit.FAHRENHEIT
         state.distanceUnit shouldBe DistanceUnit.MILES
     }


### PR DESCRIPTION
## Summary

Fix-forward for the test failures that landed in main with PR #9.

The `setTemperatureUnit and setDistanceUnit persist independently` test was failing with `expected:<FAHRENHEIT> but was:<CELSIUS>` because of a real race in `SettingsViewModel`:

- `setUnits(temp, distance)` on the repository writes both keys atomically, so the ViewModel read `_state.value.distanceUnit` to fill the unchanged axis when only `temp` was changing.
- `_state` is updated *asynchronously* by the collector from DataStore, so two consecutive `setTemp` + `setDist` calls could each read a stale unchanged axis and clobber the other's write. Last-write-wins, with the wrong inputs.

## Fix

- **`SettingsRepository.setUnits` split** into `setTemperatureUnit` and `setDistanceUnit`, each editing exactly one preference key. No more atomic-pair writes.
- **`SettingsViewModel`** calls the new methods directly with no state-reading.
- **`SettingsViewModelTest`** now uses `state.first { predicate }` to await the collector emission rather than reading `state.value` immediately after launching a coroutine that hasn't completed. The other tests (`setApiKey`, `setDeliveryMode`, etc.) had the same latent race even though they didn't manifest in CI yet — fixed all of them.

## Test plan

- [x] Same six `SettingsViewModelTest` cases still cover the same behaviour, but now reliably
- [x] `SettingsRepositoryTest.setUnits round-trips both` updated to call the two split methods
- [ ] CI green on this PR

https://claude.ai/code/session_01VftWR7DyaaVXHnovkuQwge

---
_Generated by [Claude Code](https://claude.ai/code/session_01VftWR7DyaaVXHnovkuQwge)_