### PR TITLE
:app — Spanish UI: full tú-form pass + es-rMX vocabulary overrides

### DIFF
--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -16,4 +16,28 @@ that a Mexican speaker would notice as wrong is overridden here.
     <string name="settings_clothes_add">Agregar</string>
     <string name="settings_clothes_empty">Sin reglas. Toca Agregar para crear una.</string>
     <string name="settings_clothes_dialog_add_title">Agregar regla de ropa</string>
+
+    <!-- Mexican Spanish prefers "Configuración" over the Spain-Spanish
+         "Ajustes" for Android Settings; mirrors the platform's own
+         es-rMX system label. Re-write every es-ES sentence that
+         embeds "los/las ajustes" with "la configuración". -->
+    <string name="settings_title">Configuración</string>
+    <string name="today_open_settings">Abrir configuración</string>
+    <string name="today_empty_subtitle">Tu ClothesCast matutino aparecerá aquí cuando se genere. Configura tu ubicación en la configuración y toca Obtener ahora.</string>
+    <string name="onboarding_subtitle">Dos elecciones rápidas y ya está. Todo lo demás tiene un valor predeterminado razonable que podrás ajustar más tarde en la configuración.</string>
+    <string name="settings_location_grant_background">Conceder ubicación en segundo plano (configuración del sistema)</string>
+    <string name="settings_location_description_device_on">Si está activo, ClothesCast lee la ubicación aproximada de tu dispositivo en el momento de la notificación (solo torre de telefonía / WiFi — sin GPS por hardware). La ubicación de abajo se usa como respaldo si la lectura del dispositivo falla. La ubicación en segundo plano debe concederse en la configuración del sistema, o el Worker matutino no podrá leerla.</string>
+    <string name="settings_calendar_open_settings">Acceso al calendario denegado. Concédelo en la configuración del sistema.</string>
+
+    <!-- Mexican Spanish prefers "agregar" over the Spain-Spanish "añadir"
+         for "Add" — mirrors the existing settings_clothes_add override
+         a few lines up. -->
+    <string name="settings_tts_no_key_hint">No hay clave de %1$s configurada — agrega una para habilitar este motor.</string>
+    <string name="settings_tts_add_api_key">Agregar clave API</string>
+    <string name="settings_tts_add_api_key_title">Agregar clave API de %1$s</string>
+
+    <!-- Mexican Spanish prefers "reportar" over "informar de" for
+         bug reports / error reporting — both verb and noun forms. -->
+    <string name="today_report_a_bug">Reportar un error</string>
+    <string name="settings_about_share_bug_report">Compartir reporte de error</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -38,11 +38,58 @@ Mexico-specific vocabulary overrides live in values-es-rMX.
     <string name="settings_clothes_cond_temp_above">cuando la temperatura percibida es superior a %.0f°C</string>
     <string name="settings_clothes_cond_precip_above">cuando la probabilidad de lluvia supera %.0f%%</string>
 
+    <!--
+    Today screen — top bar, refresh toasts, empty state, generated-at
+    timestamp, outfit card, hourly chart, confidence chip, work-status
+    banner. Informal tú-form throughout: "toca", "tu", "configura".
+    -->
+    <string name="today_title">Hoy</string>
+    <string name="today_open_settings">Abrir ajustes</string>
+    <string name="today_more_options">Más opciones</string>
+    <string name="today_report_a_bug">Informar de un error</string>
+    <string name="today_refresh">Actualizar</string>
+    <string name="today_refresh_toast_daily">Actualizando tu ClothesCast diario — aparecerá enseguida.</string>
+    <string name="today_refresh_toast_nightly">Actualizando tu ClothesCast nocturno — aparecerá enseguida.</string>
+    <string name="today_empty_title">Aún no hay ClothesCast</string>
+    <string name="today_empty_subtitle">Tu ClothesCast matutino aparecerá aquí cuando se genere. Configura tu ubicación en los ajustes y toca Obtener ahora.</string>
+    <string name="today_fetch_now">Obtener ahora</string>
+    <string name="today_generated_at">Generado a las %1$s</string>
+
+    <string name="today_outfit_title">Qué ponerte</string>
+    <string name="today_outfit_label_today">Hoy</string>
+    <string name="today_outfit_label_tonight">Esta noche</string>
+    <string name="today_outfit_label_tomorrow">Mañana</string>
+
     <string name="today_outfit_top_tshirt">Camiseta</string>
     <string name="today_outfit_top_sweater">Jersey</string>
     <string name="today_outfit_top_thick_jacket">Abrigo grueso</string>
     <string name="today_outfit_bottom_shorts">Pantalones cortos</string>
     <string name="today_outfit_bottom_long_pants">Pantalones</string>
+
+    <string name="today_forecast_title">Pronóstico por horas</string>
+    <string name="today_forecast_min_max">Sensación %1$d – %2$d%3$s · Aire %4$d – %5$d%6$s</string>
+    <string name="today_forecast_legend_feels_like">Sensación térmica (%1$s) por hora · toca para ver la temperatura del aire</string>
+    <string name="today_forecast_legend_air">Temperatura del aire (%1$s) por hora · toca para ver la sensación térmica</string>
+
+    <string name="today_confidence_high">Alta confianza — los principales modelos coinciden</string>
+    <string name="today_confidence_medium">Confianza media</string>
+    <string name="today_confidence_low">Baja confianza — los pronósticos difieren</string>
+    <string name="today_confidence_spread">Dispersión: %1$.1f°C, %2$.0fpp de precipitación en %3$d modelos</string>
+
+    <string name="today_working">Obteniendo tu ClothesCast…</string>
+    <string name="today_failed_title">El último intento falló</string>
+    <string name="today_failed_unexpected_http">Error HTTP inesperado del servicio del pronóstico.</string>
+    <string name="today_failed_unhandled">Se ha producido un error inesperado.</string>
+    <string name="today_failed_show_details">Mostrar detalles</string>
+    <string name="today_failed_hide_details">Ocultar detalles</string>
+
+    <!-- Home-screen App Widget. "Outfit" stays as the loanword (in
+         common Spanish use, fits the casual register and matches the
+         brand-name register the rest of the file uses). -->
+    <string name="widget_label">Outfit</string>
+    <string name="widget_description">El outfit del periodo actual de un vistazo.</string>
+    <string name="widget_empty_title">Aún no hay outfit</string>
+    <string name="widget_empty_subtitle">Toca para abrir ClothesCast</string>
 
     <string name="insight_lead_today">Hoy</string>
     <string name="insight_lead_tonight">Esta noche</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -192,6 +192,35 @@ Mexico-specific vocabulary overrides live in values-es-rMX.
     <string name="settings_tts_voice_locale_fa_ir">Persa (Irán)</string>
 
     <!--
+    API keys screen — three identical-shape blocks (Gemini, OpenAI,
+    ElevenLabs), each with status copy, paste-key placeholder, and
+    save / clear buttons. URLs stay verbatim.
+    -->
+    <string name="settings_api_keys_title">Claves API</string>
+    <string name="settings_api_keys_description">Configura las claves API para los motores de voz online que quieras usar. Las claves se cifran en reposo usando el Android Keystore.</string>
+    <string name="settings_api_key_gemini_label">Gemini</string>
+    <string name="settings_api_key_openai_label">OpenAI</string>
+    <string name="settings_api_key_elevenlabs_label">ElevenLabs</string>
+
+    <string name="settings_api_key_status_set">Hay una clave de Gemini configurada.</string>
+    <string name="settings_api_key_status_unset">No hay clave de Gemini configurada. Consigue una en aistudio.google.com para usar las voces de Gemini.</string>
+    <string name="settings_api_key_placeholder">Pega tu clave API de Gemini</string>
+    <string name="settings_api_key_save">Guardar clave de Gemini</string>
+    <string name="settings_api_key_clear">Borrar clave de Gemini guardada</string>
+
+    <string name="settings_openai_key_status_set">Hay una clave de OpenAI configurada.</string>
+    <string name="settings_openai_key_status_unset">No hay clave de OpenAI configurada. Consigue una en platform.openai.com para usar las voces de OpenAI.</string>
+    <string name="settings_openai_key_placeholder">Pega tu clave API de OpenAI</string>
+    <string name="settings_openai_key_save">Guardar clave de OpenAI</string>
+    <string name="settings_openai_key_clear">Borrar clave de OpenAI guardada</string>
+
+    <string name="settings_elevenlabs_key_status_set">Hay una clave de ElevenLabs configurada.</string>
+    <string name="settings_elevenlabs_key_status_unset">No hay clave de ElevenLabs configurada. Consigue una en elevenlabs.io para usar las voces de ElevenLabs.</string>
+    <string name="settings_elevenlabs_key_placeholder">Pega tu clave API de ElevenLabs</string>
+    <string name="settings_elevenlabs_key_save">Guardar clave de ElevenLabs</string>
+    <string name="settings_elevenlabs_key_clear">Borrar clave de ElevenLabs guardada</string>
+
+    <!--
     Today screen — top bar, refresh toasts, empty state, generated-at
     timestamp, outfit card, hourly chart, confidence chip, work-status
     banner. Informal tú-form throughout: "toca", "tu", "configura".

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -104,6 +104,94 @@ Mexico-specific vocabulary overrides live in values-es-rMX.
     <string name="settings_tts_add_api_key_cancel">Cancelar</string>
 
     <!--
+    Region screen — language picker title + caption (the disambiguation
+    copy explaining that this knob is the *displayed text*, not the
+    spoken accent), the system-default option, and the per-locale
+    labels in Spanish style ("Inglés (Estados Unidos)", "Francés
+    (Canadá)", "Chino (simplificado)", …). The locale tag stored on
+    disk (en-US / fr-CA / zh-CN) is unchanged; only the displayed label
+    localizes.
+    -->
+    <string name="settings_region_language_title">Idioma</string>
+    <string name="settings_region_language_description">Establece el idioma del texto mostrado y las notificaciones.</string>
+    <string name="settings_region_language_system">Seguir la configuración regional del sistema</string>
+    <string name="settings_region_language_en_us">Inglés (Estados Unidos)</string>
+    <string name="settings_region_language_en_gb">Inglés (Reino Unido)</string>
+    <string name="settings_region_language_en_au">Inglés (Australia)</string>
+    <string name="settings_region_language_en_ca">Inglés (Canadá)</string>
+    <string name="settings_region_language_en_za">Inglés (Sudáfrica)</string>
+    <string name="settings_region_language_de_de">Alemán (Alemania)</string>
+    <string name="settings_region_language_fr_fr">Francés (Francia)</string>
+    <string name="settings_region_language_fr_ca">Francés (Canadá)</string>
+    <string name="settings_region_language_it_it">Italiano (Italia)</string>
+    <string name="settings_region_language_ru_ru">Ruso (Rusia)</string>
+    <string name="settings_region_language_pl_pl">Polaco (Polonia)</string>
+    <string name="settings_region_language_hr_hr">Croata (Croacia)</string>
+    <string name="settings_region_language_uk_ua">Ucraniano (Ucrania)</string>
+    <string name="settings_region_language_pt_br">Portugués (Brasil)</string>
+    <string name="settings_region_language_nl_nl">Neerlandés (Países Bajos)</string>
+    <string name="settings_region_language_sv_se">Sueco (Suecia)</string>
+    <string name="settings_region_language_tr_tr">Turco (Turquía)</string>
+    <string name="settings_region_language_id_id">Indonesio (Indonesia)</string>
+    <string name="settings_region_language_fil_ph">Filipino (Filipinas)</string>
+    <string name="settings_region_language_vi_vn">Vietnamita (Vietnam)</string>
+    <string name="settings_region_language_zh_cn">Chino (simplificado)</string>
+    <string name="settings_region_language_hi_in">Hindi (India)</string>
+    <string name="settings_region_language_bn_bd">Bengalí (Bangladés)</string>
+    <string name="settings_region_language_ja_jp">Japonés (Japón)</string>
+    <string name="settings_region_language_ko_kr">Coreano (Corea del Sur)</string>
+    <string name="settings_region_language_ar_sa">Árabe (Arabia Saudita)</string>
+    <string name="settings_region_language_he_il">Hebreo (Israel)</string>
+    <string name="settings_region_language_fa_ir">Persa (Irán)</string>
+
+    <!-- Region screen — units pickers (Temperature: Celsius / Fahrenheit;
+         Distance: Kilómetros / Millas). The unit symbols (°C, °F) stay
+         unchanged. -->
+    <string name="settings_temperature_unit_title">Unidad de temperatura</string>
+    <string name="settings_temperature_unit_celsius">Celsius (°C)</string>
+    <string name="settings_temperature_unit_fahrenheit">Fahrenheit (°F)</string>
+    <string name="settings_distance_unit_title">Unidad de distancia</string>
+    <string name="settings_distance_unit_kilometers">Kilómetros</string>
+    <string name="settings_distance_unit_miles">Millas</string>
+
+    <!--
+    Voice locale picker labels — same Spanish language-name translations
+    as the Region picker above, just keyed under
+    `settings_tts_voice_locale_*` because the Voice screen's language
+    sub-picker is a separate UI surface. The two pickers steer different
+    things: Region is the *displayed text*, Voice locale is the *spoken
+    accent*.
+    -->
+    <string name="settings_tts_voice_locale_en_us">Inglés (Estados Unidos)</string>
+    <string name="settings_tts_voice_locale_en_gb">Inglés (Reino Unido)</string>
+    <string name="settings_tts_voice_locale_en_au">Inglés (Australia)</string>
+    <string name="settings_tts_voice_locale_en_ca">Inglés (Canadá)</string>
+    <string name="settings_tts_voice_locale_en_za">Inglés (Sudáfrica)</string>
+    <string name="settings_tts_voice_locale_de_de">Alemán (Alemania)</string>
+    <string name="settings_tts_voice_locale_fr_fr">Francés (Francia)</string>
+    <string name="settings_tts_voice_locale_fr_ca">Francés (Canadá)</string>
+    <string name="settings_tts_voice_locale_it_it">Italiano (Italia)</string>
+    <string name="settings_tts_voice_locale_ru_ru">Ruso (Rusia)</string>
+    <string name="settings_tts_voice_locale_pl_pl">Polaco (Polonia)</string>
+    <string name="settings_tts_voice_locale_hr_hr">Croata (Croacia)</string>
+    <string name="settings_tts_voice_locale_uk_ua">Ucraniano (Ucrania)</string>
+    <string name="settings_tts_voice_locale_pt_br">Portugués (Brasil)</string>
+    <string name="settings_tts_voice_locale_nl_nl">Neerlandés (Países Bajos)</string>
+    <string name="settings_tts_voice_locale_sv_se">Sueco (Suecia)</string>
+    <string name="settings_tts_voice_locale_tr_tr">Turco (Turquía)</string>
+    <string name="settings_tts_voice_locale_id_id">Indonesio (Indonesia)</string>
+    <string name="settings_tts_voice_locale_fil_ph">Filipino (Filipinas)</string>
+    <string name="settings_tts_voice_locale_vi_vn">Vietnamita (Vietnam)</string>
+    <string name="settings_tts_voice_locale_zh_cn">Chino (simplificado)</string>
+    <string name="settings_tts_voice_locale_hi_in">Hindi (India)</string>
+    <string name="settings_tts_voice_locale_bn_bd">Bengalí (Bangladés)</string>
+    <string name="settings_tts_voice_locale_ja_jp">Japonés (Japón)</string>
+    <string name="settings_tts_voice_locale_ko_kr">Coreano (Corea del Sur)</string>
+    <string name="settings_tts_voice_locale_ar_sa">Árabe (Arabia Saudita)</string>
+    <string name="settings_tts_voice_locale_he_il">Hebreo (Israel)</string>
+    <string name="settings_tts_voice_locale_fa_ir">Persa (Irán)</string>
+
+    <!--
     Today screen — top bar, refresh toasts, empty state, generated-at
     timestamp, outfit card, hourly chart, confidence chip, work-status
     banner. Informal tú-form throughout: "toca", "tu", "configura".

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -79,6 +79,31 @@ Mexico-specific vocabulary overrides live in values-es-rMX.
     <string name="settings_delivery_notification_and_tts">Notificación y lectura en voz alta</string>
 
     <!--
+    Voice screen — engine picker (Device / Gemini / OpenAI / ElevenLabs),
+    voice + language sub-pickers, test-voice button, missing-API-key
+    hint and the in-line "Añadir clave API" dialog.
+    -->
+    <string name="settings_tts_engine_title">Motor de voz</string>
+    <string name="settings_tts_engine_description">Los motores online (Gemini, OpenAI, ElevenLabs) suenan mucho más naturales, pero requieren una llamada de red en el momento de hablar y usan tu clave API para la síntesis (una llamada corta por cada ClothesCast hablado). Vuelve a la voz del dispositivo si el motor elegido falla.</string>
+    <string name="settings_tts_engine_device">Dispositivo (offline, gratis)</string>
+    <string name="settings_tts_engine_gemini">Gemini (alta calidad, online)</string>
+    <string name="settings_tts_engine_openai">OpenAI (alta calidad, online)</string>
+    <string name="settings_tts_engine_elevenlabs">ElevenLabs (máxima calidad, online)</string>
+
+    <string name="settings_tts_voice_label">Voz</string>
+    <string name="settings_tts_voice_dismiss">Hecho</string>
+    <string name="settings_tts_voice_locale_description">Establece el acento de la voz hablada. No cambia el texto mostrado.</string>
+    <string name="settings_tts_voice_locale_system">Seguir el idioma del teléfono</string>
+
+    <string name="settings_tts_test">Probar voz</string>
+    <string name="settings_tts_test_in_flight">Probando — espera…</string>
+    <string name="settings_tts_no_key_hint">No hay clave de %1$s configurada — añade una para habilitar este motor.</string>
+    <string name="settings_tts_add_api_key">Añadir clave API</string>
+    <string name="settings_tts_add_api_key_title">Añadir clave API de %1$s</string>
+    <string name="settings_tts_add_api_key_save">Guardar</string>
+    <string name="settings_tts_add_api_key_cancel">Cancelar</string>
+
+    <!--
     Today screen — top bar, refresh toasts, empty state, generated-at
     timestamp, outfit card, hourly chart, confidence chip, work-status
     banner. Informal tú-form throughout: "toca", "tu", "configura".

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -240,6 +240,41 @@ Mexico-specific vocabulary overrides live in values-es-rMX.
     <string name="settings_location_no_results">Sin resultados.</string>
 
     <!--
+    Notification channels (system Settings → App → Notifications) and
+    the per-channel notification titles. Three channels: daily, nightly
+    (default + silent variants), weather alerts.
+    -->
+    <string name="notification_channel_daily_insight_name">ClothesCast diario</string>
+    <string name="notification_channel_daily_insight_description">El resumen del tiempo matutino que has activado.</string>
+    <string name="notification_daily_insight_title">El tiempo de hoy</string>
+
+    <string name="notification_channel_tonight_insight_default_name">ClothesCast nocturno (con eventos)</string>
+    <string name="notification_channel_tonight_insight_default_description">El resumen del tiempo de la tarde cuando esta noche tienes eventos en el calendario. Reproduce tu sonido de notificación predeterminado.</string>
+    <string name="notification_channel_tonight_insight_silent_name">ClothesCast nocturno (silencioso)</string>
+    <string name="notification_channel_tonight_insight_silent_description">El resumen del tiempo de la tarde cuando tu noche está libre. Se entrega en silencio — puedes echarle un vistazo en la pantalla de bloqueo, pero no emite ningún sonido.</string>
+    <string name="notification_tonight_insight_title">El tiempo de esta noche</string>
+
+    <string name="notification_channel_weather_alerts_name">Alertas meteorológicas</string>
+    <string name="notification_channel_weather_alerts_description">Alertas de alta prioridad para fenómenos meteorológicos graves o extremos en tu zona. Se entregan en cuanto la obtención diaria los detecta.</string>
+    <string name="notification_weather_alert_title">Alerta meteorológica: %1$s</string>
+
+    <!-- Notification-permission card. -->
+    <string name="settings_notification_permission_title">Las notificaciones están bloqueadas</string>
+    <string name="settings_notification_permission_description">Sin permiso de notificaciones, tu ClothesCast diario no tiene a dónde ir. Concédelas para que ClothesCast pueda aparecer mañana por la mañana.</string>
+    <string name="settings_notification_permission_grant">Conceder notificaciones</string>
+
+    <!-- Calendar opt-in card. Description preserves the privacy
+         disclosure ("descripciones, participantes y ubicaciones … nunca
+         salen del dispositivo"). Quotes around the nested example follow
+         the locale's „…" house style. -->
+    <string name="settings_calendar_title">Calendario</string>
+    <string name="settings_calendar_use_events">Usar los eventos del calendario de hoy</string>
+    <string name="settings_calendar_description_off">Si está activo, ClothesCast lee los eventos de hoy del calendario de tu dispositivo, para que tu ClothesCast matutino pueda sugerir prendas vinculadas a eventos concretos — por ejemplo „lleva un paraguas para tu carrera en el parque de las 15:00“. Solo se usan los títulos y horarios de los eventos; las descripciones, los participantes y las ubicaciones se leen, pero nunca salen del dispositivo.</string>
+    <string name="settings_calendar_description_on">Leyendo los eventos de hoy del calendario de tu dispositivo para enriquecer tu ClothesCast matutino. En el resumen solo se usan los títulos y los horarios; las descripciones y los participantes no. Todo se queda en el dispositivo.</string>
+    <string name="settings_calendar_grant_permission">Conceder acceso al calendario</string>
+    <string name="settings_calendar_open_settings">Acceso al calendario denegado. Concédelo en los ajustes del sistema.</string>
+
+    <!--
     Today screen — top bar, refresh toasts, empty state, generated-at
     timestamp, outfit card, hourly chart, confidence chip, work-status
     banner. Informal tú-form throughout: "toca", "tu", "configura".

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -11,6 +11,18 @@ Mexico-specific vocabulary overrides live in values-es-rMX.
     <string name="settings_tts_voice_locale_es_mx">Español (México)</string>
     <string name="settings_tts_voice_locale_label">Idioma</string>
 
+    <!-- Settings — top bar + root navigation list. -->
+    <string name="settings_title">Ajustes</string>
+    <string name="settings_back">Atrás</string>
+
+    <string name="settings_root_voice">Voz</string>
+    <string name="settings_root_schedule">Programación</string>
+    <string name="settings_root_region">Región</string>
+    <string name="settings_root_clothes">Ropa</string>
+    <string name="settings_root_api_keys">Claves API</string>
+    <string name="settings_root_data_sources">Fuentes de datos</string>
+    <string name="settings_root_about">Acerca de</string>
+
     <string name="garment_sweater">Jersey</string>
     <string name="garment_hoodie">Sudadera con capucha</string>
     <string name="garment_jacket">Chaqueta</string>
@@ -20,6 +32,10 @@ Mexico-specific vocabulary overrides live in values-es-rMX.
     <string name="garment_shorts">Pantalones cortos</string>
     <string name="garment_pants">Pantalones</string>
     <string name="garment_jeans">Vaqueros</string>
+
+    <!-- Clothes settings — top of the screen. -->
+    <string name="settings_clothes_title">Reglas de ropa</string>
+    <string name="settings_clothes_description">Si un pronóstico supera uno de estos umbrales, la prenda aparece en tu ClothesCast diario.</string>
 
     <string name="settings_clothes_empty">Sin reglas. Toca Añadir para crear una.</string>
     <string name="settings_clothes_add">Añadir</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -221,6 +221,25 @@ Mexico-specific vocabulary overrides live in values-es-rMX.
     <string name="settings_elevenlabs_key_clear">Borrar clave de ElevenLabs guardada</string>
 
     <!--
+    Location screen — device-location toggle, manual city search +
+    selection, and the "no location set" empty state.
+    -->
+    <string name="settings_location_title">Ubicación</string>
+    <string name="settings_location_use_device">Usar la ubicación del dispositivo</string>
+    <string name="settings_location_grant_background">Conceder ubicación en segundo plano (ajustes del sistema)</string>
+    <string name="settings_location_unset">Sin ubicación configurada — usando Londres como predeterminada</string>
+    <string name="settings_location_description">El pronóstico se obtiene para este lugar. Busca por nombre de ciudad; los resultados vienen del servicio gratuito de geocodificación de Open-Meteo.</string>
+    <string name="settings_location_description_device_on">Si está activo, ClothesCast lee la ubicación aproximada de tu dispositivo en el momento de la notificación (solo torre de telefonía / WiFi — sin GPS por hardware). La ubicación de abajo se usa como respaldo si la lectura del dispositivo falla. La ubicación en segundo plano debe concederse en los ajustes del sistema, o el Worker matutino no podrá leerla.</string>
+    <string name="settings_location_set">Establecer ubicación</string>
+    <string name="settings_location_change">Cambiar ubicación</string>
+    <string name="settings_location_clear">Borrar ubicación</string>
+    <string name="settings_location_search_title">Buscar una ubicación</string>
+    <string name="settings_location_query_label">Ciudad o lugar</string>
+    <string name="settings_location_search">Buscar</string>
+    <string name="settings_location_searching">Buscando…</string>
+    <string name="settings_location_no_results">Sin resultados.</string>
+
+    <!--
     Today screen — top bar, refresh toasts, empty state, generated-at
     timestamp, outfit card, hourly chart, confidence chip, work-status
     banner. Informal tú-form throughout: "toca", "tu", "configura".

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -274,6 +274,24 @@ Mexico-specific vocabulary overrides live in values-es-rMX.
     <string name="settings_calendar_grant_permission">Conceder acceso al calendario</string>
     <string name="settings_calendar_open_settings">Acceso al calendario denegado. Concédelo en los ajustes del sistema.</string>
 
+    <!-- Debug screen — visible only on debug builds. -->
+    <string name="settings_debug_title">Depuración (solo en builds de depuración)</string>
+    <string name="settings_debug_description">Lanza inmediatamente el pipeline del ClothesCast diario. Útil para verificar sin esperar a la hora programada.</string>
+    <string name="settings_debug_fire_now">Lanzar ClothesCast ahora</string>
+    <string name="settings_debug_fire_toast">Worker de ClothesCast en cola</string>
+
+    <!-- About screen — version line, build-type suffix, privacy summary,
+         outbound links / actions. -->
+    <string name="settings_about_title">Acerca de</string>
+    <string name="settings_about_version">Versión %1$s (%2$d)</string>
+    <string name="settings_about_build_type_suffix"> · build %1$s</string>
+    <string name="settings_about_privacy">Tu clave API de Gemini (usada para la lectura en voz alta TTS) se cifra en reposo con una clave vinculada al Android Keystore. Los pronósticos vienen de Open-Meteo (sin clave, sin cuenta); el texto del resumen diario se genera localmente en el dispositivo. ClothesCast no tiene backend — no se envía nada a ningún servidor que controlemos.</string>
+    <string name="settings_about_privacy_policy">Política de privacidad</string>
+    <string name="settings_about_source">Código fuente en GitHub</string>
+    <string name="settings_about_dontkillmyapp">Restricciones en segundo plano (dontkillmyapp.com)</string>
+    <string name="settings_about_share_bug_report">Compartir informe de error</string>
+    <string name="settings_about_version_copied">Versión copiada al portapapeles</string>
+
     <!--
     Today screen — top bar, refresh toasts, empty state, generated-at
     timestamp, outfit card, hourly chart, confidence chip, work-status

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -91,6 +91,33 @@ Mexico-specific vocabulary overrides live in values-es-rMX.
     <string name="widget_empty_title">Aún no hay outfit</string>
     <string name="widget_empty_subtitle">Toca para abrir ClothesCast</string>
 
+    <!--
+    Onboarding flow — first-run welcome, two permission steps, Gemini
+    API-key step. Welcome uses the gender-neutral "Te damos la
+    bienvenida" pattern (idiomatic Spanish app convention) so the
+    one-time greeting doesn't have to pick masc / fem on the user.
+    Buttons follow the Android Spanish convention of action-infinitives
+    ("Conceder notificaciones", "Continuar"); direct-address prose
+    stays in tú-form imperative ("Configura", "Concede", "Elige").
+    -->
+    <string name="onboarding_title">Te damos la bienvenida a ClothesCast</string>
+    <string name="onboarding_subtitle">Dos elecciones rápidas y ya está. Todo lo demás tiene un valor predeterminado razonable que podrás ajustar más tarde en los ajustes.</string>
+    <string name="onboarding_notifications_title">Notificaciones</string>
+    <string name="onboarding_notifications_description">Necesarias para entregar tu ClothesCast diario. Concédelas una vez y ClothesCast aparecerá mañana por la mañana.</string>
+    <string name="onboarding_notifications_grant">Conceder notificaciones</string>
+    <string name="onboarding_location_title">Ubicación</string>
+    <string name="onboarding_location_description">Se usa para obtener el pronóstico correcto. Si concedes la ubicación, ClothesCast podrá leer cada mañana la ubicación aproximada de tu dispositivo; si no, elige una ciudad manualmente.</string>
+    <string name="onboarding_location_grant">Conceder acceso a la ubicación</string>
+    <string name="onboarding_location_denied_hint">Acceso a la ubicación denegado. En su lugar puedes elegir una ciudad manualmente.</string>
+    <string name="onboarding_location_enter_manual">Introducir ubicación manualmente</string>
+    <string name="onboarding_location_using_device">Cada mañana usamos la ubicación de tu dispositivo.</string>
+
+    <string name="onboarding_gemini_title">Clave API de Gemini</string>
+    <string name="onboarding_gemini_description">ClothesCast la usa para las voces habladas y la generación del pronóstico. Consigue una gratis en aistudio.google.com. La clave se cifra en reposo usando el Android Keystore.</string>
+    <string name="onboarding_step_done">Hecho</string>
+    <string name="onboarding_skip">Omitir por ahora</string>
+    <string name="onboarding_continue">Continuar</string>
+
     <string name="insight_lead_today">Hoy</string>
     <string name="insight_lead_tonight">Esta noche</string>
     <string name="insight_band_single">%1$s hará %2$s.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1,8 +1,37 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-Spanish translation (Spain base). Scope: insight-prose templates, garment labels,
-clothes-rule editor, outfit-card labels, and region/voice-locale picker names.
-Mexico-specific vocabulary overrides live in values-es-rMX.
+Spanish translation (Spain base) — full UI coverage. Informal tú-form
+throughout (intimate / spousal register), matching the existing insight
+prose ("Lleva …", "Tu ClothesCast de hoy"). No usted-form anywhere.
+
+Mexico-specific vocabulary overrides live in values-es-rMX (suéter /
+playera / mezclilla / agregar / configuración / reportar).
+
+What is NOT overridden, by design:
+- `app_name` — brand identifier, identical across locales.
+- `insight_time_am` / `_pm` / `_midnight` / `_noon` (and *_minutes
+  variants) — English-only spoken-time formatter helpers. Spanish
+  locales use `insight_time_hour` / `_hour_minutes` ("15" / "15:30")
+  which are translated below; the AM/PM keys exist for the
+  `Locale.language == "en"` path only and would never be read in a
+  Spanish runtime.
+
+Spanish forces gender agreement on predicate adjectives in the tú-form;
+the welcome uses the gender-neutral "Te damos la bienvenida" (the
+standard Spanish app convention) and the subtitle uses the invariable
+"ya está" so a one-time greeting doesn't have to pick a gender for the
+user. Beyond those exceptions the rest stays in plain tú-form
+imperative ("Toca", "Configura", "Concede").
+
+Buttons follow the Android Spanish convention of action-infinitives
+("Conceder notificaciones", "Continuar", "Guardar"); direct-address
+prose stays in tú-form imperative.
+
+Picker labels under `settings_region_language_*` and
+`settings_tts_voice_locale_*` give the Spanish names for every offered
+locale (Inglés (Estados Unidos), Francés (Canadá), Chino
+(simplificado), …). The locale tag stored on disk (en-US / fr-CA /
+zh-CN) is unchanged; only the displayed label localizes.
 -->
 <resources>
     <string name="settings_region_language_es_es">Español (España)</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -55,6 +55,30 @@ Mexico-specific vocabulary overrides live in values-es-rMX.
     <string name="settings_clothes_cond_precip_above">cuando la probabilidad de lluvia supera %.0f%%</string>
 
     <!--
+    Schedule screen — daily and nightly ClothesCast cards, delivery
+    picker, "Mencionar eventos de la tarde" toggle, and the nightly-only
+    "notificar solo cuando haya eventos" toggle. Description uses
+    German-style „…" quotes around the nested toggle label, matching the
+    locale house style.
+    -->
+    <string name="settings_schedule_title">ClothesCast diario</string>
+    <string name="settings_schedule_time_label">Hora</string>
+    <string name="settings_schedule_days_label">Días de la semana</string>
+    <string name="settings_daily_mention_evening_events">Mencionar eventos de la tarde</string>
+
+    <string name="settings_tonight_title">ClothesCast nocturno</string>
+    <string name="settings_tonight_description">Un segundo ClothesCast por la tarde que cubre el tiempo de esta noche. En tardes tranquilas se queda silencioso, o no aparece en absoluto si „Notificar solo cuando haya eventos de la tarde“ está activado; en tardes con eventos reproduce un sonido y (si has activado la lectura en voz alta) se lee solo.</string>
+    <string name="settings_tonight_enabled">Mostrar un ClothesCast nocturno</string>
+    <string name="settings_tonight_time_label">Hora</string>
+    <string name="settings_tonight_days_label">Días de la semana</string>
+    <string name="settings_tonight_notify_only_on_events">Notificar solo cuando haya eventos de la tarde</string>
+
+    <string name="settings_delivery_label">Entrega</string>
+    <string name="settings_delivery_notification_only">Solo notificación</string>
+    <string name="settings_delivery_tts_only">Solo lectura en voz alta</string>
+    <string name="settings_delivery_notification_and_tts">Notificación y lectura en voz alta</string>
+
+    <!--
     Today screen — top bar, refresh toasts, empty state, generated-at
     timestamp, outfit card, hourly chart, confidence chip, work-status
     banner. Informal tú-form throughout: "toca", "tu", "configura".


### PR DESCRIPTION
## Summary

Spanish UI translation, mirroring the German / Croatian / Italian
passes. Twelve commits — ten surface-by-surface fills for the es-ES
baseline, one es-rMX override commit for Mexican vocabulary
divergences, plus a final header refresh.

The existing Spanish files already used informal tú-form throughout
("Lleva …", "Toca …", "Tu ClothesCast"), so no tone-fix commit was
needed.

## es-ES surfaces (commits 1–10)

- Today screen + home-screen widget
- Onboarding flow
- Settings root nav + Clothes section header
- Schedule screen (daily, nightly, delivery)
- Voice screen (engine + voice + language pickers)
- Region screen + Voice locale picker labels (28 locales × 2)
- API keys screen
- Location screen
- Notification channels + permission card + Calendar
- Debug + About screens

After this PR the es-ES file has 293 strings vs. 300 in the en-US
baseline; the seven gaps are the same deliberate non-overrides as the
prior locale PRs (`app_name` brand identifier + the six English-only
`insight_time_*` AM/PM helpers).

## es-rMX overrides (commit 11)

Adds Mexican-Spanish overrides only where vocabulary materially
diverges from peninsular Spanish:

- **"Ajustes" → "Configuración"** for Settings (mirrors platform
  Android es-rMX). Re-writes every es-ES sentence that embeds "los/las
  ajustes" so the Mexican prose flows naturally.
- **"Añadir" → "Agregar"** for "Add" (mirrors the existing
  `settings_clothes_add` override pattern, extended to the new
  TTS-engine "Add API key" affordances).
- **"Informar de un error" / "Compartir informe de error" → "Reportar
  un error" / "Compartir reporte de error"** for bug reports — both
  verb and noun forms.

The pre-existing es-rMX vocab (suéter / playera / mezclilla / agregar
on the clothes-rule editor) is left untouched. Everything else
(notifications, voice / region pickers, prose templates, units) reads
the same in both variants and falls through to the es-ES baseline
cleanly.

## Tone

tú-form throughout, intimate / spousal register matching the existing
insight prose. Spanish, like Italian and Croatian, forces gender
agreement on predicate adjectives in the tú-form; the welcome screen
uses the gender-neutral "Te damos la bienvenida" pattern (the standard
Spanish app convention) and the subtitle uses the invariable "ya está"
so a one-time greeting doesn't have to pick masc / fem on the user.
Buttons follow the Android Spanish convention of action-infinitives
("Conceder notificaciones", "Continuar", "Guardar"); direct-address
prose stays in tú-form imperative.

Brand "ClothesCast" stays verbatim throughout. Stale
`insight_calendar_tie_in` is left untouched in both files (fleet-wide
cleanup out of scope).

## Privacy

Display-only. No new strings cross the device boundary; the rendered
insight prose (the only thing fed to TTS / LLM endpoints) was already
fully Spanish via the existing `insight_*` translations.

## Test plan

- [ ] CI: `JVM unit tests` green (no Spanish tests pin specific prose
      so nothing to update; the Spanish `insight_*` cases the tests
      already pin live in untouched strings)
- [ ] CI: `Android debug build` green
- [ ] Manual: phone in es-ES (or **Region: Español (España)**) → walk
      every screen and confirm Spanish tú-form throughout, no English
      fall-through; Settings reads "Ajustes"
- [ ] Manual: phone in es-MX (or **Region: Español (México)**) →
      Settings reads "Configuración", "Agregar" appears where Spain
      Spanish has "Añadir", bug-report copy reads "Reportar"

https://claude.ai/code/session_01C1Q3vzGj6KmbYDfD6b2yhu

---
_Generated by [Claude Code](https://claude.ai/code/session_015agXppcN2fzATq5Xnzpozs)_