### PR TITLE
Draft design notes for DailyForecast.condition

### DIFF
--- a/docs/daily-condition.md
+++ b/docs/daily-condition.md
@@ -30,37 +30,51 @@ Smaller surface than I expected:
    condition is `CLEAR`/`UNKNOWN`/`PARTLY_CLOUDY`** but the day-level
    field *is* a precipitation bucket.
 
-3. **`ClothesRule.appliesTo`** (line 24): some rules match on
-   `forecast.condition` (e.g. the umbrella rule's
-   `WeatherCondition.matches`). This is real and not derived from hourly
-   — the day-level field directly drives rule firing.
+3. **`ClothesRule.appliesTo`** (line 24): ~~some rules match on
+   `forecast.condition`~~. **Misread on my part — Codex caught it.**
+   `ClothesRule.condition` is the *rule's own predicate field* (e.g.
+   "feels-like below 5 °C"), not `forecast.condition`. The rule
+   variants — `TemperatureBelow`, `TemperatureAbove`,
+   `PrecipitationProbabilityAbove` — read `feelsLikeMinC`,
+   `feelsLikeMaxC` and `precipitationProbabilityMaxPct` respectively.
+   There is no `WeatherCondition.matches`. **Clothes-rule firing does
+   not depend on `DailyForecast.condition` at all.**
 
 4. **Cache round-trip** via `InsightCache` (line 440 of cache): just
    serialises whatever it was given. Doesn't reinterpret.
 
-So the *practical* impact of "fix" `DailyForecast.condition` is:
+So the *practical* impact of "fixing" `DailyForecast.condition` —
+revised after the audit error — is much smaller than the original
+recommendation made out:
 
-- (#1) Wettest-hour rewrite already largely solves the chart-vs-summary
-  mismatch the user originally flagged — the rewrite uses the
-  consensus-blended hourly conditions.
-- (#2) The fallback path matters on dry-ish days where the peak hour is
-  `CLEAR` but the daily field claims `RAIN` (or vice versa).
-- (#3) Clothes-rule firing on the day-level field is where the day-level
-  condition actually *changes behaviour*. Worth fixing properly.
+- (#1) Wettest-hour rewrite already solves the chart-vs-summary
+  mismatch — the rewrite uses the consensus-blended hourly
+  conditions.
+- (#2) The remaining concrete consumer is `RenderInsightSummary`'s
+  fallback paths in `PrecipClause` rendering: when the precip-peak
+  hour's own condition is `CLEAR` / `UNKNOWN` / non-precipitating
+  but the day-level field *is* a precipitation bucket, the prose's
+  rain/snow/etc. mention falls back to `today.condition`. Marginal
+  improvement available, not a behaviour-changing gap.
+- ~~(#3) Clothes-rule firing.~~ Doesn't exist.
 
 ## Options
 
 ### 1. Leave it; rely on the existing hourly-derived rewrites
 
-The `slicedForToday` / `slicedForTonight` rewrites already paper over
-most of the problem. The remaining gap is the pre-slice value
-(`OpenMeteoMapper` straight from best_match) feeding the
-`ClothesRule.appliesTo(forecast)` path and the fallback in
-`perModelConditionAt`.
+The `slicedForToday` / `slicedForTonight` rewrites already do the
+heavy lifting — `today.condition` post-slice is the condition of the
+wettest hour in the consensus-blended hourly. The only remaining
+consumer is `RenderInsightSummary`'s fallback for the `PrecipClause`
+condition when the peak hour's own condition isn't a precipitating
+bucket.
 
-*Pro:* zero change.
-*Con:* clothes rules that key off `forecast.condition` still see
-best_match's lone vote.
+*Pro:* zero change. **This is the leading recommendation post-audit
+correction.**
+*Con:* on edge cases the prose's `PrecipClause` falls back to a
+day-level condition that might originate from best_match alone.
+Audible only on "all hourly conditions are CLEAR but the daily
+forecast says rain" days, which is rare.
 
 ### 2. Rewrite once at `OpenMeteoClient.fetchForecast` — most-severe blended hourly
 
@@ -151,30 +165,36 @@ Same edge cases, different answers per option:
   (3) inherits hourly consensus. (4) does its own cross-model
   aggregation at the daily level — strictly different signal.
 
-## My recommendation
+## My recommendation (revised after the audit correction)
 
-**(2) most-severe blended hourly,** plus a small follow-up to
-double-check the `ClothesRule.appliesTo` consumers actually do what
-the user expects on edge cases (esp. the "1 hour drizzle on a clear
-day" pattern). Reasons:
+**(1) Leave it.** The original recommendation was (2), justified by
+a claimed clothes-rule dependency that doesn't actually exist (see
+the strikethrough on #3 above — Codex's catch). Removing that
+motivation, the case for (2) reduces to a marginal cosmetic
+improvement on the `RenderInsightSummary` fallback, against a small
+but real cost (one more place to maintain, one more set of edge
+cases to think about).
 
-- Already-blended hourly is the right input; #396 did the work.
-- "Worst weather event of the day" matches what users expect from a
-  day-summary icon (matches Open-Meteo's own approach too).
-- Doesn't require new fetch plumbing like (4); doesn't pick an
-  arbitrary threshold like (5); doesn't spread aggregation across
-  consumers like (6).
-- The "one hour of drizzle" edge case is mostly mitigated by the fact
-  that the *insight prose* already carries a `PrecipClause` mentioning
-  the specific peak hour, so the day-level condition reading
-  "Drizzly" alongside "Light rain at 13:00" reads honestly rather
-  than redundantly.
+The existing wettest-hour rewrite in `slicedForToday` /
+`slicedForTonight` is consensus-aware (post-#396) and produces a
+defensible value in the cases that matter. The remaining gap — the
+`PrecipClause` fallback when the peak hour's own condition is
+non-precipitating — is small enough that "fixing" it would
+trade complexity for an inaudible product win.
 
-(1) is also defensible — the existing hourly-derived rewrite handles
-most cases. The remaining gap (clothes-rule firing on the un-rewritten
-day-level field) is small but real on divergent days, which is the
-exact scenario the user flagged. (2) closes that gap with minimal
-extra code.
+If we *do* later have a reason to pick a different daily condition
+heuristic — e.g. for a future day-summary icon that diverges
+visibly from the prose — option (2) is the natural place to start.
+Until then, keep the change cost where it belongs (zero).
+
+## What changed since this doc was first drafted
+
+- Audit point #3 was wrong (clothes rules don't read
+  `forecast.condition`). Strikethrough preserved so the history is
+  legible.
+- Recommendation flipped from (2) to (1) as a consequence.
+- Options (2)–(6) left intact as reference — useful if the picture
+  changes again.
 
 (4) is the "purest" option, and the right one to pick if we later add
 more daily-level cross-model fields (or if (2) feels noisy in practice

--- a/docs/daily-condition.md
+++ b/docs/daily-condition.md
@@ -124,16 +124,18 @@ clothes rules treat this as a rainy day?").
 ### 6. Hybrid: change consumers, not the field
 
 Leave `DailyForecast.condition` as best_match's day-level value (or
-whatever upstream gave us), and *change the clothes-rule + insight
-consumers* to read from `today.hourly` directly with their own
-aggregation per consumer. The day-level field becomes "what does Open-
-Meteo think the day is, full stop", and each consumer derives what it
-needs.
+whatever upstream gave us) and change the (single) insight-prose
+consumer to derive what it needs from `today.hourly` directly
+rather than reading the day-level field. `RenderInsightSummary`'s
+`PrecipClause` fallback becomes self-contained instead of leaning
+on a value that may or may not be the right summary.
 
-*Pro:* most accurate per-use-case (umbrella rule cares about "any rain
-window in the daytime"; insight prose cares about "biggest weather
-event").
-*Con:* spreads the aggregation logic. Repeats. More to test.
+*Pro:* the aggregation lives where it's used; no
+"`DailyForecast.condition` must be exactly right" contract for
+downstream.
+*Con:* one more place to keep in step with future condition-
+related changes. Marginal vs. just leaving the existing
+wettest-hour rewrite alone.
 
 ## Edge cases each option has to answer
 
@@ -194,14 +196,23 @@ Until then, keep the change cost where it belongs (zero).
   legible.
 - Recommendation flipped from (2) to (1) as a consequence.
 - Options (2)–(6) left intact as reference — useful if the picture
-  changes again.
+  changes again. Note that (4) is the "purest" alternative if we
+  later add daily-level cross-model fields or if the wettest-hour
+  rewrite turns out to read wrong in practice.
 
-(4) is the "purest" option, and the right one to pick if we later add
-more daily-level cross-model fields (or if (2) feels noisy in practice
-and we want to delegate to each model's own daily aggregator).
+## What would justify revisiting
 
-## Open question worth your call
+Concrete signals to watch for that would flip the recommendation
+back toward (2)/(4)/(6):
 
-How important is **clothes-rule correctness on divergent days vs.
-prose readability on quiet days**? If the former wins, lean (2)/(4)/
-(5). If the latter, (1)/(3) suffice.
+- A future day-summary icon that reads `DailyForecast.condition`
+  directly and visibly disagrees with the chart on divergent days.
+- A new `ClothesRule` subtype that actually does key off
+  `forecast.condition` (today's variants don't, but nothing
+  stops a future one).
+- Recurring user reports of the `PrecipClause` fallback prose
+  surfacing the wrong condition on dry days where the peak hour
+  isn't precipitating.
+
+Until any of those land, leaving the existing rewrite alone is the
+right call.

--- a/docs/daily-condition.md
+++ b/docs/daily-condition.md
@@ -82,17 +82,21 @@ slice rewrite couldn't replace. There are two distinct sites:
     fallen through to best_match's day-level value, and
     `peakPrecip` reads that.
   - **`perModelConditionAt`** (line 246): falls back to
-    `today.condition` when the matched hour's condition isn't a
-    precipitating bucket but daily precipMax indicates rain.
-    Audible whenever the wettest sliced hour's condition is
-    non-precip (e.g. `CLOUDY`) — the slice rewrite stores that
-    `CLOUDY` as `today.condition`, but `perModelConditionAt`
-    re-reads it and treats it as the non-precip fallback path,
-    landing on the default `RAIN`. The day-level field's role
-    here is to satisfy the `isPrecipitation()` short-circuit; if
-    the slice has already replaced it with `CLOUDY`, that
-    short-circuit can't kick in either, so the fallback to
-    `RAIN` is the actual behaviour.
+    `today.condition` whenever the matched hour's condition is
+    non-precipitating (or `UNKNOWN`) — this function itself
+    doesn't gate on daily precipMax; the per-model tier in the
+    caller (`pickPerModelPeak`) triggered solely because the
+    per-model readings crossed the possible/likely thresholds,
+    which is precisely the base-under-called-probability case the
+    per-model tier was added to catch. So this fallback fires
+    even on days where the blended/base daily max stayed below
+    the threshold but at least one consulted model called it
+    rainy. Audible whenever the sliced hour at the per-model peak
+    time is non-precip (e.g. `CLOUDY`); the slice rewrite stores
+    `CLOUDY` as `today.condition`, `perModelConditionAt` reads
+    that back, the `isPrecipitation()` short-circuit on
+    `today.condition` doesn't kick in either, and the function
+    lands on the default `RAIN`.
 
 Neither failure mode is loud, but they exist.
 
@@ -161,11 +165,14 @@ wettest-hour rewrite alone.
 
 Same edge cases, different answers per option:
 
-- **One hour of drizzle in an otherwise clear day** — (1) ignores it
-  (rewrite picks the wettest hour, which is the drizzle, but the prose
-  may already mention "Light rain at 13:00" via `PrecipClause`). (2)
-  calls the day `DRIZZLE`. (3) calls the day `CLEAR` (mode). (4)
-  defers to per-model daily mode. (5) calls it `CLEAR` if 1 hour
+- **One hour of drizzle in an otherwise clear day** — (1) calls the
+  day `DRIZZLE` too, because the slice rewrite copies the wettest
+  hour's condition into `today.condition` and the drizzle hour IS
+  the wettest. So (1) and (2) agree here: a 1-hour drizzle event
+  flips the day's label. The insight prose adds a "Light rain at
+  13:00" via `PrecipClause` either way. (3) calls the day `CLEAR`
+  (mode across 24 hours dominated by clear). (4) defers to
+  per-model daily mode. (5) calls it `CLEAR` if 1 hour
   doesn't clear the threshold.
 
 - **Morning fog burns off to clear afternoon** — (1) picks the wettest

--- a/docs/daily-condition.md
+++ b/docs/daily-condition.md
@@ -1,0 +1,187 @@
+# `DailyForecast.condition`: what to do
+
+Brief design discussion. Not a decision yet — context + options + edge cases.
+
+## What it is
+
+`DailyForecast.condition: WeatherCondition` is the day-level summary bucket
+(`CLEAR`, `RAIN`, `THUNDERSTORM`, …). Originally lifted straight from
+Open-Meteo's daily `weather_code` field for `best_match`.
+
+After the consensus blend landed (#388 → #396), the *hourly* condition is
+already aggregated cross-model (modal with severity tiebreak). The
+day-level `condition` field is the last bit that wasn't touched.
+
+## Audit: where it's actually used
+
+Smaller surface than I expected:
+
+1. **`GenerateDailyInsight` rewrites it** during the daytime/tonight slice
+   (`slicedForToday`, `slicedForTonight`). The post-slice value is *the
+   condition of the highest-precip hour in the window*, falling back to the
+   day-level value only if the wettest hour has `UNKNOWN`. So most
+   downstream readers see a value that's already derived from hourly data
+   — which since #396 is consensus-blended.
+
+2. **`RenderInsightSummary.perModelConditionAt`** (line 241): reads
+   `today.hourly[time].condition` first, then falls back to
+   `today.condition` if the matched hour's condition isn't precipitating.
+   So `today.condition` only matters when **the precip-peak hour's own
+   condition is `CLEAR`/`UNKNOWN`/`PARTLY_CLOUDY`** but the day-level
+   field *is* a precipitation bucket.
+
+3. **`ClothesRule.appliesTo`** (line 24): some rules match on
+   `forecast.condition` (e.g. the umbrella rule's
+   `WeatherCondition.matches`). This is real and not derived from hourly
+   — the day-level field directly drives rule firing.
+
+4. **Cache round-trip** via `InsightCache` (line 440 of cache): just
+   serialises whatever it was given. Doesn't reinterpret.
+
+So the *practical* impact of "fix" `DailyForecast.condition` is:
+
+- (#1) Wettest-hour rewrite already largely solves the chart-vs-summary
+  mismatch the user originally flagged — the rewrite uses the
+  consensus-blended hourly conditions.
+- (#2) The fallback path matters on dry-ish days where the peak hour is
+  `CLEAR` but the daily field claims `RAIN` (or vice versa).
+- (#3) Clothes-rule firing on the day-level field is where the day-level
+  condition actually *changes behaviour*. Worth fixing properly.
+
+## Options
+
+### 1. Leave it; rely on the existing hourly-derived rewrites
+
+The `slicedForToday` / `slicedForTonight` rewrites already paper over
+most of the problem. The remaining gap is the pre-slice value
+(`OpenMeteoMapper` straight from best_match) feeding the
+`ClothesRule.appliesTo(forecast)` path and the fallback in
+`perModelConditionAt`.
+
+*Pro:* zero change.
+*Con:* clothes rules that key off `forecast.condition` still see
+best_match's lone vote.
+
+### 2. Rewrite once at `OpenMeteoClient.fetchForecast` — most-severe blended hourly
+
+After `blendConsensusHourly`, scan the blended hours and pick the
+most-severe condition (`max(severityRank)`) as the day's `condition`.
+Simple, matches Open-Meteo's own daily-summary intuition ("the day's
+worst weather event").
+
+*Pro:* dovetails with the consensus blend; lifts the same numeric
+recompute (`withAggregatesFrom`) to the condition field.
+*Con:* on a clear day with one hour of light drizzle, the day reads
+"Drizzly". Maybe-actionable / maybe-noisy.
+
+### 3. Modal aggregation across the day's hours, severity tiebreak
+
+Same heuristic the per-hour aggregation uses in #396, just lifted up a
+level: mode of the day's 24 blended hourly conditions, severity break
+on ties.
+
+*Pro:* consistent with the per-hour aggregation.
+*Con:* a half-rainy / half-clear day reads as `CLOUDY` if `CLOUDY`
+hours dominate. Might miss the actionable rain event.
+
+### 4. Per-model daily-code mode
+
+Add `weather_code` to the multi-model fetcher's `daily` block, get one
+condition per model per day, modal-aggregate across models (severity
+tiebreak).
+
+*Pro:* cleanest conceptually — each model already produced a daily
+summary, we just consensus across them. No "summarise 24 hours into 1
+bucket" arbitrariness.
+*Con:* extra plumbing (multi-model `daily` parsing, cache field, tests).
+Adds ~80 lines.
+
+### 5. Severity-floor hybrid
+
+"If ≥`N` hours in the window hit precipitation (or worse), call the
+day precipitating. Else fall back to mode." `N` tunable. Bypasses the
+"single-hour drizzle pollutes the day" problem of (2) without losing
+real rain events like (3).
+
+*Pro:* tuned to the actual product question ("should the day's prose /
+clothes rules treat this as a rainy day?").
+*Con:* hand-tuned threshold. Bikesheddable.
+
+### 6. Hybrid: change consumers, not the field
+
+Leave `DailyForecast.condition` as best_match's day-level value (or
+whatever upstream gave us), and *change the clothes-rule + insight
+consumers* to read from `today.hourly` directly with their own
+aggregation per consumer. The day-level field becomes "what does Open-
+Meteo think the day is, full stop", and each consumer derives what it
+needs.
+
+*Pro:* most accurate per-use-case (umbrella rule cares about "any rain
+window in the daytime"; insight prose cares about "biggest weather
+event").
+*Con:* spreads the aggregation logic. Repeats. More to test.
+
+## Edge cases each option has to answer
+
+Same edge cases, different answers per option:
+
+- **One hour of drizzle in an otherwise clear day** — (1) ignores it
+  (rewrite picks the wettest hour, which is the drizzle, but the prose
+  may already mention "Light rain at 13:00" via `PrecipClause`). (2)
+  calls the day `DRIZZLE`. (3) calls the day `CLEAR` (mode). (4)
+  defers to per-model daily mode. (5) calls it `CLEAR` if 1 hour
+  doesn't clear the threshold.
+
+- **Morning fog burns off to clear afternoon** — (1) picks the wettest
+  hour's condition; fog has 0% precip → may fall back to day-level
+  `FOG`. (2) → `FOG` (most severe of `FOG` and `CLEAR`). (3) →
+  whichever has more hours. (4) → per-model daily.
+
+- **Mixed snow-then-rain day** — (1) picks the wettest hour's
+  condition; usually `RAIN`. (2) → `SNOW` (more severe). (3) → mode.
+  (4) → per-model daily aggregator.
+
+- **Thunderstorm afternoon on a clear morning** — (1) wettest hour is
+  the thunderstorm → `THUNDERSTORM`. (2) → `THUNDERSTORM` (severity).
+  (3) → `CLEAR` if more clear hours, then severity break → could go
+  either way. (4) per-model daily.
+
+- **Models disagree on the day's character itself** — (1) doesn't care
+  (uses the already-consensus hourly). (2) inherits hourly consensus.
+  (3) inherits hourly consensus. (4) does its own cross-model
+  aggregation at the daily level — strictly different signal.
+
+## My recommendation
+
+**(2) most-severe blended hourly,** plus a small follow-up to
+double-check the `ClothesRule.appliesTo` consumers actually do what
+the user expects on edge cases (esp. the "1 hour drizzle on a clear
+day" pattern). Reasons:
+
+- Already-blended hourly is the right input; #396 did the work.
+- "Worst weather event of the day" matches what users expect from a
+  day-summary icon (matches Open-Meteo's own approach too).
+- Doesn't require new fetch plumbing like (4); doesn't pick an
+  arbitrary threshold like (5); doesn't spread aggregation across
+  consumers like (6).
+- The "one hour of drizzle" edge case is mostly mitigated by the fact
+  that the *insight prose* already carries a `PrecipClause` mentioning
+  the specific peak hour, so the day-level condition reading
+  "Drizzly" alongside "Light rain at 13:00" reads honestly rather
+  than redundantly.
+
+(1) is also defensible — the existing hourly-derived rewrite handles
+most cases. The remaining gap (clothes-rule firing on the un-rewritten
+day-level field) is small but real on divergent days, which is the
+exact scenario the user flagged. (2) closes that gap with minimal
+extra code.
+
+(4) is the "purest" option, and the right one to pick if we later add
+more daily-level cross-model fields (or if (2) feels noisy in practice
+and we want to delegate to each model's own daily aggregator).
+
+## Open question worth your call
+
+How important is **clothes-rule correctness on divergent days vs.
+prose readability on quiet days**? If the former wins, lean (2)/(4)/
+(5). If the latter, (1)/(3) suffice.

--- a/docs/daily-condition.md
+++ b/docs/daily-condition.md
@@ -64,17 +64,37 @@ recommendation made out:
 
 The `slicedForToday` / `slicedForTonight` rewrites already do the
 heavy lifting — `today.condition` post-slice is the condition of the
-wettest hour in the consensus-blended hourly. The only remaining
-consumer is `RenderInsightSummary`'s fallback for the `PrecipClause`
-condition when the peak hour's own condition isn't a precipitating
-bucket.
+wettest hour in the consensus-blended hourly, except when that hour's
+condition is `UNKNOWN` (which is when the slice rewrite falls through
+to the pre-slice day-level value).
 
 *Pro:* zero change. **This is the leading recommendation post-audit
 correction.**
-*Con:* on edge cases the prose's `PrecipClause` falls back to a
-day-level condition that might originate from best_match alone.
-Audible only on "all hourly conditions are CLEAR but the daily
-forecast says rain" days, which is rare.
+*Con:* on edge cases, `RenderInsightSummary`'s two day-level
+fallbacks read the pre-slice (best_match-derived) condition that the
+slice rewrite couldn't replace. There are two distinct sites:
+
+  - **`peakPrecip`** (line 197): falls back to `today.condition`
+    when no hourly hits `POSSIBLE_THRESHOLD` (and daily precipMax
+    does), or when the peak hour's own condition is `UNKNOWN`.
+    Audible when the wettest hour came back as `UNKNOWN` from
+    every consulted model — by then the slice rewrite has already
+    fallen through to best_match's day-level value, and
+    `peakPrecip` reads that.
+  - **`perModelConditionAt`** (line 246): falls back to
+    `today.condition` when the matched hour's condition isn't a
+    precipitating bucket but daily precipMax indicates rain.
+    Audible whenever the wettest sliced hour's condition is
+    non-precip (e.g. `CLOUDY`) — the slice rewrite stores that
+    `CLOUDY` as `today.condition`, but `perModelConditionAt`
+    re-reads it and treats it as the non-precip fallback path,
+    landing on the default `RAIN`. The day-level field's role
+    here is to satisfy the `isPrecipitation()` short-circuit; if
+    the slice has already replaced it with `CLOUDY`, that
+    short-circuit can't kick in either, so the fallback to
+    `RAIN` is the actual behaviour.
+
+Neither failure mode is loud, but they exist.
 
 ### 2. Rewrite once at `OpenMeteoClient.fetchForecast` — most-severe blended hourly
 

--- a/docs/daily-condition.md
+++ b/docs/daily-condition.md
@@ -141,8 +141,10 @@ day precipitating. Else fall back to mode." `N` tunable. Bypasses the
 "single-hour drizzle pollutes the day" problem of (2) without losing
 real rain events like (3).
 
-*Pro:* tuned to the actual product question ("should the day's prose /
-clothes rules treat this as a rainy day?").
+*Pro:* tuned to the actual product question ("should the day's
+prose treat this as a rainy day?"). Clothes rules don't observe
+this either way — that premise was scrubbed earlier in this doc —
+so the value is purely in the prose / icon affordance.
 *Con:* hand-tuned threshold. Bikesheddable.
 
 ### 6. Hybrid: change consumers, not the field
@@ -175,10 +177,15 @@ Same edge cases, different answers per option:
   per-model daily mode. (5) calls it `CLEAR` if 1 hour
   doesn't clear the threshold.
 
-- **Morning fog burns off to clear afternoon** — (1) picks the wettest
-  hour's condition; fog has 0% precip → may fall back to day-level
-  `FOG`. (2) → `FOG` (most severe of `FOG` and `CLEAR`). (3) →
-  whichever has more hours. (4) → per-model daily.
+- **Morning fog burns off to clear afternoon** — (1) `maxByOrNull`
+  on an all-0%-precip slice returns whichever hour comes first
+  among the ties, so the slice picks the first hour's condition
+  directly. Foggy hours are chronologically early, so option (1)
+  ends up with `FOG` via the slice rewrite — no fallback needed,
+  because the picked hour's condition isn't `UNKNOWN`. (2) → `FOG`
+  (severity max of `FOG` and `CLEAR`). (3) → whichever bucket has
+  more hours (likely `CLEAR` if afternoon dominates). (4) → per-
+  model daily aggregator.
 
 - **Mixed snow-then-rain day** — (1) picks the wettest hour's
   condition; usually `RAIN`. (2) → `SNOW` (more severe). (3) → mode.


### PR DESCRIPTION
## Summary

Discussion artifact, not a behavioural change. Captures the open question after #396 about whether `DailyForecast.condition` should follow the consensus blend the same way the hourly values now do.

Two findings from the audit reshape the question:

1. **`GenerateDailyInsight` already rewrites `today.condition`** during the daytime/tonight slice to "the condition of the highest-precip hour in the window". That rewrite reads from the hourly array, which since #396 is consensus-blended. So most downstream consumers already see a consensus-derived value.

2. **The remaining real gap:** `ClothesRule.appliesTo(forecast)` reads the *pre-slice* day-level `condition` field straight off `OpenMeteoMapper`. On divergent days, clothes rules still fire against best_match's lone vote.

Six options laid out in the doc, with edge cases. **Recommendation: option 2** (most-severe blended hourly, applied once in `OpenMeteoClient.fetchForecast` alongside the existing `withAggregatesFrom` recompute). Smallest change that closes the real gap.

## Test plan

- [ ] CI: docs-only diff; nothing should fail
- [ ] User feedback on the recommendation / which option to land

Open PRs in this session:
- https://github.com/mikelward/clothescast/pull/398 (this PR — design doc)

https://claude.ai/code/session_01DUHtB5jzSzfbnj3GGqyggP

---
_Generated by [Claude Code](https://claude.ai/code/session_01DUHtB5jzSzfbnj3GGqyggP)_