### PR TITLE
:app — push harder for always-on location during setup and in Data sources

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/onboarding/OnboardingScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/onboarding/OnboardingScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.HorizontalDivider
@@ -38,12 +39,14 @@ import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.clothescast.R
 import app.clothescast.core.domain.model.Location
+import app.clothescast.location.hasBackgroundLocationPermission
 import app.clothescast.location.hasCoarseLocationPermission
 import app.clothescast.notification.NotificationPermission
 import app.clothescast.ui.isTelevision
 import app.clothescast.ui.settings.KeyEntryFields
 import app.clothescast.ui.settings.LinkifiedText
 import app.clothescast.ui.settings.LocationSearchDialog
+import app.clothescast.ui.settings.openAppDetails
 
 /**
  * First-run onboarding. Shown when the user lands on a fresh install missing any
@@ -202,8 +205,23 @@ private fun LocationStep(
     var permissionGranted by remember {
         mutableStateOf(hasCoarseLocationPermission(context))
     }
+    var backgroundGranted by remember {
+        mutableStateOf(hasBackgroundLocationPermission(context))
+    }
     var permissionAsked by remember { mutableStateOf(false) }
     var searchOpen by remember { mutableStateOf(false) }
+    var backgroundRationaleOpen by remember { mutableStateOf(false) }
+    var backgroundDeniedOpen by remember { mutableStateOf(false) }
+
+    // Background launcher: on Android Q (API 29) the inline runtime prompt works;
+    // on R+ ACCESS_BACKGROUND_LOCATION can only be granted from system Settings, so
+    // we deep-link there from the rationale dialog instead of using this launcher.
+    val backgroundLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestPermission(),
+    ) { granted ->
+        backgroundGranted = granted
+        if (!granted) backgroundDeniedOpen = true
+    }
 
     val launcher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.RequestPermission(),
@@ -213,7 +231,18 @@ private fun LocationStep(
         // Mirrors LocationEditor: only flip the toggle on if foreground was granted,
         // otherwise the worker would consult the reader and silently fall through to
         // the configured fallback location every day.
-        if (granted) onSetUseDeviceLocation(true)
+        if (granted) {
+            onSetUseDeviceLocation(true)
+            // Auto-chain into the background-permission ask: the daily worker needs
+            // ACCESS_BACKGROUND_LOCATION to read the device fix when the app isn't
+            // foregrounded. Without this chain the user finishes onboarding with
+            // foreground-only and the worker silently falls back to the saved city.
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q &&
+                !hasBackgroundLocationPermission(context)
+            ) {
+                backgroundRationaleOpen = true
+            }
+        }
     }
 
     val lifecycleOwner = LocalLifecycleOwner.current
@@ -223,6 +252,7 @@ private fun LocationStep(
         val observer = LifecycleEventObserver { _, event ->
             if (event == Lifecycle.Event.ON_RESUME) {
                 permissionGranted = hasCoarseLocationPermission(context)
+                backgroundGranted = hasBackgroundLocationPermission(context)
             }
         }
         lifecycleOwner.lifecycle.addObserver(observer)
@@ -230,35 +260,62 @@ private fun LocationStep(
     }
 
     // On TV device location is unavailable; only a manually picked city counts.
+    // Otherwise we treat the step as "complete" only when both foreground *and*
+    // background are granted (or the user picked a manual fallback city). Marking
+    // the step complete on foreground-only would put a green check on a state that
+    // still breaks the morning worker.
+    val deviceLocationFullyConfigured =
+        useDeviceLocation && permissionGranted && backgroundGranted
     val configured = if (isTelevision) {
         location != null
     } else {
-        (useDeviceLocation && permissionGranted) || location != null
+        deviceLocationFullyConfigured || location != null
     }
+    val needsBackgroundPrompt =
+        !isTelevision && useDeviceLocation && permissionGranted && !backgroundGranted
 
     StepCard(
         title = stringResource(R.string.onboarding_location_title),
         description = stringResource(R.string.onboarding_location_description),
         complete = configured,
     ) {
-        if (configured) {
-            val summary = when {
-                !isTelevision && useDeviceLocation && permissionGranted ->
-                    stringResource(R.string.onboarding_location_using_device)
-                location?.displayName != null -> location.displayName!!
-                location != null -> "${location.latitude}, ${location.longitude}"
-                else -> ""
-            }
-            if (summary.isNotEmpty()) {
-                Text(text = summary, style = MaterialTheme.typography.bodyMedium)
-            }
-        } else {
+        if (deviceLocationFullyConfigured) {
+            Text(
+                text = stringResource(R.string.onboarding_location_using_device),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        } else if (location != null && !needsBackgroundPrompt) {
+            Text(
+                text = location.displayName ?: "${location.latitude}, ${location.longitude}",
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        }
+
+        if (needsBackgroundPrompt) {
+            // Foreground granted but background isn't — surface the always-on prompt
+            // as the primary affordance. The worker can't read the device fix without
+            // this, so don't let the user breeze past with foreground-only.
+            Text(
+                text = stringResource(R.string.onboarding_location_background_needed),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Button(
+                onClick = { backgroundRationaleOpen = true },
+                modifier = Modifier.fillMaxWidth(),
+            ) { Text(stringResource(R.string.onboarding_location_grant_background)) }
+        } else if (!configured) {
             // On TV, device location is not available — go straight to manual entry.
             if (!isTelevision) {
                 Button(
                     onClick = {
                         if (permissionGranted) {
                             onSetUseDeviceLocation(true)
+                            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q &&
+                                !backgroundGranted
+                            ) {
+                                backgroundRationaleOpen = true
+                            }
                         } else {
                             launcher.launch(android.Manifest.permission.ACCESS_COARSE_LOCATION)
                         }
@@ -293,6 +350,50 @@ private fun LocationStep(
                 searchOpen = false
             },
             onSearch = onSearchLocations,
+        )
+    }
+
+    if (backgroundRationaleOpen) {
+        AlertDialog(
+            onDismissRequest = { backgroundRationaleOpen = false },
+            title = { Text(stringResource(R.string.settings_location_background_rationale_title)) },
+            text = { Text(stringResource(R.string.settings_location_background_rationale_body)) },
+            confirmButton = {
+                TextButton(onClick = {
+                    backgroundRationaleOpen = false
+                    // API 30+ forces the system Settings deep-link for background
+                    // location; API 29 still accepts the inline runtime prompt.
+                    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R) {
+                        openAppDetails(context)
+                    } else {
+                        backgroundLauncher.launch(android.Manifest.permission.ACCESS_BACKGROUND_LOCATION)
+                    }
+                }) { Text(stringResource(R.string.settings_location_background_rationale_continue)) }
+            },
+            dismissButton = {
+                TextButton(onClick = { backgroundRationaleOpen = false }) {
+                    Text(stringResource(R.string.settings_location_background_rationale_dismiss))
+                }
+            },
+        )
+    }
+
+    if (backgroundDeniedOpen) {
+        AlertDialog(
+            onDismissRequest = { backgroundDeniedOpen = false },
+            title = { Text(stringResource(R.string.settings_location_background_denied_title)) },
+            text = { Text(stringResource(R.string.settings_location_background_denied_body)) },
+            confirmButton = {
+                TextButton(onClick = {
+                    backgroundDeniedOpen = false
+                    openAppDetails(context)
+                }) { Text(stringResource(R.string.settings_location_background_denied_open)) }
+            },
+            dismissButton = {
+                TextButton(onClick = { backgroundDeniedOpen = false }) {
+                    Text(stringResource(R.string.settings_location_background_denied_keep))
+                }
+            },
         )
     }
 }

--- a/app/src/main/kotlin/app/clothescast/ui/settings/DataSourcesSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/DataSourcesSettings.kt
@@ -11,6 +11,8 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
@@ -81,10 +83,32 @@ private fun LocationCard(
     onClear: () -> Unit,
     onSearch: suspend (String) -> List<Location>,
 ) {
+    val context = LocalContext.current
     var dialogOpen by remember { mutableStateOf(false) }
+    var backgroundGranted by remember {
+        mutableStateOf(hasBackgroundLocationPermission(context))
+    }
+
+    val lifecycleOwner = androidx.compose.ui.platform.LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner) {
+        // Re-check on resume so the prominent "Grant always-on" CTA disappears once
+        // the user grants the permission via the system Settings deep-link.
+        val observer = androidx.lifecycle.LifecycleEventObserver { _, event ->
+            if (event == androidx.lifecycle.Lifecycle.Event.ON_RESUME) {
+                backgroundGranted = hasBackgroundLocationPermission(context)
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
+
+    val needsBackground = useDeviceLocation && !backgroundGranted
+
     SectionCard(title = stringResource(R.string.settings_location_title)) {
         DeviceLocationToggleRow(
             checked = useDeviceLocation,
+            backgroundGranted = backgroundGranted,
+            onBackgroundChanged = { backgroundGranted = it },
             onCheckedChange = onSetUseDeviceLocation,
         )
 
@@ -102,16 +126,34 @@ private fun LocationCard(
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
-        Button(
-            onClick = { dialogOpen = true },
-            modifier = Modifier.fillMaxWidth(),
-        ) {
-            Text(
-                stringResource(
-                    if (current == null) R.string.settings_location_set
-                    else R.string.settings_location_change,
-                ),
-            )
+        // Demote "Set/Change location" to outlined while always-on is the missing
+        // piece — the banner above carries the filled-button emphasis. When device
+        // location is off (or background is granted) the location picker is the
+        // primary action and gets the filled style.
+        if (needsBackground) {
+            OutlinedButton(
+                onClick = { dialogOpen = true },
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(
+                    stringResource(
+                        if (current == null) R.string.settings_location_set
+                        else R.string.settings_location_change,
+                    ),
+                )
+            }
+        } else {
+            Button(
+                onClick = { dialogOpen = true },
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(
+                    stringResource(
+                        if (current == null) R.string.settings_location_set
+                        else R.string.settings_location_change,
+                    ),
+                )
+            }
         }
         if (current != null) {
             TextButton(onClick = onClear, modifier = Modifier.fillMaxWidth()) {
@@ -133,32 +175,41 @@ private fun LocationCard(
 }
 
 @Composable
+private fun BackgroundLocationBanner() {
+    Card(
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.errorContainer,
+            contentColor = MaterialTheme.colorScheme.onErrorContainer,
+        ),
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Column(
+            modifier = Modifier.padding(12.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.settings_location_background_banner_title),
+                style = MaterialTheme.typography.titleSmall,
+            )
+            Text(
+                text = stringResource(R.string.settings_location_background_banner_body),
+                style = MaterialTheme.typography.bodySmall,
+            )
+        }
+    }
+}
+
+@Composable
 private fun DeviceLocationToggleRow(
     checked: Boolean,
+    backgroundGranted: Boolean,
+    onBackgroundChanged: (Boolean) -> Unit,
     onCheckedChange: (Boolean) -> Unit,
 ) {
     val context = LocalContext.current
-    // Track background-permission state so the "Grant always-on" prompt actually
-    // disappears when the user returns from system Settings having granted it —
-    // without an on-resume re-check the composable keeps the stale value from
-    // first composition and the button lingers forever.
-    var backgroundGranted by remember {
-        mutableStateOf(hasBackgroundLocationPermission(context))
-    }
     var rationaleOpen by remember { mutableStateOf(false) }
     var backgroundRationaleOpen by remember { mutableStateOf(false) }
     var backgroundDeniedOpen by remember { mutableStateOf(false) }
-
-    val lifecycleOwner = androidx.compose.ui.platform.LocalLifecycleOwner.current
-    DisposableEffect(lifecycleOwner) {
-        val observer = androidx.lifecycle.LifecycleEventObserver { _, event ->
-            if (event == androidx.lifecycle.Lifecycle.Event.ON_RESUME) {
-                backgroundGranted = hasBackgroundLocationPermission(context)
-            }
-        }
-        lifecycleOwner.lifecycle.addObserver(observer)
-        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
-    }
 
     // Background launcher: on Android 11+ this auto-deep-links into the system
     // Settings location picker; on Android 10 it shows the inline dialog. If the
@@ -167,7 +218,7 @@ private fun DeviceLocationToggleRow(
     val backgroundLauncher = androidx.activity.compose.rememberLauncherForActivityResult(
         contract = androidx.activity.result.contract.ActivityResultContracts.RequestPermission(),
     ) { granted ->
-        backgroundGranted = granted
+        onBackgroundChanged(granted)
         if (!granted) backgroundDeniedOpen = true
     }
 
@@ -230,7 +281,12 @@ private fun DeviceLocationToggleRow(
     }
 
     if (checked && !backgroundGranted) {
-        OutlinedButton(
+        // Promote always-on location to a prominent banner + filled CTA: without
+        // ACCESS_BACKGROUND_LOCATION the daily worker can't read the device fix,
+        // so this is the most important call to action on the screen whenever
+        // device location is on.
+        BackgroundLocationBanner()
+        Button(
             onClick = { backgroundRationaleOpen = true },
             modifier = Modifier.fillMaxWidth(),
         ) { Text(stringResource(R.string.settings_location_grant_background)) }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -85,6 +85,8 @@
     <string name="onboarding_location_title">Location</string>
     <string name="onboarding_location_description">Used to fetch the right forecast. Granting location lets ClothesCast read your device\'s coarse location each morning; otherwise pick a city manually.</string>
     <string name="onboarding_location_grant">Grant location permission</string>
+    <string name="onboarding_location_grant_background">Grant always-on location</string>
+    <string name="onboarding_location_background_needed">One more step: ClothesCast needs \'Allow all the time\' so the morning forecast can read your location while the app is closed.</string>
     <string name="onboarding_location_denied_hint">Location permission denied. You can pick a city manually instead.</string>
     <string name="onboarding_location_enter_manual">Enter location manually</string>
     <string name="onboarding_location_using_device">Using your device\'s location each morning.</string>
@@ -143,7 +145,9 @@
 
     <string name="settings_location_title">Location</string>
     <string name="settings_location_use_device">Use device location</string>
-    <string name="settings_location_grant_background">Grant background location (system Settings)</string>
+    <string name="settings_location_grant_background">Grant always-on location</string>
+    <string name="settings_location_background_banner_title">Always-on location not granted</string>
+    <string name="settings_location_background_banner_body">ClothesCast needs \'Allow all the time\' so the morning forecast can read your device location while the app is closed. Without it, the daily forecast falls back to your saved city.</string>
     <string name="settings_location_unset">No location set</string>
     <string name="settings_location_description">The forecast is fetched for this place. Search by city name; results come from Open-Meteo\'s free geocoding service.</string>
     <string name="settings_location_description_device_on">When enabled, ClothesCast reads the device\'s coarse location at notify time (cell-tower / WiFi only — no GPS hardware fix). The location below is used as a fallback if the device read fails. Background location must be granted in system Settings or the morning Worker can\'t read it.</string>


### PR DESCRIPTION
## Summary

We weren't trying hard enough to get `ACCESS_BACKGROUND_LOCATION`, which is the permission the daily worker actually needs to read a fresh device fix. Two specific gaps:

1. **Onboarding never asked.** The "Grant location permission" button only requested coarse foreground; the user finished onboarding with a green check and the worker silently fell back to the saved city every morning.
2. **Data sources buried it.** The "Set/Change location" picker was the prominent filled button; the always-on permission was a secondary `OutlinedButton` labelled "Grant background location (system Settings)" — visually the wrong way round.

### Onboarding (`OnboardingScreen.kt` — `LocationStep`)

- After a successful foreground grant on Android Q+, auto-open the same always-on rationale dialog used in Data sources, then deep-link to system Settings on R+ (or run the inline launcher on Q).
- Re-check `hasBackgroundLocationPermission()` on `ON_RESUME` so returning from Settings updates the step state.
- Treat the step as complete only when both foreground *and* background are granted (or the user picked a manual fallback city). A green check on foreground-only was lying about a state that breaks the morning worker.
- When foreground is granted but background isn't, replace the foreground CTA with a prominent "Grant always-on location" filled button + an explanatory line.

### Data sources (`DataSourcesSettings.kt` — `LocationCard` / `DeviceLocationToggleRow`)

- Lift `backgroundGranted` from the toggle row up to `LocationCard` so it can drive button emphasis across both children.
- When `useDeviceLocation && !backgroundGranted`:
  - Render an `errorContainer`-coloured banner explaining what's missing and what breaks without it.
  - Promote the "Grant always-on location" button from `OutlinedButton` to filled `Button`.
  - Demote the "Set/Change location" picker to `OutlinedButton` so the always-on CTA is unambiguously the primary action.
- Reword the always-on button label from "Grant background location (system Settings)" to "Grant always-on location" — the rationale dialog already explains the deep-link.

### Privacy

No new data crosses the device boundary. This change only affects permission prompting / UI emphasis around a permission that already had to be granted for the worker to function.

## Test plan

I can't run `:app:assembleDebug` or `:app:testDebugUnitTest` in this sandbox (Google Maven blocked); CI is the validation surface for compile/lint.

- [ ] CI: JVM unit tests
- [ ] CI: Android debug build
- [ ] Manual: fresh install, finish onboarding on Android 12+ — confirm always-on prompt fires automatically after foreground grant, deep-links to Settings, and step turns green only after both perms are granted
- [ ] Manual: revoke background in system Settings, reopen Data sources — confirm banner + filled "Grant always-on" button appear and "Change location" demotes to outlined
- [ ] Manual: grant always-on from the banner CTA — confirm banner disappears on resume and "Change location" is filled again
- [ ] Manual: Android 10 (API 29) path — inline runtime prompt instead of Settings deep-link
- [ ] Manual: pre-Q (API 28 or below) — `hasBackgroundLocationPermission` returns true, neither banner nor extra prompt should appear

https://claude.ai/code/session_0136q6S1ouBxBNCJJn5W25wa

---
_Generated by [Claude Code](https://claude.ai/code/session_0136q6S1ouBxBNCJJn5W25wa)_