### PR TITLE
:app — harden clothes translation normalization

### DIFF
--- a/app/src/main/kotlin/app/clothescast/insight/ClothesPhraser.kt
+++ b/app/src/main/kotlin/app/clothescast/insight/ClothesPhraser.kt
@@ -49,7 +49,10 @@ internal class EnglishClothesPhraser(private val resources: Resources) : Clothes
     override fun withArticle(item: String): String = prefixArticle(translate(item))
 
     override fun joinItems(items: List<String>): String {
-        val translated = items.map(::translate)
+        val translated = items.asSequence()
+            .map(::translate)
+            .filter { it.isNotBlank() }
+            .toList()
         return when (translated.size) {
             0 -> ""
             1 -> prefixArticle(translated[0])
@@ -100,7 +103,10 @@ internal class GermanClothesPhraser(private val resources: Resources) : ClothesP
     override fun withArticle(item: String): String = translate(item)
 
     override fun joinItems(items: List<String>): String {
-        val translated = items.map(::translate)
+        val translated = items.asSequence()
+            .map(::translate)
+            .filter { it.isNotBlank() }
+            .toList()
         return when (translated.size) {
             0 -> ""
             1 -> translated[0]
@@ -121,7 +127,7 @@ internal class GermanClothesPhraser(private val resources: Resources) : ClothesP
      * the table falls through unchanged.
      */
     private fun translate(item: String): String =
-        EN_TO_DE[item.trim().lowercase(Locale.ROOT)] ?: item
+        EN_TO_DE[item.trim().lowercase(Locale.ROOT)] ?: item.trim()
 
     private companion object {
         // Defaults shipped in ClothesRule.DEFAULTS plus the obvious extras a user
@@ -181,7 +187,10 @@ internal class ResourceClothesPhraser(private val resources: Resources) : Clothe
         resources.getString(R.string.insight_clothes_article_a, translate(item))
 
     override fun joinItems(items: List<String>): String {
-        val translated = items.map(::translate)
+        val translated = items.asSequence()
+            .map(::translate)
+            .filter { it.isNotBlank() }
+            .toList()
         return when (translated.size) {
             0 -> ""
             1 -> translated[0]
@@ -196,7 +205,7 @@ internal class ResourceClothesPhraser(private val resources: Resources) : Clothe
     }
 
     private fun translate(item: String): String =
-        resources.localizedGarmentLabel(item) ?: item
+        resources.localizedGarmentLabel(item)?.lowercase(resources.currentLocale()) ?: item.trim()
 }
 
 /**
@@ -232,4 +241,11 @@ internal fun Resources.localizedGarmentLabel(item: String): String? {
     val garment = Garment.fromKey(item) ?: return null
     val resId = GARMENT_RES_IDS[garment] ?: return null
     return getString(resId)
+}
+
+private fun Resources.currentLocale(): Locale {
+    val locales = configuration.locales
+    if (!locales.isEmpty) return locales[0]
+    @Suppress("DEPRECATION")
+    return configuration.locale
 }

--- a/app/src/main/kotlin/app/clothescast/insight/InsightFormatter.kt
+++ b/app/src/main/kotlin/app/clothescast/insight/InsightFormatter.kt
@@ -48,7 +48,7 @@ class InsightFormatter(
         summary.alert?.let { add(formatAlert(it)) }
         add(formatBand(summary.period, summary.band))
         summary.delta?.let { add(formatDelta(it)) }
-        summary.clothes?.let { add(formatClothes(it)) }
+        summary.clothes?.let(::formatClothes)?.let(::add)
         summary.precip?.let { add(formatPrecip(it)) }
         // Both tie-in clauses share the item-only "Bring a X tonight." form;
         // the evening one additionally folds in the evening forecast's rain
@@ -57,8 +57,8 @@ class InsightFormatter(
         // rain. The clauses are separate fields because they're gated
         // differently (TONIGHT precip-peak overlap vs. TODAY evening-event
         // opt-in).
-        summary.calendarTieIn?.let { add(formatTieIn(it.item)) }
-        summary.eveningEventTieIn?.let { add(formatEveningEventTieIn(it)) }
+        summary.calendarTieIn?.let { formatTieIn(it.item) }?.let(::add)
+        summary.eveningEventTieIn?.let(::formatEveningEventTieIn)?.let(::add)
     }.joinToString(" ")
 
     private fun formatAlert(alert: AlertClause): String =
@@ -90,8 +90,11 @@ class InsightFormatter(
     // like umbrella. Probably wants a small domain-side classification on
     // ClothesRule (item kind: garment / accessory) rather than hard-coding
     // umbrella here.
-    private fun formatClothes(clothes: ClothesClause): String =
-        resources.getString(R.string.insight_clothes_wear, phraser.joinItems(clothes.items))
+    private fun formatClothes(clothes: ClothesClause): String? {
+        val items = phraser.joinItems(clothes.items)
+        if (items.isBlank()) return null
+        return resources.getString(R.string.insight_clothes_wear, items)
+    }
 
     private fun formatPrecip(precip: PrecipClause): String {
         val type = resources.getString(conditionRes(precip.condition))
@@ -105,17 +108,22 @@ class InsightFormatter(
         return resources.getString(R.string.insight_precip, type, timePhrase)
     }
 
-    private fun formatTieIn(item: String): String =
-        resources.getString(R.string.insight_tie_in, phraser.withArticle(item))
+    private fun formatTieIn(item: String): String? {
+        val renderedItem = phraser.withArticle(item)
+        if (renderedItem.isBlank()) return null
+        return resources.getString(R.string.insight_tie_in, renderedItem)
+    }
 
-    private fun formatEveningEventTieIn(tieIn: EveningEventTieInClause): String {
+    private fun formatEveningEventTieIn(tieIn: EveningEventTieInClause): String? {
+        val renderedItem = phraser.withArticle(tieIn.item)
+        if (renderedItem.isBlank()) return null
         // Local capture so the null check enables smart cast — the property
         // lives on a :core:domain data class and Kotlin won't smart-cast a
         // public API property across modules.
-        val rainTime = tieIn.rainTime ?: return formatTieIn(tieIn.item)
+        val rainTime = tieIn.rainTime ?: return resources.getString(R.string.insight_tie_in, renderedItem)
         return resources.getString(
             R.string.insight_tie_in_with_rain,
-            phraser.withArticle(tieIn.item),
+            renderedItem,
             spokenTime(rainTime),
         )
     }

--- a/app/src/test/kotlin/app/clothescast/insight/InsightFormatterTest.kt
+++ b/app/src/test/kotlin/app/clothescast/insight/InsightFormatterTest.kt
@@ -408,4 +408,35 @@ class InsightFormatterTest {
         )
         out shouldBe "Today will be mild. Wear a sweater."
     }
+
+    @Test
+    fun `clothes clause is omitted when all entries are blank`() {
+        val out = subject.format(
+            summary(
+                clothes = ClothesClause(listOf(" ", "\t", "")),
+            ),
+        )
+        out shouldBe "Today will be mild."
+    }
+
+    @Test
+    fun `calendar tie-in is omitted when item is blank`() {
+        val out = subject.format(
+            summary(
+                period = ForecastPeriod.TONIGHT,
+                calendarTieIn = CalendarTieInClause(" "),
+            ),
+        )
+        out shouldBe "Tonight will be mild."
+    }
+
+    @Test
+    fun `evening event tie-in is omitted when item is blank even when rain time exists`() {
+        val out = subject.format(
+            summary(
+                eveningEventTieIn = EveningEventTieInClause(" ", rainTime = LocalTime.of(21, 0)),
+            ),
+        )
+        out shouldBe "Today will be mild."
+    }
 }

--- a/app/src/test/kotlin/app/clothescast/insight/InsightFormatterTest.kt
+++ b/app/src/test/kotlin/app/clothescast/insight/InsightFormatterTest.kt
@@ -388,4 +388,24 @@ class InsightFormatterTest {
         )
         out shouldBe "Hoy hará templado. Lleva paraguas esta noche, lluvia a las 21."
     }
+
+    @Test
+    fun `es — catalog keys still translate when source casing and whitespace are messy`() {
+        val out = spanishSubject.format(
+            summary(
+                clothes = ClothesClause(listOf(" Sweater ", "JACKET")),
+            ),
+        )
+        out shouldBe "Hoy hará templado. Lleva jersey y chaqueta."
+    }
+
+    @Test
+    fun `clothes clause ignores blank entries instead of speaking empty nouns`() {
+        val out = subject.format(
+            summary(
+                clothes = ClothesClause(listOf(" ", "sweater", "")),
+            ),
+        )
+        out shouldBe "Today will be mild. Wear a sweater."
+    }
 }


### PR DESCRIPTION
### Motivation
- Prevent malformed translated prose caused by blank or whitespace-only clothing items being emitted into sentences.
- Ensure unknown/catalog-fallback items don't leak accidental surrounding whitespace into rendered output.
- Produce natural mid-sentence casing for localized garment labels (e.g. Spanish) while leaving picker labels title-cased.

### Description
- Filter out blank/whitespace entries before joining in English, German, and resource-based phrasers by mapping, trimming/translating, and `filter { it.isNotBlank() }` in `joinItems` (changes to `EnglishClothesPhraser`, `GermanClothesPhraser`, `ResourceClothesPhraser`).
- Trim unknown fallback item text in German and resource phrasers so stray whitespace is removed instead of preserved in prose.
- Lowercase localized garment labels using the active resources locale in the generic `ResourceClothesPhraser` and add a small `Resources.currentLocale()` helper to obtain the context locale.
- Add regression tests in `InsightFormatterTest` covering messy casing/whitespace Spanish catalog keys and ignoring blank clothing entries.

### Testing
- Added unit tests in `app/src/test/kotlin/app/clothescast/insight/InsightFormatterTest.kt` but could not run them end-to-end in the sandbox due to an environment Gradle/Kotlin DSL initialization failure.
- Attempts to run `./gradlew :app:testDebugUnitTest --tests "app.clothescast.insight.InsightFormatterTest"` and `./gradlew :core:domain:test` both failed early with `IllegalArgumentException: 25.0.1` from the Kotlin/Gradle tooling in this environment.
- CI should run the full Android/JVM test matrix and validate the new tests and behavior on actual build runners.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f115506b38832ba886a3cd329507e2)