### PR TITLE
ci + docs — Firebase App Distribution + PR #40 review fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,14 +154,23 @@ jobs:
         # upgrades on the next install.
         env:
           DEBUG_KEYSTORE_BASE64: ${{ secrets.DEBUG_KEYSTORE_BASE64 }}
+          DEBUG_KEYSTORE_PASSWORD: ${{ secrets.DEBUG_KEYSTORE_PASSWORD }}
         run: |
           if [ -z "$DEBUG_KEYSTORE_BASE64" ]; then
             echo "No DEBUG_KEYSTORE_BASE64 secret available; build will use AGP-default debug keystore."
             exit 0
           fi
-          echo "$DEBUG_KEYSTORE_BASE64" | base64 -d > /tmp/debug.keystore
-          # Sanity check the decoded file is a real keystore, not random bytes.
-          test -s /tmp/debug.keystore
+          # printf rather than echo: portable across shells and doesn't append
+          # a trailing newline that some base64 implementations choke on.
+          printf '%s' "$DEBUG_KEYSTORE_BASE64" | base64 --decode > /tmp/debug.keystore
+          # Validate the decoded file is actually a usable PKCS12/JKS keystore
+          # with the configured password, rather than just non-empty bytes.
+          # Catches "wrong base64", "wrong password", "uploaded a JPEG by
+          # mistake" — at the early-fail step, not at signing-step time.
+          if ! keytool -list -keystore /tmp/debug.keystore -storepass "$DEBUG_KEYSTORE_PASSWORD" >/dev/null 2>&1; then
+            echo "::error::Decoded keystore at /tmp/debug.keystore is not a valid keystore or password is wrong."
+            exit 1
+          fi
           echo "DEBUG_KEYSTORE_FILE=/tmp/debug.keystore" >> "$GITHUB_ENV"
 
       - name: Assemble debug APK
@@ -237,3 +246,33 @@ jobs:
           name: app-debug-apk
           path: app/build/outputs/apk/debug/*.apk
           retention-days: 14
+
+      - name: Distribute via Firebase App Distribution
+        # On push to main only — feature-branch CI runs would otherwise spam
+        # testers with WIP builds. Skipped when secrets aren't set so the build
+        # still finishes on a fresh repo / fork.
+        if: |
+          success() &&
+          github.event_name == 'push' &&
+          github.ref == 'refs/heads/main' &&
+          env.FIREBASE_APP_ID != '' &&
+          env.FIREBASE_SERVICE_ACCOUNT_JSON != ''
+        env:
+          FIREBASE_APP_ID: ${{ secrets.FIREBASE_APP_ID }}
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        uses: wzieba/Firebase-Distribution-Github-Action@v1
+        with:
+          appId: ${{ secrets.FIREBASE_APP_ID }}
+          serviceCredentialsFileContent: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+          # Tester group must exist in Firebase App Distribution console — see
+          # docs/firebase-app-distribution.md. "testers" is the convention; rename
+          # there + here together if you change it.
+          groups: testers
+          file: app/build/outputs/apk/debug/app-debug.apk
+          # Push notification on the tester's phone shows the first ~60 chars
+          # of these notes, so put the most useful info first. Commit subject
+          # is normally that.
+          releaseNotes: |
+            ${{ github.event.head_commit.message }}
+            ---
+            Build: ${{ github.run_number }} · ${{ github.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,10 +155,25 @@ jobs:
         env:
           DEBUG_KEYSTORE_BASE64: ${{ secrets.DEBUG_KEYSTORE_BASE64 }}
           DEBUG_KEYSTORE_PASSWORD: ${{ secrets.DEBUG_KEYSTORE_PASSWORD }}
+          DEBUG_KEY_ALIAS: ${{ secrets.DEBUG_KEY_ALIAS }}
+          DEBUG_KEY_PASSWORD: ${{ secrets.DEBUG_KEY_PASSWORD }}
         run: |
           if [ -z "$DEBUG_KEYSTORE_BASE64" ]; then
             echo "No DEBUG_KEYSTORE_BASE64 secret available; build will use AGP-default debug keystore."
             exit 0
+          fi
+          # If one stable-keystore secret is set, all four must be set. Otherwise
+          # gradle later errors with "Partial debug-keystore configuration", but
+          # the decode step itself would also throw a confusing keytool message
+          # in the meantime. Catch it here with an explicit list of what's
+          # missing so the failure is unambiguous.
+          missing=""
+          [ -z "$DEBUG_KEYSTORE_PASSWORD" ] && missing="$missing DEBUG_KEYSTORE_PASSWORD"
+          [ -z "$DEBUG_KEY_ALIAS" ]         && missing="$missing DEBUG_KEY_ALIAS"
+          [ -z "$DEBUG_KEY_PASSWORD" ]      && missing="$missing DEBUG_KEY_PASSWORD"
+          if [ -n "$missing" ]; then
+            echo "::error::DEBUG_KEYSTORE_BASE64 is set but the following companion secrets are missing or empty:$missing"
+            exit 1
           fi
           # printf rather than echo: portable across shells and doesn't append
           # a trailing newline that some base64 implementations choke on.
@@ -168,7 +183,7 @@ jobs:
           # Catches "wrong base64", "wrong password", "uploaded a JPEG by
           # mistake" — at the early-fail step, not at signing-step time.
           if ! keytool -list -keystore /tmp/debug.keystore -storepass "$DEBUG_KEYSTORE_PASSWORD" >/dev/null 2>&1; then
-            echo "::error::Decoded keystore at /tmp/debug.keystore is not a valid keystore or password is wrong."
+            echo "::error::Decoded keystore at /tmp/debug.keystore is not a valid keystore or DEBUG_KEYSTORE_PASSWORD is wrong."
             exit 1
           fi
           echo "DEBUG_KEYSTORE_FILE=/tmp/debug.keystore" >> "$GITHUB_ENV"
@@ -260,7 +275,11 @@ jobs:
         env:
           FIREBASE_APP_ID: ${{ secrets.FIREBASE_APP_ID }}
           FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
-        uses: wzieba/Firebase-Distribution-Github-Action@v1
+        # Pinned to a specific commit SHA (rather than the floating @v1 tag) so
+        # a compromised upstream release can't silently swap in malicious code
+        # on our next CI run. Bump deliberately. SHA below is wzieba/Firebase-
+        # Distribution-Github-Action v1.7.1.
+        uses: wzieba/Firebase-Distribution-Github-Action@bd494989dd4bec0343f78adee87fe66e48279ad6 # v1.7.1
         with:
           appId: ${{ secrets.FIREBASE_APP_ID }}
           serviceCredentialsFileContent: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -70,12 +70,35 @@ android {
         // unchanged behaviour for anyone running `./gradlew assembleDebug`
         // from their own machine).
         getByName("debug") {
-            val keystoreFile = System.getenv("DEBUG_KEYSTORE_FILE")?.let { file(it) }
-            if (keystoreFile != null && keystoreFile.exists()) {
-                storeFile = keystoreFile
-                storePassword = System.getenv("DEBUG_KEYSTORE_PASSWORD")
-                keyAlias = System.getenv("DEBUG_KEY_ALIAS")
-                keyPassword = System.getenv("DEBUG_KEY_PASSWORD")
+            // All four vars must be present for the override; if only some are
+            // set we'd otherwise silently install blank credentials and let
+            // signing fail with a confusing message at the end of the build.
+            // Treat partial configuration as user error, fail fast.
+            val keystorePath = System.getenv("DEBUG_KEYSTORE_FILE")?.takeIf { it.isNotBlank() }
+            val storePass = System.getenv("DEBUG_KEYSTORE_PASSWORD")?.takeIf { it.isNotBlank() }
+            val alias = System.getenv("DEBUG_KEY_ALIAS")?.takeIf { it.isNotBlank() }
+            val keyPass = System.getenv("DEBUG_KEY_PASSWORD")?.takeIf { it.isNotBlank() }
+
+            val anySet = keystorePath != null || storePass != null || alias != null || keyPass != null
+            val allSet = keystorePath != null && storePass != null && alias != null && keyPass != null
+
+            if (anySet && !allSet) {
+                error(
+                    "Partial debug-keystore configuration. Set all of DEBUG_KEYSTORE_FILE, " +
+                        "DEBUG_KEYSTORE_PASSWORD, DEBUG_KEY_ALIAS, DEBUG_KEY_PASSWORD — or none, " +
+                        "to fall back to AGP's default debug keystore.",
+                )
+            }
+
+            if (allSet) {
+                val keystore = file(keystorePath!!)
+                check(keystore.exists()) {
+                    "DEBUG_KEYSTORE_FILE is set but does not exist: ${keystore.path}"
+                }
+                storeFile = keystore
+                storePassword = storePass
+                keyAlias = alias
+                keyPassword = keyPass
             }
         }
     }

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -14,15 +14,12 @@ Code TODOs in source files are linked from here when they exist.
 
 ## Distribution
 
-- [ ] **Firebase App Distribution setup** (in progress). Plan: keystore stays
-      out of the repo, base64 + passwords go in GitHub Secrets, CI decodes on
-      the runner. Six secrets total: `KEYSTORE_BASE64`, `KEYSTORE_PASSWORD`,
-      `KEY_ALIAS`, `KEY_PASSWORD`, `FIREBASE_APP_ID`,
-      `FIREBASE_SERVICE_ACCOUNT_JSON`.
-- [ ] **`.github/workflows/build.yml`** — push-to-main signed-release upload to
-      FAD. Replaces the artifact-download workflow.
+- [x] **Firebase App Distribution setup.** Push to `main` triggers a debug
+      APK build signed with the stable keystore, uploaded to FAD with the
+      commit message as release notes. Setup steps in
+      [docs/firebase-app-distribution.md](firebase-app-distribution.md).
 - [ ] **`.github/workflows/release.yml`** — tag-triggered, runs Maestro on
-      Firebase Test Lab + cuts a GitHub Release.
+      Firebase Test Lab + cuts a GitHub Release with a release-signed APK.
 
 ## Voice / TTS
 

--- a/docs/firebase-app-distribution.md
+++ b/docs/firebase-app-distribution.md
@@ -1,0 +1,124 @@
+# Firebase App Distribution setup
+
+One-time Firebase + GitHub Secrets setup so every push to `main` produces an
+APK that lands on your phone via push notification rather than waiting for you
+to remember to grab the artifact from CI.
+
+## What this gets you
+
+- Push to `main` → CI builds + signs the debug APK → uploads to Firebase App
+  Distribution → tester device gets a notification within ~30s of CI finishing.
+- Tap the notification → install. First-time setup on the phone needs the
+  **App Tester** app from Play Store, then a sign-in with the same Google
+  account that was added as a tester in step 4.
+- Subsequent installs upgrade in place because we sign with a stable debug
+  keystore (see PR #40 / `app/build.gradle.kts:signingConfigs.debug`).
+
+## Setup checklist (one-time, ~15 minutes)
+
+### 1. Create the Firebase project
+
+[console.firebase.google.com](https://console.firebase.google.com) → **Add
+project**.
+
+- Name: anything sensible — "AdaptWeather". The display name is just for the
+  Firebase console; it has no effect on the app.
+- Skip Google Analytics when prompted (we don't use it).
+
+### 2. Add the Android app
+
+Inside the project, click the Android icon to add an app.
+
+- **Android package name**: `app.adaptweather.debug` *(this is the debug
+  variant's applicationId — not `app.adaptweather`. The `.debug` suffix
+  matters; without it, FAD will reject uploads.)*
+- **App nickname**: "AdaptWeather Debug" or similar.
+- **Debug signing certificate SHA-1**: optional, only needed for Firebase
+  Auth / App Check. We don't use either, so skip.
+
+When prompted to download `google-services.json`, **skip the download and
+continue**. We don't bundle the Firebase SDK in the app — FAD doesn't need
+the file on the device, only the upload pipeline needs the App ID and a
+service-account key.
+
+Skip the SDK setup steps for the same reason.
+
+### 3. Enable App Distribution
+
+Left nav → **Release & Monitor** → **App Distribution** → **Get started**.
+
+### 4. Add yourself as a tester
+
+App Distribution panel → **Testers & groups** tab.
+
+- Click **Add group** → name it `testers` *(must match `groups: testers` in
+  `.github/workflows/ci.yml`. Pick a different name only if you remember to
+  change it in both places.)*
+- In the new group, click **Add testers** → enter your own email address.
+- Firebase will email you an invite. Accept it on your phone (the email
+  links to install the **App Tester** app on Play Store).
+
+### 5. Create a service-account key for CI
+
+Project Settings (cog icon top-left) → **Service accounts** tab.
+
+- Click **Generate new private key** → **Generate key**. A JSON file
+  downloads.
+- Open the JSON file in a text editor; copy its **entire contents** (curly
+  braces and all).
+- This is the credential CI uses to upload APKs. **Don't commit it.**
+
+### 6. Get the App ID
+
+Project Settings → **General** tab → scroll to "Your apps" → the Android app
+you registered in step 2 → **App ID**.
+
+Format: `1:1234567890:android:abcdef1234567890`. Copy it.
+
+### 7. Add two GitHub Secrets
+
+GitHub repo → **Settings → Secrets and variables → Actions → New repository
+secret**.
+
+| Name | Value |
+|---|---|
+| `FIREBASE_APP_ID` | The App ID from step 6, e.g. `1:1234567890:android:abcdef1234567890`. |
+| `FIREBASE_SERVICE_ACCOUNT_JSON` | The full JSON content from step 5 (paste the whole `{ … }` block). |
+
+### 8. Trigger a build
+
+Push any commit to `main` (or merge a PR). The CI run on `main` should now
+finish with a "Distribute via Firebase App Distribution" step. Watch for
+green; the tester device gets a push notification ~30s after CI finishes.
+
+## Troubleshooting
+
+- **CI says "Distribute via Firebase App Distribution skipped"** → secrets
+  aren't set, or you pushed to a feature branch (only `main` distributes).
+- **"FIREBASE_APP_ID is not a valid App ID"** → format must be
+  `1:NNN:android:HASH`. Project Number alone (`1234567890`) is *not* enough.
+- **"Service account does not have permission"** → in step 5, Firebase
+  generated the right service account by default. If you re-used a
+  pre-existing one, it must have the **Firebase App Distribution Admin**
+  role (IAM in Google Cloud console).
+- **"Tester group `testers` not found"** → you skipped step 4, or used a
+  different group name. Either match `groups: testers` in
+  `.github/workflows/ci.yml` or add the missing group to FAD.
+- **No push notification on phone** → the App Tester app isn't installed or
+  isn't signed in with the email from step 4. Email from Firebase still
+  arrives; tapping the install link in the email also works.
+
+## Future: release builds
+
+This setup distributes the **debug** APK, signed with the debug keystore.
+For release builds (minified, R8'd, signed with a release keystore), we
+would:
+
+1. Generate a release keystore + add four more secrets (same shape as the
+   debug ones).
+2. Add `signingConfigs.release { … }` reading those env vars.
+3. Add a separate FAD upload step for `app/build/outputs/apk/release/*.apk`.
+
+Deferred until we actually want release-grade builds in front of testers —
+the debug build is fine for verifying behaviour and is closer to what
+you're actively iterating on.


### PR DESCRIPTION
## Summary

Two threaded changes that share the keystore + CI surface:

### 1. Firebase App Distribution on push to main

New step in the android-build job that uploads the signed debug APK to FAD whenever the merge commit lands on `main`. Gated so it skips on feature-branch CI, fork PRs, or fresh repos that haven't set the secrets yet — those still build the APK as a workflow artifact like before, no breakage.

Uses [`wzieba/Firebase-Distribution-Github-Action@v1`](https://github.com/wzieba/Firebase-Distribution-Github-Action). Tester group is `testers` (must exist in the FAD console). Release notes are the commit subject + CI run number + SHA so a tester can trace any installed APK back to its commit.

**You need to do steps 1-7 of [docs/firebase-app-distribution.md](docs/firebase-app-distribution.md)** before merging — create the Firebase project, add the Android app, enable App Distribution, add yourself as a tester, generate the service-account key, copy the App ID, add two GitHub Secrets:
- `FIREBASE_APP_ID`
- `FIREBASE_SERVICE_ACCOUNT_JSON`

If you merge before the secrets are set, CI still passes — it just skips the upload step. Set the secrets and re-run the workflow on `main` to push the APK to your phone.

### 2. PR #40 review-comment fixes (missed before merge — sorry)

Copilot left three substantive review threads on PR #40 that I didn't address before it was merged. Fixed here:

- **`app/build.gradle.kts:signingConfigs.debug`** — partial config (file env var set, password unset) was silently installing blank credentials and letting signing fail later with a confusing error. Now it fails fast with a clear message, requiring all four env vars to be set together (or none of them).
- **`ci.yml` decode step** — switched `echo` → `printf '%s'` for shell portability and to avoid trailing-newline issues with strict base64 decoders.
- **`ci.yml` decode step** — replaced the `test -s` "sanity check" (only verified non-empty) with `keytool -list`, which actually validates the decoded file is a usable keystore with the configured password. Catches wrong-base64, wrong-password, and uploaded-a-JPEG cases at decode time instead of at sign-time.

## Files

- `.github/workflows/ci.yml` — FAD step + decode-step robustness fixes.
- `app/build.gradle.kts` — partial-config detection in debug signingConfig.
- `docs/firebase-app-distribution.md` — step-by-step setup guide (new).
- `docs/TODO.md` — ticks the "FAD setup" item, links to the new guide.

## Test plan

- [ ] CI green on this PR (the FAD upload step will skip — `event_name` is `pull_request`, not `push`)
- [ ] Complete steps 1-7 of `docs/firebase-app-distribution.md` (Firebase project, tester, secrets)
- [ ] Merge this PR
- [ ] Watch the CI run on `main` — the "Distribute via Firebase App Distribution" step should run and succeed
- [ ] Phone (signed in to App Tester app with the tester email) gets a push notification within ~30s; tap → install
- [ ] Settings → About shows the new build; encrypted Gemini key + saved settings persist across the upgrade
- [ ] Push another commit to `main`; second build upgrades in place (no "App not installed" error)

https://claude.ai/code/session_01VftWR7DyaaVXHnovkuQwge

---
_Generated by [Claude Code](https://claude.ai/code/session_01VftWR7DyaaVXHnovkuQwge)_