### PR TITLE
:app — Russian UI: ты-form translations + Вы-form tone fix

### DIFF
--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -102,6 +102,92 @@ earlier passes accidentally mixed in.
     <string name="settings_tts_add_api_key_cancel">Отмена</string>
 
     <!--
+    Region screen — language picker title + caption (the disambiguation
+    copy explaining that this knob is the *displayed text*, not the
+    spoken accent), the system-default option, and the per-locale
+    labels in Russian style ("Английский (США)", "Французский (Канада)",
+    "Китайский (упрощённый)", …). The locale tag stored on disk
+    (en-US / fr-CA / zh-CN) is unchanged; only the displayed label
+    localizes.
+    -->
+    <string name="settings_region_language_title">Язык</string>
+    <string name="settings_region_language_description">Задаёт язык отображаемого текста и уведомлений.</string>
+    <string name="settings_region_language_system">По языку системы</string>
+    <string name="settings_region_language_en_us">Английский (США)</string>
+    <string name="settings_region_language_en_gb">Английский (Великобритания)</string>
+    <string name="settings_region_language_en_au">Английский (Австралия)</string>
+    <string name="settings_region_language_en_ca">Английский (Канада)</string>
+    <string name="settings_region_language_en_za">Английский (Южная Африка)</string>
+    <string name="settings_region_language_de_de">Немецкий (Германия)</string>
+    <string name="settings_region_language_fr_fr">Французский (Франция)</string>
+    <string name="settings_region_language_fr_ca">Французский (Канада)</string>
+    <string name="settings_region_language_it_it">Итальянский (Италия)</string>
+    <string name="settings_region_language_es_es">Испанский (Испания)</string>
+    <string name="settings_region_language_es_mx">Испанский (Мексика)</string>
+    <string name="settings_region_language_pl_pl">Польский (Польша)</string>
+    <string name="settings_region_language_hr_hr">Хорватский (Хорватия)</string>
+    <string name="settings_region_language_uk_ua">Украинский (Украина)</string>
+    <string name="settings_region_language_pt_br">Португальский (Бразилия)</string>
+    <string name="settings_region_language_nl_nl">Нидерландский (Нидерланды)</string>
+    <string name="settings_region_language_sv_se">Шведский (Швеция)</string>
+    <string name="settings_region_language_tr_tr">Турецкий (Турция)</string>
+    <string name="settings_region_language_id_id">Индонезийский (Индонезия)</string>
+    <string name="settings_region_language_fil_ph">Филиппинский (Филиппины)</string>
+    <string name="settings_region_language_vi_vn">Вьетнамский (Вьетнам)</string>
+    <string name="settings_region_language_zh_cn">Китайский (упрощённый)</string>
+    <string name="settings_region_language_hi_in">Хинди (Индия)</string>
+    <string name="settings_region_language_bn_bd">Бенгальский (Бангладеш)</string>
+    <string name="settings_region_language_ja_jp">Японский (Япония)</string>
+    <string name="settings_region_language_ko_kr">Корейский (Южная Корея)</string>
+    <string name="settings_region_language_ar_sa">Арабский (Саудовская Аравия)</string>
+    <string name="settings_region_language_he_il">Иврит (Израиль)</string>
+    <string name="settings_region_language_fa_ir">Персидский (Иран)</string>
+
+    <!-- Region screen — units pickers. -->
+    <string name="settings_temperature_unit_title">Единицы температуры</string>
+    <string name="settings_temperature_unit_celsius">Цельсий (°C)</string>
+    <string name="settings_temperature_unit_fahrenheit">Фаренгейт (°F)</string>
+    <string name="settings_distance_unit_title">Единицы расстояния</string>
+    <string name="settings_distance_unit_kilometers">Километры</string>
+    <string name="settings_distance_unit_miles">Мили</string>
+
+    <!--
+    Voice locale picker labels — same Russian language-name translations
+    as the Region picker above, just keyed under
+    `settings_tts_voice_locale_*` because the Voice screen's language
+    sub-picker is a separate UI surface.
+    -->
+    <string name="settings_tts_voice_locale_en_us">Английский (США)</string>
+    <string name="settings_tts_voice_locale_en_gb">Английский (Великобритания)</string>
+    <string name="settings_tts_voice_locale_en_au">Английский (Австралия)</string>
+    <string name="settings_tts_voice_locale_en_ca">Английский (Канада)</string>
+    <string name="settings_tts_voice_locale_en_za">Английский (Южная Африка)</string>
+    <string name="settings_tts_voice_locale_de_de">Немецкий (Германия)</string>
+    <string name="settings_tts_voice_locale_fr_fr">Французский (Франция)</string>
+    <string name="settings_tts_voice_locale_fr_ca">Французский (Канада)</string>
+    <string name="settings_tts_voice_locale_it_it">Итальянский (Италия)</string>
+    <string name="settings_tts_voice_locale_es_es">Испанский (Испания)</string>
+    <string name="settings_tts_voice_locale_es_mx">Испанский (Мексика)</string>
+    <string name="settings_tts_voice_locale_pl_pl">Польский (Польша)</string>
+    <string name="settings_tts_voice_locale_hr_hr">Хорватский (Хорватия)</string>
+    <string name="settings_tts_voice_locale_uk_ua">Украинский (Украина)</string>
+    <string name="settings_tts_voice_locale_pt_br">Португальский (Бразилия)</string>
+    <string name="settings_tts_voice_locale_nl_nl">Нидерландский (Нидерланды)</string>
+    <string name="settings_tts_voice_locale_sv_se">Шведский (Швеция)</string>
+    <string name="settings_tts_voice_locale_tr_tr">Турецкий (Турция)</string>
+    <string name="settings_tts_voice_locale_id_id">Индонезийский (Индонезия)</string>
+    <string name="settings_tts_voice_locale_fil_ph">Филиппинский (Филиппины)</string>
+    <string name="settings_tts_voice_locale_vi_vn">Вьетнамский (Вьетнам)</string>
+    <string name="settings_tts_voice_locale_zh_cn">Китайский (упрощённый)</string>
+    <string name="settings_tts_voice_locale_hi_in">Хинди (Индия)</string>
+    <string name="settings_tts_voice_locale_bn_bd">Бенгальский (Бангладеш)</string>
+    <string name="settings_tts_voice_locale_ja_jp">Японский (Япония)</string>
+    <string name="settings_tts_voice_locale_ko_kr">Корейский (Южная Корея)</string>
+    <string name="settings_tts_voice_locale_ar_sa">Арабский (Саудовская Аравия)</string>
+    <string name="settings_tts_voice_locale_he_il">Иврит (Израиль)</string>
+    <string name="settings_tts_voice_locale_fa_ir">Персидский (Иран)</string>
+
+    <!--
     Today screen — top bar, refresh toasts, empty state, generated-at
     timestamp, outfit card, hourly chart, confidence chip, work-status
     banner. ты-form imperatives: "нажми", "установи", "твой".

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -188,6 +188,35 @@ earlier passes accidentally mixed in.
     <string name="settings_tts_voice_locale_fa_ir">Персидский (Иран)</string>
 
     <!--
+    API keys screen — three identical-shape blocks (Gemini, OpenAI,
+    ElevenLabs), each with status copy, paste-key placeholder, and
+    save / clear buttons. URLs stay verbatim.
+    -->
+    <string name="settings_api_keys_title">Ключи API</string>
+    <string name="settings_api_keys_description">Настрой ключи API для онлайн-голосовых движков, которые ты хочешь использовать. Ключи зашифрованы с помощью Android Keystore.</string>
+    <string name="settings_api_key_gemini_label">Gemini</string>
+    <string name="settings_api_key_openai_label">OpenAI</string>
+    <string name="settings_api_key_elevenlabs_label">ElevenLabs</string>
+
+    <string name="settings_api_key_status_set">Ключ Gemini настроен.</string>
+    <string name="settings_api_key_status_unset">Ключ Gemini не настроен. Получи на aistudio.google.com, чтобы использовать голоса Gemini.</string>
+    <string name="settings_api_key_placeholder">Вставь свой ключ API Gemini</string>
+    <string name="settings_api_key_save">Сохранить ключ Gemini</string>
+    <string name="settings_api_key_clear">Удалить сохранённый ключ Gemini</string>
+
+    <string name="settings_openai_key_status_set">Ключ OpenAI настроен.</string>
+    <string name="settings_openai_key_status_unset">Ключ OpenAI не настроен. Получи на platform.openai.com, чтобы использовать голоса OpenAI.</string>
+    <string name="settings_openai_key_placeholder">Вставь свой ключ API OpenAI</string>
+    <string name="settings_openai_key_save">Сохранить ключ OpenAI</string>
+    <string name="settings_openai_key_clear">Удалить сохранённый ключ OpenAI</string>
+
+    <string name="settings_elevenlabs_key_status_set">Ключ ElevenLabs настроен.</string>
+    <string name="settings_elevenlabs_key_status_unset">Ключ ElevenLabs не настроен. Получи на elevenlabs.io, чтобы использовать голоса ElevenLabs.</string>
+    <string name="settings_elevenlabs_key_placeholder">Вставь свой ключ API ElevenLabs</string>
+    <string name="settings_elevenlabs_key_save">Сохранить ключ ElevenLabs</string>
+    <string name="settings_elevenlabs_key_clear">Удалить сохранённый ключ ElevenLabs</string>
+
+    <!--
     Today screen — top bar, refresh toasts, empty state, generated-at
     timestamp, outfit card, hourly chart, confidence chip, work-status
     banner. ты-form imperatives: "нажми", "установи", "твой".

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-Russian translation. Scope: insight-prose templates, garment labels, clothes-rule
-editor, outfit-card labels, and region/voice-locale picker names.
+Russian translation. Tone is informal "ты"-form throughout (intimate /
+spousal register), matching the spouse-style register the user wants.
+Avoid formal "Вы"-form ("Наденьте", "Возьмите", "Нажмите", "Ваш") that
+earlier passes accidentally mixed in.
 -->
 <resources>
     <string name="settings_region_language_ru_ru">Русский (Россия)</string>
@@ -18,7 +20,7 @@ editor, outfit-card labels, and region/voice-locale picker names.
     <string name="garment_pants">Брюки</string>
     <string name="garment_jeans">Джинсы</string>
 
-    <string name="settings_clothes_empty">Нет правил. Нажмите «Добавить», чтобы создать.</string>
+    <string name="settings_clothes_empty">Нет правил. Нажми «Добавить», чтобы создать.</string>
     <string name="settings_clothes_add">Добавить</string>
     <string name="settings_clothes_edit">Изменить</string>
     <string name="settings_clothes_delete">Удалить</string>
@@ -54,7 +56,7 @@ editor, outfit-card labels, and region/voice-locale picker names.
     <string name="insight_delta_warmer">Сегодня на %1$d° теплее.</string>
     <string name="insight_delta_cooler">Сегодня на %1$d° холоднее.</string>
     <string name="insight_alert">Предупреждение: %1$s.</string>
-    <string name="insight_clothes_wear">Наденьте %1$s.</string>
+    <string name="insight_clothes_wear">Надень %1$s.</string>
     <string name="insight_clothes_article_a">%1$s</string>
     <string name="insight_clothes_article_an">%1$s</string>
     <string name="insight_clothes_join_two">%1$s и %2$s</string>
@@ -72,11 +74,11 @@ editor, outfit-card labels, and region/voice-locale picker names.
     <string name="insight_condition_thunderstorm">Гроза</string>
     <string name="insight_condition_unknown">Неизвестно</string>
     <string name="insight_calendar_tie_in">Возьмите %1$s на %3$s в %2$s.</string>
-    <string name="insight_tie_in">Возьмите %1$s сегодня вечером.</string>
-    <string name="insight_tie_in_with_rain">Возьмите %1$s сегодня вечером, дождь в %2$s.</string>
+    <string name="insight_tie_in">Возьми %1$s сегодня вечером.</string>
+    <string name="insight_tie_in_with_rain">Возьми %1$s сегодня вечером, дождь в %2$s.</string>
     <!-- "15" — preposition "в" comes from surrounding templates. -->
     <string name="insight_time_hour">%1$d</string>
     <string name="insight_time_hour_minutes">%1$d:%2$02d</string>
 
-    <string name="settings_tts_test_sample">Ваш сегодняшний ClothesCast: мягкая погода, дождь в 15:00. Наденьте куртку.</string>
+    <string name="settings_tts_test_sample">Твой сегодняшний ClothesCast: мягкая погода, дождь в 15:00. Надень куртку.</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -37,11 +37,58 @@ earlier passes accidentally mixed in.
     <string name="settings_clothes_cond_temp_above">когда ощущаемая температура выше %.0f°C</string>
     <string name="settings_clothes_cond_precip_above">когда вероятность дождя превышает %.0f%%</string>
 
+    <!--
+    Today screen — top bar, refresh toasts, empty state, generated-at
+    timestamp, outfit card, hourly chart, confidence chip, work-status
+    banner. ты-form imperatives: "нажми", "установи", "твой".
+    -->
+    <string name="today_title">Сегодня</string>
+    <string name="today_open_settings">Открыть настройки</string>
+    <string name="today_more_options">Ещё</string>
+    <string name="today_report_a_bug">Сообщить об ошибке</string>
+    <string name="today_refresh">Обновить</string>
+    <string name="today_refresh_toast_daily">Обновляю твой ежедневный ClothesCast — скоро появится.</string>
+    <string name="today_refresh_toast_nightly">Обновляю твой вечерний ClothesCast — скоро появится.</string>
+    <string name="today_empty_title">ClothesCast пока нет</string>
+    <string name="today_empty_subtitle">Твой утренний ClothesCast появится здесь, как только сгенерируется. Установи местоположение в настройках, затем нажми «Получить сейчас».</string>
+    <string name="today_fetch_now">Получить сейчас</string>
+    <string name="today_generated_at">Создано в %1$s</string>
+
+    <string name="today_outfit_title">Что надеть</string>
+    <string name="today_outfit_label_today">Сегодня</string>
+    <string name="today_outfit_label_tonight">Сегодня вечером</string>
+    <string name="today_outfit_label_tomorrow">Завтра</string>
+
     <string name="today_outfit_top_tshirt">Футболка</string>
     <string name="today_outfit_top_sweater">Свитер</string>
     <string name="today_outfit_top_thick_jacket">Тёплая куртка</string>
     <string name="today_outfit_bottom_shorts">Шорты</string>
     <string name="today_outfit_bottom_long_pants">Брюки</string>
+
+    <string name="today_forecast_title">Почасовой прогноз</string>
+    <string name="today_forecast_min_max">Ощущение %1$d – %2$d%3$s · Воздух %4$d – %5$d%6$s</string>
+    <string name="today_forecast_legend_feels_like">Ощущаемая температура (%1$s) по часам · нажми, чтобы переключить на температуру воздуха</string>
+    <string name="today_forecast_legend_air">Температура воздуха (%1$s) по часам · нажми, чтобы переключить на ощущаемую температуру</string>
+
+    <string name="today_confidence_high">Высокая уверенность — основные модели согласны</string>
+    <string name="today_confidence_medium">Средняя уверенность</string>
+    <string name="today_confidence_low">Низкая уверенность — прогнозы расходятся</string>
+    <string name="today_confidence_spread">Разброс: %1$.1f°C, %2$.0fpp осадков по %3$d моделям</string>
+
+    <string name="today_working">Получаю твой ClothesCast…</string>
+    <string name="today_failed_title">Последняя попытка не удалась</string>
+    <string name="today_failed_unexpected_http">Неожиданная HTTP-ошибка от службы прогноза.</string>
+    <string name="today_failed_unhandled">Произошла непредвиденная ошибка.</string>
+    <string name="today_failed_show_details">Показать подробности</string>
+    <string name="today_failed_hide_details">Скрыть подробности</string>
+
+    <!-- Home-screen App Widget. "Образ" is the standard Russian
+         fashion-vocab word for an outfit / day's clothing combination,
+         more native than the loanword "Outfit". -->
+    <string name="widget_label">Образ</string>
+    <string name="widget_description">Образ для текущего периода — с одного взгляда.</string>
+    <string name="widget_empty_title">Образа пока нет</string>
+    <string name="widget_empty_subtitle">Нажми, чтобы открыть ClothesCast</string>
 
     <string name="insight_lead_today">Сегодня</string>
     <string name="insight_lead_tonight">Сегодня вечером</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1,9 +1,34 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-Russian translation. Tone is informal "ты"-form throughout (intimate /
-spousal register), matching the spouse-style register the user wants.
-Avoid formal "Вы"-form ("Наденьте", "Возьмите", "Нажмите", "Ваш") that
-earlier passes accidentally mixed in.
+Russian translation — full UI coverage. Informal ты-form throughout
+(intimate / spousal register). No Вы-form anywhere.
+
+What is NOT overridden, by design:
+- `app_name` — brand identifier, identical across locales.
+- `insight_time_am` / `_pm` / `_midnight` / `_noon` (and *_minutes
+  variants) — English-only spoken-time formatter helpers. Russian
+  uses `insight_time_hour` / `_hour_minutes` ("15" / "15:30") which
+  are translated below; the AM/PM keys exist for the
+  `Locale.language == "en"` path only and would never be read in a ru
+  runtime.
+
+Russian forces gender agreement on past-tense verbs and predicate
+adjectives in the ты-form ("ты включил" vs. "ты включила"). The
+welcome leans on the conventional fixed greeting "Добро пожаловать"
+(no agreement); the Schedule and notification descriptions use passive
+phrasing where ты-form past-participle would force a gender ("если
+включено озвучивание" rather than "если ты включил озвучивание"; "Утренняя
+сводка погоды, которая включена" rather than "которую ты включил").
+Beyond those exceptions the rest stays in plain ты-form imperative.
+
+Quotes around nested labels use Russian guillemet «…» — locale-native
+style. Brand "ClothesCast" stays in Latin script.
+
+Picker labels under `settings_region_language_*` and
+`settings_tts_voice_locale_*` give the Russian names for every offered
+locale (Английский (США), Французский (Канада), Китайский (упрощённый),
+…). The locale tag stored on disk (en-US / fr-CA / zh-CN) is unchanged;
+only the displayed label localizes.
 -->
 <resources>
     <string name="settings_region_language_ru_ru">Русский (Россия)</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -54,6 +54,29 @@ earlier passes accidentally mixed in.
     <string name="settings_clothes_cond_precip_above">когда вероятность дождя превышает %.0f%%</string>
 
     <!--
+    Schedule screen — daily and nightly ClothesCast cards, delivery
+    picker, "Упоминать вечерние события" toggle, and the nightly-only
+    "notify only on events" toggle. Description uses Russian guillemet
+    «…» quotes around the nested toggle label — locale-native style.
+    -->
+    <string name="settings_schedule_title">Ежедневный ClothesCast</string>
+    <string name="settings_schedule_time_label">Время</string>
+    <string name="settings_schedule_days_label">Дни недели</string>
+    <string name="settings_daily_mention_evening_events">Упоминать вечерние события</string>
+
+    <string name="settings_tonight_title">Вечерний ClothesCast</string>
+    <string name="settings_tonight_description">Второй ClothesCast вечером, охватывающий погоду на сегодня вечером. В тихие вечера остаётся беззвучным или вообще не появляется, если включено «Уведомлять только при вечерних событиях»; в вечера с событиями издаёт звук и (если включено озвучивание) читает себя вслух.</string>
+    <string name="settings_tonight_enabled">Показывать вечерний ClothesCast</string>
+    <string name="settings_tonight_time_label">Время</string>
+    <string name="settings_tonight_days_label">Дни недели</string>
+    <string name="settings_tonight_notify_only_on_events">Уведомлять только при вечерних событиях</string>
+
+    <string name="settings_delivery_label">Доставка</string>
+    <string name="settings_delivery_notification_only">Только уведомление</string>
+    <string name="settings_delivery_tts_only">Только озвучивание</string>
+    <string name="settings_delivery_notification_and_tts">Уведомление и озвучивание</string>
+
+    <!--
     Today screen — top bar, refresh toasts, empty state, generated-at
     timestamp, outfit card, hourly chart, confidence chip, work-status
     banner. ты-form imperatives: "нажми", "установи", "твой".

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -90,6 +90,30 @@ earlier passes accidentally mixed in.
     <string name="widget_empty_title">Образа пока нет</string>
     <string name="widget_empty_subtitle">Нажми, чтобы открыть ClothesCast</string>
 
+    <!--
+    Onboarding flow — first-run welcome, two permission steps, Gemini
+    API-key step. "Добро пожаловать" is the conventional Russian
+    welcome (gender-neutral fixed greeting, sidesteps the masc/fem
+    agreement gender pick).
+    -->
+    <string name="onboarding_title">Добро пожаловать в ClothesCast</string>
+    <string name="onboarding_subtitle">Два быстрых выбора — и всё готово. У всего остального есть разумные значения по умолчанию, которые ты потом сможешь настроить в настройках.</string>
+    <string name="onboarding_notifications_title">Уведомления</string>
+    <string name="onboarding_notifications_description">Нужны для доставки твоего ежедневного ClothesCast. Разреши один раз — и ClothesCast появится завтра утром.</string>
+    <string name="onboarding_notifications_grant">Разрешить уведомления</string>
+    <string name="onboarding_location_title">Местоположение</string>
+    <string name="onboarding_location_description">Используется для получения правильного прогноза. Если разрешишь местоположение, ClothesCast сможет каждое утро читать примерное местоположение твоего устройства; иначе выбери город вручную.</string>
+    <string name="onboarding_location_grant">Разрешить доступ к местоположению</string>
+    <string name="onboarding_location_denied_hint">Доступ к местоположению отклонён. Можешь выбрать город вручную.</string>
+    <string name="onboarding_location_enter_manual">Ввести местоположение вручную</string>
+    <string name="onboarding_location_using_device">Каждое утро используем местоположение твоего устройства.</string>
+
+    <string name="onboarding_gemini_title">Ключ API Gemini</string>
+    <string name="onboarding_gemini_description">Используется ClothesCast для озвучивания и генерации прогноза. Получи бесплатно на aistudio.google.com. Ключ зашифрован с помощью Android Keystore.</string>
+    <string name="onboarding_step_done">Готово</string>
+    <string name="onboarding_skip">Пропустить пока</string>
+    <string name="onboarding_continue">Продолжить</string>
+
     <string name="insight_lead_today">Сегодня</string>
     <string name="insight_lead_tonight">Сегодня вечером</string>
     <string name="insight_band_single">%1$s будет %2$s.</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -77,6 +77,31 @@ earlier passes accidentally mixed in.
     <string name="settings_delivery_notification_and_tts">Уведомление и озвучивание</string>
 
     <!--
+    Voice screen — engine picker (Device / Gemini / OpenAI / ElevenLabs),
+    voice + language sub-pickers, test-voice button, missing-API-key
+    hint and the in-line "Добавить ключ API" dialog.
+    -->
+    <string name="settings_tts_engine_title">Голосовой движок</string>
+    <string name="settings_tts_engine_description">Онлайн-движки (Gemini, OpenAI, ElevenLabs) звучат намного естественнее, но требуют сетевого вызова при озвучивании и используют твой ключ API для синтеза (один короткий вызов на каждый озвученный ClothesCast). При сбое выбранного движка возвращается к голосу устройства.</string>
+    <string name="settings_tts_engine_device">Устройство (офлайн, бесплатно)</string>
+    <string name="settings_tts_engine_gemini">Gemini (высокое качество, онлайн)</string>
+    <string name="settings_tts_engine_openai">OpenAI (высокое качество, онлайн)</string>
+    <string name="settings_tts_engine_elevenlabs">ElevenLabs (наивысшее качество, онлайн)</string>
+
+    <string name="settings_tts_voice_label">Голос</string>
+    <string name="settings_tts_voice_dismiss">Готово</string>
+    <string name="settings_tts_voice_locale_description">Задаёт акцент озвучивания. Не меняет отображаемый текст.</string>
+    <string name="settings_tts_voice_locale_system">По языку телефона</string>
+
+    <string name="settings_tts_test">Проверить голос</string>
+    <string name="settings_tts_test_in_flight">Проверка — подожди…</string>
+    <string name="settings_tts_no_key_hint">Нет ключа %1$s — добавь, чтобы включить этот движок.</string>
+    <string name="settings_tts_add_api_key">Добавить ключ API</string>
+    <string name="settings_tts_add_api_key_title">Добавить ключ API %1$s</string>
+    <string name="settings_tts_add_api_key_save">Сохранить</string>
+    <string name="settings_tts_add_api_key_cancel">Отмена</string>
+
+    <!--
     Today screen — top bar, refresh toasts, empty state, generated-at
     timestamp, outfit card, hourly chart, confidence chip, work-status
     banner. ты-form imperatives: "нажми", "установи", "твой".

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -236,6 +236,41 @@ earlier passes accidentally mixed in.
     <string name="settings_location_no_results">Нет результатов.</string>
 
     <!--
+    Notification channels (system Settings → App → Notifications) and
+    the per-channel notification titles. Three channels: daily, nightly
+    (default + silent variants), weather alerts.
+    -->
+    <string name="notification_channel_daily_insight_name">Ежедневный ClothesCast</string>
+    <string name="notification_channel_daily_insight_description">Утренняя сводка погоды, которая включена.</string>
+    <string name="notification_daily_insight_title">Погода сегодня</string>
+
+    <string name="notification_channel_tonight_insight_default_name">Вечерний ClothesCast (с событиями)</string>
+    <string name="notification_channel_tonight_insight_default_description">Вечерняя сводка погоды, когда у тебя сегодня есть события в календаре. Воспроизводит звук уведомления по умолчанию.</string>
+    <string name="notification_channel_tonight_insight_silent_name">Вечерний ClothesCast (тихий)</string>
+    <string name="notification_channel_tonight_insight_silent_description">Вечерняя сводка погоды, когда у тебя свободный вечер. Доставляется бесшумно — можешь увидеть на экране блокировки, но звук не издаётся.</string>
+    <string name="notification_tonight_insight_title">Погода сегодня вечером</string>
+
+    <string name="notification_channel_weather_alerts_name">Предупреждения о непогоде</string>
+    <string name="notification_channel_weather_alerts_description">Высокоприоритетные предупреждения о серьёзных или экстремальных погодных явлениях в твоём районе. Доставляются, как только ежедневный сбор данных их обнаружит.</string>
+    <string name="notification_weather_alert_title">Погодное предупреждение: %1$s</string>
+
+    <!-- Notification-permission card. -->
+    <string name="settings_notification_permission_title">Уведомления заблокированы</string>
+    <string name="settings_notification_permission_description">Без разрешения на уведомления твоему ежедневному ClothesCast некуда деваться. Разреши, чтобы ClothesCast мог появиться завтра утром.</string>
+    <string name="settings_notification_permission_grant">Разрешить уведомления</string>
+
+    <!-- Calendar opt-in card. Description preserves the privacy
+         disclosure ("описания, участники и места читаются, но никогда не
+         покидают устройство"). Quotes around the nested example follow
+         the locale's «…» guillemet style. -->
+    <string name="settings_calendar_title">Календарь</string>
+    <string name="settings_calendar_use_events">Использовать события календаря на сегодня</string>
+    <string name="settings_calendar_description_off">Когда включено, ClothesCast читает события сегодняшнего дня из календаря твоего устройства, чтобы утренний ClothesCast мог предложить вещи, привязанные к конкретным событиям — например, «возьми зонт на пробежку в парке в 15:00». Используются только заголовки и время событий; описания, участники и места читаются, но никогда не покидают устройство.</string>
+    <string name="settings_calendar_description_on">Читаю события сегодняшнего дня из календаря твоего устройства, чтобы обогатить утренний ClothesCast. В сводке используются только заголовки и время; описания и участники не используются. Всё остаётся на устройстве.</string>
+    <string name="settings_calendar_grant_permission">Разрешить доступ к календарю</string>
+    <string name="settings_calendar_open_settings">Доступ к календарю запрещён. Разреши в системных настройках.</string>
+
+    <!--
     Today screen — top bar, refresh toasts, empty state, generated-at
     timestamp, outfit card, hourly chart, confidence chip, work-status
     banner. ты-form imperatives: "нажми", "установи", "твой".

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -270,6 +270,24 @@ earlier passes accidentally mixed in.
     <string name="settings_calendar_grant_permission">Разрешить доступ к календарю</string>
     <string name="settings_calendar_open_settings">Доступ к календарю запрещён. Разреши в системных настройках.</string>
 
+    <!-- Debug screen — visible only on debug builds. -->
+    <string name="settings_debug_title">Отладка (только в отладочных сборках)</string>
+    <string name="settings_debug_description">Запустить ежедневный пайплайн ClothesCast немедленно. Полезно для проверки без ожидания запланированного времени.</string>
+    <string name="settings_debug_fire_now">Запустить ClothesCast сейчас</string>
+    <string name="settings_debug_fire_toast">Worker ClothesCast добавлен в очередь</string>
+
+    <!-- About screen — version line, build-type suffix, privacy summary,
+         outbound links / actions. -->
+    <string name="settings_about_title">О приложении</string>
+    <string name="settings_about_version">Версия %1$s (%2$d)</string>
+    <string name="settings_about_build_type_suffix"> · сборка %1$s</string>
+    <string name="settings_about_privacy">Твой ключ API Gemini (используемый для озвучивания TTS) зашифрован с помощью ключа, привязанного к Android Keystore. Прогнозы поступают от Open-Meteo (без ключа, без аккаунта); текст ежедневной сводки генерируется локально на устройстве. У ClothesCast нет бэкенда — ничего не отправляется ни на один сервер, который мы контролируем.</string>
+    <string name="settings_about_privacy_policy">Политика конфиденциальности</string>
+    <string name="settings_about_source">Исходный код на GitHub</string>
+    <string name="settings_about_dontkillmyapp">Ограничения в фоне (dontkillmyapp.com)</string>
+    <string name="settings_about_share_bug_report">Поделиться отчётом об ошибке</string>
+    <string name="settings_about_version_copied">Версия скопирована в буфер обмена</string>
+
     <!--
     Today screen — top bar, refresh toasts, empty state, generated-at
     timestamp, outfit card, hourly chart, confidence chip, work-status

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -217,6 +217,25 @@ earlier passes accidentally mixed in.
     <string name="settings_elevenlabs_key_clear">Удалить сохранённый ключ ElevenLabs</string>
 
     <!--
+    Location screen — device-location toggle, manual city search +
+    selection, and the "no location set" empty state.
+    -->
+    <string name="settings_location_title">Местоположение</string>
+    <string name="settings_location_use_device">Использовать местоположение устройства</string>
+    <string name="settings_location_grant_background">Разрешить фоновое местоположение (системные настройки)</string>
+    <string name="settings_location_unset">Местоположение не задано — по умолчанию используется Лондон</string>
+    <string name="settings_location_description">Прогноз получается для этого места. Ищи по названию города; результаты приходят из бесплатной службы геокодирования Open-Meteo.</string>
+    <string name="settings_location_description_device_on">Когда включено, ClothesCast при отправке уведомления читает примерное местоположение твоего устройства (только сота / WiFi — без GPS-аппаратной фиксации). Указанное ниже местоположение используется как запасное, если чтение с устройства не удаётся. Фоновое местоположение должно быть разрешено в системных настройках, иначе утренний Worker не сможет его прочитать.</string>
+    <string name="settings_location_set">Задать местоположение</string>
+    <string name="settings_location_change">Изменить местоположение</string>
+    <string name="settings_location_clear">Очистить местоположение</string>
+    <string name="settings_location_search_title">Поиск местоположения</string>
+    <string name="settings_location_query_label">Город или место</string>
+    <string name="settings_location_search">Найти</string>
+    <string name="settings_location_searching">Поиск…</string>
+    <string name="settings_location_no_results">Нет результатов.</string>
+
+    <!--
     Today screen — top bar, refresh toasts, empty state, generated-at
     timestamp, outfit card, hourly chart, confidence chip, work-status
     banner. ты-form imperatives: "нажми", "установи", "твой".

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -10,6 +10,18 @@ earlier passes accidentally mixed in.
     <string name="settings_tts_voice_locale_ru_ru">Русский (Россия)</string>
     <string name="settings_tts_voice_locale_label">Язык</string>
 
+    <!-- Settings — top bar + root navigation list. -->
+    <string name="settings_title">Настройки</string>
+    <string name="settings_back">Назад</string>
+
+    <string name="settings_root_voice">Голос</string>
+    <string name="settings_root_schedule">Расписание</string>
+    <string name="settings_root_region">Регион</string>
+    <string name="settings_root_clothes">Одежда</string>
+    <string name="settings_root_api_keys">Ключи API</string>
+    <string name="settings_root_data_sources">Источники данных</string>
+    <string name="settings_root_about">О приложении</string>
+
     <string name="garment_sweater">Свитер</string>
     <string name="garment_hoodie">Худи</string>
     <string name="garment_jacket">Куртка</string>
@@ -19,6 +31,10 @@ earlier passes accidentally mixed in.
     <string name="garment_shorts">Шорты</string>
     <string name="garment_pants">Брюки</string>
     <string name="garment_jeans">Джинсы</string>
+
+    <!-- Clothes settings — top of the screen. -->
+    <string name="settings_clothes_title">Правила одежды</string>
+    <string name="settings_clothes_description">Если прогноз пересечёт один из этих порогов, эта вещь появится в твоём ежедневном ClothesCast.</string>
 
     <string name="settings_clothes_empty">Нет правил. Нажми «Добавить», чтобы создать.</string>
     <string name="settings_clothes_add">Добавить</string>


### PR DESCRIPTION
## Summary

Russian UI translation, mirroring the prior locale passes. Twelve
commits — one tone-fix on the existing prose, ten surface-by-surface
translations of the strings the file was missing, plus a final header
refresh.

## Tone fix (commit 1)

The previous Russian file used the formal Вы-form throughout —
"Нажмите", "Наденьте", "Возьмите", "Ваш ClothesCast". That's the
formal register the user explicitly does not want; equivalent of the
German Sie/Du, French vous/tu, or Croatian Vi/ti distinction we
already fixed in those locales. Switches to informal ты-form so the
file speaks to the user the way a spouse would.

Stale `insight_calendar_tie_in` is left untouched (fleet-wide cleanup
out of scope).

## Surfaces (commits 2–11)

- Today screen + home-screen widget
- Onboarding flow
- Settings root nav + Clothes section header
- Schedule screen (daily, nightly, delivery)
- Voice screen (engine + voice + language pickers)
- Region screen + Voice locale picker labels (28 locales × 2)
- API keys screen
- Location screen
- Notification channels + permission card + Calendar
- Debug + About screens

After this PR the values-ru file has 293 strings vs. 300 in the en-US
baseline; the seven gaps are the same deliberate non-overrides as the
prior locale PRs.

## Tone

ты-form throughout, intimate / spousal register matching the prior
locale passes. Russian forces gender agreement on past-tense verbs and
predicate adjectives in the ты-form ("ты включил" vs. "ты включила").
The welcome uses the conventional fixed greeting "Добро пожаловать"
(no agreement); descriptions that would otherwise hit a past-participle
gender pick use passive phrasing instead ("если включено озвучивание"
rather than "если ты включил озвучивание").

Quotes around nested labels use Russian guillemet «…» — locale-native
style.

"Образ" rather than the loanword "Outfit" for the widget label —
standard Russian fashion-vocab.

Brand "ClothesCast" stays in Latin script throughout.

## Privacy

Display-only. No new strings cross the device boundary; the rendered
insight prose (the only thing fed to TTS / LLM endpoints) was already
fully Russian via the existing `insight_*` translations (now also in
correct ты-form thanks to commit 1).

## Test plan

- [ ] CI: `JVM unit tests` green (no ru tests pin specific prose so
      nothing to update)
- [ ] CI: `Android debug build` green
- [ ] Manual: phone in ru-RU (or **Region: Русский (Россия)**) → walk
      every screen and confirm Russian ты-form throughout, no English
      fall-through; widget label reads "Образ", Settings reads
      "Настройки"
- [ ] Manual: spoken-aloud preview reads "Надень куртку" with the
      ты-form imperative (was "Наденьте" before commit 1)

https://claude.ai/code/session_01C1Q3vzGj6KmbYDfD6b2yhu

---
_Generated by [Claude Code](https://claude.ai/code/session_015agXppcN2fzATq5Xnzpozs)_