### PR TITLE
:app — include cached today + tonight ClothesCasts in bug report payload

### DIFF
--- a/app/src/main/kotlin/app/clothescast/diag/BugReport.kt
+++ b/app/src/main/kotlin/app/clothescast/diag/BugReport.kt
@@ -19,7 +19,11 @@ import androidx.core.content.FileProvider
 import app.clothescast.BuildConfig
 import app.clothescast.ClothesCastApplication
 import app.clothescast.core.domain.model.ClothesRule
+import app.clothescast.core.domain.model.ForecastPeriod
+import app.clothescast.core.domain.model.Insight
+import app.clothescast.core.domain.model.Region
 import app.clothescast.core.domain.model.UserPreferences
+import app.clothescast.insight.InsightFormatter
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.suspendCancellableCoroutine
 import java.io.File
@@ -31,9 +35,10 @@ import kotlin.coroutines.resume
 
 /**
  * Builds a "paste-into-Claude" bug-report payload (version, device, settings,
- * recent log lines, last crash if any) and hands it off via [Intent.ACTION_SEND]
- * so the share sheet can deliver it to whichever app the user picks. Also drops
- * the text on the clipboard as a paste fallback.
+ * the latest cached today + tonight ClothesCasts, recent log lines, last crash
+ * if any) and hands it off via [Intent.ACTION_SEND] so the share sheet can
+ * deliver it to whichever app the user picks. Also drops the text on the
+ * clipboard as a paste fallback.
  */
 object BugReport {
     private const val FILE_PROVIDER_AUTHORITY_SUFFIX = ".fileprovider"
@@ -45,13 +50,13 @@ object BugReport {
      */
     suspend fun share(activity: Activity, includeScreenshot: Boolean) {
         val app = activity.application as ClothesCastApplication
-        val text = buildPayload(app)
+        val text = buildPayload(activity, app)
         val screenshotUri: Uri? = if (includeScreenshot) captureAndPersistScreenshot(activity) else null
         copyToClipboard(activity, text)
         startShare(activity, text, screenshotUri)
     }
 
-    private suspend fun buildPayload(app: ClothesCastApplication): String {
+    private suspend fun buildPayload(context: Context, app: ClothesCastApplication): String {
         val prefs = runCatching { app.settingsRepository.preferences.first() }.getOrNull()
         val keyStatus = runCatching {
             Triple(
@@ -60,6 +65,12 @@ object BugReport {
                 app.secureKeyStore.elevenLabsKeyConfiguredFlow.first(),
             )
         }.getOrDefault(Triple(false, false, false))
+        val today = runCatching {
+            app.insightCache.latestForPeriod(ForecastPeriod.TODAY).first()
+        }.getOrNull()
+        val tonight = runCatching {
+            app.insightCache.latestForPeriod(ForecastPeriod.TONIGHT).first()
+        }.getOrNull()
         val crash = DiagLog.readPersistedCrash()
         val recent = DiagLog.snapshot()
         val now = SimpleDateFormat("yyyy-MM-dd HH:mm:ss Z", Locale.US).format(Date())
@@ -89,6 +100,10 @@ object BugReport {
                 "OpenAI=${if (openAi) "set" else "unset"}, " +
                 "ElevenLabs=${if (elevenLabs) "set" else "unset"}")
             appendLine()
+            appendLine("--- Current ClothesCasts ---")
+            val region = prefs?.region ?: Region.SYSTEM
+            appendInsight("Today (TODAY)", today, context, region)
+            appendInsight("Tonight (TONIGHT)", tonight, context, region)
             if (!crash.isNullOrBlank()) {
                 appendLine("--- Last crash (from previous run) ---")
                 appendLine(crash.trim())
@@ -137,6 +152,44 @@ object BugReport {
             is ClothesRule.PrecipitationProbabilityAbove -> "precipMaxPct > ${c.percent}"
         }
         return "${rule.item} when $cond"
+    }
+
+    private fun StringBuilder.appendInsight(
+        label: String,
+        insight: Insight?,
+        context: Context,
+        region: Region,
+    ) {
+        appendLine("$label:")
+        if (insight == null) {
+            appendLine("  (no cached insight)")
+            appendLine()
+            return
+        }
+        val prose = runCatching { InsightFormatter.forRegion(context, region).format(insight.summary) }
+            .getOrElse { "(prose render failed: ${it.javaClass.simpleName})" }
+        appendLine("  Prose: $prose")
+        appendLine("  Generated: ${insight.generatedAt}")
+        appendLine("  For date: ${insight.forDate}")
+        insight.confidence?.let {
+            appendLine("  Confidence: ${it.level} (tempSpread=${it.tempSpreadC}°C, " +
+                "precipSpread=${it.precipSpreadPp}pp, ${it.modelsConsulted.size} models)")
+        }
+        insight.outfit?.let { appendLine("  Outfit: ${it.top} + ${it.bottom}") }
+        insight.nextOutfit?.let { appendLine("  Next outfit: ${it.top} + ${it.bottom}") }
+        appendLine("  Has events: ${insight.hasEvents}")
+        if (insight.recommendedItems.isNotEmpty()) {
+            appendLine("  Recommended items: ${insight.recommendedItems.joinToString(", ")}")
+        }
+        if (insight.hourly.isNotEmpty()) {
+            appendLine("  Hourly (${insight.hourly.size} entries) feels-like min/max: " +
+                "%.1f / %.1f °C".format(
+                    Locale.US,
+                    insight.hourly.minOf { it.feelsLikeC },
+                    insight.hourly.maxOf { it.feelsLikeC },
+                ))
+        }
+        appendLine()
     }
 
     private suspend fun captureAndPersistScreenshot(activity: Activity): Uri? {


### PR DESCRIPTION
## Summary

Adds the latest cached today + tonight ClothesCasts to the bug-report share payload. Sits between the existing "Settings" and "Recent log" sections.

For each cached insight (read via `InsightCache.latestForPeriod`) the payload now includes:

- **Prose** — rendered via `InsightFormatter.forRegion(...)` against the user's region, so the bug report carries the exact sentence the user sees on Today / hears via TTS
- Generated timestamp + for-date
- Confidence (level, temp spread, precip spread, models consulted) when present
- Outfit (top + bottom) and nextOutfit
- `hasEvents` flag
- Recommended items (rule outputs)
- Hourly feels-like min/max (compact form, not the full 24 entries)

`(no cached insight)` when a slot is empty — e.g. tonight before the evening fetch has run, or first launch.

Example shape (truncated):

```
--- Current ClothesCasts ---
Today (TODAY):
  Prose: Today will be cool to mild. Wear a sweater.
  Generated: 2026-04-28T20:14:33.281Z
  For date: 2026-04-28
  Confidence: HIGH (tempSpread=0.7°C, precipSpread=4.0pp, 4 models)
  Outfit: SWEATER + LONG_PANTS
  Next outfit: SWEATER + LONG_PANTS
  Has events: false
  Recommended items: sweater
  Hourly (24 entries) feels-like min/max: 11.4 / 16.2 °C

Tonight (TONIGHT):
  (no cached insight)
```

## Privacy

No new data category leaves the device. The prose included here is the same string the user already sees on Today and that ClothesCast hands to billed TTS engines (Gemini / OpenAI / ElevenLabs); calendar event titles and locations are deliberately absent from `InsightSummary` for that reason and remain absent here.

## Test plan

- [ ] Trigger a fetch (Refresh button), wait for completion, then "Report a bug" → verify Today section is populated with prose, outfit, confidence.
- [ ] If tonight hasn't fetched yet, verify Tonight shows `(no cached insight)` rather than failing.
- [ ] Switch Region (e.g. SYSTEM → DE_DE) → verify the prose in the next bug report renders in the new locale's vocab.
- [ ] Cache miss path: clear app data, share immediately → both sections show `(no cached insight)`, no crash.

https://claude.ai/code/session_01K7JqMub3xKi4HptZPFDGsW

---
_Generated by [Claude Code](https://claude.ai/code/session_01K7JqMub3xKi4HptZPFDGsW)_