### PR TITLE
:app — Croatian UI: ti-form translations + Vi-form tone fix

### DIFF
--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -104,6 +104,96 @@ spousal register), matching the existing settings_tts_test_sample's
     <string name="settings_tts_add_api_key_cancel">Odustani</string>
 
     <!--
+    Region screen — language picker title + caption (the disambiguation
+    copy explaining that this knob is the *displayed text*, not the
+    spoken accent), the system-default option, and the per-locale labels
+    in Croatian style ("Engleski (Sjedinjene Države)", "Francuski
+    (Kanada)", "Kineski (pojednostavljeni)", …). The locale tag stored
+    on disk (en-US / fr-CA / zh-CN) is unchanged; only the displayed
+    label localizes.
+    -->
+    <string name="settings_region_language_title">Jezik</string>
+    <string name="settings_region_language_description">Postavlja jezik prikazanog teksta i obavijesti.</string>
+    <string name="settings_region_language_system">Prati lokalne postavke sustava</string>
+    <string name="settings_region_language_en_us">Engleski (Sjedinjene Države)</string>
+    <string name="settings_region_language_en_gb">Engleski (Ujedinjeno Kraljevstvo)</string>
+    <string name="settings_region_language_en_au">Engleski (Australija)</string>
+    <string name="settings_region_language_en_ca">Engleski (Kanada)</string>
+    <string name="settings_region_language_en_za">Engleski (Južna Afrika)</string>
+    <string name="settings_region_language_de_de">Njemački (Njemačka)</string>
+    <string name="settings_region_language_fr_fr">Francuski (Francuska)</string>
+    <string name="settings_region_language_fr_ca">Francuski (Kanada)</string>
+    <string name="settings_region_language_it_it">Talijanski (Italija)</string>
+    <string name="settings_region_language_es_es">Španjolski (Španjolska)</string>
+    <string name="settings_region_language_es_mx">Španjolski (Meksiko)</string>
+    <string name="settings_region_language_ru_ru">Ruski (Rusija)</string>
+    <string name="settings_region_language_pl_pl">Poljski (Poljska)</string>
+    <string name="settings_region_language_uk_ua">Ukrajinski (Ukrajina)</string>
+    <string name="settings_region_language_pt_br">Portugalski (Brazil)</string>
+    <string name="settings_region_language_nl_nl">Nizozemski (Nizozemska)</string>
+    <string name="settings_region_language_sv_se">Švedski (Švedska)</string>
+    <string name="settings_region_language_tr_tr">Turski (Turska)</string>
+    <string name="settings_region_language_id_id">Indonezijski (Indonezija)</string>
+    <string name="settings_region_language_fil_ph">Filipinski (Filipini)</string>
+    <string name="settings_region_language_vi_vn">Vijetnamski (Vijetnam)</string>
+    <string name="settings_region_language_zh_cn">Kineski (pojednostavljeni)</string>
+    <string name="settings_region_language_hi_in">Hindski (Indija)</string>
+    <string name="settings_region_language_bn_bd">Bengalski (Bangladeš)</string>
+    <string name="settings_region_language_ja_jp">Japanski (Japan)</string>
+    <string name="settings_region_language_ko_kr">Korejski (Južna Koreja)</string>
+    <string name="settings_region_language_ar_sa">Arapski (Saudijska Arabija)</string>
+    <string name="settings_region_language_he_il">Hebrejski (Izrael)</string>
+    <string name="settings_region_language_fa_ir">Perzijski (Iran)</string>
+
+    <!-- Region screen — units pickers (Temperature: Celzij / Fahrenheit;
+         Distance: Kilometri / Milje). The unit symbols (°C, °F) stay
+         unchanged. -->
+    <string name="settings_temperature_unit_title">Jedinica temperature</string>
+    <string name="settings_temperature_unit_celsius">Celzij (°C)</string>
+    <string name="settings_temperature_unit_fahrenheit">Fahrenheit (°F)</string>
+    <string name="settings_distance_unit_title">Jedinica udaljenosti</string>
+    <string name="settings_distance_unit_kilometers">Kilometri</string>
+    <string name="settings_distance_unit_miles">Milje</string>
+
+    <!--
+    Voice locale picker labels — same Croatian language-name translations
+    as the Region picker above, just keyed under
+    `settings_tts_voice_locale_*` because the Voice screen's language
+    sub-picker is a separate UI surface. The two pickers steer different
+    things: Region is the *displayed text*, Voice locale is the *spoken
+    accent*.
+    -->
+    <string name="settings_tts_voice_locale_en_us">Engleski (Sjedinjene Države)</string>
+    <string name="settings_tts_voice_locale_en_gb">Engleski (Ujedinjeno Kraljevstvo)</string>
+    <string name="settings_tts_voice_locale_en_au">Engleski (Australija)</string>
+    <string name="settings_tts_voice_locale_en_ca">Engleski (Kanada)</string>
+    <string name="settings_tts_voice_locale_en_za">Engleski (Južna Afrika)</string>
+    <string name="settings_tts_voice_locale_de_de">Njemački (Njemačka)</string>
+    <string name="settings_tts_voice_locale_fr_fr">Francuski (Francuska)</string>
+    <string name="settings_tts_voice_locale_fr_ca">Francuski (Kanada)</string>
+    <string name="settings_tts_voice_locale_it_it">Talijanski (Italija)</string>
+    <string name="settings_tts_voice_locale_es_es">Španjolski (Španjolska)</string>
+    <string name="settings_tts_voice_locale_es_mx">Španjolski (Meksiko)</string>
+    <string name="settings_tts_voice_locale_ru_ru">Ruski (Rusija)</string>
+    <string name="settings_tts_voice_locale_pl_pl">Poljski (Poljska)</string>
+    <string name="settings_tts_voice_locale_uk_ua">Ukrajinski (Ukrajina)</string>
+    <string name="settings_tts_voice_locale_pt_br">Portugalski (Brazil)</string>
+    <string name="settings_tts_voice_locale_nl_nl">Nizozemski (Nizozemska)</string>
+    <string name="settings_tts_voice_locale_sv_se">Švedski (Švedska)</string>
+    <string name="settings_tts_voice_locale_tr_tr">Turski (Turska)</string>
+    <string name="settings_tts_voice_locale_id_id">Indonezijski (Indonezija)</string>
+    <string name="settings_tts_voice_locale_fil_ph">Filipinski (Filipini)</string>
+    <string name="settings_tts_voice_locale_vi_vn">Vijetnamski (Vijetnam)</string>
+    <string name="settings_tts_voice_locale_zh_cn">Kineski (pojednostavljeni)</string>
+    <string name="settings_tts_voice_locale_hi_in">Hindski (Indija)</string>
+    <string name="settings_tts_voice_locale_bn_bd">Bengalski (Bangladeš)</string>
+    <string name="settings_tts_voice_locale_ja_jp">Japanski (Japan)</string>
+    <string name="settings_tts_voice_locale_ko_kr">Korejski (Južna Koreja)</string>
+    <string name="settings_tts_voice_locale_ar_sa">Arapski (Saudijska Arabija)</string>
+    <string name="settings_tts_voice_locale_he_il">Hebrejski (Izrael)</string>
+    <string name="settings_tts_voice_locale_fa_ir">Perzijski (Iran)</string>
+
+    <!--
     Today screen — top bar, refresh toasts, empty state, generated-at
     timestamp, outfit card, hourly chart, confidence chip, work-status
     banner. ti-form imperatives: "dodirni", "postavi", "tvoj".

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -243,6 +243,42 @@ spousal register), matching the existing settings_tts_test_sample's
     <string name="settings_location_no_results">Nema rezultata.</string>
 
     <!--
+    Notification channels (system Settings → App → Notifications) and
+    the per-channel notification titles. Three channels: daily, nightly
+    (default + silent variants), weather alerts.
+    -->
+    <string name="notification_channel_daily_insight_name">Dnevni ClothesCast</string>
+    <string name="notification_channel_daily_insight_description">Jutarnji vremenski sažetak koji je uključen.</string>
+    <string name="notification_daily_insight_title">Današnje vrijeme</string>
+
+    <string name="notification_channel_tonight_insight_default_name">Noćni ClothesCast (s događajima)</string>
+    <string name="notification_channel_tonight_insight_default_description">Večernji vremenski sažetak kada večeras imaš događaje u kalendaru. Reproducira tvoj zadani zvuk obavijesti.</string>
+    <string name="notification_channel_tonight_insight_silent_name">Noćni ClothesCast (tihi)</string>
+    <string name="notification_channel_tonight_insight_silent_description">Večernji vremenski sažetak kad ti je večer slobodna. Šalje se tiho — možeš ga pogledati na zaključanom zaslonu, ali neće proizvesti zvuk.</string>
+    <string name="notification_tonight_insight_title">Vrijeme večeras</string>
+
+    <string name="notification_channel_weather_alerts_name">Upozorenja o nepogodama</string>
+    <string name="notification_channel_weather_alerts_description">Upozorenja visokog prioriteta za teška ili ekstremna vremenska zbivanja u tvom području. Šalju se čim ih dnevno dohvaćanje otkrije.</string>
+    <string name="notification_weather_alert_title">Vremensko upozorenje: %1$s</string>
+
+    <!-- Notification-permission card. -->
+    <string name="settings_notification_permission_title">Obavijesti su blokirane</string>
+    <string name="settings_notification_permission_description">Bez dopuštenja za obavijesti tvoj dnevni ClothesCast nema gdje. Dopusti ih, kako bi se ClothesCast mogao pojaviti sutra ujutro.</string>
+    <string name="settings_notification_permission_grant">Dopusti obavijesti</string>
+
+    <!-- Calendar opt-in card (Settings → Schedule → Calendar). The
+         description preserves the privacy disclosure ("opisi, sudionici
+         i lokacije … nikad ne napuštaju uređaj"). Quotes around the
+         nested example follow the same „…" house style as the German
+         file. -->
+    <string name="settings_calendar_title">Kalendar</string>
+    <string name="settings_calendar_use_events">Koristi današnje događaje iz kalendara</string>
+    <string name="settings_calendar_description_off">Kada je uključeno, ClothesCast čita današnje događaje iz tvog kalendara na uređaju, kako bi tvoj jutarnji ClothesCast mogao predložiti predmete vezane uz konkretne događaje — na primjer „ponesi kišobran za trčanje u parku u 15 sati“. Koriste se samo naslovi i vremena događaja; opisi, sudionici i lokacije se čitaju, ali nikad ne napuštaju uređaj.</string>
+    <string name="settings_calendar_description_on">Čita današnje događaje iz tvog kalendara na uređaju, kako bi obogatio tvoj jutarnji ClothesCast. U sažetku se koriste samo naslovi i vremena; opisi i sudionici ne. Sve ostaje na uređaju.</string>
+    <string name="settings_calendar_grant_permission">Dopusti pristup kalendaru</string>
+    <string name="settings_calendar_open_settings">Pristup kalendaru odbijen. Dopusti ga u postavkama sustava.</string>
+
+    <!--
     Today screen — top bar, refresh toasts, empty state, generated-at
     timestamp, outfit card, hourly chart, confidence chip, work-status
     banner. ti-form imperatives: "dodirni", "postavi", "tvoj".

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -194,6 +194,36 @@ spousal register), matching the existing settings_tts_test_sample's
     <string name="settings_tts_voice_locale_fa_ir">Perzijski (Iran)</string>
 
     <!--
+    API keys screen — three identical-shape blocks (Gemini, OpenAI,
+    ElevenLabs), each with status copy, paste-key field placeholder, and
+    save / clear buttons. URLs (aistudio.google.com, platform.openai.com,
+    elevenlabs.io) stay verbatim.
+    -->
+    <string name="settings_api_keys_title">API ključevi</string>
+    <string name="settings_api_keys_description">Postavi API ključeve za online glasovne mehanizme koje želiš koristiti. Ključevi su šifrirani u Android Keystore.</string>
+    <string name="settings_api_key_gemini_label">Gemini</string>
+    <string name="settings_api_key_openai_label">OpenAI</string>
+    <string name="settings_api_key_elevenlabs_label">ElevenLabs</string>
+
+    <string name="settings_api_key_status_set">Gemini ključ je postavljen.</string>
+    <string name="settings_api_key_status_unset">Gemini ključ nije postavljen. Nabavi ga na aistudio.google.com za korištenje Gemini glasova.</string>
+    <string name="settings_api_key_placeholder">Zalijepi svoj Gemini API ključ</string>
+    <string name="settings_api_key_save">Spremi Gemini ključ</string>
+    <string name="settings_api_key_clear">Izbriši spremljeni Gemini ključ</string>
+
+    <string name="settings_openai_key_status_set">OpenAI ključ je postavljen.</string>
+    <string name="settings_openai_key_status_unset">OpenAI ključ nije postavljen. Nabavi ga na platform.openai.com za korištenje OpenAI glasova.</string>
+    <string name="settings_openai_key_placeholder">Zalijepi svoj OpenAI API ključ</string>
+    <string name="settings_openai_key_save">Spremi OpenAI ključ</string>
+    <string name="settings_openai_key_clear">Izbriši spremljeni OpenAI ključ</string>
+
+    <string name="settings_elevenlabs_key_status_set">ElevenLabs ključ je postavljen.</string>
+    <string name="settings_elevenlabs_key_status_unset">ElevenLabs ključ nije postavljen. Nabavi ga na elevenlabs.io za korištenje ElevenLabs glasova.</string>
+    <string name="settings_elevenlabs_key_placeholder">Zalijepi svoj ElevenLabs API ključ</string>
+    <string name="settings_elevenlabs_key_save">Spremi ElevenLabs ključ</string>
+    <string name="settings_elevenlabs_key_clear">Izbriši spremljeni ElevenLabs ključ</string>
+
+    <!--
     Today screen — top bar, refresh toasts, empty state, generated-at
     timestamp, outfit card, hourly chart, confidence chip, work-status
     banner. ti-form imperatives: "dodirni", "postavi", "tvoj".

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -37,11 +37,58 @@ spousal register), matching the existing settings_tts_test_sample's
     <string name="settings_clothes_cond_temp_above">kada je osjećajna temperatura iznad %.0f°C</string>
     <string name="settings_clothes_cond_precip_above">kada je vjerojatnost kiše veća od %.0f%%</string>
 
+    <!--
+    Today screen — top bar, refresh toasts, empty state, generated-at
+    timestamp, outfit card, hourly chart, confidence chip, work-status
+    banner. ti-form imperatives: "dodirni", "postavi", "tvoj".
+    -->
+    <string name="today_title">Danas</string>
+    <string name="today_open_settings">Otvori postavke</string>
+    <string name="today_more_options">Više opcija</string>
+    <string name="today_report_a_bug">Prijavi grešku</string>
+    <string name="today_refresh">Osvježi</string>
+    <string name="today_refresh_toast_daily">Osvježavam tvoj dnevni ClothesCast — pojavit će se uskoro.</string>
+    <string name="today_refresh_toast_nightly">Osvježavam tvoj noćni ClothesCast — pojavit će se uskoro.</string>
+    <string name="today_empty_title">Još nema ClothesCasta</string>
+    <string name="today_empty_subtitle">Tvoj jutarnji ClothesCast pojavit će se ovdje čim bude generiran. Postavi svoju lokaciju u postavkama, a zatim dodirni Dohvati sada.</string>
+    <string name="today_fetch_now">Dohvati sada</string>
+    <string name="today_generated_at">Generirano u %1$s</string>
+
+    <string name="today_outfit_title">Što obući</string>
+    <string name="today_outfit_label_today">Danas</string>
+    <string name="today_outfit_label_tonight">Večeras</string>
+    <string name="today_outfit_label_tomorrow">Sutra</string>
+
     <string name="today_outfit_top_tshirt">Majica</string>
     <string name="today_outfit_top_sweater">Džemper</string>
     <string name="today_outfit_top_thick_jacket">Debela jakna</string>
     <string name="today_outfit_bottom_shorts">Kratke hlače</string>
     <string name="today_outfit_bottom_long_pants">Hlače</string>
+
+    <string name="today_forecast_title">Prognoza po satu</string>
+    <string name="today_forecast_min_max">Osjećaj %1$d – %2$d%3$s · Zrak %4$d – %5$d%6$s</string>
+    <string name="today_forecast_legend_feels_like">Osjećajna temperatura (%1$s) po satu · dodirni za temperaturu zraka</string>
+    <string name="today_forecast_legend_air">Temperatura zraka (%1$s) po satu · dodirni za osjećajnu temperaturu</string>
+
+    <string name="today_confidence_high">Visoka pouzdanost — glavni modeli se slažu</string>
+    <string name="today_confidence_medium">Srednja pouzdanost</string>
+    <string name="today_confidence_low">Niska pouzdanost — prognoze se razlikuju</string>
+    <string name="today_confidence_spread">Raspršenost: %1$.1f°C, %2$.0fpp oborine preko %3$d modela</string>
+
+    <string name="today_working">Dohvaćam tvoj ClothesCast…</string>
+    <string name="today_failed_title">Posljednji pokušaj nije uspio</string>
+    <string name="today_failed_unexpected_http">Neočekivana HTTP greška od servisa za prognozu.</string>
+    <string name="today_failed_unhandled">Došlo je do neočekivane greške.</string>
+    <string name="today_failed_show_details">Prikaži detalje</string>
+    <string name="today_failed_hide_details">Sakrij detalje</string>
+
+    <!-- Home-screen App Widget. "Outfit" is in common Croatian use as a
+         loanword and matches the casual register; the empty state
+         localises to "Još nema outfita" with the genitive ending. -->
+    <string name="widget_label">Outfit</string>
+    <string name="widget_description">Outfit za trenutni period na prvi pogled.</string>
+    <string name="widget_empty_title">Još nema outfita</string>
+    <string name="widget_empty_subtitle">Dodirni za otvaranje ClothesCasta</string>
 
     <string name="insight_lead_today">Danas</string>
     <string name="insight_lead_tonight">Večeras</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-Croatian translation. Scope: insight-prose templates, garment labels, clothes-rule
-editor, outfit-card labels, and region/voice-locale picker names.
+Croatian translation. Tone is informal "ti"-form throughout (intimate /
+spousal register), matching the existing settings_tts_test_sample's
+"Tvoj … Obuci jaknu." Avoid the formal "Vi"-form ("Obucite", "Ponesite",
+"Dodirnite") that earlier passes accidentally mixed in.
 -->
 <resources>
     <string name="settings_region_language_hr_hr">Hrvatski (Hrvatska)</string>
@@ -18,7 +20,7 @@ editor, outfit-card labels, and region/voice-locale picker names.
     <string name="garment_pants">Hlače</string>
     <string name="garment_jeans">Traperice</string>
 
-    <string name="settings_clothes_empty">Nema pravila. Dodirnite Dodaj za kreiranje.</string>
+    <string name="settings_clothes_empty">Nema pravila. Dodirni Dodaj za kreiranje.</string>
     <string name="settings_clothes_add">Dodaj</string>
     <string name="settings_clothes_edit">Uredi</string>
     <string name="settings_clothes_delete">Izbriši</string>
@@ -54,7 +56,7 @@ editor, outfit-card labels, and region/voice-locale picker names.
     <string name="insight_delta_warmer">Danas će biti %1$d° toplije.</string>
     <string name="insight_delta_cooler">Danas će biti %1$d° hladnije.</string>
     <string name="insight_alert">Upozorenje: %1$s.</string>
-    <string name="insight_clothes_wear">Obucite %1$s.</string>
+    <string name="insight_clothes_wear">Obuci %1$s.</string>
     <string name="insight_clothes_article_a">%1$s</string>
     <string name="insight_clothes_article_an">%1$s</string>
     <string name="insight_clothes_join_two">%1$s i %2$s</string>
@@ -72,8 +74,8 @@ editor, outfit-card labels, and region/voice-locale picker names.
     <string name="insight_condition_thunderstorm">Grmljavina</string>
     <string name="insight_condition_unknown">Nepoznato</string>
     <string name="insight_calendar_tie_in">Ponesite %1$s na %3$s u %2$s.</string>
-    <string name="insight_tie_in">Ponesite %1$s večeras.</string>
-    <string name="insight_tie_in_with_rain">Ponesite %1$s večeras, kiša u %2$s.</string>
+    <string name="insight_tie_in">Ponesi %1$s večeras.</string>
+    <string name="insight_tie_in_with_rain">Ponesi %1$s večeras, kiša u %2$s.</string>
     <!-- "15" — preposition "u" comes from surrounding templates. -->
     <string name="insight_time_hour">%1$d</string>
     <string name="insight_time_hour_minutes">%1$d:%2$02d</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -10,6 +10,18 @@ spousal register), matching the existing settings_tts_test_sample's
     <string name="settings_tts_voice_locale_hr_hr">Hrvatski (Hrvatska)</string>
     <string name="settings_tts_voice_locale_label">Jezik</string>
 
+    <!-- Settings — top bar + root navigation list. -->
+    <string name="settings_title">Postavke</string>
+    <string name="settings_back">Natrag</string>
+
+    <string name="settings_root_voice">Glas</string>
+    <string name="settings_root_schedule">Raspored</string>
+    <string name="settings_root_region">Regija</string>
+    <string name="settings_root_clothes">Odjeća</string>
+    <string name="settings_root_api_keys">API ključevi</string>
+    <string name="settings_root_data_sources">Izvori podataka</string>
+    <string name="settings_root_about">O aplikaciji</string>
+
     <string name="garment_sweater">Džemper</string>
     <string name="garment_hoodie">Hoodie</string>
     <string name="garment_jacket">Jakna</string>
@@ -19,6 +31,10 @@ spousal register), matching the existing settings_tts_test_sample's
     <string name="garment_shorts">Kratke hlače</string>
     <string name="garment_pants">Hlače</string>
     <string name="garment_jeans">Traperice</string>
+
+    <!-- Clothes settings — top of the screen. -->
+    <string name="settings_clothes_title">Pravila odijevanja</string>
+    <string name="settings_clothes_description">Ako prognoza prijeđe jedan od ovih pragova, predmet se pojavljuje u tvom dnevnom ClothesCastu.</string>
 
     <string name="settings_clothes_empty">Nema pravila. Dodirni Dodaj za kreiranje.</string>
     <string name="settings_clothes_add">Dodaj</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -278,6 +278,24 @@ spousal register), matching the existing settings_tts_test_sample's
     <string name="settings_calendar_grant_permission">Dopusti pristup kalendaru</string>
     <string name="settings_calendar_open_settings">Pristup kalendaru odbijen. Dopusti ga u postavkama sustava.</string>
 
+    <!-- Debug screen — visible only on debug builds. -->
+    <string name="settings_debug_title">Debug (samo u debug verzijama)</string>
+    <string name="settings_debug_description">Odmah pokreni dnevni ClothesCast tijek. Korisno za provjeru bez čekanja na zakazano vrijeme.</string>
+    <string name="settings_debug_fire_now">Pokreni ClothesCast sada</string>
+    <string name="settings_debug_fire_toast">ClothesCast worker u redu čekanja</string>
+
+    <!-- About screen — version line, build-type suffix, privacy summary,
+         outbound links / actions. -->
+    <string name="settings_about_title">O aplikaciji</string>
+    <string name="settings_about_version">Verzija %1$s (%2$d)</string>
+    <string name="settings_about_build_type_suffix"> · %1$s verzija</string>
+    <string name="settings_about_privacy">Tvoj Gemini API ključ (za glasovni TTS) šifriran je ključem vezanim uz Android Keystore. Prognoze dolaze s Open-Meteoa (bez ključa, bez računa); tekst dnevnog sažetka generira se lokalno na uređaju. ClothesCast nema backend — ništa se ne šalje ni na jedan server koji mi kontroliramo.</string>
+    <string name="settings_about_privacy_policy">Politika privatnosti</string>
+    <string name="settings_about_source">Izvorni kod na GitHubu</string>
+    <string name="settings_about_dontkillmyapp">Pozadinska ograničenja (dontkillmyapp.com)</string>
+    <string name="settings_about_share_bug_report">Podijeli izvješće o grešci</string>
+    <string name="settings_about_version_copied">Verzija kopirana u međuspremnik</string>
+
     <!--
     Today screen — top bar, refresh toasts, empty state, generated-at
     timestamp, outfit card, hourly chart, confidence chip, work-status

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -54,6 +54,31 @@ spousal register), matching the existing settings_tts_test_sample's
     <string name="settings_clothes_cond_precip_above">kada je vjerojatnost kiše veća od %.0f%%</string>
 
     <!--
+    Schedule screen — daily and nightly ClothesCast cards, delivery
+    picker, "Mention evening events" toggle, and the nightly-only
+    "notify only on events" toggle. The toggle label nested inside the
+    description uses the same low-9/low-9 quotes („…") the German file
+    uses — Croatian accepts both " and „… "; keeping a single house
+    style across the locales avoids visual drift.
+    -->
+    <string name="settings_schedule_title">Dnevni ClothesCast</string>
+    <string name="settings_schedule_time_label">Vrijeme</string>
+    <string name="settings_schedule_days_label">Dani u tjednu</string>
+    <string name="settings_daily_mention_evening_events">Spomeni večernje događaje</string>
+
+    <string name="settings_tonight_title">Noćni ClothesCast</string>
+    <string name="settings_tonight_description">Drugi ClothesCast navečer koji pokriva vrijeme za večeras. Tihim večerima ostaje bez zvuka ili se uopće ne pojavi ako je „Obavijesti samo kad ima večernjih događaja“ uključeno; večerima s događajima reproducira zvuk i (ako je uključen izgovor) sam se čita.</string>
+    <string name="settings_tonight_enabled">Prikaži noćni ClothesCast</string>
+    <string name="settings_tonight_time_label">Vrijeme</string>
+    <string name="settings_tonight_days_label">Dani u tjednu</string>
+    <string name="settings_tonight_notify_only_on_events">Obavijesti samo kad ima večernjih događaja</string>
+
+    <string name="settings_delivery_label">Isporuka</string>
+    <string name="settings_delivery_notification_only">Samo obavijest</string>
+    <string name="settings_delivery_tts_only">Samo izgovor</string>
+    <string name="settings_delivery_notification_and_tts">Obavijest i izgovor</string>
+
+    <!--
     Today screen — top bar, refresh toasts, empty state, generated-at
     timestamp, outfit card, hourly chart, confidence chip, work-status
     banner. ti-form imperatives: "dodirni", "postavi", "tvoj".

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -79,6 +79,31 @@ spousal register), matching the existing settings_tts_test_sample's
     <string name="settings_delivery_notification_and_tts">Obavijest i izgovor</string>
 
     <!--
+    Voice screen — engine picker (Device / Gemini / OpenAI / ElevenLabs),
+    voice + language sub-pickers, test-voice button, missing-API-key
+    hint and the in-line "Add API key" dialog.
+    -->
+    <string name="settings_tts_engine_title">Glasovni mehanizam</string>
+    <string name="settings_tts_engine_description">Online mehanizmi (Gemini, OpenAI, ElevenLabs) zvuče puno prirodnije, ali zahtijevaju mrežni poziv prilikom govora i koriste tvoj API ključ za sintezu (jedan kratki poziv po izgovorenom ClothesCastu). Vraća se na glas uređaja ako odabrani mehanizam zakaže.</string>
+    <string name="settings_tts_engine_device">Uređaj (offline, besplatno)</string>
+    <string name="settings_tts_engine_gemini">Gemini (visoka kvaliteta, online)</string>
+    <string name="settings_tts_engine_openai">OpenAI (visoka kvaliteta, online)</string>
+    <string name="settings_tts_engine_elevenlabs">ElevenLabs (najviša kvaliteta, online)</string>
+
+    <string name="settings_tts_voice_label">Glas</string>
+    <string name="settings_tts_voice_dismiss">Gotovo</string>
+    <string name="settings_tts_voice_locale_description">Postavlja naglasak izgovorenog glasa. Ne mijenja prikazani tekst.</string>
+    <string name="settings_tts_voice_locale_system">Koristi jezik telefona</string>
+
+    <string name="settings_tts_test">Testiraj glas</string>
+    <string name="settings_tts_test_in_flight">Testiranje — pričekaj…</string>
+    <string name="settings_tts_no_key_hint">Nije postavljen %1$s ključ — dodaj ga za korištenje ovog mehanizma.</string>
+    <string name="settings_tts_add_api_key">Dodaj API ključ</string>
+    <string name="settings_tts_add_api_key_title">Dodaj %1$s API ključ</string>
+    <string name="settings_tts_add_api_key_save">Spremi</string>
+    <string name="settings_tts_add_api_key_cancel">Odustani</string>
+
+    <!--
     Today screen — top bar, refresh toasts, empty state, generated-at
     timestamp, outfit card, hourly chart, confidence chip, work-status
     banner. ti-form imperatives: "dodirni", "postavi", "tvoj".

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -90,6 +90,31 @@ spousal register), matching the existing settings_tts_test_sample's
     <string name="widget_empty_title">Još nema outfita</string>
     <string name="widget_empty_subtitle">Dodirni za otvaranje ClothesCasta</string>
 
+    <!--
+    Onboarding flow — first-run welcome, two permission steps, Gemini
+    API-key step. Welcome uses the conventional Croatian greeting
+    "Dobrodošli" (formally plural, idiomatic as a fixed greeting) to
+    sidestep the masc/fem agreement Croatian otherwise forces on ti-form
+    addresses; everything else uses true ti-form.
+    -->
+    <string name="onboarding_title">Dobrodošli u ClothesCast</string>
+    <string name="onboarding_subtitle">Dva brza odabira i to je sve. Sve ostalo ima razuman zadani izbor koji kasnije možeš podesiti u postavkama.</string>
+    <string name="onboarding_notifications_title">Obavijesti</string>
+    <string name="onboarding_notifications_description">Potrebno za isporuku tvog dnevnog ClothesCasta. Dopusti jednom, i ClothesCast će se pojaviti sutra ujutro.</string>
+    <string name="onboarding_notifications_grant">Dopusti obavijesti</string>
+    <string name="onboarding_location_title">Lokacija</string>
+    <string name="onboarding_location_description">Koristi se za dohvaćanje točne prognoze. Ako dopustiš lokaciju, ClothesCast svako jutro može pročitati približnu lokaciju tvog uređaja; inače ručno odaberi grad.</string>
+    <string name="onboarding_location_grant">Dopusti pristup lokaciji</string>
+    <string name="onboarding_location_denied_hint">Pristup lokaciji odbijen. Umjesto toga možeš ručno odabrati grad.</string>
+    <string name="onboarding_location_enter_manual">Unesi lokaciju ručno</string>
+    <string name="onboarding_location_using_device">Svako jutro koristimo lokaciju tvog uređaja.</string>
+
+    <string name="onboarding_gemini_title">Gemini API ključ</string>
+    <string name="onboarding_gemini_description">ClothesCast ga koristi za izgovorene glasove i generiranje prognoza. Nabavi besplatno na aistudio.google.com. Ključ je šifriran u Android Keystore.</string>
+    <string name="onboarding_step_done">Gotovo</string>
+    <string name="onboarding_skip">Preskoči zasad</string>
+    <string name="onboarding_continue">Nastavi</string>
+
     <string name="insight_lead_today">Danas</string>
     <string name="insight_lead_tonight">Večeras</string>
     <string name="insight_band_single">%1$s će biti %2$s.</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -224,6 +224,25 @@ spousal register), matching the existing settings_tts_test_sample's
     <string name="settings_elevenlabs_key_clear">Izbriši spremljeni ElevenLabs ključ</string>
 
     <!--
+    Location screen — device-location toggle, manual city search +
+    selection, and the "no location set" empty state.
+    -->
+    <string name="settings_location_title">Lokacija</string>
+    <string name="settings_location_use_device">Koristi lokaciju uređaja</string>
+    <string name="settings_location_grant_background">Dopusti pozadinsku lokaciju (postavke sustava)</string>
+    <string name="settings_location_unset">Lokacija nije postavljena — koristi se London</string>
+    <string name="settings_location_description">Prognoza se dohvaća za ovu lokaciju. Pretraži po imenu grada; rezultati dolaze iz Open-Meteovog besplatnog servisa za geokodiranje.</string>
+    <string name="settings_location_description_device_on">Kada je uključeno, ClothesCast pri vremenu obavijesti čita približnu lokaciju tvog uređaja (samo mobilni odašiljač / WiFi — bez GPS-a). Lokacija ispod služi kao rezerva ako čitanje uređaja zakaže. Pozadinska lokacija mora biti dopuštena u postavkama sustava, inače je jutarnji Worker ne može pročitati.</string>
+    <string name="settings_location_set">Postavi lokaciju</string>
+    <string name="settings_location_change">Promijeni lokaciju</string>
+    <string name="settings_location_clear">Obriši lokaciju</string>
+    <string name="settings_location_search_title">Pretraži lokaciju</string>
+    <string name="settings_location_query_label">Grad ili mjesto</string>
+    <string name="settings_location_search">Pretraži</string>
+    <string name="settings_location_searching">Pretraživanje…</string>
+    <string name="settings_location_no_results">Nema rezultata.</string>
+
+    <!--
     Today screen — top bar, refresh toasts, empty state, generated-at
     timestamp, outfit card, hourly chart, confidence chip, work-status
     banner. ti-form imperatives: "dodirni", "postavi", "tvoj".


### PR DESCRIPTION
## Summary

Croatian UI translation, mirroring the German pass in PR #168.
Eleven commits — one tone-fix on the existing prose, ten surface-by-
surface translations of the strings the file was missing.

## Tone fix (commit 1)

The previous Croatian file mixed registers — the test sample read
informal ti-form ("Tvoj današnji ClothesCast … Obuci jaknu") but four
older strings (clothes-rule empty hint, the insight clothes-wear
template, both tie-in templates) used the formal Vi-form ("Dodirnite",
"Obucite", "Ponesite"). That's the equivalent of the German Sie/Du mix
the user does not want. Drops the "-te" plural-imperative ending in
those four places so the file speaks to the user with a single voice;
header refreshed to call out the ti-form rule explicitly.

Stale `insight_calendar_tie_in` is left untouched — it's no longer
referenced anywhere in code, and the same dead key exists in nine
other locale files, so any clean-up should be a fleet-wide pass rather
than a Croatian-only one.

## Surface-by-surface (commits 2–11)

- Today screen + home-screen widget
- Onboarding flow
- Settings root nav + Clothes section header
- Schedule screen (daily, nightly, delivery)
- Voice screen (engine + voice + language pickers)
- Region screen + Voice locale picker labels (28 locales × 2)
- API keys screen
- Location screen
- Notification channels + permission card + Calendar
- Debug + About screens

After this PR the Croatian file has 293 strings vs. 300 in the en-US
baseline; the seven gaps are the same deliberate non-overrides as
German (`app_name` brand identifier + the six English-only
`insight_time_*` AM/PM helpers that the Croatian formatter doesn't
read).

## Tone

ti-form throughout — addressing the user the way a spouse would. Croatian
forces gender agreement on predicate adjectives in the ti-form, which
the welcome screen and a few notification descriptions can't pick
cleanly; those passages either lean on the idiomatic fixed greeting
"Dobrodošli" (formally plural, the conventional Croatian app welcome)
or use passive / impersonal phrasings ("ako je uključen izgovor", "koji
je uključen") to sidestep the masc/fem question. Every step beyond
those exceptions stays in true ti-form. The tradeoffs are flagged in
the relevant commit messages.

Brand "ClothesCast" stays verbatim throughout, declined to "ClothesCasta"
(genitive) where the surrounding case requires.

## Privacy

Display-only. No new strings cross the device boundary; the rendered
insight prose (the only thing fed to TTS / LLM endpoints) was already
fully Croatian via the existing `insight_*` translations from prior PRs
(now also in correct ti-form thanks to commit 1).

## Test plan

- [ ] CI: `JVM unit tests` green (no Croatian tests pin specific prose
      so nothing to update)
- [ ] CI: `Android debug build` green
- [ ] Manual: phone in hr-HR or **Region: Hrvatski (Hrvatska)** → walk
      every screen (Today, widget, onboarding, Settings root + every
      sub-screen, notifications, About) and confirm Croatian ti-form
      throughout, no English fall-through
- [ ] Manual: spoken-aloud preview reads "Obuci jaknu" / "Ponesi
      kišobran večeras" with the ti-form imperative (was "Obucite" /
      "Ponesite" before commit 1)

https://claude.ai/code/session_01C1Q3vzGj6KmbYDfD6b2yhu

---
_Generated by [Claude Code](https://claude.ai/code/session_015agXppcN2fzATq5Xnzpozs)_