### PR TITLE
:app + :core — variant picker actually steers Gemini + filters ElevenLabs voices

### DIFF
--- a/app/src/main/kotlin/app/clothescast/tts/GeminiTtsSpeaker.kt
+++ b/app/src/main/kotlin/app/clothescast/tts/GeminiTtsSpeaker.kt
@@ -20,7 +20,7 @@ class GeminiTtsSpeaker(
 ) : TtsSpeaker {
 
     override suspend fun speak(text: String, locale: Locale) {
-        val audio = client.synthesize(text = text, voiceName = voiceName)
+        val audio = client.synthesize(text = text, voiceName = voiceName, locale = locale)
         PcmAudioPlayer.play(audio)
     }
 }

--- a/app/src/main/kotlin/app/clothescast/tts/TtsVoices.kt
+++ b/app/src/main/kotlin/app/clothescast/tts/TtsVoices.kt
@@ -1,5 +1,7 @@
 package app.clothescast.tts
 
+import app.clothescast.core.domain.model.VoiceLocale
+
 /**
  * Curated voice lists for the user-facing voice picker. Each provider has many more
  * options than this — these are the ones surfaced in Settings to keep the picker
@@ -8,8 +10,36 @@ package app.clothescast.tts
  * The [id] is what's persisted and sent to the API. The [displayName] is shown in the
  * dropdown and is intentionally English-only for v1; if/when we localize, these move
  * to strings.xml.
+ *
+ * [locale] is the voice's *baked-in* accent — only meaningful for providers whose
+ * voices have a fixed accent that can't be steered by prompt (ElevenLabs voice
+ * clones). Null means the picker does not filter that voice by accent: Gemini's
+ * prebuilt voices are language-agnostic personalities and accept accent steering
+ * via prompt, and OpenAI's tts-1 voices have *fixed* accents that aren't
+ * prompt-steerable but the variant indirectly drives which voice gets picked as
+ * the default via `VoiceLocaleExt.defaultOpenAiVoiceFor` (e.g. en-GB → fable).
+ * The picker only filters by [locale] when it's non-null.
  */
-data class TtsVoiceOption(val id: String, val displayName: String)
+data class TtsVoiceOption(
+    val id: String,
+    val displayName: String,
+    val locale: VoiceLocale? = null,
+)
+
+/**
+ * Filters [voices] to the user's preferred [variant]. Falls back to the full
+ * list when the filter would empty out — handing the user an empty picker is
+ * worse than offering whatever voices we have, even if the accent doesn't match.
+ *
+ * Voices with a null [TtsVoiceOption.locale] are accent-agnostic and always
+ * pass the filter. [VoiceLocale.SYSTEM] disables filtering — the user has not
+ * expressed a preference, so show everything.
+ */
+fun List<TtsVoiceOption>.filterByVariant(variant: VoiceLocale): List<TtsVoiceOption> {
+    if (variant == VoiceLocale.SYSTEM) return this
+    val matched = filter { it.locale == null || it.locale == variant }
+    return matched.ifEmpty { this }
+}
 
 val GEMINI_VOICES: List<TtsVoiceOption> = listOf(
     TtsVoiceOption("Kore", "Kore — Firm"),
@@ -43,13 +73,19 @@ val OPENAI_VOICES: List<TtsVoiceOption> = listOf(
 // the picker. These are the popular pre-made library voices. Users with a paid
 // plan can clone their own voice — they'd need to copy/paste the voice ID by
 // hand, which we don't surface in v1.
+//
+// Each entry is tagged with the voice's native accent — ElevenLabs voices are
+// clones of specific speakers, so the accent is fixed and can't be steered by
+// prompt. The Settings picker filters by the user's selected variant; if the
+// filter empties out we fall back to the full list. The v1 library is entirely
+// en-US, so en-GB and en-AU users see the fallback today.
 val ELEVENLABS_VOICES: List<TtsVoiceOption> = listOf(
-    TtsVoiceOption("EXAVITQu4vr4xnSDxMaL", "Sarah — Warm, female"),
-    TtsVoiceOption("21m00Tcm4TlvDq8ikWAM", "Rachel — Calm, female"),
-    TtsVoiceOption("AZnzlk1v9MwlGOIKvxn0", "Domi — Strong, female"),
-    TtsVoiceOption("MF3mGyEYCl7XYWbV9V6O", "Elli — Emotional, female"),
-    TtsVoiceOption("pNInz6obpgDQGcFmaJgB", "Adam — Deep, male"),
-    TtsVoiceOption("ErXwobaYiN019PkySvjV", "Antoni — Well-rounded, male"),
-    TtsVoiceOption("TxGEqnHWrfWFTfGW9XjX", "Josh — Young, male"),
-    TtsVoiceOption("VR6AewLTigWG4xSOukaG", "Arnold — Crisp, male"),
+    TtsVoiceOption("EXAVITQu4vr4xnSDxMaL", "Sarah — Warm, female", VoiceLocale.EN_US),
+    TtsVoiceOption("21m00Tcm4TlvDq8ikWAM", "Rachel — Calm, female", VoiceLocale.EN_US),
+    TtsVoiceOption("AZnzlk1v9MwlGOIKvxn0", "Domi — Strong, female", VoiceLocale.EN_US),
+    TtsVoiceOption("MF3mGyEYCl7XYWbV9V6O", "Elli — Emotional, female", VoiceLocale.EN_US),
+    TtsVoiceOption("pNInz6obpgDQGcFmaJgB", "Adam — Deep, male", VoiceLocale.EN_US),
+    TtsVoiceOption("ErXwobaYiN019PkySvjV", "Antoni — Well-rounded, male", VoiceLocale.EN_US),
+    TtsVoiceOption("TxGEqnHWrfWFTfGW9XjX", "Josh — Young, male", VoiceLocale.EN_US),
+    TtsVoiceOption("VR6AewLTigWG4xSOukaG", "Arnold — Crisp, male", VoiceLocale.EN_US),
 )

--- a/app/src/main/kotlin/app/clothescast/ui/settings/VoiceSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/VoiceSettings.kt
@@ -39,6 +39,7 @@ import app.clothescast.tts.GeminiTtsSpeaker
 import app.clothescast.tts.OPENAI_VOICES
 import app.clothescast.tts.OpenAITtsSpeaker
 import app.clothescast.tts.TtsVoiceOption
+import app.clothescast.tts.filterByVariant
 import app.clothescast.tts.resolve
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
@@ -168,7 +169,7 @@ internal fun VoiceContent(
                     }
                     VoicePicker(
                         title = stringResource(R.string.settings_tts_voice_label),
-                        voices = ELEVENLABS_VOICES,
+                        voices = ELEVENLABS_VOICES.filterByVariant(voiceLocale),
                         selectedId = elevenLabsVoice,
                         enabled = !isPreviewing,
                         onSelect = {

--- a/app/src/test/kotlin/app/clothescast/tts/TtsVoicesTest.kt
+++ b/app/src/test/kotlin/app/clothescast/tts/TtsVoicesTest.kt
@@ -1,0 +1,42 @@
+package app.clothescast.tts
+
+import app.clothescast.core.domain.model.VoiceLocale
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+class TtsVoicesTest {
+
+    private val american = TtsVoiceOption("a", "Alice — US", VoiceLocale.EN_US)
+    private val british = TtsVoiceOption("b", "Bob — UK", VoiceLocale.EN_GB)
+    private val agnostic = TtsVoiceOption("c", "Cleo — any")
+
+    @Test
+    fun `SYSTEM disables filtering`() {
+        val all = listOf(american, british, agnostic)
+        all.filterByVariant(VoiceLocale.SYSTEM) shouldBe all
+    }
+
+    @Test
+    fun `keeps matching variant and accent-agnostic voices`() {
+        val all = listOf(american, british, agnostic)
+        all.filterByVariant(VoiceLocale.EN_GB)
+            .shouldContainExactlyInAnyOrder(british, agnostic)
+    }
+
+    @Test
+    fun `falls back to the full list when no voice matches the variant`() {
+        // No EN_AU voices in this list — better to show every voice (with the
+        // accent in the display name) than to leave the user with an empty picker.
+        val all = listOf(american, british)
+        all.filterByVariant(VoiceLocale.EN_AU) shouldBe all
+    }
+
+    @Test
+    fun `accent-agnostic voices alone are kept as-is, not treated as empty`() {
+        // A list of only null-locale voices isn't "empty after filter" — it's
+        // a list where every voice opts in. Don't trip the fallback path.
+        val all = listOf(agnostic)
+        all.filterByVariant(VoiceLocale.EN_GB) shouldBe all
+    }
+}

--- a/core/data/src/main/kotlin/app/clothescast/core/data/tts/GeminiTtsClient.kt
+++ b/core/data/src/main/kotlin/app/clothescast/core/data/tts/GeminiTtsClient.kt
@@ -19,6 +19,7 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import java.util.Base64
+import java.util.Locale
 
 const val DEFAULT_GEMINI_TTS_MODEL: String = "gemini-2.5-flash-preview-tts"
 const val DEFAULT_GEMINI_TTS_VOICE: String = "Kore"
@@ -37,6 +38,26 @@ internal const val GEMINI_API_VERSION = "v1beta"
 internal const val GEMINI_TTS_STYLE_DIRECTIVE: String =
     "Read the following in a clean, crisp studio voice with no audio effects, " +
         "background noise, or vinyl-style texture:\n\n"
+
+/**
+ * Returns a one-line accent instruction for Gemini's TTS prompt, or null when
+ * the locale doesn't map to a known English variant (in which case the model's
+ * default — North American English — applies).
+ *
+ * Gemini's prebuilt voices are language-agnostic and accept natural-language
+ * accent steering in the same prompt that carries the spoken text. The
+ * instruction is prepended to the user text alongside [GEMINI_TTS_STYLE_DIRECTIVE]
+ * and is interpreted as direction, not spoken back.
+ */
+internal fun geminiAccentDirectiveFor(locale: Locale): String? {
+    if (locale.language != "en") return null
+    return when (locale.country) {
+        "GB" -> "Speak with a British English accent."
+        "AU" -> "Speak with an Australian English accent."
+        "US" -> "Speak with a North American English accent."
+        else -> null
+    }
+}
 
 /**
  * Calls Gemini's audio-output model (e.g. `gemini-2.5-flash-preview-tts`). Uses the
@@ -62,9 +83,20 @@ class GeminiTtsClient(
     suspend fun synthesize(
         text: String,
         voiceName: String = DEFAULT_GEMINI_TTS_VOICE,
+        locale: Locale? = null,
     ): PcmAudio {
         val key = keyProvider.get().also {
             if (it.isBlank()) throw MissingApiKeyException()
+        }
+
+        val accent = locale?.let { geminiAccentDirectiveFor(it) }
+        val prompt = buildString {
+            append(GEMINI_TTS_STYLE_DIRECTIVE)
+            if (accent != null) {
+                append(accent)
+                append("\n\n")
+            }
+            append(text)
         }
 
         val httpResponse: HttpResponse = httpClient.post {
@@ -78,7 +110,7 @@ class GeminiTtsClient(
             setBody(
                 TtsRequest(
                     contents = listOf(
-                        TtsContent(parts = listOf(TtsTextPart(GEMINI_TTS_STYLE_DIRECTIVE + text))),
+                        TtsContent(parts = listOf(TtsTextPart(prompt))),
                     ),
                     generationConfig = TtsGenerationConfig(
                         responseModalities = listOf("AUDIO"),

--- a/core/data/src/test/kotlin/app/clothescast/core/data/tts/GeminiTtsClientTest.kt
+++ b/core/data/src/test/kotlin/app/clothescast/core/data/tts/GeminiTtsClientTest.kt
@@ -19,6 +19,7 @@ import io.ktor.utils.io.ByteReadChannel
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Test
+import java.util.Locale
 
 class GeminiTtsClientTest {
 
@@ -102,6 +103,62 @@ class GeminiTtsClientTest {
         val body = checkNotNull(capturedBody)
         body.shouldContain("clean, crisp studio voice")
         body.shouldContain("hello world")
+    }
+
+    @Test
+    fun `request body includes a british accent directive for en-GB locale`() = runTest {
+        var capturedBody: String? = null
+        val client = GeminiTtsClient(
+            httpClient = mockClient(SUCCESS_BODY) {
+                capturedBody = (it.body as io.ktor.http.content.OutgoingContent.ByteArrayContent)
+                    .bytes()
+                    .toString(Charsets.UTF_8)
+            },
+            keyProvider = FakeKeyProvider("test-key"),
+        )
+
+        client.synthesize(text = "hello", locale = Locale.UK)
+
+        val body = checkNotNull(capturedBody)
+        body.shouldContain("British English accent")
+    }
+
+    @Test
+    fun `request body includes an australian accent directive for en-AU locale`() = runTest {
+        var capturedBody: String? = null
+        val client = GeminiTtsClient(
+            httpClient = mockClient(SUCCESS_BODY) {
+                capturedBody = (it.body as io.ktor.http.content.OutgoingContent.ByteArrayContent)
+                    .bytes()
+                    .toString(Charsets.UTF_8)
+            },
+            keyProvider = FakeKeyProvider("test-key"),
+        )
+
+        client.synthesize(text = "hello", locale = Locale.forLanguageTag("en-AU"))
+
+        val body = checkNotNull(capturedBody)
+        body.shouldContain("Australian English accent")
+    }
+
+    @Test
+    fun `request body omits the accent directive for unknown english variants`() = runTest {
+        // en-CA isn't in our supported variant list — fall through to whatever the
+        // model defaults to rather than picking a wrong-but-confident accent.
+        var capturedBody: String? = null
+        val client = GeminiTtsClient(
+            httpClient = mockClient(SUCCESS_BODY) {
+                capturedBody = (it.body as io.ktor.http.content.OutgoingContent.ByteArrayContent)
+                    .bytes()
+                    .toString(Charsets.UTF_8)
+            },
+            keyProvider = FakeKeyProvider("test-key"),
+        )
+
+        client.synthesize(text = "hello", locale = Locale.forLanguageTag("en-CA"))
+
+        val body = checkNotNull(capturedBody)
+        body.shouldNotContain("English accent")
     }
 
     @Test

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Settings.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Settings.kt
@@ -22,19 +22,24 @@ enum class DeliveryMode { NOTIFICATION_ONLY, TTS_ONLY, NOTIFICATION_AND_TTS }
 enum class TtsEngine { DEVICE, GEMINI, OPENAI, ELEVENLABS }
 
 /**
- * User-selectable accent / language preference for spoken playback. Used in
- * two ways:
+ * User-selectable accent / language preference for spoken playback. Used by
+ * each engine as best fits its capabilities:
  *
- *  - For [TtsEngine.DEVICE] it picks the actual voice to speak in (the
- *    Android TextToSpeech engine has separate en-US / en-GB / en-AU voices).
- *  - For [TtsEngine.OPENAI] it influences the *default* voice when the user
- *    hasn't explicitly chosen one — en-GB picks `fable` (the only British
- *    voice), everything else picks `nova`. Once the user explicitly picks
- *    a voice in Settings, that choice wins regardless of locale.
- *
- * Gemini's prebuilt voices are language-agnostic personalities, so this
- * preference doesn't change the Gemini voice — but the resolved [java.util.Locale]
- * is still passed through to all engines for consistency at the call sites.
+ *  - [TtsEngine.DEVICE] picks the actual voice to speak in (the Android
+ *    TextToSpeech engine has separate en-US / en-GB / en-AU voices).
+ *  - [TtsEngine.GEMINI] passes the locale through as a natural-language
+ *    accent directive prepended to the prompt — Gemini's prebuilt voices are
+ *    language-agnostic personalities and follow that direction.
+ *  - [TtsEngine.ELEVENLABS] filters the voice picker to voices whose baked-in
+ *    accent matches the variant; falls back to the full list if no voice
+ *    matches. Voice clones have a fixed accent that can't be prompt-steered.
+ *  - [TtsEngine.OPENAI] influences the *default* voice when the user hasn't
+ *    explicitly chosen one — en-GB picks `fable` (the only British voice),
+ *    everything else picks `nova`. Once the user explicitly picks a voice in
+ *    Settings, that choice wins regardless of locale. (tts-1's voices have
+ *    fixed accents that can't be prompt-steered; switching to
+ *    `gpt-4o-mini-tts` would unlock instruction-based accent steering at a
+ *    higher per-character cost.)
  *
  * [SYSTEM] means "follow the phone's locale" — the right default for almost
  * everyone, since their device language already encodes their accent


### PR DESCRIPTION
## Why

The English-variant picker (en-US / en-GB / en-AU / SYSTEM) was a no-op
for cloud TTS:

- `GeminiTtsSpeaker.speak(text, locale)` accepted a `Locale` and dropped
  it on the floor — never forwarded to the request.
- ElevenLabs voices have **baked-in accents** (clones of specific
  speakers) and the v1 curated list happens to be entirely American
  (Sarah, Rachel, Adam, Antoni, Domi, Elli, Josh, Arnold). Picking en-GB
  did nothing because there were no UK voices to switch to.

So picking "British English" still sounded American on every cloud
engine. Only the device engine honoured it.

## What

**Gemini — locale becomes a style directive.** The existing
`GEMINI_TTS_STYLE_DIRECTIVE` (the "clean studio voice" preamble) gets a
one-line accent instruction appended for known English variants:

| Locale | Directive |
| --- | --- |
| en-US | `Speak with a North American English accent.` |
| en-GB | `Speak with a British English accent.` |
| en-AU | `Speak with an Australian English accent.` |
| other | (omitted — model default applies) |

`GeminiTtsSpeaker` now forwards its `locale` parameter to the client.
Tests cover en-GB / en-AU / en-CA-as-unknown.

**ElevenLabs — picker filters by tagged variant with fallback.**
`TtsVoiceOption` gains an optional `locale: VoiceLocale?` (null =
accent-agnostic, always passes the filter). The eight ElevenLabs voices
are tagged `EN_US`. A new `List<TtsVoiceOption>.filterByVariant(variant)`
extension is wired into the ElevenLabs branch of the voice picker and:

- returns the full list for `VoiceLocale.SYSTEM` (no expressed
  preference)
- filters to matching + null-locale voices otherwise
- falls back to the full list when the filter would empty out — better
  to show all voices (with the accent in the display name) than hand
  the user an empty picker

The v1 list is entirely en-US, so en-GB / en-AU users see the fallback
today. The plumbing is in place for adding non-US voice IDs later.

**OpenAI — intentionally unchanged.** `tts-1` voices have fixed accents
that can't be prompt-steered, and the existing `defaultOpenAiVoiceFor`
heuristic already maps en-GB → `fable`. Switching to `gpt-4o-mini-tts`
would unlock instruction-based accent steering, but that's a different
pricing model and worth being a deliberate, separate decision.

## Test plan

- [ ] CI green (JVM unit tests + Android debug build)
- [ ] On-device sanity: open Settings → Voice, with Gemini selected, set
  variant to en-GB, hit Test Voice → confirm British accent
- [ ] Same with en-AU → Australian
- [ ] Switch engine to ElevenLabs, set variant to en-GB → confirm picker
  shows all 8 voices (fallback path), default voice still works
- [ ] Switch to en-US → picker shows all 8 voices (filter passes them)
- [ ] Switch to SYSTEM → picker shows all 8 voices (no filter)

## Notes for review

- I couldn't run `:app:assembleDebug` or `:app:testDebugUnitTest`
  locally (sandbox can't fetch the Gradle distribution). Relying on CI
  for both jobs.
- The `Settings.kt` `VoiceLocale` KDoc was rewritten to match the new
  per-engine behaviour — that file's diff is mostly comment changes.

https://claude.ai/code/session_01Q37WC1LUsnQW19J7oK1En4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q37WC1LUsnQW19J7oK1En4)_