### PR TITLE
:core:data — TTS clients: date-stamp pricing comments (PR #175 review)

### DIFF
--- a/core/data/src/main/kotlin/app/clothescast/core/data/tts/ElevenLabsTtsClient.kt
+++ b/core/data/src/main/kotlin/app/clothescast/core/data/tts/ElevenLabsTtsClient.kt
@@ -22,12 +22,13 @@ import kotlinx.serialization.json.JsonPrimitive
 // `eleven_multilingual_v2` is ElevenLabs' "1 character = 1 credit" model
 // (their Flash/Turbo variants run at 0.5 credits/char but trade quality
 // for latency, which we don't need for an asynchronous morning brief).
-// Pricing is plan-based rather than purely metered: the free tier covers
-// 10k credits/month (no commercial use), Starter is $5/mo for 30k credits,
-// Creator $22/mo for 100k. ClothesCast's two ~100-char clips/day works out
-// to ~6k credits/month — comfortably inside the free tier and ~5% of
-// Starter, so on a BYOK key the per-clip marginal cost is effectively zero
-// until the user overruns their plan's allotment.
+// Pricing as of April 2026 is plan-based rather than purely metered: the
+// free tier covers 10k credits/month (no commercial use), Starter is
+// $5/mo for 30k credits, Creator $22/mo for 100k. ClothesCast's two
+// ~100-char clips/day works out to ~6k credits/month — comfortably inside
+// the free tier and ~5% of Starter, so on a BYOK key the per-clip
+// marginal cost is effectively zero until the user overruns their plan's
+// allotment.
 const val DEFAULT_ELEVENLABS_TTS_MODEL: String = "eleven_multilingual_v2"
 const val DEFAULT_ELEVENLABS_TTS_VOICE: String = "EXAVITQu4vr4xnSDxMaL" // Sarah
 

--- a/core/data/src/main/kotlin/app/clothescast/core/data/tts/GeminiTtsClient.kt
+++ b/core/data/src/main/kotlin/app/clothescast/core/data/tts/GeminiTtsClient.kt
@@ -22,14 +22,14 @@ import java.util.Base64
 import java.util.Locale
 
 // `gemini-2.5-flash-preview-tts` is the audio-output variant of Flash 2.5
-// (text-only Flash 2.5 is much cheaper but doesn't speak). Standard-tier
-// pricing is $1.00/M text input tokens + $20.00/M audio output tokens; a
-// typical ~100-char insight ≈ 25 input tokens + ~160 audio output tokens
-// for a ~5 s clip, which works out to ~$0.003 per call (~$0.20/month at
-// two clips/day). The Gemini free tier covers low-volume BYOK use without
-// billing at all. Note this model is still on the `-preview-` track — see
-// CLAUDE.md's "Don't rename Gemini models from web-search guesses" before
-// swapping it for a GA-sounding name.
+// (text-only Flash 2.5 is much cheaper but doesn't speak). Pricing as of
+// April 2026: standard-tier pricing is $1.00/M text input tokens + $20.00/M
+// audio output tokens; a typical ~100-char insight ≈ 25 input tokens + ~160
+// audio output tokens for a ~5 s clip, which works out to ~$0.003 per call
+// (~$0.20/month at two clips/day). The Gemini free tier covers low-volume
+// BYOK use without billing at all. Note this model is still on the
+// `-preview-` track — see CLAUDE.md's "Don't rename Gemini models from
+// web-search guesses" before swapping it for a GA-sounding name.
 const val DEFAULT_GEMINI_TTS_MODEL: String = "gemini-2.5-flash-preview-tts"
 const val DEFAULT_GEMINI_TTS_VOICE: String = "Kore"
 

--- a/core/data/src/main/kotlin/app/clothescast/core/data/tts/OpenAITtsClient.kt
+++ b/core/data/src/main/kotlin/app/clothescast/core/data/tts/OpenAITtsClient.kt
@@ -18,10 +18,11 @@ import kotlinx.serialization.json.JsonPrimitive
 
 // `gpt-4o-mini-tts` is OpenAI's current TTS-of-record (March 2025). The
 // upgrade from `tts-1` is a per-clip-quality win — positioned by OpenAI as
-// comparable to `tts-1-hd`. Pricing is $0.60/M text input tokens + $12/M
-// audio output tokens, which works out to ~$0.015/min of audio (roughly
-// 35-40% more than tts-1's per-character rate); for clothescast's two-
-// clips-a-day usage that's ~$0.003/day, ~$0.09/month on a BYOK key.
+// comparable to `tts-1-hd`. Pricing, as of April 2026, is $0.60/M text
+// input tokens + $12/M audio output tokens, which works out to ~$0.015/min
+// of audio (roughly 35-40% more than tts-1's per-character rate); for
+// ClothesCast's two-clips-a-day usage that's ~$0.003/day, ~$0.09/month on
+// a BYOK key.
 //
 // Earlier work tried to steer accent via the `instructions` field on this
 // model, but field-testing confirmed the voice's baked-in accent dominates


### PR DESCRIPTION
## Summary

Follow-up to merged PR #175 addressing Copilot review feedback on the inline pricing comments:

- Add `as of April 2026` marker to each per-call pricing block (OpenAI, Gemini, ElevenLabs) so future readers can judge how stale the numbers are. The PR description on #175 carried the date; the inline comments themselves didn't.
- Capitalise `ClothesCast` in the OpenAI block (was lowercase `clothescast`, inconsistent with the product name used everywhere else and in the PR description).

## Privacy

No change. Comments-only — nothing new crosses the device boundary.

## Test plan

- [ ] CI: `JVM unit tests` green (no behavioural change, just docstring tweaks on `const val`s in `:core:data`)
- [ ] CI: `Android debug build` green

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrEHsu4sgyvZhCFQ9F5FBx)_