### PR TITLE
Severe weather alerts (Open-Meteo /v1/warnings)

### DIFF
--- a/app/src/main/kotlin/com/adaptweather/AdaptWeatherApplication.kt
+++ b/app/src/main/kotlin/com/adaptweather/AdaptWeatherApplication.kt
@@ -17,6 +17,7 @@ import com.adaptweather.data.SettingsRepository
 import com.adaptweather.location.LocationResolver
 import com.adaptweather.notification.InsightNotifier
 import com.adaptweather.notification.NotificationChannelRegistrar
+import com.adaptweather.notification.WeatherAlertNotifier
 import com.adaptweather.tts.AndroidTtsSpeaker
 import com.adaptweather.tts.TtsSpeaker
 import io.ktor.client.HttpClient
@@ -46,6 +47,7 @@ class AdaptWeatherApplication : Application() {
     val insightCache: InsightCache by lazy { InsightCache.create(this) }
     val locationResolver: LocationResolver by lazy { LocationResolver(this) }
     val insightNotifier: InsightNotifier by lazy { InsightNotifier(this) }
+    val weatherAlertNotifier: WeatherAlertNotifier by lazy { WeatherAlertNotifier(this) }
     val dailyAlarmScheduler: DailyAlarmScheduler by lazy { DailyAlarmScheduler(this) }
     val deviceTtsSpeaker: TtsSpeaker by lazy { AndroidTtsSpeaker(this) }
     val geminiTtsClient: GeminiTtsClient by lazy { GeminiTtsClient(httpClient, secureKeyStore) }

--- a/app/src/main/kotlin/com/adaptweather/notification/NotificationChannelRegistrar.kt
+++ b/app/src/main/kotlin/com/adaptweather/notification/NotificationChannelRegistrar.kt
@@ -11,19 +11,23 @@ import com.adaptweather.R
  * is a user-visible change. Bump the suffix when channel semantics change.
  */
 internal const val CHANNEL_DAILY_INSIGHT = "daily_insight_v1"
+internal const val CHANNEL_WEATHER_ALERTS = "weather_alerts_v1"
 
 /**
  * Registers the notification channel(s) used by the app. Idempotent — safe to call from
  * Application.onCreate on every cold start.
  *
- * The daily-insight channel is high-importance because the user explicitly opted in to a
- * morning notification, and the OS otherwise groups it silently if a lower importance is used.
+ * Two channels:
+ * - **Daily insight** (HIGH): the morning weather summary the user opted in to.
+ * - **Severe weather alerts** (MAX): out-of-band notifications for SEVERE / EXTREME
+ *   alerts. Separate channel so the user can mute the daily summary without losing
+ *   life-safety alerts (and vice-versa).
  */
 object NotificationChannelRegistrar {
     fun register(context: Context) {
         val manager = context.getSystemService<NotificationManager>() ?: return
 
-        val channel = NotificationChannel(
+        val daily = NotificationChannel(
             CHANNEL_DAILY_INSIGHT,
             context.getString(R.string.notification_channel_daily_insight_name),
             NotificationManager.IMPORTANCE_HIGH,
@@ -33,6 +37,18 @@ object NotificationChannelRegistrar {
             lockscreenVisibility = android.app.Notification.VISIBILITY_PUBLIC
         }
 
-        manager.createNotificationChannel(channel)
+        val alerts = NotificationChannel(
+            CHANNEL_WEATHER_ALERTS,
+            context.getString(R.string.notification_channel_weather_alerts_name),
+            NotificationManager.IMPORTANCE_MAX,
+        ).apply {
+            description = context.getString(R.string.notification_channel_weather_alerts_description)
+            setShowBadge(true)
+            enableVibration(true)
+            lockscreenVisibility = android.app.Notification.VISIBILITY_PUBLIC
+        }
+
+        manager.createNotificationChannel(daily)
+        manager.createNotificationChannel(alerts)
     }
 }

--- a/app/src/main/kotlin/com/adaptweather/notification/WeatherAlertNotifier.kt
+++ b/app/src/main/kotlin/com/adaptweather/notification/WeatherAlertNotifier.kt
@@ -1,0 +1,78 @@
+package com.adaptweather.notification
+
+import android.Manifest
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.core.content.ContextCompat
+import com.adaptweather.MainActivity
+import com.adaptweather.R
+import com.adaptweather.core.domain.model.WeatherAlert
+
+/**
+ * Posts a SEVERE / EXTREME weather alert as a separate, max-importance notification.
+ * Each alert gets its own notification ID (derived from event + onset) so distinct
+ * concurrent alerts stack rather than collapsing onto a single line.
+ *
+ * Permission semantics mirror [InsightNotifier]: a missing POST_NOTIFICATIONS grant
+ * silently no-ops — the alert is already cached on the bundle and the user will see
+ * it the next time they open the app.
+ */
+class WeatherAlertNotifier(private val context: Context) {
+
+    fun notify(alert: WeatherAlert) {
+        if (!hasPostNotificationPermission()) return
+
+        val tapIntent = Intent(context, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
+        }
+        val pendingIntent = PendingIntent.getActivity(
+            context,
+            REQUEST_OPEN_APP,
+            tapIntent,
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+        )
+
+        val body = alert.headline ?: alert.description ?: alert.event
+        val title = context.getString(R.string.notification_weather_alert_title, alert.event)
+
+        val notification = NotificationCompat.Builder(context, CHANNEL_WEATHER_ALERTS)
+            .setSmallIcon(R.drawable.ic_notification_insight)
+            .setContentTitle(title)
+            .setContentText(body)
+            .setStyle(NotificationCompat.BigTextStyle().bigText(body))
+            .setPriority(NotificationCompat.PRIORITY_MAX)
+            .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
+            .setCategory(NotificationCompat.CATEGORY_ALARM)
+            .setAutoCancel(true)
+            .setContentIntent(pendingIntent)
+            .build()
+
+        NotificationManagerCompat.from(context).notify(notificationIdFor(alert), notification)
+    }
+
+    private fun hasPostNotificationPermission(): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return true
+        return ContextCompat.checkSelfPermission(
+            context,
+            Manifest.permission.POST_NOTIFICATIONS,
+        ) == PackageManager.PERMISSION_GRANTED
+    }
+
+    private fun notificationIdFor(alert: WeatherAlert): Int {
+        // Stable ID per (event, onset) so re-posting the same alert updates in place,
+        // while distinct alerts stack. Offset into the alert ID space to avoid collision
+        // with the daily insight notification.
+        val raw = (alert.event + alert.onset.toString()).hashCode()
+        return NOTIFICATION_ID_BASE + (raw and 0x7FFFFF)
+    }
+
+    companion object {
+        private const val NOTIFICATION_ID_BASE = 2000
+        private const val REQUEST_OPEN_APP = 200
+    }
+}

--- a/app/src/main/kotlin/com/adaptweather/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/com/adaptweather/work/FetchAndNotifyWorker.kt
@@ -89,8 +89,16 @@ class FetchAndNotifyWorker(
         languageTag: String,
     ): Result {
         return try {
-            val insight = app.createGenerateDailyInsight(prefs.geminiModel)
+            val result = app.createGenerateDailyInsight(prefs.geminiModel)
                 .invoke(location, prefs, languageTag)
+            val insight = result.insight
+            // Severe alerts are out-of-band: post them as separate high-priority
+            // notifications on every fresh fetch, regardless of whether the daily
+            // summary itself is blank or suppressed.
+            result.alerts.filter { it.isHighPriority() }.forEach { alert ->
+                runCatching { app.weatherAlertNotifier.notify(alert) }
+                    .onFailure { Log.w(TAG, "Severe alert notification failed for ${alert.event}.", it) }
+            }
             runCatching { app.insightCache.store(insight) }
                 .onFailure { Log.w(TAG, "Insight cache write failed; not blocking delivery.", it) }
             deliver(insight, prefs)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -108,6 +108,10 @@
     <string name="notification_channel_daily_insight_description">The morning weather summary you opted in to.</string>
     <string name="notification_daily_insight_title">Today\'s weather</string>
 
+    <string name="notification_channel_weather_alerts_name">Severe weather alerts</string>
+    <string name="notification_channel_weather_alerts_description">High-priority alerts for severe or extreme weather events affecting your area. Delivered as soon as the daily fetch detects them.</string>
+    <string name="notification_weather_alert_title">Weather alert: %1$s</string>
+
     <string name="settings_notification_permission_title">Notifications are blocked</string>
     <string name="settings_notification_permission_description">Without notification permission, the daily insight has nowhere to go. Grant it so AdaptWeather can post tomorrow morning.</string>
     <string name="settings_notification_permission_grant">Grant notification permission</string>

--- a/core/data/src/main/kotlin/com/adaptweather/core/data/weather/OpenMeteoClient.kt
+++ b/core/data/src/main/kotlin/com/adaptweather/core/data/weather/OpenMeteoClient.kt
@@ -1,6 +1,7 @@
 package com.adaptweather.core.data.weather
 
 import com.adaptweather.core.domain.model.Location
+import com.adaptweather.core.domain.model.WeatherAlert
 import com.adaptweather.core.domain.repository.ForecastBundle
 import com.adaptweather.core.domain.repository.WeatherRepository
 import io.ktor.client.HttpClient
@@ -9,6 +10,7 @@ import io.ktor.client.request.get
 import io.ktor.client.request.parameter
 import io.ktor.http.URLProtocol
 import io.ktor.http.path
+import kotlinx.coroutines.CancellationException
 
 internal const val OPEN_METEO_HOST = "api.open-meteo.com"
 
@@ -16,6 +18,11 @@ internal const val OPEN_METEO_HOST = "api.open-meteo.com"
  * Open-Meteo `forecast` endpoint with past_days=1&forecast_days=1, returning yesterday's
  * actuals plus today's forecast in one call. Free, key-less. Free-tier soft cap is 10k
  * requests/day; this app makes one call per device per day.
+ *
+ * Severe-weather alerts come from a second `/v1/warnings` call. The warnings endpoint
+ * is best-effort: if it fails (4xx, 5xx, network), we return the forecast with an empty
+ * alerts list rather than failing the whole fetch — a missing alerts feed must not
+ * suppress the daily insight.
  */
 class OpenMeteoClient(private val httpClient: HttpClient) : WeatherRepository {
     override suspend fun fetchForecast(location: Location): ForecastBundle {
@@ -41,6 +48,25 @@ class OpenMeteoClient(private val httpClient: HttpClient) : WeatherRepository {
             )
         }.body()
 
-        return OpenMeteoMapper.toBundle(response)
+        val bundle = OpenMeteoMapper.toBundle(response)
+        return bundle.copy(alerts = fetchAlerts(location))
+    }
+
+    private suspend fun fetchAlerts(location: Location): List<WeatherAlert> = try {
+        val response: OpenMeteoWarningsResponse = httpClient.get {
+            url {
+                protocol = URLProtocol.HTTPS
+                host = OPEN_METEO_HOST
+                path("v1", "warnings")
+            }
+            parameter("latitude", location.latitude)
+            parameter("longitude", location.longitude)
+            parameter("timezone", "auto")
+        }.body()
+        OpenMeteoWarningsMapper.toAlerts(response)
+    } catch (ce: CancellationException) {
+        throw ce
+    } catch (_: Throwable) {
+        emptyList()
     }
 }

--- a/core/data/src/main/kotlin/com/adaptweather/core/data/weather/OpenMeteoWarningsDto.kt
+++ b/core/data/src/main/kotlin/com/adaptweather/core/data/weather/OpenMeteoWarningsDto.kt
@@ -1,0 +1,24 @@
+package com.adaptweather.core.data.weather
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Wire types for the Open-Meteo `/v1/warnings` endpoint. The feed is a list of
+ * CAP-shaped alerts. All free-text fields are nullable — the upstream provider may
+ * publish only an event type and a valid window.
+ */
+@Serializable
+internal data class OpenMeteoWarningsResponse(
+    @SerialName("warnings") val warnings: List<WarningDto> = emptyList(),
+)
+
+@Serializable
+internal data class WarningDto(
+    @SerialName("event") val event: String,
+    @SerialName("severity") val severity: String? = null,
+    @SerialName("headline") val headline: String? = null,
+    @SerialName("description") val description: String? = null,
+    @SerialName("onset") val onset: String,
+    @SerialName("expires") val expires: String,
+)

--- a/core/data/src/main/kotlin/com/adaptweather/core/data/weather/OpenMeteoWarningsMapper.kt
+++ b/core/data/src/main/kotlin/com/adaptweather/core/data/weather/OpenMeteoWarningsMapper.kt
@@ -1,0 +1,48 @@
+package com.adaptweather.core.data.weather
+
+import com.adaptweather.core.domain.model.AlertSeverity
+import com.adaptweather.core.domain.model.WeatherAlert
+import java.time.Instant
+import java.time.format.DateTimeParseException
+import java.util.Locale
+
+/**
+ * Maps [OpenMeteoWarningsResponse] into a list of [WeatherAlert]. Entries with an
+ * unparseable `onset` / `expires` timestamp are dropped rather than failing the whole
+ * batch — a single malformed alert shouldn't suppress the rest. Severity strings are
+ * compared case-insensitively against the CAP ladder; anything else falls back to
+ * [AlertSeverity.UNKNOWN] so it still reaches the prompt as a non-priority alert.
+ */
+internal object OpenMeteoWarningsMapper {
+    fun toAlerts(response: OpenMeteoWarningsResponse): List<WeatherAlert> =
+        response.warnings.mapNotNull { it.toAlert() }
+
+    private fun WarningDto.toAlert(): WeatherAlert? {
+        val onsetInstant = parseInstant(onset) ?: return null
+        val expiresInstant = parseInstant(expires) ?: return null
+        return WeatherAlert(
+            event = event,
+            severity = parseSeverity(severity),
+            headline = headline,
+            description = description,
+            onset = onsetInstant,
+            expires = expiresInstant,
+        )
+    }
+
+    private fun parseInstant(raw: String): Instant? = try {
+        Instant.parse(raw)
+    } catch (_: DateTimeParseException) {
+        null
+    }
+
+    // Locale.ROOT keeps casing language-invariant: under tr-TR, "MINOR".lowercase()
+    // becomes "mınor" (dotless ı) and would slip through to UNKNOWN.
+    private fun parseSeverity(raw: String?): AlertSeverity = when (raw?.lowercase(Locale.ROOT)) {
+        "minor" -> AlertSeverity.MINOR
+        "moderate" -> AlertSeverity.MODERATE
+        "severe" -> AlertSeverity.SEVERE
+        "extreme" -> AlertSeverity.EXTREME
+        else -> AlertSeverity.UNKNOWN
+    }
+}

--- a/core/data/src/test/kotlin/com/adaptweather/core/data/weather/OpenMeteoClientTest.kt
+++ b/core/data/src/test/kotlin/com/adaptweather/core/data/weather/OpenMeteoClientTest.kt
@@ -1,5 +1,6 @@
 package com.adaptweather.core.data.weather
 
+import com.adaptweather.core.domain.model.AlertSeverity
 import com.adaptweather.core.domain.model.Location
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldContainAll
@@ -7,6 +8,7 @@ import io.kotest.matchers.shouldBe
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
+import io.ktor.client.engine.mock.respondError
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.request.HttpRequestData
 import io.ktor.http.HttpHeaders
@@ -21,21 +23,48 @@ import org.junit.jupiter.api.Test
 class OpenMeteoClientTest {
     private val london = Location(latitude = 51.5074, longitude = -0.1278, displayName = "London")
 
-    private fun fixtureBytes(): ByteReadChannel {
-        val text = checkNotNull(javaClass.getResourceAsStream("/openmeteo_london.json")) {
-            "fixture missing"
+    private fun fixtureBytes(name: String): ByteReadChannel {
+        val text = checkNotNull(javaClass.getResourceAsStream(name)) {
+            "fixture $name missing"
         }.bufferedReader().readText()
         return ByteReadChannel(text)
     }
 
-    private fun mockClient(captureRequest: (HttpRequestData) -> Unit): HttpClient {
+    private fun mockClient(captureRequest: (HttpRequestData) -> Unit = {}): HttpClient {
         val engine = MockEngine { request ->
             captureRequest(request)
-            respond(
-                content = fixtureBytes(),
-                status = HttpStatusCode.OK,
-                headers = headersOf(HttpHeaders.ContentType, "application/json"),
-            )
+            when (request.url.encodedPath) {
+                "/v1/forecast" -> respond(
+                    content = fixtureBytes("/openmeteo_london.json"),
+                    status = HttpStatusCode.OK,
+                    headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                )
+                "/v1/warnings" -> respond(
+                    content = fixtureBytes("/openmeteo_warnings_london.json"),
+                    status = HttpStatusCode.OK,
+                    headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                )
+                else -> error("unexpected path ${request.url.encodedPath}")
+            }
+        }
+        return HttpClient(engine) {
+            install(ContentNegotiation) {
+                json(Json { ignoreUnknownKeys = true })
+            }
+        }
+    }
+
+    private fun mockClientWithWarningsFailure(): HttpClient {
+        val engine = MockEngine { request ->
+            when (request.url.encodedPath) {
+                "/v1/forecast" -> respond(
+                    content = fixtureBytes("/openmeteo_london.json"),
+                    status = HttpStatusCode.OK,
+                    headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                )
+                "/v1/warnings" -> respondError(HttpStatusCode.InternalServerError)
+                else -> error("unexpected path ${request.url.encodedPath}")
+            }
         }
         return HttpClient(engine) {
             install(ContentNegotiation) {
@@ -46,16 +75,15 @@ class OpenMeteoClientTest {
 
     @Test
     fun `request hits open-meteo with required parameters`() = runTest {
-        var captured: HttpRequestData? = null
-        val client = OpenMeteoClient(mockClient { captured = it })
+        val captured = mutableListOf<HttpRequestData>()
+        val client = OpenMeteoClient(mockClient { captured += it })
 
         client.fetchForecast(london)
 
-        val req = checkNotNull(captured)
-        req.url.host shouldBe OPEN_METEO_HOST
-        req.url.encodedPath shouldBe "/v1/forecast"
+        val forecastReq = captured.first { it.url.encodedPath == "/v1/forecast" }
+        forecastReq.url.host shouldBe OPEN_METEO_HOST
 
-        val params = req.url.parameters
+        val params = forecastReq.url.parameters
         params["latitude"] shouldBe "51.5074"
         params["longitude"] shouldBe "-0.1278"
         params["past_days"] shouldBe "1"
@@ -80,13 +108,39 @@ class OpenMeteoClientTest {
     }
 
     @Test
-    fun `parses fixture into a forecast bundle`() = runTest {
-        val client = OpenMeteoClient(mockClient { })
+    fun `also queries the warnings endpoint with location and timezone`() = runTest {
+        val captured = mutableListOf<HttpRequestData>()
+        val client = OpenMeteoClient(mockClient { captured += it })
+
+        client.fetchForecast(london)
+
+        val warningsReq = captured.first { it.url.encodedPath == "/v1/warnings" }
+        warningsReq.url.host shouldBe OPEN_METEO_HOST
+        warningsReq.url.parameters["latitude"] shouldBe "51.5074"
+        warningsReq.url.parameters["longitude"] shouldBe "-0.1278"
+        warningsReq.url.parameters["timezone"] shouldBe "auto"
+    }
+
+    @Test
+    fun `parses fixture into a forecast bundle with alerts`() = runTest {
+        val client = OpenMeteoClient(mockClient())
 
         val bundle = client.fetchForecast(london)
 
         bundle.yesterday.temperatureMaxC shouldBe 18.0
         bundle.today.temperatureMaxC shouldBe 24.0
         bundle.today.hourly.size shouldBe 8
+        bundle.alerts.size shouldBe 3
+        bundle.alerts.first().severity shouldBe AlertSeverity.SEVERE
+    }
+
+    @Test
+    fun `warnings failure does not fail the forecast fetch`() = runTest {
+        val client = OpenMeteoClient(mockClientWithWarningsFailure())
+
+        val bundle = client.fetchForecast(london)
+
+        bundle.today.temperatureMaxC shouldBe 24.0
+        bundle.alerts shouldBe emptyList()
     }
 }

--- a/core/data/src/test/kotlin/com/adaptweather/core/data/weather/OpenMeteoWarningsMapperTest.kt
+++ b/core/data/src/test/kotlin/com/adaptweather/core/data/weather/OpenMeteoWarningsMapperTest.kt
@@ -1,0 +1,121 @@
+package com.adaptweather.core.data.weather
+
+import com.adaptweather.core.domain.model.AlertSeverity
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.Locale
+
+class OpenMeteoWarningsMapperTest {
+    private val json = Json { ignoreUnknownKeys = true }
+    private val originalLocale: Locale = Locale.getDefault()
+
+    @AfterEach
+    fun restoreLocale() {
+        Locale.setDefault(originalLocale)
+    }
+
+    private fun loadFixture(): OpenMeteoWarningsResponse {
+        val text = checkNotNull(javaClass.getResourceAsStream("/openmeteo_warnings_london.json")) {
+            "fixture missing"
+        }.bufferedReader().readText()
+        return json.decodeFromString(text)
+    }
+
+    @Test
+    fun `maps event severity headline and valid window`() {
+        val alerts = OpenMeteoWarningsMapper.toAlerts(loadFixture())
+
+        alerts shouldHaveSize 3
+        val severe = alerts[0]
+        severe.event shouldBe "Severe Thunderstorm Warning"
+        severe.severity shouldBe AlertSeverity.SEVERE
+        severe.headline shouldBe "Damaging hail and 90 km/h gusts expected"
+        severe.onset shouldBe Instant.parse("2026-04-25T15:00:00Z")
+        severe.expires shouldBe Instant.parse("2026-04-25T20:00:00Z")
+    }
+
+    @Test
+    fun `severity is parsed case-insensitively`() {
+        val response = OpenMeteoWarningsResponse(
+            warnings = listOf(
+                WarningDto("a", "minor", null, null, "2026-04-25T00:00:00Z", "2026-04-25T01:00:00Z"),
+                WarningDto("b", "MODERATE", null, null, "2026-04-25T00:00:00Z", "2026-04-25T01:00:00Z"),
+                WarningDto("c", "Severe", null, null, "2026-04-25T00:00:00Z", "2026-04-25T01:00:00Z"),
+                WarningDto("d", "extreme", null, null, "2026-04-25T00:00:00Z", "2026-04-25T01:00:00Z"),
+            ),
+        )
+
+        val alerts = OpenMeteoWarningsMapper.toAlerts(response)
+
+        alerts.map { it.severity } shouldBe listOf(
+            AlertSeverity.MINOR,
+            AlertSeverity.MODERATE,
+            AlertSeverity.SEVERE,
+            AlertSeverity.EXTREME,
+        )
+    }
+
+    @Test
+    fun `unknown or null severity falls back to UNKNOWN`() {
+        val response = OpenMeteoWarningsResponse(
+            warnings = listOf(
+                WarningDto("a", null, null, null, "2026-04-25T00:00:00Z", "2026-04-25T01:00:00Z"),
+                WarningDto("b", "weird-grade", null, null, "2026-04-25T00:00:00Z", "2026-04-25T01:00:00Z"),
+            ),
+        )
+
+        val alerts = OpenMeteoWarningsMapper.toAlerts(response)
+
+        alerts.map { it.severity } shouldBe listOf(AlertSeverity.UNKNOWN, AlertSeverity.UNKNOWN)
+    }
+
+    @Test
+    fun `unparseable timestamps drop only the offending alert`() {
+        val response = OpenMeteoWarningsResponse(
+            warnings = listOf(
+                WarningDto("good", "Severe", null, null, "2026-04-25T15:00:00Z", "2026-04-25T20:00:00Z"),
+                WarningDto("bad-onset", "Severe", null, null, "not-a-date", "2026-04-25T20:00:00Z"),
+                WarningDto("bad-expires", "Severe", null, null, "2026-04-25T15:00:00Z", "also-not-a-date"),
+            ),
+        )
+
+        val alerts = OpenMeteoWarningsMapper.toAlerts(response)
+
+        alerts shouldHaveSize 1
+        alerts.single().event shouldBe "good"
+    }
+
+    @Test
+    fun `empty warnings list yields empty alerts list`() {
+        val alerts = OpenMeteoWarningsMapper.toAlerts(OpenMeteoWarningsResponse(emptyList()))
+        alerts shouldBe emptyList()
+    }
+
+    @Test
+    fun `severity parsing is locale-invariant under Turkish default locale`() {
+        // tr-TR's lowercase mapping turns "MINOR" into "mınor" (dotless ı). Under
+        // a locale-sensitive case fold this would fall through to UNKNOWN.
+        Locale.setDefault(Locale.forLanguageTag("tr-TR"))
+        val response = OpenMeteoWarningsResponse(
+            warnings = listOf(
+                WarningDto("a", "MINOR", null, null, "2026-04-25T00:00:00Z", "2026-04-25T01:00:00Z"),
+                WarningDto("b", "MODERATE", null, null, "2026-04-25T00:00:00Z", "2026-04-25T01:00:00Z"),
+                WarningDto("c", "SEVERE", null, null, "2026-04-25T00:00:00Z", "2026-04-25T01:00:00Z"),
+                WarningDto("d", "EXTREME", null, null, "2026-04-25T00:00:00Z", "2026-04-25T01:00:00Z"),
+            ),
+        )
+
+        val alerts = OpenMeteoWarningsMapper.toAlerts(response)
+
+        alerts.map { it.severity } shouldBe listOf(
+            AlertSeverity.MINOR,
+            AlertSeverity.MODERATE,
+            AlertSeverity.SEVERE,
+            AlertSeverity.EXTREME,
+        )
+    }
+}

--- a/core/data/src/test/resources/openmeteo_warnings_london.json
+++ b/core/data/src/test/resources/openmeteo_warnings_london.json
@@ -1,0 +1,28 @@
+{
+  "warnings": [
+    {
+      "event": "Severe Thunderstorm Warning",
+      "severity": "Severe",
+      "headline": "Damaging hail and 90 km/h gusts expected",
+      "description": "A line of severe storms will move across Greater London this afternoon.",
+      "onset": "2026-04-25T15:00:00Z",
+      "expires": "2026-04-25T20:00:00Z"
+    },
+    {
+      "event": "Wind Advisory",
+      "severity": "Moderate",
+      "headline": null,
+      "description": null,
+      "onset": "2026-04-25T08:00:00Z",
+      "expires": "2026-04-25T18:00:00Z"
+    },
+    {
+      "event": "Coastal Flood Warning",
+      "severity": "Extreme",
+      "headline": "Major coastal flooding likely",
+      "description": null,
+      "onset": "2026-04-25T22:00:00Z",
+      "expires": "2026-04-26T06:00:00Z"
+    }
+  ]
+}

--- a/core/domain/src/main/kotlin/com/adaptweather/core/domain/model/WeatherAlert.kt
+++ b/core/domain/src/main/kotlin/com/adaptweather/core/domain/model/WeatherAlert.kt
@@ -1,0 +1,34 @@
+package com.adaptweather.core.domain.model
+
+import java.time.Instant
+
+/**
+ * One severe-weather alert as published by the upstream warnings feed.
+ *
+ * `event` is the headline alert type (e.g. "Severe Thunderstorm Warning"); `severity`
+ * follows the Common Alerting Protocol levels. `onset` and `expires` define the valid
+ * window — alerts whose `expires` is in the past are filtered out before consumers see
+ * them. `headline` and `description` are free-form strings from the upstream provider
+ * and may be null when the feed only sends an event type.
+ */
+data class WeatherAlert(
+    val event: String,
+    val severity: AlertSeverity,
+    val headline: String?,
+    val description: String?,
+    val onset: Instant,
+    val expires: Instant,
+) {
+    fun isHighPriority(): Boolean = severity.isHighPriority()
+}
+
+/** CAP-aligned severity ladder. SEVERE and EXTREME drive a separate notification. */
+enum class AlertSeverity {
+    MINOR,
+    MODERATE,
+    SEVERE,
+    EXTREME,
+    UNKNOWN;
+
+    fun isHighPriority(): Boolean = this == SEVERE || this == EXTREME
+}

--- a/core/domain/src/main/kotlin/com/adaptweather/core/domain/repository/WeatherRepository.kt
+++ b/core/domain/src/main/kotlin/com/adaptweather/core/domain/repository/WeatherRepository.kt
@@ -2,11 +2,16 @@ package com.adaptweather.core.domain.repository
 
 import com.adaptweather.core.domain.model.DailyForecast
 import com.adaptweather.core.domain.model.Location
+import com.adaptweather.core.domain.model.WeatherAlert
 
 /**
  * Source of weather data. Implementations are responsible for combining yesterday's
  * actual weather with today's forecast — Open-Meteo's `forecast?past_days=1` returns
  * both in one response, so a single call satisfies this contract.
+ *
+ * Severe-weather alerts are returned alongside the forecast in [ForecastBundle.alerts].
+ * Implementations should treat the alerts feed as best-effort: a failure to fetch
+ * warnings must not fail the whole forecast call — return an empty list instead.
  */
 interface WeatherRepository {
     suspend fun fetchForecast(location: Location): ForecastBundle
@@ -15,6 +20,7 @@ interface WeatherRepository {
 data class ForecastBundle(
     val today: DailyForecast,
     val yesterday: DailyForecast,
+    val alerts: List<WeatherAlert> = emptyList(),
 ) {
     init {
         require(yesterday.date.isBefore(today.date)) {

--- a/core/domain/src/main/kotlin/com/adaptweather/core/domain/usecase/BuildPrompt.kt
+++ b/core/domain/src/main/kotlin/com/adaptweather/core/domain/usecase/BuildPrompt.kt
@@ -1,8 +1,10 @@
 package com.adaptweather.core.domain.usecase
 
+import com.adaptweather.core.domain.model.AlertSeverity
 import com.adaptweather.core.domain.model.DailyForecast
 import com.adaptweather.core.domain.model.TemperatureUnit
 import com.adaptweather.core.domain.model.WardrobeRule
+import com.adaptweather.core.domain.model.WeatherAlert
 import com.adaptweather.core.domain.model.WeatherCondition
 import com.adaptweather.core.domain.model.symbol
 import com.adaptweather.core.domain.model.toUnit
@@ -17,11 +19,13 @@ import java.util.Locale
  * say; if every rule yields nothing, the worker skips the notification entirely.
  *
  * Rules (each yields 0 or 1 sentence):
- * 1. **Temperature**: if max OR min feels-like differs from yesterday by ≥ 3°C, output
+ * 1. **Severe-weather alert**: if any active alert is SEVERE or EXTREME, output
+ *    "Alert: <event>." for the highest-severity one.
+ * 2. **Temperature**: if max OR min feels-like differs from yesterday by ≥ 3°C, output
  *    "It will be N° warmer/cooler today." (using the larger delta).
- * 2. **Wardrobe**: if today's triggered items differ from yesterday's, output
+ * 3. **Wardrobe**: if today's triggered items differ from yesterday's, output
  *    "Wear <items>."
- * 3. **Precipitation**: if today's peak chance is ≥ 30%, output "<Type> at <HH:MM>."
+ * 4. **Precipitation**: if today's peak chance is ≥ 30%, output "<Type> at <HH:MM>."
  *
  * Calendar-event filtering and the 7pm out-of-hours briefing are not yet wired up.
  */
@@ -38,6 +42,7 @@ class BuildPrompt {
         todayTriggeredRules: List<WardrobeRule>,
         temperatureUnit: TemperatureUnit,
         languageTag: String,
+        alerts: List<WeatherAlert> = emptyList(),
     ): Prompt {
         val system = systemInstruction(languageTag)
         val user = buildUserMessage(
@@ -46,6 +51,7 @@ class BuildPrompt {
             yesterdayItems = yesterdayTriggeredRules.map { it.item },
             todayItems = todayTriggeredRules.map { it.item },
             temperatureUnit = temperatureUnit,
+            alerts = alerts,
         )
         return Prompt(systemInstruction = system, userMessage = user)
     }
@@ -55,16 +61,20 @@ class BuildPrompt {
 
         All temperatures provided to you are pre-computed "feels like" (apparent) values.
 
-        Apply these three rules in order. Each rule yields zero or one sentence.
+        Apply these four rules in order. Each rule yields zero or one sentence.
 
-        1. Temperature change: if today's high differs from yesterday's by at least 3°,
+        1. Severe alert: if a severe-weather alert is listed below with severity SEVERE
+           or EXTREME, output exactly "Alert: <event>." using the event name of the
+           highest-severity alert (EXTREME outranks SEVERE; ties take the first listed).
+           Otherwise omit. If multiple alerts share the top severity, mention only one.
+        2. Temperature change: if today's high differs from yesterday's by at least 3°,
            OR today's low differs from yesterday's by at least 3°, output exactly
            "It will be N° warmer today." or "It will be N° cooler today.", using the
            larger absolute delta rounded to the nearest integer. Otherwise omit.
-        2. Wardrobe change: today's triggered items and yesterday's are listed below.
+        3. Wardrobe change: today's triggered items and yesterday's are listed below.
            If they differ, output exactly "Wear <items>." with items separated by commas
            (Oxford comma for three or more). Otherwise omit.
-        3. Precipitation: if today's peak precipitation chance is at least 30%, output
+        4. Precipitation: if today's peak precipitation chance is at least 30%, output
            exactly "<Type> at <HH:MM>." (e.g. "Rain at 15:00."). Otherwise omit.
 
         Concatenate the resulting sentences with a single space between each.
@@ -79,6 +89,7 @@ class BuildPrompt {
         yesterdayItems: List<String>,
         todayItems: List<String>,
         temperatureUnit: TemperatureUnit,
+        alerts: List<WeatherAlert>,
     ): String = buildString {
         appendLine("Yesterday (${yesterday.date}):")
         appendLine("- feels-like high: ${tempStr(yesterday.feelsLikeMaxC, temperatureUnit)}")
@@ -98,6 +109,8 @@ class BuildPrompt {
         appendLine()
         appendLine("Yesterday's wardrobe items: ${yesterdayItems.formatList()}")
         appendLine("Today's wardrobe items: ${todayItems.formatList()}")
+        appendLine()
+        appendLine("Severe-weather alerts: ${alertsBlock(alerts)}")
     }
 
     /**
@@ -119,6 +132,16 @@ class BuildPrompt {
     }
 
     private fun List<String>.formatList(): String = if (isEmpty()) "(none)" else joinToString(", ")
+
+    private fun alertsBlock(alerts: List<WeatherAlert>): String {
+        if (alerts.isEmpty()) return "(none)"
+        return alerts.joinToString(separator = "; ") { alert ->
+            "${alert.event} [${alert.severity.label()}]"
+        }
+    }
+
+    private fun AlertSeverity.label(): String =
+        name.lowercase(Locale.ROOT).replaceFirstChar { it.titlecase(Locale.ROOT) }
 
     private fun tempStr(celsius: Double, unit: TemperatureUnit): String {
         val v = celsius.toUnit(unit)

--- a/core/domain/src/main/kotlin/com/adaptweather/core/domain/usecase/GenerateDailyInsight.kt
+++ b/core/domain/src/main/kotlin/com/adaptweather/core/domain/usecase/GenerateDailyInsight.kt
@@ -3,6 +3,7 @@ package com.adaptweather.core.domain.usecase
 import com.adaptweather.core.domain.model.Insight
 import com.adaptweather.core.domain.model.Location
 import com.adaptweather.core.domain.model.UserPreferences
+import com.adaptweather.core.domain.model.WeatherAlert
 import com.adaptweather.core.domain.repository.InsightGenerator
 import com.adaptweather.core.domain.repository.WeatherRepository
 import java.time.Clock
@@ -13,6 +14,10 @@ import java.time.Clock
  *
  * The rule evaluation runs *before* the LLM call so the deterministic list of items
  * is preserved in the [Insight] regardless of LLM output quality.
+ *
+ * Severe-weather alerts piggy-back on the same fetch and are returned alongside the
+ * insight in [DailyInsightResult]; the worker uses them to drive a separate
+ * high-priority notification while still feeding them into the daily summary.
  */
 class GenerateDailyInsight(
     private val weatherRepository: WeatherRepository,
@@ -25,8 +30,9 @@ class GenerateDailyInsight(
         location: Location,
         prefs: UserPreferences,
         languageTag: String,
-    ): Insight {
+    ): DailyInsightResult {
         val bundle = weatherRepository.fetchForecast(location)
+        val activeAlerts = bundle.alerts.filter { it.expires.isAfter(clock.instant()) }
         val yesterdayTriggered = evaluateWardrobeRules(bundle.yesterday, prefs.wardrobeRules)
         val todayTriggered = evaluateWardrobeRules(bundle.today, prefs.wardrobeRules)
         val prompt = buildPrompt(
@@ -36,13 +42,26 @@ class GenerateDailyInsight(
             todayTriggeredRules = todayTriggered,
             temperatureUnit = prefs.temperatureUnit,
             languageTag = languageTag,
+            alerts = activeAlerts,
         )
         val summary = insightGenerator.generate(prompt).trim()
-        return Insight(
+        val insight = Insight(
             summary = summary,
             recommendedItems = todayTriggered.map { it.item },
             generatedAt = clock.instant(),
             forDate = bundle.today.date,
         )
+        return DailyInsightResult(insight = insight, alerts = activeAlerts)
     }
 }
+
+/**
+ * Bundles the daily insight with the active alerts that informed it. Alerts are kept
+ * separate from [Insight] because they have a different lifecycle: the insight is
+ * cached for the day and redelivered on demand, while alerts drive a one-shot
+ * high-priority notification at fetch time.
+ */
+data class DailyInsightResult(
+    val insight: Insight,
+    val alerts: List<WeatherAlert>,
+)

--- a/core/domain/src/test/kotlin/com/adaptweather/core/domain/model/WeatherAlertTest.kt
+++ b/core/domain/src/test/kotlin/com/adaptweather/core/domain/model/WeatherAlertTest.kt
@@ -1,0 +1,31 @@
+package com.adaptweather.core.domain.model
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+class WeatherAlertTest {
+    private val window = Instant.parse("2026-04-25T15:00:00Z") to Instant.parse("2026-04-25T20:00:00Z")
+
+    private fun alert(severity: AlertSeverity) = WeatherAlert(
+        event = "Test",
+        severity = severity,
+        headline = null,
+        description = null,
+        onset = window.first,
+        expires = window.second,
+    )
+
+    @Test
+    fun `severe and extreme are high priority`() {
+        alert(AlertSeverity.SEVERE).isHighPriority() shouldBe true
+        alert(AlertSeverity.EXTREME).isHighPriority() shouldBe true
+    }
+
+    @Test
+    fun `minor moderate and unknown are not high priority`() {
+        alert(AlertSeverity.MINOR).isHighPriority() shouldBe false
+        alert(AlertSeverity.MODERATE).isHighPriority() shouldBe false
+        alert(AlertSeverity.UNKNOWN).isHighPriority() shouldBe false
+    }
+}

--- a/core/domain/src/test/kotlin/com/adaptweather/core/domain/usecase/BuildPromptTest.kt
+++ b/core/domain/src/test/kotlin/com/adaptweather/core/domain/usecase/BuildPromptTest.kt
@@ -1,13 +1,16 @@
 package com.adaptweather.core.domain.usecase
 
+import com.adaptweather.core.domain.model.AlertSeverity
 import com.adaptweather.core.domain.model.DailyForecast
 import com.adaptweather.core.domain.model.HourlyForecast
 import com.adaptweather.core.domain.model.TemperatureUnit
 import com.adaptweather.core.domain.model.WardrobeRule
+import com.adaptweather.core.domain.model.WeatherAlert
 import com.adaptweather.core.domain.model.WeatherCondition
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldNotContain
 import org.junit.jupiter.api.Test
+import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalTime
 
@@ -123,5 +126,48 @@ class BuildPromptTest {
         val prompt = subject(today, yesterday, emptyList(), emptyList(), TemperatureUnit.CELSIUS, "en-AU")
         prompt.userMessage.shouldContain("conditions: partly cloudy")
         prompt.userMessage.shouldContain("conditions: rain")
+    }
+
+    @Test
+    fun `system instruction calls out the severe-alert rule`() {
+        val prompt = subject(today, yesterday, emptyList(), emptyList(), TemperatureUnit.CELSIUS, "en-AU")
+        prompt.systemInstruction.shouldContain("Severe alert")
+        prompt.systemInstruction.shouldContain("\"Alert: <event>.\"")
+        prompt.systemInstruction.shouldContain("EXTREME outranks SEVERE")
+    }
+
+    @Test
+    fun `alerts block lists each alert with its severity label`() {
+        val severe = WeatherAlert(
+            event = "Severe Thunderstorm Warning",
+            severity = AlertSeverity.SEVERE,
+            headline = "Damaging hail expected",
+            description = null,
+            onset = Instant.parse("2026-04-25T15:00:00Z"),
+            expires = Instant.parse("2026-04-25T20:00:00Z"),
+        )
+        val moderate = WeatherAlert(
+            event = "Wind Advisory",
+            severity = AlertSeverity.MODERATE,
+            headline = null,
+            description = null,
+            onset = Instant.parse("2026-04-25T08:00:00Z"),
+            expires = Instant.parse("2026-04-25T18:00:00Z"),
+        )
+
+        val prompt = subject(
+            today, yesterday, emptyList(), emptyList(),
+            TemperatureUnit.CELSIUS, "en-AU",
+            alerts = listOf(severe, moderate),
+        )
+
+        prompt.userMessage.shouldContain("Severe Thunderstorm Warning [Severe]")
+        prompt.userMessage.shouldContain("Wind Advisory [Moderate]")
+    }
+
+    @Test
+    fun `alerts block reads (none) when no alerts are active`() {
+        val prompt = subject(today, yesterday, emptyList(), emptyList(), TemperatureUnit.CELSIUS, "en-AU")
+        prompt.userMessage.shouldContain("Severe-weather alerts: (none)")
     }
 }

--- a/core/domain/src/test/kotlin/com/adaptweather/core/domain/usecase/GenerateDailyInsightTest.kt
+++ b/core/domain/src/test/kotlin/com/adaptweather/core/domain/usecase/GenerateDailyInsightTest.kt
@@ -1,5 +1,6 @@
 package com.adaptweather.core.domain.usecase
 
+import com.adaptweather.core.domain.model.AlertSeverity
 import com.adaptweather.core.domain.model.DailyForecast
 import com.adaptweather.core.domain.model.DeliveryMode
 import com.adaptweather.core.domain.model.DistanceUnit
@@ -8,6 +9,7 @@ import com.adaptweather.core.domain.model.Schedule
 import com.adaptweather.core.domain.model.TemperatureUnit
 import com.adaptweather.core.domain.model.UserPreferences
 import com.adaptweather.core.domain.model.WardrobeRule
+import com.adaptweather.core.domain.model.WeatherAlert
 import com.adaptweather.core.domain.model.WeatherCondition
 import com.adaptweather.core.domain.repository.ForecastBundle
 import com.adaptweather.core.domain.repository.InsightGenerator
@@ -84,7 +86,7 @@ class GenerateDailyInsightTest {
         val gen = FakeInsightGenerator("  Cooler this morning but warmer than yesterday's peak — bring a jumper.  ")
         val subject = GenerateDailyInsight(weather, gen, clock = clock)
 
-        val insight = subject(london, prefs, languageTag = "en-AU")
+        val insight = subject(london, prefs, languageTag = "en-AU").insight
 
         insight.summary shouldBe "Cooler this morning but warmer than yesterday's peak — bring a jumper."
         insight.recommendedItems.shouldContainExactly("jumper", "jacket", "shorts", "umbrella")
@@ -129,8 +131,48 @@ class GenerateDailyInsightTest {
         val gen = FakeInsightGenerator("ok")
         val subject = GenerateDailyInsight(weather, gen, clock = clock)
 
-        val insight = subject(london, prefs, languageTag = "en-AU")
+        val result = subject(london, prefs, languageTag = "en-AU")
 
-        insight.recommendedItems shouldBe emptyList()
+        result.insight.recommendedItems shouldBe emptyList()
+    }
+
+    @Test
+    fun `severe alerts are surfaced in result and forwarded to the prompt`() = runTest {
+        val severe = WeatherAlert(
+            event = "Severe Thunderstorm Warning",
+            severity = AlertSeverity.SEVERE,
+            headline = "Damaging hail expected",
+            description = null,
+            onset = clockInstant,
+            expires = clockInstant.plusSeconds(3600),
+        )
+        val weather = FakeWeatherRepository(ForecastBundle(today, yesterday, alerts = listOf(severe)))
+        val gen = FakeInsightGenerator("ok")
+        val subject = GenerateDailyInsight(weather, gen, clock = clock)
+
+        val result = subject(london, prefs, languageTag = "en-AU")
+
+        result.alerts.shouldContainExactly(severe)
+        checkNotNull(gen.lastPrompt).userMessage.shouldContain("Severe Thunderstorm Warning")
+    }
+
+    @Test
+    fun `expired alerts are filtered before reaching the prompt and the result`() = runTest {
+        val stale = WeatherAlert(
+            event = "Wind Advisory",
+            severity = AlertSeverity.MODERATE,
+            headline = null,
+            description = null,
+            onset = clockInstant.minusSeconds(7200),
+            expires = clockInstant.minusSeconds(60),
+        )
+        val weather = FakeWeatherRepository(ForecastBundle(today, yesterday, alerts = listOf(stale)))
+        val gen = FakeInsightGenerator("ok")
+        val subject = GenerateDailyInsight(weather, gen, clock = clock)
+
+        val result = subject(london, prefs, languageTag = "en-AU")
+
+        result.alerts shouldBe emptyList()
+        checkNotNull(gen.lastPrompt).userMessage.shouldContain("Severe-weather alerts: (none)")
     }
 }

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -46,9 +46,9 @@ Code TODOs in source files are linked from here when they exist.
 
 ## Forecast & alerts
 
-- [ ] **Severe weather alerts.** Open-Meteo exposes a free alerts endpoint —
-      layer onto the daily insight, post a separate notification on
-      severe-grade events.
+- [x] **Severe weather alerts.** Open-Meteo's `/v1/warnings` is now wired up:
+      alerts feed into `BuildPrompt`, and SEVERE / EXTREME alerts also fire a
+      separate high-priority notification on a dedicated channel.
 - [ ] **Hourly / multi-day forecast UI** on Today. Currently Today only shows
       the latest insight; useful to see the underlying data the LLM saw.
 - [ ] **Forecast accuracy & multi-model ideas** — confidence badge from


### PR DESCRIPTION
## Summary

- Adds a `WeatherAlert` domain model with a CAP-aligned `AlertSeverity` ladder (`MINOR`/`MODERATE`/`SEVERE`/`EXTREME`/`UNKNOWN`).
- `OpenMeteoClient` now makes a second call to `/v1/warnings` after the daily forecast and returns the alerts on `ForecastBundle.alerts`. The warnings call is best-effort: any failure (network, 4xx, 5xx, malformed JSON) falls back to an empty list rather than failing the whole forecast.
- `BuildPrompt` learns a new rule (rule 1, ahead of temperature/wardrobe/precipitation): if any active alert is `SEVERE` or `EXTREME`, emit `"Alert: <event>."` for the highest-severity one.
- `GenerateDailyInsight` now returns a `DailyInsightResult` (insight + active alerts) so the worker can drive both the daily delivery and a separate alert path. Expired alerts (`expires < now`) are filtered out at this layer.
- New `WeatherAlertNotifier` posts SEVERE/EXTREME alerts on a dedicated `weather_alerts_v1` channel at `IMPORTANCE_MAX` with category `CATEGORY_ALARM`. Stable per-alert ID derived from event + onset so repeated fetches update in place while distinct alerts stack.
- Reuses the existing `POST_NOTIFICATIONS` grant — **no new permissions**.

## Test plan

- [ ] CI green: `:core:domain:test`, `:core:data:test`, `:app:testDebugUnitTest`, `:app:assembleDebug`.
- [ ] Manual: stub `/v1/warnings` to return a SEVERE alert, run "Fire insight now" from debug Settings, confirm:
  - [ ] A high-priority notification appears on the new "Severe weather alerts" channel.
  - [ ] The daily insight body mentions the alert event.
  - [ ] Toggling the alerts channel off in system Settings does not affect the daily-insight channel.
- [ ] Manual: simulate `/v1/warnings` returning HTTP 500 — confirm the daily insight still posts normally with no alert side-effects.

https://claude.ai/code/session_01WwpdcsjPGt7Hv9kF9msy1v

---
_Generated by [Claude Code](https://claude.ai/code/session_01WwpdcsjPGt7Hv9kF9msy1v)_