### PR TITLE
:app + :core — OpenAI speed slider, ElevenLabs stability slider

### DIFF
--- a/app/src/main/kotlin/app/clothescast/data/SettingsRepository.kt
+++ b/app/src/main/kotlin/app/clothescast/data/SettingsRepository.kt
@@ -134,6 +134,16 @@ class SettingsRepository(
         dataStore.edit { it[OPENAI_VOICE] = voice }
     }
 
+    suspend fun setOpenAiSpeed(speed: Double) {
+        // Clamp on write so a misconfigured caller can't push out-of-range
+        // values into DataStore. Mirrors setElevenLabsSpeed.
+        val clamped = speed.coerceIn(
+            UserPreferences.MIN_OPENAI_SPEED,
+            UserPreferences.MAX_OPENAI_SPEED,
+        )
+        dataStore.edit { it[OPENAI_SPEED] = clamped }
+    }
+
     suspend fun setElevenLabsVoice(voice: String) {
         dataStore.edit { it[ELEVENLABS_VOICE] = voice }
     }
@@ -150,6 +160,14 @@ class SettingsRepository(
             UserPreferences.MAX_ELEVENLABS_SPEED,
         )
         dataStore.edit { it[ELEVENLABS_SPEED] = clamped }
+    }
+
+    suspend fun setElevenLabsStability(stability: Double) {
+        val clamped = stability.coerceIn(
+            UserPreferences.MIN_ELEVENLABS_STABILITY,
+            UserPreferences.MAX_ELEVENLABS_STABILITY,
+        )
+        dataStore.edit { it[ELEVENLABS_STABILITY] = clamped }
     }
 
     suspend fun setDeviceVoice(voice: String?) {
@@ -213,6 +231,14 @@ class SettingsRepository(
             UserPreferences.MIN_ELEVENLABS_SPEED,
             UserPreferences.MAX_ELEVENLABS_SPEED,
         ) ?: UserPreferences.DEFAULT_ELEVENLABS_SPEED
+        val elevenLabsStability = this[ELEVENLABS_STABILITY]?.coerceIn(
+            UserPreferences.MIN_ELEVENLABS_STABILITY,
+            UserPreferences.MAX_ELEVENLABS_STABILITY,
+        ) ?: UserPreferences.DEFAULT_ELEVENLABS_STABILITY
+        val openAiSpeed = this[OPENAI_SPEED]?.coerceIn(
+            UserPreferences.MIN_OPENAI_SPEED,
+            UserPreferences.MAX_OPENAI_SPEED,
+        ) ?: UserPreferences.DEFAULT_OPENAI_SPEED
         val deviceVoice = this[DEVICE_VOICE]?.takeIf { it.isNotBlank() }
         val useCalendarEvents = this[USE_CALENDAR_EVENTS] == true
         val tonightTime = this[TONIGHT_TIME]?.let { LocalTime.parse(it, TIME_FORMAT) }
@@ -241,9 +267,11 @@ class SettingsRepository(
             ttsEngine = ttsEngine,
             geminiVoice = geminiVoice,
             openAiVoice = openAiVoice,
+            openAiSpeed = openAiSpeed,
             elevenLabsVoice = elevenLabsVoice,
             elevenLabsModel = elevenLabsModel,
             elevenLabsSpeed = elevenLabsSpeed,
+            elevenLabsStability = elevenLabsStability,
             deviceVoice = deviceVoice,
             voiceLocale = voiceLocale,
             useCalendarEvents = useCalendarEvents,
@@ -298,6 +326,8 @@ class SettingsRepository(
         private val ELEVENLABS_VOICE = stringPreferencesKey("elevenlabs_voice")
         private val ELEVENLABS_MODEL = stringPreferencesKey("elevenlabs_model")
         private val ELEVENLABS_SPEED = doublePreferencesKey("elevenlabs_speed")
+        private val ELEVENLABS_STABILITY = doublePreferencesKey("elevenlabs_stability")
+        private val OPENAI_SPEED = doublePreferencesKey("openai_speed")
         private val DEVICE_VOICE = stringPreferencesKey("device_voice")
         private val VOICE_LOCALE = stringPreferencesKey("voice_locale")
         private val USE_CALENDAR_EVENTS = booleanPreferencesKey("use_calendar_events")

--- a/app/src/main/kotlin/app/clothescast/tts/ElevenLabsTtsSpeaker.kt
+++ b/app/src/main/kotlin/app/clothescast/tts/ElevenLabsTtsSpeaker.kt
@@ -2,6 +2,7 @@ package app.clothescast.tts
 
 import app.clothescast.core.data.tts.DEFAULT_ELEVENLABS_TTS_MODEL
 import app.clothescast.core.data.tts.DEFAULT_ELEVENLABS_TTS_SPEED
+import app.clothescast.core.data.tts.DEFAULT_ELEVENLABS_TTS_STABILITY
 import app.clothescast.core.data.tts.DEFAULT_ELEVENLABS_TTS_VOICE
 import app.clothescast.core.data.tts.ElevenLabsTtsClient
 import java.util.Locale
@@ -24,6 +25,7 @@ class ElevenLabsTtsSpeaker(
     private val voiceId: String = DEFAULT_ELEVENLABS_TTS_VOICE,
     private val model: String = DEFAULT_ELEVENLABS_TTS_MODEL,
     private val speed: Double = DEFAULT_ELEVENLABS_TTS_SPEED,
+    private val stability: Double = DEFAULT_ELEVENLABS_TTS_STABILITY,
 ) : TtsSpeaker {
 
     override suspend fun speak(text: String, locale: Locale) {
@@ -32,6 +34,7 @@ class ElevenLabsTtsSpeaker(
             voiceId = voiceId,
             model = model,
             speed = speed,
+            stability = stability,
         )
         PcmAudioPlayer.play(audio)
     }

--- a/app/src/main/kotlin/app/clothescast/tts/OpenAITtsSpeaker.kt
+++ b/app/src/main/kotlin/app/clothescast/tts/OpenAITtsSpeaker.kt
@@ -1,5 +1,6 @@
 package app.clothescast.tts
 
+import app.clothescast.core.data.tts.DEFAULT_OPENAI_TTS_SPEED
 import app.clothescast.core.data.tts.DEFAULT_OPENAI_TTS_VOICE
 import app.clothescast.core.data.tts.OpenAITtsClient
 import java.util.Locale
@@ -17,6 +18,7 @@ import java.util.Locale
 class OpenAITtsSpeaker(
     private val client: OpenAITtsClient,
     private val voice: String = DEFAULT_OPENAI_TTS_VOICE,
+    private val speed: Double = DEFAULT_OPENAI_TTS_SPEED,
 ) : TtsSpeaker {
 
     override suspend fun speak(text: String, locale: Locale) {
@@ -26,7 +28,7 @@ class OpenAITtsSpeaker(
         // Settings, not from anything we can send at synthesis time. So we drop
         // [locale] on the floor here, intentionally — see TtsVoices.kt for the
         // picker-side filter that surfaces the accent-appropriate voices.
-        val audio = client.synthesize(text = prepareForTts(text), voice = voice)
+        val audio = client.synthesize(text = prepareForTts(text), voice = voice, speed = speed)
         PcmAudioPlayer.play(audio)
     }
 }

--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsScreen.kt
@@ -150,11 +150,14 @@ fun SettingsScreen(
                 elevenLabsRefreshing = state.elevenLabsRefreshing,
                 elevenLabsModel = state.elevenLabsModel,
                 elevenLabsSpeed = state.elevenLabsSpeed,
+                elevenLabsStability = state.elevenLabsStability,
+                openAiSpeed = state.openAiSpeed,
                 voiceLocale = state.voiceLocale,
                 padding = padding,
                 onSetTtsEngine = viewModel::setTtsEngine,
                 onSetGeminiVoice = viewModel::setGeminiVoice,
                 onSetOpenAiVoice = viewModel::setOpenAiVoice,
+                onSetOpenAiSpeed = viewModel::setOpenAiSpeed,
                 onSetElevenLabsVoice = viewModel::setElevenLabsVoice,
                 onSetDeviceVoice = viewModel::setDeviceVoice,
                 onSetVoiceLocale = viewModel::setVoiceLocale,
@@ -167,6 +170,7 @@ fun SettingsScreen(
                 onRefreshElevenLabsVoices = viewModel::refreshElevenLabsVoices,
                 onSetElevenLabsModel = viewModel::setElevenLabsModel,
                 onSetElevenLabsSpeed = viewModel::setElevenLabsSpeed,
+                onSetElevenLabsStability = viewModel::setElevenLabsStability,
             )
             SettingsRoute.DataSources -> DataSourcesContent(
                 location = state.location,

--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsState.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsState.kt
@@ -46,9 +46,11 @@ data class SettingsState(
     // When voiceLocale is SYSTEM (the default), this resolves through the phone's
     // current locale → fable on en-GB, nova everywhere else.
     val openAiVoice: String = defaultOpenAiVoiceFor(VoiceLocale.SYSTEM),
+    val openAiSpeed: Double = UserPreferences.DEFAULT_OPENAI_SPEED,
     val elevenLabsVoice: String = UserPreferences.DEFAULT_ELEVENLABS_VOICE,
     val elevenLabsModel: String = UserPreferences.DEFAULT_ELEVENLABS_MODEL,
     val elevenLabsSpeed: Double = UserPreferences.DEFAULT_ELEVENLABS_SPEED,
+    val elevenLabsStability: Double = UserPreferences.DEFAULT_ELEVENLABS_STABILITY,
     /**
      * On-device voice ID the user has pinned, or `null` for "auto-pick the
      * highest-quality voice for [voiceLocale]" (the default for installs

--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsViewModel.kt
@@ -83,9 +83,11 @@ class SettingsViewModel(
                         ttsEngine = prefs.ttsEngine,
                         geminiVoice = prefs.geminiVoice,
                         openAiVoice = prefs.openAiVoice,
+                        openAiSpeed = prefs.openAiSpeed,
                         elevenLabsVoice = prefs.elevenLabsVoice,
                         elevenLabsModel = prefs.elevenLabsModel,
                         elevenLabsSpeed = prefs.elevenLabsSpeed,
+                        elevenLabsStability = prefs.elevenLabsStability,
                         deviceVoice = prefs.deviceVoice,
                         voiceLocale = prefs.voiceLocale,
                         useCalendarEvents = prefs.useCalendarEvents,
@@ -189,6 +191,10 @@ class SettingsViewModel(
         viewModelScope.launch { settingsRepository.setOpenAiVoice(voice) }
     }
 
+    fun setOpenAiSpeed(speed: Double) {
+        viewModelScope.launch { settingsRepository.setOpenAiSpeed(speed) }
+    }
+
     fun setElevenLabsVoice(voice: String) {
         viewModelScope.launch { settingsRepository.setElevenLabsVoice(voice) }
     }
@@ -199,6 +205,10 @@ class SettingsViewModel(
 
     fun setElevenLabsSpeed(speed: Double) {
         viewModelScope.launch { settingsRepository.setElevenLabsSpeed(speed) }
+    }
+
+    fun setElevenLabsStability(stability: Double) {
+        viewModelScope.launch { settingsRepository.setElevenLabsStability(stability) }
     }
 
     /**

--- a/app/src/main/kotlin/app/clothescast/ui/settings/VoiceSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/VoiceSettings.kt
@@ -85,11 +85,14 @@ internal fun VoiceContent(
     elevenLabsRefreshing: Boolean,
     elevenLabsModel: String,
     elevenLabsSpeed: Double,
+    elevenLabsStability: Double,
+    openAiSpeed: Double,
     voiceLocale: VoiceLocale,
     padding: PaddingValues,
     onSetTtsEngine: (TtsEngine) -> Unit,
     onSetGeminiVoice: (String) -> Unit,
     onSetOpenAiVoice: (String) -> Unit,
+    onSetOpenAiSpeed: (Double) -> Unit,
     onSetElevenLabsVoice: (String) -> Unit,
     onSetDeviceVoice: (String?) -> Unit,
     onSetVoiceLocale: (VoiceLocale) -> Unit,
@@ -102,6 +105,7 @@ internal fun VoiceContent(
     onRefreshElevenLabsVoices: () -> Unit,
     onSetElevenLabsModel: (String) -> Unit,
     onSetElevenLabsSpeed: (Double) -> Unit,
+    onSetElevenLabsStability: (Double) -> Unit,
 ) {
     val context = LocalContext.current
     val coroutineScope = rememberCoroutineScope()
@@ -119,17 +123,19 @@ internal fun VoiceContent(
         isPreviewing = true
         coroutineScope.launch {
             try {
-                // ElevenLabs model + speed are read off the latest props on
-                // every preview (rather than threaded through every caller)
-                // because they only matter for the one engine.
+                // Engine-specific tuning params are read off the latest props
+                // on every preview (rather than threaded through every
+                // caller) because each only matters for its one engine.
                 runTtsPreview(
                     context = context,
                     engine = engine,
                     geminiVoice = gVoice,
                     openAiVoice = oVoice,
+                    openAiSpeed = openAiSpeed,
                     elevenLabsVoice = eVoice,
                     elevenLabsModel = elevenLabsModel,
                     elevenLabsSpeed = elevenLabsSpeed,
+                    elevenLabsStability = elevenLabsStability,
                     deviceVoice = dVoice,
                     voiceLocale = locale,
                 )
@@ -234,6 +240,18 @@ internal fun VoiceContent(
                             preview(TtsEngine.OPENAI, geminiVoice, it, elevenLabsVoice, deviceVoice, voiceLocale)
                         },
                     )
+                    TtsParameterSlider(
+                        labelRes = R.string.settings_openai_speed_label,
+                        persistedValue = openAiSpeed,
+                        min = UserPreferences.MIN_OPENAI_SPEED,
+                        max = UserPreferences.MAX_OPENAI_SPEED,
+                        step = 0.05,
+                        enabled = !isPreviewing,
+                        onValueChangeFinished = { released ->
+                            onSetOpenAiSpeed(released)
+                            preview(TtsEngine.OPENAI, geminiVoice, openAiVoice, elevenLabsVoice, deviceVoice, voiceLocale)
+                        },
+                    )
                     TestVoiceButton(isPreviewing = isPreviewing) {
                         preview(selected, geminiVoice, openAiVoice, elevenLabsVoice, deviceVoice, voiceLocale)
                     }
@@ -323,8 +341,12 @@ internal fun VoiceContent(
                             preview(TtsEngine.ELEVENLABS, geminiVoice, openAiVoice, elevenLabsVoice, deviceVoice, voiceLocale)
                         },
                     )
-                    ElevenLabsSpeedSlider(
+                    TtsParameterSlider(
+                        labelRes = R.string.settings_elevenlabs_speed_label,
                         persistedValue = elevenLabsSpeed,
+                        min = UserPreferences.MIN_ELEVENLABS_SPEED,
+                        max = UserPreferences.MAX_ELEVENLABS_SPEED,
+                        step = 0.05,
                         enabled = !isPreviewing,
                         // Persist + preview on slider release only. Every
                         // drag tick would fire a DataStore write, a
@@ -333,6 +355,22 @@ internal fun VoiceContent(
                         // value in local Compose state until release.
                         onValueChangeFinished = { released ->
                             onSetElevenLabsSpeed(released)
+                            preview(TtsEngine.ELEVENLABS, geminiVoice, openAiVoice, elevenLabsVoice, deviceVoice, voiceLocale)
+                        },
+                    )
+                    TtsParameterSlider(
+                        labelRes = R.string.settings_elevenlabs_stability_label,
+                        persistedValue = elevenLabsStability,
+                        min = UserPreferences.MIN_ELEVENLABS_STABILITY,
+                        max = UserPreferences.MAX_ELEVENLABS_STABILITY,
+                        // 0.05 increments give 21 selectable values across
+                        // 0.0–1.0 — fine enough that the user can audition
+                        // "expressive" (≤0.4), "default" (~0.65), and
+                        // "steady" (≥0.85) without overwhelming the picker.
+                        step = 0.05,
+                        enabled = !isPreviewing,
+                        onValueChangeFinished = { released ->
+                            onSetElevenLabsStability(released)
                             preview(TtsEngine.ELEVENLABS, geminiVoice, openAiVoice, elevenLabsVoice, deviceVoice, voiceLocale)
                         },
                     )
@@ -601,11 +639,9 @@ private fun ElevenLabsModelPicker(
 }
 
 /**
- * Slider for the per-clip ElevenLabs playback rate (0.7×–1.2×, the
- * documented voice_settings.speed range). Steps in 0.05 increments — fine
- * enough to be expressive, coarse enough that one tap of the thumb makes a
- * clearly audible difference. The vendor's stock 1.0 is "too fast" by
- * field-report; we default to 0.9.
+ * Slider for a per-clip TTS tuning parameter (currently used for ElevenLabs
+ * speed + stability and OpenAI speed). [labelRes] takes one `%1$s` formatted
+ * placeholder for the live numeric value (e.g. "Speed × %1$s" → "Speed × 0.95").
  *
  * The dragged value is held in local Compose state — only on release does
  * [onValueChangeFinished] fire with the final value, which the caller
@@ -617,31 +653,37 @@ private fun ElevenLabsModelPicker(
  * thumb-following number isn't laggy.
  */
 @Composable
-private fun ElevenLabsSpeedSlider(
+private fun TtsParameterSlider(
+    @androidx.annotation.StringRes labelRes: Int,
     persistedValue: Double,
+    min: Double,
+    max: Double,
+    step: Double,
     onValueChangeFinished: (Double) -> Unit,
     enabled: Boolean = true,
 ) {
-    val min = UserPreferences.MIN_ELEVENLABS_SPEED.toFloat()
-    val max = UserPreferences.MAX_ELEVENLABS_SPEED.toFloat()
-    // (max - min) / 0.05 = 10 internal positions ⇒ 11 selectable values.
-    val steps = 9
+    val minF = min.toFloat()
+    val maxF = max.toFloat()
+    // Slider's `steps` is the count of positions *between* the endpoints, so
+    // an N-step range uses (N - 1) here. round() guards against the floating
+    // tail of e.g. (1.0 - 0.0) / 0.05 producing 19.999…
+    val steps = (((max - min) / step).let { Math.round(it).toInt() } - 1).coerceAtLeast(0)
     // `persistedValue` keys the remember so an external change (DataStore
     // emission landing after `onValueChangeFinished` persists, or a future
     // settings reset) overwrites the local-during-drag value.
     var draggedValue by remember(persistedValue) {
-        mutableStateOf(persistedValue.toFloat().coerceIn(min, max))
+        mutableStateOf(persistedValue.toFloat().coerceIn(minF, maxF))
     }
     val displayValue = String.format(Locale.US, "%.2f", draggedValue)
     Text(
-        text = stringResource(R.string.settings_elevenlabs_speed_label, displayValue),
+        text = stringResource(labelRes, displayValue),
         style = MaterialTheme.typography.titleSmall,
     )
     Slider(
         value = draggedValue,
         onValueChange = { draggedValue = it },
         onValueChangeFinished = { onValueChangeFinished(draggedValue.toDouble()) },
-        valueRange = min..max,
+        valueRange = minF..maxF,
         steps = steps,
         enabled = enabled,
         modifier = Modifier.fillMaxWidth(),
@@ -759,9 +801,11 @@ private suspend fun runTtsPreview(
     engine: TtsEngine,
     geminiVoice: String,
     openAiVoice: String,
+    openAiSpeed: Double,
     elevenLabsVoice: String,
     elevenLabsModel: String,
     elevenLabsSpeed: Double,
+    elevenLabsStability: Double,
     deviceVoice: String?,
     voiceLocale: VoiceLocale,
 ) {
@@ -782,13 +826,18 @@ private suspend fun runTtsPreview(
                     TtsEngine.GEMINI ->
                         GeminiTtsSpeaker(app.geminiTtsClient, voiceName = geminiVoice).speak(text, locale)
                     TtsEngine.OPENAI ->
-                        OpenAITtsSpeaker(app.openAiTtsClient, voice = openAiVoice).speak(text, locale)
+                        OpenAITtsSpeaker(
+                            client = app.openAiTtsClient,
+                            voice = openAiVoice,
+                            speed = openAiSpeed,
+                        ).speak(text, locale)
                     TtsEngine.ELEVENLABS ->
                         ElevenLabsTtsSpeaker(
                             client = app.elevenLabsTtsClient,
                             voiceId = elevenLabsVoice,
                             model = elevenLabsModel,
                             speed = elevenLabsSpeed,
+                            stability = elevenLabsStability,
                         ).speak(text, locale)
                     TtsEngine.DEVICE ->
                         app.deviceTtsSpeaker(deviceVoice).speak(text, locale)

--- a/app/src/main/kotlin/app/clothescast/ui/settings/VoiceSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/VoiceSettings.kt
@@ -118,24 +118,38 @@ internal fun VoiceContent(
     // atomic with respect to other UI events.
     var isPreviewing by remember { mutableStateOf(false) }
 
-    fun preview(engine: TtsEngine, gVoice: String, oVoice: String, eVoice: String, dVoice: String?, locale: VoiceLocale) {
+    // Slider / picker callbacks need to pass the just-released value into
+    // `preview` directly: `onSet…` writes asynchronously through DataStore →
+    // StateFlow, so the prop hasn't caught up yet when we kick off the
+    // preview. Defaulting each override to the current prop means callers
+    // that aren't changing that knob can keep passing positional args as
+    // before; callers that *are* changing it pass the released value.
+    fun preview(
+        engine: TtsEngine,
+        gVoice: String,
+        oVoice: String,
+        eVoice: String,
+        dVoice: String?,
+        locale: VoiceLocale,
+        oSpeed: Double = openAiSpeed,
+        eSpeed: Double = elevenLabsSpeed,
+        eStability: Double = elevenLabsStability,
+        eModel: String = elevenLabsModel,
+    ) {
         if (isPreviewing) return
         isPreviewing = true
         coroutineScope.launch {
             try {
-                // Engine-specific tuning params are read off the latest props
-                // on every preview (rather than threaded through every
-                // caller) because each only matters for its one engine.
                 runTtsPreview(
                     context = context,
                     engine = engine,
                     geminiVoice = gVoice,
                     openAiVoice = oVoice,
-                    openAiSpeed = openAiSpeed,
+                    openAiSpeed = oSpeed,
                     elevenLabsVoice = eVoice,
-                    elevenLabsModel = elevenLabsModel,
-                    elevenLabsSpeed = elevenLabsSpeed,
-                    elevenLabsStability = elevenLabsStability,
+                    elevenLabsModel = eModel,
+                    elevenLabsSpeed = eSpeed,
+                    elevenLabsStability = eStability,
                     deviceVoice = dVoice,
                     voiceLocale = locale,
                 )
@@ -249,7 +263,10 @@ internal fun VoiceContent(
                         enabled = !isPreviewing,
                         onValueChangeFinished = { released ->
                             onSetOpenAiSpeed(released)
-                            preview(TtsEngine.OPENAI, geminiVoice, openAiVoice, elevenLabsVoice, deviceVoice, voiceLocale)
+                            preview(
+                                TtsEngine.OPENAI, geminiVoice, openAiVoice, elevenLabsVoice, deviceVoice, voiceLocale,
+                                oSpeed = released,
+                            )
                         },
                     )
                     TestVoiceButton(isPreviewing = isPreviewing) {
@@ -336,9 +353,12 @@ internal fun VoiceContent(
                     ElevenLabsModelPicker(
                         selected = elevenLabsModel,
                         enabled = !isPreviewing,
-                        onSelect = {
-                            onSetElevenLabsModel(it)
-                            preview(TtsEngine.ELEVENLABS, geminiVoice, openAiVoice, elevenLabsVoice, deviceVoice, voiceLocale)
+                        onSelect = { picked ->
+                            onSetElevenLabsModel(picked)
+                            preview(
+                                TtsEngine.ELEVENLABS, geminiVoice, openAiVoice, elevenLabsVoice, deviceVoice, voiceLocale,
+                                eModel = picked,
+                            )
                         },
                     )
                     TtsParameterSlider(
@@ -355,7 +375,10 @@ internal fun VoiceContent(
                         // value in local Compose state until release.
                         onValueChangeFinished = { released ->
                             onSetElevenLabsSpeed(released)
-                            preview(TtsEngine.ELEVENLABS, geminiVoice, openAiVoice, elevenLabsVoice, deviceVoice, voiceLocale)
+                            preview(
+                                TtsEngine.ELEVENLABS, geminiVoice, openAiVoice, elevenLabsVoice, deviceVoice, voiceLocale,
+                                eSpeed = released,
+                            )
                         },
                     )
                     TtsParameterSlider(
@@ -371,7 +394,10 @@ internal fun VoiceContent(
                         enabled = !isPreviewing,
                         onValueChangeFinished = { released ->
                             onSetElevenLabsStability(released)
-                            preview(TtsEngine.ELEVENLABS, geminiVoice, openAiVoice, elevenLabsVoice, deviceVoice, voiceLocale)
+                            preview(
+                                TtsEngine.ELEVENLABS, geminiVoice, openAiVoice, elevenLabsVoice, deviceVoice, voiceLocale,
+                                eStability = released,
+                            )
                         },
                     )
                     TestVoiceButton(isPreviewing = isPreviewing) {

--- a/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
@@ -356,7 +356,11 @@ class FetchAndNotifyWorker(
                 }
                 TtsEngine.OPENAI -> {
                     try {
-                        OpenAITtsSpeaker(app.openAiTtsClient, voice = prefs.openAiVoice).speak(text, locale)
+                        OpenAITtsSpeaker(
+                            client = app.openAiTtsClient,
+                            voice = prefs.openAiVoice,
+                            speed = prefs.openAiSpeed,
+                        ).speak(text, locale)
                         return@withSpeechAudioFocus
                     } catch (t: Throwable) {
                         DiagLog.w(TAG, "OpenAI TTS failed; falling back to device TTS.", t)
@@ -369,6 +373,7 @@ class FetchAndNotifyWorker(
                             voiceId = prefs.elevenLabsVoice,
                             model = prefs.elevenLabsModel,
                             speed = prefs.elevenLabsSpeed,
+                            stability = prefs.elevenLabsStability,
                         ).speak(text, locale)
                         return@withSpeechAudioFocus
                     } catch (t: Throwable) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -238,6 +238,14 @@
     <!-- Heading above the speed slider; %1$s is the current value formatted
          as e.g. "0.90". -->
     <string name="settings_elevenlabs_speed_label">Speed × %1$s</string>
+    <!-- Heading above the stability slider; %1$s is the current value
+         formatted as e.g. "0.65". Higher = steadier pronunciation, lower =
+         more expressive. -->
+    <string name="settings_elevenlabs_stability_label">Stability %1$s</string>
+    <!-- Heading above the OpenAI speed slider; %1$s is the current value
+         formatted as e.g. "1.00". Mirrors the ElevenLabs speed slider for
+         consistency. -->
+    <string name="settings_openai_speed_label">Speed × %1$s</string>
 
     <string name="settings_region_language_title">Language</string>
     <!-- Caption rendered under the Region > Language title, pairing with

--- a/app/src/test/kotlin/app/clothescast/data/SettingsRepositoryTest.kt
+++ b/app/src/test/kotlin/app/clothescast/data/SettingsRepositoryTest.kt
@@ -317,6 +317,43 @@ class SettingsRepositoryTest {
     }
 
     @Test
+    fun `elevenLabs stability defaults to 0_65 and round-trips`() = runTest {
+        // Default mirrors the previously-hardcoded value in
+        // ElevenLabsTtsClient so existing installs hear no change after the
+        // slider lands.
+        subject.preferences.first().elevenLabsStability shouldBe 0.65
+
+        subject.setElevenLabsStability(0.4)
+        subject.preferences.first().elevenLabsStability shouldBe 0.4
+    }
+
+    @Test
+    fun `elevenLabs stability setter clamps to the documented 0 to 1 range`() = runTest {
+        subject.setElevenLabsStability(2.0)
+        subject.preferences.first().elevenLabsStability shouldBe 1.0
+
+        subject.setElevenLabsStability(-0.5)
+        subject.preferences.first().elevenLabsStability shouldBe 0.0
+    }
+
+    @Test
+    fun `openAi speed defaults to 1_0 and round-trips`() = runTest {
+        subject.preferences.first().openAiSpeed shouldBe 1.0
+
+        subject.setOpenAiSpeed(0.85)
+        subject.preferences.first().openAiSpeed shouldBe 0.85
+    }
+
+    @Test
+    fun `openAi speed setter clamps to the picker range`() = runTest {
+        subject.setOpenAiSpeed(2.0)
+        subject.preferences.first().openAiSpeed shouldBe 1.2
+
+        subject.setOpenAiSpeed(0.1)
+        subject.preferences.first().openAiSpeed shouldBe 0.7
+    }
+
+    @Test
     fun `openAiVoice defaults to nova for non-British locale preferences`() = runTest {
         subject.setVoiceLocale(VoiceLocale.EN_US)
         subject.preferences.first().openAiVoice shouldBe "nova"

--- a/core/data/src/main/kotlin/app/clothescast/core/data/tts/ElevenLabsTtsClient.kt
+++ b/core/data/src/main/kotlin/app/clothescast/core/data/tts/ElevenLabsTtsClient.kt
@@ -68,8 +68,9 @@ const val ELEVENLABS_MODEL_V3: String = "eleven_v3"
 const val DEFAULT_ELEVENLABS_TTS_SPEED: Double = 0.9
 
 // Above the stock 0.5 to favour pronunciation consistency over expression
-// for short weather briefings — drops fewer consonants.
-private const val DEFAULT_STABILITY = 0.65
+// for short weather briefings — drops fewer consonants. Mirrors
+// `core:domain:UserPreferences.DEFAULT_ELEVENLABS_STABILITY`.
+const val DEFAULT_ELEVENLABS_TTS_STABILITY: Double = 0.65
 
 /**
  * ElevenLabs TTS via `POST https://api.elevenlabs.io/v1/text-to-speech/{voice_id}`.
@@ -93,6 +94,7 @@ class ElevenLabsTtsClient(
         voiceId: String = DEFAULT_ELEVENLABS_TTS_VOICE,
         model: String = defaultModel,
         speed: Double = DEFAULT_ELEVENLABS_TTS_SPEED,
+        stability: Double = DEFAULT_ELEVENLABS_TTS_STABILITY,
     ): PcmAudio {
         val key = keyProvider.get().also {
             if (it.isBlank()) throw MissingApiKeyException("ElevenLabs")
@@ -117,7 +119,7 @@ class ElevenLabsTtsClient(
                     modelId = model,
                     voiceSettings = ElevenLabsVoiceSettings(
                         speed = speed,
-                        stability = DEFAULT_STABILITY,
+                        stability = stability,
                     ),
                 ),
             )

--- a/core/data/src/main/kotlin/app/clothescast/core/data/tts/OpenAITtsClient.kt
+++ b/core/data/src/main/kotlin/app/clothescast/core/data/tts/OpenAITtsClient.kt
@@ -36,6 +36,9 @@ import kotlinx.serialization.json.JsonPrimitive
 //     "clear and unrushed in any language" rather than accent-shaping.
 const val DEFAULT_OPENAI_TTS_MODEL: String = "gpt-4o-mini-tts"
 const val DEFAULT_OPENAI_TTS_VOICE: String = "alloy"
+// Mirrors `core:domain:UserPreferences.DEFAULT_OPENAI_SPEED` — the API's
+// stock 1.0× pace. Duplicated here so this layer can stay domain-free.
+const val DEFAULT_OPENAI_TTS_SPEED: Double = 1.0
 
 private const val PACE_AND_CLARITY_INSTRUCTIONS: String =
     "Speak clearly at a measured, conversational pace, enunciating each word."
@@ -59,6 +62,7 @@ class OpenAITtsClient(
     suspend fun synthesize(
         text: String,
         voice: String = DEFAULT_OPENAI_TTS_VOICE,
+        speed: Double = DEFAULT_OPENAI_TTS_SPEED,
     ): PcmAudio {
         val key = keyProvider.get().also {
             if (it.isBlank()) throw MissingApiKeyException("OpenAI")
@@ -74,6 +78,10 @@ class OpenAITtsClient(
                     voice = voice,
                     responseFormat = "pcm",
                     instructions = PACE_AND_CLARITY_INSTRUCTIONS,
+                    // Only send a non-default value to keep the request body
+                    // minimal and to avoid the (slim) chance that the field
+                    // changes the model's behaviour at exactly 1.0.
+                    speed = speed.takeIf { it != DEFAULT_OPENAI_TTS_SPEED },
                 ),
             )
         }

--- a/core/data/src/main/kotlin/app/clothescast/core/data/tts/OpenAITtsDto.kt
+++ b/core/data/src/main/kotlin/app/clothescast/core/data/tts/OpenAITtsDto.kt
@@ -25,4 +25,12 @@ internal data class OpenAISpeechRequest(
      * enunciation directives do land. Null when we have nothing to add.
      */
     val instructions: String? = null,
+    /**
+     * Playback-rate multiplier (0.25–4.0 per the API; we only expose
+     * 0.7–1.2 in the picker). Documented as supported on `tts-1` /
+     * `tts-1-hd`; on `gpt-4o-mini-tts` pace is primarily steered through
+     * [instructions] but the field is harmless when the model ignores it.
+     * Null leaves the API default (1.0) untouched.
+     */
+    val speed: Double? = null,
 )

--- a/core/data/src/test/kotlin/app/clothescast/core/data/tts/ElevenLabsTtsClientTest.kt
+++ b/core/data/src/test/kotlin/app/clothescast/core/data/tts/ElevenLabsTtsClientTest.kt
@@ -115,6 +115,20 @@ class ElevenLabsTtsClientTest {
     }
 
     @Test
+    fun `synthesize forwards a per-call stability override into voice_settings`() = runTest {
+        var capturedBody: String? = null
+        val client = ElevenLabsTtsClient(
+            httpClient = mockClient { capturedBody = capturedBodyOf(it) },
+            keyProvider = FakeKeyProvider("test-key"),
+        )
+
+        client.synthesize(text = "hello", stability = 0.4)
+
+        val body = checkNotNull(capturedBody)
+        body.shouldContain("\"stability\":0.4")
+    }
+
+    @Test
     fun `request body sends voice_settings with speed and stability`() = runTest {
         // We override per-voice library defaults on every clip so the pacing
         // / stability tuning is consistent regardless of which voice the user

--- a/core/data/src/test/kotlin/app/clothescast/core/data/tts/OpenAITtsClientTest.kt
+++ b/core/data/src/test/kotlin/app/clothescast/core/data/tts/OpenAITtsClientTest.kt
@@ -106,6 +106,38 @@ class OpenAITtsClientTest {
     }
 
     @Test
+    fun `synthesize forwards a per-call speed override`() = runTest {
+        var capturedBody: String? = null
+        val client = OpenAITtsClient(
+            httpClient = mockClient { capturedBody = capturedBodyOf(it) },
+            keyProvider = FakeKeyProvider("test-key"),
+        )
+
+        client.synthesize(text = "hello", speed = 0.85)
+
+        val body = checkNotNull(capturedBody)
+        body.shouldContain("\"speed\":0.85")
+    }
+
+    @Test
+    fun `synthesize omits the speed field at the API default`() = runTest {
+        // The default 1.0 is the API's stock pace; we leave the field off
+        // entirely rather than send a redundant value, both to keep the
+        // request body minimal and to avoid the (slim) chance the model
+        // changes behaviour at exactly 1.0.
+        var capturedBody: String? = null
+        val client = OpenAITtsClient(
+            httpClient = mockClient { capturedBody = capturedBodyOf(it) },
+            keyProvider = FakeKeyProvider("test-key"),
+        )
+
+        client.synthesize(text = "hello")
+
+        val body = checkNotNull(capturedBody)
+        check(!body.contains("\"speed\"")) { "expected no speed field at default; body was: $body" }
+    }
+
+    @Test
     fun `throws MissingApiKeyException when key is blank`() = runTest {
         val client = OpenAITtsClient(
             httpClient = mockClient(),

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Settings.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Settings.kt
@@ -175,6 +175,16 @@ data class UserPreferences(
      */
     val openAiVoice: String = DEFAULT_OPENAI_VOICE,
     /**
+     * Per-clip OpenAI playback rate (multiplier). Mirrors the ElevenLabs speed
+     * knob for consistency — same 0.7–1.2 range, same UI affordance. Sent as
+     * the `speed` field on the speech request. The active model
+     * (`gpt-4o-mini-tts`) currently steers pace primarily through the
+     * `instructions` field, but the wire parameter is harmless when ignored
+     * and forward-compatible with `tts-1` / `tts-1-hd`. Only consulted when
+     * [ttsEngine] == [TtsEngine.OPENAI].
+     */
+    val openAiSpeed: Double = DEFAULT_OPENAI_SPEED,
+    /**
      * ElevenLabs voice ID — the opaque library identifier (e.g.
      * "EXAVITQu4vr4xnSDxMaL" for Sarah). Only consulted when [ttsEngine]
      * == [TtsEngine.ELEVENLABS].
@@ -195,6 +205,13 @@ data class UserPreferences(
      * == [TtsEngine.ELEVENLABS].
      */
     val elevenLabsSpeed: Double = DEFAULT_ELEVENLABS_SPEED,
+    /**
+     * Per-clip ElevenLabs `voice_settings.stability` (0.0–1.0). Higher =
+     * steadier pronunciation, lower = more expressive. Default 0.65 favours
+     * pronunciation consistency over expression for short weather briefings.
+     * Only consulted when [ttsEngine] == [TtsEngine.ELEVENLABS].
+     */
+    val elevenLabsStability: Double = DEFAULT_ELEVENLABS_STABILITY,
     /**
      * On-device TextToSpeech voice ID (e.g. "en-us-x-tpc-network"). Only
      * consulted when [ttsEngine] == [TtsEngine.DEVICE]. `null` (the default)
@@ -268,5 +285,21 @@ data class UserPreferences(
         const val DEFAULT_ELEVENLABS_SPEED = 0.9
         const val MIN_ELEVENLABS_SPEED = 0.7
         const val MAX_ELEVENLABS_SPEED = 1.2
+        // Documented voice_settings.stability range is 0–1. Default mirrors
+        // the previously-hardcoded value in ElevenLabsTtsClient so existing
+        // installs hear no change after the slider lands.
+        const val DEFAULT_ELEVENLABS_STABILITY = 0.65
+        const val MIN_ELEVENLABS_STABILITY = 0.0
+        const val MAX_ELEVENLABS_STABILITY = 1.0
+
+        // Same range as ElevenLabs speed for UI parity. OpenAI's API
+        // accepts 0.25–4.0 but values outside ~0.7–1.2 sound robotic / silly
+        // for a weather briefing; matching the ElevenLabs slider keeps the
+        // UX consistent and prevents users from accidentally picking 4×.
+        // Default 1.0 because there are no field reports of OpenAI sounding
+        // "too fast" the way ElevenLabs has.
+        const val DEFAULT_OPENAI_SPEED = 1.0
+        const val MIN_OPENAI_SPEED = 0.7
+        const val MAX_OPENAI_SPEED = 1.2
     }
 }


### PR DESCRIPTION
## Summary

Cross-pollinate tuning knobs across cloud TTS providers so the Voice settings UX is consistent across engines:

- **OpenAI playback-rate slider** — parity with the existing ElevenLabs one, same 0.7–1.2 range, default 1.0× (the API's stock pace; no field reports of OpenAI sounding "too fast" the way ElevenLabs has).
- **ElevenLabs stability slider** — 0.0–1.0, default 0.65 (mirrors the previously-hardcoded value so existing installs hear no change). Higher = steadier pronunciation, lower = more expressive.
- **Refactor**: the existing `ElevenLabsSpeedSlider` becomes a generic `TtsParameterSlider`, since three callers now share the same dragged-then-released-then-preview mechanic.

Skipped (per discussion): Gemini speed via prompt directive, Gemini "works with all locales" hint, OpenAI `instructions` presets (TODO).

## Privacy

No change to what's sent off device — same providers, same endpoints, same BYOK keys. Only adds two existing-but-previously-fixed parameters to the request bodies (`speed` on OpenAI; user-controlled `stability` on ElevenLabs, replacing the hardcoded 0.65).

## Caveat — OpenAI speed on `gpt-4o-mini-tts`

`gpt-4o-mini-tts` documents pace steering through the `instructions` field rather than the wire `speed` parameter. We send both: `speed` so the slider has an effect on `tts-1` / `tts-1-hd` and is forward-compatible if mini-tts gains explicit speed support; the existing pace-and-clarity instruction still steers the current default model. Worth field-testing whether mini-tts audibly honours the wire speed at 0.7 vs 1.2 — if not, a follow-up could vary the `instructions` text by slider position.

## Test plan

- [ ] `:core:domain:test` (sandbox can't load AGP — relying on CI)
- [ ] CI: JVM unit tests pass (new SettingsRepository round-trip + clamp tests for `openAiSpeed`, `elevenLabsStability`; new wire-body assertions in `OpenAITtsClientTest` and `ElevenLabsTtsClientTest`)
- [ ] CI: Android debug build passes
- [ ] Manual: open Voice settings on each engine; confirm OpenAI now shows a speed slider, ElevenLabs shows speed + stability sliders, sliders preview on release, values persist across app restart
- [ ] Manual: confirm an ElevenLabs preview at stability 0.0 sounds noticeably more expressive than at 1.0 (sanity-check the param actually reaches the wire)

https://claude.ai/code/session_0165kNMwi2dJMLx9F6hsPT7s

---
_Generated by [Claude Code](https://claude.ai/code/session_0165kNMwi2dJMLx9F6hsPT7s)_