### PR TITLE
Fix the Smart Home MQTT bridge crashing on first publish

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -33,7 +33,28 @@
 -dontwarn org.apache.logging.log4j.**
 -dontwarn org.eclipse.jetty.alpn.**
 -dontwarn org.eclipse.jetty.npn.**
--dontwarn reactor.blockhound.integration.**
+-dontwarn reactor.blockhound.**
+
+# Keeping all of io.netty.** (below) brings every optional codec / native /
+# Graal / JDK-internal class that Netty conditionally references back into the
+# R8 input. None are reachable from an MQTT publisher that just opens a TLS
+# socket and publishes a UTF-8 string — they're all alternative codec paths
+# (Brotli, Zstd, jzlib, LZ4, LZF, LZMA), protobuf serialization, JBoss
+# marshalling, GraalVM/SVM substitution annotations, and JDK-private SSL
+# self-signed cert utilities — but their references would trip R8 without
+# these warnings suppressed. List harvested from missing_rules.txt; if a
+# Netty version bump adds new optional integrations, re-run assembleDebug
+# and append any new ones here.
+-dontwarn com.aayushatharva.brotli4j.**
+-dontwarn com.github.luben.zstd.**
+-dontwarn com.google.protobuf.**
+-dontwarn com.jcraft.jzlib.**
+-dontwarn com.ning.compress.**
+-dontwarn com.oracle.svm.core.annotate.**
+-dontwarn lzma.sdk.**
+-dontwarn net.jpountz.**
+-dontwarn org.jboss.marshalling.**
+-dontwarn sun.security.x509.**
 
 # HiveMQ MQTT Client wires its Netty pipeline through an internal Dagger 2
 # graph. The generated factories (e.g. *_Factory, DoubleCheck Provider chains)
@@ -51,8 +72,18 @@
 # can devirtualize / strip the JDK-logger backstop, leaving HiveMQ unable to
 # install a logger at startup. The transitive Netty deps the MQTT client
 # uses (buffer, codec, handler, transport, resolver) all rely on this path.
--keep class io.netty.util.internal.logging.** { *; }
--keep class io.netty.util.concurrent.** { *; }
--keepclassmembers class io.netty.** {
-    private <init>(...);
-}
+#
+# Beyond logging, Netty's buffer layer reflectively resolves methods like
+# `AbstractByteBufAllocator#toLeakAwareBuffer` from its `ResourceLeakDetector`
+# static init — R8 has no way to see that call graph and will both rename and
+# strip the target methods, blowing up the encoder construction chain at the
+# first publish with
+# "Can't find '[toLeakAwareBuffer]' in <obfuscated>". The reliable fix is to
+# keep all of `io.netty.**` intact: the buffer/codec/handler classes are
+# transitively referenced through reflection from initializers we can't fully
+# enumerate, and trying to pick individual classes is brittle across Netty
+# point releases. The `-dontwarn` lines above already permit the optional
+# integrations (epoll / tcnative / websockets / log4j / Jetty ALPN / proxy
+# / BlockHound) to keep references to classes we don't ship.
+-keep class io.netty.** { *; }
+-keepclassmembers class io.netty.** { *; }


### PR DESCRIPTION
## Summary

PR #506 made the HiveMQ Dagger graph survive R8, but only kept Netty's
`util.internal.logging.**` and `util.concurrent.**`. The actual
publisher crash on a 871 APK was one library deeper: Netty's buffer
layer reflectively resolves `AbstractByteBufAllocator#toLeakAwareBuffer`
from `AbstractByteBuf.<clinit>` for leak-detection wiring. R8 — which
can't see the reflective lookup — both stripped the method and renamed
its enclosing class, so the first publish crashed inside
`MqttPingReqEncoder.<clinit>` with:

```
ExceptionInInitializerError at MqttPingReqEncoder.<clinit>
Caused by: IllegalArgumentException: Can't find '[toLeakAwareBuffer]' in d8.b
```

## Diagnostics worked as intended ✅

The diagnostic logs from PR #506 pinpointed the failure cleanly. The
871 bug-report log read:

```
I MqttPublisher: MQTT bridge enabled; publishing today insight to
  mqtts://homeassistant.local:8883/clothescast/insight/today
  (auth=true, password=set, payload=91 chars).
W MqttPublisher: MQTT publish failed to mqtts://...
  java.lang.ExceptionInInitializerError
  ... (HiveMQ class names now visible thanks to the previous keep rule)
  Caused by: IllegalArgumentException: Can't find '[toLeakAwareBuffer]' in d8.b
```

So the entry log + the unobfuscated HiveMQ side of the stack +
`d8.b` (an obfuscated Netty class) made it obvious that round two was
Netty stripping.

## Fix

**Keep `io.netty.**` in full**, mirroring the
`com.hivemq.client.**` rule from PR #506. The Netty
buffer/codec/handler/transport/resolver paths are all transitively
reachable through Netty's own reflective initializers; picking
individual classes is brittle across Netty point releases.

**Broaden the `-dontwarn` set** to cover every optional codec /
integration Netty conditionally references — Brotli, Zstd, jzlib, LZ4,
LZF, LZMA, protobuf, JBoss marshalling, GraalVM/SVM substitution
annotations, and JDK-private SSL self-signed cert utilities. None are
reachable from an MQTT publisher that just opens a TLS socket and
publishes a UTF-8 string. List harvested from R8's
`missing_rules.txt`; future Netty version bumps may add more.

## Test plan

- [x] `:app:assembleDebug` — R8 minification succeeds with the new
  rules, no missing-class errors
- [x] `:app:testDebugUnitTest` — `MqttPublisherTest` still green
- [ ] Manual on-device: install the new APK, tap Refresh on Today —
  the diag log should show `Published today insight to mqtts://…`
  (instead of an exception)

## APK size cost

Keeping all of `io.netty.**` brings in the unused codec / proxy /
websocket / native paths that R8 was previously stripping (with the
attendant references-to-missing-classes warnings). The trade-off is
APK size for correctness; the previous round's targeted keeps weren't
sufficient to cover Netty's internal reflective graph.

https://claude.ai/code/session_01VJAatDSm5xC1dWwQRP8dqB

---
_Generated by [Claude Code](https://claude.ai/code/session_01VJAatDSm5xC1dWwQRP8dqB)_