### PR TITLE
:app — add values-en-rCA to block en-rGB vocab leak for Canadian English

### DIFF
--- a/app/src/main/res/values-en-rCA/strings.xml
+++ b/app/src/main/res/values-en-rCA/strings.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+Canadian English overrides. The natural en-CA choice for this app's
+vocabulary tracks en-US: "Sweater" (cold-weather top) + "Pants" (long-
+pants garment). Canadians don't say "jumper" or "trousers" the way en-GB
+speakers do; an en-CA user picking Region: English (Canada) and seeing
+"Jumper" would read as the British vocabulary leaking through.
+
+Why this file restates the en-US choices even though they match the
+baseline: Android's API 24+ resource resolver ranks candidate
+values-en-rXX folders by CLDR locale-similarity, and en-CA and en-GB both
+descend from en-001 (English-World) while en-US doesn't — so without an
+explicit en-rCA override the resolver picks values-en-rGB ("Jumper",
+"Trousers") as a closer match than the en-US-flavoured default. We
+re-state the en-US choice here to block that en-rGB inheritance, the
+same trick values-en-rAU and values-en-rZA already use.
+
+Future en-rGB additions silently leak to en-CA the same way; mirror them
+here whenever en-CA should diverge.
+-->
+<resources>
+    <string name="today_outfit_top_sweater">Sweater</string>
+    <string name="today_outfit_bottom_long_pants">Long pants</string>
+    <!-- "Shorts" matches en-US and en-rGB doesn't currently override it,
+         so this isn't blocking a leak today — it's pinning the natural
+         en-CA choice in case a future en-rGB override (or a CLDR change)
+         starts pulling something else in. -->
+    <string name="today_outfit_bottom_shorts">Shorts</string>
+
+    <!-- Clothes-rule garment dropdown — same vocabulary swap as the
+         outfit-card labels above. en-CA agrees with en-US on "Sweater"
+         and "Pants" (no underwear collision in Canadian English). -->
+    <string name="garment_sweater">Sweater</string>
+    <string name="garment_pants">Pants</string>
+    <string name="garment_shorts">Shorts</string>
+</resources>


### PR DESCRIPTION
## Summary

`Region.EN_CA` is already a picker option (and the baseline strings file
carries `English (Canada)` labels), but the repo was missing a
`values-en-rCA/` folder. Without one, Android's API 24+ resource
resolver picks `values-en-rGB` for an en-CA device because en-CA and
en-GB both descend from `en-001` (English-World) while en-US doesn't —
so a Canadian user picking **Region: English (Canada)** currently sees
"Jumper" / "Trousers" instead of "Sweater" / "Pants". Wrong vocabulary
for Canadian English.

This is the same bug `values-en-rAU` and `values-en-rZA` were created to
fix. Mirror the same "pin the en-US choice to block en-rGB" trick:

- `today_outfit_top_sweater` → "Sweater"
- `today_outfit_bottom_long_pants` → "Long pants"
- `today_outfit_bottom_shorts` → "Shorts" (defensive, in case a future
  en-rGB override starts pulling it in)
- `garment_sweater` → "Sweater"
- `garment_pants` → "Pants"
- `garment_shorts` → "Shorts"

## Notes

- Display-only. The stored garment keys remain the en-US baseline
  (`sweater`, `pants`, `shorts`); only the displayed label changes.
- No code or test changes — pure resource override.
- No new strings sent off-device, no privacy delta.

## Test plan

- [ ] CI: `JVM unit tests` green
- [ ] CI: `Android debug build` green
- [ ] Manual: set device locale to en-CA (or pick **Region: English
      (Canada)** in Settings) → outfit card reads "Sweater" / "Long
      pants", clothes-rule editor dropdown reads "Sweater" / "Pants"
- [ ] Manual: switch back to **Region: English (United Kingdom)** →
      labels return to "Jumper" / "Trousers" (regression check)

https://claude.ai/code/session_01C1Q3vzGj6KmbYDfD6b2yhu

---
_Generated by [Claude Code](https://claude.ai/code/session_015agXppcN2fzATq5Xnzpozs)_