### PR TITLE
Refresh wind chart values when the unit changes

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/today/PerModelDiagnosticCard.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/PerModelDiagnosticCard.kt
@@ -61,15 +61,20 @@ internal fun PerModelDiagnosticCard(
     perModelHourly: PerModelHourly,
     picker: (PerModelHour) -> Double?,
     yAxis: YAxis,
+    /**
+     * Extra cache key for callers whose [picker] closes over mutable state
+     * (e.g. the wind card converts km/h → mph using the user's unit). Defaults
+     * to [Unit] so plain field-accessor pickers (cloud, humidity) keep their
+     * old single-key behaviour. Passing the lambda itself wouldn't work —
+     * Compose treats fresh lambda instances as unequal, which would invalidate
+     * the cache every recomposition.
+     */
+    pickerKey: Any? = Unit,
 ) {
     // Build (originalIndex, value) pairs per model so a sparse series plots at
     // its real positions on the x-axis instead of getting compacted left and
     // misaligned with the rest of the screen's hourly axes.
-    // Key on perModelHourly only — the picker is conceptually fixed per card
-    // type (Wind/Cloud/Humidity each pass a literal field accessor) and
-    // including a lambda in a remember key invalidates the cache every
-    // recomposition because Compose doesn't treat lambda instances as stable.
-    val seriesByModel = remember(perModelHourly) {
+    val seriesByModel = remember(perModelHourly, pickerKey) {
         perModelHourly.byModel
             .mapValues { (_, entries) ->
                 entries.mapIndexedNotNull { i, e -> picker(e)?.let { i to it } }

--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
@@ -1212,6 +1212,10 @@ internal fun WindCard(
         perModelHourly = perModelHourly,
         picker = { it.windSpeedKmh?.toWindSpeedUnit(windSpeedUnit) },
         yAxis = YAxis.AutoZeroBased(minSpan = minSpan),
+        // Picker closes over windSpeedUnit; key the series cache on it so the
+        // chart values follow when the user flips distance unit while the
+        // overlay payload is unchanged.
+        pickerKey = windSpeedUnit,
     )
 }
 


### PR DESCRIPTION
PerModelDiagnosticCard cached its (originalIndex, value) series in a
remember keyed on perModelHourly alone, under the assumption (from the
pre-existing comment) that each card's picker was a fixed field accessor.
The new wind picker closes over windSpeedUnit to do the km/h→mph
conversion inside the lambda, breaking that assumption: a unit flip with
an unchanged overlay payload left the cached km/h values on the chart
even though the subtitle and y-axis had already switched to mph.

Adds an explicit `pickerKey` parameter (defaults to Unit so cloud and
humidity callers keep their existing single-key behaviour) and threads
windSpeedUnit through from the wind card. Passing the lambda itself
isn't viable — Compose treats fresh lambda instances as unequal, which
would invalidate the cache every recomposition.

Caught by Codex review on PR #403.