### PR TITLE
:app — show resolved system locale next to "System"; clarify Region vs Voice scope

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/settings/RegionSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/RegionSettings.kt
@@ -7,7 +7,10 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -15,6 +18,7 @@ import app.clothescast.R
 import app.clothescast.core.domain.model.DistanceUnit
 import app.clothescast.core.domain.model.Region
 import app.clothescast.core.domain.model.TemperatureUnit
+import java.util.Locale
 
 @Composable
 internal fun RegionContent(
@@ -35,9 +39,21 @@ internal fun RegionContent(
         verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {
         SectionCard(title = stringResource(R.string.settings_region_language_title)) {
+            Text(
+                text = stringResource(R.string.settings_region_language_description),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            // System tag exposed next to "Follow system locale" so the user can
+            // verify what their phone is actually resolving to (e.g. "en-GB").
+            // Locale.getDefault() matches what InsightFormatter.forRegion falls
+            // back to when Region.SYSTEM is selected, so this is the same
+            // locale that drives the rendered prose.
+            val systemTag = remember { Locale.getDefault().toLanguageTag() }
             Region.entries.forEach { option ->
+                val base = stringResource(regionLabel(option))
                 RadioRow(
-                    label = stringResource(regionLabel(option)),
+                    label = if (option == Region.SYSTEM) "$base ($systemTag)" else base,
                     selected = option == region,
                     onSelect = { onSetRegion(option) },
                 )

--- a/app/src/main/kotlin/app/clothescast/ui/settings/VoiceSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/VoiceSettings.kt
@@ -45,6 +45,7 @@ import app.clothescast.tts.OpenAITtsSpeaker
 import app.clothescast.tts.TtsVoiceOption
 import app.clothescast.tts.filterByVariant
 import app.clothescast.tts.resolve
+import java.util.Locale
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -105,6 +106,11 @@ internal fun VoiceContent(
         // (en-GB → fable, else nova) as well as the device engine, so users on any
         // engine can pick it without first switching engine.
         SectionCard(title = stringResource(R.string.settings_tts_voice_locale_label)) {
+            Text(
+                text = stringResource(R.string.settings_tts_voice_locale_description),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
             VoiceLocalePicker(
                 selected = voiceLocale,
                 enabled = !isPreviewing,
@@ -295,12 +301,20 @@ private fun VoiceLocalePicker(
 ) {
     var dialogOpen by remember { mutableStateOf(false) }
     val title = stringResource(R.string.settings_tts_voice_locale_label)
+    // Mirrors RegionSettings: append the resolved phone-locale tag to the
+    // "Follow phone language" entry so the user can see what System actually
+    // means on their device (e.g. en-GB) without leaving the screen.
+    val systemTag = remember { Locale.getDefault().toLanguageTag() }
+    val labelFor: @Composable (VoiceLocale) -> String = { option ->
+        val base = stringResource(voiceLocaleLabel(option))
+        if (option == VoiceLocale.SYSTEM) "$base ($systemTag)" else base
+    }
     OutlinedButton(
         onClick = { dialogOpen = true },
         enabled = enabled,
         modifier = Modifier.fillMaxWidth(),
     ) {
-        Text("$title: ${stringResource(voiceLocaleLabel(selected))}")
+        Text("$title: ${labelFor(selected)}")
     }
     if (dialogOpen) {
         AlertDialog(
@@ -310,7 +324,7 @@ private fun VoiceLocalePicker(
                 Column {
                     VoiceLocale.entries.forEach { option ->
                         RadioRow(
-                            label = stringResource(voiceLocaleLabel(option)),
+                            label = labelFor(option),
                             selected = option == selected,
                             onSelect = {
                                 onSelect(option)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -127,6 +127,9 @@
     <string name="settings_tts_voice_label">Voice</string>
     <string name="settings_tts_voice_dismiss">Done</string>
     <string name="settings_tts_voice_locale_label">Language</string>
+    <!-- Caption under Voice > Language: only the spoken accent, not the on-screen
+         text. Pairs with settings_region_language_description. -->
+    <string name="settings_tts_voice_locale_description">Sets the accent of the spoken voice. Doesn\'t change the displayed text.</string>
     <string name="settings_tts_voice_locale_system">Follow phone language</string>
     <string name="settings_tts_voice_locale_en_us">English (United States)</string>
     <string name="settings_tts_voice_locale_en_gb">English (United Kingdom)</string>
@@ -184,6 +187,11 @@
     <string name="settings_elevenlabs_key_clear">Clear stored ElevenLabs key</string>
 
     <string name="settings_region_language_title">Language</string>
+    <!-- Caption rendered under the Region > Language title, pairing with
+         settings_tts_voice_locale_description so the user can tell which knob
+         changes which surface. The bug we keep getting reported is "I'm en-GB
+         but it still says sweater" — that's this setting, not Voice. -->
+    <string name="settings_region_language_description">Sets the language of the displayed text and notifications.</string>
     <string name="settings_region_language_system">Follow system locale</string>
     <string name="settings_region_language_en_us">English (United States)</string>
     <string name="settings_region_language_en_gb">English (United Kingdom)</string>


### PR DESCRIPTION
## Summary

You hit "I'm on en-GB but it still says sweater" and asked for two things: show the locale (short code) next to System, and clarify whether Region or Voice is what controls displayed text. This does both.

- **Region > Language** and **Voice > Language** each get a one-line caption under the title:
  - Region: "Sets the language of the displayed text and notifications."
  - Voice: "Sets the accent of the spoken voice. Doesn't change the displayed text."
- The "Follow system locale" / "Follow phone language" entries now append the resolved BCP-47 tag in parentheses, e.g. "Follow system locale (en-GB)". Pulled from `Locale.getDefault().toLanguageTag()` — the same locale `InsightFormatter.forRegion` falls back to when `Region.SYSTEM` is selected, so what you see in the picker matches what actually drives the rendered prose.

## Which knob is the sweater bug?

Region. Voice only changes the spoken accent. So on an en-GB phone with Region=System, the picker now reads "Follow system locale (en-GB)" — confirming the system locale is being respected.

## Note: residual "sweater" bug

Even with Region resolving to en-GB correctly, `EnglishClothesPhraser` embeds the raw stored item key ("sweater", "pants") into the prose rather than translating to the en-GB `garment_*` resources. So the *outfit-card label* says "Jumper" (en-GB override on `today_outfit_top_sweater`) while the *insight prose* still says "Wear a sweater." That's a separate fix — flagging here so it's not lost.

## Test plan

- [ ] On an en-GB device with Region=System, open Settings > Region: row reads "Follow system locale (en-GB)" with the caption above.
- [ ] On the same device, open Settings > Voice: locale picker button reads "Language: Follow phone language (en-GB)"; tapping in shows the same in the dialog.
- [ ] Pick an explicit region (e.g. EN_AU): only the SYSTEM row shows the tag; explicit entries are unchanged.
- [ ] CI green (JVM unit tests + Android debug build).

https://claude.ai/code/session_01JjXDtdtaF8w7wtPwGncCde

---
_Generated by [Claude Code](https://claude.ai/code/session_01JjXDtdtaF8w7wtPwGncCde)_