### PR TITLE
Prepend studio-voice style directive to Gemini TTS input

### DIFF
--- a/core/data/src/main/kotlin/app/adaptweather/core/data/tts/GeminiTtsClient.kt
+++ b/core/data/src/main/kotlin/app/adaptweather/core/data/tts/GeminiTtsClient.kt
@@ -27,6 +27,18 @@ internal const val GEMINI_HOST = "generativelanguage.googleapis.com"
 internal const val GEMINI_API_VERSION = "v1beta"
 
 /**
+ * Natural-language style instruction prepended to every TTS request. Gemini
+ * documents the input text as a style-steerable prompt — preambles like this
+ * are interpreted as direction and not spoken back. We use it to suppress the
+ * lo-fi "vinyl crackle" character the model otherwise bakes into the output
+ * across the full clip (OpenAI TTS, going through the same player at the same
+ * 24 kHz, has none of it — so this is server-side, not playback-side).
+ */
+internal const val GEMINI_TTS_STYLE_DIRECTIVE: String =
+    "Read the following in a clean, crisp studio voice with no audio effects, " +
+        "background noise, or vinyl-style texture:\n\n"
+
+/**
  * Calls Gemini's audio-output model (e.g. `gemini-2.5-flash-preview-tts`). Uses the
  * standard Generative Language host with a BYOK `x-goog-api-key` header.
  *
@@ -65,7 +77,9 @@ class GeminiTtsClient(
             contentType(ContentType.Application.Json)
             setBody(
                 TtsRequest(
-                    contents = listOf(TtsContent(parts = listOf(TtsTextPart(text)))),
+                    contents = listOf(
+                        TtsContent(parts = listOf(TtsTextPart(GEMINI_TTS_STYLE_DIRECTIVE + text))),
+                    ),
                     generationConfig = TtsGenerationConfig(
                         responseModalities = listOf("AUDIO"),
                         speechConfig = SpeechConfig(

--- a/core/data/src/test/kotlin/app/adaptweather/core/data/tts/GeminiTtsClientTest.kt
+++ b/core/data/src/test/kotlin/app/adaptweather/core/data/tts/GeminiTtsClientTest.kt
@@ -86,6 +86,25 @@ class GeminiTtsClientTest {
     }
 
     @Test
+    fun `request body prepends the studio-voice style directive to the user text`() = runTest {
+        var capturedBody: String? = null
+        val client = GeminiTtsClient(
+            httpClient = mockClient(SUCCESS_BODY) {
+                capturedBody = (it.body as io.ktor.http.content.OutgoingContent.ByteArrayContent)
+                    .bytes()
+                    .toString(Charsets.UTF_8)
+            },
+            keyProvider = FakeKeyProvider("test-key"),
+        )
+
+        client.synthesize(text = "hello world")
+
+        val body = checkNotNull(capturedBody)
+        body.shouldContain("clean, crisp studio voice")
+        body.shouldContain("hello world")
+    }
+
+    @Test
     fun `decodes inline pcm and parses sample rate from mime type`() = runTest {
         val client = GeminiTtsClient(
             httpClient = mockClient(SUCCESS_BODY),


### PR DESCRIPTION
## Summary

Gemini TTS produces a lo-fi "vinyl crackle" character throughout the full clip. OpenAI TTS, going through the same `PcmAudioPlayer` at the same 24 kHz, has none of it — so the artifact is on the model side, not playback. Gemini documents the input text as a natural-language style prompt (preambles are interpreted as direction and not spoken back), so the cheapest knob is a prepended style directive asking for a clean studio read.

This change adds `GEMINI_TTS_STYLE_DIRECTIVE` and prepends it to every synthesise call. Independent of voice and model — any future voice/model swap benefits from this too.

If this isn't enough on its own, the next escalation steps (none of them in this PR) are:
1. Drop `temperature` to ~0.3 in `generationConfig`
2. A/B different voices to see if the crackle is voice-specific (would let us filter in the picker)
3. Switch the default model to `gemini-2.5-pro-preview-tts` (billed as "studio-quality"; more expensive per call)

Adds a request-body regression test mirroring the `responseModalities` one — same `kotlinx.serialization` trap class, same defense: assert the directive actually lands on the wire.

## Test plan

- [ ] `./gradlew :core:data:test --tests "app.adaptweather.core.data.tts.GeminiTtsClientTest"` passes
- [ ] On-device: trigger Gemini TTS (Settings → Test Gemini voice) with the default voice and confirm the vinyl-crackle texture is gone or noticeably reduced
- [ ] On-device: confirm the directive itself is **not** spoken back at the start of the utterance — if it is, we'll need to wrap it differently (e.g. brackets, separate part)
- [ ] On-device: try a few other voices in the picker and note whether crackle is uniform or voice-specific (informs follow-up work)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Mjh87TweVN4xzxG1zeEB14)_