### PR TITLE
Translate the forecasters picker, garment-colour picker, and update-downloading banner for Turkish, Arabic, Persian, Hebrew, Amharic, and Swahili

### DIFF
--- a/app/src/main/res/values-am/strings.xml
+++ b/app/src/main/res/values-am/strings.xml
@@ -568,4 +568,55 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="settings_tts_voice_locale_ar_eg">አረብኛ (ግብጽ)</string>
     <string name="settings_region_language_ar_ma">አረብኛ (ሞሮኮ)</string>
     <string name="settings_tts_voice_locale_ar_ma">አረብኛ (ሞሮኮ)</string>
+
+    <!-- Strings added to match base — forecasters picker, garment-colour picker,
+         update-downloading banner, placeholder cards, Open-Meteo credit, + debug screen. -->
+    <string name="today_update_downloading_body">ዝመና በመውረድ ላይ…</string>
+    <string name="today_update_downloading_action">በመዘመን ላይ</string>
+    <string name="today_update_downloading_dismiss">ሰርዝ</string>
+    <string name="today_view_other_period">ሌላ ትንበያ ይመልከቱ</string>
+    <string name="today_back_to_primary">ተመለስ</string>
+    <string name="today_placeholder_today_title">የዛሬ ትንበያ</string>
+    <string name="today_placeholder_tonight_title">የዛሬ ምሽት ትንበያ</string>
+    <string name="today_placeholder_body">በ %1$s አካባቢ ዝግጁ ይሆናል።</string>
+
+    <string name="settings_root_forecasters">የትንበያ ሞዴሎች</string>
+    <string name="settings_root_forecasters_subtitle">የአየር ሁኔታ ምንጮችና ሞዴሎች</string>
+
+    <string name="settings_display_garment_colors_title">የልብስ ቀለሞች</string>
+    <string name="settings_display_garment_colors_description">በዛሬ ማያ፣ በመነሻ ማያ ዊጅት እና በማሳወቂያዎች ላይ ለሚታይ ለእያንዳንዱ የልብስ አዶ ቀለም ይምረጡ። የጠርዙ ቀለም በራሱ ይጠቁራል።</string>
+    <string name="settings_garment_color_default">ነባሪ</string>
+    <string name="settings_garment_color_picker_title">ቀለም ይምረጡ</string>
+    <string name="settings_garment_color_swatch_description">የቀለም ናሙና %1$s</string>
+    <string name="settings_garment_color_default_swatch_description">%1$s ን ወደ ነባሪ ቀለም ይመልሱ</string>
+    <string name="settings_garment_color_dialog_close">ዝጋ</string>
+
+    <string name="settings_forecasters_title">የትንበያ ሞዴሎች</string>
+    <string name="settings_forecasters_description">የእምነት ምልክቱና በሞዴል የተከፋፈለው ቻርት ከእነዚህ ሞዴሎች ይነሳሉ። ብዙ መምረጥ ሰፊ ድርሻ ይሰጣል፤ ጥቂት መምረጥ ትኩረት ያጠብባል። ቢያንስ ሁለት ሞዴሎች ሁልጊዜ ተመርጠው ይቆያሉ።</string>
+    <string name="settings_forecasters_auto_title">ራስ-ሰር (ለቦታዎ ምርጥ)</string>
+    <string name="settings_forecasters_auto_subtitle">የክልል ትንበያ ሞዴሉን በራሱ ይመርጣል — በብሪታኒያ ደሴቶች UKMO፣ በጃፓን JMA፣ በሰሜን አሜሪካ GFS + GEM ወዘተ። ሞዴሎቹን በራስዎ ለመምረጥ ካስፈለገ ያጥፉ።</string>
+    <string name="settings_forecasters_cap_hint">%1$d ሞዴሎችን መርጠዋል — ቻርቱ ለማንበብ የሚቀልበት ከፍተኛ ቁጥር። ሌላ ሞዴል ለመጨመር አንዱን ምርጫ ይሰርዙ።</string>
+    <string name="settings_forecasters_ecmwf">ECMWF</string>
+    <string name="settings_forecasters_ecmwf_subtitle">አውሮፓዊ — በአጠቃላይ በጣም ትክክለኛው ዓለም አቀፍ ሞዴል። በክፍት ምግብ በሰዓታት ሶስት።</string>
+    <string name="settings_forecasters_icon">ICON</string>
+    <string name="settings_forecasters_icon_subtitle">ጀርመናዊ (DWD) — በአውሮፓ እና በአጭር ጊዜ ጠንካራ። የራሱ ሰዓታዊ።</string>
+    <string name="settings_forecasters_gfs">GFS</string>
+    <string name="settings_forecasters_gfs_subtitle">አሜሪካዊ (NOAA) — በሰሜን አሜሪካ ጠንካራ። የራሱ ሰዓታዊ።</string>
+    <string name="settings_forecasters_gem">GEM</string>
+    <string name="settings_forecasters_gem_subtitle">ካናዳዊ (ECCC) — በሰሜን አሜሪካ ጠንካራ። በክፍት ምግብ በሰዓታት ሶስት።</string>
+    <string name="settings_forecasters_arpege">ARPEGE</string>
+    <string name="settings_forecasters_arpege_subtitle">ፈረንሳዊ (Météo-France) — በፈረንሳይና በምዕራብ አውሮፓ ጠንካራ። የራሱ ሰዓታዊ።</string>
+    <string name="settings_forecasters_ukmo">UKMO</string>
+    <string name="settings_forecasters_ukmo_subtitle">ብሪታኒያዊ (UK Met Office) — በታሪክ ከ ECMWF በቀር ሁለተኛ። በክፍት ምግብ በሰዓታት ሶስት።</string>
+    <string name="settings_forecasters_jma">JMA</string>
+    <string name="settings_forecasters_jma_subtitle">ጃፓናዊ — በእስያ-ፓሲፊክ ጠንካራ። በክፍት ምግብ በሰዓታት ሶስት እስከ ስድስት።</string>
+    <string name="settings_forecasters_bom">BOM</string>
+    <string name="settings_forecasters_bom_subtitle">አውስትራሊያዊ — በጥገና ላይ፣ በተቻለ ፍጥነት ይመለሳል።</string>
+
+    <string name="settings_about_open_meteo">የአየር ሁኔታ ውሂብ በ Open-Meteo</string>
+
+    <string name="settings_debug_title">ማረሚያ (የልማት ግንባታ ብቻ)</string>
+    <string name="settings_debug_description">ዕለታዊውን የClothesCast ሂደት ወዲያው ያስነሳል። የተያዘውን ጊዜ ሳይጠብቅ ለማረጋገጥ ይጠቅማል።</string>
+    <string name="settings_debug_fire_now">ClothesCast አሁን አስኪድ</string>
+    <string name="settings_debug_fire_toast">የClothesCast ሠራተኛ በወረፋ ተቀመጠ</string>
 </resources>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -595,4 +595,55 @@ they work correctly in both the single-band and range templates.
     <string name="settings_region_language_ar_ae">العربية (الإمارات العربية المتحدة)</string>
     <string name="settings_region_language_ar_eg">العربية (مصر)</string>
     <string name="settings_region_language_ar_ma">العربية (المغرب)</string>
+
+    <!-- Strings added to match base — forecasters picker, garment-colour picker,
+         update-downloading banner, placeholder cards, Open-Meteo credit, + debug screen. -->
+    <string name="today_update_downloading_body">جارٍ تنزيل التحديث…</string>
+    <string name="today_update_downloading_action">جارٍ التحديث</string>
+    <string name="today_update_downloading_dismiss">إلغاء</string>
+    <string name="today_view_other_period">عرض توقعات أخرى</string>
+    <string name="today_back_to_primary">رجوع</string>
+    <string name="today_placeholder_today_title">توقعات اليوم</string>
+    <string name="today_placeholder_tonight_title">توقعات الليلة</string>
+    <string name="today_placeholder_body">ستكون جاهزة حوالي %1$s.</string>
+
+    <string name="settings_root_forecasters">نماذج التنبؤ</string>
+    <string name="settings_root_forecasters_subtitle">مصادر الطقس والنماذج</string>
+
+    <string name="settings_display_garment_colors_title">ألوان الملابس</string>
+    <string name="settings_display_garment_colors_description">اختر لونًا لكل أيقونة ملابس تظهر في شاشة اليوم وفي أداة الشاشة الرئيسية والإشعارات. يصبح الحد الخارجي أغمق تلقائيًا.</string>
+    <string name="settings_garment_color_default">افتراضي</string>
+    <string name="settings_garment_color_picker_title">اختر لونًا</string>
+    <string name="settings_garment_color_swatch_description">عينة لون %1$s</string>
+    <string name="settings_garment_color_default_swatch_description">إعادة تعيين %1$s إلى اللون الافتراضي</string>
+    <string name="settings_garment_color_dialog_close">إغلاق</string>
+
+    <string name="settings_forecasters_title">نماذج التنبؤ</string>
+    <string name="settings_forecasters_description">يعتمد مؤشر الثقة والرسم البياني لكل نموذج على هذه النماذج. اختيار عدد أكبر يمنح تشتتًا أوسع؛ وعدد أقل يمنح تركيزًا أضيق. يظل نموذجان مختاران على الأقل في كل الأحوال.</string>
+    <string name="settings_forecasters_auto_title">تلقائي (الأفضل لموقعك)</string>
+    <string name="settings_forecasters_auto_subtitle">يختار نموذج التنبؤ الإقليمي تلقائيًا — UKMO في الجزر البريطانية، وJMA في اليابان، وGFS مع GEM في أمريكا الشمالية، وهكذا. أوقف هذا لاختيار النماذج بنفسك.</string>
+    <string name="settings_forecasters_cap_hint">اخترت %1$d نماذج — الحد الأقصى الذي يظل عنده الرسم البياني واضحًا. ألغِ اختيار أحدها لإضافة نموذج مختلف.</string>
+    <string name="settings_forecasters_ecmwf">ECMWF</string>
+    <string name="settings_forecasters_ecmwf_subtitle">أوروبي — يُعد عمومًا النموذج العالمي الأدق. كل ثلاث ساعات على البيانات المفتوحة.</string>
+    <string name="settings_forecasters_icon">ICON</string>
+    <string name="settings_forecasters_icon_subtitle">ألماني (DWD) — قوي في أوروبا وعلى المدى القصير. ساعي أصلي.</string>
+    <string name="settings_forecasters_gfs">GFS</string>
+    <string name="settings_forecasters_gfs_subtitle">أمريكي (NOAA) — قوي فوق أمريكا الشمالية. ساعي أصلي.</string>
+    <string name="settings_forecasters_gem">GEM</string>
+    <string name="settings_forecasters_gem_subtitle">كندي (ECCC) — قوي فوق أمريكا الشمالية. كل ثلاث ساعات على البيانات المفتوحة.</string>
+    <string name="settings_forecasters_arpege">ARPEGE</string>
+    <string name="settings_forecasters_arpege_subtitle">فرنسي (Météo-France) — قوي فوق فرنسا وأوروبا الغربية. ساعي أصلي.</string>
+    <string name="settings_forecasters_ukmo">UKMO</string>
+    <string name="settings_forecasters_ukmo_subtitle">بريطاني (UK Met Office) — تاريخيًا الثاني بعد ECMWF فقط. كل ثلاث ساعات على البيانات المفتوحة.</string>
+    <string name="settings_forecasters_jma">JMA</string>
+    <string name="settings_forecasters_jma_subtitle">ياباني — قوي فوق آسيا والمحيط الهادئ. كل 3 إلى 6 ساعات على البيانات المفتوحة.</string>
+    <string name="settings_forecasters_bom">BOM</string>
+    <string name="settings_forecasters_bom_subtitle">أسترالي — قيد الصيانة، سيعود في أقرب وقت ممكن.</string>
+
+    <string name="settings_about_open_meteo">بيانات الطقس من Open-Meteo</string>
+
+    <string name="settings_debug_title">تصحيح الأخطاء (إصدارات التطوير فقط)</string>
+    <string name="settings_debug_description">تشغيل مسار ClothesCast اليومي على الفور. مفيد للتحقق دون انتظار الموعد المجدول.</string>
+    <string name="settings_debug_fire_now">تشغيل ClothesCast الآن</string>
+    <string name="settings_debug_fire_toast">تم وضع عامل ClothesCast في قائمة الانتظار</string>
 </resources>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -586,4 +586,55 @@ Western Arabic numerals (0-9) are used for TTS compatibility.
     <string name="settings_tts_voice_locale_ar_eg">عربی (مصر)</string>
     <string name="settings_region_language_ar_ma">عربی (مراکش)</string>
     <string name="settings_tts_voice_locale_ar_ma">عربی (مراکش)</string>
+
+    <!-- Strings added to match base — forecasters picker, garment-colour picker,
+         update-downloading banner, placeholder cards, Open-Meteo credit, + debug screen. -->
+    <string name="today_update_downloading_body">در حال دانلود به‌روزرسانی…</string>
+    <string name="today_update_downloading_action">در حال به‌روزرسانی</string>
+    <string name="today_update_downloading_dismiss">لغو</string>
+    <string name="today_view_other_period">مشاهده پیش‌بینی دیگر</string>
+    <string name="today_back_to_primary">بازگشت</string>
+    <string name="today_placeholder_today_title">پیش‌بینی امروز</string>
+    <string name="today_placeholder_tonight_title">پیش‌بینی امشب</string>
+    <string name="today_placeholder_body">حدود %1$s آماده می‌شود.</string>
+
+    <string name="settings_root_forecasters">مدل‌های پیش‌بینی</string>
+    <string name="settings_root_forecasters_subtitle">منابع و مدل‌های آب‌وهوا</string>
+
+    <string name="settings_display_garment_colors_title">رنگ لباس‌ها</string>
+    <string name="settings_display_garment_colors_description">برای هر آیکن لباسی که در امروز، ابزارک صفحه اصلی و اعلان‌ها نمایش داده می‌شود یک رنگ انتخاب کنید. خط دور به‌طور خودکار تیره‌تر می‌شود.</string>
+    <string name="settings_garment_color_default">پیش‌فرض</string>
+    <string name="settings_garment_color_picker_title">یک رنگ انتخاب کنید</string>
+    <string name="settings_garment_color_swatch_description">نمونه رنگ %1$s</string>
+    <string name="settings_garment_color_default_swatch_description">بازنشانی %1$s به رنگ پیش‌فرض</string>
+    <string name="settings_garment_color_dialog_close">بستن</string>
+
+    <string name="settings_forecasters_title">مدل‌های پیش‌بینی</string>
+    <string name="settings_forecasters_description">نشان اطمینان و نمودار هر مدل از این مدل‌ها تغذیه می‌شود. انتخاب تعداد بیشتر گستره‌ای غنی‌تر می‌دهد؛ تعداد کمتر تمرکز را محدودتر می‌کند. دست‌کم دو مدل همیشه انتخاب باقی می‌ماند.</string>
+    <string name="settings_forecasters_auto_title">خودکار (بهترین برای موقعیت شما)</string>
+    <string name="settings_forecasters_auto_subtitle">مدل پیش‌بینی منطقه‌ای را به‌طور خودکار انتخاب می‌کند — UKMO در جزایر بریتانیا، JMA در ژاپن، GFS + GEM در آمریکای شمالی و غیره. برای انتخاب دستی مدل‌ها، آن را خاموش کنید.</string>
+    <string name="settings_forecasters_cap_hint">%1$d مدل انتخاب کرده‌اید — بیشترین تعدادی که نمودار خوانا می‌ماند. برای افزودن مدل دیگر، انتخاب یکی را بردارید.</string>
+    <string name="settings_forecasters_ecmwf">ECMWF</string>
+    <string name="settings_forecasters_ecmwf_subtitle">اروپایی — معمولاً دقیق‌ترین مدل جهانی. روی خوراک باز، هر 3 ساعت یک بار.</string>
+    <string name="settings_forecasters_icon">ICON</string>
+    <string name="settings_forecasters_icon_subtitle">آلمانی (DWD) — قوی در اروپا و در برد کوتاه. ساعتی بومی.</string>
+    <string name="settings_forecasters_gfs">GFS</string>
+    <string name="settings_forecasters_gfs_subtitle">آمریکایی (NOAA) — قوی روی آمریکای شمالی. ساعتی بومی.</string>
+    <string name="settings_forecasters_gem">GEM</string>
+    <string name="settings_forecasters_gem_subtitle">کانادایی (ECCC) — قوی روی آمریکای شمالی. روی خوراک باز، هر 3 ساعت یک بار.</string>
+    <string name="settings_forecasters_arpege">ARPEGE</string>
+    <string name="settings_forecasters_arpege_subtitle">فرانسوی (Météo-France) — قوی روی فرانسه و اروپای غربی. ساعتی بومی.</string>
+    <string name="settings_forecasters_ukmo">UKMO</string>
+    <string name="settings_forecasters_ukmo_subtitle">بریتانیایی (UK Met Office) — از نظر تاریخی تنها پس از ECMWF در رتبه دوم. روی خوراک باز، هر 3 ساعت یک بار.</string>
+    <string name="settings_forecasters_jma">JMA</string>
+    <string name="settings_forecasters_jma_subtitle">ژاپنی — قوی روی آسیا-اقیانوسیه. روی خوراک باز، هر 3 تا 6 ساعت یک بار.</string>
+    <string name="settings_forecasters_bom">BOM</string>
+    <string name="settings_forecasters_bom_subtitle">استرالیایی — در حال نگهداری، در اسرع وقت بازمی‌گردد.</string>
+
+    <string name="settings_about_open_meteo">داده‌های آب‌وهوا از Open-Meteo</string>
+
+    <string name="settings_debug_title">اشکال‌زدایی (فقط در نسخه‌های توسعه)</string>
+    <string name="settings_debug_description">فرایند روزانه ClothesCast را بلافاصله اجرا می‌کند. برای بررسی بدون انتظار تا زمان زمان‌بندی‌شده مفید است.</string>
+    <string name="settings_debug_fire_now">اجرای ClothesCast هم‌اکنون</string>
+    <string name="settings_debug_fire_toast">کارگر ClothesCast در صف قرار گرفت</string>
 </resources>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -594,4 +594,55 @@ standard in Israeli digital communication.
     <string name="settings_tts_voice_locale_ar_eg">ערבית (מצרים)</string>
     <string name="settings_region_language_ar_ma">ערבית (מרוקו)</string>
     <string name="settings_tts_voice_locale_ar_ma">ערבית (מרוקו)</string>
+
+    <!-- Strings added to match base — forecasters picker, garment-colour picker,
+         update-downloading banner, placeholder cards, Open-Meteo credit, + debug screen. -->
+    <string name="today_update_downloading_body">מוריד עדכון…</string>
+    <string name="today_update_downloading_action">מעדכן</string>
+    <string name="today_update_downloading_dismiss">ביטול</string>
+    <string name="today_view_other_period">הצג/י תחזית אחרת</string>
+    <string name="today_back_to_primary">חזור/י</string>
+    <string name="today_placeholder_today_title">תחזית להיום</string>
+    <string name="today_placeholder_tonight_title">תחזית להלילה</string>
+    <string name="today_placeholder_body">תהיה מוכנה בסביבות %1$s.</string>
+
+    <string name="settings_root_forecasters">מודלי תחזית</string>
+    <string name="settings_root_forecasters_subtitle">מקורות ומודלי מזג אוויר</string>
+
+    <string name="settings_display_garment_colors_title">צבעי בגדים</string>
+    <string name="settings_display_garment_colors_description">בחר/י צבע לכל אייקון בגד שמופיע במסך היום, בווידג׳ט של מסך הבית ובהתראות. קו המתאר יוכהה אוטומטית.</string>
+    <string name="settings_garment_color_default">ברירת מחדל</string>
+    <string name="settings_garment_color_picker_title">בחר/י צבע</string>
+    <string name="settings_garment_color_swatch_description">דגימת צבע %1$s</string>
+    <string name="settings_garment_color_default_swatch_description">איפוס %1$s לצבע ברירת המחדל</string>
+    <string name="settings_garment_color_dialog_close">סגור/י</string>
+
+    <string name="settings_forecasters_title">מודלי תחזית</string>
+    <string name="settings_forecasters_description">תווית הביטחון והגרף לפי מודל ניזונים מהמודלים האלה. בחירת יותר מודלים מרחיבה את הפיזור; פחות מודלים מצמצמים את המיקוד. לפחות שניים נשארים מסומנים תמיד.</string>
+    <string name="settings_forecasters_auto_title">אוטומטי (הכי טוב למיקום שלך)</string>
+    <string name="settings_forecasters_auto_subtitle">בוחר אוטומטית את מודל התחזית האזורי — UKMO באיים הבריטיים, JMA ביפן, GFS + GEM בצפון אמריקה וכו׳. כבה/י כדי לבחור מודלים בעצמך.</string>
+    <string name="settings_forecasters_cap_hint">בחרת %1$d מודלים — המספר המרבי שבו הגרף נשאר קריא. בטל/י בחירה של אחד כדי להוסיף מודל אחר.</string>
+    <string name="settings_forecasters_ecmwf">ECMWF</string>
+    <string name="settings_forecasters_ecmwf_subtitle">אירופי — בדרך כלל המודל הגלובלי המדויק ביותר. כל 3 שעות בפיד הפתוח.</string>
+    <string name="settings_forecasters_icon">ICON</string>
+    <string name="settings_forecasters_icon_subtitle">גרמני (DWD) — חזק באירופה ובטווח קצר. שעתי מקורי.</string>
+    <string name="settings_forecasters_gfs">GFS</string>
+    <string name="settings_forecasters_gfs_subtitle">אמריקאי (NOAA) — חזק מעל צפון אמריקה. שעתי מקורי.</string>
+    <string name="settings_forecasters_gem">GEM</string>
+    <string name="settings_forecasters_gem_subtitle">קנדי (ECCC) — חזק מעל צפון אמריקה. כל 3 שעות בפיד הפתוח.</string>
+    <string name="settings_forecasters_arpege">ARPEGE</string>
+    <string name="settings_forecasters_arpege_subtitle">צרפתי (Météo-France) — חזק מעל צרפת ומערב אירופה. שעתי מקורי.</string>
+    <string name="settings_forecasters_ukmo">UKMO</string>
+    <string name="settings_forecasters_ukmo_subtitle">בריטי (UK Met Office) — היסטורית במקום השני, אחרי ECMWF בלבד. כל 3 שעות בפיד הפתוח.</string>
+    <string name="settings_forecasters_jma">JMA</string>
+    <string name="settings_forecasters_jma_subtitle">יפני — חזק מעל אסיה-פסיפיק. כל 3 עד 6 שעות בפיד הפתוח.</string>
+    <string name="settings_forecasters_bom">BOM</string>
+    <string name="settings_forecasters_bom_subtitle">אוסטרלי — בתחזוקה, חוזר ברגע שאפשר.</string>
+
+    <string name="settings_about_open_meteo">נתוני מזג אוויר באדיבות Open-Meteo</string>
+
+    <string name="settings_debug_title">ניפוי שגיאות (גרסאות פיתוח בלבד)</string>
+    <string name="settings_debug_description">הפעלה מיידית של תהליך ClothesCast היומי. שימושי לאימות בלי להמתין לשעה המתוזמנת.</string>
+    <string name="settings_debug_fire_now">הפעל/י את ClothesCast עכשיו</string>
+    <string name="settings_debug_fire_toast">עובד ClothesCast הוכנס לתור</string>
 </resources>

--- a/app/src/main/res/values-sw/strings.xml
+++ b/app/src/main/res/values-sw/strings.xml
@@ -569,4 +569,55 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="settings_tts_voice_locale_ar_eg">Kiarabu (Misri)</string>
     <string name="settings_region_language_ar_ma">Kiarabu (Moroko)</string>
     <string name="settings_tts_voice_locale_ar_ma">Kiarabu (Moroko)</string>
+
+    <!-- Strings added to match base — forecasters picker, garment-colour picker,
+         update-downloading banner, placeholder cards, Open-Meteo credit, + debug screen. -->
+    <string name="today_update_downloading_body">Inapakua sasisho…</string>
+    <string name="today_update_downloading_action">Inasasisha</string>
+    <string name="today_update_downloading_dismiss">Ghairi</string>
+    <string name="today_view_other_period">Tazama utabiri mwingine</string>
+    <string name="today_back_to_primary">Rudi</string>
+    <string name="today_placeholder_today_title">Utabiri wa leo</string>
+    <string name="today_placeholder_tonight_title">Utabiri wa usiku huu</string>
+    <string name="today_placeholder_body">Utakuwa tayari karibu na %1$s.</string>
+
+    <string name="settings_root_forecasters">Modeli za utabiri</string>
+    <string name="settings_root_forecasters_subtitle">Vyanzo na modeli za hali ya hewa</string>
+
+    <string name="settings_display_garment_colors_title">Rangi za mavazi</string>
+    <string name="settings_display_garment_colors_description">Chagua rangi kwa kila aikoni ya vazi inayoonekana kwenye Leo, kwenye wijeti ya skrini ya nyumbani, na kwenye arifa. Mstari wa nje hutiwa giza moja kwa moja.</string>
+    <string name="settings_garment_color_default">Chaguo-msingi</string>
+    <string name="settings_garment_color_picker_title">Chagua rangi</string>
+    <string name="settings_garment_color_swatch_description">Sampuli ya rangi ya %1$s</string>
+    <string name="settings_garment_color_default_swatch_description">Rejesha %1$s kwa rangi ya chaguo-msingi</string>
+    <string name="settings_garment_color_dialog_close">Funga</string>
+
+    <string name="settings_forecasters_title">Modeli za utabiri</string>
+    <string name="settings_forecasters_description">Beji ya uhakika na chati ya kila modeli hutegemea modeli hizi. Kuchagua zaidi hutoa mtawanyiko mpana; chache hupunguza umakini. Angalau mbili hubaki zikiwa zimechaguliwa kila wakati.</string>
+    <string name="settings_forecasters_auto_title">Otomatiki (bora kwa eneo lako)</string>
+    <string name="settings_forecasters_auto_subtitle">Huchagua modeli ya utabiri ya kanda kiotomatiki — UKMO katika Visiwa vya Uingereza, JMA Japani, GFS + GEM Amerika Kaskazini, n.k. Zima ili uchague modeli mwenyewe.</string>
+    <string name="settings_forecasters_cap_hint">Umechagua modeli %1$d — idadi kubwa zaidi ambapo chati hubaki ikisomeka. Ondoa moja ili kuongeza modeli nyingine.</string>
+    <string name="settings_forecasters_ecmwf">ECMWF</string>
+    <string name="settings_forecasters_ecmwf_subtitle">Ulaya — kwa kawaida modeli sahihi zaidi duniani. Kila saa 3 kwenye mlisho wa wazi.</string>
+    <string name="settings_forecasters_icon">ICON</string>
+    <string name="settings_forecasters_icon_subtitle">Kijerumani (DWD) — imara Ulaya na kwa muda mfupi. Kila saa moja kwa asili.</string>
+    <string name="settings_forecasters_gfs">GFS</string>
+    <string name="settings_forecasters_gfs_subtitle">Kimarekani (NOAA) — imara juu ya Amerika Kaskazini. Kila saa moja kwa asili.</string>
+    <string name="settings_forecasters_gem">GEM</string>
+    <string name="settings_forecasters_gem_subtitle">Kikanada (ECCC) — imara juu ya Amerika Kaskazini. Kila saa 3 kwenye mlisho wa wazi.</string>
+    <string name="settings_forecasters_arpege">ARPEGE</string>
+    <string name="settings_forecasters_arpege_subtitle">Kifaransa (Météo-France) — imara juu ya Ufaransa na Ulaya Magharibi. Kila saa moja kwa asili.</string>
+    <string name="settings_forecasters_ukmo">UKMO</string>
+    <string name="settings_forecasters_ukmo_subtitle">Kiingereza (UK Met Office) — kihistoria ya pili nyuma ya ECMWF tu. Kila saa 3 kwenye mlisho wa wazi.</string>
+    <string name="settings_forecasters_jma">JMA</string>
+    <string name="settings_forecasters_jma_subtitle">Kijapani — imara juu ya Asia-Pasifiki. Kila saa 3 hadi 6 kwenye mlisho wa wazi.</string>
+    <string name="settings_forecasters_bom">BOM</string>
+    <string name="settings_forecasters_bom_subtitle">Kiaustralia — chini ya matengenezo, itarudi haraka iwezekanavyo.</string>
+
+    <string name="settings_about_open_meteo">Data ya hali ya hewa kutoka Open-Meteo</string>
+
+    <string name="settings_debug_title">Utatuzi (miundo ya utatuzi pekee)</string>
+    <string name="settings_debug_description">Endesha mara moja mtiririko wa kila siku wa ClothesCast. Inafaa kwa uthibitisho bila kusubiri muda uliopangwa.</string>
+    <string name="settings_debug_fire_now">Endesha ClothesCast sasa</string>
+    <string name="settings_debug_fire_toast">Mfanyakazi wa ClothesCast amewekwa kwenye foleni</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -605,4 +605,50 @@ displayed label localizes.
     <string name="today_uv_peak">Tepe %1$d, saat %2$s</string>
     <string name="today_uv_title">UV endeksi</string>
     <string name="today_wind_peak">Tepe %1$d %2$s, saat %3$s</string>
+
+    <!-- Strings added to match base — forecasters picker, garment-colour picker,
+         update-downloading banner, placeholder cards, Open-Meteo credit. -->
+    <string name="today_update_downloading_body">Güncelleme indiriliyor…</string>
+    <string name="today_update_downloading_action">Güncelleniyor</string>
+    <string name="today_update_downloading_dismiss">İptal</string>
+    <string name="today_view_other_period">Diğer tahmini gör</string>
+    <string name="today_back_to_primary">Geri</string>
+    <string name="today_placeholder_today_title">Bugünün tahmini</string>
+    <string name="today_placeholder_tonight_title">Bu gecenin tahmini</string>
+    <string name="today_placeholder_body">Yaklaşık %1$s\'de hazır olur.</string>
+
+    <string name="settings_root_forecasters">Tahmin modelleri</string>
+    <string name="settings_root_forecasters_subtitle">Hava kaynakları ve modeller</string>
+
+    <string name="settings_display_garment_colors_title">Giysi renkleri</string>
+    <string name="settings_display_garment_colors_description">Bugün ekranında, ana ekran widget\'ında ve bildirimlerde gösterilen her giysi simgesi için bir renk seç. Kontur otomatik olarak koyulaşır.</string>
+    <string name="settings_garment_color_default">Varsayılan</string>
+    <string name="settings_garment_color_picker_title">Bir renk seç</string>
+    <string name="settings_garment_color_swatch_description">%1$s renk örneği</string>
+    <string name="settings_garment_color_default_swatch_description">%1$s rengini varsayılana sıfırla</string>
+    <string name="settings_garment_color_dialog_close">Kapat</string>
+
+    <string name="settings_forecasters_title">Tahmin modelleri</string>
+    <string name="settings_forecasters_description">Güven rozeti ve model bazlı grafik bu modellerden beslenir. Daha fazla seçmek dağılımı zenginleştirir; daha az seçmek odağı daraltır. En az iki model her zaman seçili kalır.</string>
+    <string name="settings_forecasters_auto_title">Otomatik (konumun için en iyisi)</string>
+    <string name="settings_forecasters_auto_subtitle">Bölgesel tahmin sağlayıcıyı otomatik olarak seçer — Britanya Adaları\'nda UKMO, Japonya\'da JMA, Kuzey Amerika\'da GFS + GEM gibi. Modelleri kendin seçmek istersen kapat.</string>
+    <string name="settings_forecasters_cap_hint">%1$d model seçtin — grafiğin okunabilir kaldığı en yüksek sayı. Farklı bir model eklemek için birinin seçimini kaldır.</string>
+    <string name="settings_forecasters_ecmwf">ECMWF</string>
+    <string name="settings_forecasters_ecmwf_subtitle">Avrupa — genelde en doğru küresel model. Açık akışta 3 saatte bir.</string>
+    <string name="settings_forecasters_icon">ICON</string>
+    <string name="settings_forecasters_icon_subtitle">Alman (DWD) — Avrupa\'da ve kısa vadede güçlü. Saatlik veri sağlar.</string>
+    <string name="settings_forecasters_gfs">GFS</string>
+    <string name="settings_forecasters_gfs_subtitle">Amerikan (NOAA) — Kuzey Amerika üzerinde güçlü. Saatlik veri sağlar.</string>
+    <string name="settings_forecasters_gem">GEM</string>
+    <string name="settings_forecasters_gem_subtitle">Kanadalı (ECCC) — Kuzey Amerika üzerinde güçlü. Açık akışta 3 saatte bir.</string>
+    <string name="settings_forecasters_arpege">ARPEGE</string>
+    <string name="settings_forecasters_arpege_subtitle">Fransız (Météo-France) — Fransa ve Batı Avrupa üzerinde güçlü. Saatlik veri sağlar.</string>
+    <string name="settings_forecasters_ukmo">UKMO</string>
+    <string name="settings_forecasters_ukmo_subtitle">İngiliz (UK Met Office) — tarihsel olarak yalnızca ECMWF\'nin ardından ikinci. Açık akışta 3 saatte bir.</string>
+    <string name="settings_forecasters_jma">JMA</string>
+    <string name="settings_forecasters_jma_subtitle">Japon — Asya-Pasifik üzerinde güçlü. Açık akışta 3 ila 6 saatte bir.</string>
+    <string name="settings_forecasters_bom">BOM</string>
+    <string name="settings_forecasters_bom_subtitle">Avustralyalı — bakım altında, mümkün olan en kısa sürede geri dönecek.</string>
+
+    <string name="settings_about_open_meteo">Hava durumu verileri Open-Meteo tarafından sağlanır</string>
 </resources>


### PR DESCRIPTION
## Summary

Final follow-up after #492 / #494 (European) and the East Asian / South-SE Asian commits — fills in the same forecasters / garment-colour / update-downloading / placeholder-card / Open-Meteo-credit strings for the remaining locales that weren't covered by any previous pass.

After this lands, every shipped locale (excluding the regional-overlay locales like `de-rAT` / `es-rMX` / `fr-rCA` / `en-rGB` which are by-design partial overlays) is fully in sync with `values/strings.xml` modulo the 7 documented per-locale omissions (`app_name` brand + the English-only `insight_time_am/pm/midnight/noon` and `*_minutes` AM/PM helpers).

Locales touched (register per each file's header):

- `values-tr/` (Turkish) — sen-form informal singular; vowel harmony on suffixes ("Yaklaşık %1$s\'de", "%1$d model seçtin")
- `values-ar/` (Arabic / MSA) — RTL; predicate forms without tanwin per file convention
- `values-fa/` (Persian) — RTL; SOV with verbs at clause end; Western Arabic numerals 0-9 per file header
- `values-iw/` (Hebrew) — RTL; gender-neutral slash notation (בחר/י, סגור/י, חזור/י) for imperatives the user is told to do now; masculine singular for system-narrating continuous-aspect verbs (מוריד, מעדכן), matching the file's existing pattern
- `values-am/` (Amharic, Ethiopia) — Ge'ez script
- `values-sw/` (Swahili / Kiswahili)

Key set:

- 39 standard strings (same as #492 / #494): `today_update_downloading_*` (3), `today_view_other_period` / `today_back_to_primary` / `today_placeholder_*` (5), `settings_root_forecasters` + subtitle, `settings_display_garment_colors_*` and `settings_garment_color_*` (7), `settings_forecasters_*` (21), `settings_about_open_meteo`.
- Plus **4 extra `settings_debug_*` strings** for ar / fa / iw / am / sw (these locales were also stale on the debug-build-only Settings screen that other locales already cover). Turkish (tr) already had those.

Agency / model acronyms (ECMWF, ICON, GFS, GEM, ARPEGE, UKMO, JMA, BOM) and brand names (Météo-France, Open-Meteo, ClothesCast, DWD, NOAA, ECCC, UK Met Office) stay verbatim across every locale — Latin-script even inside the Arabic / Hebrew / Persian / Amharic files, matching the existing precedent in each file.

No RLM / LRM directional controls were inserted: none of the four RTL files had a prior precedent for them, and the source order is logical per Android's RTL guidance.

No privacy-relevant strings — nothing here leaves the device.

## Test plan

- [x] `xmllint --noout` clean on all 6 modified files
- [x] `./gradlew :app:processDebugResources` succeeds (aapt accepts every locale)
- [x] Missing-keys diff vs `values/strings.xml` — every locale now reports exactly the 7 by-design omissions
- [x] Format specifiers (`%1$s`, `%1$d`, `%%`) preserved verbatim across every string
- [x] Apostrophe-style audit — no typographic `’` in the added block; Turkish uses `\'` for the locative-suffix attachment to `%1$s`
- [ ] CI: JVM unit tests + `:app:assembleDebug` green
- [ ] Eyeball a few strings in-app on a Turkish / Arabic / Hebrew build before un-drafting

https://claude.ai/code/session_01PP2B53SaZaK2j19ZJMyv1d

---
_Generated by [Claude Code](https://claude.ai/code/session_01PP2B53SaZaK2j19ZJMyv1d)_