### PR TITLE
:app — drop stale force-refresh flag when the day rolls over

### DIFF
--- a/app/src/main/kotlin/app/adaptweather/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/app/adaptweather/work/FetchAndNotifyWorker.kt
@@ -57,7 +57,18 @@ class FetchAndNotifyWorker(
 
         val location = resolveLocation(prefs)
         val today = LocalDate.now()
-        val forceRefresh = inputData.getBoolean(KEY_FORCE_REFRESH, false)
+
+        // Honour force-refresh only when it's still the day the user tapped on. If
+        // the request was enqueued near midnight and only ran after the date rolled
+        // over (offline retries, deferred backoff), the *new* day's cache should
+        // win — otherwise we'd silently bypass it and burn an extra Gemini call on
+        // a stale tap.
+        val requestedEpochDay = inputData.getLong(KEY_REQUESTED_EPOCH_DAY, Long.MIN_VALUE)
+        val forceRequested = inputData.getBoolean(KEY_FORCE_REFRESH, false)
+        val forceRefresh = forceRequested && requestedEpochDay == today.toEpochDay()
+        if (forceRequested && !forceRefresh) {
+            Log.i(TAG, "Ignoring force refresh from a previous day (requested=$requestedEpochDay, today=${today.toEpochDay()}).")
+        }
 
         // 24h cost cap: if we already generated an insight for today, redeliver it
         // rather than refetching. Same path serves the morning alarm and any
@@ -216,6 +227,13 @@ class FetchAndNotifyWorker(
         /** Set true via [enqueueOneShot] when the user explicitly taps Refresh. */
         private const val KEY_FORCE_REFRESH = "force_refresh"
 
+        /**
+         * Epoch-day of the calendar date the force-refresh was requested for. Used
+         * to drop a stale force flag if the worker only runs after midnight (e.g. a
+         * tap at 23:59 that retried offline until 00:05).
+         */
+        private const val KEY_REQUESTED_EPOCH_DAY = "requested_epoch_day"
+
         // Fallback when the user hasn't set a location yet — the pipeline still runs and
         // posts a (London) insight rather than silently failing. The Settings screen
         // surfaces an empty-location card so the user can change it.
@@ -233,7 +251,12 @@ class FetchAndNotifyWorker(
             val request = OneTimeWorkRequestBuilder<FetchAndNotifyWorker>()
                 .setConstraints(constraints)
                 .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, 30, TimeUnit.SECONDS)
-                .setInputData(workDataOf(KEY_FORCE_REFRESH to force))
+                .setInputData(
+                    workDataOf(
+                        KEY_FORCE_REFRESH to force,
+                        KEY_REQUESTED_EPOCH_DAY to LocalDate.now().toEpochDay(),
+                    )
+                )
                 .build()
 
             // Alarm-driven enqueues use KEEP so a still-retrying run isn't duplicated.


### PR DESCRIPTION
## Summary

Follow-up to #70 addressing Copilot's review comment ([thread](https://github.com/mikelward/adaptweather/pull/70#discussion_r3143693791)).

The `KEY_FORCE_REFRESH` input flag survives WorkManager retries, so a Refresh tap enqueued at 23:59 that only ran after midnight (offline retries, exponential backoff) would still bypass the *new* day's cache and burn an extra Gemini call on what is by then a stale tap.

## Fix

- `enqueueOneShot` now also stamps `KEY_REQUESTED_EPOCH_DAY = LocalDate.now().toEpochDay()` into `inputData`.
- `doWork` only honours the force flag when `requestedEpochDay == today.toEpochDay()`. If the date has rolled over, it logs and falls back to the normal cache-then-fetch path — the new day's morning cache (or first run) wins.

## Test plan

- [ ] Tap Refresh while offline, leave the device offline past midnight, then bring it online: verify the worker uses the new day's cache (or generates fresh for the new day) rather than bypassing.
- [ ] Same-day Refresh tap still bypasses the cache as before (regression check on #70's behaviour).
- [ ] Alarm-driven enqueues (force=false) unaffected.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SiXk2TDS9gT4pjLTj2ypnp)_