### PR TITLE
:app — zh-CN: drop 请 from TTS test in-flight string

### DIFF
--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -121,7 +121,7 @@ label localizes.
     <string name="settings_tts_voice_locale_system">跟随手机语言</string>
 
     <string name="settings_tts_test">测试语音</string>
-    <string name="settings_tts_test_in_flight">测试中 — 请稍候…</string>
+    <string name="settings_tts_test_in_flight">测试中 — 稍等…</string>
     <string name="settings_tts_no_key_hint">未配置 %1$s 密钥 — 添加一个以启用此引擎。</string>
     <string name="settings_tts_add_api_key">添加 API 密钥</string>
     <string name="settings_tts_add_api_key_title">添加 %1$s API 密钥</string>


### PR DESCRIPTION
## Summary

Follow-up to PR #176. Copilot flagged that
`settings_tts_test_in_flight` ("测试中 — 请稍候…") uses the polite
请 prefix while the file header documents a no-请 casual register
([review comment](https://github.com/mikelward/clothescast/pull/176#discussion_r3154380412)).

Replace 请稍候 with 稍等 — the natural casual imperative that
stands alone without 请. Copilot's suggestion of stripping 请 to
leave 稍候 reads awkwardly (稍候 in practice expects 请 in front);
稍等 is the genuine casual-register equivalent and matches what
the other locales do (es: "espera", fr: "patiente", it: "attendi",
pt-BR: "aguarde" — all bare-imperative casual forms).

The other 请 in the file (`settings_tts_test_sample`'s "请穿一件外套")
is sample TTS *insight prose* mimicking Gemini's rendered output —
that's the insight-register voice, not UI imperative copy, so it
stays.

## Privacy

Display-only; no boundary-crossing data changes.

## Test plan

- [ ] CI: `JVM unit tests` green
- [ ] CI: `Android debug build` green
- [ ] Manual: Settings → Voice → tap **测试语音** with phone in
      zh-CN; the in-flight label reads "测试中 — 稍等…"

https://claude.ai/code/session_01SUZbZkdjwDNM7eWYySrJZD

---
_Generated by [Claude Code](https://claude.ai/code/session_015agXppcN2fzATq5Xnzpozs)_