### PR TITLE
Warn about rain when only one model spots it

### DIFF
--- a/app/src/main/kotlin/app/clothescast/data/InsightCache.kt
+++ b/app/src/main/kotlin/app/clothescast/data/InsightCache.kt
@@ -26,6 +26,7 @@ import app.clothescast.core.domain.model.OutfitSuggestion
 import app.clothescast.core.domain.model.PerModelHour
 import app.clothescast.core.domain.model.PerModelHourly
 import app.clothescast.core.domain.model.PrecipClause
+import app.clothescast.core.domain.model.PrecipLikelihood
 import app.clothescast.core.domain.model.TemperatureBand
 import app.clothescast.core.domain.model.WeatherCondition
 import kotlinx.coroutines.flow.Flow
@@ -268,11 +269,20 @@ class InsightCache(
     }
 
     @Serializable
-    private data class PrecipDto(val condition: String, val secondOfDay: Int) {
+    private data class PrecipDto(
+        val condition: String,
+        val secondOfDay: Int,
+        // Default to LIKELY so cached payloads written before the field existed
+        // round-trip as the pre-tier "Rain at 3pm." form they were originally
+        // generated with — same rationale as PrecipClause's domain default.
+        val likelihood: String = PrecipLikelihood.LIKELY.name,
+    ) {
         fun toDomain(): PrecipClause = PrecipClause(
             condition = runCatching { WeatherCondition.valueOf(condition) }
                 .getOrDefault(WeatherCondition.UNKNOWN),
             time = LocalTime.ofSecondOfDay(secondOfDay.toLong()),
+            likelihood = runCatching { PrecipLikelihood.valueOf(likelihood) }
+                .getOrDefault(PrecipLikelihood.LIKELY),
         )
     }
 
@@ -417,7 +427,9 @@ class InsightCache(
         alert = alert?.let { AlertDto(it.event) },
         delta = delta?.let { DeltaDto(it.degrees, it.direction.name) },
         clothes = clothes?.let { ClothesDto(it.items) },
-        precip = precip?.let { PrecipDto(it.condition.name, it.time.toSecondOfDay()) },
+        precip = precip?.let {
+            PrecipDto(it.condition.name, it.time.toSecondOfDay(), it.likelihood.name)
+        },
         calendarTieIn = calendarTieIn?.let { CalendarTieInDto(it.item) },
         eveningEventTieIn = eveningEventTieIn?.let {
             EveningEventTieInDto(it.item, it.rainTime?.toSecondOfDay())

--- a/app/src/main/kotlin/app/clothescast/insight/InsightFormatter.kt
+++ b/app/src/main/kotlin/app/clothescast/insight/InsightFormatter.kt
@@ -12,6 +12,7 @@ import app.clothescast.core.domain.model.EveningEventTieInClause
 import app.clothescast.core.domain.model.ForecastPeriod
 import app.clothescast.core.domain.model.InsightSummary
 import app.clothescast.core.domain.model.PrecipClause
+import app.clothescast.core.domain.model.PrecipLikelihood
 import app.clothescast.core.domain.model.Region
 import app.clothescast.core.domain.model.TemperatureBand
 import app.clothescast.core.domain.model.WeatherCondition
@@ -97,7 +98,7 @@ class InsightFormatter(
     }
 
     private fun formatPrecip(precip: PrecipClause): String {
-        val type = resources.getString(conditionRes(precip.condition))
+        val rawType = resources.getString(conditionRes(precip.condition))
         // "Rain at 02:00" sounds robotic and a precise hour adds little value
         // when the user is asleep — collapse early-morning peaks to "overnight".
         val timePhrase = if (precip.time.hour in OVERNIGHT_HOURS) {
@@ -105,7 +106,18 @@ class InsightFormatter(
         } else {
             resources.getString(R.string.insight_precip_at_time, spokenTime(precip.time))
         }
-        return resources.getString(R.string.insight_precip, type, timePhrase)
+        return when (precip.likelihood) {
+            PrecipLikelihood.LIKELY ->
+                resources.getString(R.string.insight_precip, rawType, timePhrase)
+            // "Chance of Rain at 3pm" reads odd with the condition title-cased
+            // mid-sentence; downcase the noun so the lead "Chance of" sits
+            // naturally. Other locales' condition resources may already be
+            // lowercase or have grammatical case to handle — this lowering is
+            // safe for English ("Rain" → "rain") and a no-op for languages
+            // where the condition resource is already in lower form.
+            PrecipLikelihood.POSSIBLE ->
+                resources.getString(R.string.insight_precip_chance, rawType.lowercase(locale), timePhrase)
+        }
     }
 
     private fun formatTieIn(item: String): String? {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -702,6 +702,15 @@
     swap a verb-shaped phrase ("at 3pm" / "overnight") cleanly per locale.
     -->
     <string name="insight_precip">%1$s %2$s.</string>
+    <!--
+    Hedged variant for when only a single weather model flags the hour. %1$s
+    and %2$s are the same condition / time-phrase pair as insight_precip; the
+    template downcases the condition because "Chance of Rain" reads oddly
+    title-cased mid-sentence. Locales without an obvious "chance of <noun>"
+    construction can keep the rendered text the same as insight_precip — it's
+    a hedge, not a contradiction.
+    -->
+    <string name="insight_precip_chance">Chance of %1$s %2$s.</string>
     <!-- Inserted as %2$s above when the peak hour is named — e.g. "at 3pm". -->
     <string name="insight_precip_at_time">at %1$s</string>
     <!-- Replaces the time phrase entirely for early-morning peaks

--- a/app/src/test/kotlin/app/clothescast/data/InsightCacheTest.kt
+++ b/app/src/test/kotlin/app/clothescast/data/InsightCacheTest.kt
@@ -25,6 +25,7 @@ import app.clothescast.core.domain.model.Location
 import app.clothescast.core.domain.model.OutfitRationale
 import app.clothescast.core.domain.model.OutfitSuggestion
 import app.clothescast.core.domain.model.PrecipClause
+import app.clothescast.core.domain.model.PrecipLikelihood
 import app.clothescast.core.domain.model.TemperatureBand
 import app.clothescast.core.domain.model.WeatherCondition
 import io.kotest.matchers.shouldBe
@@ -321,5 +322,22 @@ class InsightCacheTest {
         subject.store(full)
 
         subject.latest.first() shouldBe full
+    }
+
+    @Test
+    fun `precip likelihood round-trips through the cache`() = runTest {
+        val possible = sample.copy(
+            summary = sample.summary.copy(
+                precip = PrecipClause(
+                    WeatherCondition.RAIN,
+                    LocalTime.of(10, 0),
+                    PrecipLikelihood.POSSIBLE,
+                ),
+            ),
+        )
+
+        subject.store(possible)
+
+        subject.latest.first()?.summary?.precip?.likelihood shouldBe PrecipLikelihood.POSSIBLE
     }
 }

--- a/app/src/test/kotlin/app/clothescast/insight/InsightFormatterTest.kt
+++ b/app/src/test/kotlin/app/clothescast/insight/InsightFormatterTest.kt
@@ -12,6 +12,7 @@ import app.clothescast.core.domain.model.DeltaClause
 import app.clothescast.core.domain.model.ForecastPeriod
 import app.clothescast.core.domain.model.InsightSummary
 import app.clothescast.core.domain.model.PrecipClause
+import app.clothescast.core.domain.model.PrecipLikelihood
 import app.clothescast.core.domain.model.Region
 import app.clothescast.core.domain.model.TemperatureBand
 import app.clothescast.core.domain.model.WeatherCondition
@@ -149,6 +150,35 @@ class InsightFormatterTest {
     fun `precip clause renders non-zero minutes`() {
         subject.format(summary(precip = PrecipClause(WeatherCondition.RAIN, LocalTime.of(15, 30)))) shouldBe
             "Today will be mild. Rain at 3:30pm."
+    }
+
+    @Test
+    fun `precip clause hedges with 'Chance of rain' when likelihood is POSSIBLE`() {
+        subject.format(
+            summary(
+                precip = PrecipClause(
+                    WeatherCondition.RAIN,
+                    LocalTime.of(15, 0),
+                    PrecipLikelihood.POSSIBLE,
+                ),
+            ),
+        ) shouldBe "Today will be mild. Chance of rain at 3pm."
+    }
+
+    @Test
+    fun `precip clause downcases the condition mid-sentence in the hedged form`() {
+        // Drizzle would otherwise read "Chance of Drizzle at noon." — title-
+        // cased mid-sentence. The formatter lowercases the condition for the
+        // POSSIBLE template so it sits naturally after "Chance of".
+        subject.format(
+            summary(
+                precip = PrecipClause(
+                    WeatherCondition.DRIZZLE,
+                    LocalTime.NOON,
+                    PrecipLikelihood.POSSIBLE,
+                ),
+            ),
+        ) shouldBe "Today will be mild. Chance of drizzle at noon."
     }
 
     @Test

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/InsightSummary.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/InsightSummary.kt
@@ -85,8 +85,27 @@ data class ClothesClause(val items: List<String>)
 /**
  * Peak precipitation hour: a [condition] (RAIN, SNOW, etc.) at a wall-clock [time].
  * The formatter capitalises and humanises the condition name ("Rain at 15:00.").
+ *
+ * [likelihood] tracks how confident we are. [PrecipLikelihood.LIKELY] renders as
+ * the bare condition ("Rain at 3pm."); [PrecipLikelihood.POSSIBLE] hedges
+ * ("Chance of rain at 3pm.") because only a single per-model series flagged
+ * the hour while others stayed dry. Defaults to LIKELY so legacy cached
+ * payloads — written before the field existed — keep their original wording.
  */
-data class PrecipClause(val condition: WeatherCondition, val time: LocalTime)
+data class PrecipClause(
+    val condition: WeatherCondition,
+    val time: LocalTime,
+    val likelihood: PrecipLikelihood = PrecipLikelihood.LIKELY,
+)
+
+/**
+ * Confidence tier for [PrecipClause]. The two values map to two prose forms:
+ * "Rain at 3pm." (LIKELY) when models agree, "Chance of rain at 3pm."
+ * (POSSIBLE) when only one model flags the hour. The renderer picks the tier
+ * based on cross-model agreement at the peak hour; the formatter picks the
+ * template.
+ */
+enum class PrecipLikelihood { LIKELY, POSSIBLE }
 
 /**
  * Calendar tie-in: a clothes [item] keyed off the precipitation peak overlapping

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsight.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsight.kt
@@ -124,6 +124,16 @@ class GenerateDailyInsight(
         } else {
             emptyList()
         }
+        // Per-model hourly only covers `forecast_days=1`, so only the TODAY
+        // pass can pair the precip clause with cross-model agreement. The
+        // tonight pass falls through to base-only behaviour in the renderer.
+        // Sliced to the period window so the renderer's per-hour matches line
+        // up with [periodForecast.hourly].
+        val perModelForPeriod = if (period == ForecastPeriod.TODAY) {
+            bundle.perModelHourly?.slicedTo(periodForecast.hourly)
+        } else {
+            null
+        }
         val summary = renderInsightSummary(
             today = periodForecast,
             yesterday = deltaYesterday,
@@ -135,6 +145,7 @@ class GenerateDailyInsight(
             eveningTriggeredRules = eveningTriggered,
             eveningForecast = if (period == ForecastPeriod.TODAY) tonightForecast else null,
             todayForDelta = deltaToday,
+            perModelHourly = perModelForPeriod,
         )
         val insight = Insight(
             summary = summary,
@@ -156,12 +167,9 @@ class GenerateDailyInsight(
             // narrow today's series to the same daytime window we sliced
             // `periodForecast.hourly` to — otherwise the chart plots the
             // overlays by index and the midnight model value lands on the
-            // first visible hour of the daytime window.
-            perModelHourly = if (period == ForecastPeriod.TODAY) {
-                bundle.perModelHourly?.slicedTo(periodForecast.hourly)
-            } else {
-                null
-            },
+            // first visible hour of the daytime window. Same series that
+            // fed the precip-clause tier selection above.
+            perModelHourly = perModelForPeriod,
             outfit = OutfitSuggestion.fromForecast(periodForecast, rules),
             nextOutfit = nextOutfit,
             outfitRationale = OutfitSuggestion.explainFromForecast(periodForecast, rules),

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/RenderInsightSummary.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/RenderInsightSummary.kt
@@ -12,7 +12,9 @@ import app.clothescast.core.domain.model.DeltaClause
 import app.clothescast.core.domain.model.EveningEventTieInClause
 import app.clothescast.core.domain.model.ForecastPeriod
 import app.clothescast.core.domain.model.InsightSummary
+import app.clothescast.core.domain.model.PerModelHourly
 import app.clothescast.core.domain.model.PrecipClause
+import app.clothescast.core.domain.model.PrecipLikelihood
 import app.clothescast.core.domain.model.TemperatureBand
 import app.clothescast.core.domain.model.WeatherAlert
 import app.clothescast.core.domain.model.WeatherCondition
@@ -36,8 +38,13 @@ import kotlin.math.roundToInt
  *    feels-like delta is ≥ 3°C, and only for [ForecastPeriod.TODAY] (the morning
  *    pass already mentioned this comparison; the tonight pass shouldn't repeat it).
  * 4. [ClothesClause] — items triggered by the user's rule list, in rule order.
- * 5. [PrecipClause] — peak chance ≥ 30% (hourly peak preferred; falls back to a
- *    noon synthesis when only the day-level field crosses the threshold).
+ * 5. [PrecipClause] — fires in two tiers driven by cross-model agreement:
+ *    [PrecipLikelihood.LIKELY] when a majority of consulted models hit ≥ 50%
+ *    at the same hour ("Rain at 3pm."), [PrecipLikelihood.POSSIBLE] when at
+ *    least one model hits ≥ 30% but the majority bar isn't cleared ("Chance
+ *    of rain at 3pm."). Falls back to the base hourly series — and ultimately
+ *    a noon synthesis from the day-level field — when per-model data isn't
+ *    available; both fallbacks render as LIKELY (the existing behaviour).
  * 6. [CalendarTieInClause] — when clothes + precip both fired AND a calendar
  *    event overlaps the precip peak hour. Picks "umbrella" when on the clothes
  *    list, otherwise the first triggered item, mirroring rule 4's ordering.
@@ -71,9 +78,21 @@ class RenderInsightSummary {
         // Defaults to [today], which is correct when the caller hasn't sliced
         // the forecast (e.g. in unit tests that pass raw 24h fields on both sides).
         todayForDelta: DailyForecast = today,
+        // Per-model hourly series for the same period [today] covers. When
+        // present, the precip clause uses cross-model agreement to pick its
+        // tier (see [PrecipLikelihood]); when null we fall back to the base
+        // hourly + day-level field. Caller is responsible for slicing the
+        // per-model series to the same window as [today.hourly] so peak hours
+        // line up.
+        perModelHourly: PerModelHourly? = null,
+        // Evening per-model hourly, paired with [eveningForecast]. Open-Meteo's
+        // per-model hourly currently only covers `forecast_days=1`, so the
+        // tonight pass (which wraps past midnight) usually can't supply this —
+        // null falls back to the base series exactly like the today path.
+        eveningPerModelHourly: PerModelHourly? = null,
     ): InsightSummary {
         val items = todayTriggeredRules.map { it.item }
-        val peak = peakPrecip(today)
+        val peak = peakPrecip(today, perModelHourly)
         // Compute the evening peak only when the evening tie-in is going to
         // emit (i.e. caller passed events + triggered rules + an evening
         // forecast). Avoids spending the search on every TODAY pass, and
@@ -83,7 +102,7 @@ class RenderInsightSummary {
             eveningEvents.isNotEmpty() &&
             eveningTriggeredRules.isNotEmpty()
         ) {
-            eveningForecast?.let { peakPrecip(it) }
+            eveningForecast?.let { peakPrecip(it, eveningPerModelHourly) }
         } else {
             null
         }
@@ -93,7 +112,7 @@ class RenderInsightSummary {
             band = bandClause(today),
             delta = if (period == ForecastPeriod.TODAY) deltaClause(todayForDelta, yesterday) else null,
             clothes = clothesClause(items),
-            precip = peak?.let { PrecipClause(it.condition, it.time) },
+            precip = peak?.let { PrecipClause(it.condition, it.time, it.likelihood) },
             // Calendar tie-in only fires on TONIGHT — pairing the precip peak
             // with an event the listener hasn't started yet ("Bring an umbrella
             // for your 8pm dinner") is the case where it adds value. On TODAY
@@ -140,24 +159,40 @@ class RenderInsightSummary {
      * event window against the same time without re-running the logic and getting
      * out of sync.
      *
-     * Returns null unless the resolved condition is *actual* precipitation
-     * (drizzle / rain / snow / thunderstorm). A cloudy or foggy day with a
-     * 30%+ "precip" probability isn't worth a clause — the user wants the
-     * spoken summary to mention precipitation, not haziness.
+     * Tier selection when [perModelHourly] is supplied:
+     *  - [PrecipLikelihood.LIKELY] when a *majority* of consulted models hit
+     *    ≥ [LIKELY_THRESHOLD]% probability at the same hour ("majority" = more
+     *    than half: 2 of 3, both of 2, 1 of 1). Wettest such hour wins.
+     *  - [PrecipLikelihood.POSSIBLE] when at least one model hits ≥
+     *    [POSSIBLE_THRESHOLD]% at some hour but the LIKELY bar isn't cleared.
+     *    The hour carrying the single biggest per-model reading wins.
      *
-     * When an hourly entry's condition is [WeatherCondition.UNKNOWN] (Open-Meteo
-     * omitted the weather code for that hour), the day-level condition is used as a
-     * fallback. If the day-level condition is also unknown or non-precipitating, the
-     * clause is suppressed. This is intentionally conservative — a missing code is
-     * ambiguous, and the day-level field will normally carry the right type when the
-     * API is healthy.
+     * Falls back to the base hourly series (and finally a noon synthesis from
+     * the day-level field) when per-model data isn't available. Both fallback
+     * paths emit LIKELY so legacy behaviour and cached payloads keep their
+     * original wording. The 30% bar matches the historical fallback threshold.
+     *
+     * Condition resolution: prefers the base hour's weather code at the peak
+     * time when it's a precipitating type; falls back to the day-level
+     * condition (after `slicedFor…`, this is already the wettest in-window
+     * hour's code) when the base hour is missing, UNKNOWN, or non-precip; and
+     * finally defaults to [WeatherCondition.RAIN] when the per-model tier
+     * triggered but the base forecast carries no precipitating code at all —
+     * which is the exact "base under-called both probability *and* type"
+     * scenario the per-model tier exists to catch. The base-only fallback
+     * (no per-model data) keeps the original strict "suppress when no
+     * precipitating code" behaviour, because there's no extra signal to
+     * justify overriding the base condition.
      */
-    private fun peakPrecip(today: DailyForecast): PeakPrecip? {
+    private fun peakPrecip(today: DailyForecast, perModelHourly: PerModelHourly?): PeakPrecip? {
+        val perModelHit = perModelHourly?.let { pickPerModelPeak(today, it) }
+        if (perModelHit != null) return perModelHit
+
         val peak = today.hourly.maxByOrNull { it.precipitationProbabilityPct }
         val time: LocalTime
         val condition: WeatherCondition
-        if (peak == null || peak.precipitationProbabilityPct < 30.0) {
-            if (today.precipitationProbabilityMaxPct < 30.0) return null
+        if (peak == null || peak.precipitationProbabilityPct < POSSIBLE_THRESHOLD) {
+            if (today.precipitationProbabilityMaxPct < POSSIBLE_THRESHOLD) return null
             time = LocalTime.NOON
             condition = today.condition
         } else {
@@ -165,7 +200,55 @@ class RenderInsightSummary {
             condition = if (peak.condition == WeatherCondition.UNKNOWN) today.condition else peak.condition
         }
         if (!condition.isPrecipitation()) return null
-        return PeakPrecip(time, condition)
+        return PeakPrecip(time, condition, PrecipLikelihood.LIKELY)
+    }
+
+    private fun pickPerModelPeak(today: DailyForecast, perModelHourly: PerModelHourly): PeakPrecip? {
+        val models = perModelHourly.byModel.values.toList()
+        if (models.isEmpty()) return null
+        // Majority = more than half: 2 of 3, both of 2, 1 of 1. Matches how the
+        // user described it ("any model says ≥ 30 → chance of rain; majority of
+        // models say ≥ 50 → rain"); generalises naturally to whatever subset of
+        // models reported usable hourly values today.
+        val majorityNeeded = models.size / 2 + 1
+        // Walk every hour any model reported, scoring by "models hitting LIKELY
+        // at this hour" first and the single biggest per-model reading second
+        // (tie-break, also doubles as the POSSIBLE fallback pivot).
+        val hours = models.flatMap { entries -> entries.map { it.time } }.toSortedSet()
+        val likelyHour = hours
+            .mapNotNull { hour ->
+                val readings = models.mapNotNull { entries -> entries.firstOrNull { it.time == hour } }
+                val likelyCount = readings.count { it.precipitationProbabilityPct >= LIKELY_THRESHOLD }
+                if (likelyCount >= majorityNeeded) hour to readings else null
+            }
+            .maxByOrNull { (_, readings) -> readings.maxOf { it.precipitationProbabilityPct } }
+            ?.first
+        if (likelyHour != null) {
+            return PeakPrecip(likelyHour, perModelConditionAt(likelyHour, today), PrecipLikelihood.LIKELY)
+        }
+
+        val possibleHour = models.asSequence()
+            .flatten()
+            .filter { it.precipitationProbabilityPct >= POSSIBLE_THRESHOLD }
+            .maxByOrNull { it.precipitationProbabilityPct }
+            ?.time
+        if (possibleHour != null) {
+            return PeakPrecip(possibleHour, perModelConditionAt(possibleHour, today), PrecipLikelihood.POSSIBLE)
+        }
+        return null
+    }
+
+    private fun perModelConditionAt(time: LocalTime, today: DailyForecast): WeatherCondition {
+        val baseHourCondition = today.hourly.firstOrNull { it.time == time }
+            ?.condition
+            ?.takeIf { it != WeatherCondition.UNKNOWN }
+        if (baseHourCondition != null && baseHourCondition.isPrecipitation()) return baseHourCondition
+        if (today.condition.isPrecipitation()) return today.condition
+        // The per-model tier triggered on probability alone but no part of the
+        // base forecast carries a precipitating code. Default to RAIN — the
+        // model is the source of truth here and "Chance of rain" / "Rain" reads
+        // honestly even when the base under-called the precipitation type.
+        return WeatherCondition.RAIN
     }
 
     private fun WeatherCondition.isPrecipitation(): Boolean = when (this) {
@@ -241,5 +324,18 @@ class RenderInsightSummary {
         return EveningEventTieInClause(item = item, rainTime = eveningPeak?.time)
     }
 
-    private data class PeakPrecip(val time: LocalTime, val condition: WeatherCondition)
+    private data class PeakPrecip(
+        val time: LocalTime,
+        val condition: WeatherCondition,
+        val likelihood: PrecipLikelihood,
+    )
+
+    companion object {
+        // Per-model agreement thresholds. The user's mental model is "1 model
+        // says rain → hedge it as a chance; majority of models say a lot of
+        // rain → just say rain". 30% is the historical base-only trigger
+        // threshold; 50% is the per-model bar for a *confident* announcement.
+        internal const val POSSIBLE_THRESHOLD: Double = 30.0
+        internal const val LIKELY_THRESHOLD: Double = 50.0
+    }
 }

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/RenderInsightSummaryTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/RenderInsightSummaryTest.kt
@@ -7,6 +7,9 @@ import app.clothescast.core.domain.model.DailyForecast
 import app.clothescast.core.domain.model.DeltaClause
 import app.clothescast.core.domain.model.ForecastPeriod
 import app.clothescast.core.domain.model.HourlyForecast
+import app.clothescast.core.domain.model.PerModelHour
+import app.clothescast.core.domain.model.PerModelHourly
+import app.clothescast.core.domain.model.PrecipLikelihood
 import app.clothescast.core.domain.model.TemperatureBand
 import app.clothescast.core.domain.model.WeatherAlert
 import app.clothescast.core.domain.model.WeatherCondition
@@ -561,6 +564,224 @@ class RenderInsightSummaryTest {
             period = ForecastPeriod.TONIGHT,
         ).calendarTieIn.shouldBeNull()
     }
+
+    @Test
+    fun `precip clause is LIKELY when the base hourly is the only signal`() {
+        val today = mildToday.copy(
+            precipitationProbabilityMaxPct = 60.0,
+            condition = WeatherCondition.RAIN,
+            hourly = listOf(
+                HourlyForecast(LocalTime.of(15, 0), 22.0, 22.0, 60.0, WeatherCondition.RAIN),
+            ),
+        )
+        val out = subject(today, yesterday, emptyList()).precip
+        out.shouldNotBeNull()
+        out!!.likelihood shouldBe PrecipLikelihood.LIKELY
+    }
+
+    @Test
+    fun `precip clause is LIKELY when majority of three models hit 50 percent at the same hour`() {
+        // The user's exact scenario, inverted: GFS + ECMWF both flag 10am wet,
+        // ICON disagrees. Two of three is majority → confident "Rain at 10am."
+        val today = mildToday.copy(
+            precipitationProbabilityMaxPct = 30.0,
+            condition = WeatherCondition.PARTLY_CLOUDY,
+            hourly = listOf(
+                HourlyForecast(LocalTime.of(10, 0), 18.0, 18.0, 30.0, WeatherCondition.PARTLY_CLOUDY),
+                HourlyForecast(LocalTime.of(15, 0), 22.0, 22.0, 10.0, WeatherCondition.PARTLY_CLOUDY),
+            ),
+        )
+        val perModel = perModelHourly(
+            "gfs_seamless" to listOf(
+                perModelHour(LocalTime.of(10, 0), 80.0),
+                perModelHour(LocalTime.of(15, 0), 5.0),
+            ),
+            "ecmwf_ifs04" to listOf(
+                perModelHour(LocalTime.of(10, 0), 70.0),
+                perModelHour(LocalTime.of(15, 0), 5.0),
+            ),
+            "icon_seamless" to listOf(
+                perModelHour(LocalTime.of(10, 0), 10.0),
+                perModelHour(LocalTime.of(15, 0), 5.0),
+            ),
+        )
+        val out = subject(today, yesterday, emptyList(), perModelHourly = perModel).precip
+        out.shouldNotBeNull()
+        out!!.time shouldBe LocalTime.of(10, 0)
+        out.likelihood shouldBe PrecipLikelihood.LIKELY
+        // Base condition at 10:00 is PARTLY_CLOUDY and the day-level is too,
+        // so we default to RAIN — the per-model tier triggered on probability
+        // alone and "Rain" reads honestly when the base under-called the type.
+        out.condition shouldBe WeatherCondition.RAIN
+    }
+
+    @Test
+    fun `precip clause is POSSIBLE when only one of three models hits 50 percent`() {
+        // Exact mirror of the user's screenshot: GFS at ~80% at 10am, the others
+        // stay near zero. Single-model disagreement → hedged "Chance of rain".
+        val today = mildToday.copy(
+            precipitationProbabilityMaxPct = 30.0,
+            condition = WeatherCondition.PARTLY_CLOUDY,
+            hourly = listOf(
+                HourlyForecast(LocalTime.of(10, 0), 18.0, 18.0, 30.0, WeatherCondition.PARTLY_CLOUDY),
+            ),
+        )
+        val perModel = perModelHourly(
+            "gfs_seamless" to listOf(perModelHour(LocalTime.of(10, 0), 80.0)),
+            "ecmwf_ifs04" to listOf(perModelHour(LocalTime.of(10, 0), 5.0)),
+            "icon_seamless" to listOf(perModelHour(LocalTime.of(10, 0), 10.0)),
+        )
+        val out = subject(today, yesterday, emptyList(), perModelHourly = perModel).precip
+        out.shouldNotBeNull()
+        out!!.time shouldBe LocalTime.of(10, 0)
+        out.likelihood shouldBe PrecipLikelihood.POSSIBLE
+        out.condition shouldBe WeatherCondition.RAIN
+    }
+
+    @Test
+    fun `precip clause is POSSIBLE when a single model passes 30 but no model passes 50`() {
+        // Soft signal — one model in the 30-49% band, others dry. Hedged form
+        // wins; nobody crosses the LIKELY bar.
+        val today = mildToday.copy(
+            precipitationProbabilityMaxPct = 30.0,
+            condition = WeatherCondition.RAIN,
+            hourly = listOf(
+                HourlyForecast(LocalTime.of(11, 0), 18.0, 18.0, 30.0, WeatherCondition.RAIN),
+            ),
+        )
+        val perModel = perModelHourly(
+            "gfs_seamless" to listOf(perModelHour(LocalTime.of(11, 0), 40.0)),
+            "ecmwf_ifs04" to listOf(perModelHour(LocalTime.of(11, 0), 5.0)),
+            "icon_seamless" to listOf(perModelHour(LocalTime.of(11, 0), 5.0)),
+        )
+        val out = subject(today, yesterday, emptyList(), perModelHourly = perModel).precip
+        out.shouldNotBeNull()
+        out!!.likelihood shouldBe PrecipLikelihood.POSSIBLE
+    }
+
+    @Test
+    fun `precip clause is omitted when every model stays below 30 percent`() {
+        val today = mildToday.copy(
+            precipitationProbabilityMaxPct = 10.0,
+            condition = WeatherCondition.PARTLY_CLOUDY,
+            hourly = listOf(
+                HourlyForecast(LocalTime.of(10, 0), 18.0, 18.0, 10.0, WeatherCondition.PARTLY_CLOUDY),
+            ),
+        )
+        val perModel = perModelHourly(
+            "gfs_seamless" to listOf(perModelHour(LocalTime.of(10, 0), 20.0)),
+            "ecmwf_ifs04" to listOf(perModelHour(LocalTime.of(10, 0), 25.0)),
+            "icon_seamless" to listOf(perModelHour(LocalTime.of(10, 0), 5.0)),
+        )
+        subject(today, yesterday, emptyList(), perModelHourly = perModel).precip.shouldBeNull()
+    }
+
+    @Test
+    fun `precip clause is LIKELY when both of two available models hit 50 percent`() {
+        // Majority of 2 is 2 (both). ECMWF dropped (its run wasn't ready in the
+        // wider pipeline); GFS + ICON both at 60% is still majority agreement.
+        val today = mildToday.copy(
+            precipitationProbabilityMaxPct = 20.0,
+            condition = WeatherCondition.PARTLY_CLOUDY,
+            hourly = listOf(
+                HourlyForecast(LocalTime.of(13, 0), 18.0, 18.0, 20.0, WeatherCondition.PARTLY_CLOUDY),
+            ),
+        )
+        val perModel = perModelHourly(
+            "gfs_seamless" to listOf(perModelHour(LocalTime.of(13, 0), 60.0)),
+            "icon_seamless" to listOf(perModelHour(LocalTime.of(13, 0), 70.0)),
+        )
+        val out = subject(today, yesterday, emptyList(), perModelHourly = perModel).precip
+        out.shouldNotBeNull()
+        out!!.likelihood shouldBe PrecipLikelihood.LIKELY
+        out.time shouldBe LocalTime.of(13, 0)
+    }
+
+    @Test
+    fun `precip clause is POSSIBLE when one of two available models hits 50 percent`() {
+        // Majority of 2 is 2 — one passing isn't a majority, so the LIKELY
+        // tier doesn't fire; the lone 60% still earns the hedged form.
+        val today = mildToday.copy(
+            precipitationProbabilityMaxPct = 20.0,
+            condition = WeatherCondition.RAIN,
+            hourly = listOf(
+                HourlyForecast(LocalTime.of(13, 0), 18.0, 18.0, 20.0, WeatherCondition.RAIN),
+            ),
+        )
+        val perModel = perModelHourly(
+            "gfs_seamless" to listOf(perModelHour(LocalTime.of(13, 0), 60.0)),
+            "icon_seamless" to listOf(perModelHour(LocalTime.of(13, 0), 10.0)),
+        )
+        val out = subject(today, yesterday, emptyList(), perModelHourly = perModel).precip
+        out.shouldNotBeNull()
+        out!!.likelihood shouldBe PrecipLikelihood.POSSIBLE
+    }
+
+    @Test
+    fun `precip clause uses base hour condition when the peak hour itself is precipitating`() {
+        // Per-model triggers LIKELY at 17:00 where the base hour says
+        // THUNDERSTORM — we should keep THUNDERSTORM rather than defaulting
+        // to RAIN, because the base carries a more specific code at the peak.
+        val today = mildToday.copy(
+            precipitationProbabilityMaxPct = 80.0,
+            condition = WeatherCondition.THUNDERSTORM,
+            hourly = listOf(
+                HourlyForecast(LocalTime.of(17, 0), 22.0, 22.0, 80.0, WeatherCondition.THUNDERSTORM),
+            ),
+        )
+        val perModel = perModelHourly(
+            "gfs_seamless" to listOf(perModelHour(LocalTime.of(17, 0), 80.0)),
+            "ecmwf_ifs04" to listOf(perModelHour(LocalTime.of(17, 0), 70.0)),
+            "icon_seamless" to listOf(perModelHour(LocalTime.of(17, 0), 60.0)),
+        )
+        val out = subject(today, yesterday, emptyList(), perModelHourly = perModel).precip
+        out.shouldNotBeNull()
+        out!!.condition shouldBe WeatherCondition.THUNDERSTORM
+        out.likelihood shouldBe PrecipLikelihood.LIKELY
+    }
+
+    @Test
+    fun `precip clause picks the wettest hour when several clear the LIKELY bar`() {
+        // 10:00 has 2 models ≥ 50 (60, 55); 16:00 has 3 models ≥ 50 (90, 80, 70).
+        // 16:00 wins because its max single-model reading is higher.
+        val today = mildToday.copy(
+            precipitationProbabilityMaxPct = 70.0,
+            condition = WeatherCondition.RAIN,
+            hourly = listOf(
+                HourlyForecast(LocalTime.of(10, 0), 18.0, 18.0, 50.0, WeatherCondition.RAIN),
+                HourlyForecast(LocalTime.of(16, 0), 22.0, 22.0, 70.0, WeatherCondition.RAIN),
+            ),
+        )
+        val perModel = perModelHourly(
+            "gfs_seamless" to listOf(
+                perModelHour(LocalTime.of(10, 0), 60.0),
+                perModelHour(LocalTime.of(16, 0), 90.0),
+            ),
+            "ecmwf_ifs04" to listOf(
+                perModelHour(LocalTime.of(10, 0), 55.0),
+                perModelHour(LocalTime.of(16, 0), 80.0),
+            ),
+            "icon_seamless" to listOf(
+                perModelHour(LocalTime.of(10, 0), 20.0),
+                perModelHour(LocalTime.of(16, 0), 70.0),
+            ),
+        )
+        val out = subject(today, yesterday, emptyList(), perModelHourly = perModel).precip
+        out.shouldNotBeNull()
+        out!!.time shouldBe LocalTime.of(16, 0)
+        out.likelihood shouldBe PrecipLikelihood.LIKELY
+    }
+
+    private fun perModelHour(time: LocalTime, precipPct: Double): PerModelHour =
+        PerModelHour(
+            time = time,
+            apparentTemperatureC = 18.0,
+            temperatureC = 18.0,
+            precipitationProbabilityPct = precipPct,
+        )
+
+    private fun perModelHourly(vararg models: Pair<String, List<PerModelHour>>): PerModelHourly =
+        PerModelHourly(models.toMap())
 
     @Test
     fun `temperature band classifier covers all six bands at boundaries`() {


### PR DESCRIPTION
## Summary

This morning's "Today" insight stayed silent about rain — "Today will be cold. It will be 4° cooler than yesterday. Wear a jumper, jacket, and coat." — even though the chance-of-rain chart showed an obvious morning spike on the GFS overlay (~80% at 10am) that turned out to be heavy rain, possibly hail. Only one of three consulted models flagged the hour and the existing precip rule only looked at the blended base series, which under-called both the probability *and* the weather code at the peak.

The rain clause now picks its tier from cross-model agreement:

- **`PrecipLikelihood.LIKELY`** ("Rain at 10am.") — a *majority* of consulted models hit ≥50% at the same hour. "Majority" generalises naturally across the 2- and 3-model cases the upstream fetcher actually returns: 2 of 3, both of 2, the only one of 1.
- **`PrecipLikelihood.POSSIBLE`** ("Chance of rain at 10am.") — at least one model crosses ≥30% but the LIKELY bar isn't cleared. Hedged form so a single dissenting model can still surface a warning without overstating confidence.
- **No clause** — every model stays under 30%.

When per-model data isn't available — the tonight pass (Open-Meteo's per-model hourly only covers `forecast_days=1`) and reads from cached pre-tier insights — the renderer falls through to the existing base-only behaviour and emits the LIKELY form, preserving today's wording.

A nice side effect: when the per-model tier triggers but the base hourly carries a non-precipitating weather code at the peak (the exact "base under-called both probability *and* type" failure mode), the renderer now defaults the rendered condition to `RAIN` rather than dropping the clause. The base-only fallback keeps the historical strict suppression — there's no extra signal there to justify overriding the base.

Thresholds (`POSSIBLE_THRESHOLD = 30.0`, `LIKELY_THRESHOLD = 50.0`) and the majority rule are unit-tested across all the model-count and agreement combinations in `RenderInsightSummaryTest`. The cache round-trip and "Chance of …" formatter path are covered too.

### Privacy

No change to what leaves the device. The same per-model hourly series that already drives the chance-of-rain chart now also drives the precip-clause tier selection — entirely on-device.

### Translations

Only the English (`values/`) string `insight_precip_chance` is added in this PR. Other locales fall back to the default English template via standard Android resource resolution until translations land. Per-locale strings can follow.

## Test plan

- [ ] CI's JVM unit tests pass (`:core:domain:test` covers the tiered selection; `:app:testDebugUnitTest` covers the formatter and cache round-trip).
- [ ] CI's Android debug build assembles.
- [ ] Manually verify on device: a day where one model spikes and the base under-calls now reads "Chance of <type> at <hour>." rather than dropping the clause.
- [ ] Manually verify a confident multi-model day still reads as the bare "Rain at 3pm." form.

https://claude.ai/code/session_01BTjYpQQaLofdXEsmDXzLnj

---
_Generated by [Claude Code](https://claude.ai/code/session_01BTjYpQQaLofdXEsmDXzLnj)_