### PR TITLE
:app — preserve UNSET for region / voice-locale analytics overrides

### DIFF
--- a/app/src/main/kotlin/app/clothescast/data/SettingsRepository.kt
+++ b/app/src/main/kotlin/app/clothescast/data/SettingsRepository.kt
@@ -381,10 +381,15 @@ class SettingsRepository(
         val effectiveVoiceLocale = resolved.voiceLocale.resolve(regionLocale)
         return SettingsAnalyticsSnapshot(
             regionDefault = systemLocale.toLanguageTag(),
-            regionOverride = resolved.region.name,
+            // Read the raw key rather than `resolved.region.name`: the resolved
+            // value collapses "no DataStore key" into Region.SYSTEM, which would
+            // make a never-touched picker indistinguishable from an explicit
+            // SYSTEM pick in reports — exactly the distinction this snapshot is
+            // meant to surface.
+            regionOverride = this[REGION] ?: SettingsAnalyticsSnapshot.UNSET,
             regionEffective = regionLocale.toLanguageTag(),
             voiceLocaleDefault = regionLocale.toLanguageTag(),
-            voiceLocaleOverride = resolved.voiceLocale.name,
+            voiceLocaleOverride = this[VOICE_LOCALE] ?: SettingsAnalyticsSnapshot.UNSET,
             voiceLocaleEffective = effectiveVoiceLocale.toLanguageTag(),
             ttsEngineDefault = TtsEngine.DEVICE.name,
             ttsEngineOverride = this[TTS_ENGINE] ?: SettingsAnalyticsSnapshot.UNSET,

--- a/app/src/test/kotlin/app/clothescast/data/SettingsRepositoryTest.kt
+++ b/app/src/test/kotlin/app/clothescast/data/SettingsRepositoryTest.kt
@@ -508,16 +508,17 @@ class SettingsRepositoryTest {
     @Test
     fun `analyticsSnapshot reports defaults and UNSET when nothing is stored`() = runTest {
         // Pinned systemLocaleProvider is Locale.UK → BCP-47 "en-GB". With no
-        // stored region or voice locale, both SYSTEM sentinels resolve to
-        // that, and every TTS field reads UNSET so reports can tell "user
-        // never touched it" apart from "user picked the default value".
+        // stored keys, both SYSTEM sentinels resolve to that for the
+        // *effective* values, but every override field reads UNSET so reports
+        // can tell "user never touched it" apart from "user picked SYSTEM /
+        // the default value explicitly".
         val snap = subject.analyticsSnapshot.first()
 
         snap.regionDefault shouldBe "en-GB"
-        snap.regionOverride shouldBe Region.SYSTEM.name
+        snap.regionOverride shouldBe SettingsAnalyticsSnapshot.UNSET
         snap.regionEffective shouldBe "en-GB"
         snap.voiceLocaleDefault shouldBe "en-GB"
-        snap.voiceLocaleOverride shouldBe VoiceLocale.SYSTEM.name
+        snap.voiceLocaleOverride shouldBe SettingsAnalyticsSnapshot.UNSET
         snap.voiceLocaleEffective shouldBe "en-GB"
         snap.ttsEngineDefault shouldBe TtsEngine.DEVICE.name
         snap.ttsEngineOverride shouldBe SettingsAnalyticsSnapshot.UNSET
@@ -580,15 +581,21 @@ class SettingsRepositoryTest {
 
     @Test
     fun `analyticsSnapshot SYSTEM override is distinct from UNSET`() = runTest {
-        // Persisting Region.SYSTEM is observably a different story from
-        // never having touched the picker — the user explicitly chose
-        // SYSTEM. The override field surfaces that.
+        // Persisting Region.SYSTEM / VoiceLocale.SYSTEM is observably a
+        // different story from never having touched the picker. The override
+        // field surfaces that distinction: "user actively kept the default" vs
+        // "default fell out as SYSTEM". An UNSET-vs-SYSTEM breakdown is the
+        // whole point of this snapshot, so this is contract-level.
         subject.setRegion(Region.EN_US)
         subject.setRegion(Region.SYSTEM)
+        subject.setVoiceLocale(VoiceLocale.EN_AU)
+        subject.setVoiceLocale(VoiceLocale.SYSTEM)
 
         val snap = subject.analyticsSnapshot.first()
         snap.regionOverride shouldBe Region.SYSTEM.name
         snap.regionEffective shouldBe "en-GB"
+        snap.voiceLocaleOverride shouldBe VoiceLocale.SYSTEM.name
+        snap.voiceLocaleEffective shouldBe "en-GB"
     }
 
     @Test

--- a/app/src/test/kotlin/app/clothescast/data/SettingsRepositoryTest.kt
+++ b/app/src/test/kotlin/app/clothescast/data/SettingsRepositoryTest.kt
@@ -570,11 +570,12 @@ class SettingsRepositoryTest {
     fun `analyticsSnapshot voiceLocale default tracks region override`() = runTest {
         // VoiceLocale.SYSTEM falls back to the *region* locale, not the
         // system locale — so changing the region also changes the baseline
-        // an unset voice locale resolves to.
+        // an unset voice locale resolves to. Voice locale itself is UNSET
+        // here because the user only touched the region picker.
         subject.setRegion(Region.EN_US)
 
         val snap = subject.analyticsSnapshot.first()
-        snap.voiceLocaleOverride shouldBe VoiceLocale.SYSTEM.name
+        snap.voiceLocaleOverride shouldBe SettingsAnalyticsSnapshot.UNSET
         snap.voiceLocaleDefault shouldBe "en-US"
         snap.voiceLocaleEffective shouldBe "en-US"
     }


### PR DESCRIPTION
## Summary

`SettingsAnalyticsSnapshot.regionOverride` and `voiceLocaleOverride` were being filled from `resolved.region.name` / `resolved.voiceLocale.name`, which collapses two distinct states into the same value:

- **no DataStore key written** (user never touched the picker) → resolves to `Region.SYSTEM` / `VoiceLocale.SYSTEM`
- **explicit pick of SYSTEM** → also stored as `Region.SYSTEM` / `VoiceLocale.SYSTEM`

So the override field — the whole point of which is to expose UNSET vs explicit-default — silently reported the same string for both. Any analytics breakdown or experiment that relied on that distinction was broken for these two settings (it worked correctly for `ttsEngine` / `ttsStyle` / `geminiVoice` / `deviceVoice`).

The data class KDoc on `SettingsAnalyticsSnapshot` already described the intended contract — UNSET for "no DataStore key", SYSTEM for explicit pick — but the implementation didn't match it.

## Fix

Read the raw DataStore keys instead of the resolved enum values, mapping null → UNSET. Mirrors the pattern already in use for the four other override fields:

```kotlin
regionOverride = this[REGION] ?: SettingsAnalyticsSnapshot.UNSET,
voiceLocaleOverride = this[VOICE_LOCALE] ?: SettingsAnalyticsSnapshot.UNSET,
```

The effective and default fields are unchanged — they still reflect "what the user actually gets", which is correct.

## Privacy

No new data crosses the device boundary. The fields were already being mirrored into Firebase Analytics user properties; this PR only changes which of two existing strings (`UNSET` vs `SYSTEM`) gets sent for users who haven't touched the locale pickers. Both are short configuration strings well under Firebase's 36-char per-property cap.

## Test plan

- [x] Updated `analyticsSnapshot reports defaults and UNSET when nothing is stored` to assert `UNSET` for `regionOverride` and `voiceLocaleOverride` (was incorrectly asserting SYSTEM, locking in the bug).
- [x] Extended `analyticsSnapshot SYSTEM override is distinct from UNSET` to cover `VoiceLocale` alongside `Region`, so the UNSET-vs-SYSTEM distinction is contract-tested for both fields.
- [ ] CI: `:core:*:test` + `:app:testDebugUnitTest` (sandbox lacks Android SDK / Google Maven, relying on CI as the validation surface per `CLAUDE.md`).
- [ ] CI: `:app:assembleDebug`.

https://claude.ai/code/session_013CGYRhR5un6kR3paiikzT2

---
_Generated by [Claude Code](https://claude.ai/code/session_013CGYRhR5un6kR3paiikzT2)_