### PR TITLE
:app — promote About from Settings root to Today's overflow menu

### DIFF
--- a/app/src/main/kotlin/app/clothescast/MainActivity.kt
+++ b/app/src/main/kotlin/app/clothescast/MainActivity.kt
@@ -96,6 +96,10 @@ private fun ClothesCastNav(app: ClothesCastApplication) {
                     settingsInitialRoute = null
                     screen = Screen.Settings
                 },
+                onNavigateToAbout = {
+                    settingsInitialRoute = SettingsRoute.About.name
+                    screen = Screen.Settings
+                },
             )
         }
         Screen.Settings -> {

--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsScreen.kt
@@ -31,11 +31,13 @@ import app.clothescast.R
 /**
  * One sub-page per concern. Order in the enum matches the order shown in the
  * root list: the most-frequently-tweaked rules at the top, set-once
- * configuration in the middle, and API keys / data sources / about at the
- * bottom.
+ * configuration in the middle, and API keys / data sources at the bottom.
  *
- * Public so callers (e.g. the onboarding flow) can deep-link into a specific
- * sub-page via [SettingsScreen]'s `initialRoute` param.
+ * About is reachable as a deep-link target only — it's surfaced from Today's
+ * overflow menu, not from the settings root list.
+ *
+ * Public so callers (e.g. the onboarding flow, Today's overflow) can deep-link
+ * into a specific sub-page via [SettingsScreen]'s `initialRoute` param.
  */
 enum class SettingsRoute(@StringRes val titleRes: Int) {
     Root(R.string.settings_title),
@@ -199,7 +201,7 @@ internal fun SettingsRoot(
     ) {
         NotificationPermissionBanner()
         SettingsRoute.entries
-            .filter { it != SettingsRoute.Root }
+            .filter { it != SettingsRoute.Root && it != SettingsRoute.About }
             .forEach { destination ->
                 SettingsNavRow(
                     title = stringResource(destination.titleRes),

--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
@@ -71,7 +71,11 @@ import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun TodayScreen(viewModel: TodayViewModel, onNavigateToSettings: () -> Unit) {
+fun TodayScreen(
+    viewModel: TodayViewModel,
+    onNavigateToSettings: () -> Unit,
+    onNavigateToAbout: () -> Unit,
+) {
     val state by viewModel.state.collectAsStateWithLifecycle()
     val context = LocalContext.current
     val activity = context.findActivity()
@@ -131,6 +135,13 @@ fun TodayScreen(viewModel: TodayViewModel, onNavigateToSettings: () -> Unit) {
                                         BugReport.share(activity, includeScreenshot = true)
                                     }
                                 }
+                            },
+                        )
+                        DropdownMenuItem(
+                            text = { Text(stringResource(R.string.settings_root_about)) },
+                            onClick = {
+                                overflowExpanded = false
+                                onNavigateToAbout()
                             },
                         )
                     }


### PR DESCRIPTION
## Summary

- Surface About from Today's `⋮` overflow menu (alongside "Report a bug") instead of as a row in the Settings root list.
- Settings stays where it is — its own top-bar icon — since it's the most frequent destination (API keys, schedule, clothes thresholds), so a 2-tap path would cost more than the visual tidiness it buys.
- About is reached by deep-linking into `SettingsScreen` with `initialRoute = SettingsRoute.About`, reusing the same one-back-exits-Settings behaviour onboarding already uses. The route + page stay in `SettingsRoute`; only the root list filters About out.
- Reuses `R.string.settings_root_about` ("About") for the menu label rather than introducing a new string — already translated in 10+ locales and the label is identical.

## Privacy

No change to what leaves the device.

## Test plan

- [ ] CI green (JVM unit tests + Android debug build).
- [ ] Roborazzi `settings_root` snapshot updates — About row disappears from the root list. Confirm the diff in the `ui-preview-snapshots` artifact.
- [ ] On device: Today → `⋮` → About lands on the existing About page; back returns to Today (one back, not two).
- [ ] Settings root no longer shows the About row; sub-pages (Schedule, Clothes, Region, Voice, API keys, Data sources) still navigate normally.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gsh8ZgtxCcAx4RDcPVHkAX)_