### PR TITLE
Translate the forecasters picker and recent UI additions into South / Southeast Asian languages

### DIFF
--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -280,9 +280,9 @@ West Bengal vocabulary differences in a future PR.
     <string name="settings_root_schedule_subtitle">বিজ্ঞপ্তি ও সময়</string>
     <string name="settings_root_clothes_subtitle">তাপমাত্রা ও পোশাক</string>
     <string name="settings_root_region_subtitle">ভাষা ও একক</string>
-    <string name="settings_root_voice_subtitle">প্রদানকারী ও উচ্চারণভঙ্গি</string>
+    <string name="settings_root_voice_subtitle">ভয়েস ও উচ্চারণভঙ্গি</string>
     <string name="settings_root_display_subtitle">থিম এবং রঙ</string>
-    <string name="settings_root_location_subtitle">স্বয়ংক্রিয় শনাক্ত বা শহর বেছে নিন</string>
+    <string name="settings_root_location_subtitle">স্বয়ংক্রিয় ও ম্যানুয়াল অবস্থান</string>
     <string name="settings_root_calendar_subtitle">আজকের ইভেন্ট</string>
     <string name="settings_root_privacy_subtitle">ক্র্যাশ ও ব্যবহারের রিপোর্ট</string>
 
@@ -666,4 +666,55 @@ West Bengal vocabulary differences in a future PR.
     <string name="today_uv_peak">সর্বোচ্চ %1$d সময় %2$s</string>
     <string name="today_uv_title">UV সূচক</string>
     <string name="today_wind_peak">সর্বোচ্চ %1$d %2$s সময় %3$s</string>
+
+    <!-- Today screen pager. -->
+    <string name="today_view_other_period">অন্য পূর্বাভাস দেখুন</string>
+    <string name="today_back_to_primary">ফিরুন</string>
+    <string name="today_placeholder_today_title">আজকের পূর্বাভাস</string>
+    <string name="today_placeholder_tonight_title">আজ রাতের পূর্বাভাস</string>
+    <string name="today_placeholder_body">প্রায় %1$s-এ প্রস্তুত হবে।</string>
+
+    <!-- Settings root — Forecasters row. -->
+    <string name="settings_root_forecasters">পূর্বাভাসদাতা</string>
+    <string name="settings_root_forecasters_subtitle">আবহাওয়া উৎস ও মডেল</string>
+
+    <!-- About — Open-Meteo attribution (brand stays Latin). -->
+    <string name="settings_about_open_meteo">আবহাওয়ার তথ্য Open-Meteo থেকে</string>
+
+    <!-- Display — per-garment colour picker. -->
+    <string name="settings_display_garment_colors_title">পোশাকের রং</string>
+    <string name="settings_display_garment_colors_description">আজ, হোম স্ক্রিন উইজেট এবং বিজ্ঞপ্তিতে দেখানো প্রতিটি পোশাক আইকনের জন্য একটি রং বেছে নিন। আউটলাইন স্বয়ংক্রিয়ভাবে গাঢ় হয়ে যায়।</string>
+    <string name="settings_garment_color_default">ডিফল্ট</string>
+    <string name="settings_garment_color_picker_title">একটি রং বেছে নিন</string>
+    <string name="settings_garment_color_swatch_description">রঙের সোয়াচ %1$s</string>
+    <string name="settings_garment_color_default_swatch_description">%1$s কে ডিফল্ট রঙে রিসেট করুন</string>
+    <string name="settings_garment_color_dialog_close">বন্ধ করুন</string>
+
+    <!-- Update banner — Downloading state. -->
+    <string name="today_update_downloading_body">আপডেট ডাউনলোড হচ্ছে…</string>
+    <string name="today_update_downloading_action">আপডেট হচ্ছে</string>
+    <string name="today_update_downloading_dismiss">বাতিল করুন</string>
+
+    <!-- Forecasters sub-page — picker of NWP models. -->
+    <string name="settings_forecasters_title">পূর্বাভাস মডেল</string>
+    <string name="settings_forecasters_description">কনফিডেন্স চিপ এবং প্রতি-মডেল চার্ট এই মডেলগুলো থেকে তথ্য নেয়। বেশি বেছে নিলে বিস্তার বাড়ে; কম হলে ফোকাস সংকীর্ণ হয়। অন্তত দুটি নির্বাচিত থাকে।</string>
+    <string name="settings_forecasters_auto_title">স্বয়ংক্রিয় (আপনার অবস্থানের জন্য সেরা)</string>
+    <string name="settings_forecasters_auto_subtitle">আঞ্চলিক পূর্বাভাসদাতা স্বয়ংক্রিয়ভাবে বেছে নেয় — ব্রিটিশ আইলসে UKMO, জাপানে JMA, উত্তর আমেরিকায় GFS + GEM ইত্যাদি। নিজে মডেল বেছে নিতে হলে বন্ধ করুন।</string>
+    <string name="settings_forecasters_cap_hint">আপনি %1$d টি মডেল বেছেছেন — চার্ট পাঠযোগ্য রাখার সর্বোচ্চ। অন্য মডেল যোগ করতে একটি অনির্বাচিত করুন।</string>
+    <string name="settings_forecasters_ecmwf">ECMWF</string>
+    <string name="settings_forecasters_ecmwf_subtitle">ইউরোপীয় — সাধারণত সবচেয়ে নির্ভুল বৈশ্বিক মডেল। উন্মুক্ত ফিডে ৩-ঘণ্টা পরপর।</string>
+    <string name="settings_forecasters_icon">ICON</string>
+    <string name="settings_forecasters_icon_subtitle">জার্মান (DWD) — ইউরোপে ও স্বল্প-পরিসরে শক্তিশালী। নেটিভ ঘণ্টায়।</string>
+    <string name="settings_forecasters_gfs">GFS</string>
+    <string name="settings_forecasters_gfs_subtitle">আমেরিকান (NOAA) — উত্তর আমেরিকায় শক্তিশালী। নেটিভ ঘণ্টায়।</string>
+    <string name="settings_forecasters_gem">GEM</string>
+    <string name="settings_forecasters_gem_subtitle">কানাডিয়ান (ECCC) — উত্তর আমেরিকায় শক্তিশালী। উন্মুক্ত ফিডে ৩-ঘণ্টা পরপর।</string>
+    <string name="settings_forecasters_arpege">ARPEGE</string>
+    <string name="settings_forecasters_arpege_subtitle">ফরাসি (Météo-France) — ফ্রান্স ও পশ্চিম ইউরোপে শক্তিশালী। নেটিভ ঘণ্টায়।</string>
+    <string name="settings_forecasters_ukmo">UKMO</string>
+    <string name="settings_forecasters_ukmo_subtitle">ব্রিটিশ (UK Met Office) — ঐতিহাসিকভাবে ECMWF-এর পরই। উন্মুক্ত ফিডে ৩-ঘণ্টা পরপর।</string>
+    <string name="settings_forecasters_jma">JMA</string>
+    <string name="settings_forecasters_jma_subtitle">জাপানি — এশিয়া-প্যাসিফিকে শক্তিশালী। উন্মুক্ত ফিডে ৩ থেকে ৬ ঘণ্টা পরপর।</string>
+    <string name="settings_forecasters_bom">BOM</string>
+    <string name="settings_forecasters_bom_subtitle">অস্ট্রেলিয়ান — রক্ষণাবেক্ষণ চলছে, যত দ্রুত সম্ভব ফিরবে।</string>
 </resources>

--- a/app/src/main/res/values-fil/strings.xml
+++ b/app/src/main/res/values-fil/strings.xml
@@ -265,9 +265,9 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="settings_root_schedule_subtitle">Mga Notipikasyon at Oras</string>
     <string name="settings_root_clothes_subtitle">Mga Temperatura at Outfit</string>
     <string name="settings_root_region_subtitle">Mga Wika at Yunit</string>
-    <string name="settings_root_voice_subtitle">Mga Tagapagbigay at Punto</string>
+    <string name="settings_root_voice_subtitle">Mga Boses at Punto</string>
     <string name="settings_root_display_subtitle">Mga tema at kulay</string>
-    <string name="settings_root_location_subtitle">Auto-detect o pumili ng lungsod</string>
+    <string name="settings_root_location_subtitle">Awtomatiko at Manual na Lokasyon</string>
     <string name="settings_root_calendar_subtitle">Mga evento ngayon</string>
     <string name="settings_root_privacy_subtitle">Mga ulat ng crash + paggamit</string>
 
@@ -646,4 +646,55 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="today_uv_peak">Pinakamataas na %1$d sa %2$s</string>
     <string name="today_uv_title">UV index</string>
     <string name="today_wind_peak">Pinakamataas na %1$d %2$s sa %3$s</string>
+
+    <!-- Today screen pager. -->
+    <string name="today_view_other_period">Tingnan ang ibang forecast</string>
+    <string name="today_back_to_primary">Bumalik</string>
+    <string name="today_placeholder_today_title">Forecast ngayong araw</string>
+    <string name="today_placeholder_tonight_title">Forecast ngayong gabi</string>
+    <string name="today_placeholder_body">Magiging handa nang humigit-kumulang %1$s.</string>
+
+    <!-- Settings root — Forecasters row. -->
+    <string name="settings_root_forecasters">Mga Forecaster</string>
+    <string name="settings_root_forecasters_subtitle">Mga Pinagmumulan at Modelo ng Panahon</string>
+
+    <!-- About — Open-Meteo attribution (brand stays Latin). -->
+    <string name="settings_about_open_meteo">Datos ng panahon mula sa Open-Meteo</string>
+
+    <!-- Display — per-garment colour picker. -->
+    <string name="settings_display_garment_colors_title">Mga kulay ng damit</string>
+    <string name="settings_display_garment_colors_description">Pumili ng kulay para sa bawat icon ng damit na ipinapakita sa Ngayon, sa home-screen widget, at sa mga notification. Awtomatikong pumupusyaw ang gilid.</string>
+    <string name="settings_garment_color_default">Default</string>
+    <string name="settings_garment_color_picker_title">Pumili ng kulay</string>
+    <string name="settings_garment_color_swatch_description">Swatch ng kulay %1$s</string>
+    <string name="settings_garment_color_default_swatch_description">I-reset ang %1$s sa default na kulay</string>
+    <string name="settings_garment_color_dialog_close">Isara</string>
+
+    <!-- Update banner — Downloading state. -->
+    <string name="today_update_downloading_body">Dina-download ang update…</string>
+    <string name="today_update_downloading_action">Ina-update</string>
+    <string name="today_update_downloading_dismiss">Kanselahin</string>
+
+    <!-- Forecasters sub-page — picker of NWP models. -->
+    <string name="settings_forecasters_title">Mga modelo ng forecast</string>
+    <string name="settings_forecasters_description">Ang confidence chip at chart ng bawat modelo ay kinukuha mula sa mga modelong ito. Mas maraming napiling modelo, mas malawak ang spread; mas konti, mas pokus. Hindi bababa sa dalawa ang mananatiling napili.</string>
+    <string name="settings_forecasters_auto_title">Awtomatiko (pinakamainam para sa iyong lokasyon)</string>
+    <string name="settings_forecasters_auto_subtitle">Awtomatikong pinipili ang panrehiyong forecaster — UKMO sa British Isles, JMA sa Japan, GFS + GEM sa North America, atbp. I-off para mamili ka mismo ng mga modelo.</string>
+    <string name="settings_forecasters_cap_hint">Pumili ka ng %1$d na modelo — ang pinakamarami na nababasa pa ang chart. Mag-alis ng isa para makapagdagdag ng iba.</string>
+    <string name="settings_forecasters_ecmwf">ECMWF</string>
+    <string name="settings_forecasters_ecmwf_subtitle">European — kadalasang pinakatumpak na global model. 3 oras kada update sa open feed.</string>
+    <string name="settings_forecasters_icon">ICON</string>
+    <string name="settings_forecasters_icon_subtitle">German (DWD) — malakas sa Europe at sa short-range. Native oras-oras.</string>
+    <string name="settings_forecasters_gfs">GFS</string>
+    <string name="settings_forecasters_gfs_subtitle">American (NOAA) — malakas sa North America. Native oras-oras.</string>
+    <string name="settings_forecasters_gem">GEM</string>
+    <string name="settings_forecasters_gem_subtitle">Canadian (ECCC) — malakas sa North America. 3 oras kada update sa open feed.</string>
+    <string name="settings_forecasters_arpege">ARPEGE</string>
+    <string name="settings_forecasters_arpege_subtitle">French (Météo-France) — malakas sa France at Western Europe. Native oras-oras.</string>
+    <string name="settings_forecasters_ukmo">UKMO</string>
+    <string name="settings_forecasters_ukmo_subtitle">British (UK Met Office) — historically pumapangalawa lang sa ECMWF. 3 oras kada update sa open feed.</string>
+    <string name="settings_forecasters_jma">JMA</string>
+    <string name="settings_forecasters_jma_subtitle">Japanese — malakas sa Asia-Pacific. 3 hanggang 6 oras kada update sa open feed.</string>
+    <string name="settings_forecasters_bom">BOM</string>
+    <string name="settings_forecasters_bom_subtitle">Australian — kasalukuyang maintenance, babalik sa lalong madaling panahon.</string>
 </resources>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -36,9 +36,9 @@ Not overridden by design:
     <string name="settings_root_schedule_subtitle">सूचनाएँ और समय</string>
     <string name="settings_root_clothes_subtitle">तापमान और पोशाक</string>
     <string name="settings_root_region_subtitle">भाषाएँ और इकाइयाँ</string>
-    <string name="settings_root_voice_subtitle">प्रदाता और लहजा</string>
+    <string name="settings_root_voice_subtitle">आवाज़ें और लहजे</string>
     <string name="settings_root_display_subtitle">थीम और रंग</string>
-    <string name="settings_root_location_subtitle">स्वतः पहचान या शहर चुनें</string>
+    <string name="settings_root_location_subtitle">स्वचालित और मैनुअल स्थान</string>
     <string name="settings_root_calendar_subtitle">आज की घटनाएँ</string>
 
     <!-- Garments -->
@@ -626,4 +626,55 @@ Not overridden by design:
     <string name="today_uv_peak">अधिकतम %1$d %2$s बजे</string>
     <string name="today_uv_title">UV सूचकांक</string>
     <string name="today_wind_peak">अधिकतम %1$d %2$s %3$s बजे</string>
+
+    <!-- Today screen pager. -->
+    <string name="today_view_other_period">अन्य पूर्वानुमान देखें</string>
+    <string name="today_back_to_primary">वापस</string>
+    <string name="today_placeholder_today_title">आज का पूर्वानुमान</string>
+    <string name="today_placeholder_tonight_title">आज रात का पूर्वानुमान</string>
+    <string name="today_placeholder_body">लगभग %1$s तक तैयार होगा।</string>
+
+    <!-- Settings root — Forecasters row. -->
+    <string name="settings_root_forecasters">पूर्वानुमानकर्ता</string>
+    <string name="settings_root_forecasters_subtitle">मौसम स्रोत और मॉडल</string>
+
+    <!-- About — Open-Meteo attribution (brand stays Latin). -->
+    <string name="settings_about_open_meteo">मौसम डेटा Open-Meteo से</string>
+
+    <!-- Display — per-garment colour picker. -->
+    <string name="settings_display_garment_colors_title">कपड़ों के रंग</string>
+    <string name="settings_display_garment_colors_description">आज स्क्रीन, होम-स्क्रीन विजेट और सूचनाओं पर दिखाए जाने वाले प्रत्येक कपड़े के आइकन के लिए एक रंग चुनें। बाहरी रेखा अपने आप गहरी हो जाती है।</string>
+    <string name="settings_garment_color_default">डिफ़ॉल्ट</string>
+    <string name="settings_garment_color_picker_title">रंग चुनें</string>
+    <string name="settings_garment_color_swatch_description">रंग नमूना %1$s</string>
+    <string name="settings_garment_color_default_swatch_description">%1$s को डिफ़ॉल्ट रंग पर रीसेट करें</string>
+    <string name="settings_garment_color_dialog_close">बंद करें</string>
+
+    <!-- Update banner — Downloading state. -->
+    <string name="today_update_downloading_body">अपडेट डाउनलोड हो रहा है…</string>
+    <string name="today_update_downloading_action">अपडेट हो रहा है</string>
+    <string name="today_update_downloading_dismiss">रद्द करें</string>
+
+    <!-- Forecasters sub-page — picker of NWP models. -->
+    <string name="settings_forecasters_title">पूर्वानुमान मॉडल</string>
+    <string name="settings_forecasters_description">कॉन्फिडेंस चिप और प्रति-मॉडल चार्ट इन मॉडलों से डेटा लेते हैं। ज़्यादा चुनने पर अधिक विस्तार मिलता है; कम चुनने पर ध्यान केंद्रित रहता है। कम से कम दो हमेशा चयनित रहते हैं।</string>
+    <string name="settings_forecasters_auto_title">स्वतः (आपके स्थान के लिए सर्वोत्तम)</string>
+    <string name="settings_forecasters_auto_subtitle">क्षेत्रीय पूर्वानुमानकर्ता स्वतः चुनें — ब्रिटिश आइल्स में UKMO, जापान में JMA, उत्तरी अमेरिका में GFS + GEM, इत्यादि। स्वयं मॉडल चुनने के लिए बंद करें।</string>
+    <string name="settings_forecasters_cap_hint">आपने %1$d मॉडल चुने हैं — चार्ट जितने पर पठनीय रहता है उसकी सीमा। दूसरा मॉडल जोड़ने के लिए एक का चयन हटाएँ।</string>
+    <string name="settings_forecasters_ecmwf">ECMWF</string>
+    <string name="settings_forecasters_ecmwf_subtitle">यूरोपीय — आम तौर पर सबसे सटीक वैश्विक मॉडल। ओपन फ़ीड पर 3-घंटे का अंतराल।</string>
+    <string name="settings_forecasters_icon">ICON</string>
+    <string name="settings_forecasters_icon_subtitle">जर्मन (DWD) — यूरोप और अल्प-दूरी पर मजबूत। नेटिव प्रति घंटा।</string>
+    <string name="settings_forecasters_gfs">GFS</string>
+    <string name="settings_forecasters_gfs_subtitle">अमेरिकी (NOAA) — उत्तरी अमेरिका पर मजबूत। नेटिव प्रति घंटा।</string>
+    <string name="settings_forecasters_gem">GEM</string>
+    <string name="settings_forecasters_gem_subtitle">कनाडाई (ECCC) — उत्तरी अमेरिका पर मजबूत। ओपन फ़ीड पर 3-घंटे का अंतराल।</string>
+    <string name="settings_forecasters_arpege">ARPEGE</string>
+    <string name="settings_forecasters_arpege_subtitle">फ्रांसीसी (Météo-France) — फ्रांस और पश्चिमी यूरोप पर मजबूत। नेटिव प्रति घंटा।</string>
+    <string name="settings_forecasters_ukmo">UKMO</string>
+    <string name="settings_forecasters_ukmo_subtitle">ब्रिटिश (UK Met Office) — ऐतिहासिक रूप से ECMWF के बाद। ओपन फ़ीड पर 3-घंटे का अंतराल।</string>
+    <string name="settings_forecasters_jma">JMA</string>
+    <string name="settings_forecasters_jma_subtitle">जापानी — एशिया-प्रशांत पर मजबूत। ओपन फ़ीड पर 3 से 6 घंटे का अंतराल।</string>
+    <string name="settings_forecasters_bom">BOM</string>
+    <string name="settings_forecasters_bom_subtitle">ऑस्ट्रेलियाई — रखरखाव के तहत, जल्द से जल्द लौट आएगा।</string>
 </resources>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -260,9 +260,9 @@ to values/strings.xml (English).
     <string name="settings_root_schedule_subtitle">Notifikasi dan Waktu</string>
     <string name="settings_root_clothes_subtitle">Suhu dan Pakaian</string>
     <string name="settings_root_region_subtitle">Bahasa dan Satuan</string>
-    <string name="settings_root_voice_subtitle">Penyedia dan Aksen</string>
+    <string name="settings_root_voice_subtitle">Suara dan Aksen</string>
     <string name="settings_root_display_subtitle">Tema dan warna</string>
-    <string name="settings_root_location_subtitle">Deteksi otomatis atau pilih kota</string>
+    <string name="settings_root_location_subtitle">Lokasi Otomatis dan Manual</string>
     <string name="settings_root_calendar_subtitle">Acara hari ini</string>
     <string name="settings_root_privacy_subtitle">Laporan crash + penggunaan</string>
 
@@ -596,4 +596,55 @@ to values/strings.xml (English).
     <string name="today_uv_peak">Puncak %1$d pukul %2$s</string>
     <string name="today_uv_title">Indeks UV</string>
     <string name="today_wind_peak">Puncak %1$d %2$s pukul %3$s</string>
+
+    <!-- Today screen pager. -->
+    <string name="today_view_other_period">Lihat prakiraan lain</string>
+    <string name="today_back_to_primary">Kembali</string>
+    <string name="today_placeholder_today_title">Prakiraan hari ini</string>
+    <string name="today_placeholder_tonight_title">Prakiraan malam ini</string>
+    <string name="today_placeholder_body">Akan siap sekitar pukul %1$s.</string>
+
+    <!-- Settings root — Forecasters row. -->
+    <string name="settings_root_forecasters">Prakiraan</string>
+    <string name="settings_root_forecasters_subtitle">Sumber dan Model Cuaca</string>
+
+    <!-- About — Open-Meteo attribution (brand stays Latin). -->
+    <string name="settings_about_open_meteo">Data cuaca dari Open-Meteo</string>
+
+    <!-- Display — per-garment colour picker. -->
+    <string name="settings_display_garment_colors_title">Warna pakaian</string>
+    <string name="settings_display_garment_colors_description">Pilih warna untuk setiap ikon pakaian yang ditampilkan di Hari Ini, widget layar utama, dan notifikasi. Garis tepi otomatis menjadi lebih gelap.</string>
+    <string name="settings_garment_color_default">Default</string>
+    <string name="settings_garment_color_picker_title">Pilih warna</string>
+    <string name="settings_garment_color_swatch_description">Sampel warna %1$s</string>
+    <string name="settings_garment_color_default_swatch_description">Setel ulang %1$s ke warna default</string>
+    <string name="settings_garment_color_dialog_close">Tutup</string>
+
+    <!-- Update banner — Downloading state. -->
+    <string name="today_update_downloading_body">Mengunduh pembaruan…</string>
+    <string name="today_update_downloading_action">Memperbarui</string>
+    <string name="today_update_downloading_dismiss">Batal</string>
+
+    <!-- Forecasters sub-page — picker of NWP models. -->
+    <string name="settings_forecasters_title">Model prakiraan</string>
+    <string name="settings_forecasters_description">Indikator kepercayaan dan diagram per model mengambil data dari model-model ini. Memilih lebih banyak memberi sebaran yang lebih luas; lebih sedikit berarti fokus yang lebih sempit. Minimal dua tetap dipilih.</string>
+    <string name="settings_forecasters_auto_title">Otomatis (terbaik untuk lokasi Anda)</string>
+    <string name="settings_forecasters_auto_subtitle">Memilih prakiraan regional secara otomatis — UKMO di Kepulauan Inggris, JMA di Jepang, GFS + GEM di Amerika Utara, dsb. Matikan untuk memilih model sendiri.</string>
+    <string name="settings_forecasters_cap_hint">Anda memilih %1$d model — batas maksimum agar diagram tetap mudah dibaca. Hapus pilihan satu untuk menambahkan model lain.</string>
+    <string name="settings_forecasters_ecmwf">ECMWF</string>
+    <string name="settings_forecasters_ecmwf_subtitle">Eropa — umumnya model global paling akurat. Tiap 3 jam pada open feed.</string>
+    <string name="settings_forecasters_icon">ICON</string>
+    <string name="settings_forecasters_icon_subtitle">Jerman (DWD) — kuat di Eropa dan jangka pendek. Native per jam.</string>
+    <string name="settings_forecasters_gfs">GFS</string>
+    <string name="settings_forecasters_gfs_subtitle">Amerika (NOAA) — kuat di Amerika Utara. Native per jam.</string>
+    <string name="settings_forecasters_gem">GEM</string>
+    <string name="settings_forecasters_gem_subtitle">Kanada (ECCC) — kuat di Amerika Utara. Tiap 3 jam pada open feed.</string>
+    <string name="settings_forecasters_arpege">ARPEGE</string>
+    <string name="settings_forecasters_arpege_subtitle">Prancis (Météo-France) — kuat di Prancis dan Eropa Barat. Native per jam.</string>
+    <string name="settings_forecasters_ukmo">UKMO</string>
+    <string name="settings_forecasters_ukmo_subtitle">Inggris (UK Met Office) — secara historis hanya kalah dari ECMWF. Tiap 3 jam pada open feed.</string>
+    <string name="settings_forecasters_jma">JMA</string>
+    <string name="settings_forecasters_jma_subtitle">Jepang — kuat di Asia-Pasifik. Tiap 3 sampai 6 jam pada open feed.</string>
+    <string name="settings_forecasters_bom">BOM</string>
+    <string name="settings_forecasters_bom_subtitle">Australia — sedang dalam pemeliharaan, akan kembali secepatnya.</string>
 </resources>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -259,7 +259,7 @@ vs "kemungkinan", "padam" vs "hapus").
     <string name="settings_root_schedule_subtitle">Pemberitahuan dan Masa</string>
     <string name="settings_root_clothes_subtitle">Suhu dan Pakaian</string>
     <string name="settings_root_region_subtitle">Bahasa dan Unit</string>
-    <string name="settings_root_voice_subtitle">Pembekal dan Loghat</string>
+    <string name="settings_root_voice_subtitle">Suara dan Loghat</string>
     <string name="settings_root_display_subtitle">Tema dan warna</string>
 
     <!-- Display settings -->
@@ -269,7 +269,7 @@ vs "kemungkinan", "padam" vs "hapus").
     <string name="settings_display_theme_dark">Gelap</string>
 
     <!-- Location settings subtitles -->
-    <string name="settings_root_location_subtitle">Pengesan automatik atau pilih bandar</string>
+    <string name="settings_root_location_subtitle">Lokasi Automatik dan Manual</string>
     <string name="settings_root_calendar_subtitle">Acara hari ini</string>
     <string name="settings_root_privacy_subtitle">Laporan ranap + penggunaan</string>
 
@@ -602,4 +602,55 @@ vs "kemungkinan", "padam" vs "hapus").
     <string name="today_uv_peak">Puncak %1$d pukul %2$s</string>
     <string name="today_uv_title">Indeks UV</string>
     <string name="today_wind_peak">Puncak %1$d %2$s pukul %3$s</string>
+
+    <!-- Today screen pager. -->
+    <string name="today_view_other_period">Lihat ramalan lain</string>
+    <string name="today_back_to_primary">Kembali</string>
+    <string name="today_placeholder_today_title">Ramalan hari ini</string>
+    <string name="today_placeholder_tonight_title">Ramalan malam ini</string>
+    <string name="today_placeholder_body">Akan siap sekitar pukul %1$s.</string>
+
+    <!-- Settings root — Forecasters row. -->
+    <string name="settings_root_forecasters">Peramal cuaca</string>
+    <string name="settings_root_forecasters_subtitle">Sumber dan Model Cuaca</string>
+
+    <!-- About — Open-Meteo attribution (brand stays Latin). -->
+    <string name="settings_about_open_meteo">Data cuaca daripada Open-Meteo</string>
+
+    <!-- Display — per-garment colour picker. -->
+    <string name="settings_display_garment_colors_title">Warna pakaian</string>
+    <string name="settings_display_garment_colors_description">Pilih warna untuk setiap ikon pakaian yang dipaparkan di Hari Ini, widget skrin utama dan pemberitahuan. Garis luar akan menjadi lebih gelap secara automatik.</string>
+    <string name="settings_garment_color_default">Lalai</string>
+    <string name="settings_garment_color_picker_title">Pilih warna</string>
+    <string name="settings_garment_color_swatch_description">Sampel warna %1$s</string>
+    <string name="settings_garment_color_default_swatch_description">Tetapkan semula %1$s kepada warna lalai</string>
+    <string name="settings_garment_color_dialog_close">Tutup</string>
+
+    <!-- Update banner — Downloading state. -->
+    <string name="today_update_downloading_body">Memuat turun kemaskini…</string>
+    <string name="today_update_downloading_action">Mengemaskini</string>
+    <string name="today_update_downloading_dismiss">Batal</string>
+
+    <!-- Forecasters sub-page — picker of NWP models. -->
+    <string name="settings_forecasters_title">Model ramalan</string>
+    <string name="settings_forecasters_description">Cip keyakinan dan carta setiap model mengambil data daripada model-model ini. Memilih lebih banyak memberi taburan yang lebih luas; lebih sedikit memberi tumpuan yang lebih sempit. Sekurang-kurangnya dua kekal dipilih.</string>
+    <string name="settings_forecasters_auto_title">Auto (terbaik untuk lokasi anda)</string>
+    <string name="settings_forecasters_auto_subtitle">Memilih peramal cuaca serantau secara automatik — UKMO di Kepulauan British, JMA di Jepun, GFS + GEM di Amerika Utara, dll. Matikan untuk memilih model sendiri.</string>
+    <string name="settings_forecasters_cap_hint">Anda memilih %1$d model — had maksimum supaya carta kekal boleh dibaca. Nyahpilih satu untuk menambah model lain.</string>
+    <string name="settings_forecasters_ecmwf">ECMWF</string>
+    <string name="settings_forecasters_ecmwf_subtitle">Eropah — secara amnya model global paling tepat. Setiap 3 jam pada suapan terbuka.</string>
+    <string name="settings_forecasters_icon">ICON</string>
+    <string name="settings_forecasters_icon_subtitle">Jerman (DWD) — kuat di Eropah dan jangka pendek. Asli setiap jam.</string>
+    <string name="settings_forecasters_gfs">GFS</string>
+    <string name="settings_forecasters_gfs_subtitle">Amerika (NOAA) — kuat di Amerika Utara. Asli setiap jam.</string>
+    <string name="settings_forecasters_gem">GEM</string>
+    <string name="settings_forecasters_gem_subtitle">Kanada (ECCC) — kuat di Amerika Utara. Setiap 3 jam pada suapan terbuka.</string>
+    <string name="settings_forecasters_arpege">ARPEGE</string>
+    <string name="settings_forecasters_arpege_subtitle">Perancis (Météo-France) — kuat di Perancis dan Eropah Barat. Asli setiap jam.</string>
+    <string name="settings_forecasters_ukmo">UKMO</string>
+    <string name="settings_forecasters_ukmo_subtitle">British (UK Met Office) — sejarahnya hanya selepas ECMWF. Setiap 3 jam pada suapan terbuka.</string>
+    <string name="settings_forecasters_jma">JMA</string>
+    <string name="settings_forecasters_jma_subtitle">Jepun — kuat di Asia-Pasifik. Setiap 3 hingga 6 jam pada suapan terbuka.</string>
+    <string name="settings_forecasters_bom">BOM</string>
+    <string name="settings_forecasters_bom_subtitle">Australia — dalam penyelenggaraan, akan kembali secepat mungkin.</string>
 </resources>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -263,9 +263,9 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="settings_root_schedule_subtitle">การแจ้งเตือนและเวลา</string>
     <string name="settings_root_clothes_subtitle">อุณหภูมิและชุดแต่งกาย</string>
     <string name="settings_root_region_subtitle">ภาษาและหน่วย</string>
-    <string name="settings_root_voice_subtitle">ผู้ให้บริการและสำเนียง</string>
+    <string name="settings_root_voice_subtitle">เสียงและสำเนียง</string>
     <string name="settings_root_display_subtitle">ธีมและสี</string>
-    <string name="settings_root_location_subtitle">ตรวจจับอัตโนมัติหรือเลือกเมือง</string>
+    <string name="settings_root_location_subtitle">ตำแหน่งอัตโนมัติและด้วยตนเอง</string>
     <string name="settings_root_calendar_subtitle">กิจกรรมวันนี้</string>
     <string name="settings_root_privacy_subtitle">รายงานข้อขัดข้องและการใช้งาน</string>
 
@@ -596,4 +596,55 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="today_uv_peak">สูงสุด %1$d เวลา %2$s</string>
     <string name="today_uv_title">ดัชนี UV</string>
     <string name="today_wind_peak">สูงสุด %1$d %2$s เวลา %3$s</string>
+
+    <!-- Today screen pager. -->
+    <string name="today_view_other_period">ดูพยากรณ์อื่น</string>
+    <string name="today_back_to_primary">กลับ</string>
+    <string name="today_placeholder_today_title">พยากรณ์วันนี้</string>
+    <string name="today_placeholder_tonight_title">พยากรณ์คืนนี้</string>
+    <string name="today_placeholder_body">จะพร้อมประมาณ %1$s</string>
+
+    <!-- Settings root — Forecasters row. -->
+    <string name="settings_root_forecasters">ผู้พยากรณ์</string>
+    <string name="settings_root_forecasters_subtitle">แหล่งข้อมูลและแบบจำลองสภาพอากาศ</string>
+
+    <!-- About — Open-Meteo attribution (brand stays Latin). -->
+    <string name="settings_about_open_meteo">ข้อมูลสภาพอากาศจาก Open-Meteo</string>
+
+    <!-- Display — per-garment colour picker. -->
+    <string name="settings_display_garment_colors_title">สีของเสื้อผ้า</string>
+    <string name="settings_display_garment_colors_description">เลือกสีให้ไอคอนเสื้อผ้าแต่ละชิ้นที่แสดงในหน้าวันนี้ วิดเจ็ตหน้าจอหลัก และการแจ้งเตือน เส้นขอบจะเข้มขึ้นโดยอัตโนมัติ</string>
+    <string name="settings_garment_color_default">ค่าเริ่มต้น</string>
+    <string name="settings_garment_color_picker_title">เลือกสี</string>
+    <string name="settings_garment_color_swatch_description">ตัวอย่างสี %1$s</string>
+    <string name="settings_garment_color_default_swatch_description">รีเซ็ต %1$s เป็นสีเริ่มต้น</string>
+    <string name="settings_garment_color_dialog_close">ปิด</string>
+
+    <!-- Update banner — Downloading state. -->
+    <string name="today_update_downloading_body">กำลังดาวน์โหลดอัปเดต…</string>
+    <string name="today_update_downloading_action">กำลังอัปเดต</string>
+    <string name="today_update_downloading_dismiss">ยกเลิก</string>
+
+    <!-- Forecasters sub-page — picker of NWP models. -->
+    <string name="settings_forecasters_title">แบบจำลองพยากรณ์</string>
+    <string name="settings_forecasters_description">ป้ายความเชื่อมั่นและแผนภูมิตามแบบจำลองดึงข้อมูลจากแบบจำลองเหล่านี้ เลือกเพิ่มเพื่อให้ขอบเขตกว้างขึ้น เลือกน้อยลงเพื่อโฟกัสมากขึ้น อย่างน้อยสองตัวจะถูกเลือกอยู่เสมอ</string>
+    <string name="settings_forecasters_auto_title">อัตโนมัติ (เหมาะสมที่สุดสำหรับตำแหน่งของคุณ)</string>
+    <string name="settings_forecasters_auto_subtitle">เลือกแบบจำลองพยากรณ์ระดับภูมิภาคโดยอัตโนมัติ — UKMO ในหมู่เกาะอังกฤษ JMA ในญี่ปุ่น GFS + GEM ในอเมริกาเหนือ ฯลฯ ปิดเพื่อเลือกแบบจำลองด้วยตนเอง</string>
+    <string name="settings_forecasters_cap_hint">คุณเลือก %1$d แบบจำลอง — สูงสุดที่แผนภูมิยังคงอ่านง่าย ยกเลิกการเลือกหนึ่งตัวเพื่อเพิ่มแบบจำลองอื่น</string>
+    <string name="settings_forecasters_ecmwf">ECMWF</string>
+    <string name="settings_forecasters_ecmwf_subtitle">ยุโรป — โดยทั่วไปแม่นยำที่สุดในระดับโลก ฟีดเปิด 3 ชั่วโมงต่อครั้ง</string>
+    <string name="settings_forecasters_icon">ICON</string>
+    <string name="settings_forecasters_icon_subtitle">เยอรมัน (DWD) — แม่นยำในยุโรปและพยากรณ์ระยะสั้น เนทีฟทุกชั่วโมง</string>
+    <string name="settings_forecasters_gfs">GFS</string>
+    <string name="settings_forecasters_gfs_subtitle">อเมริกัน (NOAA) — แม่นยำในอเมริกาเหนือ เนทีฟทุกชั่วโมง</string>
+    <string name="settings_forecasters_gem">GEM</string>
+    <string name="settings_forecasters_gem_subtitle">แคนาดา (ECCC) — แม่นยำในอเมริกาเหนือ ฟีดเปิด 3 ชั่วโมงต่อครั้ง</string>
+    <string name="settings_forecasters_arpege">ARPEGE</string>
+    <string name="settings_forecasters_arpege_subtitle">ฝรั่งเศส (Météo-France) — แม่นยำในฝรั่งเศสและยุโรปตะวันตก เนทีฟทุกชั่วโมง</string>
+    <string name="settings_forecasters_ukmo">UKMO</string>
+    <string name="settings_forecasters_ukmo_subtitle">อังกฤษ (UK Met Office) — ในอดีตเป็นอันดับสองรองจาก ECMWF ฟีดเปิด 3 ชั่วโมงต่อครั้ง</string>
+    <string name="settings_forecasters_jma">JMA</string>
+    <string name="settings_forecasters_jma_subtitle">ญี่ปุ่น — แม่นยำในเอเชีย-แปซิฟิก ฟีดเปิด 3 ถึง 6 ชั่วโมงต่อครั้ง</string>
+    <string name="settings_forecasters_bom">BOM</string>
+    <string name="settings_forecasters_bom_subtitle">ออสเตรเลีย — อยู่ระหว่างการบำรุงรักษา กลับมาให้บริการโดยเร็วที่สุด</string>
 </resources>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -272,9 +272,9 @@ Skipped intentionally: app_name (brand), insight_time_am/pm/midnight/noon
     <string name="settings_root_schedule_subtitle">Thông báo và giờ</string>
     <string name="settings_root_clothes_subtitle">Nhiệt độ và trang phục</string>
     <string name="settings_root_region_subtitle">Ngôn ngữ và đơn vị</string>
-    <string name="settings_root_voice_subtitle">Nhà cung cấp và giọng</string>
+    <string name="settings_root_voice_subtitle">Giọng nói và Chất giọng</string>
     <string name="settings_root_display_subtitle">Giao diện và màu sắc</string>
-    <string name="settings_root_location_subtitle">Tự động phát hiện hoặc chọn thành phố</string>
+    <string name="settings_root_location_subtitle">Vị trí tự động và thủ công</string>
     <string name="settings_root_calendar_subtitle">Sự kiện hôm nay</string>
     <string name="settings_root_privacy_subtitle">Báo cáo sự cố + sử dụng</string>
 
@@ -657,4 +657,55 @@ Skipped intentionally: app_name (brand), insight_time_am/pm/midnight/noon
     <string name="today_uv_peak">Đỉnh %1$d lúc %2$s</string>
     <string name="today_uv_title">Chỉ số UV</string>
     <string name="today_wind_peak">Đỉnh %1$d %2$s lúc %3$s</string>
+
+    <!-- Today screen pager. -->
+    <string name="today_view_other_period">Xem dự báo khác</string>
+    <string name="today_back_to_primary">Quay lại</string>
+    <string name="today_placeholder_today_title">Dự báo hôm nay</string>
+    <string name="today_placeholder_tonight_title">Dự báo tối nay</string>
+    <string name="today_placeholder_body">Sẽ sẵn sàng vào khoảng %1$s.</string>
+
+    <!-- Settings root — Forecasters row. -->
+    <string name="settings_root_forecasters">Nguồn dự báo</string>
+    <string name="settings_root_forecasters_subtitle">Nguồn và mô hình thời tiết</string>
+
+    <!-- About — Open-Meteo attribution (brand stays Latin). -->
+    <string name="settings_about_open_meteo">Dữ liệu thời tiết từ Open-Meteo</string>
+
+    <!-- Display — per-garment colour picker. -->
+    <string name="settings_display_garment_colors_title">Màu trang phục</string>
+    <string name="settings_display_garment_colors_description">Chọn màu cho từng biểu tượng trang phục hiển thị trên Hôm nay, tiện ích màn hình chính và thông báo. Đường viền tự động đậm hơn.</string>
+    <string name="settings_garment_color_default">Mặc định</string>
+    <string name="settings_garment_color_picker_title">Chọn màu</string>
+    <string name="settings_garment_color_swatch_description">Mẫu màu %1$s</string>
+    <string name="settings_garment_color_default_swatch_description">Đặt lại %1$s về màu mặc định</string>
+    <string name="settings_garment_color_dialog_close">Đóng</string>
+
+    <!-- Update banner — Downloading state. -->
+    <string name="today_update_downloading_body">Đang tải xuống bản cập nhật…</string>
+    <string name="today_update_downloading_action">Đang cập nhật</string>
+    <string name="today_update_downloading_dismiss">Huỷ</string>
+
+    <!-- Forecasters sub-page — picker of NWP models. -->
+    <string name="settings_forecasters_title">Mô hình dự báo</string>
+    <string name="settings_forecasters_description">Chỉ báo độ tin cậy và biểu đồ theo mô hình lấy dữ liệu từ các mô hình này. Chọn nhiều hơn cho phổ rộng hơn; chọn ít hơn cho tiêu điểm hẹp hơn. Tối thiểu hai mô hình luôn được chọn.</string>
+    <string name="settings_forecasters_auto_title">Tự động (tốt nhất cho vị trí của bạn)</string>
+    <string name="settings_forecasters_auto_subtitle">Tự động chọn nguồn dự báo theo khu vực — UKMO ở Quần đảo Anh, JMA ở Nhật Bản, GFS + GEM ở Bắc Mỹ, v.v. Tắt để tự chọn mô hình.</string>
+    <string name="settings_forecasters_cap_hint">Bạn đã chọn %1$d mô hình — mức tối đa để biểu đồ vẫn dễ đọc. Bỏ chọn một để thêm mô hình khác.</string>
+    <string name="settings_forecasters_ecmwf">ECMWF</string>
+    <string name="settings_forecasters_ecmwf_subtitle">Châu Âu — thường là mô hình toàn cầu chính xác nhất. Cập nhật 3 giờ một lần trên nguồn mở.</string>
+    <string name="settings_forecasters_icon">ICON</string>
+    <string name="settings_forecasters_icon_subtitle">Đức (DWD) — mạnh ở châu Âu và dự báo ngắn hạn. Gốc theo giờ.</string>
+    <string name="settings_forecasters_gfs">GFS</string>
+    <string name="settings_forecasters_gfs_subtitle">Mỹ (NOAA) — mạnh ở Bắc Mỹ. Gốc theo giờ.</string>
+    <string name="settings_forecasters_gem">GEM</string>
+    <string name="settings_forecasters_gem_subtitle">Canada (ECCC) — mạnh ở Bắc Mỹ. Cập nhật 3 giờ một lần trên nguồn mở.</string>
+    <string name="settings_forecasters_arpege">ARPEGE</string>
+    <string name="settings_forecasters_arpege_subtitle">Pháp (Météo-France) — mạnh ở Pháp và Tây Âu. Gốc theo giờ.</string>
+    <string name="settings_forecasters_ukmo">UKMO</string>
+    <string name="settings_forecasters_ukmo_subtitle">Anh (UK Met Office) — trong lịch sử chỉ đứng sau ECMWF. Cập nhật 3 giờ một lần trên nguồn mở.</string>
+    <string name="settings_forecasters_jma">JMA</string>
+    <string name="settings_forecasters_jma_subtitle">Nhật Bản — mạnh ở châu Á – Thái Bình Dương. Cập nhật 3 đến 6 giờ một lần trên nguồn mở.</string>
+    <string name="settings_forecasters_bom">BOM</string>
+    <string name="settings_forecasters_bom_subtitle">Úc — đang bảo trì, sẽ trở lại sớm nhất có thể.</string>
 </resources>


### PR DESCRIPTION
## Summary

Follow-up to #496 covering the remaining Asian locales — **Bengali (bn), Hindi (hi), Filipino (fil), Indonesian (in), Malay (ms), Thai (th), Vietnamese (vi)**. Same 39 missing keys filled in per locale, same 2 stale entries refreshed against the current English source.

### Missing strings now translated

- **Today screen pager** (7e377aa): `today_view_other_period`, `today_back_to_primary`, `today_placeholder_today_title`, `today_placeholder_tonight_title`, `today_placeholder_body`.
- **Update banner** (dfac7ee): `today_update_downloading_body` / `_action` / `_dismiss`.
- **Settings root** (2aec6a8 + c798999): `settings_root_forecasters` + subtitle.
- **Display ▸ Garment colours** (eab5e10): `settings_display_garment_colors_title`, `_description`, and the five `settings_garment_color_*` picker labels.
- **About ▸ Open-Meteo attribution** (3bb6f40): `settings_about_open_meteo`. "Open-Meteo" stays Latin in every locale per the existing convention.
- **Forecasters sub-page** (2aec6a8 / 20f180c / d4f633c / 6404264): all 18 `settings_forecasters_*` strings — title / description / Auto pair / cap_hint / 8 model labels and subtitles including the BOM-under-maintenance copy.

### Stale strings refreshed

- `settings_root_voice_subtitle`: "Providers and Accents" → "Voices and Accents" (per c798999).
- `settings_root_location_subtitle`: "Auto-detect or pick a city" → "Automatic and Manual Location".

### Left unchanged on purpose

- `app_name` and the en-only `insight_time_{am,pm,midnight,noon}{,_minutes}` spoken-time formatter helpers stay unoverridden, matching the comment at the top of each locale file.

Stylistic choices follow each file's existing register: hi keeps आप-form and Devanagari danda where natural; bn uses formal-polite ফিরুন / বেছে নিন register; fil keeps the existing `I-update` / `Magdagdag` action-prefix convention; in/ms preserve their respective vocabulary swaps (`Memperbarui` vs `Mengemaskini`, `Default` vs `Lalai`, `pemberitahuan` vs `notifikasi`); th keeps existing punctuation conventions; vi keeps the existing `Cập nhật` / `Quay lại` register.

## Privacy

No change to what leaves the device — translation-only PR.

## Test plan

- [x] All seven `values-{bn,hi,fil,in,ms,th,vi}/strings.xml` parse as XML.
- [x] `:app:assembleDebug` succeeds locally (3m31s).
- [x] `:app:testDebugUnitTest` succeeds locally.
- [ ] Wait for CI on JVM unit tests + Android debug build.

Related stack:
- https://github.com/mikelward/clothescast/pull/496 (merged — CJK)

https://claude.ai/code/session_01HudkthroW1Au13D3NqWfNS

---
_Generated by [Claude Code](https://claude.ai/code/session_01HudkthroW1Au13D3NqWfNS)_