### PR TITLE
Add missing translated strings to id, ms, fil, vi

### DIFF
--- a/app/src/main/res/values-fil/strings.xml
+++ b/app/src/main/res/values-fil/strings.xml
@@ -616,4 +616,27 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="today_forecast_air_section_title">Temperatura ng hangin</string>
     <string name="settings_default_bottom_title">Karaniwang ibabang damit</string>
     <string name="settings_default_bottom_description">Kung ano ang aming iminumungkahi sa home screen kapag hindi sapat ang init para sa shorts.</string>
+
+    <!-- Strings added to match base (new features). -->
+    <string name="settings_display_colors_title">Palette ng kulay</string>
+    <string name="settings_display_palette_accessible">Accessible</string>
+    <string name="settings_display_palette_accessible_description">Isang palette batay sa Okabe-Ito, dinisenyo upang manatiling makilala sa deuteranopia, protanopia, at tritanopia. Gumagamit ang mga confidence card ng sky blue, neutral, at amber sa halip na teal, neutral, at pula.</string>
+    <string name="settings_display_palette_rainbow">Bahaghari</string>
+    <string name="settings_display_palette_rainbow_description">Pink, orange, at berdeng linya ng tsart na may teal/pulang confidence card na Material. Default.</string>
+    <string name="settings_unit_auto">Auto</string>
+    <string name="today_cloud_range">Ulap %1$d–%2$d%%</string>
+    <string name="today_confidence_precip_spread">Hindi nagkakasundo ang mga modelo sa ulan (Δ %1$.0f%% sa %2$d modelo)</string>
+    <string name="today_confidence_tap_to_hide">I-tap upang itago ang mga hula ng modelo</string>
+    <string name="today_confidence_tap_to_show">I-tap upang tingnan ang hula ng bawat modelo</string>
+    <string name="today_humidity_range">Halumigmig %1$d–%2$d%%</string>
+    <string name="today_solar_subtitle">Surface irradiance (W/m²) bawat oras bawat modelo</string>
+    <string name="today_solar_title">Solar radiation</string>
+    <string name="today_sunshine_subtitle">Minuto ng sikat ng araw bawat oras bawat modelo</string>
+    <string name="today_sunshine_title">Sikat ng araw</string>
+    <string name="today_sunshine_total_hours_minutes">%1$dh %2$dm ng araw ngayon</string>
+    <string name="today_sunshine_total_hours_only">%1$dh ng araw ngayon</string>
+    <string name="today_sunshine_total_minutes_only">%1$dm ng araw ngayon</string>
+    <string name="today_uv_subtitle">UV index bawat oras bawat modelo</string>
+    <string name="today_uv_title">UV index</string>
+    <string name="today_wind_peak">Pinakamataas na %1$d %2$s sa %3$s</string>
 </resources>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -566,4 +566,27 @@ to values/strings.xml (English).
     <string name="today_forecast_air_section_title">Suhu udara</string>
     <string name="settings_default_bottom_title">Bawahan standar</string>
     <string name="settings_default_bottom_description">Yang kami sarankan di layar beranda saat tidak cukup panas untuk memakai celana pendek.</string>
+
+    <!-- Strings added to match base (new features). -->
+    <string name="settings_display_colors_title">Palet warna</string>
+    <string name="settings_display_palette_accessible">Aksesibel</string>
+    <string name="settings_display_palette_accessible_description">Palet berbasis Okabe-Ito yang dirancang agar tetap dapat dibedakan saat deuteranopia, protanopia, dan tritanopia. Kartu keyakinan menggunakan biru langit, netral, dan kuning amber, bukan teal, netral, dan merah.</string>
+    <string name="settings_display_palette_rainbow">Pelangi</string>
+    <string name="settings_display_palette_rainbow_description">Garis grafik merah muda, oranye, dan hijau dengan kartu keyakinan Material teal/merah. Bawaan.</string>
+    <string name="settings_unit_auto">Otomatis</string>
+    <string name="today_cloud_range">Awan %1$d–%2$d%%</string>
+    <string name="today_confidence_precip_spread">Model tidak sepakat soal hujan (Δ %1$.0f%% dari %2$d model)</string>
+    <string name="today_confidence_tap_to_hide">Ketuk untuk menyembunyikan prakiraan model</string>
+    <string name="today_confidence_tap_to_show">Ketuk untuk melihat prakiraan tiap model</string>
+    <string name="today_humidity_range">Kelembapan %1$d–%2$d%%</string>
+    <string name="today_solar_subtitle">Iradiasi permukaan (W/m²) per jam per model</string>
+    <string name="today_solar_title">Radiasi matahari</string>
+    <string name="today_sunshine_subtitle">Menit cerah per jam per model</string>
+    <string name="today_sunshine_title">Durasi cerah</string>
+    <string name="today_sunshine_total_hours_minutes">%1$d j %2$d m cerah hari ini</string>
+    <string name="today_sunshine_total_hours_only">%1$d j cerah hari ini</string>
+    <string name="today_sunshine_total_minutes_only">%1$d m cerah hari ini</string>
+    <string name="today_uv_subtitle">Indeks UV per jam per model</string>
+    <string name="today_uv_title">Indeks UV</string>
+    <string name="today_wind_peak">Puncak %1$d %2$s pukul %3$s</string>
 </resources>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -572,4 +572,27 @@ vs "kemungkinan", "padam" vs "hapus").
     <string name="today_forecast_air_section_title">Suhu udara</string>
     <string name="settings_default_bottom_title">Bawahan standard</string>
     <string name="settings_default_bottom_description">Yang kami cadangkan pada skrin utama apabila tidak cukup panas untuk seluar pendek.</string>
+
+    <!-- Strings added to match base (new features). -->
+    <string name="settings_display_colors_title">Palet warna</string>
+    <string name="settings_display_palette_accessible">Boleh Capaian</string>
+    <string name="settings_display_palette_accessible_description">Palet berasaskan Okabe-Ito yang direka untuk kekal dapat dibezakan semasa deuteranopia, protanopia, dan tritanopia. Kad keyakinan menggunakan biru langit, neutral, dan kuning amber, bukan teal, neutral, dan merah.</string>
+    <string name="settings_display_palette_rainbow">Pelangi</string>
+    <string name="settings_display_palette_rainbow_description">Garis carta merah jambu, oren, dan hijau dengan kad keyakinan Material teal/merah. Lalai.</string>
+    <string name="settings_unit_auto">Auto</string>
+    <string name="today_cloud_range">Awan %1$d–%2$d%%</string>
+    <string name="today_confidence_precip_spread">Model tidak bersetuju tentang hujan (Δ %1$.0f%% merentasi %2$d model)</string>
+    <string name="today_confidence_tap_to_hide">Ketik untuk sembunyikan ramalan model</string>
+    <string name="today_confidence_tap_to_show">Ketik untuk lihat ramalan setiap model</string>
+    <string name="today_humidity_range">Kelembapan %1$d–%2$d%%</string>
+    <string name="today_solar_subtitle">Pencahayaan permukaan (W/m²) per jam per model</string>
+    <string name="today_solar_title">Sinaran solar</string>
+    <string name="today_sunshine_subtitle">Minit cerah per jam per model</string>
+    <string name="today_sunshine_title">Cahaya matahari</string>
+    <string name="today_sunshine_total_hours_minutes">%1$d j %2$d min cerah hari ini</string>
+    <string name="today_sunshine_total_hours_only">%1$d j cerah hari ini</string>
+    <string name="today_sunshine_total_minutes_only">%1$d min cerah hari ini</string>
+    <string name="today_uv_subtitle">Indeks UV per jam per model</string>
+    <string name="today_uv_title">Indeks UV</string>
+    <string name="today_wind_peak">Puncak %1$d %2$s pukul %3$s</string>
 </resources>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -627,4 +627,27 @@ Skipped intentionally: app_name (brand), insight_time_am/pm/midnight/noon
     <string name="today_forecast_air_section_title">Nhiệt độ không khí</string>
     <string name="settings_default_bottom_title">Quần/váy tiêu chuẩn</string>
     <string name="settings_default_bottom_description">Những gì chúng tôi đề xuất trên màn hình chính khi không đủ ấm để mặc quần short.</string>
+
+    <!-- Strings added to match base (new features). -->
+    <string name="settings_display_colors_title">Bảng màu</string>
+    <string name="settings_display_palette_accessible">Dễ tiếp cận</string>
+    <string name="settings_display_palette_accessible_description">Bảng màu dựa trên Okabe-Ito, được thiết kế để vẫn phân biệt được khi bị mù màu đỏ-xanh lá và xanh lam. Thẻ độ tin cậy dùng xanh trời, trung tính và hổ phách thay vì xanh mòng két, trung tính và đỏ.</string>
+    <string name="settings_display_palette_rainbow">Cầu vồng</string>
+    <string name="settings_display_palette_rainbow_description">Đường biểu đồ màu hồng, cam và xanh lá với thẻ độ tin cậy Material xanh mòng két/đỏ. Mặc định.</string>
+    <string name="settings_unit_auto">Tự động</string>
+    <string name="today_cloud_range">Mây %1$d–%2$d%%</string>
+    <string name="today_confidence_precip_spread">Các mô hình không đồng thuận về mưa (Δ %1$.0f%% trên %2$d mô hình)</string>
+    <string name="today_confidence_tap_to_hide">Nhấn để ẩn dự báo của từng mô hình</string>
+    <string name="today_confidence_tap_to_show">Nhấn để xem dự báo của từng mô hình</string>
+    <string name="today_humidity_range">Độ ẩm %1$d–%2$d%%</string>
+    <string name="today_solar_subtitle">Bức xạ bề mặt (W/m²) theo giờ theo mô hình</string>
+    <string name="today_solar_title">Bức xạ mặt trời</string>
+    <string name="today_sunshine_subtitle">Phút nắng mỗi giờ theo mô hình</string>
+    <string name="today_sunshine_title">Thời gian nắng</string>
+    <string name="today_sunshine_total_hours_minutes">%1$dh %2$dm nắng hôm nay</string>
+    <string name="today_sunshine_total_hours_only">%1$dh nắng hôm nay</string>
+    <string name="today_sunshine_total_minutes_only">%1$dm nắng hôm nay</string>
+    <string name="today_uv_subtitle">Chỉ số UV theo giờ theo mô hình</string>
+    <string name="today_uv_title">Chỉ số UV</string>
+    <string name="today_wind_peak">Đỉnh %1$d %2$s lúc %3$s</string>
 </resources>


### PR DESCRIPTION
## Summary

Adds the 21 strings missing from Indonesian, Malay, Filipino and Vietnamese — same set as previous batches (#442, #443, #445).

**Strings added** to `in` (Indonesian), `ms`, `fil`, `vi`:
- `today_solar_{title,subtitle}`, `today_sunshine_{title,subtitle,total_*}`, `today_uv_{title,subtitle}`
- `today_wind_peak`, `today_cloud_range`, `today_humidity_range`
- `today_confidence_tap_to_{show,hide}`, `today_confidence_precip_spread`
- `settings_display_colors_title`, `settings_display_palette_{rainbow,accessible}{,_description}`
- `settings_unit_auto`

## Test plan

- [ ] `./gradlew :app:assembleDebug` — no missing-resource errors

https://claude.ai/code/session_01LoYYyN5Qsya1Nx757Fvn7c

---
_Generated by [Claude Code](https://claude.ai/code/session_01LoYYyN5Qsya1Nx757Fvn7c)_