### PR TITLE
:app — fix stuck "Detecting…" on Location settings page

### DIFF
--- a/app/src/main/kotlin/app/clothescast/MainActivity.kt
+++ b/app/src/main/kotlin/app/clothescast/MainActivity.kt
@@ -229,6 +229,7 @@ private fun ClothesCastNav(app: ClothesCastApplication, navigateToTodayVersion: 
                         // double-notify.
                         FetchAndNotifyWorker.enqueueLocationCacheRefresh(context)
                     },
+                    workManager = WorkManager.getInstance(app),
                 ),
             )
             SettingsScreen(

--- a/app/src/main/kotlin/app/clothescast/ui/settings/LocationSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/LocationSettings.kt
@@ -47,6 +47,7 @@ import kotlinx.coroutines.launch
 internal fun LocationContent(
     location: Location?,
     useDeviceLocation: Boolean,
+    locationDetecting: Boolean = false,
     padding: PaddingValues,
     onSetUseDeviceLocation: (Boolean) -> Unit,
     onSelectLocation: (Location) -> Unit,
@@ -64,6 +65,7 @@ internal fun LocationContent(
         LocationCard(
             current = location,
             useDeviceLocation = useDeviceLocation,
+            locationDetecting = locationDetecting,
             onSetUseDeviceLocation = onSetUseDeviceLocation,
             onSelect = onSelectLocation,
             onClear = onClearLocation,
@@ -76,6 +78,7 @@ internal fun LocationContent(
 private fun LocationCard(
     current: Location?,
     useDeviceLocation: Boolean,
+    locationDetecting: Boolean,
     onSetUseDeviceLocation: (Boolean) -> Unit,
     onSelect: (Location) -> Unit,
     onClear: () -> Unit,
@@ -171,7 +174,7 @@ private fun LocationCard(
         )
 
         Text(
-            text = currentLocationSummary(current, useDeviceLocation),
+            text = currentLocationSummary(current, useDeviceLocation, locationDetecting),
             style = MaterialTheme.typography.bodyLarge,
         )
 
@@ -276,11 +279,19 @@ private fun LocationCard(
 }
 
 @Composable
-private fun currentLocationSummary(current: Location?, useDeviceLocation: Boolean): String {
+private fun currentLocationSummary(
+    current: Location?,
+    useDeviceLocation: Boolean,
+    locationDetecting: Boolean,
+): String {
     if (current != null) {
         return current.displayName ?: "${current.latitude}, ${current.longitude}"
     }
-    return if (useDeviceLocation) {
+    // Show "Detecting…" only while the cache-refresh worker is actively running.
+    // Once it reaches a terminal state locationDetecting flips false, so the
+    // label falls back to the unset string instead of staying stuck forever when
+    // the worker finishes without finding a fix (no permission, provider timeout).
+    return if (useDeviceLocation && locationDetecting) {
         stringResource(R.string.settings_location_detecting)
     } else {
         stringResource(R.string.settings_location_unset)

--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsScreen.kt
@@ -195,6 +195,7 @@ fun SettingsScreen(
             SettingsRoute.Location -> LocationContent(
                 location = state.location,
                 useDeviceLocation = state.useDeviceLocation,
+                locationDetecting = state.locationDetecting,
                 padding = padding,
                 onSetUseDeviceLocation = viewModel::setUseDeviceLocation,
                 onSelectLocation = viewModel::selectLocation,

--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsState.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsState.kt
@@ -93,4 +93,11 @@ data class SettingsState(
      */
     val elevenLabsRefreshedVoices: List<TtsVoiceOption>? = null,
     val elevenLabsRefreshing: Boolean = false,
+    /**
+     * True while the WorkManager location-cache-refresh job is ENQUEUED,
+     * RUNNING, or BLOCKED. Drives "Detecting…" in the Location settings
+     * card — the label only shows "Detecting…" while this is true, so it
+     * can't get stuck after the worker finishes without resolving a fix.
+     */
+    val locationDetecting: Boolean = false,
 )

--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsViewModel.kt
@@ -3,6 +3,8 @@ package app.clothescast.ui.settings
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
+import androidx.work.WorkInfo
+import androidx.work.WorkManager
 import app.clothescast.core.data.location.OpenMeteoGeocodingClient
 import app.clothescast.core.data.tts.ElevenLabsTtsClient
 import app.clothescast.core.domain.model.ClothesRule
@@ -19,6 +21,7 @@ import app.clothescast.core.domain.model.VoiceLocale
 import app.clothescast.data.SecureKeyStore
 import app.clothescast.data.SettingsRepository
 import app.clothescast.diag.DiagLog
+import app.clothescast.work.FetchAndNotifyWorker
 import app.clothescast.tts.TtsVoiceEnumerator
 import app.clothescast.tts.resolve
 import app.clothescast.tts.toJavaLocale
@@ -67,6 +70,13 @@ class SettingsViewModel(
      * `FetchAndNotifyWorker.enqueueOneShot`.
      */
     private val refreshLocationCache: () -> Unit = {},
+    /**
+     * WorkManager for observing the location-cache-refresh job state and for
+     * cancelling it when device location is toggled off mid-flight. Null in
+     * tests — JVM test host has no Android services; [locationDetecting] then
+     * stays permanently false.
+     */
+    private val workManager: WorkManager? = null,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(SettingsState())
@@ -135,6 +145,19 @@ class SettingsViewModel(
             }
         }
         viewModelScope.launch { refreshApiKeyStatus() }
+        workManager?.let { wm ->
+            viewModelScope.launch {
+                wm.getWorkInfosForUniqueWorkFlow(FetchAndNotifyWorker.UNIQUE_WORK_NAME_LOCATION_CACHE)
+                    .collect { infos ->
+                        val detecting = infos.any { info ->
+                            info.state == WorkInfo.State.ENQUEUED ||
+                                info.state == WorkInfo.State.RUNNING ||
+                                info.state == WorkInfo.State.BLOCKED
+                        }
+                        _state.update { it.copy(locationDetecting = detecting) }
+                    }
+            }
+        }
     }
 
     /**
@@ -367,15 +390,20 @@ class SettingsViewModel(
     fun setUseDeviceLocation(enabled: Boolean) {
         viewModelScope.launch {
             settingsRepository.setUseDeviceLocation(enabled)
-            // Eagerly populate the device-location cache so the user sees
-            // their city in Settings within seconds, instead of waiting for
-            // the morning worker run. The worker resolves the device fix and
-            // writes it back via setLocation() before any cache short-circuit,
-            // so this works even when today's insight is already cached.
-            // Awaited *after* the toggle write so the worker reads the
-            // freshly-updated `useDeviceLocation = true` and actually attempts
-            // the resolve. Skipped on toggle-off — nothing to refresh there.
-            if (enabled) refreshLocationCache()
+            if (enabled) {
+                // Eagerly populate the device-location cache so the user sees
+                // their city in Settings within seconds, instead of waiting for
+                // the morning worker run. Awaited *after* the toggle write so
+                // the worker reads useDeviceLocation = true when it resolves.
+                refreshLocationCache()
+            } else {
+                // Cancel any in-flight cache-refresh job. Without this, an
+                // on→off flip before the job starts still lets it run and
+                // persist a device fix via setLocation(), silently overwriting
+                // the user's manual fallback city even though device location
+                // is now off.
+                workManager?.cancelUniqueWork(FetchAndNotifyWorker.UNIQUE_WORK_NAME_LOCATION_CACHE)
+            }
         }
     }
 
@@ -461,6 +489,7 @@ class SettingsViewModel(
         private val showError: (String) -> Unit,
         private val applyAppLocale: (Region) -> Unit,
         private val refreshLocationCache: () -> Unit,
+        private val workManager: WorkManager? = null,
     ) : ViewModelProvider.Factory {
         @Suppress("UNCHECKED_CAST")
         override fun <T : ViewModel> create(modelClass: Class<T>): T {
@@ -478,6 +507,7 @@ class SettingsViewModel(
                 showError,
                 applyAppLocale,
                 refreshLocationCache,
+                workManager,
             ) as T
         }
     }


### PR DESCRIPTION
## Problem

`currentLocationSummary` showed "Detecting…" whenever `useDeviceLocation = true` and `location == null`, with no mechanism to clear it once the cache-refresh worker finished. If the worker timed out, lacked permission, or couldn't get a fix, the label stayed stuck until the user left and re-entered the settings page.

**Note:** main's history was force-updated after this branch was first pushed; the branch is now rebased onto the new `main`. The logging improvements to `LocationResolver` and `FetchAndNotifyWorker`'s cache-only path already landed on `main` in `682f329` — this PR adds only the remaining UI/ViewModel plumbing.

## Fix

**`SettingsState` — `locationDetecting: Boolean`**
Tracks whether the WorkManager cache-refresh job (`UNIQUE_WORK_NAME_LOCATION_CACHE`) is ENQUEUED / RUNNING / BLOCKED. Flips to `false` the moment the worker reaches any terminal state, so the label can escape regardless of whether the fix succeeded or failed.

**`SettingsViewModel`**
- Subscribes to `getWorkInfosForUniqueWorkFlow(UNIQUE_WORK_NAME_LOCATION_CACHE)` in `init` and maps the live states to `locationDetecting`.
- Also **cancels** the in-flight job when the user flips device location back **off**. Without this, an on→off flip before the worker starts still lets it run and persist a device fix via `setLocation()`, silently overwriting the user's manual fallback city even though `useDeviceLocation` is now false (Codex P2 review).
- `WorkManager? = null` default keeps `SettingsViewModelTest` unchanged — the JVM test host has no Android services.

**`currentLocationSummary`**
Guards "Detecting…" on `locationDetecting` instead of bare `useDeviceLocation`, so "No location set" is shown when the worker is done but found nothing.

## Test plan

- [ ] Enable device location → card shows "Detecting…" briefly, then location name once worker completes
- [ ] Enable then immediately disable device location → "Detecting…" never appears (or clears instantly); in-flight job is cancelled
- [ ] Enable device location with no background permission → "Detecting…" clears to "No location set" once the worker terminates
- [ ] Enable device location with location services off → "Detecting…" clears within ~10 s (resolver timeout)
- [ ] CI JVM unit tests pass (`SettingsViewModelTest` unchanged)

https://claude.ai/code/session_019hT8oPaK8jT6vAm5dqVsvw