### PR TITLE
:app — Simplified Chinese UI: full casual-register translation pass

### DIFF
--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -93,6 +93,30 @@ Chinese uses the ideographic period (。) for sentence endings.
     <string name="widget_empty_title">还没有穿搭</string>
     <string name="widget_empty_subtitle">点击打开 ClothesCast</string>
 
+    <!--
+    Onboarding flow — first-run welcome, two permission steps, Gemini
+    API-key step. "欢迎使用" is the standard zh-CN app welcome (gender-
+    neutral by virtue of Chinese not marking gender on most adjectives /
+    addresses). 你-form throughout for the casual register.
+    -->
+    <string name="onboarding_title">欢迎使用 ClothesCast</string>
+    <string name="onboarding_subtitle">两个快速选择即可开始。其他设置都有合理的默认值，你以后可以在设置里调整。</string>
+    <string name="onboarding_notifications_title">通知</string>
+    <string name="onboarding_notifications_description">用于发送你的每日 ClothesCast。授予一次权限后，ClothesCast 明天早上就会出现。</string>
+    <string name="onboarding_notifications_grant">授予通知权限</string>
+    <string name="onboarding_location_title">位置</string>
+    <string name="onboarding_location_description">用于获取准确的天气预报。授予位置权限后，ClothesCast 每天早上可以读取你设备的大致位置；否则手动选择一个城市。</string>
+    <string name="onboarding_location_grant">授予位置权限</string>
+    <string name="onboarding_location_denied_hint">位置权限被拒绝。你可以手动选择一个城市。</string>
+    <string name="onboarding_location_enter_manual">手动输入位置</string>
+    <string name="onboarding_location_using_device">每天早上使用你设备的位置。</string>
+
+    <string name="onboarding_gemini_title">Gemini API 密钥</string>
+    <string name="onboarding_gemini_description">ClothesCast 用于语音朗读和天气预报生成。可在 aistudio.google.com 免费获取。密钥会使用 Android Keystore 加密存储。</string>
+    <string name="onboarding_step_done">完成</string>
+    <string name="onboarding_skip">暂时跳过</string>
+    <string name="onboarding_continue">继续</string>
+
     <string name="insight_lead_today">今天</string>
     <string name="insight_lead_tonight">今晚</string>
     <!-- "今天天气温和。" / "今晚天气寒冷至凉爽。" -->

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -54,6 +54,30 @@ Chinese uses the ideographic period (。) for sentence endings.
     <string name="settings_clothes_cond_precip_above">当降水概率超过 %.0f%% 时</string>
 
     <!--
+    Schedule screen — daily and nightly ClothesCast cards, delivery
+    picker, "提及晚间日程" toggle, and the nightly-only "notify only on
+    events" toggle. Description uses the standard Chinese full-width
+    curly quotes "…" around the nested toggle label (the locale's own
+    house style; the German „…" form isn't Chinese typography).
+    -->
+    <string name="settings_schedule_title">每日 ClothesCast</string>
+    <string name="settings_schedule_time_label">时间</string>
+    <string name="settings_schedule_days_label">星期</string>
+    <string name="settings_daily_mention_evening_events">提及晚间日程</string>
+
+    <string name="settings_tonight_title">夜间 ClothesCast</string>
+    <string name="settings_tonight_description">晚间的第二份 ClothesCast，覆盖今晚的天气。在没有日程的夜晚保持静音，或者如果开启了“仅在有晚间日程时通知”则完全不出现；在有日程的夜晚会播放提示音，并且（如果你启用了语音朗读）会自动朗读。</string>
+    <string name="settings_tonight_enabled">显示夜间 ClothesCast</string>
+    <string name="settings_tonight_time_label">时间</string>
+    <string name="settings_tonight_days_label">星期</string>
+    <string name="settings_tonight_notify_only_on_events">仅在有晚间日程时通知</string>
+
+    <string name="settings_delivery_label">推送方式</string>
+    <string name="settings_delivery_notification_only">仅通知</string>
+    <string name="settings_delivery_tts_only">仅语音朗读</string>
+    <string name="settings_delivery_notification_and_tts">通知和语音朗读</string>
+
+    <!--
     Today screen — top bar, refresh toasts, empty state, generated-at
     timestamp, outfit card, hourly chart, confidence chip, work-status
     banner. Casual register: 你 (informal "you") rather than 您 (formal),

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -270,6 +270,24 @@ Chinese uses the ideographic period (。) for sentence endings.
     <string name="settings_calendar_grant_permission">授予日历权限</string>
     <string name="settings_calendar_open_settings">日历权限被拒绝。在系统设置里授予。</string>
 
+    <!-- Debug screen — visible only on debug builds. -->
+    <string name="settings_debug_title">调试（仅在调试构建中显示）</string>
+    <string name="settings_debug_description">立即触发每日 ClothesCast 流程。用于无需等待计划时间即可验证。</string>
+    <string name="settings_debug_fire_now">立即触发 ClothesCast</string>
+    <string name="settings_debug_fire_toast">ClothesCast Worker 已加入队列</string>
+
+    <!-- About screen — version line, build-type suffix, privacy summary,
+         outbound links / actions. -->
+    <string name="settings_about_title">关于</string>
+    <string name="settings_about_version">版本 %1$s（%2$d）</string>
+    <string name="settings_about_build_type_suffix"> · %1$s 构建</string>
+    <string name="settings_about_privacy">你的 Gemini API 密钥（用于语音朗读 TTS）会用绑定到 Android Keystore 的密钥加密存储。预报来自 Open-Meteo（无需密钥，无需账户）；每日摘要文本在设备本地生成。ClothesCast 没有后端 — 不会向我们控制的任何服务器发送数据。</string>
+    <string name="settings_about_privacy_policy">隐私政策</string>
+    <string name="settings_about_source">GitHub 上的源代码</string>
+    <string name="settings_about_dontkillmyapp">后台限制（dontkillmyapp.com）</string>
+    <string name="settings_about_share_bug_report">分享问题报告</string>
+    <string name="settings_about_version_copied">版本已复制到剪贴板</string>
+
     <!--
     Today screen — top bar, refresh toasts, empty state, generated-at
     timestamp, outfit card, hourly chart, confidence chip, work-status

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -103,6 +103,91 @@ Chinese uses the ideographic period (。) for sentence endings.
     <string name="settings_tts_add_api_key_cancel">取消</string>
 
     <!--
+    Region screen — language picker title + caption (the disambiguation
+    copy explaining that this knob is the *displayed text*, not the
+    spoken accent), the system-default option, and the per-locale
+    labels in zh-CN style ("英语（美国）", "法语（加拿大）", "中文（简体）", …)
+    using full-width parens. The locale tag stored on disk (en-US /
+    fr-CA / zh-CN) is unchanged; only the displayed label localizes.
+    -->
+    <string name="settings_region_language_title">语言</string>
+    <string name="settings_region_language_description">设置显示文本和通知的语言。</string>
+    <string name="settings_region_language_system">跟随系统语言</string>
+    <string name="settings_region_language_en_us">英语（美国）</string>
+    <string name="settings_region_language_en_gb">英语（英国）</string>
+    <string name="settings_region_language_en_au">英语（澳大利亚）</string>
+    <string name="settings_region_language_en_ca">英语（加拿大）</string>
+    <string name="settings_region_language_en_za">英语（南非）</string>
+    <string name="settings_region_language_de_de">德语（德国）</string>
+    <string name="settings_region_language_fr_fr">法语（法国）</string>
+    <string name="settings_region_language_fr_ca">法语（加拿大）</string>
+    <string name="settings_region_language_it_it">意大利语（意大利）</string>
+    <string name="settings_region_language_es_es">西班牙语（西班牙）</string>
+    <string name="settings_region_language_es_mx">西班牙语（墨西哥）</string>
+    <string name="settings_region_language_ru_ru">俄语（俄罗斯）</string>
+    <string name="settings_region_language_pl_pl">波兰语（波兰）</string>
+    <string name="settings_region_language_hr_hr">克罗地亚语（克罗地亚）</string>
+    <string name="settings_region_language_uk_ua">乌克兰语（乌克兰）</string>
+    <string name="settings_region_language_pt_br">葡萄牙语（巴西）</string>
+    <string name="settings_region_language_nl_nl">荷兰语（荷兰）</string>
+    <string name="settings_region_language_sv_se">瑞典语（瑞典）</string>
+    <string name="settings_region_language_tr_tr">土耳其语（土耳其）</string>
+    <string name="settings_region_language_id_id">印尼语（印度尼西亚）</string>
+    <string name="settings_region_language_fil_ph">菲律宾语（菲律宾）</string>
+    <string name="settings_region_language_vi_vn">越南语（越南）</string>
+    <string name="settings_region_language_hi_in">印地语（印度）</string>
+    <string name="settings_region_language_bn_bd">孟加拉语（孟加拉国）</string>
+    <string name="settings_region_language_ja_jp">日语（日本）</string>
+    <string name="settings_region_language_ko_kr">韩语（韩国）</string>
+    <string name="settings_region_language_ar_sa">阿拉伯语（沙特阿拉伯）</string>
+    <string name="settings_region_language_he_il">希伯来语（以色列）</string>
+    <string name="settings_region_language_fa_ir">波斯语（伊朗）</string>
+
+    <!-- Region screen — units pickers. -->
+    <string name="settings_temperature_unit_title">温度单位</string>
+    <string name="settings_temperature_unit_celsius">摄氏度（°C）</string>
+    <string name="settings_temperature_unit_fahrenheit">华氏度（°F）</string>
+    <string name="settings_distance_unit_title">距离单位</string>
+    <string name="settings_distance_unit_kilometers">公里</string>
+    <string name="settings_distance_unit_miles">英里</string>
+
+    <!--
+    Voice locale picker labels — same Chinese language-name translations
+    as the Region picker above, just keyed under
+    `settings_tts_voice_locale_*` because the Voice screen's language
+    sub-picker is a separate UI surface.
+    -->
+    <string name="settings_tts_voice_locale_en_us">英语（美国）</string>
+    <string name="settings_tts_voice_locale_en_gb">英语（英国）</string>
+    <string name="settings_tts_voice_locale_en_au">英语（澳大利亚）</string>
+    <string name="settings_tts_voice_locale_en_ca">英语（加拿大）</string>
+    <string name="settings_tts_voice_locale_en_za">英语（南非）</string>
+    <string name="settings_tts_voice_locale_de_de">德语（德国）</string>
+    <string name="settings_tts_voice_locale_fr_fr">法语（法国）</string>
+    <string name="settings_tts_voice_locale_fr_ca">法语（加拿大）</string>
+    <string name="settings_tts_voice_locale_it_it">意大利语（意大利）</string>
+    <string name="settings_tts_voice_locale_es_es">西班牙语（西班牙）</string>
+    <string name="settings_tts_voice_locale_es_mx">西班牙语（墨西哥）</string>
+    <string name="settings_tts_voice_locale_ru_ru">俄语（俄罗斯）</string>
+    <string name="settings_tts_voice_locale_pl_pl">波兰语（波兰）</string>
+    <string name="settings_tts_voice_locale_hr_hr">克罗地亚语（克罗地亚）</string>
+    <string name="settings_tts_voice_locale_uk_ua">乌克兰语（乌克兰）</string>
+    <string name="settings_tts_voice_locale_pt_br">葡萄牙语（巴西）</string>
+    <string name="settings_tts_voice_locale_nl_nl">荷兰语（荷兰）</string>
+    <string name="settings_tts_voice_locale_sv_se">瑞典语（瑞典）</string>
+    <string name="settings_tts_voice_locale_tr_tr">土耳其语（土耳其）</string>
+    <string name="settings_tts_voice_locale_id_id">印尼语（印度尼西亚）</string>
+    <string name="settings_tts_voice_locale_fil_ph">菲律宾语（菲律宾）</string>
+    <string name="settings_tts_voice_locale_vi_vn">越南语（越南）</string>
+    <string name="settings_tts_voice_locale_hi_in">印地语（印度）</string>
+    <string name="settings_tts_voice_locale_bn_bd">孟加拉语（孟加拉国）</string>
+    <string name="settings_tts_voice_locale_ja_jp">日语（日本）</string>
+    <string name="settings_tts_voice_locale_ko_kr">韩语（韩国）</string>
+    <string name="settings_tts_voice_locale_ar_sa">阿拉伯语（沙特阿拉伯）</string>
+    <string name="settings_tts_voice_locale_he_il">希伯来语（以色列）</string>
+    <string name="settings_tts_voice_locale_fa_ir">波斯语（伊朗）</string>
+
+    <!--
     Today screen — top bar, refresh toasts, empty state, generated-at
     timestamp, outfit card, hourly chart, confidence chip, work-status
     banner. Casual register: 你 (informal "you") rather than 您 (formal),

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -237,6 +237,40 @@ Chinese uses the ideographic period (。) for sentence endings.
     <string name="settings_location_no_results">无匹配结果。</string>
 
     <!--
+    Notification channels (system Settings → App → Notifications) and
+    the per-channel notification titles. Three channels: daily, nightly
+    (default + silent variants), weather alerts.
+    -->
+    <string name="notification_channel_daily_insight_name">每日 ClothesCast</string>
+    <string name="notification_channel_daily_insight_description">你启用的早晨天气摘要。</string>
+    <string name="notification_daily_insight_title">今天的天气</string>
+
+    <string name="notification_channel_tonight_insight_default_name">夜间 ClothesCast（有日程）</string>
+    <string name="notification_channel_tonight_insight_default_description">你今晚有日历日程时的晚间天气摘要。播放你的默认通知声音。</string>
+    <string name="notification_channel_tonight_insight_silent_name">夜间 ClothesCast（静音）</string>
+    <string name="notification_channel_tonight_insight_silent_description">晚上没有日程时的晚间天气摘要。静默发送 — 你可以在锁屏上看到，但不会发出声音。</string>
+    <string name="notification_tonight_insight_title">今晚的天气</string>
+
+    <string name="notification_channel_weather_alerts_name">极端天气警报</string>
+    <string name="notification_channel_weather_alerts_description">针对你所在地区严重或极端天气事件的高优先级警报。日常获取检测到时立即发送。</string>
+    <string name="notification_weather_alert_title">天气警报：%1$s</string>
+
+    <!-- Notification-permission card. -->
+    <string name="settings_notification_permission_title">通知已被阻止</string>
+    <string name="settings_notification_permission_description">没有通知权限，你的每日 ClothesCast 就没地方显示了。授予权限后，ClothesCast 明天早上就能出现。</string>
+    <string name="settings_notification_permission_grant">授予通知权限</string>
+
+    <!-- Calendar opt-in card. Description preserves the privacy
+         disclosure ("描述、参与人和地点会被读取，但不会离开设备"). Quotes
+         around the nested example use Chinese full-width "…". -->
+    <string name="settings_calendar_title">日历</string>
+    <string name="settings_calendar_use_events">使用今天的日历日程</string>
+    <string name="settings_calendar_description_off">启用后，ClothesCast 会读取你设备日历上今天的日程，让你的早晨 ClothesCast 能针对具体日程给出建议 — 例如“为下午 3 点的公园跑步带上雨伞”。只使用日程的标题和时间；描述、参与人和地点会被读取，但不会离开设备。</string>
+    <string name="settings_calendar_description_on">正在读取你设备日历上今天的日程，以丰富你的早晨 ClothesCast。在生成的摘要里只使用标题和时间；不使用描述和参与人。一切都留在设备上。</string>
+    <string name="settings_calendar_grant_permission">授予日历权限</string>
+    <string name="settings_calendar_open_settings">日历权限被拒绝。在系统设置里授予。</string>
+
+    <!--
     Today screen — top bar, refresh toasts, empty state, generated-at
     timestamp, outfit card, hourly chart, confidence chip, work-status
     banner. Casual register: 你 (informal "you") rather than 您 (formal),

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -10,6 +10,18 @@ Chinese uses the ideographic period (。) for sentence endings.
     <string name="settings_tts_voice_locale_zh_cn">中文（简体）</string>
     <string name="settings_tts_voice_locale_label">语言</string>
 
+    <!-- Settings — top bar + root navigation list. -->
+    <string name="settings_title">设置</string>
+    <string name="settings_back">返回</string>
+
+    <string name="settings_root_voice">语音</string>
+    <string name="settings_root_schedule">计划</string>
+    <string name="settings_root_region">地区</string>
+    <string name="settings_root_clothes">服装</string>
+    <string name="settings_root_api_keys">API 密钥</string>
+    <string name="settings_root_data_sources">数据源</string>
+    <string name="settings_root_about">关于</string>
+
     <string name="garment_sweater">毛衣</string>
     <string name="garment_hoodie">连帽衫</string>
     <string name="garment_jacket">夹克</string>
@@ -19,6 +31,10 @@ Chinese uses the ideographic period (。) for sentence endings.
     <string name="garment_shorts">短裤</string>
     <string name="garment_pants">长裤</string>
     <string name="garment_jeans">牛仔裤</string>
+
+    <!-- Clothes settings — top of the screen. -->
+    <string name="settings_clothes_title">穿衣规则</string>
+    <string name="settings_clothes_description">当天气预报达到其中某个阈值时，相应的服装会出现在你的每日 ClothesCast 里。</string>
 
     <string name="settings_clothes_empty">还没有规则。点击添加来创建一条。</string>
     <string name="settings_clothes_add">添加</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -218,6 +218,25 @@ Chinese uses the ideographic period (。) for sentence endings.
     <string name="settings_elevenlabs_key_clear">清除已保存的 ElevenLabs 密钥</string>
 
     <!--
+    Location screen — device-location toggle, manual city search +
+    selection, and the "no location set" empty state.
+    -->
+    <string name="settings_location_title">位置</string>
+    <string name="settings_location_use_device">使用设备位置</string>
+    <string name="settings_location_grant_background">授予后台位置权限（系统设置）</string>
+    <string name="settings_location_unset">未设置位置 — 默认使用伦敦</string>
+    <string name="settings_location_description">天气预报是针对这个地点获取的。按城市名称搜索；结果来自 Open-Meteo 的免费地理编码服务。</string>
+    <string name="settings_location_description_device_on">启用后，ClothesCast 在通知时会读取设备的大致位置（仅基站 / WiFi — 不使用 GPS 硬件定位）。如果设备读取失败，会使用下方的位置作为备用。后台位置权限必须在系统设置里授予，否则早晨的 Worker 无法读取。</string>
+    <string name="settings_location_set">设置位置</string>
+    <string name="settings_location_change">更改位置</string>
+    <string name="settings_location_clear">清除位置</string>
+    <string name="settings_location_search_title">搜索位置</string>
+    <string name="settings_location_query_label">城市或地点</string>
+    <string name="settings_location_search">搜索</string>
+    <string name="settings_location_searching">搜索中…</string>
+    <string name="settings_location_no_results">无匹配结果。</string>
+
+    <!--
     Today screen — top bar, refresh toasts, empty state, generated-at
     timestamp, outfit card, hourly chart, confidence chip, work-status
     banner. Casual register: 你 (informal "you") rather than 您 (formal),

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1,9 +1,35 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-Simplified Chinese (Mainland China) translation. Scope: insight-prose templates,
-garment labels, clothes-rule editor, outfit-card labels, and region/voice-locale
-picker names. The rest of the UI falls through to values/strings.xml (English).
-Chinese uses the ideographic period (。) for sentence endings.
+Simplified Chinese (Mainland China) translation — full UI coverage.
+Casual register throughout: 你 (informal "you") rather than 您 (formal),
+bare imperatives without 请 / 烦请 ("打开设置" rather than "请打开设置").
+That's the spousal-tone equivalent in Chinese (no separate tu/vous
+distinction beyond the 你/您 pronoun choice and the 请-prefix politeness).
+
+What is NOT overridden, by design:
+- `app_name` — brand identifier, identical across locales.
+- `insight_time_am` / `_pm` / `_midnight` / `_noon` (and *_minutes
+  variants) — English-only spoken-time formatter helpers. zh-CN uses
+  `insight_time_hour` / `_hour_minutes` ("15点" / "15点30分") which
+  are translated below; the AM/PM keys exist for the
+  `Locale.language == "en"` path only and would never be read in a
+  zh-CN runtime.
+
+Typography conventions:
+- Sentence-final period 。 (ideographic full stop), not Latin "."
+- List enumeration uses 、 between items (not Latin comma)
+- Quotes around nested labels use Chinese full-width "…" (not the
+  German „…" form used in the Romance / Germanic locales)
+- Parentheses use full-width （ ） around Chinese content; Latin ( )
+  only when the parenthetical is itself Latin script (e.g. URLs)
+- Latin brand names ("ClothesCast", "Open-Meteo") and Latin URLs keep
+  the conventional space-around-Latin spacing zh-CN typography uses
+
+Picker labels under `settings_region_language_*` and
+`settings_tts_voice_locale_*` give the zh-CN names for every offered
+locale (英语（美国）, 法语（加拿大）, 中文（简体）, …). The locale tag stored
+on disk (en-US / fr-CA / zh-CN) is unchanged; only the displayed
+label localizes.
 -->
 <resources>
     <string name="settings_region_language_zh_cn">中文（简体）</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -78,6 +78,31 @@ Chinese uses the ideographic period (。) for sentence endings.
     <string name="settings_delivery_notification_and_tts">通知和语音朗读</string>
 
     <!--
+    Voice screen — engine picker (Device / Gemini / OpenAI / ElevenLabs),
+    voice + language sub-pickers, test-voice button, missing-API-key
+    hint and the in-line "添加 API 密钥" dialog.
+    -->
+    <string name="settings_tts_engine_title">语音引擎</string>
+    <string name="settings_tts_engine_description">在线引擎（Gemini、OpenAI、ElevenLabs）听起来更自然，但在朗读时需要联网，并使用你的 API 密钥进行合成（每次朗读 ClothesCast 时调用一次）。如果选定的引擎失败，会回退到设备语音。</string>
+    <string name="settings_tts_engine_device">设备（离线，免费）</string>
+    <string name="settings_tts_engine_gemini">Gemini（高质量，在线）</string>
+    <string name="settings_tts_engine_openai">OpenAI（高质量，在线）</string>
+    <string name="settings_tts_engine_elevenlabs">ElevenLabs（最高质量，在线）</string>
+
+    <string name="settings_tts_voice_label">语音</string>
+    <string name="settings_tts_voice_dismiss">完成</string>
+    <string name="settings_tts_voice_locale_description">设置朗读语音的口音。不改变显示文本。</string>
+    <string name="settings_tts_voice_locale_system">跟随手机语言</string>
+
+    <string name="settings_tts_test">测试语音</string>
+    <string name="settings_tts_test_in_flight">测试中 — 请稍候…</string>
+    <string name="settings_tts_no_key_hint">未配置 %1$s 密钥 — 添加一个以启用此引擎。</string>
+    <string name="settings_tts_add_api_key">添加 API 密钥</string>
+    <string name="settings_tts_add_api_key_title">添加 %1$s API 密钥</string>
+    <string name="settings_tts_add_api_key_save">保存</string>
+    <string name="settings_tts_add_api_key_cancel">取消</string>
+
+    <!--
     Today screen — top bar, refresh toasts, empty state, generated-at
     timestamp, outfit card, hourly chart, confidence chip, work-status
     banner. Casual register: 你 (informal "you") rather than 您 (formal),

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -37,11 +37,61 @@ Chinese uses the ideographic period (。) for sentence endings.
     <string name="settings_clothes_cond_temp_above">当最高体感温度高于 %.0f°C 时</string>
     <string name="settings_clothes_cond_precip_above">当降水概率超过 %.0f%% 时</string>
 
+    <!--
+    Today screen — top bar, refresh toasts, empty state, generated-at
+    timestamp, outfit card, hourly chart, confidence chip, work-status
+    banner. Casual register: 你 (informal "you") rather than 您 (formal),
+    bare imperatives without 请 / 烦请 ("打开设置" rather than "请打开设置").
+    Brand name "ClothesCast" stays in Latin script with the conventional
+    space-around-Latin spacing used by Chinese typography.
+    -->
+    <string name="today_title">今天</string>
+    <string name="today_open_settings">打开设置</string>
+    <string name="today_more_options">更多选项</string>
+    <string name="today_report_a_bug">报告问题</string>
+    <string name="today_refresh">刷新</string>
+    <string name="today_refresh_toast_daily">正在刷新你的每日 ClothesCast — 稍后即可看到。</string>
+    <string name="today_refresh_toast_nightly">正在刷新你的夜间 ClothesCast — 稍后即可看到。</string>
+    <string name="today_empty_title">还没有 ClothesCast</string>
+    <string name="today_empty_subtitle">你的早晨 ClothesCast 生成后会显示在这里。先在设置里设定你的位置，然后点击立即获取。</string>
+    <string name="today_fetch_now">立即获取</string>
+    <string name="today_generated_at">生成时间：%1$s</string>
+
+    <string name="today_outfit_title">穿什么</string>
+    <string name="today_outfit_label_today">今天</string>
+    <string name="today_outfit_label_tonight">今晚</string>
+    <string name="today_outfit_label_tomorrow">明天</string>
+
     <string name="today_outfit_top_tshirt">T恤</string>
     <string name="today_outfit_top_sweater">毛衣</string>
     <string name="today_outfit_top_thick_jacket">厚外套</string>
     <string name="today_outfit_bottom_shorts">短裤</string>
     <string name="today_outfit_bottom_long_pants">长裤</string>
+
+    <string name="today_forecast_title">逐小时预报</string>
+    <string name="today_forecast_min_max">体感 %1$d – %2$d%3$s · 气温 %4$d – %5$d%6$s</string>
+    <string name="today_forecast_legend_feels_like">逐小时体感温度（%1$s）· 点击切换到气温</string>
+    <string name="today_forecast_legend_air">逐小时气温（%1$s）· 点击切换到体感温度</string>
+
+    <string name="today_confidence_high">高置信度 — 主要模型一致</string>
+    <string name="today_confidence_medium">中等置信度</string>
+    <string name="today_confidence_low">低置信度 — 预报不一致</string>
+    <string name="today_confidence_spread">差异：%1$.1f°C，%2$.0fpp 降水，跨 %3$d 个模型</string>
+
+    <string name="today_working">正在获取你的 ClothesCast…</string>
+    <string name="today_failed_title">上次尝试失败</string>
+    <string name="today_failed_unexpected_http">天气服务返回意外的 HTTP 错误。</string>
+    <string name="today_failed_unhandled">发生了意外错误。</string>
+    <string name="today_failed_show_details">显示详情</string>
+    <string name="today_failed_hide_details">隐藏详情</string>
+
+    <!-- Home-screen App Widget. "穿搭" is the standard zh-CN fashion-vocab
+         word for an outfit / day's clothing combination, more native
+         than the loanword "Outfit". -->
+    <string name="widget_label">穿搭</string>
+    <string name="widget_description">当前时段的穿搭一目了然。</string>
+    <string name="widget_empty_title">还没有穿搭</string>
+    <string name="widget_empty_subtitle">点击打开 ClothesCast</string>
 
     <string name="insight_lead_today">今天</string>
     <string name="insight_lead_tonight">今晚</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -188,6 +188,36 @@ Chinese uses the ideographic period (。) for sentence endings.
     <string name="settings_tts_voice_locale_fa_ir">波斯语（伊朗）</string>
 
     <!--
+    API keys screen — three identical-shape blocks (Gemini, OpenAI,
+    ElevenLabs), each with status copy, paste-key placeholder, and
+    save / clear buttons. URLs stay verbatim with the conventional
+    space-around-Latin spacing.
+    -->
+    <string name="settings_api_keys_title">API 密钥</string>
+    <string name="settings_api_keys_description">配置你要使用的在线语音引擎的 API 密钥。密钥会使用 Android Keystore 加密存储。</string>
+    <string name="settings_api_key_gemini_label">Gemini</string>
+    <string name="settings_api_key_openai_label">OpenAI</string>
+    <string name="settings_api_key_elevenlabs_label">ElevenLabs</string>
+
+    <string name="settings_api_key_status_set">已配置 Gemini 密钥。</string>
+    <string name="settings_api_key_status_unset">未配置 Gemini 密钥。可在 aistudio.google.com 获取一个，以使用 Gemini 语音。</string>
+    <string name="settings_api_key_placeholder">粘贴你的 Gemini API 密钥</string>
+    <string name="settings_api_key_save">保存 Gemini 密钥</string>
+    <string name="settings_api_key_clear">清除已保存的 Gemini 密钥</string>
+
+    <string name="settings_openai_key_status_set">已配置 OpenAI 密钥。</string>
+    <string name="settings_openai_key_status_unset">未配置 OpenAI 密钥。可在 platform.openai.com 获取一个，以使用 OpenAI 语音。</string>
+    <string name="settings_openai_key_placeholder">粘贴你的 OpenAI API 密钥</string>
+    <string name="settings_openai_key_save">保存 OpenAI 密钥</string>
+    <string name="settings_openai_key_clear">清除已保存的 OpenAI 密钥</string>
+
+    <string name="settings_elevenlabs_key_status_set">已配置 ElevenLabs 密钥。</string>
+    <string name="settings_elevenlabs_key_status_unset">未配置 ElevenLabs 密钥。可在 elevenlabs.io 获取一个，以使用 ElevenLabs 语音。</string>
+    <string name="settings_elevenlabs_key_placeholder">粘贴你的 ElevenLabs API 密钥</string>
+    <string name="settings_elevenlabs_key_save">保存 ElevenLabs 密钥</string>
+    <string name="settings_elevenlabs_key_clear">清除已保存的 ElevenLabs 密钥</string>
+
+    <!--
     Today screen — top bar, refresh toasts, empty state, generated-at
     timestamp, outfit card, hourly chart, confidence chip, work-status
     banner. Casual register: 你 (informal "you") rather than 您 (formal),


### PR DESCRIPTION
## Summary

Stacked on top of PR #173 (Brazilian Portuguese). Targets the pt-BR
branch so the diff stays clean to the zh-CN work; will be rebased onto
`main` once #173 merges.

Simplified Chinese UI translation, mirroring the prior locale passes.
Eleven commits — ten surface-by-surface fills for the values-zh-rCN
file, plus a final header refresh.

The existing zh-rCN file already used a casual register (你-form, bare
imperatives without the polite 请 prefix), so no tone-fix commit was
needed — that's the spousal-tone equivalent in Chinese (no separate
tu/vous distinction beyond the 你/您 pronoun choice and the 请-prefix
politeness).

## Surfaces

- Today screen + home-screen widget
- Onboarding flow
- Settings root nav + Clothes section header
- Schedule screen (daily, nightly, delivery)
- Voice screen (engine + voice + language pickers)
- Region screen + Voice locale picker labels (28 locales × 2)
- API keys screen
- Location screen
- Notification channels + permission card + Calendar
- Debug + About screens
- File header refresh documenting the new scope, the deliberate
  non-overrides, and the zh-CN typography conventions

After this PR the zh-rCN file has 293 strings vs. 300 in the en-US
baseline; the seven gaps are the same deliberate non-overrides as the
prior locale PRs (`app_name` brand identifier + the six English-only
`insight_time_*` AM/PM helpers).

## Tone

Casual register throughout — 你 (informal "you") rather than 您 (formal),
bare imperatives without 请 / 烦请 ("打开设置" rather than "请打开设置").
That's the closest equivalent in Chinese to the spousal-tone register
the other locales use; Chinese doesn't have the same morphological
tu/vous distinction, just the 你/您 pronoun pair and the politeness
prefix.

"穿搭" rather than the English loanword "Outfit" for the widget label —
standard zh-CN fashion-vocab word for an outfit / day's clothing
combination, more native than the loanword.

Brand "ClothesCast" stays in Latin script with the conventional
space-around-Latin spacing zh-CN typography uses. Stale
`insight_calendar_tie_in` is left untouched (fleet-wide cleanup out of
scope).

## Typography

Chinese typography conventions matter for readability:
- Sentence-final period 。 (ideographic full stop) rather than Latin "."
- List enumeration uses 、 between items
- Quotes around nested labels use Chinese full-width "…" (not the
  German „…" form used in the Romance / Germanic locales — that's not
  Chinese typography)
- Parentheses use full-width （）around Chinese content; Latin ( )
  only when the parenthetical is itself Latin script

## Privacy

Display-only. No new strings cross the device boundary; the rendered
insight prose was already fully Chinese via the existing `insight_*`
translations.

## Test plan

- [ ] CI: `JVM unit tests` green (no zh-CN tests pin specific prose so
      nothing to update)
- [ ] CI: `Android debug build` green
- [ ] Manual: phone in zh-CN (or **Region: 中文（简体）**) → walk every
      screen and confirm Chinese throughout, no English fall-through;
      widget label reads "穿搭", Settings reads "设置"

## Stacking note

The branch is `claude/zh-cn-ui-translation`, currently targeting the
pt-BR PR branch. When #173 merges, I'll rebase onto `main` and
GitHub will retarget this PR automatically; the diff then shrinks to
just the zh-CN work.

https://claude.ai/code/session_01C1Q3vzGj6KmbYDfD6b2yhu

---
_Generated by [Claude Code](https://claude.ai/code/session_015agXppcN2fzATq5Xnzpozs)_