### PR TITLE
:app + :core:data — full-day hourly + feels-like-by-default chart

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/today/ForecastChart.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/ForecastChart.kt
@@ -22,7 +22,11 @@ import com.patrykandpatrick.vico.core.cartesian.data.CartesianValueFormatter
 import com.patrykandpatrick.vico.core.cartesian.data.lineSeries
 
 /**
- * Renders today's hourly temperature and feels-like as two lines.
+ * Renders today's hourly temperature as a single line — feels-like or raw 2 m
+ * air, controlled by [showFeelsLike]. Defaults to feels-like because that's
+ * what the wardrobe rules and band sentence ("Today will be cool to mild")
+ * are evaluated against; surfacing the raw line by default invited "which
+ * line is which?" confusion. The parent toggles which series is shown.
  *
  * The hourly list is sourced from the cached Insight, populated by the morning
  * worker. When the cache predates this feature, [hourly] is empty and the chart
@@ -32,27 +36,23 @@ import com.patrykandpatrick.vico.core.cartesian.data.lineSeries
  * we convert at the edge with [toUnit] so the chart matches the user's
  * temperatureUnit preference. The legend, rendered by the parent, carries the
  * unit symbol — the axis stays unitless to avoid "10°C, 15°C, 20°C" repetition.
- *
- * Series order:
- *   0 — raw 2 m air temperature
- *   1 — apparent / feels-like
- * Drawn in that order so feels-like sits on top, matching what the wardrobe
- * rules actually evaluate against.
  */
 @Composable
 fun ForecastChart(
     hourly: List<HourlyForecast>,
     temperatureUnit: TemperatureUnit,
+    showFeelsLike: Boolean,
     modifier: Modifier = Modifier,
 ) {
     if (hourly.isEmpty()) return
 
     val producer = remember { CartesianChartModelProducer() }
-    LaunchedEffect(hourly, temperatureUnit) {
+    LaunchedEffect(hourly, temperatureUnit, showFeelsLike) {
         producer.runTransaction {
             lineSeries {
-                series(hourly.map { it.temperatureC.toUnit(temperatureUnit) })
-                series(hourly.map { it.feelsLikeC.toUnit(temperatureUnit) })
+                val pick: (HourlyForecast) -> Double =
+                    if (showFeelsLike) { h -> h.feelsLikeC } else { h -> h.temperatureC }
+                series(hourly.map { pick(it).toUnit(temperatureUnit) })
             }
         }
     }

--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
@@ -1,6 +1,7 @@
 package app.clothescast.ui.today
 
 import android.widget.Toast
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -26,6 +27,10 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.foundation.Image
@@ -46,11 +51,13 @@ import app.clothescast.core.domain.model.Insight
 import app.clothescast.core.domain.model.OutfitSuggestion
 import app.clothescast.core.domain.model.TemperatureUnit
 import app.clothescast.core.domain.model.symbol
+import app.clothescast.core.domain.model.toUnit
 import app.clothescast.work.FetchAndNotifyWorker
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
 import java.util.Locale
+import kotlin.math.roundToInt
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -357,7 +364,25 @@ internal fun ConfidenceChip(info: ConfidenceInfo) {
 
 @Composable
 private fun ForecastCard(hourly: List<HourlyForecast>, temperatureUnit: TemperatureUnit) {
-    Card(modifier = Modifier.fillMaxWidth()) {
+    // Default to feels-like — matches the band classification the user sees in the
+    // summary sentence. Tap anywhere on the card to flip to raw 2 m air, which is
+    // typically what other weather apps lead with. We surface min/max for both
+    // either way so the comparison is always visible without a tap.
+    var showFeelsLike by rememberSaveable { mutableStateOf(true) }
+
+    val symbol = temperatureUnit.symbol()
+    val feelsLikeMinMax = remember(hourly, temperatureUnit) {
+        formatMinMax(hourly.map { it.feelsLikeC }, temperatureUnit)
+    }
+    val airMinMax = remember(hourly, temperatureUnit) {
+        formatMinMax(hourly.map { it.temperatureC }, temperatureUnit)
+    }
+
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { showFeelsLike = !showFeelsLike },
+    ) {
         Column(
             modifier = Modifier.padding(20.dp),
             verticalArrangement = Arrangement.spacedBy(8.dp),
@@ -366,14 +391,39 @@ private fun ForecastCard(hourly: List<HourlyForecast>, temperatureUnit: Temperat
                 text = stringResource(R.string.today_forecast_title),
                 style = MaterialTheme.typography.titleSmall,
             )
-            ForecastChart(hourly = hourly, temperatureUnit = temperatureUnit)
+            if (feelsLikeMinMax != null && airMinMax != null) {
+                Text(
+                    text = stringResource(
+                        R.string.today_forecast_min_max,
+                        feelsLikeMinMax.first, feelsLikeMinMax.second, symbol,
+                        airMinMax.first, airMinMax.second, symbol,
+                    ),
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+            }
+            ForecastChart(
+                hourly = hourly,
+                temperatureUnit = temperatureUnit,
+                showFeelsLike = showFeelsLike,
+            )
+            val legendRes = if (showFeelsLike) {
+                R.string.today_forecast_legend_feels_like
+            } else {
+                R.string.today_forecast_legend_air
+            }
             Text(
-                text = stringResource(R.string.today_forecast_legend, temperatureUnit.symbol()),
+                text = stringResource(legendRes, symbol),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
     }
+}
+
+private fun formatMinMax(values: List<Double>, unit: TemperatureUnit): Pair<Int, Int>? {
+    if (values.isEmpty()) return null
+    val converted = values.map { it.toUnit(unit) }
+    return converted.min().roundToInt() to converted.max().roundToInt()
 }
 
 private fun triggerRefresh(context: android.content.Context) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,7 +19,9 @@
     <string name="today_outfit_bottom_long_pants">Long pants</string>
 
     <string name="today_forecast_title">Hourly forecast</string>
-    <string name="today_forecast_legend">Temperature and feels-like (%1$s) by hour</string>
+    <string name="today_forecast_min_max">Feels like %1$d – %2$d%3$s · Air %4$d – %5$d%6$s</string>
+    <string name="today_forecast_legend_feels_like">Feels-like (%1$s) by hour · tap to switch to air temperature</string>
+    <string name="today_forecast_legend_air">Air temperature (%1$s) by hour · tap to switch to feels-like</string>
 
     <string name="today_confidence_high">High confidence — major models agree</string>
     <string name="today_confidence_medium">Medium confidence</string>

--- a/core/data/src/main/kotlin/app/clothescast/core/data/weather/OpenMeteoClient.kt
+++ b/core/data/src/main/kotlin/app/clothescast/core/data/weather/OpenMeteoClient.kt
@@ -17,9 +17,15 @@ import kotlinx.coroutines.coroutineScope
 internal const val OPEN_METEO_HOST = "api.open-meteo.com"
 
 /**
- * Open-Meteo `forecast` endpoint with past_days=1&forecast_days=1, returning yesterday's
- * actuals plus today's forecast in one call. Free, key-less. Free-tier soft cap is 10k
- * requests/day; this app makes one call per device per day.
+ * Open-Meteo `forecast` endpoint with past_days=1&forecast_days=2, returning yesterday's
+ * actuals plus today's and tomorrow's forecast in one call. Free, key-less. Free-tier
+ * soft cap is 10k requests/day; this app makes one call per device per day.
+ *
+ * `forecast_days=2` (not 1) so the hourly array reliably covers all 24 hours of today
+ * regardless of when in the day the worker fires. With `forecast_days=1` Open-Meteo's
+ * hourly window stops short of end-of-day for late-morning calls — the chart was
+ * truncating at "now" instead of showing the full afternoon. Tomorrow's hourly
+ * entries are filtered out by date in the mapper before the today forecast is built.
  *
  * Severe-weather alerts come from a second `/v1/warnings` call. The warnings endpoint
  * is best-effort: if it fails (4xx, 5xx, network), we return the forecast with an empty
@@ -62,7 +68,7 @@ class OpenMeteoClient(private val httpClient: HttpClient) : WeatherRepository {
             parameter("latitude", location.latitude)
             parameter("longitude", location.longitude)
             parameter("past_days", 1)
-            parameter("forecast_days", 1)
+            parameter("forecast_days", 2)
             parameter("timezone", "auto")
             parameter(
                 "daily",

--- a/core/data/src/main/kotlin/app/clothescast/core/data/weather/OpenMeteoMapper.kt
+++ b/core/data/src/main/kotlin/app/clothescast/core/data/weather/OpenMeteoMapper.kt
@@ -8,10 +8,12 @@ import java.time.LocalDateTime
 import java.time.LocalTime
 
 /**
- * Maps an [OpenMeteoResponse] (queried with past_days=1&forecast_days=1) into a
- * [ForecastBundle]. Index 0 in the daily arrays is yesterday, index 1 is today.
- * The hourly stream covers both days; we only attach today's hours to the today
- * forecast (yesterday's hourlies are not needed by the prompt).
+ * Maps an [OpenMeteoResponse] (queried with past_days=1&forecast_days=2) into a
+ * [ForecastBundle]. Index 0 in the daily arrays is yesterday, index 1 is today;
+ * tomorrow (index 2) is fetched only so the hourly stream reliably reaches end of
+ * today, and is otherwise discarded. The hourly stream covers all three days; we
+ * filter to today's date for the today forecast (yesterday's and tomorrow's
+ * hourlies are not needed downstream).
  */
 internal object OpenMeteoMapper {
     fun toBundle(response: OpenMeteoResponse): ForecastBundle {

--- a/core/data/src/test/kotlin/app/clothescast/core/data/weather/OpenMeteoClientTest.kt
+++ b/core/data/src/test/kotlin/app/clothescast/core/data/weather/OpenMeteoClientTest.kt
@@ -92,7 +92,7 @@ class OpenMeteoClientTest {
         params["latitude"] shouldBe "51.5074"
         params["longitude"] shouldBe "-0.1278"
         params["past_days"] shouldBe "1"
-        params["forecast_days"] shouldBe "1"
+        params["forecast_days"] shouldBe "2"
         params["timezone"] shouldBe "auto"
 
         val daily = checkNotNull(params["daily"]).split(",")

--- a/core/data/src/test/kotlin/app/clothescast/core/data/weather/OpenMeteoMapperTest.kt
+++ b/core/data/src/test/kotlin/app/clothescast/core/data/weather/OpenMeteoMapperTest.kt
@@ -8,6 +8,7 @@ import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
 import java.time.LocalTime
+import java.util.Locale
 
 class OpenMeteoMapperTest {
     private val json = Json { ignoreUnknownKeys = true }
@@ -73,6 +74,44 @@ class OpenMeteoMapperTest {
         peak!!.time shouldBe LocalTime.of(15, 0)
         peak.precipitationProbabilityPct shouldBe 60.0
         peak.condition shouldBe WeatherCondition.RAIN
+    }
+
+    @Test
+    fun `today hourly stays full when response includes a tomorrow day`() {
+        // Pinned by the forecast_days=2 request. Open-Meteo's hourly window for
+        // forecast_days=1 was stopping short of end-of-today on late-morning calls;
+        // bumping to 2 guarantees today's full 24 hours regardless of clock time.
+        // The mapper must keep ignoring tomorrow's daily slot and keep date-filtering
+        // tomorrow's hourly entries out of today.
+        val threeDay = OpenMeteoResponse(
+            timezone = "UTC",
+            daily = DailyData(
+                time = listOf("2026-04-24", "2026-04-25", "2026-04-26"),
+                temperatureMin = listOf(12.0, 16.0, 14.0),
+                temperatureMax = listOf(18.0, 24.0, 22.0),
+                feelsLikeMin = listOf(10.0, 15.0, 13.0),
+                feelsLikeMax = listOf(17.0, 23.0, 21.0),
+                precipitationProbabilityMax = listOf(5, 60, 10),
+                precipitationSum = listOf(0.0, 4.5, 0.0),
+                weatherCode = listOf(2, 63, 1),
+            ),
+            hourly = HourlyData(
+                time = (0..23).map { String.format(Locale.ROOT, "2026-04-25T%02d:00", it) } +
+                    listOf("2026-04-26T00:00", "2026-04-26T01:00"),
+                temperature = (0..23).map { 16.0 + it } + listOf(14.0, 14.5),
+                feelsLike = (0..23).map { 15.0 + it } + listOf(13.0, 13.5),
+                precipitationProbability = (0..25).map { 0 },
+                weatherCode = (0..25).map { 0 },
+            ),
+        )
+
+        val today = OpenMeteoMapper.toBundle(threeDay).today
+
+        today.date shouldBe LocalDate.of(2026, 4, 25)
+        today.temperatureMaxC shouldBe 24.0
+        today.hourly shouldHaveSize 24
+        today.hourly.first().time shouldBe LocalTime.of(0, 0)
+        today.hourly.last().time shouldBe LocalTime.of(23, 0)
     }
 
     @Test


### PR DESCRIPTION
Reported in conversation: with a "forecast high of 21°C" the Today screen
was reading "cold to cool" and the chart was visibly stopping at the
current hour (e.g. 09:00) — both lines barely above 12°C, the afternoon
gone. Two separate bugs feeding one symptom; one commit each.

## 1. `:core:data` — `forecast_days=2`

With `past_days=1&forecast_days=1`, Open-Meteo's hourly window for late-
morning calls was stopping short of end-of-today, so the cached `hourly`
list only contained the morning hours already elapsed. Bumping to
`forecast_days=2` extends the window through tomorrow; the existing
date-filter in `OpenMeteoMapper.forDate` keeps tomorrow's entries out of
today's slot.

A new `OpenMeteoMapperTest` case constructs a 3-day response (yesterday
+ today + tomorrow with bleed-over hourly entries) and verifies today
still gets all 24 hours. `OpenMeteoClientTest` updated to expect
`forecast_days=2` on the request.

## 2. `:app` — feels-like by default, tap to swap, min/max readout

The two-line chart had no key telling you which series was air temp and
which was feels-like — the band sentence ("Today will be cool to mild")
classifies on feels-like, but the eye-catching peak on the chart was
typically the raw line, so the two read as unrelated.

- Chart now renders a single line, defaulting to feels-like (matches the
  band sentence).
- Tapping the card flips to raw 2 m air; the legend hint surfaces the
  affordance ("…by hour · tap to switch to air temperature").
- A `Feels like A – B°C · Air C – D°C` readout sits above the chart in
  both modes so the comparison stays visible without a tap.

Min/max are reduced from the cached hourly stream so they line up with
the chart line. Open-Meteo's daily-endpoint values can sit a tick above
hourly snapshots (sub-hourly resolution); plumbing those through the
Insight cache is deferred to a follow-up if the rounding gap turns out
to bother anyone.

## Test plan

- [ ] `:core:domain:test` and `:core:data:test` pass on CI (couldn't run
  `:core:data` locally — Google Maven blocked in sandbox).
- [ ] `:app:assembleDebug` passes on CI.
- [ ] Manually verify on device: chart fills the 24-hour x-axis after
  the morning worker runs (was truncating at "now" before).
- [ ] Manually verify: default view is single feels-like line; tapping
  the forecast card swaps to air temp and the legend updates.
- [ ] Manually verify: min/max readout shows both feels-like and air
  values and survives device rotation (`rememberSaveable`).
- [ ] Eyeball Roborazzi previews — none changed; `ForecastCard` isn't
  in the snapshot set yet.

https://claude.ai/code/session_01CSXBC84NoUHQMqnttvJyEP

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSXBC84NoUHQMqnttvJyEP)_