### PR TITLE
:app — strings comment: include ElevenLabs in settings_tts_no_key_hint engines

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -122,7 +122,7 @@
     <string name="settings_tts_voice_locale_en_au">English (Australia)</string>
     <string name="settings_tts_test">Test voice</string>
     <!-- Shown next to the engine picker when the chosen engine's API key isn't
-         configured. %1$s is the engine name ("Gemini" / "OpenAI"). -->
+         configured. %1$s is the engine name ("Gemini" / "OpenAI" / "ElevenLabs"). -->
     <string name="settings_tts_no_key_hint">No %1$s key configured — add one to enable this engine.</string>
     <!-- Button next to the missing-key hint that opens a paste-key dialog. -->
     <string name="settings_tts_add_api_key">Add API key</string>


### PR DESCRIPTION
## Summary

Follow-up to #122. The `settings_tts_no_key_hint` resource is rendered for all three cloud engines (Gemini / OpenAI / ElevenLabs) — `MissingKeyHint` in `VoiceSettings.kt` calls it with each engine's label as `%1$s`. The dev comment above the string only listed Gemini and OpenAI, which would mislead translators. One-word fix.

Comment-only change, no behavioural impact, no string text change.

## Test plan

- [ ] CI green (no functional change).

https://claude.ai/code/session_01HKWjp8tpvTZVStqMBmtvJY

---
_Generated by [Claude Code](https://claude.ai/code/session_01HKWjp8tpvTZVStqMBmtvJY)_