### PR TITLE
:app — drop About's weak privacy blurb; Privacy settings is the one place

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/settings/AboutSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/AboutSettings.kt
@@ -104,16 +104,6 @@ private fun AboutCard() {
                     }
                 },
         )
-        Text(
-            text = stringResource(R.string.settings_about_privacy),
-            style = MaterialTheme.typography.bodyMedium,
-        )
-        TextButton(
-            onClick = {
-                openUrl(context, "https://github.com/mikelward/clothescast/blob/main/PRIVACY.md")
-            },
-            modifier = Modifier.fillMaxWidth(),
-        ) { Text(stringResource(R.string.settings_about_privacy_policy)) }
         TextButton(
             onClick = { openUrl(context, "https://github.com/mikelward/clothescast") },
             modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/res/values-de-rAT/strings.xml
+++ b/app/src/main/res/values-de-rAT/strings.xml
@@ -333,8 +333,6 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_about_title">Über</string>
     <string name="settings_about_version">Version %1$s (%2$d)</string>
     <string name="settings_about_build_type_suffix"> · %1$s-Build</string>
-    <string name="settings_about_privacy">Dein Gemini-API-Schlüssel (für die gesprochene Ausgabe) wird mit einem Schlüssel verschlüsselt gespeichert, der an den Android Keystore gebunden ist. Vorhersagen kommen von Open-Meteo (kein Schlüssel, kein Konto); der Text der täglichen Zusammenfassung wird lokal auf dem Gerät erzeugt. ClothesCast hat kein Backend — es wird nichts an einen Server gesendet, den wir kontrollieren.</string>
-    <string name="settings_about_privacy_policy">Datenschutzerklärung</string>
     <string name="settings_about_source">Quellcode auf GitHub</string>
     <string name="settings_about_dontkillmyapp">Hintergrund-Einschränkungen (dontkillmyapp.com)</string>
     <string name="settings_about_share_bug_report">Fehlerbericht teilen</string>

--- a/app/src/main/res/values-de-rCH/strings.xml
+++ b/app/src/main/res/values-de-rCH/strings.xml
@@ -338,8 +338,6 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_about_title">Über</string>
     <string name="settings_about_version">Version %1$s (%2$d)</string>
     <string name="settings_about_build_type_suffix"> · %1$s-Build</string>
-    <string name="settings_about_privacy">Dein Gemini-API-Schlüssel (für die gesprochene Ausgabe) wird mit einem Schlüssel verschlüsselt gespeichert, der an den Android Keystore gebunden ist. Vorhersagen kommen von Open-Meteo (kein Schlüssel, kein Konto); der Text der täglichen Zusammenfassung wird lokal auf dem Gerät erzeugt. ClothesCast hat kein Backend — es wird nichts an einen Server gesendet, den wir kontrollieren.</string>
-    <string name="settings_about_privacy_policy">Datenschutzerklärung</string>
     <string name="settings_about_source">Quellcode auf GitHub</string>
     <string name="settings_about_dontkillmyapp">Hintergrund-Einschränkungen (dontkillmyapp.com)</string>
     <string name="settings_about_share_bug_report">Fehlerbericht teilen</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -330,8 +330,6 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_about_title">Über</string>
     <string name="settings_about_version">Version %1$s (%2$d)</string>
     <string name="settings_about_build_type_suffix"> · %1$s-Build</string>
-    <string name="settings_about_privacy">Dein Gemini-API-Schlüssel (für die gesprochene Ausgabe) wird mit einem Schlüssel verschlüsselt gespeichert, der an den Android Keystore gebunden ist. Vorhersagen kommen von Open-Meteo (kein Schlüssel, kein Konto); der Text der täglichen Zusammenfassung wird lokal auf dem Gerät erzeugt. ClothesCast hat kein Backend — es wird nichts an einen Server gesendet, den wir kontrollieren.</string>
-    <string name="settings_about_privacy_policy">Datenschutzerklärung</string>
     <string name="settings_about_source">Quellcode auf GitHub</string>
     <string name="settings_about_dontkillmyapp">Hintergrund-Einschränkungen (dontkillmyapp.com)</string>
     <string name="settings_about_share_bug_report">Fehlerbericht teilen</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -377,8 +377,6 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_about_title">Σχετικά</string>
     <string name="settings_about_version">Έκδοση %1$s (%2$d)</string>
     <string name="settings_about_build_type_suffix"> · build %1$s</string>
-    <string name="settings_about_privacy">Το Gemini API key σου (που χρησιμοποιείται για την ανάγνωση φωνητικά μέσω TTS) είναι κρυπτογραφημένο σε ηρεμία με κλειδί συνδεδεμένο στο Android Keystore. Οι προβλέψεις προέρχονται από το Open-Meteo (χωρίς key, χωρίς λογαριασμό)· το κείμενο της καθημερινής σύνοψης παράγεται τοπικά στη συσκευή. Ο ClothesCast δεν έχει backend — τίποτα δεν αποστέλλεται σε διακομιστή που ελέγχουμε.</string>
-    <string name="settings_about_privacy_policy">Πολιτική απορρήτου</string>
     <string name="settings_about_source">Πηγαίος κώδικας στο GitHub</string>
     <string name="settings_about_dontkillmyapp">Περιορισμοί παρασκηνίου (dontkillmyapp.com)</string>
     <string name="settings_about_share_bug_report">Κοινοποίηση αναφοράς σφαλμάτων</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -329,8 +329,6 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_about_title">Acerca de</string>
     <string name="settings_about_version">Versión %1$s (%2$d)</string>
     <string name="settings_about_build_type_suffix"> · build %1$s</string>
-    <string name="settings_about_privacy">Tu clave API de Gemini (usada para la lectura en voz alta TTS) se cifra en reposo con una clave vinculada al Android Keystore. Los pronósticos vienen de Open-Meteo (sin clave, sin cuenta); el texto del resumen diario se genera localmente en el dispositivo. ClothesCast no tiene backend — no se envía nada a ningún servidor que controlemos.</string>
-    <string name="settings_about_privacy_policy">Política de privacidad</string>
     <string name="settings_about_source">Código fuente en GitHub</string>
     <string name="settings_about_dontkillmyapp">Restricciones en segundo plano (dontkillmyapp.com)</string>
     <string name="settings_about_share_bug_report">Compartir informe de error</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -331,8 +331,6 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_about_title">À propos</string>
     <string name="settings_about_version">Version %1$s (%2$d)</string>
     <string name="settings_about_build_type_suffix"> · build %1$s</string>
-    <string name="settings_about_privacy">Ta clé API Gemini (utilisée pour la lecture vocale TTS) est chiffrée au repos avec une clé liée à l\'Android Keystore. Les prévisions viennent d\'Open-Meteo (sans clé, sans compte) ; le texte du résumé quotidien est généré localement sur l\'appareil. ClothesCast n\'a pas de backend — rien n\'est envoyé à un serveur que nous contrôlons.</string>
-    <string name="settings_about_privacy_policy">Politique de confidentialité</string>
     <string name="settings_about_source">Code source sur GitHub</string>
     <string name="settings_about_dontkillmyapp">Restrictions en arrière-plan (dontkillmyapp.com)</string>
     <string name="settings_about_share_bug_report">Partager un rapport de bug</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -317,8 +317,6 @@ Not overridden by design:
     <string name="settings_about_title">ऐप के बारे में</string>
     <string name="settings_about_version">संस्करण %1$s (%2$d)</string>
     <string name="settings_about_build_type_suffix"> · %1$s बिल्ड</string>
-    <string name="settings_about_privacy">आपकी Gemini API कुंजी (बोलकर TTS के लिए) Android Keystore से जुड़ी कुंजी द्वारा एन्क्रिप्ट होकर स्टोर होती है। पूर्वानुमान Open-Meteo से आते हैं (कोई कुंजी नहीं, कोई खाता नहीं); दैनिक सारांश टेक्स्ट डिवाइस पर स्थानीय रूप से बनता है। ClothesCast का कोई बैकएंड नहीं है — हमारे नियंत्रण वाले किसी सर्वर को कुछ नहीं भेजा जाता।</string>
-    <string name="settings_about_privacy_policy">गोपनीयता नीति</string>
     <string name="settings_about_source">GitHub पर स्रोत कोड</string>
     <string name="settings_about_dontkillmyapp">बैकग्राउंड प्रतिबंध (dontkillmyapp.com)</string>
     <string name="settings_about_share_bug_report">बग रिपोर्ट साझा करें</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -303,8 +303,6 @@ spousal register), matching the existing insight prose ("Ponesi …",
     <string name="settings_about_title">O aplikaciji</string>
     <string name="settings_about_version">Verzija %1$s (%2$d)</string>
     <string name="settings_about_build_type_suffix"> · %1$s verzija</string>
-    <string name="settings_about_privacy">Tvoj Gemini API ključ (za glasovni TTS) šifriran je ključem vezanim uz Android Keystore. Prognoze dolaze s Open-Meteoa (bez ključa, bez računa); tekst dnevnog sažetka generira se lokalno na uređaju. ClothesCast nema backend — ništa se ne šalje ni na jedan server koji mi kontroliramo.</string>
-    <string name="settings_about_privacy_policy">Politika privatnosti</string>
     <string name="settings_about_source">Izvorni kod na GitHubu</string>
     <string name="settings_about_dontkillmyapp">Pozadinska ograničenja (dontkillmyapp.com)</string>
     <string name="settings_about_share_bug_report">Podijeli izvješće o grešci</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -321,8 +321,6 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_about_title">Informazioni</string>
     <string name="settings_about_version">Versione %1$s (%2$d)</string>
     <string name="settings_about_build_type_suffix"> · build %1$s</string>
-    <string name="settings_about_privacy">La tua chiave API Gemini (usata per la lettura vocale TTS) è cifrata a riposo con una chiave legata all\'Android Keystore. Le previsioni provengono da Open-Meteo (nessuna chiave, nessun account); il testo del riepilogo quotidiano è generato localmente sul dispositivo. ClothesCast non ha un backend — nulla viene inviato a un server controllato da noi.</string>
-    <string name="settings_about_privacy_policy">Informativa sulla privacy</string>
     <string name="settings_about_source">Codice sorgente su GitHub</string>
     <string name="settings_about_dontkillmyapp">Restrizioni in background (dontkillmyapp.com)</string>
     <string name="settings_about_share_bug_report">Condividi report di bug</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -328,8 +328,6 @@ the displayed label localizes.
     <string name="settings_about_title">アプリについて</string>
     <string name="settings_about_version">バージョン %1$s（%2$d）</string>
     <string name="settings_about_build_type_suffix"> · %1$s ビルド</string>
-    <string name="settings_about_privacy">あなたの Gemini API キー（音声読み上げ TTS で使用）は、Android Keystore に紐付いたキーで暗号化して保存されます。予報は Open-Meteo から取得しています（キー不要、アカウント不要）。毎日の要約テキストは端末でローカルに生成されます。ClothesCast にはバックエンドはなく、私たちが管理するサーバーには何も送信されません。</string>
-    <string name="settings_about_privacy_policy">プライバシーポリシー</string>
     <string name="settings_about_source">GitHub のソースコード</string>
     <string name="settings_about_dontkillmyapp">バックグラウンド制限（dontkillmyapp.com）</string>
     <string name="settings_about_share_bug_report">バグレポートを共有</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -344,8 +344,6 @@ displayed label localizes.
     <string name="settings_about_title">정보</string>
     <string name="settings_about_version">버전 %1$s (%2$d)</string>
     <string name="settings_about_build_type_suffix"> · %1$s 빌드</string>
-    <string name="settings_about_privacy">Gemini API 키(음성 읽기 TTS에 사용)는 Android Keystore에 연결된 키로 암호화되어 저장됩니다. 예보는 Open-Meteo에서 가져옵니다 (키 없음, 계정 없음). 매일 요약 텍스트는 기기에서 로컬로 생성됩니다. ClothesCast에는 백엔드가 없으며, 우리가 관리하는 어떤 서버에도 아무것도 전송되지 않아요.</string>
-    <string name="settings_about_privacy_policy">개인정보처리방침</string>
     <string name="settings_about_source">GitHub 소스 코드</string>
     <string name="settings_about_dontkillmyapp">백그라운드 제한 (dontkillmyapp.com)</string>
     <string name="settings_about_share_bug_report">버그 보고서 공유</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -332,8 +332,6 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_about_title">Sobre</string>
     <string name="settings_about_version">Versão %1$s (%2$d)</string>
     <string name="settings_about_build_type_suffix"> · build %1$s</string>
-    <string name="settings_about_privacy">Sua chave API Gemini (usada para a leitura em voz alta TTS) é criptografada em repouso com uma chave vinculada ao Android Keystore. As previsões vêm da Open-Meteo (sem chave, sem conta); o texto do resumo diário é gerado localmente no aparelho. ClothesCast não tem backend — nada é enviado para nenhum servidor que controlamos.</string>
-    <string name="settings_about_privacy_policy">Política de privacidade</string>
     <string name="settings_about_source">Código-fonte no GitHub</string>
     <string name="settings_about_dontkillmyapp">Restrições em segundo plano (dontkillmyapp.com)</string>
     <string name="settings_about_share_bug_report">Compartilhar relatório de bug</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -350,8 +350,6 @@ they diverge from BR ("Polonês" → "Polaco", "Holandês" →
     <string name="settings_about_title">Acerca</string>
     <string name="settings_about_version">Versão %1$s (%2$d)</string>
     <string name="settings_about_build_type_suffix"> · build %1$s</string>
-    <string name="settings_about_privacy">A tua chave API Gemini (utilizada para a leitura em voz alta TTS) é encriptada em repouso com uma chave associada ao Android Keystore. As previsões vêm da Open-Meteo (sem chave, sem conta); o texto do resumo diário é gerado localmente no dispositivo. O ClothesCast não tem backend — nada é enviado para nenhum servidor que controlemos.</string>
-    <string name="settings_about_privacy_policy">Política de privacidade</string>
     <string name="settings_about_source">Código-fonte no GitHub</string>
     <string name="settings_about_dontkillmyapp">Restrições em segundo plano (dontkillmyapp.com)</string>
     <string name="settings_about_share_bug_report">Partilhar relatório de erro</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -321,8 +321,6 @@ only the displayed label localizes.
     <string name="settings_about_title">О приложении</string>
     <string name="settings_about_version">Версия %1$s (%2$d)</string>
     <string name="settings_about_build_type_suffix"> · сборка %1$s</string>
-    <string name="settings_about_privacy">Твой ключ API Gemini (используемый для озвучивания TTS) зашифрован с помощью ключа, привязанного к Android Keystore. Прогнозы поступают от Open-Meteo (без ключа, без аккаунта); текст ежедневной сводки генерируется локально на устройстве. У ClothesCast нет бэкенда — ничего не отправляется ни на один сервер, который мы контролируем.</string>
-    <string name="settings_about_privacy_policy">Политика конфиденциальности</string>
     <string name="settings_about_source">Исходный код на GitHub</string>
     <string name="settings_about_dontkillmyapp">Ограничения в фоне (dontkillmyapp.com)</string>
     <string name="settings_about_share_bug_report">Поделиться отчётом об ошибке</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -322,8 +322,6 @@ label localizes.
     <string name="settings_about_title">关于</string>
     <string name="settings_about_version">版本 %1$s（%2$d）</string>
     <string name="settings_about_build_type_suffix"> · %1$s 构建</string>
-    <string name="settings_about_privacy">你的 Gemini API 密钥（用于语音朗读 TTS）会用绑定到 Android Keystore 的密钥加密存储。预报来自 Open-Meteo（无需密钥，无需账户）；每日摘要文本在设备本地生成。ClothesCast 没有后端 — 不会向我们控制的任何服务器发送数据。</string>
-    <string name="settings_about_privacy_policy">隐私政策</string>
     <string name="settings_about_source">GitHub 上的源代码</string>
     <string name="settings_about_dontkillmyapp">后台限制（dontkillmyapp.com）</string>
     <string name="settings_about_share_bug_report">分享问题报告</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -312,8 +312,6 @@ label localises.
     <string name="settings_about_title">關於</string>
     <string name="settings_about_version">版本 %1$s（%2$d）</string>
     <string name="settings_about_build_type_suffix"> · %1$s 版本</string>
-    <string name="settings_about_privacy">你的 Gemini API 金鑰（用於語音朗讀 TTS）會以繫結到 Android Keystore 的金鑰加密儲存。預報來自 Open-Meteo（不需金鑰、不需帳號）；每日摘要文字在裝置本機產生。ClothesCast 沒有後端 — 不會向我們控制的任何伺服器送出資料。</string>
-    <string name="settings_about_privacy_policy">隱私權政策</string>
     <string name="settings_about_source">GitHub 上的原始碼</string>
     <string name="settings_about_dontkillmyapp">背景限制（dontkillmyapp.com）</string>
     <string name="settings_about_share_bug_report">分享問題回報</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -541,8 +541,6 @@
          interpunct is the same separator the chart legend uses; the build-type name itself
          comes straight from BuildConfig.BUILD_TYPE and isn't translated. -->
     <string name="settings_about_build_type_suffix"> · %1$s build</string>
-    <string name="settings_about_privacy">Your Gemini API key (used for spoken-aloud TTS) is encrypted at rest using a key bound to the Android Keystore. Forecasts come from Open-Meteo (no key, no account); the daily summary text is rendered locally on-device. ClothesCast does not have a backend — nothing is sent to any server we control.</string>
-    <string name="settings_about_privacy_policy">Privacy policy</string>
     <string name="settings_about_source">Source code on GitHub</string>
     <string name="settings_about_dontkillmyapp">Background restrictions (dontkillmyapp.com)</string>
     <string name="settings_about_share_bug_report">Share bug report</string>


### PR DESCRIPTION
## Summary

The About card carried a paragraph ending **"ClothesCast does not have a backend — nothing is sent to any server we control."** Technically true (no first-party server) but glosses over Open-Meteo, Gemini TTS, and Firebase Crashlytics + Analytics — exactly the destinations users care about. Settings → Privacy already has the opt-out toggle, the hard-limits text, and a link to PRIVACY.md, so it can be the single canonical in-app surface.

Removed from About:
- the misleading paragraph (`settings_about_privacy`)
- the duplicate "Privacy policy" link button (`settings_about_privacy_policy`)

Privacy settings keeps:
- the **Send crash + usage data** switch (`PrivacySettings.kt` → `Telemetry.kt` flips Firebase collection flags)
- the description of what's sent and the explicit hard-limits list of what isn't
- a "Read full privacy policy" link to PRIVACY.md

The Today telemetry-notice banner already deep-links to Settings → Privacy, so the discovery path is unchanged.

## Privacy

No change to what data leaves the device — wording only. The opt-out for Firebase telemetry already existed; this PR removes a misleading line that contradicted it.

## Test plan

- [ ] CI: `JVM unit tests` passes (no test references the removed strings, but `:app:testDebugUnitTest` covers the resource-stripping)
- [ ] CI: `Android debug build` passes (`:app:assembleDebug` — would catch any stray `R.string.settings_about_privacy*` reference at compile time)
- [ ] Manual: Settings → About — no privacy paragraph, no "Privacy policy" button; version line, Source code, Background restrictions, Share bug report still present
- [ ] Manual: Settings → Privacy — toggle, description, hard-limits text, "Read full privacy policy" link all still render
- [ ] Manual: Today telemetry-notice banner's "Open Privacy settings" still deep-links correctly

---
_Generated by [Claude Code](https://claude.ai/code/session_01ASLdKRxpu8Up56JMXf55nu)_