### PR TITLE
:app — rename notification titles to "Today's ClothesCast" / "Tonight's ClothesCast"

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -452,13 +452,13 @@
 
     <string name="notification_channel_daily_insight_name">Daily ClothesCast</string>
     <string name="notification_channel_daily_insight_description">The morning weather summary you opted in to.</string>
-    <string name="notification_daily_insight_title">Today\'s weather</string>
+    <string name="notification_daily_insight_title">Today\'s ClothesCast</string>
 
     <string name="notification_channel_tonight_insight_default_name">Nightly ClothesCast (with events)</string>
     <string name="notification_channel_tonight_insight_default_description">The evening weather summary when you have calendar events tonight. Plays your default notification sound.</string>
     <string name="notification_channel_tonight_insight_silent_name">Nightly ClothesCast (silent)</string>
     <string name="notification_channel_tonight_insight_silent_description">The evening weather summary when your evening is empty. Posted silently — you can glance at it on the lock screen, but it won\'t make a sound.</string>
-    <string name="notification_tonight_insight_title">Tonight\'s weather</string>
+    <string name="notification_tonight_insight_title">Tonight\'s ClothesCast</string>
 
     <string name="notification_channel_weather_alerts_name">Severe weather alerts</string>
     <string name="notification_channel_weather_alerts_description">High-priority alerts for severe or extreme weather events affecting your area. Delivered as soon as the daily fetch detects them.</string>


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Renames `notification_daily_insight_title` from `"Today's weather"` to `"Today's ClothesCast"`
- Renames `notification_tonight_insight_title` from `"Tonight's weather"` to `"Tonight's ClothesCast"`

These are the titles shown on the daily and nightly push notifications. The change aligns them with the app's brand name rather than the generic "weather" label.

## Notes

The localized string files (de, fr, es, it, etc.) have translated equivalents of "Today's weather" / "Tonight's weather" for those two keys. Those are not touched here — a translator pass would be needed to update them to e.g. "Heutiger ClothesCast" / "ClothesCast d'aujourd'hui". All other uses of "weather" in the codebase (channel descriptions, settings text, weather-alert strings) were intentionally left as-is since they describe the concept of weather, not the notification itself.

## Test plan

- [ ] Build and install a debug APK
- [ ] Trigger a daily notification — title should read "Today's ClothesCast"
- [ ] Trigger a nightly notification — title should read "Tonight's ClothesCast"

https://claude.ai/code/session_01CNscqT4xZaeHChNDETwxeD
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CNscqT4xZaeHChNDETwxeD)_