### PR TITLE
:app — alarm scheduler + receivers (boot, timezone, locale, fire)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -46,6 +46,27 @@
             </intent-filter>
         </activity>
 
+        <!-- Internal — only the OS delivers via PendingIntent. -->
+        <receiver
+            android:name=".alarm.AlarmReceiver"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.adaptweather.alarm.FIRE" />
+            </intent-filter>
+        </receiver>
+
+        <!-- System broadcasts that should re-arm the daily alarm. -->
+        <receiver
+            android:name=".alarm.ScheduleRefreshReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+                <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
+                <action android:name="android.intent.action.TIMEZONE_CHANGED" />
+                <action android:name="android.intent.action.LOCALE_CHANGED" />
+            </intent-filter>
+        </receiver>
+
     </application>
 
 </manifest>

--- a/app/src/main/kotlin/com/adaptweather/AdaptWeatherApplication.kt
+++ b/app/src/main/kotlin/com/adaptweather/AdaptWeatherApplication.kt
@@ -1,10 +1,17 @@
 package com.adaptweather
 
 import android.app.Application
+import android.util.Log
+import com.adaptweather.alarm.DailyAlarmScheduler
 import com.adaptweather.data.SecureKeyStore
 import com.adaptweather.data.SettingsRepository
 import com.adaptweather.notification.InsightNotifier
 import com.adaptweather.notification.NotificationChannelRegistrar
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
 
 /**
  * Lightweight DI: lazy singletons for repositories that depend on Android Context.
@@ -14,9 +21,24 @@ class AdaptWeatherApplication : Application() {
     val secureKeyStore: SecureKeyStore by lazy { SecureKeyStore.create(this) }
     val settingsRepository: SettingsRepository by lazy { SettingsRepository.create(this) }
     val insightNotifier: InsightNotifier by lazy { InsightNotifier(this) }
+    val dailyAlarmScheduler: DailyAlarmScheduler by lazy { DailyAlarmScheduler(this) }
+
+    private val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
     override fun onCreate() {
         super.onCreate()
         NotificationChannelRegistrar.register(this)
+        applicationScope.launch {
+            try {
+                val schedule = settingsRepository.preferences.first().schedule
+                dailyAlarmScheduler.schedule(schedule)
+            } catch (t: Throwable) {
+                Log.e(TAG, "Initial alarm scheduling failed", t)
+            }
+        }
+    }
+
+    companion object {
+        private const val TAG = "AdaptWeatherApplication"
     }
 }

--- a/app/src/main/kotlin/com/adaptweather/alarm/AlarmReceiver.kt
+++ b/app/src/main/kotlin/com/adaptweather/alarm/AlarmReceiver.kt
@@ -1,0 +1,47 @@
+package com.adaptweather.alarm
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+import com.adaptweather.AdaptWeatherApplication
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+
+/**
+ * Fires when the daily-insight alarm goes off. v1 placeholder behaviour: log the event
+ * and immediately re-arm the alarm for the next day. The follow-up PR will enqueue a
+ * WorkManager OneTimeWorkRequest that fetches forecast → calls Gemini → posts the
+ * notification, then re-arms.
+ *
+ * Re-arming inside the receiver (rather than only from the worker) keeps the alarm
+ * chain alive even if the worker fails before it can schedule the next one.
+ */
+class AlarmReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action != ACTION_FIRE) return
+        Log.i(TAG, "AlarmReceiver fired (action=${intent.action})")
+
+        val pending = goAsync()
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        scope.launch {
+            try {
+                val app = context.applicationContext as AdaptWeatherApplication
+                val schedule = app.settingsRepository.preferences.first().schedule
+                DailyAlarmScheduler(context.applicationContext).schedule(schedule)
+            } catch (t: Throwable) {
+                Log.e(TAG, "Re-arm failed", t)
+            } finally {
+                pending.finish()
+            }
+        }
+    }
+
+    companion object {
+        const val ACTION_FIRE = "com.adaptweather.alarm.FIRE"
+        private const val TAG = "AlarmReceiver"
+    }
+}

--- a/app/src/main/kotlin/com/adaptweather/alarm/DailyAlarmScheduler.kt
+++ b/app/src/main/kotlin/com/adaptweather/alarm/DailyAlarmScheduler.kt
@@ -1,0 +1,74 @@
+package com.adaptweather.alarm
+
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.util.Log
+import androidx.core.content.getSystemService
+import com.adaptweather.core.domain.model.Schedule
+import java.time.Clock
+import java.time.Instant
+
+/**
+ * Schedules an exact wake-up at the next occurrence of [Schedule]. Wraps AlarmManager
+ * so the receiver code stays small and so we can stub the manager in tests.
+ *
+ * Design choices:
+ * - `setExactAndAllowWhileIdle` is the only primitive that fires at a precise wall-clock
+ *   time even in Doze. The plan calls for it.
+ * - Permission is gated by `USE_EXACT_ALARM` (API 33+, no user prompt) and
+ *   `SCHEDULE_EXACT_ALARM` (API 31-32, granted by default). On API <31 no permission is
+ *   needed. If we ever ship on API <33 with the prompt path, callers should fall back to
+ *   `setAndAllowWhileIdle` when [AlarmManager.canScheduleExactAlarms] is false.
+ * - `Schedule.zoneId` is intentionally re-resolved by the repository on each read so DST
+ *   and travel changes pick up automatically. This scheduler does not cache the zone.
+ */
+class DailyAlarmScheduler(
+    private val context: Context,
+    private val clock: Clock = Clock.systemUTC(),
+) {
+    fun schedule(schedule: Schedule) {
+        val alarmManager = context.getSystemService<AlarmManager>() ?: run {
+            Log.w(TAG, "AlarmManager unavailable; alarm not scheduled")
+            return
+        }
+
+        val triggerAt: Instant = schedule.nextOccurrenceAfter(clock.instant())
+        val pendingIntent = pendingIntent(context)
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && !alarmManager.canScheduleExactAlarms()) {
+            // USE_EXACT_ALARM (API 33+) auto-grants this; on the API 31-32 shim path it's
+            // also granted by default. If somehow it's denied (user revoked manually),
+            // fall back to setAndAllowWhileIdle so the user still gets the notification,
+            // just possibly drifted by a few minutes.
+            alarmManager.setAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, triggerAt.toEpochMilli(), pendingIntent)
+            Log.w(TAG, "Exact-alarm permission denied; using inexact alarm at $triggerAt")
+            return
+        }
+
+        alarmManager.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, triggerAt.toEpochMilli(), pendingIntent)
+        Log.i(TAG, "Daily insight alarm armed for $triggerAt")
+    }
+
+    fun cancel() {
+        val alarmManager = context.getSystemService<AlarmManager>() ?: return
+        alarmManager.cancel(pendingIntent(context))
+    }
+
+    companion object {
+        private const val TAG = "DailyAlarmScheduler"
+        private const val ALARM_REQUEST_CODE = 0xADA1
+
+        internal fun pendingIntent(context: Context): PendingIntent {
+            val intent = Intent(context, AlarmReceiver::class.java).setAction(AlarmReceiver.ACTION_FIRE)
+            return PendingIntent.getBroadcast(
+                context,
+                ALARM_REQUEST_CODE,
+                intent,
+                PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+            )
+        }
+    }
+}

--- a/app/src/main/kotlin/com/adaptweather/alarm/ScheduleRefreshReceiver.kt
+++ b/app/src/main/kotlin/com/adaptweather/alarm/ScheduleRefreshReceiver.kt
@@ -1,0 +1,46 @@
+package com.adaptweather.alarm
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+import com.adaptweather.AdaptWeatherApplication
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+
+/**
+ * Re-arms the daily-insight alarm whenever the wall-clock context changes:
+ * - device boot (alarms are wiped)
+ * - app update (Android also wipes alarms)
+ * - timezone change (the user travelled across zones)
+ * - locale change (the next insight should be generated in the new language)
+ *
+ * The schedule's `zoneId` is re-resolved from `ZoneId.systemDefault()` at read time, so
+ * we just need to recompute "next 7am" with the now-current zone and rearm.
+ */
+class ScheduleRefreshReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        Log.i(TAG, "ScheduleRefreshReceiver action=${intent.action}")
+
+        val pending = goAsync()
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        scope.launch {
+            try {
+                val app = context.applicationContext as AdaptWeatherApplication
+                val schedule = app.settingsRepository.preferences.first().schedule
+                DailyAlarmScheduler(context.applicationContext).schedule(schedule)
+            } catch (t: Throwable) {
+                Log.e(TAG, "Re-arm failed", t)
+            } finally {
+                pending.finish()
+            }
+        }
+    }
+
+    companion object {
+        private const val TAG = "ScheduleRefreshReceiver"
+    }
+}

--- a/app/src/test/kotlin/com/adaptweather/data/SecureKeyStoreTest.kt
+++ b/app/src/test/kotlin/com/adaptweather/data/SecureKeyStoreTest.kt
@@ -12,6 +12,7 @@ import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
@@ -35,8 +36,10 @@ class SecureKeyStoreTest {
         // The :app module ships kotlinx-coroutines-android transitively (via lifecycle).
         // In unit tests, AndroidDispatcherFactory tries to call Looper.getMainLooper(),
         // which is unmocked and throws. Setting a test Main dispatcher up front shadows
-        // that lookup so DataStore's internal coroutines run cleanly.
-        Dispatchers.setMain(UnconfinedTestDispatcher())
+        // that lookup. We pass an explicit TestCoroutineScheduler so the dispatcher
+        // constructor doesn't itself read Dispatchers.Main (which would trigger the same
+        // failure before setMain has a chance to install).
+        Dispatchers.setMain(UnconfinedTestDispatcher(TestCoroutineScheduler()))
         dataStore = PreferenceDataStoreFactory.create(
             produceFile = { File(tempDir.toFile(), "secure_key.preferences_pb") },
         )

--- a/app/src/test/kotlin/com/adaptweather/data/SettingsRepositoryTest.kt
+++ b/app/src/test/kotlin/com/adaptweather/data/SettingsRepositoryTest.kt
@@ -18,6 +18,7 @@ import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
@@ -43,8 +44,9 @@ class SettingsRepositoryTest {
     @BeforeEach
     fun setUp() {
         // See SecureKeyStoreTest.setUp for why we install a test Main dispatcher even
-        // though this class doesn't directly read Dispatchers.Main.
-        Dispatchers.setMain(UnconfinedTestDispatcher())
+        // though this class doesn't directly read Dispatchers.Main, and why we pass an
+        // explicit scheduler instead of relying on the no-arg dispatcher constructor.
+        Dispatchers.setMain(UnconfinedTestDispatcher(TestCoroutineScheduler()))
         dataStore = PreferenceDataStoreFactory.create(
             produceFile = { File(tempDir.toFile(), "settings.preferences_pb") },
         )

--- a/app/src/test/kotlin/com/adaptweather/ui/settings/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/com/adaptweather/ui/settings/SettingsViewModelTest.kt
@@ -13,6 +13,7 @@ import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
@@ -28,7 +29,10 @@ import java.nio.file.Path
 class SettingsViewModelTest {
     @TempDir lateinit var tempDir: Path
 
-    private val dispatcher = UnconfinedTestDispatcher()
+    // Explicit scheduler avoids the dispatcher's internal Dispatchers.Main lookup, which
+    // crashes on Android JVM unit tests because AndroidDispatcherFactory calls the
+    // unmocked Looper.getMainLooper(). See SecureKeyStoreTest for the same workaround.
+    private val dispatcher = UnconfinedTestDispatcher(TestCoroutineScheduler())
     private lateinit var settingsDataStore: DataStore<Preferences>
     private lateinit var keyDataStore: DataStore<Preferences>
     private lateinit var settingsRepository: SettingsRepository


### PR DESCRIPTION
## Summary

Wires up the time-based half of the daily-insight pipeline. The Worker that fetches the forecast and posts the notification lands in the follow-up PR.

- **`DailyAlarmScheduler.schedule(schedule)`** — computes the next occurrence via `Schedule.nextOccurrenceAfter` (already tested in `:core:domain`) and arms `setExactAndAllowWhileIdle` on `RTC_WAKEUP`. Falls back to `setAndAllowWhileIdle` if exact-alarm capability is denied. Immutable broadcast `PendingIntent`.
- **`AlarmReceiver`** — fires on the `com.adaptweather.alarm.FIRE` action, re-arms for the next day. v1 placeholder; the Worker enqueue lands next. Uses `goAsync()` so the suspend work to read the schedule from DataStore can complete safely.
- **`ScheduleRefreshReceiver`** — re-arms on `BOOT_COMPLETED`, `MY_PACKAGE_REPLACED`, `TIMEZONE_CHANGED`, `LOCALE_CHANGED`. The schedule's `zoneId` is freshly resolved by `SettingsRepository` on each read, so the re-arm picks up DST/travel changes automatically.
- **Manifest** registers both receivers; `AlarmReceiver` internal-only, `ScheduleRefreshReceiver` exported for the system broadcasts.
- **`AdaptWeatherApplication.onCreate`** schedules on every cold start in a `SupervisorJob` scope; failures are logged but don't crash the app.

## Test plan

- [x] Existing 39+ unit tests still pass (`Schedule.nextOccurrenceAfter` is the tested logic underneath the new code)
- [x] No new unit tests — these classes are AlarmManager / BroadcastReceiver ceremony; the tested logic is in `:core:domain`
- [ ] CI green
- [ ] Sideload, confirm via `adb shell dumpsys alarm | grep adaptweather` that the alarm is armed for tomorrow at 7am
- [ ] Reboot phone, confirm the alarm survives via `dumpsys alarm`
- [ ] Follow-up PRs: `FetchAndNotifyWorker`, debug "fire now" button, TTS

https://claude.ai/code/session_01VftWR7DyaaVXHnovkuQwge

---
_Generated by [Claude Code](https://claude.ai/code/session_01VftWR7DyaaVXHnovkuQwge)_