### PR TITLE
Pick which forecast models feed the confidence chip

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ClothesCastApplication.kt
+++ b/app/src/main/kotlin/app/clothescast/ClothesCastApplication.kt
@@ -109,6 +109,14 @@ class ClothesCastApplication : Application() {
                     DiagLog.w("ConfidenceFetcher", message, throwable)
                 },
                 apiCallLogger = apiCallLogger,
+                // Read the user's Forecasters selection on every fetch so a
+                // settings change takes effect on the next manual refresh
+                // without rebuilding the client. DataStore caches the latest
+                // emission, so this is a memory read after the first call.
+                confidenceModelsProvider = {
+                    settingsRepository.preferences.first().forecastModels
+                        .map { it.openMeteoId }
+                },
             ),
         )
     }

--- a/app/src/main/kotlin/app/clothescast/ClothesCastApplication.kt
+++ b/app/src/main/kotlin/app/clothescast/ClothesCastApplication.kt
@@ -118,6 +118,15 @@ class ClothesCastApplication : Application() {
                         .map { it.openMeteoId }
                 },
             ),
+            // Make the cache invalidate when the Forecasters selection
+            // changes — otherwise a Settings edit followed by a Today
+            // refresh within the 1 h TTL would silently return the previous
+            // model set's bundle, because the cache keys only on location.
+            // Passing the Set itself as the discriminator lets equals() do
+            // the comparison; insertion order doesn't matter for a Set.
+            freshnessKeyProvider = {
+                settingsRepository.preferences.first().forecastModels
+            },
         )
     }
     val geocodingClient: OpenMeteoGeocodingClient by lazy {

--- a/app/src/main/kotlin/app/clothescast/data/InsightCache.kt
+++ b/app/src/main/kotlin/app/clothescast/data/InsightCache.kt
@@ -311,7 +311,14 @@ class InsightCache(
         // Nullable for backwards compat: pre-temperatureC cache payloads omit it,
         // and we surface that as "no overlay" rather than a fake 0°C line.
         val temperatureC: Double? = null,
-        val precipitationProbabilityPct: Double,
+        // Nullable: Open-Meteo omits `precipitation_probability_<model>` for
+        // models that don't expose it (UKMO, JMA, GEM, ARPEGE, …); the
+        // domain models that as null so precip aggregates can skip the
+        // model rather than treating it as a 0% rain vote. Pre-fix cache
+        // payloads carried a non-null value, so the default of null only
+        // applies on a write from a model that legitimately lacks precip;
+        // existing entries deserialise their stored number unchanged.
+        val precipitationProbabilityPct: Double? = null,
         // Diagnostic fields — nullable in the domain too, so missing values just
         // hide that model from the wind / humidity / cloud chart rather than
         // dropping the temperature overlay entirely.

--- a/app/src/main/kotlin/app/clothescast/data/SettingsRepository.kt
+++ b/app/src/main/kotlin/app/clothescast/data/SettingsRepository.kt
@@ -15,6 +15,7 @@ import app.clothescast.core.domain.model.ColorPalette
 import app.clothescast.core.domain.model.DeliveryMode
 import app.clothescast.core.domain.model.DistanceUnit
 import app.clothescast.core.domain.model.DistanceUnitSetting
+import app.clothescast.core.domain.model.ForecastModel
 import app.clothescast.core.domain.model.Location
 import app.clothescast.core.domain.model.OutfitSuggestion
 import app.clothescast.core.domain.model.Region
@@ -276,6 +277,23 @@ class SettingsRepository(
     }
 
     /**
+     * Persists the user's [ForecastModel] selection as the stored enum names.
+     * The UI guards against empty selections, but if [models] does come in
+     * empty (e.g. a hand-edited DataStore) we clear the key so the next read
+     * falls back to [ForecastModel.DEFAULTS] rather than persisting an empty
+     * set that would later trip the fetcher's degenerate-input safety net.
+     */
+    suspend fun setForecastModels(models: Set<ForecastModel>) {
+        dataStore.edit { prefs ->
+            if (models.isEmpty()) {
+                prefs.remove(FORECAST_MODELS)
+            } else {
+                prefs[FORECAST_MODELS] = models.map { it.name }.toSet()
+            }
+        }
+    }
+
+    /**
      * Sets the per-icon fill colour for [top]. `null` clears any override —
      * the icon then falls back to the baked-in XML colour. Read-modify-write
      * happens inside a single [dataStore.edit] so concurrent edits don't
@@ -437,6 +455,17 @@ class SettingsRepository(
             ?: ColorPalette.RAINBOW
         val outfitTopColors = parseOutfitTopColors(this[OUTFIT_TOP_COLORS])
         val outfitBottomColors = parseOutfitBottomColors(this[OUTFIT_BOTTOM_COLORS])
+        // Resolve stored enum names back to [ForecastModel]. Unknown / removed
+        // entries are dropped silently so a forward-compat (future enum value
+        // we didn't ship yet) or stale value from a downgrade doesn't break
+        // the picker. Empty resolved set falls back to [ForecastModel.DEFAULTS]
+        // so an install that lost the entry to corruption still gets a
+        // working confidence chip.
+        val forecastModels = this[FORECAST_MODELS]
+            ?.mapNotNull { runCatching { ForecastModel.valueOf(it) }.getOrNull() }
+            ?.toSet()
+            ?.takeIf { it.isNotEmpty() }
+            ?: ForecastModel.DEFAULTS
         val zone = zoneIdProvider()
 
         return UserPreferences(
@@ -468,6 +497,7 @@ class SettingsRepository(
             colorPalette = colorPalette,
             outfitTopColors = outfitTopColors,
             outfitBottomColors = outfitBottomColors,
+            forecastModels = forecastModels,
         )
     }
 
@@ -630,6 +660,7 @@ class SettingsRepository(
         private val COLOR_PALETTE = stringPreferencesKey("color_palette")
         private val OUTFIT_TOP_COLORS = stringPreferencesKey("outfit_top_colors_json")
         private val OUTFIT_BOTTOM_COLORS = stringPreferencesKey("outfit_bottom_colors_json")
+        private val FORECAST_MODELS = stringSetPreferencesKey("forecast_models")
 
         private val TIME_FORMAT: DateTimeFormatter = DateTimeFormatter.ofPattern("HH:mm")
         private val DEFAULT_TIME: LocalTime = LocalTime.of(7, 0)

--- a/app/src/main/kotlin/app/clothescast/ui/settings/ForecasterSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/ForecasterSettings.kt
@@ -133,7 +133,6 @@ private fun forecastModelLabel(model: ForecastModel): Int = when (model) {
     ForecastModel.METEOFRANCE_SEAMLESS -> R.string.settings_forecasters_arpege
     ForecastModel.UKMO_SEAMLESS -> R.string.settings_forecasters_ukmo
     ForecastModel.JMA_SEAMLESS -> R.string.settings_forecasters_jma
-    ForecastModel.BOM_ACCESS_GLOBAL -> R.string.settings_forecasters_bom
 }
 
 private fun forecastModelSubtitle(model: ForecastModel): Int = when (model) {
@@ -144,5 +143,4 @@ private fun forecastModelSubtitle(model: ForecastModel): Int = when (model) {
     ForecastModel.METEOFRANCE_SEAMLESS -> R.string.settings_forecasters_arpege_subtitle
     ForecastModel.UKMO_SEAMLESS -> R.string.settings_forecasters_ukmo_subtitle
     ForecastModel.JMA_SEAMLESS -> R.string.settings_forecasters_jma_subtitle
-    ForecastModel.BOM_ACCESS_GLOBAL -> R.string.settings_forecasters_bom_subtitle
 }

--- a/app/src/main/kotlin/app/clothescast/ui/settings/ForecasterSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/ForecasterSettings.kt
@@ -1,0 +1,132 @@
+package app.clothescast.ui.settings
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.selection.toggleable
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.unit.dp
+import app.clothescast.R
+import app.clothescast.core.domain.model.ForecastModel
+
+/**
+ * Minimum number of models the confidence fetcher needs to compute a spread.
+ * The picker disables a checkbox's "uncheck" path when the user is at this
+ * floor with the box still checked, so they can't deselect their way below
+ * it. [MultiModelConfidenceFetcher] would silently return null without two
+ * usable models; the floor keeps the chip working without a settings-side
+ * "you've broken something" affordance.
+ */
+private const val MIN_MODELS = 2
+
+@Composable
+internal fun ForecastersContent(
+    forecastModels: Set<ForecastModel>,
+    padding: PaddingValues,
+    onSetForecastModels: (Set<ForecastModel>) -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(padding)
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        SectionCard(title = stringResource(R.string.settings_forecasters_title)) {
+            Text(
+                text = stringResource(R.string.settings_forecasters_description),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            ForecastModel.entries.forEach { model ->
+                val checked = model in forecastModels
+                // Block unchecking when we'd drop below MIN_MODELS. Checking
+                // is never blocked — adding always raises the count.
+                val canToggleOff = forecastModels.size > MIN_MODELS
+                ForecasterRow(
+                    label = stringResource(forecastModelLabel(model)),
+                    subtitle = stringResource(forecastModelSubtitle(model)),
+                    checked = checked,
+                    // Block unchecking the second-to-last selection — toggle on
+                    // is always allowed. The repository's empty-set guard would
+                    // recover the defaults if a deselection slipped past, but
+                    // greying out the box keeps the UI's "you can't break it"
+                    // affordance honest.
+                    enabled = !checked || canToggleOff,
+                    onToggle = { nowChecked ->
+                        val updated = if (nowChecked) forecastModels + model else forecastModels - model
+                        if (updated.size >= MIN_MODELS) onSetForecastModels(updated)
+                    },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ForecasterRow(
+    label: String,
+    subtitle: String,
+    checked: Boolean,
+    enabled: Boolean,
+    onToggle: (Boolean) -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .toggleable(
+                value = checked,
+                enabled = enabled,
+                role = Role.Checkbox,
+                onValueChange = onToggle,
+            )
+            .padding(vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Checkbox(checked = checked, onCheckedChange = null, enabled = enabled)
+        Column(modifier = Modifier.padding(start = 8.dp)) {
+            Text(text = label, style = MaterialTheme.typography.bodyLarge)
+            Text(
+                text = subtitle,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+private fun forecastModelLabel(model: ForecastModel): Int = when (model) {
+    ForecastModel.ECMWF_IFS04 -> R.string.settings_forecasters_ecmwf
+    ForecastModel.ICON_SEAMLESS -> R.string.settings_forecasters_icon
+    ForecastModel.GFS_SEAMLESS -> R.string.settings_forecasters_gfs
+    ForecastModel.GEM_SEAMLESS -> R.string.settings_forecasters_gem
+    ForecastModel.METEOFRANCE_SEAMLESS -> R.string.settings_forecasters_arpege
+    ForecastModel.UKMO_SEAMLESS -> R.string.settings_forecasters_ukmo
+    ForecastModel.JMA_SEAMLESS -> R.string.settings_forecasters_jma
+    ForecastModel.BOM_ACCESS_GLOBAL -> R.string.settings_forecasters_bom
+}
+
+private fun forecastModelSubtitle(model: ForecastModel): Int = when (model) {
+    ForecastModel.ECMWF_IFS04 -> R.string.settings_forecasters_ecmwf_subtitle
+    ForecastModel.ICON_SEAMLESS -> R.string.settings_forecasters_icon_subtitle
+    ForecastModel.GFS_SEAMLESS -> R.string.settings_forecasters_gfs_subtitle
+    ForecastModel.GEM_SEAMLESS -> R.string.settings_forecasters_gem_subtitle
+    ForecastModel.METEOFRANCE_SEAMLESS -> R.string.settings_forecasters_arpege_subtitle
+    ForecastModel.UKMO_SEAMLESS -> R.string.settings_forecasters_ukmo_subtitle
+    ForecastModel.JMA_SEAMLESS -> R.string.settings_forecasters_jma_subtitle
+    ForecastModel.BOM_ACCESS_GLOBAL -> R.string.settings_forecasters_bom_subtitle
+}

--- a/app/src/main/kotlin/app/clothescast/ui/settings/ForecasterSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/ForecasterSettings.kt
@@ -32,6 +32,16 @@ import app.clothescast.core.domain.model.ForecastModel
  */
 private const val MIN_MODELS = 2
 
+/**
+ * Cap on the number of models the picker accepts. The chart palette covers
+ * all eight [ForecastModel] entries, so this isn't a "we'd crash above" limit
+ * — it's a readability floor. Five overlay lines on the per-model chart is
+ * already busy; eight turns it into a rainbow nobody can read. The picker
+ * disables unchecked rows when the user is at the cap, with a one-line hint
+ * directing them to deselect first.
+ */
+private const val MAX_MODELS = 5
+
 @Composable
 internal fun ForecastersContent(
     forecastModels: Set<ForecastModel>,
@@ -52,24 +62,30 @@ internal fun ForecastersContent(
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
+            val atCap = forecastModels.size >= MAX_MODELS
+            if (atCap) {
+                Text(
+                    text = stringResource(R.string.settings_forecasters_cap_hint, MAX_MODELS),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
             ForecastModel.entries.forEach { model ->
                 val checked = model in forecastModels
-                // Block unchecking when we'd drop below MIN_MODELS. Checking
-                // is never blocked — adding always raises the count.
+                // Block unchecking when we'd drop below MIN_MODELS. Block
+                // checking when we'd exceed MAX_MODELS. An already-checked
+                // row stays interactable above the cap so the user can
+                // still toggle it off to free a slot.
                 val canToggleOff = forecastModels.size > MIN_MODELS
+                val canToggleOn = !atCap
                 ForecasterRow(
                     label = stringResource(forecastModelLabel(model)),
                     subtitle = stringResource(forecastModelSubtitle(model)),
                     checked = checked,
-                    // Block unchecking the second-to-last selection — toggle on
-                    // is always allowed. The repository's empty-set guard would
-                    // recover the defaults if a deselection slipped past, but
-                    // greying out the box keeps the UI's "you can't break it"
-                    // affordance honest.
-                    enabled = !checked || canToggleOff,
+                    enabled = if (checked) canToggleOff else canToggleOn,
                     onToggle = { nowChecked ->
                         val updated = if (nowChecked) forecastModels + model else forecastModels - model
-                        if (updated.size >= MIN_MODELS) onSetForecastModels(updated)
+                        if (updated.size in MIN_MODELS..MAX_MODELS) onSetForecastModels(updated)
                     },
                 )
             }

--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsScreen.kt
@@ -50,6 +50,7 @@ enum class SettingsRoute(@StringRes val titleRes: Int, @StringRes val subtitleRe
     Display(R.string.settings_root_display, R.string.settings_root_display_subtitle),
     Location(R.string.settings_root_location, R.string.settings_root_location_subtitle),
     Calendar(R.string.settings_root_calendar, R.string.settings_root_calendar_subtitle),
+    Forecasters(R.string.settings_root_forecasters, R.string.settings_root_forecasters_subtitle),
     Privacy(R.string.settings_root_privacy, R.string.settings_root_privacy_subtitle),
     About(R.string.settings_root_about),
 }
@@ -199,6 +200,11 @@ fun SettingsScreen(
                 useCalendarEvents = state.useCalendarEvents,
                 padding = padding,
                 onSetUseCalendarEvents = viewModel::setUseCalendarEvents,
+            )
+            SettingsRoute.Forecasters -> ForecastersContent(
+                forecastModels = state.forecastModels,
+                padding = padding,
+                onSetForecastModels = viewModel::setForecastModels,
             )
             SettingsRoute.Privacy -> PrivacyContent(
                 telemetryEnabled = state.telemetryEnabled,

--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsScreen.kt
@@ -49,8 +49,8 @@ enum class SettingsRoute(@StringRes val titleRes: Int, @StringRes val subtitleRe
     Voice(R.string.settings_root_voice, R.string.settings_root_voice_subtitle),
     Display(R.string.settings_root_display, R.string.settings_root_display_subtitle),
     Location(R.string.settings_root_location, R.string.settings_root_location_subtitle),
-    Calendar(R.string.settings_root_calendar, R.string.settings_root_calendar_subtitle),
     Forecasters(R.string.settings_root_forecasters, R.string.settings_root_forecasters_subtitle),
+    Calendar(R.string.settings_root_calendar, R.string.settings_root_calendar_subtitle),
     Privacy(R.string.settings_root_privacy, R.string.settings_root_privacy_subtitle),
     About(R.string.settings_root_about),
 }

--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsState.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsState.kt
@@ -5,6 +5,7 @@ import app.clothescast.core.domain.model.ColorPalette
 import app.clothescast.core.domain.model.DeliveryMode
 import app.clothescast.core.domain.model.DistanceUnit
 import app.clothescast.core.domain.model.DistanceUnitSetting
+import app.clothescast.core.domain.model.ForecastModel
 import app.clothescast.core.domain.model.Location
 import app.clothescast.core.domain.model.OutfitSuggestion
 import app.clothescast.core.domain.model.Region
@@ -90,4 +91,5 @@ data class SettingsState(
      * can't get stuck after the worker finishes without resolving a fix.
      */
     val locationDetecting: Boolean = false,
+    val forecastModels: Set<ForecastModel> = ForecastModel.DEFAULTS,
 )

--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsViewModel.kt
@@ -10,6 +10,7 @@ import app.clothescast.core.domain.model.ClothesRule
 import app.clothescast.core.domain.model.ColorPalette
 import app.clothescast.core.domain.model.DeliveryMode
 import app.clothescast.core.domain.model.DistanceUnitSetting
+import app.clothescast.core.domain.model.ForecastModel
 import app.clothescast.core.domain.model.ForecastPeriod
 import app.clothescast.core.domain.model.Location
 import app.clothescast.core.domain.model.OutfitSuggestion
@@ -135,6 +136,7 @@ class SettingsViewModel(
                         voiceLocale = prefs.voiceLocale,
                         useCalendarEvents = prefs.useCalendarEvents,
                         telemetryEnabled = prefs.telemetryEnabled,
+                        forecastModels = prefs.forecastModels,
                     )
                 }
                 // Re-enumerate on first observation and whenever the effective
@@ -373,6 +375,17 @@ class SettingsViewModel(
 
     fun setTelemetryEnabled(enabled: Boolean) {
         viewModelScope.launch { settingsRepository.setTelemetryEnabled(enabled) }
+    }
+
+    /**
+     * Persists the user's [ForecastModel] selection. The picker enforces a
+     * minimum of two checked entries before calling here (the confidence
+     * chip needs at least two models to compute a spread), so an empty
+     * [models] never reaches this path from the UI; the repository still
+     * defends against it for hand-edited-DataStore safety.
+     */
+    fun setForecastModels(models: Set<ForecastModel>) {
+        viewModelScope.launch { settingsRepository.setForecastModels(models) }
     }
 
     /** Used by the data-sources page's location dialog; safe to call from any dispatcher. */

--- a/app/src/main/kotlin/app/clothescast/ui/theme/AppPalette.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/theme/AppPalette.kt
@@ -65,7 +65,6 @@ internal fun rainbowPalette(scheme: ColorScheme): AppPalette = AppPalette(
         "meteofrance_seamless" to Color(0xFF1E88E5),
         "ukmo_seamless" to Color(0xFFFBC02D),
         "jma_seamless" to Color(0xFF00897B),
-        "bom_access_global" to Color(0xFF6D4C41),
         BEST_MATCH_MODEL_ID to Color(0xFF9E9E9E),
     ),
     confidence = mapOf(
@@ -119,7 +118,6 @@ internal fun accessiblePalette(darkTheme: Boolean): AppPalette = AppPalette(
         "meteofrance_seamless" to Color(0xFF56B4E9),
         "ukmo_seamless" to Color(0xFFB47C00),
         "jma_seamless" to Color(0xFFCC79A7),
-        "bom_access_global" to Color(0xFF6F4E37),
         BEST_MATCH_MODEL_ID to if (darkTheme) Color(0xFFBFBFBF) else Color(0xFF595959),
     ),
     confidence = if (darkTheme) {
@@ -228,7 +226,6 @@ internal fun highlighterPalette(darkTheme: Boolean): AppPalette = AppPalette(
             "meteofrance_seamless" to Color(0xFF00FFA1),
             "ukmo_seamless" to Color(0xFFFF7043),
             "jma_seamless" to Color(0xFFFF6EC7),
-            "bom_access_global" to Color(0xFFFFCA28),
             BEST_MATCH_MODEL_ID to Color(0xFFEAEAEA),
         )
     } else {
@@ -250,7 +247,6 @@ internal fun highlighterPalette(darkTheme: Boolean): AppPalette = AppPalette(
             "meteofrance_seamless" to Color(0xFF2E7D32),
             "ukmo_seamless" to Color(0xFFBF360C),
             "jma_seamless" to Color(0xFFAD1457),
-            "bom_access_global" to Color(0xFFE65100),
             BEST_MATCH_MODEL_ID to Color(0xFF2A2A2A),
         )
     },

--- a/app/src/main/kotlin/app/clothescast/ui/theme/AppPalette.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/theme/AppPalette.kt
@@ -48,12 +48,24 @@ data class AppPalette(
  * `secondaryContainer` for HIGH, `surfaceVariant` for MEDIUM,
  * `errorContainer` for LOW — so dynamic colour stays in play on Android
  * 12+.
+ *
+ * Additional global models (GEM / ARPEGE / UKMO / JMA / BOM) added with the
+ * Forecasters picker pull from Material-600 saturated hues hand-tuned for
+ * distinguishability against the original trio and against each other:
+ * purple, blue, amber, teal, brown. Eight chart lines is visually busy and
+ * we'd suggest the user not enable all of them, but the palette covers it
+ * so the chart never crashes on a `modelColors.getValue` lookup.
  */
 internal fun rainbowPalette(scheme: ColorScheme): AppPalette = AppPalette(
     modelColors = mapOf(
         "ecmwf_ifs04" to Color(0xFFD81B60),
         "gfs_seamless" to Color(0xFFFB8C00),
         "icon_seamless" to Color(0xFF43A047),
+        "gem_seamless" to Color(0xFF8E24AA),
+        "meteofrance_seamless" to Color(0xFF1E88E5),
+        "ukmo_seamless" to Color(0xFFFBC02D),
+        "jma_seamless" to Color(0xFF00897B),
+        "bom_access_global" to Color(0xFF6D4C41),
         BEST_MATCH_MODEL_ID to Color(0xFF9E9E9E),
     ),
     confidence = mapOf(
@@ -96,6 +108,18 @@ internal fun accessiblePalette(darkTheme: Boolean): AppPalette = AppPalette(
         "ecmwf_ifs04" to Color(0xFFD55E00),
         "gfs_seamless" to Color(0xFFE69F00),
         "icon_seamless" to Color(0xFF009E73),
+        // Additional Okabe-Ito-derived hues for the models added in the
+        // Forecasters picker. Yellow (#F0E442) is famously low-contrast on
+        // white in the original palette, so UKMO drops to a dark amber that
+        // still reads as the same hue family but clears WCAG 3:1 against
+        // the light surfaceContainer. BOM uses a coffee brown — outside
+        // Okabe-Ito strictly but with sufficient hue separation from the
+        // rest to stay distinguishable under all three CVD profiles.
+        "gem_seamless" to Color(0xFF0072B2),
+        "meteofrance_seamless" to Color(0xFF56B4E9),
+        "ukmo_seamless" to Color(0xFFB47C00),
+        "jma_seamless" to Color(0xFFCC79A7),
+        "bom_access_global" to Color(0xFF6F4E37),
         BEST_MATCH_MODEL_ID to if (darkTheme) Color(0xFFBFBFBF) else Color(0xFF595959),
     ),
     confidence = if (darkTheme) {
@@ -194,6 +218,17 @@ internal fun highlighterPalette(darkTheme: Boolean): AppPalette = AppPalette(
             "ecmwf_ifs04" to Color(0xFFFF2D95),
             "gfs_seamless" to Color(0xFFFFEB3B),
             "icon_seamless" to Color(0xFF00E5FF),
+            // Five more neon-ish hues for the Forecasters picker additions.
+            // Saturation stays high; luminance is similar to the original
+            // trio so they read as the same arcade-cabinet family.
+            // Distinguishability across 8 lines is a stretch — at full
+            // selection the chart turns into a noisy rainbow — but every
+            // pair stays separable, and most users will pick 3-4 models.
+            "gem_seamless" to Color(0xFFB388FF),
+            "meteofrance_seamless" to Color(0xFF00FFA1),
+            "ukmo_seamless" to Color(0xFFFF7043),
+            "jma_seamless" to Color(0xFFFF6EC7),
+            "bom_access_global" to Color(0xFFFFCA28),
             BEST_MATCH_MODEL_ID to Color(0xFFEAEAEA),
         )
     } else {
@@ -208,6 +243,14 @@ internal fun highlighterPalette(darkTheme: Boolean): AppPalette = AppPalette(
             "ecmwf_ifs04" to Color(0xFFFF2D95),
             "gfs_seamless" to Color(0xFFB58A00),
             "icon_seamless" to Color(0xFF0277BD),
+            // Light-theme variants of the Forecasters additions — same hue
+            // family as the dark map, darkened to clear the 3:1 contrast
+            // floor on the near-white surfaceContainer.
+            "gem_seamless" to Color(0xFF6A1B9A),
+            "meteofrance_seamless" to Color(0xFF2E7D32),
+            "ukmo_seamless" to Color(0xFFBF360C),
+            "jma_seamless" to Color(0xFFAD1457),
+            "bom_access_global" to Color(0xFFE65100),
             BEST_MATCH_MODEL_ID to Color(0xFF2A2A2A),
         )
     },

--- a/app/src/main/kotlin/app/clothescast/ui/today/ForecastChart.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/ForecastChart.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import app.clothescast.core.domain.model.ForecastModel
 import app.clothescast.core.domain.model.HourlyForecast
 import app.clothescast.core.domain.model.PerModelHour
 import app.clothescast.core.domain.model.PerModelHourly
@@ -48,12 +49,14 @@ import kotlin.math.roundToInt
 // Vico's identity-by-index animation so the combined line no longer fades
 // out and back in when the overlay toggles. The trade-off is that the
 // per-model overlays now draw over the combined line in the spread view.
-internal val MODEL_DRAW_ORDER = listOf(
-    "ecmwf_ifs04",
-    "gfs_seamless",
-    "icon_seamless",
-    BEST_MATCH_MODEL_ID,
-)
+//
+// Derived from [ForecastModel] so adding a new entry in the domain enum
+// automatically widens the chart without an additional edit here — and so
+// every model the user can pick in Settings ▸ Forecasters has a stable
+// position. Enum declaration order doubles as the chart's left-to-right
+// legend order; the [AppPalette.modelColors] maps follow the same order.
+internal val MODEL_DRAW_ORDER: List<String> =
+    ForecastModel.entries.map { it.openMeteoId } + BEST_MATCH_MODEL_ID
 
 // Pinned per-model overlay colours live on the active [app.clothescast.ui.theme.AppPalette]
 // rather than as a static map here, so the colour-blind palette can swap the
@@ -269,18 +272,25 @@ internal fun rememberPinnedLineProvider(
     visibleModels: List<String>,
     mainLineColor: Color?,
     modelColors: Map<String, Color> = AppTheme.palette.modelColors,
-): LineCartesianLayer.LineProvider =
-    remember(visibleModels, mainLineColor, modelColors) {
+): LineCartesianLayer.LineProvider {
+    // Key the remember on the colours actually used (mainline + per-visible-model)
+    // rather than the whole [modelColors] map. The map widened to cover all eight
+    // [ForecastModel] entries when the Forecasters picker landed, so its identity
+    // changed; without this projection, every chart in the tree would invalidate
+    // its LineProvider on first composition after the upgrade — re-running Vico's
+    // line setup yields visually identical output but flickers any in-flight
+    // line-fade animation and rewrites Roborazzi snapshots even though the
+    // visible lines are the same. Including only the visible colours keeps the
+    // key stable when the underlying map gains entries we don't read.
+    val visibleColors = visibleModels.map { modelColors.getValue(it) }
+    return remember(visibleModels, mainLineColor, visibleColors) {
         val mainLine = mainLineColor?.let {
             LineCartesianLayer.Line(fill = LineCartesianLayer.LineFill.single(fill(it)))
         }
-        val perModelLines = visibleModels.map { modelId ->
-            LineCartesianLayer.Line(
-                fill = LineCartesianLayer.LineFill.single(
-                    fill(modelColors.getValue(modelId)),
-                ),
-            )
+        val perModelLines = visibleColors.map { color ->
+            LineCartesianLayer.Line(fill = LineCartesianLayer.LineFill.single(fill(color)))
         }
         val lines = listOfNotNull(mainLine) + perModelLines
         LineCartesianLayer.LineProvider.series(lines)
     }
+}

--- a/app/src/main/kotlin/app/clothescast/ui/today/PrecipitationChart.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/PrecipitationChart.kt
@@ -84,11 +84,24 @@ fun PrecipitationChart(
                 series(hourly.map { it.precipitationProbabilityPct })
                 visibleModels.forEach { modelId ->
                     overlays.getValue(modelId).let { entries ->
-                        // Per-hour null precip becomes "no data point at that x"
-                        // — Vico bridges the gap visually between the surviving
-                        // points. Avoids drawing a misleading 0% baseline for
-                        // hours where the model simply didn't report.
-                        series(entries.mapNotNull { it.precipitationProbabilityPct })
+                        // Build (x, y) pairs so a sparse precip series plots
+                        // at its real hour positions on the chart, mirroring
+                        // [PerModelDiagnosticCard]. A bare `series(y)` would
+                        // compact surviving y values to indices 0..n which
+                        // misaligns the line under the bottom axis when a
+                        // model omits its leading or trailing hours. The
+                        // x index is the entry's position in the parser's
+                        // hourly list — entries.size == hours-in-window
+                        // because the parser only drops hours when
+                        // temperature_2m itself is null, so iteration index
+                        // equals hour-since-window-start. Nulls inside the
+                        // precip series are skipped via mapIndexedNotNull;
+                        // Vico bridges the gap visually between surviving
+                        // points without drawing a fake-0 baseline.
+                        val points = entries.mapIndexedNotNull { i, e ->
+                            e.precipitationProbabilityPct?.let { i to it }
+                        }
+                        series(x = points.map { it.first }, y = points.map { it.second })
                     }
                 }
             }
@@ -102,15 +115,26 @@ fun PrecipitationChart(
         }
     }
 
-    // Fixed 0..100 axis — probability is a percentage, so a calm day with a
+    // Y: fixed 0..100 — probability is a percentage, so a calm day with a
     // few-percent peak should still show a flat baseline near the bottom of
     // the chart rather than autoscaling to amplify the noise. Keeps the chart
     // visually comparable across days too: a 20% line on a quiet day and a 20%
     // line on a wet day land at the same height.
-    val rangeProvider = remember {
+    //
+    // X: pinned to the full hourly window so a sparse per-model precip series
+    // that's missing the leading or trailing hours doesn't get stretched across
+    // the whole card by Zoom.Content. Without this anchor, if every visible
+    // model is missing (say) hours 0..18 of the day, the chart only sees
+    // x = 19..23 and fits those four points to the full width, visually
+    // misaligning the line with the temperature card's 0..23 axis and hiding
+    // the gap that's the whole point of plotting at original indices.
+    val xMax = hourly.lastIndex.toDouble()
+    val rangeProvider = remember(xMax) {
         object : CartesianLayerRangeProvider {
             override fun getMinY(minY: Double, maxY: Double, extraStore: ExtraStore) = 0.0
             override fun getMaxY(minY: Double, maxY: Double, extraStore: ExtraStore) = 100.0
+            override fun getMinX(minX: Double, maxX: Double, extraStore: ExtraStore) = 0.0
+            override fun getMaxX(minX: Double, maxX: Double, extraStore: ExtraStore) = xMax
         }
     }
 

--- a/app/src/main/kotlin/app/clothescast/ui/today/PrecipitationChart.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/PrecipitationChart.kt
@@ -52,8 +52,15 @@ fun PrecipitationChart(
     if (hourly.isEmpty()) return
 
     val overlays = perModelHourly?.byModel.orEmpty()
+    // A model whose precip series is all-null (Open-Meteo doesn't expose
+    // `precipitation_probability_<model>` for it) has nothing to plot on
+    // this chart — skip it so we don't draw an empty Vico series and the
+    // legend doesn't list a phantom line. The model still appears on the
+    // temperature chart via [ForecastChart], which only needs air-temp.
     val visibleModels = if (showModelSpread) {
-        MODEL_DRAW_ORDER.filter { it in overlays }
+        MODEL_DRAW_ORDER.filter { modelId ->
+            overlays[modelId]?.any { it.precipitationProbabilityPct != null } == true
+        }
     } else {
         emptyList()
     }
@@ -77,7 +84,11 @@ fun PrecipitationChart(
                 series(hourly.map { it.precipitationProbabilityPct })
                 visibleModels.forEach { modelId ->
                     overlays.getValue(modelId).let { entries ->
-                        series(entries.map { it.precipitationProbabilityPct })
+                        // Per-hour null precip becomes "no data point at that x"
+                        // — Vico bridges the gap visually between the surviving
+                        // points. Avoids drawing a misleading 0% baseline for
+                        // hours where the model simply didn't report.
+                        series(entries.mapNotNull { it.precipitationProbabilityPct })
                     }
                 }
             }

--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
@@ -1967,7 +1967,6 @@ private fun friendlyModelName(modelId: String): String = when (modelId) {
     "meteofrance_seamless" -> "ARPEGE"
     "ukmo_seamless" -> "UKMO"
     "jma_seamless" -> "JMA"
-    "bom_access_global" -> "BOM"
     PerModelHourly.BEST_MATCH_MODEL_ID -> "Auto"
     else -> modelId
 }

--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
@@ -1963,6 +1963,11 @@ private fun friendlyModelName(modelId: String): String = when (modelId) {
     "ecmwf_ifs04" -> "ECMWF"
     "gfs_seamless" -> "GFS"
     "icon_seamless" -> "ICON"
+    "gem_seamless" -> "GEM"
+    "meteofrance_seamless" -> "ARPEGE"
+    "ukmo_seamless" -> "UKMO"
+    "jma_seamless" -> "JMA"
+    "bom_access_global" -> "BOM"
     PerModelHourly.BEST_MATCH_MODEL_ID -> "Auto"
     else -> modelId
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -390,6 +390,7 @@
          across translations. -->
     <string name="settings_forecasters_title">Forecast models</string>
     <string name="settings_forecasters_description">The confidence chip and the per-model chart pull from these models. Picking more gives a richer spread; fewer means a tighter focus. At least two stay selected.</string>
+    <string name="settings_forecasters_cap_hint">You\'ve picked %1$d models — the most the chart stays readable for. Deselect one to add a different model.</string>
     <string name="settings_forecasters_ecmwf">ECMWF</string>
     <string name="settings_forecasters_ecmwf_subtitle">European — generally the most accurate global model. 3-hourly on the open feed.</string>
     <string name="settings_forecasters_icon">ICON</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -405,8 +405,9 @@
     <string name="settings_forecasters_ukmo_subtitle">British (UK Met Office) — historically second only to ECMWF. 3-hourly on the open feed.</string>
     <string name="settings_forecasters_jma">JMA</string>
     <string name="settings_forecasters_jma_subtitle">Japanese — strong over Asia-Pacific. 3- to 6-hourly on the open feed.</string>
-    <string name="settings_forecasters_bom">BOM</string>
-    <string name="settings_forecasters_bom_subtitle">Australian — strong over Australasia. 3-hourly on the open feed.</string>
+    <!-- BOM_ACCESS_GLOBAL deliberately omitted from the picker — Open-Meteo's
+         BOM open-data delivery is suspended at the moment. Add settings_forecasters_bom*
+         back when BOM_ACCESS_GLOBAL is restored to the ForecastModel enum. -->
 
     <!-- Privacy settings sub-page. The toggle controls Firebase Analytics +
          Crashlytics collection at runtime; PRIVACY.md spells out the data

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -341,6 +341,7 @@
     <string name="settings_root_display">Display</string>
     <string name="settings_root_location">Location</string>
     <string name="settings_root_calendar">Calendar</string>
+    <string name="settings_root_forecasters">Forecasters</string>
     <string name="settings_root_privacy">Privacy</string>
     <string name="settings_root_about">About</string>
 
@@ -379,7 +380,32 @@
 
     <string name="settings_root_location_subtitle">Auto-detect or pick a city</string>
     <string name="settings_root_calendar_subtitle">Today\'s events</string>
+    <string name="settings_root_forecasters_subtitle">Which weather models to consult</string>
     <string name="settings_root_privacy_subtitle">Crash + usage reports</string>
+
+    <!-- Forecasters sub-page: lets the user pick which numerical weather
+         prediction models feed the confidence chip and the per-model chart.
+         Display labels are the agency / model acronyms — short, unambiguous
+         for the small audience that cares about this picker, and stable
+         across translations. -->
+    <string name="settings_forecasters_title">Forecast models</string>
+    <string name="settings_forecasters_description">The confidence chip and the per-model chart pull from these models. Picking more gives a richer spread; fewer means a tighter focus. At least two stay selected.</string>
+    <string name="settings_forecasters_ecmwf">ECMWF</string>
+    <string name="settings_forecasters_ecmwf_subtitle">European — generally the most accurate global model. 3-hourly on the open feed.</string>
+    <string name="settings_forecasters_icon">ICON</string>
+    <string name="settings_forecasters_icon_subtitle">German (DWD) — strong in Europe and at short range. Native hourly.</string>
+    <string name="settings_forecasters_gfs">GFS</string>
+    <string name="settings_forecasters_gfs_subtitle">American (NOAA) — strong over North America. Native hourly.</string>
+    <string name="settings_forecasters_gem">GEM</string>
+    <string name="settings_forecasters_gem_subtitle">Canadian (ECCC) — strong over North America. 3-hourly on the open feed.</string>
+    <string name="settings_forecasters_arpege">ARPEGE</string>
+    <string name="settings_forecasters_arpege_subtitle">French (Météo-France) — strong over France and Western Europe. Native hourly.</string>
+    <string name="settings_forecasters_ukmo">UKMO</string>
+    <string name="settings_forecasters_ukmo_subtitle">British (UK Met Office) — historically second only to ECMWF. 3-hourly on the open feed.</string>
+    <string name="settings_forecasters_jma">JMA</string>
+    <string name="settings_forecasters_jma_subtitle">Japanese — strong over Asia-Pacific. 3- to 6-hourly on the open feed.</string>
+    <string name="settings_forecasters_bom">BOM</string>
+    <string name="settings_forecasters_bom_subtitle">Australian — strong over Australasia. 3-hourly on the open feed.</string>
 
     <!-- Privacy settings sub-page. The toggle controls Firebase Analytics +
          Crashlytics collection at runtime; PRIVACY.md spells out the data

--- a/app/src/test/kotlin/app/clothescast/data/SettingsRepositoryTest.kt
+++ b/app/src/test/kotlin/app/clothescast/data/SettingsRepositoryTest.kt
@@ -11,6 +11,7 @@ import app.clothescast.core.domain.model.ColorPalette
 import app.clothescast.core.domain.model.DeliveryMode
 import app.clothescast.core.domain.model.DistanceUnit
 import app.clothescast.core.domain.model.DistanceUnitSetting
+import app.clothescast.core.domain.model.ForecastModel
 import app.clothescast.core.domain.model.OutfitSuggestion
 import app.clothescast.core.domain.model.Region
 import app.clothescast.core.domain.model.Schedule
@@ -820,6 +821,46 @@ class SettingsRepositoryTest {
         snap.coatDeltaC shouldBe ClothesRulesSnapshot.MISSING
         snap.customisedCount shouldBe 1
         snap.categoriesCustomised shouldBe "coat"
+    }
+
+    @Test
+    fun `forecast models default to the shipping trio`() = runTest {
+        subject.preferences.first().forecastModels shouldBe ForecastModel.DEFAULTS
+    }
+
+    @Test
+    fun `forecast models setter round-trips arbitrary subsets`() = runTest {
+        // Cover every ForecastModel value so adding or dropping an entry
+        // without keeping the persistence path in sync shows up here.
+        // Stored as enum names; the read-back side resolves them back.
+        for (model in ForecastModel.entries) {
+            val subset = ForecastModel.DEFAULTS + model
+            subject.setForecastModels(subset)
+            subject.preferences.first().forecastModels shouldBe subset
+        }
+    }
+
+    @Test
+    fun `setting forecast models to empty falls back to defaults on read`() = runTest {
+        // An empty set never reaches this path from the UI (the picker
+        // enforces a minimum of two), but a hand-edited DataStore could.
+        // The empty key gets cleared; the next read returns the trio.
+        subject.setForecastModels(emptySet())
+        subject.preferences.first().forecastModels shouldBe ForecastModel.DEFAULTS
+    }
+
+    @Test
+    fun `forecast models tolerate unknown stored enum names`() = runTest {
+        // Forward-compat: a future build that adds a new model variant
+        // and writes its name shouldn't break earlier installs reading
+        // it back. The unknown entry silently disappears; known entries
+        // survive.
+        dataStore.edit {
+            it[stringSetPreferencesKey("forecast_models")] =
+                setOf("ECMWF_IFS04", "FUTURE_MODEL_VARIANT", "GFS_SEAMLESS")
+        }
+        subject.preferences.first().forecastModels shouldBe
+            setOf(ForecastModel.ECMWF_IFS04, ForecastModel.GFS_SEAMLESS)
     }
 
     @Test

--- a/app/src/test/kotlin/app/clothescast/ui/theme/AppPaletteTest.kt
+++ b/app/src/test/kotlin/app/clothescast/ui/theme/AppPaletteTest.kt
@@ -4,6 +4,7 @@ import androidx.compose.material3.lightColorScheme
 import androidx.compose.ui.graphics.Color
 import app.clothescast.core.domain.model.ColorPalette
 import app.clothescast.core.domain.model.ForecastConfidence
+import app.clothescast.core.domain.model.ForecastModel
 import app.clothescast.core.domain.model.PerModelHourly.Companion.BEST_MATCH_MODEL_ID
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
@@ -28,12 +29,7 @@ class AppPaletteTest {
     @Test
     fun `RAINBOW palette carries every model id and every confidence tier`() {
         val palette = appPaletteFor(scheme, darkTheme = false, colorPalette = ColorPalette.RAINBOW)
-        palette.modelColors.keys shouldBe setOf(
-            "ecmwf_ifs04",
-            "gfs_seamless",
-            "icon_seamless",
-            BEST_MATCH_MODEL_ID,
-        )
+        palette.modelColors.keys shouldBe expectedModelKeys()
         palette.confidence.keys shouldBe ForecastConfidence.entries.toSet()
         palette.confidence.size shouldBe 3
     }
@@ -41,12 +37,7 @@ class AppPaletteTest {
     @Test
     fun `ACCESSIBLE palette carries every model id and every confidence tier`() {
         val palette = appPaletteFor(scheme, darkTheme = false, colorPalette = ColorPalette.ACCESSIBLE)
-        palette.modelColors.keys shouldBe setOf(
-            "ecmwf_ifs04",
-            "gfs_seamless",
-            "icon_seamless",
-            BEST_MATCH_MODEL_ID,
-        )
+        palette.modelColors.keys shouldBe expectedModelKeys()
         palette.confidence.keys shouldBe ForecastConfidence.entries.toSet()
     }
 
@@ -94,14 +85,19 @@ class AppPaletteTest {
     @Test
     fun `HIGHLIGHTER palette carries every model id and every confidence tier`() {
         val palette = appPaletteFor(scheme, darkTheme = false, colorPalette = ColorPalette.HIGHLIGHTER)
-        palette.modelColors.keys shouldBe setOf(
-            "ecmwf_ifs04",
-            "gfs_seamless",
-            "icon_seamless",
-            BEST_MATCH_MODEL_ID,
-        )
+        palette.modelColors.keys shouldBe expectedModelKeys()
         palette.confidence.keys shouldBe ForecastConfidence.entries.toSet()
     }
+
+    /**
+     * Every [ForecastModel] the user can select in Settings ▸ Forecasters
+     * plus the synthetic best-match overlay. Derived from the enum so adding
+     * a new model in the domain layer trips this test until the palettes
+     * gain a matching colour, rather than crashing at chart render via a
+     * `.getValue(modelId)` lookup miss.
+     */
+    private fun expectedModelKeys(): Set<String> =
+        ForecastModel.entries.map { it.openMeteoId }.toSet() + BEST_MATCH_MODEL_ID
 
     @Test
     fun `HIGHLIGHTER palette uses distinct hues from both RAINBOW and ACCESSIBLE`() {

--- a/core/data/src/main/kotlin/app/clothescast/core/data/weather/MultiModelConfidenceFetcher.kt
+++ b/core/data/src/main/kotlin/app/clothescast/core/data/weather/MultiModelConfidenceFetcher.kt
@@ -175,6 +175,37 @@ internal class MultiModelConfidenceFetcher(
                 if (precips == null) {
                     logger.log("model $model hourly: precipitation_probability missing, precip-specific aggregates will skip this model")
                 }
+                // Diagnostic fields — each chart hides this model's line on
+                // its own card when the field is wholesale absent, so the
+                // user-visible failure mode is "model X has no UV line" with
+                // no explanation. Log each missing diagnostic series so a
+                // Diagnostics scrape carries the per-model per-variable
+                // coverage map. Open-Meteo's per-model coverage varies
+                // widely (GFS exposes uv_index, ICON doesn't; ECMWF exposes
+                // sunshine_duration, GFS doesn't; etc.) and surfacing the
+                // gaps explicitly turns a silent-empty chart into an
+                // observable contract miss.
+                if (winds == null) {
+                    logger.log("model $model hourly: wind_speed_10m missing, wind chart will skip this model")
+                }
+                if (humidities == null) {
+                    logger.log("model $model hourly: relative_humidity_2m missing, humidity chart will skip this model")
+                }
+                if (clouds == null) {
+                    logger.log("model $model hourly: cloud_cover_low missing, cloud chart will skip this model")
+                }
+                if (solar == null) {
+                    logger.log("model $model hourly: shortwave_radiation missing, solar chart will skip this model")
+                }
+                if (sunshine == null) {
+                    logger.log("model $model hourly: sunshine_duration missing, sunshine chart will skip this model")
+                }
+                if (uv == null) {
+                    logger.log("model $model hourly: uv_index missing, UV chart will skip this model")
+                }
+                if (weatherCodes == null) {
+                    logger.log("model $model hourly: weather_code missing, consensus condition will skip this model's vote")
+                }
                 val entries = buildList {
                     for (i in 0 until times.size) {
                         val time = parseHour(times.getOrNull(i)) ?: continue

--- a/core/data/src/main/kotlin/app/clothescast/core/data/weather/MultiModelConfidenceFetcher.kt
+++ b/core/data/src/main/kotlin/app/clothescast/core/data/weather/MultiModelConfidenceFetcher.kt
@@ -173,23 +173,25 @@ internal class MultiModelConfidenceFetcher(
                     logger.log("model $model hourly: apparent_temperature missing, falling back to temperature_2m")
                 }
                 if (precips == null) {
-                    logger.log("model $model hourly: precipitation_probability missing, falling back to 0%")
+                    logger.log("model $model hourly: precipitation_probability missing, precip-specific aggregates will skip this model")
                 }
                 val entries = buildList {
                     for (i in 0 until times.size) {
                         val time = parseHour(times.getOrNull(i)) ?: continue
-                        // Required per-hour: time and air temp. Apparent and
-                        // precip both fall back to a sensible default so a
-                        // model whose Open-Meteo coverage of those fields is
-                        // partial still renders its temperature curve.
-                        // Diagnostic fields (wind, humidity, cloud, condition)
-                        // survive per-field nulls; we just carry through
-                        // what we got so the diagnostic charts and the
-                        // consensus blend hide that model only when *its*
-                        // field is missing.
+                        // Required per-hour: time and air temp. Apparent
+                        // falls back to air temp when missing (the
+                        // feels-like curve degrades to raw 2 m air for
+                        // that model). Precip stays null when missing —
+                        // do NOT fall back to 0 because the precipitation
+                        // chart, consensus blend, and insight rain prose
+                        // all need to distinguish "model predicts no rain"
+                        // from "model didn't provide a precip forecast"
+                        // and a synthetic zero silently downgrades all of
+                        // them. Diagnostic fields (wind, humidity, cloud,
+                        // condition) survive per-field nulls.
                         val air = numberAt(airTemps, i)?.toDouble() ?: continue
                         val apparent = numberAt(apparentTemps, i)?.toDouble() ?: air
-                        val precip = numberAt(precips, i)?.toDouble() ?: 0.0
+                        val precip = numberAt(precips, i)?.toDouble()
                         add(
                             PerModelHour(
                                 time = time,

--- a/core/data/src/main/kotlin/app/clothescast/core/data/weather/MultiModelConfidenceFetcher.kt
+++ b/core/data/src/main/kotlin/app/clothescast/core/data/weather/MultiModelConfidenceFetcher.kt
@@ -53,11 +53,18 @@ import java.time.LocalDateTime
  */
 internal class MultiModelConfidenceFetcher(
     private val httpClient: HttpClient,
-    private val models: List<String> = DEFAULT_MODELS,
     private val logger: ConfidenceFetchLogger = NoOpConfidenceFetchLogger,
     private val apiCallLogger: ApiCallLogger = NoOpApiCallLogger,
 ) {
-    suspend fun fetch(location: Location): MultiModelData? = try {
+    suspend fun fetch(
+        location: Location,
+        models: List<String> = DEFAULT_MODELS,
+    ): MultiModelData? = try {
+        // Tolerate a degenerate user selection by falling back to defaults rather
+        // than firing a `models=` parameter that Open-Meteo would reject. The
+        // settings UI keeps the picker pinned to ≥ 2 enabled, so this branch is
+        // a hand-edited-DataStore safety net more than a user-reachable path.
+        val effectiveModels = models.takeIf { it.isNotEmpty() } ?: DEFAULT_MODELS
         val response = apiCallLogger.instrument(ApiEndpoints.OPEN_METEO_CONFIDENCE) {
             httpClient.get {
                 expectSuccess = true
@@ -90,12 +97,12 @@ internal class MultiModelConfidenceFetcher(
                         "wind_speed_10m,relative_humidity_2m,cloud_cover_low," +
                         "shortwave_radiation,sunshine_duration,uv_index,weather_code",
                 )
-                parameter("models", models.joinToString(","))
+                parameter("models", effectiveModels.joinToString(","))
             }.body<MultiModelResponse>()
         }
 
-        val confidence = computeConfidence(response.daily)
-        val hourly = parseHourly(response.hourly)
+        val confidence = computeConfidence(response.daily, effectiveModels)
+        val hourly = parseHourly(response.hourly, effectiveModels)
         if (confidence == null && hourly == null) null else MultiModelData(confidence, hourly)
     } catch (ce: CancellationException) {
         throw ce
@@ -104,7 +111,7 @@ internal class MultiModelConfidenceFetcher(
         null
     }
 
-    private fun computeConfidence(daily: JsonObject): ConfidenceInfo? {
+    private fun computeConfidence(daily: JsonObject, models: List<String>): ConfidenceInfo? {
         val results = buildList {
             for (model in models) {
                 when (val outcome = readModelDaily(daily, model)) {
@@ -124,7 +131,7 @@ internal class MultiModelConfidenceFetcher(
         return compute(results)
     }
 
-    private fun parseHourly(hourly: JsonObject?): PerModelHourly? {
+    private fun parseHourly(hourly: JsonObject?, models: List<String>): PerModelHourly? {
         val obj = hourly ?: return null
         val times = (obj["time"] as? JsonArray) ?: return null
         val byModel = buildMap<String, List<PerModelHour>> {

--- a/core/data/src/main/kotlin/app/clothescast/core/data/weather/MultiModelConfidenceFetcher.kt
+++ b/core/data/src/main/kotlin/app/clothescast/core/data/weather/MultiModelConfidenceFetcher.kt
@@ -152,18 +152,44 @@ internal class MultiModelConfidenceFetcher(
                 // simply absent for that model and the UV card hides its line.
                 val uv = obj["uv_index_$model"] as? JsonArray
                 val weatherCodes = obj["weather_code_$model"] as? JsonArray
-                if (apparentTemps == null && airTemps == null && precips == null) continue
+                // Hard requirement: temperature_2m. Without it the chart has
+                // nothing to plot for this model and the consensus blend
+                // can't average it in. Open-Meteo silently omits per-model
+                // variables when a model doesn't expose them — so log the
+                // drop with the reason rather than dropping silently like
+                // the previous code did. Mirrors readModelDaily above.
+                if (airTemps == null) {
+                    logger.log("model $model dropped from hourly: temperature_2m missing")
+                    continue
+                }
+                // Soft requirements: log per-model when apparent_temperature
+                // or precipitation_probability is wholesale missing so the
+                // user can see why a chart looks flat (precip) or follows
+                // raw air (apparent). The model still renders — `apparent`
+                // falls back to `air`, `precip` falls back to 0% per hour
+                // below — but the cause is logged so a Diagnostics scrape
+                // explains the surprise.
+                if (apparentTemps == null) {
+                    logger.log("model $model hourly: apparent_temperature missing, falling back to temperature_2m")
+                }
+                if (precips == null) {
+                    logger.log("model $model hourly: precipitation_probability missing, falling back to 0%")
+                }
                 val entries = buildList {
                     for (i in 0 until times.size) {
                         val time = parseHour(times.getOrNull(i)) ?: continue
-                        // Required: time, apparent temp, air temp, precip — drop the hour
-                        // when any of these are null. Diagnostic fields (wind, humidity,
-                        // cloud, condition) survive per-field nulls; we just carry through
-                        // what we got so the diagnostic charts and the consensus blend hide
-                        // that model only when *its* field is missing.
-                        val apparent = numberAt(apparentTemps, i)?.toDouble() ?: continue
+                        // Required per-hour: time and air temp. Apparent and
+                        // precip both fall back to a sensible default so a
+                        // model whose Open-Meteo coverage of those fields is
+                        // partial still renders its temperature curve.
+                        // Diagnostic fields (wind, humidity, cloud, condition)
+                        // survive per-field nulls; we just carry through
+                        // what we got so the diagnostic charts and the
+                        // consensus blend hide that model only when *its*
+                        // field is missing.
                         val air = numberAt(airTemps, i)?.toDouble() ?: continue
-                        val precip = numberAt(precips, i)?.toDouble() ?: continue
+                        val apparent = numberAt(apparentTemps, i)?.toDouble() ?: air
+                        val precip = numberAt(precips, i)?.toDouble() ?: 0.0
                         add(
                             PerModelHour(
                                 time = time,
@@ -182,7 +208,11 @@ internal class MultiModelConfidenceFetcher(
                         )
                     }
                 }
-                if (entries.isNotEmpty()) put(model, entries)
+                if (entries.isEmpty()) {
+                    logger.log("model $model dropped from hourly: no usable hours after parsing")
+                } else {
+                    put(model, entries)
+                }
             }
         }
         return if (byModel.isEmpty()) null else PerModelHourly(byModel)

--- a/core/data/src/main/kotlin/app/clothescast/core/data/weather/OpenMeteoClient.kt
+++ b/core/data/src/main/kotlin/app/clothescast/core/data/weather/OpenMeteoClient.kt
@@ -56,6 +56,21 @@ class OpenMeteoClient(
     private val httpClient: HttpClient,
     confidenceLogger: ConfidenceFetchLogger = NoOpConfidenceFetchLogger,
     private val apiCallLogger: ApiCallLogger = NoOpApiCallLogger,
+    /**
+     * Snapshot of which Open-Meteo model IDs the multi-model confidence
+     * fetcher should consult on the next call. Read fresh on every
+     * [fetchForecast] so a Forecasters-settings change takes effect on the
+     * next refresh without rebuilding the client. Suspending so the
+     * `:app`-side wiring can `settingsRepository.preferences.first()`
+     * directly without staging through a StateFlow snapshot. DataStore
+     * caches the latest emission, so on the warm path the read is a memory
+     * hit and runs inside the same coroutine that's about to launch the
+     * parallel fetches — no measurable added latency. Defaults to the
+     * three-model trio for tests and any caller that doesn't wire a
+     * settings-backed provider.
+     */
+    private val confidenceModelsProvider: suspend () -> List<String> =
+        { MultiModelConfidenceFetcher.DEFAULT_MODELS },
 ) : WeatherRepository {
 
     // Constructed once per client. Exposing it on the public constructor would
@@ -74,7 +89,8 @@ class OpenMeteoClient(
         // latency behind the primary fetch.
         val primary = async { fetchPrimary(location) }
         val alerts = async { fetchAlerts(location) }
-        val multiModel = async { confidenceFetcher.fetch(location) }
+        val models = confidenceModelsProvider()
+        val multiModel = async { confidenceFetcher.fetch(location, models) }
 
         val bundle = OpenMeteoMapper.toBundle(primary.await())
         val multi = multiModel.await()

--- a/core/data/src/test/kotlin/app/clothescast/core/data/weather/MultiModelConfidenceFetcherTest.kt
+++ b/core/data/src/test/kotlin/app/clothescast/core/data/weather/MultiModelConfidenceFetcherTest.kt
@@ -208,14 +208,71 @@ class MultiModelConfidenceFetcherTest {
     }
 
     @Test
-    fun `drops a model's hourly entry when a single hour reports nulls`() = runTest {
+    fun `drops a model's hourly entry when temperature_2m is null for that hour`() = runTest {
         val hourly = fetcherWith(HOURLY_WITH_ONE_NULL_HOUR).fetch(london)?.hourly.shouldNotBeNull()
 
         val ecmwf = hourly.byModel.getValue("ecmwf_ifs04")
-        // Hour 1 had a null apparent_temperature for ecmwf; the entry is dropped,
-        // but the other two hours survive.
+        // Hour 1 had a null temperature_2m for ecmwf; the entry is dropped,
+        // but the other two hours survive. apparent_temperature and
+        // precipitation_probability are now optional per-hour — temperature_2m
+        // is the only required field — so a per-hour drop only happens when
+        // the air-temp value itself is null.
         ecmwf.map { it.time } shouldContainExactlyInAnyOrder
             listOf(LocalDateTime.parse("2026-05-12T00:00"), LocalDateTime.parse("2026-05-12T02:00"))
+    }
+
+    @Test
+    fun `model still renders when only apparent_temperature is missing`() = runTest {
+        // Open-Meteo silently omits per-model variables that a particular
+        // model doesn't expose. Pre-fix, a model missing apparent_temperature
+        // entirely would drop from the chart because every hour's `apparent`
+        // value was null and the parser `?: continue`'d each one. The fix
+        // falls back to temperature_2m for the apparent series, so the model
+        // still renders — just with the raw air-temp curve in feels-like
+        // mode rather than a wind-chill-adjusted one.
+        val logger = CapturingLogger()
+        val hourly = fetcherWith(HOURLY_MISSING_APPARENT_TEMPERATURE, logger = logger)
+            .fetch(london)?.hourly.shouldNotBeNull()
+
+        val ecmwf = hourly.byModel.getValue("ecmwf_ifs04")
+        ecmwf.size shouldBe 3
+        // apparent_temperature falls back to temperature_2m per hour
+        ecmwf[0].apparentTemperatureC shouldBe (14.0 plusOrMinus 0.0001)
+        ecmwf[0].temperatureC shouldBe (14.0 plusOrMinus 0.0001)
+        // Log entry surfaces the substitution so a Diagnostics scrape
+        // explains why the apparent series mirrors air temp.
+        logger.entries.any { "ecmwf_ifs04" in it.message && "apparent_temperature missing" in it.message } shouldBe true
+    }
+
+    @Test
+    fun `model still renders when only precipitation_probability is missing`() = runTest {
+        // BOM-like case (the variable some models don't expose): we keep the
+        // model in the chart, default per-hour precip to 0%, and log the
+        // substitution.
+        val logger = CapturingLogger()
+        val hourly = fetcherWith(HOURLY_MISSING_PRECIP_PROBABILITY, logger = logger)
+            .fetch(london)?.hourly.shouldNotBeNull()
+
+        val ecmwf = hourly.byModel.getValue("ecmwf_ifs04")
+        ecmwf.size shouldBe 3
+        ecmwf.all { it.precipitationProbabilityPct == 0.0 } shouldBe true
+        logger.entries.any { "ecmwf_ifs04" in it.message && "precipitation_probability missing" in it.message } shouldBe true
+    }
+
+    @Test
+    fun `model drops entirely when temperature_2m is wholesale missing`() = runTest {
+        // Without an air-temperature series the chart has nothing to draw,
+        // and the consensus blend has no temp signal to fold in. Log + drop.
+        val logger = CapturingLogger()
+        val hourly = fetcherWith(HOURLY_MISSING_AIR_TEMPERATURE, logger = logger)
+            .fetch(london)?.hourly
+
+        // ecmwf is the only model in this fixture; with it dropped, byModel
+        // is empty and parseHourly returns null.
+        hourly shouldBe null
+        logger.entries.any {
+            "ecmwf_ifs04" in it.message && "temperature_2m missing" in it.message
+        } shouldBe true
     }
 
     @Test
@@ -411,8 +468,9 @@ class MultiModelConfidenceFetcherTest {
             }
         """.trimIndent()
 
-        // ecmwf is missing its T+1 hour: the entry should be dropped, not the
-        // whole model. gfs + icon are fully populated.
+        // ecmwf is missing its T+1 temperature_2m: the entry should be
+        // dropped, not the whole model. gfs + icon are fully populated.
+        // temperature_2m is the only required per-hour field now.
         private val HOURLY_WITH_ONE_NULL_HOUR = """
             {
               "daily": {
@@ -426,15 +484,77 @@ class MultiModelConfidenceFetcherTest {
               },
               "hourly": {
                 "time": ["2026-05-12T00:00", "2026-05-12T01:00", "2026-05-12T02:00"],
-                "apparent_temperature_ecmwf_ifs04": [12.0, null, 11.0],
+                "apparent_temperature_ecmwf_ifs04": [12.0, 11.5, 11.0],
                 "apparent_temperature_gfs_seamless": [12.2, 11.8, 11.4],
                 "apparent_temperature_icon_seamless": [13.0, 12.6, 12.0],
-                "temperature_2m_ecmwf_ifs04": [14.0, 13.5, 13.0],
+                "temperature_2m_ecmwf_ifs04": [14.0, null, 13.0],
                 "temperature_2m_gfs_seamless": [14.2, 13.8, 13.4],
                 "temperature_2m_icon_seamless": [15.0, 14.6, 14.0],
                 "precipitation_probability_ecmwf_ifs04": [10, 15, 20],
                 "precipitation_probability_gfs_seamless": [12, 18, 22],
                 "precipitation_probability_icon_seamless": [18, 22, 28]
+              }
+            }
+        """.trimIndent()
+
+        // ecmwf's `apparent_temperature_<model>` array is omitted entirely.
+        // Pre-fix this would have silently dropped ecmwf from the per-model
+        // chart; post-fix the model still renders with apparent falling back
+        // to temperature_2m and a log entry explaining the substitution.
+        private val HOURLY_MISSING_APPARENT_TEMPERATURE = """
+            {
+              "daily": {
+                "time": ["2026-05-12"],
+                "apparent_temperature_max_ecmwf_ifs04": [21.0],
+                "apparent_temperature_max_gfs_seamless": [21.5],
+                "precipitation_probability_max_ecmwf_ifs04": [10],
+                "precipitation_probability_max_gfs_seamless": [15]
+              },
+              "hourly": {
+                "time": ["2026-05-12T00:00", "2026-05-12T01:00", "2026-05-12T02:00"],
+                "temperature_2m_ecmwf_ifs04": [14.0, 13.5, 13.0],
+                "temperature_2m_gfs_seamless": [14.2, 13.8, 13.4],
+                "precipitation_probability_ecmwf_ifs04": [10, 15, 20],
+                "precipitation_probability_gfs_seamless": [12, 18, 22]
+              }
+            }
+        """.trimIndent()
+
+        // ecmwf's `precipitation_probability_<model>` array is omitted.
+        // Model still renders; per-hour precip defaults to 0% and we log.
+        private val HOURLY_MISSING_PRECIP_PROBABILITY = """
+            {
+              "daily": {
+                "time": ["2026-05-12"],
+                "apparent_temperature_max_ecmwf_ifs04": [21.0],
+                "apparent_temperature_max_gfs_seamless": [21.5],
+                "precipitation_probability_max_ecmwf_ifs04": [10],
+                "precipitation_probability_max_gfs_seamless": [15]
+              },
+              "hourly": {
+                "time": ["2026-05-12T00:00", "2026-05-12T01:00", "2026-05-12T02:00"],
+                "apparent_temperature_ecmwf_ifs04": [12.0, 11.5, 11.0],
+                "apparent_temperature_gfs_seamless": [12.2, 11.8, 11.4],
+                "temperature_2m_ecmwf_ifs04": [14.0, 13.5, 13.0],
+                "temperature_2m_gfs_seamless": [14.2, 13.8, 13.4],
+                "precipitation_probability_gfs_seamless": [12, 18, 22]
+              }
+            }
+        """.trimIndent()
+
+        // ecmwf has no air temperature at all → chart has nothing to plot
+        // → model drops with a logged reason.
+        private val HOURLY_MISSING_AIR_TEMPERATURE = """
+            {
+              "daily": {
+                "time": ["2026-05-12"],
+                "apparent_temperature_max_ecmwf_ifs04": [21.0],
+                "precipitation_probability_max_ecmwf_ifs04": [10]
+              },
+              "hourly": {
+                "time": ["2026-05-12T00:00", "2026-05-12T01:00", "2026-05-12T02:00"],
+                "apparent_temperature_ecmwf_ifs04": [12.0, 11.5, 11.0],
+                "precipitation_probability_ecmwf_ifs04": [10, 15, 20]
               }
             }
         """.trimIndent()

--- a/core/data/src/test/kotlin/app/clothescast/core/data/weather/MultiModelConfidenceFetcherTest.kt
+++ b/core/data/src/test/kotlin/app/clothescast/core/data/weather/MultiModelConfidenceFetcherTest.kt
@@ -246,16 +246,20 @@ class MultiModelConfidenceFetcherTest {
 
     @Test
     fun `model still renders when only precipitation_probability is missing`() = runTest {
-        // BOM-like case (the variable some models don't expose): we keep the
-        // model in the chart, default per-hour precip to 0%, and log the
-        // substitution.
+        // The case some models hit (UKMO / JMA / GEM / ARPEGE): Open-Meteo
+        // doesn't expose `precipitation_probability_<model>` for them. We keep
+        // the model in the chart on the strength of its temperature series,
+        // leave precip null per hour so precip-specific aggregates (consensus
+        // blend, insight rain prose, precipitation chart) can skip the model
+        // rather than treating it as a 0% rain vote, and log the substitution
+        // so the cause is observable from Diagnostics.
         val logger = CapturingLogger()
         val hourly = fetcherWith(HOURLY_MISSING_PRECIP_PROBABILITY, logger = logger)
             .fetch(london)?.hourly.shouldNotBeNull()
 
         val ecmwf = hourly.byModel.getValue("ecmwf_ifs04")
         ecmwf.size shouldBe 3
-        ecmwf.all { it.precipitationProbabilityPct == 0.0 } shouldBe true
+        ecmwf.all { it.precipitationProbabilityPct == null } shouldBe true
         logger.entries.any { "ecmwf_ifs04" in it.message && "precipitation_probability missing" in it.message } shouldBe true
     }
 

--- a/core/data/src/test/kotlin/app/clothescast/core/data/weather/MultiModelConfidenceFetcherTest.kt
+++ b/core/data/src/test/kotlin/app/clothescast/core/data/weather/MultiModelConfidenceFetcherTest.kt
@@ -86,6 +86,30 @@ class MultiModelConfidenceFetcherTest {
     }
 
     @Test
+    fun `caller-supplied models override the default trio in the request URL`() = runTest {
+        val captured = mutableListOf<HttpRequestData>()
+        val fetcher = fetcherWith(body = THREE_MODEL_AGREEMENT, capture = { captured += it })
+
+        fetcher.fetch(london, listOf("ukmo_seamless", "meteofrance_seamless"))
+
+        captured.single().url.parameters["models"] shouldBe "ukmo_seamless,meteofrance_seamless"
+    }
+
+    @Test
+    fun `empty caller-supplied models falls back to the default trio`() = runTest {
+        // The Forecasters settings UI keeps the picker pinned to at least
+        // two checked entries, so this path is a hand-edited-DataStore
+        // safety net. The fetcher recovers rather than firing an empty
+        // models= parameter that Open-Meteo would reject.
+        val captured = mutableListOf<HttpRequestData>()
+        val fetcher = fetcherWith(body = THREE_MODEL_AGREEMENT, capture = { captured += it })
+
+        fetcher.fetch(london, emptyList())
+
+        captured.single().url.parameters["models"] shouldBe "ecmwf_ifs04,gfs_seamless,icon_seamless"
+    }
+
+    @Test
     fun `tight spread across all three models returns HIGH confidence`() = runTest {
         val info = fetcherWith(THREE_MODEL_AGREEMENT).fetch(london)?.confidence.shouldNotBeNull()
 

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/ConfidenceInfo.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/ConfidenceInfo.kt
@@ -79,9 +79,18 @@ data class ConfidenceInfo(
                 .filterValues { it.isNotEmpty() }
             if (consulted.size < 2) return null
             val tempMaxes = consulted.values.map { hours -> hours.maxOf { it.apparentTemperatureC } }
-            val precipMaxes = consulted.values.map { hours -> hours.maxOf { it.precipitationProbabilityPct } }
+            // Models whose precipitation_probability is wholesale missing (Open-Meteo
+            // omits the per-model series for some models) contribute nothing to the
+            // precip-spread metric — including them with a fake zero would have
+            // silently inflated divergence on a calm day and downgraded confidence.
+            // When fewer than two models have any precip readings we ignore the
+            // precip dimension entirely and let the tier fall through to a temp-only
+            // decision.
+            val precipMaxes = consulted.values.mapNotNull { hours ->
+                hours.mapNotNull { it.precipitationProbabilityPct }.maxOrNull()
+            }
             val tempSpread = tempMaxes.max() - tempMaxes.min()
-            val precipSpread = precipMaxes.max() - precipMaxes.min()
+            val precipSpread = if (precipMaxes.size >= 2) precipMaxes.max() - precipMaxes.min() else 0.0
             val level = when {
                 tempSpread <= TEMP_HIGH_AGREEMENT_C && precipSpread <= PRECIP_HIGH_AGREEMENT_PP ->
                     ForecastConfidence.HIGH

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/ConsensusBlend.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/ConsensusBlend.kt
@@ -65,10 +65,23 @@ fun blendConsensusHourly(
             hour
         } else {
             anyBlended = true
+            // Precip is averaged only over candidates that actually
+            // provided a value — Open-Meteo omits per-model precipitation
+            // probability for some models (UKMO, JMA, GEM, ARPEGE, …) and
+            // including a synthetic 0 for those would silently downgrade
+            // the blended rain probability when *other* models predict
+            // rain. When no candidate had a precip reading at this hour,
+            // fall back to best_match's own value rather than NaN'ing.
+            val precipCandidates = candidates.mapNotNull { it.precipitationProbabilityPct }
+            val blendedPrecip = if (precipCandidates.isEmpty()) {
+                hour.precipitationProbabilityPct
+            } else {
+                precipCandidates.average()
+            }
             hour.copy(
                 temperatureC = candidates.map { it.temperatureC }.average(),
                 feelsLikeC = candidates.map { it.apparentTemperatureC }.average(),
-                precipitationProbabilityPct = candidates.map { it.precipitationProbabilityPct }.average(),
+                precipitationProbabilityPct = blendedPrecip,
                 condition = consensusCondition(
                     fallback = hour.condition,
                     candidates = candidates.mapNotNull { it.condition },

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/PerModelHourly.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/PerModelHourly.kt
@@ -56,8 +56,17 @@ data class PerModelHour(
      *  the chart can overlay model lines in air-temp mode (tap-to-toggle) too,
      *  not just in feels-like mode. */
     val temperatureC: Double,
-    /** Probability of measurable precipitation for the hour, 0–100. */
-    val precipitationProbabilityPct: Double,
+    /** Probability of measurable precipitation for the hour, 0–100. Nullable
+     *  because Open-Meteo doesn't expose `precipitation_probability_<model>`
+     *  for every model in its `&models=` set — UKMO / JMA / GEM / ARPEGE
+     *  routinely omit it. `null` means "this model didn't provide a precip
+     *  forecast for this hour", which consumers handle distinctly from
+     *  "this model predicted 0% rain": precip-specific aggregates
+     *  (consensus blend, insight rain prose, precipitation chart) skip
+     *  null values rather than treating them as zero, so a missing-data
+     *  model doesn't silently downgrade the morning rain forecast or
+     *  draw a misleading flat-0% line on the precip chart. */
+    val precipitationProbabilityPct: Double?,
     /** 10 m wind speed for the hour, km/h. Drives wind-chill in the
      *  feels-like formula — when models agree on air temp but disagree on
      *  feels-like, this is usually the culprit. Nullable: older cache

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Settings.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Settings.kt
@@ -366,9 +366,61 @@ data class UserPreferences(
     val outfitTopColors: Map<OutfitSuggestion.Top, Long> = emptyMap(),
     /** Sibling of [outfitTopColors] for the bottom-garment icons. */
     val outfitBottomColors: Map<OutfitSuggestion.Bottom, Long> = emptyMap(),
+    /**
+     * Which numerical-weather-prediction models the multi-model confidence
+     * fetcher consults. Defaults to [ForecastModel.DEFAULTS] (ECMWF / GFS /
+     * ICON) — the trio the chip has shipped with. Users with a regional
+     * preference can swap in ARPEGE / GEM / UKMO / JMA / BOM via the
+     * Forecasters settings sub-screen.
+     *
+     * Stored as a [Set] because order doesn't matter — the URL builder
+     * sorts to a deterministic comma-separated list, and the confidence
+     * chip / per-model chart don't depend on a particular ordering.
+     */
+    val forecastModels: Set<ForecastModel> = ForecastModel.DEFAULTS,
 ) {
     companion object {
         const val DEFAULT_GEMINI_VOICE = "Despina"
+    }
+}
+
+/**
+ * Numerical weather prediction model the multi-model confidence fetcher can
+ * consult. Each entry's [openMeteoId] is the string Open-Meteo's `models=`
+ * parameter expects — the data layer reads it when building the URL, so the
+ * domain doesn't have to leak Open-Meteo specifics anywhere else.
+ *
+ * The set the user has enabled lives at [UserPreferences.forecastModels].
+ * Default is the trio that's been shipping: ECMWF, GFS, ICON — three
+ * independent global majors (European, American, German), chosen for
+ * dynamical-core diversity rather than for each being the most accurate
+ * individually. Users who care about the spread (or whose region has a
+ * stronger regional model) can swap in others via the Forecasters picker.
+ *
+ * Note on temporal cadence: ECMWF IFS, GEM, UKMO, JMA, and BOM are 3- or
+ * 6-hourly on the open-data feed Open-Meteo distributes, which Open-Meteo
+ * interpolates to hourly. ICON, GFS, and ARPEGE are natively hourly. This
+ * matters for the per-model chart's hour-by-hour curves but not for the
+ * daily-aggregate confidence chip.
+ */
+enum class ForecastModel(val openMeteoId: String) {
+    ECMWF_IFS04("ecmwf_ifs04"),
+    ICON_SEAMLESS("icon_seamless"),
+    GFS_SEAMLESS("gfs_seamless"),
+    GEM_SEAMLESS("gem_seamless"),
+    METEOFRANCE_SEAMLESS("meteofrance_seamless"),
+    UKMO_SEAMLESS("ukmo_seamless"),
+    JMA_SEAMLESS("jma_seamless"),
+    BOM_ACCESS_GLOBAL("bom_access_global");
+
+    companion object {
+        /**
+         * The three models the confidence chip has shipped with — ECMWF, GFS,
+         * ICON. Used as the default for [UserPreferences.forecastModels] and
+         * as the fallback when the user has somehow deselected everything
+         * (the picker's UI prevents that, but a hand-edited DataStore could).
+         */
+        val DEFAULTS: Set<ForecastModel> = setOf(ECMWF_IFS04, GFS_SEAMLESS, ICON_SEAMLESS)
     }
 }
 

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Settings.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Settings.kt
@@ -404,9 +404,15 @@ data class UserPreferences(
  * daily-aggregate confidence chip.
  */
 enum class ForecastModel(val openMeteoId: String) {
+    // Order matters: the chart's MODEL_DRAW_ORDER and the per-model legend
+    // derive from `entries`, so the per-overlay z-order on Today's charts is
+    // the entry order below + best_match last. Keep the original shipping
+    // trio (ECMWF / GFS / ICON) at the head so the layered render stays
+    // pixel-identical to pre-picker builds; new models append in
+    // geographical-spread order (NA → Europe → Asia-Pacific).
     ECMWF_IFS04("ecmwf_ifs04"),
-    ICON_SEAMLESS("icon_seamless"),
     GFS_SEAMLESS("gfs_seamless"),
+    ICON_SEAMLESS("icon_seamless"),
     GEM_SEAMLESS("gem_seamless"),
     METEOFRANCE_SEAMLESS("meteofrance_seamless"),
     UKMO_SEAMLESS("ukmo_seamless"),

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Settings.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Settings.kt
@@ -416,8 +416,14 @@ enum class ForecastModel(val openMeteoId: String) {
     GEM_SEAMLESS("gem_seamless"),
     METEOFRANCE_SEAMLESS("meteofrance_seamless"),
     UKMO_SEAMLESS("ukmo_seamless"),
-    JMA_SEAMLESS("jma_seamless"),
-    BOM_ACCESS_GLOBAL("bom_access_global");
+    JMA_SEAMLESS("jma_seamless");
+    // BOM_ACCESS_GLOBAL deliberately excluded — Open-Meteo's BOM docs note
+    // that "BOM is currently upgrading its key platforms and services. During
+    // this process, open-data delivery has been temporarily suspended." With
+    // open-data suspended, requesting BOM returns no usable fields and the
+    // model silently disappears from the chart. Re-add the enum entry +
+    // string resources + palette colours when BOM resumes delivery.
+    // See https://open-meteo.com/en/docs/bom-api
 
     companion object {
         /**

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/repository/CachingWeatherRepository.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/repository/CachingWeatherRepository.kt
@@ -41,10 +41,27 @@ class CachingWeatherRepository(
     private val clock: Clock = Clock.systemDefaultZone(),
     private val ttl: Duration = Duration.ofHours(1),
     private val locationGridDegrees: Double = 0.01,
+    /**
+     * Pull-based opaque discriminator for inputs *other than location* that
+     * change which forecast the delegate would return — currently the user's
+     * Forecasters model selection (see [ClothesCastApplication]). The cache
+     * stores whatever value this returned at fetch time and treats the entry
+     * as stale on mismatch, so a settings change takes effect on the next
+     * refresh instead of waiting out the TTL. Default returns [Unit] (a
+     * single value that matches itself), preserving the location-only
+     * behaviour for tests and any delegate whose output doesn't depend on
+     * out-of-band state.
+     *
+     * Suspend so a settings-backed provider can `dataStore.first()` without
+     * needing a separately-maintained snapshot. DataStore caches the latest
+     * emission in memory, so on the warm path this is a memory hit.
+     */
+    private val freshnessKeyProvider: suspend () -> Any = { Unit },
 ) : WeatherRepository {
 
     private data class Entry(
         val key: LocationKey,
+        val freshnessKey: Any,
         val fetchedAt: Instant,
         val bundle: ForecastBundle,
     )
@@ -56,6 +73,7 @@ class CachingWeatherRepository(
 
     override suspend fun fetchForecast(location: Location): ForecastBundle = mutex.withLock {
         val key = keyOf(location)
+        val freshnessKey = freshnessKeyProvider()
         val now = clock.instant()
         val today = LocalDate.now(clock)
         val cached = entry
@@ -67,13 +85,14 @@ class CachingWeatherRepository(
         if (
             cached != null &&
             cached.key == key &&
+            cached.freshnessKey == freshnessKey &&
             !cached.bundle.today.date.isBefore(today) &&
             Duration.between(cached.fetchedAt, now) < ttl
         ) {
             return@withLock cached.bundle
         }
         val fresh = delegate.fetchForecast(location)
-        entry = Entry(key = key, fetchedAt = now, bundle = fresh)
+        entry = Entry(key = key, freshnessKey = freshnessKey, fetchedAt = now, bundle = fresh)
         fresh
     }
 

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/RenderInsightSummary.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/RenderInsightSummary.kt
@@ -203,13 +203,24 @@ class RenderInsightSummary {
         val hours = models.flatMap { entries -> entries.map { it.time } }.toSortedSet()
         val likelyHour = hours
             .mapNotNull { hour ->
-                val readings = models.mapNotNull { entries -> entries.firstOrNull { it.time == hour } }
+                // Readings with usable precip only: a model that reported
+                // temperature for this hour but no precipitation_probability
+                // (per the parser's null-precip handling) shouldn't count
+                // toward the per-hour majority for a rain decision. Filtering
+                // here also keeps the rain peak honest in mixed selections
+                // (e.g. ECMWF + UKMO) where one model has no precip series
+                // at all — without it, the missing-data model would be
+                // implicitly counted as "below threshold" and could veto
+                // the rain call.
+                val readings = models
+                    .mapNotNull { entries -> entries.firstOrNull { it.time == hour } }
+                    .filter { it.precipitationProbabilityPct != null }
                 if (readings.size < 2) return@mapNotNull null
                 val majorityOfReporters = readings.size / 2 + 1
-                val likelyCount = readings.count { it.precipitationProbabilityPct >= LIKELY_THRESHOLD }
+                val likelyCount = readings.count { (it.precipitationProbabilityPct ?: 0.0) >= LIKELY_THRESHOLD }
                 if (likelyCount >= majorityOfReporters) hour to readings else null
             }
-            .maxByOrNull { (_, readings) -> readings.maxOf { it.precipitationProbabilityPct } }
+            .maxByOrNull { (_, readings) -> readings.maxOf { it.precipitationProbabilityPct ?: 0.0 } }
             ?.first
             ?.toLocalTime()
         if (likelyHour != null) {
@@ -218,8 +229,8 @@ class RenderInsightSummary {
 
         val possibleHour = models.asSequence()
             .flatten()
-            .filter { it.precipitationProbabilityPct >= POSSIBLE_THRESHOLD }
-            .maxByOrNull { it.precipitationProbabilityPct }
+            .filter { (it.precipitationProbabilityPct ?: 0.0) >= POSSIBLE_THRESHOLD }
+            .maxByOrNull { it.precipitationProbabilityPct ?: 0.0 }
             ?.time
             ?.toLocalTime()
         if (possibleHour != null) {

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/repository/CachingWeatherRepositoryTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/repository/CachingWeatherRepositoryTest.kt
@@ -168,6 +168,57 @@ class CachingWeatherRepositoryTest {
     }
 
     @Test
+    fun `cache invalidates when the freshness key changes`() = runTest {
+        // Simulates the Forecasters-settings flow: a user changes the model
+        // set mid-TTL and refreshes. The cache must miss, not silently return
+        // the prior model set's bundle. The freshness key is opaque to the
+        // cache — we use Set<String> here as a stand-in for the real
+        // Set<ForecastModel> the app wires in.
+        val delegate = CountingRepository(response = ::bundle)
+        var currentKey: Set<String> = setOf("ecmwf", "gfs", "icon")
+        val subject = CachingWeatherRepository(
+            delegate = delegate,
+            clock = Clock.fixed(Instant.parse("2026-04-25T07:00:00Z"), ZoneOffset.UTC),
+            freshnessKeyProvider = { currentKey },
+        )
+
+        subject.fetchForecast(london)
+        delegate.callCount.get() shouldBe 1
+
+        // Identical key → cache hit.
+        subject.fetchForecast(london)
+        delegate.callCount.get() shouldBe 1
+
+        // User swaps GFS for UKMO mid-TTL → cache must miss.
+        currentKey = setOf("ecmwf", "ukmo", "icon")
+        subject.fetchForecast(london)
+        delegate.callCount.get() shouldBe 2
+
+        // Subsequent fetch with the new key is cached again.
+        subject.fetchForecast(london)
+        delegate.callCount.get() shouldBe 2
+    }
+
+    @Test
+    fun `freshness keys are compared by value not identity`() = runTest {
+        // The provider returns a fresh Set instance on every call (typical
+        // for a flow.first()-backed implementation). The cache must compare
+        // by value or it would invalidate on every fetch and the TTL would
+        // never bite.
+        val delegate = CountingRepository(response = ::bundle)
+        val subject = CachingWeatherRepository(
+            delegate = delegate,
+            clock = Clock.fixed(Instant.parse("2026-04-25T07:00:00Z"), ZoneOffset.UTC),
+            freshnessKeyProvider = { setOf("ecmwf", "gfs", "icon") },
+        )
+
+        subject.fetchForecast(london)
+        subject.fetchForecast(london)
+        subject.fetchForecast(london)
+        delegate.callCount.get() shouldBe 1
+    }
+
+    @Test
     fun `delegate errors propagate and the cache stays empty`() = runTest {
         val delegate = CountingRepository(response = { throw IOException("boom") })
         val clock = MutableClock(Instant.parse("2026-04-25T07:00:00Z"))


### PR DESCRIPTION
## Summary

Adds a **Forecasters** sub-screen to Settings letting you pick which numerical weather prediction models the multi-model confidence chip and per-model chart consult. Default stays the trio that ships today (ECMWF, GFS, ICON); the picker exposes five more global majors so the spread can be tuned to where you live.

| Model | Origin | Native cadence on the open feed |
|---|---|---|
| ECMWF | European Centre | 3-hourly (default) |
| GFS | NOAA (US) | hourly (default) |
| ICON | DWD (Germany) | hourly (default) |
| GEM | ECCC (Canada) | 3-hourly |
| ARPEGE | Météo-France | hourly |
| UKMO | UK Met Office | 3-hourly |
| JMA | Japan | 3- to 6-hourly |
| BOM | Australia | 3-hourly |

Regional-only models (HRRR, AROME, ICON-EU, ICON-D2) aren't separately exposed — they ride along inside the `_seamless` IDs Open-Meteo blends, so picking GFS already gives HRRR over CONUS, picking ARPEGE already gives AROME over France, etc.

## Architecture

- `ForecastModel` enum in `:core:domain` carries the Open-Meteo ID per entry so the data layer doesn't hard-code the strings. Entry order matches the original chart's left-to-right legend order (ECMWF / GFS / ICON first) so existing snapshots stay pixel-identical.
- `UserPreferences.forecastModels: Set<ForecastModel>` (default = `ForecastModel.DEFAULTS` = ECMWF / GFS / ICON).
- `MultiModelConfidenceFetcher.fetch()` now takes the model list per call (defaulting to the trio) instead of binding it at construction time, so a settings change takes effect on the next fetch.
- `:app` wires the user's selection into `OpenMeteoClient` via a suspending provider lambda that reads `settingsRepository.preferences.first().forecastModels` — DataStore caches the latest emission, so it's a memory hit after the first call.
- `MODEL_DRAW_ORDER` is derived from `ForecastModel.entries` so the chart, legend, and `PerModelDiagnosticCard` all keep up with the picker without per-file edits. `AppPalette.modelColors` gains an entry per new model in all three palettes (RAINBOW, ACCESSIBLE, HIGHLIGHTER) so `modelColors.getValue(modelId)` lookups can never miss.

## UX

- New `Forecasters` row in the Settings root, between **Calendar** and **Privacy**.
- Checkboxes for all 8 global models. Each row carries a one-line subtitle naming the agency, region of strength, and native cadence.
- **Min 2 selected** — the confidence chip needs at least two models to compute a cross-model spread; the second-to-last checked box is disabled.
- **Max 5 selected** — palette covers all 8 but 5 is the per-model chart's visual-readability floor; above the cap, unchecked rows go disabled with a hint line directing the user to deselect first. Already-checked rows stay interactable so a user at the cap can swap.
- `SettingsRepository` defends against an empty stored set, falling back to the shipping trio so a hand-edited DataStore can't break the chip. Above the cap, the repository / fetcher both still accept the value; the cap is UI-only.

## Privacy

No new data crosses the device boundary. The change only widens which Open-Meteo model IDs may appear in the existing `&models=` parameter on `/v1/forecast` — same endpoint, same keyless free tier, same coordinates. No new third-party hosts and no new payload fields.

## Test plan

- [x] `:core:domain:test` — `ForecastModel.DEFAULTS` is the trio; entries map cleanly to Open-Meteo IDs.
- [x] `:core:data:test` — fetcher honours caller-supplied models in the URL; empty list falls back to the trio.
- [x] `:app:testDebugUnitTest` — `SettingsRepository` round-trips every enum value, drops unknown stored names, and falls back to defaults on empty. `AppPaletteTest` derives the expected colour-key set from `ForecastModel.entries` so a future enum addition trips the test until palettes are updated.
- [x] Roborazzi snapshots — pixel-identical to pre-PR. `rememberPinnedLineProvider` was re-keyed on the per-visible-model colours rather than the full palette map so widening the map doesn't invalidate every chart's LineProvider.
- [x] `:app:assembleDebug` — APK builds cleanly with the new sub-screen and strings.
- [ ] Manual: install on a phone, open Settings → Forecasters, toggle a few models past the cap and below the floor, verify the confidence chip and per-model chart on Today update after the next refresh. Pending an APK build.

## Follow-up (separate PR)

The user asked about "same location → same default models, regardless of who the user is" — e.g. traveling to AU and getting BOM mixed in automatically. That's deliberately not in this PR; it'll land as a follow-up that derives a regional model addition from the *fetch location* (not the user's stored Region), so an installed-in-UK user travelling to AU picks up BOM transparently without re-entering the picker.