### PR TITLE
Clarify Android Lint guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -183,9 +183,10 @@ new rule the first time something bites you, not the third.
   depending on the JVM's default locale. This is a pre-existing issue, not
   caused by your changes. CI passes this test because the GitHub runner locale
   defaults differently.
-- **No lint task is configured** in the Gradle build. There is no `lint` or
-  `ktlint` plugin wired. Kotlin compiler warnings are the closest equivalent;
-  they are visible in the build output.
+- **Android Lint is available** for the `:app` module via AGP; run
+  `./gradlew :app:lintDebug` when app-side validation needs lint coverage.
+  There is no separate `ktlint` plugin wired, so Kotlin style checks are not
+  available beyond compiler warnings.
 - **This is a client-only Android app.** No backend server, database, or
   Docker containers to start. The app calls Open-Meteo (free, keyless) and
   optionally Gemini/OpenAI/ElevenLabs (BYOK). Testing is purely JVM-based.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Clarify that Android Lint is available for the `:app` module via AGP
- Distinguish missing ktlint/style-plugin coverage from Android Lint validation

## Validation
- Not run (documentation-only change)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-544f9777-68fe-482a-bc9b-a63d09abe75d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-544f9777-68fe-482a-bc9b-a63d09abe75d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

