### PR TITLE
:app + :core — fix red main CI, persist evening tie-in in cache, refresh KDoc

### DIFF
--- a/app/src/main/kotlin/app/clothescast/data/InsightCache.kt
+++ b/app/src/main/kotlin/app/clothescast/data/InsightCache.kt
@@ -11,6 +11,7 @@ import app.clothescast.core.domain.model.BandClause
 import app.clothescast.core.domain.model.CalendarTieInClause
 import app.clothescast.core.domain.model.ClothesClause
 import app.clothescast.core.domain.model.DeltaClause
+import app.clothescast.core.domain.model.EveningEventTieInClause
 import app.clothescast.core.domain.model.ForecastPeriod
 import app.clothescast.core.domain.model.HourlyForecast
 import app.clothescast.core.domain.model.Insight
@@ -128,6 +129,7 @@ class InsightCache(
         val clothes: ClothesDto? = null,
         val precip: PrecipDto? = null,
         val calendarTieIn: CalendarTieInDto? = null,
+        val eveningEventTieIn: EveningEventTieInDto? = null,
     ) {
         fun toDomain(): InsightSummary = InsightSummary(
             period = runCatching { ForecastPeriod.valueOf(period) }.getOrDefault(ForecastPeriod.TODAY),
@@ -137,6 +139,7 @@ class InsightCache(
             clothes = clothes?.toDomain(),
             precip = precip?.toDomain(),
             calendarTieIn = calendarTieIn?.toDomain(),
+            eveningEventTieIn = eveningEventTieIn?.toDomain(),
         )
     }
 
@@ -190,6 +193,17 @@ class InsightCache(
     }
 
     @Serializable
+    private data class EveningEventTieInDto(
+        val item: String,
+        val title: String,
+    ) {
+        fun toDomain(): EveningEventTieInClause = EveningEventTieInClause(
+            item = item,
+            title = title,
+        )
+    }
+
+    @Serializable
     private data class OutfitDto(val top: String, val bottom: String) {
         fun toDomain(): OutfitSuggestion? {
             val t = runCatching { OutfitSuggestion.Top.valueOf(top) }.getOrNull() ?: return null
@@ -237,6 +251,9 @@ class InsightCache(
         precip = precip?.let { PrecipDto(it.condition.name, it.time.toSecondOfDay()) },
         calendarTieIn = calendarTieIn?.let {
             CalendarTieInDto(it.item, it.time.toSecondOfDay(), it.title)
+        },
+        eveningEventTieIn = eveningEventTieIn?.let {
+            EveningEventTieInDto(it.item, it.title)
         },
     )
 

--- a/app/src/test/kotlin/app/clothescast/data/InsightCacheTest.kt
+++ b/app/src/test/kotlin/app/clothescast/data/InsightCacheTest.kt
@@ -10,6 +10,7 @@ import app.clothescast.core.domain.model.BandClause
 import app.clothescast.core.domain.model.CalendarTieInClause
 import app.clothescast.core.domain.model.ClothesClause
 import app.clothescast.core.domain.model.DeltaClause
+import app.clothescast.core.domain.model.EveningEventTieInClause
 import app.clothescast.core.domain.model.ForecastPeriod
 import app.clothescast.core.domain.model.HourlyForecast
 import app.clothescast.core.domain.model.Insight
@@ -177,6 +178,7 @@ class InsightCacheTest {
                 clothes = ClothesClause(listOf("sweater", "jacket", "shorts", "umbrella")),
                 precip = PrecipClause(WeatherCondition.RAIN, LocalTime.of(15, 0)),
                 calendarTieIn = CalendarTieInClause("umbrella", LocalTime.of(15, 0), "park run"),
+                eveningEventTieIn = EveningEventTieInClause("jacket", "dinner"),
             ),
         )
 

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/InsightSummary.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/InsightSummary.kt
@@ -3,11 +3,12 @@ package app.clothescast.core.domain.model
 import java.time.LocalTime
 
 /**
- * The structured form of a daily insight. Each clause is a pure-data description of
- * one of the six independent rules in [app.clothescast.core.domain.usecase.RenderInsightSummary]
- * (alert, band, delta, clothes, precip, calendar tie-in); the corresponding prose
- * is produced by an Android-side formatter that resolves item keys and templates
- * through string resources.
+ * The structured form of a daily insight. Each clause is a pure-data description
+ * of one of the seven independent rules in
+ * [app.clothescast.core.domain.usecase.RenderInsightSummary] (alert, band, delta,
+ * clothes, precip, calendar tie-in, evening-event tie-in); the corresponding
+ * prose is produced by an Android-side formatter that resolves item keys and
+ * templates through string resources.
  *
  * Splitting "what to say" (this) from "how to say it" (the formatter) lets us:
  *  - Localize clothes vocab per region without re-fetching the forecast — the
@@ -17,9 +18,14 @@ import java.time.LocalTime
  *    Android dependency, so it stays pure-Kotlin testable on the JVM.
  *
  * The [period] determines a couple of presentation choices: the band sentence's
- * lead-in ("Today will be …" vs "Tonight will be …"), and whether the [delta]
+ * lead-in ("Today will be …" vs "Tonight will be …"), whether the [delta]
  * clause is emitted at all (tonight skips the yesterday-vs-today comparison the
- * morning pass already covered).
+ * morning pass already covered), which tie-in clause carries event-mentions
+ * (TONIGHT uses [calendarTieIn]; TODAY uses [eveningEventTieIn] when the user
+ * opts in via "Mention evening events"), and whether [calendarTieIn] is
+ * suppressed entirely (it is on TODAY — the bare precip clause is enough,
+ * since the morning event the listener is mentally parsed against is already
+ * known to them).
  */
 data class InsightSummary(
     val period: ForecastPeriod,

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/RenderInsightSummary.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/RenderInsightSummary.kt
@@ -21,7 +21,7 @@ import kotlin.math.abs
 import kotlin.math.roundToInt
 
 /**
- * Builds the structured [InsightSummary] for a daily generation pass: up to six
+ * Builds the structured [InsightSummary] for a daily generation pass: up to seven
  * independent clauses, each driven by an independent rule. The presentation layer
  * (an Android-side formatter) turns this into the final prose, so anything
  * region- or locale-specific (clothes vocab, sentence templates, time formatting)
@@ -40,6 +40,15 @@ import kotlin.math.roundToInt
  * 6. [CalendarTieInClause] — when clothes + precip both fired AND a calendar
  *    event overlaps the precip peak hour. Picks "umbrella" when on the clothes
  *    list, otherwise the first triggered item, mirroring rule 4's ordering.
+ *    **Only emitted on [ForecastPeriod.TONIGHT].** On TODAY the bare precip
+ *    clause ("Rain at 3pm.") is enough — the listener already knows about
+ *    their morning event, so chaining a tie-in just repeats what they heard.
+ * 7. [EveningEventTieInClause] — the morning's heads-up about a cold/rainy
+ *    evening event, paired with a clothes item drawn from the *evening*
+ *    forecast slice. Only emits on [ForecastPeriod.TODAY], gated on the
+ *    caller passing non-empty [eveningEvents] + [eveningTriggeredRules]
+ *    (which the use case in turn gates on the user opting in via
+ *    "Mention evening events").
  *
  * All temperature comparisons use feels-like values, matching the clothes rules.
  */

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsightTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsightTest.kt
@@ -196,44 +196,30 @@ class GenerateDailyInsightTest {
     @Test
     fun `calendar reader is consulted for today's date and zone when opted in`() = runTest {
         val zone = ZoneId.of("Europe/London")
-        val rainyHourly = today.copy(
-            precipitationProbabilityMaxPct = 60.0,
-            condition = WeatherCondition.RAIN,
-            hourly = listOf(
-                HourlyForecast(LocalTime.of(15, 0), 22.0, 22.0, 60.0, WeatherCondition.RAIN),
-            ),
-        )
         val event = CalendarEvent(
             title = "park run",
             start = LocalTime.of(14, 30),
             end = LocalTime.of(16, 0),
         )
-        val weather = FakeWeatherRepository(ForecastBundle(rainyHourly, yesterday))
+        val weather = FakeWeatherRepository(ForecastBundle(today, yesterday))
         val calendar = FakeCalendarEventReader(events = listOf(event))
         val subject = GenerateDailyInsight(weather, calendarEventReader = calendar, clock = clock)
 
-        // Defaults are temperature-only now, so a 22°C rainy hour wouldn't trigger
-        // any clothes rule and the tie-in would short-circuit on `items.isEmpty()`.
-        // Add an umbrella rule explicitly — modelling a user who's personalised
-        // their wet-weather accessory — so the test still exercises the calendar
-        // tie-in path it's meant to cover.
-        val rules = ClothesRule.DEFAULTS +
-            ClothesRule("umbrella", ClothesRule.PrecipitationProbabilityAbove(50.0))
         val result = subject(
             location = london,
             prefs = prefs.copy(
                 useCalendarEvents = true,
                 schedule = Schedule.default(zone),
-                clothesRules = rules,
             ),
         )
 
         calendar.lastDate shouldBe today.date
         calendar.lastZone shouldBe zone
-        val tieIn = result.insight.summary.calendarTieIn
-        tieIn.shouldNotBeNull()
-        tieIn!!.title shouldBe "park run"
-        tieIn.time shouldBe LocalTime.of(15, 0)
+        // The morning rain tie-in is suppressed on TODAY (PR #149); the tonight
+        // pass still carries the existing CalendarTieInClause — see the
+        // `tonight period` test below for the firing case. This test only cares
+        // that the reader was consulted with the right (date, zone).
+        result.insight.summary.calendarTieIn.shouldBeNull()
     }
 
     @Test


### PR DESCRIPTION
## Summary

Three follow-ons after PR #149 merged. Squashed into one PR per the maintainer's request.

### 1. Fix red `:core:domain:test` on main

PR #149 gated the morning rain calendar tie-in on TONIGHT, but I missed updating one test in `GenerateDailyInsightTest.kt` that still asserted `shouldNotBeNull()` against `summary.calendarTieIn` under the default TODAY period. Switched to assert the new gating (`shouldBeNull()` on TODAY) and dropped the rainy-hourly + custom umbrella rule that was only there to make the now-removed morning tie-in path fire. The reader-is-consulted assertions — which is what the test name promises — stay.

### 2. Persist `eveningEventTieIn` in `InsightCache`

PR #146 added the `eveningEventTieIn` clause to `InsightSummary` but the cache DTO never grew a slot for it, so a cached redelivery of the morning insight (e.g. tapping Refresh later the same day) silently dropped the evening event mention. Added `EveningEventTieInDto(item, title)` with the same shape as the domain class and wired it through both ways. Round-trip test added.

### 3. Refresh KDoc

The class-level KDoc on `InsightSummary` and `RenderInsightSummary` still said "six clauses" and didn't reflect the per-period gating introduced in PR #149. Updated both — addresses the two Copilot review comments left on #149 after it merged ([thread 1](https://github.com/mikelward/clothescast/pull/149#discussion_r3151941805), [thread 2](https://github.com/mikelward/clothescast/pull/149#discussion_r3151941838)).

Supersedes / replaces #151.

## Test plan

- [ ] CI: `:core:domain:test` goes green again.
- [ ] CI: `Android debug build` passes.
- [ ] New `every clause type round-trips through the cache` assertion now also exercises `eveningEventTieIn` end-to-end via JSON DataStore.

https://claude.ai/code/session_01LoqLrzscNMkxbbdnivtxsn

---
_Generated by [Claude Code](https://claude.ai/code/session_01LoqLrzscNMkxbbdnivtxsn)_