### PR TITLE
ci: add test: subject prefix to release-notes filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -514,7 +514,8 @@ jobs:
         # Per-commit filter: a commit's subject is skipped if it would read
         # as noise to a non-engineer — anything prefixed `ci:` (the
         # snapshot-regen bot commits "ci: regenerate UI snapshots", workflow
-        # tweaks, etc.) and changes whose paths are all under `docs/`, all
+        # tweaks, etc.) or `test:` (test-only changes that ship nothing in
+        # the APK), and changes whose paths are all under `docs/`, all
         # top-level dotfiles or hidden directories (`.github/`, `.claude/`,
         # `.gitignore`, `.editorconfig`, …), or top-level `*.md`. PRIVACY.md
         # is treated as non-docs so that privacy-policy updates still surface
@@ -618,7 +619,7 @@ jobs:
             local sha="$1" subject non_doc_count
             subject=$(git log -1 --pretty=%s "$sha")
             case "$subject" in
-              ci:*) return 0 ;;
+              ci:*|test:*) return 0 ;;
             esac
             non_doc_count=$(git show --no-renames --name-only --pretty=format: "$sha" \
               | sed '/^$/d' \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,12 +116,21 @@ new rule the first time something bites you, not the third.
   Move scope, module names, and engineering detail (file paths, refactor
   reasoning, "fixes #123") into the commit body — reviewers see the body
   on the PR, but the Play release notes don't.
-- **`ci:` prefix and docs-only commits are filtered out** of the
-  changelog (see the "Prepare release notes" step in `ci.yml`) so the
-  snapshot-regen bot's commits and `docs/` / dotfile / `*.md` changes
-  don't surface as bullets. Anything else *will* appear — if a commit
-  shouldn't ship in the changelog, either squash it into a sibling or
-  give it a `ci:` subject prefix.
+- **`ci:` / `test:` prefixes and docs-only commits are filtered out** of
+  the changelog (see the "Prepare release notes" step in `ci.yml`) so the
+  snapshot-regen bot's commits, test-only changes, and `docs/` / dotfile
+  / `*.md` changes don't surface as bullets. Anything else *will* appear
+  — if a commit shouldn't ship in the changelog, either squash it into a
+  sibling or give it the appropriate prefix.
+- **Test-only commits use a `test:` subject prefix.** A commit that
+  touches only test sources / fixtures / snapshots (anything under
+  `src/test/`, `src/androidTest/`, `app/snapshots/`, or equivalent —
+  nothing shipped in the APK) ships no user-visible change, so it
+  doesn't belong in the Play "What's new". Prefix the subject `test:`
+  (e.g. `test: cover evening-rain fallthrough in InsightTextTest`) and
+  CI will skip it the same way it skips `ci:`. Mixed commits (test +
+  production code) stay un-prefixed and ship as normal bullets —
+  squash the test work into the feature commit instead of splitting.
 - **Play caps `whatsnew-en-US` at 500 bytes.** When the bullet list
   exceeds that, CI truncates and appends `…`. Avoid lining up a long
   stack of small commits if any one of them tells the user-facing story


### PR DESCRIPTION
## Summary

- Adds `test:` as a recognised subject prefix that the "Prepare release notes" CI step filters out of the Play Store `whatsnew-en-US` changelog, alongside the existing `ci:*` short-circuit.
- Documents the convention in `AGENTS.md` under "Commit messages": test-only commits (changes confined to test sources / fixtures / snapshots, with nothing shipped in the APK) get a `test:` subject prefix; mixed commits (test + production code) stay un-prefixed and ship as normal bullets — squash test work into the feature commit rather than splitting.

## Rationale

Test-only commits have no user-visible change, so they're pure noise in the Play "What's new" blurb. The `ci:` escape hatch already exists for the snapshot-regen bot and workflow tweaks; `test:` extends the same pattern to a category that comes up routinely on feature work.

## Privacy

No change to what leaves the device. CI release-notes formatting only.

## Test plan

- [ ] CI green on this PR.
- [ ] (Implicit) Next main run with a `test:`-prefixed commit in range omits that subject from the Play changelog — verified the next time such a commit lands.

---
_Generated by [Claude Code](https://claude.ai/code/session_011bepcg93gaUmnzpiQha5hk)_