### PR TITLE
:app — Today screen as the new home, with Settings via AppBar

### DIFF
--- a/app/src/main/kotlin/com/adaptweather/MainActivity.kt
+++ b/app/src/main/kotlin/com/adaptweather/MainActivity.kt
@@ -2,15 +2,26 @@ package com.adaptweather
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.compose.BackHandler
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.adaptweather.ui.settings.SettingsScreen
 import com.adaptweather.ui.settings.SettingsViewModel
 import com.adaptweather.ui.theme.AdaptWeatherTheme
+import com.adaptweather.ui.today.TodayScreen
+import com.adaptweather.ui.today.TodayViewModel
+
+private enum class Screen { Today, Settings }
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -22,17 +33,46 @@ class MainActivity : ComponentActivity() {
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background,
                 ) {
-                    val viewModel: SettingsViewModel = viewModel(
-                        factory = SettingsViewModel.Factory(
-                            settingsRepository = app.settingsRepository,
-                            keyStore = app.secureKeyStore,
-                            rearmAlarm = app.dailyAlarmScheduler::schedule,
-                            geocodingClient = app.geocodingClient,
-                        ),
-                    )
-                    SettingsScreen(viewModel = viewModel)
+                    AdaptWeatherNav(app)
                 }
             }
+        }
+    }
+}
+
+@Composable
+private fun AdaptWeatherNav(app: AdaptWeatherApplication) {
+    // Two-screen state machine. Compose Navigation would be overkill for this; the
+    // back stack is at most one entry deep.
+    var screen by rememberSaveable { mutableStateOf(Screen.Today) }
+
+    BackHandler(enabled = screen == Screen.Settings) {
+        screen = Screen.Today
+    }
+
+    when (screen) {
+        Screen.Today -> {
+            val today: TodayViewModel = viewModel(
+                factory = TodayViewModel.Factory(insightCache = app.insightCache),
+            )
+            TodayScreen(
+                viewModel = today,
+                onNavigateToSettings = { screen = Screen.Settings },
+            )
+        }
+        Screen.Settings -> {
+            val settings: SettingsViewModel = viewModel(
+                factory = SettingsViewModel.Factory(
+                    settingsRepository = app.settingsRepository,
+                    keyStore = app.secureKeyStore,
+                    rearmAlarm = app.dailyAlarmScheduler::schedule,
+                    geocodingClient = app.geocodingClient,
+                ),
+            )
+            SettingsScreen(
+                viewModel = settings,
+                onNavigateBack = { screen = Screen.Today },
+            )
         }
     }
 }

--- a/app/src/main/kotlin/com/adaptweather/ui/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/adaptweather/ui/settings/SettingsScreen.kt
@@ -12,6 +12,7 @@ import android.widget.Toast
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
@@ -64,12 +65,22 @@ import java.util.Locale
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun SettingsScreen(viewModel: SettingsViewModel) {
+fun SettingsScreen(viewModel: SettingsViewModel, onNavigateBack: () -> Unit) {
     val state by viewModel.state.collectAsStateWithLifecycle()
 
     Scaffold(
         topBar = {
-            TopAppBar(title = { Text(stringResource(R.string.settings_title)) })
+            TopAppBar(
+                title = { Text(stringResource(R.string.settings_title)) },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.settings_back),
+                        )
+                    }
+                },
+            )
         },
     ) { padding ->
         SettingsContent(

--- a/app/src/main/kotlin/com/adaptweather/ui/today/TodayScreen.kt
+++ b/app/src/main/kotlin/com/adaptweather/ui/today/TodayScreen.kt
@@ -1,0 +1,169 @@
+package com.adaptweather.ui.today
+
+import android.widget.Toast
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.adaptweather.BuildConfig
+import com.adaptweather.R
+import com.adaptweather.core.domain.model.Insight
+import com.adaptweather.work.FetchAndNotifyWorker
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
+import java.util.Locale
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TodayScreen(viewModel: TodayViewModel, onNavigateToSettings: () -> Unit) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.today_title)) },
+                actions = {
+                    IconButton(onClick = onNavigateToSettings) {
+                        Icon(
+                            imageVector = Icons.Default.Settings,
+                            contentDescription = stringResource(R.string.today_open_settings),
+                        )
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        TodayContent(state = state, padding = padding)
+    }
+}
+
+@Composable
+private fun TodayContent(state: TodayState, padding: PaddingValues) {
+    val context = LocalContext.current
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(padding)
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = 16.dp, vertical = 24.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        if (state.insight == null) {
+            EmptyState(
+                onFireNow = if (BuildConfig.DEBUG) {
+                    {
+                        FetchAndNotifyWorker.enqueueOneShot(context.applicationContext)
+                        Toast.makeText(
+                            context,
+                            context.getString(R.string.settings_debug_fire_toast),
+                            Toast.LENGTH_SHORT,
+                        ).show()
+                    }
+                } else {
+                    null
+                },
+            )
+        } else {
+            InsightCard(state.insight)
+        }
+    }
+}
+
+@Composable
+private fun EmptyState(onFireNow: (() -> Unit)?) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 48.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.today_empty_title),
+                style = MaterialTheme.typography.titleLarge,
+                textAlign = TextAlign.Center,
+            )
+            Text(
+                text = stringResource(R.string.today_empty_subtitle),
+                style = MaterialTheme.typography.bodyMedium,
+                textAlign = TextAlign.Center,
+            )
+            if (onFireNow != null) {
+                Button(onClick = onFireNow) {
+                    Text(stringResource(R.string.settings_debug_fire_now))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun InsightCard(insight: Insight) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier.padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text(
+                text = DATE_FORMAT.format(insight.forDate),
+                style = MaterialTheme.typography.labelLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Text(
+                text = insight.summary,
+                style = MaterialTheme.typography.headlineSmall,
+            )
+            if (insight.recommendedItems.isNotEmpty()) {
+                Text(
+                    text = stringResource(
+                        R.string.today_recommended_items,
+                        insight.recommendedItems.joinToString(", "),
+                    ),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Text(
+                text = stringResource(
+                    R.string.today_generated_at,
+                    GENERATED_AT_FORMAT.format(insight.generatedAt.atZone(ZoneId.systemDefault())),
+                ),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+private val DATE_FORMAT: DateTimeFormatter =
+    DateTimeFormatter.ofLocalizedDate(FormatStyle.FULL).withLocale(Locale.getDefault())
+private val GENERATED_AT_FORMAT: DateTimeFormatter =
+    DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT).withLocale(Locale.getDefault())

--- a/app/src/main/kotlin/com/adaptweather/ui/today/TodayViewModel.kt
+++ b/app/src/main/kotlin/com/adaptweather/ui/today/TodayViewModel.kt
@@ -1,0 +1,29 @@
+package com.adaptweather.ui.today
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.adaptweather.core.domain.model.Insight
+import com.adaptweather.data.InsightCache
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+
+data class TodayState(val insight: Insight? = null)
+
+class TodayViewModel(insightCache: InsightCache) : ViewModel() {
+    val state: StateFlow<TodayState> = insightCache.latest
+        .map { TodayState(it) }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), TodayState())
+
+    class Factory(private val insightCache: InsightCache) : ViewModelProvider.Factory {
+        @Suppress("UNCHECKED_CAST")
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            require(modelClass.isAssignableFrom(TodayViewModel::class.java)) {
+                "Unknown ViewModel: ${modelClass.name}"
+            }
+            return TodayViewModel(insightCache) as T
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,7 +2,15 @@
 <resources>
     <string name="app_name">AdaptWeather</string>
 
+    <string name="today_title">Today</string>
+    <string name="today_open_settings">Open Settings</string>
+    <string name="today_empty_title">No insight yet</string>
+    <string name="today_empty_subtitle">The morning insight will appear here once it has been generated. Set up your Gemini key and location in Settings.</string>
+    <string name="today_recommended_items">Recommended items: %1$s</string>
+    <string name="today_generated_at">Generated at %1$s</string>
+
     <string name="settings_title">Settings</string>
+    <string name="settings_back">Back</string>
 
     <string name="settings_api_key_title">Gemini API key</string>
     <string name="settings_api_key_status_set">A key is configured. The key is encrypted at rest using the Android Keystore.</string>


### PR DESCRIPTION
## Summary

Until now, opening the app dropped the user straight into Settings — fine during config but wrong as a default once the daily-insight cache from PR #20 has something to display.

- **`TodayScreen`** observes `InsightCache.latest` via a thin `TodayViewModel`:
  - When an insight is cached, renders date, summary, recommended items, and the local-time generated-at timestamp in a single Material card.
  - When nothing is cached yet (first launch, before the first morning run), shows an empty-state hint pointing the user to Settings, plus the "Fire insight now" button on debug builds so the cache can be primed from this screen too.
- **Navigation**: a Settings `IconButton` in the TopAppBar takes the user to the existing `SettingsScreen`, which now has a back arrow that returns here. A `BackHandler` makes the system back gesture do the same.
- Compose Navigation would be overkill for a two-screen state machine; a `rememberSaveable<Screen>` enum tracks the current screen and survives config changes / process death.

## Test plan

- [x] All existing unit tests still pass; added no new test surface (UI-only)
- [ ] CI green
- [ ] Sideload, on a fresh install confirm Today shows the empty-state pointing to Settings
- [ ] Tap Settings icon → Settings screen → back arrow → Today screen
- [ ] Configure key + location, tap "Fire insight now" from Today (debug only), verify the empty-state replaces with the live insight card after the worker completes

https://claude.ai/code/session_01VftWR7DyaaVXHnovkuQwge

---
_Generated by [Claude Code](https://claude.ai/code/session_01VftWR7DyaaVXHnovkuQwge)_