### PR TITLE
fix(test): GenerateDailyInsightTest feels-like-max threshold off-by-one

### DIFF
--- a/core/domain/src/test/kotlin/com/adaptweather/core/domain/usecase/GenerateDailyInsightTest.kt
+++ b/core/domain/src/test/kotlin/com/adaptweather/core/domain/usecase/GenerateDailyInsightTest.kt
@@ -44,7 +44,7 @@ class GenerateDailyInsightTest {
         temperatureMinC = 8.0,
         temperatureMaxC = 25.0,
         feelsLikeMinC = 6.0,
-        feelsLikeMaxC = 24.0,
+        feelsLikeMaxC = 25.0,
         precipitationProbabilityMaxPct = 60.0,
         precipitationMmTotal = 4.5,
         condition = WeatherCondition.RAIN,


### PR DESCRIPTION
## Summary

Fix-forward for the test failure in `GenerateDailyInsightTest` after PR #25.

`WardrobeRule.TemperatureAbove(24.0)` is strict (`feelsLikeMaxC > 24.0`). The V10 prompt rewrite switched the rule's matching basis from raw temperature to feels-like, and the test fixture had `today.feelsLikeMaxC = 24.0` — which narrowly missed the threshold, dropping the "shorts" item out of the `recommendedItems.shouldContainExactly` assertion.

Bumping `feelsLikeMaxC` to `25.0` (matching the existing `temperatureMaxC = 25.0` in the same fixture) restores the test's original intent without weakening the rule semantics.

## Test plan

- [ ] CI green on this branch

https://claude.ai/code/session_01VftWR7DyaaVXHnovkuQwge

---
_Generated by [Claude Code](https://claude.ai/code/session_01VftWR7DyaaVXHnovkuQwge)_