### PR TITLE
:app — 24h cost cap on Gemini calls (per-day insight cache)

### DIFF
--- a/app/src/main/kotlin/com/adaptweather/AdaptWeatherApplication.kt
+++ b/app/src/main/kotlin/com/adaptweather/AdaptWeatherApplication.kt
@@ -9,6 +9,7 @@ import com.adaptweather.core.data.weather.OpenMeteoClient
 import com.adaptweather.core.domain.repository.InsightGenerator
 import com.adaptweather.core.domain.repository.WeatherRepository
 import com.adaptweather.core.domain.usecase.GenerateDailyInsight
+import com.adaptweather.data.InsightCache
 import com.adaptweather.data.SecureKeyStore
 import com.adaptweather.data.SettingsRepository
 import com.adaptweather.notification.InsightNotifier
@@ -34,6 +35,7 @@ import kotlinx.serialization.json.Json
 class AdaptWeatherApplication : Application() {
     val secureKeyStore: SecureKeyStore by lazy { SecureKeyStore.create(this) }
     val settingsRepository: SettingsRepository by lazy { SettingsRepository.create(this) }
+    val insightCache: InsightCache by lazy { InsightCache.create(this) }
     val insightNotifier: InsightNotifier by lazy { InsightNotifier(this) }
     val dailyAlarmScheduler: DailyAlarmScheduler by lazy { DailyAlarmScheduler(this) }
     val ttsSpeaker: TtsSpeaker by lazy { AndroidTtsSpeaker(this) }

--- a/app/src/main/kotlin/com/adaptweather/data/InsightCache.kt
+++ b/app/src/main/kotlin/com/adaptweather/data/InsightCache.kt
@@ -1,0 +1,82 @@
+package com.adaptweather.data
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import com.adaptweather.core.domain.model.Insight
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import java.time.Instant
+import java.time.LocalDate
+
+/**
+ * Persists the most recently generated [Insight] so the daily worker can avoid hitting
+ * Gemini twice for the same day. The cache key is the insight's `forDate` (LocalDate),
+ * which means two runs on the same calendar day reuse the same insight even across
+ * process kills, reboots, or "Fire insight now" debug taps.
+ *
+ * The cache is intentionally a single slot — there's no historical browsing planned,
+ * and bounding storage at 1 entry keeps the cost of corruption (deserialization
+ * failure → drop and regenerate) trivial.
+ */
+class InsightCache(
+    private val dataStore: DataStore<Preferences>,
+    private val json: Json = Json { ignoreUnknownKeys = true },
+) {
+    val latest: Flow<Insight?> = dataStore.data.map { prefs ->
+        prefs[INSIGHT_JSON]?.let { raw ->
+            runCatching { json.decodeFromString<InsightDto>(raw).toDomain() }.getOrNull()
+        }
+    }
+
+    suspend fun store(insight: Insight) {
+        dataStore.edit { it[INSIGHT_JSON] = json.encodeToString(insight.toDto()) }
+    }
+
+    suspend fun forToday(today: LocalDate): Insight? {
+        val cached = latest.first() ?: return null
+        return cached.takeIf { it.forDate == today }
+    }
+
+    suspend fun clear() {
+        dataStore.edit { it.remove(INSIGHT_JSON) }
+    }
+
+    @Serializable
+    private data class InsightDto(
+        val summary: String,
+        val recommendedItems: List<String>,
+        val generatedAtEpochMillis: Long,
+        val forDateEpochDays: Long,
+    ) {
+        fun toDomain(): Insight = Insight(
+            summary = summary,
+            recommendedItems = recommendedItems,
+            generatedAt = Instant.ofEpochMilli(generatedAtEpochMillis),
+            forDate = LocalDate.ofEpochDay(forDateEpochDays),
+        )
+    }
+
+    private fun Insight.toDto(): InsightDto = InsightDto(
+        summary = summary,
+        recommendedItems = recommendedItems,
+        generatedAtEpochMillis = generatedAt.toEpochMilli(),
+        forDateEpochDays = forDate.toEpochDay(),
+    )
+
+    companion object {
+        private val INSIGHT_JSON = stringPreferencesKey("latest_insight_v1")
+
+        fun create(context: Context): InsightCache = InsightCache(context.insightDataStore)
+    }
+}
+
+private val Context.insightDataStore: DataStore<Preferences> by preferencesDataStore(name = "insight_cache")

--- a/app/src/main/kotlin/com/adaptweather/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/com/adaptweather/work/FetchAndNotifyWorker.kt
@@ -25,6 +25,7 @@ import io.ktor.client.plugins.ResponseException
 import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.flow.first
 import java.io.IOException
+import java.time.LocalDate
 import java.util.concurrent.TimeUnit
 
 /**
@@ -59,9 +60,34 @@ class FetchAndNotifyWorker(
 
         val location = prefs.location ?: DEFAULT_LOCATION
         val languageTag = java.util.Locale.getDefault().toLanguageTag()
+        val today = LocalDate.now()
 
+        // 24h cost cap: if we already generated an insight for today, redeliver it
+        // rather than burning another Gemini call. Same path serves the morning alarm
+        // and any "Fire insight now" debug taps later in the day.
+        val cached = runCatching { app.insightCache.forToday(today) }.getOrNull()
+        if (cached != null) {
+            Log.i(TAG, "Using cached insight for ${cached.forDate}; skipping Gemini.")
+            return runCatching { deliver(cached, prefs) }
+                .map { Result.success() }
+                .getOrElse {
+                    Log.e(TAG, "Cached delivery failed; falling through to fresh generate.", it)
+                    fresh(location, prefs, languageTag)
+                }
+        }
+
+        return fresh(location, prefs, languageTag)
+    }
+
+    private suspend fun fresh(
+        location: Location,
+        prefs: UserPreferences,
+        languageTag: String,
+    ): Result {
         return try {
             val insight = app.generateDailyInsight(location, prefs, languageTag)
+            runCatching { app.insightCache.store(insight) }
+                .onFailure { Log.w(TAG, "Insight cache write failed; not blocking delivery.", it) }
             deliver(insight, prefs)
             Log.i(TAG, "Insight delivered for ${insight.forDate}: ${insight.summary}")
             Result.success()

--- a/app/src/test/kotlin/com/adaptweather/data/InsightCacheTest.kt
+++ b/app/src/test/kotlin/com/adaptweather/data/InsightCacheTest.kt
@@ -1,0 +1,101 @@
+package com.adaptweather.data
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import com.adaptweather.core.domain.model.Insight
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.nio.file.Path
+import java.time.Instant
+import java.time.LocalDate
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class InsightCacheTest {
+    @TempDir lateinit var tempDir: Path
+
+    private lateinit var dataStore: DataStore<Preferences>
+    private lateinit var subject: InsightCache
+
+    private val today = LocalDate.of(2026, 4, 25)
+    private val now = Instant.parse("2026-04-25T07:00:00Z")
+
+    private val sample = Insight(
+        summary = "Cooler than yesterday — bring a jumper.",
+        recommendedItems = listOf("jumper", "umbrella"),
+        generatedAt = now,
+        forDate = today,
+    )
+
+    @BeforeEach
+    fun setUp() {
+        Dispatchers.setMain(UnconfinedTestDispatcher(TestCoroutineScheduler()))
+        dataStore = PreferenceDataStoreFactory.create(
+            produceFile = { File(tempDir.toFile(), "cache.preferences_pb") },
+        )
+        subject = InsightCache(dataStore)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `latest is null when nothing stored`() = runTest {
+        subject.latest.first() shouldBe null
+    }
+
+    @Test
+    fun `store then latest round-trips all fields`() = runTest {
+        subject.store(sample)
+
+        val read = subject.latest.first()
+        read shouldBe sample
+    }
+
+    @Test
+    fun `forToday returns the cached insight when forDate matches`() = runTest {
+        subject.store(sample)
+
+        subject.forToday(today) shouldBe sample
+    }
+
+    @Test
+    fun `forToday returns null when the cached insight is for a different day`() = runTest {
+        subject.store(sample)
+
+        subject.forToday(today.plusDays(1)) shouldBe null
+    }
+
+    @Test
+    fun `clear removes the stored insight`() = runTest {
+        subject.store(sample)
+        subject.clear()
+
+        subject.latest.first() shouldBe null
+    }
+
+    @Test
+    fun `corrupt JSON in the slot maps to null rather than crashing`() = runTest {
+        dataStore.edit {
+            it[stringPreferencesKey("latest_insight_v1")] = "{not valid json"
+        }
+
+        subject.latest.first() shouldBe null
+    }
+}


### PR DESCRIPTION
## Summary

Closes the per-day Gemini quota burn that's existed since PR #12: every "Fire insight now" tap, every Worker retry, and every alarm re-fire was making a fresh Gemini call.

- **`InsightCache`** persists the last generated `Insight` in a single DataStore slot keyed by `forDate` (date-only — UTC `LocalDate.toEpochDay()`).
- **Worker** checks the cache before calling `GenerateDailyInsight`. If today's insight is cached, it redelivers (notification + TTS per `DeliveryMode`) and skips Gemini entirely.
- If cached delivery fails for any reason, the Worker falls through to a fresh generate so the user still gets their morning insight.
- Cache writes happen inside `fresh()` *after* generation but *before* delivery, so delivery failures don't lose the insight either — the next attempt sees the cached value and doesn't pay for a re-generate.
- Single-slot cache; no historical browsing planned. Bounding at 1 entry keeps the corruption blast radius trivial.

## Test plan

- [x] `InsightCacheTest` — null-when-empty, store-then-read round-trip (incl. `Instant` + `LocalDate`), `forToday` date-match, `forToday` returns null on date mismatch, `clear`, corrupt-JSON fallback to null
- [x] All other unit tests still pass
- [ ] CI green
- [ ] Sideload, paste a Gemini key, tap "Fire insight now" twice in a row — first call hits Gemini, second uses cache (verify in `logcat`)

https://claude.ai/code/session_01VftWR7DyaaVXHnovkuQwge

---
_Generated by [Claude Code](https://claude.ai/code/session_01VftWR7DyaaVXHnovkuQwge)_