### PR TITLE
:app — short-circuit tie-in formatting on blank input (fix CI)

### DIFF
--- a/app/src/main/kotlin/app/clothescast/insight/InsightFormatter.kt
+++ b/app/src/main/kotlin/app/clothescast/insight/InsightFormatter.kt
@@ -109,12 +109,17 @@ class InsightFormatter(
     }
 
     private fun formatTieIn(item: String): String? {
+        // Short-circuit before article picking: prefixArticle("") emits "a "
+        // via the "a %1$s" template, which is non-blank and would slip past a
+        // post-rendering isBlank() check.
+        if (item.isBlank()) return null
         val renderedItem = phraser.withArticle(item)
         if (renderedItem.isBlank()) return null
         return resources.getString(R.string.insight_tie_in, renderedItem)
     }
 
     private fun formatEveningEventTieIn(tieIn: EveningEventTieInClause): String? {
+        if (tieIn.item.isBlank()) return null
         val renderedItem = phraser.withArticle(tieIn.item)
         if (renderedItem.isBlank()) return null
         // Local capture so the null check enables smart cast — the property


### PR DESCRIPTION
## Why

`main` is red. The `JVM unit tests` job has been failing since 9b1fda9 (PR #208 merge):
- https://github.com/mikelward/clothescast/actions/runs/25076146885/job/73469152572 — `JVM unit tests` ❌, `Android debug build` ✅

PR #208 added three regression tests asserting that blank clothes / tie-in items get omitted from the prose. Two of them fail:

- `calendar tie-in is omitted when item is blank`
- `evening event tie-in is omitted when item is blank even when rain time exists`

Root cause: `formatTieIn` / `formatEveningEventTieIn` only check the **rendered** item (`renderedItem.isBlank()`), but for English `prefixArticle("")` emits `"a "` via the `"a %1$s"` template — non-blank — so the guard slips and the formatter produces `"Bring a  tonight."` / `"Bring a  tonight, rain at 9pm."`.

## Fix

Short-circuit on the raw `item.isBlank()` *before* article picking. Keep the post-render guard for locales whose article template can collapse to whitespace (e.g. `ResourceClothesPhraser` with `"%1$s"`).

This is the same fix already drafted in #210, which was stacked on top of the now-merged #208. Landing it directly against `main` here so CI goes green without waiting for #210 to be rebased.

## Scope

- One file changed: `app/src/main/kotlin/app/clothescast/insight/InsightFormatter.kt` — five inserted lines, no logic changes for non-blank input.
- No new tests — the three regression tests added in 9b1fda9 already cover this; they were just failing.
- No string changes, no privacy-relevant changes.

## Test plan

- [ ] CI: `JVM unit tests` job green (the two failing tests should now pass).
- [ ] CI: `Android debug build` job stays green.

Sandbox can't reach Google Maven, so `:app:testDebugUnitTest` can't run locally — relying on CI as the validation surface, per CLAUDE.md.

## Follow-ups

- #210 becomes redundant once this lands; close it (or rebase to a no-op).

---
_Generated by [Claude Code](https://claude.ai/code/session_015T6g1E6YSgKyQZ35hCMGd3)_