### PR TITLE
:app — debug "fire insight now" button in Settings

### DIFF
--- a/app/src/main/kotlin/com/adaptweather/ui/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/adaptweather/ui/settings/SettingsScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
+import android.widget.Toast
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
@@ -27,16 +28,19 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.adaptweather.BuildConfig
 import com.adaptweather.R
 import com.adaptweather.core.domain.model.DeliveryMode
 import com.adaptweather.core.domain.model.DistanceUnit
 import com.adaptweather.core.domain.model.TemperatureUnit
+import com.adaptweather.work.FetchAndNotifyWorker
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -86,6 +90,31 @@ private fun SettingsContent(
         DeliveryModeCard(state.deliveryMode, onSetDeliveryMode)
         TemperatureUnitCard(state.temperatureUnit, onSetTemperatureUnit)
         DistanceUnitCard(state.distanceUnit, onSetDistanceUnit)
+        if (BuildConfig.DEBUG) {
+            DebugCard()
+        }
+    }
+}
+
+@Composable
+private fun DebugCard() {
+    val context = LocalContext.current
+    SectionCard(title = stringResource(R.string.settings_debug_title)) {
+        Text(
+            text = stringResource(R.string.settings_debug_description),
+            style = MaterialTheme.typography.bodyMedium,
+        )
+        Button(
+            onClick = {
+                FetchAndNotifyWorker.enqueueOneShot(context.applicationContext)
+                Toast.makeText(
+                    context,
+                    context.getString(R.string.settings_debug_fire_toast),
+                    Toast.LENGTH_SHORT,
+                ).show()
+            },
+            modifier = Modifier.fillMaxWidth(),
+        ) { Text(stringResource(R.string.settings_debug_fire_now)) }
     }
 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -27,4 +27,9 @@
     <string name="notification_channel_daily_insight_name">Daily insight</string>
     <string name="notification_channel_daily_insight_description">The morning weather summary you opted in to.</string>
     <string name="notification_daily_insight_title">Today\'s weather</string>
+
+    <string name="settings_debug_title">Debug (debug builds only)</string>
+    <string name="settings_debug_description">Fire the daily-insight pipeline immediately. Useful for verifying without waiting until the scheduled time.</string>
+    <string name="settings_debug_fire_now">Fire insight now</string>
+    <string name="settings_debug_fire_toast">Insight worker enqueued</string>
 </resources>


### PR DESCRIPTION
## Summary

The plan called this out as "the single most valuable test affordance you'll build." Adds a Debug card at the bottom of Settings, gated by `BuildConfig.DEBUG` so it disappears from release builds. Tapping the button enqueues `FetchAndNotifyWorker.enqueueOneShot()` — same path the 7am alarm uses — and toasts a confirmation.

Lets us exercise the full Open-Meteo + Gemini + notification pipeline on demand without waiting until 7am. The `OneTimeWorkRequest` still goes through WorkManager so the `NetworkType.CONNECTED` constraint and exponential backoff are exercised exactly as they are in production.

Click handler wired directly from Compose to the Worker companion — no `ViewModel` detour, since this is debug-only and the Worker holds no state we'd want surfaced in the UI.

## Test plan

- [x] All existing tests still pass
- [x] Debug card hidden in release builds (`BuildConfig.DEBUG` gate)
- [ ] CI green
- [ ] Sideload debug APK, paste a Gemini key, tap "Fire insight now", verify a notification appears within ~10s with a real Gemini-generated insight
- [ ] Verify the card is gone from a release build

https://claude.ai/code/session_01VftWR7DyaaVXHnovkuQwge

---
_Generated by [Claude Code](https://claude.ai/code/session_01VftWR7DyaaVXHnovkuQwge)_