### PR TITLE
:core + :app — multi-model confidence badge on Today

### DIFF
--- a/app/src/main/kotlin/com/adaptweather/ui/today/TodayScreen.kt
+++ b/app/src/main/kotlin/com/adaptweather/ui/today/TodayScreen.kt
@@ -34,6 +34,8 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.adaptweather.R
+import com.adaptweather.core.domain.model.ConfidenceInfo
+import com.adaptweather.core.domain.model.ForecastConfidence
 import com.adaptweather.core.domain.model.HourlyForecast
 import com.adaptweather.core.domain.model.Insight
 import com.adaptweather.work.FetchAndNotifyWorker
@@ -205,6 +207,7 @@ private fun InsightCard(insight: Insight) {
                 style = MaterialTheme.typography.labelLarge,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
+            insight.confidence?.let { ConfidenceChip(it) }
             Text(
                 text = insight.summary,
                 style = MaterialTheme.typography.headlineSmall,
@@ -226,6 +229,51 @@ private fun InsightCard(insight: Insight) {
                 ),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+/**
+ * Compact "How sure are we?" chip rendered inside [InsightCard]. Background color
+ * tracks the level so the user gets the cue at a glance — green-ish for HIGH,
+ * neutral for MEDIUM, error-tinted for LOW. Detail text shows the actual spread
+ * across the consulted models so the user can judge for themselves.
+ */
+@Composable
+private fun ConfidenceChip(info: ConfidenceInfo) {
+    val (bgColor, fgColor) = when (info.level) {
+        ForecastConfidence.HIGH -> MaterialTheme.colorScheme.secondaryContainer to
+            MaterialTheme.colorScheme.onSecondaryContainer
+        ForecastConfidence.MEDIUM -> MaterialTheme.colorScheme.surfaceVariant to
+            MaterialTheme.colorScheme.onSurfaceVariant
+        ForecastConfidence.LOW -> MaterialTheme.colorScheme.errorContainer to
+            MaterialTheme.colorScheme.onErrorContainer
+    }
+    val labelRes = when (info.level) {
+        ForecastConfidence.HIGH -> R.string.today_confidence_high
+        ForecastConfidence.MEDIUM -> R.string.today_confidence_medium
+        ForecastConfidence.LOW -> R.string.today_confidence_low
+    }
+    Card(
+        colors = CardDefaults.cardColors(containerColor = bgColor, contentColor = fgColor),
+    ) {
+        Column(
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(2.dp),
+        ) {
+            Text(
+                text = stringResource(labelRes),
+                style = MaterialTheme.typography.labelLarge,
+            )
+            Text(
+                text = stringResource(
+                    R.string.today_confidence_spread,
+                    info.tempSpreadC,
+                    info.precipSpreadPp,
+                    info.modelsConsulted.size,
+                ),
+                style = MaterialTheme.typography.bodySmall,
             )
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,6 +15,11 @@
     <string name="today_forecast_title">Hourly forecast</string>
     <string name="today_forecast_legend">Temperature and feels-like by hour</string>
 
+    <string name="today_confidence_high">High confidence — major models agree</string>
+    <string name="today_confidence_medium">Medium confidence</string>
+    <string name="today_confidence_low">Low confidence — forecasts disagree</string>
+    <string name="today_confidence_spread">Spread: %1$.1f°C, %2$.0fpp precip across %3$d models</string>
+
     <string name="today_working">Working — fetching forecast and generating today\'s insight…</string>
     <string name="today_failed_title">Last attempt failed</string>
     <string name="today_failed_missing_api_key">No Gemini API key configured. Set one in Settings.</string>

--- a/core/data/src/main/kotlin/com/adaptweather/core/data/weather/MultiModelConfidenceFetcher.kt
+++ b/core/data/src/main/kotlin/com/adaptweather/core/data/weather/MultiModelConfidenceFetcher.kt
@@ -1,0 +1,120 @@
+package com.adaptweather.core.data.weather
+
+import com.adaptweather.core.domain.model.ConfidenceInfo
+import com.adaptweather.core.domain.model.ForecastConfidence
+import com.adaptweather.core.domain.model.Location
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import io.ktor.client.request.parameter
+import io.ktor.http.URLProtocol
+import io.ktor.http.path
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Fetches today's apparent-max temperature and peak precipitation probability from
+ * several Open-Meteo models in parallel, computes the cross-model spread, and maps
+ * to a [ConfidenceInfo]. When the major models agree, we surface "High confidence";
+ * when they disagree, "Low confidence — forecasts disagree".
+ *
+ * Best-effort: any failure (network, model unavailable, parse error) falls through
+ * to a null result. The user still gets the daily forecast — just no confidence
+ * badge.
+ *
+ * Each model call requests only the two daily fields we need, so the responses are
+ * tiny.
+ */
+internal class MultiModelConfidenceFetcher(
+    private val httpClient: HttpClient,
+    private val models: List<String> = DEFAULT_MODELS,
+) {
+    suspend fun fetch(location: Location): ConfidenceInfo? = try {
+        coroutineScope {
+            val results = models.map { model ->
+                async { runCatching { fetchOne(location, model) }.getOrNull()?.let { model to it } }
+            }.awaitAll().filterNotNull()
+
+            // Need at least two models to compute a spread.
+            if (results.size < 2) null else compute(results)
+        }
+    } catch (ce: CancellationException) {
+        throw ce
+    } catch (_: Throwable) {
+        null
+    }
+
+    private suspend fun fetchOne(location: Location, model: String): ModelDailyValues? {
+        val response: ConfidenceResponse = httpClient.get {
+            url {
+                protocol = URLProtocol.HTTPS
+                host = OPEN_METEO_HOST
+                path("v1", "forecast")
+            }
+            parameter("latitude", location.latitude)
+            parameter("longitude", location.longitude)
+            parameter("forecast_days", 1)
+            parameter("timezone", "auto")
+            parameter("daily", "apparent_temperature_max,precipitation_probability_max")
+            parameter("models", model)
+        }.body()
+
+        // Index 0 is today (no past_days requested). Empty array or null entry → unusable.
+        val tempMax = response.daily.feelsLikeMax.firstOrNull() ?: return null
+        val precipMax = response.daily.precipitationProbabilityMax.firstOrNull()?.toDouble() ?: return null
+        return ModelDailyValues(tempMax, precipMax)
+    }
+
+    private fun compute(results: List<Pair<String, ModelDailyValues>>): ConfidenceInfo {
+        val temps = results.map { it.second.tempMaxC }
+        val precips = results.map { it.second.precipMaxPp }
+        val tempSpread = temps.max() - temps.min()
+        val precipSpread = precips.max() - precips.min()
+
+        val level = when {
+            tempSpread <= TEMP_HIGH_AGREEMENT_C && precipSpread <= PRECIP_HIGH_AGREEMENT_PP ->
+                ForecastConfidence.HIGH
+            tempSpread <= TEMP_MEDIUM_AGREEMENT_C && precipSpread <= PRECIP_MEDIUM_AGREEMENT_PP ->
+                ForecastConfidence.MEDIUM
+            else -> ForecastConfidence.LOW
+        }
+
+        return ConfidenceInfo(
+            level = level,
+            tempSpreadC = tempSpread,
+            precipSpreadPp = precipSpread,
+            modelsConsulted = results.map { it.first },
+        )
+    }
+
+    private data class ModelDailyValues(val tempMaxC: Double, val precipMaxPp: Double)
+
+    companion object {
+        // Three models with global coverage so the spread is meaningful regardless of
+        // where the user is. Could be made user-tunable later (MODELS.md idea).
+        val DEFAULT_MODELS = listOf("ecmwf_ifs04", "gfs_seamless", "icon_seamless")
+
+        // Thresholds are deliberate first-pass guesses; refine with real data.
+        // Both temp and precip have to clear the bar for HIGH; either dropping
+        // moves us down a tier.
+        internal const val TEMP_HIGH_AGREEMENT_C = 1.5
+        internal const val TEMP_MEDIUM_AGREEMENT_C = 3.0
+        internal const val PRECIP_HIGH_AGREEMENT_PP = 15.0
+        internal const val PRECIP_MEDIUM_AGREEMENT_PP = 30.0
+    }
+}
+
+@Serializable
+private data class ConfidenceResponse(
+    @SerialName("daily") val daily: ConfidenceDaily,
+)
+
+@Serializable
+private data class ConfidenceDaily(
+    @SerialName("apparent_temperature_max") val feelsLikeMax: List<Double?>,
+    @SerialName("precipitation_probability_max") val precipitationProbabilityMax: List<Int?>,
+)

--- a/core/data/src/main/kotlin/com/adaptweather/core/data/weather/OpenMeteoClient.kt
+++ b/core/data/src/main/kotlin/com/adaptweather/core/data/weather/OpenMeteoClient.kt
@@ -30,13 +30,12 @@ internal const val OPEN_METEO_HOST = "api.open-meteo.com"
  * forecast calls in parallel. Same best-effort policy: confidence is null when the
  * extra calls fail.
  */
-class OpenMeteoClient(
-    private val httpClient: HttpClient,
-    confidenceFetcher: MultiModelConfidenceFetcher? = null,
-) : WeatherRepository {
+class OpenMeteoClient(private val httpClient: HttpClient) : WeatherRepository {
 
-    private val confidenceFetcher: MultiModelConfidenceFetcher =
-        confidenceFetcher ?: MultiModelConfidenceFetcher(httpClient)
+    // Constructed once per client. Exposing it on the public constructor would
+    // leak the internal type; if we ever need a test seam, add an internal-only
+    // secondary constructor instead.
+    private val confidenceFetcher = MultiModelConfidenceFetcher(httpClient)
 
     override suspend fun fetchForecast(location: Location): ForecastBundle = coroutineScope {
         // Primary forecast and the side-band fetches all kick off in parallel — confidence

--- a/core/data/src/main/kotlin/com/adaptweather/core/data/weather/OpenMeteoClient.kt
+++ b/core/data/src/main/kotlin/com/adaptweather/core/data/weather/OpenMeteoClient.kt
@@ -11,6 +11,8 @@ import io.ktor.client.request.parameter
 import io.ktor.http.URLProtocol
 import io.ktor.http.path
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 
 internal const val OPEN_METEO_HOST = "api.open-meteo.com"
 
@@ -23,10 +25,36 @@ internal const val OPEN_METEO_HOST = "api.open-meteo.com"
  * is best-effort: if it fails (4xx, 5xx, network), we return the forecast with an empty
  * alerts list rather than failing the whole fetch — a missing alerts feed must not
  * suppress the daily insight.
+ *
+ * Cross-model confidence is computed by a third path that fires several model-specific
+ * forecast calls in parallel. Same best-effort policy: confidence is null when the
+ * extra calls fail.
  */
-class OpenMeteoClient(private val httpClient: HttpClient) : WeatherRepository {
-    override suspend fun fetchForecast(location: Location): ForecastBundle {
-        val response: OpenMeteoResponse = httpClient.get {
+class OpenMeteoClient(
+    private val httpClient: HttpClient,
+    confidenceFetcher: MultiModelConfidenceFetcher? = null,
+) : WeatherRepository {
+
+    private val confidenceFetcher: MultiModelConfidenceFetcher =
+        confidenceFetcher ?: MultiModelConfidenceFetcher(httpClient)
+
+    override suspend fun fetchForecast(location: Location): ForecastBundle = coroutineScope {
+        // Primary forecast and the side-band fetches all kick off in parallel — confidence
+        // adds three more model calls, so doing them concurrently with the alerts call
+        // hides their latency behind the primary fetch.
+        val primary = async { fetchPrimary(location) }
+        val alerts = async { fetchAlerts(location) }
+        val confidence = async { confidenceFetcher.fetch(location) }
+
+        val bundle = OpenMeteoMapper.toBundle(primary.await())
+        bundle.copy(
+            alerts = alerts.await(),
+            confidence = confidence.await(),
+        )
+    }
+
+    private suspend fun fetchPrimary(location: Location): OpenMeteoResponse =
+        httpClient.get {
             url {
                 protocol = URLProtocol.HTTPS
                 host = OPEN_METEO_HOST
@@ -47,10 +75,6 @@ class OpenMeteoClient(private val httpClient: HttpClient) : WeatherRepository {
                 "temperature_2m,apparent_temperature,precipitation_probability,weather_code",
             )
         }.body()
-
-        val bundle = OpenMeteoMapper.toBundle(response)
-        return bundle.copy(alerts = fetchAlerts(location))
-    }
 
     private suspend fun fetchAlerts(location: Location): List<WeatherAlert> = try {
         val response: OpenMeteoWarningsResponse = httpClient.get {

--- a/core/data/src/test/kotlin/com/adaptweather/core/data/weather/OpenMeteoClientTest.kt
+++ b/core/data/src/test/kotlin/com/adaptweather/core/data/weather/OpenMeteoClientTest.kt
@@ -80,7 +80,12 @@ class OpenMeteoClientTest {
 
         client.fetchForecast(london)
 
-        val forecastReq = captured.first { it.url.encodedPath == "/v1/forecast" }
+        // The confidence fetcher also calls /v1/forecast (3x, one per model) with
+        // a different param shape (no past_days). Pick out the primary call by
+        // looking for past_days=1 so this test isn't sensitive to async ordering.
+        val forecastReq = captured.first {
+            it.url.encodedPath == "/v1/forecast" && it.url.parameters["past_days"] == "1"
+        }
         forecastReq.url.host shouldBe OPEN_METEO_HOST
 
         val params = forecastReq.url.parameters

--- a/core/domain/src/main/kotlin/com/adaptweather/core/domain/model/ConfidenceInfo.kt
+++ b/core/domain/src/main/kotlin/com/adaptweather/core/domain/model/ConfidenceInfo.kt
@@ -1,0 +1,25 @@
+package com.adaptweather.core.domain.model
+
+/**
+ * Cross-model agreement signal. Open-Meteo aggregates several national weather
+ * services (ECMWF, DWD ICON, NOAA GFS, Météo-France, …) under one API; the same
+ * endpoint accepts `&models=…` and returns each requested model side-by-side.
+ *
+ * When the major models *disagree* — say, one says 18 °C and another says 23 °C
+ * — the forecast is least trustworthy. Surfacing that as a confidence level on
+ * Today is actionable information we get for free; the user has a cue to check
+ * again later or hedge their wardrobe choice.
+ *
+ * Idea sketched in [docs/MODELS.md](../../../../../../../../docs/MODELS.md) #1.
+ */
+data class ConfidenceInfo(
+    val level: ForecastConfidence,
+    /** Max - min of today's apparent-max temperature across the consulted models, °C. */
+    val tempSpreadC: Double,
+    /** Max - min of today's peak precipitation probability across the consulted models, percentage points. */
+    val precipSpreadPp: Double,
+    /** Open-Meteo model ids that contributed (e.g. `ecmwf_ifs04`, `gfs_seamless`). */
+    val modelsConsulted: List<String>,
+)
+
+enum class ForecastConfidence { HIGH, MEDIUM, LOW }

--- a/core/domain/src/main/kotlin/com/adaptweather/core/domain/model/Insight.kt
+++ b/core/domain/src/main/kotlin/com/adaptweather/core/domain/model/Insight.kt
@@ -15,6 +15,12 @@ data class Insight(
     val generatedAt: Instant,
     val forDate: LocalDate,
     val hourly: List<HourlyForecast> = emptyList(),
+    /**
+     * Cross-model agreement at fetch time, when available. Null when the
+     * multi-model confidence call failed or the implementation doesn't compute
+     * it. UI should treat null as "unknown" rather than "high".
+     */
+    val confidence: ConfidenceInfo? = null,
 ) {
     /**
      * The text that gets spoken aloud. The LLM is told to weave the items into its

--- a/core/domain/src/main/kotlin/com/adaptweather/core/domain/repository/WeatherRepository.kt
+++ b/core/domain/src/main/kotlin/com/adaptweather/core/domain/repository/WeatherRepository.kt
@@ -1,5 +1,6 @@
 package com.adaptweather.core.domain.repository
 
+import com.adaptweather.core.domain.model.ConfidenceInfo
 import com.adaptweather.core.domain.model.DailyForecast
 import com.adaptweather.core.domain.model.Location
 import com.adaptweather.core.domain.model.WeatherAlert
@@ -12,6 +13,9 @@ import com.adaptweather.core.domain.model.WeatherAlert
  * Severe-weather alerts are returned alongside the forecast in [ForecastBundle.alerts].
  * Implementations should treat the alerts feed as best-effort: a failure to fetch
  * warnings must not fail the whole forecast call — return an empty list instead.
+ *
+ * Cross-model confidence ([ForecastBundle.confidence]) is also best-effort: implementations
+ * may return null when the multi-model fetch fails or isn't supported.
  */
 interface WeatherRepository {
     suspend fun fetchForecast(location: Location): ForecastBundle
@@ -21,6 +25,7 @@ data class ForecastBundle(
     val today: DailyForecast,
     val yesterday: DailyForecast,
     val alerts: List<WeatherAlert> = emptyList(),
+    val confidence: ConfidenceInfo? = null,
 ) {
     init {
         require(yesterday.date.isBefore(today.date)) {

--- a/core/domain/src/main/kotlin/com/adaptweather/core/domain/usecase/GenerateDailyInsight.kt
+++ b/core/domain/src/main/kotlin/com/adaptweather/core/domain/usecase/GenerateDailyInsight.kt
@@ -51,6 +51,7 @@ class GenerateDailyInsight(
             generatedAt = clock.instant(),
             forDate = bundle.today.date,
             hourly = bundle.today.hourly,
+            confidence = bundle.confidence,
         )
         return DailyInsightResult(insight = insight, alerts = activeAlerts)
     }

--- a/docs/MODELS.md
+++ b/docs/MODELS.md
@@ -33,7 +33,7 @@ information we can surface, and it's free.
 
 ## Ideas
 
-### 1. Multi-model "forecast confidence" badge
+### 1. Multi-model "forecast confidence" badge ✅ shipped
 
 Fetch 3-5 models in the daily forecast call. Compute disagreement (e.g.
 range of `temperature_2m_max` across models, or stdev of
@@ -48,6 +48,14 @@ check again before heading out" to the daily prose. Otherwise stay quiet.
 
 Cost: free (one Open-Meteo call, a bit more JSON).
 Complexity: small (parse extra arrays + a confidence helper).
+
+**As shipped:** three parallel calls to ECMWF (`ecmwf_ifs04`), GFS
+(`gfs_seamless`), and DWD ICON (`icon_seamless`) — each requesting only
+`apparent_temperature_max` and `precipitation_probability_max`. Best-effort:
+any failure falls through to a null badge. Thresholds in
+`MultiModelConfidenceFetcher` are first-pass guesses (≤1.5°C/15pp = HIGH,
+≤3°C/30pp = MEDIUM, else LOW); refine with real data. The "feed into
+LLM prompt" half is still TODO.
 
 ### 2. End-of-day accuracy survey
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -49,14 +49,15 @@ Code TODOs in source files are linked from here when they exist.
 - [x] **Severe weather alerts.** Open-Meteo's `/v1/warnings` is now wired up:
       alerts feed into `BuildPrompt`, and SEVERE / EXTREME alerts also fire a
       separate high-priority notification on a dedicated channel.
-- [ ] **Hourly / multi-day forecast UI** on Today. Currently Today only shows
-      the latest insight; useful to see the underlying data the LLM saw.
-- [ ] **Forecast accuracy & multi-model ideas** — confidence badge from
-      multi-model disagreement, end-of-day accuracy survey, user-flagged
+- [x] **Hourly forecast UI** on Today. Vico chart of temperature + feels-like
+      across today's hours. Multi-day extension still possible.
+- [ ] **Forecast accuracy ideas** — end-of-day accuracy survey, user-flagged
       incorrect forecasts, background multi-provider comparison. Sketched in
-      [docs/MODELS.md](MODELS.md). Idea 1 (confidence badge) is cheapest,
-      builds on data Open-Meteo already returns when you ask for several
-      models in one call.
+      [docs/MODELS.md](MODELS.md) (ideas 2-4). Idea 1 (confidence badge)
+      shipped — see below.
+- [x] **Multi-model confidence badge** (MODELS.md idea #1) — Today shows
+      a chip indicating how much ECMWF / GFS / ICON disagree about today's
+      apparent high and peak precip probability.
 
 ## Feature ideas (queued)
 


### PR DESCRIPTION
## Summary

Makes [`MODELS.md` idea #1](docs/MODELS.md) real. The forecast fetch now also kicks off three small parallel calls — one each to **ECMWF** (`ecmwf_ifs04`), **NOAA GFS** (`gfs_seamless`), and **DWD ICON** (`icon_seamless`) — each requesting only today's `apparent_temperature_max` and `precipitation_probability_max`. Spread across the responses maps to a `HIGH` / `MEDIUM` / `LOW` `ForecastConfidence` level surfaced as a chip on Today.

### Why

Open-Meteo aggregates several national weather services under one API and lets the caller pick which model(s) to use. We were taking the default `best_match` and throwing away the rest. **When the major models disagree, the forecast is least trustworthy** — actionable signal the user now sees.

### Mechanics

- New `:core:domain` types: `ConfidenceInfo` + `ForecastConfidence` enum.
- `ForecastBundle` gains an optional `confidence`; `Insight` does too. Both default null so existing call sites compile unchanged.
- `:core:data/weather/MultiModelConfidenceFetcher` runs the three model calls in parallel via `async`/`coroutineScope`, computes max-min spread on the two daily fields, maps to a level via threshold tables: `≤1.5°C and ≤15pp = HIGH`, `≤3°C and ≤30pp = MEDIUM`, else `LOW`. Best-effort: any failure → null confidence, daily forecast unaffected. Thresholds are deliberate first-pass guesses; refine with real data.
- `OpenMeteoClient.fetchForecast` wraps primary forecast + alerts + confidence in `coroutineScope`/`async` so the side fetches hide their latency behind the primary call.
- Today's `InsightCard` renders a small chip below the date — green-ish for HIGH, neutral for MEDIUM, error-tinted for LOW. Subtitle shows the actual spread numbers and the model count so the user can judge for themselves.
- `OpenMeteoClientTest` filters by `past_days=1` to find the primary fetch amongst the new model-specific forecast calls (otherwise the test would race-pick whichever `/v1/forecast` request landed first).
- `docs/TODO.md` ticks the forecast-UI item (already shipped) and the confidence-badge; `docs/MODELS.md` marks idea #1 as shipped.

### Deferred

- **Feed low-confidence into the LLM prompt** ("Forecasts disagree today — check again before heading out"). The chip is the higher-leverage piece; the prompt half can iterate after real-world feedback on the threshold tables.
- **User-tunable model list** — currently hardcoded to ECMWF / GFS / ICON.

## Test plan

- [ ] CI green
- [ ] Sideload, tap Refresh on Today
  - When models agree: chip shows "High confidence — major models agree" with small spread numbers.
  - When models disagree: chip shows "Low confidence — forecasts disagree" with larger spread.
- [ ] Force a confidence-fetch failure (airplane mode mid-fetch is awkward; easiest is to confirm the chip simply doesn't render — the daily forecast still works.)

https://claude.ai/code/session_01VftWR7DyaaVXHnovkuQwge

---
_Generated by [Claude Code](https://claude.ai/code/session_01VftWR7DyaaVXHnovkuQwge)_