### PR TITLE
Forecast chart respects the C/F preference

### DIFF
--- a/app/src/main/kotlin/com/adaptweather/MainActivity.kt
+++ b/app/src/main/kotlin/com/adaptweather/MainActivity.kt
@@ -57,6 +57,7 @@ private fun AdaptWeatherNav(app: AdaptWeatherApplication) {
                 factory = TodayViewModel.Factory(
                     insightCache = app.insightCache,
                     workManager = WorkManager.getInstance(app),
+                    settingsRepository = app.settingsRepository,
                 ),
             )
             TodayScreen(

--- a/app/src/main/kotlin/com/adaptweather/ui/today/ForecastChart.kt
+++ b/app/src/main/kotlin/com/adaptweather/ui/today/ForecastChart.kt
@@ -8,6 +8,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.adaptweather.core.domain.model.HourlyForecast
+import com.adaptweather.core.domain.model.TemperatureUnit
+import com.adaptweather.core.domain.model.toUnit
 import com.patrykandpatrick.vico.compose.cartesian.CartesianChartHost
 import com.patrykandpatrick.vico.compose.cartesian.axis.rememberBottom
 import com.patrykandpatrick.vico.compose.cartesian.axis.rememberStart
@@ -26,6 +28,11 @@ import com.patrykandpatrick.vico.core.cartesian.data.lineSeries
  * worker. When the cache predates this feature, [hourly] is empty and the chart
  * hides itself — the next worker run will fill it in.
  *
+ * Underlying values are always Celsius (that's what HourlyForecast carries);
+ * we convert at the edge with [toUnit] so the chart matches the user's
+ * temperatureUnit preference. The legend, rendered by the parent, carries the
+ * unit symbol — the axis stays unitless to avoid "10°C, 15°C, 20°C" repetition.
+ *
  * Series order:
  *   0 — raw 2 m air temperature
  *   1 — apparent / feels-like
@@ -35,16 +42,17 @@ import com.patrykandpatrick.vico.core.cartesian.data.lineSeries
 @Composable
 fun ForecastChart(
     hourly: List<HourlyForecast>,
+    temperatureUnit: TemperatureUnit,
     modifier: Modifier = Modifier,
 ) {
     if (hourly.isEmpty()) return
 
     val producer = remember { CartesianChartModelProducer() }
-    LaunchedEffect(hourly) {
+    LaunchedEffect(hourly, temperatureUnit) {
         producer.runTransaction {
             lineSeries {
-                series(hourly.map { it.temperatureC })
-                series(hourly.map { it.feelsLikeC })
+                series(hourly.map { it.temperatureC.toUnit(temperatureUnit) })
+                series(hourly.map { it.feelsLikeC.toUnit(temperatureUnit) })
             }
         }
     }

--- a/app/src/main/kotlin/com/adaptweather/ui/today/TodayScreen.kt
+++ b/app/src/main/kotlin/com/adaptweather/ui/today/TodayScreen.kt
@@ -36,6 +36,8 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.adaptweather.R
 import com.adaptweather.core.domain.model.HourlyForecast
 import com.adaptweather.core.domain.model.Insight
+import com.adaptweather.core.domain.model.TemperatureUnit
+import com.adaptweather.core.domain.model.symbol
 import com.adaptweather.work.FetchAndNotifyWorker
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.size
@@ -95,7 +97,7 @@ private fun TodayContent(
         } else {
             InsightCard(state.insight)
             if (state.insight.hourly.isNotEmpty()) {
-                ForecastCard(state.insight.hourly)
+                ForecastCard(state.insight.hourly, state.temperatureUnit)
             }
         }
     }
@@ -232,7 +234,7 @@ private fun InsightCard(insight: Insight) {
 }
 
 @Composable
-private fun ForecastCard(hourly: List<HourlyForecast>) {
+private fun ForecastCard(hourly: List<HourlyForecast>, temperatureUnit: TemperatureUnit) {
     Card(modifier = Modifier.fillMaxWidth()) {
         Column(
             modifier = Modifier.padding(20.dp),
@@ -242,9 +244,9 @@ private fun ForecastCard(hourly: List<HourlyForecast>) {
                 text = stringResource(R.string.today_forecast_title),
                 style = MaterialTheme.typography.titleSmall,
             )
-            ForecastChart(hourly = hourly)
+            ForecastChart(hourly = hourly, temperatureUnit = temperatureUnit)
             Text(
-                text = stringResource(R.string.today_forecast_legend),
+                text = stringResource(R.string.today_forecast_legend, temperatureUnit.symbol()),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )

--- a/app/src/main/kotlin/com/adaptweather/ui/today/TodayViewModel.kt
+++ b/app/src/main/kotlin/com/adaptweather/ui/today/TodayViewModel.kt
@@ -6,7 +6,9 @@ import androidx.lifecycle.viewModelScope
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import com.adaptweather.core.domain.model.Insight
+import com.adaptweather.core.domain.model.TemperatureUnit
 import com.adaptweather.data.InsightCache
+import com.adaptweather.data.SettingsRepository
 import com.adaptweather.work.FetchAndNotifyWorker
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -16,6 +18,7 @@ import kotlinx.coroutines.flow.stateIn
 data class TodayState(
     val insight: Insight? = null,
     val workStatus: WorkStatus = WorkStatus.Idle,
+    val temperatureUnit: TemperatureUnit = TemperatureUnit.CELSIUS,
 )
 
 sealed class WorkStatus {
@@ -27,12 +30,18 @@ sealed class WorkStatus {
 class TodayViewModel(
     insightCache: InsightCache,
     workManager: WorkManager,
+    settingsRepository: SettingsRepository,
 ) : ViewModel() {
     val state: StateFlow<TodayState> = combine(
         insightCache.latest,
         workManager.getWorkInfosForUniqueWorkFlow(FetchAndNotifyWorker.UNIQUE_WORK_NAME),
-    ) { insight, workInfos ->
-        TodayState(insight = insight, workStatus = workInfos.toStatus())
+        settingsRepository.preferences,
+    ) { insight, workInfos, prefs ->
+        TodayState(
+            insight = insight,
+            workStatus = workInfos.toStatus(),
+            temperatureUnit = prefs.temperatureUnit,
+        )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), TodayState())
 
     private fun List<WorkInfo>.toStatus(): WorkStatus {
@@ -53,13 +62,14 @@ class TodayViewModel(
     class Factory(
         private val insightCache: InsightCache,
         private val workManager: WorkManager,
+        private val settingsRepository: SettingsRepository,
     ) : ViewModelProvider.Factory {
         @Suppress("UNCHECKED_CAST")
         override fun <T : ViewModel> create(modelClass: Class<T>): T {
             require(modelClass.isAssignableFrom(TodayViewModel::class.java)) {
                 "Unknown ViewModel: ${modelClass.name}"
             }
-            return TodayViewModel(insightCache, workManager) as T
+            return TodayViewModel(insightCache, workManager, settingsRepository) as T
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,7 +13,7 @@
     <string name="today_generated_at">Generated at %1$s</string>
 
     <string name="today_forecast_title">Hourly forecast</string>
-    <string name="today_forecast_legend">Temperature and feels-like by hour</string>
+    <string name="today_forecast_legend">Temperature and feels-like (%1$s) by hour</string>
 
     <string name="today_working">Working — fetching forecast and generating today\'s insight…</string>
     <string name="today_failed_title">Last attempt failed</string>


### PR DESCRIPTION
## Summary
- `TodayViewModel` now combines `settingsRepository.preferences` alongside the existing `InsightCache.latest` and WorkManager flow. `TodayState` carries `temperatureUnit`.
- `ForecastChart` takes a `TemperatureUnit` and converts the stored Celsius values via the existing `Double.toUnit(unit)` helper at render time.
- Legend interpolates the unit symbol — Fahrenheit users see `(°F)` instead of nothing.

## Why
Follow-up to PR #34 review (Copilot pointed out the previous legend hardcoded `(°C)` while the C/F preference existed; that PR removed the unit from the legend as a stop-gap).

## Notes
- Axis labels stay unitless: repeating "°C" / "°F" on every gridline is visual noise; the legend states the unit once.
- `LaunchedEffect(hourly, temperatureUnit)` re-runs the producer transaction when either changes, so a unit toggle in Settings live-updates the chart on return.

## Test plan
- [ ] `./gradlew :app:testDebugUnitTest :core:domain:test` should still pass — `TodayViewModel`'s constructor changed but no existing test uses it.
- [ ] Set `Settings → Temperature unit → Fahrenheit`, return to Today: chart values shift (multiplied by 9/5 + 32) and legend reads `(°F)`.
- [ ] Toggle back to Celsius without leaving the app: chart re-renders with °C values and legend.

https://claude.ai/code/session_01Fc6RXbcUJ2o19deQXb2NpN

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fc6RXbcUJ2o19deQXb2NpN)_