### PR TITLE
Spread morning fetches and align delivery across a multi-device home

### DIFF
--- a/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
@@ -45,6 +45,7 @@ import java.time.LocalDate
 import java.util.concurrent.TimeUnit
 import kotlin.math.cos
 import kotlin.math.sqrt
+import kotlin.random.Random
 
 /**
  * Performs one daily fetch + insight + notify cycle. Runs in a WorkManager
@@ -243,6 +244,29 @@ class FetchAndNotifyWorker(
         prefs: UserPreferences,
         period: ForecastPeriod,
     ): Result {
+        // Spread alarm-triggered fetches across a small window so multiple
+        // devices on the same home IP (alarms armed for the same wall-clock
+        // time) don't all hit Open-Meteo at the same instant. Without this,
+        // the API answers one device and rate-limits the rest with HTTP 429
+        // "Too many concurrent requests" — and re-rolled on every retry,
+        // since WorkManager's exponential backoff would otherwise re-sync
+        // the collision on each attempt. Force-refresh taps and location-cache
+        // runs (KEY_ALARM_FIRED_AT_MS == 0) skip the wait — the user expects
+        // immediate work in those paths.
+        //
+        // Pair with [awaitDeliveryAlignment] in deliver*: jitter spreads the
+        // API calls; alignment then resyncs every device's notification post
+        // and TTS start to alarm + [DELIVERY_ALIGN_AFTER_ALARM_MS]. The
+        // user-visible morning briefing time stays deterministic regardless
+        // of how the jitter rolled.
+        val alarmFiredAtMs = inputData.getLong(KEY_ALARM_FIRED_AT_MS, 0L)
+        if (alarmFiredAtMs != 0L) {
+            val jitterMs = Random.Default.nextLong(0L, ALARM_FETCH_JITTER_MS)
+            if (jitterMs > 0L) {
+                DiagLog.i(TAG, "Jittering alarm-triggered fetch by ${jitterMs}ms.")
+                delay(jitterMs)
+            }
+        }
         return try {
             val result = app.generateDailyInsight(location, prefs, period)
             // Stamp the resolved location onto the insight so the home screen
@@ -277,14 +301,26 @@ class FetchAndNotifyWorker(
             DiagLog.i(TAG, "Insight delivered for ${insight.forDate}: $prose")
             Result.success()
         } catch (e: ResponseException) {
-            // OpenMeteo 4xx → fail; 5xx → retry with backoff.
+            // OpenMeteo 4xx → fail; 5xx → retry with backoff. 429 is the one
+            // 4xx we *also* retry — "Too many concurrent requests" is transient
+            // by definition and surfaces when several devices on the same home
+            // IP wake at 7am together. The per-run jitter above already spreads
+            // them, but if a burst still collides we want the backoff to clear
+            // it rather than burning today's slot on a permanent failure.
             val status = e.response.status
-            if (status.value in 500..599) {
-                DiagLog.w(TAG, "Server error $status from OpenMeteo; retrying.")
-                Result.retry()
-            } else {
-                DiagLog.e(TAG, "Unexpected HTTP status $status from OpenMeteo", e)
-                Result.failure(reason(REASON_UNEXPECTED_HTTP, "$status"))
+            when {
+                status.value == 429 -> {
+                    DiagLog.w(TAG, "Rate-limited by OpenMeteo ($status); retrying.")
+                    Result.retry()
+                }
+                status.value in 500..599 -> {
+                    DiagLog.w(TAG, "Server error $status from OpenMeteo; retrying.")
+                    Result.retry()
+                }
+                else -> {
+                    DiagLog.e(TAG, "Unexpected HTTP status $status from OpenMeteo", e)
+                    Result.failure(reason(REASON_UNEXPECTED_HTTP, "$status"))
+                }
             }
         } catch (e: ConnectTimeoutException) {
             DiagLog.w(TAG, "Connect timeout; retrying.", e); Result.retry()
@@ -440,36 +476,43 @@ class FetchAndNotifyWorker(
     }
 
     private suspend fun deliverToday(insight: Insight, prefs: UserPreferences, prose: String) {
+        awaitDeliveryAlignment()
         val mode = prefs.deliveryMode
-        val includesTts = mode == DeliveryMode.TTS_ONLY || mode == DeliveryMode.NOTIFICATION_AND_TTS
-        if (includesTts) awaitSpeakTime()
         if (mode == DeliveryMode.NOTIFICATION_ONLY || mode == DeliveryMode.NOTIFICATION_AND_TTS) {
             app.insightNotifier.notify(insight, prose)
             recordDeliveryDelay(ForecastPeriod.TODAY)
         }
-        if (includesTts) {
+        if (mode == DeliveryMode.TTS_ONLY || mode == DeliveryMode.NOTIFICATION_AND_TTS) {
             speakWithFallback(ttsUtterance(insight, prefs), prefs)
         }
     }
 
     /**
-     * Delays TTS until [TTS_DEFER_AFTER_ALARM_MS] past the alarm-fire timestamp so
-     * the spoken briefing doesn't overlap the ringing alarm. Alarm audio uses
-     * STREAM_ALARM which bypasses AudioFocus entirely, so focus-based ducking has no
-     * effect on alarm volume; a time-based gap is the only reliable approach.
+     * Holds the worker until [DELIVERY_ALIGN_AFTER_ALARM_MS] past the alarm-fire
+     * timestamp before posting the notification or speaking TTS. Two reasons:
+     *
+     *  - Originally: the spoken briefing must not overlap the ringing alarm.
+     *    Alarm audio uses STREAM_ALARM which bypasses AudioFocus entirely, so
+     *    focus-based ducking has no effect on alarm volume; a time-based gap is
+     *    the only reliable approach.
+     *  - Added later: deterministic delivery time across a multi-device home.
+     *    The per-run jitter in [fresh] spreads the API calls across a
+     *    [ALARM_FETCH_JITTER_MS] window so devices on the same IP don't
+     *    rate-limit each other; we then realign here so every device's
+     *    notification posts (and TTS starts) at the same wall-clock moment.
      *
      * The target time is derived from [KEY_ALARM_FIRED_AT_MS] set by [AlarmReceiver].
      * If the key is absent (force-refresh tap, location-cache run) or the target has
-     * already passed (slow fetch, retry backoff), the wait is skipped so TTS starts
-     * immediately.
+     * already passed (slow fetch, retry backoff), the wait is skipped and delivery
+     * starts immediately.
      */
-    private suspend fun awaitSpeakTime() {
+    private suspend fun awaitDeliveryAlignment() {
         val alarmFiredAtMs = inputData.getLong(KEY_ALARM_FIRED_AT_MS, 0L)
         if (alarmFiredAtMs == 0L) return
-        val speakAfterMs = alarmFiredAtMs + TTS_DEFER_AFTER_ALARM_MS
-        val waitMs = speakAfterMs - System.currentTimeMillis()
+        val alignAtMs = alarmFiredAtMs + DELIVERY_ALIGN_AFTER_ALARM_MS
+        val waitMs = alignAtMs - System.currentTimeMillis()
         if (waitMs > 0) {
-            DiagLog.i(TAG, "Deferring TTS for ${waitMs}ms (alarm + ${TTS_DEFER_AFTER_ALARM_MS}ms window).")
+            DiagLog.i(TAG, "Aligning delivery to alarm + ${DELIVERY_ALIGN_AFTER_ALARM_MS}ms (waiting ${waitMs}ms).")
             delay(waitMs)
         }
     }
@@ -550,6 +593,7 @@ class FetchAndNotifyWorker(
         )
 
     private suspend fun deliverTonight(insight: Insight, prefs: UserPreferences, prose: String) {
+        awaitDeliveryAlignment()
         val mode = prefs.tonightDeliveryMode
         val canNotify = mode == DeliveryMode.NOTIFICATION_ONLY || mode == DeliveryMode.NOTIFICATION_AND_TTS
         // The notify-only-on-events toggle skips the notification entirely on
@@ -667,7 +711,7 @@ class FetchAndNotifyWorker(
         /**
          * Wall-clock millis at which the alarm fired. Set by [AlarmReceiver] for
          * scheduled morning runs; absent (0) for force-refresh taps and other
-         * non-alarm-triggered enqueues. Read by [awaitSpeakTime] to compute the
+         * non-alarm-triggered enqueues. Read by [awaitDeliveryAlignment] to compute the
          * earliest moment TTS should start speaking, and by [recordDeliveryDelay]
          * to split the scheduled→delivered gap into "doze deferral" vs "worker
          * wait".
@@ -685,12 +729,33 @@ class FetchAndNotifyWorker(
         private const val KEY_ALARM_SCHEDULED_AT_MS = "alarm_scheduled_at_ms"
 
         /**
-         * How long after the alarm fires before TTS is allowed to speak. One minute
-         * gives the user time to silence the alarm before the briefing begins.
-         * STREAM_ALARM bypasses AudioFocus so this time-based gap is the only
-         * reliable way to avoid talking over a ringing alarm.
+         * Sync point for the notification post and the spoken briefing on
+         * alarm-triggered runs: both fire at `alarmFiredAt + this`. Originally
+         * a TTS-only "wait for the alarm to stop ringing" gap; now also the
+         * realignment after [ALARM_FETCH_JITTER_MS] so every device in a
+         * multi-device home delivers at the same wall-clock moment. One
+         * minute leaves plenty of slack for the longest jitter roll plus a
+         * slow fetch.
          */
-        private const val TTS_DEFER_AFTER_ALARM_MS = 30_000L
+        private const val DELIVERY_ALIGN_AFTER_ALARM_MS = 60_000L
+
+        /**
+         * Upper bound (exclusive) of the randomized wait before an alarm-triggered
+         * fetch. Spreads multiple devices on the same home IP across this window
+         * so Open-Meteo doesn't see them as a synchronized concurrent-request
+         * burst. Held strictly below [DELIVERY_ALIGN_AFTER_ALARM_MS] so the
+         * post-fetch alignment is *reliable* — worst-case jitter (30 s) plus
+         * a slow fetch (a few seconds) still leaves headroom to land before
+         * the 60 s deadline, and every device delivers at exactly alarm + 60 s.
+         * Going wider would let some rolls overshoot the deadline and reintroduce
+         * the staggered-delivery problem alignment exists to fix.
+         *
+         * The math for the 429 case still works at 30 s: 4 devices land
+         * ~6 s apart on average, well over Open-Meteo's per-IP concurrent
+         * budget for the ~1–2 s connections we make, and the 429 retry covers
+         * the unlucky tail where rolls bunch up.
+         */
+        private const val ALARM_FETCH_JITTER_MS = 30_000L
 
         /**
          * Epoch-day of the calendar date the force-refresh was requested for. Used

--- a/core/data/src/test/kotlin/app/clothescast/core/data/weather/OpenMeteoClientTest.kt
+++ b/core/data/src/test/kotlin/app/clothescast/core/data/weather/OpenMeteoClientTest.kt
@@ -10,6 +10,7 @@ import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
 import io.ktor.client.engine.mock.respondError
+import io.ktor.client.plugins.ClientRequestException
 import io.ktor.client.plugins.ServerResponseException
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.request.HttpRequestData
@@ -178,5 +179,35 @@ class OpenMeteoClientTest {
         )
 
         shouldThrow<ServerResponseException> { client.fetchForecast(london) }
+    }
+
+    @Test
+    fun `429 from the primary forecast surfaces as ClientRequestException with the status`() = runTest {
+        // When several devices on the same home IP wake at 07:00 the primary
+        // fetch can come back with "Too many concurrent requests". FetchAndNotifyWorker
+        // distinguishes 429 from other 4xx via response.status so it can retry —
+        // verify the client surfaces the exception type and status the worker
+        // expects rather than swallowing it as a deserialization error.
+        val engine = MockEngine { request ->
+            when (request.url.encodedPath) {
+                "/v1/forecast" -> respond(
+                    content = """{"error":true,"reason":"Too many concurrent requests"}""",
+                    status = HttpStatusCode.TooManyRequests,
+                    headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                )
+                "/v1/warnings" -> respondError(HttpStatusCode.InternalServerError)
+                else -> error("unexpected path ${request.url.encodedPath}")
+            }
+        }
+        val client = OpenMeteoClient(
+            HttpClient(engine) {
+                install(ContentNegotiation) {
+                    json(Json { ignoreUnknownKeys = true })
+                }
+            },
+        )
+
+        val ex = shouldThrow<ClientRequestException> { client.fetchForecast(london) }
+        ex.response.status shouldBe HttpStatusCode.TooManyRequests
     }
 }


### PR DESCRIPTION
## Summary

Bug report 2026-05-15 07:25: alarm at 07:00 → primary fetch came back
502 Bad Gateway → WorkManager retried 10 s later → both primary and
multi-model confidence fetches came back **429 Too Many Requests**
("Too many concurrent requests") → worker treated the 429 as an
unrecoverable 4xx and failed the run. No morning briefing.

User runs ClothesCast on several devices in one house with the morning
alarm set to exactly 07:00; from Open-Meteo's view that's a
synchronized burst of correlated traffic from one shared IP, and each
device also fans out into three parallel calls (primary forecast +
warnings + multi-model confidence).

The flow on alarm-triggered runs is now: **jitter → API → align →
notify + speak.**

- **Jitter** — 0..30 s randomized wait at the top of every alarm-triggered
  fresh fetch. Spreads multi-device homes across a window so Open-Meteo
  doesn't see them as a synchronized concurrent-request burst (4 devices
  land ~6 s apart on average, well over the per-IP concurrent budget for
  the 1–2 s connections we make). Force-refresh taps and the
  location-cache path skip the wait. Rerolled on every run so WorkManager's
  exponential backoff doesn't keep retries synced.
- **Retry HTTP 429** alongside 5xx instead of failing the run. "Too many
  concurrent requests" is transient by definition; if the jittered bursts
  still collide, the backoff clears it.
- **Align** — every alarm-triggered delivery (notification *and* TTS,
  every mode) waits until `alarmFiredAt + 60 s` before posting. The
  jitter spread the API calls; the alignment resyncs the user-visible
  moment. Every device in the house now delivers at the same wall-clock
  minute mark.

The 30 s jitter cap is deliberate: it leaves enough headroom under the
60 s alignment deadline that every roll plus a slow fetch still lands
before alignment, so the deterministic delivery time holds. Going wider
would let some rolls overshoot and reintroduce staggered delivery.

Renames `TTS_DEFER_AFTER_ALARM_MS` → `DELIVERY_ALIGN_AFTER_ALARM_MS` and
`awaitSpeakTime` → `awaitDeliveryAlignment` to reflect the broader role.
The original 30 s "don't talk over the ringing alarm" purpose still
holds at the new 60 s deadline.

### User-visible timing changes

- `NOTIFICATION_AND_TTS` / `TTS_ONLY`: morning notification slides from
  alarm + 30 s to alarm + 60 s. Spoken briefing slides 30 s later.
  Deterministic across all devices in a household.
- `NOTIFICATION_ONLY`: morning notification slides from alarm + ~1 s to
  alarm + 60 s on alarm-triggered runs — a deliberate trade so a
  multi-device home sees one coherent post time instead of staggered
  notifications scattered across the jitter window.
- Force-refresh taps and the location-cache path are unaffected (no
  alarm fingerprint, no wait).

### Out of scope (deliberately)

- Serializing the 3 parallel calls per device in `OpenMeteoClient`. Cuts
  the per-device concurrent footprint 3×, at the cost of ~1–3 s added
  latency. The jitter + 429 retry should be enough; revisit if 429s
  still land after this ships.
- Honoring `Retry-After`. WorkManager's `setBackoffCriteria` is fixed
  at the request level, so per-response delays would mean re-enqueuing
  with `setInitialDelay`. Defer until evidence the 10 s exponential
  backoff is insufficient.

### Privacy

No change to what crosses the device boundary.

### Validation gap

Couldn't run `:core:data:test` / `:app:testDebugUnitTest` locally — the
Gradle Plugin Portal was returning 503 for the Kotlin plugin POM at the
time (external infra issue). Static-checked the diff; relying on CI.

## Test plan

- [ ] CI: `JVM unit tests` green (new `OpenMeteoClientTest` case for
      429 surfacing as `ClientRequestException` with the right status)
- [ ] CI: `Android debug build` green
- [ ] After release: confirm the next 07:00 across the user's
      multi-device house delivers a morning briefing on every device at
      the same moment (alarm + 60 s).
- [ ] Logs on the next alarm fire show `Jittering alarm-triggered fetch
      by …ms` and `Aligning delivery to alarm + 60000ms (waiting …ms)`.

https://claude.ai/code/session_01CSWb9zfqJjUMWdR9X4Yqg2