### PR TITLE
:app — FetchAndNotifyWorker: actual fetch + insight + notify pipeline

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -85,6 +85,7 @@ dependencies {
     implementation(libs.tink.android)
     implementation(libs.androidx.datastore.preferences)
     implementation(libs.kotlinx.serialization.json)
+    implementation(libs.androidx.work.runtime.ktx)
 
     // Ktor with the OkHttp engine for production HTTP. Tests in :core:data use MockEngine,
     // so the engine choice is :app's concern.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -58,6 +58,13 @@ android {
         unitTests.all {
             it.useJUnitPlatform()
         }
+        // Required because kotlinx-coroutines-android is on the unit-test classpath
+        // (transitively via androidx.lifecycle). Without this, AndroidDispatcherFactory
+        // calls the unmocked Looper.getMainLooper() and throws "not mocked", which
+        // poisons MainDispatcherLoader for the rest of the JVM. With defaults enabled,
+        // getMainLooper() returns null, AndroidDispatcherFactory fails cleanly, and
+        // Dispatchers.setMain installs a TestMainDispatcher as expected.
+        unitTests.isReturnDefaultValues = true
     }
 }
 

--- a/app/src/main/kotlin/com/adaptweather/AdaptWeatherApplication.kt
+++ b/app/src/main/kotlin/com/adaptweather/AdaptWeatherApplication.kt
@@ -3,25 +3,50 @@ package com.adaptweather
 import android.app.Application
 import android.util.Log
 import com.adaptweather.alarm.DailyAlarmScheduler
+import com.adaptweather.core.data.insight.DirectGeminiClient
+import com.adaptweather.core.data.weather.OpenMeteoClient
+import com.adaptweather.core.domain.repository.InsightGenerator
+import com.adaptweather.core.domain.repository.WeatherRepository
+import com.adaptweather.core.domain.usecase.GenerateDailyInsight
 import com.adaptweather.data.SecureKeyStore
 import com.adaptweather.data.SettingsRepository
 import com.adaptweather.notification.InsightNotifier
 import com.adaptweather.notification.NotificationChannelRegistrar
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.okhttp.OkHttp
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.serialization.kotlinx.json.json
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.serialization.json.Json
 
 /**
- * Lightweight DI: lazy singletons for repositories that depend on Android Context.
- * Will move to Hilt once we have more than a handful of consumers.
+ * Lightweight DI: lazy singletons for things that depend on Android Context or that
+ * the Worker / UI / receivers all share. Will move to Hilt once we have more than a
+ * handful of consumers.
  */
 class AdaptWeatherApplication : Application() {
     val secureKeyStore: SecureKeyStore by lazy { SecureKeyStore.create(this) }
     val settingsRepository: SettingsRepository by lazy { SettingsRepository.create(this) }
     val insightNotifier: InsightNotifier by lazy { InsightNotifier(this) }
     val dailyAlarmScheduler: DailyAlarmScheduler by lazy { DailyAlarmScheduler(this) }
+
+    private val httpClient: HttpClient by lazy {
+        HttpClient(OkHttp) {
+            install(ContentNegotiation) {
+                json(Json { ignoreUnknownKeys = true })
+            }
+        }
+    }
+
+    val weatherRepository: WeatherRepository by lazy { OpenMeteoClient(httpClient) }
+    val insightGenerator: InsightGenerator by lazy { DirectGeminiClient(httpClient, secureKeyStore) }
+    val generateDailyInsight: GenerateDailyInsight by lazy {
+        GenerateDailyInsight(weatherRepository, insightGenerator)
+    }
 
     private val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 

--- a/app/src/main/kotlin/com/adaptweather/alarm/AlarmReceiver.kt
+++ b/app/src/main/kotlin/com/adaptweather/alarm/AlarmReceiver.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.Intent
 import android.util.Log
 import com.adaptweather.AdaptWeatherApplication
+import com.adaptweather.work.FetchAndNotifyWorker
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -12,18 +13,20 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 
 /**
- * Fires when the daily-insight alarm goes off. v1 placeholder behaviour: log the event
- * and immediately re-arm the alarm for the next day. The follow-up PR will enqueue a
- * WorkManager OneTimeWorkRequest that fetches forecast → calls Gemini → posts the
- * notification, then re-arms.
+ * Fires when the daily-insight alarm goes off. The receiver does two things:
  *
- * Re-arming inside the receiver (rather than only from the worker) keeps the alarm
- * chain alive even if the worker fails before it can schedule the next one.
+ * 1. Enqueues a WorkManager OneTimeWorkRequest ([FetchAndNotifyWorker]) which actually
+ *    does the fetch + Gemini call + notification under network/retry constraints.
+ * 2. Re-arms the alarm for the next day. Re-arming here (rather than only inside the
+ *    Worker) keeps the alarm chain alive even if the Worker is permanently failing.
  */
 class AlarmReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
         if (intent.action != ACTION_FIRE) return
         Log.i(TAG, "AlarmReceiver fired (action=${intent.action})")
+
+        // Enqueue the Worker synchronously — it does its own off-thread work.
+        FetchAndNotifyWorker.enqueueOneShot(context.applicationContext)
 
         val pending = goAsync()
         val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)

--- a/app/src/main/kotlin/com/adaptweather/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/com/adaptweather/work/FetchAndNotifyWorker.kt
@@ -1,0 +1,127 @@
+package com.adaptweather.work
+
+import android.content.Context
+import android.util.Log
+import androidx.work.BackoffPolicy
+import androidx.work.Constraints
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import com.adaptweather.AdaptWeatherApplication
+import com.adaptweather.core.data.insight.GeminiBlockedException
+import com.adaptweather.core.data.insight.GeminiEmptyResponseException
+import com.adaptweather.core.data.insight.MissingApiKeyException
+import com.adaptweather.core.domain.model.Location
+import io.ktor.client.network.sockets.ConnectTimeoutException
+import io.ktor.client.network.sockets.SocketTimeoutException
+import io.ktor.client.plugins.HttpRequestTimeoutException
+import io.ktor.client.plugins.ResponseException
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.flow.first
+import java.io.IOException
+import java.util.concurrent.TimeUnit
+
+/**
+ * Performs one daily fetch + insight + notify cycle. Runs in a WorkManager
+ * OneTimeWorkRequest enqueued by AlarmReceiver, with NetworkType.CONNECTED and
+ * exponential backoff so transient failures (no Wi-Fi at 7am) retry on next connectivity.
+ *
+ * Outcomes:
+ * - Result.success — insight posted (or notification permission denied; we still cached the insight).
+ * - Result.retry — transient network / 5xx; WorkManager will retry with backoff.
+ * - Result.failure — non-recoverable: missing key, blocked by safety, or 4xx auth.
+ *   Caller (the user) is expected to fix the configuration; no point retrying.
+ *
+ * Location for v1 is hard-coded to London. The plan calls for device GPS at notify time,
+ * which lands in a follow-up alongside the location-permission UX.
+ */
+class FetchAndNotifyWorker(
+    context: Context,
+    params: WorkerParameters,
+) : CoroutineWorker(context, params) {
+
+    private val app: AdaptWeatherApplication
+        get() = applicationContext as AdaptWeatherApplication
+
+    override suspend fun doWork(): Result {
+        val prefs = try {
+            app.settingsRepository.preferences.first()
+        } catch (t: Throwable) {
+            Log.e(TAG, "Failed to read user preferences; retrying", t)
+            return Result.retry()
+        }
+
+        val location = resolveLocation()
+        val languageTag = java.util.Locale.getDefault().toLanguageTag()
+
+        return try {
+            val insight = app.generateDailyInsight(location, prefs, languageTag)
+            app.insightNotifier.notify(insight)
+            Log.i(TAG, "Insight delivered for ${insight.forDate}: ${insight.summary}")
+            Result.success()
+        } catch (e: MissingApiKeyException) {
+            Log.w(TAG, "No Gemini API key configured; user must set one in Settings.")
+            Result.failure()
+        } catch (e: GeminiBlockedException) {
+            Log.w(TAG, "Gemini refused the prompt: ${e.message}")
+            Result.failure()
+        } catch (e: GeminiEmptyResponseException) {
+            Log.w(TAG, "Gemini returned no candidate text; will retry.")
+            Result.retry()
+        } catch (e: ResponseException) {
+            // 4xx auth/quota: don't retry. 5xx server-side: retry with backoff.
+            val status = e.response.status
+            if (status == HttpStatusCode.Unauthorized || status == HttpStatusCode.Forbidden) {
+                Log.w(TAG, "Auth failed against Gemini ($status); user must fix the key.")
+                Result.failure()
+            } else if (status.value in 500..599) {
+                Log.w(TAG, "Server error $status; retrying.")
+                Result.retry()
+            } else {
+                Log.e(TAG, "Unexpected HTTP status $status", e)
+                Result.failure()
+            }
+        } catch (e: ConnectTimeoutException) {
+            Log.w(TAG, "Connect timeout; retrying.", e); Result.retry()
+        } catch (e: SocketTimeoutException) {
+            Log.w(TAG, "Socket timeout; retrying.", e); Result.retry()
+        } catch (e: HttpRequestTimeoutException) {
+            Log.w(TAG, "Request timeout; retrying.", e); Result.retry()
+        } catch (e: IOException) {
+            Log.w(TAG, "Network IO failure; retrying.", e); Result.retry()
+        } catch (t: Throwable) {
+            Log.e(TAG, "Unhandled error; failing.", t)
+            Result.failure()
+        }
+    }
+
+    private fun resolveLocation(): Location {
+        // TODO: replace with the GPS-at-notify-time resolver once the location-permission
+        // UX lands. London is a sensible v1 default and lets the rest of the pipeline run.
+        return Location(latitude = 51.5074, longitude = -0.1278, displayName = "London")
+    }
+
+    companion object {
+        private const val TAG = "FetchAndNotifyWorker"
+        const val UNIQUE_WORK_NAME = "daily_insight_fetch"
+
+        fun enqueueOneShot(context: Context) {
+            val constraints = Constraints.Builder()
+                .setRequiredNetworkType(NetworkType.CONNECTED)
+                .build()
+
+            val request = OneTimeWorkRequestBuilder<FetchAndNotifyWorker>()
+                .setConstraints(constraints)
+                .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, 30, TimeUnit.SECONDS)
+                .build()
+
+            // KEEP: if a previous run is still in flight (e.g. retrying), don't start
+            // a duplicate. The next 7am alarm will enqueue afresh.
+            WorkManager.getInstance(context)
+                .enqueueUniqueWork(UNIQUE_WORK_NAME, ExistingWorkPolicy.KEEP, request)
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ ktor = "3.0.2"
 serialization = "1.7.3"
 tink = "1.15.0"
 datastore = "1.1.1"
+work = "2.10.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -52,6 +53,8 @@ tink-android = { group = "com.google.crypto.tink", name = "tink-android", versio
 
 androidx-datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastore" }
 androidx-datastore-preferences-core = { group = "androidx.datastore", name = "datastore-preferences-core", version.ref = "datastore" }
+
+androidx-work-runtime-ktx = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "work" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary

Closes the daily-insight loop. `AlarmReceiver` now enqueues a WorkManager `OneTimeWorkRequest` that does the real work:

1. Reads `UserPreferences` from `SettingsRepository`.
2. Fetches yesterday + today via `OpenMeteoClient`.
3. Calls `GenerateDailyInsight` (under the hood: `DirectGeminiClient` with the BYOK key from `SecureKeyStore`).
4. Posts the `Insight` via `InsightNotifier`.

**Constraints**: `NetworkType.CONNECTED` + 30s exponential backoff so a 7am wake without Wi-Fi retries when connectivity returns. `ExistingWorkPolicy.KEEP` prevents stacking duplicate work if a previous run is still retrying.

**Failure routing** (matters because `Result.retry` burns battery):
| Error | Outcome | Why |
|---|---|---|
| `MissingApiKeyException`, `GeminiBlockedException`, 401/403 | `failure` | User must fix configuration |
| `GeminiEmptyResponseException`, connect/socket/request timeouts, `IOException`, 5xx | `retry` | Transient |
| Anything else | `failure` | Logged for triage |

**DI**: `AdaptWeatherApplication` gains lazy properties for `HttpClient` (Ktor + OkHttp), `WeatherRepository`, `InsightGenerator`, `GenerateDailyInsight`. The Worker fetches them from the app context — no custom `WorkerFactory` needed yet.

**Out of scope (follow-ups)**:
- GPS at notify time (currently hard-coded to London) + location-permission UX
- 24h cost cap on Gemini calls
- Debug "fire now" button in Settings to exercise this end-to-end without waiting until 7am
- TTS

## Test plan

- [x] All existing unit tests still pass
- [x] No new unit tests — Worker is orchestration with the tested logic in `:core:domain` (`GenerateDailyInsight`) and `:core:data` (`OpenMeteoClient`, `DirectGeminiClient`)
- [ ] CI green
- [ ] Sideload on phone, set Gemini key, set time to 1 minute from now, verify a notification fires with a real Gemini-generated insight
- [ ] Verify retry behaviour with airplane mode at fire time

https://claude.ai/code/session_01VftWR7DyaaVXHnovkuQwge

---
_Generated by [Claude Code](https://claude.ai/code/session_01VftWR7DyaaVXHnovkuQwge)_