### PR TITLE
:app — diagnostic &quot;Test Gemini voice&quot; button in Settings

### DIFF
--- a/app/src/main/kotlin/com/adaptweather/ui/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/adaptweather/ui/settings/SettingsScreen.kt
@@ -847,6 +847,44 @@ private fun TtsEngineCard(
                 onSelect = { onSelect(engine) },
             )
         }
+        if (selected == TtsEngine.GEMINI) {
+            TestGeminiVoiceButton()
+        }
+    }
+}
+
+@Composable
+private fun TestGeminiVoiceButton() {
+    val context = LocalContext.current
+    val coroutineScope = rememberCoroutineScope()
+    var inFlight by remember { mutableStateOf(false) }
+    Button(
+        enabled = !inFlight,
+        onClick = {
+            coroutineScope.launch {
+                inFlight = true
+                val app = context.applicationContext as com.adaptweather.AdaptWeatherApplication
+                try {
+                    app.geminiTtsSpeaker.speak(
+                        context.getString(R.string.settings_tts_test_sample),
+                    )
+                } catch (t: Throwable) {
+                    val message = "${t.javaClass.simpleName}: ${t.message ?: "(no detail)"}"
+                    android.util.Log.w("SettingsScreen", "Gemini TTS test failed", t)
+                    android.widget.Toast.makeText(context, message, android.widget.Toast.LENGTH_LONG).show()
+                } finally {
+                    inFlight = false
+                }
+            }
+        },
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Text(
+            stringResource(
+                if (inFlight) R.string.settings_tts_test_in_flight
+                else R.string.settings_tts_test,
+            ),
+        )
     }
 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -58,6 +58,9 @@
     <string name="settings_tts_engine_description">Gemini\'s voice is much more natural but needs a network call and uses your Gemini API key for synthesis (one short call per spoken insight). Falls back to the device voice if it fails.</string>
     <string name="settings_tts_engine_device">Device (offline, free)</string>
     <string name="settings_tts_engine_gemini">Gemini (high quality, online)</string>
+    <string name="settings_tts_test">Test Gemini voice</string>
+    <string name="settings_tts_test_in_flight">Testing — please wait…</string>
+    <string name="settings_tts_test_sample">Hello — this is the Gemini text to speech voice.</string>
 
     <string name="settings_temperature_unit_title">Temperature unit</string>
     <string name="settings_temperature_unit_celsius">Celsius (°C)</string>


### PR DESCRIPTION
## Summary

You reported that switching to Gemini in **Voice engine** still played the device voice. The worker has a silent fallback to device TTS on any Gemini failure, so the actual reason (missing key, HTTP 4xx, parse error, …) was invisible.

This adds a **Test Gemini voice** button inside the Voice engine card — only shown when **Gemini** is selected. Tapping it calls `geminiTtsSpeaker.speak("Hello — this is the Gemini text to speech voice.")`. If it succeeds you hear the high-quality voice; if it throws, the error class + message are surfaced as a Toast (and `Log.w`d under tag `SettingsScreen`). No new background plumbing — same code path the worker uses.

### Why this and not just better worker logging

The worker only runs at the morning fire (or via Refresh on Today), so debugging required reproducing a real fetch + watching `logcat`. A user-facing button gives a one-tap reproduction with the failure visible in the UI, no adb / no logcat. That's the highest-leverage diagnostic I can add without restructuring the existing fallback logic.

### Strings

Three new translatable entries (English only for v1):

- `settings_tts_test` — "Test Gemini voice"
- `settings_tts_test_in_flight` — "Testing — please wait…"
- `settings_tts_test_sample` — "Hello — this is the Gemini text to speech voice."

## Test plan

- [ ] CI green
- [ ] Sideload, set **Voice engine → Gemini**, tap **Test Gemini voice**
  - With a valid key: hear the Gemini voice
  - With no key: Toast shows `MissingApiKeyException`
  - With a bad key: Toast shows the HTTP failure
- [ ] Switch back to **Device** — button disappears, existing offline path unaffected

https://claude.ai/code/session_01VftWR7DyaaVXHnovkuQwge

---
_Generated by [Claude Code](https://claude.ai/code/session_01VftWR7DyaaVXHnovkuQwge)_