### PR TITLE
:core + :app — feels-like prompt rewrite (V10 phrasing rules)

### DIFF
--- a/app/src/main/kotlin/com/adaptweather/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/com/adaptweather/work/FetchAndNotifyWorker.kt
@@ -145,6 +145,12 @@ class FetchAndNotifyWorker(
     }
 
     private suspend fun deliver(insight: Insight, prefs: UserPreferences) {
+        // Silent run: when nothing meaningful changed, the prompt rules tell Gemini to
+        // emit an empty string. Don't post a blank notification or speak silence.
+        if (insight.summary.isBlank()) {
+            Log.i(TAG, "Insight summary is blank; skipping notification + TTS.")
+            return
+        }
         val mode = prefs.deliveryMode
         if (mode == DeliveryMode.NOTIFICATION_ONLY || mode == DeliveryMode.NOTIFICATION_AND_TTS) {
             app.insightNotifier.notify(insight)

--- a/core/data/src/main/kotlin/com/adaptweather/core/data/weather/OpenMeteoClient.kt
+++ b/core/data/src/main/kotlin/com/adaptweather/core/data/weather/OpenMeteoClient.kt
@@ -32,11 +32,12 @@ class OpenMeteoClient(private val httpClient: HttpClient) : WeatherRepository {
             parameter("timezone", "auto")
             parameter(
                 "daily",
-                "temperature_2m_min,temperature_2m_max,precipitation_probability_max,precipitation_sum,weather_code",
+                "temperature_2m_min,temperature_2m_max,apparent_temperature_min,apparent_temperature_max," +
+                    "precipitation_probability_max,precipitation_sum,weather_code",
             )
             parameter(
                 "hourly",
-                "temperature_2m,precipitation_probability,weather_code",
+                "temperature_2m,apparent_temperature,precipitation_probability,weather_code",
             )
         }.body()
 

--- a/core/data/src/main/kotlin/com/adaptweather/core/data/weather/OpenMeteoDto.kt
+++ b/core/data/src/main/kotlin/com/adaptweather/core/data/weather/OpenMeteoDto.kt
@@ -22,6 +22,8 @@ internal data class DailyData(
     @SerialName("time") val time: List<String>,
     @SerialName("temperature_2m_min") val temperatureMin: List<Double?>,
     @SerialName("temperature_2m_max") val temperatureMax: List<Double?>,
+    @SerialName("apparent_temperature_min") val feelsLikeMin: List<Double?>,
+    @SerialName("apparent_temperature_max") val feelsLikeMax: List<Double?>,
     @SerialName("precipitation_probability_max") val precipitationProbabilityMax: List<Int?>,
     @SerialName("precipitation_sum") val precipitationSum: List<Double?>,
     @SerialName("weather_code") val weatherCode: List<Int?>,
@@ -31,6 +33,7 @@ internal data class DailyData(
 internal data class HourlyData(
     @SerialName("time") val time: List<String>,
     @SerialName("temperature_2m") val temperature: List<Double?>,
+    @SerialName("apparent_temperature") val feelsLike: List<Double?>,
     @SerialName("precipitation_probability") val precipitationProbability: List<Int?>,
     @SerialName("weather_code") val weatherCode: List<Int?>,
 )

--- a/core/data/src/main/kotlin/com/adaptweather/core/data/weather/OpenMeteoMapper.kt
+++ b/core/data/src/main/kotlin/com/adaptweather/core/data/weather/OpenMeteoMapper.kt
@@ -29,25 +29,33 @@ internal object OpenMeteoMapper {
         return ForecastBundle(today = today, yesterday = yesterday)
     }
 
-    private fun DailyData.toForecast(index: Int, date: LocalDate, hourly: List<HourlyForecast>): DailyForecast =
-        DailyForecast(
+    private fun DailyData.toForecast(index: Int, date: LocalDate, hourly: List<HourlyForecast>): DailyForecast {
+        val rawMin = temperatureMin[index] ?: 0.0
+        val rawMax = temperatureMax[index] ?: 0.0
+        return DailyForecast(
             date = date,
-            temperatureMinC = temperatureMin[index] ?: 0.0,
-            temperatureMaxC = temperatureMax[index] ?: 0.0,
+            temperatureMinC = rawMin,
+            temperatureMaxC = rawMax,
+            // Fall back to raw temp if Open-Meteo didn't provide apparent — better than 0 °C.
+            feelsLikeMinC = feelsLikeMin[index] ?: rawMin,
+            feelsLikeMaxC = feelsLikeMax[index] ?: rawMax,
             precipitationProbabilityMaxPct = (precipitationProbabilityMax[index] ?: 0).toDouble(),
             precipitationMmTotal = precipitationSum[index] ?: 0.0,
             condition = WmoCodeMapper.map(weatherCode[index]),
             hourly = hourly,
         )
+    }
 
     private fun HourlyData.forDate(date: LocalDate): List<HourlyForecast> {
         val out = ArrayList<HourlyForecast>(24)
         for (i in time.indices) {
             val ts = LocalDateTime.parse(time[i])
             if (ts.toLocalDate() != date) continue
+            val raw = temperature[i] ?: 0.0
             out += HourlyForecast(
                 time = LocalTime.of(ts.hour, ts.minute),
-                temperatureC = temperature[i] ?: 0.0,
+                temperatureC = raw,
+                feelsLikeC = feelsLike[i] ?: raw,
                 precipitationProbabilityPct = (precipitationProbability[i] ?: 0).toDouble(),
                 condition = WmoCodeMapper.map(weatherCode[i]),
             )

--- a/core/data/src/test/kotlin/com/adaptweather/core/data/weather/OpenMeteoMapperTest.kt
+++ b/core/data/src/test/kotlin/com/adaptweather/core/data/weather/OpenMeteoMapperTest.kt
@@ -33,6 +33,8 @@ class OpenMeteoMapperTest {
 
         y.temperatureMinC shouldBe 12.0
         y.temperatureMaxC shouldBe 18.0
+        y.feelsLikeMinC shouldBe 10.0
+        y.feelsLikeMaxC shouldBe 17.0
         y.precipitationProbabilityMaxPct shouldBe 5.0
         y.precipitationMmTotal shouldBe 0.0
         y.condition shouldBe WeatherCondition.PARTLY_CLOUDY
@@ -45,6 +47,8 @@ class OpenMeteoMapperTest {
 
         t.temperatureMinC shouldBe 16.0
         t.temperatureMaxC shouldBe 24.0
+        t.feelsLikeMinC shouldBe 15.0
+        t.feelsLikeMaxC shouldBe 23.0
         t.precipitationProbabilityMaxPct shouldBe 60.0
         t.precipitationMmTotal shouldBe 4.5
         t.condition shouldBe WeatherCondition.RAIN
@@ -79,6 +83,8 @@ class OpenMeteoMapperTest {
                 time = listOf("2026-04-24", "2026-04-25"),
                 temperatureMin = listOf(null, 16.0),
                 temperatureMax = listOf(null, 24.0),
+                feelsLikeMin = listOf(null, null),
+                feelsLikeMax = listOf(null, null),
                 precipitationProbabilityMax = listOf(null, null),
                 precipitationSum = listOf(null, 4.5),
                 weatherCode = listOf(null, 63),
@@ -86,6 +92,7 @@ class OpenMeteoMapperTest {
             hourly = HourlyData(
                 time = listOf("2026-04-25T15:00"),
                 temperature = listOf(null),
+                feelsLike = listOf(null),
                 precipitationProbability = listOf(null),
                 weatherCode = listOf(null),
             ),
@@ -95,11 +102,41 @@ class OpenMeteoMapperTest {
 
         bundle.yesterday.temperatureMinC shouldBe 0.0
         bundle.yesterday.temperatureMaxC shouldBe 0.0
+        bundle.yesterday.feelsLikeMinC shouldBe 0.0
+        bundle.yesterday.feelsLikeMaxC shouldBe 0.0
         bundle.yesterday.precipitationProbabilityMaxPct shouldBe 0.0
         bundle.yesterday.condition shouldBe WeatherCondition.UNKNOWN
         bundle.today.precipitationProbabilityMaxPct shouldBe 0.0
         bundle.today.hourly.single().temperatureC shouldBe 0.0
+        bundle.today.hourly.single().feelsLikeC shouldBe 0.0
         bundle.today.hourly.single().condition shouldBe WeatherCondition.UNKNOWN
+    }
+
+    @Test
+    fun `feels-like falls back to raw temperature when missing`() {
+        // Open-Meteo can return apparent_temperature null even when temperature_2m is set
+        // (rare, but observed). Fall back so wardrobe rules still match something sensible.
+        val partial = OpenMeteoResponse(
+            timezone = "UTC",
+            daily = DailyData(
+                time = listOf("2026-04-24", "2026-04-25"),
+                temperatureMin = listOf(12.0, 16.0),
+                temperatureMax = listOf(18.0, 24.0),
+                feelsLikeMin = listOf(null, null),
+                feelsLikeMax = listOf(null, null),
+                precipitationProbabilityMax = listOf(0, 0),
+                precipitationSum = listOf(0.0, 0.0),
+                weatherCode = listOf(0, 0),
+            ),
+            hourly = HourlyData(emptyList(), emptyList(), emptyList(), emptyList(), emptyList()),
+        )
+
+        val bundle = OpenMeteoMapper.toBundle(partial)
+
+        bundle.yesterday.feelsLikeMinC shouldBe 12.0
+        bundle.yesterday.feelsLikeMaxC shouldBe 18.0
+        bundle.today.feelsLikeMinC shouldBe 16.0
+        bundle.today.feelsLikeMaxC shouldBe 24.0
     }
 
     @Test
@@ -110,11 +147,13 @@ class OpenMeteoMapperTest {
                 time = listOf("2026-04-25"),
                 temperatureMin = listOf(16.0),
                 temperatureMax = listOf(24.0),
+                feelsLikeMin = listOf(15.0),
+                feelsLikeMax = listOf(23.0),
                 precipitationProbabilityMax = listOf(60),
                 precipitationSum = listOf(4.5),
                 weatherCode = listOf(63),
             ),
-            hourly = HourlyData(emptyList(), emptyList(), emptyList(), emptyList()),
+            hourly = HourlyData(emptyList(), emptyList(), emptyList(), emptyList(), emptyList()),
         )
 
         try {

--- a/core/data/src/test/resources/openmeteo_london.json
+++ b/core/data/src/test/resources/openmeteo_london.json
@@ -8,6 +8,8 @@
     "time": "iso8601",
     "temperature_2m_min": "°C",
     "temperature_2m_max": "°C",
+    "apparent_temperature_min": "°C",
+    "apparent_temperature_max": "°C",
     "precipitation_probability_max": "%",
     "precipitation_sum": "mm",
     "weather_code": "wmo code"
@@ -16,6 +18,8 @@
     "time": ["2026-04-24", "2026-04-25"],
     "temperature_2m_min": [12.0, 16.0],
     "temperature_2m_max": [18.0, 24.0],
+    "apparent_temperature_min": [10.0, 15.0],
+    "apparent_temperature_max": [17.0, 23.0],
     "precipitation_probability_max": [5, 60],
     "precipitation_sum": [0.0, 4.5],
     "weather_code": [2, 63]
@@ -23,6 +27,7 @@
   "hourly_units": {
     "time": "iso8601",
     "temperature_2m": "°C",
+    "apparent_temperature": "°C",
     "precipitation_probability": "%",
     "weather_code": "wmo code"
   },
@@ -34,6 +39,7 @@
       "2026-04-25T18:00", "2026-04-25T21:00"
     ],
     "temperature_2m": [13.0, 12.5, 12.0, 13.0, 16.0, 18.0, 22.0, 22.0, 19.0, 17.0],
+    "apparent_temperature": [11.0, 10.5, 10.0, 11.0, 14.0, 16.0, 20.0, 20.0, 17.0, 15.0],
     "precipitation_probability": [0, 0, 0, 0, 5, 10, 30, 60, 30, 5],
     "weather_code": [2, 2, 2, 2, 2, 2, 3, 63, 51, 2]
   }

--- a/core/domain/src/main/kotlin/com/adaptweather/core/domain/model/Forecast.kt
+++ b/core/domain/src/main/kotlin/com/adaptweather/core/domain/model/Forecast.kt
@@ -3,10 +3,20 @@ package com.adaptweather.core.domain.model
 import java.time.LocalDate
 import java.time.LocalTime
 
+/**
+ * One day's forecast.
+ *
+ * Temperature is provided as both raw 2 m air temperature ([temperatureMinC],
+ * [temperatureMaxC]) and apparent / "feels like" ([feelsLikeMinC], [feelsLikeMaxC]),
+ * which factors in wind chill and humidity. The user-facing prompt and wardrobe
+ * thresholds use feels-like — that's what people actually experience.
+ */
 data class DailyForecast(
     val date: LocalDate,
     val temperatureMinC: Double,
     val temperatureMaxC: Double,
+    val feelsLikeMinC: Double,
+    val feelsLikeMaxC: Double,
     val precipitationProbabilityMaxPct: Double,
     val precipitationMmTotal: Double,
     val condition: WeatherCondition,
@@ -16,6 +26,7 @@ data class DailyForecast(
 data class HourlyForecast(
     val time: LocalTime,
     val temperatureC: Double,
+    val feelsLikeC: Double,
     val precipitationProbabilityPct: Double,
     val condition: WeatherCondition,
 )

--- a/core/domain/src/main/kotlin/com/adaptweather/core/domain/model/WardrobeRule.kt
+++ b/core/domain/src/main/kotlin/com/adaptweather/core/domain/model/WardrobeRule.kt
@@ -2,9 +2,12 @@ package com.adaptweather.core.domain.model
 
 /**
  * A user-configured rule that suggests an item of clothing or gear when a forecast
- * crosses a threshold. The semantics are deliberately simple: "below" rules check
- * the day's minimum temperature, "above" rules check the day's maximum, and precipitation
- * rules check the day's peak probability.
+ * crosses a threshold.
+ *
+ * Temperature thresholds are checked against "feels like" (apparent) values rather
+ * than raw 2 m air temperature — what the user actually experiences when stepping
+ * outside, factoring in wind chill and humidity. Precipitation rules check the day's
+ * peak probability.
  */
 data class WardrobeRule(
     val item: String,
@@ -17,11 +20,11 @@ data class WardrobeRule(
     }
 
     data class TemperatureBelow(val celsius: Double) : Condition {
-        override fun matches(forecast: DailyForecast) = forecast.temperatureMinC < celsius
+        override fun matches(forecast: DailyForecast) = forecast.feelsLikeMinC < celsius
     }
 
     data class TemperatureAbove(val celsius: Double) : Condition {
-        override fun matches(forecast: DailyForecast) = forecast.temperatureMaxC > celsius
+        override fun matches(forecast: DailyForecast) = forecast.feelsLikeMaxC > celsius
     }
 
     data class PrecipitationProbabilityAbove(val percent: Double) : Condition {

--- a/core/domain/src/main/kotlin/com/adaptweather/core/domain/usecase/BuildPrompt.kt
+++ b/core/domain/src/main/kotlin/com/adaptweather/core/domain/usecase/BuildPrompt.kt
@@ -3,18 +3,27 @@ package com.adaptweather.core.domain.usecase
 import com.adaptweather.core.domain.model.DailyForecast
 import com.adaptweather.core.domain.model.TemperatureUnit
 import com.adaptweather.core.domain.model.WardrobeRule
+import com.adaptweather.core.domain.model.WeatherCondition
 import com.adaptweather.core.domain.model.symbol
 import com.adaptweather.core.domain.model.toUnit
+import java.time.LocalTime
 import java.util.Locale
 
 /**
- * The prompt sent to Gemini. System instruction sets style; user message carries
- * the structured forecast comparison and the deterministic wardrobe-rule output.
+ * The prompt sent to Gemini.
  *
- * The triggered items are computed by [EvaluateWardrobeRules] and threaded into the
- * prompt as a hint — the LLM can weave them naturally — but callers also keep the
- * structured list in the [com.adaptweather.core.domain.model.Insight], so a flaky
- * LLM response never hides them from the UI.
+ * Phrasing follows a deterministic rule set so the daily notification is always brief
+ * and information-dense. The LLM only fires when at least one rule has something to
+ * say; if every rule yields nothing, the worker skips the notification entirely.
+ *
+ * Rules (each yields 0 or 1 sentence):
+ * 1. **Temperature**: if max OR min feels-like differs from yesterday by ≥ 3°C, output
+ *    "It will be N° warmer/cooler today." (using the larger delta).
+ * 2. **Wardrobe**: if today's triggered items differ from yesterday's, output
+ *    "Wear <items>."
+ * 3. **Precipitation**: if today's peak chance is ≥ 30%, output "<Type> at <HH:MM>."
+ *
+ * Calendar-event filtering and the 7pm out-of-hours briefing are not yet wired up.
  */
 data class Prompt(
     val systemInstruction: String,
@@ -25,51 +34,99 @@ class BuildPrompt {
     operator fun invoke(
         today: DailyForecast,
         yesterday: DailyForecast,
-        triggeredRules: List<WardrobeRule>,
+        yesterdayTriggeredRules: List<WardrobeRule>,
+        todayTriggeredRules: List<WardrobeRule>,
         temperatureUnit: TemperatureUnit,
         languageTag: String,
     ): Prompt {
-        val system = buildString {
-            append("Write one short sentence (max 25 words) in language ")
-            append(languageTag)
-            append(" comparing today's weather to yesterday's actual weather, and offer ")
-            append("one piece of actionable advice if useful. ")
-            append("Output the sentence only — no quotes, no preamble, no greetings, no emojis.")
-        }
-
-        val user = buildString {
-            appendLine("Yesterday (${yesterday.date}):")
-            appendLine("- min ${tempStr(yesterday.temperatureMinC, temperatureUnit)}, max ${tempStr(yesterday.temperatureMaxC, temperatureUnit)}")
-            appendLine("- precipitation chance peak: ${yesterday.precipitationProbabilityMaxPct.toInt()}%")
-            appendLine("- conditions: ${conditionStr(yesterday)}")
-            appendLine()
-            appendLine("Today (${today.date}):")
-            appendLine("- min ${tempStr(today.temperatureMinC, temperatureUnit)}, max ${tempStr(today.temperatureMaxC, temperatureUnit)}")
-            appendLine("- precipitation chance peak: ${today.precipitationProbabilityMaxPct.toInt()}%")
-            appendLine("- conditions: ${conditionStr(today)}")
-
-            val peakHour = today.hourly.maxByOrNull { it.precipitationProbabilityPct }
-            if (peakHour != null && peakHour.precipitationProbabilityPct >= 30.0) {
-                appendLine("- highest rain chance around ${peakHour.time} (${peakHour.precipitationProbabilityPct.toInt()}%)")
-            }
-
-            if (triggeredRules.isNotEmpty()) {
-                appendLine()
-                appendLine("Recommended items based on user thresholds: ${triggeredRules.joinToString(", ") { it.item }}")
-            }
-
-            appendLine()
-            append("Compare yesterday and today, and advise.")
-        }
-
+        val system = systemInstruction(languageTag)
+        val user = buildUserMessage(
+            today = today,
+            yesterday = yesterday,
+            yesterdayItems = yesterdayTriggeredRules.map { it.item },
+            todayItems = todayTriggeredRules.map { it.item },
+            temperatureUnit = temperatureUnit,
+        )
         return Prompt(systemInstruction = system, userMessage = user)
     }
+
+    private fun systemInstruction(languageTag: String): String = """
+        You generate the body of a brief morning weather notification.
+
+        All temperatures provided to you are pre-computed "feels like" (apparent) values.
+
+        Apply these three rules in order. Each rule yields zero or one sentence.
+
+        1. Temperature change: if today's high differs from yesterday's by at least 3°,
+           OR today's low differs from yesterday's by at least 3°, output exactly
+           "It will be N° warmer today." or "It will be N° cooler today.", using the
+           larger absolute delta rounded to the nearest integer. Otherwise omit.
+        2. Wardrobe change: today's triggered items and yesterday's are listed below.
+           If they differ, output exactly "Wear <items>." with items separated by commas
+           (Oxford comma for three or more). Otherwise omit.
+        3. Precipitation: if today's peak precipitation chance is at least 30%, output
+           exactly "<Type> at <HH:MM>." (e.g. "Rain at 15:00."). Otherwise omit.
+
+        Concatenate the resulting sentences with a single space between each.
+        No labels, no quotes, no preamble, no greetings, no emojis.
+        If every rule produced nothing, output an empty string with no whitespace.
+        Output language: $languageTag.
+    """.trimIndent()
+
+    private fun buildUserMessage(
+        today: DailyForecast,
+        yesterday: DailyForecast,
+        yesterdayItems: List<String>,
+        todayItems: List<String>,
+        temperatureUnit: TemperatureUnit,
+    ): String = buildString {
+        appendLine("Yesterday (${yesterday.date}):")
+        appendLine("- feels-like high: ${tempStr(yesterday.feelsLikeMaxC, temperatureUnit)}")
+        appendLine("- feels-like low: ${tempStr(yesterday.feelsLikeMinC, temperatureUnit)}")
+        appendLine("- conditions: ${conditionStr(yesterday.condition)}")
+        appendLine()
+        appendLine("Today (${today.date}):")
+        appendLine("- feels-like high: ${tempStr(today.feelsLikeMaxC, temperatureUnit)}")
+        appendLine("- feels-like low: ${tempStr(today.feelsLikeMinC, temperatureUnit)}")
+        appendLine("- conditions: ${conditionStr(today.condition)}")
+        appendLine("- max precipitation chance: ${today.precipitationProbabilityMaxPct.toInt()}%")
+        val peakHour = peakPrecipHour(today)
+        if (peakHour != null) {
+            appendLine("- precipitation type: ${conditionStr(peakHour.condition)}")
+            appendLine("- precipitation peak hour: ${peakHour.time}")
+        }
+        appendLine()
+        appendLine("Yesterday's wardrobe items: ${yesterdayItems.formatList()}")
+        appendLine("Today's wardrobe items: ${todayItems.formatList()}")
+    }
+
+    /**
+     * The hour with the highest precipitation chance, only if that chance is ≥ 30%.
+     * Used to feed the LLM both the type and the time so it can emit the precipitation
+     * sentence. Falls back to the daily condition when no hourly entry qualifies.
+     */
+    private fun peakPrecipHour(today: DailyForecast): PeakHour? {
+        val candidate = today.hourly.maxByOrNull { it.precipitationProbabilityPct }
+        if (candidate == null || candidate.precipitationProbabilityPct < 30.0) {
+            return if (today.precipitationProbabilityMaxPct >= 30.0) {
+                PeakHour(time = LocalTime.NOON, condition = today.condition)
+            } else {
+                null
+            }
+        }
+        val condition = if (candidate.condition == WeatherCondition.UNKNOWN) today.condition else candidate.condition
+        return PeakHour(time = candidate.time, condition = condition)
+    }
+
+    private fun List<String>.formatList(): String = if (isEmpty()) "(none)" else joinToString(", ")
 
     private fun tempStr(celsius: Double, unit: TemperatureUnit): String {
         val v = celsius.toUnit(unit)
         return "%.0f%s".format(Locale.ROOT, v, unit.symbol())
     }
 
-    private fun conditionStr(forecast: DailyForecast): String =
-        forecast.condition.name.lowercase().replace('_', ' ')
+    private fun conditionStr(condition: WeatherCondition): String =
+        condition.name.lowercase().replace('_', ' ')
+
+    private data class PeakHour(val time: LocalTime, val condition: WeatherCondition)
 }

--- a/core/domain/src/main/kotlin/com/adaptweather/core/domain/usecase/GenerateDailyInsight.kt
+++ b/core/domain/src/main/kotlin/com/adaptweather/core/domain/usecase/GenerateDailyInsight.kt
@@ -27,18 +27,20 @@ class GenerateDailyInsight(
         languageTag: String,
     ): Insight {
         val bundle = weatherRepository.fetchForecast(location)
-        val triggered = evaluateWardrobeRules(bundle.today, prefs.wardrobeRules)
+        val yesterdayTriggered = evaluateWardrobeRules(bundle.yesterday, prefs.wardrobeRules)
+        val todayTriggered = evaluateWardrobeRules(bundle.today, prefs.wardrobeRules)
         val prompt = buildPrompt(
             today = bundle.today,
             yesterday = bundle.yesterday,
-            triggeredRules = triggered,
+            yesterdayTriggeredRules = yesterdayTriggered,
+            todayTriggeredRules = todayTriggered,
             temperatureUnit = prefs.temperatureUnit,
             languageTag = languageTag,
         )
         val summary = insightGenerator.generate(prompt).trim()
         return Insight(
             summary = summary,
-            recommendedItems = triggered.map { it.item },
+            recommendedItems = todayTriggered.map { it.item },
             generatedAt = clock.instant(),
             forDate = bundle.today.date,
         )

--- a/core/domain/src/test/kotlin/com/adaptweather/core/domain/model/WardrobeRuleTest.kt
+++ b/core/domain/src/test/kotlin/com/adaptweather/core/domain/model/WardrobeRuleTest.kt
@@ -7,36 +7,54 @@ import java.time.LocalDate
 class WardrobeRuleTest {
     private val date = LocalDate.of(2026, 4, 25)
 
-    private fun forecast(min: Double, max: Double, precip: Double = 0.0): DailyForecast =
-        DailyForecast(
-            date = date,
-            temperatureMinC = min,
-            temperatureMaxC = max,
-            precipitationProbabilityMaxPct = precip,
-            precipitationMmTotal = 0.0,
-            condition = WeatherCondition.CLEAR,
-        )
+    /**
+     * Builds a forecast where feels-like equals the raw temp by default — most tests
+     * don't need to distinguish, and the rules now key off feels-like.
+     */
+    private fun forecast(
+        min: Double,
+        max: Double,
+        precip: Double = 0.0,
+        feelsLikeMin: Double = min,
+        feelsLikeMax: Double = max,
+    ): DailyForecast = DailyForecast(
+        date = date,
+        temperatureMinC = min,
+        temperatureMaxC = max,
+        feelsLikeMinC = feelsLikeMin,
+        feelsLikeMaxC = feelsLikeMax,
+        precipitationProbabilityMaxPct = precip,
+        precipitationMmTotal = 0.0,
+        condition = WeatherCondition.CLEAR,
+    )
 
     @Test
-    fun `temperature below applies when daily min is colder`() {
+    fun `temperature below applies when feels-like min is colder`() {
         val rule = WardrobeRule("jumper", WardrobeRule.TemperatureBelow(18.0))
         rule.appliesTo(forecast(min = 14.0, max = 22.0)) shouldBe true
     }
 
     @Test
-    fun `temperature below does not apply when daily min meets threshold`() {
+    fun `temperature below uses feels-like, not raw temperature`() {
+        // Raw min is 20°C (above threshold) but wind chill makes it feel like 14°C.
+        val rule = WardrobeRule("jumper", WardrobeRule.TemperatureBelow(18.0))
+        rule.appliesTo(forecast(min = 20.0, max = 24.0, feelsLikeMin = 14.0, feelsLikeMax = 22.0)) shouldBe true
+    }
+
+    @Test
+    fun `temperature below does not apply when feels-like min meets threshold`() {
         val rule = WardrobeRule("jumper", WardrobeRule.TemperatureBelow(18.0))
         rule.appliesTo(forecast(min = 18.0, max = 22.0)) shouldBe false
     }
 
     @Test
-    fun `temperature above applies when daily max is warmer`() {
+    fun `temperature above applies when feels-like max is warmer`() {
         val rule = WardrobeRule("shorts", WardrobeRule.TemperatureAbove(24.0))
         rule.appliesTo(forecast(min = 12.0, max = 26.5)) shouldBe true
     }
 
     @Test
-    fun `temperature above does not apply when daily max meets threshold`() {
+    fun `temperature above does not apply when feels-like max meets threshold`() {
         val rule = WardrobeRule("shorts", WardrobeRule.TemperatureAbove(24.0))
         rule.appliesTo(forecast(min = 12.0, max = 24.0)) shouldBe false
     }

--- a/core/domain/src/test/kotlin/com/adaptweather/core/domain/usecase/BuildPromptTest.kt
+++ b/core/domain/src/test/kotlin/com/adaptweather/core/domain/usecase/BuildPromptTest.kt
@@ -18,6 +18,8 @@ class BuildPromptTest {
         date = LocalDate.of(2026, 4, 24),
         temperatureMinC = 12.0,
         temperatureMaxC = 18.0,
+        feelsLikeMinC = 10.0,
+        feelsLikeMaxC = 17.0,
         precipitationProbabilityMaxPct = 5.0,
         precipitationMmTotal = 0.0,
         condition = WeatherCondition.PARTLY_CLOUDY,
@@ -27,74 +29,98 @@ class BuildPromptTest {
         date = LocalDate.of(2026, 4, 25),
         temperatureMinC = 16.0,
         temperatureMaxC = 24.0,
+        feelsLikeMinC = 15.0,
+        feelsLikeMaxC = 23.0,
         precipitationProbabilityMaxPct = 60.0,
         precipitationMmTotal = 4.5,
         condition = WeatherCondition.RAIN,
         hourly = listOf(
-            HourlyForecast(LocalTime.of(9, 0), 18.0, 10.0, WeatherCondition.PARTLY_CLOUDY),
-            HourlyForecast(LocalTime.of(15, 0), 22.0, 60.0, WeatherCondition.RAIN),
-            HourlyForecast(LocalTime.of(18, 0), 19.0, 30.0, WeatherCondition.DRIZZLE),
+            HourlyForecast(LocalTime.of(9, 0), 18.0, 16.0, 10.0, WeatherCondition.PARTLY_CLOUDY),
+            HourlyForecast(LocalTime.of(15, 0), 22.0, 20.0, 60.0, WeatherCondition.RAIN),
+            HourlyForecast(LocalTime.of(18, 0), 19.0, 17.0, 30.0, WeatherCondition.DRIZZLE),
         ),
     )
 
+    private val jumperRule = WardrobeRule("jumper", WardrobeRule.TemperatureBelow(18.0))
+    private val umbrellaRule = WardrobeRule("umbrella", WardrobeRule.PrecipitationProbabilityAbove(50.0))
+
     @Test
-    fun `system instruction carries length cap and language tag`() {
-        val prompt = subject(today, yesterday, emptyList(), TemperatureUnit.CELSIUS, "en-AU")
-        prompt.systemInstruction.shouldContain("max 25 words")
+    fun `system instruction states the three rules and the language tag`() {
+        val prompt = subject(today, yesterday, emptyList(), emptyList(), TemperatureUnit.CELSIUS, "en-AU")
+
+        prompt.systemInstruction.shouldContain("at least 3°")
+        prompt.systemInstruction.shouldContain("at least 30%")
+        prompt.systemInstruction.shouldContain("\"It will be N° warmer today.\"")
+        prompt.systemInstruction.shouldContain("\"Wear <items>.\"")
+        prompt.systemInstruction.shouldContain("\"<Type> at <HH:MM>.\"")
         prompt.systemInstruction.shouldContain("en-AU")
+        prompt.systemInstruction.shouldContain("empty string")
     }
 
     @Test
-    fun `user message includes both day temperatures in celsius`() {
-        val prompt = subject(today, yesterday, emptyList(), TemperatureUnit.CELSIUS, "en-AU")
-        prompt.userMessage.shouldContain("min 12°C, max 18°C")
-        prompt.userMessage.shouldContain("min 16°C, max 24°C")
+    fun `user message uses feels-like, not raw temperatures`() {
+        val prompt = subject(today, yesterday, emptyList(), emptyList(), TemperatureUnit.CELSIUS, "en-AU")
+
+        prompt.userMessage.shouldContain("feels-like high: 17°C")
+        prompt.userMessage.shouldContain("feels-like low: 10°C")
+        prompt.userMessage.shouldContain("feels-like high: 23°C")
+        prompt.userMessage.shouldContain("feels-like low: 15°C")
     }
 
     @Test
-    fun `user message converts to fahrenheit when requested`() {
-        val prompt = subject(today, yesterday, emptyList(), TemperatureUnit.FAHRENHEIT, "en-US")
-        // 18C -> 64.4F -> 64°F, 24C -> 75.2F -> 75°F
-        prompt.userMessage.shouldContain("max 64°F")
-        prompt.userMessage.shouldContain("max 75°F")
+    fun `feels-like is converted to fahrenheit when requested`() {
+        val prompt = subject(today, yesterday, emptyList(), emptyList(), TemperatureUnit.FAHRENHEIT, "en-US")
+        // 17°C -> 62.6°F -> 63°F, 23°C -> 73.4°F -> 73°F
+        prompt.userMessage.shouldContain("feels-like high: 63°F")
+        prompt.userMessage.shouldContain("feels-like high: 73°F")
         prompt.userMessage.shouldNotContain("°C")
     }
 
     @Test
-    fun `peak rain hour is included when chance is at least 30 percent`() {
-        val prompt = subject(today, yesterday, emptyList(), TemperatureUnit.CELSIUS, "en-AU")
-        prompt.userMessage.shouldContain("highest rain chance around 15:00 (60%)")
+    fun `user message lists yesterday's and today's wardrobe items`() {
+        val prompt = subject(
+            today, yesterday,
+            yesterdayTriggeredRules = listOf(jumperRule),
+            todayTriggeredRules = listOf(jumperRule, umbrellaRule),
+            temperatureUnit = TemperatureUnit.CELSIUS,
+            languageTag = "en-AU",
+        )
+
+        prompt.userMessage.shouldContain("Yesterday's wardrobe items: jumper")
+        prompt.userMessage.shouldContain("Today's wardrobe items: jumper, umbrella")
     }
 
     @Test
-    fun `peak rain hour is omitted on dry days`() {
+    fun `user message marks empty wardrobe lists explicitly`() {
+        val prompt = subject(today, yesterday, emptyList(), emptyList(), TemperatureUnit.CELSIUS, "en-AU")
+
+        prompt.userMessage.shouldContain("Yesterday's wardrobe items: (none)")
+        prompt.userMessage.shouldContain("Today's wardrobe items: (none)")
+    }
+
+    @Test
+    fun `peak precipitation hour is included with type when chance is at least 30 percent`() {
+        val prompt = subject(today, yesterday, emptyList(), emptyList(), TemperatureUnit.CELSIUS, "en-AU")
+
+        prompt.userMessage.shouldContain("precipitation type: rain")
+        prompt.userMessage.shouldContain("precipitation peak hour: 15:00")
+    }
+
+    @Test
+    fun `precipitation hints are omitted on a dry day`() {
         val dryToday = today.copy(
             precipitationProbabilityMaxPct = 5.0,
-            hourly = listOf(HourlyForecast(LocalTime.of(15, 0), 22.0, 5.0, WeatherCondition.CLEAR)),
+            hourly = listOf(HourlyForecast(LocalTime.of(15, 0), 22.0, 20.0, 5.0, WeatherCondition.CLEAR)),
         )
-        val prompt = subject(dryToday, yesterday, emptyList(), TemperatureUnit.CELSIUS, "en-AU")
-        prompt.userMessage.shouldNotContain("highest rain chance")
-    }
+        val prompt = subject(dryToday, yesterday, emptyList(), emptyList(), TemperatureUnit.CELSIUS, "en-AU")
 
-    @Test
-    fun `triggered items appear in user message when present`() {
-        val triggered = listOf(
-            WardrobeRule("jumper", WardrobeRule.TemperatureBelow(18.0)),
-            WardrobeRule("umbrella", WardrobeRule.PrecipitationProbabilityAbove(50.0)),
-        )
-        val prompt = subject(today, yesterday, triggered, TemperatureUnit.CELSIUS, "en-AU")
-        prompt.userMessage.shouldContain("Recommended items based on user thresholds: jumper, umbrella")
-    }
-
-    @Test
-    fun `no recommendation line when no rules triggered`() {
-        val prompt = subject(today, yesterday, emptyList(), TemperatureUnit.CELSIUS, "en-AU")
-        prompt.userMessage.shouldNotContain("Recommended items")
+        prompt.userMessage.shouldNotContain("precipitation type")
+        prompt.userMessage.shouldNotContain("precipitation peak hour")
     }
 
     @Test
     fun `condition labels are human readable`() {
-        val prompt = subject(today, yesterday, emptyList(), TemperatureUnit.CELSIUS, "en-AU")
+        val prompt = subject(today, yesterday, emptyList(), emptyList(), TemperatureUnit.CELSIUS, "en-AU")
         prompt.userMessage.shouldContain("conditions: partly cloudy")
         prompt.userMessage.shouldContain("conditions: rain")
     }

--- a/core/domain/src/test/kotlin/com/adaptweather/core/domain/usecase/EvaluateWardrobeRulesTest.kt
+++ b/core/domain/src/test/kotlin/com/adaptweather/core/domain/usecase/EvaluateWardrobeRulesTest.kt
@@ -17,6 +17,8 @@ class EvaluateWardrobeRulesTest {
             date = date,
             temperatureMinC = min,
             temperatureMaxC = max,
+            feelsLikeMinC = min,
+            feelsLikeMaxC = max,
             precipitationProbabilityMaxPct = precip,
             precipitationMmTotal = 0.0,
             condition = WeatherCondition.CLEAR,

--- a/core/domain/src/test/kotlin/com/adaptweather/core/domain/usecase/GenerateDailyInsightTest.kt
+++ b/core/domain/src/test/kotlin/com/adaptweather/core/domain/usecase/GenerateDailyInsightTest.kt
@@ -32,6 +32,8 @@ class GenerateDailyInsightTest {
         date = LocalDate.of(2026, 4, 24),
         temperatureMinC = 12.0,
         temperatureMaxC = 18.0,
+        feelsLikeMinC = 10.0,
+        feelsLikeMaxC = 17.0,
         precipitationProbabilityMaxPct = 5.0,
         precipitationMmTotal = 0.0,
         condition = WeatherCondition.PARTLY_CLOUDY,
@@ -41,6 +43,8 @@ class GenerateDailyInsightTest {
         date = LocalDate.of(2026, 4, 25),
         temperatureMinC = 8.0,
         temperatureMaxC = 25.0,
+        feelsLikeMinC = 6.0,
+        feelsLikeMaxC = 24.0,
         precipitationProbabilityMaxPct = 60.0,
         precipitationMmTotal = 4.5,
         condition = WeatherCondition.RAIN,
@@ -114,7 +118,13 @@ class GenerateDailyInsightTest {
 
     @Test
     fun `recommended items reflect rule evaluation, not raw rule list`() = runTest {
-        val mildToday = today.copy(temperatureMinC = 19.0, temperatureMaxC = 22.0, precipitationProbabilityMaxPct = 10.0)
+        val mildToday = today.copy(
+            temperatureMinC = 19.0,
+            temperatureMaxC = 22.0,
+            feelsLikeMinC = 19.0,
+            feelsLikeMaxC = 22.0,
+            precipitationProbabilityMaxPct = 10.0,
+        )
         val weather = FakeWeatherRepository(ForecastBundle(mildToday, yesterday))
         val gen = FakeInsightGenerator("ok")
         val subject = GenerateDailyInsight(weather, gen, clock = clock)


### PR DESCRIPTION
## Summary

Replaces the LLM's "write a comparative sentence" instruction with three explicit phrasing rules drawn from your V10 spec. The output is now templated prose like *"It will be 4° warmer today. Wear shorts. Rain at 15:00."* instead of LLM-flavoured paragraphs. Each rule yields zero or one sentence; if all three yield nothing, the worker is silent (no notification, no TTS).

### Rules (each yields 0 or 1 sentence)

| Rule | Trigger | Output |
|---|---|---|
| 1 — temperature change | abs feels-like high or low delta vs yesterday ≥ 3°C | "It will be N° warmer today." / "It will be N° cooler today." |
| 2 — wardrobe diff | today's triggered items ≠ yesterday's | "Wear `<items>`." |
| 3 — precipitation | today's peak chance ≥ 30% | "`<Type>` at `<HH:MM>`." |

### Data-model changes the rules require

- **`DailyForecast`** / **`HourlyForecast`** gain `feelsLike` fields. People experience apparent temperature, not raw 2 m air.
- **`WardrobeRule.appliesTo`** switches to feels-like — *"shorts above 24°C"* means 24° as it feels, not as the thermometer reads.
- **`OpenMeteoClient`** asks for `apparent_temperature_{min,max}` (daily) + `apparent_temperature` (hourly). Falls back to raw temp when the API returns null for apparent (rare, observed).
- **`GenerateDailyInsight`** now evaluates wardrobe rules against *both* yesterday and today so `BuildPrompt` can describe the diff.
- **`FetchAndNotifyWorker.deliver`** short-circuits when the LLM returns blank — preserves silent-running semantics.

### Out of scope (explicitly deferred)

- **Calendar events** ("Bring a `<item>` for `<event>`") — needs `CalendarContract` read + per-event location filtering.
- **7pm out-of-hours briefing** — needs a second alarm slot + the calendar reader above.
- **Two-daily-prompts schedule UX** — current scheduler is a single time per day.

## Test plan

- [x] All :core:domain + :core:data tests updated and passing locally
- [ ] CI green
- [ ] Sideload, paste a Gemini key, tap Refresh
  - Verify the notification body matches the rule output (or is absent if nothing triggered)
  - Toggle wardrobe rules / location and confirm the prose updates accordingly the next morning

https://claude.ai/code/session_01VftWR7DyaaVXHnovkuQwge

---
_Generated by [Claude Code](https://claude.ai/code/session_01VftWR7DyaaVXHnovkuQwge)_