### PR TITLE
:app — proactively prompt for always-on location with a one-tap chained flow

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/settings/DataSourcesSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/DataSourcesSettings.kt
@@ -198,14 +198,25 @@ private fun DeviceLocationToggleRow(
                     return@Switch
                 }
                 when {
-                    !hasCoarseLocationPermission(context) -> rationaleOpen = true
-                    !backgroundGranted -> {
-                        // Foreground already granted from a previous attempt; just
-                        // chase the missing background grant directly.
-                        onCheckedChange(true)
+                    !hasCoarseLocationPermission(context) -> {
+                        // Pre-Q has no separate "Allow all the time" choice — coarse
+                        // grant *is* always-on — so the rationale dialog's copy doesn't
+                        // apply. Skip straight to the foreground request there; the
+                        // background launcher + denied dialog also no-op on pre-Q
+                        // because hasBackgroundLocationPermission() returns true.
                         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
-                            backgroundLauncher.launch(android.Manifest.permission.ACCESS_BACKGROUND_LOCATION)
+                            rationaleOpen = true
+                        } else {
+                            foregroundLauncher.launch(android.Manifest.permission.ACCESS_COARSE_LOCATION)
                         }
+                    }
+                    !backgroundGranted -> {
+                        // Only reachable on Q+ — hasBackgroundLocationPermission()
+                        // returns true on pre-Q so backgroundGranted is always true
+                        // there. Foreground was granted in a previous attempt; chase
+                        // the missing background grant directly.
+                        onCheckedChange(true)
+                        backgroundLauncher.launch(android.Manifest.permission.ACCESS_BACKGROUND_LOCATION)
                     }
                     else -> onCheckedChange(true)
                 }

--- a/app/src/main/kotlin/app/clothescast/ui/settings/DataSourcesSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/DataSourcesSettings.kt
@@ -142,6 +142,9 @@ private fun DeviceLocationToggleRow(
     var backgroundGranted by remember {
         mutableStateOf(hasBackgroundLocationPermission(context))
     }
+    var rationaleOpen by remember { mutableStateOf(false) }
+    var backgroundDeniedOpen by remember { mutableStateOf(false) }
+
     val lifecycleOwner = androidx.compose.ui.platform.LocalLifecycleOwner.current
     DisposableEffect(lifecycleOwner) {
         val observer = androidx.lifecycle.LifecycleEventObserver { _, event ->
@@ -153,6 +156,17 @@ private fun DeviceLocationToggleRow(
         onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
     }
 
+    // Background launcher: on Android 11+ this auto-deep-links into the system
+    // Settings location picker; on Android 10 it shows the inline dialog. If the
+    // user ends up granting only foreground we surface a follow-up dialog so
+    // they understand the daily worker will fall back to the saved location.
+    val backgroundLauncher = androidx.activity.compose.rememberLauncherForActivityResult(
+        contract = androidx.activity.result.contract.ActivityResultContracts.RequestPermission(),
+    ) { granted ->
+        backgroundGranted = granted
+        if (!granted) backgroundDeniedOpen = true
+    }
+
     val foregroundLauncher = androidx.activity.compose.rememberLauncherForActivityResult(
         contract = androidx.activity.result.contract.ActivityResultContracts.RequestPermission(),
     ) { granted ->
@@ -160,6 +174,11 @@ private fun DeviceLocationToggleRow(
         // hit our isPermissionGranted check, return null, and quietly fall through to
         // the settings location every day.
         onCheckedChange(granted)
+        if (granted && !hasBackgroundLocationPermission(context) &&
+            android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q
+        ) {
+            backgroundLauncher.launch(android.Manifest.permission.ACCESS_BACKGROUND_LOCATION)
+        }
     }
 
     Row(
@@ -178,10 +197,17 @@ private fun DeviceLocationToggleRow(
                     onCheckedChange(false)
                     return@Switch
                 }
-                if (hasCoarseLocationPermission(context)) {
-                    onCheckedChange(true)
-                } else {
-                    foregroundLauncher.launch(android.Manifest.permission.ACCESS_COARSE_LOCATION)
+                when {
+                    !hasCoarseLocationPermission(context) -> rationaleOpen = true
+                    !backgroundGranted -> {
+                        // Foreground already granted from a previous attempt; just
+                        // chase the missing background grant directly.
+                        onCheckedChange(true)
+                        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
+                            backgroundLauncher.launch(android.Manifest.permission.ACCESS_BACKGROUND_LOCATION)
+                        }
+                    }
+                    else -> onCheckedChange(true)
                 }
             },
         )
@@ -192,6 +218,44 @@ private fun DeviceLocationToggleRow(
             onClick = { openAppDetails(context) },
             modifier = Modifier.fillMaxWidth(),
         ) { Text(stringResource(R.string.settings_location_grant_background)) }
+    }
+
+    if (rationaleOpen) {
+        AlertDialog(
+            onDismissRequest = { rationaleOpen = false },
+            title = { Text(stringResource(R.string.settings_location_rationale_title)) },
+            text = { Text(stringResource(R.string.settings_location_rationale_body)) },
+            confirmButton = {
+                TextButton(onClick = {
+                    rationaleOpen = false
+                    foregroundLauncher.launch(android.Manifest.permission.ACCESS_COARSE_LOCATION)
+                }) { Text(stringResource(R.string.settings_location_rationale_continue)) }
+            },
+            dismissButton = {
+                TextButton(onClick = { rationaleOpen = false }) {
+                    Text(stringResource(R.string.settings_location_rationale_dismiss))
+                }
+            },
+        )
+    }
+
+    if (backgroundDeniedOpen) {
+        AlertDialog(
+            onDismissRequest = { backgroundDeniedOpen = false },
+            title = { Text(stringResource(R.string.settings_location_background_denied_title)) },
+            text = { Text(stringResource(R.string.settings_location_background_denied_body)) },
+            confirmButton = {
+                TextButton(onClick = {
+                    backgroundDeniedOpen = false
+                    openAppDetails(context)
+                }) { Text(stringResource(R.string.settings_location_background_denied_open)) }
+            },
+            dismissButton = {
+                TextButton(onClick = { backgroundDeniedOpen = false }) {
+                    Text(stringResource(R.string.settings_location_background_denied_keep))
+                }
+            },
+        )
     }
 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -102,6 +102,14 @@
     <string name="settings_location_search">Search</string>
     <string name="settings_location_searching">Searching…</string>
     <string name="settings_location_no_results">No matches.</string>
+    <string name="settings_location_rationale_title">Always-on location</string>
+    <string name="settings_location_rationale_body">ClothesCast updates your forecast in the background to deliver it on time, so it needs \'Allow all the time\' location permission.</string>
+    <string name="settings_location_rationale_continue">Continue</string>
+    <string name="settings_location_rationale_dismiss">Not now</string>
+    <string name="settings_location_background_denied_title">Always-on not granted</string>
+    <string name="settings_location_background_denied_body">Without \'Allow all the time\', the morning forecast falls back to your saved location. Open system Settings to grant it?</string>
+    <string name="settings_location_background_denied_open">Open Settings</string>
+    <string name="settings_location_background_denied_keep">Keep using saved location</string>
 
     <string name="settings_schedule_title">Daily ClothesCast</string>
     <string name="settings_schedule_time_label">Time</string>


### PR DESCRIPTION
Follow-up to #196 — that PR made location failures actually visible in DiagLog; this one fixes the more common cause (users never seeing a background-permission prompt at all).

## Why

Before this, the only way to grant `ACCESS_BACKGROUND_LOCATION` was a passive "Grant background location" TextButton tucked under the **Use device location** toggle. Most users never noticed it: they flipped the toggle, granted foreground, and that was it — the daily worker silently fell back to the saved location forever.

## What

New flow when the user turns the toggle on without coarse-location already granted:

1. **Rationale dialog** — "ClothesCast updates your forecast in the background to deliver it on time, so it needs 'Allow all the time' location permission." with **[Continue]** / **[Not now]**.
2. **Continue** chains the launchers — request `ACCESS_COARSE_LOCATION`, on grant immediately request `ACCESS_BACKGROUND_LOCATION`. On Android 11+ that request auto-deep-links into the system Settings location picker; on Android 10 it shows the inline dialog. Either way, the user sees an actual system prompt instead of a passive button.
3. **If the background callback returns denied** — surface a follow-up dialog: "Without 'Allow all the time', the morning forecast falls back to your saved location. Open Settings to grant it?" with **[Open Settings]** / **[Keep using saved location]**.

Toggle stays on regardless of background outcome — interactive opens of the app still get device-location, and the worker silently falls back to the saved location when background is denied (the existing behaviour, no regression). The original passive "Grant background location" button stays as a permanent fallback for users who declined the dialogs and want to fix it later.

For users who already have foreground granted but not background, the switch's `onCheckedChange` now also chases the missing background grant directly rather than just flipping the toggle and hoping they spot the fallback button.

## Strings

Four new base strings added under `values/strings.xml`. Translations to follow as a separate PR (consistent with the repo's localization workflow).

## Privacy

No change to what leaves the device — location is still resolved on-device via `NETWORK_PROVIDER` once a day; this PR only changes how we ask the user for the grant that the daily worker already needs.

## Test plan

- [ ] CI green (`JVM unit tests` + `Android debug build`).
- [ ] Manual on Android 11+: fresh install → toggle on → rationale dialog appears → Continue → foreground prompt → grant → system Settings location picker opens for "Allow all the time".
- [ ] Same flow but pick "While using the app" in the picker → return → "Always-on not granted" follow-up dialog appears.
- [ ] Tap **Open Settings** in the follow-up → app-details opens. Tap **Keep using saved location** → dialog dismisses, toggle stays on, fallback button still visible.
- [ ] Manual on Android 10: foreground prompt is followed by the inline background dialog, not a Settings deep-link.
- [ ] Already-granted foreground + missing background → flipping the toggle on chases background directly without re-asking foreground.
- [ ] Toggle off → no dialogs, just turns off.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uk35GrkBLepC2XpMgfZpAe)_