### PR TITLE
:app — retry instead of fail on transient device-location read failures (PR #216 review)

### DIFF
--- a/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
@@ -20,6 +20,8 @@ import app.clothescast.core.domain.model.Location
 import app.clothescast.core.domain.model.TtsEngine
 import app.clothescast.core.domain.model.UserPreferences
 import app.clothescast.insight.InsightFormatter
+import app.clothescast.location.hasBackgroundLocationPermission
+import app.clothescast.location.hasCoarseLocationPermission
 import app.clothescast.tts.ElevenLabsTtsSpeaker
 import app.clothescast.tts.GeminiTtsSpeaker
 import app.clothescast.tts.OpenAITtsSpeaker
@@ -76,12 +78,34 @@ class FetchAndNotifyWorker(
 
         val location = resolveLocation(prefs)
             ?: run {
-                // Either useDeviceLocation is on but the worker can't read it
-                // (background grant missing / providers disabled / timeout) and
-                // there's no saved fallback, or both inputs are blank. Fail
-                // loudly via the failure-reason channel so the Today banner can
-                // prompt the user to act, instead of silently posting a
-                // London-default insight that erodes trust in the outfit advice.
+                // Two distinct null cases land here, and they want different
+                // outcomes:
+                //
+                //   1. Misconfigured — useDeviceLocation off + no saved
+                //      fallback, OR useDeviceLocation on but the user hasn't
+                //      granted ACCESS_BACKGROUND_LOCATION (Q+) yet. The user
+                //      has to do something; retrying on backoff would just
+                //      hammer the system every 30s with no progress. Fail
+                //      with REASON_NO_LOCATION so the Today banner prompts
+                //      them to grant permission or pick a city.
+                //
+                //   2. Transient — useDeviceLocation on, both permissions
+                //      granted, no saved fallback, but LocationResolver
+                //      returned null this time (NETWORK provider down,
+                //      timeout, momentary signal flake). A later attempt is
+                //      likely to succeed, so let WorkManager retry with
+                //      exponential backoff rather than burning the period's
+                //      forecast. Without a saved fallback this would
+                //      otherwise be the only path; with one, resolveLocation
+                //      would have used it and we wouldn't be in this branch.
+                val transientDeviceFailure = prefs.useDeviceLocation &&
+                    prefs.location == null &&
+                    hasCoarseLocationPermission(applicationContext) &&
+                    hasBackgroundLocationPermission(applicationContext)
+                if (transientDeviceFailure) {
+                    DiagLog.w(TAG, "Device location read failed transiently; retrying.")
+                    return Result.retry()
+                }
                 DiagLog.w(TAG, "No location available; failing run.")
                 return Result.failure(reason(REASON_NO_LOCATION))
             }

--- a/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
@@ -1,7 +1,9 @@
 package app.clothescast.work
 
 import android.content.Context
+import android.location.LocationManager
 import app.clothescast.diag.DiagLog
+import androidx.core.content.getSystemService
 import androidx.work.BackoffPolicy
 import androidx.work.Constraints
 import androidx.work.CoroutineWorker
@@ -90,18 +92,25 @@ class FetchAndNotifyWorker(
                 //      them to grant permission or pick a city.
                 //
                 //   2. Transient — useDeviceLocation on, both permissions
-                //      granted, no saved fallback, but LocationResolver
-                //      returned null this time (NETWORK provider down,
-                //      timeout, momentary signal flake). A later attempt is
-                //      likely to succeed, so let WorkManager retry with
+                //      granted, location services enabled system-wide, no
+                //      saved fallback, but LocationResolver returned null
+                //      this time (NETWORK provider returned null, timeout,
+                //      momentary signal flake). A later attempt is likely
+                //      to succeed, so let WorkManager retry with
                 //      exponential backoff rather than burning the period's
                 //      forecast. Without a saved fallback this would
                 //      otherwise be the only path; with one, resolveLocation
                 //      would have used it and we wouldn't be in this branch.
+                //
+                // The provider-enabled check is what separates "Location
+                // services flipped off in system Settings" (user-actionable
+                // misconfig — would retry forever otherwise) from the
+                // genuinely-transient cases above.
                 val transientDeviceFailure = prefs.useDeviceLocation &&
                     prefs.location == null &&
                     hasCoarseLocationPermission(applicationContext) &&
-                    hasBackgroundLocationPermission(applicationContext)
+                    hasBackgroundLocationPermission(applicationContext) &&
+                    isLocationServicesEnabled(applicationContext)
                 if (transientDeviceFailure) {
                     DiagLog.w(TAG, "Device location read failed transiently; retrying.")
                     return Result.retry()
@@ -250,6 +259,21 @@ class FetchAndNotifyWorker(
             DiagLog.i(TAG, "Device location unavailable; falling back to settings location.")
         }
         return prefs.location
+    }
+
+    // Mirrors the providers LocationResolver itself queries — NETWORK +
+    // PASSIVE only (no GPS hardware fix). When both are off system-wide the
+    // user has flipped Location services off in Settings; our retry path
+    // would then loop indefinitely with no chance of progress, so callers
+    // treat that as misconfiguration and fail visibly instead.
+    private fun isLocationServicesEnabled(context: Context): Boolean {
+        val manager = context.getSystemService<LocationManager>() ?: return false
+        return try {
+            manager.isProviderEnabled(LocationManager.NETWORK_PROVIDER) ||
+                manager.isProviderEnabled(LocationManager.PASSIVE_PROVIDER)
+        } catch (_: Throwable) {
+            false
+        }
     }
 
     private suspend fun deliver(insight: Insight, prefs: UserPreferences, prose: String) {


### PR DESCRIPTION
## Summary

Follow-up to #216. Codex's [P2 review](https://github.com/mikelward/clothescast/pull/216#discussion_r3157732063) flagged that the new `Result.failure(REASON_NO_LOCATION)` path covers two distinct null-from-`resolveLocation()` cases, but only one of them should fail:

1. **Misconfigured** — `useDeviceLocation` off + no saved fallback, OR `useDeviceLocation` on but the user hasn't granted `ACCESS_BACKGROUND_LOCATION` (Q+). The user has to act; retrying on backoff just burns 30s every wake-up with zero chance of progress. Keeps `Result.failure(REASON_NO_LOCATION)` so the Today banner from #216 prompts them.

2. **Transient** — `useDeviceLocation` on, both permissions granted, no saved fallback, but `LocationResolver` returned null this run (NETWORK provider momentarily disabled, single-update timeout, signal flake). A later attempt is likely to succeed; without retry, a flaky `NETWORK_PROVIDER` read permanently kills that period's forecast for users on device-location-only.

Distinguish at the call site after the null using the permission helpers added in #216 — if `prefs.useDeviceLocation && prefs.location == null && hasCoarseLocationPermission(...) && hasBackgroundLocationPermission(...)` the null must be a runtime read failure → `Result.retry()`. Otherwise keep `Result.failure(REASON_NO_LOCATION)`.

The case where the user has *both* device-location and a saved fallback isn't reachable from this branch — `resolveLocation()` would have returned the fallback and we wouldn't be in the null path at all.

## Privacy

No change to what leaves the device.

## Test plan

- [ ] CI: `JVM unit tests` and `Android debug build` pass.
- [ ] Manual: device with `useDeviceLocation=true`, both perms granted, no fallback, in airplane mode (or a known-bad location reading) — verify worker reports `WorkInfo.State.ENQUEUED` for the retry rather than terminal `FAILED`.
- [ ] Manual: same device, revoke background permission via system Settings — verify worker hits `Result.failure(REASON_NO_LOCATION)` and the Today action banner shows.

https://claude.ai/code/session_01SDLNvwoNGp5m8Mm6qXoMvX

---
_Generated by [Claude Code](https://claude.ai/code/session_01SDLNvwoNGp5m8Mm6qXoMvX)_