### PR TITLE
Normalize Locale for Android resource lookups and add Indonesian/Hebrew tests

### DIFF
--- a/app/src/main/kotlin/app/clothescast/insight/InsightFormatter.kt
+++ b/app/src/main/kotlin/app/clothescast/insight/InsightFormatter.kt
@@ -16,6 +16,7 @@ import app.clothescast.core.domain.model.Region
 import app.clothescast.core.domain.model.TemperatureBand
 import app.clothescast.core.domain.model.WeatherCondition
 import java.time.LocalTime
+import java.util.IllformedLocaleException
 import java.util.Locale
 
 /**
@@ -198,6 +199,32 @@ class InsightFormatter(
 private fun Region.toJavaLocale(): Locale? = bcp47?.let { Locale.forLanguageTag(it) }
 
 private fun Context.localizedResources(locale: Locale): Resources {
-    val config = Configuration(resources.configuration).apply { setLocale(locale) }
+    // Android resource qualifiers still use legacy language codes for a couple
+    // of locales (`values-in`, `values-iw`). Locale.forLanguageTag() returns
+    // modern tags (`id`, `he`), and forcing those through setLocale can miss
+    // our translated string buckets and fall back to English.
+    val resourcesLocale = locale.toAndroidResourceLocale()
+    val config = Configuration(resources.configuration).apply { setLocale(resourcesLocale) }
     return createConfigurationContext(config).resources
+}
+
+private fun Locale.toAndroidResourceLocale(): Locale {
+    val normalizedLanguage = when (language.lowercase(Locale.ROOT)) {
+        "id" -> "in"
+        "he" -> "iw"
+        else -> language
+    }
+    if (normalizedLanguage == language) return this
+    return try {
+        // Keep script/variant/extensions from the original locale when present
+        // (e.g. zh-Hant-*), and only swap the language subtag.
+        Locale.Builder()
+            .setLocale(this)
+            .setLanguage(normalizedLanguage)
+            .build()
+    } catch (_: IllformedLocaleException) {
+        // Defensive fallback for malformed/partial tags coming from outside
+        // our enums — preserve the old behaviour of keeping language+country.
+        if (country.isNotBlank()) Locale(normalizedLanguage, country) else Locale(normalizedLanguage)
+    }
 }

--- a/app/src/test/kotlin/app/clothescast/insight/InsightFormatterTest.kt
+++ b/app/src/test/kotlin/app/clothescast/insight/InsightFormatterTest.kt
@@ -11,6 +11,7 @@ import app.clothescast.core.domain.model.DeltaClause
 import app.clothescast.core.domain.model.ForecastPeriod
 import app.clothescast.core.domain.model.InsightSummary
 import app.clothescast.core.domain.model.PrecipClause
+import app.clothescast.core.domain.model.Region
 import app.clothescast.core.domain.model.TemperatureBand
 import app.clothescast.core.domain.model.WeatherCondition
 import io.kotest.matchers.shouldBe
@@ -363,4 +364,29 @@ class InsightFormatterTest {
         )
         out shouldBe "Hoy hará templado. Lleva paraguas esta noche, lluvia a las 21."
     }
+
+    @Test
+    fun `id-ID locale resolves Indonesian insight strings instead of English fallback`() {
+        val indonesianSubject = InsightFormatter.forContext(context, Locale.forLanguageTag("id-ID"))
+        indonesianSubject.format(summary()) shouldBe "Hari ini cuacanya hangat sedang."
+    }
+
+    @Test
+    fun `he-IL locale resolves Hebrew insight strings instead of English fallback`() {
+        val hebrewSubject = InsightFormatter.forContext(context, Locale.forLanguageTag("he-IL"))
+        hebrewSubject.format(summary()) shouldBe "היום יהיה נעים."
+    }
+
+    @Test
+    fun `Region ID_ID resolves Indonesian insight strings`() {
+        val indonesianSubject = InsightFormatter.forRegion(context, Region.ID_ID)
+        indonesianSubject.format(summary()) shouldBe "Hari ini cuacanya hangat sedang."
+    }
+
+    @Test
+    fun `Region HE_IL resolves Hebrew insight strings`() {
+        val hebrewSubject = InsightFormatter.forRegion(context, Region.HE_IL)
+        hebrewSubject.format(summary()) shouldBe "היום יהיה נעים."
+    }
+
 }


### PR DESCRIPTION
### Motivation
- Prevent falling back to English when a modern BCP-47 locale (e.g. `id`, `he`) doesn't match legacy Android resource qualifiers (`values-in`, `values-iw`).
- Preserve script/variant/extensions when swapping only the language subtag so locale-sensitive strings (e.g. Chinese variants) continue to resolve correctly.

### Description
- Added `Locale.toAndroidResourceLocale()` to normalize language subtags (`"id" -> "in"`, `"he" -> "iw"`) and to build a `Locale` that preserves script/variant/extensions, with a defensive `IllformedLocaleException` fallback to `Locale(language, country)`.
- Updated `Context.localizedResources` to call `locale.toAndroidResourceLocale()` before applying `setLocale` so resource bucket lookup uses legacy Android language codes when needed.
- Added tests in `InsightFormatterTest` that assert Indonesian (`id-ID`) and Hebrew (`he-IL`) locales (and corresponding `Region` values) resolve the correct localized strings instead of falling back to English.

### Testing
- Ran the `InsightFormatterTest` suite under Robolectric, including the new locale tests, and all tests passed.
- Verified new tests `id-ID locale resolves Indonesian insight strings`, `he-IL locale resolves Hebrew insight strings`, `Region ID_ID resolves Indonesian insight strings`, and `Region HE_IL resolves Hebrew insight strings` execute successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f103be1690832b9ccb29b3fa0981a0)