### PR TITLE
Add missing translated strings to ja, ko, zh-CN, zh-TW

### DIFF
--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -700,4 +700,27 @@ the displayed label localizes.
     <string name="today_forecast_air_section_title">気温</string>
     <string name="settings_default_bottom_title">標準ボトム</string>
     <string name="settings_default_bottom_description">ショートパンツには寒すぎる時に、ホーム画面でおすすめするもの。</string>
+
+    <!-- Strings added to match base (new features). -->
+    <string name="settings_display_colors_title">カラーパレット</string>
+    <string name="settings_display_palette_accessible">アクセシブル</string>
+    <string name="settings_display_palette_accessible_description">第二色盲・第一色盲・第三色盲でも識別しやすいOkabe-Itoベースのパレット。信頼度カードはティール・ニュートラル・レッドの代わりにスカイブルー・ニュートラル・アンバーを使用。</string>
+    <string name="settings_display_palette_rainbow">レインボー</string>
+    <string name="settings_display_palette_rainbow_description">ピンク・オレンジ・グリーンのグラフ線とMaterialのティール/レッドの信頼度カード。デフォルト設定。</string>
+    <string name="settings_unit_auto">自動</string>
+    <string name="today_cloud_range">雲量 %1$d〜%2$d%%</string>
+    <string name="today_confidence_precip_spread">降水確率でモデル間に差あり（Δ %1$.0f%%、%2$dモデル間）</string>
+    <string name="today_confidence_tap_to_hide">タップしてモデル別の予報を非表示</string>
+    <string name="today_confidence_tap_to_show">タップして各モデルの予報を表示</string>
+    <string name="today_humidity_range">湿度 %1$d〜%2$d%%</string>
+    <string name="today_solar_subtitle">モデル別の地表面日射量（W/m²）、1時間ごと</string>
+    <string name="today_solar_title">日射量</string>
+    <string name="today_sunshine_subtitle">モデル別の1時間あたりの日照分数</string>
+    <string name="today_sunshine_title">日照時間</string>
+    <string name="today_sunshine_total_hours_minutes">本日の日照時間 %1$d時間%2$d分</string>
+    <string name="today_sunshine_total_hours_only">本日の日照時間 %1$d時間</string>
+    <string name="today_sunshine_total_minutes_only">本日の日照時間 %1$d分</string>
+    <string name="today_uv_subtitle">モデル別のUV指数、1時間ごと</string>
+    <string name="today_uv_title">UV指数</string>
+    <string name="today_wind_peak">最大 %1$d %2$s（%3$s）</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -704,4 +704,27 @@ displayed label localizes.
     <string name="today_forecast_air_section_title">기온</string>
     <string name="settings_default_bottom_title">기본 하의</string>
     <string name="settings_default_bottom_description">반바지를 입기에 충분히 따뜻하지 않을 때 홈 화면에서 추천하는 것.</string>
+
+    <!-- Strings added to match base (new features). -->
+    <string name="settings_display_colors_title">팔레트</string>
+    <string name="settings_display_palette_accessible">접근성</string>
+    <string name="settings_display_palette_accessible_description">제2색맹, 제1색맹, 제3색맹에서도 구별 가능하도록 설계된 Okabe-Ito 기반 팔레트. 신뢰도 카드는 청록, 중립, 빨강 대신 하늘색, 중립, 호박색을 사용합니다.</string>
+    <string name="settings_display_palette_rainbow">레인보우</string>
+    <string name="settings_display_palette_rainbow_description">핑크, 주황, 초록 차트 선과 Material 청록/빨강 신뢰도 카드. 기본값.</string>
+    <string name="settings_unit_auto">자동</string>
+    <string name="today_cloud_range">구름량 %1$d〜%2$d%%</string>
+    <string name="today_confidence_precip_spread">강수 확률에서 모델 간 의견 불일치 (Δ %1$.0f%%, %2$d개 모델)</string>
+    <string name="today_confidence_tap_to_hide">모델 예보를 숨기려면 탭하세요</string>
+    <string name="today_confidence_tap_to_show">각 모델의 예보를 보려면 탭하세요</string>
+    <string name="today_humidity_range">습도 %1$d〜%2$d%%</string>
+    <string name="today_solar_subtitle">모델별 시간당 지면 일사량 (W/m²)</string>
+    <string name="today_solar_title">태양 복사량</string>
+    <string name="today_sunshine_subtitle">모델별 시간당 햇빛 분</string>
+    <string name="today_sunshine_title">일조 시간</string>
+    <string name="today_sunshine_total_hours_minutes">오늘 햇빛 %1$d시간 %2$d분</string>
+    <string name="today_sunshine_total_hours_only">오늘 햇빛 %1$d시간</string>
+    <string name="today_sunshine_total_minutes_only">오늘 햇빛 %1$d분</string>
+    <string name="today_uv_subtitle">모델별 시간당 자외선 지수</string>
+    <string name="today_uv_title">자외선 지수</string>
+    <string name="today_wind_peak">최대 %1$d %2$s (%3$s)</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -692,4 +692,27 @@ label localizes.
     <string name="today_forecast_air_section_title">气温</string>
     <string name="settings_default_bottom_title">默认下装</string>
     <string name="settings_default_bottom_description">当天气不够暖和、不适合穿短裤时，主屏幕显示的建议。</string>
+
+    <!-- Strings added to match base (new features). -->
+    <string name="settings_display_colors_title">调色板</string>
+    <string name="settings_display_palette_accessible">无障碍</string>
+    <string name="settings_display_palette_accessible_description">基于 Okabe-Ito 的调色板，设计上在绿色弱视、红色弱视和蓝色弱视情况下仍可辨识。置信度卡片使用天蓝色、中性色和琥珀色，而非青色、中性色和红色。</string>
+    <string name="settings_display_palette_rainbow">彩虹</string>
+    <string name="settings_display_palette_rainbow_description">粉红、橙色和绿色图表线条，以及 Material 青色/红色置信度卡片。默认设置。</string>
+    <string name="settings_unit_auto">自动</string>
+    <string name="today_cloud_range">云量 %1$d〜%2$d%%</string>
+    <string name="today_confidence_precip_spread">各模型对降水意见不一（Δ %1$.0f%%，共 %2$d 个模型）</string>
+    <string name="today_confidence_tap_to_hide">点击隐藏模型预报</string>
+    <string name="today_confidence_tap_to_show">点击查看各模型预报</string>
+    <string name="today_humidity_range">湿度 %1$d〜%2$d%%</string>
+    <string name="today_solar_subtitle">各模型每小时地面辐照度（W/m²）</string>
+    <string name="today_solar_title">太阳辐射</string>
+    <string name="today_sunshine_subtitle">各模型每小时的日照分钟数</string>
+    <string name="today_sunshine_title">日照</string>
+    <string name="today_sunshine_total_hours_minutes">今日日照 %1$d小时%2$d分钟</string>
+    <string name="today_sunshine_total_hours_only">今日日照 %1$d小时</string>
+    <string name="today_sunshine_total_minutes_only">今日日照 %1$d分钟</string>
+    <string name="today_uv_subtitle">各模型每小时紫外线指数</string>
+    <string name="today_uv_title">紫外线指数</string>
+    <string name="today_wind_peak">最高 %1$d %2$s（%3$s）</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -708,4 +708,27 @@ label localises.
     <string name="today_forecast_air_section_title">氣溫</string>
     <string name="settings_default_bottom_title">預設下身</string>
     <string name="settings_default_bottom_description">當天氣不夠暖和、不適合穿短褲時，主畫面顯示的建議。</string>
+
+    <!-- Strings added to match base (new features). -->
+    <string name="settings_display_colors_title">調色板</string>
+    <string name="settings_display_palette_accessible">無障礙</string>
+    <string name="settings_display_palette_accessible_description">基於 Okabe-Ito 的調色板，設計上在綠色弱視、紅色弱視和藍色弱視情況下仍可辨識。信心卡片使用天藍色、中性色和琥珀色，而非青色、中性色和紅色。</string>
+    <string name="settings_display_palette_rainbow">彩虹</string>
+    <string name="settings_display_palette_rainbow_description">粉紅、橙色和綠色圖表線條，以及 Material 青色/紅色信心卡片。預設值。</string>
+    <string name="settings_unit_auto">自動</string>
+    <string name="today_cloud_range">雲量 %1$d〜%2$d%%</string>
+    <string name="today_confidence_precip_spread">各模型對降水意見不一（Δ %1$.0f%%，共 %2$d 個模型）</string>
+    <string name="today_confidence_tap_to_hide">點擊隱藏模型預報</string>
+    <string name="today_confidence_tap_to_show">點擊查看各模型預報</string>
+    <string name="today_humidity_range">濕度 %1$d〜%2$d%%</string>
+    <string name="today_solar_subtitle">各模型每小時地表輻照度（W/m²）</string>
+    <string name="today_solar_title">太陽輻射</string>
+    <string name="today_sunshine_subtitle">各模型每小時的日照分鐘數</string>
+    <string name="today_sunshine_title">日照</string>
+    <string name="today_sunshine_total_hours_minutes">今日日照 %1$d小時%2$d分鐘</string>
+    <string name="today_sunshine_total_hours_only">今日日照 %1$d小時</string>
+    <string name="today_sunshine_total_minutes_only">今日日照 %1$d分鐘</string>
+    <string name="today_uv_subtitle">各模型每小時紫外線指數</string>
+    <string name="today_uv_title">紫外線指數</string>
+    <string name="today_wind_peak">最高 %1$d %2$s（%3$s）</string>
 </resources>


### PR DESCRIPTION
## Summary

Adds the 21 strings that were missing from all four East Asian locales following the new-feature additions in the base file. These are the same strings caught up for the 17 European locales in #442.

**Strings added** to `ja`, `ko`, `zh-CN`, `zh-TW`:
- `today_solar_{title,subtitle}`, `today_sunshine_{title,subtitle,total_*}`, `today_uv_{title,subtitle}`
- `today_wind_peak`, `today_cloud_range`, `today_humidity_range`
- `today_confidence_tap_to_{show,hide}`, `today_confidence_precip_spread`
- `settings_display_colors_title`, `settings_display_palette_{rainbow,accessible}{,_description}`
- `settings_unit_auto`

## Test plan

- [ ] `./gradlew :app:assembleDebug` — no missing-resource errors
- [ ] Spot-check settings Display screen under Japanese locale

https://claude.ai/code/session_01LoYYyN5Qsya1Nx757Fvn7c

---
_Generated by [Claude Code](https://claude.ai/code/session_01LoYYyN5Qsya1Nx757Fvn7c)_