### PR TITLE
:app — bump InsightCache key to v2 to drop truncated LLM summaries

### DIFF
--- a/app/src/main/kotlin/app/adaptweather/data/InsightCache.kt
+++ b/app/src/main/kotlin/app/adaptweather/data/InsightCache.kt
@@ -121,7 +121,13 @@ class InsightCache(
     )
 
     companion object {
-        private val INSIGHT_JSON = stringPreferencesKey("latest_insight_v1")
+        // Bumped from `latest_insight_v1` when the daily insight moved from a Gemini
+        // text call to the deterministic local renderer. Pre-bump entries can carry
+        // truncated LLM output (`"Today will be"` with nothing after — the band
+        // sentence chopped at maxOutputTokens) and would otherwise stick around
+        // until the user crossed midnight, since the worker reuses any cached
+        // entry that matches `forToday`.
+        private val INSIGHT_JSON = stringPreferencesKey("latest_insight_v2")
 
         fun create(context: Context): InsightCache = InsightCache(context.insightDataStore)
     }

--- a/app/src/test/kotlin/app/adaptweather/data/InsightCacheTest.kt
+++ b/app/src/test/kotlin/app/adaptweather/data/InsightCacheTest.kt
@@ -96,7 +96,7 @@ class InsightCacheTest {
     @Test
     fun `corrupt JSON in the slot maps to null rather than crashing`() = runTest {
         dataStore.edit {
-            it[stringPreferencesKey("latest_insight_v1")] = "{not valid json"
+            it[stringPreferencesKey("latest_insight_v2")] = "{not valid json"
         }
 
         subject.latest.first() shouldBe null
@@ -128,11 +128,10 @@ class InsightCacheTest {
     }
 
     @Test
-    fun `legacy v1 payloads without hourly decode to an empty hourly list`() = runTest {
-        // Simulates a payload written before the hourly field existed: same key,
-        // no `hourly` member. The cache must treat the missing field as empty
-        // rather than crashing — otherwise existing users would see a blank
-        // Today screen until the next worker run.
+    fun `legacy payloads without hourly decode to an empty hourly list`() = runTest {
+        // Simulates a payload written before the hourly field existed. The cache must
+        // treat the missing field as empty rather than crashing — otherwise existing
+        // users would see a blank Today screen until the next worker run.
         val legacyJson = """
             {
               "summary": "Cooler than yesterday — bring a jumper.",
@@ -142,7 +141,7 @@ class InsightCacheTest {
             }
         """.trimIndent()
         dataStore.edit {
-            it[stringPreferencesKey("latest_insight_v1")] = legacyJson
+            it[stringPreferencesKey("latest_insight_v2")] = legacyJson
         }
 
         val read = subject.latest.first()


### PR DESCRIPTION
## Summary

The `Today will be` (silence) symptom in the Settings test-voice button has the same root cause as the daily-notification "Today will be" cutoff the user reported earlier: a stale insight from before PR #54 (`9cdbfcc — render daily insight locally, drop Gemini call`) is still in the per-day cache.

In the LLM era, the prompt asked for `"Today will be <band>."` and `maxOutputTokens=100` capped the response. When the model bailed mid-stream — finish-reason "OTHER" or a streaming hiccup — the stored `summary` could end up as exactly `"Today will be"`. The worker's `forToday` cache hit reuses that broken entry until midnight, and the test-voice button reads the same cache, so it plays three words then goes silent. The deterministic local renderer that replaced the Gemini call can't truncate, so any *new* cache entry is fine — but pre-bump entries can't be told apart from real ones at decode time.

Cleanest fix is to bump the DataStore key:

- `latest_insight_v1` → `latest_insight_v2`
- Pre-bump entries become invisible to the cache.
- Next worker run, or a "Fire insight now" tap, regenerates the day's insight using the deterministic renderer and writes to v2.
- No migration code needed — losing a single day's cached insight is cheap; storage is bounded to one slot anyway.

## Test plan

- [x] `InsightCacheTest` updated: existing `corrupt JSON in the slot maps to null` and `legacy payloads without hourly` tests now write to v2 (their real subject is "schema-tolerance", not "key-name-v1").
- [ ] Manual: install build with this change, open Settings → Test voice. First tap should fall through to the `settings_tts_test_sample` ("Hello — this is the AdaptWeather voice preview.") because the cache is empty. Tap "Fire insight now"; once today's insight is delivered, Test voice should now read the full deterministic summary.
- [ ] Manual: confirm the daily 7am notification reads the full text the next morning.


---
_Generated by [Claude Code](https://claude.ai/code/session_011r2zYNjDML7R475zeXhnMH)_