### PR TITLE
:app — fix stale insight_calendar_tie_in: formal → informal in ru/fr/hr

### DIFF
--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -435,7 +435,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="insight_condition_snow">Neige</string>
     <string name="insight_condition_thunderstorm">Orage</string>
     <string name="insight_condition_unknown">Inconnu</string>
-    <string name="insight_calendar_tie_in">Prenez %1$s pour votre %3$s de %2$s.</string>
+    <string name="insight_calendar_tie_in">Prends %1$s pour ton %3$s de %2$s.</string>
     <string name="insight_tie_in">Prends %1$s ce soir.</string>
     <string name="insight_tie_in_with_rain">Prends %1$s ce soir, pluie à %2$s.</string>
     <!-- "15h" / "15h30" — French TTS reads as "quinze heures" / "quinze heures trente". -->

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -404,7 +404,7 @@ spousal register), matching the existing settings_tts_test_sample's
     <string name="insight_condition_snow">Snijeg</string>
     <string name="insight_condition_thunderstorm">Grmljavina</string>
     <string name="insight_condition_unknown">Nepoznato</string>
-    <string name="insight_calendar_tie_in">Ponesite %1$s na %3$s u %2$s.</string>
+    <string name="insight_calendar_tie_in">Ponesi %1$s na %3$s u %2$s.</string>
     <string name="insight_tie_in">Ponesi %1$s večeras.</string>
     <string name="insight_tie_in_with_rain">Ponesi %1$s večeras, kiša u %2$s.</string>
     <!-- "15" — preposition "u" comes from surrounding templates. -->

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -420,7 +420,7 @@ only the displayed label localizes.
     <string name="insight_condition_snow">Снег</string>
     <string name="insight_condition_thunderstorm">Гроза</string>
     <string name="insight_condition_unknown">Неизвестно</string>
-    <string name="insight_calendar_tie_in">Возьмите %1$s на %3$s в %2$s.</string>
+    <string name="insight_calendar_tie_in">Возьми %1$s на %3$s в %2$s.</string>
     <string name="insight_tie_in">Возьми %1$s сегодня вечером.</string>
     <string name="insight_tie_in_with_rain">Возьми %1$s сегодня вечером, дождь в %2$s.</string>
     <!-- "15" — preposition "в" comes from surrounding templates. -->


### PR DESCRIPTION
## Summary

Tiny follow-up to PR #185 review feedback. Copilot caught that the
Russian file header claims "No Вы-form anywhere" while the dead
`insight_calendar_tie_in` key still reads "Возьмите …" (formal). Same
header-claim-vs-stale-string contradiction exists in French (vous-form
"Prenez …") and Croatian (Vi-form "Ponesite …") from earlier passes.

Three one-character fixes drop the formal-imperative ending so each
file's header statement is accurate:

- **ru**: "Возьмите %1$s на %3$s в %2$s." → "Возьми %1$s на %3$s в %2$s."
- **fr**: "Prenez %1$s pour votre %3$s de %2$s." → "Prends %1$s pour ton %3$s de %2$s." (also votre → ton)
- **hr**: "Ponesite %1$s na %3$s u %2$s." → "Ponesi %1$s na %3$s u %2$s."

## Why these three

The same dead key exists in nine other locale files. Three reasons
they're not all touched in this PR:

- **es / it / pt-rBR / ko**: the key is already informal-equivalent
  register-wise (es uses tú, it uses tu, pt-BR uses você, ko uses
  해요체), no contradiction with their headers.
- **nl / in / vi**: no full tone pass on those locales yet, so their
  headers don't make a "no formal-form anywhere" claim.

## Why not delete the dead key fleet-wide

The key isn't referenced anywhere in `:app` or `:core` — fleet-wide
cleanup is the right move long-term but is a different concern (touch
all 10 locale files plus the en-US baseline) and warrants its own PR.

## Privacy

Display-only. Dead-key strings aren't read by any code path.

## Test plan

- [ ] CI: `JVM unit tests` green (no tests pin this string in any of the
      three locales)
- [ ] CI: `Android debug build` green

https://claude.ai/code/session_01C1Q3vzGj6KmbYDfD6b2yhu

---
_Generated by [Claude Code](https://claude.ai/code/session_015agXppcN2fzATq5Xnzpozs)_