### PR TITLE
:app — sync ForecastChart y-axis comment with MIN_Y_SPAN=4

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/today/ForecastChart.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/ForecastChart.kt
@@ -119,9 +119,9 @@ fun ForecastChart(
         }
     }
 
-    // Format y-axis labels as integers. With integer bounds and a 5-unit
+    // Format y-axis labels as integers. With integer bounds and a 4-unit
     // minimum span Vico's auto-stepper lands on sensible whole-number steps
-    // (1, 2, 5) so we don't need to override the item placer — adjacent labels
+    // (1, 2) so we don't need to override the item placer — adjacent labels
     // never collapse onto the same rounded value.
     val startFormatter = remember {
         CartesianValueFormatter { _, value, _ -> value.roundToInt().toString() }


### PR DESCRIPTION
## Summary

Comment-vs-code drift in `ForecastChart.kt`: the block above `startFormatter` claimed "a 5-unit minimum span" and listed Vico steps "(1, 2, 5)", but `MIN_Y_SPAN` is `4.0` (and the comment on the constant itself spells out why 4). With a 4-unit range Vico's auto-stepper lands on step 1 or 2, never 5, so the description was misleading the next reader. Tightened to match.

## Wider scan

Also did a wider sweep for genuine bugs / inconsistencies. Things I checked and **decided not to touch**, in case it's useful:

- `RenderInsightSummary.deltaClause`: `rounded.toInt()` direction logic looked dicey at zero, but the `abs(biggest) < 3.0` guard above already excludes any input that could round to 0.
- `TemperatureBand.forCelsius`: comment "12.0°C is COOL, 11.9°C is COLD" matches the `c < 12.0 -> COLD` code (12.0 falls through to the COOL branch).
- `GenerateDailyInsight.slicedForToday`: empty-slice branch keeping day-level aggregates is intentional and called out in the docstring (always emit *something* rather than zeros).
- `LocalBuildBanner` hardcoded English ("Local build", "Dismiss"): banner is gated on `BuildConfig.IS_LOCAL_BUILD` (only non-CI dev builds), so end users never see it — translation isn't needed.
- `TodayScreen.formatFact` `collide` guard: heuristic is conservative but well-commented and correct.
- `PairingScreen` `LaunchedEffect(Unit) { delay; onSuccess() }`: stale-closure shape is theoretically there but `onSuccess` in practice comes from a stable nav graph; not a real bug today.

## Test plan

- [ ] Comment-only change; build is unaffected. Local Gradle compile blocked by Google Maven access in this sandbox, but CI will validate.

https://claude.ai/code/session_019ZZQihLvvFQ7MaYQRUcujJ

---
_Generated by [Claude Code](https://claude.ai/code/session_019ZZQihLvvFQ7MaYQRUcujJ)_