### PR TITLE
:core + :app — Gemini TTS as an opt-in voice engine

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,6 +6,13 @@ plugins {
 }
 
 android {
+    // TODO(release): pin the final namespace + applicationId BEFORE the first
+    // distribution outside this dev team. Once a sideloaded build with applicationId
+    // X is in the wild, switching to Y means installs of Y are a different app —
+    // users have to uninstall + reinstall and lose their encrypted Gemini key,
+    // schedule, location, and wardrobe rules. Convention is reverse-DNS based on
+    // a domain you own (e.g. dev.mikelward.adaptweather) and a confirmed product
+    // name; "AdaptWeather" itself is also up for grabs.
     namespace = "com.adaptweather"
     compileSdk = 35
 

--- a/app/src/main/kotlin/com/adaptweather/AdaptWeatherApplication.kt
+++ b/app/src/main/kotlin/com/adaptweather/AdaptWeatherApplication.kt
@@ -5,6 +5,7 @@ import android.util.Log
 import com.adaptweather.alarm.DailyAlarmScheduler
 import com.adaptweather.core.data.insight.DirectGeminiClient
 import com.adaptweather.core.data.location.OpenMeteoGeocodingClient
+import com.adaptweather.core.data.tts.GeminiTtsClient
 import com.adaptweather.core.data.weather.OpenMeteoClient
 import com.adaptweather.core.domain.repository.InsightGenerator
 import com.adaptweather.core.domain.repository.WeatherRepository
@@ -16,6 +17,7 @@ import com.adaptweather.location.LocationResolver
 import com.adaptweather.notification.InsightNotifier
 import com.adaptweather.notification.NotificationChannelRegistrar
 import com.adaptweather.tts.AndroidTtsSpeaker
+import com.adaptweather.tts.GeminiTtsSpeaker
 import com.adaptweather.tts.TtsSpeaker
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.okhttp.OkHttp
@@ -40,7 +42,10 @@ class AdaptWeatherApplication : Application() {
     val locationResolver: LocationResolver by lazy { LocationResolver(this) }
     val insightNotifier: InsightNotifier by lazy { InsightNotifier(this) }
     val dailyAlarmScheduler: DailyAlarmScheduler by lazy { DailyAlarmScheduler(this) }
-    val ttsSpeaker: TtsSpeaker by lazy { AndroidTtsSpeaker(this) }
+    val deviceTtsSpeaker: TtsSpeaker by lazy { AndroidTtsSpeaker(this) }
+    val geminiTtsSpeaker: TtsSpeaker by lazy {
+        GeminiTtsSpeaker(GeminiTtsClient(httpClient, secureKeyStore))
+    }
 
     private val httpClient: HttpClient by lazy {
         HttpClient(OkHttp) {

--- a/app/src/main/kotlin/com/adaptweather/data/SettingsRepository.kt
+++ b/app/src/main/kotlin/com/adaptweather/data/SettingsRepository.kt
@@ -14,6 +14,7 @@ import com.adaptweather.core.domain.model.DistanceUnit
 import com.adaptweather.core.domain.model.Location
 import com.adaptweather.core.domain.model.Schedule
 import com.adaptweather.core.domain.model.TemperatureUnit
+import com.adaptweather.core.domain.model.TtsEngine
 import com.adaptweather.core.domain.model.UserPreferences
 import com.adaptweather.core.domain.model.WardrobeRule
 import kotlinx.coroutines.flow.Flow
@@ -88,6 +89,10 @@ class SettingsRepository(
         dataStore.edit { it[USE_DEVICE_LOCATION] = enabled }
     }
 
+    suspend fun setTtsEngine(engine: TtsEngine) {
+        dataStore.edit { it[TTS_ENGINE] = engine.name }
+    }
+
     private fun Preferences.toUserPreferences(): UserPreferences {
         val time = this[SCHEDULE_TIME]?.let { LocalTime.parse(it, TIME_FORMAT) }
             ?: DEFAULT_TIME
@@ -104,6 +109,8 @@ class SettingsRepository(
         val rules = parseRules(this[WARDROBE_RULES])
         val location = parseLocation(this)
         val useDeviceLocation = this[USE_DEVICE_LOCATION] == true
+        val ttsEngine = this[TTS_ENGINE]?.let { runCatching { TtsEngine.valueOf(it) }.getOrNull() }
+            ?: TtsEngine.DEVICE
 
         return UserPreferences(
             schedule = Schedule(time = time, days = days, zoneId = zoneIdProvider()),
@@ -113,6 +120,7 @@ class SettingsRepository(
             wardrobeRules = rules,
             location = location,
             useDeviceLocation = useDeviceLocation,
+            ttsEngine = ttsEngine,
         )
     }
 
@@ -146,6 +154,7 @@ class SettingsRepository(
         private val LOCATION_LON = doublePreferencesKey("location_longitude")
         private val LOCATION_NAME = stringPreferencesKey("location_display_name")
         private val USE_DEVICE_LOCATION = booleanPreferencesKey("use_device_location")
+        private val TTS_ENGINE = stringPreferencesKey("tts_engine")
 
         private val TIME_FORMAT: DateTimeFormatter = DateTimeFormatter.ofPattern("HH:mm")
         private val DEFAULT_TIME: LocalTime = LocalTime.of(7, 0)

--- a/app/src/main/kotlin/com/adaptweather/tts/GeminiTtsSpeaker.kt
+++ b/app/src/main/kotlin/com/adaptweather/tts/GeminiTtsSpeaker.kt
@@ -1,0 +1,93 @@
+package com.adaptweather.tts
+
+import android.media.AudioAttributes
+import android.media.AudioFormat
+import android.media.AudioTrack
+import android.util.Log
+import com.adaptweather.core.data.tts.GeminiTtsClient
+import com.adaptweather.core.data.tts.PcmAudio
+import kotlinx.coroutines.suspendCancellableCoroutine
+import java.util.Locale
+import kotlin.coroutines.resume
+
+/**
+ * High-quality TTS via Gemini's audio-output model. Synthesises PCM audio in one
+ * network call and plays it back through [AudioTrack] in MODE_STATIC, which lets
+ * us hand the entire buffer at once and listen for the playback-head reaching the
+ * end. Cleaner than streaming from a short utterance.
+ *
+ * Fallback is the caller's responsibility — see [com.adaptweather.work.FetchAndNotifyWorker]
+ * which retries with [AndroidTtsSpeaker] when this throws.
+ */
+class GeminiTtsSpeaker(
+    private val client: GeminiTtsClient,
+    private val voiceName: String? = null,
+) : TtsSpeaker {
+
+    override suspend fun speak(text: String, locale: Locale) {
+        val audio = client.synthesize(
+            text = text,
+            voiceName = voiceName ?: com.adaptweather.core.data.tts.DEFAULT_GEMINI_TTS_VOICE,
+        )
+        play(audio)
+    }
+
+    private suspend fun play(audio: PcmAudio) {
+        val pcm = audio.bytes
+        if (pcm.isEmpty()) return
+
+        val track = AudioTrack.Builder()
+            .setAudioAttributes(
+                AudioAttributes.Builder()
+                    .setUsage(AudioAttributes.USAGE_NOTIFICATION)
+                    .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
+                    .build(),
+            )
+            .setAudioFormat(
+                AudioFormat.Builder()
+                    .setEncoding(AudioFormat.ENCODING_PCM_16BIT)
+                    .setSampleRate(audio.sampleRate)
+                    .setChannelMask(AudioFormat.CHANNEL_OUT_MONO)
+                    .build(),
+            )
+            .setBufferSizeInBytes(pcm.size)
+            .setTransferMode(AudioTrack.MODE_STATIC)
+            .build()
+
+        try {
+            // MODE_STATIC accepts the whole buffer in one write before play().
+            val written = track.write(pcm, 0, pcm.size)
+            if (written < 0) {
+                Log.w(TAG, "AudioTrack.write rejected the buffer (code=$written)")
+                return
+            }
+            // 2 bytes per 16-bit sample, mono.
+            val totalFrames = pcm.size / 2
+            track.notificationMarkerPosition = totalFrames
+            awaitMarker(track, totalFrames)
+        } finally {
+            runCatching { track.stop() }
+            track.release()
+        }
+    }
+
+    private suspend fun awaitMarker(track: AudioTrack, markerInFrames: Int) {
+        suspendCancellableCoroutine<Unit> { cont ->
+            track.setPlaybackPositionUpdateListener(
+                object : AudioTrack.OnPlaybackPositionUpdateListener {
+                    override fun onMarkerReached(t: AudioTrack?) {
+                        if (cont.isActive) cont.resume(Unit)
+                    }
+                    override fun onPeriodicNotification(t: AudioTrack?) {}
+                },
+            )
+            track.play()
+            cont.invokeOnCancellation { runCatching { track.stop() } }
+        }
+        Log.i(TAG, "Played ${markerInFrames} PCM frames")
+    }
+
+    companion object {
+        private const val TAG = "GeminiTtsSpeaker"
+    }
+}

--- a/app/src/main/kotlin/com/adaptweather/ui/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/adaptweather/ui/settings/SettingsScreen.kt
@@ -55,6 +55,7 @@ import com.adaptweather.core.domain.model.DeliveryMode
 import com.adaptweather.core.domain.model.DistanceUnit
 import com.adaptweather.core.domain.model.Location
 import com.adaptweather.core.domain.model.TemperatureUnit
+import com.adaptweather.core.domain.model.TtsEngine
 import com.adaptweather.core.domain.model.WardrobeRule
 import com.adaptweather.work.FetchAndNotifyWorker
 import kotlinx.coroutines.launch
@@ -100,6 +101,7 @@ fun SettingsScreen(viewModel: SettingsViewModel, onNavigateBack: () -> Unit) {
             onClearLocation = viewModel::clearLocation,
             onSearchLocations = viewModel::searchLocations,
             onSetUseDeviceLocation = viewModel::setUseDeviceLocation,
+            onSetTtsEngine = viewModel::setTtsEngine,
         )
     }
 }
@@ -121,6 +123,7 @@ private fun SettingsContent(
     onClearLocation: () -> Unit,
     onSearchLocations: suspend (String) -> List<Location>,
     onSetUseDeviceLocation: (Boolean) -> Unit,
+    onSetTtsEngine: (TtsEngine) -> Unit,
 ) {
     Column(
         modifier = Modifier
@@ -150,6 +153,7 @@ private fun SettingsContent(
             onChange = onSetSchedule,
         )
         DeliveryModeCard(state.deliveryMode, onSetDeliveryMode)
+        TtsEngineCard(state.ttsEngine, onSetTtsEngine)
         TemperatureUnitCard(state.temperatureUnit, onSetTemperatureUnit)
         DistanceUnitCard(state.distanceUnit, onSetDistanceUnit)
         WardrobeRulesCard(
@@ -826,6 +830,27 @@ private fun DeliveryModeCard(
 }
 
 @Composable
+private fun TtsEngineCard(
+    selected: TtsEngine,
+    onSelect: (TtsEngine) -> Unit,
+) {
+    SectionCard(title = stringResource(R.string.settings_tts_engine_title)) {
+        Text(
+            text = stringResource(R.string.settings_tts_engine_description),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        TtsEngine.entries.forEach { engine ->
+            RadioRow(
+                label = stringResource(ttsEngineLabel(engine)),
+                selected = engine == selected,
+                onSelect = { onSelect(engine) },
+            )
+        }
+    }
+}
+
+@Composable
 private fun TemperatureUnitCard(
     selected: TemperatureUnit,
     onSelect: (TemperatureUnit) -> Unit,
@@ -878,6 +903,11 @@ private fun deliveryModeLabel(mode: DeliveryMode): Int = when (mode) {
     DeliveryMode.NOTIFICATION_ONLY -> R.string.settings_delivery_notification_only
     DeliveryMode.TTS_ONLY -> R.string.settings_delivery_tts_only
     DeliveryMode.NOTIFICATION_AND_TTS -> R.string.settings_delivery_notification_and_tts
+}
+
+private fun ttsEngineLabel(engine: TtsEngine): Int = when (engine) {
+    TtsEngine.DEVICE -> R.string.settings_tts_engine_device
+    TtsEngine.GEMINI -> R.string.settings_tts_engine_gemini
 }
 
 private fun temperatureUnitLabel(unit: TemperatureUnit): Int = when (unit) {

--- a/app/src/main/kotlin/com/adaptweather/ui/settings/SettingsState.kt
+++ b/app/src/main/kotlin/com/adaptweather/ui/settings/SettingsState.kt
@@ -5,6 +5,7 @@ import com.adaptweather.core.domain.model.DistanceUnit
 import com.adaptweather.core.domain.model.Location
 import com.adaptweather.core.domain.model.Schedule
 import com.adaptweather.core.domain.model.TemperatureUnit
+import com.adaptweather.core.domain.model.TtsEngine
 import com.adaptweather.core.domain.model.WardrobeRule
 import java.time.DayOfWeek
 import java.time.LocalTime
@@ -19,5 +20,6 @@ data class SettingsState(
     val wardrobeRules: List<WardrobeRule> = WardrobeRule.DEFAULTS,
     val location: Location? = null,
     val useDeviceLocation: Boolean = false,
+    val ttsEngine: TtsEngine = TtsEngine.DEVICE,
     val apiKeyConfigured: Boolean = false,
 )

--- a/app/src/main/kotlin/com/adaptweather/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/adaptweather/ui/settings/SettingsViewModel.kt
@@ -9,6 +9,7 @@ import com.adaptweather.core.domain.model.DistanceUnit
 import com.adaptweather.core.domain.model.Location
 import com.adaptweather.core.domain.model.Schedule
 import com.adaptweather.core.domain.model.TemperatureUnit
+import com.adaptweather.core.domain.model.TtsEngine
 import com.adaptweather.core.domain.model.WardrobeRule
 import com.adaptweather.data.SecureKeyStore
 import com.adaptweather.data.SettingsRepository
@@ -44,6 +45,7 @@ class SettingsViewModel(
                         wardrobeRules = prefs.wardrobeRules,
                         location = prefs.location,
                         useDeviceLocation = prefs.useDeviceLocation,
+                        ttsEngine = prefs.ttsEngine,
                     )
                 }
             }
@@ -109,6 +111,10 @@ class SettingsViewModel(
 
     fun setUseDeviceLocation(enabled: Boolean) {
         viewModelScope.launch { settingsRepository.setUseDeviceLocation(enabled) }
+    }
+
+    fun setTtsEngine(engine: TtsEngine) {
+        viewModelScope.launch { settingsRepository.setTtsEngine(engine) }
     }
 
     /** Used by [LocationCard] inside a LaunchedEffect; safe to call from any dispatcher. */

--- a/app/src/main/kotlin/com/adaptweather/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/com/adaptweather/work/FetchAndNotifyWorker.kt
@@ -18,6 +18,7 @@ import com.adaptweather.core.data.insight.MissingApiKeyException
 import com.adaptweather.core.domain.model.DeliveryMode
 import com.adaptweather.core.domain.model.Insight
 import com.adaptweather.core.domain.model.Location
+import com.adaptweather.core.domain.model.TtsEngine
 import com.adaptweather.core.domain.model.UserPreferences
 import io.ktor.client.network.sockets.ConnectTimeoutException
 import io.ktor.client.network.sockets.SocketTimeoutException
@@ -156,13 +157,29 @@ class FetchAndNotifyWorker(
             app.insightNotifier.notify(insight)
         }
         if (mode == DeliveryMode.TTS_ONLY || mode == DeliveryMode.NOTIFICATION_AND_TTS) {
+            speakWithFallback(insight.spokenText(), prefs.ttsEngine)
+        }
+    }
+
+    /**
+     * Speaks via the user-preferred engine; on Gemini failure (network, quota, missing
+     * key) falls back to the on-device engine so the user still hears something. We
+     * never let a TTS error fail the worker — the notification path is the primary
+     * delivery channel and has already fired by this point.
+     */
+    private suspend fun speakWithFallback(text: String, engine: TtsEngine) {
+        if (engine == TtsEngine.GEMINI) {
             try {
-                app.ttsSpeaker.speak(insight.spokenText())
+                app.geminiTtsSpeaker.speak(text)
+                return
             } catch (t: Throwable) {
-                // TTS engine failures shouldn't lose the insight; the notification path
-                // (when also enabled) already covered the user-visible delivery.
-                Log.w(TAG, "TTS playback failed; insight is still posted as notification.", t)
+                Log.w(TAG, "Gemini TTS failed; falling back to device TTS.", t)
             }
+        }
+        try {
+            app.deviceTtsSpeaker.speak(text)
+        } catch (t: Throwable) {
+            Log.w(TAG, "Device TTS failed; insight is still posted as notification.", t)
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -54,6 +54,11 @@
     <string name="settings_delivery_tts_only">Spoken aloud only</string>
     <string name="settings_delivery_notification_and_tts">Notification and spoken aloud</string>
 
+    <string name="settings_tts_engine_title">Voice engine</string>
+    <string name="settings_tts_engine_description">Gemini\'s voice is much more natural but needs a network call and uses your Gemini API key for synthesis (one short call per spoken insight). Falls back to the device voice if it fails.</string>
+    <string name="settings_tts_engine_device">Device (offline, free)</string>
+    <string name="settings_tts_engine_gemini">Gemini (high quality, online)</string>
+
     <string name="settings_temperature_unit_title">Temperature unit</string>
     <string name="settings_temperature_unit_celsius">Celsius (°C)</string>
     <string name="settings_temperature_unit_fahrenheit">Fahrenheit (°F)</string>

--- a/core/data/src/main/kotlin/com/adaptweather/core/data/tts/GeminiTtsClient.kt
+++ b/core/data/src/main/kotlin/com/adaptweather/core/data/tts/GeminiTtsClient.kt
@@ -1,0 +1,102 @@
+package com.adaptweather.core.data.tts
+
+import com.adaptweather.core.data.insight.GEMINI_API_VERSION
+import com.adaptweather.core.data.insight.GEMINI_HOST
+import com.adaptweather.core.data.insight.KeyProvider
+import com.adaptweather.core.data.insight.MissingApiKeyException
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.URLProtocol
+import io.ktor.http.contentType
+import io.ktor.http.path
+import java.util.Base64
+
+const val DEFAULT_GEMINI_TTS_MODEL: String = "gemini-2.5-flash-preview-tts"
+const val DEFAULT_GEMINI_TTS_VOICE: String = "Kore"
+
+/**
+ * Calls Gemini's audio-output model (e.g. `gemini-2.5-flash-preview-tts`). Same host,
+ * same auth header, same BYOK key as [com.adaptweather.core.data.insight.DirectGeminiClient].
+ *
+ * The model returns a single 16-bit signed PCM audio stream at a sample rate carried
+ * in the `mimeType` (`audio/L16;codec=pcm;rate=24000`). [PcmAudio.sampleRate] parses
+ * that out of the response so the caller can hand the bytes straight to AudioTrack.
+ *
+ * Default voice is `Kore` (firm). Other prebuilt voices are listed in Google's docs;
+ * pass via [voiceName] when calling.
+ */
+class GeminiTtsClient(
+    private val httpClient: HttpClient,
+    private val keyProvider: KeyProvider,
+    private val model: String = DEFAULT_GEMINI_TTS_MODEL,
+) {
+    suspend fun synthesize(
+        text: String,
+        voiceName: String = DEFAULT_GEMINI_TTS_VOICE,
+    ): PcmAudio {
+        val key = keyProvider.get().also {
+            if (it.isBlank()) throw MissingApiKeyException()
+        }
+
+        val response: TtsResponse = httpClient.post {
+            url {
+                protocol = URLProtocol.HTTPS
+                host = GEMINI_HOST
+                path(GEMINI_API_VERSION, "models", "$model:generateContent")
+            }
+            header("x-goog-api-key", key)
+            contentType(ContentType.Application.Json)
+            setBody(
+                TtsRequest(
+                    contents = listOf(TtsContent(parts = listOf(TtsTextPart(text)))),
+                    generationConfig = TtsGenerationConfig(
+                        responseModalities = listOf("AUDIO"),
+                        speechConfig = SpeechConfig(
+                            voiceConfig = VoiceConfig(
+                                prebuiltVoiceConfig = PrebuiltVoiceConfig(voiceName),
+                            ),
+                        ),
+                    ),
+                ),
+            )
+        }.body()
+
+        val inline = response.candidates.firstOrNull()
+            ?.content?.parts?.firstOrNull { it.inlineData != null }
+            ?.inlineData
+            ?: throw GeminiTtsEmptyResponseException()
+
+        val pcm = Base64.getDecoder().decode(inline.data)
+        val sampleRate = parseSampleRate(inline.mimeType) ?: DEFAULT_SAMPLE_RATE_HZ
+        return PcmAudio(bytes = pcm, sampleRate = sampleRate)
+    }
+
+    private fun parseSampleRate(mimeType: String): Int? {
+        // mimeType looks like "audio/L16;codec=pcm;rate=24000". Pull the rate token out
+        // rather than assume — the model could change defaults.
+        return mimeType.split(';')
+            .map { it.trim() }
+            .firstOrNull { it.startsWith("rate=") }
+            ?.removePrefix("rate=")
+            ?.toIntOrNull()
+    }
+
+    companion object {
+        private const val DEFAULT_SAMPLE_RATE_HZ = 24_000
+    }
+}
+
+/** Decoded TTS audio: signed 16-bit PCM, mono, at [sampleRate] Hz. */
+data class PcmAudio(val bytes: ByteArray, val sampleRate: Int) {
+    override fun equals(other: Any?): Boolean =
+        other is PcmAudio && bytes.contentEquals(other.bytes) && sampleRate == other.sampleRate
+
+    override fun hashCode(): Int = 31 * bytes.contentHashCode() + sampleRate
+}
+
+class GeminiTtsEmptyResponseException :
+    IllegalStateException("Gemini TTS returned no inline-audio part")

--- a/core/data/src/main/kotlin/com/adaptweather/core/data/tts/GeminiTtsDto.kt
+++ b/core/data/src/main/kotlin/com/adaptweather/core/data/tts/GeminiTtsDto.kt
@@ -1,0 +1,60 @@
+package com.adaptweather.core.data.tts
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Wire types for the Gemini TTS variant of generateContent.
+ *
+ * The shape is `generateContent` like the text endpoint, but the request specifies
+ * `responseModalities: ["AUDIO"]` and a [SpeechConfig], and the response carries an
+ * [InlineData] PCM payload instead of plain text. Kept in its own file so the
+ * existing text DTOs in `:core:data/insight` stay focused.
+ */
+@Serializable
+internal data class TtsRequest(
+    val contents: List<TtsContent>,
+    val generationConfig: TtsGenerationConfig,
+)
+
+@Serializable
+internal data class TtsContent(val parts: List<TtsTextPart>)
+
+@Serializable
+internal data class TtsTextPart(val text: String)
+
+@Serializable
+internal data class TtsGenerationConfig(
+    val responseModalities: List<String> = listOf("AUDIO"),
+    val speechConfig: SpeechConfig,
+)
+
+@Serializable
+internal data class SpeechConfig(val voiceConfig: VoiceConfig)
+
+@Serializable
+internal data class VoiceConfig(val prebuiltVoiceConfig: PrebuiltVoiceConfig)
+
+@Serializable
+internal data class PrebuiltVoiceConfig(val voiceName: String)
+
+@Serializable
+internal data class TtsResponse(
+    val candidates: List<TtsCandidate> = emptyList(),
+)
+
+@Serializable
+internal data class TtsCandidate(val content: TtsCandidateContent? = null)
+
+@Serializable
+internal data class TtsCandidateContent(val parts: List<TtsResponsePart> = emptyList())
+
+@Serializable
+internal data class TtsResponsePart(
+    val inlineData: InlineData? = null,
+)
+
+@Serializable
+internal data class InlineData(
+    val mimeType: String,
+    val data: String,
+)

--- a/core/domain/src/main/kotlin/com/adaptweather/core/domain/model/Settings.kt
+++ b/core/domain/src/main/kotlin/com/adaptweather/core/domain/model/Settings.kt
@@ -6,6 +6,17 @@ enum class DistanceUnit { KILOMETERS, MILES }
 
 enum class DeliveryMode { NOTIFICATION_ONLY, TTS_ONLY, NOTIFICATION_AND_TTS }
 
+/**
+ * Where the spoken-aloud audio comes from.
+ *
+ * - [DEVICE] uses Android's on-device TextToSpeech engine. Free, fully offline once
+ *   voices are installed, but quality varies by vendor.
+ * - [GEMINI] uses Gemini's audio-output model (`gemini-2.5-flash-preview-tts`) over
+ *   the BYOK key. Near-human quality, requires network at speak-time, costs a small
+ *   amount per character. Falls back to [DEVICE] if the call fails.
+ */
+enum class TtsEngine { DEVICE, GEMINI }
+
 data class UserPreferences(
     val schedule: Schedule,
     val deliveryMode: DeliveryMode,
@@ -24,4 +35,5 @@ data class UserPreferences(
      * platform default if the read fails or permission is not granted.
      */
     val useDeviceLocation: Boolean = false,
+    val ttsEngine: TtsEngine = TtsEngine.DEVICE,
 )


### PR DESCRIPTION
## Summary

Adds Gemini TTS as an opt-in alternative to the on-device `TextToSpeech` engine. Sounds dramatically more natural; falls back to the device engine if the Gemini call fails so a missing key / network blip / quota doesn't kill the morning playback.

### Pieces

- **`UserPreferences.ttsEngine: TtsEngine`** — `DEVICE` | `GEMINI`, default `DEVICE`. Persisted by `SettingsRepository` as a string preference.
- **`:core:data/tts/GeminiTtsClient`** — calls `generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-preview-tts:generateContent` with `responseModalities = ["AUDIO"]` + `speechConfig.voiceConfig.prebuiltVoiceConfig.voiceName`. Returns `PcmAudio(bytes, sampleRate)`. Sample rate is parsed out of the response `mimeType` (`audio/L16;codec=pcm;rate=24000`), not assumed.
- **`:app/tts/GeminiTtsSpeaker`** — plays `PcmAudio` through `AudioTrack` in `MODE_STATIC`, awaits the playback head reaching the buffer end via `setPlaybackPositionUpdateListener`. No `MediaPlayer` / temp-file dance.
- **`AdaptWeatherApplication`** exposes `deviceTtsSpeaker` and `geminiTtsSpeaker` separately.
- **`FetchAndNotifyWorker.speakWithFallback`** picks the engine per `prefs.ttsEngine`. Any throwable from the Gemini path falls through to device TTS.
- **Settings** gets a new "Voice engine" card with two radios + an explainer about the network/cost tradeoff.

Default voice is `Kore` (firm). Switching voices is a constructor arg today; can become a Settings choice if useful.

## Test plan

- [x] All existing unit tests still pass — `UserPreferences.ttsEngine` has a default so existing constructors compile unchanged
- [ ] CI green
- [ ] Sideload, set delivery mode to "Spoken aloud only" (or "Notification and spoken aloud"), pick **Gemini** in Voice engine, tap Refresh — verify a clearly-better voice plays
- [ ] Repeat with **Device** to confirm the existing path still works
- [ ] Toggle Gemini, then revoke the key — confirm it falls back to device speech (logcat: "Gemini TTS failed; falling back to device TTS.")

https://claude.ai/code/session_01VftWR7DyaaVXHnovkuQwge

---
_Generated by [Claude Code](https://claude.ai/code/session_01VftWR7DyaaVXHnovkuQwge)_