### PR TITLE
Customise the colour of each clothing icon

### DIFF
--- a/app/src/main/kotlin/app/clothescast/data/SettingsRepository.kt
+++ b/app/src/main/kotlin/app/clothescast/data/SettingsRepository.kt
@@ -275,6 +275,29 @@ class SettingsRepository(
         dataStore.edit { it[COLOR_PALETTE] = palette.name }
     }
 
+    /**
+     * Sets the per-icon fill colour for [top]. `null` clears any override —
+     * the icon then falls back to the baked-in XML colour. Read-modify-write
+     * happens inside a single [dataStore.edit] so concurrent edits don't
+     * drop entries; serialisation matches [parseOutfitTopColors] below.
+     */
+    suspend fun setOutfitTopColor(top: OutfitSuggestion.Top, argb: Long?) {
+        dataStore.edit { prefs ->
+            val current = parseOutfitTopColors(prefs[OUTFIT_TOP_COLORS])
+            val updated = if (argb == null) current - top else current + (top to argb)
+            prefs[OUTFIT_TOP_COLORS] = json.encodeToString(updated.mapKeys { it.key.name })
+        }
+    }
+
+    /** Sibling of [setOutfitTopColor] for the bottom-garment slot. */
+    suspend fun setOutfitBottomColor(bottom: OutfitSuggestion.Bottom, argb: Long?) {
+        dataStore.edit { prefs ->
+            val current = parseOutfitBottomColors(prefs[OUTFIT_BOTTOM_COLORS])
+            val updated = if (argb == null) current - bottom else current + (bottom to argb)
+            prefs[OUTFIT_BOTTOM_COLORS] = json.encodeToString(updated.mapKeys { it.key.name })
+        }
+    }
+
     suspend fun setTelemetryNoticeAcked(acked: Boolean) {
         dataStore.edit { it[TELEMETRY_NOTICE_ACKED] = acked }
     }
@@ -412,6 +435,8 @@ class SettingsRepository(
         val telemetryNoticeAcked = this[TELEMETRY_NOTICE_ACKED] == true
         val colorPalette = this[COLOR_PALETTE]?.let { runCatching { ColorPalette.valueOf(it) }.getOrNull() }
             ?: ColorPalette.RAINBOW
+        val outfitTopColors = parseOutfitTopColors(this[OUTFIT_TOP_COLORS])
+        val outfitBottomColors = parseOutfitBottomColors(this[OUTFIT_BOTTOM_COLORS])
         val zone = zoneIdProvider()
 
         return UserPreferences(
@@ -441,6 +466,8 @@ class SettingsRepository(
             telemetryEnabled = telemetryEnabled,
             telemetryNoticeAcked = telemetryNoticeAcked,
             colorPalette = colorPalette,
+            outfitTopColors = outfitTopColors,
+            outfitBottomColors = outfitBottomColors,
         )
     }
 
@@ -522,6 +549,27 @@ class SettingsRepository(
         }.getOrNull()
     }
 
+    private fun parseOutfitTopColors(raw: String?): Map<OutfitSuggestion.Top, Long> =
+        parseOutfitColors(raw) { name -> runCatching { OutfitSuggestion.Top.valueOf(name) }.getOrNull() }
+
+    private fun parseOutfitBottomColors(raw: String?): Map<OutfitSuggestion.Bottom, Long> =
+        parseOutfitColors(raw) { name -> runCatching { OutfitSuggestion.Bottom.valueOf(name) }.getOrNull() }
+
+    /**
+     * Decodes a `Map<String, Long>` JSON blob and projects keys through
+     * [resolveKey], dropping entries with unknown enum names. Tolerant of
+     * forward-compat values (a future-added `Top` variant in stored JSON
+     * silently disappears on read rather than crashing the whole flow).
+     */
+    private fun <K : Any> parseOutfitColors(raw: String?, resolveKey: (String) -> K?): Map<K, Long> {
+        if (raw.isNullOrBlank()) return emptyMap()
+        return runCatching {
+            json.decodeFromString<Map<String, Long>>(raw)
+                .mapNotNull { (key, value) -> resolveKey(key)?.let { it to value } }
+                .toMap()
+        }.getOrDefault(emptyMap())
+    }
+
     private fun parseRules(raw: String?): List<ClothesRule> {
         if (raw.isNullOrBlank()) return ClothesRule.DEFAULTS
         return runCatching {
@@ -580,6 +628,8 @@ class SettingsRepository(
         private val TELEMETRY_NOTICE_ACKED = booleanPreferencesKey("telemetry_notice_acked")
         private val BUG_REPORT_CONSENT_ACKED = booleanPreferencesKey("bug_report_consent_acked")
         private val COLOR_PALETTE = stringPreferencesKey("color_palette")
+        private val OUTFIT_TOP_COLORS = stringPreferencesKey("outfit_top_colors_json")
+        private val OUTFIT_BOTTOM_COLORS = stringPreferencesKey("outfit_bottom_colors_json")
 
         private val TIME_FORMAT: DateTimeFormatter = DateTimeFormatter.ofPattern("HH:mm")
         private val DEFAULT_TIME: LocalTime = LocalTime.of(7, 0)

--- a/app/src/main/kotlin/app/clothescast/notification/InsightNotifier.kt
+++ b/app/src/main/kotlin/app/clothescast/notification/InsightNotifier.kt
@@ -4,15 +4,15 @@ import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.graphics.Bitmap
-import androidx.annotation.DrawableRes
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
-import androidx.core.content.res.ResourcesCompat
-import androidx.core.graphics.drawable.toBitmap
 import app.clothescast.MainActivity
 import app.clothescast.R
 import app.clothescast.core.domain.model.Insight
 import app.clothescast.core.domain.model.OutfitSuggestion
+import app.clothescast.ui.garment.outfitTopDefaults
+import app.clothescast.ui.garment.renderOutfitBitmap
+import app.clothescast.ui.garment.topDrawable
 
 /**
  * Posts the daily insight as a system notification. Tapping the notification opens
@@ -22,7 +22,11 @@ import app.clothescast.core.domain.model.OutfitSuggestion
  */
 class InsightNotifier(private val context: Context) {
 
-    fun notify(insight: Insight, prose: String) {
+    fun notify(
+        insight: Insight,
+        prose: String,
+        topColors: Map<OutfitSuggestion.Top, Long> = emptyMap(),
+    ) {
         if (!NotificationPermission.isGranted(context)) return
 
         val tapIntent = Intent(context, MainActivity::class.java).apply {
@@ -39,10 +43,12 @@ class InsightNotifier(private val context: Context) {
         // The small status-bar icon mirrors the recommended top (silhouette).
         // The large icon picks up the same top in full colour so the expanded
         // notification carries the same glanceable "what to wear today" cue the
-        // Today screen's OutfitPreviewCard does.
+        // Today screen's OutfitPreviewCard does — recoloured if the user has
+        // customised the icon's fill.
+        val top = insight.outfit?.top
         val notification = NotificationCompat.Builder(context, CHANNEL_DAILY_INSIGHT)
-            .setSmallIcon(smallIconFor(insight.outfit?.top))
-            .setLargeIcon(largeIconForTop(context, insight.outfit?.top))
+            .setSmallIcon(smallIconFor(top))
+            .setLargeIcon(largeIconForTop(context, top, top?.let { topColors[it] }))
             .setContentTitle(context.getString(R.string.notification_daily_insight_title))
             .setContentText(prose)
             .setStyle(NotificationCompat.BigTextStyle().bigText(prose))
@@ -81,18 +87,27 @@ class InsightNotifier(private val context: Context) {
          * Renders the recommended top as a Bitmap for [NotificationCompat.Builder.setLargeIcon].
          * Reuses the full-colour `ic_outfit_tshirt` / `ic_outfit_sweater` /
          * `ic_outfit_thick_jacket` drawables from `OutfitPreviewCard` so the
-         * notification visual matches the home-screen card. Returns null when the
-         * outfit is missing (older cached payloads), letting the system fall back
-         * to no large icon.
+         * notification visual matches the home-screen card — including any
+         * user-picked colour override passed in via [customFillArgb]. Returns
+         * null when [top] is missing (older cached payloads), letting the
+         * system fall back to no large icon.
          */
-        internal fun largeIconForTop(context: Context, top: OutfitSuggestion.Top?): Bitmap? {
-            val drawableRes = largeTopDrawable(top) ?: return null
-            val drawable = ResourcesCompat.getDrawable(context.resources, drawableRes, context.theme)
-                ?: return null
+        internal fun largeIconForTop(
+            context: Context,
+            top: OutfitSuggestion.Top?,
+            customFillArgb: Long? = null,
+        ): Bitmap? {
+            if (top == null) return null
             val sizePx = context.resources.getDimensionPixelSize(android.R.dimen.notification_large_icon_width)
                 .takeIf { it > 0 }
                 ?: LARGE_ICON_FALLBACK_PX
-            return drawable.toBitmap(width = sizePx, height = sizePx)
+            return renderOutfitBitmap(
+                context = context,
+                drawableRes = topDrawable(top),
+                defaults = outfitTopDefaults.getValue(top),
+                customFillArgb = customFillArgb,
+                sizePx = sizePx,
+            )
         }
 
         // Fallback large-icon size in raw pixels for the rare case where
@@ -100,17 +115,5 @@ class InsightNotifier(private val context: Context) {
         // Robolectric configs and a handful of stripped-down OEM ROMs do this).
         // 192px ≈ 64dp on xxhdpi, which is the recommended large-icon target.
         private const val LARGE_ICON_FALLBACK_PX = 192
-
-        @DrawableRes
-        private fun largeTopDrawable(top: OutfitSuggestion.Top?): Int? = when (top) {
-            OutfitSuggestion.Top.TSHIRT -> R.drawable.ic_outfit_tshirt
-            OutfitSuggestion.Top.POLO -> R.drawable.ic_outfit_polo
-            OutfitSuggestion.Top.SWEATER -> R.drawable.ic_outfit_sweater
-            OutfitSuggestion.Top.THIN_JACKET -> R.drawable.ic_outfit_thin_jacket
-            OutfitSuggestion.Top.THICK_JACKET -> R.drawable.ic_outfit_thick_jacket
-            OutfitSuggestion.Top.THICK_COAT -> R.drawable.ic_outfit_thick_coat
-            OutfitSuggestion.Top.PUFFER_JACKET -> R.drawable.ic_outfit_puffer_jacket
-            null -> null
-        }
     }
 }

--- a/app/src/main/kotlin/app/clothescast/notification/TonightInsightNotifier.kt
+++ b/app/src/main/kotlin/app/clothescast/notification/TonightInsightNotifier.kt
@@ -8,6 +8,7 @@ import androidx.core.app.NotificationManagerCompat
 import app.clothescast.MainActivity
 import app.clothescast.R
 import app.clothescast.core.domain.model.Insight
+import app.clothescast.core.domain.model.OutfitSuggestion
 
 /**
  * Posts the tonight insight as a system notification. Picks one of two channels
@@ -25,7 +26,11 @@ import app.clothescast.core.domain.model.Insight
  */
 class TonightInsightNotifier(private val context: Context) {
 
-    fun notify(insight: Insight, prose: String) {
+    fun notify(
+        insight: Insight,
+        prose: String,
+        topColors: Map<OutfitSuggestion.Top, Long> = emptyMap(),
+    ) {
         if (!NotificationPermission.isGranted(context)) return
 
         val tapIntent = Intent(context, MainActivity::class.java).apply {
@@ -42,9 +47,10 @@ class TonightInsightNotifier(private val context: Context) {
         val channel = if (insight.hasEvents) CHANNEL_TONIGHT_INSIGHT_DEFAULT else CHANNEL_TONIGHT_INSIGHT_SILENT
         val priority = if (insight.hasEvents) NotificationCompat.PRIORITY_DEFAULT else NotificationCompat.PRIORITY_LOW
 
+        val top = insight.outfit?.top
         val notification = NotificationCompat.Builder(context, channel)
-            .setSmallIcon(InsightNotifier.smallIconFor(insight.outfit?.top))
-            .setLargeIcon(InsightNotifier.largeIconForTop(context, insight.outfit?.top))
+            .setSmallIcon(InsightNotifier.smallIconFor(top))
+            .setLargeIcon(InsightNotifier.largeIconForTop(context, top, top?.let { topColors[it] }))
             .setContentTitle(context.getString(R.string.notification_tonight_insight_title))
             .setContentText(prose)
             .setStyle(NotificationCompat.BigTextStyle().bigText(prose))

--- a/app/src/main/kotlin/app/clothescast/ui/garment/GarmentColors.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/garment/GarmentColors.kt
@@ -1,0 +1,154 @@
+package app.clothescast.ui.garment
+
+import androidx.annotation.DrawableRes
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import app.clothescast.R
+import app.clothescast.core.domain.model.OutfitSuggestion
+import kotlin.math.abs
+import kotlin.math.max
+import kotlin.math.min
+import kotlin.math.roundToInt
+
+/**
+ * The baked-in primary fill and stroke for each outfit drawable. The recolor
+ * pipeline matches by *original* colour: every path whose fill equals
+ * [GarmentDefaults.fillArgb] gets remapped to the user's chosen colour, and
+ * every path whose fill or stroke equals [GarmentDefaults.strokeArgb] gets
+ * remapped to a darker shade derived from the chosen colour. Accent colours
+ * (white puffer panels, beige sweater neckline trim, etc.) aren't listed
+ * here — they survive the recolour unchanged, which is what we want.
+ *
+ * The hex values must match the XML drawables. If a drawable is regenerated
+ * with new primary colours, this table needs the same update or the recolour
+ * silently no-ops on the customized icon.
+ */
+internal data class GarmentDefaults(val fillArgb: Int, val strokeArgb: Int)
+
+internal val outfitTopDefaults: Map<OutfitSuggestion.Top, GarmentDefaults> = mapOf(
+    OutfitSuggestion.Top.TSHIRT to GarmentDefaults(0xFF4FC3F7.toInt(), 0xFF0288D1.toInt()),
+    OutfitSuggestion.Top.POLO to GarmentDefaults(0xFF26C6DA.toInt(), 0xFF00838F.toInt()),
+    OutfitSuggestion.Top.SWEATER to GarmentDefaults(0xFF8D6E63.toInt(), 0xFF5D4037.toInt()),
+    OutfitSuggestion.Top.THIN_JACKET to GarmentDefaults(0xFF3949AB.toInt(), 0xFF1A237E.toInt()),
+    OutfitSuggestion.Top.THICK_JACKET to GarmentDefaults(0xFF7E57C2.toInt(), 0xFF4527A0.toInt()),
+    OutfitSuggestion.Top.THICK_COAT to GarmentDefaults(0xFFFFB74D.toInt(), 0xFFEF6C00.toInt()),
+    OutfitSuggestion.Top.PUFFER_JACKET to GarmentDefaults(0xFFF5F7FA.toInt(), 0xFF90A4AE.toInt()),
+)
+
+internal val outfitBottomDefaults: Map<OutfitSuggestion.Bottom, GarmentDefaults> = mapOf(
+    OutfitSuggestion.Bottom.SHORTS to GarmentDefaults(0xFFC8B27A.toInt(), 0xFF8D743F.toInt()),
+    OutfitSuggestion.Bottom.LONG_SKIRT to GarmentDefaults(0xFFF06292.toInt(), 0xFFC2185B.toInt()),
+    OutfitSuggestion.Bottom.JEANS to GarmentDefaults(0xFF5C6BC0.toInt(), 0xFF303F9F.toInt()),
+    OutfitSuggestion.Bottom.LONG_PANTS to GarmentDefaults(0xFF455A64.toInt(), 0xFF263238.toInt()),
+)
+
+@DrawableRes
+internal fun topDrawable(top: OutfitSuggestion.Top): Int = when (top) {
+    OutfitSuggestion.Top.TSHIRT -> R.drawable.ic_outfit_tshirt
+    OutfitSuggestion.Top.POLO -> R.drawable.ic_outfit_polo
+    OutfitSuggestion.Top.SWEATER -> R.drawable.ic_outfit_sweater
+    OutfitSuggestion.Top.THIN_JACKET -> R.drawable.ic_outfit_thin_jacket
+    OutfitSuggestion.Top.THICK_JACKET -> R.drawable.ic_outfit_thick_jacket
+    OutfitSuggestion.Top.THICK_COAT -> R.drawable.ic_outfit_thick_coat
+    OutfitSuggestion.Top.PUFFER_JACKET -> R.drawable.ic_outfit_puffer_jacket
+}
+
+@DrawableRes
+internal fun bottomDrawable(bottom: OutfitSuggestion.Bottom): Int = when (bottom) {
+    OutfitSuggestion.Bottom.SHORTS -> R.drawable.ic_outfit_shorts
+    OutfitSuggestion.Bottom.LONG_SKIRT -> R.drawable.ic_outfit_skirt
+    OutfitSuggestion.Bottom.JEANS -> R.drawable.ic_outfit_jeans
+    OutfitSuggestion.Bottom.LONG_PANTS -> R.drawable.ic_outfit_long_pants
+}
+
+/**
+ * Derives a darker stroke colour from a user-chosen fill. The XML drawables'
+ * baked stroke colours are roughly 35-40% lower L than their matching fills,
+ * so a 0.6× scale on L (in HSL) approximates the existing two-tone look.
+ * Clamped to a minimum L so a near-black fill doesn't produce a stroke
+ * indistinguishable from it.
+ *
+ * Pure Kotlin maths (no `androidx.core.graphics.ColorUtils` /
+ * `android.graphics.Color`) so the function works under the project's
+ * `unitTests.isReturnDefaultValues = true` config without Robolectric.
+ */
+internal fun deriveStrokeArgb(argb: Long): Long {
+    val alpha = ((argb ushr 24) and 0xFFL).toInt()
+    val r = ((argb ushr 16) and 0xFFL).toInt()
+    val g = ((argb ushr 8) and 0xFFL).toInt()
+    val b = (argb and 0xFFL).toInt()
+    val (h, s, l) = rgbToHsl(r, g, b)
+    val newL = (l * STROKE_LIGHTNESS_SCALE).coerceAtLeast(STROKE_MIN_LIGHTNESS)
+    val (nr, ng, nb) = hslToRgb(h, s, newL)
+    val packed = (alpha shl 24) or (nr shl 16) or (ng shl 8) or nb
+    return packed.toLong() and 0xFFFFFFFFL
+}
+
+internal fun deriveStroke(fill: Color): Color =
+    Color(deriveStrokeArgb(fill.toArgb().toLong() and 0xFFFFFFFFL).toInt())
+
+private const val STROKE_LIGHTNESS_SCALE = 0.6f
+private const val STROKE_MIN_LIGHTNESS = 0.08f
+
+/** Standard sRGB → HSL conversion. Returns hue in degrees [0, 360). */
+private fun rgbToHsl(r: Int, g: Int, b: Int): Triple<Float, Float, Float> {
+    val rf = r / 255f
+    val gf = g / 255f
+    val bf = b / 255f
+    val mx = max(rf, max(gf, bf))
+    val mn = min(rf, min(gf, bf))
+    val l = (mx + mn) / 2f
+    if (mx == mn) return Triple(0f, 0f, l)
+    val d = mx - mn
+    val s = if (l > 0.5f) d / (2f - mx - mn) else d / (mx + mn)
+    val h = when (mx) {
+        rf -> ((gf - bf) / d + (if (gf < bf) 6f else 0f)) * 60f
+        gf -> ((bf - rf) / d + 2f) * 60f
+        else -> ((rf - gf) / d + 4f) * 60f
+    }
+    return Triple(h, s, l)
+}
+
+/** Standard HSL → sRGB conversion. Returns each channel as 8-bit int [0, 255]. */
+private fun hslToRgb(h: Float, s: Float, l: Float): Triple<Int, Int, Int> {
+    val c = (1f - abs(2f * l - 1f)) * s
+    val m = l - c / 2f
+    val x = c * (1f - abs((h / 60f) % 2f - 1f))
+    val (rp, gp, bp) = when (((h / 60f).toInt()) % 6) {
+        0 -> Triple(c, x, 0f)
+        1 -> Triple(x, c, 0f)
+        2 -> Triple(0f, c, x)
+        3 -> Triple(0f, x, c)
+        4 -> Triple(x, 0f, c)
+        else -> Triple(c, 0f, x)
+    }
+    return Triple(
+        ((rp + m) * 255f).roundToInt().coerceIn(0, 255),
+        ((gp + m) * 255f).roundToInt().coerceIn(0, 255),
+        ((bp + m) * 255f).roundToInt().coerceIn(0, 255),
+    )
+}
+
+/**
+ * Curated swatches for the garment-colour picker. Hand-picked to span the
+ * hue circle while staying visually pleasant when paired with their derived
+ * stroke. Avoids near-black entries — those collapse against the
+ * derived-stroke clamp in [deriveStrokeArgb] and look identical to mid-grey
+ * after the recolour.
+ */
+internal val garmentColorPresets: List<Color> = listOf(
+    Color(0xFFE53935), // red
+    Color(0xFFFF7043), // orange
+    Color(0xFFFFB300), // amber
+    Color(0xFFFDD835), // yellow
+    Color(0xFF7CB342), // light green
+    Color(0xFF43A047), // green
+    Color(0xFF26A69A), // teal
+    Color(0xFF29B6F6), // light blue
+    Color(0xFF1E88E5), // blue
+    Color(0xFF5E35B1), // purple
+    Color(0xFFAB47BC), // magenta
+    Color(0xFFEC407A), // pink
+    Color(0xFF8D6E63), // brown
+    Color(0xFF78909C), // blue-grey
+)

--- a/app/src/main/kotlin/app/clothescast/ui/garment/GarmentRender.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/garment/GarmentRender.kt
@@ -1,0 +1,274 @@
+package app.clothescast.ui.garment
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Paint
+import androidx.annotation.DrawableRes
+import androidx.compose.foundation.Canvas as ComposeCanvas
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.drawscope.scale
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.graphics.vector.PathParser
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.core.content.res.ResourcesCompat
+import androidx.core.graphics.drawable.toBitmap
+
+/**
+ * Renders a top-tier garment icon with the user's chosen [customFill]
+ * (or the baked-in default when [customFill] is null). The auto-derived
+ * stroke colour comes from [deriveStroke] so the two-tone look survives
+ * the recolour.
+ */
+@Composable
+internal fun GarmentTopIcon(
+    top: app.clothescast.core.domain.model.OutfitSuggestion.Top,
+    customFill: Color?,
+    contentDescription: String,
+    modifier: Modifier = Modifier,
+) {
+    val defaults = outfitTopDefaults.getValue(top)
+    GarmentIconImpl(
+        drawableRes = topDrawable(top),
+        defaults = defaults,
+        customFill = customFill,
+        contentDescription = contentDescription,
+        modifier = modifier,
+    )
+}
+
+@Composable
+internal fun GarmentBottomIcon(
+    bottom: app.clothescast.core.domain.model.OutfitSuggestion.Bottom,
+    customFill: Color?,
+    contentDescription: String,
+    modifier: Modifier = Modifier,
+) {
+    val defaults = outfitBottomDefaults.getValue(bottom)
+    GarmentIconImpl(
+        drawableRes = bottomDrawable(bottom),
+        defaults = defaults,
+        customFill = customFill,
+        contentDescription = contentDescription,
+        modifier = modifier,
+    )
+}
+
+@Composable
+private fun GarmentIconImpl(
+    @DrawableRes drawableRes: Int,
+    defaults: GarmentDefaults,
+    customFill: Color?,
+    contentDescription: String,
+    modifier: Modifier,
+) {
+    // Default-colour fast path: render the original vector via painterResource
+    // so the existing snapshot tests stay byte-identical for users who haven't
+    // customised. The Canvas-based recolour path only kicks in when a custom
+    // fill is set.
+    if (customFill == null) {
+        Image(
+            painter = painterResource(drawableRes),
+            contentDescription = contentDescription,
+            modifier = modifier,
+        )
+        return
+    }
+    val context = LocalContext.current
+    val vector = remember(drawableRes) { loadOutfitVector(context, drawableRes) }
+    val recolor = remember(customFill, defaults) { buildRecolorMap(defaults, customFill) }
+    val composePaths = remember(vector) {
+        // Convert pathData to Compose Path once; re-rendering on customFill change
+        // only swaps the colour entries, not the geometry.
+        vector.paths.map { p ->
+            ComposePathSpec(
+                path = PathParser().parsePathString(p.pathData).toPath(),
+                originalFill = p.fillArgb,
+                originalStroke = p.strokeArgb,
+                strokeWidth = p.strokeWidth,
+                strokeCap = p.strokeCap.toComposeCap(),
+                strokeJoin = p.strokeJoin.toComposeJoin(),
+            )
+        }
+    }
+    ComposeCanvas(
+        // Pin the aspect ratio to the drawable's viewport so a width-only
+        // modifier (the common case from callers) still produces the right
+        // height — matching the previous painterResource(Image) behaviour
+        // where the painter's intrinsic size handled this implicitly.
+        modifier = modifier
+            .aspectRatio(vector.viewportWidth / vector.viewportHeight)
+            .semantics {
+                this.contentDescription = contentDescription
+                role = Role.Image
+            },
+    ) {
+        scale(
+            scaleX = size.width / vector.viewportWidth,
+            scaleY = size.height / vector.viewportHeight,
+            pivot = Offset.Zero,
+        ) {
+            composePaths.forEach { spec ->
+                spec.originalFill?.let { fillArgb ->
+                    val color = recolor[fillArgb] ?: fillArgb
+                    drawPath(spec.path, Color(color))
+                }
+                spec.originalStroke?.let { strokeArgb ->
+                    val color = recolor[strokeArgb] ?: strokeArgb
+                    drawPath(
+                        path = spec.path,
+                        color = Color(color),
+                        style = Stroke(
+                            width = spec.strokeWidth,
+                            cap = spec.strokeCap,
+                            join = spec.strokeJoin,
+                        ),
+                    )
+                }
+            }
+        }
+    }
+}
+
+private data class ComposePathSpec(
+    val path: Path,
+    val originalFill: Int?,
+    val originalStroke: Int?,
+    val strokeWidth: Float,
+    val strokeCap: StrokeCap,
+    val strokeJoin: StrokeJoin,
+)
+
+private fun Paint.Cap.toComposeCap(): StrokeCap = when (this) {
+    Paint.Cap.ROUND -> StrokeCap.Round
+    Paint.Cap.SQUARE -> StrokeCap.Square
+    Paint.Cap.BUTT -> StrokeCap.Butt
+}
+
+private fun Paint.Join.toComposeJoin(): StrokeJoin = when (this) {
+    Paint.Join.ROUND -> StrokeJoin.Round
+    Paint.Join.BEVEL -> StrokeJoin.Bevel
+    Paint.Join.MITER -> StrokeJoin.Miter
+}
+
+/**
+ * Rasterizes the recoloured outfit icon into a [Bitmap] for surfaces that
+ * can't render Compose composables — notification large icons (via
+ * [androidx.core.app.NotificationCompat.Builder.setLargeIcon]) and the
+ * Glance widget (via [androidx.glance.ImageProvider]). Memoised by
+ * `(drawableRes, fillArgb, sizePx)` so rapid widget refreshes don't
+ * re-rasterize. [customFillArgb] = null preserves the baked-in two-tone.
+ */
+internal fun renderOutfitBitmap(
+    context: Context,
+    @DrawableRes drawableRes: Int,
+    defaults: GarmentDefaults,
+    customFillArgb: Long?,
+    sizePx: Int,
+): Bitmap {
+    require(sizePx > 0) { "sizePx must be positive, got $sizePx" }
+    val cacheKey = BitmapCacheKey(drawableRes, customFillArgb, sizePx)
+    bitmapCache[cacheKey]?.let { return it }
+    val bitmap = if (customFillArgb == null) {
+        // Default-colour fast path: lean on the platform's VectorDrawable
+        // rasterizer so the bitmap matches what users have always seen on
+        // notifications + widgets pre-customisation.
+        renderDefaultBitmap(context, drawableRes, sizePx)
+    } else {
+        renderRecoloredBitmap(context, drawableRes, defaults, customFillArgb, sizePx)
+    }
+    bitmapCache[cacheKey] = bitmap
+    return bitmap
+}
+
+private fun renderDefaultBitmap(
+    context: Context,
+    @DrawableRes drawableRes: Int,
+    sizePx: Int,
+): Bitmap {
+    val drawable = ResourcesCompat.getDrawable(context.resources, drawableRes, context.theme)
+        ?: error("Unable to load drawable $drawableRes")
+    return drawable.toBitmap(width = sizePx, height = sizePx)
+}
+
+private fun renderRecoloredBitmap(
+    context: Context,
+    @DrawableRes drawableRes: Int,
+    defaults: GarmentDefaults,
+    customFillArgb: Long,
+    sizePx: Int,
+): Bitmap {
+    val vector = loadOutfitVector(context, drawableRes)
+    val recolor = buildRecolorMap(defaults, Color(customFillArgb.toInt()))
+    val bitmap = Bitmap.createBitmap(sizePx, sizePx, Bitmap.Config.ARGB_8888)
+    val canvas = Canvas(bitmap)
+    val scaleX = sizePx / vector.viewportWidth
+    val scaleY = sizePx / vector.viewportHeight
+    canvas.scale(scaleX, scaleY)
+    val paint = Paint().apply { isAntiAlias = true }
+    vector.paths.forEach { p ->
+        val androidPath = p.toAndroidPath()
+        p.fillArgb?.let { argb ->
+            paint.style = Paint.Style.FILL
+            paint.color = recolor[argb] ?: argb
+            canvas.drawPath(androidPath, paint)
+        }
+        p.strokeArgb?.let { argb ->
+            paint.style = Paint.Style.STROKE
+            paint.color = recolor[argb] ?: argb
+            paint.strokeWidth = p.strokeWidth
+            paint.strokeCap = p.strokeCap
+            paint.strokeJoin = p.strokeJoin
+            canvas.drawPath(androidPath, paint)
+        }
+    }
+    return bitmap
+}
+
+private data class BitmapCacheKey(
+    @DrawableRes val drawableRes: Int,
+    val customFillArgb: Long?,
+    val sizePx: Int,
+)
+
+/**
+ * LRU-ish bitmap cache. Most users have ≤2 widget cells × ≤4 garment slots ×
+ * a couple of size variants, so a small bound covers the realistic working
+ * set without holding onto stale bitmaps after a colour change. Customising
+ * a colour invalidates only that garment's entry (different cache key).
+ */
+private val bitmapCache = object : LinkedHashMap<BitmapCacheKey, Bitmap>(16, 0.75f, true) {
+    override fun removeEldestEntry(eldest: Map.Entry<BitmapCacheKey, Bitmap>): Boolean = size > MAX
+    private val MAX = 32
+}
+
+/**
+ * Builds the original-ARGB → new-ARGB substitution map for one garment.
+ * [customFill] of null returns an empty map — the renderer then leaves
+ * every path's colour untouched, which is byte-identical to the unchanged
+ * XML.
+ */
+private fun buildRecolorMap(defaults: GarmentDefaults, customFill: Color?): Map<Int, Int> {
+    if (customFill == null) return emptyMap()
+    val newFill = customFill.toArgb()
+    val newStroke = deriveStroke(customFill).toArgb()
+    return mapOf(
+        defaults.fillArgb to newFill,
+        defaults.strokeArgb to newStroke,
+    )
+}

--- a/app/src/main/kotlin/app/clothescast/ui/garment/OutfitVector.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/garment/OutfitVector.kt
@@ -1,0 +1,125 @@
+package app.clothescast.ui.garment
+
+import android.content.Context
+import android.content.res.Resources
+import android.graphics.Paint
+import android.graphics.Path
+import android.util.Xml
+import androidx.annotation.DrawableRes
+import androidx.core.graphics.PathParser
+import org.xmlpull.v1.XmlPullParser
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Light-weight in-memory representation of one of the `ic_outfit_*.xml`
+ * vector drawables, parsed once and reused for both the Compose render path
+ * (Today screen) and the bitmap render path (notification large icon, Glance
+ * widget). Only the subset of [android.graphics.drawable.VectorDrawable] this
+ * project actually uses is supported — flat list of `<path>` elements, no
+ * `<group>`, no gradients — so the parser stays small. New attributes that
+ * land on a future drawable need a parser-side update.
+ */
+internal data class OutfitVector(
+    val viewportWidth: Float,
+    val viewportHeight: Float,
+    val paths: List<OutfitPath>,
+)
+
+internal data class OutfitPath(
+    val pathData: String,
+    /** ARGB int from `android:fillColor`; null when the path has no fill. */
+    val fillArgb: Int?,
+    val strokeArgb: Int?,
+    val strokeWidth: Float,
+    val strokeCap: Paint.Cap,
+    val strokeJoin: Paint.Join,
+)
+
+private val ANDROID_NS = "http://schemas.android.com/apk/res/android"
+
+private val cache = ConcurrentHashMap<Int, OutfitVector>()
+
+/**
+ * Parses [resId] into an [OutfitVector] the first time it's requested and
+ * memoises the result. Resource parsing is cheap (<1ms per drawable on
+ * a midrange phone) but caching keeps the widget refresh path free of
+ * repeated XML pull-parser allocations during rapid tile updates.
+ */
+internal fun loadOutfitVector(context: Context, @DrawableRes resId: Int): OutfitVector =
+    cache.getOrPut(resId) { parseOutfitVector(context.resources, resId) }
+
+private fun parseOutfitVector(res: Resources, @DrawableRes resId: Int): OutfitVector {
+    val parser = res.getXml(resId)
+    val attrs = Xml.asAttributeSet(parser)
+    var viewportWidth = 0f
+    var viewportHeight = 0f
+    val paths = mutableListOf<OutfitPath>()
+    try {
+        var event = parser.next()
+        while (event != XmlPullParser.END_DOCUMENT) {
+            if (event == XmlPullParser.START_TAG) {
+                when (parser.name) {
+                    "vector" -> {
+                        viewportWidth = floatAttr(attrs, "viewportWidth") ?: 0f
+                        viewportHeight = floatAttr(attrs, "viewportHeight") ?: 0f
+                    }
+                    "path" -> paths += parsePath(attrs)
+                }
+            }
+            event = parser.next()
+        }
+    } finally {
+        parser.close()
+    }
+    require(viewportWidth > 0f && viewportHeight > 0f) {
+        "Vector drawable $resId is missing viewportWidth / viewportHeight"
+    }
+    return OutfitVector(viewportWidth, viewportHeight, paths)
+}
+
+private fun parsePath(attrs: android.util.AttributeSet): OutfitPath {
+    val pathData = stringAttr(attrs, "pathData")
+        ?: error("Vector <path> missing android:pathData")
+    return OutfitPath(
+        pathData = pathData,
+        fillArgb = colorAttr(attrs, "fillColor"),
+        strokeArgb = colorAttr(attrs, "strokeColor"),
+        strokeWidth = floatAttr(attrs, "strokeWidth") ?: 0f,
+        strokeCap = capAttr(attrs, "strokeLineCap") ?: Paint.Cap.BUTT,
+        strokeJoin = joinAttr(attrs, "strokeLineJoin") ?: Paint.Join.MITER,
+    )
+}
+
+private fun stringAttr(attrs: android.util.AttributeSet, name: String): String? =
+    attrs.getAttributeValue(ANDROID_NS, name)
+
+private fun floatAttr(attrs: android.util.AttributeSet, name: String): Float? =
+    stringAttr(attrs, name)?.toFloatOrNull()
+
+private fun colorAttr(attrs: android.util.AttributeSet, name: String): Int? {
+    val raw = stringAttr(attrs, name) ?: return null
+    return runCatching { android.graphics.Color.parseColor(raw) }.getOrNull()
+}
+
+private fun capAttr(attrs: android.util.AttributeSet, name: String): Paint.Cap? =
+    when (stringAttr(attrs, name)) {
+        "round" -> Paint.Cap.ROUND
+        "square" -> Paint.Cap.SQUARE
+        "butt" -> Paint.Cap.BUTT
+        else -> null
+    }
+
+private fun joinAttr(attrs: android.util.AttributeSet, name: String): Paint.Join? =
+    when (stringAttr(attrs, name)) {
+        "round" -> Paint.Join.ROUND
+        "bevel" -> Paint.Join.BEVEL
+        "miter" -> Paint.Join.MITER
+        else -> null
+    }
+
+/** Cached [Path] for [OutfitPath.pathData] — parsing the SVG-like data string is the
+ *  per-render hot loop, so we memoise once per unique pathData string. */
+private val pathCache = ConcurrentHashMap<String, Path>()
+
+internal fun OutfitPath.toAndroidPath(): Path =
+    pathCache.getOrPut(pathData) { PathParser.createPathFromPathData(pathData) }

--- a/app/src/main/kotlin/app/clothescast/ui/settings/ClothesSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/ClothesSettings.kt
@@ -1,14 +1,20 @@
 package app.clothescast.ui.settings
 
 import androidx.annotation.StringRes
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -33,6 +39,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
@@ -44,6 +52,8 @@ import app.clothescast.core.domain.model.TemperatureUnit
 import app.clothescast.core.domain.model.fromUnit
 import app.clothescast.core.domain.model.symbol
 import app.clothescast.core.domain.model.toUnit
+import app.clothescast.ui.garment.outfitBottomDefaults
+import app.clothescast.ui.garment.outfitTopDefaults
 import kotlin.math.roundToInt
 
 /**
@@ -60,11 +70,15 @@ internal fun ClothesContent(
     rules: List<ClothesRule>,
     defaultBottom: OutfitSuggestion.Bottom,
     temperatureUnit: TemperatureUnit,
+    outfitTopColors: Map<OutfitSuggestion.Top, Long>,
+    outfitBottomColors: Map<OutfitSuggestion.Bottom, Long>,
     padding: PaddingValues,
     onAdd: (ClothesRule) -> Unit,
     onReplace: (Int, ClothesRule) -> Unit,
     onDelete: (Int) -> Unit,
     onSetDefaultBottom: (OutfitSuggestion.Bottom) -> Unit,
+    onSetOutfitTopColor: (OutfitSuggestion.Top, Long?) -> Unit,
+    onSetOutfitBottomColor: (OutfitSuggestion.Bottom, Long?) -> Unit,
 ) {
     Column(
         modifier = Modifier
@@ -76,7 +90,130 @@ internal fun ClothesContent(
     ) {
         ClothesRulesCard(rules, temperatureUnit, onAdd, onReplace, onDelete)
         DefaultBottomCard(defaultBottom, onSetDefaultBottom)
+        GarmentColorsCard(
+            outfitTopColors = outfitTopColors,
+            outfitBottomColors = outfitBottomColors,
+            onSetOutfitTopColor = onSetOutfitTopColor,
+            onSetOutfitBottomColor = onSetOutfitBottomColor,
+        )
     }
+}
+
+/**
+ * Lets the user pick a fill colour for each rendered outfit-icon tier.
+ * Lives under Clothes (alongside the rule list and the default-bottom
+ * picker) rather than Display because it's a per-garment customisation
+ * keyed off the same icon catalogue the rules drive — not a global
+ * appearance preference like the chart palette.
+ */
+@Composable
+private fun GarmentColorsCard(
+    outfitTopColors: Map<OutfitSuggestion.Top, Long>,
+    outfitBottomColors: Map<OutfitSuggestion.Bottom, Long>,
+    onSetOutfitTopColor: (OutfitSuggestion.Top, Long?) -> Unit,
+    onSetOutfitBottomColor: (OutfitSuggestion.Bottom, Long?) -> Unit,
+) {
+    var pickerTarget by remember { mutableStateOf<GarmentPickerTarget?>(null) }
+    SectionCard(title = stringResource(R.string.settings_display_garment_colors_title)) {
+        Text(
+            text = stringResource(R.string.settings_display_garment_colors_description),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        // Tops first (in OutfitSuggestion's declaration order — coldest tier
+        // last), then bottoms, matching the reading order of the Today
+        // screen's stacked icons.
+        OutfitSuggestion.Top.entries.forEach { top ->
+            GarmentColorRow(
+                label = stringResource(topOutfitLabelRes(top)),
+                effectiveColor = colorFor(outfitTopColors[top], outfitTopDefaults.getValue(top).fillArgb),
+                onClick = { pickerTarget = GarmentPickerTarget.Top(top) },
+            )
+        }
+        OutfitSuggestion.Bottom.entries.forEach { bottom ->
+            GarmentColorRow(
+                label = stringResource(bottomOutfitLabelRes(bottom)),
+                effectiveColor = colorFor(outfitBottomColors[bottom], outfitBottomDefaults.getValue(bottom).fillArgb),
+                onClick = { pickerTarget = GarmentPickerTarget.Bottom(bottom) },
+            )
+        }
+    }
+    pickerTarget?.let { target ->
+        val (label, current) = when (target) {
+            is GarmentPickerTarget.Top -> stringResource(topOutfitLabelRes(target.top)) to outfitTopColors[target.top]
+            is GarmentPickerTarget.Bottom -> stringResource(bottomOutfitLabelRes(target.bottom)) to outfitBottomColors[target.bottom]
+        }
+        GarmentColorPickerDialog(
+            garmentLabel = label,
+            currentArgb = current,
+            onPick = { picked ->
+                when (target) {
+                    is GarmentPickerTarget.Top -> onSetOutfitTopColor(target.top, picked)
+                    is GarmentPickerTarget.Bottom -> onSetOutfitBottomColor(target.bottom, picked)
+                }
+            },
+            onDismiss = { pickerTarget = null },
+        )
+    }
+}
+
+private sealed interface GarmentPickerTarget {
+    data class Top(val top: OutfitSuggestion.Top) : GarmentPickerTarget
+    data class Bottom(val bottom: OutfitSuggestion.Bottom) : GarmentPickerTarget
+}
+
+@Composable
+private fun GarmentColorRow(
+    label: String,
+    effectiveColor: Color,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Box(
+            modifier = Modifier
+                .size(28.dp)
+                .clip(CircleShape)
+                .background(effectiveColor)
+                .border(
+                    width = 1.dp,
+                    color = MaterialTheme.colorScheme.outlineVariant,
+                    shape = CircleShape,
+                ),
+        )
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyLarge,
+            modifier = Modifier.padding(start = 16.dp),
+        )
+    }
+}
+
+private fun colorFor(customArgb: Long?, defaultArgb: Int): Color =
+    Color((customArgb?.toInt()) ?: defaultArgb)
+
+@StringRes
+private fun topOutfitLabelRes(top: OutfitSuggestion.Top): Int = when (top) {
+    OutfitSuggestion.Top.TSHIRT -> R.string.today_outfit_top_tshirt
+    OutfitSuggestion.Top.POLO -> R.string.today_outfit_top_polo
+    OutfitSuggestion.Top.SWEATER -> R.string.today_outfit_top_sweater
+    OutfitSuggestion.Top.THIN_JACKET -> R.string.today_outfit_top_thin_jacket
+    OutfitSuggestion.Top.THICK_JACKET -> R.string.today_outfit_top_thick_jacket
+    OutfitSuggestion.Top.THICK_COAT -> R.string.today_outfit_top_thick_coat
+    OutfitSuggestion.Top.PUFFER_JACKET -> R.string.today_outfit_top_puffer_jacket
+}
+
+@StringRes
+private fun bottomOutfitLabelRes(bottom: OutfitSuggestion.Bottom): Int = when (bottom) {
+    OutfitSuggestion.Bottom.SHORTS -> R.string.today_outfit_bottom_shorts
+    OutfitSuggestion.Bottom.LONG_SKIRT -> R.string.today_outfit_bottom_long_skirt
+    OutfitSuggestion.Bottom.JEANS -> R.string.today_outfit_bottom_jeans
+    OutfitSuggestion.Bottom.LONG_PANTS -> R.string.today_outfit_bottom_long_pants
 }
 
 /**

--- a/app/src/main/kotlin/app/clothescast/ui/settings/GarmentColorPicker.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/GarmentColorPicker.kt
@@ -1,0 +1,181 @@
+package app.clothescast.ui.settings
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.itemsIndexed
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.selected
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import app.clothescast.R
+import app.clothescast.ui.garment.garmentColorPresets
+
+/**
+ * Modal picker for one garment's fill colour. Shows a grid of preset
+ * swatches plus a "Default" tile that clears the override.
+ *
+ * - [garmentLabel] is the localised garment name shown in the title and
+ *   used in the swatch content descriptions ("Reset T-shirt to the default
+ *   colour").
+ * - [currentArgb] is the user's current pick (drawn with a ring), or null
+ *   when the icon is on its baked-in default.
+ * - [onPick] is called with the chosen ARGB; pass `null` to clear.
+ */
+@Composable
+internal fun GarmentColorPickerDialog(
+    garmentLabel: String,
+    currentArgb: Long?,
+    onPick: (Long?) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = {
+            Column {
+                Text(stringResource(R.string.settings_garment_color_picker_title))
+                Text(
+                    text = garmentLabel,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        },
+        text = {
+            LazyVerticalGrid(
+                columns = GridCells.Fixed(SWATCH_COLUMNS),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                item {
+                    DefaultSwatch(
+                        garmentLabel = garmentLabel,
+                        selected = currentArgb == null,
+                        onClick = {
+                            onPick(null)
+                            onDismiss()
+                        },
+                    )
+                }
+                itemsIndexed(garmentColorPresets) { _, color ->
+                    val argb = color.toLongArgb()
+                    PresetSwatch(
+                        color = color,
+                        selected = currentArgb == argb,
+                        garmentLabel = garmentLabel,
+                        onClick = {
+                            onPick(argb)
+                            onDismiss()
+                        },
+                    )
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.settings_garment_color_dialog_close))
+            }
+        },
+    )
+}
+
+@Composable
+private fun PresetSwatch(
+    color: Color,
+    selected: Boolean,
+    garmentLabel: String,
+    onClick: () -> Unit,
+) {
+    val description = stringResource(R.string.settings_garment_color_swatch_description, garmentLabel)
+    Box(
+        modifier = Modifier
+            .size(SWATCH_SIZE)
+            .clip(CircleShape)
+            .background(color)
+            .selectionRing(selected)
+            .clickable(role = Role.Button, onClick = onClick)
+            .semantics {
+                contentDescription = description
+                this.selected = selected
+                this.role = Role.RadioButton
+            },
+    )
+}
+
+@Composable
+private fun DefaultSwatch(
+    garmentLabel: String,
+    selected: Boolean,
+    onClick: () -> Unit,
+) {
+    val description = stringResource(R.string.settings_garment_color_default_swatch_description, garmentLabel)
+    Box(
+        modifier = Modifier
+            .size(SWATCH_SIZE)
+            .clip(CircleShape)
+            .background(MaterialTheme.colorScheme.surfaceVariant)
+            .selectionRing(selected)
+            .clickable(role = Role.Button, onClick = onClick)
+            .semantics {
+                contentDescription = description
+                this.selected = selected
+                this.role = Role.RadioButton
+            },
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = stringResource(R.string.settings_garment_color_default),
+            style = MaterialTheme.typography.labelSmall,
+            textAlign = TextAlign.Center,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun Modifier.selectionRing(selected: Boolean): Modifier =
+    if (selected) {
+        this.border(
+            width = 3.dp,
+            color = MaterialTheme.colorScheme.primary,
+            shape = CircleShape,
+        )
+    } else {
+        this
+    }
+
+/**
+ * Packs a Compose [Color] (sRGB) into the ARGB long shape we persist. The
+ * conversion goes through `toArgb()` so non-sRGB colour spaces can't sneak
+ * past the round-trip; presets are sRGB anyway, but the helper makes the
+ * contract explicit.
+ */
+private fun Color.toLongArgb(): Long = toArgb().toLong() and 0xFFFFFFFFL
+
+private val SWATCH_SIZE = 56.dp
+private const val SWATCH_COLUMNS = 4

--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsPreviews.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsPreviews.kt
@@ -89,11 +89,15 @@ internal fun SettingsClothesPreview() {
             rules = ClothesRule.DEFAULTS,
             defaultBottom = OutfitSuggestion.Bottom.LONG_PANTS,
             temperatureUnit = TemperatureUnit.CELSIUS,
+            outfitTopColors = emptyMap(),
+            outfitBottomColors = emptyMap(),
             padding = PaddingValues(0.dp),
             onAdd = {},
             onReplace = { _, _ -> },
             onDelete = {},
             onSetDefaultBottom = {},
+            onSetOutfitTopColor = { _, _ -> },
+            onSetOutfitBottomColor = { _, _ -> },
         )
     }
 }
@@ -115,11 +119,15 @@ internal fun SettingsClothesFahrenheitPreview() {
             ),
             defaultBottom = OutfitSuggestion.Bottom.LONG_PANTS,
             temperatureUnit = TemperatureUnit.FAHRENHEIT,
+            outfitTopColors = emptyMap(),
+            outfitBottomColors = emptyMap(),
             padding = PaddingValues(0.dp),
             onAdd = {},
             onReplace = { _, _ -> },
             onDelete = {},
             onSetDefaultBottom = {},
+            onSetOutfitTopColor = { _, _ -> },
+            onSetOutfitBottomColor = { _, _ -> },
         )
     }
 }

--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsScreen.kt
@@ -138,11 +138,15 @@ fun SettingsScreen(
                 rules = state.clothesRules,
                 defaultBottom = state.defaultBottom,
                 temperatureUnit = state.temperatureUnit,
+                outfitTopColors = state.outfitTopColors,
+                outfitBottomColors = state.outfitBottomColors,
                 padding = padding,
                 onAdd = viewModel::addClothesRule,
                 onReplace = viewModel::replaceClothesRule,
                 onDelete = viewModel::deleteClothesRule,
                 onSetDefaultBottom = viewModel::setDefaultBottom,
+                onSetOutfitTopColor = viewModel::setOutfitTopColor,
+                onSetOutfitBottomColor = viewModel::setOutfitBottomColor,
             )
             SettingsRoute.Region -> RegionContent(
                 region = state.region,

--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsState.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsState.kt
@@ -44,6 +44,10 @@ data class SettingsState(
     val distanceUnitSetting: DistanceUnitSetting = DistanceUnitSetting.AUTO,
     val themeMode: ThemeMode = ThemeMode.SYSTEM,
     val colorPalette: ColorPalette = ColorPalette.RAINBOW,
+    /** User-picked fill colour overrides for each top-icon tier. Empty = baked-in defaults. */
+    val outfitTopColors: Map<OutfitSuggestion.Top, Long> = emptyMap(),
+    /** Sibling of [outfitTopColors] for the bottom-icon tier. */
+    val outfitBottomColors: Map<OutfitSuggestion.Bottom, Long> = emptyMap(),
     val clothesRules: List<ClothesRule> = ClothesRule.DEFAULTS,
     val defaultBottom: OutfitSuggestion.Bottom = OutfitSuggestion.Bottom.LONG_PANTS,
     val location: Location? = null,

--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsViewModel.kt
@@ -122,6 +122,8 @@ class SettingsViewModel(
                         distanceUnitSetting = prefs.distanceUnitSetting,
                         themeMode = prefs.themeMode,
                         colorPalette = prefs.colorPalette,
+                        outfitTopColors = prefs.outfitTopColors,
+                        outfitBottomColors = prefs.outfitBottomColors,
                         clothesRules = prefs.clothesRules,
                         defaultBottom = prefs.defaultBottom,
                         location = prefs.location,
@@ -266,6 +268,27 @@ class SettingsViewModel(
 
     fun setColorPalette(palette: ColorPalette) {
         viewModelScope.launch { settingsRepository.setColorPalette(palette) }
+    }
+
+    /**
+     * Sets the user's fill-colour override for the [top] icon (or clears it
+     * with `argb = null`). Re-renders the cached outfit + widget so the
+     * Today screen and any home-screen widget pick up the new colour in
+     * the same frame as the picker dismisses.
+     */
+    fun setOutfitTopColor(top: OutfitSuggestion.Top, argb: Long?) {
+        viewModelScope.launch {
+            settingsRepository.setOutfitTopColor(top, argb)
+            refreshCachedOutfits()
+        }
+    }
+
+    /** Sibling of [setOutfitTopColor] for the bottom-icon tier. */
+    fun setOutfitBottomColor(bottom: OutfitSuggestion.Bottom, argb: Long?) {
+        viewModelScope.launch {
+            settingsRepository.setOutfitBottomColor(bottom, argb)
+            refreshCachedOutfits()
+        }
     }
 
     fun addClothesRule(rule: ClothesRule) {

--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
@@ -53,7 +53,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
@@ -61,7 +60,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLifecycleOwner
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
@@ -96,6 +94,8 @@ import app.clothescast.core.domain.model.toUnit
 import app.clothescast.core.domain.model.toWindSpeedUnit
 import app.clothescast.core.domain.model.windSpeedUnit
 import app.clothescast.ClothesCastApplication
+import app.clothescast.ui.garment.GarmentBottomIcon
+import app.clothescast.ui.garment.GarmentTopIcon
 import app.clothescast.diag.BugReport
 import app.clothescast.diag.BugReportConsentDialog
 import app.clothescast.diag.findActivity
@@ -320,6 +320,8 @@ private fun TodayContent(
                     insight = primary,
                     temperatureUnit = state.temperatureUnit,
                     clothesRules = state.clothesRules,
+                    outfitTopColors = state.outfitTopColors,
+                    outfitBottomColors = state.outfitBottomColors,
                     onAdjustThreshold = onAdjustThreshold,
                 )
             }
@@ -740,6 +742,8 @@ internal fun OutfitPreviewRow(
     insight: Insight,
     temperatureUnit: TemperatureUnit = TemperatureUnit.CELSIUS,
     clothesRules: List<ClothesRule> = emptyList(),
+    outfitTopColors: Map<OutfitSuggestion.Top, Long> = emptyMap(),
+    outfitBottomColors: Map<OutfitSuggestion.Bottom, Long> = emptyMap(),
     onAdjustThreshold: (String, Double) -> Unit = { _, _ -> },
 ) {
     val primary = insight.outfit ?: return
@@ -754,6 +758,8 @@ internal fun OutfitPreviewRow(
             rationale = insight.outfitRationale,
             temperatureUnit = temperatureUnit,
             clothesRules = clothesRules,
+            outfitTopColors = outfitTopColors,
+            outfitBottomColors = outfitBottomColors,
             onAdjustThreshold = onAdjustThreshold,
             modifier = Modifier.weight(1f),
         )
@@ -764,6 +770,8 @@ internal fun OutfitPreviewRow(
                 rationale = insight.nextOutfitRationale,
                 temperatureUnit = temperatureUnit,
                 clothesRules = clothesRules,
+                outfitTopColors = outfitTopColors,
+                outfitBottomColors = outfitBottomColors,
                 onAdjustThreshold = onAdjustThreshold,
                 modifier = Modifier.weight(1f),
             )
@@ -785,6 +793,8 @@ internal fun OutfitPreviewCard(
     rationale: OutfitRationale? = null,
     temperatureUnit: TemperatureUnit = TemperatureUnit.CELSIUS,
     clothesRules: List<ClothesRule> = emptyList(),
+    outfitTopColors: Map<OutfitSuggestion.Top, Long> = emptyMap(),
+    outfitBottomColors: Map<OutfitSuggestion.Bottom, Long> = emptyMap(),
     onAdjustThreshold: (String, Double) -> Unit = { _, _ -> },
 ) {
     var showRationale by remember { mutableStateOf(false) }
@@ -812,13 +822,15 @@ internal fun OutfitPreviewCard(
                 verticalArrangement = Arrangement.spacedBy(0.dp),
                 horizontalAlignment = Alignment.CenterHorizontally,
             ) {
-                Image(
-                    painter = painterResource(id = topIconRes(outfit.top)),
+                GarmentTopIcon(
+                    top = outfit.top,
+                    customFill = outfitTopColors[outfit.top]?.let { Color(it.toInt()) },
                     contentDescription = stringResource(topLabelRes(outfit.top)),
                     modifier = Modifier.width(80.dp),
                 )
-                Image(
-                    painter = painterResource(id = bottomIconRes(outfit.bottom)),
+                GarmentBottomIcon(
+                    bottom = outfit.bottom,
+                    customFill = outfitBottomColors[outfit.bottom]?.let { Color(it.toInt()) },
                     contentDescription = stringResource(bottomLabelRes(outfit.bottom)),
                     modifier = Modifier.width(80.dp),
                 )
@@ -1087,16 +1099,6 @@ private val ONE_DECIMAL_FORMAT: java.text.NumberFormat =
         maximumFractionDigits = 1
     }
 
-private fun topIconRes(top: OutfitSuggestion.Top): Int = when (top) {
-    OutfitSuggestion.Top.TSHIRT -> R.drawable.ic_outfit_tshirt
-    OutfitSuggestion.Top.POLO -> R.drawable.ic_outfit_polo
-    OutfitSuggestion.Top.SWEATER -> R.drawable.ic_outfit_sweater
-    OutfitSuggestion.Top.THIN_JACKET -> R.drawable.ic_outfit_thin_jacket
-    OutfitSuggestion.Top.THICK_JACKET -> R.drawable.ic_outfit_thick_jacket
-    OutfitSuggestion.Top.THICK_COAT -> R.drawable.ic_outfit_thick_coat
-    OutfitSuggestion.Top.PUFFER_JACKET -> R.drawable.ic_outfit_puffer_jacket
-}
-
 private fun topLabelRes(top: OutfitSuggestion.Top): Int = when (top) {
     OutfitSuggestion.Top.TSHIRT -> R.string.today_outfit_top_tshirt
     OutfitSuggestion.Top.POLO -> R.string.today_outfit_top_polo
@@ -1105,13 +1107,6 @@ private fun topLabelRes(top: OutfitSuggestion.Top): Int = when (top) {
     OutfitSuggestion.Top.THICK_JACKET -> R.string.today_outfit_top_thick_jacket
     OutfitSuggestion.Top.THICK_COAT -> R.string.today_outfit_top_thick_coat
     OutfitSuggestion.Top.PUFFER_JACKET -> R.string.today_outfit_top_puffer_jacket
-}
-
-private fun bottomIconRes(bottom: OutfitSuggestion.Bottom): Int = when (bottom) {
-    OutfitSuggestion.Bottom.SHORTS -> R.drawable.ic_outfit_shorts
-    OutfitSuggestion.Bottom.LONG_SKIRT -> R.drawable.ic_outfit_skirt
-    OutfitSuggestion.Bottom.JEANS -> R.drawable.ic_outfit_jeans
-    OutfitSuggestion.Bottom.LONG_PANTS -> R.drawable.ic_outfit_long_pants
 }
 
 private fun bottomLabelRes(bottom: OutfitSuggestion.Bottom): Int = when (bottom) {

--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayViewModel.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayViewModel.kt
@@ -10,6 +10,7 @@ import app.clothescast.core.domain.model.ClothesRule
 import app.clothescast.core.domain.model.DistanceUnit
 import app.clothescast.core.domain.model.ForecastPeriod
 import app.clothescast.core.domain.model.Insight
+import app.clothescast.core.domain.model.OutfitSuggestion
 import app.clothescast.core.domain.model.Region
 import app.clothescast.core.domain.model.TemperatureUnit
 import app.clothescast.data.InsightCache
@@ -76,6 +77,10 @@ data class TodayState(
      * [Insight.perModelHourly] is present.
      */
     val showModelSpread: Boolean = false,
+    /** User-picked fill colour overrides for each top-icon tier. Empty = baked-in defaults. */
+    val outfitTopColors: Map<OutfitSuggestion.Top, Long> = emptyMap(),
+    /** Sibling of [outfitTopColors] for the bottom-icon tier. */
+    val outfitBottomColors: Map<OutfitSuggestion.Bottom, Long> = emptyMap(),
 )
 
 sealed class WorkStatus {
@@ -255,6 +260,8 @@ class TodayViewModel(
             hasFallbackLocation = prefs.location != null,
             clothesRules = prefs.clothesRules,
             showModelSpread = spread,
+            outfitTopColors = prefs.outfitTopColors,
+            outfitBottomColors = prefs.outfitBottomColors,
         )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), TodayState())
 

--- a/app/src/main/kotlin/app/clothescast/widget/OutfitWidget.kt
+++ b/app/src/main/kotlin/app/clothescast/widget/OutfitWidget.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.TextUnit
@@ -42,6 +43,11 @@ import app.clothescast.R
 import app.clothescast.core.domain.model.ForecastPeriod
 import app.clothescast.core.domain.model.Insight
 import app.clothescast.core.domain.model.OutfitSuggestion
+import app.clothescast.ui.garment.bottomDrawable
+import app.clothescast.ui.garment.outfitBottomDefaults
+import app.clothescast.ui.garment.outfitTopDefaults
+import app.clothescast.ui.garment.renderOutfitBitmap
+import app.clothescast.ui.garment.topDrawable
 import kotlinx.coroutines.flow.first
 
 /**
@@ -72,9 +78,15 @@ class OutfitWidget : GlanceAppWidget() {
         // emits the freshest of the two cached periods (TODAY / TONIGHT), which
         // is the same "what's relevant right now" choice the Today screen makes.
         val insight = runCatching { app.insightCache.latest.first() }.getOrNull()
+        // Per-garment colour overrides — empty when the user hasn't customised.
+        // Pulled here (not inside the Composable) so the bitmap rasterizer can
+        // run on this dispatcher rather than during composition.
+        val prefs = runCatching { app.settingsRepository.preferences.first() }.getOrNull()
+        val topColors = prefs?.outfitTopColors ?: emptyMap()
+        val bottomColors = prefs?.outfitBottomColors ?: emptyMap()
         provideContent {
             GlanceTheme {
-                OutfitWidgetContent(insight)
+                OutfitWidgetContent(insight, topColors, bottomColors)
             }
         }
     }
@@ -100,7 +112,11 @@ private fun launchAppIntent(context: Context): Intent =
         .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
 
 @Composable
-private fun OutfitWidgetContent(insight: Insight?) {
+private fun OutfitWidgetContent(
+    insight: Insight?,
+    topColors: Map<OutfitSuggestion.Top, Long>,
+    bottomColors: Map<OutfitSuggestion.Bottom, Long>,
+) {
     val size = LocalSize.current
     val context = LocalContext.current
     val outfit = insight?.outfit
@@ -116,21 +132,30 @@ private fun OutfitWidgetContent(insight: Insight?) {
         if (insight == null || outfit == null) {
             EmptyContent(size)
         } else if (size.width >= SIDE_BY_SIDE_MIN_WIDTH && insight.nextOutfit != null) {
-            SideBySideContent(insight, size)
+            SideBySideContent(insight, size, topColors, bottomColors)
         } else {
             SingleColumnContent(
                 label = context.getString(periodLabelRes(insight.period)),
                 outfit = outfit,
                 size = size,
+                topColors = topColors,
+                bottomColors = bottomColors,
             )
         }
     }
 }
 
 @Composable
-private fun SingleColumnContent(label: String, outfit: OutfitSuggestion, size: DpSize) {
+private fun SingleColumnContent(
+    label: String,
+    outfit: OutfitSuggestion,
+    size: DpSize,
+    topColors: Map<OutfitSuggestion.Top, Long>,
+    bottomColors: Map<OutfitSuggestion.Bottom, Long>,
+) {
     val context = LocalContext.current
     val iconSize = scaledIconSize(size)
+    val iconPx = with(Density(context)) { iconSize.toPx() }.toInt().coerceAtLeast(1)
     Column(
         modifier = GlanceModifier.fillMaxSize(),
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -142,12 +167,28 @@ private fun SingleColumnContent(label: String, outfit: OutfitSuggestion, size: D
         // OutfitPreviewCard so the home-screen glance reads the same way as
         // the in-app card the user already knows.
         Image(
-            provider = ImageProvider(topIconRes(outfit.top)),
+            provider = ImageProvider(
+                renderOutfitBitmap(
+                    context = context,
+                    drawableRes = topDrawable(outfit.top),
+                    defaults = outfitTopDefaults.getValue(outfit.top),
+                    customFillArgb = topColors[outfit.top],
+                    sizePx = iconPx,
+                ),
+            ),
             contentDescription = context.getString(topLabelRes(outfit.top)),
             modifier = GlanceModifier.size(iconSize),
         )
         Image(
-            provider = ImageProvider(bottomIconRes(outfit.bottom)),
+            provider = ImageProvider(
+                renderOutfitBitmap(
+                    context = context,
+                    drawableRes = bottomDrawable(outfit.bottom),
+                    defaults = outfitBottomDefaults.getValue(outfit.bottom),
+                    customFillArgb = bottomColors[outfit.bottom],
+                    sizePx = iconPx,
+                ),
+            ),
             contentDescription = context.getString(bottomLabelRes(outfit.bottom)),
             modifier = GlanceModifier.size(iconSize),
         )
@@ -162,7 +203,12 @@ private fun SingleColumnContent(label: String, outfit: OutfitSuggestion, size: D
 }
 
 @Composable
-private fun SideBySideContent(insight: Insight, size: DpSize) {
+private fun SideBySideContent(
+    insight: Insight,
+    size: DpSize,
+    topColors: Map<OutfitSuggestion.Top, Long>,
+    bottomColors: Map<OutfitSuggestion.Bottom, Long>,
+) {
     val context = LocalContext.current
     val primaryOutfit = insight.outfit ?: return
     val nextOutfit = insight.nextOutfit ?: return
@@ -183,6 +229,8 @@ private fun SideBySideContent(insight: Insight, size: DpSize) {
                 label = context.getString(primaryLabelRes),
                 outfit = primaryOutfit,
                 size = columnSize,
+                topColors = topColors,
+                bottomColors = bottomColors,
             )
         }
         Box(
@@ -193,6 +241,8 @@ private fun SideBySideContent(insight: Insight, size: DpSize) {
                 label = context.getString(nextLabelRes),
                 outfit = nextOutfit,
                 size = columnSize,
+                topColors = topColors,
+                bottomColors = bottomColors,
             )
         }
     }
@@ -264,16 +314,6 @@ private fun sideBySideLabelRes(period: ForecastPeriod): Pair<Int, Int> = when (p
         R.string.today_outfit_label_tonight to R.string.today_outfit_label_tomorrow
 }
 
-private fun topIconRes(top: OutfitSuggestion.Top): Int = when (top) {
-    OutfitSuggestion.Top.TSHIRT -> R.drawable.ic_outfit_tshirt
-    OutfitSuggestion.Top.POLO -> R.drawable.ic_outfit_polo
-    OutfitSuggestion.Top.SWEATER -> R.drawable.ic_outfit_sweater
-    OutfitSuggestion.Top.THIN_JACKET -> R.drawable.ic_outfit_thin_jacket
-    OutfitSuggestion.Top.THICK_JACKET -> R.drawable.ic_outfit_thick_jacket
-    OutfitSuggestion.Top.THICK_COAT -> R.drawable.ic_outfit_thick_coat
-    OutfitSuggestion.Top.PUFFER_JACKET -> R.drawable.ic_outfit_puffer_jacket
-}
-
 private fun topLabelRes(top: OutfitSuggestion.Top): Int = when (top) {
     OutfitSuggestion.Top.TSHIRT -> R.string.today_outfit_top_tshirt
     OutfitSuggestion.Top.POLO -> R.string.today_outfit_top_polo
@@ -282,13 +322,6 @@ private fun topLabelRes(top: OutfitSuggestion.Top): Int = when (top) {
     OutfitSuggestion.Top.THICK_JACKET -> R.string.today_outfit_top_thick_jacket
     OutfitSuggestion.Top.THICK_COAT -> R.string.today_outfit_top_thick_coat
     OutfitSuggestion.Top.PUFFER_JACKET -> R.string.today_outfit_top_puffer_jacket
-}
-
-private fun bottomIconRes(bottom: OutfitSuggestion.Bottom): Int = when (bottom) {
-    OutfitSuggestion.Bottom.SHORTS -> R.drawable.ic_outfit_shorts
-    OutfitSuggestion.Bottom.LONG_SKIRT -> R.drawable.ic_outfit_skirt
-    OutfitSuggestion.Bottom.JEANS -> R.drawable.ic_outfit_jeans
-    OutfitSuggestion.Bottom.LONG_PANTS -> R.drawable.ic_outfit_long_pants
 }
 
 private fun bottomLabelRes(bottom: OutfitSuggestion.Bottom): Int = when (bottom) {

--- a/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
@@ -479,7 +479,7 @@ class FetchAndNotifyWorker(
         awaitDeliveryAlignment()
         val mode = prefs.deliveryMode
         if (mode == DeliveryMode.NOTIFICATION_ONLY || mode == DeliveryMode.NOTIFICATION_AND_TTS) {
-            app.insightNotifier.notify(insight, prose)
+            app.insightNotifier.notify(insight, prose, prefs.outfitTopColors)
             recordDeliveryDelay(ForecastPeriod.TODAY)
         }
         if (mode == DeliveryMode.TTS_ONLY || mode == DeliveryMode.NOTIFICATION_AND_TTS) {
@@ -604,7 +604,7 @@ class FetchAndNotifyWorker(
         if (skipEmptyEveningNotification) {
             DiagLog.i(TAG, "Tonight insight has no events and notify-only-on-events is on; skipping notification.")
         } else if (canNotify) {
-            app.tonightInsightNotifier.notify(insight, prose)
+            app.tonightInsightNotifier.notify(insight, prose, prefs.outfitTopColors)
             recordDeliveryDelay(ForecastPeriod.TONIGHT)
         }
         if (!insight.hasEvents) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -366,6 +366,14 @@
     <string name="settings_display_palette_accessible_description">An Okabe-Ito-derived palette designed to stay distinguishable under deuteranopia, protanopia, and tritanopia. Confidence cards use sky blue, neutral, and amber instead of teal, neutral, and red.</string>
     <string name="settings_display_palette_highlighter_description">Magenta, yellow, and cyan chart lines — like highlighter pens on the page. Visibly different from Rainbow at a glance; the light theme uses deeper variants for readability. Safe under red-green colour blindness.</string>
 
+    <string name="settings_display_garment_colors_title">Garment colours</string>
+    <string name="settings_display_garment_colors_description">Pick a colour for each clothing icon shown on Today, the home-screen widget, and notifications. The stroke darkens automatically.</string>
+    <string name="settings_garment_color_default">Default</string>
+    <string name="settings_garment_color_picker_title">Pick a colour</string>
+    <string name="settings_garment_color_swatch_description">Colour swatch %1$s</string>
+    <string name="settings_garment_color_default_swatch_description">Reset %1$s to the default colour</string>
+    <string name="settings_garment_color_dialog_close">Close</string>
+
     <string name="settings_root_location_subtitle">Auto-detect or pick a city</string>
     <string name="settings_root_calendar_subtitle">Today\'s events</string>
     <string name="settings_root_privacy_subtitle">Crash + usage reports</string>

--- a/app/src/test/kotlin/app/clothescast/data/SettingsRepositoryTest.kt
+++ b/app/src/test/kotlin/app/clothescast/data/SettingsRepositoryTest.kt
@@ -353,6 +353,57 @@ class SettingsRepositoryTest {
     }
 
     @Test
+    fun `outfit colour overrides default to empty maps`() = runTest {
+        val prefs = subject.preferences.first()
+        prefs.outfitTopColors shouldBe emptyMap()
+        prefs.outfitBottomColors shouldBe emptyMap()
+    }
+
+    @Test
+    fun `setOutfitTopColor round-trips a fill and clears with null`() = runTest {
+        subject.setOutfitTopColor(OutfitSuggestion.Top.SWEATER, 0xFFE53935L)
+        subject.setOutfitTopColor(OutfitSuggestion.Top.TSHIRT, 0xFF1E88E5L)
+        val withTwo = subject.preferences.first().outfitTopColors
+        withTwo[OutfitSuggestion.Top.SWEATER] shouldBe 0xFFE53935L
+        withTwo[OutfitSuggestion.Top.TSHIRT] shouldBe 0xFF1E88E5L
+
+        // Clearing one entry leaves the other intact — the partial update path
+        // is what the picker's "Default" tile relies on.
+        subject.setOutfitTopColor(OutfitSuggestion.Top.SWEATER, null)
+        val afterClear = subject.preferences.first().outfitTopColors
+        afterClear.containsKey(OutfitSuggestion.Top.SWEATER) shouldBe false
+        afterClear[OutfitSuggestion.Top.TSHIRT] shouldBe 0xFF1E88E5L
+    }
+
+    @Test
+    fun `setOutfitBottomColor round-trips`() = runTest {
+        subject.setOutfitBottomColor(OutfitSuggestion.Bottom.JEANS, 0xFF7CB342L)
+        subject.preferences.first().outfitBottomColors[OutfitSuggestion.Bottom.JEANS] shouldBe 0xFF7CB342L
+    }
+
+    @Test
+    fun `outfit colours tolerate unknown enum names in stored JSON`() = runTest {
+        // Forward-compat — a future build that adds a new Top variant and
+        // writes its colour shouldn't crash earlier installs that read it
+        // back. The unknown entry silently disappears; known entries survive.
+        // Numbers are positive Longs (the writer normalises ARGB ints into
+        // the unsigned-Long range so JSON output stays human-readable).
+        dataStore.edit {
+            it[stringPreferencesKey("outfit_top_colors_json")] =
+                """{"SWEATER":4294901760,"FUTURE_VARIANT":4278255360}"""
+        }
+        val prefs = subject.preferences.first()
+        prefs.outfitTopColors[OutfitSuggestion.Top.SWEATER] shouldBe 0xFFFF0000L
+        prefs.outfitTopColors.size shouldBe 1
+    }
+
+    @Test
+    fun `corrupt outfit colours JSON falls back to empty`() = runTest {
+        dataStore.edit { it[stringPreferencesKey("outfit_top_colors_json")] = "not json" }
+        subject.preferences.first().outfitTopColors shouldBe emptyMap()
+    }
+
+    @Test
     fun `gemini voice setter round-trips`() = runTest {
         subject.setGeminiVoice("Puck")
         subject.preferences.first().geminiVoice shouldBe "Puck"

--- a/app/src/test/kotlin/app/clothescast/ui/garment/GarmentColorsTest.kt
+++ b/app/src/test/kotlin/app/clothescast/ui/garment/GarmentColorsTest.kt
@@ -1,0 +1,101 @@
+package app.clothescast.ui.garment
+
+import io.kotest.matchers.ints.shouldBeGreaterThan
+import io.kotest.matchers.ints.shouldBeGreaterThanOrEqual
+import io.kotest.matchers.ints.shouldBeLessThan
+import io.kotest.matchers.ints.shouldBeLessThanOrEqual
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+/**
+ * Pure-JVM unit tests for [deriveStrokeArgb]. Avoid the
+ * `androidx.core.graphics.ColorUtils` round-trip in assertions because the
+ * project's `unitTests.isReturnDefaultValues = true` config stubs every
+ * `android.graphics.Color.*` static to return 0. Components are extracted
+ * by bit math.
+ */
+class GarmentColorsTest {
+
+    @Test
+    fun `deriveStrokeArgb darkens the fill colour`() {
+        // tshirt's baked colours: #4FC3F7 fill → #0288D1 stroke. The derived
+        // stroke should be visibly darker than the fill while staying
+        // recognisably the same hue family — sanity-checked here by:
+        //  - mean RGB drops (darker overall),
+        //  - blue channel still dominates (hue family preserved).
+        val fill = 0xFF4FC3F7L
+        val derived = deriveStrokeArgb(fill)
+        val (fr, fg, fb) = derived.rgb()
+        val (orR, orG, orB) = fill.rgb()
+        meanOf(fr, fg, fb) shouldBeLessThan meanOf(orR, orG, orB)
+        fb shouldBeGreaterThan fr  // blue channel still dominates red
+        fb shouldBeGreaterThan fg  // blue channel still dominates green
+    }
+
+    @Test
+    fun `deriveStrokeArgb is roughly 60 percent of fill lightness for mid-saturated colours`() {
+        // Spot-check across the wheel — the project's preset palette is mostly
+        // saturated mid-lightness colours, so the L scale is what determines
+        // whether derived strokes look like the originals.
+        val pairs = listOf(
+            0xFFFF7043L to 0.55f,  // orange
+            0xFF1E88E5L to 0.55f,  // blue
+            0xFF43A047L to 0.55f,  // green
+            0xFFEC407AL to 0.55f,  // pink
+        )
+        for ((fill, ratio) in pairs) {
+            val derived = deriveStrokeArgb(fill)
+            val (fr, fg, fb) = fill.rgb()
+            val (dr, dg, db) = derived.rgb()
+            val fillMean = meanOf(fr, fg, fb)
+            val derivedMean = meanOf(dr, dg, db)
+            val actualRatio = derivedMean.toFloat() / fillMean.toFloat()
+            // Loose tolerance — RGB mean isn't a perfect proxy for HSL L,
+            // but it tracks well enough on saturated mid-lightness colours.
+            (actualRatio - ratio).let { delta ->
+                check(delta in -0.20f..0.20f) {
+                    "Derived/fill mean ratio for ${fill.toString(16)} = $actualRatio, expected ~$ratio (Δ=$delta)"
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `deriveStrokeArgb preserves alpha`() {
+        val fullyOpaque = deriveStrokeArgb(0xFFFF0000L)
+        ((fullyOpaque ushr 24) and 0xFFL) shouldBe 0xFFL
+
+        // A non-opaque fill keeps its alpha through the derivation. We don't
+        // emit alpha-blended garments today, but the contract holds.
+        val translucent = deriveStrokeArgb(0x80FF0000L)
+        ((translucent ushr 24) and 0xFFL) shouldBe 0x80L
+    }
+
+    @Test
+    fun `deriveStrokeArgb clamps near-black fills above the floor`() {
+        // A near-black input would scale L to ~0; the clamp keeps the stroke
+        // visibly distinguishable from a very dark fill.
+        val nearBlack = 0xFF050505L
+        val derived = deriveStrokeArgb(nearBlack)
+        val (r, g, b) = derived.rgb()
+        // L=0.08 → mid-grey at ~20/255 per channel, allow +/- a few from the
+        // round-trip rounding.
+        meanOf(r, g, b) shouldBeGreaterThanOrEqual 16
+        meanOf(r, g, b) shouldBeLessThanOrEqual 25
+    }
+
+    @Test
+    fun `deriveStrokeArgb returns a Long that fits in 32 bits unsigned`() {
+        val derived = deriveStrokeArgb(0xFFFF0000L)
+        // No bits above the alpha byte — i.e. the Long is in the unsigned-Int range.
+        (derived ushr 32) shouldBe 0L
+    }
+}
+
+private fun Long.rgb(): Triple<Int, Int, Int> = Triple(
+    ((this ushr 16) and 0xFFL).toInt(),
+    ((this ushr 8) and 0xFFL).toInt(),
+    (this and 0xFFL).toInt(),
+)
+
+private fun meanOf(a: Int, b: Int, c: Int): Int = (a + b + c) / 3

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Settings.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Settings.kt
@@ -347,6 +347,25 @@ data class UserPreferences(
      * deuteranopia, protanopia, and tritanopia.
      */
     val colorPalette: ColorPalette = ColorPalette.RAINBOW,
+    /**
+     * User overrides for the fill colour of each top-garment icon (the
+     * shirt / sweater / jacket pictures shown on Today, the home-screen
+     * widget, and notification large icons). Keyed by [OutfitSuggestion.Top]
+     * since that's the rendered icon tier — `Garment` (the rule-list
+     * catalogue) has entries like `hoodie` and `shirt` that share an icon
+     * with `sweater` / `polo`, so colouring per icon is what matches the
+     * user's mental model of "the jacket icon."
+     *
+     * Stored as packed ARGB ([Int.toLong] of an ARGB int — a `Long` so the
+     * top byte's alpha doesn't sign-extend). A missing entry means "use the
+     * baked-in default colour from the XML," so existing installs read empty
+     * and render byte-identical to today. The stroke is auto-derived as a
+     * darker shade of the chosen fill at render time; only the fill is
+     * persisted.
+     */
+    val outfitTopColors: Map<OutfitSuggestion.Top, Long> = emptyMap(),
+    /** Sibling of [outfitTopColors] for the bottom-garment icons. */
+    val outfitBottomColors: Map<OutfitSuggestion.Bottom, Long> = emptyMap(),
 ) {
     companion object {
         const val DEFAULT_GEMINI_VOICE = "Despina"


### PR DESCRIPTION
## Summary

Adds a new **Garment colours** section to **Settings → Clothes** that lets you pick a fill colour for each rendered outfit icon (t-shirt, polo, sweater, thin / thick / puffer jacket, thick coat, shorts, long skirt, jeans, long pants). The picker is a curated 14-swatch grid plus a Default tile that clears the override; the icon's stroke is auto-derived as a darker shade of the chosen fill so the existing two-tone look survives the recolour.

Customised colours apply everywhere the icon renders — Today screen, Glance home-screen widget, and notification large icons. The default-colour render path is byte-identical to before, so users who don't customise see no visual change.

## Why this lives under Clothes settings

The customisation is keyed off `OutfitSuggestion.Top` / `.Bottom` (the icon catalogue the rules drive), not the catalogue-wide `Garment` enum or a global appearance preference like the chart palette. Settings → Clothes already hosts the rule list and the default-bottom picker; keeping the colour picker alongside them matches users' mental model of "what icon shows up on Today and how it looks."

## How recolour works

Each XML drawable's primary fill and stroke colours are recorded in a small constant table (`GarmentColors.kt`). At render time the user's chosen fill replaces every path matching the original primary fill, and the derived stroke replaces every path matching the original primary stroke. Accent paths (white puffer panels, sweater neckline trim, etc.) survive untouched.

- **Compose path (Today screen):** Canvas-based draw of the parsed `ImageVector`'s path data when a custom fill is set; the no-customisation branch falls through to the original `painterResource(Image)` so default-state snapshots stay byte-identical.
- **Bitmap path (widget `ImageProvider`, notification `setLargeIcon`):** same fork — `ResourcesCompat.getDrawable(...).toBitmap()` for defaults, `Canvas`-based recolour when customised. Bitmap renders are LRU-cached by `(drawable, fill, size)` so rapid widget refreshes don't re-rasterise.

## Persistence

Two new `Map<OutfitSuggestion.*, Long>` fields on `UserPreferences` (`outfitTopColors` / `outfitBottomColors`), JSON-serialised via two new DataStore preference keys. Stored as packed ARGB longs (the top byte's alpha doesn't sign-extend through the `Long` path). Forward-compat: unknown enum names in stored JSON drop silently on read, so a future-added `Top` variant won't crash older installs.

## Privacy

No change to what crosses the device boundary. Garment colour overrides live in DataStore Preferences only — they don't touch the insight prose fed to Gemini TTS, weather / geocoding requests, or Firebase telemetry. The renderer reads the user's choice on the device and applies it locally.

## Test plan

- [x] Pure-JVM unit tests for the HSL stroke-derivation maths (rebuilt as pure Kotlin so it works under the project's `unitTests.isReturnDefaultValues = true` config).
- [x] `SettingsRepositoryTest` round-trip tests for both colour maps, including null-clears-entry, unknown-enum-tolerance, and corrupt-JSON-falls-back-empty paths.
- [x] `:core:domain:test :core:data:test :app:testDebugUnitTest` — only the pre-existing locale-flake (`SettingsViewModelTest > initial state reflects repository defaults`, expected:&lt;CELSIUS&gt; but was:&lt;FAHRENHEIT&gt;, called out in `CLAUDE.md`) fails locally.
- [x] `:app:assembleDebug` succeeds.
- [x] Existing snapshot PNGs unchanged — the default-colour fast-path keeps byte-identity for non-customising users.
- [ ] Manual: Today screen → Settings → Clothes → Garment colours → pick a non-default colour for "Jacket" → confirm Today preview updates, widget updates, notification large icon updates after the next insight refresh.
- [ ] Manual: tap "Default" in the picker → confirm the garment reverts everywhere.

---
_Generated by [Claude Code](https://claude.ai/code/session_0138QJ1TMyMQPBGxX476pRkb)_