### PR TITLE
:app — French UI: full tu-form pass + fr-rCA Quebec overrides

### DIFF
--- a/app/src/main/res/values-fr-rCA/strings.xml
+++ b/app/src/main/res/values-fr-rCA/strings.xml
@@ -8,4 +8,15 @@ falls through to the base French translation.
     <!-- "Chandail" is the standard Quebec word; "pull" (France) sounds foreign. -->
     <string name="garment_sweater">Chandail</string>
     <string name="today_outfit_top_sweater">Chandail</string>
+
+    <!-- Quebec French uses "bogue" for software bugs where France French
+         carries the English loanword "bug". Both verb-form ("signaler
+         un bogue") and noun-form ("rapport de bogue") covered. -->
+    <string name="today_report_a_bug">Signaler un bogue</string>
+    <string name="settings_about_share_bug_report">Partager un rapport de bogue</string>
+
+    <!-- Quebec French spells the imperial mile "Mille" (plur. "Milles");
+         France carries the English loan "Miles" since the unit is
+         basically only used in en-imported software. -->
+    <string name="settings_distance_unit_miles">Milles</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -244,6 +244,41 @@ agreement; garment names are listed without articles and read naturally in conte
     <string name="settings_location_no_results">Aucun résultat.</string>
 
     <!--
+    Notification channels (system Settings → App → Notifications) and
+    the per-channel notification titles. Three channels: daily, nightly
+    (default + silent variants), weather alerts.
+    -->
+    <string name="notification_channel_daily_insight_name">ClothesCast quotidien</string>
+    <string name="notification_channel_daily_insight_description">Le résumé météo matinal que tu as activé.</string>
+    <string name="notification_daily_insight_title">Météo d\'aujourd\'hui</string>
+
+    <string name="notification_channel_tonight_insight_default_name">ClothesCast nocturne (avec événements)</string>
+    <string name="notification_channel_tonight_insight_default_description">Le résumé météo du soir quand tu as des événements ce soir dans ton calendrier. Joue ton son de notification par défaut.</string>
+    <string name="notification_channel_tonight_insight_silent_name">ClothesCast nocturne (silencieux)</string>
+    <string name="notification_channel_tonight_insight_silent_description">Le résumé météo du soir quand ta soirée est libre. Envoyé en silence — tu peux y jeter un œil sur l\'écran de verrouillage, mais aucun son ne sera émis.</string>
+    <string name="notification_tonight_insight_title">Météo de ce soir</string>
+
+    <string name="notification_channel_weather_alerts_name">Alertes météo</string>
+    <string name="notification_channel_weather_alerts_description">Alertes haute priorité pour les phénomènes météo graves ou extrêmes dans ta région. Envoyées dès que la récupération quotidienne les détecte.</string>
+    <string name="notification_weather_alert_title">Alerte météo : %1$s</string>
+
+    <!-- Notification-permission card. -->
+    <string name="settings_notification_permission_title">Les notifications sont bloquées</string>
+    <string name="settings_notification_permission_description">Sans autorisation de notifications, ton ClothesCast quotidien n\'a nulle part où aller. Autorise-les pour que ClothesCast puisse apparaître demain matin.</string>
+    <string name="settings_notification_permission_grant">Autoriser les notifications</string>
+
+    <!-- Calendar opt-in card. Description preserves the privacy
+         disclosure ("les descriptions, les participants et les lieux …
+         ne quittent jamais l'appareil"). Quotes around the nested
+         example follow the locale's „…" house style. -->
+    <string name="settings_calendar_title">Calendrier</string>
+    <string name="settings_calendar_use_events">Utiliser les événements du calendrier d\'aujourd\'hui</string>
+    <string name="settings_calendar_description_off">Quand activé, ClothesCast lit les événements d\'aujourd\'hui depuis le calendrier de ton appareil, pour que ton ClothesCast matinal puisse suggérer des vêtements liés à des événements précis — par exemple „prends un parapluie pour ta course au parc de 15 h“. Seuls les titres et les horaires des événements sont utilisés ; les descriptions, les participants et les lieux sont lus, mais ne quittent jamais l\'appareil.</string>
+    <string name="settings_calendar_description_on">Lecture des événements d\'aujourd\'hui depuis le calendrier de ton appareil, pour enrichir ton ClothesCast matinal. Seuls les titres et les horaires sont utilisés dans le résumé ; les descriptions et les participants non. Tout reste sur l\'appareil.</string>
+    <string name="settings_calendar_grant_permission">Autoriser l\'accès au calendrier</string>
+    <string name="settings_calendar_open_settings">Accès au calendrier refusé. Autorise-le dans les paramètres du système.</string>
+
+    <!--
     Today screen — top bar, refresh toasts, empty state, generated-at
     timestamp, outfit card, hourly chart, confidence chip, work-status
     banner. tu-form throughout: "appuie", "ton", "définis".

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -128,7 +128,7 @@ zh-CN) is unchanged; only the displayed label localizes.
 
     <string name="settings_tts_test">Tester la voix</string>
     <string name="settings_tts_test_in_flight">Test en cours — patiente…</string>
-    <string name="settings_tts_no_key_hint">Aucune clé %1$s configurée — ajoutes-en une pour activer ce moteur.</string>
+    <string name="settings_tts_no_key_hint">Aucune clé %1$s configurée — ajoute-en une pour activer ce moteur.</string>
     <string name="settings_tts_add_api_key">Ajouter une clé API</string>
     <string name="settings_tts_add_api_key_title">Ajouter une clé API %1$s</string>
     <string name="settings_tts_add_api_key_save">Enregistrer</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -15,6 +15,18 @@ agreement; garment names are listed without articles and read naturally in conte
     <string name="settings_tts_voice_locale_fr_ca">Français (Canada)</string>
     <string name="settings_tts_voice_locale_label">Langue</string>
 
+    <!-- Settings — top bar + root navigation list. -->
+    <string name="settings_title">Paramètres</string>
+    <string name="settings_back">Retour</string>
+
+    <string name="settings_root_voice">Voix</string>
+    <string name="settings_root_schedule">Programmation</string>
+    <string name="settings_root_region">Région</string>
+    <string name="settings_root_clothes">Vêtements</string>
+    <string name="settings_root_api_keys">Clés API</string>
+    <string name="settings_root_data_sources">Sources de données</string>
+    <string name="settings_root_about">À propos</string>
+
     <string name="garment_sweater">Pull</string>
     <string name="garment_hoodie">Sweat à capuche</string>
     <string name="garment_jacket">Veste</string>
@@ -24,6 +36,10 @@ agreement; garment names are listed without articles and read naturally in conte
     <string name="garment_shorts">Short</string>
     <string name="garment_pants">Pantalon</string>
     <string name="garment_jeans">Jean</string>
+
+    <!-- Clothes settings — top of the screen. -->
+    <string name="settings_clothes_title">Règles vestimentaires</string>
+    <string name="settings_clothes_description">Si une prévision dépasse l\'un de ces seuils, le vêtement apparaît dans ton ClothesCast quotidien.</string>
 
     <string name="settings_clothes_empty">Aucune règle. Appuie sur Ajouter pour en créer une.</string>
     <string name="settings_clothes_add">Ajouter</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1,12 +1,39 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-French translation. Tone is informal "tu" form throughout (intimate /
-spousal register), matching the spouse-style register the user wants.
-Avoid formal "vous" form ("Portez", "Prenez", "Appuyez", "Votre")
-that earlier passes accidentally mixed in.
+French translation (France base) — full UI coverage. Informal tu-form
+throughout (intimate / spousal register). No vous-form anywhere.
 
-Note: articles are omitted from insight_clothes_article_* to avoid gender
-agreement; garment names are listed without articles and read naturally in context.
+Quebec-specific vocabulary overrides live in values-fr-rCA (chandail /
+bogue / Milles).
+
+What is NOT overridden, by design:
+- `app_name` — brand identifier, identical across locales.
+- `insight_time_am` / `_pm` / `_midnight` / `_noon` (and *_minutes
+  variants) — English-only spoken-time formatter helpers. French
+  locales use `insight_time_hour` / `_hour_minutes` ("15h" / "15h30")
+  which are translated below; the AM/PM keys exist for the
+  `Locale.language == "en"` path only and would never be read in a
+  French runtime.
+
+French forces gender agreement on past-participle adjectives in the
+tu-form; the welcome leans on "Bienvenue" (invariable interjection)
+and the subtitle uses "c'est prêt" (invariable) so a one-time greeting
+doesn't have to pick masc / fem on the user. Beyond those, the rest
+stays in plain tu-form imperative ("Définis", "Accorde", "Choisis").
+
+Buttons follow the Android French convention of action-infinitives
+("Autoriser les notifications", "Continuer", "Enregistrer"); direct-
+address prose stays in tu-form imperative.
+
+Articles are omitted from insight_clothes_article_* to avoid gender
+agreement on garment names; a flat list ("Porte pull, veste") reads
+naturally in context.
+
+Picker labels under `settings_region_language_*` and
+`settings_tts_voice_locale_*` give the French names for every offered
+locale (Anglais (États-Unis), Espagnol (Mexique), Chinois
+(simplifié), …). The locale tag stored on disk (en-US / fr-CA /
+zh-CN) is unchanged; only the displayed label localizes.
 -->
 <resources>
     <string name="settings_region_language_fr_fr">Français (France)</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -59,6 +59,30 @@ agreement; garment names are listed without articles and read naturally in conte
     <string name="settings_clothes_cond_precip_above">quand le risque de pluie dépasse %.0f%%</string>
 
     <!--
+    Schedule screen — daily and nightly ClothesCast cards, delivery
+    picker, "Mentionner les événements du soir" toggle, and the
+    nightly-only "notify only on events" toggle. Description uses
+    German-style „…" quotes around the nested toggle label, matching
+    the locale house style.
+    -->
+    <string name="settings_schedule_title">ClothesCast quotidien</string>
+    <string name="settings_schedule_time_label">Heure</string>
+    <string name="settings_schedule_days_label">Jours de la semaine</string>
+    <string name="settings_daily_mention_evening_events">Mentionner les événements du soir</string>
+
+    <string name="settings_tonight_title">ClothesCast nocturne</string>
+    <string name="settings_tonight_description">Un second ClothesCast le soir qui couvre la météo de ce soir. Les soirs tranquilles, il reste silencieux, ou n\'apparaît pas du tout si „Notifier uniquement les soirs avec événements“ est activé ; les soirs avec événements, il joue un son et (si tu as activé la lecture à voix haute) se lit tout seul.</string>
+    <string name="settings_tonight_enabled">Afficher un ClothesCast nocturne</string>
+    <string name="settings_tonight_time_label">Heure</string>
+    <string name="settings_tonight_days_label">Jours de la semaine</string>
+    <string name="settings_tonight_notify_only_on_events">Notifier uniquement les soirs avec événements</string>
+
+    <string name="settings_delivery_label">Diffusion</string>
+    <string name="settings_delivery_notification_only">Notification seule</string>
+    <string name="settings_delivery_tts_only">Lecture à voix haute seule</string>
+    <string name="settings_delivery_notification_and_tts">Notification et lecture à voix haute</string>
+
+    <!--
     Today screen — top bar, refresh toasts, empty state, generated-at
     timestamp, outfit card, hourly chart, confidence chip, work-status
     banner. tu-form throughout: "appuie", "ton", "définis".

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -196,6 +196,35 @@ agreement; garment names are listed without articles and read naturally in conte
     <string name="settings_tts_voice_locale_fa_ir">Persan (Iran)</string>
 
     <!--
+    API keys screen — three identical-shape blocks (Gemini, OpenAI,
+    ElevenLabs), each with status copy, paste-key placeholder, and
+    save / clear buttons. URLs stay verbatim.
+    -->
+    <string name="settings_api_keys_title">Clés API</string>
+    <string name="settings_api_keys_description">Configure les clés API pour les moteurs vocaux en ligne que tu veux utiliser. Les clés sont chiffrées au repos avec l\'Android Keystore.</string>
+    <string name="settings_api_key_gemini_label">Gemini</string>
+    <string name="settings_api_key_openai_label">OpenAI</string>
+    <string name="settings_api_key_elevenlabs_label">ElevenLabs</string>
+
+    <string name="settings_api_key_status_set">Une clé Gemini est configurée.</string>
+    <string name="settings_api_key_status_unset">Aucune clé Gemini configurée. Obtiens-en une sur aistudio.google.com pour utiliser les voix Gemini.</string>
+    <string name="settings_api_key_placeholder">Colle ta clé API Gemini</string>
+    <string name="settings_api_key_save">Enregistrer la clé Gemini</string>
+    <string name="settings_api_key_clear">Effacer la clé Gemini enregistrée</string>
+
+    <string name="settings_openai_key_status_set">Une clé OpenAI est configurée.</string>
+    <string name="settings_openai_key_status_unset">Aucune clé OpenAI configurée. Obtiens-en une sur platform.openai.com pour utiliser les voix OpenAI.</string>
+    <string name="settings_openai_key_placeholder">Colle ta clé API OpenAI</string>
+    <string name="settings_openai_key_save">Enregistrer la clé OpenAI</string>
+    <string name="settings_openai_key_clear">Effacer la clé OpenAI enregistrée</string>
+
+    <string name="settings_elevenlabs_key_status_set">Une clé ElevenLabs est configurée.</string>
+    <string name="settings_elevenlabs_key_status_unset">Aucune clé ElevenLabs configurée. Obtiens-en une sur elevenlabs.io pour utiliser les voix ElevenLabs.</string>
+    <string name="settings_elevenlabs_key_placeholder">Colle ta clé API ElevenLabs</string>
+    <string name="settings_elevenlabs_key_save">Enregistrer la clé ElevenLabs</string>
+    <string name="settings_elevenlabs_key_clear">Effacer la clé ElevenLabs enregistrée</string>
+
+    <!--
     Today screen — top bar, refresh toasts, empty state, generated-at
     timestamp, outfit card, hourly chart, confidence chip, work-status
     banner. tu-form throughout: "appuie", "ton", "définis".

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-French translation. Scope: insight-prose templates, garment labels, clothes-rule
-editor, outfit-card labels, and region/voice-locale picker names. The rest of the
-UI falls through to values/strings.xml (English) until a follow-up PR fills it in.
+French translation. Tone is informal "tu" form throughout (intimate /
+spousal register), matching the spouse-style register the user wants.
+Avoid formal "vous" form ("Portez", "Prenez", "Appuyez", "Votre")
+that earlier passes accidentally mixed in.
 
 Note: articles are omitted from insight_clothes_article_* to avoid gender
 agreement; garment names are listed without articles and read naturally in context.
@@ -24,7 +25,7 @@ agreement; garment names are listed without articles and read naturally in conte
     <string name="garment_pants">Pantalon</string>
     <string name="garment_jeans">Jean</string>
 
-    <string name="settings_clothes_empty">Aucune règle. Appuyez sur Ajouter pour en créer une.</string>
+    <string name="settings_clothes_empty">Aucune règle. Appuie sur Ajouter pour en créer une.</string>
     <string name="settings_clothes_add">Ajouter</string>
     <string name="settings_clothes_edit">Modifier</string>
     <string name="settings_clothes_delete">Supprimer</string>
@@ -60,7 +61,7 @@ agreement; garment names are listed without articles and read naturally in conte
     <string name="insight_delta_warmer">Il fera %1$d° de plus aujourd\'hui.</string>
     <string name="insight_delta_cooler">Il fera %1$d° de moins aujourd\'hui.</string>
     <string name="insight_alert">Alerte : %1$s.</string>
-    <string name="insight_clothes_wear">Portez %1$s.</string>
+    <string name="insight_clothes_wear">Porte %1$s.</string>
     <!-- Articles omitted — French gender agreement can\'t be resolved without
          per-garment metadata; a flat list reads naturally ("Portez pull, veste"). -->
     <string name="insight_clothes_article_a">%1$s</string>
@@ -80,11 +81,11 @@ agreement; garment names are listed without articles and read naturally in conte
     <string name="insight_condition_thunderstorm">Orage</string>
     <string name="insight_condition_unknown">Inconnu</string>
     <string name="insight_calendar_tie_in">Prenez %1$s pour votre %3$s de %2$s.</string>
-    <string name="insight_tie_in">Prenez %1$s ce soir.</string>
-    <string name="insight_tie_in_with_rain">Prenez %1$s ce soir, pluie à %2$s.</string>
+    <string name="insight_tie_in">Prends %1$s ce soir.</string>
+    <string name="insight_tie_in_with_rain">Prends %1$s ce soir, pluie à %2$s.</string>
     <!-- "15h" / "15h30" — French TTS reads as "quinze heures" / "quinze heures trente". -->
     <string name="insight_time_hour">%1$dh</string>
     <string name="insight_time_hour_minutes">%1$dh%2$02d</string>
 
-    <string name="settings_tts_test_sample">Votre ClothesCast d\'aujourd\'hui : doux, avec de la pluie à 15 h. Portez une veste.</string>
+    <string name="settings_tts_test_sample">Ton ClothesCast d\'aujourd\'hui : doux, avec de la pluie à 15 h. Porte une veste.</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -108,6 +108,94 @@ agreement; garment names are listed without articles and read naturally in conte
     <string name="settings_tts_add_api_key_cancel">Annuler</string>
 
     <!--
+    Region screen — language picker title + caption (the disambiguation
+    copy explaining that this knob is the *displayed text*, not the
+    spoken accent), the system-default option, and the per-locale
+    labels in French style ("Anglais (États-Unis)", "Espagnol
+    (Mexique)", "Chinois (simplifié)", …). The locale tag stored on
+    disk (en-US / fr-CA / zh-CN) is unchanged; only the displayed
+    label localizes.
+    -->
+    <string name="settings_region_language_title">Langue</string>
+    <string name="settings_region_language_description">Définit la langue du texte affiché et des notifications.</string>
+    <string name="settings_region_language_system">Suivre les paramètres régionaux du système</string>
+    <string name="settings_region_language_en_us">Anglais (États-Unis)</string>
+    <string name="settings_region_language_en_gb">Anglais (Royaume-Uni)</string>
+    <string name="settings_region_language_en_au">Anglais (Australie)</string>
+    <string name="settings_region_language_en_ca">Anglais (Canada)</string>
+    <string name="settings_region_language_en_za">Anglais (Afrique du Sud)</string>
+    <string name="settings_region_language_de_de">Allemand (Allemagne)</string>
+    <string name="settings_region_language_it_it">Italien (Italie)</string>
+    <string name="settings_region_language_es_es">Espagnol (Espagne)</string>
+    <string name="settings_region_language_es_mx">Espagnol (Mexique)</string>
+    <string name="settings_region_language_ru_ru">Russe (Russie)</string>
+    <string name="settings_region_language_pl_pl">Polonais (Pologne)</string>
+    <string name="settings_region_language_hr_hr">Croate (Croatie)</string>
+    <string name="settings_region_language_uk_ua">Ukrainien (Ukraine)</string>
+    <string name="settings_region_language_pt_br">Portugais (Brésil)</string>
+    <string name="settings_region_language_nl_nl">Néerlandais (Pays-Bas)</string>
+    <string name="settings_region_language_sv_se">Suédois (Suède)</string>
+    <string name="settings_region_language_tr_tr">Turc (Turquie)</string>
+    <string name="settings_region_language_id_id">Indonésien (Indonésie)</string>
+    <string name="settings_region_language_fil_ph">Filipino (Philippines)</string>
+    <string name="settings_region_language_vi_vn">Vietnamien (Vietnam)</string>
+    <string name="settings_region_language_zh_cn">Chinois (simplifié)</string>
+    <string name="settings_region_language_hi_in">Hindi (Inde)</string>
+    <string name="settings_region_language_bn_bd">Bengali (Bangladesh)</string>
+    <string name="settings_region_language_ja_jp">Japonais (Japon)</string>
+    <string name="settings_region_language_ko_kr">Coréen (Corée du Sud)</string>
+    <string name="settings_region_language_ar_sa">Arabe (Arabie saoudite)</string>
+    <string name="settings_region_language_he_il">Hébreu (Israël)</string>
+    <string name="settings_region_language_fa_ir">Persan (Iran)</string>
+
+    <!-- Region screen — units pickers (Temperature: Celsius / Fahrenheit;
+         Distance: Kilomètres / Miles). The unit symbols (°C, °F) stay
+         unchanged. -->
+    <string name="settings_temperature_unit_title">Unité de température</string>
+    <string name="settings_temperature_unit_celsius">Celsius (°C)</string>
+    <string name="settings_temperature_unit_fahrenheit">Fahrenheit (°F)</string>
+    <string name="settings_distance_unit_title">Unité de distance</string>
+    <string name="settings_distance_unit_kilometers">Kilomètres</string>
+    <string name="settings_distance_unit_miles">Miles</string>
+
+    <!--
+    Voice locale picker labels — same French language-name translations
+    as the Region picker above, just keyed under
+    `settings_tts_voice_locale_*` because the Voice screen's language
+    sub-picker is a separate UI surface. The two pickers steer different
+    things: Region is the *displayed text*, Voice locale is the *spoken
+    accent*.
+    -->
+    <string name="settings_tts_voice_locale_en_us">Anglais (États-Unis)</string>
+    <string name="settings_tts_voice_locale_en_gb">Anglais (Royaume-Uni)</string>
+    <string name="settings_tts_voice_locale_en_au">Anglais (Australie)</string>
+    <string name="settings_tts_voice_locale_en_ca">Anglais (Canada)</string>
+    <string name="settings_tts_voice_locale_en_za">Anglais (Afrique du Sud)</string>
+    <string name="settings_tts_voice_locale_de_de">Allemand (Allemagne)</string>
+    <string name="settings_tts_voice_locale_it_it">Italien (Italie)</string>
+    <string name="settings_tts_voice_locale_es_es">Espagnol (Espagne)</string>
+    <string name="settings_tts_voice_locale_es_mx">Espagnol (Mexique)</string>
+    <string name="settings_tts_voice_locale_ru_ru">Russe (Russie)</string>
+    <string name="settings_tts_voice_locale_pl_pl">Polonais (Pologne)</string>
+    <string name="settings_tts_voice_locale_hr_hr">Croate (Croatie)</string>
+    <string name="settings_tts_voice_locale_uk_ua">Ukrainien (Ukraine)</string>
+    <string name="settings_tts_voice_locale_pt_br">Portugais (Brésil)</string>
+    <string name="settings_tts_voice_locale_nl_nl">Néerlandais (Pays-Bas)</string>
+    <string name="settings_tts_voice_locale_sv_se">Suédois (Suède)</string>
+    <string name="settings_tts_voice_locale_tr_tr">Turc (Turquie)</string>
+    <string name="settings_tts_voice_locale_id_id">Indonésien (Indonésie)</string>
+    <string name="settings_tts_voice_locale_fil_ph">Filipino (Philippines)</string>
+    <string name="settings_tts_voice_locale_vi_vn">Vietnamien (Vietnam)</string>
+    <string name="settings_tts_voice_locale_zh_cn">Chinois (simplifié)</string>
+    <string name="settings_tts_voice_locale_hi_in">Hindi (Inde)</string>
+    <string name="settings_tts_voice_locale_bn_bd">Bengali (Bangladesh)</string>
+    <string name="settings_tts_voice_locale_ja_jp">Japonais (Japon)</string>
+    <string name="settings_tts_voice_locale_ko_kr">Coréen (Corée du Sud)</string>
+    <string name="settings_tts_voice_locale_ar_sa">Arabe (Arabie saoudite)</string>
+    <string name="settings_tts_voice_locale_he_il">Hébreu (Israël)</string>
+    <string name="settings_tts_voice_locale_fa_ir">Persan (Iran)</string>
+
+    <!--
     Today screen — top bar, refresh toasts, empty state, generated-at
     timestamp, outfit card, hourly chart, confidence chip, work-status
     banner. tu-form throughout: "appuie", "ton", "définis".

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -96,6 +96,32 @@ agreement; garment names are listed without articles and read naturally in conte
     <string name="widget_empty_title">Pas encore de tenue</string>
     <string name="widget_empty_subtitle">Appuie pour ouvrir ClothesCast</string>
 
+    <!--
+    Onboarding flow — first-run welcome, two permission steps, Gemini
+    API-key step. Welcome uses "Bienvenue" (invariable, sidesteps gender
+    agreement that "Bienvenu/e" would force) and the subtitle uses
+    "c'est prêt" (invariable) for "you're set". Buttons follow the
+    Android French convention of action-infinitives ("Autoriser …",
+    "Continuer"); direct-address prose stays in tu-form imperative.
+    -->
+    <string name="onboarding_title">Bienvenue dans ClothesCast</string>
+    <string name="onboarding_subtitle">Deux choix rapides et c\'est prêt. Tout le reste a une valeur par défaut sensée que tu pourras ajuster plus tard dans les paramètres.</string>
+    <string name="onboarding_notifications_title">Notifications</string>
+    <string name="onboarding_notifications_description">Nécessaires pour livrer ton ClothesCast quotidien. Accorde-les une fois, et ClothesCast apparaîtra demain matin.</string>
+    <string name="onboarding_notifications_grant">Autoriser les notifications</string>
+    <string name="onboarding_location_title">Position</string>
+    <string name="onboarding_location_description">Utilisée pour récupérer les bonnes prévisions. Si tu accordes la position, ClothesCast peut lire chaque matin la position approximative de ton appareil ; sinon choisis une ville manuellement.</string>
+    <string name="onboarding_location_grant">Autoriser l\'accès à la position</string>
+    <string name="onboarding_location_denied_hint">Accès à la position refusé. Tu peux choisir une ville manuellement à la place.</string>
+    <string name="onboarding_location_enter_manual">Saisir la position manuellement</string>
+    <string name="onboarding_location_using_device">Chaque matin, on utilise la position de ton appareil.</string>
+
+    <string name="onboarding_gemini_title">Clé API Gemini</string>
+    <string name="onboarding_gemini_description">Utilisée par ClothesCast pour les voix lues à voix haute et la génération des prévisions. Obtiens-en une gratuitement sur aistudio.google.com. La clé est chiffrée au repos avec l\'Android Keystore.</string>
+    <string name="onboarding_step_done">Terminé</string>
+    <string name="onboarding_skip">Passer pour l\'instant</string>
+    <string name="onboarding_continue">Continuer</string>
+
     <string name="insight_lead_today">Aujourd\'hui</string>
     <string name="insight_lead_tonight">Ce soir</string>
     <string name="insight_band_single">%1$s, il fera %2$s.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -83,6 +83,31 @@ agreement; garment names are listed without articles and read naturally in conte
     <string name="settings_delivery_notification_and_tts">Notification et lecture à voix haute</string>
 
     <!--
+    Voice screen — engine picker (Device / Gemini / OpenAI / ElevenLabs),
+    voice + language sub-pickers, test-voice button, missing-API-key
+    hint and the in-line "Ajouter une clé API" dialog.
+    -->
+    <string name="settings_tts_engine_title">Moteur vocal</string>
+    <string name="settings_tts_engine_description">Les moteurs en ligne (Gemini, OpenAI, ElevenLabs) sonnent beaucoup plus naturels, mais nécessitent un appel réseau au moment de parler et utilisent ta clé API pour la synthèse (un court appel par ClothesCast lu). Bascule sur la voix de l\'appareil si le moteur choisi échoue.</string>
+    <string name="settings_tts_engine_device">Appareil (hors ligne, gratuit)</string>
+    <string name="settings_tts_engine_gemini">Gemini (haute qualité, en ligne)</string>
+    <string name="settings_tts_engine_openai">OpenAI (haute qualité, en ligne)</string>
+    <string name="settings_tts_engine_elevenlabs">ElevenLabs (qualité maximale, en ligne)</string>
+
+    <string name="settings_tts_voice_label">Voix</string>
+    <string name="settings_tts_voice_dismiss">Terminé</string>
+    <string name="settings_tts_voice_locale_description">Définit l\'accent de la voix parlée. Ne change pas le texte affiché.</string>
+    <string name="settings_tts_voice_locale_system">Suivre la langue du téléphone</string>
+
+    <string name="settings_tts_test">Tester la voix</string>
+    <string name="settings_tts_test_in_flight">Test en cours — patiente…</string>
+    <string name="settings_tts_no_key_hint">Aucune clé %1$s configurée — ajoutes-en une pour activer ce moteur.</string>
+    <string name="settings_tts_add_api_key">Ajouter une clé API</string>
+    <string name="settings_tts_add_api_key_title">Ajouter une clé API %1$s</string>
+    <string name="settings_tts_add_api_key_save">Enregistrer</string>
+    <string name="settings_tts_add_api_key_cancel">Annuler</string>
+
+    <!--
     Today screen — top bar, refresh toasts, empty state, generated-at
     timestamp, outfit card, hourly chart, confidence chip, work-status
     banner. tu-form throughout: "appuie", "ton", "définis".

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -42,11 +42,59 @@ agreement; garment names are listed without articles and read naturally in conte
     <string name="settings_clothes_cond_temp_above">quand la température ressentie est au-dessus de %.0f°C</string>
     <string name="settings_clothes_cond_precip_above">quand le risque de pluie dépasse %.0f%%</string>
 
+    <!--
+    Today screen — top bar, refresh toasts, empty state, generated-at
+    timestamp, outfit card, hourly chart, confidence chip, work-status
+    banner. tu-form throughout: "appuie", "ton", "définis".
+    -->
+    <string name="today_title">Aujourd\'hui</string>
+    <string name="today_open_settings">Ouvrir les paramètres</string>
+    <string name="today_more_options">Plus d\'options</string>
+    <string name="today_report_a_bug">Signaler un bug</string>
+    <string name="today_refresh">Actualiser</string>
+    <string name="today_refresh_toast_daily">Actualisation de ton ClothesCast quotidien — il apparaîtra bientôt.</string>
+    <string name="today_refresh_toast_nightly">Actualisation de ton ClothesCast nocturne — il apparaîtra bientôt.</string>
+    <string name="today_empty_title">Pas encore de ClothesCast</string>
+    <string name="today_empty_subtitle">Ton ClothesCast matinal apparaîtra ici dès qu\'il sera généré. Définis ta position dans les paramètres, puis appuie sur Récupérer maintenant.</string>
+    <string name="today_fetch_now">Récupérer maintenant</string>
+    <string name="today_generated_at">Généré à %1$s</string>
+
+    <string name="today_outfit_title">Que porter</string>
+    <string name="today_outfit_label_today">Aujourd\'hui</string>
+    <string name="today_outfit_label_tonight">Ce soir</string>
+    <string name="today_outfit_label_tomorrow">Demain</string>
+
     <string name="today_outfit_top_tshirt">T-shirt</string>
     <string name="today_outfit_top_sweater">Pull</string>
     <string name="today_outfit_top_thick_jacket">Manteau épais</string>
     <string name="today_outfit_bottom_shorts">Short</string>
     <string name="today_outfit_bottom_long_pants">Pantalon</string>
+
+    <string name="today_forecast_title">Prévisions horaires</string>
+    <string name="today_forecast_min_max">Ressenti %1$d – %2$d%3$s · Air %4$d – %5$d%6$s</string>
+    <string name="today_forecast_legend_feels_like">Température ressentie (%1$s) par heure · appuie pour la température de l\'air</string>
+    <string name="today_forecast_legend_air">Température de l\'air (%1$s) par heure · appuie pour la température ressentie</string>
+
+    <string name="today_confidence_high">Confiance élevée — les principaux modèles s\'accordent</string>
+    <string name="today_confidence_medium">Confiance moyenne</string>
+    <string name="today_confidence_low">Confiance faible — les prévisions divergent</string>
+    <string name="today_confidence_spread">Dispersion : %1$.1f°C, %2$.0fpp de précipitations sur %3$d modèles</string>
+
+    <string name="today_working">Récupération de ton ClothesCast…</string>
+    <string name="today_failed_title">Dernière tentative échouée</string>
+    <string name="today_failed_unexpected_http">Erreur HTTP inattendue du service de prévisions.</string>
+    <string name="today_failed_unhandled">Une erreur inattendue s\'est produite.</string>
+    <string name="today_failed_show_details">Afficher les détails</string>
+    <string name="today_failed_hide_details">Masquer les détails</string>
+
+    <!-- Home-screen App Widget. "Tenue" is the standard French word
+         (French generally translates rather than loanwords for
+         everyday concepts; the Académie convention discourages
+         "outfit" as loanword in this context). -->
+    <string name="widget_label">Tenue</string>
+    <string name="widget_description">La tenue de la période actuelle en un coup d\'œil.</string>
+    <string name="widget_empty_title">Pas encore de tenue</string>
+    <string name="widget_empty_subtitle">Appuie pour ouvrir ClothesCast</string>
 
     <string name="insight_lead_today">Aujourd\'hui</string>
     <string name="insight_lead_tonight">Ce soir</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -225,6 +225,25 @@ agreement; garment names are listed without articles and read naturally in conte
     <string name="settings_elevenlabs_key_clear">Effacer la clé ElevenLabs enregistrée</string>
 
     <!--
+    Location screen — device-location toggle, manual city search +
+    selection, and the "no location set" empty state.
+    -->
+    <string name="settings_location_title">Position</string>
+    <string name="settings_location_use_device">Utiliser la position de l\'appareil</string>
+    <string name="settings_location_grant_background">Autoriser la position en arrière-plan (paramètres du système)</string>
+    <string name="settings_location_unset">Aucune position définie — Londres par défaut</string>
+    <string name="settings_location_description">Les prévisions sont récupérées pour ce lieu. Recherche par nom de ville ; les résultats proviennent du service de géocodage gratuit d\'Open-Meteo.</string>
+    <string name="settings_location_description_device_on">Quand activé, ClothesCast lit la position approximative de ton appareil au moment de la notification (antenne mobile / WiFi uniquement — pas de localisation GPS matérielle). La position ci-dessous sert de secours si la lecture sur l\'appareil échoue. La position en arrière-plan doit être autorisée dans les paramètres du système, sinon le Worker matinal ne peut pas la lire.</string>
+    <string name="settings_location_set">Définir la position</string>
+    <string name="settings_location_change">Changer de position</string>
+    <string name="settings_location_clear">Effacer la position</string>
+    <string name="settings_location_search_title">Rechercher une position</string>
+    <string name="settings_location_query_label">Ville ou lieu</string>
+    <string name="settings_location_search">Rechercher</string>
+    <string name="settings_location_searching">Recherche…</string>
+    <string name="settings_location_no_results">Aucun résultat.</string>
+
+    <!--
     Today screen — top bar, refresh toasts, empty state, generated-at
     timestamp, outfit card, hourly chart, confidence chip, work-status
     banner. tu-form throughout: "appuie", "ton", "définis".

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -278,6 +278,24 @@ agreement; garment names are listed without articles and read naturally in conte
     <string name="settings_calendar_grant_permission">Autoriser l\'accès au calendrier</string>
     <string name="settings_calendar_open_settings">Accès au calendrier refusé. Autorise-le dans les paramètres du système.</string>
 
+    <!-- Debug screen — visible only on debug builds. -->
+    <string name="settings_debug_title">Débogage (uniquement sur les builds de débogage)</string>
+    <string name="settings_debug_description">Lance immédiatement le pipeline du ClothesCast quotidien. Utile pour vérifier sans attendre l\'heure programmée.</string>
+    <string name="settings_debug_fire_now">Lancer ClothesCast maintenant</string>
+    <string name="settings_debug_fire_toast">Worker ClothesCast en file d\'attente</string>
+
+    <!-- About screen — version line, build-type suffix, privacy summary,
+         outbound links / actions. -->
+    <string name="settings_about_title">À propos</string>
+    <string name="settings_about_version">Version %1$s (%2$d)</string>
+    <string name="settings_about_build_type_suffix"> · build %1$s</string>
+    <string name="settings_about_privacy">Ta clé API Gemini (utilisée pour la lecture vocale TTS) est chiffrée au repos avec une clé liée à l\'Android Keystore. Les prévisions viennent d\'Open-Meteo (sans clé, sans compte) ; le texte du résumé quotidien est généré localement sur l\'appareil. ClothesCast n\'a pas de backend — rien n\'est envoyé à un serveur que nous contrôlons.</string>
+    <string name="settings_about_privacy_policy">Politique de confidentialité</string>
+    <string name="settings_about_source">Code source sur GitHub</string>
+    <string name="settings_about_dontkillmyapp">Restrictions en arrière-plan (dontkillmyapp.com)</string>
+    <string name="settings_about_share_bug_report">Partager un rapport de bug</string>
+    <string name="settings_about_version_copied">Version copiée dans le presse-papiers</string>
+
     <!--
     Today screen — top bar, refresh toasts, empty state, generated-at
     timestamp, outfit card, hourly chart, confidence chip, work-status


### PR DESCRIPTION
## Summary

French UI translation, mirroring the German / Croatian / Italian /
Spanish passes. Thirteen commits — one tone-fix on the existing prose,
ten surface-by-surface translations of the strings the file was
missing, one fr-rCA overrides commit for Quebec-French divergences,
and a final header refresh.

## Tone fix (commit 1)

The previous French file used the formal vous-form throughout —
"Appuyez", "Portez", "Prenez", "Votre ClothesCast". That's the formal
register the user explicitly does not want; equivalent of the German
Sie/Du or Croatian Vi/ti distinction we already fixed in those locales.
Switches to informal tu-form imperatives so the file speaks to the
user the way a spouse would:

- "Appuyez sur Ajouter" → "Appuie sur Ajouter"
- "Portez %1$s."        → "Porte %1$s."
- "Prenez %1$s ce soir" → "Prends %1$s ce soir"  (×2)
- "Votre ClothesCast …" → "Ton ClothesCast …"

Stale `insight_calendar_tie_in` is left untouched (fleet-wide cleanup
out of scope, same dead key in 9 other locale files).

## fr-FR surfaces (commits 2–11)

- Today screen + home-screen widget
- Onboarding flow
- Settings root nav + Clothes section header
- Schedule screen (daily, nightly, delivery)
- Voice screen (engine + voice + language pickers)
- Region screen + Voice locale picker labels (28 locales × 2)
- API keys screen
- Location screen
- Notification channels + permission card + Calendar
- Debug + About screens

After this PR the fr-FR file has 293 strings vs. 300 in the en-US
baseline; the seven gaps are the same deliberate non-overrides as the
prior locale PRs.

## fr-rCA overrides (commit 12)

Adds Quebec-French overrides only where vocabulary materially diverges
from France French:

- **"bug" → "bogue"** (OQLF-recommended French spelling). Both the
  verb form (today_report_a_bug: "Signaler un bogue") and the noun
  form (settings_about_share_bug_report: "Partager un rapport de
  bogue").
- **"Miles" → "Milles"** (Quebec French spelling for the imperial
  unit; France carries the English loan because the unit is
  essentially only used in en-imported software).

Pre-existing override (chandail / sweater) is left untouched.
Everything else (notifications, voice / region pickers, prose
templates) reads the same in both variants and falls through to the
fr-FR baseline cleanly.

## Tone

tu-form throughout, intimate / spousal register matching the German /
Italian / Spanish / Croatian passes. French forces gender agreement on
past-participle adjectives; the welcome uses "Bienvenue" (invariable
interjection) and the subtitle uses "c'est prêt" (invariable) so a
one-time greeting doesn't have to pick masc / fem. Buttons follow the
Android French convention of action-infinitives ("Autoriser les
notifications", "Continuer", "Enregistrer"); direct-address prose stays
in tu-form imperative ("Définis", "Accorde", "Choisis").

"Tenue" rather than the English loanword "Outfit" for the widget label
— French generally translates this kind of everyday-vocab loanword
rather than carrying it in (the Romance / Germanic / Slavic locale
files we did kept "Outfit" because those languages absorb English more
freely).

Brand "ClothesCast" stays verbatim throughout.

## Privacy

Display-only. No new strings cross the device boundary; the rendered
insight prose (the only thing fed to TTS / LLM endpoints) was already
fully French via the existing `insight_*` translations.

## Test plan

- [ ] CI: `JVM unit tests` green (no French tests pin specific prose
      so nothing to update)
- [ ] CI: `Android debug build` green
- [ ] Manual: phone in fr-FR (or **Region: Français (France)**) → walk
      every screen and confirm French tu-form throughout, no English
      fall-through; widget label reads "Tenue", bug-report copy reads
      "bug"
- [ ] Manual: phone in fr-CA (or **Region: Français (Canada)**) →
      sweater reads "Chandail" (existing), bug-report copy reads
      "bogue", distance unit reads "Milles"

https://claude.ai/code/session_01C1Q3vzGj6KmbYDfD6b2yhu

---
_Generated by [Claude Code](https://claude.ai/code/session_015agXppcN2fzATq5Xnzpozs)_