### PR TITLE
ci — run FAD distribute before release-AAB steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -319,6 +319,53 @@ jobs:
           set -o pipefail
           ./gradlew :app:assembleDebug --stacktrace --info 2>&1 | tee /tmp/android-build.log
 
+      - name: Upload debug APK
+        # Up here, before the release-AAB steps, so a bundleRelease failure
+        # doesn't gate this artifact behind a now-failed `success()`.
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-debug-apk
+          path: app/build/outputs/apk/debug/*.apk
+          retention-days: 14
+
+      - name: Distribute via Firebase App Distribution
+        # On push to main only — feature-branch CI runs would otherwise spam
+        # testers with WIP builds. Skipped when secrets aren't set so the build
+        # still finishes on a fresh repo / fork. The env vars referenced here
+        # are populated at the job level (see env: block above) — the secrets
+        # context isn't allowed in step `if:` and step-level env isn't in scope.
+        #
+        # Ordered before the release-AAB steps so a bundleRelease failure on
+        # main doesn't skip FAD distribution under the `success()` gate — debug
+        # testers get the build either way; only the Play AAB artifact is lost.
+        if: |
+          success() &&
+          github.event_name == 'push' &&
+          github.ref == 'refs/heads/main' &&
+          env.FIREBASE_APP_ID != '' &&
+          env.FIREBASE_SERVICE_ACCOUNT_JSON != ''
+        # Pinned to a specific commit SHA (rather than the floating @v1 tag) so
+        # a compromised upstream release can't silently swap in malicious code
+        # on our next CI run. Bump deliberately. SHA below is wzieba/Firebase-
+        # Distribution-Github-Action v1.7.1.
+        uses: wzieba/Firebase-Distribution-Github-Action@bd494989dd4bec0343f78adee87fe66e48279ad6 # v1.7.1
+        with:
+          appId: ${{ secrets.FIREBASE_APP_ID }}
+          serviceCredentialsFileContent: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+          # Tester group must exist in Firebase App Distribution console — see
+          # docs/firebase-app-distribution.md. "testers" is the convention; rename
+          # there + here together if you change it.
+          groups: testers
+          file: app/build/outputs/apk/debug/app-debug.apk
+          # Push notification on the tester's phone shows the first ~60 chars
+          # of these notes, so put the most useful info first. Commit subject
+          # is normally that.
+          releaseNotes: |
+            ${{ github.event.head_commit.message }}
+            ---
+            Build: ${{ github.run_number }} · ${{ github.sha }}
+
       - name: Decode upload keystore from secret
         # Push-to-main only. PR builds (incl. forks) skip — forks don't have the
         # secret, and even non-fork PRs don't need to burn ~3min signing a release
@@ -442,44 +489,3 @@ jobs:
           name: android-build-log
           path: /tmp/android-build.log
           retention-days: 14
-
-      - name: Upload debug APK
-        if: success()
-        uses: actions/upload-artifact@v4
-        with:
-          name: app-debug-apk
-          path: app/build/outputs/apk/debug/*.apk
-          retention-days: 14
-
-      - name: Distribute via Firebase App Distribution
-        # On push to main only — feature-branch CI runs would otherwise spam
-        # testers with WIP builds. Skipped when secrets aren't set so the build
-        # still finishes on a fresh repo / fork. The env vars referenced here
-        # are populated at the job level (see env: block above) — the secrets
-        # context isn't allowed in step `if:` and step-level env isn't in scope.
-        if: |
-          success() &&
-          github.event_name == 'push' &&
-          github.ref == 'refs/heads/main' &&
-          env.FIREBASE_APP_ID != '' &&
-          env.FIREBASE_SERVICE_ACCOUNT_JSON != ''
-        # Pinned to a specific commit SHA (rather than the floating @v1 tag) so
-        # a compromised upstream release can't silently swap in malicious code
-        # on our next CI run. Bump deliberately. SHA below is wzieba/Firebase-
-        # Distribution-Github-Action v1.7.1.
-        uses: wzieba/Firebase-Distribution-Github-Action@bd494989dd4bec0343f78adee87fe66e48279ad6 # v1.7.1
-        with:
-          appId: ${{ secrets.FIREBASE_APP_ID }}
-          serviceCredentialsFileContent: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
-          # Tester group must exist in Firebase App Distribution console — see
-          # docs/firebase-app-distribution.md. "testers" is the convention; rename
-          # there + here together if you change it.
-          groups: testers
-          file: app/build/outputs/apk/debug/app-debug.apk
-          # Push notification on the tester's phone shows the first ~60 chars
-          # of these notes, so put the most useful info first. Commit subject
-          # is normally that.
-          releaseNotes: |
-            ${{ github.event.head_commit.message }}
-            ---
-            Build: ${{ github.run_number }} · ${{ github.sha }}


### PR DESCRIPTION
## Summary

Addresses the structural concern Copilot raised on PR #89 (https://github.com/mikelward/clothescast/pull/89#discussion_r3145103103), which materialised as the actual post-merge failure: bundleRelease threw, the `android-build` job went red, and FAD distribute (gated on `success()`) was skipped — losing FAD shipment of versionCode 135.

Reorders the `android-build` job so the FAD-related steps run **before** any release-AAB work:

```
... assembleDebug → upload debug APK → FAD distribute  ← new position
                  → decode upload keystore → bundleRelease → upload release AAB
                  → (PR-only comment cleanup steps) → upload build log
```

Now any bundleRelease failure on `main` only loses the Play AAB artifact; debug testers still get the build via FAD.

## Why not split into a separate job

Same logical isolation, cheaper. A second job would re-do `setup-java` + `setup-android` + `setup-gradle` (~1-2min cache-cold) for the same outcome. Single-job reorder achieves the same "FAD survives a release failure" property at zero extra cost.

## Test plan

- [ ] PR-mode CI green; FAD/release steps skipped per their `if:` gates.
- [ ] On the merge commit's `main` run:
  - [ ] `Upload debug APK` succeeds.
  - [ ] `Distribute via Firebase App Distribution` ships a new release to FAD testers.
  - [ ] `Bundle release AAB` runs to completion.
  - [ ] `Upload release AAB` artifact appears.
- [ ] Hypothetical: a future bundleRelease failure on `main` would still allow FAD to ship and debug APK artifact to be uploaded (validate by inspecting the new step order — can't easily test without forcing a regression).

https://claude.ai/code/session_01HoWCPRxxn9Jae7LaJGyAhv

---
_Generated by [Claude Code](https://claude.ai/code/session_01HoWCPRxxn9Jae7LaJGyAhv)_