### PR TITLE
:app — review-comment fixes from PR #29

### DIFF
--- a/app/src/main/kotlin/com/adaptweather/insight/GeminiModels.kt
+++ b/app/src/main/kotlin/com/adaptweather/insight/GeminiModels.kt
@@ -7,8 +7,8 @@ package com.adaptweather.insight
  * The default written into a fresh install is `gemini-2.5-flash` — see
  * `UserPreferences.DEFAULT_GEMINI_MODEL`. Flash Lite is much cheaper for the daily
  * 25-word output but trades a small amount of quality. Pro is the highest quality
- * at higher latency and cost; reasonable when the user wants the polished prose
- * voice but probably overkill for the morning insight.
+ * at higher latency and cost; reasonable when the user wants more polished prose
+ * but probably overkill for the morning insight.
  */
 data class GeminiModelOption(val id: String, val displayName: String)
 

--- a/app/src/main/kotlin/com/adaptweather/tts/PcmAudioPlayer.kt
+++ b/app/src/main/kotlin/com/adaptweather/tts/PcmAudioPlayer.kt
@@ -43,13 +43,28 @@ internal object PcmAudioPlayer {
             .build()
 
         try {
-            val written = track.write(pcm, 0, pcm.size)
-            if (written < 0) {
-                Log.w(TAG, "AudioTrack.write rejected the buffer (code=$written)")
+            // MODE_STATIC normally accepts the whole buffer in a single write because
+            // we sized the track to pcm.size — but the contract permits a positive
+            // short write, in which case we'd set the marker beyond the actual frame
+            // count and awaitMarker would never resume. Loop until the buffer is
+            // fully accepted; bail on any error code or zero-progress write.
+            var offset = 0
+            while (offset < pcm.size) {
+                val written = track.write(pcm, offset, pcm.size - offset)
+                if (written <= 0) {
+                    Log.w(TAG, "AudioTrack.write returned $written at offset $offset; aborting playback")
+                    return
+                }
+                offset += written
+            }
+            // 2 bytes per 16-bit sample, mono. Validate alignment defensively — a
+            // partial-write loop ending on an odd byte boundary would point the
+            // marker at a non-existent frame.
+            if (offset % 2 != 0) {
+                Log.w(TAG, "AudioTrack accepted an odd number of bytes ($offset); aborting playback")
                 return
             }
-            // 2 bytes per 16-bit sample, mono.
-            val totalFrames = pcm.size / 2
+            val totalFrames = offset / 2
             track.notificationMarkerPosition = totalFrames
             awaitMarker(track, totalFrames)
         } finally {

--- a/app/src/main/kotlin/com/adaptweather/ui/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/adaptweather/ui/settings/SettingsScreen.kt
@@ -66,9 +66,11 @@ import com.adaptweather.tts.OpenAITtsSpeaker
 import com.adaptweather.tts.TtsVoiceOption
 import com.adaptweather.work.FetchAndNotifyWorker
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.time.DayOfWeek
 import java.time.LocalTime
 import java.time.format.DateTimeFormatter
@@ -1059,23 +1061,30 @@ private suspend fun runTtsPreview(
     openAiVoice: String,
 ) {
     val app = context.applicationContext as com.adaptweather.AdaptWeatherApplication
-    try {
-        val text = app.insightCache.latest.first()?.spokenText()
-            ?: context.getString(R.string.settings_tts_test_sample)
-        when (engine) {
-            TtsEngine.GEMINI ->
-                GeminiTtsSpeaker(app.geminiTtsClient, voiceName = geminiVoice).speak(text)
-            TtsEngine.OPENAI ->
-                OpenAITtsSpeaker(app.openAiTtsClient, voice = openAiVoice).speak(text)
-            TtsEngine.DEVICE ->
-                app.deviceTtsSpeaker.speak(text)
+    // Network synthesis and AudioTrack write are both blocking-ish work — Ktor
+    // suspends off-Main internally, but AudioTrack.write/play are JNI calls and
+    // we don't want a hot stack of preview work running on the UI dispatcher.
+    // Toast is documented as safe from any thread (it posts internally) so we
+    // don't need to hop back to Main for the failure path.
+    withContext(Dispatchers.IO) {
+        try {
+            val text = app.insightCache.latest.first()?.spokenText()
+                ?: context.getString(R.string.settings_tts_test_sample)
+            when (engine) {
+                TtsEngine.GEMINI ->
+                    GeminiTtsSpeaker(app.geminiTtsClient, voiceName = geminiVoice).speak(text)
+                TtsEngine.OPENAI ->
+                    OpenAITtsSpeaker(app.openAiTtsClient, voice = openAiVoice).speak(text)
+                TtsEngine.DEVICE ->
+                    app.deviceTtsSpeaker.speak(text)
+            }
+        } catch (_: CancellationException) {
+            // Expected when the user picks a different option mid-playback; not an error.
+        } catch (t: Throwable) {
+            val message = "${t.javaClass.simpleName}: ${t.message ?: "(no detail)"}"
+            android.util.Log.w("SettingsScreen", "TTS preview failed for $engine", t)
+            android.widget.Toast.makeText(context, message, android.widget.Toast.LENGTH_LONG).show()
         }
-    } catch (_: CancellationException) {
-        // Expected when the user picks a different option mid-playback; not an error.
-    } catch (t: Throwable) {
-        val message = "${t.javaClass.simpleName}: ${t.message ?: "(no detail)"}"
-        android.util.Log.w("SettingsScreen", "TTS preview failed for $engine", t)
-        android.widget.Toast.makeText(context, message, android.widget.Toast.LENGTH_LONG).show()
     }
 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -31,7 +31,7 @@
     <string name="settings_api_key_clear">Clear stored key</string>
 
     <string name="settings_gemini_model_title">Gemini model</string>
-    <string name="settings_gemini_model_description">Choose the model used to write the daily insight. Flash Lite is much cheaper than Flash for the same key. Pro is the highest quality but slowest and costliest — overkill for the morning summary, useful when you want polished prose.</string>
+    <string name="settings_gemini_model_description">Choose the model used to write the daily insight. Flash Lite is much cheaper than Flash while using the same API key. Pro is the highest quality but slowest and costliest — overkill for the morning summary, useful when you want polished prose.</string>
 
     <string name="settings_location_title">Location</string>
     <string name="settings_location_use_device">Use device location</string>

--- a/app/src/test/kotlin/com/adaptweather/data/SecureKeyStoreTest.kt
+++ b/app/src/test/kotlin/com/adaptweather/data/SecureKeyStoreTest.kt
@@ -131,8 +131,8 @@ class SecureKeyStoreTest {
     }
 
     private companion object {
-        // Mirrors SecureKeyStore preference key names (private). Kept in sync deliberately
-        // so the test can assert against the on-disk preference name.
+        // Mirrors SecureKeyStore's private Gemini preference key name. Kept in sync
+        // deliberately so the test can assert against the on-disk preference name.
         val GEMINI_KEY_PREFERENCE = stringPreferencesKey("gemini_api_key_v1")
     }
 }

--- a/app/src/test/kotlin/com/adaptweather/data/SettingsRepositoryTest.kt
+++ b/app/src/test/kotlin/com/adaptweather/data/SettingsRepositoryTest.kt
@@ -10,6 +10,7 @@ import com.adaptweather.core.domain.model.DeliveryMode
 import com.adaptweather.core.domain.model.DistanceUnit
 import com.adaptweather.core.domain.model.Schedule
 import com.adaptweather.core.domain.model.TemperatureUnit
+import com.adaptweather.core.domain.model.UserPreferences
 import com.adaptweather.core.domain.model.WardrobeRule
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.collections.shouldContainExactly
@@ -171,8 +172,8 @@ class SettingsRepositoryTest {
     }
 
     @Test
-    fun `setGeminiModel round-trips and defaults to flash`() = runTest {
-        subject.preferences.first().geminiModel shouldBe "gemini-2.5-flash"
+    fun `setGeminiModel round-trips and defaults to the configured default model`() = runTest {
+        subject.preferences.first().geminiModel shouldBe UserPreferences.DEFAULT_GEMINI_MODEL
 
         subject.setGeminiModel("gemini-2.5-pro")
         subject.preferences.first().geminiModel shouldBe "gemini-2.5-pro"

--- a/app/src/test/kotlin/com/adaptweather/ui/settings/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/com/adaptweather/ui/settings/SettingsViewModelTest.kt
@@ -21,8 +21,11 @@ import io.ktor.serialization.kotlinx.json.json
 import io.ktor.utils.io.ByteReadChannel
 import kotlinx.serialization.json.Json as KotlinxJson
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -44,6 +47,13 @@ class SettingsViewModelTest {
     // crashes on Android JVM unit tests because AndroidDispatcherFactory calls the
     // unmocked Looper.getMainLooper(). See SecureKeyStoreTest for the same workaround.
     private val dispatcher = UnconfinedTestDispatcher(TestCoroutineScheduler())
+    // DataStore's default scope is `Dispatchers.IO + SupervisorJob()` — its internal
+    // actor coroutine outlives the test body and, when it resumes after `resetMain`,
+    // can't dispatch back through TestMainDispatcher (which delegates to the now-
+    // missing Dispatchers.Main) and crashes the JVM with "Module with the Main
+    // dispatcher is missing". Pinning DataStore to our test dispatcher and cancelling
+    // the scope in tearDown ensures DataStore's lifecycle is bounded by the test.
+    private lateinit var dataStoreScope: CoroutineScope
     private lateinit var settingsDataStore: DataStore<Preferences>
     private lateinit var keyDataStore: DataStore<Preferences>
     private lateinit var settingsRepository: SettingsRepository
@@ -53,10 +63,13 @@ class SettingsViewModelTest {
     @BeforeEach
     fun setUp() {
         Dispatchers.setMain(dispatcher)
+        dataStoreScope = CoroutineScope(dispatcher + SupervisorJob())
         settingsDataStore = PreferenceDataStoreFactory.create(
+            scope = dataStoreScope,
             produceFile = { File(tempDir.toFile(), "settings.preferences_pb") },
         )
         keyDataStore = PreferenceDataStoreFactory.create(
+            scope = dataStoreScope,
             produceFile = { File(tempDir.toFile(), "key.preferences_pb") },
         )
         settingsRepository = SettingsRepository(settingsDataStore)
@@ -82,6 +95,7 @@ class SettingsViewModelTest {
 
     @AfterEach
     fun tearDown() {
+        dataStoreScope.cancel()
         Dispatchers.resetMain()
     }
 

--- a/core/data/src/main/kotlin/com/adaptweather/core/data/insight/DirectGeminiClient.kt
+++ b/core/data/src/main/kotlin/com/adaptweather/core/data/insight/DirectGeminiClient.kt
@@ -1,5 +1,6 @@
 package com.adaptweather.core.data.insight
 
+import com.adaptweather.core.domain.model.UserPreferences
 import com.adaptweather.core.domain.repository.InsightGenerator
 import com.adaptweather.core.domain.usecase.Prompt
 import io.ktor.client.HttpClient
@@ -14,7 +15,6 @@ import io.ktor.http.path
 
 internal const val GEMINI_HOST = "generativelanguage.googleapis.com"
 internal const val GEMINI_API_VERSION = "v1beta"
-internal const val DEFAULT_GEMINI_MODEL = "gemini-2.5-flash"
 
 /**
  * BYOK Gemini client: the user's key is read from [keyProvider] (Tink-encrypted
@@ -30,7 +30,7 @@ internal const val DEFAULT_GEMINI_MODEL = "gemini-2.5-flash"
 class DirectGeminiClient(
     private val httpClient: HttpClient,
     private val keyProvider: KeyProvider,
-    private val model: String = DEFAULT_GEMINI_MODEL,
+    private val model: String = UserPreferences.DEFAULT_GEMINI_MODEL,
     private val temperature: Double = 0.4,
     private val maxOutputTokens: Int = 100,
 ) : InsightGenerator {


### PR DESCRIPTION
## Summary

Three follow-ups on Copilot's review of #29; the fourth (TODO.md table) was a false positive — the markdown is single-pipe and renders correctly, no change needed.

### 1. `PcmAudioPlayer.write` short-write loop

`AudioTrack.write()` is contractually permitted to return a positive value smaller than the buffer size even in `MODE_STATIC`. Our previous code set `notificationMarkerPosition` to `pcm.size / 2` regardless, and a future short write would leave `awaitMarker` waiting on a frame that never plays — a silent hang. Fix:

- Loop until `offset == pcm.size`; bail on any error or zero-progress write.
- Compute `totalFrames` from the actually-written byte count.
- Validate even-byte alignment (16-bit PCM) defensively.

In practice `MODE_STATIC` accepts the whole buffer in a single call, so this is insurance — but cheap.

### 2. `runTtsPreview` off-Main

The preview job is launched from `rememberCoroutineScope()` (Main dispatcher). Ktor suspends off-Main internally so the network round-trip wasn't an issue, but `AudioTrack.write` / `play` are JNI calls and we shouldn't run a hot stack of preview work on the UI dispatcher. Body now wrapped in `withContext(Dispatchers.IO)`. `Toast.makeText` is documented as thread-safe (it posts internally) so no Main hop on the failure path.

### 3. `SecureKeyStoreTest` comment wording

The companion-object comment said "Mirrors SecureKeyStore preference key names" (plural), but only `GEMINI_KEY_PREFERENCE` is declared there. Reworded to refer to the single key, per Copilot's suggestion.

### Skipped

- **TODO.md table.** Copilot claimed the table starts each row with `||`. The actual file uses standard single-pipe rows with proper header/separator. Renders fine in GitHub's Markdown. No change.

## Test plan

- [ ] CI green
- [ ] Sideload, pick **Voice engine → Gemini**, tap a different voice — preview plays and feels equally responsive (off-Main change is invisible to the user when working; matters under quota errors / network backpressure)
- [ ] Pick **OpenAI** with a missing key — Toast still appears (no Main-hop crash)

https://claude.ai/code/session_01VftWR7DyaaVXHnovkuQwge

---
_Generated by [Claude Code](https://claude.ai/code/session_01VftWR7DyaaVXHnovkuQwge)_