### PR TITLE
:app + :core + docs — trim voice picker to 7, default Despina

### DIFF
--- a/app/src/main/kotlin/app/clothescast/tts/GeminiTtsSpeaker.kt
+++ b/app/src/main/kotlin/app/clothescast/tts/GeminiTtsSpeaker.kt
@@ -9,8 +9,8 @@ import java.util.Locale
  * High-quality TTS via Gemini's audio-output model. Synthesises PCM audio in one
  * network call, hands the buffer to [PcmAudioPlayer] for playback.
  *
- * Voice is configurable; defaults to `Leda` (youthful). Other prebuilt voices are
- * surfaced via the Settings voice picker.
+ * Voice is configurable; defaults to `Despina` (smooth). Other prebuilt voices
+ * are surfaced via the Settings voice picker.
  *
  * Fallback is the caller's responsibility — see [app.clothescast.work.FetchAndNotifyWorker]
  * which retries with [AndroidTtsSpeaker] when this throws.

--- a/app/src/main/kotlin/app/clothescast/tts/TtsVoices.kt
+++ b/app/src/main/kotlin/app/clothescast/tts/TtsVoices.kt
@@ -14,31 +14,28 @@ data class TtsVoiceOption(
     val displayName: String,
 )
 
-// Curated from listening tests across en-AU and en-GB. Leda is the default —
-// chosen alongside the v505-equivalent "Normal" style preamble being the
-// default style; pending a broader re-audition under Normal. Grouped by
-// character:
-//   Clear/Firm (newsreader-y): Erinome, Iapetus, Kore
-//   Informative/Knowledgeable (male alternatives): Charon, Sadaltager
-//   Gentle/Smooth/Warm: Vindemiatrix, Despina, Algieba, Sulafat
-//   Breezy/Youthful: Aoede, Leda
-// Aoede and Leda were dropped in the previous curation under the newsreader
-// directive (Aoede sounded "Alan Rickman" on en-GB+newsreader; Leda flattened
-// in newsreader register). Both come back now that the user can pick the
-// "Normal" style preamble — Leda is the originating ask. Sulafat / Algieba
-// re-added as additional warm/smooth options. Still dropped: Orus
-// (theatrical), Achird (vowel issues), Zephyr / Puck / Fenrir (theatrical /
-// excitable) — those are voice-character traits not fixed by switching style.
+// Curated from listening tests across en-GB, en-AU, en-US, and de-* under the
+// post-#353 shipping configuration (clarity-trimmed accents, B3 register-in-
+// directive routing on en-AU). Despina is the default — validated across all
+// six tested locales, four-roll en-AU B3 distribution all ≥8 (the user's
+// acceptance bar). Order: Despina (default) first, then by character cluster.
+//
+// Leda showed wide en-AU B3 4-roll variance (5 / 7.5 / 8 / 7) in eval but
+// stays in the picker on user preference — qualitatively strong on real-world
+// audio. She loses the default slot to Despina's tighter distribution but is
+// retained for users who want her character.
+//
+// Dropped from the previous 11-voice picker: Sadaltager, Vindemiatrix,
+// Algieba, Sulafat (untested under current shipping config — trimming the
+// picker to voices the eval has actually validated). Earlier drops stand:
+// Orus (theatrical), Achird (vowel issues), Zephyr / Puck / Fenrir
+// (theatrical / excitable). See docs/voice-evals.md for the data.
 val GEMINI_VOICES: List<TtsVoiceOption> = listOf(
-    TtsVoiceOption("Erinome", "Erinome — Clear"),
+    TtsVoiceOption("Despina", "Despina — Smooth"),
+    TtsVoiceOption("Charon", "Charon — Informative"),
     TtsVoiceOption("Iapetus", "Iapetus — Clear"),
     TtsVoiceOption("Kore", "Kore — Firm"),
-    TtsVoiceOption("Charon", "Charon — Informative"),
-    TtsVoiceOption("Sadaltager", "Sadaltager — Knowledgeable"),
-    TtsVoiceOption("Vindemiatrix", "Vindemiatrix — Gentle"),
-    TtsVoiceOption("Despina", "Despina — Smooth"),
-    TtsVoiceOption("Algieba", "Algieba — Smooth"),
-    TtsVoiceOption("Sulafat", "Sulafat — Warm"),
+    TtsVoiceOption("Erinome", "Erinome — Clear"),
     TtsVoiceOption("Aoede", "Aoede — Breezy"),
     TtsVoiceOption("Leda", "Leda — Youthful"),
 )

--- a/app/src/test/kotlin/app/clothescast/data/SettingsRepositoryTest.kt
+++ b/app/src/test/kotlin/app/clothescast/data/SettingsRepositoryTest.kt
@@ -293,8 +293,8 @@ class SettingsRepositoryTest {
     }
 
     @Test
-    fun `gemini voice defaults to Leda when nothing stored`() = runTest {
-        subject.preferences.first().geminiVoice shouldBe "Leda"
+    fun `gemini voice defaults to Despina when nothing stored`() = runTest {
+        subject.preferences.first().geminiVoice shouldBe "Despina"
     }
 
     @Test
@@ -512,9 +512,9 @@ class SettingsRepositoryTest {
         snap.ttsStyleDefault shouldBe TtsStyle.WEATHER_FORECASTER.name
         snap.ttsStyleOverride shouldBe SettingsAnalyticsSnapshot.UNSET
         snap.ttsStyleEffective shouldBe TtsStyle.WEATHER_FORECASTER.name
-        snap.geminiVoiceDefault shouldBe "Leda"
+        snap.geminiVoiceDefault shouldBe "Despina"
         snap.geminiVoiceOverride shouldBe SettingsAnalyticsSnapshot.UNSET
-        snap.geminiVoiceEffective shouldBe "Leda"
+        snap.geminiVoiceEffective shouldBe "Despina"
         snap.deviceVoiceDefault shouldBe SettingsAnalyticsSnapshot.AUTO
         snap.deviceVoiceOverride shouldBe SettingsAnalyticsSnapshot.UNSET
         snap.deviceVoiceEffective shouldBe SettingsAnalyticsSnapshot.AUTO

--- a/core/data/src/main/kotlin/app/clothescast/core/data/tts/GeminiTtsClient.kt
+++ b/core/data/src/main/kotlin/app/clothescast/core/data/tts/GeminiTtsClient.kt
@@ -32,10 +32,17 @@ import java.util.Locale
 // `-preview-` track — see CLAUDE.md's "Don't rename Gemini models from
 // web-search guesses" before swapping it for a GA-sounding name.
 const val DEFAULT_GEMINI_TTS_MODEL: String = "gemini-2.5-flash-preview-tts"
-// TODO: decide default voice — top candidates from style eval are Aoede,
-//  Charon, Kore (all avg 8.6 on B1+B2 combined). Current default Leda is
-//  6th overall and untested under the updated accent directives.
-const val DEFAULT_GEMINI_TTS_VOICE: String = "Leda"
+// Despina chosen via the post-#353 evals: clears the user's ≥8 bar across
+// en-GB, en-AU (B3, four rolls all ≥8), en-US, de, de-AT, de-CH. Reliable
+// rather than dazzling — it's the most consistently-acceptable voice across
+// the languages we ship. See docs/voice-evals.md → "Despina-as-default
+// decision".
+// TODO: revisit default — Erinome may actually be the winner now that the
+//  clarity-trim (#351) and B3 routing (#353) have rescued her on en-GB and
+//  en-AU. Needs a head-to-head Despina vs. Erinome eval across the same
+//  six locales (en-GB / en-AU B3 / en-US / de / de-AT / de-CH) before any
+//  switch.
+const val DEFAULT_GEMINI_TTS_VOICE: String = "Despina"
 
 internal const val GEMINI_HOST = "generativelanguage.googleapis.com"
 internal const val GEMINI_API_VERSION = "v1beta"

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Settings.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Settings.kt
@@ -311,6 +311,6 @@ data class UserPreferences(
     val telemetryNoticeAcked: Boolean = false,
 ) {
     companion object {
-        const val DEFAULT_GEMINI_VOICE = "Leda"
+        const val DEFAULT_GEMINI_VOICE = "Despina"
     }
 }

--- a/docs/voice-evals.md
+++ b/docs/voice-evals.md
@@ -265,8 +265,7 @@ locale only. Two accent variants:
 
 Tested on the Firebase APK against the trimmed
 `"Speak with a General Australian accent, not broad."` and the same B2
-directive. Just the four voices in PR #338's keep-list — single read per
-voice, no re-rolls.
+directive. Single read per voice, no re-rolls.
 
 | Voice | Trim today | Historical (B2 + "— clear and natural, not broad.") | Verdict |
 |---|---|---|---|
@@ -291,9 +290,10 @@ follow-up sniff test if we want to specifically rescue Despina-on-en-AU;
 otherwise users who want en-AU liveliness pick Charon, Iapetus, or Leda.
 
 Erinome was also tested ad hoc — flagged as flat on en-AU and as
-having an over-rhotic "sweater" on en-US. Both look like Erinome's
-phonetic anchor leaking through; PR #338 drops Erinome from the picker,
-so this isn't a shipping concern.
+having an over-rhotic "sweater" on en-US under the old prod accent.
+Both look like Erinome's phonetic anchor leaking through; the
+clarity-trim eval below rescues en-GB (2 → 8) and the B3 eval rescues
+en-AU (7 → 9), so Erinome stays in the picker after #353.
 
 ### Bonus finding: de-CH
 
@@ -359,9 +359,8 @@ Two locales tested formally; a third spot-checked.
 | **avg** | 7.4 | 8.3 | +0.9 |
 
 Iapetus 5 → 9 is the standout — lifts a near-degenerate voice into the
-shipping band. Leda showed wide variance (5 to 8) on en-AU under B3 but
-stays in the picker only via PR #338 considerations; see "Leda dropped"
-below.
+shipping band. Leda showed wide variance (5 to 8) on en-AU under B3; see
+"Leda dropped" below.
 
 ### en-GB — slight regression, off-brand
 
@@ -437,10 +436,10 @@ single outlier at 6–7 on en-AU B2 prod (the condition we're moving away
 from). Under the actual en-AU shipping condition (B3 + bare), all four
 rolls were ≥8.
 
-**Leda dropped from picker** (PR #338 amendment): default goes Leda →
-Despina. Leda's 5–8 lottery on en-AU under B3 is the immediate trigger;
-the broader pattern (Leda below the user's ≥8 bar across multiple
-configurations) supports the broader picker decision.
+**Leda dropped from picker** (see picker section below): default goes
+Leda → Despina. Leda's 5–8 lottery on en-AU under B3 is the immediate
+trigger; the broader pattern (Leda below the user's ≥8 bar across
+multiple configurations) supports the broader picker decision.
 
 ### Shipped
 
@@ -450,7 +449,80 @@ configurations) supports the broader picker decision.
   every other locale stays on the existing `GEMINI_TTS_STYLE_DIRECTIVE_WEATHER_FORECASTER`.
 - `ACCENT_DIRECTIVES["en-AU"]` drops "General": `"Speak with an Australian accent, not broad."`
 - All other locales unchanged from the post-#351 clarity-trimmed strings.
-- Picker amended in PR #338: Leda dropped; default voice → Despina.
+
+---
+
+## Picker + default (2026-05, post-#353)
+
+After the directive landscape stabilised (clarity-trim in #351, en-AU
+register routing in #353), re-evaluated the full 11-voice picker against
+the shipping configuration: the user's bar is ≥8/10 on every roll, with
+single-roll degeneracies disqualifying.
+
+### Cross-voice German spot check
+
+Three voices were probed across the German locales we ship — driven by
+the question of whether the picker needs a "weather forecaster" male
+alternative beyond Charon. Single read per cell.
+
+| Voice | de | de-AT | de-CH |
+|---|---|---|---|
+| Despina | 9 | 9 | 9 |
+| Charon | 9 | 8.5 | fine |
+| Iapetus | 9 | 8 | fine |
+
+All three clear the bar across all three German locales. Confirms
+Despina-as-default extends to German territory and gives the picker two
+shipping male alternatives (Charon + Iapetus).
+
+### Picker decision
+
+Trimmed picker from 11 voices to 7, ordered with default first then by
+character cluster:
+
+| Voice | Label | Status |
+|---|---|---|
+| **Despina** | Smooth | Default. Validated en-GB / en-AU B3 (4-roll all ≥8) / en-US / de / de-AT / de-CH |
+| Charon | Informative | Solid across locales; user's preferred male voice |
+| Iapetus | Clear | Rescued by B3 routing on en-AU (5 → 9); solid elsewhere |
+| Kore | Firm | Lifted by clarity-trim on en-GB (5 → 9); solid on B3 en-AU (8) |
+| Erinome | Clear | Rescued twice — clarity-trim on en-GB (2 → 8), B3 on en-AU (7 → 9) |
+| Aoede | Breezy | Strong consistent voice across locales |
+| Leda | Youthful | Loses default slot to Despina but kept on user preference (see note) |
+
+**Note on Leda:** the en-AU B3 4-roll variance (5 / 7.5 / 8 / 7, only
+1/4 above the ≥8 bar) put her on the drop list during this eval. She
+came back after a real-world listen on an older build where the user
+rated her qualitatively strong. The variance data is real; the user's
+preference is the spec. She loses the default slot to Despina's tighter
+distribution but stays in the picker for users who want her character.
+
+**Dropped:**
+
+- **Sadaltager, Vindemiatrix, Algieba, Sulafat** — untested under the
+  post-#351 + post-#353 shipping config. Trim-rather-than-extend approach:
+  better to ship a smaller picker of voices the eval has actually
+  validated than carry voices forward unchecked. Re-add follows a
+  sniff-test if a real use case surfaces.
+
+### Shipped
+
+- `GEMINI_VOICES` trimmed to the seven above, Despina first.
+- `DEFAULT_GEMINI_TTS_VOICE` and `UserPreferences.DEFAULT_GEMINI_VOICE`
+  → "Despina".
+- Existing user picks are persisted by id; users on any of the four
+  dropped voices keep their pick (no migration), they just won't see
+  those entries in the picker if they reset to default.
+
+### TODO: revisit default — Despina vs. Erinome head-to-head
+
+Erinome was rescued twice in this eval arc — clarity-trim on en-GB
+(2 → 8 in #351) and B3 routing on en-AU (7 → 9 in #353). She may now
+actually be the winner over Despina under the post-#353 shipping
+configuration. Needs a dedicated head-to-head across the same six
+locales we used for Despina (en-GB / en-AU B3 / en-US / de / de-AT /
+de-CH), multiple rolls per cell, before any default switch. Tracked in
+`GeminiTtsClient.kt` next to `DEFAULT_GEMINI_TTS_VOICE`.
 
 ---
 

--- a/docs/voice-evals.md
+++ b/docs/voice-evals.md
@@ -295,6 +295,14 @@ Both look like Erinome's phonetic anchor leaking through; the
 clarity-trim eval below rescues en-GB (2 → 8) and the B3 eval rescues
 en-AU (7 → 9), so Erinome stays in the picker after #353.
 
+A follow-up en-US sniff-test under the current shipping config —
+B2 directive + `"Speak with a General American accent."` (post-#351
+trim, no "clear and natural") — rated **10/10**. The over-rhotic
+"sweater" issue was a casualty of the old "clear and natural" accent
+prod string and is fixed by the trim. Erinome on en-US is now a
+strong shipping candidate (and a strong contender for default-voice;
+see the TODO at the end of this doc).
+
 ### Bonus finding: de-CH
 
 Single-voice spot check (Leda, German weather text):
@@ -517,12 +525,23 @@ distribution but stays in the picker for users who want her character.
 ### TODO: revisit default — Despina vs. Erinome head-to-head
 
 Erinome was rescued twice in this eval arc — clarity-trim on en-GB
-(2 → 8 in #351) and B3 routing on en-AU (7 → 9 in #353). She may now
-actually be the winner over Despina under the post-#353 shipping
-configuration. Needs a dedicated head-to-head across the same six
-locales we used for Despina (en-GB / en-AU B3 / en-US / de / de-AT /
-de-CH), multiple rolls per cell, before any default switch. Tracked in
-`GeminiTtsClient.kt` next to `DEFAULT_GEMINI_TTS_VOICE`.
+(2 → 8 in #351) and B3 routing on en-AU (7 → 9 in #353) — and a
+follow-up en-US sniff-test under the current shipping config rated
+**10/10**, fixing the historical over-rhotic "sweater" anchor. She
+may now actually be the winner over Despina under the post-#353
+shipping configuration. Needs a dedicated head-to-head across the
+same six locales we used for Despina (en-GB / en-AU B3 / en-US / de /
+de-AT / de-CH), multiple rolls per cell, before any default switch.
+Tracked in `GeminiTtsClient.kt` next to `DEFAULT_GEMINI_TTS_VOICE`.
+
+| Locale | Despina | Erinome |
+|---|---|---|
+| en-GB B2 prod | 9 | 8 (post-#351 bare; was 2 under old "clear and natural") |
+| en-AU B3 bare | 9 / 8 / 8 / 9 (4-roll) | 9 (single roll) |
+| en-US B2 prod | 8 | **10** (post-#351 trim, single roll) |
+| de B2 prod | 8.5–9 | untested |
+| de-AT B2 prod | 9 | untested |
+| de-CH (post-#351) | 9 | untested |
 
 ---
 


### PR DESCRIPTION
## Summary

Trim Gemini voice picker from 11 voices to 7 and switch the default from Leda → Despina. Lands the voice-side decisions from the post-#351 / post-#353 evaluation arc.

**Picker (Despina first, then by character cluster):**

| Voice | Label | Why it ships |
|---|---|---|
| **Despina** *(default)* | Smooth | Validated en-GB / en-AU B3 (4-roll all ≥8) / en-US / de / de-AT / de-CH |
| Charon | Informative | Rock-solid across locales; preferred male voice |
| Iapetus | Clear | Rescued by B3 routing on en-AU (5 → 9); solid elsewhere |
| Kore | Firm | Lifted by clarity-trim on en-GB (5 → 9); 8 on en-AU B3 |
| Erinome | Clear | Rescued twice — clarity-trim on en-GB (2 → 8), B3 on en-AU (7 → 9) |
| Aoede | Breezy | Strong consistent voice across locales |
| Leda | Youthful | Loses default slot to Despina but kept on user preference |

**Note on Leda:** the en-AU B3 4-roll variance (5 / 7.5 / 8 / 7) put her on the drop list during this eval, but a real-world listen on an older build came in qualitatively strong. The variance data is real; user preference is the spec. She loses the default slot to Despina's tighter distribution but stays in the picker for users who want her character.

**Dropped:**

- **Sadaltager / Vindemiatrix / Algieba / Sulafat** — untested under post-#351 + post-#353 shipping config. Trim-rather-than-extend; re-add follows a sniff-test if a use case surfaces.

## Follow-up TODO

Erinome was rescued twice in this arc (clarity-trim on en-GB 2 → 8, B3 on en-AU 7 → 9). She may actually be the winner over Despina now — there's a `TODO` next to `DEFAULT_GEMINI_TTS_VOICE` and a matching note in `voice-evals.md` to run a dedicated Despina-vs-Erinome head-to-head across the six tested locales before any default switch.

## Existing user picks

Persisted by id, so users on Sadaltager / Vindemiatrix / Algieba / Sulafat keep getting their voice — the API still accepts those names. They just won't see those entries in the picker if they reset to default. No migration code.

## Privacy

No change to what crosses the device boundary. Voice IDs were already sent to Gemini.

## Test plan

- [ ] CI: `JVM unit tests` job covers `:core:domain:test`, `:core:data:test`, `:app:testDebugUnitTest` (default-voice assertions in `SettingsRepositoryTest` updated).
- [ ] CI: `Android debug build` job covers `:app:assembleDebug`.
- [ ] On-device: open Settings → Voice picker shows 7 voices in the order above, Despina selected on a fresh install.
- [ ] On-device: existing user with one of the four dropped voices persisted still hears it (button reads "Voice: <id>" with no radio selected in dialog — acceptable degraded state).

🤖 Generated with [Claude Code](https://claude.ai/code)