### PR TITLE
:app — harden widget tap intent against Glance trampoline crash

### DIFF
--- a/app/src/main/kotlin/app/clothescast/widget/OutfitWidget.kt
+++ b/app/src/main/kotlin/app/clothescast/widget/OutfitWidget.kt
@@ -1,6 +1,8 @@
 package app.clothescast.widget
 
 import android.content.Context
+import android.content.Intent
+import android.net.Uri
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
@@ -14,10 +16,10 @@ import androidx.glance.Image
 import androidx.glance.ImageProvider
 import androidx.glance.LocalContext
 import androidx.glance.LocalSize
-import androidx.glance.action.actionStartActivity
 import androidx.glance.action.clickable
 import androidx.glance.appwidget.GlanceAppWidget
 import androidx.glance.appwidget.SizeMode
+import androidx.glance.appwidget.action.actionStartActivity
 import androidx.glance.appwidget.cornerRadius
 import androidx.glance.appwidget.provideContent
 import androidx.glance.background
@@ -83,16 +85,31 @@ class OutfitWidget : GlanceAppWidget() {
 // the minimum that doesn't cramp either side.
 private val SIDE_BY_SIDE_MIN_WIDTH = 240.dp
 
+// Glance 1.1.x's actionStartActivity<MainActivity>() crashed in the wild with
+// "List adapter activity trampoline invoked without specifying target intent"
+// — the launcher dispatches the trampoline activity with empty extras, so the
+// wrapped target Intent is missing. Constructing the Intent ourselves with
+// ACTION_MAIN + a unique data URI gives the framework a fully-specified
+// component / action / data tuple to key the PendingIntent on, which makes
+// the trampoline more resilient to launcher-side state stripping.
+private fun launchAppIntent(context: Context): Intent =
+    Intent(Intent.ACTION_MAIN)
+        .setClass(context, MainActivity::class.java)
+        .addCategory(Intent.CATEGORY_LAUNCHER)
+        .setData(Uri.parse("clothescast://widget/open"))
+        .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+
 @Composable
 private fun OutfitWidgetContent(insight: Insight?) {
     val size = LocalSize.current
+    val context = LocalContext.current
     val outfit = insight?.outfit
     Box(
         modifier = GlanceModifier
             .fillMaxSize()
             .background(GlanceTheme.colors.widgetBackground)
             .cornerRadius(16.dp)
-            .clickable(actionStartActivity<MainActivity>())
+            .clickable(actionStartActivity(launchAppIntent(context)))
             .padding(4.dp),
         contentAlignment = Alignment.Center,
     ) {
@@ -101,7 +118,6 @@ private fun OutfitWidgetContent(insight: Insight?) {
         } else if (size.width >= SIDE_BY_SIDE_MIN_WIDTH && insight.nextOutfit != null) {
             SideBySideContent(insight, size)
         } else {
-            val context = LocalContext.current
             SingleColumnContent(
                 label = context.getString(periodLabelRes(insight.period)),
                 outfit = outfit,


### PR DESCRIPTION
## Summary

Crashlytics surfaced `java.lang.IllegalArgumentException: List adapter activity trampoline invoked without specifying target intent` thrown from `androidx.glance.appwidget.action.ActionTrampolineKt.launchTrampolineAction` when the user taps the home-screen `OutfitWidget`.

The exception is `requireNotNull` on `intent.getParcelableExtra<Intent>(ActionIntentKey)` inside Glance's trampoline activity. We don't call that activity directly — Glance wraps `actionStartActivity<MainActivity>()` in a trampoline `PendingIntent`. The wrapped target Intent is supposed to ride along as `ActionIntentKey`, but in the wild the launcher sometimes invokes the trampoline with empty extras (stale RemoteViews after process death / app update / launcher cache reuse). When that happens the trampoline crashes before our `MainActivity` ever launches.

Glance 1.1.x has no fixed-version that addresses this, and 1.2.x would force a `compileSdk 36` / AGP 8.9 lift (per the existing pin comment in `libs.versions.toml`), so the fix is on our side: build the Intent ourselves and hand `actionStartActivity` an Intent with every component set.

The new `launchAppIntent(context)` helper sets:
- explicit `setClass(context, MainActivity::class.java)`
- `Intent.ACTION_MAIN` + `Intent.CATEGORY_LAUNCHER`
- `FLAG_ACTIVITY_NEW_TASK or FLAG_ACTIVITY_CLEAR_TOP`
- a stable `clothescast://widget/open` data URI

The unique component+action+data tuple is what `PendingIntent.getActivity` uses for equality, so the framework keys the trampoline `PendingIntent` more strongly and the launcher is less likely to merge / drop our extras. It also matches Google's documented "ensure all components (package, class, data, extras) are correctly set" recommendation for `actionStartActivity` in Glance widgets.

Switched the import from `androidx.glance.action.actionStartActivity` (the generic `<T : Activity>` overload) to `androidx.glance.appwidget.action.actionStartActivity` (the `Intent` overload).

## Test plan

- [ ] CI: `JVM unit tests` passes
- [ ] CI: `Android debug build` assembles
- [ ] Manual (post-merge APK): tap the home-screen widget, confirm `MainActivity` launches and no Crashlytics report fires
- [ ] Manual: rebind the widget after an app update, tap it, confirm same

## Privacy

No change to what leaves the device. The widget tap still opens our own `MainActivity` — the new data URI (`clothescast://widget/open`) is a synthetic key on an explicit-component intent, no `intent-filter` declares it and nothing outside the app can match.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PkqSYnn27HyyQVynkRCtBM)_