### PR TITLE
:core — slice TODAY hourly to the daytime window, mirroring TONIGHT

### DIFF
--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsight.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsight.kt
@@ -37,18 +37,24 @@ class GenerateDailyInsight(
     ): DailyInsightResult {
         val bundle = weatherRepository.fetchForecast(location)
         val activeAlerts = bundle.alerts.filter { it.expires.isAfter(clock.instant()) }
-        // For TONIGHT, narrow the daily slice to the user-configured overnight
-        // window: from the user's tonight time today, wrapping past midnight, up
-        // to the user's morning time tomorrow. We thread `prefs.tonightSchedule.time`
-        // and `prefs.schedule.time` (not fixed constants) so a user who moved
-        // either dial sees an insight that matches the alarm that just fired.
+        // Each period is narrowed to the user-configured window so the insight
+        // talks about hours the user will actually walk into:
+        //  - TODAY = morning time → tonight time (e.g. 07:00–19:00)
+        //  - TONIGHT = tonight time → next morning time (e.g. 19:00–07:00, wrapping
+        //    past midnight via tomorrow's hourly)
+        // Both reads pull from `prefs.schedule.time` and `prefs.tonightSchedule.time`
+        // (not fixed constants) so a user who moved either dial sees an insight
+        // that matches the alarm that just fired.
+        val morningStart = prefs.schedule.time
         val tonightStart = prefs.tonightSchedule.time
-        val morningEnd = prefs.schedule.time
         val periodForecast = when (period) {
-            ForecastPeriod.TODAY -> bundle.today
+            ForecastPeriod.TODAY -> bundle.today.slicedForToday(
+                morningStart = morningStart,
+                eveningEnd = tonightStart,
+            )
             ForecastPeriod.TONIGHT -> bundle.today.slicedForTonight(
                 tonightStart = tonightStart,
-                morningEnd = morningEnd,
+                morningEnd = morningStart,
                 tomorrowHourly = bundle.tomorrowHourly,
             )
         }
@@ -99,6 +105,48 @@ class GenerateDailyInsight(
         // event that bleeds across the evening (treated as relevant context).
         ForecastPeriod.TONIGHT -> events.filter { it.allDay || !it.start.isBefore(tonightStart) }
     }
+}
+
+/**
+ * Slices [DailyForecast] to the daytime window (today at [morningStart] through
+ * today at [eveningEnd]). The TODAY counterpart of [slicedForTonight]: keeps the
+ * rendered insight, wardrobe evaluation and outfit suggestion focused on the
+ * hours the user is awake and out, not on past pre-dawn hours or a late-evening
+ * peak the user has already gone to bed for.
+ *
+ * Behaves like [slicedForTonight]:
+ *  - filters today's hourly to entries in `[morningStart, eveningEnd)`,
+ *  - recomputes daily-level aggregates ([feelsLikeMinC] etc.) from the slice so
+ *    the band sentence and wardrobe rules talk about the daytime range, not the
+ *    raw 24h day-level fields,
+ *  - rewrites [DailyForecast.condition] to the wettest in-window hour (preventing
+ *    the precip-peak fallback from naming a midday rain on a sunny afternoon),
+ *  - falls back to the original [DailyForecast] when the slice would be empty
+ *    (sparse fixtures, legacy day-level-only payloads, or a degenerate
+ *    `morningStart >= eveningEnd` window) so the pipeline always emits something.
+ */
+private fun DailyForecast.slicedForToday(
+    morningStart: LocalTime,
+    eveningEnd: LocalTime,
+): DailyForecast {
+    // Degenerate window (user's day end is at or before its start). Bail out
+    // rather than produce an empty or wrapped slice; the tonight pass covers
+    // overnight users via its own wrap.
+    if (!morningStart.isBefore(eveningEnd)) return this
+    val sliced = hourly.filter { it.time >= morningStart && it.time < eveningEnd }
+    if (sliced.isEmpty()) return copy(hourly = sliced)
+    return copy(
+        hourly = sliced,
+        temperatureMinC = sliced.minOf { it.temperatureC },
+        temperatureMaxC = sliced.maxOf { it.temperatureC },
+        feelsLikeMinC = sliced.minOf { it.feelsLikeC },
+        feelsLikeMaxC = sliced.maxOf { it.feelsLikeC },
+        precipitationProbabilityMaxPct = sliced.maxOf { it.precipitationProbabilityPct },
+        condition = sliced.maxByOrNull { it.precipitationProbabilityPct }
+            ?.condition
+            ?.takeIf { it != WeatherCondition.UNKNOWN }
+            ?: condition,
+    )
 }
 
 /**

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsightTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsightTest.kt
@@ -254,6 +254,69 @@ class GenerateDailyInsightTest {
     }
 
     @Test
+    fun `today period slices hourly to the daytime window so peak precip ignores past dawn and late evening`() = runTest {
+        val todayHourly = listOf(
+            // Pre-morning: 6:00 with 80% rain — already past, must not surface.
+            HourlyForecast(LocalTime.of(6, 0), 8.0, 6.0, 80.0, WeatherCondition.RAIN),
+            // In-window: 09:00 quiet, 15:00 partly cloudy with 35% precip.
+            HourlyForecast(LocalTime.of(9, 0), 14.0, 12.0, 5.0, WeatherCondition.CLEAR),
+            HourlyForecast(LocalTime.of(15, 0), 22.0, 20.0, 35.0, WeatherCondition.PARTLY_CLOUDY),
+            // Late evening: 23:00 cloudy with 60% precip — user is asleep, must not
+            // be the headline for the daytime insight.
+            HourlyForecast(LocalTime.of(23, 0), 12.0, 10.0, 60.0, WeatherCondition.CLOUDY),
+        )
+        val todayWithHourly = today.copy(hourly = todayHourly)
+        val weather = FakeWeatherRepository(ForecastBundle(todayWithHourly, yesterday))
+        val subject = GenerateDailyInsight(weather, clock = clock)
+
+        val result = subject(london, prefs)
+
+        // Only hours in [07:00, 19:00) survive — the 06:00 and 23:00 entries are dropped.
+        result.insight.hourly.map { it.time } shouldBe listOf(LocalTime.of(9, 0), LocalTime.of(15, 0))
+        // Peak precip is the wettest in-window hour (15:00, partly cloudy at 35%) —
+        // not the 23:00 cloudy spike, which is what the pre-slice peak would have surfaced.
+        result.insight.summary.precip!!.condition shouldBe WeatherCondition.PARTLY_CLOUDY
+        result.insight.summary.precip!!.time shouldBe LocalTime.of(15, 0)
+    }
+
+    @Test
+    fun `today period recomputes aggregates from the daytime slice, not from the day-level fields`() = runTest {
+        val todayHourly = listOf(
+            // The day-level feelsLikeMinC on `today` is 6.0°C — but that's the pre-dawn
+            // low. The actual daytime range is 12→20°C, which is what the band sentence
+            // and wardrobe rules should see.
+            HourlyForecast(LocalTime.of(6, 0), 8.0, 6.0, 5.0, WeatherCondition.CLEAR),
+            HourlyForecast(LocalTime.of(9, 0), 14.0, 12.0, 5.0, WeatherCondition.CLEAR),
+            HourlyForecast(LocalTime.of(15, 0), 22.0, 20.0, 5.0, WeatherCondition.CLEAR),
+            HourlyForecast(LocalTime.of(23, 0), 6.0, 4.0, 5.0, WeatherCondition.CLEAR),
+        )
+        val todayWithHourly = today.copy(hourly = todayHourly)
+        val weather = FakeWeatherRepository(ForecastBundle(todayWithHourly, yesterday))
+        val subject = GenerateDailyInsight(weather, clock = clock)
+
+        val result = subject(london, prefs)
+
+        // Daytime feels-like 12→20 → COOL to MILD. The 6.0°C / 4.0°C edges of the day
+        // are correctly ignored.
+        result.insight.summary.band.low shouldBe TemperatureBand.COOL
+        result.insight.summary.band.high shouldBe TemperatureBand.MILD
+    }
+
+    @Test
+    fun `today period falls back to day-level fields when no hourly is available`() = runTest {
+        // The default fixture has no hourly array; the slice is empty and the band
+        // sentence should still come through from the daily aggregates rather than
+        // collapsing to defaults.
+        val weather = FakeWeatherRepository(ForecastBundle(today, yesterday))
+        val subject = GenerateDailyInsight(weather, clock = clock)
+
+        val result = subject(london, prefs)
+
+        result.insight.summary.band.low shouldBe TemperatureBand.COLD
+        result.insight.summary.band.high shouldBe TemperatureBand.WARM
+    }
+
+    @Test
     fun `tonight period leads with TONIGHT and skips the yesterday delta clause`() = runTest {
         val weather = FakeWeatherRepository(ForecastBundle(today, yesterday))
         val subject = GenerateDailyInsight(weather, clock = clock)


### PR DESCRIPTION
## Why

A user-reported 19:43 TODAY insight rendered as:

> Today will be cold to mild. Wear a jumper, jacket, and umbrella. **Cloudy at 23:00.**

The "Cloudy at 23:00." sentence is unhelpful — the user is about to go to bed,
and the supposedly-rainy hour is past their tonight time. Tracing it: the
TODAY pipeline was forwarding the unsliced day-level hourly array into
`RenderInsightSummary`, so `peakPrecip()` picked the wettest hour anywhere in
the 24h day, with no awareness of when the user is actually awake.

The TONIGHT pipeline already does the right thing — it slices via
`slicedForTonight()` to the user's overnight window (default 19:00–07:00).
TODAY just wasn't symmetric.

## What

Mirror the existing `slicedForTonight()` with a new `slicedForToday()` that:

- filters today's hourly to `[morningStart, eveningEnd)` (defaults 07:00–19:00,
  threaded from `prefs.schedule.time` and `prefs.tonightSchedule.time` so a
  user who moved either dial sees a matching insight);
- recomputes the daily aggregates (min/max temperature, peak precipitation,
  condition) from the slice, so the band sentence, wardrobe rules,
  outfit suggestion and precip-peak fallback all see the daytime range
  rather than the raw 24h day-level fields;
- falls back to the original aggregates on an empty or degenerate window
  (sparse fixtures, legacy day-level-only payloads, inverted times) so the
  pipeline always emits something.

Three new tests cover (a) hourly outside the day window getting dropped,
(b) aggregates recomputed from the slice, and (c) the empty-hourly fallback
preserving day-level fields.

## Stacked next

A follow-up PR will add a "next interval" sentence — only emitted on rain or
notably colder conditions — so a TODAY insight can briefly warn about
tonight's rain (and vice versa) without spamming on every quiet evening.

## Test plan
- [ ] CI: `JVM unit tests` job (the new tests live in `:core:domain`).
- [ ] CI: `Android debug build`.
- [ ] Eyeball next-day APK on Firebase: confirm a 07:00 TODAY insight no longer
      surfaces post-19:00 hours in `formatPrecip()`.

https://claude.ai/code/session_01CBdNYt2ZPFf9FAC4CjZfuv

---
_Generated by [Claude Code](https://claude.ai/code/session_01CBdNYt2ZPFf9FAC4CjZfuv)_