### PR TITLE
:app + :core — OpenAI TTS: voice-filter by accent, drop dead instructions plumbing

### DIFF
--- a/app/src/main/kotlin/app/clothescast/tts/OpenAITtsSpeaker.kt
+++ b/app/src/main/kotlin/app/clothescast/tts/OpenAITtsSpeaker.kt
@@ -20,7 +20,13 @@ class OpenAITtsSpeaker(
 ) : TtsSpeaker {
 
     override suspend fun speak(text: String, locale: Locale) {
-        val audio = client.synthesize(text = text, voice = voice, locale = locale)
+        // [locale] is part of the [TtsSpeaker] contract (the device speaker uses
+        // it to pick a system voice) but OpenAI's accent is purely voice-bound:
+        // the right accent comes from the user picking the right voice in
+        // Settings, not from anything we can send at synthesis time. So we drop
+        // [locale] on the floor here, intentionally — see TtsVoices.kt for the
+        // picker-side filter that surfaces the accent-appropriate voices.
+        val audio = client.synthesize(text = text, voice = voice)
         PcmAudioPlayer.play(audio)
     }
 }

--- a/app/src/main/kotlin/app/clothescast/tts/TtsVoices.kt
+++ b/app/src/main/kotlin/app/clothescast/tts/TtsVoices.kt
@@ -12,12 +12,15 @@ import app.clothescast.core.domain.model.VoiceLocale
  * to strings.xml.
  *
  * [locale] is the voice's *baked-in* accent — only meaningful for providers whose
- * voices have a fixed accent that can't be steered by prompt (ElevenLabs voice
- * clones). Null means the picker does not filter that voice by accent: Gemini's
- * prebuilt voices and OpenAI's `gpt-4o-mini-tts` voices both accept a prompt-
- * side accent directive at synthesis time (Gemini reliably; OpenAI imperfectly
- * — see the per-engine notes in `geminiAccentDirectiveFor` and
- * `openAiAccentInstructionFor`). The picker only filters by [locale] when it's
+ * voices have a fixed accent that can't be reliably steered by prompt. Both
+ * ElevenLabs voice clones and OpenAI's `gpt-4o-mini-tts` voices fall into this
+ * bucket: OpenAI's `instructions` field documents accent as steerable but in
+ * practice the voice's baked-in timbre dominates (we tried both vague and
+ * linguist-standard phrasings — "British English accent" and "Standard
+ * Southern British accent" — and neither shifts `nova` off American). Null
+ * means the picker does not filter that voice by accent — Gemini's prebuilt
+ * voices are language-agnostic personalities and reliably follow accent
+ * direction in the prompt. The picker only filters by [locale] when it's
  * non-null.
  */
 data class TtsVoiceOption(
@@ -34,11 +37,23 @@ data class TtsVoiceOption(
  * Voices with a null [TtsVoiceOption.locale] are accent-agnostic and always
  * pass the filter. [VoiceLocale.SYSTEM] disables filtering — the user has not
  * expressed a preference, so show everything.
+ *
+ * If [keepSelected] is supplied and points to a voice in the receiver list
+ * that doesn't match the filter, that voice is appended so the picker still
+ * shows the user's current selection. Without this, a user who'd persisted
+ * `nova` and then switched the variant to en-GB would see a picker label of
+ * "Voice: nova" with no `nova` row in the dialog — confusing UX. Pass `null`
+ * (the default) when this preservation isn't needed.
  */
-fun List<TtsVoiceOption>.filterByVariant(variant: VoiceLocale): List<TtsVoiceOption> {
+fun List<TtsVoiceOption>.filterByVariant(
+    variant: VoiceLocale,
+    keepSelected: String? = null,
+): List<TtsVoiceOption> {
     if (variant == VoiceLocale.SYSTEM) return this
     val matched = filter { it.locale == null || it.locale == variant }
-    return matched.ifEmpty { this }
+    if (matched.isEmpty()) return this
+    val selected = keepSelected?.let { id -> firstOrNull { it.id == id } }
+    return if (selected != null && selected !in matched) matched + selected else matched
 }
 
 val GEMINI_VOICES: List<TtsVoiceOption> = listOf(
@@ -60,13 +75,23 @@ val GEMINI_VOICES: List<TtsVoiceOption> = listOf(
     TtsVoiceOption("Sadaltager", "Sadaltager — Knowledgeable"),
 )
 
+// OpenAI's stock voices have *baked-in* accents. The `gpt-4o-mini-tts` model
+// documents `instructions` as accepting an accent direction, but field-testing
+// confirmed it doesn't shift the voice off its native accent — only `fable`
+// (the one British voice in the stock library) actually sounds non-American.
+// So treat them like ElevenLabs voices: tag each with its native accent and
+// filter the picker by the user's selected variant.
+//
+// `fable` is the only British voice. There is no Australian voice — en-AU
+// users see the full list via the empty-filter fallback in [filterByVariant].
+// The other five (alloy / echo / onyx / nova / shimmer) sound American.
 val OPENAI_VOICES: List<TtsVoiceOption> = listOf(
-    TtsVoiceOption("alloy", "alloy — Neutral"),
-    TtsVoiceOption("echo", "echo — Soft, male"),
-    TtsVoiceOption("fable", "fable — Storyteller"),
-    TtsVoiceOption("onyx", "onyx — Deep, male"),
-    TtsVoiceOption("nova", "nova — Bright, female"),
-    TtsVoiceOption("shimmer", "shimmer — Warm, female"),
+    TtsVoiceOption("alloy", "alloy — Neutral", VoiceLocale.EN_US),
+    TtsVoiceOption("echo", "echo — Soft, male", VoiceLocale.EN_US),
+    TtsVoiceOption("fable", "fable — Storyteller", VoiceLocale.EN_GB),
+    TtsVoiceOption("onyx", "onyx — Deep, male", VoiceLocale.EN_US),
+    TtsVoiceOption("nova", "nova — Bright, female", VoiceLocale.EN_US),
+    TtsVoiceOption("shimmer", "shimmer — Warm, female", VoiceLocale.EN_US),
 )
 
 // ElevenLabs voice IDs are opaque strings; the human-readable name only shows in

--- a/app/src/main/kotlin/app/clothescast/tts/VoiceLocaleExt.kt
+++ b/app/src/main/kotlin/app/clothescast/tts/VoiceLocaleExt.kt
@@ -17,12 +17,12 @@ fun VoiceLocale.resolve(): Locale = toJavaLocale() ?: Locale.getDefault()
 /**
  * Picks the most natural OpenAI voice for a given locale preference.
  *
- * Historically a v1 workaround for `tts-1`'s fixed-accent voices: `fable`
- * was the only British-sounding option, so en-GB users defaulted to it.
- * On `gpt-4o-mini-tts` accent is steerable via the request `instructions`
- * field (see `openAiAccentInstructionFor`), but the default-voice choice
- * still matters for first-launch quality of the unconfigured user — pick
- * the voice whose *baseline* timbre is closest to what they'd expect.
+ * OpenAI's stock voices have *fixed accents* that prompt-side instructions
+ * can't reliably override, so the right voice is the one whose baseline
+ * timbre matches the user's variant. `fable` is the only British-sounding
+ * option in the curated list; everything else sounds American. There's no
+ * Australian voice — en-AU users default to `nova` (the same default as
+ * en-US) and can pick from the full list in Settings.
  *
  * Used as the *default* when the user hasn't explicitly chosen a voice;
  * once they pick one in Settings the chosen voice wins regardless of locale.

--- a/app/src/main/kotlin/app/clothescast/ui/settings/VoiceSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/VoiceSettings.kt
@@ -167,7 +167,7 @@ internal fun VoiceContent(
                     }
                     VoicePicker(
                         title = stringResource(R.string.settings_tts_voice_label),
-                        voices = OPENAI_VOICES,
+                        voices = OPENAI_VOICES.filterByVariant(voiceLocale, keepSelected = openAiVoice),
                         selectedId = openAiVoice,
                         enabled = !isPreviewing,
                         onSelect = {

--- a/app/src/test/kotlin/app/clothescast/tts/TtsVoicesTest.kt
+++ b/app/src/test/kotlin/app/clothescast/tts/TtsVoicesTest.kt
@@ -39,4 +39,38 @@ class TtsVoicesTest {
         val all = listOf(agnostic)
         all.filterByVariant(VoiceLocale.EN_GB) shouldBe all
     }
+
+    @Test
+    fun `keepSelected appends a filtered-out selection`() {
+        // The motivating case: en-GB user has previously persisted `nova`
+        // (en-US), then opens the picker. Without keepSelected the dialog
+        // omits nova and the button label falls back to the raw voice ID.
+        val all = listOf(american, british)
+        all.filterByVariant(VoiceLocale.EN_GB, keepSelected = "a")
+            .shouldContainExactlyInAnyOrder(british, american)
+    }
+
+    @Test
+    fun `keepSelected has no effect when the selection already matches`() {
+        // Selection's already in the filtered list — no duplication.
+        val all = listOf(american, british)
+        all.filterByVariant(VoiceLocale.EN_GB, keepSelected = "b") shouldBe listOf(british)
+    }
+
+    @Test
+    fun `keepSelected does nothing when the id isn't in the source list at all`() {
+        // Stale persisted id (e.g. a voice that was removed from the curated
+        // list). Drop silently — the picker can't render a row we have no
+        // metadata for.
+        val all = listOf(american, british)
+        all.filterByVariant(VoiceLocale.EN_GB, keepSelected = "ghost") shouldBe listOf(british)
+    }
+
+    @Test
+    fun `keepSelected is ignored when the empty-filter fallback fires`() {
+        // No matches → fallback to full list (which already includes
+        // selected). keepSelected becomes a no-op rather than re-appending.
+        val all = listOf(american)
+        all.filterByVariant(VoiceLocale.EN_AU, keepSelected = "a") shouldBe all
+    }
 }

--- a/core/data/src/main/kotlin/app/clothescast/core/data/tts/OpenAITtsClient.kt
+++ b/core/data/src/main/kotlin/app/clothescast/core/data/tts/OpenAITtsClient.kt
@@ -15,47 +15,20 @@ import io.ktor.http.isSuccess
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
-import java.util.Locale
 
-// `gpt-4o-mini-tts` is OpenAI's current TTS-of-record (March 2025). Unlike the
-// older `tts-1`, it accepts a natural-language `instructions` field that
-// steers accent, tone, and pacing — which is what makes the variant picker
-// audibly affect OpenAI playback. Cost works out to ~$0.015/min of audio,
-// roughly 35-40% more than tts-1's per-character rate but at meaningfully
-// higher quality (positioned by OpenAI as comparable to tts-1-hd). For
-// clothescast's two-clips-a-day usage the absolute monthly cost stays in
-// pennies on a BYOK key.
+// `gpt-4o-mini-tts` is OpenAI's current TTS-of-record (March 2025). The
+// upgrade from `tts-1` is a per-clip-quality win — positioned by OpenAI as
+// comparable to `tts-1-hd`. Cost works out to ~$0.015/min of audio, roughly
+// 35-40% more than tts-1's per-character rate; for clothescast's two-clips-
+// a-day usage the absolute monthly cost stays in pennies on a BYOK key.
+//
+// Earlier work tried to steer accent via the `instructions` field on this
+// model, but field-testing confirmed the voice's baked-in accent dominates
+// regardless of how the directive is worded. Voice-list filtering in
+// `TtsVoices` is now the only mechanism for giving the user a non-American
+// OpenAI voice (just `fable`, the only British voice in the stock library).
 const val DEFAULT_OPENAI_TTS_MODEL: String = "gpt-4o-mini-tts"
 const val DEFAULT_OPENAI_TTS_VOICE: String = "alloy"
-
-/**
- * Returns a one-line accent instruction for the OpenAI TTS `instructions`
- * field, or null when the locale doesn't map to a known English variant
- * (in which case the model's default applies).
- *
- * Uses linguist-standard accent labels (Standard Southern British, General
- * Australian, General American) rather than vague "British English accent"
- * phrasing — empirically, `gpt-4o-mini-tts` only weakly honours `instructions`
- * for accent (the voice's baked-in timbre dominates), so any nudge we get
- * comes from being as specific as possible. If the empirical effect on real
- * traffic remains marginal, the next step is to tag voices by their native
- * accent and filter the picker (mirroring the ElevenLabs approach).
- *
- * Mirrors the Gemini version — same wording, same coverage — so the audible
- * accent stays consistent across providers when the user picks the same variant.
- * Only honoured by `gpt-4o-mini-tts`; older OpenAI TTS models silently ignore
- * the field, which is fine for forward-compat if [DEFAULT_OPENAI_TTS_MODEL]
- * is ever overridden.
- */
-internal fun openAiAccentInstructionFor(locale: Locale): String? {
-    if (locale.language != "en") return null
-    return when (locale.country) {
-        "GB" -> "Speak with a Standard Southern British accent."
-        "AU" -> "Speak with a General Australian accent."
-        "US" -> "Speak with a General American accent."
-        else -> null
-    }
-}
 
 /**
  * OpenAI text-to-speech via `https://api.openai.com/v1/audio/speech`.
@@ -76,7 +49,6 @@ class OpenAITtsClient(
     suspend fun synthesize(
         text: String,
         voice: String = DEFAULT_OPENAI_TTS_VOICE,
-        locale: Locale? = null,
     ): PcmAudio {
         val key = keyProvider.get().also {
             if (it.isBlank()) throw MissingApiKeyException("OpenAI")
@@ -91,7 +63,6 @@ class OpenAITtsClient(
                     input = text,
                     voice = voice,
                     responseFormat = "pcm",
-                    instructions = locale?.let { openAiAccentInstructionFor(it) },
                 ),
             )
         }

--- a/core/data/src/main/kotlin/app/clothescast/core/data/tts/OpenAITtsDto.kt
+++ b/core/data/src/main/kotlin/app/clothescast/core/data/tts/OpenAITtsDto.kt
@@ -7,11 +7,6 @@ import kotlinx.serialization.Serializable
  * Wire type for `POST /v1/audio/speech`. Field names match OpenAI's snake_case
  * via [SerialName]. Request only — the response is raw audio bytes (no JSON to
  * deserialize), so there's no response DTO.
- *
- * [instructions] is only honoured by `gpt-4o-mini-tts` (silently ignored by
- * `tts-1` / `tts-1-hd`). Stays null when the caller has no accent / style
- * direction; kotlinx's default `encodeDefaults = false` keeps the field off
- * the wire in that case.
  */
 @Serializable
 internal data class OpenAISpeechRequest(
@@ -20,5 +15,4 @@ internal data class OpenAISpeechRequest(
     val voice: String,
     @SerialName("response_format")
     val responseFormat: String,
-    val instructions: String? = null,
 )

--- a/core/data/src/test/kotlin/app/clothescast/core/data/tts/OpenAITtsClientTest.kt
+++ b/core/data/src/test/kotlin/app/clothescast/core/data/tts/OpenAITtsClientTest.kt
@@ -19,7 +19,6 @@ import io.ktor.utils.io.ByteReadChannel
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Test
-import java.util.Locale
 
 class OpenAITtsClientTest {
 
@@ -69,10 +68,10 @@ class OpenAITtsClientTest {
 
     @Test
     fun `default model is gpt-4o-mini-tts`() = runTest {
-        // We bumped the default off `tts-1` because gpt-4o-mini-tts is the only
-        // OpenAI TTS model that honours the `instructions` field — without that
-        // the variant picker stays a no-op for OpenAI. Lock the default in a
-        // test so a careless edit can't silently regress accent steering.
+        // We bumped the default off `tts-1` because gpt-4o-mini-tts is a
+        // documented quality upgrade (positioned by OpenAI as comparable to
+        // tts-1-hd). Lock the default in a test so a careless edit doesn't
+        // silently regress users to the older model.
         var capturedBody: String? = null
         val client = OpenAITtsClient(
             httpClient = mockClient { capturedBody = capturedBodyOf(it) },
@@ -86,38 +85,11 @@ class OpenAITtsClientTest {
     }
 
     @Test
-    fun `request body includes british instructions for en-GB locale`() = runTest {
-        var capturedBody: String? = null
-        val client = OpenAITtsClient(
-            httpClient = mockClient { capturedBody = capturedBodyOf(it) },
-            keyProvider = FakeKeyProvider("test-key"),
-        )
-
-        client.synthesize(text = "hello", locale = Locale.UK)
-
-        val body = checkNotNull(capturedBody)
-        body.shouldContain("\"instructions\":\"Speak with a Standard Southern British accent.\"")
-    }
-
-    @Test
-    fun `request body includes australian instructions for en-AU locale`() = runTest {
-        var capturedBody: String? = null
-        val client = OpenAITtsClient(
-            httpClient = mockClient { capturedBody = capturedBodyOf(it) },
-            keyProvider = FakeKeyProvider("test-key"),
-        )
-
-        client.synthesize(text = "hello", locale = Locale.forLanguageTag("en-AU"))
-
-        val body = checkNotNull(capturedBody)
-        body.shouldContain("General Australian accent")
-    }
-
-    @Test
-    fun `request body omits instructions when locale is null`() = runTest {
-        // No locale → no instructions field on the wire (kotlinx defaults
-        // `encodeDefaults = false`). Important because OpenAI's older TTS
-        // models reject unknown / unsupported fields with a 400.
+    fun `request body never includes the instructions field`() = runTest {
+        // Field-testing showed `instructions` doesn't reliably steer accent on
+        // gpt-4o-mini-tts (the voice's baked-in timbre dominates), so we don't
+        // send it at all — accent is voice-bound, controlled by the picker
+        // filter. This guards against re-introducing the dead plumbing.
         var capturedBody: String? = null
         val client = OpenAITtsClient(
             httpClient = mockClient { capturedBody = capturedBodyOf(it) },
@@ -125,22 +97,6 @@ class OpenAITtsClientTest {
         )
 
         client.synthesize(text = "hello")
-
-        val body = checkNotNull(capturedBody)
-        body.shouldNotContain("instructions")
-    }
-
-    @Test
-    fun `request body omits instructions for unknown english variants`() = runTest {
-        // en-CA isn't in our supported variant list — fall through to the
-        // model's default rather than picking a wrong-but-confident accent.
-        var capturedBody: String? = null
-        val client = OpenAITtsClient(
-            httpClient = mockClient { capturedBody = capturedBodyOf(it) },
-            keyProvider = FakeKeyProvider("test-key"),
-        )
-
-        client.synthesize(text = "hello", locale = Locale.forLanguageTag("en-CA"))
 
         val body = checkNotNull(capturedBody)
         body.shouldNotContain("instructions")

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Settings.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Settings.kt
@@ -30,15 +30,15 @@ enum class TtsEngine { DEVICE, GEMINI, OPENAI, ELEVENLABS }
  *  - [TtsEngine.GEMINI] passes the locale through as a natural-language
  *    accent directive prepended to the prompt — Gemini's prebuilt voices are
  *    language-agnostic personalities and follow that direction.
- *  - [TtsEngine.OPENAI] passes the locale through as the request's
- *    `instructions` field (e.g. *"Speak with a British English accent."*),
- *    which `gpt-4o-mini-tts` honours. The locale also influences the
- *    *default* voice for first-launch users (en-GB → `fable`, else `nova`)
- *    via `defaultOpenAiVoiceFor` — once the user explicitly picks a voice
- *    in Settings, that choice wins.
- *  - [TtsEngine.ELEVENLABS] filters the voice picker to voices whose baked-in
- *    accent matches the variant; falls back to the full list if no voice
- *    matches. Voice clones have a fixed accent that can't be prompt-steered.
+ *  - [TtsEngine.OPENAI] and [TtsEngine.ELEVENLABS] both filter the voice
+ *    picker to voices whose baked-in accent matches the variant, falling
+ *    back to the full list if no voice matches. Their voices have fixed
+ *    accents that prompt-steering can't reliably override (we tried; only
+ *    voice selection actually changes the audible accent), so the variant
+ *    has to drive *which voice* gets used rather than *how* a given voice
+ *    speaks. For OpenAI, [defaultOpenAiVoiceFor] also picks a sensible
+ *    starting voice for first-launch users (en-GB → `fable`, else `nova`)
+ *    so the user hears the right accent before they ever open Settings.
  *
  * [SYSTEM] means "follow the phone's locale" — the right default for almost
  * everyone, since their device language already encodes their accent


### PR DESCRIPTION
## Why

PR #123 added `instructions` to steer OpenAI's accent on
`gpt-4o-mini-tts`. PR #126 tightened the phrasing to linguist-standard
labels (Standard Southern British / General Australian / General
American). **Both failed empirical testing**: only `fable` ever sounds
non-American, regardless of what we put in `instructions` — the voice's
baked-in timbre wins.

So switching strategies: mirror what we did for ElevenLabs in #121. Let
the user pick the right *voice* for their accent rather than trying to
prompt-steer.

## What

**Voice tagging + filter (the actual fix).**

`OPENAI_VOICES` entries now carry a `locale` tag. The Settings picker's
OpenAI branch runs through `filterByVariant`:

| Voice | Tagged accent |
| --- | --- |
| alloy / echo / onyx / nova / shimmer | en-US |
| fable | en-GB |

| Variant | Picker shows |
| --- | --- |
| en-US | alloy / echo / onyx / nova / shimmer |
| en-GB | fable |
| en-AU | full list (no Australian voice in stock library — empty-filter fallback) |
| SYSTEM | full list |

**`keepSelected` parameter on `filterByVariant`.**

A user who'd persisted `nova` and then switched variant to en-GB would,
under a naive filter, see "Voice: nova" with no nova row in the dialog
(picker label falls back to the raw id when the selection isn't in
`voices`). New optional param appends the persisted selection back into
the filtered list when needed. Existing ElevenLabs call site keeps the
default `null` and is unaffected.

**Dead code removed.**

- `openAiAccentInstructionFor` helper.
- `instructions` field on `OpenAISpeechRequest` DTO.
- `locale` parameter on `OpenAITtsClient.synthesize`.
- Locale forwarding in `OpenAITtsSpeaker` — the speaker still takes a
  `Locale` (interface contract) but drops it with an explanatory comment.

**Kept**: the `tts-1` → `gpt-4o-mini-tts` model bump from #123. That
upgrade is a quality win independent of accent steering.

## Tests

- `OpenAITtsClientTest`: dropped four `instructions`-related cases;
  added `request body never includes the instructions field` as a
  regression guard against re-introducing the dead plumbing.
- `TtsVoicesTest`: four new cases for the `keepSelected` paths —
  appends a filtered-out selection, no-op when already matching, no-op
  for unknown id, no-op when the empty-filter fallback fires.

## KDocs

Updated to match reality across `VoiceLocale` (`:core:domain`),
`defaultOpenAiVoiceFor`, and `TtsVoiceOption`: OpenAI accent is
voice-bound, not prompt-steerable, picker filter is the only mechanism.
Each comment names the empirical evidence so we don't loop back through
the same dead end.

## Test plan

- [ ] CI green
- [ ] On-device with OpenAI key configured: Settings → Voice → OpenAI →
  set variant en-GB → picker shows only `fable` → Test Voice → British.
- [ ] Set variant en-US → picker shows alloy / echo / onyx / nova /
  shimmer (5) → all American.
- [ ] Set variant en-AU → picker shows full list of 6 (fallback) → can
  pick any; none are actually Australian.
- [ ] Set variant SYSTEM → picker shows full list of 6 → behaves like
  pre-PR.
- [ ] **Persistence edge case**: with variant en-US and `nova` selected,
  switch variant to en-GB → picker shows `fable` *and* `nova` (because
  of `keepSelected`); switching to fable, then back to en-US, then to
  variant en-GB again → picker shows only `fable` (no longer keeping
  `nova`).

https://claude.ai/code/session_01Q37WC1LUsnQW19J7oK1En4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q37WC1LUsnQW19J7oK1En4)_