### PR TITLE
:app + ci — release signing config and bundleRelease for Play uploads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -319,6 +319,64 @@ jobs:
           set -o pipefail
           ./gradlew :app:assembleDebug --stacktrace --info 2>&1 | tee /tmp/android-build.log
 
+      - name: Decode upload keystore from secret
+        # Push-to-main only. PR builds (incl. forks) skip — forks don't have the
+        # secret, and even non-fork PRs don't need to burn ~3min signing a release
+        # AAB on every commit. Mirrors the debug-keystore decode step above:
+        # base64-decode, validate with `keytool -list` so wrong-base64 / wrong-
+        # password fails here rather than at signing time, then export the path
+        # to GITHUB_ENV for bundleRelease to pick up.
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        env:
+          UPLOAD_KEYSTORE_BASE64: ${{ secrets.UPLOAD_KEYSTORE_BASE64 }}
+          UPLOAD_KEYSTORE_PASSWORD: ${{ secrets.UPLOAD_KEYSTORE_PASSWORD }}
+          UPLOAD_KEY_ALIAS: ${{ secrets.UPLOAD_KEY_ALIAS }}
+          UPLOAD_KEY_PASSWORD: ${{ secrets.UPLOAD_KEY_PASSWORD }}
+        run: |
+          if [ -z "$UPLOAD_KEYSTORE_BASE64" ]; then
+            echo "::error::UPLOAD_KEYSTORE_BASE64 secret is not set; cannot build a Play-uploadable AAB."
+            exit 1
+          fi
+          missing=""
+          [ -z "$UPLOAD_KEYSTORE_PASSWORD" ] && missing="$missing UPLOAD_KEYSTORE_PASSWORD"
+          [ -z "$UPLOAD_KEY_ALIAS" ]         && missing="$missing UPLOAD_KEY_ALIAS"
+          [ -z "$UPLOAD_KEY_PASSWORD" ]      && missing="$missing UPLOAD_KEY_PASSWORD"
+          if [ -n "$missing" ]; then
+            echo "::error::UPLOAD_KEYSTORE_BASE64 is set but the following companion secrets are missing or empty:$missing"
+            exit 1
+          fi
+          printf '%s' "$UPLOAD_KEYSTORE_BASE64" | base64 --decode > "$RUNNER_TEMP/upload.jks"
+          if ! keytool -list -keystore "$RUNNER_TEMP/upload.jks" -storepass "$UPLOAD_KEYSTORE_PASSWORD" >/dev/null 2>&1; then
+            echo "::error::Decoded keystore at \$RUNNER_TEMP/upload.jks is not a valid keystore or UPLOAD_KEYSTORE_PASSWORD is wrong."
+            exit 1
+          fi
+          echo "UPLOAD_KEYSTORE_FILE=$RUNNER_TEMP/upload.jks" >> "$GITHUB_ENV"
+
+      - name: Bundle release AAB
+        # Push-to-main only — see "Decode upload keystore" rationale. Produces
+        # app/build/outputs/bundle/release/app-release.aab signed with the upload
+        # key; Play App Signing re-signs with the real signing key on download.
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        env:
+          UPLOAD_KEYSTORE_PASSWORD: ${{ secrets.UPLOAD_KEYSTORE_PASSWORD }}
+          UPLOAD_KEY_ALIAS: ${{ secrets.UPLOAD_KEY_ALIAS }}
+          UPLOAD_KEY_PASSWORD: ${{ secrets.UPLOAD_KEY_PASSWORD }}
+        run: |
+          set -o pipefail
+          ./gradlew :app:bundleRelease --stacktrace --info 2>&1 | tee -a /tmp/android-build.log
+
+      - name: Upload release AAB
+        # Browser-downloadable artifact for manual upload to Play Console (no API
+        # exists to *create* a Play app, so the first upload is browser-only;
+        # subsequent uploads can be automated in a follow-up PR via
+        # r0adkll/upload-google-play once the app shell exists).
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-release-aab
+          path: app/build/outputs/bundle/release/app-release.aab
+          retention-days: 14
+
       - name: Clear prior CI comments for this job
         # Same rationale as the JVM job — drops stale failure comments on a
         # clean re-run so the PR doesn't accumulate.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -102,6 +102,40 @@ android {
                 keyPassword = keyPass
             }
         }
+        // Upload key for Play App Signing. Same env-var-or-fail pattern as the
+        // debug block above: in CI the four UPLOAD_* env vars are populated from
+        // GitHub Secrets and bundleRelease produces a Play-uploadable AAB; locally
+        // the env vars are absent, the signing config has no storeFile, and AGP
+        // fails loudly on bundleRelease/assembleRelease — which is the right
+        // default (better than silently shipping a debug-signed release).
+        create("release") {
+            val keystorePath = System.getenv("UPLOAD_KEYSTORE_FILE")?.takeIf { it.isNotBlank() }
+            val storePass = System.getenv("UPLOAD_KEYSTORE_PASSWORD")?.takeIf { it.isNotBlank() }
+            val alias = System.getenv("UPLOAD_KEY_ALIAS")?.takeIf { it.isNotBlank() }
+            val keyPass = System.getenv("UPLOAD_KEY_PASSWORD")?.takeIf { it.isNotBlank() }
+
+            val anySet = keystorePath != null || storePass != null || alias != null || keyPass != null
+            val allSet = keystorePath != null && storePass != null && alias != null && keyPass != null
+
+            if (anySet && !allSet) {
+                error(
+                    "Partial upload-keystore configuration. Set all of UPLOAD_KEYSTORE_FILE, " +
+                        "UPLOAD_KEYSTORE_PASSWORD, UPLOAD_KEY_ALIAS, UPLOAD_KEY_PASSWORD — or none, " +
+                        "to leave the release signing config empty (bundleRelease will then fail).",
+                )
+            }
+
+            if (allSet) {
+                val keystore = file(keystorePath!!)
+                check(keystore.exists()) {
+                    "UPLOAD_KEYSTORE_FILE is set but does not exist: ${keystore.path}"
+                }
+                storeFile = keystore
+                storePassword = storePass
+                keyAlias = alias
+                keyPassword = keyPass
+            }
+        }
     }
 
     buildTypes {
@@ -116,8 +150,7 @@ android {
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro",
             )
-            // Signing config wired in by CI; assembleRelease in dev builds will fail loudly
-            // until then, which is the right default.
+            signingConfig = signingConfigs.getByName("release")
         }
     }
 


### PR DESCRIPTION
## Summary

- `app/build.gradle.kts`: add `signingConfigs.create("release") { ... }` reading `UPLOAD_KEYSTORE_FILE` / `UPLOAD_KEYSTORE_PASSWORD` / `UPLOAD_KEY_ALIAS` / `UPLOAD_KEY_PASSWORD` env vars, mirroring the existing debug-keystore pattern. Wire `buildTypes.release.signingConfig` to it. Locally the env vars are absent → `bundleRelease` fails loudly with AGP's "store file not specified" rather than silently shipping a debug-signed release.
- `.github/workflows/ci.yml`: on push to `main` only, decode `UPLOAD_KEYSTORE_BASE64` to `$RUNNER_TEMP/upload.jks`, validate with `keytool -list`, run `:app:bundleRelease`, upload `app-release.aab` as a workflow artifact (14d retention).

## What this enables

After merge, every push to `main` produces a Play-uploadable AAB on the run's Artifacts panel. Download via browser → Play Console → upload to Internal Testing.

The very first Play upload still has to be browser-only because the Play Console API can't *create* a new app shell, only update an existing one. Once the app exists, automated upload via `r0adkll/upload-google-play` is a follow-up PR — defer.

## Required secrets (already added by user before this PR lands)

- `UPLOAD_KEYSTORE_BASE64` — `base64 -w0 upload.jks` output
- `UPLOAD_KEYSTORE_PASSWORD`
- `UPLOAD_KEY_PASSWORD`
- `UPLOAD_KEY_ALIAS` (typically `upload`)

## Test plan

- [ ] PR-mode CI is green, with the new release-signing steps **skipped** (gated to `push` + `refs/heads/main`).
- [ ] After merge to `main`, the `Android debug build` job:
  - [ ] Decodes the upload keystore (no error log lines about partial config).
  - [ ] Runs `:app:bundleRelease` to completion.
  - [ ] Uploads the `app-release-aab` artifact.
- [ ] Download `app-release.aab` from the Actions run, upload to a brand-new Play Console app under Internal Testing, complete the rollout.
- [ ] FAD distribute step at `.github/workflows/ci.yml:386` still fires unchanged.

https://claude.ai/code/session_01HoWCPRxxn9Jae7LaJGyAhv

---
_Generated by [Claude Code](https://claude.ai/code/session_01HoWCPRxxn9Jae7LaJGyAhv)_