### PR TITLE
:app — consume EXTRA_NAVIGATE_TO_TODAY so it isn't sticky across recreations

### DIFF
--- a/app/src/main/kotlin/app/clothescast/MainActivity.kt
+++ b/app/src/main/kotlin/app/clothescast/MainActivity.kt
@@ -49,9 +49,7 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        if (intent?.getBooleanExtra(EXTRA_NAVIGATE_TO_TODAY, false) == true) {
-            navigateToTodayVersion++
-        }
+        consumeNavigateToTodayExtra(intent)
         val app = application as ClothesCastApplication
         setContent {
             ClothesCastTheme {
@@ -67,8 +65,19 @@ class MainActivity : ComponentActivity() {
 
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
-        if (intent.getBooleanExtra(EXTRA_NAVIGATE_TO_TODAY, false)) {
+        // Update the stored intent so a later configuration change replays this
+        // (already-consumed) intent rather than the original launching one.
+        setIntent(intent)
+        consumeNavigateToTodayExtra(intent)
+    }
+
+    // Removes the extra after handling so a later onCreate (rotation, process
+    // recreation) replaying the same intent doesn't snap the user back to Today
+    // after they've navigated away.
+    private fun consumeNavigateToTodayExtra(intent: Intent?) {
+        if (intent?.getBooleanExtra(EXTRA_NAVIGATE_TO_TODAY, false) == true) {
             navigateToTodayVersion++
+            intent.removeExtra(EXTRA_NAVIGATE_TO_TODAY)
         }
     }
 


### PR DESCRIPTION
## Summary

The cold-start handling added in f45aab2 reads `EXTRA_NAVIGATE_TO_TODAY` from the launching intent in `onCreate` but never removes it. Any later activity recreation with that same intent — rotation, process recreation, or a config change after the user has navigated to Settings — re-fires `onCreate`, re-reads the extra, re-increments `navigateToTodayVersion`, and snaps the user back to Today against their wishes.

Fix: `removeExtra` after handling, in both `onCreate` and `onNewIntent`. Also call `setIntent(intent)` in `onNewIntent` so `getIntent()` reflects the latest delivered intent (now without the extra) on subsequent recreations — otherwise `getIntent()` would still return the original launching intent, which may itself have been a notification tap carrying the extra.

## Repro (before this PR)

1. Tap a notification → app cold-starts on Today (intent has `navigate_to_today=true`).
2. Open Settings.
3. Rotate the device, or trigger any process recreation while the launching intent is reused.
4. Observed: app snaps back to Today. Expected: stays on Settings.

## Test plan

- [ ] CI: `JVM unit tests` green
- [ ] CI: `Android debug build` green
- [ ] Manual: cold-start from notification → navigate to Settings → rotate → still on Settings
- [ ] Manual: cold-start from notification → land on Today (snap still works first time)
- [ ] Manual: app already on Settings, tap notification → snap to Today (warm-path still works)
- [ ] Manual: app already on Settings, tap notification, navigate back to Settings, rotate → stays on Settings (no replay of consumed warm intent)


---
_Generated by [Claude Code](https://claude.ai/code/session_014MT6giYsD1hhbwJ4eGwva4)_