### PR TITLE
:app + :core — fit hourly chart to width instead of starting zoomed-in

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/today/ForecastChart.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/ForecastChart.kt
@@ -15,6 +15,8 @@ import com.patrykandpatrick.vico.compose.cartesian.axis.rememberBottom
 import com.patrykandpatrick.vico.compose.cartesian.axis.rememberStart
 import com.patrykandpatrick.vico.compose.cartesian.layer.rememberLineCartesianLayer
 import com.patrykandpatrick.vico.compose.cartesian.rememberCartesianChart
+import com.patrykandpatrick.vico.compose.cartesian.rememberVicoZoomState
+import com.patrykandpatrick.vico.core.cartesian.Zoom
 import com.patrykandpatrick.vico.core.cartesian.axis.HorizontalAxis
 import com.patrykandpatrick.vico.core.cartesian.axis.VerticalAxis
 import com.patrykandpatrick.vico.core.cartesian.data.CartesianChartModelProducer
@@ -71,6 +73,11 @@ fun ForecastChart(
             bottomAxis = HorizontalAxis.rememberBottom(valueFormatter = bottomFormatter),
         ),
         modelProducer = producer,
+        // Vico's default initial zoom is `max(fixed, content)`, which on a 24-point
+        // hourly series renders only the first ~10 hours and hides the rest behind
+        // a scroll. Force-fit instead so the full day is visible at a glance — this
+        // is a glanceable summary card, not an interactive explorer.
+        zoomState = rememberVicoZoomState(initialZoom = Zoom.Content),
         modifier = modifier
             .fillMaxWidth()
             .height(180.dp),

--- a/core/data/src/main/kotlin/app/clothescast/core/data/weather/OpenMeteoClient.kt
+++ b/core/data/src/main/kotlin/app/clothescast/core/data/weather/OpenMeteoClient.kt
@@ -21,14 +21,12 @@ internal const val OPEN_METEO_HOST = "api.open-meteo.com"
  * actuals plus today's and tomorrow's forecast in one call. Free, key-less. Free-tier
  * soft cap is 10k requests/day; this app makes one call per device per day.
  *
- * `forecast_days=2` (not 1) does double duty:
- *  - Today's hourly array reliably covers all 24 hours regardless of when in the day
- *    the worker fires. With `forecast_days=1` Open-Meteo's hourly window stops short
- *    of end-of-day for late-morning calls — the chart was truncating at "now" instead
- *    of showing the full afternoon.
- *  - Tomorrow's pre-dawn hourly entries are exposed via [ForecastBundle.tomorrowHourly]
- *    so the tonight insight can wrap from 19:00 today through 07:00 next morning, and
- *    its overnight low / pre-dawn rain reflect what the user will actually walk into.
+ * `forecast_days=2` (not 1) is to expose tomorrow's pre-dawn hourly entries via
+ * [ForecastBundle.tomorrowHourly] so the tonight insight can wrap from 19:00 today
+ * through 07:00 next morning, and its overnight low / pre-dawn rain reflect what the
+ * user will actually walk into. Today's hourly is always complete regardless of
+ * `forecast_days` — Open-Meteo anchors its hourly window to local 00:00 — so the
+ * count doesn't matter for the today chart.
  *
  * The mapper splits today's vs tomorrow's hourly entries by date and keeps the daily
  * fields (yesterday + today only) untouched.

--- a/core/data/src/test/kotlin/app/clothescast/core/data/weather/OpenMeteoMapperTest.kt
+++ b/core/data/src/test/kotlin/app/clothescast/core/data/weather/OpenMeteoMapperTest.kt
@@ -78,11 +78,11 @@ class OpenMeteoMapperTest {
 
     @Test
     fun `today hourly stays full when response includes a tomorrow day`() {
-        // Pinned by the forecast_days=2 request. Open-Meteo's hourly window for
-        // forecast_days=1 was stopping short of end-of-today on late-morning calls;
-        // bumping to 2 guarantees today's full 24 hours regardless of clock time.
-        // The mapper must keep ignoring tomorrow's daily slot and keep date-filtering
-        // tomorrow's hourly entries out of today.
+        // Pinned by the forecast_days=2 request — we ask for tomorrow's pre-dawn
+        // hourly so the tonight insight can wrap past midnight. The mapper must
+        // keep ignoring tomorrow's daily slot and keep date-filtering tomorrow's
+        // hourly entries out of today, so today's chart is unaffected by the
+        // extra day in the response.
         val threeDay = OpenMeteoResponse(
             timezone = "UTC",
             daily = DailyData(


### PR DESCRIPTION
## Summary

The Today screen's hourly chart only renders the first ~10 of 24 hours
("00h–09h or so" as the user reported it on v157). The remaining hours
are hidden behind a horizontal scroll Vico never advertises.

PR-author note: this fix supersedes the misdiagnosis in 49c2d16, which
attributed the truncation to Open-Meteo and bumped `forecast_days` from
1 to 2 to "guarantee" today's full hourly. That didn't help — Open-Meteo
always anchors its hourly window to local 00:00, so a single day's
request already includes today 00:00–23:00 regardless of clock time.
The user kept seeing "00h–09h" on v157 because the data was always
there; only the rendered slice was clipped.

The real cause is Vico's default `initialZoom = max(Zoom.fixed(), Zoom.Content)`,
which on a 24-point series resolves to a zoom that renders ~10 points wide.

### Changes
- `ForecastChart.kt`: pass `zoomState = rememberVicoZoomState(initialZoom = Zoom.Content)`
  to the `CartesianChartHost` so the full day's line fits the card on
  first composition. This is a glanceable summary, not an interactive
  explorer — there's no value in starting it scrolled.
- `OpenMeteoClient.kt`: rewrite the docstring around `forecast_days=2`
  so it reflects the only reason that's actually load-bearing — the
  tonight insight needs tomorrow's pre-dawn hourly to wrap past
  midnight. Keep `forecast_days=2` itself.
- `OpenMeteoMapperTest.kt`: update the rationale comment on
  `today hourly stays full when response includes a tomorrow day` for
  the same reason; the test is unchanged.

## Test plan

- [ ] CI: `:core:*:test` and `:app:testDebugUnitTest` green (no behavior
      changes; comment-only updates outside the chart file).
- [ ] CI: `:app:assembleDebug` green.
- [ ] On-device check at versionCode ≥ 158: open the Today screen with
      a same-day cached insight and confirm the chart shows hours
      00–23 across the full card width, no horizontal scroll needed.

https://claude.ai/code/session_01Re59AhPw54yAArE63S1m7d

---
_Generated by [Claude Code](https://claude.ai/code/session_01Re59AhPw54yAArE63S1m7d)_