### PR TITLE
Revert Gemini TTS model rename — `-preview-tts` is still the right name

### DIFF
--- a/app/src/main/kotlin/app/adaptweather/tts/AndroidTtsSpeaker.kt
+++ b/app/src/main/kotlin/app/adaptweather/tts/AndroidTtsSpeaker.kt
@@ -28,7 +28,7 @@ import kotlin.coroutines.resumeWithException
  *    language matches. Voice quality runs from VERY_LOW (100) through VERY_HIGH (500).
  *
  * TODO: evaluate higher-quality alternatives. Two candidates:
- *   - Gemini's audio-output model (`gemini-2.5-flash-tts`). Uses the existing
+ *   - Gemini's audio-output model (`gemini-2.5-flash-preview-tts`). Uses the existing
  *     BYOK key. Network round-trip per speak; produces near-human voices.
  *   - ElevenLabs / OpenAI TTS. Highest fidelity but adds another vendor + key.
  */

--- a/core/data/src/main/kotlin/app/adaptweather/core/data/tts/GeminiTtsClient.kt
+++ b/core/data/src/main/kotlin/app/adaptweather/core/data/tts/GeminiTtsClient.kt
@@ -20,14 +20,14 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import java.util.Base64
 
-const val DEFAULT_GEMINI_TTS_MODEL: String = "gemini-2.5-flash-tts"
+const val DEFAULT_GEMINI_TTS_MODEL: String = "gemini-2.5-flash-preview-tts"
 const val DEFAULT_GEMINI_TTS_VOICE: String = "Kore"
 
 internal const val GEMINI_HOST = "generativelanguage.googleapis.com"
 internal const val GEMINI_API_VERSION = "v1beta"
 
 /**
- * Calls Gemini's audio-output model (e.g. `gemini-2.5-flash-tts`). Uses the
+ * Calls Gemini's audio-output model (e.g. `gemini-2.5-flash-preview-tts`). Uses the
  * standard Generative Language host with a BYOK `x-goog-api-key` header.
  *
  * The model returns a single 16-bit signed PCM audio stream at a sample rate carried

--- a/core/data/src/test/kotlin/app/adaptweather/core/data/tts/GeminiTtsClientTest.kt
+++ b/core/data/src/test/kotlin/app/adaptweather/core/data/tts/GeminiTtsClientTest.kt
@@ -47,7 +47,7 @@ class GeminiTtsClientTest {
     }
 
     @Test
-    fun `posts to the GA tts model endpoint with the api key header`() = runTest {
+    fun `posts to the default tts model endpoint with the api key header`() = runTest {
         var captured: HttpRequestData? = null
         val client = GeminiTtsClient(
             httpClient = mockClient(SUCCESS_BODY) { captured = it },
@@ -58,7 +58,7 @@ class GeminiTtsClientTest {
 
         val req = checkNotNull(captured)
         req.url.host shouldBe GEMINI_HOST
-        req.url.encodedPath shouldBe "/v1beta/models/gemini-2.5-flash-tts:generateContent"
+        req.url.encodedPath shouldBe "/v1beta/models/gemini-2.5-flash-preview-tts:generateContent"
         req.headers["x-goog-api-key"] shouldBe "test-key"
     }
 

--- a/core/domain/src/main/kotlin/app/adaptweather/core/domain/model/Settings.kt
+++ b/core/domain/src/main/kotlin/app/adaptweather/core/domain/model/Settings.kt
@@ -11,7 +11,7 @@ enum class DeliveryMode { NOTIFICATION_ONLY, TTS_ONLY, NOTIFICATION_AND_TTS }
  *
  * - [DEVICE] uses Android's on-device TextToSpeech engine. Free, fully offline once
  *   voices are installed, but quality varies by vendor.
- * - [GEMINI] uses Gemini's audio-output model (`gemini-2.5-flash-tts`) over
+ * - [GEMINI] uses Gemini's audio-output model (`gemini-2.5-flash-preview-tts`) over
  *   the BYOK Gemini key. Near-human quality, requires network at speak-time, costs
  *   a small amount per character. Falls back to [DEVICE] if the call fails.
  * - [OPENAI] uses OpenAI's `audio/speech` endpoint over a separate BYOK OpenAI key.


### PR DESCRIPTION
## Summary

PR #59 swapped the default Gemini TTS model from `gemini-2.5-flash-preview-tts` to `gemini-2.5-flash-tts`, on the (wrong) assumption that the preview alias had been promoted to a GA name. The runtime disagrees:

> `Gemini TTS HTTP 404: models/gemini-2.5-flash-tts is not found for API version v1beta, or is not supported for generateContent. Call ListModels to see the list of av…`

The original `-preview-tts` name is still the right one for the v1beta `generateContent` endpoint as of April 2026.

This PR reverts **just the model string**. The other half of #59 — the HTTP-status check, the parsed `error.message` extraction, and the shorter Settings toast — stays. It's exactly what made this regression visible in one tidy line instead of an ellipsis-truncated JSON dump.

## Test plan

- [x] Updated `GeminiTtsClientTest` endpoint assertion to the reverted name.
- [ ] Manual: tap **Test voice** with engine = Gemini and a valid key — should hear the sample line again instead of the 404 toast.

> [!NOTE]
> Holding off on un-drafting until the in-app test confirms the audio plays.


---
_Generated by [Claude Code](https://claude.ai/code/session_011r2zYNjDML7R475zeXhnMH)_