### PR TITLE
:app — keep manual location fallback reachable in onboarding when always-on is skipped

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/onboarding/OnboardingScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/onboarding/OnboardingScreen.kt
@@ -284,7 +284,7 @@ private fun LocationStep(
                 text = stringResource(R.string.onboarding_location_using_device),
                 style = MaterialTheme.typography.bodyMedium,
             )
-        } else if (location != null && !needsBackgroundPrompt) {
+        } else if (location != null) {
             Text(
                 text = location.displayName ?: "${location.latitude}, ${location.longitude}",
                 style = MaterialTheme.typography.bodyMedium,
@@ -304,9 +304,14 @@ private fun LocationStep(
                 onClick = { backgroundRationaleOpen = true },
                 modifier = Modifier.fillMaxWidth(),
             ) { Text(stringResource(R.string.onboarding_location_grant_background)) }
-        } else if (!configured) {
-            // On TV, device location is not available — go straight to manual entry.
-            if (!isTelevision) {
+        }
+
+        if (!configured) {
+            // Once useDeviceLocation is on, the always-on prompt above takes over and
+            // this grant-foreground button is redundant. Hide it then but keep the
+            // manual fallback reachable below so the user can still finish onboarding
+            // with a valid configuration if they skip always-on.
+            if (!isTelevision && !useDeviceLocation) {
                 Button(
                     onClick = {
                         if (permissionGranted) {
@@ -324,9 +329,9 @@ private fun LocationStep(
                 ) { Text(stringResource(R.string.onboarding_location_grant)) }
 
                 // Once the user has been asked once and denied, surface the manual
-                // fallback as a primary path. Showing it from the start would compete
-                // with the permission button; showing it only on denial keeps the
-                // happier path uncluttered.
+                // fallback hint as a primary path. Showing it from the start would
+                // compete with the permission button; showing it only on denial keeps
+                // the happier path uncluttered.
                 if (permissionAsked && !permissionGranted) {
                     Text(
                         text = stringResource(R.string.onboarding_location_denied_hint),


### PR DESCRIPTION
## Summary

Follow-up to #265, addressing a [P1 Codex review comment](https://github.com/mikelward/clothescast/pull/265#discussion_r3173044548) that landed after merge.

When the always-on prompt path took over (foreground granted, background not granted), the onboarding `LocationStep` rendered *only* the always-on permission CTA and bypassed the `!configured` branch that contained the manual-search action. A user who declined always-on then had no way to enter a fallback city in onboarding, and could exit the flow with `useDeviceLocation=true` and no saved city — the daily worker would have nothing to read.

This PR keeps the manual `Enter location manually` action reachable whenever the step isn't yet configured, alongside the always-on prompt. It also stops hiding the saved-city display in the foreground-only state — there's no reason to hide what the user already picked.

The grant-foreground button now keys off `!useDeviceLocation` instead of `!configured`, so it isn't shown once the always-on prompt is in charge but is still available to a returning user with foreground already granted who wants to flip the toggle on.

### Cases I checked

| state | shows |
|---|---|
| fresh, no perm, no city | grant Button + manual TextButton |
| foreground granted, useDeviceLocation=true, !bg, no city, Q+ | always-on Button + manual TextButton |
| foreground+bg granted, useDeviceLocation=true | "Using device location" only |
| foreground granted, !bg, useDeviceLocation=true, manual city set | saved city + always-on Button (step shows complete) |
| returning, foreground already granted, useDeviceLocation=false, no city | grant Button (taps → enable + chain to always-on) + manual TextButton |
| TV, no city | manual TextButton only |
| permission denied | grant Button + denied hint + manual TextButton |

### Privacy

No new data crosses the device boundary.

## Test plan

- [ ] CI: JVM unit tests
- [ ] CI: Android debug build
- [ ] Manual: fresh install on Android 12+, tap grant location → decline always-on rationale → confirm manual entry button still visible and usable
- [ ] Manual: enter a manual city after declining always-on → confirm step turns green and "Continue" works
- [ ] Manual: with a saved city already, return to LocationStep with foreground granted but background revoked → confirm city is still displayed and always-on prompt is shown

https://claude.ai/code/session_0136q6S1ouBxBNCJJn5W25wa

---
_Generated by [Claude Code](https://claude.ai/code/session_0136q6S1ouBxBNCJJn5W25wa)_