### PR TITLE
:core + :app — Gemini model picker (Flash Lite / Flash / Pro)

### DIFF
--- a/app/src/main/kotlin/com/adaptweather/AdaptWeatherApplication.kt
+++ b/app/src/main/kotlin/com/adaptweather/AdaptWeatherApplication.kt
@@ -63,9 +63,19 @@ class AdaptWeatherApplication : Application() {
 
     val weatherRepository: WeatherRepository by lazy { OpenMeteoClient(httpClient) }
     val geocodingClient: OpenMeteoGeocodingClient by lazy { OpenMeteoGeocodingClient(httpClient) }
-    val insightGenerator: InsightGenerator by lazy { DirectGeminiClient(httpClient, secureKeyStore) }
-    val generateDailyInsight: GenerateDailyInsight by lazy {
-        GenerateDailyInsight(weatherRepository, insightGenerator)
+
+    /**
+     * Build a [GenerateDailyInsight] use case bound to the user-chosen Gemini
+     * model. The model id is part of the URL path on each call so we pass it in
+     * here rather than caching a singleton — same shape as how TTS speakers are
+     * constructed per-call from the user-chosen voice.
+     *
+     * The httpClient + secure key store are shared across calls; only the thin
+     * [DirectGeminiClient] wrapper is reconstructed.
+     */
+    fun createGenerateDailyInsight(model: String): GenerateDailyInsight {
+        val generator: InsightGenerator = DirectGeminiClient(httpClient, secureKeyStore, model = model)
+        return GenerateDailyInsight(weatherRepository, generator)
     }
 
     private val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)

--- a/app/src/main/kotlin/com/adaptweather/data/SettingsRepository.kt
+++ b/app/src/main/kotlin/com/adaptweather/data/SettingsRepository.kt
@@ -101,6 +101,10 @@ class SettingsRepository(
         dataStore.edit { it[OPENAI_VOICE] = voice }
     }
 
+    suspend fun setGeminiModel(model: String) {
+        dataStore.edit { it[GEMINI_MODEL] = model }
+    }
+
     private fun Preferences.toUserPreferences(): UserPreferences {
         val time = this[SCHEDULE_TIME]?.let { LocalTime.parse(it, TIME_FORMAT) }
             ?: DEFAULT_TIME
@@ -123,6 +127,8 @@ class SettingsRepository(
             ?: UserPreferences.DEFAULT_GEMINI_VOICE
         val openAiVoice = this[OPENAI_VOICE]?.takeIf { it.isNotBlank() }
             ?: UserPreferences.DEFAULT_OPENAI_VOICE
+        val geminiModel = this[GEMINI_MODEL]?.takeIf { it.isNotBlank() }
+            ?: UserPreferences.DEFAULT_GEMINI_MODEL
 
         return UserPreferences(
             schedule = Schedule(time = time, days = days, zoneId = zoneIdProvider()),
@@ -135,6 +141,7 @@ class SettingsRepository(
             ttsEngine = ttsEngine,
             geminiVoice = geminiVoice,
             openAiVoice = openAiVoice,
+            geminiModel = geminiModel,
         )
     }
 
@@ -171,6 +178,7 @@ class SettingsRepository(
         private val TTS_ENGINE = stringPreferencesKey("tts_engine")
         private val GEMINI_VOICE = stringPreferencesKey("gemini_voice")
         private val OPENAI_VOICE = stringPreferencesKey("openai_voice")
+        private val GEMINI_MODEL = stringPreferencesKey("gemini_model")
 
         private val TIME_FORMAT: DateTimeFormatter = DateTimeFormatter.ofPattern("HH:mm")
         private val DEFAULT_TIME: LocalTime = LocalTime.of(7, 0)

--- a/app/src/main/kotlin/com/adaptweather/insight/GeminiModels.kt
+++ b/app/src/main/kotlin/com/adaptweather/insight/GeminiModels.kt
@@ -1,0 +1,19 @@
+package com.adaptweather.insight
+
+/**
+ * Curated list of Gemini models surfaced in Settings. Each option pairs the model
+ * id (sent to the API) with a short human label.
+ *
+ * The default written into a fresh install is `gemini-2.5-flash` — see
+ * `UserPreferences.DEFAULT_GEMINI_MODEL`. Flash Lite is much cheaper for the daily
+ * 25-word output but trades a small amount of quality. Pro is the highest quality
+ * at higher latency and cost; reasonable when the user wants the polished prose
+ * voice but probably overkill for the morning insight.
+ */
+data class GeminiModelOption(val id: String, val displayName: String)
+
+val GEMINI_MODELS: List<GeminiModelOption> = listOf(
+    GeminiModelOption("gemini-2.5-flash-lite", "Flash Lite — cheapest, fast"),
+    GeminiModelOption("gemini-2.5-flash", "Flash — balanced (default)"),
+    GeminiModelOption("gemini-2.5-pro", "Pro — highest quality, slowest"),
+)

--- a/app/src/main/kotlin/com/adaptweather/ui/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/adaptweather/ui/settings/SettingsScreen.kt
@@ -57,6 +57,8 @@ import com.adaptweather.core.domain.model.Location
 import com.adaptweather.core.domain.model.TemperatureUnit
 import com.adaptweather.core.domain.model.TtsEngine
 import com.adaptweather.core.domain.model.WardrobeRule
+import com.adaptweather.insight.GEMINI_MODELS
+import com.adaptweather.insight.GeminiModelOption
 import com.adaptweather.tts.GEMINI_VOICES
 import com.adaptweather.tts.GeminiTtsSpeaker
 import com.adaptweather.tts.OPENAI_VOICES
@@ -114,6 +116,7 @@ fun SettingsScreen(viewModel: SettingsViewModel, onNavigateBack: () -> Unit) {
             onSetOpenAiVoice = viewModel::setOpenAiVoice,
             onSetOpenAiKey = viewModel::setOpenAiKey,
             onClearOpenAiKey = viewModel::clearOpenAiKey,
+            onSetGeminiModel = viewModel::setGeminiModel,
         )
     }
 }
@@ -140,6 +143,7 @@ private fun SettingsContent(
     onSetOpenAiVoice: (String) -> Unit,
     onSetOpenAiKey: (String) -> Unit,
     onClearOpenAiKey: () -> Unit,
+    onSetGeminiModel: (String) -> Unit,
 ) {
     Column(
         modifier = Modifier
@@ -154,6 +158,10 @@ private fun SettingsContent(
             configured = state.apiKeyConfigured,
             onSave = onSetApiKey,
             onClear = onClearApiKey,
+        )
+        GeminiModelCard(
+            selected = state.geminiModel,
+            onSelect = onSetGeminiModel,
         )
         LocationCard(
             current = state.location,
@@ -836,6 +844,53 @@ private fun ApiKeyCard(
                 ) { Text(stringResource(R.string.settings_api_key_clear)) }
             }
         }
+    }
+}
+
+@Composable
+private fun GeminiModelCard(
+    selected: String,
+    onSelect: (String) -> Unit,
+) {
+    var dialogOpen by remember { mutableStateOf(false) }
+    val current = GEMINI_MODELS.firstOrNull { it.id == selected }
+    SectionCard(title = stringResource(R.string.settings_gemini_model_title)) {
+        Text(
+            text = stringResource(R.string.settings_gemini_model_description),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        OutlinedButton(
+            onClick = { dialogOpen = true },
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text(current?.displayName ?: selected)
+        }
+    }
+    if (dialogOpen) {
+        AlertDialog(
+            onDismissRequest = { dialogOpen = false },
+            title = { Text(stringResource(R.string.settings_gemini_model_title)) },
+            text = {
+                Column {
+                    GEMINI_MODELS.forEach { option: GeminiModelOption ->
+                        RadioRow(
+                            label = option.displayName,
+                            selected = option.id == selected,
+                            onSelect = {
+                                onSelect(option.id)
+                                dialogOpen = false
+                            },
+                        )
+                    }
+                }
+            },
+            confirmButton = {
+                TextButton(onClick = { dialogOpen = false }) {
+                    Text(stringResource(R.string.settings_tts_voice_dismiss))
+                }
+            },
+        )
     }
 }
 

--- a/app/src/main/kotlin/com/adaptweather/ui/settings/SettingsState.kt
+++ b/app/src/main/kotlin/com/adaptweather/ui/settings/SettingsState.kt
@@ -24,6 +24,7 @@ data class SettingsState(
     val ttsEngine: TtsEngine = TtsEngine.DEVICE,
     val geminiVoice: String = UserPreferences.DEFAULT_GEMINI_VOICE,
     val openAiVoice: String = UserPreferences.DEFAULT_OPENAI_VOICE,
+    val geminiModel: String = UserPreferences.DEFAULT_GEMINI_MODEL,
     val apiKeyConfigured: Boolean = false,
     val openAiKeyConfigured: Boolean = false,
 )

--- a/app/src/main/kotlin/com/adaptweather/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/adaptweather/ui/settings/SettingsViewModel.kt
@@ -48,6 +48,7 @@ class SettingsViewModel(
                         ttsEngine = prefs.ttsEngine,
                         geminiVoice = prefs.geminiVoice,
                         openAiVoice = prefs.openAiVoice,
+                        geminiModel = prefs.geminiModel,
                     )
                 }
             }
@@ -89,6 +90,10 @@ class SettingsViewModel(
 
     fun setOpenAiVoice(voice: String) {
         viewModelScope.launch { settingsRepository.setOpenAiVoice(voice) }
+    }
+
+    fun setGeminiModel(model: String) {
+        viewModelScope.launch { settingsRepository.setGeminiModel(model) }
     }
 
     fun setDeliveryMode(mode: DeliveryMode) {

--- a/app/src/main/kotlin/com/adaptweather/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/com/adaptweather/work/FetchAndNotifyWorker.kt
@@ -89,7 +89,8 @@ class FetchAndNotifyWorker(
         languageTag: String,
     ): Result {
         return try {
-            val insight = app.generateDailyInsight(location, prefs, languageTag)
+            val insight = app.createGenerateDailyInsight(prefs.geminiModel)
+                .invoke(location, prefs, languageTag)
             runCatching { app.insightCache.store(insight) }
                 .onFailure { Log.w(TAG, "Insight cache write failed; not blocking delivery.", it) }
             deliver(insight, prefs)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -30,6 +30,9 @@
     <string name="settings_api_key_save">Save key</string>
     <string name="settings_api_key_clear">Clear stored key</string>
 
+    <string name="settings_gemini_model_title">Gemini model</string>
+    <string name="settings_gemini_model_description">Choose the model used to write the daily insight. Flash Lite is much cheaper than Flash for the same key. Pro is the highest quality but slowest and costliest — overkill for the morning summary, useful when you want polished prose.</string>
+
     <string name="settings_location_title">Location</string>
     <string name="settings_location_use_device">Use device location</string>
     <string name="settings_location_grant_background">Grant background location (system Settings)</string>

--- a/app/src/test/kotlin/com/adaptweather/data/SettingsRepositoryTest.kt
+++ b/app/src/test/kotlin/com/adaptweather/data/SettingsRepositoryTest.kt
@@ -171,6 +171,14 @@ class SettingsRepositoryTest {
     }
 
     @Test
+    fun `setGeminiModel round-trips and defaults to flash`() = runTest {
+        subject.preferences.first().geminiModel shouldBe "gemini-2.5-flash"
+
+        subject.setGeminiModel("gemini-2.5-pro")
+        subject.preferences.first().geminiModel shouldBe "gemini-2.5-pro"
+    }
+
+    @Test
     fun `zoneId is resolved fresh on each emission`() = runTest {
         val zones = mutableListOf(ZoneId.of("UTC"), ZoneId.of("America/New_York"))
         val rotating = SettingsRepository(

--- a/core/domain/src/main/kotlin/com/adaptweather/core/domain/model/Settings.kt
+++ b/core/domain/src/main/kotlin/com/adaptweather/core/domain/model/Settings.kt
@@ -49,9 +49,16 @@ data class UserPreferences(
      * == [TtsEngine.OPENAI].
      */
     val openAiVoice: String = DEFAULT_OPENAI_VOICE,
+    /**
+     * Gemini model id used to generate the daily prose (e.g.
+     * `gemini-2.5-flash`). Stored as a free-form string so adding new models
+     * doesn't require a domain-enum migration.
+     */
+    val geminiModel: String = DEFAULT_GEMINI_MODEL,
 ) {
     companion object {
         const val DEFAULT_GEMINI_VOICE = "Kore"
         const val DEFAULT_OPENAI_VOICE = "alloy"
+        const val DEFAULT_GEMINI_MODEL = "gemini-2.5-flash"
     }
 }

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -68,11 +68,9 @@ Code TODOs in source files are linked from here when they exist.
 - [ ] **Per-locale defaults** — Fahrenheit / miles when the system locale is
       en-US.
 - [ ] **Multiple schedule profiles** — weekday vs weekend.
-- [ ] **Gemini model picker** — Flash Lite (cheapest), Flash (default), Pro
-      (highest quality, slowest, costliest). Currently hardcoded to
-      `gemini-2.5-flash` in `core/data/.../insight/DirectGeminiClient.kt`.
-      Daily prompts are tiny (~25 words out) so Flash Lite would be ~5x cheaper
-      with little quality loss.
+- [x] **Gemini model picker** — Flash Lite (cheapest), Flash (default), Pro
+      (highest quality, slowest, costliest). User picks from Settings; the
+      Worker passes the chosen id into a per-call `DirectGeminiClient`.
 
 ## Testing & quality
 


### PR DESCRIPTION
## Summary

Adds a **Gemini model** card to Settings. Pick between:

| Option | When to use |
|---|---|
| **Flash Lite** | Cheapest, fast. Daily prose is ~25 words out, so quality cost is small. |
| **Flash** *(default)* | Balanced. Same default we've been hardcoding. |
| **Pro** | Highest quality, slowest, costliest. Overkill for the morning summary; useful when you want polished prose. |

Choice is persisted; the Worker reads it on each fire and constructs a fresh `DirectGeminiClient` bound to that model id — same shape as how TTS speakers are constructed per-call from the user-chosen voice.

## Mechanics

- `:core:domain` — `UserPreferences.geminiModel` + `DEFAULT_GEMINI_MODEL` companion constant.
- `:app/data/SettingsRepository` — persists / reads via `stringPreferencesKey("gemini_model")`.
- `:app/insight/GeminiModels` — three curated options with short labels.
- `:app/AdaptWeatherApplication` — drops the lazy `insightGenerator` + `generateDailyInsight` singletons in favour of a `createGenerateDailyInsight(model)` factory.
- `:app/work/FetchAndNotifyWorker` — calls `app.createGenerateDailyInsight(prefs.geminiModel).invoke(...)`.
- `:app/ui/settings/SettingsScreen` — new `GeminiModelCard` placed right after the Gemini API key card (both relate to the BYOK Gemini path). `AlertDialog`-backed picker matching the voice-picker pattern.
- `SettingsRepositoryTest` — round-trip + default-when-empty test for the new field.
- `docs/TODO.md` — ticked.

## Test plan

- [ ] CI green
- [ ] Sideload, open Settings — see the new "Gemini model" card right after the API key card with a description and dropdown showing "Flash — balanced (default)".
- [ ] Tap the dropdown, pick **Flash Lite** — choice persists across app restart (verify in `dumpsys` or by reopening Settings).
- [ ] Tap **Refresh** on Today — logcat shows the call going to `…/v1beta/models/gemini-2.5-flash-lite:generateContent`.
- [ ] Switch to **Pro**, refresh again — call routes to `gemini-2.5-pro`.

## Follow-up

The four review comments from PR #29 (PcmAudioPlayer short-write defensive loop, runTtsPreview off-Main dispatcher, SecureKeyStoreTest comment wording, TODO.md table) will land as a separate small PR right after this — kept out of this branch to keep the diff focused on the new feature.

https://claude.ai/code/session_01VftWR7DyaaVXHnovkuQwge

---
_Generated by [Claude Code](https://claude.ai/code/session_01VftWR7DyaaVXHnovkuQwge)_