### PR TITLE
:app — refresh system locale tag in voice language picker

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/settings/VoiceSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/VoiceSettings.kt
@@ -338,7 +338,10 @@ private fun VoiceLocalePicker(
     // default), which can differ from the app UI language when the user sets
     // an in-app language override.
     val uiLocale = LocalContext.current.resourcesLocale()
-    val systemTag = remember { VoiceLocale.SYSTEM.resolve().toLanguageTag() }
+    // Don't memoize without a key: Locale.getDefault() can change at runtime
+    // (device language switch) and we want the SYSTEM row to reflect the
+    // current resolved tag immediately.
+    val systemTag = VoiceLocale.SYSTEM.resolve().toLanguageTag()
     val labelFor: @Composable (VoiceLocale) -> String = { option ->
         val base = stringResource(voiceLocaleLabel(option))
         if (option == VoiceLocale.SYSTEM) "$base ($systemTag)" else base


### PR DESCRIPTION
### Motivation
- Fix a UI/translation bug where the `SYSTEM` locale language tag shown in the Voice locale picker could become stale after a runtime device language change because it was memoized with `remember { ... }`.

### Description
- Stop memoizing the system tag and recompute `VoiceLocale.SYSTEM.resolve().toLanguageTag()` on each recomposition in `VoiceLocalePicker` in `app/src/main/kotlin/app/clothescast/ui/settings/VoiceSettings.kt`, and add a comment explaining why an unkeyed `remember` is inappropriate.

### Testing
- Attempted to run `./gradlew :core:data:test` and `./gradlew :core:domain:test`, but both builds failed in this sandbox with Gradle/AGP environment error `What went wrong: 25.0.1`, so automated JVM tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f112a736fc832bbb05798af8217bb9)