### PR TITLE
:app — apply per-app locale process-wide so UI follows Region setting

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ClothesCastApplication.kt
+++ b/app/src/main/kotlin/app/clothescast/ClothesCastApplication.kt
@@ -1,6 +1,7 @@
 package app.clothescast
 
 import android.app.Application
+import android.content.Context
 import app.clothescast.alarm.DailyAlarmScheduler
 import app.clothescast.calendar.CalendarContractEventReader
 import app.clothescast.core.data.location.OpenMeteoGeocodingClient
@@ -16,6 +17,7 @@ import app.clothescast.data.InsightCache
 import app.clothescast.data.SecureKeyStore
 import app.clothescast.data.SettingsRepository
 import app.clothescast.diag.DiagLog
+import app.clothescast.locale.AppLocale
 import app.clothescast.location.LocationResolver
 import app.clothescast.notification.InsightNotifier
 import app.clothescast.notification.NotificationChannelRegistrar
@@ -97,6 +99,14 @@ class ClothesCastApplication : Application() {
 
     private val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
+    override fun attachBaseContext(base: Context) {
+        // Re-apply the persisted per-app locale before the framework caches a
+        // Resources reference for the Application context (used by the worker
+        // and any non-Activity component). On API 33+ this is a no-op — the
+        // system honours LocaleManager.setApplicationLocales without our help.
+        super.attachBaseContext(AppLocale.wrap(base))
+    }
+
     override fun onCreate() {
         super.onCreate()
         DiagLog.install(this)
@@ -104,6 +114,11 @@ class ClothesCastApplication : Application() {
         applicationScope.launch {
             try {
                 val prefs = settingsRepository.preferences.first()
+                // Reconcile Locale.setDefault (process-scoped, lost on cold
+                // start) and the API 33+ LocaleManager state with the
+                // persisted Region. The pre-API-33 SharedPreferences cache is
+                // already consulted by attachBaseContext above.
+                AppLocale.apply(this@ClothesCastApplication, prefs.region)
                 dailyAlarmScheduler.schedule(prefs.schedule, ForecastPeriod.TODAY)
                 if (prefs.tonightEnabled) {
                     dailyAlarmScheduler.schedule(prefs.tonightSchedule, ForecastPeriod.TONIGHT)

--- a/app/src/main/kotlin/app/clothescast/MainActivity.kt
+++ b/app/src/main/kotlin/app/clothescast/MainActivity.kt
@@ -1,7 +1,9 @@
 package app.clothescast
 
+import android.app.Activity
 import android.content.Context
 import android.content.Intent
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.BackHandler
@@ -188,7 +190,17 @@ private fun ClothesCastNav(app: ClothesCastApplication, navigateToTodayVersion: 
                             .makeText(context, message, android.widget.Toast.LENGTH_LONG)
                             .show()
                     },
-                    applyAppLocale = { region -> AppLocale.apply(app, region) },
+                    applyAppLocale = { region ->
+                        AppLocale.apply(app, region)
+                        // API 33+ recreates Activities automatically when
+                        // applicationLocales changes; below that we have to
+                        // do it ourselves so the currently visible screen
+                        // re-renders in the new language instead of waiting
+                        // until the user navigates away and back.
+                        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+                            (context as? Activity)?.recreate()
+                        }
+                    },
                 ),
             )
             SettingsScreen(

--- a/app/src/main/kotlin/app/clothescast/MainActivity.kt
+++ b/app/src/main/kotlin/app/clothescast/MainActivity.kt
@@ -1,5 +1,6 @@
 package app.clothescast
 
+import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
@@ -20,6 +21,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.work.WorkManager
+import app.clothescast.locale.AppLocale
 import app.clothescast.notification.NotificationPermission
 import app.clothescast.ui.isTelevision
 import app.clothescast.ui.onboarding.OnboardingScreen
@@ -46,6 +48,13 @@ class MainActivity : ComponentActivity() {
     // whenever it ticks, so a notification tap reliably lands the user on Today
     // regardless of cold/warm start.
     private var navigateToTodayVersion by mutableIntStateOf(0)
+
+    override fun attachBaseContext(newBase: Context) {
+        // Wrap with the persisted per-app locale so Activity Resources render
+        // in the user's chosen Region. No-op on API 33+ where the framework
+        // routes the LocaleManager-supplied locale through automatically.
+        super.attachBaseContext(AppLocale.wrap(newBase))
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -179,6 +188,7 @@ private fun ClothesCastNav(app: ClothesCastApplication, navigateToTodayVersion: 
                             .makeText(context, message, android.widget.Toast.LENGTH_LONG)
                             .show()
                     },
+                    applyAppLocale = { region -> AppLocale.apply(app, region) },
                 ),
             )
             SettingsScreen(

--- a/app/src/main/kotlin/app/clothescast/diag/BugReport.kt
+++ b/app/src/main/kotlin/app/clothescast/diag/BugReport.kt
@@ -29,6 +29,8 @@ import kotlinx.coroutines.suspendCancellableCoroutine
 import java.io.File
 import java.io.FileOutputStream
 import java.text.SimpleDateFormat
+import java.time.Duration
+import java.time.Instant
 import java.util.Date
 import java.util.Locale
 import kotlin.coroutines.resume
@@ -150,6 +152,24 @@ object BugReport {
         prefs.clothesRules.forEach { appendLine("  - ${describeRule(it)}") }
     }
 
+    /**
+     * Humanises age relative to now so a glance at the bug report tells you
+     * whether the prose was rendered fresh during this run (seconds old) or
+     * served from cache (hours / days). Stops at days because anything older
+     * is already obviously stale.
+     */
+    internal fun humanAge(generatedAt: Instant, now: Instant = Instant.now()): String {
+        val d = Duration.between(generatedAt, now)
+        if (d.isNegative) return "in the future"
+        val seconds = d.seconds
+        return when {
+            seconds < 60 -> "${seconds}s ago"
+            seconds < 3600 -> "${d.toMinutes()}m ago"
+            seconds < 86_400 -> "${d.toHours()}h ago"
+            else -> "${d.toDays()}d ago"
+        }
+    }
+
     private fun describeRule(rule: ClothesRule): String {
         val cond = when (val c = rule.condition) {
             is ClothesRule.TemperatureBelow -> "feelsLikeMinC < ${c.celsius}"
@@ -174,7 +194,7 @@ object BugReport {
         val prose = runCatching { InsightFormatter.forRegion(context, region).format(insight.summary) }
             .getOrElse { "(prose render failed: ${it.javaClass.simpleName})" }
         appendLine("  Prose: $prose")
-        appendLine("  Generated: ${insight.generatedAt}")
+        appendLine("  Generated: ${insight.generatedAt} (${humanAge(insight.generatedAt)})")
         appendLine("  For date: ${insight.forDate}")
         insight.confidence?.let {
             appendLine("  Confidence: ${it.level} (tempSpread=${it.tempSpreadC}°C, " +

--- a/app/src/main/kotlin/app/clothescast/locale/AppLocale.kt
+++ b/app/src/main/kotlin/app/clothescast/locale/AppLocale.kt
@@ -4,6 +4,7 @@ import android.app.LocaleManager
 import android.content.Context
 import android.content.SharedPreferences
 import android.content.res.Configuration
+import android.content.res.Resources
 import android.os.Build
 import android.os.LocaleList
 import app.clothescast.core.domain.model.Region
@@ -57,12 +58,28 @@ object AppLocale {
 
     /** Drop the per-app override so the device locale takes effect. */
     fun clear(context: Context) {
+        // Reset the JVM default to the device locale; otherwise switching from
+        // a non-system region back to SYSTEM in the same process leaves
+        // Locale.getDefault() stuck on the previous app locale (formatting,
+        // TTS fallbacks, etc. would keep behaving as the old region until
+        // process restart).
+        Locale.setDefault(systemLocale())
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             context.getSystemService(LocaleManager::class.java)
                 ?.applicationLocales = LocaleList.getEmptyLocaleList()
         } else {
             context.prefs().edit().remove(KEY_TAG).apply()
         }
+    }
+
+    /**
+     * The device-level locale, ignoring any per-app override we've installed.
+     * Read from system Resources rather than [Locale.getDefault] because the
+     * latter has already been polluted by [apply] in the same process.
+     */
+    private fun systemLocale(): Locale {
+        val locales = Resources.getSystem().configuration.locales
+        return if (!locales.isEmpty) locales[0] else Locale.ROOT
     }
 
     /**

--- a/app/src/main/kotlin/app/clothescast/locale/AppLocale.kt
+++ b/app/src/main/kotlin/app/clothescast/locale/AppLocale.kt
@@ -1,0 +1,86 @@
+package app.clothescast.locale
+
+import android.app.LocaleManager
+import android.content.Context
+import android.content.SharedPreferences
+import android.content.res.Configuration
+import android.os.Build
+import android.os.LocaleList
+import app.clothescast.core.domain.model.Region
+import java.util.Locale
+
+/**
+ * Single source of truth for "what language is the app rendering in?"
+ *
+ * The user's [Region] setting carries a BCP-47 tag (e.g. `de-AT`); this helper
+ * pushes that locale into the three places it actually matters:
+ *  - [Locale.setDefault] — for code paths that ask for the default locale
+ *    (date / number formatting, TTS resolution, library defaults).
+ *  - [LocaleManager.setApplicationLocales] on API 33+ — Android persists this
+ *    across launches and applies it to all Activity / Application Resources,
+ *    so the entire UI re-renders in the chosen language without us having to
+ *    wrap each Context.
+ *  - SharedPreferences cache + [Configuration.setLocale] override applied via
+ *    [attachBaseContext] on API ≤32 — Android predates per-app language
+ *    preferences, so we wrap each Context with a Configuration whose locale
+ *    is the persisted choice and recreate Activities when it changes.
+ *
+ * Without this, the user's Region choice only reaches the InsightFormatter
+ * (via `forRegion`'s explicit `createConfigurationContext`) and the TTS voice
+ * picker — the rest of the UI keeps rendering in the device's default locale,
+ * and on Android 13+ even the InsightFormatter path has been observed to fall
+ * back to the device locale once `android:localeConfig` is declared (yielding
+ * the "Today will be cold to mild. Wear Pullover and Jacke." mixed output).
+ *
+ * [Region.SYSTEM] (`bcp47 == null`) clears the override so device locale wins.
+ */
+object AppLocale {
+    private const val PREFS_NAME = "app_locale"
+    private const val KEY_TAG = "tag"
+
+    /** Persist [region]'s locale and apply it process-wide. */
+    fun apply(context: Context, region: Region) {
+        val tag = region.bcp47
+        if (tag == null) {
+            clear(context)
+            return
+        }
+        val locale = Locale.forLanguageTag(tag)
+        Locale.setDefault(locale)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            context.getSystemService(LocaleManager::class.java)
+                ?.applicationLocales = LocaleList(locale)
+        } else {
+            context.prefs().edit().putString(KEY_TAG, tag).apply()
+        }
+    }
+
+    /** Drop the per-app override so the device locale takes effect. */
+    fun clear(context: Context) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            context.getSystemService(LocaleManager::class.java)
+                ?.applicationLocales = LocaleList.getEmptyLocaleList()
+        } else {
+            context.prefs().edit().remove(KEY_TAG).apply()
+        }
+    }
+
+    /**
+     * Wrap [base] with a Configuration whose locale is the persisted choice,
+     * for use from `attachBaseContext` overrides. Returns [base] unchanged on
+     * API 33+ (the system already routes the right locale through
+     * [Context.createConfigurationContext]) and when no override has been
+     * stored yet.
+     */
+    fun wrap(base: Context): Context {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) return base
+        val tag = base.prefs().getString(KEY_TAG, null) ?: return base
+        val locale = Locale.forLanguageTag(tag)
+        Locale.setDefault(locale)
+        val config = Configuration(base.resources.configuration).apply { setLocale(locale) }
+        return base.createConfigurationContext(config)
+    }
+
+    private fun Context.prefs(): SharedPreferences =
+        getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+}

--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsViewModel.kt
@@ -49,6 +49,14 @@ class SettingsViewModel(
      * Activity passes a Toast-backed implementation.
      */
     private val showError: (String) -> Unit = {},
+    /**
+     * Pushes the chosen [Region] into the platform locale machinery
+     * (Locale.setDefault + LocaleManager / attachBaseContext cache) so the
+     * whole UI re-renders in the chosen language. Defaulted to a no-op so
+     * pure-VM tests don't need an Android Context; the Activity passes an
+     * AppLocale-backed implementation.
+     */
+    private val applyAppLocale: (Region) -> Unit = {},
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(SettingsState())
@@ -287,6 +295,11 @@ class SettingsViewModel(
     }
 
     fun setRegion(region: Region) {
+        // Apply the locale up front so the UI recreates immediately; the
+        // DataStore write happens in the background. The Application's
+        // onCreate reconciler re-applies on next cold start, so the order
+        // here can't drift out of sync.
+        applyAppLocale(region)
         viewModelScope.launch { settingsRepository.setRegion(region) }
     }
 
@@ -412,6 +425,7 @@ class SettingsViewModel(
         private val voiceEnumerator: TtsVoiceEnumerator,
         private val elevenLabsTtsClient: ElevenLabsTtsClient,
         private val showError: (String) -> Unit,
+        private val applyAppLocale: (Region) -> Unit,
     ) : ViewModelProvider.Factory {
         @Suppress("UNCHECKED_CAST")
         override fun <T : ViewModel> create(modelClass: Class<T>): T {
@@ -427,6 +441,7 @@ class SettingsViewModel(
                 voiceEnumerator,
                 elevenLabsTtsClient,
                 showError,
+                applyAppLocale,
             ) as T
         }
     }

--- a/app/src/test/kotlin/app/clothescast/insight/InsightFormatterTest.kt
+++ b/app/src/test/kotlin/app/clothescast/insight/InsightFormatterTest.kt
@@ -235,11 +235,14 @@ class InsightFormatterTest {
 
     @Test
     fun `de-AT region on an en-GB base context produces fully German prose`() {
-        // Regression: device locale en-GB, Region set to DE_AT.
-        // On Android 13+ without android:localeConfig, createConfigurationContext()
-        // could fall back to the device locale instead of honouring the de-AT
-        // override, producing English sentence templates but German clothing names
-        // ("Tonight will be cold to cool. Wear Pullover and Jacke.").
+        // Regression: device locale en-GB, Region set to DE_AT used to render
+        // "Tonight will be cold to cool. Wear Pullover and Jacke." on Android
+        // 13+ — the InsightFormatter's locale-bound Locale picked German for
+        // the phraser while createConfigurationContext silently fell back to
+        // the device locale for the templates. The runtime fix lives in
+        // AppLocale (Locale.setDefault + LocaleManager.setApplicationLocales /
+        // attachBaseContext wrap); this test pins the formatter's own
+        // forRegion path as a belt-and-suspenders unit check.
         val enGbConfig = Configuration(context.resources.configuration).apply {
             setLocale(Locale.forLanguageTag("en-GB"))
         }


### PR DESCRIPTION
## Summary

Reported regression: on a Pixel 10 Pro (Android 16, device locale en-GB) with Region set to DE_AT, the prose comes out half-translated — `"Today will be cold to mild. It will be 7° warmer than yesterday. Wear Pullover and Jacke."` — and the rest of the UI stays in English. The user's tablet on build 447 was fine; the phone on build 490 is broken.

**Root cause.** The Region setting only ever reached `InsightFormatter` (via `forRegion`'s explicit `createConfigurationContext`) and the TTS picker. Activity and worker Resources kept rendering in the device's default locale. Once `android:localeConfig` landed in `c3adcf4`, the `createConfigurationContext` fallback also stopped honouring the override on Android 13+ — so even the formatter path leaked English templates while the locale-bound `GermanClothesPhraser` kept translating garments. The Roborazzi-level regression test in `c3adcf4` passed in CI but didn't model the runtime LocaleManager behaviour, so the "fix" merged green.

## What this PR does

Adds an `AppLocale` helper that pushes the Region locale into:
- `Locale.setDefault` — for date/number/TTS/library defaults.
- `LocaleManager.setApplicationLocales` on API 33+ — system persists and re-routes Resources for all Contexts.
- SharedPreferences cache + `attachBaseContext` wrap on API ≤32 — wraps each Context with the locale Configuration on lookup.

Wires it into:
- `ClothesCastApplication.attachBaseContext` / `onCreate` — covers the worker's `applicationContext` and reconciles `Locale.setDefault` on cold start.
- `MainActivity.attachBaseContext` — Activity Resources.
- `SettingsViewModel.setRegion` — applies immediately on change so the UI re-renders.

`forRegion`'s `createConfigurationContext` stays in place as a unit-testable belt-and-suspenders; the existing regression test's comment is refreshed to point at `AppLocale` as the actual runtime fix.

Bug report now humanises insight age (`11s ago` / `3h ago`) so "is this prose fresh or cached?" is obvious at a glance — addresses the diagnostic ask in the original report.

## Test plan

Sandbox can't reach Google Maven, so CI is the validation surface for compile and JVM tests. Manual verification on a real Android 13+ device (the only environment that actually exercises the LocaleManager path) is needed:

- [ ] Install on a Pixel-class device with system locale en-GB.
- [ ] Set Region to `DE_AT` in app Settings.
- [ ] Verify the Today screen, Settings, etc. render fully in German.
- [ ] Force-refresh a ClothesCast and verify prose is fully German (no "Today will be… Wear Pullover…" mix).
- [ ] Kill and relaunch the app — locale should persist (LocaleManager handles this on 33+; the `Locale.setDefault` is re-applied in `Application.onCreate`).
- [ ] Switch back to `Region.SYSTEM` — UI should return to device locale (en-GB).
- [ ] Open the bug-report dialog — `Generated:` line should now have a humanised age suffix like `(11s ago)` or `(2h ago)`.
- [ ] Spot-check on an older device (API ≤32) if available — the SharedPreferences + `attachBaseContext` path is the only one that runs there.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TxuGjzQgPV3xwgjiSxBjrS)_