### PR TITLE
:core:domain + :core:data + :app — collapse TtsStyle to Weather Forecaster

### DIFF
--- a/app/src/main/kotlin/app/clothescast/data/SettingsRepository.kt
+++ b/app/src/main/kotlin/app/clothescast/data/SettingsRepository.kt
@@ -318,7 +318,7 @@ class SettingsRepository(
         val geminiVoice = this[GEMINI_VOICE]?.takeIf { it.isNotBlank() }
             ?: UserPreferences.DEFAULT_GEMINI_VOICE
         val ttsStyle = this[TTS_STYLE]?.let { runCatching { TtsStyle.valueOf(it) }.getOrNull() }
-            ?: TtsStyle.NORMAL
+            ?: TtsStyle.WEATHER_FORECASTER
         val customTtsStyleDirective = this[CUSTOM_TTS_STYLE_DIRECTIVE].orEmpty()
         val voiceLocale = this[VOICE_LOCALE]?.let { runCatching { VoiceLocale.valueOf(it) }.getOrNull() }
             ?: VoiceLocale.SYSTEM
@@ -394,7 +394,7 @@ class SettingsRepository(
             ttsEngineDefault = TtsEngine.DEVICE.name,
             ttsEngineOverride = this[TTS_ENGINE] ?: SettingsAnalyticsSnapshot.UNSET,
             ttsEngineEffective = resolved.ttsEngine.name,
-            ttsStyleDefault = TtsStyle.NORMAL.name,
+            ttsStyleDefault = TtsStyle.WEATHER_FORECASTER.name,
             ttsStyleOverride = this[TTS_STYLE] ?: SettingsAnalyticsSnapshot.UNSET,
             ttsStyleEffective = resolved.ttsStyle.name,
             geminiVoiceDefault = UserPreferences.DEFAULT_GEMINI_VOICE,

--- a/app/src/main/kotlin/app/clothescast/tts/GeminiTtsSpeaker.kt
+++ b/app/src/main/kotlin/app/clothescast/tts/GeminiTtsSpeaker.kt
@@ -18,7 +18,7 @@ import java.util.Locale
 class GeminiTtsSpeaker(
     private val client: GeminiTtsClient,
     private val voiceName: String = DEFAULT_GEMINI_TTS_VOICE,
-    private val style: TtsStyle = TtsStyle.NORMAL,
+    private val style: TtsStyle = TtsStyle.WEATHER_FORECASTER,
     private val customStyleDirective: String = "",
 ) : TtsSpeaker {
 

--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsPreviews.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsPreviews.kt
@@ -151,7 +151,7 @@ internal fun SettingsVoiceDevicePreview() {
         VoiceContent(
             selected = TtsEngine.DEVICE,
             geminiVoice = UserPreferences.DEFAULT_GEMINI_VOICE,
-            ttsStyle = TtsStyle.NORMAL,
+            ttsStyle = TtsStyle.WEATHER_FORECASTER,
             customTtsStyleDirective = "",
             deviceVoice = null,
             deviceVoices = emptyList(),
@@ -179,7 +179,7 @@ internal fun SettingsVoiceGeminiPreview() {
         VoiceContent(
             selected = TtsEngine.GEMINI,
             geminiVoice = UserPreferences.DEFAULT_GEMINI_VOICE,
-            ttsStyle = TtsStyle.NORMAL,
+            ttsStyle = TtsStyle.WEATHER_FORECASTER,
             customTtsStyleDirective = "",
             deviceVoice = null,
             deviceVoices = emptyList(),

--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsState.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsState.kt
@@ -42,10 +42,10 @@ data class SettingsState(
     val useDeviceLocation: Boolean = false,
     val ttsEngine: TtsEngine = TtsEngine.DEVICE,
     val geminiVoice: String = UserPreferences.DEFAULT_GEMINI_VOICE,
-    val ttsStyle: TtsStyle = TtsStyle.NORMAL,
+    val ttsStyle: TtsStyle = TtsStyle.WEATHER_FORECASTER,
     /**
      * Free-text directive used when [ttsStyle] is [TtsStyle.CUSTOM]. Empty
-     * means "fall back to the [TtsStyle.NORMAL] preamble". Mirrors
+     * means "fall back to the [TtsStyle.WEATHER_FORECASTER] preamble". Mirrors
      * [UserPreferences.customTtsStyleDirective].
      *
      * TODO(pre-release): remove alongside [TtsStyle.CUSTOM].

--- a/app/src/main/kotlin/app/clothescast/ui/settings/VoiceSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/VoiceSettings.kt
@@ -412,8 +412,6 @@ private fun StylePicker(
 }
 
 private fun ttsStyleLabel(style: TtsStyle): Int = when (style) {
-    TtsStyle.NORMAL -> R.string.settings_tts_style_normal
-    TtsStyle.NEWSREADER -> R.string.settings_tts_style_newsreader
     TtsStyle.WEATHER_FORECASTER -> R.string.settings_tts_style_weather_forecaster
     TtsStyle.PIRATE -> R.string.settings_tts_style_pirate
     TtsStyle.COWBOY -> R.string.settings_tts_style_cowboy

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -285,9 +285,7 @@
          a freeform directive — TODO(pre-release) remove before shipping.
          Only shown for the Gemini engine. -->
     <string name="settings_tts_style_label">Style</string>
-    <string name="settings_tts_style_normal">Normal</string>
-    <string name="settings_tts_style_newsreader">Newsreader</string>
-    <string name="settings_tts_style_weather_forecaster">Weather forecaster</string>
+    <string name="settings_tts_style_weather_forecaster">Weather Forecaster</string>
     <string name="settings_tts_style_pirate">Pirate</string>
     <string name="settings_tts_style_cowboy">Cowboy</string>
     <string name="settings_tts_style_shakespearean">Shakespearean</string>

--- a/app/src/test/kotlin/app/clothescast/data/SettingsRepositoryTest.kt
+++ b/app/src/test/kotlin/app/clothescast/data/SettingsRepositoryTest.kt
@@ -299,7 +299,7 @@ class SettingsRepositoryTest {
 
     @Test
     fun `tts style defaults to NORMAL when nothing stored`() = runTest {
-        subject.preferences.first().ttsStyle shouldBe TtsStyle.NORMAL
+        subject.preferences.first().ttsStyle shouldBe TtsStyle.WEATHER_FORECASTER
     }
 
     @Test
@@ -523,9 +523,9 @@ class SettingsRepositoryTest {
         snap.ttsEngineDefault shouldBe TtsEngine.DEVICE.name
         snap.ttsEngineOverride shouldBe SettingsAnalyticsSnapshot.UNSET
         snap.ttsEngineEffective shouldBe TtsEngine.DEVICE.name
-        snap.ttsStyleDefault shouldBe TtsStyle.NORMAL.name
+        snap.ttsStyleDefault shouldBe TtsStyle.WEATHER_FORECASTER.name
         snap.ttsStyleOverride shouldBe SettingsAnalyticsSnapshot.UNSET
-        snap.ttsStyleEffective shouldBe TtsStyle.NORMAL.name
+        snap.ttsStyleEffective shouldBe TtsStyle.WEATHER_FORECASTER.name
         snap.geminiVoiceDefault shouldBe "Erinome"
         snap.geminiVoiceOverride shouldBe SettingsAnalyticsSnapshot.UNSET
         snap.geminiVoiceEffective shouldBe "Erinome"
@@ -539,7 +539,7 @@ class SettingsRepositoryTest {
         subject.setRegion(Region.EN_US)
         subject.setVoiceLocale(VoiceLocale.EN_AU)
         subject.setTtsEngine(TtsEngine.GEMINI)
-        subject.setTtsStyle(TtsStyle.NEWSREADER)
+        subject.setTtsStyle(TtsStyle.PIRATE)
         subject.setGeminiVoice("Puck")
         subject.setDeviceVoice("en-us-x-tpc-network")
 
@@ -558,8 +558,8 @@ class SettingsRepositoryTest {
         snap.voiceLocaleEffective shouldBe "en-AU"
         snap.ttsEngineOverride shouldBe TtsEngine.GEMINI.name
         snap.ttsEngineEffective shouldBe TtsEngine.GEMINI.name
-        snap.ttsStyleOverride shouldBe TtsStyle.NEWSREADER.name
-        snap.ttsStyleEffective shouldBe TtsStyle.NEWSREADER.name
+        snap.ttsStyleOverride shouldBe TtsStyle.PIRATE.name
+        snap.ttsStyleEffective shouldBe TtsStyle.PIRATE.name
         snap.geminiVoiceOverride shouldBe "Puck"
         snap.geminiVoiceEffective shouldBe "Puck"
         snap.deviceVoiceOverride shouldBe "en-us-x-tpc-network"

--- a/core/data/src/main/kotlin/app/clothescast/core/data/tts/GeminiTtsClient.kt
+++ b/core/data/src/main/kotlin/app/clothescast/core/data/tts/GeminiTtsClient.kt
@@ -42,39 +42,24 @@ internal const val GEMINI_API_VERSION = "v1beta"
  * documents the input text as a style-steerable prompt — preambles like this
  * are interpreted as direction and not spoken back.
  *
- * The two baseline registers, user-selectable via [TtsStyle]:
+ * [GEMINI_TTS_STYLE_DIRECTIVE_WEATHER_FORECASTER] is the default register —
+ * national-news broadcast delivery, deliberate cadence, sentence-final lift,
+ * gentle emphasis on clothing advice. Chosen via listening eval over a neutral
+ * "studio voice" and a newsreader variant.
  *
- * - [GEMINI_TTS_STYLE_DIRECTIVE_NORMAL] — neutral "studio voice" wording. Lets
- *   each prebuilt voice's own character through. Default. Brought back after
- *   the newsreader-only rewrite was found to flatten voices like Leda.
- * - [GEMINI_TTS_STYLE_DIRECTIVE_NEWSREADER] — clear, educated newsreader
- *   register. Suppresses theatrical drift on some voices (e.g. en-AU Kore
- *   sliding broad/nasal) but at the cost of squashing voice character.
- *
- * Below the two baselines are character / persona registers (pirate, cowboy,
- * etc.). Each one starts with "Read the following…" so the model treats it
- * as delivery direction rather than a rewrite, permits brief in-character
+ * Below the default are character / persona registers (pirate, cowboy, etc.).
+ * Each one starts with "Read the following…" so the model treats it as
+ * delivery direction rather than a rewrite, permits brief in-character
  * interjections, and ends with the standard "no audio effects, background
  * noise, or vinyl-style texture" trailer — important for personas like
  * PIRATE that might otherwise tempt the model to add ocean ambience.
  */
-internal const val GEMINI_TTS_STYLE_DIRECTIVE_NORMAL: String =
+internal const val GEMINI_TTS_STYLE_DIRECTIVE_WEATHER_FORECASTER: String =
     "Read the following weather forecast in the style of a national-news " +
         "weather report. Use a deliberate cadence: unhurried, clearly enunciated, " +
         "with a natural lift at the end of each sentence. Give a gentle extra " +
         "emphasis to clothing advice. No audio effects, background noise, or " +
         "vinyl-style texture:\n\n"
-
-internal const val GEMINI_TTS_STYLE_DIRECTIVE_NEWSREADER: String =
-    "Read the following in a clear, educated newsreader style — articulate but " +
-        "not theatrical or exaggerated. No audio effects, background noise, or " +
-        "vinyl-style texture:\n\n"
-
-internal const val GEMINI_TTS_STYLE_DIRECTIVE_WEATHER_FORECASTER: String =
-    "Read the following as a friendly TV weather presenter walking the viewer " +
-        "through today's forecast — clear, upbeat, lightly emphatic on the key " +
-        "numbers. Brief asides such as 'and over to the temperatures' are fine. " +
-        "No audio effects, background noise, or vinyl-style texture:\n\n"
 
 internal const val GEMINI_TTS_STYLE_DIRECTIVE_PIRATE: String =
     "Read the following as a swaggering pirate, with hearty nautical flair. " +
@@ -158,16 +143,14 @@ internal const val GEMINI_TTS_STYLE_DIRECTIVE_SPORTSCASTER: String =
 /**
  * Resolves the style preamble for [style], honouring [customDirective] when
  * the user has picked [TtsStyle.CUSTOM]. A blank custom directive falls back
- * to [GEMINI_TTS_STYLE_DIRECTIVE_NORMAL] so a half-typed CUSTOM doesn't break
- * TTS for the user — they get a normal-sounding read and the chance to fill
- * the field in.
+ * to [GEMINI_TTS_STYLE_DIRECTIVE_WEATHER_FORECASTER] so a half-typed CUSTOM
+ * doesn't break TTS for the user — they get a normal-sounding read and the
+ * chance to fill the field in.
  */
 internal fun styleDirectiveFor(
     style: TtsStyle,
     customDirective: String = "",
 ): String = when (style) {
-    TtsStyle.NORMAL -> GEMINI_TTS_STYLE_DIRECTIVE_NORMAL
-    TtsStyle.NEWSREADER -> GEMINI_TTS_STYLE_DIRECTIVE_NEWSREADER
     TtsStyle.WEATHER_FORECASTER -> GEMINI_TTS_STYLE_DIRECTIVE_WEATHER_FORECASTER
     TtsStyle.PIRATE -> GEMINI_TTS_STYLE_DIRECTIVE_PIRATE
     TtsStyle.COWBOY -> GEMINI_TTS_STYLE_DIRECTIVE_COWBOY
@@ -185,7 +168,7 @@ internal fun styleDirectiveFor(
     TtsStyle.SPORTSCASTER -> GEMINI_TTS_STYLE_DIRECTIVE_SPORTSCASTER
     TtsStyle.CUSTOM -> customDirective.trim().takeIf { it.isNotEmpty() }
         ?.let { "$it\n\n" }
-        ?: GEMINI_TTS_STYLE_DIRECTIVE_NORMAL
+        ?: GEMINI_TTS_STYLE_DIRECTIVE_WEATHER_FORECASTER
 }
 
 /**
@@ -320,7 +303,7 @@ class GeminiTtsClient(
         text: String,
         voiceName: String = DEFAULT_GEMINI_TTS_VOICE,
         locale: Locale? = null,
-        style: TtsStyle = TtsStyle.NORMAL,
+        style: TtsStyle = TtsStyle.WEATHER_FORECASTER,
         customStyleDirective: String = "",
     ): PcmAudio {
         val key = keyProvider.get().also {

--- a/core/data/src/test/kotlin/app/clothescast/core/data/tts/GeminiTtsClientTest.kt
+++ b/core/data/src/test/kotlin/app/clothescast/core/data/tts/GeminiTtsClientTest.kt
@@ -89,11 +89,7 @@ class GeminiTtsClientTest {
     }
 
     @Test
-    fun `request body prepends the normal studio-voice directive by default`() = runTest {
-        // Default style is NORMAL — the user-selectable preamble that brought
-        // back the v505 "studio voice" wording so voices like Leda keep their
-        // character. The newsreader register only kicks in when the user opts
-        // into TtsStyle.NEWSREADER from Settings.
+    fun `request body prepends the weather-forecaster directive by default`() = runTest {
         var capturedBody: String? = null
         val client = GeminiTtsClient(
             httpClient = mockClient(SUCCESS_BODY) {
@@ -108,27 +104,6 @@ class GeminiTtsClientTest {
 
         val body = checkNotNull(capturedBody)
         body.shouldContain("national-news weather report")
-        body.shouldNotContain("newsreader style")
-        body.shouldContain("hello world")
-    }
-
-    @Test
-    fun `request body uses the newsreader directive when style is NEWSREADER`() = runTest {
-        var capturedBody: String? = null
-        val client = GeminiTtsClient(
-            httpClient = mockClient(SUCCESS_BODY) {
-                capturedBody = (it.body as io.ktor.http.content.OutgoingContent.ByteArrayContent)
-                    .bytes()
-                    .toString(Charsets.UTF_8)
-            },
-            keyProvider = FakeKeyProvider("test-key"),
-        )
-
-        client.synthesize(text = "hello world", style = TtsStyle.NEWSREADER)
-
-        val body = checkNotNull(capturedBody)
-        body.shouldContain("newsreader style")
-        body.shouldNotContain("national-news weather report")
         body.shouldContain("hello world")
     }
 
@@ -483,7 +458,6 @@ class GeminiTtsClientTest {
         // styleDirectiveFor() — adding a new TtsStyle without adding the
         // map entry here is the regression this catches.
         val signatures: Map<TtsStyle, String> = mapOf(
-            TtsStyle.WEATHER_FORECASTER to "TV weather presenter",
             TtsStyle.PIRATE to "swaggering pirate",
             TtsStyle.COWBOY to "Old West drawl",
             TtsStyle.SHAKESPEAREAN to "Elizabethan stage actor",

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Settings.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Settings.kt
@@ -22,20 +22,16 @@ enum class TtsEngine { DEVICE, GEMINI }
 /**
  * Steers the global style preamble Gemini TTS prepends to every request.
  *
- * - [NORMAL] is the original "clean, crisp studio voice" wording — neutral
- *   delivery that lets each prebuilt voice's own character through.
- * - [NEWSREADER] biases toward a clear, educated newsreader register.
- *   Suppresses theatrical drift on some voices but flattens character on
- *   others, which is why this is user-selectable.
- * - [WEATHER_FORECASTER] reads the briefing as a friendly TV weather
- *   presenter — clear, upbeat, lightly emphatic on the key numbers.
+ * - [WEATHER_FORECASTER] reads the briefing in a national-news weather
+ *   broadcast register — deliberate cadence, sentence-final lift, gentle
+ *   emphasis on clothing advice. Default.
  * - The remaining entries — [PIRATE], [COWBOY], [SHAKESPEAREAN], [SURFER],
  *   [PARENT], [CHILD], [TEENAGER], [GRANDPARENT], [KIDS_HOST], [RADIO_HOST],
  *   [MORNING_DJ], [SCIENCE_TEACHER], [HISTORIAN], [SPORTSCASTER] — are
  *   character / persona registers. They shape *delivery* (the words read
  *   aloud are unchanged) but the directive permits brief in-character
  *   exclamations like "Arrr" or "Howdy" so the result is more obviously
- *   playful than the flat NORMAL register.
+ *   playful than the default register.
  * - [CUSTOM] uses the free-text directive stored on
  *   [UserPreferences.customTtsStyleDirective]. Development-only knob for
  *   iterating on directive wording at runtime so good ones can be promoted
@@ -45,8 +41,6 @@ enum class TtsEngine { DEVICE, GEMINI }
  * doesn't accept style prompts.
  */
 enum class TtsStyle {
-    NORMAL,
-    NEWSREADER,
     WEATHER_FORECASTER,
     PIRATE,
     COWBOY,
@@ -246,18 +240,17 @@ data class UserPreferences(
      */
     val geminiVoice: String = DEFAULT_GEMINI_VOICE,
     /**
-     * Steers the style preamble for Gemini TTS. Default is [TtsStyle.NORMAL]
-     * (original "studio voice" wording); users who prefer the tighter
-     * newsreader register can switch to [TtsStyle.NEWSREADER], or one of
-     * the character registers (pirate, cowboy, etc.). Only consulted when
-     * [ttsEngine] == [TtsEngine.GEMINI].
+     * Steers the style preamble for Gemini TTS. Default is
+     * [TtsStyle.WEATHER_FORECASTER] — national-news broadcast delivery.
+     * Users can switch to any of the character registers (pirate, cowboy,
+     * etc.). Only consulted when [ttsEngine] == [TtsEngine.GEMINI].
      */
-    val ttsStyle: TtsStyle = TtsStyle.NORMAL,
+    val ttsStyle: TtsStyle = TtsStyle.WEATHER_FORECASTER,
     /**
      * Free-text directive used when [ttsStyle] is [TtsStyle.CUSTOM]. The full
      * preamble — the user's text plus a trailing blank line — is sent to
      * Gemini TTS in place of the canned directive. Blank means "fall back to
-     * [TtsStyle.NORMAL]" so a misconfigured CUSTOM doesn't break TTS.
+     * [TtsStyle.WEATHER_FORECASTER]" so a misconfigured CUSTOM doesn't break TTS.
      *
      * TODO(pre-release): remove this field along with [TtsStyle.CUSTOM] —
      * it's a development knob for iterating on directive wording, not a


### PR DESCRIPTION
Cleans up the TtsStyle enum now that the NORMAL directive has been rewritten to broadcast-weather delivery (PR #335).

## What changed

- **`NORMAL`** and **`NEWSREADER`** dropped — both redundant with the new WEATHER_FORECASTER default
- **Old `WEATHER_FORECASTER`** (friendly TV presenter with ad-lib permission) also dropped — rated worse than both baselines in listening tests
- **`WEATHER_FORECASTER`** is now the single default, carrying the PR #335 directive: deliberate cadence, sentence-final lift, gentle clothing emphasis
- UI label capitalised to **"Weather Forecaster"** for consistency with other persona labels (Radio Host, Morning DJ, etc.)
- All defaults, KDoc, constants, and tests updated; translated strings had no entries for the removed keys

## No migration needed

Unknown stored style values already fall back to the default in `SettingsRepository.toUserPreferences()` via `runCatching { TtsStyle.valueOf(it) }.getOrNull() ?: TtsStyle.WEATHER_FORECASTER`.

## Test plan
- [ ] CI passes
- [ ] Settings screen shows "Weather Forecaster" as the selected style for existing users
- [ ] Style picker no longer shows Normal / Newsreader entries

https://claude.ai/code/session_01DFrE8pdhyfX9phbVCqggZ1

---
_Generated by [Claude Code](https://claude.ai/code/session_01DFrE8pdhyfX9phbVCqggZ1)_