### PR TITLE
:app + :core — add Arabic, Hebrew, Persian (RTL) language support

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/settings/RegionSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/RegionSettings.kt
@@ -93,6 +93,9 @@ private fun regionLabel(region: Region): Int = when (region) {
     Region.BN_BD -> R.string.settings_region_language_bn_bd
     Region.JA_JP -> R.string.settings_region_language_ja_jp
     Region.KO_KR -> R.string.settings_region_language_ko_kr
+    Region.AR_SA -> R.string.settings_region_language_ar_sa
+    Region.HE_IL -> R.string.settings_region_language_he_il
+    Region.FA_IR -> R.string.settings_region_language_fa_ir
 }
 
 private fun temperatureUnitLabel(unit: TemperatureUnit): Int = when (unit) {

--- a/app/src/main/kotlin/app/clothescast/ui/settings/VoiceSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/VoiceSettings.kt
@@ -358,6 +358,9 @@ private fun voiceLocaleLabel(locale: VoiceLocale): Int = when (locale) {
     VoiceLocale.BN_BD -> R.string.settings_tts_voice_locale_bn_bd
     VoiceLocale.JA_JP -> R.string.settings_tts_voice_locale_ja_jp
     VoiceLocale.KO_KR -> R.string.settings_tts_voice_locale_ko_kr
+    VoiceLocale.AR_SA -> R.string.settings_tts_voice_locale_ar_sa
+    VoiceLocale.HE_IL -> R.string.settings_tts_voice_locale_he_il
+    VoiceLocale.FA_IR -> R.string.settings_tts_voice_locale_fa_ir
 }
 
 @Composable

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+Arabic translation (Modern Standard Arabic). Scope: insight-prose templates,
+garment labels, clothes-rule editor, outfit-card labels, and region/voice-locale
+picker names. The rest of the UI falls through to values/strings.xml (English).
+Arabic is RTL; android:supportsRtl="true" is already set in the manifest.
+Temperature-band adjectives are in the simple predicate form (no tanwin) so
+they work correctly in both the single-band and range templates.
+-->
+<resources>
+    <string name="settings_region_language_ar_sa">العربية (المملكة العربية السعودية)</string>
+    <string name="settings_tts_voice_locale_ar_sa">العربية (المملكة العربية السعودية)</string>
+    <string name="settings_tts_voice_locale_label">اللغة</string>
+
+    <string name="garment_sweater">سترة صوفية</string>
+    <string name="garment_hoodie">هودي</string>
+    <string name="garment_jacket">جاكيت</string>
+    <string name="garment_coat">معطف</string>
+    <string name="garment_tshirt">تي شيرت</string>
+    <string name="garment_shirt">قميص</string>
+    <string name="garment_shorts">شورت</string>
+    <string name="garment_pants">بنطلون</string>
+    <string name="garment_jeans">جينز</string>
+
+    <string name="settings_clothes_empty">لا توجد قواعد. اضغط على إضافة لإنشاء واحدة.</string>
+    <string name="settings_clothes_add">إضافة</string>
+    <string name="settings_clothes_edit">تعديل</string>
+    <string name="settings_clothes_delete">حذف</string>
+    <string name="settings_clothes_dialog_add_title">إضافة قاعدة ملابس</string>
+    <string name="settings_clothes_dialog_edit_title">تعديل قاعدة الملابس</string>
+    <string name="settings_clothes_item_label">الملابس</string>
+    <string name="settings_clothes_condition_label">الشرط</string>
+    <string name="settings_clothes_value_label_temp_c">العتبة (°C)</string>
+    <string name="settings_clothes_value_label_precip">العتبة (%%)</string>
+    <string name="settings_clothes_cond_type_temp_below">عندما تكون درجة الحرارة المحسوسة أقل من</string>
+    <string name="settings_clothes_cond_type_temp_above">عندما تكون درجة الحرارة المحسوسة أعلى من</string>
+    <string name="settings_clothes_cond_type_precip_above">عندما تكون احتمالية الأمطار أعلى من</string>
+    <string name="settings_clothes_cond_temp_below">عندما تكون درجة الحرارة المحسوسة الدنيا أقل من %.0f°C</string>
+    <string name="settings_clothes_cond_temp_above">عندما تكون درجة الحرارة المحسوسة القصوى أعلى من %.0f°C</string>
+    <string name="settings_clothes_cond_precip_above">عندما تكون احتمالية الأمطار أعلى من %.0f%%</string>
+
+    <string name="today_outfit_top_tshirt">تي شيرت</string>
+    <string name="today_outfit_top_sweater">سترة صوفية</string>
+    <string name="today_outfit_top_thick_jacket">جاكيت ثقيل</string>
+    <string name="today_outfit_bottom_shorts">شورت</string>
+    <string name="today_outfit_bottom_long_pants">بنطلون طويل</string>
+
+    <string name="insight_lead_today">اليوم</string>
+    <string name="insight_lead_tonight">الليلة</string>
+    <!-- "اليوم سيكون الجو معتدل." -->
+    <string name="insight_band_single">%1$s سيكون الجو %2$s.</string>
+    <string name="insight_band_range">%1$s سيكون الجو بين %2$s و%3$s.</string>
+    <string name="insight_band_freezing">شديد البرودة</string>
+    <string name="insight_band_cold">بارد</string>
+    <string name="insight_band_cool">لطيف</string>
+    <string name="insight_band_mild">معتدل</string>
+    <string name="insight_band_warm">دافئ</string>
+    <string name="insight_band_hot">حار</string>
+    <string name="insight_delta_warmer">سيكون اليوم أدفأ بـ %1$d°.</string>
+    <string name="insight_delta_cooler">سيكون اليوم أبرد بـ %1$d°.</string>
+    <string name="insight_alert">تنبيه: %1$s.</string>
+    <string name="insight_clothes_wear">ارتدِ %1$s.</string>
+    <!-- Arabic has no indefinite article equivalent to English "a/an". -->
+    <string name="insight_clothes_article_a">%1$s</string>
+    <string name="insight_clothes_article_an">%1$s</string>
+    <!-- "و" (wa) = and; no Oxford comma in Arabic. -->
+    <string name="insight_clothes_join_two">%1$s و%2$s</string>
+    <string name="insight_clothes_join_many">%1$s و%2$s و%3$s</string>
+    <string name="insight_precip">%1$s %2$s.</string>
+    <!-- "في الساعة 15" — "في الساعة" = "at hour". -->
+    <string name="insight_precip_at_time">في الساعة %1$s</string>
+    <string name="insight_precip_overnight">طوال الليل</string>
+    <string name="insight_condition_clear">صافٍ</string>
+    <string name="insight_condition_partly_cloudy">غائم جزئياً</string>
+    <string name="insight_condition_cloudy">غائم</string>
+    <string name="insight_condition_fog">ضباب</string>
+    <string name="insight_condition_drizzle">رذاذ</string>
+    <string name="insight_condition_rain">مطر</string>
+    <string name="insight_condition_snow">ثلج</string>
+    <string name="insight_condition_thunderstorm">عاصفة رعدية</string>
+    <string name="insight_condition_unknown">غير معروف</string>
+    <string name="insight_tie_in">خذ %1$s الليلة.</string>
+    <!-- %2$s is the spoken time from insight_time_hour — "الساعة" embedded here. -->
+    <string name="insight_tie_in_with_rain">خذ %1$s الليلة، مطر الساعة %2$s.</string>
+    <!-- Bare number; "في الساعة" comes from insight_precip_at_time. -->
+    <string name="insight_time_hour">%1$d</string>
+    <string name="insight_time_hour_minutes">%1$d:%2$02d</string>
+</resources>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+Persian (Farsi) translation. Scope: insight-prose templates, garment labels,
+clothes-rule editor, outfit-card labels, and region/voice-locale picker names.
+The rest of the UI falls through to values/strings.xml (English).
+Persian is RTL; android:supportsRtl="true" is already set in the manifest.
+Persian word order is SOV (Subject-Object-Verb): object (the garment) precedes
+the verb in commands — "%1$s بپوشید" reads naturally as "[item] wear".
+Western Arabic numerals (0-9) are used for TTS compatibility.
+-->
+<resources>
+    <string name="settings_region_language_fa_ir">فارسی (ایران)</string>
+    <string name="settings_tts_voice_locale_fa_ir">فارسی (ایران)</string>
+    <string name="settings_tts_voice_locale_label">زبان</string>
+
+    <string name="garment_sweater">پلیور</string>
+    <string name="garment_hoodie">هودی</string>
+    <string name="garment_jacket">کت</string>
+    <string name="garment_coat">پالتو</string>
+    <string name="garment_tshirt">تی‌شرت</string>
+    <string name="garment_shirt">پیراهن</string>
+    <string name="garment_shorts">شلوارک</string>
+    <string name="garment_pants">شلوار</string>
+    <string name="garment_jeans">جین</string>
+
+    <string name="settings_clothes_empty">قانونی وجود ندارد. برای ایجاد یک قانون روی افزودن ضربه بزنید.</string>
+    <string name="settings_clothes_add">افزودن</string>
+    <string name="settings_clothes_edit">ویرایش</string>
+    <string name="settings_clothes_delete">حذف</string>
+    <string name="settings_clothes_dialog_add_title">افزودن قانون لباس</string>
+    <string name="settings_clothes_dialog_edit_title">ویرایش قانون لباس</string>
+    <string name="settings_clothes_item_label">لباس</string>
+    <string name="settings_clothes_condition_label">شرط</string>
+    <string name="settings_clothes_value_label_temp_c">آستانه (°C)</string>
+    <string name="settings_clothes_value_label_precip">آستانه (%%)</string>
+    <string name="settings_clothes_cond_type_temp_below">وقتی دمای احساس‌شده کمتر از</string>
+    <string name="settings_clothes_cond_type_temp_above">وقتی دمای احساس‌شده بیشتر از</string>
+    <string name="settings_clothes_cond_type_precip_above">وقتی احتمال بارندگی بیشتر از</string>
+    <string name="settings_clothes_cond_temp_below">وقتی حداقل دمای احساس‌شده کمتر از %.0f°C است</string>
+    <string name="settings_clothes_cond_temp_above">وقتی حداکثر دمای احساس‌شده بیشتر از %.0f°C است</string>
+    <string name="settings_clothes_cond_precip_above">وقتی احتمال بارندگی بیشتر از %.0f%% است</string>
+
+    <string name="today_outfit_top_tshirt">تی‌شرت</string>
+    <string name="today_outfit_top_sweater">پلیور</string>
+    <string name="today_outfit_top_thick_jacket">کت ضخیم</string>
+    <string name="today_outfit_bottom_shorts">شلوارک</string>
+    <string name="today_outfit_bottom_long_pants">شلوار بلند</string>
+
+    <string name="insight_lead_today">امروز</string>
+    <string name="insight_lead_tonight">امشب</string>
+    <!-- "امروز هوا معتدل خواهد بود." — SOV with lead first. -->
+    <string name="insight_band_single">%1$s هوا %2$s خواهد بود.</string>
+    <string name="insight_band_range">%1$s هوا بین %2$s و %3$s خواهد بود.</string>
+    <string name="insight_band_freezing">یخ‌زده</string>
+    <string name="insight_band_cold">سرد</string>
+    <string name="insight_band_cool">خنک</string>
+    <string name="insight_band_mild">معتدل</string>
+    <string name="insight_band_warm">گرم</string>
+    <string name="insight_band_hot">داغ</string>
+    <string name="insight_delta_warmer">امروز %1$d° گرم‌تر خواهد بود.</string>
+    <string name="insight_delta_cooler">امروز %1$d° سردتر خواهد بود.</string>
+    <string name="insight_alert">هشدار: %1$s.</string>
+    <!-- SOV: "%1$s را بپوشید" = "[item] را (object marker) wear". -->
+    <string name="insight_clothes_wear">%1$s را بپوشید.</string>
+    <!-- Persian has no indefinite article equivalent to English "a/an". -->
+    <string name="insight_clothes_article_a">%1$s</string>
+    <string name="insight_clothes_article_an">%1$s</string>
+    <!-- "و" (va) = and. -->
+    <string name="insight_clothes_join_two">%1$s و %2$s</string>
+    <string name="insight_clothes_join_many">%1$s، %2$s و %3$s</string>
+    <string name="insight_precip">%1$s %2$s.</string>
+    <!-- "ساعت 15" — "ساعت" = "hour/o\'clock". -->
+    <string name="insight_precip_at_time">ساعت %1$s</string>
+    <string name="insight_precip_overnight">در طول شب</string>
+    <string name="insight_condition_clear">آفتابی</string>
+    <string name="insight_condition_partly_cloudy">نیمه ابری</string>
+    <string name="insight_condition_cloudy">ابری</string>
+    <string name="insight_condition_fog">مه</string>
+    <string name="insight_condition_drizzle">نم‌نم باران</string>
+    <string name="insight_condition_rain">باران</string>
+    <string name="insight_condition_snow">برف</string>
+    <string name="insight_condition_thunderstorm">طوفان</string>
+    <string name="insight_condition_unknown">نامشخص</string>
+    <!-- SOV: "%1$s را امشب ببرید" = "[item] را tonight bring". -->
+    <string name="insight_tie_in">%1$s را امشب ببرید.</string>
+    <!-- %2$s is the spoken time — "ساعت" embedded here since time is a bare number. -->
+    <string name="insight_tie_in_with_rain">%1$s را امشب ببرید، باران ساعت %2$s.</string>
+    <!-- Bare number; "ساعت" comes from insight_precip_at_time. -->
+    <string name="insight_time_hour">%1$d</string>
+    <string name="insight_time_hour_minutes">%1$d:%2$02d</string>
+</resources>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+Hebrew translation. Scope: insight-prose templates, garment labels,
+clothes-rule editor, outfit-card labels, and region/voice-locale picker names.
+The rest of the UI falls through to values/strings.xml (English).
+Hebrew is RTL; android:supportsRtl="true" is already set in the manifest.
+Android uses the legacy Java code "iw" for Hebrew resource folders (same
+pattern as Indonesian uses "in" for "id"). The BCP-47 tag in the enum is he-IL.
+Gender-neutral imperatives use the slash notation (לבש/י, קח/י) which is
+standard in Israeli digital communication.
+-->
+<resources>
+    <string name="settings_region_language_he_il">עברית (ישראל)</string>
+    <string name="settings_tts_voice_locale_he_il">עברית (ישראל)</string>
+    <string name="settings_tts_voice_locale_label">שפה</string>
+
+    <string name="garment_sweater">סוודר</string>
+    <string name="garment_hoodie">הודי</string>
+    <string name="garment_jacket">ג׳קט</string>
+    <string name="garment_coat">מעיל</string>
+    <string name="garment_tshirt">חולצת טי</string>
+    <string name="garment_shirt">חולצה</string>
+    <string name="garment_shorts">מכנסיים קצרים</string>
+    <string name="garment_pants">מכנסיים ארוכים</string>
+    <string name="garment_jeans">ג׳ינס</string>
+
+    <string name="settings_clothes_empty">אין חוקים. הקש על הוספה כדי ליצור אחד.</string>
+    <string name="settings_clothes_add">הוספה</string>
+    <string name="settings_clothes_edit">עריכה</string>
+    <string name="settings_clothes_delete">מחיקה</string>
+    <string name="settings_clothes_dialog_add_title">הוספת חוק לגדים</string>
+    <string name="settings_clothes_dialog_edit_title">עריכת חוק לגדים</string>
+    <string name="settings_clothes_item_label">פריט לבוש</string>
+    <string name="settings_clothes_condition_label">תנאי</string>
+    <string name="settings_clothes_value_label_temp_c">סף (°C)</string>
+    <string name="settings_clothes_value_label_precip">סף (%%)</string>
+    <string name="settings_clothes_cond_type_temp_below">כאשר הטמפרטורה המורגשת נמוכה מ</string>
+    <string name="settings_clothes_cond_type_temp_above">כאשר הטמפרטורה המורגשת גבוהה מ</string>
+    <string name="settings_clothes_cond_type_precip_above">כאשר הסיכוי לגשם גבוה מ</string>
+    <string name="settings_clothes_cond_temp_below">כשהטמפ׳ המורגשת המינימלית מתחת ל-%.0f°C</string>
+    <string name="settings_clothes_cond_temp_above">כשהטמפ׳ המורגשת המקסימלית מעל %.0f°C</string>
+    <string name="settings_clothes_cond_precip_above">כשסיכוי הגשם מעל %.0f%%</string>
+
+    <string name="today_outfit_top_tshirt">חולצת טי</string>
+    <string name="today_outfit_top_sweater">סוודר</string>
+    <string name="today_outfit_top_thick_jacket">ז׳קט כבד</string>
+    <string name="today_outfit_bottom_shorts">מכנסיים קצרים</string>
+    <string name="today_outfit_bottom_long_pants">מכנסיים ארוכים</string>
+
+    <string name="insight_lead_today">היום</string>
+    <string name="insight_lead_tonight">הלילה</string>
+    <!-- "היום יהיה נעים." -->
+    <string name="insight_band_single">%1$s יהיה %2$s.</string>
+    <string name="insight_band_range">%1$s יהיה %2$s עד %3$s.</string>
+    <string name="insight_band_freezing">קפוא</string>
+    <string name="insight_band_cold">קר</string>
+    <string name="insight_band_cool">קריר</string>
+    <string name="insight_band_mild">נעים</string>
+    <string name="insight_band_warm">חמים</string>
+    <string name="insight_band_hot">חם</string>
+    <string name="insight_delta_warmer">היום יהיה %1$d° יותר חם.</string>
+    <string name="insight_delta_cooler">היום יהיה %1$d° יותר קר.</string>
+    <string name="insight_alert">אזהרה: %1$s.</string>
+    <!-- Slash notation for gender-neutral imperative (standard in Israeli digital text). -->
+    <string name="insight_clothes_wear">לבש/י %1$s.</string>
+    <!-- Hebrew articles function differently from English "a/an" — no direct equivalent. -->
+    <string name="insight_clothes_article_a">%1$s</string>
+    <string name="insight_clothes_article_an">%1$s</string>
+    <!-- "ו" (vav) = and, directly prefixed (no space before next word). -->
+    <string name="insight_clothes_join_two">%1$s ו%2$s</string>
+    <string name="insight_clothes_join_many">%1$s, %2$s ו%3$s</string>
+    <string name="insight_precip">%1$s %2$s.</string>
+    <!-- "בשעה 15" — "בשעה" = "at hour". -->
+    <string name="insight_precip_at_time">בשעה %1$s</string>
+    <string name="insight_precip_overnight">בלילה</string>
+    <string name="insight_condition_clear">בהיר</string>
+    <string name="insight_condition_partly_cloudy">מעונן חלקית</string>
+    <string name="insight_condition_cloudy">מעונן</string>
+    <string name="insight_condition_fog">ערפל</string>
+    <string name="insight_condition_drizzle">טפטוף</string>
+    <string name="insight_condition_rain">גשם</string>
+    <string name="insight_condition_snow">שלג</string>
+    <string name="insight_condition_thunderstorm">סופת רעמים</string>
+    <string name="insight_condition_unknown">לא ידוע</string>
+    <string name="insight_tie_in">קח/י %1$s הלילה.</string>
+    <!-- %2$s is the spoken time — "בשעה" embedded here since time is a bare number. -->
+    <string name="insight_tie_in_with_rain">קח/י %1$s הלילה, גשם בשעה %2$s.</string>
+    <!-- Bare number; "בשעה" comes from insight_precip_at_time. -->
+    <string name="insight_time_hour">%1$d</string>
+    <string name="insight_time_hour_minutes">%1$d:%2$02d</string>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -153,6 +153,9 @@
     <string name="settings_tts_voice_locale_bn_bd">Bengali (Bangladesh)</string>
     <string name="settings_tts_voice_locale_ja_jp">Japanese (Japan)</string>
     <string name="settings_tts_voice_locale_ko_kr">Korean (South Korea)</string>
+    <string name="settings_tts_voice_locale_ar_sa">Arabic (Saudi Arabia)</string>
+    <string name="settings_tts_voice_locale_he_il">Hebrew (Israel)</string>
+    <string name="settings_tts_voice_locale_fa_ir">Persian (Iran)</string>
     <string name="settings_tts_test">Test voice</string>
     <!-- Shown next to the engine picker when the chosen engine's API key isn't
          configured. %1$s is the engine name ("Gemini" / "OpenAI" / "ElevenLabs"). -->
@@ -207,6 +210,9 @@
     <string name="settings_region_language_bn_bd">Bengali (Bangladesh)</string>
     <string name="settings_region_language_ja_jp">Japanese (Japan)</string>
     <string name="settings_region_language_ko_kr">Korean (South Korea)</string>
+    <string name="settings_region_language_ar_sa">Arabic (Saudi Arabia)</string>
+    <string name="settings_region_language_he_il">Hebrew (Israel)</string>
+    <string name="settings_region_language_fa_ir">Persian (Iran)</string>
 
     <string name="settings_temperature_unit_title">Temperature unit</string>
     <string name="settings_temperature_unit_celsius">Celsius (°C)</string>

--- a/core/data/src/main/kotlin/app/clothescast/core/data/tts/GeminiTtsClient.kt
+++ b/core/data/src/main/kotlin/app/clothescast/core/data/tts/GeminiTtsClient.kt
@@ -100,6 +100,10 @@ private val ACCENT_DIRECTIVES: Map<String, String> = mapOf(
     "bn" to "অনুগ্রহ করে বাংলায় স্পষ্ট ও প্রাকৃতিক উচ্চারণে পড়ুন।",
     "ja" to "はっきりと自然な発音で日本語で読んでください。",
     "ko" to "명확하고 자연스러운 발음으로 한국어로 읽어주세요。",
+    // Language-only entries cover all regional Arabic/Persian variants.
+    "ar" to "اقرأ النص التالي بالعربية بنطق واضح وطبيعي.",
+    "he" to "קרא/י את הטקסט הבא בעברית בהגייה ברורה וטבעית.",
+    "fa" to "متن زیر را به فارسی با تلفظ واضح و طبیعی بخوانید.",
 )
 
 /**

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Settings.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Settings.kt
@@ -75,6 +75,9 @@ enum class VoiceLocale(val bcp47: String?) {
     BN_BD("bn-BD"),
     JA_JP("ja-JP"),
     KO_KR("ko-KR"),
+    AR_SA("ar-SA"),
+    HE_IL("he-IL"),
+    FA_IR("fa-IR"),
 }
 
 /**
@@ -120,6 +123,9 @@ enum class Region(val bcp47: String?) {
     BN_BD("bn-BD"),
     JA_JP("ja-JP"),
     KO_KR("ko-KR"),
+    AR_SA("ar-SA"),
+    HE_IL("he-IL"),
+    FA_IR("fa-IR"),
 }
 
 data class UserPreferences(


### PR DESCRIPTION
## Summary

Adds Arabic (ar-SA), Hebrew (he-IL), and Persian (fa-IR) to the Region and VoiceLocale pickers. RTL rendering is already supported — `android:supportsRtl="true"` is in the manifest and Compose mirrors layouts automatically for RTL locales.

**Android folder mapping** (same legacy-code pattern as Indonesian):
- Arabic → `values-ar/` (standard)
- Hebrew → `values-iw/` (Android maps BCP-47 `he` to legacy Java code `iw`)
- Persian → `values-fa/` (standard)

**Translation choices:**
- Arabic: Modern Standard Arabic, adjectives in simple predicate form (no tanwin) so they work in both `insight_band_single` and `insight_band_range` templates
- Hebrew: gender-neutral imperatives with slash notation (`לבש/י`, `קח/י`) — standard in Israeli digital communication
- Persian: SOV word order for commands (`%1$s را بپوشید` = "[item] را wear"), Western Arabic numerals for TTS compatibility

**Time format:** all three locales use bare `%1$d` for `insight_time_hour` — the surrounding templates (`insight_precip_at_time`, `insight_tie_in_with_rain`) embed the hour word ("في الساعة", "בשעה", "ساعت").

**Gemini TTS directives** added for `"ar"`, `"he"`, `"fa"` (language-only keys cover all regional variants).

## Test plan

- [ ] CI passes
- [ ] Select Arabic region: insight prose renders RTL, temperature bands read naturally ("اليوم سيكون الجو معتدل")
- [ ] Select Hebrew region: clothes sentence uses slash imperative ("לבש/י סוודר")
- [ ] Select Persian region: SOV order correct ("سترة صوفية را بپوشید")
- [ ] Gemini TTS with Arabic locale speaks Arabic, not English-accented numbers

https://claude.ai/code/session_019ZFqfAA5UykN1MiD8S48oU

---
_Generated by [Claude Code](https://claude.ai/code/session_019ZFqfAA5UykN1MiD8S48oU)_