### PR TITLE
:app — raise minSdk to 31 and fix BG-location deep-link on Android 11+

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -48,7 +48,7 @@ android {
 
     defaultConfig {
         applicationId = "app.clothescast"
-        minSdk = 26
+        minSdk = 31
         targetSdk = 35
         versionCode = gitCommitCount
         // semver build metadata: <base>+<commitCount>.<shortSha>. Some downstream
@@ -233,8 +233,8 @@ dependencies {
     implementation(libs.androidx.work.runtime.ktx)
 
     // Home-screen App Widget — Glance speaks Compose at the source level but
-    // emits RemoteViews under the hood, so it works back to the API 26 minSdk
-    // and there's no separate XML layout to maintain.
+    // emits RemoteViews under the hood, so there's no separate XML layout to
+    // maintain.
     implementation(libs.androidx.glance.appwidget)
     implementation(libs.androidx.glance.material3)
 

--- a/app/src/main/kotlin/app/clothescast/alarm/DailyAlarmScheduler.kt
+++ b/app/src/main/kotlin/app/clothescast/alarm/DailyAlarmScheduler.kt
@@ -4,7 +4,6 @@ import android.app.AlarmManager
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
-import android.os.Build
 import app.clothescast.diag.DiagLog
 import androidx.core.content.getSystemService
 import app.clothescast.core.domain.model.ForecastPeriod
@@ -25,9 +24,8 @@ import java.time.Instant
  * - `setExactAndAllowWhileIdle` is the only primitive that fires at a precise wall-clock
  *   time even in Doze. The plan calls for it.
  * - Permission is gated by `USE_EXACT_ALARM` (API 33+, no user prompt) and
- *   `SCHEDULE_EXACT_ALARM` (API 31-32, granted by default). On API <31 no permission is
- *   needed. If we ever ship on API <33 with the prompt path, callers should fall back to
- *   `setAndAllowWhileIdle` when [AlarmManager.canScheduleExactAlarms] is false.
+ *   `SCHEDULE_EXACT_ALARM` (API 31-32, granted by default). The fallback to
+ *   `setAndAllowWhileIdle` covers a manual revoke at runtime.
  * - `Schedule.zoneId` is intentionally re-resolved by the repository on each read so DST
  *   and travel changes pick up automatically. This scheduler does not cache the zone.
  */
@@ -44,7 +42,7 @@ class DailyAlarmScheduler(
         val triggerAt: Instant = schedule.nextOccurrenceAfter(clock.instant())
         val pendingIntent = pendingIntent(context, period)
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && !alarmManager.canScheduleExactAlarms()) {
+        if (!alarmManager.canScheduleExactAlarms()) {
             // USE_EXACT_ALARM (API 33+) auto-grants this; on the API 31-32 shim path it's
             // also granted by default. If somehow it's denied (user revoked manually),
             // fall back to setAndAllowWhileIdle so the user still gets the notification,

--- a/app/src/main/kotlin/app/clothescast/location/LocationPermissions.kt
+++ b/app/src/main/kotlin/app/clothescast/location/LocationPermissions.kt
@@ -3,7 +3,6 @@ package app.clothescast.location
 import android.Manifest
 import android.content.Context
 import android.content.pm.PackageManager
-import android.os.Build
 import androidx.core.content.ContextCompat
 
 // Permission helpers shared by the onboarding step, the Data sources Settings
@@ -17,10 +16,8 @@ fun hasCoarseLocationPermission(context: Context): Boolean =
         Manifest.permission.ACCESS_COARSE_LOCATION,
     ) == PackageManager.PERMISSION_GRANTED
 
-fun hasBackgroundLocationPermission(context: Context): Boolean {
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) return true
-    return ContextCompat.checkSelfPermission(
+fun hasBackgroundLocationPermission(context: Context): Boolean =
+    ContextCompat.checkSelfPermission(
         context,
         Manifest.permission.ACCESS_BACKGROUND_LOCATION,
     ) == PackageManager.PERMISSION_GRANTED
-}

--- a/app/src/main/kotlin/app/clothescast/location/LocationResolver.kt
+++ b/app/src/main/kotlin/app/clothescast/location/LocationResolver.kt
@@ -7,7 +7,6 @@ import android.content.pm.PackageManager
 import android.location.Location as AndroidLocation
 import android.location.LocationListener
 import android.location.LocationManager
-import android.os.Build
 import android.os.Looper
 import app.clothescast.diag.DiagLog
 import androidx.core.content.ContextCompat
@@ -60,14 +59,11 @@ class LocationResolver(
             return null
         }
         // The Worker runs in the background, so a missing ACCESS_BACKGROUND_LOCATION
-        // grant on Android 10+ will make the OS throw SecurityException from any
-        // location call — log it up front so the cause is obvious in DiagLog
-        // instead of looking like a generic "location returned null".
+        // grant will make the OS throw SecurityException from any location call —
+        // log it up front so the cause is obvious in DiagLog instead of looking
+        // like a generic "location returned null".
         if (!hasBackgroundPermission()) {
-            DiagLog.w(
-                TAG,
-                "Background location not granted (Android 10+); calls from the worker will fail.",
-            )
+            DiagLog.w(TAG, "Background location not granted; calls from the worker will fail.")
         }
         val manager = context.getSystemService<LocationManager>()
         if (manager == null) {
@@ -92,13 +88,10 @@ class LocationResolver(
         Manifest.permission.ACCESS_COARSE_LOCATION,
     ) == PackageManager.PERMISSION_GRANTED
 
-    private fun hasBackgroundPermission(): Boolean {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) return true
-        return ContextCompat.checkSelfPermission(
-            context,
-            Manifest.permission.ACCESS_BACKGROUND_LOCATION,
-        ) == PackageManager.PERMISSION_GRANTED
-    }
+    private fun hasBackgroundPermission(): Boolean = ContextCompat.checkSelfPermission(
+        context,
+        Manifest.permission.ACCESS_BACKGROUND_LOCATION,
+    ) == PackageManager.PERMISSION_GRANTED
 
     @SuppressLint("MissingPermission")
     private fun lastKnown(manager: LocationManager): AndroidLocation? = try {

--- a/app/src/main/kotlin/app/clothescast/ui/onboarding/OnboardingScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/onboarding/OnboardingScreen.kt
@@ -213,11 +213,8 @@ private fun LocationStep(
     var backgroundRationaleOpen by remember { mutableStateOf(false) }
     var backgroundDeniedOpen by remember { mutableStateOf(false) }
 
-    // Background launcher: on Android 10 (API 29) the launcher shows the inline
-    // runtime prompt with "Allow all the time"; on Android 11+ launching the same
-    // permission deep-links straight to the system Location permission page (the
-    // picker that contains "Allow all the time"). The platform handles the split
-    // — we just call .launch().
+    // Background launcher: launching ACCESS_BACKGROUND_LOCATION deep-links to the
+    // system Location-permission picker (the page with "Allow all the time").
     val backgroundLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.RequestPermission(),
     ) { granted ->
@@ -239,9 +236,7 @@ private fun LocationStep(
             // ACCESS_BACKGROUND_LOCATION to read the device fix when the app isn't
             // foregrounded. Without this chain the user finishes onboarding with
             // foreground-only and the worker silently falls back to the saved city.
-            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q &&
-                !hasBackgroundLocationPermission(context)
-            ) {
+            if (!hasBackgroundLocationPermission(context)) {
                 backgroundRationaleOpen = true
             }
         }
@@ -318,9 +313,7 @@ private fun LocationStep(
                     onClick = {
                         if (permissionGranted) {
                             onSetUseDeviceLocation(true)
-                            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q &&
-                                !backgroundGranted
-                            ) {
+                            if (!backgroundGranted) {
                                 backgroundRationaleOpen = true
                             }
                         } else {
@@ -379,11 +372,10 @@ private fun LocationStep(
             confirmButton = {
                 TextButton(onClick = {
                     backgroundRationaleOpen = false
-                    // The launcher handles the SDK split: API 29 shows the inline
-                    // runtime prompt; API 30+ deep-links to the Location permission
-                    // page so the user can tap "Allow all the time". Earlier code
-                    // sent R+ through openAppDetails, which dumps them on the
-                    // generic App info screen instead of the location picker.
+                    // Launching ACCESS_BACKGROUND_LOCATION deep-links to the system
+                    // Location-permission picker so the user can tap "Allow all the
+                    // time". An earlier version routed through openAppDetails here,
+                    // which dumps them on the generic App info screen instead.
                     backgroundLauncher.launch(android.Manifest.permission.ACCESS_BACKGROUND_LOCATION)
                 }) { Text(stringResource(R.string.settings_location_background_rationale_continue)) }
             },

--- a/app/src/main/kotlin/app/clothescast/ui/onboarding/OnboardingScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/onboarding/OnboardingScreen.kt
@@ -213,9 +213,11 @@ private fun LocationStep(
     var backgroundRationaleOpen by remember { mutableStateOf(false) }
     var backgroundDeniedOpen by remember { mutableStateOf(false) }
 
-    // Background launcher: on Android Q (API 29) the inline runtime prompt works;
-    // on R+ ACCESS_BACKGROUND_LOCATION can only be granted from system Settings, so
-    // we deep-link there from the rationale dialog instead of using this launcher.
+    // Background launcher: on Android 10 (API 29) the launcher shows the inline
+    // runtime prompt with "Allow all the time"; on Android 11+ launching the same
+    // permission deep-links straight to the system Location permission page (the
+    // picker that contains "Allow all the time"). The platform handles the split
+    // — we just call .launch().
     val backgroundLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.RequestPermission(),
     ) { granted ->
@@ -377,13 +379,12 @@ private fun LocationStep(
             confirmButton = {
                 TextButton(onClick = {
                     backgroundRationaleOpen = false
-                    // API 30+ forces the system Settings deep-link for background
-                    // location; API 29 still accepts the inline runtime prompt.
-                    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R) {
-                        openAppDetails(context)
-                    } else {
-                        backgroundLauncher.launch(android.Manifest.permission.ACCESS_BACKGROUND_LOCATION)
-                    }
+                    // The launcher handles the SDK split: API 29 shows the inline
+                    // runtime prompt; API 30+ deep-links to the Location permission
+                    // page so the user can tap "Allow all the time". Earlier code
+                    // sent R+ through openAppDetails, which dumps them on the
+                    // generic App info screen instead of the location picker.
+                    backgroundLauncher.launch(android.Manifest.permission.ACCESS_BACKGROUND_LOCATION)
                 }) { Text(stringResource(R.string.settings_location_background_rationale_continue)) }
             },
             dismissButton = {

--- a/app/src/main/kotlin/app/clothescast/ui/settings/LocationSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/LocationSettings.kt
@@ -1,7 +1,6 @@
 package app.clothescast.ui.settings
 
 import android.Manifest
-import android.os.Build
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
@@ -120,11 +119,9 @@ private fun LocationCard(
         // would hit our isPermissionGranted check, return null, and quietly fall
         // through to the settings location every day.
         onSetUseDeviceLocation(granted)
-        if (granted && !hasBackgroundLocationPermission(context) &&
-            Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q
-        ) {
+        if (granted && !hasBackgroundLocationPermission(context)) {
             // Auto-chain into the always-on rationale; the worker can't read the
-            // device fix without ACCESS_BACKGROUND_LOCATION on Q+.
+            // device fix without ACCESS_BACKGROUND_LOCATION.
             backgroundRationaleOpen = true
         }
     }
@@ -153,22 +150,12 @@ private fun LocationCard(
                         return@Switch
                     }
                     when {
-                        !coarseGranted -> {
-                            // Pre-Q has no separate "Allow all the time" choice — coarse
-                            // grant *is* always-on — so the rationale dialog applies on
-                            // Q+ only. On older platforms skip straight to the
-                            // foreground request; the background launcher and denied
-                            // dialog also no-op there because
-                            // hasBackgroundLocationPermission() returns true.
-                            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                                rationaleOpen = true
-                            } else {
-                                foregroundLauncher.launch(Manifest.permission.ACCESS_COARSE_LOCATION)
-                            }
-                        }
+                        // Show the rationale before the foreground prompt; we'll auto-
+                        // chain into the background rationale when the user grants.
+                        !coarseGranted -> rationaleOpen = true
                         !backgroundGranted -> {
-                            // Q+ only: foreground granted previously; surface the
-                            // always-on rationale before deep-linking into Settings.
+                            // Foreground granted previously; surface the always-on
+                            // rationale before deep-linking into Settings.
                             onSetUseDeviceLocation(true)
                             backgroundRationaleOpen = true
                         }
@@ -252,13 +239,11 @@ private fun LocationCard(
             confirmButton = {
                 TextButton(onClick = {
                     backgroundRationaleOpen = false
-                    // The platform handles the SDK split for us: on Android 10 the
-                    // launcher shows the inline runtime prompt with "Allow all the
-                    // time"; on Android 11+ it deep-links straight to the Location
-                    // permission settings page (the picker with the "Allow all the
-                    // time" radio). Earlier code routed R+ through openAppDetails,
-                    // which only opens the generic App info screen and forces the
-                    // user to drill in via Permissions → Location themselves.
+                    // Launching ACCESS_BACKGROUND_LOCATION deep-links to the system
+                    // Location-permission picker (the page with the "Allow all the
+                    // time" radio). An earlier version routed through openAppDetails
+                    // here, which only opens the generic App info screen and forces
+                    // the user to drill in via Permissions → Location themselves.
                     backgroundLauncher.launch(Manifest.permission.ACCESS_BACKGROUND_LOCATION)
                 }) { Text(stringResource(R.string.settings_location_background_rationale_continue)) }
             },

--- a/app/src/main/kotlin/app/clothescast/ui/settings/LocationSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/LocationSettings.kt
@@ -252,13 +252,14 @@ private fun LocationCard(
             confirmButton = {
                 TextButton(onClick = {
                     backgroundRationaleOpen = false
-                    // API 30+ forces the system Settings deep-link; API 29 still
-                    // accepts the inline runtime prompt.
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-                        openAppDetails(context)
-                    } else {
-                        backgroundLauncher.launch(Manifest.permission.ACCESS_BACKGROUND_LOCATION)
-                    }
+                    // The platform handles the SDK split for us: on Android 10 the
+                    // launcher shows the inline runtime prompt with "Allow all the
+                    // time"; on Android 11+ it deep-links straight to the Location
+                    // permission settings page (the picker with the "Allow all the
+                    // time" radio). Earlier code routed R+ through openAppDetails,
+                    // which only opens the generic App info screen and forces the
+                    // user to drill in via Permissions → Location themselves.
+                    backgroundLauncher.launch(Manifest.permission.ACCESS_BACKGROUND_LOCATION)
                 }) { Text(stringResource(R.string.settings_location_background_rationale_continue)) }
             },
             dismissButton = {

--- a/app/src/main/kotlin/app/clothescast/ui/theme/Theme.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/theme/Theme.kt
@@ -1,6 +1,5 @@
 package app.clothescast.ui.theme
 
-import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
@@ -32,7 +31,7 @@ fun ClothesCastTheme(
     content: @Composable () -> Unit,
 ) {
     val colorScheme = when {
-        dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
+        dynamicColor -> {
             val ctx = LocalContext.current
             if (darkTheme) dynamicDarkColorScheme(ctx) else dynamicLightColorScheme(ctx)
         }

--- a/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
@@ -101,7 +101,7 @@ class FetchAndNotifyWorker(
                 //
                 //   1. Misconfigured — useDeviceLocation off + no saved
                 //      fallback, OR useDeviceLocation on but the user hasn't
-                //      granted ACCESS_BACKGROUND_LOCATION (Q+) yet. The user
+                //      granted ACCESS_BACKGROUND_LOCATION yet. The user
                 //      has to do something; retrying on backoff would just
                 //      hammer the system every 30s with no progress. Fail
                 //      with REASON_NO_LOCATION so the Today banner prompts


### PR DESCRIPTION
## Summary

Two commits, in order:

1. **`:app — deep-link straight to Location permission page on Android 11+`** — the bug fix the PR was opened for. Tapping "Grant always-on location" was sending users to the generic _App info_ screen via `openAppDetails(...)` because of a stale `SDK_INT >= R` branch. Calling `RequestPermission().launch(ACCESS_BACKGROUND_LOCATION)` already deep-links to the Location-permission picker on its own — the special-case was strictly worse.

2. **`:app — raise minSdk to 31 (Android 12); prune now-trivial SDK_INT branches`** — bumps the floor from API 26 (Android 8 Oreo, 2017) to API 31 (Android 12, Oct 2021) and removes every `SDK_INT >= Q / R / S` guard the bump renders trivially-true. ~75% of active devices are on API 31+; we'd been carrying ~8 years of platform-version branching for the bottom slice.

`TIRAMISU` (API 33) guards stay — they cover real Android 12-vs-13 behaviour and our chosen floor is 31, not 33. The manifest's `SCHEDULE_EXACT_ALARM android:maxSdkVersion="32"` stays too: API 31-32 auto-grants via that line; API 33+ uses `USE_EXACT_ALARM`.

## Test plan

- [ ] Android 12 device — toggle "use device location" → grant foreground → tap continue on the rationale → the **Location permission page** opens with the "Allow all the time / While using the app / Don't allow" radios (not the generic App info screen).
- [ ] Same flow from the onboarding location step.
- [ ] Deny background, return to the app → the `backgroundDeniedOpen` dialog still routes to App info as the fallback.
- [ ] Dynamic colour theming still applies on a Pixel.
- [ ] Daily 7am alarm still arms (visible via diagnostics).
- [ ] CI: `:app:testDebugUnitTest` (Roborazzi snapshots — pinned to `@Config(sdk = [33])`, so unaffected by the floor bump) and `:app:assembleDebug` clean.