### PR TITLE
Mark per-locale unit defaults as done in the TODO

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -83,8 +83,10 @@ Code TODOs in source files are linked from here when they exist.
 - [ ] **Clothes rule presets** ("Cyclist", "Commuter", "Dog walker") — pick a
       preset, customise from there.
 - [ ] **Quiet hours** — don't fire if the device is in DND.
-- [ ] **Per-locale defaults** — Fahrenheit / miles when the system locale is
-      en-US.
+- [x] **Per-locale defaults** — Fahrenheit / miles when the system locale is
+      en-US. Shipped via `TemperatureUnitSetting.AUTO` / `DistanceUnitSetting.AUTO`
+      (the defaults in `UserPreferences`), which resolve from the device/region
+      locale at read time.
 - [ ] **Multiple schedule profiles** — weekday vs weekend.
 - [x] **Gemini model picker** — Flash Lite (cheapest), Flash (default), Pro
       (highest quality, slowest, costliest). User picks from Settings; the


### PR DESCRIPTION
## Summary

Docs-only tidy-up: the "Per-locale defaults — Fahrenheit / miles when the system locale is en-US" item under **Feature ideas (queued)** in `docs/TODO.md` is already shipped. `UserPreferences` defaults `temperatureUnitSetting` and `distanceUnitSetting` to `AUTO` (see `core/domain/.../Settings.kt:223-224`), and the `AUTO` resolver picks Fahrenheit/miles from the device/region locale at read time.

Marked the entry `[x]` with a one-line note pointing at the existing implementation so it doesn't keep surfacing as an open priority.

## Test plan

- [ ] CI green (docs-only change; release-notes step should also skip per the `docs/`-filter rule).


---
_Generated by [Claude Code](https://claude.ai/code/session_0195BX3JK3hdP4ybVHhgUob1)_