### PR TITLE
Fix the Smart Home MQTT bridge crashing under R8

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -34,3 +34,25 @@
 -dontwarn org.eclipse.jetty.alpn.**
 -dontwarn org.eclipse.jetty.npn.**
 -dontwarn reactor.blockhound.integration.**
+
+# HiveMQ MQTT Client wires its Netty pipeline through an internal Dagger 2
+# graph. The generated factories (e.g. *_Factory, DoubleCheck Provider chains)
+# are resolved by name at runtime when buildAsync() constructs the client, so
+# R8 must not strip or rename them. Without these rules the publisher crashes
+# at the first publishWith() call with NoClassDefFoundError on an obfuscated
+# Dagger factory (z5.b etc.). Keeping the whole package is heavier than the
+# minimum set but is the only reliable shape — picking individual generated
+# classes is brittle across HiveMQ versions.
+-keep class com.hivemq.client.** { *; }
+-keepclassmembers class com.hivemq.client.** { *; }
+
+# Netty resolves its logger and event-loop implementations via service-loader
+# style reflection on a string class name. Without the keep rules below R8
+# can devirtualize / strip the JDK-logger backstop, leaving HiveMQ unable to
+# install a logger at startup. The transitive Netty deps the MQTT client
+# uses (buffer, codec, handler, transport, resolver) all rely on this path.
+-keep class io.netty.util.internal.logging.** { *; }
+-keep class io.netty.util.concurrent.** { *; }
+-keepclassmembers class io.netty.** {
+    private <init>(...);
+}

--- a/app/src/main/kotlin/app/clothescast/mqtt/MqttPublisher.kt
+++ b/app/src/main/kotlin/app/clothescast/mqtt/MqttPublisher.kt
@@ -51,11 +51,22 @@ class MqttPublisher(
             preferences.first()
         } catch (ce: CancellationException) {
             throw ce
-        } catch (_: Throwable) {
+        } catch (t: Throwable) {
+            DiagLog.w(TAG, "Failed to read settings for ${period.name.lowercase()} insight MQTT publish; skipping.", t)
             return
         }
+        // Bridge-off is the silent-no-op path for users who haven't opted in;
+        // not logged to keep the diag stream clean for the 99% no-bridge case.
         if (!prefs.mqttBridgeEnabled) return
-        val host = prefs.mqttHost?.takeIf { it.isNotBlank() } ?: return
+        val host = prefs.mqttHost?.takeIf { it.isNotBlank() } ?: run {
+            DiagLog.w(
+                TAG,
+                "MQTT bridge is enabled but no broker host is configured; " +
+                    "${period.name.lowercase()} insight not published. " +
+                    "Set the host in Settings → Smart Home.",
+            )
+            return
+        }
         val password = if (prefs.mqttUsername.isNullOrBlank()) {
             null
         } else {
@@ -63,7 +74,8 @@ class MqttPublisher(
                 passwordProvider()
             } catch (ce: CancellationException) {
                 throw ce
-            } catch (_: Throwable) {
+            } catch (t: Throwable) {
+                DiagLog.w(TAG, "Failed to read MQTT password from keystore; attempting anonymous connect.", t)
                 null
             }
         }
@@ -75,10 +87,23 @@ class MqttPublisher(
             password = password,
         )
         val topic = topicFor(prefs.mqttTopic, period)
+        val scheme = if (prefs.mqttUseTls) "mqtts" else "mqtt"
+        // Entry log: fires only when the bridge is enabled and the host is set.
+        // If you see this line in the diag log, the publisher reached the
+        // network attempt; if you don't, the bridge is either off or the host
+        // is blank (and the warn above will tell you which).
+        DiagLog.i(
+            TAG,
+            "MQTT bridge enabled; publishing ${period.name.lowercase()} insight to " +
+                "$scheme://$host:${prefs.mqttPort}/$topic " +
+                "(auth=${!prefs.mqttUsername.isNullOrBlank()}, " +
+                "password=${if (password != null) "set" else "none"}, " +
+                "payload=${prose.length} chars).",
+        )
         withTimeoutOrNull(publishTimeoutMs) {
             try {
                 publish(config, topic, prose)
-                DiagLog.i(TAG, "Published ${period.name.lowercase()} insight to mqtt://$host:${prefs.mqttPort}/$topic")
+                DiagLog.i(TAG, "Published ${period.name.lowercase()} insight to $scheme://$host:${prefs.mqttPort}/$topic")
             } catch (ce: CancellationException) {
                 // Re-raise so withTimeoutOrNull sees a timeout (returns null
                 // and we log "timed out" below) and so a WorkManager-issued
@@ -86,9 +111,9 @@ class MqttPublisher(
                 // shadowed by a misleading "MQTT publish failed" line.
                 throw ce
             } catch (t: Throwable) {
-                DiagLog.w(TAG, "MQTT publish failed to $host:${prefs.mqttPort}/$topic", t)
+                DiagLog.w(TAG, "MQTT publish failed to $scheme://$host:${prefs.mqttPort}/$topic", t)
             }
-        } ?: DiagLog.w(TAG, "MQTT publish timed out after ${publishTimeoutMs}ms to $host:${prefs.mqttPort}/$topic")
+        } ?: DiagLog.w(TAG, "MQTT publish timed out after ${publishTimeoutMs}ms to $scheme://$host:${prefs.mqttPort}/$topic")
     }
 
     companion object {


### PR DESCRIPTION
## Summary

PR #504 wired the Smart Home MQTT bridge on the JVM test classpath
fine, but on a real APK the first publish blows up with
`NoClassDefFoundError: z5.b` (obfuscated Dagger Provider chain).
HiveMQ MQTT Client uses Dagger 2 internally to wire its Netty
pipeline, and the generated `DoubleCheck` Provider chain is
resolved by class name at runtime when `buildAsync()` constructs
the client. This project sets `isMinifyEnabled = true` on **both**
debug and release variants, so the moment R8 strips or renames a
factory that Dagger looks up by name, the chain explodes. Unit
tests don't catch it because R8 doesn't run on the test classpath.

## Fix

**R8 keep rules** for the whole `com.hivemq.client.**` package plus
the Netty service-loader paths the MQTT pipeline uses
(`io.netty.util.internal.logging.**`, `io.netty.util.concurrent.**`,
and the no-arg private constructors Netty resolves reflectively).
Heavy but reliable — picking individual generated classes is
brittle across HiveMQ versions.

**Diagnostic logging at every silent-return branch in
`publishIfEnabled`** so future "publisher didn't run" mysteries are
self-diagnosing from the diag log:

- **Entry log** when the bridge is enabled, showing the destination
  URL (with `mqtt://` vs `mqtts://` reflecting the TLS toggle),
  whether auth is configured, whether a password is set, and the
  payload size. Fires only after the bridge-on + host-set checks
  pass, so seeing it in the diag log means the network attempt was
  reached.
- **Warn** when the bridge is enabled but the broker host is blank
  (previously a silent no-op).
- **Warn** when the preferences read or password lookup throws
  (previously a silent return after `runCatching`).
- **Bridge-off stays silent** — it's the no-opt-in case for the
  99% of users who haven't enabled the bridge; no need to spam.

## Triage shape after this PR

If a user reports "MQTT bridge isn't working", their bug-report
diag log now tells you exactly which leg the publisher took:

| Log line                                       | Diagnosis                                 |
|------------------------------------------------|-------------------------------------------|
| (nothing matching `MqttPublisher`)             | Bridge is off, or APK predates the bridge |
| `enabled but no broker host is configured`     | Host field is blank in settings           |
| `MQTT bridge enabled; publishing today …`      | Reached network attempt — see next line   |
| `Published today insight to …`                 | ✓ Success                                 |
| `MQTT publish failed to … <Exception>`         | Auth / connection / broker reject         |
| `MQTT publish timed out after 5000ms to …`     | Broker took TCP but never PUBACKed        |

## Test plan

- [x] `:app:testDebugUnitTest` — `MqttPublisherTest` (all 12 cases)
  still green; new logs don't change observable behaviour
- [x] `:app:assembleDebug` — R8 minification succeeds with the new
  keep rules, no new missing-class warnings
- [ ] Manual on-device: install the new APK, enable the bridge with
  a real broker, tap Refresh on Today — the diag log should show
  the entry log followed by either the success line or a concrete
  exception (no more `NoClassDefFoundError`)

## Followups

A second PR will address the password-field UX (the "Replace
password" field sitting empty when a password is already saved
implies you must retype, but you don't — and Save with empty input
preserves the stored password). Same fix pattern applies to the
Gemini key entry; both get the "hide the input when a credential is
already saved" treatment.

https://claude.ai/code/session_01VJAatDSm5xC1dWwQRP8dqB

---
_Generated by [Claude Code](https://claude.ai/code/session_01VJAatDSm5xC1dWwQRP8dqB)_