### PR TITLE
Send aggregate settings, clothes-rule, and refresh-outcome analytics

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,6 +1,6 @@
 # Privacy Policy
 
-_Last updated: 2026-05-12_
+_Last updated: 2026-05-14_
 
 ClothesCast is a daily weather-insight app for Android. This policy
 describes what data the app handles, where it goes, and what control you
@@ -210,6 +210,42 @@ What's sent:
   Powered-off / airplane-mode misses simply don't appear in the
   stream — the event only fires when a notification is actually
   posted, so unfired alarms aren't reported.
+- **Daily refresh outcomes:** when the scheduled fetch + insight + notify
+  pipeline reaches a terminal result, one event carries the slot
+  (`today` / `tonight`), an outcome bucket (`success`, `forecast_error`,
+  `no_location`, `cancelled`, or `other_error`), and the wall-clock
+  latency from worker start to terminal result in milliseconds. No
+  forecast content, no insight prose, no location coordinates, no error
+  messages. Used to spot regressions in delivery reliability ("what
+  percentage of scheduled refreshes actually completed today?").
+  WorkManager retries between transient failures (no connectivity, 5xx
+  from upstream) aren't reported individually — only the terminal
+  outcome the user actually sees.
+- **Settings snapshot:** once per app process start, and again each time
+  the user changes a non-voice setting later in the same process, one
+  event carries the resolved values: unit settings (auto vs. explicit
+  choice + the unit in effect), delivery mode for the daily and
+  tonight slots, theme mode, colour palette, the default-bottom
+  fallback choice, the four schedule booleans (tonight enabled,
+  notify-only-on-events, daily-mention-evening-events, use-calendar-
+  events), the day-of-week counts for daily and tonight schedules
+  (1..7), and the schedule times bucketed to the hour ("00".."23").
+  No exact local time, no calendar content, no location, no insight
+  prose. The launch-time emission is intentional — it samples the
+  population's default behaviour without requiring the user to
+  interact, so reports can answer "which features do users actually
+  configure and which defaults serve them best?"
+- **Clothes-rule customisation snapshot:** same cadence as the settings
+  snapshot — once per app process start, then again whenever the user
+  edits their clothes rules in the same process. One event carries:
+  the count of catalog defaults the user has changed (the four
+  `sweater` / `jacket` / `coat` / `shorts` rules); the count of extra
+  rules added beyond the catalog defaults; a sorted comma-joined list
+  of which catalog categories were customised; an `all_defaults` flag;
+  and per-category integer Celsius deltas from the default threshold,
+  clamped to ±5°C (so e.g. moving the jacket threshold from 12°C down
+  to 10°C reports `-2`). No raw thresholds, no user-added rule items,
+  no precipitation thresholds.
 
 What's **not** sent — these are hard limits, not "best-effort":
 
@@ -253,6 +289,19 @@ email the address listed on the Play Store listing.
 
 ## Changelog
 
+- **2026-05-14** — Added three new aggregate analytics events:
+  `daily_refresh` (slot + outcome bucket + latency, one per terminal
+  result of the scheduled fetch + notify pipeline; WorkManager retries
+  between transient failures aren't individually reported),
+  `settings_snapshot` (the resolved values of the non-voice user
+  settings — units, delivery mode, theme / palette / default-bottom,
+  the four schedule booleans, day counts, and schedule times bucketed
+  to the hour), and `clothes_rules_snapshot` (counts of customised
+  defaults and extra rules, sorted list of customised categories, plus
+  per-category integer Celsius delta from the default threshold,
+  clamped to ±5°C). No raw thresholds, no exact local times, no
+  calendar / location / insight content; same hard limits in
+  "Analytics and crash reporting" apply.
 - **2026-05-12** — Added two new aggregate analytics events: per-request
   API-call outcomes (endpoint identifier, HTTP status, outcome bucket,
   latency) for Open-Meteo and Gemini, and notification-delivery delay

--- a/app/src/main/kotlin/app/clothescast/data/SettingsRepository.kt
+++ b/app/src/main/kotlin/app/clothescast/data/SettingsRepository.kt
@@ -28,7 +28,9 @@ import app.clothescast.core.domain.model.UserPreferences
 import app.clothescast.core.domain.model.VoiceLocale
 import app.clothescast.core.domain.model.thresholdC
 import app.clothescast.core.domain.model.withThresholdC
+import app.clothescast.diag.ClothesRulesSnapshot
 import app.clothescast.diag.SettingsAnalyticsSnapshot
+import app.clothescast.diag.SettingsSnapshot
 import app.clothescast.tts.resolve
 import app.clothescast.tts.toJavaLocale
 import kotlinx.coroutines.flow.Flow
@@ -70,6 +72,22 @@ class SettingsRepository(
      * resolves a default.
      */
     val analyticsSnapshot: Flow<SettingsAnalyticsSnapshot> = dataStore.data.map { it.toAnalyticsSnapshot() }
+
+    /**
+     * Non-voice user settings flattened for the Firebase Analytics
+     * `settings_snapshot` event. Driven by the resolved [UserPreferences] so
+     * the bucketed time-of-day and effective unit values reflect what the
+     * user actually sees, not the raw DataStore key.
+     */
+    val settingsSnapshot: Flow<SettingsSnapshot> = preferences.map { it.toSettingsSnapshot() }
+
+    /**
+     * Clothes-rule customisation flattened for the Firebase Analytics
+     * `clothes_rules_snapshot` event. Per-category deltas are integer °C
+     * differences from [ClothesRule.DEFAULTS], clamped to ±5°C.
+     */
+    val clothesRulesSnapshot: Flow<ClothesRulesSnapshot> =
+        preferences.map { ClothesRulesSnapshot.from(it.clothesRules) }
 
     /**
      * The available-version code the user has dismissed the in-app update
@@ -464,6 +482,33 @@ class SettingsRepository(
             deviceVoiceEffective = resolved.deviceVoice ?: SettingsAnalyticsSnapshot.AUTO,
         )
     }
+
+    /**
+     * Flattens [UserPreferences] into the [SettingsSnapshot] shape Firebase
+     * Analytics consumes as event params. Effective-value-only (the
+     * default-vs-override distinction lives in [SettingsAnalyticsSnapshot] for
+     * the voice / region settings, which is where it matters for SYSTEM
+     * sentinels); schedule times are hour-bucketed.
+     */
+    private fun UserPreferences.toSettingsSnapshot(): SettingsSnapshot = SettingsSnapshot(
+        temperatureUnitSetting = temperatureUnitSetting.name,
+        temperatureUnitEffective = temperatureUnit.name,
+        distanceUnitSetting = distanceUnitSetting.name,
+        distanceUnitEffective = distanceUnit.name,
+        deliveryModeDaily = deliveryMode.name,
+        deliveryModeTonight = tonightDeliveryMode.name,
+        themeMode = themeMode.name,
+        colorPalette = colorPalette.name,
+        defaultBottom = defaultBottom.name,
+        dailyTimeBucketHour = schedule.time.hour.toString().padStart(2, '0'),
+        dailyDaysCount = schedule.days.size,
+        tonightEnabled = tonightEnabled,
+        tonightTimeBucketHour = tonightSchedule.time.hour.toString().padStart(2, '0'),
+        tonightDaysCount = tonightSchedule.days.size,
+        tonightNotifyOnlyOnEvents = tonightNotifyOnlyOnEvents,
+        dailyMentionEveningEvents = dailyMentionEveningEvents,
+        useCalendarEvents = useCalendarEvents,
+    )
 
     private fun parseLocation(prefs: Preferences): Location? {
         val lat = prefs[LOCATION_LAT] ?: return null

--- a/app/src/main/kotlin/app/clothescast/diag/ClothesRulesSnapshot.kt
+++ b/app/src/main/kotlin/app/clothescast/diag/ClothesRulesSnapshot.kt
@@ -1,0 +1,94 @@
+package app.clothescast.diag
+
+import app.clothescast.core.domain.model.ClothesRule
+import app.clothescast.core.domain.model.thresholdC
+import kotlin.math.roundToInt
+
+/**
+ * Aggregate-analytics view of the user's clothes-rule customisation, intended
+ * as the params of a Firebase Analytics `clothes_rules_snapshot` event.
+ *
+ * Per-category delta is the integer Celsius difference from the catalog's
+ * default threshold ([ClothesRule.DEFAULTS]), clamped to ±[DELTA_CLAMP_C]°C
+ * and prefixed with sign — `"0"`, `"+1"`, `"-3"`, `"+5+"` (saturated above
+ * the clamp), `"-5-"` (saturated below). Categories the user has deleted
+ * from their list report [MISSING].
+ *
+ * No raw thresholds and no per-rule values — just the delta bucket relative
+ * to default, so the analytics stream stays aggregate per the PRIVACY.md
+ * "aggregate counts only" line.
+ */
+data class ClothesRulesSnapshot(
+    val customisedCount: Int,
+    val extraRulesCount: Int,
+    val categoriesCustomised: String,
+    val allDefaults: Boolean,
+    val sweaterDeltaC: String,
+    val jacketDeltaC: String,
+    val coatDeltaC: String,
+    val shortsDeltaC: String,
+) {
+    companion object {
+        const val MISSING = "MISSING"
+
+        /** Largest absolute integer Celsius delta reported verbatim; beyond this saturates. */
+        const val DELTA_CLAMP_C: Int = 5
+
+        /** Firebase Analytics caps event-param strings at 100 chars; this stays well clear. */
+        private const val CATEGORIES_MAX_LEN = 36
+
+        /**
+         * Builds a snapshot from the user's current rule list against the catalog
+         * defaults. The default-category set is [ClothesRule.DEFAULTS] keyed by
+         * `item` — extra rules in [rules] beyond the defaults bump
+         * [extraRulesCount] but don't appear individually.
+         */
+        fun from(rules: List<ClothesRule>): ClothesRulesSnapshot {
+            val defaults = ClothesRule.DEFAULTS.associateBy { it.item }
+            val byItem = rules.associateBy { it.item }
+            val perCategory: Map<String, String> = defaults.mapValues { (item, defaultRule) ->
+                val userRule = byItem[item]
+                if (userRule == null) MISSING else deltaBucket(userRule, defaultRule)
+            }
+            val customisedKeys = perCategory.entries
+                .filter { it.value != "0" }
+                .map { it.key }
+                .sorted()
+            val extras = rules.count { it.item !in defaults }
+            return ClothesRulesSnapshot(
+                customisedCount = customisedKeys.size,
+                extraRulesCount = extras,
+                categoriesCustomised = customisedKeys.joinToString(",").takeCategories(),
+                allDefaults = customisedKeys.isEmpty() && extras == 0,
+                sweaterDeltaC = perCategory["sweater"] ?: MISSING,
+                jacketDeltaC = perCategory["jacket"] ?: MISSING,
+                coatDeltaC = perCategory["coat"] ?: MISSING,
+                shortsDeltaC = perCategory["shorts"] ?: MISSING,
+            )
+        }
+
+        /**
+         * Integer °C delta of [userRule] from [defaultRule], formatted as a signed
+         * bucket. Non-temperature rules (precipitation) and type-mismatch cases
+         * report `"0"` only when both thresholds are absent — otherwise the bucket
+         * reflects whichever side has a temperature. Default rules in the current
+         * catalog are all temperature, so the type-mismatch arm is defensive.
+         */
+        private fun deltaBucket(userRule: ClothesRule, defaultRule: ClothesRule): String {
+            val userC = userRule.thresholdC()
+            val defaultC = defaultRule.thresholdC() ?: return if (userC == null) "0" else MISSING
+            if (userC == null) return MISSING
+            val raw = (userC - defaultC).roundToInt()
+            return when {
+                raw >= DELTA_CLAMP_C + 1 -> "+${DELTA_CLAMP_C}+"
+                raw <= -(DELTA_CLAMP_C + 1) -> "-${DELTA_CLAMP_C}-"
+                raw > 0 -> "+$raw"
+                raw < 0 -> "$raw"
+                else -> "0"
+            }
+        }
+
+        private fun String.takeCategories(): String =
+            if (length <= CATEGORIES_MAX_LEN) this else take(CATEGORIES_MAX_LEN)
+    }
+}

--- a/app/src/main/kotlin/app/clothescast/diag/SettingsSnapshot.kt
+++ b/app/src/main/kotlin/app/clothescast/diag/SettingsSnapshot.kt
@@ -1,0 +1,36 @@
+package app.clothescast.diag
+
+/**
+ * Aggregate-analytics view of the non-voice user settings, intended as the
+ * params of a Firebase Analytics `settings_snapshot` event.
+ *
+ * The voice / region / TTS-engine settings live separately in
+ * [SettingsAnalyticsSnapshot] as user properties so reports can break every
+ * event down by them. The settings captured here are emitted as event params
+ * instead because Firebase Analytics caps custom user properties at 25 per
+ * app — comprehensive configuration breakdowns belong on a periodic event.
+ *
+ * Schedule times are bucketed to the hour ("00".."23") rather than exact
+ * local times; the day-of-week shape is captured only as a count. No user
+ * content, no identifiers — every value is a short enum name, integer count,
+ * or two-digit hour string.
+ */
+data class SettingsSnapshot(
+    val temperatureUnitSetting: String,
+    val temperatureUnitEffective: String,
+    val distanceUnitSetting: String,
+    val distanceUnitEffective: String,
+    val deliveryModeDaily: String,
+    val deliveryModeTonight: String,
+    val themeMode: String,
+    val colorPalette: String,
+    val defaultBottom: String,
+    val dailyTimeBucketHour: String,
+    val dailyDaysCount: Int,
+    val tonightEnabled: Boolean,
+    val tonightTimeBucketHour: String,
+    val tonightDaysCount: Int,
+    val tonightNotifyOnlyOnEvents: Boolean,
+    val dailyMentionEveningEvents: Boolean,
+    val useCalendarEvents: Boolean,
+)

--- a/app/src/main/kotlin/app/clothescast/diag/Telemetry.kt
+++ b/app/src/main/kotlin/app/clothescast/diag/Telemetry.kt
@@ -89,6 +89,16 @@ object Telemetry {
                 .distinctUntilChanged()
                 .collect { snapshot -> snapshot.applyTo(analytics) }
         }
+        scope.launch {
+            settings.settingsSnapshot
+                .distinctUntilChanged()
+                .collect { snapshot -> logSettingsSnapshot(snapshot) }
+        }
+        scope.launch {
+            settings.clothesRulesSnapshot
+                .distinctUntilChanged()
+                .collect { snapshot -> logClothesRulesSnapshot(snapshot) }
+        }
     }
 
     /**
@@ -141,17 +151,121 @@ object Telemetry {
         analytics.logEvent(EVENT_NOTIFICATION_DELIVERY, params)
     }
 
+    /**
+     * Emits a `daily_refresh` event when a scheduled / force-refresh run of
+     * the FetchAndNotifyWorker reaches a terminal Result. Params:
+     *
+     *  - `slot` (string): `today` or `tonight`.
+     *  - `outcome` (string): `success`, `forecast_error`, `no_location`,
+     *    `cancelled`, or `other_error`. See [classifyDailyRefreshReason].
+     *  - `latency_ms` (long): wall-clock from `doWork()` entry to the
+     *    terminal Result.
+     *
+     * Result.retry is not terminal and does not emit — WorkManager retries
+     * silently on backoff, so the offline / transient-network case shows up
+     * only when it eventually succeeds (or gives up and fails for some other
+     * reason). That keeps the stream reflecting "did the user actually get a
+     * refresh today?" rather than "how many retry hops did it take."
+     */
+    fun logDailyRefresh(slot: String, outcome: String, latencyMs: Long) {
+        val analytics = analyticsRef ?: return
+        val params = Bundle().apply {
+            putString(PARAM_SLOT, slot)
+            putString(PARAM_OUTCOME, outcome)
+            putLong(PARAM_LATENCY_MS, latencyMs)
+        }
+        analytics.logEvent(EVENT_DAILY_REFRESH, params)
+    }
+
+    /**
+     * Emits a `settings_snapshot` event whose params mirror the non-voice user
+     * settings. Fires once per process start (the DataStore-backed flow
+     * replays its current value to each new subscriber) and again every time
+     * the resolved snapshot's `equals` changes within the process — i.e.
+     * whenever the user toggles a setting. The per-launch baseline is
+     * intentional: it lets reports see "what's the default-vs-customised
+     * mix across the population?" without requiring the user to interact.
+     */
+    private fun logSettingsSnapshot(snapshot: SettingsSnapshot) {
+        val analytics = analyticsRef ?: return
+        val params = Bundle().apply {
+            putString("temperature_unit_setting", snapshot.temperatureUnitSetting)
+            putString("temperature_unit_effective", snapshot.temperatureUnitEffective)
+            putString("distance_unit_setting", snapshot.distanceUnitSetting)
+            putString("distance_unit_effective", snapshot.distanceUnitEffective)
+            putString("delivery_mode_daily", snapshot.deliveryModeDaily)
+            putString("delivery_mode_tonight", snapshot.deliveryModeTonight)
+            putString("theme_mode", snapshot.themeMode)
+            putString("color_palette", snapshot.colorPalette)
+            putString("default_bottom", snapshot.defaultBottom)
+            putString("daily_time_bucket_hour", snapshot.dailyTimeBucketHour)
+            putLong("daily_days_count", snapshot.dailyDaysCount.toLong())
+            putLong("tonight_enabled", snapshot.tonightEnabled.toLongFlag())
+            putString("tonight_time_bucket_hour", snapshot.tonightTimeBucketHour)
+            putLong("tonight_days_count", snapshot.tonightDaysCount.toLong())
+            putLong("tonight_notify_only_on_events", snapshot.tonightNotifyOnlyOnEvents.toLongFlag())
+            putLong("daily_mention_evening_events", snapshot.dailyMentionEveningEvents.toLongFlag())
+            putLong("use_calendar_events", snapshot.useCalendarEvents.toLongFlag())
+        }
+        analytics.logEvent(EVENT_SETTINGS_SNAPSHOT, params)
+    }
+
+    /**
+     * Emits a `clothes_rules_snapshot` event whose params describe the user's
+     * clothes-rule customisation. Per-category deltas are integer Celsius
+     * differences from the catalog default, clamped to ±5°C — see
+     * [ClothesRulesSnapshot] for the bucket format.
+     *
+     * Same emission cadence as [logSettingsSnapshot]: once on process start
+     * (DataStore replay) and again on each subsequent change to the user's
+     * rule list within the process.
+     */
+    private fun logClothesRulesSnapshot(snapshot: ClothesRulesSnapshot) {
+        val analytics = analyticsRef ?: return
+        val params = Bundle().apply {
+            putLong("customised_count", snapshot.customisedCount.toLong())
+            putLong("extra_rules_count", snapshot.extraRulesCount.toLong())
+            putString("categories_customised", snapshot.categoriesCustomised)
+            putLong("all_defaults", snapshot.allDefaults.toLongFlag())
+            putString("sweater_delta_c", snapshot.sweaterDeltaC)
+            putString("jacket_delta_c", snapshot.jacketDeltaC)
+            putString("coat_delta_c", snapshot.coatDeltaC)
+            putString("shorts_delta_c", snapshot.shortsDeltaC)
+        }
+        analytics.logEvent(EVENT_CLOTHES_RULES_SNAPSHOT, params)
+    }
+
+    /** Booleans ship as `0` / `1` longs so they slice cleanly in Firebase reports. */
+    private fun Boolean.toLongFlag(): Long = if (this) 1L else 0L
+
     // Firebase Analytics caps: event names ≤40 chars, param names ≤40 chars,
     // string values ≤100 chars. All identifiers below comfortably fit.
     private const val EVENT_API_CALL = "api_call"
     private const val EVENT_NOTIFICATION_DELIVERY = "notification_delivery"
+    private const val EVENT_DAILY_REFRESH = "daily_refresh"
+    private const val EVENT_SETTINGS_SNAPSHOT = "settings_snapshot"
+    private const val EVENT_CLOTHES_RULES_SNAPSHOT = "clothes_rules_snapshot"
     private const val PARAM_ENDPOINT = "endpoint"
     private const val PARAM_OUTCOME = "outcome"
     private const val PARAM_STATUS_CODE = "status_code"
     private const val PARAM_LATENCY_MS = "latency_ms"
     private const val PARAM_PERIOD = "period"
+    private const val PARAM_SLOT = "slot"
     private const val PARAM_ALARM_DELAY_MS = "alarm_delay_ms"
     private const val PARAM_TOTAL_DELAY_MS = "total_delay_ms"
+}
+
+/**
+ * Pure mapping from a [androidx.work.ListenableWorker.Result.Failure] reason
+ * code (the `KEY_REASON` string stamped by FetchAndNotifyWorker) onto the
+ * `outcome` bucket of the `daily_refresh` event. Extracted so the
+ * classification is unit-testable without dragging WorkManager into the test
+ * classpath.
+ */
+internal fun classifyDailyRefreshReason(reason: String?): String = when (reason) {
+    "no_location" -> "no_location"
+    "unexpected_http" -> "forecast_error"
+    else -> "other_error"
 }
 
 /**

--- a/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
@@ -23,6 +23,7 @@ import app.clothescast.core.domain.model.Location
 import app.clothescast.core.domain.model.TtsEngine
 import app.clothescast.core.domain.model.UserPreferences
 import app.clothescast.diag.Telemetry
+import app.clothescast.diag.classifyDailyRefreshReason
 import app.clothescast.insight.InsightFormatter
 import app.clothescast.location.hasBackgroundLocationPermission
 import app.clothescast.location.hasCoarseLocationPermission
@@ -63,7 +64,56 @@ class FetchAndNotifyWorker(
     private val app: ClothesCastApplication
         get() = applicationContext as ClothesCastApplication
 
-    override suspend fun doWork(): Result = stamped(doWorkInternal())
+    override suspend fun doWork(): Result {
+        val isCacheOnly = inputData.getBoolean(KEY_CACHE_LOCATION_ONLY, false)
+        val period = inputData.getString(KEY_PERIOD)
+            ?.let { runCatching { ForecastPeriod.valueOf(it) }.getOrNull() }
+            ?: ForecastPeriod.TODAY
+        val startMs = System.currentTimeMillis()
+        // The cache-only path doesn't deliver an insight, so don't count it
+        // as a refresh outcome — that would skew the success-rate dashboard
+        // with no-op runs every time the user toggles device location.
+        return try {
+            val result = stamped(doWorkInternal())
+            if (!isCacheOnly) recordDailyRefreshOutcome(period, result, startMs)
+            result
+        } catch (ce: CancellationException) {
+            if (!isCacheOnly) {
+                Telemetry.logDailyRefresh(
+                    slot = slotName(period),
+                    outcome = OUTCOME_CANCELLED,
+                    latencyMs = System.currentTimeMillis() - startMs,
+                )
+            }
+            throw ce
+        }
+    }
+
+    private fun recordDailyRefreshOutcome(period: ForecastPeriod, result: Result, startMs: Long) {
+        val outcome = when (result) {
+            is Result.Success -> {
+                // Tonight-disabled and similar early-exit branches stamp
+                // KEY_SKIP_TELEMETRY so the dashboard's success rate
+                // reflects "did the user actually get a refresh?", not
+                // "did the worker happen to return successfully?".
+                if (result.outputData.getBoolean(KEY_SKIP_TELEMETRY, false)) return
+                OUTCOME_SUCCESS
+            }
+            is Result.Failure -> classifyDailyRefreshReason(result.outputData.getString(KEY_REASON))
+            // Result.retry is non-terminal — WorkManager will re-run us — so leave it off the stream.
+            else -> return
+        }
+        Telemetry.logDailyRefresh(
+            slot = slotName(period),
+            outcome = outcome,
+            latencyMs = System.currentTimeMillis() - startMs,
+        )
+    }
+
+    private fun slotName(period: ForecastPeriod): String = when (period) {
+        ForecastPeriod.TODAY -> "today"
+        ForecastPeriod.TONIGHT -> "tonight"
+    }
 
     private suspend fun doWorkInternal(): Result {
         val prefs = try {
@@ -93,7 +143,12 @@ class FetchAndNotifyWorker(
         // after the user disabled the feature.
         if (period == ForecastPeriod.TONIGHT && !prefs.tonightEnabled) {
             DiagLog.i(TAG, "Tonight insight is disabled; skipping.")
-            return Result.success()
+            // Stamp KEY_SKIP_TELEMETRY so the daily_refresh outcome event
+            // doesn't count this as a success. TodayScreen.triggerRefresh
+            // enqueues a TONIGHT run purely on the clock, so any user who
+            // turned the feature off would otherwise show a steady stream
+            // of "successful" tonight refreshes that delivered nothing.
+            return Result.success(workDataOf(KEY_SKIP_TELEMETRY to true))
         }
 
         val location = resolveLocation(prefs)
@@ -573,6 +628,21 @@ class FetchAndNotifyWorker(
         const val REASON_UNEXPECTED_HTTP = "unexpected_http"
         const val REASON_UNHANDLED = "unhandled"
         const val REASON_NO_LOCATION = "no_location"
+
+        // daily_refresh event outcome buckets — kept here next to the reason
+        // codes so the mapping in classifyDailyRefreshReason stays
+        // discoverable. "success" / "cancelled" don't have matching reason
+        // codes because they aren't WorkManager Failure reasons.
+        private const val OUTCOME_SUCCESS = "success"
+        private const val OUTCOME_CANCELLED = "cancelled"
+
+        /**
+         * Output-data flag set on the no-op success branches (tonight-disabled
+         * being the canonical case) to tell [recordDailyRefreshOutcome] that
+         * the run reached `Result.success()` without delivering anything, so
+         * the daily_refresh event should be suppressed for it.
+         */
+        private const val KEY_SKIP_TELEMETRY = "skip_telemetry"
 
         // Cap unhandled-error detail so the "Show details" pane stays readable.
         private const val MAX_DETAIL_LEN = 240

--- a/app/src/test/kotlin/app/clothescast/data/SettingsRepositoryTest.kt
+++ b/app/src/test/kotlin/app/clothescast/data/SettingsRepositoryTest.kt
@@ -20,6 +20,8 @@ import app.clothescast.core.domain.model.TtsEngine
 import app.clothescast.core.domain.model.TtsStyle
 import app.clothescast.core.domain.model.VoiceLocale
 import app.clothescast.core.domain.model.thresholdC
+import app.clothescast.core.domain.model.ThemeMode
+import app.clothescast.diag.ClothesRulesSnapshot
 import app.clothescast.diag.SettingsAnalyticsSnapshot
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.collections.shouldContainExactly
@@ -677,6 +679,96 @@ class SettingsRepositoryTest {
         snap.regionEffective shouldBe "en-GB"
         snap.voiceLocaleOverride shouldBe VoiceLocale.SYSTEM.name
         snap.voiceLocaleEffective shouldBe "en-GB"
+    }
+
+    @Test
+    fun `settingsSnapshot reflects effective values and hour-bucketed schedule`() = runTest {
+        // Pinned systemLocaleProvider is Locale.UK → temperature CELSIUS,
+        // distance MILES (UK uses miles for everyday distances per
+        // defaultDistanceUnitFor). Defaults give NOTIFICATION_AND_TTS for both
+        // slots and 07:00 / 19:00 every day.
+        val defaults = subject.settingsSnapshot.first()
+
+        defaults.temperatureUnitSetting shouldBe TemperatureUnitSetting.AUTO.name
+        defaults.temperatureUnitEffective shouldBe TemperatureUnit.CELSIUS.name
+        defaults.distanceUnitSetting shouldBe DistanceUnitSetting.AUTO.name
+        defaults.distanceUnitEffective shouldBe DistanceUnit.MILES.name
+        defaults.deliveryModeDaily shouldBe DeliveryMode.NOTIFICATION_AND_TTS.name
+        defaults.deliveryModeTonight shouldBe DeliveryMode.NOTIFICATION_AND_TTS.name
+        defaults.themeMode shouldBe ThemeMode.SYSTEM.name
+        defaults.dailyTimeBucketHour shouldBe "07"
+        defaults.dailyDaysCount shouldBe 7
+        defaults.tonightTimeBucketHour shouldBe "19"
+        defaults.tonightDaysCount shouldBe 7
+        defaults.tonightEnabled shouldBe true
+        defaults.tonightNotifyOnlyOnEvents shouldBe false
+        defaults.dailyMentionEveningEvents shouldBe true
+        defaults.useCalendarEvents shouldBe false
+
+        subject.setSchedule(
+            time = LocalTime.of(6, 30),
+            days = setOf(DayOfWeek.MONDAY, DayOfWeek.WEDNESDAY, DayOfWeek.FRIDAY),
+        )
+        subject.setTemperatureUnitSetting(TemperatureUnitSetting.FAHRENHEIT)
+        subject.setDeliveryMode(DeliveryMode.NOTIFICATION_ONLY)
+        subject.setUseCalendarEvents(true)
+
+        val edited = subject.settingsSnapshot.first()
+
+        // Hour bucket drops the minutes — 06:30 reports as "06" so reports
+        // don't see exact-time precision that could fingerprint a schedule.
+        edited.dailyTimeBucketHour shouldBe "06"
+        edited.dailyDaysCount shouldBe 3
+        edited.temperatureUnitSetting shouldBe TemperatureUnitSetting.FAHRENHEIT.name
+        edited.temperatureUnitEffective shouldBe TemperatureUnit.FAHRENHEIT.name
+        edited.deliveryModeDaily shouldBe DeliveryMode.NOTIFICATION_ONLY.name
+        edited.useCalendarEvents shouldBe true
+    }
+
+    @Test
+    fun `clothesRulesSnapshot reflects user edits to thresholds`() = runTest {
+        // Nudge jacket from default 12°C down to 10°C — delta should report
+        // as "-2" and the customised count should land at exactly 1.
+        val edited = ClothesRule.DEFAULTS.map { rule ->
+            if (rule.item == "jacket") rule.copy(condition = ClothesRule.TemperatureBelow(10.0))
+            else rule
+        }
+        subject.setClothesRules(edited)
+
+        val snap = subject.clothesRulesSnapshot.first()
+
+        snap.customisedCount shouldBe 1
+        snap.jacketDeltaC shouldBe "-2"
+        snap.categoriesCustomised shouldBe "jacket"
+        snap.allDefaults shouldBe false
+    }
+
+    @Test
+    fun `clothesRulesSnapshot defaults report all zeros and allDefaults true`() = runTest {
+        // Untouched repository — falls back to ClothesRule.DEFAULTS, which the
+        // snapshot must report as completely unmodified.
+        val snap = subject.clothesRulesSnapshot.first()
+
+        snap.allDefaults shouldBe true
+        snap.customisedCount shouldBe 0
+        snap.extraRulesCount shouldBe 0
+        snap.sweaterDeltaC shouldBe "0"
+        snap.jacketDeltaC shouldBe "0"
+        snap.coatDeltaC shouldBe "0"
+        snap.shortsDeltaC shouldBe "0"
+        snap.categoriesCustomised shouldBe ""
+    }
+
+    @Test
+    fun `clothesRulesSnapshot deleted category surfaces as MISSING`() = runTest {
+        // User wiped coat from their list — every other default unchanged.
+        subject.setClothesRules(ClothesRule.DEFAULTS.filter { it.item != "coat" })
+
+        val snap = subject.clothesRulesSnapshot.first()
+
+        snap.coatDeltaC shouldBe ClothesRulesSnapshot.MISSING
+        snap.customisedCount shouldBe 1
+        snap.categoriesCustomised shouldBe "coat"
     }
 
     @Test

--- a/app/src/test/kotlin/app/clothescast/diag/ClothesRulesSnapshotTest.kt
+++ b/app/src/test/kotlin/app/clothescast/diag/ClothesRulesSnapshotTest.kt
@@ -1,0 +1,136 @@
+package app.clothescast.diag
+
+import app.clothescast.core.domain.model.ClothesRule
+import app.clothescast.core.domain.model.TemperatureUnit
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+class ClothesRulesSnapshotTest {
+
+    @Test
+    fun `unchanged defaults report all zeros`() {
+        val snap = ClothesRulesSnapshot.from(ClothesRule.DEFAULTS)
+
+        snap.customisedCount shouldBe 0
+        snap.extraRulesCount shouldBe 0
+        snap.categoriesCustomised shouldBe ""
+        snap.allDefaults shouldBe true
+        snap.sweaterDeltaC shouldBe "0"
+        snap.jacketDeltaC shouldBe "0"
+        snap.coatDeltaC shouldBe "0"
+        snap.shortsDeltaC shouldBe "0"
+    }
+
+    @Test
+    fun `single category nudged reports signed integer delta`() {
+        // Default jacket is TemperatureBelow(12.0); nudge to 10°C → delta of -2.
+        val rules = ClothesRule.DEFAULTS.map { rule ->
+            if (rule.item == "jacket") rule.copy(condition = ClothesRule.TemperatureBelow(10.0))
+            else rule
+        }
+
+        val snap = ClothesRulesSnapshot.from(rules)
+
+        snap.customisedCount shouldBe 1
+        snap.extraRulesCount shouldBe 0
+        snap.categoriesCustomised shouldBe "jacket"
+        snap.allDefaults shouldBe false
+        snap.jacketDeltaC shouldBe "-2"
+        snap.sweaterDeltaC shouldBe "0"
+    }
+
+    @Test
+    fun `positive delta is sign-prefixed`() {
+        // Default shorts is TemperatureAbove(24.0); nudge to 27°C → delta of +3.
+        val rules = ClothesRule.DEFAULTS.map { rule ->
+            if (rule.item == "shorts") rule.copy(condition = ClothesRule.TemperatureAbove(27.0))
+            else rule
+        }
+
+        val snap = ClothesRulesSnapshot.from(rules)
+
+        snap.shortsDeltaC shouldBe "+3"
+        snap.customisedCount shouldBe 1
+    }
+
+    @Test
+    fun `deltas beyond the clamp saturate to bucket boundary`() {
+        // 12°C - 30°C = -18 → clamps to "-5-"; 6°C + 50°C = +44 → clamps to "+5+".
+        val rules = ClothesRule.DEFAULTS.map { rule ->
+            when (rule.item) {
+                "jacket" -> rule.copy(condition = ClothesRule.TemperatureBelow(30.0))
+                "coat" -> rule.copy(condition = ClothesRule.TemperatureBelow(50.0))
+                else -> rule
+            }
+        }
+
+        val snap = ClothesRulesSnapshot.from(rules)
+
+        // jacket: default 12, user 30, delta = +18 → "+5+"
+        snap.jacketDeltaC shouldBe "+5+"
+        // coat: default 6, user 50, delta = +44 → "+5+"
+        snap.coatDeltaC shouldBe "+5+"
+    }
+
+    @Test
+    fun `deleted category is reported as MISSING`() {
+        val rules = ClothesRule.DEFAULTS.filter { it.item != "coat" }
+
+        val snap = ClothesRulesSnapshot.from(rules)
+
+        snap.coatDeltaC shouldBe ClothesRulesSnapshot.MISSING
+        // Missing categories count as customisation so the dashboard sees the user
+        // has tweaked their setup, not just left the defaults.
+        snap.customisedCount shouldBe 1
+        snap.categoriesCustomised shouldBe "coat"
+        snap.allDefaults shouldBe false
+    }
+
+    @Test
+    fun `extra non-default rule increments extra count without affecting default deltas`() {
+        // Hat isn't in DEFAULTS; should bump extraRulesCount but not customisedCount.
+        val rules = ClothesRule.DEFAULTS + ClothesRule(
+            item = "hat",
+            condition = ClothesRule.TemperatureBelow(5.0),
+        )
+
+        val snap = ClothesRulesSnapshot.from(rules)
+
+        snap.customisedCount shouldBe 0
+        snap.extraRulesCount shouldBe 1
+        snap.allDefaults shouldBe false
+        snap.sweaterDeltaC shouldBe "0"
+    }
+
+    @Test
+    fun `unit-typed Fahrenheit threshold is converted to Celsius before bucketing`() {
+        // 53°F ≈ 11.7°C; rounded delta from default 12°C is 0. Confirms that
+        // thresholdC() does the unit conversion under the bucket math.
+        val rules = ClothesRule.DEFAULTS.map { rule ->
+            if (rule.item == "jacket") rule.copy(
+                condition = ClothesRule.TemperatureBelow(53.0, TemperatureUnit.FAHRENHEIT),
+            ) else rule
+        }
+
+        val snap = ClothesRulesSnapshot.from(rules)
+
+        snap.jacketDeltaC shouldBe "0"
+        snap.customisedCount shouldBe 0
+    }
+
+    @Test
+    fun `categories_customised is sorted alphabetically`() {
+        // Customise shorts and jacket; expect "jacket,shorts" not "shorts,jacket".
+        val rules = ClothesRule.DEFAULTS.map { rule ->
+            when (rule.item) {
+                "shorts" -> rule.copy(condition = ClothesRule.TemperatureAbove(26.0))
+                "jacket" -> rule.copy(condition = ClothesRule.TemperatureBelow(10.0))
+                else -> rule
+            }
+        }
+
+        val snap = ClothesRulesSnapshot.from(rules)
+
+        snap.categoriesCustomised shouldBe "jacket,shorts"
+    }
+}

--- a/app/src/test/kotlin/app/clothescast/diag/TelemetryRefreshOutcomeTest.kt
+++ b/app/src/test/kotlin/app/clothescast/diag/TelemetryRefreshOutcomeTest.kt
@@ -1,0 +1,32 @@
+package app.clothescast.diag
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+class TelemetryRefreshOutcomeTest {
+
+    @Test
+    fun `no_location reason maps to dedicated bucket`() {
+        // FetchAndNotifyWorker stamps REASON_NO_LOCATION when the user has no
+        // saved location AND device location is unavailable / not permitted;
+        // it's a user-actionable misconfig rather than a transient failure, so
+        // the dashboard wants to see it separately from other_error.
+        classifyDailyRefreshReason("no_location") shouldBe "no_location"
+    }
+
+    @Test
+    fun `unexpected_http reason maps to forecast_error`() {
+        // 4xx from OpenMeteo lands here — the request reached the upstream
+        // but came back with a status we can't recover from. Distinguishing
+        // it from network blips is the point of the bucket.
+        classifyDailyRefreshReason("unexpected_http") shouldBe "forecast_error"
+    }
+
+    @Test
+    fun `unhandled and unknown reasons collapse into other_error`() {
+        classifyDailyRefreshReason("unhandled") shouldBe "other_error"
+        classifyDailyRefreshReason("") shouldBe "other_error"
+        classifyDailyRefreshReason(null) shouldBe "other_error"
+        classifyDailyRefreshReason("some_future_reason_we_havent_added_yet") shouldBe "other_error"
+    }
+}

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -90,42 +90,38 @@ Code TODOs in source files are linked from here when they exist.
       (highest quality, slowest, costliest). User picks from Settings; the
       Worker passes the chosen id into a per-call `DirectGeminiClient`.
 
-## Analytics & telemetry — under consideration
+## Analytics & telemetry
 
-The post-crash share banner (this PR) covers "tell us when it broke" via
-strictly user-initiated sharing. The questions still open are about
-**product analytics** — which features are worth keeping, which defaults
-serve users best, and which TTS engines are too underused to maintain.
-Decide before wiring anything; the wiring is the easy part.
+Product analytics ships in all builds. Default-on with a one-time
+non-blocking Today banner pointing at Settings → Privacy to turn it off;
+PRIVACY.md → "Analytics and crash reporting" has the contract. Backend
+is Firebase Analytics + Crashlytics, gated on `app/google-services.json`
+so CI builds no-op. The hard "do not transmit" list (calendar data,
+location, insight prose, API keys, precise GPS, ad identifiers) lives in
+PRIVACY.md and is mirrored inline in the Settings → Privacy card.
 
-- [ ] **Decide whether to ship product analytics at all.** If yes, decide
-      delivery shape: opt-out-with-toggle vs. required-first-launch
-      question. PRIVACY.md → "Under consideration" section names both
-      options; resolve and update there before any code lands.
-- [ ] **Lock the event schema before any SDK is added.** Aggregate counts
-      only — never free text. Candidate events: TTS engine in use,
-      schedule cadence (number of slots, weekday vs. weekend), delivery
-      mode (notification vs. widget vs. TTS), clothes-rule customisation
-      (any thresholds tweaked from default? how many rules added?), region
-      / unit settings. Bucketed times rather than exact local times.
-- [ ] **Hard "do not transmit" list — codify in review checklist + tests:**
-      - Calendar event data (titles, times, locations, attendee data).
-        Not aggregated, not hashed, not bucketed — *not at all*.
-      - User names, account identifiers, email addresses, contact info.
-      - Location coordinates or geocoded place names.
-      - Insight prose, notification text, or any free-form rendered
-        content (the same prose that goes to TTS — that's already a
-        bounded, user-controlled flow; analytics must not duplicate it).
-      - Persistent device / install identifiers beyond what's strictly
-        required to honour the opt-out choice.
-- [ ] **Pick a backend before the SDK.** Firebase Analytics pulls Google
-      Play Services telemetry into the app; PostHog / Plausible-style
-      self-hosted avoids that but needs a server. Picking the SDK first
-      and the backend second is how privacy boundaries quietly slip.
-- [ ] **Crash reporting → reconsider remote** after analytics is decided.
-      The local-only banner covers reachability; a remote service (Sentry
-      self-hosted, Bugsnag, etc.) would cover crashes from users who
-      never tap Share. Same opt-in / privacy-policy bar as analytics.
+Live events: `api_call` (endpoint, outcome, status, latency;
+offline-filtered), `notification_delivery` (slot, alarm delay, total
+delay), `daily_refresh` (slot, outcome, latency), `settings_snapshot`
+(non-voice configuration), and `clothes_rules_snapshot` (customisation
+summary + per-category integer Celsius delta from default, clamped to
+±5°C). Live user properties: language / region / TTS-engine / TTS-style
+/ voice settings as default / override / effective triples — kept to a
+small set since Firebase caps custom user properties at 25 per app.
+
+Open work:
+
+- [ ] **Codify the do-not-transmit list in tests.** PRIVACY.md and the
+      Settings → Privacy card describe the contract; we don't yet have
+      a regression test asserting no Telemetry call site reads insight
+      prose, calendar data, location, or API keys. PR-time review
+      catches it today; lock it in code.
+- [ ] **Insight-composition events — decide separately.** Which evening
+      tie-in path fired (clothes-rule vs per-model rain bare warning vs
+      none), which confidence tier emitted, whether tonight was
+      suppressed. Useful but a new category of "what the engine
+      decided" telemetry; revisit once the settings + refresh streams
+      have answered the bigger questions.
 
 ## Testing & quality
 


### PR DESCRIPTION
## Summary

Closes out the analytics design discussion from `docs/TODO.md:93-128`
("Analytics & telemetry — under consideration"). The questions are
resolved — analytics ships, Firebase is already wired — so this PR adds
the three remaining events the candidate list called for and rewrites
the section to match shipped reality.

### Design decisions baked in

- **Ship analytics: yes**, default-on with the existing
  Settings → Privacy toggle and one-time Today banner. Already shipped
  on `main` (PRIVACY.md changelog 2026-05-05).
- **Backend: Firebase Analytics + Crashlytics**, gated on
  `app/google-services.json` (CI no-ops). Already shipped.
- **Hard "do not transmit" list:** documented in PRIVACY.md and mirrored
  inline in the Settings → Privacy card. Already shipped.
- **New: comprehensive settings mirror as event params, not user
  properties.** Firebase Analytics caps custom user properties at 25
  per app; the existing six voice / region triples already use 18
  slots, so the new settings ride as `settings_snapshot` event params
  instead. Same dimensionality, more headroom.
- **New: clothes-rule customisation snapshot with per-category integer
  Celsius delta from default, clamped to ±5°C.** Bucketed strings
  (`"0"`, `"+1"`, `"-3"`, `"+5+"`, `"-5-"`, `"MISSING"`) so the
  dashboard sees customisation shape without seeing raw thresholds.
- **New: `daily_refresh` outcome event** at every terminal Result of the
  fetch + insight + notify pipeline. WorkManager retries between
  transient failures aren't reported individually — the stream
  reflects whether the user actually got a refresh, not how many hops
  it took.

### Snapshot emission cadence

`settings_snapshot` and `clothes_rules_snapshot` fire once per process
start (the DataStore-backed flow replays its current value to each new
subscriber) and again whenever the resolved snapshot's `equals` changes
within the same process. The launch-time emission is intentional — it
samples the population's default behaviour without requiring the user
to interact, so reports can see the default-vs-customised mix rather
than only "active customisers". KDoc and PRIVACY.md spell this out so
the contract isn't ambiguous.

### Implementation

- Two new data classes in `app/diag`: `SettingsSnapshot` (17 params,
  hour-bucketed schedule times, day counts, unit / delivery / theme /
  palette / default-bottom / four booleans) and `ClothesRulesSnapshot`
  (count of customised defaults + extras, sorted comma-joined category
  list, per-category delta bucket).
- Two new flows on `SettingsRepository`: `settingsSnapshot`,
  `clothesRulesSnapshot`. Both `distinctUntilChanged()` in `Telemetry`
  so within a single launch a no-op edit doesn't re-fire.
- `Telemetry.logDailyRefresh(slot, outcome, latencyMs)` plus a pure
  `classifyDailyRefreshReason(reason)` helper that maps the worker's
  `KEY_REASON` strings onto `outcome` buckets. Extracted as a
  top-level internal fn so it's unit-testable without dragging
  WorkManager onto the test classpath.
- `FetchAndNotifyWorker.doWork()` now wraps the existing
  `stamped(doWorkInternal())` path: records the start time, classifies
  the terminal Result, and emits `daily_refresh`. `CancellationException`
  rethrows but emits `cancelled` first. The cache-only-location pseudo-
  run is excluded — it isn't a refresh and would skew the success-rate
  dashboard.

### Privacy

- PRIVACY.md → "Analytics and crash reporting" extended with three new
  bullets describing what each event carries (including the per-launch
  cadence for the two snapshot events), with explicit "no forecast
  content / no insight prose / no location / no calendar / no
  timestamps" disclaimers.
- 2026-05-14 changelog entry summarises the additions.
- Last-updated bumped.
- Hard limits ("no calendar event data, no location, no insight prose,
  no API keys, no precise GPS, no ad identifiers") unchanged. Every
  new param is a short enum name, a small integer count, a bucketed
  string, or a 0/1 flag — no user content of any kind.

### Docs

- `docs/TODO.md` analytics section rewritten. The "under consideration"
  framing is gone — decisions are resolved and reflected in the section
  intro. Two genuinely-open follow-ups remain: codify the do-not-
  transmit list as a regression test, and decide separately on
  insight-composition events.

## Test plan

- [ ] `:core:domain:test` — no domain code changed.
- [ ] `:core:data:test` + `:app:testDebugUnitTest` — sandbox lacks
  Android SDK / Google Maven, so CI is the validation surface here.
  Watch the JVM unit tests job.
- [ ] `:app:assembleDebug` (CI) — confirms the worker / repository /
  Telemetry edits compile against AGP.
- [ ] On a device with `google-services.json` present: launch the app
  cold, confirm a `settings_snapshot` and `clothes_rules_snapshot`
  appear in Firebase DebugView; change a setting (e.g. flip
  Fahrenheit ↔ Celsius), confirm a fresh `settings_snapshot`; tweak
  a clothes-rule threshold via the rationale `+1° / -1°` buttons,
  confirm `clothes_rules_snapshot`; let the morning alarm fire,
  confirm a `daily_refresh` event with `outcome=success`.
- [ ] On a CI / `google-services.json`-less build: confirm no Telemetry
  call site crashes — the `analyticsRef` null-check covers this and is
  already exercised by the existing `api_call` / `notification_delivery`
  paths.