### PR TITLE
scripts: use real ClothesCast prose as eval sample text

### DIFF
--- a/scripts/eval-weather-report-style.py
+++ b/scripts/eval-weather-report-style.py
@@ -53,20 +53,9 @@ SAMPLE_RATE = 24_000
 # Realistic clips in each supported language — one temperature read + one
 # clothing call-to-action so we can hear whether emphasis on the recommendation
 # actually fires.
-SAMPLE_TEXT_EN = (
-    "Feels like 9 degrees this morning, with a brisk northerly wind and patchy "
-    "cloud. Grab a warm coat and a waterproof layer — showers are likely through "
-    "midday before clearing by late afternoon. Temperatures recover to around 13 "
-    "degrees this evening, so a light jacket should be fine heading out tonight."
-)
+SAMPLE_TEXT_EN = "Today will be cold to cool. Wear a jumper and jacket."
 
-SAMPLE_TEXT_DE = (
-    "Heute Morgen fühlt es sich wie 9 Grad an, mit frischem Nordwind und "
-    "wechselhafter Bewölkung. Zieh eine warme Jacke und eine wasserdichte Schicht "
-    "an — Schauer sind bis zum Mittag wahrscheinlich, bevor es am späten Nachmittag "
-    "aufklart. Am Abend erholen sich die Temperaturen auf etwa 13 Grad, also reicht "
-    "eine leichte Jacke für den Abend."
-)
+SAMPLE_TEXT_DE = "Heute wird es kalt bis kühl. Trag Pullover und Jacke."
 
 def sample_text_for(locale: str) -> str:
     lang = locale.split("-")[0]

--- a/scripts/eval-weather-report-style.py
+++ b/scripts/eval-weather-report-style.py
@@ -27,15 +27,15 @@ Usage
 
 Output
 ------
-Writes .wav files to /tmp/tts-weather-style/:
-  en-US-<candidate>-<voice>.wav
-  en-AU-<candidate>-<voice>.wav
-  en-GB-<candidate>-<voice>.wav
+Writes .wav files to /tmp/tts-weather-style/<locale>/:
+  en-US/<candidate>-<voice>.wav
+  en-AU/<candidate>-<voice>.wav
+  en-GB/<candidate>-<voice>.wav
 
 Rate with:
   python3 scripts/rate-tts-clips.py /tmp/tts-weather-style/
-  python3 scripts/rate-tts-clips.py /tmp/tts-weather-style/ --pattern en-AU
-  python3 scripts/rate-tts-clips.py /tmp/tts-weather-style/ --pattern en-GB-weather-B2
+  python3 scripts/rate-tts-clips.py /tmp/tts-weather-style/en-AU/
+  python3 scripts/rate-tts-clips.py /tmp/tts-weather-style/en-GB/ --pattern weather-B2
 """
 
 import argparse
@@ -241,7 +241,7 @@ def main() -> None:
 
     # Build full clip list, then apply filter
     clips: list[tuple[str, str, str, str, str]] = [  # (slug, directive, accent, voice, sample)
-        (f"{locale}-{label}-{voice.lower()}", directive, accent, voice, sample_text_for(locale))
+        (locale, f"{label}-{voice.lower()}", directive, accent, voice, sample_text_for(locale))
         for locale, accent in LOCALES.items()
         for label, directive in CANDIDATES
         for voice in VOICES
@@ -254,14 +254,14 @@ def main() -> None:
         clips = list(reversed(clips))
 
     out = pathlib.Path("/tmp/tts-weather-style")
-    print(f"Writing {len(clips)} clip(s) to {out}/\n")
+    print(f"Writing {len(clips)} clip(s) to {out}/<locale>/\n")
 
-    for slug, directive, accent, voice, sample in clips:
-        path = out / f"{slug}.wav"
+    for locale, slug, directive, accent, voice, sample in clips:
+        path = out / locale / f"{slug}.wav"
         if path.exists():
-            print(f"  {slug} ... skip (already exists)")
+            print(f"  {locale}/{slug} ... skip (already exists)")
             continue
-        print(f"  {slug} ...", end=" ", flush=True)
+        print(f"  {locale}/{slug} ...", end=" ", flush=True)
         try:
             pcm = synthesize(directive, accent, voice, sample)
             write_wav(path, pcm)
@@ -273,7 +273,7 @@ def main() -> None:
     print(f"  python3 scripts/rate-tts-clips.py {out}/")
     print(f"\nBy locale:")
     for locale in LOCALES:
-        print(f"  python3 scripts/rate-tts-clips.py {out}/ --pattern {locale}")
+        print(f"  python3 scripts/rate-tts-clips.py {out}/{locale}/")
     print(f"\nBy voice:")
     for v in VOICES:
         print(f"  python3 scripts/rate-tts-clips.py {out}/ --pattern {v.lower()}")

--- a/scripts/rate-tts-clips.py
+++ b/scripts/rate-tts-clips.py
@@ -54,12 +54,12 @@ def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("directory", help="Directory containing .wav files")
     parser.add_argument(
-        "--pattern", default="", help="Only play files whose name contains this string"
+        "--pattern", default="", help="Only play files whose path contains this string (locale, candidate, or voice)"
     )
     args = parser.parse_args()
 
     directory = pathlib.Path(args.directory)
-    files = sorted(f for f in directory.glob("*.wav") if args.pattern in f.name)
+    files = sorted(f for f in directory.rglob("*.wav") if args.pattern in str(f))
 
     if not files:
         sys.exit(f"No .wav files found in {directory}" + (f" matching '{args.pattern}'" if args.pattern else ""))


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Replaces the hand-written broadcast paragraph in `eval-weather-report-style.py` with a literal `InsightFormatter` output: `"Today will be cold to cool. Wear a jumper and jacket."` and its German equivalent
- The old text was too long and fluent — it made every style directive sound reasonable on prose the app never actually produces
- The terse real output better reveals whether a directive improves the short sentences users actually hear

## Test plan

- [ ] Run `python3 scripts/eval-weather-report-style.py --filter en-AU-weather-B2` with a Gemini API key and confirm the generated clips reflect realistic app output length/style

https://claude.ai/code/session_01UZqWUsUR4s2wzTc2mgZWAA
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UZqWUsUR4s2wzTc2mgZWAA)_