### PR TITLE
:app — normalize minute placeholders to zero-padded format

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -462,5 +462,5 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="insight_tie_in_with_rain">Denk an %1$s für heute Abend, Regen um %2$s.</string>
     <!-- "15 Uhr" / "15 Uhr 30" — read naturally by German TTS. -->
     <string name="insight_time_hour">%1$d Uhr</string>
-    <string name="insight_time_hour_minutes">%1$d Uhr %2$d</string>
+    <string name="insight_time_hour_minutes">%1$d Uhr %2$02d</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -427,6 +427,6 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="insight_tie_in_with_rain">Porta %1$s stasera, pioggia alle %2$s.</string>
     <!-- "15" / "15 e 30" — preposition "alle" comes from surrounding templates. -->
     <string name="insight_time_hour">%1$d</string>
-    <string name="insight_time_hour_minutes">%1$d e %2$d</string>
+    <string name="insight_time_hour_minutes">%1$d e %2$02d</string>
 
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -442,6 +442,6 @@ the displayed label localizes.
     <string name="insight_tie_in_with_rain">今夜は%1$sを持っていきましょう。%2$s頃に雨。</string>
     <!-- "15時" / "15時30分" — Japanese spoken time; postposition "頃" comes from insight_precip_at_time. -->
     <string name="insight_time_hour">%1$d時</string>
-    <string name="insight_time_hour_minutes">%1$d時%2$d分</string>
+    <string name="insight_time_hour_minutes">%1$d時%2$02d分</string>
 
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -455,6 +455,6 @@ displayed label localizes.
     <string name="insight_tie_in_with_rain">오늘 밤 %1$s 챙기세요, %2$s경에 비.</string>
     <!-- "15시" / "15시 30분" — Korean spoken time; postposition "경에" comes from insight_precip_at_time. -->
     <string name="insight_time_hour">%1$d시</string>
-    <string name="insight_time_hour_minutes">%1$d시 %2$d분</string>
+    <string name="insight_time_hour_minutes">%1$d시 %2$02d분</string>
 
 </resources>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -79,6 +79,6 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="insight_tie_in_with_rain">Mang %1$s tối nay, mưa lúc %2$s.</string>
     <!-- "15 giờ" / "15 giờ 30 phút" — preposition "lúc" comes from surrounding templates. -->
     <string name="insight_time_hour">%1$d giờ</string>
-    <string name="insight_time_hour_minutes">%1$d giờ %2$d phút</string>
+    <string name="insight_time_hour_minutes">%1$d giờ %2$02d phút</string>
 
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -434,6 +434,6 @@ label localizes.
     <string name="insight_tie_in_with_rain">今晚带上%1$s，%2$s有雨。</string>
     <!-- "15点" / "15点30分" — Chinese spoken time. insight_precip_at_time is a passthrough. -->
     <string name="insight_time_hour">%1$d点</string>
-    <string name="insight_time_hour_minutes">%1$d点%2$d分</string>
+    <string name="insight_time_hour_minutes">%1$d点%2$02d分</string>
 
 </resources>


### PR DESCRIPTION
### Motivation
- Ensure placeholder-format consistency so minute values in localized time strings are zero-padded (e.g. `15:05` renders/spoken with the leading zero) and avoid runtime/formatting mismatches across locales.
- Audit translations for printf-placeholder shape mismatches against the base `values/strings.xml` to find locales needing fixes.

### Description
- Updated `insight_time_hour_minutes` to use `%2$02d` (zero-padded minutes) in six locale files: `app/src/main/res/values-de/strings.xml`, `values-it/strings.xml`, `values-ja/strings.xml`, `values-ko/strings.xml`, `values-vi/strings.xml`, and `values-zh-rCN/strings.xml`.
- Added/ran a small Python audit that compares format-placeholder signatures across `values*/strings.xml` against the base `values/strings.xml` and used its output to drive the fixes.
- Committed the changes with message `:app — normalize minute placeholders to zero-padded format`.

### Testing
- Ran the placeholder-audit Python script before the changes to identify mismatches, which reported the non-zero-padded minute placeholders; the script completed successfully.
- Ran the placeholder-audit Python script after the changes and confirmed there are no remaining placeholder-shape mismatches for the updated keys; the audit completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1131d2cb0832b84c6679e1ee1d69a)