### PR TITLE
:app — block + spinner on Refresh and voice preview while in flight

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsCommon.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsCommon.kt
@@ -35,6 +35,7 @@ internal fun RadioRow(
     label: String,
     selected: Boolean,
     onSelect: () -> Unit,
+    enabled: Boolean = true,
 ) {
     Row(
         modifier = Modifier
@@ -42,7 +43,7 @@ internal fun RadioRow(
             .padding(vertical = 4.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        RadioButton(selected = selected, onClick = onSelect)
+        RadioButton(selected = selected, onClick = onSelect, enabled = enabled)
         Text(text = label, modifier = Modifier.padding(start = 8.dp))
     }
 }

--- a/app/src/main/kotlin/app/clothescast/ui/settings/VoiceSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/VoiceSettings.kt
@@ -1,15 +1,18 @@
 package app.clothescast.ui.settings
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
@@ -20,6 +23,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -37,7 +41,6 @@ import app.clothescast.tts.TtsVoiceOption
 import app.clothescast.tts.resolve
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -61,15 +64,24 @@ internal fun VoiceContent(
 ) {
     val context = LocalContext.current
     val coroutineScope = rememberCoroutineScope()
-    // Ongoing preview job is held in remember-state so each new selection cancels
-    // the previous before starting a new one. Otherwise rapid taps would queue up
-    // overlapping playbacks.
-    var previewJob by remember { mutableStateOf<Job?>(null) }
+    // While a preview is in flight (synthesis + playback) we lock the whole
+    // voice section. Cloud TTS calls are billed per-character and the in-flight
+    // request can't reliably be un-billed by client-side cancellation, so the
+    // safe behaviour is to ignore further triggers — engine taps, voice taps,
+    // locale taps, the Test Voice button — until the current preview finishes.
+    // Compose callbacks run on the main thread, so the read-then-write here is
+    // atomic with respect to other UI events.
+    var isPreviewing by remember { mutableStateOf(false) }
 
     fun preview(engine: TtsEngine, gVoice: String, oVoice: String, eVoice: String, locale: VoiceLocale) {
-        previewJob?.cancel()
-        previewJob = coroutineScope.launch {
-            runTtsPreview(context, engine, gVoice, oVoice, eVoice, locale)
+        if (isPreviewing) return
+        isPreviewing = true
+        coroutineScope.launch {
+            try {
+                runTtsPreview(context, engine, gVoice, oVoice, eVoice, locale)
+            } finally {
+                isPreviewing = false
+            }
         }
     }
 
@@ -87,6 +99,7 @@ internal fun VoiceContent(
         SectionCard(title = stringResource(R.string.settings_tts_voice_locale_label)) {
             VoiceLocalePicker(
                 selected = voiceLocale,
+                enabled = !isPreviewing,
                 onSelect = {
                     onSetVoiceLocale(it)
                     preview(selected, geminiVoice, openAiVoice, elevenLabsVoice, it)
@@ -104,6 +117,7 @@ internal fun VoiceContent(
                 RadioRow(
                     label = stringResource(ttsEngineLabel(engine)),
                     selected = engine == selected,
+                    enabled = !isPreviewing,
                     onSelect = {
                         onSetTtsEngine(engine)
                         preview(engine, geminiVoice, openAiVoice, elevenLabsVoice, voiceLocale)
@@ -119,12 +133,13 @@ internal fun VoiceContent(
                         title = stringResource(R.string.settings_tts_voice_label),
                         voices = GEMINI_VOICES,
                         selectedId = geminiVoice,
+                        enabled = !isPreviewing,
                         onSelect = {
                             onSetGeminiVoice(it)
                             preview(TtsEngine.GEMINI, it, openAiVoice, elevenLabsVoice, voiceLocale)
                         },
                     )
-                    TestVoiceButton {
+                    TestVoiceButton(isPreviewing = isPreviewing) {
                         preview(selected, geminiVoice, openAiVoice, elevenLabsVoice, voiceLocale)
                     }
                 }
@@ -136,12 +151,13 @@ internal fun VoiceContent(
                         title = stringResource(R.string.settings_tts_voice_label),
                         voices = OPENAI_VOICES,
                         selectedId = openAiVoice,
+                        enabled = !isPreviewing,
                         onSelect = {
                             onSetOpenAiVoice(it)
                             preview(TtsEngine.OPENAI, geminiVoice, it, elevenLabsVoice, voiceLocale)
                         },
                     )
-                    TestVoiceButton {
+                    TestVoiceButton(isPreviewing = isPreviewing) {
                         preview(selected, geminiVoice, openAiVoice, elevenLabsVoice, voiceLocale)
                     }
                 }
@@ -153,17 +169,18 @@ internal fun VoiceContent(
                         title = stringResource(R.string.settings_tts_voice_label),
                         voices = ELEVENLABS_VOICES,
                         selectedId = elevenLabsVoice,
+                        enabled = !isPreviewing,
                         onSelect = {
                             onSetElevenLabsVoice(it)
                             preview(TtsEngine.ELEVENLABS, geminiVoice, openAiVoice, it, voiceLocale)
                         },
                     )
-                    TestVoiceButton {
+                    TestVoiceButton(isPreviewing = isPreviewing) {
                         preview(selected, geminiVoice, openAiVoice, elevenLabsVoice, voiceLocale)
                     }
                 }
                 TtsEngine.DEVICE -> {
-                    TestVoiceButton {
+                    TestVoiceButton(isPreviewing = isPreviewing) {
                         preview(selected, geminiVoice, openAiVoice, elevenLabsVoice, voiceLocale)
                     }
                 }
@@ -190,11 +207,13 @@ private fun MissingKeyHint(engineName: String) {
 private fun VoiceLocalePicker(
     selected: VoiceLocale,
     onSelect: (VoiceLocale) -> Unit,
+    enabled: Boolean = true,
 ) {
     var dialogOpen by remember { mutableStateOf(false) }
     val title = stringResource(R.string.settings_tts_voice_locale_label)
     OutlinedButton(
         onClick = { dialogOpen = true },
+        enabled = enabled,
         modifier = Modifier.fillMaxWidth(),
     ) {
         Text("$title: ${stringResource(voiceLocaleLabel(selected))}")
@@ -239,11 +258,13 @@ private fun VoicePicker(
     voices: List<TtsVoiceOption>,
     selectedId: String,
     onSelect: (String) -> Unit,
+    enabled: Boolean = true,
 ) {
     var dialogOpen by remember { mutableStateOf(false) }
     val current = voices.firstOrNull { it.id == selectedId }
     OutlinedButton(
         onClick = { dialogOpen = true },
+        enabled = enabled,
         modifier = Modifier.fillMaxWidth(),
     ) {
         Text("$title: ${current?.displayName ?: selectedId}")
@@ -276,11 +297,27 @@ private fun VoicePicker(
 }
 
 @Composable
-private fun TestVoiceButton(onClick: () -> Unit) {
+private fun TestVoiceButton(isPreviewing: Boolean, onClick: () -> Unit) {
+    // Disabled while previewing — billed cloud TTS calls can't be reliably
+    // un-billed once dispatched, and the in-flight playback is already what
+    // a fresh tap would re-trigger. Spinner replaces the label so the user
+    // sees the click was registered and something is happening.
     Button(
         onClick = onClick,
+        enabled = !isPreviewing,
         modifier = Modifier.fillMaxWidth(),
-    ) { Text(stringResource(R.string.settings_tts_test)) }
+    ) {
+        if (isPreviewing) {
+            Box(contentAlignment = Alignment.Center) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(20.dp),
+                    strokeWidth = 2.dp,
+                )
+            }
+        } else {
+            Text(stringResource(R.string.settings_tts_test))
+        }
+    }
 }
 
 /**
@@ -319,7 +356,7 @@ private suspend fun runTtsPreview(
                     app.deviceTtsSpeaker.speak(text, locale)
             }
         } catch (_: CancellationException) {
-            // Expected when the user picks a different option mid-playback; not an error.
+            // Composable scope cancelled (user navigated away mid-preview); not an error.
         } catch (t: Throwable) {
             // TTS exceptions already name their provider in the message
             // (e.g. "Gemini TTS HTTP 400: …"); don't double that up.

--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
@@ -57,17 +57,34 @@ import java.util.Locale
 fun TodayScreen(viewModel: TodayViewModel, onNavigateToSettings: () -> Unit) {
     val state by viewModel.state.collectAsStateWithLifecycle()
     val context = LocalContext.current
+    val isWorking = state.workStatus is WorkStatus.Running
 
     Scaffold(
         topBar = {
             TopAppBar(
                 title = { Text(stringResource(R.string.today_title)) },
                 actions = {
-                    IconButton(onClick = { triggerRefresh(context) }) {
-                        Icon(
-                            imageVector = Icons.Default.Refresh,
-                            contentDescription = stringResource(R.string.today_refresh),
-                        )
+                    // While the worker is enqueued or running we disable Refresh and swap
+                    // the icon for a spinner. The work makes a billed Gemini insight call
+                    // and (depending on the engine) a billed TTS call; re-tapping Refresh
+                    // while one is in flight uses ExistingWorkPolicy.REPLACE, which kills
+                    // the in-flight worker and starts another — re-issuing both requests.
+                    // Disabling the button removes the foot-gun.
+                    IconButton(
+                        onClick = { triggerRefresh(context) },
+                        enabled = !isWorking,
+                    ) {
+                        if (isWorking) {
+                            CircularProgressIndicator(
+                                modifier = Modifier.size(20.dp),
+                                strokeWidth = 2.dp,
+                            )
+                        } else {
+                            Icon(
+                                imageVector = Icons.Default.Refresh,
+                                contentDescription = stringResource(R.string.today_refresh),
+                            )
+                        }
                     }
                     IconButton(onClick = onNavigateToSettings) {
                         Icon(
@@ -79,7 +96,12 @@ fun TodayScreen(viewModel: TodayViewModel, onNavigateToSettings: () -> Unit) {
             )
         },
     ) { padding ->
-        TodayContent(state = state, padding = padding, onRefresh = { triggerRefresh(context) })
+        TodayContent(
+            state = state,
+            padding = padding,
+            isWorking = isWorking,
+            onRefresh = { triggerRefresh(context) },
+        )
     }
 }
 
@@ -87,6 +109,7 @@ fun TodayScreen(viewModel: TodayViewModel, onNavigateToSettings: () -> Unit) {
 private fun TodayContent(
     state: TodayState,
     padding: PaddingValues,
+    isWorking: Boolean,
     onRefresh: () -> Unit,
 ) {
     Column(
@@ -99,7 +122,7 @@ private fun TodayContent(
     ) {
         WorkStatusBanner(status = state.workStatus)
         if (state.insight == null) {
-            EmptyState(onRefresh = onRefresh)
+            EmptyState(onRefresh = onRefresh, isWorking = isWorking)
         } else {
             state.insight.outfit?.let { OutfitPreviewCard(it) }
             InsightCard(state.insight)
@@ -168,7 +191,7 @@ private fun describeFailure(failed: WorkStatus.Failed): String {
 }
 
 @Composable
-internal fun EmptyState(onRefresh: () -> Unit) {
+internal fun EmptyState(onRefresh: () -> Unit, isWorking: Boolean = false) {
     Box(
         modifier = Modifier
             .fillMaxWidth()
@@ -189,7 +212,7 @@ internal fun EmptyState(onRefresh: () -> Unit) {
                 style = MaterialTheme.typography.bodyMedium,
                 textAlign = TextAlign.Center,
             )
-            Button(onClick = onRefresh) {
+            Button(onClick = onRefresh, enabled = !isWorking) {
                 Text(stringResource(R.string.today_fetch_now))
             }
         }


### PR DESCRIPTION
## Why

Two surfaces in the app kick off billed cloud calls and offer no feedback while
they're in flight, so a second tap before the first finishes happily issues
another paid request:

- **Today → Refresh** runs `FetchAndNotifyWorker` (billed Gemini insight +,
  depending on engine, billed TTS) and uses `ExistingWorkPolicy.REPLACE` —
  so a second tap doesn't just bill a second run, it throws away the
  already-issued calls from the first.
- **Settings → Voice** auto-previews on every voice / engine / locale tap and
  on the Test Voice button. Existing logic cancelled the previous coroutine,
  but client-side cancellation doesn't un-bill a request the cloud TTS
  server has already accepted, and there was no UI feedback at all — rapid
  taps on a voice row stacked up billed synthesis calls.

## What changed

- **Today screen:** when `WorkStatus is Running`, the Refresh `IconButton` is
  disabled and its icon is replaced with a `CircularProgressIndicator`. The
  `EmptyState` "Fetch now" button is disabled in the same window.
- **Voice settings:** a single `isPreviewing` Compose state flag gates the
  whole section. The engine radios, voice picker, locale picker and Test
  Voice button are all `enabled = !isPreviewing`. Test Voice swaps its label
  for a `CircularProgressIndicator` while the preview is in flight. The
  preview launcher early-returns if `isPreviewing` is already true; the
  read-then-write happens on the Main dispatcher so it's atomic against
  rapid taps.
- **`SettingsCommon.RadioRow`** gains an `enabled: Boolean = true` parameter
  to support the engine radios.

`runTtsPreview` is unchanged; only the call-site gate around it differs.

## Test plan

- [ ] CI: JVM unit tests + Android debug build green (sandbox has no AGP, so
      build verification happens here).
- [ ] On a build of this branch, tap Refresh on Today: the icon should
      become a spinner and the button should be unresponsive until the work
      finishes; second tap during that window does nothing.
- [ ] On Voice settings, tap Test Voice: the button text becomes a spinner,
      the engine / voice / locale rows visibly disable, and tapping any of
      them while the preview is playing has no effect. After the preview
      ends, everything re-enables.
- [ ] Switching between engines (e.g. tap OPENAI radio) still auto-previews
      *the first time*; rapid follow-up taps are absorbed.
- [ ] On the DEVICE engine path (no network), the spinner still appears for
      the duration of the on-device synthesis + playback.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SewCNUsN9F6pw7zfPmxESK)_