### PR TITLE
:app — prefer UK post town over Geocoder locality for reverse-geocoded names

### DIFF
--- a/app/src/main/kotlin/app/clothescast/location/CityNamePicker.kt
+++ b/app/src/main/kotlin/app/clothescast/location/CityNamePicker.kt
@@ -1,0 +1,43 @@
+package app.clothescast.location
+
+/** Picks a user-facing city name from the structured fields of an Android `Address`. */
+internal fun pickCityName(
+    locality: String?,
+    subLocality: String?,
+    subAdminArea: String?,
+    countryCode: String?,
+    postalCode: String?,
+    addressLines: List<String>,
+): String? {
+    // UK: Google's Geocoder fills `locality` with the hamlet (Oakley Green) or leaves it blank
+    // for inner-London residentials. The Royal Mail post town — what people actually call the
+    // place — is the addressLine token containing the postcode.
+    if (countryCode.equals("GB", ignoreCase = true)) {
+        extractUkPostTown(postalCode, addressLines)?.let { return it }
+    }
+    return listOf(locality, subLocality, subAdminArea)
+        .firstOrNull { !it.isNullOrBlank() }
+        ?.trim()
+}
+
+private fun extractUkPostTown(postalCode: String?, addressLines: List<String>): String? {
+    if (postalCode.isNullOrBlank()) return null
+    val pcPattern = postalCode.trim()
+        .split("\\s+".toRegex())
+        .filter { it.isNotEmpty() }
+        .joinToString("\\s*") { Regex.escape(it) }
+        .toRegex(RegexOption.IGNORE_CASE)
+    for (line in addressLines) {
+        for (rawToken in line.split(",")) {
+            val token = rawToken.trim()
+            if (token.isEmpty() || !pcPattern.containsMatchIn(token)) continue
+            val cleaned = pcPattern.replace(token, " ")
+                .replace("\\s+".toRegex(), " ")
+                .trim()
+                .trim(',')
+                .trim()
+            if (cleaned.isNotBlank()) return cleaned
+        }
+    }
+    return null
+}

--- a/app/src/main/kotlin/app/clothescast/location/ReverseGeocoder.kt
+++ b/app/src/main/kotlin/app/clothescast/location/ReverseGeocoder.kt
@@ -52,7 +52,7 @@ class ReverseGeocoder(
                 DiagLog.w(TAG, "Reverse geocode timed out after ${timeoutMillis}ms.")
                 return null
             }
-        return addresses.firstOrNull()?.pickCityName()
+        return addresses.firstOrNull()?.toCityName()
     }
 
     private suspend fun fetch(geocoder: Geocoder, lat: Double, lon: Double): List<Address> =
@@ -105,10 +105,19 @@ class ReverseGeocoder(
             }
         }
 
-    private fun Address.pickCityName(): String? =
-        listOf(locality, subLocality, subAdminArea)
-            .firstOrNull { !it.isNullOrBlank() }
-            ?.trim()
+    private fun Address.toCityName(): String? {
+        val maxIdx = maxAddressLineIndex
+        val lines = if (maxIdx < 0) emptyList<String>()
+        else (0..maxIdx).mapNotNull { getAddressLine(it) }
+        return pickCityName(
+            locality = locality,
+            subLocality = subLocality,
+            subAdminArea = subAdminArea,
+            countryCode = countryCode,
+            postalCode = postalCode,
+            addressLines = lines,
+        )
+    }
 
     companion object {
         private const val TAG = "ReverseGeocoder"

--- a/app/src/test/kotlin/app/clothescast/location/CityNamePickerTest.kt
+++ b/app/src/test/kotlin/app/clothescast/location/CityNamePickerTest.kt
@@ -1,0 +1,177 @@
+package app.clothescast.location
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+/**
+ * Unit tests for [pickCityName]. Pure JVM — exercises the picker logic
+ * with the same field shapes Android's `Geocoder` returns, without needing
+ * Robolectric or an actual `Address`.
+ */
+class CityNamePickerTest {
+
+    @Test
+    fun `UK address with empty locality returns post town from addressLine`() {
+        // Muswell Hill (London N10): Geocoder leaves locality blank; we
+        // recover "London" from the addressLine token containing the postcode.
+        pickCityName(
+            locality = null,
+            subLocality = null,
+            subAdminArea = "Greater London",
+            countryCode = "GB",
+            postalCode = "N10 1XX",
+            addressLines = listOf("1 Some Street, Muswell Hill, London N10 1XX, UK"),
+        ) shouldBe "London"
+    }
+
+    @Test
+    fun `UK address prefers post town over hamlet locality`() {
+        // Oakley Green (Windsor SL4): Geocoder fills locality with the hamlet,
+        // but the post town "Windsor" is what people expect.
+        pickCityName(
+            locality = "Oakley Green",
+            subLocality = null,
+            subAdminArea = "Windsor and Maidenhead",
+            countryCode = "GB",
+            postalCode = "SL4 5XX",
+            addressLines = listOf("1 Some Lane, Oakley Green, Windsor SL4 5XX, UK"),
+        ) shouldBe "Windsor"
+    }
+
+    @Test
+    fun `US address falls through to locality`() {
+        // Brooklyn 11201: GB branch is skipped; locality is the right answer.
+        pickCityName(
+            locality = "Brooklyn",
+            subLocality = null,
+            subAdminArea = "Kings County",
+            countryCode = "US",
+            postalCode = "11201",
+            addressLines = listOf("123 Main St, Brooklyn, NY 11201, USA"),
+        ) shouldBe "Brooklyn"
+    }
+
+    @Test
+    fun `US locality is preferred even when postcode appears in addressLine`() {
+        // Confirms the GB extraction logic doesn't accidentally fire for non-GB.
+        pickCityName(
+            locality = "New York",
+            subLocality = null,
+            subAdminArea = "New York County",
+            countryCode = "US",
+            postalCode = "10020",
+            addressLines = listOf("10 W 50th St, New York, NY 10020, USA"),
+        ) shouldBe "New York"
+    }
+
+    @Test
+    fun `country code is matched case-insensitively`() {
+        pickCityName(
+            locality = null,
+            subLocality = null,
+            subAdminArea = "Greater London",
+            countryCode = "gb",
+            postalCode = "N10 1XX",
+            addressLines = listOf("1 Some Street, Muswell Hill, London N10 1XX, UK"),
+        ) shouldBe "London"
+    }
+
+    @Test
+    fun `UK postcode without space in addressLine still matches`() {
+        // postalCode field is "N10 1XX" but the addressLine packs it as "N101XX".
+        pickCityName(
+            locality = null,
+            subLocality = null,
+            subAdminArea = "Greater London",
+            countryCode = "GB",
+            postalCode = "N10 1XX",
+            addressLines = listOf("1 Some Street, Muswell Hill, London N101XX, UK"),
+        ) shouldBe "London"
+    }
+
+    @Test
+    fun `UK address with no postcode falls back to locality chain`() {
+        pickCityName(
+            locality = "Edinburgh",
+            subLocality = null,
+            subAdminArea = "City of Edinburgh",
+            countryCode = "GB",
+            postalCode = null,
+            addressLines = listOf("Some Street, Edinburgh, UK"),
+        ) shouldBe "Edinburgh"
+    }
+
+    @Test
+    fun `UK address whose addressLines do not contain the postcode falls back`() {
+        pickCityName(
+            locality = "Edinburgh",
+            subLocality = null,
+            subAdminArea = "City of Edinburgh",
+            countryCode = "GB",
+            postalCode = "EH1 1AA",
+            addressLines = listOf("Some Street, no postcode here, UK"),
+        ) shouldBe "Edinburgh"
+    }
+
+    @Test
+    fun `UK addressLine token that is only the postcode is skipped`() {
+        // Stripping the postcode leaves the token empty; don't return blank.
+        pickCityName(
+            locality = "Edinburgh",
+            subLocality = null,
+            subAdminArea = "City of Edinburgh",
+            countryCode = "GB",
+            postalCode = "EH1 1AA",
+            addressLines = listOf("Some Street, EH1 1AA, UK"),
+        ) shouldBe "Edinburgh"
+    }
+
+    @Test
+    fun `UK with empty locality and no addressLine match falls back to subAdminArea`() {
+        pickCityName(
+            locality = null,
+            subLocality = null,
+            subAdminArea = "Greater London",
+            countryCode = "GB",
+            postalCode = "N10 1XX",
+            addressLines = listOf("Some Street, no postcode here, UK"),
+        ) shouldBe "Greater London"
+    }
+
+    @Test
+    fun `multi-line addressLines are scanned`() {
+        // Some Geocoder responses split across multiple addressLines.
+        pickCityName(
+            locality = null,
+            subLocality = null,
+            subAdminArea = "Greater London",
+            countryCode = "GB",
+            postalCode = "N10 1XX",
+            addressLines = listOf("1 Some Street", "Muswell Hill, London N10 1XX", "UK"),
+        ) shouldBe "London"
+    }
+
+    @Test
+    fun `everything blank returns null`() {
+        pickCityName(
+            locality = null,
+            subLocality = null,
+            subAdminArea = null,
+            countryCode = "GB",
+            postalCode = null,
+            addressLines = emptyList(),
+        ) shouldBe null
+    }
+
+    @Test
+    fun `locality is trimmed`() {
+        pickCityName(
+            locality = "  Boston  ",
+            subLocality = null,
+            subAdminArea = null,
+            countryCode = "US",
+            postalCode = "02108",
+            addressLines = listOf("1 Beacon St, Boston, MA 02108, USA"),
+        ) shouldBe "Boston"
+    }
+}


### PR DESCRIPTION
## Summary

Reverse geocoding via Android's `Geocoder` was returning surprising names for UK locations:

- **Oakley Green (SL4)** — Geocoder fills `locality` with the hamlet name; users expect "Windsor" (the Royal Mail post town).
- **Muswell Hill (N10)** — Geocoder leaves `locality` blank for inner-London residentials and we fell through to `subAdminArea` = "Greater London"; users expect "London".

For UK addresses (`countryCode == "GB"`) we now extract the post town from the formatted addressLine — specifically, the comma-separated token containing `postalCode`, with the postcode stripped. That gives `London` for N10, `Windsor` for SL4, `Edinburgh` for EH1, etc., matching how people actually refer to those places.

Non-GB addresses are unchanged: the existing `locality → subLocality → subAdminArea` chain still wins, so US (`Brooklyn`, `Boston`, `Manhattan` → `New York`) keeps working. UK addresses also fall back to that chain when the post-town extraction can't find a match (missing postcode, no token containing it, token that strips to empty), with `subAdminArea` ("Greater London") as the final escape.

The picker is now a pure-Kotlin top-level function (`CityNamePicker.kt`), exercised by JUnit 5 unit tests in `:app:testDebugUnitTest` — no Robolectric required.

## Why GB-only

`addressLine` is **not** a documented contract — Google's localized formatter shapes it differently per country (DE puts `PLZ Stadt` in one token, US puts `state + ZIP`). The "find token containing postcode, strip postcode" trick happens to give the post town in the UK because of how Royal Mail / Google formats GB addresses, but it doesn't generalise. Other countries can be added one-by-one if a similar mismatch shows up.

We discussed but did not implement borough-rollup (Brooklyn → NYC). It'd require a hand-maintained table and isn't recoverable from any field Geocoder returns; deferred until someone actually complains about Brooklyn.

## Privacy

No change to what we send off-device. `Geocoder` still calls Google's geocoding service with the same coordinates on Play Services devices; only the post-processing of its response is different.

## Test plan

- [ ] CI: `JVM unit tests` runs the new `CityNamePickerTest` (12 cases covering Muswell Hill, Oakley Green, Brooklyn, Manhattan, lowercase `gb`, postcode-with/without-space variants, fall-through paths)
- [ ] CI: `Android debug build` confirms the rewired `ReverseGeocoder` still compiles
- [ ] Local sandbox can't run `:app:testDebugUnitTest` (Google Maven blocked) — relying on CI for validation
- [ ] On-device verification once merged: check the Today header on a Muswell Hill device-location forecast says "London" (was "Greater London") and on an Oakley Green / SL4 location says "Windsor" (was "Oakley Green")

https://claude.ai/code/session_019nyouGRz9VzwBGurMqvzro

---
_Generated by [Claude Code](https://claude.ai/code/session_019nyouGRz9VzwBGurMqvzro)_