### PR TITLE
:app + :core — natural-language times in insight prose; drop non-precip clauses

### DIFF
--- a/app/src/main/kotlin/app/clothescast/insight/InsightFormatter.kt
+++ b/app/src/main/kotlin/app/clothescast/insight/InsightFormatter.kt
@@ -9,7 +9,7 @@ import app.clothescast.core.domain.model.ForecastPeriod
 import app.clothescast.core.domain.model.InsightSummary
 import app.clothescast.core.domain.model.PrecipClause
 import app.clothescast.core.domain.model.TemperatureBand
-import java.time.format.DateTimeFormatter
+import java.time.LocalTime
 import java.util.Locale
 
 /**
@@ -18,8 +18,10 @@ import java.util.Locale
  * Living in `:app` means this is the natural place to fold in region-localized
  * vocabulary (Android string resources, BCP-47 locale picking) — the upcoming
  * Region setting will replace the hardcoded English here with `getString` calls.
- * For now the strings are inline and produce the same prose the previous
- * domain-side renderer did, byte-for-byte.
+ * For now the strings are inline.
+ *
+ * Times are rendered as natural language ("midnight", "2am", "noon", "3pm") —
+ * better for TTS than "02:00" and identical text feeds both UI and speech.
  */
 class InsightFormatter {
 
@@ -28,7 +30,7 @@ class InsightFormatter {
         add(formatBand(summary.period, summary.band))
         summary.delta?.let { add(formatDelta(it)) }
         summary.clothes?.let { add(formatClothes(it)) }
-        summary.precip?.let { add(formatPrecip(it)) }
+        summary.precip?.let { add(formatPrecip(it, hasCalendarTieIn = summary.calendarTieIn != null)) }
         summary.calendarTieIn?.let { add(formatCalendarTieIn(it)) }
     }.joinToString(" ")
 
@@ -67,14 +69,23 @@ class InsightFormatter {
         return "Wear $phrase."
     }
 
-    private fun formatPrecip(precip: PrecipClause): String {
+    private fun formatPrecip(precip: PrecipClause, hasCalendarTieIn: Boolean): String {
         val type = precip.condition.name.lowercase(Locale.ROOT).replace('_', ' ')
             .replaceFirstChar { it.titlecase(Locale.ROOT) }
-        return "$type at ${EVENT_TIME.format(precip.time)}."
+        // "Rain at 02:00" sounds robotic and a precise hour adds little value when
+        // the user is asleep. Collapse early-morning peaks to "overnight" — but only
+        // when there's no calendar tie-in pinning the time, since that clause names
+        // the same hour and the two should agree.
+        val timePhrase = if (precip.time.hour in OVERNIGHT_HOURS && !hasCalendarTieIn) {
+            "overnight"
+        } else {
+            "at ${spokenTime(precip.time)}"
+        }
+        return "$type $timePhrase."
     }
 
     private fun formatCalendarTieIn(tieIn: CalendarTieInClause): String =
-        "Bring ${withArticle(tieIn.item)} for your ${EVENT_TIME.format(tieIn.time)} ${tieIn.title}."
+        "Bring ${withArticle(tieIn.item)} for your ${spokenTime(tieIn.time)} ${tieIn.title}."
 
     private fun bandLabel(band: TemperatureBand): String = when (band) {
         TemperatureBand.FREEZING -> "freezing"
@@ -99,12 +110,25 @@ class InsightFormatter {
         else -> "a $item"
     }
 
+    /**
+     * 24h LocalTime → spoken English ("midnight", "2am", "noon", "3:30pm").
+     * Locale-agnostic ASCII output: Arabic locale digits would otherwise shape
+     * any numeric minutes into Eastern Arabic numerals, breaking the prose
+     * contract the rest of the app expects.
+     */
+    private fun spokenTime(time: LocalTime): String {
+        val hour = time.hour
+        val minute = time.minute
+        if (hour == 0 && minute == 0) return "midnight"
+        if (hour == 12 && minute == 0) return "noon"
+        val h12 = ((hour + 11) % 12) + 1
+        val suffix = if (hour < 12) "am" else "pm"
+        return if (minute == 0) "$h12$suffix" else "$h12:%02d$suffix".format(Locale.ROOT, minute)
+    }
+
     private companion object {
-        // Locale.ROOT keeps digits ASCII regardless of device locale — under e.g.
-        // Arabic locales the system default would otherwise shape "15:00" into
-        // Eastern Arabic numerals, breaking the prose contract the rest of the
-        // app expects.
-        private val EVENT_TIME: DateTimeFormatter =
-            DateTimeFormatter.ofPattern("HH:mm").withLocale(Locale.ROOT)
+        // Hours treated as "overnight" when collapsing precip times. 5am is borderline
+        // morning rather than night, so the band stops at 4:59.
+        private val OVERNIGHT_HOURS = 0..4
     }
 }

--- a/app/src/test/kotlin/app/clothescast/insight/InsightFormatterTest.kt
+++ b/app/src/test/kotlin/app/clothescast/insight/InsightFormatterTest.kt
@@ -93,15 +93,65 @@ class InsightFormatterTest {
     }
 
     @Test
-    fun `precip clause emits with peak hour and capitalised type`() {
+    fun `precip clause emits with spoken peak hour and capitalised type`() {
         subject.format(summary(precip = PrecipClause(WeatherCondition.RAIN, LocalTime.of(15, 0)))) shouldBe
-            "Today will be mild. Rain at 15:00."
+            "Today will be mild. Rain at 3pm."
     }
 
     @Test
-    fun `precip clause humanises an underscored condition name`() {
-        subject.format(summary(precip = PrecipClause(WeatherCondition.PARTLY_CLOUDY, LocalTime.NOON))) shouldBe
-            "Today will be mild. Partly cloudy at 12:00."
+    fun `precip clause says 'noon' for 12-00`() {
+        subject.format(summary(precip = PrecipClause(WeatherCondition.DRIZZLE, LocalTime.NOON))) shouldBe
+            "Today will be mild. Drizzle at noon."
+    }
+
+    @Test
+    fun `precip clause says 'overnight' for early-morning peak when no calendar tie-in`() {
+        subject.format(summary(precip = PrecipClause(WeatherCondition.RAIN, LocalTime.of(2, 0)))) shouldBe
+            "Today will be mild. Rain overnight."
+    }
+
+    @Test
+    fun `precip clause says 'overnight' for midnight peak when no calendar tie-in`() {
+        subject.format(summary(precip = PrecipClause(WeatherCondition.SNOW, LocalTime.MIDNIGHT))) shouldBe
+            "Today will be mild. Snow overnight."
+    }
+
+    @Test
+    fun `precip clause names the hour even overnight when a calendar tie-in pins the same time`() {
+        // The tie-in clause spells out "your 2am yoga class" — the precip clause
+        // should agree on the time rather than collapse to "overnight".
+        val out = subject.format(
+            summary(
+                clothes = ClothesClause(listOf("umbrella")),
+                precip = PrecipClause(WeatherCondition.RAIN, LocalTime.of(2, 0)),
+                calendarTieIn = CalendarTieInClause("umbrella", LocalTime.of(2, 0), "yoga class"),
+            ),
+        )
+        out shouldBe "Today will be mild. Wear an umbrella. Rain at 2am. Bring an umbrella for your 2am yoga class."
+    }
+
+    @Test
+    fun `precip clause uses 'midnight' when calendar tie-in pins 00-00`() {
+        val out = subject.format(
+            summary(
+                clothes = ClothesClause(listOf("umbrella")),
+                precip = PrecipClause(WeatherCondition.RAIN, LocalTime.MIDNIGHT),
+                calendarTieIn = CalendarTieInClause("umbrella", LocalTime.MIDNIGHT, "stargazing"),
+            ),
+        )
+        out shouldBe "Today will be mild. Wear an umbrella. Rain at midnight. Bring an umbrella for your midnight stargazing."
+    }
+
+    @Test
+    fun `precip clause uses 12-hour pm form for late-afternoon peak`() {
+        subject.format(summary(precip = PrecipClause(WeatherCondition.RAIN, LocalTime.of(23, 0)))) shouldBe
+            "Today will be mild. Rain at 11pm."
+    }
+
+    @Test
+    fun `precip clause renders non-zero minutes`() {
+        subject.format(summary(precip = PrecipClause(WeatherCondition.RAIN, LocalTime.of(15, 30)))) shouldBe
+            "Today will be mild. Rain at 3:30pm."
     }
 
     @Test
@@ -111,7 +161,7 @@ class InsightFormatterTest {
     }
 
     @Test
-    fun `calendar tie-in renders bring + article + time + title`() {
+    fun `calendar tie-in renders bring + article + spoken time + title`() {
         val out = subject.format(
             summary(
                 clothes = ClothesClause(listOf("umbrella")),
@@ -119,7 +169,7 @@ class InsightFormatterTest {
                 calendarTieIn = CalendarTieInClause("umbrella", LocalTime.of(15, 0), "park run"),
             ),
         )
-        out shouldBe "Today will be mild. Wear an umbrella. Rain at 15:00. Bring an umbrella for your 15:00 park run."
+        out shouldBe "Today will be mild. Wear an umbrella. Rain at 3pm. Bring an umbrella for your 3pm park run."
     }
 
     @Test
@@ -134,6 +184,6 @@ class InsightFormatterTest {
             ),
         )
         out shouldBe "Alert: Flood Warning. Today will be cool to mild. It will be 6° warmer today. " +
-            "Wear a jumper and umbrella. Rain at 15:00."
+            "Wear a jumper and umbrella. Rain at 3pm."
     }
 }

--- a/app/src/test/kotlin/app/clothescast/insight/InsightFormatterTest.kt
+++ b/app/src/test/kotlin/app/clothescast/insight/InsightFormatterTest.kt
@@ -143,7 +143,7 @@ class InsightFormatterTest {
     }
 
     @Test
-    fun `precip clause uses 12-hour pm form for late-afternoon peak`() {
+    fun `precip clause uses 12-hour pm form for late-evening peak`() {
         subject.format(summary(precip = PrecipClause(WeatherCondition.RAIN, LocalTime.of(23, 0)))) shouldBe
             "Today will be mild. Rain at 11pm."
     }

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/RenderInsightSummary.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/RenderInsightSummary.kt
@@ -97,6 +97,11 @@ class RenderInsightSummary {
      * out of the precip clause assembly so the calendar-tie-in rule can pair an
      * event window against the same time without re-running the logic and getting
      * out of sync.
+     *
+     * Returns null unless the resolved condition is *actual* precipitation
+     * (drizzle / rain / snow / thunderstorm). A cloudy or foggy day with a
+     * 30%+ "precip" probability isn't worth a clause — the user wants the
+     * spoken summary to mention precipitation, not haziness.
      */
     private fun peakPrecip(today: DailyForecast): PeakPrecip? {
         val peak = today.hourly.maxByOrNull { it.precipitationProbabilityPct }
@@ -110,7 +115,20 @@ class RenderInsightSummary {
             time = peak.time
             condition = if (peak.condition == WeatherCondition.UNKNOWN) today.condition else peak.condition
         }
+        if (!condition.isPrecipitation()) return null
         return PeakPrecip(time, condition)
+    }
+
+    private fun WeatherCondition.isPrecipitation(): Boolean = when (this) {
+        WeatherCondition.DRIZZLE,
+        WeatherCondition.RAIN,
+        WeatherCondition.SNOW,
+        WeatherCondition.THUNDERSTORM -> true
+        WeatherCondition.CLEAR,
+        WeatherCondition.PARTLY_CLOUDY,
+        WeatherCondition.CLOUDY,
+        WeatherCondition.FOG,
+        WeatherCondition.UNKNOWN -> false
     }
 
     private fun calendarTieInClause(

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsightTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsightTest.kt
@@ -259,11 +259,13 @@ class GenerateDailyInsightTest {
         val todayHourly = listOf(
             // Pre-morning: 6:00 with 80% rain — already past, must not surface.
             HourlyForecast(LocalTime.of(6, 0), 8.0, 6.0, 80.0, WeatherCondition.RAIN),
-            // In-window: 09:00 quiet, 15:00 partly cloudy with 35% precip.
+            // In-window: 09:00 quiet, 15:00 rain at 35%.
             HourlyForecast(LocalTime.of(9, 0), 14.0, 12.0, 5.0, WeatherCondition.CLEAR),
-            HourlyForecast(LocalTime.of(15, 0), 22.0, 20.0, 35.0, WeatherCondition.PARTLY_CLOUDY),
+            HourlyForecast(LocalTime.of(15, 0), 22.0, 20.0, 35.0, WeatherCondition.RAIN),
             // Late evening: 23:00 cloudy with 60% precip — user is asleep, must not
-            // be the headline for the daytime insight.
+            // be the headline for the daytime insight. (Cloudy conditions never
+            // earn a precip clause anyway, but the slicing assertion still cares
+            // that this entry doesn't reach `peakPrecip` in the first place.)
             HourlyForecast(LocalTime.of(23, 0), 12.0, 10.0, 60.0, WeatherCondition.CLOUDY),
         )
         val todayWithHourly = today.copy(hourly = todayHourly)
@@ -274,9 +276,9 @@ class GenerateDailyInsightTest {
 
         // Only hours in [07:00, 19:00) survive — the 06:00 and 23:00 entries are dropped.
         result.insight.hourly.map { it.time } shouldBe listOf(LocalTime.of(9, 0), LocalTime.of(15, 0))
-        // Peak precip is the wettest in-window hour (15:00, partly cloudy at 35%) —
-        // not the 23:00 cloudy spike, which is what the pre-slice peak would have surfaced.
-        result.insight.summary.precip!!.condition shouldBe WeatherCondition.PARTLY_CLOUDY
+        // Peak precip is the wettest in-window hour (15:00, rain at 35%) — not the
+        // 23:00 spike, which is what the pre-slice peak would have surfaced.
+        result.insight.summary.precip!!.condition shouldBe WeatherCondition.RAIN
         result.insight.summary.precip!!.time shouldBe LocalTime.of(15, 0)
     }
 

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/RenderInsightSummaryTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/RenderInsightSummaryTest.kt
@@ -156,6 +156,48 @@ class RenderInsightSummaryTest {
     }
 
     @Test
+    fun `precip clause is omitted when the peak hour's condition is cloudy`() {
+        // "Cloudy at 15:00" doesn't earn a clause: precipitation info is what the
+        // user wants to hear, not haziness. A 30%+ probability with a non-precip
+        // dominant condition gets dropped entirely.
+        val today = mildToday.copy(
+            precipitationProbabilityMaxPct = 60.0,
+            condition = WeatherCondition.CLOUDY,
+            hourly = listOf(
+                HourlyForecast(LocalTime.of(15, 0), 22.0, 22.0, 60.0, WeatherCondition.CLOUDY),
+            ),
+        )
+        subject(today, yesterday, emptyList()).precip.shouldBeNull()
+    }
+
+    @Test
+    fun `precip clause is omitted when the noon fallback condition is partly cloudy`() {
+        // Day-level chance 40% but no hourly entry crosses 30%, so we'd normally fall
+        // back to noon with today.condition. If today.condition is non-precip we still
+        // drop the clause.
+        val today = mildToday.copy(
+            precipitationProbabilityMaxPct = 40.0,
+            condition = WeatherCondition.PARTLY_CLOUDY,
+            hourly = emptyList(),
+        )
+        subject(today, yesterday, emptyList()).precip.shouldBeNull()
+    }
+
+    @Test
+    fun `calendar tie-in is omitted when the peak condition is non-precipitation`() {
+        // Even with the umbrella rule firing on day-level probability and an event
+        // overlapping the peak hour, a cloudy peak shouldn't motivate a tie-in —
+        // there's no precipitation clause to anchor it to.
+        val today = mildToday.copy(
+            precipitationProbabilityMaxPct = 60.0,
+            condition = WeatherCondition.CLOUDY,
+            hourly = listOf(HourlyForecast(LocalTime.of(15, 0), 22.0, 22.0, 60.0, WeatherCondition.CLOUDY)),
+        )
+        val event = CalendarEvent("park run", LocalTime.of(14, 30), LocalTime.of(16, 0))
+        subject(today, yesterday, listOf(umbrellaRule), events = listOf(event)).calendarTieIn.shouldBeNull()
+    }
+
+    @Test
     fun `alert clause is emitted with the highest-severity event`() {
         val severe = WeatherAlert(
             event = "Severe Thunderstorm Warning",


### PR DESCRIPTION
## Summary

"Rain at 02:00" sounds robotic to a TTS engine and the precise hour adds little
value when the user is asleep. Three behaviour changes, all in the insight
clause pipeline:

- **Spoken-English times.** The precip and calendar-tie-in clauses now render
  times as "midnight", "2am", "noon", "3pm", "3:30pm" — instead of "02:00",
  "12:00", "15:00". Same string feeds the on-screen card and the TTS pipeline,
  so UI and speech stay in sync.
- **"overnight" for early-morning peaks.** When the precip peak falls between
  00:00 and 04:59 *and* no calendar event pins the hour, the clause collapses
  to "Rain overnight." A naked 2am peak rarely earns a precise hour. When a
  tie-in *is* present ("Bring an umbrella for your 2am yoga class") the precip
  clause names the same hour so the two agree.
- **No precip clause for non-precipitation conditions.** A cloudy / partly
  cloudy / foggy / clear day with a 30%+ "precip" probability no longer earns
  a precip clause — the user wants to hear about rain, not haziness. The
  calendar tie-in cascades from the same gate (no precip → no tie-in).

## Files

- `core/domain/.../RenderInsightSummary.kt` — `peakPrecip` returns null unless
  the resolved condition is DRIZZLE / RAIN / SNOW / THUNDERSTORM. Cascades into
  both the precip clause and the calendar tie-in.
- `app/.../insight/InsightFormatter.kt` — replaces the `HH:mm` formatter with a
  `spokenTime` helper, threads `hasCalendarTieIn` into `formatPrecip` for the
  overnight override.
- Test fixtures updated; new coverage for noon, midnight, 11pm, 3:30pm,
  overnight (with and without tie-in), and the cloudy/partly-cloudy
  suppression branches.

## Test plan

- [ ] `:core:domain:test` (sandbox can't run AGP — relying on CI)
- [ ] `:app:testDebugUnitTest` on CI
- [ ] `:app:assembleDebug` on CI
- [ ] Eyeball a TTS preview after merge to confirm "Rain at 3pm" / "Rain
  overnight" actually sound natural through ElevenLabs / OpenAI.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PTzRGJh4pcuLkwyaisJ4fC)_