### PR TITLE
:core — daytime/evening split for wardrobe summary

### DIFF
--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Forecast.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Forecast.kt
@@ -43,3 +43,47 @@ enum class WeatherCondition {
     THUNDERSTORM,
     UNKNOWN,
 }
+
+/**
+ * Wall-clock boundary between the "daytime" and "evening" forecast windows. The
+ * daily insight summary speaks for [DAY_START_HOUR, DAY_END_HOUR); anything past
+ * that is the evening slice that piggy-backs on calendar events with a location.
+ * 07:00 / 19:00 — early enough that the morning commute is covered, late enough
+ * that an after-work dinner falls into the evening bucket where it belongs.
+ */
+const val DAY_START_HOUR: Int = 7
+const val DAY_END_HOUR: Int = 19
+
+/**
+ * Returns a copy of this forecast restricted to hourly entries within
+ * `[start, end)` (start-of-hour comparison), with feels-like / raw-temp / precip
+ * aggregates recomputed over the slice. When [hourly] is empty or the slice is
+ * empty, returns the original — fixtures and providers without hourly resolution
+ * fall through unchanged so callers don't have to special-case them.
+ */
+internal fun DailyForecast.window(start: LocalTime, end: LocalTime): DailyForecast {
+    if (hourly.isEmpty()) return this
+    val slice = hourly.filter { !it.time.isBefore(start) && it.time.isBefore(end) }
+    if (slice.isEmpty()) return this
+    return copy(
+        temperatureMinC = slice.minOf { it.temperatureC },
+        temperatureMaxC = slice.maxOf { it.temperatureC },
+        feelsLikeMinC = slice.minOf { it.feelsLikeC },
+        feelsLikeMaxC = slice.maxOf { it.feelsLikeC },
+        precipitationProbabilityMaxPct = slice.maxOf { it.precipitationProbabilityPct },
+        hourly = slice,
+    )
+}
+
+/** The day window the summary is *about*: [DAY_START_HOUR, DAY_END_HOUR). */
+fun DailyForecast.daytime(): DailyForecast =
+    window(LocalTime.of(DAY_START_HOUR, 0), LocalTime.of(DAY_END_HOUR, 0))
+
+/**
+ * The evening slice of *today*: [DAY_END_HOUR, end-of-day). Tomorrow's small hours
+ * (00:00–07:00) aren't in scope yet — the bundle only carries today + yesterday —
+ * so a late event ending after midnight is evaluated against the temps we have
+ * for tonight, which is fine in practice.
+ */
+fun DailyForecast.evening(): DailyForecast =
+    window(LocalTime.of(DAY_END_HOUR, 0), LocalTime.MAX)

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/OutfitSuggestion.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/OutfitSuggestion.kt
@@ -10,6 +10,14 @@ package app.clothescast.core.domain.model
  * Thresholds use feels-like temperatures (wind chill / humidity adjusted), matching what
  * [WardrobeRule] does, since that's what people actually experience on the way out the
  * door.
+ *
+ * TODO: render a paired Day / Night outfit on the Today screen when the user has an
+ * evening calendar event with a location. The summary already carries the evening
+ * "Bring a jacket for your 20:00 dinner." sentence (rule 7 in
+ * [app.clothescast.core.domain.usecase.RenderInsightSummary]); the home screen still
+ * shows a single icon pair. Plan: have [GenerateDailyInsight] surface a second
+ * `OutfitSuggestion` (built from `today.evening()`) on [Insight], and add a
+ * "Day"/"Night" caption above each on the Today card.
  */
 data class OutfitSuggestion(
     val top: Top,

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsight.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsight.kt
@@ -1,13 +1,17 @@
 package app.clothescast.core.domain.usecase
 
+import app.clothescast.core.domain.model.DAY_END_HOUR
 import app.clothescast.core.domain.model.Insight
 import app.clothescast.core.domain.model.Location
 import app.clothescast.core.domain.model.OutfitSuggestion
 import app.clothescast.core.domain.model.UserPreferences
 import app.clothescast.core.domain.model.WeatherAlert
+import app.clothescast.core.domain.model.daytime
+import app.clothescast.core.domain.model.evening
 import app.clothescast.core.domain.repository.CalendarEventReader
 import app.clothescast.core.domain.repository.WeatherRepository
 import java.time.Clock
+import java.time.LocalTime
 
 /**
  * The product. Fetches the forecast, evaluates wardrobe rules, renders the
@@ -30,7 +34,14 @@ class GenerateDailyInsight(
     ): DailyInsightResult {
         val bundle = weatherRepository.fetchForecast(location)
         val activeAlerts = bundle.alerts.filter { it.expires.isAfter(clock.instant()) }
-        val todayTriggered = evaluateWardrobeRules(bundle.today, prefs.wardrobeRules)
+        // Wardrobe and summary speak for the daytime window only; the evening slice
+        // is reserved for "bring a jacket for your dinner"-style addenda that piggy-
+        // back on calendar events with a location.
+        val todayDay = bundle.today.daytime()
+        val yesterdayDay = bundle.yesterday.daytime()
+        val todayEvening = bundle.today.evening()
+        val todayTriggered = evaluateWardrobeRules(todayDay, prefs.wardrobeRules)
+        val eveningTriggered = evaluateWardrobeRules(todayEvening, prefs.wardrobeRules)
         // Calendar events are gated on both the opt-in pref AND a configured reader.
         // Failures (missing permission, provider crash) degrade to no events so a
         // misbehaving reader can never fail the insight pipeline; the rest of the
@@ -44,12 +55,24 @@ class GenerateDailyInsight(
         } else {
             emptyList()
         }
+        // "Out tonight" = a real, non-all-day event with a location that runs past
+        // 19:00. Location-as-a-string stands in for "not at home" until we have a
+        // proper home-location setting. Tomorrow's small hours aren't queried yet
+        // (eventsForDay is single-day), so a midnight–02:00 event next door is missed
+        // for now — TODO: also fetch tomorrow's events and union the windows.
+        val eveningEvents = events.filter { event ->
+            !event.allDay &&
+                !event.location.isNullOrBlank() &&
+                event.end.isAfter(LocalTime.of(DAY_END_HOUR, 0))
+        }
         val summary = renderInsightSummary(
-            today = bundle.today,
-            yesterday = bundle.yesterday,
+            today = todayDay,
+            yesterday = yesterdayDay,
             todayTriggeredRules = todayTriggered,
             alerts = activeAlerts,
             events = events,
+            eveningTriggeredRules = eveningTriggered,
+            eveningEvents = eveningEvents,
         )
         val insight = Insight(
             summary = summary,
@@ -58,7 +81,7 @@ class GenerateDailyInsight(
             forDate = bundle.today.date,
             hourly = bundle.today.hourly,
             confidence = bundle.confidence,
-            outfit = OutfitSuggestion.fromForecast(bundle.today),
+            outfit = OutfitSuggestion.fromForecast(todayDay),
         )
         return DailyInsightResult(insight = insight, alerts = activeAlerts)
     }

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/RenderInsightSummary.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/RenderInsightSummary.kt
@@ -13,10 +13,15 @@ import kotlin.math.abs
 import kotlin.math.roundToInt
 
 /**
- * Renders the daily insight summary as a deterministic single string of up to six
+ * Renders the daily insight summary as a deterministic single string of up to seven
  * short sentences, each driven by an independent rule. Replaces the previous
  * Gemini call: every sentence is template-fillable from the forecast, so the LLM
  * round trip wasn't earning its keep.
+ *
+ * The renderer speaks for the daytime slice — `[today]` and `[yesterday]` are the
+ * already-windowed forecasts (07:00–19:00). The caller is responsible for slicing
+ * before calling in; an empty hourly array on the input falls through unsliced
+ * (which is fine — the daily aggregates already approximate the daytime).
  *
  * Rules (each yields 0 or 1 sentence, joined with single spaces):
  * 1. Severe alert: highest-severity SEVERE/EXTREME → "Alert: <event>." Extreme
@@ -36,6 +41,12 @@ import kotlin.math.roundToInt
  *    is on the wardrobe list, otherwise the first triggered item. Only fires
  *    when the caller passes events; the worker only does that when the user
  *    has opted in to calendar reading.
+ * 7. Evening tie-in (optional): if the caller passes evening-triggered rules AND
+ *    qualifying evening events (filtering — non-allDay, has a location, runs past
+ *    19:00 — happens at the use-case layer), output
+ *    "Bring <items> for your <HH:MM> <title>." against the earliest such event.
+ *    Drives the "you're going out tonight, take a jacket" nudge without nagging
+ *    when the user is staying in.
  *
  * All temperature comparisons use feels-like values, matching the wardrobe rules.
  */
@@ -46,6 +57,8 @@ class RenderInsightSummary {
         todayTriggeredRules: List<WardrobeRule>,
         alerts: List<WeatherAlert> = emptyList(),
         events: List<CalendarEvent> = emptyList(),
+        eveningTriggeredRules: List<WardrobeRule> = emptyList(),
+        eveningEvents: List<CalendarEvent> = emptyList(),
     ): String = buildList {
         alertSentence(alerts)?.let { add(it) }
         add(bandSentence(today))
@@ -55,6 +68,7 @@ class RenderInsightSummary {
         val peak = peakPrecip(today)
         precipSentence(peak)?.let { add(it) }
         calendarSentence(items, peak, events)?.let { add(it) }
+        eveningSentence(eveningTriggeredRules.map { it.item }, eveningEvents)?.let { add(it) }
     }.joinToString(" ")
 
     private fun alertSentence(alerts: List<WeatherAlert>): String? {
@@ -152,6 +166,22 @@ class RenderInsightSummary {
         // take the first triggered item, mirroring rule 4's ordering.
         val item = items.firstOrNull { it.equals("umbrella", ignoreCase = true) } ?: items.first()
         return "Bring ${withArticle(item)} for your ${EVENT_TIME.format(peak.time)} ${event.title}."
+    }
+
+    private fun eveningSentence(items: List<String>, events: List<CalendarEvent>): String? {
+        if (items.isEmpty() || events.isEmpty()) return null
+        val event = events.minByOrNull { it.start } ?: return null
+        val phrase = when (items.size) {
+            1 -> withArticle(items[0])
+            2 -> "${withArticle(items[0])} and ${items[1]}"
+            else -> {
+                val head = withArticle(items[0])
+                val middle = items.subList(1, items.size - 1).joinToString(", ")
+                val tail = items.last()
+                "$head, $middle, and $tail"
+            }
+        }
+        return "Bring $phrase for your ${EVENT_TIME.format(event.start)} ${event.title}."
     }
 
     private data class PeakPrecip(val time: LocalTime, val condition: WeatherCondition)

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/model/ForecastWindowTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/model/ForecastWindowTest.kt
@@ -1,0 +1,113 @@
+package app.clothescast.core.domain.model
+
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.time.LocalTime
+
+class ForecastWindowTest {
+    private val date = LocalDate.of(2026, 4, 25)
+
+    private fun base(
+        hourly: List<HourlyForecast> = emptyList(),
+    ): DailyForecast = DailyForecast(
+        date = date,
+        temperatureMinC = 8.0,
+        temperatureMaxC = 25.0,
+        feelsLikeMinC = 6.0,
+        feelsLikeMaxC = 25.0,
+        precipitationProbabilityMaxPct = 60.0,
+        precipitationMmTotal = 4.5,
+        condition = WeatherCondition.RAIN,
+        hourly = hourly,
+    )
+
+    @Test
+    fun `daytime returns identity when hourly is empty`() {
+        val forecast = base()
+        forecast.daytime() shouldBe forecast
+    }
+
+    @Test
+    fun `daytime returns identity when slice yields no entries`() {
+        // Only night-time hours present; daytime slice is empty so we keep the daily
+        // aggregates rather than fabricating a flat day at 0°.
+        val forecast = base(
+            hourly = listOf(
+                HourlyForecast(LocalTime.of(2, 0), 4.0, 2.0, 0.0, WeatherCondition.CLEAR),
+                HourlyForecast(LocalTime.of(22, 0), 6.0, 4.0, 0.0, WeatherCondition.CLEAR),
+            ),
+        )
+        forecast.daytime() shouldBe forecast
+    }
+
+    @Test
+    fun `daytime recomputes aggregates from the sliced hours`() {
+        val forecast = base(
+            hourly = listOf(
+                HourlyForecast(LocalTime.of(6, 0), 4.0, 2.0, 5.0, WeatherCondition.CLEAR),
+                HourlyForecast(LocalTime.of(8, 0), 12.0, 10.0, 10.0, WeatherCondition.CLEAR),
+                HourlyForecast(LocalTime.of(15, 0), 22.0, 22.0, 60.0, WeatherCondition.RAIN),
+                HourlyForecast(LocalTime.of(20, 0), 14.0, 12.0, 30.0, WeatherCondition.CLOUDY),
+            ),
+        )
+        val day = forecast.daytime()
+        day.feelsLikeMinC shouldBe 10.0
+        day.feelsLikeMaxC shouldBe 22.0
+        day.temperatureMinC shouldBe 12.0
+        day.temperatureMaxC shouldBe 22.0
+        day.precipitationProbabilityMaxPct shouldBe 60.0
+        day.hourly.map { it.time }.shouldContainExactly(LocalTime.of(8, 0), LocalTime.of(15, 0))
+    }
+
+    @Test
+    fun `daytime excludes the 19_00 boundary`() {
+        // 07:00 is in, 19:00 is out — the evening window owns 19:00 onwards.
+        val forecast = base(
+            hourly = listOf(
+                HourlyForecast(LocalTime.of(7, 0), 8.0, 8.0, 5.0, WeatherCondition.CLEAR),
+                HourlyForecast(LocalTime.of(19, 0), 12.0, 10.0, 5.0, WeatherCondition.CLEAR),
+            ),
+        )
+        forecast.daytime().hourly.map { it.time }.shouldContainExactly(LocalTime.of(7, 0))
+    }
+
+    @Test
+    fun `evening covers 19_00 onwards`() {
+        val forecast = base(
+            hourly = listOf(
+                HourlyForecast(LocalTime.of(15, 0), 22.0, 22.0, 60.0, WeatherCondition.RAIN),
+                HourlyForecast(LocalTime.of(19, 0), 16.0, 14.0, 20.0, WeatherCondition.CLOUDY),
+                HourlyForecast(LocalTime.of(22, 0), 10.0, 8.0, 0.0, WeatherCondition.CLEAR),
+            ),
+        )
+        val night = forecast.evening()
+        night.hourly.map { it.time }.shouldContainExactly(LocalTime.of(19, 0), LocalTime.of(22, 0))
+        night.feelsLikeMinC shouldBe 8.0
+        night.feelsLikeMaxC shouldBe 14.0
+    }
+
+    @Test
+    fun `evening returns identity when no hourly entries fall in the slice`() {
+        // Daytime-only hourly. Falls back to the whole-day aggregates so the caller
+        // doesn't get a synthetic "evening" with the daytime numbers — and an evening
+        // wardrobe rule won't fire spuriously here.
+        val forecast = base(
+            hourly = listOf(
+                HourlyForecast(LocalTime.of(15, 0), 22.0, 22.0, 60.0, WeatherCondition.RAIN),
+            ),
+        )
+        forecast.evening() shouldBe forecast
+    }
+
+    @Test
+    fun `daytime is empty-safe with no input hours`() {
+        // Confidence check: a forecast that explicitly has no hourly array round-trips
+        // through both windows without producing a different object.
+        val forecast = base()
+        forecast.evening() shouldBe forecast
+        forecast.daytime().hourly.shouldBeEmpty()
+    }
+}

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsightTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsightTest.kt
@@ -244,6 +244,133 @@ class GenerateDailyInsightTest {
     }
 
     @Test
+    fun `evening tie-in fires for an evening event with a location and chilly evening hours`() = runTest {
+        val zone = ZoneId.of("Europe/London")
+        // Mild day so daytime rules stay quiet, then a cold evening that triggers
+        // the jacket rule on the evening slice.
+        val mildDayChillyNight = today.copy(
+            feelsLikeMinC = 18.0,
+            feelsLikeMaxC = 22.0,
+            precipitationProbabilityMaxPct = 5.0,
+            condition = WeatherCondition.PARTLY_CLOUDY,
+            hourly = listOf(
+                HourlyForecast(LocalTime.of(8, 0), 18.0, 18.0, 5.0, WeatherCondition.CLEAR),
+                HourlyForecast(LocalTime.of(15, 0), 22.0, 22.0, 5.0, WeatherCondition.CLEAR),
+                HourlyForecast(LocalTime.of(20, 0), 12.0, 10.0, 5.0, WeatherCondition.CLEAR),
+                HourlyForecast(LocalTime.of(22, 0), 10.0, 8.0, 5.0, WeatherCondition.CLEAR),
+            ),
+        )
+        val event = CalendarEvent(
+            title = "dinner",
+            start = LocalTime.of(20, 0),
+            end = LocalTime.of(22, 0),
+            location = "Trattoria",
+        )
+        val weather = FakeWeatherRepository(ForecastBundle(mildDayChillyNight, yesterday))
+        val calendar = FakeCalendarEventReader(events = listOf(event))
+        val subject = GenerateDailyInsight(weather, calendarEventReader = calendar, clock = clock)
+
+        val result = subject(
+            location = london,
+            prefs = prefs.copy(useCalendarEvents = true, schedule = Schedule.default(zone)),
+        )
+
+        // The default wardrobe rules trigger both jumper (<18°C) and jacket (<12°C)
+        // at this evening's feels-like, so the sentence is the multi-item form.
+        result.insight.summary.shouldContain("Bring a jumper and jacket for your 20:00 dinner.")
+        // Daytime wardrobe stays quiet — neither rule fires on the warm afternoon
+        // slice — and the day-summary recommendedItems reflects the day.
+        result.insight.recommendedItems shouldBe emptyList()
+    }
+
+    @Test
+    fun `evening tie-in is suppressed when the event has no location`() = runTest {
+        val zone = ZoneId.of("Europe/London")
+        val mildDayChillyNight = today.copy(
+            feelsLikeMinC = 18.0,
+            feelsLikeMaxC = 22.0,
+            precipitationProbabilityMaxPct = 5.0,
+            hourly = listOf(
+                HourlyForecast(LocalTime.of(15, 0), 22.0, 22.0, 5.0, WeatherCondition.CLEAR),
+                HourlyForecast(LocalTime.of(20, 0), 12.0, 10.0, 5.0, WeatherCondition.CLEAR),
+            ),
+        )
+        // location absent → "at home" stand-in, no nag.
+        val event = CalendarEvent("call mum", LocalTime.of(20, 0), LocalTime.of(20, 30))
+        val weather = FakeWeatherRepository(ForecastBundle(mildDayChillyNight, yesterday))
+        val calendar = FakeCalendarEventReader(events = listOf(event))
+        val subject = GenerateDailyInsight(weather, calendarEventReader = calendar, clock = clock)
+
+        val result = subject(
+            location = london,
+            prefs = prefs.copy(useCalendarEvents = true, schedule = Schedule.default(zone)),
+        )
+
+        result.insight.summary.shouldNotContain("Bring")
+    }
+
+    @Test
+    fun `evening tie-in is suppressed for all-day events even when they have a location`() = runTest {
+        val zone = ZoneId.of("Europe/London")
+        val mildDayChillyNight = today.copy(
+            feelsLikeMinC = 18.0,
+            feelsLikeMaxC = 22.0,
+            precipitationProbabilityMaxPct = 5.0,
+            hourly = listOf(
+                HourlyForecast(LocalTime.of(15, 0), 22.0, 22.0, 5.0, WeatherCondition.CLEAR),
+                HourlyForecast(LocalTime.of(20, 0), 12.0, 10.0, 5.0, WeatherCondition.CLEAR),
+            ),
+        )
+        val holiday = CalendarEvent(
+            title = "conference",
+            start = LocalTime.MIDNIGHT,
+            end = LocalTime.MIDNIGHT,
+            location = "ExCeL London",
+            allDay = true,
+        )
+        val weather = FakeWeatherRepository(ForecastBundle(mildDayChillyNight, yesterday))
+        val calendar = FakeCalendarEventReader(events = listOf(holiday))
+        val subject = GenerateDailyInsight(weather, calendarEventReader = calendar, clock = clock)
+
+        val result = subject(
+            location = london,
+            prefs = prefs.copy(useCalendarEvents = true, schedule = Schedule.default(zone)),
+        )
+
+        result.insight.summary.shouldNotContain("Bring")
+    }
+
+    @Test
+    fun `evening tie-in is suppressed for events that end before 19_00`() = runTest {
+        val zone = ZoneId.of("Europe/London")
+        val mildDayChillyNight = today.copy(
+            feelsLikeMinC = 18.0,
+            feelsLikeMaxC = 22.0,
+            precipitationProbabilityMaxPct = 5.0,
+            hourly = listOf(
+                HourlyForecast(LocalTime.of(15, 0), 22.0, 22.0, 5.0, WeatherCondition.CLEAR),
+                HourlyForecast(LocalTime.of(20, 0), 12.0, 10.0, 5.0, WeatherCondition.CLEAR),
+            ),
+        )
+        val event = CalendarEvent(
+            title = "coffee",
+            start = LocalTime.of(17, 0),
+            end = LocalTime.of(18, 0),
+            location = "Cafe Nero",
+        )
+        val weather = FakeWeatherRepository(ForecastBundle(mildDayChillyNight, yesterday))
+        val calendar = FakeCalendarEventReader(events = listOf(event))
+        val subject = GenerateDailyInsight(weather, calendarEventReader = calendar, clock = clock)
+
+        val result = subject(
+            location = london,
+            prefs = prefs.copy(useCalendarEvents = true, schedule = Schedule.default(zone)),
+        )
+
+        result.insight.summary.shouldNotContain("Bring")
+    }
+
+    @Test
     fun `expired alerts are filtered before reaching the summary and the result`() = runTest {
         val stale = WeatherAlert(
             event = "Wind Advisory",

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/RenderInsightSummaryTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/RenderInsightSummaryTest.kt
@@ -315,6 +315,81 @@ class RenderInsightSummaryTest {
     }
 
     @Test
+    fun `evening tie-in fires when evening rules trigger and a qualifying event is supplied`() {
+        // Caller-side filtering (allDay/location/end-after-19:00) lives in the use-case;
+        // the renderer just trusts what it's handed.
+        val event = CalendarEvent(
+            title = "dinner",
+            start = LocalTime.of(20, 0),
+            end = LocalTime.of(22, 0),
+            location = "Trattoria",
+        )
+        val out = subject(
+            mildToday, yesterday,
+            todayTriggeredRules = emptyList(),
+            eveningTriggeredRules = listOf(jacketRule),
+            eveningEvents = listOf(event),
+        )
+        out.shouldContain("Bring a jacket for your 20:00 dinner.")
+    }
+
+    @Test
+    fun `evening tie-in joins multiple items like the wardrobe sentence`() {
+        val event = CalendarEvent(
+            title = "concert",
+            start = LocalTime.of(21, 0),
+            end = LocalTime.of(23, 0),
+            location = "Royal Albert Hall",
+        )
+        val out = subject(
+            mildToday, yesterday,
+            todayTriggeredRules = emptyList(),
+            eveningTriggeredRules = listOf(jacketRule, umbrellaRule),
+            eveningEvents = listOf(event),
+        )
+        out.shouldContain("Bring a jacket and umbrella for your 21:00 concert.")
+    }
+
+    @Test
+    fun `evening tie-in picks the earliest event when multiple qualify`() {
+        val late = CalendarEvent("late drinks", LocalTime.of(22, 0), LocalTime.of(23, 30), location = "Pub")
+        val early = CalendarEvent("dinner", LocalTime.of(20, 0), LocalTime.of(21, 30), location = "Trattoria")
+        val out = subject(
+            mildToday, yesterday,
+            todayTriggeredRules = emptyList(),
+            eveningTriggeredRules = listOf(jacketRule),
+            eveningEvents = listOf(late, early),
+        )
+        out.shouldContain("for your 20:00 dinner.")
+        out.shouldNotContain("for your 22:00 late drinks.")
+    }
+
+    @Test
+    fun `evening tie-in is omitted when no evening rules trigger`() {
+        // Mild evening + going-out plans → no jacket nudge. The whole point of the
+        // rule is "you're going out *and* you'd want something extra"; it must stay
+        // quiet on a balmy night out.
+        val event = CalendarEvent("dinner", LocalTime.of(20, 0), LocalTime.of(22, 0), location = "Trattoria")
+        subject(
+            mildToday, yesterday,
+            todayTriggeredRules = emptyList(),
+            eveningTriggeredRules = emptyList(),
+            eveningEvents = listOf(event),
+        ).shouldNotContain("Bring")
+    }
+
+    @Test
+    fun `evening tie-in is omitted when no qualifying event is supplied`() {
+        // Cold evening but the user is staying in — no nag.
+        subject(
+            mildToday, yesterday,
+            todayTriggeredRules = emptyList(),
+            eveningTriggeredRules = listOf(jacketRule),
+            eveningEvents = emptyList(),
+        ).shouldNotContain("Bring")
+    }
+
+    @Test
     fun `temperature band classifier covers all six bands at boundaries`() {
         TemperatureBand.forCelsius(-1.0) shouldBe TemperatureBand.FREEZING
         TemperatureBand.forCelsius(3.999) shouldBe TemperatureBand.FREEZING


### PR DESCRIPTION
## Summary

The daily insight now speaks for the **daytime window (07:00–19:00)** only:
band, delta, wardrobe, precip and the existing calendar tie-in all run
against that slice. After 19:00 the summary stays quiet **unless** the
user has a calendar event running past 19:00 with a non-blank location,
in which case a new **evening tie-in** appends a sentence like:

> Bring a jacket for your 20:00 dinner.

If the evening forecast triggers wardrobe rules but the user is staying
in (no qualifying event), nothing is said — no nag.

### Behaviour

- Day window: `[07:00, 19:00)`. New `DailyForecast.daytime()` /
  `evening()` extensions slice the hourly array and recompute feels-like
  / raw / precip aggregates from the slice. Both fall through to identity
  when hourly is empty, so existing fixtures and providers without hourly
  resolution don't change.
- "Out tonight" predicate (in `GenerateDailyInsight`):
  `!event.allDay && !event.location.isNullOrBlank() && event.end.isAfter(19:00)`.
  Location-as-a-string stands in for "not at home" until a real
  home-location setting lands.
- The existing rule-6 daytime calendar tie-in
  (`Bring an umbrella for your 15:00 park run.`) is unaffected — it still
  runs against the unfiltered events list and the daytime precip peak.

### Known limitations

- `eventsForDay` is single-day, so a midnight–02:00 event that starts
  tomorrow isn't seen yet. Followup: union with tomorrow's events to
  cover the full 19:00 → 07:00 window.
- "Has a location" matches events whose location is literally `Home`
  until we add a real home-location setting. Acceptable for now.

### Out of scope

- A paired Day / Night icon pair on the home screen `OutfitSuggestion`
  card. The summary already carries the evening sentence; the glanceable
  card still shows a single outfit. Marked with a TODO on
  `OutfitSuggestion`.

## Test plan

- [ ] CI: `JVM unit tests` green (new `ForecastWindowTest`, plus new
      cases in `RenderInsightSummaryTest` and `GenerateDailyInsightTest`).
- [ ] CI: `Android debug build` green.
- [ ] On-device sniff: with calendar opt-in and a chilly evening, schedule
      an event 20:00–22:00 with a location → notification body ends with
      "Bring … for your 20:00 …".
- [ ] On-device sniff: same forecast, event has no location → no
      "Bring …" sentence.

> Note: I couldn't run `:core:domain:test` in the agent sandbox — the
> root build's AGP plugin can't resolve from Google Maven. Per CLAUDE.md
> CI is the validation surface.

---
_Generated by [Claude Code](https://claude.ai/code/session_016amo6FFnQGzn6UcH1C8BBg)_