### PR TITLE
docs — PRIVACY: API keys use Tink + Keystore + DataStore, not EncryptedSharedPreferences

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -71,10 +71,12 @@ The source code is at <https://github.com/mikelward/clothescast>.
 ### API keys you provide
 
 - If you use online TTS, you supply your own Google Gemini, OpenAI,
-  and / or ElevenLabs API key. Keys are stored on your device using
-  Android's `EncryptedSharedPreferences` and are sent only to the
-  corresponding provider on requests you initiate. They are never
-  shared with us or any third party.
+  and / or ElevenLabs API key. Keys are stored on your device encrypted
+  at rest — the ciphertext lives in Android's DataStore Preferences and
+  is wrapped by a Tink AEAD primitive whose own keyset is sealed by an
+  Android Keystore master key. Keys are sent only to the corresponding
+  provider on requests you initiate, and are never shared with us or
+  any third party.
 
 ## Third-party services
 


### PR DESCRIPTION
## Summary

The "API keys you provide" paragraph in PRIVACY.md said keys are stored using Android's `EncryptedSharedPreferences`. That hasn't been true since the key store was introduced — `SecureKeyStore.kt` uses **Tink AEAD + Android Keystore master key + DataStore Preferences**, and its own KDoc (lines 24-30) explicitly notes that `EncryptedSharedPreferences` is deprecated as of `androidx.security:security-crypto 1.1.0-alpha07` and that "Tink + DataStore is its modern replacement."

This is a privacy-policy-on-the-Play-Store-listing doc, so it's worth getting right.

## Changes

- One paragraph in PRIVACY.md: replace the `EncryptedSharedPreferences` claim with the actual storage chain (Tink AEAD + Keystore-sealed keyset + DataStore Preferences).
- "Last updated" date already today (2026-04-27); no bump needed.

## Test plan

- [ ] Eyeball the rendered paragraph in the PR diff.
- [ ] Confirm the wording matches what `SecureKeyStore.kt:21-44` describes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UZySZC1V4eYdsiQgcp6BLr)_