### PR TITLE
:app — fill 27 translation gaps in de, fr, es

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -583,4 +583,51 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="today_rationale_max_below">Gefühlte Höchsttemperatur nur %1$s%2$s, unter %3$s%2$s</string>
     <string name="today_rationale_max_above_with_time">Gefühlte Höchsttemperatur %1$s%2$s um %3$s Uhr, mindestens %4$s%2$s</string>
     <string name="today_rationale_max_above">Gefühlte Höchsttemperatur %1$s%2$s, mindestens %3$s%2$s</string>
+
+    <!-- Fallback label for the maps link when GPS coords are known but no
+         city name could be resolved (reverse geocoding returned nothing). -->
+    <string name="today_location_unknown">Dein Standort</string>
+
+    <!-- Shown while WorkManager is in exponential back-off between retries
+         (distinct from today_working, which covers the first attempt). -->
+    <string name="today_retrying">Letzter Versuch fehlgeschlagen — wird erneut versucht…</string>
+
+    <!-- Crash-report banner shown on the Today screen after a previous crash. -->
+    <string name="today_crash_banner_title">Letzter Start abgestürzt</string>
+    <string name="today_crash_banner_body">Ein Absturzbericht wurde auf deinem Gerät gespeichert. Möchtest du ihn teilen, damit der Fehler behoben werden kann? Nichts wird gesendet, bis du ein Ziel auswählst.</string>
+    <string name="today_crash_banner_share">Bericht teilen</string>
+    <string name="today_crash_banner_dismiss">Schließen</string>
+
+    <!-- TV-specific onboarding subtitle (two steps instead of three). -->
+    <string name="onboarding_subtitle_tv">Zwei schnelle Auswahlen, und du bist startklar. Alles andere kannst du später in den Einstellungen anpassen.</string>
+
+    <!-- Onboarding — background location step. -->
+    <string name="onboarding_location_grant_background">Immer zulassen</string>
+    <string name="onboarding_location_background_needed">Noch ein Schritt: ClothesCast benötigt \'Immer zulassen\', damit die Morgenvorhersage deinen Standort lesen kann, während die App geschlossen ist.</string>
+    <string name="onboarding_location_enter_manual_hint">Du kannst deinen Standort manuell eingeben, wenn du den Standortzugriff ablehnst oder der Gerätestandort falsch ist.</string>
+
+    <!-- Settings root — rows not yet translated. -->
+    <string name="settings_root_display">Anzeige</string>
+    <string name="settings_root_location">Standort</string>
+    <string name="settings_root_calendar">Kalender</string>
+    <string name="settings_root_display_subtitle">Design</string>
+    <string name="settings_root_location_subtitle">Automatisch oder Stadt wählen</string>
+    <string name="settings_root_calendar_subtitle">Heutige Termine</string>
+
+    <!-- Display / theme settings. -->
+    <string name="settings_display_theme_title">Design</string>
+    <string name="settings_display_theme_system">Systemeinstellung</string>
+    <string name="settings_display_theme_light">Hell</string>
+    <string name="settings_display_theme_dark">Dunkel</string>
+
+    <!-- API key screen — Gemini section header. -->
+    <string name="settings_api_key_gemini_header">Verwende Gemini für hochwertige Stimmen.</string>
+
+    <!-- Location screen — additional strings. -->
+    <string name="settings_location_use_device_description">Letzter ungefährer Standort</string>
+    <string name="settings_location_detecting">Wird ermittelt…</string>
+    <string name="settings_location_background_banner_title">Dauerhafter Standort erforderlich</string>
+    <string name="settings_location_background_banner_body">Ohne ihn kann die Morgenvorhersage deinen Standort nicht lesen.</string>
+    <string name="settings_location_manual_override">Falscher Standort? Manuell festlegen</string>
+    <string name="settings_location_manual_override_disclosure">Wenn du eine Stadt wählst, wird die automatische Erkennung deaktiviert.</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -561,4 +561,50 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="today_rationale_max_below">Sensación máxima de solo %1$s%2$s, por debajo de %3$s%2$s</string>
     <string name="today_rationale_max_above_with_time">Sensación máxima de %1$s%2$s a las %3$s, al menos %4$s%2$s</string>
     <string name="today_rationale_max_above">Sensación máxima de %1$s%2$s, al menos %3$s%2$s</string>
+
+    <!-- Fallback label for the maps link when GPS coords are known but no
+         city name could be resolved. -->
+    <string name="today_location_unknown">Tu ubicación</string>
+
+    <!-- Shown while WorkManager is in exponential back-off between retries. -->
+    <string name="today_retrying">El último intento falló — reintentando…</string>
+
+    <!-- Crash-report banner shown on the Today screen after a previous crash. -->
+    <string name="today_crash_banner_title">El último inicio se cerró de forma inesperada</string>
+    <string name="today_crash_banner_body">Se guardó un informe de error en tu dispositivo. ¿Compartirlo para corregir el fallo? No se envía nada hasta que elijas dónde.</string>
+    <string name="today_crash_banner_share">Compartir informe</string>
+    <string name="today_crash_banner_dismiss">Ignorar</string>
+
+    <!-- TV-specific onboarding subtitle (two steps instead of three). -->
+    <string name="onboarding_subtitle_tv">Dos elecciones rápidas y ya está. Todo lo demás se puede ajustar más tarde en los ajustes.</string>
+
+    <!-- Onboarding — background location step. -->
+    <string name="onboarding_location_grant_background">Permitir siempre</string>
+    <string name="onboarding_location_background_needed">Un paso más: ClothesCast necesita \'Permitir siempre\' para poder leer tu ubicación por la mañana cuando la app está cerrada.</string>
+    <string name="onboarding_location_enter_manual_hint">Puedes introducir tu ubicación manualmente si denegas el permiso de ubicación o si la ubicación de tu dispositivo es incorrecta.</string>
+
+    <!-- Settings root — rows not yet translated. -->
+    <string name="settings_root_display">Pantalla</string>
+    <string name="settings_root_location">Ubicación</string>
+    <string name="settings_root_calendar">Calendario</string>
+    <string name="settings_root_display_subtitle">Tema</string>
+    <string name="settings_root_location_subtitle">Detección automática o elegir ciudad</string>
+    <string name="settings_root_calendar_subtitle">Eventos de hoy</string>
+
+    <!-- Display / theme settings. -->
+    <string name="settings_display_theme_title">Tema</string>
+    <string name="settings_display_theme_system">Seguir el sistema</string>
+    <string name="settings_display_theme_light">Claro</string>
+    <string name="settings_display_theme_dark">Oscuro</string>
+
+    <!-- API key screen — Gemini section header. -->
+    <string name="settings_api_key_gemini_header">Usa Gemini para obtener voces de alta calidad.</string>
+
+    <!-- Location screen — additional strings. -->
+    <string name="settings_location_use_device_description">Última ubicación aproximada</string>
+    <string name="settings_location_detecting">Detectando…</string>
+    <string name="settings_location_background_banner_title">Se necesita ubicación permanente</string>
+    <string name="settings_location_background_banner_body">Sin ella, el pronóstico matutino no puede leer tu ubicación.</string>
+    <string name="settings_location_manual_override">¿Ubicación incorrecta? Configurar manualmente</string>
+    <string name="settings_location_manual_override_disclosure">Elegir una ciudad desactiva la detección automática.</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -561,4 +561,50 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="today_rationale_max_below">Ressenti haut de seulement %1$s%2$s, sous %3$s%2$s</string>
     <string name="today_rationale_max_above_with_time">Ressenti haut de %1$s%2$s à %3$s, au moins %4$s%2$s</string>
     <string name="today_rationale_max_above">Ressenti haut de %1$s%2$s, au moins %3$s%2$s</string>
+
+    <!-- Fallback label for the maps link when GPS coords are known but no
+         city name could be resolved. -->
+    <string name="today_location_unknown">Ta position</string>
+
+    <!-- Shown while WorkManager is in exponential back-off between retries. -->
+    <string name="today_retrying">Dernière tentative échouée — nouvelle tentative…</string>
+
+    <!-- Crash-report banner shown on the Today screen after a previous crash. -->
+    <string name="today_crash_banner_title">Dernier démarrage planté</string>
+    <string name="today_crash_banner_body">Un rapport de plantage a été enregistré sur ton appareil. Le partager pour corriger le bug ? Rien n\'est envoyé tant que tu n\'as pas choisi où.</string>
+    <string name="today_crash_banner_share">Partager le rapport</string>
+    <string name="today_crash_banner_dismiss">Ignorer</string>
+
+    <!-- TV-specific onboarding subtitle (two steps instead of three). -->
+    <string name="onboarding_subtitle_tv">Deux choix rapides et c\'est prêt. Tout le reste peut être ajusté plus tard dans les paramètres.</string>
+
+    <!-- Onboarding — background location step. -->
+    <string name="onboarding_location_grant_background">Autoriser en permanence</string>
+    <string name="onboarding_location_background_needed">Une dernière étape : ClothesCast a besoin de \'Autoriser en permanence\' pour pouvoir lire ta position le matin quand l\'app est fermée.</string>
+    <string name="onboarding_location_enter_manual_hint">Tu peux saisir ta position manuellement si tu refuses l\'autorisation de position ou si la position de ton appareil est incorrecte.</string>
+
+    <!-- Settings root — rows not yet translated. -->
+    <string name="settings_root_display">Affichage</string>
+    <string name="settings_root_location">Position</string>
+    <string name="settings_root_calendar">Calendrier</string>
+    <string name="settings_root_display_subtitle">Thème</string>
+    <string name="settings_root_location_subtitle">Détection auto ou choix d\'une ville</string>
+    <string name="settings_root_calendar_subtitle">Événements du jour</string>
+
+    <!-- Display / theme settings. -->
+    <string name="settings_display_theme_title">Thème</string>
+    <string name="settings_display_theme_system">Suivre le système</string>
+    <string name="settings_display_theme_light">Clair</string>
+    <string name="settings_display_theme_dark">Sombre</string>
+
+    <!-- API key screen — Gemini section header. -->
+    <string name="settings_api_key_gemini_header">Utilise Gemini pour obtenir des voix de haute qualité.</string>
+
+    <!-- Location screen — additional strings. -->
+    <string name="settings_location_use_device_description">Dernière position approximative</string>
+    <string name="settings_location_detecting">Détection…</string>
+    <string name="settings_location_background_banner_title">Position permanente requise</string>
+    <string name="settings_location_background_banner_body">Sans elle, les prévisions matinales ne peuvent pas lire ta position.</string>
+    <string name="settings_location_manual_override">Position incorrecte ? Définir manuellement</string>
+    <string name="settings_location_manual_override_disclosure">Choisir une ville désactive la détection auto.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,6 +17,22 @@
          coordinates but no friendly city name (reverse geocoding returned
          nothing useful, or the device is on AOSP without a backend). The
          link still opens the user's maps app at the actual coords. -->
+    <!-- TODO(translations): today_location_unknown, today_retrying,
+         today_crash_banner_*, onboarding_subtitle_tv,
+         onboarding_location_grant_background,
+         onboarding_location_background_needed,
+         onboarding_location_enter_manual_hint, settings_root_display/
+         _location/_calendar (+ _subtitle variants),
+         settings_display_theme_*, settings_api_key_gemini_header,
+         settings_location_use_device_description/_detecting/
+         _background_banner_*/_manual_override* are translated for
+         de/fr/es (de-AT/CH, fr-CA, es-MX inherit via Android's
+         base-language fallback and need no separate entry), but still
+         missing from all other language trees: it, nl, pl, ru, pt-BR,
+         pt-PT, sv, da, nb, fi, et, lv, lt, tr, cs, sk, hu, ro, bg,
+         hr, sl, sr, el, uk, ca, ar, he, fa, hi, bn, ja, ko, zh-CN,
+         zh-TW, th, vi, id, ms, fil, sw, am, sq, and any future
+         additions. -->
     <string name="today_location_unknown">Your location</string>
 
     <string name="today_outfit_title">What to wear</string>


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- 27 string keys were present in `values/strings.xml` (English) but missing from `values-de`, `values-fr`, and `values-es`, meaning German, French, and Spanish users saw English for those UI surfaces.
- All 27 are now translated and appended to each locale file.
- A `TODO(translations)` comment added to `values/strings.xml` tracks the same gaps still outstanding in the other ~50 locales (de-AT/CH, fr-CA, es-MX, it, nl, pl, ru, …).

### Strings filled in (all three locales)

| Key | What it surfaces |
|-----|-----------------|
| `today_location_unknown` | Fallback maps-link label when reverse-geocoding returns nothing |
| `today_retrying` | Work-status banner during exponential back-off retry |
| `today_crash_banner_{title,body,share,dismiss}` | Crash-report banner on Today screen |
| `onboarding_subtitle_tv` | TV-only onboarding subtitle (2 steps, not 3) |
| `onboarding_location_grant_background` | "Allow all the time" button on onboarding |
| `onboarding_location_background_needed` | Explanatory copy for background-location step |
| `onboarding_location_enter_manual_hint` | Hint under manual-entry option on onboarding |
| `settings_root_{display,location,calendar}` | Three root-settings nav rows |
| `settings_root_{display,location,calendar}_subtitle` | Subtitles under those rows |
| `settings_display_theme_{title,system,light,dark}` | Theme picker on Display screen |
| `settings_api_key_gemini_header` | Section header on Voice / API key screen |
| `settings_location_use_device_description` | Caption under "Use device location" toggle |
| `settings_location_detecting` | "Detecting…" transient state label |
| `settings_location_background_banner_{title,body}` | Always-on banner on Location screen |
| `settings_location_manual_override` | "Wrong location? Set manually" link |
| `settings_location_manual_override_disclosure` | Disclosure under city picker |

## Test plan

- [ ] Build a debug APK with `language = "de"` / `"fr"` / `"es"` in Developer Options and confirm none of the UI surfaces listed above show English text.
- [ ] Verify the crash-banner (de/fr/es) by forcing a crash and reopening the app.
- [ ] Verify the TV onboarding subtitle appears correctly with `language = "de"`.
- [ ] CI green.

https://claude.ai/code/session_01GbrQCfYQ3gj8GmuQhNyg8M
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GbrQCfYQ3gj8GmuQhNyg8M)_