### PR TITLE
:app — insight delta: "warmer/cooler today" → "warmer/cooler than yesterday"

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -355,8 +355,8 @@
     <string name="insight_band_hot">hot</string>
 
     <!-- Day-on-day temperature delta. %1$d is the rounded degree difference. -->
-    <string name="insight_delta_warmer">It will be %1$d° warmer today.</string>
-    <string name="insight_delta_cooler">It will be %1$d° cooler today.</string>
+    <string name="insight_delta_warmer">It will be %1$d° warmer than yesterday.</string>
+    <string name="insight_delta_cooler">It will be %1$d° cooler than yesterday.</string>
 
     <!-- Severe-weather alert prefix. %1$s = event name (e.g. "Tornado Warning"). -->
     <string name="insight_alert">Alert: %1$s.</string>

--- a/app/src/test/kotlin/app/clothescast/insight/InsightFormatterTest.kt
+++ b/app/src/test/kotlin/app/clothescast/insight/InsightFormatterTest.kt
@@ -61,13 +61,13 @@ class InsightFormatterTest {
     @Test
     fun `delta clause emits warmer with rounded degrees`() {
         val out = subject.format(summary(delta = DeltaClause(5, DeltaClause.Direction.WARMER)))
-        out shouldBe "Today will be mild. It will be 5° warmer today."
+        out shouldBe "Today will be mild. It will be 5° warmer than yesterday."
     }
 
     @Test
     fun `delta clause emits cooler`() {
         val out = subject.format(summary(delta = DeltaClause(6, DeltaClause.Direction.COOLER)))
-        out shouldBe "Today will be mild. It will be 6° cooler today."
+        out shouldBe "Today will be mild. It will be 6° cooler than yesterday."
     }
 
     @Test
@@ -204,7 +204,7 @@ class InsightFormatterTest {
                 precip = PrecipClause(WeatherCondition.RAIN, LocalTime.of(15, 0)),
             ),
         )
-        out shouldBe "Alert: Flood Warning. Today will be cool to mild. It will be 6° warmer today. " +
+        out shouldBe "Alert: Flood Warning. Today will be cool to mild. It will be 6° warmer than yesterday. " +
             "Wear a sweater and umbrella. Rain at 3pm."
     }
 


### PR DESCRIPTION
## Summary

The day-on-day delta clause read "Today will be cold. It will be 7° cooler today." — the trailing "today" is ambiguous since the whole insight is already about today. Reword to "than yesterday" so the comparison subject is explicit:

- "It will be 6° cooler today." → "It will be 6° cooler than yesterday."
- "It will be 5° warmer today." → "It will be 5° warmer than yesterday."

English (default) strings only — `values/strings.xml`. Other locales keep their translators' phrasings; touching those without a translator review is out of scope.

`InsightFormatterTest` expectations updated to match.

## Heads-up: snapshot needs re-record

`app/snapshots/today_insight_card.png` is rendered from `SAMPLE_INSIGHT` in `TodayPreviews.kt:55` (`DeltaClause(4, WARMER)`), so its prose now reads "4° warmer than yesterday" and the `verifyRoborazzi` check will fail until the PNG is re-recorded with `recordRoborazzi`. I couldn't run that here — no Android SDK in the agent sandbox.

## Test plan

- [ ] CI: `JVM unit tests` passes (`InsightFormatterTest` updated)
- [ ] CI: `Android debug build` passes
- [ ] Re-record `today_insight_card.png` locally with `./gradlew :app:recordRoborazzi`, commit the updated PNG
- [ ] Eyeball the rendered Today card on device — text wraps cleanly with the longer string

🤖 https://claude.ai/code

---
_Generated by [Claude Code](https://claude.ai/code/session_01QCjwL8b9w5miihRxstbJVx)_