### PR TITLE
:app — fill translation gaps in ja, ko, zh-CN, zh-TW; add Hindi TODO

### DIFF
--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -3,6 +3,22 @@
 Hindi (India) translation. Scope: insight-prose templates, garment labels,
 clothes-rule editor, outfit-card labels, and region/voice-locale picker names.
 The rest of the UI falls through to values/strings.xml (English).
+
+TODO: expand to full UI coverage like ja / ko / zh-CN / zh-TW. Currently
+~344 of the 412 base keys are not translated and fall through to English —
+chrome (Settings, Today, Onboarding, Pairing, notification channels,
+About) all read in English on a Hindi device. Mirror the structure used
+by the East Asian locales: friendly-polite register (आप-form, not तू),
+Devanagari typography (Devanagari danda । for sentence final where it
+reads naturally; Latin period after Latin script). Brand name
+"ClothesCast" stays in Latin. Picker labels under
+`settings_region_language_*` and `settings_tts_voice_locale_*` should
+give Hindi names for every offered locale (अंग्रेज़ी (अमेरिका), फ़्रेंच (कनाडा),
+चीनी (सरलीकृत), …); the locale tag stored on disk is unchanged, only
+the displayed label localises. As with the other locales, leave
+`app_name` and the English-only `insight_time_am/pm/midnight/noon[_minutes]`
+formatter helpers unoverridden — Hindi already has `insight_time_hour`
+/ `_hour_minutes` translated below.
 -->
 <resources>
     <string name="settings_region_language_hi_in">हिंदी (भारत)</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -535,4 +535,66 @@ the displayed label localizes.
     <string name="today_rationale_max_below">体感最高気温わずか %1$s%2$s、%3$s%2$s未満</string>
     <string name="today_rationale_max_above_with_time">体感最高気温 %1$s%2$s（%3$s）、少なくとも %4$s%2$s</string>
     <string name="today_rationale_max_above">体感最高気温 %1$s%2$s、少なくとも %3$s%2$s</string>
+
+
+    <!-- Today screen — additions: location-unknown label, retry banner,
+         crash-report banner (post-crash share prompt), and Play Store
+         in-app update prompts (available + downloaded states). -->
+    <string name="today_location_unknown">現在地</string>
+    <string name="today_retrying">前回の試行に失敗しました — 再試行中…</string>
+
+    <string name="today_crash_banner_title">前回の実行がクラッシュしました</string>
+    <string name="today_crash_banner_body">クラッシュレポートが端末に保存されました。バグを修正できるよう共有しますか？送信先を選ぶまで何も送信されません。</string>
+    <string name="today_crash_banner_share">レポートを共有</string>
+    <string name="today_crash_banner_dismiss">閉じる</string>
+
+    <string name="today_update_available_title">アップデートあり</string>
+    <string name="today_update_available_body">ClothesCast の新しいバージョンが Play ストアで公開されています。</string>
+    <string name="today_update_available_action">アップデート</string>
+    <string name="today_update_available_dismiss">後で</string>
+    <string name="today_update_downloaded_body">アップデートをダウンロードしました。インストールを完了するには再起動してください。</string>
+    <string name="today_update_downloaded_action">再起動</string>
+
+    <!-- Onboarding additions — TV-shorter subtitle (TV onboarding has
+         less screen real-estate), the always-on location step, and the
+         manual-entry hint shown on the location screen. -->
+    <string name="onboarding_subtitle_tv">2つの簡単な選択で準備完了。後から設定で調整できます。</string>
+    <string name="onboarding_location_grant_background">常時位置情報を許可</string>
+    <string name="onboarding_location_background_needed">あと1ステップ：朝の予報がアプリ終了中も位置情報を読み取れるよう、ClothesCast には「常に許可」が必要です。</string>
+    <string name="onboarding_location_enter_manual_hint">位置情報の許可を拒否した場合や、端末の位置が間違っている場合は、位置を手動で入力できます。</string>
+
+    <!-- Settings root list — three new rows (Display / Location /
+         Calendar) and their subtitles. The earlier root rows
+         (Schedule / Clothes / Region / Voice / About) were already
+         translated above. -->
+    <string name="settings_root_display">表示</string>
+    <string name="settings_root_location">位置情報</string>
+    <string name="settings_root_calendar">カレンダー</string>
+    <string name="settings_root_display_subtitle">テーマ</string>
+    <string name="settings_root_location_subtitle">自動検出または都市を選択</string>
+    <string name="settings_root_calendar_subtitle">今日の予定</string>
+
+    <!-- Display screen — theme picker (system / light / dark). -->
+    <string name="settings_display_theme_title">テーマ</string>
+    <string name="settings_display_theme_system">システム設定に従う</string>
+    <string name="settings_display_theme_light">ライト</string>
+    <string name="settings_display_theme_dark">ダーク</string>
+
+    <!-- API keys screen — header above the Gemini block. -->
+    <string name="settings_api_key_gemini_header">Gemini を使うと高品質な音声が利用できます。</string>
+
+    <!-- Location screen additions — device-location subtitle, in-flight
+         "detecting…" state, the always-on banner shown when the
+         background-location permission is missing, and the manual-
+         override link with its disclosure. -->
+    <string name="settings_location_use_device_description">最後のおおよその位置</string>
+    <string name="settings_location_detecting">検出中…</string>
+    <string name="settings_location_background_banner_title">常時位置情報が必要です</string>
+    <string name="settings_location_background_banner_body">これがないと、朝の予報があなたの位置を読み取れません。</string>
+    <string name="settings_location_manual_override">位置が違う？手動で設定</string>
+    <string name="settings_location_manual_override_disclosure">都市を選ぶと自動検出はオフになります。</string>
+
+    <!-- Voice screen — engine-picker description (Device vs Gemini
+         trade-offs). -->
+    <string name="settings_tts_engine_description">Gemini は端末の音声よりずっと自然に聞こえますが、読み上げ時にネットワーク通信が必要で、合成にあなたの API キーを使います（ClothesCast の読み上げ1回につき短いリクエスト1回）。Gemini が失敗した場合は端末の音声にフォールバックします。</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -539,4 +539,66 @@ displayed label localizes.
     <string name="today_rationale_max_below">체감 최고 %1$s%2$s에 불과, %3$s%2$s 미만</string>
     <string name="today_rationale_max_above_with_time">체감 최고 %1$s%2$s(%3$s), 최소 %4$s%2$s</string>
     <string name="today_rationale_max_above">체감 최고 %1$s%2$s, 최소 %3$s%2$s</string>
+
+
+    <!-- Today screen — additions: location-unknown label, retry banner,
+         crash-report banner (post-crash share prompt), and Play Store
+         in-app update prompts (available + downloaded states). -->
+    <string name="today_location_unknown">현재 위치</string>
+    <string name="today_retrying">이전 시도 실패 — 재시도 중…</string>
+
+    <string name="today_crash_banner_title">이전 실행이 충돌했습니다</string>
+    <string name="today_crash_banner_body">충돌 보고서가 기기에 저장되었습니다. 버그를 수정할 수 있도록 공유할까요? 보낼 곳을 선택할 때까지 아무것도 전송되지 않습니다.</string>
+    <string name="today_crash_banner_share">보고서 공유</string>
+    <string name="today_crash_banner_dismiss">닫기</string>
+
+    <string name="today_update_available_title">업데이트가 있습니다</string>
+    <string name="today_update_available_body">Play 스토어에 ClothesCast의 새 버전이 있습니다.</string>
+    <string name="today_update_available_action">업데이트</string>
+    <string name="today_update_available_dismiss">나중에</string>
+    <string name="today_update_downloaded_body">업데이트가 다운로드되었습니다. 설치를 완료하려면 다시 시작하세요.</string>
+    <string name="today_update_downloaded_action">다시 시작</string>
+
+    <!-- Onboarding additions — TV-shorter subtitle (TV onboarding has
+         less screen real-estate), the always-on location step, and the
+         manual-entry hint shown on the location screen. -->
+    <string name="onboarding_subtitle_tv">두 가지 빠른 선택으로 준비 완료. 나머지는 나중에 설정에서 조정할 수 있어요.</string>
+    <string name="onboarding_location_grant_background">상시 위치 허용</string>
+    <string name="onboarding_location_background_needed">한 단계 더: 앱이 닫혀 있어도 아침 예보가 위치를 읽을 수 있도록 ClothesCast에 \'항상 허용\'이 필요합니다.</string>
+    <string name="onboarding_location_enter_manual_hint">위치 권한을 거부하거나 기기 위치가 잘못된 경우 위치를 직접 입력할 수 있습니다.</string>
+
+    <!-- Settings root list — three new rows (Display / Location /
+         Calendar) and their subtitles. The earlier root rows
+         (Schedule / Clothes / Region / Voice / About) were already
+         translated above. -->
+    <string name="settings_root_display">디스플레이</string>
+    <string name="settings_root_location">위치</string>
+    <string name="settings_root_calendar">캘린더</string>
+    <string name="settings_root_display_subtitle">테마</string>
+    <string name="settings_root_location_subtitle">자동 감지 또는 도시 선택</string>
+    <string name="settings_root_calendar_subtitle">오늘의 일정</string>
+
+    <!-- Display screen — theme picker (system / light / dark). -->
+    <string name="settings_display_theme_title">테마</string>
+    <string name="settings_display_theme_system">시스템 설정 따르기</string>
+    <string name="settings_display_theme_light">라이트</string>
+    <string name="settings_display_theme_dark">다크</string>
+
+    <!-- API keys screen — header above the Gemini block. -->
+    <string name="settings_api_key_gemini_header">Gemini를 사용하면 고품질 음성을 얻을 수 있습니다.</string>
+
+    <!-- Location screen additions — device-location subtitle, in-flight
+         "detecting…" state, the always-on banner shown when the
+         background-location permission is missing, and the manual-
+         override link with its disclosure. -->
+    <string name="settings_location_use_device_description">마지막 대략적 위치</string>
+    <string name="settings_location_detecting">감지 중…</string>
+    <string name="settings_location_background_banner_title">상시 위치가 필요합니다</string>
+    <string name="settings_location_background_banner_body">허용하지 않으면 아침 예보가 위치를 읽을 수 없습니다.</string>
+    <string name="settings_location_manual_override">위치가 잘못됐나요? 직접 설정</string>
+    <string name="settings_location_manual_override_disclosure">도시를 선택하면 자동 감지가 꺼집니다.</string>
+
+    <!-- Voice screen — engine-picker description (Device vs Gemini
+         trade-offs). -->
+    <string name="settings_tts_engine_description">Gemini는 기기 음성보다 훨씬 자연스럽게 들리지만, 말할 때 네트워크 호출이 필요하고 합성에 회원님의 API 키를 사용합니다 (ClothesCast 한 번 읽을 때마다 짧은 호출 한 번). Gemini가 실패하면 기기 음성으로 대체됩니다.</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -527,4 +527,66 @@ label localizes.
     <string name="today_rationale_max_below">体感最高气温仅 %1$s%2$s，低于 %3$s%2$s</string>
     <string name="today_rationale_max_above_with_time">体感最高气温 %1$s%2$s（%3$s），至少 %4$s%2$s</string>
     <string name="today_rationale_max_above">体感最高气温 %1$s%2$s，至少 %3$s%2$s</string>
+
+
+    <!-- Today screen — additions: location-unknown label, retry banner,
+         crash-report banner (post-crash share prompt), and Play Store
+         in-app update prompts (available + downloaded states). -->
+    <string name="today_location_unknown">当前位置</string>
+    <string name="today_retrying">上次尝试失败 — 重试中…</string>
+
+    <string name="today_crash_banner_title">上次运行已崩溃</string>
+    <string name="today_crash_banner_body">崩溃报告已保存在你的设备上。要分享出来以便修复 bug 吗？在你选择发送目标之前不会发送任何内容。</string>
+    <string name="today_crash_banner_share">分享报告</string>
+    <string name="today_crash_banner_dismiss">关闭</string>
+
+    <string name="today_update_available_title">有可用更新</string>
+    <string name="today_update_available_body">Play 商店上有 ClothesCast 的新版本。</string>
+    <string name="today_update_available_action">更新</string>
+    <string name="today_update_available_dismiss">暂不</string>
+    <string name="today_update_downloaded_body">更新已下载。重启以完成安装。</string>
+    <string name="today_update_downloaded_action">重启</string>
+
+    <!-- Onboarding additions — TV-shorter subtitle (TV onboarding has
+         less screen real-estate), the always-on location step, and the
+         manual-entry hint shown on the location screen. -->
+    <string name="onboarding_subtitle_tv">两个快速选择即可开始。之后可在设置里调整。</string>
+    <string name="onboarding_location_grant_background">授予始终开启位置权限</string>
+    <string name="onboarding_location_background_needed">还有一步：ClothesCast 需要"始终允许"权限，以便在应用关闭时也能读取你的位置以生成早晨预报。</string>
+    <string name="onboarding_location_enter_manual_hint">如果你拒绝位置权限或设备位置有误，可以手动输入位置。</string>
+
+    <!-- Settings root list — three new rows (Display / Location /
+         Calendar) and their subtitles. The earlier root rows
+         (Schedule / Clothes / Region / Voice / About) were already
+         translated above. -->
+    <string name="settings_root_display">显示</string>
+    <string name="settings_root_location">位置</string>
+    <string name="settings_root_calendar">日历</string>
+    <string name="settings_root_display_subtitle">主题</string>
+    <string name="settings_root_location_subtitle">自动检测或选择城市</string>
+    <string name="settings_root_calendar_subtitle">今天的日程</string>
+
+    <!-- Display screen — theme picker (system / light / dark). -->
+    <string name="settings_display_theme_title">主题</string>
+    <string name="settings_display_theme_system">跟随系统</string>
+    <string name="settings_display_theme_light">浅色</string>
+    <string name="settings_display_theme_dark">深色</string>
+
+    <!-- API keys screen — header above the Gemini block. -->
+    <string name="settings_api_key_gemini_header">使用 Gemini 获得高质量语音。</string>
+
+    <!-- Location screen additions — device-location subtitle, in-flight
+         "detecting…" state, the always-on banner shown when the
+         background-location permission is missing, and the manual-
+         override link with its disclosure. -->
+    <string name="settings_location_use_device_description">最近的大致位置</string>
+    <string name="settings_location_detecting">检测中…</string>
+    <string name="settings_location_background_banner_title">需要始终开启位置权限</string>
+    <string name="settings_location_background_banner_body">没有该权限，早晨预报无法读取你的位置。</string>
+    <string name="settings_location_manual_override">位置不对？手动设置</string>
+    <string name="settings_location_manual_override_disclosure">选择城市会关闭自动检测。</string>
+
+    <!-- Voice screen — engine-picker description (Device vs Gemini
+         trade-offs). -->
+    <string name="settings_tts_engine_description">Gemini 比设备语音听起来自然得多，但在朗读时需要网络通信，并使用你的 API 密钥进行合成（每次朗读一份 ClothesCast 约一次短请求）。Gemini 失败时会回退到设备语音。</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -441,4 +441,168 @@ label localises.
     <string name="insight_time_hour">%1$d點</string>
     <string name="insight_time_hour_minutes">%1$d點%2$02d分</string>
 
+
+    <!-- Today screen — additions: location-unknown label, retry banner,
+         crash-report banner (post-crash share prompt), and Play Store
+         in-app update prompts (available + downloaded states). -->
+    <string name="today_location_unknown">目前位置</string>
+    <string name="today_retrying">上次嘗試失敗 — 重試中…</string>
+
+    <string name="today_crash_banner_title">上次執行已當機</string>
+    <string name="today_crash_banner_body">當機回報已儲存在你的裝置上。要分享出來以便修復 bug 嗎？在你選擇傳送目標之前不會傳送任何內容。</string>
+    <string name="today_crash_banner_share">分享回報</string>
+    <string name="today_crash_banner_dismiss">關閉</string>
+
+    <string name="today_update_available_title">有可用更新</string>
+    <string name="today_update_available_body">Play 商店上有 ClothesCast 的新版本。</string>
+    <string name="today_update_available_action">更新</string>
+    <string name="today_update_available_dismiss">暫不</string>
+    <string name="today_update_downloaded_body">更新已下載。請重新啟動以完成安裝。</string>
+    <string name="today_update_downloaded_action">重新啟動</string>
+
+    <!-- Today rationale strip — "Why this outfit?" expandable block
+         that explains which feels-like threshold tipped the rule, plus
+         ±1° threshold-tweak buttons and the "refresh to see new" hint. -->
+    <string name="today_rationale_title">為什麼是這套穿搭？</string>
+    <string name="today_rationale_show">為什麼？</string>
+    <string name="today_rationale_dismiss">了解</string>
+    <string name="today_rationale_threshold_decrease">閾值降低 1 度</string>
+    <string name="today_rationale_threshold_increase">閾值提高 1 度</string>
+    <string name="today_rationale_threshold_changed_hint">重新整理以查看新穿搭。</string>
+    <string name="today_rationale_unavailable">暫無說明 — 下次重新整理後開啟應用程式查看。</string>
+    <string name="today_rationale_min_below_with_time">體感最低氣溫 %1$s%2$s（%3$s），低於 %4$s%2$s</string>
+    <string name="today_rationale_min_below">體感最低氣溫 %1$s%2$s，低於 %3$s%2$s</string>
+    <string name="today_rationale_min_above_with_time">體感最低氣溫 %1$s%2$s（%3$s），至少 %4$s%2$s</string>
+    <string name="today_rationale_min_above">體感最低氣溫 %1$s%2$s，至少 %3$s%2$s</string>
+    <string name="today_rationale_max_below_with_time">體感最高氣溫僅 %1$s%2$s（%3$s），低於 %4$s%2$s</string>
+    <string name="today_rationale_max_below">體感最高氣溫僅 %1$s%2$s，低於 %3$s%2$s</string>
+    <string name="today_rationale_max_above_with_time">體感最高氣溫 %1$s%2$s（%3$s），至少 %4$s%2$s</string>
+    <string name="today_rationale_max_above">體感最高氣溫 %1$s%2$s，至少 %3$s%2$s</string>
+
+    <!-- Today screen — failure state when location is missing, plus
+         the prompt that takes the user to location settings. -->
+    <string name="today_failed_no_location">無法取得你的位置。請授予始終開啟位置權限，或在設定中設定城市。</string>
+    <string name="today_location_required_title">設定你的位置</string>
+    <string name="today_location_required_body">ClothesCast 需要知道你的位置才能取得天氣預報。請授予始終開啟位置權限，或選擇一個城市。</string>
+    <string name="today_location_required_action">開啟位置設定</string>
+
+    <!-- Onboarding additions — TV-shorter subtitle (TV onboarding has
+         less screen real-estate), the always-on location step, the
+         manual-entry hint, and the TV phone-pairing fallback link. -->
+    <string name="onboarding_subtitle_tv">兩個快速選擇即可開始。之後可在設定裡調整。</string>
+    <string name="onboarding_location_grant_background">授予始終開啟位置權限</string>
+    <string name="onboarding_location_background_needed">還有一步：ClothesCast 需要「始終允許」權限，讓早晨預報在應用程式關閉時也能讀取你的位置。</string>
+    <string name="onboarding_location_enter_manual_hint">如果你拒絕位置權限，或裝置位置有誤，可以手動輸入位置。</string>
+    <string name="onboarding_pair_from_phone">改用手機配對</string>
+
+    <!-- TV pairing flow — phone scans the QR, pastes the Gemini API
+         key into a form on the phone, key is sent over local Wi-Fi
+         straight to the TV (no cloud relay). -->
+    <string name="pairing_title">掃描配對</string>
+    <string name="pairing_instructions">用手機掃描此 QR 碼，然後將你的 Gemini API 金鑰貼到開啟的表單中。金鑰會透過你家中的 Wi-Fi 直接傳送到此電視 — 不經雲端轉送。</string>
+    <string name="pairing_qr_description">連到 %1$s 的 QR 碼</string>
+    <string name="pairing_cancel">取消</string>
+    <string name="pairing_received">已收到金鑰 — 儲存中…</string>
+    <string name="pairing_timeout_title">配對視窗已過期</string>
+    <string name="pairing_timeout_body">5 分鐘的配對視窗已關閉。點一下重試以開啟新視窗。</string>
+    <string name="pairing_error_title">無法啟動配對</string>
+    <string name="pairing_error_body">請確認電視已連接 Wi-Fi，然後再試一次。</string>
+    <string name="pairing_retry">重試</string>
+
+    <!-- Settings root list — three new rows (Display / Location /
+         Calendar) and the four newer subtitles for the existing rows
+         (Schedule / Clothes / Region / Voice). -->
+    <string name="settings_root_display">顯示</string>
+    <string name="settings_root_location">位置</string>
+    <string name="settings_root_calendar">行事曆</string>
+    <string name="settings_root_display_subtitle">佈景主題</string>
+    <string name="settings_root_location_subtitle">自動偵測或選擇城市</string>
+    <string name="settings_root_calendar_subtitle">今天的行程</string>
+    <string name="settings_root_schedule_subtitle">通知與時間</string>
+    <string name="settings_root_clothes_subtitle">氣溫與穿搭</string>
+    <string name="settings_root_region_subtitle">語言與單位</string>
+    <string name="settings_root_voice_subtitle">提供者與口音</string>
+
+    <!-- Display screen — theme picker (system / light / dark). -->
+    <string name="settings_display_theme_title">佈景主題</string>
+    <string name="settings_display_theme_system">跟隨系統</string>
+    <string name="settings_display_theme_light">淺色</string>
+    <string name="settings_display_theme_dark">深色</string>
+
+    <!-- API keys screen — header above the Gemini block. -->
+    <string name="settings_api_key_gemini_header">使用 Gemini 獲得高品質語音。</string>
+
+    <!-- Location screen additions — device-location subtitle, in-flight
+         "detecting…" state, the always-on banner shown when the
+         background-location permission is missing, the manual-override
+         link with its disclosure, and the rationale + denied dialogs
+         for the foreground / background location permissions. -->
+    <string name="settings_location_use_device_description">最近的概略位置</string>
+    <string name="settings_location_detecting">偵測中…</string>
+    <string name="settings_location_background_banner_title">需要始終開啟位置權限</string>
+    <string name="settings_location_background_banner_body">沒有該權限，早晨預報無法讀取你的位置。</string>
+    <string name="settings_location_manual_override">位置不對？手動設定</string>
+    <string name="settings_location_manual_override_disclosure">選擇城市會關閉自動偵測。</string>
+
+    <string name="settings_location_rationale_title">位置權限</string>
+    <string name="settings_location_rationale_body">ClothesCast 會讀取你的位置以取得當地天氣預報。</string>
+    <string name="settings_location_rationale_continue">繼續</string>
+    <string name="settings_location_rationale_dismiss">暫不</string>
+
+    <string name="settings_location_background_rationale_title">始終允許</string>
+    <string name="settings_location_background_rationale_body">允許 ClothesCast 在應用程式關閉時也讀取你的位置，讓早晨預報能準時更新。</string>
+    <string name="settings_location_background_rationale_continue">開啟設定</string>
+    <string name="settings_location_background_rationale_dismiss">暫不</string>
+
+    <string name="settings_location_background_denied_title">未授予始終開啟</string>
+    <string name="settings_location_background_denied_body">若沒有「始終允許」，早晨預報就無法自動更新。</string>
+    <string name="settings_location_background_denied_open">開啟設定</string>
+    <string name="settings_location_background_denied_keep">暫不</string>
+
+    <!-- Voice screen — engine-picker description, the device-voice
+         sub-picker with auto / network / offline labels, and the
+         Google-TTS install hint shown when the system has no engine. -->
+    <string name="settings_tts_engine_description">Gemini 比裝置語音聽起來自然得多，但在朗讀時需要網路通訊，並使用你的 API 金鑰進行合成（每次朗讀一份 ClothesCast 約一次短請求）。Gemini 失敗時會回退到裝置語音。</string>
+
+    <string name="settings_tts_device_voice_label">裝置語音</string>
+    <string name="settings_tts_device_voice_auto">自動（最適合口音）</string>
+    <string name="settings_tts_device_voice_currently">目前：%1$s</string>
+    <string name="settings_tts_device_voice_currently_loading">載入中…</string>
+    <string name="settings_tts_device_voice_network">網路</string>
+    <string name="settings_tts_device_voice_offline">離線</string>
+    <string name="settings_tts_install_google_hint">安裝 Google 文字轉語音引擎以獲得更高品質的語音。</string>
+    <string name="settings_tts_install_google_button">安裝 Google TTS</string>
+
+    <!-- Region screen — additional language picker labels for locales
+         that landed after the original zh-TW translation pass. -->
+    <string name="settings_region_language_ca_es">加泰隆尼亞文（西班牙）</string>
+    <string name="settings_region_language_sl_si">斯洛維尼亞文（斯洛維尼亞）</string>
+    <string name="settings_region_language_el_gr">希臘文（希臘）</string>
+    <string name="settings_region_language_da_dk">丹麥文（丹麥）</string>
+    <string name="settings_region_language_nb_no">挪威文 Bokmål（挪威）</string>
+    <string name="settings_region_language_fi_fi">芬蘭文（芬蘭）</string>
+    <string name="settings_region_language_et_ee">愛沙尼亞文（愛沙尼亞）</string>
+    <string name="settings_region_language_lv_lv">拉脫維亞文（拉脫維亞）</string>
+    <string name="settings_region_language_lt_lt">立陶宛文（立陶宛）</string>
+    <string name="settings_region_language_ms_my">馬來文（馬來西亞）</string>
+    <string name="settings_region_language_sw_ke">斯瓦希里文（肯亞）</string>
+    <string name="settings_region_language_th_th">泰文（泰國）</string>
+    <string name="settings_region_language_sq_al">阿爾巴尼亞文（阿爾巴尼亞）</string>
+    <string name="settings_region_language_am_et">阿姆哈拉文（衣索比亞）</string>
+
+    <!-- Voice locale picker — same set, keyed for the Voice screen. -->
+    <string name="settings_tts_voice_locale_ca_es">加泰隆尼亞文（西班牙）</string>
+    <string name="settings_tts_voice_locale_sl_si">斯洛維尼亞文（斯洛維尼亞）</string>
+    <string name="settings_tts_voice_locale_el_gr">希臘文（希臘）</string>
+    <string name="settings_tts_voice_locale_da_dk">丹麥文（丹麥）</string>
+    <string name="settings_tts_voice_locale_nb_no">挪威文 Bokmål（挪威）</string>
+    <string name="settings_tts_voice_locale_fi_fi">芬蘭文（芬蘭）</string>
+    <string name="settings_tts_voice_locale_et_ee">愛沙尼亞文（愛沙尼亞）</string>
+    <string name="settings_tts_voice_locale_lv_lv">拉脫維亞文（拉脫維亞）</string>
+    <string name="settings_tts_voice_locale_lt_lt">立陶宛文（立陶宛）</string>
+    <string name="settings_tts_voice_locale_ms_my">馬來文（馬來西亞）</string>
+    <string name="settings_tts_voice_locale_sw_ke">斯瓦希里文（肯亞）</string>
+    <string name="settings_tts_voice_locale_th_th">泰文（泰國）</string>
+    <string name="settings_tts_voice_locale_sq_al">阿爾巴尼亞文（阿爾巴尼亞）</string>
+    <string name="settings_tts_voice_locale_am_et">阿姆哈拉文（衣索比亞）</string>
 </resources>


### PR DESCRIPTION
## Summary

Audits and closes translation gaps in the East Asian locales, and leaves a TODO for Hindi to expand later.

Before this PR (excluding the 7 keys every non-English locale intentionally omits — `app_name` brand identifier + 6 English-only `insight_time_am/pm/midnight/noon[_minutes]` formatter helpers):

| Locale | Missing |
|---|---|
| `values-ja` | 34 |
| `values-ko` | 34 |
| `values-zh-rCN` | 34 (same set as ja/ko) |
| `values-zh-rTW` | 116 (same 34 + 82 more) |
| `values-hi` | 344 (intentional minimal scope per existing header) |

After: 0 unintentional gaps in ja / ko / zh-CN / zh-TW.

### What landed in the 34 common keys (ja / ko / zh-CN / zh-TW)

- **Today screen** — `today_location_unknown`, `today_retrying`, crash-report banner (4 keys), in-app update prompts: available + downloaded states (6 keys)
- **Onboarding** — TV-shorter subtitle, always-on location step, manual-entry hint (4 keys)
- **Settings root** — Display / Location / Calendar rows + their subtitles (6 keys)
- **Display** — theme picker title + system / light / dark options (4 keys)
- **API keys** — Gemini header
- **Location** — device-location subtitle, detecting state, always-on banner, manual-override link + disclosure (6 keys)
- **Voice** — engine description (Gemini vs device trade-offs)

### Additional 82 keys that only zh-TW was missing

- **Phone-pairing flow** (11 keys): `onboarding_pair_from_phone` + `pairing_*`
- **Today rationale strip** (16 keys): `today_rationale_*` (the "Why this outfit?" expandable + ±1° threshold tweak buttons)
- **Location-required + denied dialogs** (8 keys)
- **Foreground / background location rationale dialogs** (8 keys)
- **TTS device-voice sub-picker + Google-TTS install hint** (8 keys)
- **Settings root subtitles** for Schedule / Clothes / Region / Voice (4 keys)
- **Region + Voice locale picker rows** for ca-ES, sl-SI, el-GR, da-DK, nb-NO, fi-FI, et-EE, lv-LV, lt-LT, ms-MY, sw-KE, th-TH, sq-AL, am-ET (28 keys)

### Hindi

Existing header documents intentional minimal scope (insight prose + garments + clothes-rule editor + locale picker labels — the rest falls through to English). Added a TODO note in the header explaining what's missing (~344 keys, all of Settings / Today / Onboarding / Pairing / notification channels / About read in English on a Hindi device) and how to approach it: friendly-polite आप-form register, Devanagari typography conventions, brand name kept Latin, and which keys to leave unoverridden by precedent (`app_name` + the English-only AM/PM time helpers — Hindi already has `insight_time_hour` / `_hour_minutes`).

### Conventions followed

Each locale's existing register and typography were preserved:
- **ja**: ます-form, sentence-final 。, list separator 、, corner brackets 「」 for nested labels, full-width （） around Japanese content
- **ko**: 해요체 in interactive prose, 하십시오체 for system / channel descriptions, half-width ( ) with leading space
- **zh-rCN**: 你-form, 。, 、, full-width （）, mainland software vocabulary
- **zh-rTW**: 你-form, 。, 、, full-width （）, traditional software vocabulary (設定 / 預設 / 新增 / 儲存 / 金鑰 / 行事曘 / 重新整理 / 偵測 / 機率 / 裝置 / 網路 / 離線 / 啟用 / 背景 …)

### Privacy

No new strings cross the device boundary. All additions are UI chrome / labels / prompts that stay on-device; nothing changes what's sent to Gemini / OpenAI / ElevenLabs / Open-Meteo.

## Test plan

- [ ] CI: `JVM unit tests` green (string resources have no test impact in `:core:domain`)
- [ ] CI: `Android debug build` green (`:app:assembleDebug` will catch any AAPT issues with the new strings)
- [ ] Eyeball a Japanese / Korean / Simplified-Chinese / Traditional-Chinese device or emulator on the Today screen, Settings root, Display screen, and Onboarding flow

## Verification

Verified locally with Python XML parsing + a placeholder-consistency check against the base file: 0 missing keys (excluding the 7 intentional ones), 0 placeholder mismatches across all four updated locales.

https://claude.ai/code/session_012JsHAAS72GeemuTuwB8SMh

---
_Generated by [Claude Code](https://claude.ai/code/session_012JsHAAS72GeemuTuwB8SMh)_