### PR TITLE
:app — clearer schedule chips, full-row delivery taps, setup Done button

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/settings/ScheduleSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/ScheduleSettings.kt
@@ -7,12 +7,17 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
@@ -44,6 +49,7 @@ internal fun ScheduleContent(
     padding: PaddingValues,
     onSetSchedule: (LocalTime, Set<DayOfWeek>) -> Unit,
     onSetDeliveryMode: (DeliveryMode) -> Unit,
+    onDone: (() -> Unit)? = null,
 ) {
     Column(
         modifier = Modifier
@@ -55,6 +61,16 @@ internal fun ScheduleContent(
     ) {
         ScheduleCard(time, days, onSetSchedule)
         DeliveryModeCard(deliveryMode, onSetDeliveryMode)
+        if (onDone != null) {
+            Button(
+                onClick = onDone,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 8.dp),
+            ) {
+                Text(stringResource(R.string.onboarding_step_done))
+            }
+        }
     }
 }
 
@@ -100,6 +116,17 @@ private fun ScheduleCard(
                     },
                     label = {
                         Text(text = dow.getDisplayName(TextStyle.SHORT, Locale.getDefault()))
+                    },
+                    leadingIcon = if (selected) {
+                        {
+                            Icon(
+                                imageVector = Icons.Filled.Check,
+                                contentDescription = null,
+                                modifier = Modifier.size(FilterChipDefaults.IconSize),
+                            )
+                        }
+                    } else {
+                        null
                     },
                     colors = FilterChipDefaults.filterChipColors(),
                 )

--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsCommon.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsCommon.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.selection.selectable
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material3.Card
@@ -15,6 +16,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 
 @Composable
@@ -40,10 +42,19 @@ internal fun RadioRow(
     Row(
         modifier = Modifier
             .fillMaxWidth()
+            .selectable(
+                selected = selected,
+                enabled = enabled,
+                role = Role.RadioButton,
+                onClick = onSelect,
+            )
             .padding(vertical = 4.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        RadioButton(selected = selected, onClick = onSelect, enabled = enabled)
+        // onClick = null so the row's selectable handles the click; this avoids
+        // a doubled "selected" announcement from TalkBack and gives the whole
+        // row a single tap target.
+        RadioButton(selected = selected, onClick = null, enabled = enabled)
         Text(text = label, modifier = Modifier.padding(start = 8.dp))
     }
 }

--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsScreen.kt
@@ -100,6 +100,11 @@ fun SettingsScreen(
                 padding = padding,
                 onSetSchedule = viewModel::setSchedule,
                 onSetDeliveryMode = viewModel::setDeliveryMode,
+                // Show a Done button only when this page is the deep-link
+                // landing from onboarding's "Continue" — gives the user an
+                // obvious way to finish setup and reach Today. In the regular
+                // settings flow they exit via the top-bar back arrow.
+                onDone = if (initialRoute == SettingsRoute.Schedule) onNavigateBack else null,
             )
             SettingsRoute.Wardrobe -> WardrobeContent(
                 rules = state.wardrobeRules,


### PR DESCRIPTION
Three small UX tweaks on Settings → Schedule, all flagged in chat:

## Changes

**1. Day-of-week chips show on/off state more clearly.** Each `FilterChip` now renders a leading `Icons.Filled.Check` when selected. The default Material 3 tonal fill alone was easy to misread — selected vs. not-selected differed only by background tint, which can be subtle in some themes / for users with reduced colour vision. The check is the documented Material 3 selected-chip pattern and makes the state unambiguous at a glance.

**2. Whole "How to deliver the daily insight" row is tappable.** `RadioRow` (used by the delivery-mode card) was wrapped in `Modifier.selectable(role = Role.RadioButton)`. The `RadioButton`'s own `onClick` is now `null` so the row's selectable handles the click — this avoids TalkBack double-announcing the selection and makes the entire row a single ~48dp tap target instead of just the radio circle.

**3. "Done" button on the schedule page during first-run setup.** When `SettingsScreen` is opened with `initialRoute = SettingsRoute.Schedule` (the deep-link from onboarding's "Continue"), `ScheduleContent` now shows a primary `Button` labelled **Done** at the bottom that calls `onNavigateBack` → which in turn lands the user on Today. The regular Settings → Schedule entry passes `onDone = null` and is unchanged. Reuses the existing `R.string.onboarding_step_done` ("Done").

`RadioRow` is shared with the Voice / Units / API-keys / Data-sources sub-pages, so they all benefit from the bigger tap target too.

## Validation

Couldn't run `:app:assembleDebug` or `:app:testDebugUnitTest` locally — the Android Gradle plugin can't resolve from this sandbox (Google Maven blocked, per `CLAUDE.md`). Relying on CI for build + JVM tests; no Roborazzi snapshot covers these specific composables, so no snapshot churn is expected.

## Test plan

- [ ] CI: `JVM unit tests` green
- [ ] CI: `Android debug build` green
- [ ] Manual: Settings → Schedule, tap label / row whitespace next to each delivery-mode radio — selection follows the tap
- [ ] Manual: Settings → Schedule, toggle weekday chips — checkmark appears/disappears as the chip flips selected/unselected
- [ ] Manual: fresh install / wipe data → Onboarding → Continue lands on Schedule with a Done button at the bottom; tapping Done reaches Today
- [ ] Manual: Settings (entered the normal way) → Schedule has no Done button
- [ ] Manual: TalkBack on the delivery-mode rows — single "selected" announcement, not doubled

---
_Generated by [Claude Code](https://claude.ai/code/session_014pRGXG5w91mikqxs3Aerji)_