### PR TITLE
:app — paste API key from the Voice screen when an engine is missing one

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsScreen.kt
@@ -142,6 +142,9 @@ fun SettingsScreen(
                 onSetOpenAiVoice = viewModel::setOpenAiVoice,
                 onSetElevenLabsVoice = viewModel::setElevenLabsVoice,
                 onSetVoiceLocale = viewModel::setVoiceLocale,
+                onSetGeminiKey = viewModel::setApiKey,
+                onSetOpenAiKey = viewModel::setOpenAiKey,
+                onSetElevenLabsKey = viewModel::setElevenLabsKey,
             )
             SettingsRoute.ApiKeys -> ApiKeysContent(
                 geminiConfigured = state.apiKeyConfigured,

--- a/app/src/main/kotlin/app/clothescast/ui/settings/VoiceSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/VoiceSettings.kt
@@ -9,12 +9,14 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -27,6 +29,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
 import app.clothescast.R
 import app.clothescast.core.domain.model.TtsEngine
@@ -62,6 +67,9 @@ internal fun VoiceContent(
     onSetOpenAiVoice: (String) -> Unit,
     onSetElevenLabsVoice: (String) -> Unit,
     onSetVoiceLocale: (VoiceLocale) -> Unit,
+    onSetGeminiKey: (String) -> Unit,
+    onSetOpenAiKey: (String) -> Unit,
+    onSetElevenLabsKey: (String) -> Unit,
 ) {
     val context = LocalContext.current
     val coroutineScope = rememberCoroutineScope()
@@ -128,7 +136,11 @@ internal fun VoiceContent(
             when (selected) {
                 TtsEngine.GEMINI -> {
                     if (!geminiKeyConfigured) {
-                        MissingKeyHint(stringResource(R.string.settings_api_key_gemini_label))
+                        MissingKeyHint(
+                            engineName = stringResource(R.string.settings_api_key_gemini_label),
+                            placeholder = stringResource(R.string.settings_api_key_placeholder),
+                            onSaveKey = onSetGeminiKey,
+                        )
                     }
                     VoicePicker(
                         title = stringResource(R.string.settings_tts_voice_label),
@@ -146,7 +158,11 @@ internal fun VoiceContent(
                 }
                 TtsEngine.OPENAI -> {
                     if (!openAiKeyConfigured) {
-                        MissingKeyHint(stringResource(R.string.settings_api_key_openai_label))
+                        MissingKeyHint(
+                            engineName = stringResource(R.string.settings_api_key_openai_label),
+                            placeholder = stringResource(R.string.settings_openai_key_placeholder),
+                            onSaveKey = onSetOpenAiKey,
+                        )
                     }
                     VoicePicker(
                         title = stringResource(R.string.settings_tts_voice_label),
@@ -164,7 +180,11 @@ internal fun VoiceContent(
                 }
                 TtsEngine.ELEVENLABS -> {
                     if (!elevenLabsKeyConfigured) {
-                        MissingKeyHint(stringResource(R.string.settings_api_key_elevenlabs_label))
+                        MissingKeyHint(
+                            engineName = stringResource(R.string.settings_api_key_elevenlabs_label),
+                            placeholder = stringResource(R.string.settings_elevenlabs_key_placeholder),
+                            onSaveKey = onSetElevenLabsKey,
+                        )
                     }
                     VoicePicker(
                         title = stringResource(R.string.settings_tts_voice_label),
@@ -192,15 +212,79 @@ internal fun VoiceContent(
 
 /**
  * Inline hint shown next to the engine picker when the chosen engine's key isn't
- * configured. Points the user up to the API keys section instead of trying to
- * collect the key here — keys are managed in one place now.
+ * configured. Tapping "Add API key" opens a paste dialog so the user can enter
+ * the key without leaving the Voice screen — the same key that the API keys
+ * page would store.
  */
 @Composable
-private fun MissingKeyHint(engineName: String) {
+private fun MissingKeyHint(
+    engineName: String,
+    placeholder: String,
+    onSaveKey: (String) -> Unit,
+) {
+    var dialogOpen by remember { mutableStateOf(false) }
     Text(
         text = stringResource(R.string.settings_tts_no_key_hint, engineName),
         style = MaterialTheme.typography.bodyMedium,
         color = MaterialTheme.colorScheme.error,
+    )
+    Button(
+        onClick = { dialogOpen = true },
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Text(stringResource(R.string.settings_tts_add_api_key))
+    }
+    if (dialogOpen) {
+        AddApiKeyDialog(
+            engineName = engineName,
+            placeholder = placeholder,
+            onSave = {
+                onSaveKey(it)
+                dialogOpen = false
+            },
+            onDismiss = { dialogOpen = false },
+        )
+    }
+}
+
+@Composable
+private fun AddApiKeyDialog(
+    engineName: String,
+    placeholder: String,
+    onSave: (String) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var input by remember { mutableStateOf("") }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.settings_tts_add_api_key_title, engineName)) },
+        text = {
+            OutlinedTextField(
+                value = input,
+                onValueChange = { input = it },
+                singleLine = true,
+                visualTransformation = if (input.isEmpty()) VisualTransformation.None else PasswordVisualTransformation(),
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+                placeholder = { Text(placeholder) },
+                modifier = Modifier.fillMaxWidth(),
+            )
+        },
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    val trimmed = input.trim()
+                    if (trimmed.isNotEmpty()) onSave(trimmed)
+                },
+                enabled = input.isNotBlank(),
+            ) {
+                Text(stringResource(R.string.settings_tts_add_api_key_save))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.settings_tts_add_api_key_cancel))
+            }
+        },
     )
 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -123,7 +123,13 @@
     <string name="settings_tts_test">Test voice</string>
     <!-- Shown next to the engine picker when the chosen engine's API key isn't
          configured. %1$s is the engine name ("Gemini" / "OpenAI"). -->
-    <string name="settings_tts_no_key_hint">No %1$s key configured — add one in API keys above to enable this engine.</string>
+    <string name="settings_tts_no_key_hint">No %1$s key configured — add one to enable this engine.</string>
+    <!-- Button next to the missing-key hint that opens a paste-key dialog. -->
+    <string name="settings_tts_add_api_key">Add API key</string>
+    <!-- Title of the paste-key dialog. %1$s is the engine name. -->
+    <string name="settings_tts_add_api_key_title">Add %1$s API key</string>
+    <string name="settings_tts_add_api_key_save">Save</string>
+    <string name="settings_tts_add_api_key_cancel">Cancel</string>
     <string name="settings_tts_test_in_flight">Testing — please wait…</string>
     <string name="settings_tts_test_sample">Hello — this is the ClothesCast voice preview.</string>
 


### PR DESCRIPTION
## Summary

Selecting a cloud TTS engine (Gemini / OpenAI / ElevenLabs) without a configured key used to show only a red hint pointing the user up to the API keys page. That's a long round-trip for what should be a one-tap action.

This PR adds an **Add API key** button right under the engine in the Voice screen. Tapping it opens a small `AlertDialog` with a password-masked paste field and Save / Cancel buttons. Save is wired to the same `viewModel.setApiKey` / `setOpenAiKey` / `setElevenLabsKey` methods the API keys page already uses, so the key lands in the same Tink-encrypted DataStore either way.

The button only appears when the selected engine's key is unset — pasting a key clears the hint on the next state tick (the `*KeyConfigured` flag flips), so the dialog effectively dismisses itself.

## Changes

- `VoiceSettings.kt` — new `MissingKeyHint` (hint text + button + dialog launcher) and `AddApiKeyDialog` composables; three new `onSetXxxKey` parameters on `VoiceContent`.
- `SettingsScreen.kt` — wires the new callbacks to the existing VM methods.
- `strings.xml` — four new strings (`settings_tts_add_api_key`, `_title`, `_save`, `_cancel`); rephrased `settings_tts_no_key_hint` to drop "in API keys above".

## Test plan

- [ ] Voice → pick Gemini / OpenAI / ElevenLabs without a key — red hint + **Add API key** button appears.
- [ ] Tap the button — dialog opens with a password-masked paste field.
- [ ] Paste a key, tap Save — dialog dismisses, hint and button disappear, voice picker / Test voice usable.
- [ ] Cancel button closes the dialog without saving; Save is disabled while the field is blank.
- [ ] Same engine on the API keys page still shows "configured" after saving from the Voice dialog (same encrypted key).

I can't run `:app:assembleDebug` or `:app:testDebugUnitTest` in the agent sandbox (Google Maven blocked), so this leans on CI for build / snapshot validation.

https://claude.ai/code/session_01HKWjp8tpvTZVStqMBmtvJY

---
_Generated by [Claude Code](https://claude.ai/code/session_01HKWjp8tpvTZVStqMBmtvJY)_