### PR TITLE
:app — remove stale translated insight_calendar_tie_in keys

### DIFF
--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -77,7 +77,6 @@ West Bengal vocabulary differences in a future PR.
     <string name="insight_condition_thunderstorm">বজ্রপাত</string>
     <string name="insight_condition_unknown">অজানা</string>
     <!-- "মিটিং (15)-এর জন্য কোট নিন।" -->
-    <string name="insight_calendar_tie_in">%3$s (%2$s)-এর জন্য %1$s নিন।</string>
     <string name="insight_tie_in">আজ রাতে %1$s নিন।</string>
     <string name="insight_tie_in_with_rain">আজ রাতে %1$s নিন, %2$s-এ বৃষ্টি।</string>
     <!-- "15" — suffix "-এ" comes from insight_precip_at_time wrapper. -->

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -432,7 +432,6 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="insight_condition_snow">Nieve</string>
     <string name="insight_condition_thunderstorm">Tormenta</string>
     <string name="insight_condition_unknown">Desconocido</string>
-    <string name="insight_calendar_tie_in">Lleva %1$s para tu %3$s de las %2$s.</string>
     <!-- Evening tie-in counterparts of the English insight_tie_in / insight_tie_in_with_rain.
          Without these the Spanish formatter falls through to another locale that *does*
          have the keys (German), which is how "sieben Grad" leaks into Spanish output. -->

--- a/app/src/main/res/values-fil/strings.xml
+++ b/app/src/main/res/values-fil/strings.xml
@@ -74,7 +74,6 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="insight_condition_snow">Niyebe</string>
     <string name="insight_condition_thunderstorm">Bagyo</string>
     <string name="insight_condition_unknown">Hindi kilala</string>
-    <string name="insight_calendar_tie_in">Magdala ng %1$s para sa %3$s ng %2$s.</string>
     <string name="insight_tie_in">Magdala ng %1$s ngayong gabi.</string>
     <string name="insight_tie_in_with_rain">Magdala ng %1$s ngayong gabi, ulan ng %2$s.</string>
     <!-- "15" — preposition "ng" comes from surrounding templates. -->

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -435,7 +435,6 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="insight_condition_snow">Neige</string>
     <string name="insight_condition_thunderstorm">Orage</string>
     <string name="insight_condition_unknown">Inconnu</string>
-    <string name="insight_calendar_tie_in">Prends %1$s pour %3$s à %2$s.</string>
     <string name="insight_tie_in">Prends %1$s ce soir.</string>
     <string name="insight_tie_in_with_rain">Prends %1$s ce soir, pluie à %2$s.</string>
     <!-- "15h" / "15h30" — French TTS reads as "quinze heures" / "quinze heures trente". -->

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -75,7 +75,6 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="insight_condition_thunderstorm">तूफ़ान</string>
     <string name="insight_condition_unknown">अज्ञात</string>
     <!-- "मीटिंग (15 बजे) के लिए कोट साथ लें।" -->
-    <string name="insight_calendar_tie_in">%3$s (%2$s) के लिए %1$s साथ लें।</string>
     <string name="insight_tie_in">आज रात %1$s साथ लें।</string>
     <string name="insight_tie_in_with_rain">आज रात %1$s साथ लें, %2$s बजे बारिश।</string>
     <!-- "15" — postposition "बजे" comes from insight_precip_at_time wrapper. -->

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -404,7 +404,6 @@ spousal register), matching the existing insight prose ("Ponesi …",
     <string name="insight_condition_snow">Snijeg</string>
     <string name="insight_condition_thunderstorm">Grmljavina</string>
     <string name="insight_condition_unknown">Nepoznato</string>
-    <string name="insight_calendar_tie_in">Ponesi %1$s na %3$s u %2$s.</string>
     <string name="insight_tie_in">Ponesi %1$s večeras.</string>
     <string name="insight_tie_in_with_rain">Ponesi %1$s večeras, kiša u %2$s.</string>
     <!-- "15" — preposition "u" comes from surrounding templates. -->

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -76,7 +76,6 @@ to values/strings.xml (English).
     <string name="insight_condition_snow">Salju</string>
     <string name="insight_condition_thunderstorm">Badai petir</string>
     <string name="insight_condition_unknown">Tidak diketahui</string>
-    <string name="insight_calendar_tie_in">Bawa %1$s untuk %3$s pukul %2$s.</string>
     <string name="insight_tie_in">Bawa %1$s malam ini.</string>
     <string name="insight_tie_in_with_rain">Bawa %1$s malam ini, hujan pukul %2$s.</string>
     <!-- "15" / "15.30" — "pukul" comes from surrounding templates. -->

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -422,7 +422,6 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="insight_condition_snow">Neve</string>
     <string name="insight_condition_thunderstorm">Temporale</string>
     <string name="insight_condition_unknown">Sconosciuto</string>
-    <string name="insight_calendar_tie_in">Porta %1$s per il tuo %3$s alle %2$s.</string>
     <string name="insight_tie_in">Porta %1$s stasera.</string>
     <string name="insight_tie_in_with_rain">Porta %1$s stasera, pioggia alle %2$s.</string>
     <!-- "15" / "15 e 30" — preposition "alle" comes from surrounding templates. -->

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -437,7 +437,6 @@ the displayed label localizes.
     <string name="insight_condition_thunderstorm">雷雨</string>
     <string name="insight_condition_unknown">不明</string>
     <!-- "会議（15時）のためにコートを持っていきましょう。" -->
-    <string name="insight_calendar_tie_in">%3$s（%2$s）のために%1$sを持っていきましょう。</string>
     <string name="insight_tie_in">今夜は%1$sを持っていきましょう。</string>
     <string name="insight_tie_in_with_rain">今夜は%1$sを持っていきましょう。%2$s頃に雨。</string>
     <!-- "15時" / "15時30分" — Japanese spoken time; postposition "頃" comes from insight_precip_at_time. -->

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -450,7 +450,6 @@ displayed label localizes.
     <string name="insight_condition_thunderstorm">뇌우</string>
     <string name="insight_condition_unknown">알 수 없음</string>
     <!-- "회의(15시)에 코트 챙기세요." -->
-    <string name="insight_calendar_tie_in">%3$s(%2$s)에 %1$s 챙기세요.</string>
     <string name="insight_tie_in">오늘 밤 %1$s 챙기세요.</string>
     <string name="insight_tie_in_with_rain">오늘 밤 %1$s 챙기세요, %2$s경에 비.</string>
     <!-- "15시" / "15시 30분" — Korean spoken time; postposition "경에" comes from insight_precip_at_time. -->

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -73,7 +73,6 @@ editor, outfit-card labels, and region/voice-locale picker names.
     <string name="insight_condition_snow">Sneeuw</string>
     <string name="insight_condition_thunderstorm">Onweer</string>
     <string name="insight_condition_unknown">Onbekend</string>
-    <string name="insight_calendar_tie_in">Neem %1$s mee voor je %3$s om %2$s.</string>
     <string name="insight_tie_in">Neem %1$s mee vanavond.</string>
     <string name="insight_tie_in_with_rain">Neem %1$s mee vanavond, regen om %2$s.</string>
     <!-- "15 uur" — preposition "om" comes from surrounding templates. -->

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -71,7 +71,6 @@ editor, outfit-card labels, and region/voice-locale picker names.
     <string name="insight_condition_snow">Śnieg</string>
     <string name="insight_condition_thunderstorm">Burza</string>
     <string name="insight_condition_unknown">Nieznane</string>
-    <string name="insight_calendar_tie_in">Weź %1$s na %3$s o %2$s.</string>
     <string name="insight_tie_in">Weź %1$s wieczorem.</string>
     <string name="insight_tie_in_with_rain">Weź %1$s wieczorem, deszcz o %2$s.</string>
     <!-- "15" — preposition "o" comes from surrounding templates. -->

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -439,7 +439,6 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="insight_condition_snow">Neve</string>
     <string name="insight_condition_thunderstorm">Tempestade</string>
     <string name="insight_condition_unknown">Desconhecido</string>
-    <string name="insight_calendar_tie_in">Leve %1$s para seu %3$s às %2$s.</string>
     <string name="insight_tie_in">Leve %1$s esta noite.</string>
     <string name="insight_tie_in_with_rain">Leve %1$s esta noite, chuva às %2$s.</string>
     <!-- "15h" / "15h30" — Brazilian Portuguese hour notation, TTS reads naturally. -->

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -420,7 +420,6 @@ only the displayed label localizes.
     <string name="insight_condition_snow">Снег</string>
     <string name="insight_condition_thunderstorm">Гроза</string>
     <string name="insight_condition_unknown">Неизвестно</string>
-    <string name="insight_calendar_tie_in">Возьми %1$s на %3$s в %2$s.</string>
     <string name="insight_tie_in">Возьми %1$s сегодня вечером.</string>
     <string name="insight_tie_in_with_rain">Возьми %1$s сегодня вечером, дождь в %2$s.</string>
     <!-- "15" — preposition "в" comes from surrounding templates. -->

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -72,7 +72,6 @@ editor, outfit-card labels, and region/voice-locale picker names.
     <string name="insight_condition_snow">Snö</string>
     <string name="insight_condition_thunderstorm">Åskväder</string>
     <string name="insight_condition_unknown">Okänt</string>
-    <string name="insight_calendar_tie_in">Ta med %1$s till din %3$s klockan %2$s.</string>
     <string name="insight_tie_in">Ta med %1$s i kväll.</string>
     <string name="insight_tie_in_with_rain">Ta med %1$s i kväll, regn klockan %2$s.</string>
     <!-- "15" — "klockan" comes from surrounding templates. -->

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -72,7 +72,6 @@ editor, outfit-card labels, and region/voice-locale picker names.
     <string name="insight_condition_snow">Kar</string>
     <string name="insight_condition_thunderstorm">Fırtına</string>
     <string name="insight_condition_unknown">Bilinmiyor</string>
-    <string name="insight_calendar_tie_in">%2$s\'deki %3$s için %1$s al.</string>
     <string name="insight_tie_in">Bu gece %1$s al.</string>
     <string name="insight_tie_in_with_rain">Bu gece %1$s al, saat %2$s\'de yağmur.</string>
     <!-- "15" — "saat" comes from surrounding templates. -->

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -71,7 +71,6 @@ editor, outfit-card labels, and region/voice-locale picker names.
     <string name="insight_condition_snow">Сніг</string>
     <string name="insight_condition_thunderstorm">Гроза</string>
     <string name="insight_condition_unknown">Невідомо</string>
-    <string name="insight_calendar_tie_in">Візьміть %1$s на %3$s о %2$s.</string>
     <string name="insight_tie_in">Візьміть %1$s сьогодні ввечері.</string>
     <string name="insight_tie_in_with_rain">Візьміть %1$s сьогодні ввечері, дощ о %2$s.</string>
     <!-- "15" — preposition "о" comes from surrounding templates. -->

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -74,7 +74,6 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="insight_condition_snow">Tuyết</string>
     <string name="insight_condition_thunderstorm">Giông bão</string>
     <string name="insight_condition_unknown">Không xác định</string>
-    <string name="insight_calendar_tie_in">Mang %1$s cho %3$s lúc %2$s.</string>
     <string name="insight_tie_in">Mang %1$s tối nay.</string>
     <string name="insight_tie_in_with_rain">Mang %1$s tối nay, mưa lúc %2$s.</string>
     <!-- "15 giờ" / "15 giờ 30 phút" — preposition "lúc" comes from surrounding templates. -->

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -429,7 +429,6 @@ label localizes.
     <string name="insight_condition_thunderstorm">雷暴</string>
     <string name="insight_condition_unknown">未知</string>
     <!-- "为15点的会议带上雨伞。" — time before event name follows Chinese convention. -->
-    <string name="insight_calendar_tie_in">为%2$s的%3$s带上%1$s。</string>
     <string name="insight_tie_in">今晚带上%1$s。</string>
     <string name="insight_tie_in_with_rain">今晚带上%1$s，%2$s有雨。</string>
     <!-- "15点" / "15点30分" — Chinese spoken time. insight_precip_at_time is a passthrough. -->


### PR DESCRIPTION
### Motivation
- Several localized `strings.xml` files contained a stale `insight_calendar_tie_in` key that no longer exists in the base `app/src/main/res/values/strings.xml`. 
- Locale-only leftovers can trigger translation-drift and `ExtraTranslation`-style lint issues and should be removed to keep resource sets aligned.

### Description
- Remove the obsolete `insight_calendar_tie_in` string from 19 localized files under `app/src/main/res/values-*` so locale resource sets match the default `values/strings.xml`.
- Changes are limited to deleting the single stale key in each affected `strings.xml` file; no other strings were modified.
- Commit recorded as `a5a1e4b` with the message `:app — remove stale translated insight_calendar_tie_in keys`.

### Testing
- Parsed all `app/src/main/res/**/strings.xml` files with `xml.etree.ElementTree` to validate XML remained well-formed (`bad 0`).
- Ran a key-audit script comparing each locale against `app/src/main/res/values/strings.xml` to confirm no locale defines extra keys after the removals. 
- Verified the targeted removals in the diff via `git show` / `git diff` and confirmed the stale key is absent in the edited files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f115c6d498832bab1e0dbb743d1eae)