### PR TITLE
:core — accent prompts: switch to linguist-standard labels (SSB / General Australian / General American)

### DIFF
--- a/app/src/main/kotlin/app/clothescast/tts/TtsVoices.kt
+++ b/app/src/main/kotlin/app/clothescast/tts/TtsVoices.kt
@@ -13,10 +13,12 @@ import app.clothescast.core.domain.model.VoiceLocale
  *
  * [locale] is the voice's *baked-in* accent — only meaningful for providers whose
  * voices have a fixed accent that can't be steered by prompt (ElevenLabs voice
- * clones). Null means the picker does not filter that voice by accent: both
- * Gemini's prebuilt voices and OpenAI's `gpt-4o-mini-tts` voices are
- * language-agnostic and accept accent steering via prompt directives at
- * synthesis time. The picker only filters by [locale] when it's non-null.
+ * clones). Null means the picker does not filter that voice by accent: Gemini's
+ * prebuilt voices and OpenAI's `gpt-4o-mini-tts` voices both accept a prompt-
+ * side accent directive at synthesis time (Gemini reliably; OpenAI imperfectly
+ * — see the per-engine notes in `geminiAccentDirectiveFor` and
+ * `openAiAccentInstructionFor`). The picker only filters by [locale] when it's
+ * non-null.
  */
 data class TtsVoiceOption(
     val id: String,

--- a/core/data/src/main/kotlin/app/clothescast/core/data/tts/GeminiTtsClient.kt
+++ b/core/data/src/main/kotlin/app/clothescast/core/data/tts/GeminiTtsClient.kt
@@ -52,9 +52,9 @@ internal const val GEMINI_TTS_STYLE_DIRECTIVE: String =
 internal fun geminiAccentDirectiveFor(locale: Locale): String? {
     if (locale.language != "en") return null
     return when (locale.country) {
-        "GB" -> "Speak with a British English accent."
-        "AU" -> "Speak with an Australian English accent."
-        "US" -> "Speak with a North American English accent."
+        "GB" -> "Speak with a Standard Southern British accent."
+        "AU" -> "Speak with a General Australian accent."
+        "US" -> "Speak with a General American accent."
         else -> null
     }
 }

--- a/core/data/src/main/kotlin/app/clothescast/core/data/tts/OpenAITtsClient.kt
+++ b/core/data/src/main/kotlin/app/clothescast/core/data/tts/OpenAITtsClient.kt
@@ -33,8 +33,16 @@ const val DEFAULT_OPENAI_TTS_VOICE: String = "alloy"
  * field, or null when the locale doesn't map to a known English variant
  * (in which case the model's default applies).
  *
+ * Uses linguist-standard accent labels (Standard Southern British, General
+ * Australian, General American) rather than vague "British English accent"
+ * phrasing — empirically, `gpt-4o-mini-tts` only weakly honours `instructions`
+ * for accent (the voice's baked-in timbre dominates), so any nudge we get
+ * comes from being as specific as possible. If the empirical effect on real
+ * traffic remains marginal, the next step is to tag voices by their native
+ * accent and filter the picker (mirroring the ElevenLabs approach).
+ *
  * Mirrors the Gemini version — same wording, same coverage — so the audible
- * accent is consistent across providers when the user picks the same variant.
+ * accent stays consistent across providers when the user picks the same variant.
  * Only honoured by `gpt-4o-mini-tts`; older OpenAI TTS models silently ignore
  * the field, which is fine for forward-compat if [DEFAULT_OPENAI_TTS_MODEL]
  * is ever overridden.
@@ -42,9 +50,9 @@ const val DEFAULT_OPENAI_TTS_VOICE: String = "alloy"
 internal fun openAiAccentInstructionFor(locale: Locale): String? {
     if (locale.language != "en") return null
     return when (locale.country) {
-        "GB" -> "Speak with a British English accent."
-        "AU" -> "Speak with an Australian English accent."
-        "US" -> "Speak with a North American English accent."
+        "GB" -> "Speak with a Standard Southern British accent."
+        "AU" -> "Speak with a General Australian accent."
+        "US" -> "Speak with a General American accent."
         else -> null
     }
 }

--- a/core/data/src/test/kotlin/app/clothescast/core/data/tts/GeminiTtsClientTest.kt
+++ b/core/data/src/test/kotlin/app/clothescast/core/data/tts/GeminiTtsClientTest.kt
@@ -120,7 +120,7 @@ class GeminiTtsClientTest {
         client.synthesize(text = "hello", locale = Locale.UK)
 
         val body = checkNotNull(capturedBody)
-        body.shouldContain("British English accent")
+        body.shouldContain("Standard Southern British accent")
     }
 
     @Test
@@ -138,7 +138,7 @@ class GeminiTtsClientTest {
         client.synthesize(text = "hello", locale = Locale.forLanguageTag("en-AU"))
 
         val body = checkNotNull(capturedBody)
-        body.shouldContain("Australian English accent")
+        body.shouldContain("General Australian accent")
     }
 
     @Test
@@ -158,7 +158,9 @@ class GeminiTtsClientTest {
         client.synthesize(text = "hello", locale = Locale.forLanguageTag("en-CA"))
 
         val body = checkNotNull(capturedBody)
-        body.shouldNotContain("English accent")
+        // No accent directive at all — none of the SSB / General Australian /
+        // General American sentinels should leak in for unknown variants.
+        body.shouldNotContain("Speak with a")
     }
 
     @Test

--- a/core/data/src/test/kotlin/app/clothescast/core/data/tts/OpenAITtsClientTest.kt
+++ b/core/data/src/test/kotlin/app/clothescast/core/data/tts/OpenAITtsClientTest.kt
@@ -96,7 +96,7 @@ class OpenAITtsClientTest {
         client.synthesize(text = "hello", locale = Locale.UK)
 
         val body = checkNotNull(capturedBody)
-        body.shouldContain("\"instructions\":\"Speak with a British English accent.\"")
+        body.shouldContain("\"instructions\":\"Speak with a Standard Southern British accent.\"")
     }
 
     @Test
@@ -110,7 +110,7 @@ class OpenAITtsClientTest {
         client.synthesize(text = "hello", locale = Locale.forLanguageTag("en-AU"))
 
         val body = checkNotNull(capturedBody)
-        body.shouldContain("Australian English accent")
+        body.shouldContain("General Australian accent")
     }
 
     @Test


### PR DESCRIPTION
## Why

Field-testing #123 showed that *"only fable seems to not be US English"* on
OpenAI — i.e. the `instructions = "Speak with a British English accent."`
plumbing barely moves the needle. OpenAI's `gpt-4o-mini-tts` lists "accent"
as a steerable property of `instructions`, but in practice the voice's
baked-in timbre wins and a vague directive like "British English accent"
isn't enough to override it.

This PR is the cheap experiment: try **more specific** phrasing first
before reaching for voice-list filtering.

## What

- `geminiAccentDirectiveFor` / `openAiAccentInstructionFor` now emit the
  linguist-standard accent names instead of the vague variant-name form:

  | Variant | Old | New |
  | --- | --- | --- |
  | en-GB | "Speak with a British English accent." | "Speak with a Standard Southern British accent." |
  | en-AU | "Speak with an Australian English accent." | "Speak with a General Australian accent." |
  | en-US | "Speak with a North American English accent." | "Speak with a General American accent." |

  These are the technical names for the *neutral / reference accent*
  within each variant (Standard Southern British is the modern term for
  what people used to call RP; General Australian is the dominant non-
  regional Australian accent; General American is the unmarked American).

- Both engines updated for symmetry. Gemini already steered reliably; the
  rewording is a refinement, not a fix.

- KDocs in `OpenAITtsClient` and `TtsVoices` now name the imperfect-
  steering reality explicitly and flag voice-list filtering as the
  fallback if this doesn't move the needle on real traffic.

- Tests adjusted for the new strings. The Gemini "unknown variant" test
  asserts the absence of the directive prefix sentinel (*"Speak with a"*)
  rather than the now-stale "English accent" substring, which gives a
  cleaner regression guard.

## Test plan

- [ ] CI green
- [ ] **Empirical accent test on a real device** with an OpenAI key
  configured: Settings → Voice → OpenAI → pick `nova` (en-US baseline) →
  set variant to en-GB → hit Test Voice. Did the new phrasing nudge it
  toward British, or does it still sound American?
- [ ] Same test with `alloy`, `onyx`, `shimmer` and `echo`.
- [ ] Test variant en-AU on `nova` — does "General Australian" produce
  anything Australian-sounding, or still American?
- [ ] On Gemini: same battery (en-GB / en-AU on a few voices) — should
  remain reliable; this is just a refinement.

## What's next if this doesn't work

The follow-up plan is voice-list filtering, mirroring what #121 did for
ElevenLabs:
- Tag `OPENAI_VOICES` with native accent (5 × en-US, `fable` × en-GB).
- Wire `OPENAI_VOICES.filterByVariant(...)` into the OpenAI branch of
  the picker.
- en-GB users see only `fable`; en-AU users get the full list as
  fallback (no Australian voice in OpenAI's stock library).

I'd open that as a separate PR if needed — keeping this one minimal so
the empirical test is uncontaminated by other changes.

https://claude.ai/code/session_01Q37WC1LUsnQW19J7oK1En4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q37WC1LUsnQW19J7oK1En4)_