### PR TITLE
Add missing translated strings to th, bn, hi

### DIFF
--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -636,4 +636,27 @@ West Bengal vocabulary differences in a future PR.
     <string name="today_forecast_air_section_title">বায়ু তাপমাত্রা</string>
     <string name="settings_default_bottom_title">সাধারণ নিচের পোশাক</string>
     <string name="settings_default_bottom_description">শর্টসের জন্য যথেষ্ট গরম না হলে হোম স্ক্রিনে আমরা কী সাজেস্ট করি।</string>
+
+    <!-- Strings added to match base (new features). -->
+    <string name="settings_display_colors_title">রঙের প্যালেট</string>
+    <string name="settings_display_palette_accessible">অ্যাক্সেসযোগ্য</string>
+    <string name="settings_display_palette_accessible_description">Okabe-Ito ভিত্তিক একটি প্যালেট যা ডিউটেরানোপিয়া, প্রোটানোপিয়া এবং ট্রিটানোপিয়ায় আলাদাভাবে চেনা যায়। আস্থা কার্ডগুলো টিল, নিরপেক্ষ এবং লাল রঙের পরিবর্তে আকাশি নীল, নিরপেক্ষ এবং অ্যাম্বার ব্যবহার করে।</string>
+    <string name="settings_display_palette_rainbow">রংধনু</string>
+    <string name="settings_display_palette_rainbow_description">গোলাপি, কমলা এবং সবুজ চার্ট লাইন সহ Material টিল/লাল আস্থা কার্ড। ডিফল্ট।</string>
+    <string name="settings_unit_auto">স্বয়ংক্রিয়</string>
+    <string name="today_cloud_range">মেঘ %1$d–%2$d%%</string>
+    <string name="today_confidence_precip_spread">মডেলগুলো বৃষ্টি নিয়ে একমত নয় (Δ %1$.0f%%, %2$dটি মডেল)</string>
+    <string name="today_confidence_tap_to_hide">মডেলের পূর্বাভাস লুকাতে ট্যাপ করুন</string>
+    <string name="today_confidence_tap_to_show">প্রতিটি মডেলের পূর্বাভাস দেখতে ট্যাপ করুন</string>
+    <string name="today_humidity_range">আর্দ্রতা %1$d–%2$d%%</string>
+    <string name="today_solar_subtitle">পৃষ্ঠ বিকিরণ তীব্রতা (W/m²) প্রতি ঘণ্টায় প্রতি মডেলে</string>
+    <string name="today_solar_title">সৌর বিকিরণ</string>
+    <string name="today_sunshine_subtitle">প্রতি মডেলে প্রতি ঘণ্টায় রোদের মিনিট</string>
+    <string name="today_sunshine_title">রোদ</string>
+    <string name="today_sunshine_total_hours_minutes">আজ %1$d ঘণ্টা %2$d মিনিট রোদ</string>
+    <string name="today_sunshine_total_hours_only">আজ %1$d ঘণ্টা রোদ</string>
+    <string name="today_sunshine_total_minutes_only">আজ %1$d মিনিট রোদ</string>
+    <string name="today_uv_subtitle">প্রতি মডেলে প্রতি ঘণ্টায় UV সূচক</string>
+    <string name="today_uv_title">UV সূচক</string>
+    <string name="today_wind_peak">সর্বোচ্চ %1$d %2$s সময় %3$s</string>
 </resources>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -596,4 +596,27 @@ Not overridden by design:
     <string name="today_forecast_air_section_title">हवा का तापमान</string>
     <string name="settings_default_bottom_title">मानक नीचे का वस्त्र</string>
     <string name="settings_default_bottom_description">जब शॉर्ट्स के लिए पर्याप्त गर्मी नहीं होती तो होम स्क्रीन पर हम क्या सुझाते हैं।</string>
+
+    <!-- Strings added to match base (new features). -->
+    <string name="settings_display_colors_title">रंग पैलेट</string>
+    <string name="settings_display_palette_accessible">सुलभ</string>
+    <string name="settings_display_palette_accessible_description">Okabe-Ito पर आधारित पैलेट, जो ड्यूटेरानोपिया, प्रोटानोपिया और ट्रिटानोपिया में भी पहचाने जाने योग्य रहे। विश्वास कार्ड टील, तटस्थ और लाल की जगह आसमानी नीला, तटस्थ और एम्बर रंग का उपयोग करते हैं।</string>
+    <string name="settings_display_palette_rainbow">इंद्रधनुष</string>
+    <string name="settings_display_palette_rainbow_description">गुलाबी, नारंगी और हरी चार्ट लाइनें Material टील/लाल विश्वास कार्ड के साथ। डिफ़ॉल्ट।</string>
+    <string name="settings_unit_auto">स्वचालित</string>
+    <string name="today_cloud_range">बादल %1$d–%2$d%%</string>
+    <string name="today_confidence_precip_spread">मॉडल बारिश पर सहमत नहीं (Δ %1$.0f%%, %2$d मॉडल में)</string>
+    <string name="today_confidence_tap_to_hide">मॉडल पूर्वानुमान छुपाने के लिए टैप करें</string>
+    <string name="today_confidence_tap_to_show">प्रत्येक मॉडल का पूर्वानुमान देखने के लिए टैप करें</string>
+    <string name="today_humidity_range">नमी %1$d–%2$d%%</string>
+    <string name="today_solar_subtitle">सतह विकिरण तीव्रता (W/m²) प्रति घंटे प्रति मॉडल</string>
+    <string name="today_solar_title">सौर विकिरण</string>
+    <string name="today_sunshine_subtitle">प्रति मॉडल प्रति घंटे धूप के मिनट</string>
+    <string name="today_sunshine_title">धूप</string>
+    <string name="today_sunshine_total_hours_minutes">आज %1$d घंटे %2$d मिनट धूप</string>
+    <string name="today_sunshine_total_hours_only">आज %1$d घंटे धूप</string>
+    <string name="today_sunshine_total_minutes_only">आज %1$d मिनट धूप</string>
+    <string name="today_uv_subtitle">प्रति मॉडल प्रति घंटे UV सूचकांक</string>
+    <string name="today_uv_title">UV सूचकांक</string>
+    <string name="today_wind_peak">अधिकतम %1$d %2$s %3$s बजे</string>
 </resources>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -566,4 +566,27 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="today_forecast_air_section_title">อุณหภูมิอากาศ</string>
     <string name="settings_default_bottom_title">ท่อนล่างมาตรฐาน</string>
     <string name="settings_default_bottom_description">สิ่งที่เราแนะนำบนหน้าจอหลักเมื่ออากาศไม่อบอุ่นพอที่จะใส่กางเกงขาสั้น</string>
+
+    <!-- Strings added to match base (new features). -->
+    <string name="settings_display_colors_title">ชุดสี</string>
+    <string name="settings_display_palette_accessible">เข้าถึงได้</string>
+    <string name="settings_display_palette_accessible_description">ชุดสีที่อิงจาก Okabe-Ito ออกแบบให้แยกแยะได้ในภาวะตาบอดสีเขียว-แดงและสีน้ำเงิน การ์ดความเชื่อมั่นใช้สีฟ้าฟ้า, กลาง และอำพัน แทนสีเขียวน้ำทะเล, กลาง และแดง</string>
+    <string name="settings_display_palette_rainbow">สีรุ้ง</string>
+    <string name="settings_display_palette_rainbow_description">เส้นกราฟสีชมพู ส้ม และเขียว พร้อมการ์ดความเชื่อมั่น Material สีเขียวน้ำทะเล/แดง ค่าเริ่มต้น</string>
+    <string name="settings_unit_auto">อัตโนมัติ</string>
+    <string name="today_cloud_range">เมฆ %1$d–%2$d%%</string>
+    <string name="today_confidence_precip_spread">แบบจำลองไม่ตรงกันเรื่องฝน (Δ %1$.0f%% ใน %2$d แบบจำลอง)</string>
+    <string name="today_confidence_tap_to_hide">แตะเพื่อซ่อนพยากรณ์ของแต่ละแบบจำลอง</string>
+    <string name="today_confidence_tap_to_show">แตะเพื่อดูพยากรณ์ของแต่ละแบบจำลอง</string>
+    <string name="today_humidity_range">ความชื้น %1$d–%2$d%%</string>
+    <string name="today_solar_subtitle">ความเข้มรังสีพื้นผิว (W/m²) ต่อชั่วโมงต่อแบบจำลอง</string>
+    <string name="today_solar_title">รังสีดวงอาทิตย์</string>
+    <string name="today_sunshine_subtitle">นาทีแดดออกต่อชั่วโมงต่อแบบจำลอง</string>
+    <string name="today_sunshine_title">ชั่วโมงแดด</string>
+    <string name="today_sunshine_total_hours_minutes">แดดวันนี้ %1$d ชม. %2$d นาที</string>
+    <string name="today_sunshine_total_hours_only">แดดวันนี้ %1$d ชม.</string>
+    <string name="today_sunshine_total_minutes_only">แดดวันนี้ %1$d นาที</string>
+    <string name="today_uv_subtitle">ดัชนี UV ต่อชั่วโมงต่อแบบจำลอง</string>
+    <string name="today_uv_title">ดัชนี UV</string>
+    <string name="today_wind_peak">สูงสุด %1$d %2$s เวลา %3$s</string>
 </resources>


### PR DESCRIPTION
## Summary

Adds the 21 strings missing from Thai, Bengali and Hindi — same set as all previous batches.

**Strings added** to `th`, `bn`, `hi`:
- `today_solar_{title,subtitle}`, `today_sunshine_{title,subtitle,total_*}`, `today_uv_{title,subtitle}`
- `today_wind_peak`, `today_cloud_range`, `today_humidity_range`
- `today_confidence_tap_to_{show,hide}`, `today_confidence_precip_spread`
- `settings_display_colors_title`, `settings_display_palette_{rainbow,accessible}{,_description}`
- `settings_unit_auto`

## Remaining gaps

After this PR, only `am`, `ar`, `fa`, `iw` (Hebrew), and `sw` still have missing strings — but those are 133–136 strings each (large pre-existing translation holes, not just the new-feature set). The regional variants (`de-rAT`, `en-rGB`, `fr-rCA`, `es-rMX`, etc.) are intentionally sparse and fall back to their parent locale normally.

## Test plan

- [ ] `./gradlew :app:assembleDebug` — no missing-resource errors

https://claude.ai/code/session_01LoYYyN5Qsya1Nx757Fvn7c

---
_Generated by [Claude Code](https://claude.ai/code/session_01LoYYyN5Qsya1Nx757Fvn7c)_