### PR TITLE
ci + :app — stable debug-keystore signing from GitHub Secrets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,8 +144,32 @@ jobs:
         with:
           cache-read-only: ${{ github.ref != 'refs/heads/main' }}
 
+      - name: Decode debug keystore from secret
+        # Stable signing identity across CI builds so the installed app upgrades
+        # in place instead of failing "App not installed (signature mismatch)"
+        # on every new APK. If the secret isn't set (e.g. a PR from a fork
+        # without secret access, or a fresh repo before the secret is added),
+        # the step quietly no-ops and AGP falls back to its auto-generated
+        # debug keystore — the build still works, you just lose in-place
+        # upgrades on the next install.
+        env:
+          DEBUG_KEYSTORE_BASE64: ${{ secrets.DEBUG_KEYSTORE_BASE64 }}
+        run: |
+          if [ -z "$DEBUG_KEYSTORE_BASE64" ]; then
+            echo "No DEBUG_KEYSTORE_BASE64 secret available; build will use AGP-default debug keystore."
+            exit 0
+          fi
+          echo "$DEBUG_KEYSTORE_BASE64" | base64 -d > /tmp/debug.keystore
+          # Sanity check the decoded file is a real keystore, not random bytes.
+          test -s /tmp/debug.keystore
+          echo "DEBUG_KEYSTORE_FILE=/tmp/debug.keystore" >> "$GITHUB_ENV"
+
       - name: Assemble debug APK
         id: gradle
+        env:
+          DEBUG_KEYSTORE_PASSWORD: ${{ secrets.DEBUG_KEYSTORE_PASSWORD }}
+          DEBUG_KEY_ALIAS: ${{ secrets.DEBUG_KEY_ALIAS }}
+          DEBUG_KEY_PASSWORD: ${{ secrets.DEBUG_KEY_PASSWORD }}
         run: |
           set -o pipefail
           ./gradlew :app:assembleDebug --stacktrace --info 2>&1 | tee /tmp/android-build.log

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -57,6 +57,29 @@ android {
         versionName = "$versionNameBase+$gitCommitCount.$gitShortSha"
     }
 
+    signingConfigs {
+        // Stable debug-keystore signing. When the env vars below are present
+        // (decoded from GitHub Secrets in the workflow), every CI build is
+        // signed with the same identity — so the user's installed APK upgrades
+        // in place rather than failing with "App not installed (signature
+        // mismatch)" on each new build, which would otherwise force a wipe of
+        // their encrypted Gemini key + saved settings.
+        //
+        // Locally, the env vars are absent, so AGP's auto-generated
+        // ~/.android/debug.keystore is used (the conventional dev path —
+        // unchanged behaviour for anyone running `./gradlew assembleDebug`
+        // from their own machine).
+        getByName("debug") {
+            val keystoreFile = System.getenv("DEBUG_KEYSTORE_FILE")?.let { file(it) }
+            if (keystoreFile != null && keystoreFile.exists()) {
+                storeFile = keystoreFile
+                storePassword = System.getenv("DEBUG_KEYSTORE_PASSWORD")
+                keyAlias = System.getenv("DEBUG_KEY_ALIAS")
+                keyPassword = System.getenv("DEBUG_KEY_PASSWORD")
+            }
+        }
+    }
+
     buildTypes {
         debug {
             isMinifyEnabled = false


### PR DESCRIPTION
## Summary

Each CI run was generating a fresh debug keystore on a brand-new runner. Every APK artifact had a different signing certificate, so installing one on top of another fails with **"App not installed (signature mismatch)"** — silently from the user's perspective, leaving them on a stale build wondering why their changes didn't appear (which is exactly what just happened).

Fix: a fixed-identity debug keystore lives in GitHub Secrets. CI decodes it on the runner, the `:app` debug `signingConfig` reads it via env vars, every CI APK is signed with the same identity, and sideloads upgrade in place.

## Setup — secrets you need to add

**Settings → Secrets and variables → Actions → New repository secret**, add these four. Values are delivered out-of-band (Claude Code session chat, never in this repo or PR description).

- `DEBUG_KEYSTORE_BASE64` — base64-encoded keystore bytes
- `DEBUG_KEYSTORE_PASSWORD` — random hex
- `DEBUG_KEY_PASSWORD` — same as keystore password (PKCS12 convention)
- `DEBUG_KEY_ALIAS` — `androiddebugkey`

## Mechanics

- New `signingConfigs.debug { }` in `app/build.gradle.kts` reads `DEBUG_KEYSTORE_FILE`, `DEBUG_KEYSTORE_PASSWORD`, `DEBUG_KEY_ALIAS`, `DEBUG_KEY_PASSWORD` from env. **All four absent → falls through to AGP's auto-generated debug keystore**, so local `./gradlew assembleDebug` is unchanged.
- New "Decode debug keystore from secret" step in `ci.yml`'s android-build job: base64-decodes the secret to `/tmp/debug.keystore`, exports `DEBUG_KEYSTORE_FILE`. Step is unconditional but quietly no-ops when the secret isn't set (fork PRs, fresh repos, before the secret is added) — build still passes.
- Three more env vars (`DEBUG_KEYSTORE_PASSWORD` / `DEBUG_KEY_ALIAS` / `DEBUG_KEY_PASSWORD`) are passed straight to gradle.

## Once the secret is set

Every subsequent debug APK from CI has the same signing cert. Sideload upgrades work in place. **Encrypted Gemini key + saved settings persist across versions.** (The current `app.adaptweather` rename forces *one* fresh install regardless — but everything after that is incremental.)

The same keystore can later be reused as the Firebase App Distribution upload target without changing the install identity.

## Test plan

- [ ] Add the four secrets in repo settings (values from session chat)
- [ ] Merge this PR; CI runs decode the keystore and signs the APK with the stable cert
- [ ] Download the APK from the CI artifact, sideload — first install (post-rename) is fresh
- [ ] On the next CI run, sideload again — Android shows the standard "Update" dialog (not "signature mismatch"), settings persist

https://claude.ai/code/session_01VftWR7DyaaVXHnovkuQwge

---
_Generated by [Claude Code](https://claude.ai/code/session_01VftWR7DyaaVXHnovkuQwge)_