### PR TITLE
PRIVACY — drop "no tracking" from TL;DR (resolves Codex review on #277)

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -26,7 +26,12 @@ have over it.
   (e.g. _"Bring a jacket for your concert tonight"_), and is therefore
   also sent to the TTS provider in that one case — only when both calendar
   tie-in and online TTS are enabled.
-- Nothing is sold, no advertising, no profiling, no tracking.
+- Nothing is sold, no advertising, no ad-targeting profiles, no
+  third-party data sharing beyond the services listed below. (The
+  aggregate usage analytics + crash reports above _do_ count as
+  cross-session telemetry — that's what the install identifier in the
+  crash payload is for. The "Analytics and crash reporting" section
+  spells out exactly what's in and out.)
 
 ## Who we are
 


### PR DESCRIPTION
## Summary

Addresses [Codex's review comment on #277](https://github.com/mikelward/clothescast/pull/277#discussion_r3177655340) (was unresolved when #277 / #278 merged).

The TL;DR's last bullet read: _"Nothing is sold, no advertising, no profiling, no tracking."_ — but the analytics + crash-reporting section now permits default-on aggregate usage events for all users plus a non-resettable install identifier in the crash payload. Codex correctly flagged that as cross-session behaviour data that contradicts "no tracking."

This narrows the TL;DR claim instead of narrowing the telemetry, since shipping default-on analytics is the explicit goal:

> Nothing is sold, no advertising, no ad-targeting profiles, no third-party data sharing beyond the services listed below. (The aggregate usage analytics + crash reports above _do_ count as cross-session telemetry — that's what the install identifier in the crash payload is for. The "Analytics and crash reporting" section spells out exactly what's in and out.)

### Privacy surface change

No new data leaves the device — this only fixes a misleading claim in the policy text. Hard exclusions in the analytics section are unchanged.

## Test plan

- [ ] Skim the TL;DR and "Analytics and crash reporting" sections together and confirm the wording no longer contradicts itself.

---
_Generated by [Claude Code](https://claude.ai/code/session_017GLgrMHtCLjZFV72BbRRLq)_