### PR TITLE
ci: clean up prior failure comments on each PR run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,31 @@ jobs:
           set -o pipefail
           ./gradlew :core:domain:test :core:data:test :app:testDebugUnitTest --stacktrace --info 2>&1 | tee /tmp/jvm-tests.log
 
+      - name: Clear prior CI comments for this job
+        # Runs on both pass and fail. A green run on a fix commit removes the
+        # earlier failure comment, so the PR conversation doesn't accumulate
+        # stale stack traces every time someone pushes a typo and then fixes it.
+        # Skipped on cancellation so a manually-cancelled run doesn't wipe the
+        # comment from a still-real failure.
+        if: ${{ !cancelled() && github.event_name == 'pull_request' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = '<!-- ci-jvm-tests -->';
+            const { data: comments } = await github.rest.issues.listComments({
+              ...context.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+            for (const c of comments) {
+              if (c.user.type === 'Bot' && c.body && c.body.includes(marker)) {
+                await github.rest.issues.deleteComment({
+                  ...context.repo,
+                  comment_id: c.id,
+                });
+              }
+            }
+
       - name: Post tail of gradle log on failure
         if: failure() && github.event_name == 'pull_request'
         uses: actions/github-script@v7
@@ -116,6 +141,28 @@ jobs:
         run: |
           set -o pipefail
           ./gradlew :app:assembleDebug --stacktrace --info 2>&1 | tee /tmp/android-build.log
+
+      - name: Clear prior CI comments for this job
+        # Same rationale as the JVM job — drops stale failure comments on a
+        # clean re-run so the PR doesn't accumulate.
+        if: ${{ !cancelled() && github.event_name == 'pull_request' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = '<!-- ci-android-build -->';
+            const { data: comments } = await github.rest.issues.listComments({
+              ...context.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+            for (const c of comments) {
+              if (c.user.type === 'Bot' && c.body && c.body.includes(marker)) {
+                await github.rest.issues.deleteComment({
+                  ...context.repo,
+                  comment_id: c.id,
+                });
+              }
+            }
 
       - name: Post tail of gradle log on failure
         if: failure() && github.event_name == 'pull_request'


### PR DESCRIPTION
## Summary

Each failed CI run was leaving a stack-trace comment on the PR, and nothing ever cleaned them up. A typo + fix cycle would bury the conversation under historical failures even though the head commit was green.

New step in each CI job runs after the gradle invocation and deletes any prior bot comments carrying that job's marker (`<!-- ci-jvm-tests -->` / `<!-- ci-android-build -->`). The existing failure-post step is unchanged; the cleanup just runs first.

### Behaviour

| Scenario | Cleanup runs? | New comment posted? | Net effect |
|---|---|---|---|
| Run passes | Yes | No | Any prior failure comment removed; PR stays clean. |
| Run fails | Yes | Yes | Old failure comment removed, fresh one posted. |
| Run cancelled | No | No | Existing comments left alone (don't wipe a still-real failure). |

### Safety

- Filters by `user.type === 'Bot'` — humans can quote the marker text in conversation without their comments getting nuked.
- Permission already granted at job level (`pull-requests: write`).
- One marker per check so the JVM and Android jobs don't interfere with each other.

## Test plan

- [ ] CI green on this PR
- [ ] Open a follow-up PR with a deliberate compile error → CI posts failure comment as before
- [ ] Push a fix → on the green re-run, the failure comment disappears
- [ ] Open a follow-up PR with a passing first run → no comment ever posted

https://claude.ai/code/session_01VftWR7DyaaVXHnovkuQwge

---
_Generated by [Claude Code](https://claude.ai/code/session_01VftWR7DyaaVXHnovkuQwge)_