### PR TITLE
:app — post notification and speak TTS together after alarm gap

### DIFF
--- a/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
@@ -348,11 +348,12 @@ class FetchAndNotifyWorker(
 
     private suspend fun deliverToday(insight: Insight, prefs: UserPreferences, prose: String) {
         val mode = prefs.deliveryMode
+        val includesTts = mode == DeliveryMode.TTS_ONLY || mode == DeliveryMode.NOTIFICATION_AND_TTS
+        if (includesTts) awaitSpeakTime()
         if (mode == DeliveryMode.NOTIFICATION_ONLY || mode == DeliveryMode.NOTIFICATION_AND_TTS) {
             app.insightNotifier.notify(insight, prose)
         }
-        if (mode == DeliveryMode.TTS_ONLY || mode == DeliveryMode.NOTIFICATION_AND_TTS) {
-            awaitSpeakTime()
+        if (includesTts) {
             speakWithFallback(prose, prefs)
         }
     }


### PR DESCRIPTION
## Summary

- When delivery mode includes TTS, the notification is now deferred alongside TTS — both fire after the 30s alarm gap rather than the notification firing immediately and TTS arriving 30s later
- `NOTIFICATION_ONLY` mode is unchanged — no TTS involved, no reason to defer

## Before / After

| Mode | Before | After |
|---|---|---|
| `NOTIFICATION_ONLY` | notification at T+0s | notification at T+0s (unchanged) |
| `TTS_ONLY` | TTS at T+30s | TTS at T+30s (unchanged) |
| `NOTIFICATION_AND_TTS` | notification at T+0s, TTS at T+30s | notification + TTS together at T+30s |

## Test plan

- [ ] Set delivery mode to `Notification + TTS` — verify notification and voice briefing arrive at roughly the same moment (~30s after alarm)
- [ ] Set delivery mode to `Notification only` — verify notification still fires promptly at alarm time

https://claude.ai/code/session_01X2rbRQZrzyJPCkx8MxNj8w

---
_Generated by [Claude Code](https://claude.ai/code/session_01X2rbRQZrzyJPCkx8MxNj8w)_