### PR TITLE
:app — voice preview: speak sample in the selected voice locale

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/settings/VoiceSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/VoiceSettings.kt
@@ -1,6 +1,7 @@
 package app.clothescast.ui.settings
 
 import app.clothescast.diag.DiagLog
+import android.content.res.Configuration
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -450,7 +451,9 @@ private fun TestVoiceButton(isPreviewing: Boolean, onClick: () -> Unit) {
  * Plays a preview through the chosen engine + voice. Uses a fixed weather-y
  * sample (rather than the latest cached prose) so every preview tap exercises
  * the brand name's pronunciation and costs the same number of BYOK tokens —
- * making it easier to compare engines and voices on identical words.
+ * making it easier to compare engines and voices on identical words. The
+ * sample is read in the selected *voice locale* so the preview matches the
+ * accent and language the user is auditioning, not the app's UI locale.
  *
  * Errors are surfaced as a Toast so the user can see *why* the voice failed
  * (most often: missing or wrong API key for the chosen provider).
@@ -469,7 +472,14 @@ private suspend fun runTtsPreview(
     // we don't want a hot stack of preview work running on the UI dispatcher.
     withContext(Dispatchers.IO) {
         val locale = voiceLocale.resolve()
-        val text = context.getString(R.string.settings_tts_test_sample)
+        // Fetch the sample in the *voice* locale, not the app's UI locale —
+        // playing English prose through a Japanese voice is exactly the
+        // mismatch the user picked the locale to avoid. Falls back to the
+        // default values/strings.xml entry for any locale we haven't
+        // translated yet.
+        val voiceConfig = Configuration(context.resources.configuration).apply { setLocale(locale) }
+        val text = context.createConfigurationContext(voiceConfig)
+            .getString(R.string.settings_tts_test_sample)
         try {
             when (engine) {
                 TtsEngine.GEMINI ->

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -85,4 +85,6 @@ they work correctly in both the single-band and range templates.
     <!-- Bare number; "في الساعة" comes from insight_precip_at_time. -->
     <string name="insight_time_hour">%1$d</string>
     <string name="insight_time_hour_minutes">%1$d:%2$02d</string>
+
+    <string name="settings_tts_test_sample">ClothesCast اليوم: معتدل، مع أمطار في الساعة 3 عصرًا. ارتدِ سترة.</string>
 </resources>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -83,5 +83,7 @@ West Bengal vocabulary differences in a future PR.
     <!-- "15" — suffix "-এ" comes from insight_precip_at_time wrapper. -->
     <string name="insight_time_hour">%1$d</string>
     <string name="insight_time_hour_minutes">%1$d:%2$02d</string>
+
+    <string name="settings_tts_test_sample">আজকের ClothesCast: মৃদু, বিকেল ৩টায় বৃষ্টি। একটি জ্যাকেট পরুন।</string>
 </resources>
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -123,4 +123,8 @@ the rest of the app stays in English.
     <!-- "15 Uhr" / "15 Uhr 30" — read naturally by German TTS. -->
     <string name="insight_time_hour">%1$d Uhr</string>
     <string name="insight_time_hour_minutes">%1$d Uhr %2$d</string>
+
+    <!-- Spoken sample for the voice preview. The brand name is kept; the rest
+         is fully translated so the chosen voice reads its own language. -->
+    <string name="settings_tts_test_sample">Dein heutiger ClothesCast: mild, mit Regen um 15 Uhr. Trag eine Jacke.</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -84,4 +84,6 @@ Mexico-specific vocabulary overrides live in values-es-rMX.
     <!-- "15" — prepositions ("a las", "de las") come from surrounding templates. -->
     <string name="insight_time_hour">%1$d</string>
     <string name="insight_time_hour_minutes">%1$d:%2$02d</string>
+
+    <string name="settings_tts_test_sample">Tu ClothesCast de hoy: templado, con lluvia a las 3 de la tarde. Lleva una chaqueta.</string>
 </resources>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -88,4 +88,6 @@ Western Arabic numerals (0-9) are used for TTS compatibility.
     <!-- Bare number; "ساعت" comes from insight_precip_at_time. -->
     <string name="insight_time_hour">%1$d</string>
     <string name="insight_time_hour_minutes">%1$d:%2$02d</string>
+
+    <string name="settings_tts_test_sample">ClothesCast امروز: ملایم، با باران ساعت ۳ بعد از ظهر. یک ژاکت بپوشید.</string>
 </resources>

--- a/app/src/main/res/values-fil/strings.xml
+++ b/app/src/main/res/values-fil/strings.xml
@@ -80,4 +80,6 @@ The rest of the UI falls through to values/strings.xml (English).
     <!-- "15" — preposition "ng" comes from surrounding templates. -->
     <string name="insight_time_hour">%1$d</string>
     <string name="insight_time_hour_minutes">%1$d:%2$02d</string>
+
+    <string name="settings_tts_test_sample">ClothesCast mo ngayon: malumanay, may ulan sa alas-3 ng hapon. Magsuot ng dyaket.</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -85,4 +85,6 @@ agreement; garment names are listed without articles and read naturally in conte
     <!-- "15h" / "15h30" — French TTS reads as "quinze heures" / "quinze heures trente". -->
     <string name="insight_time_hour">%1$dh</string>
     <string name="insight_time_hour_minutes">%1$dh%2$02d</string>
+
+    <string name="settings_tts_test_sample">Votre ClothesCast d\'aujourd\'hui : doux, avec de la pluie à 15 h. Portez une veste.</string>
 </resources>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -81,4 +81,6 @@ The rest of the UI falls through to values/strings.xml (English).
     <!-- "15" — postposition "बजे" comes from insight_precip_at_time wrapper. -->
     <string name="insight_time_hour">%1$d</string>
     <string name="insight_time_hour_minutes">%1$d:%2$02d</string>
+
+    <string name="settings_tts_test_sample">आज का ClothesCast: हल्का, दोपहर 3 बजे बारिश के साथ। एक जैकेट पहनें।</string>
 </resources>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -77,4 +77,6 @@ editor, outfit-card labels, and region/voice-locale picker names.
     <!-- "15" — preposition "u" comes from surrounding templates. -->
     <string name="insight_time_hour">%1$d</string>
     <string name="insight_time_hour_minutes">%1$d:%2$02d</string>
+
+    <string name="settings_tts_test_sample">Tvoj današnji ClothesCast: blago, s kišom u 15 sati. Obuci jaknu.</string>
 </resources>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -82,4 +82,6 @@ to values/strings.xml (English).
     <!-- "15" / "15.30" — "pukul" comes from surrounding templates. -->
     <string name="insight_time_hour">%1$d</string>
     <string name="insight_time_hour_minutes">%1$d.%2$02d</string>
+
+    <string name="settings_tts_test_sample">ClothesCast hari ini: sejuk, dengan hujan pukul 3 sore. Kenakan jaket.</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -78,4 +78,6 @@ editor, outfit-card labels, and region/voice-locale picker names.
     <!-- "15" / "15 e 30" — preposition "alle" comes from surrounding templates. -->
     <string name="insight_time_hour">%1$d</string>
     <string name="insight_time_hour_minutes">%1$d e %2$d</string>
+
+    <string name="settings_tts_test_sample">Il tuo ClothesCast di oggi: mite, con pioggia alle 15. Indossa una giacca.</string>
 </resources>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -88,4 +88,6 @@ standard in Israeli digital communication.
     <!-- Bare number; "בשעה" comes from insight_precip_at_time. -->
     <string name="insight_time_hour">%1$d</string>
     <string name="insight_time_hour_minutes">%1$d:%2$02d</string>
+
+    <string name="settings_tts_test_sample">ה-ClothesCast של היום: נעים, עם גשם בשעה 15:00. לבש מעיל.</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -85,4 +85,6 @@ Japanese uses the ideographic period (。) for sentence endings.
     <!-- "15時" / "15時30分" — Japanese spoken time; postposition "頃" comes from insight_precip_at_time. -->
     <string name="insight_time_hour">%1$d時</string>
     <string name="insight_time_hour_minutes">%1$d時%2$d分</string>
+
+    <string name="settings_tts_test_sample">今日の ClothesCast：穏やか、午後3時に雨。ジャケットを着てください。</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -84,4 +84,6 @@ the 을/를 object particle which depends on the noun's final consonant.
     <!-- "15시" / "15시 30분" — Korean spoken time; postposition "경에" comes from insight_precip_at_time. -->
     <string name="insight_time_hour">%1$d시</string>
     <string name="insight_time_hour_minutes">%1$d시 %2$d분</string>
+
+    <string name="settings_tts_test_sample">오늘의 ClothesCast: 온화함, 오후 3시에 비. 재킷을 입으세요.</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -79,4 +79,6 @@ editor, outfit-card labels, and region/voice-locale picker names.
     <!-- "15 uur" — preposition "om" comes from surrounding templates. -->
     <string name="insight_time_hour">%1$d uur</string>
     <string name="insight_time_hour_minutes">%1$d:%2$02d</string>
+
+    <string name="settings_tts_test_sample">Je ClothesCast van vandaag: mild, met regen om 15.00 uur. Trek een jas aan.</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -77,4 +77,6 @@ editor, outfit-card labels, and region/voice-locale picker names.
     <!-- "15" — preposition "o" comes from surrounding templates. -->
     <string name="insight_time_hour">%1$d</string>
     <string name="insight_time_hour_minutes">%1$d:%2$02d</string>
+
+    <string name="settings_tts_test_sample">Twój dzisiejszy ClothesCast: łagodnie, z deszczem o 15:00. Załóż kurtkę.</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -78,4 +78,6 @@ clothes-rule editor, outfit-card labels, and region/voice-locale picker names.
     <!-- "15h" / "15h30" — Brazilian Portuguese hour notation, TTS reads naturally. -->
     <string name="insight_time_hour">%1$dh</string>
     <string name="insight_time_hour_minutes">%1$dh%2$02d</string>
+
+    <string name="settings_tts_test_sample">Seu ClothesCast de hoje: ameno, com chuva às 15h. Use uma jaqueta.</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -77,4 +77,6 @@ editor, outfit-card labels, and region/voice-locale picker names.
     <!-- "15" — preposition "в" comes from surrounding templates. -->
     <string name="insight_time_hour">%1$d</string>
     <string name="insight_time_hour_minutes">%1$d:%2$02d</string>
+
+    <string name="settings_tts_test_sample">Ваш сегодняшний ClothesCast: мягкая погода, дождь в 15:00. Наденьте куртку.</string>
 </resources>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -78,4 +78,6 @@ editor, outfit-card labels, and region/voice-locale picker names.
     <!-- "15" — "klockan" comes from surrounding templates. -->
     <string name="insight_time_hour">%1$d</string>
     <string name="insight_time_hour_minutes">%1$d:%2$02d</string>
+
+    <string name="settings_tts_test_sample">Dagens ClothesCast: milt, med regn klockan 15. Ta på dig en jacka.</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -78,4 +78,6 @@ editor, outfit-card labels, and region/voice-locale picker names.
     <!-- "15" — "saat" comes from surrounding templates. -->
     <string name="insight_time_hour">%1$d</string>
     <string name="insight_time_hour_minutes">%1$d:%2$02d</string>
+
+    <string name="settings_tts_test_sample">Bugünün ClothesCast\'i: ılıman, saat 15.00\'te yağmurlu. Bir ceket giy.</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -77,4 +77,6 @@ editor, outfit-card labels, and region/voice-locale picker names.
     <!-- "15" — preposition "о" comes from surrounding templates. -->
     <string name="insight_time_hour">%1$d</string>
     <string name="insight_time_hour_minutes">%1$d:%2$02d</string>
+
+    <string name="settings_tts_test_sample">Твій сьогоднішній ClothesCast: тепло, з дощем о 15:00. Одягни куртку.</string>
 </resources>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -80,4 +80,6 @@ The rest of the UI falls through to values/strings.xml (English).
     <!-- "15 giờ" / "15 giờ 30 phút" — preposition "lúc" comes from surrounding templates. -->
     <string name="insight_time_hour">%1$d giờ</string>
     <string name="insight_time_hour_minutes">%1$d giờ %2$d phút</string>
+
+    <string name="settings_tts_test_sample">ClothesCast hôm nay: dịu nhẹ, có mưa lúc 3 giờ chiều. Hãy mặc áo khoác.</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -84,4 +84,6 @@ Chinese uses the ideographic period (。) for sentence endings.
     <!-- "15点" / "15点30分" — Chinese spoken time. insight_precip_at_time is a passthrough. -->
     <string name="insight_time_hour">%1$d点</string>
     <string name="insight_time_hour_minutes">%1$d点%2$d分</string>
+
+    <string name="settings_tts_test_sample">今天的 ClothesCast：温和，下午 3 点有雨。请穿一件外套。</string>
 </resources>


### PR DESCRIPTION
## Summary

The Voice Settings preview always fetched `settings_tts_test_sample`
through the Activity context, which resolves to the *app's UI* locale.
That meant tapping a Japanese voice played the **English** sample with
a Japanese TTS engine — exactly the language mismatch the locale
picker exists to avoid. Same for de / fr / es / etc.: users heard
English text spoken with their chosen accent, never the language they
were auditioning.

- Build a `Configuration` overridden with the resolved voice `Locale`
  and fetch the sample through `createConfigurationContext` so the
  preview text matches the voice.
- Add `settings_tts_test_sample` translations to every locale we
  already ship: de, fr, es, it, pt-rBR, nl, sv, pl, hr, uk, ru, tr,
  in, fil, vi, zh-rCN, hi, bn, ja, ko, ar, iw, fa. en-rGB / en-rAU /
  en-rZA fall through to the base English sample — "jacket" is
  universal across en-\* variants. The brand name "ClothesCast" is
  kept literal in every translation; TTS speakers already split it
  for pronunciation (`prepareForTts`), so the existing path handles
  the brand correctly.

## Privacy

No change to what crosses the device boundary. Same fixed sample text
shape, same engines, same BYOK keys — only the source language of the
sample changes, and the user opts in by picking the locale.

## Test plan

- [ ] CI green: `JVM unit tests` + `Android debug build`.
- [ ] Manual: install with Voice → Language = Japanese, tap Test
      Voice — should hear Japanese, not English-with-Japanese-accent.
- [ ] Manual: Voice = System on an English phone, app Region = German
      — preview should still be English (System ⇒ phone locale).
- [ ] Manual: pick a locale we don't yet translate (e.g. fr-CA) —
      preview should fall back to base French (the variant inherits).


---
_Generated by [Claude Code](https://claude.ai/code/session_01MxYBm6MYSJ85iVAvHYezsn)_