### PR TITLE
:app + :core — tonight insight at 7pm with event-aware silent / default notifications

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -61,6 +61,7 @@
             android:exported="false">
             <intent-filter>
                 <action android:name="app.clothescast.alarm.FIRE" />
+                <action android:name="app.clothescast.alarm.FIRE_TONIGHT" />
             </intent-filter>
         </receiver>
 

--- a/app/src/main/kotlin/app/clothescast/ClothesCastApplication.kt
+++ b/app/src/main/kotlin/app/clothescast/ClothesCastApplication.kt
@@ -9,6 +9,7 @@ import app.clothescast.core.data.tts.ElevenLabsTtsClient
 import app.clothescast.core.data.tts.GeminiTtsClient
 import app.clothescast.core.data.tts.OpenAITtsClient
 import app.clothescast.core.data.weather.OpenMeteoClient
+import app.clothescast.core.domain.model.ForecastPeriod
 import app.clothescast.core.domain.repository.CalendarEventReader
 import app.clothescast.core.domain.repository.WeatherRepository
 import app.clothescast.core.domain.usecase.GenerateDailyInsight
@@ -18,6 +19,7 @@ import app.clothescast.data.SettingsRepository
 import app.clothescast.location.LocationResolver
 import app.clothescast.notification.InsightNotifier
 import app.clothescast.notification.NotificationChannelRegistrar
+import app.clothescast.notification.TonightInsightNotifier
 import app.clothescast.notification.WeatherAlertNotifier
 import app.clothescast.tts.AndroidTtsSpeaker
 import app.clothescast.tts.TtsSpeaker
@@ -48,6 +50,7 @@ class ClothesCastApplication : Application() {
     val insightCache: InsightCache by lazy { InsightCache.create(this) }
     val locationResolver: LocationResolver by lazy { LocationResolver(this) }
     val insightNotifier: InsightNotifier by lazy { InsightNotifier(this) }
+    val tonightInsightNotifier: TonightInsightNotifier by lazy { TonightInsightNotifier(this) }
     val weatherAlertNotifier: WeatherAlertNotifier by lazy { WeatherAlertNotifier(this) }
     val dailyAlarmScheduler: DailyAlarmScheduler by lazy { DailyAlarmScheduler(this) }
     val deviceTtsSpeaker: TtsSpeaker by lazy { AndroidTtsSpeaker(this) }
@@ -85,8 +88,13 @@ class ClothesCastApplication : Application() {
         NotificationChannelRegistrar.register(this)
         applicationScope.launch {
             try {
-                val schedule = settingsRepository.preferences.first().schedule
-                dailyAlarmScheduler.schedule(schedule)
+                val prefs = settingsRepository.preferences.first()
+                dailyAlarmScheduler.schedule(prefs.schedule, ForecastPeriod.TODAY)
+                if (prefs.tonightEnabled) {
+                    dailyAlarmScheduler.schedule(prefs.tonightSchedule, ForecastPeriod.TONIGHT)
+                } else {
+                    dailyAlarmScheduler.cancel(ForecastPeriod.TONIGHT)
+                }
             } catch (t: Throwable) {
                 Log.e(TAG, "Initial alarm scheduling failed", t)
             }

--- a/app/src/main/kotlin/app/clothescast/MainActivity.kt
+++ b/app/src/main/kotlin/app/clothescast/MainActivity.kt
@@ -104,6 +104,7 @@ private fun ClothesCastNav(app: ClothesCastApplication) {
                     settingsRepository = app.settingsRepository,
                     keyStore = app.secureKeyStore,
                     rearmAlarm = app.dailyAlarmScheduler::schedule,
+                    cancelAlarm = app.dailyAlarmScheduler::cancel,
                     geocodingClient = app.geocodingClient,
                 ),
             )

--- a/app/src/main/kotlin/app/clothescast/alarm/AlarmReceiver.kt
+++ b/app/src/main/kotlin/app/clothescast/alarm/AlarmReceiver.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.Intent
 import android.util.Log
 import app.clothescast.ClothesCastApplication
+import app.clothescast.core.domain.model.ForecastPeriod
 import app.clothescast.work.FetchAndNotifyWorker
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -13,30 +14,43 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 
 /**
- * Fires when the daily-insight alarm goes off. The receiver does two things:
+ * Fires when an insight alarm goes off. Two actions arrive on this receiver:
  *
+ *  - [ACTION_FIRE]         — the morning ([ForecastPeriod.TODAY]) alarm
+ *  - [ACTION_FIRE_TONIGHT] — the evening ([ForecastPeriod.TONIGHT]) alarm
+ *
+ * For each, the receiver:
  * 1. Enqueues a WorkManager OneTimeWorkRequest ([FetchAndNotifyWorker]) which actually
- *    does the fetch + Gemini call + notification under network/retry constraints.
- * 2. Re-arms the alarm for the next day. Re-arming here (rather than only inside the
- *    Worker) keeps the alarm chain alive even if the Worker is permanently failing.
+ *    does the fetch + insight + notification under network/retry constraints.
+ * 2. Re-arms the same slot's alarm for the next day. Re-arming here (rather than only
+ *    inside the Worker) keeps the alarm chain alive even if the Worker is permanently
+ *    failing.
  */
 class AlarmReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
-        if (intent.action != ACTION_FIRE) return
-        Log.i(TAG, "AlarmReceiver fired (action=${intent.action})")
+        val period = when (intent.action) {
+            ACTION_FIRE -> ForecastPeriod.TODAY
+            ACTION_FIRE_TONIGHT -> ForecastPeriod.TONIGHT
+            else -> return
+        }
+        Log.i(TAG, "AlarmReceiver fired (action=${intent.action}, period=$period)")
 
         // Enqueue the Worker synchronously — it does its own off-thread work.
-        FetchAndNotifyWorker.enqueueOneShot(context.applicationContext)
+        FetchAndNotifyWorker.enqueueOneShot(context.applicationContext, period = period)
 
         val pending = goAsync()
         val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
         scope.launch {
             try {
                 val app = context.applicationContext as ClothesCastApplication
-                val schedule = app.settingsRepository.preferences.first().schedule
-                DailyAlarmScheduler(context.applicationContext).schedule(schedule)
+                val prefs = app.settingsRepository.preferences.first()
+                val schedule = when (period) {
+                    ForecastPeriod.TODAY -> prefs.schedule
+                    ForecastPeriod.TONIGHT -> prefs.tonightSchedule
+                }
+                DailyAlarmScheduler(context.applicationContext).schedule(schedule, period)
             } catch (t: Throwable) {
-                Log.e(TAG, "Re-arm failed", t)
+                Log.e(TAG, "Re-arm failed for $period", t)
             } finally {
                 pending.finish()
             }
@@ -45,6 +59,7 @@ class AlarmReceiver : BroadcastReceiver() {
 
     companion object {
         const val ACTION_FIRE = "app.clothescast.alarm.FIRE"
+        const val ACTION_FIRE_TONIGHT = "app.clothescast.alarm.FIRE_TONIGHT"
         private const val TAG = "AlarmReceiver"
     }
 }

--- a/app/src/main/kotlin/app/clothescast/alarm/AlarmReceiver.kt
+++ b/app/src/main/kotlin/app/clothescast/alarm/AlarmReceiver.kt
@@ -35,22 +35,37 @@ class AlarmReceiver : BroadcastReceiver() {
         }
         Log.i(TAG, "AlarmReceiver fired (action=${intent.action}, period=$period)")
 
-        // Enqueue the Worker synchronously — it does its own off-thread work.
-        FetchAndNotifyWorker.enqueueOneShot(context.applicationContext, period = period)
-
         val pending = goAsync()
         val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
         scope.launch {
+            val appCtx = context.applicationContext
+            val app = appCtx as ClothesCastApplication
+            val scheduler = DailyAlarmScheduler(appCtx)
             try {
-                val app = context.applicationContext as ClothesCastApplication
                 val prefs = app.settingsRepository.preferences.first()
+                if (period == ForecastPeriod.TONIGHT && !prefs.tonightEnabled) {
+                    // The user disabled tonight after this alarm was already armed.
+                    // Cancel any future tonight alarm (belt-and-braces: SettingsViewModel
+                    // already cancels on toggle-off, but a stale OS-scheduled alarm or a
+                    // failed cancel would otherwise keep us re-arming forever) and skip
+                    // the worker enqueue so we don't pay alarm + work overhead daily.
+                    Log.i(TAG, "Tonight alarm fired but tonight is disabled; cancelling and not re-arming.")
+                    scheduler.cancel(ForecastPeriod.TONIGHT)
+                    return@launch
+                }
+                FetchAndNotifyWorker.enqueueOneShot(appCtx, period = period)
                 val schedule = when (period) {
                     ForecastPeriod.TODAY -> prefs.schedule
                     ForecastPeriod.TONIGHT -> prefs.tonightSchedule
                 }
-                DailyAlarmScheduler(context.applicationContext).schedule(schedule, period)
+                scheduler.schedule(schedule, period)
             } catch (t: Throwable) {
                 Log.e(TAG, "Re-arm failed for $period", t)
+                // Best-effort: still enqueue the worker even if pref read failed,
+                // so the user gets *something* if it's the morning slot.
+                if (period == ForecastPeriod.TODAY) {
+                    FetchAndNotifyWorker.enqueueOneShot(appCtx, period = period)
+                }
             } finally {
                 pending.finish()
             }

--- a/app/src/main/kotlin/app/clothescast/alarm/DailyAlarmScheduler.kt
+++ b/app/src/main/kotlin/app/clothescast/alarm/DailyAlarmScheduler.kt
@@ -7,6 +7,7 @@ import android.content.Intent
 import android.os.Build
 import android.util.Log
 import androidx.core.content.getSystemService
+import app.clothescast.core.domain.model.ForecastPeriod
 import app.clothescast.core.domain.model.Schedule
 import java.time.Clock
 import java.time.Instant
@@ -14,6 +15,11 @@ import java.time.Instant
 /**
  * Schedules an exact wake-up at the next occurrence of [Schedule]. Wraps AlarmManager
  * so the receiver code stays small and so we can stub the manager in tests.
+ *
+ * Two slots are supported via [ForecastPeriod]: the morning ([ForecastPeriod.TODAY])
+ * insight at the user's wake-up time, and the evening ([ForecastPeriod.TONIGHT])
+ * insight at the user's evening time. Each slot has its own request code + receiver
+ * action so AlarmManager keeps them independent and the receiver can route by action.
  *
  * Design choices:
  * - `setExactAndAllowWhileIdle` is the only primitive that fires at a precise wall-clock
@@ -29,14 +35,14 @@ class DailyAlarmScheduler(
     private val context: Context,
     private val clock: Clock = Clock.systemUTC(),
 ) {
-    fun schedule(schedule: Schedule) {
+    fun schedule(schedule: Schedule, period: ForecastPeriod = ForecastPeriod.TODAY) {
         val alarmManager = context.getSystemService<AlarmManager>() ?: run {
             Log.w(TAG, "AlarmManager unavailable; alarm not scheduled")
             return
         }
 
         val triggerAt: Instant = schedule.nextOccurrenceAfter(clock.instant())
-        val pendingIntent = pendingIntent(context)
+        val pendingIntent = pendingIntent(context, period)
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && !alarmManager.canScheduleExactAlarms()) {
             // USE_EXACT_ALARM (API 33+) auto-grants this; on the API 31-32 shim path it's
@@ -44,28 +50,37 @@ class DailyAlarmScheduler(
             // fall back to setAndAllowWhileIdle so the user still gets the notification,
             // just possibly drifted by a few minutes.
             alarmManager.setAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, triggerAt.toEpochMilli(), pendingIntent)
-            Log.w(TAG, "Exact-alarm permission denied; using inexact alarm at $triggerAt")
+            Log.w(TAG, "Exact-alarm permission denied; using inexact alarm at $triggerAt for $period")
             return
         }
 
         alarmManager.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, triggerAt.toEpochMilli(), pendingIntent)
-        Log.i(TAG, "Daily insight alarm armed for $triggerAt")
+        Log.i(TAG, "Insight alarm armed for $triggerAt ($period)")
     }
 
-    fun cancel() {
+    fun cancel(period: ForecastPeriod = ForecastPeriod.TODAY) {
         val alarmManager = context.getSystemService<AlarmManager>() ?: return
-        alarmManager.cancel(pendingIntent(context))
+        alarmManager.cancel(pendingIntent(context, period))
     }
 
     companion object {
         private const val TAG = "DailyAlarmScheduler"
-        private const val ALARM_REQUEST_CODE = 0xADA1
+        private const val ALARM_REQUEST_CODE_TODAY = 0xADA1
+        private const val ALARM_REQUEST_CODE_TONIGHT = 0xADA2
 
-        internal fun pendingIntent(context: Context): PendingIntent {
-            val intent = Intent(context, AlarmReceiver::class.java).setAction(AlarmReceiver.ACTION_FIRE)
+        internal fun pendingIntent(context: Context, period: ForecastPeriod): PendingIntent {
+            val action = when (period) {
+                ForecastPeriod.TODAY -> AlarmReceiver.ACTION_FIRE
+                ForecastPeriod.TONIGHT -> AlarmReceiver.ACTION_FIRE_TONIGHT
+            }
+            val requestCode = when (period) {
+                ForecastPeriod.TODAY -> ALARM_REQUEST_CODE_TODAY
+                ForecastPeriod.TONIGHT -> ALARM_REQUEST_CODE_TONIGHT
+            }
+            val intent = Intent(context, AlarmReceiver::class.java).setAction(action)
             return PendingIntent.getBroadcast(
                 context,
-                ALARM_REQUEST_CODE,
+                requestCode,
                 intent,
                 PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
             )

--- a/app/src/main/kotlin/app/clothescast/alarm/ScheduleRefreshReceiver.kt
+++ b/app/src/main/kotlin/app/clothescast/alarm/ScheduleRefreshReceiver.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.Intent
 import android.util.Log
 import app.clothescast.ClothesCastApplication
+import app.clothescast.core.domain.model.ForecastPeriod
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -12,14 +13,15 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 
 /**
- * Re-arms the daily-insight alarm whenever the wall-clock context changes:
- * - device boot (alarms are wiped)
- * - app update (Android also wipes alarms)
- * - timezone change (the user travelled across zones)
- * - locale change (the next insight should be generated in the new language)
+ * Re-arms both the morning and the tonight insight alarms whenever the wall-clock
+ * context changes:
+ *  - device boot (alarms are wiped)
+ *  - app update (Android also wipes alarms)
+ *  - timezone change (the user travelled across zones)
+ *  - locale change (the next insight should be generated in the new language)
  *
- * The schedule's `zoneId` is re-resolved from `ZoneId.systemDefault()` at read time, so
- * we just need to recompute "next 7am" with the now-current zone and rearm.
+ * The schedules' `zoneId` is re-resolved from `ZoneId.systemDefault()` at read time, so
+ * we just need to recompute "next 7am" / "next 7pm" with the now-current zone and rearm.
  */
 class ScheduleRefreshReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
@@ -30,8 +32,14 @@ class ScheduleRefreshReceiver : BroadcastReceiver() {
         scope.launch {
             try {
                 val app = context.applicationContext as ClothesCastApplication
-                val schedule = app.settingsRepository.preferences.first().schedule
-                DailyAlarmScheduler(context.applicationContext).schedule(schedule)
+                val prefs = app.settingsRepository.preferences.first()
+                val scheduler = DailyAlarmScheduler(context.applicationContext)
+                scheduler.schedule(prefs.schedule, ForecastPeriod.TODAY)
+                if (prefs.tonightEnabled) {
+                    scheduler.schedule(prefs.tonightSchedule, ForecastPeriod.TONIGHT)
+                } else {
+                    scheduler.cancel(ForecastPeriod.TONIGHT)
+                }
             } catch (t: Throwable) {
                 Log.e(TAG, "Re-arm failed", t)
             } finally {

--- a/app/src/main/kotlin/app/clothescast/data/InsightCache.kt
+++ b/app/src/main/kotlin/app/clothescast/data/InsightCache.kt
@@ -6,6 +6,7 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
+import app.clothescast.core.domain.model.ForecastPeriod
 import app.clothescast.core.domain.model.HourlyForecast
 import app.clothescast.core.domain.model.Insight
 import app.clothescast.core.domain.model.OutfitSuggestion
@@ -35,24 +36,54 @@ class InsightCache(
     private val dataStore: DataStore<Preferences>,
     private val json: Json = Json { ignoreUnknownKeys = true },
 ) {
+    /**
+     * The most recent insight written to the cache, regardless of period. The Today
+     * screen surfaces this so opening the app after the tonight alarm fired shows
+     * the tonight insight (the freshest read of what the user is about to walk
+     * into), while opening the app at noon still shows the morning insight.
+     *
+     * Per-period storage lives in [latestForPeriod] / [forPeriodToday] so the
+     * worker can avoid clobbering the morning insight with the tonight one.
+     */
     val latest: Flow<Insight?> = dataStore.data.map { prefs ->
-        prefs[INSIGHT_JSON]?.let { raw ->
-            runCatching { json.decodeFromString<InsightDto>(raw).toDomain() }.getOrNull()
-        }
+        listOfNotNull(
+            prefs.readSlot(TODAY_INSIGHT_JSON),
+            prefs.readSlot(TONIGHT_INSIGHT_JSON),
+        ).maxByOrNull { it.generatedAt }
+    }
+
+    fun latestForPeriod(period: ForecastPeriod): Flow<Insight?> = dataStore.data.map { prefs ->
+        prefs.readSlot(keyFor(period))
     }
 
     suspend fun store(insight: Insight) {
-        dataStore.edit { it[INSIGHT_JSON] = json.encodeToString(insight.toDto()) }
+        dataStore.edit { it[keyFor(insight.period)] = json.encodeToString(insight.toDto()) }
     }
 
-    suspend fun forToday(today: LocalDate): Insight? {
-        val cached = latest.first() ?: return null
+    suspend fun forToday(today: LocalDate): Insight? = forPeriodToday(today, ForecastPeriod.TODAY)
+
+    suspend fun forPeriodToday(today: LocalDate, period: ForecastPeriod): Insight? {
+        val cached = latestForPeriod(period).first() ?: return null
         return cached.takeIf { it.forDate == today }
     }
 
     suspend fun clear() {
-        dataStore.edit { it.remove(INSIGHT_JSON) }
+        dataStore.edit {
+            it.remove(TODAY_INSIGHT_JSON)
+            it.remove(TONIGHT_INSIGHT_JSON)
+        }
     }
+
+    private fun Preferences.readSlot(key: androidx.datastore.preferences.core.Preferences.Key<String>): Insight? {
+        val raw = this[key] ?: return null
+        return runCatching { json.decodeFromString<InsightDto>(raw).toDomain() }.getOrNull()
+    }
+
+    private fun keyFor(period: ForecastPeriod): androidx.datastore.preferences.core.Preferences.Key<String> =
+        when (period) {
+            ForecastPeriod.TODAY -> TODAY_INSIGHT_JSON
+            ForecastPeriod.TONIGHT -> TONIGHT_INSIGHT_JSON
+        }
 
     @Serializable
     private data class InsightDto(
@@ -65,6 +96,8 @@ class InsightCache(
         // run rewrites with hourly populated.
         val hourly: List<HourlyDto> = emptyList(),
         val outfit: OutfitDto? = null,
+        val period: String = ForecastPeriod.TODAY.name,
+        val hasEvents: Boolean = false,
     ) {
         fun toDomain(): Insight = Insight(
             summary = summary,
@@ -73,6 +106,8 @@ class InsightCache(
             forDate = LocalDate.ofEpochDay(forDateEpochDays),
             hourly = hourly.map { it.toDomain() },
             outfit = outfit?.toDomain(),
+            period = runCatching { ForecastPeriod.valueOf(period) }.getOrDefault(ForecastPeriod.TODAY),
+            hasEvents = hasEvents,
         )
     }
 
@@ -110,6 +145,8 @@ class InsightCache(
         forDateEpochDays = forDate.toEpochDay(),
         hourly = hourly.map { it.toDto() },
         outfit = outfit?.let { OutfitDto(it.top.name, it.bottom.name) },
+        period = period.name,
+        hasEvents = hasEvents,
     )
 
     private fun HourlyForecast.toDto(): HourlyDto = HourlyDto(
@@ -127,7 +164,10 @@ class InsightCache(
         // sentence chopped at maxOutputTokens) and would otherwise stick around
         // until the user crossed midnight, since the worker reuses any cached
         // entry that matches `forToday`.
-        private val INSIGHT_JSON = stringPreferencesKey("latest_insight_v2")
+        // The today slot kept the v2 key so an in-place upgrade redelivers the
+        // existing cached morning insight; tonight is brand-new so it gets v1.
+        private val TODAY_INSIGHT_JSON = stringPreferencesKey("latest_insight_v2")
+        private val TONIGHT_INSIGHT_JSON = stringPreferencesKey("latest_tonight_insight_v1")
 
         fun create(context: Context): InsightCache = InsightCache(context.insightDataStore)
     }

--- a/app/src/main/kotlin/app/clothescast/data/SettingsRepository.kt
+++ b/app/src/main/kotlin/app/clothescast/data/SettingsRepository.kt
@@ -55,6 +55,18 @@ class SettingsRepository(
         }
     }
 
+    suspend fun setTonightSchedule(time: LocalTime, days: Set<DayOfWeek>) {
+        require(days.isNotEmpty()) { "Schedule must include at least one day" }
+        dataStore.edit { prefs ->
+            prefs[TONIGHT_TIME] = TIME_FORMAT.format(time)
+            prefs[TONIGHT_DAYS] = days.map { it.name }.toSet()
+        }
+    }
+
+    suspend fun setTonightEnabled(enabled: Boolean) {
+        dataStore.edit { it[TONIGHT_ENABLED] = enabled }
+    }
+
     suspend fun setDeliveryMode(mode: DeliveryMode) {
         dataStore.edit { it[DELIVERY_MODE] = mode.name }
     }
@@ -144,9 +156,20 @@ class SettingsRepository(
         val elevenLabsVoice = this[ELEVENLABS_VOICE]?.takeIf { it.isNotBlank() }
             ?: UserPreferences.DEFAULT_ELEVENLABS_VOICE
         val useCalendarEvents = this[USE_CALENDAR_EVENTS] == true
+        val tonightTime = this[TONIGHT_TIME]?.let { LocalTime.parse(it, TIME_FORMAT) }
+            ?: DEFAULT_TONIGHT_TIME
+        val tonightDays = this[TONIGHT_DAYS]?.mapNotNull { runCatching { DayOfWeek.valueOf(it) }.getOrNull() }
+            ?.toSet()
+            ?.takeIf { it.isNotEmpty() }
+            ?: Schedule.EVERY_DAY
+        // Default-on: existing installs that haven't seen the tonight pref yet get
+        // the silent overnight notification (it's quiet by default when there are
+        // no calendar events, so it's not noisy out of the box).
+        val tonightEnabled = this[TONIGHT_ENABLED] != false
+        val zone = zoneIdProvider()
 
         return UserPreferences(
-            schedule = Schedule(time = time, days = days, zoneId = zoneIdProvider()),
+            schedule = Schedule(time = time, days = days, zoneId = zone),
             deliveryMode = deliveryMode,
             temperatureUnit = temperatureUnit,
             distanceUnit = distanceUnit,
@@ -159,6 +182,8 @@ class SettingsRepository(
             elevenLabsVoice = elevenLabsVoice,
             voiceLocale = voiceLocale,
             useCalendarEvents = useCalendarEvents,
+            tonightSchedule = Schedule(time = tonightTime, days = tonightDays, zoneId = zone),
+            tonightEnabled = tonightEnabled,
         )
     }
 
@@ -198,9 +223,13 @@ class SettingsRepository(
         private val ELEVENLABS_VOICE = stringPreferencesKey("elevenlabs_voice")
         private val VOICE_LOCALE = stringPreferencesKey("voice_locale")
         private val USE_CALENDAR_EVENTS = booleanPreferencesKey("use_calendar_events")
+        private val TONIGHT_TIME = stringPreferencesKey("tonight_time_hhmm")
+        private val TONIGHT_DAYS = stringSetPreferencesKey("tonight_days")
+        private val TONIGHT_ENABLED = booleanPreferencesKey("tonight_enabled")
 
         private val TIME_FORMAT: DateTimeFormatter = DateTimeFormatter.ofPattern("HH:mm")
         private val DEFAULT_TIME: LocalTime = LocalTime.of(7, 0)
+        private val DEFAULT_TONIGHT_TIME: LocalTime = LocalTime.of(19, 0)
 
         fun create(context: Context): SettingsRepository =
             SettingsRepository(context.settingsDataStore)

--- a/app/src/main/kotlin/app/clothescast/notification/InsightNotifier.kt
+++ b/app/src/main/kotlin/app/clothescast/notification/InsightNotifier.kt
@@ -5,10 +5,14 @@ import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.graphics.Bitmap
 import android.os.Build
+import androidx.annotation.DrawableRes
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.ContextCompat
+import androidx.core.content.res.ResourcesCompat
+import androidx.core.graphics.drawable.toBitmap
 import app.clothescast.MainActivity
 import app.clothescast.R
 import app.clothescast.core.domain.model.Insight
@@ -35,14 +39,13 @@ class InsightNotifier(private val context: Context) {
             PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
         )
 
-        // TODO(notification-figure): when [insight.outfit] is non-null, also render the
-        // outfit icons (the same ic_outfit_* drawables the Today screen shows in
-        // OutfitPreviewCard) into a Bitmap sized for Notification.LARGE_ICON_SIZE and
-        // attach via .setLargeIcon(bitmap), so the expanded notification carries the
-        // same glanceable "what to wear today" cue the Today screen does. The small
-        // status-bar icon below already mirrors the recommended top.
+        // The small status-bar icon mirrors the recommended top (silhouette).
+        // The large icon picks up the same top in full colour so the expanded
+        // notification carries the same glanceable "what to wear today" cue the
+        // Today screen's OutfitPreviewCard does.
         val notification = NotificationCompat.Builder(context, CHANNEL_DAILY_INSIGHT)
             .setSmallIcon(smallIconFor(insight.outfit?.top))
+            .setLargeIcon(largeIconForTop(context, insight.outfit?.top))
             .setContentTitle(context.getString(R.string.notification_daily_insight_title))
             .setContentText(insight.summary)
             .setStyle(NotificationCompat.BigTextStyle().bigText(insight.summary))
@@ -77,6 +80,31 @@ class InsightNotifier(private val context: Context) {
             OutfitSuggestion.Top.SWEATER -> R.drawable.ic_notification_top_sweater
             OutfitSuggestion.Top.THICK_JACKET -> R.drawable.ic_notification_top_thick_jacket
             OutfitSuggestion.Top.TSHIRT, null -> R.drawable.ic_notification_insight
+        }
+
+        /**
+         * Renders the recommended top as a Bitmap for [NotificationCompat.Builder.setLargeIcon].
+         * Reuses the full-colour `ic_outfit_top_*` drawables from [OutfitPreviewCard]
+         * so the notification visual matches the home-screen card. Returns null when
+         * the outfit is missing (older cached payloads), letting the system fall back
+         * to no large icon.
+         */
+        internal fun largeIconForTop(context: Context, top: OutfitSuggestion.Top?): Bitmap? {
+            val drawableRes = largeTopDrawable(top) ?: return null
+            val drawable = ResourcesCompat.getDrawable(context.resources, drawableRes, context.theme)
+                ?: return null
+            val sizePx = context.resources.getDimensionPixelSize(android.R.dimen.notification_large_icon_width)
+                .takeIf { it > 0 }
+                ?: 192
+            return drawable.toBitmap(width = sizePx, height = sizePx)
+        }
+
+        @DrawableRes
+        private fun largeTopDrawable(top: OutfitSuggestion.Top?): Int? = when (top) {
+            OutfitSuggestion.Top.TSHIRT -> R.drawable.ic_outfit_tshirt
+            OutfitSuggestion.Top.SWEATER -> R.drawable.ic_outfit_sweater
+            OutfitSuggestion.Top.THICK_JACKET -> R.drawable.ic_outfit_thick_jacket
+            null -> null
         }
     }
 }

--- a/app/src/main/kotlin/app/clothescast/notification/NotificationChannelRegistrar.kt
+++ b/app/src/main/kotlin/app/clothescast/notification/NotificationChannelRegistrar.kt
@@ -12,16 +12,29 @@ import app.clothescast.R
  */
 internal const val CHANNEL_DAILY_INSIGHT = "daily_insight_v1"
 internal const val CHANNEL_WEATHER_ALERTS = "weather_alerts_v1"
+internal const val CHANNEL_TONIGHT_INSIGHT_DEFAULT = "tonight_insight_default_v1"
+internal const val CHANNEL_TONIGHT_INSIGHT_SILENT = "tonight_insight_silent_v1"
 
 /**
  * Registers the notification channel(s) used by the app. Idempotent — safe to call from
  * Application.onCreate on every cold start.
  *
- * Two channels:
+ * Four channels:
  * - **Daily insight** (HIGH): the morning weather summary the user opted in to.
  * - **Severe weather alerts** (MAX): out-of-band notifications for SEVERE / EXTREME
  *   alerts. Separate channel so the user can mute the daily summary without losing
  *   life-safety alerts (and vice-versa).
+ * - **Tonight insight (with events)** (DEFAULT): the evening summary when the user
+ *   has calendar events tonight. Plays the default notification sound — the user is
+ *   actually heading out and should hear the heads-up.
+ * - **Tonight insight (silent)** (LOW): the evening summary when the evening is
+ *   empty. Posts so the user can glance at it on the lock screen, but no sound or
+ *   vibration so it doesn't interrupt the evening.
+ *
+ * Two tonight channels (rather than per-notification silencing) is the canonical
+ * Android approach: channel importance is sticky, the user can mute / un-mute either
+ * independently in system settings, and silent-vs-default behaviour is reliable
+ * across OEMs.
  */
 object NotificationChannelRegistrar {
     fun register(context: Context) {
@@ -48,7 +61,31 @@ object NotificationChannelRegistrar {
             lockscreenVisibility = android.app.Notification.VISIBILITY_PUBLIC
         }
 
+        val tonightWithEvents = NotificationChannel(
+            CHANNEL_TONIGHT_INSIGHT_DEFAULT,
+            context.getString(R.string.notification_channel_tonight_insight_default_name),
+            NotificationManager.IMPORTANCE_DEFAULT,
+        ).apply {
+            description = context.getString(R.string.notification_channel_tonight_insight_default_description)
+            setShowBadge(true)
+            lockscreenVisibility = android.app.Notification.VISIBILITY_PUBLIC
+        }
+
+        val tonightSilent = NotificationChannel(
+            CHANNEL_TONIGHT_INSIGHT_SILENT,
+            context.getString(R.string.notification_channel_tonight_insight_silent_name),
+            NotificationManager.IMPORTANCE_LOW,
+        ).apply {
+            description = context.getString(R.string.notification_channel_tonight_insight_silent_description)
+            setShowBadge(false)
+            setSound(null, null)
+            enableVibration(false)
+            lockscreenVisibility = android.app.Notification.VISIBILITY_PUBLIC
+        }
+
         manager.createNotificationChannel(daily)
         manager.createNotificationChannel(alerts)
+        manager.createNotificationChannel(tonightWithEvents)
+        manager.createNotificationChannel(tonightSilent)
     }
 }

--- a/app/src/main/kotlin/app/clothescast/notification/TonightInsightNotifier.kt
+++ b/app/src/main/kotlin/app/clothescast/notification/TonightInsightNotifier.kt
@@ -1,0 +1,82 @@
+package app.clothescast.notification
+
+import android.Manifest
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.core.content.ContextCompat
+import app.clothescast.MainActivity
+import app.clothescast.R
+import app.clothescast.core.domain.model.Insight
+
+/**
+ * Posts the tonight insight as a system notification. Picks one of two channels
+ * based on whether the insight has calendar events tonight:
+ *  - [CHANNEL_TONIGHT_INSIGHT_DEFAULT] when events are present — default importance,
+ *    plays the user's notification sound. The user is heading out somewhere; the
+ *    summary is worth interrupting them for.
+ *  - [CHANNEL_TONIGHT_INSIGHT_SILENT] when the evening is empty — low importance,
+ *    silent. Still posted so the user can glance at the lock screen and see the
+ *    overnight insight, but nothing audible.
+ *
+ * Tapping the notification opens MainActivity. POST_NOTIFICATIONS is checked before
+ * posting; on Android 13+ a missing permission silently no-ops (the insight is
+ * still cached and surfaced in-app the next time the user opens it).
+ */
+class TonightInsightNotifier(private val context: Context) {
+
+    fun notify(insight: Insight) {
+        if (!hasPostNotificationPermission()) return
+
+        val tapIntent = Intent(context, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
+        }
+        val pendingIntent = PendingIntent.getActivity(
+            context,
+            REQUEST_OPEN_APP,
+            tapIntent,
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+        )
+
+        val channel = if (insight.hasEvents) CHANNEL_TONIGHT_INSIGHT_DEFAULT else CHANNEL_TONIGHT_INSIGHT_SILENT
+        val priority = if (insight.hasEvents) NotificationCompat.PRIORITY_DEFAULT else NotificationCompat.PRIORITY_LOW
+
+        val notification = NotificationCompat.Builder(context, channel)
+            .setSmallIcon(InsightNotifier.smallIconFor(insight.outfit?.top))
+            .setLargeIcon(InsightNotifier.largeIconForTop(context, insight.outfit?.top))
+            .setContentTitle(context.getString(R.string.notification_tonight_insight_title))
+            .setContentText(insight.summary)
+            .setStyle(NotificationCompat.BigTextStyle().bigText(insight.summary))
+            .setPriority(priority)
+            .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
+            .setAutoCancel(true)
+            .setContentIntent(pendingIntent)
+            .setCategory(NotificationCompat.CATEGORY_REMINDER)
+            .apply {
+                // Belt-and-braces: even if a downstream OEM ignores the silent
+                // channel's importance, the per-notification flag still suppresses
+                // sound + heads-up for the no-events case.
+                if (!insight.hasEvents) setSilent(true)
+            }
+            .build()
+
+        NotificationManagerCompat.from(context).notify(NOTIFICATION_ID_TONIGHT_INSIGHT, notification)
+    }
+
+    private fun hasPostNotificationPermission(): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return true
+        return ContextCompat.checkSelfPermission(
+            context,
+            Manifest.permission.POST_NOTIFICATIONS,
+        ) == PackageManager.PERMISSION_GRANTED
+    }
+
+    companion object {
+        const val NOTIFICATION_ID_TONIGHT_INSIGHT = 1003
+        private const val REQUEST_OPEN_APP = 102
+    }
+}

--- a/app/src/main/kotlin/app/clothescast/ui/settings/ScheduleSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/ScheduleSettings.kt
@@ -22,6 +22,7 @@ import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TimePicker
@@ -47,9 +48,14 @@ import java.util.Locale
 internal fun ScheduleContent(
     time: LocalTime,
     days: Set<DayOfWeek>,
+    tonightTime: LocalTime,
+    tonightDays: Set<DayOfWeek>,
+    tonightEnabled: Boolean,
     deliveryMode: DeliveryMode,
     padding: PaddingValues,
     onSetSchedule: (LocalTime, Set<DayOfWeek>) -> Unit,
+    onSetTonightSchedule: (LocalTime, Set<DayOfWeek>) -> Unit,
+    onSetTonightEnabled: (Boolean) -> Unit,
     onSetDeliveryMode: (DeliveryMode) -> Unit,
     onDone: (() -> Unit)? = null,
 ) {
@@ -62,6 +68,13 @@ internal fun ScheduleContent(
         verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {
         ScheduleCard(time, days, onSetSchedule)
+        TonightCard(
+            time = tonightTime,
+            days = tonightDays,
+            enabled = tonightEnabled,
+            onSetEnabled = onSetTonightEnabled,
+            onChange = onSetTonightSchedule,
+        )
         DeliveryModeCard(deliveryMode, onSetDeliveryMode)
         if (onDone != null) {
             Button(
@@ -175,6 +188,98 @@ private fun TimePickerDialog(
         },
         text = { TimePicker(state = state) },
     )
+}
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+@Composable
+private fun TonightCard(
+    time: LocalTime,
+    days: Set<DayOfWeek>,
+    enabled: Boolean,
+    onSetEnabled: (Boolean) -> Unit,
+    onChange: (LocalTime, Set<DayOfWeek>) -> Unit,
+) {
+    var pickerOpen by remember { mutableStateOf(false) }
+
+    SectionCard(title = stringResource(R.string.settings_tonight_title)) {
+        Text(
+            text = stringResource(R.string.settings_tonight_description),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = stringResource(R.string.settings_tonight_enabled),
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier.weight(1f),
+            )
+            Switch(checked = enabled, onCheckedChange = onSetEnabled)
+        }
+        if (enabled) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = stringResource(R.string.settings_tonight_time_label),
+                    style = MaterialTheme.typography.bodyMedium,
+                    modifier = Modifier.padding(end = 12.dp),
+                )
+                OutlinedButton(onClick = { pickerOpen = true }) {
+                    Text(text = TIME_FORMAT.format(time))
+                }
+            }
+            Text(
+                text = stringResource(R.string.settings_tonight_days_label),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+            FlowRow(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(4.dp),
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                DayOfWeek.entries.forEach { dow ->
+                    val selected = dow in days
+                    FilterChip(
+                        selected = selected,
+                        onClick = {
+                            val next = if (selected) days - dow else days + dow
+                            if (next.isNotEmpty()) onChange(time, next)
+                        },
+                        label = {
+                            Text(text = dow.getDisplayName(TextStyle.SHORT, Locale.getDefault()))
+                        },
+                        leadingIcon = if (selected) {
+                            {
+                                Icon(
+                                    imageVector = Icons.Filled.Check,
+                                    contentDescription = null,
+                                    modifier = Modifier.size(FilterChipDefaults.IconSize),
+                                )
+                            }
+                        } else {
+                            null
+                        },
+                        colors = FilterChipDefaults.filterChipColors(),
+                    )
+                }
+            }
+        }
+    }
+
+    if (pickerOpen) {
+        TimePickerDialog(
+            initial = time,
+            onDismiss = { pickerOpen = false },
+            onConfirm = { newTime ->
+                pickerOpen = false
+                onChange(newTime, days)
+            },
+        )
+    }
 }
 
 @Composable

--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsScreen.kt
@@ -96,9 +96,14 @@ fun SettingsScreen(
             SettingsRoute.Schedule -> ScheduleContent(
                 time = state.scheduleTime,
                 days = state.scheduleDays,
+                tonightTime = state.tonightTime,
+                tonightDays = state.tonightDays,
+                tonightEnabled = state.tonightEnabled,
                 deliveryMode = state.deliveryMode,
                 padding = padding,
                 onSetSchedule = viewModel::setSchedule,
+                onSetTonightSchedule = viewModel::setTonightSchedule,
+                onSetTonightEnabled = viewModel::setTonightEnabled,
                 onSetDeliveryMode = viewModel::setDeliveryMode,
                 // Show a Done button only when this page is the deep-link
                 // landing from onboarding's "Continue" — gives the user an

--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsState.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsState.kt
@@ -17,6 +17,9 @@ import java.time.LocalTime
 data class SettingsState(
     val scheduleTime: LocalTime = LocalTime.of(7, 0),
     val scheduleDays: Set<DayOfWeek> = Schedule.EVERY_DAY,
+    val tonightTime: LocalTime = LocalTime.of(19, 0),
+    val tonightDays: Set<DayOfWeek> = Schedule.EVERY_DAY,
+    val tonightEnabled: Boolean = true,
     val deliveryMode: DeliveryMode = DeliveryMode.NOTIFICATION_ONLY,
     val temperatureUnit: TemperatureUnit = TemperatureUnit.CELSIUS,
     val distanceUnit: DistanceUnit = DistanceUnit.KILOMETERS,

--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.viewModelScope
 import app.clothescast.core.data.location.OpenMeteoGeocodingClient
 import app.clothescast.core.domain.model.DeliveryMode
 import app.clothescast.core.domain.model.DistanceUnit
+import app.clothescast.core.domain.model.ForecastPeriod
 import app.clothescast.core.domain.model.Location
 import app.clothescast.core.domain.model.Schedule
 import app.clothescast.core.domain.model.TemperatureUnit
@@ -26,7 +27,8 @@ import java.time.LocalTime
 class SettingsViewModel(
     private val settingsRepository: SettingsRepository,
     private val keyStore: SecureKeyStore,
-    private val rearmAlarm: (Schedule) -> Unit,
+    private val rearmAlarm: (Schedule, ForecastPeriod) -> Unit,
+    private val cancelAlarm: (ForecastPeriod) -> Unit,
     private val geocodingClient: OpenMeteoGeocodingClient,
 ) : ViewModel() {
 
@@ -40,6 +42,9 @@ class SettingsViewModel(
                     it.copy(
                         scheduleTime = prefs.schedule.time,
                         scheduleDays = prefs.schedule.days,
+                        tonightTime = prefs.tonightSchedule.time,
+                        tonightDays = prefs.tonightSchedule.days,
+                        tonightEnabled = prefs.tonightEnabled,
                         deliveryMode = prefs.deliveryMode,
                         temperatureUnit = prefs.temperatureUnit,
                         distanceUnit = prefs.distanceUnit,
@@ -182,7 +187,30 @@ class SettingsViewModel(
             // The repository resolves zoneId fresh on each emission, so the schedule we read
             // back is the new one with the current zone.
             val updated = settingsRepository.preferences.first().schedule
-            rearmAlarm(updated)
+            rearmAlarm(updated, ForecastPeriod.TODAY)
+        }
+    }
+
+    fun setTonightSchedule(time: LocalTime, days: Set<DayOfWeek>) {
+        if (days.isEmpty()) return
+        viewModelScope.launch {
+            settingsRepository.setTonightSchedule(time, days)
+            val prefs = settingsRepository.preferences.first()
+            // Don't arm the alarm if tonight is disabled — would just trigger an
+            // ignored worker run.
+            if (prefs.tonightEnabled) rearmAlarm(prefs.tonightSchedule, ForecastPeriod.TONIGHT)
+        }
+    }
+
+    fun setTonightEnabled(enabled: Boolean) {
+        viewModelScope.launch {
+            settingsRepository.setTonightEnabled(enabled)
+            val prefs = settingsRepository.preferences.first()
+            if (prefs.tonightEnabled) {
+                rearmAlarm(prefs.tonightSchedule, ForecastPeriod.TONIGHT)
+            } else {
+                cancelAlarm(ForecastPeriod.TONIGHT)
+            }
         }
     }
 
@@ -202,7 +230,8 @@ class SettingsViewModel(
     class Factory(
         private val settingsRepository: SettingsRepository,
         private val keyStore: SecureKeyStore,
-        private val rearmAlarm: (Schedule) -> Unit,
+        private val rearmAlarm: (Schedule, ForecastPeriod) -> Unit,
+        private val cancelAlarm: (ForecastPeriod) -> Unit,
         private val geocodingClient: OpenMeteoGeocodingClient,
     ) : ViewModelProvider.Factory {
         @Suppress("UNCHECKED_CAST")
@@ -210,7 +239,7 @@ class SettingsViewModel(
             require(modelClass.isAssignableFrom(SettingsViewModel::class.java)) {
                 "Unknown ViewModel: ${modelClass.name}"
             }
-            return SettingsViewModel(settingsRepository, keyStore, rearmAlarm, geocodingClient) as T
+            return SettingsViewModel(settingsRepository, keyStore, rearmAlarm, cancelAlarm, geocodingClient) as T
         }
     }
 }

--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
@@ -231,6 +231,13 @@ internal fun EmptyState(onRefresh: () -> Unit, isWorking: Boolean = false) {
  * icons stacked vertically — shirt above pants — so the pair reads as a head-to-toe
  * outfit instead of two unrelated items. Icons are fixed-colour SVGs (not Material-themed)
  * so each garment stays recognisable in light or dark mode.
+ *
+ * TODO(outfit-weather-overlay): place a small weather glyph (sun / cloud / rain /
+ *   snow) over the centre of the top icon so a glance carries both "what to wear"
+ *   *and* "what's it doing outside" — e.g. a t-shirt with a sun, a sweater with a
+ *   raincloud. Use the same imagery for the product launcher icon (mipmap/ic_launcher,
+ *   ic_launcher_round, ic_launcher_background) so the home-screen icon, the
+ *   OutfitPreviewCard, and the notification large icon all read as one family.
  */
 @Composable
 internal fun OutfitPreviewCard(outfit: OutfitSuggestion) {

--- a/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
@@ -202,22 +202,25 @@ class FetchAndNotifyWorker(
     }
 
     /**
-     * Tonight delivery is event-gated:
-     *  - Notification fires every time, but on the silent channel when there are no
-     *    calendar events (no sound / no vibration), and on the default-priority
-     *    channel when there are events (plays the user's notification sound).
-     *  - TTS only speaks when there are events tonight. The user explicitly opted
-     *    in to events; if their evening is empty there's nothing to interrupt for.
+     * Tonight delivery honours the user's [DeliveryMode] (consistent with
+     * [deliverToday]) and is also event-gated:
+     *  - Notification posts only when the delivery mode includes notifications,
+     *    matching today's behaviour. The notifier still picks the silent channel
+     *    vs the default-priority channel based on whether there are calendar
+     *    events tonight.
+     *  - TTS only speaks when the delivery mode includes TTS *and* there are
+     *    events tonight. If the evening is empty there's nothing to interrupt
+     *    for, even on a TTS-enabled mode.
      */
     private suspend fun deliverTonight(insight: Insight, prefs: UserPreferences) {
-        // The notification always posts so the user can still see the tonight
-        // insight on the lock screen even when their evening is empty.
-        app.tonightInsightNotifier.notify(insight)
+        val mode = prefs.deliveryMode
+        if (mode == DeliveryMode.NOTIFICATION_ONLY || mode == DeliveryMode.NOTIFICATION_AND_TTS) {
+            app.tonightInsightNotifier.notify(insight)
+        }
         if (!insight.hasEvents) {
-            Log.i(TAG, "Tonight insight has no events; silent notification, no TTS.")
+            Log.i(TAG, "Tonight insight has no events; skipping TTS.")
             return
         }
-        val mode = prefs.deliveryMode
         if (mode == DeliveryMode.TTS_ONLY || mode == DeliveryMode.NOTIFICATION_AND_TTS) {
             speakWithFallback(insight.spokenText(), prefs)
         }

--- a/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
@@ -13,6 +13,7 @@ import androidx.work.WorkerParameters
 import androidx.work.workDataOf
 import app.clothescast.ClothesCastApplication
 import app.clothescast.core.domain.model.DeliveryMode
+import app.clothescast.core.domain.model.ForecastPeriod
 import app.clothescast.core.domain.model.Insight
 import app.clothescast.core.domain.model.Location
 import app.clothescast.core.domain.model.TtsEngine
@@ -56,6 +57,18 @@ class FetchAndNotifyWorker(
             return Result.retry()
         }
 
+        val period = inputData.getString(KEY_PERIOD)
+            ?.let { runCatching { ForecastPeriod.valueOf(it) }.getOrNull() }
+            ?: ForecastPeriod.TODAY
+
+        // The tonight alarm rearms blindly via AlarmReceiver; the user's enable
+        // toggle is honoured here so a stale alarm doesn't ship a tonight insight
+        // after the user disabled the feature.
+        if (period == ForecastPeriod.TONIGHT && !prefs.tonightEnabled) {
+            Log.i(TAG, "Tonight insight is disabled; skipping.")
+            return Result.success()
+        }
+
         val location = resolveLocation(prefs)
         val today = LocalDate.now()
 
@@ -88,27 +101,28 @@ class FetchAndNotifyWorker(
             Log.i(TAG, "Force refresh requested; bypassing today's cache.")
             null
         } else {
-            runCatching { app.insightCache.forToday(today) }.getOrNull()
+            runCatching { app.insightCache.forPeriodToday(today, period) }.getOrNull()
         }
         if (cached != null) {
-            Log.i(TAG, "Using cached insight for ${cached.forDate}.")
+            Log.i(TAG, "Using cached $period insight for ${cached.forDate}.")
             return runCatching { deliver(cached, prefs) }
                 .map { Result.success() }
                 .getOrElse {
                     Log.e(TAG, "Cached delivery failed; falling through to fresh generate.", it)
-                    fresh(location, prefs)
+                    fresh(location, prefs, period)
                 }
         }
 
-        return fresh(location, prefs)
+        return fresh(location, prefs, period)
     }
 
     private suspend fun fresh(
         location: Location,
         prefs: UserPreferences,
+        period: ForecastPeriod,
     ): Result {
         return try {
-            val result = app.generateDailyInsight(location, prefs)
+            val result = app.generateDailyInsight(location, prefs, period)
             val insight = result.insight
             // Severe alerts are out-of-band: post them as separate high-priority
             // notifications on every fresh fetch, regardless of whether the daily
@@ -171,10 +185,39 @@ class FetchAndNotifyWorker(
             Log.i(TAG, "Insight summary is blank; skipping notification + TTS.")
             return
         }
+        when (insight.period) {
+            ForecastPeriod.TODAY -> deliverToday(insight, prefs)
+            ForecastPeriod.TONIGHT -> deliverTonight(insight, prefs)
+        }
+    }
+
+    private suspend fun deliverToday(insight: Insight, prefs: UserPreferences) {
         val mode = prefs.deliveryMode
         if (mode == DeliveryMode.NOTIFICATION_ONLY || mode == DeliveryMode.NOTIFICATION_AND_TTS) {
             app.insightNotifier.notify(insight)
         }
+        if (mode == DeliveryMode.TTS_ONLY || mode == DeliveryMode.NOTIFICATION_AND_TTS) {
+            speakWithFallback(insight.spokenText(), prefs)
+        }
+    }
+
+    /**
+     * Tonight delivery is event-gated:
+     *  - Notification fires every time, but on the silent channel when there are no
+     *    calendar events (no sound / no vibration), and on the default-priority
+     *    channel when there are events (plays the user's notification sound).
+     *  - TTS only speaks when there are events tonight. The user explicitly opted
+     *    in to events; if their evening is empty there's nothing to interrupt for.
+     */
+    private suspend fun deliverTonight(insight: Insight, prefs: UserPreferences) {
+        // The notification always posts so the user can still see the tonight
+        // insight on the lock screen even when their evening is empty.
+        app.tonightInsightNotifier.notify(insight)
+        if (!insight.hasEvents) {
+            Log.i(TAG, "Tonight insight has no events; silent notification, no TTS.")
+            return
+        }
+        val mode = prefs.deliveryMode
         if (mode == DeliveryMode.TTS_ONLY || mode == DeliveryMode.NOTIFICATION_AND_TTS) {
             speakWithFallback(insight.spokenText(), prefs)
         }
@@ -225,6 +268,7 @@ class FetchAndNotifyWorker(
     companion object {
         private const val TAG = "FetchAndNotifyWorker"
         const val UNIQUE_WORK_NAME = "daily_insight_fetch"
+        const val UNIQUE_WORK_NAME_TONIGHT = "tonight_insight_fetch"
 
         // Output Data keys for surfacing failure reasons in the UI.
         const val KEY_REASON = "reason"
@@ -243,6 +287,9 @@ class FetchAndNotifyWorker(
          */
         private const val KEY_REQUESTED_EPOCH_DAY = "requested_epoch_day"
 
+        /** Which slice of the day this run is for; defaults to TODAY when absent. */
+        private const val KEY_PERIOD = "period"
+
         // Fallback when the user hasn't set a location yet — the pipeline still runs and
         // posts a (London) insight rather than silently failing. The Settings screen
         // surfaces an empty-location card so the user can change it.
@@ -252,7 +299,11 @@ class FetchAndNotifyWorker(
             displayName = "London (default)",
         )
 
-        fun enqueueOneShot(context: Context, force: Boolean = false) {
+        fun enqueueOneShot(
+            context: Context,
+            force: Boolean = false,
+            period: ForecastPeriod = ForecastPeriod.TODAY,
+        ) {
             val constraints = Constraints.Builder()
                 .setRequiredNetworkType(NetworkType.CONNECTED)
                 .build()
@@ -264,6 +315,7 @@ class FetchAndNotifyWorker(
                     workDataOf(
                         KEY_FORCE_REFRESH to force,
                         KEY_REQUESTED_EPOCH_DAY to LocalDate.now().toEpochDay(),
+                        KEY_PERIOD to period.name,
                     )
                 )
                 .build()
@@ -272,8 +324,12 @@ class FetchAndNotifyWorker(
             // User-initiated force enqueues use REPLACE — the user just tapped Refresh
             // expecting a fresh fetch, so cancel any in-flight retry and start over.
             val policy = if (force) ExistingWorkPolicy.REPLACE else ExistingWorkPolicy.KEEP
+            val workName = when (period) {
+                ForecastPeriod.TODAY -> UNIQUE_WORK_NAME
+                ForecastPeriod.TONIGHT -> UNIQUE_WORK_NAME_TONIGHT
+            }
             WorkManager.getInstance(context)
-                .enqueueUniqueWork(UNIQUE_WORK_NAME, policy, request)
+                .enqueueUniqueWork(workName, policy, request)
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -93,6 +93,12 @@
     <string name="settings_schedule_time_label">Time</string>
     <string name="settings_schedule_days_label">Days of the week</string>
 
+    <string name="settings_tonight_title">Tonight insight</string>
+    <string name="settings_tonight_description">A second insight in the evening that covers tonight\'s weather. Silent when there\'s nothing on your calendar; plays a sound and (if you\'ve enabled spoken-aloud delivery) reads itself out when you have evening events.</string>
+    <string name="settings_tonight_enabled">Show a tonight insight</string>
+    <string name="settings_tonight_time_label">Time</string>
+    <string name="settings_tonight_days_label">Days of the week</string>
+
     <string name="settings_delivery_title">How to deliver the daily insight</string>
     <string name="settings_delivery_notification_only">Notification only</string>
     <string name="settings_delivery_tts_only">Spoken aloud only</string>
@@ -163,6 +169,12 @@
     <string name="notification_channel_daily_insight_name">Daily insight</string>
     <string name="notification_channel_daily_insight_description">The morning weather summary you opted in to.</string>
     <string name="notification_daily_insight_title">Today\'s weather</string>
+
+    <string name="notification_channel_tonight_insight_default_name">Tonight insight (with events)</string>
+    <string name="notification_channel_tonight_insight_default_description">The evening weather summary when you have calendar events tonight. Plays your default notification sound.</string>
+    <string name="notification_channel_tonight_insight_silent_name">Tonight insight (silent)</string>
+    <string name="notification_channel_tonight_insight_silent_description">The evening weather summary when your evening is empty. Posted silently — you can glance at it on the lock screen, but it won\'t make a sound.</string>
+    <string name="notification_tonight_insight_title">Tonight\'s weather</string>
 
     <string name="notification_channel_weather_alerts_name">Severe weather alerts</string>
     <string name="notification_channel_weather_alerts_description">High-priority alerts for severe or extreme weather events affecting your area. Delivered as soon as the daily fetch detects them.</string>

--- a/app/src/test/kotlin/app/clothescast/ui/settings/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/app/clothescast/ui/settings/SettingsViewModelTest.kt
@@ -88,7 +88,8 @@ class SettingsViewModelTest {
         subject = SettingsViewModel(
             settingsRepository,
             keyStore,
-            rearmAlarm = {},
+            rearmAlarm = { _, _ -> },
+            cancelAlarm = { _ -> },
             geocodingClient = OpenMeteoGeocodingClient(emptyGeocoding),
         )
     }

--- a/core/data/src/main/kotlin/app/clothescast/core/data/weather/OpenMeteoClient.kt
+++ b/core/data/src/main/kotlin/app/clothescast/core/data/weather/OpenMeteoClient.kt
@@ -21,11 +21,17 @@ internal const val OPEN_METEO_HOST = "api.open-meteo.com"
  * actuals plus today's and tomorrow's forecast in one call. Free, key-less. Free-tier
  * soft cap is 10k requests/day; this app makes one call per device per day.
  *
- * `forecast_days=2` (not 1) so the hourly array reliably covers all 24 hours of today
- * regardless of when in the day the worker fires. With `forecast_days=1` Open-Meteo's
- * hourly window stops short of end-of-day for late-morning calls — the chart was
- * truncating at "now" instead of showing the full afternoon. Tomorrow's hourly
- * entries are filtered out by date in the mapper before the today forecast is built.
+ * `forecast_days=2` (not 1) does double duty:
+ *  - Today's hourly array reliably covers all 24 hours regardless of when in the day
+ *    the worker fires. With `forecast_days=1` Open-Meteo's hourly window stops short
+ *    of end-of-day for late-morning calls — the chart was truncating at "now" instead
+ *    of showing the full afternoon.
+ *  - Tomorrow's pre-dawn hourly entries are exposed via [ForecastBundle.tomorrowHourly]
+ *    so the tonight insight can wrap from 19:00 today through 07:00 next morning, and
+ *    its overnight low / pre-dawn rain reflect what the user will actually walk into.
+ *
+ * The mapper splits today's vs tomorrow's hourly entries by date and keeps the daily
+ * fields (yesterday + today only) untouched.
  *
  * Severe-weather alerts come from a second `/v1/warnings` call. The warnings endpoint
  * is best-effort: if it fails (4xx, 5xx, network), we return the forecast with an empty

--- a/core/data/src/main/kotlin/app/clothescast/core/data/weather/OpenMeteoMapper.kt
+++ b/core/data/src/main/kotlin/app/clothescast/core/data/weather/OpenMeteoMapper.kt
@@ -9,11 +9,19 @@ import java.time.LocalTime
 
 /**
  * Maps an [OpenMeteoResponse] (queried with past_days=1&forecast_days=2) into a
- * [ForecastBundle]. Index 0 in the daily arrays is yesterday, index 1 is today;
- * tomorrow (index 2) is fetched only so the hourly stream reliably reaches end of
- * today, and is otherwise discarded. The hourly stream covers all three days; we
- * filter to today's date for the today forecast (yesterday's and tomorrow's
- * hourlies are not needed downstream).
+ * [ForecastBundle]. Index 0 in the daily arrays is yesterday, index 1 is today,
+ * index 2 (when present) is tomorrow. The daily fields for tomorrow are not surfaced
+ * — only its hourly entries — but the third daily entry is what makes Open-Meteo
+ * return tomorrow's hours at all.
+ *
+ * The hourly stream covers all three days. We split it by date: today's hours
+ * attach to the today forecast, tomorrow's hours flow through on
+ * [ForecastBundle.tomorrowHourly] so the tonight insight can wrap from 19:00 today
+ * into tomorrow's pre-dawn morning. Yesterday's hourlies are not needed downstream.
+ *
+ * Tolerates 2-entry responses (forecast_days=1) for backwards compatibility with
+ * older fixtures and any caller that downgrades the request — tomorrow's hourly
+ * just comes through empty in that case.
  */
 internal object OpenMeteoMapper {
     fun toBundle(response: OpenMeteoResponse): ForecastBundle {
@@ -28,7 +36,14 @@ internal object OpenMeteoMapper {
         val todayHourly = response.hourly.forDate(todayDate)
         val today = response.daily.toForecast(index = 1, date = todayDate, hourly = todayHourly)
 
-        return ForecastBundle(today = today, yesterday = yesterday)
+        val tomorrowHourly = if (response.daily.time.size >= 3) {
+            val tomorrowDate = LocalDate.parse(response.daily.time[2])
+            response.hourly.forDate(tomorrowDate)
+        } else {
+            emptyList()
+        }
+
+        return ForecastBundle(today = today, yesterday = yesterday, tomorrowHourly = tomorrowHourly)
     }
 
     private fun DailyData.toForecast(index: Int, date: LocalDate, hourly: List<HourlyForecast>): DailyForecast {

--- a/core/data/src/test/kotlin/app/clothescast/core/data/weather/OpenMeteoMapperTest.kt
+++ b/core/data/src/test/kotlin/app/clothescast/core/data/weather/OpenMeteoMapperTest.kt
@@ -179,6 +179,50 @@ class OpenMeteoMapperTest {
     }
 
     @Test
+    fun `tomorrow hourly is exposed when the response carries a third daily entry`() {
+        val threeDay = OpenMeteoResponse(
+            timezone = "UTC",
+            daily = DailyData(
+                time = listOf("2026-04-24", "2026-04-25", "2026-04-26"),
+                temperatureMin = listOf(12.0, 16.0, 14.0),
+                temperatureMax = listOf(18.0, 24.0, 21.0),
+                feelsLikeMin = listOf(10.0, 15.0, 13.0),
+                feelsLikeMax = listOf(17.0, 23.0, 20.0),
+                precipitationProbabilityMax = listOf(5, 60, 20),
+                precipitationSum = listOf(0.0, 4.5, 0.5),
+                weatherCode = listOf(2, 63, 3),
+            ),
+            hourly = HourlyData(
+                time = listOf(
+                    "2026-04-25T20:00",
+                    "2026-04-25T23:00",
+                    "2026-04-26T03:00",
+                    "2026-04-26T06:00",
+                ),
+                temperature = listOf(16.0, 12.0, 6.0, 8.0),
+                feelsLike = listOf(14.0, 10.0, 3.0, 5.0),
+                precipitationProbability = listOf(10, 5, 5, 5),
+                weatherCode = listOf(2, 2, 2, 2),
+            ),
+        )
+
+        val bundle = OpenMeteoMapper.toBundle(threeDay)
+
+        bundle.today.hourly shouldHaveSize 2
+        bundle.tomorrowHourly shouldHaveSize 2
+        bundle.tomorrowHourly.first().time shouldBe LocalTime.of(3, 0)
+        bundle.tomorrowHourly.last().time shouldBe LocalTime.of(6, 0)
+    }
+
+    @Test
+    fun `tomorrow hourly is empty when the response only carries two daily entries`() {
+        // Backwards compat for older fixtures / a forecast_days=1 caller.
+        val bundle = OpenMeteoMapper.toBundle(loadFixture())
+
+        bundle.tomorrowHourly shouldBe emptyList()
+    }
+
+    @Test
     fun `rejects responses missing two daily entries`() {
         val short = OpenMeteoResponse(
             timezone = "UTC",

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/ForecastPeriod.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/ForecastPeriod.kt
@@ -1,0 +1,12 @@
+package app.clothescast.core.domain.model
+
+/**
+ * Which slice of the day the insight is talking about.
+ *
+ *  - [TODAY]    — the morning forecast that fires at the user's scheduled wake-up time
+ *    (default 07:00). Covers the daytime window 07:00–19:00.
+ *  - [TONIGHT]  — the evening forecast that fires at the user's evening time (default
+ *    19:00). Covers the overnight window 19:00–07:00. The summary leads with
+ *    "Tonight will be …" and the wardrobe / outfit reflect the overnight low.
+ */
+enum class ForecastPeriod { TODAY, TONIGHT }

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/ForecastPeriod.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/ForecastPeriod.kt
@@ -4,9 +4,12 @@ package app.clothescast.core.domain.model
  * Which slice of the day the insight is talking about.
  *
  *  - [TODAY]    — the morning forecast that fires at the user's scheduled wake-up time
- *    (default 07:00). Covers the daytime window 07:00–19:00.
+ *    (default 07:00). Covers the daytime window from the wake-up time onward.
  *  - [TONIGHT]  — the evening forecast that fires at the user's evening time (default
- *    19:00). Covers the overnight window 19:00–07:00. The summary leads with
- *    "Tonight will be …" and the wardrobe / outfit reflect the overnight low.
+ *    19:00). Spans the overnight window from the evening time today through to the
+ *    next morning's wake-up time (default 07:00 next day) — Open-Meteo is fetched
+ *    with `forecast_days=2` so the bundle carries tomorrow's pre-dawn hourly slice.
+ *    The summary leads with "Tonight will be …" and the wardrobe / outfit reflect
+ *    the actual overnight low.
  */
 enum class ForecastPeriod { TODAY, TONIGHT }

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Insight.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Insight.kt
@@ -27,6 +27,21 @@ data class Insight(
      * run repopulates it.
      */
     val outfit: OutfitSuggestion? = null,
+    /**
+     * Which slice of the day this insight is for. [ForecastPeriod.TODAY] is the
+     * morning pass (covers 07:00–19:00); [ForecastPeriod.TONIGHT] is the evening
+     * pass (covers 19:00–07:00). Defaults to TODAY so older cached insights from
+     * before the tonight feature still deserialise as morning insights.
+     */
+    val period: ForecastPeriod = ForecastPeriod.TODAY,
+    /**
+     * True when at least one calendar event was found in the relevant window for
+     * this insight (today's events for TODAY, tonight's events for TONIGHT). Used
+     * by the tonight notifier to decide between a silent and a default-priority
+     * notification — events present means "you might need to actually leave the
+     * house tonight," which warrants a sound and TTS read-out.
+     */
+    val hasEvents: Boolean = false,
 ) {
     /**
      * The text that gets spoken aloud. The summary already includes the wardrobe

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Schedule.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Schedule.kt
@@ -34,7 +34,16 @@ data class Schedule(
 
     companion object {
         val EVERY_DAY: Set<DayOfWeek> = DayOfWeek.entries.toSet()
+
+        /** Morning insight default — 07:00 every day. */
         fun default(zoneId: ZoneId = ZoneId.systemDefault()): Schedule =
             Schedule(time = LocalTime.of(7, 0), days = EVERY_DAY, zoneId = zoneId)
+
+        /**
+         * Tonight insight default — 19:00 every day. The tonight pass mirrors the
+         * morning one; only the wall-clock time and the summary period differ.
+         */
+        fun defaultTonight(zoneId: ZoneId = ZoneId.systemDefault()): Schedule =
+            Schedule(time = LocalTime.of(19, 0), days = EVERY_DAY, zoneId = zoneId)
     }
 }

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Settings.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Settings.kt
@@ -94,6 +94,19 @@ data class UserPreferences(
      * the runtime permission for events to actually be read.
      */
     val useCalendarEvents: Boolean = false,
+    /**
+     * When the evening / "tonight" insight should fire. Distinct from [schedule]
+     * (the morning slot) so the user can keep the morning at 07:00 and still
+     * tweak the evening time independently. Default is 19:00 every day.
+     */
+    val tonightSchedule: Schedule = Schedule.defaultTonight(schedule.zoneId),
+    /**
+     * Master switch for the evening / "tonight" insight. On by default — the
+     * tonight notifier is silent when there are no calendar events for the
+     * evening, so it's not noisy out of the box. The user can disable it from
+     * the schedule settings page.
+     */
+    val tonightEnabled: Boolean = true,
 ) {
     companion object {
         const val DEFAULT_GEMINI_VOICE = "Kore"

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/repository/WeatherRepository.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/repository/WeatherRepository.kt
@@ -2,6 +2,7 @@ package app.clothescast.core.domain.repository
 
 import app.clothescast.core.domain.model.ConfidenceInfo
 import app.clothescast.core.domain.model.DailyForecast
+import app.clothescast.core.domain.model.HourlyForecast
 import app.clothescast.core.domain.model.Location
 import app.clothescast.core.domain.model.WeatherAlert
 
@@ -26,6 +27,17 @@ data class ForecastBundle(
     val yesterday: DailyForecast,
     val alerts: List<WeatherAlert> = emptyList(),
     val confidence: ConfidenceInfo? = null,
+    /**
+     * Tomorrow's hourly entries, when the underlying API response carried them.
+     * Used by the tonight insight to wrap from today's evening hours through to
+     * tomorrow morning (so "Tonight will be cold to mild" reflects the actual
+     * overnight low, and a 06:00 rain hour can drive the umbrella suggestion).
+     *
+     * Empty when the fetch only covered today (legacy `forecast_days=1` calls,
+     * sparse test fixtures). The tonight slice falls back to today-only in that
+     * case rather than failing.
+     */
+    val tomorrowHourly: List<HourlyForecast> = emptyList(),
 ) {
     init {
         require(yesterday.date.isBefore(today.date)) {

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsight.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsight.kt
@@ -1,5 +1,7 @@
 package app.clothescast.core.domain.usecase
 
+import app.clothescast.core.domain.model.CalendarEvent
+import app.clothescast.core.domain.model.ForecastPeriod
 import app.clothescast.core.domain.model.Insight
 import app.clothescast.core.domain.model.Location
 import app.clothescast.core.domain.model.OutfitSuggestion
@@ -8,6 +10,7 @@ import app.clothescast.core.domain.model.WeatherAlert
 import app.clothescast.core.domain.repository.CalendarEventReader
 import app.clothescast.core.domain.repository.WeatherRepository
 import java.time.Clock
+import java.time.LocalTime
 
 /**
  * The product. Fetches the forecast, evaluates wardrobe rules, renders the
@@ -27,40 +30,68 @@ class GenerateDailyInsight(
     suspend operator fun invoke(
         location: Location,
         prefs: UserPreferences,
+        period: ForecastPeriod = ForecastPeriod.TODAY,
     ): DailyInsightResult {
         val bundle = weatherRepository.fetchForecast(location)
         val activeAlerts = bundle.alerts.filter { it.expires.isAfter(clock.instant()) }
-        val todayTriggered = evaluateWardrobeRules(bundle.today, prefs.wardrobeRules)
+        // For TONIGHT, narrow the daily slice to the overnight window. The bundle's
+        // hourly already covers the full day; we just trim it to >=19:00 so the
+        // chart and the precip-peak calculation talk about tonight, not the morning
+        // hours the user already heard about.
+        val source = bundle.today
+        val periodForecast = when (period) {
+            ForecastPeriod.TODAY -> source
+            ForecastPeriod.TONIGHT -> source.copy(hourly = source.hourly.filter { it.time >= TONIGHT_START })
+        }
+        val todayTriggered = evaluateWardrobeRules(periodForecast, prefs.wardrobeRules)
         // Calendar events are gated on both the opt-in pref AND a configured reader.
         // Failures (missing permission, provider crash) degrade to no events so a
         // misbehaving reader can never fail the insight pipeline; the rest of the
         // summary still renders. Capture the property as a local so the smart-cast
         // survives across the runCatching lambda boundary.
         val reader = calendarEventReader
-        val events = if (prefs.useCalendarEvents && reader != null) {
+        val allEvents = if (prefs.useCalendarEvents && reader != null) {
             runCatching {
                 reader.eventsForDay(bundle.today.date, prefs.schedule.zoneId)
             }.getOrDefault(emptyList())
         } else {
             emptyList()
         }
+        val periodEvents = filterEventsForPeriod(allEvents, period)
         val summary = renderInsightSummary(
-            today = bundle.today,
+            today = periodForecast,
             yesterday = bundle.yesterday,
             todayTriggeredRules = todayTriggered,
             alerts = activeAlerts,
-            events = events,
+            events = periodEvents,
+            period = period,
         )
         val insight = Insight(
             summary = summary,
             recommendedItems = todayTriggered.map { it.item },
             generatedAt = clock.instant(),
             forDate = bundle.today.date,
-            hourly = bundle.today.hourly,
+            hourly = periodForecast.hourly,
             confidence = bundle.confidence,
-            outfit = OutfitSuggestion.fromForecast(bundle.today),
+            outfit = OutfitSuggestion.fromForecast(periodForecast),
+            period = period,
+            hasEvents = periodEvents.isNotEmpty(),
         )
         return DailyInsightResult(insight = insight, alerts = activeAlerts)
+    }
+
+    private fun filterEventsForPeriod(
+        events: List<CalendarEvent>,
+        period: ForecastPeriod,
+    ): List<CalendarEvent> = when (period) {
+        ForecastPeriod.TODAY -> events
+        // Tonight = anything starting at or after 19:00 today, OR an all-day event
+        // that bleeds across the evening (treated as relevant context).
+        ForecastPeriod.TONIGHT -> events.filter { it.allDay || !it.start.isBefore(TONIGHT_START) }
+    }
+
+    private companion object {
+        private val TONIGHT_START: LocalTime = LocalTime.of(19, 0)
     }
 }
 

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsight.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsight.kt
@@ -1,12 +1,15 @@
 package app.clothescast.core.domain.usecase
 
 import app.clothescast.core.domain.model.CalendarEvent
+import app.clothescast.core.domain.model.DailyForecast
 import app.clothescast.core.domain.model.ForecastPeriod
+import app.clothescast.core.domain.model.HourlyForecast
 import app.clothescast.core.domain.model.Insight
 import app.clothescast.core.domain.model.Location
 import app.clothescast.core.domain.model.OutfitSuggestion
 import app.clothescast.core.domain.model.UserPreferences
 import app.clothescast.core.domain.model.WeatherAlert
+import app.clothescast.core.domain.model.WeatherCondition
 import app.clothescast.core.domain.repository.CalendarEventReader
 import app.clothescast.core.domain.repository.WeatherRepository
 import java.time.Clock
@@ -34,14 +37,20 @@ class GenerateDailyInsight(
     ): DailyInsightResult {
         val bundle = weatherRepository.fetchForecast(location)
         val activeAlerts = bundle.alerts.filter { it.expires.isAfter(clock.instant()) }
-        // For TONIGHT, narrow the daily slice to the overnight window. The bundle's
-        // hourly already covers the full day; we just trim it to >=19:00 so the
-        // chart and the precip-peak calculation talk about tonight, not the morning
-        // hours the user already heard about.
-        val source = bundle.today
+        // For TONIGHT, narrow the daily slice to the user-configured overnight
+        // window: from the user's tonight time today, wrapping past midnight, up
+        // to the user's morning time tomorrow. We thread `prefs.tonightSchedule.time`
+        // and `prefs.schedule.time` (not fixed constants) so a user who moved
+        // either dial sees an insight that matches the alarm that just fired.
+        val tonightStart = prefs.tonightSchedule.time
+        val morningEnd = prefs.schedule.time
         val periodForecast = when (period) {
-            ForecastPeriod.TODAY -> source
-            ForecastPeriod.TONIGHT -> source.copy(hourly = source.hourly.filter { it.time >= TONIGHT_START })
+            ForecastPeriod.TODAY -> bundle.today
+            ForecastPeriod.TONIGHT -> bundle.today.slicedForTonight(
+                tonightStart = tonightStart,
+                morningEnd = morningEnd,
+                tomorrowHourly = bundle.tomorrowHourly,
+            )
         }
         val todayTriggered = evaluateWardrobeRules(periodForecast, prefs.wardrobeRules)
         // Calendar events are gated on both the opt-in pref AND a configured reader.
@@ -57,7 +66,7 @@ class GenerateDailyInsight(
         } else {
             emptyList()
         }
-        val periodEvents = filterEventsForPeriod(allEvents, period)
+        val periodEvents = filterEventsForPeriod(allEvents, period, tonightStart)
         val summary = renderInsightSummary(
             today = periodForecast,
             yesterday = bundle.yesterday,
@@ -83,16 +92,80 @@ class GenerateDailyInsight(
     private fun filterEventsForPeriod(
         events: List<CalendarEvent>,
         period: ForecastPeriod,
+        tonightStart: LocalTime,
     ): List<CalendarEvent> = when (period) {
         ForecastPeriod.TODAY -> events
-        // Tonight = anything starting at or after 19:00 today, OR an all-day event
-        // that bleeds across the evening (treated as relevant context).
-        ForecastPeriod.TONIGHT -> events.filter { it.allDay || !it.start.isBefore(TONIGHT_START) }
+        // Tonight = anything starting at or after the tonight time, OR an all-day
+        // event that bleeds across the evening (treated as relevant context).
+        ForecastPeriod.TONIGHT -> events.filter { it.allDay || !it.start.isBefore(tonightStart) }
     }
+}
 
-    private companion object {
-        private val TONIGHT_START: LocalTime = LocalTime.of(19, 0)
+/**
+ * Slices [DailyForecast] to the overnight tonight window (today at [tonightStart]
+ * through tomorrow at [morningEnd]). Used by TONIGHT to keep the rendered insight
+ * focused on what the user will walk into between bedtime and the morning.
+ *
+ * Concatenates today's hourly entries at or after [tonightStart] with tomorrow's
+ * hourly entries strictly before [morningEnd]. Tomorrow entries keep their wall
+ * time (e.g. 06:00) — [HourlyForecast] doesn't carry a date, but the precip-peak
+ * sentence is fine with that since it talks about wall-clock times.
+ *
+ * Beyond just filtering, this also recomputes the daily-level aggregates
+ * ([DailyForecast.feelsLikeMinC] etc.) from the combined hourly so that:
+ *
+ *  - [RenderInsightSummary]'s band sentence ("Tonight will be cold to mild.") talks
+ *    about the actual overnight low — typically the pre-dawn hours from
+ *    [tomorrowHourly], which the day-level fields don't capture.
+ *  - The wardrobe rules evaluate against the overnight conditions (the user
+ *    pulling a thicker jumper because it'll be 4°C at 05:00, not the day's 18°C
+ *    midday high).
+ *  - [OutfitSuggestion.fromForecast] picks a top + bottom appropriate for what
+ *    the user will leave in tonight and arrive in tomorrow morning.
+ *  - The precip-peak fallback (when the hourly peak < 30% and it falls back to
+ *    the daily fields) doesn't surface "Rain at 12:00" on a tonight insight
+ *    after the morning rain has already passed.
+ *
+ * If [tonightStart] isn't strictly before [morningEnd] (e.g. the user set their
+ * tonight time to 03:00) we treat tonight as today-only, no wrap — anything else
+ * would either double-count hours or invert the window.
+ *
+ * Falls back to the original [DailyForecast] when the combined hourly is empty
+ * (older cached payloads, sparse fixtures, or a tonight time after the last
+ * available hour) so we still emit *something* rather than a forecast with
+ * all-zero aggregates.
+ */
+private fun DailyForecast.slicedForTonight(
+    tonightStart: LocalTime,
+    morningEnd: LocalTime,
+    tomorrowHourly: List<HourlyForecast>,
+): DailyForecast {
+    val tonightHours = hourly.filter { it.time >= tonightStart }
+    val tomorrowMorning = if (tonightStart.isBefore(morningEnd)) {
+        // Same-day window (no real "evening"); skip the overnight wrap to avoid
+        // double-counting hours with today.
+        emptyList()
+    } else {
+        tomorrowHourly.filter { it.time < morningEnd }
     }
+    val sliced = tonightHours + tomorrowMorning
+    if (sliced.isEmpty()) return copy(hourly = sliced)
+    return copy(
+        hourly = sliced,
+        temperatureMinC = sliced.minOf { it.temperatureC },
+        temperatureMaxC = sliced.maxOf { it.temperatureC },
+        feelsLikeMinC = sliced.minOf { it.feelsLikeC },
+        feelsLikeMaxC = sliced.maxOf { it.feelsLikeC },
+        precipitationProbabilityMaxPct = sliced.maxOf { it.precipitationProbabilityPct },
+        // The day's overall condition (e.g. RAIN) may have applied to morning rain
+        // that's now over. Use the condition from the wettest hour in the slice as
+        // a better proxy for "what's it doing tonight"; fall back to the day-level
+        // condition only if every overnight hour is UNKNOWN.
+        condition = sliced.maxByOrNull { it.precipitationProbabilityPct }
+            ?.condition
+            ?.takeIf { it != WeatherCondition.UNKNOWN }
+            ?: condition,
+    )
 }
 
 /**

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/RenderInsightSummary.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/RenderInsightSummary.kt
@@ -3,6 +3,7 @@ package app.clothescast.core.domain.usecase
 import app.clothescast.core.domain.model.AlertSeverity
 import app.clothescast.core.domain.model.CalendarEvent
 import app.clothescast.core.domain.model.DailyForecast
+import app.clothescast.core.domain.model.ForecastPeriod
 import app.clothescast.core.domain.model.WardrobeRule
 import app.clothescast.core.domain.model.WeatherAlert
 import app.clothescast.core.domain.model.WeatherCondition
@@ -46,10 +47,15 @@ class RenderInsightSummary {
         todayTriggeredRules: List<WardrobeRule>,
         alerts: List<WeatherAlert> = emptyList(),
         events: List<CalendarEvent> = emptyList(),
+        period: ForecastPeriod = ForecastPeriod.TODAY,
     ): String = buildList {
         alertSentence(alerts)?.let { add(it) }
-        add(bandSentence(today))
-        deltaSentence(today, yesterday)?.let { add(it) }
+        add(bandSentence(today, period))
+        // Yesterday→today deltas don't carry meaning for the tonight pass — the
+        // user already heard the morning summary referencing that comparison.
+        if (period == ForecastPeriod.TODAY) {
+            deltaSentence(today, yesterday)?.let { add(it) }
+        }
         val items = todayTriggeredRules.map { it.item }
         wardrobeSentence(items)?.let { add(it) }
         val peak = peakPrecip(today)
@@ -64,11 +70,15 @@ class RenderInsightSummary {
         return "Alert: ${top.event}."
     }
 
-    private fun bandSentence(today: DailyForecast): String {
+    private fun bandSentence(today: DailyForecast, period: ForecastPeriod): String {
         val low = TemperatureBand.forCelsius(today.feelsLikeMinC)
         val high = TemperatureBand.forCelsius(today.feelsLikeMaxC)
         val label = if (low == high) low.label else "${low.label} to ${high.label}"
-        return "Today will be $label."
+        val lead = when (period) {
+            ForecastPeriod.TODAY -> "Today"
+            ForecastPeriod.TONIGHT -> "Tonight"
+        }
+        return "$lead will be $label."
     }
 
     private fun deltaSentence(today: DailyForecast, yesterday: DailyForecast): String? {

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/model/ScheduleTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/model/ScheduleTest.kt
@@ -109,6 +109,18 @@ class ScheduleTest {
     }
 
     @Test
+    fun `defaultTonight has 7pm every day`() {
+        val schedule = Schedule.defaultTonight(london)
+        schedule.time shouldBe LocalTime.of(19, 0)
+        schedule.days shouldBe Schedule.EVERY_DAY
+    }
+
+    @Test
+    fun `defaultTonight uses provided zone`() {
+        Schedule.defaultTonight(sydney).zoneId shouldBe sydney
+    }
+
+    @Test
     fun `single-day schedule wraps to next week when now equals fire time`() {
         val schedule = Schedule(LocalTime.of(7, 0), setOf(DayOfWeek.MONDAY), london)
         // Monday 2026-04-27 at exactly 07:00 -> not strictly after, so next is following Monday.

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsightTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsightTest.kt
@@ -5,6 +5,7 @@ import app.clothescast.core.domain.model.CalendarEvent
 import app.clothescast.core.domain.model.DailyForecast
 import app.clothescast.core.domain.model.DeliveryMode
 import app.clothescast.core.domain.model.DistanceUnit
+import app.clothescast.core.domain.model.ForecastPeriod
 import app.clothescast.core.domain.model.HourlyForecast
 import app.clothescast.core.domain.model.Location
 import app.clothescast.core.domain.model.Schedule
@@ -241,6 +242,98 @@ class GenerateDailyInsightTest {
         // The summary still composes — we just lose the calendar tie-in sentence.
         result.insight.summary.shouldContain("Today will be")
         result.insight.summary.shouldNotContain("for your")
+    }
+
+    @Test
+    fun `tonight period leads with Tonight will be and skips the yesterday delta sentence`() = runTest {
+        val weather = FakeWeatherRepository(ForecastBundle(today, yesterday))
+        val subject = GenerateDailyInsight(weather, clock = clock)
+
+        val result = subject(london, prefs, ForecastPeriod.TONIGHT)
+
+        result.insight.summary.shouldContain("Tonight will be")
+        result.insight.summary.shouldNotContain("Today will be")
+        // The morning pass already mentioned the +8°C delta against yesterday;
+        // the evening pass deliberately omits it.
+        result.insight.summary.shouldNotContain("warmer today")
+        result.insight.period shouldBe ForecastPeriod.TONIGHT
+    }
+
+    @Test
+    fun `tonight period filters hourly to the overnight window`() = runTest {
+        val hourly = listOf(
+            HourlyForecast(LocalTime.of(8, 0), 10.0, 8.0, 5.0, WeatherCondition.CLEAR),
+            HourlyForecast(LocalTime.of(15, 0), 24.0, 24.0, 5.0, WeatherCondition.CLEAR),
+            HourlyForecast(LocalTime.of(20, 0), 16.0, 14.0, 10.0, WeatherCondition.CLEAR),
+            HourlyForecast(LocalTime.of(23, 0), 12.0, 10.0, 5.0, WeatherCondition.CLEAR),
+        )
+        val todayWithHourly = today.copy(hourly = hourly)
+        val weather = FakeWeatherRepository(ForecastBundle(todayWithHourly, yesterday))
+        val subject = GenerateDailyInsight(weather, clock = clock)
+
+        val result = subject(london, prefs, ForecastPeriod.TONIGHT)
+
+        // Only 20:00 and 23:00 are in the >=19:00 tonight window.
+        result.insight.hourly.map { it.time } shouldBe listOf(LocalTime.of(20, 0), LocalTime.of(23, 0))
+    }
+
+    @Test
+    fun `tonight period flags hasEvents when an evening event is present and gates the calendar sentence by it`() = runTest {
+        val zone = ZoneId.of("Europe/London")
+        val rainyEvening = today.copy(
+            precipitationProbabilityMaxPct = 60.0,
+            condition = WeatherCondition.RAIN,
+            hourly = listOf(
+                HourlyForecast(LocalTime.of(8, 0), 10.0, 8.0, 5.0, WeatherCondition.CLEAR),
+                // Peak precip is in the tonight window, after 19:00.
+                HourlyForecast(LocalTime.of(20, 0), 16.0, 14.0, 80.0, WeatherCondition.RAIN),
+            ),
+        )
+        val morningStandup = CalendarEvent(
+            title = "standup",
+            start = LocalTime.of(9, 0),
+            end = LocalTime.of(9, 30),
+        )
+        val eveningGig = CalendarEvent(
+            title = "gig",
+            start = LocalTime.of(20, 0),
+            end = LocalTime.of(22, 0),
+        )
+        val weather = FakeWeatherRepository(ForecastBundle(rainyEvening, yesterday))
+        val calendar = FakeCalendarEventReader(events = listOf(morningStandup, eveningGig))
+        val subject = GenerateDailyInsight(weather, calendarEventReader = calendar, clock = clock)
+
+        val result = subject(
+            location = london,
+            prefs = prefs.copy(useCalendarEvents = true, schedule = Schedule.default(zone)),
+            period = ForecastPeriod.TONIGHT,
+        )
+
+        // Morning event must be filtered out for the tonight pass; the gig must drive the tie-in sentence.
+        result.insight.summary.shouldContain("for your 20:00 gig")
+        result.insight.summary.shouldNotContain("standup")
+        result.insight.hasEvents shouldBe true
+    }
+
+    @Test
+    fun `tonight period reports hasEvents=false when only morning events are present`() = runTest {
+        val zone = ZoneId.of("Europe/London")
+        val morningOnly = CalendarEvent(
+            title = "standup",
+            start = LocalTime.of(9, 0),
+            end = LocalTime.of(9, 30),
+        )
+        val weather = FakeWeatherRepository(ForecastBundle(today, yesterday))
+        val calendar = FakeCalendarEventReader(events = listOf(morningOnly))
+        val subject = GenerateDailyInsight(weather, calendarEventReader = calendar, clock = clock)
+
+        val result = subject(
+            location = london,
+            prefs = prefs.copy(useCalendarEvents = true, schedule = Schedule.default(zone)),
+            period = ForecastPeriod.TONIGHT,
+        )
+
+        result.insight.hasEvents shouldBe false
     }
 
     @Test

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsightTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsightTest.kt
@@ -260,20 +260,58 @@ class GenerateDailyInsightTest {
     }
 
     @Test
-    fun `tonight period filters hourly to the overnight window`() = runTest {
-        val hourly = listOf(
+    fun `tonight period wraps from today's evening hours through tomorrow's pre-morning hours`() = runTest {
+        val todayHourly = listOf(
             HourlyForecast(LocalTime.of(8, 0), 10.0, 8.0, 5.0, WeatherCondition.CLEAR),
             HourlyForecast(LocalTime.of(15, 0), 24.0, 24.0, 5.0, WeatherCondition.CLEAR),
             HourlyForecast(LocalTime.of(20, 0), 16.0, 14.0, 10.0, WeatherCondition.CLEAR),
             HourlyForecast(LocalTime.of(23, 0), 12.0, 10.0, 5.0, WeatherCondition.CLEAR),
         )
-        val todayWithHourly = today.copy(hourly = hourly)
+        val tomorrowHourly = listOf(
+            // 03:00 and 06:00 are inside the overnight window (< default morning 07:00).
+            // The 03:00 feels-like (3.0°C) is the actual overnight low — it's lower
+            // than anything in today's hourly slice, which is the whole point of
+            // wrapping past midnight.
+            HourlyForecast(LocalTime.of(3, 0), 6.0, 3.0, 5.0, WeatherCondition.CLEAR),
+            HourlyForecast(LocalTime.of(6, 0), 8.0, 5.0, 5.0, WeatherCondition.CLEAR),
+            // 08:00 is past morning end and must be excluded.
+            HourlyForecast(LocalTime.of(8, 0), 12.0, 10.0, 5.0, WeatherCondition.CLEAR),
+        )
+        val todayWithHourly = today.copy(hourly = todayHourly)
+        val weather = FakeWeatherRepository(
+            ForecastBundle(todayWithHourly, yesterday, tomorrowHourly = tomorrowHourly),
+        )
+        val subject = GenerateDailyInsight(weather, clock = clock)
+
+        val result = subject(london, prefs, ForecastPeriod.TONIGHT)
+
+        // 20:00 + 23:00 from today, then 03:00 + 06:00 from tomorrow. 08:00 is past the
+        // default 07:00 morning end and is dropped.
+        result.insight.hourly.map { it.time } shouldBe listOf(
+            LocalTime.of(20, 0),
+            LocalTime.of(23, 0),
+            LocalTime.of(3, 0),
+            LocalTime.of(6, 0),
+        )
+        // Aggregates recomputed from the slice — overnight low (4.0°C feels-like at 03:00)
+        // is what drives the tonight band sentence and outfit, not today's daytime min.
+        result.insight.summary.shouldContain("Tonight will be freezing to cool.")
+    }
+
+    @Test
+    fun `tonight period falls back to today-only when tomorrow hourly is unavailable`() = runTest {
+        val todayHourly = listOf(
+            HourlyForecast(LocalTime.of(8, 0), 10.0, 8.0, 5.0, WeatherCondition.CLEAR),
+            HourlyForecast(LocalTime.of(20, 0), 16.0, 14.0, 10.0, WeatherCondition.CLEAR),
+            HourlyForecast(LocalTime.of(23, 0), 12.0, 10.0, 5.0, WeatherCondition.CLEAR),
+        )
+        val todayWithHourly = today.copy(hourly = todayHourly)
+        // No tomorrowHourly on the bundle (legacy forecast_days=1 path).
         val weather = FakeWeatherRepository(ForecastBundle(todayWithHourly, yesterday))
         val subject = GenerateDailyInsight(weather, clock = clock)
 
         val result = subject(london, prefs, ForecastPeriod.TONIGHT)
 
-        // Only 20:00 and 23:00 are in the >=19:00 tonight window.
         result.insight.hourly.map { it.time } shouldBe listOf(LocalTime.of(20, 0), LocalTime.of(23, 0))
     }
 


### PR DESCRIPTION
## Summary
Parallel evening insight pass alongside the existing morning one. Fires at the user's tonight time (default 19:00), updates the UI, outfit, and notification icon, and is event-aware: silent when the calendar is empty, default-priority sound + TTS when there are events.

- **`ForecastPeriod {TODAY, TONIGHT}`** drives `GenerateDailyInsight` + `RenderInsightSummary`. Tonight leads with "Tonight will be …", filters hourly to ≥19:00, drops the yesterday-delta sentence (the morning pass already mentioned it), and only considers calendar events starting ≥19:00 (or all-day).
- **Two new notification channels**: `tonight_insight_default_v1` (DEFAULT importance, plays sound) when `hasEvents=true`, `tonight_insight_silent_v1` (LOW, silent) when the evening is empty. `setSilent(true)` is also applied per-notification as belt-and-braces against OEM importance overrides. TTS speaks only when events are present.
- **Outfit top picture as the notification large icon** for *both* today and tonight notifications — same `ic_outfit_top_*` drawables the home-screen `OutfitPreviewCard` uses, so all three surfaces read as one family. The small status-bar silhouette already mirrored the top.
- **Settings**: new "Tonight insight" card on the Schedule page with enable toggle, time picker, and weekday chips, mirroring the morning section. Persisted in DataStore via `SettingsRepository.setTonightSchedule` / `setTonightEnabled`.
- **Alarm wiring**: `DailyAlarmScheduler` parameterised by period; second receiver action `FIRE_TONIGHT`; `ScheduleRefreshReceiver` re-arms both alarms on boot / tz change / package replace; `Application.onCreate` schedules both at startup.
- **Cache**: separate slot per period (`latest_insight_v2` for today, `latest_tonight_insight_v1` for tonight). The Today screen surfaces the most recent of the two so opening the app after the tonight alarm fires shows the tonight insight.
- **Tests**: `ScheduleTest` covers `defaultTonight`; `GenerateDailyInsightTest` covers TONIGHT-period summary text, hourly filtering, evening event filtering, and the `hasEvents` flag. Existing tests unchanged (period defaults to TODAY).

Followup parked as a TODO comment in `TodayScreen.kt`: overlay a sun / rain / cloud / snow glyph on the top icon and reuse the same imagery for the launcher icon (so the home-screen icon, the OutfitPreviewCard, and the notification large icon all carry both "what to wear" and "what's it doing outside").

I could not run `:core:domain:test` locally — this sandbox can't reach the Kotlin compose plugin from the Gradle plugin portal. Relying on CI as the validation surface.

## Test plan
- [ ] CI: `JVM unit tests` job is green (covers the new domain tests + the `SettingsViewModelTest` constructor change)
- [ ] CI: `Android debug build` job is green (covers the manifest receiver action, channel registrar, notifier wiring, and the Schedule UI changes)
- [ ] On-device: morning insight at 07:00 still fires and now carries the top picture as a large icon
- [ ] On-device: tonight insight at 19:00 fires, posts on the silent channel with no sound when the evening is empty
- [ ] On-device: with a calendar event scheduled after 19:00 and `useCalendarEvents=true`, the tonight insight posts on the default channel with sound, summary mentions "for your … <event>", and TTS speaks if the user has TTS enabled
- [ ] On-device: toggling "Show a tonight insight" off in Settings cancels the pending tonight alarm; toggling it back on rearms it
- [ ] On-device: lock-screen reading of both notifications is reasonable (large icon + summary visible)

https://claude.ai/code/session_01L77HpCpDSqkFYEn9sPkhUg

---
_Generated by [Claude Code](https://claude.ai/code/session_01L77HpCpDSqkFYEn9sPkhUg)_