### PR TITLE
:app — skip Firebase Analytics + Crashlytics on virtual devices

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,6 +1,6 @@
 # Privacy Policy
 
-_Last updated: 2026-05-05_
+_Last updated: 2026-05-06_
 
 ClothesCast is a daily weather-insight app for Android. This policy
 describes what data the app handles, where it goes, and what control you
@@ -203,6 +203,10 @@ so you can audit exactly what's instrumented at
 <https://github.com/mikelward/clothescast> — or build a copy with the
 reporting calls stripped out, if you'd rather not participate.
 
+Runs on virtual devices (Android emulator, Genymotion) never report —
+collection is forced off there regardless of the in-app toggle, so dev
+and instrumentation builds don't show up in dashboards.
+
 ## Children
 
 ClothesCast is not directed at children under 13 and does not knowingly
@@ -226,6 +230,12 @@ email the address listed on the Play Store listing.
 
 ## Changelog
 
+- **2026-05-06** — Suppress Firebase Analytics + Crashlytics collection on
+  virtual devices (Android emulator, Genymotion) regardless of the user's
+  Privacy toggle, to keep dashboards free of dev / instrumentation noise.
+  Reduces what leaves the device; the persisted user preference is
+  unchanged so the same install on real hardware still honours the
+  toggle.
 - **2026-05-05** — Wired the previously-anticipated Firebase Crashlytics
   + Google Analytics for Firebase integration into the app. Default-on
   with a one-time non-blocking notice on the Today screen pointing the

--- a/app/src/main/kotlin/app/clothescast/diag/Telemetry.kt
+++ b/app/src/main/kotlin/app/clothescast/diag/Telemetry.kt
@@ -1,6 +1,7 @@
 package app.clothescast.diag
 
 import android.content.Context
+import android.os.Build
 import app.clothescast.data.SettingsRepository
 import com.google.firebase.FirebaseApp
 import com.google.firebase.analytics.FirebaseAnalytics
@@ -29,6 +30,11 @@ import kotlinx.coroutines.launch
  * "no JSON, no SDK calls" is the natural quiet path. The Settings toggle
  * still flips the persisted preference in that case so a later build that
  * does have the JSON inherits the user's choice.
+ *
+ * On virtual devices (Android emulator, Genymotion) collection is forced off
+ * regardless of the user's preference so dev / instrumentation runs don't
+ * pollute the dashboards. The persisted preference is left alone so the same
+ * install booted on real hardware still honours the user's choice.
  */
 object Telemetry {
     /**
@@ -47,6 +53,16 @@ object Telemetry {
         if (FirebaseApp.getApps(context).isEmpty()) return
         val analytics = FirebaseAnalytics.getInstance(context)
         val crashlytics = FirebaseCrashlytics.getInstance()
+        if (isProbablyEmulator()) {
+            // Virtual devices report as "unknown" / "google_sdk" / etc. and pollute
+            // crash + analytics dashboards with noise that doesn't reflect any real
+            // user. Force collection off here without touching the user's
+            // persisted preference, so the same install on real hardware still
+            // honours their Settings → Privacy choice.
+            analytics.setAnalyticsCollectionEnabled(false)
+            crashlytics.setCrashlyticsCollectionEnabled(false)
+            return
+        }
         scope.launch {
             settings.preferences
                 .map { it.telemetryEnabled }
@@ -61,6 +77,29 @@ object Telemetry {
                 .distinctUntilChanged()
                 .collect { snapshot -> snapshot.applyTo(analytics) }
         }
+    }
+
+    private fun isProbablyEmulator(): Boolean {
+        val fp = Build.FINGERPRINT
+        val model = Build.MODEL
+        val product = Build.PRODUCT
+        val hardware = Build.HARDWARE
+        return fp.startsWith("generic")
+            || fp.startsWith("unknown")
+            || fp.contains("emulator", ignoreCase = true)
+            || model.contains("google_sdk")
+            || model.contains("Emulator")
+            || model.contains("Android SDK built for")
+            || product.contains("sdk_gphone")
+            || product == "google_sdk"
+            || product == "sdk"
+            || product == "sdk_x86"
+            || product == "sdk_x86_64"
+            || product == "vbox86p"
+            || hardware == "goldfish"
+            || hardware == "ranchu"
+            || Build.MANUFACTURER.contains("Genymotion")
+            || (Build.BRAND.startsWith("generic") && Build.DEVICE.startsWith("generic"))
     }
 }
 


### PR DESCRIPTION
## Summary

Force-disable Firebase Analytics + Crashlytics collection in `Telemetry.start()` when the app is running on a virtual device (Android emulator / Genymotion), regardless of the user's Privacy toggle. The persisted preference is left untouched, so the same install booted on real hardware still honours the user's choice.

Motivation: crash reports from "unknown" devices were appearing in dashboards. CI itself is not the source — `:app:assembleDebug` runs without `app/google-services.json`, so Firebase no-ops in CI. The likely culprits are local emulators (developer or QA debug builds with the JSON present), which this PR silences.

Detection uses standard `Build.*` heuristics:
- `FINGERPRINT` starts with `generic` / `unknown`, or contains `emulator`
- `MODEL` contains `google_sdk`, `Emulator`, `Android SDK built for`
- `PRODUCT` is one of `google_sdk` / `sdk` / `sdk_x86` / `sdk_x86_64` / `vbox86p`, or contains `sdk_gphone`
- `HARDWARE` is `goldfish` / `ranchu`
- `MANUFACTURER` contains `Genymotion`
- `BRAND` and `DEVICE` both start with `generic`

## Privacy

This change **reduces** what leaves the device. PRIVACY.md updated:
- New `2026-05-06` changelog entry.
- One-sentence note in "Analytics and crash reporting" stating that virtual-device runs never report.

## Test plan

- [ ] CI green (`JVM unit tests`, `Android debug build`).
- [ ] Manual: run a debug build with `google-services.json` on an AVD and confirm no Crashlytics / Analytics traffic appears in the Firebase console.
- [ ] Manual: run the same install on real hardware and confirm the user's toggle still controls reporting.

I cannot run `:app` Gradle tasks in this sandbox (Google Maven blocked), so CI is the validation surface for compilation.

---
_Generated by [Claude Code](https://claude.ai/code/session_0133yJPgtCfUgVzkCSiGnspc)_