### PR TITLE
:app + :core — German insight prose + spoken-aloud TTS (UI strings still en)

### DIFF
--- a/app/src/main/kotlin/app/clothescast/insight/ClothesPhraser.kt
+++ b/app/src/main/kotlin/app/clothescast/insight/ClothesPhraser.kt
@@ -23,6 +23,7 @@ internal interface ClothesPhraser {
         fun forLocale(resources: Resources, locale: Locale): ClothesPhraser =
             when (locale.language) {
                 "en" -> EnglishClothesPhraser(resources)
+                "de" -> GermanClothesPhraser(resources)
                 else -> BareClothesPhraser()
             }
     }
@@ -51,6 +52,33 @@ internal class EnglishClothesPhraser(private val resources: Resources) : Clothes
         else -> resources.getString(
             R.string.insight_clothes_join_many,
             withArticle(items[0]),
+            items.subList(1, items.size - 1).joinToString(", "),
+            items.last(),
+        )
+    }
+}
+
+/**
+ * German list join: items are emitted bare because we don't carry grammatical
+ * gender on each clothes rule (der/die/das ⇒ einen/eine/ein for "Trag …"), so
+ * any guessed article is wrong half the time. Items are joined with commas
+ * and a final "und"; no Oxford comma. The calendar tie-in ("Denk an …")
+ * likewise emits the item bare.
+ *
+ * A future PR could thread a gender hint through `ClothesRule` so we can
+ * pick a real article — until then, "Trag Pullover, Jacke und Regenschirm."
+ * reads naturally enough.
+ */
+internal class GermanClothesPhraser(private val resources: Resources) : ClothesPhraser {
+    override fun withArticle(item: String): String = item
+
+    override fun joinItems(items: List<String>): String = when (items.size) {
+        0 -> ""
+        1 -> items[0]
+        2 -> resources.getString(R.string.insight_clothes_join_two, items[0], items[1])
+        else -> resources.getString(
+            R.string.insight_clothes_join_many,
+            items[0],
             items.subList(1, items.size - 1).joinToString(", "),
             items.last(),
         )

--- a/app/src/main/kotlin/app/clothescast/ui/settings/RegionSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/RegionSettings.kt
@@ -69,6 +69,7 @@ private fun regionLabel(region: Region): Int = when (region) {
     Region.EN_US -> R.string.settings_region_language_en_us
     Region.EN_GB -> R.string.settings_region_language_en_gb
     Region.EN_AU -> R.string.settings_region_language_en_au
+    Region.DE_DE -> R.string.settings_region_language_de_de
 }
 
 private fun temperatureUnitLabel(unit: TemperatureUnit): Int = when (unit) {

--- a/app/src/main/kotlin/app/clothescast/ui/settings/VoiceSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/VoiceSettings.kt
@@ -336,6 +336,7 @@ private fun voiceLocaleLabel(locale: VoiceLocale): Int = when (locale) {
     VoiceLocale.EN_US -> R.string.settings_tts_voice_locale_en_us
     VoiceLocale.EN_GB -> R.string.settings_tts_voice_locale_en_gb
     VoiceLocale.EN_AU -> R.string.settings_tts_voice_locale_en_au
+    VoiceLocale.DE_DE -> R.string.settings_tts_voice_locale_de_de
 }
 
 @Composable

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+First-pass German translation. Scope: just the spoken-aloud insight-prose
+templates (insight_* keys) + the German labels for the Region / VoiceLocale
+pickers. The rest of the UI is intentionally not yet translated — settings
+labels, onboarding, notifications etc. fall through to values/strings.xml
+(English) until a follow-up PR fills them in. Picking Region = DE_DE today
+gives the user a German morning summary spoken in German via Gemini, while
+the rest of the app stays in English.
+-->
+<resources>
+    <string name="settings_region_language_de_de">Deutsch (Deutschland)</string>
+    <string name="settings_tts_voice_locale_de_de">Deutsch (Deutschland)</string>
+
+    <!-- Insight prose templates — German equivalents of the keys in values/strings.xml. -->
+    <string name="insight_lead_today">Heute</string>
+    <string name="insight_lead_tonight">Heute Abend</string>
+
+    <!-- "Heute wird es mild." / "Heute wird es kühl bis mild." Subject-second
+         word order means the lead-in flows into "wird es ...". -->
+    <string name="insight_band_single">%1$s wird es %2$s.</string>
+    <string name="insight_band_range">%1$s wird es %2$s bis %3$s.</string>
+
+    <string name="insight_band_freezing">eiskalt</string>
+    <string name="insight_band_cold">kalt</string>
+    <string name="insight_band_cool">kühl</string>
+    <string name="insight_band_mild">mild</string>
+    <string name="insight_band_warm">warm</string>
+    <string name="insight_band_hot">heiß</string>
+
+    <string name="insight_delta_warmer">Heute wird es %1$d° wärmer.</string>
+    <string name="insight_delta_cooler">Heute wird es %1$d° kälter.</string>
+
+    <string name="insight_alert">Warnung: %1$s.</string>
+
+    <!--
+    Imperative "Trag …" — informal Du-form, matches the app's casual tone.
+    The body comes from GermanClothesPhraser, which lists items unprefixed
+    because we don't know each item's grammatical gender (der/die/das ⇒ einen
+    /eine/ein) without per-rule metadata. A flat comma-separated list reads
+    fine ("Trag Pullover, Jacke und Regenschirm.") and avoids guessing the
+    wrong article. A future PR could add a gender hint to ClothesRule.
+    -->
+    <string name="insight_clothes_wear">Trag %1$s.</string>
+    <!-- Articles unused by GermanClothesPhraser (defined for parity / future use). -->
+    <string name="insight_clothes_article_a">%1$s</string>
+    <string name="insight_clothes_article_an">%1$s</string>
+    <string name="insight_clothes_join_two">%1$s und %2$s</string>
+    <!-- German doesn't use the Oxford comma — last item joined with "und" only. -->
+    <string name="insight_clothes_join_many">%1$s, %2$s und %3$s</string>
+
+    <!-- Same composed shape as the English template ("%1$s %2$s.") — German
+         likewise wants the type then the time-phrase, just with German tokens. -->
+    <string name="insight_precip">%1$s %2$s.</string>
+    <!-- "Regen um 15:00." — the time itself comes from the InsightFormatter
+         24h ASCII fallback for non-English locales (no insight_time_* needed). -->
+    <string name="insight_precip_at_time">um %1$s</string>
+    <!-- "Regen über Nacht." for the early-morning collapse. -->
+    <string name="insight_precip_overnight">über Nacht</string>
+
+    <string name="insight_condition_clear">Klar</string>
+    <string name="insight_condition_partly_cloudy">Teilweise bewölkt</string>
+    <string name="insight_condition_cloudy">Bewölkt</string>
+    <string name="insight_condition_fog">Nebel</string>
+    <string name="insight_condition_drizzle">Nieselregen</string>
+    <string name="insight_condition_rain">Regen</string>
+    <string name="insight_condition_snow">Schnee</string>
+    <string name="insight_condition_thunderstorm">Gewitter</string>
+    <string name="insight_condition_unknown">Unbekannt</string>
+
+    <!-- "Denk an Regenschirm für park run um 15:00." -->
+    <string name="insight_calendar_tie_in">Denk an %1$s für %3$s um %2$s.</string>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -120,6 +120,7 @@
     <string name="settings_tts_voice_locale_en_us">English (United States)</string>
     <string name="settings_tts_voice_locale_en_gb">English (United Kingdom)</string>
     <string name="settings_tts_voice_locale_en_au">English (Australia)</string>
+    <string name="settings_tts_voice_locale_de_de">German (Germany)</string>
     <string name="settings_tts_test">Test voice</string>
     <!-- Shown next to the engine picker when the chosen engine's API key isn't
          configured. %1$s is the engine name ("Gemini" / "OpenAI" / "ElevenLabs"). -->
@@ -150,6 +151,7 @@
     <string name="settings_region_language_en_us">English (United States)</string>
     <string name="settings_region_language_en_gb">English (United Kingdom)</string>
     <string name="settings_region_language_en_au">English (Australia)</string>
+    <string name="settings_region_language_de_de">German (Germany)</string>
 
     <string name="settings_temperature_unit_title">Temperature unit</string>
     <string name="settings_temperature_unit_celsius">Celsius (°C)</string>

--- a/app/src/test/kotlin/app/clothescast/insight/InsightFormatterTest.kt
+++ b/app/src/test/kotlin/app/clothescast/insight/InsightFormatterTest.kt
@@ -199,4 +199,55 @@ class InsightFormatterTest {
         out shouldBe "Alert: Flood Warning. Today will be cool to mild. It will be 6° warmer today. " +
             "Wear a jumper and umbrella. Rain at 3pm."
     }
+
+    // ---------------------------------------------------------------------
+    // German locale — picks up values-de/strings.xml + GermanClothesPhraser.
+    // Spot-checks rather than mirroring every English case: the goal is to
+    // confirm the localized resources are actually wired through and that
+    // GermanClothesPhraser's bare-with-und join produces idiomatic prose.
+    // ---------------------------------------------------------------------
+
+    private val germanSubject = InsightFormatter.forContext(context, Locale.GERMAN)
+
+    @Test
+    fun `de — single band reads 'Heute wird es mild'`() {
+        germanSubject.format(summary()) shouldBe "Heute wird es mild."
+    }
+
+    @Test
+    fun `de — band range uses 'bis'`() {
+        germanSubject.format(summary(band = BandClause(TemperatureBand.COOL, TemperatureBand.MILD))) shouldBe
+            "Heute wird es kühl bis mild."
+    }
+
+    @Test
+    fun `de — tonight lead-in becomes 'Heute Abend'`() {
+        germanSubject.format(summary(period = ForecastPeriod.TONIGHT)) shouldBe
+            "Heute Abend wird es mild."
+    }
+
+    @Test
+    fun `de — clothes list is bare comma + und with no articles`() {
+        germanSubject.format(
+            summary(clothes = ClothesClause(listOf("Pullover", "Jacke", "Regenschirm"))),
+        ) shouldBe "Heute wird es mild. Trag Pullover, Jacke und Regenschirm."
+    }
+
+    @Test
+    fun `de — precip uses 'um' between condition and time`() {
+        germanSubject.format(summary(precip = PrecipClause(WeatherCondition.RAIN, LocalTime.of(15, 0)))) shouldBe
+            "Heute wird es mild. Regen um 15:00."
+    }
+
+    @Test
+    fun `de — calendar tie-in reorders args via positional placeholders`() {
+        val out = germanSubject.format(
+            summary(
+                clothes = ClothesClause(listOf("Regenschirm")),
+                calendarTieIn = CalendarTieInClause("Regenschirm", LocalTime.of(15, 0), "Park-Lauf"),
+            ),
+        )
+        out shouldBe "Heute wird es mild. Trag Regenschirm. " +
+            "Denk an Regenschirm für Park-Lauf um 15:00."
+    }
 }

--- a/core/data/src/main/kotlin/app/clothescast/core/data/tts/GeminiTtsClient.kt
+++ b/core/data/src/main/kotlin/app/clothescast/core/data/tts/GeminiTtsClient.kt
@@ -68,6 +68,12 @@ private val ACCENT_DIRECTIVES: Map<String, String> = mapOf(
     "en-GB" to "Speak with a Standard Southern British accent.",
     "en-AU" to "Speak with a General Australian accent.",
     "en-US" to "Speak with a General American accent.",
+    // Language-only entry — Gemini follows the directive *language* even though
+    // the prompt itself is English, so the synthesised audio is in German. The
+    // German prose comes from the `:app` formatter once the user's Region is
+    // set to DE_DE; this directive just nudges the model to read it as German
+    // rather than mangling it through an English phoneme pipeline.
+    "de" to "Sprich auf Deutsch in einem klaren, hochdeutschen Akzent.",
 )
 
 /**

--- a/core/data/src/test/kotlin/app/clothescast/core/data/tts/GeminiTtsClientTest.kt
+++ b/core/data/src/test/kotlin/app/clothescast/core/data/tts/GeminiTtsClientTest.kt
@@ -142,6 +142,28 @@ class GeminiTtsClientTest {
     }
 
     @Test
+    fun `request body includes a german directive for de locale`() = runTest {
+        // German is the first non-English entry in the directive table — verifies
+        // the language-only fallback (no language-COUNTRY entry) actually fires
+        // and that the model is told to read the prose as German rather than
+        // the en-default North American English.
+        var capturedBody: String? = null
+        val client = GeminiTtsClient(
+            httpClient = mockClient(SUCCESS_BODY) {
+                capturedBody = (it.body as io.ktor.http.content.OutgoingContent.ByteArrayContent)
+                    .bytes()
+                    .toString(Charsets.UTF_8)
+            },
+            keyProvider = FakeKeyProvider("test-key"),
+        )
+
+        client.synthesize(text = "hallo", locale = Locale.forLanguageTag("de-DE"))
+
+        val body = checkNotNull(capturedBody)
+        body.shouldContain("Sprich auf Deutsch")
+    }
+
+    @Test
     fun `request body omits the accent directive for unknown english variants`() = runTest {
         // en-CA isn't in our supported variant list — fall through to whatever the
         // model defaults to rather than picking a wrong-but-confident accent.

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Settings.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Settings.kt
@@ -51,6 +51,7 @@ enum class VoiceLocale(val bcp47: String?) {
     EN_US("en-US"),
     EN_GB("en-GB"),
     EN_AU("en-AU"),
+    DE_DE("de-DE"),
 }
 
 /**
@@ -72,6 +73,7 @@ enum class Region(val bcp47: String?) {
     EN_US("en-US"),
     EN_GB("en-GB"),
     EN_AU("en-AU"),
+    DE_DE("de-DE"),
 }
 
 data class UserPreferences(


### PR DESCRIPTION
## Summary

Re-creation of #132, which GitHub auto-closed when its base branch (`claude/add-translation-tts-VzRVj`) was deleted on the merge of #131. Same content; rebased onto `main` so the diff cleanly shows just the German work. Original conversation history at #132.

Picking **Region = Deutsch (Deutschland)** in Settings makes the morning insight render in German and read itself out in German via Gemini / device TTS. The rest of the app's UI (Settings labels, onboarding, notifications metadata) stays in English for now — a follow-up PR can fill the rest of `values-de/` once the prose-and-TTS path is validated on a real phone.

The user note that prompted scoping it this way: insight prose and TTS are the *same path*. The formatter renders the localized text and the speakers speak whatever it returns, so translating the templates picks up both surfaces in one move.

### What changes

**`:core:domain`**
- `Region` and `VoiceLocale` gain `DE_DE` entries. Existing dispatchers are exhaustive `when` blocks, so the compiler flagged every site needing the new arm. No behaviour change for `EN_*` / `SYSTEM` users.

**`:core:data`**
- `geminiAccentDirectiveFor` gets a language-only `"de"` entry: `Sprich auf Deutsch in einem klaren, hochdeutschen Akzent.` Gemini follows the directive language even when the prompt itself is English, so it switches to a `hochdeutsch` reading instead of mangling the German prose through an `en-US` phoneme pipeline. New `GeminiTtsClientTest` case asserts the directive fires for `de-DE`.

**`:app`**
- `values-de/strings.xml` carries the `insight_*` templates + `Region` / `VoiceLocale` labels. Verb-second order (`Heute wird es mild.`), no Oxford comma, German weather vocab (`Bewölkt`, `Nieselregen`, `Gewitter`, …). Includes the `insight_precip_at_time` (`um %1$s`) and `insight_precip_overnight` (`über Nacht`) sub-templates that the new infra split out; non-English locales fall back to a 24h ASCII spoken-time format ("15:00") rather than the English am/pm form.
- `GermanClothesPhraser` emits items bare (`Trag Pullover, Jacke und Regenschirm.`) because we don't carry grammatical gender per `ClothesRule`; guessing der/die/das is wrong half the time. English `EnglishClothesPhraser` stays untouched. A future PR could thread a gender hint through `ClothesRule` to enable `Trag einen Pullover, eine Jacke und Shorts.`
- `RegionSettings` + `VoiceSettings` dispatchers gain the `DE_DE` arm. `InsightFormatterTest` gets six German spot-check cases under Robolectric (band single + range, `Heute Abend` lead-in, comma+`und` join, `um` precip, calendar tie-in arg reorder).

### Known follow-ups (intentionally not in this PR)

- Translate the rest of `values-de/strings.xml` (Settings labels, onboarding, notifications, About). The to-do is mentioned in the file's leading comment so the next translator sees it.
- Per-app locale override: a German-prose rendering on an `en-US` phone today still leaves the `Settings` UI in English. `AppCompatDelegate.setApplicationLocales(...)` driven from `Region` would fix that — but it's a separate concern from this translation pass.
- Gender hint on `ClothesRule` so the German phraser can emit real articles.

### Sandbox limitation

Same as #131 — Google Maven blocked, so `:app:assembleDebug` and `:app:testDebugUnitTest` ran on CI rather than locally.

## Test plan

- [ ] CI green: JVM unit tests + Android debug build.
- [ ] New `InsightFormatterTest` German cases pass (Robolectric loads `values-de/`).
- [ ] New `GeminiTtsClientTest` German directive case passes.
- [ ] Manual on-device sanity (after merge): pick `Region = Deutsch (Deutschland)`, fire an insight — German prose, German TTS via Gemini.

https://claude.ai/code/session_01C1Q3vzGj6KmbYDfD6b2yhu

---
_Generated by [Claude Code](https://claude.ai/code/session_01C1Q3vzGj6KmbYDfD6b2yhu)_