### PR TITLE
ci — pass DEBUG_* env vars to bundleRelease step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -356,8 +356,18 @@ jobs:
         # Push-to-main only — see "Decode upload keystore" rationale. Produces
         # app/build/outputs/bundle/release/app-release.aab signed with the upload
         # key; Play App Signing re-signs with the real signing key on download.
+        #
+        # Both DEBUG_* and UPLOAD_* env vars are passed: Gradle evaluates *all*
+        # signingConfigs at configure time, so even though `bundleRelease` only
+        # uses the release config, the debug block at app/build.gradle.kts also
+        # runs and its partial-config guard would fail the build if DEBUG_*
+        # were only partially populated. DEBUG_KEYSTORE_FILE comes via
+        # $GITHUB_ENV from the earlier decode step.
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         env:
+          DEBUG_KEYSTORE_PASSWORD: ${{ secrets.DEBUG_KEYSTORE_PASSWORD }}
+          DEBUG_KEY_ALIAS: ${{ secrets.DEBUG_KEY_ALIAS }}
+          DEBUG_KEY_PASSWORD: ${{ secrets.DEBUG_KEY_PASSWORD }}
           UPLOAD_KEYSTORE_PASSWORD: ${{ secrets.UPLOAD_KEYSTORE_PASSWORD }}
           UPLOAD_KEY_ALIAS: ${{ secrets.UPLOAD_KEY_ALIAS }}
           UPLOAD_KEY_PASSWORD: ${{ secrets.UPLOAD_KEY_PASSWORD }}


### PR DESCRIPTION
## Summary

Fix for the post-merge CI failure on PR #89: the new `Bundle release AAB` step was failing at gradle configuration time with "Partial debug-keystore configuration" because it inherited `DEBUG_KEYSTORE_FILE` from `$GITHUB_ENV` but not the three companion `DEBUG_*` env vars (those were scoped step-locally to `Assemble debug APK`). Gradle evaluates all `signingConfigs` at configure time, so even `bundleRelease` triggered the debug block's partial-config guard.

Pass all four `DEBUG_*` values to the bundleRelease step, matching the assembleDebug shape.

## Test plan

- [ ] Once merged, the next push to `main` runs the `Bundle release AAB` step to completion (no "Partial debug-keystore configuration" error).
- [ ] `app-release-aab` artifact appears on the run.
- [ ] FAD `Distribute via Firebase App Distribution` step still succeeds.

https://claude.ai/code/session_01HoWCPRxxn9Jae7LaJGyAhv

---
_Generated by [Claude Code](https://claude.ai/code/session_01HoWCPRxxn9Jae7LaJGyAhv)_