### PR TITLE
docs — remove OpenAI and ElevenLabs references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,7 +150,7 @@ new rule the first time something bites you, not the third.
 
 - **Surface any change to what we send off device.** When a change touches
   data that crosses the device boundary — anything in the rendered insight
-  prose (it's fed to Gemini / OpenAI / ElevenLabs TTS over BYOK keys),
+  prose (it's fed to Gemini TTS over BYOK keys),
   weather / geocoding requests, or future analytics / error reporting —
   call it out explicitly in the PR description and commit message. Calendar
   event titles, locations, contacts, identifiers: default is "less, not
@@ -219,5 +219,5 @@ new rule the first time something bites you, not the third.
   available beyond compiler warnings.
 - **This is a client-only Android app.** No backend server, database, or
   Docker containers to start. The app calls Open-Meteo (free, keyless) and
-  optionally Gemini/OpenAI/ElevenLabs (BYOK). Testing is purely JVM-based.
+  optionally Gemini (BYOK). Testing is purely JVM-based.
 - **`CLAUDE.md` is a symlink** to `AGENTS.md` — editing either edits both.

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -19,8 +19,7 @@ have over it.
   user-content data the app sends off your device by default.
 - If you opt in to **online text-to-speech**, the short spoken sentence
   (e.g. _"50% chance of rain at 3pm — take an umbrella"_) is sent to the
-  TTS provider you chose (Google Gemini, OpenAI, or ElevenLabs) so it can
-  return the audio.
+  TTS provider you chose (Google Gemini) so it can return the audio.
 - If you opt in to **calendar tie-in**, the app reads today's events on
   your device. The event title may appear inside the spoken sentence
   (e.g. _"Bring a jacket for your concert tonight"_), and is therefore
@@ -114,11 +113,11 @@ The source code is at <https://github.com/mikelward/clothescast>.
 
 ### API keys you provide
 
-- If you use online TTS, you supply your own Google Gemini, OpenAI,
-  and / or ElevenLabs API key. Keys are stored on your device,
-  encrypted at rest using a key sealed by the Android Keystore. They
-  are sent only to the corresponding provider on requests you initiate,
-  and are never shared with us or any third party.
+- If you use online TTS, you supply your own Google Gemini API key.
+  Keys are stored on your device, encrypted at rest using a key sealed
+  by the Android Keystore. They are sent only to the corresponding
+  provider on requests you initiate, and are never shared with us or
+  any third party.
 
 ## Third-party services
 
@@ -129,19 +128,15 @@ policies apply to anything they receive:
 |---|---|---|
 | [Open-Meteo](https://open-meteo.com/en/terms) | Coarse coordinate | Always (forecast + geocoding) |
 | [Google Gemini API](https://ai.google.dev/gemini-api/terms) | The short rendered insight sentence | Only if you select Gemini TTS |
-| [OpenAI API](https://openai.com/policies/privacy-policy) | The short rendered insight sentence | Only if you select OpenAI TTS |
-| [ElevenLabs API](https://elevenlabs.io/privacy) | The short rendered insight sentence | Only if you select ElevenLabs TTS |
 | Analytics / crash-reporting service (e.g. Firebase Crashlytics + Google Analytics for Firebase) | Aggregate usage events and crash diagnostics — see "Analytics and crash reporting" below for what's in and out | Possibly always, in all builds |
 
 These providers act as service providers fulfilling a single request and
 returning the result. The TTS providers receive only the sentence to be
 spoken, with no user identifier attached beyond the API key you supplied.
 
-Note on OpenAI: under OpenAI's API terms, request inputs may be retained
-for up to 30 days for abuse monitoring before being deleted, and are not
-used to train OpenAI's models by default for API traffic. Gemini API and
-ElevenLabs API do not retain prompts for training by default. See each
-provider's policy linked above for the authoritative terms.
+Note on Gemini API: request inputs are not retained for training by
+default. See the provider's policy linked above for the authoritative
+terms.
 
 ## What we do _not_ collect
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@ actual weather, today's forecast, and the clothes thresholds you've
 configured.
 
 It can also speak the insight aloud — through the platform TTS engine, or
-through an online voice (Gemini, OpenAI, or ElevenLabs) if you'd rather a
-more natural read.
+through an online voice (Gemini) if you'd rather a more natural read.
 
 See [PRIVACY.md](PRIVACY.md) for what data leaves the device and when.
 
@@ -40,9 +39,9 @@ artifact (see below) for sideload installs.
   template-fillable rules over the forecast, clothes thresholds, weather
   alerts, and (optionally) today's calendar events. No LLM round trip.
 - **TTS — your choice of engine**: the platform `TextToSpeech` engine
-  (default, fully on-device), or an online voice via the Gemini, OpenAI,
-  or ElevenLabs API. Online engines are BYOK; keys are encrypted on-device
-  via Tink + Android Keystore + DataStore Preferences.
+  (default, fully on-device), or an online voice via the Gemini API.
+  Online engines are BYOK; keys are encrypted on-device via Tink +
+  Android Keystore + DataStore Preferences.
 - **Optional calendar tie-in**: with `READ_CALENDAR` granted, the daily
   sentence can name the event the clothes advice is for —
   _"Bring an umbrella for your 3pm meeting."_
@@ -58,7 +57,7 @@ artifact (see below) for sideload installs.
 | Module | Status |
 |---|---|
 | `:core:domain` | Pure-Kotlin models, use cases (insight rendering, clothes rules), repository interfaces |
-| `:core:data` | Open-Meteo forecast + geocoding clients, Gemini / OpenAI / ElevenLabs TTS clients, parser tests |
+| `:core:data` | Open-Meteo forecast + geocoding clients, Gemini TTS client, parser tests |
 | `:app` | Compose UI, manifest, receivers, worker, alarm scheduler, DI, platform TTS, calendar reader, encrypted key store |
 
 ## Installing on a phone
@@ -95,8 +94,8 @@ Three options, in roughly increasing order of friction:
    `shorts`, `umbrella`) are a sensible starting set. Add your own — e.g.
    `gloves` when temperature drops below 5°C.
 5. **Voice** (optional): the platform TTS engine works out of the box. To
-   use a more natural online voice, pick Gemini / OpenAI / ElevenLabs in
-   Settings → Voice and paste the matching API key in Settings → API Keys.
+   use a more natural online voice, pick Gemini in Settings → Voice and
+   paste your API key in Settings → API Keys.
 6. **Calendar tie-in** (optional): toggle _Use calendar events_ in
    Settings → Data Sources and grant `READ_CALENDAR` to let the daily
    sentence reference an overlapping event by name.
@@ -128,10 +127,10 @@ suppresses it is a vendor-side override.
 
 ## Roadmap
 
-- **v0.x** _(now)_: daily insight notification + TTS (device / Gemini /
-  OpenAI / ElevenLabs), full Settings UI, optional calendar tie-in and
-  device location, sideload via CI artifacts, Firebase App Distribution
-  for testers, Play Store internal track for testers.
+- **v0.x** _(now)_: daily insight notification + TTS (device / Gemini),
+  full Settings UI, optional calendar tie-in and device location,
+  sideload via CI artifacts, Firebase App Distribution for testers,
+  Play Store internal track for testers.
 - **v1.0**: Play Store listing + public release (production track);
   24-hour cost cap on online TTS calls.
 - **v2.0**: hourly / 3-hourly forecast UI, Google Home integration.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -95,7 +95,7 @@ val buildTimestampMs: Long = System.currentTimeMillis()
 android {
     // Pinned to app.clothescast. Renamed from app.adaptweather as part of the
     // product rename; existing FAD testers had to uninstall + reinstall,
-    // losing their encrypted API keys (Gemini, OpenAI, ElevenLabs), schedule,
+    // losing their encrypted API keys (Gemini), schedule,
     // location, and clothes rules. Once a sideloaded build with applicationId
     // X is in the wild, switching to Y means installs of Y are a different
     // app — the applicationId is the install identity; do not change it again

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -26,11 +26,7 @@ Code TODOs in source files are linked from here when they exist.
 
 - [x] Gemini TTS as opt-in voice engine (PR #27)
 - [x] Diagnostic "Test Gemini voice" button in Settings (PR #28)
-- [ ] **OpenAI TTS** as a third voice engine. BYOK pattern, same as Gemini.
-- [ ] **Voice picker** for both Gemini and OpenAI. Currently Gemini is
-      hardcoded to `Kore`.
-- [ ] ElevenLabs / Azure as further options (only after the abstractions are
-      proven by OpenAI).
+- [ ] **Voice picker** for Gemini. Currently hardcoded to `Kore`.
 
 ## Calendar integration (next-up after TTS)
 
@@ -144,4 +140,4 @@ Decide before wiring anything; the wiring is the easy part.
 | File | Note |
 |---|---|
 | `app/build.gradle.kts:9` | Pin namespace + applicationId before first distribution. |
-| `app/src/main/kotlin/app/clothescast/tts/AndroidTtsSpeaker.kt:30` | Evaluate higher-quality TTS alternatives. (Gemini + OpenAI now landed.) |
+| `app/src/main/kotlin/app/clothescast/tts/AndroidTtsSpeaker.kt:30` | Evaluate higher-quality TTS alternatives. (Gemini now landed.) |


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Scrubs all mentions of OpenAI and ElevenLabs from docs and comments, since both providers have already been removed from the app
- Affected files: `PRIVACY.md`, `README.md`, `docs/TODO.md`, `AGENTS.md`, `app/build.gradle.kts`
- No code changes — docs/comments only

## Test plan

- [ ] Grep confirms zero remaining `OpenAI`/`ElevenLabs` references in tracked files

https://claude.ai/code/session_016vLc81oEpLvfV25XzhjWhE
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_016vLc81oEpLvfV25XzhjWhE)_