### PR TITLE
:app — POST_NOTIFICATIONS runtime permission UX

### DIFF
--- a/app/src/main/kotlin/com/adaptweather/ui/settings/NotificationPermissionBanner.kt
+++ b/app/src/main/kotlin/com/adaptweather/ui/settings/NotificationPermissionBanner.kt
@@ -1,0 +1,87 @@
+package com.adaptweather.ui.settings
+
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import com.adaptweather.R
+import com.adaptweather.notification.NotificationPermission
+
+/**
+ * Banner shown when POST_NOTIFICATIONS is required (Android 13+) but not yet granted.
+ * Renders nothing on older platforms or once permission is granted.
+ *
+ * Re-checks permission on resume so toggling it from system Settings is reflected
+ * without requiring an in-app action.
+ */
+@Composable
+fun NotificationPermissionBanner(modifier: Modifier = Modifier) {
+    if (!NotificationPermission.isRequired()) return
+
+    val context = LocalContext.current
+    var granted by remember { mutableStateOf(NotificationPermission.isGranted(context)) }
+
+    val launcher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestPermission(),
+    ) { result ->
+        granted = result
+    }
+
+    val lifecycleOwner = LocalLifecycleOwner.current
+    LaunchedEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                granted = NotificationPermission.isGranted(context)
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+    }
+
+    if (granted) return
+
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.errorContainer,
+            contentColor = MaterialTheme.colorScheme.onErrorContainer,
+        ),
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.settings_notification_permission_title),
+                style = MaterialTheme.typography.titleMedium,
+            )
+            Text(
+                text = stringResource(R.string.settings_notification_permission_description),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+            Button(
+                onClick = { launcher.launch(NotificationPermission.MANIFEST_PERMISSION) },
+                modifier = Modifier.fillMaxWidth(),
+            ) { Text(stringResource(R.string.settings_notification_permission_grant)) }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/adaptweather/ui/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/adaptweather/ui/settings/SettingsScreen.kt
@@ -82,6 +82,7 @@ private fun SettingsContent(
             .padding(horizontal = 16.dp, vertical = 8.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {
+        NotificationPermissionBanner()
         ApiKeyCard(
             configured = state.apiKeyConfigured,
             onSave = onSetApiKey,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,6 +28,10 @@
     <string name="notification_channel_daily_insight_description">The morning weather summary you opted in to.</string>
     <string name="notification_daily_insight_title">Today\'s weather</string>
 
+    <string name="settings_notification_permission_title">Notifications are blocked</string>
+    <string name="settings_notification_permission_description">Without notification permission, the daily insight has nowhere to go. Grant it so AdaptWeather can post tomorrow morning.</string>
+    <string name="settings_notification_permission_grant">Grant notification permission</string>
+
     <string name="settings_debug_title">Debug (debug builds only)</string>
     <string name="settings_debug_description">Fire the daily-insight pipeline immediately. Useful for verifying without waiting until the scheduled time.</string>
     <string name="settings_debug_fire_now">Fire insight now</string>


### PR DESCRIPTION
## Summary

Surfaces the missing `POST_NOTIFICATIONS` runtime permission. Without this, on Android 13+ the `InsightNotifier` silently no-ops and the daily worker effectively disappears — confusing UX, since the user thinks they configured everything.

`NotificationPermissionBanner` sits at the top of Settings and renders a red error-container card when the permission is required but not granted. Tapping the button launches the standard `ActivityResultContracts.RequestPermission` flow. Re-checks state on every `ON_RESUME` so toggling from system Settings is reflected without an in-app action. Renders nothing on Android <13 or once permission is granted.

## Test plan

- [x] All existing tests still pass
- [ ] CI green
- [ ] Sideload, on a fresh install confirm the banner appears
- [ ] Tap "Grant", verify the system dialog, grant, banner disappears
- [ ] Revoke from system Settings, return to app, banner reappears
- [ ] On a hypothetical Android <13 device the banner is invisible (gated by `NotificationPermission.isRequired()`)

https://claude.ai/code/session_01VftWR7DyaaVXHnovkuQwge

---
_Generated by [Claude Code](https://claude.ai/code/session_01VftWR7DyaaVXHnovkuQwge)_