### PR TITLE
Publish to internal testing automatically on every main push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -660,15 +660,7 @@ jobs:
           packageName: app.clothescast
           releaseFiles: app/build/outputs/bundle/release/app-release.aab
           track: internal
-          # TEMPORARY: `draft` while the app's first Play Console review is
-          # pending — the API rejects `completed` releases on a draft app
-          # ("Only releases with status draft may be created on draft app"),
-          # which fails CI on every push to main. With `draft`, the AAB still
-          # uploads to the internal track; activating it requires one click on
-          # the "Release to internal testing" button in Play Console per push.
-          # Switch back to `completed` once Google approves the listing and
-          # the app is no longer in Draft state.
-          status: draft
+          status: completed
           whatsNewDirectory: ${{ runner.temp }}/whatsnew
 
       - name: Clear prior CI comments for this job


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Removes the `status: draft` workaround on the Play Store upload step now that the Play Console listing is approved and out of draft state
- Every push to `main` will now automatically publish the signed AAB to the internal testing track without requiring a manual "Release to internal testing" click in Play Console

## Test plan

- [ ] Merge and verify the next push to `main` shows the build as active in Play Console → Internal testing (no manual click needed)
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WBzWkjDah2DpajxRWpXhMn)_