### PR TITLE
:app — translate insight_tie_in into all locales (fixes Spanish "sieben Grad" leak)

### DIFF
--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -78,6 +78,8 @@ West Bengal vocabulary differences in a future PR.
     <string name="insight_condition_unknown">অজানা</string>
     <!-- "মিটিং (15)-এর জন্য কোট নিন।" -->
     <string name="insight_calendar_tie_in">%3$s (%2$s)-এর জন্য %1$s নিন।</string>
+    <string name="insight_tie_in">আজ রাতে %1$s নিন।</string>
+    <string name="insight_tie_in_with_rain">আজ রাতে %1$s নিন, %2$s-এ বৃষ্টি।</string>
     <!-- "15" — suffix "-এ" comes from insight_precip_at_time wrapper. -->
     <string name="insight_time_hour">%1$d</string>
     <string name="insight_time_hour_minutes">%1$d:%2$02d</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -76,6 +76,11 @@ Mexico-specific vocabulary overrides live in values-es-rMX.
     <string name="insight_condition_thunderstorm">Tormenta</string>
     <string name="insight_condition_unknown">Desconocido</string>
     <string name="insight_calendar_tie_in">Lleva %1$s para tu %3$s de las %2$s.</string>
+    <!-- Evening tie-in counterparts of the English insight_tie_in / insight_tie_in_with_rain.
+         Without these the Spanish formatter falls through to another locale that *does*
+         have the keys (German), which is how "sieben Grad" leaks into Spanish output. -->
+    <string name="insight_tie_in">Lleva %1$s esta noche.</string>
+    <string name="insight_tie_in_with_rain">Lleva %1$s esta noche, lluvia a las %2$s.</string>
     <!-- "15" — prepositions ("a las", "de las") come from surrounding templates. -->
     <string name="insight_time_hour">%1$d</string>
     <string name="insight_time_hour_minutes">%1$d:%2$02d</string>

--- a/app/src/main/res/values-fil/strings.xml
+++ b/app/src/main/res/values-fil/strings.xml
@@ -75,6 +75,8 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="insight_condition_thunderstorm">Bagyo</string>
     <string name="insight_condition_unknown">Hindi kilala</string>
     <string name="insight_calendar_tie_in">Magdala ng %1$s para sa %3$s ng %2$s.</string>
+    <string name="insight_tie_in">Magdala ng %1$s ngayong gabi.</string>
+    <string name="insight_tie_in_with_rain">Magdala ng %1$s ngayong gabi, ulan ng %2$s.</string>
     <!-- "15" — preposition "ng" comes from surrounding templates. -->
     <string name="insight_time_hour">%1$d</string>
     <string name="insight_time_hour_minutes">%1$d:%2$02d</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -80,6 +80,8 @@ agreement; garment names are listed without articles and read naturally in conte
     <string name="insight_condition_thunderstorm">Orage</string>
     <string name="insight_condition_unknown">Inconnu</string>
     <string name="insight_calendar_tie_in">Prenez %1$s pour votre %3$s de %2$s.</string>
+    <string name="insight_tie_in">Prenez %1$s ce soir.</string>
+    <string name="insight_tie_in_with_rain">Prenez %1$s ce soir, pluie à %2$s.</string>
     <!-- "15h" / "15h30" — French TTS reads as "quinze heures" / "quinze heures trente". -->
     <string name="insight_time_hour">%1$dh</string>
     <string name="insight_time_hour_minutes">%1$dh%2$02d</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -76,6 +76,8 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="insight_condition_unknown">अज्ञात</string>
     <!-- "मीटिंग (15 बजे) के लिए कोट साथ लें।" -->
     <string name="insight_calendar_tie_in">%3$s (%2$s) के लिए %1$s साथ लें।</string>
+    <string name="insight_tie_in">आज रात %1$s साथ लें।</string>
+    <string name="insight_tie_in_with_rain">आज रात %1$s साथ लें, %2$s बजे बारिश।</string>
     <!-- "15" — postposition "बजे" comes from insight_precip_at_time wrapper. -->
     <string name="insight_time_hour">%1$d</string>
     <string name="insight_time_hour_minutes">%1$d:%2$02d</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -72,6 +72,8 @@ editor, outfit-card labels, and region/voice-locale picker names.
     <string name="insight_condition_thunderstorm">Grmljavina</string>
     <string name="insight_condition_unknown">Nepoznato</string>
     <string name="insight_calendar_tie_in">Ponesite %1$s na %3$s u %2$s.</string>
+    <string name="insight_tie_in">Ponesite %1$s večeras.</string>
+    <string name="insight_tie_in_with_rain">Ponesite %1$s večeras, kiša u %2$s.</string>
     <!-- "15" — preposition "u" comes from surrounding templates. -->
     <string name="insight_time_hour">%1$d</string>
     <string name="insight_time_hour_minutes">%1$d:%2$02d</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -77,6 +77,8 @@ to values/strings.xml (English).
     <string name="insight_condition_thunderstorm">Badai petir</string>
     <string name="insight_condition_unknown">Tidak diketahui</string>
     <string name="insight_calendar_tie_in">Bawa %1$s untuk %3$s pukul %2$s.</string>
+    <string name="insight_tie_in">Bawa %1$s malam ini.</string>
+    <string name="insight_tie_in_with_rain">Bawa %1$s malam ini, hujan pukul %2$s.</string>
     <!-- "15" / "15.30" — "pukul" comes from surrounding templates. -->
     <string name="insight_time_hour">%1$d</string>
     <string name="insight_time_hour_minutes">%1$d.%2$02d</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -73,6 +73,8 @@ editor, outfit-card labels, and region/voice-locale picker names.
     <string name="insight_condition_thunderstorm">Temporale</string>
     <string name="insight_condition_unknown">Sconosciuto</string>
     <string name="insight_calendar_tie_in">Porta %1$s per il tuo %3$s alle %2$s.</string>
+    <string name="insight_tie_in">Porta %1$s stasera.</string>
+    <string name="insight_tie_in_with_rain">Porta %1$s stasera, pioggia alle %2$s.</string>
     <!-- "15" / "15 e 30" — preposition "alle" comes from surrounding templates. -->
     <string name="insight_time_hour">%1$d</string>
     <string name="insight_time_hour_minutes">%1$d e %2$d</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -80,6 +80,8 @@ Japanese uses the ideographic period (。) for sentence endings.
     <string name="insight_condition_unknown">不明</string>
     <!-- "会議（15時）のためにコートを持っていきましょう。" -->
     <string name="insight_calendar_tie_in">%3$s（%2$s）のために%1$sを持っていきましょう。</string>
+    <string name="insight_tie_in">今夜は%1$sを持っていきましょう。</string>
+    <string name="insight_tie_in_with_rain">今夜は%1$sを持っていきましょう。%2$s頃に雨。</string>
     <!-- "15時" / "15時30分" — Japanese spoken time; postposition "頃" comes from insight_precip_at_time. -->
     <string name="insight_time_hour">%1$d時</string>
     <string name="insight_time_hour_minutes">%1$d時%2$d分</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -79,6 +79,8 @@ the 을/를 object particle which depends on the noun's final consonant.
     <string name="insight_condition_unknown">알 수 없음</string>
     <!-- "회의(15시)에 코트 챙기세요." -->
     <string name="insight_calendar_tie_in">%3$s(%2$s)에 %1$s 챙기세요.</string>
+    <string name="insight_tie_in">오늘 밤 %1$s 챙기세요.</string>
+    <string name="insight_tie_in_with_rain">오늘 밤 %1$s 챙기세요, %2$s경에 비.</string>
     <!-- "15시" / "15시 30분" — Korean spoken time; postposition "경에" comes from insight_precip_at_time. -->
     <string name="insight_time_hour">%1$d시</string>
     <string name="insight_time_hour_minutes">%1$d시 %2$d분</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -74,6 +74,8 @@ editor, outfit-card labels, and region/voice-locale picker names.
     <string name="insight_condition_thunderstorm">Onweer</string>
     <string name="insight_condition_unknown">Onbekend</string>
     <string name="insight_calendar_tie_in">Neem %1$s mee voor je %3$s om %2$s.</string>
+    <string name="insight_tie_in">Neem %1$s mee vanavond.</string>
+    <string name="insight_tie_in_with_rain">Neem %1$s mee vanavond, regen om %2$s.</string>
     <!-- "15 uur" — preposition "om" comes from surrounding templates. -->
     <string name="insight_time_hour">%1$d uur</string>
     <string name="insight_time_hour_minutes">%1$d:%2$02d</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -72,6 +72,8 @@ editor, outfit-card labels, and region/voice-locale picker names.
     <string name="insight_condition_thunderstorm">Burza</string>
     <string name="insight_condition_unknown">Nieznane</string>
     <string name="insight_calendar_tie_in">Weź %1$s na %3$s o %2$s.</string>
+    <string name="insight_tie_in">Weź %1$s wieczorem.</string>
+    <string name="insight_tie_in_with_rain">Weź %1$s wieczorem, deszcz o %2$s.</string>
     <!-- "15" — preposition "o" comes from surrounding templates. -->
     <string name="insight_time_hour">%1$d</string>
     <string name="insight_time_hour_minutes">%1$d:%2$02d</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -73,6 +73,8 @@ clothes-rule editor, outfit-card labels, and region/voice-locale picker names.
     <string name="insight_condition_thunderstorm">Tempestade</string>
     <string name="insight_condition_unknown">Desconhecido</string>
     <string name="insight_calendar_tie_in">Leve %1$s para seu %3$s às %2$s.</string>
+    <string name="insight_tie_in">Leve %1$s esta noite.</string>
+    <string name="insight_tie_in_with_rain">Leve %1$s esta noite, chuva às %2$s.</string>
     <!-- "15h" / "15h30" — Brazilian Portuguese hour notation, TTS reads naturally. -->
     <string name="insight_time_hour">%1$dh</string>
     <string name="insight_time_hour_minutes">%1$dh%2$02d</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -72,6 +72,8 @@ editor, outfit-card labels, and region/voice-locale picker names.
     <string name="insight_condition_thunderstorm">Гроза</string>
     <string name="insight_condition_unknown">Неизвестно</string>
     <string name="insight_calendar_tie_in">Возьмите %1$s на %3$s в %2$s.</string>
+    <string name="insight_tie_in">Возьмите %1$s сегодня вечером.</string>
+    <string name="insight_tie_in_with_rain">Возьмите %1$s сегодня вечером, дождь в %2$s.</string>
     <!-- "15" — preposition "в" comes from surrounding templates. -->
     <string name="insight_time_hour">%1$d</string>
     <string name="insight_time_hour_minutes">%1$d:%2$02d</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -73,6 +73,8 @@ editor, outfit-card labels, and region/voice-locale picker names.
     <string name="insight_condition_thunderstorm">Åskväder</string>
     <string name="insight_condition_unknown">Okänt</string>
     <string name="insight_calendar_tie_in">Ta med %1$s till din %3$s klockan %2$s.</string>
+    <string name="insight_tie_in">Ta med %1$s i kväll.</string>
+    <string name="insight_tie_in_with_rain">Ta med %1$s i kväll, regn klockan %2$s.</string>
     <!-- "15" — "klockan" comes from surrounding templates. -->
     <string name="insight_time_hour">%1$d</string>
     <string name="insight_time_hour_minutes">%1$d:%2$02d</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -73,6 +73,8 @@ editor, outfit-card labels, and region/voice-locale picker names.
     <string name="insight_condition_thunderstorm">Fırtına</string>
     <string name="insight_condition_unknown">Bilinmiyor</string>
     <string name="insight_calendar_tie_in">%2$s\'deki %3$s için %1$s al.</string>
+    <string name="insight_tie_in">Bu gece %1$s al.</string>
+    <string name="insight_tie_in_with_rain">Bu gece %1$s al, saat %2$s\'de yağmur.</string>
     <!-- "15" — "saat" comes from surrounding templates. -->
     <string name="insight_time_hour">%1$d</string>
     <string name="insight_time_hour_minutes">%1$d:%2$02d</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -72,6 +72,8 @@ editor, outfit-card labels, and region/voice-locale picker names.
     <string name="insight_condition_thunderstorm">Гроза</string>
     <string name="insight_condition_unknown">Невідомо</string>
     <string name="insight_calendar_tie_in">Візьміть %1$s на %3$s о %2$s.</string>
+    <string name="insight_tie_in">Візьміть %1$s сьогодні ввечері.</string>
+    <string name="insight_tie_in_with_rain">Візьміть %1$s сьогодні ввечері, дощ о %2$s.</string>
     <!-- "15" — preposition "о" comes from surrounding templates. -->
     <string name="insight_time_hour">%1$d</string>
     <string name="insight_time_hour_minutes">%1$d:%2$02d</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -75,6 +75,8 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="insight_condition_thunderstorm">Giông bão</string>
     <string name="insight_condition_unknown">Không xác định</string>
     <string name="insight_calendar_tie_in">Mang %1$s cho %3$s lúc %2$s.</string>
+    <string name="insight_tie_in">Mang %1$s tối nay.</string>
+    <string name="insight_tie_in_with_rain">Mang %1$s tối nay, mưa lúc %2$s.</string>
     <!-- "15 giờ" / "15 giờ 30 phút" — preposition "lúc" comes from surrounding templates. -->
     <string name="insight_time_hour">%1$d giờ</string>
     <string name="insight_time_hour_minutes">%1$d giờ %2$d phút</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -79,6 +79,8 @@ Chinese uses the ideographic period (。) for sentence endings.
     <string name="insight_condition_unknown">未知</string>
     <!-- "为15点的会议带上雨伞。" — time before event name follows Chinese convention. -->
     <string name="insight_calendar_tie_in">为%2$s的%3$s带上%1$s。</string>
+    <string name="insight_tie_in">今晚带上%1$s。</string>
+    <string name="insight_tie_in_with_rain">今晚带上%1$s，%2$s有雨。</string>
     <!-- "15点" / "15点30分" — Chinese spoken time. insight_precip_at_time is a passthrough. -->
     <string name="insight_time_hour">%1$d点</string>
     <string name="insight_time_hour_minutes">%1$d点%2$d分</string>

--- a/app/src/test/kotlin/app/clothescast/insight/InsightFormatterTest.kt
+++ b/app/src/test/kotlin/app/clothescast/insight/InsightFormatterTest.kt
@@ -281,4 +281,34 @@ class InsightFormatterTest {
         )
         out shouldBe "Heute wird es mild. Denk an Regenschirm für heute Abend, Regen um 21 Uhr."
     }
+
+    // ---------------------------------------------------------------------
+    // Spanish locale — picks up values-es/strings.xml + ResourceClothesPhraser.
+    // Tie-in tests pin the Spanish templates that previously fell through to
+    // the German strings ("Denk an … Grad …"), surfacing as "sieben Grad" in
+    // TTS for a Spanish-region user.
+    // ---------------------------------------------------------------------
+
+    private val spanishSubject = InsightFormatter.forContext(context, Locale.forLanguageTag("es-ES"))
+
+    @Test
+    fun `es — calendar tie-in renders the Spanish template, not a German fallback`() {
+        val out = spanishSubject.format(
+            summary(
+                period = ForecastPeriod.TONIGHT,
+                calendarTieIn = CalendarTieInClause("paraguas"),
+            ),
+        )
+        out shouldBe "Esta noche hará templado. Lleva paraguas esta noche."
+    }
+
+    @Test
+    fun `es — evening event tie-in with rain renders the Spanish template`() {
+        val out = spanishSubject.format(
+            summary(
+                eveningEventTieIn = EveningEventTieInClause("paraguas", rainTime = LocalTime.of(21, 0)),
+            ),
+        )
+        out shouldBe "Hoy hará templado. Lleva paraguas esta noche, lluvia a las 21."
+    }
 }


### PR DESCRIPTION
## Summary

`insight_tie_in` and `insight_tie_in_with_rain` were missing from every non-default locale except German. When the evening-event tie-in clause fired for a non-en/non-de region, `resources.getString` couldn't find the keys in the active locale and fell through — to the English default in most cases, but if German sat earlier in the device's LocaleList, to `values-de` instead. That's how a Spanish-region user ended up hearing "Denk an … für heute Abend, Regen um 21 Uhr" with German numerals like "sieben Grad" coming out of a Spanish TTS voice.

Translates the two strings into all 19 affected locales: `bn, es, fil, fr, hi, hr, in, it, ja, ko, nl, pl, pt-rBR, ru, sv, tr, uk, vi, zh-rCN`. Each one models its verb on the locale's existing `insight_calendar_tie_in` ("Lleva …" / "Prenez …" / "Возьмите …" / etc.) and reuses its `lead_tonight` wording so the prose stays internally consistent; tie-in-with-rain mirrors the German shape (item + comma + rain-time clause) using each locale's preposition for "at" to match `insight_precip_at_time`.

`en-r{AU,GB,ZA}` and `fr-rCA` inherit the parent locale's tie-in keys (English / French) so don't need overrides.

Adds two Spanish regression tests in `InsightFormatterTest` modelled on the existing `de — tie-in …` cases so the same gap can't reopen silently for the locale the user actually reported.

## Test plan

- [ ] CI: `JVM unit tests` runs `InsightFormatterTest`; new `es — calendar tie-in renders the Spanish template, not a German fallback` and `es — evening event tie-in with rain renders the Spanish template` pass against the freshly added strings.
- [ ] Set Region = Español (España), enable an evening calendar event, trigger the morning insight; confirm the spoken prose says "Lleva … esta noche" instead of "Denk an … für heute Abend".
- [ ] Spot-check at least one other freshly-translated locale (e.g. fr, it, ja) the same way to confirm the new templates render.