### PR TITLE
Surface finishReason / blockReason in Gemini TTS errors

### DIFF
--- a/core/data/src/main/kotlin/app/adaptweather/core/data/tts/GeminiTtsClient.kt
+++ b/core/data/src/main/kotlin/app/adaptweather/core/data/tts/GeminiTtsClient.kt
@@ -65,10 +65,14 @@ class GeminiTtsClient(
             )
         }.body()
 
-        val inline = response.candidates.firstOrNull()
-            ?.content?.parts?.firstOrNull { it.inlineData != null }
+        response.promptFeedback?.blockReason?.let {
+            throw GeminiTtsBlockedException("Gemini TTS prompt blocked: $it")
+        }
+
+        val candidate = response.candidates.firstOrNull()
+        val inline = candidate?.content?.parts?.firstOrNull { it.inlineData != null }
             ?.inlineData
-            ?: throw GeminiTtsEmptyResponseException()
+            ?: throw GeminiTtsEmptyResponseException(candidate?.finishReason)
 
         val pcm = Base64.getDecoder().decode(inline.data)
         val sampleRate = parseSampleRate(inline.mimeType) ?: DEFAULT_SAMPLE_RATE_HZ
@@ -98,5 +102,13 @@ data class PcmAudio(val bytes: ByteArray, val sampleRate: Int) {
     override fun hashCode(): Int = 31 * bytes.contentHashCode() + sampleRate
 }
 
-class GeminiTtsEmptyResponseException :
-    IllegalStateException("Gemini TTS returned no inline-audio part")
+class GeminiTtsEmptyResponseException(finishReason: String?) :
+    IllegalStateException(
+        if (finishReason.isNullOrBlank()) {
+            "Gemini TTS returned no inline-audio part"
+        } else {
+            "Gemini TTS returned no inline-audio part (finishReason=$finishReason)"
+        },
+    )
+
+class GeminiTtsBlockedException(message: String) : IllegalStateException(message)

--- a/core/data/src/main/kotlin/app/adaptweather/core/data/tts/GeminiTtsDto.kt
+++ b/core/data/src/main/kotlin/app/adaptweather/core/data/tts/GeminiTtsDto.kt
@@ -40,10 +40,14 @@ internal data class PrebuiltVoiceConfig(val voiceName: String)
 @Serializable
 internal data class TtsResponse(
     val candidates: List<TtsCandidate> = emptyList(),
+    val promptFeedback: TtsPromptFeedback? = null,
 )
 
 @Serializable
-internal data class TtsCandidate(val content: TtsCandidateContent? = null)
+internal data class TtsCandidate(
+    val content: TtsCandidateContent? = null,
+    val finishReason: String? = null,
+)
 
 @Serializable
 internal data class TtsCandidateContent(val parts: List<TtsResponsePart> = emptyList())
@@ -57,4 +61,9 @@ internal data class TtsResponsePart(
 internal data class InlineData(
     val mimeType: String,
     val data: String,
+)
+
+@Serializable
+internal data class TtsPromptFeedback(
+    val blockReason: String? = null,
 )


### PR DESCRIPTION
## Summary
The Gemini TTS path was hiding diagnostic info Gemini already sends on every call. `GeminiTtsClient` threw the same `GeminiTtsEmptyResponseException("Gemini TTS returned no inline-audio part")` for *every* failure mode — safety block, `MAX_TOKENS`, preview-model rejection, missing audio modality, etc. — because the response DTO captured neither `finishReason` on the candidate nor `promptFeedback` on the response.

This was caught while debugging a real failure: the Toast showed `GEMINI TTS failed: returned no inline-audio part`, with no clue why the audio was missing.

## Changes
Mirror the diagnostic pattern already in `DirectGeminiClient`:
- Add `finishReason: String?` to `TtsCandidate`. When the empty-response exception fires, append it to the message: `"Gemini TTS returned no inline-audio part (finishReason=SAFETY)"`.
- Add `promptFeedback: TtsPromptFeedback?` (with `blockReason`) to `TtsResponse`. When a block reason is set, throw a new `GeminiTtsBlockedException("Gemini TTS prompt blocked: SAFETY")` instead of the generic empty-response error.

Settings TTS preview already shows exception messages in a Toast, so the user sees the diagnostic immediately. No downstream changes needed.

## Test plan
- [ ] CI green
- [ ] Manual: trigger Gemini TTS with the previously-failing input and confirm the Toast now shows `finishReason=` or a block reason instead of the generic message

https://claude.ai/code/session_01GqXdR3wZt3KNnHwxSnWGWa

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqXdR3wZt3KNnHwxSnWGWa)_