### PR TITLE
PRIVACY — broaden analytics to settings values; simplify API-key wording

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -94,9 +94,11 @@ The source code is at <https://github.com/mikelward/clothescast>.
     report — stack trace, app version, Android version, device model,
     and a non-resettable install identifier used only to group duplicate
     crashes — to a third-party crash-reporting service. This automatic
-    payload does **not** include settings, insight prose, calendar
-    data, location, API keys, or the in-memory log buffer. See
-    "Analytics and crash reporting" below for the full limits.
+    payload does **not** include insight prose, calendar data, location,
+    API keys, or the in-memory log buffer. (Your settings values may
+    travel separately as part of the aggregate analytics described
+    below.) See "Analytics and crash reporting" below for the full
+    limits.
 - **Stored on device:** The ring buffer is process-memory only. The
   crash file persists across launches until a fresh crash overwrites
   it, and is cleared on uninstall.
@@ -108,12 +110,10 @@ The source code is at <https://github.com/mikelward/clothescast>.
 ### API keys you provide
 
 - If you use online TTS, you supply your own Google Gemini, OpenAI,
-  and / or ElevenLabs API key. Keys are stored on your device encrypted
-  at rest — the ciphertext lives in Android's DataStore Preferences and
-  is wrapped by a Tink AEAD primitive whose own keyset is sealed by an
-  Android Keystore master key. Keys are sent only to the corresponding
-  provider on requests you initiate, and are never shared with us or
-  any third party.
+  and / or ElevenLabs API key. Keys are stored on your device,
+  encrypted at rest using a key sealed by the Android Keystore. They
+  are sent only to the corresponding provider on requests you initiate,
+  and are never shared with us or any third party.
 
 ## Third-party services
 
@@ -173,10 +173,11 @@ What's sent:
 - **Crash reports:** stack trace, app version, Android version, device
   model, and a non-resettable install identifier used to group duplicate
   crashes. Sent automatically when a crash occurs.
-- **Aggregate usage events:** counts of which TTS engines, schedule
-  cadences, delivery modes, and clothes-rule customisations are in use,
-  plus basic lifecycle events such as app open and daily refresh, so
-  unused options can be pruned and defaults tuned.
+- **Aggregate usage events:** the values of your in-app settings — TTS
+  engine, schedule cadence, delivery mode, units, notification time,
+  clothes-rule customisations, and the like — plus basic lifecycle
+  events such as app open and daily refresh, so unused options can be
+  pruned and defaults tuned.
 
 What's **not** sent — these are hard limits, not "best-effort":
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -205,12 +205,28 @@ collect personal data from them.
 
 ## Changes
 
-If this policy changes, the updated version will be committed to
-<https://github.com/mikelward/clothescast/blob/main/PRIVACY.md>; the
-"Last updated" date at the top will reflect the change. Material changes
-to data handling will also be noted in the app's release notes.
+If this policy changes, the updated version is committed to
+<https://github.com/mikelward/clothescast/blob/main/PRIVACY.md> and the
+"Last updated" date at the top reflects the change. A short summary of
+each material change is added to the [Changelog](#changelog) below, and
+material changes are also noted in the app's release notes.
+
+The full revision history of this file is viewable on GitHub:
+**[View all changes to PRIVACY.md →](https://github.com/mikelward/clothescast/commits/main/PRIVACY.md)**
 
 ## Contact
 
 Open an issue at <https://github.com/mikelward/clothescast/issues> or
 email the address listed on the Play Store listing.
+
+## Changelog
+
+- **2026-05-03** — Permitted automatic crash reporting and aggregate
+  usage analytics in all builds and for all users, with hard limits on
+  what those payloads may include (no calendar data, location, insight
+  prose, API keys, precise GPS, or ad identifiers). Broadened analytics
+  to cover in-app settings values. Simplified the API-key storage
+  description.
+- **2026-05-01** — Initial publication.
+
+[View full revision history on GitHub →](https://github.com/mikelward/clothescast/commits/main/PRIVACY.md)


### PR DESCRIPTION
## Summary

Two follow-ups to the policy that landed in #277:

- **Analytics — broaden "Aggregate usage events" to settings values.** Was: "counts of which TTS engines, schedule cadences, delivery modes, and clothes-rule customisations are in use." Now: "the values of your in-app settings — TTS engine, schedule cadence, delivery mode, units, notification time, clothes-rule customisations, and the like." Gives room to ship richer product-decision analytics later without another policy update.
- **Crash-report exclusion drops "settings."** The "Automatically, possibly" sub-bullet under "Diagnostic logs and crash reports" no longer claims settings are excluded from the auto crash payload — it points at the analytics section instead, so settings can travel via either channel. Insight prose, calendar data, location, API keys, and the in-memory log buffer remain hard-excluded from the crash payload.
- **API-keys section simplified.** Was: "the ciphertext lives in Android's DataStore Preferences and is wrapped by a Tink AEAD primitive whose own keyset is sealed by an Android Keystore master key." Now: "encrypted at rest using a key sealed by the Android Keystore." Same guarantee, less jargon for a user-facing policy.

### Privacy surface change

Per `CLAUDE.md`'s privacy rule, flagging:

- **Broadened off-device payload:** analytics may now carry settings values, not just usage counts.
- **Unchanged hard exclusions:** calendar event data, location coordinates / place names, insight prose, notification text, API keys, precise GPS, ad identifiers, contact info.

No code change — markdown only.

## Test plan

- [ ] Re-read the analytics bullet, the crash-report sub-bullet, and the "What's not sent" hard-limits list end-to-end and confirm they describe a consistent payload shape (settings ✅ in, content ❌ out).
- [ ] Confirm the API-keys section still accurately describes the implementation (Keystore-sealed key wrapping the credentials at rest).

---
_Generated by [Claude Code](https://claude.ai/code/session_017GLgrMHtCLjZFV72BbRRLq)_