### PR TITLE
address outstanding review comments on recently merged PRs (#249, #250, #253, #255, #257, #258, #260, #261)

### DIFF
--- a/app/src/main/kotlin/app/clothescast/MainActivity.kt
+++ b/app/src/main/kotlin/app/clothescast/MainActivity.kt
@@ -38,14 +38,20 @@ import kotlinx.coroutines.runBlocking
 private enum class Screen { Today, Settings, Onboarding, Pairing }
 
 class MainActivity : ComponentActivity() {
-    // Incremented each time a notification tap arrives via onNewIntent while the
-    // activity is already running. ClothesCastNav observes this counter and snaps
-    // back to Today whenever it ticks — so e.g. a Settings-screen user who taps the
-    // morning notification lands on Today, not the Settings screen they left open.
+    // Incremented every time a notification tap delivers EXTRA_NAVIGATE_TO_TODAY —
+    // both via onNewIntent (activity already running) and via the launching intent
+    // in onCreate (cold start / activity recreated after process death, where
+    // rememberSaveable would otherwise restore the previously-saved screen, e.g.
+    // Settings). ClothesCastNav observes this counter and snaps back to Today
+    // whenever it ticks, so a notification tap reliably lands the user on Today
+    // regardless of cold/warm start.
     private var navigateToTodayVersion by mutableIntStateOf(0)
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        if (intent?.getBooleanExtra(EXTRA_NAVIGATE_TO_TODAY, false) == true) {
+            navigateToTodayVersion++
+        }
         val app = application as ClothesCastApplication
         setContent {
             ClothesCastTheme {

--- a/app/src/main/kotlin/app/clothescast/notification/InsightNotifier.kt
+++ b/app/src/main/kotlin/app/clothescast/notification/InsightNotifier.kt
@@ -64,8 +64,8 @@ class InsightNotifier(private val context: Context) {
         // notification shade already says "sweater day" / "jacket day" before the
         // user reads anything. ic_notification_insight is itself a t-shirt silhouette,
         // so it doubles as both the TSHIRT icon and the null fallback (older cached
-        // insights without an outfit). Each variant is an explicit branch so adding a
-        // new Top to the enum is a compile error here, not a silent fall-through.
+        // insights without an outfit). Each variant gets its own explicit branch so
+        // the mapping is easy to scan and the t-shirt-vs-null sharing is obvious.
         internal fun smallIconFor(top: OutfitSuggestion.Top?): Int = when (top) {
             OutfitSuggestion.Top.SWEATER -> R.drawable.ic_notification_top_sweater
             OutfitSuggestion.Top.THICK_JACKET -> R.drawable.ic_notification_top_thick_jacket

--- a/app/src/main/kotlin/app/clothescast/tts/TtsVoices.kt
+++ b/app/src/main/kotlin/app/clothescast/tts/TtsVoices.kt
@@ -294,4 +294,6 @@ private val ACCENT_TO_VOICE_LOCALE: Map<String, VoiceLocale> = mapOf(
     "hebrew" to VoiceLocale.HE_IL,
     "persian" to VoiceLocale.FA_IR,
     "amharic" to VoiceLocale.AM_ET,
+    "swahili" to VoiceLocale.SW_KE,
+    "kiswahili" to VoiceLocale.SW_KE,
 )

--- a/app/src/main/kotlin/app/clothescast/ui/settings/DataSourcesSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/DataSourcesSettings.kt
@@ -263,7 +263,15 @@ private fun DeviceLocationToggleRow(
             confirmButton = {
                 TextButton(onClick = {
                     backgroundRationaleOpen = false
-                    openAppDetails(context)
+                    // On Android 10 (API 29), ACCESS_BACKGROUND_LOCATION is grantable
+                    // through the inline runtime-permission prompt; only API 30+
+                    // forces the system Settings deep-link. Match the platform
+                    // affordance instead of always sending the user to Settings.
+                    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R) {
+                        openAppDetails(context)
+                    } else {
+                        backgroundLauncher.launch(android.Manifest.permission.ACCESS_BACKGROUND_LOCATION)
+                    }
                 }) { Text(stringResource(R.string.settings_location_background_rationale_continue)) }
             },
             dismissButton = {

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -12,6 +12,7 @@ surfaces fall back to default English (matching values-pl / values-uk).
     <string name="settings_tts_voice_locale_system">Следвай езиковата настройка</string>
 
     <string name="garment_sweater">Пуловер</string>
+    <string name="garment_hoodie">Суитчър с качулка</string>
     <string name="garment_jacket">Яке</string>
     <string name="garment_coat">Палто</string>
     <string name="garment_tshirt">Тениска</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -10,6 +10,7 @@ editor, outfit-card labels, and region/voice-locale picker names.
     <string name="settings_tts_voice_locale_system">Følg sprogindstilling</string>
 
     <string name="garment_sweater">Sweater</string>
+    <string name="garment_hoodie">Hættetrøje</string>
     <string name="garment_jacket">Jakke</string>
     <string name="garment_coat">Frakke</string>
     <string name="garment_tshirt">T-shirt</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -565,12 +565,12 @@ displayed label localizes.
     <string name="today_rationale_threshold_increase">임계값 1도 높이기</string>
     <string name="today_rationale_threshold_changed_hint">새 의상을 보려면 새로고침하세요.</string>
     <string name="today_rationale_unavailable">사용 가능한 근거가 없습니다 — 다음 새로고침 후 앱을 열어보세요.</string>
-    <string name="today_rationale_min_below_with_time">체감 최저 %1$s%2$s(%3$s시), %4$s%2$s 미만</string>
+    <string name="today_rationale_min_below_with_time">체감 최저 %1$s%2$s(%3$s), %4$s%2$s 미만</string>
     <string name="today_rationale_min_below">체감 최저 %1$s%2$s, %3$s%2$s 미만</string>
-    <string name="today_rationale_min_above_with_time">체감 최저 %1$s%2$s(%3$s시), 최소 %4$s%2$s</string>
+    <string name="today_rationale_min_above_with_time">체감 최저 %1$s%2$s(%3$s), 최소 %4$s%2$s</string>
     <string name="today_rationale_min_above">체감 최저 %1$s%2$s, 최소 %3$s%2$s</string>
-    <string name="today_rationale_max_below_with_time">체감 최고 %1$s%2$s(%3$s시)에 불과, %4$s%2$s 미만</string>
+    <string name="today_rationale_max_below_with_time">체감 최고 %1$s%2$s(%3$s)에 불과, %4$s%2$s 미만</string>
     <string name="today_rationale_max_below">체감 최고 %1$s%2$s에 불과, %3$s%2$s 미만</string>
-    <string name="today_rationale_max_above_with_time">체감 최고 %1$s%2$s(%3$s시), 최소 %4$s%2$s</string>
+    <string name="today_rationale_max_above_with_time">체감 최고 %1$s%2$s(%3$s), 최소 %4$s%2$s</string>
     <string name="today_rationale_max_above">체감 최고 %1$s%2$s, 최소 %3$s%2$s</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -10,6 +10,7 @@ editor, outfit-card labels, and region/voice-locale picker names.
     <string name="settings_tts_voice_locale_system">Taalinstelling volgen</string>
 
     <string name="garment_sweater">Trui</string>
+    <string name="garment_hoodie">Hoodie</string>
     <string name="garment_jacket">Jas</string>
     <string name="garment_coat">Winterjas</string>
     <string name="garment_tshirt">T-shirt</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -563,12 +563,12 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="today_rationale_threshold_increase">Aumentar limite em 1 grau</string>
     <string name="today_rationale_threshold_changed_hint">Atualize para ver a nova roupa.</string>
     <string name="today_rationale_unavailable">Nenhuma justificativa disponível — abra o app após a próxima atualização.</string>
-    <string name="today_rationale_min_below_with_time">Sensação mínima de %1$s%2$s às %3$sh, abaixo de %4$s%2$s</string>
+    <string name="today_rationale_min_below_with_time">Sensação mínima de %1$s%2$s às %3$s, abaixo de %4$s%2$s</string>
     <string name="today_rationale_min_below">Sensação mínima de %1$s%2$s, abaixo de %3$s%2$s</string>
-    <string name="today_rationale_min_above_with_time">Sensação mínima de %1$s%2$s às %3$sh, pelo menos %4$s%2$s</string>
+    <string name="today_rationale_min_above_with_time">Sensação mínima de %1$s%2$s às %3$s, pelo menos %4$s%2$s</string>
     <string name="today_rationale_min_above">Sensação mínima de %1$s%2$s, pelo menos %3$s%2$s</string>
-    <string name="today_rationale_max_below_with_time">Sensação máxima de apenas %1$s%2$s às %3$sh, abaixo de %4$s%2$s</string>
+    <string name="today_rationale_max_below_with_time">Sensação máxima de apenas %1$s%2$s às %3$s, abaixo de %4$s%2$s</string>
     <string name="today_rationale_max_below">Sensação máxima de apenas %1$s%2$s, abaixo de %3$s%2$s</string>
-    <string name="today_rationale_max_above_with_time">Sensação máxima de %1$s%2$s às %3$sh, pelo menos %4$s%2$s</string>
+    <string name="today_rationale_max_above_with_time">Sensação máxima de %1$s%2$s às %3$s, pelo menos %4$s%2$s</string>
     <string name="today_rationale_max_above">Sensação máxima de %1$s%2$s, pelo menos %3$s%2$s</string>
 </resources>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -12,6 +12,7 @@ surfaces fall back to default English (matching values-pl / values-uk).
     <string name="settings_tts_voice_locale_system">Urmează setarea limbii</string>
 
     <string name="garment_sweater">Pulover</string>
+    <string name="garment_hoodie">Hanorac</string>
     <string name="garment_jacket">Geacă</string>
     <string name="garment_coat">Palton</string>
     <string name="garment_tshirt">Tricou</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -10,6 +10,7 @@ editor, outfit-card labels, and region/voice-locale picker names.
     <string name="settings_tts_voice_locale_system">За налаштуванням мови</string>
 
     <string name="garment_sweater">Светр</string>
+    <string name="garment_hoodie">Худі</string>
     <string name="garment_jacket">Куртка</string>
     <string name="garment_coat">Пальто</string>
     <string name="garment_tshirt">Футболка</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -553,12 +553,12 @@ label localizes.
     <string name="today_rationale_threshold_increase">将阈值提高 1 度</string>
     <string name="today_rationale_threshold_changed_hint">刷新以查看新穿搭。</string>
     <string name="today_rationale_unavailable">暂无说明 — 下次刷新后打开应用查看。</string>
-    <string name="today_rationale_min_below_with_time">体感最低气温 %1$s%2$s（%3$s点），低于 %4$s%2$s</string>
+    <string name="today_rationale_min_below_with_time">体感最低气温 %1$s%2$s（%3$s），低于 %4$s%2$s</string>
     <string name="today_rationale_min_below">体感最低气温 %1$s%2$s，低于 %3$s%2$s</string>
-    <string name="today_rationale_min_above_with_time">体感最低气温 %1$s%2$s（%3$s点），至少 %4$s%2$s</string>
+    <string name="today_rationale_min_above_with_time">体感最低气温 %1$s%2$s（%3$s），至少 %4$s%2$s</string>
     <string name="today_rationale_min_above">体感最低气温 %1$s%2$s，至少 %3$s%2$s</string>
-    <string name="today_rationale_max_below_with_time">体感最高气温仅 %1$s%2$s（%3$s点），低于 %4$s%2$s</string>
+    <string name="today_rationale_max_below_with_time">体感最高气温仅 %1$s%2$s（%3$s），低于 %4$s%2$s</string>
     <string name="today_rationale_max_below">体感最高气温仅 %1$s%2$s，低于 %3$s%2$s</string>
-    <string name="today_rationale_max_above_with_time">体感最高气温 %1$s%2$s（%3$s点），至少 %4$s%2$s</string>
+    <string name="today_rationale_max_above_with_time">体感最高气温 %1$s%2$s（%3$s），至少 %4$s%2$s</string>
     <string name="today_rationale_max_above">体感最高气温 %1$s%2$s，至少 %3$s%2$s</string>
 </resources>

--- a/app/src/main/res/xml/locales_config.xml
+++ b/app/src/main/res/xml/locales_config.xml
@@ -8,6 +8,12 @@
     the user picks a Region whose language differs from their device locale
     (e.g. device=en-GB, Region=DE_AT → prose renders in English).
 
+    Note: this list uses canonical BCP-47 language tags (id, he), while the
+    matching Android resource directories still use the legacy ISO-639-1
+    codes the framework froze in 1989 — values-in/ for Indonesian and
+    values-iw/ for Hebrew. The runtime resource resolver maps the canonical
+    tag here to the legacy directory automatically.
+
     This file also enables per-app language preferences in system Settings
     on Android 13+ (users can override the app's display language
     independently of the system locale).

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsight.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsight.kt
@@ -163,9 +163,13 @@ class GenerateDailyInsight(
  *  - rewrites [DailyForecast.condition] to the wettest in-window hour (preventing
  *    the precip-peak fallback from naming a midday rain on a sunny afternoon),
  *  - falls back to the day-level aggregates with an empty hourly list when the
- *    slice would be empty (sparse fixtures, legacy day-level-only payloads, or
- *    a degenerate `morningStart >= eveningEnd` window) so the pipeline always
- *    emits something even without in-window hourly data.
+ *    slice would be empty for an otherwise valid window (sparse fixtures or
+ *    legacy day-level-only payloads), so the pipeline always emits something
+ *    even without in-window hourly data,
+ *  - returns the original [DailyForecast] unchanged on a degenerate
+ *    `morningStart >= eveningEnd` window — the tonight pass covers overnight
+ *    users via its own wrap, so blanking out the hourly here would just lose
+ *    information the tonight slice still needs.
  */
 private fun DailyForecast.slicedForToday(
     morningStart: LocalTime,

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/RenderInsightSummary.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/RenderInsightSummary.kt
@@ -17,6 +17,7 @@ import app.clothescast.core.domain.model.TemperatureBand
 import app.clothescast.core.domain.model.WeatherAlert
 import app.clothescast.core.domain.model.WeatherCondition
 import java.time.LocalTime
+import java.util.Locale
 import kotlin.math.abs
 import kotlin.math.roundToInt
 
@@ -200,10 +201,12 @@ class RenderInsightSummary {
     /**
      * Evening-event tie-in for the morning insight. Only emits on [ForecastPeriod.TODAY]
      * — the tonight pass already covers evening events via [calendarTieInClause].
-     * Picks the first evening event with a known start time and pairs it with the
-     * first clothes item triggered by the evening forecast slice (umbrella first if
-     * present). Caller is responsible for filtering [eveningEvents] to actually-evening
-     * events and for evaluating clothes rules against the evening forecast.
+     * Pairs the evening forecast slice with the first triggered clothes item (umbrella
+     * first if present) and the evening precip-peak time, gated on the existence of at
+     * least one located evening event. Caller is responsible for filtering [eveningEvents]
+     * to actually-evening events and for evaluating clothes rules against the evening
+     * forecast. Calendar event titles, locations, and start times are never captured
+     * into the returned clause.
      *
      * Suppressed when:
      *  - No evening event has a location (location-less events don't imply outdoor
@@ -229,7 +232,11 @@ class RenderInsightSummary {
         val items = eveningTriggeredRules.map { it.item }
         // If the evening clothes are a subset of (or equal to) today's clothes,
         // the morning insight already covered every item — no new information to add.
-        if (todayItems.toSet().containsAll(items.toSet())) return null
+        // Compare normalized (trim + lowercase) so legacy free-form ClothesRule.item
+        // values don't fail to suppress on a casing/whitespace mismatch ("Jacket" vs
+        // "jacket"); matches the case-insensitive umbrella check below.
+        val normalize: (String) -> String = { it.trim().lowercase(Locale.ROOT) }
+        if (todayItems.map(normalize).toSet().containsAll(items.map(normalize).toSet())) return null
         val item = items.firstOrNull { it.equals("umbrella", ignoreCase = true) } ?: items.first()
         return EveningEventTieInClause(item = item, rainTime = eveningPeak?.time)
     }


### PR DESCRIPTION
## Summary

Sweeps through unresolved review comments on the eight most recently merged PRs and addresses each one with a targeted commit. Each commit references the PR whose review thread it answers.

| Commit | Addresses | What |
| --- | --- | --- |
| `:app — drop hardcoded hour suffix from zh-rCN/ko/pt-rBR threshold rationales` | #261 | `%3$s` is a localised SHORT time; appending `点`/`시`/`h` produced `15:30点` etc. |
| `:core:domain — make evening tie-in subset check case-insensitive` | #260 | `containsAll` was case-sensitive on free-form `ClothesRule.item`; mismatched suppression on "Jacket" vs "jacket". KDoc rewritten to match implementation. |
| `:app — consume EXTRA_NAVIGATE_TO_TODAY on cold start as well as onNewIntent` | #258 | After process death, `rememberSaveable` restored Settings; `onNewIntent` never ran so the notification-tap intent extra was ignored. Also softens a misleading comment about `when`-exhaustiveness. |
| `:app — restore garment_hoodie translations in nl, da, bg, uk, ro` | #255 | PR #255 accidentally dropped the key, leaving five locales with mixed-language garment lists. |
| `:app — clarify locales_config in/iw legacy mapping in header comment` | #257 | Documents the BCP-47 → legacy ISO-639-1 mapping (id↔in, he↔iw) so the next editor doesn't "fix" the canonical tags. |
| `:core:domain — split slicedForToday KDoc into empty-slice vs degenerate-window` | #253 | Doc now reflects that the degenerate-window branch returns `this` unchanged; only the empty-slice-with-valid-window branch returns `copy(hourly = sliced)`. |
| `:app — show inline background-location prompt on Android 10` | #250 | API 29 supports the inline launcher; only API 30+ forces the Settings deep-link. Matches the comment over `backgroundLauncher`. |
| `:app — recognise "swahili" / "kiswahili" as ElevenLabs accent labels` | #249 | `VoiceLocale.SW_KE` was wired up but not added to `ACCENT_TO_VOICE_LOCALE`, so refreshed ElevenLabs voices labelled "swahili" weren't classified. |

## Notes

- All eight fixes are independent — happy to split into stacked PRs if reviewers want one concern per PR (per CLAUDE.md). They're grouped here because each one is a small follow-up to a comment, and grouping keeps the rebase pain low.
- No new dependencies, no resource adds beyond restoring previously-translated strings, no privacy-relevant changes (nothing new crosses the device boundary).
- Sandbox can't run AGP, so `:app:assembleDebug` / `:app:testDebugUnitTest` validation is on CI per CLAUDE.md.

## Test plan

- [ ] CI green: `JVM unit tests` + `Android debug build`.
- [ ] Manual: tap a daily-insight notification while on Settings → app lands on Today (warm path).
- [ ] Manual: kill the app from Settings, tap notification → app lands on Today (cold path / process-death recreate).
- [ ] Manual on Android 10 device/emulator: turn on device-location toggle when only foreground granted → background-rationale dialog → confirm shows the inline runtime prompt rather than deep-linking to Settings.
- [ ] Manual on a device set to a Region with a hardcoded-suffix locale (zh-CN, ko, pt-BR) → threshold rationale chip shows the SHORT time without trailing `点`/`시`/`h`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DRNJ2xYHoSRCBkd3XnvRE2)_