### PR TITLE
:app — add installAndRun Gradle task

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -337,6 +337,14 @@ dependencies {
     debugImplementation(libs.androidx.compose.ui.test.manifest)
 }
 
+tasks.register<Exec>("installAndRun") {
+    dependsOn("installDebug")
+    commandLine(
+        "adb", "shell", "am", "start",
+        "-n", "app.clothescast.debug/app.clothescast.MainActivity",
+    )
+}
+
 configurations.matching { it.name.startsWith("test") || it.name.startsWith("debugUnitTest") }.all {
     // kotlinx-coroutines-android arrives transitively via androidx.lifecycle. Its
     // AndroidDispatcherFactory is the highest-priority MainDispatcherFactory on the


### PR DESCRIPTION
## Summary

- Adds a `installAndRun` Gradle task to `:app` that depends on `installDebug` and then launches the app via `adb shell am start`
- Component: `app.clothescast.debug/app.clothescast.MainActivity`
- Replaces the manual two-step `./gradlew :app:installDebug` + `adb shell am start ...`

## Usage

```
./gradlew :app:installAndRun
```

## Test plan

- [ ] Run `./gradlew :app:installAndRun` with a device/emulator connected — APK installs and app launches