### PR TITLE
:app — make long settings dialogs scroll their content

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/settings/ClothesSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/ClothesSettings.kt
@@ -266,7 +266,10 @@ private fun ClothesRuleDialog(
             )
         },
         text = {
-            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Column(
+                modifier = Modifier.verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
                 GarmentDropdown(
                     selected = garment,
                     onSelect = { garment = it },

--- a/app/src/main/kotlin/app/clothescast/ui/settings/DataSourcesSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/DataSourcesSettings.kt
@@ -223,7 +223,10 @@ internal fun LocationSearchDialog(
         },
         title = { Text(stringResource(R.string.settings_location_search_title)) },
         text = {
-            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Column(
+                modifier = Modifier.verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     verticalAlignment = Alignment.CenterVertically,

--- a/app/src/main/kotlin/app/clothescast/ui/settings/VoiceSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/VoiceSettings.kt
@@ -357,7 +357,7 @@ private fun VoiceLocalePicker(
                     .map { it to labelFor(it) }
                     .partition { it.first == VoiceLocale.SYSTEM }
                 val sorted = system + rest.sortedWith(compareBy(collator) { it.second })
-                Column {
+                Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
                     sorted.forEach { (option, label) ->
                         RadioRow(
                             label = label,
@@ -435,7 +435,7 @@ private fun VoicePicker(
             onDismissRequest = { dialogOpen = false },
             title = { Text(title) },
             text = {
-                Column {
+                Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
                     voices.forEach { option ->
                         RadioRow(
                             label = option.displayName,


### PR DESCRIPTION
## Summary

The voice-locale picker dialog packs ~33 language entries into a non-scrolling `Column` inside an `AlertDialog`, so on shorter screens the bottom entries are clipped and unreachable. Wraps the inner `Column` with `verticalScroll(rememberScrollState())` so the list scrolls inside the dialog.

Audited every other `AlertDialog` in the app and applied the same fix to the three other dialogs whose content can grow beyond the dialog's max height:

- `VoiceLocalePicker` (33 hard-coded language entries — the original report)
- `VoicePicker` (cloud + device voice lists; device voices can be 30+ on phones with many installed locales)
- `LocationSearchDialog` (geocoder results — variable length, unbounded by us)
- `ClothesRuleDialog` (bounded but tall enough to clip on small landscape phones)

Left alone: `TimePickerDialog` (fixed-size Material3 TimePicker) and `AddApiKeyDialog` (single text field) — neither can grow tall enough to clip.

## Test plan

- [ ] CI: `JVM unit tests` + `Android debug build` green
- [ ] Manual: open Settings → Voice → "Spoken language" picker on a small device, confirm the list scrolls and every entry is reachable
- [ ] Manual: same check for the cloud and device voice pickers
- [ ] Manual: same check for the city-search dialog with a query that returns many results
- [ ] Manual: same check for the clothes rule add/edit dialog in landscape on a small device

https://claude.ai/code/session_01P7bQbZEqYzL34vmGXBFgdn

---
_Generated by [Claude Code](https://claude.ai/code/session_01P7bQbZEqYzL34vmGXBFgdn)_