### PR TITLE
Drop the standalone detekt CLI TODO

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,12 +71,6 @@ new rule the first time something bites you, not the third.
   via `sdkmanager`). `firebase.google.com` and
   `firebaseinstallations.googleapis.com` are runtime hosts; the build
   itself doesn't need them.
-- **TODO — standalone detekt CLI for `:app` static analysis.** Wire a
-  `detekt-cli` jar fetched from Maven Central plus a `scripts/detekt.sh`
-  runner over `app/src/main/kotlin`. Useful as a fast pre-push check
-  that doesn't need AGP loaded, and as a fallback signal for `:app` if
-  Google Maven is ever unreachable. Not done yet; do this if `:app`
-  changes start landing with avoidable lint issues that CI catches.
 - `:core:domain:test` alone is the minimum signal for any pure-Kotlin
   domain change, regardless of which path you take.
 


### PR DESCRIPTION
Removes the "wire a standalone `detekt-cli`" TODO from `AGENTS.md`.

The TODO was hedging against two cases:

1. **Fallback for `:app` when Google Maven is blocked.** The Cursor Cloud sandbox now has Google Maven allowlisted and the Android SDK pre-installed at `/opt/android-sdk`, so `:app:assembleDebug` / `:app:lintDebug` work in-sandbox.
2. **Fast pre-push static-analysis signal for `:app`.** `./gradlew :app:lintDebug` covers this via AGP — no new tooling needed.

No `:app` PRs have landed avoidable lint issues that detekt would have caught, so the motivating "do this if it starts biting" condition hasn't fired either. Cleaning up the TODO rather than carrying it indefinitely.

Docs-only — filtered out of the Play Store changelog by CI's `*.md` rule.

## Test plan

- [x] No code changes; `AGENTS.md` / `CLAUDE.md` (symlink) only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RRZufRyQp3FJ9FPCEd2v4q)_