### PR TITLE
scripts: add en-GB accent variants for B2 eval

### DIFF
--- a/scripts/eval-weather-report-style.py
+++ b/scripts/eval-weather-report-style.py
@@ -81,7 +81,10 @@ LOCALES: dict[str, str] = {
     "en-AU-natural":   "Speak with a natural Australian accent — clear, not broad or nasal.",
     "en-AU-presenter": "Speak with the clear, natural accent of an Australian broadcast news presenter.",
     "en-AU-minimal":   "Speak with an Australian accent — clear and natural.",
-    "en-GB": "Speak with a Standard Southern British accent.",
+    "en-GB":           "Speak with a Standard Southern British accent.",
+    "en-GB-bbc":       "Speak with a Standard Southern British accent, as spoken by a BBC news presenter.",
+    "en-GB-presenter": "Speak with the clear accent of a British television news presenter.",
+    "en-GB-measured":  "Speak with a Standard British accent — clear, measured, and natural.",
     # de-DE falls back to the language-only "de" key in the app (no explicit
     # de-DE entry in ACCENT_DIRECTIVES); de-AT has its own entry.
     "de-DE": "Sprich auf Deutsch in einem klaren, hochdeutschen Akzent.",


### PR DESCRIPTION
## Summary

- Adds three en-GB accent variants to `eval-weather-report-style.py` to test whether a softer framing closes B2's gap vs B1 in en-GB:
  - `en-GB-bbc` — "...as spoken by a BBC news presenter"
  - `en-GB-presenter` — "...clear accent of a British television news presenter"
  - `en-GB-measured` — "...clear, measured, and natural"

- Current prod en-GB directive ("Standard Southern British") scores B2 at 7.6 vs B1 at 8.3 — testing whether a concrete presenter reference or softer descriptor closes that gap.

https://claude.ai/code/session_01UZqWUsUR4s2wzTc2mgZWAA

---
_Generated by [Claude Code](https://claude.ai/code/session_01UZqWUsUR4s2wzTc2mgZWAA)_