### PR TITLE
:app + :core — default Gemini voice Erinome → Leda

### DIFF
--- a/app/src/main/kotlin/app/clothescast/tts/GeminiTtsSpeaker.kt
+++ b/app/src/main/kotlin/app/clothescast/tts/GeminiTtsSpeaker.kt
@@ -9,7 +9,7 @@ import java.util.Locale
  * High-quality TTS via Gemini's audio-output model. Synthesises PCM audio in one
  * network call, hands the buffer to [PcmAudioPlayer] for playback.
  *
- * Voice is configurable; defaults to `Erinome` (clear). Other prebuilt voices are
+ * Voice is configurable; defaults to `Leda` (youthful). Other prebuilt voices are
  * surfaced via the Settings voice picker.
  *
  * Fallback is the caller's responsibility — see [app.clothescast.work.FetchAndNotifyWorker]

--- a/app/src/main/kotlin/app/clothescast/tts/TtsVoices.kt
+++ b/app/src/main/kotlin/app/clothescast/tts/TtsVoices.kt
@@ -14,8 +14,10 @@ data class TtsVoiceOption(
     val displayName: String,
 )
 
-// Curated from listening tests across en-AU and en-GB. Erinome is the default
-// — excellent across both locales. Grouped by character:
+// Curated from listening tests across en-AU and en-GB. Leda is the default —
+// chosen alongside the v505-equivalent "Normal" style preamble being the
+// default style; pending a broader re-audition under Normal. Grouped by
+// character:
 //   Clear/Firm (newsreader-y): Erinome, Iapetus, Kore
 //   Informative/Knowledgeable (male alternatives): Charon, Sadaltager
 //   Gentle/Smooth/Warm: Vindemiatrix, Despina, Algieba, Sulafat

--- a/app/src/test/kotlin/app/clothescast/data/SettingsRepositoryTest.kt
+++ b/app/src/test/kotlin/app/clothescast/data/SettingsRepositoryTest.kt
@@ -291,8 +291,8 @@ class SettingsRepositoryTest {
     }
 
     @Test
-    fun `gemini voice defaults to Erinome when nothing stored`() = runTest {
-        subject.preferences.first().geminiVoice shouldBe "Erinome"
+    fun `gemini voice defaults to Leda when nothing stored`() = runTest {
+        subject.preferences.first().geminiVoice shouldBe "Leda"
     }
 
     @Test

--- a/core/data/src/main/kotlin/app/clothescast/core/data/tts/GeminiTtsClient.kt
+++ b/core/data/src/main/kotlin/app/clothescast/core/data/tts/GeminiTtsClient.kt
@@ -32,7 +32,7 @@ import java.util.Locale
 // `-preview-` track — see CLAUDE.md's "Don't rename Gemini models from
 // web-search guesses" before swapping it for a GA-sounding name.
 const val DEFAULT_GEMINI_TTS_MODEL: String = "gemini-2.5-flash-preview-tts"
-const val DEFAULT_GEMINI_TTS_VOICE: String = "Erinome"
+const val DEFAULT_GEMINI_TTS_VOICE: String = "Leda"
 
 internal const val GEMINI_HOST = "generativelanguage.googleapis.com"
 internal const val GEMINI_API_VERSION = "v1beta"
@@ -185,8 +185,8 @@ private val ACCENT_DIRECTIVES: Map<String, String> = mapOf(
  * `ENCODING_PCM_16BIT` consumes. A previous attempt to byte-swap on decode was
  * reverted because it turned correctly-decoded speech into noise.
  *
- * Default voice is `Kore` (firm). Other prebuilt voices are listed in Google's docs;
- * pass via [voiceName] when calling.
+ * Default voice is [DEFAULT_GEMINI_TTS_VOICE]. Other prebuilt voices are listed
+ * in Google's docs; pass via [voiceName] when calling.
  */
 class GeminiTtsClient(
     private val httpClient: HttpClient,

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Settings.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Settings.kt
@@ -277,6 +277,6 @@ data class UserPreferences(
     val dailyMentionEveningEvents: Boolean = true,
 ) {
     companion object {
-        const val DEFAULT_GEMINI_VOICE = "Erinome"
+        const val DEFAULT_GEMINI_VOICE = "Leda"
     }
 }

--- a/docs/voice-evals.md
+++ b/docs/voice-evals.md
@@ -4,6 +4,14 @@ Results from a manual listening session conducted against real app output
 (en-AU and en-GB, Gemini 2.5 Flash Preview TTS). All scores are subjective
 1–10 ratings by the primary user unless noted.
 
+> **Note (post-PR #323):** the newsreader directive this eval was
+> conducted under is now opt-in via the new "Style" picker, with `Normal`
+> (the v505-equivalent studio-voice preamble) as the default. The default
+> voice has moved from Erinome to Leda alongside that change. A
+> re-audition under Normal is pending — sections below remain the
+> historical record of the newsreader-only eval, not the current
+> recommendation.
+
 ---
 
 ## Problem statement


### PR DESCRIPTION
## Summary

Switches the default Gemini voice from **Erinome** to **Leda**. Pairs with #323's switch to the v505-equivalent "Normal" style preamble — Erinome's 10/10 score was specifically against the newsreader directive in `docs/voice-evals.md`, so that default rationale is partially stale now that fresh installs hear the studio-voice preamble.

A broader re-audition under Normal will follow as a separate PR; this just realigns the default ahead of that work.

## Impact

- Fresh installs: default voice is Leda
- Old installs that never opened the voice picker: switches Erinome → Leda silently
- Old installs with explicit voice pick: unchanged

## Privacy

No change to what we send off device — same per-call POST to Gemini TTS, only the voice ID differs.

## Test plan

- [ ] CI: green (`:core:domain:test` already pinned the new default; `SettingsRepositoryTest` updated)
- [ ] Manual: fresh install → Settings → Voice → Gemini shows Leda as the picked voice
- [ ] Manual: under en-US / en-GB / en-AU, Leda renders without obvious regional artifacts
- [ ] Follow-up: re-audition under Normal across all 11 voices, update `docs/voice-evals.md`

https://claude.ai/code/session_01FjxuYJKnntRUk1AfuRx54o

---
_Generated by [Claude Code](https://claude.ai/code/session_01FjxuYJKnntRUk1AfuRx54o)_