### PR TITLE
:app — diagnostic: labelled bitmaps in setSmallIcon vs setLargeIcon

### DIFF
--- a/app/src/main/kotlin/app/clothescast/notification/InsightNotifier.kt
+++ b/app/src/main/kotlin/app/clothescast/notification/InsightNotifier.kt
@@ -6,17 +6,18 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
 import android.os.Build
-import androidx.annotation.DrawableRes
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.ContextCompat
-import androidx.core.content.res.ResourcesCompat
-import androidx.core.graphics.drawable.toBitmap
+import androidx.core.graphics.createBitmap
+import androidx.core.graphics.drawable.IconCompat
 import app.clothescast.MainActivity
 import app.clothescast.R
 import app.clothescast.core.domain.model.Insight
-import app.clothescast.core.domain.model.OutfitSuggestion
 import app.clothescast.insight.InsightFormatter
 
 /**
@@ -44,13 +45,16 @@ class InsightNotifier(
             PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
         )
 
-        // The small status-bar icon mirrors the recommended top (silhouette).
-        // The large icon picks up the same top in full colour so the expanded
-        // notification carries the same glanceable "what to wear today" cue the
-        // Today screen's OutfitPreviewCard does.
+        // Diagnostic build: feed two visually distinct labelled bitmaps into
+        // setSmallIcon and setLargeIcon so we can see on-device which API maps
+        // to the left-hand avatar slot vs. any thumbnail / status-bar /
+        // corner-badge slot. "S" on a red background = setSmallIcon. "L" on a
+        // green background = setLargeIcon. Wherever each letter lands, that's
+        // where the API rendered. Once eyeballed on Android 16 we'll drop the
+        // losing API and put the real outfit drawable into the winner.
         val notification = NotificationCompat.Builder(context, CHANNEL_DAILY_INSIGHT)
-            .setSmallIcon(smallIconFor(insight.outfit?.top))
-            .setLargeIcon(largeIconForTop(context, insight.outfit?.top))
+            .setSmallIcon(IconCompat.createWithBitmap(diagnosticBitmap("S", Color.RED)))
+            .setLargeIcon(diagnosticBitmap("L", Color.rgb(0, 160, 0)))
             .setContentTitle(context.getString(R.string.notification_daily_insight_title))
             .setContentText(prose)
             .setStyle(NotificationCompat.BigTextStyle().bigText(prose))
@@ -76,40 +80,28 @@ class InsightNotifier(
         const val NOTIFICATION_ID_DAILY_INSIGHT = 1001
         private const val REQUEST_OPEN_APP = 100
 
-        // The status-bar silhouette mirrors the recommended top so a glance at the
-        // notification shade already says "sweater day" / "jacket day" before the
-        // user reads anything. ic_notification_insight is itself a t-shirt silhouette,
-        // so it doubles as both the TSHIRT case and the null fallback (older cached
-        // insights without an outfit, weather alerts).
-        internal fun smallIconFor(top: OutfitSuggestion.Top?): Int = when (top) {
-            OutfitSuggestion.Top.SWEATER -> R.drawable.ic_notification_top_sweater
-            OutfitSuggestion.Top.THICK_JACKET -> R.drawable.ic_notification_top_thick_jacket
-            OutfitSuggestion.Top.TSHIRT, null -> R.drawable.ic_notification_insight
-        }
-
         /**
-         * Renders the recommended top as a Bitmap for [NotificationCompat.Builder.setLargeIcon].
-         * Reuses the full-colour `ic_outfit_top_*` drawables from [OutfitPreviewCard]
-         * so the notification visual matches the home-screen card. Returns null when
-         * the outfit is missing (older cached payloads), letting the system fall back
-         * to no large icon.
+         * Builds a 192×192 solid-colour bitmap with [label] drawn in white in
+         * the centre. Diagnostic-only — the labels let us tell on-device which
+         * Notification API rendered which slot ("S" = small icon, "L" = large
+         * icon), so we know where to put the real outfit drawable once the
+         * avatar slot is identified.
          */
-        internal fun largeIconForTop(context: Context, top: OutfitSuggestion.Top?): Bitmap? {
-            val drawableRes = largeTopDrawable(top) ?: return null
-            val drawable = ResourcesCompat.getDrawable(context.resources, drawableRes, context.theme)
-                ?: return null
-            val sizePx = context.resources.getDimensionPixelSize(android.R.dimen.notification_large_icon_width)
-                .takeIf { it > 0 }
-                ?: 192
-            return drawable.toBitmap(width = sizePx, height = sizePx)
-        }
-
-        @DrawableRes
-        private fun largeTopDrawable(top: OutfitSuggestion.Top?): Int? = when (top) {
-            OutfitSuggestion.Top.TSHIRT -> R.drawable.ic_outfit_tshirt
-            OutfitSuggestion.Top.SWEATER -> R.drawable.ic_outfit_sweater
-            OutfitSuggestion.Top.THICK_JACKET -> R.drawable.ic_outfit_thick_jacket
-            null -> null
+        internal fun diagnosticBitmap(label: String, backgroundColor: Int): Bitmap {
+            val sizePx = 192
+            val bitmap = createBitmap(sizePx, sizePx)
+            val canvas = Canvas(bitmap)
+            canvas.drawColor(backgroundColor)
+            val paint = Paint().apply {
+                color = Color.WHITE
+                textSize = 128f
+                textAlign = Paint.Align.CENTER
+                isAntiAlias = true
+                isFakeBoldText = true
+            }
+            val baseline = sizePx / 2f - (paint.descent() + paint.ascent()) / 2f
+            canvas.drawText(label, sizePx / 2f, baseline, paint)
+            return bitmap
         }
     }
 }

--- a/app/src/main/kotlin/app/clothescast/notification/TonightInsightNotifier.kt
+++ b/app/src/main/kotlin/app/clothescast/notification/TonightInsightNotifier.kt
@@ -5,10 +5,12 @@ import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.graphics.Color
 import android.os.Build
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.ContextCompat
+import androidx.core.graphics.drawable.IconCompat
 import app.clothescast.MainActivity
 import app.clothescast.R
 import app.clothescast.core.domain.model.Insight
@@ -50,9 +52,12 @@ class TonightInsightNotifier(
         val channel = if (insight.hasEvents) CHANNEL_TONIGHT_INSIGHT_DEFAULT else CHANNEL_TONIGHT_INSIGHT_SILENT
         val priority = if (insight.hasEvents) NotificationCompat.PRIORITY_DEFAULT else NotificationCompat.PRIORITY_LOW
 
+        // Diagnostic: see InsightNotifier for the labelled-bitmap rationale.
+        // "T-S" / "T-L" so we can tell tonight notifications apart from the
+        // daily ones if both happen to be on screen at once.
         val notification = NotificationCompat.Builder(context, channel)
-            .setSmallIcon(InsightNotifier.smallIconFor(insight.outfit?.top))
-            .setLargeIcon(InsightNotifier.largeIconForTop(context, insight.outfit?.top))
+            .setSmallIcon(IconCompat.createWithBitmap(InsightNotifier.diagnosticBitmap("T-S", Color.RED)))
+            .setLargeIcon(InsightNotifier.diagnosticBitmap("T-L", Color.rgb(0, 160, 0)))
             .setContentTitle(context.getString(R.string.notification_tonight_insight_title))
             .setContentText(prose)
             .setStyle(NotificationCompat.BigTextStyle().bigText(prose))


### PR DESCRIPTION
## Summary

Diagnostic build for the "outfit on the left, no duplicate on the right" ask from v0.1.0+157. Google's docs only label the small icon as "required" and the large icon as an "optional thumbnail" / "contact photo" slot, with no Android 16-specific layout guidance, so rather than keep guessing this branch puts **two unmistakably distinct labelled bitmaps** into the small and large icon slots so the avatar position can be read off a single screenshot:

- `setSmallIcon` ← solid **red** 192×192 with a white **"S"** (built via `IconCompat.createWithBitmap`)
- `setLargeIcon` ← solid **green** 192×192 with a white **"L"**

Tonight notifications use `T-S` / `T-L` so daily and tonight can be told apart if both are on screen. Both notifiers share the same `InsightNotifier.diagnosticBitmap(label, color)` helper.

`WeatherAlertNotifier` is unchanged.

## Why labelled colours, not "colour outfit in both slots"

With the same outfit bitmap in both slots, you can't tell which API rendered which. With distinct labelled bitmaps, the answer is unambiguous from one screenshot.

## Why we ruled out the other paths (so far)

- **`MessagingStyle` + `Person` avatar.** Documented mechanism for "circular avatar on the left," but Google's [conversations guide](https://developer.android.com/develop/ui/views/notifications/conversations) explicitly scopes it to "real-time conversations" and on Android 11+ requires a long-lived dynamic shortcut to actually get the avatar treatment. Side effects: notification routes to the Conversations priority section in the shade, plumbing for shortcut + Person data, possible DnD-bypass surfacing. Held in reserve in case neither small nor large gives us the avatar slot we want.
- **Drop large icon, keep silhouette small icon.** Tried first; turns out the LEFT circle on Pixel/Android 16 isn't the small icon — it's the launcher icon (`ic_launcher_background.xml` is `#87CEEB` sky blue, foreground is the t-shirt-with-sun, which matches the user's screenshot). So that approach removed the colour outfit without putting it where we wanted.

## How to use this build

1. Wait for CI green.
2. Sideload the debug APK on an Android 16 device.
3. Trigger the daily / tonight insight notification (manual fetch in the app, or wait for the scheduled work).
4. Look at the notification shade and read off:
   - Which slot shows **"S"** (red)? → that's `setSmallIcon`.
   - Which slot shows **"L"** (green)? → that's `setLargeIcon`.
   - If a letter is missing, that API didn't render anywhere visible.
5. Also note the status-bar icon — a colour bitmap small icon may appear there as a solid blob, which is a separate problem from where the avatar lands.

## Test plan

- [ ] CI green (JVM tests + Android debug build).
- [ ] APK installed on Android 16; observed `S` and `L` placement in both daily and tonight notifications.
- [ ] Status-bar icon legibility checked.
- [ ] Follow-up commit replaces the diagnostic helper with the real `ic_outfit_top_*` drawable in the winning slot, removes the losing API's call, and drops any silhouette helper / drawables / snapshot previews left unused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)