### PR TITLE
Pick forecasters automatically based on the user's location

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ClothesCastApplication.kt
+++ b/app/src/main/kotlin/app/clothescast/ClothesCastApplication.kt
@@ -9,7 +9,9 @@ import app.clothescast.core.data.location.OpenMeteoGeocodingClient
 import app.clothescast.core.data.tts.GeminiTtsClient
 import app.clothescast.core.data.weather.ConfidenceFetchLogger
 import app.clothescast.core.data.weather.OpenMeteoClient
+import app.clothescast.core.domain.model.ForecastModel
 import app.clothescast.core.domain.model.ForecastPeriod
+import app.clothescast.core.domain.model.defaultsFor
 import app.clothescast.core.domain.repository.CachingWeatherRepository
 import app.clothescast.core.domain.repository.CalendarEventReader
 import app.clothescast.core.domain.repository.WeatherRepository
@@ -111,21 +113,30 @@ class ClothesCastApplication : Application() {
                 apiCallLogger = apiCallLogger,
                 // Read the user's Forecasters selection on every fetch so a
                 // settings change takes effect on the next manual refresh
-                // without rebuilding the client. DataStore caches the latest
-                // emission, so this is a memory read after the first call.
-                confidenceModelsProvider = {
-                    settingsRepository.preferences.first().forecastModels
-                        .map { it.openMeteoId }
+                // without rebuilding the client. When the user is on Auto
+                // (stored selection is null), resolve a location-aware
+                // default trio via [ForecastModel.defaultsFor] — so a UK
+                // user gets UKMO + ECMWF + ICON without ever opening the
+                // picker, a North American gets GFS + GEM + ECMWF, etc.
+                // DataStore caches the latest emission, so this is a memory
+                // read after the first call.
+                confidenceModelsProvider = { location ->
+                    val prefs = settingsRepository.preferences.first()
+                    val effective = prefs.forecastModels ?: ForecastModel.defaultsFor(location)
+                    effective.map { it.openMeteoId }
                 },
             ),
-            // Make the cache invalidate when the Forecasters selection
-            // changes — otherwise a Settings edit followed by a Today
-            // refresh within the 1 h TTL would silently return the previous
-            // model set's bundle, because the cache keys only on location.
-            // Passing the Set itself as the discriminator lets equals() do
-            // the comparison; insertion order doesn't matter for a Set.
-            freshnessKeyProvider = {
-                settingsRepository.preferences.first().forecastModels
+            // Make the cache invalidate when the *effective* Forecasters set
+            // changes — otherwise a Settings edit (or a move to a different
+            // region while on Auto) followed by a Today refresh within the
+            // 1 h TTL would silently return the previous model set's bundle.
+            // Resolving the same null-or-Set chain as confidenceModelsProvider
+            // means an Auto user crossing regions invalidates the cache,
+            // and an explicit-pick user's invalidation is unaffected by
+            // location.
+            freshnessKeyProvider = { location ->
+                val prefs = settingsRepository.preferences.first()
+                prefs.forecastModels ?: ForecastModel.defaultsFor(location)
             },
         )
     }

--- a/app/src/main/kotlin/app/clothescast/data/SettingsRepository.kt
+++ b/app/src/main/kotlin/app/clothescast/data/SettingsRepository.kt
@@ -277,15 +277,17 @@ class SettingsRepository(
     }
 
     /**
-     * Persists the user's [ForecastModel] selection as the stored enum names.
-     * The UI guards against empty selections, but if [models] does come in
-     * empty (e.g. a hand-edited DataStore) we clear the key so the next read
-     * falls back to [ForecastModel.DEFAULTS] rather than persisting an empty
-     * set that would later trip the fetcher's degenerate-input safety net.
+     * Persists the user's [ForecastModel] selection as the stored enum names,
+     * or clears the key when [models] is null — which is the "Auto, derive
+     * from current location" state the Forecasters picker exposes via the
+     * Auto switch. An explicitly-passed empty set is treated the same as
+     * null (clear), guarding against a hand-edited DataStore persisting an
+     * empty set that would later trip the fetcher's degenerate-input
+     * safety net.
      */
-    suspend fun setForecastModels(models: Set<ForecastModel>) {
+    suspend fun setForecastModels(models: Set<ForecastModel>?) {
         dataStore.edit { prefs ->
-            if (models.isEmpty()) {
+            if (models.isNullOrEmpty()) {
                 prefs.remove(FORECAST_MODELS)
             } else {
                 prefs[FORECAST_MODELS] = models.map { it.name }.toSet()
@@ -458,14 +460,16 @@ class SettingsRepository(
         // Resolve stored enum names back to [ForecastModel]. Unknown / removed
         // entries are dropped silently so a forward-compat (future enum value
         // we didn't ship yet) or stale value from a downgrade doesn't break
-        // the picker. Empty resolved set falls back to [ForecastModel.DEFAULTS]
-        // so an install that lost the entry to corruption still gets a
-        // working confidence chip.
-        val forecastModels = this[FORECAST_MODELS]
+        // the picker. A missing key or one that resolves to an empty set
+        // becomes null — that's "Auto", and downstream code resolves the
+        // location-aware default via [ForecastModel.defaultsFor]. The previous
+        // behaviour ("fall back to DEFAULTS") was equivalent to a global trio
+        // forced on every install; null lets fresh installs follow the user's
+        // region.
+        val forecastModels: Set<ForecastModel>? = this[FORECAST_MODELS]
             ?.mapNotNull { runCatching { ForecastModel.valueOf(it) }.getOrNull() }
             ?.toSet()
             ?.takeIf { it.isNotEmpty() }
-            ?: ForecastModel.DEFAULTS
         val zone = zoneIdProvider()
 
         return UserPreferences(

--- a/app/src/main/kotlin/app/clothescast/ui/settings/ForecasterSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/ForecasterSettings.kt
@@ -11,7 +11,9 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Checkbox
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -23,6 +25,8 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 import app.clothescast.R
 import app.clothescast.core.domain.model.ForecastModel
+import app.clothescast.core.domain.model.Location
+import app.clothescast.core.domain.model.defaultsFor
 
 /**
  * Minimum number of models the confidence fetcher needs to compute a spread.
@@ -46,11 +50,22 @@ private const val MAX_MODELS = 5
 
 @Composable
 internal fun ForecastersContent(
-    forecastModels: Set<ForecastModel>,
+    forecastModels: Set<ForecastModel>?,
+    location: Location?,
     padding: PaddingValues,
-    onSetForecastModels: (Set<ForecastModel>) -> Unit,
+    onSetForecastModels: (Set<ForecastModel>?) -> Unit,
 ) {
     val context = LocalContext.current
+    // When the stored selection is null we're in Auto mode: derive a
+    // location-aware trio for display via [ForecastModel.defaultsFor] and
+    // disable the per-model checkboxes. When non-null, the user has
+    // explicitly customised: show their set, enable the checkboxes, and
+    // the Auto switch is off. Toggling Auto on clears the stored set to
+    // null; toggling any checkbox switches to a non-null effective set
+    // with the toggle applied (so an Auto user who unchecks one model
+    // ends up explicitly customised, starting from what Auto picked).
+    val isAuto = forecastModels == null
+    val effective = forecastModels ?: ForecastModel.defaultsFor(location)
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -65,8 +80,23 @@ internal fun ForecastersContent(
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
-            val atCap = forecastModels.size >= MAX_MODELS
-            if (atCap) {
+            AutoSwitchRow(
+                isAuto = isAuto,
+                onToggle = { nowAuto ->
+                    if (nowAuto) {
+                        onSetForecastModels(null)
+                    } else {
+                        // Flipping Auto off persists whatever Auto was
+                        // already resolving to, so the visible checkboxes
+                        // don't suddenly jump — the user then explicitly
+                        // edits from that starting point.
+                        onSetForecastModels(effective)
+                    }
+                },
+            )
+            HorizontalDivider()
+            val atCap = effective.size >= MAX_MODELS
+            if (atCap && !isAuto) {
                 Text(
                     text = stringResource(R.string.settings_forecasters_cap_hint, MAX_MODELS),
                     style = MaterialTheme.typography.bodySmall,
@@ -74,20 +104,23 @@ internal fun ForecastersContent(
                 )
             }
             ForecastModel.entries.forEach { model ->
-                val checked = model in forecastModels
-                // Block unchecking when we'd drop below MIN_MODELS. Block
-                // checking when we'd exceed MAX_MODELS. An already-checked
-                // row stays interactable above the cap so the user can
-                // still toggle it off to free a slot.
-                val canToggleOff = forecastModels.size > MIN_MODELS
+                val checked = model in effective
+                // Auto mode: every row reflects the resolver's pick but is
+                // not toggleable — user has to flip Auto off first. Custom
+                // mode: block unchecking when we'd drop below MIN_MODELS,
+                // block checking when we'd exceed MAX_MODELS. An already-
+                // checked row stays interactable above the cap so the user
+                // can still toggle it off to free a slot.
+                val canToggleOff = effective.size > MIN_MODELS
                 val canToggleOn = !atCap
+                val enabled = !isAuto && (if (checked) canToggleOff else canToggleOn)
                 ForecasterRow(
                     label = stringResource(forecastModelLabel(model)),
                     subtitle = stringResource(forecastModelSubtitle(model)),
                     checked = checked,
-                    enabled = if (checked) canToggleOff else canToggleOn,
+                    enabled = enabled,
                     onToggle = { nowChecked ->
-                        val updated = if (nowChecked) forecastModels + model else forecastModels - model
+                        val updated = if (nowChecked) effective + model else effective - model
                         if (updated.size in MIN_MODELS..MAX_MODELS) onSetForecastModels(updated)
                     },
                 )
@@ -97,6 +130,37 @@ internal fun ForecastersContent(
                 modifier = Modifier.fillMaxWidth(),
             ) { Text(stringResource(R.string.settings_about_open_meteo)) }
         }
+    }
+}
+
+@Composable
+private fun AutoSwitchRow(
+    isAuto: Boolean,
+    onToggle: (Boolean) -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .toggleable(
+                value = isAuto,
+                role = Role.Switch,
+                onValueChange = onToggle,
+            )
+            .padding(vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = stringResource(R.string.settings_forecasters_auto_title),
+                style = MaterialTheme.typography.bodyLarge,
+            )
+            Text(
+                text = stringResource(R.string.settings_forecasters_auto_subtitle),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        Switch(checked = isAuto, onCheckedChange = null)
     }
 }
 

--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsScreen.kt
@@ -203,6 +203,7 @@ fun SettingsScreen(
             )
             SettingsRoute.Forecasters -> ForecastersContent(
                 forecastModels = state.forecastModels,
+                location = state.location,
                 padding = padding,
                 onSetForecastModels = viewModel::setForecastModels,
             )

--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsState.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsState.kt
@@ -91,5 +91,13 @@ data class SettingsState(
      * can't get stuck after the worker finishes without resolving a fix.
      */
     val locationDetecting: Boolean = false,
-    val forecastModels: Set<ForecastModel> = ForecastModel.DEFAULTS,
+    /**
+     * The user's explicit [ForecastModel] selection, or `null` for "Auto"
+     * (location-derived defaults). Auto is the default for fresh installs;
+     * the first explicit pick in the Forecasters picker switches it to a
+     * non-null Set; flipping the Auto switch on clears it back to null.
+     * See [app.clothescast.core.domain.model.defaultsFor] for the region
+     * mapping the Auto state resolves through.
+     */
+    val forecastModels: Set<ForecastModel>? = null,
 )

--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsViewModel.kt
@@ -384,7 +384,7 @@ class SettingsViewModel(
      * [models] never reaches this path from the UI; the repository still
      * defends against it for hand-edited-DataStore safety.
      */
-    fun setForecastModels(models: Set<ForecastModel>) {
+    fun setForecastModels(models: Set<ForecastModel>?) {
         viewModelScope.launch { settingsRepository.setForecastModels(models) }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -390,6 +390,8 @@
          across translations. -->
     <string name="settings_forecasters_title">Forecast models</string>
     <string name="settings_forecasters_description">The confidence chip and the per-model chart pull from these models. Picking more gives a richer spread; fewer means a tighter focus. At least two stay selected.</string>
+    <string name="settings_forecasters_auto_title">Auto (best for your location)</string>
+    <string name="settings_forecasters_auto_subtitle">Pick the regional forecaster automatically — UKMO in the British Isles, JMA in Japan, GFS + GEM in North America, etc. Turn off to choose models yourself.</string>
     <string name="settings_forecasters_cap_hint">You\'ve picked %1$d models — the most the chart stays readable for. Deselect one to add a different model.</string>
     <string name="settings_forecasters_ecmwf">ECMWF</string>
     <string name="settings_forecasters_ecmwf_subtitle">European — generally the most accurate global model. 3-hourly on the open feed.</string>

--- a/app/src/test/kotlin/app/clothescast/data/SettingsRepositoryTest.kt
+++ b/app/src/test/kotlin/app/clothescast/data/SettingsRepositoryTest.kt
@@ -824,8 +824,12 @@ class SettingsRepositoryTest {
     }
 
     @Test
-    fun `forecast models default to the shipping trio`() = runTest {
-        subject.preferences.first().forecastModels shouldBe ForecastModel.DEFAULTS
+    fun `forecast models default to null on fresh install`() = runTest {
+        // Auto mode: no stored key means the location-aware resolver runs
+        // in [ClothesCastApplication] instead of forcing the global trio.
+        // The picker shows the Auto switch as on and the per-model
+        // checkboxes derive from the user's location.
+        subject.preferences.first().forecastModels shouldBe null
     }
 
     @Test
@@ -841,12 +845,24 @@ class SettingsRepositoryTest {
     }
 
     @Test
-    fun `setting forecast models to empty falls back to defaults on read`() = runTest {
+    fun `setting forecast models to empty clears the key to Auto`() = runTest {
         // An empty set never reaches this path from the UI (the picker
         // enforces a minimum of two), but a hand-edited DataStore could.
-        // The empty key gets cleared; the next read returns the trio.
+        // The empty key gets cleared and the next read returns null —
+        // i.e. the user is back in Auto mode.
         subject.setForecastModels(emptySet())
-        subject.preferences.first().forecastModels shouldBe ForecastModel.DEFAULTS
+        subject.preferences.first().forecastModels shouldBe null
+    }
+
+    @Test
+    fun `setting forecast models to null clears the key to Auto`() = runTest {
+        // First persist an explicit set, then clear by passing null —
+        // mirrors the picker's Auto-switch-on flow.
+        subject.setForecastModels(setOf(ForecastModel.UKMO_SEAMLESS, ForecastModel.ECMWF_IFS04))
+        subject.preferences.first().forecastModels shouldBe
+            setOf(ForecastModel.UKMO_SEAMLESS, ForecastModel.ECMWF_IFS04)
+        subject.setForecastModels(null)
+        subject.preferences.first().forecastModels shouldBe null
     }
 
     @Test

--- a/core/data/src/main/kotlin/app/clothescast/core/data/weather/OpenMeteoClient.kt
+++ b/core/data/src/main/kotlin/app/clothescast/core/data/weather/OpenMeteoClient.kt
@@ -60,17 +60,22 @@ class OpenMeteoClient(
      * Snapshot of which Open-Meteo model IDs the multi-model confidence
      * fetcher should consult on the next call. Read fresh on every
      * [fetchForecast] so a Forecasters-settings change takes effect on the
-     * next refresh without rebuilding the client. Suspending so the
-     * `:app`-side wiring can `settingsRepository.preferences.first()`
-     * directly without staging through a StateFlow snapshot. DataStore
-     * caches the latest emission, so on the warm path the read is a memory
-     * hit and runs inside the same coroutine that's about to launch the
-     * parallel fetches — no measurable added latency. Defaults to the
-     * three-model trio for tests and any caller that doesn't wire a
+     * next refresh without rebuilding the client. Takes the request's
+     * [Location] because an Auto-mode Forecasters selection resolves to a
+     * different model trio depending on which region the user is in (UKMO
+     * trio over the British Isles, GFS trio over North America, etc.);
+     * passing it through lets the `:app` wiring run the [Location]-aware
+     * resolver. Suspending so the `:app`-side wiring can
+     * `settingsRepository.preferences.first()` directly without staging
+     * through a StateFlow snapshot. DataStore caches the latest emission,
+     * so on the warm path the read is a memory hit and runs inside the
+     * same coroutine that's about to launch the parallel fetches — no
+     * measurable added latency. Defaults to the three-model trio,
+     * ignoring location, for tests and any caller that doesn't wire a
      * settings-backed provider.
      */
-    private val confidenceModelsProvider: suspend () -> List<String> =
-        { MultiModelConfidenceFetcher.DEFAULT_MODELS },
+    private val confidenceModelsProvider: suspend (Location) -> List<String> =
+        { _ -> MultiModelConfidenceFetcher.DEFAULT_MODELS },
 ) : WeatherRepository {
 
     // Constructed once per client. Exposing it on the public constructor would
@@ -89,7 +94,7 @@ class OpenMeteoClient(
         // latency behind the primary fetch.
         val primary = async { fetchPrimary(location) }
         val alerts = async { fetchAlerts(location) }
-        val models = confidenceModelsProvider()
+        val models = confidenceModelsProvider(location)
         val multiModel = async { confidenceFetcher.fetch(location, models) }
 
         val bundle = OpenMeteoMapper.toBundle(primary.await())

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/ForecastModelDefaults.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/ForecastModelDefaults.kt
@@ -1,0 +1,106 @@
+package app.clothescast.core.domain.model
+
+/**
+ * Picks a sensible default set of [ForecastModel]s for [location] — the trio
+ * the multi-model confidence fetcher consults when the user hasn't explicitly
+ * customised their Forecasters selection (i.e. when
+ * [UserPreferences.forecastModels] is null).
+ *
+ * The rule of thumb: the official national/regional meteorological service's
+ * model is usually the most accurate over its own territory (UKMO over the
+ * British Isles, JMA over Japan, GEM over Canada, etc.) because the agency
+ * invests in local mesoscale modelling, fine-grained terrain handling, and
+ * regional observation networks that a generic global model doesn't get. So
+ * for each broad region we pair the local official with two strong global
+ * majors as a divergence check: ECMWF — widely benchmarked as the world's
+ * most accurate global model — plus a structurally different second one
+ * (GFS or ICON) so the spread doesn't collapse when the regional model and
+ * ECMWF happen to share a synoptic interpretation.
+ *
+ * The mapping is intentionally coarse — bounding boxes, not country
+ * polygons — because the goal is "good defaults", not "perfect mapping".
+ * Anyone unhappy with what auto picks for them can flip Auto off and pick
+ * explicitly; a misclassified Strasbourg user (Western Europe vs. German
+ * border, but still gets ECMWF + ICON + ARPEGE either way) won't notice.
+ *
+ * Overlap handling: the `when` cascade is ordered so British Isles wins over
+ * Western Europe for the Channel area, and Nordics wins over Western Europe
+ * for the southern Baltic. Inside any one branch the order also matters —
+ * the picker's MIN_MODELS = 2 floor means dropping the first model leaves
+ * a usable pair, so the "most local" model goes first.
+ *
+ * Returns the global default trio (ECMWF / GFS / ICON) when [location] is
+ * null (no location set yet) or falls outside every regional bounding box.
+ * This matches the picker's pre-location-awareness behaviour and also acts
+ * as a safe initial value for a fresh install before the first GPS fix
+ * resolves.
+ */
+fun ForecastModel.Companion.defaultsFor(location: Location?): Set<ForecastModel> {
+    if (location == null) return DEFAULTS
+    val lat = location.latitude
+    val lon = location.longitude
+    return when {
+        // British Isles + Ireland: roughly Land's End to the Shetlands, with
+        // a generous easterly slop that catches the Channel coast of France
+        // too. UKMO over Calais is still a sensible pick — the Channel is
+        // UKMO's home synoptic region. Tested by the London / Dublin /
+        // Edinburgh entries in ForecastModelDefaultsTest.
+        lat in 49.5..61.0 && lon in -10.5..2.0 ->
+            setOf(ForecastModel.UKMO_SEAMLESS, ForecastModel.ECMWF_IFS04, ForecastModel.ICON_SEAMLESS)
+
+        // Iceland: handled before the Nordic branch because it sits west of
+        // 0° longitude. Same trio as Nordics (ECMWF + ICON + UKMO) — UKMO
+        // covers the North Atlantic well, no native Icelandic model on
+        // Open-Meteo.
+        lat in 63.0..67.0 && lon in -25.0..-13.0 ->
+            setOf(ForecastModel.ECMWF_IFS04, ForecastModel.ICON_SEAMLESS, ForecastModel.UKMO_SEAMLESS)
+
+        // Nordics (Norway / Sweden / Finland / Denmark, plus a Baltic slop
+        // that catches Tallinn / Riga). UKMO is the local-ish official —
+        // MET Norway's flagship MetCoOp Nordic model isn't on Open-Meteo
+        // as a per-model series.
+        lat in 55.0..72.0 && lon in 4.0..32.0 ->
+            setOf(ForecastModel.ECMWF_IFS04, ForecastModel.ICON_SEAMLESS, ForecastModel.UKMO_SEAMLESS)
+
+        // Western + Central Europe (Iberia / France / Benelux / Germany /
+        // Italy / Switzerland / Austria / Poland / Czechia). Three European
+        // mesoscale models: ECMWF (Reading), ICON (DWD), ARPEGE
+        // (Météo-France). British Isles + Iceland + Nordics already took
+        // their slice above, so this catches the rest.
+        lat in 36.0..58.0 && lon in -10.0..28.0 ->
+            setOf(ForecastModel.ECMWF_IFS04, ForecastModel.ICON_SEAMLESS, ForecastModel.METEOFRANCE_SEAMLESS)
+
+        // Japan: JMA is the local official, ECMWF + ICON as the global
+        // cross-checks. Tightish lat/lon — overlapping the Korean peninsula
+        // is fine, the next branch will catch it.
+        lat in 30.0..46.0 && lon in 128.0..146.0 ->
+            setOf(ForecastModel.JMA_SEAMLESS, ForecastModel.ECMWF_IFS04, ForecastModel.ICON_SEAMLESS)
+
+        // Korean peninsula: KMA isn't on Open-Meteo, so JMA is the closest
+        // regional model with native East Asia coverage. ECMWF + ICON
+        // round out the trio.
+        lat in 33.0..43.0 && lon in 124.0..131.0 ->
+            setOf(ForecastModel.JMA_SEAMLESS, ForecastModel.ECMWF_IFS04, ForecastModel.ICON_SEAMLESS)
+
+        // North America: US (lower 48 + Alaska) + Canada + Mexico. GFS
+        // (NCEP, American) and GEM (Environment Canada) are the locals;
+        // ECMWF as the global cross-check that's still considered the
+        // most accurate over North America even by NOAA's own metrics.
+        lat in 15.0..72.0 && lon in -170.0..-50.0 ->
+            setOf(ForecastModel.GFS_SEAMLESS, ForecastModel.GEM_SEAMLESS, ForecastModel.ECMWF_IFS04)
+
+        // Australia + New Zealand: BOM (Australian Bureau of Meteorology)
+        // would be the obvious local pick but Open-Meteo currently has
+        // BOM open-data delivery suspended (see Settings.kt for the link),
+        // so we fall back to the global trio. Re-add BOM to this branch
+        // when the enum entry comes back in Settings.kt.
+        lat in -47.0..-10.0 && lon in 110.0..180.0 -> DEFAULTS
+
+        // Default: everywhere else (South America, Africa, Middle East,
+        // South + Southeast Asia, polar regions) falls back to the global
+        // trio. The big regional models on Open-Meteo are all Northern-
+        // Hemisphere-and-Europe-leaning, and we'd be picking arbitrarily
+        // for these continents.
+        else -> DEFAULTS
+    }
+}

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Settings.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Settings.kt
@@ -368,16 +368,19 @@ data class UserPreferences(
     val outfitBottomColors: Map<OutfitSuggestion.Bottom, Long> = emptyMap(),
     /**
      * Which numerical-weather-prediction models the multi-model confidence
-     * fetcher consults. Defaults to [ForecastModel.DEFAULTS] (ECMWF / GFS /
-     * ICON) — the trio the chip has shipped with. Users with a regional
-     * preference can swap in ARPEGE / GEM / UKMO / JMA / BOM via the
-     * Forecasters settings sub-screen.
+     * fetcher consults — or `null` for "auto, derive from current location"
+     * (see [ForecastModel.defaultsFor]). Fresh installs default to null so
+     * a user who never opens the Forecasters picker gets a region-appropriate
+     * trio (UKMO + ECMWF + ICON over the British Isles, JMA over Japan,
+     * GFS + GEM + ECMWF over North America, etc.) that follows them if they
+     * move. The first explicit pick in the picker switches this to a non-null
+     * Set; flipping the Auto switch back on clears it to null again.
      *
      * Stored as a [Set] because order doesn't matter — the URL builder
      * sorts to a deterministic comma-separated list, and the confidence
      * chip / per-model chart don't depend on a particular ordering.
      */
-    val forecastModels: Set<ForecastModel> = ForecastModel.DEFAULTS,
+    val forecastModels: Set<ForecastModel>? = null,
 ) {
     companion object {
         const val DEFAULT_GEMINI_VOICE = "Despina"
@@ -428,8 +431,10 @@ enum class ForecastModel(val openMeteoId: String) {
     companion object {
         /**
          * The three models the confidence chip has shipped with — ECMWF, GFS,
-         * ICON. Used as the default for [UserPreferences.forecastModels] and
-         * as the fallback when the user has somehow deselected everything
+         * ICON. The location-agnostic fallback used by [defaultsFor] when no
+         * location is known yet (fresh install before first GPS fix) or when
+         * the location doesn't sit in any of the regional branches, and as
+         * the recovery set when the user has somehow deselected everything
          * (the picker's UI prevents that, but a hand-edited DataStore could).
          */
         val DEFAULTS: Set<ForecastModel> = setOf(ECMWF_IFS04, GFS_SEAMLESS, ICON_SEAMLESS)

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/repository/CachingWeatherRepository.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/repository/CachingWeatherRepository.kt
@@ -42,21 +42,30 @@ class CachingWeatherRepository(
     private val ttl: Duration = Duration.ofHours(1),
     private val locationGridDegrees: Double = 0.01,
     /**
-     * Pull-based opaque discriminator for inputs *other than location* that
-     * change which forecast the delegate would return — currently the user's
-     * Forecasters model selection (see [ClothesCastApplication]). The cache
-     * stores whatever value this returned at fetch time and treats the entry
-     * as stale on mismatch, so a settings change takes effect on the next
-     * refresh instead of waiting out the TTL. Default returns [Unit] (a
-     * single value that matches itself), preserving the location-only
-     * behaviour for tests and any delegate whose output doesn't depend on
-     * out-of-band state.
+     * Pull-based opaque discriminator for inputs *other than location-grid-key*
+     * that change which forecast the delegate would return — currently the
+     * user's Forecasters model selection (see [ClothesCastApplication]),
+     * which itself can depend on location when set to Auto. The cache stores
+     * whatever value this returned at fetch time and treats the entry as
+     * stale on mismatch, so a settings change takes effect on the next
+     * refresh instead of waiting out the TTL.
+     *
+     * Takes the request's [Location] because an Auto-mode forecasters
+     * selection resolves to different models in different regions (UKMO
+     * trio in the British Isles, GFS trio over North America, etc.), so
+     * the freshness key must vary with location too — otherwise a user
+     * who moves from London to Paris on Auto would keep getting the
+     * London-trio bundle until the TTL expired.
+     *
+     * Default ignores the location and returns [Unit] (a single value that
+     * matches itself), preserving the location-only behaviour for tests
+     * and any delegate whose output doesn't depend on out-of-band state.
      *
      * Suspend so a settings-backed provider can `dataStore.first()` without
      * needing a separately-maintained snapshot. DataStore caches the latest
      * emission in memory, so on the warm path this is a memory hit.
      */
-    private val freshnessKeyProvider: suspend () -> Any = { Unit },
+    private val freshnessKeyProvider: suspend (Location) -> Any = { _ -> Unit },
 ) : WeatherRepository {
 
     private data class Entry(
@@ -73,7 +82,7 @@ class CachingWeatherRepository(
 
     override suspend fun fetchForecast(location: Location): ForecastBundle = mutex.withLock {
         val key = keyOf(location)
-        val freshnessKey = freshnessKeyProvider()
+        val freshnessKey = freshnessKeyProvider(location)
         val now = clock.instant()
         val today = LocalDate.now(clock)
         val cached = entry

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/model/ForecastModelDefaultsTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/model/ForecastModelDefaultsTest.kt
@@ -1,0 +1,157 @@
+package app.clothescast.core.domain.model
+
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+class ForecastModelDefaultsTest {
+
+    private fun at(lat: Double, lon: Double): Location =
+        Location(latitude = lat, longitude = lon, displayName = null)
+
+    @Test
+    fun `null location returns global default trio`() {
+        ForecastModel.defaultsFor(null) shouldBe ForecastModel.DEFAULTS
+    }
+
+    @Test
+    fun `London picks UKMO + ECMWF + ICON`() {
+        ForecastModel.defaultsFor(at(51.51, -0.13)) shouldContainExactlyInAnyOrder listOf(
+            ForecastModel.UKMO_SEAMLESS,
+            ForecastModel.ECMWF_IFS04,
+            ForecastModel.ICON_SEAMLESS,
+        )
+    }
+
+    @Test
+    fun `Dublin picks UKMO + ECMWF + ICON`() {
+        ForecastModel.defaultsFor(at(53.35, -6.26)) shouldContainExactlyInAnyOrder listOf(
+            ForecastModel.UKMO_SEAMLESS,
+            ForecastModel.ECMWF_IFS04,
+            ForecastModel.ICON_SEAMLESS,
+        )
+    }
+
+    @Test
+    fun `Edinburgh picks UKMO + ECMWF + ICON`() {
+        ForecastModel.defaultsFor(at(55.95, -3.19)) shouldContainExactlyInAnyOrder listOf(
+            ForecastModel.UKMO_SEAMLESS,
+            ForecastModel.ECMWF_IFS04,
+            ForecastModel.ICON_SEAMLESS,
+        )
+    }
+
+    @Test
+    fun `Paris picks ECMWF + ICON + ARPEGE`() {
+        ForecastModel.defaultsFor(at(48.86, 2.35)) shouldContainExactlyInAnyOrder listOf(
+            ForecastModel.ECMWF_IFS04,
+            ForecastModel.ICON_SEAMLESS,
+            ForecastModel.METEOFRANCE_SEAMLESS,
+        )
+    }
+
+    @Test
+    fun `Berlin picks ECMWF + ICON + ARPEGE`() {
+        ForecastModel.defaultsFor(at(52.52, 13.41)) shouldContainExactlyInAnyOrder listOf(
+            ForecastModel.ECMWF_IFS04,
+            ForecastModel.ICON_SEAMLESS,
+            ForecastModel.METEOFRANCE_SEAMLESS,
+        )
+    }
+
+    @Test
+    fun `Madrid picks ECMWF + ICON + ARPEGE`() {
+        ForecastModel.defaultsFor(at(40.42, -3.70)) shouldContainExactlyInAnyOrder listOf(
+            ForecastModel.ECMWF_IFS04,
+            ForecastModel.ICON_SEAMLESS,
+            ForecastModel.METEOFRANCE_SEAMLESS,
+        )
+    }
+
+    @Test
+    fun `Stockholm picks ECMWF + ICON + UKMO`() {
+        ForecastModel.defaultsFor(at(59.33, 18.07)) shouldContainExactlyInAnyOrder listOf(
+            ForecastModel.ECMWF_IFS04,
+            ForecastModel.ICON_SEAMLESS,
+            ForecastModel.UKMO_SEAMLESS,
+        )
+    }
+
+    @Test
+    fun `Reykjavik picks ECMWF + ICON + UKMO`() {
+        ForecastModel.defaultsFor(at(64.13, -21.94)) shouldContainExactlyInAnyOrder listOf(
+            ForecastModel.ECMWF_IFS04,
+            ForecastModel.ICON_SEAMLESS,
+            ForecastModel.UKMO_SEAMLESS,
+        )
+    }
+
+    @Test
+    fun `New York picks GFS + GEM + ECMWF`() {
+        ForecastModel.defaultsFor(at(40.71, -74.01)) shouldContainExactlyInAnyOrder listOf(
+            ForecastModel.GFS_SEAMLESS,
+            ForecastModel.GEM_SEAMLESS,
+            ForecastModel.ECMWF_IFS04,
+        )
+    }
+
+    @Test
+    fun `Vancouver picks GFS + GEM + ECMWF`() {
+        ForecastModel.defaultsFor(at(49.28, -123.12)) shouldContainExactlyInAnyOrder listOf(
+            ForecastModel.GFS_SEAMLESS,
+            ForecastModel.GEM_SEAMLESS,
+            ForecastModel.ECMWF_IFS04,
+        )
+    }
+
+    @Test
+    fun `Mexico City picks GFS + GEM + ECMWF`() {
+        ForecastModel.defaultsFor(at(19.43, -99.13)) shouldContainExactlyInAnyOrder listOf(
+            ForecastModel.GFS_SEAMLESS,
+            ForecastModel.GEM_SEAMLESS,
+            ForecastModel.ECMWF_IFS04,
+        )
+    }
+
+    @Test
+    fun `Tokyo picks JMA + ECMWF + ICON`() {
+        ForecastModel.defaultsFor(at(35.68, 139.76)) shouldContainExactlyInAnyOrder listOf(
+            ForecastModel.JMA_SEAMLESS,
+            ForecastModel.ECMWF_IFS04,
+            ForecastModel.ICON_SEAMLESS,
+        )
+    }
+
+    @Test
+    fun `Seoul picks JMA + ECMWF + ICON`() {
+        ForecastModel.defaultsFor(at(37.57, 126.98)) shouldContainExactlyInAnyOrder listOf(
+            ForecastModel.JMA_SEAMLESS,
+            ForecastModel.ECMWF_IFS04,
+            ForecastModel.ICON_SEAMLESS,
+        )
+    }
+
+    @Test
+    fun `Sydney falls back to global default while BOM is suspended`() {
+        // Open-Meteo currently has BOM open-data delivery suspended, so the
+        // ANZ branch points at DEFAULTS until BOM comes back. When BOM is
+        // re-added to the enum + resolver, update this test to expect the
+        // local-official trio instead.
+        ForecastModel.defaultsFor(at(-33.87, 151.21)) shouldBe ForecastModel.DEFAULTS
+    }
+
+    @Test
+    fun `Sao Paulo falls back to global default`() {
+        ForecastModel.defaultsFor(at(-23.55, -46.63)) shouldBe ForecastModel.DEFAULTS
+    }
+
+    @Test
+    fun `Cape Town falls back to global default`() {
+        ForecastModel.defaultsFor(at(-33.93, 18.42)) shouldBe ForecastModel.DEFAULTS
+    }
+
+    @Test
+    fun `Singapore falls back to global default`() {
+        ForecastModel.defaultsFor(at(1.35, 103.82)) shouldBe ForecastModel.DEFAULTS
+    }
+}


### PR DESCRIPTION
## Summary

Fresh installs default to a global ECMWF + GFS + ICON trio that's heavily American (GFS) for a user base that's mostly elsewhere. With the picker now exposing the regional models, the natural default for a UK user is UKMO + ECMWF + ICON; for a North American it's GFS + GEM + ECMWF; for a Japanese user JMA + ECMWF + ICON; and so on. This PR makes that default location-aware so users get a regionally-tuned trio out of the box without ever opening the picker.

## Lifecycle (the part that was confusing in the first draft)

Auto **does not bake a trio in at install time**. Nothing is persisted in Auto mode — `UserPreferences.forecastModels` stays `null` — and the regional trio is resolved on **every weather fetch** against the user's *current* location:

- `ClothesCastApplication.confidenceModelsProvider` runs `prefs.forecastModels ?: ForecastModel.defaultsFor(location)` per request to `OpenMeteoClient.fetchForecast(location)`.
- `freshnessKeyProvider` runs the same expression so the 1 h weather cache invalidates the moment the resolved set changes.
- The Forecasters picker shows the resolver's current pick live (recomputes on every recomposition from `SettingsState.location`).

Concrete consequences:

- A user installs in London, sees UKMO + ECMWF + ICON. They never open the picker. They fly to Tokyo. The next refresh fetches with JMA + ECMWF + ICON — no migration step, no settings nudge.
- A user installs in London on Auto, then taps a checkbox to add GFS. That **persists** the resulting four-model Set. They now ignore location: flying to Tokyo still fetches with London-plus-GFS until they flip Auto back on (which clears the stored Set to null).
- A user explicitly picks UKMO + ECMWF in 2024 (pre-Auto-switch). On upgrade their stored Set round-trips unchanged; they stay opted-out of Auto.

The cost is one `defaultsFor()` call per fetch, which is a tiny `when` cascade — no I/O, no allocations on the hot path.

## What's in the diff

- **New `ForecastModel.defaultsFor(location: Location?)`** in `:core:domain`. Bounding-box `when` cascade — no polygon dataset, no extra dependency:
  - British Isles → **UKMO + ECMWF + ICON**
  - Iceland + Nordics → **ECMWF + ICON + UKMO**
  - Western / Central Europe → **ECMWF + ICON + ARPEGE**
  - Japan → **JMA + ECMWF + ICON**
  - Korea → **JMA + ECMWF + ICON** (KMA isn't on Open-Meteo)
  - North America (US + Canada + Mexico) → **GFS + GEM + ECMWF**
  - Australia / NZ → falls back to global default (BOM still suspended)
  - Null location or fall-through → global default (ECMWF + GFS + ICON)
- **"Auto (best for your location)" switch** at the top of the Forecasters picker. When on, the per-model checkboxes still render but are disabled and reflect the resolver's *current* pick for the user's location (live, not frozen). Toggling any checkbox flips Auto off, persists the displayed effective set with the toggle applied, and re-enables editing. Toggling Auto on clears the stored selection to null.
- **`UserPreferences.forecastModels` is now `Set<ForecastModel>?`**. `null` means "Auto, look it up each fetch from the current location". Fresh installs default to null. DataStore key absent / empty deserialises to null.
- **`confidenceModelsProvider` and `freshnessKeyProvider`** now take the request's `Location` so they can run the resolver. Same null-or-Set chain in both, so the cache invalidates when an Auto user's resolved set changes (e.g. cross-region travel).

## Privacy

No new off-device data. The resolver runs entirely on-device against the location the user already has set; no new fields are added to any Open-Meteo / Gemini request, no new analytics events, no new Crashlytics keys.

## Test plan

- [x] `:core:domain:test` — 17 new resolver tests (London / Dublin / Edinburgh / Paris / Berlin / Madrid / Stockholm / Reykjavík / NYC / Vancouver / Mexico City / Tokyo / Seoul / Sydney / São Paulo / Cape Town / Singapore + null-location fallback)
- [x] `:core:data:test` — existing tests still pass with the new `Location`-taking provider signature
- [x] `:app:testDebugUnitTest` — `SettingsRepositoryTest` updated for the nullable + Auto semantics
- [x] `:app:assembleDebug` builds
- [x] No snapshot drift
- [ ] Manual: fresh install in a UK location → Forecasters picker shows Auto on with UKMO + ECMWF + ICON checked-but-disabled
- [ ] Manual: toggle Auto off → checkboxes become editable, stored set is the previously-displayed trio
- [ ] Manual: toggle Auto on after customising → stored set clears, picker returns to the resolver's pick
- [ ] Manual: change location from London to Paris while on Auto → next refresh invalidates the cache and resolves ECMWF + ICON + ARPEGE