### PR TITLE
Keep PR title and body in sync with the branch on every push

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,18 @@ new rule the first time something bites you, not the third.
   CLI is **not** available in this sandbox.
 - Open PRs as **draft** by default. Un-draft only after CI is green and you
   (or the user) have eyeballed the change.
+- **Keep PR title and body in sync with the branch on every push.** A PR's
+  title and description are read as the canonical summary of what's
+  landing; if the branch has grown, narrowed, or pivoted since the PR
+  opened, the original text lies. After every push (force-push, follow-up
+  commit, rebase-and-push) re-read the full branch diff vs. the base and
+  update the title and body via `mcp__github__update_pull_request` so
+  they describe the *current* state — not the state at PR creation.
+  Subject line stays Play-Store-ready (sentence case, end-user copy, ≤
+  ~80 chars, matches the squash-merge subject); body covers scope,
+  rationale, privacy-relevant changes, and test plan for everything now
+  in the diff. If nothing material changed, no update is needed — but
+  check, don't assume.
 - **Never leave a review comment thread silently dismissed.** Either reply on
   the thread *or* resolve it — the user wants every thread to end in one of
   those two states, not "left open and ignored." When you think a comment is


### PR DESCRIPTION
## Summary

Adds a new AGENTS.md rule under the **GitHub** section: after every push
(force-push, follow-up commit, rebase-and-push), re-read the full branch
diff vs. the base and update the PR title and body via
`mcp__github__update_pull_request` so they describe the *current* state,
not the state at PR creation.

- Subject stays Play-Store-ready (sentence case, ≤ ~80 chars, matches
  the squash-merge subject that ships to `whatsnew-en-US`).
- Body covers scope, rationale, privacy-relevant changes, and test plan
  for everything now in the diff.
- "If nothing material changed, no update is needed — but check, don't
  assume."

## Test plan

- [ ] Docs-only change; no code, no tests to run.
- [ ] CLAUDE.md is a symlink to AGENTS.md, so the rule is visible under
      either filename.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CTuCHMzYhez4punkdnPBch)_