### PR TITLE
:app — fix Settings → About source link to renamed repo

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/settings/AboutSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/AboutSettings.kt
@@ -65,7 +65,7 @@ private fun AboutCard() {
             style = MaterialTheme.typography.bodyMedium,
         )
         TextButton(
-            onClick = { openUrl(context, "https://github.com/mikelward/adaptweather") },
+            onClick = { openUrl(context, "https://github.com/mikelward/clothescast") },
             modifier = Modifier.fillMaxWidth(),
         ) { Text(stringResource(R.string.settings_about_source)) }
         TextButton(


### PR DESCRIPTION
The Settings → About → Source button still pointed at
`github.com/mikelward/adaptweather`, which would either 404 or rely on
GitHub's rename redirect. Updated to `github.com/mikelward/clothescast`.

The other two `adaptweather` mentions left in the tree are deliberate —
both `app/build.gradle.kts:39` and `docs/TODO.md:10` document *why* the
applicationId is pinned to `app.clothescast` and can't change again
without a migration story (the rename already cost FAD testers their
encrypted API keys, schedule, location, and wardrobe rules). Erasing the
history would erase that warning.

## Test plan

- [ ] CI green (JVM unit tests + Android debug build)
- [ ] Manual: Settings → About → Source opens the clothescast repo

https://claude.ai/code/session_01LuMxdJsZKhbA8TRgRTzfag

---
_Generated by [Claude Code](https://claude.ai/code/session_01LuMxdJsZKhbA8TRgRTzfag)_