### PR TITLE
ci — auto-publish release AAB to Play Store internal track

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,6 +243,7 @@ jobs:
     env:
       FIREBASE_APP_ID: ${{ secrets.FIREBASE_APP_ID }}
       FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+      PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -423,16 +424,65 @@ jobs:
           ./gradlew :app:bundleRelease --stacktrace --info 2>&1 | tee -a /tmp/android-build.log
 
       - name: Upload release AAB
-        # Browser-downloadable artifact for manual upload to Play Console (no API
-        # exists to *create* a Play app, so the first upload is browser-only;
-        # subsequent uploads can be automated in a follow-up PR via
-        # r0adkll/upload-google-play once the app shell exists).
+        # Browser-downloadable artifact for manual upload to Play Console — kept
+        # even after the auto-upload step below so the AAB is recoverable if the
+        # Play upload fails (or for ad-hoc browser uploads to other tracks).
         if: github.event_name == 'push' && github.ref == 'refs/heads/main' && success()
         uses: actions/upload-artifact@v4
         with:
           name: app-release-aab
           path: app/build/outputs/bundle/release/app-release.aab
           retention-days: 14
+
+      - name: Prepare Play release notes
+        # Play Console accepts per-locale "what's new" files in a directory,
+        # each capped at 500 chars. Write the head-commit subject + build
+        # metadata into whatsnew-en-US so internal testers see what changed.
+        # Skipped when the Play secret isn't set, so a fresh repo / fork still
+        # finishes CI without this step.
+        if: |
+          success() &&
+          github.event_name == 'push' &&
+          github.ref == 'refs/heads/main' &&
+          env.PLAY_SERVICE_ACCOUNT_JSON != ''
+        env:
+          # Pass the commit message via env rather than direct GHA expression
+          # interpolation so quotes / backticks in the subject can't break the
+          # shell script.
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+          RUN_NUMBER: ${{ github.run_number }}
+          COMMIT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/whatsnew"
+          subject=$(printf '%s\n' "$COMMIT_MESSAGE" | head -n1)
+          {
+            printf '%s\n\n' "$subject"
+            printf 'Build %s · %s\n' "$RUN_NUMBER" "${COMMIT_SHA:0:7}"
+          } | head -c 500 > "$RUNNER_TEMP/whatsnew/whatsnew-en-US"
+
+      - name: Upload AAB to Play Store internal track
+        # Push-to-main only; skipped when PLAY_SERVICE_ACCOUNT_JSON isn't set so
+        # a fresh repo / fork still completes CI. Ordered AFTER the release-AAB
+        # artifact upload so a Play API failure (e.g. listing not yet approved,
+        # versionCode collision) doesn't gate the artifact behind `success()`.
+        # Pinned to the v1.1.5 commit SHA — bump deliberately.
+        if: |
+          success() &&
+          github.event_name == 'push' &&
+          github.ref == 'refs/heads/main' &&
+          env.PLAY_SERVICE_ACCOUNT_JSON != ''
+        uses: r0adkll/upload-google-play@e738b9dd8f2476ea806d921b64aacd24f34515a5 # v1.1.5
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
+          packageName: app.clothescast
+          releaseFiles: app/build/outputs/bundle/release/app-release.aab
+          track: internal
+          # `completed` makes the build immediately available to internal
+          # testers; `draft` would require a manual click in Play Console for
+          # every push.
+          status: completed
+          whatsNewDirectory: ${{ runner.temp }}/whatsnew
 
       - name: Clear prior CI comments for this job
         # Same rationale as the JVM job — drops stale failure comments on a

--- a/docs/play-store-internal-testing.md
+++ b/docs/play-store-internal-testing.md
@@ -1,0 +1,110 @@
+# Play Store internal testing — auto-publish setup
+
+One-time Play Console + GitHub Secrets setup so every push to `main` produces a
+signed AAB that lands on the Play Store **Internal testing** track without you
+clicking anything in the Play Console.
+
+## What this gets you
+
+- Push to `main` → CI builds + signs the release AAB → uploads to Play Console
+  on the `internal` track with `status: completed` → testers in the internal
+  list get the new version on next Play Store check (typically minutes to a
+  few hours, depending on Play caching on each device).
+- Independent of Firebase App Distribution, which keeps shipping the **debug**
+  APK to the same testers via push notification — different signing key,
+  different package id (`app.clothescast.debug`), so the two coexist on the
+  same device.
+
+## Prerequisites
+
+- The Play Console app listing exists (you've created the app in Play Console
+  and uploaded a first AAB by hand at least once *or* the API call below
+  successfully creates the first internal-track release for you — Google has
+  flipped this requirement back and forth; in practice the very first upload
+  sometimes needs to be a manual browser upload).
+- Internal testing track has at least one tester email or list.
+- The upload AAB signing chain is set up (`UPLOAD_KEYSTORE_BASE64` + companion
+  secrets — see `app/build.gradle.kts` and the existing CI step). Play App
+  Signing re-signs with the actual signing key on download.
+
+## Setup checklist (one-time, ~15 minutes)
+
+### 1. Create a Google Cloud service account
+
+[console.cloud.google.com](https://console.cloud.google.com) → pick the
+project linked to your Play Console (Play Console → **Setup → API access**
+shows which GCP project, and lets you link one if none yet).
+
+- IAM & Admin → **Service Accounts → Create service account**.
+- Name: `play-publisher-ci` (anything sensible).
+- Skip the optional role-grant step — Play permissions are granted in Play
+  Console, not via GCP IAM.
+- Open the new service account → **Keys → Add key → Create new key → JSON**.
+  A JSON file downloads. Copy its entire contents (curly braces and all).
+  **Don't commit it.**
+
+### 2. Grant the service account release permission in Play Console
+
+Play Console → **Setup → API access**.
+
+- If you haven't already, click the prompt to **link** your GCP project. The
+  service account from step 1 should appear in the list.
+- Next to the service account, click **Grant access**.
+- App permissions: add this app (ClothesCast).
+- Account permissions: at minimum, **Release apps to testing tracks** and
+  **Release to production, exclude devices, and use Play App Signing**
+  (the latter is needed to upload AABs that Play re-signs). The "Admin (all
+  permissions)" preset also works but is more access than needed.
+- **Invite user** → **Send invite**. Permissions take effect within a minute.
+
+### 3. Add the GitHub Secret
+
+GitHub repo → **Settings → Secrets and variables → Actions → New repository
+secret**.
+
+| Name | Value |
+|---|---|
+| `PLAY_SERVICE_ACCOUNT_JSON` | The full JSON content from step 1 (paste the whole `{ … }` block). |
+
+### 4. Trigger a build
+
+Push any commit to `main` (or merge a PR). The CI run on `main` should now
+finish with an "Upload AAB to Play Store internal track" step. Watch for
+green.
+
+## Troubleshooting
+
+- **"Upload AAB to Play Store internal track" is skipped** → `PLAY_SERVICE_ACCOUNT_JSON`
+  isn't set, or you pushed to a feature branch (only `main` publishes).
+- **`APK specifies a version code that has already been used`** → Play
+  rejects re-uploads with the same `versionCode`. The repo derives
+  `versionCode` from `git rev-list --count HEAD`, so a force-push to `main`
+  that doesn't increase the count would collide. Land a real new commit.
+- **`The caller does not have permission`** → step 2 didn't take effect, or
+  the service account in step 1 doesn't match the one granted access. Check
+  Play Console → API access shows the same email as the JSON's
+  `client_email`.
+- **`Package not found: app.clothescast`** → Play Console listing doesn't
+  exist yet, or `applicationId` doesn't match. Verify in Play Console that
+  the package id is exactly `app.clothescast`.
+- **`Changes cannot be sent for review automatically`** → can happen on the
+  very first internal release if Play Console is mid-review of the listing.
+  Either wait for the listing review to complete, or set
+  `changesNotSentForReview: true` on the action (then push the green
+  "Send for review" button manually in Play Console once).
+
+## Relationship with Firebase App Distribution
+
+Both auto-publish on push to `main` and they're complementary, not redundant:
+
+| | Firebase App Distribution | Play Store internal track |
+|---|---|---|
+| What ships | debug APK (`app.clothescast.debug`) | release AAB (`app.clothescast`) |
+| Signing | debug keystore | upload key → Play App Signing |
+| Install path | App Tester app, push notification | Play Store, internal-testing opt-in URL |
+| Audience | engineers iterating on builds | shape-of-prod testing, store-flow QA |
+| Latency | ~30s after CI green | minutes to hours (Play cache) |
+
+If you only want one of them on a given push, the other can be disabled by
+removing the relevant secret — both steps no-op cleanly when their secret is
+unset.


### PR DESCRIPTION
## Summary

Now that the Play Console listing exists and accepts uploads, wire up
`r0adkll/upload-google-play` (pinned to v1.1.5 commit SHA
`e738b9d`) as a CI step after the existing release-AAB artifact upload.
Push-to-main only, gated on `PLAY_SERVICE_ACCOUNT_JSON` being set so a
fresh repo / fork still completes CI when the secret isn't present.

The release-AAB *artifact* upload is intentionally kept — useful for
recovering the build if a Play API call fails, and for ad-hoc uploads to
other tracks via browser.

Internal-track release notes come from the head commit's subject + run
number + short SHA, written into a per-locale `whatsnew-en-US` file capped
at Play's 500-char limit.

## One-time setup needed before this does anything

This step **silently no-ops until `PLAY_SERVICE_ACCOUNT_JSON` is set**.
Full instructions in `docs/play-store-internal-testing.md`. TL;DR:

1. GCP service account → JSON key.
2. Play Console → API access → grant the service account
   "Release apps to testing tracks" + "Release to production / use Play
   App Signing" on the ClothesCast app.
3. GitHub secret `PLAY_SERVICE_ACCOUNT_JSON` = the entire JSON contents.

The doc also covers the four failures that bite first-time uploads
(versionCode collision, package-name mismatch, permission propagation
delay, listing still mid-review).

## Coexistence with FAD

Firebase App Distribution keeps shipping the **debug** APK
(`app.clothescast.debug`) on every push to main; this adds a parallel
release-AAB pipeline (`app.clothescast`, Play App Signing). Different
package id and signing key, so both can sit on the same tester device.
Disabling either is a matter of removing the relevant secret — both
no-op cleanly when their secret is unset.

## Test plan

- [ ] CI green on this PR (Play upload step skipped because secret not yet
  set on PR-from-fork-style runs and on PR runs in general — the `if:`
  also gates on push-to-main).
- [ ] After merge: configure `PLAY_SERVICE_ACCOUNT_JSON`, push a trivial
  commit to main, watch CI's "Upload AAB to Play Store internal track"
  step succeed.
- [ ] Internal tester device picks up the build via Play Store within
  minutes to a few hours.
- [ ] Bump deliberately: when v1.1.6 of the action ships, update the
  pinned SHA + the `# v1.1.5` comment together.

https://claude.ai/code/session_01Eog1oUP4pq4mZYhgDRT42s


---
_Generated by [Claude Code](https://claude.ai/code/session_01Eog1oUP4pq4mZYhgDRT42s)_