### PR TITLE
:app — translate stored garment keys in en-GB / en-AU insight prose

### DIFF
--- a/app/src/main/kotlin/app/clothescast/insight/ClothesPhraser.kt
+++ b/app/src/main/kotlin/app/clothescast/insight/ClothesPhraser.kt
@@ -34,6 +34,11 @@ internal interface ClothesPhraser {
 
 /**
  * English article picker.
+ *  - Stored item keys ("sweater", "pants", "t-shirt") are translated through
+ *    the locale's `garment_*` resources first so en-GB / en-AU prose says
+ *    "Wear a jumper" / en-GB "Wear trousers" while en-US still says
+ *    "Wear a sweater" / "Wear pants". Items not in the [Garment] catalog
+ *    (e.g. "umbrella", user-typed extras) pass through unchanged.
  *  - Items ending in 's' are treated as plural (shorts, boots, gloves) and take
  *    no article.
  *  - Items starting with a vowel letter take "an"; everything else takes "a".
@@ -41,24 +46,36 @@ internal interface ClothesPhraser {
  * "Wear a sweater and jacket." rather than fully grammatical "a sweater and a jacket."
  */
 internal class EnglishClothesPhraser(private val resources: Resources) : ClothesPhraser {
-    override fun withArticle(item: String): String = when {
-        item.endsWith("s", ignoreCase = true) -> item
-        item.firstOrNull()?.let { it.lowercaseChar() in "aeiou" } == true ->
-            resources.getString(R.string.insight_clothes_article_an, item)
-        else -> resources.getString(R.string.insight_clothes_article_a, item)
+    override fun withArticle(item: String): String = prefixArticle(translate(item))
+
+    override fun joinItems(items: List<String>): String {
+        val translated = items.map(::translate)
+        return when (translated.size) {
+            0 -> ""
+            1 -> prefixArticle(translated[0])
+            2 -> resources.getString(R.string.insight_clothes_join_two, prefixArticle(translated[0]), translated[1])
+            else -> resources.getString(
+                R.string.insight_clothes_join_many,
+                prefixArticle(translated[0]),
+                translated.subList(1, translated.size - 1).joinToString(", "),
+                translated.last(),
+            )
+        }
     }
 
-    override fun joinItems(items: List<String>): String = when (items.size) {
-        0 -> ""
-        1 -> withArticle(items[0])
-        2 -> resources.getString(R.string.insight_clothes_join_two, withArticle(items[0]), items[1])
-        else -> resources.getString(
-            R.string.insight_clothes_join_many,
-            withArticle(items[0]),
-            items.subList(1, items.size - 1).joinToString(", "),
-            items.last(),
-        )
+    private fun prefixArticle(display: String): String = when {
+        display.endsWith("s", ignoreCase = true) -> display
+        display.firstOrNull()?.let { it.lowercaseChar() in "aeiou" } == true ->
+            resources.getString(R.string.insight_clothes_article_an, display)
+        else -> resources.getString(R.string.insight_clothes_article_a, display)
     }
+
+    // Lowercased so the noun reads naturally mid-sentence ("Wear a jumper.")
+    // — the `garment_*` resources are title-cased for the dropdown UI, and the
+    // article picker also wants to see the *display* string (en-GB "trousers"
+    // ends in 's' → bare; en-GB "umbrella" stays vowel-led → "an umbrella").
+    private fun translate(item: String): String =
+        resources.localizedGarmentLabel(item)?.lowercase(Locale.ENGLISH) ?: item
 }
 
 /**
@@ -177,25 +194,8 @@ internal class ResourceClothesPhraser(private val resources: Resources) : Clothe
         }
     }
 
-    private fun translate(item: String): String {
-        val garment = Garment.fromKey(item) ?: return item
-        val resId = GARMENT_RES_IDS[garment] ?: return item
-        return resources.getString(resId)
-    }
-
-    private companion object {
-        val GARMENT_RES_IDS: Map<Garment, Int> = mapOf(
-            Garment.SWEATER to R.string.garment_sweater,
-            Garment.HOODIE to R.string.garment_hoodie,
-            Garment.JACKET to R.string.garment_jacket,
-            Garment.COAT to R.string.garment_coat,
-            Garment.TSHIRT to R.string.garment_tshirt,
-            Garment.SHIRT to R.string.garment_shirt,
-            Garment.SHORTS to R.string.garment_shorts,
-            Garment.PANTS to R.string.garment_pants,
-            Garment.JEANS to R.string.garment_jeans,
-        )
-    }
+    private fun translate(item: String): String =
+        resources.localizedGarmentLabel(item) ?: item
 }
 
 /**
@@ -207,4 +207,28 @@ internal class BareClothesPhraser : ClothesPhraser {
     override fun withArticle(item: String): String = item
 
     override fun joinItems(items: List<String>): String = items.joinToString(", ")
+}
+
+private val GARMENT_RES_IDS: Map<Garment, Int> = mapOf(
+    Garment.SWEATER to R.string.garment_sweater,
+    Garment.HOODIE to R.string.garment_hoodie,
+    Garment.JACKET to R.string.garment_jacket,
+    Garment.COAT to R.string.garment_coat,
+    Garment.TSHIRT to R.string.garment_tshirt,
+    Garment.SHIRT to R.string.garment_shirt,
+    Garment.SHORTS to R.string.garment_shorts,
+    Garment.PANTS to R.string.garment_pants,
+    Garment.JEANS to R.string.garment_jeans,
+)
+
+/**
+ * Look up the locale-specific display label for a stored garment key
+ * (e.g. "sweater" → "Sweater" / "Jumper" / "Pullover" depending on resources).
+ * Returns null when the key isn't in the catalog (caller should fall back to
+ * the raw item — this preserves user-typed extras like "umbrella" or "boots").
+ */
+internal fun Resources.localizedGarmentLabel(item: String): String? {
+    val garment = Garment.fromKey(item) ?: return null
+    val resId = GARMENT_RES_IDS[garment] ?: return null
+    return getString(resId)
 }

--- a/app/src/main/res/values-en-rAU/strings.xml
+++ b/app/src/main/res/values-en-rAU/strings.xml
@@ -1,14 +1,34 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-Australian English overrides. en-AU is essentially en-US-flavoured for this
-app's vocabulary — the only label that diverges from the en-US base is
-"Sweater" (en-AU says "Jumper"). "Long pants" stays as-is: en-AU shares
-"pants" with en-US (no en-GB-style underwear collision).
+Australian English overrides. The natural en-AU choice for this app's
+vocabulary is "Jumper" (cold-weather top) + "Pants" (long-pants garment) —
+"jumper" is universal Aussie usage, and "pants" doesn't trigger the en-GB
+underwear collision in en-AU.
+
+Why this file lists "Pants" + "Long pants" explicitly even though they
+match the en-US default: Android's API 24+ resource resolver ranks
+candidate values-en-rXX folders by CLDR locale-similarity, and en-AU and
+en-GB both descend from en-001 (English-World) while en-US doesn't — so
+without an explicit en-rAU override the resolver picks values-en-rGB
+("Trousers") as a closer match than the en-US-flavoured default. We
+re-state the en-US choice here to block that en-rGB inheritance.
+
+Future en-rGB additions silently leak to en-AU the same way; mirror them
+here whenever en-AU should diverge.
 -->
 <resources>
     <string name="today_outfit_top_sweater">Jumper</string>
+    <string name="today_outfit_bottom_long_pants">Long pants</string>
+    <!-- "Shorts" is what en-US says too and en-rGB doesn't currently
+         override it, so this isn't blocking a leak today — it's pinning
+         the natural en-AU choice in case a future en-rGB override (or a
+         CLDR change) starts pulling something else in. -->
+    <string name="today_outfit_bottom_shorts">Shorts</string>
 
-    <!-- Clothes-rule garment dropdown — en-AU shares "Jumper" with en-GB but
-         keeps "Pants" (no underwear collision like en-GB has). -->
+    <!-- Clothes-rule garment dropdown — same vocabulary swap as the
+         outfit-card labels above. en-AU agrees with en-GB on "Jumper"
+         but stays with "Pants" (no underwear collision) and "Shorts". -->
     <string name="garment_sweater">Jumper</string>
+    <string name="garment_pants">Pants</string>
+    <string name="garment_shorts">Shorts</string>
 </resources>

--- a/app/src/test/kotlin/app/clothescast/insight/InsightFormatterTest.kt
+++ b/app/src/test/kotlin/app/clothescast/insight/InsightFormatterTest.kt
@@ -209,6 +209,58 @@ class InsightFormatterTest {
     }
 
     // ---------------------------------------------------------------------
+    // British / Australian English — picks up the en-rGB / en-rAU vocabulary
+    // overrides on `garment_*` resources so the rendered prose matches the
+    // dropdown labels (en-GB user reads "Wear a jumper.", not "Wear a sweater.").
+    // ---------------------------------------------------------------------
+
+    private val britishSubject = InsightFormatter.forContext(context, Locale.forLanguageTag("en-GB"))
+    private val australianSubject = InsightFormatter.forContext(context, Locale.forLanguageTag("en-AU"))
+
+    @Test
+    fun `en-GB — sweater key renders as 'a jumper'`() {
+        britishSubject.format(summary(clothes = ClothesClause(listOf("sweater")))) shouldBe
+            "Today will be mild. Wear a jumper."
+    }
+
+    @Test
+    fun `en-GB — pants key renders bare as 'trousers' (plural ending)`() {
+        britishSubject.format(summary(clothes = ClothesClause(listOf("pants")))) shouldBe
+            "Today will be mild. Wear trousers."
+    }
+
+    @Test
+    fun `en-GB — multi-item list translates each item, article only on the first`() {
+        britishSubject.format(
+            summary(clothes = ClothesClause(listOf("sweater", "pants", "umbrella"))),
+        ) shouldBe "Today will be mild. Wear a jumper, trousers, and umbrella."
+    }
+
+    @Test
+    fun `en-GB — calendar tie-in translates the item`() {
+        val out = britishSubject.format(
+            summary(
+                period = ForecastPeriod.TONIGHT,
+                calendarTieIn = CalendarTieInClause("sweater"),
+            ),
+        )
+        out shouldBe "Tonight will be mild. Bring a jumper tonight."
+    }
+
+    @Test
+    fun `en-AU — sweater renders as 'a jumper' and pants stays 'pants'`() {
+        // values-en-rAU/strings.xml explicitly overrides garment_pants to
+        // "Pants" to block the en-rGB inheritance — Android's API 24+
+        // resource resolver would otherwise pick values-en-rGB ("Trousers")
+        // as a closer match for en-AU than the en-US default, since en-AU
+        // and en-GB share the en-001 CLDR ancestor. The override pins the
+        // natural Aussie usage.
+        australianSubject.format(
+            summary(clothes = ClothesClause(listOf("sweater", "pants"))),
+        ) shouldBe "Today will be mild. Wear a jumper and pants."
+    }
+
+    // ---------------------------------------------------------------------
     // German locale — picks up values-de/strings.xml + GermanClothesPhraser.
     // Spot-checks rather than mirroring every English case: the goal is to
     // confirm the localized resources are actually wired through and that


### PR DESCRIPTION
## Summary

Fixes the residual sweater bug from #163: an en-GB user with Region=System sees "Wear a sweater." in the rendered prose even though the picker and outfit-card label both say "Jumper".

`EnglishClothesPhraser` was embedding the raw stored item key (`sweater`, `pants`, `t-shirt`) directly. The German and generic phrasers already translate via `garment_*` resources; this brings English parity.

- Phraser now resolves `Garment.fromKey(item)` → `garment_*` resource → lowercase for mid-sentence use.
- Article picker runs against the *display* string, so en-GB "trousers" → bare (plural ending) and "umbrella" → "an umbrella" (vowel-led) still work.
- Items outside the catalog (user-typed extras, accessories like umbrella) pass through unchanged.
- `ResourceClothesPhraser` and `EnglishClothesPhraser` share the lookup via a new `Resources.localizedGarmentLabel` extension; the previous private `GARMENT_RES_IDS` companion is gone.

## Privacy

Insight prose is fed to TTS engines over BYOK keys. This change only swaps which English vocabulary is in the rendered string; no new fields or identifiers leave the device.

## Test plan

- [ ] CI green: `:core:domain:test`, `:app:testDebugUnitTest`, `:app:assembleDebug`.
- [ ] New `InsightFormatterTest` cases: en-GB ("Wear a jumper.", "Wear trousers.", multi-item Oxford join, calendar tie-in) and en-AU (jumper but pants stays as "pants").
- [ ] Existing en-US / German / Spanish prose expectations unchanged.
- [ ] On-device sanity: en-GB phone, Region=System, fire daily ClothesCast → InsightCard reads "Wear a jumper." rather than "Wear a sweater."

https://claude.ai/code/session_01JjXDtdtaF8w7wtPwGncCde

---
_Generated by [Claude Code](https://claude.ai/code/session_01JjXDtdtaF8w7wtPwGncCde)_