### PR TITLE
Read today's calendar events into the daily insight summary

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,6 +16,11 @@
     <!-- Daily notification. POST_NOTIFICATIONS is runtime on Android 13+. -->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
+    <!-- Read today's calendar events to enrich the morning insight. Opt-in via the
+         Settings toggle; runtime grant requested from there. We deliberately do NOT
+         declare WRITE_CALENDAR — AdaptWeather only reads. -->
+    <uses-permission android:name="android.permission.READ_CALENDAR" />
+
     <!-- Re-arm the alarm on reboot, package update, timezone change, locale change. -->
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 

--- a/app/src/main/kotlin/app/adaptweather/AdaptWeatherApplication.kt
+++ b/app/src/main/kotlin/app/adaptweather/AdaptWeatherApplication.kt
@@ -3,10 +3,12 @@ package app.adaptweather
 import android.app.Application
 import android.util.Log
 import app.adaptweather.alarm.DailyAlarmScheduler
+import app.adaptweather.calendar.CalendarContractEventReader
 import app.adaptweather.core.data.location.OpenMeteoGeocodingClient
 import app.adaptweather.core.data.tts.GeminiTtsClient
 import app.adaptweather.core.data.tts.OpenAITtsClient
 import app.adaptweather.core.data.weather.OpenMeteoClient
+import app.adaptweather.core.domain.repository.CalendarEventReader
 import app.adaptweather.core.domain.repository.WeatherRepository
 import app.adaptweather.core.domain.usecase.GenerateDailyInsight
 import app.adaptweather.data.InsightCache
@@ -48,6 +50,7 @@ class AdaptWeatherApplication : Application() {
     val weatherAlertNotifier: WeatherAlertNotifier by lazy { WeatherAlertNotifier(this) }
     val dailyAlarmScheduler: DailyAlarmScheduler by lazy { DailyAlarmScheduler(this) }
     val deviceTtsSpeaker: TtsSpeaker by lazy { AndroidTtsSpeaker(this) }
+    val calendarEventReader: CalendarEventReader by lazy { CalendarContractEventReader(this) }
     val geminiTtsClient: GeminiTtsClient by lazy { GeminiTtsClient(httpClient, secureKeyStore) }
     val openAiTtsClient: OpenAITtsClient by lazy {
         OpenAITtsClient(httpClient, secureKeyStore.openAiKeyProvider)
@@ -64,7 +67,12 @@ class AdaptWeatherApplication : Application() {
     val weatherRepository: WeatherRepository by lazy { OpenMeteoClient(httpClient) }
     val geocodingClient: OpenMeteoGeocodingClient by lazy { OpenMeteoGeocodingClient(httpClient) }
 
-    val generateDailyInsight: GenerateDailyInsight by lazy { GenerateDailyInsight(weatherRepository) }
+    val generateDailyInsight: GenerateDailyInsight by lazy {
+        GenerateDailyInsight(
+            weatherRepository = weatherRepository,
+            calendarEventReader = calendarEventReader,
+        )
+    }
 
     private val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 

--- a/app/src/main/kotlin/app/adaptweather/calendar/CalendarContractEventReader.kt
+++ b/app/src/main/kotlin/app/adaptweather/calendar/CalendarContractEventReader.kt
@@ -1,0 +1,116 @@
+package app.adaptweather.calendar
+
+import android.annotation.SuppressLint
+import android.content.ContentUris
+import android.content.Context
+import android.net.Uri
+import android.provider.CalendarContract
+import android.util.Log
+import app.adaptweather.core.domain.model.CalendarEvent
+import app.adaptweather.core.domain.repository.CalendarEventReader
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalTime
+import java.time.ZoneId
+
+/**
+ * Reads device calendar events for a single local day via [CalendarContract.Instances].
+ *
+ * Why `Instances` and not `Events`: `Events` rows describe recurring patterns; one
+ * recurring meeting that fires every weekday is a single Events row but we want each
+ * individual occurrence. The `Instances` view materialises occurrences into the
+ * `[begin, end]` window we query, so a "9am standup, every weekday" only shows up
+ * once per day with the correct start time.
+ *
+ * Returns an empty list on any failure path (missing permission, missing provider,
+ * cursor crash) so the daily insight pipeline degrades gracefully to no events.
+ */
+class CalendarContractEventReader(private val context: Context) : CalendarEventReader {
+
+    override suspend fun eventsForDay(date: LocalDate, zoneId: ZoneId): List<CalendarEvent> {
+        if (!CalendarPermission.isGranted(context)) {
+            Log.i(TAG, "READ_CALENDAR not granted; skipping calendar read.")
+            return emptyList()
+        }
+        return withContext(Dispatchers.IO) {
+            runCatching { query(date, zoneId) }
+                .onFailure { Log.w(TAG, "Calendar query failed; degrading to no events.", it) }
+                .getOrDefault(emptyList())
+        }
+    }
+
+    @SuppressLint("MissingPermission")
+    private fun query(date: LocalDate, zoneId: ZoneId): List<CalendarEvent> {
+        val startOfDay = date.atStartOfDay(zoneId).toInstant().toEpochMilli()
+        val endOfDay = date.plusDays(1).atStartOfDay(zoneId).toInstant().toEpochMilli()
+
+        val uriBuilder = CalendarContract.Instances.CONTENT_URI.buildUpon()
+        ContentUris.appendId(uriBuilder, startOfDay)
+        ContentUris.appendId(uriBuilder, endOfDay)
+        val uri: Uri = uriBuilder.build()
+
+        val projection = arrayOf(
+            CalendarContract.Instances.TITLE,
+            CalendarContract.Instances.BEGIN,
+            CalendarContract.Instances.END,
+            CalendarContract.Instances.EVENT_LOCATION,
+            CalendarContract.Instances.ALL_DAY,
+            CalendarContract.Instances.STATUS,
+            CalendarContract.Instances.AVAILABILITY,
+        )
+        val sortOrder = "${CalendarContract.Instances.BEGIN} ASC"
+
+        val results = mutableListOf<CalendarEvent>()
+        context.contentResolver.query(uri, projection, null, null, sortOrder)?.use { cursor ->
+            val titleIdx = cursor.getColumnIndex(CalendarContract.Instances.TITLE)
+            val beginIdx = cursor.getColumnIndex(CalendarContract.Instances.BEGIN)
+            val endIdx = cursor.getColumnIndex(CalendarContract.Instances.END)
+            val locationIdx = cursor.getColumnIndex(CalendarContract.Instances.EVENT_LOCATION)
+            val allDayIdx = cursor.getColumnIndex(CalendarContract.Instances.ALL_DAY)
+            val statusIdx = cursor.getColumnIndex(CalendarContract.Instances.STATUS)
+            val availabilityIdx = cursor.getColumnIndex(CalendarContract.Instances.AVAILABILITY)
+
+            while (cursor.moveToNext()) {
+                // Cancelled events are still in the cursor; the calendar tie-in would
+                // pair an item against a meeting that isn't happening, so drop early.
+                // FREE busy slots are typically calendar holds the user doesn't want
+                // surfaced as actual events either.
+                if (statusIdx >= 0 && cursor.getInt(statusIdx) == CalendarContract.Instances.STATUS_CANCELED) continue
+                if (availabilityIdx >= 0 && cursor.getInt(availabilityIdx) == CalendarContract.Instances.AVAILABILITY_FREE) continue
+
+                val title = cursor.takeIf { titleIdx >= 0 }?.getString(titleIdx)?.takeIf { it.isNotBlank() }
+                    ?: continue
+                val begin = if (beginIdx >= 0) cursor.getLong(beginIdx) else continue
+                val end = if (endIdx >= 0) cursor.getLong(endIdx) else continue
+                val location = locationIdx.takeIf { it >= 0 }?.let { cursor.getString(it) }?.takeIf { it.isNotBlank() }
+                val allDay = allDayIdx >= 0 && cursor.getInt(allDayIdx) != 0
+
+                // CalendarContract stores all-day events in UTC midnight-to-midnight; converting
+                // those into the user's zone shifts them off the day boundary. Keep them as
+                // pure all-day markers and project the rest into wall-clock in the user zone.
+                val (start, finish) = if (allDay) {
+                    LocalTime.MIDNIGHT to LocalTime.MIDNIGHT
+                } else {
+                    val s = Instant.ofEpochMilli(begin).atZone(zoneId).toLocalTime()
+                    val e = Instant.ofEpochMilli(end).atZone(zoneId).toLocalTime()
+                    s to e
+                }
+
+                results += CalendarEvent(
+                    title = title,
+                    start = start,
+                    end = finish,
+                    location = location,
+                    allDay = allDay,
+                )
+            }
+        }
+        return results
+    }
+
+    private companion object {
+        private const val TAG = "CalendarReader"
+    }
+}

--- a/app/src/main/kotlin/app/adaptweather/calendar/CalendarPermission.kt
+++ b/app/src/main/kotlin/app/adaptweather/calendar/CalendarPermission.kt
@@ -1,0 +1,23 @@
+package app.adaptweather.calendar
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import androidx.core.content.ContextCompat
+
+/**
+ * Helper for the runtime READ_CALENDAR permission. Calendar reading is opt-in: the
+ * Settings toggle drives intent, this gate drives capability. Both must be true for
+ * the worker to actually read events — and if the user revokes the permission from
+ * system Settings, the toggle is auto-flipped off on next resume so the persisted
+ * pref stays consistent with reality.
+ */
+object CalendarPermission {
+    fun isGranted(context: Context): Boolean = ContextCompat.checkSelfPermission(
+        context,
+        Manifest.permission.READ_CALENDAR,
+    ) == PackageManager.PERMISSION_GRANTED
+
+    /** The permission string callers feed into ActivityResultContracts.RequestPermission. */
+    val MANIFEST_PERMISSION: String = Manifest.permission.READ_CALENDAR
+}

--- a/app/src/main/kotlin/app/adaptweather/data/SettingsRepository.kt
+++ b/app/src/main/kotlin/app/adaptweather/data/SettingsRepository.kt
@@ -107,6 +107,10 @@ class SettingsRepository(
         dataStore.edit { it[VOICE_LOCALE] = locale.name }
     }
 
+    suspend fun setUseCalendarEvents(enabled: Boolean) {
+        dataStore.edit { it[USE_CALENDAR_EVENTS] = enabled }
+    }
+
     private fun Preferences.toUserPreferences(): UserPreferences {
         val time = this[SCHEDULE_TIME]?.let { LocalTime.parse(it, TIME_FORMAT) }
             ?: DEFAULT_TIME
@@ -133,6 +137,7 @@ class SettingsRepository(
         // Resolve only after voiceLocale is known so the picked voice matches.
         val openAiVoice = this[OPENAI_VOICE]?.takeIf { it.isNotBlank() }
             ?: defaultOpenAiVoiceFor(voiceLocale)
+        val useCalendarEvents = this[USE_CALENDAR_EVENTS] == true
 
         return UserPreferences(
             schedule = Schedule(time = time, days = days, zoneId = zoneIdProvider()),
@@ -146,6 +151,7 @@ class SettingsRepository(
             geminiVoice = geminiVoice,
             openAiVoice = openAiVoice,
             voiceLocale = voiceLocale,
+            useCalendarEvents = useCalendarEvents,
         )
     }
 
@@ -183,6 +189,7 @@ class SettingsRepository(
         private val GEMINI_VOICE = stringPreferencesKey("gemini_voice")
         private val OPENAI_VOICE = stringPreferencesKey("openai_voice")
         private val VOICE_LOCALE = stringPreferencesKey("voice_locale")
+        private val USE_CALENDAR_EVENTS = booleanPreferencesKey("use_calendar_events")
 
         private val TIME_FORMAT: DateTimeFormatter = DateTimeFormatter.ofPattern("HH:mm")
         private val DEFAULT_TIME: LocalTime = LocalTime.of(7, 0)

--- a/app/src/main/kotlin/app/adaptweather/ui/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/app/adaptweather/ui/settings/SettingsScreen.kt
@@ -35,10 +35,13 @@ import androidx.compose.material3.TimePicker
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.rememberTimePickerState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -119,6 +122,7 @@ fun SettingsScreen(viewModel: SettingsViewModel, onNavigateBack: () -> Unit) {
             onSetOpenAiKey = viewModel::setOpenAiKey,
             onClearOpenAiKey = viewModel::clearOpenAiKey,
             onSetVoiceLocale = viewModel::setVoiceLocale,
+            onSetUseCalendarEvents = viewModel::setUseCalendarEvents,
         )
     }
 }
@@ -146,6 +150,7 @@ private fun SettingsContent(
     onSetOpenAiKey: (String) -> Unit,
     onClearOpenAiKey: () -> Unit,
     onSetVoiceLocale: (VoiceLocale) -> Unit,
+    onSetUseCalendarEvents: (Boolean) -> Unit,
 ) {
     Column(
         modifier = Modifier
@@ -197,6 +202,10 @@ private fun SettingsContent(
             onAdd = onAddWardrobeRule,
             onReplace = onReplaceWardrobeRule,
             onDelete = onDeleteWardrobeRule,
+        )
+        CalendarCard(
+            useEvents = state.useCalendarEvents,
+            onSetUseEvents = onSetUseCalendarEvents,
         )
         if (BuildConfig.DEBUG) {
             DebugCard()
@@ -773,6 +782,97 @@ private fun TimePickerDialog(
 }
 
 private val TIME_FORMAT: DateTimeFormatter = DateTimeFormatter.ofPattern("HH:mm")
+
+@Composable
+private fun CalendarCard(
+    useEvents: Boolean,
+    onSetUseEvents: (Boolean) -> Unit,
+) {
+    val context = LocalContext.current
+    var permissionGranted by remember {
+        mutableStateOf(app.adaptweather.calendar.CalendarPermission.isGranted(context))
+    }
+
+    // rememberUpdatedState so the lifecycle observer sees the *current* useEvents
+    // and onSetUseEvents on every check, not the values captured the first time
+    // the effect ran.
+    val currentUseEvents by rememberUpdatedState(useEvents)
+    val currentOnSetUseEvents by rememberUpdatedState(onSetUseEvents)
+
+    val lifecycleOwner = androidx.compose.ui.platform.LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner) {
+        // Re-check on resume so the toggle reflects whatever the user did in system
+        // Settings while we were backgrounded. If permission was revoked, also flip
+        // the persisted pref off so the worker stops consulting the reader.
+        val observer = androidx.lifecycle.LifecycleEventObserver { _, event ->
+            if (event == androidx.lifecycle.Lifecycle.Event.ON_RESUME) {
+                val granted = app.adaptweather.calendar.CalendarPermission.isGranted(context)
+                permissionGranted = granted
+                if (!granted && currentUseEvents) {
+                    currentOnSetUseEvents(false)
+                }
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
+
+    val launcher = androidx.activity.compose.rememberLauncherForActivityResult(
+        contract = androidx.activity.result.contract.ActivityResultContracts.RequestPermission(),
+    ) { granted ->
+        permissionGranted = granted
+        // Only flip the toggle on if the user granted; otherwise the worker would
+        // consult the reader, get an empty list every morning, and silently log a
+        // permission-denied warning forever.
+        onSetUseEvents(granted)
+    }
+
+    SectionCard(title = stringResource(R.string.settings_calendar_title)) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = stringResource(R.string.settings_calendar_use_events),
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier.weight(1f),
+            )
+            Switch(
+                checked = useEvents && permissionGranted,
+                onCheckedChange = { wantsOn ->
+                    if (!wantsOn) {
+                        onSetUseEvents(false)
+                        return@Switch
+                    }
+                    if (permissionGranted) {
+                        onSetUseEvents(true)
+                    } else {
+                        launcher.launch(app.adaptweather.calendar.CalendarPermission.MANIFEST_PERMISSION)
+                    }
+                },
+            )
+        }
+        Text(
+            text = stringResource(
+                if (useEvents && permissionGranted) R.string.settings_calendar_description_on
+                else R.string.settings_calendar_description_off,
+            ),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        if (useEvents && !permissionGranted) {
+            Text(
+                text = stringResource(R.string.settings_calendar_open_settings),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.error,
+            )
+            TextButton(
+                onClick = { openAppDetails(context) },
+                modifier = Modifier.fillMaxWidth(),
+            ) { Text(stringResource(R.string.settings_calendar_grant_permission)) }
+        }
+    }
+}
 
 @Composable
 private fun DebugCard() {

--- a/app/src/main/kotlin/app/adaptweather/ui/settings/SettingsState.kt
+++ b/app/src/main/kotlin/app/adaptweather/ui/settings/SettingsState.kt
@@ -31,6 +31,7 @@ data class SettingsState(
     // current locale → fable on en-GB, nova everywhere else.
     val openAiVoice: String = defaultOpenAiVoiceFor(VoiceLocale.SYSTEM),
     val voiceLocale: VoiceLocale = VoiceLocale.SYSTEM,
+    val useCalendarEvents: Boolean = false,
     val apiKeyConfigured: Boolean = false,
     val openAiKeyConfigured: Boolean = false,
 )

--- a/app/src/main/kotlin/app/adaptweather/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/app/adaptweather/ui/settings/SettingsViewModel.kt
@@ -50,6 +50,7 @@ class SettingsViewModel(
                         geminiVoice = prefs.geminiVoice,
                         openAiVoice = prefs.openAiVoice,
                         voiceLocale = prefs.voiceLocale,
+                        useCalendarEvents = prefs.useCalendarEvents,
                     )
                 }
             }
@@ -145,6 +146,10 @@ class SettingsViewModel(
 
     fun setVoiceLocale(locale: VoiceLocale) {
         viewModelScope.launch { settingsRepository.setVoiceLocale(locale) }
+    }
+
+    fun setUseCalendarEvents(enabled: Boolean) {
+        viewModelScope.launch { settingsRepository.setUseCalendarEvents(enabled) }
     }
 
     /** Used by [LocationCard] inside a LaunchedEffect; safe to call from any dispatcher. */

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -136,6 +136,13 @@
     <string name="settings_notification_permission_description">Without notification permission, the daily insight has nowhere to go. Grant it so AdaptWeather can post tomorrow morning.</string>
     <string name="settings_notification_permission_grant">Grant notification permission</string>
 
+    <string name="settings_calendar_title">Calendar</string>
+    <string name="settings_calendar_use_events">Use today\'s calendar events</string>
+    <string name="settings_calendar_description_off">When enabled, AdaptWeather reads today\'s events from your device calendar so the morning insight can suggest items keyed to specific events — for example, "bring an umbrella for your 3pm park run". Only event titles and times are used; descriptions, attendees, and locations are read but never sent off-device.</string>
+    <string name="settings_calendar_description_on">Reading today\'s events from your device calendar to enrich the morning insight. Only titles and times are used in the rendered summary; descriptions and attendees are not. Everything stays on-device.</string>
+    <string name="settings_calendar_grant_permission">Grant calendar permission</string>
+    <string name="settings_calendar_open_settings">Calendar permission denied. Grant it from system Settings.</string>
+
     <string name="settings_debug_title">Debug (debug builds only)</string>
     <string name="settings_debug_description">Fire the daily-insight pipeline immediately. Useful for verifying without waiting until the scheduled time.</string>
     <string name="settings_debug_fire_now">Fire insight now</string>

--- a/app/src/test/kotlin/app/adaptweather/data/SettingsRepositoryTest.kt
+++ b/app/src/test/kotlin/app/adaptweather/data/SettingsRepositoryTest.kt
@@ -193,6 +193,17 @@ class SettingsRepositoryTest {
     }
 
     @Test
+    fun `useCalendarEvents defaults to false and round-trips`() = runTest {
+        subject.preferences.first().useCalendarEvents shouldBe false
+
+        subject.setUseCalendarEvents(true)
+        subject.preferences.first().useCalendarEvents shouldBe true
+
+        subject.setUseCalendarEvents(false)
+        subject.preferences.first().useCalendarEvents shouldBe false
+    }
+
+    @Test
     fun `zoneId is resolved fresh on each emission`() = runTest {
         val zones = mutableListOf(ZoneId.of("UTC"), ZoneId.of("America/New_York"))
         val rotating = SettingsRepository(

--- a/app/src/test/kotlin/app/adaptweather/ui/settings/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/app/adaptweather/ui/settings/SettingsViewModelTest.kt
@@ -140,6 +140,17 @@ class SettingsViewModelTest {
     }
 
     @Test
+    fun `setUseCalendarEvents persists and surfaces in state`() = runTest {
+        subject.setUseCalendarEvents(true)
+        subject.state.first { it.useCalendarEvents }
+        settingsRepository.preferences.first().useCalendarEvents shouldBe true
+
+        subject.setUseCalendarEvents(false)
+        subject.state.first { !it.useCalendarEvents }
+        settingsRepository.preferences.first().useCalendarEvents shouldBe false
+    }
+
+    @Test
     fun `setTemperatureUnit and setDistanceUnit persist independently`() = runTest {
         subject.setTemperatureUnit(TemperatureUnit.FAHRENHEIT)
         subject.setDistanceUnit(DistanceUnit.MILES)

--- a/core/domain/src/main/kotlin/app/adaptweather/core/domain/model/CalendarEvent.kt
+++ b/core/domain/src/main/kotlin/app/adaptweather/core/domain/model/CalendarEvent.kt
@@ -1,0 +1,34 @@
+package app.adaptweather.core.domain.model
+
+import java.time.LocalTime
+
+/**
+ * One scheduled event read from the user's device calendar, projected into the
+ * local day the daily insight is being generated for. Times are wall-clock in the
+ * user's zone — the reader is responsible for applying timezone conversion before
+ * constructing the model so downstream code never has to think about Instants.
+ *
+ * Privacy posture: only the [title], [start]/[end], and an optional [location] line
+ * are carried. Descriptions, attendees, organizers, and account info are not
+ * surfaced. The current consumer [app.adaptweather.core.domain.usecase.RenderInsightSummary]
+ * never includes the location in the rendered string, but the field is kept so a
+ * future "what to bring + where" sentence can use it without a model migration.
+ */
+data class CalendarEvent(
+    val title: String,
+    val start: LocalTime,
+    val end: LocalTime,
+    val location: String? = null,
+    val allDay: Boolean = false,
+) {
+    /**
+     * True when [time] falls within `[start, end)`. All-day events match every
+     * non-midnight time so the precip-peak overlap check below them never
+     * accidentally pairs an umbrella with "your all-day Public holiday".
+     */
+    fun overlaps(time: LocalTime): Boolean {
+        if (allDay) return false
+        if (start == end) return time == start
+        return !time.isBefore(start) && time.isBefore(end)
+    }
+}

--- a/core/domain/src/main/kotlin/app/adaptweather/core/domain/model/Settings.kt
+++ b/core/domain/src/main/kotlin/app/adaptweather/core/domain/model/Settings.kt
@@ -78,6 +78,14 @@ data class UserPreferences(
      */
     val openAiVoice: String = DEFAULT_OPENAI_VOICE,
     val voiceLocale: VoiceLocale = VoiceLocale.SYSTEM,
+    /**
+     * When true, the worker reads today's calendar events (via `READ_CALENDAR`)
+     * and feeds them into the insight summary so the rendered string can tie a
+     * wardrobe suggestion to a specific event ("bring an umbrella for your 3pm
+     * standup"). Off by default — the user must both enable the toggle and grant
+     * the runtime permission for events to actually be read.
+     */
+    val useCalendarEvents: Boolean = false,
 ) {
     companion object {
         const val DEFAULT_GEMINI_VOICE = "Kore"

--- a/core/domain/src/main/kotlin/app/adaptweather/core/domain/repository/CalendarEventReader.kt
+++ b/core/domain/src/main/kotlin/app/adaptweather/core/domain/repository/CalendarEventReader.kt
@@ -1,0 +1,15 @@
+package app.adaptweather.core.domain.repository
+
+import app.adaptweather.core.domain.model.CalendarEvent
+import java.time.LocalDate
+import java.time.ZoneId
+
+/**
+ * Reads the user's calendar events for a given local day. Implementations are
+ * expected to be best-effort: missing permission, an unavailable provider, or a
+ * query failure should return an empty list rather than throw, so the daily
+ * insight pipeline degrades gracefully to its calendar-free behaviour.
+ */
+interface CalendarEventReader {
+    suspend fun eventsForDay(date: LocalDate, zoneId: ZoneId): List<CalendarEvent>
+}

--- a/core/domain/src/main/kotlin/app/adaptweather/core/domain/usecase/GenerateDailyInsight.kt
+++ b/core/domain/src/main/kotlin/app/adaptweather/core/domain/usecase/GenerateDailyInsight.kt
@@ -5,6 +5,7 @@ import app.adaptweather.core.domain.model.Location
 import app.adaptweather.core.domain.model.OutfitSuggestion
 import app.adaptweather.core.domain.model.UserPreferences
 import app.adaptweather.core.domain.model.WeatherAlert
+import app.adaptweather.core.domain.repository.CalendarEventReader
 import app.adaptweather.core.domain.repository.WeatherRepository
 import java.time.Clock
 
@@ -20,6 +21,7 @@ class GenerateDailyInsight(
     private val weatherRepository: WeatherRepository,
     private val evaluateWardrobeRules: EvaluateWardrobeRules = EvaluateWardrobeRules(),
     private val renderInsightSummary: RenderInsightSummary = RenderInsightSummary(),
+    private val calendarEventReader: CalendarEventReader? = null,
     private val clock: Clock = Clock.systemUTC(),
 ) {
     suspend operator fun invoke(
@@ -29,11 +31,25 @@ class GenerateDailyInsight(
         val bundle = weatherRepository.fetchForecast(location)
         val activeAlerts = bundle.alerts.filter { it.expires.isAfter(clock.instant()) }
         val todayTriggered = evaluateWardrobeRules(bundle.today, prefs.wardrobeRules)
+        // Calendar events are gated on both the opt-in pref AND a configured reader.
+        // Failures (missing permission, provider crash) degrade to no events so a
+        // misbehaving reader can never fail the insight pipeline; the rest of the
+        // summary still renders. Capture the property as a local so the smart-cast
+        // survives across the runCatching lambda boundary.
+        val reader = calendarEventReader
+        val events = if (prefs.useCalendarEvents && reader != null) {
+            runCatching {
+                reader.eventsForDay(bundle.today.date, prefs.schedule.zoneId)
+            }.getOrDefault(emptyList())
+        } else {
+            emptyList()
+        }
         val summary = renderInsightSummary(
             today = bundle.today,
             yesterday = bundle.yesterday,
             todayTriggeredRules = todayTriggered,
             alerts = activeAlerts,
+            events = events,
         )
         val insight = Insight(
             summary = summary,

--- a/core/domain/src/main/kotlin/app/adaptweather/core/domain/usecase/RenderInsightSummary.kt
+++ b/core/domain/src/main/kotlin/app/adaptweather/core/domain/usecase/RenderInsightSummary.kt
@@ -1,17 +1,19 @@
 package app.adaptweather.core.domain.usecase
 
 import app.adaptweather.core.domain.model.AlertSeverity
+import app.adaptweather.core.domain.model.CalendarEvent
 import app.adaptweather.core.domain.model.DailyForecast
 import app.adaptweather.core.domain.model.WardrobeRule
 import app.adaptweather.core.domain.model.WeatherAlert
 import app.adaptweather.core.domain.model.WeatherCondition
 import java.time.LocalTime
+import java.time.format.DateTimeFormatter
 import java.util.Locale
 import kotlin.math.abs
 import kotlin.math.roundToInt
 
 /**
- * Renders the daily insight summary as a deterministic single string of up to five
+ * Renders the daily insight summary as a deterministic single string of up to six
  * short sentences, each driven by an independent rule. Replaces the previous
  * Gemini call: every sentence is template-fillable from the forecast, so the LLM
  * round trip wasn't earning its keep.
@@ -28,6 +30,12 @@ import kotlin.math.roundToInt
  *    an article on the first item ("a" / "an" / no article for plurals) and
  *    " and " before the last item (Oxford comma for three or more).
  * 5. Precipitation: peak chance ≥ 30% → "<Type> at <HH:MM>."
+ * 6. Calendar tie-in (optional): if rules 4 and 5 both fired AND a calendar event
+ *    is in progress at the precip peak hour, output
+ *    "Bring <first-item> for your <HH:MM> <title>." Picks the umbrella when one
+ *    is on the wardrobe list, otherwise the first triggered item. Only fires
+ *    when the caller passes events; the worker only does that when the user
+ *    has opted in to calendar reading.
  *
  * All temperature comparisons use feels-like values, matching the wardrobe rules.
  */
@@ -37,12 +45,16 @@ class RenderInsightSummary {
         yesterday: DailyForecast,
         todayTriggeredRules: List<WardrobeRule>,
         alerts: List<WeatherAlert> = emptyList(),
+        events: List<CalendarEvent> = emptyList(),
     ): String = buildList {
         alertSentence(alerts)?.let { add(it) }
         add(bandSentence(today))
         deltaSentence(today, yesterday)?.let { add(it) }
-        wardrobeSentence(todayTriggeredRules.map { it.item })?.let { add(it) }
-        precipSentence(today)?.let { add(it) }
+        val items = todayTriggeredRules.map { it.item }
+        wardrobeSentence(items)?.let { add(it) }
+        val peak = peakPrecip(today)
+        precipSentence(peak)?.let { add(it) }
+        calendarSentence(items, peak, events)?.let { add(it) }
     }.joinToString(" ")
 
     private fun alertSentence(alerts: List<WeatherAlert>): String? {
@@ -101,7 +113,12 @@ class RenderInsightSummary {
         else -> "a $item"
     }
 
-    private fun precipSentence(today: DailyForecast): String? {
+    /**
+     * Resolves the precipitation peak hour the way the precip rule needs it. Lifted
+     * out of [precipSentence] so the calendar-tie-in rule can pair an event window
+     * against the same time without re-running the logic and getting out of sync.
+     */
+    private fun peakPrecip(today: DailyForecast): PeakPrecip? {
         val peak = today.hourly.maxByOrNull { it.precipitationProbabilityPct }
         val time: LocalTime
         val condition: WeatherCondition
@@ -113,9 +130,34 @@ class RenderInsightSummary {
             time = peak.time
             condition = if (peak.condition == WeatherCondition.UNKNOWN) today.condition else peak.condition
         }
-        val type = condition.name.lowercase(Locale.ROOT).replace('_', ' ')
+        return PeakPrecip(time, condition)
+    }
+
+    private fun precipSentence(peak: PeakPrecip?): String? {
+        if (peak == null) return null
+        val type = peak.condition.name.lowercase(Locale.ROOT).replace('_', ' ')
             .replaceFirstChar { it.titlecase(Locale.ROOT) }
-        return "$type at $time."
+        return "$type at ${peak.time}."
+    }
+
+    private fun calendarSentence(
+        items: List<String>,
+        peak: PeakPrecip?,
+        events: List<CalendarEvent>,
+    ): String? {
+        if (items.isEmpty() || peak == null || events.isEmpty()) return null
+        val event = events.firstOrNull { it.overlaps(peak.time) } ?: return null
+        // Prefer "umbrella" when the user has it on their list — that's the wardrobe
+        // item the precip-peak overlap was actually motivated by. Otherwise just
+        // take the first triggered item, mirroring rule 4's ordering.
+        val item = items.firstOrNull { it.equals("umbrella", ignoreCase = true) } ?: items.first()
+        return "Bring ${withArticle(item)} for your ${EVENT_TIME.format(peak.time)} ${event.title}."
+    }
+
+    private data class PeakPrecip(val time: LocalTime, val condition: WeatherCondition)
+
+    private companion object {
+        private val EVENT_TIME: DateTimeFormatter = DateTimeFormatter.ofPattern("HH:mm")
     }
 }
 

--- a/core/domain/src/test/kotlin/app/adaptweather/core/domain/usecase/GenerateDailyInsightTest.kt
+++ b/core/domain/src/test/kotlin/app/adaptweather/core/domain/usecase/GenerateDailyInsightTest.kt
@@ -1,6 +1,7 @@
 package app.adaptweather.core.domain.usecase
 
 import app.adaptweather.core.domain.model.AlertSeverity
+import app.adaptweather.core.domain.model.CalendarEvent
 import app.adaptweather.core.domain.model.DailyForecast
 import app.adaptweather.core.domain.model.DeliveryMode
 import app.adaptweather.core.domain.model.DistanceUnit
@@ -12,17 +13,21 @@ import app.adaptweather.core.domain.model.UserPreferences
 import app.adaptweather.core.domain.model.WardrobeRule
 import app.adaptweather.core.domain.model.WeatherAlert
 import app.adaptweather.core.domain.model.WeatherCondition
+import app.adaptweather.core.domain.repository.CalendarEventReader
 import app.adaptweather.core.domain.repository.ForecastBundle
 import app.adaptweather.core.domain.repository.WeatherRepository
 import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import java.time.Clock
 import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalTime
+import java.time.ZoneId
 import java.time.ZoneOffset
 
 class GenerateDailyInsightTest {
@@ -68,6 +73,23 @@ class GenerateDailyInsightTest {
         override suspend fun fetchForecast(location: Location): ForecastBundle {
             lastQueriedLocation = location
             return bundle
+        }
+    }
+
+    private class FakeCalendarEventReader(
+        private val events: List<CalendarEvent> = emptyList(),
+        private val throws: Throwable? = null,
+    ) : CalendarEventReader {
+        var lastDate: LocalDate? = null
+            private set
+        var lastZone: ZoneId? = null
+            private set
+
+        override suspend fun eventsForDay(date: LocalDate, zoneId: ZoneId): List<CalendarEvent> {
+            lastDate = date
+            lastZone = zoneId
+            throws?.let { throw it }
+            return events
         }
     }
 
@@ -160,6 +182,65 @@ class GenerateDailyInsightTest {
         val result = subject(london, prefs)
 
         result.insight.hourly.shouldContainExactly(hourly)
+    }
+
+    @Test
+    fun `calendar reader is consulted for today's date and zone when opted in`() = runTest {
+        val zone = ZoneId.of("Europe/London")
+        val rainyHourly = today.copy(
+            precipitationProbabilityMaxPct = 60.0,
+            condition = WeatherCondition.RAIN,
+            hourly = listOf(
+                HourlyForecast(LocalTime.of(15, 0), 22.0, 22.0, 60.0, WeatherCondition.RAIN),
+            ),
+        )
+        val event = CalendarEvent(
+            title = "park run",
+            start = LocalTime.of(14, 30),
+            end = LocalTime.of(16, 0),
+        )
+        val weather = FakeWeatherRepository(ForecastBundle(rainyHourly, yesterday))
+        val calendar = FakeCalendarEventReader(events = listOf(event))
+        val subject = GenerateDailyInsight(weather, calendarEventReader = calendar, clock = clock)
+
+        val result = subject(
+            location = london,
+            prefs = prefs.copy(
+                useCalendarEvents = true,
+                schedule = Schedule.default(zone),
+            ),
+        )
+
+        calendar.lastDate shouldBe today.date
+        calendar.lastZone shouldBe zone
+        result.insight.summary.shouldContain("for your 15:00 park run")
+    }
+
+    @Test
+    fun `calendar reader is not consulted when the toggle is off`() = runTest {
+        val weather = FakeWeatherRepository(ForecastBundle(today, yesterday))
+        val calendar = FakeCalendarEventReader(events = listOf(
+            CalendarEvent("standup", LocalTime.of(9, 0), LocalTime.of(9, 30)),
+        ))
+        val subject = GenerateDailyInsight(weather, calendarEventReader = calendar, clock = clock)
+
+        val result = subject(london, prefs.copy(useCalendarEvents = false))
+
+        calendar.lastDate.shouldBeNull()
+        result.insight.summary.shouldNotContain("for your")
+    }
+
+    @Test
+    fun `calendar reader failure degrades to no events without failing the insight`() = runTest {
+        val weather = FakeWeatherRepository(ForecastBundle(today, yesterday))
+        val calendar = FakeCalendarEventReader(throws = SecurityException("permission denied"))
+        val subject = GenerateDailyInsight(weather, calendarEventReader = calendar, clock = clock)
+
+        val result = subject(london, prefs.copy(useCalendarEvents = true))
+
+        // The summary still composes — we just lose the calendar tie-in sentence.
+        result.insight.summary.shouldContain("Today will be")
+        result.insight.summary.shouldNotContain("for your")
     }
 
     @Test

--- a/core/domain/src/test/kotlin/app/adaptweather/core/domain/usecase/RenderInsightSummaryTest.kt
+++ b/core/domain/src/test/kotlin/app/adaptweather/core/domain/usecase/RenderInsightSummaryTest.kt
@@ -1,6 +1,7 @@
 package app.adaptweather.core.domain.usecase
 
 import app.adaptweather.core.domain.model.AlertSeverity
+import app.adaptweather.core.domain.model.CalendarEvent
 import app.adaptweather.core.domain.model.DailyForecast
 import app.adaptweather.core.domain.model.HourlyForecast
 import app.adaptweather.core.domain.model.WardrobeRule
@@ -226,6 +227,91 @@ class RenderInsightSummaryTest {
         )
         out shouldBe "Alert: Flood Warning. Today will be cool to mild. It will be 6° warmer today. " +
             "Wear a jumper and umbrella. Rain at 15:00."
+    }
+
+    @Test
+    fun `calendar tie-in fires when wardrobe + precip + overlapping event all present`() {
+        val today = mildToday.copy(
+            precipitationProbabilityMaxPct = 60.0,
+            condition = WeatherCondition.RAIN,
+            hourly = listOf(
+                HourlyForecast(LocalTime.of(15, 0), 22.0, 22.0, 60.0, WeatherCondition.RAIN),
+            ),
+        )
+        val event = CalendarEvent(
+            title = "park run",
+            start = LocalTime.of(14, 30),
+            end = LocalTime.of(16, 0),
+        )
+        val out = subject(today, yesterday, listOf(umbrellaRule), events = listOf(event))
+        out.shouldContain("Bring an umbrella for your 15:00 park run.")
+    }
+
+    @Test
+    fun `calendar tie-in prefers umbrella over the first listed item when both apply`() {
+        val today = mildToday.copy(
+            precipitationProbabilityMaxPct = 60.0,
+            condition = WeatherCondition.RAIN,
+            hourly = listOf(HourlyForecast(LocalTime.of(15, 0), 22.0, 22.0, 60.0, WeatherCondition.RAIN)),
+        )
+        val event = CalendarEvent("standup", LocalTime.of(14, 0), LocalTime.of(16, 0))
+        val out = subject(today, yesterday, listOf(jumperRule, umbrellaRule), events = listOf(event))
+        out.shouldContain("Bring an umbrella for your 15:00 standup.")
+    }
+
+    @Test
+    fun `calendar tie-in falls back to the first item when umbrella is not on the list`() {
+        val today = mildToday.copy(
+            precipitationProbabilityMaxPct = 60.0,
+            condition = WeatherCondition.RAIN,
+            hourly = listOf(HourlyForecast(LocalTime.of(15, 0), 22.0, 22.0, 60.0, WeatherCondition.RAIN)),
+        )
+        val event = CalendarEvent("park run", LocalTime.of(14, 0), LocalTime.of(16, 0))
+        val out = subject(today, yesterday, listOf(jumperRule, jacketRule), events = listOf(event))
+        out.shouldContain("Bring a jumper for your 15:00 park run.")
+    }
+
+    @Test
+    fun `calendar tie-in is omitted when no event overlaps the precip peak`() {
+        val today = mildToday.copy(
+            precipitationProbabilityMaxPct = 60.0,
+            condition = WeatherCondition.RAIN,
+            hourly = listOf(HourlyForecast(LocalTime.of(15, 0), 22.0, 22.0, 60.0, WeatherCondition.RAIN)),
+        )
+        val event = CalendarEvent("breakfast", LocalTime.of(8, 0), LocalTime.of(9, 0))
+        subject(today, yesterday, listOf(umbrellaRule), events = listOf(event))
+            .shouldNotContain("Bring")
+    }
+
+    @Test
+    fun `calendar tie-in is omitted when no wardrobe rule fires`() {
+        val today = mildToday.copy(
+            precipitationProbabilityMaxPct = 60.0,
+            condition = WeatherCondition.RAIN,
+            hourly = listOf(HourlyForecast(LocalTime.of(15, 0), 22.0, 22.0, 60.0, WeatherCondition.RAIN)),
+        )
+        val event = CalendarEvent("park run", LocalTime.of(14, 30), LocalTime.of(16, 0))
+        subject(today, yesterday, emptyList(), events = listOf(event))
+            .shouldNotContain("Bring")
+    }
+
+    @Test
+    fun `calendar tie-in is omitted on a dry day even when an event exists`() {
+        val event = CalendarEvent("park run", LocalTime.of(11, 0), LocalTime.of(13, 0))
+        subject(mildToday, yesterday, listOf(umbrellaRule), events = listOf(event))
+            .shouldNotContain("Bring")
+    }
+
+    @Test
+    fun `calendar tie-in skips all-day events`() {
+        val today = mildToday.copy(
+            precipitationProbabilityMaxPct = 60.0,
+            condition = WeatherCondition.RAIN,
+            hourly = listOf(HourlyForecast(LocalTime.of(15, 0), 22.0, 22.0, 60.0, WeatherCondition.RAIN)),
+        )
+        val holiday = CalendarEvent("public holiday", LocalTime.MIDNIGHT, LocalTime.MIDNIGHT, allDay = true)
+        subject(today, yesterday, listOf(umbrellaRule), events = listOf(holiday))
+            .shouldNotContain("Bring")
     }
 
     @Test

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -33,13 +33,16 @@ Code TODOs in source files are linked from here when they exist.
 
 ## Calendar integration (next-up after TTS)
 
-- [ ] **Read today's calendar events** (`CalendarContract`) so the daily
+- [x] **Read today's calendar events** (`CalendarContract`) so the daily
       insight can suggest items keyed to events: *"Bring an umbrella for your
-      3pm at the park."*
-  - Opt-in toggle in Settings + runtime `READ_CALENDAR` grant.
-  - New `:core:domain` model `CalendarEvent`.
-  - Worker reads events for today and feeds them into `BuildPrompt`.
-  - Privacy disclosure update in `docs/privacy.md`.
+      3pm park run."* Opt-in via Settings → Calendar (off by default), runtime
+      `READ_CALENDAR` granted from the same card. The reader projects only
+      titles, times, and locations; the rendered summary uses only title and
+      time. The 6th sentence in `RenderInsightSummary` fires only when a
+      wardrobe rule + a precip-peak event window both apply, preferring
+      "umbrella" when on the wardrobe list. Reader failures degrade silently
+      to no events.
+  - Privacy disclosure update in `docs/privacy.md` (file not yet created).
 
 ## Forecast & alerts
 


### PR DESCRIPTION
## Summary

Wires up the CalendarContract integration tracked in `docs/TODO.md` against the **new deterministic `RenderInsightSummary` architecture** (no LLM round-trip). The morning worker reads today's calendar events when the user has both flipped the new **Settings → Calendar** toggle and granted `READ_CALENDAR`, and a 6th sentence appends `"Bring <item> for your <HH:MM> <title>."` when a wardrobe rule fires AND the precip-peak hour overlaps a calendar event window.

> Rebased onto current `main` (was 48 commits behind). Previous commit is gone; the surviving commit (`e180ef9`) targets the new `RenderInsightSummary` rather than the old `BuildPrompt` (which has been removed from `main`).

## What changed

- **`:core:domain`**
  - New `CalendarEvent` model — title, start/end `LocalTime`, optional location, allDay flag. Includes an `overlaps(time)` helper so the renderer doesn't have to re-implement window math.
  - New `CalendarEventReader` interface — best-effort: implementations return `[]` on failure rather than throwing.
  - `RenderInsightSummary` accepts `events: List<CalendarEvent>` and gains a 6th rule. Picks `umbrella` when on the wardrobe list, otherwise the first triggered item. Lifted `peakPrecip()` out of `precipSentence` so the calendar sentence pairs against the same time without re-running the logic.
  - `GenerateDailyInsight` accepts an optional reader, gates on `prefs.useCalendarEvents`, swallows reader exceptions defensively.

- **`:app`**
  - `CalendarContractEventReader` queries `CalendarContract.Instances` for `[startOfDay, endOfDay)` in the user's zone, drops `STATUS_CANCELED` and `AVAILABILITY_FREE` rows, and projects all-day events as wall-clock midnight markers (the Instances view stores them in UTC, so naive zone conversion would shift them off the day boundary).
  - `CalendarPermission` helper + `READ_CALENDAR` declared in the manifest (no `WRITE_CALENDAR` — we only read).
  - `UserPreferences.useCalendarEvents` (default `false`), persisted via `SettingsRepository`.
  - New `CalendarCard` in `SettingsScreen` with the same toggle+permission shape as `LocationCard`. Uses `DisposableEffect` to add/remove the lifecycle observer; on resume, if the user revoked `READ_CALENDAR` from system Settings while we were backgrounded, the card auto-flips the persisted pref off so the worker stops consulting the reader.
  - `AdaptWeatherApplication` exposes the reader and injects it into the `GenerateDailyInsight` singleton. The Worker needs no changes — the use case already gates on `prefs.useCalendarEvents`.

## Privacy posture

Only event title and start/end times reach the rendered summary. The location field is read into the model so a future "what to bring + where" sentence can use it without a model migration, but `RenderInsightSummary` doesn't surface it today. Descriptions, attendees, organizers, and account info are deliberately not read at all. Everything stays on-device — there's no LLM call.

## Copilot review feedback

Both review comments on the original PR commit are addressed in the rebase:
- **`SettingsScreen.kt:500` (revoke handling)** — when `permissionGranted` flips false on resume and the persisted pref is `true`, the card now calls `onSetUseEvents(false)` so the pref stays consistent with the system grant.
- **`SettingsScreen.kt:502` (observer leak)** — the lifecycle observer is now added in a `DisposableEffect` and removed in `onDispose`. `rememberUpdatedState` ensures the observer always sees the current `useEvents` / `onSetUseEvents`.

## Test plan

- [ ] CI: `:core:domain:test` passes — new `RenderInsightSummaryTest` cases for the 6th sentence (umbrella preference, no-overlap, no-wardrobe, dry day, all-day events) + `GenerateDailyInsightTest` cases for reader gating and graceful degradation.
- [ ] CI: `:app` unit tests pass — `SettingsRepositoryTest` round-trip + `SettingsViewModelTest` setter.
- [ ] CI: debug APK builds.
- [ ] Manual on a real device:
  - Toggle on, grant permission, calendar event at 3pm with rainy forecast → summary contains "Bring an umbrella for your 15:00 <title>."
  - All-day event → no calendar sentence (covered by test).
  - Cancelled / busy=free event → not surfaced.
  - Revoke permission from system Settings while AdaptWeather is backgrounded; reopen → toggle flips off automatically; persisted pref is false; daily insight still fires (calendar-free).
