### PR TITLE
:app — defer briefing until phone call ends; pin focus listener to main Looper

### DIFF
--- a/app/src/main/kotlin/app/clothescast/tts/SpeechAudioFocus.kt
+++ b/app/src/main/kotlin/app/clothescast/tts/SpeechAudioFocus.kt
@@ -4,18 +4,31 @@ import android.content.Context
 import android.media.AudioAttributes
 import android.media.AudioFocusRequest
 import android.media.AudioManager
+import android.os.Handler
+import android.os.Looper
 import app.clothescast.diag.DiagLog
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.withTimeoutOrNull
 
 /**
- * Holds transient audio focus with ducking around [block] so the spoken briefing
- * doesn't talk over music or a podcast — other apps drop their volume for the
- * duration and recover when we abandon focus. [block] always runs: if focus is
- * denied (rare; usually a phone call), we log and play at full volume rather
- * than swallow the briefing the user is waiting on.
+ * Holds audio focus around [block] so the spoken briefing doesn't talk over
+ * music or a podcast.
  *
- * Used at the *playback session* boundary (the worker's speak-with-fallback,
- * the Settings preview) rather than per-engine, so the focus is held across the
- * whole "try cloud, fall back to device" chain in one request.
+ * Two-stage strategy:
+ * 1. Try `AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK` first — polite. Other apps just
+ *    drop their volume for the duration; nothing pauses. This is the path
+ *    taken in the common case (no phone call, no exclusive holder).
+ * 2. If ducking is refused (typically because a phone call holds exclusive
+ *    focus), retry with `AUDIOFOCUS_GAIN` + `setAcceptsDelayedFocusGain(true)`.
+ *    The system queues us until the call ends, then fires `AUDIOFOCUS_GAIN`
+ *    on the listener — at which point we proceed. Only `AUDIOFOCUS_GAIN`
+ *    supports delayed grant; ducking grants are immediate-or-fail.
+ *
+ * The delayed wait is bounded ([MAX_DELAYED_FOCUS_WAIT_MS]) so a long phone
+ * call doesn't hold a [androidx.work.CoroutineWorker] open until WorkManager
+ * kills the whole job. Past the cap, the briefing is stale enough that the
+ * notification (which fired before TTS) is the better delivery anyway, so we
+ * speak at full volume rather than silently swallowing the briefing.
  */
 internal suspend fun <T> withSpeechAudioFocus(
     context: Context,
@@ -23,22 +36,67 @@ internal suspend fun <T> withSpeechAudioFocus(
 ): T {
     val am = context.applicationContext.getSystemService(Context.AUDIO_SERVICE) as? AudioManager
         ?: return block()
-    val request = AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK)
-        .setAudioAttributes(
-            AudioAttributes.Builder()
-                .setUsage(AudioAttributes.USAGE_ASSISTANT)
-                .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
-                .build(),
-        )
-        .setOnAudioFocusChangeListener {}
+
+    // The listener Handler must be supplied explicitly: the no-arg
+    // setOnAudioFocusChangeListener overload uses the calling thread's Looper,
+    // and we're invoked from Dispatchers.IO / WorkManager — neither has one,
+    // so Builder.build() would crash with "Can't create handler inside thread
+    // that has not called Looper.prepare()". Pin the listener to the main
+    // Looper, which is always available.
+    val mainHandler = Handler(Looper.getMainLooper())
+    val ducking = AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK)
+        .setAudioAttributes(SPEECH_ATTRS)
+        .setOnAudioFocusChangeListener({}, mainHandler)
         .build()
-    val granted = am.requestAudioFocus(request) == AudioManager.AUDIOFOCUS_REQUEST_GRANTED
-    if (!granted) DiagLog.w(TAG, "Audio focus not granted; speaking anyway.")
+    if (am.requestAudioFocus(ducking) == AudioManager.AUDIOFOCUS_REQUEST_GRANTED) {
+        return try {
+            block()
+        } finally {
+            runCatching { am.abandonAudioFocusRequest(ducking) }
+        }
+    }
+
+    // Ducking refused — most often a phone call holding exclusive focus. Retry
+    // with an exclusive request that the system can defer until the holder
+    // releases. Past the cap we give up and speak anyway.
+    val granted = CompletableDeferred<Boolean>()
+    val listener = AudioManager.OnAudioFocusChangeListener { change ->
+        when (change) {
+            AudioManager.AUDIOFOCUS_GAIN ->
+                if (!granted.isCompleted) granted.complete(true)
+            AudioManager.AUDIOFOCUS_LOSS ->
+                if (!granted.isCompleted) granted.complete(false)
+        }
+    }
+    val exclusive = AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN)
+        .setAudioAttributes(SPEECH_ATTRS)
+        .setAcceptsDelayedFocusGain(true)
+        .setOnAudioFocusChangeListener(listener, mainHandler)
+        .build()
+    when (am.requestAudioFocus(exclusive)) {
+        AudioManager.AUDIOFOCUS_REQUEST_GRANTED -> Unit
+        AudioManager.AUDIOFOCUS_REQUEST_DELAYED -> {
+            DiagLog.i(TAG, "Audio focus delayed (likely a call); waiting up to ${MAX_DELAYED_FOCUS_WAIT_MS}ms")
+            val gotIt = withTimeoutOrNull(MAX_DELAYED_FOCUS_WAIT_MS) { granted.await() } == true
+            if (!gotIt) DiagLog.w(TAG, "Gave up waiting for delayed audio focus; speaking anyway.")
+        }
+        else -> DiagLog.w(TAG, "Audio focus refused outright; speaking anyway.")
+    }
     return try {
         block()
     } finally {
-        runCatching { am.abandonAudioFocusRequest(request) }
+        runCatching { am.abandonAudioFocusRequest(exclusive) }
     }
 }
+
+// 5 minutes. Catches typical short calls (under ~3 min) with margin while
+// staying well inside WorkManager's ~10-minute soft job ceiling and well
+// short of the point where the briefing is too stale to matter.
+private const val MAX_DELAYED_FOCUS_WAIT_MS: Long = 5 * 60 * 1000L
+
+private val SPEECH_ATTRS: AudioAttributes = AudioAttributes.Builder()
+    .setUsage(AudioAttributes.USAGE_ASSISTANT)
+    .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
+    .build()
 
 private const val TAG = "SpeechAudioFocus"


### PR DESCRIPTION
Follow-up to #179. Two related changes to `SpeechAudioFocus`.

## Summary

**1. Delayed focus grant.** When the polite ducking request is refused — typically because a phone call holds `AUDIOFOCUS_GAIN_TRANSIENT_EXCLUSIVE`, which can't coexist with ducking — retry with `AUDIOFOCUS_GAIN` + `setAcceptsDelayedFocusGain(true)`. The system queues the request and fires `AUDIOFOCUS_GAIN` on the listener when the call ends, at which point `block()` proceeds. Wait is capped at 5 minutes so a long call doesn't keep WorkManager's ~10-minute job alive past the OS's tolerance; past the cap the briefing is stale enough that the notification is the better delivery path anyway, so we speak unyielded.

**2. Crash fix from #179 review** ([Copilot](https://github.com/mikelward/clothescast/pull/179#pullrequestreview-4189225378)). `Builder.setOnAudioFocusChangeListener`'s no-arg overload calls `Handler()` under the hood, which throws on any thread without a Looper. The helper is invoked from `Dispatchers.IO` (settings preview) and WorkManager's CoroutineWorker (worker), neither of which has one — so the previous code would crash on first use in those paths. Pin both listeners to `Handler(Looper.getMainLooper())`.

## Out of scope

Mid-briefing yield — pause / resume when focus is lost *after* speech has started — is not covered here. `TextToSpeech` has no native pause, and `PcmAudioPlayer` would need frame-offset tracking. Both are real engineering, separate PR.

## Privacy

No change to what leaves the device.

## Test plan

- [ ] CI: `JVM unit tests` and `Android debug build` green
- [ ] Manual: trigger a manual briefing while on a phone call — briefing waits, plays after the call ends
- [ ] Manual: trigger a manual briefing while on a > 5-minute call — briefing fires at the cap, plays at full volume (notification was already delivered)
- [ ] Manual: regression — briefing still ducks Spotify when no call is active
- [ ] Manual: Settings → Test Voice from each engine — does not crash on the IO dispatcher (this is the path #179 would have crashed on without the Handler fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PpqBaTxkUW7h3xpjUdzRvY)_