### PR TITLE
:app — normalize english clothes items mid-sentence

### DIFF
--- a/app/src/main/kotlin/app/clothescast/insight/ClothesPhraser.kt
+++ b/app/src/main/kotlin/app/clothescast/insight/ClothesPhraser.kt
@@ -75,7 +75,8 @@ internal class EnglishClothesPhraser(private val resources: Resources) : Clothes
     // article picker also wants to see the *display* string (en-GB "trousers"
     // ends in 's' → bare; en-GB "umbrella" stays vowel-led → "an umbrella").
     private fun translate(item: String): String =
-        resources.localizedGarmentLabel(item)?.lowercase(Locale.ENGLISH) ?: item
+        resources.localizedGarmentLabel(item)?.lowercase(Locale.ENGLISH)
+            ?: item.trim().lowercase(Locale.ENGLISH)
 }
 
 /**

--- a/app/src/test/kotlin/app/clothescast/insight/InsightFormatterTest.kt
+++ b/app/src/test/kotlin/app/clothescast/insight/InsightFormatterTest.kt
@@ -85,6 +85,12 @@ class InsightFormatterTest {
     }
 
     @Test
+    fun `clothes normalizes capitalized english items mid-sentence`() {
+        subject.format(summary(clothes = ClothesClause(listOf("Sweater", "Jacket")))) shouldBe
+            "Today will be mild. Wear a sweater and jacket."
+    }
+
+    @Test
     fun `clothes drops the article on plural-looking items`() {
         subject.format(summary(clothes = ClothesClause(listOf("shorts")))) shouldBe
             "Today will be mild. Wear shorts."


### PR DESCRIPTION
### Motivation
- Prevent garments/custom items stored with initial capitals from appearing capitalised inside English sentences (e.g. avoid "Wear a Sweater.").
- Keep the existing behaviour of translating cataloged garment keys via localized `garment_*` resources while making unknown/custom fallbacks read naturally in prose.

### Description
- Normalize non-catalog English fallbacks by trimming and lowercasing the raw item key before article selection; updated `EnglishClothesPhraser.translate` to return `item.trim().lowercase(Locale.ENGLISH)` when no localized label exists (`app/src/main/kotlin/app/clothescast/insight/ClothesPhraser.kt`).
- Preserve prior behaviour for known catalog items by still lowercasing translated `garment_*` labels for article logic.
- Add a regression unit test that verifies capitalized inputs (`"Sweater", "Jacket"`) render as `"Wear a sweater and jacket."` (`app/src/test/kotlin/app/clothescast/insight/InsightFormatterTest.kt`).

### Testing
- Added the `InsightFormatterTest` regression case that asserts normalized mid-sentence rendering; the test is included in `app` unit tests.
- Attempted to run `./gradlew :app:testDebugUnitTest --tests app.clothescast.insight.InsightFormatterTest`, but the run failed in this sandbox due to the missing Android SDK/toolchain (Gradle reported `25.0.1`), so Android unit tests should be validated by CI.
- No changes were made to `:core:domain` so the pure-JVM domain test surface was not required for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f111bddc70832ba9167a763c404aab)