### PR TITLE
:core:data + docs — trim clarity adjectives from ACCENT_DIRECTIVES

### DIFF
--- a/core/data/src/main/kotlin/app/clothescast/core/data/tts/GeminiTtsClient.kt
+++ b/core/data/src/main/kotlin/app/clothescast/core/data/tts/GeminiTtsClient.kt
@@ -224,65 +224,81 @@ internal fun geminiAccentDirectiveFor(locale: Locale): String? {
     return ACCENT_DIRECTIVES[locale.language]
 }
 
+// Each entry names the language and (where meaningful) a regional variety.
+// Clarity / naturalness adjectives that used to live here ("clear and
+// natural", "klaren", "claro", etc.) were stripped after the en-GB
+// listening eval (docs/voice-evals.md → "Accent clarity-trim eval, 2026-05")
+// showed they duplicate the WEATHER_FORECASTER directive's "Enunciate
+// clearly" clause and actively destabilise some voices toward
+// over-articulation. Where the only thing left after the trim was a
+// tautology (e.g. "Italian with an Italian accent"), the entry collapses
+// to a bare language directive.
 private val ACCENT_DIRECTIVES: Map<String, String> = mapOf(
-    "en-GB" to "Speak with a Standard British accent — clear and natural.",
-    "en-AU" to "Speak with a General Australian accent — clear and natural, not broad.",
+    "en-GB" to "Speak with a Standard British accent.",
+    "en-AU" to "Speak with a General Australian accent, not broad.",
     "en-US" to "Speak with a General American accent.",
     "en-CA" to "Speak with a Canadian English accent.",
     // Language-only fallback for Standard German (de-DE) and any de-* variant
     // not explicitly enumerated. Austrian (de-AT) and Swiss German (de-CH) have
     // their own entries below so the audio sounds like those regions rather than
     // the Hochdeutsch that the language-only fallback would give them.
-    "de" to "Sprich auf Deutsch in einem klaren, hochdeutschen Akzent.",
-    "de-AT" to "Sprich auf Deutsch mit einem klaren österreichischen Akzent.",
-    "de-CH" to "Sprich auf Deutsch mit einem klaren deutschschweizerischen Akzent.",
-    "fr-FR" to "Parle en français de France avec un accent parisien clair.",
+    "de" to "Sprich auf Deutsch in einem hochdeutschen Akzent.",
+    "de-AT" to "Sprich auf Deutsch mit einem österreichischen Akzent.",
+    "de-CH" to "Sprich auf Deutsch mit einem deutschschweizerischen Akzent.",
+    "fr-FR" to "Parle en français de France avec un accent parisien.",
     "fr-CA" to "Parle en français québécois avec un accent canadien-français.",
-    "it" to "Parla in italiano con un accento italiano chiaro e naturale.",
-    "es-ES" to "Habla en español de España con un acento castellano claro.",
-    "es-MX" to "Habla en español mexicano con un acento neutro y claro.",
-    "ca" to "Parla en català amb una pronunciació clara i natural.",
-    "ru" to "Говори по-русски с чётким литературным произношением.",
-    "pl" to "Mów po polsku z wyraźną i naturalną wymową.",
-    "hr" to "Govori na hrvatskom jeziku s jasnim i prirodnim izgovorom.",
-    "sl" to "Govori v slovenščini z jasnim in naravnim izgovorom.",
-    "sr" to "Govori srpskim jezikom s jasnim i prirodnim izgovorom.",
-    "bg" to "Говори на български с ясно и естествено произношение.",
-    "cs" to "Mluvte česky s jasnou a přirozenou výslovností.",
-    "sk" to "Hovorte po slovensky s jasnou a prirodzenou výslovnosťou.",
-    "hu" to "Beszélj magyarul tiszta és természetes kiejtéssel.",
-    "ro" to "Vorbiți în română cu o pronunție clară și naturală.",
-    "el" to "Μίλα στα ελληνικά με καθαρή και φυσική προφορά.",
-    "uk" to "Говори українською мовою з чітким літературним вимовленням.",
-    "pt-BR" to "Fale em português brasileiro com sotaque neutro e claro.",
-    "pt-PT" to "Fale em português europeu com um sotaque de Portugal claro e natural.",
+    "it" to "Parla in italiano.",
+    "es-ES" to "Habla en español de España con un acento castellano.",
+    "es-MX" to "Habla en español mexicano con un acento neutro.",
+    "ca" to "Parla en català.",
+    // Russian / Ukrainian keep "литературным" / "літературним" — that's a
+    // register descriptor (Standard / literary register, the broadcast norm),
+    // not a clarity adjective.
+    "ru" to "Говори по-русски с литературным произношением.",
+    "pl" to "Mów po polsku.",
+    "hr" to "Govori na hrvatskom jeziku.",
+    "sl" to "Govori v slovenščini.",
+    "sr" to "Govori srpskim jezikom.",
+    "bg" to "Говори на български.",
+    "cs" to "Mluvte česky.",
+    "sk" to "Hovorte po slovensky.",
+    "hu" to "Beszélj magyarul.",
+    "ro" to "Vorbiți în română.",
+    "el" to "Μίλα στα ελληνικά.",
+    "uk" to "Говори українською мовою з літературним вимовленням.",
+    "pt-BR" to "Fale em português brasileiro com sotaque neutro.",
+    "pt-PT" to "Fale em português europeu com um sotaque de Portugal.",
     // Language-only fallback covers any pt-* variant not explicitly listed.
-    "pt" to "Fale em português com pronúncia clara e natural.",
-    "nl" to "Spreek in het Nederlands met een duidelijk en natuurlijk accent.",
-    "sv" to "Tala på svenska med ett tydligt och naturligt uttal.",
-    "da" to "Tal på dansk med en tydelig og naturlig udtale.",
-    "nb" to "Snakk på norsk bokmål med tydelig og naturlig uttale.",
-    "fi" to "Puhu suomea selkeällä ja luonnollisella ääntämyksellä.",
-    "et" to "Räägi eesti keelt selge ja loomuliku hääldusega.",
-    "lv" to "Runā latviski ar skaidru un dabīgu izrunu.",
-    "lt" to "Kalbėk lietuviškai aiškiai ir natūraliai tariant.",
-    "tr" to "Türkçe konuş, net ve doğal bir Türkçe aksanıyla.",
+    "pt" to "Fale em português.",
+    "nl" to "Spreek in het Nederlands.",
+    "sv" to "Tala på svenska.",
+    "da" to "Tal på dansk.",
+    "nb" to "Snakk på norsk bokmål.",
+    "fi" to "Puhu suomea.",
+    "et" to "Räägi eesti keelt.",
+    "lv" to "Runā latviski.",
+    "lt" to "Kalbėk lietuviškai.",
+    "tr" to "Türkçe konuş.",
     "en-ZA" to "Speak with a South African English accent.",
-    "id" to "Bicara dalam bahasa Indonesia dengan aksen yang jelas dan alami.",
-    "ms" to "Bertutur dalam bahasa Melayu dengan sebutan yang jelas dan semula jadi.",
-    "fil" to "Magsalita sa Filipino na may malinaw at natural na diin.",
-    "sw" to "Soma maandishi yafuatayo kwa Kiswahili fasaha na matamshi wazi na ya asili.",
-    "vi" to "Nói tiếng Việt với giọng điệu rõ ràng và tự nhiên.",
-    "th" to "กรุณาอ่านเป็นภาษาไทยด้วยน้ำเสียงที่ชัดเจนและเป็นธรรมชาติ",
-    "zh-CN" to "请用标准普通话朗读，发音清晰自然。",
-    "zh-TW" to "請用標準國語朗讀，發音清晰自然。",
+    "id" to "Bicara dalam bahasa Indonesia.",
+    "ms" to "Bertutur dalam bahasa Melayu.",
+    "fil" to "Magsalita sa Filipino.",
+    // Swahili keeps "fasaha" — an "eloquent / standard" register descriptor,
+    // analogous to Russian's "литературным".
+    "sw" to "Soma maandishi yafuatayo kwa Kiswahili fasaha.",
+    "vi" to "Nói tiếng Việt.",
+    "th" to "กรุณาอ่านเป็นภาษาไทย",
+    // Mandarin keeps "标准 / 標準" (Standard) — Putonghua / Guoyu vary across
+    // the Chinese-speaking world and the standard register is what news uses.
+    "zh-CN" to "请用标准普通话朗读。",
+    "zh-TW" to "請用標準國語朗讀。",
     // Language-only fallback covers generic zh locale and any zh-* variant
     // not explicitly listed (zh-HK, etc.) — all are Mandarin-readable.
-    "zh" to "请用标准普通话朗读，发音清晰自然。",
-    "hi" to "कृपया हिंदी में स्पष्ट और प्राकृतिक उच्चारण के साथ पढ़ें।",
-    "bn" to "অনুগ্রহ করে বাংলায় স্পষ্ট ও প্রাকৃতিক উচ্চারণে পড়ুন।",
-    "ja" to "はっきりと自然な発音で日本語で読んでください。",
-    "ko" to "명확하고 자연스러운 발음으로 한국어로 읽어주세요。",
+    "zh" to "请用标准普通话朗读。",
+    "hi" to "कृपया हिंदी में पढ़ें।",
+    "bn" to "অনুগ্রহ করে বাংলায় পড়ুন।",
+    "ja" to "日本語で読んでください。",
+    "ko" to "한국어로 읽어주세요。",
     // Arabic: directives nudge the model to read MSA prose with the named
     // country's accent (Egyptian / Saudi / Emirati / Moroccan), not to
     // code-switch to the colloquial dialect — the :app formatter produces
@@ -294,15 +310,18 @@ private val ACCENT_DIRECTIVES: Map<String, String> = mapOf(
     // Mandarin variants; community reports for Arabic are mixed). Worst
     // case it ignores the country qualifier and we get generic MSA — same
     // as before the split, no regression.
-    "ar-SA" to "اقرأ النص التالي بالعربية الفصحى بنطق سعودي واضح وطبيعي.",
-    "ar-EG" to "اقرأ النص التالي بالعربية الفصحى بنطق مصري واضح وطبيعي.",
-    "ar-AE" to "اقرأ النص التالي بالعربية الفصحى بنطق إماراتي واضح وطبيعي.",
-    "ar-MA" to "اقرأ النص التالي بالعربية الفصحى بنطق مغربي واضح وطبيعي.",
-    "ar" to "اقرأ النص التالي بالعربية بنطق واضح وطبيعي.",
+    //
+    // "الفصحى" (al-Fuṣḥā = MSA) stays — that's the register the formatter
+    // produces, not a clarity adjective.
+    "ar-SA" to "اقرأ النص التالي بالعربية الفصحى بنطق سعودي.",
+    "ar-EG" to "اقرأ النص التالي بالعربية الفصحى بنطق مصري.",
+    "ar-AE" to "اقرأ النص التالي بالعربية الفصحى بنطق إماراتي.",
+    "ar-MA" to "اقرأ النص التالي بالعربية الفصحى بنطق مغربي.",
+    "ar" to "اقرأ النص التالي بالعربية.",
     // Hebrew / Persian remain language-only — only he-IL / fa-IR are offered
     // in the picker, so there's nothing to disambiguate.
-    "he" to "קרא/י את הטקסט הבא בעברית בהגייה ברורה וטבעית.",
-    "fa" to "متن زیر را به فارسی با تلفظ واضح و طبیعی بخوانید.",
+    "he" to "קרא/י את הטקסט הבא בעברית.",
+    "fa" to "متن زیر را به فارسی بخوانید.",
 )
 
 /**
@@ -337,9 +356,9 @@ class GeminiTtsClient(
         }
 
         // WEATHER_FORECASTER gets the full accent directive ("Speak with a
-        // Standard British accent — clear and natural."). Character styles get
-        // only a bare language hint ("Speak in British English.") so the accent
-        // words don't conflict with the persona.
+        // Standard British accent."). Character styles get only a bare language
+        // hint ("Speak in British English.") so the accent words don't conflict
+        // with the persona.
         val accent = if (style == TtsStyle.WEATHER_FORECASTER) {
             locale?.let { geminiAccentDirectiveFor(it) }
         } else {

--- a/core/data/src/test/kotlin/app/clothescast/core/data/tts/GeminiTtsClientTest.kt
+++ b/core/data/src/test/kotlin/app/clothescast/core/data/tts/GeminiTtsClientTest.kt
@@ -343,8 +343,11 @@ class GeminiTtsClientTest {
         client.synthesize(text = "hi", locale = Locale.forLanguageTag("ar-LB"))
 
         val body = checkNotNull(capturedBody)
-        // Bare `ar` directive omits the country adjective.
-        body.shouldContain("اقرأ النص التالي بالعربية بنطق")
+        // Bare `ar` directive omits both the country adjective and the
+        // "الفصحى" (MSA) marker — the trailing period right after "بالعربية"
+        // is unique to this fallback (country variants continue with
+        // " الفصحى بنطق <country>." and have a space, not a period, there).
+        body.shouldContain("اقرأ النص التالي بالعربية.")
         body.shouldNotContain("سعودي")
         body.shouldNotContain("مصري")
     }

--- a/docs/voice-evals.md
+++ b/docs/voice-evals.md
@@ -217,6 +217,77 @@ underperform vs B1 (7.6 vs 8.3). Three replacements were tested with B2:
 
 - `GEMINI_TTS_STYLE_DIRECTIVE_WEATHER_FORECASTER` → B2 wording
 - en-GB accent directive → "Speak with a Standard British accent — clear and natural."
+  *(Superseded by the clarity-trim eval below — now "Speak with a Standard
+  British accent.")*
+
+---
+
+## Accent clarity-trim eval (2026-05)
+
+Tests whether the "clear and natural" / "klaren" / "claro" / etc. clarity
+adjectives in `ACCENT_DIRECTIVES` add value, given that the WEATHER_FORECASTER
+directive already says "Enunciate clearly and use a measured speed."
+
+Run via `scripts/eval-weather-report-style.py --filter en-GB-prod-weather-B2`
+and `--filter en-GB-bare-weather-B2`. Same 7 voices, same B2 directive, en-GB
+locale only. Two accent variants:
+
+- **prod:** "Speak with a Standard British accent — clear and natural." (was shipped)
+- **bare:** "Speak with a Standard British accent." (clarity trimmed)
+
+### Per-voice scores (en-GB, B2 directive)
+
+| Voice | prod | bare | Δ |
+|---|---|---|---|
+| Aoede | 8 | 8 | 0 |
+| Charon | 8 | 9 | +1 |
+| Despina | 8 | 9 | +1 |
+| Erinome | 2 | 8 | +6 |
+| Iapetus | 5 | 8 | +3 |
+| Kore | 5 | 9 | +4 |
+| Leda | 7 | 9 | +2 |
+| **avg** | **6.1** | **8.6** | **+2.5** |
+
+### Findings
+
+- **No voice regressed** under the clarity trim; every voice was same-or-better.
+- **Erinome (2/10 → 8/10) was the most striking lift** — degenerate under prod,
+  fine under bare. Iapetus (5 → 8) and Kore (5 → 9) — voices most prone to
+  RP/villain register — also lifted significantly. The clarity adjectives appear
+  to actively destabilise some voices, likely by pushing toward
+  over-articulation.
+- The prior eval (Weather-report style eval above) recorded prod en-GB at 8.3
+  avg vs. 6.1 here — TTS run-to-run variance, mainly Erinome going degenerate
+  this run. Bare is uniformly in the 8–9 band so the conclusion holds even on
+  the optimistic 8.3 read of prod.
+
+### Bonus finding: de-CH
+
+Single-voice spot check (Leda, German weather text):
+
+- Original (`klaren deutschschweizerischen Akzent`): weird mishmash of Swiss
+  German and Hochdeutsch — neither register, just confused.
+- Clarity-trimmed (`deutschschweizerischen Akzent`): clean Schwiizerdütsch
+  dialect.
+
+The clarity word was the destabiliser. Trimming it lets the model commit to a
+register. Schwiizerdütsch isn't standard broadcast Swiss-German for weather
+(Schweizer Hochdeutsch would be), but the dialect is recognisable and pleasant
+and the previous mishmash was the actual bug. A separate follow-up could push
+de-CH toward Schweizer Hochdeutsch via directive shaping; keeping the cute
+Schwiizerdütsch render is also a defensible choice.
+
+### Shipped
+
+- Clarity adjectives ("clear and natural", "klaren", "claro", чёткий, jasnim,
+  selkeällä, 清晰, स्पष्ट, واضح, etc.) removed from every entry in
+  `ACCENT_DIRECTIVES`. Variety descriptors ("Standard", "General",
+  "hochdeutsch", "castellano", "neutro", "标准", "Fuṣḥā", literary/literary
+  register markers in Russian / Ukrainian / Swahili) remain — those carry
+  per-locale work that the directive doesn't.
+- For locales where the only thing left after the trim was a tautology
+  (e.g. "Italian with an Italian accent"), the entry simplifies to a bare
+  language directive (`"Parla in italiano."`).
 
 ---
 
@@ -228,3 +299,4 @@ underperform vs B1 (7.6 vs 8.3). Three replacements were tested with B2:
 | `scripts/compare-gemini-voices.py` | Generate one clip per voice for a single directive |
 | `scripts/eval-weather-report-style.py` | Generate clips for 7 candidates × 7 voices × 9 locales |
 | `scripts/rate-tts-clips.py` | Play each clip with `aplay`, prompt for a score + notes |
+| `scripts/say.py` | One-shot helper for rapid prompt iteration (prints / plays a single clip) |

--- a/docs/voice-evals.md
+++ b/docs/voice-evals.md
@@ -261,6 +261,40 @@ locale only. Two accent variants:
   this run. Bare is uniformly in the 8–9 band so the conclusion holds even on
   the optimistic 8.3 read of prod.
 
+### en-AU spot check (on-device, shipping voices only)
+
+Tested on the Firebase APK against the trimmed
+`"Speak with a General Australian accent, not broad."` and the same B2
+directive. Just the four voices in PR #338's keep-list — single read per
+voice, no re-rolls.
+
+| Voice | Trim today | Historical (B2 + "— clear and natural, not broad.") | Verdict |
+|---|---|---|---|
+| Charon | 9 | "Rock-solid" (tied #1 overall) | consistent |
+| Iapetus | 8.5–9 | "Weakest overall" (#7) | **improvement** |
+| Leda | 8 | "Fine under current accents" (#6) | consistent |
+| Despina | flat | "One degenerate on B1/en-AU-general" (#4) | pre-existing |
+
+Average across the three non-flat voices ≈ 8.5 — right in line with the
+en-GB trimmed average of 8.6. The trim generalises well from en-GB to
+en-AU on three of four voices.
+
+**No new regression.** Despina-on-en-AU was already flagged in the prior
+en-AU-general eval as the one degenerate combo for that voice; what
+on-device testing surfaced is the same voice-anchor limitation surviving
+through the trim, not a new flaw the trim introduced. Iapetus actually
+improved (from "weakest overall" to 8.5–9). Charon and Leda are stable.
+
+A `"...General Australian accent — natural, not broad."` partial-trim
+(drop "clear" only, keep "natural" as positive shaping) is worth a
+follow-up sniff test if we want to specifically rescue Despina-on-en-AU;
+otherwise users who want en-AU liveliness pick Charon, Iapetus, or Leda.
+
+Erinome was also tested ad hoc — flagged as flat on en-AU and as
+having an over-rhotic "sweater" on en-US. Both look like Erinome's
+phonetic anchor leaking through; PR #338 drops Erinome from the picker,
+so this isn't a shipping concern.
+
 ### Bonus finding: de-CH
 
 Single-voice spot check (Leda, German weather text):


### PR DESCRIPTION
## Summary

Strips the "clear and natural" / "klaren" / "claro" / "чётким" / "jasnim" / "清晰" / "स्पष्ट" / "واضح" etc. clarity adjectives from every entry in `ACCENT_DIRECTIVES`. The `WEATHER_FORECASTER` directive already says "Enunciate clearly and use a measured speed" — those adjectives were duplicating it, and the eval below showed they were actively destabilising some voices.

(Opening as draft — not ready for review until CI passes; un-draft via the UI after that.)

## Eval data

Run via `scripts/eval-weather-report-style.py --filter en-GB-prod-weather-B2` and `--filter en-GB-bare-weather-B2`. Same B2 directive, same 7 voices, en-GB locale. Two accent variants:

- **prod:** `"Speak with a Standard British accent — clear and natural."` (was shipped)
- **bare:** `"Speak with a Standard British accent."` (clarity trimmed)

| Voice | prod | bare | Δ |
|---|---|---|---|
| Aoede | 8 | 8 | 0 |
| Charon | 8 | 9 | +1 |
| Despina | 8 | 9 | +1 |
| Erinome | **2** | 8 | **+6** |
| Iapetus | 5 | 8 | +3 |
| Kore | 5 | 9 | +4 |
| Leda | 7 | 9 | +2 |
| **avg** | **6.1** | **8.6** | **+2.5** |

No voice regressed. The biggest lifts were the voices most prone to RP / villain register (Erinome, Kore, Iapetus) — the clarity adjectives push those toward over-articulation. Full write-up in `docs/voice-evals.md` → "Accent clarity-trim eval (2026-05)".

## Bonus finding: de-CH

Single-voice spot check (Leda, German weather text):

- Original (`klaren deutschschweizerischen Akzent`): weird mishmash of Schwiizerdütsch and Hochdeutsch — neither register, just confused.
- After trim (`deutschschweizerischen Akzent`): clean Schwiizerdütsch dialect.

The clarity word was the destabiliser. Schweizer Hochdeutsch (the broadcast register Swiss audiences expect for weather) is a separate concern; the trim alone fixes the mishmash.

## What stays

Variety / register descriptors that carry real per-locale work — "Standard British", "General Australian, not broad", "Hochdeutsch", "castellano", "neutro", "标准 / 標準", "الفصحى" (MSA), literary-register markers in Russian / Ukrainian / Swahili. None of those duplicate the directive.

Where the only thing left after the trim was a tautology ("Italian with an Italian accent"), the entry simplifies to a bare language directive (`"Parla in italiano."`).

## Test changes

One assertion needed updating — the `ar-LB → bare ar` fallback test asserted on `"اقرأ النص التالي بالعربية بنطق"` (the bit that came right before the trimmed "واضح وطبيعي"). New bare `ar` ends in `"بالعربية."` (with period), which is unique to this fallback since country variants continue with `" الفصحى بنطق <country>."` (space, no period). Updated the assertion with a comment explaining the disambiguation.

All other locale tests assert on stable substrings (`"Standard British accent"`, `"General Australian accent"`, `"österreichischen"`, `"deutschschweizerischen"`, `"português europeu"`, `"國語"`, `"بنطق سعودي"` etc.) that the trim preserves.

## Test plan

- [ ] CI: `JVM unit tests` (`:core:data:test` covers the assertion changes; couldn't run locally — Google Maven plugin resolution blocked from the agent sandbox)
- [ ] CI: `Android debug build`
- [ ] Spot-check a Firebase APK on en-GB / en-AU / de / de-CH against the new strings before un-drafting

## Privacy

No change to what we send off device — accent directives are part of the BYOK Gemini TTS prompt and were already crossing the device boundary. The strings sent are *shorter* now (less text per request).

## Branch #2 follow-up (separate PR)

Move "Standard / General / Hochdeutsch" register signal from per-locale accents into the directive (option B3 from the listening session), so accents can collapse further. Initial single-voice tests across en-GB / en-AU / de / de-AT / de-CH found no regressions but the data is too thin to ship without a proper 7-voice eval.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FF83vZToLynJVUMpPs7duK)_