### PR TITLE
Add missing translated strings to el, uk, bg, sl, sr

### DIFF
--- a/app/src/main/res/values-b+sr+Latn/strings.xml
+++ b/app/src/main/res/values-b+sr+Latn/strings.xml
@@ -582,4 +582,27 @@ default English (matching values-pl / values-uk).
     <string name="today_forecast_air_section_title">Temperatura vazduha</string>
     <string name="settings_default_bottom_title">Standardni donji deo</string>
     <string name="settings_default_bottom_description">Ono što predlažemo na početnom ekranu kada nije dovoljno toplo za kratke hlače.</string>
+
+    <!-- Strings added to match base (new features). -->
+    <string name="settings_display_colors_title">Paleta boja</string>
+    <string name="settings_display_palette_accessible">Pristupačna</string>
+    <string name="settings_display_palette_accessible_description">Paleta izvedena iz Okabe-Ito, dizajnirana da ostane razlučiva pri deuteranopiji, protanopiji i tritanopiji. Kartice pouzdanosti koriste nebesko plavu, neutralnu i jantarnu umesto tirkizne, neutralne i crvene.</string>
+    <string name="settings_display_palette_rainbow">Duga</string>
+    <string name="settings_display_palette_rainbow_description">Roze, narandžaste i zelene linije grafikona sa tirkiznim/crvenim karticama pouzdanosti Material. Podrazumevano.</string>
+    <string name="settings_unit_auto">Auto</string>
+    <string name="today_cloud_range">Oblačnost %1$d–%2$d%%</string>
+    <string name="today_confidence_precip_spread">Modeli se ne slažu oko kiše (Δ %1$.0f%% kod %2$d modela)</string>
+    <string name="today_confidence_tap_to_hide">Dodirnite za skrivanje prognoza po modelu</string>
+    <string name="today_confidence_tap_to_show">Dodirnite za prikaz prognoze svakog modela</string>
+    <string name="today_humidity_range">Vlažnost %1$d–%2$d%%</string>
+    <string name="today_solar_subtitle">Površinska iradijansa (W/m²) po satu po modelu</string>
+    <string name="today_solar_title">Sunčevo zračenje</string>
+    <string name="today_sunshine_subtitle">Minute sunca po satu po modelu</string>
+    <string name="today_sunshine_title">Sijanje sunca</string>
+    <string name="today_sunshine_total_hours_minutes">%1$dh %2$dm sunca danas</string>
+    <string name="today_sunshine_total_hours_only">%1$dh sunca danas</string>
+    <string name="today_sunshine_total_minutes_only">%1$dm sunca danas</string>
+    <string name="today_uv_subtitle">UV indeks po satu po modelu</string>
+    <string name="today_uv_title">UV indeks</string>
+    <string name="today_wind_peak">Vrhunac %1$d %2$s u %3$s</string>
 </resources>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -580,4 +580,27 @@ What is NOT overridden, by design:
     <string name="today_forecast_air_section_title">Температура на въздуха</string>
     <string name="settings_default_bottom_title">Стандартен долен</string>
     <string name="settings_default_bottom_description">Какво предлагаме на началния екран, когато не е достатъчно топло за шорти.</string>
+
+    <!-- Strings added to match base (new features). -->
+    <string name="settings_display_colors_title">Цветова палитра</string>
+    <string name="settings_display_palette_accessible">Достъпна</string>
+    <string name="settings_display_palette_accessible_description">Палитра, базирана на Okabe-Ito, проектирана да остане различима при дейтеранопия, протанопия и тританопия. Картите за достоверност използват небесно синьо, неутрално и кехлибарено вместо синьо-зелено, неутрално и червено.</string>
+    <string name="settings_display_palette_rainbow">Дъга</string>
+    <string name="settings_display_palette_rainbow_description">Розови, оранжеви и зелени линии на графиките с карти за достоверност Material синьо-зелено/червено. По подразбиране.</string>
+    <string name="settings_unit_auto">Авто</string>
+    <string name="today_cloud_range">Облачност %1$d–%2$d%%</string>
+    <string name="today_confidence_precip_spread">Моделите не са съгласни за дъжда (Δ %1$.0f%% при %2$d модела)</string>
+    <string name="today_confidence_tap_to_hide">Докоснете, за да скриете прогнозите по модел</string>
+    <string name="today_confidence_tap_to_show">Докоснете, за да видите прогнозата на всеки модел</string>
+    <string name="today_humidity_range">Влажност %1$d–%2$d%%</string>
+    <string name="today_solar_subtitle">Повърхностна облъченост (W/m²) по часове по модели</string>
+    <string name="today_solar_title">Слънчева радиация</string>
+    <string name="today_sunshine_subtitle">Минути слънце на час по модели</string>
+    <string name="today_sunshine_title">Слънчево греене</string>
+    <string name="today_sunshine_total_hours_minutes">%1$d ч %2$d мин слънце днес</string>
+    <string name="today_sunshine_total_hours_only">%1$d ч слънце днес</string>
+    <string name="today_sunshine_total_minutes_only">%1$d мин слънце днес</string>
+    <string name="today_uv_subtitle">УВ индекс по часове по модели</string>
+    <string name="today_uv_title">УВ индекс</string>
+    <string name="today_wind_peak">Максимум %1$d %2$s в %3$s</string>
 </resources>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -715,4 +715,27 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="today_forecast_air_section_title">Θερμοκρασία αέρα</string>
     <string name="settings_default_bottom_title">Κανονικό κάτω μέρος</string>
     <string name="settings_default_bottom_description">Αυτό που προτείνουμε στην αρχική οθόνη όταν δεν κάνει αρκετά ζέστη για σορτς.</string>
+
+    <!-- Strings added to match base (new features). -->
+    <string name="settings_display_colors_title">Παλέτα χρωμάτων</string>
+    <string name="settings_display_palette_accessible">Προσβάσιμη</string>
+    <string name="settings_display_palette_accessible_description">Παλέτα βασισμένη στο Okabe-Ito, σχεδιασμένη να παραμένει διακριτή σε δευτερανωπία, πρωτανωπία και τριτανωπία. Οι κάρτες αξιοπιστίας χρησιμοποιούν γαλάζιο, ουδέτερο και κεχριμπαρί αντί για πετρόλ, ουδέτερο και κόκκινο.</string>
+    <string name="settings_display_palette_rainbow">Ουράνιο τόξο</string>
+    <string name="settings_display_palette_rainbow_description">Ροζ, πορτοκαλί και πράσινες γραμμές γραφημάτων με κάρτες αξιοπιστίας Material πετρόλ/κόκκινο. Προεπιλογή.</string>
+    <string name="settings_unit_auto">Αυτόματο</string>
+    <string name="today_cloud_range">Νέφωση %1$d–%2$d%%</string>
+    <string name="today_confidence_precip_spread">Τα μοντέλα διαφωνούν για τη βροχή (Δ %1$.0f%% σε %2$d μοντέλα)</string>
+    <string name="today_confidence_tap_to_hide">Πατήστε για απόκρυψη προβλέψεων μοντέλων</string>
+    <string name="today_confidence_tap_to_show">Πατήστε για εμφάνιση πρόβλεψης κάθε μοντέλου</string>
+    <string name="today_humidity_range">Υγρασία %1$d–%2$d%%</string>
+    <string name="today_solar_subtitle">Επιφανειακή ηλιακή ακτινοβολία (W/m²) ανά ώρα ανά μοντέλο</string>
+    <string name="today_solar_title">Ηλιακή ακτινοβολία</string>
+    <string name="today_sunshine_subtitle">Λεπτά ηλιοφάνειας ανά ώρα ανά μοντέλο</string>
+    <string name="today_sunshine_title">Ηλιοφάνεια</string>
+    <string name="today_sunshine_total_hours_minutes">%1$d ώ %2$d λ ηλιοφάνεια σήμερα</string>
+    <string name="today_sunshine_total_hours_only">%1$d ώρ. ηλιοφάνεια σήμερα</string>
+    <string name="today_sunshine_total_minutes_only">%1$d λ. ηλιοφάνεια σήμερα</string>
+    <string name="today_uv_subtitle">Δείκτης UV ανά ώρα ανά μοντέλο</string>
+    <string name="today_uv_title">Δείκτης UV</string>
+    <string name="today_wind_peak">Μέγιστο %1$d %2$s στις %3$s</string>
 </resources>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -578,4 +578,27 @@ informal "ti"-form throughout, mirroring the Croatian / Serbian pass.
     <string name="today_forecast_air_section_title">Temperatura zraka</string>
     <string name="settings_default_bottom_title">Standardni spodnji del</string>
     <string name="settings_default_bottom_description">Kar predlagamo na začetnem zaslonu, ko ni dovolj toplo za kratke hlače.</string>
+
+    <!-- Strings added to match base (new features). -->
+    <string name="settings_display_colors_title">Barvna paleta</string>
+    <string name="settings_display_palette_accessible">Dostopna</string>
+    <string name="settings_display_palette_accessible_description">Paleta, izpeljana iz Okabe-Ito, zasnovana tako, da ostane razločna pri devteranopiji, protanopiji in tritanopiji. Kartice zanesljivosti uporabljajo nebeško modro, nevtralno in jantarno namesto modrozelene, nevtralne in rdeče.</string>
+    <string name="settings_display_palette_rainbow">Mavrica</string>
+    <string name="settings_display_palette_rainbow_description">Rožnate, oranžne in zelene linije grafikonov z modrozeleno/rdečimi karticami zanesljivosti Material. Privzeto.</string>
+    <string name="settings_unit_auto">Samodejno</string>
+    <string name="today_cloud_range">Oblačnost %1$d–%2$d%%</string>
+    <string name="today_confidence_precip_spread">Modeli se ne strinjajo glede dežja (Δ %1$.0f%% za %2$d modele)</string>
+    <string name="today_confidence_tap_to_hide">Dotaknite se za skritje napovedi po modelih</string>
+    <string name="today_confidence_tap_to_show">Dotaknite se za ogled napovedi vsakega modela</string>
+    <string name="today_humidity_range">Vlažnost %1$d–%2$d%%</string>
+    <string name="today_solar_subtitle">Površinska osvetljenost (W/m²) po urah po modelih</string>
+    <string name="today_solar_title">Sončno sevanje</string>
+    <string name="today_sunshine_subtitle">Minute sonca na uro po modelih</string>
+    <string name="today_sunshine_title">Sončno obsevanje</string>
+    <string name="today_sunshine_total_hours_minutes">%1$d h %2$d min sonca danes</string>
+    <string name="today_sunshine_total_hours_only">%1$d h sonca danes</string>
+    <string name="today_sunshine_total_minutes_only">%1$d min sonca danes</string>
+    <string name="today_uv_subtitle">UV indeks po urah po modelih</string>
+    <string name="today_uv_title">UV indeks</string>
+    <string name="today_wind_peak">Vrh %1$d %2$s ob %3$s</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -594,4 +594,27 @@ only the displayed label localizes.
     <string name="today_forecast_air_section_title">Температура повітря</string>
     <string name="settings_default_bottom_title">Стандартний низ</string>
     <string name="settings_default_bottom_description">Те, що ми пропонуємо на головному екрані, коли недостатньо тепло для шортів.</string>
+
+    <!-- Strings added to match base (new features). -->
+    <string name="settings_display_colors_title">Палітра кольорів</string>
+    <string name="settings_display_palette_accessible">Доступна</string>
+    <string name="settings_display_palette_accessible_description">Палітра на основі Okabe-Ito, розроблена для розрізнення при дейтеранопії, протанопії та тританопії. Картки достовірності використовують блакитний, нейтральний і бурштиновий замість бірюзового, нейтрального і червоного.</string>
+    <string name="settings_display_palette_rainbow">Веселка</string>
+    <string name="settings_display_palette_rainbow_description">Рожеві, помаранчеві та зелені лінії графіків з картками достовірності Material бірюзово/червоного. За замовчуванням.</string>
+    <string name="settings_unit_auto">Авто</string>
+    <string name="today_cloud_range">Хмарність %1$d–%2$d%%</string>
+    <string name="today_confidence_precip_spread">Моделі розходяться щодо дощу (Δ %1$.0f%% по %2$d моделях)</string>
+    <string name="today_confidence_tap_to_hide">Торкніться, щоб приховати прогнози моделей</string>
+    <string name="today_confidence_tap_to_show">Торкніться, щоб побачити прогноз кожної моделі</string>
+    <string name="today_humidity_range">Вологість %1$d–%2$d%%</string>
+    <string name="today_solar_subtitle">Поверхнева опромінюваність (Вт/м²) по годинах по моделях</string>
+    <string name="today_solar_title">Сонячна радіація</string>
+    <string name="today_sunshine_subtitle">Хвилини сонця на годину по моделях</string>
+    <string name="today_sunshine_title">Сонячне сяйво</string>
+    <string name="today_sunshine_total_hours_minutes">%1$d год %2$d хв сонця сьогодні</string>
+    <string name="today_sunshine_total_hours_only">%1$d год сонця сьогодні</string>
+    <string name="today_sunshine_total_minutes_only">%1$d хв сонця сьогодні</string>
+    <string name="today_uv_subtitle">УФ-індекс по годинах по моделях</string>
+    <string name="today_uv_title">УФ-індекс</string>
+    <string name="today_wind_peak">Максимум %1$d %2$s о %3$s</string>
 </resources>


### PR DESCRIPTION
## Summary

Adds the 21 strings missing from Greek, Ukrainian, Bulgarian, Slovenian and Serbian (Latin) — the same set caught up for 17 European locales in #442 and East Asian locales in #443.

**Strings added** to `el`, `uk`, `bg`, `sl`, `b+sr+Latn`:
- `today_solar_{title,subtitle}`, `today_sunshine_{title,subtitle,total_*}`, `today_uv_{title,subtitle}`
- `today_wind_peak`, `today_cloud_range`, `today_humidity_range`
- `today_confidence_tap_to_{show,hide}`, `today_confidence_precip_spread`
- `settings_display_colors_title`, `settings_display_palette_{rainbow,accessible}{,_description}`
- `settings_unit_auto`

## Test plan

- [ ] `./gradlew :app:assembleDebug` — no missing-resource errors
- [ ] Spot-check settings Display screen under Greek and Ukrainian locales

https://claude.ai/code/session_01LoYYyN5Qsya1Nx757Fvn7c

---
_Generated by [Claude Code](https://claude.ai/code/session_01LoYYyN5Qsya1Nx757Fvn7c)_