### PR TITLE
Credit Open-Meteo on the About and Forecasters pages

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/settings/AboutSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/AboutSettings.kt
@@ -113,6 +113,10 @@ private fun AboutCard() {
             modifier = Modifier.fillMaxWidth(),
         ) { Text(stringResource(R.string.settings_about_dontkillmyapp)) }
         TextButton(
+            onClick = { openUrl(context, OPEN_METEO_URL) },
+            modifier = Modifier.fillMaxWidth(),
+        ) { Text(stringResource(R.string.settings_about_open_meteo)) }
+        TextButton(
             onClick = {
                 if (bugReportConsentAcked) {
                     launchBugReport()

--- a/app/src/main/kotlin/app/clothescast/ui/settings/ForecasterSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/ForecasterSettings.kt
@@ -13,9 +13,11 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
@@ -48,6 +50,7 @@ internal fun ForecastersContent(
     padding: PaddingValues,
     onSetForecastModels: (Set<ForecastModel>) -> Unit,
 ) {
+    val context = LocalContext.current
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -89,6 +92,10 @@ internal fun ForecastersContent(
                     },
                 )
             }
+            TextButton(
+                onClick = { openUrl(context, OPEN_METEO_URL) },
+                modifier = Modifier.fillMaxWidth(),
+            ) { Text(stringResource(R.string.settings_about_open_meteo)) }
         }
     }
 }

--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsCommon.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsCommon.kt
@@ -152,6 +152,11 @@ internal fun LinkifiedText(
     Text(text = annotated, modifier = modifier, style = style, color = color)
 }
 
+// Open-Meteo's free tier is CC BY 4.0 and asks for a "Weather data by
+// Open-Meteo.com" credit with a link back to the site. Surfaced from both
+// the About page and the Forecasters picker.
+internal const val OPEN_METEO_URL = "https://open-meteo.com/"
+
 internal fun openUrl(context: android.content.Context, url: String) {
     val intent = android.content.Intent(android.content.Intent.ACTION_VIEW, android.net.Uri.parse(url))
         .addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -746,6 +746,13 @@
     <string name="settings_about_build_type_suffix"> · %1$s build</string>
     <string name="settings_about_source">Source code on GitHub</string>
     <string name="settings_about_dontkillmyapp">Background restrictions (dontkillmyapp.com)</string>
+    <!-- Attribution link surfaced on both the About page and the Forecasters
+         picker. Open-Meteo's free tier publishes its data under CC BY 4.0 and
+         asks for a "Weather data by Open-Meteo.com" credit with a link back
+         to open-meteo.com. The string is kept short so it fits a TextButton
+         row alongside the other About links. "Open-Meteo" is a brand name
+         and stays Latin in CJK / other non-Latin locales. -->
+    <string name="settings_about_open_meteo">Weather data by Open-Meteo</string>
     <string name="settings_about_share_bug_report">Share bug report</string>
     <string name="settings_about_version_copied">Version copied to clipboard</string>
 


### PR DESCRIPTION
## Summary

Open-Meteo's free tier publishes its data under CC BY 4.0 and asks for a "Weather data by Open-Meteo.com" attribution with a link back to the site. The app calls Open-Meteo forecast + geocoding on every refresh, so the credit belongs in-app, not just in `README.md` / `PRIVACY.md`.

- Adds `Weather data by Open-Meteo` link rows on **Settings ▸ About** (alongside the GitHub / dontkillmyapp links) and **Settings ▸ Forecasters** (under the model checkboxes, where the ECMWF / GFS / ICON names from Open-Meteo's open feed are listed).
- One shared string (`settings_about_open_meteo`) and one shared URL constant (`OPEN_METEO_URL` in `SettingsCommon.kt`) so both paths stay in sync.
- Source string only — translations follow in the next batch pass. "Open-Meteo" is a Latin brand name and stays Latin in CJK / other non-Latin locales per the existing convention noted in `values-zh-rCN` / `values-ja` / `values-el`.

## Privacy

No change to what leaves the device. This is a UI-only attribution link; tapping it launches the browser to https://open-meteo.com/ via the existing `openUrl` helper.

## Test plan

- [x] `./gradlew :app:testDebugUnitTest` — green
- [x] `./gradlew :app:assembleDebug` — green
- [ ] CI green on push
- [ ] Eyeball About and Forecasters pages on a device once installed

---
_Generated by [Claude Code](https://claude.ai/code/session_01VVr9taWTGC3ZK9LMQ2mTYU)_