### PR TITLE
Byte-swap Gemini TTS PCM (fixes continuous static)

### DIFF
--- a/core/data/src/main/kotlin/app/adaptweather/core/data/tts/GeminiTtsClient.kt
+++ b/core/data/src/main/kotlin/app/adaptweather/core/data/tts/GeminiTtsClient.kt
@@ -32,7 +32,13 @@ internal const val GEMINI_API_VERSION = "v1beta"
  *
  * The model returns a single 16-bit signed PCM audio stream at a sample rate carried
  * in the `mimeType` (`audio/L16;codec=pcm;rate=24000`). [PcmAudio.sampleRate] parses
- * that out of the response so the caller can hand the bytes straight to AudioTrack.
+ * that out of the response.
+ *
+ * **Endianness**: per RFC 2586, `audio/L16` is *big-endian* (network byte order).
+ * Android `AudioTrack` only consumes little-endian PCM16, so we byte-swap each
+ * 16-bit sample after decode. Without this, every sample is byte-flipped, which
+ * sounds like continuous static throughout playback. (OpenAI's `pcm` response
+ * format is documented as little-endian, so [OpenAITtsClient] doesn't need this.)
  *
  * Default voice is `Kore` (firm). Other prebuilt voices are listed in Google's docs;
  * pass via [voiceName] when calling.
@@ -94,8 +100,21 @@ class GeminiTtsClient(
             ?: throw GeminiTtsEmptyResponseException(candidate?.finishReason)
 
         val pcm = Base64.getDecoder().decode(inline.data)
+        swapBytePairsInPlace(pcm)
         val sampleRate = parseSampleRate(inline.mimeType) ?: DEFAULT_SAMPLE_RATE_HZ
         return PcmAudio(bytes = pcm, sampleRate = sampleRate)
+    }
+
+    /** Big-endian → little-endian conversion for 16-bit samples; see class KDoc. */
+    private fun swapBytePairsInPlace(bytes: ByteArray) {
+        var i = 0
+        val end = bytes.size and 1.inv() // round down to even — last odd byte (if any) left untouched
+        while (i < end) {
+            val tmp = bytes[i]
+            bytes[i] = bytes[i + 1]
+            bytes[i + 1] = tmp
+            i += 2
+        }
     }
 
     private fun parseSampleRate(mimeType: String): Int? {

--- a/core/data/src/test/kotlin/app/adaptweather/core/data/tts/GeminiTtsClientTest.kt
+++ b/core/data/src/test/kotlin/app/adaptweather/core/data/tts/GeminiTtsClientTest.kt
@@ -94,8 +94,10 @@ class GeminiTtsClientTest {
 
         val audio = client.synthesize(text = "hello")
 
-        // SUCCESS_BODY encodes the four bytes 0xDE 0xAD 0xBE 0xEF.
-        audio.bytes.toList() shouldBe listOf(0xDE.toByte(), 0xAD.toByte(), 0xBE.toByte(), 0xEF.toByte())
+        // SUCCESS_BODY encodes the four bytes 0xDE 0xAD 0xBE 0xEF in big-endian
+        // L16 (per RFC 2586). The client byte-swaps each 16-bit sample so AudioTrack
+        // (which only consumes little-endian PCM16) plays them correctly.
+        audio.bytes.toList() shouldBe listOf(0xAD.toByte(), 0xDE.toByte(), 0xEF.toByte(), 0xBE.toByte())
         audio.sampleRate shouldBe 24_000
     }
 


### PR DESCRIPTION
## Summary

Gemini's TTS reports `mimeType: audio/L16;codec=pcm;rate=24000`. Per [RFC 2586](https://datatracker.ietf.org/doc/html/rfc2586), `audio/L16` is **big-endian** (network byte order). Android `AudioTrack` only consumes little-endian PCM16, so feeding Gemini's bytes straight in flips every 16-bit sample — which sounds like continuous static / crackle throughout the entire utterance.

This PR byte-swaps each 16-bit sample after base64 decode in `GeminiTtsClient`.

OpenAI's `pcm` response format is documented as little-endian, so `OpenAITtsClient` doesn't need the same treatment (and was reported clean by the user).

## Why the previous TTS cleanup commit didn't fix it

`e5e3a53` (`clean up Gemini TTS playback and surface smoother voices`) addressed buffer sizing and `AudioAttributes` routing — that smoothed boundary pops but had nothing to do with sample byte order.

## Test plan

- [ ] Play a Gemini TTS utterance → speech is clear, no continuous crackle / static
- [ ] Play an OpenAI TTS utterance → still clear (regression check on the unchanged path)
- [ ] Existing unit test covers the byte-swap (`decodes inline pcm and parses sample rate from mime type` — assertion updated to expect swapped order)

https://claude.ai/code/session_01T5P8n8dTywRkQqFfTCBUWS

---
_Generated by [Claude Code](https://claude.ai/code/session_01T5P8n8dTywRkQqFfTCBUWS)_