### PR TITLE
:core:data + docs — per-locale TTS directive routing for en-AU

### DIFF
--- a/core/data/src/main/kotlin/app/clothescast/core/data/tts/GeminiTtsClient.kt
+++ b/core/data/src/main/kotlin/app/clothescast/core/data/tts/GeminiTtsClient.kt
@@ -50,7 +50,14 @@ internal const val GEMINI_API_VERSION = "v1beta"
  * gentle emphasis on clothing advice. Chosen via listening eval over a neutral
  * "studio voice" and a newsreader variant.
  *
- * Below the default are character / persona registers (pirate, cowboy, etc.).
+ * [GEMINI_TTS_STYLE_DIRECTIVE_WEATHER_FORECASTER_REGISTER] is the same with
+ * an extra "Use the language's standard variety, not a regional dialect"
+ * sentence. Empirically rescues Iapetus on en-AU (5 → 9) and lifts other
+ * voices that were below the user's quality bar; on en-GB it nudged voices
+ * off-brand and is **not** used there. [directiveFor] picks the variant per
+ * locale. See docs/voice-evals.md → "B3 register-in-directive eval".
+ *
+ * Below the defaults are character / persona registers (pirate, cowboy, etc.).
  * Each one starts with "Read the following…" so the model treats it as
  * delivery direction rather than a rewrite, permits brief in-character
  * interjections, and ends with the standard "no audio effects, background
@@ -60,6 +67,14 @@ internal const val GEMINI_API_VERSION = "v1beta"
 internal const val GEMINI_TTS_STYLE_DIRECTIVE_WEATHER_FORECASTER: String =
     "Read the following weather forecast in the style of a weather report on a " +
         "national news service. Enunciate clearly and use a measured speed. " +
+        "Accentuate the ends of sentences and give a gentle emphasis to clothing " +
+        "recommendations. No audio effects, background noise, or vinyl-style " +
+        "texture.\n\n"
+
+internal const val GEMINI_TTS_STYLE_DIRECTIVE_WEATHER_FORECASTER_REGISTER: String =
+    "Read the following weather forecast in the style of a weather report on a " +
+        "national news service. Use the language's standard variety, not a " +
+        "regional dialect. Enunciate clearly and use a measured speed. " +
         "Accentuate the ends of sentences and give a gentle emphasis to clothing " +
         "recommendations. No audio effects, background noise, or vinyl-style " +
         "texture.\n\n"
@@ -125,6 +140,29 @@ internal fun styleDirectiveFor(style: TtsStyle): String = when (style) {
     TtsStyle.STORYTELLER -> GEMINI_TTS_STYLE_DIRECTIVE_STORYTELLER
     TtsStyle.FITNESS_INSTRUCTOR -> GEMINI_TTS_STYLE_DIRECTIVE_FITNESS_INSTRUCTOR
     TtsStyle.MORNING_PRESENTER -> GEMINI_TTS_STYLE_DIRECTIVE_MORNING_PRESENTER
+}
+
+/**
+ * Picks the right WEATHER_FORECASTER variant for [locale]. Most locales get
+ * [GEMINI_TTS_STYLE_DIRECTIVE_WEATHER_FORECASTER] (B2 wording). en-AU gets
+ * [GEMINI_TTS_STYLE_DIRECTIVE_WEATHER_FORECASTER_REGISTER] (B2 + the explicit
+ * "standard variety, not regional dialect" sentence), which empirically
+ * rescues Iapetus on en-AU from a near-degenerate 5/10 to 9/10 and lifts
+ * other voices that were below the user's quality bar. The same change on
+ * en-GB nudged voices off-brand, hence the per-locale routing rather than a
+ * global directive update. See docs/voice-evals.md.
+ *
+ * Character styles (PIRATE, COWBOY, etc.) ignore the locale routing and use
+ * the persona's directive verbatim — adding a register-direction sentence
+ * would conflict with persona delivery.
+ */
+internal fun directiveFor(style: TtsStyle, locale: Locale?): String {
+    if (style == TtsStyle.WEATHER_FORECASTER &&
+        locale?.language == "en" && locale.country == "AU"
+    ) {
+        return GEMINI_TTS_STYLE_DIRECTIVE_WEATHER_FORECASTER_REGISTER
+    }
+    return styleDirectiveFor(style)
 }
 
 /**
@@ -235,7 +273,13 @@ internal fun geminiAccentDirectiveFor(locale: Locale): String? {
 // to a bare language directive.
 private val ACCENT_DIRECTIVES: Map<String, String> = mapOf(
     "en-GB" to "Speak with a Standard British accent.",
-    "en-AU" to "Speak with a General Australian accent, not broad.",
+    // en-AU drops "General" — paired with the per-locale register sentence in
+    // GEMINI_TTS_STYLE_DIRECTIVE_WEATHER_FORECASTER_REGISTER (selected by
+    // directiveFor for en-AU only). The combination empirically rescues
+    // Iapetus on en-AU; "General" was redundant once the directive carries
+    // "standard variety, not regional dialect" for this locale. See
+    // docs/voice-evals.md → "B3 register-in-directive eval".
+    "en-AU" to "Speak with an Australian accent, not broad.",
     "en-US" to "Speak with a General American accent.",
     "en-CA" to "Speak with a Canadian English accent.",
     // Language-only fallback for Standard German (de-DE) and any de-* variant
@@ -365,7 +409,7 @@ class GeminiTtsClient(
             locale?.let { geminiLanguageDirectiveFor(it) }
         }
         val prompt = buildString {
-            append(styleDirectiveFor(style))
+            append(directiveFor(style, locale))
             if (accent != null) {
                 append(accent)
                 append("\n\n")

--- a/core/data/src/test/kotlin/app/clothescast/core/data/tts/GeminiTtsClientTest.kt
+++ b/core/data/src/test/kotlin/app/clothescast/core/data/tts/GeminiTtsClientTest.kt
@@ -140,7 +140,78 @@ class GeminiTtsClientTest {
         client.synthesize(text = "hello", locale = Locale.forLanguageTag("en-AU"))
 
         val body = checkNotNull(capturedBody)
-        body.shouldContain("General Australian accent")
+        body.shouldContain("Australian accent")
+        // "General" was dropped — the per-locale register sentence in the
+        // directive carries the standard-variety signal instead.
+        body.shouldNotContain("General Australian")
+    }
+
+    @Test
+    fun `weather forecaster on en-AU uses the register-in-directive variant`() = runTest {
+        // en-AU is the only locale where directiveFor returns the variant with
+        // the "standard variety, not regional dialect" sentence — empirically
+        // needed to rescue Iapetus on en-AU. See docs/voice-evals.md →
+        // "B3 register-in-directive eval".
+        var capturedBody: String? = null
+        val client = GeminiTtsClient(
+            httpClient = mockClient(SUCCESS_BODY) {
+                capturedBody = (it.body as io.ktor.http.content.OutgoingContent.ByteArrayContent)
+                    .bytes()
+                    .toString(Charsets.UTF_8)
+            },
+            keyProvider = FakeKeyProvider("test-key"),
+        )
+
+        client.synthesize(text = "hello", locale = Locale.forLanguageTag("en-AU"))
+
+        val body = checkNotNull(capturedBody)
+        body.shouldContain("standard variety, not a regional dialect")
+    }
+
+    @Test
+    fun `weather forecaster on en-GB uses the default directive without the register sentence`() = runTest {
+        // en-GB stays on the B2 directive — adding the register sentence
+        // empirically nudged en-GB voices off-brand. See voice-evals.md.
+        var capturedBody: String? = null
+        val client = GeminiTtsClient(
+            httpClient = mockClient(SUCCESS_BODY) {
+                capturedBody = (it.body as io.ktor.http.content.OutgoingContent.ByteArrayContent)
+                    .bytes()
+                    .toString(Charsets.UTF_8)
+            },
+            keyProvider = FakeKeyProvider("test-key"),
+        )
+
+        client.synthesize(text = "hello", locale = Locale.forLanguageTag("en-GB"))
+
+        val body = checkNotNull(capturedBody)
+        body.shouldNotContain("standard variety, not a regional dialect")
+    }
+
+    @Test
+    fun `character style on en-AU does not get the register-in-directive variant`() = runTest {
+        // The register sentence is WEATHER_FORECASTER-specific. Persona styles
+        // (PIRATE here) get their own directive verbatim — adding register
+        // direction would conflict with persona delivery.
+        var capturedBody: String? = null
+        val client = GeminiTtsClient(
+            httpClient = mockClient(SUCCESS_BODY) {
+                capturedBody = (it.body as io.ktor.http.content.OutgoingContent.ByteArrayContent)
+                    .bytes()
+                    .toString(Charsets.UTF_8)
+            },
+            keyProvider = FakeKeyProvider("test-key"),
+        )
+
+        client.synthesize(
+            text = "ahoy",
+            locale = Locale.forLanguageTag("en-AU"),
+            style = TtsStyle.PIRATE,
+        )
+
+        val body = checkNotNull(capturedBody)
+        body.shouldNotContain("standard variety, not a regional dialect")
+        body.shouldContain("swaggering pirate")
     }
 
     @Test

--- a/docs/voice-evals.md
+++ b/docs/voice-evals.md
@@ -325,6 +325,135 @@ Schwiizerdütsch render is also a defensible choice.
 
 ---
 
+## B3 register-in-directive eval (2026-05)
+
+Tests whether the per-locale variety descriptors in `ACCENT_DIRECTIVES`
+("Standard British", "General Australian", "in einem hochdeutschen Akzent")
+can collapse into the directive once the directive itself carries the
+register signal. Hypothesis: with the directive instructing "Use the
+language's standard variety, not a regional dialect", the per-locale
+"Standard / General" qualifiers become redundant.
+
+Run via `scripts/eval-weather-report-style.py`. Two conditions per locale:
+
+- **B2 + with-variety** (control): current shipped, e.g. en-AU =
+  `"Speak with a General Australian accent, not broad."`
+- **B3 + bare** (treatment): directive gains
+  `"Use the language's standard variety, not a regional dialect."`,
+  accent drops the variety qualifier (e.g.
+  `"Speak with an Australian accent, not broad."`)
+
+Two locales tested formally; a third spot-checked.
+
+### en-AU — clear win
+
+| Voice | B2 + prod | B3 + bare | Δ |
+|---|---|---|---|
+| Aoede | 9 | 9 | 0 |
+| Charon | 9 | 9 | 0 |
+| Despina | 9 | 9 (re-rolls 8/8/9) | 0 |
+| Erinome | 7 | 9 | +2 |
+| Iapetus | **5** | 9 | **+4** |
+| Kore | 6 | 8 | +2 |
+| Leda | 7 | 5/7.5/8/7 (avg ~6.9) | mixed |
+| **avg** | 7.4 | 8.3 | +0.9 |
+
+Iapetus 5 → 9 is the standout — lifts a near-degenerate voice into the
+shipping band. Leda showed wide variance (5 to 8) on en-AU under B3 but
+stays in the picker only via PR #338 considerations; see "Leda dropped"
+below.
+
+### en-GB — slight regression, off-brand
+
+| Voice | B2 + prod | B3 + bare | Δ |
+|---|---|---|---|
+| Aoede | 8 | 7 | −1 |
+| Charon | 9 | 9 | 0 |
+| Despina | 9 | 9 | 0 |
+| Erinome | 8 | 9 | +1 |
+| Iapetus | 8 | 8 | 0 |
+| Kore | 9 | 8 | −1 |
+| Leda | 9 | 8 | −1 |
+| **avg** | 8.6 | 8.3 | −0.3 |
+
+Numerically a mild −0.3, but **qualitatively worse than the numbers
+suggest** — voices under B3 read as "serviceable but not on-brand" for the
+cultivated Weather Forecaster identity. The "Standard British" qualifier
+was doing real work on en-GB; the directive sentence couldn't replace it.
+
+### de-CH spot check (one voice each)
+
+The directive change does *not* fix de-CH's broader register question; the
+post-#351 clarity trim alone produces clean Schwiizerdütsch dialect. B3 +
+bare-er accent (drop the "deutsch-" prefix from `deutschschweizerischen`)
+nudged Leda toward Hochdeutsch but isn't shipping in this PR — kept
+de-CH on the post-#351 string.
+
+### Asymmetry interpretation
+
+The directive sentence helps when the locale's accent anchor is
+comparatively weak (en-AU "General Australian" is a less common phrase
+in Gemini training than the en-GB equivalent) and adds noise when the
+anchor is already strong (en-GB "Standard British" carries cultivated
+broadcast register on its own). One directive change isn't the right
+shape for both locales — hence the per-locale routing rather than a
+global update.
+
+### Negative findings (kept for posterity)
+
+Single-voice tests on Despina + en-AU + B3 against several "more
+newsreader feel" expansions. **All caused regressions on at least one
+shipping voice** while only marginally helping Despina:
+
+| Variant added on top of B3 | Despina | Charon | Iapetus |
+|---|---|---|---|
+| `+ "engaged, articulate, professional, not theatrical"` | 8.5 | **7.5** (British "jackit") | 8.5 (a bit fast) |
+| `+ "engaged…" + "unhurried, measured pace"` | 9 (single roll) | **5** (too regional) | 9 (still slightly fast) |
+| `+ "pausing briefly between key points"` | **5** | (untested) | (untested) |
+
+Same pattern as the historical en-GB-presenter eval (`voice-evals.md`
+above): every additional shaping clause has pulled some voice off-register
+or off-accent. The directive prose is at the variance ceiling — single-
+word tweaks are at or below the noise floor on the voices that respond
+well, and reliably regress voices that were already at 9.
+
+### Despina-as-default decision
+
+After Leda showed wide variance on en-AU under B3 (rolls 5, 7.5, 8, 7 — only
+1/4 hits user's ≥8 acceptance bar), Despina was probed as the default-voice
+replacement:
+
+| Locale | Despina score |
+|---|---|
+| en-GB B2 prod | 9 |
+| en-GB B3 bare | 9 |
+| en-AU B2 prod | 9 / 8.5–9 / 8 / 6–7 (4-roll variance) |
+| en-AU B3 bare | 9 / 8 / 8 / 9 (4-roll, all ≥8) |
+| en-US B2 prod | 8 |
+| de B2 prod | 8.5–9 |
+
+Despina is reliable, not dazzling — distribution clusters at 8–9 with a
+single outlier at 6–7 on en-AU B2 prod (the condition we're moving away
+from). Under the actual en-AU shipping condition (B3 + bare), all four
+rolls were ≥8.
+
+**Leda dropped from picker** (PR #338 amendment): default goes Leda →
+Despina. Leda's 5–8 lottery on en-AU under B3 is the immediate trigger;
+the broader pattern (Leda below the user's ≥8 bar across multiple
+configurations) supports the broader picker decision.
+
+### Shipped
+
+- Per-locale directive routing in `directiveFor(style, locale)`:
+  WEATHER_FORECASTER on en-AU gets `GEMINI_TTS_STYLE_DIRECTIVE_WEATHER_FORECASTER_REGISTER`
+  (B2 + the explicit "standard variety, not regional dialect" sentence);
+  every other locale stays on the existing `GEMINI_TTS_STYLE_DIRECTIVE_WEATHER_FORECASTER`.
+- `ACCENT_DIRECTIVES["en-AU"]` drops "General": `"Speak with an Australian accent, not broad."`
+- All other locales unchanged from the post-#351 clarity-trimmed strings.
+- Picker amended in PR #338: Leda dropped; default voice → Despina.
+
+---
+
 ## Scripts
 
 | Script | Purpose |

--- a/scripts/eval-weather-report-style.py
+++ b/scripts/eval-weather-report-style.py
@@ -7,7 +7,8 @@ measured pace, accentuate clothing recommendations."
 Candidates move in three steps:
   A) baselines — current NORMAL and NEWSREADER directives
   B) core proposal — the user's explicit weather-report idea, with and without
-     the sentence/clothing-emphasis clause
+     the sentence/clothing-emphasis clause; B3 also adds a "standard variety,
+     not regional dialect" sentence (paired with the no-variety locales)
   C) tweaks — minor wording changes that may sharpen or soften the effect
 
 Each candidate is tested across three locales (en-US, en-AU, en-GB) using the
@@ -24,6 +25,13 @@ Usage
 
   # one candidate across all locales/voices:
   python3 scripts/eval-weather-report-style.py --filter weather-B2
+
+  # the B3 register-in-directive eval (control = post-#351 shipped pair;
+  # treatment = bare-variety accent + B3 directive):
+  python3 scripts/eval-weather-report-style.py --filter en-GB-bare-weather-B2-with-emphasis
+  python3 scripts/eval-weather-report-style.py --filter en-GB-no-variety-weather-B3
+  python3 scripts/eval-weather-report-style.py --filter en-AU-prod-weather-B2-with-emphasis
+  python3 scripts/eval-weather-report-style.py --filter en-AU-no-variety-weather-B3
 
 Output
 ------
@@ -91,10 +99,22 @@ LOCALES: dict[str, str] = {
     # in the accent clause.
     "en-GB-prod":      "Speak with a Standard British accent — clear and natural.",
     "en-GB-bare":      "Speak with a Standard British accent.",
+    # en-GB-no-variety / en-AU-no-variety / en-AU-prod: the "B3 register-in-
+    # directive" eval. Hypothesis: with the WEATHER_FORECASTER directive
+    # carrying "Use the language's standard variety, not a regional dialect."
+    # the per-locale variety descriptors ("Standard", "General") become
+    # redundant and the accent strings can drop them. Pair the bare-variety
+    # locale with the B3 directive candidate; the prod locale with B2.
+    "en-AU-prod":         "Speak with a General Australian accent, not broad.",
+    "en-AU-no-variety":   "Speak with an Australian accent, not broad.",
+    "en-GB-no-variety":   "Speak with a British accent.",
     # de-DE falls back to the language-only "de" key in the app (no explicit
     # de-DE entry in ACCENT_DIRECTIVES); de-AT has its own entry.
     "de-DE": "Sprich auf Deutsch in einem klaren, hochdeutschen Akzent.",
     "de-AT": "Sprich auf Deutsch mit einem klaren österreichischen Akzent.",
+    # de-no-variety: B3 candidate — drops "in einem hochdeutschen Akzent",
+    # relying on the directive to convey the standard register.
+    "de-no-variety":      "Sprich auf Deutsch.",
 }
 
 # ── A: baselines (current production directives) ─────────────────────────────
@@ -168,16 +188,35 @@ TWEAK_C3_WITH_PAUSES = (
     "texture:\n\n"
 )
 
+# ── B3: register-in-directive (paired with no-variety accents) ───────────────
+#
+# B3 — adds an explicit "use the language's standard variety, not a regional
+#      dialect" sentence early in the directive. Hypothesis: the per-locale
+#      variety descriptors in ACCENT_DIRECTIVES ("Standard British", "General
+#      Australian", "hochdeutsch") become redundant once the directive carries
+#      this signal, and the accent strings can collapse to just the language /
+#      regional flavour. Test against the no-variety locales above.
+
+WEATHER_B3_REGISTER_IN_DIRECTIVE = (
+    "Read the following weather forecast in the style of a weather report on a "
+    "national news service. Use the language's standard variety, not a "
+    "regional dialect. Enunciate clearly and use a measured speed. "
+    "Accentuate the ends of sentences and give a gentle emphasis to clothing "
+    "recommendations. No audio effects, background noise, or vinyl-style "
+    "texture:\n\n"
+)
+
 # ── candidate table ───────────────────────────────────────────────────────────
 
 CANDIDATES: list[tuple[str, str]] = [
-    ("baseline-A1-normal",          BASELINE_NORMAL),
-    ("baseline-A2-newsreader",      BASELINE_NEWSREADER),
-    ("weather-B1-basic",            WEATHER_B1_BASIC),
-    ("weather-B2-with-emphasis",    WEATHER_B2_WITH_EMPHASIS),
-    ("tweak-C1-authoritative",      TWEAK_C1_AUTHORITATIVE),
-    ("tweak-C2-cadence",            TWEAK_C2_CADENCE),
-    ("tweak-C3-with-pauses",        TWEAK_C3_WITH_PAUSES),
+    ("baseline-A1-normal",                  BASELINE_NORMAL),
+    ("baseline-A2-newsreader",              BASELINE_NEWSREADER),
+    ("weather-B1-basic",                    WEATHER_B1_BASIC),
+    ("weather-B2-with-emphasis",            WEATHER_B2_WITH_EMPHASIS),
+    ("weather-B3-register-in-directive",    WEATHER_B3_REGISTER_IN_DIRECTIVE),
+    ("tweak-C1-authoritative",              TWEAK_C1_AUTHORITATIVE),
+    ("tweak-C2-cadence",                    TWEAK_C2_CADENCE),
+    ("tweak-C3-with-pauses",                TWEAK_C3_WITH_PAUSES),
 ]
 
 VOICES = ["Erinome", "Kore", "Aoede", "Despina", "Iapetus", "Charon", "Leda"]


### PR DESCRIPTION
## Summary

Per-locale routing of the WEATHER_FORECASTER directive: en-AU now gets a variant with the explicit `"Use the language's standard variety, not a regional dialect."` sentence, while every other locale stays on the existing directive. Paired with dropping "General" from the en-AU accent string, this empirically rescues Iapetus on en-AU (5/10 → 9/10) without affecting other locales.

## Eval data — en-AU is the win, en-GB is the reason for per-locale routing

Run via `scripts/eval-weather-report-style.py` plus `say.py` follow-ups. Two conditions per locale:

- **B2 + with-variety** (control): post-#351 shipped (`"Speak with a General Australian accent, not broad."`)
- **B3 + bare** (treatment): directive gains the register sentence; accent drops "General"

### en-AU — clear win

| Voice | B2 + prod | B3 + bare | Δ |
|---|---|---|---|
| Aoede | 9 | 9 | 0 |
| Charon | 9 | 9 | 0 |
| Despina | 9 | 9 (re-rolls 8/8/9) | 0 |
| Erinome | 7 | 9 | +2 |
| Iapetus | **5** | 9 | **+4** |
| Kore | 6 | 8 | +2 |
| Leda | 7 | 5/7.5/8/7 | mixed |
| **avg** | 7.4 | 8.3 | +0.9 |

Iapetus 5→9 is the standout. Once PR #338's voice-picker trim lands (drops Leda, sets Despina as default), the four shipping voices land 8 / 9 / 9 / 9 on en-AU.

### en-GB — slight regression, deliberately not changed

| Voice | B2 + prod | B3 + bare | Δ |
|---|---|---|---|
| avg | 8.6 | 8.3 | −0.3 |

Numerically a mild dip, but **qualitatively worse than the numbers suggest** — voices under B3 read as "serviceable but not on-brand" for the cultivated Weather Forecaster identity. The "Standard British" qualifier was doing real work on en-GB that the directive sentence can't replace. Hence: per-locale routing rather than a global directive update.

## Negative findings (recorded in voice-evals.md)

Tested several expansions to the chosen directive on top of B3+bare to chase a slightly more newsreader feel for Despina:

| Variant added | Despina | Charon | Iapetus |
|---|---|---|---|
| `+ "engaged, articulate, professional, not theatrical"` | 8.5 | **7.5** (British "jackit") | 8.5 (a bit fast) |
| `+ "engaged…" + "unhurried, measured pace"` | 9 single roll | **5** (too regional) | 9 (still slightly fast) |
| `+ "pausing briefly between key points"` | **5** | (untested) | (untested) |

Every "more newsreader-y" expansion regressed at least one shipping voice. Single-word directive prose tweaks are at the variance ceiling.

## Despina-as-default

After Leda showed wide variance under B3+en-AU (5 / 7.5 / 8 / 7 — only 1/4 hits user's ≥8 acceptance bar), Despina was probed as default-voice replacement:

| Locale | Despina score |
|---|---|
| en-GB | 9 (multiple sessions) |
| en-AU B3 | 9 / 8 / 8 / 9 (all ≥8) |
| en-AU B2 prod | 9 / 8.5–9 / 8 / 6–7 (single outlier on the *outgoing* condition) |
| en-US | 8 |
| de | 8.5–9 |

PR #338 will be amended separately to drop Leda from the picker and set `DEFAULT_GEMINI_TTS_VOICE = "Despina"`.

## Code changes

- `GEMINI_TTS_STYLE_DIRECTIVE_WEATHER_FORECASTER_REGISTER` constant (B2 + register sentence)
- `directiveFor(style, locale)` helper — routes en-AU + WEATHER_FORECASTER to the new variant; everywhere else falls through to `styleDirectiveFor()`
- `synthesize()` now calls `directiveFor()` instead of `styleDirectiveFor()` directly
- `ACCENT_DIRECTIVES["en-AU"]` drops "General" → `"Speak with an Australian accent, not broad."`
- Tests: en-AU assertion updated; 3 new tests for locale-specific directive routing
- voice-evals.md: full B3 eval narrative + Despina-as-default rationale + negative findings

## Test plan

- [ ] CI: `JVM unit tests` (covers all the new test changes; couldn't run locally, plugin resolution blocked)
- [ ] CI: `Android debug build`
- [ ] On-device: confirm en-AU on Despina/Charon/Iapetus matches the validated eval clips at versionCode after merge
- [ ] On-device: confirm en-GB / de / other locales unchanged

## Privacy

The WEATHER_FORECASTER prompt prefix already crosses the device boundary as part of the BYOK Gemini TTS request. This change alters the prefix wording for en-AU only; no new data types leave the device. Net per-call payload is roughly +60 chars on en-AU from the new sentence, partially offset by the shorter "Australian accent" string.

## Followup PRs

- **#338** (open, draft) — needs amendment to drop Leda + set Despina as default. The "drop Leda" decision was made empirically based on this PR's data; see voice-evals.md.
- **Other locales:** B3 not generalised. de / fr / es / it / pt / Asian / RTL all stay on the existing directive. en-GB result suggests the asymmetry "weak default anchor → B3 helps; strong default anchor → B3 hurts" may not transfer cleanly. Per-locale evals as future work.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FF83vZToLynJVUMpPs7duK)_