### PR TITLE
:core:domain — make garment key normalization locale-invariant

### DIFF
--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Garment.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Garment.kt
@@ -1,5 +1,7 @@
 package app.clothescast.core.domain.model
 
+import java.util.Locale
+
 /**
  * Catalog of garments the user can pick from when adding or editing a
  * [ClothesRule] in Settings. Each entry has a stable, en-US-flavoured
@@ -46,7 +48,7 @@ enum class Garment(val itemKey: String) {
          * fall back to the raw string.
          */
         fun fromKey(key: String): Garment? {
-            val normalized = key.trim().lowercase()
+            val normalized = key.trim().lowercase(Locale.ROOT)
             entries.firstOrNull { it.itemKey == normalized }?.let { return it }
             return when (normalized) {
                 "tshirt" -> TSHIRT

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/model/GarmentTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/model/GarmentTest.kt
@@ -2,6 +2,7 @@ package app.clothescast.core.domain.model
 
 import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
+import java.util.Locale
 
 class GarmentTest {
 
@@ -37,5 +38,19 @@ class GarmentTest {
     fun `fromKey returns null for unknown items`() {
         Garment.fromKey("kilt") shouldBe null
         Garment.fromKey("") shouldBe null
+    }
+
+    @Test
+    fun `fromKey does not depend on process locale`() {
+        val originalDefault = Locale.getDefault()
+        Locale.setDefault(Locale.forLanguageTag("tr-TR"))
+        try {
+            // In Turkish locale, lowercase("SHIRT") with default-locale rules
+            // becomes "shırt" (dotless ı), which won't match the stored key
+            // "shirt". fromKey must stay locale-invariant.
+            Garment.fromKey("SHIRT") shouldBe Garment.SHIRT
+        } finally {
+            Locale.setDefault(originalDefault)
+        }
     }
 }


### PR DESCRIPTION
### Motivation
- Prevent locale-sensitive string normalization from breaking stored garment-key lookups (e.g. Turkish lowercasing turning "SHIRT" → "shırt" which no longer matches the English key "shirt").

### Description
- Use `lowercase(Locale.ROOT)` when normalizing the input in `Garment.fromKey` so key matching is locale-invariant.
- Add an import for `java.util.Locale` in `Garment.kt` to support the explicit-root normalization.
- Add a regression test that sets the process locale to `tr-TR` and asserts `Garment.fromKey("SHIRT")` still resolves to `Garment.SHIRT`.

### Testing
- Ran `./gradlew :core:domain:test` in the sandbox, but the build fails before executing tests due to the environment JDK (`openjdk 25.0.1`) causing a Kotlin/Gradle compile error (`IllegalArgumentException: 25.0.1`).
- The new unit test is present and should pass under the project-supported JDK; please run CI or `./gradlew :core:domain:test` in a supported environment to validate.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1114d4360832ba96e7a188382570f)