### PR TITLE
:app — enable R8 tree-shaking on debug builds

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -215,7 +215,13 @@ android {
 
     buildTypes {
         debug {
-            isMinifyEnabled = false
+            isMinifyEnabled = true
+            isShrinkResources = true
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro",
+                "proguard-debug.pro",
+            )
             applicationIdSuffix = ".debug"
         }
         release {

--- a/app/proguard-debug.pro
+++ b/app/proguard-debug.pro
@@ -1,0 +1,4 @@
+# Debug builds: shrink (tree-shake) only — no renaming, no optimization passes.
+# R8 removes unused classes and members; stack traces stay readable.
+-dontobfuscate
+-dontoptimize


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Enables `isMinifyEnabled = true` and `isShrinkResources = true` on the `debug` build type so R8 removes unused classes and resources on all debug (CI and local) builds
- Adds `app/proguard-debug.pro` with `-dontobfuscate -dontoptimize` — identifiers stay readable and no code-transformation passes run; this is pure dead-code / unused-resource elimination only
- The `release` build type is unchanged (it already runs full R8 with obfuscation and optimization)

## Test plan

- [ ] CI `Android debug build` job passes (`assembleDebug` with R8 shrinking enabled)
- [ ] CI `JVM unit tests` job passes
- [ ] Debug APK artifact size is smaller than before (unused classes/resources removed)
- [ ] Stack traces in debug builds remain readable (no obfuscated names)

https://claude.ai/code/session_014gVBvdGvD2DaXNWAeYty6g
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_014gVBvdGvD2DaXNWAeYty6g)_