### PR TITLE
:app — default TTS engine to Gemini when user enters Gemini key during onboarding

### DIFF
--- a/app/src/main/kotlin/app/clothescast/MainActivity.kt
+++ b/app/src/main/kotlin/app/clothescast/MainActivity.kt
@@ -238,6 +238,7 @@ private fun ClothesCastNav(app: ClothesCastApplication, navigateToTodayVersion: 
             val pairing: PairingViewModel = viewModel(
                 factory = PairingViewModel.Factory(
                     secureKeyStore = app.secureKeyStore,
+                    settingsRepository = app.settingsRepository,
                 ),
             )
             PairingScreen(

--- a/app/src/main/kotlin/app/clothescast/data/SettingsRepository.kt
+++ b/app/src/main/kotlin/app/clothescast/data/SettingsRepository.kt
@@ -129,6 +129,18 @@ class SettingsRepository(
         dataStore.edit { it[TTS_ENGINE] = engine.name }
     }
 
+    /**
+     * Writes [engine] only if no TTS engine has been explicitly stored. Used by
+     * onboarding to flip the default from DEVICE to GEMINI when the user enters
+     * a Gemini key, without clobbering an explicit choice the user later made
+     * in Settings if they re-enter onboarding.
+     */
+    suspend fun setTtsEngineIfUnset(engine: TtsEngine) {
+        dataStore.edit { prefs ->
+            if (prefs[TTS_ENGINE] == null) prefs[TTS_ENGINE] = engine.name
+        }
+    }
+
     suspend fun setGeminiVoice(voice: String) {
         dataStore.edit { it[GEMINI_VOICE] = voice }
     }

--- a/app/src/main/kotlin/app/clothescast/ui/onboarding/OnboardingViewModel.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/onboarding/OnboardingViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import app.clothescast.core.data.location.OpenMeteoGeocodingClient
 import app.clothescast.core.domain.model.Location
+import app.clothescast.core.domain.model.TtsEngine
 import app.clothescast.data.SecureKeyStore
 import app.clothescast.data.SettingsRepository
 import kotlinx.coroutines.flow.SharingStarted
@@ -44,7 +45,13 @@ class OnboardingViewModel(
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), OnboardingState())
 
     fun setApiKey(key: String) {
-        viewModelScope.launch { secureKeyStore.set(key.trim()) }
+        viewModelScope.launch {
+            secureKeyStore.set(key.trim())
+            // First-run flip: if the user hasn't picked a TTS engine yet,
+            // default to Gemini now that they've configured a Gemini key.
+            // setTtsEngineIfUnset is a no-op when an explicit choice exists.
+            settingsRepository.setTtsEngineIfUnset(TtsEngine.GEMINI)
+        }
     }
 
     fun setUseDeviceLocation(enabled: Boolean) {

--- a/app/src/main/kotlin/app/clothescast/ui/pairing/PairingViewModel.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/pairing/PairingViewModel.kt
@@ -6,7 +6,9 @@ import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
+import app.clothescast.core.domain.model.TtsEngine
 import app.clothescast.data.SecureKeyStore
+import app.clothescast.data.SettingsRepository
 import app.clothescast.pairing.PairingServer
 import com.google.zxing.BarcodeFormat
 import com.google.zxing.qrcode.QRCodeWriter
@@ -52,6 +54,7 @@ sealed interface PairingState {
  */
 class PairingViewModel(
     private val secureKeyStore: SecureKeyStore,
+    private val settingsRepository: SettingsRepository,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow<PairingState>(PairingState.Error)
@@ -79,6 +82,10 @@ class PairingViewModel(
             val srv = PairingServer { key ->
                 viewModelScope.launch {
                     secureKeyStore.set(key)
+                    // Mirror OnboardingViewModel.setApiKey: configuring a Gemini
+                    // key during onboarding flips the TTS default to Gemini,
+                    // unless the user already picked an engine in Settings.
+                    settingsRepository.setTtsEngineIfUnset(TtsEngine.GEMINI)
                     _state.value = PairingState.Received
                 }
             }
@@ -119,13 +126,14 @@ class PairingViewModel(
 
     class Factory(
         private val secureKeyStore: SecureKeyStore,
+        private val settingsRepository: SettingsRepository,
     ) : ViewModelProvider.Factory {
         @Suppress("UNCHECKED_CAST")
         override fun <T : ViewModel> create(modelClass: Class<T>): T {
             require(modelClass.isAssignableFrom(PairingViewModel::class.java)) {
                 "Unknown ViewModel: ${modelClass.name}"
             }
-            return PairingViewModel(secureKeyStore) as T
+            return PairingViewModel(secureKeyStore, settingsRepository) as T
         }
     }
 

--- a/app/src/test/kotlin/app/clothescast/data/SettingsRepositoryTest.kt
+++ b/app/src/test/kotlin/app/clothescast/data/SettingsRepositoryTest.kt
@@ -14,6 +14,7 @@ import app.clothescast.core.domain.model.OutfitSuggestion
 import app.clothescast.core.domain.model.Region
 import app.clothescast.core.domain.model.Schedule
 import app.clothescast.core.domain.model.TemperatureUnit
+import app.clothescast.core.domain.model.TtsEngine
 import app.clothescast.core.domain.model.VoiceLocale
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.collections.shouldContainExactly
@@ -338,6 +339,33 @@ class SettingsRepositoryTest {
 
         subject.setElevenLabsStability(-0.5)
         subject.preferences.first().elevenLabsStability shouldBe 0.0
+    }
+
+    @Test
+    fun `setTtsEngineIfUnset writes when nothing is stored`() = runTest {
+        subject.preferences.first().ttsEngine shouldBe TtsEngine.DEVICE
+
+        subject.setTtsEngineIfUnset(TtsEngine.GEMINI)
+        subject.preferences.first().ttsEngine shouldBe TtsEngine.GEMINI
+    }
+
+    @Test
+    fun `setTtsEngineIfUnset does not clobber an explicit choice`() = runTest {
+        subject.setTtsEngine(TtsEngine.ELEVENLABS)
+
+        subject.setTtsEngineIfUnset(TtsEngine.GEMINI)
+        subject.preferences.first().ttsEngine shouldBe TtsEngine.ELEVENLABS
+    }
+
+    @Test
+    fun `setTtsEngineIfUnset does not clobber an explicit DEVICE choice`() = runTest {
+        // The default is also DEVICE, so explicitly picking DEVICE has to
+        // count as "set" — otherwise re-running onboarding would silently
+        // promote a deliberately-DEVICE user to Gemini.
+        subject.setTtsEngine(TtsEngine.DEVICE)
+
+        subject.setTtsEngineIfUnset(TtsEngine.GEMINI)
+        subject.preferences.first().ttsEngine shouldBe TtsEngine.DEVICE
     }
 
     @Test


### PR DESCRIPTION
## Summary

- During onboarding's "save Gemini API key" step, also flip the TTS engine preference from the `DEVICE` default to `GEMINI` — but only if the user hasn't explicitly chosen one yet.
- Adds `SettingsRepository.setTtsEngineIfUnset()` so the write is a no-op once any explicit choice (including a deliberate `DEVICE` pick) is stored. Onboarding can be re-entered (e.g. after a key clear), and we don't want to clobber a Settings-level choice the user made between visits.

## Rationale

Today the default TTS engine is `DEVICE` regardless of which providers the user has configured. A user who enters a Gemini key during onboarding has effectively opted into Gemini for the cloud-backed bits — defaulting their TTS to Gemini too is the least-surprising thing.

Doesn't add new TTS providers or change what data is sent off device. Gemini TTS was already an option requiring a user-supplied key; this just changes which provider is selected by default for users who set the key during onboarding.

## Test plan

- [ ] CI: `JVM unit tests` job stays green (new `SettingsRepositoryTest` cases cover the three branches: unset → writes, explicit non-default → preserved, explicit DEVICE → preserved).
- [ ] CI: `Android debug build` stays green.
- [ ] Manual on a fresh install: enter a Gemini key in onboarding → open Settings → Voice → engine reads `Gemini`.
- [ ] Manual: pick `ElevenLabs` in Settings, clear the Gemini key, re-enter onboarding, set the key again → engine still reads `ElevenLabs`.
- [ ] Manual: pick `On-device` explicitly in Settings, clear the Gemini key, re-enter onboarding, set the key again → engine still reads `On-device` (deliberate `DEVICE` pick is preserved).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qe8p6vLA4T2fyJUhTAxxcj)_