### PR TITLE
Cache the weather forecast for an hour

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ClothesCastApplication.kt
+++ b/app/src/main/kotlin/app/clothescast/ClothesCastApplication.kt
@@ -10,6 +10,7 @@ import app.clothescast.core.data.tts.GeminiTtsClient
 import app.clothescast.core.data.weather.ConfidenceFetchLogger
 import app.clothescast.core.data.weather.OpenMeteoClient
 import app.clothescast.core.domain.model.ForecastPeriod
+import app.clothescast.core.domain.repository.CachingWeatherRepository
 import app.clothescast.core.domain.repository.CalendarEventReader
 import app.clothescast.core.domain.repository.WeatherRepository
 import app.clothescast.core.domain.usecase.GenerateDailyInsight
@@ -96,12 +97,19 @@ class ClothesCastApplication : Application() {
     private val apiCallLogger: ApiCallLogger by lazy { TelemetryApiCallLogger(this) }
 
     val weatherRepository: WeatherRepository by lazy {
-        OpenMeteoClient(
-            httpClient = httpClient,
-            confidenceLogger = ConfidenceFetchLogger { message, throwable ->
-                DiagLog.w("ConfidenceFetcher", message, throwable)
-            },
-            apiCallLogger = apiCallLogger,
+        // Wrap the network client in a 1 h in-memory cache so a manual
+        // refresh on the Today screen — or back-to-back worker fires — reuse
+        // a fresh forecast instead of re-hitting Open-Meteo each time. The
+        // cache keys on location rounded to ~1 km, so small GPS jitter still
+        // hits and a real move (different suburb / city) misses.
+        CachingWeatherRepository(
+            delegate = OpenMeteoClient(
+                httpClient = httpClient,
+                confidenceLogger = ConfidenceFetchLogger { message, throwable ->
+                    DiagLog.w("ConfidenceFetcher", message, throwable)
+                },
+                apiCallLogger = apiCallLogger,
+            ),
         )
     }
     val geocodingClient: OpenMeteoGeocodingClient by lazy {

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/repository/CachingWeatherRepository.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/repository/CachingWeatherRepository.kt
@@ -1,0 +1,84 @@
+package app.clothescast.core.domain.repository
+
+import app.clothescast.core.domain.model.Location
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.LocalDate
+import kotlin.math.roundToLong
+
+/**
+ * Decorates a [WeatherRepository] with a single-entry in-memory cache so that
+ * manual refreshes (and other near-simultaneous fetches) don't hammer the
+ * Open-Meteo endpoint. Open-Meteo's grid is several km and the forecast it
+ * returns doesn't materially change within an hour, so a 1 h TTL is plenty
+ * fresh for the Today screen and the daily insight worker.
+ *
+ * Cache key is the [Location] rounded to [locationGridDegrees] in each
+ * dimension — at the default 0.01° (~1 km at the equator), GPS jitter and
+ * walking around the same neighbourhood reuse the cached forecast, while a
+ * real move (different suburb, a drive across town) misses and triggers a
+ * fresh fetch. No separate location TTL is needed; staleness in the lat/lon
+ * sense falls out of the rounded key.
+ *
+ * Errors from the delegate propagate; the cache is only written on success.
+ *
+ * TODO: alerts ride along with the cached bundle, so a severe warning that
+ * Open-Meteo issues mid-TTL is invisible to the worker until the next
+ * miss. Acceptable for now (the alerts feed is best-effort and the worker
+ * runs at least twice a day) but if alert latency starts mattering, give
+ * alerts a shorter TTL or split them out of `WeatherRepository.fetchForecast`
+ * onto their own method so the caching decorator can leave them alone.
+ */
+class CachingWeatherRepository(
+    private val delegate: WeatherRepository,
+    // Default to the device's local zone so the date-rollover check below
+    // compares against the same wall-clock day the user — and the insight
+    // worker, which stamps `Insight.forDate` from the device's local date —
+    // is looking at.
+    private val clock: Clock = Clock.systemDefaultZone(),
+    private val ttl: Duration = Duration.ofHours(1),
+    private val locationGridDegrees: Double = 0.01,
+) : WeatherRepository {
+
+    private data class Entry(
+        val key: LocationKey,
+        val fetchedAt: Instant,
+        val bundle: ForecastBundle,
+    )
+
+    private data class LocationKey(val latBucket: Long, val lonBucket: Long)
+
+    private val mutex = Mutex()
+    private var entry: Entry? = null
+
+    override suspend fun fetchForecast(location: Location): ForecastBundle = mutex.withLock {
+        val key = keyOf(location)
+        val now = clock.instant()
+        val today = LocalDate.now(clock)
+        val cached = entry
+        // Date check uses `isBefore` rather than `==` because Open-Meteo
+        // returns dates in the forecast location's local zone (timezone=auto).
+        // When the device zone is east of the location's zone, the cached
+        // bundle's today.date can sit one day ahead of the device's local
+        // date without being stale — only invalidate when it lags behind.
+        if (
+            cached != null &&
+            cached.key == key &&
+            !cached.bundle.today.date.isBefore(today) &&
+            Duration.between(cached.fetchedAt, now) < ttl
+        ) {
+            return@withLock cached.bundle
+        }
+        val fresh = delegate.fetchForecast(location)
+        entry = Entry(key = key, fetchedAt = now, bundle = fresh)
+        fresh
+    }
+
+    private fun keyOf(location: Location): LocationKey = LocationKey(
+        latBucket = (location.latitude / locationGridDegrees).roundToLong(),
+        lonBucket = (location.longitude / locationGridDegrees).roundToLong(),
+    )
+}

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/repository/CachingWeatherRepositoryTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/repository/CachingWeatherRepositoryTest.kt
@@ -1,0 +1,185 @@
+package app.clothescast.core.domain.repository
+
+import app.clothescast.core.domain.model.DailyForecast
+import app.clothescast.core.domain.model.Location
+import app.clothescast.core.domain.model.WeatherCondition
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import java.io.IOException
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneOffset
+import java.util.concurrent.atomic.AtomicInteger
+
+class CachingWeatherRepositoryTest {
+
+    private val london = Location(latitude = 51.5074, longitude = -0.1278, displayName = "London")
+
+    private val today = DailyForecast(
+        date = LocalDate.of(2026, 4, 25),
+        temperatureMinC = 8.0,
+        temperatureMaxC = 25.0,
+        feelsLikeMinC = 6.0,
+        feelsLikeMaxC = 25.0,
+        precipitationProbabilityMaxPct = 60.0,
+        precipitationMmTotal = 4.5,
+        condition = WeatherCondition.RAIN,
+    )
+
+    private val yesterday = today.copy(
+        date = LocalDate.of(2026, 4, 24),
+        feelsLikeMaxC = 17.0,
+    )
+
+    private fun bundle() = ForecastBundle(today = today, yesterday = yesterday)
+
+    private class CountingRepository(
+        private val response: () -> ForecastBundle = { throw AssertionError("not stubbed") },
+    ) : WeatherRepository {
+        val callCount = AtomicInteger(0)
+        var lastLocation: Location? = null
+            private set
+
+        override suspend fun fetchForecast(location: Location): ForecastBundle {
+            callCount.incrementAndGet()
+            lastLocation = location
+            return response()
+        }
+    }
+
+    private class MutableClock(initial: Instant) : Clock() {
+        private var now: Instant = initial
+        fun advance(duration: Duration) {
+            now = now.plus(duration)
+        }
+        override fun instant(): Instant = now
+        override fun getZone() = ZoneOffset.UTC
+        override fun withZone(zone: java.time.ZoneId): Clock = this
+    }
+
+    @Test
+    fun `first call hits the delegate`() = runTest {
+        val delegate = CountingRepository(response = ::bundle)
+        val subject = CachingWeatherRepository(
+            delegate = delegate,
+            clock = Clock.fixed(Instant.parse("2026-04-25T07:00:00Z"), ZoneOffset.UTC),
+        )
+
+        subject.fetchForecast(london)
+
+        delegate.callCount.get() shouldBe 1
+        delegate.lastLocation shouldBe london
+    }
+
+    @Test
+    fun `second call within TTL returns cached bundle without hitting the delegate`() = runTest {
+        val delegate = CountingRepository(response = ::bundle)
+        val clock = MutableClock(Instant.parse("2026-04-25T07:00:00Z"))
+        val subject = CachingWeatherRepository(delegate, clock = clock)
+
+        val first = subject.fetchForecast(london)
+        clock.advance(Duration.ofMinutes(59))
+        val second = subject.fetchForecast(london)
+
+        delegate.callCount.get() shouldBe 1
+        second shouldBe first
+    }
+
+    @Test
+    fun `call after TTL refetches`() = runTest {
+        val delegate = CountingRepository(response = ::bundle)
+        val clock = MutableClock(Instant.parse("2026-04-25T07:00:00Z"))
+        val subject = CachingWeatherRepository(delegate, clock = clock)
+
+        subject.fetchForecast(london)
+        clock.advance(Duration.ofMinutes(61))
+        subject.fetchForecast(london)
+
+        delegate.callCount.get() shouldBe 2
+    }
+
+    @Test
+    fun `tiny location jitter still hits cache`() = runTest {
+        val delegate = CountingRepository(response = ::bundle)
+        val clock = MutableClock(Instant.parse("2026-04-25T07:00:00Z"))
+        val subject = CachingWeatherRepository(delegate, clock = clock)
+
+        subject.fetchForecast(london)
+        // ~10 m of lat/lon noise — same grid cell at the default 0.01° precision.
+        subject.fetchForecast(london.copy(latitude = london.latitude + 0.0001))
+
+        delegate.callCount.get() shouldBe 1
+    }
+
+    @Test
+    fun `large location move misses cache`() = runTest {
+        val delegate = CountingRepository(response = ::bundle)
+        val clock = MutableClock(Instant.parse("2026-04-25T07:00:00Z"))
+        val subject = CachingWeatherRepository(delegate, clock = clock)
+
+        subject.fetchForecast(london)
+        val paris = Location(latitude = 48.8566, longitude = 2.3522, displayName = "Paris")
+        subject.fetchForecast(paris)
+
+        delegate.callCount.get() shouldBe 2
+    }
+
+    @Test
+    fun `bundle dated ahead of the device's local date still hits cache`() = runTest {
+        // When the forecast location is east of the device (Open-Meteo returns
+        // dates in the location's local zone via timezone=auto), the bundle's
+        // today.date can legitimately be a day ahead of the device's local date.
+        // The cache must not treat that as stale.
+        val aheadBundle = ForecastBundle(
+            today = today.copy(date = LocalDate.of(2026, 4, 26)),
+            yesterday = today.copy(date = LocalDate.of(2026, 4, 25)),
+        )
+        val delegate = CountingRepository(response = { aheadBundle })
+        val clock = MutableClock(Instant.parse("2026-04-25T13:00:00Z"))
+        val subject = CachingWeatherRepository(delegate, clock = clock)
+
+        subject.fetchForecast(london)
+        clock.advance(Duration.ofMinutes(5))
+        subject.fetchForecast(london)
+
+        delegate.callCount.get() shouldBe 1
+    }
+
+    @Test
+    fun `cache invalidated when local date rolls over even within TTL`() = runTest {
+        val delegate = CountingRepository(response = ::bundle)
+        // Fixture bundle's today.date = 2026-04-25. Start the clock at
+        // 23:55 on the same UTC day so LocalDate.now(clock) matches.
+        val clock = MutableClock(Instant.parse("2026-04-25T23:55:00Z"))
+        val subject = CachingWeatherRepository(delegate, clock = clock)
+
+        subject.fetchForecast(london)
+        // 15 minutes later: still inside the 1 h TTL, but the UTC date has
+        // rolled over to 2026-04-26 while the cached bundle's today.date
+        // still says 2026-04-25 — must refetch.
+        clock.advance(Duration.ofMinutes(15))
+        subject.fetchForecast(london)
+
+        delegate.callCount.get() shouldBe 2
+    }
+
+    @Test
+    fun `delegate errors propagate and the cache stays empty`() = runTest {
+        val delegate = CountingRepository(response = { throw IOException("boom") })
+        val clock = MutableClock(Instant.parse("2026-04-25T07:00:00Z"))
+        val subject = CachingWeatherRepository(delegate, clock = clock)
+
+        shouldThrow<IOException> { subject.fetchForecast(london) }
+
+        // A retry that succeeds should populate the cache normally.
+        val good = CountingRepository(response = ::bundle)
+        val retry = CachingWeatherRepository(good, clock = clock)
+        retry.fetchForecast(london)
+        retry.fetchForecast(london)
+        good.callCount.get() shouldBe 1
+    }
+}


### PR DESCRIPTION
## Summary

Wrap `OpenMeteoClient` in a single-entry in-memory cache with a 1 h TTL so a manual refresh on the Today screen — or back-to-back worker fires — reuses a fresh forecast instead of re-hitting Open-Meteo every time.

- New `CachingWeatherRepository` decorator in `:core:domain` (pure Kotlin, JVM-testable). Implements `WeatherRepository`, delegates to the underlying impl, caches the resulting `ForecastBundle`.
- TTL is `java.time.Duration.ofHours(1)` against an injectable `java.time.Clock` (same convention as `DailyAlarmScheduler`).
- Cache key is the `Location` rounded to a `0.01°` grid (~1 km at the equator) — GPS jitter and walking around the same neighbourhood hit the cache; a real move (different suburb / city) misses and refetches. No separate location TTL needed.
- Errors propagate; the cache is only written on success.
- Wired into `ClothesCastApplication` by wrapping the existing `OpenMeteoClient`.

## Behaviour on manual refresh

The Worker still passes `force=true` for manual refreshes; that flag continues to bypass the *insight* cache (so the prose / outfit regenerate), but it now hits the new *weather* cache and skips the network when fresh — which is the user-facing intent.

## Privacy

No change to what crosses the device boundary. This shrinks the number of Open-Meteo requests we send; nothing new is sent.

## Test plan

- [ ] CI: `JVM unit tests` passes (new `CachingWeatherRepositoryTest` covers TTL hit, TTL expiry, jitter-still-hits, large-move-misses, and error-propagation paths)
- [ ] CI: `Android debug build` passes
- [ ] Local: tests not run in this sandbox — no Android SDK and Google Maven unreachable from agent env, so even `:core:domain:test` can't run through the root build. CI is the validation surface.

https://claude.ai/code/session_01Kr58bgrXwezgUvAgV3D6hh

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kr58bgrXwezgUvAgV3D6hh)_