### PR TITLE
:app — voice locale picker: "English variant" → "Language"

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -11,6 +11,9 @@ the rest of the app stays in English.
 <resources>
     <string name="settings_region_language_de_de">Deutsch (Deutschland)</string>
     <string name="settings_tts_voice_locale_de_de">Deutsch (Deutschland)</string>
+    <!-- Voice-engine "Language" picker title (was "English variant" before
+         German got added; "English variant: Deutsch" was self-contradictory). -->
+    <string name="settings_tts_voice_locale_label">Sprache</string>
 
     <!--
     Outfit-card category labels — shown in OutfitPreviewCard on the Today

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -115,7 +115,7 @@
     <string name="settings_tts_engine_elevenlabs">ElevenLabs (highest quality, online)</string>
     <string name="settings_tts_voice_label">Voice</string>
     <string name="settings_tts_voice_dismiss">Done</string>
-    <string name="settings_tts_voice_locale_label">English variant</string>
+    <string name="settings_tts_voice_locale_label">Language</string>
     <string name="settings_tts_voice_locale_system">Follow phone language</string>
     <string name="settings_tts_voice_locale_en_us">English (United States)</string>
     <string name="settings_tts_voice_locale_en_gb">English (United Kingdom)</string>


### PR DESCRIPTION
## Summary

Voice-settings picker title was `English variant`, dating from when only en-* options existed. Once `Deutsch (Deutschland)` joined the list (#134), the line read `English variant: Deutsch (Deutschland)` — self-contradictory.

Switching to **"Language"** ("Sprache" in `values-de/`). The picker entries are language-and-region pairs, so a plain "Language" label scans naturally for both English variants and German. en-GB / en-US / en-AU are still strictly accent variants of the *same* language — that's a slight stretch — but cleaner than the pre-existing self-contradiction. Easy swap to **"Language & Accent"** later if more locales arrive and it starts to feel under-specified.

## Test plan

- [ ] CI green.
- [ ] Manual on-device sanity: Settings → Voice shows `Language: <selection>` (not `English variant: …`); de-DE phone shows `Sprache: …`.

https://claude.ai/code/session_01C1Q3vzGj6KmbYDfD6b2yhu

---
_Generated by [Claude Code](https://claude.ai/code/session_01C1Q3vzGj6KmbYDfD6b2yhu)_