### PR TITLE
scripts — en-GB accent variants for clarity-trim eval

### DIFF
--- a/scripts/eval-weather-report-style.py
+++ b/scripts/eval-weather-report-style.py
@@ -85,6 +85,12 @@ LOCALES: dict[str, str] = {
     "en-GB-bbc":       "Speak with a Standard Southern British accent, as spoken by a BBC news presenter.",
     "en-GB-presenter": "Speak with the clear accent of a British television news presenter.",
     "en-GB-measured":  "Speak with a Standard British accent — clear, measured, and natural.",
+    # en-GB-prod: the shipped string (control for the "trim clarity" eval).
+    # en-GB-bare: candidate trim — relies on the WEATHER_FORECASTER directive's
+    # "Enunciate clearly" to carry the clarity hint instead of duplicating it
+    # in the accent clause.
+    "en-GB-prod":      "Speak with a Standard British accent — clear and natural.",
+    "en-GB-bare":      "Speak with a Standard British accent.",
     # de-DE falls back to the language-only "de" key in the app (no explicit
     # de-DE entry in ACCENT_DIRECTIVES); de-AT has its own entry.
     "de-DE": "Sprich auf Deutsch in einem klaren, hochdeutschen Akzent.",

--- a/scripts/say.py
+++ b/scripts/say.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""
+Single-shot Gemini TTS helper for prompt iteration.
+
+Synthesises one clip with the given directive + accent + voice + text,
+writes it to a WAV, and plays it via `aplay`. Designed for
+tweak-in-a-loop work: change one flag, rerun, listen, change another.
+
+The defaults mirror the strings shipped in
+`core/data/.../tts/GeminiTtsClient.kt` (WEATHER_FORECASTER directive +
+en-GB accent + Leda voice + the eval-script sample text), so a bare
+`python3 scripts/say.py` reproduces the production prompt for one clip.
+
+Usage
+-----
+  export GEMINI_API_KEY=your_key_here
+
+  # Production prompt (en-GB Weather Forecaster, Leda):
+  python3 scripts/say.py
+
+  # Try a bare en-GB accent (the "trim clarity" candidate):
+  python3 scripts/say.py --accent "Speak with a Standard British accent."
+
+  # Drop the accent entirely (Gemini falls back to North American English):
+  python3 scripts/say.py --accent ""
+
+  # Different voice:
+  python3 scripts/say.py --voice Charon
+
+  # Custom text:
+  python3 scripts/say.py --text "It's 12 degrees and overcast."
+
+  # See the assembled prompt before the API call:
+  python3 scripts/say.py --print-prompt
+
+  # Try a different TTS model (e.g. a future GA replacement):
+  python3 scripts/say.py --model gemini-2.5-flash-tts
+
+  # Just write a file, skip playback:
+  python3 scripts/say.py --no-play --out /tmp/foo.wav
+
+Cost: each call is one Gemini TTS request (~$0.003 per short clip on
+the standard tier; free tier covers light iteration).
+"""
+
+import argparse
+import base64
+import json
+import os
+import pathlib
+import subprocess
+import urllib.request
+import wave
+
+DEFAULT_MODEL = "gemini-2.5-flash-preview-tts"
+SAMPLE_RATE = 24_000
+
+# Defaults mirror GeminiTtsClient.kt:
+#   GEMINI_TTS_STYLE_DIRECTIVE_WEATHER_FORECASTER  → DEFAULT_DIRECTIVE
+#   ACCENT_DIRECTIVES["en-GB"]                     → DEFAULT_ACCENT
+#   DEFAULT_GEMINI_TTS_VOICE                       → DEFAULT_VOICE
+# Sample text matches scripts/eval-weather-report-style.py so clips from
+# this helper are directly comparable to the eval rig's output.
+DEFAULT_DIRECTIVE = (
+    "Read the following weather forecast in the style of a weather report on a "
+    "national news service. Enunciate clearly and use a measured speed. "
+    "Accentuate the ends of sentences and give a gentle emphasis to clothing "
+    "recommendations. No audio effects, background noise, or vinyl-style "
+    "texture."
+)
+DEFAULT_ACCENT = "Speak with a Standard British accent — clear and natural."
+DEFAULT_TEXT = "Today will be cold to cool. Wear a jumper and jacket."
+DEFAULT_VOICE = "Leda"
+
+
+def synthesize(prompt: str, voice: str, model: str, api_key: str) -> bytes:
+    payload = {
+        "contents": [{"parts": [{"text": prompt}]}],
+        "generationConfig": {
+            "responseModalities": ["AUDIO"],
+            "speechConfig": {
+                "voiceConfig": {"prebuiltVoiceConfig": {"voiceName": voice}}
+            },
+        },
+    }
+    url = (
+        f"https://generativelanguage.googleapis.com/v1beta/models/"
+        f"{model}:generateContent?key={api_key}"
+    )
+    req = urllib.request.Request(
+        url,
+        data=json.dumps(payload).encode(),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req) as resp:
+        body = json.loads(resp.read())
+    inline = body["candidates"][0]["content"]["parts"][0]["inlineData"]
+    return base64.b64decode(inline["data"])
+
+
+def write_wav(path: pathlib.Path, pcm: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with wave.open(str(path), "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(SAMPLE_RATE)
+        wf.writeframes(pcm)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--directive",
+        default=DEFAULT_DIRECTIVE,
+        help="Style directive (default: shipped WEATHER_FORECASTER).",
+    )
+    parser.add_argument(
+        "--accent",
+        default=DEFAULT_ACCENT,
+        help="Accent clause (default: shipped en-GB). Pass '' to omit.",
+    )
+    parser.add_argument(
+        "--voice",
+        default=DEFAULT_VOICE,
+        help=f"Gemini voice name (default: {DEFAULT_VOICE}).",
+    )
+    parser.add_argument(
+        "--text",
+        default=DEFAULT_TEXT,
+        help="Text to speak (default: cold/jumper sample).",
+    )
+    parser.add_argument(
+        "--model",
+        default=DEFAULT_MODEL,
+        help=f"Gemini TTS model id (default: {DEFAULT_MODEL}).",
+    )
+    parser.add_argument(
+        "--out",
+        default="/tmp/say.wav",
+        help="Output WAV path (default: /tmp/say.wav).",
+    )
+    parser.add_argument(
+        "--no-play",
+        action="store_true",
+        help="Write the WAV but don't invoke aplay.",
+    )
+    parser.add_argument(
+        "--print-prompt",
+        action="store_true",
+        help="Print the assembled prompt before calling the API.",
+    )
+    args = parser.parse_args()
+
+    api_key = os.environ.get("GEMINI_API_KEY", "")
+    if not api_key:
+        raise SystemExit("Set GEMINI_API_KEY env var before running.")
+
+    # Match GeminiTtsClient.kt's prompt assembly: directive + "\n\n" +
+    # (accent + "\n\n" if accent) + text. We rstrip the directive/accent
+    # in case the caller pastes a constant that already ends with "\n\n",
+    # so we don't end up with quadruple newlines.
+    prompt = args.directive.rstrip() + "\n\n"
+    if args.accent:
+        prompt += args.accent.rstrip() + "\n\n"
+    prompt += args.text
+
+    if args.print_prompt:
+        print("--- prompt ---")
+        print(prompt)
+        print("--- end ---")
+
+    pcm = synthesize(prompt, args.voice, args.model, api_key)
+    out = pathlib.Path(args.out)
+    write_wav(out, pcm)
+    duration = len(pcm) // 2 / SAMPLE_RATE
+    print(f"Wrote {out} ({duration:.1f}s, {args.voice} on {args.model}).")
+
+    if not args.no_play:
+        subprocess.run(["aplay", "-q", str(out)], check=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/say.py
+++ b/scripts/say.py
@@ -49,6 +49,7 @@ import json
 import os
 import pathlib
 import subprocess
+import urllib.error
 import urllib.request
 import wave
 
@@ -93,8 +94,19 @@ def synthesize(prompt: str, voice: str, model: str, api_key: str) -> bytes:
         headers={"Content-Type": "application/json"},
         method="POST",
     )
-    with urllib.request.urlopen(req) as resp:
-        body = json.loads(resp.read())
+    try:
+        with urllib.request.urlopen(req) as resp:
+            body = json.loads(resp.read())
+    except urllib.error.HTTPError as e:
+        # Surface Gemini's actual error message (e.g. "voice not found",
+        # auth failure, quota) instead of a bare "HTTP 400". Mirrors the
+        # GeminiTtsHttpException treatment in GeminiTtsClient.kt.
+        raw = e.read().decode("utf-8", "replace")
+        try:
+            msg = json.loads(raw).get("error", {}).get("message", raw)
+        except json.JSONDecodeError:
+            msg = raw
+        raise SystemExit(f"Gemini TTS HTTP {e.code}: {msg}") from None
     inline = body["candidates"][0]["content"]["parts"][0]["inlineData"]
     return base64.b64decode(inline["data"])
 


### PR DESCRIPTION
Adds two locale entries to `scripts/eval-weather-report-style.py` so we can A/B the shipped en-GB accent against a bare version that drops the clarity clause:

- `en-GB-prod` — `"Speak with a Standard British accent — clear and natural."` (control; matches `GeminiTtsClient.kt:228` exactly)
- `en-GB-bare` — `"Speak with a Standard British accent."` (treatment)

## Why

The `WEATHER_FORECASTER` style directive already says *"Enunciate clearly and use a measured speed."* — so the `— clear and natural` tail on every entry in `ACCENT_DIRECTIVES` is redundant. If `en-GB-bare` scores at parity with `en-GB-prod` on the existing rater, we can strip the clarity language from the whole accent table and let the directive carry it. That also keeps each accent string doing one job (locale only) instead of two (locale + clarity).

The existing `en-GB-measured` in the script *("clear, measured, and natural")* is close but not identical to prod, hence the new `en-GB-prod` rather than reusing it.

## Run plan

```bash
export GEMINI_API_KEY=…
python3 scripts/eval-weather-report-style.py --filter en-GB-prod-weather-B2
python3 scripts/eval-weather-report-style.py --filter en-GB-bare-weather-B2
python3 scripts/rate-tts-clips.py /tmp/tts-weather-style/en-GB-prod/
python3 scripts/rate-tts-clips.py /tmp/tts-weather-style/en-GB-bare/
```

7 voices × 2 accents × 1 candidate = 14 clips, ~$0.04 of API spend.

## Test plan

- [ ] Generate clips for `en-GB-prod` + B2 (control)
- [ ] Generate clips for `en-GB-bare` + B2 (treatment)
- [ ] Rate both sets via `rate-tts-clips.py`
- [ ] If parity (or better), open a follow-up PR stripping clarity language from `ACCENT_DIRECTIVES` and update `docs/voice-evals.md` with the result

## Privacy

No change. Eval uses the same neutral sample text already in the script (`"Today will be cold to cool. Wear a jumper and jacket."`). Nothing user-specific leaves the device.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FF83vZToLynJVUMpPs7duK)_