### PR TITLE
:repo — add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,3 +162,31 @@ new rule the first time something bites you, not the third.
   names (`gemini-2.5-flash-tts`) for models that only exist as previews
   (`gemini-2.5-flash-preview-tts`). PR #59 → #60 was a same-day
   rename-and-revert because of this.
+
+## Cursor Cloud specific instructions
+
+- **Android SDK is installed** at `/opt/android-sdk`. The update script
+  installs it idempotently if missing (command-line tools + platforms;android-35
+  + build-tools;35.0.0). `ANDROID_HOME` / `ANDROID_SDK_ROOT` are exported via
+  `~/.bashrc`; source it or `export ANDROID_HOME=/opt/android-sdk` before
+  running Gradle if your shell hasn't picked it up.
+- **All three modules build and test on this VM.** Unlike the AGENTS.md note
+  about agent sandboxes lacking the SDK, the Cursor Cloud VM has it. You can
+  run the full CI-equivalent locally:
+  ```
+  export ANDROID_HOME=/opt/android-sdk
+  ./gradlew :core:domain:test :core:data:test :app:testDebugUnitTest
+  ./gradlew :app:assembleDebug
+  ```
+- **Pre-existing flaky test:** `SettingsViewModelTest > initial state reflects
+  repository defaults` may fail with `expected:<CELSIUS> but was:<FAHRENHEIT>`
+  depending on the JVM's default locale. This is a pre-existing issue, not
+  caused by your changes. CI passes this test because the GitHub runner locale
+  defaults differently.
+- **No lint task is configured** in the Gradle build. There is no `lint` or
+  `ktlint` plugin wired. Kotlin compiler warnings are the closest equivalent;
+  they are visible in the build output.
+- **This is a client-only Android app.** No backend server, database, or
+  Docker containers to start. The app calls Open-Meteo (free, keyless) and
+  optionally Gemini/OpenAI/ElevenLabs (BYOK). Testing is purely JVM-based.
+- **`CLAUDE.md` is a symlink** to `AGENTS.md` — editing either edits both.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` documenting the dev environment setup for Cursor Cloud VMs:

- Android SDK location (`/opt/android-sdk`) and env var setup
- Full local build/test capability (all three modules)
- Pre-existing locale-dependent test flake (`SettingsViewModelTest`)
- No lint plugin wired; no backend/Docker needed
- `CLAUDE.md` symlink note

The update script installs the Android SDK idempotently and warms the Gradle wrapper.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1567f3b5-a27c-496a-864f-083dfa0ac413"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1567f3b5-a27c-496a-864f-083dfa0ac413"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

