### PR TITLE
:app — tiered locale fallback in voice picker; caption when no exact match

### DIFF
--- a/app/src/main/kotlin/app/clothescast/tts/TtsVoices.kt
+++ b/app/src/main/kotlin/app/clothescast/tts/TtsVoices.kt
@@ -35,8 +35,7 @@ data class TtsVoiceOption(
  * so the picker is never empty *and* near-matches are preferred over a
  * language-mismatched dump:
  *
- *  1. **Exact**: voices whose [TtsVoiceOption.locale] matches [variant]
- *     (plus accent-agnostic voices, which always pass).
+ *  1. **Exact**: voices whose [TtsVoiceOption.locale] matches [variant].
  *  2. **Language**: if (1) is empty, voices whose locale shares the BCP-47
  *     language subtag with [variant] — e.g. an en-AU user with no AU voice
  *     in the list still gets the en-US + en-GB voices, not Japanese ones.
@@ -44,11 +43,18 @@ data class TtsVoiceOption(
  *     *some* picker. The UI surfaces a "try another accent" caption in this
  *     case via [localeFallbackTier].
  *
+ * Voices with a `null` locale are accent-agnostic (Gemini's prebuilt voices,
+ * or ElevenLabs voices whose `accent` label didn't parse): they always ride
+ * along with whichever tier wins, but they don't drive tier selection. This
+ * matters for refreshed ElevenLabs lists that mix known-accent voices with
+ * unparseable ones — without this distinction a single unknown-accent voice
+ * would suppress the language-fallback tier and hide the caption.
+ *
  * [VoiceLocale.SYSTEM] disables filtering — the user has not expressed a
  * preference, so show everything.
  *
  * If [keepSelected] is supplied and points to a voice in the receiver list
- * that doesn't match the filter tier, that voice is appended so the picker
+ * that doesn't match the chosen tier, that voice is appended so the picker
  * still shows the user's current selection. Without this, a user who'd
  * persisted `nova` and then switched the variant to en-GB would see a
  * picker label of "Voice: nova" with no `nova` row in the dialog —
@@ -60,12 +66,14 @@ fun List<TtsVoiceOption>.filterByVariant(
     keepSelected: String? = null,
 ): List<TtsVoiceOption> {
     if (variant == VoiceLocale.SYSTEM) return this
-    val exact = filter { it.locale == null || it.locale == variant }
-    if (exact.isNotEmpty()) return appendKeepSelected(exact, keepSelected)
+    val agnostic = filter { it.locale == null }
+    val withLocale = filter { it.locale != null }
+    val exact = withLocale.filter { it.locale == variant }
+    if (exact.isNotEmpty()) return appendKeepSelected(agnostic + exact, keepSelected)
     val variantLang = variant.languageSubtag()
     if (variantLang != null) {
-        val sameLanguage = filter { it.locale?.languageSubtag() == variantLang }
-        if (sameLanguage.isNotEmpty()) return appendKeepSelected(sameLanguage, keepSelected)
+        val sameLanguage = withLocale.filter { it.locale?.languageSubtag() == variantLang }
+        if (sameLanguage.isNotEmpty()) return appendKeepSelected(agnostic + sameLanguage, keepSelected)
     }
     return this
 }
@@ -74,9 +82,15 @@ fun List<TtsVoiceOption>.filterByVariant(
  * Which tier [filterByVariant] landed on for [variant]. The picker UI uses
  * this to caption the picker with the right explanation when we couldn't
  * give the user their exact accent.
+ *
+ * Tier detection considers only voices whose locale is known (non-null).
+ * An all-agnostic source — Gemini's prebuilt voices, or a refreshed
+ * ElevenLabs library where every voice's accent label was unparseable —
+ * is treated as Exact (no caption), since by construction we can't tell
+ * the user a more useful story than "showing everything".
  */
 enum class LocaleFallbackTier {
-    /** Engine has voices in this exact accent (or accent-agnostic). No caption needed. */
+    /** Engine has voices in this exact accent. No caption needed. */
     Exact,
 
     /** No exact-accent match, but at least one same-language voice exists. */
@@ -88,7 +102,13 @@ enum class LocaleFallbackTier {
 
 fun List<TtsVoiceOption>.localeFallbackTier(variant: VoiceLocale): LocaleFallbackTier {
     if (variant == VoiceLocale.SYSTEM) return LocaleFallbackTier.Exact
-    if (any { it.locale == null || it.locale == variant }) return LocaleFallbackTier.Exact
+    // All-agnostic (or empty) source: there's no accent claim to fall back
+    // *from*, so don't try to caption one. Gemini's voice list lands here
+    // by design; an ElevenLabs library where every voice failed accent-
+    // parsing also lands here, since we can't credibly say "no <locale>
+    // voices" when we don't know any voice's accent.
+    if (none { it.locale != null }) return LocaleFallbackTier.Exact
+    if (any { it.locale == variant }) return LocaleFallbackTier.Exact
     val variantLang = variant.languageSubtag() ?: return LocaleFallbackTier.FullList
     if (any { it.locale?.languageSubtag() == variantLang }) return LocaleFallbackTier.SameLanguage
     return LocaleFallbackTier.FullList

--- a/app/src/main/kotlin/app/clothescast/tts/TtsVoices.kt
+++ b/app/src/main/kotlin/app/clothescast/tts/TtsVoices.kt
@@ -31,31 +31,80 @@ data class TtsVoiceOption(
 )
 
 /**
- * Filters [voices] to the user's preferred [variant]. Falls back to the full
- * list when the filter would empty out — handing the user an empty picker is
- * worse than offering whatever voices we have, even if the accent doesn't match.
+ * Filters [voices] to the user's preferred [variant], with a tiered fallback
+ * so the picker is never empty *and* near-matches are preferred over a
+ * language-mismatched dump:
  *
- * Voices with a null [TtsVoiceOption.locale] are accent-agnostic and always
- * pass the filter. [VoiceLocale.SYSTEM] disables filtering — the user has not
- * expressed a preference, so show everything.
+ *  1. **Exact**: voices whose [TtsVoiceOption.locale] matches [variant]
+ *     (plus accent-agnostic voices, which always pass).
+ *  2. **Language**: if (1) is empty, voices whose locale shares the BCP-47
+ *     language subtag with [variant] — e.g. an en-AU user with no AU voice
+ *     in the list still gets the en-US + en-GB voices, not Japanese ones.
+ *  3. **Full list**: if (2) is also empty, return everything so the user has
+ *     *some* picker. The UI surfaces a "try another accent" caption in this
+ *     case via [localeFallbackTier].
+ *
+ * [VoiceLocale.SYSTEM] disables filtering — the user has not expressed a
+ * preference, so show everything.
  *
  * If [keepSelected] is supplied and points to a voice in the receiver list
- * that doesn't match the filter, that voice is appended so the picker still
- * shows the user's current selection. Without this, a user who'd persisted
- * `nova` and then switched the variant to en-GB would see a picker label of
- * "Voice: nova" with no `nova` row in the dialog — confusing UX. Pass `null`
- * (the default) when this preservation isn't needed.
+ * that doesn't match the filter tier, that voice is appended so the picker
+ * still shows the user's current selection. Without this, a user who'd
+ * persisted `nova` and then switched the variant to en-GB would see a
+ * picker label of "Voice: nova" with no `nova` row in the dialog —
+ * confusing UX. Pass `null` (the default) when this preservation isn't
+ * needed.
  */
 fun List<TtsVoiceOption>.filterByVariant(
     variant: VoiceLocale,
     keepSelected: String? = null,
 ): List<TtsVoiceOption> {
     if (variant == VoiceLocale.SYSTEM) return this
-    val matched = filter { it.locale == null || it.locale == variant }
-    if (matched.isEmpty()) return this
-    val selected = keepSelected?.let { id -> firstOrNull { it.id == id } }
+    val exact = filter { it.locale == null || it.locale == variant }
+    if (exact.isNotEmpty()) return appendKeepSelected(exact, keepSelected)
+    val variantLang = variant.languageSubtag()
+    if (variantLang != null) {
+        val sameLanguage = filter { it.locale?.languageSubtag() == variantLang }
+        if (sameLanguage.isNotEmpty()) return appendKeepSelected(sameLanguage, keepSelected)
+    }
+    return this
+}
+
+/**
+ * Which tier [filterByVariant] landed on for [variant]. The picker UI uses
+ * this to caption the picker with the right explanation when we couldn't
+ * give the user their exact accent.
+ */
+enum class LocaleFallbackTier {
+    /** Engine has voices in this exact accent (or accent-agnostic). No caption needed. */
+    Exact,
+
+    /** No exact-accent match, but at least one same-language voice exists. */
+    SameLanguage,
+
+    /** No same-language match either — picker is showing the full list. */
+    FullList,
+}
+
+fun List<TtsVoiceOption>.localeFallbackTier(variant: VoiceLocale): LocaleFallbackTier {
+    if (variant == VoiceLocale.SYSTEM) return LocaleFallbackTier.Exact
+    if (any { it.locale == null || it.locale == variant }) return LocaleFallbackTier.Exact
+    val variantLang = variant.languageSubtag() ?: return LocaleFallbackTier.FullList
+    if (any { it.locale?.languageSubtag() == variantLang }) return LocaleFallbackTier.SameLanguage
+    return LocaleFallbackTier.FullList
+}
+
+private fun List<TtsVoiceOption>.appendKeepSelected(
+    matched: List<TtsVoiceOption>,
+    keepSelectedId: String?,
+): List<TtsVoiceOption> {
+    val selected = keepSelectedId?.let { id -> firstOrNull { it.id == id } }
     return if (selected != null && selected !in matched) matched + selected else matched
 }
+
+// "en-GB" → "en"; "sr-Latn-RS" → "sr"; null → null. ICU/BCP-47 always puts
+// the language tag first.
+private fun VoiceLocale.languageSubtag(): String? = bcp47?.substringBefore('-')
 
 val GEMINI_VOICES: List<TtsVoiceOption> = listOf(
     TtsVoiceOption("Kore", "Kore — Firm"),

--- a/app/src/main/kotlin/app/clothescast/ui/settings/VoiceSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/VoiceSettings.kt
@@ -58,8 +58,10 @@ import app.clothescast.tts.GOOGLE_TTS_PACKAGE
 import app.clothescast.tts.GeminiTtsSpeaker
 import app.clothescast.tts.OPENAI_VOICES
 import app.clothescast.tts.OpenAITtsSpeaker
+import app.clothescast.tts.LocaleFallbackTier
 import app.clothescast.tts.TtsVoiceOption
 import app.clothescast.tts.filterByVariant
+import app.clothescast.tts.localeFallbackTier
 import app.clothescast.tts.resolve
 import app.clothescast.tts.withSpeechAudioFocus
 import java.text.Collator
@@ -254,6 +256,10 @@ internal fun VoiceContent(
                             preview(TtsEngine.OPENAI, geminiVoice, it, elevenLabsVoice, deviceVoice, voiceLocale)
                         },
                     )
+                    LocaleFallbackCaption(
+                        source = OPENAI_VOICES,
+                        voiceLocale = voiceLocale,
+                    )
                     TtsParameterSlider(
                         labelRes = R.string.settings_openai_speed_label,
                         persistedValue = openAiSpeed,
@@ -297,10 +303,11 @@ internal fun VoiceContent(
                     // raw voice ID). Empty refreshed list (exotic account
                     // state) silently falls back to the curated list so the
                     // picker is never empty.
-                    val pickerVoices = elevenLabsRefreshedVoices
+                    val elevenLabsSource = elevenLabsRefreshedVoices
                         ?.takeIf { it.isNotEmpty() }
-                        ?.filterByVariant(voiceLocale, keepSelected = elevenLabsVoice)
-                        ?: ELEVENLABS_VOICES.filterByVariant(voiceLocale, keepSelected = elevenLabsVoice)
+                        ?: ELEVENLABS_VOICES
+                    val pickerVoices = elevenLabsSource
+                        .filterByVariant(voiceLocale, keepSelected = elevenLabsVoice)
                     VoicePicker(
                         title = stringResource(R.string.settings_tts_voice_label),
                         voices = pickerVoices,
@@ -310,6 +317,10 @@ internal fun VoiceContent(
                             onSetElevenLabsVoice(it)
                             preview(TtsEngine.ELEVENLABS, geminiVoice, openAiVoice, it, deviceVoice, voiceLocale)
                         },
+                    )
+                    LocaleFallbackCaption(
+                        source = elevenLabsSource,
+                        voiceLocale = voiceLocale,
                     )
                     // Caption only when we actually rendered the refreshed
                     // list. An empty refresh result silently falls back to
@@ -781,6 +792,35 @@ private fun InstallGoogleTtsHint() {
     ) {
         Text(stringResource(R.string.settings_tts_install_google_button))
     }
+}
+
+/**
+ * Caption rendered under a cloud-engine voice picker when [filterByVariant]
+ * fell back from an exact-accent match — `filterByVariant` silently falls
+ * back to a same-language list (or the full list) so the picker is never
+ * empty, and without context that looks like the engine ignored the
+ * locale setting. The caption names the locale so the user knows the
+ * fallback was deliberate, and tells them whether the visible voices are
+ * a same-language near-match or just "everything we have, try another
+ * accent".
+ *
+ * Renders nothing when [voiceLocale] is [VoiceLocale.SYSTEM] (no
+ * preference expressed) or when at least one voice in [source] matches it.
+ */
+@Composable
+private fun LocaleFallbackCaption(source: List<TtsVoiceOption>, voiceLocale: VoiceLocale) {
+    val tier = source.localeFallbackTier(voiceLocale)
+    val captionRes = when (tier) {
+        LocaleFallbackTier.Exact -> return
+        LocaleFallbackTier.SameLanguage -> R.string.settings_tts_voice_locale_language_fallback
+        LocaleFallbackTier.FullList -> R.string.settings_tts_voice_locale_no_match
+    }
+    val localeLabel = stringResource(voiceLocaleLabel(voiceLocale))
+    Text(
+        text = stringResource(captionRes, localeLabel),
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
 }
 
 @Composable

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -250,6 +250,16 @@
          consistency. -->
     <string name="settings_openai_speed_label">Speed × %1$s</string>
 
+    <!-- Captions under the cloud voice pickers when the user's chosen voice
+         locale has no exact-accent match. %1$s is the human-readable locale
+         label (e.g. "English (Australia)", "Japanese (Japan)"). The
+         "language fallback" variant fires when there's at least one voice
+         in the same language but a different accent — e.g. en-AU user with
+         only en-US/en-GB voices. The "no match" variant fires when nothing
+         in this engine speaks the requested language at all. -->
+    <string name="settings_tts_voice_locale_language_fallback">No %1$s voices in this engine — showing voices in the same language.</string>
+    <string name="settings_tts_voice_locale_no_match">No %1$s voices in this engine — try another accent.</string>
+
     <string name="settings_region_language_title">Language</string>
     <!-- Caption rendered under the Region > Language title, pairing with
          settings_tts_voice_locale_description so the user can tell which knob

--- a/app/src/test/kotlin/app/clothescast/tts/TtsVoicesTest.kt
+++ b/app/src/test/kotlin/app/clothescast/tts/TtsVoicesTest.kt
@@ -38,6 +38,28 @@ class TtsVoicesTest {
     }
 
     @Test
+    fun `accent-agnostic voices ride along with the language-fallback tier`() {
+        // Mixed list (e.g. refreshed ElevenLabs library where one voice's
+        // accent label didn't parse → locale=null). en-AU user: the unknown-
+        // accent voice rides along with the same-language matches rather
+        // than being the *only* voice shown. Without this, a single
+        // unparseable voice would hide the en-* near-matches and leave the
+        // user with one weirdly-named voice and no caption.
+        val all = listOf(american, british, japanese, agnostic)
+        all.filterByVariant(VoiceLocale.EN_AU)
+            .shouldContainExactlyInAnyOrder(american, british, agnostic)
+    }
+
+    @Test
+    fun `accent-agnostic voices ride along with the full-list fallback tier`() {
+        // No "en" voice and a single null-locale voice. The agnostic voice
+        // still appears (it's part of `this` when we return the full list);
+        // the test mostly locks in that nothing magic happens here.
+        val all = listOf(japanese, agnostic)
+        all.filterByVariant(VoiceLocale.EN_AU) shouldBe all
+    }
+
+    @Test
     fun `falls back to the full list when nothing in the source speaks that language`() {
         // No "en" voice at all — showing the Japanese voice is the least bad
         // option. The picker UI surfaces a "try another accent" caption in
@@ -72,11 +94,30 @@ class TtsVoicesTest {
     }
 
     @Test
-    fun `localeFallbackTier treats accent-agnostic voices as exact matches`() {
-        // Gemini-style language-agnostic voices count as Exact for any
-        // variant — they always pass the filter.
+    fun `localeFallbackTier treats an all-agnostic source as Exact`() {
+        // Gemini's prebuilt voices are language-agnostic — there's no
+        // accent claim to fall back *from*, so the picker doesn't caption.
         val all = listOf(agnostic)
         all.localeFallbackTier(VoiceLocale.JA_JP) shouldBe LocaleFallbackTier.Exact
+    }
+
+    @Test
+    fun `localeFallbackTier ignores agnostic voices when other voices have known accents`() {
+        // Mixed list where the *known-accent* voices don't include en-AU:
+        // tier should be SameLanguage so the picker captions the fallback.
+        // Previously a single null-locale voice would have collapsed the
+        // detection to Exact and hidden the caption.
+        val all = listOf(american, british, japanese, agnostic)
+        all.localeFallbackTier(VoiceLocale.EN_AU) shouldBe LocaleFallbackTier.SameLanguage
+    }
+
+    @Test
+    fun `localeFallbackTier reports FullList on a mixed source with no language match`() {
+        // Same shape as above but the user's language isn't represented
+        // among the known-accent voices either. Caption should be the
+        // "try another accent" copy.
+        val all = listOf(japanese, agnostic)
+        all.localeFallbackTier(VoiceLocale.EN_AU) shouldBe LocaleFallbackTier.FullList
     }
 
     @Test

--- a/app/src/test/kotlin/app/clothescast/tts/TtsVoicesTest.kt
+++ b/app/src/test/kotlin/app/clothescast/tts/TtsVoicesTest.kt
@@ -11,6 +11,7 @@ class TtsVoicesTest {
     private val american = TtsVoiceOption("a", "Alice — US", VoiceLocale.EN_US)
     private val british = TtsVoiceOption("b", "Bob — UK", VoiceLocale.EN_GB)
     private val agnostic = TtsVoiceOption("c", "Cleo — any")
+    private val japanese = TtsVoiceOption("j", "Junko — JP", VoiceLocale.JA_JP)
 
     @Test
     fun `SYSTEM disables filtering`() {
@@ -26,11 +27,56 @@ class TtsVoicesTest {
     }
 
     @Test
-    fun `falls back to the full list when no voice matches the variant`() {
-        // No EN_AU voices in this list — better to show every voice (with the
-        // accent in the display name) than to leave the user with an empty picker.
-        val all = listOf(american, british)
+    fun `falls back to same-language voices when no exact accent matches`() {
+        // No EN_AU voice in the list, but both en-US and en-GB share the
+        // "en" language subtag with en-AU. Better to surface those near-
+        // matches than dump every voice — and certainly better than leaving
+        // the picker empty.
+        val all = listOf(american, british, japanese)
+        all.filterByVariant(VoiceLocale.EN_AU)
+            .shouldContainExactlyInAnyOrder(american, british)
+    }
+
+    @Test
+    fun `falls back to the full list when nothing in the source speaks that language`() {
+        // No "en" voice at all — showing the Japanese voice is the least bad
+        // option. The picker UI surfaces a "try another accent" caption in
+        // this case (see localeFallbackTier).
+        val all = listOf(japanese)
         all.filterByVariant(VoiceLocale.EN_AU) shouldBe all
+    }
+
+    @Test
+    fun `localeFallbackTier reports Exact when at least one voice matches`() {
+        val all = listOf(american, british)
+        all.localeFallbackTier(VoiceLocale.EN_GB) shouldBe LocaleFallbackTier.Exact
+    }
+
+    @Test
+    fun `localeFallbackTier reports SameLanguage on language-only fallback`() {
+        val all = listOf(american, british)
+        all.localeFallbackTier(VoiceLocale.EN_AU) shouldBe LocaleFallbackTier.SameLanguage
+    }
+
+    @Test
+    fun `localeFallbackTier reports FullList when no language match exists`() {
+        val all = listOf(japanese)
+        all.localeFallbackTier(VoiceLocale.EN_AU) shouldBe LocaleFallbackTier.FullList
+    }
+
+    @Test
+    fun `localeFallbackTier reports Exact for SYSTEM regardless of source`() {
+        // SYSTEM disables filtering, so there's no fallback caption to show.
+        val all = listOf(japanese)
+        all.localeFallbackTier(VoiceLocale.SYSTEM) shouldBe LocaleFallbackTier.Exact
+    }
+
+    @Test
+    fun `localeFallbackTier treats accent-agnostic voices as exact matches`() {
+        // Gemini-style language-agnostic voices count as Exact for any
+        // variant — they always pass the filter.
+        val all = listOf(agnostic)
+        all.localeFallbackTier(VoiceLocale.JA_JP) shouldBe LocaleFallbackTier.Exact
     }
 
     @Test
@@ -69,10 +115,22 @@ class TtsVoicesTest {
 
     @Test
     fun `keepSelected is ignored when the empty-filter fallback fires`() {
-        // No matches → fallback to full list (which already includes
-        // selected). keepSelected becomes a no-op rather than re-appending.
-        val all = listOf(american)
-        all.filterByVariant(VoiceLocale.EN_AU, keepSelected = "a") shouldBe all
+        // No "en" voice at all → tier=FullList, returns the source as-is
+        // (which already includes selected). keepSelected becomes a no-op
+        // rather than re-appending.
+        val all = listOf(japanese)
+        all.filterByVariant(VoiceLocale.EN_AU, keepSelected = "j") shouldBe all
+    }
+
+    @Test
+    fun `keepSelected appends a different-language voice on language-tier fallback`() {
+        // en-AU user with `j` (Japanese) persisted: tier resolves to
+        // SameLanguage, returning the en-* voices. keepSelected ensures the
+        // user's current pick still shows in the dialog so the button
+        // label doesn't fall back to a raw voice id.
+        val all = listOf(american, british, japanese)
+        all.filterByVariant(VoiceLocale.EN_AU, keepSelected = "j")
+            .shouldContainExactlyInAnyOrder(american, british, japanese)
     }
 
     @Test


### PR DESCRIPTION
## Summary

When the user picks a `voiceLocale` the engine has no exact-accent voice for, `filterByVariant` previously dumped the full list silently — which looked like the engine ignored the locale setting. Two changes:

1. **Tiered fallback** in `filterByVariant`:
   - **Exact** accent match (unchanged).
   - **Same-language** voices — e.g. an en-AU user with no AU voice in the list now gets en-US + en-GB voices, not the full multilingual dump.
   - **Full list** only when nothing in the same language exists either.

2. **Caption** under the voice picker explaining what just happened:
   - SameLanguage: *"No English (Australia) voices in this engine — showing voices in the same language."*
   - FullList: *"No Japanese (Japan) voices in this engine — try another accent."*
   - Exact: no caption (current behaviour).

A new `localeFallbackTier` helper exposes which tier was hit so the caption picks the right copy. ElevenLabs uses the same caption against whichever source list drove the picker — refreshed library if non-empty, curated fallback otherwise — so a user whose actual library has no Japanese voices sees the caption keyed off their library, not the unrelated curated list.

## Privacy

No change to what's sent off device. Same providers, same endpoints. Pure UI / picker-side filter behaviour.

## Test plan

- [ ] `:app:testDebugUnitTest` passes (rewrote one existing test, added six new ones in `TtsVoicesTest`)
- [ ] CI: JVM unit tests + Android debug build pass
- [ ] Manual: switch voice locale to en-AU on OpenAI → see caption "showing voices in the same language", picker shows alloy/echo/fable/nova/onyx/shimmer (en-US + en-GB)
- [ ] Manual: switch voice locale to ja-JP on OpenAI → see caption "try another accent", picker shows the full list
- [ ] Manual: en-US (exact match) shows no caption

https://claude.ai/code/session_0165kNMwi2dJMLx9F6hsPT7s

---
_Generated by [Claude Code](https://claude.ai/code/session_0165kNMwi2dJMLx9F6hsPT7s)_