### PR TITLE
:app — voice preview reuses the real briefing pipeline (drops 25 per-locale samples)

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/settings/VoiceSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/VoiceSettings.kt
@@ -1,7 +1,6 @@
 package app.clothescast.ui.settings
 
 import app.clothescast.diag.DiagLog
-import android.content.res.Configuration
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -40,8 +39,15 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
 import app.clothescast.R
+import app.clothescast.core.domain.model.BandClause
+import app.clothescast.core.domain.model.ClothesClause
+import app.clothescast.core.domain.model.DeltaClause
+import app.clothescast.core.domain.model.ForecastPeriod
+import app.clothescast.core.domain.model.InsightSummary
+import app.clothescast.core.domain.model.TemperatureBand
 import app.clothescast.core.domain.model.TtsEngine
 import app.clothescast.core.domain.model.VoiceLocale
+import app.clothescast.insight.InsightFormatter
 import app.clothescast.tts.DeviceVoice
 import app.clothescast.tts.ELEVENLABS_VOICES
 import app.clothescast.tts.ElevenLabsTtsSpeaker
@@ -595,12 +601,19 @@ private fun TestVoiceButton(isPreviewing: Boolean, onClick: () -> Unit) {
 }
 
 /**
- * Plays a preview through the chosen engine + voice. Uses a fixed weather-y
- * sample (rather than the latest cached prose) so every preview tap exercises
- * the brand name's pronunciation and costs the same number of BYOK tokens —
- * making it easier to compare engines and voices on identical words. The
- * sample is read in the selected *voice locale* so the preview matches the
- * accent and language the user is auditioning, not the app's UI locale.
+ * Plays a preview through the chosen engine + voice. Builds a fixed canned
+ * [InsightSummary] and renders it through the same [InsightFormatter] the
+ * real briefing pipeline uses, so the preview reads exactly like a real
+ * morning briefing in the chosen voice locale — no separate per-locale
+ * sample string to keep in sync with the prose templates. The summary is
+ * deliberately broad enough to exercise band + delta + multi-item clothes
+ * clauses on every preview tap, and costs the same number of BYOK tokens
+ * each time so engines / voices compare on identical words.
+ *
+ * The sample is rendered in the selected *voice locale* so the preview
+ * matches the accent and language the user is auditioning, not the app's
+ * UI locale. Brand-prefix framing ("Today's ClothesCast: …") is omitted
+ * for now — see TODO(brand-intro) in [FetchAndNotifyWorker.formatProse].
  *
  * Errors are surfaced as a Toast so the user can see *why* the voice failed
  * (most often: missing or wrong API key for the chosen provider).
@@ -620,14 +633,11 @@ private suspend fun runTtsPreview(
     // we don't want a hot stack of preview work running on the UI dispatcher.
     withContext(Dispatchers.IO) {
         val locale = voiceLocale.resolve()
-        // Fetch the sample in the *voice* locale, not the app's UI locale —
-        // playing English prose through a Japanese voice is exactly the
-        // mismatch the user picked the locale to avoid. Falls back to the
-        // default values/strings.xml entry for any locale we haven't
-        // translated yet.
-        val voiceConfig = Configuration(context.resources.configuration).apply { setLocale(locale) }
-        val text = context.createConfigurationContext(voiceConfig)
-            .getString(R.string.settings_tts_test_sample)
+        // Render the canned sample in the *voice* locale, not the app's UI
+        // locale — playing English prose through a Japanese voice is exactly
+        // the mismatch the user picked the locale to avoid. The formatter
+        // resolves to values/strings.xml for any locale without an override.
+        val text = InsightFormatter.forContext(context, locale).format(SAMPLE_SUMMARY)
         withSpeechAudioFocus(context) {
             try {
                 when (engine) {
@@ -674,3 +684,15 @@ private fun ttsEngineLabel(engine: TtsEngine): Int = when (engine) {
     TtsEngine.OPENAI -> R.string.settings_tts_engine_openai
     TtsEngine.ELEVENLABS -> R.string.settings_tts_engine_elevenlabs
 }
+
+// Canned forecast for the voice preview: a cold day 7° down on yesterday with
+// sweater + jacket as the clothes pick. Renders (en-US) as "Today will be cold.
+// It will be 7° cooler today. Wear a sweater and jacket." — exercises band,
+// delta, and a multi-item clothes clause without dragging in a precip / tie-in
+// time that would force a different number of TTS tokens per locale.
+private val SAMPLE_SUMMARY = InsightSummary(
+    period = ForecastPeriod.TODAY,
+    band = BandClause(TemperatureBand.COLD, TemperatureBand.COLD),
+    delta = DeltaClause(degrees = 7, direction = DeltaClause.Direction.COOLER),
+    clothes = ClothesClause(items = listOf("sweater", "jacket")),
+)

--- a/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
@@ -245,7 +245,10 @@ class FetchAndNotifyWorker(
      *    for, even on a TTS-enabled mode.
      */
     // TODO(brand-intro): consider prepending "Today's ClothesCast: " / "Tonight's ClothesCast: "
-    // here once the voice preview's phrasing settles — see settings_tts_test_sample.
+    // here (and mirror it in VoiceSettings.runTtsPreview's SAMPLE_SUMMARY render)
+    // once the voice preview's phrasing settles — the brand-name pronunciation
+    // check that the per-locale settings_tts_test_sample used to give us is
+    // currently absent from both the preview and the real briefing.
     private fun formatProse(insight: Insight, prefs: UserPreferences): String =
         InsightFormatter.forRegion(applicationContext, prefs.region).format(insight.summary)
 

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -86,5 +86,4 @@ they work correctly in both the single-band and range templates.
     <string name="insight_time_hour">%1$d</string>
     <string name="insight_time_hour_minutes">%1$d:%2$02d</string>
 
-    <string name="settings_tts_test_sample">ClothesCast اليوم: معتدل، مع أمطار في الساعة 3 عصرًا. ارتدِ سترة.</string>
 </resources>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -84,6 +84,5 @@ West Bengal vocabulary differences in a future PR.
     <string name="insight_time_hour">%1$d</string>
     <string name="insight_time_hour_minutes">%1$d:%2$02d</string>
 
-    <string name="settings_tts_test_sample">আজকের ClothesCast: মৃদু, বিকেল ৩টায় বৃষ্টি। একটি জ্যাকেট পরুন।</string>
 </resources>
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -466,5 +466,4 @@ zh-CN) is unchanged; only the displayed label localizes.
 
     <!-- Spoken sample for the voice preview. The brand name is kept; the rest
          is fully translated so the chosen voice reads its own language. -->
-    <string name="settings_tts_test_sample">Dein heutiger ClothesCast: mild, mit Regen um 15 Uhr. Trag eine Jacke.</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -442,5 +442,4 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="insight_time_hour">%1$d</string>
     <string name="insight_time_hour_minutes">%1$d:%2$02d</string>
 
-    <string name="settings_tts_test_sample">Tu ClothesCast de hoy: templado, con lluvia a las 3 de la tarde. Lleva una chaqueta.</string>
 </resources>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -89,5 +89,4 @@ Western Arabic numerals (0-9) are used for TTS compatibility.
     <string name="insight_time_hour">%1$d</string>
     <string name="insight_time_hour_minutes">%1$d:%2$02d</string>
 
-    <string name="settings_tts_test_sample">ClothesCast امروز: ملایم، با باران ساعت ۳ بعد از ظهر. یک ژاکت بپوشید.</string>
 </resources>

--- a/app/src/main/res/values-fil/strings.xml
+++ b/app/src/main/res/values-fil/strings.xml
@@ -81,5 +81,4 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="insight_time_hour">%1$d</string>
     <string name="insight_time_hour_minutes">%1$d:%2$02d</string>
 
-    <string name="settings_tts_test_sample">ClothesCast mo ngayon: malumanay, may ulan sa alas-3 ng hapon. Magsuot ng dyaket.</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -442,5 +442,4 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="insight_time_hour">%1$dh</string>
     <string name="insight_time_hour_minutes">%1$dh%2$02d</string>
 
-    <string name="settings_tts_test_sample">Ton ClothesCast d\'aujourd\'hui : doux, avec de la pluie à 15 h. Porte une veste.</string>
 </resources>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -82,5 +82,4 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="insight_time_hour">%1$d</string>
     <string name="insight_time_hour_minutes">%1$d:%2$02d</string>
 
-    <string name="settings_tts_test_sample">आज का ClothesCast: हल्का, दोपहर 3 बजे बारिश के साथ। एक जैकेट पहनें।</string>
 </resources>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
 Croatian translation. Tone is informal "ti"-form throughout (intimate /
-spousal register), matching the existing settings_tts_test_sample's
-"Tvoj … Obuci jaknu." Avoid the formal "Vi"-form ("Obucite", "Ponesite",
+spousal register), matching the existing insight prose ("Ponesi …",
+"Obuci …"). Avoid the formal "Vi"-form ("Obucite", "Ponesite",
 "Dodirnite") that earlier passes accidentally mixed in.
 -->
 <resources>
@@ -411,5 +411,4 @@ spousal register), matching the existing settings_tts_test_sample's
     <string name="insight_time_hour">%1$d</string>
     <string name="insight_time_hour_minutes">%1$d:%2$02d</string>
 
-    <string name="settings_tts_test_sample">Tvoj današnji ClothesCast: blago, s kišom u 15 sati. Obuci jaknu.</string>
 </resources>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -83,5 +83,4 @@ to values/strings.xml (English).
     <string name="insight_time_hour">%1$d</string>
     <string name="insight_time_hour_minutes">%1$d.%2$02d</string>
 
-    <string name="settings_tts_test_sample">ClothesCast hari ini: sejuk, dengan hujan pukul 3 sore. Kenakan jaket.</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -429,5 +429,4 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="insight_time_hour">%1$d</string>
     <string name="insight_time_hour_minutes">%1$d e %2$d</string>
 
-    <string name="settings_tts_test_sample">Il tuo ClothesCast di oggi: mite, con pioggia alle 15. Indossa una giacca.</string>
 </resources>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -89,5 +89,4 @@ standard in Israeli digital communication.
     <string name="insight_time_hour">%1$d</string>
     <string name="insight_time_hour_minutes">%1$d:%2$02d</string>
 
-    <string name="settings_tts_test_sample">ה-ClothesCast של היום: נעים, עם גשם בשעה 15:00. לבש מעיל.</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -444,5 +444,4 @@ the displayed label localizes.
     <string name="insight_time_hour">%1$d時</string>
     <string name="insight_time_hour_minutes">%1$d時%2$d分</string>
 
-    <string name="settings_tts_test_sample">今日の ClothesCast：穏やか、午後3時に雨。ジャケットを着てください。</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -457,5 +457,4 @@ displayed label localizes.
     <string name="insight_time_hour">%1$d시</string>
     <string name="insight_time_hour_minutes">%1$d시 %2$d분</string>
 
-    <string name="settings_tts_test_sample">오늘의 ClothesCast: 온화함, 오후 3시에 비. 재킷을 입으세요.</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -80,5 +80,4 @@ editor, outfit-card labels, and region/voice-locale picker names.
     <string name="insight_time_hour">%1$d uur</string>
     <string name="insight_time_hour_minutes">%1$d:%2$02d</string>
 
-    <string name="settings_tts_test_sample">Je ClothesCast van vandaag: mild, met regen om 15.00 uur. Trek een jas aan.</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -78,5 +78,4 @@ editor, outfit-card labels, and region/voice-locale picker names.
     <string name="insight_time_hour">%1$d</string>
     <string name="insight_time_hour_minutes">%1$d:%2$02d</string>
 
-    <string name="settings_tts_test_sample">Twój dzisiejszy ClothesCast: łagodnie, z deszczem o 15:00. Załóż kurtkę.</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -446,5 +446,4 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="insight_time_hour">%1$dh</string>
     <string name="insight_time_hour_minutes">%1$dh%2$02d</string>
 
-    <string name="settings_tts_test_sample">Seu ClothesCast de hoje: ameno, com chuva às 15h. Use uma jaqueta.</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -427,5 +427,4 @@ only the displayed label localizes.
     <string name="insight_time_hour">%1$d</string>
     <string name="insight_time_hour_minutes">%1$d:%2$02d</string>
 
-    <string name="settings_tts_test_sample">Твой сегодняшний ClothesCast: мягкая погода, дождь в 15:00. Надень куртку.</string>
 </resources>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -79,5 +79,4 @@ editor, outfit-card labels, and region/voice-locale picker names.
     <string name="insight_time_hour">%1$d</string>
     <string name="insight_time_hour_minutes">%1$d:%2$02d</string>
 
-    <string name="settings_tts_test_sample">Dagens ClothesCast: milt, med regn klockan 15. Ta på dig en jacka.</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -79,5 +79,4 @@ editor, outfit-card labels, and region/voice-locale picker names.
     <string name="insight_time_hour">%1$d</string>
     <string name="insight_time_hour_minutes">%1$d:%2$02d</string>
 
-    <string name="settings_tts_test_sample">Bugünün ClothesCast\'i: ılıman, saat 15.00\'te yağmurlu. Bir ceket giy.</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -78,5 +78,4 @@ editor, outfit-card labels, and region/voice-locale picker names.
     <string name="insight_time_hour">%1$d</string>
     <string name="insight_time_hour_minutes">%1$d:%2$02d</string>
 
-    <string name="settings_tts_test_sample">Твій сьогоднішній ClothesCast: тепло, з дощем о 15:00. Одягни куртку.</string>
 </resources>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -81,5 +81,4 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="insight_time_hour">%1$d giờ</string>
     <string name="insight_time_hour_minutes">%1$d giờ %2$d phút</string>
 
-    <string name="settings_tts_test_sample">ClothesCast hôm nay: dịu nhẹ, có mưa lúc 3 giờ chiều. Hãy mặc áo khoác.</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -436,5 +436,4 @@ label localizes.
     <string name="insight_time_hour">%1$d点</string>
     <string name="insight_time_hour_minutes">%1$d点%2$d分</string>
 
-    <string name="settings_tts_test_sample">今天的 ClothesCast：温和，下午 3 点有雨。请穿一件外套。</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -184,7 +184,6 @@
     <string name="settings_tts_add_api_key_save">Save</string>
     <string name="settings_tts_add_api_key_cancel">Cancel</string>
     <string name="settings_tts_test_in_flight">Testing — please wait…</string>
-    <string name="settings_tts_test_sample">Today\'s ClothesCast: mild, with rain at 3pm. Wear a jacket.</string>
 
     <string name="settings_openai_key_status_set">An OpenAI key is configured.</string>
     <string name="settings_openai_key_status_unset">No OpenAI key configured. Get one at platform.openai.com to use OpenAI voices.</string>


### PR DESCRIPTION
## Summary

The voice preview's "test voice" button used to play a hand-translated `settings_tts_test_sample` string — 25 per-locale overrides + the English default. They drifted: zh-CN had `请穿一件外套` despite the file header documenting a no-请 casual register, iw used the masc-only `לבש` despite documenting the gender-neutral slash form (`לבש/י`), and the recent ru / fr / hr formal-form sweep (PR #185) hadn't reached this string. Every prose tweak meant another 25-locale audit.

This PR replaces the canned text with a canned `InsightSummary` rendered through the same `InsightFormatter` the real briefing pipeline uses:

```kotlin
InsightSummary(
    period  = TODAY,
    band    = BandClause(COLD, COLD),
    delta   = DeltaClause(7, COOLER),
    clothes = ClothesClause(["sweater", "jacket"]),
)
```

The preview now reads exactly like a real morning briefing in the chosen voice locale (en-US: *"Today will be cold. It will be 7° cooler today. Wear a sweater and jacket."*; localized equivalents elsewhere) and inherits every register / tone / typography fix already living in `insight_*` for free. The 25 per-locale `settings_tts_test_sample` entries — and the default English one — are removed.

Decisions worth flagging:

- **Brand-prefix framing (`Today's ClothesCast: …`) is intentionally dropped** for now. The real briefing doesn't say it either, so the preview is now more truthful at the cost of the brand-name pronunciation check that string was partly meant to provide. The existing `TODO(brand-intro)` in `FetchAndNotifyWorker.formatProse` is extended to also cover wiring it into the preview's `SAMPLE_SUMMARY` render if we add it.
- **Token-cost parity across engines / voices is preserved** — every preview tap still renders the same canned summary, so BYOK token counts stay comparable.
- **Privacy:** no change to what crosses the device boundary. The preview text was already sent to the chosen TTS provider; only the words sent change.

## Test plan

- [ ] CI: `JVM unit tests` green
- [ ] CI: `Android debug build` green
- [ ] Manual: tap "Test voice" with a few different voice locales (en-US, de-DE, fr-FR, ja-JP, zh-CN) and confirm the spoken output matches the localized briefing prose
- [ ] Manual: confirm zh-CN preview no longer says `请` and iw preview uses gender-neutral slash form (both come for free via existing `insight_clothes_wear` translations)

https://claude.ai/code/session_01BNCDT9vLRxBy71rfDFaL5X

---
_Generated by [Claude Code](https://claude.ai/code/session_01BNCDT9vLRxBy71rfDFaL5X)_