### PR TITLE
docs — agents must report versionCode after each merge

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,13 @@ new rule the first time something bites you, not the third.
   links as plain text, so a single link can hide the rest of the stack
   (and may surface an already-merged PR while obscuring the live one).
   Worth the extra two lines.
+- **Report Android versionCode after every merge to `main`.** When a PR
+  merges, fetch `main` and run `git rev-list --count origin/main` to get
+  the versionCode (`app/build.gradle.kts` derives it from this count).
+  Report it as e.g. `Need versionCode 72 (b81c23d) or higher to test PR
+  #52's HTTP-error surfacing` — number, short SHA, and a one-clause
+  summary of what the change gates. The user uses this to know which
+  Firebase / locally-built APK contains their fix.
 
 ## CI
 


### PR DESCRIPTION
## Summary
Adds a rule to AGENTS.md telling agents to report the Android versionCode after every merge to `main`. Format example:

> Need versionCode 72 (`b81c23d`) or higher to test PR #52's HTTP-error surfacing.

The user reads this to know which Firebase / locally-built APK contains their fix — `app/build.gradle.kts` derives the versionCode from `git rev-list --count HEAD`, so a fresh `git rev-list --count origin/main` after merge gives the answer.

https://claude.ai/code/session_01GqXdR3wZt3KNnHwxSnWGWa

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqXdR3wZt3KNnHwxSnWGWa)_