### PR TITLE
:app + :core — Region settings page subsumes Units, defaults from locale

### DIFF
--- a/app/src/main/kotlin/app/clothescast/data/SettingsRepository.kt
+++ b/app/src/main/kotlin/app/clothescast/data/SettingsRepository.kt
@@ -12,6 +12,7 @@ import androidx.datastore.preferences.preferencesDataStore
 import app.clothescast.core.domain.model.DeliveryMode
 import app.clothescast.core.domain.model.DistanceUnit
 import app.clothescast.core.domain.model.Location
+import app.clothescast.core.domain.model.Region
 import app.clothescast.core.domain.model.Schedule
 import app.clothescast.core.domain.model.TemperatureUnit
 import app.clothescast.core.domain.model.TtsEngine
@@ -28,6 +29,7 @@ import java.time.DayOfWeek
 import java.time.LocalTime
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
+import java.util.Locale
 
 /**
  * Persists [UserPreferences] in DataStore Preferences.
@@ -43,6 +45,7 @@ import java.time.format.DateTimeFormatter
 class SettingsRepository(
     private val dataStore: DataStore<Preferences>,
     private val zoneIdProvider: () -> ZoneId = { ZoneId.systemDefault() },
+    private val systemLocaleProvider: () -> Locale = { Locale.getDefault() },
     private val json: Json = Json { ignoreUnknownKeys = true },
 ) {
     val preferences: Flow<UserPreferences> = dataStore.data.map { prefs -> prefs.toUserPreferences() }
@@ -69,6 +72,10 @@ class SettingsRepository(
 
     suspend fun setDeliveryMode(mode: DeliveryMode) {
         dataStore.edit { it[DELIVERY_MODE] = mode.name }
+    }
+
+    suspend fun setRegion(region: Region) {
+        dataStore.edit { it[REGION] = region.name }
     }
 
     suspend fun setTemperatureUnit(unit: TemperatureUnit) {
@@ -136,10 +143,16 @@ class SettingsRepository(
             ?: Schedule.EVERY_DAY
         val deliveryMode = this[DELIVERY_MODE]?.let { runCatching { DeliveryMode.valueOf(it) }.getOrNull() }
             ?: DeliveryMode.NOTIFICATION_ONLY
+        val region = this[REGION]?.let { runCatching { Region.valueOf(it) }.getOrNull() }
+            ?: Region.SYSTEM
+        // Resolve units off the user's region — SYSTEM falls through to the
+        // phone locale. Once they explicitly pick a unit it sticks regardless
+        // of region (mirrors how openAiVoice handles voiceLocale).
+        val regionLocale = region.toJavaLocale() ?: systemLocaleProvider()
         val temperatureUnit = this[TEMPERATURE_UNIT]?.let { runCatching { TemperatureUnit.valueOf(it) }.getOrNull() }
-            ?: TemperatureUnit.CELSIUS
+            ?: defaultTemperatureUnitFor(regionLocale)
         val distanceUnit = this[DISTANCE_UNIT]?.let { runCatching { DistanceUnit.valueOf(it) }.getOrNull() }
-            ?: DistanceUnit.KILOMETERS
+            ?: defaultDistanceUnitFor(regionLocale)
         val rules = parseRules(this[WARDROBE_RULES])
         val location = parseLocation(this)
         val useDeviceLocation = this[USE_DEVICE_LOCATION] == true
@@ -171,6 +184,7 @@ class SettingsRepository(
         return UserPreferences(
             schedule = Schedule(time = time, days = days, zoneId = zone),
             deliveryMode = deliveryMode,
+            region = region,
             temperatureUnit = temperatureUnit,
             distanceUnit = distanceUnit,
             wardrobeRules = rules,
@@ -210,6 +224,7 @@ class SettingsRepository(
         private val SCHEDULE_TIME = stringPreferencesKey("schedule_time_hhmm")
         private val SCHEDULE_DAYS = stringSetPreferencesKey("schedule_days")
         private val DELIVERY_MODE = stringPreferencesKey("delivery_mode")
+        private val REGION = stringPreferencesKey("region")
         private val TEMPERATURE_UNIT = stringPreferencesKey("temperature_unit")
         private val DISTANCE_UNIT = stringPreferencesKey("distance_unit")
         private val WARDROBE_RULES = stringPreferencesKey("wardrobe_rules_json")
@@ -237,3 +252,17 @@ class SettingsRepository(
 }
 
 private val Context.settingsDataStore: DataStore<Preferences> by preferencesDataStore(name = "settings")
+
+private fun Region.toJavaLocale(): Locale? = bcp47?.let { Locale.forLanguageTag(it) }
+
+// Only the US uses Fahrenheit in everyday weather contexts. A handful of
+// dependencies (BS, BZ, KY, PW) also do, but they're rounding error and the
+// user can override via the unit picker if needed — not worth the extra surface.
+private fun defaultTemperatureUnitFor(locale: Locale): TemperatureUnit =
+    if (locale.country == "US") TemperatureUnit.FAHRENHEIT else TemperatureUnit.CELSIUS
+
+// Only the US sticks with imperial for weather-app distance contexts (wind
+// speed in mph, precipitation in inches). UK uses miles for *roads* but km/h
+// and mm for weather, so it lands on the metric default with everyone else.
+private fun defaultDistanceUnitFor(locale: Locale): DistanceUnit =
+    if (locale.country == "US") DistanceUnit.MILES else DistanceUnit.KILOMETERS

--- a/app/src/main/kotlin/app/clothescast/ui/settings/RegionSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/RegionSettings.kt
@@ -13,13 +13,16 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import app.clothescast.R
 import app.clothescast.core.domain.model.DistanceUnit
+import app.clothescast.core.domain.model.Region
 import app.clothescast.core.domain.model.TemperatureUnit
 
 @Composable
-internal fun UnitsContent(
+internal fun RegionContent(
+    region: Region,
     temperatureUnit: TemperatureUnit,
     distanceUnit: DistanceUnit,
     padding: PaddingValues,
+    onSetRegion: (Region) -> Unit,
     onSetTemperatureUnit: (TemperatureUnit) -> Unit,
     onSetDistanceUnit: (DistanceUnit) -> Unit,
 ) {
@@ -31,6 +34,15 @@ internal fun UnitsContent(
             .padding(horizontal = 16.dp, vertical = 8.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {
+        SectionCard(title = stringResource(R.string.settings_region_language_title)) {
+            Region.entries.forEach { option ->
+                RadioRow(
+                    label = stringResource(regionLabel(option)),
+                    selected = option == region,
+                    onSelect = { onSetRegion(option) },
+                )
+            }
+        }
         SectionCard(title = stringResource(R.string.settings_temperature_unit_title)) {
             TemperatureUnit.entries.forEach { unit ->
                 RadioRow(
@@ -50,6 +62,13 @@ internal fun UnitsContent(
             }
         }
     }
+}
+
+private fun regionLabel(region: Region): Int = when (region) {
+    Region.SYSTEM -> R.string.settings_region_language_system
+    Region.EN_US -> R.string.settings_region_language_en_us
+    Region.EN_GB -> R.string.settings_region_language_en_gb
+    Region.EN_AU -> R.string.settings_region_language_en_au
 }
 
 private fun temperatureUnitLabel(unit: TemperatureUnit): Int = when (unit) {

--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsScreen.kt
@@ -42,7 +42,7 @@ enum class SettingsRoute(@StringRes val titleRes: Int) {
     Schedule(R.string.settings_root_schedule),
     Wardrobe(R.string.settings_root_wardrobe),
     Voice(R.string.settings_root_voice),
-    Units(R.string.settings_root_units),
+    Region(R.string.settings_root_region),
     ApiKeys(R.string.settings_root_api_keys),
     DataSources(R.string.settings_root_data_sources),
     About(R.string.settings_root_about),
@@ -134,10 +134,12 @@ fun SettingsScreen(
                 onSetElevenLabsVoice = viewModel::setElevenLabsVoice,
                 onSetVoiceLocale = viewModel::setVoiceLocale,
             )
-            SettingsRoute.Units -> UnitsContent(
+            SettingsRoute.Region -> RegionContent(
+                region = state.region,
                 temperatureUnit = state.temperatureUnit,
                 distanceUnit = state.distanceUnit,
                 padding = padding,
+                onSetRegion = viewModel::setRegion,
                 onSetTemperatureUnit = viewModel::setTemperatureUnit,
                 onSetDistanceUnit = viewModel::setDistanceUnit,
             )

--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsState.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsState.kt
@@ -3,6 +3,7 @@ package app.clothescast.ui.settings
 import app.clothescast.core.domain.model.DeliveryMode
 import app.clothescast.core.domain.model.DistanceUnit
 import app.clothescast.core.domain.model.Location
+import app.clothescast.core.domain.model.Region
 import app.clothescast.core.domain.model.Schedule
 import app.clothescast.core.domain.model.TemperatureUnit
 import app.clothescast.core.domain.model.TtsEngine
@@ -21,6 +22,7 @@ data class SettingsState(
     val tonightDays: Set<DayOfWeek> = Schedule.EVERY_DAY,
     val tonightEnabled: Boolean = true,
     val deliveryMode: DeliveryMode = DeliveryMode.NOTIFICATION_ONLY,
+    val region: Region = Region.SYSTEM,
     val temperatureUnit: TemperatureUnit = TemperatureUnit.CELSIUS,
     val distanceUnit: DistanceUnit = DistanceUnit.KILOMETERS,
     val wardrobeRules: List<WardrobeRule> = WardrobeRule.DEFAULTS,

--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsViewModel.kt
@@ -8,6 +8,7 @@ import app.clothescast.core.domain.model.DeliveryMode
 import app.clothescast.core.domain.model.DistanceUnit
 import app.clothescast.core.domain.model.ForecastPeriod
 import app.clothescast.core.domain.model.Location
+import app.clothescast.core.domain.model.Region
 import app.clothescast.core.domain.model.Schedule
 import app.clothescast.core.domain.model.TemperatureUnit
 import app.clothescast.core.domain.model.TtsEngine
@@ -46,6 +47,7 @@ class SettingsViewModel(
                         tonightDays = prefs.tonightSchedule.days,
                         tonightEnabled = prefs.tonightEnabled,
                         deliveryMode = prefs.deliveryMode,
+                        region = prefs.region,
                         temperatureUnit = prefs.temperatureUnit,
                         distanceUnit = prefs.distanceUnit,
                         wardrobeRules = prefs.wardrobeRules,
@@ -120,6 +122,10 @@ class SettingsViewModel(
 
     fun setDeliveryMode(mode: DeliveryMode) {
         viewModelScope.launch { settingsRepository.setDeliveryMode(mode) }
+    }
+
+    fun setRegion(region: Region) {
+        viewModelScope.launch { settingsRepository.setRegion(region) }
     }
 
     fun setTemperatureUnit(unit: TemperatureUnit) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -56,7 +56,7 @@
 
     <string name="settings_root_voice">Voice</string>
     <string name="settings_root_schedule">Schedule</string>
-    <string name="settings_root_units">Units</string>
+    <string name="settings_root_region">Region</string>
     <string name="settings_root_wardrobe">Wardrobe</string>
     <string name="settings_root_api_keys">API keys</string>
     <string name="settings_root_data_sources">Data sources</string>
@@ -135,6 +135,12 @@
     <string name="settings_elevenlabs_key_placeholder">Paste your ElevenLabs API key</string>
     <string name="settings_elevenlabs_key_save">Save ElevenLabs key</string>
     <string name="settings_elevenlabs_key_clear">Clear stored ElevenLabs key</string>
+
+    <string name="settings_region_language_title">Language</string>
+    <string name="settings_region_language_system">Follow system locale</string>
+    <string name="settings_region_language_en_us">English (United States)</string>
+    <string name="settings_region_language_en_gb">English (United Kingdom)</string>
+    <string name="settings_region_language_en_au">English (Australia)</string>
 
     <string name="settings_temperature_unit_title">Temperature unit</string>
     <string name="settings_temperature_unit_celsius">Celsius (°C)</string>

--- a/app/src/test/kotlin/app/clothescast/data/SettingsRepositoryTest.kt
+++ b/app/src/test/kotlin/app/clothescast/data/SettingsRepositoryTest.kt
@@ -8,6 +8,7 @@ import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.core.stringSetPreferencesKey
 import app.clothescast.core.domain.model.DeliveryMode
 import app.clothescast.core.domain.model.DistanceUnit
+import app.clothescast.core.domain.model.Region
 import app.clothescast.core.domain.model.Schedule
 import app.clothescast.core.domain.model.TemperatureUnit
 import app.clothescast.core.domain.model.VoiceLocale
@@ -33,6 +34,7 @@ import java.nio.file.Path
 import java.time.DayOfWeek
 import java.time.LocalTime
 import java.time.ZoneId
+import java.util.Locale
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class SettingsRepositoryTest {
@@ -54,6 +56,9 @@ class SettingsRepositoryTest {
         subject = SettingsRepository(
             dataStore = dataStore,
             zoneIdProvider = { zone },
+            // Pin the locale so default-unit assertions don't drift with the
+            // host machine's locale (CI runs on en_US, dev machines vary).
+            systemLocaleProvider = { Locale.UK },
         )
     }
 
@@ -99,6 +104,47 @@ class SettingsRepositoryTest {
         subject.setDeliveryMode(DeliveryMode.NOTIFICATION_AND_TTS)
 
         subject.preferences.first().deliveryMode shouldBe DeliveryMode.NOTIFICATION_AND_TTS
+    }
+
+    @Test
+    fun `region defaults to SYSTEM when nothing stored`() = runTest {
+        subject.preferences.first().region shouldBe Region.SYSTEM
+    }
+
+    @Test
+    fun `setRegion round-trips`() = runTest {
+        subject.setRegion(Region.EN_US)
+        subject.preferences.first().region shouldBe Region.EN_US
+    }
+
+    @Test
+    fun `temperature default follows region locale - en-US picks Fahrenheit`() = runTest {
+        subject.setRegion(Region.EN_US)
+        subject.preferences.first().temperatureUnit shouldBe TemperatureUnit.FAHRENHEIT
+    }
+
+    @Test
+    fun `distance default follows region locale - en-US picks miles`() = runTest {
+        subject.setRegion(Region.EN_US)
+        subject.preferences.first().distanceUnit shouldBe DistanceUnit.MILES
+    }
+
+    @Test
+    fun `temperature default falls back to system locale when region is SYSTEM`() = runTest {
+        // Test setUp pins systemLocaleProvider to Locale.UK → metric.
+        subject.preferences.first().temperatureUnit shouldBe TemperatureUnit.CELSIUS
+        subject.preferences.first().distanceUnit shouldBe DistanceUnit.KILOMETERS
+    }
+
+    @Test
+    fun `explicitly chosen unit overrides the region-derived default`() = runTest {
+        subject.setRegion(Region.EN_US)
+        subject.setTemperatureUnit(TemperatureUnit.CELSIUS)
+        subject.setDistanceUnit(DistanceUnit.KILOMETERS)
+
+        val prefs = subject.preferences.first()
+        prefs.temperatureUnit shouldBe TemperatureUnit.CELSIUS
+        prefs.distanceUnit shouldBe DistanceUnit.KILOMETERS
     }
 
     @Test

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Settings.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Settings.kt
@@ -49,9 +49,31 @@ enum class VoiceLocale(val bcp47: String?) {
     EN_AU("en-AU"),
 }
 
+/**
+ * The user's region — drives the language used for rendered insight text and
+ * the *default* unit choices for users who haven't explicitly picked units yet.
+ *
+ * [SYSTEM] (the default) means "follow the phone's locale": the right answer
+ * for almost everyone, since their device language already encodes where they
+ * are. The explicit en-* options are for users on a phone whose locale doesn't
+ * match the region they want the app to behave as (e.g. an en-AU traveller on
+ * an en-US phone).
+ *
+ * Distinct from [VoiceLocale]: that one is specifically about the *spoken
+ * accent* of the audio playback — you might be in Australia but prefer a US
+ * voice, or vice versa. Region is the higher-level "where am I" setting.
+ */
+enum class Region(val bcp47: String?) {
+    SYSTEM(null),
+    EN_US("en-US"),
+    EN_GB("en-GB"),
+    EN_AU("en-AU"),
+}
+
 data class UserPreferences(
     val schedule: Schedule,
     val deliveryMode: DeliveryMode,
+    val region: Region = Region.SYSTEM,
     val temperatureUnit: TemperatureUnit,
     val distanceUnit: DistanceUnit,
     val wardrobeRules: List<WardrobeRule>,


### PR DESCRIPTION
## Summary

- New top-level **Region** settings page (replaces the Units page) with three subheads: **Language**, **Temperature unit**, **Distance unit**.
- Adds a `Region` enum to `:core:domain` (SYSTEM / en-US / en-GB / en-AU). Defaults to SYSTEM — i.e. follow the phone's locale.
- Default temperature and distance units now derive from the resolved region locale (US → Fahrenheit + miles, everyone else → Celsius + km) when the user hasn't explicitly picked a unit. Explicit choices still win, mirroring the way `openAiVoice` is keyed off `voiceLocale`.

## Why a separate `Region` (not reusing `VoiceLocale`)?

`VoiceLocale` is specifically the *spoken accent of TTS playback* — you might be in Australia but want a US voice (or vice versa), so it stays an independent setting on the Voice page. `Region` is the higher-level "where am I" setting that future `InsightFormatter` work will key wardrobe vocab off (per the existing TODOs in `InsightFormatter.kt`, `InsightCache.kt`, `InsightSummary.kt`).

## Test plan

- [ ] CI: `JVM unit tests` — new `SettingsRepositoryTest` cases for Region round-trip, locale-derived unit defaults, explicit overrides.
- [ ] CI: `Android debug build`.
- [ ] Manual: open Settings → Region; verify Language / Temperature unit / Distance unit pickers all work and persist across app restart.
- [ ] Manual on en-US device with no prior install: confirm defaults are Fahrenheit + miles.
- [ ] Manual on en-GB device with no prior install: confirm defaults are Celsius + km.
- [ ] Manual: switch Region from SYSTEM to en-US; existing explicit unit choice (if any) should *not* be overwritten.

https://claude.ai/code/session_019PpWzcBeEHkdSuUSNPmYF6

---
_Generated by [Claude Code](https://claude.ai/code/session_019PpWzcBeEHkdSuUSNPmYF6)_