### PR TITLE
:app + :core — add Arabic voice variants for Egypt, UAE, and Morocco

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/settings/VoiceSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/VoiceSettings.kt
@@ -422,6 +422,9 @@ private fun voiceLocaleLabel(locale: VoiceLocale): Int = when (locale) {
     VoiceLocale.JA_JP -> R.string.settings_tts_voice_locale_ja_jp
     VoiceLocale.KO_KR -> R.string.settings_tts_voice_locale_ko_kr
     VoiceLocale.AR_SA -> R.string.settings_tts_voice_locale_ar_sa
+    VoiceLocale.AR_EG -> R.string.settings_tts_voice_locale_ar_eg
+    VoiceLocale.AR_AE -> R.string.settings_tts_voice_locale_ar_ae
+    VoiceLocale.AR_MA -> R.string.settings_tts_voice_locale_ar_ma
     VoiceLocale.HE_IL -> R.string.settings_tts_voice_locale_he_il
     VoiceLocale.FA_IR -> R.string.settings_tts_voice_locale_fa_ir
 }

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -10,6 +10,9 @@ they work correctly in both the single-band and range templates.
 <resources>
     <string name="settings_region_language_ar_sa">العربية (المملكة العربية السعودية)</string>
     <string name="settings_tts_voice_locale_ar_sa">العربية (المملكة العربية السعودية)</string>
+    <string name="settings_tts_voice_locale_ar_eg">العربية (مصر)</string>
+    <string name="settings_tts_voice_locale_ar_ae">العربية (الإمارات العربية المتحدة)</string>
+    <string name="settings_tts_voice_locale_ar_ma">العربية (المغرب)</string>
     <string name="settings_tts_voice_locale_label">اللغة</string>
 
     <string name="garment_sweater">سترة صوفية</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -215,6 +215,9 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_tts_voice_locale_ja_jp">Japanisch (Japan)</string>
     <string name="settings_tts_voice_locale_ko_kr">Koreanisch (Südkorea)</string>
     <string name="settings_tts_voice_locale_ar_sa">Arabisch (Saudi-Arabien)</string>
+    <string name="settings_tts_voice_locale_ar_eg">Arabisch (Ägypten)</string>
+    <string name="settings_tts_voice_locale_ar_ae">Arabisch (Vereinigte Arabische Emirate)</string>
+    <string name="settings_tts_voice_locale_ar_ma">Arabisch (Marokko)</string>
     <string name="settings_tts_voice_locale_he_il">Hebräisch (Israel)</string>
     <string name="settings_tts_voice_locale_fa_ir">Persisch (Iran)</string>
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -217,6 +217,9 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_tts_voice_locale_ja_jp">Japonés (Japón)</string>
     <string name="settings_tts_voice_locale_ko_kr">Coreano (Corea del Sur)</string>
     <string name="settings_tts_voice_locale_ar_sa">Árabe (Arabia Saudita)</string>
+    <string name="settings_tts_voice_locale_ar_eg">Árabe (Egipto)</string>
+    <string name="settings_tts_voice_locale_ar_ae">Árabe (Emiratos Árabes Unidos)</string>
+    <string name="settings_tts_voice_locale_ar_ma">Árabe (Marruecos)</string>
     <string name="settings_tts_voice_locale_he_il">Hebreo (Israel)</string>
     <string name="settings_tts_voice_locale_fa_ir">Persa (Irán)</string>
 

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -219,6 +219,9 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_tts_voice_locale_ja_jp">Japonais (Japon)</string>
     <string name="settings_tts_voice_locale_ko_kr">Coréen (Corée du Sud)</string>
     <string name="settings_tts_voice_locale_ar_sa">Arabe (Arabie saoudite)</string>
+    <string name="settings_tts_voice_locale_ar_eg">Arabe (Égypte)</string>
+    <string name="settings_tts_voice_locale_ar_ae">Arabe (Émirats arabes unis)</string>
+    <string name="settings_tts_voice_locale_ar_ma">Arabe (Maroc)</string>
     <string name="settings_tts_voice_locale_he_il">Hébreu (Israël)</string>
     <string name="settings_tts_voice_locale_fa_ir">Persan (Iran)</string>
 

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -190,6 +190,9 @@ spousal register), matching the existing insight prose ("Ponesi …",
     <string name="settings_tts_voice_locale_ja_jp">Japanski (Japan)</string>
     <string name="settings_tts_voice_locale_ko_kr">Korejski (Južna Koreja)</string>
     <string name="settings_tts_voice_locale_ar_sa">Arapski (Saudijska Arabija)</string>
+    <string name="settings_tts_voice_locale_ar_eg">Arapski (Egipat)</string>
+    <string name="settings_tts_voice_locale_ar_ae">Arapski (Ujedinjeni Arapski Emirati)</string>
+    <string name="settings_tts_voice_locale_ar_ma">Arapski (Maroko)</string>
     <string name="settings_tts_voice_locale_he_il">Hebrejski (Izrael)</string>
     <string name="settings_tts_voice_locale_fa_ir">Perzijski (Iran)</string>
 

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -209,6 +209,9 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_tts_voice_locale_ja_jp">Giapponese (Giappone)</string>
     <string name="settings_tts_voice_locale_ko_kr">Coreano (Corea del Sud)</string>
     <string name="settings_tts_voice_locale_ar_sa">Arabo (Arabia Saudita)</string>
+    <string name="settings_tts_voice_locale_ar_eg">Arabo (Egitto)</string>
+    <string name="settings_tts_voice_locale_ar_ae">Arabo (Emirati Arabi Uniti)</string>
+    <string name="settings_tts_voice_locale_ar_ma">Arabo (Marocco)</string>
     <string name="settings_tts_voice_locale_he_il">Ebraico (Israele)</string>
     <string name="settings_tts_voice_locale_fa_ir">Persiano (Iran)</string>
 

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -215,6 +215,9 @@ the displayed label localizes.
     <string name="settings_tts_voice_locale_bn_bd">ベンガル語（バングラデシュ）</string>
     <string name="settings_tts_voice_locale_ko_kr">韓国語（韓国）</string>
     <string name="settings_tts_voice_locale_ar_sa">アラビア語（サウジアラビア）</string>
+    <string name="settings_tts_voice_locale_ar_eg">アラビア語（エジプト）</string>
+    <string name="settings_tts_voice_locale_ar_ae">アラビア語（アラブ首長国連邦）</string>
+    <string name="settings_tts_voice_locale_ar_ma">アラビア語（モロッコ）</string>
     <string name="settings_tts_voice_locale_he_il">ヘブライ語（イスラエル）</string>
     <string name="settings_tts_voice_locale_fa_ir">ペルシャ語（イラン）</string>
 

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -232,6 +232,9 @@ displayed label localizes.
     <string name="settings_tts_voice_locale_bn_bd">벵골어 (방글라데시)</string>
     <string name="settings_tts_voice_locale_ja_jp">일본어 (일본)</string>
     <string name="settings_tts_voice_locale_ar_sa">아랍어 (사우디아라비아)</string>
+    <string name="settings_tts_voice_locale_ar_eg">아랍어 (이집트)</string>
+    <string name="settings_tts_voice_locale_ar_ae">아랍어 (아랍에미리트)</string>
+    <string name="settings_tts_voice_locale_ar_ma">아랍어 (모로코)</string>
     <string name="settings_tts_voice_locale_he_il">히브리어 (이스라엘)</string>
     <string name="settings_tts_voice_locale_fa_ir">페르시아어 (이란)</string>
 

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -220,6 +220,9 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_tts_voice_locale_ja_jp">Japonês (Japão)</string>
     <string name="settings_tts_voice_locale_ko_kr">Coreano (Coreia do Sul)</string>
     <string name="settings_tts_voice_locale_ar_sa">Árabe (Arábia Saudita)</string>
+    <string name="settings_tts_voice_locale_ar_eg">Árabe (Egito)</string>
+    <string name="settings_tts_voice_locale_ar_ae">Árabe (Emirados Árabes Unidos)</string>
+    <string name="settings_tts_voice_locale_ar_ma">Árabe (Marrocos)</string>
     <string name="settings_tts_voice_locale_he_il">Hebraico (Israel)</string>
     <string name="settings_tts_voice_locale_fa_ir">Persa (Irã)</string>
 

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -209,6 +209,9 @@ only the displayed label localizes.
     <string name="settings_tts_voice_locale_ja_jp">Японский (Япония)</string>
     <string name="settings_tts_voice_locale_ko_kr">Корейский (Южная Корея)</string>
     <string name="settings_tts_voice_locale_ar_sa">Арабский (Саудовская Аравия)</string>
+    <string name="settings_tts_voice_locale_ar_eg">Арабский (Египет)</string>
+    <string name="settings_tts_voice_locale_ar_ae">Арабский (Объединённые Арабские Эмираты)</string>
+    <string name="settings_tts_voice_locale_ar_ma">Арабский (Марокко)</string>
     <string name="settings_tts_voice_locale_he_il">Иврит (Израиль)</string>
     <string name="settings_tts_voice_locale_fa_ir">Персидский (Иран)</string>
 

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -210,6 +210,9 @@ label localizes.
     <string name="settings_tts_voice_locale_ja_jp">日语（日本）</string>
     <string name="settings_tts_voice_locale_ko_kr">韩语（韩国）</string>
     <string name="settings_tts_voice_locale_ar_sa">阿拉伯语（沙特阿拉伯）</string>
+    <string name="settings_tts_voice_locale_ar_eg">阿拉伯语（埃及）</string>
+    <string name="settings_tts_voice_locale_ar_ae">阿拉伯语（阿联酋）</string>
+    <string name="settings_tts_voice_locale_ar_ma">阿拉伯语（摩洛哥）</string>
     <string name="settings_tts_voice_locale_he_il">希伯来语（以色列）</string>
     <string name="settings_tts_voice_locale_fa_ir">波斯语（伊朗）</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -179,6 +179,9 @@
     <string name="settings_tts_voice_locale_ja_jp">Japanese (Japan)</string>
     <string name="settings_tts_voice_locale_ko_kr">Korean (South Korea)</string>
     <string name="settings_tts_voice_locale_ar_sa">Arabic (Saudi Arabia)</string>
+    <string name="settings_tts_voice_locale_ar_eg">Arabic (Egypt)</string>
+    <string name="settings_tts_voice_locale_ar_ae">Arabic (United Arab Emirates)</string>
+    <string name="settings_tts_voice_locale_ar_ma">Arabic (Morocco)</string>
     <string name="settings_tts_voice_locale_he_il">Hebrew (Israel)</string>
     <string name="settings_tts_voice_locale_fa_ir">Persian (Iran)</string>
     <string name="settings_tts_test">Test voice</string>

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Settings.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Settings.kt
@@ -76,6 +76,9 @@ enum class VoiceLocale(val bcp47: String?) {
     JA_JP("ja-JP"),
     KO_KR("ko-KR"),
     AR_SA("ar-SA"),
+    AR_EG("ar-EG"),
+    AR_AE("ar-AE"),
+    AR_MA("ar-MA"),
     HE_IL("he-IL"),
     FA_IR("fa-IR"),
 }


### PR DESCRIPTION
## Why

The voice-locale picker only offered **Arabic (Saudi Arabia)**, so a user
in Cairo, Dubai, or Casablanca who picked the only Arabic option got their
morning briefing labelled as Saudi Arabic. Add three more variants — `ar-EG`,
`ar-AE`, `ar-MA` — covering the largest TTS-supported Arab country accents.

## What changed

- `VoiceLocale` enum: `AR_EG`, `AR_AE`, `AR_MA` (BCP-47 `ar-EG` / `ar-AE` /
  `ar-MA`).
- `voiceLocaleLabel` in `VoiceSettings.kt`: three new branches mapping to
  the new string resources.
- String resources: English defaults plus the ten "full coverage" locales
  that already translate `ar_sa` (de, es, fr, hr, it, ja, ko, pt-BR, ru,
  zh-rCN), and native Arabic names in `values-ar`. Locales that fall
  through `ar_sa` to English fall through the new entries the same way.

## Where the variants actually differ today

After the [Copilot review pointed this out](https://github.com/mikelward/clothescast/pull/215#pullrequestreview-4192926127), the honest picture per engine:

- **Device TTS** — meaningfully differentiates. Android's installed-voice
  catalogue has separate ar-EG / ar-SA / etc. voices on devices that have
  them; the locale flows straight through to `TextToSpeech.setLanguage`.
- **Gemini** — does *not* currently differentiate by country for Arabic.
  `GeminiTtsClient.ACCENT_DIRECTIVES` has only a language-only `"ar"`
  entry (intentional — the comment there says "Language-only entries cover
  all regional Arabic/Persian variants"), so all four Arabic variants share
  one directive. Adding country-specific Arabic directives is a real
  follow-up but a substantive tone/translation decision (modulate accent
  on MSA vs. code-switch to colloquial) and out of scope for this PR.
- **OpenAI** — does *not* differentiate. `OpenAITtsSpeaker.speak` drops
  locale by design ("OpenAI's accent is purely voice-bound"); accent flows
  through `TtsVoices.filterByVariant`. The catalogue currently has zero
  Arabic voices tagged, so even the existing AR_SA falls through to the
  unfiltered list — same for the new variants.
- **ElevenLabs** — same story as OpenAI.

So the user-visible effect of this PR today is: **(a) the picker offers
four Arabic options instead of one**, and **(b) device-TTS users in Egypt
/ UAE / Morocco can now pick a voice that matches their accent** when
their installed voice catalogue contains one. Cloud-engine users see no
audible change vs. AR_SA until the follow-ups land.

## Scope notes

- **Voice only, not Region.** Modern Standard Arabic — what `values-ar`
  already ships — is the universal written register, so adding regional
  text variants would be redundant. This PR is voice-only.
- **Privacy.** No new data crosses the device boundary. The variants only
  affect which voice gets picked locally; the prompt sent to cloud TTS
  engines is unchanged byte-for-byte (the Gemini directive is the same
  `"ar"` for all four variants).
- **Persistence safety.** `SettingsRepository` reads via
  `VoiceLocale.valueOf(...)` with a `SYSTEM` fallback, so existing installs
  are unaffected and the new entries deserialise once a user picks them.
- **Picker order.** The voice picker collator-sorts by display label, so
  the new entries land in the right alphabetical slot for whichever UI
  language is active.

## Test plan

- [ ] CI: `JVM unit tests` + `Android debug build` green.
- [ ] On device: open Settings → Voice → language picker, confirm the
      four Arabic options appear and sort sensibly under each UI language.
- [ ] Pick `ar-EG` with the device TTS engine on a device that has an
      Egyptian Arabic voice installed — confirm Android picks it.
- [ ] Pick `ar-EG` with Gemini / OpenAI / ElevenLabs — *no audible change
      from AR_SA expected* (per the engine table above); just confirm no
      regression.

I can't run `:app:assembleDebug` or `:app:testDebugUnitTest` locally
(Android SDK / Google Maven not reachable in the sandbox), so CI is the
build-validation surface.

## Follow-ups (not in this PR)

- Country-specific Arabic entries in Gemini's `ACCENT_DIRECTIVES`.
- Curated Arabic voice IDs in `TtsVoices.kt` for OpenAI / ElevenLabs (need
  to verify against the providers' live voice catalogues per the project's
  "don't guess from web search" rule).