### PR TITLE
Harden Android SDK hook against /proc walk crash

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -13,6 +13,19 @@ if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
 fi
 
 ANDROID_HOME="${ANDROID_HOME:-/opt/android-sdk}"
+# sdkmanager's LocalRepoLoaderImpl Files.walk()s the SDK root looking for
+# package.xml. If the root resolves to "/" (empty / relative ANDROID_HOME,
+# or a CWD-based fallback when the hook runs with cwd=/), the walk descends
+# into /proc and the JVM dies on /proc/self/task/<tid>/fd/<n>/... with
+# "Invalid argument" — exactly the failure we hit on a previous run. Refuse
+# anything but an absolute path so the walk always starts somewhere sane.
+case "$ANDROID_HOME" in
+  /*) ;;
+  *)
+    echo "ANDROID_HOME must be an absolute path, got: '$ANDROID_HOME'" >&2
+    exit 1
+    ;;
+esac
 ANDROID_SDK_ROOT="$ANDROID_HOME"
 CMDLINE_TOOLS_DIR="$ANDROID_HOME/cmdline-tools/latest"
 # Pinned to the version CI installs via android-actions/setup-android@v3.
@@ -64,20 +77,32 @@ fi
 export ANDROID_HOME ANDROID_SDK_ROOT
 export PATH="$CMDLINE_TOOLS_DIR/bin:$PATH"
 
+# Run sdkmanager from inside the SDK home so its cwd is a known-good
+# directory: any path resolution that falls back to cwd lands here, not
+# at "/" (where Files.walk recurses into /proc and crashes — see the
+# absolute-path guard above for the full failure mode).
+cd "$ANDROID_HOME"
+
+# Pass --sdk_root explicitly. ANDROID_HOME is exported above and sdkmanager
+# is documented to pick it up, but on at least one sandbox run the JVM
+# resolved the SDK location to "/" instead and walked /proc to its death.
+# Being explicit removes the ambiguity for ~no cost.
+SDK_ROOT_FLAG="--sdk_root=$ANDROID_HOME"
+
 # Accept every license prompt non-interactively. `printf | sdkmanager` would
 # trip `set -o pipefail` if sdkmanager closes stdin before consuming every
 # `y\n` (printf gets SIGPIPE, exits 141, pipeline fails — even though
 # sdkmanager itself succeeded). Disable pipefail just for this line and
 # read sdkmanager's exit code directly from PIPESTATUS.
 set +o pipefail
-printf 'y\n%.0s' $(seq 1 50) | sdkmanager --licenses >/dev/null
+printf 'y\n%.0s' $(seq 1 50) | sdkmanager "$SDK_ROOT_FLAG" --licenses >/dev/null
 license_rc=${PIPESTATUS[1]}
 set -o pipefail
 if [ "$license_rc" -ne 0 ]; then
   echo "sdkmanager --licenses failed (exit $license_rc)" >&2
   exit "$license_rc"
 fi
-sdkmanager --install "$PLATFORM" "$BUILD_TOOLS" "$PLATFORM_TOOLS" >/dev/null
+sdkmanager "$SDK_ROOT_FLAG" --install "$PLATFORM" "$BUILD_TOOLS" "$PLATFORM_TOOLS" >/dev/null
 
 persist_env
 echo "Android SDK ready at $ANDROID_HOME."


### PR DESCRIPTION
## Summary

A previous sandbox run failed the SessionStart hook with `sdkmanager` crashing inside `LocalRepoLoaderImpl.collectPackages`:

```
java.nio.file.FileSystemException:
  /proc/self/task/1133/fd/48/595/task/595/net: Invalid argument
```

That path is reachable only if `Files.walk()` starts somewhere upstream of `/proc` — i.e. the SDK root resolved to `/` (or close to it) instead of `$ANDROID_HOME`. Either the env var wasn't picked up by the JVM on that run, or the resolver fell back to cwd (= `/` when the hook runs with no explicit `cd`). Walking `/proc` dies as soon as it hits a per-task net-namespace handle, which the kernel refuses to enumerate as a directory (`EINVAL`).

Three layered defenses, cheapest first:

1. **Refuse a non-absolute `ANDROID_HOME`** outright. Any future regression that empties or relativises the var fails fast with a clear message instead of crashing the SDK loader 30s in.
2. **`cd "$ANDROID_HOME"`** before invoking sdkmanager. If anything in the tool ever does fall back to cwd, it lands inside the SDK home rather than at `/`.
3. **Pass `--sdk_root="$ANDROID_HOME"` explicitly** on both `--licenses` and `--install`. Removes the ambiguity entirely; documented to take precedence over env vars.

Fast path (warm sandbox, SDK already installed) is unchanged.

## Scope

Sandbox-only — touches just `.claude/hooks/session-start.sh`, no app code, no privacy-relevant surface, no behaviour change for end users or CI. Dotfile-only change so the existing CI/release-notes skip rule applies.

## Test plan

- [x] `bash -n .claude/hooks/session-start.sh` — syntax OK
- [x] Run hook on warm SDK (this VM): short-circuits with `Android SDK already installed at /opt/android-sdk`, persists env file correctly
- [x] Run hook with `ANDROID_HOME=relative/path`: fails fast with `rc=1` and clear error message
- [x] Run hook with `ANDROID_HOME=""`: defaults to `/opt/android-sdk` via `:-` and continues
- [ ] Cold-sandbox install path — covered by next session start in CI / agent runs

## Open PRs in this stack

- https://github.com/mikelward/clothescast/pull/new/claude/harden-android-sdk-hook (this PR)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWWhPZk16j9dVVFshpMvzS)_