### PR TITLE
:app + :core — drop calendar event titles from rendered prose; fold evening rain into evening tie-in

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,6 +124,19 @@ new rule the first time something bites you, not the third.
   If you see "no tests found" after adding a `@Test`-annotated JUnit 4
   class, check that `vintage-engine` is on the test classpath.
 
+## Privacy
+
+- **Surface any change to what we send off device.** When a change touches
+  data that crosses the device boundary — anything in the rendered insight
+  prose (it's fed to Gemini / OpenAI / ElevenLabs TTS over BYOK keys),
+  weather / geocoding requests, or future analytics / error reporting —
+  call it out explicitly in the PR description and commit message. Calendar
+  event titles, locations, contacts, identifiers: default is "less, not
+  more" — if you're broadening what leaves the device, flag it for review
+  even if it seems harmless. The TTS endpoints log requests; "the user's
+  3pm standup" landing in someone's logs is exactly the surprise the user
+  doesn't want.
+
 ## Domain conventions
 
 - Clothes rules and outfit suggestions both look at *feels-like*

--- a/app/src/main/kotlin/app/clothescast/data/InsightCache.kt
+++ b/app/src/main/kotlin/app/clothescast/data/InsightCache.kt
@@ -180,26 +180,18 @@ class InsightCache(
     }
 
     @Serializable
-    private data class CalendarTieInDto(
-        val item: String,
-        val secondOfDay: Int,
-        val title: String,
-    ) {
-        fun toDomain(): CalendarTieInClause = CalendarTieInClause(
-            item = item,
-            time = LocalTime.ofSecondOfDay(secondOfDay.toLong()),
-            title = title,
-        )
+    private data class CalendarTieInDto(val item: String) {
+        fun toDomain(): CalendarTieInClause = CalendarTieInClause(item = item)
     }
 
     @Serializable
     private data class EveningEventTieInDto(
         val item: String,
-        val title: String,
+        val rainSecondOfDay: Int? = null,
     ) {
         fun toDomain(): EveningEventTieInClause = EveningEventTieInClause(
             item = item,
-            title = title,
+            rainTime = rainSecondOfDay?.let { LocalTime.ofSecondOfDay(it.toLong()) },
         )
     }
 
@@ -249,11 +241,9 @@ class InsightCache(
         delta = delta?.let { DeltaDto(it.degrees, it.direction.name) },
         clothes = clothes?.let { ClothesDto(it.items) },
         precip = precip?.let { PrecipDto(it.condition.name, it.time.toSecondOfDay()) },
-        calendarTieIn = calendarTieIn?.let {
-            CalendarTieInDto(it.item, it.time.toSecondOfDay(), it.title)
-        },
+        calendarTieIn = calendarTieIn?.let { CalendarTieInDto(it.item) },
         eveningEventTieIn = eveningEventTieIn?.let {
-            EveningEventTieInDto(it.item, it.title)
+            EveningEventTieInDto(it.item, it.rainTime?.toSecondOfDay())
         },
     )
 

--- a/app/src/main/kotlin/app/clothescast/insight/InsightFormatter.kt
+++ b/app/src/main/kotlin/app/clothescast/insight/InsightFormatter.kt
@@ -32,10 +32,11 @@ import java.util.Locale
  *
  * Times are rendered as natural language ("midnight", "2am", "noon", "3pm") —
  * better for TTS than "02:00" and identical text feeds both UI and speech.
- * Early-morning peaks (00:00–04:59) collapse to "overnight" when no calendar
- * event pins the hour. The spoken-time logic itself is English-specific; the
- * default impl falls back to 24h ASCII for non-English locales until a
- * dedicated formatter is added.
+ * Early-morning precip peaks (00:00–04:59) always collapse to "overnight" —
+ * the previous "only when no tie-in pins this hour" carve-out is gone now
+ * that tie-in clauses no longer name a specific time. The spoken-time logic
+ * itself is English-specific; the default impl falls back to 24h ASCII for
+ * non-English locales until a dedicated formatter is added.
  */
 class InsightFormatter(
     private val resources: Resources,

--- a/app/src/main/kotlin/app/clothescast/insight/InsightFormatter.kt
+++ b/app/src/main/kotlin/app/clothescast/insight/InsightFormatter.kt
@@ -107,16 +107,17 @@ class InsightFormatter(
     private fun formatTieIn(item: String): String =
         resources.getString(R.string.insight_tie_in, phraser.withArticle(item))
 
-    private fun formatEveningEventTieIn(tieIn: EveningEventTieInClause): String =
-        if (tieIn.rainTime != null) {
-            resources.getString(
-                R.string.insight_tie_in_with_rain,
-                phraser.withArticle(tieIn.item),
-                spokenTime(tieIn.rainTime),
-            )
-        } else {
-            formatTieIn(tieIn.item)
-        }
+    private fun formatEveningEventTieIn(tieIn: EveningEventTieInClause): String {
+        // Local capture so the null check enables smart cast — the property
+        // lives on a :core:domain data class and Kotlin won't smart-cast a
+        // public API property across modules.
+        val rainTime = tieIn.rainTime ?: return formatTieIn(tieIn.item)
+        return resources.getString(
+            R.string.insight_tie_in_with_rain,
+            phraser.withArticle(tieIn.item),
+            spokenTime(rainTime),
+        )
+    }
 
     private fun leadRes(period: ForecastPeriod): Int = when (period) {
         ForecastPeriod.TODAY -> R.string.insight_lead_today

--- a/app/src/main/kotlin/app/clothescast/insight/InsightFormatter.kt
+++ b/app/src/main/kotlin/app/clothescast/insight/InsightFormatter.kt
@@ -6,7 +6,6 @@ import android.content.res.Resources
 import app.clothescast.R
 import app.clothescast.core.domain.model.AlertClause
 import app.clothescast.core.domain.model.BandClause
-import app.clothescast.core.domain.model.CalendarTieInClause
 import app.clothescast.core.domain.model.ClothesClause
 import app.clothescast.core.domain.model.DeltaClause
 import app.clothescast.core.domain.model.EveningEventTieInClause
@@ -49,8 +48,15 @@ class InsightFormatter(
         add(formatBand(summary.period, summary.band))
         summary.delta?.let { add(formatDelta(it)) }
         summary.clothes?.let { add(formatClothes(it)) }
-        summary.precip?.let { add(formatPrecip(it, hasCalendarTieIn = summary.calendarTieIn != null)) }
-        summary.calendarTieIn?.let { add(formatCalendarTieIn(it)) }
+        summary.precip?.let { add(formatPrecip(it)) }
+        // Both tie-in clauses share the item-only "Bring a X tonight." form;
+        // the evening one additionally folds in the evening forecast's rain
+        // time when it's ≥ 30%, since the morning's own precip clause only
+        // covers the morning slice and otherwise wouldn't surface evening
+        // rain. The clauses are separate fields because they're gated
+        // differently (TONIGHT precip-peak overlap vs. TODAY evening-event
+        // opt-in).
+        summary.calendarTieIn?.let { add(formatTieIn(it.item)) }
         summary.eveningEventTieIn?.let { add(formatEveningEventTieIn(it)) }
     }.joinToString(" ")
 
@@ -86,13 +92,11 @@ class InsightFormatter(
     private fun formatClothes(clothes: ClothesClause): String =
         resources.getString(R.string.insight_clothes_wear, phraser.joinItems(clothes.items))
 
-    private fun formatPrecip(precip: PrecipClause, hasCalendarTieIn: Boolean): String {
+    private fun formatPrecip(precip: PrecipClause): String {
         val type = resources.getString(conditionRes(precip.condition))
-        // "Rain at 02:00" sounds robotic and a precise hour adds little value when
-        // the user is asleep. Collapse early-morning peaks to "overnight" — but only
-        // when there's no calendar tie-in pinning the time, since that clause names
-        // the same hour and the two should agree.
-        val timePhrase = if (precip.time.hour in OVERNIGHT_HOURS && !hasCalendarTieIn) {
+        // "Rain at 02:00" sounds robotic and a precise hour adds little value
+        // when the user is asleep — collapse early-morning peaks to "overnight".
+        val timePhrase = if (precip.time.hour in OVERNIGHT_HOURS) {
             resources.getString(R.string.insight_precip_overnight)
         } else {
             resources.getString(R.string.insight_precip_at_time, spokenTime(precip.time))
@@ -100,20 +104,19 @@ class InsightFormatter(
         return resources.getString(R.string.insight_precip, type, timePhrase)
     }
 
-    private fun formatCalendarTieIn(tieIn: CalendarTieInClause): String =
-        resources.getString(
-            R.string.insight_calendar_tie_in,
-            phraser.withArticle(tieIn.item),
-            spokenTime(tieIn.time),
-            tieIn.title,
-        )
+    private fun formatTieIn(item: String): String =
+        resources.getString(R.string.insight_tie_in, phraser.withArticle(item))
 
     private fun formatEveningEventTieIn(tieIn: EveningEventTieInClause): String =
-        resources.getString(
-            R.string.insight_evening_event_tie_in,
-            phraser.withArticle(tieIn.item),
-            tieIn.title,
-        )
+        if (tieIn.rainTime != null) {
+            resources.getString(
+                R.string.insight_tie_in_with_rain,
+                phraser.withArticle(tieIn.item),
+                spokenTime(tieIn.rainTime),
+            )
+        } else {
+            formatTieIn(tieIn.item)
+        }
 
     private fun leadRes(period: ForecastPeriod): Int = when (period) {
         ForecastPeriod.TODAY -> R.string.insight_lead_today

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -118,6 +118,6 @@ the rest of the app stays in English.
     <string name="insight_condition_thunderstorm">Gewitter</string>
     <string name="insight_condition_unknown">Unbekannt</string>
 
-    <!-- "Denk an Regenschirm für park run um 15:00." -->
-    <string name="insight_calendar_tie_in">Denk an %1$s für %3$s um %2$s.</string>
+    <string name="insight_tie_in">Denk an %1$s für heute Abend.</string>
+    <string name="insight_tie_in_with_rain">Denk an %1$s für heute Abend, Regen um %2$s.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -347,8 +347,9 @@
     <string name="insight_precip">%1$s %2$s.</string>
     <!-- Inserted as %2$s above when the peak hour is named — e.g. "at 3pm". -->
     <string name="insight_precip_at_time">at %1$s</string>
-    <!-- Replaces the time phrase entirely for early-morning peaks (00:00–04:59)
-         when no calendar tie-in pins the hour. -->
+    <!-- Replaces the time phrase entirely for early-morning peaks
+         (00:00–04:59) — "Rain at 2am" sounds robotic and the user is asleep
+         anyway. -->
     <string name="insight_precip_overnight">overnight</string>
 
     <!--

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -377,17 +377,21 @@
     <string name="insight_condition_unknown">Unknown</string>
 
     <!--
-    Calendar tie-in — picks an event-relevant item for a specific upcoming
-    event. %1$s = item phrase (with article, via the same phraser as clothes),
-    %2$s = HH:mm event time, %3$s = event title.
+    Tie-in clause — appended after the precip clause on TONIGHT (when the precip
+    peak overlaps a calendar event) or on TODAY's morning insight (when the user
+    has "Mention evening events" on and there's an evening event). %1$s = item
+    phrase (with article, via the same phraser as clothes). No event title or
+    time deliberately: titles never flow off-device (the prose is fed to TTS
+    engines over BYOK keys), and the "tonight" anchor is enough — the listener
+    already knows their schedule.
     -->
-    <string name="insight_calendar_tie_in">Bring %1$s for your %2$s %3$s.</string>
+    <string name="insight_tie_in">Bring %1$s tonight.</string>
     <!--
-    Evening-event tie-in attached to the morning insight when "Mention evening
-    events" is on. %1$s = item phrase (with article, via the same phraser as
-    clothes), %2$s = event title. No time deliberately — the user already knows
-    when their event is, and the conversational "tonight" reads better than a
-    redundant clock reference.
+    Variant of insight_tie_in for the morning insight's evening tie-in when the
+    evening forecast also has rain ≥ 30%. Folds the rain time into the same
+    sentence so the morning insight mentions evening rain alongside the evening
+    clothing tip, without emitting a second precip clause that would compete
+    with the morning slice's own. %1$s = item phrase, %2$s = spoken time.
     -->
-    <string name="insight_evening_event_tie_in">Bring %1$s for your %2$s tonight.</string>
+    <string name="insight_tie_in_with_rain">Bring %1$s tonight, rain at %2$s.</string>
 </resources>

--- a/app/src/test/kotlin/app/clothescast/data/InsightCacheTest.kt
+++ b/app/src/test/kotlin/app/clothescast/data/InsightCacheTest.kt
@@ -177,8 +177,8 @@ class InsightCacheTest {
                 delta = DeltaClause(8, DeltaClause.Direction.WARMER),
                 clothes = ClothesClause(listOf("sweater", "jacket", "shorts", "umbrella")),
                 precip = PrecipClause(WeatherCondition.RAIN, LocalTime.of(15, 0)),
-                calendarTieIn = CalendarTieInClause("umbrella", LocalTime.of(15, 0), "park run"),
-                eveningEventTieIn = EveningEventTieInClause("jacket", "dinner"),
+                calendarTieIn = CalendarTieInClause("umbrella"),
+                eveningEventTieIn = EveningEventTieInClause("jacket", rainTime = LocalTime.of(21, 0)),
             ),
         )
 

--- a/app/src/test/kotlin/app/clothescast/insight/InsightFormatterTest.kt
+++ b/app/src/test/kotlin/app/clothescast/insight/InsightFormatterTest.kt
@@ -120,41 +120,15 @@ class InsightFormatterTest {
     }
 
     @Test
-    fun `precip clause says 'overnight' for early-morning peak when no calendar tie-in`() {
+    fun `precip clause says 'overnight' for early-morning peak`() {
         subject.format(summary(precip = PrecipClause(WeatherCondition.RAIN, LocalTime.of(2, 0)))) shouldBe
             "Today will be mild. Rain overnight."
     }
 
     @Test
-    fun `precip clause says 'overnight' for midnight peak when no calendar tie-in`() {
+    fun `precip clause says 'overnight' for midnight peak`() {
         subject.format(summary(precip = PrecipClause(WeatherCondition.SNOW, LocalTime.MIDNIGHT))) shouldBe
             "Today will be mild. Snow overnight."
-    }
-
-    @Test
-    fun `precip clause names the hour even overnight when a calendar tie-in pins the same time`() {
-        // The tie-in clause spells out "your 2am yoga class" — the precip clause
-        // should agree on the time rather than collapse to "overnight".
-        val out = subject.format(
-            summary(
-                clothes = ClothesClause(listOf("umbrella")),
-                precip = PrecipClause(WeatherCondition.RAIN, LocalTime.of(2, 0)),
-                calendarTieIn = CalendarTieInClause("umbrella", LocalTime.of(2, 0), "yoga class"),
-            ),
-        )
-        out shouldBe "Today will be mild. Wear an umbrella. Rain at 2am. Bring an umbrella for your 2am yoga class."
-    }
-
-    @Test
-    fun `precip clause uses 'midnight' when calendar tie-in pins 00-00`() {
-        val out = subject.format(
-            summary(
-                clothes = ClothesClause(listOf("umbrella")),
-                precip = PrecipClause(WeatherCondition.RAIN, LocalTime.MIDNIGHT),
-                calendarTieIn = CalendarTieInClause("umbrella", LocalTime.MIDNIGHT, "stargazing"),
-            ),
-        )
-        out shouldBe "Today will be mild. Wear an umbrella. Rain at midnight. Bring an umbrella for your midnight stargazing."
     }
 
     @Test
@@ -176,25 +150,36 @@ class InsightFormatterTest {
     }
 
     @Test
-    fun `calendar tie-in renders bring + article + spoken time + title`() {
+    fun `calendar tie-in renders 'Bring a item tonight' with no event title`() {
         val out = subject.format(
             summary(
+                period = ForecastPeriod.TONIGHT,
                 clothes = ClothesClause(listOf("umbrella")),
-                precip = PrecipClause(WeatherCondition.RAIN, LocalTime.of(15, 0)),
-                calendarTieIn = CalendarTieInClause("umbrella", LocalTime.of(15, 0), "park run"),
+                precip = PrecipClause(WeatherCondition.RAIN, LocalTime.of(21, 0)),
+                calendarTieIn = CalendarTieInClause("umbrella"),
             ),
         )
-        out shouldBe "Today will be mild. Wear an umbrella. Rain at 3pm. Bring an umbrella for your 3pm park run."
+        out shouldBe "Tonight will be mild. Wear an umbrella. Rain at 9pm. Bring an umbrella tonight."
     }
 
     @Test
-    fun `evening event tie-in renders bring + article + title + tonight (no time)`() {
+    fun `evening event tie-in renders 'Bring a item tonight' when no evening rain`() {
         val out = subject.format(
             summary(
-                eveningEventTieIn = EveningEventTieInClause("jacket", "dinner"),
+                eveningEventTieIn = EveningEventTieInClause("jacket"),
             ),
         )
-        out shouldBe "Today will be mild. Bring a jacket for your dinner tonight."
+        out shouldBe "Today will be mild. Bring a jacket tonight."
+    }
+
+    @Test
+    fun `evening event tie-in folds rain time into the same sentence when present`() {
+        val out = subject.format(
+            summary(
+                eveningEventTieIn = EveningEventTieInClause("umbrella", rainTime = LocalTime.of(21, 0)),
+            ),
+        )
+        out shouldBe "Today will be mild. Bring an umbrella tonight, rain at 9pm."
     }
 
     @Test
@@ -202,10 +187,10 @@ class InsightFormatterTest {
         val out = subject.format(
             summary(
                 clothes = ClothesClause(listOf("shorts")),
-                eveningEventTieIn = EveningEventTieInClause("jacket", "dinner"),
+                eveningEventTieIn = EveningEventTieInClause("jacket"),
             ),
         )
-        out shouldBe "Today will be mild. Wear shorts. Bring a jacket for your dinner tonight."
+        out shouldBe "Today will be mild. Wear shorts. Bring a jacket tonight."
     }
 
     @Test
@@ -275,14 +260,25 @@ class InsightFormatterTest {
     }
 
     @Test
-    fun `de — calendar tie-in reorders args via positional placeholders`() {
+    fun `de — tie-in renders the German template with item only`() {
         val out = germanSubject.format(
             summary(
+                period = ForecastPeriod.TONIGHT,
                 clothes = ClothesClause(listOf("Regenschirm")),
-                calendarTieIn = CalendarTieInClause("Regenschirm", LocalTime.of(15, 0), "Park-Lauf"),
+                calendarTieIn = CalendarTieInClause("Regenschirm"),
             ),
         )
-        out shouldBe "Heute wird es mild. Trag Regenschirm. " +
-            "Denk an Regenschirm für Park-Lauf um 15:00."
+        out shouldBe "Heute Abend wird es mild. Trag Regenschirm. " +
+            "Denk an Regenschirm für heute Abend."
+    }
+
+    @Test
+    fun `de — evening event tie-in folds rain time via German positional placeholders`() {
+        val out = germanSubject.format(
+            summary(
+                eveningEventTieIn = EveningEventTieInClause("Regenschirm", rainTime = LocalTime.of(21, 0)),
+            ),
+        )
+        out shouldBe "Heute wird es mild. Denk an Regenschirm für heute Abend, Regen um 21:00."
     }
 }

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/InsightSummary.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/InsightSummary.kt
@@ -89,26 +89,32 @@ data class ClothesClause(val items: List<String>)
 data class PrecipClause(val condition: WeatherCondition, val time: LocalTime)
 
 /**
- * Calendar tie-in: a clothes [item] paired with a calendar event that overlaps
- * the precipitation peak. The formatter renders this as "Bring <item> for your
- * <time> <title>." with article picking on [item].
+ * Calendar tie-in: a clothes [item] keyed off the precipitation peak overlapping
+ * a calendar event. The formatter renders this as "Bring <item> tonight." — no
+ * event title, because we never want a calendar event name in the rendered prose
+ * (the prose is fed to off-device TTS engines), and no time, because the matched
+ * event is already pinned to the precip clause's hour. Only emitted on
+ * [ForecastPeriod.TONIGHT]; on [ForecastPeriod.TODAY] the bare precip clause
+ * carries the message.
  */
-data class CalendarTieInClause(
-    val item: String,
-    val time: LocalTime,
-    val title: String,
-)
+data class CalendarTieInClause(val item: String)
 
 /**
- * Evening-event tie-in for the morning insight: a clothes [item] paired with a
- * calendar event [title] happening tonight. The formatter renders this as
- * "Bring <item> for your <title> tonight." — no time, because the user already
- * knows when their evening event is and the conversational wording reads better
- * than a redundant clock reference.
+ * Evening-event tie-in for the morning insight: a clothes [item] hinted at by
+ * an evening calendar event. The formatter renders this as "Bring <item>
+ * tonight." — no event title, for the same off-device-prose reason as
+ * [CalendarTieInClause]. Only emitted on [ForecastPeriod.TODAY] when the user
+ * has the "Mention evening events" setting on.
+ *
+ * When the evening forecast slice has rain ≥ 30%, [rainTime] carries the peak
+ * hour and the formatter folds it into the same sentence ("Bring an umbrella
+ * tonight, rain at 9pm.") — keeps the morning insight's mention of evening rain
+ * tied to the evening event, rather than emitting a second precip clause that
+ * would compete with the morning slice's own precip clause.
  */
 data class EveningEventTieInClause(
     val item: String,
-    val title: String,
+    val rainTime: LocalTime? = null,
 )
 
 /**

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsight.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsight.kt
@@ -111,6 +111,7 @@ class GenerateDailyInsight(
             period = period,
             eveningEvents = eveningEvents,
             eveningTriggeredRules = eveningTriggered,
+            eveningForecast = if (period == ForecastPeriod.TODAY) tonightForecast else null,
         )
         val insight = Insight(
             summary = summary,

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsight.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsight.kt
@@ -90,8 +90,10 @@ class GenerateDailyInsight(
         // Morning-only: when the user opted in to "Mention evening events", we
         // also evaluate clothes rules against the evening slice and pass any
         // evening events through so the renderer can attach a tie-in clause
-        // ("Bring a jacket for your 9pm dinner."). Cheap to compute — both
-        // inputs already live in this scope.
+        // ("Bring a jacket tonight." — or "Bring an umbrella tonight, rain at
+        // 9pm." when the evening slice has rain). Event titles never appear
+        // in the rendered prose; see the AGENTS.md privacy note. Cheap to
+        // compute — both inputs already live in this scope.
         val eveningEvents = if (period == ForecastPeriod.TODAY && prefs.dailyMentionEveningEvents) {
             allEvents.filter { !it.allDay && !it.start.isBefore(tonightStart) }
         } else {

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/RenderInsightSummary.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/RenderInsightSummary.kt
@@ -62,9 +62,23 @@ class RenderInsightSummary {
         period: ForecastPeriod = ForecastPeriod.TODAY,
         eveningEvents: List<CalendarEvent> = emptyList(),
         eveningTriggeredRules: List<ClothesRule> = emptyList(),
+        eveningForecast: DailyForecast? = null,
     ): InsightSummary {
         val items = todayTriggeredRules.map { it.item }
         val peak = peakPrecip(today)
+        // Compute the evening peak only when the evening tie-in is going to
+        // emit (i.e. caller passed events + triggered rules + an evening
+        // forecast). Avoids spending the search on every TODAY pass, and
+        // keeps the result strictly scoped to the tie-in clause.
+        val eveningPeak = if (
+            period == ForecastPeriod.TODAY &&
+            eveningEvents.isNotEmpty() &&
+            eveningTriggeredRules.isNotEmpty()
+        ) {
+            eveningForecast?.let { peakPrecip(it) }
+        } else {
+            null
+        }
         return InsightSummary(
             period = period,
             alert = alertClause(alerts),
@@ -80,7 +94,7 @@ class RenderInsightSummary {
             // enough; chaining "Bring an umbrella for your 3pm standup." after
             // it just repeats what the user already heard.
             calendarTieIn = if (period == ForecastPeriod.TONIGHT) calendarTieInClause(items, peak, events) else null,
-            eveningEventTieIn = eveningEventTieInClause(period, eveningEvents, eveningTriggeredRules),
+            eveningEventTieIn = eveningEventTieInClause(period, eveningEvents, eveningTriggeredRules, eveningPeak),
         )
     }
 
@@ -157,12 +171,16 @@ class RenderInsightSummary {
         events: List<CalendarEvent>,
     ): CalendarTieInClause? {
         if (items.isEmpty() || peak == null || events.isEmpty()) return null
-        val event = events.firstOrNull { it.overlaps(peak.time) } ?: return null
+        // Need an overlapping event to motivate the clause, but we don't capture
+        // the event's title or time — neither is in the rendered prose, and we
+        // never want a calendar event title flowing through to off-device TTS
+        // (the prose is fed to Gemini / OpenAI / ElevenLabs over BYOK keys).
+        events.firstOrNull { it.overlaps(peak.time) } ?: return null
         // Prefer "umbrella" when the user has it on their list — that's the clothes
         // item the precip-peak overlap was actually motivated by. Otherwise just
         // take the first triggered item, mirroring rule 4's ordering.
         val item = items.firstOrNull { it.equals("umbrella", ignoreCase = true) } ?: items.first()
-        return CalendarTieInClause(item = item, time = peak.time, title = event.title)
+        return CalendarTieInClause(item = item)
     }
 
     /**
@@ -177,13 +195,17 @@ class RenderInsightSummary {
         period: ForecastPeriod,
         eveningEvents: List<CalendarEvent>,
         eveningTriggeredRules: List<ClothesRule>,
+        eveningPeak: PeakPrecip?,
     ): EveningEventTieInClause? {
         if (period != ForecastPeriod.TODAY) return null
         if (eveningEvents.isEmpty() || eveningTriggeredRules.isEmpty()) return null
-        val event = eveningEvents.firstOrNull { !it.allDay } ?: return null
+        // Gate on at least one non-all-day evening event existing, but don't
+        // capture its title — the rendered prose only says "Bring a jacket
+        // tonight." Calendar event titles never flow to off-device TTS.
+        eveningEvents.firstOrNull { !it.allDay } ?: return null
         val items = eveningTriggeredRules.map { it.item }
         val item = items.firstOrNull { it.equals("umbrella", ignoreCase = true) } ?: items.first()
-        return EveningEventTieInClause(item = item, title = event.title)
+        return EveningEventTieInClause(item = item, rainTime = eveningPeak?.time)
     }
 
     private data class PeakPrecip(val time: LocalTime, val condition: WeatherCondition)

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsightTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsightTest.kt
@@ -486,11 +486,16 @@ class GenerateDailyInsightTest {
             period = ForecastPeriod.TONIGHT,
         )
 
-        // Morning event must be filtered out for the tonight pass; the gig must drive the tie-in.
+        // Morning event must be filtered out for the tonight pass; the gig
+        // must drive the tie-in. The tie-in's data class only carries the
+        // clothes item now (event title + time were dropped to keep calendar
+        // event metadata off-device); the precip clause still names the
+        // 8pm rain. With temperature-only defaults firing on the 14°C feels-like
+        // and no umbrella rule, the picked item is the first triggered: sweater.
         val tieIn = result.insight.summary.calendarTieIn
         tieIn.shouldNotBeNull()
-        tieIn!!.title shouldBe "gig"
-        tieIn.time shouldBe LocalTime.of(20, 0)
+        tieIn!!.item shouldBe "sweater"
+        result.insight.summary.precip!!.time shouldBe LocalTime.of(20, 0)
         result.insight.hasEvents shouldBe true
     }
 

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/RenderInsightSummaryTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/RenderInsightSummaryTest.kt
@@ -196,7 +196,53 @@ class RenderInsightSummaryTest {
         val tie = out.eveningEventTieIn
         tie.shouldNotBeNull()
         tie!!.item shouldBe "jacket"
-        tie.title shouldBe "dinner"
+        // No title or rainTime — caller didn't pass an evening forecast and
+        // we never carry the event title in the rendered prose.
+        tie.rainTime.shouldBeNull()
+    }
+
+    @Test
+    fun `evening event tie-in carries rain time when evening forecast peaks above 30 percent`() {
+        val event = CalendarEvent("dinner", LocalTime.of(21, 0), LocalTime.of(23, 0))
+        val rainyEvening = mildToday.copy(
+            precipitationProbabilityMaxPct = 60.0,
+            condition = WeatherCondition.RAIN,
+            hourly = listOf(HourlyForecast(LocalTime.of(21, 0), 12.0, 10.0, 60.0, WeatherCondition.RAIN)),
+        )
+        val out = subject(
+            today = mildToday,
+            yesterday = yesterday,
+            todayTriggeredRules = emptyList(),
+            eveningEvents = listOf(event),
+            eveningTriggeredRules = listOf(umbrellaRule),
+            eveningForecast = rainyEvening,
+        )
+        val tie = out.eveningEventTieIn
+        tie.shouldNotBeNull()
+        tie!!.item shouldBe "umbrella"
+        tie.rainTime shouldBe LocalTime.of(21, 0)
+    }
+
+    @Test
+    fun `evening event tie-in omits rain time when evening peak is below threshold`() {
+        val event = CalendarEvent("dinner", LocalTime.of(21, 0), LocalTime.of(23, 0))
+        val dryEvening = mildToday.copy(
+            precipitationProbabilityMaxPct = 5.0,
+            condition = WeatherCondition.PARTLY_CLOUDY,
+            hourly = listOf(HourlyForecast(LocalTime.of(21, 0), 8.0, 6.0, 5.0, WeatherCondition.PARTLY_CLOUDY)),
+        )
+        val out = subject(
+            today = mildToday,
+            yesterday = yesterday,
+            todayTriggeredRules = emptyList(),
+            eveningEvents = listOf(event),
+            eveningTriggeredRules = listOf(jacketRule),
+            eveningForecast = dryEvening,
+        )
+        val tie = out.eveningEventTieIn
+        tie.shouldNotBeNull()
+        tie!!.item shouldBe "jacket"
+        tie.rainTime.shouldBeNull()
     }
 
     @Test
@@ -376,8 +422,10 @@ class RenderInsightSummaryTest {
         ).calendarTieIn
         out.shouldNotBeNull()
         out!!.item shouldBe "umbrella"
-        out.time shouldBe LocalTime.of(15, 0)
-        out.title shouldBe "park run"
+        // No time or title in the clause — the clause only carries the
+        // clothes item now; the precip clause's own time covers "Rain at
+        // 3pm.", and event titles never flow off-device via the rendered
+        // prose.
     }
 
     @Test


### PR DESCRIPTION
## Privacy impact (per the new AGENTS.md rule this PR also adds)

The rendered insight prose is fed to off-device TTS engines (Gemini / OpenAI / ElevenLabs over BYOK keys). Calendar event titles like *"3pm standup"* and *"9pm dinner"* were ending up in those API requests. This PR removes event titles from the rendered prose entirely.

## Summary

### 1. Drop event titles from both tie-ins

- **`CalendarTieInClause`** (TONIGHT only): now carries only the clothes item. Rendered prose: *"Bring an umbrella tonight."* (was *"Bring an umbrella for your 8pm dinner."*). The TONIGHT pass's existing `PrecipClause` continues to name the rain hour right before it ("Rain at 9pm."), so the time info isn't lost.
- **`EveningEventTieInClause`** (TODAY only, behind "Mention evening events"): loses its title field, gains an optional `rainTime`. When the morning insight's evening forecast slice has rain ≥ 30%, the tie-in folds the rain time into the same sentence — *"Bring an umbrella tonight, rain at 9pm."* Otherwise stays as the bare *"Bring a jacket tonight."* The morning slice's own precip clause only covers 07:00–19:00, so without this rainTime fold the morning insight would silently drop any evening rain mention.

### 2. New AGENTS.md privacy rule

Adds a `## Privacy` section that calls out the boundary explicitly: *"Surface any change to what we send off device."* This PR is itself the kind of change the rule is about — flagged here in the commit and PR body per that rule.

### 3. Cleanup

- `formatPrecip` drops the `hasCalendarTieIn` coordination param. The tie-in no longer pins a specific hour, so there's nothing to coordinate with for the overnight-collapse logic; 00:00–04:59 peaks always collapse to "overnight" now.
- Strings: `insight_calendar_tie_in` and `insight_evening_event_tie_in` collapse into one shared `insight_tie_in` (*"Bring %1$s tonight."*), with an evening-only `insight_tie_in_with_rain` variant. German translations follow.
- Cache DTOs shrink (`CalendarTieInDto`: just `item`; `EveningEventTieInDto`: `item` + nullable `rainSecondOfDay`).

## Examples (morning insight)

| Scenario | Before | After |
|---|---|---|
| Rainy 9pm dinner, *Mention evening events* on, evening forecast has rain at 21:00 | "Today will be mild. Wear a sweater. Bring a jacket for your 9pm dinner." | "Today will be mild. Wear a sweater. **Bring an umbrella tonight, rain at 9pm.**" |
| Cool 9pm dinner, *Mention evening events* on, no evening rain | "Today will be mild. Wear a sweater. Bring a jacket for your 9pm dinner." | "Today will be mild. Wear a sweater. **Bring a jacket tonight.**" |

## Examples (tonight insight)

| Scenario | Before | After |
|---|---|---|
| Tonight pass with 8pm dinner + rain at 8pm | "Tonight will be cool. Wear an umbrella. Rain at 8pm. Bring an umbrella for your 8pm dinner." | "Tonight will be cool. Wear an umbrella. Rain at 8pm. **Bring an umbrella tonight.**" |

## Test plan

- [ ] CI: `:core:domain:test` (clause shape + rain-time fold cases).
- [ ] CI: `:app:testDebugUnitTest` (formatter prose + cache round-trip).
- [ ] CI: `Android debug build`.
- [ ] Manual sanity: morning insight on a day with a cold evening event + no evening rain — confirm "Bring a jacket tonight."
- [ ] Manual sanity: morning insight on a day with a wet evening + event — confirm "Bring an umbrella tonight, rain at 9pm."
- [ ] Manual sanity: TTS playback (Gemini / OpenAI) — capture the request body and confirm no event titles in the prose.

Sandbox couldn't run `:core:domain:test` (Google Maven blocked → AGP plugin fails to resolve), so all validation is via CI.

https://claude.ai/code/session_01LoqLrzscNMkxbbdnivtxsn

---
_Generated by [Claude Code](https://claude.ai/code/session_01LoqLrzscNMkxbbdnivtxsn)_