### PR TITLE
Translate the Highlighter palette strings into 43 locales

### DIFF
--- a/app/src/main/res/values-am/strings.xml
+++ b/app/src/main/res/values-am/strings.xml
@@ -430,6 +430,8 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="settings_display_colors_title">የቀለም ፓሌት</string>
     <string name="settings_display_palette_rainbow">ቀስተ ደመና</string>
     <string name="settings_display_palette_rainbow_description">ሮዝ፣ ብርቱካናማ እና አረንጓዴ ሰንጠረዥ መስመሮች የ Material ቲያ/ቀይ የአስተማማኝነት ካርዶች ጋር። ነባሪ።</string>
+    <string name="settings_display_palette_highlighter">ማድመቂያ</string>
+    <string name="settings_display_palette_highlighter_description">ማጄንታ፣ ቢጫ እና ሳያን የግራፍ መስመሮች — በወረቀት ላይ እንዳለ የማስታወቂያ ብዕር ሁሉ። ከ\"ቀስተ ደመና\" በቅጽበት ይለያያሉ፤ የብርሃን ጭብጥ ለንባብ ምቾት ጥልቅ ቅርጾች ይጠቀማል። ለቀይ-አረንጓዴ የቀለም ዕውር ሁኔታ ደህንነቱ የተጠበቀ።</string>
     <string name="settings_display_palette_accessible">ተደራሽ</string>
     <string name="settings_display_palette_accessible_description">ዲዩተራኖፒያ፣ ፕሮቶናኖፒያ እና ትሪታኖፒያ ሲኖር ሊለዩ የሚችሉ Okabe-Ito ፓሌት። ካርዶቹ ቲያ፣ ገለልተኛ እና ቀይ ፋንታ ሰማያዊ፣ ገለልተኛ እና ሀምበር ይጠቀማሉ።</string>
     <string name="today_cloud_range">ደመና %1$d–%2$d%%</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -460,6 +460,8 @@ they work correctly in both the single-band and range templates.
     <string name="settings_display_colors_title">لوحة الألوان</string>
     <string name="settings_display_palette_rainbow">قوس قزح</string>
     <string name="settings_display_palette_rainbow_description">خطوط مخطط وردي وبرتقالي وأخضر مع بطاقات ثقة Material باللون الفيروزي/الأحمر. الافتراضي.</string>
+    <string name="settings_display_palette_highlighter">قلم تظليل</string>
+    <string name="settings_display_palette_highlighter_description">خطوط رسم بياني بألوان أرجواني وأصفر وسماوي — كأثر قلم تظليل على الورق. تختلف عن \"قوس قزح\" بوضوح من النظرة الأولى؛ يستخدم الوضع الفاتح إصدارات أعمق لزيادة الوضوح. آمنة لعمى الألوان الأحمر-الأخضر.</string>
     <string name="settings_display_palette_accessible">إمكانية الوصول</string>
     <string name="settings_display_palette_accessible_description">لوحة ألوان مشتقة من Okabe-Ito مصممة للتمييز في حالات عمى الألوان. تستخدم بطاقات الثقة الأزرق السماوي والمحايد والكهرماني بدلاً من الفيروزي والمحايد والأحمر.</string>
     <string name="today_cloud_range">السحب %1$d–%2$d%%</string>

--- a/app/src/main/res/values-b+sr+Latn/strings.xml
+++ b/app/src/main/res/values-b+sr+Latn/strings.xml
@@ -589,6 +589,8 @@ default English (matching values-pl / values-uk).
     <string name="settings_display_palette_accessible_description">Paleta izvedena iz Okabe-Ito, dizajnirana da ostane razlučiva pri deuteranopiji, protanopiji i tritanopiji. Kartice pouzdanosti koriste nebesko plavu, neutralnu i jantarnu umesto tirkizne, neutralne i crvene.</string>
     <string name="settings_display_palette_rainbow">Duga</string>
     <string name="settings_display_palette_rainbow_description">Roze, narandžaste i zelene linije grafikona sa tirkiznim/crvenim karticama pouzdanosti Material. Podrazumevano.</string>
+    <string name="settings_display_palette_highlighter">Marker</string>
+    <string name="settings_display_palette_highlighter_description">Magenta, žute i cijan linije grafikona — kao trag markera na stranici. Na prvi pogled vidno drugačije od \"Duge\"; svetla tema koristi dublje varijante za čitljivost. Bezbedno za crveno-zeleno slepilo za boje.</string>
     <string name="settings_unit_auto">Auto</string>
     <string name="today_cloud_range">Oblačnost %1$d–%2$d%%</string>
     <string name="today_confidence_precip_spread">Modeli se ne slažu oko kiše (Δ %1$.0f%% kod %2$d modela)</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -587,6 +587,8 @@ What is NOT overridden, by design:
     <string name="settings_display_palette_accessible_description">Палитра, базирана на Okabe-Ito, проектирана да остане различима при дейтеранопия, протанопия и тританопия. Картите за достоверност използват небесно синьо, неутрално и кехлибарено вместо синьо-зелено, неутрално и червено.</string>
     <string name="settings_display_palette_rainbow">Дъга</string>
     <string name="settings_display_palette_rainbow_description">Розови, оранжеви и зелени линии на графиките с карти за достоверност Material синьо-зелено/червено. По подразбиране.</string>
+    <string name="settings_display_palette_highlighter">Маркер</string>
+    <string name="settings_display_palette_highlighter_description">Линии на графиката в магента, жълто и циан — като следа от маркер върху страницата. Видимо различни от \"Дъга\" от пръв поглед; светлата тема използва по-наситени варианти за четливост. Безопасни при червено-зелена цветна слепота.</string>
     <string name="settings_unit_auto">Авто</string>
     <string name="today_cloud_range">Облачност %1$d–%2$d%%</string>
     <string name="today_confidence_precip_spread">Моделите не са съгласни за дъжда (Δ %1$.0f%% при %2$d модела)</string>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -643,6 +643,8 @@ West Bengal vocabulary differences in a future PR.
     <string name="settings_display_palette_accessible_description">Okabe-Ito ভিত্তিক একটি প্যালেট যা ডিউটেরানোপিয়া, প্রোটানোপিয়া এবং ট্রিটানোপিয়ায় আলাদাভাবে চেনা যায়। আস্থা কার্ডগুলো টিল, নিরপেক্ষ এবং লাল রঙের পরিবর্তে আকাশি নীল, নিরপেক্ষ এবং অ্যাম্বার ব্যবহার করে।</string>
     <string name="settings_display_palette_rainbow">রংধনু</string>
     <string name="settings_display_palette_rainbow_description">গোলাপি, কমলা এবং সবুজ চার্ট লাইন সহ Material টিল/লাল আস্থা কার্ড। ডিফল্ট।</string>
+    <string name="settings_display_palette_highlighter">হাইলাইটার</string>
+    <string name="settings_display_palette_highlighter_description">ম্যাজেন্টা, হলুদ এবং সায়ান চার্ট লাইন — যেন পাতার উপর হাইলাইটার কলমের ছোঁয়া। এক নজরেই \"রংধনু\" থেকে দৃশ্যমানভাবে আলাদা; লাইট থিমে পঠনযোগ্যতার জন্য গভীরতর সংস্করণ ব্যবহার করা হয়। লাল-সবুজ বর্ণান্ধতার জন্য নিরাপদ।</string>
     <string name="settings_unit_auto">স্বয়ংক্রিয়</string>
     <string name="today_cloud_range">মেঘ %1$d–%2$d%%</string>
     <string name="today_confidence_precip_spread">মডেলগুলো বৃষ্টি নিয়ে একমত নয় (Δ %1$.0f%%, %2$dটি মডেল)</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -540,6 +540,8 @@ the in-app clock is digit-driven and reads consistently across locales.
     <string name="settings_display_palette_accessible_description">Una paleta derivada d\'Okabe-Ito, dissenyada per mantenir-se distingible amb deuteranopia, protanopia i tritanopia. Les targetes de confiança utilitzen blau cel, neutre i ambre en lloc de blau verdós, neutre i vermell.</string>
     <string name="settings_display_palette_rainbow">Arc de Sant Martí</string>
     <string name="settings_display_palette_rainbow_description">Línies de gràfic rosa, taronja i verd amb targetes de confiança Material blau verdós/vermell. Per defecte.</string>
+    <string name="settings_display_palette_highlighter">Marcador</string>
+    <string name="settings_display_palette_highlighter_description">Línies de gràfic en magenta, groc i cian — com una pinzellada de marcador a la pàgina. Es distingeixen clarament de l\'\"Arc de Sant Martí\" d\'un cop d\'ull; el tema clar utilitza variants més profundes per a la llegibilitat. Segures per al daltonisme vermell-verd.</string>
     <string name="settings_unit_auto">Auto</string>
     <string name="today_cloud_range">Nuvolositat %1$d–%2$d%%</string>
     <string name="today_confidence_precip_spread">Els models no es posen d\'acord sobre la pluja (Δ %1$.0f%% entre %2$d models)</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -590,6 +590,8 @@ locale (Angličtina (USA), Francouzština (Francie), Němčina (Německo), …).
     <string name="settings_display_palette_accessible_description">Paleta odvozená od Okabe-Ito, navržená tak, aby zůstala rozlišitelná při deuteranopii, protanopii a tritanopii. Karty spolehlivosti používají nebeskou modrou, neutrální a jantarovou místo tyrkysové, neutrální a červené.</string>
     <string name="settings_display_palette_rainbow">Duha</string>
     <string name="settings_display_palette_rainbow_description">Růžové, oranžové a zelené linky grafů s tyrkysovými/červenými kartami spolehlivosti Material. Výchozí.</string>
+    <string name="settings_display_palette_highlighter">Zvýrazňovač</string>
+    <string name="settings_display_palette_highlighter_description">Purpurové, žluté a azurové čáry grafu — jako stopa zvýrazňovače na stránce. Na první pohled viditelně odlišné od \"Duhy\"; světlý motiv používá hlubší varianty pro čitelnost. Bezpečné při červeno-zelené barvosleposti.</string>
     <string name="settings_unit_auto">Auto</string>
     <string name="today_cloud_range">Oblačnost %1$d\u2013%2$d%%</string>
     <string name="today_confidence_precip_spread">Modely se neshodují na srážkách (Δ %1$.0f%% pro %2$d modely)</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -603,6 +603,8 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrig)").
     <string name="settings_display_palette_accessible_description">En Okabe-Ito-baseret palette designet til at forblive skelneligt ved deuteranopi, protanopi og tritanopi. Tillidskorene bruger himmelblå, neutral og rav i stedet for teal, neutral og rød.</string>
     <string name="settings_display_palette_rainbow">Regnbue</string>
     <string name="settings_display_palette_rainbow_description">Lyserøde, orange og grønne diagramlinjer med Material teal/røde tillidskort. Standard.</string>
+    <string name="settings_display_palette_highlighter">Markeringspen</string>
+    <string name="settings_display_palette_highlighter_description">Magenta, gule og cyan grafiklinjer — som markeringspenne på siden. Ved første øjekast synligt anderledes end \"Regnbue\"; det lyse tema bruger dybere varianter for læsbarhed. Sikker ved rød-grøn farveblindhed.</string>
     <string name="settings_unit_auto">Auto</string>
     <string name="today_cloud_range">Skydække %1$d\u2013%2$d%%</string>
     <string name="today_confidence_precip_spread">Modellerne er uenige om regn (Δ %1$.0f%% på tværs af %2$d modeller)</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -725,6 +725,8 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_display_palette_accessible_description">Eine an Okabe-Ito angelehnte Palette, die bei Deuteranopie, Protanopie und Tritanopie unterscheidbar bleibt. Konfidenz-Karten verwenden Himmelblau, Neutral und Bernstein statt Türkis, Neutral und Rot.</string>
     <string name="settings_display_palette_rainbow">Regenbogen</string>
     <string name="settings_display_palette_rainbow_description">Pinke, orange und grüne Diagrammlinien sowie türkis/rote Konfidenz-Karten. Standard.</string>
+    <string name="settings_display_palette_highlighter">Textmarker</string>
+    <string name="settings_display_palette_highlighter_description">Magenta, gelbe und cyanfarbene Diagrammlinien — wie Textmarker auf dem Papier. Auf einen Blick sichtbar anders als \"Regenbogen\"; das helle Design verwendet tiefere Varianten für bessere Lesbarkeit. Sicher bei Rot-Grün-Sehschwäche.</string>
     <string name="settings_unit_auto">Auto</string>
     <string name="today_cloud_range">Bewölkung %1$d\u2013%2$d%%</string>
     <string name="today_confidence_tap_to_hide">Tippen zum Ausblenden der Modellvorhersagen</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -722,6 +722,8 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_display_palette_accessible_description">Παλέτα βασισμένη στο Okabe-Ito, σχεδιασμένη να παραμένει διακριτή σε δευτερανωπία, πρωτανωπία και τριτανωπία. Οι κάρτες αξιοπιστίας χρησιμοποιούν γαλάζιο, ουδέτερο και κεχριμπαρί αντί για πετρόλ, ουδέτερο και κόκκινο.</string>
     <string name="settings_display_palette_rainbow">Ουράνιο τόξο</string>
     <string name="settings_display_palette_rainbow_description">Ροζ, πορτοκαλί και πράσινες γραμμές γραφημάτων με κάρτες αξιοπιστίας Material πετρόλ/κόκκινο. Προεπιλογή.</string>
+    <string name="settings_display_palette_highlighter">Μαρκαδόρος</string>
+    <string name="settings_display_palette_highlighter_description">Γραμμές γραφήματος σε ματζέντα, κίτρινο και κυανό — σαν ίχνος μαρκαδόρου στη σελίδα. Με μια ματιά διακρίνονται από το \"Ουράνιο τόξο\"· το ανοιχτό θέμα χρησιμοποιεί πιο σκούρες εκδοχές για αναγνωσιμότητα. Ασφαλές για κόκκινη-πράσινη αχρωματοψία.</string>
     <string name="settings_unit_auto">Αυτόματο</string>
     <string name="today_cloud_range">Νέφωση %1$d–%2$d%%</string>
     <string name="today_confidence_precip_spread">Τα μοντέλα διαφωνούν για τη βροχή (Δ %1$.0f%% σε %2$d μοντέλα)</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -702,6 +702,8 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_display_palette_accessible_description">Una paleta derivada de Okabe-Ito diseñada para seguir siendo distinguible con deuteranopía, protanopía y tritanopía. Las tarjetas de confianza usan azul cielo, neutro y ámbar en lugar de verde azulado, neutro y rojo.</string>
     <string name="settings_display_palette_rainbow">Arcoíris</string>
     <string name="settings_display_palette_rainbow_description">Líneas de gráfico rosa, naranja y verde con tarjetas de confianza Material en verde azulado/rojo. La predeterminada.</string>
+    <string name="settings_display_palette_highlighter">Marcador</string>
+    <string name="settings_display_palette_highlighter_description">Líneas de gráfico en magenta, amarillo y cian — como marcadores fluorescentes sobre el papel. Visiblemente diferentes de \"Arcoíris\" a primera vista; el tema claro usa variantes más oscuras para mayor legibilidad. Seguro con daltonismo rojo-verde.</string>
     <string name="settings_unit_auto">Auto</string>
     <string name="today_cloud_range">Nubosidad %1$d\u2013%2$d%%</string>
     <string name="today_confidence_tap_to_hide">Toca para ocultar las previsiones por modelo</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -548,6 +548,8 @@ Tone is informal "sina"-form throughout ("Pane … selga", "Võta … kaasa",
     <string name="settings_display_palette_accessible_description">Okabe-Ito põhine palett, mis on loodud olema eristatav deuteranoopiaga, protanoopiaga ja tritanoopiaga. Usaldusväärsuskaardid kasutavad taevasinist, neutraalset ja merevaigukollast teal, neutraalse ja punase asemel.</string>
     <string name="settings_display_palette_rainbow">Vikerkaar</string>
     <string name="settings_display_palette_rainbow_description">Roosa, oranž ja roheline diagrammijoon koos Material teal/punaste usaldusväärsuskaartidega. Vaikimisi.</string>
+    <string name="settings_display_palette_highlighter">Esiletõstja</string>
+    <string name="settings_display_palette_highlighter_description">Magenta, kollased ja tsüaani värvi graafiku jooned — nagu esiletõstja jälg lehel. Ühe pilguga selgelt erinevad \"Vikerkaarest\"; hele teema kasutab loetavuse jaoks tumedamaid variante. Ohutu punase-rohelise värvipimeduse korral.</string>
     <string name="settings_unit_auto">Automaatne</string>
     <string name="today_cloud_range">Pilvisus %1$d–%2$d%%</string>
     <string name="today_confidence_precip_spread">Mudelid ei nõustu vihma osas (Δ %1$.0f%% %2$d mudeli vahel)</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -448,6 +448,8 @@ Western Arabic numerals (0-9) are used for TTS compatibility.
     <string name="settings_display_colors_title">پالت رنگ</string>
     <string name="settings_display_palette_rainbow">رنگین‌کمان</string>
     <string name="settings_display_palette_rainbow_description">خطوط نمودار صورتی، نارنجی و سبز با کارت‌های اطمینان Material فیروزه‌ای/قرمز. پیش‌فرض.</string>
+    <string name="settings_display_palette_highlighter">ماژیک هایلایت</string>
+    <string name="settings_display_palette_highlighter_description">خطوط نمودار به رنگ‌های ارغوانی، زرد و فیروزه‌ای — مانند ردّ ماژیک هایلایت روی کاغذ. در نگاه اول به‌وضوح از \"رنگین‌کمان\" متمایزند؛ تم روشن از تنالیته‌های عمیق‌تر برای خوانایی استفاده می‌کند. برای کوررنگی قرمز-سبز ایمن است.</string>
     <string name="settings_display_palette_accessible">در دسترس</string>
     <string name="settings_display_palette_accessible_description">پالتی برگرفته از Okabe-Ito که برای تمایز در انواع کوررنگی طراحی شده. کارت‌های اطمینان از آبی آسمانی، خنثی و کهربایی به‌جای فیروزه‌ای، خنثی و قرمز استفاده می‌کنند.</string>
     <string name="today_cloud_range">ابر %1$d–%2$d%%</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -583,6 +583,8 @@ displayed label localizes.
     <string name="settings_display_palette_accessible_description">Okabe-Ito-pohjainen paletti, joka on suunniteltu pysymään erotettavana deuteranopian, protanopian ja tritanopian yhteydessä. Luotettavuuskortit käyttävät taivaansinistä, neutraalia ja meripihkaa tealin, neutraalin ja punaisen sijaan.</string>
     <string name="settings_display_palette_rainbow">Sateenkaari</string>
     <string name="settings_display_palette_rainbow_description">Vaaleanpunaiset, oranssit ja vihreät kaavioviivat sekä Material teal/punaiset luotettavuuskortit. Oletus.</string>
+    <string name="settings_display_palette_highlighter">Korostuskynä</string>
+    <string name="settings_display_palette_highlighter_description">Magenta, keltaiset ja syaaninväriset kaaviolinjat — kuin korostuskynänjälki sivulla. Erottuu ensisilmäyksellä \"Sateenkaaresta\"; vaalea teema käyttää syvempiä variantteja luettavuuden vuoksi. Turvallinen puna-vihersokeudelle.</string>
     <string name="settings_unit_auto">Auto</string>
     <string name="today_cloud_range">Pilvisyys %1$d\u2013%2$d%%</string>
     <string name="today_confidence_precip_spread">Mallit ovat eri mieltä sateesta (Δ %1$.0f%% %2$d mallin kesken)</string>

--- a/app/src/main/res/values-fil/strings.xml
+++ b/app/src/main/res/values-fil/strings.xml
@@ -623,6 +623,8 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="settings_display_palette_accessible_description">Isang palette batay sa Okabe-Ito, dinisenyo upang manatiling makilala sa deuteranopia, protanopia, at tritanopia. Gumagamit ang mga confidence card ng sky blue, neutral, at amber sa halip na teal, neutral, at pula.</string>
     <string name="settings_display_palette_rainbow">Bahaghari</string>
     <string name="settings_display_palette_rainbow_description">Pink, orange, at berdeng linya ng tsart na may teal/pulang confidence card na Material. Default.</string>
+    <string name="settings_display_palette_highlighter">Highlighter</string>
+    <string name="settings_display_palette_highlighter_description">Mga linya ng tsart sa magenta, dilaw, at cyan — parang gurit ng highlighter sa pahina. Madaling makita ang pagkaiba sa \"Bahaghari\"; gumagamit ang light theme ng mas matingkad na bersyon para sa kabasahan. Ligtas para sa pagkabulag sa pula-berde.</string>
     <string name="settings_unit_auto">Auto</string>
     <string name="today_cloud_range">Ulap %1$d–%2$d%%</string>
     <string name="today_confidence_precip_spread">Hindi nagkakasundo ang mga modelo sa ulan (Δ %1$.0f%% sa %2$d modelo)</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -701,6 +701,8 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_display_palette_accessible_description">Une palette inspirée d\'Okabe-Ito, conçue pour rester distinguable en cas de deutéranopie, protanopie et tritanopie. Les cartes de confiance utilisent bleu ciel, neutre et ambre au lieu de sarcelle, neutre et rouge.</string>
     <string name="settings_display_palette_rainbow">Arc-en-ciel</string>
     <string name="settings_display_palette_rainbow_description">Lignes de graphique roses, oranges et vertes avec des cartes de confiance sarcelle/rouge Material. Par défaut.</string>
+    <string name="settings_display_palette_highlighter">Surligneur</string>
+    <string name="settings_display_palette_highlighter_description">Lignes de graphique magenta, jaune et cyan — comme un coup de surligneur sur la page. Visiblement différentes d\'\"Arc-en-ciel\" d\'un coup d\'œil ; le thème clair utilise des variantes plus profondes pour la lisibilité. Adapté au daltonisme rouge-vert.</string>
     <string name="settings_unit_auto">Auto</string>
     <string name="today_cloud_range">Nuages %1$d\u2013%2$d%%</string>
     <string name="today_confidence_tap_to_hide">Appuyer pour masquer les prévisions par modèle</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -603,6 +603,8 @@ Not overridden by design:
     <string name="settings_display_palette_accessible_description">Okabe-Ito पर आधारित पैलेट, जो ड्यूटेरानोपिया, प्रोटानोपिया और ट्रिटानोपिया में भी पहचाने जाने योग्य रहे। विश्वास कार्ड टील, तटस्थ और लाल की जगह आसमानी नीला, तटस्थ और एम्बर रंग का उपयोग करते हैं।</string>
     <string name="settings_display_palette_rainbow">इंद्रधनुष</string>
     <string name="settings_display_palette_rainbow_description">गुलाबी, नारंगी और हरी चार्ट लाइनें Material टील/लाल विश्वास कार्ड के साथ। डिफ़ॉल्ट।</string>
+    <string name="settings_display_palette_highlighter">हाइलाइटर</string>
+    <string name="settings_display_palette_highlighter_description">मैजेंटा, पीली और सायन रंग की चार्ट लाइनें — पन्ने पर हाइलाइटर पेन की तरह। \"इंद्रधनुष\" से एक नज़र में स्पष्ट रूप से अलग; लाइट थीम पठनीयता के लिए गहरे संस्करण उपयोग करती है। लाल-हरे रंग अंधता में सुरक्षित।</string>
     <string name="settings_unit_auto">स्वचालित</string>
     <string name="today_cloud_range">बादल %1$d–%2$d%%</string>
     <string name="today_confidence_precip_spread">मॉडल बारिश पर सहमत नहीं (Δ %1$.0f%%, %2$d मॉडल में)</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -670,6 +670,8 @@ spousal register), matching the existing insight prose ("Ponesi …",
     <string name="settings_display_palette_accessible_description">Paleta izvedena iz Okabe-Ito-a, dizajnirana da ostane razlučiva u slučaju deuteranopije, protanopije i tritanopije. Kartice pouzdanosti koriste nebesko plavu, neutralnu i jantarnu umjesto tirkizne, neutralne i crvene.</string>
     <string name="settings_display_palette_rainbow">Duga</string>
     <string name="settings_display_palette_rainbow_description">Ružičaste, narančaste i zelene linije grafikona s tirkiznim/crvenim karticama pouzdanosti Material. Zadano.</string>
+    <string name="settings_display_palette_highlighter">Marker</string>
+    <string name="settings_display_palette_highlighter_description">Magenta, žute i cijan linije grafikona — kao trag markera na stranici. Na prvi pogled vidno različite od \"Duge\"; svijetla tema koristi dublje varijante za čitljivost. Sigurne za crveno-zelenu sljepoću za boje.</string>
     <string name="settings_unit_auto">Auto</string>
     <string name="today_cloud_range">Oblačnost %1$d\u2013%2$d%%</string>
     <string name="today_confidence_tap_to_hide">Dodirnite za skrivanje prognoza po modelu</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -593,6 +593,8 @@ locale (Angol (Egyesült Államok), Francia (Franciaország), Német
     <string name="settings_display_palette_accessible_description">Okabe-Ito alapú paletta, amelyet deuteranópia, protanópia és tritanópia esetén is megkülönböztethetőnek terveztek. A megbízhatósági kártyák kékeszöld, semleges és piros helyett égkéket, semlegeset és borostyánsárgát használnak.</string>
     <string name="settings_display_palette_rainbow">Szivárvány</string>
     <string name="settings_display_palette_rainbow_description">Rózsaszín, narancssárga és zöld diagramvonalak Material kékeszöld/piros megbízhatósági kártyákkal. Az alapértelmezett.</string>
+    <string name="settings_display_palette_highlighter">Szövegkiemelő</string>
+    <string name="settings_display_palette_highlighter_description">Magenta, sárga és ciánkék diagramvonalak — mint a szövegkiemelő nyoma a lapon. Első pillantásra láthatóan más, mint a \"Szivárvány\"; a világos téma mélyebb változatokat használ az olvashatóság érdekében. Biztonságos vörös-zöld színtévesztéshez.</string>
     <string name="settings_unit_auto">Auto</string>
     <string name="today_cloud_range">Felhőzet %1$d\u2013%2$d%%</string>
     <string name="today_confidence_precip_spread">A modellek nem értenek egyet a csapadékban (Δ %1$.0f%% %2$d modell között)</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -573,6 +573,8 @@ to values/strings.xml (English).
     <string name="settings_display_palette_accessible_description">Palet berbasis Okabe-Ito yang dirancang agar tetap dapat dibedakan saat deuteranopia, protanopia, dan tritanopia. Kartu keyakinan menggunakan biru langit, netral, dan kuning amber, bukan teal, netral, dan merah.</string>
     <string name="settings_display_palette_rainbow">Pelangi</string>
     <string name="settings_display_palette_rainbow_description">Garis grafik merah muda, oranye, dan hijau dengan kartu keyakinan Material teal/merah. Bawaan.</string>
+    <string name="settings_display_palette_highlighter">Stabilo</string>
+    <string name="settings_display_palette_highlighter_description">Garis grafik magenta, kuning, dan cyan — seperti goresan stabilo di halaman. Sekilas tampak jelas berbeda dari \"Pelangi\"; tema terang memakai varian yang lebih gelap agar lebih mudah dibaca. Aman untuk buta warna merah-hijau.</string>
     <string name="settings_unit_auto">Otomatis</string>
     <string name="today_cloud_range">Awan %1$d–%2$d%%</string>
     <string name="today_confidence_precip_spread">Model tidak sepakat soal hujan (Δ %1$.0f%% dari %2$d model)</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -687,6 +687,8 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_display_palette_accessible_description">Una tavolozza derivata da Okabe-Ito, progettata per rimanere distinguibile in caso di deuteranopia, protanopia e tritanopia. Le schede di affidabilità usano azzurro cielo, neutro e ambra al posto di verde acqua, neutro e rosso.</string>
     <string name="settings_display_palette_rainbow">Arcobaleno</string>
     <string name="settings_display_palette_rainbow_description">Linee del grafico rosa, arancione e verde con schede di affidabilità Material verde acqua/rosso. Il valore predefinito.</string>
+    <string name="settings_display_palette_highlighter">Evidenziatore</string>
+    <string name="settings_display_palette_highlighter_description">Linee del grafico magenta, gialle e ciano — come tratti di evidenziatore sulla pagina. Visivamente diverse da \"Arcobaleno\" al primo sguardo; il tema chiaro usa varianti più scure per la leggibilità. Sicuro per il daltonismo rosso-verde.</string>
     <string name="settings_unit_auto">Auto</string>
     <string name="today_cloud_range">Nuvolosità %1$d\u2013%2$d%%</string>
     <string name="today_confidence_tap_to_hide">Tocca per nascondere le previsioni per modello</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -456,6 +456,8 @@ standard in Israeli digital communication.
     <string name="settings_display_colors_title">פלטת צבעים</string>
     <string name="settings_display_palette_rainbow">קשת בענן</string>
     <string name="settings_display_palette_rainbow_description">קווי גרף ורוד, כתום וירוק עם כרטיסי אמון Material בירקרק/אדום. ברירת המחדל.</string>
+    <string name="settings_display_palette_highlighter">טוש זוהר</string>
+    <string name="settings_display_palette_highlighter_description">קווי גרף בצבעי מגנטה, צהוב ותכלת — כמו טוש זוהר על הדף. נבדלים מ\"קשת בענן\" במבט ראשון; הערכת הבהיר משתמשת בגוונים עמוקים יותר לקריאות. בטוחים לעיוורי צבעים אדום-ירוק.</string>
     <string name="settings_display_palette_accessible">נגיש</string>
     <string name="settings_display_palette_accessible_description">פלטה המבוססת על Okabe-Ito, מעוצבת להישאר מבחינה בעיוורון צבעים. כרטיסי האמון משתמשים בכחול שמים, ניטרלי וענבר במקום ירקרק, ניטרלי ואדום.</string>
     <string name="today_cloud_range">ענן %1$d–%2$d%%</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -707,6 +707,8 @@ the displayed label localizes.
     <string name="settings_display_palette_accessible_description">第二色盲・第一色盲・第三色盲でも識別しやすいOkabe-Itoベースのパレット。信頼度カードはティール・ニュートラル・レッドの代わりにスカイブルー・ニュートラル・アンバーを使用。</string>
     <string name="settings_display_palette_rainbow">レインボー</string>
     <string name="settings_display_palette_rainbow_description">ピンク・オレンジ・グリーンのグラフ線とMaterialのティール/レッドの信頼度カード。デフォルト設定。</string>
+    <string name="settings_display_palette_highlighter">ハイライト</string>
+    <string name="settings_display_palette_highlighter_description">マゼンタ・イエロー・シアンのグラフ線。ページの上の蛍光ペンのよう。「レインボー」とひと目で見分けがつき、ライトテーマでは読みやすさのため少し濃いバージョンを使います。赤緑の色覚特性でも安全です。</string>
     <string name="settings_unit_auto">自動</string>
     <string name="today_cloud_range">雲量 %1$d〜%2$d%%</string>
     <string name="today_confidence_precip_spread">降水確率でモデル間に差あり（Δ %1$.0f%%、%2$dモデル間）</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -711,6 +711,8 @@ displayed label localizes.
     <string name="settings_display_palette_accessible_description">제2색맹, 제1색맹, 제3색맹에서도 구별 가능하도록 설계된 Okabe-Ito 기반 팔레트. 신뢰도 카드는 청록, 중립, 빨강 대신 하늘색, 중립, 호박색을 사용합니다.</string>
     <string name="settings_display_palette_rainbow">레인보우</string>
     <string name="settings_display_palette_rainbow_description">핑크, 주황, 초록 차트 선과 Material 청록/빨강 신뢰도 카드. 기본값.</string>
+    <string name="settings_display_palette_highlighter">형광펜</string>
+    <string name="settings_display_palette_highlighter_description">마젠타·노랑·시안 차트 선 — 종이 위에 형광펜으로 그은 듯한 느낌입니다. 한눈에 \"무지개\"와 분명히 구분되며, 라이트 테마는 가독성을 위해 더 짙은 색을 사용합니다. 적-녹 색각 이상에서도 안전합니다.</string>
     <string name="settings_unit_auto">자동</string>
     <string name="today_cloud_range">구름량 %1$d〜%2$d%%</string>
     <string name="today_confidence_precip_spread">강수 확률에서 모델 간 의견 불일치 (Δ %1$.0f%%, %2$d개 모델)</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -592,6 +592,8 @@ What is NOT overridden, by design:
     <string name="settings_display_palette_accessible_description">Okabe-Ito pagrindu sudaryta paletė, skirta išlikti atskiriama esant deuteranopija, protanopija ir tritanopija. Patikimumo kortelės naudoja dangaus mėlyną, neutralų ir gintaro spalvas, o ne žalsvą, neutralų ir raudoną.</string>
     <string name="settings_display_palette_rainbow">Vaivorykštė</string>
     <string name="settings_display_palette_rainbow_description">Rožinės, oranžinės ir žalios diagramų linijos su Material žalsvomis/raudonomis patikimumo kortelėmis. Numatytoji.</string>
+    <string name="settings_display_palette_highlighter">Žymeklis</string>
+    <string name="settings_display_palette_highlighter_description">Purpurinės, geltonos ir žydros diagramos linijos — tarsi žymeklio brūkšnis ant puslapio. Iš pirmo žvilgsnio aiškiai skiriasi nuo \"Vaivorykštės\"; šviesi tema naudoja tamsesnius variantus, kad būtų geriau įskaitoma. Saugu esant raudonai-žaliai spalvinei aklumai.</string>
     <string name="settings_unit_auto">Automatiškai</string>
     <string name="today_cloud_range">Debesuotumas %1$d–%2$d%%</string>
     <string name="today_confidence_precip_spread">Modeliai nesutaria dėl lietaus (Δ %1$.0f%% iš %2$d modelių)</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -545,6 +545,8 @@ informal "tu"-form throughout ("Apģērb …", "Paņem … līdzi").
     <string name="settings_display_palette_accessible_description">Okabe-Ito palete, kas paredzēta, lai paliktu atšķirama deuteranopijas, protanopijas un tritanopijas gadījumā. Ticamības kartes izmanto debesu zilu, neitrālu un dzintarkrāsu, nevis tirkīzu, neitrālu un sarkanu.</string>
     <string name="settings_display_palette_rainbow">Varavīksne</string>
     <string name="settings_display_palette_rainbow_description">Rozā, oranžas un zaļas diagrammas līnijas ar Material tirkīza/sarkanām ticamības kartēm. Noklusējums.</string>
+    <string name="settings_display_palette_highlighter">Marķieris</string>
+    <string name="settings_display_palette_highlighter_description">Fuksiju, dzeltenas un ciāna grafika līnijas — kā marķiera pēdas uz lapas. No pirmā skatiena nepārprotami atšķiras no \"Varavīksnes\"; gaišā tēma izmanto tumšākus variantus labākai lasāmībai. Droši sarkanas-zaļas krāsu akluma gadījumā.</string>
     <string name="settings_unit_auto">Automātiski</string>
     <string name="today_cloud_range">Mākoņainums %1$d–%2$d%%</string>
     <string name="today_confidence_precip_spread">Modeļi nepiekrīt lietus jautājumā (Δ %1$.0f%% starp %2$d modeļiem)</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -579,6 +579,8 @@ vs "kemungkinan", "padam" vs "hapus").
     <string name="settings_display_palette_accessible_description">Palet berasaskan Okabe-Ito yang direka untuk kekal dapat dibezakan semasa deuteranopia, protanopia, dan tritanopia. Kad keyakinan menggunakan biru langit, neutral, dan kuning amber, bukan teal, neutral, dan merah.</string>
     <string name="settings_display_palette_rainbow">Pelangi</string>
     <string name="settings_display_palette_rainbow_description">Garis carta merah jambu, oren, dan hijau dengan kad keyakinan Material teal/merah. Lalai.</string>
+    <string name="settings_display_palette_highlighter">Stabilo</string>
+    <string name="settings_display_palette_highlighter_description">Garis carta magenta, kuning, dan biru kehijauan — seperti coretan stabilo di muka surat. Sekilas pandang ternyata berbeza daripada \"Pelangi\"; tema cerah menggunakan varian yang lebih gelap untuk kebolehbacaan. Selamat untuk buta warna merah-hijau.</string>
     <string name="settings_unit_auto">Auto</string>
     <string name="today_cloud_range">Awan %1$d–%2$d%%</string>
     <string name="today_confidence_precip_spread">Model tidak bersetuju tentang hujan (Δ %1$.0f%% merentasi %2$d model)</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -602,6 +602,8 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrike)").
     <string name="settings_display_palette_accessible_description">En Okabe-Ito-basert palett utformet for å forbli skillbar ved deuteranopi, protanopi og tritanopi. Tillitskorte bruker himmelblå, nøytral og rav i stedet for teal, nøytral og rød.</string>
     <string name="settings_display_palette_rainbow">Regnbue</string>
     <string name="settings_display_palette_rainbow_description">Rosa, oransje og grønne diagramlinjer med Material teal/røde tillitskort. Standard.</string>
+    <string name="settings_display_palette_highlighter">Markeringspenn</string>
+    <string name="settings_display_palette_highlighter_description">Magenta, gule og cyan grafikklinjer — som markeringspenner på siden. Ved første øyekast synlig forskjellig fra \"Regnbue\"; det lyse temaet bruker dypere varianter for lesbarhet. Trygg ved rød-grønn fargeblindhet.</string>
     <string name="settings_unit_auto">Auto</string>
     <string name="today_cloud_range">Skydekke %1$d\u2013%2$d%%</string>
     <string name="today_confidence_precip_spread">Modellene er uenige om nedbør (Δ %1$.0f%% på tvers av %2$d modeller)</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -649,6 +649,8 @@ the displayed label localizes.
     <string name="settings_display_palette_accessible_description">Een van Okabe-Ito afgeleid palet dat onderscheidbaar blijft bij deuteranopie, protanopie en tritanopie. Betrouwbaarheidskaarten gebruiken hemelsblauw, neutraal en amber in plaats van teal, neutraal en rood.</string>
     <string name="settings_display_palette_rainbow">Regenboog</string>
     <string name="settings_display_palette_rainbow_description">Roze, oranje en groene grafieklijnen met Material teal/rode betrouwbaarheidskaarten. De standaard.</string>
+    <string name="settings_display_palette_highlighter">Markeerstift</string>
+    <string name="settings_display_palette_highlighter_description">Magenta, gele en cyaan grafieklijnen — als markeerstift op de pagina. Op het eerste gezicht zichtbaar anders dan \"Regenboog\"; het lichte thema gebruikt diepere varianten voor leesbaarheid. Veilig bij rood-groen kleurenblindheid.</string>
     <string name="settings_unit_auto">Auto</string>
     <string name="today_cloud_range">Bewolking %1$d\u2013%2$d%%</string>
     <string name="today_confidence_precip_spread">Modellen het niet eens over neerslag (Δ %1$.0f%% over %2$d modellen)</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -647,6 +647,8 @@ is unchanged; only the displayed label localizes.
     <string name="settings_display_palette_accessible_description">Paleta wywodząca się z Okabe-Ito, zaprojektowana tak, aby pozostała rozróżnialna przy deuteranopii, protanopii i tritanopii. Karty pewności używają błękitu nieba, neutralnego i bursztynowego zamiast turkusowego, neutralnego i czerwonego.</string>
     <string name="settings_display_palette_rainbow">Tęcza</string>
     <string name="settings_display_palette_rainbow_description">Różowe, pomarańczowe i zielone linie wykresów z turkusowo/czerwonymi kartami pewności Material. Domyślna.</string>
+    <string name="settings_display_palette_highlighter">Zakreślacz</string>
+    <string name="settings_display_palette_highlighter_description">Magentowe, żółte i cyjanowe linie wykresu — jak ślad zakreślacza na stronie. Na pierwszy rzut oka widocznie inne niż \"Tęcza\"; jasny motyw używa głębszych wariantów dla czytelności. Bezpieczne przy daltonizmie czerwono-zielonym.</string>
     <string name="settings_unit_auto">Auto</string>
     <string name="today_cloud_range">Zachmurzenie %1$d\u2013%2$d%%</string>
     <string name="today_confidence_precip_spread">Modele nie zgadzają się co do opadów (Δ %1$.0f%% dla %2$d modeli)</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -688,6 +688,8 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_display_palette_accessible_description">Uma paleta derivada de Okabe-Ito, projetada para permanecer distinguível em deuteranopia, protanopia e tritanopia. Os cartões de confiança usam azul-céu, neutro e âmbar em vez de verde-azulado, neutro e vermelho.</string>
     <string name="settings_display_palette_rainbow">Arco-íris</string>
     <string name="settings_display_palette_rainbow_description">Linhas de gráfico rosa, laranja e verde com cartões de confiança Material verde-azulado/vermelho. O padrão.</string>
+    <string name="settings_display_palette_highlighter">Marca-texto</string>
+    <string name="settings_display_palette_highlighter_description">Linhas de gráfico magenta, amarelas e ciano — como marcadores fluorescentes na página. Visivelmente diferentes de \"Arco-íris\" à primeira vista; o tema claro usa variantes mais escuras para legibilidade. Seguro para daltonismo vermelho-verde.</string>
     <string name="settings_unit_auto">Auto</string>
     <string name="today_cloud_range">Nuvens %1$d\u2013%2$d%%</string>
     <string name="today_confidence_precip_spread">Os modelos discordam sobre chuva (Δ %1$.0f%% em %2$d modelos)</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -730,6 +730,8 @@ they diverge from BR ("Polonês" → "Polaco", "Holandês" →
     <string name="settings_display_palette_accessible_description">Uma paleta derivada de Okabe-Ito, concebida para permanecer distinguível em deuteranopia, protanopia e tritanopia. Os cartões de confiança utilizam azul-céu, neutro e âmbar em vez de verde-azulado, neutro e vermelho.</string>
     <string name="settings_display_palette_rainbow">Arco-íris</string>
     <string name="settings_display_palette_rainbow_description">Linhas de gráfico rosa, cor-de-laranja e verde com cartões de confiança Material verde-azulado/vermelho. A predefinição.</string>
+    <string name="settings_display_palette_highlighter">Marcador</string>
+    <string name="settings_display_palette_highlighter_description">Linhas de gráfico magenta, amarelas e ciano — como marcadores fluorescentes na página. Visivelmente diferentes do \"Arco-íris\" à primeira vista; o tema claro usa variantes mais escuras para legibilidade. Seguro para daltonismo vermelho-verde.</string>
     <string name="settings_unit_auto">Auto</string>
     <string name="today_cloud_range">Nuvens %1$d\u2013%2$d%%</string>
     <string name="today_confidence_precip_spread">Os modelos discordam sobre chuva (Δ %1$.0f%% em %2$d modelos)</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -576,6 +576,8 @@ surfaces fall back to default English (matching values-pl / values-uk).
     <string name="settings_display_palette_accessible_description">O paletă derivată din Okabe-Ito, concepută să rămână distinctă în caz de deuteranopie, protanopie și tritanopie. Cardurile de încredere folosesc albastru cer, neutru și chihlimbar în loc de teal, neutru și roșu.</string>
     <string name="settings_display_palette_rainbow">Curcubeu</string>
     <string name="settings_display_palette_rainbow_description">Linii de grafic roz, portocaliu și verde cu carduri de încredere Material teal/roșu. Implicit.</string>
+    <string name="settings_display_palette_highlighter">Marker</string>
+    <string name="settings_display_palette_highlighter_description">Linii de grafic magenta, galben și cyan — ca urma unui marker pe pagină. Vizibil diferite față de \"Curcubeu\" de la prima privire; tema deschisă folosește variante mai închise pentru lizibilitate. Sigure în cazul daltonismului roșu-verde.</string>
     <string name="settings_unit_auto">Auto</string>
     <string name="today_cloud_range">Nori %1$d–%2$d%%</string>
     <string name="today_confidence_precip_spread">Modelele nu sunt de acord cu privire la ploaie (Δ %1$.0f%% pe %2$d modele)</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -658,6 +658,8 @@ only the displayed label localizes.
     <string name="settings_display_palette_accessible_description">Палитра на основе Okabe-Ito, разработанная для различимости при дейтеранопии, протанопии и тританопии. Карточки достоверности используют голубой, нейтральный и янтарный вместо бирюзового, нейтрального и красного.</string>
     <string name="settings_display_palette_rainbow">Радуга</string>
     <string name="settings_display_palette_rainbow_description">Розовые, оранжевые и зелёные линии графиков с карточками достоверности Material бирюзово/красного цвета. По умолчанию.</string>
+    <string name="settings_display_palette_highlighter">Маркер</string>
+    <string name="settings_display_palette_highlighter_description">Линии графика пурпурного, жёлтого и голубого цвета — как след маркера на странице. Заметно отличаются от \"Радуги\" с первого взгляда; светлая тема использует более глубокие оттенки для читаемости. Безопасно при красно-зелёной цветовой слепоте.</string>
     <string name="settings_unit_auto">Авто</string>
     <string name="today_cloud_range">Облачность %1$d\u2013%2$d%%</string>
     <string name="today_confidence_precip_spread">Модели расходятся во мнении о дожде (Δ %1$.0f%% по %2$d моделям)</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -604,6 +604,8 @@ What is NOT overridden, by design:
     <string name="settings_display_palette_accessible_description">Paleta odvodená od Okabe-Ito, navrhnutá tak, aby zostala rozlíšiteľná pri deuteranopii, protanopii a tritanopii. Karty istoty používajú nebesky modrú, neutrálnu a jantárovú namiesto tyrkysovej, neutrálnej a červenej.</string>
     <string name="settings_display_palette_rainbow">Dúha</string>
     <string name="settings_display_palette_rainbow_description">Ružové, oranžové a zelené čiary grafov s tyrkysovými/červenými kartami istoty Material. Predvolené.</string>
+    <string name="settings_display_palette_highlighter">Zvýrazňovač</string>
+    <string name="settings_display_palette_highlighter_description">Purpurové, žlté a azúrové čiary grafu — ako stopa zvýrazňovača na stránke. Na prvý pohľad viditeľne odlišné od \"Dúhy\"; svetlá téma používa hlbšie varianty pre čitateľnosť. Bezpečné pri červeno-zelenej farboslepote.</string>
     <string name="settings_unit_auto">Auto</string>
     <string name="today_cloud_range">Oblačnosť %1$d–%2$d%%</string>
     <string name="today_confidence_precip_spread">Modely sa nezhodujú na zrážkach (Δ %1$.0f%% pre %2$d modely)</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -585,6 +585,8 @@ informal "ti"-form throughout, mirroring the Croatian / Serbian pass.
     <string name="settings_display_palette_accessible_description">Paleta, izpeljana iz Okabe-Ito, zasnovana tako, da ostane razločna pri devteranopiji, protanopiji in tritanopiji. Kartice zanesljivosti uporabljajo nebeško modro, nevtralno in jantarno namesto modrozelene, nevtralne in rdeče.</string>
     <string name="settings_display_palette_rainbow">Mavrica</string>
     <string name="settings_display_palette_rainbow_description">Rožnate, oranžne in zelene linije grafikonov z modrozeleno/rdečimi karticami zanesljivosti Material. Privzeto.</string>
+    <string name="settings_display_palette_highlighter">Označevalec</string>
+    <string name="settings_display_palette_highlighter_description">Magenta, rumene in cijan črte grafa — kot sled označevalca na strani. Na prvi pogled vidno drugačne od \"Mavrice\"; svetla tema uporablja temnejše različice za boljšo berljivost. Varno za rdeče-zeleno barvno slepoto.</string>
     <string name="settings_unit_auto">Samodejno</string>
     <string name="today_cloud_range">Oblačnost %1$d–%2$d%%</string>
     <string name="today_confidence_precip_spread">Modeli se ne strinjajo glede dežja (Δ %1$.0f%% za %2$d modele)</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -602,6 +602,8 @@ native names for all locales (e.g. "Tyska (Tyskland)", "Franska (Frankrike)").
     <string name="settings_display_palette_accessible_description">En Okabe-Ito-baserad palett utformad för att förbli urskiljbar vid deuteranopi, protanopi och tritanopi. Konfidenskorten använder himmelsblått, neutralt och bärnsten i stället för teal, neutralt och rött.</string>
     <string name="settings_display_palette_rainbow">Regnbåge</string>
     <string name="settings_display_palette_rainbow_description">Rosa, orange och gröna diagramlinjer med Material teal/röda konfidenskort. Standardalternativet.</string>
+    <string name="settings_display_palette_highlighter">Överstrykningspenna</string>
+    <string name="settings_display_palette_highlighter_description">Magenta, gula och cyanfärgade diagramlinjer — som en överstrykningspenna på sidan. Vid en första anblick synligt annorlunda än \"Regnbåge\"; det ljusa temat använder djupare varianter för läsbarhet. Säker vid röd-grön färgblindhet.</string>
     <string name="settings_unit_auto">Auto</string>
     <string name="today_cloud_range">Molnighet %1$d\u2013%2$d%%</string>
     <string name="today_confidence_precip_spread">Modellerna är oeniga om regn (Δ %1$.0f%% för %2$d modeller)</string>

--- a/app/src/main/res/values-sw/strings.xml
+++ b/app/src/main/res/values-sw/strings.xml
@@ -431,6 +431,8 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="settings_display_colors_title">Rangi ya paleti</string>
     <string name="settings_display_palette_rainbow">Upinde wa mvua</string>
     <string name="settings_display_palette_rainbow_description">Mistari ya chati ya rangi waridi, machungwa na kijani na kadi za imani za Material bluu-kijani/nyekundu. Chaguo-msingi.</string>
+    <string name="settings_display_palette_highlighter">Highlighter</string>
+    <string name="settings_display_palette_highlighter_description">Mistari ya chati ya magenta, manjano, na cyan — kama alama ya kalamu ya kuangaza kwenye karatasi. Inatofautiana wazi na \"Upinde wa Mvua\" kwa mtazamo wa kwanza; mandhari nyepesi hutumia rangi za kina zaidi kwa kusomeka kwa urahisi. Salama kwa upofu wa rangi nyekundu-kijani.</string>
     <string name="settings_display_palette_accessible">Inayopatikana</string>
     <string name="settings_display_palette_accessible_description">Paleti inayotokana na Okabe-Ito, iliyoundwa kubaki inayoweza kutofautishwa katika hali za upofu wa rangi. Kadi za imani hutumia bluu ya anga, ya wastani na ya amber badala ya bluu-kijani, ya wastani na nyekundu.</string>
     <string name="today_cloud_range">Mawingu %1$d–%2$d%%</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -573,6 +573,8 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="settings_display_palette_accessible_description">ชุดสีที่อิงจาก Okabe-Ito ออกแบบให้แยกแยะได้ในภาวะตาบอดสีเขียว-แดงและสีน้ำเงิน การ์ดความเชื่อมั่นใช้สีฟ้าฟ้า, กลาง และอำพัน แทนสีเขียวน้ำทะเล, กลาง และแดง</string>
     <string name="settings_display_palette_rainbow">สีรุ้ง</string>
     <string name="settings_display_palette_rainbow_description">เส้นกราฟสีชมพู ส้ม และเขียว พร้อมการ์ดความเชื่อมั่น Material สีเขียวน้ำทะเล/แดง ค่าเริ่มต้น</string>
+    <string name="settings_display_palette_highlighter">ปากกาเน้น</string>
+    <string name="settings_display_palette_highlighter_description">เส้นกราฟสีบานเย็น เหลือง และฟ้าคราม — เหมือนรอยปากกาเน้นข้อความบนหน้ากระดาษ มองปุ๊บก็เห็นต่างจาก \"สีรุ้ง\" ทันที ธีมสว่างใช้โทนเข้มขึ้นเพื่อให้อ่านง่าย ปลอดภัยกับตาบอดสีแดง-เขียว</string>
     <string name="settings_unit_auto">อัตโนมัติ</string>
     <string name="today_cloud_range">เมฆ %1$d–%2$d%%</string>
     <string name="today_confidence_precip_spread">แบบจำลองไม่ตรงกันเรื่องฝน (Δ %1$.0f%% ใน %2$d แบบจำลอง)</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -582,6 +582,8 @@ displayed label localizes.
     <string name="settings_display_palette_accessible_description">Deuteranopi, protanopi ve tritanopide ayırt edilebilir kalacak şekilde tasarlanmış, Okabe-Ito\'dan türetilmiş bir palet. Güven kartları teal, nötr ve kırmızı yerine gök mavisi, nötr ve kehribar rengi kullanır.</string>
     <string name="settings_display_palette_rainbow">Gökkuşağı</string>
     <string name="settings_display_palette_rainbow_description">Pembe, turuncu ve yeşil grafik çizgileri ile Material teal/kırmızı güven kartları. Varsayılan.</string>
+    <string name="settings_display_palette_highlighter">Fosforlu kalem</string>
+    <string name="settings_display_palette_highlighter_description">Macenta, sarı ve camgöbeği renkli grafik çizgileri — sayfa üzerindeki fosforlu kalem izi gibi. \"Gökkuşağı\"ndan ilk bakışta belirgin biçimde farklı; açık tema okunabilirlik için daha koyu varyantlar kullanır. Kırmızı-yeşil renk körlüğünde güvenli.</string>
     <string name="settings_unit_auto">Otomatik</string>
     <string name="today_cloud_range">Bulutluluk %1$d\u2013%2$d%%</string>
     <string name="today_confidence_precip_spread">Modeller yağmur konusunda hemfikir değil (Δ %1$.0f%%, %2$d model arasında)</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -601,6 +601,8 @@ only the displayed label localizes.
     <string name="settings_display_palette_accessible_description">Палітра на основі Okabe-Ito, розроблена для розрізнення при дейтеранопії, протанопії та тританопії. Картки достовірності використовують блакитний, нейтральний і бурштиновий замість бірюзового, нейтрального і червоного.</string>
     <string name="settings_display_palette_rainbow">Веселка</string>
     <string name="settings_display_palette_rainbow_description">Рожеві, помаранчеві та зелені лінії графіків з картками достовірності Material бірюзово/червоного. За замовчуванням.</string>
+    <string name="settings_display_palette_highlighter">Маркер</string>
+    <string name="settings_display_palette_highlighter_description">Лінії графіка пурпурового, жовтого та блакитного кольорів — наче слід маркера на сторінці. Помітно відрізняються від \"Райдуги\" з першого погляду; світла тема використовує глибші варіанти для читабельності. Безпечно для червоно-зеленої цветової сліпоти.</string>
     <string name="settings_unit_auto">Авто</string>
     <string name="today_cloud_range">Хмарність %1$d–%2$d%%</string>
     <string name="today_confidence_precip_spread">Моделі розходяться щодо дощу (Δ %1$.0f%% по %2$d моделях)</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -634,6 +634,8 @@ Skipped intentionally: app_name (brand), insight_time_am/pm/midnight/noon
     <string name="settings_display_palette_accessible_description">Bảng màu dựa trên Okabe-Ito, được thiết kế để vẫn phân biệt được khi bị mù màu đỏ-xanh lá và xanh lam. Thẻ độ tin cậy dùng xanh trời, trung tính và hổ phách thay vì xanh mòng két, trung tính và đỏ.</string>
     <string name="settings_display_palette_rainbow">Cầu vồng</string>
     <string name="settings_display_palette_rainbow_description">Đường biểu đồ màu hồng, cam và xanh lá với thẻ độ tin cậy Material xanh mòng két/đỏ. Mặc định.</string>
+    <string name="settings_display_palette_highlighter">Bút dạ quang</string>
+    <string name="settings_display_palette_highlighter_description">Các đường biểu đồ màu hồng cánh sen, vàng và xanh lơ — như nét bút dạ quang trên trang giấy. Khác biệt rõ rệt so với \"Cầu vồng\" ngay từ cái nhìn đầu tiên; chủ đề sáng dùng các biến thể đậm hơn để dễ đọc. An toàn cho người mù màu đỏ-xanh lục.</string>
     <string name="settings_unit_auto">Tự động</string>
     <string name="today_cloud_range">Mây %1$d–%2$d%%</string>
     <string name="today_confidence_precip_spread">Các mô hình không đồng thuận về mưa (Δ %1$.0f%% trên %2$d mô hình)</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -699,6 +699,8 @@ label localizes.
     <string name="settings_display_palette_accessible_description">基于 Okabe-Ito 的调色板，设计上在绿色弱视、红色弱视和蓝色弱视情况下仍可辨识。置信度卡片使用天蓝色、中性色和琥珀色，而非青色、中性色和红色。</string>
     <string name="settings_display_palette_rainbow">彩虹</string>
     <string name="settings_display_palette_rainbow_description">粉红、橙色和绿色图表线条，以及 Material 青色/红色置信度卡片。默认设置。</string>
+    <string name="settings_display_palette_highlighter">荧光笔</string>
+    <string name="settings_display_palette_highlighter_description">洋红、黄色和青色的图表线条——像是用荧光笔在纸上画过。一眼就能与\"彩虹\"区分；浅色主题使用更深的变体以提高可读性。对红绿色盲安全。</string>
     <string name="settings_unit_auto">自动</string>
     <string name="today_cloud_range">云量 %1$d〜%2$d%%</string>
     <string name="today_confidence_precip_spread">各模型对降水意见不一（Δ %1$.0f%%，共 %2$d 个模型）</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -715,6 +715,8 @@ label localises.
     <string name="settings_display_palette_accessible_description">基於 Okabe-Ito 的調色板，設計上在綠色弱視、紅色弱視和藍色弱視情況下仍可辨識。信心卡片使用天藍色、中性色和琥珀色，而非青色、中性色和紅色。</string>
     <string name="settings_display_palette_rainbow">彩虹</string>
     <string name="settings_display_palette_rainbow_description">粉紅、橙色和綠色圖表線條，以及 Material 青色/紅色信心卡片。預設值。</string>
+    <string name="settings_display_palette_highlighter">螢光筆</string>
+    <string name="settings_display_palette_highlighter_description">洋紅、黃色和青色的圖表線條——彷彿用螢光筆在紙上劃過。一眼即可與「彩虹」區分；淺色佈景使用更深的變體以提升可讀性。對紅綠色盲安全。</string>
     <string name="settings_unit_auto">自動</string>
     <string name="today_cloud_range">雲量 %1$d〜%2$d%%</string>
     <string name="today_confidence_precip_spread">各模型對降水意見不一（Δ %1$.0f%%，共 %2$d 個模型）</string>


### PR DESCRIPTION
## Summary

Follow-up to merged #455. Closes the i18n gap codex flagged: the Highlighter label and description shipped in English only in #455, so non-English device locales saw a mixed-language Display settings page (Rainbow and Accessible translated, Highlighter falling back to English).

This PR adds `settings_display_palette_highlighter` and `..._description` across all 43 fully-translated locales — every `values-*` dir that already carries the Accessible translation.

## Locale coverage

- **43 locales translated** — every locale that has the existing Accessible palette translation
- **8 regional variants intentionally skipped** (`en-rGB/AU/CA/ZA`, `de-rAT/CH`, `es-rMX`, `fr-rCA`) — these dirs only override regional-specific strings and inherit everything else from their parent locale; they didn't have Accessible either

## Translation strategy

- **Label**: each locale uses its native word for "highlighter pen" rather than transliterating the English. Filipino (`Highlighter`) and Swahili (`Highlighter`) keep the English loanword because that's the form in common use in those languages. Examples: German `Textmarker`, French `Surligneur`, Japanese `ハイライト`, Chinese (Simplified) `荧光笔`, Chinese (Traditional) `螢光筆`, Russian `Маркер`, Arabic `قلم تظليل`
- **Description**: preserves the English copy's three-beat structure — pen metaphor, "visibly different from Rainbow at a glance", red-green CVD note — adapted for each language's idiom and orthography

## Test plan

- [ ] CI: JVM unit tests + Android debug build green
- [ ] Switch device language to one of the translated locales (e.g. de, fr, ja, zh) and verify Display settings → Palette shows all three options in the target language
- [ ] Native speaker review (where available) for tone and idiom — best-effort renders; refinements welcome

## Privacy

No data-flow changes. Strings are static UI labels.

https://claude.ai/code/session_01TAh4NA2fyxgGegfQww2hhk

---
_Generated by [Claude Code](https://claude.ai/code/session_01TAh4NA2fyxgGegfQww2hhk)_