### PR TITLE
:core + :app — OpenAI TTS, voice pickers, auto-preview, TODO doc

### DIFF
--- a/app/src/main/kotlin/com/adaptweather/AdaptWeatherApplication.kt
+++ b/app/src/main/kotlin/com/adaptweather/AdaptWeatherApplication.kt
@@ -6,6 +6,7 @@ import com.adaptweather.alarm.DailyAlarmScheduler
 import com.adaptweather.core.data.insight.DirectGeminiClient
 import com.adaptweather.core.data.location.OpenMeteoGeocodingClient
 import com.adaptweather.core.data.tts.GeminiTtsClient
+import com.adaptweather.core.data.tts.OpenAITtsClient
 import com.adaptweather.core.data.weather.OpenMeteoClient
 import com.adaptweather.core.domain.repository.InsightGenerator
 import com.adaptweather.core.domain.repository.WeatherRepository
@@ -17,7 +18,6 @@ import com.adaptweather.location.LocationResolver
 import com.adaptweather.notification.InsightNotifier
 import com.adaptweather.notification.NotificationChannelRegistrar
 import com.adaptweather.tts.AndroidTtsSpeaker
-import com.adaptweather.tts.GeminiTtsSpeaker
 import com.adaptweather.tts.TtsSpeaker
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.okhttp.OkHttp
@@ -34,6 +34,11 @@ import kotlinx.serialization.json.Json
  * Lightweight DI: lazy singletons for things that depend on Android Context or that
  * the Worker / UI / receivers all share. Will move to Hilt once we have more than a
  * handful of consumers.
+ *
+ * The TTS *clients* are exposed (Gemini, OpenAI) but not the speakers — speakers wrap
+ * a per-call voice choice, so they're constructed at the call site from current
+ * preferences. The clients themselves are heavy (share the OkHttp engine) so they
+ * stay singletons.
  */
 class AdaptWeatherApplication : Application() {
     val secureKeyStore: SecureKeyStore by lazy { SecureKeyStore.create(this) }
@@ -43,8 +48,9 @@ class AdaptWeatherApplication : Application() {
     val insightNotifier: InsightNotifier by lazy { InsightNotifier(this) }
     val dailyAlarmScheduler: DailyAlarmScheduler by lazy { DailyAlarmScheduler(this) }
     val deviceTtsSpeaker: TtsSpeaker by lazy { AndroidTtsSpeaker(this) }
-    val geminiTtsSpeaker: TtsSpeaker by lazy {
-        GeminiTtsSpeaker(GeminiTtsClient(httpClient, secureKeyStore))
+    val geminiTtsClient: GeminiTtsClient by lazy { GeminiTtsClient(httpClient, secureKeyStore) }
+    val openAiTtsClient: OpenAITtsClient by lazy {
+        OpenAITtsClient(httpClient, secureKeyStore.openAiKeyProvider)
     }
 
     private val httpClient: HttpClient by lazy {

--- a/app/src/main/kotlin/com/adaptweather/data/SecureKeyStore.kt
+++ b/app/src/main/kotlin/com/adaptweather/data/SecureKeyStore.kt
@@ -17,11 +17,12 @@ import kotlinx.coroutines.flow.map
 import java.util.Base64
 
 /**
- * Encrypted on-device storage of the user's Gemini API key.
+ * Encrypted on-device storage of the user's API keys.
  *
- * The key is encrypted with a Tink AEAD primitive whose keyset is itself encrypted
+ * Each key is encrypted with a Tink AEAD primitive whose keyset is itself encrypted
  * by an Android-Keystore master key — so the secret material never appears in
- * SharedPreferences in plaintext. Ciphertext is persisted in DataStore Preferences.
+ * SharedPreferences in plaintext. Ciphertext is persisted in DataStore Preferences
+ * under per-provider preference keys (Gemini in one slot, OpenAI in another).
  *
  * EncryptedSharedPreferences is deprecated as of androidx.security:security-crypto
  * 1.1.0-alpha07 — Tink + DataStore is its modern replacement.
@@ -34,39 +35,67 @@ import java.util.Base64
  * the stored value. This handles the Keystore master key rotating (factory reset,
  * device-to-device transfer that doesn't preserve hardware-backed keys, etc.) by asking
  * the user to re-enter their key, rather than looping on a corrupt ciphertext.
+ *
+ * `SecureKeyStore` itself implements [KeyProvider] for backwards compatibility — `get()`
+ * returns the Gemini key, since that's the historical contract used by `DirectGeminiClient`
+ * and `GeminiTtsClient`. The OpenAI key is exposed through [openAiKeyProvider].
  */
 class SecureKeyStore(
     private val aead: Aead,
     private val dataStore: DataStore<Preferences>,
 ) : KeyProvider {
 
-    override suspend fun get(): String {
-        val ciphertextB64 = dataStore.data.map { it[GEMINI_KEY] }.first()
+    override suspend fun get(): String = read(GEMINI_PREF_KEY, GEMINI_AAD)
+
+    suspend fun set(key: String) = write(GEMINI_PREF_KEY, GEMINI_AAD, key)
+
+    suspend fun clear() = remove(GEMINI_PREF_KEY)
+
+    suspend fun getOpenAi(): String = read(OPENAI_PREF_KEY, OPENAI_AAD)
+
+    suspend fun setOpenAi(key: String) = write(OPENAI_PREF_KEY, OPENAI_AAD, key)
+
+    suspend fun clearOpenAi() = remove(OPENAI_PREF_KEY)
+
+    /**
+     * KeyProvider view onto the OpenAI key. Used to wire `OpenAITtsClient` while
+     * keeping the underlying SecureKeyStore as the single source of truth for
+     * encrypted on-device storage.
+     */
+    val openAiKeyProvider: KeyProvider = object : KeyProvider {
+        override suspend fun get(): String = getOpenAi()
+    }
+
+    private suspend fun read(prefKey: Preferences.Key<String>, aad: ByteArray): String {
+        val ciphertextB64 = dataStore.data.map { it[prefKey] }.first()
             ?: throw MissingApiKeyException()
         return try {
             val ciphertext = Base64.getDecoder().decode(ciphertextB64)
-            aead.decrypt(ciphertext, AAD).toString(Charsets.UTF_8)
+            aead.decrypt(ciphertext, aad).toString(Charsets.UTF_8)
         } catch (_: Exception) {
             // Corrupt ciphertext or unrecoverable Keystore state — drop the bad value so
             // the next attempt prompts the user to re-enter their key cleanly.
-            clear()
+            remove(prefKey)
             throw MissingApiKeyException()
         }
     }
 
-    suspend fun set(key: String) {
-        val ciphertext = aead.encrypt(key.toByteArray(Charsets.UTF_8), AAD)
+    private suspend fun write(prefKey: Preferences.Key<String>, aad: ByteArray, key: String) {
+        val ciphertext = aead.encrypt(key.toByteArray(Charsets.UTF_8), aad)
         val ciphertextB64 = Base64.getEncoder().encodeToString(ciphertext)
-        dataStore.edit { it[GEMINI_KEY] = ciphertextB64 }
+        dataStore.edit { it[prefKey] = ciphertextB64 }
     }
 
-    suspend fun clear() {
-        dataStore.edit { it.remove(GEMINI_KEY) }
+    private suspend fun remove(prefKey: Preferences.Key<String>) {
+        dataStore.edit { it.remove(prefKey) }
     }
 
     companion object {
-        private val GEMINI_KEY = stringPreferencesKey("gemini_api_key_v1")
-        private val AAD = "adaptweather:gemini_api_key:v1".toByteArray(Charsets.UTF_8)
+        private val GEMINI_PREF_KEY = stringPreferencesKey("gemini_api_key_v1")
+        private val GEMINI_AAD = "adaptweather:gemini_api_key:v1".toByteArray(Charsets.UTF_8)
+
+        private val OPENAI_PREF_KEY = stringPreferencesKey("openai_api_key_v1")
+        private val OPENAI_AAD = "adaptweather:openai_api_key:v1".toByteArray(Charsets.UTF_8)
 
         private const val MASTER_KEY_URI = "android-keystore://adaptweather_master_key"
         private const val KEYSET_PREFS = "adaptweather_master_prefs"

--- a/app/src/main/kotlin/com/adaptweather/data/SettingsRepository.kt
+++ b/app/src/main/kotlin/com/adaptweather/data/SettingsRepository.kt
@@ -93,6 +93,14 @@ class SettingsRepository(
         dataStore.edit { it[TTS_ENGINE] = engine.name }
     }
 
+    suspend fun setGeminiVoice(voice: String) {
+        dataStore.edit { it[GEMINI_VOICE] = voice }
+    }
+
+    suspend fun setOpenAiVoice(voice: String) {
+        dataStore.edit { it[OPENAI_VOICE] = voice }
+    }
+
     private fun Preferences.toUserPreferences(): UserPreferences {
         val time = this[SCHEDULE_TIME]?.let { LocalTime.parse(it, TIME_FORMAT) }
             ?: DEFAULT_TIME
@@ -111,6 +119,10 @@ class SettingsRepository(
         val useDeviceLocation = this[USE_DEVICE_LOCATION] == true
         val ttsEngine = this[TTS_ENGINE]?.let { runCatching { TtsEngine.valueOf(it) }.getOrNull() }
             ?: TtsEngine.DEVICE
+        val geminiVoice = this[GEMINI_VOICE]?.takeIf { it.isNotBlank() }
+            ?: UserPreferences.DEFAULT_GEMINI_VOICE
+        val openAiVoice = this[OPENAI_VOICE]?.takeIf { it.isNotBlank() }
+            ?: UserPreferences.DEFAULT_OPENAI_VOICE
 
         return UserPreferences(
             schedule = Schedule(time = time, days = days, zoneId = zoneIdProvider()),
@@ -121,6 +133,8 @@ class SettingsRepository(
             location = location,
             useDeviceLocation = useDeviceLocation,
             ttsEngine = ttsEngine,
+            geminiVoice = geminiVoice,
+            openAiVoice = openAiVoice,
         )
     }
 
@@ -155,6 +169,8 @@ class SettingsRepository(
         private val LOCATION_NAME = stringPreferencesKey("location_display_name")
         private val USE_DEVICE_LOCATION = booleanPreferencesKey("use_device_location")
         private val TTS_ENGINE = stringPreferencesKey("tts_engine")
+        private val GEMINI_VOICE = stringPreferencesKey("gemini_voice")
+        private val OPENAI_VOICE = stringPreferencesKey("openai_voice")
 
         private val TIME_FORMAT: DateTimeFormatter = DateTimeFormatter.ofPattern("HH:mm")
         private val DEFAULT_TIME: LocalTime = LocalTime.of(7, 0)

--- a/app/src/main/kotlin/com/adaptweather/tts/GeminiTtsSpeaker.kt
+++ b/app/src/main/kotlin/com/adaptweather/tts/GeminiTtsSpeaker.kt
@@ -1,93 +1,26 @@
 package com.adaptweather.tts
 
-import android.media.AudioAttributes
-import android.media.AudioFormat
-import android.media.AudioTrack
-import android.util.Log
+import com.adaptweather.core.data.tts.DEFAULT_GEMINI_TTS_VOICE
 import com.adaptweather.core.data.tts.GeminiTtsClient
-import com.adaptweather.core.data.tts.PcmAudio
-import kotlinx.coroutines.suspendCancellableCoroutine
 import java.util.Locale
-import kotlin.coroutines.resume
 
 /**
  * High-quality TTS via Gemini's audio-output model. Synthesises PCM audio in one
- * network call and plays it back through [AudioTrack] in MODE_STATIC, which lets
- * us hand the entire buffer at once and listen for the playback-head reaching the
- * end. Cleaner than streaming from a short utterance.
+ * network call, hands the buffer to [PcmAudioPlayer] for playback.
+ *
+ * Voice is configurable; defaults to `Kore` (firm). Other prebuilt voices are
+ * surfaced via the Settings voice picker.
  *
  * Fallback is the caller's responsibility — see [com.adaptweather.work.FetchAndNotifyWorker]
  * which retries with [AndroidTtsSpeaker] when this throws.
  */
 class GeminiTtsSpeaker(
     private val client: GeminiTtsClient,
-    private val voiceName: String? = null,
+    private val voiceName: String = DEFAULT_GEMINI_TTS_VOICE,
 ) : TtsSpeaker {
 
     override suspend fun speak(text: String, locale: Locale) {
-        val audio = client.synthesize(
-            text = text,
-            voiceName = voiceName ?: com.adaptweather.core.data.tts.DEFAULT_GEMINI_TTS_VOICE,
-        )
-        play(audio)
-    }
-
-    private suspend fun play(audio: PcmAudio) {
-        val pcm = audio.bytes
-        if (pcm.isEmpty()) return
-
-        val track = AudioTrack.Builder()
-            .setAudioAttributes(
-                AudioAttributes.Builder()
-                    .setUsage(AudioAttributes.USAGE_NOTIFICATION)
-                    .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
-                    .build(),
-            )
-            .setAudioFormat(
-                AudioFormat.Builder()
-                    .setEncoding(AudioFormat.ENCODING_PCM_16BIT)
-                    .setSampleRate(audio.sampleRate)
-                    .setChannelMask(AudioFormat.CHANNEL_OUT_MONO)
-                    .build(),
-            )
-            .setBufferSizeInBytes(pcm.size)
-            .setTransferMode(AudioTrack.MODE_STATIC)
-            .build()
-
-        try {
-            // MODE_STATIC accepts the whole buffer in one write before play().
-            val written = track.write(pcm, 0, pcm.size)
-            if (written < 0) {
-                Log.w(TAG, "AudioTrack.write rejected the buffer (code=$written)")
-                return
-            }
-            // 2 bytes per 16-bit sample, mono.
-            val totalFrames = pcm.size / 2
-            track.notificationMarkerPosition = totalFrames
-            awaitMarker(track, totalFrames)
-        } finally {
-            runCatching { track.stop() }
-            track.release()
-        }
-    }
-
-    private suspend fun awaitMarker(track: AudioTrack, markerInFrames: Int) {
-        suspendCancellableCoroutine<Unit> { cont ->
-            track.setPlaybackPositionUpdateListener(
-                object : AudioTrack.OnPlaybackPositionUpdateListener {
-                    override fun onMarkerReached(t: AudioTrack?) {
-                        if (cont.isActive) cont.resume(Unit)
-                    }
-                    override fun onPeriodicNotification(t: AudioTrack?) {}
-                },
-            )
-            track.play()
-            cont.invokeOnCancellation { runCatching { track.stop() } }
-        }
-        Log.i(TAG, "Played ${markerInFrames} PCM frames")
-    }
-
-    companion object {
-        private const val TAG = "GeminiTtsSpeaker"
+        val audio = client.synthesize(text = text, voiceName = voiceName)
+        PcmAudioPlayer.play(audio)
     }
 }

--- a/app/src/main/kotlin/com/adaptweather/tts/OpenAITtsSpeaker.kt
+++ b/app/src/main/kotlin/com/adaptweather/tts/OpenAITtsSpeaker.kt
@@ -1,0 +1,26 @@
+package com.adaptweather.tts
+
+import com.adaptweather.core.data.tts.DEFAULT_OPENAI_TTS_VOICE
+import com.adaptweather.core.data.tts.OpenAITtsClient
+import java.util.Locale
+
+/**
+ * TTS via OpenAI's `audio/speech` endpoint. Synthesises PCM audio in one network
+ * call, hands the buffer to [PcmAudioPlayer] for playback.
+ *
+ * Voice is one of the OpenAI stock voices (alloy, echo, fable, onyx, nova,
+ * shimmer); selectable from Settings.
+ *
+ * Fallback is the caller's responsibility — see [com.adaptweather.work.FetchAndNotifyWorker]
+ * which retries with [AndroidTtsSpeaker] when this throws.
+ */
+class OpenAITtsSpeaker(
+    private val client: OpenAITtsClient,
+    private val voice: String = DEFAULT_OPENAI_TTS_VOICE,
+) : TtsSpeaker {
+
+    override suspend fun speak(text: String, locale: Locale) {
+        val audio = client.synthesize(text = text, voice = voice)
+        PcmAudioPlayer.play(audio)
+    }
+}

--- a/app/src/main/kotlin/com/adaptweather/tts/PcmAudioPlayer.kt
+++ b/app/src/main/kotlin/com/adaptweather/tts/PcmAudioPlayer.kt
@@ -1,0 +1,76 @@
+package com.adaptweather.tts
+
+import android.media.AudioAttributes
+import android.media.AudioFormat
+import android.media.AudioTrack
+import android.util.Log
+import com.adaptweather.core.data.tts.PcmAudio
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
+
+/**
+ * Plays a chunk of 16-bit signed mono PCM through [AudioTrack] in `MODE_STATIC`,
+ * suspending until the playback head reaches the end of the buffer.
+ *
+ * Shared by [GeminiTtsSpeaker] and [OpenAITtsSpeaker] — both providers return PCM
+ * with the same encoding, only the sample rate differs (Gemini reports it in the
+ * response mimeType; OpenAI fixes it at 24 kHz).
+ */
+internal object PcmAudioPlayer {
+
+    private const val TAG = "PcmAudioPlayer"
+
+    suspend fun play(audio: PcmAudio) {
+        val pcm = audio.bytes
+        if (pcm.isEmpty()) return
+
+        val track = AudioTrack.Builder()
+            .setAudioAttributes(
+                AudioAttributes.Builder()
+                    .setUsage(AudioAttributes.USAGE_NOTIFICATION)
+                    .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
+                    .build(),
+            )
+            .setAudioFormat(
+                AudioFormat.Builder()
+                    .setEncoding(AudioFormat.ENCODING_PCM_16BIT)
+                    .setSampleRate(audio.sampleRate)
+                    .setChannelMask(AudioFormat.CHANNEL_OUT_MONO)
+                    .build(),
+            )
+            .setBufferSizeInBytes(pcm.size)
+            .setTransferMode(AudioTrack.MODE_STATIC)
+            .build()
+
+        try {
+            val written = track.write(pcm, 0, pcm.size)
+            if (written < 0) {
+                Log.w(TAG, "AudioTrack.write rejected the buffer (code=$written)")
+                return
+            }
+            // 2 bytes per 16-bit sample, mono.
+            val totalFrames = pcm.size / 2
+            track.notificationMarkerPosition = totalFrames
+            awaitMarker(track, totalFrames)
+        } finally {
+            runCatching { track.stop() }
+            track.release()
+        }
+    }
+
+    private suspend fun awaitMarker(track: AudioTrack, markerInFrames: Int) {
+        suspendCancellableCoroutine<Unit> { cont ->
+            track.setPlaybackPositionUpdateListener(
+                object : AudioTrack.OnPlaybackPositionUpdateListener {
+                    override fun onMarkerReached(t: AudioTrack?) {
+                        if (cont.isActive) cont.resume(Unit)
+                    }
+                    override fun onPeriodicNotification(t: AudioTrack?) {}
+                },
+            )
+            track.play()
+            cont.invokeOnCancellation { runCatching { track.stop() } }
+        }
+        Log.i(TAG, "Played $markerInFrames PCM frames")
+    }
+}

--- a/app/src/main/kotlin/com/adaptweather/tts/TtsVoices.kt
+++ b/app/src/main/kotlin/com/adaptweather/tts/TtsVoices.kt
@@ -1,0 +1,32 @@
+package com.adaptweather.tts
+
+/**
+ * Curated voice lists for the user-facing voice picker. Each provider has many more
+ * options than this — these are the ones surfaced in Settings to keep the picker
+ * scannable.
+ *
+ * The [id] is what's persisted and sent to the API. The [displayName] is shown in the
+ * dropdown and is intentionally English-only for v1; if/when we localize, these move
+ * to strings.xml.
+ */
+data class TtsVoiceOption(val id: String, val displayName: String)
+
+val GEMINI_VOICES: List<TtsVoiceOption> = listOf(
+    TtsVoiceOption("Kore", "Kore — Firm"),
+    TtsVoiceOption("Charon", "Charon — Informative"),
+    TtsVoiceOption("Puck", "Puck — Upbeat"),
+    TtsVoiceOption("Zephyr", "Zephyr — Bright"),
+    TtsVoiceOption("Leda", "Leda — Youthful"),
+    TtsVoiceOption("Aoede", "Aoede — Breezy"),
+    TtsVoiceOption("Fenrir", "Fenrir — Excitable"),
+    TtsVoiceOption("Sadaltager", "Sadaltager — Knowledgeable"),
+)
+
+val OPENAI_VOICES: List<TtsVoiceOption> = listOf(
+    TtsVoiceOption("alloy", "alloy — Neutral"),
+    TtsVoiceOption("echo", "echo — Soft, male"),
+    TtsVoiceOption("fable", "fable — Storyteller"),
+    TtsVoiceOption("onyx", "onyx — Deep, male"),
+    TtsVoiceOption("nova", "nova — Bright, female"),
+    TtsVoiceOption("shimmer", "shimmer — Warm, female"),
+)

--- a/app/src/main/kotlin/com/adaptweather/ui/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/adaptweather/ui/settings/SettingsScreen.kt
@@ -57,7 +57,15 @@ import com.adaptweather.core.domain.model.Location
 import com.adaptweather.core.domain.model.TemperatureUnit
 import com.adaptweather.core.domain.model.TtsEngine
 import com.adaptweather.core.domain.model.WardrobeRule
+import com.adaptweather.tts.GEMINI_VOICES
+import com.adaptweather.tts.GeminiTtsSpeaker
+import com.adaptweather.tts.OPENAI_VOICES
+import com.adaptweather.tts.OpenAITtsSpeaker
+import com.adaptweather.tts.TtsVoiceOption
 import com.adaptweather.work.FetchAndNotifyWorker
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import java.time.DayOfWeek
 import java.time.LocalTime
@@ -102,6 +110,10 @@ fun SettingsScreen(viewModel: SettingsViewModel, onNavigateBack: () -> Unit) {
             onSearchLocations = viewModel::searchLocations,
             onSetUseDeviceLocation = viewModel::setUseDeviceLocation,
             onSetTtsEngine = viewModel::setTtsEngine,
+            onSetGeminiVoice = viewModel::setGeminiVoice,
+            onSetOpenAiVoice = viewModel::setOpenAiVoice,
+            onSetOpenAiKey = viewModel::setOpenAiKey,
+            onClearOpenAiKey = viewModel::clearOpenAiKey,
         )
     }
 }
@@ -124,6 +136,10 @@ private fun SettingsContent(
     onSearchLocations: suspend (String) -> List<Location>,
     onSetUseDeviceLocation: (Boolean) -> Unit,
     onSetTtsEngine: (TtsEngine) -> Unit,
+    onSetGeminiVoice: (String) -> Unit,
+    onSetOpenAiVoice: (String) -> Unit,
+    onSetOpenAiKey: (String) -> Unit,
+    onClearOpenAiKey: () -> Unit,
 ) {
     Column(
         modifier = Modifier
@@ -153,7 +169,17 @@ private fun SettingsContent(
             onChange = onSetSchedule,
         )
         DeliveryModeCard(state.deliveryMode, onSetDeliveryMode)
-        TtsEngineCard(state.ttsEngine, onSetTtsEngine)
+        TtsEngineCard(
+            selected = state.ttsEngine,
+            onSelect = onSetTtsEngine,
+            geminiVoice = state.geminiVoice,
+            onGeminiVoice = onSetGeminiVoice,
+            openAiVoice = state.openAiVoice,
+            onOpenAiVoice = onSetOpenAiVoice,
+            openAiKeyConfigured = state.openAiKeyConfigured,
+            onSetOpenAiKey = onSetOpenAiKey,
+            onClearOpenAiKey = onClearOpenAiKey,
+        )
         TemperatureUnitCard(state.temperatureUnit, onSetTemperatureUnit)
         DistanceUnitCard(state.distanceUnit, onSetDistanceUnit)
         WardrobeRulesCard(
@@ -833,7 +859,28 @@ private fun DeliveryModeCard(
 private fun TtsEngineCard(
     selected: TtsEngine,
     onSelect: (TtsEngine) -> Unit,
+    geminiVoice: String,
+    onGeminiVoice: (String) -> Unit,
+    openAiVoice: String,
+    onOpenAiVoice: (String) -> Unit,
+    openAiKeyConfigured: Boolean,
+    onSetOpenAiKey: (String) -> Unit,
+    onClearOpenAiKey: () -> Unit,
 ) {
+    val context = LocalContext.current
+    val coroutineScope = rememberCoroutineScope()
+    // Ongoing preview job is held in remember-state so each new selection cancels
+    // the previous before starting a new one. Otherwise rapid taps would queue up
+    // overlapping playbacks.
+    var previewJob by remember { mutableStateOf<Job?>(null) }
+
+    fun preview(engine: TtsEngine, gVoice: String, oVoice: String) {
+        previewJob?.cancel()
+        previewJob = coroutineScope.launch {
+            runTtsPreview(context, engine, gVoice, oVoice)
+        }
+    }
+
     SectionCard(title = stringResource(R.string.settings_tts_engine_title)) {
         Text(
             text = stringResource(R.string.settings_tts_engine_description),
@@ -844,47 +891,179 @@ private fun TtsEngineCard(
             RadioRow(
                 label = stringResource(ttsEngineLabel(engine)),
                 selected = engine == selected,
-                onSelect = { onSelect(engine) },
+                onSelect = {
+                    onSelect(engine)
+                    preview(engine, geminiVoice, openAiVoice)
+                },
             )
         }
-        if (selected == TtsEngine.GEMINI) {
-            TestGeminiVoiceButton()
+        when (selected) {
+            TtsEngine.GEMINI -> {
+                VoicePicker(
+                    title = stringResource(R.string.settings_tts_voice_label),
+                    voices = GEMINI_VOICES,
+                    selectedId = geminiVoice,
+                    onSelect = {
+                        onGeminiVoice(it)
+                        preview(TtsEngine.GEMINI, it, openAiVoice)
+                    },
+                )
+                TestVoiceButton { preview(selected, geminiVoice, openAiVoice) }
+            }
+            TtsEngine.OPENAI -> {
+                KeyEntryFields(
+                    configured = openAiKeyConfigured,
+                    statusText = stringResource(
+                        if (openAiKeyConfigured) R.string.settings_openai_key_status_set
+                        else R.string.settings_openai_key_status_unset,
+                    ),
+                    placeholder = stringResource(R.string.settings_openai_key_placeholder),
+                    saveLabel = stringResource(R.string.settings_openai_key_save),
+                    clearLabel = stringResource(R.string.settings_openai_key_clear),
+                    onSave = onSetOpenAiKey,
+                    onClear = onClearOpenAiKey,
+                )
+                VoicePicker(
+                    title = stringResource(R.string.settings_tts_voice_label),
+                    voices = OPENAI_VOICES,
+                    selectedId = openAiVoice,
+                    onSelect = {
+                        onOpenAiVoice(it)
+                        preview(TtsEngine.OPENAI, geminiVoice, it)
+                    },
+                )
+                TestVoiceButton { preview(selected, geminiVoice, openAiVoice) }
+            }
+            TtsEngine.DEVICE -> Unit
         }
     }
 }
 
 @Composable
-private fun TestGeminiVoiceButton() {
-    val context = LocalContext.current
-    val coroutineScope = rememberCoroutineScope()
-    var inFlight by remember { mutableStateOf(false) }
-    Button(
-        enabled = !inFlight,
-        onClick = {
-            coroutineScope.launch {
-                inFlight = true
-                val app = context.applicationContext as com.adaptweather.AdaptWeatherApplication
-                try {
-                    app.geminiTtsSpeaker.speak(
-                        context.getString(R.string.settings_tts_test_sample),
-                    )
-                } catch (t: Throwable) {
-                    val message = "${t.javaClass.simpleName}: ${t.message ?: "(no detail)"}"
-                    android.util.Log.w("SettingsScreen", "Gemini TTS test failed", t)
-                    android.widget.Toast.makeText(context, message, android.widget.Toast.LENGTH_LONG).show()
-                } finally {
-                    inFlight = false
-                }
-            }
-        },
+private fun VoicePicker(
+    title: String,
+    voices: List<TtsVoiceOption>,
+    selectedId: String,
+    onSelect: (String) -> Unit,
+) {
+    var dialogOpen by remember { mutableStateOf(false) }
+    val current = voices.firstOrNull { it.id == selectedId }
+    OutlinedButton(
+        onClick = { dialogOpen = true },
         modifier = Modifier.fillMaxWidth(),
     ) {
-        Text(
-            stringResource(
-                if (inFlight) R.string.settings_tts_test_in_flight
-                else R.string.settings_tts_test,
-            ),
+        Text("$title: ${current?.displayName ?: selectedId}")
+    }
+    if (dialogOpen) {
+        AlertDialog(
+            onDismissRequest = { dialogOpen = false },
+            title = { Text(title) },
+            text = {
+                Column {
+                    voices.forEach { option ->
+                        RadioRow(
+                            label = option.displayName,
+                            selected = option.id == selectedId,
+                            onSelect = {
+                                onSelect(option.id)
+                                dialogOpen = false
+                            },
+                        )
+                    }
+                }
+            },
+            confirmButton = {
+                TextButton(onClick = { dialogOpen = false }) {
+                    Text(stringResource(R.string.settings_tts_voice_dismiss))
+                }
+            },
         )
+    }
+}
+
+@Composable
+private fun TestVoiceButton(onClick: () -> Unit) {
+    Button(
+        onClick = onClick,
+        modifier = Modifier.fillMaxWidth(),
+    ) { Text(stringResource(R.string.settings_tts_test)) }
+}
+
+/**
+ * Plays a preview through the chosen engine + voice. Source text is the latest
+ * cached insight if there is one (so the user hears what the actual morning
+ * delivery would sound like), otherwise a short fixed sample.
+ *
+ * Errors are surfaced as a Toast so the user can see *why* the voice failed
+ * (most often: missing or wrong API key for the chosen provider).
+ */
+private suspend fun runTtsPreview(
+    context: android.content.Context,
+    engine: TtsEngine,
+    geminiVoice: String,
+    openAiVoice: String,
+) {
+    val app = context.applicationContext as com.adaptweather.AdaptWeatherApplication
+    try {
+        val text = app.insightCache.latest.first()?.spokenText()
+            ?: context.getString(R.string.settings_tts_test_sample)
+        when (engine) {
+            TtsEngine.GEMINI ->
+                GeminiTtsSpeaker(app.geminiTtsClient, voiceName = geminiVoice).speak(text)
+            TtsEngine.OPENAI ->
+                OpenAITtsSpeaker(app.openAiTtsClient, voice = openAiVoice).speak(text)
+            TtsEngine.DEVICE ->
+                app.deviceTtsSpeaker.speak(text)
+        }
+    } catch (_: CancellationException) {
+        // Expected when the user picks a different option mid-playback; not an error.
+    } catch (t: Throwable) {
+        val message = "${t.javaClass.simpleName}: ${t.message ?: "(no detail)"}"
+        android.util.Log.w("SettingsScreen", "TTS preview failed for $engine", t)
+        android.widget.Toast.makeText(context, message, android.widget.Toast.LENGTH_LONG).show()
+    }
+}
+
+@Composable
+private fun KeyEntryFields(
+    configured: Boolean,
+    statusText: String,
+    placeholder: String,
+    saveLabel: String,
+    clearLabel: String,
+    onSave: (String) -> Unit,
+    onClear: () -> Unit,
+) {
+    Text(text = statusText, style = MaterialTheme.typography.bodyMedium)
+
+    var input by remember { mutableStateOf("") }
+    OutlinedTextField(
+        value = input,
+        onValueChange = { input = it },
+        singleLine = true,
+        visualTransformation = if (input.isEmpty()) VisualTransformation.None else PasswordVisualTransformation(),
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+        placeholder = { Text(placeholder) },
+        modifier = Modifier.fillMaxWidth(),
+    )
+
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        Button(
+            onClick = {
+                if (input.isNotBlank()) {
+                    onSave(input)
+                    input = ""
+                }
+            },
+            enabled = input.isNotBlank(),
+            modifier = Modifier.fillMaxWidth(),
+        ) { Text(saveLabel) }
+
+        if (configured) {
+            TextButton(onClick = onClear, modifier = Modifier.fillMaxWidth()) {
+                Text(clearLabel)
+            }
+        }
     }
 }
 
@@ -946,6 +1125,7 @@ private fun deliveryModeLabel(mode: DeliveryMode): Int = when (mode) {
 private fun ttsEngineLabel(engine: TtsEngine): Int = when (engine) {
     TtsEngine.DEVICE -> R.string.settings_tts_engine_device
     TtsEngine.GEMINI -> R.string.settings_tts_engine_gemini
+    TtsEngine.OPENAI -> R.string.settings_tts_engine_openai
 }
 
 private fun temperatureUnitLabel(unit: TemperatureUnit): Int = when (unit) {

--- a/app/src/main/kotlin/com/adaptweather/ui/settings/SettingsState.kt
+++ b/app/src/main/kotlin/com/adaptweather/ui/settings/SettingsState.kt
@@ -6,6 +6,7 @@ import com.adaptweather.core.domain.model.Location
 import com.adaptweather.core.domain.model.Schedule
 import com.adaptweather.core.domain.model.TemperatureUnit
 import com.adaptweather.core.domain.model.TtsEngine
+import com.adaptweather.core.domain.model.UserPreferences
 import com.adaptweather.core.domain.model.WardrobeRule
 import java.time.DayOfWeek
 import java.time.LocalTime
@@ -21,5 +22,8 @@ data class SettingsState(
     val location: Location? = null,
     val useDeviceLocation: Boolean = false,
     val ttsEngine: TtsEngine = TtsEngine.DEVICE,
+    val geminiVoice: String = UserPreferences.DEFAULT_GEMINI_VOICE,
+    val openAiVoice: String = UserPreferences.DEFAULT_OPENAI_VOICE,
     val apiKeyConfigured: Boolean = false,
+    val openAiKeyConfigured: Boolean = false,
 )

--- a/app/src/main/kotlin/com/adaptweather/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/adaptweather/ui/settings/SettingsViewModel.kt
@@ -46,6 +46,8 @@ class SettingsViewModel(
                         location = prefs.location,
                         useDeviceLocation = prefs.useDeviceLocation,
                         ttsEngine = prefs.ttsEngine,
+                        geminiVoice = prefs.geminiVoice,
+                        openAiVoice = prefs.openAiVoice,
                     )
                 }
             }
@@ -65,6 +67,28 @@ class SettingsViewModel(
             keyStore.clear()
             refreshApiKeyStatus()
         }
+    }
+
+    fun setOpenAiKey(key: String) {
+        viewModelScope.launch {
+            keyStore.setOpenAi(key.trim())
+            refreshApiKeyStatus()
+        }
+    }
+
+    fun clearOpenAiKey() {
+        viewModelScope.launch {
+            keyStore.clearOpenAi()
+            refreshApiKeyStatus()
+        }
+    }
+
+    fun setGeminiVoice(voice: String) {
+        viewModelScope.launch { settingsRepository.setGeminiVoice(voice) }
+    }
+
+    fun setOpenAiVoice(voice: String) {
+        viewModelScope.launch { settingsRepository.setOpenAiVoice(voice) }
     }
 
     fun setDeliveryMode(mode: DeliveryMode) {
@@ -133,8 +157,9 @@ class SettingsViewModel(
     }
 
     private suspend fun refreshApiKeyStatus() {
-        val configured = runCatching { keyStore.get().isNotBlank() }.getOrDefault(false)
-        _state.update { it.copy(apiKeyConfigured = configured) }
+        val gemini = runCatching { keyStore.get().isNotBlank() }.getOrDefault(false)
+        val openAi = runCatching { keyStore.getOpenAi().isNotBlank() }.getOrDefault(false)
+        _state.update { it.copy(apiKeyConfigured = gemini, openAiKeyConfigured = openAi) }
     }
 
     class Factory(

--- a/app/src/main/kotlin/com/adaptweather/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/com/adaptweather/work/FetchAndNotifyWorker.kt
@@ -20,6 +20,8 @@ import com.adaptweather.core.domain.model.Insight
 import com.adaptweather.core.domain.model.Location
 import com.adaptweather.core.domain.model.TtsEngine
 import com.adaptweather.core.domain.model.UserPreferences
+import com.adaptweather.tts.GeminiTtsSpeaker
+import com.adaptweather.tts.OpenAITtsSpeaker
 import io.ktor.client.network.sockets.ConnectTimeoutException
 import io.ktor.client.network.sockets.SocketTimeoutException
 import io.ktor.client.plugins.HttpRequestTimeoutException
@@ -157,46 +159,41 @@ class FetchAndNotifyWorker(
             app.insightNotifier.notify(insight)
         }
         if (mode == DeliveryMode.TTS_ONLY || mode == DeliveryMode.NOTIFICATION_AND_TTS) {
-            speakWithFallback(insight.spokenText(), prefs.ttsEngine)
+            speakWithFallback(insight.spokenText(), prefs)
         }
     }
 
     /**
-     * Speaks via the user-preferred engine; on Gemini failure (network, quota, missing
-     * key) falls back to the on-device engine so the user still hears something. We
-     * never let a TTS error fail the worker — the notification path is the primary
-     * delivery channel and has already fired by this point.
+     * Speaks via the user-preferred engine; on Gemini / OpenAI failure (network,
+     * quota, missing key) falls back to the on-device engine so the user still
+     * hears something. We never let a TTS error fail the worker — the notification
+     * path is the primary delivery channel and has already fired by this point.
      */
-    private suspend fun speakWithFallback(text: String, engine: TtsEngine) {
-        if (engine == TtsEngine.GEMINI) {
-            try {
-                app.geminiTtsSpeaker.speak(text)
-                return
-            } catch (t: Throwable) {
-                Log.w(TAG, "Gemini TTS failed; falling back to device TTS.", t)
+    private suspend fun speakWithFallback(text: String, prefs: UserPreferences) {
+        when (prefs.ttsEngine) {
+            TtsEngine.GEMINI -> {
+                try {
+                    GeminiTtsSpeaker(app.geminiTtsClient, voiceName = prefs.geminiVoice).speak(text)
+                    return
+                } catch (t: Throwable) {
+                    Log.w(TAG, "Gemini TTS failed; falling back to device TTS.", t)
+                }
             }
+            TtsEngine.OPENAI -> {
+                try {
+                    OpenAITtsSpeaker(app.openAiTtsClient, voice = prefs.openAiVoice).speak(text)
+                    return
+                } catch (t: Throwable) {
+                    Log.w(TAG, "OpenAI TTS failed; falling back to device TTS.", t)
+                }
+            }
+            TtsEngine.DEVICE -> Unit
         }
         try {
             app.deviceTtsSpeaker.speak(text)
         } catch (t: Throwable) {
             Log.w(TAG, "Device TTS failed; insight is still posted as notification.", t)
         }
-    }
-
-    /**
-     * The text that gets spoken aloud. The LLM is told to weave the items into its
-     * sentence but it's not guaranteed; appending them explicitly ensures the user
-     * always hears what their wardrobe rules suggest, even if the summary skips them.
-     */
-    private fun Insight.spokenText(): String {
-        if (recommendedItems.isEmpty()) return summary
-        val joined = when (recommendedItems.size) {
-            1 -> recommendedItems[0]
-            2 -> "${recommendedItems[0]} and ${recommendedItems[1]}"
-            else -> recommendedItems.dropLast(1).joinToString(", ") + ", and " + recommendedItems.last()
-        }
-        val separator = if (summary.endsWith(".") || summary.endsWith("!") || summary.endsWith("?")) " " else ". "
-        return "$summary${separator}Recommended: $joined."
     }
 
     companion object {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -55,12 +55,21 @@
     <string name="settings_delivery_notification_and_tts">Notification and spoken aloud</string>
 
     <string name="settings_tts_engine_title">Voice engine</string>
-    <string name="settings_tts_engine_description">Gemini\'s voice is much more natural but needs a network call and uses your Gemini API key for synthesis (one short call per spoken insight). Falls back to the device voice if it fails.</string>
+    <string name="settings_tts_engine_description">Online engines (Gemini, OpenAI) sound much more natural but need a network call at speak-time and use your API key for synthesis (one short call per spoken insight). Falls back to the device voice if the chosen engine fails.</string>
     <string name="settings_tts_engine_device">Device (offline, free)</string>
     <string name="settings_tts_engine_gemini">Gemini (high quality, online)</string>
-    <string name="settings_tts_test">Test Gemini voice</string>
+    <string name="settings_tts_engine_openai">OpenAI (high quality, online)</string>
+    <string name="settings_tts_voice_label">Voice</string>
+    <string name="settings_tts_voice_dismiss">Done</string>
+    <string name="settings_tts_test">Test voice</string>
     <string name="settings_tts_test_in_flight">Testing — please wait…</string>
-    <string name="settings_tts_test_sample">Hello — this is the Gemini text to speech voice.</string>
+    <string name="settings_tts_test_sample">Hello — this is the AdaptWeather voice preview.</string>
+
+    <string name="settings_openai_key_status_set">An OpenAI key is configured. The key is encrypted at rest using the Android Keystore.</string>
+    <string name="settings_openai_key_status_unset">No OpenAI key configured. Get one at platform.openai.com to use OpenAI voices.</string>
+    <string name="settings_openai_key_placeholder">Paste your OpenAI API key</string>
+    <string name="settings_openai_key_save">Save OpenAI key</string>
+    <string name="settings_openai_key_clear">Clear stored OpenAI key</string>
 
     <string name="settings_temperature_unit_title">Temperature unit</string>
     <string name="settings_temperature_unit_celsius">Celsius (°C)</string>

--- a/app/src/test/kotlin/com/adaptweather/data/SecureKeyStoreTest.kt
+++ b/app/src/test/kotlin/com/adaptweather/data/SecureKeyStoreTest.kt
@@ -104,9 +104,35 @@ class SecureKeyStoreTest {
         dataStore.data.first()[GEMINI_KEY_PREFERENCE] shouldBe null
     }
 
+    @Test
+    fun `setOpenAi then getOpenAi returns the same key, and is independent of Gemini`() = runTest {
+        subject.set("gemini-key")
+        subject.setOpenAi("sk-openai")
+
+        subject.get() shouldBe "gemini-key"
+        subject.getOpenAi() shouldBe "sk-openai"
+    }
+
+    @Test
+    fun `clearOpenAi removes the OpenAI key without affecting the Gemini key`() = runTest {
+        subject.set("gemini-key")
+        subject.setOpenAi("sk-openai")
+        subject.clearOpenAi()
+
+        subject.get() shouldBe "gemini-key"
+        shouldThrow<MissingApiKeyException> { subject.getOpenAi() }
+    }
+
+    @Test
+    fun `openAiKeyProvider is a live view onto the stored OpenAI key`() = runTest {
+        subject.setOpenAi("sk-from-provider")
+
+        subject.openAiKeyProvider.get() shouldBe "sk-from-provider"
+    }
+
     private companion object {
-        // Mirrors SecureKeyStore.GEMINI_KEY (private). Kept in sync deliberately so the
-        // test can assert against the on-disk preference name.
+        // Mirrors SecureKeyStore preference key names (private). Kept in sync deliberately
+        // so the test can assert against the on-disk preference name.
         val GEMINI_KEY_PREFERENCE = stringPreferencesKey("gemini_api_key_v1")
     }
 }

--- a/app/src/test/kotlin/com/adaptweather/data/SettingsRepositoryTest.kt
+++ b/app/src/test/kotlin/com/adaptweather/data/SettingsRepositoryTest.kt
@@ -154,6 +154,23 @@ class SettingsRepositoryTest {
     }
 
     @Test
+    fun `setGeminiVoice and setOpenAiVoice round-trip and are independent`() = runTest {
+        subject.setGeminiVoice("Puck")
+        subject.setOpenAiVoice("nova")
+
+        val prefs = subject.preferences.first()
+        prefs.geminiVoice shouldBe "Puck"
+        prefs.openAiVoice shouldBe "nova"
+    }
+
+    @Test
+    fun `voice prefs default to Kore and alloy when nothing stored`() = runTest {
+        val prefs = subject.preferences.first()
+        prefs.geminiVoice shouldBe "Kore"
+        prefs.openAiVoice shouldBe "alloy"
+    }
+
+    @Test
     fun `zoneId is resolved fresh on each emission`() = runTest {
         val zones = mutableListOf(ZoneId.of("UTC"), ZoneId.of("America/New_York"))
         val rotating = SettingsRepository(

--- a/core/data/src/main/kotlin/com/adaptweather/core/data/tts/OpenAITtsClient.kt
+++ b/core/data/src/main/kotlin/com/adaptweather/core/data/tts/OpenAITtsClient.kt
@@ -1,0 +1,95 @@
+package com.adaptweather.core.data.tts
+
+import com.adaptweather.core.data.insight.KeyProvider
+import com.adaptweather.core.data.insight.MissingApiKeyException
+import io.ktor.client.HttpClient
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsBytes
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.http.isSuccess
+
+const val DEFAULT_OPENAI_TTS_MODEL: String = "tts-1"
+const val DEFAULT_OPENAI_TTS_VOICE: String = "alloy"
+
+/**
+ * OpenAI text-to-speech via `https://api.openai.com/v1/audio/speech`.
+ *
+ * Asks for `response_format: "pcm"` so the response body is raw 16-bit signed
+ * little-endian mono PCM at 24 kHz — bit-compatible with Gemini's TTS output and
+ * with the same [PcmAudio] structure, so playback reuses the existing AudioTrack
+ * path on the app side.
+ *
+ * Auth is the user's OpenAI key as a `Bearer` token. Like the Gemini path the key
+ * never leaves the device.
+ */
+class OpenAITtsClient(
+    private val httpClient: HttpClient,
+    private val keyProvider: KeyProvider,
+    private val model: String = DEFAULT_OPENAI_TTS_MODEL,
+) {
+    suspend fun synthesize(
+        text: String,
+        voice: String = DEFAULT_OPENAI_TTS_VOICE,
+    ): PcmAudio {
+        val key = keyProvider.get().also {
+            if (it.isBlank()) throw MissingApiKeyException()
+        }
+
+        val response: HttpResponse = httpClient.post(SPEECH_URL) {
+            header("Authorization", "Bearer $key")
+            contentType(ContentType.Application.Json)
+            setBody(
+                OpenAISpeechRequest(
+                    model = model,
+                    input = text,
+                    voice = voice,
+                    responseFormat = "pcm",
+                ),
+            )
+        }
+
+        if (!response.status.isSuccess()) {
+            throw OpenAITtsHttpException(response.status, response.bodyAsBytes())
+        }
+
+        val pcm = response.bodyAsBytes()
+        if (pcm.isEmpty()) throw OpenAITtsEmptyResponseException()
+
+        return PcmAudio(bytes = pcm, sampleRate = OPENAI_PCM_SAMPLE_RATE_HZ)
+    }
+
+    companion object {
+        // OpenAI's PCM response format is documented as 24000 Hz, 16-bit signed
+        // little-endian, mono — fixed, not negotiable, and not reflected in any
+        // response header. Hard-coded here.
+        private const val OPENAI_PCM_SAMPLE_RATE_HZ = 24_000
+        private const val SPEECH_URL = "https://api.openai.com/v1/audio/speech"
+    }
+}
+
+class OpenAITtsEmptyResponseException :
+    IllegalStateException("OpenAI TTS returned no audio body")
+
+/**
+ * HTTP failure surfaced with a short body excerpt so the diagnostic Toast in
+ * Settings shows the actual reason (auth failure / quota / model unavailable).
+ */
+class OpenAITtsHttpException(val status: HttpStatusCode, body: ByteArray) :
+    IllegalStateException(buildMessage(status, body)) {
+
+    companion object {
+        private fun buildMessage(status: HttpStatusCode, body: ByteArray): String {
+            val excerpt = runCatching { body.toString(Charsets.UTF_8) }
+                .getOrDefault("(unparseable body)")
+                .take(MAX_EXCERPT_CHARS)
+            return "OpenAI TTS HTTP ${status.value}: $excerpt"
+        }
+
+        private const val MAX_EXCERPT_CHARS = 240
+    }
+}

--- a/core/data/src/main/kotlin/com/adaptweather/core/data/tts/OpenAITtsDto.kt
+++ b/core/data/src/main/kotlin/com/adaptweather/core/data/tts/OpenAITtsDto.kt
@@ -1,0 +1,18 @@
+package com.adaptweather.core.data.tts
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Wire type for `POST /v1/audio/speech`. Field names match OpenAI's snake_case
+ * via [SerialName]. Request only — the response is raw audio bytes (no JSON to
+ * deserialize), so there's no response DTO.
+ */
+@Serializable
+internal data class OpenAISpeechRequest(
+    val model: String,
+    val input: String,
+    val voice: String,
+    @SerialName("response_format")
+    val responseFormat: String,
+)

--- a/core/domain/src/main/kotlin/com/adaptweather/core/domain/model/Insight.kt
+++ b/core/domain/src/main/kotlin/com/adaptweather/core/domain/model/Insight.kt
@@ -14,4 +14,20 @@ data class Insight(
     val recommendedItems: List<String>,
     val generatedAt: Instant,
     val forDate: LocalDate,
-)
+) {
+    /**
+     * The text that gets spoken aloud. The LLM is told to weave the items into its
+     * sentence but it's not guaranteed; appending them explicitly ensures the listener
+     * always hears what their wardrobe rules suggest, even if the summary skips them.
+     */
+    fun spokenText(): String {
+        if (recommendedItems.isEmpty()) return summary
+        val joined = when (recommendedItems.size) {
+            1 -> recommendedItems[0]
+            2 -> "${recommendedItems[0]} and ${recommendedItems[1]}"
+            else -> recommendedItems.dropLast(1).joinToString(", ") + ", and " + recommendedItems.last()
+        }
+        val separator = if (summary.endsWith(".") || summary.endsWith("!") || summary.endsWith("?")) " " else ". "
+        return "$summary${separator}Recommended: $joined."
+    }
+}

--- a/core/domain/src/main/kotlin/com/adaptweather/core/domain/model/Settings.kt
+++ b/core/domain/src/main/kotlin/com/adaptweather/core/domain/model/Settings.kt
@@ -12,10 +12,12 @@ enum class DeliveryMode { NOTIFICATION_ONLY, TTS_ONLY, NOTIFICATION_AND_TTS }
  * - [DEVICE] uses Android's on-device TextToSpeech engine. Free, fully offline once
  *   voices are installed, but quality varies by vendor.
  * - [GEMINI] uses Gemini's audio-output model (`gemini-2.5-flash-preview-tts`) over
- *   the BYOK key. Near-human quality, requires network at speak-time, costs a small
- *   amount per character. Falls back to [DEVICE] if the call fails.
+ *   the BYOK Gemini key. Near-human quality, requires network at speak-time, costs
+ *   a small amount per character. Falls back to [DEVICE] if the call fails.
+ * - [OPENAI] uses OpenAI's `audio/speech` endpoint over a separate BYOK OpenAI key.
+ *   Comparable quality to Gemini; falls back to [DEVICE] on failure.
  */
-enum class TtsEngine { DEVICE, GEMINI }
+enum class TtsEngine { DEVICE, GEMINI, OPENAI }
 
 data class UserPreferences(
     val schedule: Schedule,
@@ -36,4 +38,20 @@ data class UserPreferences(
      */
     val useDeviceLocation: Boolean = false,
     val ttsEngine: TtsEngine = TtsEngine.DEVICE,
-)
+    /**
+     * Prebuilt Gemini voice name (e.g. "Kore", "Puck"). Only consulted when
+     * [ttsEngine] == [TtsEngine.GEMINI]. Stored as a free-form string so adding
+     * voices doesn't require a domain enum migration.
+     */
+    val geminiVoice: String = DEFAULT_GEMINI_VOICE,
+    /**
+     * OpenAI voice name (e.g. "alloy", "echo"). Only consulted when [ttsEngine]
+     * == [TtsEngine.OPENAI].
+     */
+    val openAiVoice: String = DEFAULT_OPENAI_VOICE,
+) {
+    companion object {
+        const val DEFAULT_GEMINI_VOICE = "Kore"
+        const val DEFAULT_OPENAI_VOICE = "alloy"
+    }
+}

--- a/core/domain/src/test/kotlin/com/adaptweather/core/domain/model/InsightTest.kt
+++ b/core/domain/src/test/kotlin/com/adaptweather/core/domain/model/InsightTest.kt
@@ -1,0 +1,56 @@
+package com.adaptweather.core.domain.model
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.time.LocalDate
+
+class InsightTest {
+
+    private val base = Insight(
+        summary = "It will be 4° warmer today.",
+        recommendedItems = emptyList(),
+        generatedAt = Instant.parse("2026-04-25T07:00:00Z"),
+        forDate = LocalDate.of(2026, 4, 25),
+    )
+
+    @Test
+    fun `spokenText returns just the summary when no items`() {
+        base.spokenText() shouldBe "It will be 4° warmer today."
+    }
+
+    @Test
+    fun `spokenText appends a single item with proper separator`() {
+        base.copy(recommendedItems = listOf("jumper")).spokenText() shouldBe
+            "It will be 4° warmer today. Recommended: jumper."
+    }
+
+    @Test
+    fun `spokenText joins two items with and`() {
+        base.copy(recommendedItems = listOf("jumper", "umbrella")).spokenText() shouldBe
+            "It will be 4° warmer today. Recommended: jumper and umbrella."
+    }
+
+    @Test
+    fun `spokenText oxford-joins three or more items`() {
+        base.copy(recommendedItems = listOf("jumper", "scarf", "umbrella")).spokenText() shouldBe
+            "It will be 4° warmer today. Recommended: jumper, scarf, and umbrella."
+    }
+
+    @Test
+    fun `spokenText uses single space when summary already ends in punctuation`() {
+        // Summary already ending in a period should not get ". ." appended.
+        base.copy(
+            summary = "Bring a brolly!",
+            recommendedItems = listOf("umbrella"),
+        ).spokenText() shouldBe "Bring a brolly! Recommended: umbrella."
+    }
+
+    @Test
+    fun `spokenText adds period+space when summary lacks terminal punctuation`() {
+        base.copy(
+            summary = "Cooler today",
+            recommendedItems = listOf("jumper"),
+        ).spokenText() shouldBe "Cooler today. Recommended: jumper."
+    }
+}

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,0 +1,104 @@
+# AdaptWeather — TODO
+
+Living to-do list. Items are roughly ordered by priority within each section.
+Code TODOs in source files are linked from here when they exist.
+
+## Pre-publishing blockers
+
+- [ ] **Pick a stable namespace + applicationId.** Currently `com.adaptweather`,
+      a placeholder. Reverse-DNS based on a domain you own (e.g.
+      `dev.mikelward.adaptweather`) and a settled product name. Marked TODO in
+      `app/build.gradle.kts:9`. *Renaming after sideload destroys settings —
+      Android treats the new applicationId as a different app.*
+- [ ] **Pick a stable product name.** "AdaptWeather" is a working title.
+
+## Distribution
+
+- [ ] **Firebase App Distribution setup** (in progress). Plan: keystore stays
+      out of the repo, base64 + passwords go in GitHub Secrets, CI decodes on
+      the runner. Six secrets total: `KEYSTORE_BASE64`, `KEYSTORE_PASSWORD`,
+      `KEY_ALIAS`, `KEY_PASSWORD`, `FIREBASE_APP_ID`,
+      `FIREBASE_SERVICE_ACCOUNT_JSON`.
+- [ ] **`.github/workflows/build.yml`** — push-to-main signed-release upload to
+      FAD. Replaces the artifact-download workflow.
+- [ ] **`.github/workflows/release.yml`** — tag-triggered, runs Maestro on
+      Firebase Test Lab + cuts a GitHub Release.
+
+## Voice / TTS
+
+- [x] Gemini TTS as opt-in voice engine (PR #27)
+- [x] Diagnostic "Test Gemini voice" button in Settings (PR #28)
+- [ ] **OpenAI TTS** as a third voice engine. BYOK pattern, same as Gemini.
+- [ ] **Voice picker** for both Gemini and OpenAI. Currently Gemini is
+      hardcoded to `Kore`.
+- [ ] ElevenLabs / Azure as further options (only after the abstractions are
+      proven by OpenAI).
+
+## Calendar integration (next-up after TTS)
+
+- [ ] **Read today's calendar events** (`CalendarContract`) so the daily
+      insight can suggest items keyed to events: *"Bring an umbrella for your
+      3pm at the park."*
+  - Opt-in toggle in Settings + runtime `READ_CALENDAR` grant.
+  - New `:core:domain` model `CalendarEvent`.
+  - Worker reads events for today and feeds them into `BuildPrompt`.
+  - Privacy disclosure update in `docs/privacy.md`.
+
+## Forecast & alerts
+
+- [ ] **Severe weather alerts.** Open-Meteo exposes a free alerts endpoint —
+      layer onto the daily insight, post a separate notification on
+      severe-grade events.
+- [ ] **Hourly / multi-day forecast UI** on Today. Currently Today only shows
+      the latest insight; useful to see the underlying data the LLM saw.
+
+## Feature ideas (queued)
+
+- [ ] **Multiple daily insights** — morning + evening, configurable per slot.
+      Needs a second alarm slot and the calendar reader above for the evening
+      "what to bring tomorrow" briefing.
+- [ ] **Notification actions** — "read aloud" / "snooze for today" buttons in
+      the notification.
+- [ ] **Tap-to-replay TTS** on Today.
+- [ ] **Past 7 days history** on Today — pull from `InsightCache`, persist
+      beyond the current single slot.
+- [ ] **Wardrobe rule presets** ("Cyclist", "Commuter", "Dog walker") — pick a
+      preset, customise from there.
+- [ ] **Quiet hours** — don't fire if the device is in DND.
+- [ ] **Per-locale defaults** — Fahrenheit / miles when the system locale is
+      en-US.
+- [ ] **Multiple schedule profiles** — weekday vs weekend.
+- [ ] **Gemini model picker** — Flash Lite (cheapest), Flash (default), Pro
+      (highest quality, slowest, costliest). Currently hardcoded to
+      `gemini-2.5-flash` in `core/data/.../insight/DirectGeminiClient.kt`.
+      Daily prompts are tiny (~25 words out) so Flash Lite would be ~5x cheaper
+      with little quality loss.
+
+## Testing & quality
+
+- [ ] **Robolectric tests** for `NotificationBuilder`, `DailyAlarmScheduler`,
+      `BootReceiver`. Currently zero coverage on those error-prone bits.
+- [ ] **Compose UI tests** for `SettingsScreen` (state transitions, dialog
+      flow). No `app/src/androidTest/` exists today.
+- [ ] **Maestro flows** — `.maestro/first_launch.yaml`,
+      `.maestro/daily_insight_debug_fire.yaml`. Plan called for both; need
+      Firebase Test Lab in CI to run them automatically.
+- [ ] **`detekt` + `ktlintCheck` in CI.** Neither plugin applied today.
+- [ ] **JaCoCo coverage** — plan target ≥85% on `:core:domain` +
+      `:core:data`. No coverage measurement wired up.
+- [ ] **`docs/acceptance.md`** — manual checklist (TTS audio, real 7am fire,
+      lock-screen visibility, OEM background-killer).
+
+## Deferred to v2 (out of scope for v1)
+
+- iOS port (needs a Mac + KMP-promotion of the core modules).
+- Backend Gemini proxy (interface in place; swap before Play Store).
+- Google Home / alarm-clock-app integration.
+- Play Store submission. Sideload + FAD only for v1.
+
+## Code TODOs
+
+| File | Note |
+|---|---|
+| `app/build.gradle.kts:9` | Pin namespace + applicationId before first distribution. |
+| `app/src/main/kotlin/com/adaptweather/tts/AndroidTtsSpeaker.kt:30` | Evaluate higher-quality TTS alternatives. (Gemini + OpenAI now landed.) |


### PR DESCRIPTION
## Summary

Three threaded changes that land together because they share the same machinery:

1. **OpenAI as a third Voice engine.** New `OpenAITtsClient` calls `POST /v1/audio/speech` with `response_format: "pcm"` — the response body is raw 16-bit signed mono PCM at 24 kHz, bit-compatible with Gemini's TTS output. Extracted `PcmAudioPlayer` from `GeminiTtsSpeaker` so both providers share the AudioTrack scaffolding. `SecureKeyStore` generalised to hold a separate OpenAI key (encrypted under its own AAD, in its own preference slot — Gemini API on the class is unchanged).

2. **Voice pickers for both Gemini and OpenAI.** Eight curated Gemini voices (Kore default), six OpenAI stock voices (alloy default). `AlertDialog`-backed picker, same UX shape as the existing Wardrobe-rule dialog.

3. **Auto-preview on change.** When you pick a different engine or voice, the new selection plays back immediately so you can compare. Source text is the latest cached insight (so you hear what the actual morning delivery would sound like), falling back to a short fixed sample if there isn't one yet. A `previewJob` cancels any in-flight playback so rapid taps don't queue overlapping ones. Errors surface as a Toast — same pattern as the existing Test Gemini voice button — so the actual reason (most often a missing/wrong API key) is visible without logcat.

### Bonus

- `Insight.spokenText()` moved from a private fun on `FetchAndNotifyWorker` to a member on the domain `Insight`, so the Settings auto-preview uses the exact same join logic as the morning Worker. New `InsightTest` covers single-item, two-item Oxford, multi-item Oxford, terminal-punctuation, and missing-punctuation cases.
- `SecureKeyStoreTest` + `SettingsRepositoryTest` extended with parallel coverage for the OpenAI key + voice prefs.
- **`docs/TODO.md`** — a single living to-do list capturing pre-publishing blockers, distribution work, queued features (calendar integration, severe weather alerts, forecast UI, Gemini model picker, multiple daily insights), and testing gaps. Replaces the conversation as the source of truth.

## Files

- `:core:domain` — `TtsEngine.OPENAI`, `UserPreferences.geminiVoice`/`openAiVoice`, `Insight.spokenText()`.
- `:core:data` — `OpenAITtsClient` + DTO.
- `:app/tts/` — `OpenAITtsSpeaker`, `PcmAudioPlayer`, `TtsVoices`. `GeminiTtsSpeaker` slimmed down to use the shared player.
- `:app/data/SecureKeyStore` — Gemini API unchanged; adds OpenAI methods + `openAiKeyProvider` view.
- `:app/data/SettingsRepository` — `setGeminiVoice`/`setOpenAiVoice` + parsing.
- `:app/work/FetchAndNotifyWorker` — `speakWithFallback` switches on `prefs.ttsEngine` (Gemini / OpenAI / device).
- `:app/ui/settings/SettingsScreen` — `TtsEngineCard` rewrites: OpenAI radio, OpenAI key entry, voice picker per provider, generalised test button, auto-preview wiring.
- Strings updated; `settings_tts_test_sample` reworded to be provider-agnostic.

## Test plan

- [ ] CI green
- [ ] Sideload, set delivery to "Spoken aloud" or "Notification and spoken aloud"
- [ ] Pick **Gemini** in Voice engine — hear preview in Kore
- [ ] Open the voice dropdown, pick a different Gemini voice — preview re-plays in the new voice
- [ ] Pick **OpenAI**, paste a key, pick a voice — preview plays in OpenAI
- [ ] With no OpenAI key set: preview triggers a Toast showing `MissingApiKeyException`
- [ ] With a wrong OpenAI key: Toast shows `OpenAITtsHttpException: HTTP 401: …`
- [ ] Tap **Refresh** on Today; the morning delivery uses the same engine + voice the preview played

https://claude.ai/code/session_01VftWR7DyaaVXHnovkuQwge

---
_Generated by [Claude Code](https://claude.ai/code/session_01VftWR7DyaaVXHnovkuQwge)_