### PR TITLE
:app — empty stored clothes-rules list reads back as DEFAULTS

### DIFF
--- a/app/src/main/kotlin/app/clothescast/data/SettingsRepository.kt
+++ b/app/src/main/kotlin/app/clothescast/data/SettingsRepository.kt
@@ -218,6 +218,12 @@ class SettingsRepository(
         return runCatching {
             json.decodeFromString<List<ClothesRuleDto>>(raw).map { it.toDomain() }
         }.getOrDefault(ClothesRule.DEFAULTS)
+            // An empty stored list is also treated as "no rules configured" rather
+            // than honoured as an intentional zero — with editing locked
+            // (ClothesSettings is read-only), a user who deleted all their rules
+            // in a previous editable-UI version would otherwise have no way to
+            // recover the defaults.
+            .ifEmpty { ClothesRule.DEFAULTS }
     }
 
     companion object {

--- a/app/src/test/kotlin/app/clothescast/data/SettingsRepositoryTest.kt
+++ b/app/src/test/kotlin/app/clothescast/data/SettingsRepositoryTest.kt
@@ -171,10 +171,15 @@ class SettingsRepositoryTest {
     }
 
     @Test
-    fun `setClothesRules with empty list persists empty list, not defaults`() = runTest {
+    fun `setClothesRules with empty list reads back as defaults`() = runTest {
+        // An empty stored list — whether set deliberately or left over from the
+        // editable-UI era when a user deleted all their rules — is treated as
+        // "no rules configured" and resolves to DEFAULTS at read time. Editing
+        // is locked (ClothesSettings is read-only), so otherwise such a user
+        // would have no way to recover the defaults.
         subject.setClothesRules(emptyList())
 
-        subject.preferences.first().clothesRules shouldBe emptyList()
+        subject.preferences.first().clothesRules shouldBe ClothesRule.DEFAULTS
     }
 
     @Test


### PR DESCRIPTION
## Summary

Existing users who deleted all their rules in the editable-UI era have an `[]` stored in DataStore. With editing now locked (`ClothesSettings` is read-only post-#140) they otherwise have no way to recover the defaults.

`parseRules` already returned `DEFAULTS` on null / blank / corrupt JSON; this PR adds `.ifEmpty { ClothesRule.DEFAULTS }` after the `runCatching` decode so a successfully-parsed empty list resolves the same way.

Existing `setClothesRules with empty list persists empty list, not defaults` test renamed and flipped to assert the new semantics — the previous name describes the bug, not the desired behaviour.

### Scope

Addresses Copilot review comment 1 of 3 from #140. The other two are skipped here:

- **Trim consistency** — defensive-only with editing locked; revisit when editing returns.
- **en-GB / en-AU `sweater` → `jumper`** — cleaner as part of the rules-redesign already TODO'd on `ClothesRule` (fixed garment enum + `clothes_item_*` resources).

## Test plan

- [ ] CI green.
- [ ] Manual on-device sanity: a debug build with `[]` injected into DataStore reads back as the three defaults instead of an empty list.

https://claude.ai/code/session_01C1Q3vzGj6KmbYDfD6b2yhu

---
_Generated by [Claude Code](https://claude.ai/code/session_01C1Q3vzGj6KmbYDfD6b2yhu)_