### PR TITLE
Wire up Claude Code on the web for this repo (Android SDK install + dotfile-only CI gating)

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+# SessionStart hook for Claude Code on the web. Installs the Android SDK so
+# `:app` Gradle tasks (assembleDebug, testDebugUnitTest, lintDebug) work in
+# the sandbox. CI uses android-actions/setup-android@v3 with the same
+# package set; mirroring it here gives the agent CI parity.
+#
+# Skipped outside the remote sandbox so local dev environments aren't
+# clobbered. Idempotent: re-runs after install are a no-op.
+set -euo pipefail
+
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+ANDROID_HOME="${ANDROID_HOME:-/opt/android-sdk}"
+ANDROID_SDK_ROOT="$ANDROID_HOME"
+CMDLINE_TOOLS_DIR="$ANDROID_HOME/cmdline-tools/latest"
+# Pinned to the version CI installs via android-actions/setup-android@v3.
+# Bump in lockstep with `app/build.gradle.kts` (compileSdk) and ci.yml.
+PLATFORM="platforms;android-35"
+BUILD_TOOLS="build-tools;35.0.0"
+PLATFORM_TOOLS="platform-tools"
+# Released August 2024; the last build before Google started shipping JDK 21
+# checks. Any newer cmdline-tools would also be fine — pinning makes the
+# install reproducible across warm-cache restores.
+CMDLINE_TOOLS_VERSION="11076708"
+CMDLINE_TOOLS_URL="https://dl.google.com/android/repository/commandlinetools-linux-${CMDLINE_TOOLS_VERSION}_latest.zip"
+
+persist_env() {
+  if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+    {
+      echo "export ANDROID_HOME=\"$ANDROID_HOME\""
+      echo "export ANDROID_SDK_ROOT=\"$ANDROID_SDK_ROOT\""
+      echo "export PATH=\"$CMDLINE_TOOLS_DIR/bin:$ANDROID_HOME/platform-tools:\$PATH\""
+    } >> "$CLAUDE_ENV_FILE"
+  fi
+}
+
+# Fast path: SDK already installed (warm sandbox or re-run). Just re-export.
+if [ -x "$CMDLINE_TOOLS_DIR/bin/sdkmanager" ] \
+  && [ -d "$ANDROID_HOME/platforms/android-35" ] \
+  && [ -d "$ANDROID_HOME/build-tools/35.0.0" ]; then
+  echo "Android SDK already installed at $ANDROID_HOME — skipping install."
+  persist_env
+  exit 0
+fi
+
+echo "Installing Android SDK to $ANDROID_HOME ..."
+mkdir -p "$ANDROID_HOME/cmdline-tools"
+
+if [ ! -x "$CMDLINE_TOOLS_DIR/bin/sdkmanager" ]; then
+  TMPZIP="$(mktemp --suffix=.zip)"
+  trap 'rm -f "$TMPZIP"' EXIT
+  curl -fsSL --retry 3 --retry-delay 2 -o "$TMPZIP" "$CMDLINE_TOOLS_URL"
+  # The zip extracts to `cmdline-tools/`, but sdkmanager expects the layout
+  # `cmdline-tools/latest/bin/sdkmanager`, so move it into place.
+  TMPDIR="$(mktemp -d)"
+  unzip -q "$TMPZIP" -d "$TMPDIR"
+  rm -rf "$CMDLINE_TOOLS_DIR"
+  mv "$TMPDIR/cmdline-tools" "$CMDLINE_TOOLS_DIR"
+  rm -rf "$TMPDIR"
+fi
+
+export ANDROID_HOME ANDROID_SDK_ROOT
+export PATH="$CMDLINE_TOOLS_DIR/bin:$PATH"
+
+# Accept every license prompt non-interactively. `printf | sdkmanager` would
+# trip `set -o pipefail` if sdkmanager closes stdin before consuming every
+# `y\n` (printf gets SIGPIPE, exits 141, pipeline fails — even though
+# sdkmanager itself succeeded). Disable pipefail just for this line and
+# read sdkmanager's exit code directly from PIPESTATUS.
+set +o pipefail
+printf 'y\n%.0s' $(seq 1 50) | sdkmanager --licenses >/dev/null
+license_rc=${PIPESTATUS[1]}
+set -o pipefail
+if [ "$license_rc" -ne 0 ]; then
+  echo "sdkmanager --licenses failed (exit $license_rc)" >&2
+  exit "$license_rc"
+fi
+sdkmanager --install "$PLATFORM" "$BUILD_TOOLS" "$PLATFORM_TOOLS" >/dev/null
+
+persist_env
+echo "Android SDK ready at $ANDROID_HOME."

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,36 @@ on:
   # Without this, every commit on a PR branch fires CI twice (once for `push`
   # to the branch, once for `pull_request`), and the two runs race on the
   # shared Gradle cache so one frequently fails while the other passes.
+  #
+  # paths: skip CI when a push/PR only touches top-level dotfiles or
+  # hidden directories (.claude/, .gitignore, .editorconfig, .github/
+  # ISSUE_TEMPLATE, dependabot.yml, …). Agent-config / repo-metadata
+  # changes don't move app or build logic, so the ~5min CI cycle is
+  # wasted there. A push that mixes a dotfile change with any non-
+  # dotfile path still runs (the include `**` matches the non-dotfile).
+  #
+  # Uses `paths` (with `!` negations) rather than `paths-ignore` because
+  # `paths-ignore` is documented as exclude-only — combining include
+  # and exclude requires the `paths` form per GitHub's workflow syntax
+  # docs. Patterns evaluate in order, with later overriding earlier:
+  #   1. `**`                     — default, every path triggers
+  #   2. `!.*` / `!.*/**`         — …except top-level dotfiles + hidden dirs
+  #   3. `.github/workflows/**`   — …re-include this file's peers, since
+  #                                 a workflow-only PR IS exactly what
+  #                                 CI most needs to validate.
   push:
     branches: [main]
+    paths:
+      - '**'
+      - '!.*'
+      - '!.*/**'
+      - '.github/workflows/**'
   pull_request:
+    paths:
+      - '**'
+      - '!.*'
+      - '!.*/**'
+      - '.github/workflows/**'
   # Manual rescue trigger so the release-AAB / Firebase / Play-upload steps
   # can be re-fired when the natural `push` event didn't produce a usable
   # build (e.g. a transient gradle / Play API failure on the original
@@ -458,14 +485,15 @@ jobs:
         # noise to a non-engineer reader: anything prefixed `ci:` (the
         # snapshot-regen bot commits "ci: regenerate UI snapshots", workflow
         # tweaks, etc.) and changes whose paths are all under `docs/`, all
-        # under `.github/` (workflow / repo metadata), or top-level `*.md`.
-        # PRIVACY.md is treated as non-docs so that privacy-policy updates
-        # still surface to users. The `.github/` filter is a safety net for
-        # workflow-only commits that forget the `ci:` subject prefix — they
-        # still get walked past on the path-based check. Falls back to the
-        # head subject after 20 hops without a match, so an unusual stretch
-        # of filtered commits still produces *some* changelog rather than
-        # nothing.
+        # top-level dotfiles or hidden directories (`.github/`, `.claude/`,
+        # `.gitignore`, `.editorconfig`, …), or top-level `*.md`. PRIVACY.md
+        # is treated as non-docs so that privacy-policy updates still surface
+        # to users. The `^\.` filter is a safety net for workflow- /
+        # agent-config-only commits that forget the `ci:` subject prefix —
+        # they still get walked past on the path-based check. Falls back to
+        # the head subject after 20 hops without a match, so an unusual
+        # stretch of filtered commits still produces *some* changelog rather
+        # than nothing.
         #
         # Outputs:
         #   - $RUNNER_TEMP/whatsnew/whatsnew-en-US  (consumed by Play upload,
@@ -505,7 +533,7 @@ jobs:
               | awk '
                   /^PRIVACY\.md$/ { count++; next }
                   /^docs\//       { next }
-                  /^\.github\//   { next }
+                  /^\./           { next }
                   /\.md$/         { next }
                                   { count++ }
                   END             { print count + 0 }


### PR DESCRIPTION
## Summary

Two related dev-infra changes that bundle naturally:

**1. Install the Android SDK automatically in Claude Code on the web sessions.** Adds a `SessionStart` hook (`.claude/hooks/session-start.sh`, registered via `.claude/settings.json`) that installs the Android SDK to `/opt/android-sdk` on first run inside a Claude Code on the web sandbox. Mirrors CI's `android-actions/setup-android@v3` setup so the agent can run the same `./gradlew :app:*` commands CI does, instead of being limited to the `cd core && ../gradlew :core:*:test` fallback path documented in `AGENTS.md`.

- Installs `cmdline-tools 11076708`, accepts SDK licenses non-interactively, then `sdkmanager --install platforms;android-35 build-tools;35.0.0 platform-tools`.
- Idempotent: warm sessions short-circuit when both `platforms/android-35/` and `build-tools/35.0.0/` already exist.
- Persists `ANDROID_HOME` / `ANDROID_SDK_ROOT` / `PATH` via `$CLAUDE_ENV_FILE` so subsequent `Bash` calls in the session pick the SDK up without sourcing anything.
- No-ops outside the sandbox (`CLAUDE_CODE_REMOTE != "true"`) so local checkouts don't get clobbered.
- License-accept pipeline reads `sdkmanager`'s exit code via `PIPESTATUS[1]` with `pipefail` disabled around it, so a SIGPIPE on the `printf` producer (sdkmanager closing stdin early) doesn't fail the hook (per Codex review).

**2. Skip CI and release notes for top-level-dotfile-only changes.** Adds a `paths` filter to the workflow's `push` and `pull_request` triggers so a push that only touches `.claude/`, `.gitignore`, `.editorconfig`, `.github/ISSUE_TEMPLATE`, `dependabot.yml`, etc. doesn't burn the ~5min `JVM unit tests` + `Android debug build` cycle on agent-config / repo-metadata commits that can't move app or build behaviour. Mixed pushes (any non-dotfile path) still run.

```yaml
paths:
  - '**'                     # default: every path triggers
  - '!.*'                    # …except top-level dotfiles
  - '!.*/**'                 # …and hidden top-level dirs
  - '.github/workflows/**'   # …re-include workflows (a workflow-only PR
                             # IS exactly what CI most needs to validate)
```

Uses `paths` with `!` negations rather than `paths-ignore` because `paths-ignore` is documented as exclude-only — combining include and exclude requires the `paths` form per GitHub's workflow syntax docs (per Codex review).

Also broadens the existing release-notes walk-back filter in *Prepare release notes for FAD and Play* from `^\.github\/` to `^\.`, so the same paths are walked past when computing the Play "What's new" subject — `.claude/`-only commits no longer have a chance of becoming the user-facing changelog blurb when someone forgets the `ci:` subject prefix. PRIVACY.md still counts as non-doc so privacy-policy updates surface to users.

`AGENTS.md`'s "Cursor Cloud specific instructions" already documented `/opt/android-sdk` as the expected layout; this just wires it up for the web sandbox too.

## Privacy

No change to anything that crosses the device boundary. The hook only touches `/opt/android-sdk` inside the sandbox VM and downloads from `dl.google.com`. The CI / release-notes change only affects which commits are considered for the `whatsnew-en-US` blurb — it strictly reduces what can leak from internal commit subjects to the Play Store.

## Test plan

- [x] Hook completes end-to-end on cold sandbox (~2m: download cmdline-tools → license accept → install three packages).
- [x] Hook short-circuits in <1s when SDK is already installed (warm session).
- [x] `$CLAUDE_ENV_FILE` populated with `ANDROID_HOME` / `ANDROID_SDK_ROOT` / `PATH` exports.
- [x] License-accept survives a hypothetical short stdin read from `sdkmanager` (PIPESTATUS path, validated by re-running the cold install after the SIGPIPE fix).
- [x] `./gradlew :app:compileDebugKotlin` succeeds against the freshly-installed SDK (proves `android.jar` resolves).
- [x] `./gradlew :core:data:test` succeeds via the outer build (proves AGP loads end-to-end).
- [x] awk filter smoke-test: `.claude/`, `.github/`, `.gitignore`, `.editorconfig`, `docs/foo.md`, `README.md` all skipped; `PRIVACY.md`, `app/...` counted.
- [ ] CI runs on this PR (mixed-paths: `.claude/` + `.github/workflows/ci.yml`); next workflow-only push will exercise the workflow re-include, and any future `.claude/`-only push will exercise the skip.
