### PR TITLE
Fix invisible status and nav bar icons on Android 15

### DIFF
--- a/app/src/main/kotlin/app/clothescast/MainActivity.kt
+++ b/app/src/main/kotlin/app/clothescast/MainActivity.kt
@@ -8,13 +8,16 @@ import android.os.Bundle
 import android.view.Gravity
 import android.widget.TextView
 import androidx.activity.ComponentActivity
+import androidx.activity.SystemBarStyle
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
@@ -70,6 +73,12 @@ class MainActivity : ComponentActivity() {
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        // Edge-to-edge is forced by the system on targetSdk 35; opting in
+        // explicitly lets us drive the status / nav bar icon contrast from
+        // our own theme choice (see the DisposableEffect below) instead of
+        // leaving the icons mismatched against our surface — light icons on
+        // our light background, or vice versa.
+        enableEdgeToEdge()
         super.onCreate(savedInstanceState)
         consumeNavigateToTodayExtra(intent)
         val app = application as ClothesCastApplication
@@ -93,6 +102,24 @@ class MainActivity : ComponentActivity() {
                     ThemeMode.SYSTEM -> isSystemInDarkTheme()
                     ThemeMode.LIGHT -> false
                     ThemeMode.DARK -> true
+                }
+                // Re-apply edge-to-edge with the in-app darkTheme as the
+                // dark-mode source so the bar icons flip when the user picks
+                // Light or Dark explicitly (not just when the system theme
+                // changes). Transparent scrims on both bars — the surface
+                // background shows through directly.
+                DisposableEffect(darkTheme) {
+                    enableEdgeToEdge(
+                        statusBarStyle = SystemBarStyle.auto(
+                            android.graphics.Color.TRANSPARENT,
+                            android.graphics.Color.TRANSPARENT,
+                        ) { darkTheme },
+                        navigationBarStyle = SystemBarStyle.auto(
+                            android.graphics.Color.TRANSPARENT,
+                            android.graphics.Color.TRANSPARENT,
+                        ) { darkTheme },
+                    )
+                    onDispose {}
                 }
                 ClothesCastTheme(darkTheme = darkTheme, colorPalette = colorPalette) {
                     Surface(


### PR DESCRIPTION
## Summary

Android 15 forces edge-to-edge for `targetSdk 35` apps: the status and navigation bars go transparent and content draws behind them whether the app opts in or not. We were never opting in, so the bar icons defaulted to whatever the system picked — typically light icons over our light `#F7F8FA` surface (and dark over our `#101114` surface in dark mode), making them effectively invisible.

This wires up `enableEdgeToEdge()` properly:

- `enableEdgeToEdge()` in `onCreate` so the first frame already has the right icon contrast.
- `DisposableEffect(darkTheme)` re-applies the bar styles whenever the in-app theme flips, so a manual **Light** or **Dark** pick (not just **System**) updates the icons immediately.
- Both bars use transparent scrims — the `Surface` background shows through directly.

## Privacy

No change. Nothing new leaves the device.

## Test plan

- [x] `:app:compileDebugKotlin` clean.
- [x] `:app:testDebugUnitTest` passes (Roborazzi snapshots unchanged — Compose previews don't render system bars).
- [x] `:app:assembleDebug` produces an APK.
- [ ] Manually verify on an Android 15 device: status-bar icons dark on light theme, light on dark theme; nav-bar icons same; switching theme mode in Settings flips both immediately.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UnZNgL2TGDD2anskLASyv8)_