### PR TITLE
:core:data — steer Gemini TTS toward friendly announcement, not theatrical

### DIFF
--- a/core/data/src/main/kotlin/app/clothescast/core/data/tts/GeminiTtsClient.kt
+++ b/core/data/src/main/kotlin/app/clothescast/core/data/tts/GeminiTtsClient.kt
@@ -43,10 +43,18 @@ internal const val GEMINI_API_VERSION = "v1beta"
  * lo-fi "vinyl crackle" character the model otherwise bakes into the output
  * across the full clip (OpenAI TTS, going through the same player at the same
  * 24 kHz, has none of it — so this is server-side, not playback-side).
+ *
+ * Tone guidance: voices default to an exaggerated theatrical delivery without
+ * explicit direction. "Friendly PA announcement" / "morning radio host" is the
+ * target — clear, well-enunciated, slightly upbeat and attention-getting, but
+ * grounded and conversational, not cinematic or over-the-top.
  */
 internal const val GEMINI_TTS_STYLE_DIRECTIVE: String =
-    "Read the following in a clean, crisp studio voice with no audio effects, " +
-        "background noise, or vinyl-style texture:\n\n"
+    "Read the following as a clear, well-enunciated, slightly upbeat announcement — " +
+        "like a friendly morning radio host or public address system. " +
+        "Speak with energy and confidence so it grabs attention, but keep the tone " +
+        "grounded and conversational. Not theatrical, not dramatic, not cinematic. " +
+        "No audio effects, background noise, or vinyl-style texture:\n\n"
 
 /**
  * Returns a one-line accent / language instruction for Gemini's TTS prompt, or

--- a/core/data/src/main/kotlin/app/clothescast/core/data/tts/OpenAITtsClient.kt
+++ b/core/data/src/main/kotlin/app/clothescast/core/data/tts/OpenAITtsClient.kt
@@ -29,19 +29,23 @@ import kotlinx.serialization.json.JsonPrimitive
 //     voice's baked-in accent dominates regardless of directive. Voice-list
 //     filtering in `TtsVoices` is the mechanism for giving the user a
 //     non-American voice (just `fable`, the only British in the stock list).
-//   - *pace* and *enunciation* steering does land — directives like "speak
-//     clearly at a measured pace" measurably slow the synthesis and reduce
-//     dropped consonants on field tests. We send the directive below for
-//     every clip; it's a constant, not locale-aware, since the goal is
-//     "clear and unrushed in any language" rather than accent-shaping.
+//   - *tone* and *pace* steering does land — directives like "speak clearly
+//     at a measured pace" measurably slow the synthesis and reduce dropped
+//     consonants on field tests. We also steer toward a friendly-announcement
+//     tone to avoid the theatrical delivery the model defaults to. The
+//     directive is a constant, not locale-aware, since the goal is
+//     "clear, upbeat, and grounded in any language" rather than accent-shaping.
 const val DEFAULT_OPENAI_TTS_MODEL: String = "gpt-4o-mini-tts"
 const val DEFAULT_OPENAI_TTS_VOICE: String = "alloy"
 // Mirrors `core:domain:UserPreferences.DEFAULT_OPENAI_SPEED` — the API's
 // stock 1.0× pace. Duplicated here so this layer can stay domain-free.
 const val DEFAULT_OPENAI_TTS_SPEED: Double = 1.0
 
-private const val PACE_AND_CLARITY_INSTRUCTIONS: String =
-    "Speak clearly at a measured, conversational pace, enunciating each word."
+private const val TONE_INSTRUCTIONS: String =
+    "Speak as a clear, well-enunciated, slightly upbeat announcement — like a friendly " +
+        "morning radio host or public address system. Speak with energy and confidence " +
+        "so it grabs attention, but keep the tone grounded and conversational. " +
+        "Not theatrical, not dramatic, not cinematic."
 
 /**
  * OpenAI text-to-speech via `https://api.openai.com/v1/audio/speech`.
@@ -77,7 +81,7 @@ class OpenAITtsClient(
                     input = text,
                     voice = voice,
                     responseFormat = "pcm",
-                    instructions = PACE_AND_CLARITY_INSTRUCTIONS,
+                    instructions = TONE_INSTRUCTIONS,
                     // Only send a non-default value to keep the request body
                     // minimal and to avoid the (slim) chance that the field
                     // changes the model's behaviour at exactly 1.0.

--- a/core/data/src/test/kotlin/app/clothescast/core/data/tts/GeminiTtsClientTest.kt
+++ b/core/data/src/test/kotlin/app/clothescast/core/data/tts/GeminiTtsClientTest.kt
@@ -101,7 +101,7 @@ class GeminiTtsClientTest {
         client.synthesize(text = "hello world")
 
         val body = checkNotNull(capturedBody)
-        body.shouldContain("clean, crisp studio voice")
+        body.shouldContain("clear, well-enunciated, slightly upbeat announcement")
         body.shouldContain("hello world")
     }
 

--- a/core/data/src/test/kotlin/app/clothescast/core/data/tts/OpenAITtsClientTest.kt
+++ b/core/data/src/test/kotlin/app/clothescast/core/data/tts/OpenAITtsClientTest.kt
@@ -101,8 +101,7 @@ class OpenAITtsClientTest {
 
         val body = checkNotNull(capturedBody)
         body.shouldContain("\"instructions\":")
-        body.shouldContain("measured, conversational pace")
-        body.shouldContain("enunciating each word")
+        body.shouldContain("friendly morning radio host or public address system")
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Replaces the vague "clean, crisp studio voice" directive with explicit tone guidance: clear, well-enunciated, slightly upbeat — like a morning radio host or PA system
- The old directive only suppressed audio artefacts; it said nothing about delivery, leaving the model free to use theatrical/cinematic reads
- Updates the test assertion to match the new directive text

## Test plan

- [ ] CI passes (JVM unit tests check the directive text is included in the request body)
- [ ] Manually test a sample TTS clip — should sound like a friendly PA announcement, not a movie trailer

https://claude.ai/code/session_015zpa5EsTGUDkjLfKsJ8C5F

---
_Generated by [Claude Code](https://claude.ai/code/session_015zpa5EsTGUDkjLfKsJ8C5F)_