### PR TITLE
Show each model's air-temperature forecast on the charts too

### DIFF
--- a/app/src/main/kotlin/app/clothescast/data/InsightCache.kt
+++ b/app/src/main/kotlin/app/clothescast/data/InsightCache.kt
@@ -168,12 +168,15 @@ class InsightCache(
         val temperatureC: Double? = null,
         val precipitationProbabilityPct: Double,
     ) {
-        fun toDomain(): PerModelHour? = PerModelHour(
-            time = LocalTime.ofSecondOfDay(secondOfDay.toLong()),
-            apparentTemperatureC = apparentTemperatureC,
-            temperatureC = temperatureC ?: return null,
-            precipitationProbabilityPct = precipitationProbabilityPct,
-        )
+        fun toDomain(): PerModelHour? {
+            val airTemp = temperatureC ?: return null
+            return PerModelHour(
+                time = LocalTime.ofSecondOfDay(secondOfDay.toLong()),
+                apparentTemperatureC = apparentTemperatureC,
+                temperatureC = airTemp,
+                precipitationProbabilityPct = precipitationProbabilityPct,
+            )
+        }
     }
 
     @Serializable

--- a/app/src/main/kotlin/app/clothescast/data/InsightCache.kt
+++ b/app/src/main/kotlin/app/clothescast/data/InsightCache.kt
@@ -142,20 +142,36 @@ class InsightCache(
     private data class PerModelHourlyDto(
         val byModel: Map<String, List<PerModelHourDto>>,
     ) {
-        fun toDomain(): PerModelHourly = PerModelHourly(
-            byModel = byModel.mapValues { (_, hours) -> hours.map { it.toDomain() } },
-        )
+        // Returns null when any entry on any model lacks [PerModelHourDto.temperatureC]
+        // — i.e., the cached payload was written by a version that only carried
+        // apparent temperature. Dropping the whole overlay (rather than backfilling
+        // a placeholder 0°C) means the air-temp model lines simply hide until the
+        // next worker refresh repopulates the cache; the alternative would draw a
+        // glaringly-wrong flat-0 line.
+        fun toDomain(): PerModelHourly? {
+            val out = LinkedHashMap<String, List<PerModelHour>>(byModel.size)
+            for ((model, hours) in byModel) {
+                val converted = ArrayList<PerModelHour>(hours.size)
+                for (dto in hours) converted += dto.toDomain() ?: return null
+                out[model] = converted
+            }
+            return PerModelHourly(byModel = out)
+        }
     }
 
     @Serializable
     private data class PerModelHourDto(
         val secondOfDay: Int,
         val apparentTemperatureC: Double,
+        // Nullable for backwards compat: pre-temperatureC cache payloads omit it,
+        // and we surface that as "no overlay" rather than a fake 0°C line.
+        val temperatureC: Double? = null,
         val precipitationProbabilityPct: Double,
     ) {
-        fun toDomain(): PerModelHour = PerModelHour(
+        fun toDomain(): PerModelHour? = PerModelHour(
             time = LocalTime.ofSecondOfDay(secondOfDay.toLong()),
             apparentTemperatureC = apparentTemperatureC,
+            temperatureC = temperatureC ?: return null,
             precipitationProbabilityPct = precipitationProbabilityPct,
         )
     }
@@ -359,6 +375,7 @@ class InsightCache(
     private fun PerModelHour.toDto(): PerModelHourDto = PerModelHourDto(
         secondOfDay = time.toSecondOfDay(),
         apparentTemperatureC = apparentTemperatureC,
+        temperatureC = temperatureC,
         precipitationProbabilityPct = precipitationProbabilityPct,
     )
 

--- a/app/src/main/kotlin/app/clothescast/ui/today/ForecastChart.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/ForecastChart.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import app.clothescast.core.domain.model.HourlyForecast
+import app.clothescast.core.domain.model.PerModelHour
 import app.clothescast.core.domain.model.PerModelHourly
 import app.clothescast.core.domain.model.TemperatureUnit
 import app.clothescast.core.domain.model.toUnit
@@ -90,16 +91,23 @@ fun ForecastChart(
     showFeelsLike: Boolean,
     modifier: Modifier = Modifier,
     // Optional per-model overlays — passed by the caller when the user has
-    // the "Show model spread" Display setting on. Apparent-temperature only;
-    // we suppress the overlays in air-temperature mode so the visible model
-    // lines stay semantically aligned with the main line.
+    // the "Show model spread" Display setting on. Drawn against whichever
+    // series the parent has the toggle on for: apparent-temperature when
+    // [showFeelsLike], raw 2 m air otherwise. The per-model entries carry
+    // both, so the overlay stays semantically aligned with the main line in
+    // either mode.
     perModelHourly: PerModelHourly? = null,
 ) {
     if (hourly.isEmpty()) return
 
-    val overlays = perModelHourly?.takeIf { showFeelsLike }?.byModel.orEmpty()
+    val overlays = perModelHourly?.byModel.orEmpty()
     val visibleModels = MODEL_DRAW_ORDER.filter { it in overlays }
     val mainLineColor = MaterialTheme.colorScheme.primary
+
+    val pickModel: (PerModelHour) -> Double =
+        if (showFeelsLike) { e -> e.apparentTemperatureC } else { e -> e.temperatureC }
+    val pickHourly: (HourlyForecast) -> Double =
+        if (showFeelsLike) { h -> h.feelsLikeC } else { h -> h.temperatureC }
 
     val producer = remember { CartesianChartModelProducer() }
     LaunchedEffect(hourly, temperatureUnit, showFeelsLike, overlays) {
@@ -110,12 +118,10 @@ fun ForecastChart(
                 // is stable across recompositions.
                 visibleModels.forEach { modelId ->
                     overlays.getValue(modelId).let { entries ->
-                        series(entries.map { it.apparentTemperatureC.toUnit(temperatureUnit) })
+                        series(entries.map { pickModel(it).toUnit(temperatureUnit) })
                     }
                 }
-                val pick: (HourlyForecast) -> Double =
-                    if (showFeelsLike) { h -> h.feelsLikeC } else { h -> h.temperatureC }
-                series(hourly.map { pick(it).toUnit(temperatureUnit) })
+                series(hourly.map { pickHourly(it).toUnit(temperatureUnit) })
             }
         }
     }
@@ -143,7 +149,12 @@ fun ForecastChart(
             listOf(it.feelsLikeC.toUnit(temperatureUnit), it.temperatureC.toUnit(temperatureUnit))
         }
         val extras = overlays.values.flatMap { entries ->
-            entries.map { it.apparentTemperatureC.toUnit(temperatureUnit) }
+            entries.flatMap {
+                listOf(
+                    it.apparentTemperatureC.toUnit(temperatureUnit),
+                    it.temperatureC.toUnit(temperatureUnit),
+                )
+            }
         }
         val all = main + extras
         val rawMin = floor(all.min())

--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayPreviews.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayPreviews.kt
@@ -631,6 +631,7 @@ private val SAMPLE_PER_MODEL_HOURLY: PerModelHourly = run {
         PerModelHour(
             time = h.time,
             apparentTemperatureC = h.feelsLikeC + deltaC,
+            temperatureC = h.temperatureC + deltaC,
             precipitationProbabilityPct = (h.precipitationProbabilityPct + precipDelta)
                 .coerceIn(0.0, 100.0),
         )

--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
@@ -1057,11 +1057,12 @@ private fun ForecastCard(
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
-            // Per-model overlay legend — only meaningful when the overlays are
-            // actually being drawn (apparent-temperature mode + setting on +
-            // overlays available). Hidden in air mode so it doesn't suggest
-            // the lines visible on screen are per-model when they aren't.
-            if (perModelHourly != null && showFeelsLike) {
+            // Per-model overlay legend — drawn whenever the overlays themselves
+            // are. The chart now draws per-model lines in both apparent and air
+            // modes (each entry carries both temperatures), so the legend
+            // applies regardless of which series the card is currently
+            // showing.
+            if (perModelHourly != null) {
                 ModelSpreadLegend(perModelHourly)
             }
         }

--- a/app/src/test/kotlin/app/clothescast/data/InsightCacheTest.kt
+++ b/app/src/test/kotlin/app/clothescast/data/InsightCacheTest.kt
@@ -77,12 +77,12 @@ class InsightCacheTest {
         perModelHourly = PerModelHourly(
             byModel = mapOf(
                 "ecmwf_ifs04" to listOf(
-                    PerModelHour(LocalTime.of(0, 0), 12.0, 10.0),
-                    PerModelHour(LocalTime.of(1, 0), 11.5, 15.0),
+                    PerModelHour(LocalTime.of(0, 0), 12.0, 14.0, 10.0),
+                    PerModelHour(LocalTime.of(1, 0), 11.5, 13.5, 15.0),
                 ),
                 "gfs_seamless" to listOf(
-                    PerModelHour(LocalTime.of(0, 0), 12.2, 12.0),
-                    PerModelHour(LocalTime.of(1, 0), 11.8, 18.0),
+                    PerModelHour(LocalTime.of(0, 0), 12.2, 14.2, 12.0),
+                    PerModelHour(LocalTime.of(1, 0), 11.8, 13.8, 18.0),
                 ),
             ),
         ),

--- a/core/data/src/main/kotlin/app/clothescast/core/data/weather/MultiModelConfidenceFetcher.kt
+++ b/core/data/src/main/kotlin/app/clothescast/core/data/weather/MultiModelConfidenceFetcher.kt
@@ -72,7 +72,7 @@ internal class MultiModelConfidenceFetcher(
                 parameter("forecast_days", 1)
                 parameter("timezone", "auto")
                 parameter("daily", "apparent_temperature_max,precipitation_probability_max")
-                parameter("hourly", "apparent_temperature,precipitation_probability")
+                parameter("hourly", "apparent_temperature,temperature_2m,precipitation_probability")
                 parameter("models", models.joinToString(","))
             }.body<MultiModelResponse>()
         }
@@ -112,15 +112,17 @@ internal class MultiModelConfidenceFetcher(
         val times = (obj["time"] as? JsonArray) ?: return null
         val byModel = buildMap<String, List<PerModelHour>> {
             for (model in models) {
-                val temps = obj["apparent_temperature_$model"] as? JsonArray
+                val apparentTemps = obj["apparent_temperature_$model"] as? JsonArray
+                val airTemps = obj["temperature_2m_$model"] as? JsonArray
                 val precips = obj["precipitation_probability_$model"] as? JsonArray
-                if (temps == null && precips == null) continue
+                if (apparentTemps == null && airTemps == null && precips == null) continue
                 val entries = buildList {
                     for (i in 0 until times.size) {
                         val time = parseHour(times.getOrNull(i)) ?: continue
-                        val temp = numberAt(temps, i)?.toDouble() ?: continue
+                        val apparent = numberAt(apparentTemps, i)?.toDouble() ?: continue
+                        val air = numberAt(airTemps, i)?.toDouble() ?: continue
                         val precip = numberAt(precips, i)?.toDouble() ?: continue
-                        add(PerModelHour(time, temp, precip))
+                        add(PerModelHour(time, apparent, air, precip))
                     }
                 }
                 if (entries.isNotEmpty()) put(model, entries)

--- a/core/data/src/test/kotlin/app/clothescast/core/data/weather/MultiModelConfidenceFetcherTest.kt
+++ b/core/data/src/test/kotlin/app/clothescast/core/data/weather/MultiModelConfidenceFetcherTest.kt
@@ -73,7 +73,8 @@ class MultiModelConfidenceFetcherTest {
         req.url.encodedPath shouldBe "/v1/forecast"
         req.url.parameters["models"] shouldBe "ecmwf_ifs04,gfs_seamless,icon_seamless"
         req.url.parameters["daily"] shouldBe "apparent_temperature_max,precipitation_probability_max"
-        req.url.parameters["hourly"] shouldBe "apparent_temperature,precipitation_probability"
+        req.url.parameters["hourly"] shouldBe
+            "apparent_temperature,temperature_2m,precipitation_probability"
         req.url.parameters["forecast_days"] shouldBe "1"
         req.url.parameters["past_days"].shouldBeNull()
     }
@@ -133,6 +134,7 @@ class MultiModelConfidenceFetcherTest {
         ecmwf.size shouldBe 3
         ecmwf[0].time shouldBe LocalTime.of(0, 0)
         ecmwf[0].apparentTemperatureC shouldBe (12.0 plusOrMinus 0.0001)
+        ecmwf[0].temperatureC shouldBe (14.0 plusOrMinus 0.0001)
         ecmwf[0].precipitationProbabilityPct shouldBe (10.0 plusOrMinus 0.0001)
         ecmwf[2].time shouldBe LocalTime.of(2, 0)
     }
@@ -286,6 +288,9 @@ class MultiModelConfidenceFetcherTest {
                 "apparent_temperature_ecmwf_ifs04": [12.0, 11.5, 11.0],
                 "apparent_temperature_gfs_seamless": [12.2, 11.8, 11.4],
                 "apparent_temperature_icon_seamless": [13.0, 12.6, 12.0],
+                "temperature_2m_ecmwf_ifs04": [14.0, 13.5, 13.0],
+                "temperature_2m_gfs_seamless": [14.2, 13.8, 13.4],
+                "temperature_2m_icon_seamless": [15.0, 14.6, 14.0],
                 "precipitation_probability_ecmwf_ifs04": [10, 15, 20],
                 "precipitation_probability_gfs_seamless": [12, 18, 22],
                 "precipitation_probability_icon_seamless": [18, 22, 28]
@@ -311,6 +316,9 @@ class MultiModelConfidenceFetcherTest {
                 "apparent_temperature_ecmwf_ifs04": [12.0, null, 11.0],
                 "apparent_temperature_gfs_seamless": [12.2, 11.8, 11.4],
                 "apparent_temperature_icon_seamless": [13.0, 12.6, 12.0],
+                "temperature_2m_ecmwf_ifs04": [14.0, 13.5, 13.0],
+                "temperature_2m_gfs_seamless": [14.2, 13.8, 13.4],
+                "temperature_2m_icon_seamless": [15.0, 14.6, 14.0],
                 "precipitation_probability_ecmwf_ifs04": [10, 15, 20],
                 "precipitation_probability_gfs_seamless": [12, 18, 22],
                 "precipitation_probability_icon_seamless": [18, 22, 28]

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/PerModelHourly.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/PerModelHourly.kt
@@ -28,6 +28,25 @@ data class PerModelHour(
     val time: LocalTime,
     /** Apparent ("feels-like") temperature for the hour, °C. */
     val apparentTemperatureC: Double,
+    /** Raw 2 m air temperature for the hour, °C — the same series the blended
+     *  [HourlyForecast.temperatureC] line carries, but per model. Surfaced so
+     *  the chart can overlay model lines in air-temp mode (tap-to-toggle) too,
+     *  not just in feels-like mode. */
+    val temperatureC: Double,
     /** Probability of measurable precipitation for the hour, 0–100. */
     val precipitationProbabilityPct: Double,
 )
+
+// TODO(model-divergence-diagnostics): when models disagree, the cause is
+//   usually one of two things — disagreement on raw 2 m air temperature, or
+//   disagreement on the wind / humidity inputs that get folded into the
+//   apparent-temperature calculation. Carrying [temperatureC] alongside
+//   [apparentTemperatureC] is the first half; a follow-up should add the
+//   per-model wind-speed and relative-humidity hourly series so we can
+//   visualise where the divergence is *coming from*, and a small Insight-
+//   detail panel that summarises which factor is the biggest contributor.
+// TODO(model-spread-stat): cross-model spread is currently reported as
+//   `max - min` (see [ConfidenceInfo.tempSpreadC]). That's intuitive but
+//   one outlying model swings it disproportionately; explore RMSE or std-dev
+//   across the consulted models as an alternative confidence input, plotted
+//   alongside the existing spread so we can A/B them before switching.

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsightTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsightTest.kt
@@ -414,10 +414,10 @@ class GenerateDailyInsightTest {
         // renders. TONIGHT drops the field entirely (today's per-model series
         // doesn't span the overnight window).
         val ecmwfFull = (0..23).map { hour ->
-            PerModelHour(LocalTime.of(hour, 0), 10.0 + hour, 5.0 * hour)
+            PerModelHour(LocalTime.of(hour, 0), 10.0 + hour, 12.0 + hour, 5.0 * hour)
         }
         val gfsFull = (0..23).map { hour ->
-            PerModelHour(LocalTime.of(hour, 0), 11.0 + hour, 6.0 * hour)
+            PerModelHour(LocalTime.of(hour, 0), 11.0 + hour, 13.0 + hour, 6.0 * hour)
         }
         val bundleHourly = PerModelHourly(
             byModel = mapOf("ecmwf_ifs04" to ecmwfFull, "gfs_seamless" to gfsFull),
@@ -459,11 +459,16 @@ class GenerateDailyInsightTest {
         )
         val incompleteEcmwf = listOf(
             // 12:00 hour missing — the model is dropped from the overlay.
-            PerModelHour(LocalTime.of(8, 0), 11.5, 9.0),
-            PerModelHour(LocalTime.of(15, 0), 21.5, 38.0),
+            PerModelHour(LocalTime.of(8, 0), 11.5, 12.5, 9.0),
+            PerModelHour(LocalTime.of(15, 0), 21.5, 22.5, 38.0),
         )
         val completeGfs = daytime.map { h ->
-            PerModelHour(h.time, h.feelsLikeC + 0.5, h.precipitationProbabilityPct + 2.0)
+            PerModelHour(
+                h.time,
+                h.feelsLikeC + 0.5,
+                h.temperatureC + 0.5,
+                h.precipitationProbabilityPct + 2.0,
+            )
         }
         val bundleHourly = PerModelHourly(
             byModel = mapOf("ecmwf_ifs04" to incompleteEcmwf, "gfs_seamless" to completeGfs),


### PR DESCRIPTION
## Summary

The per-model overlay was apparent-temperature only — tapping the forecast card to flip to raw 2 m air would hide the model spread entirely, which made it hard to tell whether models were diverging on underlying air temperature or on the wind / humidity inputs folded into feels-like.

- `PerModelHour` now carries `temperatureC` alongside `apparentTemperatureC`, populated from Open-Meteo's `temperature_2m_*` hourly fields on the same batched multi-model request (no extra round-trip).
- `ForecastChart` picks the matching per-model series based on the existing `showFeelsLike` toggle; legend renders in both modes.
- Cache backwards-compat: legacy `PerModelHourDto` payloads without `temperatureC` hide the whole overlay rather than backfill a fake 0°C line. Next worker refresh repopulates and the overlay returns.

## TODOs for the broader investigation (added in `PerModelHourly.kt`)

- **model-divergence-diagnostics**: per-model wind / humidity series so we can visualise *what's driving* the divergence when models disagree on feels-like, plus a small Insight-detail panel that summarises the biggest contributor.
- **model-spread-stat**: cross-model spread is currently `max - min`, which a single outlier swings disproportionately. Try RMSE / std-dev alongside, plotted next to the current spread so we can A/B them before switching the confidence input.

## Privacy

No change to what leaves the device — Open-Meteo already saw the lat/lon; we just ask for one extra hourly field on the same call.

## Test plan

- [ ] CI: `:core:domain:test` + `:core:data:test` + `:app:testDebugUnitTest` (couldn't run locally — Google Maven blocked, AGP plugin won't resolve)
- [ ] CI: snapshot regen for `forecast_chart_with_model_spread` (rangeProvider now considers overlay `temperatureC` too; bounds may shift by ≤2°C)
- [ ] Manually verify on device: tap the forecast card to flip between feels-like and air; per-model overlays should stay visible in both modes

https://claude.ai/code/session_01DUHtB5jzSzfbnj3GGqyggP

---
_Generated by [Claude Code](https://claude.ai/code/session_01DUHtB5jzSzfbnj3GGqyggP)_