### PR TITLE
Render TTS prose in selected voice locale

### DIFF
--- a/app/src/main/kotlin/app/clothescast/tts/InsightTtsUtterance.kt
+++ b/app/src/main/kotlin/app/clothescast/tts/InsightTtsUtterance.kt
@@ -1,0 +1,33 @@
+package app.clothescast.tts
+
+import android.content.Context
+import app.clothescast.core.domain.model.InsightSummary
+import app.clothescast.core.domain.model.Region
+import app.clothescast.core.domain.model.VoiceLocale
+import app.clothescast.insight.InsightFormatter
+import java.util.Locale
+
+internal data class InsightTtsUtterance(
+    val text: String,
+    val locale: Locale,
+)
+
+/**
+ * Render the spoken insight in the selected voice locale, not necessarily the
+ * app-display region. This keeps notifications in the UI language while a
+ * de-AT voice request speaks Austrian German text instead of English prose with
+ * an Austrian accent.
+ */
+internal fun insightTtsUtterance(
+    context: Context,
+    summary: InsightSummary,
+    region: Region,
+    voiceLocale: VoiceLocale,
+    fallbackLocale: Locale = Locale.getDefault(),
+): InsightTtsUtterance {
+    val locale = voiceLocale.resolve(region.toJavaLocale() ?: fallbackLocale)
+    return InsightTtsUtterance(
+        text = InsightFormatter.forContext(context, locale).format(summary),
+        locale = locale,
+    )
+}

--- a/app/src/main/kotlin/app/clothescast/ui/settings/VoiceSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/VoiceSettings.kt
@@ -44,17 +44,16 @@ import app.clothescast.core.domain.model.Region
 import app.clothescast.core.domain.model.TtsEngine
 import app.clothescast.core.domain.model.TtsStyle
 import app.clothescast.core.domain.model.VoiceLocale
-import app.clothescast.insight.InsightFormatter
 import app.clothescast.tts.DeviceVoice
 import app.clothescast.tts.GEMINI_VOICES
 import app.clothescast.tts.GOOGLE_TTS_PACKAGE
 import app.clothescast.tts.GeminiTtsSpeaker
 import app.clothescast.tts.TtsVoiceOption
+import app.clothescast.tts.insightTtsUtterance
 import app.clothescast.tts.resolve
 import app.clothescast.tts.toJavaLocale
 import app.clothescast.tts.withSpeechAudioFocus
 import java.text.Collator
-import java.util.Locale
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -591,7 +590,7 @@ private fun TestVoiceButton(isPreviewing: Boolean, onClick: () -> Unit) {
 
 /**
  * Plays a preview through the chosen engine + voice. Builds a fixed canned
- * [InsightSummary] and renders it through the same [InsightFormatter] the
+ * [InsightSummary] and renders it through the same TTS-utterance formatter the
  * real briefing pipeline uses, so the preview reads exactly like a real
  * morning briefing in the chosen voice locale — no separate per-locale
  * sample string to keep in sync with the prose templates. The summary is
@@ -621,12 +620,12 @@ private suspend fun runTtsPreview(
     // suspends off-Main internally, but AudioTrack.write/play are JNI calls and
     // we don't want a hot stack of preview work running on the UI dispatcher.
     withContext(Dispatchers.IO) {
-        val locale = voiceLocale.resolve(region.toJavaLocale() ?: Locale.getDefault())
-        // Render the canned sample in the *voice* locale, not the app's UI
-        // locale — playing English prose through a Japanese voice is exactly
-        // the mismatch the user picked the locale to avoid. The formatter
-        // resolves to values/strings.xml for any locale without an override.
-        val text = InsightFormatter.forContext(context, locale).format(SAMPLE_SUMMARY)
+        val utterance = insightTtsUtterance(
+            context = context,
+            summary = SAMPLE_SUMMARY,
+            region = region,
+            voiceLocale = voiceLocale,
+        )
         withSpeechAudioFocus(context) {
             try {
                 when (engine) {
@@ -635,9 +634,9 @@ private suspend fun runTtsPreview(
                             app.geminiTtsClient,
                             voiceName = geminiVoice,
                             style = ttsStyle,
-                        ).speak(text, locale)
+                        ).speak(utterance.text, utterance.locale)
                     TtsEngine.DEVICE ->
-                        app.deviceTtsSpeaker(deviceVoice).speak(text, locale)
+                        app.deviceTtsSpeaker(deviceVoice).speak(utterance.text, utterance.locale)
                 }
             } catch (_: CancellationException) {
                 // Composable scope cancelled (user navigated away mid-preview); not an error.
@@ -655,7 +654,7 @@ private suspend fun runTtsPreview(
                 // and can confirm audio output is working — mirrors FetchAndNotifyWorker.
                 if (engine != TtsEngine.DEVICE) {
                     try {
-                        app.deviceTtsSpeaker(deviceVoice).speak(text, locale)
+                        app.deviceTtsSpeaker(deviceVoice).speak(utterance.text, utterance.locale)
                     } catch (_: CancellationException) {
                         // user moved on; fine
                     } catch (fallback: Throwable) {

--- a/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
@@ -26,8 +26,8 @@ import app.clothescast.insight.InsightFormatter
 import app.clothescast.location.hasBackgroundLocationPermission
 import app.clothescast.location.hasCoarseLocationPermission
 import app.clothescast.tts.GeminiTtsSpeaker
-import app.clothescast.tts.resolve
-import app.clothescast.tts.toJavaLocale
+import app.clothescast.tts.InsightTtsUtterance
+import app.clothescast.tts.insightTtsUtterance
 import app.clothescast.tts.withSpeechAudioFocus
 import app.clothescast.widget.OutfitWidget
 import io.ktor.client.call.NoTransformationFoundException
@@ -40,7 +40,6 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import java.io.IOException
 import java.time.LocalDate
-import java.util.Locale
 import java.util.concurrent.TimeUnit
 
 /**
@@ -354,7 +353,7 @@ class FetchAndNotifyWorker(
             app.insightNotifier.notify(insight, prose)
         }
         if (includesTts) {
-            speakWithFallback(prose, prefs)
+            speakWithFallback(ttsUtterance(insight, prefs), prefs)
         }
     }
 
@@ -392,14 +391,25 @@ class FetchAndNotifyWorker(
      *    events tonight. If the evening is empty there's nothing to interrupt
      *    for, even on a TTS-enabled mode.
      */
+    // Region-language prose for notification text and the audit log. Spoken
+    // playback is rendered separately through ttsUtterance() so explicit voice
+    // locales like de-AT speak German even when the app UI remains English.
+    private fun formatProse(insight: Insight, prefs: UserPreferences): String =
+        InsightFormatter.forRegion(applicationContext, prefs.region).format(insight.summary)
+
     // TODO(brand-intro): consider prepending "Today's ClothesCast: " / "Tonight's ClothesCast: "
     // here (and mirror it in the SAMPLE_SUMMARY render used by the top-level
     // runTtsPreview function in ui/settings/VoiceSettings.kt) once the voice
     // preview's phrasing settles — the brand-name pronunciation check that the
     // per-locale settings_tts_test_sample used to give us is currently absent
     // from both the preview and the real briefing.
-    private fun formatProse(insight: Insight, prefs: UserPreferences): String =
-        InsightFormatter.forRegion(applicationContext, prefs.region).format(insight.summary)
+    private fun ttsUtterance(insight: Insight, prefs: UserPreferences): InsightTtsUtterance =
+        insightTtsUtterance(
+            context = applicationContext,
+            summary = insight.summary,
+            region = prefs.region,
+            voiceLocale = prefs.voiceLocale,
+        )
 
     private suspend fun deliverTonight(insight: Insight, prefs: UserPreferences, prose: String) {
         val mode = prefs.tonightDeliveryMode
@@ -419,7 +429,7 @@ class FetchAndNotifyWorker(
             return
         }
         if (mode == DeliveryMode.TTS_ONLY || mode == DeliveryMode.NOTIFICATION_AND_TTS) {
-            speakWithFallback(prose, prefs)
+            speakWithFallback(ttsUtterance(insight, prefs), prefs)
         }
     }
 
@@ -429,9 +439,7 @@ class FetchAndNotifyWorker(
      * something. We never let a TTS error fail the worker — the notification
      * path is the primary delivery channel and has already fired by this point.
      */
-    private suspend fun speakWithFallback(text: String, prefs: UserPreferences) {
-        val regionLocale = prefs.region.toJavaLocale() ?: Locale.getDefault()
-        val locale = prefs.voiceLocale.resolve(regionLocale)
+    private suspend fun speakWithFallback(utterance: InsightTtsUtterance, prefs: UserPreferences) {
         withSpeechAudioFocus(applicationContext) {
             when (prefs.ttsEngine) {
                 TtsEngine.GEMINI -> {
@@ -440,7 +448,7 @@ class FetchAndNotifyWorker(
                             app.geminiTtsClient,
                             voiceName = prefs.geminiVoice,
                             style = prefs.ttsStyle,
-                        ).speak(text, locale)
+                        ).speak(utterance.text, utterance.locale)
                         return@withSpeechAudioFocus
                     } catch (t: Throwable) {
                         DiagLog.w(TAG, "Gemini TTS failed; falling back to device TTS.", t)
@@ -449,7 +457,7 @@ class FetchAndNotifyWorker(
                 TtsEngine.DEVICE -> Unit
             }
             try {
-                app.deviceTtsSpeaker(prefs.deviceVoice).speak(text, locale)
+                app.deviceTtsSpeaker(prefs.deviceVoice).speak(utterance.text, utterance.locale)
             } catch (t: Throwable) {
                 DiagLog.w(TAG, "Device TTS failed; insight is still posted as notification.", t)
             }

--- a/app/src/test/kotlin/app/clothescast/tts/InsightTtsUtteranceTest.kt
+++ b/app/src/test/kotlin/app/clothescast/tts/InsightTtsUtteranceTest.kt
@@ -1,0 +1,56 @@
+package app.clothescast.tts
+
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import app.clothescast.core.domain.model.BandClause
+import app.clothescast.core.domain.model.ClothesClause
+import app.clothescast.core.domain.model.ForecastPeriod
+import app.clothescast.core.domain.model.InsightSummary
+import app.clothescast.core.domain.model.Region
+import app.clothescast.core.domain.model.TemperatureBand
+import app.clothescast.core.domain.model.VoiceLocale
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.Locale
+
+@RunWith(AndroidJUnit4::class)
+class InsightTtsUtteranceTest {
+    private val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+
+    @Test
+    fun `explicit de-AT voice locale renders German speech even when app region is English`() {
+        val utterance = insightTtsUtterance(
+            context = context,
+            summary = sampleSummary,
+            region = Region.EN_GB,
+            voiceLocale = VoiceLocale.DE_AT,
+            fallbackLocale = Locale.US,
+        )
+
+        utterance.locale.toLanguageTag() shouldBe "de-AT"
+        utterance.text shouldBe "Heute wird es kalt bis kühl. Trag Pullover und Jacke."
+    }
+
+    @Test
+    fun `system voice locale continues to follow the app region`() {
+        val utterance = insightTtsUtterance(
+            context = context,
+            summary = sampleSummary,
+            region = Region.EN_GB,
+            voiceLocale = VoiceLocale.SYSTEM,
+            fallbackLocale = Locale.US,
+        )
+
+        utterance.locale.toLanguageTag() shouldBe "en-GB"
+        utterance.text shouldBe "Today will be cold to cool. Wear a jumper and jacket."
+    }
+
+    private companion object {
+        val sampleSummary = InsightSummary(
+            period = ForecastPeriod.TODAY,
+            band = BandClause(TemperatureBand.COLD, TemperatureBand.COOL),
+            clothes = ClothesClause(listOf("sweater", "jacket")),
+        )
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Render spoken insight text in the selected voice locale instead of reusing notification prose.
- Share the TTS utterance formatter between Settings preview and the scheduled worker.
- Add regression coverage for an English app region with a de-AT voice locale.

## Privacy
- Gemini TTS now receives the same local insight rendered in the selected voice locale when it differs from the app/notification region. No new fields are included and no additional user data leaves the device.

## Validation
- `./gradlew :app:testDebugUnitTest --tests app.clothescast.tts.InsightTtsUtteranceTest --tests app.clothescast.insight.InsightFormatterTest`
- `JAVA_TOOL_OPTIONS='-Duser.language=en -Duser.country=GB' ./gradlew :core:domain:test :core:data:test :app:testDebugUnitTest`
- `JAVA_TOOL_OPTIONS='-Duser.language=en -Duser.country=GB' ./gradlew :app:assembleDebug`

Note: the unqualified JVM suite hit the documented pre-existing `SettingsViewModelTest > initial state reflects repository defaults` locale failure in this VM before passing with an explicit en-GB JVM locale.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c6f2b26d-e7f0-46f7-8f74-a9069074fc97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c6f2b26d-e7f0-46f7-8f74-a9069074fc97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

