### PR TITLE
:app — fix Today header showing "Your location" after reverse-geo timeout

### DIFF
--- a/app/src/main/kotlin/app/clothescast/location/ReverseGeocoder.kt
+++ b/app/src/main/kotlin/app/clothescast/location/ReverseGeocoder.kt
@@ -6,6 +6,7 @@ import android.location.Geocoder
 import android.os.Build
 import app.clothescast.diag.DiagLog
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
@@ -31,6 +32,8 @@ import kotlin.coroutines.resume
 class ReverseGeocoder(
     private val context: Context,
     private val timeoutMillis: Long = 5_000L,
+    private val maxAttempts: Int = 2,
+    private val retryBackoffMillis: Long = 1_000L,
 ) {
     /** Best-effort city/locality name, or null if the geocoder is unavailable
      *  / times out / returns nothing useful. */
@@ -47,12 +50,26 @@ class ReverseGeocoder(
             return null
         }
         val geocoder = Geocoder(context, Locale.getDefault())
-        val addresses = withTimeoutOrNull(timeoutMillis) { fetch(geocoder, latitude, longitude) }
-            ?: run {
-                DiagLog.w(TAG, "Reverse geocode timed out after ${timeoutMillis}ms.")
-                return null
+        // Retry only on timeout — empty results / framework `onError`
+        // resume with `emptyList()`, and a second call against the same
+        // backend with the same coords won't conjure up addresses that
+        // weren't there. Timeouts, by contrast, are routinely transient:
+        // the daily worker runs from a low-priority background dispatcher
+        // and the geocoder backend's first call after device idle can
+        // exceed [timeoutMillis] cold while a second call seconds later
+        // returns immediately.
+        repeat(maxAttempts) { attempt ->
+            val addresses = withTimeoutOrNull(timeoutMillis) { fetch(geocoder, latitude, longitude) }
+            if (addresses != null) return addresses.firstOrNull()?.toCityName()
+            val isLastAttempt = attempt == maxAttempts - 1
+            if (isLastAttempt) {
+                DiagLog.w(TAG, "Reverse geocode timed out after ${timeoutMillis}ms (final of $maxAttempts).")
+            } else {
+                DiagLog.w(TAG, "Reverse geocode timed out after ${timeoutMillis}ms; retrying (${attempt + 2}/$maxAttempts).")
+                delay(retryBackoffMillis)
             }
-        return addresses.firstOrNull()?.toCityName()
+        }
+        return null
     }
 
     private suspend fun fetch(geocoder: Geocoder, lat: Double, lon: Double): List<Address> =

--- a/app/src/main/kotlin/app/clothescast/location/ReverseGeocoder.kt
+++ b/app/src/main/kotlin/app/clothescast/location/ReverseGeocoder.kt
@@ -5,6 +5,7 @@ import android.location.Address
 import android.location.Geocoder
 import android.os.Build
 import app.clothescast.diag.DiagLog
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.suspendCancellableCoroutine
@@ -39,6 +40,12 @@ class ReverseGeocoder(
      *  / times out / returns nothing useful. */
     suspend fun resolveCityName(latitude: Double, longitude: Double): String? = try {
         resolveInner(latitude, longitude)
+    } catch (t: CancellationException) {
+        // Coroutine cancellation must propagate — otherwise a Settings
+        // toggle that cancels the cache-refresh worker mid-retry would
+        // sail through and let the caller still write a stale
+        // setLocation. The broad catch below would otherwise swallow it.
+        throw t
     } catch (t: Throwable) {
         DiagLog.w(TAG, "Unexpected ${t.javaClass.simpleName} from resolveCityName; returning null.", t)
         null

--- a/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
@@ -41,6 +41,8 @@ import kotlinx.coroutines.flow.first
 import java.io.IOException
 import java.time.LocalDate
 import java.util.concurrent.TimeUnit
+import kotlin.math.cos
+import kotlin.math.sqrt
 
 /**
  * Performs one daily fetch + insight + notify cycle. Runs in a WorkManager
@@ -304,7 +306,18 @@ class FetchAndNotifyWorker(
                 // network failure / nothing useful in the address — the UI
                 // falls back to a date-only header in that case.
                 val cityName = app.reverseGeocoder.resolveCityName(device.latitude, device.longitude)
-                val resolved = if (cityName != null) device.copy(displayName = cityName) else device
+                // When reverse-geo fails for a fix close to the previously
+                // cached one, reuse the cached friendly name rather than
+                // clobbering "London" with the placeholder. Without this
+                // a single transient geocoder timeout permanently degrades
+                // the home screen to the localised "Your location" fallback
+                // until reverse-geo next succeeds.
+                val resolved = when {
+                    cityName != null -> device.copy(displayName = cityName)
+                    else -> reuseNearbyDisplayName(prefs.location, device)
+                        ?.let { device.copy(displayName = it) }
+                        ?: device
+                }
                 // Persist the resolved fix as the fallback so the next run can
                 // use the most recent good read when the device read fails
                 // (provider blip, no fix, services briefly off). With this in
@@ -321,6 +334,31 @@ class FetchAndNotifyWorker(
             DiagLog.i(TAG, "Device location unavailable; falling back to settings location.")
         }
         return prefs.location
+    }
+
+    // Reuse the previously cached displayName when it's a real city (not
+    // blank / not the LocationResolver placeholder) and the new device fix
+    // is close enough that the cached name is still meaningful. ~25km
+    // covers a typical commute / errand radius while still rejecting
+    // yesterday's trip to a different city.
+    private fun reuseNearbyDisplayName(prior: Location?, device: Location): String? {
+        if (prior == null) return null
+        val priorName = prior.displayName
+            ?.takeUnless { it.isBlank() || it == DEVICE_LOCATION_PLACEHOLDER }
+            ?: return null
+        return if (approxDistanceKm(prior, device) < REUSE_LABEL_RADIUS_KM) priorName else null
+    }
+
+    // Equirectangular approximation. Accurate to well under a kilometre
+    // at temperate latitudes for sub-100km separations — fine for "is
+    // the cached city name still meaningful?". TODO: switch to haversine
+    // if we ever need correctness near the poles or across the
+    // antimeridian; neither applies to current users.
+    private fun approxDistanceKm(a: Location, b: Location): Double {
+        val avgLatRad = (a.latitude + b.latitude) / 2 * Math.PI / 180
+        val dLat = (a.latitude - b.latitude) * Math.PI / 180
+        val dLon = (a.longitude - b.longitude) * Math.PI / 180 * cos(avgLatRad)
+        return EARTH_RADIUS_KM * sqrt(dLat * dLat + dLon * dLon)
     }
 
     // Mirrors the providers LocationResolver itself queries — NETWORK +
@@ -492,6 +530,20 @@ class FetchAndNotifyWorker(
 
         // Cap unhandled-error detail so the "Show details" pane stays readable.
         private const val MAX_DETAIL_LEN = 240
+
+        // Must match the literal LocationResolver stamps onto every device
+        // fix; we use it to spot the "no friendly name yet" case when
+        // deciding whether the previously cached displayName is worth
+        // reusing on a reverse-geo miss.
+        private const val DEVICE_LOCATION_PLACEHOLDER = "Device location"
+
+        // Radius within which we'll reuse the previously cached city name
+        // when reverse-geo fails. ~25km is generous enough to cover a
+        // commute or weekend outing without keeping yesterday's "Paris"
+        // glued to today's "London" fix.
+        private const val REUSE_LABEL_RADIUS_KM = 25.0
+
+        private const val EARTH_RADIUS_KM = 6371.0
 
         /** Set true via [enqueueOneShot] when the user explicitly taps Refresh. */
         private const val KEY_FORCE_REFRESH = "force_refresh"


### PR DESCRIPTION
## Summary
Bug report: Today header shows the localised "Your location" instead of "London" for a London-based device. The captured `Settings → Location: 51.5856, -0.1450 — Device location` shows the persisted location's `displayName` has been clobbered by the `LocationResolver` placeholder, and `shortLocationLabel` (`TodayScreen.kt:1037`) maps that placeholder to `null` → the localised fallback fires.

Two related fixes:

1. **Don't clobber the cached city name on a reverse-geo miss.** `FetchAndNotifyWorker.resolveLocation` now reuses the previously persisted `displayName` when reverse-geo returns `null` and the new device fix is within ~25km of the cached fix. Coordinates are always updated; only the friendly name is preserved across the miss. A simple equirectangular distance approximation is fine here — TODO left for haversine if we ever care about pole / antimeridian correctness.

2. **Retry `ReverseGeocoder` once on timeout.** Weather already retries via WorkManager's `Result.retry()`; reverse-geo had a single 5s `withTimeoutOrNull` and gave up. Now: two attempts, 1s backoff, retry only on timeout (empty results / `onError` are deterministic for these coords). Worst-case extra delay ~6s, well within the worker's budget.

The two changes compose: the retry catches transient timeouts; the cache-don't-clobber covers the case where both attempts still miss.

## Test plan
- [ ] CI: JVM unit tests + Android debug build (sandbox lacks the SDK).
- [ ] Manual: with a Pixel 10 / GB locale, force-refresh on a known-good fix → Today header shows the city name.
- [ ] Manual: simulate a reverse-geo miss (e.g. airplane mode briefly during the fetch) → Today header keeps the previously cached city instead of falling back to "Your location".
- [ ] Logs: when both attempts time out, the diag ring buffer should show `Reverse geocode timed out after 5000ms; retrying (2/2)` then `Reverse geocode timed out after 5000ms (final of 2)`.

## Privacy
No change to what leaves the device — same `Geocoder` call, same Open-Meteo call. The retry just calls the same endpoint twice in the worst case.

https://claude.ai/code/session_01JxrzQcF1GxKPHMvT8FrKhK

---
_Generated by [Claude Code](https://claude.ai/code/session_01JxrzQcF1GxKPHMvT8FrKhK)_