### PR TITLE
Lead with "Tomorrow" on page 2 when the insight is for the next day

### DIFF
--- a/app/src/main/kotlin/app/clothescast/insight/InsightFormatter.kt
+++ b/app/src/main/kotlin/app/clothescast/insight/InsightFormatter.kt
@@ -44,7 +44,15 @@ class InsightFormatter(
 ) {
     private val phraser: ClothesPhraser = ClothesPhraser.forLocale(resources, locale)
 
-    fun format(summary: InsightSummary): String {
+    /**
+     * Render [summary] as prose. When [isFutureDay] is true the [ForecastPeriod.TODAY]
+     * lead-in switches from "Today" to "Tomorrow" — this is the page-2 case where
+     * the evening worker has cached a daytime insight for the next calendar date
+     * and rendering "Today, …" would be wrong. The TONIGHT lead is left alone:
+     * the worker never pairs a primary insight with tomorrow night, so the only
+     * tomorrow-shaped payload that reaches the formatter is a daytime one.
+     */
+    fun format(summary: InsightSummary, isFutureDay: Boolean = false): String {
         // Accessories (umbrella, etc.) are filtered out of the rendered prose
         // entirely — we only surface temperature-driven clothing for now. The
         // user's umbrella rule still triggers and the precip clause still
@@ -63,7 +71,7 @@ class InsightFormatter(
         val mentionedKeys = wearItems.map(::normalizeItemKey).toSet()
         return buildList {
             summary.alert?.let { add(formatAlert(it)) }
-            add(formatBand(summary.period, summary.band))
+            add(formatBand(summary.period, summary.band, isFutureDay))
             summary.delta?.let { add(formatDelta(it)) }
             if (wearItems.isNotEmpty()) formatClothesWear(wearItems)?.let(::add)
             summary.precip?.let { add(formatPrecip(it)) }
@@ -101,8 +109,8 @@ class InsightFormatter(
     private fun formatAlert(alert: AlertClause): String =
         resources.getString(R.string.insight_alert, alert.event)
 
-    private fun formatBand(period: ForecastPeriod, band: BandClause): String {
-        val lead = resources.getString(leadRes(period))
+    private fun formatBand(period: ForecastPeriod, band: BandClause, isFutureDay: Boolean): String {
+        val lead = resources.getString(leadRes(period, isFutureDay))
         val low = resources.getString(bandRes(band.low))
         return if (band.low == band.high) {
             resources.getString(R.string.insight_band_single, lead, low)
@@ -203,8 +211,8 @@ class InsightFormatter(
         return resources.getString(template, renderedItems, spokenTime(rainTime))
     }
 
-    private fun leadRes(period: ForecastPeriod): Int = when (period) {
-        ForecastPeriod.TODAY -> R.string.insight_lead_today
+    private fun leadRes(period: ForecastPeriod, isFutureDay: Boolean): Int = when (period) {
+        ForecastPeriod.TODAY -> if (isFutureDay) R.string.insight_lead_tomorrow else R.string.insight_lead_today
         ForecastPeriod.TONIGHT -> R.string.insight_lead_tonight
     }
 

--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
@@ -105,6 +105,7 @@ import app.clothescast.location.hasBackgroundLocationPermission
 import app.clothescast.location.hasCoarseLocationPermission
 import app.clothescast.ui.theme.AppTheme
 import app.clothescast.work.FetchAndNotifyWorker
+import java.time.LocalDate
 import java.time.LocalTime
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
@@ -1242,8 +1243,12 @@ internal fun InsightCard(
                     }
                 }
             }
+            // Page 2 caches tomorrow's daytime insight after the evening
+            // worker run; without this flag the prose would lead with "Today"
+            // even though the date row above says e.g. "Saturday, May 16".
+            val isFutureDay = insight.forDate.isAfter(LocalDate.now())
             Text(
-                text = formatter.format(insight.summary),
+                text = formatter.format(insight.summary, isFutureDay = isFutureDay),
                 style = MaterialTheme.typography.headlineSmall,
             )
             Text(

--- a/app/src/main/res/values-am/strings.xml
+++ b/app/src/main/res/values-am/strings.xml
@@ -371,6 +371,7 @@ The rest of the UI falls through to values/strings.xml (English).
 
     <!-- Insight prose -->
     <string name="insight_lead_today">ዛሬ</string>
+    <string name="insight_lead_tomorrow">ነገ</string>
     <string name="insight_lead_tonight">ዛሬ ምሽት</string>
     <!-- Amharic: "ዛሬ ምቹ ይሆናል።" -->
     <string name="insight_band_single">%1$s %2$s ይሆናል።</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -50,6 +50,7 @@ they work correctly in both the single-band and range templates.
     <string name="today_outfit_bottom_long_pants">بنطلون طويل</string>
 
     <string name="insight_lead_today">اليوم</string>
+    <string name="insight_lead_tomorrow">غدًا</string>
     <string name="insight_lead_tonight">الليلة</string>
     <!-- "اليوم سيكون الجو معتدل." -->
     <string name="insight_band_single">%1$s سيكون الجو %2$s.</string>

--- a/app/src/main/res/values-b+sr+Latn/strings.xml
+++ b/app/src/main/res/values-b+sr+Latn/strings.xml
@@ -72,6 +72,7 @@ default English (matching values-pl / values-uk).
     <string name="today_outfit_bottom_long_pants">Pantalone</string>
 
     <string name="insight_lead_today">Danas</string>
+    <string name="insight_lead_tomorrow">Sutra</string>
     <string name="insight_lead_tonight">Večeras</string>
     <string name="insight_band_single">%1$s će biti %2$s.</string>
     <string name="insight_band_range">%1$s će biti od %2$s do %3$s.</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -58,6 +58,7 @@ What is NOT overridden, by design:
     <string name="today_outfit_bottom_long_pants">Панталон</string>
 
     <string name="insight_lead_today">Днес</string>
+    <string name="insight_lead_tomorrow">Утре</string>
     <string name="insight_lead_tonight">Тази вечер</string>
     <string name="insight_band_single">%1$s ще бъде %2$s.</string>
     <string name="insight_band_range">%1$s ще бъде от %2$s до %3$s.</string>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -46,6 +46,7 @@ West Bengal vocabulary differences in a future PR.
     <string name="today_outfit_bottom_long_pants">প্যান্ট</string>
 
     <string name="insight_lead_today">আজ</string>
+    <string name="insight_lead_tomorrow">আগামীকাল</string>
     <string name="insight_lead_tonight">আজ রাতে</string>
     <!-- "আজ আবহাওয়া মনোরম থাকবে।" -->
     <string name="insight_band_single">%1$s আবহাওয়া %2$s থাকবে।</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -488,6 +488,7 @@ the in-app clock is digit-driven and reads consistently across locales.
     <string name="bug_report_consent_cancel">Cancel·la</string>
 
     <string name="insight_lead_today">Avui</string>
+    <string name="insight_lead_tomorrow">Demà</string>
     <string name="insight_lead_tonight">Aquesta nit</string>
     <!-- Catalan weather-as-verb: "Avui farà fred." (today will-make cold). -->
     <string name="insight_band_single">%1$s farà %2$s.</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -538,6 +538,7 @@ locale (Angličtina (USA), Francouzština (Francie), Němčina (Německo), …).
 
     <!-- Insight prose templates. -->
     <string name="insight_lead_today">Dnes</string>
+    <string name="insight_lead_tomorrow">Zítra</string>
     <string name="insight_lead_tonight">Dnes večer</string>
     <string name="insight_band_single">%1$s bude %2$s.</string>
     <string name="insight_band_range">%1$s bude od %2$s do %3$s.</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -541,6 +541,7 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrig)").
 
     <!-- Insight prose templates. -->
     <string name="insight_lead_today">I dag</string>
+    <string name="insight_lead_tomorrow">I morgen</string>
     <string name="insight_lead_tonight">I aften</string>
     <!-- Danish V2 word order: "I dag bliver det mildt." -->
     <string name="insight_band_single">%1$s bliver det %2$s.</string>

--- a/app/src/main/res/values-de-rAT/strings.xml
+++ b/app/src/main/res/values-de-rAT/strings.xml
@@ -419,6 +419,7 @@ zh-CN) is unchanged; only the displayed label localizes.
 
     <!-- Insight prose templates — German equivalents of the keys in values/strings.xml. -->
     <string name="insight_lead_today">Heute</string>
+    <string name="insight_lead_tomorrow">Morgen</string>
     <string name="insight_lead_tonight">Heute Abend</string>
 
     <!-- "Heute wird es mild." / "Heute wird es kühl bis mild." Subject-second

--- a/app/src/main/res/values-de-rCH/strings.xml
+++ b/app/src/main/res/values-de-rCH/strings.xml
@@ -424,6 +424,7 @@ zh-CN) is unchanged; only the displayed label localizes.
 
     <!-- Insight prose templates — German equivalents of the keys in values/strings.xml. -->
     <string name="insight_lead_today">Heute</string>
+    <string name="insight_lead_tomorrow">Morgen</string>
     <string name="insight_lead_tonight">Heute Abend</string>
 
     <!-- "Heute wird es mild." / "Heute wird es kühl bis mild." Subject-second

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -416,6 +416,7 @@ zh-CN) is unchanged; only the displayed label localizes.
 
     <!-- Insight prose templates — German equivalents of the keys in values/strings.xml. -->
     <string name="insight_lead_today">Heute</string>
+    <string name="insight_lead_tomorrow">Morgen</string>
     <string name="insight_lead_tonight">Heute Abend</string>
 
     <!-- "Heute wird es mild." / "Heute wird es kühl bis mild." Subject-second

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -475,6 +475,7 @@ zh-CN) is unchanged; only the displayed label localizes.
          "%1$s θα είναι %2$s" template. Time format uses the standard
          Greek 24-hour colon notation ("15:00" / "15:30"). -->
     <string name="insight_lead_today">Σήμερα</string>
+    <string name="insight_lead_tomorrow">Αύριο</string>
     <string name="insight_lead_tonight">Απόψε</string>
     <string name="insight_band_single">%1$s θα κάνει %2$s.</string>
     <string name="insight_band_range">%1$s θα έχει %2$s έως %3$s.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -415,6 +415,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="onboarding_continue">Continuar</string>
 
     <string name="insight_lead_today">Hoy</string>
+    <string name="insight_lead_tomorrow">Mañana</string>
     <string name="insight_lead_tonight">Esta noche</string>
     <string name="insight_band_single">%1$s hará %2$s.</string>
     <string name="insight_band_range">%1$s hará entre %2$s y %3$s.</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -494,6 +494,7 @@ Tone is informal "sina"-form throughout ("Pane … selga", "Võta … kaasa",
     <string name="bug_report_consent_cancel">Tühista</string>
 
     <string name="insight_lead_today">Täna</string>
+    <string name="insight_lead_tomorrow">Homme</string>
     <string name="insight_lead_tonight">Täna õhtul</string>
     <!-- Estonian copular shape: "Täna on külm." -->
     <string name="insight_band_single">%1$s on %2$s.</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -48,6 +48,7 @@ Western Arabic numerals (0-9) are used for TTS compatibility.
     <string name="today_outfit_bottom_long_pants">شلوار بلند</string>
 
     <string name="insight_lead_today">امروز</string>
+    <string name="insight_lead_tomorrow">فردا</string>
     <string name="insight_lead_tonight">امشب</string>
     <!-- "امروز هوا معتدل خواهد بود." — SOV with lead first. -->
     <string name="insight_band_single">%1$s هوا %2$s خواهد بود.</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -334,6 +334,7 @@ displayed label localizes.
     <string name="onboarding_continue">Jatka</string>
 
     <string name="insight_lead_today">Tänään</string>
+    <string name="insight_lead_tomorrow">Huomenna</string>
     <string name="insight_lead_tonight">Tänä iltana</string>
 
     <!-- Finnish predicative-partitive: "Tänään on kylmää." -->

--- a/app/src/main/res/values-fil/strings.xml
+++ b/app/src/main/res/values-fil/strings.xml
@@ -44,6 +44,7 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="today_outfit_bottom_long_pants">Mahabang pantalon</string>
 
     <string name="insight_lead_today">Ngayon</string>
+    <string name="insight_lead_tomorrow">Bukas</string>
     <string name="insight_lead_tonight">Ngayong gabi</string>
     <!-- Filipino: "Ngayon, magiging malamig." -->
     <string name="insight_band_single">%1$s, magiging %2$s.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -417,6 +417,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="onboarding_continue">Continuer</string>
 
     <string name="insight_lead_today">Aujourd\'hui</string>
+    <string name="insight_lead_tomorrow">Demain</string>
     <string name="insight_lead_tonight">Ce soir</string>
     <string name="insight_band_single">%1$s, il fera %2$s.</string>
     <string name="insight_band_range">%1$s, il fera entre %2$s et %3$s.</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -454,6 +454,7 @@ Not overridden by design:
 
     <!-- Insight prose templates. -->
     <string name="insight_lead_today">आज</string>
+    <string name="insight_lead_tomorrow">कल</string>
     <string name="insight_lead_tonight">आज रात</string>
     <!-- "आज मौसम सुहाना रहेगा।" -->
     <string name="insight_band_single">%1$s मौसम %2$s रहेगा।</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -387,6 +387,7 @@ spousal register), matching the existing insight prose ("Ponesi …",
     <string name="onboarding_continue">Nastavi</string>
 
     <string name="insight_lead_today">Danas</string>
+    <string name="insight_lead_tomorrow">Sutra</string>
     <string name="insight_lead_tonight">Večeras</string>
     <string name="insight_band_single">%1$s će biti %2$s.</string>
     <string name="insight_band_range">%1$s će biti od %2$s do %3$s.</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -540,6 +540,7 @@ locale (Angol (Egyesült Államok), Francia (Franciaország), Német
 
     <!-- Insight prose templates. -->
     <string name="insight_lead_today">Ma</string>
+    <string name="insight_lead_tomorrow">Holnap</string>
     <string name="insight_lead_tonight">Ma este</string>
     <!-- "%1$s %2$s lesz." → "Ma hideg lesz." Lead first, then band, copula at end. -->
     <string name="insight_band_single">%1$s %2$s lesz.</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -46,6 +46,7 @@ to values/strings.xml (English).
     <string name="today_outfit_bottom_long_pants">Celana panjang</string>
 
     <string name="insight_lead_today">Hari ini</string>
+    <string name="insight_lead_tomorrow">Besok</string>
     <string name="insight_lead_tonight">Malam ini</string>
     <!-- Indonesian SVO: "Hari ini cuacanya sejuk." -->
     <string name="insight_band_single">%1$s cuacanya %2$s.</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -404,6 +404,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="onboarding_continue">Continua</string>
 
     <string name="insight_lead_today">Oggi</string>
+    <string name="insight_lead_tomorrow">Domani</string>
     <string name="insight_lead_tonight">Stasera</string>
     <string name="insight_band_single">%1$s sarà %2$s.</string>
     <string name="insight_band_range">%1$s sarà tra %2$s e %3$s.</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -49,6 +49,7 @@ standard in Israeli digital communication.
     <string name="today_outfit_bottom_long_pants">מכנסיים ארוכים</string>
 
     <string name="insight_lead_today">היום</string>
+    <string name="insight_lead_tomorrow">מחר</string>
     <string name="insight_lead_tonight">הלילה</string>
     <!-- "היום יהיה נעים." -->
     <string name="insight_band_single">%1$s יהיה %2$s.</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -415,6 +415,7 @@ the displayed label localizes.
     <string name="onboarding_continue">続ける</string>
 
     <string name="insight_lead_today">今日</string>
+    <string name="insight_lead_tomorrow">明日</string>
     <string name="insight_lead_tonight">今夜</string>
     <!-- "今日は穏やかでしょう。" — は marks the topic. -->
     <string name="insight_band_single">%1$sは%2$sでしょう。</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -430,6 +430,7 @@ displayed label localizes.
     <string name="onboarding_continue">계속</string>
 
     <string name="insight_lead_today">오늘</string>
+    <string name="insight_lead_tomorrow">내일</string>
     <string name="insight_lead_tonight">오늘 밤</string>
     <!-- "오늘 포근한 날씨입니다." -->
     <string name="insight_band_single">%1$s %2$s 날씨입니다.</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -51,6 +51,7 @@ What is NOT overridden, by design:
     <string name="today_outfit_bottom_long_pants">Ilgos kelnės</string>
 
     <string name="insight_lead_today">Šiandien</string>
+    <string name="insight_lead_tomorrow">Rytoj</string>
     <string name="insight_lead_tonight">Šįvakar</string>
     <!-- Lithuanian neuter short-form weather: "Šiandien bus šalta." -->
     <string name="insight_band_single">%1$s bus %2$s.</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -56,6 +56,7 @@ informal "tu"-form throughout ("Apģērb …", "Paņem … līdzi").
     <string name="today_outfit_bottom_jeans">Džinsi</string>
 
     <string name="insight_lead_today">Šodien</string>
+    <string name="insight_lead_tomorrow">Rīt</string>
     <string name="insight_lead_tonight">Šovakar</string>
     <!-- Latvian masculine-nominative agreement (implicit subject "laiks"):
          "Šodien būs auksts." -->

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -46,6 +46,7 @@ vs "kemungkinan", "padam" vs "hapus").
     <string name="today_outfit_bottom_long_pants">Seluar panjang</string>
 
     <string name="insight_lead_today">Hari ini</string>
+    <string name="insight_lead_tomorrow">Esok</string>
     <string name="insight_lead_tonight">Malam ini</string>
     <!-- Malay topic-comment shape: "Hari ini cuacanya sejuk." -->
     <string name="insight_band_single">%1$s cuacanya %2$s.</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -541,6 +541,7 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrike)").
 
     <!-- Insight prose templates. -->
     <string name="insight_lead_today">I dag</string>
+    <string name="insight_lead_tomorrow">I morgen</string>
     <string name="insight_lead_tonight">I kveld</string>
     <!-- Norwegian V2 word order: "I dag blir det mildt." -->
     <string name="insight_band_single">%1$s blir det %2$s.</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -378,6 +378,7 @@ the displayed label localizes.
 
     <!-- Insight prose templates. -->
     <string name="insight_lead_today">Vandaag</string>
+    <string name="insight_lead_tomorrow">Morgen</string>
     <string name="insight_lead_tonight">Vanavond</string>
 
     <!-- Dutch V2 word order: "Vandaag wordt het mild." -->

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -378,6 +378,7 @@ is unchanged; only the displayed label localizes.
 
     <!-- Insight prose templates. -->
     <string name="insight_lead_today">Dziś</string>
+    <string name="insight_lead_tomorrow">Jutro</string>
     <string name="insight_lead_tonight">Wieczorem</string>
 
     <string name="insight_band_single">%1$s będzie %2$s.</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -422,6 +422,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="onboarding_continue">Continuar</string>
 
     <string name="insight_lead_today">Hoje</string>
+    <string name="insight_lead_tomorrow">Amanhã</string>
     <string name="insight_lead_tonight">Esta noite</string>
     <string name="insight_band_single">%1$s será %2$s.</string>
     <string name="insight_band_range">%1$s estará entre %2$s e %3$s.</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -446,6 +446,7 @@ they diverge from BR ("Polonês" → "Polaco", "Holandês" →
          (PT) for "Garoa" (BR drizzle), "Trovoada" (PT) for
          "Tempestade" (BR thunderstorm). -->
     <string name="insight_lead_today">Hoje</string>
+    <string name="insight_lead_tomorrow">Amanhã</string>
     <string name="insight_lead_tonight">Esta noite</string>
     <string name="insight_band_single">%1$s será %2$s.</string>
     <string name="insight_band_range">%1$s estará entre %2$s e %3$s.</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -45,6 +45,7 @@ surfaces fall back to default English (matching values-pl / values-uk).
     <string name="today_outfit_bottom_long_pants">Pantaloni lungi</string>
 
     <string name="insight_lead_today">Astăzi</string>
+    <string name="insight_lead_tomorrow">Mâine</string>
     <string name="insight_lead_tonight">Diseară</string>
     <string name="insight_band_single">%1$s va fi %2$s.</string>
     <string name="insight_band_range">%1$s va fi între %2$s și %3$s.</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -609,6 +609,7 @@ only the displayed label localizes.
 
     <!-- Insight prose templates. -->
     <string name="insight_lead_today">Сегодня</string>
+    <string name="insight_lead_tomorrow">Завтра</string>
     <string name="insight_lead_tonight">Сегодня вечером</string>
     <string name="insight_band_single">%1$s будет %2$s.</string>
     <string name="insight_band_range">%1$s будет от %2$s до %3$s.</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -552,6 +552,7 @@ What is NOT overridden, by design:
 
     <!-- Insight prose templates. -->
     <string name="insight_lead_today">Dnes</string>
+    <string name="insight_lead_tomorrow">Zajtra</string>
     <string name="insight_lead_tonight">Dnes večer</string>
     <string name="insight_band_single">%1$s bude %2$s.</string>
     <string name="insight_band_range">%1$s bude od %2$s do %3$s.</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -44,6 +44,7 @@ informal "ti"-form throughout, mirroring the Croatian / Serbian pass.
     <string name="today_outfit_bottom_long_pants">Dolge hlače</string>
 
     <string name="insight_lead_today">Danes</string>
+    <string name="insight_lead_tomorrow">Jutri</string>
     <string name="insight_lead_tonight">Nocoj</string>
     <!-- "Danes bo mrzlo." — leading time adverb + "bo" + adjective. -->
     <string name="insight_band_single">%1$s bo %2$s.</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -541,6 +541,7 @@ native names for all locales (e.g. "Tyska (Tyskland)", "Franska (Frankrike)").
 
     <!-- Insight prose templates. -->
     <string name="insight_lead_today">Idag</string>
+    <string name="insight_lead_tomorrow">Imorgon</string>
     <string name="insight_lead_tonight">I kväll</string>
     <!-- Swedish V2 word order: "Idag blir det milt." -->
     <string name="insight_band_single">%1$s blir det %2$s.</string>

--- a/app/src/main/res/values-sw/strings.xml
+++ b/app/src/main/res/values-sw/strings.xml
@@ -44,6 +44,7 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="today_outfit_bottom_long_pants">Suruali ndefu</string>
 
     <string name="insight_lead_today">Leo</string>
+    <string name="insight_lead_tomorrow">Kesho</string>
     <string name="insight_lead_tonight">Usiku huu</string>
     <!-- Swahili: "Leo itakuwa baridi." -->
     <string name="insight_band_single">%1$s itakuwa %2$s.</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -44,6 +44,7 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="today_outfit_bottom_long_pants">กางเกงขายาว</string>
 
     <string name="insight_lead_today">วันนี้</string>
+    <string name="insight_lead_tomorrow">พรุ่งนี้</string>
     <string name="insight_lead_tonight">คืนนี้</string>
     <!-- Thai: "วันนี้อากาศเย็น" (time + topic + predicate, no copula). -->
     <string name="insight_band_single">%1$sอากาศ%2$s</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -334,6 +334,7 @@ displayed label localizes.
     <string name="onboarding_continue">Devam et</string>
 
     <string name="insight_lead_today">Bugün</string>
+    <string name="insight_lead_tomorrow">Yarın</string>
     <string name="insight_lead_tonight">Bu gece</string>
 
     <!-- Turkish SOV word order: subject-object-verb; predicate at the end. -->

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -550,6 +550,7 @@ only the displayed label localizes.
     -->
 
     <string name="insight_lead_today">Сьогодні</string>
+    <string name="insight_lead_tomorrow">Завтра</string>
     <string name="insight_lead_tonight">Сьогодні ввечері</string>
     <string name="insight_band_single">%1$s буде %2$s.</string>
     <string name="insight_band_range">%1$s буде від %2$s до %3$s.</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -49,6 +49,7 @@ Skipped intentionally: app_name (brand), insight_time_am/pm/midnight/noon
     <string name="today_outfit_bottom_long_pants">Quần dài</string>
 
     <string name="insight_lead_today">Hôm nay</string>
+    <string name="insight_lead_tomorrow">Ngày mai</string>
     <string name="insight_lead_tonight">Tối nay</string>
     <!-- Vietnamese: "Hôm nay trời mát." (time + topic + predicate) -->
     <string name="insight_band_single">%1$s trời %2$s.</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -408,6 +408,7 @@ label localizes.
     <string name="onboarding_continue">继续</string>
 
     <string name="insight_lead_today">今天</string>
+    <string name="insight_lead_tomorrow">明天</string>
     <string name="insight_lead_tonight">今晚</string>
     <!-- "今天天气温和。" / "今晚天气寒冷至凉爽。" -->
     <string name="insight_band_single">%1$s天气%2$s。</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -399,6 +399,7 @@ label localises.
     <string name="onboarding_continue">繼續</string>
 
     <string name="insight_lead_today">今天</string>
+    <string name="insight_lead_tomorrow">明天</string>
     <string name="insight_lead_tonight">今晚</string>
     <!-- "今天天氣溫和。" / "今晚天氣寒冷至涼爽。" -->
     <string name="insight_band_single">%1$s天氣%2$s。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -781,9 +781,13 @@
     args let translations rearrange tokens.
     -->
 
-    <!-- "Today" / "Tonight" lead-in for the band-temperature sentence. -->
+    <!-- "Today" / "Tonight" / "Tomorrow" lead-in for the band-temperature sentence.
+         "Tomorrow" is used on page 2 when the evening worker has cached
+         tomorrow's daytime insight; in every other case the daytime forecast
+         shows "Today". -->
     <string name="insight_lead_today">Today</string>
     <string name="insight_lead_tonight">Tonight</string>
+    <string name="insight_lead_tomorrow">Tomorrow</string>
 
     <!-- Single-band sentence: %1$s = lead-in ("Today"), %2$s = band label ("mild").
          The comma-fronted "Today, it will be …" / "Tonight, it will be …" structure

--- a/app/src/test/kotlin/app/clothescast/insight/InsightFormatterTest.kt
+++ b/app/src/test/kotlin/app/clothescast/insight/InsightFormatterTest.kt
@@ -62,6 +62,21 @@ class InsightFormatterTest {
     }
 
     @Test
+    fun `isFutureDay swaps the today lead-in for tomorrow`() {
+        subject.format(summary(), isFutureDay = true) shouldBe "Tomorrow, it will be mild."
+    }
+
+    @Test
+    fun `isFutureDay leaves the tonight lead-in alone`() {
+        // The evening worker only ever pairs a primary insight with tomorrow's
+        // daytime, so a TONIGHT payload with isFutureDay=true isn't a real
+        // path — but if it ever arrived we'd rather say "Tonight" than
+        // accidentally promote it to tomorrow.
+        subject.format(summary(period = ForecastPeriod.TONIGHT), isFutureDay = true) shouldBe
+            "Tonight, it will be mild."
+    }
+
+    @Test
     fun `delta clause emits warmer with rounded degrees`() {
         val out = subject.format(summary(delta = DeltaClause(5, DeltaClause.Direction.WARMER)))
         out shouldBe "Today, it will be mild. 5° warmer than yesterday."


### PR DESCRIPTION
## Summary

- The Today screen's page 2 caches the *next-period* insight. After the evening worker runs, that's tomorrow's daytime forecast — its `period` is `TODAY` (it's a daytime band), but its `forDate` is the next calendar day. The formatter only looked at `period`, so the prose led with "Today, it will be …" while the date row right above it said e.g. "Saturday, May 16."
- This PR plumbs an `isFutureDay` flag from the `InsightCard` call site (computed as `insight.forDate.isAfter(LocalDate.now())`) into `InsightFormatter.format`, swaps the `TODAY` lead-in for a new `insight_lead_tomorrow` string when set, and ships translations for all 46 localized variants.
- `TONIGHT` keeps its existing "Tonight" lead unchanged — `FetchAndNotifyWorker.generatePairedInsight` never pairs a primary insight with tomorrow night, so no tomorrow-shaped `TONIGHT` payload reaches the formatter.
- The other three call sites of `InsightFormatter.format` (notification body, TTS, bug report) all render the *primary* / current-period insight, so they pick up the default `isFutureDay = false` and are unchanged.

## Test plan

- [x] `:app:testDebugUnitTest` — new cases in `InsightFormatterTest`: `isFutureDay swaps the today lead-in for tomorrow`, `isFutureDay leaves the tonight lead-in alone`. All pre-existing tests still pass.
- [x] `:core:domain:test` / `:core:data:test`
- [x] `:app:assembleDebug` (debug APK builds clean with the new resource in every locale)
- [ ] Manual: after the evening worker run, swipe to page 2 in English and confirm the prose now starts with "Tomorrow, …" instead of "Today, …" (CI build).

https://claude.ai/code/session_01M3YdVcohSBeULy4EC7ouZ4

---
_Generated by [Claude Code](https://claude.ai/code/session_01M3YdVcohSBeULy4EC7ouZ4)_