### PR TITLE
:app + :core — two outfits side-by-side (today+tonight or tonight+tomorrow)

### DIFF
--- a/app/src/main/kotlin/app/clothescast/data/InsightCache.kt
+++ b/app/src/main/kotlin/app/clothescast/data/InsightCache.kt
@@ -102,6 +102,7 @@ class InsightCache(
         val forDateEpochDays: Long,
         val hourly: List<HourlyDto> = emptyList(),
         val outfit: OutfitDto? = null,
+        val nextOutfit: OutfitDto? = null,
         val period: String = ForecastPeriod.TODAY.name,
         val hasEvents: Boolean = false,
     ) {
@@ -112,6 +113,7 @@ class InsightCache(
             forDate = LocalDate.ofEpochDay(forDateEpochDays),
             hourly = hourly.map { it.toDomain() },
             outfit = outfit?.toDomain(),
+            nextOutfit = nextOutfit?.toDomain(),
             period = runCatching { ForecastPeriod.valueOf(period) }.getOrDefault(ForecastPeriod.TODAY),
             hasEvents = hasEvents,
         )
@@ -221,6 +223,7 @@ class InsightCache(
         forDateEpochDays = forDate.toEpochDay(),
         hourly = hourly.map { it.toDto() },
         outfit = outfit?.let { OutfitDto(it.top.name, it.bottom.name) },
+        nextOutfit = nextOutfit?.let { OutfitDto(it.top.name, it.bottom.name) },
         period = period.name,
         hasEvents = hasEvents,
     )

--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayPreviews.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayPreviews.kt
@@ -63,44 +63,105 @@ private val SAMPLE_INSIGHT = Insight(
 @Preview(name = "Outfit · t-shirt + shorts", widthDp = 360)
 @Composable
 internal fun OutfitTShirtShortsPreview() {
-    Frame { OutfitPreviewCard(OutfitSuggestion(OutfitSuggestion.Top.TSHIRT, OutfitSuggestion.Bottom.SHORTS)) }
+    Frame {
+        OutfitPreviewCard(
+            outfit = OutfitSuggestion(OutfitSuggestion.Top.TSHIRT, OutfitSuggestion.Bottom.SHORTS),
+            label = "Today",
+        )
+    }
 }
 
 @Preview(name = "Outfit · t-shirt + long pants", widthDp = 360)
 @Composable
 internal fun OutfitTShirtPantsPreview() {
-    Frame { OutfitPreviewCard(OutfitSuggestion(OutfitSuggestion.Top.TSHIRT, OutfitSuggestion.Bottom.LONG_PANTS)) }
+    Frame {
+        OutfitPreviewCard(
+            outfit = OutfitSuggestion(OutfitSuggestion.Top.TSHIRT, OutfitSuggestion.Bottom.LONG_PANTS),
+            label = "Today",
+        )
+    }
 }
 
 @Preview(name = "Outfit · sweater + shorts", widthDp = 360)
 @Composable
 internal fun OutfitSweaterShortsPreview() {
-    Frame { OutfitPreviewCard(OutfitSuggestion(OutfitSuggestion.Top.SWEATER, OutfitSuggestion.Bottom.SHORTS)) }
+    Frame {
+        OutfitPreviewCard(
+            outfit = OutfitSuggestion(OutfitSuggestion.Top.SWEATER, OutfitSuggestion.Bottom.SHORTS),
+            label = "Tonight",
+        )
+    }
 }
 
 @Preview(name = "Outfit · sweater + long pants", widthDp = 360)
 @Composable
 internal fun OutfitSweaterPantsPreview() {
-    Frame { OutfitPreviewCard(OutfitSuggestion(OutfitSuggestion.Top.SWEATER, OutfitSuggestion.Bottom.LONG_PANTS)) }
+    Frame {
+        OutfitPreviewCard(
+            outfit = OutfitSuggestion(OutfitSuggestion.Top.SWEATER, OutfitSuggestion.Bottom.LONG_PANTS),
+            label = "Tonight",
+        )
+    }
 }
 
 @Preview(name = "Outfit · thick jacket + shorts", widthDp = 360)
 @Composable
 internal fun OutfitJacketShortsPreview() {
-    Frame { OutfitPreviewCard(OutfitSuggestion(OutfitSuggestion.Top.THICK_JACKET, OutfitSuggestion.Bottom.SHORTS)) }
+    Frame {
+        OutfitPreviewCard(
+            outfit = OutfitSuggestion(OutfitSuggestion.Top.THICK_JACKET, OutfitSuggestion.Bottom.SHORTS),
+            label = "Tomorrow",
+        )
+    }
 }
 
 @Preview(name = "Outfit · thick jacket + long pants", widthDp = 360)
 @Composable
 internal fun OutfitJacketPantsPreview() {
-    Frame { OutfitPreviewCard(OutfitSuggestion(OutfitSuggestion.Top.THICK_JACKET, OutfitSuggestion.Bottom.LONG_PANTS)) }
+    Frame {
+        OutfitPreviewCard(
+            outfit = OutfitSuggestion(OutfitSuggestion.Top.THICK_JACKET, OutfitSuggestion.Bottom.LONG_PANTS),
+            label = "Tomorrow",
+        )
+    }
 }
 
 @Preview(name = "Outfit · sweater + pants (dark)", widthDp = 360)
 @Composable
 internal fun OutfitSweaterPantsDarkPreview() {
     Frame(darkTheme = true) {
-        OutfitPreviewCard(OutfitSuggestion(OutfitSuggestion.Top.SWEATER, OutfitSuggestion.Bottom.LONG_PANTS))
+        OutfitPreviewCard(
+            outfit = OutfitSuggestion(OutfitSuggestion.Top.SWEATER, OutfitSuggestion.Bottom.LONG_PANTS),
+            label = "Tonight",
+        )
+    }
+}
+
+@Preview(name = "Outfit row · today + tonight", widthDp = 360)
+@Composable
+internal fun OutfitRowTodayTonightPreview() {
+    Frame {
+        OutfitPreviewRow(
+            SAMPLE_INSIGHT.copy(
+                period = ForecastPeriod.TODAY,
+                outfit = OutfitSuggestion(OutfitSuggestion.Top.TSHIRT, OutfitSuggestion.Bottom.SHORTS),
+                nextOutfit = OutfitSuggestion(OutfitSuggestion.Top.SWEATER, OutfitSuggestion.Bottom.LONG_PANTS),
+            ),
+        )
+    }
+}
+
+@Preview(name = "Outfit row · tonight + tomorrow", widthDp = 360)
+@Composable
+internal fun OutfitRowTonightTomorrowPreview() {
+    Frame {
+        OutfitPreviewRow(
+            SAMPLE_INSIGHT.copy(
+                period = ForecastPeriod.TONIGHT,
+                outfit = OutfitSuggestion(OutfitSuggestion.Top.SWEATER, OutfitSuggestion.Bottom.LONG_PANTS),
+                nextOutfit = OutfitSuggestion(OutfitSuggestion.Top.THICK_JACKET, OutfitSuggestion.Bottom.LONG_PANTS),
+            ),
+        )
     }
 }
 

--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
@@ -46,6 +46,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.clothescast.R
 import app.clothescast.core.domain.model.ConfidenceInfo
 import app.clothescast.core.domain.model.ForecastConfidence
+import app.clothescast.core.domain.model.ForecastPeriod
 import app.clothescast.core.domain.model.HourlyForecast
 import app.clothescast.core.domain.model.Insight
 import app.clothescast.core.domain.model.OutfitSuggestion
@@ -132,7 +133,7 @@ private fun TodayContent(
         if (state.insight == null) {
             EmptyState(onRefresh = onRefresh, isWorking = isWorking)
         } else {
-            state.insight.outfit?.let { OutfitPreviewCard(it) }
+            OutfitPreviewRow(state.insight)
             InsightCard(state.insight)
             if (state.insight.hourly.isNotEmpty()) {
                 ForecastCard(state.insight.hourly, state.temperatureUnit)
@@ -228,47 +229,85 @@ internal fun EmptyState(onRefresh: () -> Unit, isWorking: Boolean = false) {
 }
 
 /**
- * Glanceable "What to wear" card. Shows the top + bottom as flat-colour GNOME-style
- * icons stacked vertically — shirt above pants — so the pair reads as a head-to-toe
- * outfit instead of two unrelated items. Icons are fixed-colour SVGs (not Material-themed)
- * so each garment stays recognisable in light or dark mode.
+ * Side-by-side "What to wear" row. Shows the primary outfit on the left and the
+ * upcoming-period outfit on the right — "Today + Tonight" on a morning insight,
+ * "Tonight + Tomorrow" on an evening one — so a glance covers both the next few
+ * hours and the next handover (heading-out outfit + coming-home outfit).
+ *
+ * Falls back to a single card when the insight didn't carry a [Insight.nextOutfit]
+ * (legacy cache payloads, or a tonight insight on a forecast bundle without
+ * tomorrow's daily aggregates).
  *
  * TODO(outfit-weather-overlay): place a small weather glyph (sun / cloud / rain /
  *   snow) over the centre of the top icon so a glance carries both "what to wear"
  *   *and* "what's it doing outside" — e.g. a t-shirt with a sun, a sweater with a
  *   raincloud. Use the same imagery for the product launcher icon (mipmap/ic_launcher,
  *   ic_launcher_round, ic_launcher_background) so the home-screen icon, the
- *   OutfitPreviewCard, and the notification large icon all read as one family.
+ *   outfit cards, and the notification large icon all read as one family.
  */
 @Composable
-internal fun OutfitPreviewCard(outfit: OutfitSuggestion) {
-    Card(modifier = Modifier.fillMaxWidth()) {
+internal fun OutfitPreviewRow(insight: Insight) {
+    val primary = insight.outfit ?: return
+    val (primaryLabel, nextLabel) = outfitLabels(insight.period)
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        OutfitPreviewCard(
+            outfit = primary,
+            label = stringResource(primaryLabel),
+            modifier = Modifier.weight(1f),
+        )
+        insight.nextOutfit?.let {
+            OutfitPreviewCard(
+                outfit = it,
+                label = stringResource(nextLabel),
+                modifier = Modifier.weight(1f),
+            )
+        }
+    }
+}
+
+private fun outfitLabels(period: ForecastPeriod): Pair<Int, Int> = when (period) {
+    ForecastPeriod.TODAY -> R.string.today_outfit_label_today to R.string.today_outfit_label_tonight
+    ForecastPeriod.TONIGHT -> R.string.today_outfit_label_tonight to R.string.today_outfit_label_tomorrow
+}
+
+@Composable
+internal fun OutfitPreviewCard(
+    outfit: OutfitSuggestion,
+    label: String,
+    modifier: Modifier = Modifier,
+) {
+    Card(modifier = modifier) {
         Column(
-            modifier = Modifier.padding(20.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(6.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             Text(
-                text = stringResource(R.string.today_outfit_title),
+                text = label,
                 style = MaterialTheme.typography.titleSmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier.fillMaxWidth(),
+                textAlign = TextAlign.Center,
             )
             Image(
                 painter = painterResource(id = topIconRes(outfit.top)),
                 contentDescription = stringResource(topLabelRes(outfit.top)),
-                modifier = Modifier.height(112.dp),
+                modifier = Modifier.height(96.dp),
             )
             Image(
                 painter = painterResource(id = bottomIconRes(outfit.bottom)),
                 contentDescription = stringResource(bottomLabelRes(outfit.bottom)),
-                modifier = Modifier.height(112.dp),
+                modifier = Modifier.height(96.dp),
             )
             Text(
                 text = stringResource(topLabelRes(outfit.top)) +
                     " · " +
                     stringResource(bottomLabelRes(outfit.bottom)),
-                style = MaterialTheme.typography.bodyMedium,
+                style = MaterialTheme.typography.bodySmall,
+                textAlign = TextAlign.Center,
             )
         }
     }
@@ -440,13 +479,33 @@ private fun triggerRefresh(context: android.content.Context) {
     // actually regenerates. Without this, Refresh on the same calendar day
     // just redelivers the morning's payload — surprising when the user has
     // changed wardrobe rules, location, or the underlying forecast has moved.
-    FetchAndNotifyWorker.enqueueOneShot(context.applicationContext, force = true)
+    //
+    // Period follows wall-clock time so an evening tap (>=19:00 or <07:00)
+    // regenerates the tonight insight — that's the one whose primary outfit
+    // is "Tonight" and whose nextOutfit drives the "Tomorrow" card. A morning
+    // tap regenerates today, whose nextOutfit drives the "Tonight" card.
+    val period = if (java.time.LocalTime.now().isInTonightWindow()) {
+        ForecastPeriod.TONIGHT
+    } else {
+        ForecastPeriod.TODAY
+    }
+    FetchAndNotifyWorker.enqueueOneShot(context.applicationContext, force = true, period = period)
     Toast.makeText(
         context,
         context.getString(R.string.today_refresh_toast),
         Toast.LENGTH_SHORT,
     ).show()
 }
+
+/**
+ * 19:00 inclusive through 07:00 exclusive — matches the default tonight /
+ * morning schedule boundaries. Hardcoded rather than threaded from prefs so
+ * the refresh trigger doesn't need a [TodayState] field; if the user has
+ * shifted their schedule far from these defaults, the alarm-driven runs still
+ * fire at their custom times and only the manual Refresh window is fixed.
+ */
+private fun java.time.LocalTime.isInTonightWindow(): Boolean =
+    this >= java.time.LocalTime.of(19, 0) || this < java.time.LocalTime.of(7, 0)
 
 private val DATE_FORMAT: DateTimeFormatter =
     DateTimeFormatter.ofLocalizedDate(FormatStyle.FULL).withLocale(Locale.getDefault())

--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayViewModel.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayViewModel.kt
@@ -32,14 +32,18 @@ class TodayViewModel(
     workManager: WorkManager,
     settingsRepository: SettingsRepository,
 ) : ViewModel() {
+    // Combine status across both unique-work names so the spinner / failure
+    // banner reflects an in-flight tonight refresh too — the Refresh button
+    // routes to TONIGHT when it's tapped between 19:00 and 07:00.
     val state: StateFlow<TodayState> = combine(
         insightCache.latest,
         workManager.getWorkInfosForUniqueWorkFlow(FetchAndNotifyWorker.UNIQUE_WORK_NAME),
+        workManager.getWorkInfosForUniqueWorkFlow(FetchAndNotifyWorker.UNIQUE_WORK_NAME_TONIGHT),
         settingsRepository.preferences,
-    ) { insight, workInfos, prefs ->
+    ) { insight, todayInfos, tonightInfos, prefs ->
         TodayState(
             insight = insight,
-            workStatus = workInfos.toStatus(),
+            workStatus = (todayInfos + tonightInfos).toStatus(),
             temperatureUnit = prefs.temperatureUnit,
         )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), TodayState())

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,6 +12,9 @@
     <string name="today_generated_at">Generated at %1$s</string>
 
     <string name="today_outfit_title">What to wear</string>
+    <string name="today_outfit_label_today">Today</string>
+    <string name="today_outfit_label_tonight">Tonight</string>
+    <string name="today_outfit_label_tomorrow">Tomorrow</string>
     <string name="today_outfit_top_tshirt">T-shirt</string>
     <string name="today_outfit_top_sweater">Sweater</string>
     <string name="today_outfit_top_thick_jacket">Thick jacket</string>

--- a/app/src/test/kotlin/app/clothescast/ui/today/PreviewSnapshots.kt
+++ b/app/src/test/kotlin/app/clothescast/ui/today/PreviewSnapshots.kt
@@ -74,6 +74,8 @@ class PreviewSnapshots {
     @Test fun outfit_jacket_shorts() = capture { OutfitJacketShortsPreview() }
     @Test fun outfit_jacket_pants() = capture { OutfitJacketPantsPreview() }
     @Test fun outfit_sweater_pants_dark() = capture { OutfitSweaterPantsDarkPreview() }
+    @Test fun outfit_row_today_tonight() = capture { OutfitRowTodayTonightPreview() }
+    @Test fun outfit_row_tonight_tomorrow() = capture { OutfitRowTonightTomorrowPreview() }
 
     @Test fun today_empty_state() = capture { EmptyStatePreview() }
     @Test fun today_insight_card() = capture { InsightCardPreview() }

--- a/core/data/src/main/kotlin/app/clothescast/core/data/weather/OpenMeteoMapper.kt
+++ b/core/data/src/main/kotlin/app/clothescast/core/data/weather/OpenMeteoMapper.kt
@@ -36,14 +36,20 @@ internal object OpenMeteoMapper {
         val todayHourly = response.hourly.forDate(todayDate)
         val today = response.daily.toForecast(index = 1, date = todayDate, hourly = todayHourly)
 
-        val tomorrowHourly = if (response.daily.time.size >= 3) {
+        val (tomorrowHourly, tomorrow) = if (response.daily.time.size >= 3) {
             val tomorrowDate = LocalDate.parse(response.daily.time[2])
-            response.hourly.forDate(tomorrowDate)
+            val hourly = response.hourly.forDate(tomorrowDate)
+            hourly to response.daily.toForecast(index = 2, date = tomorrowDate, hourly = hourly)
         } else {
-            emptyList()
+            emptyList<HourlyForecast>() to null
         }
 
-        return ForecastBundle(today = today, yesterday = yesterday, tomorrowHourly = tomorrowHourly)
+        return ForecastBundle(
+            today = today,
+            yesterday = yesterday,
+            tomorrowHourly = tomorrowHourly,
+            tomorrow = tomorrow,
+        )
     }
 
     private fun DailyData.toForecast(index: Int, date: LocalDate, hourly: List<HourlyForecast>): DailyForecast {

--- a/core/data/src/test/kotlin/app/clothescast/core/data/weather/OpenMeteoMapperTest.kt
+++ b/core/data/src/test/kotlin/app/clothescast/core/data/weather/OpenMeteoMapperTest.kt
@@ -223,6 +223,48 @@ class OpenMeteoMapperTest {
     }
 
     @Test
+    fun `tomorrow daily is populated when the response carries a third daily entry`() {
+        // The third daily entry is what feeds the home screen's "Tomorrow" outfit
+        // card on a tonight insight — populate min / max / feels-like / condition
+        // so [OutfitSuggestion.fromForecast] can pick a sensible top + bottom.
+        val threeDay = OpenMeteoResponse(
+            timezone = "UTC",
+            daily = DailyData(
+                time = listOf("2026-04-24", "2026-04-25", "2026-04-26"),
+                temperatureMin = listOf(12.0, 16.0, 14.0),
+                temperatureMax = listOf(18.0, 24.0, 21.0),
+                feelsLikeMin = listOf(10.0, 15.0, 13.0),
+                feelsLikeMax = listOf(17.0, 23.0, 20.0),
+                precipitationProbabilityMax = listOf(5, 60, 20),
+                precipitationSum = listOf(0.0, 4.5, 0.5),
+                weatherCode = listOf(2, 63, 3),
+            ),
+            hourly = HourlyData(
+                time = listOf("2026-04-26T03:00", "2026-04-26T06:00"),
+                temperature = listOf(6.0, 8.0),
+                feelsLike = listOf(3.0, 5.0),
+                precipitationProbability = listOf(5, 5),
+                weatherCode = listOf(2, 2),
+            ),
+        )
+
+        val tomorrow = OpenMeteoMapper.toBundle(threeDay).tomorrow
+
+        tomorrow shouldNotBe null
+        tomorrow!!.date shouldBe LocalDate.of(2026, 4, 26)
+        tomorrow.feelsLikeMinC shouldBe 13.0
+        tomorrow.feelsLikeMaxC shouldBe 20.0
+        tomorrow.condition shouldBe WeatherCondition.CLOUDY
+    }
+
+    @Test
+    fun `tomorrow daily is null when the response only carries two daily entries`() {
+        val bundle = OpenMeteoMapper.toBundle(loadFixture())
+
+        bundle.tomorrow shouldBe null
+    }
+
+    @Test
     fun `rejects responses missing two daily entries`() {
         val short = OpenMeteoResponse(
             timezone = "UTC",

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Insight.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Insight.kt
@@ -34,6 +34,15 @@ data class Insight(
      */
     val outfit: OutfitSuggestion? = null,
     /**
+     * The outfit for the period that follows [period] — tonight when this is a
+     * TODAY insight, tomorrow's daytime when this is a TONIGHT insight. Null
+     * when the underlying forecast didn't carry enough data (legacy fixtures,
+     * old caches) — the home screen falls back to a single-card layout in that
+     * case. Lets the home screen show "Today + Tonight" or "Tonight + Tomorrow"
+     * side-by-side from a single cached insight.
+     */
+    val nextOutfit: OutfitSuggestion? = null,
+    /**
      * Which slice of the day this insight is for. [ForecastPeriod.TODAY] is the
      * morning pass (covers 07:00–19:00); [ForecastPeriod.TONIGHT] is the evening
      * pass (covers 19:00–07:00). Defaults to TODAY so older cached insights from

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/repository/WeatherRepository.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/repository/WeatherRepository.kt
@@ -38,6 +38,14 @@ data class ForecastBundle(
      * case rather than failing.
      */
     val tomorrowHourly: List<HourlyForecast> = emptyList(),
+    /**
+     * Tomorrow's full daily aggregates, when available. Used by the tonight
+     * insight to derive a next-day outfit preview ("Tomorrow" card) without
+     * burning a second forecast call. Null when the response only covered
+     * today (legacy `forecast_days=1`, sparse fixtures); the home screen
+     * falls back to a single-card layout in that case.
+     */
+    val tomorrow: DailyForecast? = null,
 ) {
     init {
         require(yesterday.date.isBefore(today.date)) {

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsight.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsight.kt
@@ -47,16 +47,30 @@ class GenerateDailyInsight(
         // that matches the alarm that just fired.
         val morningStart = prefs.schedule.time
         val tonightStart = prefs.tonightSchedule.time
+        val todayForecast = bundle.today.slicedForToday(
+            morningStart = morningStart,
+            eveningEnd = tonightStart,
+        )
+        val tonightForecast = bundle.today.slicedForTonight(
+            tonightStart = tonightStart,
+            morningEnd = morningStart,
+            tomorrowHourly = bundle.tomorrowHourly,
+        )
         val periodForecast = when (period) {
-            ForecastPeriod.TODAY -> bundle.today.slicedForToday(
-                morningStart = morningStart,
-                eveningEnd = tonightStart,
-            )
-            ForecastPeriod.TONIGHT -> bundle.today.slicedForTonight(
-                tonightStart = tonightStart,
-                morningEnd = morningStart,
-                tomorrowHourly = bundle.tomorrowHourly,
-            )
+            ForecastPeriod.TODAY -> todayForecast
+            ForecastPeriod.TONIGHT -> tonightForecast
+        }
+        // The home screen wants a side-by-side preview pair: "Today + Tonight"
+        // on a morning insight, "Tonight + Tomorrow" on an evening one. We
+        // compute the second outfit from the same forecast bundle so showing
+        // both costs no extra API call. Null when the underlying data isn't
+        // there (e.g. evening insight on a legacy bundle without tomorrow's
+        // daily aggregates) — the screen falls back to a single card.
+        val nextOutfit = when (period) {
+            ForecastPeriod.TODAY -> tonightForecast
+                .takeIf { it.hourly.isNotEmpty() }
+                ?.let { OutfitSuggestion.fromForecast(it) }
+            ForecastPeriod.TONIGHT -> bundle.tomorrow?.let { OutfitSuggestion.fromForecast(it) }
         }
         val todayTriggered = evaluateWardrobeRules(periodForecast, prefs.wardrobeRules)
         // Calendar events are gated on both the opt-in pref AND a configured reader.
@@ -89,6 +103,7 @@ class GenerateDailyInsight(
             hourly = periodForecast.hourly,
             confidence = bundle.confidence,
             outfit = OutfitSuggestion.fromForecast(periodForecast),
+            nextOutfit = nextOutfit,
             period = period,
             hasEvents = periodEvents.isNotEmpty(),
         )

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsightTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsightTest.kt
@@ -9,6 +9,7 @@ import app.clothescast.core.domain.model.DistanceUnit
 import app.clothescast.core.domain.model.ForecastPeriod
 import app.clothescast.core.domain.model.HourlyForecast
 import app.clothescast.core.domain.model.Location
+import app.clothescast.core.domain.model.OutfitSuggestion
 import app.clothescast.core.domain.model.Schedule
 import app.clothescast.core.domain.model.TemperatureBand
 import app.clothescast.core.domain.model.TemperatureUnit
@@ -368,6 +369,75 @@ class GenerateDailyInsightTest {
         // is what drives the tonight band sentence and outfit, not today's daytime min.
         result.insight.summary.band.low shouldBe TemperatureBand.FREEZING
         result.insight.summary.band.high shouldBe TemperatureBand.COOL
+    }
+
+    @Test
+    fun `today period populates nextOutfit from the overnight slice when hourly carries tonight hours`() = runTest {
+        val todayHourly = listOf(
+            HourlyForecast(LocalTime.of(8, 0), 22.0, 22.0, 5.0, WeatherCondition.CLEAR),
+            HourlyForecast(LocalTime.of(15, 0), 26.0, 26.0, 5.0, WeatherCondition.CLEAR),
+            // Overnight hours dropping into the SWEATER band — drives a different
+            // nextOutfit than the daytime TSHIRT.
+            HourlyForecast(LocalTime.of(20, 0), 14.0, 12.0, 5.0, WeatherCondition.CLEAR),
+            HourlyForecast(LocalTime.of(23, 0), 11.0, 9.0, 5.0, WeatherCondition.CLEAR),
+        )
+        val warmDay = today.copy(
+            temperatureMinC = 20.0,
+            temperatureMaxC = 26.0,
+            feelsLikeMinC = 20.0,
+            feelsLikeMaxC = 26.0,
+            hourly = todayHourly,
+        )
+        val weather = FakeWeatherRepository(ForecastBundle(warmDay, yesterday))
+        val subject = GenerateDailyInsight(weather, clock = clock)
+
+        val result = subject(london, prefs, ForecastPeriod.TODAY)
+
+        result.insight.outfit shouldBe OutfitSuggestion(
+            top = OutfitSuggestion.Top.TSHIRT,
+            bottom = OutfitSuggestion.Bottom.SHORTS,
+        )
+        result.insight.nextOutfit shouldBe OutfitSuggestion(
+            top = OutfitSuggestion.Top.SWEATER,
+            bottom = OutfitSuggestion.Bottom.LONG_PANTS,
+        )
+    }
+
+    @Test
+    fun `tonight period populates nextOutfit from tomorrow's daily forecast`() = runTest {
+        val tomorrow = DailyForecast(
+            date = LocalDate.of(2026, 4, 26),
+            temperatureMinC = 14.0,
+            temperatureMaxC = 26.0,
+            feelsLikeMinC = 14.0,
+            feelsLikeMaxC = 26.0,
+            precipitationProbabilityMaxPct = 5.0,
+            precipitationMmTotal = 0.0,
+            condition = WeatherCondition.CLEAR,
+        )
+        val weather = FakeWeatherRepository(
+            ForecastBundle(today, yesterday, tomorrow = tomorrow),
+        )
+        val subject = GenerateDailyInsight(weather, clock = clock)
+
+        val result = subject(london, prefs, ForecastPeriod.TONIGHT)
+
+        // Tomorrow's feels-like 14→26: SWEATER (min < 18) and LONG_PANTS
+        // (min ≤ 15 — shorts need both max > 22 and min > 15).
+        result.insight.nextOutfit shouldBe OutfitSuggestion(
+            top = OutfitSuggestion.Top.SWEATER,
+            bottom = OutfitSuggestion.Bottom.LONG_PANTS,
+        )
+    }
+
+    @Test
+    fun `tonight period leaves nextOutfit null when tomorrow daily is unavailable`() = runTest {
+        val weather = FakeWeatherRepository(ForecastBundle(today, yesterday))
+        val subject = GenerateDailyInsight(weather, clock = clock)
+
+        val result = subject(london, prefs, ForecastPeriod.TONIGHT)
+
+        result.insight.nextOutfit.shouldBeNull()
     }
 
     @Test


### PR DESCRIPTION
## Summary

The home screen now renders two outfit cards in a Row at the top instead of a single card.
- **Morning insight** (TODAY) → `Today + Tonight`
- **Evening insight** (TONIGHT) → `Tonight + Tomorrow`

Both outfits come from the same forecast bundle so the second card is free — no extra API call. `nextOutfit` is computed from the overnight slice on TODAY, and from `bundle.tomorrow` (newly surfaced from the existing `forecast_days=2` Open-Meteo response) on TONIGHT.

## Highlights

- `Insight.nextOutfit: OutfitSuggestion?` — upcoming-period outfit, defaults to null so old cached payloads still deserialise.
- `ForecastBundle.tomorrow: DailyForecast?` — tomorrow's full daily aggregates, populated by `OpenMeteoMapper` from index 2.
- `OutfitPreviewRow` (TodayScreen) — compact paired cards with a label above each (`Today` / `Tonight` / `Tomorrow`). Falls back to a single card when `nextOutfit` is null.
- Manual **Refresh** now picks period by wall clock (≥19:00 or <07:00 → TONIGHT) so an evening tap regenerates the right slot. The work-status banner subscribes to both unique-work names so the spinner/error surface still works on the tonight path.

## Tests

- `:core:domain` — three new cases on `GenerateDailyInsightTest`:
  - TODAY populates `nextOutfit` from the overnight slice.
  - TONIGHT populates `nextOutfit` from `bundle.tomorrow`.
  - TONIGHT leaves `nextOutfit` null when tomorrow daily isn't available.
- `:core:data` — two new cases on `OpenMeteoMapperTest` for `bundle.tomorrow` populated / null.
- `:app` — two new Roborazzi snapshot wrappers (`OutfitRowTodayTonightPreview`, `OutfitRowTonightTomorrowPreview`).

Sandbox can't pull AGP / Kotlin plugins, so I couldn't run JVM/Android builds locally — relying on CI for validation.

## Test plan

- [ ] CI: `JVM unit tests` green
- [ ] CI: `Android debug build` green
- [ ] Eyeball `ui-preview-snapshots` artifact for the two new outfit-row PNGs
- [ ] Smoke on device: morning shows `Today + Tonight`; evening shows `Tonight + Tomorrow`; legacy cache (no `nextOutfit`) still renders a single card.

https://claude.ai/code/session_01QVDJH2SRYGz92A7ebL6TCK

---
_Generated by [Claude Code](https://claude.ai/code/session_01QVDJH2SRYGz92A7ebL6TCK)_