### PR TITLE
Translate the forecasters picker, garment-colour picker, and update-downloading banner for the remaining European languages

### DIFF
--- a/app/src/main/res/values-b+sr+Latn/strings.xml
+++ b/app/src/main/res/values-b+sr+Latn/strings.xml
@@ -612,4 +612,50 @@ default English (matching values-pl / values-uk).
     <string name="today_uv_peak">Vrhunac %1$d u %2$s</string>
     <string name="today_uv_title">UV indeks</string>
     <string name="today_wind_peak">Vrhunac %1$d %2$s u %3$s</string>
+
+    <!-- Strings added to match base — forecasters picker, garment-colour picker,
+         update-downloading banner, placeholder cards, Open-Meteo credit. -->
+    <string name="today_update_downloading_body">Preuzimanje ažuriranja…</string>
+    <string name="today_update_downloading_action">Ažuriram…</string>
+    <string name="today_update_downloading_dismiss">Otkaži</string>
+    <string name="today_view_other_period">Pogledaj drugu prognozu</string>
+    <string name="today_back_to_primary">Nazad</string>
+    <string name="today_placeholder_today_title">Današnja prognoza</string>
+    <string name="today_placeholder_tonight_title">Večerašnja prognoza</string>
+    <string name="today_placeholder_body">Biće spremna oko %1$s.</string>
+
+    <string name="settings_root_forecasters">Modeli prognoze</string>
+    <string name="settings_root_forecasters_subtitle">Izvori i modeli vremena</string>
+
+    <string name="settings_display_garment_colors_title">Boje odeće</string>
+    <string name="settings_display_garment_colors_description">Izaberi boju za svaku ikonu odeće prikazanu na ekranu Danas, u vidžetu na početnom ekranu i u obaveštenjima. Obrub se automatski zatamnjuje.</string>
+    <string name="settings_garment_color_default">Podrazumevano</string>
+    <string name="settings_garment_color_picker_title">Izaberi boju</string>
+    <string name="settings_garment_color_swatch_description">Uzorak boje %1$s</string>
+    <string name="settings_garment_color_default_swatch_description">Vrati %1$s na podrazumevanu boju</string>
+    <string name="settings_garment_color_dialog_close">Zatvori</string>
+
+    <string name="settings_forecasters_title">Modeli prognoze</string>
+    <string name="settings_forecasters_description">Oznaka pouzdanosti i grafikon po modelu povlače podatke iz ovih modela. Više izabranih daje širi raspon; manje znači uži fokus. Najmanje dva ostaju izabrana.</string>
+    <string name="settings_forecasters_auto_title">Automatski (najbolje za tvoju lokaciju)</string>
+    <string name="settings_forecasters_auto_subtitle">Automatski bira regionalni model — UKMO na Britanskim ostrvima, JMA u Japanu, GFS + GEM u Severnoj Americi itd. Isključi da modele biraš sam.</string>
+    <string name="settings_forecasters_cap_hint">Izabrao si %1$d modela — najviše koliko grafikon ostaje čitljiv. Odznači jedan da dodaš drugi.</string>
+    <string name="settings_forecasters_ecmwf">ECMWF</string>
+    <string name="settings_forecasters_ecmwf_subtitle">Evropski — uglavnom najtačniji globalni model. Trosatni korak na otvorenom fidu.</string>
+    <string name="settings_forecasters_icon">ICON</string>
+    <string name="settings_forecasters_icon_subtitle">Nemački (DWD) — jak u Evropi i na kratke rokove. Nativno satni.</string>
+    <string name="settings_forecasters_gfs">GFS</string>
+    <string name="settings_forecasters_gfs_subtitle">Američki (NOAA) — jak nad Severnom Amerikom. Nativno satni.</string>
+    <string name="settings_forecasters_gem">GEM</string>
+    <string name="settings_forecasters_gem_subtitle">Kanadski (ECCC) — jak nad Severnom Amerikom. Trosatni korak na otvorenom fidu.</string>
+    <string name="settings_forecasters_arpege">ARPEGE</string>
+    <string name="settings_forecasters_arpege_subtitle">Francuski (Météo-France) — jak nad Francuskom i Zapadnom Evropom. Nativno satni.</string>
+    <string name="settings_forecasters_ukmo">UKMO</string>
+    <string name="settings_forecasters_ukmo_subtitle">Britanski (UK Met Office) — istorijski drugi odmah iza ECMWF-a. Trosatni korak na otvorenom fidu.</string>
+    <string name="settings_forecasters_jma">JMA</string>
+    <string name="settings_forecasters_jma_subtitle">Japanski — jak nad azijsko-pacifičkim regionom. Tro- do šestosatni korak na otvorenom fidu.</string>
+    <string name="settings_forecasters_bom">BOM</string>
+    <string name="settings_forecasters_bom_subtitle">Australijski — na održavanju, vraća se čim pre.</string>
+
+    <string name="settings_about_open_meteo">Vremenske podatke obezbeđuje Open-Meteo</string>
 </resources>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -610,4 +610,50 @@ What is NOT overridden, by design:
     <string name="today_uv_peak">Максимум %1$d в %2$s</string>
     <string name="today_uv_title">УВ индекс</string>
     <string name="today_wind_peak">Максимум %1$d %2$s в %3$s</string>
+
+    <!-- Strings added to match base — forecasters picker, garment-colour picker,
+         update-downloading banner, placeholder cards, Open-Meteo credit. -->
+    <string name="today_update_downloading_body">Изтегля се актуализация…</string>
+    <string name="today_update_downloading_action">Актуализира се</string>
+    <string name="today_update_downloading_dismiss">Откажи</string>
+    <string name="today_view_other_period">Покажи другата прогноза</string>
+    <string name="today_back_to_primary">Назад</string>
+    <string name="today_placeholder_today_title">Прогноза за днес</string>
+    <string name="today_placeholder_tonight_title">Прогноза за тази вечер</string>
+    <string name="today_placeholder_body">Ще е готова около %1$s.</string>
+
+    <string name="settings_root_forecasters">Прогностици</string>
+    <string name="settings_root_forecasters_subtitle">Източници на време и модели</string>
+
+    <string name="settings_display_garment_colors_title">Цветове на дрехите</string>
+    <string name="settings_display_garment_colors_description">Избери цвят за всяка икона на дреха на „Днес“, в притурката на началния екран и в известията. Контурът автоматично потъмнява.</string>
+    <string name="settings_garment_color_default">По подразбиране</string>
+    <string name="settings_garment_color_picker_title">Избери цвят</string>
+    <string name="settings_garment_color_swatch_description">Мостра на цвят „%1$s“</string>
+    <string name="settings_garment_color_default_swatch_description">Възстанови „%1$s“ към цвета по подразбиране</string>
+    <string name="settings_garment_color_dialog_close">Затвори</string>
+
+    <string name="settings_forecasters_title">Модели за прогноза</string>
+    <string name="settings_forecasters_description">Чипът за увереност и графиката по модели се захранват от тези модели. Повече избрани модели дават по-широк разсейв; по-малко — по-стегнат фокус. Поне два остават избрани.</string>
+    <string name="settings_forecasters_auto_title">Авто (най-добро за твоето местоположение)</string>
+    <string name="settings_forecasters_auto_subtitle">Избира регионалния модел автоматично — UKMO на Британските острови, JMA в Япония, GFS + GEM в Северна Америка и т.н. Изключи, за да избираш моделите сам.</string>
+    <string name="settings_forecasters_cap_hint">Избрал си %1$d модела — максимумът, при който графиката остава четлива. Махни отметката от един, за да добавиш друг.</string>
+    <string name="settings_forecasters_ecmwf">ECMWF</string>
+    <string name="settings_forecasters_ecmwf_subtitle">Европейски — като правило най-точният глобален модел. На отворения канал — на всеки 3 часа.</string>
+    <string name="settings_forecasters_icon">ICON</string>
+    <string name="settings_forecasters_icon_subtitle">Немски (DWD) — силен в Европа и в краткосрочен план. По принцип на час.</string>
+    <string name="settings_forecasters_gfs">GFS</string>
+    <string name="settings_forecasters_gfs_subtitle">Американски (NOAA) — силен над Северна Америка. По принцип на час.</string>
+    <string name="settings_forecasters_gem">GEM</string>
+    <string name="settings_forecasters_gem_subtitle">Канадски (ECCC) — силен над Северна Америка. На отворения канал — на всеки 3 часа.</string>
+    <string name="settings_forecasters_arpege">ARPEGE</string>
+    <string name="settings_forecasters_arpege_subtitle">Френски (Météo-France) — силен над Франция и Западна Европа. По принцип на час.</string>
+    <string name="settings_forecasters_ukmo">UKMO</string>
+    <string name="settings_forecasters_ukmo_subtitle">Британски (UK Met Office) — исторически отстъпва само на ECMWF. На отворения канал — на всеки 3 часа.</string>
+    <string name="settings_forecasters_jma">JMA</string>
+    <string name="settings_forecasters_jma_subtitle">Японски — силен над Азиатско-тихоокеанския регион. На отворения канал — на всеки 3 до 6 часа.</string>
+    <string name="settings_forecasters_bom">BOM</string>
+    <string name="settings_forecasters_bom_subtitle">Австралийски — в поддръжка, ще се върне възможно най-скоро.</string>
+
+    <string name="settings_about_open_meteo">Данни за времето от Open-Meteo</string>
 </resources>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -613,4 +613,50 @@ locale (Angličtina (USA), Francouzština (Francie), Němčina (Německo), …).
     <string name="today_uv_peak">Vrchol %1$d v %2$s</string>
     <string name="today_uv_title">UV index</string>
     <string name="today_wind_peak">Vrchol %1$d %2$s v %3$s</string>
+
+    <!-- Strings added to match base — forecasters picker, garment-colour picker,
+         update-downloading banner, placeholder cards, Open-Meteo credit. -->
+    <string name="today_update_downloading_body">Stahuje se aktualizace…</string>
+    <string name="today_update_downloading_action">Aktualizuji…</string>
+    <string name="today_update_downloading_dismiss">Zrušit</string>
+    <string name="today_view_other_period">Zobrazit druhou předpověď</string>
+    <string name="today_back_to_primary">Zpět</string>
+    <string name="today_placeholder_today_title">Dnešní předpověď</string>
+    <string name="today_placeholder_tonight_title">Večerní předpověď</string>
+    <string name="today_placeholder_body">Bude připravena okolo %1$s.</string>
+
+    <string name="settings_root_forecasters">Modely předpovědi</string>
+    <string name="settings_root_forecasters_subtitle">Zdroje a modely počasí</string>
+
+    <string name="settings_display_garment_colors_title">Barvy oblečení</string>
+    <string name="settings_display_garment_colors_description">Vyber barvu pro každou ikonu oblečení zobrazenou na obrazovce Dnes, ve widgetu na domovské obrazovce a v oznámeních. Obrys se automaticky ztmaví.</string>
+    <string name="settings_garment_color_default">Výchozí</string>
+    <string name="settings_garment_color_picker_title">Vyber barvu</string>
+    <string name="settings_garment_color_swatch_description">Vzorek barvy %1$s</string>
+    <string name="settings_garment_color_default_swatch_description">Obnovit výchozí barvu %1$s</string>
+    <string name="settings_garment_color_dialog_close">Zavřít</string>
+
+    <string name="settings_forecasters_title">Modely předpovědi</string>
+    <string name="settings_forecasters_description">Indikátor jistoty a graf podle modelů čerpají z těchto modelů. Více vybraných znamená širší rozptyl; méně znamená užší zaměření. Alespoň dva zůstávají vybrané.</string>
+    <string name="settings_forecasters_auto_title">Automaticky (nejlepší pro tvou polohu)</string>
+    <string name="settings_forecasters_auto_subtitle">Automaticky vybere regionální model — UKMO na Britských ostrovech, JMA v Japonsku, GFS + GEM v Severní Americe atd. Vypni, pokud si chceš modely zvolit sám.</string>
+    <string name="settings_forecasters_cap_hint">Vybral jsi %1$d modelů — nejvíc, kolik graf udrží čitelný. Odznač jeden, abys mohl přidat jiný model.</string>
+    <string name="settings_forecasters_ecmwf">ECMWF</string>
+    <string name="settings_forecasters_ecmwf_subtitle">Evropský — obecně nejpřesnější globální model. Tříhodinový krok na otevřeném feedu.</string>
+    <string name="settings_forecasters_icon">ICON</string>
+    <string name="settings_forecasters_icon_subtitle">Německý (DWD) — silný v Evropě a na krátký horizont. Nativně hodinový.</string>
+    <string name="settings_forecasters_gfs">GFS</string>
+    <string name="settings_forecasters_gfs_subtitle">Americký (NOAA) — silný nad Severní Amerikou. Nativně hodinový.</string>
+    <string name="settings_forecasters_gem">GEM</string>
+    <string name="settings_forecasters_gem_subtitle">Kanadský (ECCC) — silný nad Severní Amerikou. Tříhodinový krok na otevřeném feedu.</string>
+    <string name="settings_forecasters_arpege">ARPEGE</string>
+    <string name="settings_forecasters_arpege_subtitle">Francouzský (Météo-France) — silný nad Francií a Západní Evropou. Nativně hodinový.</string>
+    <string name="settings_forecasters_ukmo">UKMO</string>
+    <string name="settings_forecasters_ukmo_subtitle">Britský (UK Met Office) — historicky druhý hned za ECMWF. Tříhodinový krok na otevřeném feedu.</string>
+    <string name="settings_forecasters_jma">JMA</string>
+    <string name="settings_forecasters_jma_subtitle">Japonský — silný nad asijsko-tichomořskou oblastí. Tří- až šestihodinový krok na otevřeném feedu.</string>
+    <string name="settings_forecasters_bom">BOM</string>
+    <string name="settings_forecasters_bom_subtitle">Australský — v údržbě, vrátí se co nejdříve.</string>
+
+    <string name="settings_about_open_meteo">Data o počasí poskytuje Open-Meteo</string>
 </resources>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -626,4 +626,50 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrig)").
     <string name="today_uv_peak">Top %1$d kl. %2$s</string>
     <string name="today_uv_title">UV-indeks</string>
     <string name="today_wind_peak">Topvind %1$d %2$s kl. %3$s</string>
+
+    <!-- Strings added to match base — forecasters picker, garment-colour picker,
+         update-downloading banner, placeholder cards, Open-Meteo credit. -->
+    <string name="today_update_downloading_body">Opdatering hentes…</string>
+    <string name="today_update_downloading_action">Opdaterer</string>
+    <string name="today_update_downloading_dismiss">Annuller</string>
+    <string name="today_view_other_period">Vis anden prognose</string>
+    <string name="today_back_to_primary">Tilbage</string>
+    <string name="today_placeholder_today_title">Dagens prognose</string>
+    <string name="today_placeholder_tonight_title">Prognose for i aften</string>
+    <string name="today_placeholder_body">Klar omkring kl. %1$s.</string>
+
+    <string name="settings_root_forecasters">Prognosemodeller</string>
+    <string name="settings_root_forecasters_subtitle">Vejrkilder og modeller</string>
+
+    <string name="settings_display_garment_colors_title">Tøjfarver</string>
+    <string name="settings_display_garment_colors_description">Vælg en farve til hvert tøjikon, der vises i Dag, på hjemmeskærms-widgetten og i notifikationer. Konturen mørkner automatisk.</string>
+    <string name="settings_garment_color_default">Standard</string>
+    <string name="settings_garment_color_picker_title">Vælg en farve</string>
+    <string name="settings_garment_color_swatch_description">Farveprøve %1$s</string>
+    <string name="settings_garment_color_default_swatch_description">Nulstil %1$s til standardfarven</string>
+    <string name="settings_garment_color_dialog_close">Luk</string>
+
+    <string name="settings_forecasters_title">Prognosemodeller</string>
+    <string name="settings_forecasters_description">Sikkerhedschippen og modeldiagrammet trækker på disse modeller. Flere valgte giver en bredere spredning, færre giver et snævrere fokus. Mindst to forbliver valgt.</string>
+    <string name="settings_forecasters_auto_title">Auto (bedst for din placering)</string>
+    <string name="settings_forecasters_auto_subtitle">Vælger den regionale model automatisk — UKMO på De Britiske Øer, JMA i Japan, GFS + GEM i Nordamerika osv. Slå fra for at vælge modeller selv.</string>
+    <string name="settings_forecasters_cap_hint">Du har valgt %1$d modeller — det maksimale antal, hvor diagrammet forbliver læsbart. Fravælg en for at tilføje en anden model.</string>
+    <string name="settings_forecasters_ecmwf">ECMWF</string>
+    <string name="settings_forecasters_ecmwf_subtitle">Europæisk — generelt den mest præcise globale model. 3-timers opløsning i det åbne feed.</string>
+    <string name="settings_forecasters_icon">ICON</string>
+    <string name="settings_forecasters_icon_subtitle">Tysk (DWD) — stærk i Europa og på kort sigt. Nativ timeopløsning.</string>
+    <string name="settings_forecasters_gfs">GFS</string>
+    <string name="settings_forecasters_gfs_subtitle">Amerikansk (NOAA) — stærk over Nordamerika. Nativ timeopløsning.</string>
+    <string name="settings_forecasters_gem">GEM</string>
+    <string name="settings_forecasters_gem_subtitle">Canadisk (ECCC) — stærk over Nordamerika. 3-timers opløsning i det åbne feed.</string>
+    <string name="settings_forecasters_arpege">ARPEGE</string>
+    <string name="settings_forecasters_arpege_subtitle">Fransk (Météo-France) — stærk over Frankrig og Vesteuropa. Nativ timeopløsning.</string>
+    <string name="settings_forecasters_ukmo">UKMO</string>
+    <string name="settings_forecasters_ukmo_subtitle">Britisk (UK Met Office) — historisk kun lige efter ECMWF. 3-timers opløsning i det åbne feed.</string>
+    <string name="settings_forecasters_jma">JMA</string>
+    <string name="settings_forecasters_jma_subtitle">Japansk — stærk over Asien-Stillehavet. 3- til 6-timers opløsning i det åbne feed.</string>
+    <string name="settings_forecasters_bom">BOM</string>
+    <string name="settings_forecasters_bom_subtitle">Australsk — under vedligeholdelse, tilbage så hurtigt som muligt.</string>
+
+    <string name="settings_about_open_meteo">Vejrdata fra Open-Meteo</string>
 </resources>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -745,4 +745,50 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="today_uv_peak">Μέγιστο %1$d στις %2$s</string>
     <string name="today_uv_title">Δείκτης UV</string>
     <string name="today_wind_peak">Μέγιστο %1$d %2$s στις %3$s</string>
+
+    <!-- Strings added to match base — forecasters picker, garment-colour picker,
+         update-downloading banner, placeholder cards, Open-Meteo credit. -->
+    <string name="today_update_downloading_body">Λήψη ενημέρωσης…</string>
+    <string name="today_update_downloading_action">Ενημέρωση</string>
+    <string name="today_update_downloading_dismiss">Άκυρο</string>
+    <string name="today_view_other_period">Δες την άλλη πρόβλεψη</string>
+    <string name="today_back_to_primary">Πίσω</string>
+    <string name="today_placeholder_today_title">Πρόβλεψη για σήμερα</string>
+    <string name="today_placeholder_tonight_title">Πρόβλεψη για απόψε</string>
+    <string name="today_placeholder_body">Θα είναι έτοιμη γύρω στις %1$s.</string>
+
+    <string name="settings_root_forecasters">Μοντέλα πρόβλεψης</string>
+    <string name="settings_root_forecasters_subtitle">Πηγές καιρού και μοντέλα</string>
+
+    <string name="settings_display_garment_colors_title">Χρώματα ρούχων</string>
+    <string name="settings_display_garment_colors_description">Διάλεξε ένα χρώμα για κάθε εικονίδιο ρούχου που εμφανίζεται στο Σήμερα, στο widget της αρχικής οθόνης και στις ειδοποιήσεις. Το περίγραμμα σκουραίνει αυτόματα.</string>
+    <string name="settings_garment_color_default">Προεπιλογή</string>
+    <string name="settings_garment_color_picker_title">Διάλεξε χρώμα</string>
+    <string name="settings_garment_color_swatch_description">Δείγμα χρώματος %1$s</string>
+    <string name="settings_garment_color_default_swatch_description">Επανέφερε το %1$s στο προεπιλεγμένο χρώμα</string>
+    <string name="settings_garment_color_dialog_close">Κλείσιμο</string>
+
+    <string name="settings_forecasters_title">Μοντέλα πρόβλεψης</string>
+    <string name="settings_forecasters_description">Το chip βεβαιότητας και το διάγραμμα ανά μοντέλο αντλούν από αυτά τα μοντέλα. Όσα περισσότερα διαλέξεις, τόσο πιο πλούσια η διασπορά· όσα λιγότερα, τόσο πιο εστιασμένη η εικόνα. Τουλάχιστον δύο παραμένουν επιλεγμένα.</string>
+    <string name="settings_forecasters_auto_title">Αυτόματο (το καλύτερο για την τοποθεσία σου)</string>
+    <string name="settings_forecasters_auto_subtitle">Διαλέγει αυτόματα το περιφερειακό μοντέλο — UKMO στις Βρετανικές Νήσους, JMA στην Ιαπωνία, GFS + GEM στη Βόρεια Αμερική κ.ο.κ. Απενεργοποίησέ το για να διαλέξεις μοντέλα μόνος σου.</string>
+    <string name="settings_forecasters_cap_hint">Έχεις διαλέξει %1$d μοντέλα — ο μέγιστος αριθμός στον οποίο το διάγραμμα παραμένει ευανάγνωστο. Αποεπίλεξε ένα για να προσθέσεις άλλο.</string>
+    <string name="settings_forecasters_ecmwf">ECMWF</string>
+    <string name="settings_forecasters_ecmwf_subtitle">Ευρωπαϊκό — γενικά το πιο ακριβές παγκόσμιο μοντέλο. 3-ωρη ανάλυση στο ανοιχτό feed.</string>
+    <string name="settings_forecasters_icon">ICON</string>
+    <string name="settings_forecasters_icon_subtitle">Γερμανικό (DWD) — ισχυρό στην Ευρώπη και σε μικρή χρονική εμβέλεια. Εγγενώς ωριαία ανάλυση.</string>
+    <string name="settings_forecasters_gfs">GFS</string>
+    <string name="settings_forecasters_gfs_subtitle">Αμερικανικό (NOAA) — ισχυρό στη Βόρεια Αμερική. Εγγενώς ωριαία ανάλυση.</string>
+    <string name="settings_forecasters_gem">GEM</string>
+    <string name="settings_forecasters_gem_subtitle">Καναδικό (ECCC) — ισχυρό στη Βόρεια Αμερική. 3-ωρη ανάλυση στο ανοιχτό feed.</string>
+    <string name="settings_forecasters_arpege">ARPEGE</string>
+    <string name="settings_forecasters_arpege_subtitle">Γαλλικό (Météo-France) — ισχυρό στη Γαλλία και τη Δυτική Ευρώπη. Εγγενώς ωριαία ανάλυση.</string>
+    <string name="settings_forecasters_ukmo">UKMO</string>
+    <string name="settings_forecasters_ukmo_subtitle">Βρετανικό (UK Met Office) — ιστορικά μόλις πίσω από το ECMWF. 3-ωρη ανάλυση στο ανοιχτό feed.</string>
+    <string name="settings_forecasters_jma">JMA</string>
+    <string name="settings_forecasters_jma_subtitle">Ιαπωνικό — ισχυρό στην περιοχή Ασίας-Ειρηνικού. 3- έως 6-ωρη ανάλυση στο ανοιχτό feed.</string>
+    <string name="settings_forecasters_bom">BOM</string>
+    <string name="settings_forecasters_bom_subtitle">Αυστραλιανό — υπό συντήρηση, επιστρέφει το συντομότερο δυνατό.</string>
+
+    <string name="settings_about_open_meteo">Δεδομένα καιρού από το Open-Meteo</string>
 </resources>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -571,4 +571,50 @@ Tone is informal "sina"-form throughout ("Pane … selga", "Võta … kaasa",
     <string name="today_uv_peak">Tipp %1$d kell %2$s</string>
     <string name="today_uv_title">UV-indeks</string>
     <string name="today_wind_peak">Tipp %1$d %2$s kell %3$s</string>
+
+    <!-- Strings added to match base — forecasters picker, garment-colour picker,
+         update-downloading banner, placeholder cards, Open-Meteo credit. -->
+    <string name="today_update_downloading_body">Uuendust laaditakse alla…</string>
+    <string name="today_update_downloading_action">Uuendatakse</string>
+    <string name="today_update_downloading_dismiss">Tühista</string>
+    <string name="today_view_other_period">Vaata teist prognoosi</string>
+    <string name="today_back_to_primary">Tagasi</string>
+    <string name="today_placeholder_today_title">Tänane prognoos</string>
+    <string name="today_placeholder_tonight_title">Tänaõhtune prognoos</string>
+    <string name="today_placeholder_body">Valmib umbes kell %1$s.</string>
+
+    <string name="settings_root_forecasters">Prognoosijad</string>
+    <string name="settings_root_forecasters_subtitle">Ilmaallikad ja mudelid</string>
+
+    <string name="settings_display_garment_colors_title">Riietuse värvid</string>
+    <string name="settings_display_garment_colors_description">Vali värv igale rõivaikoonile, mida näidatakse vaates „Täna“, avaekraani vidinas ja teavitustes. Kontuur tumeneb automaatselt.</string>
+    <string name="settings_garment_color_default">Vaikimisi</string>
+    <string name="settings_garment_color_picker_title">Vali värv</string>
+    <string name="settings_garment_color_swatch_description">Värvinäidis „%1$s“</string>
+    <string name="settings_garment_color_default_swatch_description">Lähtesta „%1$s“ vaikevärvile</string>
+    <string name="settings_garment_color_dialog_close">Sulge</string>
+
+    <string name="settings_forecasters_title">Prognoosimudelid</string>
+    <string name="settings_forecasters_description">Kindlustunde silt ja mudelite graafik tuginevad neile mudelitele. Rohkem mudeleid annab laiema hajumise; vähem — kitsama fookuse. Vähemalt kaks jäävad valituks.</string>
+    <string name="settings_forecasters_auto_title">Auto (parim sinu asukohale)</string>
+    <string name="settings_forecasters_auto_subtitle">Valib piirkondliku mudeli automaatselt — UKMO Briti saartel, JMA Jaapanis, GFS + GEM Põhja-Ameerikas jne. Lülita välja, et valida mudelid ise.</string>
+    <string name="settings_forecasters_cap_hint">Oled valinud %1$d mudelit — maksimum, mille puhul graafik püsib loetav. Eemalda valik ühelt, et lisada teine.</string>
+    <string name="settings_forecasters_ecmwf">ECMWF</string>
+    <string name="settings_forecasters_ecmwf_subtitle">Euroopa — üldjuhul kõige täpsem globaalne mudel. Avatud kanalil iga 3 tunni järel.</string>
+    <string name="settings_forecasters_icon">ICON</string>
+    <string name="settings_forecasters_icon_subtitle">Saksa (DWD) — tugev Euroopas ja lühikeses prognoosis. Algselt tunnipõhine.</string>
+    <string name="settings_forecasters_gfs">GFS</string>
+    <string name="settings_forecasters_gfs_subtitle">Ameerika (NOAA) — tugev Põhja-Ameerika kohal. Algselt tunnipõhine.</string>
+    <string name="settings_forecasters_gem">GEM</string>
+    <string name="settings_forecasters_gem_subtitle">Kanada (ECCC) — tugev Põhja-Ameerika kohal. Avatud kanalil iga 3 tunni järel.</string>
+    <string name="settings_forecasters_arpege">ARPEGE</string>
+    <string name="settings_forecasters_arpege_subtitle">Prantsuse (Météo-France) — tugev Prantsusmaa ja Lääne-Euroopa kohal. Algselt tunnipõhine.</string>
+    <string name="settings_forecasters_ukmo">UKMO</string>
+    <string name="settings_forecasters_ukmo_subtitle">Briti (UK Met Office) — ajalooliselt vaid ECMWF-i järel. Avatud kanalil iga 3 tunni järel.</string>
+    <string name="settings_forecasters_jma">JMA</string>
+    <string name="settings_forecasters_jma_subtitle">Jaapani — tugev Aasia-Vaikse ookeani piirkonnas. Avatud kanalil iga 3–6 tunni järel.</string>
+    <string name="settings_forecasters_bom">BOM</string>
+    <string name="settings_forecasters_bom_subtitle">Austraalia — hoolduses, naaseb nii ruttu kui võimalik.</string>
+
+    <string name="settings_about_open_meteo">Ilmaandmed Open-Meteolt</string>
 </resources>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -606,4 +606,50 @@ displayed label localizes.
     <string name="today_uv_peak">Huippuarvo %1$d klo %2$s</string>
     <string name="today_uv_title">UV-indeksi</string>
     <string name="today_wind_peak">Huippuarvo %1$d %2$s klo %3$s</string>
+
+    <!-- Strings added to match base — forecasters picker, garment-colour picker,
+         update-downloading banner, placeholder cards, Open-Meteo credit. -->
+    <string name="today_update_downloading_body">Päivitystä ladataan…</string>
+    <string name="today_update_downloading_action">Päivitetään</string>
+    <string name="today_update_downloading_dismiss">Peruuta</string>
+    <string name="today_view_other_period">Näytä toinen ennuste</string>
+    <string name="today_back_to_primary">Takaisin</string>
+    <string name="today_placeholder_today_title">Tämän päivän ennuste</string>
+    <string name="today_placeholder_tonight_title">Illan ennuste</string>
+    <string name="today_placeholder_body">Valmis noin klo %1$s.</string>
+
+    <string name="settings_root_forecasters">Ennustemallit</string>
+    <string name="settings_root_forecasters_subtitle">Sääpalvelut ja mallit</string>
+
+    <string name="settings_display_garment_colors_title">Vaatteiden värit</string>
+    <string name="settings_display_garment_colors_description">Valitse väri jokaiselle vaatekuvakkeelle, joka näkyy Tänään-näytöllä, aloitusnäytön widgetissä ja ilmoituksissa. Reuna tummenee automaattisesti.</string>
+    <string name="settings_garment_color_default">Oletus</string>
+    <string name="settings_garment_color_picker_title">Valitse väri</string>
+    <string name="settings_garment_color_swatch_description">Värinäyte %1$s</string>
+    <string name="settings_garment_color_default_swatch_description">Palauta %1$s oletusväriin</string>
+    <string name="settings_garment_color_dialog_close">Sulje</string>
+
+    <string name="settings_forecasters_title">Ennustemallit</string>
+    <string name="settings_forecasters_description">Varmuussiru ja mallikaavio perustuvat näihin malleihin. Useammat valinnat antavat laajemman hajonnan, harvemmat tarkemman keskittymisen. Vähintään kaksi pysyy valittuna.</string>
+    <string name="settings_forecasters_auto_title">Automaattinen (paras sijaintiisi)</string>
+    <string name="settings_forecasters_auto_subtitle">Valitsee alueellisen mallin automaattisesti — UKMO Britteinsaarilla, JMA Japanissa, GFS + GEM Pohjois-Amerikassa jne. Poista käytöstä valitaksesi mallit itse.</string>
+    <string name="settings_forecasters_cap_hint">Olet valinnut %1$d mallia — enimmäismäärä, jolla kaavio pysyy luettavana. Poista valinta lisätäksesi toisen mallin.</string>
+    <string name="settings_forecasters_ecmwf">ECMWF</string>
+    <string name="settings_forecasters_ecmwf_subtitle">Eurooppalainen — yleensä tarkin globaali malli. 3 tunnin tarkkuus avoimessa syötteessä.</string>
+    <string name="settings_forecasters_icon">ICON</string>
+    <string name="settings_forecasters_icon_subtitle">Saksalainen (DWD) — vahva Euroopassa ja lyhyellä aikavälillä. Natiivisti tunneittain.</string>
+    <string name="settings_forecasters_gfs">GFS</string>
+    <string name="settings_forecasters_gfs_subtitle">Yhdysvaltalainen (NOAA) — vahva Pohjois-Amerikassa. Natiivisti tunneittain.</string>
+    <string name="settings_forecasters_gem">GEM</string>
+    <string name="settings_forecasters_gem_subtitle">Kanadalainen (ECCC) — vahva Pohjois-Amerikassa. 3 tunnin tarkkuus avoimessa syötteessä.</string>
+    <string name="settings_forecasters_arpege">ARPEGE</string>
+    <string name="settings_forecasters_arpege_subtitle">Ranskalainen (Météo-France) — vahva Ranskassa ja Länsi-Euroopassa. Natiivisti tunneittain.</string>
+    <string name="settings_forecasters_ukmo">UKMO</string>
+    <string name="settings_forecasters_ukmo_subtitle">Brittiläinen (UK Met Office) — historiallisesti vain ECMWF:n jäljessä. 3 tunnin tarkkuus avoimessa syötteessä.</string>
+    <string name="settings_forecasters_jma">JMA</string>
+    <string name="settings_forecasters_jma_subtitle">Japanilainen — vahva Aasian ja Tyynenmeren alueella. 3–6 tunnin tarkkuus avoimessa syötteessä.</string>
+    <string name="settings_forecasters_bom">BOM</string>
+    <string name="settings_forecasters_bom_subtitle">Australialainen — huoltokatkolla, palaa heti kun mahdollista.</string>
+
+    <string name="settings_about_open_meteo">Säädata: Open-Meteo</string>
 </resources>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -692,4 +692,50 @@ spousal register), matching the existing insight prose ("Ponesi …",
     <string name="today_uv_peak">Vršna vrijednost %1$d u %2$s</string>
     <string name="today_uv_title">UV indeks</string>
     <string name="today_wind_peak">Vršna vrijednost %1$d %2$s u %3$s</string>
+
+    <!-- Strings added to match base — forecasters picker, garment-colour picker,
+         update-downloading banner, placeholder cards, Open-Meteo credit. -->
+    <string name="today_update_downloading_body">Preuzimanje ažuriranja…</string>
+    <string name="today_update_downloading_action">Ažuriram…</string>
+    <string name="today_update_downloading_dismiss">Odustani</string>
+    <string name="today_view_other_period">Pogledaj drugu prognozu</string>
+    <string name="today_back_to_primary">Natrag</string>
+    <string name="today_placeholder_today_title">Današnja prognoza</string>
+    <string name="today_placeholder_tonight_title">Večerašnja prognoza</string>
+    <string name="today_placeholder_body">Bit će spremna oko %1$s.</string>
+
+    <string name="settings_root_forecasters">Modeli prognoze</string>
+    <string name="settings_root_forecasters_subtitle">Izvori i modeli vremena</string>
+
+    <string name="settings_display_garment_colors_title">Boje odjeće</string>
+    <string name="settings_display_garment_colors_description">Odaberi boju za svaku ikonu odjeće prikazanu na Danas, u widgetu na početnom zaslonu i u obavijestima. Obrub se automatski zatamnjuje.</string>
+    <string name="settings_garment_color_default">Zadano</string>
+    <string name="settings_garment_color_picker_title">Odaberi boju</string>
+    <string name="settings_garment_color_swatch_description">Uzorak boje %1$s</string>
+    <string name="settings_garment_color_default_swatch_description">Vrati %1$s na zadanu boju</string>
+    <string name="settings_garment_color_dialog_close">Zatvori</string>
+
+    <string name="settings_forecasters_title">Modeli prognoze</string>
+    <string name="settings_forecasters_description">Oznaka pouzdanosti i grafikon po modelu povlače podatke iz ovih modela. Više odabranih daje širi raspon; manje znači uži fokus. Najmanje dva ostaju odabrana.</string>
+    <string name="settings_forecasters_auto_title">Automatski (najbolje za tvoju lokaciju)</string>
+    <string name="settings_forecasters_auto_subtitle">Automatski odabire regionalni model — UKMO na Britanskom otočju, JMA u Japanu, GFS + GEM u Sjevernoj Americi itd. Isključi da modele biraš sam.</string>
+    <string name="settings_forecasters_cap_hint">Odabrao si %1$d modela — najviše koliko grafikon ostaje čitljiv. Odznači jedan da dodaš drugi.</string>
+    <string name="settings_forecasters_ecmwf">ECMWF</string>
+    <string name="settings_forecasters_ecmwf_subtitle">Europski — općenito najtočniji globalni model. Trosatno na otvorenom feedu.</string>
+    <string name="settings_forecasters_icon">ICON</string>
+    <string name="settings_forecasters_icon_subtitle">Njemački (DWD) — jak u Europi i na kratke rokove. Nativno satno.</string>
+    <string name="settings_forecasters_gfs">GFS</string>
+    <string name="settings_forecasters_gfs_subtitle">Američki (NOAA) — jak nad Sjevernom Amerikom. Nativno satno.</string>
+    <string name="settings_forecasters_gem">GEM</string>
+    <string name="settings_forecasters_gem_subtitle">Kanadski (ECCC) — jak nad Sjevernom Amerikom. Trosatno na otvorenom feedu.</string>
+    <string name="settings_forecasters_arpege">ARPEGE</string>
+    <string name="settings_forecasters_arpege_subtitle">Francuski (Météo-France) — jak nad Francuskom i Zapadnom Europom. Nativno satno.</string>
+    <string name="settings_forecasters_ukmo">UKMO</string>
+    <string name="settings_forecasters_ukmo_subtitle">Britanski (UK Met Office) — povijesno drugi odmah iza ECMWF-a. Trosatno na otvorenom feedu.</string>
+    <string name="settings_forecasters_jma">JMA</string>
+    <string name="settings_forecasters_jma_subtitle">Japanski — jak nad azijsko-pacifičkom regijom. Tro- do šestosatno na otvorenom feedu.</string>
+    <string name="settings_forecasters_bom">BOM</string>
+    <string name="settings_forecasters_bom_subtitle">Australski — na održavanju, vraća se čim prije.</string>
+
+    <string name="settings_about_open_meteo">Vremenski podaci: Open-Meteo</string>
 </resources>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -616,4 +616,50 @@ locale (Angol (Egyesült Államok), Francia (Franciaország), Német
     <string name="today_uv_peak">Csúcs %1$d, %2$s-kor</string>
     <string name="today_uv_title">UV-index</string>
     <string name="today_wind_peak">Csúcs %1$d %2$s, %3$s-kor</string>
+
+    <!-- Strings added to match base — forecasters picker, garment-colour picker,
+         update-downloading banner, placeholder cards, Open-Meteo credit. -->
+    <string name="today_update_downloading_body">Frissítés letöltése…</string>
+    <string name="today_update_downloading_action">Frissítés folyamatban</string>
+    <string name="today_update_downloading_dismiss">Mégse</string>
+    <string name="today_view_other_period">Másik előrejelzés megtekintése</string>
+    <string name="today_back_to_primary">Vissza</string>
+    <string name="today_placeholder_today_title">Mai előrejelzés</string>
+    <string name="today_placeholder_tonight_title">Esti előrejelzés</string>
+    <string name="today_placeholder_body">Körülbelül %1$s-kor lesz kész.</string>
+
+    <string name="settings_root_forecasters">Előrejelzők</string>
+    <string name="settings_root_forecasters_subtitle">Időjárás-források és modellek</string>
+
+    <string name="settings_display_garment_colors_title">Ruhák színei</string>
+    <string name="settings_display_garment_colors_description">Válassz színt minden ruhaikonhoz, amely a Ma képernyőn, a kezdőképernyő-modulban és az értesítésekben jelenik meg. A körvonal automatikusan sötétebb lesz.</string>
+    <string name="settings_garment_color_default">Alapértelmezett</string>
+    <string name="settings_garment_color_picker_title">Válassz színt</string>
+    <string name="settings_garment_color_swatch_description">„%1$s” színminta</string>
+    <string name="settings_garment_color_default_swatch_description">„%1$s” visszaállítása az alapértelmezett színre</string>
+    <string name="settings_garment_color_dialog_close">Bezárás</string>
+
+    <string name="settings_forecasters_title">Előrejelzési modellek</string>
+    <string name="settings_forecasters_description">A megbízhatósági címke és a modellenkénti grafikon ezekből a modellekből merít. Több kiválasztott modell szélesebb szórást ad, kevesebb feszesebb fókuszt. Legalább kettő mindig kiválasztva marad.</string>
+    <string name="settings_forecasters_auto_title">Auto (a helyedhez legjobb)</string>
+    <string name="settings_forecasters_auto_subtitle">A regionális előrejelzőt automatikusan választja — UKMO a Brit-szigeteken, JMA Japánban, GFS + GEM Észak-Amerikában stb. Kapcsold ki, ha magad szeretnéd kiválasztani a modelleket.</string>
+    <string name="settings_forecasters_cap_hint">%1$d modellt választottál — ennyinél marad még olvasható a grafikon. Vegyél le egyet a listáról, hogy másikat tehess hozzá.</string>
+    <string name="settings_forecasters_ecmwf">ECMWF</string>
+    <string name="settings_forecasters_ecmwf_subtitle">Európai — általában a legpontosabb globális modell. A nyílt csatornán 3 óránként.</string>
+    <string name="settings_forecasters_icon">ICON</string>
+    <string name="settings_forecasters_icon_subtitle">Német (DWD) — erős Európában és rövid távon. Eredetileg óránkénti.</string>
+    <string name="settings_forecasters_gfs">GFS</string>
+    <string name="settings_forecasters_gfs_subtitle">Amerikai (NOAA) — erős Észak-Amerika felett. Eredetileg óránkénti.</string>
+    <string name="settings_forecasters_gem">GEM</string>
+    <string name="settings_forecasters_gem_subtitle">Kanadai (ECCC) — erős Észak-Amerika felett. A nyílt csatornán 3 óránként.</string>
+    <string name="settings_forecasters_arpege">ARPEGE</string>
+    <string name="settings_forecasters_arpege_subtitle">Francia (Météo-France) — erős Franciaország és Nyugat-Európa felett. Eredetileg óránkénti.</string>
+    <string name="settings_forecasters_ukmo">UKMO</string>
+    <string name="settings_forecasters_ukmo_subtitle">Brit (UK Met Office) — történelmileg csak az ECMWF előzte meg. A nyílt csatornán 3 óránként.</string>
+    <string name="settings_forecasters_jma">JMA</string>
+    <string name="settings_forecasters_jma_subtitle">Japán — erős az ázsiai–csendes-óceáni térségben. A nyílt csatornán 3–6 óránként.</string>
+    <string name="settings_forecasters_bom">BOM</string>
+    <string name="settings_forecasters_bom_subtitle">Ausztrál — karbantartás alatt, amint lehet, visszatér.</string>
+
+    <string name="settings_about_open_meteo">Időjárási adatok az Open-Meteótól</string>
 </resources>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -615,4 +615,50 @@ What is NOT overridden, by design:
     <string name="today_uv_peak">Smaigas %1$d %2$s val.</string>
     <string name="today_uv_title">UV indeksas</string>
     <string name="today_wind_peak">Smaigas %1$d %2$s %3$s val.</string>
+
+    <!-- Strings added to match base — forecasters picker, garment-colour picker,
+         update-downloading banner, placeholder cards, Open-Meteo credit. -->
+    <string name="today_update_downloading_body">Atsisiunčiamas atnaujinimas…</string>
+    <string name="today_update_downloading_action">Atnaujinama</string>
+    <string name="today_update_downloading_dismiss">Atšaukti</string>
+    <string name="today_view_other_period">Rodyti kitą prognozę</string>
+    <string name="today_back_to_primary">Atgal</string>
+    <string name="today_placeholder_today_title">Šios dienos prognozė</string>
+    <string name="today_placeholder_tonight_title">Šio vakaro prognozė</string>
+    <string name="today_placeholder_body">Bus paruošta apie %1$s.</string>
+
+    <string name="settings_root_forecasters">Prognozuotojai</string>
+    <string name="settings_root_forecasters_subtitle">Orų šaltiniai ir modeliai</string>
+
+    <string name="settings_display_garment_colors_title">Drabužių spalvos</string>
+    <string name="settings_display_garment_colors_description">Pasirink spalvą kiekvienai drabužio piktogramai ekrane „Šiandien“, pradžios ekrano valdiklyje ir pranešimuose. Kontūras automatiškai tamsėja.</string>
+    <string name="settings_garment_color_default">Numatytoji</string>
+    <string name="settings_garment_color_picker_title">Pasirink spalvą</string>
+    <string name="settings_garment_color_swatch_description">Spalvos pavyzdys „%1$s“</string>
+    <string name="settings_garment_color_default_swatch_description">Atkurti „%1$s“ numatytąją spalvą</string>
+    <string name="settings_garment_color_dialog_close">Uždaryti</string>
+
+    <string name="settings_forecasters_title">Prognozės modeliai</string>
+    <string name="settings_forecasters_description">Pasitikėjimo žetonas ir modelių diagrama remiasi šiais modeliais. Pasirinkus daugiau, sklaida platesnė; pasirinkus mažiau — fokusas tikslesnis. Bent du modeliai lieka pasirinkti.</string>
+    <string name="settings_forecasters_auto_title">Auto (geriausia tavo vietovei)</string>
+    <string name="settings_forecasters_auto_subtitle">Automatiškai parenka regioninį modelį — UKMO Britų salose, JMA Japonijoje, GFS + GEM Šiaurės Amerikoje ir t. t. Išjunk, kad rinktumeisi modelius pats.</string>
+    <string name="settings_forecasters_cap_hint">Pasirinkai %1$d modelių — daugiausia, kiek diagrama išlieka įskaitoma. Atžymėk vieną, kad pridėtum kitą.</string>
+    <string name="settings_forecasters_ecmwf">ECMWF</string>
+    <string name="settings_forecasters_ecmwf_subtitle">Europos — paprastai tiksliausias pasaulinis modelis. Atvirame sraute kas 3 valandas.</string>
+    <string name="settings_forecasters_icon">ICON</string>
+    <string name="settings_forecasters_icon_subtitle">Vokiečių (DWD) — stiprus Europoje ir trumpalaikėje prognozėje. Iš prigimties kas valandą.</string>
+    <string name="settings_forecasters_gfs">GFS</string>
+    <string name="settings_forecasters_gfs_subtitle">Amerikiečių (NOAA) — stiprus virš Šiaurės Amerikos. Iš prigimties kas valandą.</string>
+    <string name="settings_forecasters_gem">GEM</string>
+    <string name="settings_forecasters_gem_subtitle">Kanados (ECCC) — stiprus virš Šiaurės Amerikos. Atvirame sraute kas 3 valandas.</string>
+    <string name="settings_forecasters_arpege">ARPEGE</string>
+    <string name="settings_forecasters_arpege_subtitle">Prancūzų (Météo-France) — stiprus virš Prancūzijos ir Vakarų Europos. Iš prigimties kas valandą.</string>
+    <string name="settings_forecasters_ukmo">UKMO</string>
+    <string name="settings_forecasters_ukmo_subtitle">Britų (UK Met Office) — istoriškai nusileido tik ECMWF. Atvirame sraute kas 3 valandas.</string>
+    <string name="settings_forecasters_jma">JMA</string>
+    <string name="settings_forecasters_jma_subtitle">Japonų — stiprus virš Azijos ir Ramiojo vandenyno regiono. Atvirame sraute kas 3–6 valandas.</string>
+    <string name="settings_forecasters_bom">BOM</string>
+    <string name="settings_forecasters_bom_subtitle">Australijos — atliekama techninė priežiūra, sugrįš kuo greičiau.</string>
+
+    <string name="settings_about_open_meteo">Orų duomenys iš Open-Meteo</string>
 </resources>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -568,4 +568,50 @@ informal "tu"-form throughout ("Apģērb …", "Paņem … līdzi").
     <string name="today_uv_peak">Maksimums %1$d plkst. %2$s</string>
     <string name="today_uv_title">UV indekss</string>
     <string name="today_wind_peak">Maksimums %1$d %2$s plkst. %3$s</string>
+
+    <!-- Strings added to match base — forecasters picker, garment-colour picker,
+         update-downloading banner, placeholder cards, Open-Meteo credit. -->
+    <string name="today_update_downloading_body">Lejupielādē atjauninājumu…</string>
+    <string name="today_update_downloading_action">Atjaunina</string>
+    <string name="today_update_downloading_dismiss">Atcelt</string>
+    <string name="today_view_other_period">Skatīt otru prognozi</string>
+    <string name="today_back_to_primary">Atpakaļ</string>
+    <string name="today_placeholder_today_title">Šodienas prognoze</string>
+    <string name="today_placeholder_tonight_title">Vakara prognoze</string>
+    <string name="today_placeholder_body">Būs gatava aptuveni plkst. %1$s.</string>
+
+    <string name="settings_root_forecasters">Prognozētāji</string>
+    <string name="settings_root_forecasters_subtitle">Laika avoti un modeļi</string>
+
+    <string name="settings_display_garment_colors_title">Apģērba krāsas</string>
+    <string name="settings_display_garment_colors_description">Izvēlies krāsu katrai apģērba ikonai, kas redzama sadaļā „Šodien“, mājas ekrāna logrīkā un paziņojumos. Kontūra automātiski kļūst tumšāka.</string>
+    <string name="settings_garment_color_default">Noklusējums</string>
+    <string name="settings_garment_color_picker_title">Izvēlies krāsu</string>
+    <string name="settings_garment_color_swatch_description">Krāsas paraugs „%1$s“</string>
+    <string name="settings_garment_color_default_swatch_description">Atiestatīt „%1$s“ uz noklusējuma krāsu</string>
+    <string name="settings_garment_color_dialog_close">Aizvērt</string>
+
+    <string name="settings_forecasters_title">Prognozes modeļi</string>
+    <string name="settings_forecasters_description">Pārliecības čips un modeļu diagramma balstās uz šiem modeļiem. Vairāk izvēlētu modeļu dod plašāku izkliedi; mazāk — ciešāku fokusu. Vismaz divi paliek izvēlēti.</string>
+    <string name="settings_forecasters_auto_title">Auto (vislabākais tavai atrašanās vietai)</string>
+    <string name="settings_forecasters_auto_subtitle">Automātiski izvēlas reģionālo modeli — UKMO Britu salās, JMA Japānā, GFS + GEM Ziemeļamerikā utt. Izslēdz, lai izvēlētos modeļus pats.</string>
+    <string name="settings_forecasters_cap_hint">Esi izvēlējies %1$d modeļus — maksimums, pie kura diagramma paliek lasāma. Atzīmē kādu, lai pievienotu citu.</string>
+    <string name="settings_forecasters_ecmwf">ECMWF</string>
+    <string name="settings_forecasters_ecmwf_subtitle">Eiropas — parasti precīzākais globālais modelis. Atvērtajā plūsmā ik pēc 3 stundām.</string>
+    <string name="settings_forecasters_icon">ICON</string>
+    <string name="settings_forecasters_icon_subtitle">Vācu (DWD) — spēcīgs Eiropā un īsā termiņā. Sākotnēji ik stundu.</string>
+    <string name="settings_forecasters_gfs">GFS</string>
+    <string name="settings_forecasters_gfs_subtitle">Amerikāņu (NOAA) — spēcīgs pār Ziemeļameriku. Sākotnēji ik stundu.</string>
+    <string name="settings_forecasters_gem">GEM</string>
+    <string name="settings_forecasters_gem_subtitle">Kanādas (ECCC) — spēcīgs pār Ziemeļameriku. Atvērtajā plūsmā ik pēc 3 stundām.</string>
+    <string name="settings_forecasters_arpege">ARPEGE</string>
+    <string name="settings_forecasters_arpege_subtitle">Franču (Météo-France) — spēcīgs pār Franciju un Rietumeiropu. Sākotnēji ik stundu.</string>
+    <string name="settings_forecasters_ukmo">UKMO</string>
+    <string name="settings_forecasters_ukmo_subtitle">Britu (UK Met Office) — vēsturiski uzreiz aiz ECMWF. Atvērtajā plūsmā ik pēc 3 stundām.</string>
+    <string name="settings_forecasters_jma">JMA</string>
+    <string name="settings_forecasters_jma_subtitle">Japāņu — spēcīgs pār Āzijas un Klusā okeāna reģionu. Atvērtajā plūsmā ik pēc 3–6 stundām.</string>
+    <string name="settings_forecasters_bom">BOM</string>
+    <string name="settings_forecasters_bom_subtitle">Austrālijas — apkopē, atgriezīsies, cik drīz vien iespējams.</string>
+
+    <string name="settings_about_open_meteo">Laika dati no Open-Meteo</string>
 </resources>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -625,4 +625,50 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrike)").
     <string name="today_uv_peak">Topp %1$d kl. %2$s</string>
     <string name="today_uv_title">UV-indeks</string>
     <string name="today_wind_peak">Toppvind %1$d %2$s kl. %3$s</string>
+
+    <!-- Strings added to match base — forecasters picker, garment-colour picker,
+         update-downloading banner, placeholder cards, Open-Meteo credit. -->
+    <string name="today_update_downloading_body">Oppdatering lastes ned…</string>
+    <string name="today_update_downloading_action">Oppdaterer</string>
+    <string name="today_update_downloading_dismiss">Avbryt</string>
+    <string name="today_view_other_period">Vis annen prognose</string>
+    <string name="today_back_to_primary">Tilbake</string>
+    <string name="today_placeholder_today_title">Dagens prognose</string>
+    <string name="today_placeholder_tonight_title">Prognose for i kveld</string>
+    <string name="today_placeholder_body">Klar rundt kl. %1$s.</string>
+
+    <string name="settings_root_forecasters">Prognosemodeller</string>
+    <string name="settings_root_forecasters_subtitle">Værkilder og modeller</string>
+
+    <string name="settings_display_garment_colors_title">Plaggfarger</string>
+    <string name="settings_display_garment_colors_description">Velg en farge for hvert plaggikon som vises på I dag, i hjemskjermwidgeten og i varsler. Konturen mørkner automatisk.</string>
+    <string name="settings_garment_color_default">Standard</string>
+    <string name="settings_garment_color_picker_title">Velg en farge</string>
+    <string name="settings_garment_color_swatch_description">Fargeprøve %1$s</string>
+    <string name="settings_garment_color_default_swatch_description">Tilbakestill %1$s til standardfargen</string>
+    <string name="settings_garment_color_dialog_close">Lukk</string>
+
+    <string name="settings_forecasters_title">Prognosemodeller</string>
+    <string name="settings_forecasters_description">Sikkerhetsbrikken og modelldiagrammet henter fra disse modellene. Flere valgte gir en bredere spredning, færre gir et smalere fokus. Minst to forblir valgt.</string>
+    <string name="settings_forecasters_auto_title">Auto (best for stedet ditt)</string>
+    <string name="settings_forecasters_auto_subtitle">Velger den regionale modellen automatisk — UKMO på De britiske øyer, JMA i Japan, GFS + GEM i Nord-Amerika osv. Slå av for å velge modeller selv.</string>
+    <string name="settings_forecasters_cap_hint">Du har valgt %1$d modeller — det høyeste antallet der diagrammet forblir lesbart. Fjern en for å legge til en annen modell.</string>
+    <string name="settings_forecasters_ecmwf">ECMWF</string>
+    <string name="settings_forecasters_ecmwf_subtitle">Europeisk — som regel den mest nøyaktige globale modellen. 3-timers oppløsning i den åpne strømmen.</string>
+    <string name="settings_forecasters_icon">ICON</string>
+    <string name="settings_forecasters_icon_subtitle">Tysk (DWD) — sterk i Europa og på kort sikt. Nativ timeoppløsning.</string>
+    <string name="settings_forecasters_gfs">GFS</string>
+    <string name="settings_forecasters_gfs_subtitle">Amerikansk (NOAA) — sterk over Nord-Amerika. Nativ timeoppløsning.</string>
+    <string name="settings_forecasters_gem">GEM</string>
+    <string name="settings_forecasters_gem_subtitle">Kanadisk (ECCC) — sterk over Nord-Amerika. 3-timers oppløsning i den åpne strømmen.</string>
+    <string name="settings_forecasters_arpege">ARPEGE</string>
+    <string name="settings_forecasters_arpege_subtitle">Fransk (Météo-France) — sterk over Frankrike og Vest-Europa. Nativ timeoppløsning.</string>
+    <string name="settings_forecasters_ukmo">UKMO</string>
+    <string name="settings_forecasters_ukmo_subtitle">Britisk (UK Met Office) — historisk kun like bak ECMWF. 3-timers oppløsning i den åpne strømmen.</string>
+    <string name="settings_forecasters_jma">JMA</string>
+    <string name="settings_forecasters_jma_subtitle">Japansk — sterk over Asia-Stillehavet. 3- til 6-timers oppløsning i den åpne strømmen.</string>
+    <string name="settings_forecasters_bom">BOM</string>
+    <string name="settings_forecasters_bom_subtitle">Australsk — under vedlikehold, tilbake så snart som mulig.</string>
+
+    <string name="settings_about_open_meteo">Værdata fra Open-Meteo</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -670,4 +670,50 @@ is unchanged; only the displayed label localizes.
     <string name="today_uv_peak">Szczyt %1$d o %2$s</string>
     <string name="today_uv_title">Indeks UV</string>
     <string name="today_wind_peak">Szczyt %1$d %2$s o %3$s</string>
+
+    <!-- Strings added to match base — forecasters picker, garment-colour picker,
+         update-downloading banner, placeholder cards, Open-Meteo credit. -->
+    <string name="today_update_downloading_body">Pobieranie aktualizacji…</string>
+    <string name="today_update_downloading_action">Aktualizowanie…</string>
+    <string name="today_update_downloading_dismiss">Anuluj</string>
+    <string name="today_view_other_period">Zobacz drugą prognozę</string>
+    <string name="today_back_to_primary">Wstecz</string>
+    <string name="today_placeholder_today_title">Dzisiejsza prognoza</string>
+    <string name="today_placeholder_tonight_title">Wieczorna prognoza</string>
+    <string name="today_placeholder_body">Będzie gotowa około %1$s.</string>
+
+    <string name="settings_root_forecasters">Modele prognoz</string>
+    <string name="settings_root_forecasters_subtitle">Źródła i modele pogody</string>
+
+    <string name="settings_display_garment_colors_title">Kolory ubrań</string>
+    <string name="settings_display_garment_colors_description">Wybierz kolor dla każdej ikony ubrania pokazywanej na ekranie Dziś, w widżecie ekranu głównego i w powiadomieniach. Obrys automatycznie ciemnieje.</string>
+    <string name="settings_garment_color_default">Domyślny</string>
+    <string name="settings_garment_color_picker_title">Wybierz kolor</string>
+    <string name="settings_garment_color_swatch_description">Próbka koloru %1$s</string>
+    <string name="settings_garment_color_default_swatch_description">Przywróć domyślny kolor: %1$s</string>
+    <string name="settings_garment_color_dialog_close">Zamknij</string>
+
+    <string name="settings_forecasters_title">Modele prognoz</string>
+    <string name="settings_forecasters_description">Wskaźnik pewności i wykres dla poszczególnych modeli korzystają z tych modeli. Więcej wybranych daje szerszy rozrzut; mniej oznacza węższy fokus. Co najmniej dwa pozostają wybrane.</string>
+    <string name="settings_forecasters_auto_title">Automatycznie (najlepiej dla Twojej lokalizacji)</string>
+    <string name="settings_forecasters_auto_subtitle">Automatycznie dobiera regionalny model — UKMO na Wyspach Brytyjskich, JMA w Japonii, GFS + GEM w Ameryce Północnej itd. Wyłącz, aby wybrać modele samodzielnie.</string>
+    <string name="settings_forecasters_cap_hint">Wybrałeś %1$d modeli — najwięcej, ile wykres pozostaje czytelny. Odznacz jeden, aby dodać inny.</string>
+    <string name="settings_forecasters_ecmwf">ECMWF</string>
+    <string name="settings_forecasters_ecmwf_subtitle">Europejski — generalnie najdokładniejszy model globalny. Co 3 godziny w otwartym kanale.</string>
+    <string name="settings_forecasters_icon">ICON</string>
+    <string name="settings_forecasters_icon_subtitle">Niemiecki (DWD) — mocny w Europie i na krótki horyzont. Natywnie godzinowy.</string>
+    <string name="settings_forecasters_gfs">GFS</string>
+    <string name="settings_forecasters_gfs_subtitle">Amerykański (NOAA) — mocny nad Ameryką Północną. Natywnie godzinowy.</string>
+    <string name="settings_forecasters_gem">GEM</string>
+    <string name="settings_forecasters_gem_subtitle">Kanadyjski (ECCC) — mocny nad Ameryką Północną. Co 3 godziny w otwartym kanale.</string>
+    <string name="settings_forecasters_arpege">ARPEGE</string>
+    <string name="settings_forecasters_arpege_subtitle">Francuski (Météo-France) — mocny nad Francją i Europą Zachodnią. Natywnie godzinowy.</string>
+    <string name="settings_forecasters_ukmo">UKMO</string>
+    <string name="settings_forecasters_ukmo_subtitle">Brytyjski (UK Met Office) — historycznie drugi zaraz za ECMWF. Co 3 godziny w otwartym kanale.</string>
+    <string name="settings_forecasters_jma">JMA</string>
+    <string name="settings_forecasters_jma_subtitle">Japoński — mocny nad regionem Azji i Pacyfiku. Co 3–6 godzin w otwartym kanale.</string>
+    <string name="settings_forecasters_bom">BOM</string>
+    <string name="settings_forecasters_bom_subtitle">Australijski — w konserwacji, wraca tak szybko, jak to możliwe.</string>
+
+    <string name="settings_about_open_meteo">Dane pogodowe od Open-Meteo</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -681,4 +681,50 @@ only the displayed label localizes.
     <string name="today_uv_peak">Максимум %1$d в %2$s</string>
     <string name="today_uv_title">УФ-индекс</string>
     <string name="today_wind_peak">Максимум %1$d %2$s в %3$s</string>
+
+    <!-- Strings added to match base — forecasters picker, garment-colour picker,
+         update-downloading banner, placeholder cards, Open-Meteo credit. -->
+    <string name="today_update_downloading_body">Загружается обновление…</string>
+    <string name="today_update_downloading_action">Обновляется</string>
+    <string name="today_update_downloading_dismiss">Отмена</string>
+    <string name="today_view_other_period">Показать другой прогноз</string>
+    <string name="today_back_to_primary">Назад</string>
+    <string name="today_placeholder_today_title">Прогноз на сегодня</string>
+    <string name="today_placeholder_tonight_title">Прогноз на вечер</string>
+    <string name="today_placeholder_body">Будет готов примерно к %1$s.</string>
+
+    <string name="settings_root_forecasters">Прогнозисты</string>
+    <string name="settings_root_forecasters_subtitle">Источники погоды и модели</string>
+
+    <string name="settings_display_garment_colors_title">Цвета одежды</string>
+    <string name="settings_display_garment_colors_description">Выбери цвет для каждой иконки одежды на экране «Сегодня», в виджете и в уведомлениях. Контур автоматически становится темнее.</string>
+    <string name="settings_garment_color_default">По умолчанию</string>
+    <string name="settings_garment_color_picker_title">Выбери цвет</string>
+    <string name="settings_garment_color_swatch_description">Образец цвета «%1$s»</string>
+    <string name="settings_garment_color_default_swatch_description">Сбросить «%1$s» на цвет по умолчанию</string>
+    <string name="settings_garment_color_dialog_close">Закрыть</string>
+
+    <string name="settings_forecasters_title">Модели прогноза</string>
+    <string name="settings_forecasters_description">Чип уверенности и график по моделям опираются на эти модели. Чем больше моделей выбрано, тем шире разброс; чем меньше — тем чётче фокус. Минимум две модели остаются выбранными.</string>
+    <string name="settings_forecasters_auto_title">Авто (лучшее для твоего местоположения)</string>
+    <string name="settings_forecasters_auto_subtitle">Автоматически выбирает региональную модель — UKMO на Британских островах, JMA в Японии, GFS + GEM в Северной Америке и т. д. Отключи, чтобы выбирать модели самостоятельно.</string>
+    <string name="settings_forecasters_cap_hint">Выбрано %1$d моделей — максимум, при котором график остаётся читаемым. Сними отметку с одной, чтобы добавить другую.</string>
+    <string name="settings_forecasters_ecmwf">ECMWF</string>
+    <string name="settings_forecasters_ecmwf_subtitle">Европейская — как правило, самая точная глобальная модель. На открытом канале каждые 3 часа.</string>
+    <string name="settings_forecasters_icon">ICON</string>
+    <string name="settings_forecasters_icon_subtitle">Немецкая (DWD) — сильна в Европе и на коротких сроках. Изначально почасовая.</string>
+    <string name="settings_forecasters_gfs">GFS</string>
+    <string name="settings_forecasters_gfs_subtitle">Американская (NOAA) — сильна над Северной Америкой. Изначально почасовая.</string>
+    <string name="settings_forecasters_gem">GEM</string>
+    <string name="settings_forecasters_gem_subtitle">Канадская (ECCC) — сильна над Северной Америкой. На открытом канале каждые 3 часа.</string>
+    <string name="settings_forecasters_arpege">ARPEGE</string>
+    <string name="settings_forecasters_arpege_subtitle">Французская (Météo-France) — сильна над Францией и Западной Европой. Изначально почасовая.</string>
+    <string name="settings_forecasters_ukmo">UKMO</string>
+    <string name="settings_forecasters_ukmo_subtitle">Британская (UK Met Office) — исторически уступает только ECMWF. На открытом канале каждые 3 часа.</string>
+    <string name="settings_forecasters_jma">JMA</string>
+    <string name="settings_forecasters_jma_subtitle">Японская — сильна над Азиатско-Тихоокеанским регионом. На открытом канале с шагом 3–6 часов.</string>
+    <string name="settings_forecasters_bom">BOM</string>
+    <string name="settings_forecasters_bom_subtitle">Австралийская — на обслуживании, вернётся как можно скорее.</string>
+
+    <string name="settings_about_open_meteo">Данные о погоде от Open-Meteo</string>
 </resources>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -627,4 +627,50 @@ What is NOT overridden, by design:
     <string name="today_uv_peak">Vrchol %1$d o %2$s</string>
     <string name="today_uv_title">UV index</string>
     <string name="today_wind_peak">Vrchol %1$d %2$s o %3$s</string>
+
+    <!-- Strings added to match base — forecasters picker, garment-colour picker,
+         update-downloading banner, placeholder cards, Open-Meteo credit. -->
+    <string name="today_update_downloading_body">Sťahuje sa aktualizácia…</string>
+    <string name="today_update_downloading_action">Aktualizuje sa…</string>
+    <string name="today_update_downloading_dismiss">Zrušiť</string>
+    <string name="today_view_other_period">Zobraziť druhú prognózu</string>
+    <string name="today_back_to_primary">Späť</string>
+    <string name="today_placeholder_today_title">Dnešná prognóza</string>
+    <string name="today_placeholder_tonight_title">Večerná prognóza</string>
+    <string name="today_placeholder_body">Bude pripravená okolo %1$s.</string>
+
+    <string name="settings_root_forecasters">Modely prognóz</string>
+    <string name="settings_root_forecasters_subtitle">Zdroje a modely počasia</string>
+
+    <string name="settings_display_garment_colors_title">Farby oblečenia</string>
+    <string name="settings_display_garment_colors_description">Vyber farbu pre každú ikonu oblečenia zobrazenú na obrazovke Dnes, vo widgete na domovskej obrazovke a v upozorneniach. Obrys sa automaticky stmaví.</string>
+    <string name="settings_garment_color_default">Predvolené</string>
+    <string name="settings_garment_color_picker_title">Vyber farbu</string>
+    <string name="settings_garment_color_swatch_description">Vzorka farby %1$s</string>
+    <string name="settings_garment_color_default_swatch_description">Obnoviť predvolenú farbu %1$s</string>
+    <string name="settings_garment_color_dialog_close">Zavrieť</string>
+
+    <string name="settings_forecasters_title">Modely prognóz</string>
+    <string name="settings_forecasters_description">Indikátor istoty a graf podľa modelov čerpajú z týchto modelov. Viac vybraných znamená širší rozptyl; menej znamená užší fokus. Aspoň dva zostávajú vybrané.</string>
+    <string name="settings_forecasters_auto_title">Automaticky (najlepšie pre tvoju polohu)</string>
+    <string name="settings_forecasters_auto_subtitle">Automaticky vyberie regionálny model — UKMO na Britských ostrovoch, JMA v Japonsku, GFS + GEM v Severnej Amerike atď. Vypni, ak si chceš modely zvoliť sám.</string>
+    <string name="settings_forecasters_cap_hint">Vybral si %1$d modelov — najviac, koľko zostane graf čitateľný. Odznač jeden, ak chceš pridať iný model.</string>
+    <string name="settings_forecasters_ecmwf">ECMWF</string>
+    <string name="settings_forecasters_ecmwf_subtitle">Európsky — vo všeobecnosti najpresnejší globálny model. Trojhodinový krok na otvorenom feede.</string>
+    <string name="settings_forecasters_icon">ICON</string>
+    <string name="settings_forecasters_icon_subtitle">Nemecký (DWD) — silný v Európe a na krátky horizont. Natívne hodinový.</string>
+    <string name="settings_forecasters_gfs">GFS</string>
+    <string name="settings_forecasters_gfs_subtitle">Americký (NOAA) — silný nad Severnou Amerikou. Natívne hodinový.</string>
+    <string name="settings_forecasters_gem">GEM</string>
+    <string name="settings_forecasters_gem_subtitle">Kanadský (ECCC) — silný nad Severnou Amerikou. Trojhodinový krok na otvorenom feede.</string>
+    <string name="settings_forecasters_arpege">ARPEGE</string>
+    <string name="settings_forecasters_arpege_subtitle">Francúzsky (Météo-France) — silný nad Francúzskom a Západnou Európou. Natívne hodinový.</string>
+    <string name="settings_forecasters_ukmo">UKMO</string>
+    <string name="settings_forecasters_ukmo_subtitle">Britský (UK Met Office) — historicky druhý hneď za ECMWF. Trojhodinový krok na otvorenom feede.</string>
+    <string name="settings_forecasters_jma">JMA</string>
+    <string name="settings_forecasters_jma_subtitle">Japonský — silný nad ázijsko-pacifickou oblasťou. Tri- až šesťhodinový krok na otvorenom feede.</string>
+    <string name="settings_forecasters_bom">BOM</string>
+    <string name="settings_forecasters_bom_subtitle">Austrálsky — v údržbe, vráti sa hneď, ako to bude možné.</string>
+
+    <string name="settings_about_open_meteo">Údaje o počasí poskytuje Open-Meteo</string>
 </resources>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -608,4 +608,50 @@ informal "ti"-form throughout, mirroring the Croatian / Serbian pass.
     <string name="today_uv_peak">Vrh %1$d ob %2$s</string>
     <string name="today_uv_title">UV indeks</string>
     <string name="today_wind_peak">Vrh %1$d %2$s ob %3$s</string>
+
+    <!-- Strings added to match base — forecasters picker, garment-colour picker,
+         update-downloading banner, placeholder cards, Open-Meteo credit. -->
+    <string name="today_update_downloading_body">Prenašanje posodobitve…</string>
+    <string name="today_update_downloading_action">Posodabljam…</string>
+    <string name="today_update_downloading_dismiss">Prekliči</string>
+    <string name="today_view_other_period">Pokaži drugo napoved</string>
+    <string name="today_back_to_primary">Nazaj</string>
+    <string name="today_placeholder_today_title">Današnja napoved</string>
+    <string name="today_placeholder_tonight_title">Nocojšnja napoved</string>
+    <string name="today_placeholder_body">Pripravljena bo okoli %1$s.</string>
+
+    <string name="settings_root_forecasters">Modeli napovedi</string>
+    <string name="settings_root_forecasters_subtitle">Viri in modeli vremena</string>
+
+    <string name="settings_display_garment_colors_title">Barve oblačil</string>
+    <string name="settings_display_garment_colors_description">Izberi barvo za vsako ikono oblačila, prikazano na zaslonu Danes, v pripomočku domačega zaslona in v obvestilih. Obroba se samodejno potemni.</string>
+    <string name="settings_garment_color_default">Privzeto</string>
+    <string name="settings_garment_color_picker_title">Izberi barvo</string>
+    <string name="settings_garment_color_swatch_description">Barvni vzorec %1$s</string>
+    <string name="settings_garment_color_default_swatch_description">Ponastavi %1$s na privzeto barvo</string>
+    <string name="settings_garment_color_dialog_close">Zapri</string>
+
+    <string name="settings_forecasters_title">Modeli napovedi</string>
+    <string name="settings_forecasters_description">Oznaka zanesljivosti in graf po modelih črpata podatke iz teh modelov. Več izbranih pomeni širši razpon; manj pomeni ožji fokus. Vsaj dva ostaneta izbrana.</string>
+    <string name="settings_forecasters_auto_title">Samodejno (najboljše za tvojo lokacijo)</string>
+    <string name="settings_forecasters_auto_subtitle">Samodejno izbere regionalni model — UKMO na Britanskem otočju, JMA na Japonskem, GFS + GEM v Severni Ameriki itd. Izklopi, da modele izbereš sam.</string>
+    <string name="settings_forecasters_cap_hint">Izbral si %1$d modelov — največ, pri katerih graf ostane berljiv. Odznači enega, da dodaš drug model.</string>
+    <string name="settings_forecasters_ecmwf">ECMWF</string>
+    <string name="settings_forecasters_ecmwf_subtitle">Evropski — na splošno najnatančnejši globalni model. Trourni korak na odprtem viru.</string>
+    <string name="settings_forecasters_icon">ICON</string>
+    <string name="settings_forecasters_icon_subtitle">Nemški (DWD) — močan v Evropi in na kratek rok. Domorodno urni.</string>
+    <string name="settings_forecasters_gfs">GFS</string>
+    <string name="settings_forecasters_gfs_subtitle">Ameriški (NOAA) — močan nad Severno Ameriko. Domorodno urni.</string>
+    <string name="settings_forecasters_gem">GEM</string>
+    <string name="settings_forecasters_gem_subtitle">Kanadski (ECCC) — močan nad Severno Ameriko. Trourni korak na odprtem viru.</string>
+    <string name="settings_forecasters_arpege">ARPEGE</string>
+    <string name="settings_forecasters_arpege_subtitle">Francoski (Météo-France) — močan nad Francijo in Zahodno Evropo. Domorodno urni.</string>
+    <string name="settings_forecasters_ukmo">UKMO</string>
+    <string name="settings_forecasters_ukmo_subtitle">Britanski (UK Met Office) — zgodovinsko drugi takoj za ECMWF. Trourni korak na odprtem viru.</string>
+    <string name="settings_forecasters_jma">JMA</string>
+    <string name="settings_forecasters_jma_subtitle">Japonski — močan nad azijsko-pacifiško regijo. Tri- do šesturni korak na odprtem viru.</string>
+    <string name="settings_forecasters_bom">BOM</string>
+    <string name="settings_forecasters_bom_subtitle">Avstralski — v vzdrževanju, vrne se takoj, ko bo mogoče.</string>
+
+    <string name="settings_about_open_meteo">Vremenske podatke posreduje Open-Meteo</string>
 </resources>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -625,4 +625,50 @@ native names for all locales (e.g. "Tyska (Tyskland)", "Franska (Frankrike)").
     <string name="today_uv_peak">Topp %1$d kl. %2$s</string>
     <string name="today_uv_title">UV-index</string>
     <string name="today_wind_peak">Topphastighet %1$d %2$s kl. %3$s</string>
+
+    <!-- Strings added to match base — forecasters picker, garment-colour picker,
+         update-downloading banner, placeholder cards, Open-Meteo credit. -->
+    <string name="today_update_downloading_body">Uppdatering laddas ned…</string>
+    <string name="today_update_downloading_action">Uppdaterar</string>
+    <string name="today_update_downloading_dismiss">Avbryt</string>
+    <string name="today_view_other_period">Visa annan prognos</string>
+    <string name="today_back_to_primary">Tillbaka</string>
+    <string name="today_placeholder_today_title">Dagens prognos</string>
+    <string name="today_placeholder_tonight_title">Prognos för i kväll</string>
+    <string name="today_placeholder_body">Klar runt kl. %1$s.</string>
+
+    <string name="settings_root_forecasters">Prognosmodeller</string>
+    <string name="settings_root_forecasters_subtitle">Väderkällor och modeller</string>
+
+    <string name="settings_display_garment_colors_title">Plaggfärger</string>
+    <string name="settings_display_garment_colors_description">Välj en färg för varje plaggikon som visas på Idag, i hemskärmswidgeten och i aviseringar. Konturen mörknar automatiskt.</string>
+    <string name="settings_garment_color_default">Standard</string>
+    <string name="settings_garment_color_picker_title">Välj en färg</string>
+    <string name="settings_garment_color_swatch_description">Färgprov %1$s</string>
+    <string name="settings_garment_color_default_swatch_description">Återställ %1$s till standardfärgen</string>
+    <string name="settings_garment_color_dialog_close">Stäng</string>
+
+    <string name="settings_forecasters_title">Prognosmodeller</string>
+    <string name="settings_forecasters_description">Säkerhetschippet och modelldiagrammet bygger på de här modellerna. Fler val ger en bredare spridning, färre ger ett snävare fokus. Minst två förblir valda.</string>
+    <string name="settings_forecasters_auto_title">Auto (bäst för din plats)</string>
+    <string name="settings_forecasters_auto_subtitle">Väljer den regionala modellen automatiskt — UKMO på Brittiska öarna, JMA i Japan, GFS + GEM i Nordamerika osv. Stäng av för att välja modeller själv.</string>
+    <string name="settings_forecasters_cap_hint">Du har valt %1$d modeller — det maximala antal där diagrammet förblir läsbart. Avmarkera en för att lägga till en annan modell.</string>
+    <string name="settings_forecasters_ecmwf">ECMWF</string>
+    <string name="settings_forecasters_ecmwf_subtitle">Europeisk — i regel den mest precisa globala modellen. 3-timmesupplösning i det öppna flödet.</string>
+    <string name="settings_forecasters_icon">ICON</string>
+    <string name="settings_forecasters_icon_subtitle">Tysk (DWD) — stark i Europa och på kort sikt. Nativ timupplösning.</string>
+    <string name="settings_forecasters_gfs">GFS</string>
+    <string name="settings_forecasters_gfs_subtitle">Amerikansk (NOAA) — stark över Nordamerika. Nativ timupplösning.</string>
+    <string name="settings_forecasters_gem">GEM</string>
+    <string name="settings_forecasters_gem_subtitle">Kanadensisk (ECCC) — stark över Nordamerika. 3-timmesupplösning i det öppna flödet.</string>
+    <string name="settings_forecasters_arpege">ARPEGE</string>
+    <string name="settings_forecasters_arpege_subtitle">Fransk (Météo-France) — stark över Frankrike och Västeuropa. Nativ timupplösning.</string>
+    <string name="settings_forecasters_ukmo">UKMO</string>
+    <string name="settings_forecasters_ukmo_subtitle">Brittisk (UK Met Office) — historiskt strax efter ECMWF. 3-timmesupplösning i det öppna flödet.</string>
+    <string name="settings_forecasters_jma">JMA</string>
+    <string name="settings_forecasters_jma_subtitle">Japansk — stark över Asien-Stillahavsområdet. 3- till 6-timmesupplösning i det öppna flödet.</string>
+    <string name="settings_forecasters_bom">BOM</string>
+    <string name="settings_forecasters_bom_subtitle">Australisk — under underhåll, tillbaka så snart som möjligt.</string>
+
+    <string name="settings_about_open_meteo">Väderdata från Open-Meteo</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -624,4 +624,50 @@ only the displayed label localizes.
     <string name="today_uv_peak">Максимум %1$d о %2$s</string>
     <string name="today_uv_title">УФ-індекс</string>
     <string name="today_wind_peak">Максимум %1$d %2$s о %3$s</string>
+
+    <!-- Strings added to match base — forecasters picker, garment-colour picker,
+         update-downloading banner, placeholder cards, Open-Meteo credit. -->
+    <string name="today_update_downloading_body">Завантажується оновлення…</string>
+    <string name="today_update_downloading_action">Оновлюється</string>
+    <string name="today_update_downloading_dismiss">Скасувати</string>
+    <string name="today_view_other_period">Показати інший прогноз</string>
+    <string name="today_back_to_primary">Назад</string>
+    <string name="today_placeholder_today_title">Прогноз на сьогодні</string>
+    <string name="today_placeholder_tonight_title">Прогноз на вечір</string>
+    <string name="today_placeholder_body">Буде готовий приблизно о %1$s.</string>
+
+    <string name="settings_root_forecasters">Прогнозисти</string>
+    <string name="settings_root_forecasters_subtitle">Джерела погоди та моделі</string>
+
+    <string name="settings_display_garment_colors_title">Кольори одягу</string>
+    <string name="settings_display_garment_colors_description">Виберіть колір для кожної піктограми одягу, що відображається на екрані «Сьогодні», у віджеті на головному екрані та у сповіщеннях. Контур автоматично темнішає.</string>
+    <string name="settings_garment_color_default">За замовчуванням</string>
+    <string name="settings_garment_color_picker_title">Виберіть колір</string>
+    <string name="settings_garment_color_swatch_description">Зразок кольору «%1$s»</string>
+    <string name="settings_garment_color_default_swatch_description">Скинути «%1$s» до кольору за замовчуванням</string>
+    <string name="settings_garment_color_dialog_close">Закрити</string>
+
+    <string name="settings_forecasters_title">Моделі прогнозу</string>
+    <string name="settings_forecasters_description">Чип впевненості та графік по моделях спираються на ці моделі. Чим більше моделей вибрано, тим ширший розкид; чим менше — тим чіткіший фокус. Принаймні дві моделі залишаються вибраними.</string>
+    <string name="settings_forecasters_auto_title">Авто (найкраще для вашого місцезнаходження)</string>
+    <string name="settings_forecasters_auto_subtitle">Автоматично вибирає регіональну модель — UKMO на Британських островах, JMA у Японії, GFS + GEM у Північній Америці тощо. Вимкніть, щоб вибирати моделі самостійно.</string>
+    <string name="settings_forecasters_cap_hint">Вибрано %1$d моделей — максимум, за якого графік залишається читабельним. Зніміть позначку з однієї, щоб додати іншу.</string>
+    <string name="settings_forecasters_ecmwf">ECMWF</string>
+    <string name="settings_forecasters_ecmwf_subtitle">Європейська — як правило, найточніша глобальна модель. На відкритому каналі кожні 3 години.</string>
+    <string name="settings_forecasters_icon">ICON</string>
+    <string name="settings_forecasters_icon_subtitle">Німецька (DWD) — сильна в Європі та на коротких термінах. Початково погодинна.</string>
+    <string name="settings_forecasters_gfs">GFS</string>
+    <string name="settings_forecasters_gfs_subtitle">Американська (NOAA) — сильна над Північною Америкою. Початково погодинна.</string>
+    <string name="settings_forecasters_gem">GEM</string>
+    <string name="settings_forecasters_gem_subtitle">Канадська (ECCC) — сильна над Північною Америкою. На відкритому каналі кожні 3 години.</string>
+    <string name="settings_forecasters_arpege">ARPEGE</string>
+    <string name="settings_forecasters_arpege_subtitle">Французька (Météo-France) — сильна над Францією та Західною Європою. Початково погодинна.</string>
+    <string name="settings_forecasters_ukmo">UKMO</string>
+    <string name="settings_forecasters_ukmo_subtitle">Британська (UK Met Office) — історично поступається лише ECMWF. На відкритому каналі кожні 3 години.</string>
+    <string name="settings_forecasters_jma">JMA</string>
+    <string name="settings_forecasters_jma_subtitle">Японська — сильна над Азійсько-Тихоокеанським регіоном. На відкритому каналі з кроком 3–6 годин.</string>
+    <string name="settings_forecasters_bom">BOM</string>
+    <string name="settings_forecasters_bom_subtitle">Австралійська — на обслуговуванні, повернеться якнайшвидше.</string>
+
+    <string name="settings_about_open_meteo">Дані про погоду від Open-Meteo</string>
 </resources>


### PR DESCRIPTION
## Summary

Follow-up to #492 — fills in the same 39 base strings for the 18 European languages it didn't cover. Every European-language `values-*` folder is now fully in sync with `values/strings.xml` (modulo the 7 by-design omissions documented in each file's header: `app_name` brand identifier + the English-only `insight_time_am/pm/midnight/noon` and `*_minutes` AM/PM helpers).

Locales touched (register per each file's header):

- `values-hr/` (Croatian) — informal *ti*-form, ijekavian
- `values-sk/` (Slovak) — *ty*-form
- `values-cs/` (Czech) — *ty*-form
- `values-sl/` (Slovenian) — *ti*-form
- `values-b+sr+Latn/` (Serbian, Latin script) — *ti*-form, ekavian variant
- `values-pl/` (Polish) — *Ty*-form
- `values-ru/` (Russian) — informal *ты*-form; gender-neutral passive where past-tense would force gender; «…» guillemets for nested labels
- `values-uk/` (Ukrainian) — **formal *ви*-form** (matches the file's existing register, intentionally not informal); «…» guillemets
- `values-bg/` (Bulgarian) — informal *ти*-form
- `values-lv/` (Latvian) — informal *tu*-form
- `values-lt/` (Lithuanian) — informal *tu*-form
- `values-et/` (Estonian) — informal *sina*-form
- `values-hu/` (Hungarian) — *te*-form; uses the `%1$s-kor` suffix idiom from existing `today_uv_peak` for the placeholder body
- `values-sv/` (Swedish) — informal *du*-form; `kl.` time prefix
- `values-da/` (Danish) — informal *du*-form; `kl.` time prefix
- `values-nb/` (Norwegian Bokmål) — informal *du*-form; `kl.` time prefix
- `values-fi/` (Finnish) — *sinä*-form; `klo` time prefix
- `values-el/` (Greek) — informal *εσύ*-form ("Πάτησε", "Διάλεξε", "Φόρεσε"); «…» guillemets; Latin-script brand names

Same key set as #492:
- `today_update_downloading_*` (3) — in-app-update banner during download
- `today_view_other_period` / `today_back_to_primary` / `today_placeholder_*` (5) — Today ↔ Tonight toggle + placeholder
- `settings_root_forecasters` (+ subtitle) — Settings root nav entry
- `settings_display_garment_colors_*` and `settings_garment_color_*` (7) — garment-colour picker
- `settings_forecasters_*` (21) — Forecasters sub-page
- `settings_about_open_meteo` — Open-Meteo attribution

Agency / model acronyms (ECMWF, ICON, GFS, GEM, ARPEGE, UKMO, JMA, BOM) and brand names (Météo-France, Open-Meteo, ClothesCast, DWD, NOAA, ECCC, UK Met Office) stay verbatim across every locale — Latin-script even inside Cyrillic and Greek files, matching the existing precedent those files already set elsewhere.

No privacy-relevant strings — nothing here leaves the device.

## Test plan

- [x] `xmllint --noout` clean on all 18 modified files
- [x] `./gradlew :app:processDebugResources` succeeds (aapt accepts every locale)
- [x] Re-ran the "missing keys" diff against `values/strings.xml` — every locale now reports exactly the 7 by-design omissions
- [x] Audited format specifiers (`%1$s`, `%1$d`, `%%`) — preserved verbatim
- [x] Apostrophe-style audit — no stray typographic `’`, all use `\'` per file convention
- [ ] CI: JVM unit tests + `:app:assembleDebug` green
- [ ] Eyeball a couple of strings in-app on a Polish / Russian / Greek build before un-drafting

https://claude.ai/code/session_01PP2B53SaZaK2j19ZJMyv1d

---
_Generated by [Claude Code](https://claude.ai/code/session_01PP2B53SaZaK2j19ZJMyv1d)_