### PR TITLE
Default delivery to notification+TTS and evening events on

### DIFF
--- a/app/src/main/kotlin/app/clothescast/data/SettingsRepository.kt
+++ b/app/src/main/kotlin/app/clothescast/data/SettingsRepository.kt
@@ -271,7 +271,7 @@ class SettingsRepository(
             ?.takeIf { it.isNotEmpty() }
             ?: Schedule.EVERY_DAY
         val deliveryMode = this[DELIVERY_MODE]?.let { runCatching { DeliveryMode.valueOf(it) }.getOrNull() }
-            ?: DeliveryMode.NOTIFICATION_ONLY
+            ?: DeliveryMode.NOTIFICATION_AND_TTS
         // Tonight's mode falls back to [deliveryMode] when absent so existing
         // installs keep the old "shared mode" behaviour until the user
         // explicitly diverges the two cards in Settings.
@@ -333,7 +333,7 @@ class SettingsRepository(
         // no calendar events, so it's not noisy out of the box).
         val tonightEnabled = this[TONIGHT_ENABLED] != false
         val tonightNotifyOnlyOnEvents = this[TONIGHT_NOTIFY_ONLY_ON_EVENTS] == true
-        val dailyMentionEveningEvents = this[DAILY_MENTION_EVENING_EVENTS] == true
+        val dailyMentionEveningEvents = this[DAILY_MENTION_EVENING_EVENTS] != false
         // Each cutoff falls back independently to the matching DEFAULT field, so a user
         // who only nudged the jacket cutoff still gets the default sweater/shorts cuts.
         val outfitThresholds = OutfitSuggestion.Thresholds(

--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsState.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsState.kt
@@ -28,9 +28,9 @@ data class SettingsState(
     val tonightDays: Set<DayOfWeek> = Schedule.EVERY_DAY,
     val tonightEnabled: Boolean = true,
     val tonightNotifyOnlyOnEvents: Boolean = false,
-    val deliveryMode: DeliveryMode = DeliveryMode.NOTIFICATION_ONLY,
-    val tonightDeliveryMode: DeliveryMode = DeliveryMode.NOTIFICATION_ONLY,
-    val dailyMentionEveningEvents: Boolean = false,
+    val deliveryMode: DeliveryMode = DeliveryMode.NOTIFICATION_AND_TTS,
+    val tonightDeliveryMode: DeliveryMode = DeliveryMode.NOTIFICATION_AND_TTS,
+    val dailyMentionEveningEvents: Boolean = true,
     val region: Region = Region.SYSTEM,
     // Match SettingsRepository's locale-aware defaults so en-US devices don't
     // briefly render °C / km before the first DataStore emission overrides it.

--- a/app/src/test/kotlin/app/clothescast/data/SettingsRepositoryTest.kt
+++ b/app/src/test/kotlin/app/clothescast/data/SettingsRepositoryTest.kt
@@ -79,7 +79,7 @@ class SettingsRepositoryTest {
         prefs.schedule.time shouldBe LocalTime.of(7, 0)
         prefs.schedule.days shouldBe Schedule.EVERY_DAY
         prefs.schedule.zoneId shouldBe zone
-        prefs.deliveryMode shouldBe DeliveryMode.NOTIFICATION_ONLY
+        prefs.deliveryMode shouldBe DeliveryMode.NOTIFICATION_AND_TTS
         prefs.temperatureUnit shouldBe TemperatureUnit.CELSIUS
         prefs.distanceUnit shouldBe DistanceUnit.KILOMETERS
         prefs.clothesRules shouldBe ClothesRule.DEFAULTS
@@ -131,14 +131,14 @@ class SettingsRepositoryTest {
     }
 
     @Test
-    fun `dailyMentionEveningEvents defaults to false and round-trips`() = runTest {
-        subject.preferences.first().dailyMentionEveningEvents shouldBe false
-
-        subject.setDailyMentionEveningEvents(true)
+    fun `dailyMentionEveningEvents defaults to true and round-trips`() = runTest {
         subject.preferences.first().dailyMentionEveningEvents shouldBe true
 
         subject.setDailyMentionEveningEvents(false)
         subject.preferences.first().dailyMentionEveningEvents shouldBe false
+
+        subject.setDailyMentionEveningEvents(true)
+        subject.preferences.first().dailyMentionEveningEvents shouldBe true
     }
 
     @Test
@@ -246,7 +246,7 @@ class SettingsRepositoryTest {
         }
 
         val prefs = subject.preferences.first()
-        prefs.deliveryMode shouldBe DeliveryMode.NOTIFICATION_ONLY
+        prefs.deliveryMode shouldBe DeliveryMode.NOTIFICATION_AND_TTS
         prefs.temperatureUnit shouldBe TemperatureUnit.CELSIUS
         prefs.schedule.days shouldBe Schedule.EVERY_DAY
     }

--- a/app/src/test/kotlin/app/clothescast/ui/settings/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/app/clothescast/ui/settings/SettingsViewModelTest.kt
@@ -126,7 +126,7 @@ class SettingsViewModelTest {
         // The initial MutableStateFlow value matches our defaults; await the first
         // collector emission so anything from DataStore that disagreed would surface here.
         val state = subject.state.first {
-            !it.apiKeyConfigured && it.deliveryMode == DeliveryMode.NOTIFICATION_ONLY
+            !it.apiKeyConfigured && it.deliveryMode == DeliveryMode.NOTIFICATION_AND_TTS
         }
         state.temperatureUnit shouldBe TemperatureUnit.CELSIUS
         state.distanceUnit shouldBe DistanceUnit.KILOMETERS

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Settings.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Settings.kt
@@ -306,9 +306,9 @@ data class UserPreferences(
      * calendar events with a clothing tip keyed to the *evening* forecast — e.g.
      * "Bring a jacket for your 9pm dinner." The tip is gated on
      * [useCalendarEvents] (no events without that), and only fires when at least
-     * one clothes rule triggers against the evening hourly slice. Off by default.
+     * one clothes rule triggers against the evening hourly slice. On by default.
      */
-    val dailyMentionEveningEvents: Boolean = false,
+    val dailyMentionEveningEvents: Boolean = true,
     /**
      * Feels-like cutoffs that decide which top + bottom the home screen renders
      * as the glanceable outfit. Defaults match the previously-hardcoded values


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Fresh installs now default the delivery mode to `NOTIFICATION_AND_TTS` (notification shown + spoken aloud) for both the morning and evening schedule slots, instead of `NOTIFICATION_ONLY`
- `dailyMentionEveningEvents` now defaults to `true` so the morning insight mentions relevant evening calendar events out of the box
- Updated tests to assert the new defaults and kept round-trip coverage intact

## Test plan

- [ ] CI passes (JVM unit tests cover `SettingsRepositoryTest` and `SettingsViewModelTest` default assertions)
- [ ] Fresh install: open Settings → Schedule card shows "Notification + spoken aloud" pre-selected for both Daily and Tonight slots
- [ ] Fresh install: "Mention evening events in morning insight" toggle is on by default
- [ ] Existing install (DataStore already has a value): delivery mode and evening-events toggle are unchanged (stored value wins over default)

https://claude.ai/code/session_01591kwLTfpUxAuxckiyHV1L
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01591kwLTfpUxAuxckiyHV1L)_