### PR TITLE
Refresh button bypasses today's cache

### DIFF
--- a/app/src/main/kotlin/app/adaptweather/ui/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/app/adaptweather/ui/settings/SettingsScreen.kt
@@ -964,6 +964,12 @@ private fun TtsEngineCard(
                 TestVoiceButton { preview(selected, geminiVoice, openAiVoice) }
             }
             TtsEngine.DEVICE -> {
+                // TODO: promote VoiceLocalePicker out of TtsEngineCard. The locale
+                // also drives the OpenAI default voice (en-GB → fable, else nova),
+                // so users on the OpenAI engine can't currently see/change it
+                // without switching to Device first. The picker should live in its
+                // own section above the engine card so it's visible regardless of
+                // engine choice.
                 VoiceLocalePicker(
                     selected = voiceLocale,
                     onSelect = {

--- a/app/src/main/kotlin/app/adaptweather/ui/today/TodayScreen.kt
+++ b/app/src/main/kotlin/app/adaptweather/ui/today/TodayScreen.kt
@@ -354,7 +354,11 @@ private fun ForecastCard(hourly: List<HourlyForecast>, temperatureUnit: Temperat
 }
 
 private fun triggerRefresh(context: android.content.Context) {
-    FetchAndNotifyWorker.enqueueOneShot(context.applicationContext)
+    // force=true so an explicit user tap bypasses the same-day cache and
+    // actually regenerates. Without this, Refresh on the same calendar day
+    // just redelivers the morning's payload — surprising when the user has
+    // changed wardrobe rules, location, or the underlying forecast has moved.
+    FetchAndNotifyWorker.enqueueOneShot(context.applicationContext, force = true)
     Toast.makeText(
         context,
         context.getString(R.string.today_refresh_toast),

--- a/app/src/main/kotlin/app/adaptweather/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/app/adaptweather/work/FetchAndNotifyWorker.kt
@@ -57,11 +57,27 @@ class FetchAndNotifyWorker(
 
         val location = resolveLocation(prefs)
         val today = LocalDate.now()
+        val forceRefresh = inputData.getBoolean(KEY_FORCE_REFRESH, false)
 
         // 24h cost cap: if we already generated an insight for today, redeliver it
         // rather than refetching. Same path serves the morning alarm and any
         // "Fire insight now" debug taps later in the day.
-        val cached = runCatching { app.insightCache.forToday(today) }.getOrNull()
+        //
+        // The Today screen's Refresh button sets [KEY_FORCE_REFRESH] = true so an
+        // explicit user tap always regenerates — without that flag, tapping Refresh
+        // on the same calendar day just redelivers the same cached payload, which
+        // is surprising for the user.
+        //
+        // TODO: opportunistic auto-refresh — when the user opens the app and the
+        // cached insight is more than ~1h old, regenerate (bypassing the same-day
+        // cache). Avoids a full Refresh tap when the wardrobe / forecast has moved
+        // since the morning generation.
+        val cached = if (forceRefresh) {
+            Log.i(TAG, "Force refresh requested; bypassing today's cache.")
+            null
+        } else {
+            runCatching { app.insightCache.forToday(today) }.getOrNull()
+        }
         if (cached != null) {
             Log.i(TAG, "Using cached insight for ${cached.forDate}.")
             return runCatching { deliver(cached, prefs) }
@@ -197,6 +213,9 @@ class FetchAndNotifyWorker(
         const val REASON_UNEXPECTED_HTTP = "unexpected_http"
         const val REASON_UNHANDLED = "unhandled"
 
+        /** Set true via [enqueueOneShot] when the user explicitly taps Refresh. */
+        private const val KEY_FORCE_REFRESH = "force_refresh"
+
         // Fallback when the user hasn't set a location yet — the pipeline still runs and
         // posts a (London) insight rather than silently failing. The Settings screen
         // surfaces an empty-location card so the user can change it.
@@ -206,7 +225,7 @@ class FetchAndNotifyWorker(
             displayName = "London (default)",
         )
 
-        fun enqueueOneShot(context: Context) {
+        fun enqueueOneShot(context: Context, force: Boolean = false) {
             val constraints = Constraints.Builder()
                 .setRequiredNetworkType(NetworkType.CONNECTED)
                 .build()
@@ -214,12 +233,15 @@ class FetchAndNotifyWorker(
             val request = OneTimeWorkRequestBuilder<FetchAndNotifyWorker>()
                 .setConstraints(constraints)
                 .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, 30, TimeUnit.SECONDS)
+                .setInputData(workDataOf(KEY_FORCE_REFRESH to force))
                 .build()
 
-            // KEEP: if a previous run is still in flight (e.g. retrying), don't start
-            // a duplicate. The next 7am alarm will enqueue afresh.
+            // Alarm-driven enqueues use KEEP so a still-retrying run isn't duplicated.
+            // User-initiated force enqueues use REPLACE — the user just tapped Refresh
+            // expecting a fresh fetch, so cancel any in-flight retry and start over.
+            val policy = if (force) ExistingWorkPolicy.REPLACE else ExistingWorkPolicy.KEEP
             WorkManager.getInstance(context)
-                .enqueueUniqueWork(UNIQUE_WORK_NAME, ExistingWorkPolicy.KEEP, request)
+                .enqueueUniqueWork(UNIQUE_WORK_NAME, policy, request)
         }
     }
 }


### PR DESCRIPTION
## Summary

Tapping **Refresh** on the Today screen now actually regenerates the insight. Previously the worker's first action was to check the same-day cache and redeliver — meaning a Refresh tap on the same calendar day just replayed the morning's payload. Wardrobe-rule changes, location moves, and genuine forecast updates were all invisible until midnight.

`FetchAndNotifyWorker.enqueueOneShot` now takes a `force: Boolean = false` parameter:
- Alarm-driven enqueues (default `false`) keep current `ExistingWorkPolicy.KEEP` semantics — same cost cap, no duplicate on retry.
- User-initiated enqueues from the Today screen pass `force = true` — uses `ExistingWorkPolicy.REPLACE` (cancels any retrying alarm run) and sets a `KEY_FORCE_REFRESH` input flag the worker reads to skip the cache check.

The debug "Fire insight now" button in Settings still uses `force = false` — its current job is to test the alarm-driven path including cache behaviour. Easy to flip later if that's the wrong call.

## Two follow-up TODOs added in-line

1. **Auto-refresh on open** when the cached insight is >~1h old (`FetchAndNotifyWorker.doWork` near the cache check). Avoids needing a Refresh tap when the wardrobe / forecast has moved since the morning generation.
2. **Promote `VoiceLocalePicker` out of `TtsEngineCard`** (in `SettingsScreen.kt`). The locale also drives the OpenAI default voice, so users on the OpenAI engine can't currently see / change it without switching to Device first.

## Test plan

- [ ] Wait for the morning insight, then change a wardrobe rule. Tap Refresh — the new rule should be reflected in the new payload.
- [ ] Confirm the morning alarm still uses the cache (only one Gemini call per calendar day for alarm-driven runs).
- [ ] If a Refresh tap fires while a previous alarm-driven retry is in flight, the old run is cancelled and the force run takes over.

https://claude.ai/code/session_01T5P8n8dTywRkQqFfTCBUWS

---
_Generated by [Claude Code](https://claude.ai/code/session_01T5P8n8dTywRkQqFfTCBUWS)_