### PR TITLE
:app — schedule editor (time picker + day-of-week chips)

### DIFF
--- a/app/src/main/kotlin/com/adaptweather/MainActivity.kt
+++ b/app/src/main/kotlin/com/adaptweather/MainActivity.kt
@@ -26,6 +26,7 @@ class MainActivity : ComponentActivity() {
                         factory = SettingsViewModel.Factory(
                             settingsRepository = app.settingsRepository,
                             keyStore = app.secureKeyStore,
+                            rearmAlarm = app.dailyAlarmScheduler::schedule,
                         ),
                     )
                     SettingsScreen(viewModel = viewModel)

--- a/app/src/main/kotlin/com/adaptweather/ui/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/adaptweather/ui/settings/SettingsScreen.kt
@@ -11,16 +11,22 @@ import androidx.compose.foundation.rememberScrollState
 import android.widget.Toast
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.TimePicker
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.rememberTimePickerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -41,6 +47,11 @@ import com.adaptweather.core.domain.model.DeliveryMode
 import com.adaptweather.core.domain.model.DistanceUnit
 import com.adaptweather.core.domain.model.TemperatureUnit
 import com.adaptweather.work.FetchAndNotifyWorker
+import java.time.DayOfWeek
+import java.time.LocalTime
+import java.time.format.DateTimeFormatter
+import java.time.format.TextStyle
+import java.util.Locale
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -57,6 +68,7 @@ fun SettingsScreen(viewModel: SettingsViewModel) {
             padding = padding,
             onSetApiKey = viewModel::setApiKey,
             onClearApiKey = viewModel::clearApiKey,
+            onSetSchedule = viewModel::setSchedule,
             onSetDeliveryMode = viewModel::setDeliveryMode,
             onSetTemperatureUnit = viewModel::setTemperatureUnit,
             onSetDistanceUnit = viewModel::setDistanceUnit,
@@ -70,6 +82,7 @@ private fun SettingsContent(
     padding: PaddingValues,
     onSetApiKey: (String) -> Unit,
     onClearApiKey: () -> Unit,
+    onSetSchedule: (LocalTime, Set<DayOfWeek>) -> Unit,
     onSetDeliveryMode: (DeliveryMode) -> Unit,
     onSetTemperatureUnit: (TemperatureUnit) -> Unit,
     onSetDistanceUnit: (DistanceUnit) -> Unit,
@@ -88,6 +101,11 @@ private fun SettingsContent(
             onSave = onSetApiKey,
             onClear = onClearApiKey,
         )
+        ScheduleCard(
+            time = state.scheduleTime,
+            days = state.scheduleDays,
+            onChange = onSetSchedule,
+        )
         DeliveryModeCard(state.deliveryMode, onSetDeliveryMode)
         TemperatureUnitCard(state.temperatureUnit, onSetTemperatureUnit)
         DistanceUnitCard(state.distanceUnit, onSetDistanceUnit)
@@ -96,6 +114,100 @@ private fun SettingsContent(
         }
     }
 }
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ScheduleCard(
+    time: LocalTime,
+    days: Set<DayOfWeek>,
+    onChange: (LocalTime, Set<DayOfWeek>) -> Unit,
+) {
+    var pickerOpen by remember { mutableStateOf(false) }
+
+    SectionCard(title = stringResource(R.string.settings_schedule_title)) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = stringResource(R.string.settings_schedule_time_label),
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier.padding(end = 12.dp),
+            )
+            OutlinedButton(onClick = { pickerOpen = true }) {
+                Text(text = TIME_FORMAT.format(time))
+            }
+        }
+
+        Text(
+            text = stringResource(R.string.settings_schedule_days_label),
+            style = MaterialTheme.typography.bodyMedium,
+        )
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            // Iterate week starting from MONDAY for European-style locales; Compose's
+            // FilterChip wraps to multiple lines if needed. Picking a Set<DayOfWeek>
+            // is semantic enough that the user-set order is irrelevant to scheduling.
+            DayOfWeek.entries.forEach { dow ->
+                val selected = dow in days
+                FilterChip(
+                    selected = selected,
+                    onClick = {
+                        val next = if (selected) days - dow else days + dow
+                        if (next.isNotEmpty()) onChange(time, next)
+                    },
+                    label = {
+                        Text(text = dow.getDisplayName(TextStyle.SHORT, Locale.getDefault()))
+                    },
+                    colors = FilterChipDefaults.filterChipColors(),
+                )
+            }
+        }
+    }
+
+    if (pickerOpen) {
+        TimePickerDialog(
+            initial = time,
+            onDismiss = { pickerOpen = false },
+            onConfirm = { newTime ->
+                pickerOpen = false
+                onChange(newTime, days)
+            },
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun TimePickerDialog(
+    initial: LocalTime,
+    onDismiss: () -> Unit,
+    onConfirm: (LocalTime) -> Unit,
+) {
+    val state = rememberTimePickerState(
+        initialHour = initial.hour,
+        initialMinute = initial.minute,
+        is24Hour = true,
+    )
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        confirmButton = {
+            TextButton(onClick = { onConfirm(LocalTime.of(state.hour, state.minute)) }) {
+                Text(stringResource(android.R.string.ok))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(android.R.string.cancel))
+            }
+        },
+        text = { TimePicker(state = state) },
+    )
+}
+
+private val TIME_FORMAT: DateTimeFormatter = DateTimeFormatter.ofPattern("HH:mm")
 
 @Composable
 private fun DebugCard() {

--- a/app/src/main/kotlin/com/adaptweather/ui/settings/SettingsState.kt
+++ b/app/src/main/kotlin/com/adaptweather/ui/settings/SettingsState.kt
@@ -2,13 +2,18 @@ package com.adaptweather.ui.settings
 
 import com.adaptweather.core.domain.model.DeliveryMode
 import com.adaptweather.core.domain.model.DistanceUnit
+import com.adaptweather.core.domain.model.Schedule
 import com.adaptweather.core.domain.model.TemperatureUnit
+import java.time.DayOfWeek
+import java.time.LocalTime
 
 /**
- * What [SettingsScreen] needs to render. Settings that are not yet user-editable
- * (schedule, wardrobe rules) are intentionally absent and will land in follow-up PRs.
+ * What [SettingsScreen] needs to render. The wardrobe-rules editor is not yet user-
+ * editable and will land in a follow-up PR.
  */
 data class SettingsState(
+    val scheduleTime: LocalTime = LocalTime.of(7, 0),
+    val scheduleDays: Set<DayOfWeek> = Schedule.EVERY_DAY,
     val deliveryMode: DeliveryMode = DeliveryMode.NOTIFICATION_ONLY,
     val temperatureUnit: TemperatureUnit = TemperatureUnit.CELSIUS,
     val distanceUnit: DistanceUnit = DistanceUnit.KILOMETERS,

--- a/app/src/main/kotlin/com/adaptweather/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/adaptweather/ui/settings/SettingsViewModel.kt
@@ -5,18 +5,23 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.adaptweather.core.domain.model.DeliveryMode
 import com.adaptweather.core.domain.model.DistanceUnit
+import com.adaptweather.core.domain.model.Schedule
 import com.adaptweather.core.domain.model.TemperatureUnit
 import com.adaptweather.data.SecureKeyStore
 import com.adaptweather.data.SettingsRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import java.time.DayOfWeek
+import java.time.LocalTime
 
 class SettingsViewModel(
     private val settingsRepository: SettingsRepository,
     private val keyStore: SecureKeyStore,
+    private val rearmAlarm: (Schedule) -> Unit,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(SettingsState())
@@ -27,6 +32,8 @@ class SettingsViewModel(
             settingsRepository.preferences.collect { prefs ->
                 _state.update {
                     it.copy(
+                        scheduleTime = prefs.schedule.time,
+                        scheduleDays = prefs.schedule.days,
                         deliveryMode = prefs.deliveryMode,
                         temperatureUnit = prefs.temperatureUnit,
                         distanceUnit = prefs.distanceUnit,
@@ -63,6 +70,18 @@ class SettingsViewModel(
         viewModelScope.launch { settingsRepository.setDistanceUnit(unit) }
     }
 
+    fun setSchedule(time: LocalTime, days: Set<DayOfWeek>) {
+        if (days.isEmpty()) return
+        viewModelScope.launch {
+            settingsRepository.setSchedule(time, days)
+            // Re-arm the alarm immediately so the next occurrence picks up the new wall-clock.
+            // The repository resolves zoneId fresh on each emission, so the schedule we read
+            // back is the new one with the current zone.
+            val updated = settingsRepository.preferences.first().schedule
+            rearmAlarm(updated)
+        }
+    }
+
     private suspend fun refreshApiKeyStatus() {
         val configured = runCatching { keyStore.get().isNotBlank() }.getOrDefault(false)
         _state.update { it.copy(apiKeyConfigured = configured) }
@@ -71,13 +90,14 @@ class SettingsViewModel(
     class Factory(
         private val settingsRepository: SettingsRepository,
         private val keyStore: SecureKeyStore,
+        private val rearmAlarm: (Schedule) -> Unit,
     ) : ViewModelProvider.Factory {
         @Suppress("UNCHECKED_CAST")
         override fun <T : ViewModel> create(modelClass: Class<T>): T {
             require(modelClass.isAssignableFrom(SettingsViewModel::class.java)) {
                 "Unknown ViewModel: ${modelClass.name}"
             }
-            return SettingsViewModel(settingsRepository, keyStore) as T
+            return SettingsViewModel(settingsRepository, keyStore, rearmAlarm) as T
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,6 +11,10 @@
     <string name="settings_api_key_save">Save key</string>
     <string name="settings_api_key_clear">Clear stored key</string>
 
+    <string name="settings_schedule_title">When to deliver the daily insight</string>
+    <string name="settings_schedule_time_label">Time</string>
+    <string name="settings_schedule_days_label">Days of the week</string>
+
     <string name="settings_delivery_title">How to deliver the daily insight</string>
     <string name="settings_delivery_notification_only">Notification only</string>
     <string name="settings_delivery_tts_only">Spoken aloud only</string>

--- a/app/src/test/kotlin/com/adaptweather/ui/settings/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/com/adaptweather/ui/settings/SettingsViewModelTest.kt
@@ -50,7 +50,7 @@ class SettingsViewModelTest {
         )
         settingsRepository = SettingsRepository(settingsDataStore)
         keyStore = SecureKeyStore(IdentityFakeAead, keyDataStore)
-        subject = SettingsViewModel(settingsRepository, keyStore)
+        subject = SettingsViewModel(settingsRepository, keyStore, rearmAlarm = {})
     }
 
     @AfterEach


### PR DESCRIPTION
## Summary

Closes the second of the two MVP UI requirements: the user can now set **when** the daily insight fires.

`ScheduleCard` renders the current `HH:mm` in an `OutlinedButton` that opens a Material 3 `TimePickerDialog` (24-hour) plus a `FilterChip` per `DayOfWeek`. Either edit calls back through `SettingsViewModel.setSchedule`, which:

1. Persists via `SettingsRepository.setSchedule`.
2. Re-arms the alarm immediately via the `rearmAlarm` callback so the next occurrence picks up the new wall-clock without waiting for a reboot or timezone-change broadcast.

Day toggles refuse to leave an empty set (the `Schedule` `init` also guards server-side).

**Architecture**: replaced the `DailyAlarmScheduler` dependency on the ViewModel with a `(Schedule) -> Unit` callback so the ViewModel stays trivially unit-testable without faking `AlarmManager`. `MainActivity` wires `app.dailyAlarmScheduler::schedule`.

## Test plan

- [x] All existing tests still pass; `SettingsViewModelTest` updated to pass a no-op `rearmAlarm`
- [ ] CI green
- [ ] Sideload, change time to 1 minute from now, verify the new alarm fires (via either notification or `dumpsys alarm`)
- [ ] Toggle off all days, confirm the day-chip stays selected (last-day guard)
- [ ] Toggle off Saturday/Sunday, verify weekday-only schedule survives a process kill
- [ ] Follow-ups: wardrobe rules editor, GPS at notify time

https://claude.ai/code/session_01VftWR7DyaaVXHnovkuQwge

---
_Generated by [Claude Code](https://claude.ai/code/session_01VftWR7DyaaVXHnovkuQwge)_