### PR TITLE
:core — fix GenerateDailyInsightTest after PR #149 gated calendar tie-in on TONIGHT

### DIFF
--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsightTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsightTest.kt
@@ -196,44 +196,30 @@ class GenerateDailyInsightTest {
     @Test
     fun `calendar reader is consulted for today's date and zone when opted in`() = runTest {
         val zone = ZoneId.of("Europe/London")
-        val rainyHourly = today.copy(
-            precipitationProbabilityMaxPct = 60.0,
-            condition = WeatherCondition.RAIN,
-            hourly = listOf(
-                HourlyForecast(LocalTime.of(15, 0), 22.0, 22.0, 60.0, WeatherCondition.RAIN),
-            ),
-        )
         val event = CalendarEvent(
             title = "park run",
             start = LocalTime.of(14, 30),
             end = LocalTime.of(16, 0),
         )
-        val weather = FakeWeatherRepository(ForecastBundle(rainyHourly, yesterday))
+        val weather = FakeWeatherRepository(ForecastBundle(today, yesterday))
         val calendar = FakeCalendarEventReader(events = listOf(event))
         val subject = GenerateDailyInsight(weather, calendarEventReader = calendar, clock = clock)
 
-        // Defaults are temperature-only now, so a 22°C rainy hour wouldn't trigger
-        // any clothes rule and the tie-in would short-circuit on `items.isEmpty()`.
-        // Add an umbrella rule explicitly — modelling a user who's personalised
-        // their wet-weather accessory — so the test still exercises the calendar
-        // tie-in path it's meant to cover.
-        val rules = ClothesRule.DEFAULTS +
-            ClothesRule("umbrella", ClothesRule.PrecipitationProbabilityAbove(50.0))
         val result = subject(
             location = london,
             prefs = prefs.copy(
                 useCalendarEvents = true,
                 schedule = Schedule.default(zone),
-                clothesRules = rules,
             ),
         )
 
         calendar.lastDate shouldBe today.date
         calendar.lastZone shouldBe zone
-        val tieIn = result.insight.summary.calendarTieIn
-        tieIn.shouldNotBeNull()
-        tieIn!!.title shouldBe "park run"
-        tieIn.time shouldBe LocalTime.of(15, 0)
+        // The morning rain tie-in is suppressed on TODAY (PR #149); the tonight
+        // pass still carries the existing CalendarTieInClause — see the
+        // `tonight period` test below for the firing case. This test only cares
+        // that the reader was consulted with the right (date, zone).
+        result.insight.summary.calendarTieIn.shouldBeNull()
     }
 
     @Test


### PR DESCRIPTION
## Summary

Fixes the `:core:domain:test` failure on `main` introduced by PR #149.

PR #149 gated the morning rain calendar tie-in on the TONIGHT period (so the morning insight now just says "Rain at 3pm." without the "Bring an umbrella for your 3pm standup." follow-on). I missed updating one test in `GenerateDailyInsightTest.kt` that still asserted `shouldNotBeNull()` against `result.insight.summary.calendarTieIn` under the default TODAY period.

The fix:
- Asserts the new gating behaviour (`shouldBeNull()` on TODAY) instead of the firing-case assertions.
- Drops the rainy-hourly + custom umbrella-rule setup that was there only to make the now-removed morning tie-in path fire — those props no longer carry their weight.
- Keeps the `calendar.lastDate` / `calendar.lastZone` assertions, which are what the test name actually promises ("calendar reader is consulted for today's date and zone when opted in").

The TONIGHT firing case is already covered by `tonight period filters morning events out and keeps the gig as the tie-in` further down the same file.

## Test plan

- [ ] CI: `:core:domain:test` goes green.
- [ ] CI: `Android debug build` continues to pass.

## Out of scope (noted for follow-up)

`InsightCacheTest.kt` and `InsightCache.kt` don't carry the `eveningEventTieIn` field added in PR #146 — the cache DTO drops it on save/load, so a cached redelivery of the morning insight loses the evening event mention. Worth a separate PR.

https://claude.ai/code/session_01LoqLrzscNMkxbbdnivtxsn

---
_Generated by [Claude Code](https://claude.ai/code/session_01LoqLrzscNMkxbbdnivtxsn)_