### PR TITLE
:app — sort language pickers alphabetically by display name

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/settings/RegionSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/RegionSettings.kt
@@ -18,6 +18,7 @@ import app.clothescast.R
 import app.clothescast.core.domain.model.DistanceUnit
 import app.clothescast.core.domain.model.Region
 import app.clothescast.core.domain.model.TemperatureUnit
+import java.text.Collator
 import java.util.Locale
 
 @Composable
@@ -50,10 +51,20 @@ internal fun RegionContent(
             // back to when Region.SYSTEM is selected, so this is the same
             // locale that drives the rendered prose.
             val systemTag = remember { Locale.getDefault().toLanguageTag() }
-            Region.entries.forEach { option ->
+            // Sort by the resolved display label using a locale-aware collator
+            // so the order reads naturally in the user's UI language. SYSTEM
+            // stays pinned at the top — it's a "follow device" option, not a
+            // language to sort with the rest.
+            val collator = remember { Collator.getInstance(Locale.getDefault()) }
+            val labelled = Region.entries.map { option ->
                 val base = stringResource(regionLabel(option))
+                option to if (option == Region.SYSTEM) "$base ($systemTag)" else base
+            }
+            val (system, rest) = labelled.partition { it.first == Region.SYSTEM }
+            val sorted = system + rest.sortedWith(compareBy(collator) { it.second })
+            sorted.forEach { (option, label) ->
                 RadioRow(
-                    label = if (option == Region.SYSTEM) "$base ($systemTag)" else base,
+                    label = label,
                     selected = option == region,
                     onSelect = { onSetRegion(option) },
                 )

--- a/app/src/main/kotlin/app/clothescast/ui/settings/VoiceSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/VoiceSettings.kt
@@ -47,6 +47,7 @@ import app.clothescast.tts.OpenAITtsSpeaker
 import app.clothescast.tts.TtsVoiceOption
 import app.clothescast.tts.filterByVariant
 import app.clothescast.tts.resolve
+import java.text.Collator
 import java.util.Locale
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
@@ -323,10 +324,19 @@ private fun VoiceLocalePicker(
             onDismissRequest = { dialogOpen = false },
             title = { Text(title) },
             text = {
+                // Sort by the resolved display label using a locale-aware
+                // collator (so e.g. "Ç" sorts with "C" in fr-FR, "Ä" with "A"
+                // in de-DE). SYSTEM stays pinned at the top — it's a "follow
+                // device" option, not a language to sort with the rest.
+                val collator = remember { Collator.getInstance(Locale.getDefault()) }
+                val (system, rest) = VoiceLocale.entries
+                    .map { it to labelFor(it) }
+                    .partition { it.first == VoiceLocale.SYSTEM }
+                val sorted = system + rest.sortedWith(compareBy(collator) { it.second })
                 Column {
-                    VoiceLocale.entries.forEach { option ->
+                    sorted.forEach { (option, label) ->
                         RadioRow(
-                            label = labelFor(option),
+                            label = label,
                             selected = option == selected,
                             onSelect = {
                                 onSelect(option)


### PR DESCRIPTION
## Summary

Both the **Region** (UI language) and **TTS Voice locale** pickers in Settings were rendering in enum-declaration order, which produced a semi-arbitrary "English variants first, then everything else by language code" sequence. Sort by the resolved display label using a locale-aware `java.text.Collator` so the order reads naturally in whichever UI language the user has selected (e.g. "Allemand" sorts near the top in fr-FR, "Deutsch" near the top in de-DE, "ドイツ語" sorts correctly in ja-JP).

`SYSTEM` ("Follow phone language" / "Follow system locale") stays pinned at the top in both pickers — it's a "follow device" option, not a language to sort with the rest.

Files touched:
- `app/src/main/kotlin/app/clothescast/ui/settings/VoiceSettings.kt` — `VoiceLocalePicker` dialog
- `app/src/main/kotlin/app/clothescast/ui/settings/RegionSettings.kt` — `RegionContent` language section

## Test plan

- [ ] CI: `JVM unit tests` + `Android debug build` green
- [ ] Settings → Region & language: list shows SYSTEM first, then languages alphabetised by display name in the current UI locale
- [ ] Settings → Voice → locale picker: same behaviour
- [ ] Switch UI language to a non-English one (e.g. de-DE or fr-FR) and reconfirm the order changes accordingly

## Privacy

No change — sorting is purely local UI; nothing new leaves the device.

https://claude.ai/code/session_012it6ZXufjBSHQVpxtZbj2C

---
_Generated by [Claude Code](https://claude.ai/code/session_012it6ZXufjBSHQVpxtZbj2C)_