### PR TITLE
:app — hash crash file for ack identity, not mtime

### DIFF
--- a/app/src/main/kotlin/app/clothescast/diag/DiagLog.kt
+++ b/app/src/main/kotlin/app/clothescast/diag/DiagLog.kt
@@ -5,6 +5,7 @@ import android.util.Log
 import java.io.File
 import java.io.PrintWriter
 import java.io.StringWriter
+import java.security.MessageDigest
 import java.text.SimpleDateFormat
 import java.util.ArrayDeque
 import java.util.Date
@@ -87,8 +88,10 @@ object DiagLog {
      * surface a "share crash report" banner; tapping either button on the
      * banner calls [acknowledgePersistedCrash].
      *
-     * Identity is the crash file's last-modified time, so a fresh crash bumps
-     * mtime and the banner re-appears even if the previous one was acked.
+     * Identity is a content hash of the crash file. Filesystem mtime tick can
+     * be coarser than ms (1s on ext4) and would collide in a fast crash loop;
+     * hashing the bytes — which include a ms-precision timestamp header and
+     * the recent log buffer — gives a fresh identity for each new crash.
      */
     fun hasUnacknowledgedCrash(): Boolean {
         val crash = crashFileProvider?.invoke() ?: return false
@@ -106,17 +109,34 @@ object DiagLog {
     internal fun isCrashUnacknowledged(crashFile: File, ackFile: File): Boolean {
         if (!crashFile.exists() || crashFile.length() == 0L) return false
         if (!ackFile.exists()) return true
-        val ackedMtime = runCatching { ackFile.readText().trim().toLong() }.getOrNull()
+        val ackedHash = runCatching { ackFile.readText().trim() }.getOrNull()
+            ?.takeIf { it.isNotEmpty() }
             ?: return true
-        return ackedMtime != crashFile.lastModified()
+        val currentHash = runCatching { crashIdentity(crashFile) }.getOrNull()
+            ?: return true
+        return ackedHash != currentHash
     }
 
     internal fun writeCrashAcknowledgement(crashFile: File, ackFile: File) {
         if (!crashFile.exists()) return
         runCatching {
+            val hash = crashIdentity(crashFile)
             ackFile.parentFile?.mkdirs()
-            ackFile.writeText(crashFile.lastModified().toString())
+            ackFile.writeText(hash)
         }
+    }
+
+    private fun crashIdentity(file: File): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+        file.inputStream().use { stream ->
+            val buf = ByteArray(8192)
+            while (true) {
+                val n = stream.read(buf)
+                if (n <= 0) break
+                digest.update(buf, 0, n)
+            }
+        }
+        return digest.digest().joinToString("") { "%02x".format(it) }
     }
 
     private fun writeCrashLog(thread: Thread, throwable: Throwable) {

--- a/app/src/test/kotlin/app/clothescast/diag/CrashAckTest.kt
+++ b/app/src/test/kotlin/app/clothescast/diag/CrashAckTest.kt
@@ -10,8 +10,9 @@ import java.nio.file.Path
  * Validates the file-based ack tracking that backs the post-crash banner on
  * the Today screen — see [DiagLog.hasUnacknowledgedCrash] and
  * [DiagLog.acknowledgePersistedCrash]. Identity of "the current crash" is
- * the crash file's last-modified time, so a fresh crash bumps mtime and the
- * banner re-surfaces even when an older crash was already acked.
+ * a content hash of the crash file, so a fresh crash hashes differently and
+ * the banner re-surfaces even when filesystem mtime resolution (1s on ext4)
+ * would have collided with the previously-acked crash.
  */
 class CrashAckTest {
 
@@ -50,22 +51,43 @@ class CrashAckTest {
         DiagLog.writeCrashAcknowledgement(crash, ack)
         DiagLog.isCrashUnacknowledged(crash, ack) shouldBe false
 
-        // Force a different last-modified time. Filesystem mtime resolution
-        // varies (1s on ext4 by default) so explicit setLastModified rather
-        // than relying on a sleep + write keeps the test fast and robust.
         crash.writeText("second")
-        crash.setLastModified(crash.lastModified() + 5_000)
+        DiagLog.isCrashUnacknowledged(crash, ack) shouldBe true
+    }
+
+    @Test
+    fun `mtime collision with new content still re-surfaces`(@TempDir dir: Path) {
+        // Filesystem mtime can tick at 1s granularity (ext4 default) so a
+        // fast crash / restart loop can produce two different crash logs that
+        // share an mtime. Identity must be content, not mtime, or the second
+        // crash would be silently swallowed as already-acked.
+        val (crash, ack) = files(dir)
+        crash.writeText("first")
+        val sharedMtime = crash.lastModified()
+        DiagLog.writeCrashAcknowledgement(crash, ack)
+        DiagLog.isCrashUnacknowledged(crash, ack) shouldBe false
+
+        crash.writeText("second")
+        crash.setLastModified(sharedMtime)
         DiagLog.isCrashUnacknowledged(crash, ack) shouldBe true
     }
 
     @Test
     fun `corrupt ack file falls back to surfacing`(@TempDir dir: Path) {
-        // If the ack file ever ends up with non-numeric junk (manual tamper,
-        // truncated write), prefer to show the banner once more rather than
-        // swallow a real crash report.
+        // If the ack file ever ends up with junk that doesn't match the
+        // current crash hash (manual tamper, truncated write), prefer to
+        // show the banner once more rather than swallow a real crash report.
         val (crash, ack) = files(dir)
         crash.writeText("boom")
-        ack.writeText("not-a-number")
+        ack.writeText("not-a-hash")
+        DiagLog.isCrashUnacknowledged(crash, ack) shouldBe true
+    }
+
+    @Test
+    fun `empty ack file falls back to surfacing`(@TempDir dir: Path) {
+        val (crash, ack) = files(dir)
+        crash.writeText("boom")
+        ack.writeText("")
         DiagLog.isCrashUnacknowledged(crash, ack) shouldBe true
     }
 


### PR DESCRIPTION
## Summary

- Crash banner identity was the crash file's `lastModified()` mtime. Filesystem mtime resolution can be coarser than ms (1s on ext4), so two distinct crash logs in a fast crash / restart loop can share an mtime — after the first is acked, the second is silently swallowed and the banner never reappears.
- Switch to a SHA-256 content hash. The crash file already includes a ms-precision header line and the recent log buffer, so two real crashes hash differently even when their mtimes collide.
- Added a regression test (`mtime collision with new content still re-surfaces`) that pins the new mtime to match the old one and asserts the new crash still surfaces. Updated the existing "fresh crash" test to drop the now-unnecessary `setLastModified` nudge, and added an "empty ack file falls back to surfacing" guard for truncated writes.

## Test plan

- [ ] CI: `JVM unit tests` green (covers `:app:testDebugUnitTest` including `CrashAckTest`).
- [ ] CI: `Android debug build` green.
- [ ] Manual: trigger two crashes back-to-back on device, ack the first, verify the second's banner appears on the next launch.

https://claude.ai/code/session_011bhAmNdwZdpXhZuveQn4hn

---
_Generated by [Claude Code](https://claude.ai/code/session_011bhAmNdwZdpXhZuveQn4hn)_