### PR TITLE
:app — bigger notification icon, mirroring recommended top

### DIFF
--- a/app/src/main/kotlin/app/clothescast/notification/InsightNotifier.kt
+++ b/app/src/main/kotlin/app/clothescast/notification/InsightNotifier.kt
@@ -12,6 +12,7 @@ import androidx.core.content.ContextCompat
 import app.clothescast.MainActivity
 import app.clothescast.R
 import app.clothescast.core.domain.model.Insight
+import app.clothescast.core.domain.model.OutfitSuggestion
 
 /**
  * Posts the daily insight as a system notification. Tapping the notification opens
@@ -34,14 +35,14 @@ class InsightNotifier(private val context: Context) {
             PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
         )
 
-        // TODO(notification-figure): when [insight.outfit] is non-null, render the
+        // TODO(notification-figure): when [insight.outfit] is non-null, also render the
         // outfit icons (the same ic_outfit_* drawables the Today screen shows in
-        // OutfitPreviewCard) into a Bitmap sized for Notification.LARGE_ICON_SIZE
-        // and attach via .setLargeIcon(bitmap), so the notification carries the
-        // same glanceable "what to wear today" cue without the user having to
-        // open the app.
+        // OutfitPreviewCard) into a Bitmap sized for Notification.LARGE_ICON_SIZE and
+        // attach via .setLargeIcon(bitmap), so the expanded notification carries the
+        // same glanceable "what to wear today" cue the Today screen does. The small
+        // status-bar icon below already mirrors the recommended top.
         val notification = NotificationCompat.Builder(context, CHANNEL_DAILY_INSIGHT)
-            .setSmallIcon(R.drawable.ic_notification_insight)
+            .setSmallIcon(smallIconFor(insight.outfit?.top))
             .setContentTitle(context.getString(R.string.notification_daily_insight_title))
             .setContentText(insight.summary)
             .setStyle(NotificationCompat.BigTextStyle().bigText(insight.summary))
@@ -66,5 +67,16 @@ class InsightNotifier(private val context: Context) {
     companion object {
         const val NOTIFICATION_ID_DAILY_INSIGHT = 1001
         private const val REQUEST_OPEN_APP = 100
+
+        // The status-bar silhouette mirrors the recommended top so a glance at the
+        // notification shade already says "sweater day" / "jacket day" before the
+        // user reads anything. ic_notification_insight is itself a t-shirt silhouette,
+        // so it doubles as both the TSHIRT case and the null fallback (older cached
+        // insights without an outfit, weather alerts).
+        internal fun smallIconFor(top: OutfitSuggestion.Top?): Int = when (top) {
+            OutfitSuggestion.Top.SWEATER -> R.drawable.ic_notification_top_sweater
+            OutfitSuggestion.Top.THICK_JACKET -> R.drawable.ic_notification_top_thick_jacket
+            OutfitSuggestion.Top.TSHIRT, null -> R.drawable.ic_notification_insight
+        }
     }
 }

--- a/app/src/main/res/drawable/ic_notification_insight.xml
+++ b/app/src/main/res/drawable/ic_notification_insight.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-    Notification icons must be silhouetted: white-on-transparent. The system applies the
-    accent / channel colour at runtime. A t-shirt silhouette with a sun-shaped cutout in
-    the middle keeps the ClothesCast brand visible at status-bar sizes.
+    Default notification small icon: a plain t-shirt silhouette filling most of
+    the 24dp viewport, so it reads at the same visual weight as the other
+    status-bar icons (e.g. GitHub) instead of looking like a tiny speck.
+    Notification icons must be silhouetted: white-on-transparent. The system
+    applies the channel / accent colour at runtime. [InsightNotifier] swaps
+    this for a top-specific silhouette when an outfit is recommended; this
+    file remains the fallback (no outfit yet, weather alerts).
 -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
@@ -11,7 +15,5 @@
     android:viewportHeight="24">
     <path
         android:fillColor="#FFFFFF"
-        android:fillType="evenOdd"
-        android:pathData="M9.8,5.8 Q7.6,5.8 5.3,7.1 Q4,8.4 4,11.1 Q4.9,12.4 7.1,12 L6.7,20 Q12,20.7 17.3,20 L16.9,12 Q19.1,12.4 20,11.1 Q20,8.4 18.7,7.1 Q16.4,5.8 14.2,5.8 Q12,7.6 9.8,5.8 Z
-                         M12,13.8 m-2.5,0 a2.5,2.5 0 1,1 5,0 a2.5,2.5 0 1,1 -5,0" />
+        android:pathData="M10.5,4 L9,2 L1.5,5.5 L4,10 L6.5,9 L6.5,22 L17.5,22 L17.5,9 L20,10 L22.5,5.5 L15,2 L13.5,4 Q12,5 10.5,4 Z" />
 </vector>

--- a/app/src/main/res/drawable/ic_notification_top_sweater.xml
+++ b/app/src/main/res/drawable/ic_notification_top_sweater.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Notification small icon variant: sweater silhouette. Distinguished from
+    the t-shirt by a turtleneck collar (squared off above the shoulders) and
+    long sleeves with cuffs that drop further down the body. Used by
+    [InsightNotifier] when the recommended top is [OutfitSuggestion.Top.SWEATER].
+    Silhouette fills ~90% of the 24dp viewport so it reads at the same weight
+    as neighbouring status-bar icons.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M9,4 L9,1.5 L15,1.5 L15,4 L22.5,7 L21,18 L18,18 L17,11 L17,22 L7,22 L7,11 L6,18 L3,18 L1.5,7 Z" />
+</vector>

--- a/app/src/main/res/drawable/ic_notification_top_thick_jacket.xml
+++ b/app/src/main/res/drawable/ic_notification_top_thick_jacket.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Notification small icon variant: thick / puffy jacket silhouette. A hood
+    arc rises above the shoulders and the body is wider with longer sleeves
+    so it reads visibly bulkier than the sweater. Used by [InsightNotifier]
+    when the recommended top is [OutfitSuggestion.Top.THICK_JACKET]. Silhouette
+    fills ~92% of the 24dp viewport so it carries the same visual weight as
+    other status-bar icons.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M7.5,5.5 Q12,0.5 16.5,5.5 L23,7.5 L23,19 L18.5,19 L17.5,11 L17.5,22.5 L6.5,22.5 L6.5,11 L5.5,19 L1,19 L1,7.5 Z" />
+</vector>


### PR DESCRIPTION
## Summary

The status-bar small icon was a shrunken t-shirt-with-sun-cutout silhouette
that filled only ~67% of its 24dp viewport, so it read as a faint speck next
to denser neighbours like the GitHub icon. Two changes:

1. **Bigger:** drop the sun cutout and grow the silhouette to ~90% of the
   24dp viewport, so it carries the same visual weight as the GitHub icon
   and other neighbours in the status bar.
2. **Just the top, and the right top:** pick the silhouette to match the
   day's recommended top —
   - `TSHIRT` → t-shirt silhouette (also the fallback / weather-alert icon)
   - `SWEATER` → turtleneck + cuffed sleeves
   - `THICK_JACKET` → hooded, bulkier body
   so a glance at the notification shade already says "sweater day" /
   "jacket day" before the user reads the body.

The notification body's large icon (TODO in `InsightNotifier`) is a
separate concern — left as a follow-up.

## Test plan

- [ ] CI: JVM unit tests + Android debug build green
- [ ] Eyeball each variant on a phone: confirm small icon now reads at
      similar density to the GitHub icon
- [ ] Confirm sweater / jacket variants render with their distinctive
      silhouette in the shade (not just the t-shirt)
- [ ] Older cached insights (no outfit) still post with the t-shirt
      silhouette fallback
- [ ] Severe-weather alerts still post (also use the fallback icon)

Cannot run `:app:testDebugUnitTest` locally — Android Gradle plugin
artifact isn't reachable from this sandbox. Relying on CI.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GSbXzoCnXKrnxUYfsQvH8d)_