### PR TITLE
Fix stale and missing translations across 22 locale files

### DIFF
--- a/app/src/main/res/values-am/strings.xml
+++ b/app/src/main/res/values-am/strings.xml
@@ -117,8 +117,6 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="today_confidence_high">ከፍተኛ እምነት — ዋና ሞዴሎቹ ይስማማሉ</string>
     <string name="today_confidence_medium">መካከለኛ እምነት</string>
     <string name="today_confidence_low">ዝቅተኛ እምነት — ትንበያዎቹ ይለያያሉ</string>
-    <string name="today_low_confidence_callout_title">ትንበያዎቹ ይለያያሉ</string>
-    <string name="today_low_confidence_callout_body">የሙቀት ልዩነት %1$.1f°C ሲሆን የዝናብ ዕድል ልዩነት %2$.0f%% ነው በ%3$d ሞዴሎቹ።</string>
 
     <!-- Today screen states -->
     <string name="today_working">እየሰራ ነው — ClothesCast እያምጣ ነው…</string>
@@ -217,9 +215,6 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="settings_display_theme_system">ስርዓቱን ተከተል</string>
     <string name="settings_display_theme_light">ብርሃን</string>
     <string name="settings_display_theme_dark">ጨለማ</string>
-    <string name="settings_display_charts_title">ቻርቶች</string>
-    <string name="settings_display_model_spread_label">በቻርቶቹ ላይ የሞዴል ልዩነት አሳይ</string>
-    <string name="settings_display_model_spread_description">እያንዳንዱ ዋና የአየር ሁኔታ ሞዴል ሰዓታዊ ትንበያ በሙቀት እና ዝናብ ቻርቶቹ ላይ ያሳያል። ትንበያው ዕርግጠኛ ባልሆነ ጊዜ ለማወቅ ጠቃሚ ነው።</string>
 
     <!-- Settings — privacy -->
     <string name="settings_privacy_telemetry_title">ስህተት + አጠቃቀም ሪፖርቶች</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -183,8 +183,6 @@ they work correctly in both the single-band and range templates.
     <string name="today_confidence_high">ثقة عالية — تتفق النماذج الرئيسية</string>
     <string name="today_confidence_medium">ثقة متوسطة</string>
     <string name="today_confidence_low">ثقة منخفضة — تتباين التوقعات</string>
-    <string name="today_low_confidence_callout_title">التوقعات متباينة</string>
-    <string name="today_low_confidence_callout_body">يتراوح نطاق درجات الحرارة بـ %1$.1f°C واحتمالية الأمطار بـ %2$.0f%% عبر %3$d نماذج.</string>
 
     <!-- Today — loading / error states -->
     <string name="today_working">جارٍ العمل — يتم جلب ClothesCast…</string>
@@ -277,9 +275,6 @@ they work correctly in both the single-band and range templates.
     <string name="settings_display_theme_system">اتبع النظام</string>
     <string name="settings_display_theme_light">فاتح</string>
     <string name="settings_display_theme_dark">داكن</string>
-    <string name="settings_display_charts_title">الرسوم البيانية</string>
-    <string name="settings_display_model_spread_label">إظهار انتشار النماذج في الرسوم البيانية</string>
-    <string name="settings_display_model_spread_description">يعرض التوقعات الساعية لكل نموذج طقس رئيسي على رسوم درجات الحرارة والأمطار. مفيد للكشف عن حالات عدم اليقين في التوقعات.</string>
 
     <!-- Settings — location subtitles -->
     <string name="settings_root_location_subtitle">الكشف التلقائي أو اختيار مدينة</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -583,4 +583,27 @@ locale (Angličtina (USA), Francouzština (Francie), Němčina (Německo), …).
     <string name="today_forecast_air_section_title">Teplota vzduchu</string>
     <string name="settings_default_bottom_title">Standardní spodní díl</string>
     <string name="settings_default_bottom_description">Co doporučujeme na domovské obrazovce, když není dost teplo na šortky.</string>
+
+    <!-- Strings added to match base (new features). -->
+    <string name="settings_display_colors_title">Paleta</string>
+    <string name="settings_display_palette_accessible">Přístupná</string>
+    <string name="settings_display_palette_accessible_description">Paleta odvozená od Okabe-Ito, navržená tak, aby zůstala rozlišitelná při deuteranopii, protanopii a tritanopii. Karty spolehlivosti používají nebeskou modrou, neutrální a jantarovou místo tyrkysové, neutrální a červené.</string>
+    <string name="settings_display_palette_rainbow">Duha</string>
+    <string name="settings_display_palette_rainbow_description">Růžové, oranžové a zelené linky grafů s tyrkysovými/červenými kartami spolehlivosti Material. Výchozí.</string>
+    <string name="settings_unit_auto">Auto</string>
+    <string name="today_cloud_range">Oblačnost %1$d\u2013%2$d%%</string>
+    <string name="today_confidence_precip_spread">Modely se neshodují na srážkách (Δ %1$.0f%% pro %2$d modely)</string>
+    <string name="today_confidence_tap_to_hide">Klepnutím skryjete předpovědi modelů</string>
+    <string name="today_confidence_tap_to_show">Klepnutím zobrazíte předpověď každého modelu</string>
+    <string name="today_humidity_range">Vlhkost %1$d\u2013%2$d%%</string>
+    <string name="today_solar_subtitle">Povrchová ozářenost (W/m²) za hodinu na model</string>
+    <string name="today_solar_title">Sluneční záření</string>
+    <string name="today_sunshine_subtitle">Minuty slunce za hodinu na model</string>
+    <string name="today_sunshine_title">Sluneční svit</string>
+    <string name="today_sunshine_total_hours_minutes">%1$d hod %2$d min slunce dnes</string>
+    <string name="today_sunshine_total_hours_only">%1$d hod slunce dnes</string>
+    <string name="today_sunshine_total_minutes_only">%1$d min slunce dnes</string>
+    <string name="today_uv_subtitle">UV index za hodinu na model</string>
+    <string name="today_uv_title">UV index</string>
+    <string name="today_wind_peak">Vrchol %1$d %2$s v %3$s</string>
 </resources>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -596,4 +596,27 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrig)").
     <string name="today_forecast_air_section_title">Lufttemperatur</string>
     <string name="settings_default_bottom_title">Standard bundstykke</string>
     <string name="settings_default_bottom_description">Det vi foreslår på startskærmen, når det ikke er varmt nok til shorts.</string>
+
+    <!-- Strings added to match base (new features). -->
+    <string name="settings_display_colors_title">Palette</string>
+    <string name="settings_display_palette_accessible">Tilgængelig</string>
+    <string name="settings_display_palette_accessible_description">En Okabe-Ito-baseret palette designet til at forblive skelneligt ved deuteranopi, protanopi og tritanopi. Tillidskorene bruger himmelblå, neutral og rav i stedet for teal, neutral og rød.</string>
+    <string name="settings_display_palette_rainbow">Regnbue</string>
+    <string name="settings_display_palette_rainbow_description">Lyserøde, orange og grønne diagramlinjer med Material teal/røde tillidskort. Standard.</string>
+    <string name="settings_unit_auto">Auto</string>
+    <string name="today_cloud_range">Skydække %1$d\u2013%2$d%%</string>
+    <string name="today_confidence_precip_spread">Modellerne er uenige om regn (Δ %1$.0f%% på tværs af %2$d modeller)</string>
+    <string name="today_confidence_tap_to_hide">Tryk for at skjule modelforudsigelser</string>
+    <string name="today_confidence_tap_to_show">Tryk for at se hver models forudsigelse</string>
+    <string name="today_humidity_range">Luftfugtighed %1$d\u2013%2$d%%</string>
+    <string name="today_solar_subtitle">Overfladeindstråling (W/m²) pr. time pr. model</string>
+    <string name="today_solar_title">Solindstråling</string>
+    <string name="today_sunshine_subtitle">Minutter sol pr. time pr. model</string>
+    <string name="today_sunshine_title">Solskin</string>
+    <string name="today_sunshine_total_hours_minutes">%1$d t %2$d min sol i dag</string>
+    <string name="today_sunshine_total_hours_only">%1$d t sol i dag</string>
+    <string name="today_sunshine_total_minutes_only">%1$d min sol i dag</string>
+    <string name="today_uv_subtitle">UV-indeks pr. time pr. model</string>
+    <string name="today_uv_title">UV-indeks</string>
+    <string name="today_wind_peak">Topvind %1$d %2$s kl. %3$s</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -718,4 +718,26 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="today_forecast_air_section_title">Lufttemperatur</string>
     <string name="settings_default_bottom_title">Standard-Unterteil</string>
     <string name="settings_default_bottom_description">Was wir auf dem Startbildschirm vorschlagen, wenn es nicht warm genug für Shorts ist.</string>
+
+    <!-- Strings added to match base (new features). -->
+    <string name="settings_display_colors_title">Farbpalette</string>
+    <string name="settings_display_palette_accessible">Barrierefrei</string>
+    <string name="settings_display_palette_accessible_description">Eine an Okabe-Ito angelehnte Palette, die bei Deuteranopie, Protanopie und Tritanopie unterscheidbar bleibt. Konfidenz-Karten verwenden Himmelblau, Neutral und Bernstein statt Türkis, Neutral und Rot.</string>
+    <string name="settings_display_palette_rainbow">Regenbogen</string>
+    <string name="settings_display_palette_rainbow_description">Pinke, orange und grüne Diagrammlinien sowie türkis/rote Konfidenz-Karten. Standard.</string>
+    <string name="settings_unit_auto">Auto</string>
+    <string name="today_cloud_range">Bewölkung %1$d\u2013%2$d%%</string>
+    <string name="today_confidence_tap_to_hide">Tippen zum Ausblenden der Modellvorhersagen</string>
+    <string name="today_confidence_tap_to_show">Tippen für die Vorhersage je Modell</string>
+    <string name="today_humidity_range">Luftfeuchtigkeit %1$d\u2013%2$d%%</string>
+    <string name="today_solar_subtitle">Oberflächenstrahlung (W/m²) pro Stunde je Modell</string>
+    <string name="today_solar_title">Sonneneinstrahlung</string>
+    <string name="today_sunshine_subtitle">Sonnenstunden pro Stunde je Modell</string>
+    <string name="today_sunshine_title">Sonnenschein</string>
+    <string name="today_sunshine_total_hours_minutes">%1$d Std. %2$d Min. Sonne heute</string>
+    <string name="today_sunshine_total_hours_only">%1$d Std. Sonne heute</string>
+    <string name="today_sunshine_total_minutes_only">%1$d Min. Sonne heute</string>
+    <string name="today_uv_subtitle">UV-Index pro Stunde je Modell</string>
+    <string name="today_uv_title">UV-Index</string>
+    <string name="today_wind_peak">Spitze %1$d %2$s um %3$s</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -695,4 +695,26 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="today_forecast_air_section_title">Temperatura del aire</string>
     <string name="settings_default_bottom_title">Parte inferior estándar</string>
     <string name="settings_default_bottom_description">Lo que sugerimos en la pantalla de inicio cuando no hace suficiente calor para shorts.</string>
+
+    <!-- Strings added to match base (new features). -->
+    <string name="settings_display_colors_title">Paleta</string>
+    <string name="settings_display_palette_accessible">Accesible</string>
+    <string name="settings_display_palette_accessible_description">Una paleta derivada de Okabe-Ito diseñada para seguir siendo distinguible con deuteranopía, protanopía y tritanopía. Las tarjetas de confianza usan azul cielo, neutro y ámbar en lugar de verde azulado, neutro y rojo.</string>
+    <string name="settings_display_palette_rainbow">Arcoíris</string>
+    <string name="settings_display_palette_rainbow_description">Líneas de gráfico rosa, naranja y verde con tarjetas de confianza Material en verde azulado/rojo. La predeterminada.</string>
+    <string name="settings_unit_auto">Auto</string>
+    <string name="today_cloud_range">Nubosidad %1$d\u2013%2$d%%</string>
+    <string name="today_confidence_tap_to_hide">Toca para ocultar las previsiones por modelo</string>
+    <string name="today_confidence_tap_to_show">Toca para ver la previsión de cada modelo</string>
+    <string name="today_humidity_range">Humedad %1$d\u2013%2$d%%</string>
+    <string name="today_solar_subtitle">Irradiancia superficial (W/m²) por hora por modelo</string>
+    <string name="today_solar_title">Radiación solar</string>
+    <string name="today_sunshine_subtitle">Minutos de sol por hora por modelo</string>
+    <string name="today_sunshine_title">Horas de sol</string>
+    <string name="today_sunshine_total_hours_minutes">%1$dh %2$dm de sol hoy</string>
+    <string name="today_sunshine_total_hours_only">%1$dh de sol hoy</string>
+    <string name="today_sunshine_total_minutes_only">%1$dm de sol hoy</string>
+    <string name="today_uv_subtitle">Índice UV por hora por modelo</string>
+    <string name="today_uv_title">Índice UV</string>
+    <string name="today_wind_peak">Pico %1$d %2$s a las %3$s</string>
 </resources>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -173,8 +173,6 @@ Western Arabic numerals (0-9) are used for TTS compatibility.
     <string name="today_confidence_high">اطمینان بالا — مدل‌های اصلی توافق دارند</string>
     <string name="today_confidence_medium">اطمینان متوسط</string>
     <string name="today_confidence_low">اطمینان پایین — پیش‌بینی‌ها با هم اختلاف دارند</string>
-    <string name="today_low_confidence_callout_title">پیش‌بینی‌ها اختلاف دارند</string>
-    <string name="today_low_confidence_callout_body">دمای محدوده %1$.1f°C و احتمال بارندگی %2$.0f%% در %3$d مدل متفاوت است.</string>
 
     <!-- Today — loading / error states -->
     <string name="today_working">در حال کار — در حال دریافت ClothesCast شما…</string>
@@ -272,9 +270,6 @@ Western Arabic numerals (0-9) are used for TTS compatibility.
     <string name="settings_display_theme_system">پیروی از سیستم</string>
     <string name="settings_display_theme_light">روشن</string>
     <string name="settings_display_theme_dark">تیره</string>
-    <string name="settings_display_charts_title">نمودارها</string>
-    <string name="settings_display_model_spread_label">نمایش پراکندگی مدل در نمودارها</string>
-    <string name="settings_display_model_spread_description">پیش‌بینی ساعتی هر مدل آب‌وهوایی اصلی را روی نمودارهای دما و بارندگی همپوشانی می‌کند. برای تشخیص زمانی که پیش‌بینی نامطمئن است مفید است.</string>
 
     <!-- Settings — privacy -->
     <string name="settings_privacy_telemetry_title">گزارش‌های خرابی و استفاده</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -576,4 +576,27 @@ displayed label localizes.
     <string name="today_forecast_air_section_title">Ilman lämpötila</string>
     <string name="settings_default_bottom_title">Standardialaosa</string>
     <string name="settings_default_bottom_description">Mitä suosittelemme kotinäytöllä, kun ei ole tarpeeksi lämmintä shortseja varten.</string>
+
+    <!-- Strings added to match base (new features). -->
+    <string name="settings_display_colors_title">Väripaletti</string>
+    <string name="settings_display_palette_accessible">Saavutettava</string>
+    <string name="settings_display_palette_accessible_description">Okabe-Ito-pohjainen paletti, joka on suunniteltu pysymään erotettavana deuteranopian, protanopian ja tritanopian yhteydessä. Luotettavuuskortit käyttävät taivaansinistä, neutraalia ja meripihkaa tealin, neutraalin ja punaisen sijaan.</string>
+    <string name="settings_display_palette_rainbow">Sateenkaari</string>
+    <string name="settings_display_palette_rainbow_description">Vaaleanpunaiset, oranssit ja vihreät kaavioviivat sekä Material teal/punaiset luotettavuuskortit. Oletus.</string>
+    <string name="settings_unit_auto">Auto</string>
+    <string name="today_cloud_range">Pilvisyys %1$d\u2013%2$d%%</string>
+    <string name="today_confidence_precip_spread">Mallit ovat eri mieltä sateesta (Δ %1$.0f%% %2$d mallin kesken)</string>
+    <string name="today_confidence_tap_to_hide">Napauta piilottaaksesi malliennusteet</string>
+    <string name="today_confidence_tap_to_show">Napauta nähdäksesi jokaisen mallin ennuste</string>
+    <string name="today_humidity_range">Kosteus %1$d\u2013%2$d%%</string>
+    <string name="today_solar_subtitle">Pinnan säteilyvoimakkuus (W/m²) tunnissa per malli</string>
+    <string name="today_solar_title">Aurinkolämpösäteily</string>
+    <string name="today_sunshine_subtitle">Aurinkoisia minuutteja tunnissa per malli</string>
+    <string name="today_sunshine_title">Aurinkopaiste</string>
+    <string name="today_sunshine_total_hours_minutes">%1$d h %2$d min aurinkoa tänään</string>
+    <string name="today_sunshine_total_hours_only">%1$d h aurinkoa tänään</string>
+    <string name="today_sunshine_total_minutes_only">%1$d min aurinkoa tänään</string>
+    <string name="today_uv_subtitle">UV-indeksi tunnissa per malli</string>
+    <string name="today_uv_title">UV-indeksi</string>
+    <string name="today_wind_peak">Huippuarvo %1$d %2$s klo %3$s</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -694,4 +694,26 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="today_forecast_air_section_title">Température de l\'air</string>
     <string name="settings_default_bottom_title">Bas standard</string>
     <string name="settings_default_bottom_description">Ce que nous suggérons sur l\'écran d\'accueil quand il ne fait pas assez chaud pour les shorts.</string>
+
+    <!-- Strings added to match base (new features). -->
+    <string name="settings_display_colors_title">Palette</string>
+    <string name="settings_display_palette_accessible">Accessible</string>
+    <string name="settings_display_palette_accessible_description">Une palette inspirée d\'Okabe-Ito, conçue pour rester distinguable en cas de deutéranopie, protanopie et tritanopie. Les cartes de confiance utilisent bleu ciel, neutre et ambre au lieu de sarcelle, neutre et rouge.</string>
+    <string name="settings_display_palette_rainbow">Arc-en-ciel</string>
+    <string name="settings_display_palette_rainbow_description">Lignes de graphique roses, oranges et vertes avec des cartes de confiance sarcelle/rouge Material. Par défaut.</string>
+    <string name="settings_unit_auto">Auto</string>
+    <string name="today_cloud_range">Nuages %1$d\u2013%2$d%%</string>
+    <string name="today_confidence_tap_to_hide">Appuyer pour masquer les prévisions par modèle</string>
+    <string name="today_confidence_tap_to_show">Appuyer pour voir la prévision de chaque modèle</string>
+    <string name="today_humidity_range">Humidité %1$d\u2013%2$d%%</string>
+    <string name="today_solar_subtitle">Irradiance de surface (W/m²) par heure par modèle</string>
+    <string name="today_solar_title">Rayonnement solaire</string>
+    <string name="today_sunshine_subtitle">Minutes de soleil par heure par modèle</string>
+    <string name="today_sunshine_title">Ensoleillement</string>
+    <string name="today_sunshine_total_hours_minutes">%1$dh %2$dm de soleil aujourd\'hui</string>
+    <string name="today_sunshine_total_hours_only">%1$dh de soleil aujourd\'hui</string>
+    <string name="today_sunshine_total_minutes_only">%1$dm de soleil aujourd\'hui</string>
+    <string name="today_uv_subtitle">Indice UV par heure par modèle</string>
+    <string name="today_uv_title">Indice UV</string>
+    <string name="today_wind_peak">Pointe %1$d %2$s à %3$s</string>
 </resources>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -663,4 +663,26 @@ spousal register), matching the existing insight prose ("Ponesi …",
     <string name="today_forecast_air_section_title">Temperatura zraka</string>
     <string name="settings_default_bottom_title">Standardni donji dio</string>
     <string name="settings_default_bottom_description">Ono što predlažemo na početnom zaslonu kad nije dovoljno toplo za kratke hlače.</string>
+
+    <!-- Strings added to match base (new features). -->
+    <string name="settings_display_colors_title">Paleta</string>
+    <string name="settings_display_palette_accessible">Pristupačna</string>
+    <string name="settings_display_palette_accessible_description">Paleta izvedena iz Okabe-Ito-a, dizajnirana da ostane razlučiva u slučaju deuteranopije, protanopije i tritanopije. Kartice pouzdanosti koriste nebesko plavu, neutralnu i jantarnu umjesto tirkizne, neutralne i crvene.</string>
+    <string name="settings_display_palette_rainbow">Duga</string>
+    <string name="settings_display_palette_rainbow_description">Ružičaste, narančaste i zelene linije grafikona s tirkiznim/crvenim karticama pouzdanosti Material. Zadano.</string>
+    <string name="settings_unit_auto">Auto</string>
+    <string name="today_cloud_range">Oblačnost %1$d\u2013%2$d%%</string>
+    <string name="today_confidence_tap_to_hide">Dodirnite za skrivanje prognoza po modelu</string>
+    <string name="today_confidence_tap_to_show">Dodirnite za prikaz prognoze svakog modela</string>
+    <string name="today_humidity_range">Vlažnost %1$d\u2013%2$d%%</string>
+    <string name="today_solar_subtitle">Površinska iradijancija (W/m²) po satu po modelu</string>
+    <string name="today_solar_title">Sunčevo zračenje</string>
+    <string name="today_sunshine_subtitle">Minute sunca po satu po modelu</string>
+    <string name="today_sunshine_title">Sijanje sunca</string>
+    <string name="today_sunshine_total_hours_minutes">%1$dh %2$dm sunca danas</string>
+    <string name="today_sunshine_total_hours_only">%1$dh sunca danas</string>
+    <string name="today_sunshine_total_minutes_only">%1$dm sunca danas</string>
+    <string name="today_uv_subtitle">UV indeks po satu po modelu</string>
+    <string name="today_uv_title">UV indeks</string>
+    <string name="today_wind_peak">Vršna vrijednost %1$d %2$s u %3$s</string>
 </resources>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -586,4 +586,27 @@ locale (Angol (Egyesült Államok), Francia (Franciaország), Német
     <string name="today_forecast_air_section_title">Levegő hőmérséklete</string>
     <string name="settings_default_bottom_title">Alapértelmezett alsó ruha</string>
     <string name="settings_default_bottom_description">Amit a főképernyőn javaslunk, ha nem elég meleg a rövidnadrághoz.</string>
+
+    <!-- Strings added to match base (new features). -->
+    <string name="settings_display_colors_title">Paletta</string>
+    <string name="settings_display_palette_accessible">Akadálymentes</string>
+    <string name="settings_display_palette_accessible_description">Okabe-Ito alapú paletta, amelyet deuteranópia, protanópia és tritanópia esetén is megkülönböztethetőnek terveztek. A megbízhatósági kártyák kékeszöld, semleges és piros helyett égkéket, semlegeset és borostyánsárgát használnak.</string>
+    <string name="settings_display_palette_rainbow">Szivárvány</string>
+    <string name="settings_display_palette_rainbow_description">Rózsaszín, narancssárga és zöld diagramvonalak Material kékeszöld/piros megbízhatósági kártyákkal. Az alapértelmezett.</string>
+    <string name="settings_unit_auto">Auto</string>
+    <string name="today_cloud_range">Felhőzet %1$d\u2013%2$d%%</string>
+    <string name="today_confidence_precip_spread">A modellek nem értenek egyet a csapadékban (Δ %1$.0f%% %2$d modell között)</string>
+    <string name="today_confidence_tap_to_hide">Koppintson a modell-előrejelzések elrejtéséhez</string>
+    <string name="today_confidence_tap_to_show">Koppintson az egyes modellek előrejelzésének megtekintéséhez</string>
+    <string name="today_humidity_range">Páratartalom %1$d\u2013%2$d%%</string>
+    <string name="today_solar_subtitle">Felszíni besugárzás (W/m²) óránként modellenként</string>
+    <string name="today_solar_title">Napsugárzás</string>
+    <string name="today_sunshine_subtitle">Napsütéses percek óránként modellenként</string>
+    <string name="today_sunshine_title">Napsütés</string>
+    <string name="today_sunshine_total_hours_minutes">%1$d ó %2$d p napsütés ma</string>
+    <string name="today_sunshine_total_hours_only">%1$d ó napsütés ma</string>
+    <string name="today_sunshine_total_minutes_only">%1$d p napsütés ma</string>
+    <string name="today_uv_subtitle">UV-index óránként modellenként</string>
+    <string name="today_uv_title">UV-index</string>
+    <string name="today_wind_peak">Csúcs %1$d %2$s, %3$s-kor</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -680,4 +680,26 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="today_forecast_air_section_title">Temperatura dell\'aria</string>
     <string name="settings_default_bottom_title">Fondo standard</string>
     <string name="settings_default_bottom_description">Cosa consigliamo nella schermata iniziale quando non fa abbastanza caldo per i pantaloncini.</string>
+
+    <!-- Strings added to match base (new features). -->
+    <string name="settings_display_colors_title">Tavolozza</string>
+    <string name="settings_display_palette_accessible">Accessibile</string>
+    <string name="settings_display_palette_accessible_description">Una tavolozza derivata da Okabe-Ito, progettata per rimanere distinguibile in caso di deuteranopia, protanopia e tritanopia. Le schede di affidabilità usano azzurro cielo, neutro e ambra al posto di verde acqua, neutro e rosso.</string>
+    <string name="settings_display_palette_rainbow">Arcobaleno</string>
+    <string name="settings_display_palette_rainbow_description">Linee del grafico rosa, arancione e verde con schede di affidabilità Material verde acqua/rosso. Il valore predefinito.</string>
+    <string name="settings_unit_auto">Auto</string>
+    <string name="today_cloud_range">Nuvolosità %1$d\u2013%2$d%%</string>
+    <string name="today_confidence_tap_to_hide">Tocca per nascondere le previsioni per modello</string>
+    <string name="today_confidence_tap_to_show">Tocca per vedere le previsioni di ogni modello</string>
+    <string name="today_humidity_range">Umidità %1$d\u2013%2$d%%</string>
+    <string name="today_solar_subtitle">Irradianza superficiale (W/m²) per ora per modello</string>
+    <string name="today_solar_title">Radiazione solare</string>
+    <string name="today_sunshine_subtitle">Minuti di sole per ora per modello</string>
+    <string name="today_sunshine_title">Soleggiamento</string>
+    <string name="today_sunshine_total_hours_minutes">%1$dh %2$dm di sole oggi</string>
+    <string name="today_sunshine_total_hours_only">%1$dh di sole oggi</string>
+    <string name="today_sunshine_total_minutes_only">%1$dm di sole oggi</string>
+    <string name="today_uv_subtitle">Indice UV per ora per modello</string>
+    <string name="today_uv_title">Indice UV</string>
+    <string name="today_wind_peak">Picco %1$d %2$s alle %3$s</string>
 </resources>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -179,8 +179,6 @@ standard in Israeli digital communication.
     <string name="today_confidence_high">אמון גבוה — מודלים עיקריים מסכימים</string>
     <string name="today_confidence_medium">אמון בינוני</string>
     <string name="today_confidence_low">אמון נמוך — תחזיות אינן מסכימות</string>
-    <string name="today_low_confidence_callout_title">התחזיות חלוקות</string>
-    <string name="today_low_confidence_callout_body">טווח הטמפרטורה משתנה ב-%1$.1f°C וסיכוי לגשם ב-%2$.0f%% על פני %3$d מודלים.</string>
 
     <!-- Today — loading / error states -->
     <string name="today_working">עובד/ת — מוריד/ת את ClothesCast שלך…</string>
@@ -278,9 +276,6 @@ standard in Israeli digital communication.
     <string name="settings_display_theme_system">עקוב/י אחר המערכת</string>
     <string name="settings_display_theme_light">בהיר</string>
     <string name="settings_display_theme_dark">כהה</string>
-    <string name="settings_display_charts_title">גרפים</string>
-    <string name="settings_display_model_spread_label">הצג/י פיזור מודלים בגרפים</string>
-    <string name="settings_display_model_spread_description">מציג שכבת-על של התחזית השעתית של כל מודל מזג אוויר עיקרי על גרפי הטמפרטורה והגשם. שימושי לזיהוי אי-ודאות בתחזית.</string>
 
     <!-- Settings — privacy / telemetry -->
     <string name="settings_privacy_telemetry_title">דוחות קריסה ושימוש</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -595,4 +595,27 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrike)").
     <string name="today_forecast_air_section_title">Lufttemperatur</string>
     <string name="settings_default_bottom_title">Standard underdel</string>
     <string name="settings_default_bottom_description">Hva vi foreslår på startskjermen når det ikke er varmt nok for shorts.</string>
+
+    <!-- Strings added to match base (new features). -->
+    <string name="settings_display_colors_title">Palett</string>
+    <string name="settings_display_palette_accessible">Tilgjengelig</string>
+    <string name="settings_display_palette_accessible_description">En Okabe-Ito-basert palett utformet for å forbli skillbar ved deuteranopi, protanopi og tritanopi. Tillitskorte bruker himmelblå, nøytral og rav i stedet for teal, nøytral og rød.</string>
+    <string name="settings_display_palette_rainbow">Regnbue</string>
+    <string name="settings_display_palette_rainbow_description">Rosa, oransje og grønne diagramlinjer med Material teal/røde tillitskort. Standard.</string>
+    <string name="settings_unit_auto">Auto</string>
+    <string name="today_cloud_range">Skydekke %1$d\u2013%2$d%%</string>
+    <string name="today_confidence_precip_spread">Modellene er uenige om nedbør (Δ %1$.0f%% på tvers av %2$d modeller)</string>
+    <string name="today_confidence_tap_to_hide">Trykk for å skjule modellprognoser</string>
+    <string name="today_confidence_tap_to_show">Trykk for å se hver modells prognose</string>
+    <string name="today_humidity_range">Luftfuktighet %1$d\u2013%2$d%%</string>
+    <string name="today_solar_subtitle">Overflateinnstråling (W/m²) per time per modell</string>
+    <string name="today_solar_title">Solinnstråling</string>
+    <string name="today_sunshine_subtitle">Minutter sol per time per modell</string>
+    <string name="today_sunshine_title">Solskinn</string>
+    <string name="today_sunshine_total_hours_minutes">%1$d t %2$d min sol i dag</string>
+    <string name="today_sunshine_total_hours_only">%1$d t sol i dag</string>
+    <string name="today_sunshine_total_minutes_only">%1$d min sol i dag</string>
+    <string name="today_uv_subtitle">UV-indeks per time per modell</string>
+    <string name="today_uv_title">UV-indeks</string>
+    <string name="today_wind_peak">Toppvind %1$d %2$s kl. %3$s</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -642,4 +642,27 @@ the displayed label localizes.
     <string name="today_forecast_air_section_title">Luchttemperatuur</string>
     <string name="settings_default_bottom_title">Standaard onderstuk</string>
     <string name="settings_default_bottom_description">Wat we op het beginscherm voorstellen als het niet warm genoeg is voor shorts.</string>
+
+    <!-- Strings added to match base (new features). -->
+    <string name="settings_display_colors_title">Palet</string>
+    <string name="settings_display_palette_accessible">Toegankelijk</string>
+    <string name="settings_display_palette_accessible_description">Een van Okabe-Ito afgeleid palet dat onderscheidbaar blijft bij deuteranopie, protanopie en tritanopie. Betrouwbaarheidskaarten gebruiken hemelsblauw, neutraal en amber in plaats van teal, neutraal en rood.</string>
+    <string name="settings_display_palette_rainbow">Regenboog</string>
+    <string name="settings_display_palette_rainbow_description">Roze, oranje en groene grafieklijnen met Material teal/rode betrouwbaarheidskaarten. De standaard.</string>
+    <string name="settings_unit_auto">Auto</string>
+    <string name="today_cloud_range">Bewolking %1$d\u2013%2$d%%</string>
+    <string name="today_confidence_precip_spread">Modellen het niet eens over neerslag (Δ %1$.0f%% over %2$d modellen)</string>
+    <string name="today_confidence_tap_to_hide">Tik om modelprognoses te verbergen</string>
+    <string name="today_confidence_tap_to_show">Tik om de prognose van elk model te zien</string>
+    <string name="today_humidity_range">Luchtvochtigheid %1$d\u2013%2$d%%</string>
+    <string name="today_solar_subtitle">Oppervlakte-instraling (W/m²) per uur per model</string>
+    <string name="today_solar_title">Zonnestraling</string>
+    <string name="today_sunshine_subtitle">Minuten zon per uur per model</string>
+    <string name="today_sunshine_title">Zonneschijn</string>
+    <string name="today_sunshine_total_hours_minutes">%1$du %2$dm zon vandaag</string>
+    <string name="today_sunshine_total_hours_only">%1$du zon vandaag</string>
+    <string name="today_sunshine_total_minutes_only">%1$dm zon vandaag</string>
+    <string name="today_uv_subtitle">UV-index per uur per model</string>
+    <string name="today_uv_title">UV-index</string>
+    <string name="today_wind_peak">Piek %1$d %2$s om %3$s</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -640,4 +640,27 @@ is unchanged; only the displayed label localizes.
     <string name="today_forecast_air_section_title">Temperatura powietrza</string>
     <string name="settings_default_bottom_title">Standardowy dół</string>
     <string name="settings_default_bottom_description">To, co proponujemy na ekranie głównym, gdy jest za zimno na szorty.</string>
+
+    <!-- Strings added to match base (new features). -->
+    <string name="settings_display_colors_title">Paleta</string>
+    <string name="settings_display_palette_accessible">Dostępna</string>
+    <string name="settings_display_palette_accessible_description">Paleta wywodząca się z Okabe-Ito, zaprojektowana tak, aby pozostała rozróżnialna przy deuteranopii, protanopii i tritanopii. Karty pewności używają błękitu nieba, neutralnego i bursztynowego zamiast turkusowego, neutralnego i czerwonego.</string>
+    <string name="settings_display_palette_rainbow">Tęcza</string>
+    <string name="settings_display_palette_rainbow_description">Różowe, pomarańczowe i zielone linie wykresów z turkusowo/czerwonymi kartami pewności Material. Domyślna.</string>
+    <string name="settings_unit_auto">Auto</string>
+    <string name="today_cloud_range">Zachmurzenie %1$d\u2013%2$d%%</string>
+    <string name="today_confidence_precip_spread">Modele nie zgadzają się co do opadów (Δ %1$.0f%% dla %2$d modeli)</string>
+    <string name="today_confidence_tap_to_hide">Dotknij, aby ukryć prognozy modeli</string>
+    <string name="today_confidence_tap_to_show">Dotknij, aby zobaczyć prognozę każdego modelu</string>
+    <string name="today_humidity_range">Wilgotność %1$d\u2013%2$d%%</string>
+    <string name="today_solar_subtitle">Natężenie promieniowania powierzchniowego (W/m²) na godzinę per model</string>
+    <string name="today_solar_title">Promieniowanie słoneczne</string>
+    <string name="today_sunshine_subtitle">Minuty słońca na godzinę per model</string>
+    <string name="today_sunshine_title">Nasłonecznienie</string>
+    <string name="today_sunshine_total_hours_minutes">%1$dg %2$dm słońca dziś</string>
+    <string name="today_sunshine_total_hours_only">%1$dg słońca dziś</string>
+    <string name="today_sunshine_total_minutes_only">%1$dm słońca dziś</string>
+    <string name="today_uv_subtitle">Indeks UV na godzinę per model</string>
+    <string name="today_uv_title">Indeks UV</string>
+    <string name="today_wind_peak">Szczyt %1$d %2$s o %3$s</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -681,4 +681,27 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="today_forecast_air_section_title">Temperatura do ar</string>
     <string name="settings_default_bottom_title">Parte inferior padrão</string>
     <string name="settings_default_bottom_description">O que sugerimos na tela inicial quando não está quente o suficiente para shorts.</string>
+
+    <!-- Strings added to match base (new features). -->
+    <string name="settings_display_colors_title">Paleta</string>
+    <string name="settings_display_palette_accessible">Acessível</string>
+    <string name="settings_display_palette_accessible_description">Uma paleta derivada de Okabe-Ito, projetada para permanecer distinguível em deuteranopia, protanopia e tritanopia. Os cartões de confiança usam azul-céu, neutro e âmbar em vez de verde-azulado, neutro e vermelho.</string>
+    <string name="settings_display_palette_rainbow">Arco-íris</string>
+    <string name="settings_display_palette_rainbow_description">Linhas de gráfico rosa, laranja e verde com cartões de confiança Material verde-azulado/vermelho. O padrão.</string>
+    <string name="settings_unit_auto">Auto</string>
+    <string name="today_cloud_range">Nuvens %1$d\u2013%2$d%%</string>
+    <string name="today_confidence_precip_spread">Os modelos discordam sobre chuva (Δ %1$.0f%% em %2$d modelos)</string>
+    <string name="today_confidence_tap_to_hide">Toque para ocultar as previsões por modelo</string>
+    <string name="today_confidence_tap_to_show">Toque para ver a previsão de cada modelo</string>
+    <string name="today_humidity_range">Umidade %1$d\u2013%2$d%%</string>
+    <string name="today_solar_subtitle">Irradiância superficial (W/m²) por hora por modelo</string>
+    <string name="today_solar_title">Radiação solar</string>
+    <string name="today_sunshine_subtitle">Minutos de sol por hora por modelo</string>
+    <string name="today_sunshine_title">Insolação</string>
+    <string name="today_sunshine_total_hours_minutes">%1$dh %2$dm de sol hoje</string>
+    <string name="today_sunshine_total_hours_only">%1$dh de sol hoje</string>
+    <string name="today_sunshine_total_minutes_only">%1$dm de sol hoje</string>
+    <string name="today_uv_subtitle">Índice UV por hora por modelo</string>
+    <string name="today_uv_title">Índice UV</string>
+    <string name="today_wind_peak">Pico de %1$d %2$s às %3$s</string>
 </resources>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -723,4 +723,27 @@ they diverge from BR ("Polonês" → "Polaco", "Holandês" →
     <string name="today_forecast_air_section_title">Temperatura do ar</string>
     <string name="settings_default_bottom_title">Parte inferior padrão</string>
     <string name="settings_default_bottom_description">O que sugerimos no ecrã inicial quando não está quente o suficiente para calções.</string>
+
+    <!-- Strings added to match base (new features). -->
+    <string name="settings_display_colors_title">Paleta</string>
+    <string name="settings_display_palette_accessible">Acessível</string>
+    <string name="settings_display_palette_accessible_description">Uma paleta derivada de Okabe-Ito, concebida para permanecer distinguível em deuteranopia, protanopia e tritanopia. Os cartões de confiança utilizam azul-céu, neutro e âmbar em vez de verde-azulado, neutro e vermelho.</string>
+    <string name="settings_display_palette_rainbow">Arco-íris</string>
+    <string name="settings_display_palette_rainbow_description">Linhas de gráfico rosa, cor-de-laranja e verde com cartões de confiança Material verde-azulado/vermelho. A predefinição.</string>
+    <string name="settings_unit_auto">Auto</string>
+    <string name="today_cloud_range">Nuvens %1$d\u2013%2$d%%</string>
+    <string name="today_confidence_precip_spread">Os modelos discordam sobre chuva (Δ %1$.0f%% em %2$d modelos)</string>
+    <string name="today_confidence_tap_to_hide">Toque para ocultar as previsões por modelo</string>
+    <string name="today_confidence_tap_to_show">Toque para ver a previsão de cada modelo</string>
+    <string name="today_humidity_range">Humidade %1$d\u2013%2$d%%</string>
+    <string name="today_solar_subtitle">Irradiância superficial (W/m²) por hora por modelo</string>
+    <string name="today_solar_title">Radiação solar</string>
+    <string name="today_sunshine_subtitle">Minutos de sol por hora por modelo</string>
+    <string name="today_sunshine_title">Insolação</string>
+    <string name="today_sunshine_total_hours_minutes">%1$dh %2$dm de sol hoje</string>
+    <string name="today_sunshine_total_hours_only">%1$dh de sol hoje</string>
+    <string name="today_sunshine_total_minutes_only">%1$dm de sol hoje</string>
+    <string name="today_uv_subtitle">Índice UV por hora por modelo</string>
+    <string name="today_uv_title">Índice UV</string>
+    <string name="today_wind_peak">Pico de %1$d %2$s às %3$s</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -651,4 +651,27 @@ only the displayed label localizes.
     <string name="today_forecast_air_section_title">Температура воздуха</string>
     <string name="settings_default_bottom_title">Стандартный низ</string>
     <string name="settings_default_bottom_description">То, что мы предлагаем на главном экране, когда недостаточно тепло для шортов.</string>
+
+    <!-- Strings added to match base (new features). -->
+    <string name="settings_display_colors_title">Палитра</string>
+    <string name="settings_display_palette_accessible">Доступная</string>
+    <string name="settings_display_palette_accessible_description">Палитра на основе Okabe-Ito, разработанная для различимости при дейтеранопии, протанопии и тританопии. Карточки достоверности используют голубой, нейтральный и янтарный вместо бирюзового, нейтрального и красного.</string>
+    <string name="settings_display_palette_rainbow">Радуга</string>
+    <string name="settings_display_palette_rainbow_description">Розовые, оранжевые и зелёные линии графиков с карточками достоверности Material бирюзово/красного цвета. По умолчанию.</string>
+    <string name="settings_unit_auto">Авто</string>
+    <string name="today_cloud_range">Облачность %1$d\u2013%2$d%%</string>
+    <string name="today_confidence_precip_spread">Модели расходятся во мнении о дожде (Δ %1$.0f%% по %2$d моделям)</string>
+    <string name="today_confidence_tap_to_hide">Нажмите, чтобы скрыть прогнозы моделей</string>
+    <string name="today_confidence_tap_to_show">Нажмите, чтобы увидеть прогноз каждой модели</string>
+    <string name="today_humidity_range">Влажность %1$d\u2013%2$d%%</string>
+    <string name="today_solar_subtitle">Поверхностная облучённость (Вт/м²) по часам по моделям</string>
+    <string name="today_solar_title">Солнечная радиация</string>
+    <string name="today_sunshine_subtitle">Минуты солнца в час по моделям</string>
+    <string name="today_sunshine_title">Солнечное сияние</string>
+    <string name="today_sunshine_total_hours_minutes">%1$d ч %2$d мин солнца сегодня</string>
+    <string name="today_sunshine_total_hours_only">%1$d ч солнца сегодня</string>
+    <string name="today_sunshine_total_minutes_only">%1$d мин солнца сегодня</string>
+    <string name="today_uv_subtitle">УФ-индекс по часам по моделям</string>
+    <string name="today_uv_title">УФ-индекс</string>
+    <string name="today_wind_peak">Максимум %1$d %2$s в %3$s</string>
 </resources>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -595,4 +595,27 @@ native names for all locales (e.g. "Tyska (Tyskland)", "Franska (Frankrike)").
     <string name="today_forecast_air_section_title">Lufttemperatur</string>
     <string name="settings_default_bottom_title">Standard underdel</string>
     <string name="settings_default_bottom_description">Vad vi föreslår på startskärmen när det inte är varmt nog för shorts.</string>
+
+    <!-- Strings added to match base (new features). -->
+    <string name="settings_display_colors_title">Palett</string>
+    <string name="settings_display_palette_accessible">Tillgänglig</string>
+    <string name="settings_display_palette_accessible_description">En Okabe-Ito-baserad palett utformad för att förbli urskiljbar vid deuteranopi, protanopi och tritanopi. Konfidenskorten använder himmelsblått, neutralt och bärnsten i stället för teal, neutralt och rött.</string>
+    <string name="settings_display_palette_rainbow">Regnbåge</string>
+    <string name="settings_display_palette_rainbow_description">Rosa, orange och gröna diagramlinjer med Material teal/röda konfidenskort. Standardalternativet.</string>
+    <string name="settings_unit_auto">Auto</string>
+    <string name="today_cloud_range">Molnighet %1$d\u2013%2$d%%</string>
+    <string name="today_confidence_precip_spread">Modellerna är oeniga om regn (Δ %1$.0f%% för %2$d modeller)</string>
+    <string name="today_confidence_tap_to_hide">Tryck för att dölja modellprognoser</string>
+    <string name="today_confidence_tap_to_show">Tryck för att se varje modells prognos</string>
+    <string name="today_humidity_range">Luftfuktighet %1$d\u2013%2$d%%</string>
+    <string name="today_solar_subtitle">Ytbestrålningsstyrka (W/m²) per timme per modell</string>
+    <string name="today_solar_title">Solinstrålning</string>
+    <string name="today_sunshine_subtitle">Minuter sol per timme per modell</string>
+    <string name="today_sunshine_title">Solsken</string>
+    <string name="today_sunshine_total_hours_minutes">%1$d tim %2$d min sol idag</string>
+    <string name="today_sunshine_total_hours_only">%1$d tim sol idag</string>
+    <string name="today_sunshine_total_minutes_only">%1$d min sol idag</string>
+    <string name="today_uv_subtitle">UV-index per timme per modell</string>
+    <string name="today_uv_title">UV-index</string>
+    <string name="today_wind_peak">Topphastighet %1$d %2$s kl. %3$s</string>
 </resources>

--- a/app/src/main/res/values-sw/strings.xml
+++ b/app/src/main/res/values-sw/strings.xml
@@ -160,8 +160,6 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="today_confidence_high">Imani ya juu — mifano mikubwa inakubaliana</string>
     <string name="today_confidence_medium">Imani ya kati</string>
     <string name="today_confidence_low">Imani ya chini — utabiri hutofautiana</string>
-    <string name="today_low_confidence_callout_title">Utabiri hutofautiana</string>
-    <string name="today_low_confidence_callout_body">Halijoto inatofautiana kwa %1$.1f°C na uwezekano wa mvua kwa %2$.0f%% kwenye mifano %3$d.</string>
 
     <!-- Today status / errors -->
     <string name="today_working">Inafanya kazi — inashuka ClothesCast yako…</string>
@@ -250,9 +248,6 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="settings_display_theme_system">Fuata mfumo</string>
     <string name="settings_display_theme_light">Mwanga</string>
     <string name="settings_display_theme_dark">Giza</string>
-    <string name="settings_display_charts_title">Chati</string>
-    <string name="settings_display_model_spread_label">Onyesha usambazaji wa mifano kwenye chati</string>
-    <string name="settings_display_model_spread_description">Inaweka tabaka mstari wa kila mfano mkubwa wa hali ya hewa kwenye chati za halijoto na mvua. Muhimu kwa kutambua wakati utabiri hauna uhakika.</string>
 
     <!-- Settings: location -->
     <string name="settings_root_location_subtitle">Gundua kiotomatiki au chagua mji</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -575,4 +575,27 @@ displayed label localizes.
     <string name="today_forecast_air_section_title">Hava sıcaklığı</string>
     <string name="settings_default_bottom_title">Standart alt giysi</string>
     <string name="settings_default_bottom_description">Şort için yeterince sıcak olmadığında ana ekranda önerdiğimiz şey.</string>
+
+    <!-- Strings added to match base (new features). -->
+    <string name="settings_display_colors_title">Palet</string>
+    <string name="settings_display_palette_accessible">Erişilebilir</string>
+    <string name="settings_display_palette_accessible_description">Deuteranopi, protanopi ve tritanopide ayırt edilebilir kalacak şekilde tasarlanmış, Okabe-Ito\'dan türetilmiş bir palet. Güven kartları teal, nötr ve kırmızı yerine gök mavisi, nötr ve kehribar rengi kullanır.</string>
+    <string name="settings_display_palette_rainbow">Gökkuşağı</string>
+    <string name="settings_display_palette_rainbow_description">Pembe, turuncu ve yeşil grafik çizgileri ile Material teal/kırmızı güven kartları. Varsayılan.</string>
+    <string name="settings_unit_auto">Otomatik</string>
+    <string name="today_cloud_range">Bulutluluk %1$d\u2013%2$d%%</string>
+    <string name="today_confidence_precip_spread">Modeller yağmur konusunda hemfikir değil (Δ %1$.0f%%, %2$d model arasında)</string>
+    <string name="today_confidence_tap_to_hide">Model tahminlerini gizlemek için dokunun</string>
+    <string name="today_confidence_tap_to_show">Her modelin tahminini görmek için dokunun</string>
+    <string name="today_humidity_range">Nem %1$d\u2013%2$d%%</string>
+    <string name="today_solar_subtitle">Yüzey ışıması (W/m²) saate göre model başına</string>
+    <string name="today_solar_title">Güneş ışıması</string>
+    <string name="today_sunshine_subtitle">Saate göre güneş dakikaları model başına</string>
+    <string name="today_sunshine_title">Güneşlenme</string>
+    <string name="today_sunshine_total_hours_minutes">Bugün %1$d sa %2$d dk güneş</string>
+    <string name="today_sunshine_total_hours_only">Bugün %1$d sa güneş</string>
+    <string name="today_sunshine_total_minutes_only">Bugün %1$d dk güneş</string>
+    <string name="today_uv_subtitle">Saate göre UV endeksi model başına</string>
+    <string name="today_uv_title">UV endeksi</string>
+    <string name="today_wind_peak">Tepe %1$d %2$s, saat %3$s</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -24,21 +24,11 @@
          coordinates but no friendly city name (reverse geocoding returned
          nothing useful, or the device is on AOSP without a backend). The
          link still opens the user's maps app at the actual coords. -->
-    <!-- TODO(translations): today_location_unknown, today_retrying,
-         today_crash_banner_*, onboarding_subtitle_tv,
-         onboarding_location_grant_background,
-         onboarding_location_background_needed,
-         onboarding_location_enter_manual_hint, settings_root_display/
-         _location/_calendar (+ _subtitle variants),
-         settings_display_theme_*, settings_api_key_gemini_header,
-         settings_location_use_device_description/_detecting/
-         _background_banner_*/_manual_override*,
-         settings_tts_engine_description, today_update_available_*,
-         today_update_downloaded_* are translated for
+    <!-- TODO(translations): the strings below are translated for
          de/fr/es/it/pt-BR/pt-PT/hr/nl/pl/ru/sv/da/nb/fi/tr/cs/hu
          (de-AT/CH, fr-CA, es-MX inherit via Android's base-language
          fallback and need no separate entry), but still missing from
-         all other language trees:
+         the remaining language trees:
          et, lv, lt, sk, ro, bg, sl, sr, el, uk, ca, ar, he, fa,
          bn, ja, ko, zh-CN, zh-TW, th, vi, id, ms, fil, sw, am, sq,
          and any future additions. -->


### PR DESCRIPTION
## Summary

- **Remove 5 stale keys** from `am`, `ar`, `fa`, `iw`, `sw`: `settings_display_charts_title`, `settings_display_model_spread_label`, `settings_display_model_spread_description`, `today_low_confidence_callout_title`, `today_low_confidence_callout_body`. These were renamed/removed in the base file but the translated copies were never cleaned up.
- **Add 20–21 missing strings** to the 17 main locales (`de`, `fr`, `es`, `it`, `pt-BR`, `pt-PT`, `hr`, `nl`, `pl`, `ru`, `sv`, `da`, `nb`, `fi`, `tr`, `cs`, `hu`): the solar, sunshine, UV, wind-peak, cloud-range, humidity-range, confidence tap-to-show/hide, precip-spread (where absent), and palette/color settings strings that were added to the base file since the last translation pass.
- **Trim the stale TODO comment** in `values/strings.xml` — the main-locale debt is now cleared; the comment still lists the ~20 lower-priority language trees that remain untranslated.

## Scope

Only `app/src/main/res/values*/strings.xml` files touched. No code changes.

## Test plan

- [ ] XML parses cleanly (`xmllint` or Android build) — confirmed locally via Python ET
- [ ] Run `:app:assembleDebug` to verify no missing-resource build errors
- [ ] Spot-check a few added strings in-app under German and French locales

https://claude.ai/code/session_01LoYYyN5Qsya1Nx757Fvn7c

---
_Generated by [Claude Code](https://claude.ai/code/session_01LoYYyN5Qsya1Nx757Fvn7c)_