### PR TITLE
Show per-model cloud cover and humidity alongside wind

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/today/CloudChart.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/CloudChart.kt
@@ -1,0 +1,103 @@
+package app.clothescast.ui.today
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import app.clothescast.core.domain.model.PerModelHourly
+import com.patrykandpatrick.vico.compose.cartesian.CartesianChartHost
+import com.patrykandpatrick.vico.compose.cartesian.axis.rememberBottom
+import com.patrykandpatrick.vico.compose.cartesian.axis.rememberStart
+import com.patrykandpatrick.vico.compose.cartesian.layer.rememberLineCartesianLayer
+import com.patrykandpatrick.vico.compose.cartesian.rememberCartesianChart
+import com.patrykandpatrick.vico.compose.cartesian.rememberVicoZoomState
+import com.patrykandpatrick.vico.core.cartesian.Zoom
+import com.patrykandpatrick.vico.core.cartesian.axis.HorizontalAxis
+import com.patrykandpatrick.vico.core.cartesian.axis.VerticalAxis
+import com.patrykandpatrick.vico.core.cartesian.data.CartesianChartModelProducer
+import com.patrykandpatrick.vico.core.cartesian.data.CartesianLayerRangeProvider
+import com.patrykandpatrick.vico.core.cartesian.data.CartesianValueFormatter
+import com.patrykandpatrick.vico.core.cartesian.data.lineSeries
+import com.patrykandpatrick.vico.core.common.data.ExtraStore
+import java.time.LocalTime
+import kotlin.math.roundToInt
+
+/**
+ * Diagnostic chart of total cloud cover per model — the most useful diagnostic
+ * when models disagree on raw air temperature: one model predicts a mid-day
+ * clearing (more solar gain → warmer surface), the other keeps it overcast
+ * (less gain → cooler). Cloud isn't a feels-like input but it's the upstream
+ * driver of the air-temp divergence that propagates into feels-like.
+ *
+ * Pinned 0–100% y-axis (same shape as [PrecipitationChart]) so an overcast
+ * day and a clear day are visually comparable across days. No "main" cloud
+ * line — [HourlyForecast] doesn't carry cloud cover, so we draw the per-model
+ * overlays alone.
+ */
+@Composable
+fun CloudChart(
+    times: List<LocalTime>,
+    perModelHourly: PerModelHourly,
+    modifier: Modifier = Modifier,
+) {
+    val overlays = perModelHourly.byModel
+        .mapValues { (_, entries) -> entries.filter { it.cloudCoverPct != null } }
+        .filterValues { it.size == times.size }
+    val visibleModels = MODEL_DRAW_ORDER.filter { it in overlays }
+    if (visibleModels.isEmpty() || times.isEmpty()) return
+
+    val producer = remember { CartesianChartModelProducer() }
+    LaunchedEffect(overlays) {
+        producer.runTransaction {
+            lineSeries {
+                visibleModels.forEach { modelId ->
+                    overlays.getValue(modelId).let { entries ->
+                        series(entries.map { it.cloudCoverPct!! })
+                    }
+                }
+            }
+        }
+    }
+
+    val bottomFormatter = remember(times) {
+        CartesianValueFormatter { _, value, _ ->
+            val idx = value.toInt().coerceIn(0, times.lastIndex)
+            "%02d".format(times[idx].hour)
+        }
+    }
+
+    // Fixed 0..100 axis — cloud cover is a percentage, so a clear day's flat
+    // baseline near zero and an overcast day's flat top near 100 should both
+    // read cleanly. Same logic as PrecipitationChart's fixed range.
+    val rangeProvider = remember {
+        object : CartesianLayerRangeProvider {
+            override fun getMinY(minY: Double, maxY: Double, extraStore: ExtraStore) = 0.0
+            override fun getMaxY(minY: Double, maxY: Double, extraStore: ExtraStore) = 100.0
+        }
+    }
+
+    val startFormatter = remember {
+        CartesianValueFormatter { _, value, _ -> "${value.roundToInt()}%" }
+    }
+
+    val lineProvider = rememberPinnedLineProvider(visibleModels, mainLineColor = null)
+
+    CartesianChartHost(
+        chart = rememberCartesianChart(
+            rememberLineCartesianLayer(
+                lineProvider = lineProvider,
+                rangeProvider = rangeProvider,
+            ),
+            startAxis = VerticalAxis.rememberStart(valueFormatter = startFormatter),
+            bottomAxis = HorizontalAxis.rememberBottom(valueFormatter = bottomFormatter),
+        ),
+        modelProducer = producer,
+        zoomState = rememberVicoZoomState(initialZoom = Zoom.Content),
+        modifier = modifier
+            .fillMaxWidth()
+            .height(140.dp),
+    )
+}

--- a/app/src/main/kotlin/app/clothescast/ui/today/HumidityChart.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/HumidityChart.kt
@@ -1,0 +1,99 @@
+package app.clothescast.ui.today
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import app.clothescast.core.domain.model.PerModelHourly
+import com.patrykandpatrick.vico.compose.cartesian.CartesianChartHost
+import com.patrykandpatrick.vico.compose.cartesian.axis.rememberBottom
+import com.patrykandpatrick.vico.compose.cartesian.axis.rememberStart
+import com.patrykandpatrick.vico.compose.cartesian.layer.rememberLineCartesianLayer
+import com.patrykandpatrick.vico.compose.cartesian.rememberCartesianChart
+import com.patrykandpatrick.vico.compose.cartesian.rememberVicoZoomState
+import com.patrykandpatrick.vico.core.cartesian.Zoom
+import com.patrykandpatrick.vico.core.cartesian.axis.HorizontalAxis
+import com.patrykandpatrick.vico.core.cartesian.axis.VerticalAxis
+import com.patrykandpatrick.vico.core.cartesian.data.CartesianChartModelProducer
+import com.patrykandpatrick.vico.core.cartesian.data.CartesianLayerRangeProvider
+import com.patrykandpatrick.vico.core.cartesian.data.CartesianValueFormatter
+import com.patrykandpatrick.vico.core.cartesian.data.lineSeries
+import com.patrykandpatrick.vico.core.common.data.ExtraStore
+import java.time.LocalTime
+import kotlin.math.roundToInt
+
+/**
+ * Diagnostic chart of 2 m relative humidity per model. Low-signal at the cool
+ * temperatures Europe sees most of the year — apparent-temperature's humidity
+ * term only kicks in above ~20 °C — but worth surfacing for hot days where
+ * it's the dominant feels-like contributor and for catching the rare cool-day
+ * frontal-passage case where models disagree sharply on dew point.
+ *
+ * Pinned 0–100% y-axis (same shape as [PrecipitationChart] / [CloudChart]).
+ * No "main" humidity line — [HourlyForecast] doesn't carry humidity, so we
+ * draw the per-model overlays alone.
+ */
+@Composable
+fun HumidityChart(
+    times: List<LocalTime>,
+    perModelHourly: PerModelHourly,
+    modifier: Modifier = Modifier,
+) {
+    val overlays = perModelHourly.byModel
+        .mapValues { (_, entries) -> entries.filter { it.relativeHumidityPct != null } }
+        .filterValues { it.size == times.size }
+    val visibleModels = MODEL_DRAW_ORDER.filter { it in overlays }
+    if (visibleModels.isEmpty() || times.isEmpty()) return
+
+    val producer = remember { CartesianChartModelProducer() }
+    LaunchedEffect(overlays) {
+        producer.runTransaction {
+            lineSeries {
+                visibleModels.forEach { modelId ->
+                    overlays.getValue(modelId).let { entries ->
+                        series(entries.map { it.relativeHumidityPct!! })
+                    }
+                }
+            }
+        }
+    }
+
+    val bottomFormatter = remember(times) {
+        CartesianValueFormatter { _, value, _ ->
+            val idx = value.toInt().coerceIn(0, times.lastIndex)
+            "%02d".format(times[idx].hour)
+        }
+    }
+
+    val rangeProvider = remember {
+        object : CartesianLayerRangeProvider {
+            override fun getMinY(minY: Double, maxY: Double, extraStore: ExtraStore) = 0.0
+            override fun getMaxY(minY: Double, maxY: Double, extraStore: ExtraStore) = 100.0
+        }
+    }
+
+    val startFormatter = remember {
+        CartesianValueFormatter { _, value, _ -> "${value.roundToInt()}%" }
+    }
+
+    val lineProvider = rememberPinnedLineProvider(visibleModels, mainLineColor = null)
+
+    CartesianChartHost(
+        chart = rememberCartesianChart(
+            rememberLineCartesianLayer(
+                lineProvider = lineProvider,
+                rangeProvider = rangeProvider,
+            ),
+            startAxis = VerticalAxis.rememberStart(valueFormatter = startFormatter),
+            bottomAxis = HorizontalAxis.rememberBottom(valueFormatter = bottomFormatter),
+        ),
+        modelProducer = producer,
+        zoomState = rememberVicoZoomState(initialZoom = Zoom.Content),
+        modifier = modifier
+            .fillMaxWidth()
+            .height(140.dp),
+    )
+}

--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayPreviews.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayPreviews.kt
@@ -664,6 +664,28 @@ internal fun WindCardWithModelSpreadPreview() {
     }
 }
 
+@Preview(name = "Cloud card · with model spread", widthDp = 360)
+@Composable
+internal fun CloudCardWithModelSpreadPreview() {
+    Frame {
+        CloudCard(
+            hourly = SAMPLE_HOURLY_RAINY,
+            perModelHourly = SAMPLE_PER_MODEL_HOURLY,
+        )
+    }
+}
+
+@Preview(name = "Humidity card · with model spread", widthDp = 360)
+@Composable
+internal fun HumidityCardWithModelSpreadPreview() {
+    Frame {
+        HumidityCard(
+            hourly = SAMPLE_HOURLY_RAINY,
+            perModelHourly = SAMPLE_PER_MODEL_HOURLY,
+        )
+    }
+}
+
 @Preview(name = "Forecast chart · with model spread", widthDp = 360)
 @Composable
 internal fun ForecastChartWithModelSpreadPreview() {

--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
@@ -317,6 +317,8 @@ private fun TodayContent(
                 // cards self-hide until the next worker refresh repopulates.
                 if (overlay != null) {
                     WindCard(hourly = state.insight.hourly, perModelHourly = overlay)
+                    CloudCard(hourly = state.insight.hourly, perModelHourly = overlay)
+                    HumidityCard(hourly = state.insight.hourly, perModelHourly = overlay)
                 }
             }
         }
@@ -1115,6 +1117,82 @@ internal fun WindCard(
                 style = MaterialTheme.typography.bodyMedium,
             )
             WindChart(times = times, perModelHourly = perModelHourly)
+            ModelSpreadLegend(perModelHourly)
+        }
+    }
+}
+
+/**
+ * Diagnostic cloud-cover card. Same gating + scaffolding as [WindCard]: only
+ * renders when the per-model overlay is active and at least one model returned
+ * cloud cover. Cloud divergence is the upstream cause of most mid-day air-temp
+ * disagreements between models (one predicts a clearing, the other doesn't),
+ * so this is the most useful follow-up to the wind diagnostic.
+ */
+@Composable
+internal fun CloudCard(
+    hourly: List<HourlyForecast>,
+    perModelHourly: PerModelHourly,
+) {
+    val times = remember(hourly) { hourly.map { it.time } }
+    val anyCloud = remember(perModelHourly) {
+        perModelHourly.byModel.values.any { entries ->
+            entries.any { it.cloudCoverPct != null }
+        }
+    }
+    if (!anyCloud) return
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier.padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.today_cloud_title),
+                style = MaterialTheme.typography.titleSmall,
+            )
+            Text(
+                text = stringResource(R.string.today_cloud_subtitle),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+            CloudChart(times = times, perModelHourly = perModelHourly)
+            ModelSpreadLegend(perModelHourly)
+        }
+    }
+}
+
+/**
+ * Diagnostic relative-humidity card. Same gating + scaffolding as the wind /
+ * cloud cards. Humidity has low signal at the cool temperatures Europe sees
+ * most of the year (apparent-temperature's humidity term only kicks in above
+ * ~20 °C) but the data ride the same Open-Meteo call for free, so we surface
+ * it for the warmer days where it does drive feels-like.
+ */
+@Composable
+internal fun HumidityCard(
+    hourly: List<HourlyForecast>,
+    perModelHourly: PerModelHourly,
+) {
+    val times = remember(hourly) { hourly.map { it.time } }
+    val anyHumidity = remember(perModelHourly) {
+        perModelHourly.byModel.values.any { entries ->
+            entries.any { it.relativeHumidityPct != null }
+        }
+    }
+    if (!anyHumidity) return
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier.padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.today_humidity_title),
+                style = MaterialTheme.typography.titleSmall,
+            )
+            Text(
+                text = stringResource(R.string.today_humidity_subtitle),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+            HumidityChart(times = times, perModelHourly = perModelHourly)
             ModelSpreadLegend(perModelHourly)
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -119,6 +119,21 @@
     <string name="today_wind_title">Wind speed</string>
     <string name="today_wind_subtitle">Per-model 10 m wind speed (km/h) by hour</string>
 
+    <!-- Cloud-cover diagnostic card. Sits below the wind card; cloud cover
+         is the upstream driver of air-temperature divergence between models
+         (more clearing means more solar gain means warmer surface), so this
+         is the most useful follow-up when models disagree on temperature
+         itself. -->
+    <string name="today_cloud_title">Cloud cover</string>
+    <string name="today_cloud_subtitle">Per-model total cloud cover (%) by hour</string>
+
+    <!-- Relative-humidity diagnostic card. Low signal at cool temperatures
+         (apparent-temperature's humidity term only kicks in above ~20°C)
+         but the data ride the same Open-Meteo call for free, so we surface
+         it for the warm days where it does drive feels-like. -->
+    <string name="today_humidity_title">Humidity</string>
+    <string name="today_humidity_subtitle">Per-model 2 m relative humidity (%) by hour</string>
+
     <string name="today_confidence_high">High confidence — major models agree</string>
     <string name="today_confidence_medium">Medium confidence</string>
     <string name="today_confidence_low">Low confidence — forecasts disagree</string>

--- a/app/src/test/kotlin/app/clothescast/ui/today/PreviewSnapshots.kt
+++ b/app/src/test/kotlin/app/clothescast/ui/today/PreviewSnapshots.kt
@@ -161,6 +161,8 @@ class PreviewSnapshots {
     @Test fun forecast_chart_with_model_spread() = capture { ForecastChartWithModelSpreadPreview() }
     @Test fun precipitation_card_with_model_spread() = capture { PrecipitationCardWithModelSpreadPreview() }
     @Test fun wind_card_with_model_spread() = capture { WindCardWithModelSpreadPreview() }
+    @Test fun cloud_card_with_model_spread() = capture { CloudCardWithModelSpreadPreview() }
+    @Test fun humidity_card_with_model_spread() = capture { HumidityCardWithModelSpreadPreview() }
 
     @Test fun precipitation_card() = capture { PrecipitationCardPreview() }
     @Test fun precipitation_card_dark() = capture { PrecipitationCardDarkPreview() }


### PR DESCRIPTION
## Summary

Follow-up to #385. The user's screenshots showed today's air-temp models (ICON vs GFS) disagreeing by 2–3 °C in the afternoon, with the divergence surviving roughly intact into feels-like — meaning wind chill isn't the primary driver and the underlying air temperatures genuinely disagree. Cloud cover is the upstream cause of that kind of disagreement (one model predicts a clearing, the other doesn't).

- New `CloudCard` below the wind card. Same scaffolding: gated on the existing "Show model spread" power-user setting, no main line, auto-hides when no consulted model returned cloud cover. Pinned 0–100% y-axis (like the rain chart) so an overcast day and a clear day are visually comparable across days.
- New `HumidityCard` below cloud. Same scaffolding. Low signal at cool temperatures but data rides the same Open-Meteo call for free, so we surface it for hot days.
- Layout: temp → rain → wind → cloud → humidity, in roughly decreasing relevance for typical UK / Europe spring days.

## No new fetching

The wind PR (#385) already plumbed all three fields through Open-Meteo, the domain model, and the cache; this PR just wires the visualisation. Zero new network bytes.

## What's left from the original "model divergence" thread

- **main-line-model (H6)** — separate PR. The user's screenshots showed the rain chart's grey "main" line tracking *neither* consulted model (GFS or ICON), confirming the OpenMeteoClient `best_match` default is picking a third model invisible to the diagnostic. This is the next priority.
- **model-divergence-summary** — per-hour "biggest contributing factor" hint when spread is wide.
- **model-spread-stat** — RMSE / std-dev alongside max-min for confidence.

TODOs in `core/domain/src/main/kotlin/app/clothescast/core/domain/model/PerModelHourly.kt` track all three.

## Test plan

- [ ] CI: JVM + Android debug build green
- [ ] CI: snapshot regen for the two new previews (`cloud_card_with_model_spread.png`, `humidity_card_with_model_spread.png`)
- [ ] On device with model spread on: cloud + humidity cards appear below the wind card, three coloured lines diverge visibly across the day

Privacy: no change — same lat/lon, same fields already on the wire from #385.

Open PRs in this session's stack:
- https://github.com/mikelward/clothescast/pull/386 (this PR)

https://claude.ai/code/session_01DUHtB5jzSzfbnj3GGqyggP

---
_Generated by [Claude Code](https://claude.ai/code/session_01DUHtB5jzSzfbnj3GGqyggP)_