### PR TITLE
:app — Italian UI: full tu-form translation pass

### DIFF
--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -274,6 +274,24 @@ editor, outfit-card labels, and region/voice-locale picker names.
     <string name="settings_calendar_grant_permission">Concedi l\'accesso al calendario</string>
     <string name="settings_calendar_open_settings">Accesso al calendario negato. Concedilo dalle impostazioni di sistema.</string>
 
+    <!-- Debug screen — visible only on debug builds. -->
+    <string name="settings_debug_title">Debug (solo nelle build di debug)</string>
+    <string name="settings_debug_description">Avvia subito la pipeline del ClothesCast quotidiano. Utile per verificare senza aspettare l\'ora programmata.</string>
+    <string name="settings_debug_fire_now">Avvia ClothesCast ora</string>
+    <string name="settings_debug_fire_toast">Worker ClothesCast in coda</string>
+
+    <!-- About screen — version line, build-type suffix, privacy summary,
+         outbound links / actions. -->
+    <string name="settings_about_title">Informazioni</string>
+    <string name="settings_about_version">Versione %1$s (%2$d)</string>
+    <string name="settings_about_build_type_suffix"> · build %1$s</string>
+    <string name="settings_about_privacy">La tua chiave API Gemini (usata per la lettura vocale TTS) è cifrata a riposo con una chiave legata all\'Android Keystore. Le previsioni provengono da Open-Meteo (nessuna chiave, nessun account); il testo del riepilogo quotidiano è generato localmente sul dispositivo. ClothesCast non ha un backend — nulla viene inviato a un server controllato da noi.</string>
+    <string name="settings_about_privacy_policy">Informativa sulla privacy</string>
+    <string name="settings_about_source">Codice sorgente su GitHub</string>
+    <string name="settings_about_dontkillmyapp">Restrizioni in background (dontkillmyapp.com)</string>
+    <string name="settings_about_share_bug_report">Condividi report di bug</string>
+    <string name="settings_about_version_copied">Versione copiata negli appunti</string>
+
     <!--
     Today screen — top bar, refresh toasts, empty state, generated-at
     timestamp, outfit card, hourly chart, confidence chip, work-status

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -87,6 +87,31 @@ editor, outfit-card labels, and region/voice-locale picker names.
     <string name="widget_empty_title">Ancora nessun outfit</string>
     <string name="widget_empty_subtitle">Tocca per aprire ClothesCast</string>
 
+    <!--
+    Onboarding flow — first-run welcome, two permission steps, Gemini
+    API-key step. Italian forces gender agreement on predicate adjectives;
+    the welcome uses the conventional masc-default "Benvenuto" and the
+    subtitle rephrases "you're set" as the invariable "sei a posto" to
+    avoid forcing a gender on the user.
+    -->
+    <string name="onboarding_title">Benvenuto in ClothesCast</string>
+    <string name="onboarding_subtitle">Due scelte rapide e sei a posto. Tutto il resto ha un valore predefinito sensato che potrai regolare più tardi nelle impostazioni.</string>
+    <string name="onboarding_notifications_title">Notifiche</string>
+    <string name="onboarding_notifications_description">Necessarie per recapitare il tuo ClothesCast quotidiano. Concedile una volta e ClothesCast apparirà domattina.</string>
+    <string name="onboarding_notifications_grant">Concedi le notifiche</string>
+    <string name="onboarding_location_title">Posizione</string>
+    <string name="onboarding_location_description">Serve per recuperare la previsione corretta. Concedendo la posizione, ClothesCast può leggere ogni mattina la posizione approssimativa del tuo dispositivo; altrimenti scegli manualmente una città.</string>
+    <string name="onboarding_location_grant">Concedi l\'accesso alla posizione</string>
+    <string name="onboarding_location_denied_hint">Accesso alla posizione negato. Puoi invece scegliere una città manualmente.</string>
+    <string name="onboarding_location_enter_manual">Inserisci la posizione manualmente</string>
+    <string name="onboarding_location_using_device">Ogni mattina usiamo la posizione del tuo dispositivo.</string>
+
+    <string name="onboarding_gemini_title">Chiave API Gemini</string>
+    <string name="onboarding_gemini_description">Usata da ClothesCast per le voci parlate e la generazione delle previsioni. Ottienine una gratis su aistudio.google.com. La chiave è cifrata a riposo nell\'Android Keystore.</string>
+    <string name="onboarding_step_done">Fatto</string>
+    <string name="onboarding_skip">Salta per ora</string>
+    <string name="onboarding_continue">Continua</string>
+
     <string name="insight_lead_today">Oggi</string>
     <string name="insight_lead_tonight">Stasera</string>
     <string name="insight_band_single">%1$s sarà %2$s.</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -191,6 +191,36 @@ editor, outfit-card labels, and region/voice-locale picker names.
     <string name="settings_tts_voice_locale_fa_ir">Persiano (Iran)</string>
 
     <!--
+    API keys screen — three identical-shape blocks (Gemini, OpenAI,
+    ElevenLabs), each with status copy, paste-key field placeholder, and
+    save / clear buttons. URLs (aistudio.google.com, platform.openai.com,
+    elevenlabs.io) stay verbatim.
+    -->
+    <string name="settings_api_keys_title">Chiavi API</string>
+    <string name="settings_api_keys_description">Configura le chiavi API per i motori vocali online che vuoi usare. Le chiavi sono cifrate a riposo nell\'Android Keystore.</string>
+    <string name="settings_api_key_gemini_label">Gemini</string>
+    <string name="settings_api_key_openai_label">OpenAI</string>
+    <string name="settings_api_key_elevenlabs_label">ElevenLabs</string>
+
+    <string name="settings_api_key_status_set">È configurata una chiave Gemini.</string>
+    <string name="settings_api_key_status_unset">Nessuna chiave Gemini configurata. Ottienine una su aistudio.google.com per usare le voci Gemini.</string>
+    <string name="settings_api_key_placeholder">Incolla la tua chiave API Gemini</string>
+    <string name="settings_api_key_save">Salva chiave Gemini</string>
+    <string name="settings_api_key_clear">Cancella chiave Gemini salvata</string>
+
+    <string name="settings_openai_key_status_set">È configurata una chiave OpenAI.</string>
+    <string name="settings_openai_key_status_unset">Nessuna chiave OpenAI configurata. Ottienine una su platform.openai.com per usare le voci OpenAI.</string>
+    <string name="settings_openai_key_placeholder">Incolla la tua chiave API OpenAI</string>
+    <string name="settings_openai_key_save">Salva chiave OpenAI</string>
+    <string name="settings_openai_key_clear">Cancella chiave OpenAI salvata</string>
+
+    <string name="settings_elevenlabs_key_status_set">È configurata una chiave ElevenLabs.</string>
+    <string name="settings_elevenlabs_key_status_unset">Nessuna chiave ElevenLabs configurata. Ottienine una su elevenlabs.io per usare le voci ElevenLabs.</string>
+    <string name="settings_elevenlabs_key_placeholder">Incolla la tua chiave API ElevenLabs</string>
+    <string name="settings_elevenlabs_key_save">Salva chiave ElevenLabs</string>
+    <string name="settings_elevenlabs_key_clear">Cancella chiave ElevenLabs salvata</string>
+
+    <!--
     Today screen — top bar, refresh toasts, empty state, generated-at
     timestamp, outfit card, hourly chart, confidence chip, work-status
     banner. Informal tu-form throughout: "tocca", "il tuo", "imposta".

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -240,6 +240,41 @@ editor, outfit-card labels, and region/voice-locale picker names.
     <string name="settings_location_no_results">Nessun risultato.</string>
 
     <!--
+    Notification channels (system Settings → App → Notifications) and
+    the per-channel notification titles. Three channels: daily, nightly
+    (default + silent variants), weather alerts.
+    -->
+    <string name="notification_channel_daily_insight_name">ClothesCast quotidiano</string>
+    <string name="notification_channel_daily_insight_description">Il riepilogo meteo mattutino che hai attivato.</string>
+    <string name="notification_daily_insight_title">Meteo di oggi</string>
+
+    <string name="notification_channel_tonight_insight_default_name">ClothesCast serale (con eventi)</string>
+    <string name="notification_channel_tonight_insight_default_description">Il riepilogo meteo serale quando stasera hai eventi in calendario. Riproduce il tuo suono di notifica predefinito.</string>
+    <string name="notification_channel_tonight_insight_silent_name">ClothesCast serale (silenzioso)</string>
+    <string name="notification_channel_tonight_insight_silent_description">Il riepilogo meteo serale quando la serata è libera. Inviato in silenzio — puoi dargli un\'occhiata sulla schermata di blocco, ma non emette suoni.</string>
+    <string name="notification_tonight_insight_title">Meteo di stasera</string>
+
+    <string name="notification_channel_weather_alerts_name">Allerte meteo</string>
+    <string name="notification_channel_weather_alerts_description">Allerte ad alta priorità per eventi meteo gravi o estremi nella tua zona. Recapitate non appena il recupero quotidiano le rileva.</string>
+    <string name="notification_weather_alert_title">Allerta meteo: %1$s</string>
+
+    <!-- Notification-permission card. -->
+    <string name="settings_notification_permission_title">Le notifiche sono bloccate</string>
+    <string name="settings_notification_permission_description">Senza il permesso per le notifiche, il tuo ClothesCast quotidiano non ha dove andare. Concedilo, così ClothesCast può comparire domattina.</string>
+    <string name="settings_notification_permission_grant">Concedi le notifiche</string>
+
+    <!-- Calendar opt-in card. Description preserves the privacy
+         disclosure ("descrizioni, partecipanti e luoghi vengono letti
+         ma non lasciano mai il dispositivo"). Quotes around the nested
+         example follow the same „…" house style. -->
+    <string name="settings_calendar_title">Calendario</string>
+    <string name="settings_calendar_use_events">Usa gli eventi del calendario di oggi</string>
+    <string name="settings_calendar_description_off">Quando attivo, ClothesCast legge gli eventi di oggi dal calendario del tuo dispositivo, così il tuo ClothesCast mattutino può suggerire capi legati a eventi specifici — per esempio „porta un ombrello per la corsa al parco delle 15“. Vengono usati solo titolo e orario degli eventi; descrizioni, partecipanti e luoghi vengono letti ma non lasciano mai il dispositivo.</string>
+    <string name="settings_calendar_description_on">Sto leggendo gli eventi di oggi dal calendario del tuo dispositivo per arricchire il tuo ClothesCast mattutino. Nel riepilogo si usano solo titoli e orari; descrizioni e partecipanti no. Tutto resta sul dispositivo.</string>
+    <string name="settings_calendar_grant_permission">Concedi l\'accesso al calendario</string>
+    <string name="settings_calendar_open_settings">Accesso al calendario negato. Concedilo dalle impostazioni di sistema.</string>
+
+    <!--
     Today screen — top bar, refresh toasts, empty state, generated-at
     timestamp, outfit card, hourly chart, confidence chip, work-status
     banner. Informal tu-form throughout: "tocca", "il tuo", "imposta".

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -221,6 +221,25 @@ editor, outfit-card labels, and region/voice-locale picker names.
     <string name="settings_elevenlabs_key_clear">Cancella chiave ElevenLabs salvata</string>
 
     <!--
+    Location screen — device-location toggle, manual city search +
+    selection, and the "no location set" empty state.
+    -->
+    <string name="settings_location_title">Posizione</string>
+    <string name="settings_location_use_device">Usa la posizione del dispositivo</string>
+    <string name="settings_location_grant_background">Concedi la posizione in background (impostazioni di sistema)</string>
+    <string name="settings_location_unset">Posizione non impostata — uso Londra come predefinita</string>
+    <string name="settings_location_description">La previsione viene recuperata per questa località. Cerca per nome di città; i risultati provengono dal servizio gratuito di geocoding di Open-Meteo.</string>
+    <string name="settings_location_description_device_on">Quando attivo, al momento della notifica ClothesCast legge la posizione approssimativa del tuo dispositivo (solo cella / WiFi — niente GPS hardware). La posizione qui sotto fa da riserva se la lettura dal dispositivo fallisce. La posizione in background deve essere concessa nelle impostazioni di sistema, altrimenti il Worker mattutino non può leggerla.</string>
+    <string name="settings_location_set">Imposta posizione</string>
+    <string name="settings_location_change">Cambia posizione</string>
+    <string name="settings_location_clear">Cancella posizione</string>
+    <string name="settings_location_search_title">Cerca una posizione</string>
+    <string name="settings_location_query_label">Città o luogo</string>
+    <string name="settings_location_search">Cerca</string>
+    <string name="settings_location_searching">Ricerca in corso…</string>
+    <string name="settings_location_no_results">Nessun risultato.</string>
+
+    <!--
     Today screen — top bar, refresh toasts, empty state, generated-at
     timestamp, outfit card, hourly chart, confidence chip, work-status
     banner. Informal tu-form throughout: "tocca", "il tuo", "imposta".

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -8,6 +8,18 @@ editor, outfit-card labels, and region/voice-locale picker names.
     <string name="settings_tts_voice_locale_it_it">Italiano (Italia)</string>
     <string name="settings_tts_voice_locale_label">Lingua</string>
 
+    <!-- Settings — top bar + root navigation list. -->
+    <string name="settings_title">Impostazioni</string>
+    <string name="settings_back">Indietro</string>
+
+    <string name="settings_root_voice">Voce</string>
+    <string name="settings_root_schedule">Programmazione</string>
+    <string name="settings_root_region">Regione</string>
+    <string name="settings_root_clothes">Abbigliamento</string>
+    <string name="settings_root_api_keys">Chiavi API</string>
+    <string name="settings_root_data_sources">Fonti dati</string>
+    <string name="settings_root_about">Informazioni</string>
+
     <string name="garment_sweater">Maglione</string>
     <string name="garment_hoodie">Felpa con cappuccio</string>
     <string name="garment_jacket">Giacca</string>
@@ -17,6 +29,10 @@ editor, outfit-card labels, and region/voice-locale picker names.
     <string name="garment_shorts">Pantaloncini</string>
     <string name="garment_pants">Pantaloni</string>
     <string name="garment_jeans">Jeans</string>
+
+    <!-- Clothes settings — top of the screen. -->
+    <string name="settings_clothes_title">Regole abbigliamento</string>
+    <string name="settings_clothes_description">Se una previsione supera una di queste soglie, il capo appare nel tuo ClothesCast quotidiano.</string>
 
     <string name="settings_clothes_empty">Nessuna regola. Tocca Aggiungi per crearne una.</string>
     <string name="settings_clothes_add">Aggiungi</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -52,6 +52,30 @@ editor, outfit-card labels, and region/voice-locale picker names.
     <string name="settings_clothes_cond_precip_above">quando la probabilità di pioggia supera %.0f%%</string>
 
     <!--
+    Schedule screen — daily and nightly ClothesCast cards, delivery
+    picker, "Mention evening events" toggle, and the nightly-only
+    "notify only on events" toggle. Description uses German-style
+    „…" quotes around the nested toggle label, matching the locale
+    house style.
+    -->
+    <string name="settings_schedule_title">ClothesCast quotidiano</string>
+    <string name="settings_schedule_time_label">Ora</string>
+    <string name="settings_schedule_days_label">Giorni della settimana</string>
+    <string name="settings_daily_mention_evening_events">Cita gli eventi serali</string>
+
+    <string name="settings_tonight_title">ClothesCast serale</string>
+    <string name="settings_tonight_description">Un secondo ClothesCast la sera che copre il tempo di stasera. Nelle serate tranquille resta silenzioso, o non appare affatto se „Avvisa solo quando ci sono eventi serali“ è attivo; nelle serate con eventi riproduce un suono e (se hai attivato la lettura vocale) si legge da solo.</string>
+    <string name="settings_tonight_enabled">Mostra un ClothesCast serale</string>
+    <string name="settings_tonight_time_label">Ora</string>
+    <string name="settings_tonight_days_label">Giorni della settimana</string>
+    <string name="settings_tonight_notify_only_on_events">Avvisa solo quando ci sono eventi serali</string>
+
+    <string name="settings_delivery_label">Recapito</string>
+    <string name="settings_delivery_notification_only">Solo notifica</string>
+    <string name="settings_delivery_tts_only">Solo lettura vocale</string>
+    <string name="settings_delivery_notification_and_tts">Notifica e lettura vocale</string>
+
+    <!--
     Today screen — top bar, refresh toasts, empty state, generated-at
     timestamp, outfit card, hourly chart, confidence chip, work-status
     banner. Informal tu-form throughout: "tocca", "il tuo", "imposta".

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -101,6 +101,96 @@ editor, outfit-card labels, and region/voice-locale picker names.
     <string name="settings_tts_add_api_key_cancel">Annulla</string>
 
     <!--
+    Region screen — language picker title + caption (the disambiguation
+    copy explaining that this knob is the *displayed text*, not the
+    spoken accent), the system-default option, and the per-locale
+    labels in Italian style ("Inglese (Stati Uniti)", "Francese
+    (Canada)", "Cinese (semplificato)", …). The locale tag stored on
+    disk (en-US / fr-CA / zh-CN) is unchanged; only the displayed label
+    localizes.
+    -->
+    <string name="settings_region_language_title">Lingua</string>
+    <string name="settings_region_language_description">Imposta la lingua del testo visualizzato e delle notifiche.</string>
+    <string name="settings_region_language_system">Segui le impostazioni di sistema</string>
+    <string name="settings_region_language_en_us">Inglese (Stati Uniti)</string>
+    <string name="settings_region_language_en_gb">Inglese (Regno Unito)</string>
+    <string name="settings_region_language_en_au">Inglese (Australia)</string>
+    <string name="settings_region_language_en_ca">Inglese (Canada)</string>
+    <string name="settings_region_language_en_za">Inglese (Sudafrica)</string>
+    <string name="settings_region_language_de_de">Tedesco (Germania)</string>
+    <string name="settings_region_language_fr_fr">Francese (Francia)</string>
+    <string name="settings_region_language_fr_ca">Francese (Canada)</string>
+    <string name="settings_region_language_es_es">Spagnolo (Spagna)</string>
+    <string name="settings_region_language_es_mx">Spagnolo (Messico)</string>
+    <string name="settings_region_language_ru_ru">Russo (Russia)</string>
+    <string name="settings_region_language_pl_pl">Polacco (Polonia)</string>
+    <string name="settings_region_language_hr_hr">Croato (Croazia)</string>
+    <string name="settings_region_language_uk_ua">Ucraino (Ucraina)</string>
+    <string name="settings_region_language_pt_br">Portoghese (Brasile)</string>
+    <string name="settings_region_language_nl_nl">Olandese (Paesi Bassi)</string>
+    <string name="settings_region_language_sv_se">Svedese (Svezia)</string>
+    <string name="settings_region_language_tr_tr">Turco (Turchia)</string>
+    <string name="settings_region_language_id_id">Indonesiano (Indonesia)</string>
+    <string name="settings_region_language_fil_ph">Filippino (Filippine)</string>
+    <string name="settings_region_language_vi_vn">Vietnamita (Vietnam)</string>
+    <string name="settings_region_language_zh_cn">Cinese (semplificato)</string>
+    <string name="settings_region_language_hi_in">Hindi (India)</string>
+    <string name="settings_region_language_bn_bd">Bengalese (Bangladesh)</string>
+    <string name="settings_region_language_ja_jp">Giapponese (Giappone)</string>
+    <string name="settings_region_language_ko_kr">Coreano (Corea del Sud)</string>
+    <string name="settings_region_language_ar_sa">Arabo (Arabia Saudita)</string>
+    <string name="settings_region_language_he_il">Ebraico (Israele)</string>
+    <string name="settings_region_language_fa_ir">Persiano (Iran)</string>
+
+    <!-- Region screen — units pickers (Temperature: Celsius / Fahrenheit;
+         Distance: Chilometri / Miglia). The unit symbols (°C, °F) stay
+         unchanged. -->
+    <string name="settings_temperature_unit_title">Unità di temperatura</string>
+    <string name="settings_temperature_unit_celsius">Celsius (°C)</string>
+    <string name="settings_temperature_unit_fahrenheit">Fahrenheit (°F)</string>
+    <string name="settings_distance_unit_title">Unità di distanza</string>
+    <string name="settings_distance_unit_kilometers">Chilometri</string>
+    <string name="settings_distance_unit_miles">Miglia</string>
+
+    <!--
+    Voice locale picker labels — same Italian language-name translations
+    as the Region picker above, just keyed under
+    `settings_tts_voice_locale_*` because the Voice screen's language
+    sub-picker is a separate UI surface. The two pickers steer different
+    things: Region is the *displayed text*, Voice locale is the *spoken
+    accent*.
+    -->
+    <string name="settings_tts_voice_locale_en_us">Inglese (Stati Uniti)</string>
+    <string name="settings_tts_voice_locale_en_gb">Inglese (Regno Unito)</string>
+    <string name="settings_tts_voice_locale_en_au">Inglese (Australia)</string>
+    <string name="settings_tts_voice_locale_en_ca">Inglese (Canada)</string>
+    <string name="settings_tts_voice_locale_en_za">Inglese (Sudafrica)</string>
+    <string name="settings_tts_voice_locale_de_de">Tedesco (Germania)</string>
+    <string name="settings_tts_voice_locale_fr_fr">Francese (Francia)</string>
+    <string name="settings_tts_voice_locale_fr_ca">Francese (Canada)</string>
+    <string name="settings_tts_voice_locale_es_es">Spagnolo (Spagna)</string>
+    <string name="settings_tts_voice_locale_es_mx">Spagnolo (Messico)</string>
+    <string name="settings_tts_voice_locale_ru_ru">Russo (Russia)</string>
+    <string name="settings_tts_voice_locale_pl_pl">Polacco (Polonia)</string>
+    <string name="settings_tts_voice_locale_hr_hr">Croato (Croazia)</string>
+    <string name="settings_tts_voice_locale_uk_ua">Ucraino (Ucraina)</string>
+    <string name="settings_tts_voice_locale_pt_br">Portoghese (Brasile)</string>
+    <string name="settings_tts_voice_locale_nl_nl">Olandese (Paesi Bassi)</string>
+    <string name="settings_tts_voice_locale_sv_se">Svedese (Svezia)</string>
+    <string name="settings_tts_voice_locale_tr_tr">Turco (Turchia)</string>
+    <string name="settings_tts_voice_locale_id_id">Indonesiano (Indonesia)</string>
+    <string name="settings_tts_voice_locale_fil_ph">Filippino (Filippine)</string>
+    <string name="settings_tts_voice_locale_vi_vn">Vietnamita (Vietnam)</string>
+    <string name="settings_tts_voice_locale_zh_cn">Cinese (semplificato)</string>
+    <string name="settings_tts_voice_locale_hi_in">Hindi (India)</string>
+    <string name="settings_tts_voice_locale_bn_bd">Bengalese (Bangladesh)</string>
+    <string name="settings_tts_voice_locale_ja_jp">Giapponese (Giappone)</string>
+    <string name="settings_tts_voice_locale_ko_kr">Coreano (Corea del Sud)</string>
+    <string name="settings_tts_voice_locale_ar_sa">Arabo (Arabia Saudita)</string>
+    <string name="settings_tts_voice_locale_he_il">Ebraico (Israele)</string>
+    <string name="settings_tts_voice_locale_fa_ir">Persiano (Iran)</string>
+
+    <!--
     Today screen — top bar, refresh toasts, empty state, generated-at
     timestamp, outfit card, hourly chart, confidence chip, work-status
     banner. Informal tu-form throughout: "tocca", "il tuo", "imposta".

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -76,6 +76,31 @@ editor, outfit-card labels, and region/voice-locale picker names.
     <string name="settings_delivery_notification_and_tts">Notifica e lettura vocale</string>
 
     <!--
+    Voice screen — engine picker (Device / Gemini / OpenAI / ElevenLabs),
+    voice + language sub-pickers, test-voice button, missing-API-key
+    hint and the in-line "Aggiungi chiave API" dialog.
+    -->
+    <string name="settings_tts_engine_title">Motore vocale</string>
+    <string name="settings_tts_engine_description">I motori online (Gemini, OpenAI, ElevenLabs) suonano molto più naturali, ma richiedono una chiamata di rete al momento della lettura e usano la tua chiave API per la sintesi (una breve chiamata per ogni ClothesCast letto). Ricade sulla voce del dispositivo se il motore scelto fallisce.</string>
+    <string name="settings_tts_engine_device">Dispositivo (offline, gratis)</string>
+    <string name="settings_tts_engine_gemini">Gemini (alta qualità, online)</string>
+    <string name="settings_tts_engine_openai">OpenAI (alta qualità, online)</string>
+    <string name="settings_tts_engine_elevenlabs">ElevenLabs (massima qualità, online)</string>
+
+    <string name="settings_tts_voice_label">Voce</string>
+    <string name="settings_tts_voice_dismiss">Fatto</string>
+    <string name="settings_tts_voice_locale_description">Imposta l\'accento della voce parlata. Non modifica il testo visualizzato.</string>
+    <string name="settings_tts_voice_locale_system">Segui la lingua del telefono</string>
+
+    <string name="settings_tts_test">Prova la voce</string>
+    <string name="settings_tts_test_in_flight">Test in corso — attendi…</string>
+    <string name="settings_tts_no_key_hint">Nessuna chiave %1$s configurata — aggiungine una per attivare questo motore.</string>
+    <string name="settings_tts_add_api_key">Aggiungi chiave API</string>
+    <string name="settings_tts_add_api_key_title">Aggiungi chiave API %1$s</string>
+    <string name="settings_tts_add_api_key_save">Salva</string>
+    <string name="settings_tts_add_api_key_cancel">Annulla</string>
+
+    <!--
     Today screen — top bar, refresh toasts, empty state, generated-at
     timestamp, outfit card, hourly chart, confidence chip, work-status
     banner. Informal tu-form throughout: "tocca", "il tuo", "imposta".

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -35,11 +35,57 @@ editor, outfit-card labels, and region/voice-locale picker names.
     <string name="settings_clothes_cond_temp_above">quando la temperatura percepita è sopra %.0f°C</string>
     <string name="settings_clothes_cond_precip_above">quando la probabilità di pioggia supera %.0f%%</string>
 
+    <!--
+    Today screen — top bar, refresh toasts, empty state, generated-at
+    timestamp, outfit card, hourly chart, confidence chip, work-status
+    banner. Informal tu-form throughout: "tocca", "il tuo", "imposta".
+    -->
+    <string name="today_title">Oggi</string>
+    <string name="today_open_settings">Apri impostazioni</string>
+    <string name="today_more_options">Altre opzioni</string>
+    <string name="today_report_a_bug">Segnala un bug</string>
+    <string name="today_refresh">Aggiorna</string>
+    <string name="today_refresh_toast_daily">Sto aggiornando il tuo ClothesCast quotidiano — apparirà a momenti.</string>
+    <string name="today_refresh_toast_nightly">Sto aggiornando il tuo ClothesCast serale — apparirà a momenti.</string>
+    <string name="today_empty_title">Ancora nessun ClothesCast</string>
+    <string name="today_empty_subtitle">Il tuo ClothesCast mattutino apparirà qui una volta generato. Imposta la tua posizione nelle impostazioni e poi tocca Aggiorna ora.</string>
+    <string name="today_fetch_now">Aggiorna ora</string>
+    <string name="today_generated_at">Generato alle %1$s</string>
+
+    <string name="today_outfit_title">Cosa indossare</string>
+    <string name="today_outfit_label_today">Oggi</string>
+    <string name="today_outfit_label_tonight">Stasera</string>
+    <string name="today_outfit_label_tomorrow">Domani</string>
+
     <string name="today_outfit_top_tshirt">T-shirt</string>
     <string name="today_outfit_top_sweater">Maglione</string>
     <string name="today_outfit_top_thick_jacket">Giacca pesante</string>
     <string name="today_outfit_bottom_shorts">Pantaloncini</string>
     <string name="today_outfit_bottom_long_pants">Pantaloni</string>
+
+    <string name="today_forecast_title">Previsione oraria</string>
+    <string name="today_forecast_min_max">Percepita %1$d – %2$d%3$s · Aria %4$d – %5$d%6$s</string>
+    <string name="today_forecast_legend_feels_like">Temperatura percepita (%1$s) per ora · tocca per la temperatura dell\'aria</string>
+    <string name="today_forecast_legend_air">Temperatura dell\'aria (%1$s) per ora · tocca per la temperatura percepita</string>
+
+    <string name="today_confidence_high">Alta confidenza — i modelli principali concordano</string>
+    <string name="today_confidence_medium">Confidenza media</string>
+    <string name="today_confidence_low">Bassa confidenza — le previsioni non concordano</string>
+    <string name="today_confidence_spread">Dispersione: %1$.1f°C, %2$.0fpp precipitazioni su %3$d modelli</string>
+
+    <string name="today_working">Sto recuperando il tuo ClothesCast…</string>
+    <string name="today_failed_title">L\'ultimo tentativo non è riuscito</string>
+    <string name="today_failed_unexpected_http">Errore HTTP inatteso dal servizio meteo.</string>
+    <string name="today_failed_unhandled">Si è verificato un errore imprevisto.</string>
+    <string name="today_failed_show_details">Mostra dettagli</string>
+    <string name="today_failed_hide_details">Nascondi dettagli</string>
+
+    <!-- Home-screen App Widget. "Outfit" is in common Italian use as a
+         loanword; the empty state localises naturally. -->
+    <string name="widget_label">Outfit</string>
+    <string name="widget_description">L\'outfit del momento attuale a colpo d\'occhio.</string>
+    <string name="widget_empty_title">Ancora nessun outfit</string>
+    <string name="widget_empty_subtitle">Tocca per aprire ClothesCast</string>
 
     <string name="insight_lead_today">Oggi</string>
     <string name="insight_lead_tonight">Stasera</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1,7 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-Italian translation. Scope: insight-prose templates, garment labels, clothes-rule
-editor, outfit-card labels, and region/voice-locale picker names.
+Italian translation — full UI coverage. Informal tu-form throughout
+(intimate / spousal register), matching the existing insight prose
+("Indossa …", "Porta …", "Il tuo ClothesCast di oggi"). No Lei-form.
+
+What is NOT overridden, by design:
+- `app_name` — brand identifier, identical across locales.
+- `insight_time_am` / `_pm` / `_midnight` / `_noon` (and *_minutes
+  variants) — English-only spoken-time formatter helpers. Italian
+  locales use `insight_time_hour` / `_hour_minutes` ("15" / "15 e 30")
+  which are translated below; the AM/PM keys exist for the
+  `Locale.language == "en"` path only and would never be read in an
+  Italian runtime.
+
+Italian forces gender agreement on predicate adjectives in the tu-form;
+the welcome leans on the conventional masc-default "Benvenuto" and
+the subtitle uses the invariable "sei a posto" so a one-time greeting
+doesn't have to pick a gender for the user. The rest of the file is
+plain tu-form imperative.
+
+Picker labels under `settings_region_language_*` and
+`settings_tts_voice_locale_*` give the Italian names for every offered
+locale (Inglese (Stati Uniti), Francese (Canada), Cinese
+(semplificato), …). The locale tag stored on disk (en-US / fr-CA /
+zh-CN) is unchanged; only the displayed label localizes.
 -->
 <resources>
     <string name="settings_region_language_it_it">Italiano (Italia)</string>


### PR DESCRIPTION
## Summary

Italian UI translation, mirroring the German pass in PR #168 and the
Croatian pass in PR #169. Eleven commits — ten surface-by-surface fills
plus a final header refresh.

The existing Italian file already used informal tu-form throughout
("Indossa …", "Porta …", "Il tuo ClothesCast di oggi") so no tone-fix
commit was needed — just the surface-by-surface fill-in of the strings
the file was missing.

## Surfaces

- Today screen + home-screen widget
- Onboarding flow
- Settings root nav + Clothes section header
- Schedule screen (daily, nightly, delivery)
- Voice screen (engine + voice + language pickers)
- Region screen + Voice locale picker labels (28 locales × 2)
- API keys screen
- Location screen
- Notification channels + permission card + Calendar
- Debug + About screens
- File header refresh documenting the new scope and the deliberate
  non-overrides

After this PR the Italian file has 293 strings vs. 300 in the en-US
baseline; the seven gaps are the same deliberate non-overrides as the
German and Croatian PRs (`app_name` brand identifier + the six
English-only `insight_time_*` AM/PM helpers that the Italian formatter
doesn't read).

## Tone

tu-form throughout, intimate / spousal register matching the existing
insight prose. Italian, like Croatian, forces gender agreement on
predicate adjectives in the tu-form; the welcome screen leans on the
conventional masc-default "Benvenuto" and the subtitle uses the
invariable "sei a posto" so a one-time greeting doesn't have to pick a
gender for the user. The rest stays in plain tu-form imperative
("Imposta", "Concedi", "Tocca"). Brand "ClothesCast" stays verbatim
throughout.

Stale `insight_calendar_tie_in` is left untouched — it's no longer
referenced in code, and the same dead key exists in nine other locale
files. Cleanup should be a fleet-wide pass rather than per-locale.

## Privacy

Display-only. No new strings cross the device boundary; the rendered
insight prose (the only thing fed to TTS / LLM endpoints) was already
fully Italian via the existing `insight_*` translations.

## Test plan

- [ ] CI: `JVM unit tests` green (no Italian tests pin specific prose
      so nothing to update)
- [ ] CI: `Android debug build` green
- [ ] Manual: phone in it-IT or **Region: Italiano (Italia)** → walk
      every screen (Today, widget, onboarding, Settings root + every
      sub-screen, notifications, About) and confirm Italian tu-form
      throughout, no English fall-through

https://claude.ai/code/session_01C1Q3vzGj6KmbYDfD6b2yhu

---
_Generated by [Claude Code](https://claude.ai/code/session_015agXppcN2fzATq5Xnzpozs)_