### PR TITLE
Harden Gemini client + TTS preview reliability + missing-key UX

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -377,15 +377,17 @@ jobs:
         # On push to main only — feature-branch CI runs would otherwise spam
         # testers with WIP builds. Skipped when secrets aren't set so the build
         # still finishes on a fresh repo / fork.
+        #
+        # Guarded against `secrets.*` directly: step-level `env:` is not in
+        # scope when GitHub evaluates the step's own `if`, so referencing
+        # `env.FIREBASE_APP_ID` here would always be empty and the step would
+        # never run.
         if: |
           success() &&
           github.event_name == 'push' &&
           github.ref == 'refs/heads/main' &&
-          env.FIREBASE_APP_ID != '' &&
-          env.FIREBASE_SERVICE_ACCOUNT_JSON != ''
-        env:
-          FIREBASE_APP_ID: ${{ secrets.FIREBASE_APP_ID }}
-          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+          secrets.FIREBASE_APP_ID != '' &&
+          secrets.FIREBASE_SERVICE_ACCOUNT_JSON != ''
         # Pinned to a specific commit SHA (rather than the floating @v1 tag) so
         # a compromised upstream release can't silently swap in malicious code
         # on our next CI run. Bump deliberately. SHA below is wzieba/Firebase-

--- a/app/src/main/kotlin/app/adaptweather/AdaptWeatherApplication.kt
+++ b/app/src/main/kotlin/app/adaptweather/AdaptWeatherApplication.kt
@@ -16,6 +16,7 @@ import app.adaptweather.data.SecureKeyStore
 import app.adaptweather.data.SettingsRepository
 import app.adaptweather.location.LocationResolver
 import app.adaptweather.notification.InsightNotifier
+import app.adaptweather.notification.MissingApiKeyNotifier
 import app.adaptweather.notification.NotificationChannelRegistrar
 import app.adaptweather.notification.WeatherAlertNotifier
 import app.adaptweather.tts.AndroidTtsSpeaker
@@ -48,6 +49,7 @@ class AdaptWeatherApplication : Application() {
     val locationResolver: LocationResolver by lazy { LocationResolver(this) }
     val insightNotifier: InsightNotifier by lazy { InsightNotifier(this) }
     val weatherAlertNotifier: WeatherAlertNotifier by lazy { WeatherAlertNotifier(this) }
+    val missingApiKeyNotifier: MissingApiKeyNotifier by lazy { MissingApiKeyNotifier(this) }
     val dailyAlarmScheduler: DailyAlarmScheduler by lazy { DailyAlarmScheduler(this) }
     val deviceTtsSpeaker: TtsSpeaker by lazy { AndroidTtsSpeaker(this) }
     val geminiTtsClient: GeminiTtsClient by lazy { GeminiTtsClient(httpClient, secureKeyStore) }

--- a/app/src/main/kotlin/app/adaptweather/data/SecureKeyStore.kt
+++ b/app/src/main/kotlin/app/adaptweather/data/SecureKeyStore.kt
@@ -45,13 +45,13 @@ class SecureKeyStore(
     private val dataStore: DataStore<Preferences>,
 ) : KeyProvider {
 
-    override suspend fun get(): String = read(GEMINI_PREF_KEY, GEMINI_AAD)
+    override suspend fun get(): String = read(GEMINI_PREF_KEY, GEMINI_AAD, "Gemini")
 
     suspend fun set(key: String) = write(GEMINI_PREF_KEY, GEMINI_AAD, key)
 
     suspend fun clear() = remove(GEMINI_PREF_KEY)
 
-    suspend fun getOpenAi(): String = read(OPENAI_PREF_KEY, OPENAI_AAD)
+    suspend fun getOpenAi(): String = read(OPENAI_PREF_KEY, OPENAI_AAD, "OpenAI")
 
     suspend fun setOpenAi(key: String) = write(OPENAI_PREF_KEY, OPENAI_AAD, key)
 
@@ -66,9 +66,9 @@ class SecureKeyStore(
         override suspend fun get(): String = getOpenAi()
     }
 
-    private suspend fun read(prefKey: Preferences.Key<String>, aad: ByteArray): String {
+    private suspend fun read(prefKey: Preferences.Key<String>, aad: ByteArray, provider: String): String {
         val ciphertextB64 = dataStore.data.map { it[prefKey] }.first()
-            ?: throw MissingApiKeyException()
+            ?: throw MissingApiKeyException(provider)
         return try {
             val ciphertext = Base64.getDecoder().decode(ciphertextB64)
             aead.decrypt(ciphertext, aad).toString(Charsets.UTF_8)
@@ -76,7 +76,7 @@ class SecureKeyStore(
             // Corrupt ciphertext or unrecoverable Keystore state — drop the bad value so
             // the next attempt prompts the user to re-enter their key cleanly.
             remove(prefKey)
-            throw MissingApiKeyException()
+            throw MissingApiKeyException(provider)
         }
     }
 

--- a/app/src/main/kotlin/app/adaptweather/notification/MissingApiKeyNotifier.kt
+++ b/app/src/main/kotlin/app/adaptweather/notification/MissingApiKeyNotifier.kt
@@ -1,0 +1,66 @@
+package app.adaptweather.notification
+
+import android.Manifest
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.core.content.ContextCompat
+import app.adaptweather.MainActivity
+import app.adaptweather.R
+
+/**
+ * Posts a notification when the daily worker can't run because no API key is
+ * configured. Without this the worker fails silently — the user wakes up to no
+ * insight and no explanation. Reuses the daily-insight channel so the user can
+ * mute or unmute both via the same toggle.
+ */
+class MissingApiKeyNotifier(private val context: Context) {
+
+    // Named `post`, not `notify`, because a no-arg `notify()` would clash with
+    // java.lang.Object.notify() — Kotlin flags it as an accidental override.
+    fun post() {
+        if (!hasPostNotificationPermission()) return
+
+        val tapIntent = Intent(context, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
+        }
+        val pendingIntent = PendingIntent.getActivity(
+            context,
+            REQUEST_OPEN_APP,
+            tapIntent,
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+        )
+
+        val text = context.getString(R.string.notification_missing_api_key_text)
+        val notification = NotificationCompat.Builder(context, CHANNEL_DAILY_INSIGHT)
+            .setSmallIcon(R.drawable.ic_notification_insight)
+            .setContentTitle(context.getString(R.string.notification_missing_api_key_title))
+            .setContentText(text)
+            .setStyle(NotificationCompat.BigTextStyle().bigText(text))
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
+            .setAutoCancel(true)
+            .setContentIntent(pendingIntent)
+            .setCategory(NotificationCompat.CATEGORY_REMINDER)
+            .build()
+
+        NotificationManagerCompat.from(context).notify(NOTIFICATION_ID_MISSING_API_KEY, notification)
+    }
+
+    private fun hasPostNotificationPermission(): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return true
+        return ContextCompat.checkSelfPermission(
+            context,
+            Manifest.permission.POST_NOTIFICATIONS,
+        ) == PackageManager.PERMISSION_GRANTED
+    }
+
+    companion object {
+        const val NOTIFICATION_ID_MISSING_API_KEY = 1002
+        private const val REQUEST_OPEN_APP = 102
+    }
+}

--- a/app/src/main/kotlin/app/adaptweather/ui/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/app/adaptweather/ui/settings/SettingsScreen.kt
@@ -1074,9 +1074,9 @@ private suspend fun runTtsPreview(
     // suspends off-Main internally, but AudioTrack.write/play are JNI calls and
     // we don't want a hot stack of preview work running on the UI dispatcher.
     withContext(Dispatchers.IO) {
+        val text = app.insightCache.latest.first()?.spokenText()
+            ?: context.getString(R.string.settings_tts_test_sample)
         try {
-            val text = app.insightCache.latest.first()?.spokenText()
-                ?: context.getString(R.string.settings_tts_test_sample)
             when (engine) {
                 TtsEngine.GEMINI ->
                     GeminiTtsSpeaker(app.geminiTtsClient, voiceName = geminiVoice).speak(text)
@@ -1088,12 +1088,23 @@ private suspend fun runTtsPreview(
         } catch (_: CancellationException) {
             // Expected when the user picks a different option mid-playback; not an error.
         } catch (t: Throwable) {
-            val message = "${t.javaClass.simpleName}: ${t.message ?: "(no detail)"}"
+            val message = "${engine.name} TTS failed: ${t.message ?: t.javaClass.simpleName}"
             android.util.Log.w("SettingsScreen", "TTS preview failed for $engine", t)
             // Toast.show() posts internally, but Toast.makeText()'s constructor needs
             // a Looper on the calling thread — Dispatchers.IO has none, so hop to Main.
             withContext(Dispatchers.Main) {
                 android.widget.Toast.makeText(context, message, android.widget.Toast.LENGTH_LONG).show()
+            }
+            // Fall back to the on-device engine so the user still hears the preview
+            // and can confirm audio output is working — mirrors FetchAndNotifyWorker.
+            if (engine != TtsEngine.DEVICE) {
+                try {
+                    app.deviceTtsSpeaker.speak(text)
+                } catch (_: CancellationException) {
+                    // user moved on; fine
+                } catch (fallback: Throwable) {
+                    android.util.Log.w("SettingsScreen", "Device TTS fallback also failed", fallback)
+                }
             }
         }
     }

--- a/app/src/main/kotlin/app/adaptweather/ui/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/app/adaptweather/ui/settings/SettingsScreen.kt
@@ -1073,8 +1073,6 @@ private suspend fun runTtsPreview(
     // Network synthesis and AudioTrack write are both blocking-ish work — Ktor
     // suspends off-Main internally, but AudioTrack.write/play are JNI calls and
     // we don't want a hot stack of preview work running on the UI dispatcher.
-    // Toast is documented as safe from any thread (it posts internally) so we
-    // don't need to hop back to Main for the failure path.
     withContext(Dispatchers.IO) {
         try {
             val text = app.insightCache.latest.first()?.spokenText()
@@ -1092,7 +1090,11 @@ private suspend fun runTtsPreview(
         } catch (t: Throwable) {
             val message = "${t.javaClass.simpleName}: ${t.message ?: "(no detail)"}"
             android.util.Log.w("SettingsScreen", "TTS preview failed for $engine", t)
-            android.widget.Toast.makeText(context, message, android.widget.Toast.LENGTH_LONG).show()
+            // Toast.show() posts internally, but Toast.makeText()'s constructor needs
+            // a Looper on the calling thread — Dispatchers.IO has none, so hop to Main.
+            withContext(Dispatchers.Main) {
+                android.widget.Toast.makeText(context, message, android.widget.Toast.LENGTH_LONG).show()
+            }
         }
     }
 }

--- a/app/src/main/kotlin/app/adaptweather/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/app/adaptweather/work/FetchAndNotifyWorker.kt
@@ -106,6 +106,10 @@ class FetchAndNotifyWorker(
             Result.success()
         } catch (e: MissingApiKeyException) {
             Log.w(TAG, "No Gemini API key configured; user must set one in Settings.")
+            // Surface this to the user — without it the morning is silent and they have
+            // no idea why no insight arrived.
+            runCatching { app.missingApiKeyNotifier.post() }
+                .onFailure { Log.w(TAG, "Failed to post missing-API-key notification.", it) }
             Result.failure(reason(REASON_MISSING_API_KEY))
         } catch (e: GeminiBlockedException) {
             Log.w(TAG, "Gemini refused the prompt: ${e.message}")

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -116,6 +116,9 @@
     <string name="notification_channel_daily_insight_description">The morning weather summary you opted in to.</string>
     <string name="notification_daily_insight_title">Today\'s weather</string>
 
+    <string name="notification_missing_api_key_title">AdaptWeather needs an API key</string>
+    <string name="notification_missing_api_key_text">Set up your Gemini API key in Settings to receive daily weather insights.</string>
+
     <string name="notification_channel_weather_alerts_name">Severe weather alerts</string>
     <string name="notification_channel_weather_alerts_description">High-priority alerts for severe or extreme weather events affecting your area. Delivered as soon as the daily fetch detects them.</string>
     <string name="notification_weather_alert_title">Weather alert: %1$s</string>

--- a/core/data/src/main/kotlin/app/adaptweather/core/data/insight/GeminiDto.kt
+++ b/core/data/src/main/kotlin/app/adaptweather/core/data/insight/GeminiDto.kt
@@ -18,7 +18,7 @@ internal data class GenerateContentRequest(
 internal data class SystemInstruction(val parts: List<Part>)
 
 @Serializable
-internal data class Content(val role: String, val parts: List<Part>)
+internal data class Content(val role: String? = null, val parts: List<Part> = emptyList())
 
 @Serializable
 internal data class Part(val text: String)

--- a/core/data/src/main/kotlin/app/adaptweather/core/data/insight/KeyProvider.kt
+++ b/core/data/src/main/kotlin/app/adaptweather/core/data/insight/KeyProvider.kt
@@ -12,4 +12,5 @@ interface KeyProvider {
 }
 
 /** Thrown when no API key has been configured by the user. */
-class MissingApiKeyException : IllegalStateException("Gemini API key has not been configured")
+class MissingApiKeyException(provider: String = "Gemini") :
+    IllegalStateException("$provider API key has not been configured")

--- a/core/data/src/main/kotlin/app/adaptweather/core/data/tts/OpenAITtsClient.kt
+++ b/core/data/src/main/kotlin/app/adaptweather/core/data/tts/OpenAITtsClient.kt
@@ -37,7 +37,7 @@ class OpenAITtsClient(
         voice: String = DEFAULT_OPENAI_TTS_VOICE,
     ): PcmAudio {
         val key = keyProvider.get().also {
-            if (it.isBlank()) throw MissingApiKeyException()
+            if (it.isBlank()) throw MissingApiKeyException("OpenAI")
         }
 
         val response: HttpResponse = httpClient.post(SPEECH_URL) {

--- a/core/data/src/test/kotlin/app/adaptweather/core/data/insight/DirectGeminiClientTest.kt
+++ b/core/data/src/test/kotlin/app/adaptweather/core/data/insight/DirectGeminiClientTest.kt
@@ -118,6 +118,18 @@ class DirectGeminiClientTest {
     }
 
     @Test
+    fun `throws GeminiEmptyResponseException when candidate content omits parts`() = runTest {
+        val client = DirectGeminiClient(
+            httpClient = mockClient(
+                """{"candidates":[{"content":{"role":"model"},"finishReason":"MAX_TOKENS"}]}""",
+            ),
+            keyProvider = FakeKeyProvider("test-key"),
+        )
+
+        shouldThrow<GeminiEmptyResponseException> { client.generate(prompt) }
+    }
+
+    @Test
     fun `throws GeminiBlockedException when promptFeedback indicates a block`() = runTest {
         val client = DirectGeminiClient(
             httpClient = mockClient("""{"promptFeedback":{"blockReason":"SAFETY"}}"""),


### PR DESCRIPTION
## Summary
Five behaviour changes added on top of the two pre-existing inherited commits (Firebase App Distribution + PR #42 review fixes — listed at the bottom for context).

### 1. Tolerate Gemini candidates with no `parts` (commit 1)
Gemini sometimes returns a candidate whose `content` object omits `parts` — most often with `finishReason: MAX_TOKENS`, where Gemini 2.5's thinking tokens exhaust our 100-token output budget before any visible text is produced; safety filters can also strip it. The strict deserializer threw `JsonConvertException` before our empty-response handling could run.

Made `role` and `parts` optional on `Content` so requests still serialise the same way and the response path falls through to `GeminiEmptyResponseException`. Regression test covers the `MAX_TOKENS`-with-no-parts shape.

### 2. Show TTS preview error Toast on Main thread (commit 2)
Tapping a TTS voice in Settings could crash with `NullPointerException: Can't toast on a thread that has not called Looper.prepare()`. `Toast.show()` posts to the main looper internally, but `Toast.makeText()`'s constructor instantiates a `Handler` on the calling thread, which requires a Looper. The catch ran on `Dispatchers.IO` (no Looper). Hopped back to `Dispatchers.Main` for the Toast, which now actually surfaces the underlying TTS error to the user.

### 3. Fall back to device TTS preview, name the right provider in errors (commit 3)
- Settings TTS preview now falls back to the on-device engine when the chosen Gemini/OpenAI engine throws (network, missing key, quota). Toast still names the underlying failure so the user knows what to fix; they also hear the test audio so they can confirm playback works independently of the network providers. Mirrors the `speakWithFallback` policy already used by `FetchAndNotifyWorker`.
- `MissingApiKeyException` now takes a provider name so OpenAI failures no longer claim the Gemini key is missing. Threaded through `SecureKeyStore.read` so both the missing-value and corrupt-ciphertext paths report the right provider.

### 4. Notify user when daily worker has no API key (commit 4)
Previously the worker caught `MissingApiKeyException`, logged a warning, and returned `Result.failure`. Users woke to no morning insight and no notification explaining why. New `MissingApiKeyNotifier` posts on the existing daily-insight channel (so muting one mutes both); tap opens MainActivity. Wrapped in `runCatching` so a notification failure never escalates the worker outcome. Entry point named `post()` rather than `notify()` because Kotlin flags a no-arg `notify()` as an accidental override of `Object.notify()`.

### 5. Fix Firebase App Distribution if-guard scoping (commit 5, from Copilot review)
The Firebase distribution step's `if:` referenced `env.FIREBASE_APP_ID` and `env.FIREBASE_SERVICE_ACCOUNT_JSON`, which were defined in the same step's `env:` block. Step-level env isn't visible to that step's own `if`, so the guard was always empty and the distribution step would never run, even on `main` with secrets set. Switched to `secrets.* != ''` and dropped the now-redundant step `env:` block.

## Inherited commits (already on this branch when work started — not new in this PR's scope)
- `a2187f3 ci + docs — Firebase App Distribution + PR #40 review fixes`
- `edaab41 ci: address PR #42 review fixes`

## Test plan
- [x] `./gradlew :core:data:test` — DirectGeminiClientTest including new `throws GeminiEmptyResponseException when candidate content omits parts` (CI green)
- [x] Android debug build (CI green)
- [ ] Manual: tap TTS voice with no API key → Toast names the missing provider AND device TTS speaks the sample
- [ ] Manual: trigger daily worker with no API key → notification appears explaining the missing key
- [ ] Manual: confirm `gemini-2.5-flash` `MAX_TOKENS` response no longer crashes (most easily reproduced by setting `maxOutputTokens` very low)

https://claude.ai/code/session_01GqXdR3wZt3KNnHwxSnWGWa