### PR TITLE
:app + :core — add en-ZA, Indonesian, Filipino, Vietnamese language support

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/settings/RegionSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/RegionSettings.kt
@@ -84,6 +84,10 @@ private fun regionLabel(region: Region): Int = when (region) {
     Region.NL_NL -> R.string.settings_region_language_nl_nl
     Region.SV_SE -> R.string.settings_region_language_sv_se
     Region.TR_TR -> R.string.settings_region_language_tr_tr
+    Region.EN_ZA -> R.string.settings_region_language_en_za
+    Region.ID_ID -> R.string.settings_region_language_id_id
+    Region.FIL_PH -> R.string.settings_region_language_fil_ph
+    Region.VI_VN -> R.string.settings_region_language_vi_vn
 }
 
 private fun temperatureUnitLabel(unit: TemperatureUnit): Int = when (unit) {

--- a/app/src/main/kotlin/app/clothescast/ui/settings/VoiceSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/VoiceSettings.kt
@@ -351,6 +351,10 @@ private fun voiceLocaleLabel(locale: VoiceLocale): Int = when (locale) {
     VoiceLocale.NL_NL -> R.string.settings_tts_voice_locale_nl_nl
     VoiceLocale.SV_SE -> R.string.settings_tts_voice_locale_sv_se
     VoiceLocale.TR_TR -> R.string.settings_tts_voice_locale_tr_tr
+    VoiceLocale.EN_ZA -> R.string.settings_tts_voice_locale_en_za
+    VoiceLocale.ID_ID -> R.string.settings_tts_voice_locale_id_id
+    VoiceLocale.FIL_PH -> R.string.settings_tts_voice_locale_fil_ph
+    VoiceLocale.VI_VN -> R.string.settings_tts_voice_locale_vi_vn
 }
 
 @Composable

--- a/app/src/main/res/values-en-rZA/strings.xml
+++ b/app/src/main/res/values-en-rZA/strings.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+English (South Africa) overrides. Scope: vocabulary differences from en-US.
+Insight prose templates are identical to English so they fall through to
+values/strings.xml. Only garment names and outfit labels with local vocabulary
+are overridden here.
+-->
+<resources>
+    <string name="settings_region_language_en_za">English (South Africa)</string>
+    <string name="settings_tts_voice_locale_en_za">English (South Africa)</string>
+
+    <!-- South African English uses "jersey" for sweater and "trousers" for
+         long pants (both lower and upper clothing pieces follow local usage). -->
+    <string name="garment_sweater">Jersey</string>
+    <string name="garment_pants">Trousers</string>
+
+    <string name="today_outfit_top_sweater">Jersey</string>
+    <string name="today_outfit_bottom_long_pants">Trousers</string>
+</resources>

--- a/app/src/main/res/values-fil/strings.xml
+++ b/app/src/main/res/values-fil/strings.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+Filipino translation. Scope: insight-prose templates, garment labels,
+clothes-rule editor, outfit-card labels, and region/voice-locale picker names.
+The rest of the UI falls through to values/strings.xml (English).
+-->
+<resources>
+    <string name="settings_region_language_fil_ph">Filipino (Pilipinas)</string>
+    <string name="settings_tts_voice_locale_fil_ph">Filipino (Pilipinas)</string>
+    <string name="settings_tts_voice_locale_label">Wika</string>
+
+    <string name="garment_sweater">Sweater</string>
+    <string name="garment_hoodie">Hoodie</string>
+    <string name="garment_jacket">Jacket</string>
+    <string name="garment_coat">Makapal na amerikana</string>
+    <string name="garment_tshirt">T-shirt</string>
+    <string name="garment_shirt">Polo</string>
+    <string name="garment_shorts">Short</string>
+    <string name="garment_pants">Mahabang pantalon</string>
+    <string name="garment_jeans">Maong</string>
+
+    <string name="settings_clothes_empty">Wala pang panuntunan. I-tap ang Magdagdag para lumikha.</string>
+    <string name="settings_clothes_add">Magdagdag</string>
+    <string name="settings_clothes_edit">I-edit</string>
+    <string name="settings_clothes_delete">Burahin</string>
+    <string name="settings_clothes_dialog_add_title">Magdagdag ng panuntunan sa damit</string>
+    <string name="settings_clothes_dialog_edit_title">I-edit ang panuntunan sa damit</string>
+    <string name="settings_clothes_item_label">Damit</string>
+    <string name="settings_clothes_condition_label">Kondisyon</string>
+    <string name="settings_clothes_value_label_temp_c">Limitasyon (°C)</string>
+    <string name="settings_clothes_value_label_precip">Limitasyon (%%)</string>
+    <string name="settings_clothes_cond_type_temp_below">Kapag malamig nang mas mababa sa</string>
+    <string name="settings_clothes_cond_type_temp_above">Kapag mainit nang higit sa</string>
+    <string name="settings_clothes_cond_type_precip_above">Kapag ang tsansa ng ulan ay higit sa</string>
+    <string name="settings_clothes_cond_temp_below">kapag ang nararamdamang pinakamababang temperatura ay mas mababa sa %.0f°C</string>
+    <string name="settings_clothes_cond_temp_above">kapag ang nararamdamang pinakamataas na temperatura ay higit sa %.0f°C</string>
+    <string name="settings_clothes_cond_precip_above">kapag ang tsansa ng ulan ay higit sa %.0f%%</string>
+
+    <string name="today_outfit_top_tshirt">T-shirt</string>
+    <string name="today_outfit_top_sweater">Sweater</string>
+    <string name="today_outfit_top_thick_jacket">Makapal na jacket</string>
+    <string name="today_outfit_bottom_shorts">Short</string>
+    <string name="today_outfit_bottom_long_pants">Mahabang pantalon</string>
+
+    <string name="insight_lead_today">Ngayon</string>
+    <string name="insight_lead_tonight">Ngayong gabi</string>
+    <!-- Filipino: "Ngayon, magiging malamig." -->
+    <string name="insight_band_single">%1$s, magiging %2$s.</string>
+    <string name="insight_band_range">%1$s, magiging %2$s hanggang %3$s.</string>
+    <string name="insight_band_freezing">napakalamig</string>
+    <string name="insight_band_cold">malamig</string>
+    <string name="insight_band_cool">medyo malamig</string>
+    <string name="insight_band_mild">katamtaman</string>
+    <string name="insight_band_warm">mainit-init</string>
+    <string name="insight_band_hot">mainit</string>
+    <string name="insight_delta_warmer">Ngayon ay %1$d° mas mainit.</string>
+    <string name="insight_delta_cooler">Ngayon ay %1$d° mas malamig.</string>
+    <string name="insight_alert">Babala: %1$s.</string>
+    <string name="insight_clothes_wear">Magsuot ng %1$s.</string>
+    <!-- Filipino particles ("ng") are omitted in list context for naturalness. -->
+    <string name="insight_clothes_article_a">%1$s</string>
+    <string name="insight_clothes_article_an">%1$s</string>
+    <string name="insight_clothes_join_two">%1$s at %2$s</string>
+    <string name="insight_clothes_join_many">%1$s, %2$s, at %3$s</string>
+    <string name="insight_precip">%1$s %2$s.</string>
+    <string name="insight_precip_at_time">ng %1$s</string>
+    <string name="insight_precip_overnight">buong gabi</string>
+    <string name="insight_condition_clear">Maliwanag</string>
+    <string name="insight_condition_partly_cloudy">Bahagyang maulap</string>
+    <string name="insight_condition_cloudy">Maulap</string>
+    <string name="insight_condition_fog">Hamog</string>
+    <string name="insight_condition_drizzle">Ambon</string>
+    <string name="insight_condition_rain">Ulan</string>
+    <string name="insight_condition_snow">Niyebe</string>
+    <string name="insight_condition_thunderstorm">Bagyo</string>
+    <string name="insight_condition_unknown">Hindi kilala</string>
+    <string name="insight_calendar_tie_in">Magdala ng %1$s para sa %3$s ng %2$s.</string>
+</resources>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+Indonesian translation. Resource folder is values-in/ because Android maps
+the ISO 639-1 code "id" to legacy Java code "in" for locale resolution.
+Scope: insight-prose templates, garment labels, clothes-rule editor, outfit-card
+labels, and region/voice-locale picker names. The rest of the UI falls through
+to values/strings.xml (English).
+-->
+<resources>
+    <string name="settings_region_language_id_id">Indonesia</string>
+    <string name="settings_tts_voice_locale_id_id">Indonesia</string>
+    <string name="settings_tts_voice_locale_label">Bahasa</string>
+
+    <string name="garment_sweater">Sweater</string>
+    <string name="garment_hoodie">Hoodie</string>
+    <string name="garment_jacket">Jaket</string>
+    <string name="garment_coat">Mantel</string>
+    <string name="garment_tshirt">Kaos</string>
+    <string name="garment_shirt">Kemeja</string>
+    <string name="garment_shorts">Celana pendek</string>
+    <string name="garment_pants">Celana panjang</string>
+    <string name="garment_jeans">Celana jeans</string>
+
+    <string name="settings_clothes_empty">Belum ada aturan. Ketuk Tambah untuk membuat satu.</string>
+    <string name="settings_clothes_add">Tambah</string>
+    <string name="settings_clothes_edit">Edit</string>
+    <string name="settings_clothes_delete">Hapus</string>
+    <string name="settings_clothes_dialog_add_title">Tambah aturan pakaian</string>
+    <string name="settings_clothes_dialog_edit_title">Edit aturan pakaian</string>
+    <string name="settings_clothes_item_label">Pakaian</string>
+    <string name="settings_clothes_condition_label">Pemicu</string>
+    <string name="settings_clothes_value_label_temp_c">Ambang batas (°C)</string>
+    <string name="settings_clothes_value_label_precip">Ambang batas (%%)</string>
+    <string name="settings_clothes_cond_type_temp_below">Ketika terasa lebih dingin dari</string>
+    <string name="settings_clothes_cond_type_temp_above">Ketika terasa lebih panas dari</string>
+    <string name="settings_clothes_cond_type_precip_above">Ketika kemungkinan hujan di atas</string>
+    <string name="settings_clothes_cond_temp_below">ketika suhu terasa di bawah %.0f°C</string>
+    <string name="settings_clothes_cond_temp_above">ketika suhu terasa di atas %.0f°C</string>
+    <string name="settings_clothes_cond_precip_above">ketika kemungkinan hujan di atas %.0f%%</string>
+
+    <string name="today_outfit_top_tshirt">Kaos</string>
+    <string name="today_outfit_top_sweater">Sweater</string>
+    <string name="today_outfit_top_thick_jacket">Jaket tebal</string>
+    <string name="today_outfit_bottom_shorts">Celana pendek</string>
+    <string name="today_outfit_bottom_long_pants">Celana panjang</string>
+
+    <string name="insight_lead_today">Hari ini</string>
+    <string name="insight_lead_tonight">Malam ini</string>
+    <!-- Indonesian SVO: "Hari ini cuacanya sejuk." -->
+    <string name="insight_band_single">%1$s cuacanya %2$s.</string>
+    <string name="insight_band_range">%1$s cuacanya antara %2$s hingga %3$s.</string>
+    <string name="insight_band_freezing">sangat dingin</string>
+    <string name="insight_band_cold">dingin</string>
+    <string name="insight_band_cool">sejuk</string>
+    <string name="insight_band_mild">hangat sedang</string>
+    <string name="insight_band_warm">hangat</string>
+    <string name="insight_band_hot">panas</string>
+    <string name="insight_delta_warmer">Hari ini %1$d° lebih panas.</string>
+    <string name="insight_delta_cooler">Hari ini %1$d° lebih dingin.</string>
+    <string name="insight_alert">Peringatan: %1$s.</string>
+    <string name="insight_clothes_wear">Kenakan %1$s.</string>
+    <!-- Indonesian has no grammatical articles. -->
+    <string name="insight_clothes_article_a">%1$s</string>
+    <string name="insight_clothes_article_an">%1$s</string>
+    <string name="insight_clothes_join_two">%1$s dan %2$s</string>
+    <string name="insight_clothes_join_many">%1$s, %2$s, dan %3$s</string>
+    <string name="insight_precip">%1$s %2$s.</string>
+    <string name="insight_precip_at_time">pukul %1$s</string>
+    <string name="insight_precip_overnight">semalam</string>
+    <string name="insight_condition_clear">Cerah</string>
+    <string name="insight_condition_partly_cloudy">Sebagian berawan</string>
+    <string name="insight_condition_cloudy">Berawan</string>
+    <string name="insight_condition_fog">Kabut</string>
+    <string name="insight_condition_drizzle">Gerimis</string>
+    <string name="insight_condition_rain">Hujan</string>
+    <string name="insight_condition_snow">Salju</string>
+    <string name="insight_condition_thunderstorm">Badai petir</string>
+    <string name="insight_condition_unknown">Tidak diketahui</string>
+    <string name="insight_calendar_tie_in">Bawa %1$s untuk %3$s pukul %2$s.</string>
+</resources>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+Vietnamese translation. Scope: insight-prose templates, garment labels,
+clothes-rule editor, outfit-card labels, and region/voice-locale picker names.
+The rest of the UI falls through to values/strings.xml (English).
+-->
+<resources>
+    <string name="settings_region_language_vi_vn">Tiếng Việt (Việt Nam)</string>
+    <string name="settings_tts_voice_locale_vi_vn">Tiếng Việt (Việt Nam)</string>
+    <string name="settings_tts_voice_locale_label">Ngôn ngữ</string>
+
+    <string name="garment_sweater">Áo len</string>
+    <string name="garment_hoodie">Áo hoodie</string>
+    <string name="garment_jacket">Áo khoác</string>
+    <string name="garment_coat">Áo măng tô</string>
+    <string name="garment_tshirt">Áo phông</string>
+    <string name="garment_shirt">Áo sơ mi</string>
+    <string name="garment_shorts">Quần short</string>
+    <string name="garment_pants">Quần dài</string>
+    <string name="garment_jeans">Quần jean</string>
+
+    <string name="settings_clothes_empty">Chưa có quy tắc. Nhấn Thêm để tạo mới.</string>
+    <string name="settings_clothes_add">Thêm</string>
+    <string name="settings_clothes_edit">Sửa</string>
+    <string name="settings_clothes_delete">Xóa</string>
+    <string name="settings_clothes_dialog_add_title">Thêm quy tắc quần áo</string>
+    <string name="settings_clothes_dialog_edit_title">Sửa quy tắc quần áo</string>
+    <string name="settings_clothes_item_label">Trang phục</string>
+    <string name="settings_clothes_condition_label">Điều kiện</string>
+    <string name="settings_clothes_value_label_temp_c">Ngưỡng (°C)</string>
+    <string name="settings_clothes_value_label_precip">Ngưỡng (%%)</string>
+    <string name="settings_clothes_cond_type_temp_below">Khi cảm giác lạnh hơn</string>
+    <string name="settings_clothes_cond_type_temp_above">Khi cảm giác nóng hơn</string>
+    <string name="settings_clothes_cond_type_precip_above">Khi khả năng mưa vượt</string>
+    <string name="settings_clothes_cond_temp_below">khi nhiệt độ cảm nhận thấp nhất dưới %.0f°C</string>
+    <string name="settings_clothes_cond_temp_above">khi nhiệt độ cảm nhận cao nhất trên %.0f°C</string>
+    <string name="settings_clothes_cond_precip_above">khi khả năng mưa vượt %.0f%%</string>
+
+    <string name="today_outfit_top_tshirt">Áo phông</string>
+    <string name="today_outfit_top_sweater">Áo len</string>
+    <string name="today_outfit_top_thick_jacket">Áo khoác dày</string>
+    <string name="today_outfit_bottom_shorts">Quần short</string>
+    <string name="today_outfit_bottom_long_pants">Quần dài</string>
+
+    <string name="insight_lead_today">Hôm nay</string>
+    <string name="insight_lead_tonight">Tối nay</string>
+    <!-- Vietnamese: "Hôm nay trời mát." (time + topic + predicate) -->
+    <string name="insight_band_single">%1$s trời %2$s.</string>
+    <string name="insight_band_range">%1$s trời từ %2$s đến %3$s.</string>
+    <string name="insight_band_freezing">đóng băng</string>
+    <string name="insight_band_cold">lạnh</string>
+    <string name="insight_band_cool">mát</string>
+    <string name="insight_band_mild">dễ chịu</string>
+    <string name="insight_band_warm">ấm</string>
+    <string name="insight_band_hot">nóng</string>
+    <string name="insight_delta_warmer">Hôm nay ấm hơn %1$d°.</string>
+    <string name="insight_delta_cooler">Hôm nay lạnh hơn %1$d°.</string>
+    <string name="insight_alert">Cảnh báo: %1$s.</string>
+    <string name="insight_clothes_wear">Mặc %1$s.</string>
+    <!-- Vietnamese has no grammatical articles. -->
+    <string name="insight_clothes_article_a">%1$s</string>
+    <string name="insight_clothes_article_an">%1$s</string>
+    <string name="insight_clothes_join_two">%1$s và %2$s</string>
+    <string name="insight_clothes_join_many">%1$s, %2$s và %3$s</string>
+    <string name="insight_precip">%1$s %2$s.</string>
+    <string name="insight_precip_at_time">lúc %1$s</string>
+    <string name="insight_precip_overnight">suốt đêm</string>
+    <string name="insight_condition_clear">Trời quang</string>
+    <string name="insight_condition_partly_cloudy">Có mây</string>
+    <string name="insight_condition_cloudy">Nhiều mây</string>
+    <string name="insight_condition_fog">Sương mù</string>
+    <string name="insight_condition_drizzle">Mưa phùn</string>
+    <string name="insight_condition_rain">Mưa</string>
+    <string name="insight_condition_snow">Tuyết</string>
+    <string name="insight_condition_thunderstorm">Giông bão</string>
+    <string name="insight_condition_unknown">Không xác định</string>
+    <string name="insight_calendar_tie_in">Mang %1$s cho %3$s lúc %2$s.</string>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -144,6 +144,10 @@
     <string name="settings_tts_voice_locale_nl_nl">Dutch (Netherlands)</string>
     <string name="settings_tts_voice_locale_sv_se">Swedish (Sweden)</string>
     <string name="settings_tts_voice_locale_tr_tr">Turkish (Turkey)</string>
+    <string name="settings_tts_voice_locale_en_za">English (South Africa)</string>
+    <string name="settings_tts_voice_locale_id_id">Indonesian (Indonesia)</string>
+    <string name="settings_tts_voice_locale_fil_ph">Filipino (Philippines)</string>
+    <string name="settings_tts_voice_locale_vi_vn">Vietnamese (Vietnam)</string>
     <string name="settings_tts_test">Test voice</string>
     <!-- Shown next to the engine picker when the chosen engine's API key isn't
          configured. %1$s is the engine name ("Gemini" / "OpenAI" / "ElevenLabs"). -->
@@ -189,6 +193,10 @@
     <string name="settings_region_language_nl_nl">Dutch (Netherlands)</string>
     <string name="settings_region_language_sv_se">Swedish (Sweden)</string>
     <string name="settings_region_language_tr_tr">Turkish (Turkey)</string>
+    <string name="settings_region_language_en_za">English (South Africa)</string>
+    <string name="settings_region_language_id_id">Indonesian (Indonesia)</string>
+    <string name="settings_region_language_fil_ph">Filipino (Philippines)</string>
+    <string name="settings_region_language_vi_vn">Vietnamese (Vietnam)</string>
 
     <string name="settings_temperature_unit_title">Temperature unit</string>
     <string name="settings_temperature_unit_celsius">Celsius (°C)</string>

--- a/core/data/src/main/kotlin/app/clothescast/core/data/tts/GeminiTtsClient.kt
+++ b/core/data/src/main/kotlin/app/clothescast/core/data/tts/GeminiTtsClient.kt
@@ -88,6 +88,10 @@ private val ACCENT_DIRECTIVES: Map<String, String> = mapOf(
     "nl" to "Spreek in het Nederlands met een duidelijk en natuurlijk accent.",
     "sv" to "Tala på svenska med ett tydligt och naturligt uttal.",
     "tr" to "Türkçe konuş, net ve doğal bir Türkçe aksanıyla.",
+    "en-ZA" to "Speak with a South African English accent.",
+    "id" to "Bicara dalam bahasa Indonesia dengan aksen yang jelas dan alami.",
+    "fil" to "Magsalita sa Filipino na may malinaw at natural na diin.",
+    "vi" to "Nói tiếng Việt với giọng điệu rõ ràng và tự nhiên.",
 )
 
 /**

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Settings.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Settings.kt
@@ -66,6 +66,10 @@ enum class VoiceLocale(val bcp47: String?) {
     NL_NL("nl-NL"),
     SV_SE("sv-SE"),
     TR_TR("tr-TR"),
+    EN_ZA("en-ZA"),
+    ID_ID("id-ID"),
+    FIL_PH("fil-PH"),
+    VI_VN("vi-VN"),
 }
 
 /**
@@ -102,6 +106,10 @@ enum class Region(val bcp47: String?) {
     NL_NL("nl-NL"),
     SV_SE("sv-SE"),
     TR_TR("tr-TR"),
+    EN_ZA("en-ZA"),
+    ID_ID("id-ID"),
+    FIL_PH("fil-PH"),
+    VI_VN("vi-VN"),
 }
 
 data class UserPreferences(


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds **English (South Africa)** (`en-ZA`) — minimal vocabulary overrides only: "jersey" for sweater, "trousers" for long pants; insight prose and settings strings fall through to English templates
- Adds **Indonesian** (`id-ID`) — full translation of insight prose, garment names, clothes-rule editor, and outfit card labels; resource folder is `values-in/` because Android maps ISO 639-1 `id` to legacy Java code `in`
- Adds **Filipino** (`fil-PH`) — full translation including local vocabulary (`maong` for jeans, `polo` for shirt)
- Adds **Vietnamese** (`vi-VN`) — full translation; insight templates use Vietnamese topic-comment structure ("Hôm nay trời mát.")
- Gemini accent directives added for all four new locales
- `VoiceLocale` and `Region` enums, `regionLabel()`, and `voiceLocaleLabel()` extended with the four new entries

Note: Swedish was already included in the previous batch (PR #147) — `SV_SE` enum entry, `values-sv/` folder, and all wiring are already on `main`.

## Test plan

- [ ] Build passes (`assembleDebug`)
- [ ] Region picker shows all four new entries with correct labels
- [ ] Voice locale picker shows all four new entries
- [ ] Selecting `ID_ID` region renders Indonesian insight prose and garment names
- [ ] Selecting `FIL_PH` region renders Filipino insight prose
- [ ] Selecting `VI_VN` region renders Vietnamese insight prose
- [ ] Selecting `EN_ZA` region shows "Jersey" and "Trousers" in garment/outfit labels, English elsewhere
- [ ] Gemini TTS with Indonesian locale prepends the Indonesian accent directive
- [ ] `values-in/` folder is picked up correctly (Android `in` = ISO `id`)

https://claude.ai/code/session_019ZFqfAA5UykN1MiD8S48oU
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_019ZFqfAA5UykN1MiD8S48oU)_