### PR TITLE
:app — clearer wording around AUDIOFOCUS_GAIN; distinguish timeout from loss in logs

### DIFF
--- a/app/src/main/kotlin/app/clothescast/tts/SpeechAudioFocus.kt
+++ b/app/src/main/kotlin/app/clothescast/tts/SpeechAudioFocus.kt
@@ -17,12 +17,15 @@ import kotlinx.coroutines.withTimeoutOrNull
  * Two-stage strategy:
  * 1. Try `AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK` first — polite. Other apps just
  *    drop their volume for the duration; nothing pauses. This is the path
- *    taken in the common case (no phone call, no exclusive holder).
- * 2. If ducking is refused (typically because a phone call holds exclusive
- *    focus), retry with `AUDIOFOCUS_GAIN` + `setAcceptsDelayedFocusGain(true)`.
- *    The system queues us until the call ends, then fires `AUDIOFOCUS_GAIN`
- *    on the listener — at which point we proceed. Only `AUDIOFOCUS_GAIN`
- *    supports delayed grant; ducking grants are immediate-or-fail.
+ *    taken in the common case (no phone call, no other holder of exclusive
+ *    focus).
+ * 2. If ducking is refused (typically because a phone call holds
+ *    `AUDIOFOCUS_GAIN_TRANSIENT_EXCLUSIVE`), retry with `AUDIOFOCUS_GAIN`
+ *    (full focus, non-ducking — other media stops rather than just dimming)
+ *    plus `setAcceptsDelayedFocusGain(true)`. The system queues us until
+ *    the holder releases, then fires `AUDIOFOCUS_GAIN` on the listener — at
+ *    which point we proceed. Only `AUDIOFOCUS_GAIN` supports delayed grant;
+ *    ducking grants are immediate-or-fail.
  *
  * The delayed wait is bounded ([MAX_DELAYED_FOCUS_WAIT_MS]) so a long phone
  * call doesn't hold a [androidx.work.CoroutineWorker] open until WorkManager
@@ -56,9 +59,13 @@ internal suspend fun <T> withSpeechAudioFocus(
         }
     }
 
-    // Ducking refused — most often a phone call holding exclusive focus. Retry
-    // with an exclusive request that the system can defer until the holder
-    // releases. Past the cap we give up and speak anyway.
+    // Ducking refused — most often a phone call holding the
+    // AUDIOFOCUS_GAIN_TRANSIENT_EXCLUSIVE that calls take, which is
+    // incompatible with our duck-alongside request. Retry with full focus
+    // (AUDIOFOCUS_GAIN, the non-ducking gain) plus delayed-grant; the system
+    // queues us until the holder releases. Past the cap we give up and speak
+    // anyway — the notification has already fired and a stale briefing isn't
+    // worth waiting forever for.
     val granted = CompletableDeferred<Boolean>()
     val listener = AudioManager.OnAudioFocusChangeListener { change ->
         when (change) {
@@ -68,24 +75,32 @@ internal suspend fun <T> withSpeechAudioFocus(
                 if (!granted.isCompleted) granted.complete(false)
         }
     }
-    val exclusive = AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN)
+    val fullFocus = AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN)
         .setAudioAttributes(SPEECH_ATTRS)
         .setAcceptsDelayedFocusGain(true)
         .setOnAudioFocusChangeListener(listener, mainHandler)
         .build()
-    when (am.requestAudioFocus(exclusive)) {
+    when (am.requestAudioFocus(fullFocus)) {
         AudioManager.AUDIOFOCUS_REQUEST_GRANTED -> Unit
         AudioManager.AUDIOFOCUS_REQUEST_DELAYED -> {
             DiagLog.i(TAG, "Audio focus delayed (likely a call); waiting up to ${MAX_DELAYED_FOCUS_WAIT_MS}ms")
-            val gotIt = withTimeoutOrNull(MAX_DELAYED_FOCUS_WAIT_MS) { granted.await() } == true
-            if (!gotIt) DiagLog.w(TAG, "Gave up waiting for delayed audio focus; speaking anyway.")
+            // null = our own timeout fired (current holder still has focus
+            // after the cap); false = the listener got an explicit
+            // AUDIOFOCUS_LOSS while we were queued (some other system event
+            // revoked our pending grant). Distinguish in the log so a stuck
+            // call vs. a system revocation is visible.
+            when (withTimeoutOrNull(MAX_DELAYED_FOCUS_WAIT_MS) { granted.await() }) {
+                true -> Unit
+                false -> DiagLog.w(TAG, "Delayed audio focus explicitly lost while waiting; speaking anyway.")
+                null -> DiagLog.w(TAG, "Timed out waiting for delayed audio focus; speaking anyway.")
+            }
         }
         else -> DiagLog.w(TAG, "Audio focus refused outright; speaking anyway.")
     }
     return try {
         block()
     } finally {
-        runCatching { am.abandonAudioFocusRequest(exclusive) }
+        runCatching { am.abandonAudioFocusRequest(fullFocus) }
     }
 }
 


### PR DESCRIPTION
Three drive-by clarifications from #182's [Copilot review](https://github.com/mikelward/clothescast/pull/182). No functional change.

## Summary

1. **"Exclusive" was loose terminology.** The retry path uses `AUDIOFOCUS_GAIN`, not `AUDIOFOCUS_GAIN_TRANSIENT_EXCLUSIVE`. Phone calls hold exclusive focus, but our request is plain `GAIN` (full focus, non-ducking — other media stops rather than just dimming). Renamed the local variable `exclusive` → `fullFocus` and reworked the surrounding KDoc / inline comment so future readers don't assume exclusivity semantics that aren't present.

2. **Distinguish timeout from loss in the delayed-grant path.** `withTimeoutOrNull` returning `null` means our 5-minute cap fired (the holder still has focus); a `false` from the deferred means the listener observed `AUDIOFOCUS_LOSS` while we were queued (some other system event revoked our pending grant). The previous single "Gave up waiting…" log conflated both. Now they log separately, which makes the cause visible in bug reports.

## Privacy

No change to what leaves the device.

## Test plan

- [ ] CI green
- [ ] Code reads cleanly with the new naming

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PpqBaTxkUW7h3xpjUdzRvY)_