### PR TITLE
:app — French dead-key: drop gendered possessive (#187 review)

### DIFF
--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -435,7 +435,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="insight_condition_snow">Neige</string>
     <string name="insight_condition_thunderstorm">Orage</string>
     <string name="insight_condition_unknown">Inconnu</string>
-    <string name="insight_calendar_tie_in">Prends %1$s pour ton %3$s de %2$s.</string>
+    <string name="insight_calendar_tie_in">Prends %1$s pour %3$s à %2$s.</string>
     <string name="insight_tie_in">Prends %1$s ce soir.</string>
     <string name="insight_tie_in_with_rain">Prends %1$s ce soir, pluie à %2$s.</string>
     <!-- "15h" / "15h30" — French TTS reads as "quinze heures" / "quinze heures trente". -->


### PR DESCRIPTION
## Summary

One-line follow-up to PR #187 review feedback. Copilot caught that my
"votre" → "ton" change in the French `insight_calendar_tie_in` template
introduced a gender-agreement bug: French requires `ton`/`ta`/`tes` to
agree with the noun's gender, and the `%3$s` event title is free-form
user input we can't gender-tag.

Adopt Copilot's gender-safe rewrite:

```
"Prends %1$s pour ton %3$s de %2$s."   →   "Prends %1$s pour %3$s à %2$s."
```

- Drops the possessive entirely (no agreement to get wrong).
- Switches "de %2$s" → "à %2$s" — "à 15h" is the standard French
  preposition for "at 3pm".

## Why only French

The same masculine-only gendered-possessive issue exists in this dead
key in it / de / ru / pt-rBR (their possessives also agree with
gender), but those weren't part of #187's scope. Out of scope here
too — better swept as part of the eventual fleet-wide cleanup that
deletes the unreferenced key altogether.

## Why fix at all if the key is dead

It is dead (no code path renders it), so this is precision cleanup on
a string that isn't currently shown to users. But fixing while I'm in
the file is cheap, and the next person who reaches for this template
won't hit the gender bug.

## Privacy

Display-only. Dead-key string isn't read by any code path.

## Test plan

- [ ] CI: `JVM unit tests` green (no test pins this string)
- [ ] CI: `Android debug build` green

https://claude.ai/code/session_01C1Q3vzGj6KmbYDfD6b2yhu

---
_Generated by [Claude Code](https://claude.ai/code/session_015agXppcN2fzATq5Xnzpozs)_