### PR TITLE
:core:data + :app — log full geocoder response fields for UI field audit

### DIFF
--- a/app/src/main/kotlin/app/clothescast/location/ReverseGeocoder.kt
+++ b/app/src/main/kotlin/app/clothescast/location/ReverseGeocoder.kt
@@ -52,6 +52,7 @@ class ReverseGeocoder(
                 DiagLog.w(TAG, "Reverse geocode timed out after ${timeoutMillis}ms.")
                 return null
             }
+        addresses.firstOrNull()?.logAllFields()
         return addresses.firstOrNull()?.pickCityName()
     }
 
@@ -109,6 +110,26 @@ class ReverseGeocoder(
         listOf(locality, subLocality, subAdminArea)
             .firstOrNull { !it.isNullOrBlank() }
             ?.trim()
+
+    private fun Address.logAllFields() {
+        DiagLog.d(TAG, "reverse geocode address fields:")
+        DiagLog.d(TAG, "  featureName=$featureName")
+        DiagLog.d(TAG, "  premises=$premises")
+        DiagLog.d(TAG, "  subThoroughfare=$subThoroughfare")
+        DiagLog.d(TAG, "  thoroughfare=$thoroughfare")
+        DiagLog.d(TAG, "  subLocality=$subLocality")
+        DiagLog.d(TAG, "  locality=$locality")
+        DiagLog.d(TAG, "  subAdminArea=$subAdminArea")
+        DiagLog.d(TAG, "  adminArea=$adminArea")
+        DiagLog.d(TAG, "  countryCode=$countryCode")
+        DiagLog.d(TAG, "  countryName=$countryName")
+        DiagLog.d(TAG, "  postalCode=$postalCode")
+        DiagLog.d(TAG, "  phone=$phone")
+        DiagLog.d(TAG, "  url=$url")
+        for (i in 0..maxAddressLineIndex) {
+            DiagLog.d(TAG, "  addressLine[$i]=${getAddressLine(i)}")
+        }
+    }
 
     companion object {
         private const val TAG = "ReverseGeocoder"

--- a/core/data/src/main/kotlin/app/clothescast/core/data/location/GeocodingDto.kt
+++ b/core/data/src/main/kotlin/app/clothescast/core/data/location/GeocodingDto.kt
@@ -11,6 +11,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 internal data class OpenMeteoGeocodingResponse(
     val results: List<GeocodingResult>? = null,
+    @SerialName("generationtime_ms") val generationtimeMs: Double? = null,
 )
 
 @Serializable
@@ -19,7 +20,19 @@ internal data class GeocodingResult(
     val name: String,
     val latitude: Double,
     val longitude: Double,
-    val country: String? = null,
-    val admin1: String? = null,
+    val elevation: Double? = null,
+    @SerialName("feature_code") val featureCode: String? = null,
     @SerialName("country_code") val countryCode: String? = null,
+    @SerialName("country_id") val countryId: Long? = null,
+    val country: String? = null,
+    val timezone: String? = null,
+    val population: Long? = null,
+    @SerialName("admin1_id") val admin1Id: Long? = null,
+    @SerialName("admin2_id") val admin2Id: Long? = null,
+    @SerialName("admin3_id") val admin3Id: Long? = null,
+    @SerialName("admin4_id") val admin4Id: Long? = null,
+    val admin1: String? = null,
+    val admin2: String? = null,
+    val admin3: String? = null,
+    val admin4: String? = null,
 )

--- a/core/data/src/main/kotlin/app/clothescast/core/data/location/OpenMeteoGeocodingClient.kt
+++ b/core/data/src/main/kotlin/app/clothescast/core/data/location/OpenMeteoGeocodingClient.kt
@@ -7,6 +7,7 @@ import io.ktor.client.request.get
 import io.ktor.client.request.parameter
 import io.ktor.http.URLProtocol
 import io.ktor.http.path
+import java.util.logging.Logger
 
 internal const val GEOCODING_HOST = "geocoding-api.open-meteo.com"
 
@@ -35,11 +36,27 @@ class OpenMeteoGeocodingClient(private val httpClient: HttpClient) {
             parameter("format", "json")
         }.body()
 
+        response.results.orEmpty().forEachIndexed { i, r ->
+            logger.fine("geocoding result[$i]: " +
+                "id=${r.id} name=${r.name} " +
+                "lat=${r.latitude} lon=${r.longitude} elevation=${r.elevation} " +
+                "featureCode=${r.featureCode} " +
+                "countryCode=${r.countryCode} countryId=${r.countryId} country=${r.country} " +
+                "timezone=${r.timezone} population=${r.population} " +
+                "admin1Id=${r.admin1Id} admin1=${r.admin1} " +
+                "admin2Id=${r.admin2Id} admin2=${r.admin2} " +
+                "admin3Id=${r.admin3Id} admin3=${r.admin3} " +
+                "admin4Id=${r.admin4Id} admin4=${r.admin4}")
+        }
         return response.results.orEmpty().map { it.toDomain() }
     }
 
     private fun GeocodingResult.toDomain(): Location {
         val displayName = listOfNotNull(name, admin1, country).joinToString(", ")
         return Location(latitude = latitude, longitude = longitude, displayName = displayName)
+    }
+
+    private companion object {
+        val logger: Logger = Logger.getLogger(OpenMeteoGeocodingClient::class.java.name)
     }
 }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Expands `GeocodingDto.GeocodingResult` to deserialise all Open-Meteo geocoding fields currently dropped on the floor: `elevation`, `feature_code`, `admin2`–`admin4` (names and `*_id` keys), `timezone`, `population`, `country_id`
- Logs every field of each result at `FINE` level in `OpenMeteoGeocodingClient.search()` so a local run with verbose logging shows exactly what the API returns
- Logs every field of the Android `Address` object via `DiagLog.d` in `ReverseGeocoder` (full address-line array, `featureName`, `premises`, thoroughfare hierarchy, `adminArea`, `postalCode`, `phone`, `url`) before the city-name pick — gives a full picture for the reverse side

No behaviour change: `toDomain()` and `pickCityName()` are untouched; this is a read-only audit build.

## Privacy note

No new data leaves the device. The logging is local (logcat / DiagLog file) only.

## Test plan

- [ ] Build and install debug APK
- [ ] Search for a location in Settings — check logcat tag `OpenMeteoGeocodingClient` at FINE/VERBOSE for all result fields
- [ ] Enable device location — trigger a background refresh — check logcat tag `ReverseGeocoder` for all `Address` fields
- [ ] Confirm existing city-name resolution still works (Today screen shows location label)

https://claude.ai/code/session_01QwBHiqAu1dqX1DVYgn7pit
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QwBHiqAu1dqX1DVYgn7pit)_