### PR TITLE
:app — auto-fetch location after permission grant in onboarding

### DIFF
--- a/app/src/main/kotlin/app/clothescast/MainActivity.kt
+++ b/app/src/main/kotlin/app/clothescast/MainActivity.kt
@@ -248,6 +248,16 @@ private fun ClothesCastNav(app: ClothesCastApplication, navigateToTodayVersion: 
                     secureKeyStore = app.secureKeyStore,
                     settingsRepository = app.settingsRepository,
                     geocodingClient = app.geocodingClient,
+                    refreshLocationCache = {
+                        // Eager device-location populate when the user grants
+                        // location permission during onboarding. Cache-only
+                        // path — same worker used by Settings — so the
+                        // resolved city surfaces in seconds and the user can
+                        // tell at a glance whether they need to enter a
+                        // manual fallback instead.
+                        FetchAndNotifyWorker.enqueueLocationCacheRefresh(context)
+                    },
+                    workManager = WorkManager.getInstance(app),
                 ),
             )
             OnboardingScreen(

--- a/app/src/main/kotlin/app/clothescast/ui/onboarding/OnboardingScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/onboarding/OnboardingScreen.kt
@@ -74,6 +74,7 @@ fun OnboardingScreen(
             geminiKeyConfigured = state.geminiKeyConfigured,
             location = state.location,
             useDeviceLocation = state.useDeviceLocation,
+            locationDetecting = state.locationDetecting,
             isTelevision = isTV,
             padding = padding,
             onSetApiKey = viewModel::setApiKey,
@@ -92,6 +93,7 @@ internal fun OnboardingContent(
     geminiKeyConfigured: Boolean,
     location: Location?,
     useDeviceLocation: Boolean,
+    locationDetecting: Boolean = false,
     isTelevision: Boolean = false,
     padding: PaddingValues,
     onSetApiKey: (String) -> Unit,
@@ -128,6 +130,7 @@ internal fun OnboardingContent(
         LocationStep(
             location = location,
             useDeviceLocation = useDeviceLocation,
+            locationDetecting = locationDetecting,
             isTelevision = isTelevision,
             onSetUseDeviceLocation = onSetUseDeviceLocation,
             onSelectLocation = onSelectLocation,
@@ -196,6 +199,7 @@ private fun NotificationStep() {
 private fun LocationStep(
     location: Location?,
     useDeviceLocation: Boolean,
+    locationDetecting: Boolean,
     isTelevision: Boolean,
     onSetUseDeviceLocation: (Boolean) -> Unit,
     onSelectLocation: (Location) -> Unit,
@@ -276,14 +280,27 @@ private fun LocationStep(
         description = stringResource(R.string.onboarding_location_description),
         complete = configured,
     ) {
-        if (deviceLocationFullyConfigured) {
-            Text(
-                text = stringResource(R.string.onboarding_location_using_device),
-                style = MaterialTheme.typography.bodyMedium,
-            )
-        } else if (location != null) {
+        // Prefer the resolved city — once the cache-refresh worker has
+        // written through, location is non-null even when device location
+        // is on, and showing the actual displayName lets the user verify
+        // the fix matches reality before continuing. Fall back to
+        // "Detecting…" while the worker is in-flight, and to the static
+        // device-location confirmation text only when both perms are
+        // granted but we somehow have no fix yet (e.g. NETWORK_PROVIDER
+        // returned no result).
+        if (location != null) {
             Text(
                 text = location.displayName ?: "${location.latitude}, ${location.longitude}",
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        } else if (useDeviceLocation && locationDetecting) {
+            Text(
+                text = stringResource(R.string.settings_location_detecting),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        } else if (deviceLocationFullyConfigured) {
+            Text(
+                text = stringResource(R.string.onboarding_location_using_device),
                 style = MaterialTheme.typography.bodyMedium,
             )
         }

--- a/app/src/main/kotlin/app/clothescast/ui/onboarding/OnboardingScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/onboarding/OnboardingScreen.kt
@@ -223,7 +223,20 @@ private fun LocationStep(
         contract = ActivityResultContracts.RequestPermission(),
     ) { granted ->
         backgroundGranted = granted
-        if (!granted) backgroundDeniedOpen = true
+        if (granted) {
+            // Re-trigger cache refresh: the foreground-grant callback above
+            // already enqueued a refresh, but that run can fire and complete
+            // before the user has tapped "Allow all the time" — in which case
+            // LocationResolver returns null (SecurityException from
+            // requestSingleUpdate without ACCESS_BACKGROUND_LOCATION) and
+            // onboarding stays stuck without a resolved city. Calling
+            // setUseDeviceLocation(true) is idempotent for the preference but
+            // re-enqueues the cache-refresh worker via REPLACE, which now
+            // succeeds with both perms in place.
+            onSetUseDeviceLocation(true)
+        } else {
+            backgroundDeniedOpen = true
+        }
     }
 
     val launcher = rememberLauncherForActivityResult(
@@ -280,22 +293,24 @@ private fun LocationStep(
         description = stringResource(R.string.onboarding_location_description),
         complete = configured,
     ) {
-        // Prefer the resolved city — once the cache-refresh worker has
-        // written through, location is non-null even when device location
-        // is on, and showing the actual displayName lets the user verify
-        // the fix matches reality before continuing. Fall back to
-        // "Detecting…" while the worker is in-flight, and to the static
-        // device-location confirmation text only when both perms are
-        // granted but we somehow have no fix yet (e.g. NETWORK_PROVIDER
-        // returned no result).
-        if (location != null) {
-            Text(
-                text = location.displayName ?: "${location.latitude}, ${location.longitude}",
-                style = MaterialTheme.typography.bodyMedium,
-            )
-        } else if (useDeviceLocation && locationDetecting) {
+        // While the cache-refresh worker is in flight, surface "Detecting…"
+        // *before* any cached location — otherwise a manual fallback the
+        // user picked earlier in onboarding would mask the fact that a
+        // device-location lookup is still running, and they'd treat the
+        // stale manual pick as the freshly-resolved device fix. Once the
+        // worker writes through, location is non-null and we show the
+        // real displayName so the user can verify the fix matches reality.
+        // Fall back to the static device-location confirmation text only
+        // when both perms are granted but we have no fix yet (e.g.
+        // NETWORK_PROVIDER returned no result).
+        if (useDeviceLocation && locationDetecting) {
             Text(
                 text = stringResource(R.string.settings_location_detecting),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        } else if (location != null) {
+            Text(
+                text = location.displayName ?: "${location.latitude}, ${location.longitude}",
                 style = MaterialTheme.typography.bodyMedium,
             )
         } else if (deviceLocationFullyConfigured) {

--- a/app/src/main/kotlin/app/clothescast/ui/onboarding/OnboardingViewModel.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/onboarding/OnboardingViewModel.kt
@@ -3,11 +3,15 @@ package app.clothescast.ui.onboarding
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
+import androidx.work.WorkInfo
+import androidx.work.WorkManager
 import app.clothescast.core.data.location.OpenMeteoGeocodingClient
 import app.clothescast.core.domain.model.Location
 import app.clothescast.core.domain.model.TtsEngine
 import app.clothescast.data.SecureKeyStore
 import app.clothescast.data.SettingsRepository
+import app.clothescast.work.FetchAndNotifyWorker
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
@@ -18,6 +22,7 @@ data class OnboardingState(
     val geminiKeyConfigured: Boolean = false,
     val location: Location? = null,
     val useDeviceLocation: Boolean = false,
+    val locationDetecting: Boolean = false,
 )
 
 /**
@@ -31,16 +36,54 @@ class OnboardingViewModel(
     private val secureKeyStore: SecureKeyStore,
     private val settingsRepository: SettingsRepository,
     private val geocodingClient: OpenMeteoGeocodingClient,
+    /**
+     * Kicks off a one-shot worker run to resolve the device location and
+     * write it through to settings. Triggered when the user grants
+     * foreground location permission so the resolved city appears in
+     * onboarding within seconds — otherwise the user has no way to know if
+     * the device's idea of "here" is right and might continue to a manual
+     * pick they don't actually need. Defaulted to a no-op so pure-VM tests
+     * don't need WorkManager; the Activity wires
+     * `FetchAndNotifyWorker.enqueueLocationCacheRefresh`.
+     */
+    private val refreshLocationCache: () -> Unit = {},
+    /**
+     * WorkManager for observing the cache-refresh job so onboarding can show
+     * "Detecting…" while the worker resolves the fix, and cancel it when the
+     * user toggles device location off mid-flight. Null in tests — JVM test
+     * host has no Android services; [OnboardingState.locationDetecting] then
+     * stays permanently false.
+     */
+    private val workManager: WorkManager? = null,
 ) : ViewModel() {
+
+    private val locationDetecting = MutableStateFlow(false)
+
+    init {
+        workManager?.let { wm ->
+            viewModelScope.launch {
+                wm.getWorkInfosForUniqueWorkFlow(FetchAndNotifyWorker.UNIQUE_WORK_NAME_LOCATION_CACHE)
+                    .collect { infos ->
+                        locationDetecting.value = infos.any { info ->
+                            info.state == WorkInfo.State.ENQUEUED ||
+                                info.state == WorkInfo.State.RUNNING ||
+                                info.state == WorkInfo.State.BLOCKED
+                        }
+                    }
+            }
+        }
+    }
 
     val state: StateFlow<OnboardingState> = combine(
         secureKeyStore.geminiKeyConfiguredFlow,
         settingsRepository.preferences,
-    ) { keyConfigured, prefs ->
+        locationDetecting,
+    ) { keyConfigured, prefs, detecting ->
         OnboardingState(
             geminiKeyConfigured = keyConfigured,
             location = prefs.location,
             useDeviceLocation = prefs.useDeviceLocation,
+            locationDetecting = detecting,
         )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), OnboardingState())
 
@@ -55,7 +98,22 @@ class OnboardingViewModel(
     }
 
     fun setUseDeviceLocation(enabled: Boolean) {
-        viewModelScope.launch { settingsRepository.setUseDeviceLocation(enabled) }
+        viewModelScope.launch {
+            settingsRepository.setUseDeviceLocation(enabled)
+            if (enabled) {
+                // Mirror SettingsViewModel: eagerly populate the device-location
+                // cache so the user sees their city in onboarding within
+                // seconds. Without this they'd have to either trust the
+                // permission grant blindly or wait for the morning worker
+                // before knowing whether the resolved city matches reality.
+                refreshLocationCache()
+            } else {
+                // Cancel any in-flight cache-refresh job — without this an
+                // on→off flip before the job starts still lets it run and
+                // overwrite the user's manual pick via setLocation().
+                workManager?.cancelUniqueWork(FetchAndNotifyWorker.UNIQUE_WORK_NAME_LOCATION_CACHE)
+            }
+        }
     }
 
     fun selectLocation(location: Location) {
@@ -68,6 +126,8 @@ class OnboardingViewModel(
         private val secureKeyStore: SecureKeyStore,
         private val settingsRepository: SettingsRepository,
         private val geocodingClient: OpenMeteoGeocodingClient,
+        private val refreshLocationCache: () -> Unit,
+        private val workManager: WorkManager?,
     ) : ViewModelProvider.Factory {
         @Suppress("UNCHECKED_CAST")
         override fun <T : ViewModel> create(modelClass: Class<T>): T {
@@ -78,6 +138,8 @@ class OnboardingViewModel(
                 secureKeyStore = secureKeyStore,
                 settingsRepository = settingsRepository,
                 geocodingClient = geocodingClient,
+                refreshLocationCache = refreshLocationCache,
+                workManager = workManager,
             ) as T
         }
     }


### PR DESCRIPTION
## Summary

Mirror the Settings flow in onboarding so granting location permission immediately resolves the device fix instead of leaving the user staring at a static "Using your device's location each morning" line with no way to know whether the resolved city actually matches reality (and whether they need to enter a manual fallback).

- `OnboardingViewModel` gains the same `refreshLocationCache` callback + `WorkManager` wiring `SettingsViewModel` already has. On `setUseDeviceLocation(true)` it kicks the cache-only worker; on `false` it cancels any in-flight unique work to avoid an off-flip silently overwriting the user's manual pick.
- New `OnboardingState.locationDetecting` is driven by `getWorkInfosForUniqueWorkFlow(UNIQUE_WORK_NAME_LOCATION_CACHE)` — same observation `SettingsViewModel` does — so the UI can show "Detecting…" while the fix is in flight.
- `LocationStep` now prefers the resolved city's `displayName`, falls back to the existing `settings_location_detecting` string while detecting, and only drops to the static device-location confirmation line when both perms are granted but no fix is available (e.g. NETWORK_PROVIDER returned nothing).
- `MainActivity` wires the new factory params to `FetchAndNotifyWorker.enqueueLocationCacheRefresh(context)` and `WorkManager.getInstance(app)` — same one-liner used by the settings VM.

No new strings (reused `R.string.settings_location_detecting`). No change to what we send off device — same cache-refresh worker, same reverse-geocode path that Settings already uses.

## Test plan

- [ ] CI: JVM unit tests + Android debug build pass (sandbox can't run AGP locally — relying on CI).
- [ ] Roborazzi snapshot tests still pass — `OnboardingContent`'s new `locationDetecting: Boolean = false` defaults to false, and the existing previews call it via named args.
- [ ] Manual: fresh install → grant location → confirm "Detecting…" appears, then resolves to the real city within seconds.
- [ ] Manual: grant then immediately toggle off (if reachable from onboarding) → confirm worker is cancelled and manual pick isn't overwritten.
- [ ] Manual: deny location → confirm flow falls through to the manual-entry path unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QFeZgZYu8ypAWyMTBrMD7n)_