### PR TITLE
Resolve Android resource locale aliases when creating localized Resources

### DIFF
--- a/app/src/main/kotlin/app/clothescast/insight/InsightFormatter.kt
+++ b/app/src/main/kotlin/app/clothescast/insight/InsightFormatter.kt
@@ -16,6 +16,7 @@ import app.clothescast.core.domain.model.Region
 import app.clothescast.core.domain.model.TemperatureBand
 import app.clothescast.core.domain.model.WeatherCondition
 import java.time.LocalTime
+import java.util.IllformedLocaleException
 import java.util.Locale
 
 /**
@@ -198,6 +199,32 @@ class InsightFormatter(
 private fun Region.toJavaLocale(): Locale? = bcp47?.let { Locale.forLanguageTag(it) }
 
 private fun Context.localizedResources(locale: Locale): Resources {
-    val config = Configuration(resources.configuration).apply { setLocale(locale) }
+    // Android resource qualifiers still use legacy language codes for a couple
+    // of locales (`values-in`, `values-iw`). Locale.forLanguageTag() returns
+    // modern tags (`id`, `he`), and forcing those through setLocale can miss
+    // our translated string buckets and fall back to English.
+    val resourcesLocale = locale.toAndroidResourceLocale()
+    val config = Configuration(resources.configuration).apply { setLocale(resourcesLocale) }
     return createConfigurationContext(config).resources
+}
+
+private fun Locale.toAndroidResourceLocale(): Locale {
+    val normalizedLanguage = when (language.lowercase(Locale.ROOT)) {
+        "id" -> "in"
+        "he" -> "iw"
+        else -> language
+    }
+    if (normalizedLanguage == language) return this
+    return try {
+        // Keep script/variant/extensions from the original locale when present
+        // (e.g. zh-Hant-*), and only swap the language subtag.
+        Locale.Builder()
+            .setLocale(this)
+            .setLanguage(normalizedLanguage)
+            .build()
+    } catch (_: IllformedLocaleException) {
+        // Defensive fallback for malformed/partial tags coming from outside
+        // our enums — preserve the old behaviour of keeping language+country.
+        if (country.isNotBlank()) Locale(normalizedLanguage, country) else Locale(normalizedLanguage)
+    }
 }

--- a/app/src/test/kotlin/app/clothescast/insight/InsightFormatterTest.kt
+++ b/app/src/test/kotlin/app/clothescast/insight/InsightFormatterTest.kt
@@ -363,4 +363,16 @@ class InsightFormatterTest {
         )
         out shouldBe "Hoy hará templado. Lleva paraguas esta noche, lluvia a las 21."
     }
+
+    @Test
+    fun `id-ID locale resolves Indonesian insight strings instead of English fallback`() {
+        val indonesianSubject = InsightFormatter.forContext(context, Locale.forLanguageTag("id-ID"))
+        indonesianSubject.format(summary()) shouldBe "Hari ini cuacanya hangat sedang."
+    }
+
+    @Test
+    fun `he-IL locale resolves Hebrew insight strings instead of English fallback`() {
+        val hebrewSubject = InsightFormatter.forContext(context, Locale.forLanguageTag("he-IL"))
+        hebrewSubject.format(summary()) shouldBe "היום יהיה נעים."
+    }
 }


### PR DESCRIPTION
### Motivation
- Prevent falling back to English when `Locale.forLanguageTag` returns modern language tags that don't match Android resource qualifiers for some locales. 
- Ensure Indonesian (`id-ID`) and Hebrew (`he-IL`) users get the correct translated string buckets instead of an English fallback. 

### Description
- Add `Locale.toAndroidResourceLocale()` which normalizes language subtags (mapping `id` -> `in`, `he` -> `iw`) before applying to resources. 
- Preserve script/variant/extensions when swapping the language subtag via `Locale.Builder` and defensively catch `IllformedLocaleException` to fall back to `Locale(normalizedLanguage[, country])`. 
- Update `Context.localizedResources(locale)` to call `toAndroidResourceLocale()` and use the resulting locale with `setLocale`. 
- Add tests in `InsightFormatterTest` to assert Indonesian (`id-ID`) and Hebrew (`he-IL`) locale lookups resolve the expected localized strings. 

### Testing
- Ran unit tests with `./gradlew test` and the test suite passed. 
- Added tests `id-ID locale resolves Indonesian insight strings instead of English fallback` and `he-IL locale resolves Hebrew insight strings instead of English fallback`, which both passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f103be1690832b9ccb29b3fa0981a0)