### PR TITLE
ci: sticky "UI snapshots fresh" comment on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,10 @@ jobs:
         # Loop safety: GITHUB_TOKEN-authored commits don't trigger new workflow
         # runs, and the `git diff --quiet` check no-ops when nothing changed,
         # so reruns and identical re-records don't create empty churn commits.
+        #
+        # Records SNAPSHOT_COMMIT_SHA / SNAPSHOTS_REGENERATED into the env so
+        # the freshness-comment step downstream can report what happened.
+        id: snapshot_commit
         if: >-
           success() &&
           github.event_name == 'pull_request' &&
@@ -148,10 +152,68 @@ jobs:
           git add app/src/test/snapshots
           if git diff --cached --quiet; then
             echo "No snapshot changes."
+            echo "SNAPSHOTS_REGENERATED=false" >> "$GITHUB_ENV"
+            echo "SNAPSHOT_COMMIT_SHA=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
             exit 0
           fi
           git commit -m "ci: regenerate UI snapshots [skip ci]"
           git push origin HEAD:'${{ github.event.pull_request.head.ref }}'
+          echo "SNAPSHOTS_REGENERATED=true" >> "$GITHUB_ENV"
+          echo "SNAPSHOT_COMMIT_SHA=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
+
+      - name: Comment snapshot freshness on PR
+        # Sticky comment (single per-PR, updated in place via the marker) so
+        # reviewers always know whether the PNGs in the PR's "Files changed"
+        # tab are current. Three signals:
+        #   - whether *this* run regenerated PNGs (vs reused unchanged ones)
+        #   - the head SHA the snapshots were rendered against
+        #   - the count of PNGs (catches the silent case where a renamed
+        #     @Test method writes to a new file and old PNGs go stale)
+        if: >-
+          success() &&
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = 'app/src/test/snapshots/roborazzi';
+            let count = 0;
+            try {
+              count = fs.readdirSync(path).filter(f => f.endsWith('.png')).length;
+            } catch (e) {
+              // Directory missing — first PR before any snapshot has been
+              // recorded. Report 0 so the user sees the situation clearly.
+            }
+            const headSha = (process.env.SNAPSHOT_COMMIT_SHA || context.sha).slice(0, 7);
+            const regenerated = process.env.SNAPSHOTS_REGENERATED === 'true';
+            const status = regenerated
+              ? `🔄 Regenerated ${count} UI snapshot${count === 1 ? '' : 's'} this run.`
+              : `✅ ${count} UI snapshot${count === 1 ? '' : 's'} up-to-date — no pixel changes from this push.`;
+            const body = `<!-- ui-snapshots-status -->
+            **UI snapshots:** ${status}
+
+            Head: \`${headSha}\` · Browse: [\`app/src/test/snapshots/roborazzi/\`](https://github.com/${context.repo.owner}/${context.repo.repo}/tree/${context.payload.pull_request.head.ref}/app/src/test/snapshots/roborazzi)`;
+            const marker = '<!-- ui-snapshots-status -->';
+            const { data: comments } = await github.rest.issues.listComments({
+              ...context.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+            const existing = comments.find(c => c.user.type === 'Bot' && c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                ...context.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                ...context.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
 
       - name: Upload UI preview snapshots (fallback for fork PRs)
         # Same PNGs as the in-repo commit above, kept as a workflow artifact


### PR DESCRIPTION
## Summary
Adds a sticky per-PR comment that always tells the reviewer whether the UI snapshot PNGs in `app/src/test/snapshots/roborazzi/` are current.

The snapshot commit-back step (added in #45) now records two env vars: `SNAPSHOTS_REGENERATED` (true/false) and `SNAPSHOT_COMMIT_SHA`. A new follow-up step uses those to post (or update in place via a `<!-- ui-snapshots-status -->` marker) a single comment per PR with:

- **🔄 Regenerated N snapshots this run** if the PNGs changed and were committed back, or
- **✅ N snapshots up-to-date — no pixel changes from this push** if Roborazzi re-rendered identical PNGs (no diff to commit).

Plus the head SHA the PNGs were rendered against and a direct link into the snapshots directory at that ref.

## Why
Came up on #43 — when I rebased the branch, the previous CI auto-commit got dropped, so the branch ended up with stale (missing) PNGs and there was no obvious way to tell from the PR. With this comment, that situation is loud: count goes from 15 → 8, regenerated flag flips, and the reviewer can see it immediately.

Also catches the silent failure mode where a `@Test` method gets renamed and the old PNG files still exist alongside new ones — the PNG count would go *up* unexpectedly, signalling an orphaned file to clean up.

## Test plan
- [ ] CI passes on this PR
- [ ] On the next push to a PR, the bot posts a single sticky comment with the right status
- [ ] On a follow-up push that doesn't change pixels, the comment updates in place to "✅ up-to-date" rather than spawning a second comment
- [ ] Forks (gated out of the same-repo-only step) don't break the workflow

---
_Generated by [Claude Code](https://claude.ai/code/session_01MK7Rxq2HrXHX3NHNkD7Gtf)_