### PR TITLE
:app — wrap day-of-week chips on Schedule screen

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/settings/ScheduleSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/ScheduleSettings.kt
@@ -2,6 +2,8 @@ package app.clothescast.ui.settings
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
@@ -74,7 +76,7 @@ internal fun ScheduleContent(
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
 private fun ScheduleCard(
     time: LocalTime,
@@ -102,9 +104,10 @@ private fun ScheduleCard(
             text = stringResource(R.string.settings_schedule_days_label),
             style = MaterialTheme.typography.bodyMedium,
         )
-        Row(
+        FlowRow(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.spacedBy(4.dp),
+            verticalArrangement = Arrangement.spacedBy(4.dp),
         ) {
             DayOfWeek.entries.forEach { dow ->
                 val selected = dow in days


### PR DESCRIPTION
## Summary

The day-of-week chips (Mon–Sun) on the Schedule screen were laid out in a single `Row`. On narrow phones the row didn't fit, so the trailing chip ("Sun") got clipped at the screen edge — see screenshot in the original report where Fri/Sat/Sun show only a check mark.

Switched to `FlowRow` so the chips overflow onto a second line instead of being truncated. `FlowRow` is still flagged `@ExperimentalLayoutApi` in Compose foundation 1.7.6 (Compose BOM 2024.12.01), so `ScheduleCard` opts in to the layout API alongside its existing `ExperimentalMaterial3Api` opt-in.

Kept the existing 4.dp horizontal spacing and added matching 4.dp vertical spacing for when chips wrap.

## Test plan

- [ ] CI: JVM unit tests + Android debug build green
- [ ] Visual: open Schedule screen on a narrow phone (≤360dp width) — all seven chips visible, wrapping to a second line if needed
- [ ] Visual: on a wider phone the chips still fit on one line as before
- [ ] Functional: tapping any chip still toggles the day; selected day chips show the check leading icon

---
_Generated by [Claude Code](https://claude.ai/code/session_01U6FDh7uL9fFgsTTXhKwQWb)_