### PR TITLE
:app — disable Firebase below minSdk to silence dashboard noise from zombie installs

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -105,7 +105,10 @@ android {
 
     defaultConfig {
         applicationId = "app.clothescast"
-        minSdk = 31
+        // Sourced from the version catalog so the same number drives both the
+        // install-time gate (this line) and BuildConfig.MIN_SDK_VERSION below
+        // — see the catalog entry for why the runtime guard exists.
+        minSdk = libs.versions.minSdk.get().toInt()
         targetSdk = 35
         versionCode = gitCommitCount
         // semver build metadata: <base>+<commitCount>.<shortSha>. Some downstream
@@ -131,6 +134,11 @@ android {
         buildConfigField("String", "GIT_SHA", "\"$gitShortSha\"")
         buildConfigField("boolean", "GIT_DIRTY", gitDirty.toString())
         buildConfigField("long", "BUILD_TIMESTAMP_MS", "${buildTimestampMs}L")
+        // Mirror of `minSdk` above. The Telemetry controller reads this to
+        // silence Firebase when SDK_INT < MIN_SDK_VERSION so APKs that
+        // somehow land on sub-minSdk devices don't pollute Crashlytics /
+        // Analytics with a config the app was never built for.
+        buildConfigField("int", "MIN_SDK_VERSION", libs.versions.minSdk.get())
     }
 
     signingConfigs {

--- a/app/src/main/kotlin/app/clothescast/diag/Telemetry.kt
+++ b/app/src/main/kotlin/app/clothescast/diag/Telemetry.kt
@@ -1,6 +1,8 @@
 package app.clothescast.diag
 
 import android.content.Context
+import android.os.Build
+import app.clothescast.BuildConfig
 import app.clothescast.data.SettingsRepository
 import com.google.firebase.FirebaseApp
 import com.google.firebase.analytics.FirebaseAnalytics
@@ -47,6 +49,20 @@ object Telemetry {
         if (FirebaseApp.getApps(context).isEmpty()) return
         val analytics = FirebaseAnalytics.getInstance(context)
         val crashlytics = FirebaseCrashlytics.getInstance()
+        // Firebase has shown the app crashing on a OnePlus 8 Pro reporting
+        // Android 11 (API 30) against a minSdk=31 APK — the OS package
+        // manager normally enforces minSdk at install time, but Test Lab
+        // elevated installs and some sideload paths can bypass that. The
+        // resulting Crashlytics / Analytics traffic is from a config the app
+        // was never built for, so silence both SDKs synchronously here
+        // (before the collectors below race a startup crash) and skip the
+        // user-preference subscription entirely — the persisted disable
+        // survives across launches.
+        if (Build.VERSION.SDK_INT < BuildConfig.MIN_SDK_VERSION) {
+            analytics.setAnalyticsCollectionEnabled(false)
+            crashlytics.setCrashlyticsCollectionEnabled(false)
+            return
+        }
         scope.launch {
             settings.preferences
                 .map { it.telemetryEnabled }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,15 @@
 [versions]
 agp = "8.7.3"
 kotlin = "2.0.21"
+# Android API floor. Single source of truth: `app/build.gradle.kts` reads this
+# for `minSdk` and re-emits it as `BuildConfig.MIN_SDK_VERSION` so the runtime
+# can defend against APKs landing on devices below the floor. The OS package
+# manager normally enforces this at install time, but Firebase has shown the
+# app crashing on a OnePlus 8 Pro reporting Android 11 (API 30 — see PR #369)
+# against this minSdk=31 APK. Whatever install path produced that, the
+# resulting Crashlytics noise is from a configuration we never built for, so
+# Telemetry silences Firebase when SDK_INT < MIN_SDK_VERSION.
+minSdk = "31"
 ksp = "2.0.21-1.0.27"
 coreKtx = "1.15.0"
 lifecycle = "2.8.7"


### PR DESCRIPTION
## Summary

Stops Firebase Analytics + Crashlytics from reporting on devices below `minSdk`. Complements PR #369 (which catches the `Configuration.fontWeightAdjustment` Compose-startup crash at the activity boundary): #369 handles the *user-facing* crash on the OnePlus 8 Pro reporting Android 11 (API 30); this PR handles the *dashboard noise* from that same device population.

Why both: an APK landing on a device below `minSdk` is a configuration the app was never built for. The OS package manager normally enforces `minSdk` at install time, but Test Lab's elevated install path and some sideload flows can bypass that gate. Once installed, the resulting crash reports and analytics events aren't actionable signal — they're a config we don't support — so they shouldn't be polluting Crashlytics.

## Change

- `gradle/libs.versions.toml`: introduce `minSdk = "31"` as the single source of truth (previously hardcoded in `app/build.gradle.kts`).
- `app/build.gradle.kts`: read the catalog entry for both `minSdk` and a new `BuildConfig.MIN_SDK_VERSION` int field, so the runtime can defend against the gate having been bypassed.
- `app/src/main/kotlin/app/clothescast/diag/Telemetry.kt`: when `Build.VERSION.SDK_INT < BuildConfig.MIN_SDK_VERSION`, call `setAnalyticsCollectionEnabled(false)` and `setCrashlyticsCollectionEnabled(false)` synchronously and skip the user-preference collectors. Both flags persist across launches, so subsequent launches stop reporting without the guard needing to win a race against the startup crash.

The guard runs early in `Application.onCreate`, before any Activity attaches and before Compose's API-31-only code path runs. One in-flight crash may still be reported the first time the disable lands on a device (Crashlytics's uncaught-exception handler is auto-installed by `FirebaseInitProvider` before `Application.onCreate`), but everything after that is suppressed.

## Privacy

Strictly *reduces* what leaves the device — sub-minSdk installs stop transmitting crash reports and analytics events. Within the PRIVACY.md contract; no new data crosses the boundary.

## Test plan

- [ ] CI: `JVM unit tests` green — change is additive to `Telemetry.start` plus a new BuildConfig field.
- [ ] CI: `Android debug build` green — `BuildConfig.MIN_SDK_VERSION` is a standard `int` field.
- [ ] Real-device validation only possible on the affected device population — relying on Crashlytics's `os_version` filter to confirm the Android 11 traffic stops after this lands.

---
Generated by [Claude Code](https://claude.ai/code/session_0135haS7RHf8jACEw4HyVFbp)

---
_Generated by [Claude Code](https://claude.ai/code/session_0135haS7RHf8jACEw4HyVFbp)_