### PR TITLE
:app — badge launcher icon on local builds (not CI)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -35,6 +35,18 @@ val gitCommitCount: Int = git("rev-list", "--count", "HEAD").toInt()
 val versionNameBase = "0.1.0"
 val gitShortSha: String = git("rev-parse", "--short", "HEAD")
 
+// "Is this a CI build?" CI builds keep the unmodified launcher icon; any
+// build run outside CI gets an under-construction badge overlaid on the icon
+// (see app/src/main/res-construction/). The `CI=true` env var is set by
+// GitHub Actions and most other CI providers, so the rule is simply: if the
+// environment looks like CI, no badge; otherwise, badge.
+//
+// This keeps the rule trivial to reason about — "the APK on my phone came
+// from CI" is exactly the question the badge answers — at the cost of
+// over-badging the rare case where a developer runs `CI=true` locally.
+val isCiBuild: Boolean = System.getenv("CI") == "true"
+println("clothescast: isCiBuild=$isCiBuild (versionCode=$gitCommitCount, HEAD=$gitShortSha)")
+
 android {
     // Pinned to app.clothescast. Renamed from app.adaptweather as part of the
     // product rename; existing FAD testers had to uninstall + reinstall,
@@ -56,6 +68,18 @@ android {
         // versionName, not versionCode — embedding the count means one string
         // identifies the build everywhere.
         versionName = "$versionNameBase+$gitCommitCount.$gitShortSha"
+    }
+
+    // Construction-badge overlay: on local builds (anything outside CI), layer
+    // an under-construction badge over the launcher icon (see res-construction/
+    // for the override XMLs). CI builds get the unmodified icon. The override
+    // directory is only added to the source set when needed — leaving it
+    // permanently registered would either silently shadow the real icon (if
+    // AGP picked the override) or error on duplicate resources (if it didn't).
+    sourceSets.named("main") {
+        if (!isCiBuild) {
+            res.srcDirs("src/main/res", "src/main/res-construction")
+        }
     }
 
     signingConfigs {

--- a/app/src/main/res-construction/drawable/ic_construction_badge.xml
+++ b/app/src/main/res-construction/drawable/ic_construction_badge.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="32dp"
+    android:height="32dp"
+    android:viewportWidth="32"
+    android:viewportHeight="32">
+
+    <path
+        android:fillColor="#FFC107"
+        android:strokeColor="#1A1A1A"
+        android:strokeWidth="1.2"
+        android:pathData="M16,1.5 C24.008,1.5 30.5,7.992 30.5,16 C30.5,24.008 24.008,30.5 16,30.5 C7.992,30.5 1.5,24.008 1.5,16 C1.5,7.992 7.992,1.5 16,1.5 Z" />
+
+    <path
+        android:fillColor="#1A1A1A"
+        android:pathData="M8,19 L24,19 L24,22 L8,22 Z" />
+    <path
+        android:fillColor="#1A1A1A"
+        android:pathData="M11,19 C11,13 12.5,11 16,11 C19.5,11 21,13 21,19 Z" />
+</vector>

--- a/app/src/main/res-construction/drawable/ic_launcher_foreground_badged.xml
+++ b/app/src/main/res-construction/drawable/ic_launcher_foreground_badged.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@mipmap/ic_launcher_foreground" />
+    <item
+        android:drawable="@drawable/ic_construction_badge"
+        android:gravity="bottom|right"
+        android:width="32dp"
+        android:height="32dp"
+        android:right="20dp"
+        android:bottom="20dp" />
+</layer-list>

--- a/app/src/main/res-construction/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/main/res-construction/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@drawable/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground_badged" />
+</adaptive-icon>

--- a/app/src/main/res-construction/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/app/src/main/res-construction/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@drawable/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground_badged" />
+</adaptive-icon>


### PR DESCRIPTION
## Summary

- Overlay an under-construction badge on the launcher icon for **every local build**; CI builds (debug APK on FAD, AAB on Play Store) keep the unmodified icon. Lets you tell at a glance whether the install on your phone came from CI or your own laptop.
- Detection is just `System.getenv("CI") == "true"` (the convention set by GitHub Actions and most other CI providers). Trivial rule, no git-state inference.
- When badged, `app/src/main/res-construction/` is appended to the main source set's `res.srcDirs` and overrides `ic_launcher{,_round}.xml` with an adaptive-icon whose foreground is a layer-list stacking the original per-density PNG foreground and a 32dp vector badge (yellow disc + hard-hat silhouette) anchored bottom-right inside the 72dp safe zone, so launcher masks don't clip it. On CI the override dir isn't on the source set at all, so AGP sees the unchanged icon and there's no duplicate-resource conflict.

## Privacy

No new data crosses the device boundary — cosmetic, build-time-only.

## Test plan

- [ ] CI's `Android debug build` job produces an unbadged `app-debug-apk` artifact (configure-time log line should report `isCiBuild=true`).
- [ ] Local `./gradlew :app:assembleDebug` produces a badged APK (configure-time log line should report `isCiBuild=false`); install and visually confirm the hard-hat badge in the bottom-right corner of the icon under all three launcher mask shapes (circle, squircle, rounded square).
- [ ] `./gradlew :app:lintDebug` on the local badged build doesn't surface new warnings on the adaptive-icon override.
- [ ] `./gradlew :core:domain:test :core:data:test :app:testDebugUnitTest` passes; Roborazzi snapshots don't render the launcher icon, so no PNG diffs are expected.
- [ ] After merge, the next push-to-`main` build's configure log shows `isCiBuild=true` and the FAD-distributed debug APK + Play AAB carry the unmodified icon.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YC7d7rbTZuJLuCKz76v7nY)_