### PR TITLE
:app + :core — settings-based location with city search

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -107,5 +107,8 @@ dependencies {
     testImplementation(libs.kotest.assertions.core)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.androidx.datastore.preferences.core)
+    // SettingsViewModelTest stubs the geocoding client with a Ktor MockEngine so the
+    // tests don't need network. Same library that :core:data already uses.
+    testImplementation(libs.ktor.client.mock)
 }
 

--- a/app/src/main/kotlin/com/adaptweather/AdaptWeatherApplication.kt
+++ b/app/src/main/kotlin/com/adaptweather/AdaptWeatherApplication.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import android.util.Log
 import com.adaptweather.alarm.DailyAlarmScheduler
 import com.adaptweather.core.data.insight.DirectGeminiClient
+import com.adaptweather.core.data.location.OpenMeteoGeocodingClient
 import com.adaptweather.core.data.weather.OpenMeteoClient
 import com.adaptweather.core.domain.repository.InsightGenerator
 import com.adaptweather.core.domain.repository.WeatherRepository
@@ -46,6 +47,7 @@ class AdaptWeatherApplication : Application() {
     }
 
     val weatherRepository: WeatherRepository by lazy { OpenMeteoClient(httpClient) }
+    val geocodingClient: OpenMeteoGeocodingClient by lazy { OpenMeteoGeocodingClient(httpClient) }
     val insightGenerator: InsightGenerator by lazy { DirectGeminiClient(httpClient, secureKeyStore) }
     val generateDailyInsight: GenerateDailyInsight by lazy {
         GenerateDailyInsight(weatherRepository, insightGenerator)

--- a/app/src/main/kotlin/com/adaptweather/MainActivity.kt
+++ b/app/src/main/kotlin/com/adaptweather/MainActivity.kt
@@ -27,6 +27,7 @@ class MainActivity : ComponentActivity() {
                             settingsRepository = app.settingsRepository,
                             keyStore = app.secureKeyStore,
                             rearmAlarm = app.dailyAlarmScheduler::schedule,
+                            geocodingClient = app.geocodingClient,
                         ),
                     )
                     SettingsScreen(viewModel = viewModel)

--- a/app/src/main/kotlin/com/adaptweather/data/SettingsRepository.kt
+++ b/app/src/main/kotlin/com/adaptweather/data/SettingsRepository.kt
@@ -3,12 +3,14 @@ package com.adaptweather.data
 import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.doublePreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.core.stringSetPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import com.adaptweather.core.domain.model.DeliveryMode
 import com.adaptweather.core.domain.model.DistanceUnit
+import com.adaptweather.core.domain.model.Location
 import com.adaptweather.core.domain.model.Schedule
 import com.adaptweather.core.domain.model.TemperatureUnit
 import com.adaptweather.core.domain.model.UserPreferences
@@ -65,6 +67,22 @@ class SettingsRepository(
         dataStore.edit { it[WARDROBE_RULES] = json.encodeToString(rules.map { rule -> rule.toDto() }) }
     }
 
+    suspend fun setLocation(location: Location) {
+        dataStore.edit { prefs ->
+            prefs[LOCATION_LAT] = location.latitude
+            prefs[LOCATION_LON] = location.longitude
+            location.displayName?.let { prefs[LOCATION_NAME] = it } ?: prefs.remove(LOCATION_NAME)
+        }
+    }
+
+    suspend fun clearLocation() {
+        dataStore.edit { prefs ->
+            prefs.remove(LOCATION_LAT)
+            prefs.remove(LOCATION_LON)
+            prefs.remove(LOCATION_NAME)
+        }
+    }
+
     private fun Preferences.toUserPreferences(): UserPreferences {
         val time = this[SCHEDULE_TIME]?.let { LocalTime.parse(it, TIME_FORMAT) }
             ?: DEFAULT_TIME
@@ -79,6 +97,7 @@ class SettingsRepository(
         val distanceUnit = this[DISTANCE_UNIT]?.let { runCatching { DistanceUnit.valueOf(it) }.getOrNull() }
             ?: DistanceUnit.KILOMETERS
         val rules = parseRules(this[WARDROBE_RULES])
+        val location = parseLocation(this)
 
         return UserPreferences(
             schedule = Schedule(time = time, days = days, zoneId = zoneIdProvider()),
@@ -86,7 +105,20 @@ class SettingsRepository(
             temperatureUnit = temperatureUnit,
             distanceUnit = distanceUnit,
             wardrobeRules = rules,
+            location = location,
         )
+    }
+
+    private fun parseLocation(prefs: Preferences): Location? {
+        val lat = prefs[LOCATION_LAT] ?: return null
+        val lon = prefs[LOCATION_LON] ?: return null
+        return runCatching {
+            Location(
+                latitude = lat,
+                longitude = lon,
+                displayName = prefs[LOCATION_NAME],
+            )
+        }.getOrNull()
     }
 
     private fun parseRules(raw: String?): List<WardrobeRule> {
@@ -103,6 +135,9 @@ class SettingsRepository(
         private val TEMPERATURE_UNIT = stringPreferencesKey("temperature_unit")
         private val DISTANCE_UNIT = stringPreferencesKey("distance_unit")
         private val WARDROBE_RULES = stringPreferencesKey("wardrobe_rules_json")
+        private val LOCATION_LAT = doublePreferencesKey("location_latitude")
+        private val LOCATION_LON = doublePreferencesKey("location_longitude")
+        private val LOCATION_NAME = stringPreferencesKey("location_display_name")
 
         private val TIME_FORMAT: DateTimeFormatter = DateTimeFormatter.ofPattern("HH:mm")
         private val DEFAULT_TIME: LocalTime = LocalTime.of(7, 0)

--- a/app/src/main/kotlin/com/adaptweather/ui/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/adaptweather/ui/settings/SettingsScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -50,9 +51,11 @@ import com.adaptweather.BuildConfig
 import com.adaptweather.R
 import com.adaptweather.core.domain.model.DeliveryMode
 import com.adaptweather.core.domain.model.DistanceUnit
+import com.adaptweather.core.domain.model.Location
 import com.adaptweather.core.domain.model.TemperatureUnit
 import com.adaptweather.core.domain.model.WardrobeRule
 import com.adaptweather.work.FetchAndNotifyWorker
+import kotlinx.coroutines.launch
 import java.time.DayOfWeek
 import java.time.LocalTime
 import java.time.format.DateTimeFormatter
@@ -81,6 +84,9 @@ fun SettingsScreen(viewModel: SettingsViewModel) {
             onAddWardrobeRule = viewModel::addWardrobeRule,
             onReplaceWardrobeRule = viewModel::replaceWardrobeRule,
             onDeleteWardrobeRule = viewModel::deleteWardrobeRule,
+            onSelectLocation = viewModel::selectLocation,
+            onClearLocation = viewModel::clearLocation,
+            onSearchLocations = viewModel::searchLocations,
         )
     }
 }
@@ -98,6 +104,9 @@ private fun SettingsContent(
     onAddWardrobeRule: (WardrobeRule) -> Unit,
     onReplaceWardrobeRule: (Int, WardrobeRule) -> Unit,
     onDeleteWardrobeRule: (Int) -> Unit,
+    onSelectLocation: (Location) -> Unit,
+    onClearLocation: () -> Unit,
+    onSearchLocations: suspend (String) -> List<Location>,
 ) {
     Column(
         modifier = Modifier
@@ -112,6 +121,12 @@ private fun SettingsContent(
             configured = state.apiKeyConfigured,
             onSave = onSetApiKey,
             onClear = onClearApiKey,
+        )
+        LocationCard(
+            current = state.location,
+            onSelect = onSelectLocation,
+            onClear = onClearLocation,
+            onSearch = onSearchLocations,
         )
         ScheduleCard(
             time = state.scheduleTime,
@@ -131,6 +146,149 @@ private fun SettingsContent(
             DebugCard()
         }
     }
+}
+
+@Composable
+private fun LocationCard(
+    current: Location?,
+    onSelect: (Location) -> Unit,
+    onClear: () -> Unit,
+    onSearch: suspend (String) -> List<Location>,
+) {
+    var dialogOpen by remember { mutableStateOf(false) }
+    SectionCard(title = stringResource(R.string.settings_location_title)) {
+        Text(
+            text = current?.displayName
+                ?: current?.let { "${it.latitude}, ${it.longitude}" }
+                ?: stringResource(R.string.settings_location_unset),
+            style = MaterialTheme.typography.bodyLarge,
+        )
+        Text(
+            text = stringResource(R.string.settings_location_description),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Button(
+            onClick = { dialogOpen = true },
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text(
+                stringResource(
+                    if (current == null) R.string.settings_location_set
+                    else R.string.settings_location_change,
+                ),
+            )
+        }
+        if (current != null) {
+            TextButton(onClick = onClear, modifier = Modifier.fillMaxWidth()) {
+                Text(stringResource(R.string.settings_location_clear))
+            }
+        }
+    }
+
+    if (dialogOpen) {
+        LocationSearchDialog(
+            onDismiss = { dialogOpen = false },
+            onSelect = {
+                onSelect(it)
+                dialogOpen = false
+            },
+            onSearch = onSearch,
+        )
+    }
+}
+
+@Composable
+private fun LocationSearchDialog(
+    onDismiss: () -> Unit,
+    onSelect: (Location) -> Unit,
+    onSearch: suspend (String) -> List<Location>,
+) {
+    var query by remember { mutableStateOf("") }
+    var results by remember { mutableStateOf<List<Location>>(emptyList()) }
+    var inFlight by remember { mutableStateOf(false) }
+    var error by remember { mutableStateOf<String?>(null) }
+    var selected by remember { mutableStateOf<Location?>(null) }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        confirmButton = {
+            TextButton(
+                enabled = selected != null,
+                onClick = { selected?.let(onSelect) },
+            ) { Text(stringResource(android.R.string.ok)) }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(android.R.string.cancel))
+            }
+        },
+        title = { Text(stringResource(R.string.settings_location_search_title)) },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    OutlinedTextField(
+                        value = query,
+                        onValueChange = { query = it },
+                        label = { Text(stringResource(R.string.settings_location_query_label)) },
+                        singleLine = true,
+                        modifier = Modifier.weight(1f),
+                    )
+                    val coroutineScope = rememberCoroutineScope()
+                    TextButton(
+                        enabled = query.isNotBlank() && !inFlight,
+                        onClick = {
+                            coroutineScope.launch {
+                                inFlight = true
+                                error = null
+                                try {
+                                    results = onSearch(query)
+                                    selected = null
+                                } catch (t: Throwable) {
+                                    error = t.message ?: t.javaClass.simpleName
+                                    results = emptyList()
+                                } finally {
+                                    inFlight = false
+                                }
+                            }
+                        },
+                        modifier = Modifier.padding(start = 8.dp),
+                    ) { Text(stringResource(R.string.settings_location_search)) }
+                }
+
+                when {
+                    inFlight -> Text(stringResource(R.string.settings_location_searching))
+                    error != null -> Text(
+                        text = error!!,
+                        color = MaterialTheme.colorScheme.error,
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                    results.isEmpty() && query.isNotBlank() ->
+                        Text(stringResource(R.string.settings_location_no_results))
+                    else -> results.forEach { result ->
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(vertical = 2.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            RadioButton(
+                                selected = selected == result,
+                                onClick = { selected = result },
+                            )
+                            Text(
+                                text = result.displayName ?: "${result.latitude}, ${result.longitude}",
+                                modifier = Modifier.padding(start = 8.dp),
+                            )
+                        }
+                    }
+                }
+            }
+        },
+    )
 }
 
 @Composable

--- a/app/src/main/kotlin/com/adaptweather/ui/settings/SettingsState.kt
+++ b/app/src/main/kotlin/com/adaptweather/ui/settings/SettingsState.kt
@@ -2,6 +2,7 @@ package com.adaptweather.ui.settings
 
 import com.adaptweather.core.domain.model.DeliveryMode
 import com.adaptweather.core.domain.model.DistanceUnit
+import com.adaptweather.core.domain.model.Location
 import com.adaptweather.core.domain.model.Schedule
 import com.adaptweather.core.domain.model.TemperatureUnit
 import com.adaptweather.core.domain.model.WardrobeRule
@@ -16,5 +17,6 @@ data class SettingsState(
     val temperatureUnit: TemperatureUnit = TemperatureUnit.CELSIUS,
     val distanceUnit: DistanceUnit = DistanceUnit.KILOMETERS,
     val wardrobeRules: List<WardrobeRule> = WardrobeRule.DEFAULTS,
+    val location: Location? = null,
     val apiKeyConfigured: Boolean = false,
 )

--- a/app/src/main/kotlin/com/adaptweather/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/adaptweather/ui/settings/SettingsViewModel.kt
@@ -3,8 +3,10 @@ package com.adaptweather.ui.settings
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
+import com.adaptweather.core.data.location.OpenMeteoGeocodingClient
 import com.adaptweather.core.domain.model.DeliveryMode
 import com.adaptweather.core.domain.model.DistanceUnit
+import com.adaptweather.core.domain.model.Location
 import com.adaptweather.core.domain.model.Schedule
 import com.adaptweather.core.domain.model.TemperatureUnit
 import com.adaptweather.core.domain.model.WardrobeRule
@@ -23,6 +25,7 @@ class SettingsViewModel(
     private val settingsRepository: SettingsRepository,
     private val keyStore: SecureKeyStore,
     private val rearmAlarm: (Schedule) -> Unit,
+    private val geocodingClient: OpenMeteoGeocodingClient,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(SettingsState())
@@ -39,6 +42,7 @@ class SettingsViewModel(
                         temperatureUnit = prefs.temperatureUnit,
                         distanceUnit = prefs.distanceUnit,
                         wardrobeRules = prefs.wardrobeRules,
+                        location = prefs.location,
                     )
                 }
             }
@@ -94,6 +98,17 @@ class SettingsViewModel(
         }
     }
 
+    fun selectLocation(location: Location) {
+        viewModelScope.launch { settingsRepository.setLocation(location) }
+    }
+
+    fun clearLocation() {
+        viewModelScope.launch { settingsRepository.clearLocation() }
+    }
+
+    /** Used by [LocationCard] inside a LaunchedEffect; safe to call from any dispatcher. */
+    suspend fun searchLocations(query: String): List<Location> = geocodingClient.search(query)
+
     fun setSchedule(time: LocalTime, days: Set<DayOfWeek>) {
         if (days.isEmpty()) return
         viewModelScope.launch {
@@ -115,13 +130,14 @@ class SettingsViewModel(
         private val settingsRepository: SettingsRepository,
         private val keyStore: SecureKeyStore,
         private val rearmAlarm: (Schedule) -> Unit,
+        private val geocodingClient: OpenMeteoGeocodingClient,
     ) : ViewModelProvider.Factory {
         @Suppress("UNCHECKED_CAST")
         override fun <T : ViewModel> create(modelClass: Class<T>): T {
             require(modelClass.isAssignableFrom(SettingsViewModel::class.java)) {
                 "Unknown ViewModel: ${modelClass.name}"
             }
-            return SettingsViewModel(settingsRepository, keyStore, rearmAlarm) as T
+            return SettingsViewModel(settingsRepository, keyStore, rearmAlarm, geocodingClient) as T
         }
     }
 }

--- a/app/src/main/kotlin/com/adaptweather/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/com/adaptweather/work/FetchAndNotifyWorker.kt
@@ -57,7 +57,7 @@ class FetchAndNotifyWorker(
             return Result.retry()
         }
 
-        val location = resolveLocation()
+        val location = prefs.location ?: DEFAULT_LOCATION
         val languageTag = java.util.Locale.getDefault().toLanguageTag()
 
         return try {
@@ -117,15 +117,18 @@ class FetchAndNotifyWorker(
         }
     }
 
-    private fun resolveLocation(): Location {
-        // TODO: replace with the GPS-at-notify-time resolver once the location-permission
-        // UX lands. London is a sensible v1 default and lets the rest of the pipeline run.
-        return Location(latitude = 51.5074, longitude = -0.1278, displayName = "London")
-    }
-
     companion object {
         private const val TAG = "FetchAndNotifyWorker"
         const val UNIQUE_WORK_NAME = "daily_insight_fetch"
+
+        // Fallback when the user hasn't set a location yet — the pipeline still runs and
+        // posts a (London) insight rather than silently failing. The Settings screen
+        // surfaces an empty-location card so the user can change it.
+        private val DEFAULT_LOCATION = Location(
+            latitude = 51.5074,
+            longitude = -0.1278,
+            displayName = "London (default)",
+        )
 
         fun enqueueOneShot(context: Context) {
             val constraints = Constraints.Builder()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,6 +11,18 @@
     <string name="settings_api_key_save">Save key</string>
     <string name="settings_api_key_clear">Clear stored key</string>
 
+    <string name="settings_location_title">Location</string>
+    <string name="settings_location_unset">No location set — defaulting to London</string>
+    <string name="settings_location_description">The forecast is fetched for this place. Search by city name; results come from Open-Meteo\'s free geocoding service.</string>
+    <string name="settings_location_set">Set location</string>
+    <string name="settings_location_change">Change location</string>
+    <string name="settings_location_clear">Clear location</string>
+    <string name="settings_location_search_title">Search for a location</string>
+    <string name="settings_location_query_label">City or place</string>
+    <string name="settings_location_search">Search</string>
+    <string name="settings_location_searching">Searching…</string>
+    <string name="settings_location_no_results">No matches.</string>
+
     <string name="settings_schedule_title">When to deliver the daily insight</string>
     <string name="settings_schedule_time_label">Time</string>
     <string name="settings_schedule_days_label">Days of the week</string>

--- a/app/src/test/kotlin/com/adaptweather/ui/settings/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/com/adaptweather/ui/settings/SettingsViewModelTest.kt
@@ -3,12 +3,23 @@ package com.adaptweather.ui.settings
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences
+import com.adaptweather.core.data.location.OpenMeteoGeocodingClient
 import com.adaptweather.core.domain.model.DeliveryMode
 import com.adaptweather.core.domain.model.DistanceUnit
 import com.adaptweather.core.domain.model.TemperatureUnit
 import com.adaptweather.data.SecureKeyStore
 import com.adaptweather.data.SettingsRepository
 import com.google.crypto.tink.Aead
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.utils.io.ByteReadChannel
+import kotlinx.serialization.json.Json as KotlinxJson
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -50,7 +61,23 @@ class SettingsViewModelTest {
         )
         settingsRepository = SettingsRepository(settingsDataStore)
         keyStore = SecureKeyStore(IdentityFakeAead, keyDataStore)
-        subject = SettingsViewModel(settingsRepository, keyStore, rearmAlarm = {})
+        // Geocoding client wired with a Mock engine that always returns an empty response;
+        // the tests in this class don't exercise location lookup.
+        val emptyGeocoding = HttpClient(
+            MockEngine {
+                respond(
+                    content = ByteReadChannel("""{"results":[]}"""),
+                    status = HttpStatusCode.OK,
+                    headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                )
+            },
+        ) { install(ContentNegotiation) { json(KotlinxJson { ignoreUnknownKeys = true }) } }
+        subject = SettingsViewModel(
+            settingsRepository,
+            keyStore,
+            rearmAlarm = {},
+            geocodingClient = OpenMeteoGeocodingClient(emptyGeocoding),
+        )
     }
 
     @AfterEach

--- a/core/data/src/main/kotlin/com/adaptweather/core/data/location/GeocodingDto.kt
+++ b/core/data/src/main/kotlin/com/adaptweather/core/data/location/GeocodingDto.kt
@@ -1,0 +1,25 @@
+package com.adaptweather.core.data.location
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Wire types for `geocoding-api.open-meteo.com/v1/search`. Same key-less, free service
+ * Open-Meteo provides for forecasts. Results may be empty when the query doesn't match
+ * any known place.
+ */
+@Serializable
+internal data class OpenMeteoGeocodingResponse(
+    val results: List<GeocodingResult>? = null,
+)
+
+@Serializable
+internal data class GeocodingResult(
+    val id: Long,
+    val name: String,
+    val latitude: Double,
+    val longitude: Double,
+    val country: String? = null,
+    val admin1: String? = null,
+    @SerialName("country_code") val countryCode: String? = null,
+)

--- a/core/data/src/main/kotlin/com/adaptweather/core/data/location/OpenMeteoGeocodingClient.kt
+++ b/core/data/src/main/kotlin/com/adaptweather/core/data/location/OpenMeteoGeocodingClient.kt
@@ -1,0 +1,45 @@
+package com.adaptweather.core.data.location
+
+import com.adaptweather.core.domain.model.Location
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import io.ktor.client.request.parameter
+import io.ktor.http.URLProtocol
+import io.ktor.http.path
+
+internal const val GEOCODING_HOST = "geocoding-api.open-meteo.com"
+
+/**
+ * Resolves a free-text place name to one or more candidate [Location]s. Free, key-less
+ * Open-Meteo service, separate host from the forecast API.
+ *
+ * Returns at most [limit] candidates ordered by Open-Meteo's relevance ranking. The
+ * displayName is built as "<name>, <admin1>, <country>" with missing parts elided so
+ * a city like "London" surfaces as "London, England, United Kingdom" while a less
+ * granular match shows just what's available.
+ */
+class OpenMeteoGeocodingClient(private val httpClient: HttpClient) {
+    suspend fun search(query: String, limit: Int = 5, languageTag: String = "en"): List<Location> {
+        if (query.isBlank()) return emptyList()
+
+        val response: OpenMeteoGeocodingResponse = httpClient.get {
+            url {
+                protocol = URLProtocol.HTTPS
+                host = GEOCODING_HOST
+                path("v1", "search")
+            }
+            parameter("name", query.trim())
+            parameter("count", limit)
+            parameter("language", languageTag)
+            parameter("format", "json")
+        }.body()
+
+        return response.results.orEmpty().map { it.toDomain() }
+    }
+
+    private fun GeocodingResult.toDomain(): Location {
+        val displayName = listOfNotNull(name, admin1, country).joinToString(", ")
+        return Location(latitude = latitude, longitude = longitude, displayName = displayName)
+    }
+}

--- a/core/data/src/test/kotlin/com/adaptweather/core/data/location/OpenMeteoGeocodingClientTest.kt
+++ b/core/data/src/test/kotlin/com/adaptweather/core/data/location/OpenMeteoGeocodingClientTest.kt
@@ -1,0 +1,92 @@
+package com.adaptweather.core.data.location
+
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.HttpRequestData
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.utils.io.ByteReadChannel
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Test
+
+class OpenMeteoGeocodingClientTest {
+    private fun fixture(): ByteReadChannel {
+        val text = checkNotNull(javaClass.getResourceAsStream("/geocoding_london.json")) {
+            "fixture missing"
+        }.bufferedReader().readText()
+        return ByteReadChannel(text)
+    }
+
+    private fun mockClient(
+        body: ByteReadChannel = fixture(),
+        capture: (HttpRequestData) -> Unit = {},
+    ): HttpClient {
+        val engine = MockEngine { request ->
+            capture(request)
+            respond(
+                content = body,
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+        return HttpClient(engine) {
+            install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
+        }
+    }
+
+    @Test
+    fun `request hits the geocoding host with name + count + language`() = runTest {
+        var captured: HttpRequestData? = null
+        val client = OpenMeteoGeocodingClient(mockClient(capture = { captured = it }))
+
+        client.search("London", limit = 5, languageTag = "en-AU")
+
+        val req = checkNotNull(captured)
+        req.url.host shouldBe GEOCODING_HOST
+        req.url.encodedPath shouldBe "/v1/search"
+        req.url.parameters["name"] shouldBe "London"
+        req.url.parameters["count"] shouldBe "5"
+        req.url.parameters["language"] shouldBe "en-AU"
+        req.url.parameters["format"] shouldBe "json"
+    }
+
+    @Test
+    fun `parses fixture into domain Locations with admin and country in displayName`() = runTest {
+        val client = OpenMeteoGeocodingClient(mockClient())
+
+        val results = client.search("London")
+
+        results shouldHaveSize 2
+        results[0].displayName shouldBe "London, England, United Kingdom"
+        results[0].latitude shouldBe 51.50853
+        results[0].longitude shouldBe -0.12574
+
+        results[1].displayName shouldBe "London, Ontario, Canada"
+    }
+
+    @Test
+    fun `empty query returns empty list without making the request`() = runTest {
+        var requested = false
+        val client = OpenMeteoGeocodingClient(mockClient(capture = { requested = true }))
+
+        client.search("   ").shouldBeEmpty()
+
+        requested shouldBe false
+    }
+
+    @Test
+    fun `null results field maps to empty list`() = runTest {
+        val emptyBody = ByteReadChannel("""{"generationtime_ms":0.1}""")
+        val client = OpenMeteoGeocodingClient(mockClient(body = emptyBody))
+
+        client.search("Atlantis").shouldBeEmpty()
+    }
+}

--- a/core/data/src/test/resources/geocoding_london.json
+++ b/core/data/src/test/resources/geocoding_london.json
@@ -1,0 +1,31 @@
+{
+  "results": [
+    {
+      "id": 2643743,
+      "name": "London",
+      "latitude": 51.50853,
+      "longitude": -0.12574,
+      "elevation": 25.0,
+      "feature_code": "PPLC",
+      "country_code": "GB",
+      "country": "United Kingdom",
+      "admin1": "England",
+      "timezone": "Europe/London",
+      "population": 8961989
+    },
+    {
+      "id": 6058560,
+      "name": "London",
+      "latitude": 42.98339,
+      "longitude": -81.23304,
+      "elevation": 251.0,
+      "feature_code": "PPL",
+      "country_code": "CA",
+      "country": "Canada",
+      "admin1": "Ontario",
+      "timezone": "America/Toronto",
+      "population": 346765
+    }
+  ],
+  "generationtime_ms": 0.4
+}

--- a/core/domain/src/main/kotlin/com/adaptweather/core/domain/model/Settings.kt
+++ b/core/domain/src/main/kotlin/com/adaptweather/core/domain/model/Settings.kt
@@ -12,4 +12,9 @@ data class UserPreferences(
     val temperatureUnit: TemperatureUnit,
     val distanceUnit: DistanceUnit,
     val wardrobeRules: List<WardrobeRule>,
+    /**
+     * The location to fetch weather for. Null when the user has not configured one;
+     * callers should fall back to a sensible default or prompt the user.
+     */
+    val location: Location? = null,
 )


### PR DESCRIPTION
## Summary

Closes the location TODO that's been hard-coding London in `FetchAndNotifyWorker` since PR #12. The Worker now reads the user's chosen `Location` from `UserPreferences`, falling back to "London (default)" only when nothing is set yet.

### Pieces

- **`UserPreferences.location: Location?`** — domain stays free of Android types
- **`OpenMeteoGeocodingClient`** in `:core:data/location` — calls `geocoding-api.open-meteo.com/v1/search`, same key-less Open-Meteo service, returns N domain `Location`s with `displayName` built from `name + admin1 + country`. Tested against a golden London/London-Ontario fixture + MockEngine assertions on URL params, empty-query short-circuit, null-results fallback
- **`SettingsRepository.setLocation` / `clearLocation`** persist lat/lon/displayName via `doublePreferencesKey` + `stringPreferencesKey`
- **`SettingsViewModel`** exposes `selectLocation`, `clearLocation`, and a suspend `searchLocations(query)` that delegates to the geocoding client
- **`LocationCard`** renders the current location, an "Edit" button that opens a search dialog (text field + Search button + radio results list), and a "Clear" button when a location is set
- **`AdaptWeatherApplication`** holds a lazy `OpenMeteoGeocodingClient` sharing the existing Ktor `HttpClient`

GPS-at-notify-time + `ACCESS_COARSE_LOCATION` runtime UX still to come.

## Test plan

- [x] `OpenMeteoGeocodingClientTest` — request shape, fixture parsing, empty-query short-circuit, null-results fallback
- [x] All other unit tests still pass; `SettingsViewModelTest` updated to construct the geocoding client with an empty-results MockEngine
- [ ] CI green
- [ ] Sideload, search "London", confirm both London-UK and London-Ontario appear, pick one, confirm display name updates and persists across process kill
- [ ] Tap "Fire insight now" with the new location, confirm the notification text refers to the chosen city

https://claude.ai/code/session_01VftWR7DyaaVXHnovkuQwge

---
_Generated by [Claude Code](https://claude.ai/code/session_01VftWR7DyaaVXHnovkuQwge)_