### PR TITLE
Show weather details for both Today and Tonight periods

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
@@ -318,18 +318,16 @@ private fun TodayContent(
                     perModelHourly = overlay,
                 )
                 // Diagnostic cards below the headline temp + rain pair. Each
-                // one is gated on the overlay being available *and* on at
-                // least one consulted model returning the metric — older
-                // cached payloads don't carry wind / humidity / cloud, so the
-                // cards self-hide until the next worker refresh repopulates.
-                if (overlay != null) {
+                // auto-hides when every consulted model is missing the metric
+                // (older cached payloads don't carry wind / humidity / cloud).
+                state.insight.perModelHourly?.let { perModelData ->
                     WindCard(
                         hourly = state.insight.hourly,
-                        perModelHourly = overlay,
+                        perModelHourly = perModelData,
                         windSpeedUnit = state.distanceUnit.windSpeedUnit(),
                     )
-                    CloudCard(hourly = state.insight.hourly, perModelHourly = overlay)
-                    HumidityCard(hourly = state.insight.hourly, perModelHourly = overlay)
+                    CloudCard(hourly = state.insight.hourly, perModelHourly = perModelData)
+                    HumidityCard(hourly = state.insight.hourly, perModelHourly = perModelData)
                 }
             }
         }


### PR DESCRIPTION
## Summary

- Wind, cloud, and humidity diagnostic cards were gated on the "show model spread" setting — they now show whenever per-model data is available, regardless of that setting
- `perModelHourly` and `confidence` were both `null` for the TONIGHT period — they now populate for both periods, so the diagnostic cards and confidence chip appear on the tonight card too
- "Forecasts disagree today" callout title changed to "Forecasts disagree" (the "today" was wrong-tense on the tonight card)

**Root cause from bug report:** the tonight fetch at 21:00 timed out; the evening was showing the tonight insight which always had `perModelHourly = null` by design. A force-refresh would have regenerated the tonight insight but still shown no cards because of the period guard.

Note: ECMWF (`ecmwf_ifs04`) is consistently being dropped on every fetch (`apparent_temperature_max` and `precipitation_probability_max` missing from the API response). Cards will show GFS + ICON lines (2 of the 3 consulted models).

## Test plan

- [ ] Tonight card: wind, cloud, humidity cards appear after a force-refresh
- [ ] Tonight card: confidence chip appears
- [ ] Tonight card: low-confidence callout (when triggered) reads "Forecasts disagree" not "Forecasts disagree today"
- [ ] Today card: behaviour unchanged — all cards still appear