### PR TITLE
Capture why the forecast confidence indicator is sometimes blank

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ClothesCastApplication.kt
+++ b/app/src/main/kotlin/app/clothescast/ClothesCastApplication.kt
@@ -6,6 +6,7 @@ import app.clothescast.alarm.DailyAlarmScheduler
 import app.clothescast.calendar.CalendarContractEventReader
 import app.clothescast.core.data.location.OpenMeteoGeocodingClient
 import app.clothescast.core.data.tts.GeminiTtsClient
+import app.clothescast.core.data.weather.ConfidenceFetchLogger
 import app.clothescast.core.data.weather.OpenMeteoClient
 import app.clothescast.core.domain.model.ForecastPeriod
 import app.clothescast.core.domain.repository.CalendarEventReader
@@ -84,7 +85,14 @@ class ClothesCastApplication : Application() {
         }
     }
 
-    val weatherRepository: WeatherRepository by lazy { OpenMeteoClient(httpClient) }
+    val weatherRepository: WeatherRepository by lazy {
+        OpenMeteoClient(
+            httpClient = httpClient,
+            confidenceLogger = ConfidenceFetchLogger { message, throwable ->
+                DiagLog.w("ConfidenceFetcher", message, throwable)
+            },
+        )
+    }
     val geocodingClient: OpenMeteoGeocodingClient by lazy { OpenMeteoGeocodingClient(httpClient) }
 
     val generateDailyInsight: GenerateDailyInsight by lazy {

--- a/core/data/src/main/kotlin/app/clothescast/core/data/weather/ConfidenceFetchLogger.kt
+++ b/core/data/src/main/kotlin/app/clothescast/core/data/weather/ConfidenceFetchLogger.kt
@@ -11,7 +11,10 @@ package app.clothescast.core.data.weather
  * code wire in their own.
  */
 fun interface ConfidenceFetchLogger {
-    fun log(message: String, throwable: Throwable? = null)
+    fun log(message: String, throwable: Throwable?)
 }
+
+/** No-throwable convenience for the common case. */
+internal fun ConfidenceFetchLogger.log(message: String) = log(message, null)
 
 internal val NoOpConfidenceFetchLogger = ConfidenceFetchLogger { _, _ -> }

--- a/core/data/src/main/kotlin/app/clothescast/core/data/weather/ConfidenceFetchLogger.kt
+++ b/core/data/src/main/kotlin/app/clothescast/core/data/weather/ConfidenceFetchLogger.kt
@@ -1,0 +1,17 @@
+package app.clothescast.core.data.weather
+
+/**
+ * Lightweight diagnostic seam for the multi-model confidence fetch path. The fetcher
+ * is best-effort and historically swallowed every failure as `null`, which made the
+ * Today screen's confidence chip silently disappear without surfacing why. This hook
+ * lets `:app` wire the drop / fail reasons to logcat without `:core:data` taking an
+ * Android dependency.
+ *
+ * The default implementation is [NoOpConfidenceFetchLogger]; tests and production
+ * code wire in their own.
+ */
+fun interface ConfidenceFetchLogger {
+    fun log(message: String, throwable: Throwable? = null)
+}
+
+internal val NoOpConfidenceFetchLogger = ConfidenceFetchLogger { _, _ -> }

--- a/core/data/src/main/kotlin/app/clothescast/core/data/weather/MultiModelConfidenceFetcher.kt
+++ b/core/data/src/main/kotlin/app/clothescast/core/data/weather/MultiModelConfidenceFetcher.kt
@@ -32,11 +32,14 @@ import kotlinx.serialization.json.jsonPrimitive
  * Best-effort: any failure (network, parse error) falls through to null. Per-model
  * failures (server returns nulls or omits a model's fields) drop just that model;
  * we still return a [ConfidenceInfo] as long as at least two models reported
- * usable values.
+ * usable values. Every drop and every failure is reported through [logger] so the
+ * caller can surface why the chip didn't render — historically this path swallowed
+ * its reasons silently.
  */
 internal class MultiModelConfidenceFetcher(
     private val httpClient: HttpClient,
     private val models: List<String> = DEFAULT_MODELS,
+    private val logger: ConfidenceFetchLogger = NoOpConfidenceFetchLogger,
 ) {
     suspend fun fetch(location: Location): ConfidenceInfo? = try {
         val daily: JsonObject = httpClient.get {
@@ -53,20 +56,44 @@ internal class MultiModelConfidenceFetcher(
             parameter("models", models.joinToString(","))
         }.body<ConfidenceResponse>().daily
 
-        val results = models.mapNotNull { model -> readModel(daily, model)?.let { model to it } }
-        if (results.size < 2) null else compute(results)
+        val results = buildList {
+            for (model in models) {
+                when (val outcome = readModel(daily, model)) {
+                    is ReadOutcome.Usable -> add(model to outcome.values)
+                    is ReadOutcome.Dropped ->
+                        logger.log("model $model dropped: ${outcome.reason}")
+                }
+            }
+        }
+        if (results.size < 2) {
+            logger.log(
+                "only ${results.size} of ${models.size} models reported usable values; " +
+                    "returning null",
+            )
+            null
+        } else {
+            compute(results)
+        }
     } catch (ce: CancellationException) {
         throw ce
-    } catch (_: Throwable) {
+    } catch (t: Throwable) {
+        logger.log("confidence fetch failed", t)
         null
     }
 
-    private fun readModel(daily: JsonObject, model: String): ModelDailyValues? {
+    private fun readModel(daily: JsonObject, model: String): ReadOutcome {
         val tempMax = firstNumber(daily["apparent_temperature_max_$model"])?.toDouble()
-            ?: return null
         val precipMax = firstNumber(daily["precipitation_probability_max_$model"])?.toDouble()
-            ?: return null
-        return ModelDailyValues(tempMax, precipMax)
+        return when {
+            tempMax == null && precipMax == null ->
+                ReadOutcome.Dropped("both apparent_temperature_max and precipitation_probability_max missing or null")
+            tempMax == null ->
+                ReadOutcome.Dropped("apparent_temperature_max missing or null")
+            precipMax == null ->
+                ReadOutcome.Dropped("precipitation_probability_max missing or null")
+            else ->
+                ReadOutcome.Usable(ModelDailyValues(tempMax, precipMax))
+        }
     }
 
     private fun firstNumber(element: JsonElement?): Number? {
@@ -99,6 +126,11 @@ internal class MultiModelConfidenceFetcher(
     }
 
     private data class ModelDailyValues(val tempMaxC: Double, val precipMaxPp: Double)
+
+    private sealed class ReadOutcome {
+        data class Usable(val values: ModelDailyValues) : ReadOutcome()
+        data class Dropped(val reason: String) : ReadOutcome()
+    }
 
     companion object {
         // Three models with global coverage so the spread is meaningful regardless of

--- a/core/data/src/main/kotlin/app/clothescast/core/data/weather/OpenMeteoClient.kt
+++ b/core/data/src/main/kotlin/app/clothescast/core/data/weather/OpenMeteoClient.kt
@@ -41,12 +41,15 @@ internal const val OPEN_METEO_HOST = "api.open-meteo.com"
  * forecast calls in parallel. Same best-effort policy: confidence is null when the
  * extra calls fail.
  */
-class OpenMeteoClient(private val httpClient: HttpClient) : WeatherRepository {
+class OpenMeteoClient(
+    private val httpClient: HttpClient,
+    confidenceLogger: ConfidenceFetchLogger = NoOpConfidenceFetchLogger,
+) : WeatherRepository {
 
     // Constructed once per client. Exposing it on the public constructor would
     // leak the internal type; if we ever need a test seam, add an internal-only
     // secondary constructor instead.
-    private val confidenceFetcher = MultiModelConfidenceFetcher(httpClient)
+    private val confidenceFetcher = MultiModelConfidenceFetcher(httpClient, logger = confidenceLogger)
 
     override suspend fun fetchForecast(location: Location): ForecastBundle = coroutineScope {
         // Primary forecast and the side-band fetches all kick off in parallel — confidence

--- a/core/data/src/test/kotlin/app/clothescast/core/data/weather/MultiModelConfidenceFetcherTest.kt
+++ b/core/data/src/test/kotlin/app/clothescast/core/data/weather/MultiModelConfidenceFetcherTest.kt
@@ -7,6 +7,7 @@ import io.kotest.matchers.doubles.plusOrMinus
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
@@ -24,10 +25,20 @@ import org.junit.jupiter.api.Test
 class MultiModelConfidenceFetcherTest {
     private val london = Location(latitude = 51.5074, longitude = -0.1278, displayName = "London")
 
+    private data class LogEntry(val message: String, val throwable: Throwable?)
+
+    private class CapturingLogger : ConfidenceFetchLogger {
+        val entries = mutableListOf<LogEntry>()
+        override fun log(message: String, throwable: Throwable?) {
+            entries += LogEntry(message, throwable)
+        }
+    }
+
     private fun fetcherWith(
         body: String,
         status: HttpStatusCode = HttpStatusCode.OK,
         capture: ((HttpRequestData) -> Unit)? = null,
+        logger: ConfidenceFetchLogger? = null,
     ): MultiModelConfidenceFetcher {
         val engine = MockEngine { request ->
             capture?.invoke(request)
@@ -42,7 +53,11 @@ class MultiModelConfidenceFetcherTest {
                 json(Json { ignoreUnknownKeys = true })
             }
         }
-        return MultiModelConfidenceFetcher(client)
+        return if (logger != null) {
+            MultiModelConfidenceFetcher(client, logger = logger)
+        } else {
+            MultiModelConfidenceFetcher(client)
+        }
     }
 
     @Test
@@ -104,6 +119,51 @@ class MultiModelConfidenceFetcherTest {
         val info = fetcherWith(ONE_MODEL_NULL_VALUES).fetch(london).shouldNotBeNull()
 
         info.modelsConsulted shouldContainExactlyInAnyOrder listOf("gfs_seamless", "icon_seamless")
+    }
+
+    @Test
+    fun `dropping a model logs which fields were missing`() = runTest {
+        val logger = CapturingLogger()
+        fetcherWith(ONE_MODEL_NULL_VALUES, logger = logger).fetch(london)
+
+        val message = logger.entries.singleOrNull { "ecmwf_ifs04" in it.message }
+            .shouldNotBeNull()
+            .message
+        message shouldContain "dropped"
+        message shouldContain "apparent_temperature_max"
+        message shouldContain "precipitation_probability_max"
+    }
+
+    @Test
+    fun `returning null because too few models reported logs the ratio`() = runTest {
+        val logger = CapturingLogger()
+        fetcherWith(TWO_MODELS_OMITTED, logger = logger).fetch(london).shouldBeNull()
+
+        val giveUp = logger.entries.lastOrNull().shouldNotBeNull()
+        giveUp.message shouldContain "1 of 3"
+        giveUp.message shouldContain "returning null"
+    }
+
+    @Test
+    fun `request failure logs the exception`() = runTest {
+        val logger = CapturingLogger()
+        fetcherWith(
+            body = "boom",
+            status = HttpStatusCode.InternalServerError,
+            logger = logger,
+        ).fetch(london).shouldBeNull()
+
+        val entry = logger.entries.singleOrNull { it.throwable != null }.shouldNotBeNull()
+        entry.message shouldContain "confidence fetch failed"
+        entry.throwable.shouldNotBeNull()
+    }
+
+    @Test
+    fun `successful fetch logs nothing`() = runTest {
+        val logger = CapturingLogger()
+        fetcherWith(THREE_MODEL_AGREEMENT, logger = logger).fetch(london).shouldNotBeNull()
+
+        logger.entries shouldBe emptyList()
     }
 
     companion object {


### PR DESCRIPTION
## Summary

The cross-model confidence path in `:core:data` silently returned `null` on every failure (`catch (_: Throwable) { null }`), and `readModel` dropped each model on the first missing field without recording which one. So when the confidence chip never appears on Today, there's no breadcrumb explaining why — network error, model rename upstream, partial daily response, all land in the same hole.

This PR adds a `ConfidenceFetchLogger` `fun interface` in `:core:data` (no-op by default to keep the module pure Kotlin) wired from `:app` to `DiagLog`, so the reason a model was dropped — and the throwable that killed the request — lands in logcat *and* the bug-report ring buffer.

Behavior is unchanged: `ForecastBundle.confidence` still nulls on any failure. Drop reasons are itemized per model so the next time the chip is missing we can tell *which* model bailed and *why*.

## Why

Conversation context: the user noticed they've never seen the `ConfidenceChip` despite the code being wired. Most likely culprit is silent failure inside `MultiModelConfidenceFetcher.fetch`. This PR makes that failure mode visible without changing the user-visible contract; the follow-up PR (stacked on top) actually visualizes per-model divergence on the forecast charts and surfaces a callout at the top of Today.

## Test plan

- [ ] CI green on `JVM unit tests` (new test cases in `MultiModelConfidenceFetcherTest`)
- [ ] CI green on `Android debug build` (no API changes affecting `:app`)
- [ ] Manual: trigger an insight cycle on device; if the chip is missing, check `DiagLog`/logcat for a `ConfidenceFetcher` warning naming the failed model or request error.

## Privacy

No new data crosses the device boundary. Logger writes to `DiagLog`, which only leaves the device if the user manually generates a bug report.

This is **PR 1 of 2** stacked on the same branch — PR 2 will rebase on top of `main` once this lands. Diagnostic-only; no UI change.

https://claude.ai/code/session_01RiLFGDXGtXB2jGqrmwRiPE

---
_Generated by [Claude Code](https://claude.ai/code/session_01RiLFGDXGtXB2jGqrmwRiPE)_