### PR TITLE
:app + :core:domain — trim Gemini voice list to Despina, Leda, Iapetus, Charon

### DIFF
--- a/app/src/main/kotlin/app/clothescast/diag/SettingsAnalyticsSnapshot.kt
+++ b/app/src/main/kotlin/app/clothescast/diag/SettingsAnalyticsSnapshot.kt
@@ -8,7 +8,7 @@ package app.clothescast.diag
  *  - [_default_]: the value that would apply if the user hasn't overridden it.
  *    For [Region] / [VoiceLocale] this is the BCP-47 tag the SYSTEM sentinel
  *    resolves to on this device; for the remaining settings it's the in-code
- *    default (DEVICE / NORMAL / "Erinome" / "AUTO").
+ *    default (DEVICE / NORMAL / "Leda" / "AUTO").
  *  - [_override_]: the user's persisted choice. [UNSET] when no DataStore key
  *    exists; otherwise the enum name for [Region] / [VoiceLocale] / [TtsEngine]
  *    / [TtsStyle], or the raw string for the voice IDs. The SYSTEM enum entry

--- a/app/src/main/kotlin/app/clothescast/tts/TtsVoices.kt
+++ b/app/src/main/kotlin/app/clothescast/tts/TtsVoices.kt
@@ -14,31 +14,9 @@ data class TtsVoiceOption(
     val displayName: String,
 )
 
-// Curated from listening tests across en-AU and en-GB. Leda is the default —
-// chosen alongside the v505-equivalent "Normal" style preamble being the
-// default style; pending a broader re-audition under Normal. Grouped by
-// character:
-//   Clear/Firm (newsreader-y): Erinome, Iapetus, Kore
-//   Informative/Knowledgeable (male alternatives): Charon, Sadaltager
-//   Gentle/Smooth/Warm: Vindemiatrix, Despina, Algieba, Sulafat
-//   Breezy/Youthful: Aoede, Leda
-// Aoede and Leda were dropped in the previous curation under the newsreader
-// directive (Aoede sounded "Alan Rickman" on en-GB+newsreader; Leda flattened
-// in newsreader register). Both come back now that the user can pick the
-// "Normal" style preamble — Leda is the originating ask. Sulafat / Algieba
-// re-added as additional warm/smooth options. Still dropped: Orus
-// (theatrical), Achird (vowel issues), Zephyr / Puck / Fenrir (theatrical /
-// excitable) — those are voice-character traits not fixed by switching style.
 val GEMINI_VOICES: List<TtsVoiceOption> = listOf(
-    TtsVoiceOption("Erinome", "Erinome — Clear"),
     TtsVoiceOption("Iapetus", "Iapetus — Clear"),
-    TtsVoiceOption("Kore", "Kore — Firm"),
     TtsVoiceOption("Charon", "Charon — Informative"),
-    TtsVoiceOption("Sadaltager", "Sadaltager — Knowledgeable"),
-    TtsVoiceOption("Vindemiatrix", "Vindemiatrix — Gentle"),
     TtsVoiceOption("Despina", "Despina — Smooth"),
-    TtsVoiceOption("Algieba", "Algieba — Smooth"),
-    TtsVoiceOption("Sulafat", "Sulafat — Warm"),
-    TtsVoiceOption("Aoede", "Aoede — Breezy"),
     TtsVoiceOption("Leda", "Leda — Youthful"),
 )

--- a/app/src/test/kotlin/app/clothescast/data/SettingsRepositoryTest.kt
+++ b/app/src/test/kotlin/app/clothescast/data/SettingsRepositoryTest.kt
@@ -526,9 +526,9 @@ class SettingsRepositoryTest {
         snap.ttsStyleDefault shouldBe TtsStyle.WEATHER_FORECASTER.name
         snap.ttsStyleOverride shouldBe SettingsAnalyticsSnapshot.UNSET
         snap.ttsStyleEffective shouldBe TtsStyle.WEATHER_FORECASTER.name
-        snap.geminiVoiceDefault shouldBe "Erinome"
+        snap.geminiVoiceDefault shouldBe "Leda"
         snap.geminiVoiceOverride shouldBe SettingsAnalyticsSnapshot.UNSET
-        snap.geminiVoiceEffective shouldBe "Erinome"
+        snap.geminiVoiceEffective shouldBe "Leda"
         snap.deviceVoiceDefault shouldBe SettingsAnalyticsSnapshot.AUTO
         snap.deviceVoiceOverride shouldBe SettingsAnalyticsSnapshot.UNSET
         snap.deviceVoiceEffective shouldBe SettingsAnalyticsSnapshot.AUTO

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Settings.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Settings.kt
@@ -234,7 +234,7 @@ data class UserPreferences(
     val useDeviceLocation: Boolean = false,
     val ttsEngine: TtsEngine = TtsEngine.DEVICE,
     /**
-     * Prebuilt Gemini voice name (e.g. "Erinome", "Kore"). Only consulted when
+     * Prebuilt Gemini voice name (e.g. "Leda", "Iapetus"). Only consulted when
      * [ttsEngine] == [TtsEngine.GEMINI]. Stored as a free-form string so adding
      * voices doesn't require a domain enum migration.
      */


### PR DESCRIPTION
Trims `GEMINI_VOICES` from 11 entries down to the four requested: Iapetus, Charon, Despina, Leda.

Also fixes two housekeeping issues uncovered along the way:
- `SettingsRepositoryTest` was asserting `geminiVoiceDefault == "Erinome"` — stale since the default was set to `"Leda"` in `Settings.kt` and never updated in the test.
- Two in-code doc comments cited `"Erinome"` / `"Kore"` as example voice names; updated to `"Leda"` / `"Iapetus"`.

No behaviour change for users who haven't explicitly picked a voice — default remains `"Leda"`. Users who had one of the removed voices stored in DataStore will fall back to `"Leda"` on next load (existing fallback logic in `SettingsRepository`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01LKEo19ntZq2qp6rDw5jinB)_