### PR TITLE
Morning forecast's evening note now matches the evening forecast

### DIFF
--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsight.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsight.kt
@@ -1,25 +1,44 @@
 package app.clothescast.core.domain.usecase
 
 import app.clothescast.core.domain.model.CalendarEvent
+import app.clothescast.core.domain.model.ClothesRule
 import app.clothescast.core.domain.model.DailyForecast
+import app.clothescast.core.domain.model.EveningEventTieInClause
 import app.clothescast.core.domain.model.ForecastPeriod
 import app.clothescast.core.domain.model.HourlyForecast
 import app.clothescast.core.domain.model.Insight
+import app.clothescast.core.domain.model.InsightSummary
 import app.clothescast.core.domain.model.Location
 import app.clothescast.core.domain.model.OutfitSuggestion
 import app.clothescast.core.domain.model.PerModelHourly
+import app.clothescast.core.domain.model.PrecipLikelihood
 import app.clothescast.core.domain.model.UserPreferences
 import app.clothescast.core.domain.model.WeatherAlert
 import app.clothescast.core.domain.model.WeatherCondition
 import app.clothescast.core.domain.repository.CalendarEventReader
+import app.clothescast.core.domain.repository.ForecastBundle
 import app.clothescast.core.domain.repository.WeatherRepository
 import java.time.Clock
+import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
+import java.util.Locale
 
 /**
  * The product. Fetches the forecast, evaluates clothes rules, renders the
  * deterministic summary string in [renderInsightSummary], and packages the result.
+ *
+ * Day / night windows are derived entirely from the user's notification times
+ * (`prefs.schedule.time` / `prefs.tonightSchedule.time`, defaulting to 07:00 and
+ * 19:00). TODAY covers `[morning, tonight)`; TONIGHT covers `[tonight, next
+ * morning)` wrapping past midnight. The morning insight's evening tie-in is
+ * derived by running this same renderer against the night slice — i.e. the
+ * tie-in's clothes + rain mention is whatever the 7pm night notification would
+ * itself say — and only emits when the user has at least one non-all-day
+ * calendar event with a location in the night window (an event "away from
+ * home"). That away-from-home gate is the only behavioural asymmetry between
+ * the two passes; everything else falls out of the period each pass is
+ * computing.
  *
  * Severe-weather alerts piggy-back on the same fetch and are returned alongside the
  * insight in [DailyInsightResult]; the worker uses them to drive a separate
@@ -39,16 +58,97 @@ class GenerateDailyInsight(
     ): DailyInsightResult {
         val bundle = weatherRepository.fetchForecast(location)
         val activeAlerts = bundle.alerts.filter { it.expires.isAfter(clock.instant()) }
-        // Each period is narrowed to the user-configured window so the insight
-        // talks about hours the user will actually walk into:
-        //  - TODAY = morning time → tonight time (e.g. 07:00–19:00)
-        //  - TONIGHT = tonight time → next morning time (e.g. 19:00–07:00, wrapping
-        //    past midnight via tomorrow's hourly)
-        // Both reads pull from `prefs.schedule.time` and `prefs.tonightSchedule.time`
-        // (not fixed constants) so a user who moved either dial sees an insight
-        // that matches the alarm that just fired.
         val morningStart = prefs.schedule.time
         val tonightStart = prefs.tonightSchedule.time
+
+        val allEvents = readEventsForDay(bundle.today.date, prefs)
+
+        val periodView = buildPeriodView(
+            bundle = bundle,
+            prefs = prefs,
+            period = period,
+            morningStart = morningStart,
+            tonightStart = tonightStart,
+            events = allEvents,
+        )
+
+        // Morning insight's tie-in: re-run the same machinery against the night
+        // slice and fold its clothes + precip clauses into an
+        // EveningEventTieInClause, but only when the user has an event away
+        // from home that night (location-set, non-all-day). When TONIGHT is
+        // the primary, no tie-in (it's already what the user is hearing).
+        val eveningEventTieIn = if (period == ForecastPeriod.TODAY && prefs.dailyMentionEveningEvents) {
+            buildEveningEventTieIn(
+                bundle = bundle,
+                prefs = prefs,
+                morningStart = morningStart,
+                tonightStart = tonightStart,
+                allEvents = allEvents,
+                alerts = activeAlerts,
+                todayItems = periodView.triggeredRules.map { it.item },
+            )
+        } else {
+            null
+        }
+
+        val summary = renderInsightSummary(
+            today = periodView.forecast,
+            yesterday = periodView.deltaYesterday,
+            todayTriggeredRules = periodView.triggeredRules,
+            alerts = activeAlerts,
+            events = periodView.events,
+            period = period,
+            todayForDelta = periodView.deltaToday,
+            perModelHourly = periodView.perModelForRender,
+            eveningEventTieIn = eveningEventTieIn,
+        )
+
+        val rules = prefs.clothesRules
+        val insight = Insight(
+            summary = summary,
+            recommendedItems = periodView.triggeredRules.map { it.item },
+            generatedAt = clock.instant(),
+            forDate = bundle.today.date,
+            hourly = periodView.forecast.hourly,
+            // Confidence and chart-side per-model overlay stay TODAY-only: their
+            // copy and chart axes are anchored to "today" and would read
+            // wrong-tense on a TONIGHT card. The precip-clause tier above
+            // does use per-model for both periods — that's prose-side, period
+            // agnostic, and benefits from cross-model agreement either way.
+            confidence = if (period == ForecastPeriod.TODAY) bundle.confidence else null,
+            perModelHourly = if (period == ForecastPeriod.TODAY) periodView.perModelForRender else null,
+            outfit = OutfitSuggestion.fromForecast(periodView.forecast, rules),
+            nextOutfit = periodView.nextForecast?.let { OutfitSuggestion.fromForecast(it, rules) },
+            outfitRationale = OutfitSuggestion.explainFromForecast(periodView.forecast, rules),
+            nextOutfitRationale = periodView.nextForecast?.let {
+                OutfitSuggestion.explainFromForecast(it, rules)
+            },
+            period = period,
+            hasEvents = periodView.events.isNotEmpty(),
+        )
+        return DailyInsightResult(insight = insight, alerts = activeAlerts)
+    }
+
+    private suspend fun readEventsForDay(date: LocalDate, prefs: UserPreferences): List<CalendarEvent> {
+        // Failures (missing permission, provider crash) degrade to no events so
+        // a misbehaving reader can never fail the insight pipeline. Capture the
+        // property as a local so the smart-cast survives across the runCatching
+        // lambda boundary.
+        val reader = calendarEventReader
+        if (!prefs.useCalendarEvents || reader == null) return emptyList()
+        return runCatching {
+            reader.eventsForDay(date, prefs.schedule.zoneId)
+        }.getOrDefault(emptyList())
+    }
+
+    private fun buildPeriodView(
+        bundle: ForecastBundle,
+        prefs: UserPreferences,
+        period: ForecastPeriod,
+        morningStart: LocalTime,
+        tonightStart: LocalTime,
+        events: List<CalendarEvent>,
+    ): PeriodView {
         val todayForecast = bundle.today.slicedForToday(
             morningStart = morningStart,
             eveningEnd = tonightStart,
@@ -62,12 +162,11 @@ class GenerateDailyInsight(
             ForecastPeriod.TODAY -> todayForecast
             ForecastPeriod.TONIGHT -> tonightForecast
         }
-        // Slice yesterday to the same daytime window as today so the delta clause
-        // compares apples to apples — daytime feels-like high/low on both sides
-        // rather than 24h aggregates that fold in overnight extremes the listener
-        // doesn't care about. Falls back to 24h-vs-24h when either side lacks
-        // daytime hourly entries (legacy cached payloads, sparse fixtures), to
-        // keep the comparison symmetric in the absence of hourly data.
+        // Yesterday paired against today's daytime window for the delta
+        // comparison — apples-to-apples daytime feels-like, falling back to 24h
+        // if either side has no hourly data. TONIGHT skips the delta clause
+        // entirely so this pair only matters for TODAY, but compute it
+        // unconditionally for symmetry.
         val yesterdayDaytime = bundle.yesterday.slicedForToday(
             morningStart = morningStart,
             eveningEnd = tonightStart,
@@ -79,126 +178,109 @@ class GenerateDailyInsight(
                 bundle.today to bundle.yesterday
             }
         // The home screen wants a side-by-side preview pair: "Today + Tonight"
-        // on a morning insight, "Tonight + Tomorrow" on an evening one. We
-        // compute the second outfit from the same forecast bundle so showing
-        // both costs no extra API call. Null when the underlying data isn't
-        // there (e.g. evening insight on a legacy bundle without tomorrow's
-        // daily aggregates) — the screen falls back to a single card.
+        // on a morning insight, "Tonight + Tomorrow" on an evening one. The
+        // second outfit comes from the same bundle so showing both costs no
+        // extra API call. Null when the underlying data isn't there (e.g.
+        // evening insight on a legacy bundle without tomorrow's daily
+        // aggregates) — the screen falls back to a single card.
         val nextForecast = when (period) {
             ForecastPeriod.TODAY -> tonightForecast.takeIf { it.hourly.isNotEmpty() }
             ForecastPeriod.TONIGHT -> bundle.tomorrow
         }
-        val rules = prefs.clothesRules
-        val nextOutfit = nextForecast?.let { OutfitSuggestion.fromForecast(it, rules) }
-        val nextOutfitRationale = nextForecast?.let {
-            OutfitSuggestion.explainFromForecast(it, rules)
-        }
-        val todayTriggered = evaluateClothesRules(periodForecast, prefs.clothesRules)
-        // Calendar events are gated on both the opt-in pref AND a configured reader.
-        // Failures (missing permission, provider crash) degrade to no events so a
-        // misbehaving reader can never fail the insight pipeline; the rest of the
-        // summary still renders. Capture the property as a local so the smart-cast
-        // survives across the runCatching lambda boundary.
-        val reader = calendarEventReader
-        val allEvents = if (prefs.useCalendarEvents && reader != null) {
-            runCatching {
-                reader.eventsForDay(bundle.today.date, prefs.schedule.zoneId)
-            }.getOrDefault(emptyList())
-        } else {
-            emptyList()
-        }
-        val periodEvents = filterEventsForPeriod(allEvents, period, tonightStart)
-        // Morning-only: when the user opted in to "Mention evening events", we
-        // also evaluate clothes rules against the evening slice and pass any
-        // evening events through so the renderer can attach a tie-in clause
-        // ("Bring a jacket tonight." — or "Bring an umbrella tonight, rain at
-        // 9pm." when the evening slice has rain). Event titles never appear
-        // in the rendered prose; see the AGENTS.md privacy note. Cheap to
-        // compute — both inputs already live in this scope.
-        val eveningEvents = if (period == ForecastPeriod.TODAY && prefs.dailyMentionEveningEvents) {
-            allEvents.filter { !it.allDay && !it.start.isBefore(tonightStart) }
-        } else {
-            emptyList()
-        }
-        val eveningTriggered = if (eveningEvents.isNotEmpty()) {
-            evaluateClothesRules(tonightForecast, prefs.clothesRules)
-        } else {
-            emptyList()
-        }
-        // Per-model hourly now covers today + tomorrow's pre-dawn hours
-        // (MultiModelConfidenceFetcher uses `forecast_days=2`). Slicing pairs
-        // each forecast hour with its calendar date so today's 02:00 doesn't
-        // alias against tomorrow's 02:00 in [PerModelHour.time] (a
-        // LocalDateTime). The TONIGHT period intentionally still strips the
-        // overlay — the chart and "Forecasts disagree today" copy talk about
-        // today, not the night ahead.
-        val perModelForPeriod = if (period == ForecastPeriod.TODAY) {
-            bundle.perModelHourly?.slicedTo(todayWindow(periodForecast.hourly, bundle.today.date))
-        } else {
-            null
-        }
-        // Evening tie-in: pair each tonight-window hour with the right date
-        // (today for pre-midnight, tomorrow for post-midnight wrap). Uses the
-        // lenient [intersectedWith] rather than [slicedTo] — the renderer's
-        // peak-finder walks per-hour readings and doesn't need positional
-        // alignment, so a model with rain at 21:00 but a null entry at, say,
-        // 05:00 tomorrow should still feed the tie-in. The strict slice would
-        // drop it wholesale (chart-alignment contract) and we'd silently fall
-        // back to base-only, missing exactly the case the per-model tier
-        // exists to catch. The event-with-location gate inside the renderer
-        // decides whether the tie-in actually emits.
-        val eveningPerModelForPeriod = if (period == ForecastPeriod.TODAY) {
-            bundle.perModelHourly?.intersectedWith(
-                tonightWindow(tonightForecast.hourly, bundle.today.date, tonightStart),
-            )
-        } else {
-            null
-        }
-        val summary = renderInsightSummary(
-            today = periodForecast,
-            yesterday = deltaYesterday,
-            todayTriggeredRules = todayTriggered,
-            alerts = activeAlerts,
-            events = periodEvents,
-            period = period,
-            eveningEvents = eveningEvents,
-            eveningTriggeredRules = eveningTriggered,
-            eveningForecast = if (period == ForecastPeriod.TODAY) tonightForecast else null,
-            todayForDelta = deltaToday,
-            perModelHourly = perModelForPeriod,
-            eveningPerModelHourly = eveningPerModelForPeriod,
+        val triggeredRules = evaluateClothesRules(periodForecast, prefs.clothesRules)
+        val perModelForRender = bundle.perModelHourly?.slicedTo(
+            when (period) {
+                ForecastPeriod.TODAY -> todayWindow(periodForecast.hourly, bundle.today.date)
+                ForecastPeriod.TONIGHT -> tonightWindow(periodForecast.hourly, bundle.today.date, tonightStart)
+            },
         )
-        val insight = Insight(
-            summary = summary,
-            recommendedItems = todayTriggered.map { it.item },
-            generatedAt = clock.instant(),
-            forDate = bundle.today.date,
-            hourly = periodForecast.hourly,
-            // Cross-model confidence is derived from today's apparent-max and
-            // peak precipitation probability (forecast_days=1 daily), so it
-            // describes how much the major models disagree about *today*. Don't
-            // attach it to a TONIGHT insight — the chip/callout copy literally
-            // says "Forecasts disagree today," which is wrong-tense when the
-            // user is reading the evening card.
-            confidence = if (period == ForecastPeriod.TODAY) bundle.confidence else null,
-            // Same reasoning for the per-model hourly overlay data: today's
-            // hourly per-model series doesn't span the tonight window
-            // (19:00 today → 07:00 tomorrow), and Open-Meteo's per-model
-            // hourly only covers `forecast_days=1`. Strip on tonight, and
-            // narrow today's series to the same daytime window we sliced
-            // `periodForecast.hourly` to — otherwise the chart plots the
-            // overlays by index and the midnight model value lands on the
-            // first visible hour of the daytime window. Same series that
-            // fed the precip-clause tier selection above.
-            perModelHourly = perModelForPeriod,
-            outfit = OutfitSuggestion.fromForecast(periodForecast, rules),
-            nextOutfit = nextOutfit,
-            outfitRationale = OutfitSuggestion.explainFromForecast(periodForecast, rules),
-            nextOutfitRationale = nextOutfitRationale,
-            period = period,
-            hasEvents = periodEvents.isNotEmpty(),
+        return PeriodView(
+            forecast = periodForecast,
+            nextForecast = nextForecast,
+            triggeredRules = triggeredRules,
+            events = filterEventsForPeriod(events, period, tonightStart),
+            perModelForRender = perModelForRender,
+            deltaToday = deltaToday,
+            deltaYesterday = deltaYesterday,
         )
-        return DailyInsightResult(insight = insight, alerts = activeAlerts)
+    }
+
+    /**
+     * Composes the morning's evening-event tie-in by running the renderer
+     * against the night slice and folding off its clothes and precip clauses.
+     * Gated on the user having at least one non-all-day calendar event with a
+     * location set in the night window — the "away from home" rule that
+     * motivates the heads-up in the first place.
+     *
+     * The clothing item carried in the clause is the *delta* between night
+     * and day — items the night needs that the day didn't already announce
+     * — so a tie-in only adds vocabulary the morning insight hasn't already
+     * delivered. If the day already says "Bring a jacket", an identical
+     * "Bring a jacket tonight" repeats; if the night additionally needs a
+     * coat, the tie-in carries "coat". When the night and day rules trigger
+     * the same items but the night insight has a precip clause, the tie-in
+     * falls through to a bare rain mention (item=null, rainTime set), since
+     * the rain itself is new information the morning slice didn't surface.
+     *
+     * Returns null when there's no away-from-home event, when there's
+     * neither a delta nor rain to surface, or both.
+     */
+    private fun buildEveningEventTieIn(
+        bundle: ForecastBundle,
+        prefs: UserPreferences,
+        morningStart: LocalTime,
+        tonightStart: LocalTime,
+        allEvents: List<CalendarEvent>,
+        alerts: List<WeatherAlert>,
+        todayItems: List<String>,
+    ): EveningEventTieInClause? {
+        val nightEvents = filterEventsForPeriod(allEvents, ForecastPeriod.TONIGHT, tonightStart)
+        // "Away from home" = any non-all-day event with a non-blank location.
+        // TODO: refine by filtering out events whose location matches a
+        // user-configured home location (settings-side, when that pref ships).
+        val awayFromHome = nightEvents.any { !it.allDay && !it.location.isNullOrBlank() }
+        if (!awayFromHome) return null
+
+        val nightView = buildPeriodView(
+            bundle = bundle,
+            prefs = prefs,
+            period = ForecastPeriod.TONIGHT,
+            morningStart = morningStart,
+            tonightStart = tonightStart,
+            events = allEvents,
+        )
+        val nightSummary: InsightSummary = renderInsightSummary(
+            today = nightView.forecast,
+            yesterday = nightView.deltaYesterday,
+            todayTriggeredRules = nightView.triggeredRules,
+            alerts = alerts,
+            events = nightView.events,
+            period = ForecastPeriod.TONIGHT,
+            todayForDelta = nightView.deltaToday,
+            perModelHourly = nightView.perModelForRender,
+            eveningEventTieIn = null,
+        )
+        val nightItems = nightSummary.clothes?.items.orEmpty()
+        val precip = nightSummary.precip
+        // Case- and whitespace-insensitive set comparison, matching the
+        // formatter's umbrella check and avoiding "Jacket" / "jacket"
+        // mismatches from legacy free-form ClothesRule.item values.
+        val normalize: (String) -> String = { it.trim().lowercase(Locale.ROOT) }
+        val todayKey = todayItems.map(normalize).toSet()
+        val deltaItems = nightItems.filter { normalize(it) !in todayKey }
+
+        if (deltaItems.isEmpty() && precip == null) return null
+
+        val item = deltaItems.firstOrNull { it.equals("umbrella", ignoreCase = true) }
+            ?: deltaItems.firstOrNull()
+        // TODO: rewording — "Tonight, bring an X" reads more naturally than
+        // "Bring an X tonight" in some locales. Leave the current template
+        // shape for now (formatter resource).
+        return EveningEventTieInClause(
+            item = item,
+            rainTime = precip?.time,
+            likelihood = precip?.likelihood ?: PrecipLikelihood.LIKELY,
+        )
     }
 
     private fun filterEventsForPeriod(
@@ -211,6 +293,62 @@ class GenerateDailyInsight(
         // event that bleeds across the evening (treated as relevant context).
         ForecastPeriod.TONIGHT -> events.filter { it.allDay || !it.start.isBefore(tonightStart) }
     }
+
+    private data class PeriodView(
+        val forecast: DailyForecast,
+        val nextForecast: DailyForecast?,
+        val triggeredRules: List<ClothesRule>,
+        val events: List<CalendarEvent>,
+        val perModelForRender: PerModelHourly?,
+        val deltaToday: DailyForecast,
+        val deltaYesterday: DailyForecast,
+    )
+}
+
+/**
+ * Filters each model's per-hour entries to just the hours covered by [window]
+ * (LocalDateTimes the caller computed from the period's hourly slice), preserving
+ * the window's order so each index in the resulting series lines up with the same
+ * index in the matching base hourly — the chart plots overlays by index.
+ *
+ * Drops a model entirely from the overlay if it's missing any in-window hour
+ * (the upstream `parseHourly` skips per-hour entries with null temp or precip
+ * values for a model whose run hasn't fully landed). Carrying a partial series
+ * would compact the surviving points left, misaligning the model line with the
+ * blended line for every hour after the gap. An empty result returns null so
+ * the caller can null the whole field.
+ */
+private fun PerModelHourly.slicedTo(window: List<LocalDateTime>): PerModelHourly? {
+    if (window.isEmpty()) return null
+    val filtered = byModel.mapNotNull { (model, entries) ->
+        val byTime = entries.associateBy { it.time }
+        val sliced = window.map { byTime[it] ?: return@mapNotNull null }
+        model to sliced
+    }.toMap()
+    return if (filtered.isEmpty()) null else PerModelHourly(filtered)
+}
+
+/**
+ * Each daytime hour belongs to [todayDate] — [slicedForToday] never wraps
+ * past midnight, so every entry's [HourlyForecast.time] is unambiguously
+ * today's calendar day.
+ */
+private fun todayWindow(windowHourly: List<HourlyForecast>, todayDate: LocalDate): List<LocalDateTime> =
+    windowHourly.map { LocalDateTime.of(todayDate, it.time) }
+
+/**
+ * Tonight wraps from [tonightStart] today to next morning, so a window hour
+ * with `time >= tonightStart` is on [todayDate]; anything before it (the
+ * tomorrow-morning portion concatenated by [slicedForTonight]) is on the
+ * next day.
+ */
+private fun tonightWindow(
+    windowHourly: List<HourlyForecast>,
+    todayDate: LocalDate,
+    tonightStart: LocalTime,
+): List<LocalDateTime> = windowHourly.map { entry ->
+    val date = if (!entry.time.isBefore(tonightStart)) todayDate else todayDate.plusDays(1)
+    LocalDateTime.of(date, entry.time)
 }
 
 /**
@@ -236,74 +374,6 @@ class GenerateDailyInsight(
  *    users via its own wrap, so blanking out the hourly here would just lose
  *    information the tonight slice still needs.
  */
-/**
- * Filters each model's per-hour entries to just the hours covered by [window]
- * (LocalDateTimes the caller computed from the period's hourly slice), preserving
- * the window's order so each index in the resulting series lines up with the same
- * index in the matching base hourly — the chart plots overlays by index.
- *
- * Drops a model entirely from the overlay if it's missing any in-window hour
- * (the upstream `parseHourly` skips per-hour entries with null temp or precip
- * values for a model whose run hasn't fully landed). Carrying a partial series
- * would compact the surviving points left, misaligning the model line with the
- * blended line for every hour after the gap — better to omit the model than
- * draw a curve that's silently shifted. An empty result returns null so the
- * caller can null the whole field.
- */
-private fun PerModelHourly.slicedTo(window: List<LocalDateTime>): PerModelHourly? {
-    if (window.isEmpty()) return null
-    val filtered = byModel.mapNotNull { (model, entries) ->
-        val byTime = entries.associateBy { it.time }
-        val sliced = window.map { byTime[it] ?: return@mapNotNull null }
-        model to sliced
-    }.toMap()
-    return if (filtered.isEmpty()) null else PerModelHourly(filtered)
-}
-
-/**
- * Lenient counterpart to [slicedTo]: filters each model's entries to the ones
- * whose [LocalDateTime] is in [window], dropping out-of-window entries but
- * keeping models that don't cover every window hour. Renderer consumers
- * (e.g. [RenderInsightSummary.pickPerModelPeak]) iterate per-hour readings
- * and don't need positional alignment, so dropping an entire model because
- * of one missing hour — what [slicedTo]'s chart-alignment contract demands
- * — would silently lose the rain reading the per-model tier exists to catch.
- * An empty result returns null so the caller can null the whole field.
- */
-private fun PerModelHourly.intersectedWith(window: List<LocalDateTime>): PerModelHourly? {
-    if (window.isEmpty()) return null
-    val keep = window.toSet()
-    val filtered = byModel.mapNotNull { (model, entries) ->
-        val sliced = entries.filter { it.time in keep }
-        if (sliced.isEmpty()) null else model to sliced
-    }.toMap()
-    return if (filtered.isEmpty()) null else PerModelHourly(filtered)
-}
-
-/**
- * Each daytime hour belongs to [todayDate] — [slicedForToday] never wraps
- * past midnight, so every entry's [HourlyForecast.time] is unambiguously
- * today's calendar day.
- */
-private fun todayWindow(windowHourly: List<HourlyForecast>, todayDate: java.time.LocalDate): List<LocalDateTime> =
-    windowHourly.map { LocalDateTime.of(todayDate, it.time) }
-
-/**
- * Tonight wraps from [tonightStart] today to next morning, so a window hour
- * with `time >= tonightStart` is on [todayDate]; anything before it (the
- * tomorrow-morning portion concatenated by [slicedForTonight]) is on the
- * next day. Same rule that keeps the LocalTime ambiguity from biting the
- * tonight wrap elsewhere in this module.
- */
-private fun tonightWindow(
-    windowHourly: List<HourlyForecast>,
-    todayDate: java.time.LocalDate,
-    tonightStart: LocalTime,
-): List<LocalDateTime> = windowHourly.map { entry ->
-    val date = if (!entry.time.isBefore(tonightStart)) todayDate else todayDate.plusDays(1)
-    LocalDateTime.of(date, entry.time)
-}
-
 private fun DailyForecast.slicedForToday(
     morningStart: LocalTime,
     eveningEnd: LocalTime,

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/RenderInsightSummary.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/RenderInsightSummary.kt
@@ -19,24 +19,24 @@ import app.clothescast.core.domain.model.TemperatureBand
 import app.clothescast.core.domain.model.WeatherAlert
 import app.clothescast.core.domain.model.WeatherCondition
 import java.time.LocalTime
-import java.util.Locale
 import kotlin.math.abs
 import kotlin.math.roundToInt
 
 /**
- * Builds the structured [InsightSummary] for a daily generation pass: up to seven
- * independent clauses, each driven by an independent rule. The presentation layer
- * (an Android-side formatter) turns this into the final prose, so anything
- * region- or locale-specific (clothes vocab, sentence templates, time formatting)
- * is resolved there rather than here.
+ * Builds the structured [InsightSummary] for a single period (TODAY or TONIGHT).
+ * Pure function: same forecast slice, same clauses. The renderer no longer
+ * special-cases evening data — the morning's heads-up about a cold or rainy
+ * evening event is computed by the caller by running this same render against
+ * the night slice and folding the resulting clothes + precip clauses into an
+ * [EveningEventTieInClause] (see [GenerateDailyInsight]).
  *
  * Rules (each yields 0 or 1 clause):
  * 1. [AlertClause] — highest-severity SEVERE/EXTREME alert. Extreme outranks Severe;
  *    ties take the first listed.
  * 2. [BandClause] — classify feels-like low and high into bands. Always emitted.
  * 3. [DeltaClause] — yesterday vs today; only emitted when the larger absolute
- *    feels-like delta is ≥ 3°C, and only for [ForecastPeriod.TODAY] (the morning
- *    pass already mentioned this comparison; the tonight pass shouldn't repeat it).
+ *    feels-like delta is ≥ 3°C, and only for [ForecastPeriod.TODAY] (yesterday's
+ *    overnight comparison isn't useful, and the morning pass already covers it).
  * 4. [ClothesClause] — items triggered by the user's rule list, in rule order.
  * 5. [PrecipClause] — fires in two tiers driven by cross-model agreement:
  *    [PrecipLikelihood.LIKELY] when a majority of consulted models hit ≥ 50%
@@ -51,12 +51,9 @@ import kotlin.math.roundToInt
  *    **Only emitted on [ForecastPeriod.TONIGHT].** On TODAY the bare precip
  *    clause ("Rain at 3pm.") is enough — the listener already knows about
  *    their morning event, so chaining a tie-in just repeats what they heard.
- * 7. [EveningEventTieInClause] — the morning's heads-up about a cold/rainy
- *    evening event, paired with a clothes item drawn from the *evening*
- *    forecast slice. Only emits on [ForecastPeriod.TODAY], gated on the
- *    caller passing non-empty [eveningEvents] + [eveningTriggeredRules]
- *    (which the use case in turn gates on the user opting in via
- *    "Mention evening events").
+ * 7. [EveningEventTieInClause] — passes through whatever the caller built. The
+ *    renderer doesn't know how to compose one because it requires consulting
+ *    the night forecast slice, which is the caller's job.
  *
  * All temperature comparisons use feels-like values, matching the clothes rules.
  */
@@ -68,9 +65,6 @@ class RenderInsightSummary {
         alerts: List<WeatherAlert> = emptyList(),
         events: List<CalendarEvent> = emptyList(),
         period: ForecastPeriod = ForecastPeriod.TODAY,
-        eveningEvents: List<CalendarEvent> = emptyList(),
-        eveningTriggeredRules: List<ClothesRule> = emptyList(),
-        eveningForecast: DailyForecast? = null,
         // The today side of the delta comparison, paired with [yesterday]. The
         // caller picks the pair so today and yesterday cover the same time range
         // — typically daytime-vs-daytime when both have hourly entries in the
@@ -82,34 +76,17 @@ class RenderInsightSummary {
         // present, the precip clause uses cross-model agreement to pick its
         // tier (see [PrecipLikelihood]); when null we fall back to the base
         // hourly + day-level field. Caller is responsible for slicing the
-        // per-model series to the same window as [today.hourly] so peak hours
-        // line up.
+        // per-model series to the same window as [today.hourly].
         perModelHourly: PerModelHourly? = null,
-        // Evening per-model hourly, paired with [eveningForecast]. Open-Meteo's
-        // per-model hourly currently only covers `forecast_days=1`, so the
-        // tonight pass (which wraps past midnight) usually can't supply this —
-        // null falls back to the base series exactly like the today path.
-        eveningPerModelHourly: PerModelHourly? = null,
+        // Pre-built evening tie-in. The caller (GenerateDailyInsight) constructs
+        // it by running render() against the night slice and folding the
+        // resulting clothes + precip clauses, gated on the user having an
+        // event away from home that night. This renderer is period-local and
+        // doesn't compose it.
+        eveningEventTieIn: EveningEventTieInClause? = null,
     ): InsightSummary {
         val items = todayTriggeredRules.map { it.item }
         val peak = peakPrecip(today, perModelHourly)
-        // Compute the evening peak whenever the tie-in could fire — i.e. the
-        // morning insight, with at least one evening event, and an evening
-        // forecast to inspect. Previously also gated on
-        // `eveningTriggeredRules.isNotEmpty()`, but per-model rain on a mild
-        // evening (no temperature rule triggered, no user-defined precip
-        // rule) is exactly the case the tie-in needs to surface — the bare
-        // rain warning falls out of the clause assembly below when no item
-        // is on the list. Cheap when no per-model data is present (the
-        // base-only peakPrecip is a single max over the hourly slice).
-        val eveningPeak = if (
-            period == ForecastPeriod.TODAY &&
-            eveningEvents.isNotEmpty()
-        ) {
-            eveningForecast?.let { peakPrecip(it, eveningPerModelHourly) }
-        } else {
-            null
-        }
         return InsightSummary(
             period = period,
             alert = alertClause(alerts),
@@ -125,7 +102,7 @@ class RenderInsightSummary {
             // enough; chaining "Bring an umbrella for your 3pm standup." after
             // it just repeats what the user already heard.
             calendarTieIn = if (period == ForecastPeriod.TONIGHT) calendarTieInClause(items, peak, events) else null,
-            eveningEventTieIn = eveningEventTieInClause(period, eveningEvents, eveningTriggeredRules, eveningPeak, items),
+            eveningEventTieIn = eveningEventTieIn,
         )
     }
 
@@ -219,14 +196,6 @@ class RenderInsightSummary {
         //
         // Majority is computed PER HOUR over the models that actually reported
         // a reading there, not over the total number of models in [byModel].
-        // The lenient evening-tie-in slice ([intersectedWith]) intentionally
-        // keeps models that only cover part of the tonight window — a model
-        // whose run hasn't fully landed reports rain at 21:00 but has no
-        // 05:00 entry, and we still want it feeding the 21:00 peak (Codex
-        // caught it). With a total-models-based bar, "both models that did
-        // report at 02:00 agree at 80%" would be treated as 2-of-4 against
-        // the absent ones — silently downgrading a genuine consensus to
-        // POSSIBLE just because the other two models had no overnight data.
         // Floor of 2 readings keeps a single-model agreement honest as a
         // POSSIBLE rather than promoting it to LIKELY: "one model says rain"
         // is the textbook chance-of-rain case the per-model tier exists to
@@ -300,95 +269,6 @@ class RenderInsightSummary {
         // take the first triggered item, mirroring rule 4's ordering.
         val item = items.firstOrNull { it.equals("umbrella", ignoreCase = true) } ?: items.first()
         return CalendarTieInClause(item = item)
-    }
-
-    /**
-     * Evening-event tie-in for the morning insight. Only emits on [ForecastPeriod.TODAY]
-     * — the tonight pass already covers evening events via [calendarTieInClause].
-     * Pairs the evening forecast slice with the first triggered clothes item (umbrella
-     * first if present) and the evening precip-peak time, gated on the existence of at
-     * least one located evening event. Caller is responsible for filtering [eveningEvents]
-     * to actually-evening events and for evaluating clothes rules against the evening
-     * forecast. Calendar event titles, locations, and start times are never captured
-     * into the returned clause.
-     *
-     * Two emission paths:
-     *  - Triggered-item path: at least one clothes rule fires on the evening
-     *    forecast → "Bring a jacket tonight." (item only) or "Bring an umbrella
-     *    tonight, rain at 9pm." (item + per-model rain).
-     *  - Bare-rain path: no rule triggers but a per-model series spots rain ≥
-     *    [POSSIBLE_THRESHOLD]% somewhere in the tonight window → emit with
-     *    [EveningEventTieInClause.item] null. The formatter renders this as
-     *    "Rain tonight at 9pm." (LIKELY) or "Chance of rain tonight at 9pm."
-     *    (POSSIBLE). Picks up the case where the user has a temperature-only
-     *    rule set on a mild evening with one-model rain — the morning insight
-     *    would otherwise stay silent on the rain even though it's exactly
-     *    what the per-model tier exists to catch.
-     *
-     * Suppressed when:
-     *  - No evening event has a location (location-less events don't imply outdoor
-     *    exposure where the weather matters).
-     *  - Triggered-item path only: the evening clothes items are a subset of (or
-     *    equal to) [todayItems] — the morning insight already told the user every
-     *    item; repeating a subset of them for the evening adds no new information.
-     *    The bare-rain path doesn't apply this filter: today's rain ≠ tonight's
-     *    rain, so the morning insight covering today's clothing list doesn't
-     *    pre-empt an evening rain warning.
-     */
-    private fun eveningEventTieInClause(
-        period: ForecastPeriod,
-        eveningEvents: List<CalendarEvent>,
-        eveningTriggeredRules: List<ClothesRule>,
-        eveningPeak: PeakPrecip?,
-        todayItems: List<String>,
-    ): EveningEventTieInClause? {
-        if (period != ForecastPeriod.TODAY) return null
-        if (eveningEvents.isEmpty()) return null
-        // Gate on at least one non-all-day evening event that has a location.
-        // Events without a location don't imply outdoor exposure, so the
-        // weather-specific clothing tip isn't warranted. Calendar event titles
-        // never flow to off-device TTS.
-        eveningEvents.firstOrNull { !it.allDay && !it.location.isNullOrBlank() } ?: return null
-        val items = eveningTriggeredRules.map { it.item }
-        if (items.isEmpty()) {
-            // Bare-rain path: no triggered rule, so the only thing left to say
-            // is that a model spotted evening rain. Suppress when there's no
-            // rain to name either — that's the genuinely-nothing-to-add case.
-            val peak = eveningPeak ?: return null
-            return EveningEventTieInClause(
-                item = null,
-                rainTime = peak.time,
-                likelihood = peak.likelihood,
-            )
-        }
-        // If the evening clothes are a subset of (or equal to) today's clothes,
-        // the morning insight already covered every item — no new information to add.
-        // Compare normalized (trim + lowercase) so legacy free-form ClothesRule.item
-        // values don't fail to suppress on a casing/whitespace mismatch ("Jacket" vs
-        // "jacket"); matches the case-insensitive umbrella check below.
-        //
-        // Exception: when there's an evening rain peak, the rain mention IS
-        // new information even if the items are a subset — the morning
-        // precip clause only covers the daytime slice, so without the
-        // tie-in there's no other place that evening rain gets surfaced
-        // (Codex caught it). Fall through to the bare-rain emission in
-        // that case rather than dropping the clause wholesale.
-        val normalize: (String) -> String = { it.trim().lowercase(Locale.ROOT) }
-        val itemsRedundant = todayItems.map(normalize).toSet().containsAll(items.map(normalize).toSet())
-        if (itemsRedundant) {
-            val peak = eveningPeak ?: return null
-            return EveningEventTieInClause(
-                item = null,
-                rainTime = peak.time,
-                likelihood = peak.likelihood,
-            )
-        }
-        val item = items.firstOrNull { it.equals("umbrella", ignoreCase = true) } ?: items.first()
-        return EveningEventTieInClause(
-            item = item,
-            rainTime = eveningPeak?.time,
-            likelihood = eveningPeak?.likelihood ?: PrecipLikelihood.LIKELY,
-        )
     }
 
     private data class PeakPrecip(

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsightTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsightTest.kt
@@ -640,53 +640,72 @@ class GenerateDailyInsightTest {
     }
 
     @Test
-    fun `evening tie-in still fires when a model is missing an unrelated tonight-window hour`() = runTest {
-        // The strict [slicedTo] used for the chart overlay drops a model
-        // entirely on any missing in-window hour (positional alignment for
-        // the chart). The evening tie-in path uses [intersectedWith] instead
-        // — the renderer's peak-finder works on whatever per-hour readings
-        // are present, so a model that reports 75% rain at 21:00 but has no
-        // 05:00 entry must still feed the tie-in. Silently dropping it would
-        // re-introduce the bug this whole feature exists to fix.
+    fun `evening tie-in is omitted when the user has no event away from home`() = runTest {
+        // The away-from-home gate is the only behavioural asymmetry between
+        // the day and night passes. With no located event in the night window
+        // — only a morning event, or an unlocated evening one — the morning
+        // insight stays silent about the night even if clothes rules would
+        // fire on the night slice.
+        val zone = ZoneId.of("Europe/London")
+        val coldEvening = listOf(
+            HourlyForecast(LocalTime.of(8, 0), 16.0, 15.0, 5.0, WeatherCondition.CLEAR),
+            HourlyForecast(LocalTime.of(21, 0), 10.0, 8.0, 5.0, WeatherCondition.CLEAR),
+        )
+        val baseHourly = today.copy(
+            hourly = coldEvening,
+            precipitationProbabilityMaxPct = 5.0,
+            condition = WeatherCondition.CLEAR,
+        )
+        val unlocated = CalendarEvent(
+            title = "call",
+            start = LocalTime.of(21, 0),
+            end = LocalTime.of(22, 0),
+            location = null,
+        )
+        val weather = FakeWeatherRepository(ForecastBundle(baseHourly, yesterday))
+        val calendar = FakeCalendarEventReader(events = listOf(unlocated))
+        val subject = GenerateDailyInsight(weather, calendarEventReader = calendar, clock = clock)
+
+        val jacketOnly = listOf(ClothesRule("jacket", ClothesRule.TemperatureBelow(12.0)))
+        val result = subject(
+            location = london,
+            prefs = prefs.copy(
+                clothesRules = jacketOnly,
+                useCalendarEvents = true,
+                schedule = Schedule.default(zone),
+            ),
+            period = ForecastPeriod.TODAY,
+        )
+
+        result.insight.summary.eveningEventTieIn.shouldBeNull()
+    }
+
+    @Test
+    fun `evening tie-in mirrors what the night notification would itself say`() = runTest {
+        // The day's evening tie-in is the night insight, dictated by the
+        // night bundle. When the night insight would say "Bring a jacket;
+        // rain at 9pm.", the tie-in carries the same item + rain time.
+        val zone = ZoneId.of("Europe/London")
         val daytime = listOf(
             HourlyForecast(LocalTime.of(8, 0), 16.0, 15.0, 5.0, WeatherCondition.CLEAR),
-            HourlyForecast(LocalTime.of(12, 0), 18.0, 17.0, 5.0, WeatherCondition.CLEAR),
             HourlyForecast(LocalTime.of(15, 0), 18.0, 17.0, 5.0, WeatherCondition.CLEAR),
         )
         val evening = listOf(
-            HourlyForecast(LocalTime.of(19, 0), 11.0, 9.0, 10.0, WeatherCondition.PARTLY_CLOUDY),
-            HourlyForecast(LocalTime.of(21, 0), 10.0, 8.0, 10.0, WeatherCondition.PARTLY_CLOUDY),
-        )
-        val tomorrowMorning = listOf(
-            HourlyForecast(LocalTime.of(2, 0), 9.0, 7.0, 10.0, WeatherCondition.PARTLY_CLOUDY),
-            HourlyForecast(LocalTime.of(5, 0), 9.0, 7.0, 10.0, WeatherCondition.PARTLY_CLOUDY),
+            HourlyForecast(LocalTime.of(19, 0), 11.0, 9.0, 60.0, WeatherCondition.RAIN),
+            HourlyForecast(LocalTime.of(21, 0), 10.0, 8.0, 80.0, WeatherCondition.RAIN),
         )
         val baseHourly = today.copy(
             hourly = daytime + evening,
-            precipitationProbabilityMaxPct = 10.0,
-            condition = WeatherCondition.PARTLY_CLOUDY,
+            precipitationProbabilityMaxPct = 80.0,
+            condition = WeatherCondition.RAIN,
         )
-        // ecmwf sees the evening rain at 21:00 but its 05:00 tomorrow entry
-        // is missing (model run still warming up — parseHourly drops null
-        // hours). Pre-fix the strict slice dropped the whole model and the
-        // tie-in fell back to base-only; with [intersectedWith] the rain
-        // hour survives.
-        val ecmwfEntries = listOf(
-            PerModelHour(LocalDateTime.of(today.date, LocalTime.of(19, 0)), 11.0, 9.0, 10.0),
-            PerModelHour(LocalDateTime.of(today.date, LocalTime.of(21, 0)), 11.0, 9.0, 75.0),
-            PerModelHour(LocalDateTime.of(today.date.plusDays(1), LocalTime.of(2, 0)), 9.0, 7.0, 10.0),
-            // 05:00 tomorrow intentionally missing.
-        )
-        val perModelHourly = PerModelHourly(byModel = mapOf("ecmwf_ifs04" to ecmwfEntries))
         val diner = CalendarEvent(
             title = "dinner",
             start = LocalTime.of(21, 0),
             end = LocalTime.of(23, 0),
             location = "Restaurant",
         )
-        val weather = FakeWeatherRepository(
-            ForecastBundle(baseHourly, yesterday, perModelHourly = perModelHourly, tomorrowHourly = tomorrowMorning),
-        )
+        val weather = FakeWeatherRepository(ForecastBundle(baseHourly, yesterday))
         val calendar = FakeCalendarEventReader(events = listOf(diner))
         val subject = GenerateDailyInsight(weather, calendarEventReader = calendar, clock = clock)
 
@@ -696,6 +715,7 @@ class GenerateDailyInsightTest {
             prefs = prefs.copy(
                 clothesRules = jacketOnly,
                 useCalendarEvents = true,
+                schedule = Schedule.default(zone),
             ),
             period = ForecastPeriod.TODAY,
         )
@@ -704,6 +724,144 @@ class GenerateDailyInsightTest {
         tie.shouldNotBeNull()
         tie!!.item shouldBe "jacket"
         tie.rainTime shouldBe LocalTime.of(21, 0)
+    }
+
+    @Test
+    fun `evening tie-in carries only the clothing delta vs the morning insight`() = runTest {
+        // Today triggers sweater on a cool daytime; night gets colder and
+        // additionally needs a jacket. The tie-in carries the new item
+        // ("jacket"), not "sweater" — the morning insight already mentioned
+        // sweater, so repeating it adds nothing.
+        val zone = ZoneId.of("Europe/London")
+        val daytime = listOf(
+            HourlyForecast(LocalTime.of(8, 0), 17.0, 16.0, 5.0, WeatherCondition.CLEAR),
+            HourlyForecast(LocalTime.of(15, 0), 17.0, 16.0, 5.0, WeatherCondition.CLEAR),
+        )
+        val evening = listOf(
+            HourlyForecast(LocalTime.of(19, 0), 11.0, 9.0, 5.0, WeatherCondition.CLEAR),
+            HourlyForecast(LocalTime.of(21, 0), 10.0, 8.0, 5.0, WeatherCondition.CLEAR),
+        )
+        val baseHourly = today.copy(
+            hourly = daytime + evening,
+            precipitationProbabilityMaxPct = 5.0,
+            condition = WeatherCondition.CLEAR,
+        )
+        val diner = CalendarEvent(
+            title = "dinner",
+            start = LocalTime.of(21, 0),
+            end = LocalTime.of(23, 0),
+            location = "Restaurant",
+        )
+        val weather = FakeWeatherRepository(ForecastBundle(baseHourly, yesterday))
+        val calendar = FakeCalendarEventReader(events = listOf(diner))
+        val subject = GenerateDailyInsight(weather, calendarEventReader = calendar, clock = clock)
+
+        val rules = listOf(
+            ClothesRule("sweater", ClothesRule.TemperatureBelow(18.0)),
+            ClothesRule("jacket", ClothesRule.TemperatureBelow(12.0)),
+        )
+        val result = subject(
+            location = london,
+            prefs = prefs.copy(
+                clothesRules = rules,
+                useCalendarEvents = true,
+                schedule = Schedule.default(zone),
+            ),
+            period = ForecastPeriod.TODAY,
+        )
+
+        val tie = result.insight.summary.eveningEventTieIn
+        tie.shouldNotBeNull()
+        tie!!.item shouldBe "jacket"
+        tie.rainTime.shouldBeNull()
+    }
+
+    @Test
+    fun `evening tie-in collapses to bare rain when night items are a subset of today`() = runTest {
+        // Today and night both trigger the same item (jacket — cold all
+        // day). With no clothing delta the tie-in skips the item part and
+        // surfaces just the rain mention, because evening rain is still new
+        // information the morning slice didn't cover.
+        val zone = ZoneId.of("Europe/London")
+        val daytime = listOf(
+            HourlyForecast(LocalTime.of(8, 0), 8.0, 6.0, 5.0, WeatherCondition.CLEAR),
+            HourlyForecast(LocalTime.of(15, 0), 10.0, 9.0, 5.0, WeatherCondition.CLEAR),
+        )
+        val evening = listOf(
+            HourlyForecast(LocalTime.of(19, 0), 9.0, 7.0, 60.0, WeatherCondition.RAIN),
+            HourlyForecast(LocalTime.of(21, 0), 8.0, 6.0, 80.0, WeatherCondition.RAIN),
+        )
+        val baseHourly = today.copy(
+            hourly = daytime + evening,
+            precipitationProbabilityMaxPct = 80.0,
+            condition = WeatherCondition.RAIN,
+        )
+        val diner = CalendarEvent(
+            title = "dinner",
+            start = LocalTime.of(21, 0),
+            end = LocalTime.of(23, 0),
+            location = "Restaurant",
+        )
+        val weather = FakeWeatherRepository(ForecastBundle(baseHourly, yesterday))
+        val calendar = FakeCalendarEventReader(events = listOf(diner))
+        val subject = GenerateDailyInsight(weather, calendarEventReader = calendar, clock = clock)
+
+        val jacketOnly = listOf(ClothesRule("jacket", ClothesRule.TemperatureBelow(12.0)))
+        val result = subject(
+            location = london,
+            prefs = prefs.copy(
+                clothesRules = jacketOnly,
+                useCalendarEvents = true,
+                schedule = Schedule.default(zone),
+            ),
+            period = ForecastPeriod.TODAY,
+        )
+
+        val tie = result.insight.summary.eveningEventTieIn
+        tie.shouldNotBeNull()
+        tie!!.item.shouldBeNull()
+        tie.rainTime shouldBe LocalTime.of(21, 0)
+    }
+
+    @Test
+    fun `evening tie-in is omitted when delta is empty and there is no rain`() = runTest {
+        // Same items today and night, no rain — there's genuinely nothing
+        // to add for the evening, so the tie-in stays silent.
+        val zone = ZoneId.of("Europe/London")
+        val daytime = listOf(
+            HourlyForecast(LocalTime.of(8, 0), 8.0, 6.0, 5.0, WeatherCondition.CLEAR),
+            HourlyForecast(LocalTime.of(15, 0), 10.0, 9.0, 5.0, WeatherCondition.CLEAR),
+        )
+        val evening = listOf(
+            HourlyForecast(LocalTime.of(21, 0), 8.0, 6.0, 5.0, WeatherCondition.CLEAR),
+        )
+        val baseHourly = today.copy(
+            hourly = daytime + evening,
+            precipitationProbabilityMaxPct = 5.0,
+            condition = WeatherCondition.CLEAR,
+        )
+        val diner = CalendarEvent(
+            title = "dinner",
+            start = LocalTime.of(21, 0),
+            end = LocalTime.of(23, 0),
+            location = "Restaurant",
+        )
+        val weather = FakeWeatherRepository(ForecastBundle(baseHourly, yesterday))
+        val calendar = FakeCalendarEventReader(events = listOf(diner))
+        val subject = GenerateDailyInsight(weather, calendarEventReader = calendar, clock = clock)
+
+        val jacketOnly = listOf(ClothesRule("jacket", ClothesRule.TemperatureBelow(12.0)))
+        val result = subject(
+            location = london,
+            prefs = prefs.copy(
+                clothesRules = jacketOnly,
+                useCalendarEvents = true,
+                schedule = Schedule.default(zone),
+            ),
+            period = ForecastPeriod.TODAY,
+        )
+
+        result.insight.summary.eveningEventTieIn.shouldBeNull()
     }
 
     @Test

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/RenderInsightSummaryTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/RenderInsightSummaryTest.kt
@@ -5,6 +5,7 @@ import app.clothescast.core.domain.model.CalendarEvent
 import app.clothescast.core.domain.model.ClothesRule
 import app.clothescast.core.domain.model.DailyForecast
 import app.clothescast.core.domain.model.DeltaClause
+import app.clothescast.core.domain.model.EveningEventTieInClause
 import app.clothescast.core.domain.model.ForecastPeriod
 import app.clothescast.core.domain.model.HourlyForecast
 import app.clothescast.core.domain.model.PerModelHour
@@ -51,7 +52,6 @@ class RenderInsightSummaryTest {
     private val sweaterRule = ClothesRule("sweater", ClothesRule.TemperatureBelow(18.0))
     private val jacketRule = ClothesRule("jacket", ClothesRule.TemperatureBelow(12.0))
     private val umbrellaRule = ClothesRule("umbrella", ClothesRule.PrecipitationProbabilityAbove(50.0))
-    private val shortsRule = ClothesRule("shorts", ClothesRule.TemperatureAbove(24.0))
 
     @Test
     fun `band clause is always emitted`() {
@@ -188,293 +188,28 @@ class RenderInsightSummaryTest {
     }
 
     @Test
-    fun `evening event tie-in pairs first evening event with first triggered evening item`() {
-        val event = CalendarEvent("dinner", LocalTime.of(21, 0), LocalTime.of(23, 0), location = "Restaurant")
-        val out = subject(
-            today = mildToday,
-            yesterday = yesterday,
-            todayTriggeredRules = emptyList(),
-            eveningEvents = listOf(event),
-            eveningTriggeredRules = listOf(jacketRule),
-        )
-        val tie = out.eveningEventTieIn
-        tie.shouldNotBeNull()
-        tie!!.item shouldBe "jacket"
-        // No title or rainTime — caller didn't pass an evening forecast and
-        // we never carry the event title in the rendered prose.
-        tie.rainTime.shouldBeNull()
-    }
-
-    @Test
-    fun `evening event tie-in carries rain time when evening forecast peaks above 30 percent`() {
-        val event = CalendarEvent("dinner", LocalTime.of(21, 0), LocalTime.of(23, 0), location = "Restaurant")
-        val rainyEvening = mildToday.copy(
-            precipitationProbabilityMaxPct = 60.0,
-            condition = WeatherCondition.RAIN,
-            hourly = listOf(HourlyForecast(LocalTime.of(21, 0), 12.0, 10.0, 60.0, WeatherCondition.RAIN)),
+    fun `evening event tie-in passes through whatever the caller built`() {
+        // The renderer no longer composes the evening tie-in — GenerateDailyInsight
+        // builds it by re-running the renderer against the night slice and
+        // folding clothes + precip into the clause. The renderer just passes
+        // it through.
+        val tieIn = EveningEventTieInClause(
+            item = "jacket",
+            rainTime = LocalTime.of(21, 0),
+            likelihood = PrecipLikelihood.POSSIBLE,
         )
         val out = subject(
             today = mildToday,
             yesterday = yesterday,
             todayTriggeredRules = emptyList(),
-            eveningEvents = listOf(event),
-            eveningTriggeredRules = listOf(umbrellaRule),
-            eveningForecast = rainyEvening,
+            eveningEventTieIn = tieIn,
         )
-        val tie = out.eveningEventTieIn
-        tie.shouldNotBeNull()
-        tie!!.item shouldBe "umbrella"
-        tie.rainTime shouldBe LocalTime.of(21, 0)
+        out.eveningEventTieIn shouldBe tieIn
     }
 
     @Test
-    fun `evening event tie-in omits rain time when evening peak is below threshold`() {
-        val event = CalendarEvent("dinner", LocalTime.of(21, 0), LocalTime.of(23, 0), location = "Restaurant")
-        val dryEvening = mildToday.copy(
-            precipitationProbabilityMaxPct = 5.0,
-            condition = WeatherCondition.PARTLY_CLOUDY,
-            hourly = listOf(HourlyForecast(LocalTime.of(21, 0), 8.0, 6.0, 5.0, WeatherCondition.PARTLY_CLOUDY)),
-        )
-        val out = subject(
-            today = mildToday,
-            yesterday = yesterday,
-            todayTriggeredRules = emptyList(),
-            eveningEvents = listOf(event),
-            eveningTriggeredRules = listOf(jacketRule),
-            eveningForecast = dryEvening,
-        )
-        val tie = out.eveningEventTieIn
-        tie.shouldNotBeNull()
-        tie!!.item shouldBe "jacket"
-        tie.rainTime.shouldBeNull()
-    }
-
-    @Test
-    fun `evening event tie-in prefers umbrella when on the triggered list`() {
-        val event = CalendarEvent("show", LocalTime.of(20, 0), LocalTime.of(22, 0), location = "Theatre")
-        val out = subject(
-            today = mildToday,
-            yesterday = yesterday,
-            todayTriggeredRules = emptyList(),
-            eveningEvents = listOf(event),
-            eveningTriggeredRules = listOf(jacketRule, umbrellaRule),
-        )
-        out.eveningEventTieIn.shouldNotBeNull()
-        out.eveningEventTieIn!!.item shouldBe "umbrella"
-    }
-
-    @Test
-    fun `evening event tie-in is omitted on the tonight period`() {
-        val event = CalendarEvent("dinner", LocalTime.of(21, 0), LocalTime.of(23, 0))
-        val out = subject(
-            today = mildToday,
-            yesterday = yesterday,
-            todayTriggeredRules = emptyList(),
-            period = ForecastPeriod.TONIGHT,
-            eveningEvents = listOf(event),
-            eveningTriggeredRules = listOf(jacketRule),
-        )
-        out.eveningEventTieIn.shouldBeNull()
-    }
-
-    @Test
-    fun `evening event tie-in is omitted when no clothes rules trigger and no rain to mention`() {
-        // The bare-rain emission path requires an evening peak; without one
-        // (no eveningForecast, or a dry evening) and with no triggered
-        // rules, there's genuinely nothing to add for the evening.
-        val event = CalendarEvent("dinner", LocalTime.of(21, 0), LocalTime.of(23, 0), location = "Restaurant")
-        val out = subject(
-            today = mildToday,
-            yesterday = yesterday,
-            todayTriggeredRules = emptyList(),
-            eveningEvents = listOf(event),
-            eveningTriggeredRules = emptyList(),
-        )
-        out.eveningEventTieIn.shouldBeNull()
-    }
-
-    @Test
-    fun `evening event tie-in emits bare rain when no rule triggers but per-model spots rain`() {
-        // The case AGENTS.md documents under "Domain conventions": user
-        // has only temperature-keyed rules, the evening is mild enough
-        // that none trigger, but a per-model series spots rain ≥ 30% in
-        // the tonight window. The morning insight must still mention the
-        // rain — staying silent is exactly the gap the per-model tier
-        // exists to catch — but it shouldn't invent a clothes
-        // recommendation the user hasn't asked for. Surfaces as
-        // item=null + rainTime set; the formatter renders this as a
-        // bare "Rain tonight at 9pm.".
-        val event = CalendarEvent("dinner", LocalTime.of(21, 0), LocalTime.of(23, 0), location = "Restaurant")
-        val mildEvening = mildToday.copy(
-            precipitationProbabilityMaxPct = 10.0,
-            condition = WeatherCondition.PARTLY_CLOUDY,
-            hourly = listOf(HourlyForecast(LocalTime.of(21, 0), 14.0, 13.0, 10.0, WeatherCondition.PARTLY_CLOUDY)),
-        )
-        // One model spots rain at 21:00 — the POSSIBLE tier (≥ 30% on a
-        // single model, < majority at ≥ 50%).
-        val perModel = PerModelHourly(
-            byModel = mapOf(
-                "ecmwf_ifs04" to listOf(
-                    PerModelHour(
-                        time = LocalDateTime.of(2026, 5, 13, 21, 0),
-                        apparentTemperatureC = 13.0,
-                        temperatureC = 14.0,
-                        precipitationProbabilityPct = 75.0,
-                    ),
-                ),
-                "gfs_seamless" to listOf(
-                    PerModelHour(
-                        time = LocalDateTime.of(2026, 5, 13, 21, 0),
-                        apparentTemperatureC = 13.0,
-                        temperatureC = 14.0,
-                        precipitationProbabilityPct = 10.0,
-                    ),
-                ),
-                "icon_seamless" to listOf(
-                    PerModelHour(
-                        time = LocalDateTime.of(2026, 5, 13, 21, 0),
-                        apparentTemperatureC = 13.0,
-                        temperatureC = 14.0,
-                        precipitationProbabilityPct = 5.0,
-                    ),
-                ),
-            ),
-        )
-        val out = subject(
-            today = mildToday,
-            yesterday = yesterday,
-            todayTriggeredRules = emptyList(),
-            eveningEvents = listOf(event),
-            eveningTriggeredRules = emptyList(),
-            eveningForecast = mildEvening,
-            eveningPerModelHourly = perModel,
-        )
-        val tie = out.eveningEventTieIn
-        tie.shouldNotBeNull()
-        tie!!.item.shouldBeNull()
-        tie.rainTime shouldBe LocalTime.of(21, 0)
-        tie.likelihood shouldBe PrecipLikelihood.POSSIBLE
-    }
-
-    @Test
-    fun `evening event tie-in bare rain requires a located evening event`() {
-        // Same setup as the bare-rain emission test above, but the event
-        // has no location — the location gate still applies on this path.
-        val event = CalendarEvent("dinner", LocalTime.of(21, 0), LocalTime.of(23, 0))
-        val mildEvening = mildToday.copy(
-            precipitationProbabilityMaxPct = 10.0,
-            condition = WeatherCondition.PARTLY_CLOUDY,
-            hourly = listOf(HourlyForecast(LocalTime.of(21, 0), 14.0, 13.0, 10.0, WeatherCondition.PARTLY_CLOUDY)),
-        )
-        val perModel = PerModelHourly(
-            byModel = mapOf(
-                "ecmwf_ifs04" to listOf(
-                    PerModelHour(
-                        time = LocalDateTime.of(2026, 5, 13, 21, 0),
-                        apparentTemperatureC = 13.0,
-                        temperatureC = 14.0,
-                        precipitationProbabilityPct = 75.0,
-                    ),
-                ),
-            ),
-        )
-        val out = subject(
-            today = mildToday,
-            yesterday = yesterday,
-            todayTriggeredRules = emptyList(),
-            eveningEvents = listOf(event),
-            eveningTriggeredRules = emptyList(),
-            eveningForecast = mildEvening,
-            eveningPerModelHourly = perModel,
-        )
-        out.eveningEventTieIn.shouldBeNull()
-    }
-
-    @Test
-    fun `evening event tie-in skips all-day events`() {
-        val allDay = CalendarEvent("public holiday", LocalTime.MIDNIGHT, LocalTime.MIDNIGHT, allDay = true)
-        val out = subject(
-            today = mildToday,
-            yesterday = yesterday,
-            todayTriggeredRules = emptyList(),
-            eveningEvents = listOf(allDay),
-            eveningTriggeredRules = listOf(jacketRule),
-        )
-        out.eveningEventTieIn.shouldBeNull()
-    }
-
-    @Test
-    fun `evening event tie-in is omitted when no evening event has a location`() {
-        // Events without a location don't imply outdoor exposure, so a
-        // weather-specific clothing tip isn't warranted.
-        val noLocation = CalendarEvent("dinner", LocalTime.of(21, 0), LocalTime.of(23, 0))
-        val out = subject(
-            today = mildToday,
-            yesterday = yesterday,
-            todayTriggeredRules = emptyList(),
-            eveningEvents = listOf(noLocation),
-            eveningTriggeredRules = listOf(jacketRule),
-        )
-        out.eveningEventTieIn.shouldBeNull()
-    }
-
-    @Test
-    fun `evening event tie-in is omitted when evening clothes are the same as today`() {
-        // If the morning insight already mentions the same items, repeating them
-        // for the evening adds no new information.
-        val event = CalendarEvent("dinner", LocalTime.of(21, 0), LocalTime.of(23, 0), location = "Restaurant")
-        val out = subject(
-            today = mildToday,
-            yesterday = yesterday,
-            todayTriggeredRules = listOf(jacketRule),
-            eveningEvents = listOf(event),
-            eveningTriggeredRules = listOf(jacketRule),
-        )
-        out.eveningEventTieIn.shouldBeNull()
-    }
-
-    @Test
-    fun `evening event tie-in is omitted when evening clothes are a strict subset of today`() {
-        // Today triggered sweater + jacket; evening only needs jacket — already
-        // mentioned in the morning, so nothing new to add.
-        val event = CalendarEvent("dinner", LocalTime.of(21, 0), LocalTime.of(23, 0), location = "Restaurant")
-        val out = subject(
-            today = mildToday,
-            yesterday = yesterday,
-            todayTriggeredRules = listOf(sweaterRule, jacketRule),
-            eveningEvents = listOf(event),
-            eveningTriggeredRules = listOf(jacketRule),
-        )
-        out.eveningEventTieIn.shouldBeNull()
-    }
-
-    @Test
-    fun `evening event tie-in falls back to bare rain when items are a subset but rain peaks`() {
-        // Codex case: morning rules and evening rules both recommend jacket
-        // (cold all day), so the item part is redundant — but a per-model
-        // series spots evening rain at 21:00. The morning precip clause
-        // only covers the daytime slice, so dropping the tie-in entirely
-        // would lose the only place evening rain gets surfaced. Fall
-        // through to the bare-rain shape (item=null, rainTime set) so the
-        // rain mention survives without repeating the jacket clothing tip.
-        val event = CalendarEvent("dinner", LocalTime.of(21, 0), LocalTime.of(23, 0), location = "Restaurant")
-        val rainyEvening = mildToday.copy(
-            precipitationProbabilityMaxPct = 60.0,
-            condition = WeatherCondition.RAIN,
-            hourly = listOf(HourlyForecast(LocalTime.of(21, 0), 11.0, 9.0, 60.0, WeatherCondition.RAIN)),
-        )
-        val out = subject(
-            today = mildToday,
-            yesterday = yesterday,
-            todayTriggeredRules = listOf(jacketRule),
-            eveningEvents = listOf(event),
-            eveningTriggeredRules = listOf(jacketRule),
-            eveningForecast = rainyEvening,
-        )
-        val tie = out.eveningEventTieIn
-        tie.shouldNotBeNull()
-        tie!!.item.shouldBeNull()
-        tie.rainTime shouldBe LocalTime.of(21, 0)
+    fun `evening event tie-in defaults to null when caller doesn't supply one`() {
+        subject(mildToday, yesterday, emptyList()).eveningEventTieIn.shouldBeNull()
     }
 
     @Test


### PR DESCRIPTION
## Summary

The morning insight's evening tie-in used to maintain its own bespoke evening slicing, lenient per-model overlay (`intersectedWith`), and a hand-rolled "bare rain" emission path — duplicating a slimmed-down version of the night insight logic. Now the morning insight just runs the same renderer against the night slice and folds the resulting clothes + precip clauses into an `EveningEventTieInClause`, gated on the user having a non-all-day calendar event with a location ("away from home") in the night window.

The clothing item carried in the tie-in is the **delta** between night and day:

| Today's items | Night's items | Night rain | Renders |
|---|---|---|---|
| `[]` | `[jacket]` | — | "Bring a jacket tonight." |
| `[sweater]` | `[sweater, jacket]` | — | "Bring a jacket tonight." |
| `[jacket]` | `[jacket]` | — | (no tie-in) |
| `[jacket]` | `[jacket]` | 9pm | "Rain tonight at 9pm." |
| `[jacket]` | `[jacket, coat]` | 9pm | "Bring a coat tonight, rain at 9pm." |

## Scope

- `RenderInsightSummary` becomes period-local. It no longer takes `eveningEvents` / `eveningTriggeredRules` / `eveningForecast` / `eveningPerModelHourly`. The renamed `eveningEventTieIn` parameter just passes the clause through.
- `GenerateDailyInsight` composes the tie-in by calling render against the night slice with identical wiring (same `slicedTo`, same per-model series, same renderer pass) and reading off `nightSummary.clothes` + `nightSummary.precip`.
- Day and night now differ behaviourally only by:
  - the period itself,
  - the "away from home" gate on whether to splice the night insight into the morning's tie-in,
  - delta clause (TODAY-only — yesterday vs overnight isn't useful),
  - calendar tie-in clause (TONIGHT-only — TODAY's listener already knows their morning events),
  - confidence + chart-side per-model overlay (TODAY-only — "today" copy / axes that'd read wrong-tense on TONIGHT; left as a follow-up).

The night primary insight now also benefits from per-model agreement for its precip clause tier (LIKELY vs POSSIBLE), since the night render call gets the per-model series. Previously TONIGHT stripped per-model entirely.

## Trade-off

Lenient `intersectedWith` is gone. A model whose run hasn't fully landed an in-window hour is dropped from the per-model overlay — same behaviour as TODAY's main precip clause already had.

## TODOs captured inline

- "away from home" currently means "event has a non-blank location"; refine to filter out events whose location matches a user-configured home address once that setting exists.
- Tie-in wording is "Bring an X tonight" via the existing string resource; "Tonight, bring an X" reads more naturally in some locales and is left as a copy follow-up.

## Privacy

No change to what leaves the device. The tie-in clause still carries only the item + rain time + likelihood; calendar event titles and locations remain off-device.

## Test plan

- [ ] `:core:domain:test` passes on CI (sandbox lacks AGP / Google Maven; couldn't run locally).
- [ ] `:app:testDebugUnitTest` passes (InsightFormatter + InsightCache tests construct `EveningEventTieInClause` directly; clause shape unchanged so they should still pass).
- [ ] `:app:assembleDebug` passes.
- [ ] Eyeball a snapshot regen if any preview prose shifted.

https://claude.ai/code/session_01XxH8GuETYmpBLTtPnUZxPE

---
_Generated by [Claude Code](https://claude.ai/code/session_01XxH8GuETYmpBLTtPnUZxPE)_