### PR TITLE
Show this period's window on page 1, next period's on page 2

### DIFF
--- a/app/src/main/kotlin/app/clothescast/data/InsightCache.kt
+++ b/app/src/main/kotlin/app/clothescast/data/InsightCache.kt
@@ -44,42 +44,67 @@ import java.time.LocalDateTime
 import java.time.LocalTime
 
 /**
- * Persists the most recently generated [Insight] so the daily worker can avoid
- * regenerating twice for the same day. The cache key is the insight's `forDate`
- * (LocalDate), which means two runs on the same calendar day reuse the same
- * insight even across process kills, reboots, or "Fire insight now" debug taps.
+ * Persists the most recently generated [Insight]s so the daily worker can avoid
+ * regenerating twice for the same day. The cache holds two slots:
+ *
+ *  - [Slot.THIS_PERIOD] — the insight covering the 12-hour window the user is
+ *    currently in (daytime in the morning, tonight in the evening). The Today
+ *    screen's pager surfaces this on page 1. May be a few hours old by the
+ *    time the user opens the app — the period itself is still "this one",
+ *    even if the bytes were generated at the period's start.
+ *  - [Slot.NEXT_PERIOD] — the insight pre-rendered for the next 12-hour window.
+ *    The morning alarm pre-renders tonight (same date); the evening alarm
+ *    pre-renders tomorrow's daytime. The Today screen's pager surfaces this
+ *    on page 2 so the "next" card always reads the next 12 hours, never the
+ *    previous one.
+ *
+ * The role-based naming keeps the pager logic trivial — page 1 shows
+ * [Slot.THIS_PERIOD], page 2 shows [Slot.NEXT_PERIOD] — and decouples the
+ * cache layout from the [ForecastPeriod] kind (which is recorded inside the
+ * stored insight).
  *
  * The cache stores the structured [InsightSummary] (each clause as typed data)
  * rather than rendered prose, so a Region-setting change re-renders the cached
  * insight in the new locale without re-fetching the forecast.
  *
- * The cache is intentionally a single slot per period — there's no historical
- * browsing planned, and bounding storage at 2 entries (TODAY + TONIGHT) keeps the
- * cost of corruption (deserialization failure → drop and regenerate) trivial.
+ * The cache is intentionally a single slot per role — there's no historical
+ * browsing planned, and bounding storage at 2 entries keeps the cost of
+ * corruption (deserialization failure → drop and regenerate) trivial.
  */
 class InsightCache(
     private val dataStore: DataStore<Preferences>,
     private val json: Json = Json { ignoreUnknownKeys = true },
 ) {
     /**
-     * The most recent insight written to the cache, regardless of period. The Today
-     * screen surfaces this so opening the app after the tonight alarm fired shows
-     * the tonight insight (the freshest read of what the user is about to walk
-     * into), while opening the app at noon still shows the morning insight.
+     * Which 12-hour window an insight occupies relative to the rendering surface:
+     * the window the user is currently inside ([THIS_PERIOD], page 1 of the pager
+     * / the home-screen widget) or the upcoming one ([NEXT_PERIOD], page 2).
+     * Stored in separate DataStore keys so the worker can overwrite each
+     * independently.
+     */
+    enum class Slot { THIS_PERIOD, NEXT_PERIOD }
+
+    /**
+     * The most recent insight written to either slot. The home-screen widget
+     * uses this to show whichever payload is freshest — opening it after the
+     * tonight alarm fired surfaces the tonight insight, while opening it at
+     * noon still surfaces the morning insight.
      */
     val latest: Flow<Insight?> = dataStore.data.map { prefs ->
         listOfNotNull(
-            prefs.readSlot(TODAY_INSIGHT_JSON),
-            prefs.readSlot(TONIGHT_INSIGHT_JSON),
+            prefs.readSlot(THIS_PERIOD_INSIGHT_JSON),
+            prefs.readSlot(NEXT_PERIOD_INSIGHT_JSON),
         ).maxByOrNull { it.generatedAt }
     }
 
-    fun latestForPeriod(period: ForecastPeriod): Flow<Insight?> = dataStore.data.map { prefs ->
-        prefs.readSlot(keyFor(period))
-    }
+    /** The insight on page 1 of the pager — the 12-hour window the user is currently in. */
+    val thisPeriod: Flow<Insight?> = dataStore.data.map { it.readSlot(THIS_PERIOD_INSIGHT_JSON) }
 
-    suspend fun store(insight: Insight) {
-        dataStore.edit { it[keyFor(insight.period)] = json.encodeToString(insight.toDto()) }
+    /** The insight on page 2 of the pager — the pre-rendered next 12-hour window. */
+    val nextPeriod: Flow<Insight?> = dataStore.data.map { it.readSlot(NEXT_PERIOD_INSIGHT_JSON) }
+
+    suspend fun store(slot: Slot, insight: Insight) {
+        dataStore.edit { it[keyFor(slot)] = json.encodeToString(insight.toDto()) }
     }
 
     /**
@@ -107,28 +132,32 @@ class InsightCache(
         defaultBottom: OutfitSuggestion.Bottom,
     ) {
         dataStore.edit { prefs ->
-            // Read both slots up front so TODAY's `nextOutfit` can borrow
-            // TONIGHT's hourly when re-deriving.
-            val todayInsight = prefs[TODAY_INSIGHT_JSON]?.let { decodeInsight(it) }
-            val tonightInsight = prefs[TONIGHT_INSIGHT_JSON]?.let { decodeInsight(it) }
-            // Only pair the slots when their forDate matches — during a morning
-            // settings edit, the TONIGHT slot may still be yesterday's evening
-            // insight while the TODAY slot is current. Rewriting today's
-            // `nextOutfit` from yesterday's overnight hourly would silently
-            // backdate the home-screen "Tonight" icon to last night's conditions
-            // (which already happened); preserving the existing `nextOutfit` is
-            // the honest choice until the next worker run rebuilds TONIGHT.
-            val tonightPair = tonightInsight?.takeIf { it.forDate == todayInsight?.forDate }
-            todayInsight?.recomputed(
+            // Read both slots up front so THIS_PERIOD's `nextOutfit` can
+            // borrow NEXT_PERIOD's hourly when re-deriving. NEXT_PERIOD's
+            // own `nextOutfit` has no peer to borrow from in the cache (we
+            // don't store a third slot), so it stays as whatever the worker
+            // last wrote.
+            val thisPeriodInsight = prefs[THIS_PERIOD_INSIGHT_JSON]?.let { decodeInsight(it) }
+            val nextPeriodInsight = prefs[NEXT_PERIOD_INSIGHT_JSON]?.let { decodeInsight(it) }
+            // Only borrow when NEXT_PERIOD actually represents the window
+            // that follows THIS_PERIOD's — opposite period kinds. After a
+            // healthy paired worker run this always holds; the guard
+            // protects against a partial-write degraded state where
+            // NEXT_PERIOD is left over from the previous worker run (same
+            // period kind, ~12 h stale).
+            val nextForBorrow = nextPeriodInsight?.takeIf {
+                it.period == thisPeriodInsight?.period?.opposite()
+            }
+            thisPeriodInsight?.recomputed(
                 clothesRules = clothesRules,
                 defaultBottom = defaultBottom,
-                nextSlot = tonightPair,
-            )?.let { prefs[TODAY_INSIGHT_JSON] = json.encodeToString(it.toDto()) }
-            tonightInsight?.recomputed(
+                nextSlot = nextForBorrow,
+            )?.let { prefs[THIS_PERIOD_INSIGHT_JSON] = json.encodeToString(it.toDto()) }
+            nextPeriodInsight?.recomputed(
                 clothesRules = clothesRules,
                 defaultBottom = defaultBottom,
                 nextSlot = null,
-            )?.let { prefs[TONIGHT_INSIGHT_JSON] = json.encodeToString(it.toDto()) }
+            )?.let { prefs[NEXT_PERIOD_INSIGHT_JSON] = json.encodeToString(it.toDto()) }
         }
     }
 
@@ -187,17 +216,28 @@ class InsightCache(
         )
     }
 
-    suspend fun forToday(today: LocalDate): Insight? = forPeriodToday(today, ForecastPeriod.TODAY)
-
-    suspend fun forPeriodToday(today: LocalDate, period: ForecastPeriod): Insight? {
-        val cached = latestForPeriod(period).first() ?: return null
-        return cached.takeIf { it.forDate == today }
+    /**
+     * The just-delivered insight matching [today] and [period], or null when
+     * the THIS_PERIOD slot holds nothing matching. Used by the worker to
+     * dedup "Fire insight now" debug taps against the same-day alarm — the
+     * second call redelivers the cached payload instead of burning another
+     * fetch.
+     *
+     * Only the THIS_PERIOD slot is consulted; the NEXT_PERIOD slot is a
+     * pre-render that hasn't been delivered yet, and dedup-matching against
+     * it would silently cause the morning alarm to redeliver yesterday-
+     * evening's pre-cached Saturday-daytime insight instead of fetching a
+     * fresh Saturday forecast.
+     */
+    suspend fun deliveredForToday(today: LocalDate, period: ForecastPeriod): Insight? {
+        val cached = thisPeriod.first() ?: return null
+        return cached.takeIf { it.forDate == today && it.period == period }
     }
 
     suspend fun clear() {
         dataStore.edit {
-            it.remove(TODAY_INSIGHT_JSON)
-            it.remove(TONIGHT_INSIGHT_JSON)
+            it.remove(THIS_PERIOD_INSIGHT_JSON)
+            it.remove(NEXT_PERIOD_INSIGHT_JSON)
         }
     }
 
@@ -206,10 +246,10 @@ class InsightCache(
         return runCatching { json.decodeFromString<InsightDto>(raw).toDomain() }.getOrNull()
     }
 
-    private fun keyFor(period: ForecastPeriod): androidx.datastore.preferences.core.Preferences.Key<String> =
-        when (period) {
-            ForecastPeriod.TODAY -> TODAY_INSIGHT_JSON
-            ForecastPeriod.TONIGHT -> TONIGHT_INSIGHT_JSON
+    private fun keyFor(slot: Slot): androidx.datastore.preferences.core.Preferences.Key<String> =
+        when (slot) {
+            Slot.THIS_PERIOD -> THIS_PERIOD_INSIGHT_JSON
+            Slot.NEXT_PERIOD -> NEXT_PERIOD_INSIGHT_JSON
         }
 
     @Serializable
@@ -609,13 +649,20 @@ class InsightCache(
     )
 
     companion object {
-        // Bumped when [Fact] swapped its `thresholdKind` enum for a free-form
-        // [Fact.ruleItem] string keyed to a [ClothesRule.item] — old payloads
-        // carried the enum name and the serializer can't infer a clothes-rule
-        // key from it. Old payloads are dropped on first read; the next worker
-        // run repopulates with the new schema.
-        private val TODAY_INSIGHT_JSON = stringPreferencesKey("latest_insight_v5")
-        private val TONIGHT_INSIGHT_JSON = stringPreferencesKey("latest_tonight_insight_v4")
+        // Bumped when the cache layout switched from period-keyed
+        // (TODAY / TONIGHT) slots to role-keyed (CURRENT / NEXT) slots so the
+        // pager can always show the current + next 12-hour window. Old
+        // period-keyed payloads stay readable from the legacy keys for one
+        // upgrade cycle; on the next worker run the new keys are populated
+        // and the legacy ones are dropped.
+        //
+        // The `_v6` suffix continues the existing schema-version pattern (the
+        // previous bump was `_v5` when [Fact] swapped its `thresholdKind` enum
+        // for a free-form [Fact.ruleItem] string), so any same-day-old cached
+        // payload with the previous shape is dropped on first read rather
+        // than silently misinterpreted.
+        private val THIS_PERIOD_INSIGHT_JSON = stringPreferencesKey("this_period_insight_v6")
+        private val NEXT_PERIOD_INSIGHT_JSON = stringPreferencesKey("next_period_insight_v6")
 
         fun create(context: Context): InsightCache = InsightCache(context.insightDataStore)
     }

--- a/app/src/main/kotlin/app/clothescast/diag/BugReport.kt
+++ b/app/src/main/kotlin/app/clothescast/diag/BugReport.kt
@@ -19,7 +19,6 @@ import androidx.core.content.FileProvider
 import app.clothescast.BuildConfig
 import app.clothescast.ClothesCastApplication
 import app.clothescast.core.domain.model.ClothesRule
-import app.clothescast.core.domain.model.ForecastPeriod
 import app.clothescast.core.domain.model.Insight
 import app.clothescast.core.domain.model.Region
 import app.clothescast.core.domain.model.UserPreferences
@@ -38,7 +37,7 @@ import kotlin.coroutines.resume
 
 /**
  * Builds a "paste-into-Claude" bug-report payload (version, device, settings,
- * the latest cached today + tonight ClothesCasts, recent log lines, last crash
+ * the latest cached this-period + next-period ClothesCasts, recent log lines, last crash
  * if any) and hands it off via [Intent.ACTION_SEND] so the share sheet can
  * deliver it to whichever app the user picks. Also drops the text on the
  * clipboard as a paste fallback.
@@ -64,11 +63,11 @@ object BugReport {
         val geminiKeyConfigured = runCatching {
             app.secureKeyStore.geminiKeyConfiguredFlow.first()
         }.getOrDefault(false)
-        val today = runCatching {
-            app.insightCache.latestForPeriod(ForecastPeriod.TODAY).first()
+        val thisPeriod = runCatching {
+            app.insightCache.thisPeriod.first()
         }.getOrNull()
-        val tonight = runCatching {
-            app.insightCache.latestForPeriod(ForecastPeriod.TONIGHT).first()
+        val nextPeriod = runCatching {
+            app.insightCache.nextPeriod.first()
         }.getOrNull()
         val crash = DiagLog.readPersistedCrash()
         val recent = DiagLog.snapshot()
@@ -98,8 +97,8 @@ object BugReport {
             appendLine()
             appendLine("--- Current ClothesCasts ---")
             val region = prefs?.region ?: Region.SYSTEM
-            appendInsight("Today (TODAY)", today, context, region)
-            appendInsight("Tonight (TONIGHT)", tonight, context, region)
+            appendInsight("This period", thisPeriod, context, region)
+            appendInsight("Next period", nextPeriod, context, region)
             if (!crash.isNullOrBlank()) {
                 appendLine("--- Last crash (from previous run) ---")
                 appendLine(crash.trim())

--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
@@ -315,16 +315,16 @@ private fun TodayContent(
                 LocationActionRequiredBanner(onSetUpLocation = onSetUpLocation)
             }
             WorkStatusBanner(status = workStatusToShow)
-            state.primaryInsight?.let { primary ->
+            state.thisPeriodInsight?.let { thisPeriod ->
                 OutfitPreviewRow(
-                    insight = primary,
+                    insight = thisPeriod,
                     temperatureUnit = state.temperatureUnit,
                     clothesRules = state.clothesRules,
                     onAdjustThreshold = onAdjustThreshold,
                 )
             }
         }
-        if (state.primaryInsight == null) {
+        if (state.thisPeriodInsight == null) {
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -334,9 +334,9 @@ private fun TodayContent(
                 EmptyState(onRefresh = onRefresh, isWorking = isWorking)
             }
         } else {
-            // Two-page pager — page 0 is the primary insight (the period
-            // that was "latest" before this change), page 1 is the paired
-            // period (or a placeholder when its slot hasn't been cached
+            // Two-page pager — page 0 is the this-period insight (the 12-hour
+            // window the user is currently in), page 1 is the next-period
+            // insight (or a placeholder when its slot hasn't been cached
             // yet). A chevron next to each page's InsightCard hints at
             // the affordance; side-swipe anywhere on the page navigates.
             //
@@ -351,14 +351,20 @@ private fun TodayContent(
             // scroll viewport matches the visible region.
             val pagerState = rememberPagerState(initialPage = 0) { 2 }
             val pagerScope = rememberCoroutineScope()
+            // Placeholder period for page 2 when its slot is empty —
+            // whatever the next 12-hour window after `thisPeriodInsight` is.
+            // The worker writes [InsightCache.Slot.NEXT_PERIOD] paired with
+            // each delivery, so this fallback only fires before the first
+            // post-upgrade worker run.
+            val nextPeriodFallback = state.thisPeriodInsight.period.opposite()
             HorizontalPager(
                 state = pagerState,
                 modifier = Modifier
                     .weight(1f)
                     .fillMaxWidth(),
             ) { page ->
-                val pageInsight = if (page == 0) state.primaryInsight else state.nextInsight
-                val pagePeriod = if (page == 0) state.primaryInsight.period else state.nextPeriod
+                val pageInsight = if (page == 0) state.thisPeriodInsight else state.nextPeriodInsight
+                val pagePeriod = if (page == 0) state.thisPeriodInsight.period else nextPeriodFallback
                 TodayPage(
                     insight = pageInsight,
                     fallbackPeriod = pagePeriod,

--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayViewModel.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayViewModel.kt
@@ -8,7 +8,6 @@ import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import app.clothescast.core.domain.model.ClothesRule
 import app.clothescast.core.domain.model.DistanceUnit
-import app.clothescast.core.domain.model.ForecastPeriod
 import app.clothescast.core.domain.model.Insight
 import app.clothescast.core.domain.model.Region
 import app.clothescast.core.domain.model.TemperatureUnit
@@ -26,23 +25,20 @@ import java.time.LocalTime
 
 data class TodayState(
     /**
-     * The insight shown on page 1 of the pager — whichever period's slot was
-     * most recently generated. Mirrors the previous `state.insight` contract
-     * so existing screen behaviour is unchanged on first open.
+     * The insight shown on page 1 of the pager — the 12-hour window the user
+     * is currently in. Backed by [InsightCache.thisPeriod], written by the
+     * worker on each alarm.
      */
-    val primaryInsight: Insight? = null,
+    val thisPeriodInsight: Insight? = null,
     /**
-     * The insight shown on page 2 of the pager — the paired period's cached
-     * slot, or `null` if the worker hasn't generated it yet. When null, the
-     * screen renders a `MissingPeriodPlaceholder` for `nextPeriod`.
+     * The insight shown on page 2 of the pager — the next 12-hour window
+     * (tonight on a morning alarm; tomorrow's daytime on an evening alarm).
+     * Backed by [InsightCache.nextPeriod], pre-rendered off the same fetch
+     * that produced `thisPeriodInsight`. Null when the worker hasn't run yet
+     * or the pre-render failed; the screen surfaces a
+     * [MissingPeriodPlaceholder] in that case.
      */
-    val nextInsight: Insight? = null,
-    /**
-     * Which period page 2 would show even when `nextInsight` is null — so the
-     * placeholder copy reads correctly the first time the user swipes to it.
-     * Always the opposite of `primaryInsight.period` when both are present.
-     */
-    val nextPeriod: ForecastPeriod = ForecastPeriod.TONIGHT,
+    val nextPeriodInsight: Insight? = null,
     val workStatus: WorkStatus = WorkStatus.Idle,
     val temperatureUnit: TemperatureUnit = TemperatureUnit.CELSIUS,
     val distanceUnit: DistanceUnit = DistanceUnit.KILOMETERS,
@@ -166,32 +162,6 @@ internal fun selectStatus(infos: List<WorkInfoLite>): WorkStatus {
  * ended in one. Comparing run-attempt counts across two unrelated unique-work
  * chains was the previous source of "old failure on the wrong chain wins".
  */
-/**
- * Picks which of the two cached insights is the "primary" (page 1) and which
- * is "next" (page 2). Tie-break: the one with the later `generatedAt` wins
- * primary, mirroring [InsightCache.latest]'s semantics so the screen's page-1
- * default doesn't drift from the pre-pager behaviour.
- *
- * Returns `Triple(primary, next, nextPeriod)`. `nextPeriod` is always the
- * *opposite* of `primary`'s period when primary exists; when both inputs are
- * null we default to TONIGHT so the empty-state path still has a sensible
- * placeholder period to surface.
- */
-internal fun pickPrimary(
-    today: Insight?,
-    tonight: Insight?,
-): Triple<Insight?, Insight?, ForecastPeriod> {
-    val todayAt = today?.generatedAt?.toEpochMilli() ?: Long.MIN_VALUE
-    val tonightAt = tonight?.generatedAt?.toEpochMilli() ?: Long.MIN_VALUE
-    return when {
-        today == null && tonight == null -> Triple(null, null, ForecastPeriod.TONIGHT)
-        today == null -> Triple(tonight, null, ForecastPeriod.TODAY)
-        tonight == null -> Triple(today, null, ForecastPeriod.TONIGHT)
-        tonightAt > todayAt -> Triple(tonight, today, ForecastPeriod.TODAY)
-        else -> Triple(today, tonight, ForecastPeriod.TONIGHT)
-    }
-}
-
 internal fun mergeWorkStatus(a: WorkStatus, b: WorkStatus): WorkStatus = when {
     a is WorkStatus.Running || b is WorkStatus.Running -> WorkStatus.Running
     a is WorkStatus.Retrying || b is WorkStatus.Retrying -> WorkStatus.Retrying
@@ -234,17 +204,15 @@ class TodayViewModel(
     }
 
     val state: StateFlow<TodayState> = combine(
-        insightCache.latestForPeriod(ForecastPeriod.TODAY),
-        insightCache.latestForPeriod(ForecastPeriod.TONIGHT),
+        insightCache.thisPeriod,
+        insightCache.nextPeriod,
         workStatusFlow,
         settingsRepository.preferences,
         showModelSpread,
-    ) { todayInsight, tonightInsight, workStatus, prefs, spread ->
-        val (primary, next, nextPeriod) = pickPrimary(todayInsight, tonightInsight)
+    ) { thisPeriodInsight, nextPeriodInsight, workStatus, prefs, spread ->
         TodayState(
-            primaryInsight = primary,
-            nextInsight = next,
-            nextPeriod = nextPeriod,
+            thisPeriodInsight = thisPeriodInsight,
+            nextPeriodInsight = nextPeriodInsight,
             workStatus = workStatus,
             temperatureUnit = prefs.temperatureUnit,
             distanceUnit = prefs.distanceUnit,

--- a/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
@@ -22,6 +22,7 @@ import app.clothescast.core.domain.model.Insight
 import app.clothescast.core.domain.model.Location
 import app.clothescast.core.domain.model.TtsEngine
 import app.clothescast.core.domain.model.UserPreferences
+import app.clothescast.data.InsightCache
 import app.clothescast.diag.Telemetry
 import app.clothescast.diag.classifyDailyRefreshReason
 import app.clothescast.insight.InsightFormatter
@@ -223,7 +224,7 @@ class FetchAndNotifyWorker(
             DiagLog.i(TAG, "Force refresh requested; bypassing today's cache.")
             null
         } else {
-            runCatching { app.insightCache.forPeriodToday(today, period) }.getOrNull()
+            runCatching { app.insightCache.deliveredForToday(today, period) }.getOrNull()
         }
         if (cached != null) {
             DiagLog.i(TAG, "Using cached $period insight for ${cached.forDate}.")
@@ -281,7 +282,7 @@ class FetchAndNotifyWorker(
                 runCatching { app.weatherAlertNotifier.notify(alert) }
                     .onFailure { DiagLog.w(TAG, "Severe alert notification failed for ${alert.event}.", it) }
             }
-            runCatching { app.insightCache.store(insight) }
+            runCatching { app.insightCache.store(InsightCache.Slot.THIS_PERIOD, insight) }
                 .onSuccess {
                     // Push the fresh outfit out to any home-screen widgets.
                     // Gated on cache success because provideGlance() reads
@@ -293,6 +294,27 @@ class FetchAndNotifyWorker(
                         .onFailure { DiagLog.w(TAG, "Outfit widget update failed.", it) }
                 }
                 .onFailure { DiagLog.w(TAG, "Insight cache write failed; not blocking delivery.", it) }
+            // Also generate and cache the *next* 12-hour window's insight off
+            // the same Open-Meteo bundle so the Today screen's pager always
+            // surfaces the current + next windows, never a previous one.
+            // CachingWeatherRepository keeps the bundle for 1h, so this is a
+            // re-render rather than a refetch — no extra network call, no
+            // extra Gemini call, no extra TTS.
+            //
+            // What "next" means depends on which alarm fired:
+            //  - Morning (period=TODAY): next is *tonight* of the same date
+            //    (the morning fetch already includes the tonight slice for
+            //    the evening tie-in).
+            //  - Evening (period=TONIGHT): next is *tomorrow's daytime*
+            //    (Open-Meteo's `forecast_days=2` response includes tomorrow's
+            //    full daily aggregates + hourly, so the day-after-the-alarm
+            //    window is fully covered).
+            //
+            // The pre-rendered insight goes into Slot.NEXT_PERIOD; dedup only
+            // consults Slot.THIS_PERIOD so the next morning's fresh fetch
+            // isn't suppressed by yesterday-evening's tomorrow-daytime
+            // pre-render.
+            generatePairedInsight(location, prefs, period)
             // Render once per delivery so notification, TTS, and the audit log
             // all share the same string and we don't reconfigure the
             // Configuration-overridden Resources three times per fire.
@@ -345,6 +367,46 @@ class FetchAndNotifyWorker(
         } catch (t: Throwable) {
             DiagLog.e(TAG, "Unhandled error; failing.", t)
             Result.failure(reason(REASON_UNHANDLED, summarize(t)))
+        }
+    }
+
+    /**
+     * Builds and caches the insight for the *next* 12-hour window after the
+     * one the current alarm is delivering, sharing the just-fetched Open-Meteo
+     * bundle via [app.clothescast.core.domain.repository.CachingWeatherRepository]'s
+     * in-memory cache so this is a re-render rather than a second network
+     * call.
+     *
+     * What "next" means depends on which alarm fired:
+     *  - Morning (`primaryPeriod = TODAY`): the next window is tonight of the
+     *    same date — generated with `dayOffset = 0`, `period = TONIGHT`.
+     *  - Evening (`primaryPeriod = TONIGHT`): the next window is tomorrow's
+     *    daytime — generated with `dayOffset = 1`, `period = TODAY`. The
+     *    bundle's `forecast_days=2` response carries tomorrow's full daily
+     *    aggregates + hourly, so no extra fetch is needed.
+     *
+     * Silent — no notification, no TTS, no widget update. Failures are
+     * logged and swallowed; the Today screen's pager falls back to its
+     * placeholder for the NEXT_PERIOD slot in that case.
+     */
+    private suspend fun generatePairedInsight(
+        location: Location,
+        prefs: UserPreferences,
+        primaryPeriod: ForecastPeriod,
+    ) {
+        val nextWindowPeriod = when (primaryPeriod) {
+            ForecastPeriod.TODAY -> ForecastPeriod.TONIGHT
+            ForecastPeriod.TONIGHT -> ForecastPeriod.TODAY
+        }
+        val dayOffset = if (primaryPeriod == ForecastPeriod.TONIGHT) 1 else 0
+        runCatching {
+            val result = app.generateDailyInsight(location, prefs, nextWindowPeriod, dayOffset)
+            val pairedInsight = result.insight.copy(location = location)
+            app.insightCache.store(InsightCache.Slot.NEXT_PERIOD, pairedInsight)
+            DiagLog.i(TAG, "Next-window $nextWindowPeriod insight cached for ${pairedInsight.forDate}.")
+        }.onFailure {
+            if (it is CancellationException) throw it
+            DiagLog.w(TAG, "Next-window $nextWindowPeriod insight generation failed; not blocking $primaryPeriod delivery.", it)
         }
     }
 

--- a/app/src/test/kotlin/app/clothescast/data/InsightCacheTest.kt
+++ b/app/src/test/kotlin/app/clothescast/data/InsightCacheTest.kt
@@ -131,29 +131,50 @@ class InsightCacheTest {
 
     @Test
     fun `store then latest round-trips all fields`() = runTest {
-        subject.store(sample)
+        subject.store(InsightCache.Slot.THIS_PERIOD, sample)
 
         val read = subject.latest.first()
         read shouldBe sample
     }
 
     @Test
-    fun `forToday returns the cached insight when forDate matches`() = runTest {
-        subject.store(sample)
+    fun `deliveredForToday returns the cached insight when forDate and period match`() = runTest {
+        subject.store(InsightCache.Slot.THIS_PERIOD, sample)
 
-        subject.forToday(today) shouldBe sample
+        subject.deliveredForToday(today, sample.period) shouldBe sample
     }
 
     @Test
-    fun `forToday returns null when the cached insight is for a different day`() = runTest {
-        subject.store(sample)
+    fun `deliveredForToday returns null when the cached insight is for a different day`() = runTest {
+        subject.store(InsightCache.Slot.THIS_PERIOD, sample)
 
-        subject.forToday(today.plusDays(1)) shouldBe null
+        subject.deliveredForToday(today.plusDays(1), sample.period) shouldBe null
+    }
+
+    @Test
+    fun `deliveredForToday returns null when the cached insight is for a different period`() = runTest {
+        // The morning alarm fires for TODAY; if THIS_PERIOD holds a TONIGHT
+        // insight (e.g. last night's evening delivery), the dedup check
+        // misses and the worker refetches — fresh forecast instead of
+        // redelivering yesterday's payload.
+        subject.store(InsightCache.Slot.THIS_PERIOD, sample.copy(period = ForecastPeriod.TONIGHT))
+
+        subject.deliveredForToday(today, ForecastPeriod.TODAY) shouldBe null
+    }
+
+    @Test
+    fun `deliveredForToday ignores the NEXT_PERIOD slot`() = runTest {
+        // The morning alarm shouldn't dedup against yesterday-evening's
+        // pre-cached tomorrow-daytime insight in NEXT_PERIOD; otherwise it
+        // would silently redeliver 12-hour-old forecast data.
+        subject.store(InsightCache.Slot.NEXT_PERIOD, sample)
+
+        subject.deliveredForToday(today, sample.period) shouldBe null
     }
 
     @Test
     fun `clear removes the stored insight`() = runTest {
-        subject.store(sample)
+        subject.store(InsightCache.Slot.THIS_PERIOD, sample)
         subject.clear()
 
         subject.latest.first() shouldBe null
@@ -162,7 +183,7 @@ class InsightCacheTest {
     @Test
     fun `corrupt JSON in the slot maps to null rather than crashing`() = runTest {
         dataStore.edit {
-            it[stringPreferencesKey("latest_insight_v5")] = "{not valid json"
+            it[stringPreferencesKey("this_period_insight_v6")] = "{not valid json"
         }
 
         subject.latest.first() shouldBe null
@@ -187,7 +208,7 @@ class InsightCacheTest {
         dataStore.edit {
             // v5 key, v2-shaped payload — the decoder fails on the `summary`
             // field and the runCatching in the cache returns null.
-            it[stringPreferencesKey("latest_insight_v5")] = v2Json
+            it[stringPreferencesKey("this_period_insight_v6")] = v2Json
         }
 
         subject.latest.first() shouldBe null
@@ -213,7 +234,7 @@ class InsightCacheTest {
         )
         val withHourly = sample.copy(hourly = hourly)
 
-        subject.store(withHourly)
+        subject.store(InsightCache.Slot.THIS_PERIOD, withHourly)
 
         subject.latest.first() shouldBe withHourly
     }
@@ -251,7 +272,7 @@ class InsightCacheTest {
             outfitRationale = rationale,
         )
 
-        subject.store(withRationale)
+        subject.store(InsightCache.Slot.THIS_PERIOD, withRationale)
 
         subject.latest.first() shouldBe withRationale
     }
@@ -266,7 +287,7 @@ class InsightCacheTest {
             ),
         )
 
-        subject.store(withLocation)
+        subject.store(InsightCache.Slot.THIS_PERIOD, withLocation)
 
         subject.latest.first() shouldBe withLocation
     }
@@ -292,7 +313,7 @@ class InsightCacheTest {
             }
         """.trimIndent()
         dataStore.edit {
-            it[stringPreferencesKey("latest_insight_v5")] = minimalJson
+            it[stringPreferencesKey("this_period_insight_v6")] = minimalJson
         }
 
         val read = subject.latest.first()
@@ -324,7 +345,7 @@ class InsightCacheTest {
             ),
         )
 
-        subject.store(full)
+        subject.store(InsightCache.Slot.THIS_PERIOD, full)
 
         subject.latest.first() shouldBe full
     }
@@ -346,7 +367,7 @@ class InsightCacheTest {
             ),
         )
 
-        subject.store(bareRain)
+        subject.store(InsightCache.Slot.THIS_PERIOD, bareRain)
 
         val tie = subject.latest.first()?.summary?.eveningEventTieIn
         tie?.items shouldBe emptyList()
@@ -377,7 +398,7 @@ class InsightCacheTest {
             }
         """.trimIndent()
         dataStore.edit {
-            it[stringPreferencesKey("latest_insight_v5")] = legacyJson
+            it[stringPreferencesKey("this_period_insight_v6")] = legacyJson
         }
 
         val tie = subject.latest.first()?.summary?.eveningEventTieIn
@@ -413,7 +434,7 @@ class InsightCacheTest {
             hourly = hourly,
             outfit = OutfitSuggestion(OutfitSuggestion.Top.SWEATER, OutfitSuggestion.Bottom.LONG_PANTS),
         )
-        subject.store(stored)
+        subject.store(InsightCache.Slot.THIS_PERIOD, stored)
 
         subject.recomputeOutfits(ClothesRule.DEFAULTS, OutfitSuggestion.Bottom.JEANS)
 
@@ -455,12 +476,12 @@ class InsightCacheTest {
             hourly = mildHourly,
             outfit = OutfitSuggestion(OutfitSuggestion.Top.SWEATER, OutfitSuggestion.Bottom.LONG_PANTS),
         )
-        subject.store(todayInsight)
-        subject.store(tonightInsight)
+        subject.store(InsightCache.Slot.THIS_PERIOD, todayInsight)
+        subject.store(InsightCache.Slot.NEXT_PERIOD, tonightInsight)
 
         subject.recomputeOutfits(ClothesRule.DEFAULTS, OutfitSuggestion.Bottom.JEANS)
 
-        val refreshedToday = subject.forPeriodToday(today, ForecastPeriod.TODAY)
+        val refreshedToday = subject.deliveredForToday(today, ForecastPeriod.TODAY)
         refreshedToday?.outfit?.bottom shouldBe OutfitSuggestion.Bottom.JEANS
         refreshedToday?.nextOutfit?.bottom shouldBe OutfitSuggestion.Bottom.JEANS
     }
@@ -482,6 +503,7 @@ class InsightCacheTest {
         )
         val storedNext = OutfitSuggestion(OutfitSuggestion.Top.SWEATER, OutfitSuggestion.Bottom.LONG_PANTS)
         subject.store(
+            InsightCache.Slot.THIS_PERIOD,
             sample.copy(
                 period = ForecastPeriod.TODAY,
                 hourly = mildHourly,
@@ -492,20 +514,21 @@ class InsightCacheTest {
 
         subject.recomputeOutfits(ClothesRule.DEFAULTS, OutfitSuggestion.Bottom.JEANS)
 
-        val refreshed = subject.forPeriodToday(today, ForecastPeriod.TODAY)
+        val refreshed = subject.deliveredForToday(today, ForecastPeriod.TODAY)
         refreshed?.outfit?.bottom shouldBe OutfitSuggestion.Bottom.JEANS
         refreshed?.nextOutfit shouldBe storedNext
     }
 
     @Test
-    fun `recomputeOutfits preserves todays nextOutfit when tonight slot is from a previous day`() = runTest {
-        // Morning settings edit: the TODAY slot was rewritten by the morning
-        // worker (forDate = today), but the TONIGHT slot is still yesterday
-        // evening's insight (forDate = yesterday). Borrowing the stale TONIGHT
-        // hourly to rewrite today's `nextOutfit` would silently backdate the
-        // home-screen "Tonight" icon to last night's conditions — which have
-        // already happened. The date guard preserves the existing nextOutfit
-        // and lets the next TONIGHT worker run repair it properly.
+    fun `recomputeOutfits preserves nextOutfit when NEXT_PERIOD slot has the same period kind as THIS_PERIOD`() = runTest {
+        // A partial-write degraded state: the morning worker wrote
+        // THIS_PERIOD (today daytime) but the paired NEXT_PERIOD write
+        // failed, so NEXT_PERIOD still holds yesterday-evening's paired
+        // write (also a daytime insight, ~12 h stale). Borrowing the
+        // stale daytime hourly to rewrite today's `nextOutfit` (which
+        // represents *tonight*) would mis-describe the upcoming window —
+        // the opposite-period guard preserves the existing `nextOutfit`
+        // until the next worker run repairs the pairing.
         val todayHourly = listOf(
             HourlyForecast(
                 time = LocalTime.of(7, 0),
@@ -515,12 +538,13 @@ class InsightCacheTest {
                 condition = WeatherCondition.CLEAR,
             ),
         )
-        // Yesterday's overnight was cold — if we mis-pair this with today's
-        // TODAY slot we'd compute a colder `nextOutfit` than today's actual
-        // upcoming evening warrants.
-        val yesterdayOvernightHourly = listOf(
+        // Yesterday's stale daytime hourly — if we mis-pair this with
+        // today's THIS_PERIOD slot's `nextOutfit` (which represents
+        // *tonight*) we'd describe an evening's clothes off morning
+        // weather data.
+        val stalePairedHourly = listOf(
             HourlyForecast(
-                time = LocalTime.of(21, 0),
+                time = LocalTime.of(12, 0),
                 temperatureC = 2.0,
                 feelsLikeC = 0.0,
                 precipitationProbabilityPct = 5.0,
@@ -529,6 +553,7 @@ class InsightCacheTest {
         )
         val storedNext = OutfitSuggestion(OutfitSuggestion.Top.SWEATER, OutfitSuggestion.Bottom.LONG_PANTS)
         subject.store(
+            InsightCache.Slot.THIS_PERIOD,
             sample.copy(
                 period = ForecastPeriod.TODAY,
                 forDate = today,
@@ -538,20 +563,24 @@ class InsightCacheTest {
             ),
         )
         subject.store(
+            InsightCache.Slot.NEXT_PERIOD,
             sample.copy(
-                period = ForecastPeriod.TONIGHT,
+                // Same period kind as THIS_PERIOD — partial-paired-write
+                // signature. Should NOT be borrowed for THIS_PERIOD's
+                // nextOutfit.
+                period = ForecastPeriod.TODAY,
                 forDate = today.minusDays(1),
-                hourly = yesterdayOvernightHourly,
+                hourly = stalePairedHourly,
                 outfit = OutfitSuggestion(OutfitSuggestion.Top.THICK_COAT, OutfitSuggestion.Bottom.LONG_PANTS),
             ),
         )
 
         subject.recomputeOutfits(ClothesRule.DEFAULTS, OutfitSuggestion.Bottom.JEANS)
 
-        val refreshed = subject.forPeriodToday(today, ForecastPeriod.TODAY)
+        val refreshed = subject.deliveredForToday(today, ForecastPeriod.TODAY)
         refreshed?.outfit?.bottom shouldBe OutfitSuggestion.Bottom.JEANS
-        // nextOutfit preserved verbatim — not silently rebuilt from yesterday's
-        // overnight data.
+        // nextOutfit preserved verbatim — not silently rebuilt from the
+        // same-period-kind partial-write leftover.
         refreshed?.nextOutfit shouldBe storedNext
     }
 
@@ -562,6 +591,7 @@ class InsightCacheTest {
         // last written and refreshes on the next worker run.
         val storedBottom = OutfitSuggestion.Bottom.LONG_PANTS
         subject.store(
+            InsightCache.Slot.THIS_PERIOD,
             sample.copy(
                 hourly = emptyList(),
                 outfit = OutfitSuggestion(OutfitSuggestion.Top.SWEATER, storedBottom),
@@ -585,7 +615,7 @@ class InsightCacheTest {
             ),
         )
 
-        subject.store(possible)
+        subject.store(InsightCache.Slot.THIS_PERIOD, possible)
 
         subject.latest.first()?.summary?.precip?.likelihood shouldBe PrecipLikelihood.POSSIBLE
     }

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/ForecastPeriod.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/ForecastPeriod.kt
@@ -12,4 +12,15 @@ package app.clothescast.core.domain.model
  *    The summary leads with "Tonight will be …" and the clothes / outfit reflect
  *    the actual overnight low.
  */
-enum class ForecastPeriod { TODAY, TONIGHT }
+enum class ForecastPeriod {
+    TODAY, TONIGHT;
+
+    /**
+     * The other period kind. Used by the Today screen's pager to pick the
+     * placeholder copy for page 2 when its cache slot is empty.
+     */
+    fun opposite(): ForecastPeriod = when (this) {
+        TODAY -> TONIGHT
+        TONIGHT -> TODAY
+    }
+}

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsight.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsight.kt
@@ -56,8 +56,27 @@ class GenerateDailyInsight(
         location: Location,
         prefs: UserPreferences,
         period: ForecastPeriod = ForecastPeriod.TODAY,
+        // Which day's window the caller wants generated. 0 == today (the
+        // default; the user-facing alarm path), 1 == tomorrow. The evening
+        // alarm uses `dayOffset = 1` with `period = TODAY` to pre-render
+        // tomorrow's daytime insight for the Today screen's "next" card —
+        // Open-Meteo's `forecast_days=2` response already carries tomorrow's
+        // daily aggregates and hourly, so no extra fetch is needed. Only
+        // `(TODAY, 1)` is supported — there's no day-after-tomorrow data in
+        // the bundle to wrap a tomorrow-tonight window around.
+        dayOffset: Int = 0,
     ): DailyInsightResult {
-        val bundle = weatherRepository.fetchForecast(location)
+        require(dayOffset == 0 || (dayOffset == 1 && period == ForecastPeriod.TODAY)) {
+            "Only same-day (dayOffset=0) and tomorrow-daytime (dayOffset=1, period=TODAY) generation are supported."
+        }
+        val fetched = weatherRepository.fetchForecast(location)
+        val bundle = if (dayOffset == 1) {
+            requireNotNull(fetched.shiftedToTomorrow()) {
+                "Bundle has no tomorrow forecast; cannot generate next-day insight (was the fetch a forecast_days=1 response?)."
+            }
+        } else {
+            fetched
+        }
         val activeAlerts = bundle.alerts.filter { it.expires.isAfter(clock.instant()) }
         val morningStart = prefs.schedule.time
         val tonightStart = prefs.tonightSchedule.time
@@ -315,6 +334,31 @@ class GenerateDailyInsight(
         val perModelForRender: PerModelHourly?,
         val deltaToday: DailyForecast,
         val deltaYesterday: DailyForecast,
+    )
+}
+
+/**
+ * Returns a view of this bundle with tomorrow promoted to today. Used by the
+ * evening worker's "next" pre-render path: the same fetch covers both the
+ * tonight window the alarm is delivering *and* the tomorrow-daytime window
+ * the Today screen's pager will show on page 2. Returns null when the bundle
+ * has no tomorrow data (legacy `forecast_days=1` fixtures); the caller drops
+ * the next-card pre-render rather than fabricate data.
+ *
+ * Yesterday becomes today's daily forecast so the delta clause still has an
+ * apples-to-apples comparison (tomorrow vs. today). The `tomorrow` and
+ * `tomorrowHourly` fields drop to empty — we don't have day-after-tomorrow
+ * data, so a hypothetical tonight-period generation off the shifted bundle
+ * would lose its overnight wrap; that's why the public `dayOffset=1` path is
+ * gated to TODAY-period only.
+ */
+private fun ForecastBundle.shiftedToTomorrow(): ForecastBundle? {
+    val tmrw = tomorrow ?: return null
+    return copy(
+        today = tmrw,
+        yesterday = today,
+        tomorrow = null,
+        tomorrowHourly = emptyList(),
     )
 }
 


### PR DESCRIPTION
## Summary

The Today screen's pager pairs the TODAY and TONIGHT cache slots, but those slots used to refresh on independent worker alarms — TODAY in the morning, TONIGHT in the evening. Between the two runs the paired slot held *yesterday's* period: on Friday morning the next card labelled itself "Thursday", and in the evening the cards never reached into the following day so the next card stayed on the already-ended daytime window.

Rework the cache so each worker run populates both windows the pager shows:

- **Cache slots renamed from period-keyed (`TODAY` / `TONIGHT`) to role-keyed (`THIS_PERIOD` / `NEXT_PERIOD`).** The new naming captures what the pager actually wants: the 12-hour window the user is in, and the one after it. Keys bump to `_v6` so legacy payloads are dropped on first read (next worker run repopulates).

- **`GenerateDailyInsight` gains a `dayOffset` parameter** so the evening worker can re-render off `bundle.tomorrow` for the next-period pre-cache without a second network call — Open-Meteo's `forecast_days=2` response already carries it. Only `(TODAY, dayOffset=1)` is supported; the bundle has no day-after-tomorrow data to wrap a tomorrow-tonight window around.

- **`FetchAndNotifyWorker`** now writes the just-delivered insight to `Slot.THIS_PERIOD` and the *next* 12-hour window's insight to `Slot.NEXT_PERIOD`:
  - Morning (`period=TODAY`): `NEXT_PERIOD` = tonight of the same date.
  - Evening (`period=TONIGHT`): `NEXT_PERIOD` = tomorrow's daytime.
  
  `CachingWeatherRepository` keeps the bundle for 1h, so the second pass is a re-render rather than a refetch — no extra network call, no extra Gemini call, no extra TTS, no extra widget update.

- **Dedup (`deliveredForToday`) now consults `Slot.THIS_PERIOD` only**; matching against `NEXT_PERIOD` would silently redeliver yesterday-evening's pre-cached Saturday-daytime insight on Saturday morning instead of refetching.

- **`TodayViewModel.pickPrimary` is gone.** The pager reads `insightCache.thisPeriod` and `insightCache.nextPeriod` directly; the role-based naming does the disambiguation at write time. TodayState fields are `thisPeriodInsight` / `nextPeriodInsight`.

- **`recomputeOutfits` only borrows the NEXT_PERIOD slot's hourly when its period kind is the opposite of THIS_PERIOD's** — defensive guard against a partial-paired-write degraded state where NEXT_PERIOD is left over from the previous worker run.

## Privacy

No change to what leaves the device. The paired-period generation reuses the existing Open-Meteo bundle and runs through the same `GenerateDailyInsight` use case as the primary period; no new outbound requests, no new TTS calls, no new payload fields.

## Test plan

- [x] `:core:domain:test`, `:core:data:test`, `:app:testDebugUnitTest` pass locally
- [x] `:app:assembleDebug` builds locally
- [x] `InsightCacheTest` updated for slot-based API plus new cases (`deliveredForToday` ignores `NEXT_PERIOD`; `recomputeOutfits` opposite-period guard)
- [ ] Manual verification on device: Friday morning shows Friday-day on page 1 + Friday-tonight on page 2; Friday evening shows Friday-tonight on page 1 + Saturday-day on page 2
