### PR TITLE
:core — drop umbrella from default clothes rules

### DIFF
--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/ClothesRule.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/ClothesRule.kt
@@ -32,11 +32,15 @@ data class ClothesRule(
     }
 
     companion object {
+        // The precip clause already announces rain on its own; bundling "Wear an
+        // umbrella" alongside it sounds redundant and wrong for users who'd reach
+        // for a rain jacket, hood, or nothing at all instead.
+        // TODO: let users personalise the wet-weather accessory (umbrella, rain
+        //  jacket, etc.) and re-introduce a default once the choice is theirs.
         val DEFAULTS: List<ClothesRule> = listOf(
             ClothesRule("jumper", TemperatureBelow(18.0)),
             ClothesRule("jacket", TemperatureBelow(12.0)),
             ClothesRule("shorts", TemperatureAbove(24.0)),
-            ClothesRule("umbrella", PrecipitationProbabilityAbove(50.0)),
         )
     }
 }

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/model/ClothesRuleTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/model/ClothesRuleTest.kt
@@ -67,9 +67,11 @@ class ClothesRuleTest {
     }
 
     @Test
-    fun `defaults cover the four MVP cases`() {
+    fun `defaults cover the temperature-driven MVP cases`() {
+        // Umbrella was deliberately dropped: the precip clause already names rain,
+        // and the wet-weather accessory is going to become a personalised setting.
         val items = ClothesRule.DEFAULTS.map { it.item }
-        items shouldBe listOf("jumper", "jacket", "shorts", "umbrella")
+        items shouldBe listOf("jumper", "jacket", "shorts")
     }
 
     @Test

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/EvaluateClothesRulesTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/EvaluateClothesRulesTest.kt
@@ -41,15 +41,17 @@ class EvaluateClothesRulesTest {
     }
 
     @Test
-    fun `wet cold day triggers cold-weather items and umbrella`() {
+    fun `wet cold day triggers cold-weather items only`() {
+        // Defaults no longer include umbrella — the precip clause announces rain,
+        // and the wet-weather accessory will become a personalised setting.
         val triggered = subject(forecast(min = 10.0, max = 16.0, precip = 70.0), ClothesRule.DEFAULTS)
-        triggered.map { it.item }.shouldContainExactly("jumper", "jacket", "umbrella")
+        triggered.map { it.item }.shouldContainExactly("jumper", "jacket")
     }
 
     @Test
-    fun `mild wet day triggers only umbrella and jumper`() {
+    fun `mild wet day triggers only jumper`() {
         val triggered = subject(forecast(min = 14.0, max = 20.0, precip = 70.0), ClothesRule.DEFAULTS)
-        triggered.map { it.item }.shouldContainExactly("jumper", "umbrella")
+        triggered.map { it.item }.shouldContainExactly("jumper")
     }
 
     @Test

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsightTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsightTest.kt
@@ -212,11 +212,19 @@ class GenerateDailyInsightTest {
         val calendar = FakeCalendarEventReader(events = listOf(event))
         val subject = GenerateDailyInsight(weather, calendarEventReader = calendar, clock = clock)
 
+        // Defaults are temperature-only now, so a 22°C rainy hour wouldn't trigger
+        // any clothes rule and the tie-in would short-circuit on `items.isEmpty()`.
+        // Add an umbrella rule explicitly — modelling a user who's personalised
+        // their wet-weather accessory — so the test still exercises the calendar
+        // tie-in path it's meant to cover.
+        val rules = ClothesRule.DEFAULTS +
+            ClothesRule("umbrella", ClothesRule.PrecipitationProbabilityAbove(50.0))
         val result = subject(
             location = london,
             prefs = prefs.copy(
                 useCalendarEvents = true,
                 schedule = Schedule.default(zone),
+                clothesRules = rules,
             ),
         )
 

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsightTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsightTest.kt
@@ -104,17 +104,18 @@ class GenerateDailyInsightTest {
         val insight = subject(london, prefs).insight
 
         // today: feels-like 6→25 → cold to warm; +8°C high vs yesterday → 8° warmer;
-        // clothes defaults at this temperature: jumper, jacket, shorts, umbrella;
+        // clothes defaults at this temperature: jumper, jacket, shorts (umbrella was
+        // dropped — the precip clause carries the rain message);
         // 60% precipitation → noon fallback (no hourly entries on `today`).
         insight.summary.band.low shouldBe TemperatureBand.COLD
         insight.summary.band.high shouldBe TemperatureBand.WARM
         insight.summary.delta.shouldNotBeNull()
         insight.summary.delta!!.degrees shouldBe 8
         insight.summary.delta!!.direction shouldBe DeltaClause.Direction.WARMER
-        insight.summary.clothes!!.items.shouldContainExactly("jumper", "jacket", "shorts", "umbrella")
+        insight.summary.clothes!!.items.shouldContainExactly("jumper", "jacket", "shorts")
         insight.summary.precip!!.condition shouldBe WeatherCondition.RAIN
         insight.summary.precip!!.time shouldBe LocalTime.NOON
-        insight.recommendedItems.shouldContainExactly("jumper", "jacket", "shorts", "umbrella")
+        insight.recommendedItems.shouldContainExactly("jumper", "jacket", "shorts")
         insight.generatedAt shouldBe clockInstant
         insight.forDate shouldBe today.date
     }


### PR DESCRIPTION
## Summary
- The insight already says "Rain at 3pm" via its own precip clause, so layering "Wear an umbrella" on top is redundant — and assumes the user reaches for an umbrella rather than a rain jacket, hood, or nothing at all.
- Drop `umbrella` from `ClothesRule.DEFAULTS`; users can still add it as a personal rule. A `TODO` on `DEFAULTS` captures the follow-up: let users personalise the wet-weather accessory (umbrella / rain jacket / etc.) and re-introduce a default once the choice is theirs.
- Tests that asserted umbrella firing via `DEFAULTS` (`ClothesRuleTest`, `EvaluateClothesRulesTest`, `GenerateDailyInsightTest`) are updated. Tests that use an explicit `umbrella` rule (`RenderInsightSummaryTest`) or hard-coded umbrella in test data (`InsightFormatterTest`, `InsightCacheTest`) are unchanged — the rule itself still works, it's just not on by default.

## Test plan
- [ ] CI `JVM unit tests` job passes (couldn't run locally — Gradle distribution download blocked in sandbox)
- [ ] CI `Android debug build` passes
- [ ] On a rainy default-rules day, the insight reads "… Rain at 3pm." with no "Wear an umbrella." sentence

https://claude.ai/code/session_01C4sukZ8HttdSSFQdw3fqEn

---
_Generated by [Claude Code](https://claude.ai/code/session_01C4sukZ8HttdSSFQdw3fqEn)_