### PR TITLE
:app — make aistudio.google.com link tappable in onboarding & settings

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/onboarding/OnboardingScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/onboarding/OnboardingScreen.kt
@@ -40,6 +40,7 @@ import app.clothescast.R
 import app.clothescast.core.domain.model.Location
 import app.clothescast.notification.NotificationPermission
 import app.clothescast.ui.settings.KeyEntryFields
+import app.clothescast.ui.settings.LinkifiedText
 import app.clothescast.ui.settings.LocationSearchDialog
 
 /**
@@ -331,7 +332,7 @@ private fun StepCard(
                     )
                 }
             }
-            Text(
+            LinkifiedText(
                 text = description,
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,

--- a/app/src/main/kotlin/app/clothescast/ui/settings/ApiKeysSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/ApiKeysSettings.kt
@@ -129,7 +129,7 @@ internal fun KeyEntryFields(
     onSave: (String) -> Unit,
     onClear: () -> Unit,
 ) {
-    Text(text = statusText, style = MaterialTheme.typography.bodyMedium)
+    LinkifiedText(text = statusText, style = MaterialTheme.typography.bodyMedium)
 
     var input by remember { mutableStateOf("") }
     OutlinedTextField(

--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsCommon.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsCommon.kt
@@ -10,13 +10,24 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material3.Card
 import androidx.compose.material3.Icon
+import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.LinkAnnotation
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextLinkStyles
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.withLink
 import androidx.compose.ui.unit.dp
 
 @Composable
@@ -86,6 +97,47 @@ internal fun SettingsNavRow(
             )
         }
     }
+}
+
+private const val AISTUDIO_HOST = "aistudio.google.com"
+private const val AISTUDIO_URL = "https://aistudio.google.com/"
+
+/**
+ * Plain Text replacement that turns the literal "aistudio.google.com" inside the
+ * supplied string into a clickable link. The Gemini-key copy in onboarding and
+ * settings mentions the URL inline; rendering it as a tappable link saves the
+ * user from typing it into a browser.
+ */
+@Composable
+internal fun LinkifiedText(
+    text: String,
+    modifier: Modifier = Modifier,
+    style: TextStyle = LocalTextStyle.current,
+    color: Color = Color.Unspecified,
+) {
+    val linkColor = MaterialTheme.colorScheme.primary
+    val annotated = remember(text, linkColor) {
+        val idx = text.indexOf(AISTUDIO_HOST)
+        if (idx < 0) {
+            AnnotatedString(text)
+        } else {
+            buildAnnotatedString {
+                append(text, 0, idx)
+                val link = LinkAnnotation.Url(
+                    url = AISTUDIO_URL,
+                    styles = TextLinkStyles(
+                        style = SpanStyle(
+                            color = linkColor,
+                            textDecoration = TextDecoration.Underline,
+                        ),
+                    ),
+                )
+                withLink(link) { append(AISTUDIO_HOST) }
+                append(text, idx + AISTUDIO_HOST.length, text.length)
+            }
+        }
+    }
+    Text(text = annotated, modifier = modifier, style = style, color = color)
 }
 
 internal fun openUrl(context: android.content.Context, url: String) {


### PR DESCRIPTION
## Summary

The Gemini-key copy in onboarding (`onboarding_gemini_description`) and in the
API-keys settings page (`settings_api_key_status_unset`) mentions
`aistudio.google.com` inline, but it rendered as plain text — users had to
copy/type it into a browser to actually get a key.

- Add a small `LinkifiedText` composable in `SettingsCommon.kt` that finds the
  literal `aistudio.google.com` substring in the supplied text and wraps it in
  a `LinkAnnotation.Url("https://aistudio.google.com/")`. Compose 1.7's
  `Text(AnnotatedString)` handles the click via `LocalUriHandler`.
- Use `LinkifiedText` in `StepCard`'s description (onboarding) and in
  `KeyEntryFields`'s status text (settings). Helper is a no-op when the
  substring is absent, so it applies safely to OpenAI / ElevenLabs status text
  too.

## Test plan

- [ ] CI: `JVM unit tests` + `Android debug build` pass (no Android SDK in
  sandbox; relying on CI per `CLAUDE.md`).
- [ ] Manual on-device: open onboarding with no Gemini key configured; verify
  "aistudio.google.com" in the description is underlined / primary-colored and
  tapping it opens the AI Studio site in a browser.
- [ ] Manual on-device: Settings → API keys → Gemini (unconfigured); verify
  the link in the status line is tappable.
- [ ] Visual check that the OpenAI / ElevenLabs status text is unchanged
  (no link, identical layout).

---
_Generated by [Claude Code](https://claude.ai/code/session_01WkX9hWsgMG1Wo2NgYMy3vp)_