### PR TITLE
:app — values-en-rAU: drop the Pants override, keep only Jumper

### DIFF
--- a/app/src/main/res/values-en-rAU/strings.xml
+++ b/app/src/main/res/values-en-rAU/strings.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-Australian English overrides. Same shape as values-en-rGB/: only strings an
-en-AU speaker would notice as wrong, everything else falls back to values/.
-en-AU shares "jumper" with en-GB but doesn't share the "pants = underwear"
-collision, so the bottom label is just "Pants" (not "Trousers").
+Australian English overrides. en-AU is essentially en-US-flavoured for this
+app's vocabulary — the only label that diverges from the en-US base is
+"Sweater" (en-AU says "Jumper"). "Long pants" stays as-is: en-AU shares
+"pants" with en-US (no en-GB-style underwear collision).
 -->
 <resources>
     <string name="today_outfit_top_sweater">Jumper</string>
-    <string name="today_outfit_bottom_long_pants">Pants</string>
 </resources>


### PR DESCRIPTION
## Summary

en-AU is essentially en-US-flavoured for this app's vocabulary. The only label that actually diverges from the en-US base is `Sweater` → `Jumper`; `Long pants` stays as the base says (en-AU shares "pants" with en-US, no underwear collision like en-GB).

Reframes the file's leading comment to put en-US as the implicit baseline rather than describing en-AU as "shares jumper with en-GB" — which framed en-AU through the en-GB lens by accident.

Independent of #140 (German clothes-rule translation + lockdown).

## Test plan

- [ ] CI green.
- [ ] Manual on-device sanity: en-AU phone shows "Jumper" / "Long pants" on the Today card.

https://claude.ai/code/session_01C1Q3vzGj6KmbYDfD6b2yhu

---
_Generated by [Claude Code](https://claude.ai/code/session_01C1Q3vzGj6KmbYDfD6b2yhu)_