### PR TITLE
:app — link to PRIVACY.md from the About card

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/settings/AboutSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/AboutSettings.kt
@@ -65,6 +65,12 @@ private fun AboutCard() {
             style = MaterialTheme.typography.bodyMedium,
         )
         TextButton(
+            onClick = {
+                openUrl(context, "https://github.com/mikelward/clothescast/blob/main/PRIVACY.md")
+            },
+            modifier = Modifier.fillMaxWidth(),
+        ) { Text(stringResource(R.string.settings_about_privacy_policy)) }
+        TextButton(
             onClick = { openUrl(context, "https://github.com/mikelward/clothescast") },
             modifier = Modifier.fillMaxWidth(),
         ) { Text(stringResource(R.string.settings_about_source)) }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -204,6 +204,7 @@
          comes straight from BuildConfig.BUILD_TYPE and isn't translated. -->
     <string name="settings_about_build_type_suffix"> · %1$s build</string>
     <string name="settings_about_privacy">Your Gemini API key (used for spoken-aloud TTS) is encrypted at rest using a key bound to the Android Keystore. Forecasts come from Open-Meteo (no key, no account); the daily summary text is rendered locally on-device. ClothesCast does not have a backend — nothing is sent to any server we control.</string>
+    <string name="settings_about_privacy_policy">Privacy policy</string>
     <string name="settings_about_source">Source code on GitHub</string>
     <string name="settings_about_dontkillmyapp">Background restrictions (dontkillmyapp.com)</string>
 </resources>


### PR DESCRIPTION
## Summary

- Adds a "Privacy policy" `TextButton` to the About card in Settings, alongside the existing Source / dontkillmyapp links.
- Tapping it opens `https://github.com/mikelward/clothescast/blob/main/PRIVACY.md` — the canonical location the policy itself names as the source of truth.
- Placed directly under the existing privacy explainer paragraph so the descriptive text leads naturally into the link.

## Test plan

- [ ] Sandbox can't run `:app:assembleDebug` — relying on CI to compile the resource + Compose change.
- [ ] On-device: open Settings → About, tap **Privacy policy**, confirm the policy renders in the browser.
- [ ] Confirm the existing Source / Background-restrictions buttons still work and ordering looks right.

---
_Generated by [Claude Code](https://claude.ai/code/session_018ngyv3exJLioDiVsRivUdV)_