### PR TITLE
:app — drop brittle per-item ordering from SettingsRoute KDoc

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsScreen.kt
@@ -30,9 +30,9 @@ import app.clothescast.R
 
 /**
  * One sub-page per concern. Order in the enum matches the order shown in the
- * root list: schedule + clothes come first (the most-frequently-tweaked rules),
- * region + voice after (set once, mostly forgotten), API keys / data sources /
- * about at the bottom.
+ * root list: the most-frequently-tweaked rules at the top, set-once
+ * configuration in the middle, and API keys / data sources / about at the
+ * bottom.
  *
  * Public so callers (e.g. the onboarding flow) can deep-link into a specific
  * sub-page via [SettingsScreen]'s `initialRoute` param.


### PR DESCRIPTION
## Summary

The `SettingsRoute` KDoc lumped Region and Voice together as "set once, mostly forgotten" and called out their order explicitly. Commit 4d50a86 already swapped the literal "voice + region" → "region + voice" when it moved Region above Voice in the enum, but the lumped grouping didn't actually capture *why* Region now leads — both items are "set once". Describing the three tiers (frequently tweaked → set-once → infrastructure) without naming items inside the middle tier means a future re-shuffle within that tier won't drift the comment again.

No behavioural change; doc-only.

## Test plan

- [ ] CI green (JVM unit tests + Android debug build)


---
_Generated by [Claude Code](https://claude.ai/code/session_01UEUQfVAbGwt8SfPn4Rkg7Y)_