### PR TITLE
:app — retry NoTransformationFoundException as a transient OpenMeteo blip

### DIFF
--- a/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
@@ -25,6 +25,7 @@ import app.clothescast.tts.GeminiTtsSpeaker
 import app.clothescast.tts.OpenAITtsSpeaker
 import app.clothescast.tts.resolve
 import app.clothescast.widget.OutfitWidget
+import io.ktor.client.call.NoTransformationFoundException
 import io.ktor.client.network.sockets.ConnectTimeoutException
 import io.ktor.client.network.sockets.SocketTimeoutException
 import io.ktor.client.plugins.HttpRequestTimeoutException
@@ -171,6 +172,16 @@ class FetchAndNotifyWorker(
             DiagLog.w(TAG, "Request timeout; retrying.", e); Result.retry()
         } catch (e: IOException) {
             DiagLog.w(TAG, "Network IO failure; retrying.", e); Result.retry()
+        } catch (e: NoTransformationFoundException) {
+            // Belt-and-braces for OpenMeteoClient's expectSuccess=true: the
+            // gateway occasionally returns a 5xx with a text/html error page,
+            // and if the response validator ever doesn't fire (R8 quirk, an
+            // un-flagged call site) the JSON deserializer throws this instead
+            // of ResponseException. Treat as transient and retry — the
+            // alternative is the cryptic Ktor message landing on the failure
+            // card.
+            DiagLog.w(TAG, "Content-type mismatch from upstream (likely 5xx HTML body); retrying.", e)
+            Result.retry()
         } catch (t: Throwable) {
             DiagLog.e(TAG, "Unhandled error; failing.", t)
             Result.failure(reason(REASON_UNHANDLED, summarize(t)))


### PR DESCRIPTION
## Summary

User on versionCode 226 reported the Open-Meteo failure card showing the full `NoTransformationFoundException` wall-of-text (URL, status `502 Bad Gateway`, `ContentType: text/html`, FAQ link) — the cryptic message that #7d65f48 was supposed to suppress.

7d65f48 added per-request `expectSuccess = true` on `OpenMeteoClient.fetchPrimary` so a 502 with `text/html` would surface as `ServerResponseException` and hit the worker's existing 5xx → retry path. The unit test confirms the validator fires under `MockEngine`. But the user is still seeing the un-trimmed message on a build that *includes* that fix, which leaves two possibilities:

1. Stale `WorkInfo` from a pre-fix run still lingering on device — failure detail is persisted by `WorkManager` and only cleared by the next worker outcome.
2. R8 in the release build defeating the per-request response validator (a known kind of quirk).

Either way, when `NoTransformationFoundException` leaks out of the OpenMeteo client there's no scenario where treating it as a permanent failure is correct: the JSON deserializer only sees the body type mismatch when upstream returned a non-JSON body, which is overwhelmingly a transient gateway 5xx for Open-Meteo. Catch it explicitly in `FetchAndNotifyWorker` and `Result.retry()` so the existing exponential backoff reabsorbs the blip instead of pinning the gnarly Ktor message on the failure card until the next morning alarm overwrites it.

Defense-in-depth on top of #7d65f48; that commit's `expectSuccess = true` stays in place.

## Test plan

- [ ] CI: `JVM unit tests` green (existing `OpenMeteoClient` 502 → `ServerResponseException` test still asserts the primary path)
- [ ] CI: `Android debug build` green
- [ ] On-device: with the fix landed, a real Open-Meteo 502 (or repro via DNS / tampered response) should leave `WorkStatus.Running` showing during retry rather than the failure card

No change to what crosses the device boundary.

https://claude.ai/code/session_013UKW6chdaXMCvW3cxSkjHR

---
_Generated by [Claude Code](https://claude.ai/code/session_013UKW6chdaXMCvW3cxSkjHR)_