### PR TITLE
docs — flip PR-comment rule: "say something or resolve", not "stay silent"

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,8 +51,14 @@ new rule the first time something bites you, not the third.
   CLI is **not** available in this sandbox.
 - Open PRs as **draft** by default. Un-draft only after CI is green and you
   (or the user) have eyeballed the change.
-- Be frugal with PR comments. Only post when there's something the reviewer
-  needs that isn't already in the diff or the PR description.
+- **Never leave a review comment thread silently dismissed.** Either reply on
+  the thread *or* resolve it — the user wants every thread to end in one of
+  those two states, not "left open and ignored." When you think a comment is
+  a false positive, say *why* on the thread (one or two sentences is fine):
+  the reasoning is exactly what the user wants surfaced, and "Linux-only CI,
+  doesn't apply" is more useful on the PR than buried in chat history.
+  Acknowledgement noise ("good catch, will do") is fine and preferred over
+  silence; the discipline is "say something or resolve," not "say nothing."
 - **Always link every open PR in the stack.** Any time you push, summarise
   CI, or invite the user to review, list every currently-open PR on the
   feature by URL — one per line — not just the topmost one. The Claude Code


### PR DESCRIPTION
## Summary

The old `AGENTS.md` rule "Be frugal with PR comments" was making me leave review threads open and silently dismissed when I disagreed with a reviewer's suggestion. The reasoning ended up in chat history instead of on the PR, which is the wrong place for it — a reviewer (or future-me) re-reading the PR months later sees an unaddressed thread, not the diagnosis.

PR #56 surfaced the issue concretely: Copilot left two review comments that were both false positives, I diagnosed them in chat, and would have closed the PR with both threads still open had the user not pushed back. Replied to both belatedly (#56 [#discussion_r3143317494](https://github.com/mikelward/adaptweather/pull/56#discussion_r3143317494), [#discussion_r3143317630](https://github.com/mikelward/adaptweather/pull/56#discussion_r3143317630)).

## Rule change

Replace "be frugal" with **"say something or resolve."** Every review thread ends in one of two states — an explicit reply or a resolve — never "open and ignored." Acknowledgement noise ("good catch, will do") is explicitly fine and preferred over silence. The real discipline is making the *decline* visible: a one-liner like "Linux-only CI, doesn't apply" on the thread is the artifact future-me wants.

## Test plan

- [ ] CI green (docs-only change, no behavioural risk).
- [ ] Eyeball `AGENTS.md` diff.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEYUsrTMwKNn6HsrRoYeHC)_