### PR TITLE
:core — compare today's daytime against yesterday's daytime in delta clause

### DIFF
--- a/core/data/src/main/kotlin/app/clothescast/core/data/weather/OpenMeteoMapper.kt
+++ b/core/data/src/main/kotlin/app/clothescast/core/data/weather/OpenMeteoMapper.kt
@@ -19,7 +19,8 @@ import java.time.LocalTime
  * The hourly stream covers all three days. We split it by date: today's hours
  * attach to the today forecast, tomorrow's hours attach to the tomorrow forecast
  * (and are also exposed via `tomorrowHourly` for the tonight slice). Yesterday's
- * hourlies are not needed downstream.
+ * hourlies attach to the yesterday forecast so the delta clause can slice both
+ * sides to the same daytime window for a symmetric comparison.
  *
  * Tolerates 2-entry responses (forecast_days=1) for backwards compatibility with
  * older fixtures and any caller that downgrades the request — tomorrow comes
@@ -34,7 +35,8 @@ internal object OpenMeteoMapper {
         val yesterdayDate = LocalDate.parse(response.daily.time[0])
         val todayDate = LocalDate.parse(response.daily.time[1])
 
-        val yesterday = response.daily.toForecast(index = 0, date = yesterdayDate, hourly = emptyList())
+        val yesterdayHourly = response.hourly.forDate(yesterdayDate)
+        val yesterday = response.daily.toForecast(index = 0, date = yesterdayDate, hourly = yesterdayHourly)
         val todayHourly = response.hourly.forDate(todayDate)
         val today = response.daily.toForecast(index = 1, date = todayDate, hourly = todayHourly)
 

--- a/core/data/src/test/kotlin/app/clothescast/core/data/weather/OpenMeteoMapperTest.kt
+++ b/core/data/src/test/kotlin/app/clothescast/core/data/weather/OpenMeteoMapperTest.kt
@@ -39,7 +39,18 @@ class OpenMeteoMapperTest {
         y.precipitationProbabilityMaxPct shouldBe 5.0
         y.precipitationMmTotal shouldBe 0.0
         y.condition shouldBe WeatherCondition.PARTLY_CLOUDY
-        y.hourly shouldBe emptyList()
+    }
+
+    @Test
+    fun `yesterday hourly is filtered to yesterday's date only`() {
+        val y = OpenMeteoMapper.toBundle(loadFixture()).yesterday
+
+        // Fixture has 2 hours on 2026-04-24 + 8 hours on 2026-04-25; yesterday
+        // gets the 2026-04-24 entries so the delta clause can slice both today
+        // and yesterday to the same daytime window.
+        y.hourly shouldHaveSize 2
+        y.hourly.first().time shouldBe LocalTime.of(22, 0)
+        y.hourly.last().time shouldBe LocalTime.of(23, 0)
     }
 
     @Test

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsight.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsight.kt
@@ -60,6 +60,22 @@ class GenerateDailyInsight(
             ForecastPeriod.TODAY -> todayForecast
             ForecastPeriod.TONIGHT -> tonightForecast
         }
+        // Slice yesterday to the same daytime window as today so the delta clause
+        // compares apples to apples — daytime feels-like high/low on both sides
+        // rather than 24h aggregates that fold in overnight extremes the listener
+        // doesn't care about. Falls back to 24h-vs-24h when either side lacks
+        // daytime hourly entries (legacy cached payloads, sparse fixtures), to
+        // keep the comparison symmetric in the absence of hourly data.
+        val yesterdayDaytime = bundle.yesterday.slicedForToday(
+            morningStart = morningStart,
+            eveningEnd = tonightStart,
+        )
+        val (deltaToday, deltaYesterday) =
+            if (todayForecast.hourly.isNotEmpty() && yesterdayDaytime.hourly.isNotEmpty()) {
+                todayForecast to yesterdayDaytime
+            } else {
+                bundle.today to bundle.yesterday
+            }
         // The home screen wants a side-by-side preview pair: "Today + Tonight"
         // on a morning insight, "Tonight + Tomorrow" on an evening one. We
         // compute the second outfit from the same forecast bundle so showing
@@ -109,7 +125,7 @@ class GenerateDailyInsight(
         }
         val summary = renderInsightSummary(
             today = periodForecast,
-            yesterday = bundle.yesterday,
+            yesterday = deltaYesterday,
             todayTriggeredRules = todayTriggered,
             alerts = activeAlerts,
             events = periodEvents,
@@ -117,7 +133,7 @@ class GenerateDailyInsight(
             eveningEvents = eveningEvents,
             eveningTriggeredRules = eveningTriggered,
             eveningForecast = if (period == ForecastPeriod.TODAY) tonightForecast else null,
-            rawToday = bundle.today,
+            todayForDelta = deltaToday,
         )
         val insight = Insight(
             summary = summary,

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/RenderInsightSummary.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/RenderInsightSummary.kt
@@ -64,13 +64,13 @@ class RenderInsightSummary {
         eveningEvents: List<CalendarEvent> = emptyList(),
         eveningTriggeredRules: List<ClothesRule> = emptyList(),
         eveningForecast: DailyForecast? = null,
-        // When [today] has been sliced to a daytime window its feelsLikeMinC
-        // reflects the morning start time rather than the overnight low, making
-        // a low-delta comparison against yesterday's full-day fields misleading.
-        // Pass the raw (un-sliced) today so both deltas use consistent 24h fields.
-        // Defaults to null, which falls back to [today] (correct when the caller
-        // hasn't sliced the forecast, e.g. in unit tests).
-        rawToday: DailyForecast? = null,
+        // The today side of the delta comparison, paired with [yesterday]. The
+        // caller picks the pair so today and yesterday cover the same time range
+        // — typically daytime-vs-daytime when both have hourly entries in the
+        // window, falling back to 24h-vs-24h when either side lacks them.
+        // Defaults to [today], which is correct when the caller hasn't sliced
+        // the forecast (e.g. in unit tests that pass raw 24h fields on both sides).
+        todayForDelta: DailyForecast = today,
     ): InsightSummary {
         val items = todayTriggeredRules.map { it.item }
         val peak = peakPrecip(today)
@@ -91,7 +91,7 @@ class RenderInsightSummary {
             period = period,
             alert = alertClause(alerts),
             band = bandClause(today),
-            delta = if (period == ForecastPeriod.TODAY) deltaClause(rawToday ?: today, yesterday) else null,
+            delta = if (period == ForecastPeriod.TODAY) deltaClause(todayForDelta, yesterday) else null,
             clothes = clothesClause(items),
             precip = peak?.let { PrecipClause(it.condition, it.time) },
             // Calendar tie-in only fires on TONIGHT — pairing the precip peak

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsightTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsightTest.kt
@@ -315,17 +315,51 @@ class GenerateDailyInsightTest {
     }
 
     @Test
-    fun `delta clause uses raw day-level fields, not the sliced daytime window`() = runTest {
-        // Scenario: yesterday and today share the same overnight low (4°C) and
-        // afternoon high (20°C) — no meaningful change. But today has an early-dawn
-        // hour at 4°C that falls outside the default daytime window (07:00–19:00).
-        // Before the fix, the sliced today had feelsLikeMinC = 12°C (the 09:00 in-
-        // window low) while yesterday's feelsLikeMinC was still 4°C, producing a
-        // spurious "+8° warmer" report. With the fix, the delta uses bundle.today's
-        // raw 24h fields (4°C min, 20°C max) vs yesterday's (4°C min, 20°C max) —
-        // delta ≈ 0 on both dimensions → no delta clause emitted.
-        val sameDayHourly = listOf(
+    fun `delta compares daytime-vs-daytime when both sides have hourly data`() = runTest {
+        // Scenario: yesterday and today share the same daytime profile (12°C low,
+        // 20°C high in the 07:00–19:00 window) but yesterday had an unusually warm
+        // overnight hour at 18°C that bumped its 24h min above today's pre-dawn
+        // 4°C. A 24h-vs-24h comparison would emit "14° warmer" on the low — a
+        // spurious headline, since the listener experiences the daytime, not the
+        // overnight. With the fix, both sides slice to the same daytime window
+        // and the deltas come out near zero.
+        val todayHourly = listOf(
             HourlyForecast(LocalTime.of(4, 0), 6.0, 4.0, 5.0, WeatherCondition.CLEAR),
+            HourlyForecast(LocalTime.of(9, 0), 14.0, 12.0, 5.0, WeatherCondition.CLEAR),
+            HourlyForecast(LocalTime.of(15, 0), 22.0, 20.0, 5.0, WeatherCondition.CLEAR),
+        )
+        val yesterdayHourly = listOf(
+            HourlyForecast(LocalTime.of(2, 0), 20.0, 18.0, 5.0, WeatherCondition.CLEAR),
+            HourlyForecast(LocalTime.of(9, 0), 14.0, 12.0, 5.0, WeatherCondition.CLEAR),
+            HourlyForecast(LocalTime.of(15, 0), 22.0, 20.0, 5.0, WeatherCondition.CLEAR),
+        )
+        val sameDaytimeToday = today.copy(
+            feelsLikeMinC = 4.0,
+            feelsLikeMaxC = 20.0,
+            hourly = todayHourly,
+        )
+        val sameDaytimeYesterday = yesterday.copy(
+            feelsLikeMinC = 18.0,
+            feelsLikeMaxC = 20.0,
+            hourly = yesterdayHourly,
+        )
+        val weather = FakeWeatherRepository(ForecastBundle(sameDaytimeToday, sameDaytimeYesterday))
+        val subject = GenerateDailyInsight(weather, clock = clock)
+
+        val result = subject(london, prefs)
+
+        // Daytime delta: high = 20 - 20 = 0, low = 12 - 12 = 0 → no clause.
+        // (24h delta would have been low = 4 - 18 = -14, emitting a spurious
+        // "14° cooler" — exactly what the daytime slice is meant to suppress.)
+        result.insight.summary.delta.shouldBeNull()
+    }
+
+    @Test
+    fun `delta falls back to 24h fields when yesterday lacks hourly data`() = runTest {
+        // Legacy / sparse fixtures (yesterday with no hourly entries) can't be
+        // sliced to a daytime window. The use case falls back to comparing 24h
+        // fields on both sides, keeping the comparison symmetric.
+        val sameDayHourly = listOf(
             HourlyForecast(LocalTime.of(9, 0), 14.0, 12.0, 5.0, WeatherCondition.CLEAR),
             HourlyForecast(LocalTime.of(15, 0), 22.0, 20.0, 5.0, WeatherCondition.CLEAR),
         )
@@ -334,6 +368,7 @@ class GenerateDailyInsightTest {
             feelsLikeMaxC = 20.0,
             hourly = sameDayHourly,
         )
+        // Yesterday: same 24h aggregates, no hourly — the fallback path.
         val sameDayYesterday = yesterday.copy(
             feelsLikeMinC = 4.0,
             feelsLikeMaxC = 20.0,
@@ -343,7 +378,7 @@ class GenerateDailyInsightTest {
 
         val result = subject(london, prefs)
 
-        // Raw delta: high = 20 - 20 = 0, low = 4 - 4 = 0 → both under 3°, no clause.
+        // 24h delta: high = 20 - 20 = 0, low = 4 - 4 = 0 → no clause.
         result.insight.summary.delta.shouldBeNull()
     }
 


### PR DESCRIPTION
## Summary

The "Today will be N° warmer/cooler" clause was previously computed from
today's full 24h feels-like min/max vs yesterday's full 24h fields. That
folded overnight extremes into a sentence the listener interprets as
"what will it feel like when I step outside today" — producing spurious
"+7° warmer" headlines whenever the overnight low shifted but the
daytime profile didn't.

Slice yesterday to the same morning–evening window today is already
sliced to, and compare daytime-vs-daytime feels-like high/low. Falls
back to 24h-vs-24h when either side lacks daytime hourly entries
(legacy cached payloads, sparse fixtures), to keep the comparison
symmetric in the absence of hourly data.

Open-Meteo already returns yesterday's hourly entries via `past_days=1`;
the mapper just needed to attach them to the yesterday `DailyForecast`
instead of dropping them. Renames `RenderInsightSummary`'s `rawToday`
parameter to `todayForDelta` to reflect its new role as the today side
of the delta comparison (paired with whatever yesterday the caller
chose), rather than a fallback for pre-slice 24h fields.

### Privacy note

No new data crosses the device boundary. The delta clause's rendered
prose ("It will be 5° warmer than yesterday.") is unchanged in shape;
only the underlying numbers it's computed from move from 24h to
daytime.

## Test plan

- [ ] CI: `:core:domain:test` (existing delta tests + two new ones for the
  daytime-vs-daytime path and the 24h fallback)
- [ ] CI: `:core:data:test` (mapper now exposes yesterday's hourly)
- [ ] CI: `:app:assembleDebug` + `:app:testDebugUnitTest`
- [ ] Manual: install on a day where yesterday had a noticeably different
  overnight low than daytime profile (e.g. warm overnight, mild day) and
  confirm the morning insight no longer reports a spurious large delta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AGyhCitgYtC5qTkfnA2dYk)_