### PR TITLE
:app + :core — add Chinese (Simplified), Hindi, Bengali, Japanese, Korean

### DIFF
--- a/app/src/main/kotlin/app/clothescast/insight/ClothesPhraser.kt
+++ b/app/src/main/kotlin/app/clothescast/insight/ClothesPhraser.kt
@@ -2,6 +2,7 @@ package app.clothescast.insight
 
 import android.content.res.Resources
 import app.clothescast.R
+import app.clothescast.core.domain.model.Garment
 import java.util.Locale
 
 /**
@@ -10,7 +11,9 @@ import java.util.Locale
  * is grammar-specific (English needs "a" / "an" only on the first item; German
  * articles depend on grammatical gender; languages with no articles need
  * nothing) so each language plugs in its own [ClothesPhraser]. Unknown locales
- * fall through to [BareClothesPhraser], which just lists items without articles.
+ * fall through to [ResourceClothesPhraser], which translates known garment keys
+ * via the current locale's `garment_*` string resources and joins with the
+ * locale's `insight_clothes_join_*` templates.
  */
 internal interface ClothesPhraser {
     /** Article-prefixed form of a single item, used by the calendar tie-in clause. */
@@ -24,7 +27,7 @@ internal interface ClothesPhraser {
             when (locale.language) {
                 "en" -> EnglishClothesPhraser(resources)
                 "de" -> GermanClothesPhraser(resources)
-                else -> BareClothesPhraser()
+                else -> ResourceClothesPhraser(resources)
             }
     }
 }
@@ -143,9 +146,62 @@ internal class GermanClothesPhraser(private val resources: Resources) : ClothesP
 }
 
 /**
- * Fallback for locales without a dedicated phraser. Lists items as a comma /
- * and-joined sequence with no articles. Good enough for a first-pass
- * translation — a language-specific phraser can override later.
+ * Generic phraser for locales with no complex article grammar (Chinese, Hindi,
+ * Japanese, Korean, French, Spanish, etc.). Translates known garment keys via
+ * the current locale's `garment_*` Android string resources, applies the
+ * locale's `insight_clothes_article_a` template for [withArticle] (a no-op
+ * passthrough `%1$s` for languages without articles), and joins using the
+ * locale's `insight_clothes_join_*` templates.
+ *
+ * Unknown garment keys fall through unchanged — better to echo the source key
+ * than guess wrong. Replaces [BareClothesPhraser] in [ClothesPhraser.forLocale]
+ * so all non-en/de locales get translated garment names and locale-correct list
+ * punctuation rather than raw English keys comma-joined.
+ */
+internal class ResourceClothesPhraser(private val resources: Resources) : ClothesPhraser {
+    override fun withArticle(item: String): String =
+        resources.getString(R.string.insight_clothes_article_a, translate(item))
+
+    override fun joinItems(items: List<String>): String {
+        val translated = items.map(::translate)
+        return when (translated.size) {
+            0 -> ""
+            1 -> translated[0]
+            2 -> resources.getString(R.string.insight_clothes_join_two, translated[0], translated[1])
+            else -> resources.getString(
+                R.string.insight_clothes_join_many,
+                translated[0],
+                translated.subList(1, translated.size - 1).joinToString(", "),
+                translated.last(),
+            )
+        }
+    }
+
+    private fun translate(item: String): String {
+        val garment = Garment.fromKey(item) ?: return item
+        val resId = GARMENT_RES_IDS[garment] ?: return item
+        return resources.getString(resId)
+    }
+
+    private companion object {
+        val GARMENT_RES_IDS: Map<Garment, Int> = mapOf(
+            Garment.SWEATER to R.string.garment_sweater,
+            Garment.HOODIE to R.string.garment_hoodie,
+            Garment.JACKET to R.string.garment_jacket,
+            Garment.COAT to R.string.garment_coat,
+            Garment.TSHIRT to R.string.garment_tshirt,
+            Garment.SHIRT to R.string.garment_shirt,
+            Garment.SHORTS to R.string.garment_shorts,
+            Garment.PANTS to R.string.garment_pants,
+            Garment.JEANS to R.string.garment_jeans,
+        )
+    }
+}
+
+/**
+ * Bare comma-join with no translation. Used in tests; not returned from
+ * [ClothesPhraser.forLocale] — [ResourceClothesPhraser] handles the generic
+ * case there.
  */
 internal class BareClothesPhraser : ClothesPhraser {
     override fun withArticle(item: String): String = item

--- a/app/src/main/kotlin/app/clothescast/ui/settings/RegionSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/RegionSettings.kt
@@ -88,6 +88,11 @@ private fun regionLabel(region: Region): Int = when (region) {
     Region.ID_ID -> R.string.settings_region_language_id_id
     Region.FIL_PH -> R.string.settings_region_language_fil_ph
     Region.VI_VN -> R.string.settings_region_language_vi_vn
+    Region.ZH_CN -> R.string.settings_region_language_zh_cn
+    Region.HI_IN -> R.string.settings_region_language_hi_in
+    Region.BN_BD -> R.string.settings_region_language_bn_bd
+    Region.JA_JP -> R.string.settings_region_language_ja_jp
+    Region.KO_KR -> R.string.settings_region_language_ko_kr
 }
 
 private fun temperatureUnitLabel(unit: TemperatureUnit): Int = when (unit) {

--- a/app/src/main/kotlin/app/clothescast/ui/settings/VoiceSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/VoiceSettings.kt
@@ -355,6 +355,11 @@ private fun voiceLocaleLabel(locale: VoiceLocale): Int = when (locale) {
     VoiceLocale.ID_ID -> R.string.settings_tts_voice_locale_id_id
     VoiceLocale.FIL_PH -> R.string.settings_tts_voice_locale_fil_ph
     VoiceLocale.VI_VN -> R.string.settings_tts_voice_locale_vi_vn
+    VoiceLocale.ZH_CN -> R.string.settings_tts_voice_locale_zh_cn
+    VoiceLocale.HI_IN -> R.string.settings_tts_voice_locale_hi_in
+    VoiceLocale.BN_BD -> R.string.settings_tts_voice_locale_bn_bd
+    VoiceLocale.JA_JP -> R.string.settings_tts_voice_locale_ja_jp
+    VoiceLocale.KO_KR -> R.string.settings_tts_voice_locale_ko_kr
 }
 
 @Composable

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+Bengali (Bangladesh) translation. Scope: insight-prose templates, garment labels,
+clothes-rule editor, outfit-card labels, and region/voice-locale picker names.
+The rest of the UI falls through to values/strings.xml (English).
+The values-bn/ folder serves bn-BD; a values-bn-rIN/ overlay can add
+West Bengal vocabulary differences in a future PR.
+-->
+<resources>
+    <string name="settings_region_language_bn_bd">বাংলা (বাংলাদেশ)</string>
+    <string name="settings_tts_voice_locale_bn_bd">বাংলা (বাংলাদেশ)</string>
+    <string name="settings_tts_voice_locale_label">ভাষা</string>
+
+    <string name="garment_sweater">সোয়েটার</string>
+    <string name="garment_hoodie">হুডি</string>
+    <string name="garment_jacket">জ্যাকেট</string>
+    <string name="garment_coat">কোট</string>
+    <string name="garment_tshirt">টি-শার্ট</string>
+    <string name="garment_shirt">শার্ট</string>
+    <string name="garment_shorts">শর্টস</string>
+    <string name="garment_pants">প্যান্ট</string>
+    <string name="garment_jeans">জিন্স</string>
+
+    <string name="settings_clothes_empty">কোনো নিয়ম নেই। একটি তৈরি করতে যোগ করুন-এ ট্যাপ করুন।</string>
+    <string name="settings_clothes_add">যোগ করুন</string>
+    <string name="settings_clothes_edit">সম্পাদনা করুন</string>
+    <string name="settings_clothes_delete">মুছুন</string>
+    <string name="settings_clothes_dialog_add_title">পোশাকের নিয়ম যোগ করুন</string>
+    <string name="settings_clothes_dialog_edit_title">পোশাকের নিয়ম সম্পাদনা করুন</string>
+    <string name="settings_clothes_item_label">পোশাক</string>
+    <string name="settings_clothes_condition_label">শর্ত</string>
+    <string name="settings_clothes_value_label_temp_c">সীমা (°C)</string>
+    <string name="settings_clothes_value_label_precip">সীমা (%%)</string>
+    <string name="settings_clothes_cond_type_temp_below">যখন অনুভব হয় তার চেয়ে ঠান্ডা</string>
+    <string name="settings_clothes_cond_type_temp_above">যখন অনুভব হয় তার চেয়ে গরম</string>
+    <string name="settings_clothes_cond_type_precip_above">যখন বৃষ্টির সম্ভাবনা বেশি</string>
+    <string name="settings_clothes_cond_temp_below">যখন সর্বনিম্ন অনুভূত তাপমাত্রা %.0f°C-এর নিচে</string>
+    <string name="settings_clothes_cond_temp_above">যখন সর্বোচ্চ অনুভূত তাপমাত্রা %.0f°C-এর বেশি</string>
+    <string name="settings_clothes_cond_precip_above">যখন বৃষ্টির সম্ভাবনা %.0f%%-এর বেশি</string>
+
+    <string name="today_outfit_top_tshirt">টি-শার্ট</string>
+    <string name="today_outfit_top_sweater">সোয়েটার</string>
+    <string name="today_outfit_top_thick_jacket">মোটা জ্যাকেট</string>
+    <string name="today_outfit_bottom_shorts">শর্টস</string>
+    <string name="today_outfit_bottom_long_pants">প্যান্ট</string>
+
+    <string name="insight_lead_today">আজ</string>
+    <string name="insight_lead_tonight">আজ রাতে</string>
+    <!-- "আজ আবহাওয়া মনোরম থাকবে।" -->
+    <string name="insight_band_single">%1$s আবহাওয়া %2$s থাকবে।</string>
+    <string name="insight_band_range">%1$s আবহাওয়া %2$s থেকে %3$s থাকবে।</string>
+    <string name="insight_band_freezing">হিমশীতল</string>
+    <string name="insight_band_cold">ঠান্ডা</string>
+    <string name="insight_band_cool">শীতল</string>
+    <string name="insight_band_mild">মনোরম</string>
+    <string name="insight_band_warm">উষ্ণ</string>
+    <string name="insight_band_hot">গরম</string>
+    <string name="insight_delta_warmer">আজ %1$d° বেশি গরম।</string>
+    <string name="insight_delta_cooler">আজ %1$d° বেশি ঠান্ডা।</string>
+    <string name="insight_alert">সতর্কতা: %1$s।</string>
+    <string name="insight_clothes_wear">%1$s পরুন।</string>
+    <!-- Bengali has no grammatical articles. -->
+    <string name="insight_clothes_article_a">%1$s</string>
+    <string name="insight_clothes_article_an">%1$s</string>
+    <string name="insight_clothes_join_two">%1$s এবং %2$s</string>
+    <string name="insight_clothes_join_many">%1$s, %2$s এবং %3$s</string>
+    <string name="insight_precip">%1$s %2$s।</string>
+    <string name="insight_precip_at_time">%1$s-এ</string>
+    <string name="insight_precip_overnight">সারারাত</string>
+    <string name="insight_condition_clear">পরিষ্কার</string>
+    <string name="insight_condition_partly_cloudy">আংশিক মেঘলা</string>
+    <string name="insight_condition_cloudy">মেঘলা</string>
+    <string name="insight_condition_fog">কুয়াশা</string>
+    <string name="insight_condition_drizzle">গুঁড়ি গুঁড়ি বৃষ্টি</string>
+    <string name="insight_condition_rain">বৃষ্টি</string>
+    <string name="insight_condition_snow">তুষার</string>
+    <string name="insight_condition_thunderstorm">বজ্রপাত</string>
+    <string name="insight_condition_unknown">অজানা</string>
+    <!-- "মিটিং (15:00)-এর জন্য কোট নিন।" -->
+    <string name="insight_calendar_tie_in">%3$s (%2$s)-এর জন্য %1$s নিন।</string>
+</resources>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+Hindi (India) translation. Scope: insight-prose templates, garment labels,
+clothes-rule editor, outfit-card labels, and region/voice-locale picker names.
+The rest of the UI falls through to values/strings.xml (English).
+-->
+<resources>
+    <string name="settings_region_language_hi_in">हिंदी (भारत)</string>
+    <string name="settings_tts_voice_locale_hi_in">हिंदी (भारत)</string>
+    <string name="settings_tts_voice_locale_label">भाषा</string>
+
+    <string name="garment_sweater">स्वेटर</string>
+    <string name="garment_hoodie">हुडी</string>
+    <string name="garment_jacket">जैकेट</string>
+    <string name="garment_coat">कोट</string>
+    <string name="garment_tshirt">टी-शर्ट</string>
+    <string name="garment_shirt">कमीज़</string>
+    <string name="garment_shorts">शॉर्ट्स</string>
+    <string name="garment_pants">पैंट</string>
+    <string name="garment_jeans">जींस</string>
+
+    <string name="settings_clothes_empty">कोई नियम नहीं। जोड़ें पर टैप करके एक बनाएँ।</string>
+    <string name="settings_clothes_add">जोड़ें</string>
+    <string name="settings_clothes_edit">संपादित करें</string>
+    <string name="settings_clothes_delete">हटाएँ</string>
+    <string name="settings_clothes_dialog_add_title">कपड़ों का नियम जोड़ें</string>
+    <string name="settings_clothes_dialog_edit_title">कपड़ों का नियम संपादित करें</string>
+    <string name="settings_clothes_item_label">कपड़ा</string>
+    <string name="settings_clothes_condition_label">शर्त</string>
+    <string name="settings_clothes_value_label_temp_c">सीमा (°C)</string>
+    <string name="settings_clothes_value_label_precip">सीमा (%%)</string>
+    <string name="settings_clothes_cond_type_temp_below">जब महसूस हो उससे ठंडा</string>
+    <string name="settings_clothes_cond_type_temp_above">जब महसूस हो उससे गर्म</string>
+    <string name="settings_clothes_cond_type_precip_above">जब बारिश की संभावना से अधिक</string>
+    <string name="settings_clothes_cond_temp_below">जब न्यूनतम महसूस तापमान %.0f°C से कम हो</string>
+    <string name="settings_clothes_cond_temp_above">जब अधिकतम महसूस तापमान %.0f°C से अधिक हो</string>
+    <string name="settings_clothes_cond_precip_above">जब बारिश की संभावना %.0f%% से अधिक हो</string>
+
+    <string name="today_outfit_top_tshirt">टी-शर्ट</string>
+    <string name="today_outfit_top_sweater">स्वेटर</string>
+    <string name="today_outfit_top_thick_jacket">मोटी जैकेट</string>
+    <string name="today_outfit_bottom_shorts">शॉर्ट्स</string>
+    <string name="today_outfit_bottom_long_pants">पैंट</string>
+
+    <string name="insight_lead_today">आज</string>
+    <string name="insight_lead_tonight">आज रात</string>
+    <!-- "आज मौसम सुहाना रहेगा।" -->
+    <string name="insight_band_single">%1$s मौसम %2$s रहेगा।</string>
+    <string name="insight_band_range">%1$s मौसम %2$s से %3$s रहेगा।</string>
+    <string name="insight_band_freezing">बेहद ठंडा</string>
+    <string name="insight_band_cold">ठंडा</string>
+    <string name="insight_band_cool">ठंडक भरा</string>
+    <string name="insight_band_mild">सुहाना</string>
+    <string name="insight_band_warm">गर्म</string>
+    <string name="insight_band_hot">बहुत गर्म</string>
+    <string name="insight_delta_warmer">आज %1$d° ज़्यादा गर्म।</string>
+    <string name="insight_delta_cooler">आज %1$d° ज़्यादा ठंडा।</string>
+    <string name="insight_alert">चेतावनी: %1$s।</string>
+    <string name="insight_clothes_wear">%1$s पहनें।</string>
+    <!-- Hindi has no grammatical articles. -->
+    <string name="insight_clothes_article_a">%1$s</string>
+    <string name="insight_clothes_article_an">%1$s</string>
+    <string name="insight_clothes_join_two">%1$s और %2$s</string>
+    <string name="insight_clothes_join_many">%1$s, %2$s और %3$s</string>
+    <string name="insight_precip">%1$s %2$s।</string>
+    <string name="insight_precip_at_time">%1$s बजे</string>
+    <string name="insight_precip_overnight">रात भर</string>
+    <string name="insight_condition_clear">साफ़</string>
+    <string name="insight_condition_partly_cloudy">आंशिक बादल</string>
+    <string name="insight_condition_cloudy">बादल</string>
+    <string name="insight_condition_fog">कोहरा</string>
+    <string name="insight_condition_drizzle">बूँदाबाँदी</string>
+    <string name="insight_condition_rain">बारिश</string>
+    <string name="insight_condition_snow">बर्फ़</string>
+    <string name="insight_condition_thunderstorm">तूफ़ान</string>
+    <string name="insight_condition_unknown">अज्ञात</string>
+    <!-- "मीटिंग (15:00) के लिए कोट साथ लें।" -->
+    <string name="insight_calendar_tie_in">%3$s (%2$s) के लिए %1$s साथ लें।</string>
+</resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+Japanese translation. Scope: insight-prose templates, garment labels,
+clothes-rule editor, outfit-card labels, and region/voice-locale picker names.
+The rest of the UI falls through to values/strings.xml (English).
+Japanese uses the ideographic period (。) for sentence endings.
+-->
+<resources>
+    <string name="settings_region_language_ja_jp">日本語（日本）</string>
+    <string name="settings_tts_voice_locale_ja_jp">日本語（日本）</string>
+    <string name="settings_tts_voice_locale_label">言語</string>
+
+    <string name="garment_sweater">セーター</string>
+    <string name="garment_hoodie">パーカー</string>
+    <string name="garment_jacket">ジャケット</string>
+    <string name="garment_coat">コート</string>
+    <string name="garment_tshirt">Tシャツ</string>
+    <string name="garment_shirt">シャツ</string>
+    <string name="garment_shorts">ショートパンツ</string>
+    <string name="garment_pants">ズボン</string>
+    <string name="garment_jeans">ジーンズ</string>
+
+    <string name="settings_clothes_empty">ルールがありません。追加をタップして作成してください。</string>
+    <string name="settings_clothes_add">追加</string>
+    <string name="settings_clothes_edit">編集</string>
+    <string name="settings_clothes_delete">削除</string>
+    <string name="settings_clothes_dialog_add_title">服のルールを追加</string>
+    <string name="settings_clothes_dialog_edit_title">服のルールを編集</string>
+    <string name="settings_clothes_item_label">衣類</string>
+    <string name="settings_clothes_condition_label">条件</string>
+    <string name="settings_clothes_value_label_temp_c">しきい値 (°C)</string>
+    <string name="settings_clothes_value_label_precip">しきい値 (%%)</string>
+    <string name="settings_clothes_cond_type_temp_below">体感温度が以下のとき</string>
+    <string name="settings_clothes_cond_type_temp_above">体感温度が以上のとき</string>
+    <string name="settings_clothes_cond_type_precip_above">降水確率が以上のとき</string>
+    <string name="settings_clothes_cond_temp_below">最低体感温度が %.0f°C 未満のとき</string>
+    <string name="settings_clothes_cond_temp_above">最高体感温度が %.0f°C を超えるとき</string>
+    <string name="settings_clothes_cond_precip_above">降水確率が %.0f%% を超えるとき</string>
+
+    <string name="today_outfit_top_tshirt">Tシャツ</string>
+    <string name="today_outfit_top_sweater">セーター</string>
+    <string name="today_outfit_top_thick_jacket">厚手のジャケット</string>
+    <string name="today_outfit_bottom_shorts">ショートパンツ</string>
+    <string name="today_outfit_bottom_long_pants">ズボン</string>
+
+    <string name="insight_lead_today">今日</string>
+    <string name="insight_lead_tonight">今夜</string>
+    <!-- "今日は穏やかでしょう。" — は marks the topic. -->
+    <string name="insight_band_single">%1$sは%2$sでしょう。</string>
+    <string name="insight_band_range">%1$sは%2$sから%3$sでしょう。</string>
+    <string name="insight_band_freezing">氷点下</string>
+    <string name="insight_band_cold">寒い</string>
+    <string name="insight_band_cool">涼しい</string>
+    <string name="insight_band_mild">穏やか</string>
+    <string name="insight_band_warm">暖かい</string>
+    <string name="insight_band_hot">暑い</string>
+    <string name="insight_delta_warmer">今日は%1$d°暖かくなります。</string>
+    <string name="insight_delta_cooler">今日は%1$d°涼しくなります。</string>
+    <string name="insight_alert">警報：%1$s。</string>
+    <!-- を is the universal object marker in Japanese, works after any noun. -->
+    <string name="insight_clothes_wear">%1$sを着ていきましょう。</string>
+    <!-- Japanese has no grammatical articles. -->
+    <string name="insight_clothes_article_a">%1$s</string>
+    <string name="insight_clothes_article_an">%1$s</string>
+    <string name="insight_clothes_join_two">%1$sと%2$s</string>
+    <!-- Japanese uses 、(読点) between list items. -->
+    <string name="insight_clothes_join_many">%1$s、%2$s、%3$s</string>
+    <!-- "雨（15:00頃）。" / "雨（夜通し）。" — parenthetical time fits Japanese style. -->
+    <string name="insight_precip">%1$s（%2$s）。</string>
+    <string name="insight_precip_at_time">%1$s頃</string>
+    <string name="insight_precip_overnight">夜通し</string>
+    <string name="insight_condition_clear">晴れ</string>
+    <string name="insight_condition_partly_cloudy">晴れのち曇り</string>
+    <string name="insight_condition_cloudy">曇り</string>
+    <string name="insight_condition_fog">霧</string>
+    <string name="insight_condition_drizzle">小雨</string>
+    <string name="insight_condition_rain">雨</string>
+    <string name="insight_condition_snow">雪</string>
+    <string name="insight_condition_thunderstorm">雷雨</string>
+    <string name="insight_condition_unknown">不明</string>
+    <!-- "会議（15:00）のためにコートを持っていきましょう。" -->
+    <string name="insight_calendar_tie_in">%3$s（%2$s）のために%1$sを持っていきましょう。</string>
+</resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+Korean translation. Scope: insight-prose templates, garment labels,
+clothes-rule editor, outfit-card labels, and region/voice-locale picker names.
+The rest of the UI falls through to values/strings.xml (English).
+"챙기세요" (bring/take with you) is used for insight_clothes_wear as it avoids
+the 을/를 object particle which depends on the noun's final consonant.
+-->
+<resources>
+    <string name="settings_region_language_ko_kr">한국어 (대한민국)</string>
+    <string name="settings_tts_voice_locale_ko_kr">한국어 (대한민국)</string>
+    <string name="settings_tts_voice_locale_label">언어</string>
+
+    <string name="garment_sweater">스웨터</string>
+    <string name="garment_hoodie">후드티</string>
+    <string name="garment_jacket">재킷</string>
+    <string name="garment_coat">코트</string>
+    <string name="garment_tshirt">티셔츠</string>
+    <string name="garment_shirt">셔츠</string>
+    <string name="garment_shorts">반바지</string>
+    <string name="garment_pants">긴바지</string>
+    <string name="garment_jeans">청바지</string>
+
+    <string name="settings_clothes_empty">규칙이 없습니다. 추가를 탭하여 만드세요.</string>
+    <string name="settings_clothes_add">추가</string>
+    <string name="settings_clothes_edit">편집</string>
+    <string name="settings_clothes_delete">삭제</string>
+    <string name="settings_clothes_dialog_add_title">옷 규칙 추가</string>
+    <string name="settings_clothes_dialog_edit_title">옷 규칙 편집</string>
+    <string name="settings_clothes_item_label">의류</string>
+    <string name="settings_clothes_condition_label">조건</string>
+    <string name="settings_clothes_value_label_temp_c">기준값 (°C)</string>
+    <string name="settings_clothes_value_label_precip">기준값 (%%)</string>
+    <string name="settings_clothes_cond_type_temp_below">체감 온도가 다음보다 낮을 때</string>
+    <string name="settings_clothes_cond_type_temp_above">체감 온도가 다음보다 높을 때</string>
+    <string name="settings_clothes_cond_type_precip_above">강수 확률이 다음보다 높을 때</string>
+    <string name="settings_clothes_cond_temp_below">최저 체감 온도가 %.0f°C 미만일 때</string>
+    <string name="settings_clothes_cond_temp_above">최고 체감 온도가 %.0f°C 초과일 때</string>
+    <string name="settings_clothes_cond_precip_above">강수 확률이 %.0f%% 초과일 때</string>
+
+    <string name="today_outfit_top_tshirt">티셔츠</string>
+    <string name="today_outfit_top_sweater">스웨터</string>
+    <string name="today_outfit_top_thick_jacket">두꺼운 재킷</string>
+    <string name="today_outfit_bottom_shorts">반바지</string>
+    <string name="today_outfit_bottom_long_pants">긴바지</string>
+
+    <string name="insight_lead_today">오늘</string>
+    <string name="insight_lead_tonight">오늘 밤</string>
+    <!-- "오늘 포근한 날씨입니다." -->
+    <string name="insight_band_single">%1$s %2$s 날씨입니다.</string>
+    <string name="insight_band_range">%1$s %2$s에서 %3$s 사이의 날씨입니다.</string>
+    <string name="insight_band_freezing">매우 추운</string>
+    <string name="insight_band_cold">추운</string>
+    <string name="insight_band_cool">서늘한</string>
+    <string name="insight_band_mild">포근한</string>
+    <string name="insight_band_warm">따뜻한</string>
+    <string name="insight_band_hot">더운</string>
+    <string name="insight_delta_warmer">오늘은 %1$d° 더 따뜻합니다.</string>
+    <string name="insight_delta_cooler">오늘은 %1$d° 더 춥습니다.</string>
+    <string name="insight_alert">경보: %1$s.</string>
+    <string name="insight_clothes_wear">%1$s 챙기세요.</string>
+    <!-- Korean has no grammatical articles. -->
+    <string name="insight_clothes_article_a">%1$s</string>
+    <string name="insight_clothes_article_an">%1$s</string>
+    <!-- 그리고 (geurigo) = and, avoids the 와/과 consonant-dependent particle. -->
+    <string name="insight_clothes_join_two">%1$s 그리고 %2$s</string>
+    <string name="insight_clothes_join_many">%1$s, %2$s 그리고 %3$s</string>
+    <string name="insight_precip">%1$s %2$s.</string>
+    <string name="insight_precip_at_time">%1$s경에</string>
+    <string name="insight_precip_overnight">밤새</string>
+    <string name="insight_condition_clear">맑음</string>
+    <string name="insight_condition_partly_cloudy">구름 조금</string>
+    <string name="insight_condition_cloudy">흐림</string>
+    <string name="insight_condition_fog">안개</string>
+    <string name="insight_condition_drizzle">이슬비</string>
+    <string name="insight_condition_rain">비</string>
+    <string name="insight_condition_snow">눈</string>
+    <string name="insight_condition_thunderstorm">뇌우</string>
+    <string name="insight_condition_unknown">알 수 없음</string>
+    <!-- "회의(15:00)에 코트 챙기세요." -->
+    <string name="insight_calendar_tie_in">%3$s(%2$s)에 %1$s 챙기세요.</string>
+</resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+Simplified Chinese (Mainland China) translation. Scope: insight-prose templates,
+garment labels, clothes-rule editor, outfit-card labels, and region/voice-locale
+picker names. The rest of the UI falls through to values/strings.xml (English).
+Chinese uses the ideographic period (。) for sentence endings.
+-->
+<resources>
+    <string name="settings_region_language_zh_cn">中文（简体）</string>
+    <string name="settings_tts_voice_locale_zh_cn">中文（简体）</string>
+    <string name="settings_tts_voice_locale_label">语言</string>
+
+    <string name="garment_sweater">毛衣</string>
+    <string name="garment_hoodie">连帽衫</string>
+    <string name="garment_jacket">夹克</string>
+    <string name="garment_coat">大衣</string>
+    <string name="garment_tshirt">T恤</string>
+    <string name="garment_shirt">衬衫</string>
+    <string name="garment_shorts">短裤</string>
+    <string name="garment_pants">长裤</string>
+    <string name="garment_jeans">牛仔裤</string>
+
+    <string name="settings_clothes_empty">还没有规则。点击添加来创建一条。</string>
+    <string name="settings_clothes_add">添加</string>
+    <string name="settings_clothes_edit">编辑</string>
+    <string name="settings_clothes_delete">删除</string>
+    <string name="settings_clothes_dialog_add_title">添加穿衣规则</string>
+    <string name="settings_clothes_dialog_edit_title">编辑穿衣规则</string>
+    <string name="settings_clothes_item_label">服装</string>
+    <string name="settings_clothes_condition_label">触发条件</string>
+    <string name="settings_clothes_value_label_temp_c">阈值 (°C)</string>
+    <string name="settings_clothes_value_label_precip">阈值 (%%)</string>
+    <string name="settings_clothes_cond_type_temp_below">当体感温度低于</string>
+    <string name="settings_clothes_cond_type_temp_above">当体感温度高于</string>
+    <string name="settings_clothes_cond_type_precip_above">当降水概率超过</string>
+    <string name="settings_clothes_cond_temp_below">当最低体感温度低于 %.0f°C 时</string>
+    <string name="settings_clothes_cond_temp_above">当最高体感温度高于 %.0f°C 时</string>
+    <string name="settings_clothes_cond_precip_above">当降水概率超过 %.0f%% 时</string>
+
+    <string name="today_outfit_top_tshirt">T恤</string>
+    <string name="today_outfit_top_sweater">毛衣</string>
+    <string name="today_outfit_top_thick_jacket">厚外套</string>
+    <string name="today_outfit_bottom_shorts">短裤</string>
+    <string name="today_outfit_bottom_long_pants">长裤</string>
+
+    <string name="insight_lead_today">今天</string>
+    <string name="insight_lead_tonight">今晚</string>
+    <!-- "今天天气温和。" / "今晚天气寒冷至凉爽。" -->
+    <string name="insight_band_single">%1$s天气%2$s。</string>
+    <string name="insight_band_range">%1$s天气%2$s至%3$s。</string>
+    <string name="insight_band_freezing">极寒</string>
+    <string name="insight_band_cold">寒冷</string>
+    <string name="insight_band_cool">凉爽</string>
+    <string name="insight_band_mild">温和</string>
+    <string name="insight_band_warm">温暖</string>
+    <string name="insight_band_hot">炎热</string>
+    <string name="insight_delta_warmer">今天气温升高%1$d°。</string>
+    <string name="insight_delta_cooler">今天气温下降%1$d°。</string>
+    <string name="insight_alert">警告：%1$s。</string>
+    <string name="insight_clothes_wear">穿上%1$s。</string>
+    <!-- Chinese has no grammatical articles. -->
+    <string name="insight_clothes_article_a">%1$s</string>
+    <string name="insight_clothes_article_an">%1$s</string>
+    <string name="insight_clothes_join_two">%1$s和%2$s</string>
+    <!-- Chinese uses the enumeration comma (、) between list items. -->
+    <string name="insight_clothes_join_many">%1$s、%2$s和%3$s</string>
+    <!-- "雨（15:00）。" / "雨（整夜）。" — parenthetical time fits Chinese style. -->
+    <string name="insight_precip">%1$s（%2$s）。</string>
+    <string name="insight_precip_at_time">%1$s</string>
+    <string name="insight_precip_overnight">整夜</string>
+    <string name="insight_condition_clear">晴</string>
+    <string name="insight_condition_partly_cloudy">多云</string>
+    <string name="insight_condition_cloudy">阴</string>
+    <string name="insight_condition_fog">雾</string>
+    <string name="insight_condition_drizzle">毛毛雨</string>
+    <string name="insight_condition_rain">雨</string>
+    <string name="insight_condition_snow">雪</string>
+    <string name="insight_condition_thunderstorm">雷暴</string>
+    <string name="insight_condition_unknown">未知</string>
+    <!-- "为3点的会议带上雨伞。" — time before event name follows Chinese convention. -->
+    <string name="insight_calendar_tie_in">为%2$s的%3$s带上%1$s。</string>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -148,6 +148,11 @@
     <string name="settings_tts_voice_locale_id_id">Indonesian (Indonesia)</string>
     <string name="settings_tts_voice_locale_fil_ph">Filipino (Philippines)</string>
     <string name="settings_tts_voice_locale_vi_vn">Vietnamese (Vietnam)</string>
+    <string name="settings_tts_voice_locale_zh_cn">Chinese (Simplified)</string>
+    <string name="settings_tts_voice_locale_hi_in">Hindi (India)</string>
+    <string name="settings_tts_voice_locale_bn_bd">Bengali (Bangladesh)</string>
+    <string name="settings_tts_voice_locale_ja_jp">Japanese (Japan)</string>
+    <string name="settings_tts_voice_locale_ko_kr">Korean (South Korea)</string>
     <string name="settings_tts_test">Test voice</string>
     <!-- Shown next to the engine picker when the chosen engine's API key isn't
          configured. %1$s is the engine name ("Gemini" / "OpenAI" / "ElevenLabs"). -->
@@ -197,6 +202,11 @@
     <string name="settings_region_language_id_id">Indonesian (Indonesia)</string>
     <string name="settings_region_language_fil_ph">Filipino (Philippines)</string>
     <string name="settings_region_language_vi_vn">Vietnamese (Vietnam)</string>
+    <string name="settings_region_language_zh_cn">Chinese (Simplified)</string>
+    <string name="settings_region_language_hi_in">Hindi (India)</string>
+    <string name="settings_region_language_bn_bd">Bengali (Bangladesh)</string>
+    <string name="settings_region_language_ja_jp">Japanese (Japan)</string>
+    <string name="settings_region_language_ko_kr">Korean (South Korea)</string>
 
     <string name="settings_temperature_unit_title">Temperature unit</string>
     <string name="settings_temperature_unit_celsius">Celsius (°C)</string>

--- a/core/data/src/main/kotlin/app/clothescast/core/data/tts/GeminiTtsClient.kt
+++ b/core/data/src/main/kotlin/app/clothescast/core/data/tts/GeminiTtsClient.kt
@@ -93,6 +93,9 @@ private val ACCENT_DIRECTIVES: Map<String, String> = mapOf(
     "fil" to "Magsalita sa Filipino na may malinaw at natural na diin.",
     "vi" to "Nói tiếng Việt với giọng điệu rõ ràng và tự nhiên.",
     "zh-CN" to "请用标准普通话朗读，发音清晰自然。",
+    // Language-only fallback covers generic zh locale and any zh-* variant
+    // not explicitly listed (zh-TW, zh-HK, etc.) — all are Mandarin-readable.
+    "zh" to "请用标准普通话朗读，发音清晰自然。",
     "hi" to "कृपया हिंदी में स्पष्ट और प्राकृतिक उच्चारण के साथ पढ़ें।",
     "bn" to "অনুগ্রহ করে বাংলায় স্পষ্ট ও প্রাকৃতিক উচ্চারণে পড়ুন।",
     "ja" to "はっきりと自然な発音で日本語で読んでください。",

--- a/core/data/src/main/kotlin/app/clothescast/core/data/tts/GeminiTtsClient.kt
+++ b/core/data/src/main/kotlin/app/clothescast/core/data/tts/GeminiTtsClient.kt
@@ -92,6 +92,11 @@ private val ACCENT_DIRECTIVES: Map<String, String> = mapOf(
     "id" to "Bicara dalam bahasa Indonesia dengan aksen yang jelas dan alami.",
     "fil" to "Magsalita sa Filipino na may malinaw at natural na diin.",
     "vi" to "Nói tiếng Việt với giọng điệu rõ ràng và tự nhiên.",
+    "zh-CN" to "请用标准普通话朗读，发音清晰自然。",
+    "hi" to "कृपया हिंदी में स्पष्ट और प्राकृतिक उच्चारण के साथ पढ़ें।",
+    "bn" to "অনুগ্রহ করে বাংলায় স্পষ্ট ও প্রাকৃতিক উচ্চারণে পড়ুন।",
+    "ja" to "はっきりと自然な発音で日本語で読んでください。",
+    "ko" to "명확하고 자연스러운 발음으로 한국어로 읽어주세요。",
 )
 
 /**

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Settings.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Settings.kt
@@ -70,6 +70,11 @@ enum class VoiceLocale(val bcp47: String?) {
     ID_ID("id-ID"),
     FIL_PH("fil-PH"),
     VI_VN("vi-VN"),
+    ZH_CN("zh-CN"),
+    HI_IN("hi-IN"),
+    BN_BD("bn-BD"),
+    JA_JP("ja-JP"),
+    KO_KR("ko-KR"),
 }
 
 /**
@@ -110,6 +115,11 @@ enum class Region(val bcp47: String?) {
     ID_ID("id-ID"),
     FIL_PH("fil-PH"),
     VI_VN("vi-VN"),
+    ZH_CN("zh-CN"),
+    HI_IN("hi-IN"),
+    BN_BD("bn-BD"),
+    JA_JP("ja-JP"),
+    KO_KR("ko-KR"),
 }
 
 data class UserPreferences(


### PR DESCRIPTION
## Summary

Adds five high-population non-Latin-script locales (combined ~1.7B native speakers):

- **Chinese Simplified** (`zh-CN`, `values-zh-rCN/`) — insight template: "今天天气温和。"; parenthetical precipitation time ("雨（15:00）。"); enumeration comma (、) in lists
- **Hindi** (`hi-IN`, `values-hi/`) — Devanagari script; no grammatical articles; "आज मौसम सुहाना रहेगा।"
- **Bengali** (`bn-BD`, `values-bn/`) — `values-bn/` serves as base; Android resolves `bn-BD → bn`; no grammatical articles; a `values-bn-rIN/` overlay can add West Bengal vocabulary differences later
- **Japanese** (`ja-JP`, `values-ja/`) — は topic marker in band template ("今日は穏やかでしょう。"); を object marker for clothes-wear; 、(読点) for item lists
- **Korean** (`ko-KR`, `values-ko/`) — "챙기세요" (bring/take with you) avoids the 을/를 particle whose form depends on the noun's final consonant; 그리고 for "and" in lists

Each locale gets: `Region` + `VoiceLocale` enum entry, `regionLabel()` + `voiceLocaleLabel()` when-branch, English picker strings in `values/strings.xml`, Gemini TTS accent directive, and a full translated resource file.

**Not included:** Chinese Traditional (`zh-TW`) and Cantonese (`yue-HK`) — Traditional is a quick follow-up (character-variant of Simplified content); Cantonese needs genuinely different prose and the `values-b+yue+HK/` qualifier, so it's a separate PR.

## Test plan

- [ ] Build passes (`assembleDebug`)
- [ ] Region picker shows all five new entries with correct script labels
- [ ] Selecting `ZH_CN` renders Simplified Chinese insight prose and garment names
- [ ] Selecting `HI_IN` renders Devanagari insight prose
- [ ] Selecting `BN_BD` renders Bengali insight prose
- [ ] Selecting `JA_JP` renders Japanese insight prose (今日は…でしょう。)
- [ ] Selecting `KO_KR` renders Korean insight prose
- [ ] Gemini TTS with each locale prepends the correct accent directive
- [ ] `values-bn/` is correctly resolved for `bn-BD` (no `values-bn-rBD/` folder needed)

https://claude.ai/code/session_019ZFqfAA5UykN1MiD8S48oU

---
_Generated by [Claude Code](https://claude.ai/code/session_019ZFqfAA5UykN1MiD8S48oU)_