### PR TITLE
:app — rebrand the calendar-description string (missed in #72)

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -138,7 +138,7 @@
 
     <string name="settings_calendar_title">Calendar</string>
     <string name="settings_calendar_use_events">Use today\'s calendar events</string>
-    <string name="settings_calendar_description_off">When enabled, AdaptWeather reads today\'s events from your device calendar so the morning insight can suggest items keyed to specific events — for example, "bring an umbrella for your 3pm park run". Only event titles and times are used; descriptions, attendees, and locations are read but never sent off-device.</string>
+    <string name="settings_calendar_description_off">When enabled, ClothesCast reads today\'s events from your device calendar so the morning insight can suggest items keyed to specific events — for example, "bring an umbrella for your 3pm park run". Only event titles and times are used; descriptions, attendees, and locations are read but never sent off-device.</string>
     <string name="settings_calendar_description_on">Reading today\'s events from your device calendar to enrich the morning insight. Only titles and times are used in the rendered summary; descriptions and attendees are not. Everything stays on-device.</string>
     <string name="settings_calendar_grant_permission">Grant calendar permission</string>
     <string name="settings_calendar_open_settings">Calendar permission denied. Grant it from system Settings.</string>


### PR DESCRIPTION
Follow-up to #72. The Calendar feature was added on `main` between when #72 was opened and when it was rebased, so the rebrand sweep missed `settings_calendar_description_off`. Caught by Copilot's post-merge review of #72.

One-line string change.

## Test plan

- [ ] CI green.
- [ ] Open Settings → Calendar; confirm the description text reads "ClothesCast" not "AdaptWeather".

https://claude.ai/code/session_01XqmfTDaTAuhDimcujLnbK9

---
_Generated by [Claude Code](https://claude.ai/code/session_01XqmfTDaTAuhDimcujLnbK9)_