### PR TITLE
:app + :core — ElevenLabs as a third online TTS engine

### DIFF
--- a/app/src/main/kotlin/app/adaptweather/AdaptWeatherApplication.kt
+++ b/app/src/main/kotlin/app/adaptweather/AdaptWeatherApplication.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import android.util.Log
 import app.adaptweather.alarm.DailyAlarmScheduler
 import app.adaptweather.core.data.location.OpenMeteoGeocodingClient
+import app.adaptweather.core.data.tts.ElevenLabsTtsClient
 import app.adaptweather.core.data.tts.GeminiTtsClient
 import app.adaptweather.core.data.tts.OpenAITtsClient
 import app.adaptweather.core.data.weather.OpenMeteoClient
@@ -51,6 +52,9 @@ class AdaptWeatherApplication : Application() {
     val geminiTtsClient: GeminiTtsClient by lazy { GeminiTtsClient(httpClient, secureKeyStore) }
     val openAiTtsClient: OpenAITtsClient by lazy {
         OpenAITtsClient(httpClient, secureKeyStore.openAiKeyProvider)
+    }
+    val elevenLabsTtsClient: ElevenLabsTtsClient by lazy {
+        ElevenLabsTtsClient(httpClient, secureKeyStore.elevenLabsKeyProvider)
     }
 
     private val httpClient: HttpClient by lazy {

--- a/app/src/main/kotlin/app/adaptweather/data/SecureKeyStore.kt
+++ b/app/src/main/kotlin/app/adaptweather/data/SecureKeyStore.kt
@@ -57,6 +57,12 @@ class SecureKeyStore(
 
     suspend fun clearOpenAi() = remove(OPENAI_PREF_KEY)
 
+    suspend fun getElevenLabs(): String = read(ELEVENLABS_PREF_KEY, ELEVENLABS_AAD, "ElevenLabs")
+
+    suspend fun setElevenLabs(key: String) = write(ELEVENLABS_PREF_KEY, ELEVENLABS_AAD, key)
+
+    suspend fun clearElevenLabs() = remove(ELEVENLABS_PREF_KEY)
+
     /**
      * KeyProvider view onto the OpenAI key. Used to wire `OpenAITtsClient` while
      * keeping the underlying SecureKeyStore as the single source of truth for
@@ -64,6 +70,11 @@ class SecureKeyStore(
      */
     val openAiKeyProvider: KeyProvider = object : KeyProvider {
         override suspend fun get(): String = getOpenAi()
+    }
+
+    /** KeyProvider view onto the ElevenLabs key. */
+    val elevenLabsKeyProvider: KeyProvider = object : KeyProvider {
+        override suspend fun get(): String = getElevenLabs()
     }
 
     private suspend fun read(prefKey: Preferences.Key<String>, aad: ByteArray, provider: String): String {
@@ -96,6 +107,9 @@ class SecureKeyStore(
 
         private val OPENAI_PREF_KEY = stringPreferencesKey("openai_api_key_v1")
         private val OPENAI_AAD = "adaptweather:openai_api_key:v1".toByteArray(Charsets.UTF_8)
+
+        private val ELEVENLABS_PREF_KEY = stringPreferencesKey("elevenlabs_api_key_v1")
+        private val ELEVENLABS_AAD = "adaptweather:elevenlabs_api_key:v1".toByteArray(Charsets.UTF_8)
 
         private const val MASTER_KEY_URI = "android-keystore://adaptweather_master_key"
         private const val KEYSET_PREFS = "adaptweather_master_prefs"

--- a/app/src/main/kotlin/app/adaptweather/data/SettingsRepository.kt
+++ b/app/src/main/kotlin/app/adaptweather/data/SettingsRepository.kt
@@ -101,6 +101,10 @@ class SettingsRepository(
         dataStore.edit { it[OPENAI_VOICE] = voice }
     }
 
+    suspend fun setElevenLabsVoice(voice: String) {
+        dataStore.edit { it[ELEVENLABS_VOICE] = voice }
+    }
+
     private fun Preferences.toUserPreferences(): UserPreferences {
         val time = this[SCHEDULE_TIME]?.let { LocalTime.parse(it, TIME_FORMAT) }
             ?: DEFAULT_TIME
@@ -123,6 +127,8 @@ class SettingsRepository(
             ?: UserPreferences.DEFAULT_GEMINI_VOICE
         val openAiVoice = this[OPENAI_VOICE]?.takeIf { it.isNotBlank() }
             ?: UserPreferences.DEFAULT_OPENAI_VOICE
+        val elevenLabsVoice = this[ELEVENLABS_VOICE]?.takeIf { it.isNotBlank() }
+            ?: UserPreferences.DEFAULT_ELEVENLABS_VOICE
 
         return UserPreferences(
             schedule = Schedule(time = time, days = days, zoneId = zoneIdProvider()),
@@ -135,6 +141,7 @@ class SettingsRepository(
             ttsEngine = ttsEngine,
             geminiVoice = geminiVoice,
             openAiVoice = openAiVoice,
+            elevenLabsVoice = elevenLabsVoice,
         )
     }
 
@@ -171,6 +178,7 @@ class SettingsRepository(
         private val TTS_ENGINE = stringPreferencesKey("tts_engine")
         private val GEMINI_VOICE = stringPreferencesKey("gemini_voice")
         private val OPENAI_VOICE = stringPreferencesKey("openai_voice")
+        private val ELEVENLABS_VOICE = stringPreferencesKey("elevenlabs_voice")
 
         private val TIME_FORMAT: DateTimeFormatter = DateTimeFormatter.ofPattern("HH:mm")
         private val DEFAULT_TIME: LocalTime = LocalTime.of(7, 0)

--- a/app/src/main/kotlin/app/adaptweather/tts/ElevenLabsTtsSpeaker.kt
+++ b/app/src/main/kotlin/app/adaptweather/tts/ElevenLabsTtsSpeaker.kt
@@ -1,0 +1,26 @@
+package app.adaptweather.tts
+
+import app.adaptweather.core.data.tts.DEFAULT_ELEVENLABS_TTS_VOICE
+import app.adaptweather.core.data.tts.ElevenLabsTtsClient
+import java.util.Locale
+
+/**
+ * TTS via ElevenLabs's `text-to-speech` endpoint. Synthesises PCM audio in one
+ * network call, hands the buffer to [PcmAudioPlayer] for playback.
+ *
+ * Voice is an ElevenLabs voice ID (the long opaque identifier from their voice
+ * library, e.g. `EXAVITQu4vr4xnSDxMaL` for Sarah); selectable from Settings.
+ *
+ * Fallback is the caller's responsibility — see [app.adaptweather.work.FetchAndNotifyWorker]
+ * which retries with [AndroidTtsSpeaker] when this throws.
+ */
+class ElevenLabsTtsSpeaker(
+    private val client: ElevenLabsTtsClient,
+    private val voiceId: String = DEFAULT_ELEVENLABS_TTS_VOICE,
+) : TtsSpeaker {
+
+    override suspend fun speak(text: String, locale: Locale) {
+        val audio = client.synthesize(text = text, voiceId = voiceId)
+        PcmAudioPlayer.play(audio)
+    }
+}

--- a/app/src/main/kotlin/app/adaptweather/tts/TtsVoices.kt
+++ b/app/src/main/kotlin/app/adaptweather/tts/TtsVoices.kt
@@ -30,3 +30,18 @@ val OPENAI_VOICES: List<TtsVoiceOption> = listOf(
     TtsVoiceOption("nova", "nova — Bright, female"),
     TtsVoiceOption("shimmer", "shimmer — Warm, female"),
 )
+
+// ElevenLabs voice IDs are opaque strings; the human-readable name only shows in
+// the picker. These are the popular pre-made library voices. Users with a paid
+// plan can clone their own voice — they'd need to copy/paste the voice ID by
+// hand, which we don't surface in v1.
+val ELEVENLABS_VOICES: List<TtsVoiceOption> = listOf(
+    TtsVoiceOption("EXAVITQu4vr4xnSDxMaL", "Sarah — Warm, female"),
+    TtsVoiceOption("21m00Tcm4TlvDq8ikWAM", "Rachel — Calm, female"),
+    TtsVoiceOption("AZnzlk1v9MwlGOIKvxn0", "Domi — Strong, female"),
+    TtsVoiceOption("MF3mGyEYCl7XYWbV9V6O", "Elli — Emotional, female"),
+    TtsVoiceOption("pNInz6obpgDQGcFmaJgB", "Adam — Deep, male"),
+    TtsVoiceOption("ErXwobaYiN019PkySvjV", "Antoni — Well-rounded, male"),
+    TtsVoiceOption("TxGEqnHWrfWFTfGW9XjX", "Josh — Young, male"),
+    TtsVoiceOption("VR6AewLTigWG4xSOukaG", "Arnold — Crisp, male"),
+)

--- a/app/src/main/kotlin/app/adaptweather/ui/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/app/adaptweather/ui/settings/SettingsScreen.kt
@@ -57,6 +57,8 @@ import app.adaptweather.core.domain.model.Location
 import app.adaptweather.core.domain.model.TemperatureUnit
 import app.adaptweather.core.domain.model.TtsEngine
 import app.adaptweather.core.domain.model.WardrobeRule
+import app.adaptweather.tts.ELEVENLABS_VOICES
+import app.adaptweather.tts.ElevenLabsTtsSpeaker
 import app.adaptweather.tts.GEMINI_VOICES
 import app.adaptweather.tts.GeminiTtsSpeaker
 import app.adaptweather.tts.OPENAI_VOICES
@@ -116,6 +118,9 @@ fun SettingsScreen(viewModel: SettingsViewModel, onNavigateBack: () -> Unit) {
             onSetOpenAiVoice = viewModel::setOpenAiVoice,
             onSetOpenAiKey = viewModel::setOpenAiKey,
             onClearOpenAiKey = viewModel::clearOpenAiKey,
+            onSetElevenLabsVoice = viewModel::setElevenLabsVoice,
+            onSetElevenLabsKey = viewModel::setElevenLabsKey,
+            onClearElevenLabsKey = viewModel::clearElevenLabsKey,
         )
     }
 }
@@ -142,6 +147,9 @@ private fun SettingsContent(
     onSetOpenAiVoice: (String) -> Unit,
     onSetOpenAiKey: (String) -> Unit,
     onClearOpenAiKey: () -> Unit,
+    onSetElevenLabsVoice: (String) -> Unit,
+    onSetElevenLabsKey: (String) -> Unit,
+    onClearElevenLabsKey: () -> Unit,
 ) {
     Column(
         modifier = Modifier
@@ -155,10 +163,13 @@ private fun SettingsContent(
         ApiKeysCard(
             geminiConfigured = state.apiKeyConfigured,
             openAiConfigured = state.openAiKeyConfigured,
+            elevenLabsConfigured = state.elevenLabsKeyConfigured,
             onSetGeminiKey = onSetApiKey,
             onClearGeminiKey = onClearApiKey,
             onSetOpenAiKey = onSetOpenAiKey,
             onClearOpenAiKey = onClearOpenAiKey,
+            onSetElevenLabsKey = onSetElevenLabsKey,
+            onClearElevenLabsKey = onClearElevenLabsKey,
         )
         LocationCard(
             current = state.location,
@@ -181,8 +192,11 @@ private fun SettingsContent(
             onGeminiVoice = onSetGeminiVoice,
             openAiVoice = state.openAiVoice,
             onOpenAiVoice = onSetOpenAiVoice,
+            elevenLabsVoice = state.elevenLabsVoice,
+            onElevenLabsVoice = onSetElevenLabsVoice,
             geminiKeyConfigured = state.apiKeyConfigured,
             openAiKeyConfigured = state.openAiKeyConfigured,
+            elevenLabsKeyConfigured = state.elevenLabsKeyConfigured,
         )
         TemperatureUnitCard(state.temperatureUnit, onSetTemperatureUnit)
         DistanceUnitCard(state.distanceUnit, onSetDistanceUnit)
@@ -805,18 +819,22 @@ private fun SectionCard(title: String, content: @Composable () -> Unit) {
 
 /**
  * One section that holds every BYOK API key the app uses (Gemini for Gemini TTS,
- * OpenAI for OpenAI TTS). Putting both in a single section makes them feel
- * symmetric — neither is "the primary" — and keeps the engine picker downstream
- * focused on engine + voice + a small "missing key" hint when relevant.
+ * OpenAI for OpenAI TTS, ElevenLabs for ElevenLabs TTS). Putting them in a single
+ * section makes them feel symmetric — none is "the primary" — and keeps the engine
+ * picker downstream focused on engine + voice + a small "missing key" hint when
+ * relevant.
  */
 @Composable
 private fun ApiKeysCard(
     geminiConfigured: Boolean,
     openAiConfigured: Boolean,
+    elevenLabsConfigured: Boolean,
     onSetGeminiKey: (String) -> Unit,
     onClearGeminiKey: () -> Unit,
     onSetOpenAiKey: (String) -> Unit,
     onClearOpenAiKey: () -> Unit,
+    onSetElevenLabsKey: (String) -> Unit,
+    onClearElevenLabsKey: () -> Unit,
 ) {
     SectionCard(title = stringResource(R.string.settings_api_keys_title)) {
         Text(
@@ -860,6 +878,25 @@ private fun ApiKeysCard(
             onSave = onSetOpenAiKey,
             onClear = onClearOpenAiKey,
         )
+
+        HorizontalDivider()
+
+        Text(
+            text = stringResource(R.string.settings_api_key_elevenlabs_label),
+            style = MaterialTheme.typography.titleSmall,
+        )
+        KeyEntryFields(
+            configured = elevenLabsConfigured,
+            statusText = stringResource(
+                if (elevenLabsConfigured) R.string.settings_elevenlabs_key_status_set
+                else R.string.settings_elevenlabs_key_status_unset,
+            ),
+            placeholder = stringResource(R.string.settings_elevenlabs_key_placeholder),
+            saveLabel = stringResource(R.string.settings_elevenlabs_key_save),
+            clearLabel = stringResource(R.string.settings_elevenlabs_key_clear),
+            onSave = onSetElevenLabsKey,
+            onClear = onClearElevenLabsKey,
+        )
     }
 }
 
@@ -887,8 +924,11 @@ private fun TtsEngineCard(
     onGeminiVoice: (String) -> Unit,
     openAiVoice: String,
     onOpenAiVoice: (String) -> Unit,
+    elevenLabsVoice: String,
+    onElevenLabsVoice: (String) -> Unit,
     geminiKeyConfigured: Boolean,
     openAiKeyConfigured: Boolean,
+    elevenLabsKeyConfigured: Boolean,
 ) {
     val context = LocalContext.current
     val coroutineScope = rememberCoroutineScope()
@@ -897,10 +937,10 @@ private fun TtsEngineCard(
     // overlapping playbacks.
     var previewJob by remember { mutableStateOf<Job?>(null) }
 
-    fun preview(engine: TtsEngine, gVoice: String, oVoice: String) {
+    fun preview(engine: TtsEngine, gVoice: String, oVoice: String, eVoice: String) {
         previewJob?.cancel()
         previewJob = coroutineScope.launch {
-            runTtsPreview(context, engine, gVoice, oVoice)
+            runTtsPreview(context, engine, gVoice, oVoice, eVoice)
         }
     }
 
@@ -916,7 +956,7 @@ private fun TtsEngineCard(
                 selected = engine == selected,
                 onSelect = {
                     onSelect(engine)
-                    preview(engine, geminiVoice, openAiVoice)
+                    preview(engine, geminiVoice, openAiVoice, elevenLabsVoice)
                 },
             )
         }
@@ -933,10 +973,10 @@ private fun TtsEngineCard(
                     selectedId = geminiVoice,
                     onSelect = {
                         onGeminiVoice(it)
-                        preview(TtsEngine.GEMINI, it, openAiVoice)
+                        preview(TtsEngine.GEMINI, it, openAiVoice, elevenLabsVoice)
                     },
                 )
-                TestVoiceButton { preview(selected, geminiVoice, openAiVoice) }
+                TestVoiceButton { preview(selected, geminiVoice, openAiVoice, elevenLabsVoice) }
             }
             TtsEngine.OPENAI -> {
                 if (!openAiKeyConfigured) {
@@ -950,10 +990,27 @@ private fun TtsEngineCard(
                     selectedId = openAiVoice,
                     onSelect = {
                         onOpenAiVoice(it)
-                        preview(TtsEngine.OPENAI, geminiVoice, it)
+                        preview(TtsEngine.OPENAI, geminiVoice, it, elevenLabsVoice)
                     },
                 )
-                TestVoiceButton { preview(selected, geminiVoice, openAiVoice) }
+                TestVoiceButton { preview(selected, geminiVoice, openAiVoice, elevenLabsVoice) }
+            }
+            TtsEngine.ELEVENLABS -> {
+                if (!elevenLabsKeyConfigured) {
+                    MissingKeyHint(
+                        engineName = stringResource(R.string.settings_api_key_elevenlabs_label),
+                    )
+                }
+                VoicePicker(
+                    title = stringResource(R.string.settings_tts_voice_label),
+                    voices = ELEVENLABS_VOICES,
+                    selectedId = elevenLabsVoice,
+                    onSelect = {
+                        onElevenLabsVoice(it)
+                        preview(TtsEngine.ELEVENLABS, geminiVoice, openAiVoice, it)
+                    },
+                )
+                TestVoiceButton { preview(selected, geminiVoice, openAiVoice, elevenLabsVoice) }
             }
             TtsEngine.DEVICE -> Unit
         }
@@ -1037,6 +1094,7 @@ private suspend fun runTtsPreview(
     engine: TtsEngine,
     geminiVoice: String,
     openAiVoice: String,
+    elevenLabsVoice: String,
 ) {
     val app = context.applicationContext as app.adaptweather.AdaptWeatherApplication
     // Network synthesis and AudioTrack write are both blocking-ish work — Ktor
@@ -1051,6 +1109,8 @@ private suspend fun runTtsPreview(
                     GeminiTtsSpeaker(app.geminiTtsClient, voiceName = geminiVoice).speak(text)
                 TtsEngine.OPENAI ->
                     OpenAITtsSpeaker(app.openAiTtsClient, voice = openAiVoice).speak(text)
+                TtsEngine.ELEVENLABS ->
+                    ElevenLabsTtsSpeaker(app.elevenLabsTtsClient, voiceId = elevenLabsVoice).speak(text)
                 TtsEngine.DEVICE ->
                     app.deviceTtsSpeaker.speak(text)
             }
@@ -1183,6 +1243,7 @@ private fun ttsEngineLabel(engine: TtsEngine): Int = when (engine) {
     TtsEngine.DEVICE -> R.string.settings_tts_engine_device
     TtsEngine.GEMINI -> R.string.settings_tts_engine_gemini
     TtsEngine.OPENAI -> R.string.settings_tts_engine_openai
+    TtsEngine.ELEVENLABS -> R.string.settings_tts_engine_elevenlabs
 }
 
 private fun temperatureUnitLabel(unit: TemperatureUnit): Int = when (unit) {

--- a/app/src/main/kotlin/app/adaptweather/ui/settings/SettingsState.kt
+++ b/app/src/main/kotlin/app/adaptweather/ui/settings/SettingsState.kt
@@ -24,6 +24,8 @@ data class SettingsState(
     val ttsEngine: TtsEngine = TtsEngine.DEVICE,
     val geminiVoice: String = UserPreferences.DEFAULT_GEMINI_VOICE,
     val openAiVoice: String = UserPreferences.DEFAULT_OPENAI_VOICE,
+    val elevenLabsVoice: String = UserPreferences.DEFAULT_ELEVENLABS_VOICE,
     val apiKeyConfigured: Boolean = false,
     val openAiKeyConfigured: Boolean = false,
+    val elevenLabsKeyConfigured: Boolean = false,
 )

--- a/app/src/main/kotlin/app/adaptweather/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/app/adaptweather/ui/settings/SettingsViewModel.kt
@@ -48,6 +48,7 @@ class SettingsViewModel(
                         ttsEngine = prefs.ttsEngine,
                         geminiVoice = prefs.geminiVoice,
                         openAiVoice = prefs.openAiVoice,
+                        elevenLabsVoice = prefs.elevenLabsVoice,
                     )
                 }
             }
@@ -83,12 +84,30 @@ class SettingsViewModel(
         }
     }
 
+    fun setElevenLabsKey(key: String) {
+        viewModelScope.launch {
+            keyStore.setElevenLabs(key.trim())
+            refreshApiKeyStatus()
+        }
+    }
+
+    fun clearElevenLabsKey() {
+        viewModelScope.launch {
+            keyStore.clearElevenLabs()
+            refreshApiKeyStatus()
+        }
+    }
+
     fun setGeminiVoice(voice: String) {
         viewModelScope.launch { settingsRepository.setGeminiVoice(voice) }
     }
 
     fun setOpenAiVoice(voice: String) {
         viewModelScope.launch { settingsRepository.setOpenAiVoice(voice) }
+    }
+
+    fun setElevenLabsVoice(voice: String) {
+        viewModelScope.launch { settingsRepository.setElevenLabsVoice(voice) }
     }
 
     fun setDeliveryMode(mode: DeliveryMode) {
@@ -159,7 +178,14 @@ class SettingsViewModel(
     private suspend fun refreshApiKeyStatus() {
         val gemini = runCatching { keyStore.get().isNotBlank() }.getOrDefault(false)
         val openAi = runCatching { keyStore.getOpenAi().isNotBlank() }.getOrDefault(false)
-        _state.update { it.copy(apiKeyConfigured = gemini, openAiKeyConfigured = openAi) }
+        val elevenLabs = runCatching { keyStore.getElevenLabs().isNotBlank() }.getOrDefault(false)
+        _state.update {
+            it.copy(
+                apiKeyConfigured = gemini,
+                openAiKeyConfigured = openAi,
+                elevenLabsKeyConfigured = elevenLabs,
+            )
+        }
     }
 
     class Factory(

--- a/app/src/main/kotlin/app/adaptweather/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/app/adaptweather/work/FetchAndNotifyWorker.kt
@@ -17,6 +17,7 @@ import app.adaptweather.core.domain.model.Insight
 import app.adaptweather.core.domain.model.Location
 import app.adaptweather.core.domain.model.TtsEngine
 import app.adaptweather.core.domain.model.UserPreferences
+import app.adaptweather.tts.ElevenLabsTtsSpeaker
 import app.adaptweather.tts.GeminiTtsSpeaker
 import app.adaptweather.tts.OpenAITtsSpeaker
 import io.ktor.client.network.sockets.ConnectTimeoutException
@@ -173,6 +174,14 @@ class FetchAndNotifyWorker(
                     return
                 } catch (t: Throwable) {
                     Log.w(TAG, "OpenAI TTS failed; falling back to device TTS.", t)
+                }
+            }
+            TtsEngine.ELEVENLABS -> {
+                try {
+                    ElevenLabsTtsSpeaker(app.elevenLabsTtsClient, voiceId = prefs.elevenLabsVoice).speak(text)
+                    return
+                } catch (t: Throwable) {
+                    Log.w(TAG, "ElevenLabs TTS failed; falling back to device TTS.", t)
                 }
             }
             TtsEngine.DEVICE -> Unit

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -38,6 +38,7 @@
     <string name="settings_api_keys_description">Configure the API keys for the online voice engines you want to use. Keys are encrypted at rest using the Android Keystore.</string>
     <string name="settings_api_key_gemini_label">Gemini</string>
     <string name="settings_api_key_openai_label">OpenAI</string>
+    <string name="settings_api_key_elevenlabs_label">ElevenLabs</string>
 
     <string name="settings_api_key_status_set">A Gemini key is configured.</string>
     <string name="settings_api_key_status_unset">No Gemini key configured. Get one at aistudio.google.com to use Gemini voices.</string>
@@ -70,10 +71,11 @@
     <string name="settings_delivery_notification_and_tts">Notification and spoken aloud</string>
 
     <string name="settings_tts_engine_title">Voice engine</string>
-    <string name="settings_tts_engine_description">Online engines (Gemini, OpenAI) sound much more natural but need a network call at speak-time and use your API key for synthesis (one short call per spoken insight). Falls back to the device voice if the chosen engine fails.</string>
+    <string name="settings_tts_engine_description">Online engines (Gemini, OpenAI, ElevenLabs) sound much more natural but need a network call at speak-time and use your API key for synthesis (one short call per spoken insight). Falls back to the device voice if the chosen engine fails.</string>
     <string name="settings_tts_engine_device">Device (offline, free)</string>
     <string name="settings_tts_engine_gemini">Gemini (high quality, online)</string>
     <string name="settings_tts_engine_openai">OpenAI (high quality, online)</string>
+    <string name="settings_tts_engine_elevenlabs">ElevenLabs (highest quality, online)</string>
     <string name="settings_tts_voice_label">Voice</string>
     <string name="settings_tts_voice_dismiss">Done</string>
     <string name="settings_tts_test">Test voice</string>
@@ -88,6 +90,12 @@
     <string name="settings_openai_key_placeholder">Paste your OpenAI API key</string>
     <string name="settings_openai_key_save">Save OpenAI key</string>
     <string name="settings_openai_key_clear">Clear stored OpenAI key</string>
+
+    <string name="settings_elevenlabs_key_status_set">An ElevenLabs key is configured.</string>
+    <string name="settings_elevenlabs_key_status_unset">No ElevenLabs key configured. Get one at elevenlabs.io to use ElevenLabs voices.</string>
+    <string name="settings_elevenlabs_key_placeholder">Paste your ElevenLabs API key</string>
+    <string name="settings_elevenlabs_key_save">Save ElevenLabs key</string>
+    <string name="settings_elevenlabs_key_clear">Clear stored ElevenLabs key</string>
 
     <string name="settings_temperature_unit_title">Temperature unit</string>
     <string name="settings_temperature_unit_celsius">Celsius (°C)</string>

--- a/app/src/test/kotlin/app/adaptweather/data/SettingsRepositoryTest.kt
+++ b/app/src/test/kotlin/app/adaptweather/data/SettingsRepositoryTest.kt
@@ -154,20 +154,23 @@ class SettingsRepositoryTest {
     }
 
     @Test
-    fun `setGeminiVoice and setOpenAiVoice round-trip and are independent`() = runTest {
+    fun `voice setters round-trip and are independent across providers`() = runTest {
         subject.setGeminiVoice("Puck")
         subject.setOpenAiVoice("nova")
+        subject.setElevenLabsVoice("21m00Tcm4TlvDq8ikWAM")
 
         val prefs = subject.preferences.first()
         prefs.geminiVoice shouldBe "Puck"
         prefs.openAiVoice shouldBe "nova"
+        prefs.elevenLabsVoice shouldBe "21m00Tcm4TlvDq8ikWAM"
     }
 
     @Test
-    fun `voice prefs default to Kore and alloy when nothing stored`() = runTest {
+    fun `voice prefs default to per-provider defaults when nothing stored`() = runTest {
         val prefs = subject.preferences.first()
         prefs.geminiVoice shouldBe "Kore"
         prefs.openAiVoice shouldBe "alloy"
+        prefs.elevenLabsVoice shouldBe "EXAVITQu4vr4xnSDxMaL"
     }
 
     @Test

--- a/core/data/src/main/kotlin/app/adaptweather/core/data/tts/ElevenLabsTtsClient.kt
+++ b/core/data/src/main/kotlin/app/adaptweather/core/data/tts/ElevenLabsTtsClient.kt
@@ -1,0 +1,111 @@
+package app.adaptweather.core.data.tts
+
+import app.adaptweather.core.data.insight.KeyProvider
+import app.adaptweather.core.data.insight.MissingApiKeyException
+import io.ktor.client.HttpClient
+import io.ktor.client.request.header
+import io.ktor.client.request.parameter
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsBytes
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.http.isSuccess
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+
+const val DEFAULT_ELEVENLABS_TTS_MODEL: String = "eleven_multilingual_v2"
+const val DEFAULT_ELEVENLABS_TTS_VOICE: String = "EXAVITQu4vr4xnSDxMaL" // Sarah
+
+/**
+ * ElevenLabs TTS via `POST https://api.elevenlabs.io/v1/text-to-speech/{voice_id}`.
+ *
+ * Asks for `output_format=pcm_24000` so the response body is raw 16-bit signed
+ * little-endian mono PCM at 24 kHz — bit-compatible with the Gemini and OpenAI
+ * TTS paths and with the same [PcmAudio] structure, so playback reuses the
+ * existing AudioTrack code on the app side.
+ *
+ * Auth is the user's ElevenLabs key as the `xi-api-key` header (not a Bearer
+ * token, unlike OpenAI). Like the other providers the key never leaves the
+ * device.
+ */
+class ElevenLabsTtsClient(
+    private val httpClient: HttpClient,
+    private val keyProvider: KeyProvider,
+    private val model: String = DEFAULT_ELEVENLABS_TTS_MODEL,
+) {
+    suspend fun synthesize(
+        text: String,
+        voiceId: String = DEFAULT_ELEVENLABS_TTS_VOICE,
+    ): PcmAudio {
+        val key = keyProvider.get().also {
+            if (it.isBlank()) throw MissingApiKeyException("ElevenLabs")
+        }
+
+        val response: HttpResponse = httpClient.post("$SPEECH_URL_BASE/$voiceId") {
+            header("xi-api-key", key)
+            contentType(ContentType.Application.Json)
+            parameter("output_format", PCM_OUTPUT_FORMAT)
+            setBody(ElevenLabsSpeechRequest(text = text, modelId = model))
+        }
+
+        if (!response.status.isSuccess()) {
+            throw ElevenLabsTtsHttpException(response.status, response.bodyAsBytes())
+        }
+
+        val pcm = response.bodyAsBytes()
+        if (pcm.isEmpty()) throw ElevenLabsTtsEmptyResponseException()
+
+        return PcmAudio(bytes = pcm, sampleRate = ELEVENLABS_PCM_SAMPLE_RATE_HZ)
+    }
+
+    companion object {
+        // `pcm_24000` is documented as 16-bit signed little-endian mono at 24 kHz —
+        // matches the AudioTrack format we already use for Gemini / OpenAI.
+        private const val ELEVENLABS_PCM_SAMPLE_RATE_HZ = 24_000
+        private const val PCM_OUTPUT_FORMAT = "pcm_24000"
+        private const val SPEECH_URL_BASE = "https://api.elevenlabs.io/v1/text-to-speech"
+    }
+}
+
+class ElevenLabsTtsEmptyResponseException :
+    IllegalStateException("ElevenLabs TTS returned no audio body")
+
+/**
+ * HTTP failure surfaced with a short body excerpt so the diagnostic Toast in
+ * Settings shows the actual reason (auth failure / quota / unknown voice ID).
+ * Pulls just `detail.message` (or `detail` itself when it's a string) out of
+ * ElevenLabs's standard error envelope; falls back to a truncated raw excerpt
+ * otherwise.
+ */
+class ElevenLabsTtsHttpException(val status: HttpStatusCode, body: ByteArray) :
+    IllegalStateException(buildMessage(status, body)) {
+
+    companion object {
+        private fun buildMessage(status: HttpStatusCode, body: ByteArray): String {
+            val raw = runCatching { body.toString(Charsets.UTF_8) }.getOrNull().orEmpty()
+            val excerpt = extractErrorMessage(raw)
+                ?: raw.take(MAX_EXCERPT_CHARS).ifBlank { "(empty body)" }
+            return "ElevenLabs TTS HTTP ${status.value}: $excerpt"
+        }
+
+        private fun extractErrorMessage(body: String): String? = runCatching {
+            val root = Json.parseToJsonElement(body) as? JsonObject ?: return@runCatching null
+            // ElevenLabs envelopes are usually `{"detail": {"status": "...", "message": "..."}}`
+            // but on validation failures `detail` is a plain string. Handle both.
+            val detail = root["detail"]
+            when (detail) {
+                is JsonObject ->
+                    (detail["message"] as? JsonPrimitive)?.content?.take(MAX_EXCERPT_CHARS)
+                is JsonPrimitive ->
+                    detail.content.takeIf { detail.isString }?.take(MAX_EXCERPT_CHARS)
+                else -> null
+            }
+        }.getOrNull()
+
+        private const val MAX_EXCERPT_CHARS = 160
+    }
+}

--- a/core/data/src/main/kotlin/app/adaptweather/core/data/tts/ElevenLabsTtsDto.kt
+++ b/core/data/src/main/kotlin/app/adaptweather/core/data/tts/ElevenLabsTtsDto.kt
@@ -1,0 +1,16 @@
+package app.adaptweather.core.data.tts
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Wire type for `POST /v1/text-to-speech/{voice_id}`. Field names match
+ * ElevenLabs's snake_case via [SerialName]. Request only — the response is
+ * raw audio bytes (no JSON to deserialize), so there's no response DTO.
+ */
+@Serializable
+internal data class ElevenLabsSpeechRequest(
+    val text: String,
+    @SerialName("model_id")
+    val modelId: String,
+)

--- a/core/domain/src/main/kotlin/app/adaptweather/core/domain/model/Settings.kt
+++ b/core/domain/src/main/kotlin/app/adaptweather/core/domain/model/Settings.kt
@@ -16,8 +16,11 @@ enum class DeliveryMode { NOTIFICATION_ONLY, TTS_ONLY, NOTIFICATION_AND_TTS }
  *   a small amount per character. Falls back to [DEVICE] if the call fails.
  * - [OPENAI] uses OpenAI's `audio/speech` endpoint over a separate BYOK OpenAI key.
  *   Comparable quality to Gemini; falls back to [DEVICE] on failure.
+ * - [ELEVENLABS] uses ElevenLabs's `text-to-speech` endpoint over a separate BYOK
+ *   ElevenLabs key. Highest perceptual naturalness of the three online options;
+ *   falls back to [DEVICE] on failure.
  */
-enum class TtsEngine { DEVICE, GEMINI, OPENAI }
+enum class TtsEngine { DEVICE, GEMINI, OPENAI, ELEVENLABS }
 
 data class UserPreferences(
     val schedule: Schedule,
@@ -49,9 +52,17 @@ data class UserPreferences(
      * == [TtsEngine.OPENAI].
      */
     val openAiVoice: String = DEFAULT_OPENAI_VOICE,
+    /**
+     * ElevenLabs voice ID — the opaque library identifier (e.g.
+     * "EXAVITQu4vr4xnSDxMaL" for Sarah). Only consulted when [ttsEngine]
+     * == [TtsEngine.ELEVENLABS].
+     */
+    val elevenLabsVoice: String = DEFAULT_ELEVENLABS_VOICE,
 ) {
     companion object {
         const val DEFAULT_GEMINI_VOICE = "Kore"
         const val DEFAULT_OPENAI_VOICE = "alloy"
+        // Sarah — the most generally pleasant of ElevenLabs's stock library voices.
+        const val DEFAULT_ELEVENLABS_VOICE = "EXAVITQu4vr4xnSDxMaL"
     }
 }


### PR DESCRIPTION
Superseded by #74 — that one is the same change rebased on top of `main` (which had moved on with the locale-aware voice picker, calendar events, the ClothesCast rebrand, and the Gemini playback cleanup). Closing this one rather than force-pushing so the history of the v1 branch stays intact.