### PR TITLE
:core:domain + :app — add 14 language/locale options

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/settings/RegionSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/RegionSettings.kt
@@ -69,7 +69,21 @@ private fun regionLabel(region: Region): Int = when (region) {
     Region.EN_US -> R.string.settings_region_language_en_us
     Region.EN_GB -> R.string.settings_region_language_en_gb
     Region.EN_AU -> R.string.settings_region_language_en_au
+    Region.EN_CA -> R.string.settings_region_language_en_ca
     Region.DE_DE -> R.string.settings_region_language_de_de
+    Region.FR_FR -> R.string.settings_region_language_fr_fr
+    Region.FR_CA -> R.string.settings_region_language_fr_ca
+    Region.IT_IT -> R.string.settings_region_language_it_it
+    Region.ES_ES -> R.string.settings_region_language_es_es
+    Region.ES_MX -> R.string.settings_region_language_es_mx
+    Region.RU_RU -> R.string.settings_region_language_ru_ru
+    Region.PL_PL -> R.string.settings_region_language_pl_pl
+    Region.HR_HR -> R.string.settings_region_language_hr_hr
+    Region.UK_UA -> R.string.settings_region_language_uk_ua
+    Region.PT_BR -> R.string.settings_region_language_pt_br
+    Region.NL_NL -> R.string.settings_region_language_nl_nl
+    Region.SV_SE -> R.string.settings_region_language_sv_se
+    Region.TR_TR -> R.string.settings_region_language_tr_tr
 }
 
 private fun temperatureUnitLabel(unit: TemperatureUnit): Int = when (unit) {

--- a/app/src/main/kotlin/app/clothescast/ui/settings/VoiceSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/VoiceSettings.kt
@@ -336,7 +336,21 @@ private fun voiceLocaleLabel(locale: VoiceLocale): Int = when (locale) {
     VoiceLocale.EN_US -> R.string.settings_tts_voice_locale_en_us
     VoiceLocale.EN_GB -> R.string.settings_tts_voice_locale_en_gb
     VoiceLocale.EN_AU -> R.string.settings_tts_voice_locale_en_au
+    VoiceLocale.EN_CA -> R.string.settings_tts_voice_locale_en_ca
     VoiceLocale.DE_DE -> R.string.settings_tts_voice_locale_de_de
+    VoiceLocale.FR_FR -> R.string.settings_tts_voice_locale_fr_fr
+    VoiceLocale.FR_CA -> R.string.settings_tts_voice_locale_fr_ca
+    VoiceLocale.IT_IT -> R.string.settings_tts_voice_locale_it_it
+    VoiceLocale.ES_ES -> R.string.settings_tts_voice_locale_es_es
+    VoiceLocale.ES_MX -> R.string.settings_tts_voice_locale_es_mx
+    VoiceLocale.RU_RU -> R.string.settings_tts_voice_locale_ru_ru
+    VoiceLocale.PL_PL -> R.string.settings_tts_voice_locale_pl_pl
+    VoiceLocale.HR_HR -> R.string.settings_tts_voice_locale_hr_hr
+    VoiceLocale.UK_UA -> R.string.settings_tts_voice_locale_uk_ua
+    VoiceLocale.PT_BR -> R.string.settings_tts_voice_locale_pt_br
+    VoiceLocale.NL_NL -> R.string.settings_tts_voice_locale_nl_nl
+    VoiceLocale.SV_SE -> R.string.settings_tts_voice_locale_sv_se
+    VoiceLocale.TR_TR -> R.string.settings_tts_voice_locale_tr_tr
 }
 
 @Composable

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+Mexican Spanish overrides on top of values-es/strings.xml. Only vocabulary
+that a Mexican speaker would notice as wrong is overridden here.
+-->
+<resources>
+    <!-- "Suéter" (Mexico) vs "jersey" (Spain). -->
+    <string name="garment_sweater">Suéter</string>
+    <!-- "Playera" is the standard Mexican word for t-shirt. -->
+    <string name="garment_tshirt">Playera</string>
+    <!-- "Mezclilla" is the common Mexican term for jeans. -->
+    <string name="garment_jeans">Mezclilla</string>
+    <string name="today_outfit_top_tshirt">Playera</string>
+    <string name="today_outfit_top_sweater">Suéter</string>
+    <!-- "Agregar" is more natural than "añadir" in Mexican Spanish. -->
+    <string name="settings_clothes_add">Agregar</string>
+    <string name="settings_clothes_empty">Sin reglas. Toca Agregar para crear una.</string>
+    <string name="settings_clothes_dialog_add_title">Agregar regla de ropa</string>
+</resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+Spanish translation (Spain base). Scope: insight-prose templates, garment labels,
+clothes-rule editor, outfit-card labels, and region/voice-locale picker names.
+Mexico-specific vocabulary overrides live in values-es-rMX.
+-->
+<resources>
+    <string name="settings_region_language_es_es">Español (España)</string>
+    <string name="settings_region_language_es_mx">Español (México)</string>
+    <string name="settings_tts_voice_locale_es_es">Español (España)</string>
+    <string name="settings_tts_voice_locale_es_mx">Español (México)</string>
+    <string name="settings_tts_voice_locale_label">Idioma</string>
+
+    <string name="garment_sweater">Jersey</string>
+    <string name="garment_hoodie">Sudadera con capucha</string>
+    <string name="garment_jacket">Chaqueta</string>
+    <string name="garment_coat">Abrigo</string>
+    <string name="garment_tshirt">Camiseta</string>
+    <string name="garment_shirt">Camisa</string>
+    <string name="garment_shorts">Pantalones cortos</string>
+    <string name="garment_pants">Pantalones</string>
+    <string name="garment_jeans">Vaqueros</string>
+
+    <string name="settings_clothes_empty">Sin reglas. Toca Añadir para crear una.</string>
+    <string name="settings_clothes_add">Añadir</string>
+    <string name="settings_clothes_edit">Editar</string>
+    <string name="settings_clothes_delete">Eliminar</string>
+    <string name="settings_clothes_dialog_add_title">Añadir regla de ropa</string>
+    <string name="settings_clothes_dialog_edit_title">Editar regla de ropa</string>
+    <string name="settings_clothes_item_label">Prenda</string>
+    <string name="settings_clothes_condition_label">Condición</string>
+    <string name="settings_clothes_value_label_temp_c">Umbral (°C)</string>
+    <string name="settings_clothes_value_label_precip">Umbral (%%)</string>
+    <string name="settings_clothes_cond_type_temp_below">Cuando se siente menos de</string>
+    <string name="settings_clothes_cond_type_temp_above">Cuando se siente más de</string>
+    <string name="settings_clothes_cond_type_precip_above">Cuando la probabilidad de lluvia supera</string>
+    <string name="settings_clothes_cond_temp_below">cuando la temperatura percibida es inferior a %.0f°C</string>
+    <string name="settings_clothes_cond_temp_above">cuando la temperatura percibida es superior a %.0f°C</string>
+    <string name="settings_clothes_cond_precip_above">cuando la probabilidad de lluvia supera %.0f%%</string>
+
+    <string name="today_outfit_top_tshirt">Camiseta</string>
+    <string name="today_outfit_top_sweater">Jersey</string>
+    <string name="today_outfit_top_thick_jacket">Abrigo grueso</string>
+    <string name="today_outfit_bottom_shorts">Pantalones cortos</string>
+    <string name="today_outfit_bottom_long_pants">Pantalones</string>
+
+    <string name="insight_lead_today">Hoy</string>
+    <string name="insight_lead_tonight">Esta noche</string>
+    <string name="insight_band_single">%1$s hará %2$s.</string>
+    <string name="insight_band_range">%1$s hará entre %2$s y %3$s.</string>
+    <string name="insight_band_freezing">helada</string>
+    <string name="insight_band_cold">frío</string>
+    <string name="insight_band_cool">fresco</string>
+    <string name="insight_band_mild">templado</string>
+    <string name="insight_band_warm">cálido</string>
+    <string name="insight_band_hot">muy caluroso</string>
+    <string name="insight_delta_warmer">Hará %1$d° más hoy.</string>
+    <string name="insight_delta_cooler">Hará %1$d° menos hoy.</string>
+    <string name="insight_alert">Alerta: %1$s.</string>
+    <string name="insight_clothes_wear">Lleva %1$s.</string>
+    <!-- Articles omitted — Spanish gender agreement requires per-garment metadata. -->
+    <string name="insight_clothes_article_a">%1$s</string>
+    <string name="insight_clothes_article_an">%1$s</string>
+    <string name="insight_clothes_join_two">%1$s y %2$s</string>
+    <string name="insight_clothes_join_many">%1$s, %2$s y %3$s</string>
+    <string name="insight_precip">%1$s %2$s.</string>
+    <string name="insight_precip_at_time">a las %1$s</string>
+    <string name="insight_precip_overnight">durante la noche</string>
+    <string name="insight_condition_clear">Despejado</string>
+    <string name="insight_condition_partly_cloudy">Parcialmente nublado</string>
+    <string name="insight_condition_cloudy">Nublado</string>
+    <string name="insight_condition_fog">Niebla</string>
+    <string name="insight_condition_drizzle">Llovizna</string>
+    <string name="insight_condition_rain">Lluvia</string>
+    <string name="insight_condition_snow">Nieve</string>
+    <string name="insight_condition_thunderstorm">Tormenta</string>
+    <string name="insight_condition_unknown">Desconocido</string>
+    <string name="insight_calendar_tie_in">Lleva %1$s para tu %3$s de las %2$s.</string>
+</resources>

--- a/app/src/main/res/values-fr-rCA/strings.xml
+++ b/app/src/main/res/values-fr-rCA/strings.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+Quebec French overrides on top of values-fr/strings.xml. Only vocabulary that
+a Quebec speaker would notice as wrong is overridden here; everything else
+falls through to the base French translation.
+-->
+<resources>
+    <!-- "Chandail" is the standard Quebec word; "pull" (France) sounds foreign. -->
+    <string name="garment_sweater">Chandail</string>
+    <string name="today_outfit_top_sweater">Chandail</string>
+</resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+French translation. Scope: insight-prose templates, garment labels, clothes-rule
+editor, outfit-card labels, and region/voice-locale picker names. The rest of the
+UI falls through to values/strings.xml (English) until a follow-up PR fills it in.
+
+Note: articles are omitted from insight_clothes_article_* to avoid gender
+agreement; garment names are listed without articles and read naturally in context.
+-->
+<resources>
+    <string name="settings_region_language_fr_fr">Français (France)</string>
+    <string name="settings_region_language_fr_ca">Français (Canada)</string>
+    <string name="settings_tts_voice_locale_fr_fr">Français (France)</string>
+    <string name="settings_tts_voice_locale_fr_ca">Français (Canada)</string>
+    <string name="settings_tts_voice_locale_label">Langue</string>
+
+    <string name="garment_sweater">Pull</string>
+    <string name="garment_hoodie">Sweat à capuche</string>
+    <string name="garment_jacket">Veste</string>
+    <string name="garment_coat">Manteau</string>
+    <string name="garment_tshirt">T-shirt</string>
+    <string name="garment_shirt">Chemise</string>
+    <string name="garment_shorts">Short</string>
+    <string name="garment_pants">Pantalon</string>
+    <string name="garment_jeans">Jean</string>
+
+    <string name="settings_clothes_empty">Aucune règle. Appuyez sur Ajouter pour en créer une.</string>
+    <string name="settings_clothes_add">Ajouter</string>
+    <string name="settings_clothes_edit">Modifier</string>
+    <string name="settings_clothes_delete">Supprimer</string>
+    <string name="settings_clothes_dialog_add_title">Ajouter une règle vestimentaire</string>
+    <string name="settings_clothes_dialog_edit_title">Modifier la règle vestimentaire</string>
+    <string name="settings_clothes_item_label">Vêtement</string>
+    <string name="settings_clothes_condition_label">Déclencheur</string>
+    <string name="settings_clothes_value_label_temp_c">Seuil (°C)</string>
+    <string name="settings_clothes_value_label_precip">Seuil (%%)</string>
+    <string name="settings_clothes_cond_type_temp_below">Quand il fait moins de</string>
+    <string name="settings_clothes_cond_type_temp_above">Quand il fait plus de</string>
+    <string name="settings_clothes_cond_type_precip_above">Quand le risque de pluie dépasse</string>
+    <string name="settings_clothes_cond_temp_below">quand la température ressentie est en dessous de %.0f°C</string>
+    <string name="settings_clothes_cond_temp_above">quand la température ressentie est au-dessus de %.0f°C</string>
+    <string name="settings_clothes_cond_precip_above">quand le risque de pluie dépasse %.0f%%</string>
+
+    <string name="today_outfit_top_tshirt">T-shirt</string>
+    <string name="today_outfit_top_sweater">Pull</string>
+    <string name="today_outfit_top_thick_jacket">Manteau épais</string>
+    <string name="today_outfit_bottom_shorts">Short</string>
+    <string name="today_outfit_bottom_long_pants">Pantalon</string>
+
+    <string name="insight_lead_today">Aujourd\'hui</string>
+    <string name="insight_lead_tonight">Ce soir</string>
+    <string name="insight_band_single">%1$s, il fera %2$s.</string>
+    <string name="insight_band_range">%1$s, il fera entre %2$s et %3$s.</string>
+    <string name="insight_band_freezing">très froid</string>
+    <string name="insight_band_cold">froid</string>
+    <string name="insight_band_cool">frais</string>
+    <string name="insight_band_mild">doux</string>
+    <string name="insight_band_warm">chaud</string>
+    <string name="insight_band_hot">très chaud</string>
+    <string name="insight_delta_warmer">Il fera %1$d° de plus aujourd\'hui.</string>
+    <string name="insight_delta_cooler">Il fera %1$d° de moins aujourd\'hui.</string>
+    <string name="insight_alert">Alerte : %1$s.</string>
+    <string name="insight_clothes_wear">Portez %1$s.</string>
+    <!-- Articles omitted — French gender agreement can\'t be resolved without
+         per-garment metadata; a flat list reads naturally ("Portez pull, veste"). -->
+    <string name="insight_clothes_article_a">%1$s</string>
+    <string name="insight_clothes_article_an">%1$s</string>
+    <string name="insight_clothes_join_two">%1$s et %2$s</string>
+    <string name="insight_clothes_join_many">%1$s, %2$s et %3$s</string>
+    <string name="insight_precip">%1$s %2$s.</string>
+    <string name="insight_precip_at_time">à %1$s</string>
+    <string name="insight_precip_overnight">pendant la nuit</string>
+    <string name="insight_condition_clear">Clair</string>
+    <string name="insight_condition_partly_cloudy">Partiellement nuageux</string>
+    <string name="insight_condition_cloudy">Nuageux</string>
+    <string name="insight_condition_fog">Brouillard</string>
+    <string name="insight_condition_drizzle">Bruine</string>
+    <string name="insight_condition_rain">Pluie</string>
+    <string name="insight_condition_snow">Neige</string>
+    <string name="insight_condition_thunderstorm">Orage</string>
+    <string name="insight_condition_unknown">Inconnu</string>
+    <string name="insight_calendar_tie_in">Prenez %1$s pour votre %3$s de %2$s.</string>
+</resources>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+Croatian translation. Scope: insight-prose templates, garment labels, clothes-rule
+editor, outfit-card labels, and region/voice-locale picker names.
+-->
+<resources>
+    <string name="settings_region_language_hr_hr">Hrvatski (Hrvatska)</string>
+    <string name="settings_tts_voice_locale_hr_hr">Hrvatski (Hrvatska)</string>
+    <string name="settings_tts_voice_locale_label">Jezik</string>
+
+    <string name="garment_sweater">Džemper</string>
+    <string name="garment_hoodie">Hoodie</string>
+    <string name="garment_jacket">Jakna</string>
+    <string name="garment_coat">Kaput</string>
+    <string name="garment_tshirt">Majica</string>
+    <string name="garment_shirt">Košulja</string>
+    <string name="garment_shorts">Kratke hlače</string>
+    <string name="garment_pants">Hlače</string>
+    <string name="garment_jeans">Traperice</string>
+
+    <string name="settings_clothes_empty">Nema pravila. Dodirnite Dodaj za kreiranje.</string>
+    <string name="settings_clothes_add">Dodaj</string>
+    <string name="settings_clothes_edit">Uredi</string>
+    <string name="settings_clothes_delete">Izbriši</string>
+    <string name="settings_clothes_dialog_add_title">Dodaj pravilo odijevanja</string>
+    <string name="settings_clothes_dialog_edit_title">Uredi pravilo odijevanja</string>
+    <string name="settings_clothes_item_label">Odjevni predmet</string>
+    <string name="settings_clothes_condition_label">Uvjet</string>
+    <string name="settings_clothes_value_label_temp_c">Prag (°C)</string>
+    <string name="settings_clothes_value_label_precip">Prag (%%)</string>
+    <string name="settings_clothes_cond_type_temp_below">Kada se osjeća hladnije od</string>
+    <string name="settings_clothes_cond_type_temp_above">Kada se osjeća toplije od</string>
+    <string name="settings_clothes_cond_type_precip_above">Kada je vjerojatnost kiše veća od</string>
+    <string name="settings_clothes_cond_temp_below">kada je osjećajna temperatura ispod %.0f°C</string>
+    <string name="settings_clothes_cond_temp_above">kada je osjećajna temperatura iznad %.0f°C</string>
+    <string name="settings_clothes_cond_precip_above">kada je vjerojatnost kiše veća od %.0f%%</string>
+
+    <string name="today_outfit_top_tshirt">Majica</string>
+    <string name="today_outfit_top_sweater">Džemper</string>
+    <string name="today_outfit_top_thick_jacket">Debela jakna</string>
+    <string name="today_outfit_bottom_shorts">Kratke hlače</string>
+    <string name="today_outfit_bottom_long_pants">Hlače</string>
+
+    <string name="insight_lead_today">Danas</string>
+    <string name="insight_lead_tonight">Večeras</string>
+    <string name="insight_band_single">%1$s će biti %2$s.</string>
+    <string name="insight_band_range">%1$s će biti od %2$s do %3$s.</string>
+    <string name="insight_band_freezing">ledeno</string>
+    <string name="insight_band_cold">hladno</string>
+    <string name="insight_band_cool">svježe</string>
+    <string name="insight_band_mild">blago</string>
+    <string name="insight_band_warm">toplo</string>
+    <string name="insight_band_hot">vruće</string>
+    <string name="insight_delta_warmer">Danas će biti %1$d° toplije.</string>
+    <string name="insight_delta_cooler">Danas će biti %1$d° hladnije.</string>
+    <string name="insight_alert">Upozorenje: %1$s.</string>
+    <string name="insight_clothes_wear">Obucite %1$s.</string>
+    <string name="insight_clothes_article_a">%1$s</string>
+    <string name="insight_clothes_article_an">%1$s</string>
+    <string name="insight_clothes_join_two">%1$s i %2$s</string>
+    <string name="insight_clothes_join_many">%1$s, %2$s i %3$s</string>
+    <string name="insight_precip">%1$s %2$s.</string>
+    <string name="insight_precip_at_time">u %1$s</string>
+    <string name="insight_precip_overnight">noću</string>
+    <string name="insight_condition_clear">Vedro</string>
+    <string name="insight_condition_partly_cloudy">Djelomično oblačno</string>
+    <string name="insight_condition_cloudy">Oblačno</string>
+    <string name="insight_condition_fog">Magla</string>
+    <string name="insight_condition_drizzle">Sitna kiša</string>
+    <string name="insight_condition_rain">Kiša</string>
+    <string name="insight_condition_snow">Snijeg</string>
+    <string name="insight_condition_thunderstorm">Grmljavina</string>
+    <string name="insight_condition_unknown">Nepoznato</string>
+    <string name="insight_calendar_tie_in">Ponesite %1$s na %3$s u %2$s.</string>
+</resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+Italian translation. Scope: insight-prose templates, garment labels, clothes-rule
+editor, outfit-card labels, and region/voice-locale picker names.
+-->
+<resources>
+    <string name="settings_region_language_it_it">Italiano (Italia)</string>
+    <string name="settings_tts_voice_locale_it_it">Italiano (Italia)</string>
+    <string name="settings_tts_voice_locale_label">Lingua</string>
+
+    <string name="garment_sweater">Maglione</string>
+    <string name="garment_hoodie">Felpa con cappuccio</string>
+    <string name="garment_jacket">Giacca</string>
+    <string name="garment_coat">Cappotto</string>
+    <string name="garment_tshirt">T-shirt</string>
+    <string name="garment_shirt">Camicia</string>
+    <string name="garment_shorts">Pantaloncini</string>
+    <string name="garment_pants">Pantaloni</string>
+    <string name="garment_jeans">Jeans</string>
+
+    <string name="settings_clothes_empty">Nessuna regola. Tocca Aggiungi per crearne una.</string>
+    <string name="settings_clothes_add">Aggiungi</string>
+    <string name="settings_clothes_edit">Modifica</string>
+    <string name="settings_clothes_delete">Elimina</string>
+    <string name="settings_clothes_dialog_add_title">Aggiungi regola abbigliamento</string>
+    <string name="settings_clothes_dialog_edit_title">Modifica regola abbigliamento</string>
+    <string name="settings_clothes_item_label">Capo</string>
+    <string name="settings_clothes_condition_label">Condizione</string>
+    <string name="settings_clothes_value_label_temp_c">Soglia (°C)</string>
+    <string name="settings_clothes_value_label_precip">Soglia (%%)</string>
+    <string name="settings_clothes_cond_type_temp_below">Quando si percepisce meno di</string>
+    <string name="settings_clothes_cond_type_temp_above">Quando si percepisce più di</string>
+    <string name="settings_clothes_cond_type_precip_above">Quando la probabilità di pioggia supera</string>
+    <string name="settings_clothes_cond_temp_below">quando la temperatura percepita è sotto %.0f°C</string>
+    <string name="settings_clothes_cond_temp_above">quando la temperatura percepita è sopra %.0f°C</string>
+    <string name="settings_clothes_cond_precip_above">quando la probabilità di pioggia supera %.0f%%</string>
+
+    <string name="today_outfit_top_tshirt">T-shirt</string>
+    <string name="today_outfit_top_sweater">Maglione</string>
+    <string name="today_outfit_top_thick_jacket">Giacca pesante</string>
+    <string name="today_outfit_bottom_shorts">Pantaloncini</string>
+    <string name="today_outfit_bottom_long_pants">Pantaloni</string>
+
+    <string name="insight_lead_today">Oggi</string>
+    <string name="insight_lead_tonight">Stasera</string>
+    <string name="insight_band_single">%1$s sarà %2$s.</string>
+    <string name="insight_band_range">%1$s sarà tra %2$s e %3$s.</string>
+    <string name="insight_band_freezing">gelido</string>
+    <string name="insight_band_cold">freddo</string>
+    <string name="insight_band_cool">fresco</string>
+    <string name="insight_band_mild">mite</string>
+    <string name="insight_band_warm">caldo</string>
+    <string name="insight_band_hot">molto caldo</string>
+    <string name="insight_delta_warmer">Oggi farà %1$d° in più.</string>
+    <string name="insight_delta_cooler">Oggi farà %1$d° in meno.</string>
+    <string name="insight_alert">Allerta: %1$s.</string>
+    <string name="insight_clothes_wear">Indossa %1$s.</string>
+    <!-- Articles omitted — Italian gender agreement requires per-garment metadata. -->
+    <string name="insight_clothes_article_a">%1$s</string>
+    <string name="insight_clothes_article_an">%1$s</string>
+    <string name="insight_clothes_join_two">%1$s e %2$s</string>
+    <string name="insight_clothes_join_many">%1$s, %2$s e %3$s</string>
+    <string name="insight_precip">%1$s %2$s.</string>
+    <string name="insight_precip_at_time">alle %1$s</string>
+    <string name="insight_precip_overnight">durante la notte</string>
+    <string name="insight_condition_clear">Sereno</string>
+    <string name="insight_condition_partly_cloudy">Parzialmente nuvoloso</string>
+    <string name="insight_condition_cloudy">Nuvoloso</string>
+    <string name="insight_condition_fog">Nebbia</string>
+    <string name="insight_condition_drizzle">Pioggerella</string>
+    <string name="insight_condition_rain">Pioggia</string>
+    <string name="insight_condition_snow">Neve</string>
+    <string name="insight_condition_thunderstorm">Temporale</string>
+    <string name="insight_condition_unknown">Sconosciuto</string>
+    <string name="insight_calendar_tie_in">Porta %1$s per il tuo %3$s alle %2$s.</string>
+</resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+Dutch translation. Scope: insight-prose templates, garment labels, clothes-rule
+editor, outfit-card labels, and region/voice-locale picker names.
+-->
+<resources>
+    <string name="settings_region_language_nl_nl">Nederlands (Nederland)</string>
+    <string name="settings_tts_voice_locale_nl_nl">Nederlands (Nederland)</string>
+    <string name="settings_tts_voice_locale_label">Taal</string>
+
+    <string name="garment_sweater">Trui</string>
+    <string name="garment_hoodie">Hoodie</string>
+    <string name="garment_jacket">Jas</string>
+    <string name="garment_coat">Winterjas</string>
+    <string name="garment_tshirt">T-shirt</string>
+    <string name="garment_shirt">Overhemd</string>
+    <string name="garment_shorts">Shorts</string>
+    <string name="garment_pants">Broek</string>
+    <string name="garment_jeans">Spijkerbroek</string>
+
+    <string name="settings_clothes_empty">Geen regels. Tik op Toevoegen om er een aan te maken.</string>
+    <string name="settings_clothes_add">Toevoegen</string>
+    <string name="settings_clothes_edit">Bewerken</string>
+    <string name="settings_clothes_delete">Verwijderen</string>
+    <string name="settings_clothes_dialog_add_title">Kledingsregel toevoegen</string>
+    <string name="settings_clothes_dialog_edit_title">Kledingsregel bewerken</string>
+    <string name="settings_clothes_item_label">Kledingstuk</string>
+    <string name="settings_clothes_condition_label">Voorwaarde</string>
+    <string name="settings_clothes_value_label_temp_c">Drempel (°C)</string>
+    <string name="settings_clothes_value_label_precip">Drempel (%%)</string>
+    <string name="settings_clothes_cond_type_temp_below">Wanneer het kouder voelt dan</string>
+    <string name="settings_clothes_cond_type_temp_above">Wanneer het warmer voelt dan</string>
+    <string name="settings_clothes_cond_type_precip_above">Wanneer de kans op regen groter is dan</string>
+    <string name="settings_clothes_cond_temp_below">wanneer de gevoelstemperatuur onder %.0f°C ligt</string>
+    <string name="settings_clothes_cond_temp_above">wanneer de gevoelstemperatuur boven %.0f°C ligt</string>
+    <string name="settings_clothes_cond_precip_above">wanneer de kans op regen groter is dan %.0f%%</string>
+
+    <string name="today_outfit_top_tshirt">T-shirt</string>
+    <string name="today_outfit_top_sweater">Trui</string>
+    <string name="today_outfit_top_thick_jacket">Dikke jas</string>
+    <string name="today_outfit_bottom_shorts">Shorts</string>
+    <string name="today_outfit_bottom_long_pants">Broek</string>
+
+    <string name="insight_lead_today">Vandaag</string>
+    <string name="insight_lead_tonight">Vanavond</string>
+    <!-- Dutch V2 word order: "Vandaag wordt het mild." -->
+    <string name="insight_band_single">%1$s wordt het %2$s.</string>
+    <string name="insight_band_range">%1$s wordt het %2$s tot %3$s.</string>
+    <string name="insight_band_freezing">vriezend koud</string>
+    <string name="insight_band_cold">koud</string>
+    <string name="insight_band_cool">fris</string>
+    <string name="insight_band_mild">mild</string>
+    <string name="insight_band_warm">warm</string>
+    <string name="insight_band_hot">erg warm</string>
+    <string name="insight_delta_warmer">Het wordt vandaag %1$d° warmer.</string>
+    <string name="insight_delta_cooler">Het wordt vandaag %1$d° kouder.</string>
+    <string name="insight_alert">Waarschuwing: %1$s.</string>
+    <string name="insight_clothes_wear">Draag %1$s.</string>
+    <string name="insight_clothes_article_a">%1$s</string>
+    <string name="insight_clothes_article_an">%1$s</string>
+    <string name="insight_clothes_join_two">%1$s en %2$s</string>
+    <string name="insight_clothes_join_many">%1$s, %2$s en %3$s</string>
+    <string name="insight_precip">%1$s %2$s.</string>
+    <string name="insight_precip_at_time">om %1$s</string>
+    <!-- Apostrophe before s-genitive in Dutch: "\'s nachts" = at night. -->
+    <string name="insight_precip_overnight">\'s nachts</string>
+    <string name="insight_condition_clear">Helder</string>
+    <string name="insight_condition_partly_cloudy">Gedeeltelijk bewolkt</string>
+    <string name="insight_condition_cloudy">Bewolkt</string>
+    <string name="insight_condition_fog">Mist</string>
+    <string name="insight_condition_drizzle">Motregen</string>
+    <string name="insight_condition_rain">Regen</string>
+    <string name="insight_condition_snow">Sneeuw</string>
+    <string name="insight_condition_thunderstorm">Onweer</string>
+    <string name="insight_condition_unknown">Onbekend</string>
+    <string name="insight_calendar_tie_in">Neem %1$s mee voor je %3$s om %2$s.</string>
+</resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+Polish translation. Scope: insight-prose templates, garment labels, clothes-rule
+editor, outfit-card labels, and region/voice-locale picker names.
+-->
+<resources>
+    <string name="settings_region_language_pl_pl">Polski (Polska)</string>
+    <string name="settings_tts_voice_locale_pl_pl">Polski (Polska)</string>
+    <string name="settings_tts_voice_locale_label">Język</string>
+
+    <string name="garment_sweater">Sweter</string>
+    <string name="garment_hoodie">Bluza z kapturem</string>
+    <string name="garment_jacket">Kurtka</string>
+    <string name="garment_coat">Płaszcz</string>
+    <string name="garment_tshirt">Koszulka</string>
+    <string name="garment_shirt">Koszula</string>
+    <string name="garment_shorts">Szorty</string>
+    <string name="garment_pants">Spodnie</string>
+    <string name="garment_jeans">Dżinsy</string>
+
+    <string name="settings_clothes_empty">Brak reguł. Dotknij Dodaj, aby je dodać.</string>
+    <string name="settings_clothes_add">Dodaj</string>
+    <string name="settings_clothes_edit">Edytuj</string>
+    <string name="settings_clothes_delete">Usuń</string>
+    <string name="settings_clothes_dialog_add_title">Dodaj regułę ubioru</string>
+    <string name="settings_clothes_dialog_edit_title">Edytuj regułę ubioru</string>
+    <string name="settings_clothes_item_label">Ubranie</string>
+    <string name="settings_clothes_condition_label">Warunek</string>
+    <string name="settings_clothes_value_label_temp_c">Próg (°C)</string>
+    <string name="settings_clothes_value_label_precip">Próg (%%)</string>
+    <string name="settings_clothes_cond_type_temp_below">Gdy odczuwalna temperatura spada poniżej</string>
+    <string name="settings_clothes_cond_type_temp_above">Gdy odczuwalna temperatura przekracza</string>
+    <string name="settings_clothes_cond_type_precip_above">Gdy prawdopodobieństwo deszczu przekracza</string>
+    <string name="settings_clothes_cond_temp_below">gdy odczuwalna temperatura spada poniżej %.0f°C</string>
+    <string name="settings_clothes_cond_temp_above">gdy odczuwalna temperatura przekracza %.0f°C</string>
+    <string name="settings_clothes_cond_precip_above">gdy prawdopodobieństwo deszczu przekracza %.0f%%</string>
+
+    <string name="today_outfit_top_tshirt">Koszulka</string>
+    <string name="today_outfit_top_sweater">Sweter</string>
+    <string name="today_outfit_top_thick_jacket">Gruby płaszcz</string>
+    <string name="today_outfit_bottom_shorts">Szorty</string>
+    <string name="today_outfit_bottom_long_pants">Spodnie</string>
+
+    <string name="insight_lead_today">Dziś</string>
+    <string name="insight_lead_tonight">Wieczorem</string>
+    <string name="insight_band_single">%1$s będzie %2$s.</string>
+    <string name="insight_band_range">%1$s będzie od %2$s do %3$s.</string>
+    <string name="insight_band_freezing">mroźnie</string>
+    <string name="insight_band_cold">zimno</string>
+    <string name="insight_band_cool">chłodno</string>
+    <string name="insight_band_mild">łagodnie</string>
+    <string name="insight_band_warm">ciepło</string>
+    <string name="insight_band_hot">gorąco</string>
+    <string name="insight_delta_warmer">Dziś będzie o %1$d° cieplej.</string>
+    <string name="insight_delta_cooler">Dziś będzie o %1$d° chłodniej.</string>
+    <string name="insight_alert">Ostrzeżenie: %1$s.</string>
+    <string name="insight_clothes_wear">Załóż %1$s.</string>
+    <string name="insight_clothes_article_a">%1$s</string>
+    <string name="insight_clothes_article_an">%1$s</string>
+    <string name="insight_clothes_join_two">%1$s i %2$s</string>
+    <string name="insight_clothes_join_many">%1$s, %2$s i %3$s</string>
+    <string name="insight_precip">%1$s %2$s.</string>
+    <string name="insight_precip_at_time">o %1$s</string>
+    <string name="insight_precip_overnight">w nocy</string>
+    <string name="insight_condition_clear">Słonecznie</string>
+    <string name="insight_condition_partly_cloudy">Częściowe zachmurzenie</string>
+    <string name="insight_condition_cloudy">Pochmurno</string>
+    <string name="insight_condition_fog">Mgła</string>
+    <string name="insight_condition_drizzle">Mżawka</string>
+    <string name="insight_condition_rain">Deszcz</string>
+    <string name="insight_condition_snow">Śnieg</string>
+    <string name="insight_condition_thunderstorm">Burza</string>
+    <string name="insight_condition_unknown">Nieznane</string>
+    <string name="insight_calendar_tie_in">Weź %1$s na %3$s o %2$s.</string>
+</resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+Brazilian Portuguese translation. Scope: insight-prose templates, garment labels,
+clothes-rule editor, outfit-card labels, and region/voice-locale picker names.
+-->
+<resources>
+    <string name="settings_region_language_pt_br">Português (Brasil)</string>
+    <string name="settings_tts_voice_locale_pt_br">Português (Brasil)</string>
+    <string name="settings_tts_voice_locale_label">Idioma</string>
+
+    <string name="garment_sweater">Suéter</string>
+    <string name="garment_hoodie">Moletom com capuz</string>
+    <string name="garment_jacket">Jaqueta</string>
+    <string name="garment_coat">Casaco</string>
+    <string name="garment_tshirt">Camiseta</string>
+    <string name="garment_shirt">Camisa</string>
+    <string name="garment_shorts">Shorts</string>
+    <string name="garment_pants">Calças</string>
+    <string name="garment_jeans">Jeans</string>
+
+    <string name="settings_clothes_empty">Nenhuma regra. Toque em Adicionar para criar uma.</string>
+    <string name="settings_clothes_add">Adicionar</string>
+    <string name="settings_clothes_edit">Editar</string>
+    <string name="settings_clothes_delete">Excluir</string>
+    <string name="settings_clothes_dialog_add_title">Adicionar regra de roupa</string>
+    <string name="settings_clothes_dialog_edit_title">Editar regra de roupa</string>
+    <string name="settings_clothes_item_label">Peça</string>
+    <string name="settings_clothes_condition_label">Condição</string>
+    <string name="settings_clothes_value_label_temp_c">Limite (°C)</string>
+    <string name="settings_clothes_value_label_precip">Limite (%%)</string>
+    <string name="settings_clothes_cond_type_temp_below">Quando a sensação for menor que</string>
+    <string name="settings_clothes_cond_type_temp_above">Quando a sensação for maior que</string>
+    <string name="settings_clothes_cond_type_precip_above">Quando a chance de chuva superar</string>
+    <string name="settings_clothes_cond_temp_below">quando a temperatura sentida for abaixo de %.0f°C</string>
+    <string name="settings_clothes_cond_temp_above">quando a temperatura sentida for acima de %.0f°C</string>
+    <string name="settings_clothes_cond_precip_above">quando a chance de chuva superar %.0f%%</string>
+
+    <string name="today_outfit_top_tshirt">Camiseta</string>
+    <string name="today_outfit_top_sweater">Suéter</string>
+    <string name="today_outfit_top_thick_jacket">Casaco grosso</string>
+    <string name="today_outfit_bottom_shorts">Shorts</string>
+    <string name="today_outfit_bottom_long_pants">Calças</string>
+
+    <string name="insight_lead_today">Hoje</string>
+    <string name="insight_lead_tonight">Esta noite</string>
+    <string name="insight_band_single">%1$s será %2$s.</string>
+    <string name="insight_band_range">%1$s estará entre %2$s e %3$s.</string>
+    <string name="insight_band_freezing">gelado</string>
+    <string name="insight_band_cold">frio</string>
+    <string name="insight_band_cool">fresco</string>
+    <string name="insight_band_mild">ameno</string>
+    <string name="insight_band_warm">quente</string>
+    <string name="insight_band_hot">muito quente</string>
+    <string name="insight_delta_warmer">Hoje estará %1$d° mais quente.</string>
+    <string name="insight_delta_cooler">Hoje estará %1$d° mais frio.</string>
+    <string name="insight_alert">Alerta: %1$s.</string>
+    <string name="insight_clothes_wear">Vista %1$s.</string>
+    <!-- Articles omitted — Portuguese gender agreement requires per-garment metadata. -->
+    <string name="insight_clothes_article_a">%1$s</string>
+    <string name="insight_clothes_article_an">%1$s</string>
+    <string name="insight_clothes_join_two">%1$s e %2$s</string>
+    <string name="insight_clothes_join_many">%1$s, %2$s e %3$s</string>
+    <string name="insight_precip">%1$s %2$s.</string>
+    <string name="insight_precip_at_time">às %1$s</string>
+    <string name="insight_precip_overnight">de madrugada</string>
+    <string name="insight_condition_clear">Céu limpo</string>
+    <string name="insight_condition_partly_cloudy">Parcialmente nublado</string>
+    <string name="insight_condition_cloudy">Nublado</string>
+    <string name="insight_condition_fog">Névoa</string>
+    <string name="insight_condition_drizzle">Garoa</string>
+    <string name="insight_condition_rain">Chuva</string>
+    <string name="insight_condition_snow">Neve</string>
+    <string name="insight_condition_thunderstorm">Tempestade</string>
+    <string name="insight_condition_unknown">Desconhecido</string>
+    <string name="insight_calendar_tie_in">Leve %1$s para seu %3$s às %2$s.</string>
+</resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+Russian translation. Scope: insight-prose templates, garment labels, clothes-rule
+editor, outfit-card labels, and region/voice-locale picker names.
+-->
+<resources>
+    <string name="settings_region_language_ru_ru">Русский (Россия)</string>
+    <string name="settings_tts_voice_locale_ru_ru">Русский (Россия)</string>
+    <string name="settings_tts_voice_locale_label">Язык</string>
+
+    <string name="garment_sweater">Свитер</string>
+    <string name="garment_hoodie">Худи</string>
+    <string name="garment_jacket">Куртка</string>
+    <string name="garment_coat">Пальто</string>
+    <string name="garment_tshirt">Футболка</string>
+    <string name="garment_shirt">Рубашка</string>
+    <string name="garment_shorts">Шорты</string>
+    <string name="garment_pants">Брюки</string>
+    <string name="garment_jeans">Джинсы</string>
+
+    <string name="settings_clothes_empty">Нет правил. Нажмите «Добавить», чтобы создать.</string>
+    <string name="settings_clothes_add">Добавить</string>
+    <string name="settings_clothes_edit">Изменить</string>
+    <string name="settings_clothes_delete">Удалить</string>
+    <string name="settings_clothes_dialog_add_title">Добавить правило одежды</string>
+    <string name="settings_clothes_dialog_edit_title">Изменить правило одежды</string>
+    <string name="settings_clothes_item_label">Одежда</string>
+    <string name="settings_clothes_condition_label">Условие</string>
+    <string name="settings_clothes_value_label_temp_c">Порог (°C)</string>
+    <string name="settings_clothes_value_label_precip">Порог (%%)</string>
+    <string name="settings_clothes_cond_type_temp_below">Когда ощущается холоднее</string>
+    <string name="settings_clothes_cond_type_temp_above">Когда ощущается теплее</string>
+    <string name="settings_clothes_cond_type_precip_above">Когда вероятность дождя превышает</string>
+    <string name="settings_clothes_cond_temp_below">когда ощущаемая температура ниже %.0f°C</string>
+    <string name="settings_clothes_cond_temp_above">когда ощущаемая температура выше %.0f°C</string>
+    <string name="settings_clothes_cond_precip_above">когда вероятность дождя превышает %.0f%%</string>
+
+    <string name="today_outfit_top_tshirt">Футболка</string>
+    <string name="today_outfit_top_sweater">Свитер</string>
+    <string name="today_outfit_top_thick_jacket">Тёплая куртка</string>
+    <string name="today_outfit_bottom_shorts">Шорты</string>
+    <string name="today_outfit_bottom_long_pants">Брюки</string>
+
+    <string name="insight_lead_today">Сегодня</string>
+    <string name="insight_lead_tonight">Сегодня вечером</string>
+    <string name="insight_band_single">%1$s будет %2$s.</string>
+    <string name="insight_band_range">%1$s будет от %2$s до %3$s.</string>
+    <string name="insight_band_freezing">морозно</string>
+    <string name="insight_band_cold">холодно</string>
+    <string name="insight_band_cool">прохладно</string>
+    <string name="insight_band_mild">тепло</string>
+    <string name="insight_band_warm">жарко</string>
+    <string name="insight_band_hot">очень жарко</string>
+    <string name="insight_delta_warmer">Сегодня на %1$d° теплее.</string>
+    <string name="insight_delta_cooler">Сегодня на %1$d° холоднее.</string>
+    <string name="insight_alert">Предупреждение: %1$s.</string>
+    <string name="insight_clothes_wear">Наденьте %1$s.</string>
+    <string name="insight_clothes_article_a">%1$s</string>
+    <string name="insight_clothes_article_an">%1$s</string>
+    <string name="insight_clothes_join_two">%1$s и %2$s</string>
+    <string name="insight_clothes_join_many">%1$s, %2$s и %3$s</string>
+    <string name="insight_precip">%1$s %2$s.</string>
+    <string name="insight_precip_at_time">в %1$s</string>
+    <string name="insight_precip_overnight">ночью</string>
+    <string name="insight_condition_clear">Ясно</string>
+    <string name="insight_condition_partly_cloudy">Переменная облачность</string>
+    <string name="insight_condition_cloudy">Облачно</string>
+    <string name="insight_condition_fog">Туман</string>
+    <string name="insight_condition_drizzle">Морось</string>
+    <string name="insight_condition_rain">Дождь</string>
+    <string name="insight_condition_snow">Снег</string>
+    <string name="insight_condition_thunderstorm">Гроза</string>
+    <string name="insight_condition_unknown">Неизвестно</string>
+    <string name="insight_calendar_tie_in">Возьмите %1$s на %3$s в %2$s.</string>
+</resources>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+Swedish translation. Scope: insight-prose templates, garment labels, clothes-rule
+editor, outfit-card labels, and region/voice-locale picker names.
+-->
+<resources>
+    <string name="settings_region_language_sv_se">Svenska (Sverige)</string>
+    <string name="settings_tts_voice_locale_sv_se">Svenska (Sverige)</string>
+    <string name="settings_tts_voice_locale_label">Språk</string>
+
+    <string name="garment_sweater">Tröja</string>
+    <string name="garment_hoodie">Huvtröja</string>
+    <string name="garment_jacket">Jacka</string>
+    <string name="garment_coat">Kappa</string>
+    <string name="garment_tshirt">T-shirt</string>
+    <string name="garment_shirt">Skjorta</string>
+    <string name="garment_shorts">Shorts</string>
+    <string name="garment_pants">Byxor</string>
+    <string name="garment_jeans">Jeans</string>
+
+    <string name="settings_clothes_empty">Inga regler. Tryck på Lägg till för att skapa en.</string>
+    <string name="settings_clothes_add">Lägg till</string>
+    <string name="settings_clothes_edit">Redigera</string>
+    <string name="settings_clothes_delete">Ta bort</string>
+    <string name="settings_clothes_dialog_add_title">Lägg till klädregel</string>
+    <string name="settings_clothes_dialog_edit_title">Redigera klädregel</string>
+    <string name="settings_clothes_item_label">Klädesplagg</string>
+    <string name="settings_clothes_condition_label">Villkor</string>
+    <string name="settings_clothes_value_label_temp_c">Tröskel (°C)</string>
+    <string name="settings_clothes_value_label_precip">Tröskel (%%)</string>
+    <string name="settings_clothes_cond_type_temp_below">När det känns kallare än</string>
+    <string name="settings_clothes_cond_type_temp_above">När det känns varmare än</string>
+    <string name="settings_clothes_cond_type_precip_above">När risken för regn överstiger</string>
+    <string name="settings_clothes_cond_temp_below">när upplevd temperatur är under %.0f°C</string>
+    <string name="settings_clothes_cond_temp_above">när upplevd temperatur är över %.0f°C</string>
+    <string name="settings_clothes_cond_precip_above">när risken för regn överstiger %.0f%%</string>
+
+    <string name="today_outfit_top_tshirt">T-shirt</string>
+    <string name="today_outfit_top_sweater">Tröja</string>
+    <string name="today_outfit_top_thick_jacket">Tjock jacka</string>
+    <string name="today_outfit_bottom_shorts">Shorts</string>
+    <string name="today_outfit_bottom_long_pants">Byxor</string>
+
+    <string name="insight_lead_today">Idag</string>
+    <string name="insight_lead_tonight">I kväll</string>
+    <!-- Swedish V2 word order: "Idag blir det milt." -->
+    <string name="insight_band_single">%1$s blir det %2$s.</string>
+    <string name="insight_band_range">%1$s blir det %2$s till %3$s.</string>
+    <string name="insight_band_freezing">iskallt</string>
+    <string name="insight_band_cold">kallt</string>
+    <string name="insight_band_cool">svalt</string>
+    <string name="insight_band_mild">milt</string>
+    <string name="insight_band_warm">varmt</string>
+    <string name="insight_band_hot">mycket varmt</string>
+    <string name="insight_delta_warmer">Det blir %1$d° varmare idag.</string>
+    <string name="insight_delta_cooler">Det blir %1$d° kallare idag.</string>
+    <string name="insight_alert">Varning: %1$s.</string>
+    <string name="insight_clothes_wear">Ta på %1$s.</string>
+    <string name="insight_clothes_article_a">%1$s</string>
+    <string name="insight_clothes_article_an">%1$s</string>
+    <string name="insight_clothes_join_two">%1$s och %2$s</string>
+    <string name="insight_clothes_join_many">%1$s, %2$s och %3$s</string>
+    <string name="insight_precip">%1$s %2$s.</string>
+    <string name="insight_precip_at_time">klockan %1$s</string>
+    <string name="insight_precip_overnight">under natten</string>
+    <string name="insight_condition_clear">Klart</string>
+    <string name="insight_condition_partly_cloudy">Delvis molnigt</string>
+    <string name="insight_condition_cloudy">Molnigt</string>
+    <string name="insight_condition_fog">Dimma</string>
+    <string name="insight_condition_drizzle">Duggregn</string>
+    <string name="insight_condition_rain">Regn</string>
+    <string name="insight_condition_snow">Snö</string>
+    <string name="insight_condition_thunderstorm">Åskväder</string>
+    <string name="insight_condition_unknown">Okänt</string>
+    <string name="insight_calendar_tie_in">Ta med %1$s till din %3$s klockan %2$s.</string>
+</resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+Turkish translation. Scope: insight-prose templates, garment labels, clothes-rule
+editor, outfit-card labels, and region/voice-locale picker names.
+-->
+<resources>
+    <string name="settings_region_language_tr_tr">Türkçe (Türkiye)</string>
+    <string name="settings_tts_voice_locale_tr_tr">Türkçe (Türkiye)</string>
+    <string name="settings_tts_voice_locale_label">Dil</string>
+
+    <string name="garment_sweater">Kazak</string>
+    <string name="garment_hoodie">Kapüşonlu sweatshirt</string>
+    <string name="garment_jacket">Ceket</string>
+    <string name="garment_coat">Kaban</string>
+    <string name="garment_tshirt">Tişört</string>
+    <string name="garment_shirt">Gömlek</string>
+    <string name="garment_shorts">Şort</string>
+    <string name="garment_pants">Pantolon</string>
+    <string name="garment_jeans">Kot pantolon</string>
+
+    <string name="settings_clothes_empty">Kural yok. Oluşturmak için Ekle\'ye dokunun.</string>
+    <string name="settings_clothes_add">Ekle</string>
+    <string name="settings_clothes_edit">Düzenle</string>
+    <string name="settings_clothes_delete">Sil</string>
+    <string name="settings_clothes_dialog_add_title">Giysi kuralı ekle</string>
+    <string name="settings_clothes_dialog_edit_title">Giysi kuralını düzenle</string>
+    <string name="settings_clothes_item_label">Giysi</string>
+    <string name="settings_clothes_condition_label">Koşul</string>
+    <string name="settings_clothes_value_label_temp_c">Eşik (°C)</string>
+    <string name="settings_clothes_value_label_precip">Eşik (%%)</string>
+    <string name="settings_clothes_cond_type_temp_below">Hissedilen sıcaklık şundan düşükse</string>
+    <string name="settings_clothes_cond_type_temp_above">Hissedilen sıcaklık şundan yüksekse</string>
+    <string name="settings_clothes_cond_type_precip_above">Yağmur ihtimali şunu aşarsa</string>
+    <string name="settings_clothes_cond_temp_below">hissedilen sıcaklık %.0f°C\'nin altındaysa</string>
+    <string name="settings_clothes_cond_temp_above">hissedilen sıcaklık %.0f°C\'nin üstündeyse</string>
+    <string name="settings_clothes_cond_precip_above">yağmur ihtimali %.0f%% üzerindeyse</string>
+
+    <string name="today_outfit_top_tshirt">Tişört</string>
+    <string name="today_outfit_top_sweater">Kazak</string>
+    <string name="today_outfit_top_thick_jacket">Kalın kaban</string>
+    <string name="today_outfit_bottom_shorts">Şort</string>
+    <string name="today_outfit_bottom_long_pants">Pantolon</string>
+
+    <string name="insight_lead_today">Bugün</string>
+    <string name="insight_lead_tonight">Bu gece</string>
+    <!-- Turkish SOV word order: subject-object-verb; predicate at the end. -->
+    <string name="insight_band_single">%1$s %2$s olacak.</string>
+    <string name="insight_band_range">%1$s %2$s ile %3$s arasında olacak.</string>
+    <string name="insight_band_freezing">dondurucu soğuk</string>
+    <string name="insight_band_cold">soğuk</string>
+    <string name="insight_band_cool">serin</string>
+    <string name="insight_band_mild">ılıman</string>
+    <string name="insight_band_warm">sıcak</string>
+    <string name="insight_band_hot">çok sıcak</string>
+    <string name="insight_delta_warmer">Bugün %1$d° daha sıcak olacak.</string>
+    <string name="insight_delta_cooler">Bugün %1$d° daha soğuk olacak.</string>
+    <string name="insight_alert">Uyarı: %1$s.</string>
+    <string name="insight_clothes_wear">%1$s giy.</string>
+    <string name="insight_clothes_article_a">%1$s</string>
+    <string name="insight_clothes_article_an">%1$s</string>
+    <string name="insight_clothes_join_two">%1$s ve %2$s</string>
+    <string name="insight_clothes_join_many">%1$s, %2$s ve %3$s</string>
+    <string name="insight_precip">%1$s %2$s.</string>
+    <string name="insight_precip_at_time">saat %1$s\'de</string>
+    <string name="insight_precip_overnight">gece boyunca</string>
+    <string name="insight_condition_clear">Açık</string>
+    <string name="insight_condition_partly_cloudy">Parçalı bulutlu</string>
+    <string name="insight_condition_cloudy">Bulutlu</string>
+    <string name="insight_condition_fog">Sis</string>
+    <string name="insight_condition_drizzle">Çiseleme</string>
+    <string name="insight_condition_rain">Yağmur</string>
+    <string name="insight_condition_snow">Kar</string>
+    <string name="insight_condition_thunderstorm">Fırtına</string>
+    <string name="insight_condition_unknown">Bilinmiyor</string>
+    <string name="insight_calendar_tie_in">%2$s\'deki %3$s için %1$s al.</string>
+</resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+Ukrainian translation. Scope: insight-prose templates, garment labels, clothes-rule
+editor, outfit-card labels, and region/voice-locale picker names.
+-->
+<resources>
+    <string name="settings_region_language_uk_ua">Українська (Україна)</string>
+    <string name="settings_tts_voice_locale_uk_ua">Українська (Україна)</string>
+    <string name="settings_tts_voice_locale_label">Мова</string>
+
+    <string name="garment_sweater">Светр</string>
+    <string name="garment_hoodie">Худі</string>
+    <string name="garment_jacket">Куртка</string>
+    <string name="garment_coat">Пальто</string>
+    <string name="garment_tshirt">Футболка</string>
+    <string name="garment_shirt">Сорочка</string>
+    <string name="garment_shorts">Шорти</string>
+    <string name="garment_pants">Штани</string>
+    <string name="garment_jeans">Джинси</string>
+
+    <string name="settings_clothes_empty">Немає правил. Натисніть «Додати», щоб створити.</string>
+    <string name="settings_clothes_add">Додати</string>
+    <string name="settings_clothes_edit">Редагувати</string>
+    <string name="settings_clothes_delete">Видалити</string>
+    <string name="settings_clothes_dialog_add_title">Додати правило одягу</string>
+    <string name="settings_clothes_dialog_edit_title">Редагувати правило одягу</string>
+    <string name="settings_clothes_item_label">Одяг</string>
+    <string name="settings_clothes_condition_label">Умова</string>
+    <string name="settings_clothes_value_label_temp_c">Поріг (°C)</string>
+    <string name="settings_clothes_value_label_precip">Поріг (%%)</string>
+    <string name="settings_clothes_cond_type_temp_below">Коли відчувається холодніше</string>
+    <string name="settings_clothes_cond_type_temp_above">Коли відчувається тепліше</string>
+    <string name="settings_clothes_cond_type_precip_above">Коли ймовірність дощу перевищує</string>
+    <string name="settings_clothes_cond_temp_below">коли відчувана температура нижче %.0f°C</string>
+    <string name="settings_clothes_cond_temp_above">коли відчувана температура вище %.0f°C</string>
+    <string name="settings_clothes_cond_precip_above">коли ймовірність дощу перевищує %.0f%%</string>
+
+    <string name="today_outfit_top_tshirt">Футболка</string>
+    <string name="today_outfit_top_sweater">Светр</string>
+    <string name="today_outfit_top_thick_jacket">Тепла куртка</string>
+    <string name="today_outfit_bottom_shorts">Шорти</string>
+    <string name="today_outfit_bottom_long_pants">Штани</string>
+
+    <string name="insight_lead_today">Сьогодні</string>
+    <string name="insight_lead_tonight">Сьогодні ввечері</string>
+    <string name="insight_band_single">%1$s буде %2$s.</string>
+    <string name="insight_band_range">%1$s буде від %2$s до %3$s.</string>
+    <string name="insight_band_freezing">морозно</string>
+    <string name="insight_band_cold">холодно</string>
+    <string name="insight_band_cool">прохолодно</string>
+    <string name="insight_band_mild">тепло</string>
+    <string name="insight_band_warm">жарко</string>
+    <string name="insight_band_hot">дуже спекотно</string>
+    <string name="insight_delta_warmer">Сьогодні на %1$d° тепліше.</string>
+    <string name="insight_delta_cooler">Сьогодні на %1$d° холодніше.</string>
+    <string name="insight_alert">Попередження: %1$s.</string>
+    <string name="insight_clothes_wear">Одягніть %1$s.</string>
+    <string name="insight_clothes_article_a">%1$s</string>
+    <string name="insight_clothes_article_an">%1$s</string>
+    <string name="insight_clothes_join_two">%1$s та %2$s</string>
+    <string name="insight_clothes_join_many">%1$s, %2$s та %3$s</string>
+    <string name="insight_precip">%1$s %2$s.</string>
+    <string name="insight_precip_at_time">о %1$s</string>
+    <string name="insight_precip_overnight">вночі</string>
+    <string name="insight_condition_clear">Ясно</string>
+    <string name="insight_condition_partly_cloudy">Мінлива хмарність</string>
+    <string name="insight_condition_cloudy">Хмарно</string>
+    <string name="insight_condition_fog">Туман</string>
+    <string name="insight_condition_drizzle">Мряка</string>
+    <string name="insight_condition_rain">Дощ</string>
+    <string name="insight_condition_snow">Сніг</string>
+    <string name="insight_condition_thunderstorm">Гроза</string>
+    <string name="insight_condition_unknown">Невідомо</string>
+    <string name="insight_calendar_tie_in">Візьміть %1$s на %3$s о %2$s.</string>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -126,7 +126,21 @@
     <string name="settings_tts_voice_locale_en_us">English (United States)</string>
     <string name="settings_tts_voice_locale_en_gb">English (United Kingdom)</string>
     <string name="settings_tts_voice_locale_en_au">English (Australia)</string>
+    <string name="settings_tts_voice_locale_en_ca">English (Canada)</string>
     <string name="settings_tts_voice_locale_de_de">German (Germany)</string>
+    <string name="settings_tts_voice_locale_fr_fr">French (France)</string>
+    <string name="settings_tts_voice_locale_fr_ca">French (Canada)</string>
+    <string name="settings_tts_voice_locale_it_it">Italian (Italy)</string>
+    <string name="settings_tts_voice_locale_es_es">Spanish (Spain)</string>
+    <string name="settings_tts_voice_locale_es_mx">Spanish (Mexico)</string>
+    <string name="settings_tts_voice_locale_ru_ru">Russian (Russia)</string>
+    <string name="settings_tts_voice_locale_pl_pl">Polish (Poland)</string>
+    <string name="settings_tts_voice_locale_hr_hr">Croatian (Croatia)</string>
+    <string name="settings_tts_voice_locale_uk_ua">Ukrainian (Ukraine)</string>
+    <string name="settings_tts_voice_locale_pt_br">Portuguese (Brazil)</string>
+    <string name="settings_tts_voice_locale_nl_nl">Dutch (Netherlands)</string>
+    <string name="settings_tts_voice_locale_sv_se">Swedish (Sweden)</string>
+    <string name="settings_tts_voice_locale_tr_tr">Turkish (Turkey)</string>
     <string name="settings_tts_test">Test voice</string>
     <!-- Shown next to the engine picker when the chosen engine's API key isn't
          configured. %1$s is the engine name ("Gemini" / "OpenAI" / "ElevenLabs"). -->
@@ -157,7 +171,21 @@
     <string name="settings_region_language_en_us">English (United States)</string>
     <string name="settings_region_language_en_gb">English (United Kingdom)</string>
     <string name="settings_region_language_en_au">English (Australia)</string>
+    <string name="settings_region_language_en_ca">English (Canada)</string>
     <string name="settings_region_language_de_de">German (Germany)</string>
+    <string name="settings_region_language_fr_fr">French (France)</string>
+    <string name="settings_region_language_fr_ca">French (Canada)</string>
+    <string name="settings_region_language_it_it">Italian (Italy)</string>
+    <string name="settings_region_language_es_es">Spanish (Spain)</string>
+    <string name="settings_region_language_es_mx">Spanish (Mexico)</string>
+    <string name="settings_region_language_ru_ru">Russian (Russia)</string>
+    <string name="settings_region_language_pl_pl">Polish (Poland)</string>
+    <string name="settings_region_language_hr_hr">Croatian (Croatia)</string>
+    <string name="settings_region_language_uk_ua">Ukrainian (Ukraine)</string>
+    <string name="settings_region_language_pt_br">Portuguese (Brazil)</string>
+    <string name="settings_region_language_nl_nl">Dutch (Netherlands)</string>
+    <string name="settings_region_language_sv_se">Swedish (Sweden)</string>
+    <string name="settings_region_language_tr_tr">Turkish (Turkey)</string>
 
     <string name="settings_temperature_unit_title">Temperature unit</string>
     <string name="settings_temperature_unit_celsius">Celsius (°C)</string>

--- a/core/data/src/main/kotlin/app/clothescast/core/data/tts/GeminiTtsClient.kt
+++ b/core/data/src/main/kotlin/app/clothescast/core/data/tts/GeminiTtsClient.kt
@@ -68,12 +68,26 @@ private val ACCENT_DIRECTIVES: Map<String, String> = mapOf(
     "en-GB" to "Speak with a Standard Southern British accent.",
     "en-AU" to "Speak with a General Australian accent.",
     "en-US" to "Speak with a General American accent.",
+    "en-CA" to "Speak with a Canadian English accent.",
     // Language-only entry — Gemini follows the directive *language* even though
     // the prompt itself is English, so the synthesised audio is in German. The
     // German prose comes from the `:app` formatter once the user's Region is
     // set to DE_DE; this directive just nudges the model to read it as German
     // rather than mangling it through an English phoneme pipeline.
     "de" to "Sprich auf Deutsch in einem klaren, hochdeutschen Akzent.",
+    "fr-FR" to "Parle en français de France avec un accent parisien clair.",
+    "fr-CA" to "Parle en français québécois avec un accent canadien-français.",
+    "it" to "Parla in italiano con un accento italiano chiaro e naturale.",
+    "es-ES" to "Habla en español de España con un acento castellano claro.",
+    "es-MX" to "Habla en español mexicano con un acento neutro y claro.",
+    "ru" to "Говори по-русски с чётким литературным произношением.",
+    "pl" to "Mów po polsku z wyraźną i naturalną wymową.",
+    "hr" to "Govori na hrvatskom jeziku s jasnim i prirodnim izgovorom.",
+    "uk" to "Говори українською мовою з чітким літературним вимовленням.",
+    "pt-BR" to "Fale em português brasileiro com sotaque neutro e claro.",
+    "nl" to "Spreek in het Nederlands met een duidelijk en natuurlijk accent.",
+    "sv" to "Tala på svenska med ett tydligt och naturligt uttal.",
+    "tr" to "Türkçe konuş, net ve doğal bir Türkçe aksanıyla.",
 )
 
 /**

--- a/core/data/src/test/kotlin/app/clothescast/core/data/tts/GeminiTtsClientTest.kt
+++ b/core/data/src/test/kotlin/app/clothescast/core/data/tts/GeminiTtsClientTest.kt
@@ -165,7 +165,7 @@ class GeminiTtsClientTest {
 
     @Test
     fun `request body omits the accent directive for unknown english variants`() = runTest {
-        // en-CA isn't in our supported variant list — fall through to whatever the
+        // en-NZ isn't in our supported variant list — fall through to whatever the
         // model defaults to rather than picking a wrong-but-confident accent.
         var capturedBody: String? = null
         val client = GeminiTtsClient(
@@ -177,7 +177,7 @@ class GeminiTtsClientTest {
             keyProvider = FakeKeyProvider("test-key"),
         )
 
-        client.synthesize(text = "hello", locale = Locale.forLanguageTag("en-CA"))
+        client.synthesize(text = "hello", locale = Locale.forLanguageTag("en-NZ"))
 
         val body = checkNotNull(capturedBody)
         // No accent directive at all — none of the SSB / General Australian /

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Settings.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Settings.kt
@@ -51,7 +51,21 @@ enum class VoiceLocale(val bcp47: String?) {
     EN_US("en-US"),
     EN_GB("en-GB"),
     EN_AU("en-AU"),
+    EN_CA("en-CA"),
     DE_DE("de-DE"),
+    FR_FR("fr-FR"),
+    FR_CA("fr-CA"),
+    IT_IT("it-IT"),
+    ES_ES("es-ES"),
+    ES_MX("es-MX"),
+    RU_RU("ru-RU"),
+    PL_PL("pl-PL"),
+    HR_HR("hr-HR"),
+    UK_UA("uk-UA"),
+    PT_BR("pt-BR"),
+    NL_NL("nl-NL"),
+    SV_SE("sv-SE"),
+    TR_TR("tr-TR"),
 }
 
 /**
@@ -73,7 +87,21 @@ enum class Region(val bcp47: String?) {
     EN_US("en-US"),
     EN_GB("en-GB"),
     EN_AU("en-AU"),
+    EN_CA("en-CA"),
     DE_DE("de-DE"),
+    FR_FR("fr-FR"),
+    FR_CA("fr-CA"),
+    IT_IT("it-IT"),
+    ES_ES("es-ES"),
+    ES_MX("es-MX"),
+    RU_RU("ru-RU"),
+    PL_PL("pl-PL"),
+    HR_HR("hr-HR"),
+    UK_UA("uk-UA"),
+    PT_BR("pt-BR"),
+    NL_NL("nl-NL"),
+    SV_SE("sv-SE"),
+    TR_TR("tr-TR"),
 }
 
 data class UserPreferences(


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds 14 new entries to both the `Region` and `VoiceLocale` enums: English (Canada), French (France), French (Canada), Italian, Spanish (Spain), Spanish (Mexico), Russian, Polish, Croatian, Ukrainian, Portuguese (Brazil), Dutch, Swedish, Turkish
- Each language gets a `values-XX/strings.xml` with translated insight prose, garment names, outfit-card labels, and clothes-rule editor strings — same scope as the existing German translation
- French (Canada) and Spanish (Mexico) are shallow override folders on top of `values-fr` / `values-es` (only vocabulary that native speakers would notice as wrong)
- Gemini TTS accent directives added for all new locales in `GeminiTtsClient.kt`
- `regionLabel()` and `voiceLocaleLabel()` `when` expressions updated; both are exhaustive so the compiler enforces completeness

## Notes on approach

- Languages with grammatical gender (French, Italian, Spanish, Portuguese) omit articles from `insight_clothes_article_a/an` — a flat comma-separated list reads naturally without per-garment gender metadata (same approach as German)
- Dutch and Swedish get V2 word-order templates (`Vandaag wordt het mild.` / `Idag blir det milt.`) matching their grammar
- Turkish gets SOV ordering in the band template (`Bugün ılıman olacak.`)
- Non-English locales use 24h time in `InsightFormatter` (no `insight_time_*` keys needed, same as German)

## Test plan

- [ ] Build passes (`assembleDebug`)
- [ ] Region picker shows all 19 options (System + 18 explicit) in English
- [ ] Selecting e.g. French (France) renders the Region picker label in French (`Français (France)`)
- [ ] Voice locale picker shows all 19 options; labels localise when the app language changes
- [ ] Morning insight prose renders in the selected language when Region is set
- [ ] Gemini TTS test plays back in the correct language/accent
- [ ] French (Canada) uses "Chandail" not "Pull" for sweater
- [ ] Spanish (Mexico) uses "Playera"/"Suéter"/"Mezclilla" not "Camiseta"/"Jersey"/"Vaqueros"

https://claude.ai/code/session_019ZFqfAA5UykN1MiD8S48oU
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_019ZFqfAA5UykN1MiD8S48oU)_