### PR TITLE
:app + :core — refresh ElevenLabs voices from the user's account

### DIFF
--- a/app/src/main/kotlin/app/clothescast/MainActivity.kt
+++ b/app/src/main/kotlin/app/clothescast/MainActivity.kt
@@ -115,6 +115,12 @@ private fun ClothesCastNav(app: ClothesCastApplication) {
                     cancelAlarm = app.dailyAlarmScheduler::cancel,
                     geocodingClient = app.geocodingClient,
                     voiceEnumerator = app.androidTtsVoiceEnumerator,
+                    elevenLabsTtsClient = app.elevenLabsTtsClient,
+                    showError = { message ->
+                        android.widget.Toast
+                            .makeText(context, message, android.widget.Toast.LENGTH_LONG)
+                            .show()
+                    },
                 ),
             )
             SettingsScreen(

--- a/app/src/main/kotlin/app/clothescast/data/SettingsRepository.kt
+++ b/app/src/main/kotlin/app/clothescast/data/SettingsRepository.kt
@@ -138,6 +138,20 @@ class SettingsRepository(
         dataStore.edit { it[ELEVENLABS_VOICE] = voice }
     }
 
+    suspend fun setElevenLabsModel(model: String) {
+        dataStore.edit { it[ELEVENLABS_MODEL] = model }
+    }
+
+    suspend fun setElevenLabsSpeed(speed: Double) {
+        // Clamp to ElevenLabs's documented range so a misconfigured caller
+        // can't push an out-of-range value into DataStore.
+        val clamped = speed.coerceIn(
+            UserPreferences.MIN_ELEVENLABS_SPEED,
+            UserPreferences.MAX_ELEVENLABS_SPEED,
+        )
+        dataStore.edit { it[ELEVENLABS_SPEED] = clamped }
+    }
+
     suspend fun setDeviceVoice(voice: String?) {
         dataStore.edit {
             // Null clears the pin → speaker reverts to auto-pick; the worker
@@ -193,6 +207,12 @@ class SettingsRepository(
             ?: defaultOpenAiVoiceFor(voiceLocale)
         val elevenLabsVoice = this[ELEVENLABS_VOICE]?.takeIf { it.isNotBlank() }
             ?: UserPreferences.DEFAULT_ELEVENLABS_VOICE
+        val elevenLabsModel = this[ELEVENLABS_MODEL]?.takeIf { it.isNotBlank() }
+            ?: UserPreferences.DEFAULT_ELEVENLABS_MODEL
+        val elevenLabsSpeed = this[ELEVENLABS_SPEED]?.coerceIn(
+            UserPreferences.MIN_ELEVENLABS_SPEED,
+            UserPreferences.MAX_ELEVENLABS_SPEED,
+        ) ?: UserPreferences.DEFAULT_ELEVENLABS_SPEED
         val deviceVoice = this[DEVICE_VOICE]?.takeIf { it.isNotBlank() }
         val useCalendarEvents = this[USE_CALENDAR_EVENTS] == true
         val tonightTime = this[TONIGHT_TIME]?.let { LocalTime.parse(it, TIME_FORMAT) }
@@ -222,6 +242,8 @@ class SettingsRepository(
             geminiVoice = geminiVoice,
             openAiVoice = openAiVoice,
             elevenLabsVoice = elevenLabsVoice,
+            elevenLabsModel = elevenLabsModel,
+            elevenLabsSpeed = elevenLabsSpeed,
             deviceVoice = deviceVoice,
             voiceLocale = voiceLocale,
             useCalendarEvents = useCalendarEvents,
@@ -274,6 +296,8 @@ class SettingsRepository(
         private val GEMINI_VOICE = stringPreferencesKey("gemini_voice")
         private val OPENAI_VOICE = stringPreferencesKey("openai_voice")
         private val ELEVENLABS_VOICE = stringPreferencesKey("elevenlabs_voice")
+        private val ELEVENLABS_MODEL = stringPreferencesKey("elevenlabs_model")
+        private val ELEVENLABS_SPEED = doublePreferencesKey("elevenlabs_speed")
         private val DEVICE_VOICE = stringPreferencesKey("device_voice")
         private val VOICE_LOCALE = stringPreferencesKey("voice_locale")
         private val USE_CALENDAR_EVENTS = booleanPreferencesKey("use_calendar_events")

--- a/app/src/main/kotlin/app/clothescast/tts/ElevenLabsTtsSpeaker.kt
+++ b/app/src/main/kotlin/app/clothescast/tts/ElevenLabsTtsSpeaker.kt
@@ -1,5 +1,7 @@
 package app.clothescast.tts
 
+import app.clothescast.core.data.tts.DEFAULT_ELEVENLABS_TTS_MODEL
+import app.clothescast.core.data.tts.DEFAULT_ELEVENLABS_TTS_SPEED
 import app.clothescast.core.data.tts.DEFAULT_ELEVENLABS_TTS_VOICE
 import app.clothescast.core.data.tts.ElevenLabsTtsClient
 import java.util.Locale
@@ -10,6 +12,9 @@ import java.util.Locale
  *
  * Voice is an ElevenLabs voice ID (the long opaque identifier from their voice
  * library, e.g. `EXAVITQu4vr4xnSDxMaL` for Sarah); selectable from Settings.
+ * Model and speed are also user-selectable in Settings — defaults match the
+ * client-level defaults so existing callers that don't pass them through
+ * keep their previous behaviour.
  *
  * Fallback is the caller's responsibility — see [app.clothescast.work.FetchAndNotifyWorker]
  * which retries with [AndroidTtsSpeaker] when this throws.
@@ -17,10 +22,17 @@ import java.util.Locale
 class ElevenLabsTtsSpeaker(
     private val client: ElevenLabsTtsClient,
     private val voiceId: String = DEFAULT_ELEVENLABS_TTS_VOICE,
+    private val model: String = DEFAULT_ELEVENLABS_TTS_MODEL,
+    private val speed: Double = DEFAULT_ELEVENLABS_TTS_SPEED,
 ) : TtsSpeaker {
 
     override suspend fun speak(text: String, locale: Locale) {
-        val audio = client.synthesize(text = prepareForTts(text), voiceId = voiceId)
+        val audio = client.synthesize(
+            text = prepareForTts(text),
+            voiceId = voiceId,
+            model = model,
+            speed = speed,
+        )
         PcmAudioPlayer.play(audio)
     }
 }

--- a/app/src/main/kotlin/app/clothescast/tts/TtsVoices.kt
+++ b/app/src/main/kotlin/app/clothescast/tts/TtsVoices.kt
@@ -1,5 +1,6 @@
 package app.clothescast.tts
 
+import app.clothescast.core.data.tts.ElevenLabsVoiceSummary
 import app.clothescast.core.domain.model.VoiceLocale
 
 /**
@@ -113,3 +114,26 @@ val ELEVENLABS_VOICES: List<TtsVoiceOption> = listOf(
     TtsVoiceOption("TxGEqnHWrfWFTfGW9XjX", "Josh — Young, male", VoiceLocale.EN_US),
     TtsVoiceOption("VR6AewLTigWG4xSOukaG", "Arnold — Crisp, male", VoiceLocale.EN_US),
 )
+
+/**
+ * Adapts a list of [ElevenLabsVoiceSummary] (the wire-side projection from
+ * `GET /v1/voices`) into the picker's [TtsVoiceOption] type.
+ *
+ * The display name is `name` plus an optional " — description" tail when the
+ * voice has a description label, matching the curated [ELEVENLABS_VOICES]
+ * formatting. We deliberately leave [TtsVoiceOption.locale] null on every
+ * refreshed entry rather than trying to map ElevenLabs's free-form `accent`
+ * label ("american", "british", "australian", "transatlantic", custom user
+ * strings, …) to [VoiceLocale]: the user explicitly hit "Refresh", so they
+ * want to see what their key has access to without the locale filter
+ * dropping non-matching accents. Cloned voices in particular often have no
+ * accent label at all.
+ */
+fun List<ElevenLabsVoiceSummary>.toVoiceOptions(): List<TtsVoiceOption> = map { summary ->
+    val displayName = if (summary.description.isNullOrBlank()) {
+        summary.name
+    } else {
+        "${summary.name} — ${summary.description}"
+    }
+    TtsVoiceOption(id = summary.id, displayName = displayName, locale = null)
+}

--- a/app/src/main/kotlin/app/clothescast/tts/TtsVoices.kt
+++ b/app/src/main/kotlin/app/clothescast/tts/TtsVoices.kt
@@ -119,21 +119,31 @@ val ELEVENLABS_VOICES: List<TtsVoiceOption> = listOf(
  * Adapts a list of [ElevenLabsVoiceSummary] (the wire-side projection from
  * `GET /v1/voices`) into the picker's [TtsVoiceOption] type.
  *
- * The display name is `name` plus an optional " — description" tail when the
- * voice has a description label, matching the curated [ELEVENLABS_VOICES]
- * formatting. We deliberately leave [TtsVoiceOption.locale] null on every
- * refreshed entry rather than trying to map ElevenLabs's free-form `accent`
- * label ("american", "british", "australian", "transatlantic", custom user
+ * Display-name shape mirrors the curated [ELEVENLABS_VOICES] format and
+ * folds in whatever metadata the API returned, so users with similarly-
+ * named voices (e.g. several clones called "Mike") can still tell them
+ * apart in the picker:
+ *
+ *  - both description and accent: `"Sarah — warm (american)"`
+ *  - description only:            `"Sarah — warm"`
+ *  - accent only:                 `"Sarah (american)"`
+ *  - neither (typical clone):     `"Sarah"`
+ *
+ * We deliberately leave [TtsVoiceOption.locale] null on every refreshed
+ * entry rather than trying to map ElevenLabs's free-form `accent` label
+ * ("american", "british", "australian", "transatlantic", custom user
  * strings, …) to [VoiceLocale]: the user explicitly hit "Refresh", so they
  * want to see what their key has access to without the locale filter
  * dropping non-matching accents. Cloned voices in particular often have no
  * accent label at all.
  */
 fun List<ElevenLabsVoiceSummary>.toVoiceOptions(): List<TtsVoiceOption> = map { summary ->
-    val displayName = if (summary.description.isNullOrBlank()) {
-        summary.name
-    } else {
-        "${summary.name} — ${summary.description}"
+    val description = summary.description?.takeIf { it.isNotBlank() }
+    val accent = summary.accent?.takeIf { it.isNotBlank() }
+    val displayName = buildString {
+        append(summary.name)
+        if (description != null) append(" — ").append(description)
+        if (accent != null) append(" (").append(accent).append(')')
     }
     TtsVoiceOption(id = summary.id, displayName = displayName, locale = null)
 }

--- a/app/src/main/kotlin/app/clothescast/tts/TtsVoices.kt
+++ b/app/src/main/kotlin/app/clothescast/tts/TtsVoices.kt
@@ -129,13 +129,12 @@ val ELEVENLABS_VOICES: List<TtsVoiceOption> = listOf(
  *  - accent only:                 `"Sarah (american)"`
  *  - neither (typical clone):     `"Sarah"`
  *
- * We deliberately leave [TtsVoiceOption.locale] null on every refreshed
- * entry rather than trying to map ElevenLabs's free-form `accent` label
- * ("american", "british", "australian", "transatlantic", custom user
- * strings, …) to [VoiceLocale]: the user explicitly hit "Refresh", so they
- * want to see what their key has access to without the locale filter
- * dropping non-matching accents. Cloned voices in particular often have no
- * accent label at all.
+ * The voice's [TtsVoiceOption.locale] is best-effort mapped from the
+ * ElevenLabs `accent` label (see [parseElevenLabsAccent]) so the picker's
+ * locale filter narrows the refreshed list the same way it narrows the
+ * curated one. Unrecognised or missing accent labels map to `null`,
+ * which the filter treats as accent-agnostic — better to show a voice
+ * than to hide it because we couldn't classify the accent string.
  */
 fun List<ElevenLabsVoiceSummary>.toVoiceOptions(): List<TtsVoiceOption> = map { summary ->
     val description = summary.description?.takeIf { it.isNotBlank() }
@@ -145,5 +144,73 @@ fun List<ElevenLabsVoiceSummary>.toVoiceOptions(): List<TtsVoiceOption> = map { 
         if (description != null) append(" — ").append(description)
         if (accent != null) append(" (").append(accent).append(')')
     }
-    TtsVoiceOption(id = summary.id, displayName = displayName, locale = null)
+    TtsVoiceOption(
+        id = summary.id,
+        displayName = displayName,
+        locale = parseElevenLabsAccent(accent),
+    )
 }
+
+/**
+ * Maps ElevenLabs's free-form `accent` label onto a [VoiceLocale] when we
+ * can do so unambiguously. Returns `null` for anything we don't recognise
+ * — including ambiguous labels like "transatlantic" and labels that
+ * straddle multiple `VoiceLocale` values ("irish", "scottish") — so the
+ * locale filter doesn't drop those voices wrongly.
+ *
+ * The label is lowercased and trimmed before lookup; ElevenLabs uses
+ * lowercase by convention but custom voices can use anything.
+ *
+ * Kept conservative on purpose: false positives are worse than false
+ * negatives here. A US user filtering to en-US who sees an extra
+ * "transatlantic" voice can ignore it; one whose only good clone is
+ * silently filtered out can't recover without flipping the picker
+ * back to "Follow phone language".
+ */
+private fun parseElevenLabsAccent(label: String?): VoiceLocale? {
+    // Locale.ROOT avoids the Turkish-locale gotcha where lowercasing "I"
+    // yields "ı" rather than "i", which would silently break the lookup
+    // for any user whose phone is set to tr-TR.
+    val key = label?.trim()?.lowercase(java.util.Locale.ROOT) ?: return null
+    return ACCENT_TO_VOICE_LOCALE[key]
+}
+
+private val ACCENT_TO_VOICE_LOCALE: Map<String, VoiceLocale> = mapOf(
+    // English variants — the ones ElevenLabs ships in the premade library.
+    "american" to VoiceLocale.EN_US,
+    "us english" to VoiceLocale.EN_US,
+    "british" to VoiceLocale.EN_GB,
+    "english" to VoiceLocale.EN_GB,
+    "british english" to VoiceLocale.EN_GB,
+    "australian" to VoiceLocale.EN_AU,
+    "canadian" to VoiceLocale.EN_CA,
+    "south african" to VoiceLocale.EN_ZA,
+    // Other locales we expose in the picker. Map the language name to the
+    // single VoiceLocale we have for it; users on the regional variants
+    // (es-MX, ar-EG, …) rely on the empty-filter fallback to still see
+    // these voices.
+    "german" to VoiceLocale.DE_DE,
+    "french" to VoiceLocale.FR_FR,
+    "italian" to VoiceLocale.IT_IT,
+    "spanish" to VoiceLocale.ES_ES,
+    "portuguese" to VoiceLocale.PT_BR,
+    "brazilian" to VoiceLocale.PT_BR,
+    "russian" to VoiceLocale.RU_RU,
+    "polish" to VoiceLocale.PL_PL,
+    "croatian" to VoiceLocale.HR_HR,
+    "ukrainian" to VoiceLocale.UK_UA,
+    "dutch" to VoiceLocale.NL_NL,
+    "swedish" to VoiceLocale.SV_SE,
+    "turkish" to VoiceLocale.TR_TR,
+    "indonesian" to VoiceLocale.ID_ID,
+    "filipino" to VoiceLocale.FIL_PH,
+    "vietnamese" to VoiceLocale.VI_VN,
+    "chinese" to VoiceLocale.ZH_CN,
+    "hindi" to VoiceLocale.HI_IN,
+    "bengali" to VoiceLocale.BN_BD,
+    "japanese" to VoiceLocale.JA_JP,
+    "korean" to VoiceLocale.KO_KR,
+    "arabic" to VoiceLocale.AR_SA,
+    "hebrew" to VoiceLocale.HE_IL,
+    "persian" to VoiceLocale.FA_IR,
+)

--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsScreen.kt
@@ -148,6 +148,8 @@ fun SettingsScreen(
                 elevenLabsKeyConfigured = state.elevenLabsKeyConfigured,
                 elevenLabsRefreshedVoices = state.elevenLabsRefreshedVoices,
                 elevenLabsRefreshing = state.elevenLabsRefreshing,
+                elevenLabsModel = state.elevenLabsModel,
+                elevenLabsSpeed = state.elevenLabsSpeed,
                 voiceLocale = state.voiceLocale,
                 padding = padding,
                 onSetTtsEngine = viewModel::setTtsEngine,
@@ -163,6 +165,8 @@ fun SettingsScreen(
                 onSetElevenLabsKey = viewModel::setElevenLabsKey,
                 onClearElevenLabsKey = viewModel::clearElevenLabsKey,
                 onRefreshElevenLabsVoices = viewModel::refreshElevenLabsVoices,
+                onSetElevenLabsModel = viewModel::setElevenLabsModel,
+                onSetElevenLabsSpeed = viewModel::setElevenLabsSpeed,
             )
             SettingsRoute.DataSources -> DataSourcesContent(
                 location = state.location,

--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsScreen.kt
@@ -146,6 +146,8 @@ fun SettingsScreen(
                 geminiKeyConfigured = state.apiKeyConfigured,
                 openAiKeyConfigured = state.openAiKeyConfigured,
                 elevenLabsKeyConfigured = state.elevenLabsKeyConfigured,
+                elevenLabsRefreshedVoices = state.elevenLabsRefreshedVoices,
+                elevenLabsRefreshing = state.elevenLabsRefreshing,
                 voiceLocale = state.voiceLocale,
                 padding = padding,
                 onSetTtsEngine = viewModel::setTtsEngine,
@@ -160,6 +162,7 @@ fun SettingsScreen(
                 onClearOpenAiKey = viewModel::clearOpenAiKey,
                 onSetElevenLabsKey = viewModel::setElevenLabsKey,
                 onClearElevenLabsKey = viewModel::clearElevenLabsKey,
+                onRefreshElevenLabsVoices = viewModel::refreshElevenLabsVoices,
             )
             SettingsRoute.DataSources -> DataSourcesContent(
                 location = state.location,

--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsState.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsState.kt
@@ -47,6 +47,8 @@ data class SettingsState(
     // current locale → fable on en-GB, nova everywhere else.
     val openAiVoice: String = defaultOpenAiVoiceFor(VoiceLocale.SYSTEM),
     val elevenLabsVoice: String = UserPreferences.DEFAULT_ELEVENLABS_VOICE,
+    val elevenLabsModel: String = UserPreferences.DEFAULT_ELEVENLABS_MODEL,
+    val elevenLabsSpeed: Double = UserPreferences.DEFAULT_ELEVENLABS_SPEED,
     /**
      * On-device voice ID the user has pinned, or `null` for "auto-pick the
      * highest-quality voice for [voiceLocale]" (the default for installs

--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsState.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsState.kt
@@ -13,6 +13,7 @@ import app.clothescast.core.domain.model.VoiceLocale
 import app.clothescast.data.defaultDistanceUnitFor
 import app.clothescast.data.defaultTemperatureUnitFor
 import app.clothescast.tts.DeviceVoice
+import app.clothescast.tts.TtsVoiceOption
 import app.clothescast.tts.defaultOpenAiVoiceFor
 import java.time.DayOfWeek
 import java.time.LocalTime
@@ -75,4 +76,14 @@ data class SettingsState(
     val apiKeyConfigured: Boolean = false,
     val openAiKeyConfigured: Boolean = false,
     val elevenLabsKeyConfigured: Boolean = false,
+    /**
+     * Voices fetched from `GET /v1/voices` after the user taps Refresh in
+     * Settings. `null` means "no refresh has happened this session" — the
+     * picker falls back to the curated [app.clothescast.tts.ELEVENLABS_VOICES]
+     * list. An empty list means the API returned no voices (exotic
+     * account state) and is rendered the same way as the fallback so the
+     * picker is never empty.
+     */
+    val elevenLabsRefreshedVoices: List<TtsVoiceOption>? = null,
+    val elevenLabsRefreshing: Boolean = false,
 )

--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsViewModel.kt
@@ -84,6 +84,8 @@ class SettingsViewModel(
                         geminiVoice = prefs.geminiVoice,
                         openAiVoice = prefs.openAiVoice,
                         elevenLabsVoice = prefs.elevenLabsVoice,
+                        elevenLabsModel = prefs.elevenLabsModel,
+                        elevenLabsSpeed = prefs.elevenLabsSpeed,
                         deviceVoice = prefs.deviceVoice,
                         voiceLocale = prefs.voiceLocale,
                         useCalendarEvents = prefs.useCalendarEvents,
@@ -189,6 +191,14 @@ class SettingsViewModel(
 
     fun setElevenLabsVoice(voice: String) {
         viewModelScope.launch { settingsRepository.setElevenLabsVoice(voice) }
+    }
+
+    fun setElevenLabsModel(model: String) {
+        viewModelScope.launch { settingsRepository.setElevenLabsModel(model) }
+    }
+
+    fun setElevenLabsSpeed(speed: Double) {
+        viewModelScope.launch { settingsRepository.setElevenLabsSpeed(speed) }
     }
 
     /**

--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import app.clothescast.core.data.location.OpenMeteoGeocodingClient
+import app.clothescast.core.data.tts.ElevenLabsTtsClient
 import app.clothescast.core.domain.model.ClothesRule
 import app.clothescast.core.domain.model.DeliveryMode
 import app.clothescast.core.domain.model.DistanceUnit
@@ -16,8 +17,10 @@ import app.clothescast.core.domain.model.TtsEngine
 import app.clothescast.core.domain.model.VoiceLocale
 import app.clothescast.data.SecureKeyStore
 import app.clothescast.data.SettingsRepository
+import app.clothescast.diag.DiagLog
 import app.clothescast.tts.TtsVoiceEnumerator
 import app.clothescast.tts.resolve
+import app.clothescast.tts.toVoiceOptions
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -37,6 +40,13 @@ class SettingsViewModel(
     private val cancelAlarm: (ForecastPeriod) -> Unit,
     private val geocodingClient: OpenMeteoGeocodingClient,
     private val voiceEnumerator: TtsVoiceEnumerator,
+    private val elevenLabsTtsClient: ElevenLabsTtsClient? = null,
+    /**
+     * Surfaces refresh failures to the user. Defaulted to a no-op so existing
+     * tests that don't exercise refresh don't have to wire it up; the
+     * Activity passes a Toast-backed implementation.
+     */
+    private val showError: (String) -> Unit = {},
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(SettingsState())
@@ -179,6 +189,39 @@ class SettingsViewModel(
 
     fun setElevenLabsVoice(voice: String) {
         viewModelScope.launch { settingsRepository.setElevenLabsVoice(voice) }
+    }
+
+    /**
+     * Hits `GET /v1/voices` with the stored ElevenLabs key and replaces the
+     * picker's voice list with whatever the user's account exposes —
+     * premade library plus their own clones / generated voices. No-ops if
+     * the key isn't configured (the UI also gates the button) or if the
+     * client wasn't injected (test wiring).
+     *
+     * Failures surface through [showError] (the Activity wires a Toast)
+     * and leave the picker on whatever list it was already showing — we
+     * don't wipe a previous successful refresh because the network blipped.
+     */
+    fun refreshElevenLabsVoices() {
+        val client = elevenLabsTtsClient ?: return
+        if (_state.value.elevenLabsRefreshing) return
+        viewModelScope.launch {
+            _state.update { it.copy(elevenLabsRefreshing = true) }
+            try {
+                val voices = withContext(Dispatchers.IO) { client.listVoices() }
+                _state.update {
+                    it.copy(
+                        elevenLabsRefreshedVoices = voices.toVoiceOptions(),
+                        elevenLabsRefreshing = false,
+                    )
+                }
+            } catch (t: Throwable) {
+                DiagLog.w(TAG, "ElevenLabs voice refresh failed", t)
+                _state.update { it.copy(elevenLabsRefreshing = false) }
+                val message = t.message?.takeIf { it.isNotBlank() } ?: t.javaClass.simpleName
+                showError(message)
+            }
+        }
     }
 
     fun setDeviceVoice(voice: String?) {
@@ -326,6 +369,8 @@ class SettingsViewModel(
         private val cancelAlarm: (ForecastPeriod) -> Unit,
         private val geocodingClient: OpenMeteoGeocodingClient,
         private val voiceEnumerator: TtsVoiceEnumerator,
+        private val elevenLabsTtsClient: ElevenLabsTtsClient,
+        private val showError: (String) -> Unit,
     ) : ViewModelProvider.Factory {
         @Suppress("UNCHECKED_CAST")
         override fun <T : ViewModel> create(modelClass: Class<T>): T {
@@ -339,7 +384,13 @@ class SettingsViewModel(
                 cancelAlarm,
                 geocodingClient,
                 voiceEnumerator,
+                elevenLabsTtsClient,
+                showError,
             ) as T
         }
+    }
+
+    private companion object {
+        private const val TAG = "SettingsViewModel"
     }
 }

--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsViewModel.kt
@@ -205,31 +205,38 @@ class SettingsViewModel(
      * Hits `GET /v1/voices` with the stored ElevenLabs key and replaces the
      * picker's voice list with whatever the user's account exposes —
      * premade library plus their own clones / generated voices. No-ops if
-     * the key isn't configured (the UI also gates the button) or if the
-     * client wasn't injected (test wiring).
+     * the key isn't configured (the UI also gates the button), if a refresh
+     * is already in flight, or if the client wasn't injected (test wiring).
      *
      * Failures surface through [showError] (the Activity wires a Toast)
      * and leave the picker on whatever list it was already showing — we
      * don't wipe a previous successful refresh because the network blipped.
+     * Coroutine cancellation (ViewModel cleared, navigation away) is *not*
+     * surfaced as a user-visible error — we re-throw so structured
+     * concurrency unwinds cleanly.
      */
     fun refreshElevenLabsVoices() {
         val client = elevenLabsTtsClient ?: return
-        if (_state.value.elevenLabsRefreshing) return
+        val current = _state.value
+        if (!current.elevenLabsKeyConfigured || current.elevenLabsRefreshing) return
         viewModelScope.launch {
             _state.update { it.copy(elevenLabsRefreshing = true) }
             try {
                 val voices = withContext(Dispatchers.IO) { client.listVoices() }
-                _state.update {
-                    it.copy(
-                        elevenLabsRefreshedVoices = voices.toVoiceOptions(),
-                        elevenLabsRefreshing = false,
-                    )
-                }
+                _state.update { it.copy(elevenLabsRefreshedVoices = voices.toVoiceOptions()) }
             } catch (t: Throwable) {
+                // Cancellation is a normal lifecycle signal (navigation
+                // away, ViewModel cleared) — re-throwing lets the
+                // coroutine machinery unwind without flashing a Toast at
+                // the user.
+                if (t is kotlinx.coroutines.CancellationException) throw t
                 DiagLog.w(TAG, "ElevenLabs voice refresh failed", t)
-                _state.update { it.copy(elevenLabsRefreshing = false) }
                 val message = t.message?.takeIf { it.isNotBlank() } ?: t.javaClass.simpleName
                 showError(message)
+            } finally {
+                // `finally` rather than per-branch updates so the spinner
+                // always clears, including on cancellation.
+                _state.update { it.copy(elevenLabsRefreshing = false) }
             }
         }
     }

--- a/app/src/main/kotlin/app/clothescast/ui/settings/VoiceSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/VoiceSettings.kt
@@ -16,6 +16,7 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Slider
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -43,6 +44,11 @@ import app.clothescast.core.domain.model.TemperatureBand
 import app.clothescast.core.domain.model.TtsEngine
 import app.clothescast.core.domain.model.VoiceLocale
 import app.clothescast.insight.InsightFormatter
+import app.clothescast.core.data.tts.ELEVENLABS_MODEL_FLASH_V2_5
+import app.clothescast.core.data.tts.ELEVENLABS_MODEL_MULTILINGUAL_V2
+import app.clothescast.core.data.tts.ELEVENLABS_MODEL_TURBO_V2_5
+import app.clothescast.core.data.tts.ELEVENLABS_MODEL_V3
+import app.clothescast.core.domain.model.UserPreferences
 import app.clothescast.tts.DeviceVoice
 import app.clothescast.tts.ELEVENLABS_VOICES
 import app.clothescast.tts.ElevenLabsTtsSpeaker
@@ -76,6 +82,8 @@ internal fun VoiceContent(
     elevenLabsKeyConfigured: Boolean,
     elevenLabsRefreshedVoices: List<TtsVoiceOption>?,
     elevenLabsRefreshing: Boolean,
+    elevenLabsModel: String,
+    elevenLabsSpeed: Double,
     voiceLocale: VoiceLocale,
     padding: PaddingValues,
     onSetTtsEngine: (TtsEngine) -> Unit,
@@ -91,6 +99,8 @@ internal fun VoiceContent(
     onSetElevenLabsKey: (String) -> Unit,
     onClearElevenLabsKey: () -> Unit,
     onRefreshElevenLabsVoices: () -> Unit,
+    onSetElevenLabsModel: (String) -> Unit,
+    onSetElevenLabsSpeed: (Double) -> Unit,
 ) {
     val context = LocalContext.current
     val coroutineScope = rememberCoroutineScope()
@@ -108,7 +118,20 @@ internal fun VoiceContent(
         isPreviewing = true
         coroutineScope.launch {
             try {
-                runTtsPreview(context, engine, gVoice, oVoice, eVoice, dVoice, locale)
+                // ElevenLabs model + speed are read off the latest props on
+                // every preview (rather than threaded through every caller)
+                // because they only matter for the one engine.
+                runTtsPreview(
+                    context = context,
+                    engine = engine,
+                    geminiVoice = gVoice,
+                    openAiVoice = oVoice,
+                    elevenLabsVoice = eVoice,
+                    elevenLabsModel = elevenLabsModel,
+                    elevenLabsSpeed = elevenLabsSpeed,
+                    deviceVoice = dVoice,
+                    voiceLocale = locale,
+                )
             } finally {
                 isPreviewing = false
             }
@@ -279,6 +302,28 @@ internal fun VoiceContent(
                             }
                         }
                     }
+                    ElevenLabsModelPicker(
+                        selected = elevenLabsModel,
+                        enabled = !isPreviewing,
+                        onSelect = {
+                            onSetElevenLabsModel(it)
+                            preview(TtsEngine.ELEVENLABS, geminiVoice, openAiVoice, elevenLabsVoice, deviceVoice, voiceLocale)
+                        },
+                    )
+                    ElevenLabsSpeedSlider(
+                        value = elevenLabsSpeed,
+                        enabled = !isPreviewing,
+                        onValueChange = onSetElevenLabsSpeed,
+                        // Preview only on slider release — every drag tick
+                        // would fire a billed synthesis call and stack
+                        // playback. The picker's "lock-while-previewing"
+                        // gate gives us release semantics for free: once
+                        // the user lifts and we trigger preview, further
+                        // drags are ignored until it finishes.
+                        onValueChangeFinished = {
+                            preview(TtsEngine.ELEVENLABS, geminiVoice, openAiVoice, elevenLabsVoice, deviceVoice, voiceLocale)
+                        },
+                    )
                     TestVoiceButton(isPreviewing = isPreviewing) {
                         preview(selected, geminiVoice, openAiVoice, elevenLabsVoice, deviceVoice, voiceLocale)
                     }
@@ -503,6 +548,79 @@ private fun DeviceVoicePicker(
 private const val DEVICE_VOICE_AUTO_ID = "__auto__"
 
 /**
+ * Radio list for the four ElevenLabs models we expose: Turbo v2.5 (default,
+ * balanced), Multilingual v2 (legacy flagship — 2× the credit cost), Flash
+ * v2.5 (lowest latency), and v3 (alpha). Kept as a small fixed list rather
+ * than a `GET /v1/models` fetch — the cost / latency trade-offs of each are
+ * UX prose the user benefits from seeing inline, and the wire IDs don't
+ * change often. Add a new constant + entry here when ElevenLabs ships
+ * something worth surfacing.
+ */
+@Composable
+private fun ElevenLabsModelPicker(
+    selected: String,
+    onSelect: (String) -> Unit,
+    enabled: Boolean = true,
+) {
+    val models = listOf(
+        ELEVENLABS_MODEL_TURBO_V2_5 to R.string.settings_elevenlabs_model_turbo_v2_5,
+        ELEVENLABS_MODEL_MULTILINGUAL_V2 to R.string.settings_elevenlabs_model_multilingual_v2,
+        ELEVENLABS_MODEL_FLASH_V2_5 to R.string.settings_elevenlabs_model_flash_v2_5,
+        ELEVENLABS_MODEL_V3 to R.string.settings_elevenlabs_model_v3,
+    )
+    Text(
+        text = stringResource(R.string.settings_elevenlabs_model_label),
+        style = MaterialTheme.typography.titleSmall,
+    )
+    models.forEach { (id, labelRes) ->
+        RadioRow(
+            label = stringResource(labelRes),
+            selected = id == selected,
+            enabled = enabled,
+            onSelect = { onSelect(id) },
+        )
+    }
+}
+
+/**
+ * Slider for the per-clip ElevenLabs playback rate (0.7×–1.2×, the
+ * documented voice_settings.speed range). Steps in 0.05 increments — fine
+ * enough to be expressive, coarse enough that one tap of the thumb makes a
+ * clearly audible difference. The vendor's stock 1.0 is "too fast" by
+ * field-report; we default to 0.9.
+ *
+ * `onValueChange` fires continuously during drag so the label updates
+ * smoothly; `onValueChangeFinished` fires once on release so the caller
+ * can trigger a single billed synthesis preview rather than one per tick.
+ */
+@Composable
+private fun ElevenLabsSpeedSlider(
+    value: Double,
+    onValueChange: (Double) -> Unit,
+    onValueChangeFinished: () -> Unit,
+    enabled: Boolean = true,
+) {
+    val min = UserPreferences.MIN_ELEVENLABS_SPEED.toFloat()
+    val max = UserPreferences.MAX_ELEVENLABS_SPEED.toFloat()
+    // (max - min) / 0.05 = 10 internal positions ⇒ 11 selectable values.
+    val steps = 9
+    val displayValue = String.format(Locale.US, "%.2f", value)
+    Text(
+        text = stringResource(R.string.settings_elevenlabs_speed_label, displayValue),
+        style = MaterialTheme.typography.titleSmall,
+    )
+    Slider(
+        value = value.toFloat().coerceIn(min, max),
+        onValueChange = { onValueChange(it.toDouble()) },
+        onValueChangeFinished = onValueChangeFinished,
+        valueRange = min..max,
+        steps = steps,
+        enabled = enabled,
+        modifier = Modifier.fillMaxWidth(),
+    )
+}
+
+/**
  * Tracks whether `com.google.android.tts` is currently installed, refreshing
  * on every `ON_RESUME`. Lives in the composable layer (rather than the
  * SettingsViewModel) because the ViewModel instance is reused across
@@ -614,6 +732,8 @@ private suspend fun runTtsPreview(
     geminiVoice: String,
     openAiVoice: String,
     elevenLabsVoice: String,
+    elevenLabsModel: String,
+    elevenLabsSpeed: Double,
     deviceVoice: String?,
     voiceLocale: VoiceLocale,
 ) {
@@ -636,7 +756,12 @@ private suspend fun runTtsPreview(
                     TtsEngine.OPENAI ->
                         OpenAITtsSpeaker(app.openAiTtsClient, voice = openAiVoice).speak(text, locale)
                     TtsEngine.ELEVENLABS ->
-                        ElevenLabsTtsSpeaker(app.elevenLabsTtsClient, voiceId = elevenLabsVoice).speak(text, locale)
+                        ElevenLabsTtsSpeaker(
+                            client = app.elevenLabsTtsClient,
+                            voiceId = elevenLabsVoice,
+                            model = elevenLabsModel,
+                            speed = elevenLabsSpeed,
+                        ).speak(text, locale)
                     TtsEngine.DEVICE ->
                         app.deviceTtsSpeaker(deviceVoice).speak(text, locale)
                 }

--- a/app/src/main/kotlin/app/clothescast/ui/settings/VoiceSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/VoiceSettings.kt
@@ -251,15 +251,20 @@ internal fun VoiceContent(
                         onClear = onClearElevenLabsKey,
                     )
                     // Use the user's account voices once they've refreshed,
-                    // else fall back to the curated en-US library list. The
-                    // refreshed list is already accent-agnostic (locale = null
-                    // on every entry) so filterByVariant only narrows the
-                    // curated fallback. An empty refreshed list (exotic
-                    // account state) also falls back so the picker is never
-                    // empty.
+                    // else fall back to the curated en-US library list. Both
+                    // paths apply the same locale filter so the picker
+                    // behaves consistently whether the list is curated or
+                    // account-fetched. `keepSelected` keeps the user's
+                    // current voice visible if its mapped accent doesn't
+                    // match the chosen locale (otherwise the dialog would
+                    // omit it and the button label would fall back to the
+                    // raw voice ID). Empty refreshed list (exotic account
+                    // state) silently falls back to the curated list so the
+                    // picker is never empty.
                     val pickerVoices = elevenLabsRefreshedVoices
                         ?.takeIf { it.isNotEmpty() }
-                        ?: ELEVENLABS_VOICES.filterByVariant(voiceLocale)
+                        ?.filterByVariant(voiceLocale, keepSelected = elevenLabsVoice)
+                        ?: ELEVENLABS_VOICES.filterByVariant(voiceLocale, keepSelected = elevenLabsVoice)
                     VoicePicker(
                         title = stringResource(R.string.settings_tts_voice_label),
                         voices = pickerVoices,

--- a/app/src/main/kotlin/app/clothescast/ui/settings/VoiceSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/VoiceSettings.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
@@ -275,7 +276,11 @@ internal fun VoiceContent(
                             preview(TtsEngine.ELEVENLABS, geminiVoice, openAiVoice, it, deviceVoice, voiceLocale)
                         },
                     )
-                    if (elevenLabsRefreshedVoices != null) {
+                    // Caption only when we actually rendered the refreshed
+                    // list. An empty refresh result silently falls back to
+                    // the curated voices (above), so "Showing 0 voices …"
+                    // would be misleading.
+                    if (!elevenLabsRefreshedVoices.isNullOrEmpty()) {
                         Text(
                             text = stringResource(
                                 R.string.settings_elevenlabs_refresh_voices_loaded,
@@ -295,16 +300,19 @@ internal fun VoiceContent(
                             enabled = !isPreviewing && !elevenLabsRefreshing,
                             modifier = Modifier.fillMaxWidth(),
                         ) {
+                            // Always render the text label so TalkBack /
+                            // VoiceOver have something to announce (the
+                            // spinner alone is unlabeled). The spinner
+                            // sits to the left of the label while a
+                            // refresh is in flight.
                             if (elevenLabsRefreshing) {
-                                Box(contentAlignment = Alignment.Center) {
-                                    CircularProgressIndicator(
-                                        modifier = Modifier.size(20.dp),
-                                        strokeWidth = 2.dp,
-                                    )
-                                }
-                            } else {
-                                Text(stringResource(R.string.settings_elevenlabs_refresh_voices))
+                                CircularProgressIndicator(
+                                    modifier = Modifier.size(16.dp),
+                                    strokeWidth = 2.dp,
+                                )
+                                Spacer(modifier = Modifier.size(8.dp))
                             }
+                            Text(stringResource(R.string.settings_elevenlabs_refresh_voices))
                         }
                     }
                     ElevenLabsModelPicker(
@@ -316,16 +324,15 @@ internal fun VoiceContent(
                         },
                     )
                     ElevenLabsSpeedSlider(
-                        value = elevenLabsSpeed,
+                        persistedValue = elevenLabsSpeed,
                         enabled = !isPreviewing,
-                        onValueChange = onSetElevenLabsSpeed,
-                        // Preview only on slider release — every drag tick
-                        // would fire a billed synthesis call and stack
-                        // playback. The picker's "lock-while-previewing"
-                        // gate gives us release semantics for free: once
-                        // the user lifts and we trigger preview, further
-                        // drags are ignored until it finishes.
-                        onValueChangeFinished = {
+                        // Persist + preview on slider release only. Every
+                        // drag tick would fire a DataStore write, a
+                        // preferences-flow emission, and (worse) a billed
+                        // synthesis call. The slider holds its dragged
+                        // value in local Compose state until release.
+                        onValueChangeFinished = { released ->
+                            onSetElevenLabsSpeed(released)
                             preview(TtsEngine.ELEVENLABS, geminiVoice, openAiVoice, elevenLabsVoice, deviceVoice, voiceLocale)
                         },
                     )
@@ -594,30 +601,40 @@ private fun ElevenLabsModelPicker(
  * clearly audible difference. The vendor's stock 1.0 is "too fast" by
  * field-report; we default to 0.9.
  *
- * `onValueChange` fires continuously during drag so the label updates
- * smoothly; `onValueChangeFinished` fires once on release so the caller
- * can trigger a single billed synthesis preview rather than one per tick.
+ * The dragged value is held in local Compose state — only on release does
+ * [onValueChangeFinished] fire with the final value, which the caller
+ * persists and uses to trigger a billed synthesis preview. This avoids a
+ * burst of DataStore writes (one per drag tick) and keeps a single
+ * preview from stacking on top of itself if the user is still dragging.
+ *
+ * The label updates live during drag (off the local state), so the
+ * thumb-following number isn't laggy.
  */
 @Composable
 private fun ElevenLabsSpeedSlider(
-    value: Double,
-    onValueChange: (Double) -> Unit,
-    onValueChangeFinished: () -> Unit,
+    persistedValue: Double,
+    onValueChangeFinished: (Double) -> Unit,
     enabled: Boolean = true,
 ) {
     val min = UserPreferences.MIN_ELEVENLABS_SPEED.toFloat()
     val max = UserPreferences.MAX_ELEVENLABS_SPEED.toFloat()
     // (max - min) / 0.05 = 10 internal positions ⇒ 11 selectable values.
     val steps = 9
-    val displayValue = String.format(Locale.US, "%.2f", value)
+    // `persistedValue` keys the remember so an external change (DataStore
+    // emission landing after `onValueChangeFinished` persists, or a future
+    // settings reset) overwrites the local-during-drag value.
+    var draggedValue by remember(persistedValue) {
+        mutableStateOf(persistedValue.toFloat().coerceIn(min, max))
+    }
+    val displayValue = String.format(Locale.US, "%.2f", draggedValue)
     Text(
         text = stringResource(R.string.settings_elevenlabs_speed_label, displayValue),
         style = MaterialTheme.typography.titleSmall,
     )
     Slider(
-        value = value.toFloat().coerceIn(min, max),
-        onValueChange = { onValueChange(it.toDouble()) },
-        onValueChangeFinished = onValueChangeFinished,
+        value = draggedValue,
+        onValueChange = { draggedValue = it },
+        onValueChangeFinished = { onValueChangeFinished(draggedValue.toDouble()) },
         valueRange = min..max,
         steps = steps,
         enabled = enabled,

--- a/app/src/main/kotlin/app/clothescast/ui/settings/VoiceSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/VoiceSettings.kt
@@ -74,6 +74,8 @@ internal fun VoiceContent(
     geminiKeyConfigured: Boolean,
     openAiKeyConfigured: Boolean,
     elevenLabsKeyConfigured: Boolean,
+    elevenLabsRefreshedVoices: List<TtsVoiceOption>?,
+    elevenLabsRefreshing: Boolean,
     voiceLocale: VoiceLocale,
     padding: PaddingValues,
     onSetTtsEngine: (TtsEngine) -> Unit,
@@ -88,6 +90,7 @@ internal fun VoiceContent(
     onClearOpenAiKey: () -> Unit,
     onSetElevenLabsKey: (String) -> Unit,
     onClearElevenLabsKey: () -> Unit,
+    onRefreshElevenLabsVoices: () -> Unit,
 ) {
     val context = LocalContext.current
     val coroutineScope = rememberCoroutineScope()
@@ -224,9 +227,19 @@ internal fun VoiceContent(
                         onSave = onSetElevenLabsKey,
                         onClear = onClearElevenLabsKey,
                     )
+                    // Use the user's account voices once they've refreshed,
+                    // else fall back to the curated en-US library list. The
+                    // refreshed list is already accent-agnostic (locale = null
+                    // on every entry) so filterByVariant only narrows the
+                    // curated fallback. An empty refreshed list (exotic
+                    // account state) also falls back so the picker is never
+                    // empty.
+                    val pickerVoices = elevenLabsRefreshedVoices
+                        ?.takeIf { it.isNotEmpty() }
+                        ?: ELEVENLABS_VOICES.filterByVariant(voiceLocale)
                     VoicePicker(
                         title = stringResource(R.string.settings_tts_voice_label),
-                        voices = ELEVENLABS_VOICES.filterByVariant(voiceLocale),
+                        voices = pickerVoices,
                         selectedId = elevenLabsVoice,
                         enabled = !isPreviewing,
                         onSelect = {
@@ -234,6 +247,38 @@ internal fun VoiceContent(
                             preview(TtsEngine.ELEVENLABS, geminiVoice, openAiVoice, it, deviceVoice, voiceLocale)
                         },
                     )
+                    if (elevenLabsRefreshedVoices != null) {
+                        Text(
+                            text = stringResource(
+                                R.string.settings_elevenlabs_refresh_voices_loaded,
+                                elevenLabsRefreshedVoices.size,
+                            ),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                    // Refresh is gated on the key being configured — without
+                    // a key the API call would 401. Disabled while a preview
+                    // or another refresh is in flight to avoid stacking
+                    // requests against the user's quota.
+                    if (elevenLabsKeyConfigured) {
+                        OutlinedButton(
+                            onClick = onRefreshElevenLabsVoices,
+                            enabled = !isPreviewing && !elevenLabsRefreshing,
+                            modifier = Modifier.fillMaxWidth(),
+                        ) {
+                            if (elevenLabsRefreshing) {
+                                Box(contentAlignment = Alignment.Center) {
+                                    CircularProgressIndicator(
+                                        modifier = Modifier.size(20.dp),
+                                        strokeWidth = 2.dp,
+                                    )
+                                }
+                            } else {
+                                Text(stringResource(R.string.settings_elevenlabs_refresh_voices))
+                            }
+                        }
+                    }
                     TestVoiceButton(isPreviewing = isPreviewing) {
                         preview(selected, geminiVoice, openAiVoice, elevenLabsVoice, deviceVoice, voiceLocale)
                     }

--- a/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
@@ -364,7 +364,12 @@ class FetchAndNotifyWorker(
                 }
                 TtsEngine.ELEVENLABS -> {
                     try {
-                        ElevenLabsTtsSpeaker(app.elevenLabsTtsClient, voiceId = prefs.elevenLabsVoice).speak(text, locale)
+                        ElevenLabsTtsSpeaker(
+                            client = app.elevenLabsTtsClient,
+                            voiceId = prefs.elevenLabsVoice,
+                            model = prefs.elevenLabsModel,
+                            speed = prefs.elevenLabsSpeed,
+                        ).speak(text, locale)
                         return@withSpeechAudioFocus
                     } catch (t: Throwable) {
                         DiagLog.w(TAG, "ElevenLabs TTS failed; falling back to device TTS.", t)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -219,6 +219,16 @@
          number of voices loaded from the user's account. -->
     <string name="settings_elevenlabs_refresh_voices_loaded">Showing %1$d voices from your ElevenLabs account.</string>
 
+    <!-- Section heading above the four-radio model picker. -->
+    <string name="settings_elevenlabs_model_label">Model</string>
+    <string name="settings_elevenlabs_model_turbo_v2_5">Turbo v2.5 — balanced (default, 0.5 credits/char)</string>
+    <string name="settings_elevenlabs_model_multilingual_v2">Multilingual v2 — flagship quality (1.0 credits/char)</string>
+    <string name="settings_elevenlabs_model_flash_v2_5">Flash v2.5 — fastest (0.5 credits/char)</string>
+    <string name="settings_elevenlabs_model_v3">v3 alpha — audio-tag aware (experimental)</string>
+    <!-- Heading above the speed slider; %1$s is the current value formatted
+         as e.g. "0.90". -->
+    <string name="settings_elevenlabs_speed_label">Speed × %1$s</string>
+
     <string name="settings_region_language_title">Language</string>
     <!-- Caption rendered under the Region > Language title, pairing with
          settings_tts_voice_locale_description so the user can tell which knob

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -210,11 +210,15 @@
     <string name="settings_elevenlabs_key_placeholder">Paste your ElevenLabs API key</string>
     <string name="settings_elevenlabs_key_save">Save ElevenLabs key</string>
     <string name="settings_elevenlabs_key_clear">Clear stored ElevenLabs key</string>
+    <!-- TODO(translations): the ElevenLabs refresh / model / speed strings
+         below are en-only for now. Localised values-*/strings.xml files
+         already translate the rest of the ElevenLabs settings keys, so
+         non-English users will see these specific controls in English
+         until translations land in a follow-up. -->
     <!-- Button shown only when an ElevenLabs key is set; fetches the
          account's voice library (premade + cloned) so the picker shows
          exactly what the user has access to. -->
     <string name="settings_elevenlabs_refresh_voices">Refresh voices</string>
-    <string name="settings_elevenlabs_refresh_voices_in_flight">Refreshing…</string>
     <!-- Caption under the picker after a successful refresh. %1$d is the
          number of voices loaded from the user's account. -->
     <string name="settings_elevenlabs_refresh_voices_loaded">Showing %1$d voices from your ElevenLabs account.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -210,6 +210,14 @@
     <string name="settings_elevenlabs_key_placeholder">Paste your ElevenLabs API key</string>
     <string name="settings_elevenlabs_key_save">Save ElevenLabs key</string>
     <string name="settings_elevenlabs_key_clear">Clear stored ElevenLabs key</string>
+    <!-- Button shown only when an ElevenLabs key is set; fetches the
+         account's voice library (premade + cloned) so the picker shows
+         exactly what the user has access to. -->
+    <string name="settings_elevenlabs_refresh_voices">Refresh voices</string>
+    <string name="settings_elevenlabs_refresh_voices_in_flight">Refreshing…</string>
+    <!-- Caption under the picker after a successful refresh. %1$d is the
+         number of voices loaded from the user's account. -->
+    <string name="settings_elevenlabs_refresh_voices_loaded">Showing %1$d voices from your ElevenLabs account.</string>
 
     <string name="settings_region_language_title">Language</string>
     <!-- Caption rendered under the Region > Language title, pairing with

--- a/app/src/test/kotlin/app/clothescast/data/SettingsRepositoryTest.kt
+++ b/app/src/test/kotlin/app/clothescast/data/SettingsRepositoryTest.kt
@@ -289,6 +289,34 @@ class SettingsRepositoryTest {
     }
 
     @Test
+    fun `elevenLabs model and speed round-trip and default sensibly`() = runTest {
+        // Defaults match the constants exposed by core:domain so the picker
+        // shows the right initial selection on a fresh install.
+        val initial = subject.preferences.first()
+        initial.elevenLabsModel shouldBe "eleven_turbo_v2_5"
+        initial.elevenLabsSpeed shouldBe 0.9
+
+        subject.setElevenLabsModel("eleven_flash_v2_5")
+        subject.setElevenLabsSpeed(1.05)
+
+        val updated = subject.preferences.first()
+        updated.elevenLabsModel shouldBe "eleven_flash_v2_5"
+        updated.elevenLabsSpeed shouldBe 1.05
+    }
+
+    @Test
+    fun `elevenLabs speed setter clamps to the documented 0_7 to 1_2 range`() = runTest {
+        // Out-of-range values get clamped on write so a malformed prefs
+        // edit (or a future migration that bypasses the slider) can't
+        // push past what ElevenLabs actually accepts.
+        subject.setElevenLabsSpeed(2.0)
+        subject.preferences.first().elevenLabsSpeed shouldBe 1.2
+
+        subject.setElevenLabsSpeed(0.1)
+        subject.preferences.first().elevenLabsSpeed shouldBe 0.7
+    }
+
+    @Test
     fun `openAiVoice defaults to nova for non-British locale preferences`() = runTest {
         subject.setVoiceLocale(VoiceLocale.EN_US)
         subject.preferences.first().openAiVoice shouldBe "nova"

--- a/app/src/test/kotlin/app/clothescast/tts/TtsVoicesTest.kt
+++ b/app/src/test/kotlin/app/clothescast/tts/TtsVoicesTest.kt
@@ -1,5 +1,6 @@
 package app.clothescast.tts
 
+import app.clothescast.core.data.tts.ElevenLabsVoiceSummary
 import app.clothescast.core.domain.model.VoiceLocale
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
@@ -72,5 +73,35 @@ class TtsVoicesTest {
         // selected). keepSelected becomes a no-op rather than re-appending.
         val all = listOf(american)
         all.filterByVariant(VoiceLocale.EN_AU, keepSelected = "a") shouldBe all
+    }
+
+    @Test
+    fun `toVoiceOptions formats name plus description plus accent when all present`() {
+        val mapped = listOf(
+            ElevenLabsVoiceSummary(id = "v1", name = "Sarah", accent = "american", description = "warm"),
+        ).toVoiceOptions()
+        mapped[0].id shouldBe "v1"
+        mapped[0].displayName shouldBe "Sarah — warm (american)"
+        // Refreshed entries are accent-agnostic so the locale filter never
+        // drops them — see the comment on toVoiceOptions.
+        mapped[0].locale shouldBe null
+    }
+
+    @Test
+    fun `toVoiceOptions falls through gracefully when labels are partial or missing`() {
+        val mapped = listOf(
+            ElevenLabsVoiceSummary(id = "d", name = "DescOnly", description = "calm"),
+            ElevenLabsVoiceSummary(id = "a", name = "AccentOnly", accent = "british"),
+            ElevenLabsVoiceSummary(id = "n", name = "Nameless"),
+            // Whitespace-only labels are treated the same as null so we don't
+            // render "Sarah —  ()" for sparsely-tagged clones.
+            ElevenLabsVoiceSummary(id = "b", name = "Blank", accent = "  ", description = ""),
+        ).toVoiceOptions()
+        mapped.map { it.displayName } shouldBe listOf(
+            "DescOnly — calm",
+            "AccentOnly (british)",
+            "Nameless",
+            "Blank",
+        )
     }
 }

--- a/app/src/test/kotlin/app/clothescast/tts/TtsVoicesTest.kt
+++ b/app/src/test/kotlin/app/clothescast/tts/TtsVoicesTest.kt
@@ -82,9 +82,10 @@ class TtsVoicesTest {
         ).toVoiceOptions()
         mapped[0].id shouldBe "v1"
         mapped[0].displayName shouldBe "Sarah — warm (american)"
-        // Refreshed entries are accent-agnostic so the locale filter never
-        // drops them — see the comment on toVoiceOptions.
-        mapped[0].locale shouldBe null
+        // "american" is one of the accent labels we map to a VoiceLocale
+        // so the picker's locale filter narrows the refreshed list the
+        // same way it narrows the curated one.
+        mapped[0].locale shouldBe VoiceLocale.EN_US
     }
 
     @Test
@@ -103,5 +104,39 @@ class TtsVoicesTest {
             "Nameless",
             "Blank",
         )
+    }
+
+    @Test
+    fun `toVoiceOptions maps recognised accent labels onto VoiceLocale`() {
+        // Spot-check the headline English variants users are most likely to
+        // filter by. "south african" exercises the multi-word lookup;
+        // upper-case input exercises the lowercase normalisation.
+        val mapped = listOf(
+            ElevenLabsVoiceSummary("a", "A", accent = "American"),
+            ElevenLabsVoiceSummary("b", "B", accent = "british"),
+            ElevenLabsVoiceSummary("c", "C", accent = "australian"),
+            ElevenLabsVoiceSummary("d", "D", accent = "south african"),
+        ).toVoiceOptions()
+        mapped.map { it.locale } shouldBe listOf(
+            VoiceLocale.EN_US,
+            VoiceLocale.EN_GB,
+            VoiceLocale.EN_AU,
+            VoiceLocale.EN_ZA,
+        )
+    }
+
+    @Test
+    fun `toVoiceOptions leaves unrecognised or ambiguous accents as null`() {
+        // Unknown ("transatlantic"), ambiguous-within-VoiceLocale
+        // ("scottish" / "irish" — would they be EN_GB? we don't claim),
+        // and made-up labels all fall back to null so the locale filter
+        // doesn't silently hide them.
+        val mapped = listOf(
+            ElevenLabsVoiceSummary("t", "T", accent = "transatlantic"),
+            ElevenLabsVoiceSummary("s", "S", accent = "scottish"),
+            ElevenLabsVoiceSummary("i", "I", accent = "irish"),
+            ElevenLabsVoiceSummary("x", "X", accent = "klingon"),
+        ).toVoiceOptions()
+        mapped.forEach { it.locale shouldBe null }
     }
 }

--- a/app/src/test/kotlin/app/clothescast/ui/settings/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/app/clothescast/ui/settings/SettingsViewModelTest.kt
@@ -3,7 +3,9 @@ package app.clothescast.ui.settings
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences
+import app.clothescast.core.data.insight.KeyProvider
 import app.clothescast.core.data.location.OpenMeteoGeocodingClient
+import app.clothescast.core.data.tts.ElevenLabsTtsClient
 import app.clothescast.core.domain.model.DeliveryMode
 import app.clothescast.core.domain.model.DistanceUnit
 import app.clothescast.core.domain.model.TemperatureUnit
@@ -23,7 +25,9 @@ import io.ktor.http.headersOf
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.utils.io.ByteReadChannel
 import kotlinx.serialization.json.Json as KotlinxJson
+import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -189,6 +193,95 @@ class SettingsViewModelTest {
         }
         state.temperatureUnit shouldBe TemperatureUnit.FAHRENHEIT
         state.distanceUnit shouldBe DistanceUnit.MILES
+    }
+
+    @Test
+    fun `refreshElevenLabsVoices populates state from the API response`() = runTest {
+        val voicesJson = """
+            {"voices":[
+              {"voice_id":"v1","name":"Sarah","labels":{"description":"warm"}},
+              {"voice_id":"v2","name":"My Clone"}
+            ]}
+        """.trimIndent()
+        val client = ElevenLabsTtsClient(
+            httpClient = HttpClient(
+                MockEngine {
+                    respond(
+                        content = ByteReadChannel(voicesJson),
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                    )
+                },
+            ) { install(ContentNegotiation) { json(KotlinxJson { ignoreUnknownKeys = true }) } },
+            keyProvider = object : KeyProvider {
+                override suspend fun get(): String = "test-key"
+            },
+        )
+        val refreshSubject = SettingsViewModel(
+            settingsRepository = settingsRepository,
+            keyStore = keyStore,
+            rearmAlarm = { _, _ -> },
+            cancelAlarm = { _ -> },
+            geocodingClient = OpenMeteoGeocodingClient(
+                HttpClient(MockEngine { respond("""{"results":[]}""") }) {
+                    install(ContentNegotiation) { json(KotlinxJson { ignoreUnknownKeys = true }) }
+                },
+            ),
+            voiceEnumerator = EmptyVoiceEnumerator,
+            elevenLabsTtsClient = client,
+        )
+
+        refreshSubject.refreshElevenLabsVoices()
+
+        val state = refreshSubject.state.first { it.elevenLabsRefreshedVoices != null }
+        state.elevenLabsRefreshing shouldBe false
+        val voices = checkNotNull(state.elevenLabsRefreshedVoices)
+        voices shouldHaveSize 2
+        voices[0].id shouldBe "v1"
+        voices[0].displayName shouldBe "Sarah — warm"
+        voices[1].id shouldBe "v2"
+        voices[1].displayName shouldBe "My Clone"
+    }
+
+    @Test
+    fun `refreshElevenLabsVoices reports failures via showError and leaves state untouched`() = runTest {
+        val client = ElevenLabsTtsClient(
+            httpClient = HttpClient(
+                MockEngine {
+                    respond(
+                        content = ByteReadChannel(
+                            """{"detail":{"status":"unauthorized","message":"Invalid API key"}}""",
+                        ),
+                        status = HttpStatusCode.Unauthorized,
+                        headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                    )
+                },
+            ) { install(ContentNegotiation) { json(KotlinxJson { ignoreUnknownKeys = true }) } },
+            keyProvider = object : KeyProvider {
+                override suspend fun get(): String = "bad-key"
+            },
+        )
+        var reported: String? = null
+        val refreshSubject = SettingsViewModel(
+            settingsRepository = settingsRepository,
+            keyStore = keyStore,
+            rearmAlarm = { _, _ -> },
+            cancelAlarm = { _ -> },
+            geocodingClient = OpenMeteoGeocodingClient(
+                HttpClient(MockEngine { respond("""{"results":[]}""") }) {
+                    install(ContentNegotiation) { json(KotlinxJson { ignoreUnknownKeys = true }) }
+                },
+            ),
+            voiceEnumerator = EmptyVoiceEnumerator,
+            elevenLabsTtsClient = client,
+            showError = { reported = it },
+        )
+
+        refreshSubject.refreshElevenLabsVoices()
+
+        refreshSubject.state.first { !it.elevenLabsRefreshing }
+        refreshSubject.state.value.elevenLabsRefreshedVoices shouldBe null
+        checkNotNull(reported).shouldContain("Invalid API key")
     }
 }
 

--- a/app/src/test/kotlin/app/clothescast/ui/settings/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/app/clothescast/ui/settings/SettingsViewModelTest.kt
@@ -230,6 +230,11 @@ class SettingsViewModelTest {
             voiceEnumerator = EmptyVoiceEnumerator,
             elevenLabsTtsClient = client,
         )
+        // refreshElevenLabsVoices early-returns when the key isn't
+        // configured (the UI also gates the button), so persist a key
+        // first and wait for the state flag to flip before triggering.
+        refreshSubject.setElevenLabsKey("test-key")
+        refreshSubject.state.first { it.elevenLabsKeyConfigured }
 
         refreshSubject.refreshElevenLabsVoices()
 
@@ -276,12 +281,62 @@ class SettingsViewModelTest {
             elevenLabsTtsClient = client,
             showError = { reported = it },
         )
+        // The early-return covers "no key" so the 401 path needs a
+        // configured (but server-rejected) key. Setting a stored key
+        // flips the state flag; the request itself will still 401
+        // because the MockEngine returns Unauthorized regardless of
+        // what the key actually is.
+        refreshSubject.setElevenLabsKey("bad-key")
+        refreshSubject.state.first { it.elevenLabsKeyConfigured }
 
         refreshSubject.refreshElevenLabsVoices()
 
         refreshSubject.state.first { !it.elevenLabsRefreshing }
         refreshSubject.state.value.elevenLabsRefreshedVoices shouldBe null
         checkNotNull(reported).shouldContain("Invalid API key")
+    }
+
+    @Test
+    fun `refreshElevenLabsVoices no-ops when no ElevenLabs key is configured`() = runTest {
+        // The UI hides the Refresh button without a key, but a defensive
+        // early-return means even if it's invoked manually (e.g. test
+        // wiring) we don't fire a guaranteed-401 request.
+        var listVoicesCallCount = 0
+        val client = ElevenLabsTtsClient(
+            httpClient = HttpClient(
+                MockEngine {
+                    listVoicesCallCount++
+                    respond("""{"voices":[]}""")
+                },
+            ) { install(ContentNegotiation) { json(KotlinxJson { ignoreUnknownKeys = true }) } },
+            keyProvider = object : KeyProvider {
+                override suspend fun get(): String = ""
+            },
+        )
+        val refreshSubject = SettingsViewModel(
+            settingsRepository = settingsRepository,
+            keyStore = keyStore,
+            rearmAlarm = { _, _ -> },
+            cancelAlarm = { _ -> },
+            geocodingClient = OpenMeteoGeocodingClient(
+                HttpClient(MockEngine { respond("""{"results":[]}""") }) {
+                    install(ContentNegotiation) { json(KotlinxJson { ignoreUnknownKeys = true }) }
+                },
+            ),
+            voiceEnumerator = EmptyVoiceEnumerator,
+            elevenLabsTtsClient = client,
+        )
+        // Wait for the initial keystore probe to land — without it the
+        // state flag is still its default `false`, which would also
+        // short-circuit but for the wrong reason.
+        refreshSubject.state.first { !it.elevenLabsKeyConfigured }
+
+        refreshSubject.refreshElevenLabsVoices()
+
+        // No HTTP traffic, no state change.
+        listVoicesCallCount shouldBe 0
+        refreshSubject.state.value.elevenLabsRefreshedVoices shouldBe null
+        refreshSubject.state.value.elevenLabsRefreshing shouldBe false
     }
 }
 

--- a/core/data/src/main/kotlin/app/clothescast/core/data/tts/ElevenLabsTtsClient.kt
+++ b/core/data/src/main/kotlin/app/clothescast/core/data/tts/ElevenLabsTtsClient.kt
@@ -44,10 +44,28 @@ import kotlinx.serialization.json.JsonPrimitive
 const val DEFAULT_ELEVENLABS_TTS_MODEL: String = "eleven_turbo_v2_5"
 const val DEFAULT_ELEVENLABS_TTS_VOICE: String = "EXAVITQu4vr4xnSDxMaL" // Sarah
 
+// Wire-IDs for the four models we surface in the picker. Kept as a small set
+// (rather than every model ElevenLabs ships) so the radio list stays scannable
+// — these are the ones with meaningfully different cost / latency / quality
+// trade-offs for short weather briefings.
+//
+// turbo_v2_5  — current default. 0.5 credits/char, multilingual, low latency,
+//               near-multilingual_v2 quality on stock voices.
+// multilingual_v2 — 1.0 credits/char (2× the cost), historically the
+//               flagship-quality option; some voice clones still tune for it.
+// flash_v2_5  — 0.5 credits/char, fastest first-byte, slightly less natural;
+//               the "if turbo is still too slow" option.
+// v3          — alpha (April 2026). Audio-tag aware. Pricing not yet
+//               finalised; surfaced for users who want to experiment.
+const val ELEVENLABS_MODEL_TURBO_V2_5: String = "eleven_turbo_v2_5"
+const val ELEVENLABS_MODEL_MULTILINGUAL_V2: String = "eleven_multilingual_v2"
+const val ELEVENLABS_MODEL_FLASH_V2_5: String = "eleven_flash_v2_5"
+const val ELEVENLABS_MODEL_V3: String = "eleven_v3"
+
 // Below ElevenLabs' stock 1.0 because field reports flagged the default pace
 // as "too fast" — 0.9 is a noticeable but not draggy slowdown. Stays inside
 // the documented 0.7–1.2 range.
-private const val DEFAULT_SPEED = 0.9
+const val DEFAULT_ELEVENLABS_TTS_SPEED: Double = 0.9
 
 // Above the stock 0.5 to favour pronunciation consistency over expression
 // for short weather briefings — drops fewer consonants.
@@ -68,11 +86,13 @@ private const val DEFAULT_STABILITY = 0.65
 class ElevenLabsTtsClient(
     private val httpClient: HttpClient,
     private val keyProvider: KeyProvider,
-    private val model: String = DEFAULT_ELEVENLABS_TTS_MODEL,
+    private val defaultModel: String = DEFAULT_ELEVENLABS_TTS_MODEL,
 ) {
     suspend fun synthesize(
         text: String,
         voiceId: String = DEFAULT_ELEVENLABS_TTS_VOICE,
+        model: String = defaultModel,
+        speed: Double = DEFAULT_ELEVENLABS_TTS_SPEED,
     ): PcmAudio {
         val key = keyProvider.get().also {
             if (it.isBlank()) throw MissingApiKeyException("ElevenLabs")
@@ -96,7 +116,7 @@ class ElevenLabsTtsClient(
                     text = text,
                     modelId = model,
                     voiceSettings = ElevenLabsVoiceSettings(
-                        speed = DEFAULT_SPEED,
+                        speed = speed,
                         stability = DEFAULT_STABILITY,
                     ),
                 ),

--- a/core/data/src/main/kotlin/app/clothescast/core/data/tts/ElevenLabsTtsClient.kt
+++ b/core/data/src/main/kotlin/app/clothescast/core/data/tts/ElevenLabsTtsClient.kt
@@ -3,6 +3,8 @@ package app.clothescast.core.data.tts
 import app.clothescast.core.data.insight.KeyProvider
 import app.clothescast.core.data.insight.MissingApiKeyException
 import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.client.request.parameter
 import io.ktor.client.request.post
@@ -111,6 +113,43 @@ class ElevenLabsTtsClient(
         return PcmAudio(bytes = pcm, sampleRate = ELEVENLABS_PCM_SAMPLE_RATE_HZ)
     }
 
+    /**
+     * Lists every voice the caller's API key has access to: ElevenLabs'
+     * premade library plus any voices the user has cloned, generated, or
+     * imported into their account. Used by the Settings refresh button so
+     * users with paid plans don't have to copy-paste voice IDs by hand.
+     *
+     * Returns lightweight [ElevenLabsVoiceSummary] records (id, display
+     * name, optional accent label) — translation to the UI's
+     * `TtsVoiceOption` happens in the app module to keep this data layer
+     * UI-agnostic.
+     */
+    suspend fun listVoices(): List<ElevenLabsVoiceSummary> {
+        val key = keyProvider.get().also {
+            if (it.isBlank()) throw MissingApiKeyException("ElevenLabs")
+        }
+        val response: HttpResponse = httpClient.get {
+            url {
+                protocol = URLProtocol.HTTPS
+                host = ELEVENLABS_HOST
+                path("v1", "voices")
+            }
+            header("xi-api-key", key)
+        }
+        if (!response.status.isSuccess()) {
+            throw ElevenLabsTtsHttpException(response.status, response.bodyAsBytes())
+        }
+        val parsed: ElevenLabsVoicesResponse = response.body()
+        return parsed.voices.map { dto ->
+            ElevenLabsVoiceSummary(
+                id = dto.voiceId,
+                name = dto.name,
+                accent = dto.labels?.get("accent"),
+                description = dto.labels?.get("description"),
+            )
+        }
+    }
+
     companion object {
         // `pcm_24000` is documented as 16-bit signed little-endian mono at 24 kHz —
         // matches the AudioTrack format we already use for Gemini / OpenAI.
@@ -119,6 +158,18 @@ class ElevenLabsTtsClient(
         private const val ELEVENLABS_HOST = "api.elevenlabs.io"
     }
 }
+
+/**
+ * Lightweight projection of an ElevenLabs voice — just what the picker
+ * needs to render a label. Lives in `core:data` so the wire DTO can stay
+ * `internal`; the app module maps these to its UI option type.
+ */
+data class ElevenLabsVoiceSummary(
+    val id: String,
+    val name: String,
+    val accent: String? = null,
+    val description: String? = null,
+)
 
 class ElevenLabsTtsEmptyResponseException :
     IllegalStateException("ElevenLabs TTS returned no audio body")

--- a/core/data/src/main/kotlin/app/clothescast/core/data/tts/ElevenLabsTtsDto.kt
+++ b/core/data/src/main/kotlin/app/clothescast/core/data/tts/ElevenLabsTtsDto.kt
@@ -40,3 +40,25 @@ internal data class ElevenLabsVoiceSettings(
     val speed: Double? = null,
     val stability: Double? = null,
 )
+
+/**
+ * Wire type for `GET /v1/voices`. The endpoint returns the full library
+ * available to the caller's API key — premade voices, generated voices and
+ * the user's clones — wrapped in a `voices` array. We only consume the
+ * fields that drive the picker label; everything else (`samples`,
+ * `fine_tuning`, `available_for_tiers`, …) is ignored via Json's
+ * `ignoreUnknownKeys = true`.
+ */
+@Serializable
+internal data class ElevenLabsVoicesResponse(
+    val voices: List<ElevenLabsVoiceDto> = emptyList(),
+)
+
+@Serializable
+internal data class ElevenLabsVoiceDto(
+    @SerialName("voice_id")
+    val voiceId: String,
+    val name: String,
+    val category: String? = null,
+    val labels: Map<String, String>? = null,
+)

--- a/core/data/src/test/kotlin/app/clothescast/core/data/tts/ElevenLabsTtsClientTest.kt
+++ b/core/data/src/test/kotlin/app/clothescast/core/data/tts/ElevenLabsTtsClientTest.kt
@@ -1,6 +1,9 @@
 package app.clothescast.core.data.tts
 
 import app.clothescast.core.data.insight.KeyProvider
+import app.clothescast.core.data.insight.MissingApiKeyException
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.ktor.client.HttpClient
@@ -9,6 +12,7 @@ import io.ktor.client.engine.mock.respond
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.request.HttpRequestData
 import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
 import io.ktor.serialization.kotlinx.json.json
@@ -100,10 +104,109 @@ class ElevenLabsTtsClientTest {
         body.shouldContain("\"stability\":0.65")
     }
 
+    @Test
+    fun `listVoices GETs v1 voices and parses the wire envelope`() = runTest {
+        var captured: HttpRequestData? = null
+        val client = ElevenLabsTtsClient(
+            httpClient = jsonMockClient(VOICES_RESPONSE_BODY) { captured = it },
+            keyProvider = FakeKeyProvider("test-key"),
+        )
+
+        val voices = client.listVoices()
+
+        val req = checkNotNull(captured)
+        req.method shouldBe HttpMethod.Get
+        req.url.host shouldBe "api.elevenlabs.io"
+        req.url.encodedPath shouldBe "/v1/voices"
+        req.headers["xi-api-key"] shouldBe "test-key"
+        voices shouldHaveSize 2
+        voices[0].id shouldBe "EXAVITQu4vr4xnSDxMaL"
+        voices[0].name shouldBe "Sarah"
+        voices[0].accent shouldBe "american"
+        voices[0].description shouldBe "warm"
+        // Cloned voice with no labels at all — accent and description fall through to null.
+        voices[1].id shouldBe "custom-clone-id"
+        voices[1].name shouldBe "My Clone"
+        voices[1].accent shouldBe null
+        voices[1].description shouldBe null
+    }
+
+    @Test
+    fun `listVoices throws MissingApiKeyException when key is blank`() = runTest {
+        val client = ElevenLabsTtsClient(
+            httpClient = jsonMockClient("""{"voices":[]}"""),
+            keyProvider = FakeKeyProvider("   "),
+        )
+        shouldThrow<MissingApiKeyException> { client.listVoices() }
+    }
+
+    @Test
+    fun `listVoices surfaces HTTP failure as ElevenLabsTtsHttpException`() = runTest {
+        val client = ElevenLabsTtsClient(
+            httpClient = jsonMockClient(
+                """{"detail":{"status":"unauthorized","message":"Invalid API key"}}""",
+                status = HttpStatusCode.Unauthorized,
+            ),
+            keyProvider = FakeKeyProvider("bad-key"),
+        )
+        val ex = shouldThrow<ElevenLabsTtsHttpException> { client.listVoices() }
+        ex.status shouldBe HttpStatusCode.Unauthorized
+        checkNotNull(ex.message).shouldContain("Invalid API key")
+    }
+
+    private fun jsonMockClient(
+        body: String,
+        status: HttpStatusCode = HttpStatusCode.OK,
+        captureRequest: (HttpRequestData) -> Unit = {},
+    ): HttpClient {
+        val engine = MockEngine { request ->
+            captureRequest(request)
+            respond(
+                content = ByteReadChannel(body),
+                status = status,
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+        return HttpClient(engine) {
+            install(ContentNegotiation) {
+                json(Json { ignoreUnknownKeys = true })
+            }
+        }
+    }
+
     private companion object {
         // Four bytes of fake PCM are enough to exercise the success path; the
         // sample-rate is hard-coded in the client so we don't need to
         // round-trip it through the response.
         val SUCCESS_PCM_BYTES = byteArrayOf(0xDE.toByte(), 0xAD.toByte(), 0xBE.toByte(), 0xEF.toByte())
+
+        // Two-voice fixture: one premade with full labels (Sarah) and one
+        // user-cloned voice with no labels block at all — exercises both
+        // mapping branches in `listVoices`. Extra fields (`samples`,
+        // `fine_tuning`, …) are dropped because of `ignoreUnknownKeys`.
+        val VOICES_RESPONSE_BODY = """
+            {
+              "voices": [
+                {
+                  "voice_id": "EXAVITQu4vr4xnSDxMaL",
+                  "name": "Sarah",
+                  "category": "premade",
+                  "labels": {
+                    "accent": "american",
+                    "description": "warm",
+                    "age": "young",
+                    "gender": "female",
+                    "use_case": "narration"
+                  },
+                  "samples": null
+                },
+                {
+                  "voice_id": "custom-clone-id",
+                  "name": "My Clone",
+                  "category": "cloned"
+                }
+              ]
+            }
+        """.trimIndent()
     }
 }

--- a/core/data/src/test/kotlin/app/clothescast/core/data/tts/ElevenLabsTtsClientTest.kt
+++ b/core/data/src/test/kotlin/app/clothescast/core/data/tts/ElevenLabsTtsClientTest.kt
@@ -85,6 +85,36 @@ class ElevenLabsTtsClientTest {
     }
 
     @Test
+    fun `synthesize forwards a per-call model override into the request body`() = runTest {
+        // The ViewModel passes the user-picked model on every call so the
+        // client constructor's default doesn't shadow Settings.
+        var capturedBody: String? = null
+        val client = ElevenLabsTtsClient(
+            httpClient = mockClient { capturedBody = capturedBodyOf(it) },
+            keyProvider = FakeKeyProvider("test-key"),
+        )
+
+        client.synthesize(text = "hello", model = ELEVENLABS_MODEL_FLASH_V2_5)
+
+        val body = checkNotNull(capturedBody)
+        body.shouldContain("\"model_id\":\"eleven_flash_v2_5\"")
+    }
+
+    @Test
+    fun `synthesize forwards a per-call speed override into voice_settings`() = runTest {
+        var capturedBody: String? = null
+        val client = ElevenLabsTtsClient(
+            httpClient = mockClient { capturedBody = capturedBodyOf(it) },
+            keyProvider = FakeKeyProvider("test-key"),
+        )
+
+        client.synthesize(text = "hello", speed = 1.05)
+
+        val body = checkNotNull(capturedBody)
+        body.shouldContain("\"speed\":1.05")
+    }
+
+    @Test
     fun `request body sends voice_settings with speed and stability`() = runTest {
         // We override per-voice library defaults on every clip so the pacing
         // / stability tuning is consistent regardless of which voice the user

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Settings.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Settings.kt
@@ -169,6 +169,21 @@ data class UserPreferences(
      */
     val elevenLabsVoice: String = DEFAULT_ELEVENLABS_VOICE,
     /**
+     * ElevenLabs synthesis model ID (e.g. `eleven_turbo_v2_5`,
+     * `eleven_multilingual_v2`, `eleven_flash_v2_5`, `eleven_v3`). Stored
+     * as a free-form string so adding a new model doesn't need a domain
+     * enum migration. Only consulted when [ttsEngine] ==
+     * [TtsEngine.ELEVENLABS].
+     */
+    val elevenLabsModel: String = DEFAULT_ELEVENLABS_MODEL,
+    /**
+     * Per-clip ElevenLabs playback rate (multiplier, 0.7–1.2 per the
+     * documented range). Default 0.9 because field reports flagged the
+     * vendor's stock 1.0 as "too fast". Only consulted when [ttsEngine]
+     * == [TtsEngine.ELEVENLABS].
+     */
+    val elevenLabsSpeed: Double = DEFAULT_ELEVENLABS_SPEED,
+    /**
      * On-device TextToSpeech voice ID (e.g. "en-us-x-tpc-network"). Only
      * consulted when [ttsEngine] == [TtsEngine.DEVICE]. `null` (the default)
      * means "auto-pick the highest-quality voice for [voiceLocale]" — the
@@ -231,5 +246,15 @@ data class UserPreferences(
         const val DEFAULT_OPENAI_VOICE = "alloy"
         // Sarah — the most generally pleasant of ElevenLabs's stock library voices.
         const val DEFAULT_ELEVENLABS_VOICE = "EXAVITQu4vr4xnSDxMaL"
+        // Mirrors `core:data:ElevenLabsTtsClient.DEFAULT_ELEVENLABS_TTS_MODEL`
+        // — duplicated as a literal so domain stays Android- and data-layer-
+        // independent. Update both sides together if the default ever shifts.
+        const val DEFAULT_ELEVENLABS_MODEL = "eleven_turbo_v2_5"
+        // Playback-rate multiplier applied per request (clamped 0.7–1.2 by
+        // the picker UI; ElevenLabs documents the same range). Below 1.0 by
+        // default for clarity over expression on short briefings.
+        const val DEFAULT_ELEVENLABS_SPEED = 0.9
+        const val MIN_ELEVENLABS_SPEED = 0.7
+        const val MAX_ELEVENLABS_SPEED = 1.2
     }
 }


### PR DESCRIPTION
## Summary

Adds a **Refresh voices** button to the ElevenLabs block of Settings → Voice. Tapping it calls `GET /v1/voices` with the stored BYOK key and replaces the curated en-US library list in the picker with whatever the user's account exposes — ElevenLabs's premade library plus the user's own clones / generated voices. Closes the gap noted in the existing `TtsVoices.kt` comment ("Users with a paid plan can clone their own voice — they'd need to copy/paste the voice ID by hand, which we don't surface in v1").

## Behaviour

- Button only renders when an ElevenLabs key is configured (no key = guaranteed 401, so we hide it).
- Disabled while a refresh or voice preview is in flight — avoids stacking requests against the user's credit quota.
- Spinner replaces the label while the request is in flight.
- Caption under the picker after a successful refresh: "Showing N voices from your ElevenLabs account."
- HTTP failures (auth / quota / network) surface as a Toast carrying the ElevenLabs error envelope's `detail.message`, just like the existing TTS preview path.
- Successful refreshes live in the ViewModel for the session — no DataStore persistence in this PR. The selected voice ID is already persisted (so TTS keeps working across restarts); the picker just re-shows the curated fallback labels until the next tap. Deliberately minimal scope for a v1 — easy to add persistence later if users push for it.
- Empty refresh result (exotic account state) silently falls back to the curated list so the picker is never empty.

## Privacy

The refresh sends only the user's BYOK key (header `xi-api-key`) to `api.elevenlabs.io` and reads back voice IDs / names / labels. No insight prose, no calendar / location data crosses the device boundary on this path — broadening this would need a fresh privacy review per CLAUDE.md.

## Files

- `core/data` — adds `ElevenLabsTtsClient.listVoices()` plus a public `ElevenLabsVoiceSummary` projection; the wire DTOs stay `internal`. Three new client tests cover the success path, blank-key short-circuit, and HTTP error envelope.
- `app` — new state fields `elevenLabsRefreshedVoices` / `elevenLabsRefreshing`, a `refreshElevenLabsVoices()` ViewModel method, and the UI wiring. Two new VM tests cover the success and 401-error paths.

## Test plan

- [ ] CI: JVM unit tests + Android debug build (sandbox can't load AGP — relying on CI per CLAUDE.md)
- [ ] Manual: Settings → Voice → ElevenLabs with no key configured → Refresh button is **not** rendered
- [ ] Manual: configure a valid ElevenLabs key, tap Refresh → picker swaps to account voices, caption shows count
- [ ] Manual: configure an invalid key, tap Refresh → Toast surfaces "ElevenLabs TTS HTTP 401: Invalid API key" (or similar) and the picker stays on its previous list
- [ ] Manual: rapid double-tap Refresh → second tap is ignored while first is in flight
- [ ] Manual: tap Refresh while a Test Voice preview is playing → Refresh is disabled

https://claude.ai/code/session_01MCsktiSyv9fxPuSXnQGmEA

---
_Generated by [Claude Code](https://claude.ai/code/session_01MCsktiSyv9fxPuSXnQGmEA)_