### PR TITLE
Speak the forecast on Home Assistant via an MQTT bridge

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,6 +1,6 @@
 # Privacy Policy
 
-_Last updated: 2026-05-14_
+_Last updated: 2026-05-16_
 
 ClothesCast is a daily weather-insight app for Android. This policy
 describes what data the app handles, where it goes, and what control you
@@ -25,6 +25,13 @@ have over it.
   (e.g. _"Bring a jacket for your concert tonight"_), and is therefore
   also sent to the TTS provider in that one case — only when both calendar
   tie-in and online TTS are enabled.
+- If you opt in to the **Smart Home / Home Assistant MQTT bridge**
+  (Settings → Smart Home, off by default), the rendered forecast
+  sentence is published as a retained MQTT message to a broker you
+  configure — typically the Mosquitto add-on running on your own Home
+  Assistant. The broker host and credentials are entirely yours; nothing
+  ClothesCast sends goes to a service the developer operates. See "Smart
+  Home / Home Assistant bridge" below for what's in the payload.
 - Nothing is sold, no advertising, no ad-targeting profiles, no
   third-party data sharing beyond the services listed below. (The
   aggregate usage analytics + crash reports above _do_ count as
@@ -121,6 +128,45 @@ The source code is at <https://github.com/mikelward/clothescast>.
   automatically to the crash-reporting service is governed by that
   service's privacy policy.
 
+### Smart Home / Home Assistant bridge _(optional, off by default)_
+
+- **What:** The rendered forecast sentence — the same one displayed in
+  the notification, e.g. _"Today, cool and mild. Wear a sweater. Chance
+  of rain at 3pm."_ The bridge publishes this string as a retained MQTT
+  message after each scheduled twice-daily refresh, so Home Assistant
+  (or any MQTT-aware consumer) can read the latest value and speak it
+  on a trigger of your choice (a wardrobe door opening, a humidity
+  spike, a fixed time of day, etc.).
+- **Why:** To let you hear your tuned ClothesCast forecast on a
+  Google Home, Nest Hub, Echo, or any other speaker your home
+  automation can reach — without reimplementing the clothes-rule and
+  insight logic in Home Assistant.
+- **Where it goes:** The MQTT broker you configure in Settings → Smart
+  Home. That's typically the Mosquitto add-on running inside your own
+  Home Assistant instance on your local network. The broker host,
+  port, optional TLS, optional username, and topic prefix are all
+  values you supply; ClothesCast never sends this payload anywhere you
+  haven't pointed it at. The broker is **not** a service the developer
+  operates; it's your infrastructure under your control.
+- **What's in the payload:** Only the rendered sentence string,
+  UTF-8 encoded — the same text you see in the notification. The
+  payload includes any calendar-event tie-in clause that fires (e.g.
+  _"Bring a jacket for your concert tonight"_) when you have the
+  calendar tie-in enabled, because that clause is part of the
+  rendered sentence. No coordinates, no API keys, no settings values,
+  no device identifiers travel with the message.
+- **Authentication:** If you set a broker username, the bridge sends
+  it on connect; the corresponding password is stored on your device
+  encrypted at rest (same Tink-AEAD pattern as the Gemini API key
+  storage above) and only sent to the broker you configured.
+- **Retention:** Retained MQTT messages persist on your broker until
+  you delete them or publish a new value to the same topic. The next
+  twice-daily refresh overwrites the previous payload. Retention by
+  the broker is governed by your own broker configuration.
+- **Setup guide:** See [docs/smart-home.md](docs/smart-home.md) for
+  step-by-step configuration on both the ClothesCast side and the
+  Home Assistant side.
+
 ### API keys you provide
 
 - If you use online TTS, you supply your own Google Gemini API key.
@@ -138,6 +184,7 @@ policies apply to anything they receive:
 |---|---|---|
 | [Open-Meteo](https://open-meteo.com/en/terms) | Coarse coordinate | Always (forecast + geocoding) |
 | [Google Gemini API](https://ai.google.dev/gemini-api/terms) | The short rendered insight sentence | Only if you select Gemini TTS |
+| Your self-hosted MQTT broker (e.g. Mosquitto inside Home Assistant) | The short rendered insight sentence, as a retained MQTT message | Only if you opt in to the Smart Home bridge and configure a broker |
 | Analytics / crash-reporting service (e.g. Firebase Crashlytics + Google Analytics for Firebase) | Aggregate usage events and crash diagnostics — see "Analytics and crash reporting" below for what's in and out | Possibly always, in all builds |
 
 These providers act as service providers fulfilling a single request and
@@ -255,7 +302,10 @@ What's **not** sent — these are hard limits, not "best-effort":
   info.
 - **No location coordinates** or geocoded place names.
 - **No insight prose**, notification text, or anything else that could
-  carry free-form user content.
+  carry free-form user content. _Exception:_ if you opt in to the Smart
+  Home / Home Assistant MQTT bridge in Settings → Smart Home and
+  configure a broker, the rendered insight sentence is sent to **that
+  broker** — your own infrastructure, not the analytics service.
 - **No API keys** or other credentials.
 - **No precise GPS** or advertising identifiers.
 
@@ -289,6 +339,17 @@ email the address listed on the Play Store listing.
 
 ## Changelog
 
+- **2026-05-16** — Added an optional **Smart Home / Home Assistant MQTT
+  bridge** (Settings → Smart Home; off by default). When enabled, the
+  app publishes the rendered forecast sentence as a retained MQTT
+  message to a broker you configure (typically the Mosquitto add-on
+  inside your own Home Assistant). This relaxes the existing "insight
+  prose never leaves the device" hard limit — but only to your own
+  broker, never to a developer-operated service or analytics endpoint.
+  The broker password, if you set one, is stored on-device encrypted
+  with the same Tink-AEAD pattern as the Gemini API key. See the new
+  "Smart Home / Home Assistant bridge" section above and
+  [docs/smart-home.md](docs/smart-home.md) for the full setup.
 - **2026-05-14** — Added three new aggregate analytics events:
   `daily_refresh` (slot + outcome bucket + latency, one per terminal
   result of the scheduled fetch + notify pipeline; WorkManager retries

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -260,6 +260,14 @@ android {
     packaging {
         resources {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
+            // HiveMQ MQTT Client pulls in six Netty submodules (netty-buffer,
+            // netty-codec, netty-handler, netty-resolver, netty-transport,
+            // netty-transport-native-unix-common), each of which ships its
+            // own META-INF/INDEX.LIST + io.netty.versions.properties. AGP's
+            // resource merger refuses to pick a winner; exclude the duplicate
+            // metadata since neither file is referenced at runtime.
+            excludes += "/META-INF/INDEX.LIST"
+            excludes += "/META-INF/io.netty.versions.properties"
         }
     }
 
@@ -343,6 +351,13 @@ dependencies {
     // QR code generation: encodes the pairing URL into a BitMatrix that we render
     // as an Android Bitmap. Pure-Java, no Android SDK dependency.
     implementation(libs.zxing.core)
+
+    // HiveMQ MQTT Client — drives the optional Smart Home bridge that publishes
+    // the rendered insight prose to a user-hosted MQTT broker so Home Assistant
+    // (or any MQTT consumer) can speak it on a sensor trigger. Pulled into :app
+    // because the bridge is an Android-side feature that piggybacks on the
+    // existing twice-daily refresh; :core stays pure-Kotlin and broker-free.
+    implementation(libs.hivemq.mqtt.client)
 
     // Play in-app updates. Used to check whether a newer build is on the Play
     // Store and to drive the FLEXIBLE update flow (background download +

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -14,3 +14,23 @@
 # the reflection guard with a direct GETFIELD, causing NoSuchFieldError on
 # those devices. Keeping the class prevents that optimization path.
 -keep class androidx.compose.ui.text.font.FontWeightAdjustmentHelper { *; }
+
+# HiveMQ MQTT Client pulls Netty in. Netty's binaries reference a long list of
+# optional integrations (epoll, tcnative, log4j adapters, Jetty ALPN/NPN,
+# BlockHound, websocket / proxy handlers) that aren't on the Android classpath
+# because the MQTT bridge uses plain-TCP / TLS-via-JSSE, no websockets, no
+# proxies, no native epoll. R8 surfaces every cross-reference as a hard error;
+# these -dontwarn lines tell it those gaps are intentional. List taken from
+# app/build/outputs/mapping/<variant>/missing_rules.txt after a fresh
+# assembleDebug. If you bump the HiveMQ / Netty version and the list grows,
+# re-run that build and append any new -dontwarn lines here.
+-dontwarn io.netty.channel.epoll.**
+-dontwarn io.netty.handler.codec.http.**
+-dontwarn io.netty.handler.codec.http.websocketx.**
+-dontwarn io.netty.handler.proxy.**
+-dontwarn io.netty.internal.tcnative.**
+-dontwarn org.apache.log4j.**
+-dontwarn org.apache.logging.log4j.**
+-dontwarn org.eclipse.jetty.alpn.**
+-dontwarn org.eclipse.jetty.npn.**
+-dontwarn reactor.blockhound.integration.**

--- a/app/src/main/kotlin/app/clothescast/ClothesCastApplication.kt
+++ b/app/src/main/kotlin/app/clothescast/ClothesCastApplication.kt
@@ -25,6 +25,7 @@ import app.clothescast.diag.TelemetryApiCallLogger
 import app.clothescast.locale.AppLocale
 import app.clothescast.location.LocationResolver
 import app.clothescast.location.ReverseGeocoder
+import app.clothescast.mqtt.MqttPublisher
 import app.clothescast.notification.InsightNotifier
 import app.clothescast.notification.NotificationChannelRegistrar
 import app.clothescast.notification.TonightInsightNotifier
@@ -82,6 +83,20 @@ class ClothesCastApplication : Application() {
     val appUpdateChecker: AppUpdateChecker by lazy { AppUpdateChecker(this) }
     val geminiTtsClient: GeminiTtsClient by lazy {
         GeminiTtsClient(httpClient, secureKeyStore, apiCallLogger = apiCallLogger)
+    }
+
+    /**
+     * Optional Smart Home / Home Assistant bridge. Off until the user enables
+     * it in Settings → Smart Home; the worker calls
+     * [MqttPublisher.publishIfEnabled] after each delivered insight, and the
+     * publisher itself gates on the runtime config — so the lazy stays cheap
+     * for users who never opt in.
+     */
+    val mqttPublisher: MqttPublisher by lazy {
+        MqttPublisher(
+            preferences = settingsRepository.preferences,
+            passwordProvider = { secureKeyStore.getMqttPassword() },
+        )
     }
 
     private val httpClient: HttpClient by lazy {

--- a/app/src/main/kotlin/app/clothescast/data/SecureKeyStore.kt
+++ b/app/src/main/kotlin/app/clothescast/data/SecureKeyStore.kt
@@ -53,12 +53,36 @@ class SecureKeyStore(
     suspend fun clear() = remove(GEMINI_PREF_KEY)
 
     /**
+     * MQTT broker password for the optional Smart Home bridge. Returns `null`
+     * if no password is set — anonymous-auth brokers and the bridge-disabled
+     * state are both indistinguishable from "unset" by design.
+     */
+    suspend fun getMqttPassword(): String? = try {
+        read(MQTT_PASS_PREF_KEY, MQTT_PASS_AAD, "MQTT")
+    } catch (_: MissingApiKeyException) {
+        null
+    }
+
+    suspend fun setMqttPassword(password: String) = write(MQTT_PASS_PREF_KEY, MQTT_PASS_AAD, password)
+
+    suspend fun clearMqttPassword() = remove(MQTT_PASS_PREF_KEY)
+
+    /**
      * Reactive view of "is a Gemini key currently stored." Used by the Today screen's
      * welcome card to decide whether to nudge the user to set a key. Reads only the
      * presence of ciphertext, not the plaintext value, so no decrypt happens here.
      */
     val geminiKeyConfiguredFlow: Flow<Boolean> = dataStore.data
         .map { it[GEMINI_PREF_KEY] != null }
+        .distinctUntilChanged()
+
+    /**
+     * Sibling of [geminiKeyConfiguredFlow] for the MQTT broker password. The
+     * Smart Home settings card uses it to render the "Password set" indicator
+     * without ever decrypting the stored value.
+     */
+    val mqttPasswordConfiguredFlow: Flow<Boolean> = dataStore.data
+        .map { it[MQTT_PASS_PREF_KEY] != null }
         .distinctUntilChanged()
 
     private suspend fun read(prefKey: Preferences.Key<String>, aad: ByteArray, provider: String): String {
@@ -88,6 +112,8 @@ class SecureKeyStore(
     companion object {
         private val GEMINI_PREF_KEY = stringPreferencesKey("gemini_api_key_v1")
         private val GEMINI_AAD = "clothescast:gemini_api_key:v1".toByteArray(Charsets.UTF_8)
+        private val MQTT_PASS_PREF_KEY = stringPreferencesKey("mqtt_password_v1")
+        private val MQTT_PASS_AAD = "clothescast:mqtt_password:v1".toByteArray(Charsets.UTF_8)
 
         private const val MASTER_KEY_URI = "android-keystore://clothescast_master_key"
         private const val KEYSET_PREFS = "clothescast_master_prefs"

--- a/app/src/main/kotlin/app/clothescast/data/SettingsRepository.kt
+++ b/app/src/main/kotlin/app/clothescast/data/SettingsRepository.kt
@@ -272,6 +272,39 @@ class SettingsRepository(
         dataStore.edit { it[TELEMETRY_ENABLED] = enabled }
     }
 
+    suspend fun setMqttBridgeEnabled(enabled: Boolean) {
+        dataStore.edit { it[MQTT_BRIDGE_ENABLED] = enabled }
+    }
+
+    /**
+     * Persists the MQTT broker connection settings for the optional Smart Home
+     * bridge. Blank host clears it (and effectively disables the bridge even
+     * if [setMqttBridgeEnabled] is true — the publisher gates on a non-blank
+     * host). The password is stored separately via [SecureKeyStore] and not
+     * touched here. A null [username] is interpreted as "anonymous auth";
+     * blank values are coerced to null so a half-typed field doesn't surface
+     * as an empty string on the next emission.
+     */
+    suspend fun setMqttConfig(
+        host: String?,
+        port: Int,
+        useTls: Boolean,
+        username: String?,
+        topic: String,
+    ) {
+        dataStore.edit { prefs ->
+            val cleanHost = host?.trim()?.takeIf { it.isNotBlank() }
+            if (cleanHost == null) prefs.remove(MQTT_HOST) else prefs[MQTT_HOST] = cleanHost
+            prefs[MQTT_PORT] = port
+            prefs[MQTT_USE_TLS] = useTls
+            val cleanUser = username?.trim()?.takeIf { it.isNotBlank() }
+            if (cleanUser == null) prefs.remove(MQTT_USER) else prefs[MQTT_USER] = cleanUser
+            val cleanTopic = topic.trim().takeIf { it.isNotBlank() }
+                ?: UserPreferences.DEFAULT_MQTT_TOPIC
+            prefs[MQTT_TOPIC] = cleanTopic
+        }
+    }
+
     suspend fun setColorPalette(palette: ColorPalette) {
         dataStore.edit { it[COLOR_PALETTE] = palette.name }
     }
@@ -470,6 +503,13 @@ class SettingsRepository(
             ?.mapNotNull { runCatching { ForecastModel.valueOf(it) }.getOrNull() }
             ?.toSet()
             ?.takeIf { it.isNotEmpty() }
+        val mqttBridgeEnabled = this[MQTT_BRIDGE_ENABLED] == true
+        val mqttHost = this[MQTT_HOST]?.takeIf { it.isNotBlank() }
+        val mqttPort = this[MQTT_PORT] ?: UserPreferences.DEFAULT_MQTT_PORT
+        val mqttUseTls = this[MQTT_USE_TLS] == true
+        val mqttUsername = this[MQTT_USER]?.takeIf { it.isNotBlank() }
+        val mqttTopic = this[MQTT_TOPIC]?.takeIf { it.isNotBlank() }
+            ?: UserPreferences.DEFAULT_MQTT_TOPIC
         val zone = zoneIdProvider()
 
         return UserPreferences(
@@ -502,6 +542,12 @@ class SettingsRepository(
             outfitTopColors = outfitTopColors,
             outfitBottomColors = outfitBottomColors,
             forecastModels = forecastModels,
+            mqttBridgeEnabled = mqttBridgeEnabled,
+            mqttHost = mqttHost,
+            mqttPort = mqttPort,
+            mqttUseTls = mqttUseTls,
+            mqttUsername = mqttUsername,
+            mqttTopic = mqttTopic,
         )
     }
 
@@ -665,6 +711,12 @@ class SettingsRepository(
         private val OUTFIT_TOP_COLORS = stringPreferencesKey("outfit_top_colors_json")
         private val OUTFIT_BOTTOM_COLORS = stringPreferencesKey("outfit_bottom_colors_json")
         private val FORECAST_MODELS = stringSetPreferencesKey("forecast_models")
+        private val MQTT_BRIDGE_ENABLED = booleanPreferencesKey("mqtt_bridge_enabled")
+        private val MQTT_HOST = stringPreferencesKey("mqtt_host")
+        private val MQTT_PORT = intPreferencesKey("mqtt_port")
+        private val MQTT_USE_TLS = booleanPreferencesKey("mqtt_use_tls")
+        private val MQTT_USER = stringPreferencesKey("mqtt_user")
+        private val MQTT_TOPIC = stringPreferencesKey("mqtt_topic")
 
         private val TIME_FORMAT: DateTimeFormatter = DateTimeFormatter.ofPattern("HH:mm")
         private val DEFAULT_TIME: LocalTime = LocalTime.of(7, 0)

--- a/app/src/main/kotlin/app/clothescast/mqtt/MqttPublisher.kt
+++ b/app/src/main/kotlin/app/clothescast/mqtt/MqttPublisher.kt
@@ -1,0 +1,180 @@
+package app.clothescast.mqtt
+
+import app.clothescast.core.domain.model.ForecastPeriod
+import app.clothescast.core.domain.model.UserPreferences
+import app.clothescast.diag.DiagLog
+import com.hivemq.client.mqtt.MqttClient
+import com.hivemq.client.mqtt.datatypes.MqttQos
+import com.hivemq.client.mqtt.mqtt3.Mqtt3AsyncClient
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.future.await
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlin.coroutines.cancellation.CancellationException
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+
+/**
+ * Publishes the rendered insight prose to a user-hosted MQTT broker as a
+ * retained message, so Home Assistant (or any other MQTT consumer) can read
+ * the latest "what to wear today" sentence and speak it on a trigger of the
+ * user's choice. The bridge is opt-in and configured in
+ * Settings → Smart Home; see PRIVACY.md for the data-handling boundary.
+ *
+ * The publisher reads the latest [UserPreferences] from the injected flow on
+ * every call so settings edits take effect on the next refresh without
+ * reconnect plumbing — connections are short-lived (connect → publish →
+ * disconnect, twice a day), which is battery-cheap and avoids holding network
+ * state in the worker.
+ */
+class MqttPublisher(
+    private val preferences: Flow<UserPreferences>,
+    private val passwordProvider: suspend () -> String?,
+    private val publish: suspend (config: MqttConfig, topic: String, payload: String) -> Unit = ::publishWithHiveMq,
+    private val publishTimeoutMs: Long = DEFAULT_PUBLISH_TIMEOUT_MS,
+) {
+
+    /**
+     * Fire-and-forget publish to `${baseTopic}/${period.lowercased()}`. No-op
+     * when the bridge is disabled or no host is configured. Any failure (DNS,
+     * connection, broker rejection, timeout) is logged and swallowed — the
+     * caller's worker must succeed regardless of broker reachability.
+     */
+    suspend fun publishIfEnabled(period: ForecastPeriod, prose: String) {
+        // CancellationException must propagate at every catch point so a
+        // WorkManager stop or withTimeoutOrNull abort unwinds the worker
+        // cleanly instead of being silently logged as an MQTT failure (which
+        // would then let deliver() report success on cancelled work).
+        val prefs = try {
+            preferences.first()
+        } catch (ce: CancellationException) {
+            throw ce
+        } catch (_: Throwable) {
+            return
+        }
+        if (!prefs.mqttBridgeEnabled) return
+        val host = prefs.mqttHost?.takeIf { it.isNotBlank() } ?: return
+        val password = if (prefs.mqttUsername.isNullOrBlank()) {
+            null
+        } else {
+            try {
+                passwordProvider()
+            } catch (ce: CancellationException) {
+                throw ce
+            } catch (_: Throwable) {
+                null
+            }
+        }
+        val config = MqttConfig(
+            host = host,
+            port = prefs.mqttPort,
+            useTls = prefs.mqttUseTls,
+            username = prefs.mqttUsername,
+            password = password,
+        )
+        val topic = topicFor(prefs.mqttTopic, period)
+        withTimeoutOrNull(publishTimeoutMs) {
+            try {
+                publish(config, topic, prose)
+                DiagLog.i(TAG, "Published ${period.name.lowercase()} insight to mqtt://$host:${prefs.mqttPort}/$topic")
+            } catch (ce: CancellationException) {
+                // Re-raise so withTimeoutOrNull sees a timeout (returns null
+                // and we log "timed out" below) and so a WorkManager-issued
+                // cancel propagates out of the worker rather than being
+                // shadowed by a misleading "MQTT publish failed" line.
+                throw ce
+            } catch (t: Throwable) {
+                DiagLog.w(TAG, "MQTT publish failed to $host:${prefs.mqttPort}/$topic", t)
+            }
+        } ?: DiagLog.w(TAG, "MQTT publish timed out after ${publishTimeoutMs}ms to $host:${prefs.mqttPort}/$topic")
+    }
+
+    companion object {
+        private const val TAG = "MqttPublisher"
+        const val DEFAULT_PUBLISH_TIMEOUT_MS = 5_000L
+
+        // Inner HiveMQ timeouts kept tighter than [DEFAULT_PUBLISH_TIMEOUT_MS]
+        // so the connect phase fails cleanly (with a ConnectionFailedException
+        // we can log) before the outer withTimeoutOrNull has to abort. Without
+        // these, a black-holed broker host would let TCP connect block past the
+        // outer timeout — coroutine cancellation can't interrupt a blocked
+        // socket call by itself.
+        internal const val SOCKET_CONNECT_TIMEOUT_MS = 4_000L
+        internal const val MQTT_CONNECT_TIMEOUT_MS = 4_000L
+
+        fun topicFor(baseTopic: String, period: ForecastPeriod): String {
+            val trimmed = baseTopic.trim().trim('/').ifBlank { UserPreferences.DEFAULT_MQTT_TOPIC }
+            return "$trimmed/${period.name.lowercase()}"
+        }
+    }
+}
+
+/**
+ * Minimal value type for a per-publish MQTT connection. Decoupled from
+ * [UserPreferences] so the publish strategy is unit-testable against a stub
+ * without dragging a full preferences instance into the test.
+ */
+data class MqttConfig(
+    val host: String,
+    val port: Int,
+    val useTls: Boolean,
+    val username: String?,
+    val password: String?,
+)
+
+private suspend fun publishWithHiveMq(
+    config: MqttConfig,
+    topic: String,
+    payload: String,
+) {
+    // Async client + awaited CompletableFutures (rather than the blocking
+    // client wrapped in Dispatchers.IO) so the outer withTimeoutOrNull and any
+    // WorkManager-issued cancel actually unwind the publish path. Coroutine
+    // cancellation cannot interrupt a blocked socket call from the blocking
+    // client; awaiting HiveMQ's CompletableFutures via kotlinx.coroutines.future
+    // is suspension-aware. The HiveMQ-level timeouts below cap the TCP +
+    // MQTT-CONNECT phase independently so a black-holed host fails clean even
+    // before the outer timeout fires.
+    val client: Mqtt3AsyncClient = MqttClient.builder()
+        .useMqttVersion3()
+        .identifier("clothescast-${UUID.randomUUID()}")
+        .serverHost(config.host)
+        .serverPort(config.port)
+        .apply { if (config.useTls) sslWithDefaultConfig() }
+        .transportConfig()
+            .mqttConnectTimeout(MqttPublisher.MQTT_CONNECT_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+            .socketConnectTimeout(MqttPublisher.SOCKET_CONNECT_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+            .applyTransportConfig()
+        .buildAsync()
+    try {
+        val connect = client.connectWith()
+        if (!config.username.isNullOrBlank()) {
+            connect.simpleAuth()
+                .username(config.username)
+                .apply { if (!config.password.isNullOrEmpty()) password(config.password.toByteArray(Charsets.UTF_8)) }
+                .applySimpleAuth()
+        }
+        connect.send().await()
+        client.publishWith()
+            .topic(topic)
+            .payload(payload.toByteArray(Charsets.UTF_8))
+            .qos(MqttQos.AT_LEAST_ONCE)
+            .retain(true)
+            .send()
+            .await()
+    } finally {
+        // Run disconnect in a NonCancellable context so that when the outer
+        // coroutine is cancelled mid-publish we still send a clean DISCONNECT
+        // (no half-open connection left on the broker) before unwinding.
+        withContext(NonCancellable) {
+            try {
+                client.disconnect().await()
+            } catch (_: Throwable) {
+                // Best-effort cleanup; nothing actionable for the caller here.
+            }
+        }
+    }
+}
+

--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsScreen.kt
@@ -51,6 +51,7 @@ enum class SettingsRoute(@StringRes val titleRes: Int, @StringRes val subtitleRe
     Location(R.string.settings_root_location, R.string.settings_root_location_subtitle),
     Forecasters(R.string.settings_root_forecasters, R.string.settings_root_forecasters_subtitle),
     Calendar(R.string.settings_root_calendar, R.string.settings_root_calendar_subtitle),
+    SmartHome(R.string.settings_root_smart_home, R.string.settings_root_smart_home_subtitle),
     Privacy(R.string.settings_root_privacy, R.string.settings_root_privacy_subtitle),
     About(R.string.settings_root_about),
 }
@@ -206,6 +207,19 @@ fun SettingsScreen(
                 location = state.location,
                 padding = padding,
                 onSetForecastModels = viewModel::setForecastModels,
+            )
+            SettingsRoute.SmartHome -> SmartHomeContent(
+                bridgeEnabled = state.mqttBridgeEnabled,
+                host = state.mqttHost,
+                port = state.mqttPort,
+                useTls = state.mqttUseTls,
+                username = state.mqttUsername,
+                topic = state.mqttTopic,
+                passwordSet = state.mqttPasswordSet,
+                padding = padding,
+                onSetBridgeEnabled = viewModel::setMqttBridgeEnabled,
+                onSaveConfig = viewModel::setMqttConfig,
+                onClearPassword = viewModel::clearMqttPassword,
             )
             SettingsRoute.Privacy -> PrivacyContent(
                 telemetryEnabled = state.telemetryEnabled,

--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsState.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsState.kt
@@ -100,4 +100,19 @@ data class SettingsState(
      * mapping the Auto state resolves through.
      */
     val forecastModels: Set<ForecastModel>? = null,
+    /**
+     * Smart Home / Home Assistant MQTT bridge configuration. Master toggle
+     * (`mqttBridgeEnabled`) gates the publisher; the rest mirror the values
+     * in [UserPreferences] so the Smart Home settings card can render the
+     * config without subscribing to a second flow. `mqttPasswordSet` is a
+     * presence-only mirror of [SecureKeyStore.mqttPasswordConfiguredFlow] so
+     * the "Password saved" indicator never decrypts the stored secret.
+     */
+    val mqttBridgeEnabled: Boolean = false,
+    val mqttHost: String = "",
+    val mqttPort: Int = UserPreferences.DEFAULT_MQTT_PORT,
+    val mqttUseTls: Boolean = false,
+    val mqttUsername: String = "",
+    val mqttTopic: String = UserPreferences.DEFAULT_MQTT_TOPIC,
+    val mqttPasswordSet: Boolean = false,
 )

--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsViewModel.kt
@@ -137,6 +137,12 @@ class SettingsViewModel(
                         useCalendarEvents = prefs.useCalendarEvents,
                         telemetryEnabled = prefs.telemetryEnabled,
                         forecastModels = prefs.forecastModels,
+                        mqttBridgeEnabled = prefs.mqttBridgeEnabled,
+                        mqttHost = prefs.mqttHost.orEmpty(),
+                        mqttPort = prefs.mqttPort,
+                        mqttUseTls = prefs.mqttUseTls,
+                        mqttUsername = prefs.mqttUsername.orEmpty(),
+                        mqttTopic = prefs.mqttTopic,
                     )
                 }
                 // Re-enumerate on first observation and whenever the effective
@@ -152,6 +158,11 @@ class SettingsViewModel(
             }
         }
         viewModelScope.launch { refreshApiKeyStatus() }
+        viewModelScope.launch {
+            keyStore.mqttPasswordConfiguredFlow.collect { set ->
+                _state.update { it.copy(mqttPasswordSet = set) }
+            }
+        }
         workManager?.let { wm ->
             viewModelScope.launch {
                 wm.getWorkInfosForUniqueWorkFlow(FetchAndNotifyWorker.UNIQUE_WORK_NAME_LOCATION_CACHE)
@@ -375,6 +386,41 @@ class SettingsViewModel(
 
     fun setTelemetryEnabled(enabled: Boolean) {
         viewModelScope.launch { settingsRepository.setTelemetryEnabled(enabled) }
+    }
+
+    fun setMqttBridgeEnabled(enabled: Boolean) {
+        viewModelScope.launch { settingsRepository.setMqttBridgeEnabled(enabled) }
+    }
+
+    /**
+     * Persists the broker connection settings. A null / blank [password]
+     * leaves the stored password untouched (useful when the user edits the
+     * host without re-typing the secret); pass an empty string explicitly via
+     * [clearMqttPassword] to clear it. Non-blank passwords are written to
+     * [SecureKeyStore] under a separate Tink AEAD slot from the Gemini key.
+     */
+    fun setMqttConfig(
+        host: String,
+        port: Int,
+        useTls: Boolean,
+        username: String,
+        topic: String,
+        password: String? = null,
+    ) {
+        viewModelScope.launch {
+            settingsRepository.setMqttConfig(
+                host = host,
+                port = port,
+                useTls = useTls,
+                username = username,
+                topic = topic,
+            )
+            if (password != null && password.isNotEmpty()) keyStore.setMqttPassword(password)
+        }
+    }
+
+    fun clearMqttPassword() {
+        viewModelScope.launch { keyStore.clearMqttPassword() }
     }
 
     /**

--- a/app/src/main/kotlin/app/clothescast/ui/settings/SmartHomeSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SmartHomeSettings.kt
@@ -1,0 +1,240 @@
+package app.clothescast.ui.settings
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.unit.dp
+import app.clothescast.R
+import app.clothescast.core.domain.model.UserPreferences
+
+private const val SETUP_GUIDE_URL =
+    "https://github.com/mikelward/clothescast/blob/main/docs/smart-home.md"
+private const val PRIVACY_POLICY_URL =
+    "https://github.com/mikelward/clothescast/blob/main/PRIVACY.md"
+
+@Composable
+internal fun SmartHomeContent(
+    bridgeEnabled: Boolean,
+    host: String,
+    port: Int,
+    useTls: Boolean,
+    username: String,
+    topic: String,
+    passwordSet: Boolean,
+    padding: PaddingValues,
+    onSetBridgeEnabled: (Boolean) -> Unit,
+    onSaveConfig: (host: String, port: Int, useTls: Boolean, username: String, topic: String, password: String?) -> Unit,
+    onClearPassword: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(padding)
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        MqttBridgeCard(
+            enabled = bridgeEnabled,
+            host = host,
+            port = port,
+            useTls = useTls,
+            username = username,
+            topic = topic,
+            passwordSet = passwordSet,
+            onSetEnabled = onSetBridgeEnabled,
+            onSaveConfig = onSaveConfig,
+            onClearPassword = onClearPassword,
+        )
+    }
+}
+
+@Composable
+private fun MqttBridgeCard(
+    enabled: Boolean,
+    host: String,
+    port: Int,
+    useTls: Boolean,
+    username: String,
+    topic: String,
+    passwordSet: Boolean,
+    onSetEnabled: (Boolean) -> Unit,
+    onSaveConfig: (host: String, port: Int, useTls: Boolean, username: String, topic: String, password: String?) -> Unit,
+    onClearPassword: () -> Unit,
+) {
+    val context = LocalContext.current
+    // Local form state seeded from the persisted prefs, rebuilt whenever the
+    // persisted values change so a config edit elsewhere (or a settings reset)
+    // refreshes the fields. The user only commits with Save; partial typing
+    // doesn't reach DataStore until then.
+    var hostField by rememberSaveable(host) { mutableStateOf(host) }
+    var portField by rememberSaveable(port) { mutableStateOf(port.toString()) }
+    var tlsField by rememberSaveable(useTls) { mutableStateOf(useTls) }
+    var userField by rememberSaveable(username) { mutableStateOf(username) }
+    var topicField by rememberSaveable(topic) { mutableStateOf(topic) }
+    var passwordField by rememberSaveable { mutableStateOf("") }
+
+    val parsedPort = remember(portField) { portField.toIntOrNull() }
+    val canSave = hostField.isNotBlank() && parsedPort != null && parsedPort in 1..65535 &&
+        topicField.isNotBlank()
+
+    SectionCard(title = stringResource(R.string.settings_smart_home_mqtt_title)) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = stringResource(R.string.settings_smart_home_mqtt_label),
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier.weight(1f),
+            )
+            Switch(checked = enabled, onCheckedChange = onSetEnabled)
+        }
+        Text(
+            text = stringResource(R.string.settings_smart_home_mqtt_description),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Text(
+            text = stringResource(R.string.settings_smart_home_mqtt_privacy_note),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+
+        if (enabled) {
+            OutlinedTextField(
+                value = hostField,
+                onValueChange = { hostField = it.trim() },
+                label = { Text(stringResource(R.string.settings_smart_home_mqtt_host)) },
+                placeholder = { Text(stringResource(R.string.settings_smart_home_mqtt_host_placeholder)) },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth(),
+            )
+            OutlinedTextField(
+                value = portField,
+                onValueChange = { portField = it.filter { ch -> ch.isDigit() }.take(5) },
+                label = { Text(stringResource(R.string.settings_smart_home_mqtt_port)) },
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth(),
+            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = stringResource(R.string.settings_smart_home_mqtt_tls),
+                    style = MaterialTheme.typography.bodyMedium,
+                    modifier = Modifier.weight(1f),
+                )
+                Switch(
+                    checked = tlsField,
+                    onCheckedChange = { checked ->
+                        tlsField = checked
+                        // Auto-bump the default port when the user toggles TLS
+                        // — saves a manual re-type for the common case
+                        // (8883 for TLS, 1883 plain). If the user has
+                        // explicitly picked a non-default port, leave it.
+                        if (checked && parsedPort == UserPreferences.DEFAULT_MQTT_PORT) {
+                            portField = UserPreferences.DEFAULT_MQTT_TLS_PORT.toString()
+                        } else if (!checked && parsedPort == UserPreferences.DEFAULT_MQTT_TLS_PORT) {
+                            portField = UserPreferences.DEFAULT_MQTT_PORT.toString()
+                        }
+                    },
+                )
+            }
+            OutlinedTextField(
+                value = userField,
+                onValueChange = { userField = it.trim() },
+                label = { Text(stringResource(R.string.settings_smart_home_mqtt_username)) },
+                placeholder = { Text(stringResource(R.string.settings_smart_home_mqtt_username_placeholder)) },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth(),
+            )
+            OutlinedTextField(
+                value = passwordField,
+                onValueChange = { passwordField = it },
+                label = {
+                    Text(
+                        if (passwordSet) {
+                            stringResource(R.string.settings_smart_home_mqtt_password_replace)
+                        } else {
+                            stringResource(R.string.settings_smart_home_mqtt_password)
+                        },
+                    )
+                },
+                visualTransformation = PasswordVisualTransformation(),
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth(),
+            )
+            if (passwordSet) {
+                TextButton(
+                    onClick = {
+                        onClearPassword()
+                        passwordField = ""
+                    },
+                ) { Text(stringResource(R.string.settings_smart_home_mqtt_password_clear)) }
+            }
+            OutlinedTextField(
+                value = topicField,
+                onValueChange = { topicField = it.trim() },
+                label = { Text(stringResource(R.string.settings_smart_home_mqtt_topic)) },
+                supportingText = {
+                    Text(stringResource(R.string.settings_smart_home_mqtt_topic_hint))
+                },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth(),
+            )
+
+            Button(
+                onClick = {
+                    onSaveConfig(
+                        hostField,
+                        parsedPort ?: UserPreferences.DEFAULT_MQTT_PORT,
+                        tlsField,
+                        userField,
+                        topicField,
+                        passwordField.ifEmpty { null },
+                    )
+                    passwordField = ""
+                },
+                enabled = canSave,
+                modifier = Modifier.fillMaxWidth(),
+            ) { Text(stringResource(R.string.settings_smart_home_mqtt_save)) }
+        }
+
+        TextButton(
+            onClick = { openUrl(context, SETUP_GUIDE_URL) },
+            modifier = Modifier.fillMaxWidth(),
+        ) { Text(stringResource(R.string.settings_smart_home_mqtt_setup_guide)) }
+        TextButton(
+            onClick = { openUrl(context, PRIVACY_POLICY_URL) },
+            modifier = Modifier.fillMaxWidth(),
+        ) { Text(stringResource(R.string.settings_smart_home_mqtt_open_privacy)) }
+    }
+}

--- a/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
@@ -535,6 +535,15 @@ class FetchAndNotifyWorker(
             ForecastPeriod.TODAY -> deliverToday(insight, prefs, prose)
             ForecastPeriod.TONIGHT -> deliverTonight(insight, prefs, prose)
         }
+        // Publish the rendered prose to the user's MQTT broker if the
+        // Smart Home bridge is enabled. Both the fresh-fetch and same-day
+        // cache redelivery paths route through this single call site, so
+        // each twice-daily refresh pushes one retained message per period.
+        // The publisher logs and swallows broker / network failures so a
+        // dead broker can't break notification or TTS delivery — by the
+        // time this runs the user-facing delivery above has already
+        // completed.
+        app.mqttPublisher.publishIfEnabled(insight.period, prose)
     }
 
     private suspend fun deliverToday(insight: Insight, prefs: UserPreferences, prose: String) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -342,6 +342,7 @@
     <string name="settings_root_location">Location</string>
     <string name="settings_root_calendar">Calendar</string>
     <string name="settings_root_forecasters">Forecasters</string>
+    <string name="settings_root_smart_home">Smart Home</string>
     <string name="settings_root_privacy">Privacy</string>
     <string name="settings_root_about">About</string>
 
@@ -375,6 +376,7 @@
     <string name="settings_root_location_subtitle">Automatic and Manual Location</string>
     <string name="settings_root_calendar_subtitle">Today\'s events</string>
     <string name="settings_root_forecasters_subtitle">Weather Sources and Models</string>
+    <string name="settings_root_smart_home_subtitle">Home Assistant, MQTT, voice announcements</string>
     <string name="settings_root_privacy_subtitle">Crash + usage reports</string>
 
     <!-- Forecasters sub-page: lets the user pick which numerical weather
@@ -419,6 +421,31 @@
     <string name="settings_privacy_telemetry_description">Sends anonymous crash reports and aggregate usage stats to help the developer fix bugs and decide which features to keep.</string>
     <string name="settings_privacy_telemetry_limits">Never sent: calendar events, location coordinates or place names, insight text or notification text, API keys, precise GPS, advertising IDs.</string>
     <string name="settings_privacy_open_policy">Read full privacy policy</string>
+
+    <!-- Smart Home settings sub-page. The MQTT bridge publishes the rendered
+         insight prose to a user-hosted broker (typically the Mosquitto add-on
+         inside Home Assistant) so HA can speak it on a sensor trigger. Off by
+         default; turning it on relaxes the "insight prose never leaves the
+         device" guarantee documented in PRIVACY.md, so the description spells
+         that out inline. -->
+    <string name="settings_smart_home_mqtt_title">Home Assistant bridge (MQTT)</string>
+    <string name="settings_smart_home_mqtt_label">Publish forecast to MQTT</string>
+    <string name="settings_smart_home_mqtt_description">After each scheduled refresh, ClothesCast publishes today\'s and tonight\'s rendered forecast to your MQTT broker as retained messages, so Home Assistant (or any MQTT consumer) can read the latest value and speak it on a sensor trigger.</string>
+    <string name="settings_smart_home_mqtt_privacy_note">When on, the rendered forecast sentence leaves your device over your network to the broker you configure. See the privacy policy.</string>
+    <string name="settings_smart_home_mqtt_host">Broker host</string>
+    <string name="settings_smart_home_mqtt_host_placeholder">homeassistant.local</string>
+    <string name="settings_smart_home_mqtt_port">Port</string>
+    <string name="settings_smart_home_mqtt_tls">Use TLS</string>
+    <string name="settings_smart_home_mqtt_username">Username (optional)</string>
+    <string name="settings_smart_home_mqtt_username_placeholder">mqtt-user</string>
+    <string name="settings_smart_home_mqtt_password">Password (optional)</string>
+    <string name="settings_smart_home_mqtt_password_replace">Replace password</string>
+    <string name="settings_smart_home_mqtt_password_clear">Clear saved password</string>
+    <string name="settings_smart_home_mqtt_topic">Topic prefix</string>
+    <string name="settings_smart_home_mqtt_topic_hint">Today publishes to {prefix}/today; tonight to {prefix}/tonight.</string>
+    <string name="settings_smart_home_mqtt_save">Save</string>
+    <string name="settings_smart_home_mqtt_setup_guide">Setup guide</string>
+    <string name="settings_smart_home_mqtt_open_privacy">Read privacy details</string>
 
     <string name="settings_api_key_gemini_label">Gemini</string>
 

--- a/app/src/test/kotlin/app/clothescast/mqtt/MqttPublisherTest.kt
+++ b/app/src/test/kotlin/app/clothescast/mqtt/MqttPublisherTest.kt
@@ -1,0 +1,302 @@
+package app.clothescast.mqtt
+
+import app.clothescast.core.domain.model.DeliveryMode
+import app.clothescast.core.domain.model.DistanceUnit
+import app.clothescast.core.domain.model.ForecastPeriod
+import app.clothescast.core.domain.model.Schedule
+import app.clothescast.core.domain.model.TemperatureUnit
+import app.clothescast.core.domain.model.UserPreferences
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.LocalTime
+import java.time.ZoneId
+import kotlin.coroutines.cancellation.CancellationException
+import kotlin.coroutines.coroutineContext
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MqttPublisherTest {
+
+    @BeforeEach
+    fun setUp() {
+        // Mirrors SecureKeyStoreTest — the AndroidDispatcherFactory on the
+        // test classpath calls Looper.getMainLooper() at static init, which
+        // throws under the AGP stub jar. Install a TestMainDispatcher up front.
+        Dispatchers.setMain(UnconfinedTestDispatcher(TestCoroutineScheduler()))
+    }
+
+    @AfterEach
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `publishes today insight to today topic with retained payload`() = runTest {
+        val captured = mutableListOf<PublishCall>()
+        val subject = MqttPublisher(
+            preferences = flowOf(
+                basePrefs.copy(
+                    mqttBridgeEnabled = true,
+                    mqttHost = "192.168.1.10",
+                    mqttPort = 1883,
+                ),
+            ),
+            passwordProvider = { null },
+            publish = capturing(captured),
+        )
+
+        subject.publishIfEnabled(ForecastPeriod.TODAY, "Today, cool and mild. Wear a sweater.")
+
+        captured shouldHaveSize 1
+        val call = captured.single()
+        call.topic shouldBe "clothescast/insight/today"
+        call.payload shouldBe "Today, cool and mild. Wear a sweater."
+        call.config.host shouldBe "192.168.1.10"
+        call.config.port shouldBe 1883
+        call.config.useTls shouldBe false
+    }
+
+    @Test
+    fun `tonight period publishes to tonight topic`() = runTest {
+        val captured = mutableListOf<PublishCall>()
+        val subject = MqttPublisher(
+            preferences = flowOf(
+                basePrefs.copy(
+                    mqttBridgeEnabled = true,
+                    mqttHost = "broker.local",
+                    mqttTopic = "home/forecast",
+                ),
+            ),
+            passwordProvider = { null },
+            publish = capturing(captured),
+        )
+
+        subject.publishIfEnabled(ForecastPeriod.TONIGHT, "Tonight, clear and cool.")
+
+        captured.single().topic shouldBe "home/forecast/tonight"
+    }
+
+    @Test
+    fun `no-op when bridge disabled`() = runTest {
+        val captured = mutableListOf<PublishCall>()
+        val subject = MqttPublisher(
+            preferences = flowOf(
+                basePrefs.copy(
+                    mqttBridgeEnabled = false,
+                    mqttHost = "broker.local",
+                ),
+            ),
+            passwordProvider = { null },
+            publish = capturing(captured),
+        )
+
+        subject.publishIfEnabled(ForecastPeriod.TODAY, "ignored")
+
+        captured shouldHaveSize 0
+    }
+
+    @Test
+    fun `no-op when host blank even if bridge enabled`() = runTest {
+        val captured = mutableListOf<PublishCall>()
+        val subject = MqttPublisher(
+            preferences = flowOf(
+                basePrefs.copy(
+                    mqttBridgeEnabled = true,
+                    mqttHost = null,
+                ),
+            ),
+            passwordProvider = { null },
+            publish = capturing(captured),
+        )
+
+        subject.publishIfEnabled(ForecastPeriod.TODAY, "ignored")
+
+        captured shouldHaveSize 0
+    }
+
+    @Test
+    fun `auth-less prefs do not invoke password provider`() = runTest {
+        val captured = mutableListOf<PublishCall>()
+        var passwordCalls = 0
+        val subject = MqttPublisher(
+            preferences = flowOf(
+                basePrefs.copy(
+                    mqttBridgeEnabled = true,
+                    mqttHost = "broker.local",
+                    mqttUsername = null,
+                ),
+            ),
+            passwordProvider = {
+                passwordCalls++
+                "should-not-be-fetched"
+            },
+            publish = capturing(captured),
+        )
+
+        subject.publishIfEnabled(ForecastPeriod.TODAY, "x")
+
+        passwordCalls shouldBe 0
+        captured.single().config.password shouldBe null
+    }
+
+    @Test
+    fun `username present pulls password from provider`() = runTest {
+        val captured = mutableListOf<PublishCall>()
+        val subject = MqttPublisher(
+            preferences = flowOf(
+                basePrefs.copy(
+                    mqttBridgeEnabled = true,
+                    mqttHost = "broker.local",
+                    mqttUsername = "mqtt-user",
+                ),
+            ),
+            passwordProvider = { "secret-from-keystore" },
+            publish = capturing(captured),
+        )
+
+        subject.publishIfEnabled(ForecastPeriod.TODAY, "x")
+
+        val call = captured.single()
+        call.config.username shouldBe "mqtt-user"
+        call.config.password shouldBe "secret-from-keystore"
+    }
+
+    @Test
+    fun `publish failure is swallowed so worker is not impacted`() = runTest {
+        var attempted = false
+        val subject = MqttPublisher(
+            preferences = flowOf(
+                basePrefs.copy(
+                    mqttBridgeEnabled = true,
+                    mqttHost = "broker.local",
+                ),
+            ),
+            passwordProvider = { null },
+            publish = { _, _, _ ->
+                attempted = true
+                error("simulated broker rejection")
+            },
+        )
+
+        // No exception escapes; the call returns normally.
+        subject.publishIfEnabled(ForecastPeriod.TODAY, "x")
+
+        attempted.shouldBeTrue()
+    }
+
+    @Test
+    fun `topic prefix is sanitised — leading and trailing slashes trimmed`() {
+        MqttPublisher.topicFor("/clothescast/insight/", ForecastPeriod.TODAY) shouldBe
+            "clothescast/insight/today"
+        MqttPublisher.topicFor("home/forecast", ForecastPeriod.TONIGHT) shouldBe
+            "home/forecast/tonight"
+        // Empty / blank base falls back to the documented default so a
+        // hand-edited DataStore can't produce a bare "/today" topic.
+        MqttPublisher.topicFor("", ForecastPeriod.TODAY) shouldBe "clothescast/insight/today"
+        MqttPublisher.topicFor("   ", ForecastPeriod.TONIGHT) shouldBe "clothescast/insight/tonight"
+    }
+
+    @Test
+    fun `publish throwing CancellationException propagates upward`() = runTest {
+        val subject = MqttPublisher(
+            preferences = flowOf(
+                basePrefs.copy(mqttBridgeEnabled = true, mqttHost = "broker.local"),
+            ),
+            passwordProvider = { null },
+            publish = { _, _, _ -> throw CancellationException("simulated worker cancel") },
+        )
+
+        // Without explicit CancellationException rethrow inside the publish
+        // try/catch, this would be swallowed and the call would return
+        // normally — letting WorkManager's stopped state be misreported as
+        // a successful delivery.
+        shouldThrow<CancellationException> {
+            subject.publishIfEnabled(ForecastPeriod.TODAY, "x")
+        }
+    }
+
+    @Test
+    fun `preferences flow throwing CancellationException propagates upward`() = runTest {
+        val subject = MqttPublisher(
+            preferences = flow { throw CancellationException("flow cancelled") },
+            passwordProvider = { null },
+            publish = { _, _, _ -> error("must not run when prefs read is cancelled") },
+        )
+
+        shouldThrow<CancellationException> {
+            subject.publishIfEnabled(ForecastPeriod.TODAY, "x")
+        }
+    }
+
+    @Test
+    fun `password provider throwing CancellationException propagates upward`() = runTest {
+        val subject = MqttPublisher(
+            preferences = flowOf(
+                basePrefs.copy(
+                    mqttBridgeEnabled = true,
+                    mqttHost = "broker.local",
+                    mqttUsername = "mqtt-user",
+                ),
+            ),
+            passwordProvider = { throw CancellationException("keystore read cancelled") },
+            publish = { _, _, _ -> error("must not run when password read is cancelled") },
+        )
+
+        shouldThrow<CancellationException> {
+            subject.publishIfEnabled(ForecastPeriod.TODAY, "x")
+        }
+    }
+
+    @Test
+    fun `publish timeout triggers a no-throw fallthrough`() = runTest {
+        val subject = MqttPublisher(
+            preferences = flowOf(
+                basePrefs.copy(
+                    mqttBridgeEnabled = true,
+                    mqttHost = "broker.local",
+                ),
+            ),
+            passwordProvider = { null },
+            publish = { _, _, _ ->
+                // Hang past the configured timeout. Yields so withTimeoutOrNull
+                // can fire; runTest's virtual time skips ahead deterministically.
+                while (true) {
+                    coroutineContext.ensureActive()
+                    kotlinx.coroutines.delay(1_000)
+                }
+            },
+            publishTimeoutMs = 50L,
+        )
+
+        subject.publishIfEnabled(ForecastPeriod.TODAY, "x")
+        // Reaching this line means withTimeoutOrNull returned without surfacing
+        // a TimeoutCancellationException — the contract the worker relies on.
+    }
+
+    private data class PublishCall(val config: MqttConfig, val topic: String, val payload: String)
+
+    private fun capturing(into: MutableList<PublishCall>): suspend (MqttConfig, String, String) -> Unit =
+        { config, topic, payload -> into.add(PublishCall(config, topic, payload)) }
+
+    private val basePrefs = UserPreferences(
+        schedule = Schedule(time = LocalTime.of(7, 0), days = Schedule.EVERY_DAY, zoneId = ZoneId.of("UTC")),
+        deliveryMode = DeliveryMode.NOTIFICATION_AND_TTS,
+        temperatureUnit = TemperatureUnit.CELSIUS,
+        distanceUnit = DistanceUnit.KILOMETERS,
+        clothesRules = emptyList(),
+    )
+}

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Settings.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Settings.kt
@@ -381,9 +381,33 @@ data class UserPreferences(
      * chip / per-model chart don't depend on a particular ordering.
      */
     val forecastModels: Set<ForecastModel>? = null,
+    /**
+     * Optional Smart Home / Home Assistant MQTT bridge. When [mqttBridgeEnabled]
+     * is true and [mqttHost] is set, the worker publishes the rendered insight
+     * prose to a retained topic on the user's MQTT broker after each twice-daily
+     * refresh, so Home Assistant (or any MQTT-aware consumer) can speak it on
+     * a sensor trigger without reimplementing the clothes / insight logic in HA.
+     * Off by default — this relaxes the "insight prose never leaves the device"
+     * guarantee, so it's opt-in and surfaced in Settings → Smart Home with an
+     * inline privacy note that links to PRIVACY.md.
+     *
+     * Topics are derived from [mqttTopic] as the prefix + the lowercased
+     * [ForecastPeriod] name (e.g. `clothescast/insight/today` and
+     * `clothescast/insight/tonight`), so morning and evening insights are
+     * separately addressable from HA automations.
+     */
+    val mqttBridgeEnabled: Boolean = false,
+    val mqttHost: String? = null,
+    val mqttPort: Int = DEFAULT_MQTT_PORT,
+    val mqttUseTls: Boolean = false,
+    val mqttUsername: String? = null,
+    val mqttTopic: String = DEFAULT_MQTT_TOPIC,
 ) {
     companion object {
         const val DEFAULT_GEMINI_VOICE = "Despina"
+        const val DEFAULT_MQTT_PORT = 1883
+        const val DEFAULT_MQTT_TLS_PORT = 8883
+        const val DEFAULT_MQTT_TOPIC = "clothescast/insight"
     }
 }
 

--- a/docs/smart-home.md
+++ b/docs/smart-home.md
@@ -1,0 +1,215 @@
+# Smart Home setup guide
+
+ClothesCast can publish the rendered forecast sentence to your MQTT
+broker after each scheduled twice-daily refresh, so Home Assistant (or
+any other MQTT-aware consumer) can speak it on a trigger of your choice
+— a wardrobe door opening, a bathroom humidity spike after a shower, a
+fixed time of day, or any other automation you wire up.
+
+This is the "single source of truth lives in the app" path: your tuned
+clothes rules and the rain / calendar / evening-event heuristics all
+stay in ClothesCast, and Home Assistant is just the dumb plumbing that
+reads a string and speaks it.
+
+The bridge is **off by default**. Turning it on relaxes the
+"insight prose never leaves the device" guarantee documented in
+[PRIVACY.md](../PRIVACY.md) — but only to a broker you configure
+yourself; no developer-operated service ever sees the payload.
+
+## App-side setup
+
+1. Open **Settings → Smart Home → Home Assistant bridge (MQTT)** and
+   toggle "Publish forecast to MQTT" on.
+2. Enter your broker's hostname (e.g. `homeassistant.local`).
+3. Set the port. Defaults to `1883` plain / `8883` TLS — the toggle
+   swaps the port for you when you flip TLS.
+4. Optionally enter a username + password. The password is stored
+   encrypted on-device under the same Tink-AEAD slot the Gemini API
+   key uses.
+5. Topic prefix defaults to `clothescast/insight`. Today's forecast
+   publishes to `<prefix>/today`; tonight's to `<prefix>/tonight`.
+6. Tap **Save**.
+
+The next scheduled refresh (07:00 by default for today, 19:00 for
+tonight — configurable in Settings → Schedule) will publish a retained
+MQTT message to each topic.
+
+## Broker
+
+### Install Mosquitto
+
+If you don't already have an MQTT broker, install the **Mosquitto
+broker** add-on inside Home Assistant
+(Settings → Add-ons → Add-on Store → Mosquitto broker → Install →
+Start). You don't need to touch the **Configuration** tab — Log
+Destinations and Log Types can stay on their defaults.
+
+### Create a dedicated user for ClothesCast
+
+The Mosquitto HA add-on uses Home Assistant's own user system for MQTT
+authentication by default, so you create the MQTT account the same
+way as any other HA user:
+
+1. **Settings → People → Users → Add User**.
+2. Display name: `ClothesCast`. Username: `clothescast`.
+3. Set a strong password — this is what you'll paste into the
+   ClothesCast app, not your everyday HA login.
+4. **Leave "Administrator" unchecked.** The publisher only needs to
+   publish on a single topic; admin rights would give it the run of
+   the broker.
+5. Save. Then in the ClothesCast app: Settings → Smart Home → enter
+   your broker host, leave port `1883` (or flip TLS for `8883`), tick
+   the username field and paste the password, save.
+
+Don't reuse your own HA user for this. A dedicated account makes the
+publisher's traffic easy to spot in MQTT logs and makes the access
+revocable in one click if you ever want to turn the bridge off
+permanently.
+
+### (Optional) Least-privilege ACL
+
+By default the Mosquitto add-on grants every authenticated HA user
+full access to every topic. For a personal LAN-only setup that's
+fine. If you'd rather lock the `clothescast` user down to only the
+topics ClothesCast actually writes:
+
+1. Create `/share/mosquitto/acl.conf` (via the **File Editor**
+   add-on, the **Studio Code Server** add-on, or SSH) with:
+   ```
+   user clothescast
+   topic write clothescast/insight/#
+   ```
+   That grants write-only access on the topic prefix and nothing else.
+   Adjust the topic if you customised the prefix in the ClothesCast
+   Smart Home settings.
+2. Open the Mosquitto broker add-on's **Configuration** tab and set:
+   ```yaml
+   customize:
+     active: true
+     folder: mosquitto
+   ```
+   Save.
+3. **Restart** the add-on so it picks up the new ACL.
+
+Home Assistant's MQTT integration itself reads via the broker's own
+internal connection (a separate, privileged client), so the ACL above
+only constrains the ClothesCast publisher — it doesn't break HA's
+ability to subscribe to the topic for the automation that speaks the
+forecast.
+
+> If you're running a **standalone Mosquitto** outside Home Assistant
+> instead of the HA add-on, the user creation step uses
+> `mosquitto_passwd -c /etc/mosquitto/passwd clothescast` and the
+> same ACL file syntax in
+> `mosquitto.conf` (`acl_file /etc/mosquitto/acl`). HA-side YAML for
+> reading the sensor is identical.
+
+## Home Assistant — reading the sensor
+
+Add the following to `configuration.yaml` (or anywhere your
+`mqtt:` block lives):
+
+```yaml
+mqtt:
+  sensor:
+    - name: "Clothescast today"
+      unique_id: clothescast_today
+      state_topic: "clothescast/insight/today"
+      value_template: "{{ value }}"
+    - name: "Clothescast tonight"
+      unique_id: clothescast_tonight
+      state_topic: "clothescast/insight/tonight"
+      value_template: "{{ value }}"
+```
+
+Restart Home Assistant or reload MQTT entries; the sensors should
+populate within seconds of the next ClothesCast refresh (or instantly,
+if you've already done one — retained messages are delivered to new
+subscribers on connect).
+
+## Home Assistant — speaking the sensor on Google Home
+
+As of mid-2026, getting Google Home / Nest devices to actually *speak*
+arbitrary text on demand is genuinely fiddly — Google has been actively
+churning the Cast pipeline and several "obvious" paths are flaky on
+Nest Minis specifically. Three options, ranked by "should work":
+
+### Option A (recommended): `notify.google_assistant_sdk`
+
+Uses Google's *own* broadcast pipeline — the same backend as a spoken
+"Hey Google, broadcast …" — rather than pushing audio over Cast.
+Because it sidesteps Cast TTS entirely, it tends to work where
+`tts.cloud_say` and Music Assistant `mass.announce` currently fail.
+
+Setup needs a Google Cloud project with OAuth credentials added to
+Home Assistant (one-time setup, documented in the
+[google_assistant_sdk integration page](https://www.home-assistant.io/integrations/google_assistant_sdk/)).
+
+**Known quirk:** the `target:` field only honours specific speakers
+when Home Assistant's language is `en-US`; non-en-US installs broadcast
+to all speakers regardless of `target:`. For a wardrobe-door
+announcement that's probably fine.
+
+```yaml
+automation:
+  - alias: "Speak forecast when wardrobe opens"
+    trigger:
+      platform: state
+      entity_id: binary_sensor.wardrobe_door
+      to: "on"
+    action:
+      service: notify.google_assistant_sdk
+      data:
+        message: "{{ states('sensor.clothescast_today') }}"
+```
+
+### Option B: Music Assistant `mass.announce`
+
+Cast-based, but wraps Cast TTS with state-restoration (it resumes
+whatever the speaker was playing) and is the community-recommended
+modern replacement for ad-hoc `tts.cloud_say` automations. Still rides
+the Cast pipe, so subject to the early-2026 "Nest Mini intermittently
+silent" reports — but Music Assistant's player-state handling masks a
+lot of the flakiness. See the
+[Music Assistant announcement docs](https://www.music-assistant.io/integration/announcements/).
+
+### Option C: `tts.cloud_say` → `media_player.*` Cast
+
+The classic, simplest setup — but currently the **least** reliable on
+Nest Mini specifically. Listed for completeness; not recommended as
+the first thing to try. If it works on your hardware, great; if it
+doesn't, jump to Option A.
+
+## Troubleshooting
+
+- **No payload arriving.** Subscribe from a terminal that's on the
+  same network as the broker:
+  ```
+  mosquitto_sub -h <broker-host> -u <user> -P <pass> -t 'clothescast/insight/#' -v
+  ```
+  Then trigger a refresh from the ClothesCast Today screen. The
+  payload should appear within ~5 seconds of the
+  `Insight delivered for …` log line.
+- **MQTT publish failed in the diag log.** The broker host or port is
+  wrong, the credentials are wrong, or the device isn't on the same
+  network as the broker. The publisher uses a 5-second timeout, so a
+  silently-unreachable broker logs a single "MQTT publish timed out"
+  line and the worker continues to its next run.
+- **Sensor exists but stays "unknown" in Home Assistant.** The retained
+  message hasn't been published yet. Either the bridge is off in
+  ClothesCast settings, or the broker hasn't seen any refresh since you
+  added the sensor. Trigger a manual refresh from the ClothesCast Today
+  screen.
+- **Sensor populates, but Google Home doesn't speak.** Skip to the
+  three-option list above. The "speak the value" step is independent
+  of the "read the value" step and is where most Google Home /
+  Home Assistant deployments hit their wall.
+
+## Privacy
+
+See [PRIVACY.md](../PRIVACY.md) for the full data-handling boundary.
+Quickly: the bridge is off by default, and turning it on sends the
+rendered forecast sentence to **your own broker** — not to a
+developer-operated service. The payload is the same string you see in
+the notification, including any calendar-event tie-in clause if you
+have the calendar tie-in enabled.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -52,6 +52,12 @@ playAppUpdate = "2.1.0"
 firebaseBom = "33.7.0"
 gmsGoogleServices = "4.4.2"
 firebaseCrashlyticsPlugin = "3.0.2"
+# HiveMQ MQTT Client — used by the optional Smart Home bridge to publish the
+# rendered insight prose to a user-hosted MQTT broker (Mosquitto add-on inside
+# Home Assistant, typically). Pure-Java + Netty; no JNI. The publisher uses the
+# blocking client wrapped in withContext(Dispatchers.IO), so no Reactor /
+# CompletableFuture await plumbing is needed in :app.
+hivemqMqttClient = "1.3.3"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -117,6 +123,8 @@ play-app-update-ktx = { group = "com.google.android.play", name = "app-update-kt
 firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebaseBom" }
 firebase-analytics = { group = "com.google.firebase", name = "firebase-analytics" }
 firebase-crashlytics = { group = "com.google.firebase", name = "firebase-crashlytics" }
+
+hivemq-mqtt-client = { group = "com.hivemq", name = "hivemq-mqtt-client", version.ref = "hivemqMqttClient" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary

Adds an optional **Smart Home / Home Assistant MQTT bridge** in
Settings → Smart Home. Off by default. When enabled, the worker
publishes today's and tonight's rendered forecast sentence to your
MQTT broker as retained messages after each scheduled refresh, so
Home Assistant (or any MQTT consumer) can read the value and speak
it on a sensor trigger (wardrobe door, bathroom humidity, fixed time
of day, whatever fires the automation).

The point is to keep clothescast as the single source of truth for
the tuned clothes rules + rain heuristic + calendar tie-in, and let
HA be the dumb plumbing that reads a string and speaks it.

## Scope

**App side** — everything in this PR:

- New `MqttPublisher` (`app/src/main/kotlin/app/clothescast/mqtt/`) —
  thin layer over HiveMQ MQTT Client. Connect → publish → disconnect
  per refresh, ~5s timeout, log-and-swallow on failure so a dead
  broker can't break notification or TTS delivery.
- Hook lives in `FetchAndNotifyWorker.deliver(...)` so the
  fresh-fetch and same-day-cache redelivery paths both publish.
- New top-level "Smart Home" Settings section (sibling of Privacy),
  with master toggle, broker host / port / TLS, optional username +
  password, and topic prefix. Password is stored alongside the
  Gemini key in `SecureKeyStore` under a separate Tink AEAD slot.
- Topics: `<prefix>/today` and `<prefix>/tonight` (default prefix
  `clothescast/insight`) — separate topics so morning and evening
  HA automations can target them independently.

**HA side** — out of scope to *implement*, documented in detail:

- `docs/smart-home.md` is a durable setup guide linked from the
  in-app settings card and from this PR body. Covers app-side
  config, the Mosquitto add-on, the MQTT sensor YAML, and three
  options for actually getting Google Home / Nest to speak the
  value: `notify.google_assistant_sdk` (recommended — uses Google's
  broadcast pipeline, sidesteps the flaky Cast TTS path), Music
  Assistant `mass.announce`, and `tts.cloud_say` as the classic
  fallback. Each option has its current-state caveat called out
  (Nest Mini intermittently silent on Cast paths in early 2026,
  `target:` only honoured on en-US for the SDK, etc.).

## Privacy boundary change

Today the rendered insight prose **never** leaves the device — that
guarantee is in `PRIVACY.md`'s "What's not sent" hard-limit list.
This PR relaxes that to "may be published to a user-hosted broker
if you opt in." Concretely:

- Bridge is **off by default**.
- Destination is always **your own broker** (typically the Mosquitto
  add-on inside your own HA instance) — never a developer-operated
  service.
- Payload is the same string you see in the notification, including
  the calendar tie-in clause when that's enabled.
- The broker password (if set) is stored on-device encrypted with
  the same Tink AEAD pattern as the Gemini API key.

`PRIVACY.md` is updated with:

- A new "Smart Home / Home Assistant bridge" section under "Data the
  app handles".
- A new TL;DR bullet.
- An exception line in the "No insight prose…" hard-limit so the
  list still reads honestly.
- A new row in the third-party services table noting the user's
  broker as the destination.
- A changelog entry dated 2026-05-16.

## Implementation notes

- HiveMQ MQTT Client pulls in Netty. R8 surfaced ~50 missing-class
  errors for optional Netty integrations not on the Android
  classpath (epoll, tcnative, log4j adapters, Jetty ALPN / NPN,
  BlockHound, websocket / proxy handlers). `proguard-rules.pro` now
  silences those with `-dontwarn` — list mirrors R8's
  `missing_rules.txt`. None of those code paths are exercised by the
  plain-TCP / TLS-via-JSSE publisher.
- `META-INF/INDEX.LIST` and `io.netty.versions.properties` are
  duplicated across the six Netty submodules; both are excluded in
  the AGP packaging block. Neither is referenced at runtime.

## Test plan

- [x] `:core:domain:test :core:data:test :app:testDebugUnitTest` —
  all green; new `MqttPublisherTest` covers topic naming, disabled /
  no-host no-ops, password provider gating, swallow-on-failure, and
  the publish timeout.
- [x] `:app:assembleDebug` — clean, R8 minification succeeds.
- [ ] Manual E2E (out-of-sandbox, on real device):
  - [ ] Mosquitto running locally (`docker run -p 1883:1883
    eclipse-mosquitto`).
  - [ ] `mosquitto_sub -h <host> -t 'clothescast/insight/#' -v`
    shows the prose payload within ~5s of `"Insight delivered for
    …"` in the diag log.
  - [ ] Bridge OFF → nothing publishes.
  - [ ] Authenticated broker → username + password reach the broker.
  - [ ] TLS toggle bumps default port 1883 ↔ 8883 in the form.
- [ ] HA side (per the docs):
  - [ ] `mqtt:` sensor populates with the published prose.
  - [ ] `notify.google_assistant_sdk` speaks the sensor value on a
    contact-sensor trigger.

## Setup guide

[`docs/smart-home.md`](https://github.com/mikelward/clothescast/blob/claude/smart-home-weather-announcements-GqO22/docs/smart-home.md)
— app config, broker install, HA YAML, and the three "actually speak
the value" options with their current-state caveats.

https://claude.ai/code/session_01VJAatDSm5xC1dWwQRP8dqB

---
_Generated by [Claude Code](https://claude.ai/code/session_01VJAatDSm5xC1dWwQRP8dqB)_