### PR TITLE
Fill translation gaps across all 44 locales

### DIFF
--- a/app/src/main/res/values-am/strings.xml
+++ b/app/src/main/res/values-am/strings.xml
@@ -10,6 +10,7 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="settings_tts_voice_locale_label">ዘዬ</string>
     <string name="settings_tts_voice_locale_system">የቋንቋ ቅንብርን ተከተል</string>
 
+    <!-- Garments -->
     <string name="garment_sweater">ስወተር</string>
     <string name="garment_hoodie">ሁዲ</string>
     <string name="garment_jacket">ጃኬት</string>
@@ -19,7 +20,12 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="garment_shorts">ሹርቴ</string>
     <string name="garment_pants">ሱሪ</string>
     <string name="garment_jeans">ጂንስ</string>
+    <string name="garment_puffer">ፑፈር ጃኬት</string>
+    <string name="garment_thin_jacket">ቀጭን ጃኬት</string>
+    <string name="garment_skirt">ቀሚስ</string>
+    <string name="garment_polo">ፖሎ</string>
 
+    <!-- Clothes rules settings -->
     <string name="settings_clothes_empty">ምንም ህግ የለም። ለመፍጠር ጨምር ን ይጫኑ።</string>
     <string name="settings_clothes_add">ጨምር</string>
     <string name="settings_clothes_edit">አርትዕ</string>
@@ -36,13 +42,340 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="settings_clothes_cond_temp_below">ዝቅተኛ ሙቀት %1$s ሲቀንስ</string>
     <string name="settings_clothes_cond_temp_above">ከፍተኛ ሙቀት %1$s ሲጨምር</string>
     <string name="settings_clothes_cond_precip_above">የዝናብ ዕድል %.0f%% ሲጨምር</string>
+    <string name="settings_clothes_title">የልብስ ህጎች</string>
+    <string name="settings_clothes_description">አንድ ትንበያ ከእነዚህ ደረጃዎች ካለፈ፣ ልብሱ ወደ ዕለታዊ ClothesCast ይታከላል።</string>
 
+    <!-- Outfit card labels -->
     <string name="today_outfit_top_tshirt">ቲሸርት</string>
     <string name="today_outfit_top_sweater">ስወተር</string>
     <string name="today_outfit_top_thick_jacket">ወፍራም ጃኬት</string>
     <string name="today_outfit_bottom_shorts">ሹርቴ</string>
     <string name="today_outfit_bottom_long_pants">ሱሪ</string>
+    <string name="today_outfit_top_polo">ፖሎ</string>
+    <string name="today_outfit_top_thin_jacket">ቀጭን ጃኬት</string>
+    <string name="today_outfit_top_thick_coat">ወፍራም ኮት</string>
+    <string name="today_outfit_top_puffer_jacket">ፑፈር ጃኬት</string>
+    <string name="today_outfit_bottom_long_skirt">ረጅም ቀሚስ</string>
+    <string name="today_outfit_bottom_jeans">ጂንስ</string>
 
+    <!-- Today screen -->
+    <string name="today_title">ዛሬ</string>
+    <string name="today_open_settings">ቅንብሮችን ክፈት</string>
+    <string name="today_more_options">ተጨማሪ አማራጮች</string>
+    <string name="today_report_a_bug">ስህተት ሪፖርት አድርግ</string>
+    <string name="today_refresh">አድስ</string>
+    <string name="today_refresh_toast_daily">ዕለታዊ ClothesCast እያዳሰ ነው — ብዙም ሳይቆይ ይታያል።</string>
+    <string name="today_refresh_toast_nightly">ምሽታዊ ClothesCast እያዳሰ ነው — ብዙም ሳይቆይ ይታያል።</string>
+    <string name="today_empty_title">እስካሁን ClothesCast የለም</string>
+    <string name="today_empty_subtitle">የጠዋቱ ClothesCast ከተሰራ በኋላ እዚህ ይታያል። ቦታዎን በቅንብሮች ውስጥ ያስቀምጡ፣ ከዚያ አሁን አምጣ ን ይጫኑ።</string>
+    <string name="today_fetch_now">አሁን አምጣ</string>
+    <string name="today_generated_at">በ%1$s ሰዓት ተሰርቷል</string>
+    <string name="today_location_unknown">ቦታዎ</string>
+    <string name="today_outfit_title">ምን ይልበሱ</string>
+    <string name="today_outfit_label_today">ዛሬ</string>
+    <string name="today_outfit_label_tonight">ዛሬ ምሽት</string>
+    <string name="today_outfit_label_tomorrow">ነገ</string>
+    <string name="today_rationale_title">ይህ ልብስ ለምን?</string>
+    <string name="today_rationale_show">ለምን?</string>
+    <string name="today_rationale_dismiss">ገባኝ</string>
+    <string name="today_rationale_threshold_decrease">ደረጃን በ1 ዲግሪ ቀንስ</string>
+    <string name="today_rationale_threshold_increase">ደረጃን በ1 ዲግሪ ጨምር</string>
+    <string name="today_rationale_threshold_changed_hint">አዲሱን ልብስ ለማየት አድስ።</string>
+    <string name="today_rationale_unavailable">ምንም ምክንያት የለም — ከሚቀጥለው ዳግም ሙከራ በኋላ መተግበሪያውን ይክፈቱ።</string>
+    <string name="today_rationale_min_below_with_time">ዝቅተኛ የሚሰማ ሙቀት %1$s%2$s በ%3$s ሰዓት፣ ከ%4$s%2$s በታች</string>
+    <string name="today_rationale_min_below">ዝቅተኛ የሚሰማ ሙቀት %1$s%2$s፣ ከ%3$s%2$s በታች</string>
+    <string name="today_rationale_min_above_with_time">ዝቅተኛ የሚሰማ ሙቀት %1$s%2$s በ%3$s ሰዓት፣ ቢያንስ %4$s%2$s</string>
+    <string name="today_rationale_min_above">ዝቅተኛ የሚሰማ ሙቀት %1$s%2$s፣ ቢያንስ %3$s%2$s</string>
+    <string name="today_rationale_max_below_with_time">ከፍተኛ የሚሰማ ሙቀት %1$s%2$s ብቻ በ%3$s ሰዓት፣ ከ%4$s%2$s በታች</string>
+    <string name="today_rationale_max_below">ከፍተኛ የሚሰማ ሙቀት %1$s%2$s ብቻ፣ ከ%3$s%2$s በታች</string>
+    <string name="today_rationale_max_above_with_time">ከፍተኛ የሚሰማ ሙቀት %1$s%2$s በ%3$s ሰዓት፣ ቢያንስ %4$s%2$s</string>
+    <string name="today_rationale_max_above">ከፍተኛ የሚሰማ ሙቀት %1$s%2$s፣ ቢያንስ %3$s%2$s</string>
+
+    <!-- Forecast and charts -->
+    <string name="today_forecast_air_section_title">የአየር ሙቀት</string>
+    <string name="today_forecast_title">የሚሰማ ሙቀት</string>
+    <string name="today_forecast_min_max">የሚሰማ %1$d – %2$d%3$s</string>
+    <string name="today_forecast_legend_feels_like">የሚሰማ ሙቀት (%1$s) በሰዓት</string>
+    <string name="today_forecast_air_min_max">አየር %1$d – %2$d%3$s</string>
+    <string name="today_forecast_legend_air">የአየር ሙቀት (%1$s) በሰዓት</string>
+    <string name="today_precipitation_title">የዝናብ ዕድል</string>
+    <string name="today_precipitation_peak">ከፍተኛ %1$d%% በ%2$s ሰዓት</string>
+    <string name="today_precipitation_dry">ዛሬ ዝናብ አይጠበቅም</string>
+    <string name="today_chart_model_legend_label">ሞዴሎች:</string>
+    <string name="today_chart_main_line_label">ጠቅላላ</string>
+    <string name="today_chart_divergence_summary">ሞዴሎቹ በ%1$s ሰዓት ይለያያሉ (Δ %2$.1f%3$s የሚሰማ) — ብዙውን ጊዜ %4$s፣ %5$s</string>
+    <string name="today_factor_air_temperature">የአየር ሙቀት</string>
+    <string name="today_factor_wind_speed">የንፋስ ፍጥነት</string>
+    <string name="today_factor_cloud_cover">ደመና ሽፋን</string>
+    <string name="today_factor_humidity">እርጥበት</string>
+    <string name="today_wind_title">የንፋስ ፍጥነት</string>
+    <string name="today_wind_subtitle">በሞዴል የንፋስ ፍጥነት (%1$s) በሰዓት</string>
+    <string name="today_cloud_title">ደመና ሽፋን</string>
+    <string name="today_cloud_subtitle">በሞዴል ጠቅላላ ደመና ሽፋን (%%) በሰዓት</string>
+    <string name="today_humidity_title">እርጥበት</string>
+    <string name="today_humidity_subtitle">በሞዴል አንጻራዊ እርጥበት (%%) በሰዓት</string>
+    <string name="today_confidence_high">ከፍተኛ እምነት — ዋና ሞዴሎቹ ይስማማሉ</string>
+    <string name="today_confidence_medium">መካከለኛ እምነት</string>
+    <string name="today_confidence_low">ዝቅተኛ እምነት — ትንበያዎቹ ይለያያሉ</string>
+    <string name="today_confidence_spread">ልዩነት: %1$.1f°C፣ %2$.0f%% ዝናብ በ%3$d ሞዴሎቹ</string>
+    <string name="today_low_confidence_callout_title">ትንበያዎቹ ይለያያሉ</string>
+    <string name="today_low_confidence_callout_body">የሙቀት ልዩነት %1$.1f°C ሲሆን የዝናብ ዕድል ልዩነት %2$.0f%% ነው በ%3$d ሞዴሎቹ።</string>
+
+    <!-- Today screen states -->
+    <string name="today_working">እየሰራ ነው — ClothesCast እያምጣ ነው…</string>
+    <string name="today_retrying">የመጨረሻ ሙከራ ሳይሳካ ቀረ — እንደገና እየሞከረ ነው…</string>
+    <string name="today_failed_title">የመጨረሻ ሙከራ ሳይሳካ ቀረ</string>
+    <string name="today_failed_unexpected_http">ከትንበያ አገልግሎቱ ያልተጠበቀ HTTP ስህተት።</string>
+    <string name="today_failed_unhandled">ያልተጠበቀ ስህተት ተፈጠረ።</string>
+    <string name="today_failed_no_location">ቦታዎን ማግኘት አልቻልንም። ሁልጊዜ ያለ ቦታ ፍቃድ ይስጡ፣ ወይም ከተማ በቅንብሮች ውስጥ ያስቀምጡ።</string>
+    <string name="today_failed_show_details">ዝርዝሮችን አሳይ</string>
+    <string name="today_failed_hide_details">ዝርዝሮችን ደብቅ</string>
+    <string name="today_location_required_title">ቦታዎን ያዋቅሩ</string>
+    <string name="today_location_required_body">ClothesCast ትንበያ ለማምጣት ቦታዎን ማወቅ ያስፈልጋል። ሁልጊዜ ያለ ቦታ ፍቃድ ይስጡ፣ ወይም ከተማ ይምረጡ።</string>
+    <string name="today_location_required_action">የቦታ ቅንብሮችን ክፈት</string>
+    <string name="today_crash_banner_title">የቀደመው አሂድ ተቋርጧል</string>
+    <string name="today_crash_banner_body">ስህተት ሪፖርት በመሳሪያዎ ላይ ተቀምጧል። ስህተቱ እንዲስተካከል ያጋሩ? ምንም ሳይላክ ወደ ምን ቦታ እንደሚላክ ይወስናሉ።</string>
+    <string name="today_crash_banner_share">ሪፖርት አጋራ</string>
+    <string name="today_crash_banner_dismiss">ዝጋ</string>
+    <string name="today_update_available_title">ዝማኔ አለ</string>
+    <string name="today_update_available_body">አዲስ የ ClothesCast ስሪት በ Play Store ላይ አለ።</string>
+    <string name="today_update_available_action">አዘምን</string>
+    <string name="today_update_available_dismiss">አሁን አይሆንም</string>
+    <string name="today_update_downloaded_body">ዝማኔ ተሰቅሏል። ጫንን ለማጠናቀቅ እንደገና ጀምር።</string>
+    <string name="today_update_downloaded_action">እንደገና ጀምር</string>
+    <string name="today_telemetry_notice_title">ስህተት + አጠቃቀም ሪፖርቶች ተከፍቷል</string>
+    <string name="today_telemetry_notice_body">ClothesCast ስህተቶችን ለማስተካከል익익 익ስምን-አልባ ስህተት ሪፖርቶችና የአጠቃቀም ትንታኔዎችን ይልካል። የቀን መቁጠሪያ ውሂብ፣ ቦታ ወይም የናሙና ጽሑፍ አይካተትም። በቅንብሮች ውስጥ በማናቸውም ጊዜ ያጥፉ።</string>
+    <string name="today_telemetry_notice_open_settings">የግለነት ቅንብሮችን ክፈት</string>
+    <string name="today_telemetry_notice_dismiss">ዝጋ</string>
+
+    <!-- Error -->
+    <string name="error_device_incompatible">ClothesCast በዚህ መሳሪያ ላይ ሊሰራ አይችልም — የ Android ስሪትዎ መተግበሪያው ለ UI የሚፈልጋቸው ባህሪያት ይጎድሉታል። ለስርዓት ዝማኔ ከመሳሪያዎ አምራች ጋር ይወያዩ።</string>
+
+    <!-- Widget -->
+    <string name="widget_label">ልብስ</string>
+    <string name="widget_description">የአሁኑ ወቅት ልብስ በፍጥነት ለማየት።</string>
+    <string name="widget_empty_title">እስካሁን ልብስ የለም</string>
+    <string name="widget_empty_subtitle">ClothesCastን ለመክፈት ይጫኑ</string>
+
+    <!-- Onboarding -->
+    <string name="onboarding_title">እንኳን ወደ ClothesCast መጡ</string>
+    <string name="onboarding_subtitle">ሶስት ፈጣን ምርጫዎች ብቻ ያደርጉታል። ቆይቶ በቅንብሮች ውስጥ ይቀይሩ።</string>
+    <string name="onboarding_subtitle_tv">ሁለት ፈጣን ምርጫዎች ብቻ ያደርጉታል። ቆይቶ በቅንብሮች ውስጥ ይቀይሩ።</string>
+    <string name="onboarding_notifications_title">ማሳወቂያዎች</string>
+    <string name="onboarding_notifications_description">ዕለታዊ ClothesCast ለማድረስ ያስፈልጋል።</string>
+    <string name="onboarding_notifications_grant">የማሳወቂያ ፍቃድ ስጥ</string>
+    <string name="onboarding_location_title">ቦታ</string>
+    <string name="onboarding_location_description">ለቦታዎ ትንበያ ማምጣት።</string>
+    <string name="onboarding_location_grant">የቦታ ፍቃድ ስጥ</string>
+    <string name="onboarding_location_grant_background">ሁልጊዜ ያለ ቦታ ፍቃድ ስጥ</string>
+    <string name="onboarding_location_background_needed">አንድ ተጨማሪ ደረጃ: ClothesCast ጠዋት ሲዘጋ ቦታዎን ሊያነብ \'ሁልጊዜ ፍቀድ\' ያስፈልጋል።</string>
+    <string name="onboarding_location_denied_hint">የቦታ ፍቃድ ተከልክሏል። ከተማ በእጅ ሊያስገቡ ይችላሉ።</string>
+    <string name="onboarding_location_enter_manual">ቦታ በእጅ አስገባ</string>
+    <string name="onboarding_location_enter_manual_hint">የቦታ ፍቃድ ከከለከሉ ወይም የመሳሪያዎ ቦታ ትክክል ካልሆነ ቦታዎን በእጅ ሊያስገቡ ይችላሉ።</string>
+    <string name="onboarding_location_using_device">ጠዋቱን የመሳሪያዎን ቦታ ይጠቀማል።</string>
+    <string name="onboarding_gemini_title">Gemini API key</string>
+    <string name="onboarding_gemini_description">ከፍተኛ ጥራት ያለው ድምፅ ለማግኘት Gemini ይጠቀሙ።</string>
+    <string name="onboarding_step_done">ተጠናቀቀ</string>
+    <string name="onboarding_skip">አሁን ዝለሉ</string>
+    <string name="onboarding_continue">ቀጥል</string>
+    <string name="onboarding_pair_from_phone">ከስልኩ ጋር አስተሳስር</string>
+
+    <!-- Pairing (TV) -->
+    <string name="pairing_title">ለማስተሳሰር ቅኝ</string>
+    <string name="pairing_instructions">ይህን QR code በስልክዎ ቅኝ፣ ከዚያ Gemini API key ወደሚከፈተው ቅጽ ይለጥፉ። ቁልፉ ቀጥታ ወደዚህ ቲቪ በቤት Wi-Fi ይላካል — ምንም የደመና ማስተላለፊያ የለም።</string>
+    <string name="pairing_qr_description">ወደ %1$s የሚያስተሳስር QR code</string>
+    <string name="pairing_cancel">ሰርዝ</string>
+    <string name="pairing_received">ቁልፉ ደረሰ — እያስቀመጠ ነው…</string>
+    <string name="pairing_timeout_title">የማስተሳሰሪያ መስኮት ጊዜ አለፈ</string>
+    <string name="pairing_timeout_body">የ5 ደቂቃ የማስተሳሰሪያ መስኮት ተዘጋ። አዲስ ለመክፈት እንደገና ሞክር ን ይጫኑ።</string>
+    <string name="pairing_error_title">ማስተሳሰር ሊጀምር አልቻለም</string>
+    <string name="pairing_error_body">ቲቪው ወደ Wi-Fi መጋጠሙን ያረጋግጡ፣ ከዚያ እንደገና ሞክሩ።</string>
+    <string name="pairing_retry">እንደገና ሞክር</string>
+
+    <!-- Settings root -->
+    <string name="settings_title">ቅንብሮች</string>
+    <string name="settings_back">ተመለስ</string>
+    <string name="settings_root_voice">ድምፅ</string>
+    <string name="settings_root_schedule">መርሃ ግብር</string>
+    <string name="settings_root_region">ክልል</string>
+    <string name="settings_root_clothes">ልብስ</string>
+    <string name="settings_root_display">ማሳያ</string>
+    <string name="settings_root_location">ቦታ</string>
+    <string name="settings_root_calendar">የቀን መቁጠሪያ</string>
+    <string name="settings_root_privacy">ግለነት</string>
+    <string name="settings_root_about">ስለ</string>
+    <string name="settings_root_schedule_subtitle">ማሳወቂያዎች እና ጊዜ</string>
+    <string name="settings_root_clothes_subtitle">ሙቀት እና ልብሶች</string>
+    <string name="settings_root_region_subtitle">ቋንቋዎች እና ክፍሎች</string>
+    <string name="settings_root_voice_subtitle">አቅራቢዎች እና ዘዬዎች</string>
+    <string name="settings_root_display_subtitle">ጭብጥ</string>
+    <string name="settings_root_location_subtitle">ራስ-ፈልጎ ወይም ከተማ ምረጥ</string>
+    <string name="settings_root_calendar_subtitle">የዛሬ ዝግጅቶች</string>
+    <string name="settings_root_privacy_subtitle">ስህተት + አጠቃቀም ሪፖርቶች</string>
+
+    <!-- Settings — display -->
+    <string name="settings_display_theme_title">ጭብጥ</string>
+    <string name="settings_display_theme_system">ስርዓቱን ተከተል</string>
+    <string name="settings_display_theme_light">ብርሃን</string>
+    <string name="settings_display_theme_dark">ጨለማ</string>
+    <string name="settings_display_charts_title">ቻርቶች</string>
+    <string name="settings_display_model_spread_label">በቻርቶቹ ላይ የሞዴል ልዩነት አሳይ</string>
+    <string name="settings_display_model_spread_description">እያንዳንዱ ዋና የአየር ሁኔታ ሞዴል ሰዓታዊ ትንበያ በሙቀት እና ዝናብ ቻርቶቹ ላይ ያሳያል። ትንበያው ዕርግጠኛ ባልሆነ ጊዜ ለማወቅ ጠቃሚ ነው።</string>
+
+    <!-- Settings — privacy -->
+    <string name="settings_privacy_telemetry_title">ስህተት + አጠቃቀም ሪፖርቶች</string>
+    <string name="settings_privacy_telemetry_label">ስህተት + አጠቃቀም ውሂብ ላክ</string>
+    <string name="settings_privacy_telemetry_description">ለገንቢው ስህተቶቹን ለማስተካከልና የትኞቹን ባህሪያት ማቆየት እንዳለበት ለመወሰን ስምን-አልባ ስህተት ሪፖርቶችና ጠቅላላ የአጠቃቀም ስታቲስቲክስ ይልካል።</string>
+    <string name="settings_privacy_telemetry_limits">ፈጽሞ አይላክም: የቀን መቁጠሪያ ዝግጅቶች፣ የቦታ መጋጠሚያዎች ወይም የቦታ ስሞች፣ የናሙና ጽሑፍ ወይም የማሳወቂያ ጽሑፍ፣ API keys፣ ትክክለኛ GPS፣ የማስታወቂያ መለያዎች።</string>
+    <string name="settings_privacy_open_policy">ሙሉ የግለነት ፖሊሲ አንብብ</string>
+
+    <!-- Settings — API key / Gemini -->
+    <string name="settings_api_key_gemini_label">Gemini</string>
+    <string name="settings_api_key_gemini_header">ከፍተኛ ጥራት ያለው ድምፅ ለማግኘት Gemini ይጠቀሙ።</string>
+    <string name="settings_api_key_status_set">Gemini ቁልፍ ተዋቅሯል።</string>
+    <string name="settings_api_key_status_unset">ነፃ API key ያግኙ aistudio.google.com ላይ</string>
+    <string name="settings_api_key_placeholder">Gemini API key ይለጥፉ</string>
+    <string name="settings_api_key_save">Gemini ቁልፍ አስቀምጥ</string>
+    <string name="settings_api_key_clear">የተቀመጠ Gemini ቁልፍ ሰርዝ</string>
+
+    <!-- Settings — location -->
+    <string name="settings_location_title">ቦታ</string>
+    <string name="settings_location_use_device">የመሳሪያ ቦታ ተጠቀም</string>
+    <string name="settings_location_use_device_description">የመጨረሻ ቦታ ግምት</string>
+    <string name="settings_location_detecting">እያሰሳ ነው…</string>
+    <string name="settings_location_grant_background">ፍቀድ</string>
+    <string name="settings_location_background_banner_title">ሁልጊዜ ያለ ቦታ ያስፈልጋል</string>
+    <string name="settings_location_background_banner_body">ከሌለ የጠዋቱ ትንበያ ቦታዎን ሊያነብ አይችልም።</string>
+    <string name="settings_location_unset">ምንም ቦታ አልተቀመጠም</string>
+    <string name="settings_location_manual_override">ቦታው ትክክል አይደለም? በእጅ ያስቀምጡ</string>
+    <string name="settings_location_manual_override_disclosure">ከተማ መምረጥ ራስ-ፈልጎን ያጠፋል።</string>
+    <string name="settings_location_clear">ቦታ ሰርዝ</string>
+    <string name="settings_location_search_title">ቦታ ፈልግ</string>
+    <string name="settings_location_query_label">ከተማ ወይም ቦታ</string>
+    <string name="settings_location_search">ፈልግ</string>
+    <string name="settings_location_searching">እየፈለገ ነው…</string>
+    <string name="settings_location_no_results">ምንም ውጤት የለም።</string>
+    <string name="settings_location_rationale_title">የቦታ ፍቃድ</string>
+    <string name="settings_location_rationale_body">ClothesCast ሀገርዎን ትንበያ ለማምጣት ቦታዎን ያነባል።</string>
+    <string name="settings_location_rationale_continue">ቀጥል</string>
+    <string name="settings_location_rationale_dismiss">አሁን አይሆንም</string>
+    <string name="settings_location_background_rationale_title">ሁልጊዜ ፍቀድ</string>
+    <string name="settings_location_background_rationale_body">ClothesCast ሲዘጋ ቦታዎን ሊያነብ \'ሁልጊዜ ፍቀድ\' ይምረጡ እናም የጠዋቱ ትንበያ ወቅቱን ጠብቆ ይዘምናል።</string>
+    <string name="settings_location_background_rationale_continue">ቅንብሮችን ክፈት</string>
+    <string name="settings_location_background_rationale_dismiss">አሁን አይሆንም</string>
+    <string name="settings_location_background_denied_title">ሁልጊዜ ያለ ፍቃድ አልተሰጠም</string>
+    <string name="settings_location_background_denied_body">\'ሁልጊዜ ፍቀድ\' ሳይኖር የጠዋቱ ትንበያ ራሱን ሊያዘምን አይችልም።</string>
+    <string name="settings_location_background_denied_open">ቅንብሮችን ክፈት</string>
+    <string name="settings_location_background_denied_keep">አሁን አይሆንም</string>
+
+    <!-- Settings — schedule -->
+    <string name="settings_schedule_title">ዕለታዊ ClothesCast</string>
+    <string name="settings_schedule_time_label">ጊዜ</string>
+    <string name="settings_schedule_days_label">የሳምንቱ ቀናት</string>
+    <string name="settings_daily_mention_evening_events">የምሽት ዝግጅቶችን ጥቀስ</string>
+    <string name="settings_tonight_title">ምሽታዊ ClothesCast</string>
+    <string name="settings_tonight_description">ዛሬ ምሽቱን ሁኔታ የሚሸፍን ምሽታዊ ሁለተኛ ClothesCast። ጸጥ ባሉ ምሽቶች ዝም ይላል፣ ዝግጅት ባለባቸው ምሽቶች ድምፅ ያሰማና ራሱን ያነባል።</string>
+    <string name="settings_tonight_enabled">ምሽታዊ ClothesCast አሳይ</string>
+    <string name="settings_tonight_time_label">ጊዜ</string>
+    <string name="settings_tonight_days_label">የሳምንቱ ቀናት</string>
+    <string name="settings_tonight_notify_only_on_events">የምሽት ዝግጅቶች ሲኖሩ ብቻ አሳውቅ</string>
+    <string name="settings_delivery_label">አደራረስ</string>
+    <string name="settings_delivery_notification_only">ማሳወቂያ ብቻ</string>
+    <string name="settings_delivery_tts_only">በድምፅ ብቻ</string>
+    <string name="settings_delivery_notification_and_tts">ማሳወቂያ እና በድምፅ</string>
+
+    <!-- Settings — TTS / voice -->
+    <string name="settings_tts_engine_title">የድምፅ ሞተር</string>
+    <string name="settings_tts_engine_description">Gemini ከመሳሪያ ድምፅ በጣም ተፈጥሯዊ ይሰማል ነገር ግን ሲናገር የኔትወርክ ጥሪ ያስፈልጋል። Gemini ካልሆነ ወደ መሳሪያ ድምፅ ይመለሳል።</string>
+    <string name="settings_tts_engine_device">መሳሪያ (offline, ነፃ)</string>
+    <string name="settings_tts_engine_gemini">Gemini (ከፍተኛ ጥራት, online)</string>
+    <string name="settings_tts_voice_label">ድምፅ</string>
+    <string name="settings_tts_voice_dismiss">ተጠናቀቀ</string>
+    <string name="settings_tts_style_label">ዘይቤ</string>
+    <string name="settings_tts_style_weather_forecaster">የአየር ሁኔታ አስተናጋጅ</string>
+    <string name="settings_tts_style_pirate">ባህር ወንበዴ</string>
+    <string name="settings_tts_style_cowboy">ካውቦይ</string>
+    <string name="settings_tts_style_shakespearean">ሼክስፒርያዊ</string>
+    <string name="settings_tts_style_surfer">ሰርፈር</string>
+    <string name="settings_tts_style_parent">ወላጅ</string>
+    <string name="settings_tts_style_child">ልጅ</string>
+    <string name="settings_tts_style_teenager">ወጣት</string>
+    <string name="settings_tts_style_grandparent">አያት</string>
+    <string name="settings_tts_style_kids_host">የህፃናት ቲቪ አቅራቢ</string>
+    <string name="settings_tts_style_radio_host">የቶክባክ አቅራቢ</string>
+    <string name="settings_tts_style_morning_dj">የጠዋቱ ዲጄ</string>
+    <string name="settings_tts_style_science_teacher">የሳይንስ መምህር</string>
+    <string name="settings_tts_style_historian">ታሪክ ምሁር</string>
+    <string name="settings_tts_style_sportscaster">የስፖርት አስተናጋጅ</string>
+    <string name="settings_tts_style_stadium_announcer">የስታዲዩም አስታዋቂ</string>
+    <string name="settings_tts_style_storyteller">ተረት ተራኪ</string>
+    <string name="settings_tts_style_fitness_instructor">የአካል ብቃት አሰልጣኝ</string>
+    <string name="settings_tts_style_morning_presenter">የጠዋቱ ሬዲዮ አቅራቢ</string>
+    <string name="settings_tts_style_custom">ብጁ…</string>
+    <string name="settings_tts_style_custom_label">ብጁ መመሪያ</string>
+    <string name="settings_tts_style_custom_placeholder">ምሳሌ: የሚከተለውን እንደ ጥብቅ ቤተ-መፃህፍት ጠባቂ በሹክሹክታ አንብብ</string>
+    <string name="settings_tts_device_voice_label">የመሳሪያ ድምፅ</string>
+    <string name="settings_tts_device_voice_auto">ራስ (ለዘዬ ምርጥ)</string>
+    <string name="settings_tts_device_voice_currently">አሁን: %1$s</string>
+    <string name="settings_tts_device_voice_currently_loading">እየጫነ ነው…</string>
+    <string name="settings_tts_device_voice_network">ኔትወርክ</string>
+    <string name="settings_tts_device_voice_offline">Offline</string>
+    <string name="settings_tts_install_google_hint">ከፍተኛ ጥራት ያላቸው ድምፆች ለማግኘት የ Google ጽሑፍ-ወደ-ንግግር ሞተር ይጫኑ።</string>
+    <string name="settings_tts_install_google_button">Google TTS ጫን</string>
+    <string name="settings_tts_test">ድምፅ ሙከራ</string>
+    <string name="settings_tts_test_in_flight">እየሞከረ ነው — እባክዎ ይጠብቁ…</string>
+
+    <!-- Settings — units -->
+    <string name="settings_temperature_unit_title">የሙቀት ክፍል</string>
+    <string name="settings_temperature_unit_celsius">ሴልሺየስ (°C)</string>
+    <string name="settings_temperature_unit_fahrenheit">ፋረንሃይት (°F)</string>
+    <string name="settings_distance_unit_title">የርቀት ክፍል</string>
+    <string name="settings_distance_unit_kilometers">ኪሎሜትር</string>
+    <string name="settings_distance_unit_miles">ማይሎች</string>
+
+    <!-- Settings — notifications permission -->
+    <string name="settings_notification_permission_title">ማሳወቂያዎች ታግደዋል</string>
+    <string name="settings_notification_permission_description">ያለ ማሳወቂያ ፍቃድ ዕለታዊ ClothesCast የሚሄድበት ቦታ የለም። ነገ ጠዋት ClothesCast እንዲልክ ፍቃዱን ስጥ።</string>
+    <string name="settings_notification_permission_grant">የማሳወቂያ ፍቃድ ስጥ</string>
+
+    <!-- Settings — calendar -->
+    <string name="settings_calendar_title">የቀን መቁጠሪያ</string>
+    <string name="settings_calendar_use_events">የዛሬ የቀን መቁጠሪያ ዝግጅቶችን ተጠቀም</string>
+    <string name="settings_calendar_description_off">የጠዋቱ ትንበያ ለዛሬ ዝግጅቶቻቸው ብጁ ያደርጋል — ርዕሶችና ጊዜዎች ብቻ ይጠቀማሉ፣ ምንም ከመሳሪያው አይወጣም።</string>
+    <string name="settings_calendar_description_on">የጠዋቱ ትንበያ ለዛሬ ዝግጅቶቻቸው ብጁ እያደረገ ነው። ርዕሶችና ጊዜዎች ብቻ ይጠቀማሉ፣ ምንም ከመሳሪያው አይወጣም።</string>
+    <string name="settings_calendar_grant_permission">የቀን መቁጠሪያ ፍቃድ ስጥ</string>
+    <string name="settings_calendar_open_settings">የቀን መቁጠሪያ ፍቃድ ተከልክሏል። ከስርዓት ቅንብሮች ፍቀዱ።</string>
+
+    <!-- Settings — about -->
+    <string name="settings_about_title">ስለ</string>
+    <string name="settings_about_version">ስሪት %1$s (%2$d)</string>
+    <string name="settings_about_build_type_suffix"> · %1$s ግንባታ</string>
+    <string name="settings_about_source">Source code on GitHub</string>
+    <string name="settings_about_dontkillmyapp">የዳራ ገደቦች (dontkillmyapp.com)</string>
+    <string name="settings_about_share_bug_report">ስህተት ሪፖርት አጋራ</string>
+    <string name="settings_about_version_copied">ስሪት ወደ ክሊፕቦርድ ተቀድቷል</string>
+
+    <!-- Bug report consent -->
+    <string name="bug_report_consent_title">ስህተት ሪፖርት ያጋሩ?</string>
+    <string name="bug_report_consent_body">ይህ ችግሮችን ለመመርመር ይረዳል። ሪፖርቱ ቦታዎን፣ የመተግበሪያ ቅንብሮችን፣ እና የቅርብ ጊዜ እንቅስቃሴዎን ጨምሮ ስሱ ግላዊ መረጃ ይይዛል። ከመላክዎ በፊት መፈተሸና ማርትዕ ይችላሉ።</string>
+    <string name="bug_report_consent_dont_show_again">ዳግም አታሳይ</string>
+    <string name="bug_report_consent_continue">ቀጥል</string>
+    <string name="bug_report_consent_cancel">ሰርዝ</string>
+
+    <!-- Notifications -->
+    <string name="notification_channel_daily_insight_name">ዕለታዊ ClothesCast</string>
+    <string name="notification_channel_daily_insight_description">የጠዋቱ የአየር ሁኔታ ማጠቃለያ ለምን ተመዘገቡ።</string>
+    <string name="notification_daily_insight_title">የዛሬ ClothesCast</string>
+    <string name="notification_channel_tonight_insight_default_name">ምሽታዊ ClothesCast (ዝግጅቶች ሲኖሩ)</string>
+    <string name="notification_channel_tonight_insight_default_description">ዛሬ ምሽት የቀን መቁጠሪያ ዝግጅቶቻቸው ሲኖሩ የምሽቱ የአየር ሁኔታ ማጠቃለያ።</string>
+    <string name="notification_channel_tonight_insight_silent_name">ምሽታዊ ClothesCast (ዝምታ)</string>
+    <string name="notification_channel_tonight_insight_silent_description">ምሽቱ ጸጥ ሲሆን የምሽቱ የአየር ሁኔታ ማጠቃለያ። ዝምታ ሆኖ ይለጠፋል።</string>
+    <string name="notification_tonight_insight_title">የዛሬ ምሽት ClothesCast</string>
+    <string name="notification_channel_weather_alerts_name">የጠና የአየር ሁኔታ ማስጠንቀቂያዎች</string>
+    <string name="notification_channel_weather_alerts_description">ለቦታዎ አካባቢ ለሚጎዱ ጠና ወይም ከፍተኛ የአየር ሁኔታ ዝግጅቶች ከፍተኛ ቅድሚያ ማስጠንቀቂያዎች።</string>
+    <string name="notification_weather_alert_title">የአየር ሁኔታ ማስጠንቀቂያ: %1$s</string>
+
+    <!-- Insight prose -->
     <string name="insight_lead_today">ዛሬ</string>
     <string name="insight_lead_tonight">ዛሬ ምሽት</string>
     <!-- Amharic: "ዛሬ ምቹ ይሆናል።" -->
@@ -80,5 +413,17 @@ The rest of the UI falls through to values/strings.xml (English).
     <!-- Amharic: bare digits for TTS-friendly 24h time. -->
     <string name="insight_time_hour">%1$d</string>
     <string name="insight_time_hour_minutes">%1$d:%2$02d</string>
+    <!-- insight_precip_chance: %1$s = condition word, %2$s = time phrase -->
+    <string name="insight_precip_chance">%1$s %2$s ሊኖር ይችላል።</string>
+    <!-- insight_tie_in_at_night: bare imperative, "tonight" already established -->
+    <string name="insight_tie_in_at_night">%1$s ይዙ።</string>
+    <!-- insight_tie_in_with_rain_chance: %1$s = item, %2$s = time -->
+    <string name="insight_tie_in_with_rain_chance">%1$s ይዙ፣ ዝናብ ሊኖር ይችላል %2$s ሰዓት።</string>
+    <!-- insight_evening_rain / insight_evening_rain_chance: %1$s = time -->
+    <string name="insight_evening_rain">ዛሬ ምሽት ዝናብ %1$s ሰዓት።</string>
+    <string name="insight_evening_rain_chance">ዛሬ ምሽት ዝናብ ሊኖር ይችላል %1$s ሰዓት።</string>
 
+    <!-- Miscellaneous -->
+    <string name="settings_default_bottom_title">መደበኛ ታች</string>
+    <string name="settings_default_bottom_description">ሹርቴ ለመልበስ ሞቃት ሳይሆን ለዋናው ማያ ምን እናሳያለን።</string>
 </resources>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -90,4 +90,370 @@ they work correctly in both the single-band and range templates.
     <string name="insight_time_hour">%1$d</string>
     <string name="insight_time_hour_minutes">%1$d:%2$02d</string>
 
+    <string name="today_forecast_air_section_title">درجة الحرارة الجوية</string>
+    <string name="settings_default_bottom_title">السروال الافتراضي</string>
+    <string name="settings_default_bottom_description">ما نقترحه على الشاشة الرئيسية عندما لا يكون الجو حاراً بما يكفي للشورت.</string>
+
+    <!-- Error / compatibility -->
+    <string name="error_device_incompatible">لا يمكن تشغيل ClothesCast على هذا الجهاز — يفتقر إصدار Android الخاص بك إلى ميزة يحتاجها تطبيق. يرجى التواصل مع الشركة المصنّعة للحصول على تحديث للنظام.</string>
+
+    <!-- Today screen -->
+    <string name="today_title">اليوم</string>
+    <string name="today_open_settings">فتح الإعدادات</string>
+    <string name="today_more_options">المزيد من الخيارات</string>
+    <string name="today_report_a_bug">الإبلاغ عن خطأ</string>
+    <string name="today_refresh">تحديث</string>
+    <string name="today_refresh_toast_daily">جارٍ تحديث ClothesCast اليومي — سيظهر قريبًا.</string>
+    <string name="today_refresh_toast_nightly">جارٍ تحديث ClothesCast الليلي — سيظهر قريبًا.</string>
+    <string name="today_empty_title">لا يوجد ClothesCast بعد</string>
+    <string name="today_empty_subtitle">سيظهر ClothesCast الصباحي هنا بعد إنشائه. حدد موقعك في الإعدادات، ثم اضغط على جلب الآن.</string>
+    <string name="today_fetch_now">جلب الآن</string>
+    <string name="today_generated_at">تم الإنشاء في %1$s</string>
+    <string name="today_location_unknown">موقعك</string>
+
+    <!-- Today — outfit card -->
+    <string name="today_outfit_title">ماذا ترتدي</string>
+    <string name="today_outfit_label_today">اليوم</string>
+    <string name="today_outfit_label_tonight">الليلة</string>
+    <string name="today_outfit_label_tomorrow">غدًا</string>
+    <string name="today_outfit_top_polo">بولو</string>
+    <string name="today_outfit_top_thin_jacket">جاكيت خفيف</string>
+    <string name="today_outfit_top_thick_coat">معطف ثقيل</string>
+    <string name="today_outfit_top_puffer_jacket">جاكيت منفوخ</string>
+    <string name="today_outfit_bottom_long_skirt">تنورة طويلة</string>
+    <string name="today_outfit_bottom_jeans">جينز</string>
+
+    <!-- Today — rationale sheet -->
+    <string name="today_rationale_title">لماذا هذا الزي؟</string>
+    <string name="today_rationale_show">لماذا؟</string>
+    <string name="today_rationale_dismiss">فهمت</string>
+    <string name="today_rationale_threshold_decrease">خفض العتبة بدرجة واحدة</string>
+    <string name="today_rationale_threshold_increase">رفع العتبة بدرجة واحدة</string>
+    <string name="today_rationale_threshold_changed_hint">حدّث لترى الزي الجديد.</string>
+    <string name="today_rationale_unavailable">لا يتوفر تبرير — افتح التطبيق بعد التحديث التالي.</string>
+    <string name="today_rationale_min_below_with_time">أدنى درجة حرارة محسوسة %1$s%2$s الساعة %3$s، أقل من %4$s%2$s</string>
+    <string name="today_rationale_min_below">أدنى درجة حرارة محسوسة %1$s%2$s، أقل من %3$s%2$s</string>
+    <string name="today_rationale_min_above_with_time">أدنى درجة حرارة محسوسة %1$s%2$s الساعة %3$s، على الأقل %4$s%2$s</string>
+    <string name="today_rationale_min_above">أدنى درجة حرارة محسوسة %1$s%2$s، على الأقل %3$s%2$s</string>
+    <string name="today_rationale_max_below_with_time">أعلى درجة حرارة محسوسة فقط %1$s%2$s الساعة %3$s، أقل من %4$s%2$s</string>
+    <string name="today_rationale_max_below">أعلى درجة حرارة محسوسة فقط %1$s%2$s، أقل من %3$s%2$s</string>
+    <string name="today_rationale_max_above_with_time">أعلى درجة حرارة محسوسة %1$s%2$s الساعة %3$s، على الأقل %4$s%2$s</string>
+    <string name="today_rationale_max_above">أعلى درجة حرارة محسوسة %1$s%2$s، على الأقل %3$s%2$s</string>
+
+    <!-- Widget -->
+    <string name="widget_label">الزي</string>
+    <string name="widget_description">زي الفترة الحالية في لمحة.</string>
+    <string name="widget_empty_title">لا يوجد زي بعد</string>
+    <string name="widget_empty_subtitle">اضغط لفتح ClothesCast</string>
+
+    <!-- Today — forecast / temperature chart -->
+    <string name="today_forecast_title">درجة الحرارة المحسوسة</string>
+    <string name="today_forecast_min_max">تبدو كـ %1$d – %2$d%3$s</string>
+    <string name="today_forecast_legend_feels_like">الحرارة المحسوسة (%1$s) بالساعة</string>
+    <string name="today_forecast_air_min_max">الهواء %1$d – %2$d%3$s</string>
+    <string name="today_forecast_legend_air">درجة حرارة الهواء (%1$s) بالساعة</string>
+
+    <!-- Today — precipitation chart -->
+    <string name="today_precipitation_title">احتمالية الأمطار</string>
+    <string name="today_precipitation_peak">الذروة %1$d%% الساعة %2$s</string>
+    <string name="today_precipitation_dry">لا أمطار متوقعة اليوم</string>
+
+    <!-- Today — model/chart -->
+    <string name="today_chart_model_legend_label">النماذج:</string>
+    <string name="today_chart_main_line_label">المجمّع</string>
+    <string name="today_chart_divergence_summary">تتباين النماذج أكثر الساعة %1$s (Δ %2$.1f%3$s محسوس) — أساسًا %4$s، %5$s</string>
+    <string name="today_factor_air_temperature">درجة حرارة الهواء</string>
+    <string name="today_factor_wind_speed">سرعة الرياح</string>
+    <string name="today_factor_cloud_cover">الغيوم</string>
+    <string name="today_factor_humidity">الرطوبة</string>
+
+    <!-- Today — wind chart -->
+    <string name="today_wind_title">سرعة الرياح</string>
+    <string name="today_wind_subtitle">سرعة الرياح (%1$s) بالنموذج والساعة</string>
+
+    <!-- Today — cloud chart -->
+    <string name="today_cloud_title">الغيوم</string>
+    <string name="today_cloud_subtitle">إجمالي الغطاء السحابي (%) بالنموذج والساعة</string>
+
+    <!-- Today — humidity chart -->
+    <string name="today_humidity_title">الرطوبة</string>
+    <string name="today_humidity_subtitle">الرطوبة النسبية (%) بالنموذج والساعة</string>
+
+    <!-- Today — confidence / divergence -->
+    <string name="today_confidence_high">ثقة عالية — تتفق النماذج الرئيسية</string>
+    <string name="today_confidence_medium">ثقة متوسطة</string>
+    <string name="today_confidence_low">ثقة منخفضة — تتباين التوقعات</string>
+    <string name="today_confidence_spread">التباين: %1$.1f°C، %2$.0f%% أمطار عبر %3$d نماذج</string>
+    <string name="today_low_confidence_callout_title">التوقعات متباينة</string>
+    <string name="today_low_confidence_callout_body">يتراوح نطاق درجات الحرارة بـ %1$.1f°C واحتمالية الأمطار بـ %2$.0f%% عبر %3$d نماذج.</string>
+
+    <!-- Today — loading / error states -->
+    <string name="today_working">جارٍ العمل — يتم جلب ClothesCast…</string>
+    <string name="today_retrying">فشلت المحاولة الأخيرة — إعادة المحاولة…</string>
+    <string name="today_failed_title">فشلت المحاولة الأخيرة</string>
+    <string name="today_failed_unexpected_http">خطأ HTTP غير متوقع من خدمة التوقعات.</string>
+    <string name="today_failed_unhandled">حدث خطأ غير متوقع.</string>
+    <string name="today_failed_no_location">تعذّر تحديد موقعك. امنح إذن الموقع الدائم، أو حدد مدينة في الإعدادات.</string>
+    <string name="today_failed_show_details">إظهار التفاصيل</string>
+    <string name="today_failed_hide_details">إخفاء التفاصيل</string>
+    <string name="today_location_required_title">إعداد موقعك</string>
+    <string name="today_location_required_body">تحتاج ClothesCast إلى معرفة موقعك لجلب التوقعات. امنح إذن الموقع الدائم، أو اختر مدينة.</string>
+    <string name="today_location_required_action">فتح إعدادات الموقع</string>
+
+    <!-- Today — crash banner -->
+    <string name="today_crash_banner_title">تعطّل التشغيل الأخير</string>
+    <string name="today_crash_banner_body">تم حفظ تقرير تعطّل على جهازك. هل تشاركه لإصلاح الخطأ؟ لا يُرسَل أي شيء حتى تختار الوجهة.</string>
+    <string name="today_crash_banner_share">مشاركة التقرير</string>
+    <string name="today_crash_banner_dismiss">إغلاق</string>
+
+    <!-- Today — update banners -->
+    <string name="today_update_available_title">تحديث متاح</string>
+    <string name="today_update_available_body">يتوفر إصدار أحدث من ClothesCast على Play Store.</string>
+    <string name="today_update_available_action">تحديث</string>
+    <string name="today_update_available_dismiss">ليس الآن</string>
+    <string name="today_update_downloaded_body">تم تنزيل التحديث. أعد التشغيل لاستكمال التثبيت.</string>
+    <string name="today_update_downloaded_action">إعادة التشغيل</string>
+
+    <!-- Today — telemetry notice -->
+    <string name="today_telemetry_notice_title">تقارير الأعطال والاستخدام مفعّلة</string>
+    <string name="today_telemetry_notice_body">ترسل ClothesCast تقارير أعطال مجهولة وإحصاءات استخدام للمساعدة في إصلاح الأخطاء. لا تُضمَّن بيانات التقويم أو الموقع أو نص التحليل. أوقفها في أي وقت من الإعدادات.</string>
+    <string name="today_telemetry_notice_open_settings">فتح إعدادات الخصوصية</string>
+    <string name="today_telemetry_notice_dismiss">إغلاق</string>
+
+    <!-- Onboarding -->
+    <string name="onboarding_title">مرحبًا بك في ClothesCast</string>
+    <string name="onboarding_subtitle">ثلاثة خيارات سريعة وأنت جاهز. عدّلها لاحقًا في الإعدادات.</string>
+    <string name="onboarding_subtitle_tv">خياران سريعان وأنت جاهز. عدّلهما لاحقًا في الإعدادات.</string>
+    <string name="onboarding_notifications_title">الإشعارات</string>
+    <string name="onboarding_notifications_description">مطلوب لتسليم ClothesCast اليومي.</string>
+    <string name="onboarding_notifications_grant">منح إذن الإشعارات</string>
+    <string name="onboarding_location_title">الموقع</string>
+    <string name="onboarding_location_description">جلب التوقعات لموقعك التقريبي.</string>
+    <string name="onboarding_location_grant">منح إذن الموقع</string>
+    <string name="onboarding_location_grant_background">منح إذن الموقع الدائم</string>
+    <string name="onboarding_location_background_needed">خطوة أخيرة: تحتاج ClothesCast إلى \'السماح في جميع الأوقات\' حتى تتمكن توقعات الصباح من قراءة موقعك أثناء إغلاق التطبيق.</string>
+    <string name="onboarding_location_denied_hint">تم رفض إذن الموقع. يمكنك اختيار مدينة يدويًا.</string>
+    <string name="onboarding_location_enter_manual">إدخال الموقع يدويًا</string>
+    <string name="onboarding_location_enter_manual_hint">يمكنك إدخال موقعك يدويًا إذا رفضت إذن الموقع أو كان موقع جهازك خاطئًا.</string>
+    <string name="onboarding_location_using_device">يستخدم موقع جهازك كل صباح.</string>
+    <string name="onboarding_gemini_title">مفتاح Gemini API</string>
+    <string name="onboarding_gemini_description">استخدم Gemini للحصول على أصوات عالية الجودة.</string>
+    <string name="onboarding_step_done">تم</string>
+    <string name="onboarding_skip">تخطي الآن</string>
+    <string name="onboarding_continue">متابعة</string>
+    <string name="onboarding_pair_from_phone">الإقران من الهاتف بدلاً من ذلك</string>
+
+    <!-- TV pairing -->
+    <string name="pairing_title">امسح للإقران</string>
+    <string name="pairing_instructions">امسح رمز QR هذا بهاتفك، ثم الصق مفتاح Gemini API في النموذج الذي يفتح. سيُرسَل المفتاح مباشرةً إلى هذا التلفاز عبر شبكة Wi-Fi المنزلية — بدون وسيط سحابي.</string>
+    <string name="pairing_qr_description">رمز QR يرتبط بـ %1$s</string>
+    <string name="pairing_cancel">إلغاء</string>
+    <string name="pairing_received">تم استقبال المفتاح — جارٍ الحفظ…</string>
+    <string name="pairing_timeout_title">انتهت صلاحية نافذة الإقران</string>
+    <string name="pairing_timeout_body">أُغلقت نافذة الإقران المدتها 5 دقائق. اضغط على إعادة المحاولة لفتح نافذة جديدة.</string>
+    <string name="pairing_error_title">تعذّر بدء الإقران</string>
+    <string name="pairing_error_body">تأكد من اتصال التلفاز بالإنترنت، ثم أعد المحاولة.</string>
+    <string name="pairing_retry">إعادة المحاولة</string>
+
+    <!-- Settings — root / navigation -->
+    <string name="settings_title">الإعدادات</string>
+    <string name="settings_back">رجوع</string>
+    <string name="settings_root_voice">الصوت</string>
+    <string name="settings_root_schedule">الجدول</string>
+    <string name="settings_root_region">المنطقة</string>
+    <string name="settings_root_clothes">الملابس</string>
+    <string name="settings_root_display">العرض</string>
+    <string name="settings_root_location">الموقع</string>
+    <string name="settings_root_calendar">التقويم</string>
+    <string name="settings_root_privacy">الخصوصية</string>
+    <string name="settings_root_about">حول</string>
+    <string name="settings_root_schedule_subtitle">الإشعارات والأوقات</string>
+    <string name="settings_root_clothes_subtitle">درجات الحرارة والأزياء</string>
+    <string name="settings_root_region_subtitle">اللغات والوحدات</string>
+    <string name="settings_root_voice_subtitle">مزودو الخدمة واللهجات</string>
+    <string name="settings_root_display_subtitle">المظهر</string>
+
+    <!-- Settings — display -->
+    <string name="settings_display_theme_title">المظهر</string>
+    <string name="settings_display_theme_system">اتبع النظام</string>
+    <string name="settings_display_theme_light">فاتح</string>
+    <string name="settings_display_theme_dark">داكن</string>
+    <string name="settings_display_charts_title">الرسوم البيانية</string>
+    <string name="settings_display_model_spread_label">إظهار انتشار النماذج في الرسوم البيانية</string>
+    <string name="settings_display_model_spread_description">يعرض التوقعات الساعية لكل نموذج طقس رئيسي على رسوم درجات الحرارة والأمطار. مفيد للكشف عن حالات عدم اليقين في التوقعات.</string>
+
+    <!-- Settings — location subtitles -->
+    <string name="settings_root_location_subtitle">الكشف التلقائي أو اختيار مدينة</string>
+    <string name="settings_root_calendar_subtitle">أحداث اليوم</string>
+    <string name="settings_root_privacy_subtitle">تقارير الأعطال والاستخدام</string>
+
+    <!-- Settings — privacy / telemetry -->
+    <string name="settings_privacy_telemetry_title">تقارير الأعطال والاستخدام</string>
+    <string name="settings_privacy_telemetry_label">إرسال بيانات الأعطال والاستخدام</string>
+    <string name="settings_privacy_telemetry_description">يرسل تقارير أعطال مجهولة وإحصاءات استخدام تجميعية لمساعدة المطور على إصلاح الأخطاء وتحديد الميزات التي يجب الإبقاء عليها.</string>
+    <string name="settings_privacy_telemetry_limits">لا يُرسَل مطلقًا: أحداث التقويم، إحداثيات الموقع أو أسماء الأماكن، نص التحليل أو الإشعارات، مفاتيح API، GPS الدقيق، معرفات الإعلانات.</string>
+    <string name="settings_privacy_open_policy">قراءة سياسة الخصوصية الكاملة</string>
+
+    <!-- Settings — API key / Gemini -->
+    <string name="settings_api_key_gemini_label">Gemini</string>
+    <string name="settings_api_key_gemini_header">استخدم Gemini للحصول على أصوات عالية الجودة.</string>
+    <string name="settings_api_key_status_set">تم تكوين مفتاح Gemini.</string>
+    <string name="settings_api_key_status_unset">احصل على مفتاح API مجاني من aistudio.google.com</string>
+    <string name="settings_api_key_placeholder">الصق مفتاح Gemini API</string>
+    <string name="settings_api_key_save">حفظ مفتاح Gemini</string>
+    <string name="settings_api_key_clear">مسح مفتاح Gemini المخزّن</string>
+
+    <!-- Settings — location screen -->
+    <string name="settings_location_title">الموقع</string>
+    <string name="settings_location_use_device">استخدام موقع الجهاز</string>
+    <string name="settings_location_use_device_description">آخر موقع تقريبي</string>
+    <string name="settings_location_detecting">جارٍ الكشف…</string>
+    <string name="settings_location_grant_background">منح</string>
+    <string name="settings_location_background_banner_title">مطلوب إذن الموقع الدائم</string>
+    <string name="settings_location_background_banner_body">بدونه، لا تستطيع توقعات الصباح قراءة موقعك.</string>
+    <string name="settings_location_unset">لم يُحدَّد موقع</string>
+    <string name="settings_location_manual_override">موقع خاطئ؟ أدخله يدويًا</string>
+    <string name="settings_location_manual_override_disclosure">اختيار مدينة يوقف الكشف التلقائي.</string>
+    <string name="settings_location_clear">مسح الموقع</string>
+    <string name="settings_location_search_title">البحث عن موقع</string>
+    <string name="settings_location_query_label">مدينة أو مكان</string>
+    <string name="settings_location_search">بحث</string>
+    <string name="settings_location_searching">جارٍ البحث…</string>
+    <string name="settings_location_no_results">لا توجد نتائج.</string>
+    <string name="settings_location_rationale_title">الوصول إلى الموقع</string>
+    <string name="settings_location_rationale_body">تقرأ ClothesCast موقعك لجلب توقعات الطقس المحلية.</string>
+    <string name="settings_location_rationale_continue">متابعة</string>
+    <string name="settings_location_rationale_dismiss">ليس الآن</string>
+    <string name="settings_location_background_rationale_title">السماح في جميع الأوقات</string>
+    <string name="settings_location_background_rationale_body">اسمح لـ ClothesCast بقراءة موقعك أثناء الإغلاق حتى تتحدث توقعات الصباح في الوقت المناسب.</string>
+    <string name="settings_location_background_rationale_continue">فتح الإعدادات</string>
+    <string name="settings_location_background_rationale_dismiss">ليس الآن</string>
+    <string name="settings_location_background_denied_title">لم يُمنَح إذن الموقع الدائم</string>
+    <string name="settings_location_background_denied_body">بدون \'السماح في جميع الأوقات\' لا تستطيع توقعات الصباح التحديث التلقائي.</string>
+    <string name="settings_location_background_denied_open">فتح الإعدادات</string>
+    <string name="settings_location_background_denied_keep">ليس الآن</string>
+
+    <!-- Settings — schedule -->
+    <string name="settings_schedule_title">ClothesCast اليومي</string>
+    <string name="settings_schedule_time_label">الوقت</string>
+    <string name="settings_schedule_days_label">أيام الأسبوع</string>
+    <string name="settings_daily_mention_evening_events">ذكر أحداث المساء</string>
+    <string name="settings_tonight_title">ClothesCast الليلي</string>
+    <string name="settings_tonight_description">ClothesCast ثانٍ مسائي يغطي طقس الليلة. في المساء الهادئ يبقى صامتًا؛ في مساء الأحداث يُصدر صوتًا ويقرأ نفسه.</string>
+    <string name="settings_tonight_enabled">إظهار ClothesCast الليلي</string>
+    <string name="settings_tonight_time_label">الوقت</string>
+    <string name="settings_tonight_days_label">أيام الأسبوع</string>
+    <string name="settings_tonight_notify_only_on_events">إشعار فقط عند وجود أحداث مسائية</string>
+
+    <!-- Settings — delivery / TTS -->
+    <string name="settings_delivery_label">التسليم</string>
+    <string name="settings_delivery_notification_only">إشعار فقط</string>
+    <string name="settings_delivery_tts_only">قراءة صوتية فقط</string>
+    <string name="settings_delivery_notification_and_tts">إشعار وقراءة صوتية</string>
+    <string name="settings_tts_engine_title">محرك الصوت</string>
+    <string name="settings_tts_engine_description">Gemini يبدو أكثر طبيعية من صوت الجهاز لكنه يحتاج اتصالًا بالشبكة أثناء الكلام. يعود إلى صوت الجهاز إذا فشل Gemini.</string>
+    <string name="settings_tts_engine_device">الجهاز (بدون إنترنت، مجاني)</string>
+    <string name="settings_tts_engine_gemini">Gemini (جودة عالية، عبر الإنترنت)</string>
+    <string name="settings_tts_voice_label">الصوت</string>
+    <string name="settings_tts_voice_dismiss">تم</string>
+    <string name="settings_tts_style_label">الأسلوب</string>
+    <string name="settings_tts_style_weather_forecaster">مذيع الطقس</string>
+    <string name="settings_tts_style_pirate">قرصان</string>
+    <string name="settings_tts_style_cowboy">رعاة بقر</string>
+    <string name="settings_tts_style_shakespearean">شكسبيري</string>
+    <string name="settings_tts_style_surfer">راكب الأمواج</string>
+    <string name="settings_tts_style_parent">أحد الوالدين</string>
+    <string name="settings_tts_style_child">طفل</string>
+    <string name="settings_tts_style_teenager">مراهق</string>
+    <string name="settings_tts_style_grandparent">جد/جدة</string>
+    <string name="settings_tts_style_kids_host">مقدم برامج أطفال</string>
+    <string name="settings_tts_style_radio_host">مذيع محادثة</string>
+    <string name="settings_tts_style_morning_dj">دي جي الصباح</string>
+    <string name="settings_tts_style_science_teacher">معلم علوم</string>
+    <string name="settings_tts_style_historian">مؤرخ</string>
+    <string name="settings_tts_style_sportscaster">معلق رياضي</string>
+    <string name="settings_tts_style_stadium_announcer">معلق الملعب</string>
+    <string name="settings_tts_style_storyteller">راوٍ</string>
+    <string name="settings_tts_style_fitness_instructor">مدرب لياقة</string>
+    <string name="settings_tts_style_morning_presenter">مقدم راديو صباحي</string>
+    <string name="settings_tts_style_custom">مخصص…</string>
+    <string name="settings_tts_style_custom_label">توجيه مخصص</string>
+    <string name="settings_tts_style_custom_placeholder">مثال: اقرأ التالي كمكتبي صارم يهمس</string>
+    <string name="settings_tts_device_voice_label">صوت الجهاز</string>
+    <string name="settings_tts_device_voice_auto">تلقائي (الأفضل للهجة)</string>
+    <string name="settings_tts_device_voice_currently">حاليًا: %1$s</string>
+    <string name="settings_tts_device_voice_currently_loading">جارٍ التحميل…</string>
+    <string name="settings_tts_device_voice_network">الشبكة</string>
+    <string name="settings_tts_device_voice_offline">بدون إنترنت</string>
+    <string name="settings_tts_install_google_hint">ثبّت محرك تحويل النص إلى كلام من Google للحصول على أصوات أعلى جودة.</string>
+    <string name="settings_tts_install_google_button">تثبيت Google TTS</string>
+    <string name="settings_tts_test">اختبار الصوت</string>
+    <string name="settings_tts_test_in_flight">جارٍ الاختبار — الرجاء الانتظار…</string>
+
+    <!-- Settings — region / units -->
+    <string name="settings_temperature_unit_title">وحدة درجة الحرارة</string>
+    <string name="settings_temperature_unit_celsius">مئوية (°C)</string>
+    <string name="settings_temperature_unit_fahrenheit">فهرنهايت (°F)</string>
+    <string name="settings_distance_unit_title">وحدة المسافة</string>
+    <string name="settings_distance_unit_kilometers">كيلومترات</string>
+    <string name="settings_distance_unit_miles">أميال</string>
+
+    <!-- Settings — clothes rules -->
+    <string name="settings_clothes_title">قواعد الملابس</string>
+    <string name="settings_clothes_description">إذا تجاوزت التوقعات إحدى هذه العتبات، يظهر الغرض في ClothesCast اليومي.</string>
+
+    <!-- Garment names (additional) -->
+    <string name="garment_puffer">جاكيت منفوخ</string>
+    <string name="garment_thin_jacket">جاكيت خفيف</string>
+    <string name="garment_skirt">تنورة</string>
+    <string name="garment_polo">بولو</string>
+
+    <!-- Notification channels and content -->
+    <string name="notification_channel_daily_insight_name">ClothesCast اليومي</string>
+    <string name="notification_channel_daily_insight_description">ملخص الطقس الصباحي الذي اشتركت فيه.</string>
+    <string name="notification_daily_insight_title">ClothesCast اليوم</string>
+    <string name="notification_channel_tonight_insight_default_name">ClothesCast الليلي (مع الأحداث)</string>
+    <string name="notification_channel_tonight_insight_default_description">ملخص الطقس المسائي عند وجود أحداث تقويم الليلة.</string>
+    <string name="notification_channel_tonight_insight_silent_name">ClothesCast الليلي (صامت)</string>
+    <string name="notification_channel_tonight_insight_silent_description">ملخص الطقس المسائي في المساء الهادئ. يُرسَل صامتًا.</string>
+    <string name="notification_tonight_insight_title">ClothesCast الليلة</string>
+    <string name="notification_channel_weather_alerts_name">تحذيرات الطقس الشديد</string>
+    <string name="notification_channel_weather_alerts_description">تحذيرات ذات أولوية عالية لأحداث الطقس الشديدة أو القاسية التي تؤثر على منطقتك.</string>
+    <string name="notification_weather_alert_title">تحذير طقس: %1$s</string>
+
+    <!-- Settings — notification permission -->
+    <string name="settings_notification_permission_title">الإشعارات محظورة</string>
+    <string name="settings_notification_permission_description">بدون إذن الإشعارات، لا يجد ClothesCast اليومي وجهة للإرسال. امنحه حتى يتمكن ClothesCast من النشر صباح الغد.</string>
+    <string name="settings_notification_permission_grant">منح إذن الإشعارات</string>
+
+    <!-- Settings — calendar -->
+    <string name="settings_calendar_title">التقويم</string>
+    <string name="settings_calendar_use_events">استخدام أحداث تقويم اليوم</string>
+    <string name="settings_calendar_description_off">تخصيص توقعات الصباح وفق أحداث اليوم — تُستخدم العناوين والأوقات فقط، ولا يغادر أي شيء الجهاز.</string>
+    <string name="settings_calendar_description_on">جارٍ تخصيص توقعات الصباح وفق أحداث اليوم. تُستخدم العناوين والأوقات فقط؛ لا يغادر أي شيء الجهاز.</string>
+    <string name="settings_calendar_grant_permission">منح إذن التقويم</string>
+    <string name="settings_calendar_open_settings">تم رفض إذن التقويم. امنحه من إعدادات النظام.</string>
+
+    <!-- Settings — about -->
+    <string name="settings_about_title">حول</string>
+    <string name="settings_about_version">الإصدار %1$s (%2$d)</string>
+    <string name="settings_about_build_type_suffix"> · إصدار %1$s</string>
+    <string name="settings_about_source">الكود المصدري على GitHub</string>
+    <string name="settings_about_dontkillmyapp">قيود الخلفية (dontkillmyapp.com)</string>
+    <string name="settings_about_share_bug_report">مشاركة تقرير الخطأ</string>
+    <string name="settings_about_version_copied">تم نسخ الإصدار إلى الحافظة</string>
+
+    <!-- Bug report consent dialog -->
+    <string name="bug_report_consent_title">مشاركة تقرير الخطأ؟</string>
+    <string name="bug_report_consent_body">يساعد ذلك في تشخيص المشكلات. يحتوي التقرير على معلومات شخصية حساسة، بما فيها موقعك وإعدادات التطبيق والنشاط الأخير. ستتمكن من مراجعته وتعديله قبل الإرسال.</string>
+    <string name="bug_report_consent_dont_show_again">لا تُظهر هذا مجددًا</string>
+    <string name="bug_report_consent_continue">متابعة</string>
+    <string name="bug_report_consent_cancel">إلغاء</string>
+
+    <!-- Insight prose (additional templates) -->
+    <string name="insight_precip_chance">احتمال %1$s %2$s.</string>
+    <string name="insight_tie_in_at_night">خذ %1$s.</string>
+    <string name="insight_tie_in_with_rain_chance">خذ %1$s الليلة، احتمال مطر الساعة %2$s.</string>
+    <string name="insight_evening_rain">الليلة، مطر الساعة %1$s.</string>
+    <string name="insight_evening_rain_chance">الليلة، احتمال مطر الساعة %1$s.</string>
 </resources>

--- a/app/src/main/res/values-b+sr+Latn/strings.xml
+++ b/app/src/main/res/values-b+sr+Latn/strings.xml
@@ -67,7 +67,7 @@ default English (matching values-pl / values-uk).
     <string name="today_outfit_top_thick_coat">Debeli kaput</string>
     <string name="today_outfit_top_puffer_jacket">Puffer jakna</string>
     <string name="today_outfit_bottom_shorts">Šorts</string>
-    <string name="today_outfit_bottom_skirt">Suknja</string>
+    <string name="today_outfit_bottom_long_skirt">Suknja</string>
     <string name="today_outfit_bottom_jeans">Farmerke</string>
     <string name="today_outfit_bottom_long_pants">Pantalone</string>
 
@@ -585,4 +585,7 @@ default English (matching values-pl / values-uk).
     <string name="bug_report_consent_continue">Nastavi</string>
     <string name="bug_report_consent_cancel">Otkaži</string>
 
+    <string name="today_forecast_air_section_title">Temperatura vazduha</string>
+    <string name="settings_default_bottom_title">Standardni donji deo</string>
+    <string name="settings_default_bottom_description">Ono što predlažemo na početnom ekranu kada nije dovoljno toplo za kratke hlače.</string>
 </resources>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -126,7 +126,7 @@ What is NOT overridden, by design:
     <string name="today_outfit_top_thin_jacket">Тънко яке</string>
     <string name="today_outfit_top_thick_coat">Дебело палто</string>
     <string name="today_outfit_top_puffer_jacket">Зимно яке</string>
-    <string name="today_outfit_bottom_skirt">Пола</string>
+    <string name="today_outfit_bottom_long_skirt">Пола</string>
     <string name="today_outfit_bottom_jeans">Дънки</string>
 
     <!-- "Why this outfit?" rationale dialog. -->
@@ -583,4 +583,7 @@ What is NOT overridden, by design:
     <string name="bug_report_consent_continue">Продължи</string>
     <string name="bug_report_consent_cancel">Откажи</string>
 
+    <string name="today_forecast_air_section_title">Температура на въздуха</string>
+    <string name="settings_default_bottom_title">Стандартен долен</string>
+    <string name="settings_default_bottom_description">Какво предлагаме на началния екран, когато не е достатъчно топло за шорти.</string>
 </resources>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -639,4 +639,7 @@ West Bengal vocabulary differences in a future PR.
 
     <string name="error_device_incompatible">ClothesCast এই ডিভাইসে চলতে পারছে না — আপনার Android বিল্ডে অ্যাপের UI-এর জন্য প্রয়োজনীয় একটি ফিচার অনুপস্থিত (Configuration.fontWeightAdjustment, Android 12 এবং উপরে প্রত্যাশিত)। সিস্টেম আপডেটের জন্য আপনার ডিভাইস প্রস্তুতকারকের সাথে যোগাযোগ করুন।</string>
 
+    <string name="today_forecast_air_section_title">বায়ু তাপমাত্রা</string>
+    <string name="settings_default_bottom_title">সাধারণ নিচের পোশাক</string>
+    <string name="settings_default_bottom_description">শর্টসের জন্য যথেষ্ট গরম না হলে হোম স্ক্রিনে আমরা কী সাজেস্ট করি।</string>
 </resources>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -34,7 +34,7 @@ the in-app clock is digit-driven and reads consistently across locales.
     <string name="today_outfit_top_thick_coat">Abric gruixut</string>
     <string name="today_outfit_top_puffer_jacket">Jaqueta acolchada</string>
     <string name="today_outfit_bottom_shorts">Pantalons curts</string>
-    <string name="today_outfit_bottom_skirt">Faldilla</string>
+    <string name="today_outfit_bottom_long_skirt">Faldilla</string>
     <string name="today_outfit_bottom_jeans">Texans</string>
     <string name="today_outfit_bottom_long_pants">Pantalons llargs</string>
 
@@ -536,4 +536,7 @@ the in-app clock is digit-driven and reads consistently across locales.
     <string name="insight_time_hour">%1$d</string>
     <string name="insight_time_hour_minutes">%1$d:%2$02d</string>
 
+    <string name="today_forecast_air_section_title">Temperatura de l\'aire</string>
+    <string name="settings_default_bottom_title">Part de baix estàndard</string>
+    <string name="settings_default_bottom_description">El que suggerim a la pantalla d\'inici quan no fa prou calor per a pantalons curts.</string>
 </resources>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -586,4 +586,7 @@ locale (Angličtina (USA), Francouzština (Francie), Němčina (Německo), …).
 
     <!-- Device incompatibility error. -->
     <string name="error_device_incompatible">ClothesCast nelze na tomto zařízení spustit — tvému Android sestavení chybí funkce, kterou rozhraní aplikace potřebuje (Configuration.fontWeightAdjustment, očekáváno od Android 12 výše). Obrať se prosím na výrobce zařízení ohledně aktualizace systému.</string>
+    <string name="today_forecast_air_section_title">Teplota vzduchu</string>
+    <string name="settings_default_bottom_title">Standardní spodní díl</string>
+    <string name="settings_default_bottom_description">Co doporučujeme na domovské obrazovce, když není dost teplo na šortky.</string>
 </resources>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -599,4 +599,7 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrig)").
 
     <!-- Device-incompatibility error screen. -->
     <string name="error_device_incompatible">ClothesCast kan ikke køre på denne enhed — din Android-build mangler en funktion, som appens brugergrænseflade kræver (Configuration.fontWeightAdjustment, forventet fra Android 12 og opefter). Kontakt din enhedsproducent for en systemopdatering.</string>
+    <string name="today_forecast_air_section_title">Lufttemperatur</string>
+    <string name="settings_default_bottom_title">Standard bundstykke</string>
+    <string name="settings_default_bottom_description">Det vi foreslår på startskærmen, når det ikke er varmt nok til shorts.</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -720,4 +720,7 @@ zh-CN) is unchanged; only the displayed label localizes.
 
     <!-- Device-incompatibility error screen. -->
     <string name="error_device_incompatible">ClothesCast kann auf diesem Gerät nicht ausgeführt werden — deinem Android-Build fehlt eine Funktion, die die App-Oberfläche benötigt (Configuration.fontWeightAdjustment, erwartet ab Android 12 aufwärts). Bitte wende dich an deinen Gerätehersteller für ein System-Update.</string>
+    <string name="today_forecast_air_section_title">Lufttemperatur</string>
+    <string name="settings_default_bottom_title">Standard-Unterteil</string>
+    <string name="settings_default_bottom_description">Was wir auf dem Startbildschirm vorschlagen, wenn es nicht warm genug für Shorts ist.</string>
 </resources>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -580,7 +580,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="today_outfit_top_thin_jacket">Λεπτό μπουφάν</string>
     <string name="today_outfit_top_thick_coat">Χοντρό παλτό</string>
     <string name="today_outfit_top_puffer_jacket">Μπουφάν puffer</string>
-    <string name="today_outfit_bottom_skirt">Φούστα</string>
+    <string name="today_outfit_bottom_long_skirt">Φούστα</string>
     <string name="today_outfit_bottom_jeans">Τζιν</string>
 
     <!-- Device incompatibility error. -->
@@ -718,4 +718,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_tts_style_custom">Προσαρμοσμένο…</string>
     <string name="settings_tts_style_custom_label">Προσαρμοσμένη οδηγία</string>
     <string name="settings_tts_style_custom_placeholder">π.χ. Διάβασε το παρακάτω ως αυστηρός βιβλιοθηκάριος που ψιθυρίζει</string>
+    <string name="today_forecast_air_section_title">Θερμοκρασία αέρα</string>
+    <string name="settings_default_bottom_title">Κανονικό κάτω μέρος</string>
+    <string name="settings_default_bottom_description">Αυτό που προτείνουμε στην αρχική οθόνη όταν δεν κάνει αρκετά ζέστη για σορτς.</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -697,4 +697,7 @@ zh-CN) is unchanged; only the displayed label localizes.
 
     <!-- Device-incompatibility error screen. -->
     <string name="error_device_incompatible">ClothesCast no puede ejecutarse en este dispositivo — tu versión de Android carece de una función que la interfaz de la app requiere (Configuration.fontWeightAdjustment, esperada en Android 12 y superior). Contacta al fabricante de tu dispositivo para obtener una actualización del sistema.</string>
+    <string name="today_forecast_air_section_title">Temperatura del aire</string>
+    <string name="settings_default_bottom_title">Parte inferior estándar</string>
+    <string name="settings_default_bottom_description">Lo que sugerimos en la pantalla de inicio cuando no hace suficiente calor para shorts.</string>
 </resources>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -34,7 +34,7 @@ Tone is informal "sina"-form throughout ("Pane … selga", "Võta … kaasa",
     <string name="today_outfit_top_thick_coat">Paks mantel</string>
     <string name="today_outfit_top_puffer_jacket">Unijope</string>
     <string name="today_outfit_bottom_shorts">Lühikesed püksid</string>
-    <string name="today_outfit_bottom_skirt">Seelik</string>
+    <string name="today_outfit_bottom_long_skirt">Seelik</string>
     <string name="today_outfit_bottom_jeans">Teksad</string>
     <string name="today_outfit_bottom_long_pants">Pikad püksid</string>
 
@@ -544,4 +544,7 @@ Tone is informal "sina"-form throughout ("Pane … selga", "Võta … kaasa",
     <string name="insight_time_hour">%1$d</string>
     <string name="insight_time_hour_minutes">%1$d.%2$02d</string>
 
+    <string name="today_forecast_air_section_title">Õhutemperatuur</string>
+    <string name="settings_default_bottom_title">Standardne alumine rõivaese</string>
+    <string name="settings_default_bottom_description">Mida soovitame avalehel, kui pole piisavalt soe, et kanda šortseid.</string>
 </resources>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -90,4 +90,358 @@ Western Arabic numerals (0-9) are used for TTS compatibility.
     <string name="insight_time_hour">%1$d</string>
     <string name="insight_time_hour_minutes">%1$d:%2$02d</string>
 
+    <string name="today_forecast_air_section_title">دمای هوا</string>
+    <string name="settings_default_bottom_title">پایین‌تنه پیش‌فرض</string>
+    <string name="settings_default_bottom_description">آنچه وقتی هوا برای شلوارک گرم نیست در صفحه اصلی پیشنهاد می‌دهیم.</string>
+
+    <!-- Error / compatibility -->
+    <string name="error_device_incompatible">ClothesCast نمی‌تواند روی این دستگاه اجرا شود — نسخه Android شما فاقد ویژگی مورد نیاز رابط کاربری برنامه است. لطفاً با سازنده دستگاه خود برای دریافت به‌روزرسانی سیستم تماس بگیرید.</string>
+
+    <!-- Today screen -->
+    <string name="today_title">امروز</string>
+    <string name="today_open_settings">باز کردن تنظیمات</string>
+    <string name="today_more_options">گزینه‌های بیشتر</string>
+    <string name="today_report_a_bug">گزارش خطا</string>
+    <string name="today_refresh">بازخوانی</string>
+    <string name="today_refresh_toast_daily">در حال به‌روزرسانی ClothesCast روزانه شما — به زودی نمایش داده می‌شود.</string>
+    <string name="today_refresh_toast_nightly">در حال به‌روزرسانی ClothesCast شبانه شما — به زودی نمایش داده می‌شود.</string>
+    <string name="today_empty_title">هنوز ClothesCast وجود ندارد</string>
+    <string name="today_empty_subtitle">ClothesCast صبحگاهی شما پس از تولید اینجا نمایش داده می‌شود. موقعیت خود را در تنظیمات تنظیم کنید، سپس روی دریافت اکنون ضربه بزنید.</string>
+    <string name="today_fetch_now">دریافت اکنون</string>
+    <string name="today_generated_at">تولید شده در %1$s</string>
+    <string name="today_location_unknown">موقعیت شما</string>
+
+    <!-- Today — outfit card -->
+    <string name="today_outfit_title">چه بپوشم</string>
+    <string name="today_outfit_label_today">امروز</string>
+    <string name="today_outfit_label_tonight">امشب</string>
+    <string name="today_outfit_label_tomorrow">فردا</string>
+    <string name="today_outfit_top_polo">پولو</string>
+    <string name="today_outfit_top_thin_jacket">کت نازک</string>
+    <string name="today_outfit_top_thick_coat">پالتوی ضخیم</string>
+    <string name="today_outfit_top_puffer_jacket">کاپشن پفی</string>
+    <string name="today_outfit_bottom_long_skirt">دامن بلند</string>
+    <string name="today_outfit_bottom_jeans">جین</string>
+
+    <!-- Today — rationale sheet -->
+    <string name="today_rationale_title">چرا این لباس؟</string>
+    <string name="today_rationale_show">چرا؟</string>
+    <string name="today_rationale_dismiss">متوجه شدم</string>
+    <string name="today_rationale_threshold_decrease">کاهش آستانه ۱ درجه</string>
+    <string name="today_rationale_threshold_increase">افزایش آستانه ۱ درجه</string>
+    <string name="today_rationale_threshold_changed_hint">بازخوانی کنید تا لباس جدید را ببینید.</string>
+    <string name="today_rationale_unavailable">توضیحی در دسترس نیست — پس از به‌روزرسانی بعدی برنامه را باز کنید.</string>
+    <string name="today_rationale_min_below_with_time">حداقل دمای احساس‌شده %1$s%2$s در ساعت %3$s، کمتر از %4$s%2$s</string>
+    <string name="today_rationale_min_below">حداقل دمای احساس‌شده %1$s%2$s، کمتر از %3$s%2$s</string>
+    <string name="today_rationale_min_above_with_time">حداقل دمای احساس‌شده %1$s%2$s در ساعت %3$s، حداقل %4$s%2$s</string>
+    <string name="today_rationale_min_above">حداقل دمای احساس‌شده %1$s%2$s، حداقل %3$s%2$s</string>
+    <string name="today_rationale_max_below_with_time">حداکثر دمای احساس‌شده فقط %1$s%2$s در ساعت %3$s، کمتر از %4$s%2$s</string>
+    <string name="today_rationale_max_below">حداکثر دمای احساس‌شده فقط %1$s%2$s، کمتر از %3$s%2$s</string>
+    <string name="today_rationale_max_above_with_time">حداکثر دمای احساس‌شده %1$s%2$s در ساعت %3$s، حداقل %4$s%2$s</string>
+    <string name="today_rationale_max_above">حداکثر دمای احساس‌شده %1$s%2$s، حداقل %3$s%2$s</string>
+
+    <!-- Widget -->
+    <string name="widget_label">لباس</string>
+    <string name="widget_description">لباس دوره جاری در یک نگاه.</string>
+    <string name="widget_empty_title">هنوز لباسی نیست</string>
+    <string name="widget_empty_subtitle">برای باز کردن ClothesCast ضربه بزنید</string>
+
+    <!-- Today — forecast charts -->
+    <string name="today_forecast_title">دمای احساس‌شده</string>
+    <string name="today_forecast_min_max">احساس می‌شود %1$d – %2$d%3$s</string>
+    <string name="today_forecast_legend_feels_like">دمای احساس‌شده (%1$s) به ازای ساعت</string>
+    <string name="today_forecast_air_min_max">هوا %1$d – %2$d%3$s</string>
+    <string name="today_forecast_legend_air">دمای هوا (%1$s) به ازای ساعت</string>
+    <string name="today_precipitation_title">احتمال بارندگی</string>
+    <string name="today_precipitation_peak">اوج %1$d%% در ساعت %2$s</string>
+    <string name="today_precipitation_dry">امروز بارندگی انتظار نمی‌رود</string>
+    <string name="today_chart_model_legend_label">مدل‌ها:</string>
+    <string name="today_chart_main_line_label">ترکیبی</string>
+    <string name="today_chart_divergence_summary">مدل‌ها بیشترین اختلاف را در ساعت %1$s دارند (Δ %2$.1f%3$s احساس‌شده) — عمدتاً %4$s، %5$s</string>
+    <string name="today_factor_air_temperature">دمای هوا</string>
+    <string name="today_factor_wind_speed">سرعت باد</string>
+    <string name="today_factor_cloud_cover">پوشش ابری</string>
+    <string name="today_factor_humidity">رطوبت</string>
+    <string name="today_wind_title">سرعت باد</string>
+    <string name="today_wind_subtitle">سرعت باد (%1$s) به ازای مدل و ساعت</string>
+    <string name="today_cloud_title">پوشش ابری</string>
+    <string name="today_cloud_subtitle">پوشش ابری کل (%) به ازای مدل و ساعت</string>
+    <string name="today_humidity_title">رطوبت</string>
+    <string name="today_humidity_subtitle">رطوبت نسبی (%) به ازای مدل و ساعت</string>
+
+    <!-- Today — confidence callout -->
+    <string name="today_confidence_high">اطمینان بالا — مدل‌های اصلی توافق دارند</string>
+    <string name="today_confidence_medium">اطمینان متوسط</string>
+    <string name="today_confidence_low">اطمینان پایین — پیش‌بینی‌ها با هم اختلاف دارند</string>
+    <string name="today_confidence_spread">پراکندگی: %1$.1f°C، %2$.0f%% بارندگی در %3$d مدل</string>
+    <string name="today_low_confidence_callout_title">پیش‌بینی‌ها اختلاف دارند</string>
+    <string name="today_low_confidence_callout_body">دمای محدوده %1$.1f°C و احتمال بارندگی %2$.0f%% در %3$d مدل متفاوت است.</string>
+
+    <!-- Today — loading / error states -->
+    <string name="today_working">در حال کار — در حال دریافت ClothesCast شما…</string>
+    <string name="today_retrying">آخرین تلاش ناموفق بود — تلاش مجدد…</string>
+    <string name="today_failed_title">آخرین تلاش ناموفق بود</string>
+    <string name="today_failed_unexpected_http">خطای HTTP غیرمنتظره از سرویس پیش‌بینی.</string>
+    <string name="today_failed_unhandled">یک خطای غیرمنتظره رخ داد.</string>
+    <string name="today_failed_no_location">موقعیت شما را نمی‌توانیم دریافت کنیم. مجوز موقعیت دائمی بدهید، یا یک شهر در تنظیمات تنظیم کنید.</string>
+    <string name="today_failed_show_details">نمایش جزئیات</string>
+    <string name="today_failed_hide_details">پنهان کردن جزئیات</string>
+
+    <!-- Today — location required -->
+    <string name="today_location_required_title">موقعیت خود را تنظیم کنید</string>
+    <string name="today_location_required_body">ClothesCast باید بداند کجا هستید تا پیش‌بینی را دریافت کند. مجوز موقعیت دائمی بدهید، یا یک شهر انتخاب کنید.</string>
+    <string name="today_location_required_action">باز کردن تنظیمات موقعیت</string>
+
+    <!-- Today — crash banner -->
+    <string name="today_crash_banner_title">آخرین اجرا خراب شد</string>
+    <string name="today_crash_banner_body">گزارش خرابی روی دستگاه شما ذخیره شد. برای رفع اشکال آن را به اشتراک می‌گذارید؟ تا زمانی که مقصد را انتخاب نکنید چیزی ارسال نمی‌شود.</string>
+    <string name="today_crash_banner_share">اشتراک‌گذاری گزارش</string>
+    <string name="today_crash_banner_dismiss">رد کردن</string>
+
+    <!-- Today — update banners -->
+    <string name="today_update_available_title">به‌روزرسانی موجود است</string>
+    <string name="today_update_available_body">نسخه جدیدتر ClothesCast در Play Store وجود دارد.</string>
+    <string name="today_update_available_action">به‌روزرسانی</string>
+    <string name="today_update_available_dismiss">نه الان</string>
+    <string name="today_update_downloaded_body">به‌روزرسانی دانلود شد. برای تکمیل نصب راه‌اندازی مجدد کنید.</string>
+    <string name="today_update_downloaded_action">راه‌اندازی مجدد</string>
+
+    <!-- Today — telemetry notice -->
+    <string name="today_telemetry_notice_title">گزارش‌های خرابی و استفاده روشن هستند</string>
+    <string name="today_telemetry_notice_body">ClothesCast گزارش‌های خرابی ناشناس و آمار استفاده را برای کمک به رفع اشکال ارسال می‌کند. هیچ داده تقویم، موقعیت یا متن بینش‌ای درج نشده. هر زمان در تنظیمات خاموش کنید.</string>
+    <string name="today_telemetry_notice_open_settings">باز کردن تنظیمات حریم خصوصی</string>
+    <string name="today_telemetry_notice_dismiss">رد کردن</string>
+
+    <!-- Onboarding -->
+    <string name="onboarding_title">به ClothesCast خوش آمدید</string>
+    <string name="onboarding_subtitle">سه انتخاب سریع و آماده‌اید. بعداً در تنظیمات تغییر دهید.</string>
+    <string name="onboarding_subtitle_tv">دو انتخاب سریع و آماده‌اید. بعداً در تنظیمات تغییر دهید.</string>
+    <string name="onboarding_notifications_title">اعلان‌ها</string>
+    <string name="onboarding_notifications_description">برای ارسال ClothesCast روزانه شما لازم است.</string>
+    <string name="onboarding_notifications_grant">اعطای مجوز اعلان</string>
+    <string name="onboarding_location_title">موقعیت</string>
+    <string name="onboarding_location_description">دریافت پیش‌بینی برای موقعیت تقریبی شما.</string>
+    <string name="onboarding_location_grant">اعطای مجوز موقعیت</string>
+    <string name="onboarding_location_grant_background">اعطای مجوز موقعیت دائمی</string>
+    <string name="onboarding_location_background_needed">یک قدم دیگر: ClothesCast به \'همیشه اجازه بده\' نیاز دارد تا پیش‌بینی صبحگاهی بتواند موقعیت شما را در زمان بسته بودن برنامه بخواند.</string>
+    <string name="onboarding_location_denied_hint">مجوز موقعیت رد شد. می‌توانید یک شهر را به صورت دستی انتخاب کنید.</string>
+    <string name="onboarding_location_enter_manual">ورود دستی موقعیت</string>
+    <string name="onboarding_location_enter_manual_hint">اگر مجوز موقعیت را رد کنید یا موقعیت دستگاه شما اشتباه باشد، می‌توانید موقعیت خود را به صورت دستی وارد کنید.</string>
+    <string name="onboarding_location_using_device">هر صبح از موقعیت دستگاه شما استفاده می‌شود.</string>
+    <string name="onboarding_gemini_title">کلید Gemini API</string>
+    <string name="onboarding_gemini_description">از Gemini برای دریافت صداهای باکیفیت استفاده کنید.</string>
+    <string name="onboarding_step_done">انجام شد</string>
+    <string name="onboarding_skip">فعلاً رد شو</string>
+    <string name="onboarding_continue">ادامه</string>
+    <string name="onboarding_pair_from_phone">جفت‌سازی از طریق گوشی</string>
+
+    <!-- Pairing (TV) -->
+    <string name="pairing_title">اسکن برای جفت‌سازی</string>
+    <string name="pairing_instructions">این کد QR را با گوشی خود اسکن کنید، سپس کلید Gemini API خود را در فرمی که باز می‌شود جای‌گذاری کنید. کلید مستقیماً از طریق Wi-Fi خانگی شما به این تلویزیون ارسال می‌شود — بدون رله ابری.</string>
+    <string name="pairing_qr_description">کد QR لینک به %1$s</string>
+    <string name="pairing_cancel">لغو</string>
+    <string name="pairing_received">کلید دریافت شد — در حال ذخیره…</string>
+    <string name="pairing_timeout_title">پنجره جفت‌سازی منقضی شد</string>
+    <string name="pairing_timeout_body">پنجره جفت‌سازی ۵ دقیقه‌ای بسته شد. برای باز کردن پنجره جدید روی تلاش مجدد ضربه بزنید.</string>
+    <string name="pairing_error_title">شروع جفت‌سازی ممکن نشد</string>
+    <string name="pairing_error_body">مطمئن شوید تلویزیون به Wi-Fi متصل است، سپس دوباره امتحان کنید.</string>
+    <string name="pairing_retry">تلاش مجدد</string>
+
+    <!-- Settings — root -->
+    <string name="settings_title">تنظیمات</string>
+    <string name="settings_back">بازگشت</string>
+    <string name="settings_root_voice">صدا</string>
+    <string name="settings_root_schedule">برنامه</string>
+    <string name="settings_root_region">منطقه</string>
+    <string name="settings_root_clothes">لباس</string>
+    <string name="settings_root_display">نمایش</string>
+    <string name="settings_root_location">موقعیت</string>
+    <string name="settings_root_calendar">تقویم</string>
+    <string name="settings_root_privacy">حریم خصوصی</string>
+    <string name="settings_root_about">درباره</string>
+    <string name="settings_root_schedule_subtitle">اعلان‌ها و زمان‌ها</string>
+    <string name="settings_root_clothes_subtitle">دماها و لباس‌ها</string>
+    <string name="settings_root_region_subtitle">زبان‌ها و واحدها</string>
+    <string name="settings_root_voice_subtitle">ارائه‌دهندگان و لهجه‌ها</string>
+    <string name="settings_root_display_subtitle">قالب</string>
+    <string name="settings_root_location_subtitle">تشخیص خودکار یا انتخاب شهر</string>
+    <string name="settings_root_calendar_subtitle">رویدادهای امروز</string>
+    <string name="settings_root_privacy_subtitle">گزارش‌های خرابی و استفاده</string>
+
+    <!-- Settings — display -->
+    <string name="settings_display_theme_title">قالب</string>
+    <string name="settings_display_theme_system">پیروی از سیستم</string>
+    <string name="settings_display_theme_light">روشن</string>
+    <string name="settings_display_theme_dark">تیره</string>
+    <string name="settings_display_charts_title">نمودارها</string>
+    <string name="settings_display_model_spread_label">نمایش پراکندگی مدل در نمودارها</string>
+    <string name="settings_display_model_spread_description">پیش‌بینی ساعتی هر مدل آب‌وهوایی اصلی را روی نمودارهای دما و بارندگی همپوشانی می‌کند. برای تشخیص زمانی که پیش‌بینی نامطمئن است مفید است.</string>
+
+    <!-- Settings — privacy -->
+    <string name="settings_privacy_telemetry_title">گزارش‌های خرابی و استفاده</string>
+    <string name="settings_privacy_telemetry_label">ارسال داده خرابی و استفاده</string>
+    <string name="settings_privacy_telemetry_description">گزارش‌های خرابی ناشناس و آمار استفاده را ارسال می‌کند تا به توسعه‌دهنده در رفع اشکال کمک کند.</string>
+    <string name="settings_privacy_telemetry_limits">هرگز ارسال نمی‌شود: رویدادهای تقویم، مختصات موقعیت یا نام مکان‌ها، متن بینش یا اعلان، کلیدهای API، GPS دقیق، شناسه‌های تبلیغاتی.</string>
+    <string name="settings_privacy_open_policy">خواندن سیاست حریم خصوصی کامل</string>
+
+    <!-- Settings — API key -->
+    <string name="settings_api_key_gemini_label">Gemini</string>
+    <string name="settings_api_key_gemini_header">از Gemini برای دریافت صداهای باکیفیت استفاده کنید.</string>
+    <string name="settings_api_key_status_set">یک کلید Gemini پیکربندی شده.</string>
+    <string name="settings_api_key_status_unset">یک کلید API رایگان از aistudio.google.com دریافت کنید</string>
+    <string name="settings_api_key_placeholder">کلید Gemini API خود را جای‌گذاری کنید</string>
+    <string name="settings_api_key_save">ذخیره کلید Gemini</string>
+    <string name="settings_api_key_clear">پاک کردن کلید ذخیره‌شده Gemini</string>
+
+    <!-- Settings — location -->
+    <string name="settings_location_title">موقعیت</string>
+    <string name="settings_location_use_device">استفاده از موقعیت دستگاه</string>
+    <string name="settings_location_use_device_description">آخرین موقعیت تقریبی</string>
+    <string name="settings_location_detecting">در حال تشخیص…</string>
+    <string name="settings_location_grant_background">اعطا</string>
+    <string name="settings_location_background_banner_title">مجوز موقعیت دائمی لازم است</string>
+    <string name="settings_location_background_banner_body">بدون آن، پیش‌بینی صبحگاهی نمی‌تواند موقعیت شما را بخواند.</string>
+    <string name="settings_location_unset">هیچ موقعیتی تنظیم نشده</string>
+    <string name="settings_location_manual_override">موقعیت اشتباه است؟ دستی تنظیم کنید</string>
+    <string name="settings_location_manual_override_disclosure">انتخاب شهر تشخیص خودکار را غیرفعال می‌کند.</string>
+    <string name="settings_location_clear">پاک کردن موقعیت</string>
+    <string name="settings_location_search_title">جستجوی موقعیت</string>
+    <string name="settings_location_query_label">شهر یا مکان</string>
+    <string name="settings_location_search">جستجو</string>
+    <string name="settings_location_searching">در حال جستجو…</string>
+    <string name="settings_location_no_results">نتیجه‌ای یافت نشد.</string>
+    <string name="settings_location_rationale_title">دسترسی به موقعیت</string>
+    <string name="settings_location_rationale_body">ClothesCast موقعیت شما را برای دریافت پیش‌بینی محلی می‌خواند.</string>
+    <string name="settings_location_rationale_continue">ادامه</string>
+    <string name="settings_location_rationale_dismiss">نه الان</string>
+    <string name="settings_location_background_rationale_title">همیشه اجازه بده</string>
+    <string name="settings_location_background_rationale_body">اجازه دهید ClothesCast موقعیت شما را در زمان بسته بودن بخواند تا پیش‌بینی صبحگاهی به موقع به‌روز شود.</string>
+    <string name="settings_location_background_rationale_continue">باز کردن تنظیمات</string>
+    <string name="settings_location_background_rationale_dismiss">نه الان</string>
+    <string name="settings_location_background_denied_title">مجوز دائمی اعطا نشد</string>
+    <string name="settings_location_background_denied_body">بدون \'همیشه اجازه بده\' پیش‌بینی صبحگاهی نمی‌تواند به‌روزرسانی خودکار شود.</string>
+    <string name="settings_location_background_denied_open">باز کردن تنظیمات</string>
+    <string name="settings_location_background_denied_keep">نه الان</string>
+
+    <!-- Settings — schedule -->
+    <string name="settings_schedule_title">ClothesCast روزانه</string>
+    <string name="settings_schedule_time_label">زمان</string>
+    <string name="settings_schedule_days_label">روزهای هفته</string>
+    <string name="settings_daily_mention_evening_events">ذکر رویدادهای عصر</string>
+    <string name="settings_tonight_title">ClothesCast شبانه</string>
+    <string name="settings_tonight_description">یک ClothesCast دوم در عصر که آب‌وهوای امشب را پوشش می‌دهد. شب‌های آرام ساکت می‌ماند؛ شب‌های رویداد صدا پخش می‌کند و خودش را می‌خواند.</string>
+    <string name="settings_tonight_enabled">نمایش ClothesCast شبانه</string>
+    <string name="settings_tonight_time_label">زمان</string>
+    <string name="settings_tonight_days_label">روزهای هفته</string>
+    <string name="settings_tonight_notify_only_on_events">فقط در صورت وجود رویدادهای عصر اعلان بده</string>
+    <string name="settings_delivery_label">تحویل</string>
+    <string name="settings_delivery_notification_only">فقط اعلان</string>
+    <string name="settings_delivery_tts_only">فقط خواندن با صدای بلند</string>
+    <string name="settings_delivery_notification_and_tts">اعلان و خواندن با صدای بلند</string>
+
+    <!-- Settings — TTS engine -->
+    <string name="settings_tts_engine_title">موتور صوتی</string>
+    <string name="settings_tts_engine_description">Gemini طبیعی‌تر از صدای دستگاه به نظر می‌رسد اما به اتصال شبکه در زمان صحبت نیاز دارد. در صورت شکست Gemini به صدای دستگاه برمی‌گردد.</string>
+    <string name="settings_tts_engine_device">دستگاه (آفلاین، رایگان)</string>
+    <string name="settings_tts_engine_gemini">Gemini (کیفیت بالا، آنلاین)</string>
+    <string name="settings_tts_voice_label">صدا</string>
+    <string name="settings_tts_voice_dismiss">انجام شد</string>
+    <string name="settings_tts_style_label">سبک</string>
+    <string name="settings_tts_style_weather_forecaster">هواشناس</string>
+    <string name="settings_tts_style_pirate">دزد دریایی</string>
+    <string name="settings_tts_style_cowboy">کابوی</string>
+    <string name="settings_tts_style_shakespearean">شکسپیری</string>
+    <string name="settings_tts_style_surfer">موج‌سوار</string>
+    <string name="settings_tts_style_parent">والدین</string>
+    <string name="settings_tts_style_child">کودک</string>
+    <string name="settings_tts_style_teenager">نوجوان</string>
+    <string name="settings_tts_style_grandparent">پدربزرگ/مادربزرگ</string>
+    <string name="settings_tts_style_kids_host">مجری برنامه کودک</string>
+    <string name="settings_tts_style_radio_host">مجری گفتگو</string>
+    <string name="settings_tts_style_morning_dj">DJ صبح</string>
+    <string name="settings_tts_style_science_teacher">معلم علوم</string>
+    <string name="settings_tts_style_historian">مورخ</string>
+    <string name="settings_tts_style_sportscaster">گزارشگر ورزشی</string>
+    <string name="settings_tts_style_stadium_announcer">گزارشگر استادیوم</string>
+    <string name="settings_tts_style_storyteller">داستان‌سرا</string>
+    <string name="settings_tts_style_fitness_instructor">مربی تناسب اندام</string>
+    <string name="settings_tts_style_morning_presenter">مجری رادیوی صبح</string>
+    <string name="settings_tts_style_custom">سفارشی…</string>
+    <string name="settings_tts_style_custom_label">دستورالعمل سفارشی</string>
+    <string name="settings_tts_style_custom_placeholder">مثال: متن بعدی را به سبک یک کتابدار جدی که زمزمه می‌کند بخوانید</string>
+    <string name="settings_tts_device_voice_label">صدای دستگاه</string>
+    <string name="settings_tts_device_voice_auto">خودکار (بهترین برای لهجه)</string>
+    <string name="settings_tts_device_voice_currently">در حال حاضر: %1$s</string>
+    <string name="settings_tts_device_voice_currently_loading">در حال بارگذاری…</string>
+    <string name="settings_tts_device_voice_network">شبکه</string>
+    <string name="settings_tts_device_voice_offline">آفلاین</string>
+    <string name="settings_tts_install_google_hint">برای صداهای باکیفیت‌تر موتور متن به گفتار Google را نصب کنید.</string>
+    <string name="settings_tts_install_google_button">نصب Google TTS</string>
+    <string name="settings_tts_test">آزمایش صدا</string>
+    <string name="settings_tts_test_in_flight">در حال آزمایش — لطفاً صبر کنید…</string>
+
+    <!-- Settings — units -->
+    <string name="settings_temperature_unit_title">واحد دما</string>
+    <string name="settings_temperature_unit_celsius">سلسیوس (°C)</string>
+    <string name="settings_temperature_unit_fahrenheit">فارنهایت (°F)</string>
+    <string name="settings_distance_unit_title">واحد فاصله</string>
+    <string name="settings_distance_unit_kilometers">کیلومتر</string>
+    <string name="settings_distance_unit_miles">مایل</string>
+
+    <!-- Settings — clothes rules -->
+    <string name="settings_clothes_title">قوانین لباس</string>
+    <string name="settings_clothes_description">اگر پیش‌بینی از یکی از این آستانه‌ها عبور کند، آن لباس در ClothesCast روزانه شما نمایش داده می‌شود.</string>
+    <string name="garment_puffer">کاپشن پفی</string>
+    <string name="garment_thin_jacket">کت نازک</string>
+    <string name="garment_skirt">دامن</string>
+    <string name="garment_polo">پولو</string>
+
+    <!-- Notifications -->
+    <string name="notification_channel_daily_insight_name">ClothesCast روزانه</string>
+    <string name="notification_channel_daily_insight_description">خلاصه آب‌وهوای صبحگاهی که ثبت‌نام کرده‌اید.</string>
+    <string name="notification_daily_insight_title">ClothesCast امروز</string>
+    <string name="notification_channel_tonight_insight_default_name">ClothesCast شبانه (با رویدادها)</string>
+    <string name="notification_channel_tonight_insight_default_description">خلاصه آب‌وهوای عصرگاهی هنگامی که امشب رویدادهای تقویم دارید.</string>
+    <string name="notification_channel_tonight_insight_silent_name">ClothesCast شبانه (ساکت)</string>
+    <string name="notification_channel_tonight_insight_silent_description">خلاصه آب‌وهوای عصرگاهی وقتی عصر شما خالی است. ساکت ارسال می‌شود.</string>
+    <string name="notification_tonight_insight_title">ClothesCast امشب</string>
+    <string name="notification_channel_weather_alerts_name">هشدارهای آب‌وهوای شدید</string>
+    <string name="notification_channel_weather_alerts_description">هشدارهای با اولویت بالا برای رویدادهای آب‌وهوایی شدید یا بحرانی که منطقه شما را تحت تأثیر قرار می‌دهند.</string>
+    <string name="notification_weather_alert_title">هشدار آب‌وهوا: %1$s</string>
+
+    <!-- Settings — notification permission -->
+    <string name="settings_notification_permission_title">اعلان‌ها مسدود شده‌اند</string>
+    <string name="settings_notification_permission_description">بدون مجوز اعلان، ClothesCast روزانه شما جایی برای ارسال ندارد. آن را اعطا کنید تا ClothesCast بتواند فردا صبح پست کند.</string>
+    <string name="settings_notification_permission_grant">اعطای مجوز اعلان</string>
+
+    <!-- Settings — calendar -->
+    <string name="settings_calendar_title">تقویم</string>
+    <string name="settings_calendar_use_events">استفاده از رویدادهای تقویم امروز</string>
+    <string name="settings_calendar_description_off">پیش‌بینی صبحگاهی را بر اساس رویدادهای امروز تنظیم کنید — فقط عناوین و زمان‌ها استفاده می‌شوند و هیچ چیز دستگاه را ترک نمی‌کند.</string>
+    <string name="settings_calendar_description_on">پیش‌بینی صبحگاهی بر اساس رویدادهای امروز تنظیم می‌شود. فقط عناوین و زمان‌ها استفاده می‌شوند؛ هیچ چیز دستگاه را ترک نمی‌کند.</string>
+    <string name="settings_calendar_grant_permission">اعطای مجوز تقویم</string>
+    <string name="settings_calendar_open_settings">مجوز تقویم رد شد. از تنظیمات سیستم آن را اعطا کنید.</string>
+
+    <!-- Settings — about -->
+    <string name="settings_about_title">درباره</string>
+    <string name="settings_about_version">نسخه %1$s (%2$d)</string>
+    <string name="settings_about_build_type_suffix"> · نسخه %1$s</string>
+    <string name="settings_about_source">کد منبع در GitHub</string>
+    <string name="settings_about_dontkillmyapp">محدودیت‌های پس‌زمینه (dontkillmyapp.com)</string>
+    <string name="settings_about_share_bug_report">اشتراک‌گذاری گزارش خطا</string>
+    <string name="settings_about_version_copied">نسخه در کلیپ‌بورد کپی شد</string>
+
+    <!-- Bug report consent dialog -->
+    <string name="bug_report_consent_title">گزارش خطا را به اشتراک می‌گذارید؟</string>
+    <string name="bug_report_consent_body">این به تشخیص مشکلات کمک می‌کند. گزارش حاوی اطلاعات شخصی حساس است، از جمله موقعیت شما، تنظیمات برنامه و فعالیت اخیر. قبل از ارسال می‌توانید آن را بررسی و ویرایش کنید.</string>
+    <string name="bug_report_consent_dont_show_again">دیگر نشان نده</string>
+    <string name="bug_report_consent_continue">ادامه</string>
+    <string name="bug_report_consent_cancel">لغو</string>
+
+    <!-- Insight prose — precipitation and tie-in variants -->
+    <string name="insight_precip_chance">احتمال %1$s %2$s.</string>
+    <string name="insight_tie_in_at_night">%1$s را ببرید.</string>
+    <string name="insight_tie_in_with_rain_chance">%1$s را امشب ببرید، احتمال باران ساعت %2$s.</string>
+    <string name="insight_evening_rain">امشب، باران ساعت %1$s.</string>
+    <string name="insight_evening_rain_chance">امشب، احتمال باران ساعت %1$s.</string>
 </resources>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -579,4 +579,7 @@ displayed label localizes.
     <string name="bug_report_consent_cancel">Peruuta</string>
 
     <string name="error_device_incompatible">ClothesCastia ei voi suorittaa tällä laitteella — Android-koontiversiostasi puuttuu ominaisuus, jota sovelluksen käyttöliittymä tarvitsee (Configuration.fontWeightAdjustment, odotetaan Android 12:sta ylöspäin). Ota yhteyttä laitevalmistajaan järjestelmäpäivitystä varten.</string>
+    <string name="today_forecast_air_section_title">Ilman lämpötila</string>
+    <string name="settings_default_bottom_title">Standardialaosa</string>
+    <string name="settings_default_bottom_description">Mitä suosittelemme kotinäytöllä, kun ei ole tarpeeksi lämmintä shortseja varten.</string>
 </resources>

--- a/app/src/main/res/values-fil/strings.xml
+++ b/app/src/main/res/values-fil/strings.xml
@@ -619,4 +619,7 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="insight_evening_rain">Ngayong gabi, ulan ng %1$s.</string>
     <string name="insight_evening_rain_chance">Ngayong gabi, posibilidad ng ulan ng %1$s.</string>
 
+    <string name="today_forecast_air_section_title">Temperatura ng hangin</string>
+    <string name="settings_default_bottom_title">Karaniwang ibabang damit</string>
+    <string name="settings_default_bottom_description">Kung ano ang aming iminumungkahi sa home screen kapag hindi sapat ang init para sa shorts.</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -696,4 +696,7 @@ zh-CN) is unchanged; only the displayed label localizes.
 
     <!-- Device-incompatibility error screen. -->
     <string name="error_device_incompatible">ClothesCast ne peut pas fonctionner sur cet appareil — ta version d\'Android ne dispose pas d\'une fonctionnalité requise par l\'interface de l\'app (Configuration.fontWeightAdjustment, attendue sur Android 12 et versions ultérieures). Contacte le fabricant de ton appareil pour une mise à jour système.</string>
+    <string name="today_forecast_air_section_title">Température de l\'air</string>
+    <string name="settings_default_bottom_title">Bas standard</string>
+    <string name="settings_default_bottom_description">Ce que nous suggérons sur l\'écran d\'accueil quand il ne fait pas assez chaud pour les shorts.</string>
 </resources>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -599,4 +599,7 @@ Not overridden by design:
 
     <!-- Device-incompatibility error screen. -->
     <string name="error_device_incompatible">ClothesCast इस डिवाइस पर नहीं चल सकता — आपके Android बिल्ड में ऐप UI के लिए ज़रूरी सुविधा (Configuration.fontWeightAdjustment, Android 12 और उससे ऊपर अपेक्षित) मौजूद नहीं है। कृपया सिस्टम अपडेट के लिए अपने डिवाइस निर्माता से संपर्क करें।</string>
+    <string name="today_forecast_air_section_title">हवा का तापमान</string>
+    <string name="settings_default_bottom_title">मानक नीचे का वस्त्र</string>
+    <string name="settings_default_bottom_description">जब शॉर्ट्स के लिए पर्याप्त गर्मी नहीं होती तो होम स्क्रीन पर हम क्या सुझाते हैं।</string>
 </resources>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -665,4 +665,7 @@ spousal register), matching the existing insight prose ("Ponesi …",
 
     <!-- Device-incompatibility error screen. -->
     <string name="error_device_incompatible">ClothesCast ne može raditi na ovom uređaju — tvoja Android verzija nema značajku koju sučelje aplikacije zahtijeva (Configuration.fontWeightAdjustment, očekuje se na Androidu 12 i novijim). Obrati se proizvođaču uređaja za ažuriranje sustava.</string>
+    <string name="today_forecast_air_section_title">Temperatura zraka</string>
+    <string name="settings_default_bottom_title">Standardni donji dio</string>
+    <string name="settings_default_bottom_description">Ono što predlažemo na početnom zaslonu kad nije dovoljno toplo za kratke hlače.</string>
 </resources>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -589,4 +589,7 @@ locale (Angol (Egyesült Államok), Francia (Franciaország), Német
 
     <!-- Device incompatibility error. -->
     <string name="error_device_incompatible">A ClothesCast nem futtatható ezen az eszközön — az Android buildedből hiányzik egy funkció, amelyre az alkalmazás felülete szükséges (Configuration.fontWeightAdjustment, Android 12-től felfelé várható). Kérjük, fordulj az eszköz gyártójához rendszerfrissítésért.</string>
+    <string name="today_forecast_air_section_title">Levegő hőmérséklete</string>
+    <string name="settings_default_bottom_title">Alapértelmezett alsó ruha</string>
+    <string name="settings_default_bottom_description">Amit a főképernyőn javaslunk, ha nem elég meleg a rövidnadrághoz.</string>
 </resources>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -569,4 +569,7 @@ to values/strings.xml (English).
     <string name="bug_report_consent_continue">Lanjutkan</string>
     <string name="bug_report_consent_cancel">Batal</string>
 
+    <string name="today_forecast_air_section_title">Suhu udara</string>
+    <string name="settings_default_bottom_title">Bawahan standar</string>
+    <string name="settings_default_bottom_description">Yang kami sarankan di layar beranda saat tidak cukup panas untuk memakai celana pendek.</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -682,4 +682,7 @@ zh-CN) is unchanged; only the displayed label localizes.
 
     <!-- Device-incompatibility error screen. -->
     <string name="error_device_incompatible">ClothesCast non può essere eseguito su questo dispositivo — la tua versione di Android manca di una funzionalità richiesta dall\'interfaccia dell\'app (Configuration.fontWeightAdjustment, prevista su Android 12 e versioni successive). Contatta il produttore del dispositivo per un aggiornamento di sistema.</string>
+    <string name="today_forecast_air_section_title">Temperatura dell\'aria</string>
+    <string name="settings_default_bottom_title">Fondo standard</string>
+    <string name="settings_default_bottom_description">Cosa consigliamo nella schermata iniziale quando non fa abbastanza caldo per i pantaloncini.</string>
 </resources>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -90,4 +90,366 @@ standard in Israeli digital communication.
     <string name="insight_time_hour">%1$d</string>
     <string name="insight_time_hour_minutes">%1$d:%2$02d</string>
 
+    <string name="today_forecast_air_section_title">טמפרטורת אוויר</string>
+    <string name="settings_default_bottom_title">תחתון סטנדרטי</string>
+    <string name="settings_default_bottom_description">מה שאנחנו מציעים במסך הבית כשלא חם מספיק לשורטס.</string>
+
+    <!-- Error / compatibility -->
+    <string name="error_device_incompatible">ClothesCast לא יכול לפעול במכשיר זה — גרסת Android שלך חסרה תכונה הנדרשת לממשק המשתמש. נא לפנות ליצרן המכשיר לקבלת עדכון מערכת.</string>
+
+    <!-- Today screen -->
+    <string name="today_title">היום</string>
+    <string name="today_open_settings">פתח/י הגדרות</string>
+    <string name="today_more_options">אפשרויות נוספות</string>
+    <string name="today_report_a_bug">דווח/י על תקלה</string>
+    <string name="today_refresh">רענן/י</string>
+    <string name="today_refresh_toast_daily">מרענן את ClothesCast היומי שלך — יופיע בקרוב.</string>
+    <string name="today_refresh_toast_nightly">מרענן את ClothesCast הלילי שלך — יופיע בקרוב.</string>
+    <string name="today_empty_title">אין ClothesCast עדיין</string>
+    <string name="today_empty_subtitle">ClothesCast הבוקר שלך יופיע כאן לאחר שייווצר. הגדר/י את מיקומך בהגדרות, ואז הקש/י על טען עכשיו.</string>
+    <string name="today_fetch_now">טען עכשיו</string>
+    <string name="today_generated_at">נוצר ב-%1$s</string>
+    <string name="today_location_unknown">המיקום שלך</string>
+
+    <!-- Today — outfit card -->
+    <string name="today_outfit_title">מה ללבוש</string>
+    <string name="today_outfit_label_today">היום</string>
+    <string name="today_outfit_label_tonight">הלילה</string>
+    <string name="today_outfit_label_tomorrow">מחר</string>
+    <string name="today_outfit_top_polo">פולו</string>
+    <string name="today_outfit_top_thin_jacket">ז׳קט דק</string>
+    <string name="today_outfit_top_thick_coat">מעיל כבד</string>
+    <string name="today_outfit_top_puffer_jacket">מעיל פוך</string>
+    <string name="today_outfit_bottom_long_skirt">חצאית ארוכה</string>
+    <string name="today_outfit_bottom_jeans">ג׳ינס</string>
+
+    <!-- Today — rationale sheet -->
+    <string name="today_rationale_title">למה הלבוש הזה?</string>
+    <string name="today_rationale_show">למה?</string>
+    <string name="today_rationale_dismiss">הבנתי</string>
+    <string name="today_rationale_threshold_decrease">הורד/י סף ב-1 מעלה</string>
+    <string name="today_rationale_threshold_increase">העלה/י סף ב-1 מעלה</string>
+    <string name="today_rationale_threshold_changed_hint">רענן/י כדי לראות את הלבוש החדש.</string>
+    <string name="today_rationale_unavailable">אין הסבר זמין — פתח/י את האפליקציה לאחר הרענון הבא.</string>
+    <string name="today_rationale_min_below_with_time">מינימום טמפ׳ מורגשת %1$s%2$s בשעה %3$s, מתחת ל-%4$s%2$s</string>
+    <string name="today_rationale_min_below">מינימום טמפ׳ מורגשת %1$s%2$s, מתחת ל-%3$s%2$s</string>
+    <string name="today_rationale_min_above_with_time">מינימום טמפ׳ מורגשת %1$s%2$s בשעה %3$s, לפחות %4$s%2$s</string>
+    <string name="today_rationale_min_above">מינימום טמפ׳ מורגשת %1$s%2$s, לפחות %3$s%2$s</string>
+    <string name="today_rationale_max_below_with_time">מקסימום טמפ׳ מורגשת רק %1$s%2$s בשעה %3$s, מתחת ל-%4$s%2$s</string>
+    <string name="today_rationale_max_below">מקסימום טמפ׳ מורגשת רק %1$s%2$s, מתחת ל-%3$s%2$s</string>
+    <string name="today_rationale_max_above_with_time">מקסימום טמפ׳ מורגשת %1$s%2$s בשעה %3$s, לפחות %4$s%2$s</string>
+    <string name="today_rationale_max_above">מקסימום טמפ׳ מורגשת %1$s%2$s, לפחות %3$s%2$s</string>
+
+    <!-- Widget -->
+    <string name="widget_label">לבוש</string>
+    <string name="widget_description">הלבוש של התקופה הנוכחית במבט מהיר.</string>
+    <string name="widget_empty_title">אין לבוש עדיין</string>
+    <string name="widget_empty_subtitle">הקש/י לפתיחת ClothesCast</string>
+
+    <!-- Today — forecast chart -->
+    <string name="today_forecast_title">טמפרטורה מורגשת</string>
+    <string name="today_forecast_min_max">מרגיש כמו %1$d – %2$d%3$s</string>
+    <string name="today_forecast_legend_feels_like">טמפ׳ מורגשת (%1$s) לפי שעה</string>
+    <string name="today_forecast_air_min_max">אוויר %1$d – %2$d%3$s</string>
+    <string name="today_forecast_legend_air">טמפרטורת אוויר (%1$s) לפי שעה</string>
+
+    <!-- Today — precipitation chart -->
+    <string name="today_precipitation_title">סיכוי לגשם</string>
+    <string name="today_precipitation_peak">שיא %1$d%% בשעה %2$s</string>
+    <string name="today_precipitation_dry">לא צפוי גשם היום</string>
+
+    <!-- Today — model divergence / confidence -->
+    <string name="today_chart_model_legend_label">מודלים:</string>
+    <string name="today_chart_main_line_label">משולב</string>
+    <string name="today_chart_divergence_summary">המודלים חלוקים ביותר בשעה %1$s (Δ %2$.1f%3$s מורגש) — בעיקר %4$s, %5$s</string>
+    <string name="today_factor_air_temperature">טמפרטורת אוויר</string>
+    <string name="today_factor_wind_speed">מהירות רוח</string>
+    <string name="today_factor_cloud_cover">כיסוי ענן</string>
+    <string name="today_factor_humidity">לחות</string>
+
+    <!-- Today — wind / cloud / humidity charts -->
+    <string name="today_wind_title">מהירות רוח</string>
+    <string name="today_wind_subtitle">מהירות רוח (%1$s) לפי מודל ושעה</string>
+    <string name="today_cloud_title">כיסוי ענן</string>
+    <string name="today_cloud_subtitle">כיסוי ענן כולל (%) לפי מודל ושעה</string>
+    <string name="today_humidity_title">לחות</string>
+    <string name="today_humidity_subtitle">לחות יחסית (%) לפי מודל ושעה</string>
+
+    <!-- Today — confidence callout -->
+    <string name="today_confidence_high">אמון גבוה — מודלים עיקריים מסכימים</string>
+    <string name="today_confidence_medium">אמון בינוני</string>
+    <string name="today_confidence_low">אמון נמוך — תחזיות אינן מסכימות</string>
+    <string name="today_confidence_spread">פיזור: %1$.1f°C, %2$.0f%% משקעים על פני %3$d מודלים</string>
+    <string name="today_low_confidence_callout_title">התחזיות חלוקות</string>
+    <string name="today_low_confidence_callout_body">טווח הטמפרטורה משתנה ב-%1$.1f°C וסיכוי לגשם ב-%2$.0f%% על פני %3$d מודלים.</string>
+
+    <!-- Today — loading / error states -->
+    <string name="today_working">עובד/ת — מוריד/ת את ClothesCast שלך…</string>
+    <string name="today_retrying">הניסיון האחרון נכשל — מנסה שוב…</string>
+    <string name="today_failed_title">הניסיון האחרון נכשל</string>
+    <string name="today_failed_unexpected_http">שגיאת HTTP בלתי צפויה משירות התחזית.</string>
+    <string name="today_failed_unhandled">אירעה שגיאה בלתי צפויה.</string>
+    <string name="today_failed_no_location">לא הצלחנו לאתר את מיקומך. הענק/י הרשאת מיקום תמידית, או הגדר/י עיר בהגדרות.</string>
+    <string name="today_failed_show_details">הצג/י פרטים</string>
+    <string name="today_failed_hide_details">הסתר/י פרטים</string>
+
+    <!-- Today — location required -->
+    <string name="today_location_required_title">הגדר/י את מיקומך</string>
+    <string name="today_location_required_body">ClothesCast צריך לדעת היכן אתה/את כדי לאחזר את התחזית. הענק/י הרשאת מיקום תמידית, או בחר/י עיר.</string>
+    <string name="today_location_required_action">פתח/י הגדרות מיקום</string>
+
+    <!-- Today — crash banner -->
+    <string name="today_crash_banner_title">ההרצה האחרונה קרסה</string>
+    <string name="today_crash_banner_body">דוח קריסה נשמר במכשירך. לשתף אותו כדי שהבאג יתוקן? שום דבר לא נשלח עד שתבחר/י יעד.</string>
+    <string name="today_crash_banner_share">שתף/י דוח</string>
+    <string name="today_crash_banner_dismiss">סגור/י</string>
+
+    <!-- Today — update banners -->
+    <string name="today_update_available_title">עדכון זמין</string>
+    <string name="today_update_available_body">גרסה חדשה יותר של ClothesCast זמינה ב-Play Store.</string>
+    <string name="today_update_available_action">עדכן/י</string>
+    <string name="today_update_available_dismiss">לא עכשיו</string>
+    <string name="today_update_downloaded_body">העדכון הורד. הפעל/י מחדש לסיום ההתקנה.</string>
+    <string name="today_update_downloaded_action">הפעל/י מחדש</string>
+
+    <!-- Today — telemetry notice -->
+    <string name="today_telemetry_notice_title">דוחות קריסה ושימוש פועלים</string>
+    <string name="today_telemetry_notice_body">ClothesCast שולח דוחות קריסה אנונימיים וסטטיסטיקות שימוש כדי לסייע בתיקון באגים. אין נתוני לוח שנה, מיקום או טקסט תובנה. כבה/י בכל עת בהגדרות.</string>
+    <string name="today_telemetry_notice_open_settings">פתח/י הגדרות פרטיות</string>
+    <string name="today_telemetry_notice_dismiss">סגור/י</string>
+
+    <!-- Onboarding -->
+    <string name="onboarding_title">ברוך/ה הבא/ה ל-ClothesCast</string>
+    <string name="onboarding_subtitle">שלוש בחירות מהירות ואתה/את מוכן/ה. שנה/י מאוחר יותר בהגדרות.</string>
+    <string name="onboarding_subtitle_tv">שתי בחירות מהירות ואתה/את מוכן/ה. שנה/י מאוחר יותר בהגדרות.</string>
+    <string name="onboarding_notifications_title">התראות</string>
+    <string name="onboarding_notifications_description">נדרש למסירת ClothesCast היומי שלך.</string>
+    <string name="onboarding_notifications_grant">הענק/י הרשאת התראות</string>
+    <string name="onboarding_location_title">מיקום</string>
+    <string name="onboarding_location_description">אחזר/י תחזית עבור מיקומך המשוער.</string>
+    <string name="onboarding_location_grant">הענק/י הרשאת מיקום</string>
+    <string name="onboarding_location_grant_background">הענק/י מיקום תמידי</string>
+    <string name="onboarding_location_background_needed">עוד שלב אחד: ClothesCast זקוק ל\'אפשר בכל עת\' כדי שתחזית הבוקר תוכל לקרוא את מיקומך כשהאפליקציה סגורה.</string>
+    <string name="onboarding_location_denied_hint">הרשאת מיקום נדחתה. תוכל/י לבחור עיר ידנית במקום.</string>
+    <string name="onboarding_location_enter_manual">הזן/י מיקום ידנית</string>
+    <string name="onboarding_location_enter_manual_hint">תוכל/י להזין את מיקומך ידנית אם תדחה/י את הרשאת המיקום או אם מיקום המכשיר שלך שגוי.</string>
+    <string name="onboarding_location_using_device">משתמש/ת במיקום המכשיר שלך בכל בוקר.</string>
+    <string name="onboarding_gemini_title">מפתח Gemini API</string>
+    <string name="onboarding_gemini_description">השתמש/י ב-Gemini לקבלת קולות איכותיים.</string>
+    <string name="onboarding_step_done">סיום</string>
+    <string name="onboarding_skip">דלג/י לעת עתה</string>
+    <string name="onboarding_continue">המשך/י</string>
+    <string name="onboarding_pair_from_phone">צמד/י מהטלפון במקום</string>
+
+    <!-- Pairing (TV) -->
+    <string name="pairing_title">סרוק/י לצימוד</string>
+    <string name="pairing_instructions">סרוק/י את קוד ה-QR הזה עם הטלפון שלך, ואז הדבק/י את מפתח Gemini API שלך בטופס שנפתח. המפתח יישלח ישירות לטלוויזיה זו דרך ה-Wi-Fi הביתי שלך — ללא ממסר ענן.</string>
+    <string name="pairing_qr_description">קוד QR המקשר אל %1$s</string>
+    <string name="pairing_cancel">ביטול</string>
+    <string name="pairing_received">המפתח התקבל — שומר…</string>
+    <string name="pairing_timeout_title">חלון הצימוד פג</string>
+    <string name="pairing_timeout_body">חלון הצימוד של 5 דקות נסגר. הקש/י על נסה שוב לפתיחת חלון חדש.</string>
+    <string name="pairing_error_title">לא ניתן להתחיל צימוד</string>
+    <string name="pairing_error_body">ודא/י שהטלוויזיה מחוברת ל-Wi-Fi, ואז נסה/י שוב.</string>
+    <string name="pairing_retry">נסה/י שוב</string>
+
+    <!-- Settings — root menu -->
+    <string name="settings_title">הגדרות</string>
+    <string name="settings_back">חזור/י</string>
+    <string name="settings_root_voice">קול</string>
+    <string name="settings_root_schedule">לוח זמנים</string>
+    <string name="settings_root_region">אזור</string>
+    <string name="settings_root_clothes">בגדים</string>
+    <string name="settings_root_display">תצוגה</string>
+    <string name="settings_root_location">מיקום</string>
+    <string name="settings_root_calendar">לוח שנה</string>
+    <string name="settings_root_privacy">פרטיות</string>
+    <string name="settings_root_about">אודות</string>
+    <string name="settings_root_schedule_subtitle">התראות וזמנים</string>
+    <string name="settings_root_clothes_subtitle">טמפרטורות ולבוש</string>
+    <string name="settings_root_region_subtitle">שפות ויחידות</string>
+    <string name="settings_root_voice_subtitle">ספקים ומבטאים</string>
+    <string name="settings_root_display_subtitle">ערכת נושא</string>
+    <string name="settings_root_location_subtitle">זיהוי אוטומטי או בחירת עיר</string>
+    <string name="settings_root_calendar_subtitle">אירועי היום</string>
+    <string name="settings_root_privacy_subtitle">דוחות קריסה ושימוש</string>
+
+    <!-- Settings — display -->
+    <string name="settings_display_theme_title">ערכת נושא</string>
+    <string name="settings_display_theme_system">עקוב/י אחר המערכת</string>
+    <string name="settings_display_theme_light">בהיר</string>
+    <string name="settings_display_theme_dark">כהה</string>
+    <string name="settings_display_charts_title">גרפים</string>
+    <string name="settings_display_model_spread_label">הצג/י פיזור מודלים בגרפים</string>
+    <string name="settings_display_model_spread_description">מציג שכבת-על של התחזית השעתית של כל מודל מזג אוויר עיקרי על גרפי הטמפרטורה והגשם. שימושי לזיהוי אי-ודאות בתחזית.</string>
+
+    <!-- Settings — privacy / telemetry -->
+    <string name="settings_privacy_telemetry_title">דוחות קריסה ושימוש</string>
+    <string name="settings_privacy_telemetry_label">שלח/י נתוני קריסה ושימוש</string>
+    <string name="settings_privacy_telemetry_description">שולח דוחות קריסה אנונימיים וסטטיסטיקות שימוש מצטברות כדי לסייע למפתח לתקן באגים ולהחליט אילו תכונות לשמור.</string>
+    <string name="settings_privacy_telemetry_limits">לעולם לא נשלח: אירועי לוח שנה, קואורדינטות מיקום או שמות מקומות, טקסט תובנה או התראות, מפתחות API, GPS מדויק, מזהי פרסום.</string>
+    <string name="settings_privacy_open_policy">קרא/י את מדיניות הפרטיות המלאה</string>
+
+    <!-- Settings — API key -->
+    <string name="settings_api_key_gemini_label">Gemini</string>
+    <string name="settings_api_key_gemini_header">השתמש/י ב-Gemini לקבלת קולות איכותיים.</string>
+    <string name="settings_api_key_status_set">מפתח Gemini מוגדר.</string>
+    <string name="settings_api_key_status_unset">קבל/י מפתח API חינמי ב-aistudio.google.com</string>
+    <string name="settings_api_key_placeholder">הדבק/י את מפתח Gemini API שלך</string>
+    <string name="settings_api_key_save">שמור/י מפתח Gemini</string>
+    <string name="settings_api_key_clear">מחק/י מפתח Gemini שמור</string>
+
+    <!-- Settings — location -->
+    <string name="settings_location_title">מיקום</string>
+    <string name="settings_location_use_device">השתמש/י במיקום המכשיר</string>
+    <string name="settings_location_use_device_description">מיקום משוער אחרון</string>
+    <string name="settings_location_detecting">מזהה…</string>
+    <string name="settings_location_grant_background">הענק/י</string>
+    <string name="settings_location_background_banner_title">נדרש מיקום תמידי</string>
+    <string name="settings_location_background_banner_body">בלעדיו, תחזית הבוקר לא יכולה לקרוא את מיקומך.</string>
+    <string name="settings_location_unset">לא הוגדר מיקום</string>
+    <string name="settings_location_manual_override">מיקום שגוי? הגדר/י ידנית</string>
+    <string name="settings_location_manual_override_disclosure">בחירת עיר מכבה את הזיהוי האוטומטי.</string>
+    <string name="settings_location_clear">נקה/י מיקום</string>
+    <string name="settings_location_search_title">חפש/י מיקום</string>
+    <string name="settings_location_query_label">עיר או מקום</string>
+    <string name="settings_location_search">חפש/י</string>
+    <string name="settings_location_searching">מחפש/ת…</string>
+    <string name="settings_location_no_results">אין תוצאות.</string>
+    <string name="settings_location_rationale_title">גישה למיקום</string>
+    <string name="settings_location_rationale_body">ClothesCast קורא את מיקומך כדי לאחזר את התחזית המקומית שלך.</string>
+    <string name="settings_location_rationale_continue">המשך/י</string>
+    <string name="settings_location_rationale_dismiss">לא עכשיו</string>
+    <string name="settings_location_background_rationale_title">אפשר/י בכל עת</string>
+    <string name="settings_location_background_rationale_body">אפשר/י ל-ClothesCast לקרוא את מיקומך כשהוא סגור כדי שתחזית הבוקר תתעדכן בזמן.</string>
+    <string name="settings_location_background_rationale_continue">פתח/י הגדרות</string>
+    <string name="settings_location_background_rationale_dismiss">לא עכשיו</string>
+    <string name="settings_location_background_denied_title">מיקום תמידי לא הוענק</string>
+    <string name="settings_location_background_denied_body">ללא \'אפשר בכל עת\' תחזית הבוקר לא יכולה להתעדכן אוטומטית.</string>
+    <string name="settings_location_background_denied_open">פתח/י הגדרות</string>
+    <string name="settings_location_background_denied_keep">לא עכשיו</string>
+
+    <!-- Settings — schedule (daily + nightly) -->
+    <string name="settings_schedule_title">ClothesCast יומי</string>
+    <string name="settings_schedule_time_label">שעה</string>
+    <string name="settings_schedule_days_label">ימות השבוע</string>
+    <string name="settings_daily_mention_evening_events">ציין/י אירועי ערב</string>
+    <string name="settings_tonight_title">ClothesCast לילי</string>
+    <string name="settings_tonight_description">ClothesCast שני בערב המכסה את מזג האוויר הלילי. בערבים שקטים נשאר שקט; בערבי אירועים משמיע צליל וקורא את עצמו.</string>
+    <string name="settings_tonight_enabled">הצג/י ClothesCast לילי</string>
+    <string name="settings_tonight_time_label">שעה</string>
+    <string name="settings_tonight_days_label">ימות השבוע</string>
+    <string name="settings_tonight_notify_only_on_events">הודע/י רק כשיש אירועי ערב</string>
+
+    <!-- Settings — delivery / TTS -->
+    <string name="settings_delivery_label">משלוח</string>
+    <string name="settings_delivery_notification_only">התראה בלבד</string>
+    <string name="settings_delivery_tts_only">קריאה בקול בלבד</string>
+    <string name="settings_delivery_notification_and_tts">התראה וקריאה בקול</string>
+    <string name="settings_tts_engine_title">מנוע קול</string>
+    <string name="settings_tts_engine_description">Gemini נשמע טבעי בהרבה מקול המכשיר אך זקוק לחיבור רשת בזמן הדיבור. חוזר לקול המכשיר אם Gemini נכשל.</string>
+    <string name="settings_tts_engine_device">מכשיר (ללא אינטרנט, חינם)</string>
+    <string name="settings_tts_engine_gemini">Gemini (איכות גבוהה, מקוון)</string>
+    <string name="settings_tts_voice_label">קול</string>
+    <string name="settings_tts_voice_dismiss">סיום</string>
+    <string name="settings_tts_style_label">סגנון</string>
+    <string name="settings_tts_style_weather_forecaster">חוזאי מזג אוויר</string>
+    <string name="settings_tts_style_pirate">פיראט</string>
+    <string name="settings_tts_style_cowboy">קאובוי</string>
+    <string name="settings_tts_style_shakespearean">שקספירי</string>
+    <string name="settings_tts_style_surfer">גולש/ת גלים</string>
+    <string name="settings_tts_style_parent">הורה</string>
+    <string name="settings_tts_style_child">ילד/ה</string>
+    <string name="settings_tts_style_teenager">מתבגר/ת</string>
+    <string name="settings_tts_style_grandparent">סבא/סבתא</string>
+    <string name="settings_tts_style_kids_host">מגיש/ת טלוויזיה לילדים</string>
+    <string name="settings_tts_style_radio_host">מגיש/ת תוכנית שיחות</string>
+    <string name="settings_tts_style_morning_dj">DJ בוקר</string>
+    <string name="settings_tts_style_science_teacher">מורה למדעים</string>
+    <string name="settings_tts_style_historian">היסטוריון/ית</string>
+    <string name="settings_tts_style_sportscaster">פרשן/ית ספורט</string>
+    <string name="settings_tts_style_stadium_announcer">כרוז/ת אצטדיון</string>
+    <string name="settings_tts_style_storyteller">מספר/ת סיפורים</string>
+    <string name="settings_tts_style_fitness_instructor">מדריך/ה כושר</string>
+    <string name="settings_tts_style_morning_presenter">מגיש/ת רדיו בוקר</string>
+    <string name="settings_tts_style_custom">מותאם אישית…</string>
+    <string name="settings_tts_style_custom_label">הוראה מותאמת אישית</string>
+    <string name="settings_tts_style_custom_placeholder">לדוגמה: קרא/י את הטקסט הבא כספרן/ית קפדני/ת שלוחש/ת</string>
+    <string name="settings_tts_device_voice_label">קול המכשיר</string>
+    <string name="settings_tts_device_voice_auto">אוטומטי (הטוב ביותר למבטא)</string>
+    <string name="settings_tts_device_voice_currently">כעת: %1$s</string>
+    <string name="settings_tts_device_voice_currently_loading">טוען/ת…</string>
+    <string name="settings_tts_device_voice_network">רשת</string>
+    <string name="settings_tts_device_voice_offline">ללא אינטרנט</string>
+    <string name="settings_tts_install_google_hint">התקן/י את מנוע הטקסט-לדיבור של Google לקולות איכותיים יותר.</string>
+    <string name="settings_tts_install_google_button">התקן/י Google TTS</string>
+    <string name="settings_tts_test">בדוק/י קול</string>
+    <string name="settings_tts_test_in_flight">בודק/ת — אנא המתן/י…</string>
+
+    <!-- Settings — units -->
+    <string name="settings_temperature_unit_title">יחידת טמפרטורה</string>
+    <string name="settings_temperature_unit_celsius">צלזיוס (°C)</string>
+    <string name="settings_temperature_unit_fahrenheit">פרנהייט (°F)</string>
+    <string name="settings_distance_unit_title">יחידת מרחק</string>
+    <string name="settings_distance_unit_kilometers">קילומטרים</string>
+    <string name="settings_distance_unit_miles">מיילים</string>
+
+    <!-- Settings — clothes rules -->
+    <string name="settings_clothes_title">כללי לבוש</string>
+    <string name="settings_clothes_description">אם תחזית חוצה את אחד מהספים הללו, הפריט יופיע ב-ClothesCast היומי שלך.</string>
+
+    <!-- Garment names (additional) -->
+    <string name="garment_puffer">מעיל פוך</string>
+    <string name="garment_thin_jacket">ז׳קט דק</string>
+    <string name="garment_skirt">חצאית</string>
+    <string name="garment_polo">פולו</string>
+
+    <!-- Notification channels -->
+    <string name="notification_channel_daily_insight_name">ClothesCast יומי</string>
+    <string name="notification_channel_daily_insight_description">סיכום מזג האוויר הבוקר שנרשמת אליו.</string>
+    <string name="notification_daily_insight_title">ClothesCast להיום</string>
+    <string name="notification_channel_tonight_insight_default_name">ClothesCast לילי (עם אירועים)</string>
+    <string name="notification_channel_tonight_insight_default_description">סיכום מזג האוויר הערבי כשיש לך אירועי לוח שנה הלילה.</string>
+    <string name="notification_channel_tonight_insight_silent_name">ClothesCast לילי (שקט)</string>
+    <string name="notification_channel_tonight_insight_silent_description">סיכום מזג האוויר הערבי כשהערב שלך ריק. נשלח בשקט.</string>
+    <string name="notification_tonight_insight_title">ClothesCast ללילה</string>
+    <string name="notification_channel_weather_alerts_name">התראות מזג אוויר קיצוני</string>
+    <string name="notification_channel_weather_alerts_description">התראות עדיפות גבוהה לאירועי מזג אוויר קיצוניים המשפיעים על אזורך.</string>
+    <string name="notification_weather_alert_title">התראת מזג אוויר: %1$s</string>
+
+    <!-- Settings — notification permission -->
+    <string name="settings_notification_permission_title">התראות חסומות</string>
+    <string name="settings_notification_permission_description">ללא הרשאת התראות, ל-ClothesCast היומי שלך אין לאן לשלוח. הענק/י אותה כדי ש-ClothesCast יוכל לפרסם מחר בבוקר.</string>
+    <string name="settings_notification_permission_grant">הענק/י הרשאת התראות</string>
+
+    <!-- Settings — calendar -->
+    <string name="settings_calendar_title">לוח שנה</string>
+    <string name="settings_calendar_use_events">השתמש/י באירועי לוח השנה של היום</string>
+    <string name="settings_calendar_description_off">התאם/י את תחזית הבוקר לאירועי היום — נעשה שימוש בכותרות ובזמנים בלבד, ושום דבר לא יוצא מהמכשיר.</string>
+    <string name="settings_calendar_description_on">מתאים את תחזית הבוקר לאירועי היום. נעשה שימוש בכותרות ובזמנים בלבד; שום דבר לא יוצא מהמכשיר.</string>
+    <string name="settings_calendar_grant_permission">הענק/י הרשאת לוח שנה</string>
+    <string name="settings_calendar_open_settings">הרשאת לוח שנה נדחתה. הענק/י אותה מהגדרות המערכת.</string>
+
+    <!-- Settings — about -->
+    <string name="settings_about_title">אודות</string>
+    <string name="settings_about_version">גרסה %1$s (%2$d)</string>
+    <string name="settings_about_build_type_suffix"> · גרסת %1$s</string>
+    <string name="settings_about_source">קוד מקור ב-GitHub</string>
+    <string name="settings_about_dontkillmyapp">הגבלות רקע (dontkillmyapp.com)</string>
+    <string name="settings_about_share_bug_report">שתף/י דוח תקלה</string>
+    <string name="settings_about_version_copied">הגרסה הועתקה ללוח</string>
+
+    <!-- Bug report consent dialog -->
+    <string name="bug_report_consent_title">לשתף דוח תקלה?</string>
+    <string name="bug_report_consent_body">זה עוזר לאבחן בעיות. הדוח מכיל מידע אישי רגיש, כולל מיקומך, הגדרות האפליקציה ופעילות אחרונה. תוכל/י לסקור ולערוך לפני השליחה.</string>
+    <string name="bug_report_consent_dont_show_again">אל תציג/י שוב</string>
+    <string name="bug_report_consent_continue">המשך/י</string>
+    <string name="bug_report_consent_cancel">ביטול</string>
+
+    <!-- Insight prose templates (additional) -->
+    <string name="insight_precip_chance">סיכוי ל%1$s %2$s.</string>
+    <string name="insight_tie_in_at_night">קח/י %1$s.</string>
+    <string name="insight_tie_in_with_rain_chance">קח/י %1$s הלילה, סיכוי לגשם בשעה %2$s.</string>
+    <string name="insight_evening_rain">הלילה, גשם בשעה %1$s.</string>
+    <string name="insight_evening_rain_chance">הלילה, סיכוי לגשם בשעה %1$s.</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -703,4 +703,7 @@ the displayed label localizes.
 
     <!-- Device-incompatibility error screen. -->
     <string name="error_device_incompatible">この端末では ClothesCast を実行できません — お使いの Android ビルドに、アプリの UI に必要な機能（Configuration.fontWeightAdjustment、Android 12 以降で利用可能）がありません。システムアップデートについては端末メーカーにお問い合わせください。</string>
+    <string name="today_forecast_air_section_title">気温</string>
+    <string name="settings_default_bottom_title">標準ボトム</string>
+    <string name="settings_default_bottom_description">ショートパンツには寒すぎる時に、ホーム画面でおすすめするもの。</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -707,4 +707,7 @@ displayed label localizes.
 
     <!-- Device-incompatibility error screen. -->
     <string name="error_device_incompatible">이 기기에서는 ClothesCast를 실행할 수 없습니다 — Android 빌드에 앱 UI가 필요한 기능(Configuration.fontWeightAdjustment, Android 12 이상에서 지원)이 없습니다. 시스템 업데이트는 기기 제조사에 문의하세요.</string>
+    <string name="today_forecast_air_section_title">기온</string>
+    <string name="settings_default_bottom_title">기본 하의</string>
+    <string name="settings_default_bottom_description">반바지를 입기에 충분히 따뜻하지 않을 때 홈 화면에서 추천하는 것.</string>
 </resources>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -113,7 +113,7 @@ What is NOT overridden, by design:
     <string name="today_outfit_top_thin_jacket">Plona striukė</string>
     <string name="today_outfit_top_thick_coat">Storas paltas</string>
     <string name="today_outfit_top_puffer_jacket">Pūkinė striukė</string>
-    <string name="today_outfit_bottom_skirt">Sijonas</string>
+    <string name="today_outfit_bottom_long_skirt">Sijonas</string>
     <string name="today_outfit_bottom_jeans">Džinsai</string>
 
     <!-- Rationale dialog. -->
@@ -588,4 +588,7 @@ What is NOT overridden, by design:
     <string name="insight_evening_rain">Šįvakar lietus %1$s val.</string>
     <string name="insight_evening_rain_chance">Šįvakar gali lyti %1$s val.</string>
 
+    <string name="today_forecast_air_section_title">Oro temperatūra</string>
+    <string name="settings_default_bottom_title">Standartinė apatinė dalis</string>
+    <string name="settings_default_bottom_description">Ką siūlome pagrindiniame ekrane, kai per šalta šortams.</string>
 </resources>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -52,7 +52,7 @@ informal "tu"-form throughout ("Apģērb …", "Paņem … līdzi").
     <string name="today_outfit_top_thin_jacket">Plāna jaka</string>
     <string name="today_outfit_top_thick_coat">Biezs mētelis</string>
     <string name="today_outfit_top_puffer_jacket">Pūķa jaka</string>
-    <string name="today_outfit_bottom_skirt">Svārki</string>
+    <string name="today_outfit_bottom_long_skirt">Svārki</string>
     <string name="today_outfit_bottom_jeans">Džinsi</string>
 
     <string name="insight_lead_today">Šodien</string>
@@ -541,4 +541,7 @@ informal "tu"-form throughout ("Apģērb …", "Paņem … līdzi").
     <string name="bug_report_consent_continue">Turpināt</string>
     <string name="bug_report_consent_cancel">Atcelt</string>
 
+    <string name="today_forecast_air_section_title">Gaisa temperatūra</string>
+    <string name="settings_default_bottom_title">Standarta apakšdaļa</string>
+    <string name="settings_default_bottom_description">Ko iesakām sākuma ekrānā, kad nav pietiekami silts šortiem.</string>
 </resources>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -575,4 +575,7 @@ vs "kemungkinan", "padam" vs "hapus").
     <string name="insight_evening_rain">Malam ini, hujan pada pukul %1$s.</string>
     <string name="insight_evening_rain_chance">Malam ini, kemungkinan hujan pada pukul %1$s.</string>
 
+    <string name="today_forecast_air_section_title">Suhu udara</string>
+    <string name="settings_default_bottom_title">Bawahan standard</string>
+    <string name="settings_default_bottom_description">Yang kami cadangkan pada skrin utama apabila tidak cukup panas untuk seluar pendek.</string>
 </resources>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -598,4 +598,7 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrike)").
 
     <!-- Device-incompatibility error screen. -->
     <string name="error_device_incompatible">ClothesCast kan ikke kjøres på denne enheten — Android-bygget ditt mangler en funksjon som appgrensesnittet krever (Configuration.fontWeightAdjustment, forventet fra Android 12 og oppover). Kontakt enhetsprodusenten din for en systemoppdatering.</string>
+    <string name="today_forecast_air_section_title">Lufttemperatur</string>
+    <string name="settings_default_bottom_title">Standard underdel</string>
+    <string name="settings_default_bottom_description">Hva vi foreslår på startskjermen når det ikke er varmt nok for shorts.</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -645,4 +645,7 @@ the displayed label localizes.
 
     <!-- Device-incompatibility error screen. -->
     <string name="error_device_incompatible">ClothesCast kan niet worden uitgevoerd op dit apparaat — je Android-build mist een functie die de app-interface nodig heeft (Configuration.fontWeightAdjustment, verwacht vanaf Android 12 en hoger). Neem contact op met je apparaatfabrikant voor een systeemupdate.</string>
+    <string name="today_forecast_air_section_title">Luchttemperatuur</string>
+    <string name="settings_default_bottom_title">Standaard onderstuk</string>
+    <string name="settings_default_bottom_description">Wat we op het beginscherm voorstellen als het niet warm genoeg is voor shorts.</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -643,4 +643,7 @@ is unchanged; only the displayed label localizes.
 
     <!-- Device-incompatibility error screen. -->
     <string name="error_device_incompatible">ClothesCast nie może działać na tym urządzeniu — Twoja kompilacja Androida nie ma funkcji wymaganej przez interfejs aplikacji (Configuration.fontWeightAdjustment, oczekiwana od Androida 12 wzwyż). Skontaktuj się z producentem urządzenia w sprawie aktualizacji systemu.</string>
+    <string name="today_forecast_air_section_title">Temperatura powietrza</string>
+    <string name="settings_default_bottom_title">Standardowy dół</string>
+    <string name="settings_default_bottom_description">To, co proponujemy na ekranie głównym, gdy jest za zimno na szorty.</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -603,7 +603,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="today_outfit_top_thin_jacket">Jaqueta leve</string>
     <string name="today_outfit_top_thick_coat">Casaco grosso</string>
     <string name="today_outfit_top_puffer_jacket">Jaqueta de plumas</string>
-    <string name="today_outfit_bottom_skirt">Saia</string>
+    <string name="today_outfit_bottom_long_skirt">Saia</string>
     <string name="today_outfit_bottom_jeans">Jeans</string>
 
     <string name="error_device_incompatible">O ClothesCast não pode funcionar neste aparelho — seu build do Android não tem um recurso exigido pela interface do app (Configuration.fontWeightAdjustment, esperado no Android 12 ou superior). Contate o fabricante do seu aparelho para obter uma atualização do sistema.</string>
@@ -684,4 +684,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_tts_style_custom">Personalizado…</string>
     <string name="settings_tts_style_custom_label">Diretriz personalizada</string>
     <string name="settings_tts_style_custom_placeholder">ex.: Leia o seguinte como um bibliotecário severo sussurrando</string>
+    <string name="today_forecast_air_section_title">Temperatura do ar</string>
+    <string name="settings_default_bottom_title">Parte inferior padrão</string>
+    <string name="settings_default_bottom_description">O que sugerimos na tela inicial quando não está quente o suficiente para shorts.</string>
 </resources>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -645,7 +645,7 @@ they diverge from BR ("Polonês" → "Polaco", "Holandês" →
     <string name="today_outfit_top_thin_jacket">Casaco leve</string>
     <string name="today_outfit_top_thick_coat">Casacão</string>
     <string name="today_outfit_top_puffer_jacket">Casaco de penas</string>
-    <string name="today_outfit_bottom_skirt">Saia</string>
+    <string name="today_outfit_bottom_long_skirt">Saia</string>
     <string name="today_outfit_bottom_jeans">Calças de ganga</string>
 
     <string name="error_device_incompatible">O ClothesCast não pode funcionar neste dispositivo — o teu build do Android não tem uma funcionalidade exigida pela interface da aplicação (Configuration.fontWeightAdjustment, esperada no Android 12 ou superior). Contacta o fabricante do teu dispositivo para obteres uma atualização do sistema.</string>
@@ -726,4 +726,7 @@ they diverge from BR ("Polonês" → "Polaco", "Holandês" →
     <string name="settings_tts_style_custom">Personalizado…</string>
     <string name="settings_tts_style_custom_label">Diretriz personalizada</string>
     <string name="settings_tts_style_custom_placeholder">ex.: Lê o seguinte como um bibliotecário severo a sussurrar</string>
+    <string name="today_forecast_air_section_title">Temperatura do ar</string>
+    <string name="settings_default_bottom_title">Parte inferior padrão</string>
+    <string name="settings_default_bottom_description">O que sugerimos no ecrã inicial quando não está quente o suficiente para calções.</string>
 </resources>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -113,7 +113,7 @@ surfaces fall back to default English (matching values-pl / values-uk).
     <string name="today_outfit_top_thin_jacket">Geacă ușoară</string>
     <string name="today_outfit_top_thick_coat">Palton gros</string>
     <string name="today_outfit_top_puffer_jacket">Geacă matlasată</string>
-    <string name="today_outfit_bottom_skirt">Fustă</string>
+    <string name="today_outfit_bottom_long_skirt">Fustă</string>
     <string name="today_outfit_bottom_jeans">Blugi</string>
 
     <!-- Rationale dialog. -->
@@ -572,4 +572,7 @@ surfaces fall back to default English (matching values-pl / values-uk).
     <string name="bug_report_consent_continue">Continuă</string>
     <string name="bug_report_consent_cancel">Anulează</string>
 
+    <string name="today_forecast_air_section_title">Temperatura aerului</string>
+    <string name="settings_default_bottom_title">Jos standard</string>
+    <string name="settings_default_bottom_description">Ceea ce sugerăm pe ecranul de start când nu este suficient de cald pentru pantaloni scurți.</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -654,4 +654,7 @@ only the displayed label localizes.
     <!-- "15" — preposition "в" comes from surrounding templates. -->
     <string name="insight_time_hour">%1$d</string>
     <string name="insight_time_hour_minutes">%1$d:%2$02d</string>
+    <string name="today_forecast_air_section_title">Температура воздуха</string>
+    <string name="settings_default_bottom_title">Стандартный низ</string>
+    <string name="settings_default_bottom_description">То, что мы предлагаем на главном экране, когда недостаточно тепло для шортов.</string>
 </resources>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -397,7 +397,7 @@ What is NOT overridden, by design:
     <string name="today_outfit_top_puffer_jacket">Páperová bunda</string>
     <string name="today_outfit_bottom_shorts">Šortky</string>
     <string name="today_outfit_bottom_long_pants">Nohavice</string>
-    <string name="today_outfit_bottom_skirt">Sukňa</string>
+    <string name="today_outfit_bottom_long_skirt">Sukňa</string>
     <string name="today_outfit_bottom_jeans">Rifle</string>
 
     <string name="today_forecast_title">Hodinová predpoveď</string>
@@ -600,4 +600,7 @@ What is NOT overridden, by design:
 
     <!-- Device-incompatibility error screen. -->
     <string name="error_device_incompatible">ClothesCast nemôže bežať na tomto zariadení — tvoja zostava Androidu nemá funkciu, ktorú vyžaduje rozhranie aplikácie (Configuration.fontWeightAdjustment, očakávaná od Androidu 12 vyššie). Kontaktuj prosím výrobcu zariadenia ohľadom aktualizácie systému.</string>
+    <string name="today_forecast_air_section_title">Teplota vzduchu</string>
+    <string name="settings_default_bottom_title">Štandardná spodná časť</string>
+    <string name="settings_default_bottom_description">Čo odporúčame na domovskej obrazovke, keď nie je dosť teplo na šortky.</string>
 </resources>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -115,7 +115,7 @@ informal "ti"-form throughout, mirroring the Croatian / Serbian pass.
     <string name="today_outfit_top_thin_jacket">Lahka jakna</string>
     <string name="today_outfit_top_thick_coat">Debel plašč</string>
     <string name="today_outfit_top_puffer_jacket">Puhovka</string>
-    <string name="today_outfit_bottom_skirt">Krilo</string>
+    <string name="today_outfit_bottom_long_skirt">Krilo</string>
     <string name="today_outfit_bottom_jeans">Kavbojke</string>
 
     <!-- Garment dropdown — additional items. -->
@@ -581,4 +581,7 @@ informal "ti"-form throughout, mirroring the Croatian / Serbian pass.
     <string name="bug_report_consent_continue">Nadaljuj</string>
     <string name="bug_report_consent_cancel">Prekliči</string>
 
+    <string name="today_forecast_air_section_title">Temperatura zraka</string>
+    <string name="settings_default_bottom_title">Standardni spodnji del</string>
+    <string name="settings_default_bottom_description">Kar predlagamo na začetnem zaslonu, ko ni dovolj toplo za kratke hlače.</string>
 </resources>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -598,4 +598,7 @@ native names for all locales (e.g. "Tyska (Tyskland)", "Franska (Frankrike)").
 
     <!-- Device-incompatibility error screen. -->
     <string name="error_device_incompatible">ClothesCast kan inte köras på den här enheten — din Android-bygge saknar en funktion som appgränssnittet behöver (Configuration.fontWeightAdjustment, förväntas från Android 12 och uppåt). Kontakta din enhetstillverkare för en systemuppdatering.</string>
+    <string name="today_forecast_air_section_title">Lufttemperatur</string>
+    <string name="settings_default_bottom_title">Standard underdel</string>
+    <string name="settings_default_bottom_description">Vad vi föreslår på startskärmen när det inte är varmt nog för shorts.</string>
 </resources>

--- a/app/src/main/res/values-sw/strings.xml
+++ b/app/src/main/res/values-sw/strings.xml
@@ -81,4 +81,350 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="insight_time_hour">%1$d</string>
     <string name="insight_time_hour_minutes">%1$d:%2$02d</string>
 
+    <string name="today_forecast_air_section_title">Joto la hewa</string>
+    <string name="settings_default_bottom_title">Suruali ya chini ya kawaida</string>
+    <string name="settings_default_bottom_description">Tunachopendekeza kwenye skrini ya nyumbani wakati si joto la kutosha kwa suruali fupi.</string>
+
+    <!-- Error / compatibility -->
+    <string name="error_device_incompatible">ClothesCast haiwezi kufanya kazi kwenye kifaa hiki — muundo wako wa Android unakosa kipengele kinachohitajika. Tafadhali wasiliana na mtengenezaji wa kifaa chako kwa sasisho la mfumo.</string>
+
+    <!-- Today screen -->
+    <string name="today_title">Leo</string>
+    <string name="today_open_settings">Fungua Mipangilio</string>
+    <string name="today_more_options">Chaguo zaidi</string>
+    <string name="today_report_a_bug">Ripoti hitilafu</string>
+    <string name="today_refresh">Onyesha upya</string>
+    <string name="today_refresh_toast_daily">Inasasisha ClothesCast yako ya kila siku — itaonekana hivi karibuni.</string>
+    <string name="today_refresh_toast_nightly">Inasasisha ClothesCast yako ya usiku — itaonekana hivi karibuni.</string>
+    <string name="today_empty_title">Hakuna ClothesCast bado</string>
+    <string name="today_empty_subtitle">ClothesCast yako ya asubuhi itaonekana hapa baada ya kuundwa. Weka mahali pako katika Mipangilio, kisha gonga Pakua sasa.</string>
+    <string name="today_fetch_now">Pakua sasa</string>
+    <string name="today_generated_at">Imetayarishwa saa %1$s</string>
+    <string name="today_location_unknown">Mahali pako</string>
+    <string name="today_outfit_title">Vaa nini</string>
+    <string name="today_outfit_label_today">Leo</string>
+    <string name="today_outfit_label_tonight">Usiku huu</string>
+    <string name="today_outfit_label_tomorrow">Kesho</string>
+    <string name="today_outfit_top_polo">Polo</string>
+    <string name="today_outfit_top_thin_jacket">Jaketi nyepesi</string>
+    <string name="today_outfit_top_thick_coat">Koti nzito</string>
+    <string name="today_outfit_top_puffer_jacket">Jaketi ya pamba</string>
+    <string name="today_outfit_bottom_long_skirt">Sketi ndefu</string>
+    <string name="today_outfit_bottom_jeans">Jins</string>
+
+    <!-- Today rationale -->
+    <string name="today_rationale_title">Kwa nini mavazi haya?</string>
+    <string name="today_rationale_show">Kwa nini?</string>
+    <string name="today_rationale_dismiss">Sawa</string>
+    <string name="today_rationale_threshold_decrease">Punguza kiwango kwa digrii 1</string>
+    <string name="today_rationale_threshold_increase">Ongeza kiwango kwa digrii 1</string>
+    <string name="today_rationale_threshold_changed_hint">Onyesha upya ili kuona mavazi mapya.</string>
+    <string name="today_rationale_unavailable">Hakuna maelezo — fungua programu baada ya kusasisha ijayo.</string>
+    <string name="today_rationale_min_below_with_time">Kiwango cha chini kinachohisi %1$s%2$s saa %3$s, chini ya %4$s%2$s</string>
+    <string name="today_rationale_min_below">Kiwango cha chini kinachohisi %1$s%2$s, chini ya %3$s%2$s</string>
+    <string name="today_rationale_min_above_with_time">Kiwango cha chini kinachohisi %1$s%2$s saa %3$s, angalau %4$s%2$s</string>
+    <string name="today_rationale_min_above">Kiwango cha chini kinachohisi %1$s%2$s, angalau %3$s%2$s</string>
+    <string name="today_rationale_max_below_with_time">Kiwango cha juu kinachohisi %1$s%2$s tu saa %3$s, chini ya %4$s%2$s</string>
+    <string name="today_rationale_max_below">Kiwango cha juu kinachohisi %1$s%2$s tu, chini ya %3$s%2$s</string>
+    <string name="today_rationale_max_above_with_time">Kiwango cha juu kinachohisi %1$s%2$s saa %3$s, angalau %4$s%2$s</string>
+    <string name="today_rationale_max_above">Kiwango cha juu kinachohisi %1$s%2$s, angalau %3$s%2$s</string>
+
+    <!-- Widget -->
+    <string name="widget_label">Mavazi</string>
+    <string name="widget_description">Mavazi ya kipindi cha sasa kwa muhtasari.</string>
+    <string name="widget_empty_title">Hakuna mavazi bado</string>
+    <string name="widget_empty_subtitle">Gonga ili kufungua ClothesCast</string>
+
+    <!-- Today forecast / charts -->
+    <string name="today_forecast_title">Joto linalohisi</string>
+    <string name="today_forecast_min_max">Inahisi kama %1$d – %2$d%3$s</string>
+    <string name="today_forecast_legend_feels_like">Joto linalohisi (%1$s) kwa saa</string>
+    <string name="today_forecast_air_min_max">Hewa %1$d – %2$d%3$s</string>
+    <string name="today_forecast_legend_air">Joto la hewa (%1$s) kwa saa</string>
+    <string name="today_precipitation_title">Uwezekano wa mvua</string>
+    <string name="today_precipitation_peak">Kilele %1$d%% saa %2$s</string>
+    <string name="today_precipitation_dry">Hakuna mvua inayotarajiwa leo</string>
+    <string name="today_chart_model_legend_label">Mifano:</string>
+    <string name="today_chart_main_line_label">Mchanganyiko</string>
+    <string name="today_chart_divergence_summary">Mifano inayotofautiana zaidi saa %1$s (Δ %2$.1f%3$s inayohisi) — hasa %4$s, %5$s</string>
+    <string name="today_factor_air_temperature">joto la hewa</string>
+    <string name="today_factor_wind_speed">kasi ya upepo</string>
+    <string name="today_factor_cloud_cover">mawingu</string>
+    <string name="today_factor_humidity">unyevu</string>
+    <string name="today_wind_title">Kasi ya upepo</string>
+    <string name="today_wind_subtitle">Kasi ya upepo (%1$s) kwa mfano na saa</string>
+    <string name="today_cloud_title">Mawingu</string>
+    <string name="today_cloud_subtitle">Mawingu yote (%) kwa mfano na saa</string>
+    <string name="today_humidity_title">Unyevu</string>
+    <string name="today_humidity_subtitle">Unyevu wa jamaa (%) kwa mfano na saa</string>
+    <string name="today_confidence_high">Imani ya juu — mifano mikubwa inakubaliana</string>
+    <string name="today_confidence_medium">Imani ya kati</string>
+    <string name="today_confidence_low">Imani ya chini — utabiri hutofautiana</string>
+    <string name="today_confidence_spread">Tofauti: %1$.1f°C, %2$.0f%% mvua kwenye mifano %3$d</string>
+    <string name="today_low_confidence_callout_title">Utabiri hutofautiana</string>
+    <string name="today_low_confidence_callout_body">Halijoto inatofautiana kwa %1$.1f°C na uwezekano wa mvua kwa %2$.0f%% kwenye mifano %3$d.</string>
+
+    <!-- Today status / errors -->
+    <string name="today_working">Inafanya kazi — inashuka ClothesCast yako…</string>
+    <string name="today_retrying">Jaribio la mwisho lilishindwa — inajaribu tena…</string>
+    <string name="today_failed_title">Jaribio la mwisho lilishindwa</string>
+    <string name="today_failed_unexpected_http">Hitilafu ya HTTP isiyotarajiwa kutoka huduma ya utabiri.</string>
+    <string name="today_failed_unhandled">Hitilafu isiyotarajiwa imetokea.</string>
+    <string name="today_failed_no_location">Hatukuweza kupata mahali pako. Toa ruhusa ya mahali daima, au weka mji katika Mipangilio.</string>
+    <string name="today_failed_show_details">Onyesha maelezo</string>
+    <string name="today_failed_hide_details">Ficha maelezo</string>
+    <string name="today_location_required_title">Weka mahali pako</string>
+    <string name="today_location_required_body">ClothesCast inahitaji kujua uko wapi ili kupata utabiri. Toa ruhusa ya mahali daima, au chagua mji.</string>
+    <string name="today_location_required_action">Fungua mipangilio ya mahali</string>
+
+    <!-- Today banners -->
+    <string name="today_crash_banner_title">Mwisho uliharibika</string>
+    <string name="today_crash_banner_body">Ripoti ya hitilafu imehifadhiwa kwenye kifaa chako. Shiriki ili hitilafu irekebishwe? Hakuna kinachotumwa hadi uchague wapi.</string>
+    <string name="today_crash_banner_share">Shiriki ripoti</string>
+    <string name="today_crash_banner_dismiss">Ondoa</string>
+    <string name="today_update_available_title">Sasisho linapatikana</string>
+    <string name="today_update_available_body">Toleo jipya la ClothesCast lipo kwenye Play Store.</string>
+    <string name="today_update_available_action">Sasisha</string>
+    <string name="today_update_available_dismiss">Si sasa</string>
+    <string name="today_update_downloaded_body">Sasisho limepakuliwa. Anzisha upya ili kumaliza usakinishaji.</string>
+    <string name="today_update_downloaded_action">Anzisha upya</string>
+    <string name="today_telemetry_notice_title">Ripoti za hitilafu na matumizi zimewashwa</string>
+    <string name="today_telemetry_notice_body">ClothesCast inatuma ripoti za hitilafu zisizo na jina na takwimu za matumizi kusaidia kurekebisha hitilafu. Hakuna data ya kalenda, mahali, au maandishi ya ufahamu yanayojumuishwa. Izime wakati wowote katika Mipangilio.</string>
+    <string name="today_telemetry_notice_open_settings">Fungua Mipangilio ya Faragha</string>
+    <string name="today_telemetry_notice_dismiss">Ondoa</string>
+
+    <!-- Onboarding -->
+    <string name="onboarding_title">Karibu ClothesCast</string>
+    <string name="onboarding_subtitle">Chaguo tatu za haraka na uko tayari. Rekebisha baadaye katika Mipangilio.</string>
+    <string name="onboarding_subtitle_tv">Chaguo mbili za haraka na uko tayari. Rekebisha baadaye katika Mipangilio.</string>
+    <string name="onboarding_notifications_title">Arifa</string>
+    <string name="onboarding_notifications_description">Inahitajika kutoa ClothesCast yako ya kila siku.</string>
+    <string name="onboarding_notifications_grant">Toa ruhusa ya arifa</string>
+    <string name="onboarding_location_title">Mahali</string>
+    <string name="onboarding_location_description">Pakua utabiri wa mahali pako pa takriban.</string>
+    <string name="onboarding_location_grant">Toa ruhusa ya mahali</string>
+    <string name="onboarding_location_grant_background">Toa ruhusa ya mahali daima</string>
+    <string name="onboarding_location_background_needed">Hatua moja zaidi: ClothesCast inahitaji \'Ruhusu wakati wote\' ili utabiri wa asubuhi uweze kusoma mahali pako programu inapofungwa.</string>
+    <string name="onboarding_location_denied_hint">Ruhusa ya mahali imekataliwa. Unaweza kuchagua mji wewe mwenyewe.</string>
+    <string name="onboarding_location_enter_manual">Ingiza mahali wewe mwenyewe</string>
+    <string name="onboarding_location_enter_manual_hint">Unaweza kuingiza mahali pako wewe mwenyewe ikiwa utakataa ruhusa ya mahali au mahali pa kifaa chako si sahihi.</string>
+    <string name="onboarding_location_using_device">Inatumia mahali pa kifaa chako kila asubuhi.</string>
+    <string name="onboarding_gemini_title">Ufunguo wa Gemini API</string>
+    <string name="onboarding_gemini_description">Tumia Gemini kupata sauti za ubora wa juu.</string>
+    <string name="onboarding_step_done">Imekamilika</string>
+    <string name="onboarding_skip">Ruka kwa sasa</string>
+    <string name="onboarding_continue">Endelea</string>
+    <string name="onboarding_pair_from_phone">Unganisha kutoka simu badala yake</string>
+
+    <!-- TV pairing -->
+    <string name="pairing_title">Scan ili kuunganisha</string>
+    <string name="pairing_instructions">Scan msimbo huu wa QR kwa simu yako, kisha bandika ufunguo wako wa Gemini API kwenye fomu inayofunguka. Ufunguo utapelekwa moja kwa moja kwenye TV hii kupitia Wi-Fi yako ya nyumbani — hakuna relay ya wingu.</string>
+    <string name="pairing_qr_description">Msimbo wa QR unaounganisha kwenye %1$s</string>
+    <string name="pairing_cancel">Ghairi</string>
+    <string name="pairing_received">Ufunguo umepokelewa — unuhifadhi…</string>
+    <string name="pairing_timeout_title">Dirisha la kuunganisha limeisha</string>
+    <string name="pairing_timeout_body">Dirisha la kuunganisha la dakika 5 limefungwa. Gonga Jaribu tena kufungua jipya.</string>
+    <string name="pairing_error_title">Haikuweza kuanza kuunganisha</string>
+    <string name="pairing_error_body">Hakikisha TV imeunganishwa na Wi-Fi, kisha jaribu tena.</string>
+    <string name="pairing_retry">Jaribu tena</string>
+
+    <!-- Settings root -->
+    <string name="settings_title">Mipangilio</string>
+    <string name="settings_back">Rudi</string>
+    <string name="settings_root_voice">Sauti</string>
+    <string name="settings_root_schedule">Ratiba</string>
+    <string name="settings_root_region">Eneo</string>
+    <string name="settings_root_clothes">Mavazi</string>
+    <string name="settings_root_display">Onyesho</string>
+    <string name="settings_root_location">Mahali</string>
+    <string name="settings_root_calendar">Kalenda</string>
+    <string name="settings_root_privacy">Faragha</string>
+    <string name="settings_root_about">Kuhusu</string>
+    <string name="settings_root_schedule_subtitle">Arifa na Nyakati</string>
+    <string name="settings_root_clothes_subtitle">Halijoto na Mavazi</string>
+    <string name="settings_root_region_subtitle">Lugha na Vitengo</string>
+    <string name="settings_root_voice_subtitle">Watoa huduma na Lafudhi</string>
+    <string name="settings_root_display_subtitle">Mandhari</string>
+
+    <!-- Settings: display -->
+    <string name="settings_display_theme_title">Mandhari</string>
+    <string name="settings_display_theme_system">Fuata mfumo</string>
+    <string name="settings_display_theme_light">Mwanga</string>
+    <string name="settings_display_theme_dark">Giza</string>
+    <string name="settings_display_charts_title">Chati</string>
+    <string name="settings_display_model_spread_label">Onyesha usambazaji wa mifano kwenye chati</string>
+    <string name="settings_display_model_spread_description">Inaweka tabaka mstari wa kila mfano mkubwa wa hali ya hewa kwenye chati za halijoto na mvua. Muhimu kwa kutambua wakati utabiri hauna uhakika.</string>
+
+    <!-- Settings: location -->
+    <string name="settings_root_location_subtitle">Gundua kiotomatiki au chagua mji</string>
+    <string name="settings_location_title">Mahali</string>
+    <string name="settings_location_use_device">Tumia mahali pa kifaa</string>
+    <string name="settings_location_use_device_description">Mahali pa mwisho pa takriban</string>
+    <string name="settings_location_detecting">Inagundua…</string>
+    <string name="settings_location_grant_background">Toa ruhusa</string>
+    <string name="settings_location_background_banner_title">Ruhusa ya mahali daima inahitajika</string>
+    <string name="settings_location_background_banner_body">Bila hiyo, utabiri wa asubuhi hauwezi kusoma mahali pako.</string>
+    <string name="settings_location_unset">Hakuna mahali palipoaandaliwa</string>
+    <string name="settings_location_manual_override">Mahali si sahihi? Weka wewe mwenyewe</string>
+    <string name="settings_location_manual_override_disclosure">Kuchagua mji kunazima utambuzi wa kiotomatiki.</string>
+    <string name="settings_location_clear">Futa mahali</string>
+    <string name="settings_location_search_title">Tafuta mahali</string>
+    <string name="settings_location_query_label">Mji au mahali</string>
+    <string name="settings_location_search">Tafuta</string>
+    <string name="settings_location_searching">Inatafuta…</string>
+    <string name="settings_location_no_results">Hakuna matokeo.</string>
+    <string name="settings_location_rationale_title">Upatikanaji wa mahali</string>
+    <string name="settings_location_rationale_body">ClothesCast inasoma mahali pako ili kupata utabiri wako wa karibu.</string>
+    <string name="settings_location_rationale_continue">Endelea</string>
+    <string name="settings_location_rationale_dismiss">Si sasa</string>
+    <string name="settings_location_background_rationale_title">Ruhusu wakati wote</string>
+    <string name="settings_location_background_rationale_body">Ruhusu ClothesCast kusoma mahali pako programu ikifungwa ili utabiri wa asubuhi usasishwe kwa wakati.</string>
+    <string name="settings_location_background_rationale_continue">Fungua Mipangilio</string>
+    <string name="settings_location_background_rationale_dismiss">Si sasa</string>
+    <string name="settings_location_background_denied_title">Ruhusa ya daima haikutolewa</string>
+    <string name="settings_location_background_denied_body">Bila \'Ruhusu wakati wote\' utabiri wa asubuhi hauwezi kusasishwa kiotomatiki.</string>
+    <string name="settings_location_background_denied_open">Fungua Mipangilio</string>
+    <string name="settings_location_background_denied_keep">Si sasa</string>
+
+    <!-- Settings: schedule -->
+    <string name="settings_schedule_title">ClothesCast ya kila siku</string>
+    <string name="settings_schedule_time_label">Wakati</string>
+    <string name="settings_schedule_days_label">Siku za wiki</string>
+    <string name="settings_daily_mention_evening_events">Taja matukio ya jioni</string>
+    <string name="settings_tonight_title">ClothesCast ya usiku</string>
+    <string name="settings_tonight_description">ClothesCast ya pili jioni inayoshughulikia hali ya hewa ya usiku huu. Jioni tulivu inabaki kimya; jioni za matukio inacheza sauti na kusoma yenyewe.</string>
+    <string name="settings_tonight_enabled">Onyesha ClothesCast ya usiku</string>
+    <string name="settings_tonight_time_label">Wakati</string>
+    <string name="settings_tonight_days_label">Siku za wiki</string>
+    <string name="settings_tonight_notify_only_on_events">Arifa tu kunapokuwa na matukio ya jioni</string>
+    <string name="settings_delivery_label">Utoaji</string>
+    <string name="settings_delivery_notification_only">Arifa peke yake</string>
+    <string name="settings_delivery_tts_only">Kusomwa kwa sauti peke yake</string>
+    <string name="settings_delivery_notification_and_tts">Arifa na kusomwa kwa sauti</string>
+
+    <!-- Settings: TTS / voice -->
+    <string name="settings_tts_engine_title">Injini ya sauti</string>
+    <string name="settings_tts_engine_description">Gemini inasikika asili zaidi kuliko sauti ya kifaa lakini inahitaji simu ya mtandao wakati wa kusema. Inarudi kwa sauti ya kifaa ikiwa Gemini itashindwa.</string>
+    <string name="settings_tts_engine_device">Kifaa (bila mtandao, bure)</string>
+    <string name="settings_tts_engine_gemini">Gemini (ubora wa juu, mtandaoni)</string>
+    <string name="settings_tts_voice_label">Sauti</string>
+    <string name="settings_tts_voice_dismiss">Imekamilika</string>
+    <string name="settings_tts_style_label">Mtindo</string>
+    <string name="settings_tts_style_weather_forecaster">Mtabiri wa hali ya hewa</string>
+    <string name="settings_tts_style_pirate">Maharamia</string>
+    <string name="settings_tts_style_cowboy">Mchungaji</string>
+    <string name="settings_tts_style_shakespearean">Kisekspiya</string>
+    <string name="settings_tts_style_surfer">Mpanda mawimbi</string>
+    <string name="settings_tts_style_parent">Mzazi</string>
+    <string name="settings_tts_style_child">Mtoto</string>
+    <string name="settings_tts_style_teenager">Kijana</string>
+    <string name="settings_tts_style_grandparent">Babu/Nyanya</string>
+    <string name="settings_tts_style_kids_host">Mwenyeji wa TV ya watoto</string>
+    <string name="settings_tts_style_radio_host">Mwenyeji wa mazungumzo</string>
+    <string name="settings_tts_style_morning_dj">DJ wa asubuhi</string>
+    <string name="settings_tts_style_science_teacher">Mwalimu wa sayansi</string>
+    <string name="settings_tts_style_historian">Mwanahistoria</string>
+    <string name="settings_tts_style_sportscaster">Mtangazaji wa michezo</string>
+    <string name="settings_tts_style_stadium_announcer">Mtangazaji wa uwanja</string>
+    <string name="settings_tts_style_storyteller">Msimulizi</string>
+    <string name="settings_tts_style_fitness_instructor">Mwalimu wa mazoezi</string>
+    <string name="settings_tts_style_morning_presenter">Mwasilishaji wa redio ya asubuhi</string>
+    <string name="settings_tts_style_custom">Maalum…</string>
+    <string name="settings_tts_style_custom_label">Agizo maalum</string>
+    <string name="settings_tts_style_custom_placeholder">mf. Soma yafuatayo kama maktabani mkali anayenong\'ona</string>
+    <string name="settings_tts_device_voice_label">Sauti ya kifaa</string>
+    <string name="settings_tts_device_voice_auto">Kiotomatiki (bora kwa lafudhi)</string>
+    <string name="settings_tts_device_voice_currently">Sasa hivi: %1$s</string>
+    <string name="settings_tts_device_voice_currently_loading">Inapakia…</string>
+    <string name="settings_tts_device_voice_network">Mtandao</string>
+    <string name="settings_tts_device_voice_offline">Bila mtandao</string>
+    <string name="settings_tts_install_google_hint">Sakinisha injini ya maandishi-kwa-sauti ya Google kwa sauti za ubora wa juu.</string>
+    <string name="settings_tts_install_google_button">Sakinisha Google TTS</string>
+    <string name="settings_tts_test">Jaribu sauti</string>
+    <string name="settings_tts_test_in_flight">Inajaribu — tafadhali subiri…</string>
+
+    <!-- Settings: region / units -->
+    <string name="settings_temperature_unit_title">Kitengo cha halijoto</string>
+    <string name="settings_temperature_unit_celsius">Celsius (°C)</string>
+    <string name="settings_temperature_unit_fahrenheit">Fahrenheit (°F)</string>
+    <string name="settings_distance_unit_title">Kitengo cha umbali</string>
+    <string name="settings_distance_unit_kilometers">Kilomita</string>
+    <string name="settings_distance_unit_miles">Maili</string>
+
+    <!-- Settings: clothes -->
+    <string name="settings_clothes_title">Sheria za mavazi</string>
+    <string name="settings_clothes_description">Ikiwa utabiri utavuka moja ya vizingiti hivi, kipengee kitaonekana katika ClothesCast yako ya kila siku.</string>
+
+    <!-- Garment names (additional) -->
+    <string name="garment_puffer">Jaketi ya pamba</string>
+    <string name="garment_thin_jacket">Jaketi nyepesi</string>
+    <string name="garment_skirt">Sketi</string>
+    <string name="garment_polo">Polo</string>
+
+    <!-- Notification channels -->
+    <string name="notification_channel_daily_insight_name">ClothesCast ya kila siku</string>
+    <string name="notification_channel_daily_insight_description">Muhtasari wa hali ya hewa ya asubuhi uliojiunga.</string>
+    <string name="notification_daily_insight_title">ClothesCast ya Leo</string>
+    <string name="notification_channel_tonight_insight_default_name">ClothesCast ya usiku (na matukio)</string>
+    <string name="notification_channel_tonight_insight_default_description">Muhtasari wa hali ya hewa ya jioni unapokuwa na matukio ya kalenda usiku huu.</string>
+    <string name="notification_channel_tonight_insight_silent_name">ClothesCast ya usiku (kimya)</string>
+    <string name="notification_channel_tonight_insight_silent_description">Muhtasari wa hali ya hewa ya jioni jioni yako ikiwa tulivu. Imetumwa kimya.</string>
+    <string name="notification_tonight_insight_title">ClothesCast ya Usiku Huu</string>
+    <string name="notification_channel_weather_alerts_name">Arifa za hali mbaya ya hewa</string>
+    <string name="notification_channel_weather_alerts_description">Arifa za kipaumbele cha juu kwa matukio ya hali mbaya au ya hatari ya hewa yanayoathiri eneo lako.</string>
+    <string name="notification_weather_alert_title">Arifa ya hali ya hewa: %1$s</string>
+
+    <!-- Settings: notifications permission -->
+    <string name="settings_notification_permission_title">Arifa zimezuiwa</string>
+    <string name="settings_notification_permission_description">Bila ruhusa ya arifa, ClothesCast yako ya kila siku haina mahali pa kwenda. Itoe ili ClothesCast iweze kutuma kesho asubuhi.</string>
+    <string name="settings_notification_permission_grant">Toa ruhusa ya arifa</string>
+
+    <!-- Settings: calendar -->
+    <string name="settings_root_calendar_subtitle">Matukio ya leo</string>
+    <string name="settings_calendar_title">Kalenda</string>
+    <string name="settings_calendar_use_events">Tumia matukio ya kalenda ya leo</string>
+    <string name="settings_calendar_description_off">Rekebisha utabiri wa asubuhi kulingana na matukio ya leo — vichwa vya habari na nyakati peke yake ndivyo vinavyotumika, na hakuna kinachoacha kifaa.</string>
+    <string name="settings_calendar_description_on">Inayorekebisha utabiri wa asubuhi kulingana na matukio ya leo. Vichwa vya habari na nyakati peke yake ndivyo vinavyotumika; hakuna kinachoacha kifaa.</string>
+    <string name="settings_calendar_grant_permission">Toa ruhusa ya kalenda</string>
+    <string name="settings_calendar_open_settings">Ruhusa ya kalenda imekataliwa. Itoe kutoka Mipangilio ya mfumo.</string>
+
+    <!-- Settings: privacy / telemetry -->
+    <string name="settings_root_privacy_subtitle">Ripoti za hitilafu na matumizi</string>
+    <string name="settings_privacy_telemetry_title">Ripoti za hitilafu na matumizi</string>
+    <string name="settings_privacy_telemetry_label">Tuma data ya hitilafu na matumizi</string>
+    <string name="settings_privacy_telemetry_description">Inatuma ripoti za hitilafu zisizo na jina na takwimu za matumizi kusaidia msanidi programu kurekebisha hitilafu.</string>
+    <string name="settings_privacy_telemetry_limits">Kamwe hazitumwi: matukio ya kalenda, kuratibu za mahali au majina ya maeneo, maandishi ya ufahamu au arifa, funguo za API, GPS sahihi, vitambulisho vya matangazo.</string>
+    <string name="settings_privacy_open_policy">Soma sera kamili ya faragha</string>
+
+    <!-- Settings: API key -->
+    <string name="settings_api_key_gemini_label">Gemini</string>
+    <string name="settings_api_key_gemini_header">Tumia Gemini kupata sauti za ubora wa juu.</string>
+    <string name="settings_api_key_status_set">Ufunguo wa Gemini umewekwa.</string>
+    <string name="settings_api_key_status_unset">Pata ufunguo wa API bure kwenye aistudio.google.com</string>
+    <string name="settings_api_key_placeholder">Bandika ufunguo wako wa Gemini API</string>
+    <string name="settings_api_key_save">Hifadhi ufunguo wa Gemini</string>
+    <string name="settings_api_key_clear">Futa ufunguo uliohifadhiwa wa Gemini</string>
+
+    <!-- Settings: about -->
+    <string name="settings_about_title">Kuhusu</string>
+    <string name="settings_about_version">Toleo %1$s (%2$d)</string>
+    <string name="settings_about_build_type_suffix"> · muundo wa %1$s</string>
+    <string name="settings_about_source">Msimbo chanzo kwenye GitHub</string>
+    <string name="settings_about_dontkillmyapp">Vizuizi vya mandharinyuma (dontkillmyapp.com)</string>
+    <string name="settings_about_share_bug_report">Shiriki ripoti ya hitilafu</string>
+    <string name="settings_about_version_copied">Toleo limenakiliwa kwenye ubao wa kunakili</string>
+
+    <!-- Bug report consent -->
+    <string name="bug_report_consent_title">Shiriki ripoti ya hitilafu?</string>
+    <string name="bug_report_consent_body">Hii husaidia kutambua matatizo. Ripoti ina taarifa za kibinafsi nyeti, ikiwa ni pamoja na mahali pako, mipangilio ya programu, na shughuli za hivi karibuni. Utaweza kukagua na kuhariri kabla ya kutuma.</string>
+    <string name="bug_report_consent_dont_show_again">Usionyeshe tena</string>
+    <string name="bug_report_consent_continue">Endelea</string>
+    <string name="bug_report_consent_cancel">Ghairi</string>
+
+    <!-- Insight: precipitation / tie-in templates (new variants) -->
+    <string name="insight_precip_chance">Uwezekano wa %1$s %2$s.</string>
+    <string name="insight_tie_in_at_night">Chukua %1$s.</string>
+    <string name="insight_tie_in_with_rain_chance">Usiku huu, uwezekano wa mvua saa %2$s, chukua %1$s.</string>
+    <string name="insight_evening_rain">Usiku huu, mvua saa %1$s.</string>
+    <string name="insight_evening_rain_chance">Usiku huu, uwezekano wa mvua saa %1$s.</string>
 </resources>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -569,4 +569,7 @@ The rest of the UI falls through to values/strings.xml (English).
     <!-- Device incompatibility error -->
     <string name="error_device_incompatible">ClothesCast ไม่สามารถทำงานบนอุปกรณ์นี้ได้ — Android build ของคุณขาดฟีเจอร์ที่ UI ของแอปต้องการ (Configuration.fontWeightAdjustment ที่คาดว่าจะมีใน Android 12 และสูงกว่า) กรุณาติดต่อผู้ผลิตอุปกรณ์ของคุณเพื่อขอการอัปเดตระบบ</string>
 
+    <string name="today_forecast_air_section_title">อุณหภูมิอากาศ</string>
+    <string name="settings_default_bottom_title">ท่อนล่างมาตรฐาน</string>
+    <string name="settings_default_bottom_description">สิ่งที่เราแนะนำบนหน้าจอหลักเมื่ออากาศไม่อบอุ่นพอที่จะใส่กางเกงขาสั้น</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -578,4 +578,7 @@ displayed label localizes.
     <string name="bug_report_consent_cancel">İptal</string>
 
     <string name="error_device_incompatible">ClothesCast bu cihazda çalıştırılamıyor — Android derlemeniz, uygulamanın kullanıcı arayüzünün ihtiyaç duyduğu bir özelliği eksik (Configuration.fontWeightAdjustment, Android 12 ve üzeri bekleniyor). Sistem güncellemesi için cihaz üreticinize başvurun.</string>
+    <string name="today_forecast_air_section_title">Hava sıcaklığı</string>
+    <string name="settings_default_bottom_title">Standart alt giysi</string>
+    <string name="settings_default_bottom_description">Şort için yeterince sıcak olmadığında ana ekranda önerdiğimiz şey.</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -402,7 +402,7 @@ only the displayed label localizes.
     <string name="today_outfit_top_thick_coat">Тепле пальто</string>
     <string name="today_outfit_top_puffer_jacket">Пуховик</string>
     <string name="today_outfit_bottom_shorts">Шорти</string>
-    <string name="today_outfit_bottom_skirt">Спідниця</string>
+    <string name="today_outfit_bottom_long_skirt">Спідниця</string>
     <string name="today_outfit_bottom_jeans">Джинси</string>
     <string name="today_outfit_bottom_long_pants">Штани</string>
 
@@ -597,4 +597,7 @@ only the displayed label localizes.
     <string name="insight_time_hour">%1$d</string>
     <string name="insight_time_hour_minutes">%1$d:%2$02d</string>
 
+    <string name="today_forecast_air_section_title">Температура повітря</string>
+    <string name="settings_default_bottom_title">Стандартний низ</string>
+    <string name="settings_default_bottom_description">Те, що ми пропонуємо на головному екрані, коли недостатньо тепло для шортів.</string>
 </resources>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -630,4 +630,7 @@ Skipped intentionally: app_name (brand), insight_time_am/pm/midnight/noon
     <string name="insight_evening_rain">Tối nay, mưa lúc %1$s.</string>
     <string name="insight_evening_rain_chance">Tối nay, có thể mưa lúc %1$s.</string>
 
+    <string name="today_forecast_air_section_title">Nhiệt độ không khí</string>
+    <string name="settings_default_bottom_title">Quần/váy tiêu chuẩn</string>
+    <string name="settings_default_bottom_description">Những gì chúng tôi đề xuất trên màn hình chính khi không đủ ấm để mặc quần short.</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -695,4 +695,7 @@ label localizes.
 
     <!-- Device-incompatibility error screen. -->
     <string name="error_device_incompatible">ClothesCast 无法在此设备上运行 — 你的 Android 版本缺少应用界面所需的功能（Configuration.fontWeightAdjustment，需 Android 12 及以上）。请联系设备制造商进行系统更新。</string>
+    <string name="today_forecast_air_section_title">气温</string>
+    <string name="settings_default_bottom_title">默认下装</string>
+    <string name="settings_default_bottom_description">当天气不够暖和、不适合穿短裤时，主屏幕显示的建议。</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -711,4 +711,7 @@ label localises.
 
     <!-- Device-incompatibility error screen. -->
     <string name="error_device_incompatible">ClothesCast 無法在此裝置上執行 — 你的 Android 版本缺少應用程式介面所需的功能（Configuration.fontWeightAdjustment，需 Android 12 以上）。請聯絡裝置製造商進行系統更新。</string>
+    <string name="today_forecast_air_section_title">氣溫</string>
+    <string name="settings_default_bottom_title">預設下身</string>
+    <string name="settings_default_bottom_description">當天氣不夠暖和、不適合穿短褲時，主畫面顯示的建議。</string>
 </resources>


### PR DESCRIPTION
## Summary

Three translation gaps fixed across all 44 locale files:

**Gap 1 — 3 new strings now in all 44 locales** (were missing from every locale):
- `today_forecast_air_section_title` — "Air temperature" chart section header
- `settings_default_bottom_title` / `settings_default_bottom_description` — Standard bottom setting screen

**Gap 2 — renamed key propagated to 13 locales**:
- `today_outfit_bottom_skirt` → `today_outfit_bottom_long_skirt` in bg, ca, el, et, lt, lv, pt-BR, pt-PT, ro, sk, sl, sr-Latn, uk (key was renamed in the default but these locales still had the old name)

**Gap 3 — full UI translation for 5 stub locales** (were at ~10% coverage):
- Amharic (am), Arabic (ar), Persian/Farsi (fa), Swahili (sw), Hebrew (iw) — all complete in this commit

Each stub locale now covers: onboarding, all settings screens, notifications, widget, rationale dialog, forecast charts, confidence callouts, crash/update/telemetry banners, TV pairing, and the newer insight-prose variants (`precip_chance`, `tie_in_at_night`, `tie_in_with_rain_chance`, `evening_rain`, `evening_rain_chance`).

Also fixes unescaped apostrophes in `today_forecast_air_section_title` for fr, it, and ca (AAPT2 requires `\'` inside string values).

## Test plan

- [ ] Build `:app:assembleDebug` — AAPT2 validates all XML string resources at compile time
- [ ] Spot-check RTL locales (ar, fa, iw) render correctly on a device/emulator with RTL layout
- [ ] Verify no duplicate string keys introduced (each file parses as valid XML)

https://claude.ai/code/session_01W6ZVUW1MCMaULfGdBriz9u