### PR TITLE
:app + :core — morning insight: drop rain tie-in, reword evening tie-in to '… tonight'

### DIFF
--- a/app/src/main/kotlin/app/clothescast/insight/InsightFormatter.kt
+++ b/app/src/main/kotlin/app/clothescast/insight/InsightFormatter.kt
@@ -9,6 +9,7 @@ import app.clothescast.core.domain.model.BandClause
 import app.clothescast.core.domain.model.CalendarTieInClause
 import app.clothescast.core.domain.model.ClothesClause
 import app.clothescast.core.domain.model.DeltaClause
+import app.clothescast.core.domain.model.EveningEventTieInClause
 import app.clothescast.core.domain.model.ForecastPeriod
 import app.clothescast.core.domain.model.InsightSummary
 import app.clothescast.core.domain.model.PrecipClause
@@ -50,10 +51,7 @@ class InsightFormatter(
         summary.clothes?.let { add(formatClothes(it)) }
         summary.precip?.let { add(formatPrecip(it, hasCalendarTieIn = summary.calendarTieIn != null)) }
         summary.calendarTieIn?.let { add(formatCalendarTieIn(it)) }
-        // The evening tie-in reuses the same sentence template as calendarTieIn
-        // ("Bring a jacket for your 9pm dinner.") — same shape, separately
-        // gated, so they can coexist on a rainy-afternoon-plus-cold-evening day.
-        summary.eveningEventTieIn?.let { add(formatCalendarTieIn(it)) }
+        summary.eveningEventTieIn?.let { add(formatEveningEventTieIn(it)) }
     }.joinToString(" ")
 
     private fun formatAlert(alert: AlertClause): String =
@@ -78,6 +76,13 @@ class InsightFormatter(
         return resources.getString(template, delta.degrees)
     }
 
+    // TODO: "Wear an umbrella" reads awkwardly — umbrellas are carried, not worn.
+    // Either drop umbrella from the clothes list (it's already implied by the
+    // precip clause and the tonight calendar tie-in) or split the clause into
+    // a "Wear …" sentence for garments and a "Bring …" sentence for accessories
+    // like umbrella. Probably wants a small domain-side classification on
+    // ClothesRule (item kind: garment / accessory) rather than hard-coding
+    // umbrella here.
     private fun formatClothes(clothes: ClothesClause): String =
         resources.getString(R.string.insight_clothes_wear, phraser.joinItems(clothes.items))
 
@@ -100,6 +105,13 @@ class InsightFormatter(
             R.string.insight_calendar_tie_in,
             phraser.withArticle(tieIn.item),
             spokenTime(tieIn.time),
+            tieIn.title,
+        )
+
+    private fun formatEveningEventTieIn(tieIn: EveningEventTieInClause): String =
+        resources.getString(
+            R.string.insight_evening_event_tie_in,
+            phraser.withArticle(tieIn.item),
             tieIn.title,
         )
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -374,4 +374,12 @@
     %2$s = HH:mm event time, %3$s = event title.
     -->
     <string name="insight_calendar_tie_in">Bring %1$s for your %2$s %3$s.</string>
+    <!--
+    Evening-event tie-in attached to the morning insight when "Mention evening
+    events" is on. %1$s = item phrase (with article, via the same phraser as
+    clothes), %2$s = event title. No time deliberately — the user already knows
+    when their event is, and the conversational "tonight" reads better than a
+    redundant clock reference.
+    -->
+    <string name="insight_evening_event_tie_in">Bring %1$s for your %2$s tonight.</string>
 </resources>

--- a/app/src/test/kotlin/app/clothescast/insight/InsightFormatterTest.kt
+++ b/app/src/test/kotlin/app/clothescast/insight/InsightFormatterTest.kt
@@ -5,6 +5,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import app.clothescast.core.domain.model.AlertClause
 import app.clothescast.core.domain.model.BandClause
 import app.clothescast.core.domain.model.CalendarTieInClause
+import app.clothescast.core.domain.model.EveningEventTieInClause
 import app.clothescast.core.domain.model.ClothesClause
 import app.clothescast.core.domain.model.DeltaClause
 import app.clothescast.core.domain.model.ForecastPeriod
@@ -38,7 +39,8 @@ class InsightFormatterTest {
         clothes: ClothesClause? = null,
         precip: PrecipClause? = null,
         calendarTieIn: CalendarTieInClause? = null,
-    ) = InsightSummary(period, band, alert, delta, clothes, precip, calendarTieIn)
+        eveningEventTieIn: EveningEventTieInClause? = null,
+    ) = InsightSummary(period, band, alert, delta, clothes, precip, calendarTieIn, eveningEventTieIn)
 
     @Test
     fun `band-only insight emits the lead-in and label`() {
@@ -183,6 +185,27 @@ class InsightFormatterTest {
             ),
         )
         out shouldBe "Today will be mild. Wear an umbrella. Rain at 3pm. Bring an umbrella for your 3pm park run."
+    }
+
+    @Test
+    fun `evening event tie-in renders bring + article + title + tonight (no time)`() {
+        val out = subject.format(
+            summary(
+                eveningEventTieIn = EveningEventTieInClause("jacket", "dinner"),
+            ),
+        )
+        out shouldBe "Today will be mild. Bring a jacket for your dinner tonight."
+    }
+
+    @Test
+    fun `evening event tie-in coexists with morning band and clothes`() {
+        val out = subject.format(
+            summary(
+                clothes = ClothesClause(listOf("shorts")),
+                eveningEventTieIn = EveningEventTieInClause("jacket", "dinner"),
+            ),
+        )
+        out shouldBe "Today will be mild. Wear shorts. Bring a jacket for your dinner tonight."
     }
 
     @Test

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/InsightSummary.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/InsightSummary.kt
@@ -31,14 +31,17 @@ data class InsightSummary(
     val calendarTieIn: CalendarTieInClause? = null,
     /**
      * A second tie-in for morning insights: an evening event paired with a
-     * clothing tip derived from the *evening* forecast slice. Distinct from
-     * [calendarTieIn] (which is anchored on a precip peak in the morning's
-     * own slice) — this clause exists so the user gets a heads-up about
-     * evening conditions for their evening event without needing a separate
-     * nightly notification. Only emitted on TODAY when the user has the
-     * "Mention evening events" setting on.
+     * clothing tip derived from the *evening* forecast slice. Renders as
+     * "Bring a jacket for your dinner tonight." — no time, since the user
+     * already knows when their event is and the wording reads more like a
+     * conversational heads-up than a calendar reminder.
+     *
+     * Only emitted on TODAY when the user has the "Mention evening events"
+     * setting on. The TONIGHT pass uses [calendarTieIn] for its own event
+     * tie-ins, which keeps the time + title because it's anchored to a
+     * precip-peak hour the listener doesn't already know about.
      */
-    val eveningEventTieIn: CalendarTieInClause? = null,
+    val eveningEventTieIn: EveningEventTieInClause? = null,
 )
 
 /**
@@ -87,6 +90,18 @@ data class PrecipClause(val condition: WeatherCondition, val time: LocalTime)
 data class CalendarTieInClause(
     val item: String,
     val time: LocalTime,
+    val title: String,
+)
+
+/**
+ * Evening-event tie-in for the morning insight: a clothes [item] paired with a
+ * calendar event [title] happening tonight. The formatter renders this as
+ * "Bring <item> for your <title> tonight." — no time, because the user already
+ * knows when their evening event is and the conversational wording reads better
+ * than a redundant clock reference.
+ */
+data class EveningEventTieInClause(
+    val item: String,
     val title: String,
 )
 

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/RenderInsightSummary.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/RenderInsightSummary.kt
@@ -9,6 +9,7 @@ import app.clothescast.core.domain.model.ClothesClause
 import app.clothescast.core.domain.model.ClothesRule
 import app.clothescast.core.domain.model.DailyForecast
 import app.clothescast.core.domain.model.DeltaClause
+import app.clothescast.core.domain.model.EveningEventTieInClause
 import app.clothescast.core.domain.model.ForecastPeriod
 import app.clothescast.core.domain.model.InsightSummary
 import app.clothescast.core.domain.model.PrecipClause
@@ -62,7 +63,14 @@ class RenderInsightSummary {
             delta = if (period == ForecastPeriod.TODAY) deltaClause(today, yesterday) else null,
             clothes = clothesClause(items),
             precip = peak?.let { PrecipClause(it.condition, it.time) },
-            calendarTieIn = calendarTieInClause(items, peak, events),
+            // Calendar tie-in only fires on TONIGHT — pairing the precip peak
+            // with an event the listener hasn't started yet ("Bring an umbrella
+            // for your 8pm dinner") is the case where it adds value. On TODAY
+            // the listener already knows about the event their morning is
+            // built around, so the bare precip clause ("Rain at 3pm.") is
+            // enough; chaining "Bring an umbrella for your 3pm standup." after
+            // it just repeats what the user already heard.
+            calendarTieIn = if (period == ForecastPeriod.TONIGHT) calendarTieInClause(items, peak, events) else null,
             eveningEventTieIn = eveningEventTieInClause(period, eveningEvents, eveningTriggeredRules),
         )
     }
@@ -160,13 +168,13 @@ class RenderInsightSummary {
         period: ForecastPeriod,
         eveningEvents: List<CalendarEvent>,
         eveningTriggeredRules: List<ClothesRule>,
-    ): CalendarTieInClause? {
+    ): EveningEventTieInClause? {
         if (period != ForecastPeriod.TODAY) return null
         if (eveningEvents.isEmpty() || eveningTriggeredRules.isEmpty()) return null
         val event = eveningEvents.firstOrNull { !it.allDay } ?: return null
         val items = eveningTriggeredRules.map { it.item }
         val item = items.firstOrNull { it.equals("umbrella", ignoreCase = true) } ?: items.first()
-        return CalendarTieInClause(item = item, time = event.start, title = event.title)
+        return EveningEventTieInClause(item = item, title = event.title)
     }
 
     private data class PeakPrecip(val time: LocalTime, val condition: WeatherCondition)

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/RenderInsightSummaryTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/RenderInsightSummaryTest.kt
@@ -196,7 +196,6 @@ class RenderInsightSummaryTest {
         val tie = out.eveningEventTieIn
         tie.shouldNotBeNull()
         tie!!.item shouldBe "jacket"
-        tie.time shouldBe LocalTime.of(21, 0)
         tie.title shouldBe "dinner"
     }
 
@@ -255,6 +254,23 @@ class RenderInsightSummaryTest {
     }
 
     @Test
+    fun `calendar tie-in is suppressed on the today period`() {
+        // The morning insight no longer chains a "Bring an umbrella for your 3pm
+        // standup" sentence after "Rain at 3pm." — the listener already knows
+        // about their morning event and the bare precip clause is enough.
+        // Tonight events get a separate evening-event tie-in via
+        // [eveningEventTieIn] when the user has the "Mention evening events"
+        // setting on.
+        val today = mildToday.copy(
+            precipitationProbabilityMaxPct = 60.0,
+            condition = WeatherCondition.RAIN,
+            hourly = listOf(HourlyForecast(LocalTime.of(15, 0), 22.0, 22.0, 60.0, WeatherCondition.RAIN)),
+        )
+        val event = CalendarEvent("standup", LocalTime.of(14, 30), LocalTime.of(16, 0))
+        subject(today, yesterday, listOf(umbrellaRule), events = listOf(event)).calendarTieIn.shouldBeNull()
+    }
+
+    @Test
     fun `calendar tie-in is omitted when the peak condition is non-precipitation`() {
         // Even with the umbrella rule firing on day-level probability and an event
         // overlapping the peak hour, a cloudy peak shouldn't motivate a tie-in —
@@ -265,7 +281,11 @@ class RenderInsightSummaryTest {
             hourly = listOf(HourlyForecast(LocalTime.of(15, 0), 22.0, 22.0, 60.0, WeatherCondition.CLOUDY)),
         )
         val event = CalendarEvent("park run", LocalTime.of(14, 30), LocalTime.of(16, 0))
-        subject(today, yesterday, listOf(umbrellaRule), events = listOf(event)).calendarTieIn.shouldBeNull()
+        subject(
+            today, yesterday, listOf(umbrellaRule),
+            events = listOf(event),
+            period = ForecastPeriod.TONIGHT,
+        ).calendarTieIn.shouldBeNull()
     }
 
     @Test
@@ -349,7 +369,11 @@ class RenderInsightSummaryTest {
             start = LocalTime.of(14, 30),
             end = LocalTime.of(16, 0),
         )
-        val out = subject(today, yesterday, listOf(umbrellaRule), events = listOf(event)).calendarTieIn
+        val out = subject(
+            today, yesterday, listOf(umbrellaRule),
+            events = listOf(event),
+            period = ForecastPeriod.TONIGHT,
+        ).calendarTieIn
         out.shouldNotBeNull()
         out!!.item shouldBe "umbrella"
         out.time shouldBe LocalTime.of(15, 0)
@@ -364,7 +388,11 @@ class RenderInsightSummaryTest {
             hourly = listOf(HourlyForecast(LocalTime.of(15, 0), 22.0, 22.0, 60.0, WeatherCondition.RAIN)),
         )
         val event = CalendarEvent("standup", LocalTime.of(14, 0), LocalTime.of(16, 0))
-        val out = subject(today, yesterday, listOf(sweaterRule, umbrellaRule), events = listOf(event)).calendarTieIn
+        val out = subject(
+            today, yesterday, listOf(sweaterRule, umbrellaRule),
+            events = listOf(event),
+            period = ForecastPeriod.TONIGHT,
+        ).calendarTieIn
         out.shouldNotBeNull()
         out!!.item shouldBe "umbrella"
     }
@@ -377,7 +405,11 @@ class RenderInsightSummaryTest {
             hourly = listOf(HourlyForecast(LocalTime.of(15, 0), 22.0, 22.0, 60.0, WeatherCondition.RAIN)),
         )
         val event = CalendarEvent("park run", LocalTime.of(14, 0), LocalTime.of(16, 0))
-        val out = subject(today, yesterday, listOf(sweaterRule, jacketRule), events = listOf(event)).calendarTieIn
+        val out = subject(
+            today, yesterday, listOf(sweaterRule, jacketRule),
+            events = listOf(event),
+            period = ForecastPeriod.TONIGHT,
+        ).calendarTieIn
         out.shouldNotBeNull()
         out!!.item shouldBe "sweater"
     }
@@ -390,7 +422,11 @@ class RenderInsightSummaryTest {
             hourly = listOf(HourlyForecast(LocalTime.of(15, 0), 22.0, 22.0, 60.0, WeatherCondition.RAIN)),
         )
         val event = CalendarEvent("breakfast", LocalTime.of(8, 0), LocalTime.of(9, 0))
-        subject(today, yesterday, listOf(umbrellaRule), events = listOf(event)).calendarTieIn.shouldBeNull()
+        subject(
+            today, yesterday, listOf(umbrellaRule),
+            events = listOf(event),
+            period = ForecastPeriod.TONIGHT,
+        ).calendarTieIn.shouldBeNull()
     }
 
     @Test
@@ -401,13 +437,21 @@ class RenderInsightSummaryTest {
             hourly = listOf(HourlyForecast(LocalTime.of(15, 0), 22.0, 22.0, 60.0, WeatherCondition.RAIN)),
         )
         val event = CalendarEvent("park run", LocalTime.of(14, 30), LocalTime.of(16, 0))
-        subject(today, yesterday, emptyList(), events = listOf(event)).calendarTieIn.shouldBeNull()
+        subject(
+            today, yesterday, emptyList(),
+            events = listOf(event),
+            period = ForecastPeriod.TONIGHT,
+        ).calendarTieIn.shouldBeNull()
     }
 
     @Test
     fun `calendar tie-in is omitted on a dry day even when an event exists`() {
         val event = CalendarEvent("park run", LocalTime.of(11, 0), LocalTime.of(13, 0))
-        subject(mildToday, yesterday, listOf(umbrellaRule), events = listOf(event)).calendarTieIn.shouldBeNull()
+        subject(
+            mildToday, yesterday, listOf(umbrellaRule),
+            events = listOf(event),
+            period = ForecastPeriod.TONIGHT,
+        ).calendarTieIn.shouldBeNull()
     }
 
     @Test
@@ -418,7 +462,11 @@ class RenderInsightSummaryTest {
             hourly = listOf(HourlyForecast(LocalTime.of(15, 0), 22.0, 22.0, 60.0, WeatherCondition.RAIN)),
         )
         val holiday = CalendarEvent("public holiday", LocalTime.MIDNIGHT, LocalTime.MIDNIGHT, allDay = true)
-        subject(today, yesterday, listOf(umbrellaRule), events = listOf(holiday)).calendarTieIn.shouldBeNull()
+        subject(
+            today, yesterday, listOf(umbrellaRule),
+            events = listOf(holiday),
+            period = ForecastPeriod.TONIGHT,
+        ).calendarTieIn.shouldBeNull()
     }
 
     @Test


### PR DESCRIPTION
## Summary

Two small follow-on prose tweaks after PR #146:

1. **Drop the rain tie-in on the morning insight.** The `CalendarTieInClause` ("Bring an umbrella for your 3pm standup") no longer fires on TODAY. The morning already mentions the precip ("Rain at 3pm.") and the listener already knows about their morning event — chaining the tie-in just repeats what they heard. The TONIGHT pass keeps the rain tie-in (there it pairs an evening precip peak with an event the listener hasn't started yet, which is the case where it actually adds value).

2. **Reword the evening-event tie-in** from *"Bring a jacket for your 9pm dinner."* to *"Bring a jacket for your dinner tonight."* Drops the time (the user already knows when their event is) and adds *"tonight"*. Backed by a dedicated `EveningEventTieInClause(item, title)` data class — the unused time field is gone.

Also adds a `TODO` on `InsightFormatter.formatClothes` about the awkward "Wear an umbrella" phrasing — umbrellas are carried, not worn.

## Examples (morning insight)

| Scenario | Before | After |
|---|---|---|
| Rainy day, 3pm standup, no evening events | "Today will be cool to mild. Wear a sweater and an umbrella. Rain at 3pm. **Bring an umbrella for your 3pm standup.**" | "Today will be cool to mild. Wear a sweater and an umbrella. Rain at 3pm." |
| Sunny day, cold 9pm dinner, *Mention evening events* on | "Today will be mild to warm. Wear shorts. **Bring a jacket for your 9pm dinner.**" | "Today will be mild to warm. Wear shorts. **Bring a jacket for your dinner tonight.**" |
| Rainy afternoon + cold 9pm dinner | "…Rain at 3pm. **Bring an umbrella for your 3pm standup. Bring a jacket for your 9pm dinner.**" | "…Rain at 3pm. **Bring a jacket for your dinner tonight.**" |

## Files

- Domain: `InsightSummary.kt` — new `EveningEventTieInClause(item, title)` data class.
- Domain: `RenderInsightSummary.kt` — gate `calendarTieIn` on TONIGHT; `eveningEventTieInClause` returns the new type.
- Formatter: `InsightFormatter.kt` — `formatEveningEventTieIn` uses the new template; `format()` calls it for the evening clause; TODO comment on `formatClothes` about umbrella phrasing.
- Strings: new `insight_evening_event_tie_in` = `"Bring %1$s for your %2$s tonight."`
- Tests: existing morning calendar tie-in cases switched to `period = ForecastPeriod.TONIGHT` so they continue to exercise the precip / overlap / clothes gates; new "calendar tie-in is suppressed on the today period" case documents the gating directly; new formatter cases for the new wording.

## Test plan

- [ ] CI: JVM unit tests (RenderInsightSummary + InsightFormatter cases).
- [ ] CI: Android debug build.
- [ ] Manual: morning insight on a rainy day with a morning calendar event — confirm no "Bring an umbrella for your 3pm standup" sentence.
- [ ] Manual: morning insight with *Mention evening events* on and a cold evening dinner — confirm "Bring a jacket for your dinner tonight." (no time, "tonight" suffix).
- [ ] Manual: tonight insight on a rainy evening with an evening event — confirm the rain tie-in still fires ("Bring an umbrella for your 8pm dinner.").

Sandbox couldn't run `:core:domain:test` (Google Maven blocked → AGP plugin fails to resolve), so all validation is via CI.

https://claude.ai/code/session_01LoqLrzscNMkxbbdnivtxsn

---
_Generated by [Claude Code](https://claude.ai/code/session_01LoqLrzscNMkxbbdnivtxsn)_