### PR TITLE
:app — fix first-launch banner showing "Last attempt failed — retrying"

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayViewModel.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayViewModel.kt
@@ -83,8 +83,10 @@ internal fun List<WorkInfo>.toLite(): List<WorkInfoLite> =
  *
  * Selection rules, in priority order:
  *  1. **Active wins.** If any entry is ENQUEUED/RUNNING/BLOCKED, that's the
- *     live run; ignore terminal history. If [WorkInfo.runAttemptCount] > 0
+ *     live run; ignore terminal history. If [WorkInfo.runAttemptCount] > 1
  *     it's a post-`Result.retry()` reattempt — surface as [WorkStatus.Retrying].
+ *     (WorkManager sets runAttemptCount = 1 on the very first execution, so
+ *     the threshold is > 1, not > 0.)
  *  2. **Most-recent terminal otherwise.** Pick the SUCCEEDED/FAILED entry with
  *     the highest [FetchAndNotifyWorker.KEY_COMPLETED_AT] timestamp. The
  *     previous heuristic (`maxByOrNull { runAttemptCount }`) was wrong: a
@@ -105,7 +107,7 @@ internal fun selectStatus(infos: List<WorkInfoLite>): WorkStatus {
             it.state == WorkInfo.State.BLOCKED
     }
     if (active != null) {
-        return if (active.runAttemptCount > 0) WorkStatus.Retrying else WorkStatus.Running
+        return if (active.runAttemptCount > 1) WorkStatus.Retrying else WorkStatus.Running
     }
     val completed = infos.filter {
         it.state == WorkInfo.State.SUCCEEDED || it.state == WorkInfo.State.FAILED

--- a/app/src/test/kotlin/app/clothescast/ui/today/TodayWorkStatusSelectionTest.kt
+++ b/app/src/test/kotlin/app/clothescast/ui/today/TodayWorkStatusSelectionTest.kt
@@ -32,11 +32,19 @@ class TodayWorkStatusSelectionTest {
     }
 
     @Test
-    fun `running entry with attempt count above zero surfaces as Retrying`() {
+    fun `first execution (runAttemptCount = 1) surfaces as Running, not Retrying`() {
+        // WorkManager sets runAttemptCount = 1 when a worker starts its first
+        // execution. The old check (> 0) incorrectly showed "Last attempt failed"
+        // on every first launch.
+        selectStatus(listOf(active(WorkInfo.State.RUNNING, runAttemptCount = 1))) shouldBe WorkStatus.Running
+    }
+
+    @Test
+    fun `running entry with attempt count above one surfaces as Retrying`() {
         // After Result.retry(), WorkManager bumps runAttemptCount and parks the
         // WorkInfo back in ENQUEUED until backoff elapses. The banner should
         // tell the user "last attempt failed" rather than pretend it's a
-        // brand-new fetch.
+        // brand-new fetch. runAttemptCount reaches 2 on the second attempt.
         selectStatus(listOf(active(WorkInfo.State.ENQUEUED, runAttemptCount = 2))) shouldBe WorkStatus.Retrying
     }
 


### PR DESCRIPTION
## Summary

- WorkManager sets `runAttemptCount = 1` when a worker starts its first execution (not 0), so the old `> 0` threshold in `selectStatus` classified every first run as `WorkStatus.Retrying`
- This caused the "Last attempt failed — retrying…" spinner to appear immediately on first launch, before any failure had actually occurred
- Fix: raise the threshold to `> 1` so `runAttemptCount = 1` (first execution) stays as `Running`, and only `runAttemptCount ≥ 2` (genuine retry after `Result.retry()`) becomes `Retrying`
- Added a new test case explicitly covering `runAttemptCount = 1 → Running`

## Test plan

- [ ] CI passes (`JVM unit tests` job runs `TodayWorkStatusSelectionTest`)
- [ ] Fresh install: the Today screen shows a plain spinner on first load, not "Last attempt failed — retrying"
- [ ] After a genuine fetch failure + backoff retry, the "Last attempt failed — retrying…" banner still appears correctly

https://claude.ai/code/session_01UuV4ysWoKEpEBNrhCavbKL

---
_Generated by [Claude Code](https://claude.ai/code/session_01UuV4ysWoKEpEBNrhCavbKL)_