### PR TITLE
:app + :core — ElevenLabs as a third online TTS engine (rebased)

### DIFF
--- a/app/src/main/kotlin/app/adaptweather/AdaptWeatherApplication.kt
+++ b/app/src/main/kotlin/app/adaptweather/AdaptWeatherApplication.kt
@@ -5,6 +5,7 @@ import android.util.Log
 import app.adaptweather.alarm.DailyAlarmScheduler
 import app.adaptweather.calendar.CalendarContractEventReader
 import app.adaptweather.core.data.location.OpenMeteoGeocodingClient
+import app.adaptweather.core.data.tts.ElevenLabsTtsClient
 import app.adaptweather.core.data.tts.GeminiTtsClient
 import app.adaptweather.core.data.tts.OpenAITtsClient
 import app.adaptweather.core.data.weather.OpenMeteoClient
@@ -54,6 +55,9 @@ class AdaptWeatherApplication : Application() {
     val geminiTtsClient: GeminiTtsClient by lazy { GeminiTtsClient(httpClient, secureKeyStore) }
     val openAiTtsClient: OpenAITtsClient by lazy {
         OpenAITtsClient(httpClient, secureKeyStore.openAiKeyProvider)
+    }
+    val elevenLabsTtsClient: ElevenLabsTtsClient by lazy {
+        ElevenLabsTtsClient(httpClient, secureKeyStore.elevenLabsKeyProvider)
     }
 
     private val httpClient: HttpClient by lazy {

--- a/app/src/main/kotlin/app/adaptweather/data/SecureKeyStore.kt
+++ b/app/src/main/kotlin/app/adaptweather/data/SecureKeyStore.kt
@@ -57,6 +57,12 @@ class SecureKeyStore(
 
     suspend fun clearOpenAi() = remove(OPENAI_PREF_KEY)
 
+    suspend fun getElevenLabs(): String = read(ELEVENLABS_PREF_KEY, ELEVENLABS_AAD, "ElevenLabs")
+
+    suspend fun setElevenLabs(key: String) = write(ELEVENLABS_PREF_KEY, ELEVENLABS_AAD, key)
+
+    suspend fun clearElevenLabs() = remove(ELEVENLABS_PREF_KEY)
+
     /**
      * KeyProvider view onto the OpenAI key. Used to wire `OpenAITtsClient` while
      * keeping the underlying SecureKeyStore as the single source of truth for
@@ -64,6 +70,11 @@ class SecureKeyStore(
      */
     val openAiKeyProvider: KeyProvider = object : KeyProvider {
         override suspend fun get(): String = getOpenAi()
+    }
+
+    /** KeyProvider view onto the ElevenLabs key. */
+    val elevenLabsKeyProvider: KeyProvider = object : KeyProvider {
+        override suspend fun get(): String = getElevenLabs()
     }
 
     private suspend fun read(prefKey: Preferences.Key<String>, aad: ByteArray, provider: String): String {
@@ -96,6 +107,9 @@ class SecureKeyStore(
 
         private val OPENAI_PREF_KEY = stringPreferencesKey("openai_api_key_v1")
         private val OPENAI_AAD = "adaptweather:openai_api_key:v1".toByteArray(Charsets.UTF_8)
+
+        private val ELEVENLABS_PREF_KEY = stringPreferencesKey("elevenlabs_api_key_v1")
+        private val ELEVENLABS_AAD = "adaptweather:elevenlabs_api_key:v1".toByteArray(Charsets.UTF_8)
 
         private const val MASTER_KEY_URI = "android-keystore://adaptweather_master_key"
         private const val KEYSET_PREFS = "adaptweather_master_prefs"

--- a/app/src/main/kotlin/app/adaptweather/data/SettingsRepository.kt
+++ b/app/src/main/kotlin/app/adaptweather/data/SettingsRepository.kt
@@ -103,6 +103,10 @@ class SettingsRepository(
         dataStore.edit { it[OPENAI_VOICE] = voice }
     }
 
+    suspend fun setElevenLabsVoice(voice: String) {
+        dataStore.edit { it[ELEVENLABS_VOICE] = voice }
+    }
+
     suspend fun setVoiceLocale(locale: VoiceLocale) {
         dataStore.edit { it[VOICE_LOCALE] = locale.name }
     }
@@ -137,6 +141,8 @@ class SettingsRepository(
         // Resolve only after voiceLocale is known so the picked voice matches.
         val openAiVoice = this[OPENAI_VOICE]?.takeIf { it.isNotBlank() }
             ?: defaultOpenAiVoiceFor(voiceLocale)
+        val elevenLabsVoice = this[ELEVENLABS_VOICE]?.takeIf { it.isNotBlank() }
+            ?: UserPreferences.DEFAULT_ELEVENLABS_VOICE
         val useCalendarEvents = this[USE_CALENDAR_EVENTS] == true
 
         return UserPreferences(
@@ -150,6 +156,7 @@ class SettingsRepository(
             ttsEngine = ttsEngine,
             geminiVoice = geminiVoice,
             openAiVoice = openAiVoice,
+            elevenLabsVoice = elevenLabsVoice,
             voiceLocale = voiceLocale,
             useCalendarEvents = useCalendarEvents,
         )
@@ -188,6 +195,7 @@ class SettingsRepository(
         private val TTS_ENGINE = stringPreferencesKey("tts_engine")
         private val GEMINI_VOICE = stringPreferencesKey("gemini_voice")
         private val OPENAI_VOICE = stringPreferencesKey("openai_voice")
+        private val ELEVENLABS_VOICE = stringPreferencesKey("elevenlabs_voice")
         private val VOICE_LOCALE = stringPreferencesKey("voice_locale")
         private val USE_CALENDAR_EVENTS = booleanPreferencesKey("use_calendar_events")
 

--- a/app/src/main/kotlin/app/adaptweather/tts/ElevenLabsTtsSpeaker.kt
+++ b/app/src/main/kotlin/app/adaptweather/tts/ElevenLabsTtsSpeaker.kt
@@ -1,0 +1,26 @@
+package app.adaptweather.tts
+
+import app.adaptweather.core.data.tts.DEFAULT_ELEVENLABS_TTS_VOICE
+import app.adaptweather.core.data.tts.ElevenLabsTtsClient
+import java.util.Locale
+
+/**
+ * TTS via ElevenLabs's `text-to-speech` endpoint. Synthesises PCM audio in one
+ * network call, hands the buffer to [PcmAudioPlayer] for playback.
+ *
+ * Voice is an ElevenLabs voice ID (the long opaque identifier from their voice
+ * library, e.g. `EXAVITQu4vr4xnSDxMaL` for Sarah); selectable from Settings.
+ *
+ * Fallback is the caller's responsibility — see [app.adaptweather.work.FetchAndNotifyWorker]
+ * which retries with [AndroidTtsSpeaker] when this throws.
+ */
+class ElevenLabsTtsSpeaker(
+    private val client: ElevenLabsTtsClient,
+    private val voiceId: String = DEFAULT_ELEVENLABS_TTS_VOICE,
+) : TtsSpeaker {
+
+    override suspend fun speak(text: String, locale: Locale) {
+        val audio = client.synthesize(text = text, voiceId = voiceId)
+        PcmAudioPlayer.play(audio)
+    }
+}

--- a/app/src/main/kotlin/app/adaptweather/tts/TtsVoices.kt
+++ b/app/src/main/kotlin/app/adaptweather/tts/TtsVoices.kt
@@ -38,3 +38,18 @@ val OPENAI_VOICES: List<TtsVoiceOption> = listOf(
     TtsVoiceOption("nova", "nova — Bright, female"),
     TtsVoiceOption("shimmer", "shimmer — Warm, female"),
 )
+
+// ElevenLabs voice IDs are opaque strings; the human-readable name only shows in
+// the picker. These are the popular pre-made library voices. Users with a paid
+// plan can clone their own voice — they'd need to copy/paste the voice ID by
+// hand, which we don't surface in v1.
+val ELEVENLABS_VOICES: List<TtsVoiceOption> = listOf(
+    TtsVoiceOption("EXAVITQu4vr4xnSDxMaL", "Sarah — Warm, female"),
+    TtsVoiceOption("21m00Tcm4TlvDq8ikWAM", "Rachel — Calm, female"),
+    TtsVoiceOption("AZnzlk1v9MwlGOIKvxn0", "Domi — Strong, female"),
+    TtsVoiceOption("MF3mGyEYCl7XYWbV9V6O", "Elli — Emotional, female"),
+    TtsVoiceOption("pNInz6obpgDQGcFmaJgB", "Adam — Deep, male"),
+    TtsVoiceOption("ErXwobaYiN019PkySvjV", "Antoni — Well-rounded, male"),
+    TtsVoiceOption("TxGEqnHWrfWFTfGW9XjX", "Josh — Young, male"),
+    TtsVoiceOption("VR6AewLTigWG4xSOukaG", "Arnold — Crisp, male"),
+)

--- a/app/src/main/kotlin/app/adaptweather/ui/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/app/adaptweather/ui/settings/SettingsScreen.kt
@@ -1131,10 +1131,10 @@ private fun TtsEngineCard(
                     selected = voiceLocale,
                     onSelect = {
                         onSetVoiceLocale(it)
-                        preview(selected, geminiVoice, openAiVoice)
+                        preview(selected, geminiVoice, openAiVoice, elevenLabsVoice)
                     },
                 )
-                TestVoiceButton { preview(selected, geminiVoice, openAiVoice) }
+                TestVoiceButton { preview(selected, geminiVoice, openAiVoice, elevenLabsVoice) }
             }
         }
     }

--- a/app/src/main/kotlin/app/adaptweather/ui/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/app/adaptweather/ui/settings/SettingsScreen.kt
@@ -61,6 +61,8 @@ import app.adaptweather.core.domain.model.TemperatureUnit
 import app.adaptweather.core.domain.model.TtsEngine
 import app.adaptweather.core.domain.model.VoiceLocale
 import app.adaptweather.core.domain.model.WardrobeRule
+import app.adaptweather.tts.ELEVENLABS_VOICES
+import app.adaptweather.tts.ElevenLabsTtsSpeaker
 import app.adaptweather.tts.GEMINI_VOICES
 import app.adaptweather.tts.GeminiTtsSpeaker
 import app.adaptweather.tts.OPENAI_VOICES
@@ -121,6 +123,9 @@ fun SettingsScreen(viewModel: SettingsViewModel, onNavigateBack: () -> Unit) {
             onSetOpenAiVoice = viewModel::setOpenAiVoice,
             onSetOpenAiKey = viewModel::setOpenAiKey,
             onClearOpenAiKey = viewModel::clearOpenAiKey,
+            onSetElevenLabsVoice = viewModel::setElevenLabsVoice,
+            onSetElevenLabsKey = viewModel::setElevenLabsKey,
+            onClearElevenLabsKey = viewModel::clearElevenLabsKey,
             onSetVoiceLocale = viewModel::setVoiceLocale,
             onSetUseCalendarEvents = viewModel::setUseCalendarEvents,
         )
@@ -149,6 +154,9 @@ private fun SettingsContent(
     onSetOpenAiVoice: (String) -> Unit,
     onSetOpenAiKey: (String) -> Unit,
     onClearOpenAiKey: () -> Unit,
+    onSetElevenLabsVoice: (String) -> Unit,
+    onSetElevenLabsKey: (String) -> Unit,
+    onClearElevenLabsKey: () -> Unit,
     onSetVoiceLocale: (VoiceLocale) -> Unit,
     onSetUseCalendarEvents: (Boolean) -> Unit,
 ) {
@@ -164,10 +172,13 @@ private fun SettingsContent(
         ApiKeysCard(
             geminiConfigured = state.apiKeyConfigured,
             openAiConfigured = state.openAiKeyConfigured,
+            elevenLabsConfigured = state.elevenLabsKeyConfigured,
             onSetGeminiKey = onSetApiKey,
             onClearGeminiKey = onClearApiKey,
             onSetOpenAiKey = onSetOpenAiKey,
             onClearOpenAiKey = onClearOpenAiKey,
+            onSetElevenLabsKey = onSetElevenLabsKey,
+            onClearElevenLabsKey = onClearElevenLabsKey,
         )
         LocationCard(
             current = state.location,
@@ -190,8 +201,11 @@ private fun SettingsContent(
             onGeminiVoice = onSetGeminiVoice,
             openAiVoice = state.openAiVoice,
             onOpenAiVoice = onSetOpenAiVoice,
+            elevenLabsVoice = state.elevenLabsVoice,
+            onElevenLabsVoice = onSetElevenLabsVoice,
             geminiKeyConfigured = state.apiKeyConfigured,
             openAiKeyConfigured = state.openAiKeyConfigured,
+            elevenLabsKeyConfigured = state.elevenLabsKeyConfigured,
             voiceLocale = state.voiceLocale,
             onSetVoiceLocale = onSetVoiceLocale,
         )
@@ -911,18 +925,22 @@ private fun SectionCard(title: String, content: @Composable () -> Unit) {
 
 /**
  * One section that holds every BYOK API key the app uses (Gemini for Gemini TTS,
- * OpenAI for OpenAI TTS). Putting both in a single section makes them feel
- * symmetric — neither is "the primary" — and keeps the engine picker downstream
- * focused on engine + voice + a small "missing key" hint when relevant.
+ * OpenAI for OpenAI TTS, ElevenLabs for ElevenLabs TTS). Putting them in a single
+ * section makes them feel symmetric — none is "the primary" — and keeps the engine
+ * picker downstream focused on engine + voice + a small "missing key" hint when
+ * relevant.
  */
 @Composable
 private fun ApiKeysCard(
     geminiConfigured: Boolean,
     openAiConfigured: Boolean,
+    elevenLabsConfigured: Boolean,
     onSetGeminiKey: (String) -> Unit,
     onClearGeminiKey: () -> Unit,
     onSetOpenAiKey: (String) -> Unit,
     onClearOpenAiKey: () -> Unit,
+    onSetElevenLabsKey: (String) -> Unit,
+    onClearElevenLabsKey: () -> Unit,
 ) {
     SectionCard(title = stringResource(R.string.settings_api_keys_title)) {
         Text(
@@ -966,6 +984,25 @@ private fun ApiKeysCard(
             onSave = onSetOpenAiKey,
             onClear = onClearOpenAiKey,
         )
+
+        HorizontalDivider()
+
+        Text(
+            text = stringResource(R.string.settings_api_key_elevenlabs_label),
+            style = MaterialTheme.typography.titleSmall,
+        )
+        KeyEntryFields(
+            configured = elevenLabsConfigured,
+            statusText = stringResource(
+                if (elevenLabsConfigured) R.string.settings_elevenlabs_key_status_set
+                else R.string.settings_elevenlabs_key_status_unset,
+            ),
+            placeholder = stringResource(R.string.settings_elevenlabs_key_placeholder),
+            saveLabel = stringResource(R.string.settings_elevenlabs_key_save),
+            clearLabel = stringResource(R.string.settings_elevenlabs_key_clear),
+            onSave = onSetElevenLabsKey,
+            onClear = onClearElevenLabsKey,
+        )
     }
 }
 
@@ -993,8 +1030,11 @@ private fun TtsEngineCard(
     onGeminiVoice: (String) -> Unit,
     openAiVoice: String,
     onOpenAiVoice: (String) -> Unit,
+    elevenLabsVoice: String,
+    onElevenLabsVoice: (String) -> Unit,
     geminiKeyConfigured: Boolean,
     openAiKeyConfigured: Boolean,
+    elevenLabsKeyConfigured: Boolean,
     voiceLocale: VoiceLocale,
     onSetVoiceLocale: (VoiceLocale) -> Unit,
 ) {
@@ -1005,10 +1045,10 @@ private fun TtsEngineCard(
     // overlapping playbacks.
     var previewJob by remember { mutableStateOf<Job?>(null) }
 
-    fun preview(engine: TtsEngine, gVoice: String, oVoice: String) {
+    fun preview(engine: TtsEngine, gVoice: String, oVoice: String, eVoice: String) {
         previewJob?.cancel()
         previewJob = coroutineScope.launch {
-            runTtsPreview(context, engine, gVoice, oVoice, voiceLocale)
+            runTtsPreview(context, engine, gVoice, oVoice, eVoice, voiceLocale)
         }
     }
 
@@ -1024,7 +1064,7 @@ private fun TtsEngineCard(
                 selected = engine == selected,
                 onSelect = {
                     onSelect(engine)
-                    preview(engine, geminiVoice, openAiVoice)
+                    preview(engine, geminiVoice, openAiVoice, elevenLabsVoice)
                 },
             )
         }
@@ -1041,10 +1081,10 @@ private fun TtsEngineCard(
                     selectedId = geminiVoice,
                     onSelect = {
                         onGeminiVoice(it)
-                        preview(TtsEngine.GEMINI, it, openAiVoice)
+                        preview(TtsEngine.GEMINI, it, openAiVoice, elevenLabsVoice)
                     },
                 )
-                TestVoiceButton { preview(selected, geminiVoice, openAiVoice) }
+                TestVoiceButton { preview(selected, geminiVoice, openAiVoice, elevenLabsVoice) }
             }
             TtsEngine.OPENAI -> {
                 if (!openAiKeyConfigured) {
@@ -1058,10 +1098,27 @@ private fun TtsEngineCard(
                     selectedId = openAiVoice,
                     onSelect = {
                         onOpenAiVoice(it)
-                        preview(TtsEngine.OPENAI, geminiVoice, it)
+                        preview(TtsEngine.OPENAI, geminiVoice, it, elevenLabsVoice)
                     },
                 )
-                TestVoiceButton { preview(selected, geminiVoice, openAiVoice) }
+                TestVoiceButton { preview(selected, geminiVoice, openAiVoice, elevenLabsVoice) }
+            }
+            TtsEngine.ELEVENLABS -> {
+                if (!elevenLabsKeyConfigured) {
+                    MissingKeyHint(
+                        engineName = stringResource(R.string.settings_api_key_elevenlabs_label),
+                    )
+                }
+                VoicePicker(
+                    title = stringResource(R.string.settings_tts_voice_label),
+                    voices = ELEVENLABS_VOICES,
+                    selectedId = elevenLabsVoice,
+                    onSelect = {
+                        onElevenLabsVoice(it)
+                        preview(TtsEngine.ELEVENLABS, geminiVoice, openAiVoice, it)
+                    },
+                )
+                TestVoiceButton { preview(selected, geminiVoice, openAiVoice, elevenLabsVoice) }
             }
             TtsEngine.DEVICE -> {
                 // TODO: promote VoiceLocalePicker out of TtsEngineCard. The locale
@@ -1207,6 +1264,7 @@ private suspend fun runTtsPreview(
     engine: TtsEngine,
     geminiVoice: String,
     openAiVoice: String,
+    elevenLabsVoice: String,
     voiceLocale: VoiceLocale,
 ) {
     val app = context.applicationContext as app.adaptweather.AdaptWeatherApplication
@@ -1223,6 +1281,8 @@ private suspend fun runTtsPreview(
                     GeminiTtsSpeaker(app.geminiTtsClient, voiceName = geminiVoice).speak(text, locale)
                 TtsEngine.OPENAI ->
                     OpenAITtsSpeaker(app.openAiTtsClient, voice = openAiVoice).speak(text, locale)
+                TtsEngine.ELEVENLABS ->
+                    ElevenLabsTtsSpeaker(app.elevenLabsTtsClient, voiceId = elevenLabsVoice).speak(text, locale)
                 TtsEngine.DEVICE ->
                     app.deviceTtsSpeaker.speak(text, locale)
             }
@@ -1355,6 +1415,7 @@ private fun ttsEngineLabel(engine: TtsEngine): Int = when (engine) {
     TtsEngine.DEVICE -> R.string.settings_tts_engine_device
     TtsEngine.GEMINI -> R.string.settings_tts_engine_gemini
     TtsEngine.OPENAI -> R.string.settings_tts_engine_openai
+    TtsEngine.ELEVENLABS -> R.string.settings_tts_engine_elevenlabs
 }
 
 private fun temperatureUnitLabel(unit: TemperatureUnit): Int = when (unit) {

--- a/app/src/main/kotlin/app/adaptweather/ui/settings/SettingsState.kt
+++ b/app/src/main/kotlin/app/adaptweather/ui/settings/SettingsState.kt
@@ -30,8 +30,10 @@ data class SettingsState(
     // When voiceLocale is SYSTEM (the default), this resolves through the phone's
     // current locale → fable on en-GB, nova everywhere else.
     val openAiVoice: String = defaultOpenAiVoiceFor(VoiceLocale.SYSTEM),
+    val elevenLabsVoice: String = UserPreferences.DEFAULT_ELEVENLABS_VOICE,
     val voiceLocale: VoiceLocale = VoiceLocale.SYSTEM,
     val useCalendarEvents: Boolean = false,
     val apiKeyConfigured: Boolean = false,
     val openAiKeyConfigured: Boolean = false,
+    val elevenLabsKeyConfigured: Boolean = false,
 )

--- a/app/src/main/kotlin/app/adaptweather/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/app/adaptweather/ui/settings/SettingsViewModel.kt
@@ -49,6 +49,7 @@ class SettingsViewModel(
                         ttsEngine = prefs.ttsEngine,
                         geminiVoice = prefs.geminiVoice,
                         openAiVoice = prefs.openAiVoice,
+                        elevenLabsVoice = prefs.elevenLabsVoice,
                         voiceLocale = prefs.voiceLocale,
                         useCalendarEvents = prefs.useCalendarEvents,
                     )
@@ -86,12 +87,30 @@ class SettingsViewModel(
         }
     }
 
+    fun setElevenLabsKey(key: String) {
+        viewModelScope.launch {
+            keyStore.setElevenLabs(key.trim())
+            refreshApiKeyStatus()
+        }
+    }
+
+    fun clearElevenLabsKey() {
+        viewModelScope.launch {
+            keyStore.clearElevenLabs()
+            refreshApiKeyStatus()
+        }
+    }
+
     fun setGeminiVoice(voice: String) {
         viewModelScope.launch { settingsRepository.setGeminiVoice(voice) }
     }
 
     fun setOpenAiVoice(voice: String) {
         viewModelScope.launch { settingsRepository.setOpenAiVoice(voice) }
+    }
+
+    fun setElevenLabsVoice(voice: String) {
+        viewModelScope.launch { settingsRepository.setElevenLabsVoice(voice) }
     }
 
     fun setDeliveryMode(mode: DeliveryMode) {
@@ -170,7 +189,14 @@ class SettingsViewModel(
     private suspend fun refreshApiKeyStatus() {
         val gemini = runCatching { keyStore.get().isNotBlank() }.getOrDefault(false)
         val openAi = runCatching { keyStore.getOpenAi().isNotBlank() }.getOrDefault(false)
-        _state.update { it.copy(apiKeyConfigured = gemini, openAiKeyConfigured = openAi) }
+        val elevenLabs = runCatching { keyStore.getElevenLabs().isNotBlank() }.getOrDefault(false)
+        _state.update {
+            it.copy(
+                apiKeyConfigured = gemini,
+                openAiKeyConfigured = openAi,
+                elevenLabsKeyConfigured = elevenLabs,
+            )
+        }
     }
 
     class Factory(

--- a/app/src/main/kotlin/app/adaptweather/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/app/adaptweather/work/FetchAndNotifyWorker.kt
@@ -17,6 +17,7 @@ import app.adaptweather.core.domain.model.Insight
 import app.adaptweather.core.domain.model.Location
 import app.adaptweather.core.domain.model.TtsEngine
 import app.adaptweather.core.domain.model.UserPreferences
+import app.adaptweather.tts.ElevenLabsTtsSpeaker
 import app.adaptweather.tts.GeminiTtsSpeaker
 import app.adaptweather.tts.OpenAITtsSpeaker
 import app.adaptweather.tts.resolve
@@ -202,6 +203,14 @@ class FetchAndNotifyWorker(
                     return
                 } catch (t: Throwable) {
                     Log.w(TAG, "OpenAI TTS failed; falling back to device TTS.", t)
+                }
+            }
+            TtsEngine.ELEVENLABS -> {
+                try {
+                    ElevenLabsTtsSpeaker(app.elevenLabsTtsClient, voiceId = prefs.elevenLabsVoice).speak(text, locale)
+                    return
+                } catch (t: Throwable) {
+                    Log.w(TAG, "ElevenLabs TTS failed; falling back to device TTS.", t)
                 }
             }
             TtsEngine.DEVICE -> Unit

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -38,6 +38,7 @@
     <string name="settings_api_keys_description">Configure the API keys for the online voice engines you want to use. Keys are encrypted at rest using the Android Keystore.</string>
     <string name="settings_api_key_gemini_label">Gemini</string>
     <string name="settings_api_key_openai_label">OpenAI</string>
+    <string name="settings_api_key_elevenlabs_label">ElevenLabs</string>
 
     <string name="settings_api_key_status_set">A Gemini key is configured.</string>
     <string name="settings_api_key_status_unset">No Gemini key configured. Get one at aistudio.google.com to use Gemini voices.</string>
@@ -70,10 +71,11 @@
     <string name="settings_delivery_notification_and_tts">Notification and spoken aloud</string>
 
     <string name="settings_tts_engine_title">Voice engine</string>
-    <string name="settings_tts_engine_description">Online engines (Gemini, OpenAI) sound much more natural but need a network call at speak-time and use your API key for synthesis (one short call per spoken insight). Falls back to the device voice if the chosen engine fails.</string>
+    <string name="settings_tts_engine_description">Online engines (Gemini, OpenAI, ElevenLabs) sound much more natural but need a network call at speak-time and use your API key for synthesis (one short call per spoken insight). Falls back to the device voice if the chosen engine fails.</string>
     <string name="settings_tts_engine_device">Device (offline, free)</string>
     <string name="settings_tts_engine_gemini">Gemini (high quality, online)</string>
     <string name="settings_tts_engine_openai">OpenAI (high quality, online)</string>
+    <string name="settings_tts_engine_elevenlabs">ElevenLabs (highest quality, online)</string>
     <string name="settings_tts_voice_label">Voice</string>
     <string name="settings_tts_voice_dismiss">Done</string>
     <string name="settings_tts_voice_locale_label">English variant</string>
@@ -93,6 +95,12 @@
     <string name="settings_openai_key_placeholder">Paste your OpenAI API key</string>
     <string name="settings_openai_key_save">Save OpenAI key</string>
     <string name="settings_openai_key_clear">Clear stored OpenAI key</string>
+
+    <string name="settings_elevenlabs_key_status_set">An ElevenLabs key is configured.</string>
+    <string name="settings_elevenlabs_key_status_unset">No ElevenLabs key configured. Get one at elevenlabs.io to use ElevenLabs voices.</string>
+    <string name="settings_elevenlabs_key_placeholder">Paste your ElevenLabs API key</string>
+    <string name="settings_elevenlabs_key_save">Save ElevenLabs key</string>
+    <string name="settings_elevenlabs_key_clear">Clear stored ElevenLabs key</string>
 
     <string name="settings_temperature_unit_title">Temperature unit</string>
     <string name="settings_temperature_unit_celsius">Celsius (°C)</string>

--- a/app/src/test/kotlin/app/adaptweather/data/SettingsRepositoryTest.kt
+++ b/app/src/test/kotlin/app/adaptweather/data/SettingsRepositoryTest.kt
@@ -155,18 +155,25 @@ class SettingsRepositoryTest {
     }
 
     @Test
-    fun `setGeminiVoice and setOpenAiVoice round-trip and are independent`() = runTest {
+    fun `voice setters round-trip and are independent across providers`() = runTest {
         subject.setGeminiVoice("Puck")
         subject.setOpenAiVoice("nova")
+        subject.setElevenLabsVoice("21m00Tcm4TlvDq8ikWAM")
 
         val prefs = subject.preferences.first()
         prefs.geminiVoice shouldBe "Puck"
         prefs.openAiVoice shouldBe "nova"
+        prefs.elevenLabsVoice shouldBe "21m00Tcm4TlvDq8ikWAM"
     }
 
     @Test
     fun `gemini voice defaults to Kore when nothing stored`() = runTest {
         subject.preferences.first().geminiVoice shouldBe "Kore"
+    }
+
+    @Test
+    fun `elevenLabs voice defaults to Sarah when nothing stored`() = runTest {
+        subject.preferences.first().elevenLabsVoice shouldBe "EXAVITQu4vr4xnSDxMaL"
     }
 
     @Test

--- a/core/data/src/main/kotlin/app/adaptweather/core/data/tts/ElevenLabsTtsClient.kt
+++ b/core/data/src/main/kotlin/app/adaptweather/core/data/tts/ElevenLabsTtsClient.kt
@@ -1,0 +1,111 @@
+package app.adaptweather.core.data.tts
+
+import app.adaptweather.core.data.insight.KeyProvider
+import app.adaptweather.core.data.insight.MissingApiKeyException
+import io.ktor.client.HttpClient
+import io.ktor.client.request.header
+import io.ktor.client.request.parameter
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsBytes
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.http.isSuccess
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+
+const val DEFAULT_ELEVENLABS_TTS_MODEL: String = "eleven_multilingual_v2"
+const val DEFAULT_ELEVENLABS_TTS_VOICE: String = "EXAVITQu4vr4xnSDxMaL" // Sarah
+
+/**
+ * ElevenLabs TTS via `POST https://api.elevenlabs.io/v1/text-to-speech/{voice_id}`.
+ *
+ * Asks for `output_format=pcm_24000` so the response body is raw 16-bit signed
+ * little-endian mono PCM at 24 kHz — bit-compatible with the Gemini and OpenAI
+ * TTS paths and with the same [PcmAudio] structure, so playback reuses the
+ * existing AudioTrack code on the app side.
+ *
+ * Auth is the user's ElevenLabs key as the `xi-api-key` header (not a Bearer
+ * token, unlike OpenAI). Like the other providers the key never leaves the
+ * device.
+ */
+class ElevenLabsTtsClient(
+    private val httpClient: HttpClient,
+    private val keyProvider: KeyProvider,
+    private val model: String = DEFAULT_ELEVENLABS_TTS_MODEL,
+) {
+    suspend fun synthesize(
+        text: String,
+        voiceId: String = DEFAULT_ELEVENLABS_TTS_VOICE,
+    ): PcmAudio {
+        val key = keyProvider.get().also {
+            if (it.isBlank()) throw MissingApiKeyException("ElevenLabs")
+        }
+
+        val response: HttpResponse = httpClient.post("$SPEECH_URL_BASE/$voiceId") {
+            header("xi-api-key", key)
+            contentType(ContentType.Application.Json)
+            parameter("output_format", PCM_OUTPUT_FORMAT)
+            setBody(ElevenLabsSpeechRequest(text = text, modelId = model))
+        }
+
+        if (!response.status.isSuccess()) {
+            throw ElevenLabsTtsHttpException(response.status, response.bodyAsBytes())
+        }
+
+        val pcm = response.bodyAsBytes()
+        if (pcm.isEmpty()) throw ElevenLabsTtsEmptyResponseException()
+
+        return PcmAudio(bytes = pcm, sampleRate = ELEVENLABS_PCM_SAMPLE_RATE_HZ)
+    }
+
+    companion object {
+        // `pcm_24000` is documented as 16-bit signed little-endian mono at 24 kHz —
+        // matches the AudioTrack format we already use for Gemini / OpenAI.
+        private const val ELEVENLABS_PCM_SAMPLE_RATE_HZ = 24_000
+        private const val PCM_OUTPUT_FORMAT = "pcm_24000"
+        private const val SPEECH_URL_BASE = "https://api.elevenlabs.io/v1/text-to-speech"
+    }
+}
+
+class ElevenLabsTtsEmptyResponseException :
+    IllegalStateException("ElevenLabs TTS returned no audio body")
+
+/**
+ * HTTP failure surfaced with a short body excerpt so the diagnostic Toast in
+ * Settings shows the actual reason (auth failure / quota / unknown voice ID).
+ * Pulls just `detail.message` (or `detail` itself when it's a string) out of
+ * ElevenLabs's standard error envelope; falls back to a truncated raw excerpt
+ * otherwise.
+ */
+class ElevenLabsTtsHttpException(val status: HttpStatusCode, body: ByteArray) :
+    IllegalStateException(buildMessage(status, body)) {
+
+    companion object {
+        private fun buildMessage(status: HttpStatusCode, body: ByteArray): String {
+            val raw = runCatching { body.toString(Charsets.UTF_8) }.getOrNull().orEmpty()
+            val excerpt = extractErrorMessage(raw)
+                ?: raw.take(MAX_EXCERPT_CHARS).ifBlank { "(empty body)" }
+            return "ElevenLabs TTS HTTP ${status.value}: $excerpt"
+        }
+
+        private fun extractErrorMessage(body: String): String? = runCatching {
+            val root = Json.parseToJsonElement(body) as? JsonObject ?: return@runCatching null
+            // ElevenLabs envelopes are usually `{"detail": {"status": "...", "message": "..."}}`
+            // but on validation failures `detail` is a plain string. Handle both.
+            val detail = root["detail"]
+            when (detail) {
+                is JsonObject ->
+                    (detail["message"] as? JsonPrimitive)?.content?.take(MAX_EXCERPT_CHARS)
+                is JsonPrimitive ->
+                    detail.content.takeIf { detail.isString }?.take(MAX_EXCERPT_CHARS)
+                else -> null
+            }
+        }.getOrNull()
+
+        private const val MAX_EXCERPT_CHARS = 160
+    }
+}

--- a/core/data/src/main/kotlin/app/adaptweather/core/data/tts/ElevenLabsTtsClient.kt
+++ b/core/data/src/main/kotlin/app/adaptweather/core/data/tts/ElevenLabsTtsClient.kt
@@ -11,8 +11,10 @@ import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsBytes
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
+import io.ktor.http.URLProtocol
 import io.ktor.http.contentType
 import io.ktor.http.isSuccess
+import io.ktor.http.path
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
@@ -45,7 +47,16 @@ class ElevenLabsTtsClient(
             if (it.isBlank()) throw MissingApiKeyException("ElevenLabs")
         }
 
-        val response: HttpResponse = httpClient.post("$SPEECH_URL_BASE/$voiceId") {
+        val response: HttpResponse = httpClient.post {
+            url {
+                protocol = URLProtocol.HTTPS
+                host = ELEVENLABS_HOST
+                // Use Ktor's path-segment builder so `voiceId` is treated as a
+                // single segment and reserved characters (/, ?, #, %) are
+                // percent-encoded — voice IDs come from persisted user input,
+                // and a stray slash would otherwise silently mis-route.
+                path("v1", "text-to-speech", voiceId)
+            }
             header("xi-api-key", key)
             contentType(ContentType.Application.Json)
             parameter("output_format", PCM_OUTPUT_FORMAT)
@@ -67,7 +78,7 @@ class ElevenLabsTtsClient(
         // matches the AudioTrack format we already use for Gemini / OpenAI.
         private const val ELEVENLABS_PCM_SAMPLE_RATE_HZ = 24_000
         private const val PCM_OUTPUT_FORMAT = "pcm_24000"
-        private const val SPEECH_URL_BASE = "https://api.elevenlabs.io/v1/text-to-speech"
+        private const val ELEVENLABS_HOST = "api.elevenlabs.io"
     }
 }
 

--- a/core/data/src/main/kotlin/app/adaptweather/core/data/tts/ElevenLabsTtsDto.kt
+++ b/core/data/src/main/kotlin/app/adaptweather/core/data/tts/ElevenLabsTtsDto.kt
@@ -1,0 +1,16 @@
+package app.adaptweather.core.data.tts
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Wire type for `POST /v1/text-to-speech/{voice_id}`. Field names match
+ * ElevenLabs's snake_case via [SerialName]. Request only — the response is
+ * raw audio bytes (no JSON to deserialize), so there's no response DTO.
+ */
+@Serializable
+internal data class ElevenLabsSpeechRequest(
+    val text: String,
+    @SerialName("model_id")
+    val modelId: String,
+)

--- a/core/domain/src/main/kotlin/app/adaptweather/core/domain/model/Settings.kt
+++ b/core/domain/src/main/kotlin/app/adaptweather/core/domain/model/Settings.kt
@@ -17,8 +17,7 @@ enum class DeliveryMode { NOTIFICATION_ONLY, TTS_ONLY, NOTIFICATION_AND_TTS }
  * - [OPENAI] uses OpenAI's `audio/speech` endpoint over a separate BYOK OpenAI key.
  *   Comparable quality to Gemini; falls back to [DEVICE] on failure.
  * - [ELEVENLABS] uses ElevenLabs's `text-to-speech` endpoint over a separate BYOK
- *   ElevenLabs key. Highest perceptual naturalness of the three online options;
- *   falls back to [DEVICE] on failure.
+ *   ElevenLabs key; falls back to [DEVICE] on failure.
  */
 enum class TtsEngine { DEVICE, GEMINI, OPENAI, ELEVENLABS }
 

--- a/core/domain/src/main/kotlin/app/adaptweather/core/domain/model/Settings.kt
+++ b/core/domain/src/main/kotlin/app/adaptweather/core/domain/model/Settings.kt
@@ -16,8 +16,11 @@ enum class DeliveryMode { NOTIFICATION_ONLY, TTS_ONLY, NOTIFICATION_AND_TTS }
  *   a small amount per character. Falls back to [DEVICE] if the call fails.
  * - [OPENAI] uses OpenAI's `audio/speech` endpoint over a separate BYOK OpenAI key.
  *   Comparable quality to Gemini; falls back to [DEVICE] on failure.
+ * - [ELEVENLABS] uses ElevenLabs's `text-to-speech` endpoint over a separate BYOK
+ *   ElevenLabs key. Highest perceptual naturalness of the three online options;
+ *   falls back to [DEVICE] on failure.
  */
-enum class TtsEngine { DEVICE, GEMINI, OPENAI }
+enum class TtsEngine { DEVICE, GEMINI, OPENAI, ELEVENLABS }
 
 /**
  * User-selectable accent / language preference for spoken playback. Used in
@@ -77,6 +80,12 @@ data class UserPreferences(
      * == [TtsEngine.OPENAI].
      */
     val openAiVoice: String = DEFAULT_OPENAI_VOICE,
+    /**
+     * ElevenLabs voice ID — the opaque library identifier (e.g.
+     * "EXAVITQu4vr4xnSDxMaL" for Sarah). Only consulted when [ttsEngine]
+     * == [TtsEngine.ELEVENLABS].
+     */
+    val elevenLabsVoice: String = DEFAULT_ELEVENLABS_VOICE,
     val voiceLocale: VoiceLocale = VoiceLocale.SYSTEM,
     /**
      * When true, the worker reads today's calendar events (via `READ_CALENDAR`)
@@ -90,5 +99,7 @@ data class UserPreferences(
     companion object {
         const val DEFAULT_GEMINI_VOICE = "Kore"
         const val DEFAULT_OPENAI_VOICE = "alloy"
+        // Sarah — the most generally pleasant of ElevenLabs's stock library voices.
+        const val DEFAULT_ELEVENLABS_VOICE = "EXAVITQu4vr4xnSDxMaL"
     }
 }


### PR DESCRIPTION
## Summary

Same change as the (now-closed) #73, rebased fresh on top of `main`. Main had moved on with the locale-aware voice/accent picker, calendar-event integration, the ClothesCast rebrand, and the Gemini playback cleanup — all of which collided with the original branch. This PR is the post-conflict-resolution result.

Adds ElevenLabs as a third online voice option, mirroring the existing Gemini / OpenAI BYOK pattern end-to-end. No shared TTS plumbing was introduced — keeping each provider's wiring straight-line and greppable was worth the duplication.

### Wire shape

- **Endpoint**: `POST https://api.elevenlabs.io/v1/text-to-speech/{voice_id}?output_format=pcm_24000`
- **Auth**: `xi-api-key: <user's key>` header (not Bearer, unlike OpenAI)
- **Model**: `eleven_multilingual_v2` by default
- **Output format**: `pcm_24000` is documented as 16-bit signed little-endian mono at 24 kHz — bit-identical to the Gemini and OpenAI PCM paths, so `PcmAudioPlayer` is reused as-is

### Conflict resolution highlights

- `Settings.kt` — `elevenLabsVoice` field added next to `openAiVoice`, alongside main's new `voiceLocale` and `useCalendarEvents` fields. `DEFAULT_ELEVENLABS_VOICE = "EXAVITQu4vr4xnSDxMaL"` (Sarah).
- `SettingsRepository.kt` — `setElevenLabsVoice` + `ELEVENLABS_VOICE` DataStore key, alongside main's `setVoiceLocale` / `setUseCalendarEvents` and the locale-aware OpenAI default. Read order in `toUserPreferences` keeps locale-aware OpenAI defaulting intact.
- `SettingsScreen.kt` — third KeyEntryFields block (Gemini / OpenAI / ElevenLabs), third TtsEngineCard branch with voice picker + missing-key hint, fourth `ttsEngineLabel`, `runTtsPreview` extended to take both `elevenLabsVoice` *and* `voiceLocale`. The TtsEngineCard signature now carries both `elevenLabsKeyConfigured` and the voice-locale picker callbacks.
- `FetchAndNotifyWorker.speakWithFallback` — third `ELEVENLABS` branch passes the resolved locale to `ElevenLabsTtsSpeaker.speak(text, locale)` for parity with the other two online speakers.
- `SettingsRepositoryTest` — kept main's locale-aware OpenAI tests and `useCalendarEvents` test intact, added a separate `elevenLabs voice defaults to Sarah when nothing stored` test, and extended the existing voice-round-trip test to cover the third provider.

### Files

- `core/data/.../ElevenLabsTtsClient.kt` (new) + `ElevenLabsTtsDto.kt` (new)
- `app/.../tts/ElevenLabsTtsSpeaker.kt` (new), `tts/TtsVoices.kt` (8 stock voices added)
- `core/domain/.../Settings.kt` — `TtsEngine.ELEVENLABS`, `UserPreferences.elevenLabsVoice`, `DEFAULT_ELEVENLABS_VOICE`
- `app/.../data/SecureKeyStore.kt` — `getElevenLabs` / `setElevenLabs` / `clearElevenLabs` + `elevenLabsKeyProvider`
- `app/.../data/SettingsRepository.kt` — `setElevenLabsVoice` + `elevenlabs_voice` DataStore key
- `app/.../AdaptWeatherApplication.kt` — lazy `elevenLabsTtsClient`
- `app/.../work/FetchAndNotifyWorker.kt` — third branch in `speakWithFallback`
- `app/.../ui/settings/{SettingsState, SettingsViewModel, SettingsScreen}.kt` — third KeyEntryFields block, third TtsEngineCard branch with voice picker + missing-key hint, fourth `ttsEngineLabel`, `runTtsPreview` extended
- `strings.xml` — labels and engine-description copy
- `SettingsRepositoryTest.kt` — round-trip + per-provider default coverage extended

### Voice picker

Eight pre-made library voices: Sarah (default), Rachel, Domi, Elli, Adam, Antoni, Josh, Arnold. Cloned voices aren't surfaced in v1 (would need a raw-paste UI for the voice ID — happy to follow up).

## Test plan

- [x] `SettingsRepositoryTest` voice round-trip and per-provider defaults assertions extended.
- [ ] Build with this branch, paste an ElevenLabs key in Settings, pick the engine + a voice, tap **Test voice** → should hear preview audio.
- [ ] Pick ElevenLabs without a key configured → "Missing key" hint appears, toast on test-voice tap names ElevenLabs.
- [ ] Pick ElevenLabs with an obviously wrong voice ID (manually injected) → toast shows the parsed `detail.message` from the envelope.
- [ ] Worker delivery: with engine = ElevenLabs and a valid key, the morning insight is read aloud through ElevenLabs; killing network mid-call falls back to device TTS without crashing the worker.


---
_Generated by [Claude Code](https://claude.ai/code/session_011r2zYNjDML7R475zeXhnMH)_