### PR TITLE
:app — fix en-US Kilometers spelling + German UI translations

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -291,6 +291,27 @@ the rest of the app stays in English.
     <string name="settings_calendar_grant_permission">Kalenderzugriff erlauben</string>
     <string name="settings_calendar_open_settings">Kalenderzugriff abgelehnt. Erlaube ihn in den System-Einstellungen.</string>
 
+    <!-- Debug screen — visible only on debug builds. -->
+    <string name="settings_debug_title">Debug (nur in Debug-Builds)</string>
+    <string name="settings_debug_description">Den täglichen ClothesCast-Ablauf sofort auslösen. Praktisch zum Prüfen, ohne auf die geplante Uhrzeit zu warten.</string>
+    <string name="settings_debug_fire_now">ClothesCast jetzt auslösen</string>
+    <string name="settings_debug_fire_toast">ClothesCast-Worker in Warteschlange eingereiht</string>
+
+    <!--
+    About screen — version line, build-type suffix on non-release builds,
+    privacy summary, and the four outbound links / actions
+    (privacy-policy / source / dontkillmyapp / share-bug-report).
+    -->
+    <string name="settings_about_title">Über</string>
+    <string name="settings_about_version">Version %1$s (%2$d)</string>
+    <string name="settings_about_build_type_suffix"> · %1$s-Build</string>
+    <string name="settings_about_privacy">Dein Gemini-API-Schlüssel (für die gesprochene Ausgabe) wird mit einem Schlüssel verschlüsselt gespeichert, der an den Android Keystore gebunden ist. Vorhersagen kommen von Open-Meteo (kein Schlüssel, kein Konto); der Text der täglichen Zusammenfassung wird lokal auf dem Gerät erzeugt. ClothesCast hat kein Backend — es wird nichts an einen Server gesendet, den wir kontrollieren.</string>
+    <string name="settings_about_privacy_policy">Datenschutzerklärung</string>
+    <string name="settings_about_source">Quellcode auf GitHub</string>
+    <string name="settings_about_dontkillmyapp">Hintergrund-Einschränkungen (dontkillmyapp.com)</string>
+    <string name="settings_about_share_bug_report">Fehlerbericht teilen</string>
+    <string name="settings_about_version_copied">Version in Zwischenablage kopiert</string>
+
     <!--
     Today screen — top-bar, refresh toasts, empty state, generation timestamp,
     outfit card, hourly chart, confidence chip, work-status banner. Tone is

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -208,6 +208,36 @@ the rest of the app stays in English.
     <string name="settings_tts_voice_locale_fa_ir">Persisch (Iran)</string>
 
     <!--
+    API keys screen — three identical-shape blocks (Gemini, OpenAI,
+    ElevenLabs), each with status copy, paste-key field placeholder, and
+    save / clear buttons. URLs (aistudio.google.com, platform.openai.com,
+    elevenlabs.io) stay verbatim.
+    -->
+    <string name="settings_api_keys_title">API-Schlüssel</string>
+    <string name="settings_api_keys_description">Richte die API-Schlüssel für die Online-Sprach-Engines ein, die du nutzen möchtest. Schlüssel werden im Android Keystore verschlüsselt gespeichert.</string>
+    <string name="settings_api_key_gemini_label">Gemini</string>
+    <string name="settings_api_key_openai_label">OpenAI</string>
+    <string name="settings_api_key_elevenlabs_label">ElevenLabs</string>
+
+    <string name="settings_api_key_status_set">Ein Gemini-Schlüssel ist eingerichtet.</string>
+    <string name="settings_api_key_status_unset">Kein Gemini-Schlüssel eingerichtet. Hol dir einen unter aistudio.google.com, um Gemini-Stimmen zu nutzen.</string>
+    <string name="settings_api_key_placeholder">Gemini-API-Schlüssel hier einfügen</string>
+    <string name="settings_api_key_save">Gemini-Schlüssel speichern</string>
+    <string name="settings_api_key_clear">Gespeicherten Gemini-Schlüssel löschen</string>
+
+    <string name="settings_openai_key_status_set">Ein OpenAI-Schlüssel ist eingerichtet.</string>
+    <string name="settings_openai_key_status_unset">Kein OpenAI-Schlüssel eingerichtet. Hol dir einen unter platform.openai.com, um OpenAI-Stimmen zu nutzen.</string>
+    <string name="settings_openai_key_placeholder">OpenAI-API-Schlüssel hier einfügen</string>
+    <string name="settings_openai_key_save">OpenAI-Schlüssel speichern</string>
+    <string name="settings_openai_key_clear">Gespeicherten OpenAI-Schlüssel löschen</string>
+
+    <string name="settings_elevenlabs_key_status_set">Ein ElevenLabs-Schlüssel ist eingerichtet.</string>
+    <string name="settings_elevenlabs_key_status_unset">Kein ElevenLabs-Schlüssel eingerichtet. Hol dir einen unter elevenlabs.io, um ElevenLabs-Stimmen zu nutzen.</string>
+    <string name="settings_elevenlabs_key_placeholder">ElevenLabs-API-Schlüssel hier einfügen</string>
+    <string name="settings_elevenlabs_key_save">ElevenLabs-Schlüssel speichern</string>
+    <string name="settings_elevenlabs_key_clear">Gespeicherten ElevenLabs-Schlüssel löschen</string>
+
+    <!--
     Today screen — top-bar, refresh toasts, empty state, generation timestamp,
     outfit card, hourly chart, confidence chip, work-status banner. Tone is
     Du-form imperative (intimate / spousal register), matching the app's

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -71,6 +71,28 @@ the rest of the app stays in English.
     <string name="settings_clothes_cond_precip_above">wenn die Regenwahrscheinlichkeit über %.0f%% liegt</string>
 
     <!--
+    Schedule screen — daily and nightly ClothesCast cards, delivery picker,
+    "Mention evening events" toggle, and the nightly-only "notify only on
+    events" toggle. German typographic quotes („…") in the description.
+    -->
+    <string name="settings_schedule_title">Täglicher ClothesCast</string>
+    <string name="settings_schedule_time_label">Uhrzeit</string>
+    <string name="settings_schedule_days_label">Wochentage</string>
+    <string name="settings_daily_mention_evening_events">Abendtermine erwähnen</string>
+
+    <string name="settings_tonight_title">Nächtlicher ClothesCast</string>
+    <string name="settings_tonight_description">Ein zweiter ClothesCast am Abend für das Wetter heute Nacht. An ruhigen Abenden bleibt er stumm oder erscheint gar nicht, wenn „Nur benachrichtigen, wenn Abendtermine anstehen“ aktiv ist; an Abenden mit Terminen spielt er einen Ton ab und (wenn du gesprochene Ausgabe aktiviert hast) liest sich selbst vor.</string>
+    <string name="settings_tonight_enabled">Nächtlichen ClothesCast anzeigen</string>
+    <string name="settings_tonight_time_label">Uhrzeit</string>
+    <string name="settings_tonight_days_label">Wochentage</string>
+    <string name="settings_tonight_notify_only_on_events">Nur benachrichtigen, wenn Abendtermine anstehen</string>
+
+    <string name="settings_delivery_label">Zustellung</string>
+    <string name="settings_delivery_notification_only">Nur Benachrichtigung</string>
+    <string name="settings_delivery_tts_only">Nur gesprochen</string>
+    <string name="settings_delivery_notification_and_tts">Benachrichtigung und gesprochen</string>
+
+    <!--
     Today screen — top-bar, refresh toasts, empty state, generation timestamp,
     outfit card, hourly chart, confidence chip, work-status banner. Tone is
     Du-form imperative (intimate / spousal register), matching the app's

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -93,6 +93,31 @@ the rest of the app stays in English.
     <string name="settings_delivery_notification_and_tts">Benachrichtigung und gesprochen</string>
 
     <!--
+    Voice screen — engine picker (Device / Gemini / OpenAI / ElevenLabs),
+    voice + language sub-pickers, test-voice button, missing-API-key hint
+    and the in-line "Add API key" dialog.
+    -->
+    <string name="settings_tts_engine_title">Sprach-Engine</string>
+    <string name="settings_tts_engine_description">Online-Engines (Gemini, OpenAI, ElevenLabs) klingen deutlich natürlicher, brauchen aber beim Sprechen einen Netzwerkaufruf und nutzen deinen API-Schlüssel für die Synthese (ein kurzer Aufruf pro gesprochenem ClothesCast). Greift auf die Gerätestimme zurück, wenn die gewählte Engine fehlschlägt.</string>
+    <string name="settings_tts_engine_device">Gerät (offline, kostenlos)</string>
+    <string name="settings_tts_engine_gemini">Gemini (hohe Qualität, online)</string>
+    <string name="settings_tts_engine_openai">OpenAI (hohe Qualität, online)</string>
+    <string name="settings_tts_engine_elevenlabs">ElevenLabs (höchste Qualität, online)</string>
+
+    <string name="settings_tts_voice_label">Stimme</string>
+    <string name="settings_tts_voice_dismiss">Fertig</string>
+    <string name="settings_tts_voice_locale_description">Legt den Akzent der gesprochenen Stimme fest. Ändert den angezeigten Text nicht.</string>
+    <string name="settings_tts_voice_locale_system">Telefonsprache verwenden</string>
+
+    <string name="settings_tts_test">Stimme testen</string>
+    <string name="settings_tts_test_in_flight">Teste — bitte warten…</string>
+    <string name="settings_tts_no_key_hint">Kein %1$s-Schlüssel konfiguriert — füg einen hinzu, um diese Engine zu nutzen.</string>
+    <string name="settings_tts_add_api_key">API-Schlüssel hinzufügen</string>
+    <string name="settings_tts_add_api_key_title">%1$s-API-Schlüssel hinzufügen</string>
+    <string name="settings_tts_add_api_key_save">Speichern</string>
+    <string name="settings_tts_add_api_key_cancel">Abbrechen</string>
+
+    <!--
     Today screen — top-bar, refresh toasts, empty state, generation timestamp,
     outfit card, hourly chart, confidence chip, work-status banner. Tone is
     Du-form imperative (intimate / spousal register), matching the app's

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -108,6 +108,28 @@ the rest of the app stays in English.
     <string name="widget_empty_title">Noch kein Outfit</string>
     <string name="widget_empty_subtitle">Tippe, um ClothesCast zu öffnen</string>
 
+    <!--
+    Onboarding flow — first-run welcome, two permission steps (notifications
+    + location), and the Gemini API-key step. Du-form throughout.
+    -->
+    <string name="onboarding_title">Willkommen bei ClothesCast</string>
+    <string name="onboarding_subtitle">Zwei schnelle Auswahlen, und du bist startklar. Alles andere hat eine sinnvolle Voreinstellung, die du später in den Einstellungen anpassen kannst.</string>
+    <string name="onboarding_notifications_title">Benachrichtigungen</string>
+    <string name="onboarding_notifications_description">Damit dein täglicher ClothesCast bei dir ankommt. Einmal erlauben, und morgen früh ist er da.</string>
+    <string name="onboarding_notifications_grant">Benachrichtigungen erlauben</string>
+    <string name="onboarding_location_title">Standort</string>
+    <string name="onboarding_location_description">Damit die richtige Vorhersage geholt wird. Mit Standortzugriff liest ClothesCast jeden Morgen den ungefähren Standort deines Geräts; andernfalls wähl eine Stadt manuell.</string>
+    <string name="onboarding_location_grant">Standortzugriff erlauben</string>
+    <string name="onboarding_location_denied_hint">Standortzugriff abgelehnt. Du kannst stattdessen eine Stadt manuell wählen.</string>
+    <string name="onboarding_location_enter_manual">Standort manuell eingeben</string>
+    <string name="onboarding_location_using_device">Wir verwenden jeden Morgen den Standort deines Geräts.</string>
+
+    <string name="onboarding_gemini_title">Gemini-API-Schlüssel</string>
+    <string name="onboarding_gemini_description">Wird von ClothesCast für gesprochene Stimmen und die Vorhersage-Generierung verwendet. Hol dir kostenlos einen unter aistudio.google.com. Der Schlüssel wird im Android Keystore verschlüsselt gespeichert.</string>
+    <string name="onboarding_step_done">Fertig</string>
+    <string name="onboarding_skip">Erstmal überspringen</string>
+    <string name="onboarding_continue">Weiter</string>
+
     <!-- Insight prose templates — German equivalents of the keys in values/strings.xml. -->
     <string name="insight_lead_today">Heute</string>
     <string name="insight_lead_tonight">Heute Abend</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -257,6 +257,41 @@ the rest of the app stays in English.
     <string name="settings_location_no_results">Keine Treffer.</string>
 
     <!--
+    Notification channels (system Settings → App → Notifications) and
+    the per-channel notification titles. Three channels: daily, nightly
+    (default + silent variants), and weather alerts.
+    -->
+    <string name="notification_channel_daily_insight_name">Täglicher ClothesCast</string>
+    <string name="notification_channel_daily_insight_description">Die morgendliche Wetterzusammenfassung, die du aktiviert hast.</string>
+    <string name="notification_daily_insight_title">Heutiges Wetter</string>
+
+    <string name="notification_channel_tonight_insight_default_name">Nächtlicher ClothesCast (mit Terminen)</string>
+    <string name="notification_channel_tonight_insight_default_description">Die abendliche Wetterzusammenfassung, wenn du heute Abend Termine hast. Spielt deinen Standard-Benachrichtigungston ab.</string>
+    <string name="notification_channel_tonight_insight_silent_name">Nächtlicher ClothesCast (lautlos)</string>
+    <string name="notification_channel_tonight_insight_silent_description">Die abendliche Wetterzusammenfassung an freien Abenden. Wird lautlos zugestellt — du kannst sie auf dem Sperrbildschirm sehen, sie macht aber keinen Ton.</string>
+    <string name="notification_tonight_insight_title">Wetter heute Abend</string>
+
+    <string name="notification_channel_weather_alerts_name">Unwetterwarnungen</string>
+    <string name="notification_channel_weather_alerts_description">Hochpriorisierte Warnungen für schwere oder extreme Wetterereignisse in deiner Region. Werden gesendet, sobald sie beim täglichen Abruf erkannt werden.</string>
+    <string name="notification_weather_alert_title">Wetterwarnung: %1$s</string>
+
+    <!-- Notification-permission card (Settings → top of any screen if
+         POST_NOTIFICATIONS is denied). -->
+    <string name="settings_notification_permission_title">Benachrichtigungen sind blockiert</string>
+    <string name="settings_notification_permission_description">Ohne Benachrichtigungserlaubnis hat dein täglicher ClothesCast nirgendwo hin. Erlaube sie, damit ClothesCast morgen früh erscheinen kann.</string>
+    <string name="settings_notification_permission_grant">Benachrichtigungen erlauben</string>
+
+    <!-- Calendar opt-in card (Settings → Schedule → Calendar). The
+         description explicitly calls out what is and isn't read off-device,
+         keeping the privacy disclosure in German parallel to the English. -->
+    <string name="settings_calendar_title">Kalender</string>
+    <string name="settings_calendar_use_events">Heutige Kalendertermine nutzen</string>
+    <string name="settings_calendar_description_off">Wenn aktiviert, liest ClothesCast die heutigen Termine aus deinem Gerätekalender, damit dein morgendlicher ClothesCast Vorschläge zu konkreten Terminen machen kann — zum Beispiel „Denk an einen Regenschirm für deinen Lauf im Park um 15 Uhr“. Nur Termintitel und Uhrzeiten werden genutzt; Beschreibungen, Teilnehmer und Orte werden gelesen, verlassen aber nie das Gerät.</string>
+    <string name="settings_calendar_description_on">Liest die heutigen Termine aus deinem Gerätekalender, um deinen morgendlichen ClothesCast zu ergänzen. In der gerenderten Zusammenfassung werden nur Titel und Uhrzeiten verwendet; Beschreibungen und Teilnehmer nicht. Alles bleibt auf dem Gerät.</string>
+    <string name="settings_calendar_grant_permission">Kalenderzugriff erlauben</string>
+    <string name="settings_calendar_open_settings">Kalenderzugriff abgelehnt. Erlaube ihn in den System-Einstellungen.</string>
+
+    <!--
     Today screen — top-bar, refresh toasts, empty state, generation timestamp,
     outfit card, hourly chart, confidence chip, work-status banner. Tone is
     Du-form imperative (intimate / spousal register), matching the app's

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -15,6 +15,21 @@ the rest of the app stays in English.
          German got added; "English variant: Deutsch" was self-contradictory). -->
     <string name="settings_tts_voice_locale_label">Sprache</string>
 
+    <!--
+    Settings — top bar + root navigation list ("Stimme", "Zeitplan", …).
+    Each row links to a sub-screen translated further below.
+    -->
+    <string name="settings_title">Einstellungen</string>
+    <string name="settings_back">Zurück</string>
+
+    <string name="settings_root_voice">Stimme</string>
+    <string name="settings_root_schedule">Zeitplan</string>
+    <string name="settings_root_region">Region</string>
+    <string name="settings_root_clothes">Kleidung</string>
+    <string name="settings_root_api_keys">API-Schlüssel</string>
+    <string name="settings_root_data_sources">Datenquellen</string>
+    <string name="settings_root_about">Über</string>
+
     <!-- Garment dropdown labels — translated names for the picker on the
          Clothes settings page. The stored key on disk is the en-US form
          ("sweater" / "pants" / …); these strings only change the display.
@@ -29,6 +44,10 @@ the rest of the app stays in English.
     <string name="garment_shorts">Kurze Hose</string>
     <string name="garment_pants">Lange Hose</string>
     <string name="garment_jeans">Jeans</string>
+
+    <!-- Clothes settings — top of the screen. -->
+    <string name="settings_clothes_title">Kleidungsregeln</string>
+    <string name="settings_clothes_description">Wenn eine Vorhersage einen dieser Schwellenwerte überschreitet, erscheint das Kleidungsstück in deinem täglichen ClothesCast.</string>
 
     <!-- Editor strings restored from the pre-lockdown UI, German equivalents. -->
     <string name="settings_clothes_empty">Noch keine Regeln. Tippe auf Hinzufügen, um eine zu erstellen.</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -238,6 +238,25 @@ the rest of the app stays in English.
     <string name="settings_elevenlabs_key_clear">Gespeicherten ElevenLabs-Schlüssel löschen</string>
 
     <!--
+    Location screen — device-location toggle, manual city search +
+    selection, and the "no location set" empty state.
+    -->
+    <string name="settings_location_title">Standort</string>
+    <string name="settings_location_use_device">Gerätestandort verwenden</string>
+    <string name="settings_location_grant_background">Hintergrundstandort erlauben (System-Einstellungen)</string>
+    <string name="settings_location_unset">Kein Standort festgelegt — Standardwert ist London</string>
+    <string name="settings_location_description">Die Vorhersage wird für diesen Ort geholt. Suche nach einem Städtenamen; die Ergebnisse stammen vom kostenlosen Geocoding-Dienst von Open-Meteo.</string>
+    <string name="settings_location_description_device_on">Wenn aktiviert, liest ClothesCast zur Benachrichtigungszeit den ungefähren Standort deines Geräts (nur Funkzelle / WLAN — keine GPS-Ortung). Der Standort unten dient als Notlösung, falls das Auslesen des Geräts fehlschlägt. Hintergrundstandort muss in den System-Einstellungen erlaubt sein, sonst kann der morgendliche Worker ihn nicht lesen.</string>
+    <string name="settings_location_set">Standort festlegen</string>
+    <string name="settings_location_change">Standort ändern</string>
+    <string name="settings_location_clear">Standort entfernen</string>
+    <string name="settings_location_search_title">Nach Standort suchen</string>
+    <string name="settings_location_query_label">Stadt oder Ort</string>
+    <string name="settings_location_search">Suchen</string>
+    <string name="settings_location_searching">Suche läuft…</string>
+    <string name="settings_location_no_results">Keine Treffer.</string>
+
+    <!--
     Today screen — top-bar, refresh toasts, empty state, generation timestamp,
     outfit card, hourly chart, confidence chip, work-status banner. Tone is
     Du-form imperative (intimate / spousal register), matching the app's

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1,12 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-First-pass German translation. Scope: just the spoken-aloud insight-prose
-templates (insight_* keys) + the German labels for the Region / VoiceLocale
-pickers. The rest of the UI is intentionally not yet translated — settings
-labels, onboarding, notifications etc. fall through to values/strings.xml
-(English) until a follow-up PR fills them in. Picking Region = DE_DE today
-gives the user a German morning summary spoken in German via Gemini, while
-the rest of the app stays in English.
+German translation — full UI coverage. Du-form throughout, intimate /
+spousal register matching the existing insight prose ("Trag …", "Denk
+an …"). No Sie-form anywhere. Brand name "ClothesCast" stays verbatim.
+
+What is NOT overridden, by design:
+- `app_name` — brand identifier, identical across locales.
+- `insight_time_am` / `_pm` / `_midnight` / `_noon` (and the *_minutes
+  variants) — English-only spoken-time formatter helpers. German
+  locales use `insight_time_hour` / `insight_time_hour_minutes`
+  ("15 Uhr" / "15 Uhr 30") which are translated below; the AM/PM keys
+  exist for `Locale.language == "en"` paths only and would never be
+  read in a German runtime.
+
+Picker labels under `settings_region_language_*` and
+`settings_tts_voice_locale_*` give the German names for every offered
+locale (Englisch (Vereinigte Staaten), Französisch (Kanada), Chinesisch
+(vereinfacht), …). The locale tag stored on disk (en-US / fr-CA /
+zh-CN) is unchanged; only the displayed label localizes.
 -->
 <resources>
     <string name="settings_region_language_de_de">Deutsch (Deutschland)</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -52,6 +52,29 @@ the rest of the app stays in English.
     <string name="settings_clothes_cond_precip_above">wenn die Regenwahrscheinlichkeit über %.0f%% liegt</string>
 
     <!--
+    Today screen — top-bar, refresh toasts, empty state, generation timestamp,
+    outfit card, hourly chart, confidence chip, work-status banner. Tone is
+    Du-form imperative (intimate / spousal register), matching the app's
+    casual style — "tipp", "dein", "leg fest".
+    -->
+    <string name="today_title">Heute</string>
+    <string name="today_open_settings">Einstellungen öffnen</string>
+    <string name="today_more_options">Mehr Optionen</string>
+    <string name="today_report_a_bug">Fehler melden</string>
+    <string name="today_refresh">Aktualisieren</string>
+    <string name="today_refresh_toast_daily">Dein täglicher ClothesCast wird aktualisiert — er erscheint gleich.</string>
+    <string name="today_refresh_toast_nightly">Dein nächtlicher ClothesCast wird aktualisiert — er erscheint gleich.</string>
+    <string name="today_empty_title">Noch kein ClothesCast</string>
+    <string name="today_empty_subtitle">Dein morgendlicher ClothesCast erscheint hier, sobald er erstellt wurde. Leg deinen Standort in den Einstellungen fest und tipp dann auf Jetzt abrufen.</string>
+    <string name="today_fetch_now">Jetzt abrufen</string>
+    <string name="today_generated_at">Erstellt um %1$s</string>
+
+    <string name="today_outfit_title">Was anziehen</string>
+    <string name="today_outfit_label_today">Heute</string>
+    <string name="today_outfit_label_tonight">Heute Abend</string>
+    <string name="today_outfit_label_tomorrow">Morgen</string>
+
+    <!--
     Outfit-card category labels — shown in OutfitPreviewCard on the Today
     screen. These are app-provided category names (the user's typed clothes
     rules are separate and stay as the user wrote them).
@@ -61,6 +84,29 @@ the rest of the app stays in English.
     <string name="today_outfit_top_thick_jacket">Dicke Jacke</string>
     <string name="today_outfit_bottom_shorts">Kurze Hose</string>
     <string name="today_outfit_bottom_long_pants">Lange Hose</string>
+
+    <string name="today_forecast_title">Stündliche Vorhersage</string>
+    <string name="today_forecast_min_max">Gefühlt %1$d – %2$d%3$s · Luft %4$d – %5$d%6$s</string>
+    <string name="today_forecast_legend_feels_like">Gefühlte Temperatur (%1$s) pro Stunde · tippen für Lufttemperatur</string>
+    <string name="today_forecast_legend_air">Lufttemperatur (%1$s) pro Stunde · tippen für gefühlte Temperatur</string>
+
+    <string name="today_confidence_high">Hohe Sicherheit — die wichtigsten Modelle stimmen überein</string>
+    <string name="today_confidence_medium">Mittlere Sicherheit</string>
+    <string name="today_confidence_low">Geringe Sicherheit — Vorhersagen weichen voneinander ab</string>
+    <string name="today_confidence_spread">Streuung: %1$.1f°C, %2$.0fpp Niederschlag über %3$d Modelle</string>
+
+    <string name="today_working">Hole deinen ClothesCast…</string>
+    <string name="today_failed_title">Letzter Versuch fehlgeschlagen</string>
+    <string name="today_failed_unexpected_http">Unerwarteter HTTP-Fehler vom Wetterdienst.</string>
+    <string name="today_failed_unhandled">Ein unerwarteter Fehler ist aufgetreten.</string>
+    <string name="today_failed_show_details">Details anzeigen</string>
+    <string name="today_failed_hide_details">Details ausblenden</string>
+
+    <!-- Home-screen App Widget. -->
+    <string name="widget_label">Outfit</string>
+    <string name="widget_description">Das Outfit für den aktuellen Tagesabschnitt auf einen Blick.</string>
+    <string name="widget_empty_title">Noch kein Outfit</string>
+    <string name="widget_empty_subtitle">Tippe, um ClothesCast zu öffnen</string>
 
     <!-- Insight prose templates — German equivalents of the keys in values/strings.xml. -->
     <string name="insight_lead_today">Heute</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -118,6 +118,96 @@ the rest of the app stays in English.
     <string name="settings_tts_add_api_key_cancel">Abbrechen</string>
 
     <!--
+    Region screen — language picker title + caption (the disambiguation
+    copy explaining that this knob is the *displayed text*, not the
+    spoken accent), the system-default option, and the per-locale labels
+    in German style ("Englisch (Vereinigte Staaten)", "Französisch
+    (Kanada)", "Chinesisch (vereinfacht)", …). The locale-tag suffix
+    (en-US / fr-CA / …) stays unchanged on disk; only the displayed
+    label localizes.
+    -->
+    <string name="settings_region_language_title">Sprache</string>
+    <string name="settings_region_language_description">Legt die Sprache von angezeigtem Text und Benachrichtigungen fest.</string>
+    <string name="settings_region_language_system">Systemsprache verwenden</string>
+    <string name="settings_region_language_en_us">Englisch (Vereinigte Staaten)</string>
+    <string name="settings_region_language_en_gb">Englisch (Vereinigtes Königreich)</string>
+    <string name="settings_region_language_en_au">Englisch (Australien)</string>
+    <string name="settings_region_language_en_ca">Englisch (Kanada)</string>
+    <string name="settings_region_language_en_za">Englisch (Südafrika)</string>
+    <string name="settings_region_language_fr_fr">Französisch (Frankreich)</string>
+    <string name="settings_region_language_fr_ca">Französisch (Kanada)</string>
+    <string name="settings_region_language_it_it">Italienisch (Italien)</string>
+    <string name="settings_region_language_es_es">Spanisch (Spanien)</string>
+    <string name="settings_region_language_es_mx">Spanisch (Mexiko)</string>
+    <string name="settings_region_language_ru_ru">Russisch (Russland)</string>
+    <string name="settings_region_language_pl_pl">Polnisch (Polen)</string>
+    <string name="settings_region_language_hr_hr">Kroatisch (Kroatien)</string>
+    <string name="settings_region_language_uk_ua">Ukrainisch (Ukraine)</string>
+    <string name="settings_region_language_pt_br">Portugiesisch (Brasilien)</string>
+    <string name="settings_region_language_nl_nl">Niederländisch (Niederlande)</string>
+    <string name="settings_region_language_sv_se">Schwedisch (Schweden)</string>
+    <string name="settings_region_language_tr_tr">Türkisch (Türkei)</string>
+    <string name="settings_region_language_id_id">Indonesisch (Indonesien)</string>
+    <string name="settings_region_language_fil_ph">Filipino (Philippinen)</string>
+    <string name="settings_region_language_vi_vn">Vietnamesisch (Vietnam)</string>
+    <string name="settings_region_language_zh_cn">Chinesisch (vereinfacht)</string>
+    <string name="settings_region_language_hi_in">Hindi (Indien)</string>
+    <string name="settings_region_language_bn_bd">Bengalisch (Bangladesch)</string>
+    <string name="settings_region_language_ja_jp">Japanisch (Japan)</string>
+    <string name="settings_region_language_ko_kr">Koreanisch (Südkorea)</string>
+    <string name="settings_region_language_ar_sa">Arabisch (Saudi-Arabien)</string>
+    <string name="settings_region_language_he_il">Hebräisch (Israel)</string>
+    <string name="settings_region_language_fa_ir">Persisch (Iran)</string>
+
+    <!-- Region screen — units pickers (Temperature: Celsius / Fahrenheit;
+         Distance: Kilometer / Meilen). The unit symbols (°C, °F) stay
+         unchanged; only the German word forms differ from the en-US
+         baseline. -->
+    <string name="settings_temperature_unit_title">Temperatureinheit</string>
+    <string name="settings_temperature_unit_celsius">Celsius (°C)</string>
+    <string name="settings_temperature_unit_fahrenheit">Fahrenheit (°F)</string>
+    <string name="settings_distance_unit_title">Entfernungseinheit</string>
+    <string name="settings_distance_unit_kilometers">Kilometer</string>
+    <string name="settings_distance_unit_miles">Meilen</string>
+
+    <!--
+    Voice locale picker labels — same German language-name translations as
+    the Region picker above, just keyed under the `settings_tts_voice_locale_*`
+    namespace because the Voice screen's language sub-picker is a separate
+    UI surface. The two pickers steer different things: Region is the
+    *displayed text*, Voice locale is the *spoken accent*.
+    -->
+    <string name="settings_tts_voice_locale_en_us">Englisch (Vereinigte Staaten)</string>
+    <string name="settings_tts_voice_locale_en_gb">Englisch (Vereinigtes Königreich)</string>
+    <string name="settings_tts_voice_locale_en_au">Englisch (Australien)</string>
+    <string name="settings_tts_voice_locale_en_ca">Englisch (Kanada)</string>
+    <string name="settings_tts_voice_locale_en_za">Englisch (Südafrika)</string>
+    <string name="settings_tts_voice_locale_fr_fr">Französisch (Frankreich)</string>
+    <string name="settings_tts_voice_locale_fr_ca">Französisch (Kanada)</string>
+    <string name="settings_tts_voice_locale_it_it">Italienisch (Italien)</string>
+    <string name="settings_tts_voice_locale_es_es">Spanisch (Spanien)</string>
+    <string name="settings_tts_voice_locale_es_mx">Spanisch (Mexiko)</string>
+    <string name="settings_tts_voice_locale_ru_ru">Russisch (Russland)</string>
+    <string name="settings_tts_voice_locale_pl_pl">Polnisch (Polen)</string>
+    <string name="settings_tts_voice_locale_hr_hr">Kroatisch (Kroatien)</string>
+    <string name="settings_tts_voice_locale_uk_ua">Ukrainisch (Ukraine)</string>
+    <string name="settings_tts_voice_locale_pt_br">Portugiesisch (Brasilien)</string>
+    <string name="settings_tts_voice_locale_nl_nl">Niederländisch (Niederlande)</string>
+    <string name="settings_tts_voice_locale_sv_se">Schwedisch (Schweden)</string>
+    <string name="settings_tts_voice_locale_tr_tr">Türkisch (Türkei)</string>
+    <string name="settings_tts_voice_locale_id_id">Indonesisch (Indonesien)</string>
+    <string name="settings_tts_voice_locale_fil_ph">Filipino (Philippinen)</string>
+    <string name="settings_tts_voice_locale_vi_vn">Vietnamesisch (Vietnam)</string>
+    <string name="settings_tts_voice_locale_zh_cn">Chinesisch (vereinfacht)</string>
+    <string name="settings_tts_voice_locale_hi_in">Hindi (Indien)</string>
+    <string name="settings_tts_voice_locale_bn_bd">Bengalisch (Bangladesch)</string>
+    <string name="settings_tts_voice_locale_ja_jp">Japanisch (Japan)</string>
+    <string name="settings_tts_voice_locale_ko_kr">Koreanisch (Südkorea)</string>
+    <string name="settings_tts_voice_locale_ar_sa">Arabisch (Saudi-Arabien)</string>
+    <string name="settings_tts_voice_locale_he_il">Hebräisch (Israel)</string>
+    <string name="settings_tts_voice_locale_fa_ir">Persisch (Iran)</string>
+
+    <!--
     Today screen — top-bar, refresh toasts, empty state, generation timestamp,
     outfit card, hourly chart, confidence chip, work-status banner. Tone is
     Du-form imperative (intimate / spousal register), matching the app's

--- a/app/src/main/res/values-en-rGB/strings.xml
+++ b/app/src/main/res/values-en-rGB/strings.xml
@@ -16,4 +16,10 @@ full re-translation.
          (en-US) on disk; only the displayed label changes. -->
     <string name="garment_sweater">Jumper</string>
     <string name="garment_pants">Trousers</string>
+
+    <!-- "Kilometres" with the British -re ending. The baseline spells it
+         "Kilometers" (en-US); the other metric-using English variants
+         (en-AU / en-CA / en-ZA) inherit this en-rGB form via CLDR
+         locale-similarity — they all descend from en-001 the same way. -->
+    <string name="settings_distance_unit_kilometers">Kilometres</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -231,7 +231,7 @@
     <string name="settings_temperature_unit_fahrenheit">Fahrenheit (°F)</string>
 
     <string name="settings_distance_unit_title">Distance unit</string>
-    <string name="settings_distance_unit_kilometers">Kilometres</string>
+    <string name="settings_distance_unit_kilometers">Kilometers</string>
     <string name="settings_distance_unit_miles">Miles</string>
 
     <string name="settings_clothes_title">Clothes rules</string>


### PR DESCRIPTION
## Summary

Localization follow-up to PR #167. Two related concerns, 12 commits total:

1. **en-US "Kilometers" spelling fix** (1 commit). Baseline spelt
   `settings_distance_unit_kilometers` as "Kilometres" — wrong for en-US.
   Flipped baseline to "Kilometers"; added a single en-rGB override
   pinning "Kilometres". en-AU / en-CA / en-ZA inherit it via CLDR
   locale-similarity (all descend from en-001), so a single override
   covers every metric-using English variant.

2. **German UI translations** — full UI coverage, one commit per
   surface. Du-form throughout, intimate / spousal register matching the
   existing insight prose ("Trag …", "Denk an …"). No Sie-form anywhere.
   Brand "ClothesCast" stays verbatim.

   - Today screen + home-screen widget
   - Onboarding flow
   - Settings root nav + Clothes section header
   - Schedule screen (daily, nightly, delivery)
   - Voice screen (engine + voice + language pickers)
   - Region screen + Voice locale picker labels (29 locales × 2)
   - API keys screen
   - Location screen
   - Notification channels + permission card + Calendar
   - Debug + About screens
   - File header refresh documenting the new scope and the deliberate
     non-overrides

After this PR the German file has 293 strings vs. 300 in the en-US
baseline; the seven gaps are all deliberate non-overrides (`app_name`
brand identifier + six English-only `insight_time_*` AM/PM helpers
that the German formatter doesn't read).

## Tone

Du-form throughout — addressing the user the way a spouse would, not the
formal Sie. Matches the register the existing German insight prose
already used. Some sample copy:
- "Hole deinen ClothesCast…" (work-status banner)
- "Tippe, um ClothesCast zu öffnen" (widget empty state)
- "Hol dir kostenlos einen unter aistudio.google.com." (onboarding)
- "Erlaube ihn in den System-Einstellungen." (calendar permission)

## Privacy

Display-only. No new strings cross the device boundary; the rendered
insight prose (the only thing fed to TTS / LLM endpoints) was already
fully German via the existing `insight_*` translations from prior PRs.

## Test plan

- [ ] CI: `JVM unit tests` green (existing German `InsightFormatterTest`
      cases still pin the prose templates I'm not touching)
- [ ] CI: `Android debug build` green
- [ ] Manual: phone in en-US → switch distance unit to km → label reads
      "Kilometers"
- [ ] Manual: phone in en-GB / en-AU / en-CA / en-ZA → distance-unit km
      label reads "Kilometres"
- [ ] Manual: phone in de-DE → walk every screen (Today, widget,
      onboarding, Settings root + every sub-screen, notifications,
      About) and confirm German Du-form throughout, no English
      fall-through

https://claude.ai/code/session_01C1Q3vzGj6KmbYDfD6b2yhu