### PR TITLE
:ci — Play upload as draft while listing is in review

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -510,10 +510,15 @@ jobs:
           packageName: app.clothescast
           releaseFiles: app/build/outputs/bundle/release/app-release.aab
           track: internal
-          # `completed` makes the build immediately available to internal
-          # testers; `draft` would require a manual click in Play Console for
-          # every push.
-          status: completed
+          # TEMPORARY: `draft` while the app's first Play Console review is
+          # pending — the API rejects `completed` releases on a draft app
+          # ("Only releases with status draft may be created on draft app"),
+          # which fails CI on every push to main. With `draft`, the AAB still
+          # uploads to the internal track; activating it requires one click on
+          # the "Release to internal testing" button in Play Console per push.
+          # Switch back to `completed` once Google approves the listing and
+          # the app is no longer in Draft state.
+          status: draft
           whatsNewDirectory: ${{ runner.temp }}/whatsnew
 
       - name: Clear prior CI comments for this job


### PR DESCRIPTION
## Summary

Run [25125827910](https://github.com/mikelward/clothescast/actions/runs/25125827910) failed on push to `main` (`a7b8b17`). The "Android debug build" job's final step — *Upload AAB to Play Store internal track* — failed with:

> Only releases with status draft may be created on draft app.

The build itself (`assembleDebug`, `bundleRelease`, Firebase App Distribution) all succeeded; only the Play upload step failed, but it failed the whole job (the JVM-tests job stayed green).

## Cause

The Play Console listing is still in **Draft** state — Google's first review is still pending. The Play Developer API refuses to create a `status: completed` release while the app is in Draft, even on the internal track. The previous "live" claim in `cfa0445` evidently rested on an earlier window where the listing had briefly cleared draft, or on the manual upload only.

## Fix

Switch `status: completed` → `status: draft` in `.github/workflows/ci.yml`. With `draft`, the AAB still uploads to the internal testing track; activating the release for testers takes one manual click on **"Release to internal testing"** in Play Console per push.

This is **temporary** — switch back to `completed` once Google approves the listing and the app exits Draft. The comment in the workflow flags this clearly so it doesn't get stranded as the new normal.

## Privacy

No change to what we send off device. Workflow only.

## Test plan

- [ ] Merge to `main` and verify the next push succeeds end-to-end (debug APK + release AAB upload to Play internal track as a draft release).
- [ ] Click "Release to internal testing" in Play Console once to activate the draft release for testers.
- [ ] Once review completes and the app moves out of Draft state, open a follow-up PR reverting `status: draft` → `status: completed`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LQKBYrguSeR1Exr5ofCGkD)_