### PR TITLE
Play Store changelog uses just the commit subject

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -560,10 +560,12 @@ jobs:
 
       - name: Prepare Play release notes
         # Play Console accepts per-locale "what's new" files in a directory,
-        # each capped at 500 chars. Write the head-commit subject + build
-        # metadata into whatsnew-en-US so internal testers see what changed.
-        # Skipped when the Play secret isn't set, so a fresh repo / fork still
-        # finishes CI without this step.
+        # each capped at 500 chars. Write *just* the commit-subject line into
+        # whatsnew-en-US — no body, no build/SHA tail — since this string
+        # ships verbatim to end users as the Play Store changelog. AGENTS.md
+        # "Commit messages" spells out the subject-line discipline that
+        # makes this safe. Skipped when the Play secret isn't set, so a
+        # fresh repo / fork still finishes CI without this step.
         if: |
           success() &&
           (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
@@ -575,7 +577,6 @@ jobs:
           # shell script. Empty on workflow_dispatch (no head_commit payload);
           # the script below falls back to `git log` in that case.
           COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
-          RUN_NUMBER: ${{ github.run_number }}
           COMMIT_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
@@ -584,10 +585,7 @@ jobs:
           if [ -z "$subject" ]; then
             subject=$(git log -1 --pretty=%s "$COMMIT_SHA")
           fi
-          {
-            printf '%s\n\n' "$subject"
-            printf 'Build %s · %s\n' "$RUN_NUMBER" "${COMMIT_SHA:0:7}"
-          } | head -c 500 > "$RUNNER_TEMP/whatsnew/whatsnew-en-US"
+          printf '%s\n' "$subject" | head -c 500 > "$RUNNER_TEMP/whatsnew/whatsnew-en-US"
 
       - name: Upload AAB to Play Store internal track
         # Push-to-main (or manual workflow_dispatch on main) only; skipped

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,9 +41,18 @@ new rule the first time something bites you, not the third.
   don't need confirmation. Do still confirm before anything destructive on
   shared / merged branches: force-pushing `main`, dropping commits already
   on `main`, rewriting another author's branch.
-- **Commit message style:** scope prefix, em-dash, lowercase imperative —
-  e.g. `:app + :core — glanceable outfit-preview icons on Today screen`.
-  Match the existing `git log` style, don't invent a new one.
+
+## Commit messages
+
+- **The subject line ships verbatim to the Play Store changelog** (CI writes
+  it to `whatsnew-en-US`, which becomes the "What's new" blurb internal
+  testers and, eventually, production users see). Treat it as end-user
+  copy: sentence case, no jargon, no scope prefix, ≤ ~80 chars.
+  e.g. `Bigger outfit icons on the Today screen`, not `:app + :core —
+  glanceable outfit-preview icons on Today screen`. Move scope, module
+  names, and engineering detail (file paths, refactor reasoning, "fixes
+  #123") into the commit body — reviewers see the body on the PR, but
+  the Play release notes don't.
 
 ## GitHub
 


### PR DESCRIPTION
## Summary

Make the Play Store "What's new" blurb read like end-user copy instead of an engineer's commit subject + `Build N · SHA` tail.

- **AGENTS.md** — new **Commit messages** section. The subject line ships verbatim to Play, so it must be end-user friendly (sentence case, no jargon, no scope prefix, ≤ ~80 chars). Scope / module / engineering detail belongs in the commit body, where reviewers see it on the PR but Play release notes don't. Replaces the old "Commit message style" bullet, whose example (`:app + :core — glanceable outfit-preview icons`) was exactly the kind of engineer-speak we don't want shipping to testers.
- **`.github/workflows/ci.yml`** — `Prepare Play release notes` step now writes only the first line of the commit subject into `whatsnew-en-US`. The body was already stripped (`head -n1`); this drops the trailing `Build <run> · <sha>` line too, so the file is just the subject.

Note: the task mentioned `android-ci.yml`, but the actual workflow file is `.github/workflows/ci.yml` — that's where the `whatsnew-en-US` step lives, so that's what got edited.

## Test plan

- [ ] Eyeball the next push-to-`main` run: `Prepare Play release notes` should produce a `whatsnew-en-US` containing only the subject line.
- [ ] Confirm the Play Console internal-track "What's new" matches the new format on the next release.
- [ ] Firebase App Distribution release notes are untouched and still include the `Build N · SHA` footer (intentional — that's an internal channel).


---
_Generated by [Claude Code](https://claude.ai/code/session_014jnqRXbZkn6U4Zojoju7K9)_