### PR TITLE
Scroll past outfit cards to see more charts

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
@@ -285,16 +285,18 @@ private fun TodayContent(
             .fillMaxSize()
             .padding(padding),
     ) {
-        // Pinned header — banners + outfit row. Outside the pager so the
-        // outfit row's at-a-glance today+tonight icons stay visible
-        // regardless of which page is in view, and so critical banners
-        // (update available, crash report, telemetry notice, location
-        // required, work status) aren't duplicated per page.
+        // Pinned header — banners only. Outside the pager so critical
+        // banners (update available, crash report, telemetry notice,
+        // location required, work status) aren't duplicated per page.
+        // The outfit row used to live here too, but it pinned a lot of
+        // vertical space at the top regardless of which page was in
+        // view; it now scrolls with each page (rendered inside TodayPage
+        // below) so more chart cards fit in a single screen of scroll.
         //
-        // First in the stack on purpose: a stale build is the upstream
-        // cause of many bug reports, so giving the user the chance to
-        // update before they notice anything else is the highest-leverage
-        // placement.
+        // UpdateAvailableBanner is first on purpose: a stale build is
+        // the upstream cause of many bug reports, so giving the user
+        // the chance to update before they notice anything else is the
+        // highest-leverage placement.
         Column(
             modifier = Modifier
                 .fillMaxWidth()
@@ -315,16 +317,6 @@ private fun TodayContent(
                 LocationActionRequiredBanner(onSetUpLocation = onSetUpLocation)
             }
             WorkStatusBanner(status = workStatusToShow)
-            state.thisPeriodInsight?.let { thisPeriod ->
-                OutfitPreviewRow(
-                    insight = thisPeriod,
-                    temperatureUnit = state.temperatureUnit,
-                    clothesRules = state.clothesRules,
-                    outfitTopColors = state.outfitTopColors,
-                    outfitBottomColors = state.outfitBottomColors,
-                    onAdjustThreshold = onAdjustThreshold,
-                )
-            }
         }
         if (state.thisPeriodInsight == null) {
             Column(
@@ -371,6 +363,11 @@ private fun TodayContent(
                     insight = pageInsight,
                     fallbackPeriod = pagePeriod,
                     state = state,
+                    // Same outfit row on both pages — page 2 shows this
+                    // period's pair too, not the page-2 period's pair. We
+                    // don't surface a 3rd period (tomorrow) on page 2; the
+                    // outfit row stays the at-a-glance today+tonight summary.
+                    outfitInsight = state.thisPeriodInsight,
                     showChevronRight = (page == 0),
                     showChevronLeft = (page == 1),
                     onChevronTap = {
@@ -378,6 +375,7 @@ private fun TodayContent(
                             pagerState.animateScrollToPage(if (page == 0) 1 else 0)
                         }
                     },
+                    onAdjustThreshold = onAdjustThreshold,
                     onToggleModelSpread = onToggleModelSpread,
                 )
             }
@@ -400,9 +398,11 @@ private fun TodayPage(
     insight: Insight?,
     fallbackPeriod: ForecastPeriod,
     state: TodayState,
+    outfitInsight: Insight,
     showChevronRight: Boolean,
     showChevronLeft: Boolean,
     onChevronTap: () -> Unit,
+    onAdjustThreshold: (String, Double) -> Unit,
     onToggleModelSpread: () -> Unit,
 ) {
     Column(
@@ -413,6 +413,19 @@ private fun TodayPage(
             .padding(bottom = 24.dp),
         verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
+        // Outfit row sits above the null-insight short-circuit so it
+        // also renders on page 2 when [insight] (the next-period
+        // insight) is null and we fall back to MissingPeriodPlaceholder.
+        // [outfitInsight] is always this period's insight, so this is
+        // independent of whether the page's own insight is cached yet.
+        OutfitPreviewRow(
+            insight = outfitInsight,
+            temperatureUnit = state.temperatureUnit,
+            clothesRules = state.clothesRules,
+            outfitTopColors = state.outfitTopColors,
+            outfitBottomColors = state.outfitBottomColors,
+            onAdjustThreshold = onAdjustThreshold,
+        )
         if (insight == null) {
             MissingPeriodPlaceholder(
                 period = fallbackPeriod,


### PR DESCRIPTION
## Summary

The outfit cards row (today + tonight icons) used to sit in a **pinned header** above the `HorizontalPager`, so it stayed glued to the top of the viewport on every page and at every scroll position — pushing every chart card down by ~150 dp on the first screen of each page.

Move `OutfitPreviewRow` into each `TodayPage`'s vertical-scroll `Column` so it scrolls with the rest of the page. More charts now fit in a single screen of scroll.

## What changed

- `OutfitPreviewRow` moves out of the pinned header in `TodayContent` and into the top of each `TodayPage`'s scroll Column.
- Both pages render the **same** Today + Tonight pair (driven by `state.thisPeriodInsight`); we don't surface a 3rd period (Tomorrow) on page 2. The user explicitly opted into this redundancy in exchange for chart space.
- Each page's `InsightCard` / `ConfidenceChip` / chart stack still shows its own period — page 1 = this period's prose, page 2 = next period's prose. Only the outfit row is shared.
- The outfit row is rendered **above** the null-insight short-circuit inside `TodayPage`, so page 2 still shows it when `state.nextPeriodInsight` is null and the page falls back to `MissingPeriodPlaceholder`. `outfitInsight` is always `state.thisPeriodInsight`, guaranteed non-null when the pager renders.
- Banners (`UpdateAvailableBanner`, `LocalBuildBanner`, `LastCrashBanner`, `TelemetryNoticeBanner`, `LocationActionRequiredBanner`, `WorkStatusBanner`) **stay pinned** in the header — their non-duplication rationale still applies.
- `EmptyState` branch (no this-period insight) unchanged.

## Privacy

No data crosses the device boundary as part of this change — pure UI layout.

## Test plan

- [x] Rebased onto `main` after #462 / #463 landed (renamed `primaryInsight` → `thisPeriodInsight`, added `nextPeriodInsight`); resolved the conflict in `TodayContent` so the outfit row stays out of the pinned header.
- [x] `./gradlew :app:testDebugUnitTest` passes locally (3m48s).
- [ ] CI: `JVM unit tests` and `Android debug build` green; snapshot regen commit lands and image diffs are posted inline.
- [ ] Manual on device/emulator:
  - [ ] Page 1 (this period): outfit cards visible at top; scroll down and the cards scroll out of view, exposing more chart cards than before.
  - [ ] Swipe to page 2 (next period): the **same** Today + Tonight outfit pair appears at the top of page 2; page scrolls vertically; `InsightCard` below the outfit row is page-2-specific prose.
  - [ ] Tap an outfit card on page 2: rationale dialog opens with the same content as on page 1.
  - [ ] When `state.nextPeriodInsight` is null: page 2 still shows the outfit row at top, followed by `MissingPeriodPlaceholder`.
  - [ ] Trigger a banner (e.g. revoke location → `LocationActionRequiredBanner`): banner still pins above the pager and is not duplicated per page.
  - [ ] Empty state (no this-period insight): unchanged — `EmptyState` renders in place of the pager.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JTXXLNLNUFFkFEm3pp7b8a)_