### PR TITLE
Recover from a partial Android SDK install in the SessionStart hook

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -58,6 +58,18 @@ if [ -x "$CMDLINE_TOOLS_DIR/bin/sdkmanager" ] \
   exit 0
 fi
 
+# Recovery path: a previous install crashed or got SIGKILLed mid-flight,
+# leaving $ANDROID_HOME partially populated. The next session's sdkmanager
+# tries to enumerate that half-tree and NPEs in LocalRepoLoaderImpl.
+# collectPackages, which manifests as "Setup script failed with exit
+# code -1" plus a Java stack trace from the SessionStart hook.
+# Detect partial state — anything under $ANDROID_HOME that isn't the
+# complete fast-path layout — and wipe before retrying.
+if [ -d "$ANDROID_HOME" ] && [ -n "$(ls -A "$ANDROID_HOME" 2>/dev/null)" ]; then
+  echo "Partial SDK install detected at $ANDROID_HOME — wiping before reinstall." >&2
+  rm -rf "$ANDROID_HOME"
+fi
+
 echo "Installing Android SDK to $ANDROID_HOME ..."
 mkdir -p "$ANDROID_HOME/cmdline-tools"
 


### PR DESCRIPTION
## Summary

Follow-up to #451. The SessionStart hook crashed for at least one user with `Setup script failed with exit code -1` and a Java stack trace from `LocalRepoLoaderImpl.collectPackages` deep in sdkmanager.

The root cause is a partial-install state. If the previous SessionStart run was killed mid-install (harness timeout, container restart, sandbox eviction), `/opt/android-sdk` is left with `cmdline-tools/latest/` in place but `platforms/android-35/` or `build-tools/35.0.0/` missing. The fast-path check at the top of the hook requires all three, so the next session falls through to the install branch — but sdkmanager's first action is to enumerate the local repo, and on a partial tree that throws an NPE that takes the whole hook down before it can re-install.

This PR adds a third path between the fast-path skip and the install:

```bash
if [ -d "$ANDROID_HOME" ] && [ -n "$(ls -A "$ANDROID_HOME" 2>/dev/null)" ]; then
  echo "Partial SDK install detected at $ANDROID_HOME — wiping before reinstall." >&2
  rm -rf "$ANDROID_HOME"
fi
```

Triggered only when the fast-path declined (something is missing) *and* `$ANDROID_HOME` is non-empty (partial state, not a fresh container). On a fresh sandbox or a properly-installed warm sandbox, this branch doesn't fire. Costs ~30s extra on the recovery path (re-downloading cmdline-tools) versus an indefinite stuck state for affected users.

## Privacy

No change to anything that crosses the device boundary — same `/opt/android-sdk` install, same `dl.google.com` source, just resilient to interrupted prior runs.

## Test plan

- [x] Cold install on a fresh `/opt/android-sdk`: succeeds, fast-path layout present.
- [x] Warm-sandbox re-run after a successful install: fast-path skip, exits in <1s.
- [x] Partial state (`rm -rf /opt/android-sdk/platforms` then re-run): recovery path triggers, wipes, reinstalls cleanly, exit 0.
- [ ] CI green (no code path touched, hook is sandbox-only).


---
_Generated by [Claude Code](https://claude.ai/code/session_01QXwUFDJEJVHtGZE2bEgz3K)_