### PR TITLE
Stabilise the settings view-model tests

### DIFF
--- a/app/src/test/kotlin/app/clothescast/ui/settings/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/app/clothescast/ui/settings/SettingsViewModelTest.kt
@@ -3,6 +3,8 @@ package app.clothescast.ui.settings
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelStore
 import app.clothescast.core.data.location.OpenMeteoGeocodingClient
 import app.clothescast.core.domain.model.ClothesRule
 import app.clothescast.core.domain.model.DeliveryMode
@@ -68,9 +70,27 @@ class SettingsViewModelTest {
     private lateinit var settingsRepository: SettingsRepository
     private lateinit var keyStore: SecureKeyStore
     private lateinit var subject: SettingsViewModel
+    // SettingsState's auto-unit defaults read Locale.getDefault(), so an en-US JVM
+    // (e.g. the Cursor Cloud VM) flips the unit defaults to Fahrenheit / miles and
+    // breaks the "initial state reflects repository defaults" assertion. Pin a
+    // metric locale for the test class so the defaults are deterministic.
+    private lateinit var originalLocale: Locale
+    // viewModelScope owns an infinite preferences.collect loop and the device-voice
+    // load job. Without bounding it to the test, those coroutines can outlive
+    // runTest's body and resume with an exception (after the test's DataStore is
+    // cancelled in tearDown), occasionally surfacing as UncaughtExceptionsBeforeTest
+    // on the next test. ViewModelStore.clear() cancels every registered viewmodel's
+    // scope in one call, matching the existing DataStore-scope cleanup pattern above.
+    private val viewModelStore = ViewModelStore()
+    private var nextViewModelKey = 0
+    private fun <T : ViewModel> track(vm: T): T = vm.also {
+        viewModelStore.put("vm-${nextViewModelKey++}", it)
+    }
 
     @BeforeEach
     fun setUp() {
+        originalLocale = Locale.getDefault()
+        Locale.setDefault(Locale.FRANCE)
         Dispatchers.setMain(dispatcher)
         dataStoreScope = CoroutineScope(dispatcher + SupervisorJob())
         settingsDataStore = PreferenceDataStoreFactory.create(
@@ -94,13 +114,15 @@ class SettingsViewModelTest {
                 )
             },
         ) { install(ContentNegotiation) { json(KotlinxJson { ignoreUnknownKeys = true }) } }
-        subject = SettingsViewModel(
-            settingsRepository,
-            keyStore,
-            rearmAlarm = { _, _ -> },
-            cancelAlarm = { _ -> },
-            geocodingClient = OpenMeteoGeocodingClient(emptyGeocoding),
-            voiceEnumerator = EmptyVoiceEnumerator,
+        subject = track(
+            SettingsViewModel(
+                settingsRepository,
+                keyStore,
+                rearmAlarm = { _, _ -> },
+                cancelAlarm = { _ -> },
+                geocodingClient = OpenMeteoGeocodingClient(emptyGeocoding),
+                voiceEnumerator = EmptyVoiceEnumerator,
+            ),
         )
     }
 
@@ -117,8 +139,10 @@ class SettingsViewModelTest {
 
     @AfterEach
     fun tearDown() {
+        viewModelStore.clear()
         dataStoreScope.cancel()
         Dispatchers.resetMain()
+        Locale.setDefault(originalLocale)
     }
 
     @Test
@@ -218,18 +242,20 @@ class SettingsViewModelTest {
         // morning worker run. Toggle-off must NOT enqueue — there's nothing
         // for the worker to refresh once device-location is off.
         var refreshCount = 0
-        val refreshSubject = SettingsViewModel(
-            settingsRepository = settingsRepository,
-            keyStore = keyStore,
-            rearmAlarm = { _, _ -> },
-            cancelAlarm = { _ -> },
-            geocodingClient = OpenMeteoGeocodingClient(
-                HttpClient(MockEngine { respond("""{"results":[]}""") }) {
-                    install(ContentNegotiation) { json(KotlinxJson { ignoreUnknownKeys = true }) }
-                },
+        val refreshSubject = track(
+            SettingsViewModel(
+                settingsRepository = settingsRepository,
+                keyStore = keyStore,
+                rearmAlarm = { _, _ -> },
+                cancelAlarm = { _ -> },
+                geocodingClient = OpenMeteoGeocodingClient(
+                    HttpClient(MockEngine { respond("""{"results":[]}""") }) {
+                        install(ContentNegotiation) { json(KotlinxJson { ignoreUnknownKeys = true }) }
+                    },
+                ),
+                voiceEnumerator = EmptyVoiceEnumerator,
+                refreshLocationCache = { refreshCount++ },
             ),
-            voiceEnumerator = EmptyVoiceEnumerator,
-            refreshLocationCache = { refreshCount++ },
         )
 
         refreshSubject.setUseDeviceLocation(true)
@@ -249,18 +275,20 @@ class SettingsViewModelTest {
         // Today screen at the next worker run — the bug Codex flagged on PR
         // #419.
         var refreshCount = 0
-        val refreshSubject = SettingsViewModel(
-            settingsRepository = settingsRepository,
-            keyStore = keyStore,
-            rearmAlarm = { _, _ -> },
-            cancelAlarm = { _ -> },
-            geocodingClient = OpenMeteoGeocodingClient(
-                HttpClient(MockEngine { respond("""{"results":[]}""") }) {
-                    install(ContentNegotiation) { json(KotlinxJson { ignoreUnknownKeys = true }) }
-                },
+        val refreshSubject = track(
+            SettingsViewModel(
+                settingsRepository = settingsRepository,
+                keyStore = keyStore,
+                rearmAlarm = { _, _ -> },
+                cancelAlarm = { _ -> },
+                geocodingClient = OpenMeteoGeocodingClient(
+                    HttpClient(MockEngine { respond("""{"results":[]}""") }) {
+                        install(ContentNegotiation) { json(KotlinxJson { ignoreUnknownKeys = true }) }
+                    },
+                ),
+                voiceEnumerator = EmptyVoiceEnumerator,
+                refreshCachedOutfits = { refreshCount++ },
             ),
-            voiceEnumerator = EmptyVoiceEnumerator,
-            refreshCachedOutfits = { refreshCount++ },
         )
 
         refreshSubject.addClothesRule(ClothesRule("hat", ClothesRule.TemperatureBelow(0.0)))
@@ -317,17 +345,19 @@ class SettingsViewModelTest {
                 override suspend fun resolveAutoPick(locale: Locale): DeviceVoice? = null
                 override suspend fun findVoice(id: String): DeviceVoice? = null
             }
-            val countingSubject = SettingsViewModel(
-                settingsRepository = settingsRepository,
-                keyStore = keyStore,
-                rearmAlarm = { _, _ -> },
-                cancelAlarm = { _ -> },
-                geocodingClient = OpenMeteoGeocodingClient(
-                    HttpClient(MockEngine { respond("""{"results":[]}""") }) {
-                        install(ContentNegotiation) { json(KotlinxJson { ignoreUnknownKeys = true }) }
-                    },
+            val countingSubject = track(
+                SettingsViewModel(
+                    settingsRepository = settingsRepository,
+                    keyStore = keyStore,
+                    rearmAlarm = { _, _ -> },
+                    cancelAlarm = { _ -> },
+                    geocodingClient = OpenMeteoGeocodingClient(
+                        HttpClient(MockEngine { respond("""{"results":[]}""") }) {
+                            install(ContentNegotiation) { json(KotlinxJson { ignoreUnknownKeys = true }) }
+                        },
+                    ),
+                    voiceEnumerator = countingEnumerator,
                 ),
-                voiceEnumerator = countingEnumerator,
             )
             // Drain the initial enumeration triggered by the first prefs
             // emission (effective locale is the JVM default while region is


### PR DESCRIPTION
## Summary

`SettingsViewModelTest` had two latent dependencies on global state that an en-US JVM trips on. Both fixes land in `app/src/test/` only — no runtime behaviour change, nothing user-visible in release notes.

### 1. Locale-driven failure (the documented Cursor Cloud flake)

`SettingsState`'s auto-unit defaults call `Locale.getDefault()`:
```kotlin
val temperatureUnit: TemperatureUnit = defaultTemperatureUnitFor(Locale.getDefault()),
val distanceUnit: DistanceUnit = defaultDistanceUnitFor(Locale.getDefault()),
```
On the Cursor Cloud VM (`Locale.US`) those resolve to `FAHRENHEIT` / `MILES`, breaking `initial state reflects repository defaults`. GitHub runners default to a different locale, so CI never saw it. CLAUDE.md flagged this as a known pre-existing flake.

Fix: pin `Locale.FRANCE` for the class in `setUp`, restore in `tearDown`. Matches the locale-pinning pattern the `re-enumerates device voices` test already uses internally (lines 303-345).

### 2. View-model coroutine leak

`SettingsViewModel.viewModelScope` owns an infinite `settingsRepository.preferences.collect { }` loop plus the device-voice load job. Those coroutines outlive `runTest`'s body. Once the test's DataStore is cancelled in `tearDown`, a leaked coroutine can resume with an exception that the next test's `TestScope` occasionally surfaces as `UncaughtExceptionsBeforeTest` — a low-rate flake that's hard to reproduce on demand (saw it once in this session, didn't recur in 5+ isolation runs after the fix).

Fix: route every created view-model through a class-level `ViewModelStore`. `store.clear()` in `tearDown` cancels every registered viewmodel's scope in one shot — same shape as the existing manual `dataStoreScope.cancel()` the class already does and documents (see the long comment at lines 59-64).

## Test plan
- [x] `./gradlew :app:testDebugUnitTest --tests "app.clothescast.ui.settings.SettingsViewModelTest" --rerun-tasks` × 5 — all green
- [x] `./gradlew :core:domain:test :core:data:test :app:testDebugUnitTest` — BUILD SUCCESSFUL
- [ ] CI green

---
_Generated by [Claude Code](https://claude.ai/code/session_012st6bd2iPCkp7TCWtUAkEa)_