### PR TITLE
:app — soft-fail Compose startup when Configuration.fontWeightAdjustment is missing

### DIFF
--- a/app/src/main/kotlin/app/clothescast/MainActivity.kt
+++ b/app/src/main/kotlin/app/clothescast/MainActivity.kt
@@ -103,7 +103,10 @@ class MainActivity : ComponentActivity() {
             // field unconditionally on API 31+, so setContent throws here
             // before any composable runs. Fall back to a native View so the
             // user sees an explanation instead of a force-close, and record
-            // a non-fatal so we can track incidence.
+            // a non-fatal so we can track incidence. Other NoSuchFieldErrors
+            // (an unrelated library or framework field mismatch) re-throw so
+            // we still notice them as fatals in Crashlytics.
+            if (e.message?.contains("fontWeightAdjustment") != true) throw e
             handleComposeStartupCrash(e)
         }
     }

--- a/app/src/main/kotlin/app/clothescast/MainActivity.kt
+++ b/app/src/main/kotlin/app/clothescast/MainActivity.kt
@@ -5,6 +5,8 @@ import android.content.Context
 import android.content.Intent
 import android.os.Build
 import android.os.Bundle
+import android.view.Gravity
+import android.widget.TextView
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.setContent
@@ -40,6 +42,8 @@ import app.clothescast.ui.theme.ClothesCastTheme
 import app.clothescast.ui.today.TodayScreen
 import app.clothescast.ui.today.TodayViewModel
 import app.clothescast.work.FetchAndNotifyWorker
+import com.google.firebase.FirebaseApp
+import com.google.firebase.crashlytics.FirebaseCrashlytics
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.runBlocking
@@ -73,24 +77,55 @@ class MainActivity : ComponentActivity() {
         val initialThemeMode = runBlocking {
             app.settingsRepository.preferences.first().themeMode
         }
-        setContent {
-            val themeMode by app.settingsRepository.preferences
-                .map { it.themeMode }
-                .collectAsStateWithLifecycle(initialValue = initialThemeMode)
-            val darkTheme = when (themeMode) {
-                ThemeMode.SYSTEM -> isSystemInDarkTheme()
-                ThemeMode.LIGHT -> false
-                ThemeMode.DARK -> true
+        try {
+            setContent {
+                val themeMode by app.settingsRepository.preferences
+                    .map { it.themeMode }
+                    .collectAsStateWithLifecycle(initialValue = initialThemeMode)
+                val darkTheme = when (themeMode) {
+                    ThemeMode.SYSTEM -> isSystemInDarkTheme()
+                    ThemeMode.LIGHT -> false
+                    ThemeMode.DARK -> true
+                }
+                ClothesCastTheme(darkTheme = darkTheme) {
+                    Surface(
+                        modifier = Modifier.fillMaxSize(),
+                        color = MaterialTheme.colorScheme.background,
+                    ) {
+                        ClothesCastNav(app, navigateToTodayVersion)
+                    }
+                }
             }
-            ClothesCastTheme(darkTheme = darkTheme) {
-                Surface(
-                    modifier = Modifier.fillMaxSize(),
-                    color = MaterialTheme.colorScheme.background,
-                ) {
-                    ClothesCastNav(app, navigateToTodayVersion)
+        } catch (e: NoSuchFieldError) {
+            // Some OEM-modified Android 12+ ROMs ship a stripped framework.jar
+            // without Configuration.fontWeightAdjustment, even though they
+            // report API 31+. AndroidComposeView's constructor reads that
+            // field unconditionally on API 31+, so setContent throws here
+            // before any composable runs. Fall back to a native View so the
+            // user sees an explanation instead of a force-close, and record
+            // a non-fatal so we can track incidence.
+            handleComposeStartupCrash(e)
+        }
+    }
+
+    private fun handleComposeStartupCrash(error: NoSuchFieldError) {
+        runCatching {
+            if (FirebaseApp.getApps(this).isNotEmpty()) {
+                FirebaseCrashlytics.getInstance().apply {
+                    setCustomKey("compose_startup_unsupported", true)
+                    recordException(error)
                 }
             }
         }
+        val padding = (24 * resources.displayMetrics.density).toInt()
+        setContentView(
+            TextView(this).apply {
+                setPadding(padding, padding, padding, padding)
+                gravity = Gravity.CENTER
+                textSize = 16f
+                text = getString(R.string.error_device_incompatible)
+            },
+        )
     }
 
     override fun onNewIntent(intent: Intent) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,6 +2,13 @@
 <resources>
     <string name="app_name">ClothesCast</string>
 
+    <!-- Shown in place of the Compose UI when the device's framework.jar is
+         missing Configuration.fontWeightAdjustment (some OEM-modified
+         Android 12+ ROMs ship without it). The app can\'t start under
+         those conditions; this screen replaces a force-close with a
+         readable explanation. -->
+    <string name="error_device_incompatible">ClothesCast can\'t run on this device — your Android build is missing a feature the app\'s UI requires (Configuration.fontWeightAdjustment, expected on Android 12 and up). Please contact your device manufacturer for a system update.</string>
+
     <string name="today_title">Today</string>
     <string name="today_open_settings">Open Settings</string>
     <string name="today_more_options">More options</string>


### PR DESCRIPTION
## Summary

Recovers from the Crashlytics `il7p0` crash where `setContent` throws
`NoSuchFieldError: No instance field fontWeightAdjustment of type I in class
Landroid/content/res/Configuration;` on launch.

Root cause: some OEM-modified Android 12+ ROMs ship a stripped
`framework.jar` without `Configuration.fontWeightAdjustment` even though
they report `Build.VERSION.SDK_INT >= 31`. `AndroidComposeView`'s
constructor reads that field unconditionally on API 31+
(`createFontFamilyResolver` → `AndroidFontResolveInterceptor` →
`FontWeightAdjustmentHelperApi31.fontWeightAdjustment`), so the very first
`setContent` call throws synchronously before any composable runs. There
is no Compose-level workaround — the crash is unrecoverable inside the
composition. The only thing we can do is detect and present a graceful
fallback at the activity boundary.

This change:

- Wraps `setContent` in a `NoSuchFieldError` catch in `MainActivity.onCreate`.
- On catch, falls back to a native `TextView` with a clear "this device's
  Android build is missing a required feature, contact your device
  manufacturer" message — replaces a force-close with a readable screen.
- Records the original error as a Crashlytics non-fatal with custom key
  `compose_startup_unsupported = true` so we can track incidence and
  see if it ever recurs on a different device population.
- Adds the message as `error_device_incompatible` in the default
  `strings.xml` only — translation can follow if this proves to affect
  more than a long-tail handful of devices.

## Privacy

Only data crossing the device boundary is the crash report itself
(if Telemetry is enabled): a `NoSuchFieldError` stack trace and a single
boolean custom key (`compose_startup_unsupported`). No PII, no user
content. Within the contract in `PRIVACY.md`.

## Test plan

- [ ] CI: `JVM unit tests` (snapshot suite) green — change is additive,
      shouldn't affect any existing behaviour on devices that have the
      field.
- [ ] CI: `Android debug build` green — only new APIs touched are
      `TextView` / `Gravity` / `FirebaseCrashlytics`, all already on the
      classpath.
- [ ] Real-device validation only possible on the affected ROM family —
      relying on Crashlytics to report whether `il7p0` recurs as a
      non-fatal `compose_startup_unsupported = true` after the next
      release.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CFKmUF2wdzmZxTBgboScKo)_