### PR TITLE
:app — switch launcher icon background from sky blue to white

### DIFF
--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="ic_launcher_background">#87CEEB</color>
+    <color name="ic_launcher_background">#FFFFFFFF</color>
 </resources>


### PR DESCRIPTION
## Summary

Switches the adaptive launcher icon background from `#87CEEB` (sky blue) to `#FFFFFF` (white). The old sky-blue tile competed with the blue t-shirt foreground on most launcher backdrops; white gives the t-shirt a cleaner, more neutral surface.

Only `colors.xml` changes — the foreground PNGs and the adaptive-icon XML stay as-is. `minSdk = 26` so `mipmap-anydpi-v26` covers every supported device; no legacy `ic_launcher.png` exists to update.

I considered a transparent background but adaptive icons require an opaque background layer to render predictably across launcher masks (circular, squircle, etc.). Happy to switch to transparent if you'd rather have the launcher's own backdrop show through.

## Test plan

- [ ] Build and install — confirm the launcher icon renders white behind the t-shirt on both square and circular masks
- [ ] Spot-check on a dark wallpaper and a light wallpaper

---
_Generated by [Claude Code](https://claude.ai/code/session_01NqeRs8ZYK66q4VaSoQkQu8)_