### PR TITLE
Add missing translated strings to et, lv, lt, sk, ro, ca

### DIFF
--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -533,4 +533,30 @@ the in-app clock is digit-driven and reads consistently across locales.
     <string name="today_forecast_air_section_title">Temperatura de l\'aire</string>
     <string name="settings_default_bottom_title">Part de baix estàndard</string>
     <string name="settings_default_bottom_description">El que suggerim a la pantalla d\'inici quan no fa prou calor per a pantalons curts.</string>
+
+    <!-- Strings added to match base (new features). -->
+    <string name="settings_display_colors_title">Paleta de colors</string>
+    <string name="settings_display_palette_accessible">Accessible</string>
+    <string name="settings_display_palette_accessible_description">Una paleta derivada d\'Okabe-Ito, dissenyada per mantenir-se distingible amb deuteranopia, protanopia i tritanopia. Les targetes de confiança utilitzen blau cel, neutre i ambre en lloc de blau verdós, neutre i vermell.</string>
+    <string name="settings_display_palette_rainbow">Arc de Sant Martí</string>
+    <string name="settings_display_palette_rainbow_description">Línies de gràfic rosa, taronja i verd amb targetes de confiança Material blau verdós/vermell. Per defecte.</string>
+    <string name="settings_unit_auto">Auto</string>
+    <string name="today_cloud_range">Nuvolositat %1$d–%2$d%%</string>
+    <string name="today_confidence_precip_spread">Els models no es posen d\'acord sobre la pluja (Δ %1$.0f%% entre %2$d models)</string>
+    <string name="today_confidence_tap_to_hide">Toca per amagar les previsions per model</string>
+    <string name="today_confidence_tap_to_show">Toca per veure la previsió de cada model</string>
+    <string name="today_humidity_range">Humitat %1$d–%2$d%%</string>
+    <string name="today_solar_subtitle">Irradiància superficial (W/m²) per hora per model</string>
+    <string name="today_solar_title">Radiació solar</string>
+    <string name="today_sunshine_subtitle">Minuts de sol per hora per model</string>
+    <string name="today_sunshine_title">Hores de sol</string>
+    <string name="today_sunshine_total_hours_minutes">%1$dh %2$dm de sol avui</string>
+    <string name="today_sunshine_total_hours_only">%1$dh de sol avui</string>
+    <string name="today_sunshine_total_minutes_only">%1$dm de sol avui</string>
+    <string name="today_uv_subtitle">Índex UV per hora per model</string>
+    <string name="today_uv_title">Índex UV</string>
+    <string name="today_wind_peak">Pic %1$d %2$s a les %3$s</string>
+
+    <string name="settings_tts_test">Prova la veu</string>
+    <string name="settings_tts_test_in_flight">Provant — espera…</string>
 </resources>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -541,4 +541,27 @@ Tone is informal "sina"-form throughout ("Pane … selga", "Võta … kaasa",
     <string name="today_forecast_air_section_title">Õhutemperatuur</string>
     <string name="settings_default_bottom_title">Standardne alumine rõivaese</string>
     <string name="settings_default_bottom_description">Mida soovitame avalehel, kui pole piisavalt soe, et kanda šortseid.</string>
+
+    <!-- Strings added to match base (new features). -->
+    <string name="settings_display_colors_title">Värvipalett</string>
+    <string name="settings_display_palette_accessible">Juurdepääsetav</string>
+    <string name="settings_display_palette_accessible_description">Okabe-Ito põhine palett, mis on loodud olema eristatav deuteranoopiaga, protanoopiaga ja tritanoopiaga. Usaldusväärsuskaardid kasutavad taevasinist, neutraalset ja merevaigukollast teal, neutraalse ja punase asemel.</string>
+    <string name="settings_display_palette_rainbow">Vikerkaar</string>
+    <string name="settings_display_palette_rainbow_description">Roosa, oranž ja roheline diagrammijoon koos Material teal/punaste usaldusväärsuskaartidega. Vaikimisi.</string>
+    <string name="settings_unit_auto">Automaatne</string>
+    <string name="today_cloud_range">Pilvisus %1$d–%2$d%%</string>
+    <string name="today_confidence_precip_spread">Mudelid ei nõustu vihma osas (Δ %1$.0f%% %2$d mudeli vahel)</string>
+    <string name="today_confidence_tap_to_hide">Puuduta mudelite prognooside peitmiseks</string>
+    <string name="today_confidence_tap_to_show">Puuduta iga mudeli prognoosi nägemiseks</string>
+    <string name="today_humidity_range">Niiskus %1$d–%2$d%%</string>
+    <string name="today_solar_subtitle">Pinnakiirgus (W/m²) tunnis mudeli kohta</string>
+    <string name="today_solar_title">Päikesekiirgus</string>
+    <string name="today_sunshine_subtitle">Päikesepaiste minutid tunnis mudeli kohta</string>
+    <string name="today_sunshine_title">Päikesepaiste</string>
+    <string name="today_sunshine_total_hours_minutes">%1$d t %2$d min päikest täna</string>
+    <string name="today_sunshine_total_hours_only">%1$d t päikest täna</string>
+    <string name="today_sunshine_total_minutes_only">%1$d min päikest täna</string>
+    <string name="today_uv_subtitle">UV-indeks tunnis mudeli kohta</string>
+    <string name="today_uv_title">UV-indeks</string>
+    <string name="today_wind_peak">Tipp %1$d %2$s kell %3$s</string>
 </resources>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -585,4 +585,27 @@ What is NOT overridden, by design:
     <string name="today_forecast_air_section_title">Oro temperatūra</string>
     <string name="settings_default_bottom_title">Standartinė apatinė dalis</string>
     <string name="settings_default_bottom_description">Ką siūlome pagrindiniame ekrane, kai per šalta šortams.</string>
+
+    <!-- Strings added to match base (new features). -->
+    <string name="settings_display_colors_title">Spalvų paletė</string>
+    <string name="settings_display_palette_accessible">Prieinama</string>
+    <string name="settings_display_palette_accessible_description">Okabe-Ito pagrindu sudaryta paletė, skirta išlikti atskiriama esant deuteranopija, protanopija ir tritanopija. Patikimumo kortelės naudoja dangaus mėlyną, neutralų ir gintaro spalvas, o ne žalsvą, neutralų ir raudoną.</string>
+    <string name="settings_display_palette_rainbow">Vaivorykštė</string>
+    <string name="settings_display_palette_rainbow_description">Rožinės, oranžinės ir žalios diagramų linijos su Material žalsvomis/raudonomis patikimumo kortelėmis. Numatytoji.</string>
+    <string name="settings_unit_auto">Automatiškai</string>
+    <string name="today_cloud_range">Debesuotumas %1$d–%2$d%%</string>
+    <string name="today_confidence_precip_spread">Modeliai nesutaria dėl lietaus (Δ %1$.0f%% iš %2$d modelių)</string>
+    <string name="today_confidence_tap_to_hide">Palieskite, kad paslėptumėte modelių prognozes</string>
+    <string name="today_confidence_tap_to_show">Palieskite, kad pamatytumėte kiekvieno modelio prognozę</string>
+    <string name="today_humidity_range">Drėgmė %1$d–%2$d%%</string>
+    <string name="today_solar_subtitle">Paviršiaus apšvieta (W/m²) per valandą pagal modelį</string>
+    <string name="today_solar_title">Saulės spinduliuotė</string>
+    <string name="today_sunshine_subtitle">Saulėtos minutės per valandą pagal modelį</string>
+    <string name="today_sunshine_title">Saulės šviesa</string>
+    <string name="today_sunshine_total_hours_minutes">%1$d val %2$d min saulės šiandien</string>
+    <string name="today_sunshine_total_hours_only">%1$d val saulės šiandien</string>
+    <string name="today_sunshine_total_minutes_only">%1$d min saulės šiandien</string>
+    <string name="today_uv_subtitle">UV indeksas per valandą pagal modelį</string>
+    <string name="today_uv_title">UV indeksas</string>
+    <string name="today_wind_peak">Smaigas %1$d %2$s %3$s val.</string>
 </resources>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -538,4 +538,27 @@ informal "tu"-form throughout ("Apģērb …", "Paņem … līdzi").
     <string name="today_forecast_air_section_title">Gaisa temperatūra</string>
     <string name="settings_default_bottom_title">Standarta apakšdaļa</string>
     <string name="settings_default_bottom_description">Ko iesakām sākuma ekrānā, kad nav pietiekami silts šortiem.</string>
+
+    <!-- Strings added to match base (new features). -->
+    <string name="settings_display_colors_title">Krāsu palete</string>
+    <string name="settings_display_palette_accessible">Pieejama</string>
+    <string name="settings_display_palette_accessible_description">Okabe-Ito palete, kas paredzēta, lai paliktu atšķirama deuteranopijas, protanopijas un tritanopijas gadījumā. Ticamības kartes izmanto debesu zilu, neitrālu un dzintarkrāsu, nevis tirkīzu, neitrālu un sarkanu.</string>
+    <string name="settings_display_palette_rainbow">Varavīksne</string>
+    <string name="settings_display_palette_rainbow_description">Rozā, oranžas un zaļas diagrammas līnijas ar Material tirkīza/sarkanām ticamības kartēm. Noklusējums.</string>
+    <string name="settings_unit_auto">Automātiski</string>
+    <string name="today_cloud_range">Mākoņainums %1$d–%2$d%%</string>
+    <string name="today_confidence_precip_spread">Modeļi nepiekrīt lietus jautājumā (Δ %1$.0f%% starp %2$d modeļiem)</string>
+    <string name="today_confidence_tap_to_hide">Pieskarieties, lai paslēptu modeļu prognozes</string>
+    <string name="today_confidence_tap_to_show">Pieskarieties, lai skatītu katra modeļa prognozi</string>
+    <string name="today_humidity_range">Mitrums %1$d–%2$d%%</string>
+    <string name="today_solar_subtitle">Virsmas starojums (W/m²) stundā katrā modelī</string>
+    <string name="today_solar_title">Saules starojums</string>
+    <string name="today_sunshine_subtitle">Saules spīdēšanas minūtes stundā katrā modelī</string>
+    <string name="today_sunshine_title">Saules spīdēšana</string>
+    <string name="today_sunshine_total_hours_minutes">%1$d st %2$d min saules šodien</string>
+    <string name="today_sunshine_total_hours_only">%1$d st saules šodien</string>
+    <string name="today_sunshine_total_minutes_only">%1$d min saules šodien</string>
+    <string name="today_uv_subtitle">UV indekss stundā katrā modelī</string>
+    <string name="today_uv_title">UV indekss</string>
+    <string name="today_wind_peak">Maksimums %1$d %2$s plkst. %3$s</string>
 </resources>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -569,4 +569,27 @@ surfaces fall back to default English (matching values-pl / values-uk).
     <string name="today_forecast_air_section_title">Temperatura aerului</string>
     <string name="settings_default_bottom_title">Jos standard</string>
     <string name="settings_default_bottom_description">Ceea ce sugerăm pe ecranul de start când nu este suficient de cald pentru pantaloni scurți.</string>
+
+    <!-- Strings added to match base (new features). -->
+    <string name="settings_display_colors_title">Paletă de culori</string>
+    <string name="settings_display_palette_accessible">Accesibilă</string>
+    <string name="settings_display_palette_accessible_description">O paletă derivată din Okabe-Ito, concepută să rămână distinctă în caz de deuteranopie, protanopie și tritanopie. Cardurile de încredere folosesc albastru cer, neutru și chihlimbar în loc de teal, neutru și roșu.</string>
+    <string name="settings_display_palette_rainbow">Curcubeu</string>
+    <string name="settings_display_palette_rainbow_description">Linii de grafic roz, portocaliu și verde cu carduri de încredere Material teal/roșu. Implicit.</string>
+    <string name="settings_unit_auto">Auto</string>
+    <string name="today_cloud_range">Nori %1$d–%2$d%%</string>
+    <string name="today_confidence_precip_spread">Modelele nu sunt de acord cu privire la ploaie (Δ %1$.0f%% pe %2$d modele)</string>
+    <string name="today_confidence_tap_to_hide">Atingeți pentru a ascunde prognozele modelelor</string>
+    <string name="today_confidence_tap_to_show">Atingeți pentru a vedea prognoza fiecărui model</string>
+    <string name="today_humidity_range">Umiditate %1$d–%2$d%%</string>
+    <string name="today_solar_subtitle">Iradierea suprafeței (W/m²) pe oră pe model</string>
+    <string name="today_solar_title">Radiație solară</string>
+    <string name="today_sunshine_subtitle">Minute de soare pe oră pe model</string>
+    <string name="today_sunshine_title">Strălucire solară</string>
+    <string name="today_sunshine_total_hours_minutes">%1$d h %2$d min soare azi</string>
+    <string name="today_sunshine_total_hours_only">%1$d h soare azi</string>
+    <string name="today_sunshine_total_minutes_only">%1$d min soare azi</string>
+    <string name="today_uv_subtitle">Indice UV pe oră pe model</string>
+    <string name="today_uv_title">Indice UV</string>
+    <string name="today_wind_peak">Vârf %1$d %2$s la %3$s</string>
 </resources>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -597,4 +597,27 @@ What is NOT overridden, by design:
     <string name="today_forecast_air_section_title">Teplota vzduchu</string>
     <string name="settings_default_bottom_title">Štandardná spodná časť</string>
     <string name="settings_default_bottom_description">Čo odporúčame na domovskej obrazovke, keď nie je dosť teplo na šortky.</string>
+
+    <!-- Strings added to match base (new features). -->
+    <string name="settings_display_colors_title">Farebná paleta</string>
+    <string name="settings_display_palette_accessible">Prístupná</string>
+    <string name="settings_display_palette_accessible_description">Paleta odvodená od Okabe-Ito, navrhnutá tak, aby zostala rozlíšiteľná pri deuteranopii, protanopii a tritanopii. Karty istoty používajú nebesky modrú, neutrálnu a jantárovú namiesto tyrkysovej, neutrálnej a červenej.</string>
+    <string name="settings_display_palette_rainbow">Dúha</string>
+    <string name="settings_display_palette_rainbow_description">Ružové, oranžové a zelené čiary grafov s tyrkysovými/červenými kartami istoty Material. Predvolené.</string>
+    <string name="settings_unit_auto">Auto</string>
+    <string name="today_cloud_range">Oblačnosť %1$d–%2$d%%</string>
+    <string name="today_confidence_precip_spread">Modely sa nezhodujú na zrážkach (Δ %1$.0f%% pre %2$d modely)</string>
+    <string name="today_confidence_tap_to_hide">Klepnutím skryjete predpovede modelov</string>
+    <string name="today_confidence_tap_to_show">Klepnutím zobrazíte predpoveď každého modelu</string>
+    <string name="today_humidity_range">Vlhkosť %1$d–%2$d%%</string>
+    <string name="today_solar_subtitle">Povrchová ožiarenosť (W/m²) za hodinu na model</string>
+    <string name="today_solar_title">Slnečné žiarenie</string>
+    <string name="today_sunshine_subtitle">Minúty slnka za hodinu na model</string>
+    <string name="today_sunshine_title">Slnečný svit</string>
+    <string name="today_sunshine_total_hours_minutes">%1$d hod %2$d min slnka dnes</string>
+    <string name="today_sunshine_total_hours_only">%1$d hod slnka dnes</string>
+    <string name="today_sunshine_total_minutes_only">%1$d min slnka dnes</string>
+    <string name="today_uv_subtitle">UV index za hodinu na model</string>
+    <string name="today_uv_title">UV index</string>
+    <string name="today_wind_peak">Vrchol %1$d %2$s o %3$s</string>
 </resources>


### PR DESCRIPTION
## Summary

Adds the 21 strings missing from Estonian, Latvian, Lithuanian, Slovak, Romanian and Catalan. Catalan also had two pre-existing gaps (`settings_tts_test` and `settings_tts_test_in_flight`) that were plugged at the same time.

**Strings added** to `et`, `lv`, `lt`, `sk`, `ro`, `ca`:
- `today_solar_{title,subtitle}`, `today_sunshine_{title,subtitle,total_*}`, `today_uv_{title,subtitle}`
- `today_wind_peak`, `today_cloud_range`, `today_humidity_range`
- `today_confidence_tap_to_{show,hide}`, `today_confidence_precip_spread`
- `settings_display_colors_title`, `settings_display_palette_{rainbow,accessible}{,_description}`
- `settings_unit_auto`
- `ca` only: `settings_tts_test`, `settings_tts_test_in_flight`

## Test plan

- [ ] `./gradlew :app:assembleDebug` — no missing-resource errors

https://claude.ai/code/session_01LoYYyN5Qsya1Nx757Fvn7c

---
_Generated by [Claude Code](https://claude.ai/code/session_01LoYYyN5Qsya1Nx757Fvn7c)_