### PR TITLE
:app — duck other audio while the briefing speaks

### DIFF
--- a/app/src/main/kotlin/app/clothescast/tts/AndroidTtsSpeaker.kt
+++ b/app/src/main/kotlin/app/clothescast/tts/AndroidTtsSpeaker.kt
@@ -1,6 +1,7 @@
 package app.clothescast.tts
 
 import android.content.Context
+import android.media.AudioAttributes
 import android.speech.tts.TextToSpeech
 import android.speech.tts.UtteranceProgressListener
 import android.speech.tts.Voice
@@ -37,6 +38,7 @@ class AndroidTtsSpeaker(private val context: Context) : TtsSpeaker {
     override suspend fun speak(text: String, locale: Locale) {
         val tts = initEngine()
         try {
+            tts.setAudioAttributes(SPEECH_AUDIO_ATTRS)
             applyBestVoice(tts, locale)
             speakAndAwait(tts, prepareForTts(text))
         } finally {
@@ -140,5 +142,12 @@ class AndroidTtsSpeaker(private val context: Context) : TtsSpeaker {
     companion object {
         private const val TAG = "AndroidTtsSpeaker"
         private const val GOOGLE_TTS_PACKAGE = "com.google.android.tts"
+
+        // Match the cloud-TTS path (PcmAudioPlayer): tag the stream as assistant
+        // speech so audio focus / ducking works the same way regardless of engine.
+        private val SPEECH_AUDIO_ATTRS: AudioAttributes = AudioAttributes.Builder()
+            .setUsage(AudioAttributes.USAGE_ASSISTANT)
+            .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
+            .build()
     }
 }

--- a/app/src/main/kotlin/app/clothescast/tts/SpeechAudioFocus.kt
+++ b/app/src/main/kotlin/app/clothescast/tts/SpeechAudioFocus.kt
@@ -1,0 +1,44 @@
+package app.clothescast.tts
+
+import android.content.Context
+import android.media.AudioAttributes
+import android.media.AudioFocusRequest
+import android.media.AudioManager
+import app.clothescast.diag.DiagLog
+
+/**
+ * Holds transient audio focus with ducking around [block] so the spoken briefing
+ * doesn't talk over music or a podcast — other apps drop their volume for the
+ * duration and recover when we abandon focus. [block] always runs: if focus is
+ * denied (rare; usually a phone call), we log and play at full volume rather
+ * than swallow the briefing the user is waiting on.
+ *
+ * Used at the *playback session* boundary (the worker's speak-with-fallback,
+ * the Settings preview) rather than per-engine, so the focus is held across the
+ * whole "try cloud, fall back to device" chain in one request.
+ */
+internal suspend fun <T> withSpeechAudioFocus(
+    context: Context,
+    block: suspend () -> T,
+): T {
+    val am = context.applicationContext.getSystemService(Context.AUDIO_SERVICE) as? AudioManager
+        ?: return block()
+    val request = AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK)
+        .setAudioAttributes(
+            AudioAttributes.Builder()
+                .setUsage(AudioAttributes.USAGE_ASSISTANT)
+                .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
+                .build(),
+        )
+        .setOnAudioFocusChangeListener {}
+        .build()
+    val granted = am.requestAudioFocus(request) == AudioManager.AUDIOFOCUS_REQUEST_GRANTED
+    if (!granted) DiagLog.w(TAG, "Audio focus not granted; speaking anyway.")
+    return try {
+        block()
+    } finally {
+        runCatching { am.abandonAudioFocusRequest(request) }
+    }
+}
+
+private const val TAG = "SpeechAudioFocus"

--- a/app/src/main/kotlin/app/clothescast/ui/settings/VoiceSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/VoiceSettings.kt
@@ -47,6 +47,7 @@ import app.clothescast.tts.OpenAITtsSpeaker
 import app.clothescast.tts.TtsVoiceOption
 import app.clothescast.tts.filterByVariant
 import app.clothescast.tts.resolve
+import app.clothescast.tts.withSpeechAudioFocus
 import java.text.Collator
 import java.util.Locale
 import kotlinx.coroutines.CancellationException
@@ -490,38 +491,40 @@ private suspend fun runTtsPreview(
         val voiceConfig = Configuration(context.resources.configuration).apply { setLocale(locale) }
         val text = context.createConfigurationContext(voiceConfig)
             .getString(R.string.settings_tts_test_sample)
-        try {
-            when (engine) {
-                TtsEngine.GEMINI ->
-                    GeminiTtsSpeaker(app.geminiTtsClient, voiceName = geminiVoice).speak(text, locale)
-                TtsEngine.OPENAI ->
-                    OpenAITtsSpeaker(app.openAiTtsClient, voice = openAiVoice).speak(text, locale)
-                TtsEngine.ELEVENLABS ->
-                    ElevenLabsTtsSpeaker(app.elevenLabsTtsClient, voiceId = elevenLabsVoice).speak(text, locale)
-                TtsEngine.DEVICE ->
-                    app.deviceTtsSpeaker.speak(text, locale)
-            }
-        } catch (_: CancellationException) {
-            // Composable scope cancelled (user navigated away mid-preview); not an error.
-        } catch (t: Throwable) {
-            // TTS exceptions already name their provider in the message
-            // (e.g. "Gemini TTS HTTP 400: …"); don't double that up.
-            val message = t.message?.takeIf { it.isNotBlank() } ?: t.javaClass.simpleName
-            DiagLog.w("VoiceSettings", "TTS preview failed for $engine", t)
-            // Toast.show() posts internally, but Toast.makeText()'s constructor needs
-            // a Looper on the calling thread — Dispatchers.IO has none, so hop to Main.
-            withContext(Dispatchers.Main) {
-                android.widget.Toast.makeText(context, message, android.widget.Toast.LENGTH_LONG).show()
-            }
-            // Fall back to the on-device engine so the user still hears the preview
-            // and can confirm audio output is working — mirrors FetchAndNotifyWorker.
-            if (engine != TtsEngine.DEVICE) {
-                try {
-                    app.deviceTtsSpeaker.speak(text, locale)
-                } catch (_: CancellationException) {
-                    // user moved on; fine
-                } catch (fallback: Throwable) {
-                    DiagLog.w("VoiceSettings", "Device TTS fallback also failed", fallback)
+        withSpeechAudioFocus(context) {
+            try {
+                when (engine) {
+                    TtsEngine.GEMINI ->
+                        GeminiTtsSpeaker(app.geminiTtsClient, voiceName = geminiVoice).speak(text, locale)
+                    TtsEngine.OPENAI ->
+                        OpenAITtsSpeaker(app.openAiTtsClient, voice = openAiVoice).speak(text, locale)
+                    TtsEngine.ELEVENLABS ->
+                        ElevenLabsTtsSpeaker(app.elevenLabsTtsClient, voiceId = elevenLabsVoice).speak(text, locale)
+                    TtsEngine.DEVICE ->
+                        app.deviceTtsSpeaker.speak(text, locale)
+                }
+            } catch (_: CancellationException) {
+                // Composable scope cancelled (user navigated away mid-preview); not an error.
+            } catch (t: Throwable) {
+                // TTS exceptions already name their provider in the message
+                // (e.g. "Gemini TTS HTTP 400: …"); don't double that up.
+                val message = t.message?.takeIf { it.isNotBlank() } ?: t.javaClass.simpleName
+                DiagLog.w("VoiceSettings", "TTS preview failed for $engine", t)
+                // Toast.show() posts internally, but Toast.makeText()'s constructor needs
+                // a Looper on the calling thread — Dispatchers.IO has none, so hop to Main.
+                withContext(Dispatchers.Main) {
+                    android.widget.Toast.makeText(context, message, android.widget.Toast.LENGTH_LONG).show()
+                }
+                // Fall back to the on-device engine so the user still hears the preview
+                // and can confirm audio output is working — mirrors FetchAndNotifyWorker.
+                if (engine != TtsEngine.DEVICE) {
+                    try {
+                        app.deviceTtsSpeaker.speak(text, locale)
+                    } catch (_: CancellationException) {
+                        // user moved on; fine
+                    } catch (fallback: Throwable) {
+                        DiagLog.w("VoiceSettings", "Device TTS fallback also failed", fallback)
+                    }
                 }
             }
         }

--- a/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
@@ -24,6 +24,7 @@ import app.clothescast.tts.ElevenLabsTtsSpeaker
 import app.clothescast.tts.GeminiTtsSpeaker
 import app.clothescast.tts.OpenAITtsSpeaker
 import app.clothescast.tts.resolve
+import app.clothescast.tts.withSpeechAudioFocus
 import app.clothescast.widget.OutfitWidget
 import io.ktor.client.call.NoTransformationFoundException
 import io.ktor.client.network.sockets.ConnectTimeoutException
@@ -278,37 +279,39 @@ class FetchAndNotifyWorker(
      */
     private suspend fun speakWithFallback(text: String, prefs: UserPreferences) {
         val locale = prefs.voiceLocale.resolve()
-        when (prefs.ttsEngine) {
-            TtsEngine.GEMINI -> {
-                try {
-                    GeminiTtsSpeaker(app.geminiTtsClient, voiceName = prefs.geminiVoice).speak(text, locale)
-                    return
-                } catch (t: Throwable) {
-                    DiagLog.w(TAG, "Gemini TTS failed; falling back to device TTS.", t)
+        withSpeechAudioFocus(applicationContext) {
+            when (prefs.ttsEngine) {
+                TtsEngine.GEMINI -> {
+                    try {
+                        GeminiTtsSpeaker(app.geminiTtsClient, voiceName = prefs.geminiVoice).speak(text, locale)
+                        return@withSpeechAudioFocus
+                    } catch (t: Throwable) {
+                        DiagLog.w(TAG, "Gemini TTS failed; falling back to device TTS.", t)
+                    }
                 }
-            }
-            TtsEngine.OPENAI -> {
-                try {
-                    OpenAITtsSpeaker(app.openAiTtsClient, voice = prefs.openAiVoice).speak(text, locale)
-                    return
-                } catch (t: Throwable) {
-                    DiagLog.w(TAG, "OpenAI TTS failed; falling back to device TTS.", t)
+                TtsEngine.OPENAI -> {
+                    try {
+                        OpenAITtsSpeaker(app.openAiTtsClient, voice = prefs.openAiVoice).speak(text, locale)
+                        return@withSpeechAudioFocus
+                    } catch (t: Throwable) {
+                        DiagLog.w(TAG, "OpenAI TTS failed; falling back to device TTS.", t)
+                    }
                 }
-            }
-            TtsEngine.ELEVENLABS -> {
-                try {
-                    ElevenLabsTtsSpeaker(app.elevenLabsTtsClient, voiceId = prefs.elevenLabsVoice).speak(text, locale)
-                    return
-                } catch (t: Throwable) {
-                    DiagLog.w(TAG, "ElevenLabs TTS failed; falling back to device TTS.", t)
+                TtsEngine.ELEVENLABS -> {
+                    try {
+                        ElevenLabsTtsSpeaker(app.elevenLabsTtsClient, voiceId = prefs.elevenLabsVoice).speak(text, locale)
+                        return@withSpeechAudioFocus
+                    } catch (t: Throwable) {
+                        DiagLog.w(TAG, "ElevenLabs TTS failed; falling back to device TTS.", t)
+                    }
                 }
+                TtsEngine.DEVICE -> Unit
             }
-            TtsEngine.DEVICE -> Unit
-        }
-        try {
-            app.deviceTtsSpeaker.speak(text, locale)
-        } catch (t: Throwable) {
-            DiagLog.w(TAG, "Device TTS failed; insight is still posted as notification.", t)
+            try {
+                app.deviceTtsSpeaker.speak(text, locale)
+            } catch (t: Throwable) {
+                DiagLog.w(TAG, "Device TTS failed; insight is still posted as notification.", t)
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

The morning / tonight briefing currently plays at full volume over whatever else the device is playing (Spotify, podcast, nav) because no playback path requests audio focus. This wraps both the worker's speak-with-fallback chain and the Settings preview in a transient-may-duck focus request, so other apps drop their volume for the duration and recover afterwards.

- New `withSpeechAudioFocus(context) { … }` helper in `:app/tts`. `AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK` with `USAGE_ASSISTANT` / `CONTENT_TYPE_SPEECH`.
- Wired into `FetchAndNotifyWorker.speakWithFallback` and `runTtsPreview` in `VoiceSettings.kt`. Focus is held at the *playback session* boundary, not per-engine, so the Gemini → device fallback chain shares one focus request across the whole sequence.
- `AndroidTtsSpeaker` now calls `setAudioAttributes(USAGE_ASSISTANT/CONTENT_TYPE_SPEECH)` on the engine itself so its routing matches `PcmAudioPlayer` (which already tags the AudioTrack the same way). Without this, the system has inconsistent signals across the four engines for whether to treat the stream as media or speech.

## Failure mode

If focus is denied (typically a phone call), we log and play anyway — silently swallowing the briefing the user is actually waiting on is worse than mixing.

## Privacy

No change to what leaves the device.

## Test plan

- [ ] CI: `JVM unit tests` and `Android debug build` green
- [ ] Manual: start a Spotify track, fire a manual briefing — Spotify ducks during speech, recovers afterwards
- [ ] Manual: same with the Settings → Test Voice button (each of the four engines)
- [ ] Manual: incoming phone call mid-briefing — playback yields rather than fighting the call
- [ ] Manual: regression — briefing still plays when nothing else is producing audio

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PpqBaTxkUW7h3xpjUdzRvY)_