### PR TITLE
:app — voice-preview comment cleanup (PR #191 review + post-merge delta rename)

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/settings/VoiceSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/VoiceSettings.kt
@@ -687,9 +687,9 @@ private fun ttsEngineLabel(engine: TtsEngine): Int = when (engine) {
 
 // Canned forecast for the voice preview: a cold day 7° down on yesterday with
 // sweater + jacket as the clothes pick. Renders (en-US) as "Today will be cold.
-// It will be 7° cooler today. Wear a sweater and jacket." — exercises band,
-// delta, and a multi-item clothes clause without dragging in a precip / tie-in
-// time that would force a different number of TTS tokens per locale.
+// It will be 7° cooler than yesterday. Wear a sweater and jacket." — exercises
+// band, delta, and a multi-item clothes clause without dragging in a precip /
+// tie-in time that would force a different number of TTS tokens per locale.
 private val SAMPLE_SUMMARY = InsightSummary(
     period = ForecastPeriod.TODAY,
     band = BandClause(TemperatureBand.COLD, TemperatureBand.COLD),

--- a/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
@@ -245,10 +245,11 @@ class FetchAndNotifyWorker(
      *    for, even on a TTS-enabled mode.
      */
     // TODO(brand-intro): consider prepending "Today's ClothesCast: " / "Tonight's ClothesCast: "
-    // here (and mirror it in VoiceSettings.runTtsPreview's SAMPLE_SUMMARY render)
-    // once the voice preview's phrasing settles — the brand-name pronunciation
-    // check that the per-locale settings_tts_test_sample used to give us is
-    // currently absent from both the preview and the real briefing.
+    // here (and mirror it in the SAMPLE_SUMMARY render used by the top-level
+    // runTtsPreview function in ui/settings/VoiceSettings.kt) once the voice
+    // preview's phrasing settles — the brand-name pronunciation check that the
+    // per-locale settings_tts_test_sample used to give us is currently absent
+    // from both the preview and the real briefing.
     private fun formatProse(insight: Insight, prefs: UserPreferences): String =
         InsightFormatter.forRegion(applicationContext, prefs.region).format(insight.summary)
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -463,7 +463,4 @@ zh-CN) is unchanged; only the displayed label localizes.
     <!-- "15 Uhr" / "15 Uhr 30" — read naturally by German TTS. -->
     <string name="insight_time_hour">%1$d Uhr</string>
     <string name="insight_time_hour_minutes">%1$d Uhr %2$d</string>
-
-    <!-- Spoken sample for the voice preview. The brand name is kept; the rest
-         is fully translated so the chosen voice reads its own language. -->
 </resources>


### PR DESCRIPTION
## Summary

Three small comment-only fixes — two from Copilot's PR #191 review, one to keep `SAMPLE_SUMMARY`'s rendered-example comment in sync with the delta-template rename that landed in `164beae` (PR after #191).

- **`values-de/strings.xml`** — drop the now-stale `<!-- Spoken sample for the voice preview … -->` trailing comment; the string it documented (`settings_tts_test_sample`) was removed in #191. ([Copilot thread](https://github.com/mikelward/clothescast/pull/191#discussion_r3156029146))
- **`FetchAndNotifyWorker.kt`** — reword `TODO(brand-intro)` to point at the top-level `runTtsPreview` function in `ui/settings/VoiceSettings.kt` rather than `VoiceSettings.runTtsPreview`; the latter implies a `VoiceSettings` type member, but `runTtsPreview` is a file-level top-level `fun`. ([Copilot thread](https://github.com/mikelward/clothescast/pull/191#discussion_r3156029197))
- **`VoiceSettings.kt`** — update `SAMPLE_SUMMARY`'s rendered-example comment from *"It will be 7° cooler today."* → *"It will be 7° cooler than yesterday."* to match the post-merge `:app — insight delta: "today" → "than yesterday"` rename.

No code-path change; comments and one stray XML comment block only.

## Test plan

- [ ] CI: `JVM unit tests` green
- [ ] CI: `Android debug build` green (resource validation will catch a malformed `values-de` if the comment trim went wrong)

https://claude.ai/code/session_01BNCDT9vLRxBy71rfDFaL5X

---
_Generated by [Claude Code](https://claude.ai/code/session_01BNCDT9vLRxBy71rfDFaL5X)_