### PR TITLE
Translate the forecasters picker and recent UI additions into East Asian languages

### DIFF
--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -497,7 +497,7 @@ the displayed label localizes.
     <string name="settings_root_schedule_subtitle">通知と時刻</string>
     <string name="settings_root_clothes_subtitle">気温と服装</string>
     <string name="settings_root_region_subtitle">言語と単位</string>
-    <string name="settings_root_voice_subtitle">プロバイダーとアクセント</string>
+    <string name="settings_root_voice_subtitle">音声とアクセント</string>
 
     <string name="settings_tts_device_voice_label">デバイスの音声</string>
     <string name="settings_tts_device_voice_auto">自動（アクセントに最適）</string>
@@ -551,6 +551,9 @@ the displayed label localizes.
     <string name="today_update_available_body">ClothesCast の新しいバージョンが Play ストアで公開されています。</string>
     <string name="today_update_available_action">アップデート</string>
     <string name="today_update_available_dismiss">後で</string>
+    <string name="today_update_downloading_body">アップデートをダウンロード中…</string>
+    <string name="today_update_downloading_action">アップデート中</string>
+    <string name="today_update_downloading_dismiss">キャンセル</string>
     <string name="today_update_downloaded_body">アップデートをダウンロードしました。インストールを完了するには再起動してください。</string>
     <string name="today_update_downloaded_action">再起動</string>
 
@@ -570,7 +573,7 @@ the displayed label localizes.
     <string name="settings_root_location">位置情報</string>
     <string name="settings_root_calendar">カレンダー</string>
     <string name="settings_root_display_subtitle">テーマとカラー</string>
-    <string name="settings_root_location_subtitle">自動検出または都市を選択</string>
+    <string name="settings_root_location_subtitle">自動と手動の位置</string>
     <string name="settings_root_calendar_subtitle">今日の予定</string>
 
     <!-- Display screen — theme picker (system / light / dark). -->
@@ -730,4 +733,55 @@ the displayed label localizes.
     <string name="today_uv_peak">最大 %1$d（%2$s）</string>
     <string name="today_uv_title">UV指数</string>
     <string name="today_wind_peak">最大 %1$d %2$s（%3$s）</string>
+
+    <!-- Today screen pager — second page (other-period forecast) and the
+         placeholder shown before the worker has generated either insight. -->
+    <string name="today_view_other_period">別の予報を表示</string>
+    <string name="today_back_to_primary">戻る</string>
+    <string name="today_placeholder_today_title">今日の予報</string>
+    <string name="today_placeholder_tonight_title">今夜の予報</string>
+    <string name="today_placeholder_body">%1$s 頃に表示されます。</string>
+
+    <!-- Settings root list — Forecasters row and subtitle. -->
+    <string name="settings_root_forecasters">予報モデル</string>
+    <string name="settings_root_forecasters_subtitle">気象情報源とモデル</string>
+
+    <!-- About screen — Open-Meteo attribution. "Open-Meteo" is a Latin brand
+         name and stays Latin. -->
+    <string name="settings_about_open_meteo">気象データ提供：Open-Meteo</string>
+
+    <!-- Display screen — per-garment colour picker. Pick a fill colour for
+         each clothing icon; the stroke darkens automatically. -->
+    <string name="settings_display_garment_colors_title">服装の色</string>
+    <string name="settings_display_garment_colors_description">「今日」、ホーム画面のウィジェット、通知に表示される各服装アイコンの色を選びます。輪郭は自動的に濃くなります。</string>
+    <string name="settings_garment_color_default">デフォルト</string>
+    <string name="settings_garment_color_picker_title">色を選択</string>
+    <string name="settings_garment_color_swatch_description">カラーサンプル %1$s</string>
+    <string name="settings_garment_color_default_swatch_description">%1$s をデフォルトの色にリセット</string>
+    <string name="settings_garment_color_dialog_close">閉じる</string>
+
+    <!-- Forecasters sub-page — picker of numerical weather prediction
+         models. Display labels are the agency / model acronyms (ECMWF,
+         GFS, ICON, …) — short, unambiguous, stable across translations. -->
+    <string name="settings_forecasters_title">予報モデル</string>
+    <string name="settings_forecasters_description">信頼度チップとモデル別チャートは、これらのモデルから値を取得します。多く選ぶほど分布が広くなり、少なくするほど焦点が絞られます。最低2つは選択されたままになります。</string>
+    <string name="settings_forecasters_auto_title">自動（あなたの場所に最適）</string>
+    <string name="settings_forecasters_auto_subtitle">地域の予報モデルを自動で選択します — 英国諸島では UKMO、日本では JMA、北米では GFS + GEM など。オフにすると自分でモデルを選べます。</string>
+    <string name="settings_forecasters_cap_hint">%1$d 個のモデルを選択しています — チャートが読みやすく保てる上限です。別のモデルを追加するには1つ解除してください。</string>
+    <string name="settings_forecasters_ecmwf">ECMWF</string>
+    <string name="settings_forecasters_ecmwf_subtitle">ヨーロッパ — 一般的に最も正確な全球モデル。オープンフィードでは3時間ごと。</string>
+    <string name="settings_forecasters_icon">ICON</string>
+    <string name="settings_forecasters_icon_subtitle">ドイツ（DWD）— ヨーロッパおよび短期予報に強い。ネイティブで1時間ごと。</string>
+    <string name="settings_forecasters_gfs">GFS</string>
+    <string name="settings_forecasters_gfs_subtitle">アメリカ（NOAA）— 北米に強い。ネイティブで1時間ごと。</string>
+    <string name="settings_forecasters_gem">GEM</string>
+    <string name="settings_forecasters_gem_subtitle">カナダ（ECCC）— 北米に強い。オープンフィードでは3時間ごと。</string>
+    <string name="settings_forecasters_arpege">ARPEGE</string>
+    <string name="settings_forecasters_arpege_subtitle">フランス（Météo-France）— フランスおよび西ヨーロッパに強い。ネイティブで1時間ごと。</string>
+    <string name="settings_forecasters_ukmo">UKMO</string>
+    <string name="settings_forecasters_ukmo_subtitle">イギリス（UK Met Office）— 歴史的に ECMWF に次ぐ精度。オープンフィードでは3時間ごと。</string>
+    <string name="settings_forecasters_jma">JMA</string>
+    <string name="settings_forecasters_jma_subtitle">日本（気象庁）— アジア・太平洋に強い。オープンフィードでは3〜6時間ごと。</string>
+    <string name="settings_forecasters_bom">BOM</string>
+    <string name="settings_forecasters_bom_subtitle">オーストラリア — メンテナンス中。できるだけ早く復旧する予定です。</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -510,7 +510,7 @@ displayed label localizes.
     <string name="settings_root_schedule_subtitle">알림 및 시간</string>
     <string name="settings_root_clothes_subtitle">온도 및 의상</string>
     <string name="settings_root_region_subtitle">언어 및 단위</string>
-    <string name="settings_root_voice_subtitle">공급자 및 억양</string>
+    <string name="settings_root_voice_subtitle">음성 및 억양</string>
 
     <string name="settings_tts_voice_locale_am_et">암하라어 (에티오피아)</string>
     <string name="settings_tts_voice_locale_da_dk">덴마크어 (덴마크)</string>
@@ -555,6 +555,9 @@ displayed label localizes.
     <string name="today_update_available_body">Play 스토어에 ClothesCast의 새 버전이 있습니다.</string>
     <string name="today_update_available_action">업데이트</string>
     <string name="today_update_available_dismiss">나중에</string>
+    <string name="today_update_downloading_body">업데이트 다운로드 중…</string>
+    <string name="today_update_downloading_action">업데이트 중</string>
+    <string name="today_update_downloading_dismiss">취소</string>
     <string name="today_update_downloaded_body">업데이트가 다운로드되었습니다. 설치를 완료하려면 다시 시작하세요.</string>
     <string name="today_update_downloaded_action">다시 시작</string>
 
@@ -574,7 +577,7 @@ displayed label localizes.
     <string name="settings_root_location">위치</string>
     <string name="settings_root_calendar">캘린더</string>
     <string name="settings_root_display_subtitle">테마 및 색상</string>
-    <string name="settings_root_location_subtitle">자동 감지 또는 도시 선택</string>
+    <string name="settings_root_location_subtitle">자동 및 수동 위치</string>
     <string name="settings_root_calendar_subtitle">오늘의 일정</string>
 
     <!-- Display screen — theme picker (system / light / dark). -->
@@ -734,4 +737,55 @@ displayed label localizes.
     <string name="today_uv_peak">최대 %1$d (%2$s)</string>
     <string name="today_uv_title">자외선 지수</string>
     <string name="today_wind_peak">최대 %1$d %2$s (%3$s)</string>
+
+    <!-- Today screen pager — second page (other-period forecast) and the
+         placeholder shown before the worker has generated either insight. -->
+    <string name="today_view_other_period">다른 예보 보기</string>
+    <string name="today_back_to_primary">뒤로</string>
+    <string name="today_placeholder_today_title">오늘의 예보</string>
+    <string name="today_placeholder_tonight_title">오늘 밤 예보</string>
+    <string name="today_placeholder_body">%1$s 즈음에 준비됩니다.</string>
+
+    <!-- Settings root list — Forecasters row and subtitle. -->
+    <string name="settings_root_forecasters">예보 모델</string>
+    <string name="settings_root_forecasters_subtitle">기상 출처 및 모델</string>
+
+    <!-- About screen — Open-Meteo attribution. "Open-Meteo" is a Latin brand
+         name and stays Latin. -->
+    <string name="settings_about_open_meteo">기상 데이터: Open-Meteo</string>
+
+    <!-- Display screen — per-garment colour picker. Pick a fill colour for
+         each clothing icon; the stroke darkens automatically. -->
+    <string name="settings_display_garment_colors_title">의상 색상</string>
+    <string name="settings_display_garment_colors_description">「오늘」 화면, 홈 화면 위젯, 알림에 표시되는 각 의상 아이콘의 색을 선택하세요. 테두리는 자동으로 어두워집니다.</string>
+    <string name="settings_garment_color_default">기본값</string>
+    <string name="settings_garment_color_picker_title">색상 선택</string>
+    <string name="settings_garment_color_swatch_description">색상 견본 %1$s</string>
+    <string name="settings_garment_color_default_swatch_description">%1$s을(를) 기본 색상으로 재설정</string>
+    <string name="settings_garment_color_dialog_close">닫기</string>
+
+    <!-- Forecasters sub-page — picker of numerical weather prediction
+         models. Display labels are the agency / model acronyms (ECMWF,
+         GFS, ICON, …) — short, unambiguous, stable across translations. -->
+    <string name="settings_forecasters_title">예보 모델</string>
+    <string name="settings_forecasters_description">신뢰도 칩과 모델별 차트는 이 모델들에서 값을 가져옵니다. 더 많이 선택하면 분포가 넓어지고, 적게 선택하면 초점이 좁아집니다. 최소 2개는 선택된 상태로 유지됩니다.</string>
+    <string name="settings_forecasters_auto_title">자동 (현재 위치에 가장 적합)</string>
+    <string name="settings_forecasters_auto_subtitle">지역 예보 모델을 자동으로 선택합니다 — 영국 제도에서는 UKMO, 일본에서는 JMA, 북미에서는 GFS + GEM 등. 끄면 직접 모델을 선택할 수 있습니다.</string>
+    <string name="settings_forecasters_cap_hint">모델을 %1$d개 선택했습니다 — 차트가 읽기 좋게 유지되는 최대치입니다. 다른 모델을 추가하려면 하나를 해제하세요.</string>
+    <string name="settings_forecasters_ecmwf">ECMWF</string>
+    <string name="settings_forecasters_ecmwf_subtitle">유럽 — 일반적으로 가장 정확한 전 지구 모델. 오픈 피드에서는 3시간 간격.</string>
+    <string name="settings_forecasters_icon">ICON</string>
+    <string name="settings_forecasters_icon_subtitle">독일 (DWD) — 유럽 및 단기 예보에 강함. 기본 1시간 간격.</string>
+    <string name="settings_forecasters_gfs">GFS</string>
+    <string name="settings_forecasters_gfs_subtitle">미국 (NOAA) — 북미에 강함. 기본 1시간 간격.</string>
+    <string name="settings_forecasters_gem">GEM</string>
+    <string name="settings_forecasters_gem_subtitle">캐나다 (ECCC) — 북미에 강함. 오픈 피드에서는 3시간 간격.</string>
+    <string name="settings_forecasters_arpege">ARPEGE</string>
+    <string name="settings_forecasters_arpege_subtitle">프랑스 (Météo-France) — 프랑스 및 서유럽에 강함. 기본 1시간 간격.</string>
+    <string name="settings_forecasters_ukmo">UKMO</string>
+    <string name="settings_forecasters_ukmo_subtitle">영국 (UK Met Office) — 역사적으로 ECMWF 다음으로 정확한 모델. 오픈 피드에서는 3시간 간격.</string>
+    <string name="settings_forecasters_jma">JMA</string>
+    <string name="settings_forecasters_jma_subtitle">일본 — 아시아 태평양에 강함. 오픈 피드에서는 3~6시간 간격.</string>
+    <string name="settings_forecasters_bom">BOM</string>
+    <string name="settings_forecasters_bom_subtitle">호주 — 점검 중입니다. 가능한 한 빨리 복구됩니다.</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -489,7 +489,7 @@ label localizes.
     <string name="settings_root_schedule_subtitle">通知与时间</string>
     <string name="settings_root_clothes_subtitle">温度与穿搭</string>
     <string name="settings_root_region_subtitle">语言与单位</string>
-    <string name="settings_root_voice_subtitle">提供商与口音</string>
+    <string name="settings_root_voice_subtitle">声音和口音</string>
 
     <string name="settings_tts_device_voice_label">设备语音</string>
     <string name="settings_tts_device_voice_auto">自动（最适合口音）</string>
@@ -543,6 +543,9 @@ label localizes.
     <string name="today_update_available_body">Play 商店上有 ClothesCast 的新版本。</string>
     <string name="today_update_available_action">更新</string>
     <string name="today_update_available_dismiss">暂不</string>
+    <string name="today_update_downloading_body">正在下载更新…</string>
+    <string name="today_update_downloading_action">正在更新</string>
+    <string name="today_update_downloading_dismiss">取消</string>
     <string name="today_update_downloaded_body">更新已下载。重启以完成安装。</string>
     <string name="today_update_downloaded_action">重启</string>
 
@@ -562,7 +565,7 @@ label localizes.
     <string name="settings_root_location">位置</string>
     <string name="settings_root_calendar">日历</string>
     <string name="settings_root_display_subtitle">主题和颜色</string>
-    <string name="settings_root_location_subtitle">自动检测或选择城市</string>
+    <string name="settings_root_location_subtitle">自动和手动位置</string>
     <string name="settings_root_calendar_subtitle">今天的日程</string>
 
     <!-- Display screen — theme picker (system / light / dark). -->
@@ -722,4 +725,55 @@ label localizes.
     <string name="today_uv_peak">最高 %1$d（%2$s）</string>
     <string name="today_uv_title">紫外线指数</string>
     <string name="today_wind_peak">最高 %1$d %2$s（%3$s）</string>
+
+    <!-- Today screen pager — second page (other-period forecast) and the
+         placeholder shown before the worker has generated either insight. -->
+    <string name="today_view_other_period">查看其他预报</string>
+    <string name="today_back_to_primary">返回</string>
+    <string name="today_placeholder_today_title">今天的预报</string>
+    <string name="today_placeholder_tonight_title">今晚的预报</string>
+    <string name="today_placeholder_body">大约 %1$s 准备就绪。</string>
+
+    <!-- Settings root list — Forecasters row and subtitle. -->
+    <string name="settings_root_forecasters">预报模型</string>
+    <string name="settings_root_forecasters_subtitle">天气来源和模型</string>
+
+    <!-- About screen — Open-Meteo attribution. "Open-Meteo" is a Latin brand
+         name and stays Latin. -->
+    <string name="settings_about_open_meteo">天气数据来自 Open-Meteo</string>
+
+    <!-- Display screen — per-garment colour picker. Pick a fill colour for
+         each clothing icon; the stroke darkens automatically. -->
+    <string name="settings_display_garment_colors_title">服装颜色</string>
+    <string name="settings_display_garment_colors_description">为「今日」页面、主屏幕小部件以及通知中显示的每个服装图标选择颜色。描边会自动加深。</string>
+    <string name="settings_garment_color_default">默认</string>
+    <string name="settings_garment_color_picker_title">选择颜色</string>
+    <string name="settings_garment_color_swatch_description">颜色色块 %1$s</string>
+    <string name="settings_garment_color_default_swatch_description">将 %1$s 重置为默认颜色</string>
+    <string name="settings_garment_color_dialog_close">关闭</string>
+
+    <!-- Forecasters sub-page — picker of numerical weather prediction
+         models. Display labels are the agency / model acronyms (ECMWF,
+         GFS, ICON, …) — short, unambiguous, stable across translations. -->
+    <string name="settings_forecasters_title">预报模型</string>
+    <string name="settings_forecasters_description">信心标签和分模型图表都来自这些模型。选得多分布更宽，选得少更聚焦。至少保留两个。</string>
+    <string name="settings_forecasters_auto_title">自动（最适合你所在位置）</string>
+    <string name="settings_forecasters_auto_subtitle">根据所在位置自动选择区域预报模型——英伦三岛使用 UKMO，日本使用 JMA，北美使用 GFS + GEM 等。关闭后可自行选择模型。</string>
+    <string name="settings_forecasters_cap_hint">你已选择 %1$d 个模型——这是图表仍能保持可读的上限。先取消选择一个，再添加其他模型。</string>
+    <string name="settings_forecasters_ecmwf">ECMWF</string>
+    <string name="settings_forecasters_ecmwf_subtitle">欧洲——通常是最准确的全球模型。开放数据源为每 3 小时。</string>
+    <string name="settings_forecasters_icon">ICON</string>
+    <string name="settings_forecasters_icon_subtitle">德国（DWD）——在欧洲及短期预报方面表现出色。原生每小时。</string>
+    <string name="settings_forecasters_gfs">GFS</string>
+    <string name="settings_forecasters_gfs_subtitle">美国（NOAA）——北美地区表现出色。原生每小时。</string>
+    <string name="settings_forecasters_gem">GEM</string>
+    <string name="settings_forecasters_gem_subtitle">加拿大（ECCC）——北美地区表现出色。开放数据源为每 3 小时。</string>
+    <string name="settings_forecasters_arpege">ARPEGE</string>
+    <string name="settings_forecasters_arpege_subtitle">法国（Météo-France）——法国及西欧表现出色。原生每小时。</string>
+    <string name="settings_forecasters_ukmo">UKMO</string>
+    <string name="settings_forecasters_ukmo_subtitle">英国（UK Met Office）——历史上仅次于 ECMWF。开放数据源为每 3 小时。</string>
+    <string name="settings_forecasters_jma">JMA</string>
+    <string name="settings_forecasters_jma_subtitle">日本——亚太地区表现出色。开放数据源为每 3 至 6 小时。</string>
+    <string name="settings_forecasters_bom">BOM</string>
+    <string name="settings_forecasters_bom_subtitle">澳大利亚——维护中，将尽快恢复。</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -456,6 +456,9 @@ label localises.
     <string name="today_update_available_body">Play 商店上有 ClothesCast 的新版本。</string>
     <string name="today_update_available_action">更新</string>
     <string name="today_update_available_dismiss">暫不</string>
+    <string name="today_update_downloading_body">正在下載更新…</string>
+    <string name="today_update_downloading_action">正在更新</string>
+    <string name="today_update_downloading_dismiss">取消</string>
     <string name="today_update_downloaded_body">更新已下載。請重新啟動以完成安裝。</string>
     <string name="today_update_downloaded_action">重新啟動</string>
 
@@ -515,12 +518,12 @@ label localises.
     <string name="settings_root_location">位置</string>
     <string name="settings_root_calendar">行事曆</string>
     <string name="settings_root_display_subtitle">主題和顏色</string>
-    <string name="settings_root_location_subtitle">自動偵測或選擇城市</string>
+    <string name="settings_root_location_subtitle">自動與手動位置</string>
     <string name="settings_root_calendar_subtitle">今天的行程</string>
     <string name="settings_root_schedule_subtitle">通知與時間</string>
     <string name="settings_root_clothes_subtitle">氣溫與穿搭</string>
     <string name="settings_root_region_subtitle">語言與單位</string>
-    <string name="settings_root_voice_subtitle">提供者與口音</string>
+    <string name="settings_root_voice_subtitle">聲音和口音</string>
 
     <!-- Display screen — theme picker (system / light / dark). -->
     <string name="settings_display_theme_title">佈景主題</string>
@@ -738,4 +741,55 @@ label localises.
     <string name="today_uv_peak">最高 %1$d（%2$s）</string>
     <string name="today_uv_title">紫外線指數</string>
     <string name="today_wind_peak">最高 %1$d %2$s（%3$s）</string>
+
+    <!-- Today screen pager — second page (other-period forecast) and the
+         placeholder shown before the worker has generated either insight. -->
+    <string name="today_view_other_period">查看其他預報</string>
+    <string name="today_back_to_primary">返回</string>
+    <string name="today_placeholder_today_title">今天的預報</string>
+    <string name="today_placeholder_tonight_title">今晚的預報</string>
+    <string name="today_placeholder_body">大約 %1$s 準備好。</string>
+
+    <!-- Settings root list — Forecasters row and subtitle. -->
+    <string name="settings_root_forecasters">預報模型</string>
+    <string name="settings_root_forecasters_subtitle">天氣來源和模型</string>
+
+    <!-- About screen — Open-Meteo attribution. "Open-Meteo" is a Latin brand
+         name and stays Latin. -->
+    <string name="settings_about_open_meteo">天氣資料來自 Open-Meteo</string>
+
+    <!-- Display screen — per-garment colour picker. Pick a fill colour for
+         each clothing icon; the stroke darkens automatically. -->
+    <string name="settings_display_garment_colors_title">服裝顏色</string>
+    <string name="settings_display_garment_colors_description">為「今日」畫面、主畫面小工具以及通知中顯示的每個服裝圖示選擇顏色。外框會自動加深。</string>
+    <string name="settings_garment_color_default">預設</string>
+    <string name="settings_garment_color_picker_title">選擇顏色</string>
+    <string name="settings_garment_color_swatch_description">顏色色塊 %1$s</string>
+    <string name="settings_garment_color_default_swatch_description">將 %1$s 重設為預設顏色</string>
+    <string name="settings_garment_color_dialog_close">關閉</string>
+
+    <!-- Forecasters sub-page — picker of numerical weather prediction
+         models. Display labels are the agency / model acronyms (ECMWF,
+         GFS, ICON, …) — short, unambiguous, stable across translations. -->
+    <string name="settings_forecasters_title">預報模型</string>
+    <string name="settings_forecasters_description">信心標籤與分模型圖表皆來自這些模型。選得越多分佈越廣，越少則焦點越集中。至少需保留兩個。</string>
+    <string name="settings_forecasters_auto_title">自動（最適合你所在位置）</string>
+    <string name="settings_forecasters_auto_subtitle">依所在位置自動選擇地區預報模型——不列顛群島使用 UKMO，日本使用 JMA，北美使用 GFS + GEM 等。關閉後可自行選擇模型。</string>
+    <string name="settings_forecasters_cap_hint">你已選擇 %1$d 個模型——這是圖表仍能保持可讀的上限。先取消選擇一個，再加入其他模型。</string>
+    <string name="settings_forecasters_ecmwf">ECMWF</string>
+    <string name="settings_forecasters_ecmwf_subtitle">歐洲——一般而言最準確的全球模型。開放資料來源為每 3 小時。</string>
+    <string name="settings_forecasters_icon">ICON</string>
+    <string name="settings_forecasters_icon_subtitle">德國（DWD）——在歐洲及短期預報方面表現出色。原生每小時。</string>
+    <string name="settings_forecasters_gfs">GFS</string>
+    <string name="settings_forecasters_gfs_subtitle">美國（NOAA）——北美地區表現出色。原生每小時。</string>
+    <string name="settings_forecasters_gem">GEM</string>
+    <string name="settings_forecasters_gem_subtitle">加拿大（ECCC）——北美地區表現出色。開放資料來源為每 3 小時。</string>
+    <string name="settings_forecasters_arpege">ARPEGE</string>
+    <string name="settings_forecasters_arpege_subtitle">法國（Météo-France）——法國及西歐表現出色。原生每小時。</string>
+    <string name="settings_forecasters_ukmo">UKMO</string>
+    <string name="settings_forecasters_ukmo_subtitle">英國（UK Met Office）——歷史上僅次於 ECMWF。開放資料來源為每 3 小時。</string>
+    <string name="settings_forecasters_jma">JMA</string>
+    <string name="settings_forecasters_jma_subtitle">日本——亞太地區表現出色。開放資料來源為每 3 至 6 小時。</string>
+    <string name="settings_forecasters_bom">BOM</string>
+    <string name="settings_forecasters_bom_subtitle">澳洲——維護中，將盡快恢復。</string>
 </resources>


### PR DESCRIPTION
## Summary

Catches Japanese, Korean, Simplified Chinese, and Traditional Chinese up to the run of recent commits that landed source-only string additions without updating `values-ja` / `-ko` / `-zh-rCN` / `-zh-rTW`. **39 missing keys** filled in per locale, and **2 stale entries** refreshed against their current English source.

### Missing strings now translated

- **Today screen pager** (added in 7e377aa, missed in CJK): `today_view_other_period`, `today_back_to_primary`, `today_placeholder_today_title`, `today_placeholder_tonight_title`, `today_placeholder_body`.
- **Update banner** (added in dfac7ee): `today_update_downloading_body`, `today_update_downloading_action`, `today_update_downloading_dismiss`.
- **Settings root** (added in 2aec6a8): `settings_root_forecasters` + its subtitle.
- **Display ▸ Garment colours** (added in eab5e10): `settings_display_garment_colors_title`, `settings_display_garment_colors_description`, and the five `settings_garment_color_*` picker labels.
- **About ▸ Open-Meteo attribution** (added in 3bb6f40): `settings_about_open_meteo`. "Open-Meteo" stays Latin in CJK per the existing convention noted in the locale headers.
- **Forecasters sub-page** (added across 2aec6a8 / 20f180c / d4f633c / 6404264 / c798999): all 18 `settings_forecasters_*` strings — title / description / Auto pair / cap_hint / 8 model labels and subtitles including the BOM-under-maintenance copy.

### Stale strings refreshed

- `settings_root_voice_subtitle`: "Providers and Accents" → "Voices and Accents" (per c798999). ja `音声とアクセント`, ko `음성 및 억양`, zh-rCN `声音和口音`, zh-rTW `聲音和口音`.
- `settings_root_location_subtitle`: "Auto-detect or pick a city" → "Automatic and Manual Location". ja `自動と手動の位置`, ko `자동 및 수동 위치`, zh-rCN `自动和手动位置`, zh-rTW `自動與手動位置`.

### Left unchanged on purpose

- `settings_root_voice` (Voice → Speech in English): the existing translations `音声` / `음성` / `语音` / `語音` already cover both meanings naturally.
- `app_name` and the en-only `insight_time_{am,pm,midnight,noon}{,_minutes}` spoken-time formatter helpers remain unoverridden, matching the comment at the top of each locale file.

Stylistic choices match each file's existing register: ja stays in friendly-polite ます-form with full-width brackets `（）` and `「…」` quotes; ko mixes 해요체 / 하십시오체 the same way the rest of the file does; zh-rCN / zh-rTW keep the casual `你` register and ideographic punctuation, with the standard space-around-Latin convention preserved around `ECMWF`, `Open-Meteo`, etc.

## Privacy

No change to what leaves the device — translation-only PR.

## Test plan

- [x] All four `values-{ja,ko,zh-rCN,zh-rTW}/strings.xml` parse as XML.
- [x] `:app:assembleDebug` succeeds locally (`./gradlew :app:assembleDebug`, 3m33s).
- [x] `:app:testDebugUnitTest` passes locally (1m16s).
- [ ] Wait for CI on JVM unit tests + Android debug build.

https://claude.ai/code/session_01HudkthroW1Au13D3NqWfNS

---
_Generated by [Claude Code](https://claude.ai/code/session_01HudkthroW1Au13D3NqWfNS)_