### PR TITLE
Fix swiping between Today and Tonight when starting on a chart

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/today/ForecastChart.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/ForecastChart.kt
@@ -21,6 +21,7 @@ import com.patrykandpatrick.vico.compose.cartesian.axis.rememberBottom
 import com.patrykandpatrick.vico.compose.cartesian.axis.rememberStart
 import com.patrykandpatrick.vico.compose.cartesian.layer.rememberLineCartesianLayer
 import com.patrykandpatrick.vico.compose.cartesian.rememberCartesianChart
+import com.patrykandpatrick.vico.compose.cartesian.rememberVicoScrollState
 import com.patrykandpatrick.vico.compose.cartesian.rememberVicoZoomState
 import com.patrykandpatrick.vico.compose.common.fill
 import com.patrykandpatrick.vico.core.cartesian.Zoom
@@ -241,7 +242,12 @@ fun ForecastChart(
         // hourly series renders only the first ~10 hours and hides the rest behind
         // a scroll. Force-fit instead so the full day is visible at a glance — this
         // is a glanceable summary card, not an interactive explorer.
-        zoomState = rememberVicoZoomState(initialZoom = Zoom.Content),
+        //
+        // Disable scroll and zoom gestures: the chart fits, so there's nothing
+        // to scroll or zoom — and Vico's default gesture handlers would otherwise
+        // swallow horizontal drags, blocking the parent HorizontalPager's swipe.
+        scrollState = rememberVicoScrollState(scrollEnabled = false),
+        zoomState = rememberVicoZoomState(zoomEnabled = false, initialZoom = Zoom.Content),
         modifier = modifier
             .fillMaxWidth()
             .height(180.dp),

--- a/app/src/main/kotlin/app/clothescast/ui/today/PerModelDiagnosticCard.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/PerModelDiagnosticCard.kt
@@ -25,6 +25,7 @@ import com.patrykandpatrick.vico.compose.cartesian.axis.rememberBottom
 import com.patrykandpatrick.vico.compose.cartesian.axis.rememberStart
 import com.patrykandpatrick.vico.compose.cartesian.layer.rememberLineCartesianLayer
 import com.patrykandpatrick.vico.compose.cartesian.rememberCartesianChart
+import com.patrykandpatrick.vico.compose.cartesian.rememberVicoScrollState
 import com.patrykandpatrick.vico.compose.cartesian.rememberVicoZoomState
 import com.patrykandpatrick.vico.core.cartesian.Zoom
 import com.patrykandpatrick.vico.core.cartesian.axis.HorizontalAxis
@@ -271,7 +272,11 @@ private fun PerModelDiagnosticChart(
             bottomAxis = HorizontalAxis.rememberBottom(valueFormatter = bottomFormatter),
         ),
         modelProducer = producer,
-        zoomState = rememberVicoZoomState(initialZoom = Zoom.Content),
+        // Disable scroll/zoom gestures so the chart doesn't swallow horizontal
+        // drags meant for the parent HorizontalPager — same fix as the temp /
+        // precip cards above.
+        scrollState = rememberVicoScrollState(scrollEnabled = false),
+        zoomState = rememberVicoZoomState(zoomEnabled = false, initialZoom = Zoom.Content),
         modifier = Modifier
             .fillMaxWidth()
             .height(140.dp),

--- a/app/src/main/kotlin/app/clothescast/ui/today/PrecipitationChart.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/PrecipitationChart.kt
@@ -15,6 +15,7 @@ import com.patrykandpatrick.vico.compose.cartesian.axis.rememberBottom
 import com.patrykandpatrick.vico.compose.cartesian.axis.rememberStart
 import com.patrykandpatrick.vico.compose.cartesian.layer.rememberLineCartesianLayer
 import com.patrykandpatrick.vico.compose.cartesian.rememberCartesianChart
+import com.patrykandpatrick.vico.compose.cartesian.rememberVicoScrollState
 import com.patrykandpatrick.vico.compose.cartesian.rememberVicoZoomState
 import com.patrykandpatrick.vico.core.cartesian.Zoom
 import com.patrykandpatrick.vico.core.cartesian.axis.HorizontalAxis
@@ -120,7 +121,10 @@ fun PrecipitationChart(
         modelProducer = producer,
         // Match ForecastChart: force-fit the full 24-hour series instead of
         // leaving the user to scroll horizontally on a glanceable summary card.
-        zoomState = rememberVicoZoomState(initialZoom = Zoom.Content),
+        // Disabling scroll/zoom gestures keeps the chart from swallowing
+        // horizontal drags meant for the parent HorizontalPager.
+        scrollState = rememberVicoScrollState(scrollEnabled = false),
+        zoomState = rememberVicoZoomState(zoomEnabled = false, initialZoom = Zoom.Content),
         modifier = modifier
             .fillMaxWidth()
             // Shorter than ForecastCard's 180.dp temperature chart — probability


### PR DESCRIPTION
## Summary

Swiping left/right to move between page 1 (Today/Tonight) and page 2 (Tonight/Tomorrow) wasn't working in v824 — except in rare cases where the user happened to start the drag on a non-chart bit of the page (gap between cards, OutfitPreviewRow, etc).

Root cause: Vico's `CartesianChartHost` installs scroll and zoom gesture handlers by default. With `initialZoom = Zoom.Content` the chart fits horizontally and there's nothing to scroll or pinch — but the handlers still claim the touch sequence, so horizontal drags that started on a chart never reached the parent `HorizontalPager`. Each page is mostly charts (temperature, precipitation, six per-model diagnostic cards), so the swipe almost never worked in practice.

Fix: pass `scrollState = rememberVicoScrollState(scrollEnabled = false)` and `zoomState = rememberVicoZoomState(zoomEnabled = false, ...)` to all three chart hosts. The charts already force-fit and were never meant to be scrolled or zoomed by the user, so this only removes never-useful interaction.

## Test plan

- [ ] Build a debug APK (versionCode ≥ 825) and install on device.
- [ ] On the Today screen, swipe right-to-left starting on the temperature chart — should switch to the next-period page.
- [ ] Swipe back left-to-right from the next-period page — should return to the current-period page.
- [ ] Same swipe gestures starting on the precipitation chart and the per-model diagnostic cards (wind / cloud / humidity / solar / sunshine / UV).
- [ ] Vertical scroll on each page still works (scroll past the outfit row into the chart stack).
- [ ] Tapping the chevron next to the InsightCard still flips pages.
- [ ] Top-bar title still updates to "Tonight" / "Tomorrow" when on page 2.

---
_Generated by [Claude Code](https://claude.ai/code/session_0181xCD7VzthhdNTP5GMcoSS)_