### PR TITLE
Aggregate per-model weather condition for the blended hourly line

### DIFF
--- a/app/src/main/kotlin/app/clothescast/data/InsightCache.kt
+++ b/app/src/main/kotlin/app/clothescast/data/InsightCache.kt
@@ -174,6 +174,11 @@ class InsightCache(
         val windSpeedKmh: Double? = null,
         val relativeHumidityPct: Double? = null,
         val cloudCoverPct: Double? = null,
+        // Weather code bucket, stored as the enum name so a future enum
+        // rename trips deserialisation rather than silently mapping to the
+        // wrong bucket. Nullable for back-compat with payloads written
+        // before the modal condition aggregation landed.
+        val conditionName: String? = null,
     ) {
         fun toDomain(): PerModelHour? {
             val airTemp = temperatureC ?: return null
@@ -185,6 +190,9 @@ class InsightCache(
                 windSpeedKmh = windSpeedKmh,
                 relativeHumidityPct = relativeHumidityPct,
                 cloudCoverPct = cloudCoverPct,
+                condition = conditionName?.let {
+                    runCatching { WeatherCondition.valueOf(it) }.getOrNull()
+                },
             )
         }
     }
@@ -402,6 +410,7 @@ class InsightCache(
         windSpeedKmh = windSpeedKmh,
         relativeHumidityPct = relativeHumidityPct,
         cloudCoverPct = cloudCoverPct,
+        conditionName = condition?.name,
     )
 
     private fun OutfitRationale.toDto(): OutfitRationaleDto = OutfitRationaleDto(

--- a/core/data/src/main/kotlin/app/clothescast/core/data/weather/MultiModelConfidenceFetcher.kt
+++ b/core/data/src/main/kotlin/app/clothescast/core/data/weather/MultiModelConfidenceFetcher.kt
@@ -75,7 +75,7 @@ internal class MultiModelConfidenceFetcher(
                 parameter(
                     "hourly",
                     "apparent_temperature,temperature_2m,precipitation_probability," +
-                        "wind_speed_10m,relative_humidity_2m,cloud_cover",
+                        "wind_speed_10m,relative_humidity_2m,cloud_cover,weather_code",
                 )
                 parameter("models", models.joinToString(","))
             }.body<MultiModelResponse>()
@@ -122,15 +122,16 @@ internal class MultiModelConfidenceFetcher(
                 val winds = obj["wind_speed_10m_$model"] as? JsonArray
                 val humidities = obj["relative_humidity_2m_$model"] as? JsonArray
                 val clouds = obj["cloud_cover_$model"] as? JsonArray
+                val weatherCodes = obj["weather_code_$model"] as? JsonArray
                 if (apparentTemps == null && airTemps == null && precips == null) continue
                 val entries = buildList {
                     for (i in 0 until times.size) {
                         val time = parseHour(times.getOrNull(i)) ?: continue
                         // Required: time, apparent temp, air temp, precip — drop the hour
                         // when any of these are null. Diagnostic fields (wind, humidity,
-                        // cloud) survive per-field nulls; we just carry through what we
-                        // got so the wind / humidity / cloud charts hide that model only
-                        // when *its* field is missing.
+                        // cloud, condition) survive per-field nulls; we just carry through
+                        // what we got so the diagnostic charts and the consensus blend hide
+                        // that model only when *its* field is missing.
                         val apparent = numberAt(apparentTemps, i)?.toDouble() ?: continue
                         val air = numberAt(airTemps, i)?.toDouble() ?: continue
                         val precip = numberAt(precips, i)?.toDouble() ?: continue
@@ -143,6 +144,8 @@ internal class MultiModelConfidenceFetcher(
                                 windSpeedKmh = numberAt(winds, i)?.toDouble(),
                                 relativeHumidityPct = numberAt(humidities, i)?.toDouble(),
                                 cloudCoverPct = numberAt(clouds, i)?.toDouble(),
+                                condition = numberAt(weatherCodes, i)?.toInt()
+                                    ?.let { WmoCodeMapper.map(it) },
                             ),
                         )
                     }

--- a/core/data/src/main/kotlin/app/clothescast/core/data/weather/OpenMeteoClient.kt
+++ b/core/data/src/main/kotlin/app/clothescast/core/data/weather/OpenMeteoClient.kt
@@ -128,11 +128,16 @@ class OpenMeteoClient(
         // ride only the side-band multi-model call and aren't fetched per
         // best_match. Surface as null so the diagnostic charts treat
         // best_match as "no data for this metric" instead of dropping it.
+        // The weather code *is* available on the primary call (already
+        // mapped to a [WeatherCondition] in [OpenMeteoMapper]), so we pass
+        // it through — the consensus blend's modal aggregation gets a 4th
+        // vote from best_match this way.
         PerModelHour(
             time = it.time,
             apparentTemperatureC = it.feelsLikeC,
             temperatureC = it.temperatureC,
             precipitationProbabilityPct = it.precipitationProbabilityPct,
+            condition = it.condition,
         )
     }
 

--- a/core/data/src/test/kotlin/app/clothescast/core/data/weather/MultiModelConfidenceFetcherTest.kt
+++ b/core/data/src/test/kotlin/app/clothescast/core/data/weather/MultiModelConfidenceFetcherTest.kt
@@ -2,6 +2,7 @@ package app.clothescast.core.data.weather
 
 import app.clothescast.core.domain.model.ForecastConfidence
 import app.clothescast.core.domain.model.Location
+import app.clothescast.core.domain.model.WeatherCondition
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.doubles.plusOrMinus
 import io.kotest.matchers.nulls.shouldBeNull
@@ -75,7 +76,7 @@ class MultiModelConfidenceFetcherTest {
         req.url.parameters["daily"] shouldBe "apparent_temperature_max,precipitation_probability_max"
         req.url.parameters["hourly"] shouldBe
             "apparent_temperature,temperature_2m,precipitation_probability," +
-            "wind_speed_10m,relative_humidity_2m,cloud_cover"
+            "wind_speed_10m,relative_humidity_2m,cloud_cover,weather_code"
         req.url.parameters["forecast_days"] shouldBe "1"
         req.url.parameters["past_days"].shouldBeNull()
     }
@@ -140,6 +141,9 @@ class MultiModelConfidenceFetcherTest {
         ecmwf[0].windSpeedKmh shouldBe (8.0 plusOrMinus 0.0001)
         ecmwf[0].relativeHumidityPct shouldBe (78.0 plusOrMinus 0.0001)
         ecmwf[0].cloudCoverPct shouldBe (60.0 plusOrMinus 0.0001)
+        // WMO 3 → CLOUDY; ensures weather_code_<model> is being parsed
+        // through [WmoCodeMapper] alongside the numeric fields.
+        ecmwf[0].condition shouldBe WeatherCondition.CLOUDY
         ecmwf[2].time shouldBe LocalTime.of(2, 0)
     }
 
@@ -323,7 +327,10 @@ class MultiModelConfidenceFetcherTest {
                 "relative_humidity_2m_icon_seamless": [82, 84, 85],
                 "cloud_cover_ecmwf_ifs04": [60, 70, 80],
                 "cloud_cover_gfs_seamless": [65, 72, 78],
-                "cloud_cover_icon_seamless": [40, 55, 70]
+                "cloud_cover_icon_seamless": [40, 55, 70],
+                "weather_code_ecmwf_ifs04": [3, 61, 61],
+                "weather_code_gfs_seamless": [2, 61, 61],
+                "weather_code_icon_seamless": [3, 51, 51]
               }
             }
         """.trimIndent()

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/ConsensusBlend.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/ConsensusBlend.kt
@@ -24,9 +24,13 @@ package app.clothescast.core.domain.model
  *   - When two or more models reported an entry at hour t, replace
  *     best_match's value with their mean. With fewer than two, keep
  *     best_match — a one-model "consensus" isn't a consensus.
- *   - [HourlyForecast.condition] (CLEAR / RAIN / etc.) stays from
- *     best_match for now; modal aggregation of weather codes across
- *     models is a follow-up — see TODO in [PerModelHourly].
+ *   - [HourlyForecast.condition] (CLEAR / RAIN / etc.) is aggregated
+ *     modally — most-commonly-predicted bucket across the same
+ *     candidate set wins, with ties broken by severity so the
+ *     "Combined" line's icon stays in sync with its numeric series
+ *     (otherwise we'd get a 90% rain line drawn alongside a "Clear"
+ *     condition icon when best_match disagreed on the code). See
+ *     [consensusCondition].
  *
  * Returns null when nothing was blended: [perModel] is null, fewer than
  * two models reported overall, or every hour fell back to best_match.
@@ -60,10 +64,53 @@ fun blendConsensusHourly(
                 temperatureC = candidates.map { it.temperatureC }.average(),
                 feelsLikeC = candidates.map { it.apparentTemperatureC }.average(),
                 precipitationProbabilityPct = candidates.map { it.precipitationProbabilityPct }.average(),
+                condition = consensusCondition(
+                    fallback = hour.condition,
+                    candidates = candidates.mapNotNull { it.condition },
+                ),
             )
         }
     }
     return if (anyBlended) out else null
+}
+
+/**
+ * Picks a single weather condition that represents the consulted models
+ * at a given hour. Strategy is **modal with severity tiebreak**: the most
+ * commonly-predicted bucket wins; on a tie, the more severe one wins
+ * (RAIN beats CLEAR, SNOW beats RAIN, etc.). Avoids the over-cautious
+ * "any-rain-anywhere → rain" failure mode of pure max-severity while
+ * still nudging toward the more actionable outcome when models genuinely
+ * split. Returns [fallback] when [candidates] is empty.
+ */
+private fun consensusCondition(
+    fallback: WeatherCondition,
+    candidates: List<WeatherCondition>,
+): WeatherCondition {
+    if (candidates.isEmpty()) return fallback
+    val counts = candidates.groupingBy { it }.eachCount()
+    val maxCount = counts.values.max()
+    val winners = counts.filterValues { it == maxCount }.keys
+    return winners.maxBy { it.severityRank() }
+}
+
+/**
+ * Severity ranking used by [consensusCondition] to break modal-aggregation
+ * ties. Order is roughly "how much would this change today's outfit", so
+ * THUNDERSTORM > SNOW > RAIN > DRIZZLE > FOG > CLOUDY > PARTLY_CLOUDY >
+ * CLEAR > UNKNOWN. Internal to the consensus blend for now; promote to a
+ * public extension on [WeatherCondition] if another caller needs it.
+ */
+private fun WeatherCondition.severityRank(): Int = when (this) {
+    WeatherCondition.THUNDERSTORM -> 8
+    WeatherCondition.SNOW -> 7
+    WeatherCondition.RAIN -> 6
+    WeatherCondition.DRIZZLE -> 5
+    WeatherCondition.FOG -> 4
+    WeatherCondition.CLOUDY -> 3
+    WeatherCondition.PARTLY_CLOUDY -> 2
+    WeatherCondition.CLEAR -> 1
+    WeatherCondition.UNKNOWN -> 0
 }
 
 /**

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/PerModelHourly.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/PerModelHourly.kt
@@ -27,9 +27,13 @@ data class PerModelHourly(
         /**
          * Sentinel model id for Open-Meteo's `best_match` auto-selection —
          * stored alongside the consulted models in [byModel] so the chart
-         * can render it as a labelled overlay. Consensus + spread / confidence
-         * computations exclude this entry; only the real consulted models
-         * (ECMWF, GFS, ICON, etc.) feed those.
+         * can render it as a labelled overlay. Treated as a regular model
+         * in the consensus blend + divergence summary: it's one of the
+         * forecasts in play and folding it in keeps Open-Meteo's
+         * (presumably location-tuned) signal in the mean. ConfidenceInfo's
+         * tempSpreadC / precipSpreadPp still come from the consulted-only
+         * subset because best_match isn't reported via the side-band
+         * `daily` block.
          */
         const val BEST_MATCH_MODEL_ID = "best_match"
     }
@@ -63,6 +67,15 @@ data class PerModelHour(
      *  gain (one predicts a mid-day clearing, the other keeps it overcast).
      *  Nullable — see [windSpeedKmh]. */
     val cloudCoverPct: Double? = null,
+    /** Coarse weather bucket for the hour, mapped from the model's WMO
+     *  weather code. Carried per-model so [blendConsensusHourly] can pick
+     *  a defensible condition for the blended main line (modal aggregation
+     *  with a severity tiebreak); without it the blended numeric series
+     *  would coexist with whichever model the [HourlyForecast] originally
+     *  came from for the icon/label, which on divergence days produced
+     *  "90% rain, Clear conditions" inconsistencies. Nullable for the same
+     *  back-compat reasons as the other diagnostic fields. */
+    val condition: WeatherCondition? = null,
 )
 
 // TODO(model-spread-stat): cross-model spread is currently reported as
@@ -70,8 +83,3 @@ data class PerModelHour(
 //   swings that disproportionately; explore RMSE / std-dev across the
 //   consulted models as an alternative confidence input, plotted
 //   alongside the existing spread so we can A/B them before switching.
-// TODO(weather-code-aggregation): [blendConsensusHourly] currently keeps
-//   the best_match weather code (CLEAR / RAIN / etc.) even when it
-//   blends the numeric fields, so a "Combined" line at 90% rain can
-//   coexist with a "Clear" condition icon. Modal aggregation of weather
-//   codes across the consulted models would close that loop.

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/model/ConsensusBlendTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/model/ConsensusBlendTest.kt
@@ -14,12 +14,13 @@ class ConsensusBlendTest {
         temp: Double,
         feels: Double = temp - 1.0,
         precip: Double = 0.0,
+        condition: WeatherCondition = WeatherCondition.CLEAR,
     ) = HourlyForecast(
         time = LocalTime.of(h, 0),
         temperatureC = temp,
         feelsLikeC = feels,
         precipitationProbabilityPct = precip,
-        condition = WeatherCondition.CLEAR,
+        condition = condition,
     )
 
     private fun perModel(
@@ -27,11 +28,13 @@ class ConsensusBlendTest {
         apparent: Double,
         air: Double,
         precip: Double = 0.0,
+        condition: WeatherCondition? = null,
     ) = PerModelHour(
         time = LocalTime.of(h, 0),
         apparentTemperatureC = apparent,
         temperatureC = air,
         precipitationProbabilityPct = precip,
+        condition = condition,
     )
 
     @Test
@@ -128,6 +131,71 @@ class ConsensusBlendTest {
 
         blended[0].temperatureC shouldBe (13.0 plusOrMinus 0.0001)  // consensus
         blended[1] shouldBe best[1]                                   // fell back
+    }
+
+    @Test
+    fun `condition is aggregated modally across models`() {
+        // best_match says CLEAR but two of three consulted models say RAIN —
+        // mode wins. This is the case the modal aggregation was added to
+        // handle: the 90%-rain Combined line used to draw with a CLEAR icon
+        // because we kept best_match's condition untouched.
+        val best = listOf(hour(12, temp = 10.0, precip = 30.0, condition = WeatherCondition.CLEAR))
+        val perModel = PerModelHourly(
+            byModel = mapOf(
+                "gfs_seamless" to listOf(perModel(12, apparent = 11.0, air = 12.0, precip = 80.0,
+                    condition = WeatherCondition.RAIN)),
+                "icon_seamless" to listOf(perModel(12, apparent = 13.0, air = 14.0, precip = 90.0,
+                    condition = WeatherCondition.RAIN)),
+                "ecmwf_ifs04" to listOf(perModel(12, apparent = 12.0, air = 13.0, precip = 60.0,
+                    condition = WeatherCondition.CLOUDY)),
+            ),
+        )
+
+        val blended = blendConsensusHourly(best, perModel).shouldNotBeNull()
+
+        blended[0].condition shouldBe WeatherCondition.RAIN
+    }
+
+    @Test
+    fun `condition tie is broken by severity, favouring the more actionable bucket`() {
+        // Two models say CLEAR, two say RAIN — mode is a 2-2 tie. Severity
+        // tiebreak picks RAIN (the more actionable / outfit-relevant
+        // outcome) rather than CLEAR.
+        val best = listOf(hour(12, temp = 15.0, condition = WeatherCondition.CLEAR))
+        val perModel = PerModelHourly(
+            byModel = mapOf(
+                "gfs_seamless" to listOf(perModel(12, apparent = 14.0, air = 15.0,
+                    condition = WeatherCondition.CLEAR)),
+                "icon_seamless" to listOf(perModel(12, apparent = 16.0, air = 17.0,
+                    condition = WeatherCondition.RAIN)),
+                "ecmwf_ifs04" to listOf(perModel(12, apparent = 15.0, air = 16.0,
+                    condition = WeatherCondition.RAIN)),
+                PerModelHourly.BEST_MATCH_MODEL_ID to listOf(perModel(12, apparent = 15.0, air = 16.0,
+                    condition = WeatherCondition.CLEAR)),
+            ),
+        )
+
+        val blended = blendConsensusHourly(best, perModel).shouldNotBeNull()
+
+        blended[0].condition shouldBe WeatherCondition.RAIN
+    }
+
+    @Test
+    fun `condition falls back to best-match when no model reported one`() {
+        // All four models present (so the numeric blend runs) but none of
+        // them carried a weather code — keep best_match's condition rather
+        // than rolling UNKNOWN through.
+        val best = listOf(hour(12, temp = 10.0, condition = WeatherCondition.CLEAR))
+        val perModel = PerModelHourly(
+            byModel = mapOf(
+                "gfs_seamless" to listOf(perModel(12, apparent = 11.0, air = 12.0)),
+                "icon_seamless" to listOf(perModel(12, apparent = 13.0, air = 14.0)),
+            ),
+        )
+
+        val blended = blendConsensusHourly(best, perModel).shouldNotBeNull()
+
+        blended[0].condition shouldBe WeatherCondition.CLEAR
     }
 
     @Test


### PR DESCRIPTION
## Summary

Closes the TODO left by #394: the consensus blend numerics (temp / feels-like / precip) combine across models, but the condition (CLEAR / RAIN / etc.) was still pulled from best_match alone — so on a divergence day the chart could draw a 90%-rain "Combined" line alongside a "Clear" icon if best_match's WMO code didn't agree with what the consulted models said.

## Plumbing

- `PerModelHour.condition: WeatherCondition?` added, fetched from Open-Meteo's `weather_code_<model>` hourly field in `MultiModelConfidenceFetcher` and mapped through the existing `WmoCodeMapper`.
- `OpenMeteoClient.asPerModelHours` passes through `HourlyForecast.condition` for the best_match overlay (the primary `/v1/forecast` call already returns `weather_code`, so no extra fetch).
- `InsightCache.PerModelHourDto.conditionName` serialises as the enum name; nullable for back-compat with older cached payloads.

## Aggregation

**Modal with severity tiebreak**, in `consensusCondition`:

- Most-commonly-predicted bucket wins.
- Ties broken by severity rank: `THUNDERSTORM > SNOW > RAIN > DRIZZLE > FOG > CLOUDY > PARTLY_CLOUDY > CLEAR > UNKNOWN`. Avoids the over-cautious bias of pure max-severity (one outlier saying RAIN doesn't override three models saying CLOUDY) while still leaning toward the more actionable outcome on genuine splits.
- Falls back to best_match's condition when no model in the candidate set carried a code, so we don't surface UNKNOWN in the rare zero-data case.

## What's intentionally not in this PR

`DailyForecast.condition` (the day-level summary used in the insight prose) stays from best_match for now. Re-deriving it from blended hourly is a separate question about how to summarise a mixed day (is "RAIN at 14:00 then CLEAR" a rainy day or a partly-cloudy one?), and outside this PR's scope.

## Test plan

- [ ] CI: `:core:domain:test` green (new condition aggregation cases in `ConsensusBlendTest`)
- [ ] CI: `:core:data:test` green (`MultiModelConfidenceFetcherTest` now parses `weather_code_<model>`)
- [ ] CI: JVM + Android debug build green
- [ ] On device, divergence day: chart icon / per-hour condition no longer disagrees with the numeric series

## Privacy

No change — same lat/lon, one extra hourly field on the existing call.

Open PRs in this session:
- https://github.com/mikelward/clothescast/pull/396 (this PR — fingers crossed)

https://claude.ai/code/session_01DUHtB5jzSzfbnj3GGqyggP

---
_Generated by [Claude Code](https://claude.ai/code/session_01DUHtB5jzSzfbnj3GGqyggP)_