### PR TITLE
:core:data — update NORMAL TTS directive and en-AU accent (eval findings)

### DIFF
--- a/core/data/src/main/kotlin/app/clothescast/core/data/tts/GeminiTtsClient.kt
+++ b/core/data/src/main/kotlin/app/clothescast/core/data/tts/GeminiTtsClient.kt
@@ -59,8 +59,11 @@ internal const val GEMINI_API_VERSION = "v1beta"
  * PIRATE that might otherwise tempt the model to add ocean ambience.
  */
 internal const val GEMINI_TTS_STYLE_DIRECTIVE_NORMAL: String =
-    "Read the following in a clean, crisp studio voice with no audio effects, " +
-        "background noise, or vinyl-style texture:\n\n"
+    "Read the following weather forecast in the style of a national-news " +
+        "weather report. Use a deliberate cadence: unhurried, clearly enunciated, " +
+        "with a natural lift at the end of each sentence. Give a gentle extra " +
+        "emphasis to clothing advice. No audio effects, background noise, or " +
+        "vinyl-style texture:\n\n"
 
 internal const val GEMINI_TTS_STYLE_DIRECTIVE_NEWSREADER: String =
     "Read the following in a clear, educated newsreader style — articulate but " +
@@ -213,7 +216,7 @@ internal fun geminiAccentDirectiveFor(locale: Locale): String? {
 
 private val ACCENT_DIRECTIVES: Map<String, String> = mapOf(
     "en-GB" to "Speak with a Standard Southern British accent.",
-    "en-AU" to "Speak with a Cultivated Australian accent — clear and educated, not broad.",
+    "en-AU" to "Speak with a General Australian accent — clear and natural, not broad.",
     "en-US" to "Speak with a General American accent.",
     "en-CA" to "Speak with a Canadian English accent.",
     // Language-only fallback for Standard German (de-DE) and any de-* variant

--- a/core/data/src/test/kotlin/app/clothescast/core/data/tts/GeminiTtsClientTest.kt
+++ b/core/data/src/test/kotlin/app/clothescast/core/data/tts/GeminiTtsClientTest.kt
@@ -107,7 +107,7 @@ class GeminiTtsClientTest {
         client.synthesize(text = "hello world")
 
         val body = checkNotNull(capturedBody)
-        body.shouldContain("clean, crisp studio voice")
+        body.shouldContain("national-news weather report")
         body.shouldNotContain("newsreader style")
         body.shouldContain("hello world")
     }
@@ -128,7 +128,7 @@ class GeminiTtsClientTest {
 
         val body = checkNotNull(capturedBody)
         body.shouldContain("newsreader style")
-        body.shouldNotContain("clean, crisp studio voice")
+        body.shouldNotContain("national-news weather report")
         body.shouldContain("hello world")
     }
 
@@ -165,7 +165,7 @@ class GeminiTtsClientTest {
         client.synthesize(text = "hello", locale = Locale.forLanguageTag("en-AU"))
 
         val body = checkNotNull(capturedBody)
-        body.shouldContain("Cultivated Australian accent")
+        body.shouldContain("General Australian accent")
     }
 
     @Test
@@ -518,7 +518,7 @@ class GeminiTtsClientTest {
                 body.shouldContain(signature)
                 body.shouldContain("hello world")
                 // Baseline NORMAL phrasing must not leak into a non-NORMAL style.
-                body.shouldNotContain("clean, crisp studio voice")
+                body.shouldNotContain("national-news weather report")
             }
         }
     }
@@ -546,7 +546,7 @@ class GeminiTtsClientTest {
 
         val body = checkNotNull(capturedBody)
         body.shouldContain("stern librarian whispering")
-        body.shouldNotContain("clean, crisp studio voice")
+        body.shouldNotContain("national-news weather report")
         body.shouldContain("hello world")
     }
 
@@ -572,7 +572,7 @@ class GeminiTtsClientTest {
         )
 
         val body = checkNotNull(capturedBody)
-        body.shouldContain("clean, crisp studio voice")
+        body.shouldContain("national-news weather report")
         body.shouldContain("hello world")
     }
 


### PR DESCRIPTION
Updates the two production TTS strings based on findings from `eval-weather-report-style.py` listening tests.

## Changes

**NORMAL style directive** — replaces "clean, crisp studio voice" with the C2 broadcast-weather wording:
> Read the following weather forecast in the style of a national-news weather report. Use a deliberate cadence: unhurried, clearly enunciated, with a natural lift at the end of each sentence. Give a gentle extra emphasis to clothing advice. No audio effects, background noise, or vinyl-style texture.

**en-AU accent directive** — replaces "Cultivated Australian — clear and educated, not broad" with:
> Speak with a General Australian accent — clear and natural, not broad.

## Why

Directive: C2 was rated "great" across en-AU and en-GB with Erinome. The deliberate cadence suits a morning briefing; sentence-final lift improves comprehension; clothing emphasis is the core value of the app. C3 (with explicit pause direction) also rated well for en-AU but C2 was preferred for en-GB, making it the better cross-locale default.

Accent: "Cultivated" and "educated" steered too formal in listening tests. General Australian (the mid-tier ABC/SBS register) sounds warmer without going broad. Minimal steering ("Australian accent — clear and natural") risked going broad on some clips.

## Test plan
- [ ] CI passes (string constant + test assertion changes only)
- [ ] Manual listen in-app on en-AU
- [ ] Manual listen in-app on en-GB

https://claude.ai/code/session_01DFrE8pdhyfX9phbVCqggZ1

---
_Generated by [Claude Code](https://claude.ai/code/session_01DFrE8pdhyfX9phbVCqggZ1)_