### PR TITLE
docs — note future per-model picker for the spread overlay

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -55,6 +55,21 @@ Code TODOs in source files are linked from here when they exist.
 - [x] **Multi-model confidence badge** (MODELS.md idea #1) — Today shows
       a chip indicating how much ECMWF / GFS / ICON disagree about today's
       apparent high and peak precip probability.
+- [ ] **User-selectable models for the spread overlay.** The consulted set
+      is hard-coded in `MultiModelConfidenceFetcher.DEFAULT_MODELS` to
+      ECMWF + GFS + ICON (with `best_match` folded in as "Auto"). A user
+      whose region is better served by MeteoFrance / GEM / JMA / BOM
+      can't add them, and a model that returns no usable hourly data for
+      a given cell (ECMWF over high latitudes or some coastal grid
+      points) silently disappears from the chart legend — reads as a bug
+      rather than an empty model. Plan: multi-select picker in Display
+      settings under the existing "Show model spread" toggle, defaulting
+      to today's trio; thread the chosen list through the fetcher's
+      already-pluggable `models` constructor argument. `best_match` stays
+      always-on (rides the primary call, no extra slot needed). Consensus
+      blend in `ConsensusBlend.kt` already iterates whatever's in
+      `PerModelHourly.byModel`, so no changes there. Same Open-Meteo
+      endpoint either way — no privacy change.
 
 ## Feature ideas (queued)
 


### PR DESCRIPTION
## Summary

Docs-only. Captures the user's follow-up from a Today-screen investigation: *"how are we deciding which models to use? perhaps the user should be allowed to choose one or more?"*

### What I found, in case the next PR needs it

- `MultiModelConfidenceFetcher.DEFAULT_MODELS` (`core/data/.../MultiModelConfidenceFetcher.kt:220`) already requests ECMWF + GFS + ICON. Always those three.
- `best_match` ("Auto") rides the primary `/v1/forecast` call and gets folded into `PerModelHourly` alongside the consulted three in `OpenMeteoClient.kt:90-103`.
- "Combined" is the local arithmetic mean across whatever's in `PerModelHourly.byModel` (`ConsensusBlend.kt:41-75`).
- The chart already knows about ECMWF: it's in `MODEL_DRAW_ORDER`, `MODEL_COLORS` (pink), and `friendlyModelName` in `ForecastChart.kt:45-68` / `TodayScreen.kt:1364-1370`.
- Only user-facing toggle today is the single boolean `showModelSpread` in Display settings (`Settings.kt:320`).

So when ECMWF is missing from a user's chart legend, it's because Open-Meteo returned no usable hourly samples for `ecmwf_ifs04` at that cell — the parser at `MultiModelConfidenceFetcher.kt:114-156` drops models with zero non-null hours. Not a wiring gap.

The user said *"fine for now, add a to-do to let users choose"* → a single new bullet in `docs/TODO.md` under **Forecast & alerts**, with the breadcrumbs above so a follow-up PR can pick up without re-deriving them. `best_match` is called out as always-on (rides the primary call, no slot consumed). Privacy: same Open-Meteo endpoint either way.

## Test plan

- [x] Docs-only diff (one new bullet in `docs/TODO.md`); nothing to run.

https://claude.ai/code/session_01899L3RMih4Xo5HXzzgb9Wu

---
_Generated by [Claude Code](https://claude.ai/code/session_01899L3RMih4Xo5HXzzgb9Wu)_