### PR TITLE
Translate the forecasters picker, garment-colour picker, and update-downloading banner for Western European languages

### DIFF
--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -566,4 +566,50 @@ the in-app clock is digit-driven and reads consistently across locales.
 
     <string name="settings_tts_test">Prova la veu</string>
     <string name="settings_tts_test_in_flight">Provant — espera…</string>
+
+    <!-- Strings added to match base — forecasters picker, garment-colour picker,
+         update-downloading banner, placeholder cards, Open-Meteo credit. -->
+    <string name="today_update_downloading_body">Baixant l\'actualització…</string>
+    <string name="today_update_downloading_action">Actualitzant</string>
+    <string name="today_update_downloading_dismiss">Cancel·la</string>
+    <string name="today_view_other_period">Mostra l\'altra previsió</string>
+    <string name="today_back_to_primary">Enrere</string>
+    <string name="today_placeholder_today_title">Previsió d\'avui</string>
+    <string name="today_placeholder_tonight_title">Previsió d\'aquesta nit</string>
+    <string name="today_placeholder_body">Llesta cap a les %1$s.</string>
+
+    <string name="settings_root_forecasters">Models de previsió</string>
+    <string name="settings_root_forecasters_subtitle">Fonts i models meteorològics</string>
+
+    <string name="settings_display_garment_colors_title">Colors de la roba</string>
+    <string name="settings_display_garment_colors_description">Tria un color per a cada icona de peça de roba que apareix a Avui, al widget de la pantalla d\'inici i a les notificacions. El contorn s\'enfosqueix automàticament.</string>
+    <string name="settings_garment_color_default">Per defecte</string>
+    <string name="settings_garment_color_picker_title">Tria un color</string>
+    <string name="settings_garment_color_swatch_description">Mostra de color %1$s</string>
+    <string name="settings_garment_color_default_swatch_description">Restableix %1$s al color per defecte</string>
+    <string name="settings_garment_color_dialog_close">Tanca</string>
+
+    <string name="settings_forecasters_title">Models de previsió</string>
+    <string name="settings_forecasters_description">L\'indicador de confiança i el gràfic per model es basen en aquests models. Triar-ne més amplia el ventall; menys, el concentra. Almenys dos resten seleccionats.</string>
+    <string name="settings_forecasters_auto_title">Auto (el millor per a la teva ubicació)</string>
+    <string name="settings_forecasters_auto_subtitle">Tria automàticament el model regional — UKMO a les illes britàniques, JMA al Japó, GFS + GEM a Amèrica del Nord, etc. Desactiva\'l per triar tu mateix els models.</string>
+    <string name="settings_forecasters_cap_hint">Has triat %1$d models — el màxim perquè el gràfic continuï llegible. Desselecciona\'n un per afegir-ne un altre.</string>
+    <string name="settings_forecasters_ecmwf">ECMWF</string>
+    <string name="settings_forecasters_ecmwf_subtitle">Europeu — generalment el model global més precís. Cada 3 h al canal obert.</string>
+    <string name="settings_forecasters_icon">ICON</string>
+    <string name="settings_forecasters_icon_subtitle">Alemany (DWD) — sòlid a Europa i a curt termini. Horari natiu.</string>
+    <string name="settings_forecasters_gfs">GFS</string>
+    <string name="settings_forecasters_gfs_subtitle">Americà (NOAA) — sòlid a Amèrica del Nord. Horari natiu.</string>
+    <string name="settings_forecasters_gem">GEM</string>
+    <string name="settings_forecasters_gem_subtitle">Canadenc (ECCC) — sòlid a Amèrica del Nord. Cada 3 h al canal obert.</string>
+    <string name="settings_forecasters_arpege">ARPEGE</string>
+    <string name="settings_forecasters_arpege_subtitle">Francès (Météo-France) — sòlid sobre França i Europa occidental. Horari natiu.</string>
+    <string name="settings_forecasters_ukmo">UKMO</string>
+    <string name="settings_forecasters_ukmo_subtitle">Britànic (UK Met Office) — històricament només per darrere de l\'ECMWF. Cada 3 h al canal obert.</string>
+    <string name="settings_forecasters_jma">JMA</string>
+    <string name="settings_forecasters_jma_subtitle">Japonès — sòlid a l\'Àsia-Pacífic. Cada 3 a 6 h al canal obert.</string>
+    <string name="settings_forecasters_bom">BOM</string>
+    <string name="settings_forecasters_bom_subtitle">Australià — en manteniment; tornarà al més aviat possible.</string>
+
+    <string name="settings_about_open_meteo">Dades meteorològiques d\'Open-Meteo</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -747,4 +747,50 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="today_uv_peak">Spitze %1$d um %2$s</string>
     <string name="today_uv_title">UV-Index</string>
     <string name="today_wind_peak">Spitze %1$d %2$s um %3$s</string>
+
+    <!-- Strings added to match base — forecasters picker, garment-colour picker,
+         update-downloading banner, placeholder cards, Open-Meteo credit. -->
+    <string name="today_update_downloading_body">Update wird heruntergeladen…</string>
+    <string name="today_update_downloading_action">Wird aktualisiert</string>
+    <string name="today_update_downloading_dismiss">Abbrechen</string>
+    <string name="today_view_other_period">Andere Vorhersage anzeigen</string>
+    <string name="today_back_to_primary">Zurück</string>
+    <string name="today_placeholder_today_title">Heutige Vorhersage</string>
+    <string name="today_placeholder_tonight_title">Vorhersage für heute Abend</string>
+    <string name="today_placeholder_body">Etwa um %1$s fertig.</string>
+
+    <string name="settings_root_forecasters">Vorhersagemodelle</string>
+    <string name="settings_root_forecasters_subtitle">Wetterquellen und Modelle</string>
+
+    <string name="settings_display_garment_colors_title">Kleidungsfarben</string>
+    <string name="settings_display_garment_colors_description">Wähle eine Farbe für jedes Kleidungssymbol auf „Heute“, im Homescreen-Widget und in Benachrichtigungen. Die Umrandung wird automatisch dunkler.</string>
+    <string name="settings_garment_color_default">Standard</string>
+    <string name="settings_garment_color_picker_title">Farbe wählen</string>
+    <string name="settings_garment_color_swatch_description">Farbmuster %1$s</string>
+    <string name="settings_garment_color_default_swatch_description">%1$s auf Standardfarbe zurücksetzen</string>
+    <string name="settings_garment_color_dialog_close">Schließen</string>
+
+    <string name="settings_forecasters_title">Vorhersagemodelle</string>
+    <string name="settings_forecasters_description">Der Konfidenz-Chip und das Modell-Diagramm beziehen sich auf diese Modelle. Mehr ausgewählte Modelle ergeben eine breitere Streuung, weniger einen engeren Fokus. Mindestens zwei bleiben ausgewählt.</string>
+    <string name="settings_forecasters_auto_title">Auto (am besten für deinen Standort)</string>
+    <string name="settings_forecasters_auto_subtitle">Wählt das regionale Modell automatisch — UKMO auf den Britischen Inseln, JMA in Japan, GFS + GEM in Nordamerika usw. Schalte es aus, um die Modelle selbst zu wählen.</string>
+    <string name="settings_forecasters_cap_hint">Du hast %1$d Modelle ausgewählt — das Maximum, bei dem das Diagramm lesbar bleibt. Deaktiviere eins, um ein anderes hinzuzufügen.</string>
+    <string name="settings_forecasters_ecmwf">ECMWF</string>
+    <string name="settings_forecasters_ecmwf_subtitle">Europäisch — in der Regel das genaueste globale Modell. 3-stündig im offenen Feed.</string>
+    <string name="settings_forecasters_icon">ICON</string>
+    <string name="settings_forecasters_icon_subtitle">Deutsch (DWD) — stark in Europa und auf kurze Sicht. Stündlich nativ.</string>
+    <string name="settings_forecasters_gfs">GFS</string>
+    <string name="settings_forecasters_gfs_subtitle">Amerikanisch (NOAA) — stark über Nordamerika. Stündlich nativ.</string>
+    <string name="settings_forecasters_gem">GEM</string>
+    <string name="settings_forecasters_gem_subtitle">Kanadisch (ECCC) — stark über Nordamerika. 3-stündig im offenen Feed.</string>
+    <string name="settings_forecasters_arpege">ARPEGE</string>
+    <string name="settings_forecasters_arpege_subtitle">Französisch (Météo-France) — stark über Frankreich und Westeuropa. Stündlich nativ.</string>
+    <string name="settings_forecasters_ukmo">UKMO</string>
+    <string name="settings_forecasters_ukmo_subtitle">Britisch (UK Met Office) — historisch nur knapp hinter ECMWF. 3-stündig im offenen Feed.</string>
+    <string name="settings_forecasters_jma">JMA</string>
+    <string name="settings_forecasters_jma_subtitle">Japanisch — stark über Asien-Pazifik. 3- bis 6-stündig im offenen Feed.</string>
+    <string name="settings_forecasters_bom">BOM</string>
+    <string name="settings_forecasters_bom_subtitle">Australisch — in Wartung, kommt sobald wie möglich zurück.</string>
+
+    <string name="settings_about_open_meteo">Wetterdaten von Open-Meteo</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -724,4 +724,50 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="today_uv_peak">Pico %1$d a las %2$s</string>
     <string name="today_uv_title">Índice UV</string>
     <string name="today_wind_peak">Pico %1$d %2$s a las %3$s</string>
+
+    <!-- Strings added to match base — forecasters picker, garment-colour picker,
+         update-downloading banner, placeholder cards, Open-Meteo credit. -->
+    <string name="today_update_downloading_body">Descargando actualización…</string>
+    <string name="today_update_downloading_action">Actualizando</string>
+    <string name="today_update_downloading_dismiss">Cancelar</string>
+    <string name="today_view_other_period">Ver la otra previsión</string>
+    <string name="today_back_to_primary">Volver</string>
+    <string name="today_placeholder_today_title">Previsión de hoy</string>
+    <string name="today_placeholder_tonight_title">Previsión de esta noche</string>
+    <string name="today_placeholder_body">Lista hacia las %1$s.</string>
+
+    <string name="settings_root_forecasters">Modelos de previsión</string>
+    <string name="settings_root_forecasters_subtitle">Fuentes y modelos meteorológicos</string>
+
+    <string name="settings_display_garment_colors_title">Colores de la ropa</string>
+    <string name="settings_display_garment_colors_description">Elige un color para cada icono de prenda que aparece en Hoy, en el widget de la pantalla de inicio y en las notificaciones. El contorno se oscurece automáticamente.</string>
+    <string name="settings_garment_color_default">Predeterminado</string>
+    <string name="settings_garment_color_picker_title">Elige un color</string>
+    <string name="settings_garment_color_swatch_description">Muestra de color %1$s</string>
+    <string name="settings_garment_color_default_swatch_description">Restablecer %1$s al color predeterminado</string>
+    <string name="settings_garment_color_dialog_close">Cerrar</string>
+
+    <string name="settings_forecasters_title">Modelos de previsión</string>
+    <string name="settings_forecasters_description">El indicador de confianza y el gráfico por modelo se basan en estos modelos. Elegir más amplía el abanico; elegir menos lo concentra. Al menos dos quedan seleccionados.</string>
+    <string name="settings_forecasters_auto_title">Auto (lo mejor para tu ubicación)</string>
+    <string name="settings_forecasters_auto_subtitle">Elige automáticamente el modelo regional: UKMO en las islas británicas, JMA en Japón, GFS + GEM en Norteamérica, etc. Desactívalo para elegir los modelos tú.</string>
+    <string name="settings_forecasters_cap_hint">Has seleccionado %1$d modelos: el máximo para que el gráfico siga siendo legible. Deselecciona uno para añadir otro.</string>
+    <string name="settings_forecasters_ecmwf">ECMWF</string>
+    <string name="settings_forecasters_ecmwf_subtitle">Europeo — por lo general el modelo global más preciso. Cada 3 h en el feed abierto.</string>
+    <string name="settings_forecasters_icon">ICON</string>
+    <string name="settings_forecasters_icon_subtitle">Alemán (DWD) — sólido en Europa y a corto plazo. Horario nativo.</string>
+    <string name="settings_forecasters_gfs">GFS</string>
+    <string name="settings_forecasters_gfs_subtitle">Estadounidense (NOAA) — sólido en Norteamérica. Horario nativo.</string>
+    <string name="settings_forecasters_gem">GEM</string>
+    <string name="settings_forecasters_gem_subtitle">Canadiense (ECCC) — sólido en Norteamérica. Cada 3 h en el feed abierto.</string>
+    <string name="settings_forecasters_arpege">ARPEGE</string>
+    <string name="settings_forecasters_arpege_subtitle">Francés (Météo-France) — sólido en Francia y Europa occidental. Horario nativo.</string>
+    <string name="settings_forecasters_ukmo">UKMO</string>
+    <string name="settings_forecasters_ukmo_subtitle">Británico (UK Met Office) — históricamente solo por detrás de ECMWF. Cada 3 h en el feed abierto.</string>
+    <string name="settings_forecasters_jma">JMA</string>
+    <string name="settings_forecasters_jma_subtitle">Japonés — sólido en Asia-Pacífico. Cada 3 a 6 h en el feed abierto.</string>
+    <string name="settings_forecasters_bom">BOM</string>
+    <string name="settings_forecasters_bom_subtitle">Australiano — en mantenimiento; vuelve lo antes posible.</string>
+
+    <string name="settings_about_open_meteo">Datos meteorológicos de Open-Meteo</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -723,4 +723,50 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="today_uv_peak">Pointe %1$d à %2$s</string>
     <string name="today_uv_title">Indice UV</string>
     <string name="today_wind_peak">Pointe %1$d %2$s à %3$s</string>
+
+    <!-- Strings added to match base — forecasters picker, garment-colour picker,
+         update-downloading banner, placeholder cards, Open-Meteo credit. -->
+    <string name="today_update_downloading_body">Téléchargement de la mise à jour…</string>
+    <string name="today_update_downloading_action">Mise à jour…</string>
+    <string name="today_update_downloading_dismiss">Annuler</string>
+    <string name="today_view_other_period">Voir l\'autre prévision</string>
+    <string name="today_back_to_primary">Retour</string>
+    <string name="today_placeholder_today_title">Prévision du jour</string>
+    <string name="today_placeholder_tonight_title">Prévision de ce soir</string>
+    <string name="today_placeholder_body">Prête vers %1$s.</string>
+
+    <string name="settings_root_forecasters">Modèles de prévision</string>
+    <string name="settings_root_forecasters_subtitle">Sources et modèles météo</string>
+
+    <string name="settings_display_garment_colors_title">Couleurs des vêtements</string>
+    <string name="settings_display_garment_colors_description">Choisis une couleur pour chaque icône de vêtement affichée sur Aujourd\'hui, sur le widget de l\'écran d\'accueil et dans les notifications. Le contour s\'assombrit automatiquement.</string>
+    <string name="settings_garment_color_default">Par défaut</string>
+    <string name="settings_garment_color_picker_title">Choisis une couleur</string>
+    <string name="settings_garment_color_swatch_description">Échantillon de couleur %1$s</string>
+    <string name="settings_garment_color_default_swatch_description">Rétablir la couleur par défaut de %1$s</string>
+    <string name="settings_garment_color_dialog_close">Fermer</string>
+
+    <string name="settings_forecasters_title">Modèles de prévision</string>
+    <string name="settings_forecasters_description">La puce de confiance et le graphique par modèle s\'appuient sur ces modèles. En choisir plus élargit l\'éventail ; en choisir moins resserre le focus. Au moins deux restent sélectionnés.</string>
+    <string name="settings_forecasters_auto_title">Auto (le mieux pour ta position)</string>
+    <string name="settings_forecasters_auto_subtitle">Choisit automatiquement le modèle régional — UKMO sur les îles Britanniques, JMA au Japon, GFS + GEM en Amérique du Nord, etc. Désactive pour choisir tes modèles toi-même.</string>
+    <string name="settings_forecasters_cap_hint">Tu as sélectionné %1$d modèles — le maximum pour que le graphique reste lisible. Désélectionnes-en un pour en ajouter un autre.</string>
+    <string name="settings_forecasters_ecmwf">ECMWF</string>
+    <string name="settings_forecasters_ecmwf_subtitle">Européen — généralement le modèle global le plus précis. Toutes les 3 h sur le flux ouvert.</string>
+    <string name="settings_forecasters_icon">ICON</string>
+    <string name="settings_forecasters_icon_subtitle">Allemand (DWD) — solide en Europe et à courte échéance. Pas horaire natif.</string>
+    <string name="settings_forecasters_gfs">GFS</string>
+    <string name="settings_forecasters_gfs_subtitle">Américain (NOAA) — solide sur l\'Amérique du Nord. Pas horaire natif.</string>
+    <string name="settings_forecasters_gem">GEM</string>
+    <string name="settings_forecasters_gem_subtitle">Canadien (ECCC) — solide sur l\'Amérique du Nord. Toutes les 3 h sur le flux ouvert.</string>
+    <string name="settings_forecasters_arpege">ARPEGE</string>
+    <string name="settings_forecasters_arpege_subtitle">Français (Météo-France) — solide sur la France et l\'Europe de l\'Ouest. Pas horaire natif.</string>
+    <string name="settings_forecasters_ukmo">UKMO</string>
+    <string name="settings_forecasters_ukmo_subtitle">Britannique (UK Met Office) — historiquement second derrière ECMWF. Toutes les 3 h sur le flux ouvert.</string>
+    <string name="settings_forecasters_jma">JMA</string>
+    <string name="settings_forecasters_jma_subtitle">Japonais — solide sur l\'Asie-Pacifique. Toutes les 3 à 6 h sur le flux ouvert.</string>
+    <string name="settings_forecasters_bom">BOM</string>
+    <string name="settings_forecasters_bom_subtitle">Australien — en maintenance, de retour dès que possible.</string>
+
+    <string name="settings_about_open_meteo">Données météo fournies par Open-Meteo</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -709,4 +709,50 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="today_uv_peak">Picco %1$d alle %2$s</string>
     <string name="today_uv_title">Indice UV</string>
     <string name="today_wind_peak">Picco %1$d %2$s alle %3$s</string>
+
+    <!-- Strings added to match base — forecasters picker, garment-colour picker,
+         update-downloading banner, placeholder cards, Open-Meteo credit. -->
+    <string name="today_update_downloading_body">Download dell\'aggiornamento…</string>
+    <string name="today_update_downloading_action">Aggiornamento…</string>
+    <string name="today_update_downloading_dismiss">Annulla</string>
+    <string name="today_view_other_period">Mostra l\'altra previsione</string>
+    <string name="today_back_to_primary">Indietro</string>
+    <string name="today_placeholder_today_title">Previsione di oggi</string>
+    <string name="today_placeholder_tonight_title">Previsione di stasera</string>
+    <string name="today_placeholder_body">Pronta verso le %1$s.</string>
+
+    <string name="settings_root_forecasters">Modelli di previsione</string>
+    <string name="settings_root_forecasters_subtitle">Sorgenti e modelli meteo</string>
+
+    <string name="settings_display_garment_colors_title">Colori degli indumenti</string>
+    <string name="settings_display_garment_colors_description">Scegli un colore per ogni icona di indumento mostrata su Oggi, sul widget della schermata Home e nelle notifiche. Il contorno si scurisce automaticamente.</string>
+    <string name="settings_garment_color_default">Predefinito</string>
+    <string name="settings_garment_color_picker_title">Scegli un colore</string>
+    <string name="settings_garment_color_swatch_description">Campione di colore %1$s</string>
+    <string name="settings_garment_color_default_swatch_description">Ripristina %1$s al colore predefinito</string>
+    <string name="settings_garment_color_dialog_close">Chiudi</string>
+
+    <string name="settings_forecasters_title">Modelli di previsione</string>
+    <string name="settings_forecasters_description">L\'indicatore di confidenza e il grafico per modello attingono da questi modelli. Sceglierne di più amplia la gamma; meno restringe il fuoco. Almeno due restano selezionati.</string>
+    <string name="settings_forecasters_auto_title">Auto (il migliore per la tua posizione)</string>
+    <string name="settings_forecasters_auto_subtitle">Sceglie automaticamente il modello regionale: UKMO nelle isole britanniche, JMA in Giappone, GFS + GEM in Nord America, ecc. Disattiva per scegliere i modelli da solo.</string>
+    <string name="settings_forecasters_cap_hint">Hai selezionato %1$d modelli — il massimo per cui il grafico resta leggibile. Deselezionane uno per aggiungerne un altro.</string>
+    <string name="settings_forecasters_ecmwf">ECMWF</string>
+    <string name="settings_forecasters_ecmwf_subtitle">Europeo — in genere il modello globale più accurato. Ogni 3 ore sul feed aperto.</string>
+    <string name="settings_forecasters_icon">ICON</string>
+    <string name="settings_forecasters_icon_subtitle">Tedesco (DWD) — solido in Europa e a breve termine. Orario nativo.</string>
+    <string name="settings_forecasters_gfs">GFS</string>
+    <string name="settings_forecasters_gfs_subtitle">Americano (NOAA) — solido sul Nord America. Orario nativo.</string>
+    <string name="settings_forecasters_gem">GEM</string>
+    <string name="settings_forecasters_gem_subtitle">Canadese (ECCC) — solido sul Nord America. Ogni 3 ore sul feed aperto.</string>
+    <string name="settings_forecasters_arpege">ARPEGE</string>
+    <string name="settings_forecasters_arpege_subtitle">Francese (Météo-France) — solido su Francia ed Europa occidentale. Orario nativo.</string>
+    <string name="settings_forecasters_ukmo">UKMO</string>
+    <string name="settings_forecasters_ukmo_subtitle">Britannico (UK Met Office) — storicamente secondo solo a ECMWF. Ogni 3 ore sul feed aperto.</string>
+    <string name="settings_forecasters_jma">JMA</string>
+    <string name="settings_forecasters_jma_subtitle">Giapponese — solido sull\'Asia-Pacifico. Ogni 3-6 ore sul feed aperto.</string>
+    <string name="settings_forecasters_bom">BOM</string>
+    <string name="settings_forecasters_bom_subtitle">Australiano — in manutenzione, torna appena possibile.</string>
+
+    <string name="settings_about_open_meteo">Dati meteo forniti da Open-Meteo</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -672,4 +672,50 @@ the displayed label localizes.
     <string name="today_uv_peak">Piek %1$d om %2$s</string>
     <string name="today_uv_title">UV-index</string>
     <string name="today_wind_peak">Piek %1$d %2$s om %3$s</string>
+
+    <!-- Strings added to match base — forecasters picker, garment-colour picker,
+         update-downloading banner, placeholder cards, Open-Meteo credit. -->
+    <string name="today_update_downloading_body">Update wordt gedownload…</string>
+    <string name="today_update_downloading_action">Bezig met bijwerken</string>
+    <string name="today_update_downloading_dismiss">Annuleren</string>
+    <string name="today_view_other_period">Andere voorspelling bekijken</string>
+    <string name="today_back_to_primary">Terug</string>
+    <string name="today_placeholder_today_title">Voorspelling van vandaag</string>
+    <string name="today_placeholder_tonight_title">Voorspelling voor vanavond</string>
+    <string name="today_placeholder_body">Klaar rond %1$s.</string>
+
+    <string name="settings_root_forecasters">Voorspellingsmodellen</string>
+    <string name="settings_root_forecasters_subtitle">Weerbronnen en modellen</string>
+
+    <string name="settings_display_garment_colors_title">Kledingkleuren</string>
+    <string name="settings_display_garment_colors_description">Kies een kleur voor elk kledingicoon op Vandaag, in de homescreen-widget en in meldingen. De rand wordt automatisch donkerder.</string>
+    <string name="settings_garment_color_default">Standaard</string>
+    <string name="settings_garment_color_picker_title">Kies een kleur</string>
+    <string name="settings_garment_color_swatch_description">Kleurstaal %1$s</string>
+    <string name="settings_garment_color_default_swatch_description">%1$s terugzetten naar de standaardkleur</string>
+    <string name="settings_garment_color_dialog_close">Sluiten</string>
+
+    <string name="settings_forecasters_title">Voorspellingsmodellen</string>
+    <string name="settings_forecasters_description">De betrouwbaarheidschip en de grafiek per model komen uit deze modellen. Meer keuzes geven een breder bereik; minder een scherpere focus. Minstens twee blijven geselecteerd.</string>
+    <string name="settings_forecasters_auto_title">Auto (het beste voor jouw locatie)</string>
+    <string name="settings_forecasters_auto_subtitle">Kiest automatisch het regionale model — UKMO op de Britse eilanden, JMA in Japan, GFS + GEM in Noord-Amerika, enz. Zet uit om zelf modellen te kiezen.</string>
+    <string name="settings_forecasters_cap_hint">Je hebt %1$d modellen gekozen — het maximum waarbij de grafiek leesbaar blijft. Schakel er een uit om een ander toe te voegen.</string>
+    <string name="settings_forecasters_ecmwf">ECMWF</string>
+    <string name="settings_forecasters_ecmwf_subtitle">Europees — doorgaans het meest nauwkeurige wereldwijde model. Om de 3 uur op de open feed.</string>
+    <string name="settings_forecasters_icon">ICON</string>
+    <string name="settings_forecasters_icon_subtitle">Duits (DWD) — sterk in Europa en op korte termijn. Natief per uur.</string>
+    <string name="settings_forecasters_gfs">GFS</string>
+    <string name="settings_forecasters_gfs_subtitle">Amerikaans (NOAA) — sterk in Noord-Amerika. Natief per uur.</string>
+    <string name="settings_forecasters_gem">GEM</string>
+    <string name="settings_forecasters_gem_subtitle">Canadees (ECCC) — sterk in Noord-Amerika. Om de 3 uur op de open feed.</string>
+    <string name="settings_forecasters_arpege">ARPEGE</string>
+    <string name="settings_forecasters_arpege_subtitle">Frans (Météo-France) — sterk in Frankrijk en West-Europa. Natief per uur.</string>
+    <string name="settings_forecasters_ukmo">UKMO</string>
+    <string name="settings_forecasters_ukmo_subtitle">Brits (UK Met Office) — historisch alleen na ECMWF. Om de 3 uur op de open feed.</string>
+    <string name="settings_forecasters_jma">JMA</string>
+    <string name="settings_forecasters_jma_subtitle">Japans — sterk in Azië-Pacific. Om de 3 tot 6 uur op de open feed.</string>
+    <string name="settings_forecasters_bom">BOM</string>
+    <string name="settings_forecasters_bom_subtitle">Australisch — in onderhoud, komt zo snel mogelijk terug.</string>
+
+    <string name="settings_about_open_meteo">Weergegevens door Open-Meteo</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -711,4 +711,50 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="today_uv_peak">Pico de %1$d às %2$s</string>
     <string name="today_uv_title">Índice UV</string>
     <string name="today_wind_peak">Pico de %1$d %2$s às %3$s</string>
+
+    <!-- Strings added to match base — forecasters picker, garment-colour picker,
+         update-downloading banner, placeholder cards, Open-Meteo credit. -->
+    <string name="today_update_downloading_body">Baixando a atualização…</string>
+    <string name="today_update_downloading_action">Atualizando</string>
+    <string name="today_update_downloading_dismiss">Cancelar</string>
+    <string name="today_view_other_period">Ver a outra previsão</string>
+    <string name="today_back_to_primary">Voltar</string>
+    <string name="today_placeholder_today_title">Previsão de hoje</string>
+    <string name="today_placeholder_tonight_title">Previsão desta noite</string>
+    <string name="today_placeholder_body">Pronta por volta das %1$s.</string>
+
+    <string name="settings_root_forecasters">Modelos de previsão</string>
+    <string name="settings_root_forecasters_subtitle">Fontes e modelos meteorológicos</string>
+
+    <string name="settings_display_garment_colors_title">Cores das roupas</string>
+    <string name="settings_display_garment_colors_description">Escolha uma cor para cada ícone de roupa mostrado em Hoje, no widget da tela inicial e nas notificações. O contorno escurece automaticamente.</string>
+    <string name="settings_garment_color_default">Padrão</string>
+    <string name="settings_garment_color_picker_title">Escolha uma cor</string>
+    <string name="settings_garment_color_swatch_description">Amostra de cor %1$s</string>
+    <string name="settings_garment_color_default_swatch_description">Restaurar %1$s para a cor padrão</string>
+    <string name="settings_garment_color_dialog_close">Fechar</string>
+
+    <string name="settings_forecasters_title">Modelos de previsão</string>
+    <string name="settings_forecasters_description">O indicador de confiança e o gráfico por modelo se baseiam nesses modelos. Escolher mais amplia o leque; escolher menos foca a previsão. Pelo menos dois permanecem selecionados.</string>
+    <string name="settings_forecasters_auto_title">Auto (o melhor para a sua localização)</string>
+    <string name="settings_forecasters_auto_subtitle">Escolhe automaticamente o modelo regional — UKMO nas ilhas britânicas, JMA no Japão, GFS + GEM na América do Norte, etc. Desative para escolher você mesmo os modelos.</string>
+    <string name="settings_forecasters_cap_hint">Você selecionou %1$d modelos — o máximo para o gráfico continuar legível. Desmarque um para adicionar outro.</string>
+    <string name="settings_forecasters_ecmwf">ECMWF</string>
+    <string name="settings_forecasters_ecmwf_subtitle">Europeu — geralmente o modelo global mais preciso. A cada 3 horas no feed aberto.</string>
+    <string name="settings_forecasters_icon">ICON</string>
+    <string name="settings_forecasters_icon_subtitle">Alemão (DWD) — forte na Europa e a curto prazo. Horário nativo.</string>
+    <string name="settings_forecasters_gfs">GFS</string>
+    <string name="settings_forecasters_gfs_subtitle">Americano (NOAA) — forte na América do Norte. Horário nativo.</string>
+    <string name="settings_forecasters_gem">GEM</string>
+    <string name="settings_forecasters_gem_subtitle">Canadense (ECCC) — forte na América do Norte. A cada 3 horas no feed aberto.</string>
+    <string name="settings_forecasters_arpege">ARPEGE</string>
+    <string name="settings_forecasters_arpege_subtitle">Francês (Météo-France) — forte na França e Europa Ocidental. Horário nativo.</string>
+    <string name="settings_forecasters_ukmo">UKMO</string>
+    <string name="settings_forecasters_ukmo_subtitle">Britânico (UK Met Office) — historicamente atrás apenas do ECMWF. A cada 3 horas no feed aberto.</string>
+    <string name="settings_forecasters_jma">JMA</string>
+    <string name="settings_forecasters_jma_subtitle">Japonês — forte na Ásia-Pacífico. A cada 3 a 6 horas no feed aberto.</string>
+    <string name="settings_forecasters_bom">BOM</string>
+    <string name="settings_forecasters_bom_subtitle">Australiano — em manutenção, voltará assim que possível.</string>
+
+    <string name="settings_about_open_meteo">Dados meteorológicos pela Open-Meteo</string>
 </resources>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -753,4 +753,50 @@ they diverge from BR ("Polonês" → "Polaco", "Holandês" →
     <string name="today_uv_peak">Pico de %1$d às %2$s</string>
     <string name="today_uv_title">Índice UV</string>
     <string name="today_wind_peak">Pico de %1$d %2$s às %3$s</string>
+
+    <!-- Strings added to match base — forecasters picker, garment-colour picker,
+         update-downloading banner, placeholder cards, Open-Meteo credit. -->
+    <string name="today_update_downloading_body">A transferir a atualização…</string>
+    <string name="today_update_downloading_action">A atualizar</string>
+    <string name="today_update_downloading_dismiss">Cancelar</string>
+    <string name="today_view_other_period">Ver a outra previsão</string>
+    <string name="today_back_to_primary">Voltar</string>
+    <string name="today_placeholder_today_title">Previsão de hoje</string>
+    <string name="today_placeholder_tonight_title">Previsão desta noite</string>
+    <string name="today_placeholder_body">Pronta por volta das %1$s.</string>
+
+    <string name="settings_root_forecasters">Modelos de previsão</string>
+    <string name="settings_root_forecasters_subtitle">Fontes e modelos meteorológicos</string>
+
+    <string name="settings_display_garment_colors_title">Cores das peças de roupa</string>
+    <string name="settings_display_garment_colors_description">Escolhe uma cor para cada ícone de peça de roupa mostrado em Hoje, no widget do ecrã inicial e nas notificações. O contorno escurece automaticamente.</string>
+    <string name="settings_garment_color_default">Predefinido</string>
+    <string name="settings_garment_color_picker_title">Escolhe uma cor</string>
+    <string name="settings_garment_color_swatch_description">Amostra de cor %1$s</string>
+    <string name="settings_garment_color_default_swatch_description">Repor %1$s para a cor predefinida</string>
+    <string name="settings_garment_color_dialog_close">Fechar</string>
+
+    <string name="settings_forecasters_title">Modelos de previsão</string>
+    <string name="settings_forecasters_description">O indicador de confiança e o gráfico por modelo baseiam-se nestes modelos. Escolher mais alarga o leque; menos torna o foco mais apertado. Pelo menos dois permanecem selecionados.</string>
+    <string name="settings_forecasters_auto_title">Auto (o melhor para a tua localização)</string>
+    <string name="settings_forecasters_auto_subtitle">Escolhe automaticamente o modelo regional — UKMO nas ilhas britânicas, JMA no Japão, GFS + GEM na América do Norte, etc. Desativa para escolheres tu os modelos.</string>
+    <string name="settings_forecasters_cap_hint">Selecionaste %1$d modelos — o máximo para que o gráfico continue legível. Desseleciona um para adicionar outro.</string>
+    <string name="settings_forecasters_ecmwf">ECMWF</string>
+    <string name="settings_forecasters_ecmwf_subtitle">Europeu — geralmente o modelo global mais preciso. De 3 em 3 horas no feed aberto.</string>
+    <string name="settings_forecasters_icon">ICON</string>
+    <string name="settings_forecasters_icon_subtitle">Alemão (DWD) — forte na Europa e a curto prazo. Horário nativo.</string>
+    <string name="settings_forecasters_gfs">GFS</string>
+    <string name="settings_forecasters_gfs_subtitle">Americano (NOAA) — forte na América do Norte. Horário nativo.</string>
+    <string name="settings_forecasters_gem">GEM</string>
+    <string name="settings_forecasters_gem_subtitle">Canadiano (ECCC) — forte na América do Norte. De 3 em 3 horas no feed aberto.</string>
+    <string name="settings_forecasters_arpege">ARPEGE</string>
+    <string name="settings_forecasters_arpege_subtitle">Francês (Météo-France) — forte em França e na Europa Ocidental. Horário nativo.</string>
+    <string name="settings_forecasters_ukmo">UKMO</string>
+    <string name="settings_forecasters_ukmo_subtitle">Britânico (UK Met Office) — historicamente apenas atrás do ECMWF. De 3 em 3 horas no feed aberto.</string>
+    <string name="settings_forecasters_jma">JMA</string>
+    <string name="settings_forecasters_jma_subtitle">Japonês — forte na Ásia-Pacífico. De 3 a 6 em 6 horas no feed aberto.</string>
+    <string name="settings_forecasters_bom">BOM</string>
+    <string name="settings_forecasters_bom_subtitle">Australiano — em manutenção, voltará assim que possível.</string>
+
+    <string name="settings_about_open_meteo">Dados meteorológicos pela Open-Meteo</string>
 </resources>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -599,4 +599,50 @@ surfaces fall back to default English (matching values-pl / values-uk).
     <string name="today_uv_peak">Vârf %1$d la %2$s</string>
     <string name="today_uv_title">Indice UV</string>
     <string name="today_wind_peak">Vârf %1$d %2$s la %3$s</string>
+
+    <!-- Strings added to match base — forecasters picker, garment-colour picker,
+         update-downloading banner, placeholder cards, Open-Meteo credit. -->
+    <string name="today_update_downloading_body">Se descarcă actualizarea…</string>
+    <string name="today_update_downloading_action">Se actualizează</string>
+    <string name="today_update_downloading_dismiss">Anulează</string>
+    <string name="today_view_other_period">Vezi cealaltă prognoză</string>
+    <string name="today_back_to_primary">Înapoi</string>
+    <string name="today_placeholder_today_title">Prognoza de azi</string>
+    <string name="today_placeholder_tonight_title">Prognoza pentru diseară</string>
+    <string name="today_placeholder_body">Gata în jur de %1$s.</string>
+
+    <string name="settings_root_forecasters">Modele de prognoză</string>
+    <string name="settings_root_forecasters_subtitle">Surse și modele meteo</string>
+
+    <string name="settings_display_garment_colors_title">Culorile hainelor</string>
+    <string name="settings_display_garment_colors_description">Alege o culoare pentru fiecare pictogramă de haină afișată în Azi, în widgetul de pe ecranul de pornire și în notificări. Conturul se închide automat.</string>
+    <string name="settings_garment_color_default">Implicit</string>
+    <string name="settings_garment_color_picker_title">Alege o culoare</string>
+    <string name="settings_garment_color_swatch_description">Mostră de culoare %1$s</string>
+    <string name="settings_garment_color_default_swatch_description">Resetează %1$s la culoarea implicită</string>
+    <string name="settings_garment_color_dialog_close">Închide</string>
+
+    <string name="settings_forecasters_title">Modele de prognoză</string>
+    <string name="settings_forecasters_description">Indicatorul de încredere și graficul per model se bazează pe aceste modele. Mai multe extind paleta; mai puține o restrâng. Cel puțin două rămân selectate.</string>
+    <string name="settings_forecasters_auto_title">Auto (cel mai bun pentru locația ta)</string>
+    <string name="settings_forecasters_auto_subtitle">Alege automat modelul regional — UKMO în Insulele Britanice, JMA în Japonia, GFS + GEM în America de Nord etc. Dezactivează pentru a alege tu modelele.</string>
+    <string name="settings_forecasters_cap_hint">Ai ales %1$d modele — maximul pentru ca graficul să rămână lizibil. Deselectează unul pentru a adăuga altul.</string>
+    <string name="settings_forecasters_ecmwf">ECMWF</string>
+    <string name="settings_forecasters_ecmwf_subtitle">European — în general cel mai precis model global. La 3 ore în feedul deschis.</string>
+    <string name="settings_forecasters_icon">ICON</string>
+    <string name="settings_forecasters_icon_subtitle">German (DWD) — solid în Europa și pe termen scurt. Orar nativ.</string>
+    <string name="settings_forecasters_gfs">GFS</string>
+    <string name="settings_forecasters_gfs_subtitle">American (NOAA) — solid în America de Nord. Orar nativ.</string>
+    <string name="settings_forecasters_gem">GEM</string>
+    <string name="settings_forecasters_gem_subtitle">Canadian (ECCC) — solid în America de Nord. La 3 ore în feedul deschis.</string>
+    <string name="settings_forecasters_arpege">ARPEGE</string>
+    <string name="settings_forecasters_arpege_subtitle">Francez (Météo-France) — solid în Franța și Europa de Vest. Orar nativ.</string>
+    <string name="settings_forecasters_ukmo">UKMO</string>
+    <string name="settings_forecasters_ukmo_subtitle">Britanic (UK Met Office) — istoric, secund doar după ECMWF. La 3 ore în feedul deschis.</string>
+    <string name="settings_forecasters_jma">JMA</string>
+    <string name="settings_forecasters_jma_subtitle">Japonez — solid în Asia-Pacific. La 3-6 ore în feedul deschis.</string>
+    <string name="settings_forecasters_bom">BOM</string>
+    <string name="settings_forecasters_bom_subtitle">Australian — în mentenanță, revine cât mai curând posibil.</string>
+
+    <string name="settings_about_open_meteo">Date meteo de la Open-Meteo</string>
 </resources>


### PR DESCRIPTION
## Summary

Fills in the 39 base strings that have landed since the Western European translation files were last refreshed, leaving all nine locales fully in sync with `values/strings.xml` again. Each locale was missing the same set of keys, all added since the forecasters / garment-colour / in-app-update work landed:

- `today_update_downloading_*` (3 keys) — the in-progress state of the Play in-app-update banner.
- `today_view_other_period` / `today_back_to_primary` / `today_placeholder_*` (5 keys) — the Today ↔ Tonight toggle plus the "forecast not ready yet" placeholder card.
- `settings_root_forecasters` + `settings_root_forecasters_subtitle` — the new Settings root entry.
- `settings_display_garment_colors_*` and `settings_garment_color_*` (7 keys) — the per-garment colour picker added with `eab5e10`.
- `settings_forecasters_*` (21 keys) — Forecasters sub-page: title / description / Auto-pick / cap hint / ECMWF / ICON / GFS / GEM / ARPEGE / UKMO / JMA / BOM entries.
- `settings_about_open_meteo` — Open-Meteo attribution line on the About screen.

The 7 keys deliberately *not* overridden per each file's header (`app_name`, plus the English-only `insight_time_am` / `_pm` / `_midnight` / `_noon` / `*_minutes` AM/PM helpers) stay omitted — non-English locales use `insight_time_hour` / `_hour_minutes` instead.

Locales touched:

- `values-fr/` — informal *tu*-form (matches existing register)
- `values-es/` — *tú*-form
- `values-it/` — *tu*-form
- `values-pt-rPT/` — European Portuguese *tu*-form, PT vocab ("A transferir", "ecrã", "predefinido")
- `values-pt-rBR/` — Brazilian Portuguese *você*-form ("Baixando", "tela", "padrão")
- `values-ca/` — *tu*-form
- `values-ro/` — *tu*-form
- `values-de/` — *du*-form, German typographic quotes (`„…"`)
- `values-nl/` — *je/jij*-form

Agency / model acronyms (ECMWF, ICON, GFS, GEM, ARPEGE, UKMO, JMA, BOM) are kept verbatim across all locales, matching base.

No privacy-relevant strings — nothing here leaves the device.

## Test plan

- [x] `xmllint --noout` clean on all nine modified files
- [x] `./gradlew :app:processDebugResources` succeeds (aapt accepts every locale)
- [x] Re-ran the "missing keys" diff against `values/strings.xml` — only the 7 by-design omissions remain in each locale
- [ ] CI: JVM unit tests + `:app:assembleDebug` green
- [ ] Eyeball a couple of strings in-app on a French / German build before un-drafting

https://claude.ai/code/session_01PP2B53SaZaK2j19ZJMyv1d

---
_Generated by [Claude Code](https://claude.ai/code/session_01PP2B53SaZaK2j19ZJMyv1d)_