### PR TITLE
:app — Japanese UI: full ます-form translation pass

### DIFF
--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -94,6 +94,30 @@ Japanese uses the ideographic period (。) for sentence endings.
     <string name="widget_empty_title">まだコーデがありません</string>
     <string name="widget_empty_subtitle">タップして ClothesCast を開く</string>
 
+    <!--
+    Onboarding flow — first-run welcome, two permission steps, Gemini
+    API-key step. "ようこそ" is the standard Japanese app welcome
+    (gender-neutral by virtue of Japanese not marking gender on most
+    addresses, so no Bienvenido/a-style workaround needed).
+    -->
+    <string name="onboarding_title">ClothesCast へようこそ</string>
+    <string name="onboarding_subtitle">2つの簡単な選択で準備完了。他はすべて妥当な初期値があり、後から設定で調整できます。</string>
+    <string name="onboarding_notifications_title">通知</string>
+    <string name="onboarding_notifications_description">毎日の ClothesCast を届けるために必要です。一度許可すれば、ClothesCast は明日の朝に表示されます。</string>
+    <string name="onboarding_notifications_grant">通知を許可</string>
+    <string name="onboarding_location_title">位置情報</string>
+    <string name="onboarding_location_description">正確な予報を取得するために使用します。位置情報を許可すると、ClothesCast は毎朝、端末のおおよその位置を読み取れます。許可しない場合は、都市を手動で選択してください。</string>
+    <string name="onboarding_location_grant">位置情報を許可</string>
+    <string name="onboarding_location_denied_hint">位置情報の許可が拒否されました。代わりに都市を手動で選択できます。</string>
+    <string name="onboarding_location_enter_manual">位置を手動で入力</string>
+    <string name="onboarding_location_using_device">毎朝、端末の位置情報を使用します。</string>
+
+    <string name="onboarding_gemini_title">Gemini API キー</string>
+    <string name="onboarding_gemini_description">ClothesCast が音声読み上げと予報生成に使用します。aistudio.google.com で無料で取得できます。キーは Android Keystore で暗号化して保存されます。</string>
+    <string name="onboarding_step_done">完了</string>
+    <string name="onboarding_skip">今はスキップ</string>
+    <string name="onboarding_continue">続ける</string>
+
     <string name="insight_lead_today">今日</string>
     <string name="insight_lead_tonight">今夜</string>
     <!-- "今日は穏やかでしょう。" — は marks the topic. -->

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -37,11 +37,62 @@ Japanese uses the ideographic period (。) for sentence endings.
     <string name="settings_clothes_cond_temp_above">最高体感温度が %.0f°C を超えるとき</string>
     <string name="settings_clothes_cond_precip_above">降水確率が %.0f%% を超えるとき</string>
 
+    <!--
+    Today screen — top bar, refresh toasts, empty state, generated-at
+    timestamp, outfit card, hourly chart, confidence chip, work-status
+    banner. ます-form (friendly-polite) throughout — that's the standard
+    Japanese app register, including for intimate / spousal addressing
+    (Japanese doesn't drop politeness for closeness the way Romance
+    languages do; the spousal register is "warm polite", not "casual
+    plain").
+    -->
+    <string name="today_title">今日</string>
+    <string name="today_open_settings">設定を開く</string>
+    <string name="today_more_options">その他のオプション</string>
+    <string name="today_report_a_bug">バグを報告</string>
+    <string name="today_refresh">更新</string>
+    <string name="today_refresh_toast_daily">毎日の ClothesCast を更新中です — もうすぐ表示されます。</string>
+    <string name="today_refresh_toast_nightly">夜間の ClothesCast を更新中です — もうすぐ表示されます。</string>
+    <string name="today_empty_title">まだ ClothesCast がありません</string>
+    <string name="today_empty_subtitle">朝の ClothesCast が生成されるとここに表示されます。設定で位置を指定してから「今すぐ取得」をタップしてください。</string>
+    <string name="today_fetch_now">今すぐ取得</string>
+    <string name="today_generated_at">生成時刻：%1$s</string>
+
+    <string name="today_outfit_title">何を着る</string>
+    <string name="today_outfit_label_today">今日</string>
+    <string name="today_outfit_label_tonight">今夜</string>
+    <string name="today_outfit_label_tomorrow">明日</string>
+
     <string name="today_outfit_top_tshirt">Tシャツ</string>
     <string name="today_outfit_top_sweater">セーター</string>
     <string name="today_outfit_top_thick_jacket">厚手のジャケット</string>
     <string name="today_outfit_bottom_shorts">ショートパンツ</string>
     <string name="today_outfit_bottom_long_pants">ズボン</string>
+
+    <string name="today_forecast_title">1時間ごとの予報</string>
+    <string name="today_forecast_min_max">体感 %1$d – %2$d%3$s · 気温 %4$d – %5$d%6$s</string>
+    <string name="today_forecast_legend_feels_like">1時間ごとの体感温度（%1$s）· タップで気温に切り替え</string>
+    <string name="today_forecast_legend_air">1時間ごとの気温（%1$s）· タップで体感温度に切り替え</string>
+
+    <string name="today_confidence_high">信頼度：高 — 主要モデルが一致</string>
+    <string name="today_confidence_medium">信頼度：中</string>
+    <string name="today_confidence_low">信頼度：低 — 予報が一致していません</string>
+    <string name="today_confidence_spread">ばらつき：%1$.1f°C、%2$.0fpp 降水、%3$d モデル</string>
+
+    <string name="today_working">ClothesCast を取得中…</string>
+    <string name="today_failed_title">前回の試行に失敗しました</string>
+    <string name="today_failed_unexpected_http">天気サービスから予期しない HTTP エラーが返されました。</string>
+    <string name="today_failed_unhandled">予期しないエラーが発生しました。</string>
+    <string name="today_failed_show_details">詳細を表示</string>
+    <string name="today_failed_hide_details">詳細を隠す</string>
+
+    <!-- Home-screen App Widget. "コーデ" (short for コーディネート) is the
+         standard Japanese fashion-vocab word for an outfit / day's
+         clothing combination, more native than the loanword "Outfit". -->
+    <string name="widget_label">コーデ</string>
+    <string name="widget_description">現在の時間帯のコーデを一目で。</string>
+    <string name="widget_empty_title">まだコーデがありません</string>
+    <string name="widget_empty_subtitle">タップして ClothesCast を開く</string>
 
     <string name="insight_lead_today">今日</string>
     <string name="insight_lead_tonight">今夜</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -103,6 +103,92 @@ Japanese uses the ideographic period (。) for sentence endings.
     <string name="settings_tts_add_api_key_cancel">キャンセル</string>
 
     <!--
+    Region screen — language picker title + caption (the disambiguation
+    copy explaining that this knob is the *displayed text*, not the
+    spoken accent), the system-default option, and the per-locale
+    labels in Japanese style ("英語（米国）", "フランス語（カナダ）", "中国語
+    （簡体字）", …) using full-width parens. The locale tag stored on
+    disk (en-US / fr-CA / zh-CN) is unchanged; only the displayed
+    label localizes.
+    -->
+    <string name="settings_region_language_title">言語</string>
+    <string name="settings_region_language_description">表示テキストと通知の言語を設定します。</string>
+    <string name="settings_region_language_system">システムの言語設定に従う</string>
+    <string name="settings_region_language_en_us">英語（米国）</string>
+    <string name="settings_region_language_en_gb">英語（英国）</string>
+    <string name="settings_region_language_en_au">英語（オーストラリア）</string>
+    <string name="settings_region_language_en_ca">英語（カナダ）</string>
+    <string name="settings_region_language_en_za">英語（南アフリカ）</string>
+    <string name="settings_region_language_de_de">ドイツ語（ドイツ）</string>
+    <string name="settings_region_language_fr_fr">フランス語（フランス）</string>
+    <string name="settings_region_language_fr_ca">フランス語（カナダ）</string>
+    <string name="settings_region_language_it_it">イタリア語（イタリア）</string>
+    <string name="settings_region_language_es_es">スペイン語（スペイン）</string>
+    <string name="settings_region_language_es_mx">スペイン語（メキシコ）</string>
+    <string name="settings_region_language_ru_ru">ロシア語（ロシア）</string>
+    <string name="settings_region_language_pl_pl">ポーランド語（ポーランド）</string>
+    <string name="settings_region_language_hr_hr">クロアチア語（クロアチア）</string>
+    <string name="settings_region_language_uk_ua">ウクライナ語（ウクライナ）</string>
+    <string name="settings_region_language_pt_br">ポルトガル語（ブラジル）</string>
+    <string name="settings_region_language_nl_nl">オランダ語（オランダ）</string>
+    <string name="settings_region_language_sv_se">スウェーデン語（スウェーデン）</string>
+    <string name="settings_region_language_tr_tr">トルコ語（トルコ）</string>
+    <string name="settings_region_language_id_id">インドネシア語（インドネシア）</string>
+    <string name="settings_region_language_fil_ph">フィリピン語（フィリピン）</string>
+    <string name="settings_region_language_vi_vn">ベトナム語（ベトナム）</string>
+    <string name="settings_region_language_zh_cn">中国語（簡体字）</string>
+    <string name="settings_region_language_hi_in">ヒンディー語（インド）</string>
+    <string name="settings_region_language_bn_bd">ベンガル語（バングラデシュ）</string>
+    <string name="settings_region_language_ko_kr">韓国語（韓国）</string>
+    <string name="settings_region_language_ar_sa">アラビア語（サウジアラビア）</string>
+    <string name="settings_region_language_he_il">ヘブライ語（イスラエル）</string>
+    <string name="settings_region_language_fa_ir">ペルシャ語（イラン）</string>
+
+    <!-- Region screen — units pickers. -->
+    <string name="settings_temperature_unit_title">温度単位</string>
+    <string name="settings_temperature_unit_celsius">摂氏（°C）</string>
+    <string name="settings_temperature_unit_fahrenheit">華氏（°F）</string>
+    <string name="settings_distance_unit_title">距離単位</string>
+    <string name="settings_distance_unit_kilometers">キロメートル</string>
+    <string name="settings_distance_unit_miles">マイル</string>
+
+    <!--
+    Voice locale picker labels — same Japanese language-name translations
+    as the Region picker above, just keyed under
+    `settings_tts_voice_locale_*` because the Voice screen's language
+    sub-picker is a separate UI surface.
+    -->
+    <string name="settings_tts_voice_locale_en_us">英語（米国）</string>
+    <string name="settings_tts_voice_locale_en_gb">英語（英国）</string>
+    <string name="settings_tts_voice_locale_en_au">英語（オーストラリア）</string>
+    <string name="settings_tts_voice_locale_en_ca">英語（カナダ）</string>
+    <string name="settings_tts_voice_locale_en_za">英語（南アフリカ）</string>
+    <string name="settings_tts_voice_locale_de_de">ドイツ語（ドイツ）</string>
+    <string name="settings_tts_voice_locale_fr_fr">フランス語（フランス）</string>
+    <string name="settings_tts_voice_locale_fr_ca">フランス語（カナダ）</string>
+    <string name="settings_tts_voice_locale_it_it">イタリア語（イタリア）</string>
+    <string name="settings_tts_voice_locale_es_es">スペイン語（スペイン）</string>
+    <string name="settings_tts_voice_locale_es_mx">スペイン語（メキシコ）</string>
+    <string name="settings_tts_voice_locale_ru_ru">ロシア語（ロシア）</string>
+    <string name="settings_tts_voice_locale_pl_pl">ポーランド語（ポーランド）</string>
+    <string name="settings_tts_voice_locale_hr_hr">クロアチア語（クロアチア）</string>
+    <string name="settings_tts_voice_locale_uk_ua">ウクライナ語（ウクライナ）</string>
+    <string name="settings_tts_voice_locale_pt_br">ポルトガル語（ブラジル）</string>
+    <string name="settings_tts_voice_locale_nl_nl">オランダ語（オランダ）</string>
+    <string name="settings_tts_voice_locale_sv_se">スウェーデン語（スウェーデン）</string>
+    <string name="settings_tts_voice_locale_tr_tr">トルコ語（トルコ）</string>
+    <string name="settings_tts_voice_locale_id_id">インドネシア語（インドネシア）</string>
+    <string name="settings_tts_voice_locale_fil_ph">フィリピン語（フィリピン）</string>
+    <string name="settings_tts_voice_locale_vi_vn">ベトナム語（ベトナム）</string>
+    <string name="settings_tts_voice_locale_zh_cn">中国語（簡体字）</string>
+    <string name="settings_tts_voice_locale_hi_in">ヒンディー語（インド）</string>
+    <string name="settings_tts_voice_locale_bn_bd">ベンガル語（バングラデシュ）</string>
+    <string name="settings_tts_voice_locale_ko_kr">韓国語（韓国）</string>
+    <string name="settings_tts_voice_locale_ar_sa">アラビア語（サウジアラビア）</string>
+    <string name="settings_tts_voice_locale_he_il">ヘブライ語（イスラエル）</string>
+    <string name="settings_tts_voice_locale_fa_ir">ペルシャ語（イラン）</string>
+
+    <!--
     Today screen — top bar, refresh toasts, empty state, generated-at
     timestamp, outfit card, hourly chart, confidence chip, work-status
     banner. ます-form (friendly-polite) throughout — that's the standard

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -189,6 +189,36 @@ Japanese uses the ideographic period (。) for sentence endings.
     <string name="settings_tts_voice_locale_fa_ir">ペルシャ語（イラン）</string>
 
     <!--
+    API keys screen — three identical-shape blocks (Gemini, OpenAI,
+    ElevenLabs), each with status copy, paste-key placeholder, and
+    save / clear buttons. URLs stay verbatim with the conventional
+    space-around-Latin spacing.
+    -->
+    <string name="settings_api_keys_title">API キー</string>
+    <string name="settings_api_keys_description">使用したいオンライン音声エンジンの API キーを設定します。キーは Android Keystore で暗号化して保存されます。</string>
+    <string name="settings_api_key_gemini_label">Gemini</string>
+    <string name="settings_api_key_openai_label">OpenAI</string>
+    <string name="settings_api_key_elevenlabs_label">ElevenLabs</string>
+
+    <string name="settings_api_key_status_set">Gemini キーが設定されています。</string>
+    <string name="settings_api_key_status_unset">Gemini キーが未設定です。aistudio.google.com で取得すると Gemini 音声を使用できます。</string>
+    <string name="settings_api_key_placeholder">Gemini API キーを貼り付け</string>
+    <string name="settings_api_key_save">Gemini キーを保存</string>
+    <string name="settings_api_key_clear">保存された Gemini キーを削除</string>
+
+    <string name="settings_openai_key_status_set">OpenAI キーが設定されています。</string>
+    <string name="settings_openai_key_status_unset">OpenAI キーが未設定です。platform.openai.com で取得すると OpenAI 音声を使用できます。</string>
+    <string name="settings_openai_key_placeholder">OpenAI API キーを貼り付け</string>
+    <string name="settings_openai_key_save">OpenAI キーを保存</string>
+    <string name="settings_openai_key_clear">保存された OpenAI キーを削除</string>
+
+    <string name="settings_elevenlabs_key_status_set">ElevenLabs キーが設定されています。</string>
+    <string name="settings_elevenlabs_key_status_unset">ElevenLabs キーが未設定です。elevenlabs.io で取得すると ElevenLabs 音声を使用できます。</string>
+    <string name="settings_elevenlabs_key_placeholder">ElevenLabs API キーを貼り付け</string>
+    <string name="settings_elevenlabs_key_save">ElevenLabs キーを保存</string>
+    <string name="settings_elevenlabs_key_clear">保存された ElevenLabs キーを削除</string>
+
+    <!--
     Today screen — top bar, refresh toasts, empty state, generated-at
     timestamp, outfit card, hourly chart, confidence chip, work-status
     banner. ます-form (friendly-polite) throughout — that's the standard

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1,9 +1,39 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-Japanese translation. Scope: insight-prose templates, garment labels,
-clothes-rule editor, outfit-card labels, and region/voice-locale picker names.
-The rest of the UI falls through to values/strings.xml (English).
-Japanese uses the ideographic period (。) for sentence endings.
+Japanese translation — full UI coverage. ます-form (friendly-polite)
+throughout — that's the standard Japanese app register, including for
+intimate / spousal addressing. Japanese doesn't drop politeness for
+closeness the way Romance languages do; the spousal-tone equivalent
+is "warm polite", not "casual plain". 〜してください for instructions,
+〜ましょう for invitations, 〜です/ます for statements.
+
+What is NOT overridden, by design:
+- `app_name` — brand identifier, identical across locales.
+- `insight_time_am` / `_pm` / `_midnight` / `_noon` (and *_minutes
+  variants) — English-only spoken-time formatter helpers. ja uses
+  `insight_time_hour` / `_hour_minutes` ("15時" / "15時30分") which are
+  translated below; the AM/PM keys exist for the
+  `Locale.language == "en"` path only and would never be read in a
+  ja runtime.
+
+Typography conventions:
+- Sentence-final period 。 (ideographic full stop)
+- List enumeration uses 、 (読点) between items
+- Quotes around nested labels use Japanese corner-bracket 「…」 (not the
+  German „…" form used in the Romance / Germanic locales)
+- Parentheses use full-width （）around Japanese content; Latin ( )
+  only when the parenthetical is itself Latin script (e.g. URLs)
+- Latin brand names ("ClothesCast", "Open-Meteo") and Latin URLs keep
+  the conventional space-around-Latin spacing Japanese typography uses
+
+"コーデ" (short for コーディネート) for the widget label rather than the
+English loanword "Outfit" — standard Japanese fashion-vocab.
+
+Picker labels under `settings_region_language_*` and
+`settings_tts_voice_locale_*` give the Japanese names for every
+offered locale (英語（米国）, フランス語（カナダ）, 中国語（簡体字）, …). The
+locale tag stored on disk (en-US / fr-CA / zh-CN) is unchanged; only
+the displayed label localizes.
 -->
 <resources>
     <string name="settings_region_language_ja_jp">日本語（日本）</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -54,6 +54,30 @@ Japanese uses the ideographic period (。) for sentence endings.
     <string name="settings_clothes_cond_precip_above">降水確率が %.0f%% を超えるとき</string>
 
     <!--
+    Schedule screen — daily and nightly ClothesCast cards, delivery
+    picker, "夜の予定に言及する" toggle, and the nightly-only "notify only
+    on events" toggle. Description uses Japanese corner-bracket quotes
+    「…」 around the nested toggle label (the locale-native quote form;
+    the German „…" form isn't Japanese typography).
+    -->
+    <string name="settings_schedule_title">毎日の ClothesCast</string>
+    <string name="settings_schedule_time_label">時刻</string>
+    <string name="settings_schedule_days_label">曜日</string>
+    <string name="settings_daily_mention_evening_events">夜の予定に言及する</string>
+
+    <string name="settings_tonight_title">夜間の ClothesCast</string>
+    <string name="settings_tonight_description">今夜の天気を伝える、夜のもう1つの ClothesCast です。予定のない夜は無音のまま、または「夜に予定があるときのみ通知」がオンの場合は表示されません。予定のある夜は音を鳴らし、（音声読み上げを有効にしている場合は）自動で読み上げます。</string>
+    <string name="settings_tonight_enabled">夜間の ClothesCast を表示</string>
+    <string name="settings_tonight_time_label">時刻</string>
+    <string name="settings_tonight_days_label">曜日</string>
+    <string name="settings_tonight_notify_only_on_events">夜に予定があるときのみ通知</string>
+
+    <string name="settings_delivery_label">配信方法</string>
+    <string name="settings_delivery_notification_only">通知のみ</string>
+    <string name="settings_delivery_tts_only">音声読み上げのみ</string>
+    <string name="settings_delivery_notification_and_tts">通知と音声読み上げ</string>
+
+    <!--
     Today screen — top bar, refresh toasts, empty state, generated-at
     timestamp, outfit card, hourly chart, confidence chip, work-status
     banner. ます-form (friendly-polite) throughout — that's the standard

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -10,6 +10,18 @@ Japanese uses the ideographic period (。) for sentence endings.
     <string name="settings_tts_voice_locale_ja_jp">日本語（日本）</string>
     <string name="settings_tts_voice_locale_label">言語</string>
 
+    <!-- Settings — top bar + root navigation list. -->
+    <string name="settings_title">設定</string>
+    <string name="settings_back">戻る</string>
+
+    <string name="settings_root_voice">音声</string>
+    <string name="settings_root_schedule">スケジュール</string>
+    <string name="settings_root_region">地域</string>
+    <string name="settings_root_clothes">服装</string>
+    <string name="settings_root_api_keys">API キー</string>
+    <string name="settings_root_data_sources">データソース</string>
+    <string name="settings_root_about">アプリについて</string>
+
     <string name="garment_sweater">セーター</string>
     <string name="garment_hoodie">パーカー</string>
     <string name="garment_jacket">ジャケット</string>
@@ -19,6 +31,10 @@ Japanese uses the ideographic period (。) for sentence endings.
     <string name="garment_shorts">ショートパンツ</string>
     <string name="garment_pants">ズボン</string>
     <string name="garment_jeans">ジーンズ</string>
+
+    <!-- Clothes settings — top of the screen. -->
+    <string name="settings_clothes_title">服のルール</string>
+    <string name="settings_clothes_description">予報がこれらのしきい値のいずれかを超えると、その服が毎日の ClothesCast に表示されます。</string>
 
     <string name="settings_clothes_empty">ルールがありません。追加をタップして作成してください。</string>
     <string name="settings_clothes_add">追加</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -78,6 +78,31 @@ Japanese uses the ideographic period (。) for sentence endings.
     <string name="settings_delivery_notification_and_tts">通知と音声読み上げ</string>
 
     <!--
+    Voice screen — engine picker (Device / Gemini / OpenAI / ElevenLabs),
+    voice + language sub-pickers, test-voice button, missing-API-key
+    hint and the in-line "API キーを追加" dialog.
+    -->
+    <string name="settings_tts_engine_title">音声エンジン</string>
+    <string name="settings_tts_engine_description">オンラインエンジン（Gemini、OpenAI、ElevenLabs）はずっと自然に聞こえますが、読み上げ時にネットワーク呼び出しが必要で、合成にあなたの API キーを使用します（読み上げる ClothesCast ごとに1回の短い呼び出し）。選択したエンジンが失敗した場合、端末の音声にフォールバックします。</string>
+    <string name="settings_tts_engine_device">端末（オフライン、無料）</string>
+    <string name="settings_tts_engine_gemini">Gemini（高品質、オンライン）</string>
+    <string name="settings_tts_engine_openai">OpenAI（高品質、オンライン）</string>
+    <string name="settings_tts_engine_elevenlabs">ElevenLabs（最高品質、オンライン）</string>
+
+    <string name="settings_tts_voice_label">音声</string>
+    <string name="settings_tts_voice_dismiss">完了</string>
+    <string name="settings_tts_voice_locale_description">読み上げ音声のアクセントを設定します。表示テキストは変更しません。</string>
+    <string name="settings_tts_voice_locale_system">端末の言語に従う</string>
+
+    <string name="settings_tts_test">音声をテスト</string>
+    <string name="settings_tts_test_in_flight">テスト中 — お待ちください…</string>
+    <string name="settings_tts_no_key_hint">%1$s キーが未設定です — このエンジンを使用するには追加してください。</string>
+    <string name="settings_tts_add_api_key">API キーを追加</string>
+    <string name="settings_tts_add_api_key_title">%1$s API キーを追加</string>
+    <string name="settings_tts_add_api_key_save">保存</string>
+    <string name="settings_tts_add_api_key_cancel">キャンセル</string>
+
+    <!--
     Today screen — top bar, refresh toasts, empty state, generated-at
     timestamp, outfit card, hourly chart, confidence chip, work-status
     banner. ます-form (friendly-polite) throughout — that's the standard

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -219,6 +219,25 @@ Japanese uses the ideographic period (。) for sentence endings.
     <string name="settings_elevenlabs_key_clear">保存された ElevenLabs キーを削除</string>
 
     <!--
+    Location screen — device-location toggle, manual city search +
+    selection, and the "no location set" empty state.
+    -->
+    <string name="settings_location_title">位置情報</string>
+    <string name="settings_location_use_device">端末の位置情報を使用</string>
+    <string name="settings_location_grant_background">バックグラウンド位置情報を許可（システム設定）</string>
+    <string name="settings_location_unset">位置情報が未設定 — ロンドンを既定として使用</string>
+    <string name="settings_location_description">予報はこの場所について取得されます。都市名で検索してください。結果は Open-Meteo の無料ジオコーディングサービスから取得されます。</string>
+    <string name="settings_location_description_device_on">有効にすると、ClothesCast は通知時に端末のおおよその位置を読み取ります（基地局 / WiFi のみ — GPS ハードウェア測位は使用しません）。端末からの読み取りに失敗した場合、下の位置がフォールバックとして使用されます。バックグラウンド位置情報はシステム設定で許可する必要があり、許可がないと朝の Worker が読み取れません。</string>
+    <string name="settings_location_set">位置を設定</string>
+    <string name="settings_location_change">位置を変更</string>
+    <string name="settings_location_clear">位置をクリア</string>
+    <string name="settings_location_search_title">位置を検索</string>
+    <string name="settings_location_query_label">都市または場所</string>
+    <string name="settings_location_search">検索</string>
+    <string name="settings_location_searching">検索中…</string>
+    <string name="settings_location_no_results">該当する結果がありません。</string>
+
+    <!--
     Today screen — top bar, refresh toasts, empty state, generated-at
     timestamp, outfit card, hourly chart, confidence chip, work-status
     banner. ます-form (friendly-polite) throughout — that's the standard

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -238,6 +238,41 @@ Japanese uses the ideographic period (。) for sentence endings.
     <string name="settings_location_no_results">該当する結果がありません。</string>
 
     <!--
+    Notification channels (system Settings → App → Notifications) and
+    the per-channel notification titles. Three channels: daily, nightly
+    (default + silent variants), weather alerts.
+    -->
+    <string name="notification_channel_daily_insight_name">毎日の ClothesCast</string>
+    <string name="notification_channel_daily_insight_description">あなたが有効にした朝の天気要約です。</string>
+    <string name="notification_daily_insight_title">今日の天気</string>
+
+    <string name="notification_channel_tonight_insight_default_name">夜間の ClothesCast（予定あり）</string>
+    <string name="notification_channel_tonight_insight_default_description">今夜カレンダーに予定があるときの夜の天気要約です。既定の通知音を鳴らします。</string>
+    <string name="notification_channel_tonight_insight_silent_name">夜間の ClothesCast（無音）</string>
+    <string name="notification_channel_tonight_insight_silent_description">予定のない夜の天気要約です。無音で配信され、ロック画面で確認できますが、音は鳴りません。</string>
+    <string name="notification_tonight_insight_title">今夜の天気</string>
+
+    <string name="notification_channel_weather_alerts_name">悪天候警報</string>
+    <string name="notification_channel_weather_alerts_description">あなたの地域の重大または極端な気象現象に対する高優先度の警報です。日次取得で検出され次第、配信されます。</string>
+    <string name="notification_weather_alert_title">気象警報：%1$s</string>
+
+    <!-- Notification-permission card. -->
+    <string name="settings_notification_permission_title">通知がブロックされています</string>
+    <string name="settings_notification_permission_description">通知の許可がないと、毎日の ClothesCast の届け先がありません。許可すれば、ClothesCast は明日の朝に表示されます。</string>
+    <string name="settings_notification_permission_grant">通知を許可</string>
+
+    <!-- Calendar opt-in card. Description preserves the privacy
+         disclosure ("説明、参加者、場所は読み取られますが端末から外には出ません").
+         Quotes around the nested example use Japanese corner-bracket
+         「…」. -->
+    <string name="settings_calendar_title">カレンダー</string>
+    <string name="settings_calendar_use_events">今日のカレンダーの予定を使用</string>
+    <string name="settings_calendar_description_off">有効にすると、ClothesCast は端末のカレンダーから今日の予定を読み取り、朝の ClothesCast が特定の予定に合わせて服装を提案できるようになります — 例：「午後3時の公園ランニングのために傘を持参」。予定のタイトルと時刻のみが使用され、説明、参加者、場所は読み取られますが端末から外には出ません。</string>
+    <string name="settings_calendar_description_on">朝の ClothesCast を充実させるため、端末のカレンダーから今日の予定を読み取っています。要約にはタイトルと時刻のみを使用し、説明や参加者は使用しません。すべて端末内に留まります。</string>
+    <string name="settings_calendar_grant_permission">カレンダーへのアクセスを許可</string>
+    <string name="settings_calendar_open_settings">カレンダーへのアクセスが拒否されました。システム設定で許可してください。</string>
+
+    <!--
     Today screen — top bar, refresh toasts, empty state, generated-at
     timestamp, outfit card, hourly chart, confidence chip, work-status
     banner. ます-form (friendly-polite) throughout — that's the standard

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -272,6 +272,24 @@ Japanese uses the ideographic period (。) for sentence endings.
     <string name="settings_calendar_grant_permission">カレンダーへのアクセスを許可</string>
     <string name="settings_calendar_open_settings">カレンダーへのアクセスが拒否されました。システム設定で許可してください。</string>
 
+    <!-- Debug screen — visible only on debug builds. -->
+    <string name="settings_debug_title">デバッグ（デバッグビルドのみ）</string>
+    <string name="settings_debug_description">毎日の ClothesCast パイプラインを直ちに実行します。スケジュールされた時刻を待たずに動作確認するのに便利です。</string>
+    <string name="settings_debug_fire_now">ClothesCast を今すぐ実行</string>
+    <string name="settings_debug_fire_toast">ClothesCast Worker をキューに追加しました</string>
+
+    <!-- About screen — version line, build-type suffix, privacy summary,
+         outbound links / actions. -->
+    <string name="settings_about_title">アプリについて</string>
+    <string name="settings_about_version">バージョン %1$s（%2$d）</string>
+    <string name="settings_about_build_type_suffix"> · %1$s ビルド</string>
+    <string name="settings_about_privacy">あなたの Gemini API キー（音声読み上げ TTS で使用）は、Android Keystore に紐付いたキーで暗号化して保存されます。予報は Open-Meteo から取得しています（キー不要、アカウント不要）。毎日の要約テキストは端末でローカルに生成されます。ClothesCast にはバックエンドはなく、私たちが管理するサーバーには何も送信されません。</string>
+    <string name="settings_about_privacy_policy">プライバシーポリシー</string>
+    <string name="settings_about_source">GitHub のソースコード</string>
+    <string name="settings_about_dontkillmyapp">バックグラウンド制限（dontkillmyapp.com）</string>
+    <string name="settings_about_share_bug_report">バグレポートを共有</string>
+    <string name="settings_about_version_copied">バージョンをクリップボードにコピーしました</string>
+
     <!--
     Today screen — top bar, refresh toasts, empty state, generated-at
     timestamp, outfit card, hourly chart, confidence chip, work-status


### PR DESCRIPTION
## Summary

Japanese UI translation, mirroring the prior locale passes. Eleven
commits — ten surface-by-surface fills for the values-ja file, plus a
final header refresh.

The existing ja file already used ます-form (friendly-polite — the
standard Japanese app register, including for intimate / spousal
addressing), so no tone-fix commit was needed. Japanese doesn't drop
politeness for closeness the way Romance languages do; the spousal-
tone equivalent is "warm polite", not "casual plain".

## Surfaces

- Today screen + home-screen widget
- Onboarding flow
- Settings root nav + Clothes section header
- Schedule screen (daily, nightly, delivery)
- Voice screen (engine + voice + language pickers)
- Region screen + Voice locale picker labels (28 locales × 2)
- API keys screen
- Location screen
- Notification channels + permission card + Calendar
- Debug + About screens
- File header refresh documenting the new scope, the deliberate
  non-overrides, and the Japanese typography conventions

After this PR the values-ja file has 293 strings vs. 300 in the en-US
baseline; the seven gaps are the same deliberate non-overrides as the
prior locale PRs.

## Tone

ます-form (friendly-polite) throughout. 〜してください for instructions,
〜ましょう for invitations, 〜です/ます for statements. Matches the
register the existing insight prose already used (着ていきましょう /
持っていきましょう).

"コーデ" (short for コーディネート) rather than the English loanword
"Outfit" for the widget label — standard Japanese fashion-vocab.

Brand "ClothesCast" stays in Latin script with the conventional
space-around-Latin spacing. Stale `insight_calendar_tie_in` is left
untouched (fleet-wide cleanup out of scope).

## Typography

Japanese typography conventions matter for readability:
- Sentence-final period 。 (ideographic full stop)
- List enumeration uses 、 (読点)
- Quotes around nested labels use corner-bracket 「…」 (not the German
  „…" form used in the Romance / Germanic locales)
- Parentheses use full-width （）around Japanese content
- Latin brand names and URLs keep space-around-Latin spacing

## Privacy

Display-only. No new strings cross the device boundary; the rendered
insight prose was already fully Japanese via the existing `insight_*`
translations.

## Test plan

- [ ] CI: `JVM unit tests` green (no ja tests pin specific prose so
      nothing to update)
- [ ] CI: `Android debug build` green
- [ ] Manual: phone in ja-JP (or **Region: 日本語（日本）**) → walk every
      screen and confirm Japanese throughout, no English fall-through;
      widget label reads "コーデ", Settings reads "設定"

https://claude.ai/code/session_01C1Q3vzGj6KmbYDfD6b2yhu

---
_Generated by [Claude Code](https://claude.ai/code/session_015agXppcN2fzATq5Xnzpozs)_