### PR TITLE
:app — revert notification icons to v157 (silhouette + colour large icon)

### DIFF
--- a/app/src/main/kotlin/app/clothescast/notification/InsightNotifier.kt
+++ b/app/src/main/kotlin/app/clothescast/notification/InsightNotifier.kt
@@ -6,18 +6,17 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.graphics.Bitmap
-import android.graphics.Canvas
-import android.graphics.Color
-import android.graphics.Paint
 import android.os.Build
+import androidx.annotation.DrawableRes
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.ContextCompat
-import androidx.core.graphics.createBitmap
-import androidx.core.graphics.drawable.IconCompat
+import androidx.core.content.res.ResourcesCompat
+import androidx.core.graphics.drawable.toBitmap
 import app.clothescast.MainActivity
 import app.clothescast.R
 import app.clothescast.core.domain.model.Insight
+import app.clothescast.core.domain.model.OutfitSuggestion
 import app.clothescast.insight.InsightFormatter
 
 /**
@@ -45,16 +44,13 @@ class InsightNotifier(
             PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
         )
 
-        // Diagnostic build: feed two visually distinct labelled bitmaps into
-        // setSmallIcon and setLargeIcon so we can see on-device which API maps
-        // to the left-hand avatar slot vs. any thumbnail / status-bar /
-        // corner-badge slot. "S" on a red background = setSmallIcon. "L" on a
-        // green background = setLargeIcon. Wherever each letter lands, that's
-        // where the API rendered. Once eyeballed on Android 16 we'll drop the
-        // losing API and put the real outfit drawable into the winner.
+        // The small status-bar icon mirrors the recommended top (silhouette).
+        // The large icon picks up the same top in full colour so the expanded
+        // notification carries the same glanceable "what to wear today" cue the
+        // Today screen's OutfitPreviewCard does.
         val notification = NotificationCompat.Builder(context, CHANNEL_DAILY_INSIGHT)
-            .setSmallIcon(IconCompat.createWithBitmap(diagnosticBitmap("S", Color.RED)))
-            .setLargeIcon(diagnosticBitmap("L", Color.rgb(0, 160, 0)))
+            .setSmallIcon(smallIconFor(insight.outfit?.top))
+            .setLargeIcon(largeIconForTop(context, insight.outfit?.top))
             .setContentTitle(context.getString(R.string.notification_daily_insight_title))
             .setContentText(prose)
             .setStyle(NotificationCompat.BigTextStyle().bigText(prose))
@@ -80,28 +76,40 @@ class InsightNotifier(
         const val NOTIFICATION_ID_DAILY_INSIGHT = 1001
         private const val REQUEST_OPEN_APP = 100
 
+        // The status-bar silhouette mirrors the recommended top so a glance at the
+        // notification shade already says "sweater day" / "jacket day" before the
+        // user reads anything. ic_notification_insight is itself a t-shirt silhouette,
+        // so it doubles as both the TSHIRT case and the null fallback (older cached
+        // insights without an outfit, weather alerts).
+        internal fun smallIconFor(top: OutfitSuggestion.Top?): Int = when (top) {
+            OutfitSuggestion.Top.SWEATER -> R.drawable.ic_notification_top_sweater
+            OutfitSuggestion.Top.THICK_JACKET -> R.drawable.ic_notification_top_thick_jacket
+            OutfitSuggestion.Top.TSHIRT, null -> R.drawable.ic_notification_insight
+        }
+
         /**
-         * Builds a 192×192 solid-colour bitmap with [label] drawn in white in
-         * the centre. Diagnostic-only — the labels let us tell on-device which
-         * Notification API rendered which slot ("S" = small icon, "L" = large
-         * icon), so we know where to put the real outfit drawable once the
-         * avatar slot is identified.
+         * Renders the recommended top as a Bitmap for [NotificationCompat.Builder.setLargeIcon].
+         * Reuses the full-colour `ic_outfit_top_*` drawables from [OutfitPreviewCard]
+         * so the notification visual matches the home-screen card. Returns null when
+         * the outfit is missing (older cached payloads), letting the system fall back
+         * to no large icon.
          */
-        internal fun diagnosticBitmap(label: String, backgroundColor: Int): Bitmap {
-            val sizePx = 192
-            val bitmap = createBitmap(sizePx, sizePx)
-            val canvas = Canvas(bitmap)
-            canvas.drawColor(backgroundColor)
-            val paint = Paint().apply {
-                color = Color.WHITE
-                textSize = 128f
-                textAlign = Paint.Align.CENTER
-                isAntiAlias = true
-                isFakeBoldText = true
-            }
-            val baseline = sizePx / 2f - (paint.descent() + paint.ascent()) / 2f
-            canvas.drawText(label, sizePx / 2f, baseline, paint)
-            return bitmap
+        internal fun largeIconForTop(context: Context, top: OutfitSuggestion.Top?): Bitmap? {
+            val drawableRes = largeTopDrawable(top) ?: return null
+            val drawable = ResourcesCompat.getDrawable(context.resources, drawableRes, context.theme)
+                ?: return null
+            val sizePx = context.resources.getDimensionPixelSize(android.R.dimen.notification_large_icon_width)
+                .takeIf { it > 0 }
+                ?: 192
+            return drawable.toBitmap(width = sizePx, height = sizePx)
+        }
+
+        @DrawableRes
+        private fun largeTopDrawable(top: OutfitSuggestion.Top?): Int? = when (top) {
+            OutfitSuggestion.Top.TSHIRT -> R.drawable.ic_outfit_tshirt
+            OutfitSuggestion.Top.SWEATER -> R.drawable.ic_outfit_sweater
+            OutfitSuggestion.Top.THICK_JACKET -> R.drawable.ic_outfit_thick_jacket
+            null -> null
         }
     }
 }

--- a/app/src/main/kotlin/app/clothescast/notification/TonightInsightNotifier.kt
+++ b/app/src/main/kotlin/app/clothescast/notification/TonightInsightNotifier.kt
@@ -5,12 +5,10 @@ import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
-import android.graphics.Color
 import android.os.Build
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.ContextCompat
-import androidx.core.graphics.drawable.IconCompat
 import app.clothescast.MainActivity
 import app.clothescast.R
 import app.clothescast.core.domain.model.Insight
@@ -52,12 +50,9 @@ class TonightInsightNotifier(
         val channel = if (insight.hasEvents) CHANNEL_TONIGHT_INSIGHT_DEFAULT else CHANNEL_TONIGHT_INSIGHT_SILENT
         val priority = if (insight.hasEvents) NotificationCompat.PRIORITY_DEFAULT else NotificationCompat.PRIORITY_LOW
 
-        // Diagnostic: see InsightNotifier for the labelled-bitmap rationale.
-        // "T-S" / "T-L" so we can tell tonight notifications apart from the
-        // daily ones if both happen to be on screen at once.
         val notification = NotificationCompat.Builder(context, channel)
-            .setSmallIcon(IconCompat.createWithBitmap(InsightNotifier.diagnosticBitmap("T-S", Color.RED)))
-            .setLargeIcon(InsightNotifier.diagnosticBitmap("T-L", Color.rgb(0, 160, 0)))
+            .setSmallIcon(InsightNotifier.smallIconFor(insight.outfit?.top))
+            .setLargeIcon(InsightNotifier.largeIconForTop(context, insight.outfit?.top))
             .setContentTitle(context.getString(R.string.notification_tonight_insight_title))
             .setContentText(prose)
             .setStyle(NotificationCompat.BigTextStyle().bigText(prose))


### PR DESCRIPTION
## Summary

PR #109 shipped a diagnostic build (red "S" / green "L" labelled bitmaps in `setSmallIcon` and `setLargeIcon`) to find out which Notification API drives the LEFT avatar slot on Android 16. The on-device result:

- **LEFT (avatar)**: launcher icon. Neither `setSmallIcon` nor `setLargeIcon` overrides it.
- **RIGHT**: green "L" (i.e. `setLargeIcon`).
- **Red "S" (`setSmallIcon`)**: not visible in the body of the notification; tucked into the status bar / corner badge.

So the only way to put the *dynamic outfit* on the LEFT is `MessagingStyle` with a long-lived shortcut + `Person`, accepting the Conversations-section / DnD-bypass side effects. Going with the simpler call: **accept the launcher icon on the left**, restore the v157 layout verbatim.

This PR rolls `InsightNotifier.kt` and `TonightInsightNotifier.kt` back to commit `760ed96`:

- `setSmallIcon` ← outfit-specific silhouette (`ic_notification_top_*`)
- `setLargeIcon` ← colour outfit (`ic_outfit_top_*`)
- `smallIconFor` / `largeIconForTop` helpers re-introduced
- `diagnosticBitmap` removed → users stop seeing the red-S / green-L diagnostic notification

Other files (silhouette XMLs, colour outfit drawables, snapshot previews, weather-alert notifier) are unchanged from `main` — the diagnostic only ever modified the two notifier files, so this revert touches only those two.

## Test plan

- [ ] CI green (JVM tests + Android debug build).
- [ ] Sideload the resulting APK on Android 16 and confirm the daily / tonight notifications match v157: launcher-icon avatar on the left, colour outfit on the right.
- [ ] Status-bar icon is back to a clean tinted silhouette (no more solid red square).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EvR9MkoGc8naVen5gMtQ7m)_