### PR TITLE
Fix evening rain check: consult all models all the way to morning

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -213,6 +213,21 @@ new rule the first time something bites you, not the third.
   temperatures (apparent, wind-chill / humidity adjusted) — never raw 2 m
   air temperature. That's what the user actually experiences stepping
   outside.
+- **Per-model rain doesn't pick clothes, but it does mention rain.** The
+  morning insight's evening tie-in clause has two emission paths. If the
+  user's clothes rules fire for the evening window (e.g. it'll be cold
+  enough for a jacket), the clause names the item *and* folds in the
+  per-model rain time when one's detected: "Bring a jacket tonight, rain
+  at 9pm." If no clothes rule fires but a per-model series spots rain ≥
+  30% in the tonight window and the user has an evening event with a
+  location, the clause still emits — without recommending clothes —
+  as a bare rain warning ("Rain tonight at 9pm." / "Chance of rain
+  tonight at 9pm." for the POSSIBLE tier). The principle: we don't
+  recommend clothes the user hasn't asked for (an umbrella isn't a
+  default, see the comment on `ClothesRule.DEFAULTS`), but we *do*
+  surface rain when a model spots it — staying silent on evening rain
+  because no rule happened to trigger is exactly the case the per-model
+  tier exists to catch.
 - The `:app` module owns Android concerns; LLM choice (which Gemini model
   to call) is `:app`'s problem. The `:core:domain` module is pure Kotlin
   and must stay that way — it's where the clothes / insight logic lives

--- a/app/src/main/kotlin/app/clothescast/data/InsightCache.kt
+++ b/app/src/main/kotlin/app/clothescast/data/InsightCache.kt
@@ -38,6 +38,7 @@ import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import java.time.Instant
 import java.time.LocalDate
+import java.time.LocalDateTime
 import java.time.LocalTime
 
 /**
@@ -121,22 +122,25 @@ class InsightCache(
         val confidence: ConfidenceInfoDto? = null,
         val perModelHourly: PerModelHourlyDto? = null,
     ) {
-        fun toDomain(): Insight = Insight(
-            summary = summary.toDomain(),
-            recommendedItems = recommendedItems,
-            generatedAt = Instant.ofEpochMilli(generatedAtEpochMillis),
-            forDate = LocalDate.ofEpochDay(forDateEpochDays),
-            location = location?.toDomain(),
-            hourly = hourly.map { it.toDomain() },
-            confidence = confidence?.toDomain(),
-            perModelHourly = perModelHourly?.toDomain(),
-            outfit = outfit?.toDomain(),
-            nextOutfit = nextOutfit?.toDomain(),
-            outfitRationale = outfitRationale?.toDomain(),
-            nextOutfitRationale = nextOutfitRationale?.toDomain(),
-            period = runCatching { ForecastPeriod.valueOf(period) }.getOrDefault(ForecastPeriod.TODAY),
-            hasEvents = hasEvents,
-        )
+        fun toDomain(): Insight {
+            val date = LocalDate.ofEpochDay(forDateEpochDays)
+            return Insight(
+                summary = summary.toDomain(),
+                recommendedItems = recommendedItems,
+                generatedAt = Instant.ofEpochMilli(generatedAtEpochMillis),
+                forDate = date,
+                location = location?.toDomain(),
+                hourly = hourly.map { it.toDomain() },
+                confidence = confidence?.toDomain(),
+                perModelHourly = perModelHourly?.toDomain(date),
+                outfit = outfit?.toDomain(),
+                nextOutfit = nextOutfit?.toDomain(),
+                outfitRationale = outfitRationale?.toDomain(),
+                nextOutfitRationale = nextOutfitRationale?.toDomain(),
+                period = runCatching { ForecastPeriod.valueOf(period) }.getOrDefault(ForecastPeriod.TODAY),
+                hasEvents = hasEvents,
+            )
+        }
     }
 
     @Serializable
@@ -149,11 +153,17 @@ class InsightCache(
         // a placeholder 0°C) means the air-temp model lines simply hide until the
         // next worker refresh repopulates the cache; the alternative would draw a
         // glaringly-wrong flat-0 line.
-        fun toDomain(): PerModelHourly? {
+        //
+        // [date] is the surrounding insight's `forDate` — used to rebuild each
+        // entry's [PerModelHour.time] LocalDateTime. GenerateDailyInsight only
+        // ever caches today's per-model hours (the slice in `slicedTo` narrows
+        // to today's daytime), so pairing with `forDate` reconstructs the
+        // correct date for every entry.
+        fun toDomain(date: LocalDate): PerModelHourly? {
             val out = LinkedHashMap<String, List<PerModelHour>>(byModel.size)
             for ((model, hours) in byModel) {
                 val converted = ArrayList<PerModelHour>(hours.size)
-                for (dto in hours) converted += dto.toDomain() ?: return null
+                for (dto in hours) converted += dto.toDomain(date) ?: return null
                 out[model] = converted
             }
             return PerModelHourly(byModel = out)
@@ -180,10 +190,10 @@ class InsightCache(
         // before the modal condition aggregation landed.
         val conditionName: String? = null,
     ) {
-        fun toDomain(): PerModelHour? {
+        fun toDomain(date: LocalDate): PerModelHour? {
             val airTemp = temperatureC ?: return null
             return PerModelHour(
-                time = LocalTime.ofSecondOfDay(secondOfDay.toLong()),
+                time = LocalDateTime.of(date, LocalTime.ofSecondOfDay(secondOfDay.toLong())),
                 apparentTemperatureC = apparentTemperatureC,
                 temperatureC = airTemp,
                 precipitationProbabilityPct = precipitationProbabilityPct,
@@ -301,12 +311,23 @@ class InsightCache(
 
     @Serializable
     private data class EveningEventTieInDto(
-        val item: String,
+        // Nullable on the bare-rain emission path (per-model rain spotted, no
+        // clothes rule triggered). Legacy payloads written before the bare-rain
+        // path landed always carry an item, so the nullable type is forward-
+        // compat only — there's no migration shape to worry about.
+        val item: String? = null,
         val rainSecondOfDay: Int? = null,
+        // Nullable for back-compat: payloads written before the field landed
+        // decode with `null`, and [toDomain] folds that to LIKELY — the same
+        // wording the older code produced unconditionally.
+        val likelihood: String? = null,
     ) {
         fun toDomain(): EveningEventTieInClause = EveningEventTieInClause(
             item = item,
             rainTime = rainSecondOfDay?.let { LocalTime.ofSecondOfDay(it.toLong()) },
+            likelihood = likelihood
+                ?.let { runCatching { PrecipLikelihood.valueOf(it) }.getOrNull() }
+                ?: PrecipLikelihood.LIKELY,
         )
     }
 
@@ -403,7 +424,11 @@ class InsightCache(
     )
 
     private fun PerModelHour.toDto(): PerModelHourDto = PerModelHourDto(
-        secondOfDay = time.toSecondOfDay(),
+        // Only the hour-of-day is persisted; the surrounding insight's
+        // `forDate` rebuilds the LocalDateTime on read. Today's per-model
+        // slice is the only thing GenerateDailyInsight caches, so the date
+        // is unambiguous.
+        secondOfDay = time.toLocalTime().toSecondOfDay(),
         apparentTemperatureC = apparentTemperatureC,
         temperatureC = temperatureC,
         precipitationProbabilityPct = precipitationProbabilityPct,
@@ -441,7 +466,11 @@ class InsightCache(
         },
         calendarTieIn = calendarTieIn?.let { CalendarTieInDto(it.item) },
         eveningEventTieIn = eveningEventTieIn?.let {
-            EveningEventTieInDto(it.item, it.rainTime?.toSecondOfDay())
+            EveningEventTieInDto(
+                item = it.item,
+                rainSecondOfDay = it.rainTime?.toSecondOfDay(),
+                likelihood = it.likelihood.name,
+            )
         },
     )
 

--- a/app/src/main/kotlin/app/clothescast/insight/InsightFormatter.kt
+++ b/app/src/main/kotlin/app/clothescast/insight/InsightFormatter.kt
@@ -131,18 +131,43 @@ class InsightFormatter(
     }
 
     private fun formatEveningEventTieIn(tieIn: EveningEventTieInClause): String? {
-        if (tieIn.item.isBlank()) return null
-        val renderedItem = phraser.withArticle(tieIn.item)
-        if (renderedItem.isBlank()) return null
-        // Local capture so the null check enables smart cast — the property
-        // lives on a :core:domain data class and Kotlin won't smart-cast a
+        // Local captures so null checks enable smart cast — the properties
+        // live on a :core:domain data class and Kotlin won't smart-cast a
         // public API property across modules.
-        val rainTime = tieIn.rainTime ?: return resources.getString(R.string.insight_tie_in, renderedItem)
-        return resources.getString(
-            R.string.insight_tie_in_with_rain,
-            renderedItem,
-            spokenTime(rainTime),
-        )
+        val item = tieIn.item
+        val rainTime = tieIn.rainTime
+        if (item == null) {
+            // Bare-rain path: no clothes rule triggered (the renderer only
+            // emits item=null in this case), so the rain mention is the
+            // entire clause. The renderer also pairs this shape with a
+            // non-null rainTime — return null if not (malformed input,
+            // rather than emit a "Rain tonight at ." sentence).
+            if (rainTime == null) return null
+            val template = when (tieIn.likelihood) {
+                PrecipLikelihood.LIKELY -> R.string.insight_evening_rain
+                PrecipLikelihood.POSSIBLE -> R.string.insight_evening_rain_chance
+            }
+            return resources.getString(template, spokenTime(rainTime))
+        }
+        // Item-led path: blank item indicates malformed input; suppress the
+        // whole clause rather than fall through to bare-rain — a blank
+        // item with rainTime set isn't the renderer's bare-rain emission
+        // (that path produces item=null specifically), so treat it as a
+        // data error.
+        if (item.isBlank()) return null
+        val renderedItem = phraser.withArticle(item)
+        if (renderedItem.isBlank()) return null
+        rainTime ?: return resources.getString(R.string.insight_tie_in, renderedItem)
+        // Hedge the item-led wording when only one model spotted the rain,
+        // matching the bare-rain path's chance-of-rain template. Otherwise
+        // a clothes rule triggering for warmth would always promote a
+        // single-model rain reading to a confident "Bring a jacket
+        // tonight, rain at 9pm." even when the per-model tier was POSSIBLE.
+        val template = when (tieIn.likelihood) {
+            PrecipLikelihood.LIKELY -> R.string.insight_tie_in_with_rain
+            PrecipLikelihood.POSSIBLE -> R.string.insight_tie_in_with_rain_chance
+        }
+        return resources.getString(template, renderedItem, spokenTime(rainTime))
     }
 
     private fun leadRes(period: ForecastPeriod): Int = when (period) {

--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayPreviews.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayPreviews.kt
@@ -625,6 +625,12 @@ internal fun PrecipitationCardDarkPreview() {
     Frame(darkTheme = true) { PrecipitationCard(hourly = SAMPLE_HOURLY_RAINY) }
 }
 
+// Sample anchor for per-model entries. Charts read `time.toLocalTime()` for
+// labels, so any LocalDate works — pinning today keeps preview output
+// deterministic-ish across runs (and matches SAMPLE_INSIGHT.forDate's
+// vintage).
+private val SAMPLE_PER_MODEL_DATE: LocalDate = LocalDate.of(2026, 4, 26)
+
 // Three model curves spread around the blended sample. Offsets are deliberate
 // so the overlay is visually distinguishable from the main line.
 private val SAMPLE_PER_MODEL_HOURLY: PerModelHourly = run {
@@ -635,7 +641,7 @@ private val SAMPLE_PER_MODEL_HOURLY: PerModelHourly = run {
             // showing where the spread is largest.
             val hourPhase = (i - 6).coerceAtLeast(0).coerceAtMost(12)
             PerModelHour(
-                time = h.time,
+                time = java.time.LocalDateTime.of(SAMPLE_PER_MODEL_DATE, h.time),
                 apparentTemperatureC = h.feelsLikeC + deltaC,
                 temperatureC = h.temperatureC + deltaC,
                 precipitationProbabilityPct = (h.precipitationProbabilityPct + precipDelta)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -772,4 +772,31 @@
     with the morning slice's own. %1$s = item phrase, %2$s = spoken time.
     -->
     <string name="insight_tie_in_with_rain">Bring %1$s tonight, rain at %2$s.</string>
+    <!--
+    POSSIBLE-tier counterpart of insight_tie_in_with_rain: a clothes rule
+    triggered for the evening but only one per-model series flagged the
+    rain at ≥ 30%. Hedges the wording so a single-model rain reading
+    doesn't render with the same definite tone as a majority-of-models
+    agreement. %1$s = item phrase, %2$s = spoken time.
+    -->
+    <string name="insight_tie_in_with_rain_chance">Bring %1$s tonight, chance of rain at %2$s.</string>
+    <!--
+    Bare-rain variant of the evening tie-in for the morning insight: emitted
+    when the user has an evening event with a location and the per-model
+    forecast tier spots rain ≥ 50% (majority of models agree) at some hour in
+    the tonight window, but no clothes rule fired for that period. The
+    morning insight stays silent on clothing because nothing's been picked
+    yet — the rain mention itself is the point. %1$s = spoken time. Mirrors
+    insight_precip's verbosity ("Rain at 9pm" → "Rain tonight at 9pm")
+    rather than introducing a separate "tonight" lead-in clause, since this
+    sits alongside today's morning band/clothes/precip prose where "tonight"
+    is the disambiguation the listener needs.
+    -->
+    <string name="insight_evening_rain">Rain tonight at %1$s.</string>
+    <!--
+    POSSIBLE-tier counterpart of insight_evening_rain: only one per-model
+    series flagged the tonight hour ≥ 30%, so we hedge the wording. Matches
+    insight_precip_chance's "Chance of rain" pattern. %1$s = spoken time.
+    -->
+    <string name="insight_evening_rain_chance">Chance of rain tonight at %1$s.</string>
 </resources>

--- a/app/src/test/kotlin/app/clothescast/data/InsightCacheTest.kt
+++ b/app/src/test/kotlin/app/clothescast/data/InsightCacheTest.kt
@@ -45,6 +45,7 @@ import java.io.File
 import java.nio.file.Path
 import java.time.Instant
 import java.time.LocalDate
+import java.time.LocalDateTime
 import java.time.LocalTime
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -79,7 +80,7 @@ class InsightCacheTest {
             byModel = mapOf(
                 "ecmwf_ifs04" to listOf(
                     PerModelHour(
-                        time = LocalTime.of(0, 0),
+                        time = LocalDateTime.of(today, LocalTime.of(0, 0)),
                         apparentTemperatureC = 12.0,
                         temperatureC = 14.0,
                         precipitationProbabilityPct = 10.0,
@@ -88,7 +89,7 @@ class InsightCacheTest {
                         cloudCoverPct = 60.0,
                     ),
                     PerModelHour(
-                        time = LocalTime.of(1, 0),
+                        time = LocalDateTime.of(today, LocalTime.of(1, 0)),
                         apparentTemperatureC = 11.5,
                         temperatureC = 13.5,
                         precipitationProbabilityPct = 15.0,
@@ -101,8 +102,8 @@ class InsightCacheTest {
                 // upstream model run didn't return wind / humidity / cloud,
                 // but temp + precip are present so the entry survives.
                 "gfs_seamless" to listOf(
-                    PerModelHour(LocalTime.of(0, 0), 12.2, 14.2, 12.0),
-                    PerModelHour(LocalTime.of(1, 0), 11.8, 13.8, 18.0),
+                    PerModelHour(LocalDateTime.of(today, LocalTime.of(0, 0)), 12.2, 14.2, 12.0),
+                    PerModelHour(LocalDateTime.of(today, LocalTime.of(1, 0)), 11.8, 13.8, 18.0),
                 ),
             ),
         ),
@@ -322,6 +323,31 @@ class InsightCacheTest {
         subject.store(full)
 
         subject.latest.first() shouldBe full
+    }
+
+    @Test
+    fun `bare-rain evening tie-in round-trips through the cache`() = runTest {
+        // The new emission shape: item null (no clothes rule triggered),
+        // rainTime set, POSSIBLE likelihood from a single-model rain
+        // signal. The DTO has to preserve all three across a serde cycle —
+        // a regression that nulled likelihood would silently downgrade
+        // every cached bare-rain clause to LIKELY on read.
+        val bareRain = sample.copy(
+            summary = sample.summary.copy(
+                eveningEventTieIn = EveningEventTieInClause(
+                    item = null,
+                    rainTime = LocalTime.of(21, 0),
+                    likelihood = PrecipLikelihood.POSSIBLE,
+                ),
+            ),
+        )
+
+        subject.store(bareRain)
+
+        val tie = subject.latest.first()?.summary?.eveningEventTieIn
+        tie?.item shouldBe null
+        tie?.rainTime shouldBe LocalTime.of(21, 0)
+        tie?.likelihood shouldBe PrecipLikelihood.POSSIBLE
     }
 
     @Test

--- a/app/src/test/kotlin/app/clothescast/insight/InsightFormatterTest.kt
+++ b/app/src/test/kotlin/app/clothescast/insight/InsightFormatterTest.kt
@@ -201,6 +201,43 @@ class InsightFormatterTest {
     }
 
     @Test
+    fun `evening event tie-in renders bare rain when item is null and rain time is set`() {
+        val out = subject.format(
+            summary(
+                eveningEventTieIn = EveningEventTieInClause(
+                    item = null,
+                    rainTime = LocalTime.of(21, 0),
+                ),
+            ),
+        )
+        out shouldBe "Today will be mild. Rain tonight at 9pm."
+    }
+
+    @Test
+    fun `evening event tie-in hedges to chance when likelihood is POSSIBLE`() {
+        val out = subject.format(
+            summary(
+                eveningEventTieIn = EveningEventTieInClause(
+                    item = null,
+                    rainTime = LocalTime.of(21, 0),
+                    likelihood = PrecipLikelihood.POSSIBLE,
+                ),
+            ),
+        )
+        out shouldBe "Today will be mild. Chance of rain tonight at 9pm."
+    }
+
+    @Test
+    fun `evening event tie-in is omitted when item is null and rain time is null too`() {
+        val out = subject.format(
+            summary(
+                eveningEventTieIn = EveningEventTieInClause(item = null, rainTime = null),
+            ),
+        )
+        out shouldBe "Today will be mild."
+    }
+
+    @Test
     fun `evening event tie-in renders 'Bring a item tonight' when no evening rain`() {
         val out = subject.format(
             summary(
@@ -218,6 +255,26 @@ class InsightFormatterTest {
             ),
         )
         out shouldBe "Today will be mild. Bring an umbrella tonight, rain at 9pm."
+    }
+
+    @Test
+    fun `evening event tie-in hedges item-led wording when likelihood is POSSIBLE`() {
+        // Matches the bare-rain path's hedge: a clothes rule triggered (the
+        // user has a jacket rule and the evening is cold) but only one
+        // per-model series flagged the rain, so the per-model tier was
+        // POSSIBLE rather than LIKELY. Without the hedge, a single-model
+        // rain reading would render with the same definite tone as
+        // "majority of models agree".
+        val out = subject.format(
+            summary(
+                eveningEventTieIn = EveningEventTieInClause(
+                    item = "jacket",
+                    rainTime = LocalTime.of(21, 0),
+                    likelihood = PrecipLikelihood.POSSIBLE,
+                ),
+            ),
+        )
+        out shouldBe "Today will be mild. Bring a jacket tonight, chance of rain at 9pm."
     }
 
     @Test

--- a/core/data/src/main/kotlin/app/clothescast/core/data/weather/MultiModelConfidenceFetcher.kt
+++ b/core/data/src/main/kotlin/app/clothescast/core/data/weather/MultiModelConfidenceFetcher.kt
@@ -27,7 +27,6 @@ import kotlinx.serialization.json.doubleOrNull
 import kotlinx.serialization.json.intOrNull
 import kotlinx.serialization.json.jsonPrimitive
 import java.time.LocalDateTime
-import java.time.LocalTime
 
 /**
  * Fetches today's apparent-max temperature and peak precipitation probability from
@@ -69,7 +68,13 @@ internal class MultiModelConfidenceFetcher(
                 }
                 parameter("latitude", location.latitude)
                 parameter("longitude", location.longitude)
-                parameter("forecast_days", 1)
+                // forecast_days=2 so the per-model series covers today AND tomorrow's
+                // pre-dawn hours. The tonight insight's evening tie-in needs the wrap
+                // past midnight to spot rain that one model sees overnight but the
+                // base-only fallback misses. Confidence aggregates read `daily[0]`
+                // (today's value), so widening the window doesn't disturb the
+                // tier calculation downstream.
+                parameter("forecast_days", 2)
                 parameter("timezone", "auto")
                 parameter("daily", "apparent_temperature_max,precipitation_probability_max")
                 parameter(
@@ -156,12 +161,9 @@ internal class MultiModelConfidenceFetcher(
         return if (byModel.isEmpty()) null else PerModelHourly(byModel)
     }
 
-    private fun parseHour(element: JsonElement?): LocalTime? {
+    private fun parseHour(element: JsonElement?): LocalDateTime? {
         val text = (element as? JsonPrimitive)?.contentOrNull ?: return null
-        return runCatching {
-            val ldt = LocalDateTime.parse(text)
-            LocalTime.of(ldt.hour, ldt.minute)
-        }.getOrNull()
+        return runCatching { LocalDateTime.parse(text) }.getOrNull()
     }
 
     private fun readModelDaily(daily: JsonObject, model: String): ReadOutcome {

--- a/core/data/src/main/kotlin/app/clothescast/core/data/weather/OpenMeteoClient.kt
+++ b/core/data/src/main/kotlin/app/clothescast/core/data/weather/OpenMeteoClient.kt
@@ -23,6 +23,8 @@ import io.ktor.http.path
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
+import java.time.LocalDateTime
+import java.time.LocalDate
 
 internal const val OPEN_METEO_HOST = "api.open-meteo.com"
 
@@ -95,10 +97,26 @@ class OpenMeteoClient(
         // posture documented on [blendConsensusHourly], and an earlier
         // ordering of these two blocks regressed that by passing the
         // pre-injection map (Codex caught it on PR review).
+        //
+        // Include tomorrow's best_match hours too. The multi-model fetcher
+        // pulls today + tomorrow's pre-dawn (forecast_days=2) to feed the
+        // evening tie-in's wrap past midnight, so the consulted models
+        // (ECMWF / GFS / ICON) have tomorrow entries. If best_match's
+        // entries stopped at today's 23:00, [RenderInsightSummary.pickPerModelPeak]'s
+        // `majorityNeeded = models.size / 2 + 1` would compute the bar from
+        // all 4 models but only 3 readings would actually exist for any
+        // tomorrow hour, silently downgrading a clean 2-of-3-models-agree
+        // tomorrow peak to POSSIBLE (Codex caught it). Pulling
+        // [ForecastBundle.tomorrowHourly] through keeps best_match a real
+        // 4th vote on both sides of the midnight boundary.
+        val tomorrowDate = bundle.today.date.plusDays(1)
+        val bestMatchPerModel =
+            bestMatchHourly.asPerModelHours(bundle.today.date) +
+                bundle.tomorrowHourly.asPerModelHours(tomorrowDate)
         val perModelWithBestMatch = multi?.hourly?.let { existing ->
             existing.copy(
                 byModel = existing.byModel +
-                    (PerModelHourly.BEST_MATCH_MODEL_ID to bestMatchHourly.asPerModelHours()),
+                    (PerModelHourly.BEST_MATCH_MODEL_ID to bestMatchPerModel),
             )
         }
 
@@ -110,7 +128,7 @@ class OpenMeteoClient(
         // steps) for a max computed from the hourly *samples*, which can
         // differ by a fraction of a degree even when the consensus didn't
         // apply anywhere.
-        val blendedToday = blendConsensusHourly(bestMatchHourly, perModelWithBestMatch)
+        val blendedToday = blendConsensusHourly(bundle.today.date, bestMatchHourly, perModelWithBestMatch)
             ?.let { bundle.today.withAggregatesFrom(it) }
             ?: bundle.today
 
@@ -122,7 +140,7 @@ class OpenMeteoClient(
         )
     }
 
-    private fun List<HourlyForecast>.asPerModelHours(): List<PerModelHour> = map {
+    private fun List<HourlyForecast>.asPerModelHours(date: LocalDate): List<PerModelHour> = map {
         // best_match's hourly comes from the primary `/v1/forecast` call which
         // doesn't include the diagnostic fields (wind, humidity, cloud); those
         // ride only the side-band multi-model call and aren't fetched per
@@ -133,7 +151,7 @@ class OpenMeteoClient(
         // it through — the consensus blend's modal aggregation gets a 4th
         // vote from best_match this way.
         PerModelHour(
-            time = it.time,
+            time = LocalDateTime.of(date, it.time),
             apparentTemperatureC = it.feelsLikeC,
             temperatureC = it.temperatureC,
             precipitationProbabilityPct = it.precipitationProbabilityPct,

--- a/core/data/src/test/kotlin/app/clothescast/core/data/weather/MultiModelConfidenceFetcherTest.kt
+++ b/core/data/src/test/kotlin/app/clothescast/core/data/weather/MultiModelConfidenceFetcherTest.kt
@@ -22,7 +22,7 @@ import io.ktor.utils.io.ByteReadChannel
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Test
-import java.time.LocalTime
+import java.time.LocalDateTime
 
 class MultiModelConfidenceFetcherTest {
     private val london = Location(latitude = 51.5074, longitude = -0.1278, displayName = "London")
@@ -77,7 +77,10 @@ class MultiModelConfidenceFetcherTest {
         req.url.parameters["hourly"] shouldBe
             "apparent_temperature,temperature_2m,precipitation_probability," +
             "wind_speed_10m,relative_humidity_2m,cloud_cover,weather_code"
-        req.url.parameters["forecast_days"] shouldBe "1"
+        // forecast_days=2 keeps the wrap-past-midnight evening tie-in able to
+        // see tomorrow's pre-dawn rain that one model spots but the base
+        // forecast under-calls.
+        req.url.parameters["forecast_days"] shouldBe "2"
         req.url.parameters["past_days"].shouldBeNull()
     }
 
@@ -134,7 +137,7 @@ class MultiModelConfidenceFetcherTest {
             listOf("ecmwf_ifs04", "gfs_seamless", "icon_seamless")
         val ecmwf = hourly.byModel.getValue("ecmwf_ifs04")
         ecmwf.size shouldBe 3
-        ecmwf[0].time shouldBe LocalTime.of(0, 0)
+        ecmwf[0].time shouldBe LocalDateTime.parse("2026-05-12T00:00")
         ecmwf[0].apparentTemperatureC shouldBe (12.0 plusOrMinus 0.0001)
         ecmwf[0].temperatureC shouldBe (14.0 plusOrMinus 0.0001)
         ecmwf[0].precipitationProbabilityPct shouldBe (10.0 plusOrMinus 0.0001)
@@ -144,7 +147,7 @@ class MultiModelConfidenceFetcherTest {
         // WMO 3 → CLOUDY; ensures weather_code_<model> is being parsed
         // through [WmoCodeMapper] alongside the numeric fields.
         ecmwf[0].condition shouldBe WeatherCondition.CLOUDY
-        ecmwf[2].time shouldBe LocalTime.of(2, 0)
+        ecmwf[2].time shouldBe LocalDateTime.parse("2026-05-12T02:00")
     }
 
     @Test
@@ -177,7 +180,7 @@ class MultiModelConfidenceFetcherTest {
         // Hour 1 had a null apparent_temperature for ecmwf; the entry is dropped,
         // but the other two hours survive.
         ecmwf.map { it.time } shouldContainExactlyInAnyOrder
-            listOf(LocalTime.of(0, 0), LocalTime.of(2, 0))
+            listOf(LocalDateTime.parse("2026-05-12T00:00"), LocalDateTime.parse("2026-05-12T02:00"))
     }
 
     @Test

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/ConsensusBlend.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/ConsensusBlend.kt
@@ -39,6 +39,7 @@ package app.clothescast.core.domain.model
  * [withAggregatesFrom] on data that hasn't actually changed.
  */
 fun blendConsensusHourly(
+    bestMatchDate: java.time.LocalDate,
     bestMatch: List<HourlyForecast>,
     perModel: PerModelHourly?,
 ): List<HourlyForecast>? {
@@ -46,7 +47,11 @@ fun blendConsensusHourly(
     val models = perModel.byModel
     if (models.size < 2) return null
 
-    val byHour = mutableMapOf<java.time.LocalTime, MutableList<PerModelHour>>()
+    // Per-model entries carry a full LocalDateTime so the tonight wrap doesn't
+    // alias today's 02:00 against tomorrow's 02:00. Best_match is today's
+    // hourly only, indexed by LocalTime — pair it against the matching
+    // calendar day before looking up consensus candidates.
+    val byHour = mutableMapOf<java.time.LocalDateTime, MutableList<PerModelHour>>()
     for (entries in models.values) {
         for (entry in entries) {
             byHour.getOrPut(entry.time) { mutableListOf() }.add(entry)
@@ -55,7 +60,7 @@ fun blendConsensusHourly(
 
     var anyBlended = false
     val out = bestMatch.map { hour ->
-        val candidates = byHour[hour.time].orEmpty()
+        val candidates = byHour[java.time.LocalDateTime.of(bestMatchDate, hour.time)].orEmpty()
         if (candidates.size < 2) {
             hour
         } else {

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/InsightSummary.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/InsightSummary.kt
@@ -130,10 +130,20 @@ data class CalendarTieInClause(val item: String)
  * tonight, rain at 9pm.") — keeps the morning insight's mention of evening rain
  * tied to the evening event, rather than emitting a second precip clause that
  * would compete with the morning slice's own precip clause.
+ *
+ * [item] is nullable so the clause can also fire on per-model evening rain
+ * alone, with no clothes rule triggered for the tonight window — the user
+ * still wants to know that a model spotted rain when they have an evening
+ * event coming up, even without a precip-keyed rule on the books. In that
+ * case the formatter renders a bare "Rain tonight at 9pm." (or "Chance of
+ * rain tonight at 9pm." when [likelihood] is POSSIBLE). [likelihood] is only
+ * meaningful when [rainTime] is set; it defaults to LIKELY for back-compat
+ * with cached payloads written before the field existed.
  */
 data class EveningEventTieInClause(
-    val item: String,
+    val item: String?,
     val rainTime: LocalTime? = null,
+    val likelihood: PrecipLikelihood = PrecipLikelihood.LIKELY,
 )
 
 /**

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/ModelDivergenceSummary.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/ModelDivergenceSummary.kt
@@ -72,7 +72,13 @@ data class ModelDivergenceSummary(
             if (models.size < 2) return null
 
             // Group hours by time across all models so we can compute spreads.
-            val byHour = mutableMapOf<LocalTime, MutableList<PerModelHour>>()
+            // Per-model entries carry a full LocalDateTime; the public
+            // [peakHour] is the wall-clock LocalTime the chart label needs, so
+            // we convert at the output below. Keying internally by
+            // LocalDateTime keeps the tonight-wrap aliasing problem out of the
+            // group-by even though [computeFrom] is currently only ever called
+            // with today-only data.
+            val byHour = mutableMapOf<java.time.LocalDateTime, MutableList<PerModelHour>>()
             for (entries in models) {
                 for (entry in entries) {
                     byHour.getOrPut(entry.time) { mutableListOf() }.add(entry)
@@ -126,7 +132,7 @@ data class ModelDivergenceSummary(
                 .filter { it.normalised > 0.0 }
                 .maxByOrNull { it.normalised } ?: return null
             return ModelDivergenceSummary(
-                peakHour = peak.key,
+                peakHour = peak.key.toLocalTime(),
                 feelsLikeSpreadC = feelsLikeSpread,
                 topFactor = top.factor,
                 topFactorMin = top.min,

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/PerModelHourly.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/PerModelHourly.kt
@@ -1,6 +1,6 @@
 package app.clothescast.core.domain.model
 
-import java.time.LocalTime
+import java.time.LocalDateTime
 
 /**
  * Per-model hourly apparent-temperature and precipitation-probability series
@@ -40,7 +40,15 @@ data class PerModelHourly(
 }
 
 data class PerModelHour(
-    val time: LocalTime,
+    /**
+     * Wall-clock timestamp for the hour in the location's local zone. Carries
+     * the calendar date alongside the hour-of-day so the tonight insight can
+     * wrap past midnight without aliasing today's 02:00 against tomorrow's
+     * 02:00 in time-keyed lookups (e.g. [PerModelHourly] slicing, consensus
+     * blending). The hour-of-day plotted on the Today chart is simply
+     * `time.hour` — the date discriminator costs nothing for the UI.
+     */
+    val time: LocalDateTime,
     /** Apparent ("feels-like") temperature for the hour, °C. */
     val apparentTemperatureC: Double,
     /** Raw 2 m air temperature for the hour, °C — the same series the blended

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsight.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsight.kt
@@ -14,6 +14,7 @@ import app.clothescast.core.domain.model.WeatherCondition
 import app.clothescast.core.domain.repository.CalendarEventReader
 import app.clothescast.core.domain.repository.WeatherRepository
 import java.time.Clock
+import java.time.LocalDateTime
 import java.time.LocalTime
 
 /**
@@ -124,13 +125,32 @@ class GenerateDailyInsight(
         } else {
             emptyList()
         }
-        // Per-model hourly only covers `forecast_days=1`, so only the TODAY
-        // pass can pair the precip clause with cross-model agreement. The
-        // tonight pass falls through to base-only behaviour in the renderer.
-        // Sliced to the period window so the renderer's per-hour matches line
-        // up with [periodForecast.hourly].
+        // Per-model hourly now covers today + tomorrow's pre-dawn hours
+        // (MultiModelConfidenceFetcher uses `forecast_days=2`). Slicing pairs
+        // each forecast hour with its calendar date so today's 02:00 doesn't
+        // alias against tomorrow's 02:00 in [PerModelHour.time] (a
+        // LocalDateTime). The TONIGHT period intentionally still strips the
+        // overlay — the chart and "Forecasts disagree today" copy talk about
+        // today, not the night ahead.
         val perModelForPeriod = if (period == ForecastPeriod.TODAY) {
-            bundle.perModelHourly?.slicedTo(periodForecast.hourly)
+            bundle.perModelHourly?.slicedTo(todayWindow(periodForecast.hourly, bundle.today.date))
+        } else {
+            null
+        }
+        // Evening tie-in: pair each tonight-window hour with the right date
+        // (today for pre-midnight, tomorrow for post-midnight wrap). Uses the
+        // lenient [intersectedWith] rather than [slicedTo] — the renderer's
+        // peak-finder walks per-hour readings and doesn't need positional
+        // alignment, so a model with rain at 21:00 but a null entry at, say,
+        // 05:00 tomorrow should still feed the tie-in. The strict slice would
+        // drop it wholesale (chart-alignment contract) and we'd silently fall
+        // back to base-only, missing exactly the case the per-model tier
+        // exists to catch. The event-with-location gate inside the renderer
+        // decides whether the tie-in actually emits.
+        val eveningPerModelForPeriod = if (period == ForecastPeriod.TODAY) {
+            bundle.perModelHourly?.intersectedWith(
+                tonightWindow(tonightForecast.hourly, bundle.today.date, tonightStart),
+            )
         } else {
             null
         }
@@ -146,6 +166,7 @@ class GenerateDailyInsight(
             eveningForecast = if (period == ForecastPeriod.TODAY) tonightForecast else null,
             todayForDelta = deltaToday,
             perModelHourly = perModelForPeriod,
+            eveningPerModelHourly = eveningPerModelForPeriod,
         )
         val insight = Insight(
             summary = summary,
@@ -216,10 +237,10 @@ class GenerateDailyInsight(
  *    information the tonight slice still needs.
  */
 /**
- * Filters each model's per-hour entries to just the hours covered by
- * [windowHourly] (typically today's daytime slice), preserving the window's
- * order so each index in the resulting series lines up with the same index
- * in `windowHourly` — the chart plots overlays by index.
+ * Filters each model's per-hour entries to just the hours covered by [window]
+ * (LocalDateTimes the caller computed from the period's hourly slice), preserving
+ * the window's order so each index in the resulting series lines up with the same
+ * index in the matching base hourly — the chart plots overlays by index.
  *
  * Drops a model entirely from the overlay if it's missing any in-window hour
  * (the upstream `parseHourly` skips per-hour entries with null temp or precip
@@ -229,15 +250,58 @@ class GenerateDailyInsight(
  * draw a curve that's silently shifted. An empty result returns null so the
  * caller can null the whole field.
  */
-private fun PerModelHourly.slicedTo(windowHourly: List<HourlyForecast>): PerModelHourly? {
-    if (windowHourly.isEmpty()) return null
-    val order = windowHourly.map { it.time }
+private fun PerModelHourly.slicedTo(window: List<LocalDateTime>): PerModelHourly? {
+    if (window.isEmpty()) return null
     val filtered = byModel.mapNotNull { (model, entries) ->
         val byTime = entries.associateBy { it.time }
-        val sliced = order.map { byTime[it] ?: return@mapNotNull null }
+        val sliced = window.map { byTime[it] ?: return@mapNotNull null }
         model to sliced
     }.toMap()
     return if (filtered.isEmpty()) null else PerModelHourly(filtered)
+}
+
+/**
+ * Lenient counterpart to [slicedTo]: filters each model's entries to the ones
+ * whose [LocalDateTime] is in [window], dropping out-of-window entries but
+ * keeping models that don't cover every window hour. Renderer consumers
+ * (e.g. [RenderInsightSummary.pickPerModelPeak]) iterate per-hour readings
+ * and don't need positional alignment, so dropping an entire model because
+ * of one missing hour — what [slicedTo]'s chart-alignment contract demands
+ * — would silently lose the rain reading the per-model tier exists to catch.
+ * An empty result returns null so the caller can null the whole field.
+ */
+private fun PerModelHourly.intersectedWith(window: List<LocalDateTime>): PerModelHourly? {
+    if (window.isEmpty()) return null
+    val keep = window.toSet()
+    val filtered = byModel.mapNotNull { (model, entries) ->
+        val sliced = entries.filter { it.time in keep }
+        if (sliced.isEmpty()) null else model to sliced
+    }.toMap()
+    return if (filtered.isEmpty()) null else PerModelHourly(filtered)
+}
+
+/**
+ * Each daytime hour belongs to [todayDate] — [slicedForToday] never wraps
+ * past midnight, so every entry's [HourlyForecast.time] is unambiguously
+ * today's calendar day.
+ */
+private fun todayWindow(windowHourly: List<HourlyForecast>, todayDate: java.time.LocalDate): List<LocalDateTime> =
+    windowHourly.map { LocalDateTime.of(todayDate, it.time) }
+
+/**
+ * Tonight wraps from [tonightStart] today to next morning, so a window hour
+ * with `time >= tonightStart` is on [todayDate]; anything before it (the
+ * tomorrow-morning portion concatenated by [slicedForTonight]) is on the
+ * next day. Same rule that keeps the LocalTime ambiguity from biting the
+ * tonight wrap elsewhere in this module.
+ */
+private fun tonightWindow(
+    windowHourly: List<HourlyForecast>,
+    todayDate: java.time.LocalDate,
+    tonightStart: LocalTime,
+): List<LocalDateTime> = windowHourly.map { entry ->
+    val date = if (!entry.time.isBefore(tonightStart)) todayDate else todayDate.plusDays(1)
+    LocalDateTime.of(date, entry.time)
 }
 
 private fun DailyForecast.slicedForToday(

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/RenderInsightSummary.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/RenderInsightSummary.kt
@@ -93,14 +93,18 @@ class RenderInsightSummary {
     ): InsightSummary {
         val items = todayTriggeredRules.map { it.item }
         val peak = peakPrecip(today, perModelHourly)
-        // Compute the evening peak only when the evening tie-in is going to
-        // emit (i.e. caller passed events + triggered rules + an evening
-        // forecast). Avoids spending the search on every TODAY pass, and
-        // keeps the result strictly scoped to the tie-in clause.
+        // Compute the evening peak whenever the tie-in could fire — i.e. the
+        // morning insight, with at least one evening event, and an evening
+        // forecast to inspect. Previously also gated on
+        // `eveningTriggeredRules.isNotEmpty()`, but per-model rain on a mild
+        // evening (no temperature rule triggered, no user-defined precip
+        // rule) is exactly the case the tie-in needs to surface — the bare
+        // rain warning falls out of the clause assembly below when no item
+        // is on the list. Cheap when no per-model data is present (the
+        // base-only peakPrecip is a single max over the hourly slice).
         val eveningPeak = if (
             period == ForecastPeriod.TODAY &&
-            eveningEvents.isNotEmpty() &&
-            eveningTriggeredRules.isNotEmpty()
+            eveningEvents.isNotEmpty()
         ) {
             eveningForecast?.let { peakPrecip(it, eveningPerModelHourly) }
         } else {
@@ -206,23 +210,39 @@ class RenderInsightSummary {
     private fun pickPerModelPeak(today: DailyForecast, perModelHourly: PerModelHourly): PeakPrecip? {
         val models = perModelHourly.byModel.values.toList()
         if (models.isEmpty()) return null
-        // Majority = more than half: 2 of 3, both of 2, 1 of 1. Matches how the
-        // user described it ("any model says ≥ 30 → chance of rain; majority of
-        // models say ≥ 50 → rain"); generalises naturally to whatever subset of
-        // models reported usable hourly values today.
-        val majorityNeeded = models.size / 2 + 1
         // Walk every hour any model reported, scoring by "models hitting LIKELY
         // at this hour" first and the single biggest per-model reading second
-        // (tie-break, also doubles as the POSSIBLE fallback pivot).
+        // (tie-break, also doubles as the POSSIBLE fallback pivot). Hours are
+        // LocalDateTimes (per-model entries carry a date so the tonight wrap
+        // doesn't alias); convert to LocalTime at emission, which is all the
+        // downstream prose / chart consumers need.
+        //
+        // Majority is computed PER HOUR over the models that actually reported
+        // a reading there, not over the total number of models in [byModel].
+        // The lenient evening-tie-in slice ([intersectedWith]) intentionally
+        // keeps models that only cover part of the tonight window — a model
+        // whose run hasn't fully landed reports rain at 21:00 but has no
+        // 05:00 entry, and we still want it feeding the 21:00 peak (Codex
+        // caught it). With a total-models-based bar, "both models that did
+        // report at 02:00 agree at 80%" would be treated as 2-of-4 against
+        // the absent ones — silently downgrading a genuine consensus to
+        // POSSIBLE just because the other two models had no overnight data.
+        // Floor of 2 readings keeps a single-model agreement honest as a
+        // POSSIBLE rather than promoting it to LIKELY: "one model says rain"
+        // is the textbook chance-of-rain case the per-model tier exists to
+        // express.
         val hours = models.flatMap { entries -> entries.map { it.time } }.toSortedSet()
         val likelyHour = hours
             .mapNotNull { hour ->
                 val readings = models.mapNotNull { entries -> entries.firstOrNull { it.time == hour } }
+                if (readings.size < 2) return@mapNotNull null
+                val majorityOfReporters = readings.size / 2 + 1
                 val likelyCount = readings.count { it.precipitationProbabilityPct >= LIKELY_THRESHOLD }
-                if (likelyCount >= majorityNeeded) hour to readings else null
+                if (likelyCount >= majorityOfReporters) hour to readings else null
             }
             .maxByOrNull { (_, readings) -> readings.maxOf { it.precipitationProbabilityPct } }
             ?.first
+            ?.toLocalTime()
         if (likelyHour != null) {
             return PeakPrecip(likelyHour, perModelConditionAt(likelyHour, today), PrecipLikelihood.LIKELY)
         }
@@ -232,6 +252,7 @@ class RenderInsightSummary {
             .filter { it.precipitationProbabilityPct >= POSSIBLE_THRESHOLD }
             .maxByOrNull { it.precipitationProbabilityPct }
             ?.time
+            ?.toLocalTime()
         if (possibleHour != null) {
             return PeakPrecip(possibleHour, perModelConditionAt(possibleHour, today), PrecipLikelihood.POSSIBLE)
         }
@@ -291,12 +312,28 @@ class RenderInsightSummary {
      * forecast. Calendar event titles, locations, and start times are never captured
      * into the returned clause.
      *
+     * Two emission paths:
+     *  - Triggered-item path: at least one clothes rule fires on the evening
+     *    forecast → "Bring a jacket tonight." (item only) or "Bring an umbrella
+     *    tonight, rain at 9pm." (item + per-model rain).
+     *  - Bare-rain path: no rule triggers but a per-model series spots rain ≥
+     *    [POSSIBLE_THRESHOLD]% somewhere in the tonight window → emit with
+     *    [EveningEventTieInClause.item] null. The formatter renders this as
+     *    "Rain tonight at 9pm." (LIKELY) or "Chance of rain tonight at 9pm."
+     *    (POSSIBLE). Picks up the case where the user has a temperature-only
+     *    rule set on a mild evening with one-model rain — the morning insight
+     *    would otherwise stay silent on the rain even though it's exactly
+     *    what the per-model tier exists to catch.
+     *
      * Suppressed when:
      *  - No evening event has a location (location-less events don't imply outdoor
      *    exposure where the weather matters).
-     *  - The evening clothes items are a subset of (or equal to) [todayItems] — the
-     *    morning insight already told the user every item; repeating a subset of them
-     *    for the evening adds no new information.
+     *  - Triggered-item path only: the evening clothes items are a subset of (or
+     *    equal to) [todayItems] — the morning insight already told the user every
+     *    item; repeating a subset of them for the evening adds no new information.
+     *    The bare-rain path doesn't apply this filter: today's rain ≠ tonight's
+     *    rain, so the morning insight covering today's clothing list doesn't
+     *    pre-empt an evening rain warning.
      */
     private fun eveningEventTieInClause(
         period: ForecastPeriod,
@@ -306,22 +343,52 @@ class RenderInsightSummary {
         todayItems: List<String>,
     ): EveningEventTieInClause? {
         if (period != ForecastPeriod.TODAY) return null
-        if (eveningEvents.isEmpty() || eveningTriggeredRules.isEmpty()) return null
+        if (eveningEvents.isEmpty()) return null
         // Gate on at least one non-all-day evening event that has a location.
         // Events without a location don't imply outdoor exposure, so the
         // weather-specific clothing tip isn't warranted. Calendar event titles
         // never flow to off-device TTS.
         eveningEvents.firstOrNull { !it.allDay && !it.location.isNullOrBlank() } ?: return null
         val items = eveningTriggeredRules.map { it.item }
+        if (items.isEmpty()) {
+            // Bare-rain path: no triggered rule, so the only thing left to say
+            // is that a model spotted evening rain. Suppress when there's no
+            // rain to name either — that's the genuinely-nothing-to-add case.
+            val peak = eveningPeak ?: return null
+            return EveningEventTieInClause(
+                item = null,
+                rainTime = peak.time,
+                likelihood = peak.likelihood,
+            )
+        }
         // If the evening clothes are a subset of (or equal to) today's clothes,
         // the morning insight already covered every item — no new information to add.
         // Compare normalized (trim + lowercase) so legacy free-form ClothesRule.item
         // values don't fail to suppress on a casing/whitespace mismatch ("Jacket" vs
         // "jacket"); matches the case-insensitive umbrella check below.
+        //
+        // Exception: when there's an evening rain peak, the rain mention IS
+        // new information even if the items are a subset — the morning
+        // precip clause only covers the daytime slice, so without the
+        // tie-in there's no other place that evening rain gets surfaced
+        // (Codex caught it). Fall through to the bare-rain emission in
+        // that case rather than dropping the clause wholesale.
         val normalize: (String) -> String = { it.trim().lowercase(Locale.ROOT) }
-        if (todayItems.map(normalize).toSet().containsAll(items.map(normalize).toSet())) return null
+        val itemsRedundant = todayItems.map(normalize).toSet().containsAll(items.map(normalize).toSet())
+        if (itemsRedundant) {
+            val peak = eveningPeak ?: return null
+            return EveningEventTieInClause(
+                item = null,
+                rainTime = peak.time,
+                likelihood = peak.likelihood,
+            )
+        }
         val item = items.firstOrNull { it.equals("umbrella", ignoreCase = true) } ?: items.first()
-        return EveningEventTieInClause(item = item, rainTime = eveningPeak?.time)
+        return EveningEventTieInClause(
+            item = item,
+            rainTime = eveningPeak?.time,
+            likelihood = eveningPeak?.likelihood ?: PrecipLikelihood.LIKELY,
+        )
     }
 
     private data class PeakPrecip(

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/model/ConsensusBlendTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/model/ConsensusBlendTest.kt
@@ -5,9 +5,16 @@ import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.time.LocalDateTime
 import java.time.LocalTime
 
 class ConsensusBlendTest {
+
+    // Anchor date for the per-model series — every entry's full LocalDateTime
+    // pairs this with the hour. Best_match is just LocalTime; the blender
+    // gets [TODAY] passed in to bridge the two.
+    private val today: LocalDate = LocalDate.of(2026, 5, 13)
 
     private fun hour(
         h: Int,
@@ -30,7 +37,7 @@ class ConsensusBlendTest {
         precip: Double = 0.0,
         condition: WeatherCondition? = null,
     ) = PerModelHour(
-        time = LocalTime.of(h, 0),
+        time = LocalDateTime.of(today, LocalTime.of(h, 0)),
         apparentTemperatureC = apparent,
         temperatureC = air,
         precipitationProbabilityPct = precip,
@@ -41,7 +48,7 @@ class ConsensusBlendTest {
     fun `returns null when per-model data is null`() {
         val best = listOf(hour(12, temp = 10.0))
 
-        blendConsensusHourly(best, perModel = null).shouldBeNull()
+        blendConsensusHourly(today, best, perModel = null).shouldBeNull()
     }
 
     @Test
@@ -54,7 +61,7 @@ class ConsensusBlendTest {
             ),
         )
 
-        blendConsensusHourly(listOf(hour(12, temp = 10.0)), perModel).shouldBeNull()
+        blendConsensusHourly(today, listOf(hour(12, temp = 10.0)), perModel).shouldBeNull()
     }
 
     @Test
@@ -75,7 +82,7 @@ class ConsensusBlendTest {
             ),
         )
 
-        val blended = blendConsensusHourly(best, perModel).shouldNotBeNull()
+        val blended = blendConsensusHourly(today, best, perModel).shouldNotBeNull()
 
         blended[0].temperatureC shouldBe (12.5 plusOrMinus 0.0001) // (15 + 10) / 2
         blended[0].feelsLikeC shouldBe (11.5 plusOrMinus 0.0001)   // (14 + 9) / 2
@@ -95,7 +102,7 @@ class ConsensusBlendTest {
             ),
         )
 
-        val blended = blendConsensusHourly(best, perModel).shouldNotBeNull()
+        val blended = blendConsensusHourly(today, best, perModel).shouldNotBeNull()
 
         blended.size shouldBe 1
         blended[0].time shouldBe LocalTime.of(12, 0)
@@ -127,7 +134,7 @@ class ConsensusBlendTest {
             ),
         )
 
-        val blended = blendConsensusHourly(best, perModel).shouldNotBeNull()
+        val blended = blendConsensusHourly(today, best, perModel).shouldNotBeNull()
 
         blended[0].temperatureC shouldBe (13.0 plusOrMinus 0.0001)  // consensus
         blended[1] shouldBe best[1]                                   // fell back
@@ -151,7 +158,7 @@ class ConsensusBlendTest {
             ),
         )
 
-        val blended = blendConsensusHourly(best, perModel).shouldNotBeNull()
+        val blended = blendConsensusHourly(today, best, perModel).shouldNotBeNull()
 
         blended[0].condition shouldBe WeatherCondition.RAIN
     }
@@ -175,7 +182,7 @@ class ConsensusBlendTest {
             ),
         )
 
-        val blended = blendConsensusHourly(best, perModel).shouldNotBeNull()
+        val blended = blendConsensusHourly(today, best, perModel).shouldNotBeNull()
 
         blended[0].condition shouldBe WeatherCondition.RAIN
     }
@@ -193,7 +200,7 @@ class ConsensusBlendTest {
             ),
         )
 
-        val blended = blendConsensusHourly(best, perModel).shouldNotBeNull()
+        val blended = blendConsensusHourly(today, best, perModel).shouldNotBeNull()
 
         blended[0].condition shouldBe WeatherCondition.CLEAR
     }
@@ -220,7 +227,7 @@ class ConsensusBlendTest {
             ),
         )
 
-        blendConsensusHourly(best, perModel).shouldBeNull()
+        blendConsensusHourly(today, best, perModel).shouldBeNull()
     }
 
     @Test

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/model/ModelDivergenceSummaryTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/model/ModelDivergenceSummaryTest.kt
@@ -5,9 +5,13 @@ import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.time.LocalDateTime
 import java.time.LocalTime
 
 class ModelDivergenceSummaryTest {
+
+    private val today: LocalDate = LocalDate.of(2026, 5, 13)
 
     private fun entry(
         hour: Int,
@@ -18,7 +22,7 @@ class ModelDivergenceSummaryTest {
         humidity: Double? = null,
         cloud: Double? = null,
     ) = PerModelHour(
-        time = LocalTime.of(hour, 0),
+        time = LocalDateTime.of(today, LocalTime.of(hour, 0)),
         apparentTemperatureC = apparent,
         temperatureC = air,
         precipitationProbabilityPct = precip,

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsightTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsightTest.kt
@@ -8,6 +8,7 @@ import app.clothescast.core.domain.model.DailyForecast
 import app.clothescast.core.domain.model.ForecastConfidence
 import app.clothescast.core.domain.model.PerModelHour
 import app.clothescast.core.domain.model.PerModelHourly
+import app.clothescast.core.domain.model.PrecipLikelihood
 import app.clothescast.core.domain.model.DeliveryMode
 import app.clothescast.core.domain.model.DeltaClause
 import app.clothescast.core.domain.model.DistanceUnit
@@ -34,6 +35,7 @@ import org.junit.jupiter.api.Test
 import java.time.Clock
 import java.time.Instant
 import java.time.LocalDate
+import java.time.LocalDateTime
 import java.time.LocalTime
 import java.time.ZoneId
 import java.time.ZoneOffset
@@ -408,17 +410,16 @@ class GenerateDailyInsightTest {
 
     @Test
     fun `per-model hourly rides the today insight but is stripped from tonight`() = runTest {
-        // The bundle's per-model hourly covers the full 24h day; the daytime
-        // window slice on TODAY should drop the overnight entries so the chart
-        // overlays line up with the blended hourly that the rest of the screen
-        // renders. TONIGHT drops the field entirely (today's per-model series
-        // doesn't span the overnight window).
-        val ecmwfFull = (0..23).map { hour ->
-            PerModelHour(LocalTime.of(hour, 0), 10.0 + hour, 12.0 + hour, 5.0 * hour)
-        }
-        val gfsFull = (0..23).map { hour ->
-            PerModelHour(LocalTime.of(hour, 0), 11.0 + hour, 13.0 + hour, 6.0 * hour)
-        }
+        // The bundle's per-model hourly covers two days (forecast_days=2); the
+        // daytime window slice on TODAY should drop everything outside the
+        // morning–evening window so the chart overlays line up with the
+        // blended hourly that the rest of the screen renders. TONIGHT drops
+        // the field entirely — today's per-model series + the tonight wrap
+        // both describe today, not the night ahead.
+        val ecmwfFull = perModelDay(today.date, 10.0, 12.0, 5.0) +
+            perModelDay(today.date.plusDays(1), 8.0, 10.0, 4.0)
+        val gfsFull = perModelDay(today.date, 11.0, 13.0, 6.0) +
+            perModelDay(today.date.plusDays(1), 9.0, 11.0, 5.0)
         val bundleHourly = PerModelHourly(
             byModel = mapOf("ecmwf_ifs04" to ecmwfFull, "gfs_seamless" to gfsFull),
         )
@@ -439,10 +440,25 @@ class GenerateDailyInsightTest {
         val todayInsight = subject(london, prefs, ForecastPeriod.TODAY).insight
         val overlay = todayInsight.perModelHourly.shouldNotBeNull()
         overlay.byModel.keys shouldContainExactlyInAnyOrder listOf("ecmwf_ifs04", "gfs_seamless")
-        overlay.byModel.getValue("ecmwf_ifs04").map { it.time } shouldBe daytime.map { it.time }
-        overlay.byModel.getValue("gfs_seamless").map { it.time } shouldBe daytime.map { it.time }
+        overlay.byModel.getValue("ecmwf_ifs04").map { it.time.toLocalTime() } shouldBe daytime.map { it.time }
+        overlay.byModel.getValue("gfs_seamless").map { it.time.toLocalTime() } shouldBe daytime.map { it.time }
 
         subject(london, prefs, ForecastPeriod.TONIGHT).insight.perModelHourly.shouldBeNull()
+    }
+
+    /** 24 hours of [PerModelHour] anchored on [date], starting at 00:00. */
+    private fun perModelDay(
+        date: LocalDate,
+        apparentBase: Double,
+        airBase: Double,
+        precipScale: Double,
+    ): List<PerModelHour> = (0..23).map { hour ->
+        PerModelHour(
+            time = LocalDateTime.of(date, LocalTime.of(hour, 0)),
+            apparentTemperatureC = apparentBase + hour,
+            temperatureC = airBase + hour,
+            precipitationProbabilityPct = precipScale * hour,
+        )
     }
 
     @Test
@@ -459,12 +475,12 @@ class GenerateDailyInsightTest {
         )
         val incompleteEcmwf = listOf(
             // 12:00 hour missing — the model is dropped from the overlay.
-            PerModelHour(LocalTime.of(8, 0), 11.5, 12.5, 9.0),
-            PerModelHour(LocalTime.of(15, 0), 21.5, 22.5, 38.0),
+            PerModelHour(LocalDateTime.of(today.date, LocalTime.of(8, 0)), 11.5, 12.5, 9.0),
+            PerModelHour(LocalDateTime.of(today.date, LocalTime.of(15, 0)), 21.5, 22.5, 38.0),
         )
         val completeGfs = daytime.map { h ->
             PerModelHour(
-                h.time,
+                LocalDateTime.of(today.date, h.time),
                 h.feelsLikeC + 0.5,
                 h.temperatureC + 0.5,
                 h.precipitationProbabilityPct + 2.0,
@@ -482,7 +498,212 @@ class GenerateDailyInsightTest {
         val overlay = subject(london, prefs, ForecastPeriod.TODAY).insight.perModelHourly
             .shouldNotBeNull()
         overlay.byModel.keys shouldContainExactlyInAnyOrder listOf("gfs_seamless")
-        overlay.byModel.getValue("gfs_seamless").map { it.time } shouldBe daytime.map { it.time }
+        overlay.byModel.getValue("gfs_seamless").map { it.time.toLocalTime() } shouldBe daytime.map { it.time }
+    }
+
+    @Test
+    fun `evening tie-in picks up rain that only one model spots in the per-model series`() = runTest {
+        // The TODAY pass evaluates the evening-event tie-in against the tonight
+        // slice. When base hourly under-calls precip (< 30% at every evening
+        // hour) but one per-model series sees real rain at an evening hour,
+        // the renderer's per-model tier should catch it. The fetch is now
+        // forecast_days=2, so the per-model series spans the full
+        // wrap-past-midnight tonight window — pre-midnight (today) AND the
+        // tomorrow-morning portion both feed the tie-in's rain time.
+        val daytime = listOf(
+            HourlyForecast(LocalTime.of(8, 0), 16.0, 15.0, 5.0, WeatherCondition.CLEAR),
+            HourlyForecast(LocalTime.of(12, 0), 18.0, 17.0, 5.0, WeatherCondition.CLEAR),
+            HourlyForecast(LocalTime.of(15, 0), 18.0, 17.0, 5.0, WeatherCondition.CLEAR),
+        )
+        // Tonight slice (19:00–06:00 wrap) cold enough to trigger the jacket
+        // rule (feelsLikeMin < 12) but with low base precip probability so the
+        // base-only fallback would leave `rainTime` null.
+        val evening = listOf(
+            HourlyForecast(LocalTime.of(19, 0), 11.0, 9.0, 10.0, WeatherCondition.PARTLY_CLOUDY),
+            HourlyForecast(LocalTime.of(20, 0), 10.5, 8.5, 10.0, WeatherCondition.PARTLY_CLOUDY),
+            HourlyForecast(LocalTime.of(21, 0), 10.0, 8.0, 10.0, WeatherCondition.PARTLY_CLOUDY),
+            HourlyForecast(LocalTime.of(22, 0), 10.0, 8.0, 10.0, WeatherCondition.PARTLY_CLOUDY),
+        )
+        val baseHourly = today.copy(
+            hourly = daytime + evening,
+            precipitationProbabilityMaxPct = 10.0,
+            condition = WeatherCondition.PARTLY_CLOUDY,
+        )
+        // One model spots evening rain at 21:00 (today). Tomorrow's pre-dawn
+        // hours stay dry — they're in scope after the forecast_days=2 widening
+        // but the peak should still pick the louder 21:00 reading. Covering
+        // both days is what the renderer expects from the wider fetch.
+        val ecmwfFull = perModelDay(today.date, 11.0, 9.0, precipScale = 0.0).mapIndexed { hour, entry ->
+            if (hour == 21) entry.copy(precipitationProbabilityPct = 75.0) else entry.copy(precipitationProbabilityPct = 10.0)
+        } + perModelDay(today.date.plusDays(1), 9.0, 7.0, precipScale = 0.0).map {
+            it.copy(precipitationProbabilityPct = 5.0)
+        }
+        val perModelHourly = PerModelHourly(byModel = mapOf("ecmwf_ifs04" to ecmwfFull))
+        val diner = CalendarEvent(
+            title = "dinner",
+            start = LocalTime.of(21, 0),
+            end = LocalTime.of(23, 0),
+            location = "Restaurant",
+        )
+        val weather = FakeWeatherRepository(
+            ForecastBundle(baseHourly, yesterday, perModelHourly = perModelHourly),
+        )
+        val calendar = FakeCalendarEventReader(events = listOf(diner))
+        val subject = GenerateDailyInsight(weather, calendarEventReader = calendar, clock = clock)
+
+        // Only-the-jacket rule isolates the assertion: with no other rule
+        // triggering, todayItems is empty and evening items = [jacket] —
+        // not a subset of today's, so the tie-in is not suppressed.
+        val jacketOnly = listOf(ClothesRule("jacket", ClothesRule.TemperatureBelow(12.0)))
+        val result = subject(
+            location = london,
+            prefs = prefs.copy(
+                clothesRules = jacketOnly,
+                useCalendarEvents = true,
+            ),
+            period = ForecastPeriod.TODAY,
+        )
+
+        val tie = result.insight.summary.eveningEventTieIn
+        tie.shouldNotBeNull()
+        tie!!.item shouldBe "jacket"
+        tie.rainTime shouldBe LocalTime.of(21, 0)
+    }
+
+    @Test
+    fun `evening tie-in picks up post-midnight rain that only one model spots`() = runTest {
+        // Same setup as the pre-midnight case above, but the rain hour is at
+        // 02:00 tomorrow — the part of the tonight window that crosses
+        // midnight. Pre-`forecast_days=2`, this hour was outside per-model
+        // coverage entirely; pre-LocalDateTime migration, it would have
+        // aliased against today's 02:00 (which is sleepy, dry, and not in the
+        // tonight slice). With both fixes, the post-midnight reading flows
+        // straight through to the tie-in's rain time.
+        val daytime = listOf(
+            HourlyForecast(LocalTime.of(8, 0), 16.0, 15.0, 5.0, WeatherCondition.CLEAR),
+            HourlyForecast(LocalTime.of(12, 0), 18.0, 17.0, 5.0, WeatherCondition.CLEAR),
+            HourlyForecast(LocalTime.of(15, 0), 18.0, 17.0, 5.0, WeatherCondition.CLEAR),
+        )
+        val evening = listOf(
+            HourlyForecast(LocalTime.of(19, 0), 11.0, 9.0, 10.0, WeatherCondition.PARTLY_CLOUDY),
+            HourlyForecast(LocalTime.of(22, 0), 10.0, 8.0, 10.0, WeatherCondition.PARTLY_CLOUDY),
+        )
+        val tomorrowMorning = listOf(
+            HourlyForecast(LocalTime.of(2, 0), 9.0, 7.0, 10.0, WeatherCondition.PARTLY_CLOUDY),
+            HourlyForecast(LocalTime.of(5, 0), 9.0, 7.0, 10.0, WeatherCondition.PARTLY_CLOUDY),
+        )
+        val baseHourly = today.copy(
+            hourly = daytime + evening,
+            precipitationProbabilityMaxPct = 10.0,
+            condition = WeatherCondition.PARTLY_CLOUDY,
+        )
+        // Today entries dry, tomorrow's 02:00 wet (75%). Both days in the
+        // per-model series; the slice picks tomorrow's because that's the
+        // hour the tonight window points to.
+        val tomorrowEntries = perModelDay(today.date.plusDays(1), 9.0, 7.0, precipScale = 0.0).map { entry ->
+            if (entry.time.toLocalTime() == LocalTime.of(2, 0)) {
+                entry.copy(precipitationProbabilityPct = 75.0)
+            } else {
+                entry.copy(precipitationProbabilityPct = 10.0)
+            }
+        }
+        val ecmwfFull = perModelDay(today.date, 11.0, 9.0, precipScale = 0.0).map {
+            it.copy(precipitationProbabilityPct = 10.0)
+        } + tomorrowEntries
+        val perModelHourly = PerModelHourly(byModel = mapOf("ecmwf_ifs04" to ecmwfFull))
+        val diner = CalendarEvent(
+            title = "after-hours",
+            start = LocalTime.of(22, 0),
+            end = LocalTime.of(23, 30),
+            location = "Theatre",
+        )
+        val weather = FakeWeatherRepository(
+            ForecastBundle(baseHourly, yesterday, perModelHourly = perModelHourly, tomorrowHourly = tomorrowMorning),
+        )
+        val calendar = FakeCalendarEventReader(events = listOf(diner))
+        val subject = GenerateDailyInsight(weather, calendarEventReader = calendar, clock = clock)
+
+        val jacketOnly = listOf(ClothesRule("jacket", ClothesRule.TemperatureBelow(12.0)))
+        val result = subject(
+            location = london,
+            prefs = prefs.copy(
+                clothesRules = jacketOnly,
+                useCalendarEvents = true,
+            ),
+            period = ForecastPeriod.TODAY,
+        )
+
+        val tie = result.insight.summary.eveningEventTieIn
+        tie.shouldNotBeNull()
+        tie!!.item shouldBe "jacket"
+        tie.rainTime shouldBe LocalTime.of(2, 0)
+    }
+
+    @Test
+    fun `evening tie-in still fires when a model is missing an unrelated tonight-window hour`() = runTest {
+        // The strict [slicedTo] used for the chart overlay drops a model
+        // entirely on any missing in-window hour (positional alignment for
+        // the chart). The evening tie-in path uses [intersectedWith] instead
+        // — the renderer's peak-finder works on whatever per-hour readings
+        // are present, so a model that reports 75% rain at 21:00 but has no
+        // 05:00 entry must still feed the tie-in. Silently dropping it would
+        // re-introduce the bug this whole feature exists to fix.
+        val daytime = listOf(
+            HourlyForecast(LocalTime.of(8, 0), 16.0, 15.0, 5.0, WeatherCondition.CLEAR),
+            HourlyForecast(LocalTime.of(12, 0), 18.0, 17.0, 5.0, WeatherCondition.CLEAR),
+            HourlyForecast(LocalTime.of(15, 0), 18.0, 17.0, 5.0, WeatherCondition.CLEAR),
+        )
+        val evening = listOf(
+            HourlyForecast(LocalTime.of(19, 0), 11.0, 9.0, 10.0, WeatherCondition.PARTLY_CLOUDY),
+            HourlyForecast(LocalTime.of(21, 0), 10.0, 8.0, 10.0, WeatherCondition.PARTLY_CLOUDY),
+        )
+        val tomorrowMorning = listOf(
+            HourlyForecast(LocalTime.of(2, 0), 9.0, 7.0, 10.0, WeatherCondition.PARTLY_CLOUDY),
+            HourlyForecast(LocalTime.of(5, 0), 9.0, 7.0, 10.0, WeatherCondition.PARTLY_CLOUDY),
+        )
+        val baseHourly = today.copy(
+            hourly = daytime + evening,
+            precipitationProbabilityMaxPct = 10.0,
+            condition = WeatherCondition.PARTLY_CLOUDY,
+        )
+        // ecmwf sees the evening rain at 21:00 but its 05:00 tomorrow entry
+        // is missing (model run still warming up — parseHourly drops null
+        // hours). Pre-fix the strict slice dropped the whole model and the
+        // tie-in fell back to base-only; with [intersectedWith] the rain
+        // hour survives.
+        val ecmwfEntries = listOf(
+            PerModelHour(LocalDateTime.of(today.date, LocalTime.of(19, 0)), 11.0, 9.0, 10.0),
+            PerModelHour(LocalDateTime.of(today.date, LocalTime.of(21, 0)), 11.0, 9.0, 75.0),
+            PerModelHour(LocalDateTime.of(today.date.plusDays(1), LocalTime.of(2, 0)), 9.0, 7.0, 10.0),
+            // 05:00 tomorrow intentionally missing.
+        )
+        val perModelHourly = PerModelHourly(byModel = mapOf("ecmwf_ifs04" to ecmwfEntries))
+        val diner = CalendarEvent(
+            title = "dinner",
+            start = LocalTime.of(21, 0),
+            end = LocalTime.of(23, 0),
+            location = "Restaurant",
+        )
+        val weather = FakeWeatherRepository(
+            ForecastBundle(baseHourly, yesterday, perModelHourly = perModelHourly, tomorrowHourly = tomorrowMorning),
+        )
+        val calendar = FakeCalendarEventReader(events = listOf(diner))
+        val subject = GenerateDailyInsight(weather, calendarEventReader = calendar, clock = clock)
+
+        val jacketOnly = listOf(ClothesRule("jacket", ClothesRule.TemperatureBelow(12.0)))
+        val result = subject(
+            location = london,
+            prefs = prefs.copy(
+                clothesRules = jacketOnly,
+                useCalendarEvents = true,
+            ),
+            period = ForecastPeriod.TODAY,
+        )
+
+        val tie = result.insight.summary.eveningEventTieIn
+        tie.shouldNotBeNull()
+        tie!!.item shouldBe "jacket"
+        tie.rainTime shouldBe LocalTime.of(21, 0)
     }
 
     @Test
@@ -713,5 +934,91 @@ class GenerateDailyInsightTest {
         val result = subject(london, prefs)
 
         result.alerts shouldBe emptyList()
+    }
+
+    @Test
+    fun `evening tie-in surfaces bare per-model rain when no clothes rule fires`() = runTest {
+        // The case AGENTS.md flags under "Domain conventions": no clothes
+        // rule triggers for the tonight window (mild evening, no
+        // user-defined umbrella rule — the defaults intentionally don't
+        // ship one), but a per-model series spots rain ≥ 30%. Pre-fix the
+        // tie-in returned null and the morning insight stayed silent on
+        // evening rain; the fix emits an item-less clause that the
+        // formatter renders as a bare "Rain tonight at 9pm." (or
+        // chance-of-rain on POSSIBLE).
+        val daytime = listOf(
+            HourlyForecast(LocalTime.of(8, 0), 16.0, 15.0, 5.0, WeatherCondition.CLEAR),
+            HourlyForecast(LocalTime.of(12, 0), 18.0, 17.0, 5.0, WeatherCondition.CLEAR),
+            HourlyForecast(LocalTime.of(15, 0), 18.0, 17.0, 5.0, WeatherCondition.CLEAR),
+        )
+        // Mild evening: feels-like stays above the jacket-rule threshold
+        // so nothing triggers from the base forecast.
+        val evening = listOf(
+            HourlyForecast(LocalTime.of(19, 0), 15.0, 14.0, 5.0, WeatherCondition.PARTLY_CLOUDY),
+            HourlyForecast(LocalTime.of(21, 0), 15.0, 14.0, 10.0, WeatherCondition.PARTLY_CLOUDY),
+        )
+        val baseHourly = today.copy(
+            hourly = daytime + evening,
+            // Above the default 18°C threshold so the jacket / coat rules
+            // can't fire — only feels-like-min < 12 triggers them.
+            feelsLikeMinC = 14.0,
+            feelsLikeMaxC = 18.0,
+            precipitationProbabilityMaxPct = 10.0,
+            condition = WeatherCondition.PARTLY_CLOUDY,
+        )
+        // One model spots rain at 21:00 ≥ POSSIBLE_THRESHOLD; the other two
+        // stay dry, so the per-model tier emits POSSIBLE.
+        val ecmwfEntries = listOf(
+            PerModelHour(LocalDateTime.of(today.date, LocalTime.of(19, 0)), 14.0, 15.0, 5.0),
+            PerModelHour(LocalDateTime.of(today.date, LocalTime.of(21, 0)), 14.0, 15.0, 75.0),
+        )
+        val gfsEntries = listOf(
+            PerModelHour(LocalDateTime.of(today.date, LocalTime.of(19, 0)), 14.0, 15.0, 5.0),
+            PerModelHour(LocalDateTime.of(today.date, LocalTime.of(21, 0)), 14.0, 15.0, 10.0),
+        )
+        val iconEntries = listOf(
+            PerModelHour(LocalDateTime.of(today.date, LocalTime.of(19, 0)), 14.0, 15.0, 5.0),
+            PerModelHour(LocalDateTime.of(today.date, LocalTime.of(21, 0)), 14.0, 15.0, 5.0),
+        )
+        val perModelHourly = PerModelHourly(
+            byModel = mapOf(
+                "ecmwf_ifs04" to ecmwfEntries,
+                "gfs_seamless" to gfsEntries,
+                "icon_seamless" to iconEntries,
+            ),
+        )
+        val diner = CalendarEvent(
+            title = "dinner",
+            start = LocalTime.of(21, 0),
+            end = LocalTime.of(23, 0),
+            location = "Restaurant",
+        )
+        val weather = FakeWeatherRepository(
+            ForecastBundle(baseHourly, yesterday, perModelHourly = perModelHourly),
+        )
+        val calendar = FakeCalendarEventReader(events = listOf(diner))
+        val subject = GenerateDailyInsight(weather, calendarEventReader = calendar, clock = clock)
+
+        // No precip-keyed rule on the books — only temperature rules, none
+        // of which trigger on a mild evening.
+        val tempOnly = listOf(
+            ClothesRule("jacket", ClothesRule.TemperatureBelow(12.0)),
+            ClothesRule("coat", ClothesRule.TemperatureBelow(6.0)),
+        )
+        val result = subject(
+            location = london,
+            prefs = prefs.copy(
+                clothesRules = tempOnly,
+                useCalendarEvents = true,
+            ),
+            period = ForecastPeriod.TODAY,
+        )
+
+        val tie = result.insight.summary.eveningEventTieIn
+        tie.shouldNotBeNull()
+        // Bare-rain emission: no item, rain time set, POSSIBLE tier.
+        tie!!.item shouldBe null
+        tie.rainTime shouldBe LocalTime.of(21, 0)
+        tie.likelihood shouldBe PrecipLikelihood.POSSIBLE
     }
 }

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/RenderInsightSummaryTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/RenderInsightSummaryTest.kt
@@ -20,6 +20,7 @@ import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
 import java.time.Instant
 import java.time.LocalDate
+import java.time.LocalDateTime
 import java.time.LocalTime
 
 class RenderInsightSummaryTest {
@@ -277,14 +278,114 @@ class RenderInsightSummaryTest {
     }
 
     @Test
-    fun `evening event tie-in is omitted when no clothes rules trigger against the evening`() {
-        val event = CalendarEvent("dinner", LocalTime.of(21, 0), LocalTime.of(23, 0))
+    fun `evening event tie-in is omitted when no clothes rules trigger and no rain to mention`() {
+        // The bare-rain emission path requires an evening peak; without one
+        // (no eveningForecast, or a dry evening) and with no triggered
+        // rules, there's genuinely nothing to add for the evening.
+        val event = CalendarEvent("dinner", LocalTime.of(21, 0), LocalTime.of(23, 0), location = "Restaurant")
         val out = subject(
             today = mildToday,
             yesterday = yesterday,
             todayTriggeredRules = emptyList(),
             eveningEvents = listOf(event),
             eveningTriggeredRules = emptyList(),
+        )
+        out.eveningEventTieIn.shouldBeNull()
+    }
+
+    @Test
+    fun `evening event tie-in emits bare rain when no rule triggers but per-model spots rain`() {
+        // The case AGENTS.md documents under "Domain conventions": user
+        // has only temperature-keyed rules, the evening is mild enough
+        // that none trigger, but a per-model series spots rain ≥ 30% in
+        // the tonight window. The morning insight must still mention the
+        // rain — staying silent is exactly the gap the per-model tier
+        // exists to catch — but it shouldn't invent a clothes
+        // recommendation the user hasn't asked for. Surfaces as
+        // item=null + rainTime set; the formatter renders this as a
+        // bare "Rain tonight at 9pm.".
+        val event = CalendarEvent("dinner", LocalTime.of(21, 0), LocalTime.of(23, 0), location = "Restaurant")
+        val mildEvening = mildToday.copy(
+            precipitationProbabilityMaxPct = 10.0,
+            condition = WeatherCondition.PARTLY_CLOUDY,
+            hourly = listOf(HourlyForecast(LocalTime.of(21, 0), 14.0, 13.0, 10.0, WeatherCondition.PARTLY_CLOUDY)),
+        )
+        // One model spots rain at 21:00 — the POSSIBLE tier (≥ 30% on a
+        // single model, < majority at ≥ 50%).
+        val perModel = PerModelHourly(
+            byModel = mapOf(
+                "ecmwf_ifs04" to listOf(
+                    PerModelHour(
+                        time = LocalDateTime.of(2026, 5, 13, 21, 0),
+                        apparentTemperatureC = 13.0,
+                        temperatureC = 14.0,
+                        precipitationProbabilityPct = 75.0,
+                    ),
+                ),
+                "gfs_seamless" to listOf(
+                    PerModelHour(
+                        time = LocalDateTime.of(2026, 5, 13, 21, 0),
+                        apparentTemperatureC = 13.0,
+                        temperatureC = 14.0,
+                        precipitationProbabilityPct = 10.0,
+                    ),
+                ),
+                "icon_seamless" to listOf(
+                    PerModelHour(
+                        time = LocalDateTime.of(2026, 5, 13, 21, 0),
+                        apparentTemperatureC = 13.0,
+                        temperatureC = 14.0,
+                        precipitationProbabilityPct = 5.0,
+                    ),
+                ),
+            ),
+        )
+        val out = subject(
+            today = mildToday,
+            yesterday = yesterday,
+            todayTriggeredRules = emptyList(),
+            eveningEvents = listOf(event),
+            eveningTriggeredRules = emptyList(),
+            eveningForecast = mildEvening,
+            eveningPerModelHourly = perModel,
+        )
+        val tie = out.eveningEventTieIn
+        tie.shouldNotBeNull()
+        tie!!.item.shouldBeNull()
+        tie.rainTime shouldBe LocalTime.of(21, 0)
+        tie.likelihood shouldBe PrecipLikelihood.POSSIBLE
+    }
+
+    @Test
+    fun `evening event tie-in bare rain requires a located evening event`() {
+        // Same setup as the bare-rain emission test above, but the event
+        // has no location — the location gate still applies on this path.
+        val event = CalendarEvent("dinner", LocalTime.of(21, 0), LocalTime.of(23, 0))
+        val mildEvening = mildToday.copy(
+            precipitationProbabilityMaxPct = 10.0,
+            condition = WeatherCondition.PARTLY_CLOUDY,
+            hourly = listOf(HourlyForecast(LocalTime.of(21, 0), 14.0, 13.0, 10.0, WeatherCondition.PARTLY_CLOUDY)),
+        )
+        val perModel = PerModelHourly(
+            byModel = mapOf(
+                "ecmwf_ifs04" to listOf(
+                    PerModelHour(
+                        time = LocalDateTime.of(2026, 5, 13, 21, 0),
+                        apparentTemperatureC = 13.0,
+                        temperatureC = 14.0,
+                        precipitationProbabilityPct = 75.0,
+                    ),
+                ),
+            ),
+        )
+        val out = subject(
+            today = mildToday,
+            yesterday = yesterday,
+            todayTriggeredRules = emptyList(),
+            eveningEvents = listOf(event),
+            eveningTriggeredRules = emptyList(),
+            eveningForecast = mildEvening,
+            eveningPerModelHourly = perModel,
         )
         out.eveningEventTieIn.shouldBeNull()
     }
@@ -345,6 +446,35 @@ class RenderInsightSummaryTest {
             eveningTriggeredRules = listOf(jacketRule),
         )
         out.eveningEventTieIn.shouldBeNull()
+    }
+
+    @Test
+    fun `evening event tie-in falls back to bare rain when items are a subset but rain peaks`() {
+        // Codex case: morning rules and evening rules both recommend jacket
+        // (cold all day), so the item part is redundant — but a per-model
+        // series spots evening rain at 21:00. The morning precip clause
+        // only covers the daytime slice, so dropping the tie-in entirely
+        // would lose the only place evening rain gets surfaced. Fall
+        // through to the bare-rain shape (item=null, rainTime set) so the
+        // rain mention survives without repeating the jacket clothing tip.
+        val event = CalendarEvent("dinner", LocalTime.of(21, 0), LocalTime.of(23, 0), location = "Restaurant")
+        val rainyEvening = mildToday.copy(
+            precipitationProbabilityMaxPct = 60.0,
+            condition = WeatherCondition.RAIN,
+            hourly = listOf(HourlyForecast(LocalTime.of(21, 0), 11.0, 9.0, 60.0, WeatherCondition.RAIN)),
+        )
+        val out = subject(
+            today = mildToday,
+            yesterday = yesterday,
+            todayTriggeredRules = listOf(jacketRule),
+            eveningEvents = listOf(event),
+            eveningTriggeredRules = listOf(jacketRule),
+            eveningForecast = rainyEvening,
+        )
+        val tie = out.eveningEventTieIn
+        tie.shouldNotBeNull()
+        tie!!.item.shouldBeNull()
+        tie.rainTime shouldBe LocalTime.of(21, 0)
     }
 
     @Test
@@ -698,6 +828,63 @@ class RenderInsightSummaryTest {
     }
 
     @Test
+    fun `precip clause is LIKELY when reporting models agree at a sparse hour`() {
+        // Codex case: the lenient evening-tie-in slice keeps models with
+        // only partial tonight-window coverage. Two models report at 02:00
+        // and both hit ≥ LIKELY_THRESHOLD; the other two are in [byModel]
+        // (they reported at other hours like 21:00) but have no 02:00
+        // entry. Majority must be computed over the two that actually
+        // reported at 02:00, not over the four in the map — otherwise the
+        // genuine 2-of-2 consensus gets silently downgraded to POSSIBLE
+        // because the absent models inflate `majorityNeeded` to 3.
+        val today = mildToday.copy(
+            precipitationProbabilityMaxPct = 20.0,
+            condition = WeatherCondition.PARTLY_CLOUDY,
+            hourly = listOf(
+                HourlyForecast(LocalTime.of(2, 0), 8.0, 8.0, 20.0, WeatherCondition.PARTLY_CLOUDY),
+            ),
+        )
+        val perModel = perModelHourly(
+            // best_match + ECMWF report at 02:00, both wet.
+            PerModelHourly.BEST_MATCH_MODEL_ID to listOf(perModelHour(LocalTime.of(2, 0), 80.0)),
+            "ecmwf_ifs04" to listOf(perModelHour(LocalTime.of(2, 0), 75.0)),
+            // GFS + ICON only have an unrelated 21:00 entry — no 02:00 data.
+            "gfs_seamless" to listOf(perModelHour(LocalTime.of(21, 0), 5.0)),
+            "icon_seamless" to listOf(perModelHour(LocalTime.of(21, 0), 10.0)),
+        )
+        val out = subject(today, yesterday, emptyList(), perModelHourly = perModel).precip
+        out.shouldNotBeNull()
+        out!!.time shouldBe LocalTime.of(2, 0)
+        out.likelihood shouldBe PrecipLikelihood.LIKELY
+    }
+
+    @Test
+    fun `precip clause is POSSIBLE when only one model reports a sparse hour`() {
+        // Counterpart to the sparse-LIKELY test above: a single model
+        // reports at 02:00 — even if it's at 80%, "one model says rain"
+        // is the textbook POSSIBLE case the per-model tier exists to
+        // express. The floor of two readings keeps a single-reading
+        // sparse hour from getting promoted to LIKELY.
+        val today = mildToday.copy(
+            precipitationProbabilityMaxPct = 10.0,
+            condition = WeatherCondition.PARTLY_CLOUDY,
+            hourly = listOf(
+                HourlyForecast(LocalTime.of(2, 0), 8.0, 8.0, 10.0, WeatherCondition.PARTLY_CLOUDY),
+            ),
+        )
+        val perModel = perModelHourly(
+            "ecmwf_ifs04" to listOf(perModelHour(LocalTime.of(2, 0), 80.0)),
+            // Other models cover other hours but not 02:00.
+            "gfs_seamless" to listOf(perModelHour(LocalTime.of(21, 0), 5.0)),
+            "icon_seamless" to listOf(perModelHour(LocalTime.of(21, 0), 10.0)),
+        )
+        val out = subject(today, yesterday, emptyList(), perModelHourly = perModel).precip
+        out.shouldNotBeNull()
+        out!!.time shouldBe LocalTime.of(2, 0)
+        out.likelihood shouldBe PrecipLikelihood.POSSIBLE
+    }
+
+    @Test
     fun `precip clause is POSSIBLE when one of two available models hits 50 percent`() {
         // Majority of 2 is 2 — one passing isn't a majority, so the LIKELY
         // tier doesn't fire; the lone 60% still earns the hedged form.
@@ -772,9 +959,16 @@ class RenderInsightSummaryTest {
         out.likelihood shouldBe PrecipLikelihood.LIKELY
     }
 
+    // PerModelHour now carries a LocalDateTime — paired against an arbitrary
+    // anchor date so the test fixtures don't have to thread a date through
+    // every call. The renderer reads `time.toLocalTime()` at output points;
+    // the date is only used internally for tonight-wrap disambiguation,
+    // which these tests don't exercise.
+    private val perModelDate: java.time.LocalDate = java.time.LocalDate.of(2026, 5, 13)
+
     private fun perModelHour(time: LocalTime, precipPct: Double): PerModelHour =
         PerModelHour(
-            time = time,
+            time = java.time.LocalDateTime.of(perModelDate, time),
             apparentTemperatureC = 18.0,
             temperatureC = 18.0,
             precipitationProbabilityPct = precipPct,


### PR DESCRIPTION
## Summary

The morning insight's evening tie-in says "Bring an umbrella for your 9pm dinner, rain at 9pm." when the evening forecast peaks above 30%. Three gaps were silently dropping the right rain warning on the days the user most wanted it:

- **Only the base forecast was consulted.** The tie-in didn't see the per-model spread the rest of the insight uses to catch rain that one model spots but best_match under-calls.
- **The check stopped at midnight.** `MultiModelConfidenceFetcher` requested `forecast_days=1`, so the post-midnight portion of the tonight window fell outside per-model coverage entirely.
- **The tie-in required a clothes rule to fire first.** On a mild evening with only temperature-keyed rules set, nothing triggered, and the morning insight stayed silent on evening rain even when a per-model spotted it. The default rule set [intentionally omits umbrella](https://github.com/mikelward/clothescast/blob/main/core/domain/src/main/kotlin/app/clothescast/core/domain/model/ClothesRule.kt) (the precip clause names rain on its own and not every user wants an umbrella), so this was the common case.

## What changed

- **Wider fetch.** `MultiModelConfidenceFetcher` now requests `forecast_days=2`. ~3KB extra on the same 7am side-band call, no new round-trip; the confidence chip still reads `daily[0]`.
- **`PerModelHour.time: LocalTime → LocalDateTime`.** Required by the wider fetch: today's 02:00 and tomorrow's 02:00 are now distinct in every time-keyed lookup. Output types (`PeakPrecip.time`, `PrecipClause.rainTime`) stay `LocalTime` — conversion happens at emission. Chart UI unaffected (`.time.hour` works on either).
- **Date-aware tonight slice.** `GenerateDailyInsight` pairs each tonight-window hour with its calendar date before slicing the per-model series.
- **Strict vs lenient slice.** `slicedTo` (chart-alignment) stays for the today daytime overlay; new lenient `intersectedWith` for the evening tie-in path, since the renderer's peak-finder doesn't need positional alignment.
- **Bare-rain emission.** `EveningEventTieInClause.item` is now nullable and the clause carries a `likelihood`. With no triggered rule and a per-model rain hit, the tie-in emits with `item = null` and the formatter renders "Rain tonight at 9pm." (LIKELY) or "Chance of rain tonight at 9pm." (POSSIBLE) — no clothes recommendation, since the user hasn't picked one. The "evening items are a subset of today's" suppression still applies on the triggered-item path but not on the bare-rain path (today's daytime rain ≠ tonight's evening rain).
- **Rule documented.** AGENTS.md gains a "Domain conventions" entry spelling out the principle: per-model rain doesn't pick clothes, but it does mention rain.
- **Cache.** `EveningEventTieInDto` gains nullable `item` + nullable `likelihood` string; legacy payloads decode cleanly with missing `likelihood` folding to LIKELY.
- **i18n.** New `insight_evening_rain` / `insight_evening_rain_chance` resources land in `values/` (English) only; other locales fall back to English for these two strings until a translation follow-up.

## Privacy

No change to what leaves the device. The tie-in clause carries a rain time and (optionally) a clothing-item key — no event title or location, same as before. The bare-rain emission carries just the rain time + likelihood. Wider fetch still goes to keyless Open-Meteo.

## Test plan

- [ ] CI: `JVM unit tests` green. New / updated coverage:
  - Domain: pre-midnight rain that only one model spots → `rainTime` at 21:00.
  - Domain: post-midnight rain (the case `forecast_days=2` exists for) → `rainTime` at 02:00 tomorrow with dinner at 22:00 today.
  - Domain: sparse per-model series (one model missing an unrelated hour) still feeds the tie-in via the lenient slice.
  - Domain: no rule triggers but per-model spots rain → bare-rain tie-in (item=null, rainTime set, POSSIBLE likelihood).
  - Renderer: bare-rain emission gated by the located-event rule, not by triggered rules.
  - Formatter: bare-rain → "Rain tonight at 9pm." (LIKELY) / "Chance of rain tonight at 9pm." (POSSIBLE) / suppressed when both item and rainTime null.
  - Cache: bare-rain shape round-trips (item null + likelihood preserved).
- [ ] CI: `Android debug build` green.
- [ ] Local validation skipped: this sandbox can't reach Google Maven for AGP plugin resolution, so even `:core:domain:test` can't be invoked from the root build.
