### PR TITLE
Refresh chart lines when per-model values update mid-day

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/today/ForecastChart.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/ForecastChart.kt
@@ -134,7 +134,12 @@ fun ForecastChart(
         if (showFeelsLike) { h -> h.feelsLikeC } else { h -> h.temperatureC }
 
     val producer = remember { CartesianChartModelProducer() }
-    LaunchedEffect(hourly, temperatureUnit, showFeelsLike, visibleModels) {
+    // Key on [overlays] (the underlying map) rather than [visibleModels] (just
+    // the ID list) so a refresh that updates per-model values while keeping
+    // the same model IDs still re-emits the series. [showModelSpread] is
+    // included separately so flipping the toggle on/off re-fires the effect
+    // even when [overlays] hasn't changed.
+    LaunchedEffect(hourly, temperatureUnit, showFeelsLike, overlays, showModelSpread) {
         producer.runTransaction {
             lineSeries {
                 // Overlays first so they render *under* the main blended line.

--- a/app/src/main/kotlin/app/clothescast/ui/today/PrecipitationChart.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/PrecipitationChart.kt
@@ -59,7 +59,12 @@ fun PrecipitationChart(
     val mainLineColor = MaterialTheme.colorScheme.primary
 
     val producer = remember { CartesianChartModelProducer() }
-    LaunchedEffect(hourly, visibleModels) {
+    // Key on [overlays] (the underlying map) rather than [visibleModels] (just
+    // the ID list) so a refresh that updates per-model values while keeping
+    // the same model IDs still re-emits the series. [showModelSpread] is
+    // included separately so flipping the toggle on/off re-fires the effect
+    // even when [overlays] hasn't changed.
+    LaunchedEffect(hourly, overlays, showModelSpread) {
         producer.runTransaction {
             lineSeries {
                 // Overlays first so they render under the blended main line.


### PR DESCRIPTION
## Summary

Follow-up to #433. After that PR's refactor, the temperature and precipitation charts' `LaunchedEffect` was keyed on `visibleModels` — just the list of model IDs. When a refresh delivered the same set of consulted models with updated per-model values (e.g. the morning worker landing a fresher run), the effect didn't re-fire and the chart kept rendering the previous run's overlay lines. The y-axis (correctly keyed on `overlays` directly) had already moved to fit the new envelope, so the stale lines could sit at the wrong height relative to the axis until something else triggered a recomposition.

Surfaced by [Codex's review of #433](https://github.com/mikelward/clothescast/pull/433#discussion_r3241452944).

The fix: key the effect on `overlays` (the underlying `Map<String, List<PerModelHour>>`) plus `showModelSpread` instead.

- `overlays` covers data-only refreshes: a new payload with the same model IDs but different values has a different map, so the effect re-fires.
- `showModelSpread` covers the toggle: when `overlays` is unchanged but the user taps the card, the effect still re-fires to emit (or stop emitting) the per-model series.

Replaces the derived `visibleModels` key, which depended on both inputs but lost data-change sensitivity once it was reduced to an ID list.

## Test plan

- [ ] CI: `JVM unit tests` (snapshots should be byte-identical — this is a key-set change, no rendering change).
- [ ] CI: `Android debug build`.
- [ ] Manual: leave the Today screen open across a worker run (or trigger a manual refresh). With the overlay toggled on, the per-model lines should redraw to match the new payload, not the previous run's values.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KkDZ7evR4Z5TPVYPPnAKuu)_