### PR TITLE
Fix widget showing next-period card instead of current one

### DIFF
--- a/app/src/main/kotlin/app/clothescast/data/InsightCache.kt
+++ b/app/src/main/kotlin/app/clothescast/data/InsightCache.kt
@@ -84,19 +84,6 @@ class InsightCache(
      */
     enum class Slot { THIS_PERIOD, NEXT_PERIOD }
 
-    /**
-     * The most recent insight written to either slot. The home-screen widget
-     * uses this to show whichever payload is freshest — opening it after the
-     * tonight alarm fired surfaces the tonight insight, while opening it at
-     * noon still surfaces the morning insight.
-     */
-    val latest: Flow<Insight?> = dataStore.data.map { prefs ->
-        listOfNotNull(
-            prefs.readSlot(THIS_PERIOD_INSIGHT_JSON),
-            prefs.readSlot(NEXT_PERIOD_INSIGHT_JSON),
-        ).maxByOrNull { it.generatedAt }
-    }
-
     /** The insight on page 1 of the pager — the 12-hour window the user is currently in. */
     val thisPeriod: Flow<Insight?> = dataStore.data.map { it.readSlot(THIS_PERIOD_INSIGHT_JSON) }
 

--- a/app/src/main/kotlin/app/clothescast/widget/OutfitWidget.kt
+++ b/app/src/main/kotlin/app/clothescast/widget/OutfitWidget.kt
@@ -74,10 +74,12 @@ class OutfitWidget : GlanceAppWidget() {
     override suspend fun provideGlance(context: Context, id: GlanceId) {
         val app = context.applicationContext as ClothesCastApplication
         // Read once on each provideGlance() pass — the worker calls updateAll()
-        // after writing to the cache, which re-invokes this function. The flow
-        // emits the freshest of the two cached periods (TODAY / TONIGHT), which
-        // is the same "what's relevant right now" choice the Today screen makes.
-        val insight = runCatching { app.insightCache.latest.first() }.getOrNull()
+        // after writing to the cache, which re-invokes this function. We read
+        // THIS_PERIOD specifically (not "freshest of either slot") because
+        // NEXT_PERIOD is a pre-render of the upcoming window — taking the
+        // newer-generated-at would surface "Tonight" while the user is still
+        // in the daytime window the morning worker just delivered.
+        val insight = runCatching { app.insightCache.thisPeriod.first() }.getOrNull()
         // Per-garment colour overrides — empty when the user hasn't customised.
         // Pulled here (not inside the Composable) so the bitmap rasterizer can
         // run on this dispatcher rather than during composition.

--- a/app/src/test/kotlin/app/clothescast/data/InsightCacheTest.kt
+++ b/app/src/test/kotlin/app/clothescast/data/InsightCacheTest.kt
@@ -125,15 +125,15 @@ class InsightCacheTest {
     }
 
     @Test
-    fun `latest is null when nothing stored`() = runTest {
-        subject.latest.first() shouldBe null
+    fun `thisPeriod is null when nothing stored`() = runTest {
+        subject.thisPeriod.first() shouldBe null
     }
 
     @Test
-    fun `store then latest round-trips all fields`() = runTest {
+    fun `store then thisPeriod round-trips all fields`() = runTest {
         subject.store(InsightCache.Slot.THIS_PERIOD, sample)
 
-        val read = subject.latest.first()
+        val read = subject.thisPeriod.first()
         read shouldBe sample
     }
 
@@ -177,7 +177,7 @@ class InsightCacheTest {
         subject.store(InsightCache.Slot.THIS_PERIOD, sample)
         subject.clear()
 
-        subject.latest.first() shouldBe null
+        subject.thisPeriod.first() shouldBe null
     }
 
     @Test
@@ -186,7 +186,7 @@ class InsightCacheTest {
             it[stringPreferencesKey("this_period_insight_v6")] = "{not valid json"
         }
 
-        subject.latest.first() shouldBe null
+        subject.thisPeriod.first() shouldBe null
     }
 
     @Test
@@ -211,7 +211,7 @@ class InsightCacheTest {
             it[stringPreferencesKey("this_period_insight_v6")] = v2Json
         }
 
-        subject.latest.first() shouldBe null
+        subject.thisPeriod.first() shouldBe null
     }
 
     @Test
@@ -236,7 +236,7 @@ class InsightCacheTest {
 
         subject.store(InsightCache.Slot.THIS_PERIOD, withHourly)
 
-        subject.latest.first() shouldBe withHourly
+        subject.thisPeriod.first() shouldBe withHourly
     }
 
     @Test
@@ -274,7 +274,7 @@ class InsightCacheTest {
 
         subject.store(InsightCache.Slot.THIS_PERIOD, withRationale)
 
-        subject.latest.first() shouldBe withRationale
+        subject.thisPeriod.first() shouldBe withRationale
     }
 
     @Test
@@ -289,7 +289,7 @@ class InsightCacheTest {
 
         subject.store(InsightCache.Slot.THIS_PERIOD, withLocation)
 
-        subject.latest.first() shouldBe withLocation
+        subject.thisPeriod.first() shouldBe withLocation
     }
 
     @Test
@@ -316,7 +316,7 @@ class InsightCacheTest {
             it[stringPreferencesKey("this_period_insight_v6")] = minimalJson
         }
 
-        val read = subject.latest.first()
+        val read = subject.thisPeriod.first()
         // Sample carries both `confidence` and `perModelHourly` so the
         // round-trip test catches a future regression where the DTO drops
         // either; the legacy/minimal payload here can't possibly carry them,
@@ -347,7 +347,7 @@ class InsightCacheTest {
 
         subject.store(InsightCache.Slot.THIS_PERIOD, full)
 
-        subject.latest.first() shouldBe full
+        subject.thisPeriod.first() shouldBe full
     }
 
     @Test
@@ -369,7 +369,7 @@ class InsightCacheTest {
 
         subject.store(InsightCache.Slot.THIS_PERIOD, bareRain)
 
-        val tie = subject.latest.first()?.summary?.eveningEventTieIn
+        val tie = subject.thisPeriod.first()?.summary?.eveningEventTieIn
         tie?.items shouldBe emptyList()
         tie?.rainTime shouldBe LocalTime.of(21, 0)
         tie?.likelihood shouldBe PrecipLikelihood.POSSIBLE
@@ -401,7 +401,7 @@ class InsightCacheTest {
             it[stringPreferencesKey("this_period_insight_v6")] = legacyJson
         }
 
-        val tie = subject.latest.first()?.summary?.eveningEventTieIn
+        val tie = subject.thisPeriod.first()?.summary?.eveningEventTieIn
         tie?.items shouldBe listOf("jacket")
         tie?.rainTime shouldBe LocalTime.of(21, 0)
         tie?.likelihood shouldBe PrecipLikelihood.LIKELY
@@ -438,7 +438,7 @@ class InsightCacheTest {
 
         subject.recomputeOutfits(ClothesRule.DEFAULTS, OutfitSuggestion.Bottom.JEANS)
 
-        subject.latest.first()?.outfit?.bottom shouldBe OutfitSuggestion.Bottom.JEANS
+        subject.thisPeriod.first()?.outfit?.bottom shouldBe OutfitSuggestion.Bottom.JEANS
     }
 
     @Test
@@ -600,7 +600,7 @@ class InsightCacheTest {
 
         subject.recomputeOutfits(ClothesRule.DEFAULTS, OutfitSuggestion.Bottom.JEANS)
 
-        subject.latest.first()?.outfit?.bottom shouldBe storedBottom
+        subject.thisPeriod.first()?.outfit?.bottom shouldBe storedBottom
     }
 
     @Test
@@ -617,6 +617,6 @@ class InsightCacheTest {
 
         subject.store(InsightCache.Slot.THIS_PERIOD, possible)
 
-        subject.latest.first()?.summary?.precip?.likelihood shouldBe PrecipLikelihood.POSSIBLE
+        subject.thisPeriod.first()?.summary?.precip?.likelihood shouldBe PrecipLikelihood.POSSIBLE
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to merged PR #463. Addresses [Codex's review comment](https://github.com/mikelward/clothescast/pull/463#discussion_r3247161653) on `InsightCache.kt`.

`InsightCache.latest` picked the slot with the later `generatedAt`. After a worker run, the pre-rendered `NEXT_PERIOD` slot is always newer than the just-delivered `THIS_PERIOD` slot, so `OutfitWidget` (single-column) could redraw as "Tonight" while the user was still in the daytime window the morning worker had just delivered.

- **`OutfitWidget` now reads `insightCache.thisPeriod` directly.** The role-based slot naming already encodes which window the user is in; "freshest of either slot" was a leftover from the period-keyed cache and never matched the widget's actual intent.
- **Drops the now-unused `latest` flow.** It had no other production callers; `InsightCacheTest` round-trip assertions move to `thisPeriod`.

## Privacy

No change to what leaves the device.

## Test plan

- [x] `:app:testDebugUnitTest` passes (including updated `InsightCacheTest`)
- [x] `:app:assembleDebug` builds
- [ ] Manual: after a morning worker run, single-column widget shows the daytime outfit (not "Tonight")


---
_Generated by [Claude Code](https://claude.ai/code/session_01Tk43NG9XiD4xXgVevHSckq)_