### PR TITLE
Smart Home MQTT bridge now publishes to your broker

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -87,3 +87,27 @@
 # / BlockHound) to keep references to classes we don't ship.
 -keep class io.netty.** { *; }
 -keepclassmembers class io.netty.** { *; }
+
+# JCTools (org.jctools) is Netty's high-performance queue library, used for
+# MpscArrayQueue / MpmcArrayQueue inside Netty's event loop and inside
+# HiveMQ's outgoing-QoS handler. JCTools resolves the byte offset of fields
+# like `consumerIndex` and `producerIndex` via
+# Unsafe.objectFieldOffset(getDeclaredField(...)) in each queue base class's
+# static initializer. R8 can't see that reflective name and will rename the
+# field — JCTools then crashes at first class-load with
+# "NoSuchFieldException: No field consumerIndex in class L<obfuscated>;".
+# Keeping the whole package preserves the field names the Unsafe lookup
+# depends on; trying to pick individual classes is brittle across JCTools
+# point releases.
+-keep class org.jctools.** { *; }
+-keepclassmembers class org.jctools.** { *; }
+
+# RxJava 2 (io.reactivex.**) is HiveMQ's reactive backbone — every connect /
+# publish / subscribe call goes through a Single / Observable before the
+# CompletableFutures we await on. RxJava resolves AtomicFieldUpdaters via
+# class+field names, so it falls under the same reflective-Unsafe pattern as
+# JCTools above. org.reactivestreams is the public interface surface; kept
+# for completeness so subclass relationships survive.
+-keep class io.reactivex.** { *; }
+-keepclassmembers class io.reactivex.** { *; }
+-keep class org.reactivestreams.** { *; }


### PR DESCRIPTION
## Summary

The 872 APK from PR #508 cleared the Netty `toLeakAwareBuffer`
reflection but hit the next layer in the same shape — JCTools'
`MpmcArrayQueueConsumerIndexField` does

```
Unsafe.objectFieldOffset(getDeclaredField("consumerIndex"))
```

in its static initializer. R8 renamed the field, the static init
crashed, HiveMQ's outgoing-QoS handler couldn't load, and the
publisher exploded on connect:

```
ExceptionInInitializerError at MqttOutgoingQosHandler.<init>
  ... R9.b.<clinit>
Caused by: NoSuchFieldException: No field consumerIndex in LR9/b;
  at S9.a.a (UnsafeAccess.fieldOffset)
```

## Fix

**Keep `org.jctools.**`** so the field names that JCTools resolves
via `Unsafe.objectFieldOffset(getDeclaredField(...))` survive R8.
Trying to pick individual queue base classes is brittle across
JCTools point releases — the queue hierarchy spans `base`, `atomic`,
`padding` etc. subpackages.

**Preemptively keep `io.reactivex.**` and `org.reactivestreams.**`**.
RxJava 2 is HiveMQ's reactive backbone (every connect / publish goes
through a `Single` before the `CompletableFuture` we `await` on) and
uses the same AtomicFieldUpdater-by-name reflection pattern that
JCTools does. Keeping these now should head off a fourth round where
the queue path is fine but the Rx pipeline isn't.

## The dep-tree-and-Unsafe pattern, summarised

This is the third round of the same fix shape. The chain:

| Round | Library  | Reflective surface R8 stripped                |
|-------|----------|-----------------------------------------------|
| #506  | HiveMQ   | Dagger 2 factories (`MqttPingReqEncoder_Factory`) |
| #508  | Netty    | `AbstractByteBufAllocator#toLeakAwareBuffer`  |
| #510  | JCTools  | `consumerIndex` / `producerIndex` field names |
| #510  | RxJava 2 | (preemptive — same `AtomicFieldUpdater` shape)|

Each library does `Unsafe.objectFieldOffset(Class.getDeclaredField(<name>))`
or equivalent reflection on field / method names in its static
initializers. R8 can't follow those reflective name lookups through
the call graph, so it renames the targets and the initializers throw
at first load. The fix at every layer is the same: `-keep` the package.

## Test plan

- [x] `:app:assembleDebug` — R8 minification succeeds with the new
  rules; `missing_rules.txt` is empty (no new -dontwarn needed)
- [x] `:app:testDebugUnitTest` — `MqttPublisherTest` still green
  (R8 doesn't run on the test classpath, but the keep rules are
  proguard-only so test behaviour is unchanged)
- [ ] Manual on-device: install the new APK, tap Refresh on Today —
  the diag log should show `Published today insight to mqtts://…`
  (instead of an exception). If a 4th round is needed, the diag log
  will pinpoint it: the entry log + a real (unobfuscated) library
  class name in the stack will tell us which keep rule is missing.

https://claude.ai/code/session_01VJAatDSm5xC1dWwQRP8dqB

---
_Generated by [Claude Code](https://claude.ai/code/session_01VJAatDSm5xC1dWwQRP8dqB)_