### PR TITLE
Locale-aware TTS voice and accent picker

### DIFF
--- a/app/src/main/kotlin/app/adaptweather/data/SettingsRepository.kt
+++ b/app/src/main/kotlin/app/adaptweather/data/SettingsRepository.kt
@@ -16,7 +16,9 @@ import app.adaptweather.core.domain.model.Schedule
 import app.adaptweather.core.domain.model.TemperatureUnit
 import app.adaptweather.core.domain.model.TtsEngine
 import app.adaptweather.core.domain.model.UserPreferences
+import app.adaptweather.core.domain.model.VoiceLocale
 import app.adaptweather.core.domain.model.WardrobeRule
+import app.adaptweather.tts.defaultOpenAiVoiceFor
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.serialization.decodeFromString
@@ -101,6 +103,10 @@ class SettingsRepository(
         dataStore.edit { it[OPENAI_VOICE] = voice }
     }
 
+    suspend fun setVoiceLocale(locale: VoiceLocale) {
+        dataStore.edit { it[VOICE_LOCALE] = locale.name }
+    }
+
     private fun Preferences.toUserPreferences(): UserPreferences {
         val time = this[SCHEDULE_TIME]?.let { LocalTime.parse(it, TIME_FORMAT) }
             ?: DEFAULT_TIME
@@ -121,8 +127,12 @@ class SettingsRepository(
             ?: TtsEngine.DEVICE
         val geminiVoice = this[GEMINI_VOICE]?.takeIf { it.isNotBlank() }
             ?: UserPreferences.DEFAULT_GEMINI_VOICE
+        val voiceLocale = this[VOICE_LOCALE]?.let { runCatching { VoiceLocale.valueOf(it) }.getOrNull() }
+            ?: VoiceLocale.SYSTEM
+        // OpenAI default depends on locale (en-GB → fable; everything else → nova).
+        // Resolve only after voiceLocale is known so the picked voice matches.
         val openAiVoice = this[OPENAI_VOICE]?.takeIf { it.isNotBlank() }
-            ?: UserPreferences.DEFAULT_OPENAI_VOICE
+            ?: defaultOpenAiVoiceFor(voiceLocale)
 
         return UserPreferences(
             schedule = Schedule(time = time, days = days, zoneId = zoneIdProvider()),
@@ -135,6 +145,7 @@ class SettingsRepository(
             ttsEngine = ttsEngine,
             geminiVoice = geminiVoice,
             openAiVoice = openAiVoice,
+            voiceLocale = voiceLocale,
         )
     }
 
@@ -171,6 +182,7 @@ class SettingsRepository(
         private val TTS_ENGINE = stringPreferencesKey("tts_engine")
         private val GEMINI_VOICE = stringPreferencesKey("gemini_voice")
         private val OPENAI_VOICE = stringPreferencesKey("openai_voice")
+        private val VOICE_LOCALE = stringPreferencesKey("voice_locale")
 
         private val TIME_FORMAT: DateTimeFormatter = DateTimeFormatter.ofPattern("HH:mm")
         private val DEFAULT_TIME: LocalTime = LocalTime.of(7, 0)

--- a/app/src/main/kotlin/app/adaptweather/tts/VoiceLocaleExt.kt
+++ b/app/src/main/kotlin/app/adaptweather/tts/VoiceLocaleExt.kt
@@ -1,0 +1,32 @@
+package app.adaptweather.tts
+
+import app.adaptweather.core.domain.model.VoiceLocale
+import java.util.Locale
+
+/**
+ * Maps a [VoiceLocale] preference to a concrete [Locale].
+ *
+ * Returns null for [VoiceLocale.SYSTEM] so callers can fall back to
+ * `Locale.getDefault()` themselves — keeps the "follow the phone" semantics
+ * deferred to the call site instead of baking it in here.
+ */
+fun VoiceLocale.toJavaLocale(): Locale? = bcp47?.let { Locale.forLanguageTag(it) }
+
+fun VoiceLocale.resolve(): Locale = toJavaLocale() ?: Locale.getDefault()
+
+/**
+ * Picks the most natural OpenAI voice for a given locale preference.
+ *
+ * OpenAI's TTS voices have fixed accents — `fable` is the only British
+ * option; the rest are American. There's no Australian voice, so en-AU
+ * falls back to American `nova` (closest "bright female" timbre) rather
+ * than to British `fable`.
+ *
+ * Used as the *default* when the user hasn't explicitly chosen a voice;
+ * once they pick one in Settings the chosen voice wins regardless of locale.
+ */
+fun defaultOpenAiVoiceFor(voiceLocale: VoiceLocale): String {
+    val effective = voiceLocale.resolve()
+    val isBritish = effective.language == "en" && effective.country == "GB"
+    return if (isBritish) "fable" else "nova"
+}

--- a/app/src/main/kotlin/app/adaptweather/ui/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/app/adaptweather/ui/settings/SettingsScreen.kt
@@ -56,12 +56,14 @@ import app.adaptweather.core.domain.model.DistanceUnit
 import app.adaptweather.core.domain.model.Location
 import app.adaptweather.core.domain.model.TemperatureUnit
 import app.adaptweather.core.domain.model.TtsEngine
+import app.adaptweather.core.domain.model.VoiceLocale
 import app.adaptweather.core.domain.model.WardrobeRule
 import app.adaptweather.tts.GEMINI_VOICES
 import app.adaptweather.tts.GeminiTtsSpeaker
 import app.adaptweather.tts.OPENAI_VOICES
 import app.adaptweather.tts.OpenAITtsSpeaker
 import app.adaptweather.tts.TtsVoiceOption
+import app.adaptweather.tts.resolve
 import app.adaptweather.work.FetchAndNotifyWorker
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
@@ -116,6 +118,7 @@ fun SettingsScreen(viewModel: SettingsViewModel, onNavigateBack: () -> Unit) {
             onSetOpenAiVoice = viewModel::setOpenAiVoice,
             onSetOpenAiKey = viewModel::setOpenAiKey,
             onClearOpenAiKey = viewModel::clearOpenAiKey,
+            onSetVoiceLocale = viewModel::setVoiceLocale,
         )
     }
 }
@@ -142,6 +145,7 @@ private fun SettingsContent(
     onSetOpenAiVoice: (String) -> Unit,
     onSetOpenAiKey: (String) -> Unit,
     onClearOpenAiKey: () -> Unit,
+    onSetVoiceLocale: (VoiceLocale) -> Unit,
 ) {
     Column(
         modifier = Modifier
@@ -183,6 +187,8 @@ private fun SettingsContent(
             onOpenAiVoice = onSetOpenAiVoice,
             geminiKeyConfigured = state.apiKeyConfigured,
             openAiKeyConfigured = state.openAiKeyConfigured,
+            voiceLocale = state.voiceLocale,
+            onSetVoiceLocale = onSetVoiceLocale,
         )
         TemperatureUnitCard(state.temperatureUnit, onSetTemperatureUnit)
         DistanceUnitCard(state.distanceUnit, onSetDistanceUnit)
@@ -889,6 +895,8 @@ private fun TtsEngineCard(
     onOpenAiVoice: (String) -> Unit,
     geminiKeyConfigured: Boolean,
     openAiKeyConfigured: Boolean,
+    voiceLocale: VoiceLocale,
+    onSetVoiceLocale: (VoiceLocale) -> Unit,
 ) {
     val context = LocalContext.current
     val coroutineScope = rememberCoroutineScope()
@@ -900,7 +908,7 @@ private fun TtsEngineCard(
     fun preview(engine: TtsEngine, gVoice: String, oVoice: String) {
         previewJob?.cancel()
         previewJob = coroutineScope.launch {
-            runTtsPreview(context, engine, gVoice, oVoice)
+            runTtsPreview(context, engine, gVoice, oVoice, voiceLocale)
         }
     }
 
@@ -955,7 +963,16 @@ private fun TtsEngineCard(
                 )
                 TestVoiceButton { preview(selected, geminiVoice, openAiVoice) }
             }
-            TtsEngine.DEVICE -> Unit
+            TtsEngine.DEVICE -> {
+                VoiceLocalePicker(
+                    selected = voiceLocale,
+                    onSelect = {
+                        onSetVoiceLocale(it)
+                        preview(selected, geminiVoice, openAiVoice)
+                    },
+                )
+                TestVoiceButton { preview(selected, geminiVoice, openAiVoice) }
+            }
         }
     }
 }
@@ -972,6 +989,53 @@ private fun MissingKeyHint(engineName: String) {
         style = MaterialTheme.typography.bodyMedium,
         color = MaterialTheme.colorScheme.error,
     )
+}
+
+@Composable
+private fun VoiceLocalePicker(
+    selected: VoiceLocale,
+    onSelect: (VoiceLocale) -> Unit,
+) {
+    var dialogOpen by remember { mutableStateOf(false) }
+    val title = stringResource(R.string.settings_tts_voice_locale_label)
+    OutlinedButton(
+        onClick = { dialogOpen = true },
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Text("$title: ${stringResource(voiceLocaleLabel(selected))}")
+    }
+    if (dialogOpen) {
+        AlertDialog(
+            onDismissRequest = { dialogOpen = false },
+            title = { Text(title) },
+            text = {
+                Column {
+                    VoiceLocale.entries.forEach { option ->
+                        RadioRow(
+                            label = stringResource(voiceLocaleLabel(option)),
+                            selected = option == selected,
+                            onSelect = {
+                                onSelect(option)
+                                dialogOpen = false
+                            },
+                        )
+                    }
+                }
+            },
+            confirmButton = {
+                TextButton(onClick = { dialogOpen = false }) {
+                    Text(stringResource(R.string.settings_tts_voice_dismiss))
+                }
+            },
+        )
+    }
+}
+
+private fun voiceLocaleLabel(locale: VoiceLocale): Int = when (locale) {
+    VoiceLocale.SYSTEM -> R.string.settings_tts_voice_locale_system
+    VoiceLocale.EN_US -> R.string.settings_tts_voice_locale_en_us
+    VoiceLocale.EN_GB -> R.string.settings_tts_voice_locale_en_gb
+    VoiceLocale.EN_AU -> R.string.settings_tts_voice_locale_en_au
 }
 
 @Composable
@@ -1037,6 +1101,7 @@ private suspend fun runTtsPreview(
     engine: TtsEngine,
     geminiVoice: String,
     openAiVoice: String,
+    voiceLocale: VoiceLocale,
 ) {
     val app = context.applicationContext as app.adaptweather.AdaptWeatherApplication
     // Network synthesis and AudioTrack write are both blocking-ish work — Ktor
@@ -1045,14 +1110,15 @@ private suspend fun runTtsPreview(
     withContext(Dispatchers.IO) {
         val text = app.insightCache.latest.first()?.spokenText()
             ?: context.getString(R.string.settings_tts_test_sample)
+        val locale = voiceLocale.resolve()
         try {
             when (engine) {
                 TtsEngine.GEMINI ->
-                    GeminiTtsSpeaker(app.geminiTtsClient, voiceName = geminiVoice).speak(text)
+                    GeminiTtsSpeaker(app.geminiTtsClient, voiceName = geminiVoice).speak(text, locale)
                 TtsEngine.OPENAI ->
-                    OpenAITtsSpeaker(app.openAiTtsClient, voice = openAiVoice).speak(text)
+                    OpenAITtsSpeaker(app.openAiTtsClient, voice = openAiVoice).speak(text, locale)
                 TtsEngine.DEVICE ->
-                    app.deviceTtsSpeaker.speak(text)
+                    app.deviceTtsSpeaker.speak(text, locale)
             }
         } catch (_: CancellationException) {
             // Expected when the user picks a different option mid-playback; not an error.
@@ -1070,7 +1136,7 @@ private suspend fun runTtsPreview(
             // and can confirm audio output is working — mirrors FetchAndNotifyWorker.
             if (engine != TtsEngine.DEVICE) {
                 try {
-                    app.deviceTtsSpeaker.speak(text)
+                    app.deviceTtsSpeaker.speak(text, locale)
                 } catch (_: CancellationException) {
                     // user moved on; fine
                 } catch (fallback: Throwable) {

--- a/app/src/main/kotlin/app/adaptweather/ui/settings/SettingsState.kt
+++ b/app/src/main/kotlin/app/adaptweather/ui/settings/SettingsState.kt
@@ -7,7 +7,9 @@ import app.adaptweather.core.domain.model.Schedule
 import app.adaptweather.core.domain.model.TemperatureUnit
 import app.adaptweather.core.domain.model.TtsEngine
 import app.adaptweather.core.domain.model.UserPreferences
+import app.adaptweather.core.domain.model.VoiceLocale
 import app.adaptweather.core.domain.model.WardrobeRule
+import app.adaptweather.tts.defaultOpenAiVoiceFor
 import java.time.DayOfWeek
 import java.time.LocalTime
 
@@ -23,7 +25,12 @@ data class SettingsState(
     val useDeviceLocation: Boolean = false,
     val ttsEngine: TtsEngine = TtsEngine.DEVICE,
     val geminiVoice: String = UserPreferences.DEFAULT_GEMINI_VOICE,
-    val openAiVoice: String = UserPreferences.DEFAULT_OPENAI_VOICE,
+    // Match SettingsRepository's locale-aware default so the picker doesn't
+    // briefly render "alloy" before the first DataStore emission overrides it.
+    // When voiceLocale is SYSTEM (the default), this resolves through the phone's
+    // current locale → fable on en-GB, nova everywhere else.
+    val openAiVoice: String = defaultOpenAiVoiceFor(VoiceLocale.SYSTEM),
+    val voiceLocale: VoiceLocale = VoiceLocale.SYSTEM,
     val apiKeyConfigured: Boolean = false,
     val openAiKeyConfigured: Boolean = false,
 )

--- a/app/src/main/kotlin/app/adaptweather/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/app/adaptweather/ui/settings/SettingsViewModel.kt
@@ -10,6 +10,7 @@ import app.adaptweather.core.domain.model.Location
 import app.adaptweather.core.domain.model.Schedule
 import app.adaptweather.core.domain.model.TemperatureUnit
 import app.adaptweather.core.domain.model.TtsEngine
+import app.adaptweather.core.domain.model.VoiceLocale
 import app.adaptweather.core.domain.model.WardrobeRule
 import app.adaptweather.data.SecureKeyStore
 import app.adaptweather.data.SettingsRepository
@@ -48,6 +49,7 @@ class SettingsViewModel(
                         ttsEngine = prefs.ttsEngine,
                         geminiVoice = prefs.geminiVoice,
                         openAiVoice = prefs.openAiVoice,
+                        voiceLocale = prefs.voiceLocale,
                     )
                 }
             }
@@ -139,6 +141,10 @@ class SettingsViewModel(
 
     fun setTtsEngine(engine: TtsEngine) {
         viewModelScope.launch { settingsRepository.setTtsEngine(engine) }
+    }
+
+    fun setVoiceLocale(locale: VoiceLocale) {
+        viewModelScope.launch { settingsRepository.setVoiceLocale(locale) }
     }
 
     /** Used by [LocationCard] inside a LaunchedEffect; safe to call from any dispatcher. */

--- a/app/src/main/kotlin/app/adaptweather/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/app/adaptweather/work/FetchAndNotifyWorker.kt
@@ -19,6 +19,7 @@ import app.adaptweather.core.domain.model.TtsEngine
 import app.adaptweather.core.domain.model.UserPreferences
 import app.adaptweather.tts.GeminiTtsSpeaker
 import app.adaptweather.tts.OpenAITtsSpeaker
+import app.adaptweather.tts.resolve
 import io.ktor.client.network.sockets.ConnectTimeoutException
 import io.ktor.client.network.sockets.SocketTimeoutException
 import io.ktor.client.plugins.HttpRequestTimeoutException
@@ -158,10 +159,11 @@ class FetchAndNotifyWorker(
      * path is the primary delivery channel and has already fired by this point.
      */
     private suspend fun speakWithFallback(text: String, prefs: UserPreferences) {
+        val locale = prefs.voiceLocale.resolve()
         when (prefs.ttsEngine) {
             TtsEngine.GEMINI -> {
                 try {
-                    GeminiTtsSpeaker(app.geminiTtsClient, voiceName = prefs.geminiVoice).speak(text)
+                    GeminiTtsSpeaker(app.geminiTtsClient, voiceName = prefs.geminiVoice).speak(text, locale)
                     return
                 } catch (t: Throwable) {
                     Log.w(TAG, "Gemini TTS failed; falling back to device TTS.", t)
@@ -169,7 +171,7 @@ class FetchAndNotifyWorker(
             }
             TtsEngine.OPENAI -> {
                 try {
-                    OpenAITtsSpeaker(app.openAiTtsClient, voice = prefs.openAiVoice).speak(text)
+                    OpenAITtsSpeaker(app.openAiTtsClient, voice = prefs.openAiVoice).speak(text, locale)
                     return
                 } catch (t: Throwable) {
                     Log.w(TAG, "OpenAI TTS failed; falling back to device TTS.", t)
@@ -178,7 +180,7 @@ class FetchAndNotifyWorker(
             TtsEngine.DEVICE -> Unit
         }
         try {
-            app.deviceTtsSpeaker.speak(text)
+            app.deviceTtsSpeaker.speak(text, locale)
         } catch (t: Throwable) {
             Log.w(TAG, "Device TTS failed; insight is still posted as notification.", t)
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -76,6 +76,11 @@
     <string name="settings_tts_engine_openai">OpenAI (high quality, online)</string>
     <string name="settings_tts_voice_label">Voice</string>
     <string name="settings_tts_voice_dismiss">Done</string>
+    <string name="settings_tts_voice_locale_label">English variant</string>
+    <string name="settings_tts_voice_locale_system">Follow phone language</string>
+    <string name="settings_tts_voice_locale_en_us">English (United States)</string>
+    <string name="settings_tts_voice_locale_en_gb">English (United Kingdom)</string>
+    <string name="settings_tts_voice_locale_en_au">English (Australia)</string>
     <string name="settings_tts_test">Test voice</string>
     <!-- Shown next to the engine picker when the chosen engine's API key isn't
          configured. %1$s is the engine name ("Gemini" / "OpenAI"). -->

--- a/app/src/test/kotlin/app/adaptweather/data/SettingsRepositoryTest.kt
+++ b/app/src/test/kotlin/app/adaptweather/data/SettingsRepositoryTest.kt
@@ -10,6 +10,7 @@ import app.adaptweather.core.domain.model.DeliveryMode
 import app.adaptweather.core.domain.model.DistanceUnit
 import app.adaptweather.core.domain.model.Schedule
 import app.adaptweather.core.domain.model.TemperatureUnit
+import app.adaptweather.core.domain.model.VoiceLocale
 import app.adaptweather.core.domain.model.WardrobeRule
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.collections.shouldContainExactly
@@ -164,10 +165,31 @@ class SettingsRepositoryTest {
     }
 
     @Test
-    fun `voice prefs default to Kore and alloy when nothing stored`() = runTest {
-        val prefs = subject.preferences.first()
-        prefs.geminiVoice shouldBe "Kore"
-        prefs.openAiVoice shouldBe "alloy"
+    fun `gemini voice defaults to Kore when nothing stored`() = runTest {
+        subject.preferences.first().geminiVoice shouldBe "Kore"
+    }
+
+    @Test
+    fun `openAiVoice defaults to nova for non-British locale preferences`() = runTest {
+        subject.setVoiceLocale(VoiceLocale.EN_US)
+        subject.preferences.first().openAiVoice shouldBe "nova"
+
+        subject.setVoiceLocale(VoiceLocale.EN_AU)
+        subject.preferences.first().openAiVoice shouldBe "nova"
+    }
+
+    @Test
+    fun `openAiVoice defaults to fable for the en-GB locale preference`() = runTest {
+        subject.setVoiceLocale(VoiceLocale.EN_GB)
+        subject.preferences.first().openAiVoice shouldBe "fable"
+    }
+
+    @Test
+    fun `explicitly chosen openAiVoice overrides the locale-derived default`() = runTest {
+        subject.setVoiceLocale(VoiceLocale.EN_GB)
+        subject.setOpenAiVoice("alloy")
+
+        subject.preferences.first().openAiVoice shouldBe "alloy"
     }
 
     @Test

--- a/core/domain/src/main/kotlin/app/adaptweather/core/domain/model/Settings.kt
+++ b/core/domain/src/main/kotlin/app/adaptweather/core/domain/model/Settings.kt
@@ -19,6 +19,34 @@ enum class DeliveryMode { NOTIFICATION_ONLY, TTS_ONLY, NOTIFICATION_AND_TTS }
  */
 enum class TtsEngine { DEVICE, GEMINI, OPENAI }
 
+/**
+ * User-selectable accent / language preference for spoken playback. Used in
+ * two ways:
+ *
+ *  - For [TtsEngine.DEVICE] it picks the actual voice to speak in (the
+ *    Android TextToSpeech engine has separate en-US / en-GB / en-AU voices).
+ *  - For [TtsEngine.OPENAI] it influences the *default* voice when the user
+ *    hasn't explicitly chosen one — en-GB picks `fable` (the only British
+ *    voice), everything else picks `nova`. Once the user explicitly picks
+ *    a voice in Settings, that choice wins regardless of locale.
+ *
+ * Gemini's prebuilt voices are language-agnostic personalities, so this
+ * preference doesn't change the Gemini voice — but the resolved [java.util.Locale]
+ * is still passed through to all engines for consistency at the call sites.
+ *
+ * [SYSTEM] means "follow the phone's locale" — the right default for almost
+ * everyone, since their device language already encodes their accent
+ * preference. The explicit en-* options are for users whose phone locale
+ * doesn't match the accent they want to hear (e.g. an en-AU speaker on an
+ * en-US phone).
+ */
+enum class VoiceLocale(val bcp47: String?) {
+    SYSTEM(null),
+    EN_US("en-US"),
+    EN_GB("en-GB"),
+    EN_AU("en-AU"),
+}
+
 data class UserPreferences(
     val schedule: Schedule,
     val deliveryMode: DeliveryMode,
@@ -49,6 +77,7 @@ data class UserPreferences(
      * == [TtsEngine.OPENAI].
      */
     val openAiVoice: String = DEFAULT_OPENAI_VOICE,
+    val voiceLocale: VoiceLocale = VoiceLocale.SYSTEM,
 ) {
     companion object {
         const val DEFAULT_GEMINI_VOICE = "Kore"


### PR DESCRIPTION
Replaces #66 — same content, clean linear history off `main` (no merge commits).

## Summary

Adds a `VoiceLocale` preference (System / en-US / en-GB / en-AU) shown in Settings under the device TTS engine. Default is `System`, which preserves current behaviour (`Locale.getDefault()` → best matching voice). Picker only surfaces for the `DEVICE` engine — OpenAI/Gemini voices have fixed accents, so a regional control there would be misleading. Routed through `FetchAndNotifyWorker.speakWithFallback` and the Settings preview path so a tap immediately plays back in the chosen accent.

The OpenAI default voice is now also locale-aware:

- `EN_GB` → `fable` (the only British voice in OpenAI's lineup)
- `EN_US` / `EN_AU` / `SYSTEM`-on-non-en-GB → `nova`

This is a *default-only* change — once a user explicitly picks an OpenAI voice in Settings, that choice persists regardless of locale changes. Existing users who never picked a voice silently move from `alloy` to the new locale-appropriate default.

OpenAI has no Australian-accented voice, so en-AU falls back to `nova` rather than to British `fable`. Gemini's voices are language-agnostic personalities and aren't remapped per locale.

`SettingsState`'s initial `openAiVoice` mirrors the same locale-aware default so the picker doesn't briefly render `alloy` before the first DataStore emission overrides it.

## Test plan

- [ ] Open Settings, pick Device engine — picker appears with four options
- [ ] Switch picker to en-GB on a US-locale phone, tap Test voice — UK accent plays
- [ ] Switch picker to en-AU, tap Test voice — AU accent plays (where available on the device)
- [ ] Set picker to System, change phone language to en-GB, fire morning insight — speaks with UK accent
- [ ] Switch to OpenAI engine on en-US — voice picker pre-selects `nova`
- [ ] Switch picker to en-GB while on OpenAI — voice picker pre-selects `fable`
- [ ] Pick a different OpenAI voice explicitly, switch picker to en-GB — explicit choice persists (not overridden)
- [ ] Existing users without the new key in DataStore default to `SYSTEM` (no migration required)

https://claude.ai/code/session_01T5P8n8dTywRkQqFfTCBUWS

---
_Generated by [Claude Code](https://claude.ai/code/session_01T5P8n8dTywRkQqFfTCBUWS)_