### PR TITLE
:core:data — actually send responseModalities=[AUDIO] in TTS request (real Gemini-400 root cause)

### DIFF
--- a/core/data/src/main/kotlin/app/adaptweather/core/data/tts/GeminiTtsDto.kt
+++ b/core/data/src/main/kotlin/app/adaptweather/core/data/tts/GeminiTtsDto.kt
@@ -1,5 +1,7 @@
 package app.adaptweather.core.data.tts
 
+import kotlinx.serialization.EncodeDefault
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
 
 /**
@@ -23,7 +25,15 @@ internal data class TtsContent(val parts: List<TtsTextPart>)
 internal data class TtsTextPart(val text: String)
 
 @Serializable
+@OptIn(ExperimentalSerializationApi::class)
 internal data class TtsGenerationConfig(
+    // `@EncodeDefault(ALWAYS)` forces the field onto the wire even when its
+    // runtime value equals the declared default. Without it, kotlinx's default
+    // `encodeDefaults = false` silently drops the field and Gemini falls back
+    // to its server-side default of `responseModalities = ["TEXT"]`, which a
+    // TTS model can't satisfy — error: "The requested combination of response
+    // modalities (TEXT) is not supported by the model."
+    @EncodeDefault(EncodeDefault.Mode.ALWAYS)
     val responseModalities: List<String> = listOf("AUDIO"),
     val speechConfig: SpeechConfig,
 )

--- a/core/data/src/test/kotlin/app/adaptweather/core/data/tts/GeminiTtsClientTest.kt
+++ b/core/data/src/test/kotlin/app/adaptweather/core/data/tts/GeminiTtsClientTest.kt
@@ -63,6 +63,29 @@ class GeminiTtsClientTest {
     }
 
     @Test
+    fun `request body includes responseModalities AUDIO`() = runTest {
+        // Regression for the kotlinx.serialization `encodeDefaults = false` trap:
+        // when the runtime value equals the declared default, the field is dropped
+        // and Gemini falls back to its TEXT modality default — which a TTS model
+        // can't satisfy ("The requested combination of response modalities (TEXT)
+        // is not supported by the model.").
+        var capturedBody: String? = null
+        val client = GeminiTtsClient(
+            httpClient = mockClient(SUCCESS_BODY) {
+                capturedBody = (it.body as io.ktor.http.content.OutgoingContent.ByteArrayContent)
+                    .bytes()
+                    .toString(Charsets.UTF_8)
+            },
+            keyProvider = FakeKeyProvider("test-key"),
+        )
+
+        client.synthesize(text = "hello")
+
+        val body = checkNotNull(capturedBody)
+        body.shouldContain("\"responseModalities\":[\"AUDIO\"]")
+    }
+
+    @Test
     fun `decodes inline pcm and parses sample rate from mime type`() = runTest {
         val client = GeminiTtsClient(
             httpClient = mockClient(SUCCESS_BODY),


### PR DESCRIPTION
## Summary

This is the actual root cause of every `"Gemini TTS HTTP 400"` we've been chasing across PRs #59 / #60 / #62. It was *never* the model name or the key — the request literally did not include `responseModalities` at all, so Gemini's server defaulted to `["TEXT"]` and rejected: *"The requested combination of response modalities (TEXT) is not supported by the model."*

### Why the field went missing

`TtsGenerationConfig` declared:

```kotlin
val responseModalities: List<String> = listOf("AUDIO"),
```

…and the call site in `GeminiTtsClient.synthesize()` passed the same value:

```kotlin
TtsGenerationConfig(
    responseModalities = listOf("AUDIO"),
    ...
)
```

kotlinx.serialization defaults to `encodeDefaults = false`, meaning a property whose runtime value is bit-for-bit equal to its declared default is **omitted from the JSON**. Since we passed exactly the default, the field was silently dropped. The body Gemini received looked like:

```json
{"contents":[...], "generationConfig":{"speechConfig":{...}}}
```

No `responseModalities` → server-side default of `["TEXT"]` → 400.

### Fix

`@EncodeDefault(EncodeDefault.Mode.ALWAYS)` forces the field onto the wire regardless of whether its value equals the default. Targeted to just this one property — no global config change, no behaviour change for any other DTO.

### Side note

The error-message-shortening + JSON-envelope-parsing work in PR #59 / #62 is what made this diagnosable. The original HTTP 400 toast was truncated by the OS at "Gemini TTS HTTP 400: {\"error\":..."; the parsed-`error.message` toast in this session showed the full sentence "The requested combination of response modalities (TEXT)..." which named the actual problem.

## Test plan

- [x] New regression test `request body includes responseModalities AUDIO` captures the outgoing request body and asserts the substring `"responseModalities":["AUDIO"]` is present.
- [ ] Manual: install ≥ this build, set Gemini key, tap Test voice — should now hear the preview voice instead of seeing the HTTP 400 toast.


---
_Generated by [Claude Code](https://claude.ai/code/session_011r2zYNjDML7R475zeXhnMH)_