### PR TITLE
:app + :core — add shorter / longer ClothesCast length toggle

### DIFF
--- a/app/src/main/kotlin/app/clothescast/data/SettingsRepository.kt
+++ b/app/src/main/kotlin/app/clothescast/data/SettingsRepository.kt
@@ -9,6 +9,7 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.core.stringSetPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
+import app.clothescast.core.domain.model.CastLength
 import app.clothescast.core.domain.model.ClothesRule
 import app.clothescast.core.domain.model.DeliveryMode
 import app.clothescast.core.domain.model.DistanceUnit
@@ -76,6 +77,10 @@ class SettingsRepository(
 
     suspend fun setDailyMentionEveningEvents(enabled: Boolean) {
         dataStore.edit { it[DAILY_MENTION_EVENING_EVENTS] = enabled }
+    }
+
+    suspend fun setCastLength(length: CastLength) {
+        dataStore.edit { it[CAST_LENGTH] = length.name }
     }
 
     suspend fun setDeliveryMode(mode: DeliveryMode) {
@@ -198,6 +203,8 @@ class SettingsRepository(
         val tonightEnabled = this[TONIGHT_ENABLED] != false
         val tonightNotifyOnlyOnEvents = this[TONIGHT_NOTIFY_ONLY_ON_EVENTS] == true
         val dailyMentionEveningEvents = this[DAILY_MENTION_EVENING_EVENTS] == true
+        val castLength = this[CAST_LENGTH]?.let { runCatching { CastLength.valueOf(it) }.getOrNull() }
+            ?: CastLength.SHORTER
         val zone = zoneIdProvider()
 
         return UserPreferences(
@@ -220,6 +227,7 @@ class SettingsRepository(
             tonightDeliveryMode = tonightDeliveryMode,
             tonightNotifyOnlyOnEvents = tonightNotifyOnlyOnEvents,
             dailyMentionEveningEvents = dailyMentionEveningEvents,
+            castLength = castLength,
         )
     }
 
@@ -272,6 +280,7 @@ class SettingsRepository(
         private val TONIGHT_DELIVERY_MODE = stringPreferencesKey("tonight_delivery_mode")
         private val TONIGHT_NOTIFY_ONLY_ON_EVENTS = booleanPreferencesKey("tonight_notify_only_on_events")
         private val DAILY_MENTION_EVENING_EVENTS = booleanPreferencesKey("daily_mention_evening_events")
+        private val CAST_LENGTH = stringPreferencesKey("cast_length")
 
         private val TIME_FORMAT: DateTimeFormatter = DateTimeFormatter.ofPattern("HH:mm")
         private val DEFAULT_TIME: LocalTime = LocalTime.of(7, 0)

--- a/app/src/main/kotlin/app/clothescast/insight/InsightFormatter.kt
+++ b/app/src/main/kotlin/app/clothescast/insight/InsightFormatter.kt
@@ -6,6 +6,7 @@ import android.content.res.Resources
 import app.clothescast.R
 import app.clothescast.core.domain.model.AlertClause
 import app.clothescast.core.domain.model.BandClause
+import app.clothescast.core.domain.model.CastLength
 import app.clothescast.core.domain.model.ClothesClause
 import app.clothescast.core.domain.model.DeltaClause
 import app.clothescast.core.domain.model.EveningEventTieInClause
@@ -41,6 +42,7 @@ import java.util.Locale
 class InsightFormatter(
     private val resources: Resources,
     private val locale: Locale = Locale.getDefault(),
+    private val castLength: CastLength = CastLength.SHORTER,
 ) {
     private val phraser: ClothesPhraser = ClothesPhraser.forLocale(resources, locale)
 
@@ -77,8 +79,14 @@ class InsightFormatter(
 
     private fun formatDelta(delta: DeltaClause): String {
         val template = when (delta.direction) {
-            DeltaClause.Direction.WARMER -> R.string.insight_delta_warmer
-            DeltaClause.Direction.COOLER -> R.string.insight_delta_cooler
+            DeltaClause.Direction.WARMER -> when (castLength) {
+                CastLength.SHORTER -> R.string.insight_delta_warmer
+                CastLength.LONGER -> R.string.insight_delta_warmer_long
+            }
+            DeltaClause.Direction.COOLER -> when (castLength) {
+                CastLength.SHORTER -> R.string.insight_delta_cooler
+                CastLength.LONGER -> R.string.insight_delta_cooler_long
+            }
         }
         return resources.getString(template, delta.degrees)
     }
@@ -184,13 +192,21 @@ class InsightFormatter(
         private val OVERNIGHT_HOURS = 0..4
 
         /** Build a formatter that renders prose in [locale] using [context]'s resources. */
-        fun forContext(context: Context, locale: Locale = Locale.getDefault()): InsightFormatter =
-            InsightFormatter(context.localizedResources(locale), locale)
+        fun forContext(
+            context: Context,
+            locale: Locale = Locale.getDefault(),
+            castLength: CastLength = CastLength.SHORTER,
+        ): InsightFormatter =
+            InsightFormatter(context.localizedResources(locale), locale, castLength)
 
         /** Convenience for the common path: render in the user's [Region]-derived locale. */
-        fun forRegion(context: Context, region: Region): InsightFormatter {
+        fun forRegion(
+            context: Context,
+            region: Region,
+            castLength: CastLength = CastLength.SHORTER,
+        ): InsightFormatter {
             val locale = region.toJavaLocale() ?: Locale.getDefault()
-            return forContext(context, locale)
+            return forContext(context, locale, castLength)
         }
     }
 }

--- a/app/src/main/kotlin/app/clothescast/ui/settings/ScheduleSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/ScheduleSettings.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 import app.clothescast.R
+import app.clothescast.core.domain.model.CastLength
 import app.clothescast.core.domain.model.DeliveryMode
 import java.time.DayOfWeek
 import java.time.LocalTime
@@ -55,6 +56,7 @@ internal fun ScheduleContent(
     tonightEnabled: Boolean,
     tonightNotifyOnlyOnEvents: Boolean,
     dailyMentionEveningEvents: Boolean,
+    castLength: CastLength,
     deliveryMode: DeliveryMode,
     tonightDeliveryMode: DeliveryMode,
     padding: PaddingValues,
@@ -63,6 +65,7 @@ internal fun ScheduleContent(
     onSetTonightEnabled: (Boolean) -> Unit,
     onSetTonightNotifyOnlyOnEvents: (Boolean) -> Unit,
     onSetDailyMentionEveningEvents: (Boolean) -> Unit,
+    onSetCastLength: (CastLength) -> Unit,
     onSetDeliveryMode: (DeliveryMode) -> Unit,
     onSetTonightDeliveryMode: (DeliveryMode) -> Unit,
     onDone: (() -> Unit)? = null,
@@ -95,6 +98,11 @@ internal fun ScheduleContent(
             onChange = onSetTonightSchedule,
             onSetDeliveryMode = onSetTonightDeliveryMode,
         )
+        // CastLength applies to both Day and Night cards, so it sits below
+        // them in its own card rather than inside either — putting it in
+        // DayCard would suggest it only affects the morning, and duplicating
+        // it across both would just confuse the user.
+        CastLengthCard(selected = castLength, onSelect = onSetCastLength)
         if (onDone != null) {
             Button(
                 onClick = onDone,
@@ -345,10 +353,36 @@ private fun DeliveryModeSection(
     }
 }
 
+@Composable
+private fun CastLengthCard(
+    selected: CastLength,
+    onSelect: (CastLength) -> Unit,
+) {
+    SectionCard(title = stringResource(R.string.settings_cast_length_label)) {
+        Text(
+            text = stringResource(R.string.settings_cast_length_description),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        CastLength.entries.forEach { length ->
+            RadioRow(
+                label = stringResource(castLengthLabel(length)),
+                selected = length == selected,
+                onSelect = { onSelect(length) },
+            )
+        }
+    }
+}
+
 private fun deliveryModeLabel(mode: DeliveryMode): Int = when (mode) {
     DeliveryMode.NOTIFICATION_ONLY -> R.string.settings_delivery_notification_only
     DeliveryMode.TTS_ONLY -> R.string.settings_delivery_tts_only
     DeliveryMode.NOTIFICATION_AND_TTS -> R.string.settings_delivery_notification_and_tts
+}
+
+private fun castLengthLabel(length: CastLength): Int = when (length) {
+    CastLength.SHORTER -> R.string.settings_cast_length_shorter
+    CastLength.LONGER -> R.string.settings_cast_length_longer
 }
 
 private val TIME_FORMAT: DateTimeFormatter = DateTimeFormatter.ofPattern("HH:mm")

--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsScreen.kt
@@ -101,6 +101,7 @@ fun SettingsScreen(
                 tonightEnabled = state.tonightEnabled,
                 tonightNotifyOnlyOnEvents = state.tonightNotifyOnlyOnEvents,
                 dailyMentionEveningEvents = state.dailyMentionEveningEvents,
+                castLength = state.castLength,
                 deliveryMode = state.deliveryMode,
                 tonightDeliveryMode = state.tonightDeliveryMode,
                 padding = padding,
@@ -109,6 +110,7 @@ fun SettingsScreen(
                 onSetTonightEnabled = viewModel::setTonightEnabled,
                 onSetTonightNotifyOnlyOnEvents = viewModel::setTonightNotifyOnlyOnEvents,
                 onSetDailyMentionEveningEvents = viewModel::setDailyMentionEveningEvents,
+                onSetCastLength = viewModel::setCastLength,
                 onSetDeliveryMode = viewModel::setDeliveryMode,
                 onSetTonightDeliveryMode = viewModel::setTonightDeliveryMode,
                 // Show a Done button only when this page is the deep-link

--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsState.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsState.kt
@@ -1,5 +1,6 @@
 package app.clothescast.ui.settings
 
+import app.clothescast.core.domain.model.CastLength
 import app.clothescast.core.domain.model.ClothesRule
 import app.clothescast.core.domain.model.DeliveryMode
 import app.clothescast.core.domain.model.DistanceUnit
@@ -28,6 +29,7 @@ data class SettingsState(
     val deliveryMode: DeliveryMode = DeliveryMode.NOTIFICATION_ONLY,
     val tonightDeliveryMode: DeliveryMode = DeliveryMode.NOTIFICATION_ONLY,
     val dailyMentionEveningEvents: Boolean = false,
+    val castLength: CastLength = CastLength.SHORTER,
     val region: Region = Region.SYSTEM,
     // Match SettingsRepository's locale-aware defaults so en-US devices don't
     // briefly render °C / km before the first DataStore emission overrides it.

--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import app.clothescast.core.data.location.OpenMeteoGeocodingClient
+import app.clothescast.core.domain.model.CastLength
 import app.clothescast.core.domain.model.ClothesRule
 import app.clothescast.core.domain.model.DeliveryMode
 import app.clothescast.core.domain.model.DistanceUnit
@@ -50,6 +51,7 @@ class SettingsViewModel(
                         deliveryMode = prefs.deliveryMode,
                         tonightDeliveryMode = prefs.tonightDeliveryMode,
                         dailyMentionEveningEvents = prefs.dailyMentionEveningEvents,
+                        castLength = prefs.castLength,
                         region = prefs.region,
                         temperatureUnit = prefs.temperatureUnit,
                         distanceUnit = prefs.distanceUnit,
@@ -221,6 +223,10 @@ class SettingsViewModel(
 
     fun setDailyMentionEveningEvents(enabled: Boolean) {
         viewModelScope.launch { settingsRepository.setDailyMentionEveningEvents(enabled) }
+    }
+
+    fun setCastLength(length: CastLength) {
+        viewModelScope.launch { settingsRepository.setCastLength(length) }
     }
 
     fun setTonightEnabled(enabled: Boolean) {

--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayPreviews.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayPreviews.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import app.clothescast.core.domain.model.BandClause
+import app.clothescast.core.domain.model.CastLength
 import app.clothescast.core.domain.model.ClothesClause
 import app.clothescast.core.domain.model.ConfidenceInfo
 import app.clothescast.core.domain.model.DeltaClause
@@ -175,13 +176,13 @@ internal fun EmptyStatePreview() {
 @Preview(name = "Today · insight loaded", widthDp = 360)
 @Composable
 internal fun InsightCardPreview() {
-    Frame { InsightCard(SAMPLE_INSIGHT, Region.SYSTEM) }
+    Frame { InsightCard(SAMPLE_INSIGHT, Region.SYSTEM, CastLength.SHORTER) }
 }
 
 @Preview(name = "Today · insight (dark)", widthDp = 360)
 @Composable
 internal fun InsightCardDarkPreview() {
-    Frame(darkTheme = true) { InsightCard(SAMPLE_INSIGHT, Region.SYSTEM) }
+    Frame(darkTheme = true) { InsightCard(SAMPLE_INSIGHT, Region.SYSTEM, CastLength.SHORTER) }
 }
 
 @Preview(name = "Confidence · high", widthDp = 360)

--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.clothescast.R
+import app.clothescast.core.domain.model.CastLength
 import app.clothescast.core.domain.model.ConfidenceInfo
 import app.clothescast.core.domain.model.ForecastConfidence
 import app.clothescast.core.domain.model.ForecastPeriod
@@ -135,7 +136,7 @@ private fun TodayContent(
             EmptyState(onRefresh = onRefresh, isWorking = isWorking)
         } else {
             OutfitPreviewRow(state.insight)
-            InsightCard(state.insight, state.region)
+            InsightCard(state.insight, state.region, state.castLength)
             if (state.insight.hourly.isNotEmpty()) {
                 ForecastCard(state.insight.hourly, state.temperatureUnit)
             }
@@ -360,9 +361,11 @@ private fun bottomLabelRes(bottom: OutfitSuggestion.Bottom): Int = when (bottom)
 }
 
 @Composable
-internal fun InsightCard(insight: Insight, region: Region) {
+internal fun InsightCard(insight: Insight, region: Region, castLength: CastLength) {
     val context = LocalContext.current
-    val formatter = remember(context, region) { InsightFormatter.forRegion(context, region) }
+    val formatter = remember(context, region, castLength) {
+        InsightFormatter.forRegion(context, region, castLength)
+    }
     Card(modifier = Modifier.fillMaxWidth()) {
         Column(
             modifier = Modifier.padding(20.dp),

--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayViewModel.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
+import app.clothescast.core.domain.model.CastLength
 import app.clothescast.core.domain.model.Insight
 import app.clothescast.core.domain.model.Region
 import app.clothescast.core.domain.model.TemperatureUnit
@@ -22,6 +23,7 @@ data class TodayState(
     val workStatus: WorkStatus = WorkStatus.Idle,
     val temperatureUnit: TemperatureUnit = TemperatureUnit.CELSIUS,
     val region: Region = Region.SYSTEM,
+    val castLength: CastLength = CastLength.SHORTER,
     // Window boundaries used by manual Refresh to decide TODAY vs TONIGHT.
     // Default to the same 7am / 7pm boundaries Schedule uses out of the box;
     // the ViewModel overwrites these with the user's actual schedule times.
@@ -54,6 +56,7 @@ class TodayViewModel(
             workStatus = mergeStatus(todayInfos.toStatus(), tonightInfos.toStatus()),
             temperatureUnit = prefs.temperatureUnit,
             region = prefs.region,
+            castLength = prefs.castLength,
             morningTime = prefs.schedule.time,
             tonightTime = prefs.tonightSchedule.time,
         )

--- a/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
@@ -235,7 +235,7 @@ class FetchAndNotifyWorker(
     // TODO(brand-intro): consider prepending "Today's ClothesCast: " / "Tonight's ClothesCast: "
     // here once the voice preview's phrasing settles — see settings_tts_test_sample.
     private fun formatProse(insight: Insight, prefs: UserPreferences): String =
-        InsightFormatter.forRegion(applicationContext, prefs.region).format(insight.summary)
+        InsightFormatter.forRegion(applicationContext, prefs.region, prefs.castLength).format(insight.summary)
 
     private suspend fun deliverTonight(insight: Insight, prefs: UserPreferences, prose: String) {
         val mode = prefs.tonightDeliveryMode

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -113,6 +113,11 @@
     <string name="settings_tonight_days_label">Days of the week</string>
     <string name="settings_tonight_notify_only_on_events">Only notify when there are evening events</string>
 
+    <string name="settings_cast_length_label">ClothesCast length</string>
+    <string name="settings_cast_length_description">Trade brevity against context. Longer adds the comparison anchor on clauses that have one (e.g. \"Today will be 5° cooler than yesterday\" instead of \"It will be 5° cooler today\"). Applies to both the daily and nightly ClothesCast.</string>
+    <string name="settings_cast_length_shorter">Shorter</string>
+    <string name="settings_cast_length_longer">Longer</string>
+
     <string name="settings_delivery_label">Delivery</string>
     <string name="settings_delivery_notification_only">Notification only</string>
     <string name="settings_delivery_tts_only">Spoken aloud only</string>
@@ -332,9 +337,14 @@
     <string name="insight_band_warm">warm</string>
     <string name="insight_band_hot">hot</string>
 
-    <!-- Day-on-day temperature delta. %1$d is the rounded degree difference. -->
+    <!-- Day-on-day temperature delta. %1$d is the rounded degree difference.
+         The default (shorter) ClothesCast length elides the comparison anchor
+         since the listener already knows it's a yesterday-vs-today read; the
+         "_long" variants spell it out for the longer ClothesCast length. -->
     <string name="insight_delta_warmer">It will be %1$d° warmer today.</string>
     <string name="insight_delta_cooler">It will be %1$d° cooler today.</string>
+    <string name="insight_delta_warmer_long">Today will be %1$d° warmer than yesterday.</string>
+    <string name="insight_delta_cooler_long">Today will be %1$d° cooler than yesterday.</string>
 
     <!-- Severe-weather alert prefix. %1$s = event name (e.g. "Tornado Warning"). -->
     <string name="insight_alert">Alert: %1$s.</string>

--- a/app/src/test/kotlin/app/clothescast/data/SettingsRepositoryTest.kt
+++ b/app/src/test/kotlin/app/clothescast/data/SettingsRepositoryTest.kt
@@ -6,6 +6,7 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.core.stringSetPreferencesKey
+import app.clothescast.core.domain.model.CastLength
 import app.clothescast.core.domain.model.ClothesRule
 import app.clothescast.core.domain.model.DeliveryMode
 import app.clothescast.core.domain.model.DistanceUnit
@@ -134,6 +135,17 @@ class SettingsRepositoryTest {
 
         subject.setDailyMentionEveningEvents(false)
         subject.preferences.first().dailyMentionEveningEvents shouldBe false
+    }
+
+    @Test
+    fun `castLength defaults to SHORTER and round-trips`() = runTest {
+        subject.preferences.first().castLength shouldBe CastLength.SHORTER
+
+        subject.setCastLength(CastLength.LONGER)
+        subject.preferences.first().castLength shouldBe CastLength.LONGER
+
+        subject.setCastLength(CastLength.SHORTER)
+        subject.preferences.first().castLength shouldBe CastLength.SHORTER
     }
 
     @Test

--- a/app/src/test/kotlin/app/clothescast/insight/InsightFormatterTest.kt
+++ b/app/src/test/kotlin/app/clothescast/insight/InsightFormatterTest.kt
@@ -5,6 +5,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import app.clothescast.core.domain.model.AlertClause
 import app.clothescast.core.domain.model.BandClause
 import app.clothescast.core.domain.model.CalendarTieInClause
+import app.clothescast.core.domain.model.CastLength
 import app.clothescast.core.domain.model.EveningEventTieInClause
 import app.clothescast.core.domain.model.ClothesClause
 import app.clothescast.core.domain.model.DeltaClause
@@ -68,6 +69,15 @@ class InsightFormatterTest {
     fun `delta clause emits cooler`() {
         val out = subject.format(summary(delta = DeltaClause(6, DeltaClause.Direction.COOLER)))
         out shouldBe "Today will be mild. It will be 6° cooler today."
+    }
+
+    @Test
+    fun `delta clause uses the longer 'than yesterday' form when castLength is LONGER`() {
+        val longer = InsightFormatter.forContext(context, Locale.ENGLISH, CastLength.LONGER)
+        longer.format(summary(delta = DeltaClause(5, DeltaClause.Direction.WARMER))) shouldBe
+            "Today will be mild. Today will be 5° warmer than yesterday."
+        longer.format(summary(delta = DeltaClause(6, DeltaClause.Direction.COOLER))) shouldBe
+            "Today will be mild. Today will be 6° cooler than yesterday."
     }
 
     @Test

--- a/app/src/test/kotlin/app/clothescast/ui/settings/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/app/clothescast/ui/settings/SettingsViewModelTest.kt
@@ -4,6 +4,7 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences
 import app.clothescast.core.data.location.OpenMeteoGeocodingClient
+import app.clothescast.core.domain.model.CastLength
 import app.clothescast.core.domain.model.DeliveryMode
 import app.clothescast.core.domain.model.DistanceUnit
 import app.clothescast.core.domain.model.TemperatureUnit
@@ -162,6 +163,17 @@ class SettingsViewModelTest {
         subject.setUseCalendarEvents(false)
         subject.state.first { !it.useCalendarEvents }
         settingsRepository.preferences.first().useCalendarEvents shouldBe false
+    }
+
+    @Test
+    fun `setCastLength persists and surfaces in state`() = runTest {
+        subject.setCastLength(CastLength.LONGER)
+        subject.state.first { it.castLength == CastLength.LONGER }
+        settingsRepository.preferences.first().castLength shouldBe CastLength.LONGER
+
+        subject.setCastLength(CastLength.SHORTER)
+        subject.state.first { it.castLength == CastLength.SHORTER }
+        settingsRepository.preferences.first().castLength shouldBe CastLength.SHORTER
     }
 
     @Test

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Settings.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Settings.kt
@@ -7,6 +7,23 @@ enum class DistanceUnit { KILOMETERS, MILES }
 enum class DeliveryMode { NOTIFICATION_ONLY, TTS_ONLY, NOTIFICATION_AND_TTS }
 
 /**
+ * How verbose the rendered ClothesCast prose should be. Toggles between the
+ * historical terse phrasing and a more conversational form that adds context
+ * the listener may already infer.
+ *
+ * - [SHORTER] is the historical default. Each clause uses the existing
+ *   spoken templates ("It will be 5° cooler today.").
+ * - [LONGER] swaps in expanded prose variants where a natural one exists —
+ *   e.g. delta becomes "Today will be 5° cooler than yesterday." Same set
+ *   of clauses fires; only the per-clause wording differs. Clauses without
+ *   a longer variant fall through to the [SHORTER] template.
+ *
+ * Applies to both the morning and evening passes — there's no reason a user
+ * would want a chatty morning and a terse evening.
+ */
+enum class CastLength { SHORTER, LONGER }
+
+/**
  * Where the spoken-aloud audio comes from.
  *
  * - [DEVICE] uses Android's on-device TextToSpeech engine. Free, fully offline once
@@ -213,6 +230,12 @@ data class UserPreferences(
      * one clothes rule triggers against the evening hourly slice. Off by default.
      */
     val dailyMentionEveningEvents: Boolean = false,
+    /**
+     * How verbose the rendered insight prose should be. Default [CastLength.SHORTER]
+     * preserves the historical per-clause templates; [CastLength.LONGER] swaps
+     * in expanded variants where a natural one exists (see [CastLength]).
+     */
+    val castLength: CastLength = CastLength.SHORTER,
 ) {
     companion object {
         const val DEFAULT_GEMINI_VOICE = "Kore"


### PR DESCRIPTION
## Summary
Adds a `CastLength` preference (Schedule settings) that chooses between
the existing terse phrasing (SHORTER, default — current behaviour) and
an expanded form that adds the comparison anchor on clauses that have
one. Currently this is the delta clause:

- SHORTER: "It will be 5° cooler today." (unchanged)
- LONGER: "Today will be 5° cooler than yesterday."

Same set of clauses fires; only per-clause wording differs. Applies to
both the morning and evening ClothesCast.

## Notes
- Domain stays Android-free: `CastLength` lives in `:core:domain` and
  flows through `UserPreferences` → `InsightFormatter`. The use case
  (`RenderInsightSummary`) is untouched — clauses are length-agnostic
  structures; only the prose rendering differs.
- Other clauses (band, clothes, precip, alert, tie-in) fall through to
  their existing SHORTER template — there's no natural longer variant
  for them yet. Easy to extend.
- Non-English locales currently fall back to the English LONGER variant
  via Android's resource lookup; per-locale translations can land
  separately rather than blocking this PR on 23 locale files.

## Privacy
No change to what leaves the device. The LONGER variant only adds
"than yesterday" to the rendered prose; it doesn't pull any new data
into the cast and it's still subject to the existing TTS/BYOK paths.

## Test plan
- [ ] CI: `JVM unit tests` green (covers `RenderInsightSummary`,
      `InsightFormatter`, `SettingsRepository`, `SettingsViewModel`)
- [ ] CI: `Android debug build` green
- [ ] Manual: flip Schedule → ClothesCast length → Longer; trigger a
      refresh on a day with a ≥3°C delta and confirm the rendered prose
      ends in "Today will be N° cooler/warmer than yesterday."
- [ ] Manual: flip back to Shorter; confirm the historical phrasing
      ("It will be N° cooler today.") returns.
- [ ] Manual: setting persists across app restart.

https://claude.ai/code/session_01ANQiTVjFxprhSGqMbDogN7

---
_Generated by [Claude Code](https://claude.ai/code/session_01ANQiTVjFxprhSGqMbDogN7)_