### PR TITLE
Revert Gemini TTS byte-swap — payload is already little-endian

### DIFF
--- a/core/data/src/main/kotlin/app/adaptweather/core/data/tts/GeminiTtsClient.kt
+++ b/core/data/src/main/kotlin/app/adaptweather/core/data/tts/GeminiTtsClient.kt
@@ -32,13 +32,12 @@ internal const val GEMINI_API_VERSION = "v1beta"
  *
  * The model returns a single 16-bit signed PCM audio stream at a sample rate carried
  * in the `mimeType` (`audio/L16;codec=pcm;rate=24000`). [PcmAudio.sampleRate] parses
- * that out of the response.
+ * that out of the response so the caller can hand the bytes straight to AudioTrack.
  *
- * **Endianness**: per RFC 2586, `audio/L16` is *big-endian* (network byte order).
- * Android `AudioTrack` only consumes little-endian PCM16, so we byte-swap each
- * 16-bit sample after decode. Without this, every sample is byte-flipped, which
- * sounds like continuous static throughout playback. (OpenAI's `pcm` response
- * format is documented as little-endian, so [OpenAITtsClient] doesn't need this.)
+ * Despite the `audio/L16` mime label (which per RFC 2586 specifies network byte
+ * order), Gemini's payload is already little-endian — the same encoding Android's
+ * `ENCODING_PCM_16BIT` consumes. A previous attempt to byte-swap on decode was
+ * reverted because it turned correctly-decoded speech into noise.
  *
  * Default voice is `Kore` (firm). Other prebuilt voices are listed in Google's docs;
  * pass via [voiceName] when calling.
@@ -100,21 +99,8 @@ class GeminiTtsClient(
             ?: throw GeminiTtsEmptyResponseException(candidate?.finishReason)
 
         val pcm = Base64.getDecoder().decode(inline.data)
-        swapBytePairsInPlace(pcm)
         val sampleRate = parseSampleRate(inline.mimeType) ?: DEFAULT_SAMPLE_RATE_HZ
         return PcmAudio(bytes = pcm, sampleRate = sampleRate)
-    }
-
-    /** Big-endian → little-endian conversion for 16-bit samples; see class KDoc. */
-    private fun swapBytePairsInPlace(bytes: ByteArray) {
-        var i = 0
-        val end = bytes.size and 1.inv() // round down to even — last odd byte (if any) left untouched
-        while (i < end) {
-            val tmp = bytes[i]
-            bytes[i] = bytes[i + 1]
-            bytes[i + 1] = tmp
-            i += 2
-        }
     }
 
     private fun parseSampleRate(mimeType: String): Int? {

--- a/core/data/src/test/kotlin/app/adaptweather/core/data/tts/GeminiTtsClientTest.kt
+++ b/core/data/src/test/kotlin/app/adaptweather/core/data/tts/GeminiTtsClientTest.kt
@@ -94,10 +94,8 @@ class GeminiTtsClientTest {
 
         val audio = client.synthesize(text = "hello")
 
-        // SUCCESS_BODY encodes the four bytes 0xDE 0xAD 0xBE 0xEF in big-endian
-        // L16 (per RFC 2586). The client byte-swaps each 16-bit sample so AudioTrack
-        // (which only consumes little-endian PCM16) plays them correctly.
-        audio.bytes.toList() shouldBe listOf(0xAD.toByte(), 0xDE.toByte(), 0xEF.toByte(), 0xBE.toByte())
+        // SUCCESS_BODY encodes the four bytes 0xDE 0xAD 0xBE 0xEF.
+        audio.bytes.toList() shouldBe listOf(0xDE.toByte(), 0xAD.toByte(), 0xBE.toByte(), 0xEF.toByte())
         audio.sampleRate shouldBe 24_000
     }
 


### PR DESCRIPTION
## Summary

- Reverts the byte-swap added in 9a2de98. That commit was based on RFC 2586 (which says `audio/L16` is big-endian); empirically Gemini sends little-endian, which is what Android's `ENCODING_PCM_16BIT` consumes natively. The swap turned recognisable (if crackly) speech into pure noise.
- KDoc updated to call out the discrepancy between the L16 mime label and the actual byte order, so we don't re-introduce the swap on RFC grounds again.
- Test reverts to expecting the raw decoded bytes.

The pre-existing crackliness in Gemini's TTS output is a separate concern and **not** addressed here — opening a follow-up discussion on what we want to do about it.

## Test plan

- [ ] `./gradlew :core:data:test --tests "app.adaptweather.core.data.tts.GeminiTtsClientTest"` passes
- [ ] On-device: trigger Gemini TTS (Settings → Test Gemini voice) and confirm speech is intelligible again, not static
- [ ] On-device: confirm OpenAI TTS still works (it shares `PcmAudioPlayer` but never went through this swap)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Mjh87TweVN4xzxG1zeEB14)_