### PR TITLE
Smart Home docs: option comparison, locale clarification, TODOs

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -70,6 +70,90 @@ Code TODOs in source files are linked from here when they exist.
       `PerModelHourly.byModel`, so no changes there. Same Open-Meteo
       endpoint either way — no privacy change.
 
+## Smart Home / Home Assistant bridge
+
+Opt-in MQTT bridge that publishes the rendered insight prose to a
+user-hosted broker (typically the Mosquitto add-on inside HA) so
+automations can speak the forecast on a sensor trigger — wardrobe
+door, bathroom humidity, fixed time of day, etc. Setup guide at
+[docs/smart-home.md](smart-home.md); the data-handling note is in
+PRIVACY.md.
+
+Done:
+
+- [x] **MQTT publisher in the worker.** Twice-daily refresh publishes
+      `clothescast/insight/today` and `clothescast/insight/tonight` as
+      retained QoS 1 messages. Configured from a new Settings → Smart
+      Home page (host, port, TLS, username, password, topic prefix).
+      Password stored in SecureKeyStore under a separate Tink AEAD
+      slot from the Gemini key. Initial PR #504, hardened against R8
+      in #506 / #508 / #509, then the HiveMQ + Netty + JCTools +
+      RxJava graph swapped for a hand-rolled MQTT 3.1.1 publisher
+      (`RawMqttClient.kt`) on `java.net.Socket` /
+      `javax.net.ssl.SSLSocketFactory` — saved 5.9 MB on the APK,
+      removed ~70 lines of keep rules, RFC-6125 hostname verification
+      enabled on the TLS socket so a CA-trusted cert for the wrong
+      name fails before CONNECT is sent (PR #510).
+
+Open:
+
+- [ ] **"Publish now" button + persistent last-error card** on the
+      Smart Home settings page. The bridge's failure modes (broker
+      unreachable, IPv6 link-local mDNS resolution, TLS on a
+      plain-only broker, wrong credentials) all surface today only
+      via the diag log after a manual Refresh + Share-bug-report
+      round-trip. A direct trigger that runs the publisher against
+      the most recent cached insight, plus a card that pins the most
+      recent error (or "last published OK at HH:MM" on success),
+      collapses that loop to one tap. Architecturally needs an
+      observable status flow on `MqttPublisher` or wrapping
+      VM-state, plus a VM action that calls the publisher directly
+      against `InsightCache.deliveredForToday(...)`. Worth combining
+      with a "test connection" pre-flight (CONNECT/CONNACK only, no
+      PUBLISH) so a misconfigured broker fails on Save without
+      surfacing as a delivered-but-not-published surprise on the
+      next refresh.
+- [ ] **Publish the outfit image alongside the prose.** Nest Hubs and
+      Nest Hub Maxes have displays; HA's
+      [`image.mqtt`](https://www.home-assistant.io/integrations/image.mqtt/)
+      platform consumes binary image payloads off MQTT and exposes
+      them as `image.*` entities. The shape: rasterise the
+      OutfitWidget composition (top + bottom icons, ~1280x800 for
+      Hub Max scaling) to PNG, publish to
+      `clothescast/insight/<period>/image` as a retained binary
+      payload. HA picks it up via `mqtt: image: - state_topic:` and a
+      downstream automation calls `media_player.play_media` with the
+      entity's `entity_picture` URL targeting the Hub's
+      `media_player.*`. New code: ~50 lines (PNG rasteriser +
+      binary MQTT publish branch in `RawMqttClient`; the wire format
+      is identical to the text publish, just `byte[]` payload).
+      Voice + visual on the kitchen / bathroom Hub at 07:00 is a
+      much nicer UX than a disembodied audio broadcast. Privacy
+      story is identical to the prose bridge — same
+      "user-hosted-broker only" caveat, same opt-in.
+- [ ] **HA MQTT discovery for the sensors.** Publish a discovery
+      payload on `homeassistant/sensor/clothescast_today/config` so
+      a fresh HA install picks up the `sensor.clothescast_today` and
+      `sensor.clothescast_tonight` entities without the user editing
+      `configuration.yaml` or pasting YAML into Devices & Services.
+      The discovery JSON is small (`{"name": "...", "state_topic":
+      "...", "unique_id": "..."}`). Same trick for `image.*` when
+      the image feature lands above. Worth it for "drop in the
+      Mosquitto add-on + flip the toggle in ClothesCast" zero-YAML
+      setup.
+- [ ] **Music Assistant `mass.announce` quick-start in the setup
+      guide.** docs/smart-home.md now describes the three speaking
+      options at a high level, but for users picking Option B the
+      install-and-discover flow ("Add-on Store → Music Assistant →
+      auto-discovers Cast devices → use `media_player.<entity>` as
+      the `target_player`") could be a numbered walkthrough rather
+      than a paragraph.
+- [ ] **Standalone Mosquitto-broker setup walkthrough.** The current
+      doc has a one-sentence aside on `mosquitto_passwd` /
+      `mosquitto.conf` ACL syntax for users not running HA's add-on.
+      Worth either expanding into a sibling sub-section or splitting
+      to a dedicated `docs/smart-home-standalone-broker.md`.
+
 ## Feature ideas (queued)
 
 - [ ] **Multiple daily insights** — morning + evening, configurable per slot.

--- a/docs/smart-home.md
+++ b/docs/smart-home.md
@@ -132,9 +132,39 @@ subscribers on connect).
 As of mid-2026, getting Google Home / Nest devices to actually *speak*
 arbitrary text on demand is genuinely fiddly — Google has been actively
 churning the Cast pipeline and several "obvious" paths are flaky on
-Nest Minis specifically. Three options, ranked by "should work":
+Nest Minis specifically. Three options below; quick comparison first.
 
-### Option A (recommended): `notify.google_assistant_sdk`
+| | **A. notify.google_assistant_sdk** | **B. mass.announce** (Music Assistant) | **C. tts.cloud_say / tts.google_translate_say** |
+|---|---|---|---|
+| Setup cost | Google Cloud project + OAuth in HA | One add-on install | Nabu Casa sub (`cloud_say`) or none (`google_translate_say`) |
+| Preamble before the text | **Yes** — Google's broadcast service prepends "There's a message, it says…" / "Here's a message for X: …" with no flag to suppress | **No** | No |
+| Targets a specific speaker | Yes — if HA language is bare "English" (en-US). Other "English (XX)" entries fall back to broadcast-to-all. | Yes — always, via `media_player.*` entity ID; no locale dependency | Yes — always, via `entity_id: media_player.*` |
+| Target value format | Bare room name from Google Home (`Master Bathroom`) | HA entity ID (`media_player.master_bathroom_display`) | HA entity ID (`media_player.master_bathroom_display`) |
+| Voice quality | Google Assistant voice (good) | Cast TTS — either Google Translate (free) or Nabu Casa (good) | Same as Music Assistant uses, just without the player-state restoration |
+| Reliability on Nest Mini | Best (sidesteps Cast pipe entirely) | OK — wraps Cast with state-restoration, masks some flakiness | Worst on Nest Mini specifically as of early 2026 |
+| Reliability on Nest Hub | Good | Good — Hubs tolerate Cast TTS better than Minis do | OK |
+| State restoration (resumes previous playback) | N/A — broadcast doesn't take over playback | **Yes** | No |
+
+Rough decision tree:
+
+- Want the **simplest setup** and don't mind a preamble: **Option A**.
+- Want the speaker to **just speak the forecast** (no preamble), or
+  you're on a non-en-US English variant, or you have Nest Hubs with
+  displays: **Option B**.
+- You already have `tts.cloud_say` working on your hardware and don't
+  want to install Music Assistant: **Option C**.
+
+Three options in detail:
+
+The YAML below is in the **UI-editor format** Home Assistant 2024.10+
+uses: top-level `alias:` / `triggers:` / `actions:`, with `trigger:`
+inside each trigger item and `action:` inside each action item. Paste
+directly into Settings → Automations → New automation → Edit in YAML.
+If you maintain `configuration.yaml` by hand, wrap each example in
+`automation:` and convert `triggers:` / `trigger:` / `actions:` /
+`action:` to the old plural-less form yourself.
+
+### Option A (simplest): `notify.google_assistant_sdk`
 
 Uses Google's *own* broadcast pipeline — the same backend as a spoken
 "Hey Google, broadcast …" — rather than pushing audio over Cast.
@@ -145,40 +175,125 @@ Setup needs a Google Cloud project with OAuth credentials added to
 Home Assistant (one-time setup, documented in the
 [google_assistant_sdk integration page](https://www.home-assistant.io/integrations/google_assistant_sdk/)).
 
-**Known quirk:** the `target:` field only honours specific speakers
-when Home Assistant's language is `en-US`; non-en-US installs broadcast
-to all speakers regardless of `target:`. For a wardrobe-door
-announcement that's probably fine.
-
 ```yaml
-automation:
-  - alias: "Speak forecast when wardrobe opens"
-    trigger:
-      platform: state
-      entity_id: binary_sensor.wardrobe_door
-      to: "on"
-    action:
-      service: notify.google_assistant_sdk
-      data:
-        message: "{{ states('sensor.clothescast_today') }}"
+alias: Speak forecast when wardrobe opens
+description: ""
+mode: single
+
+triggers:
+  - trigger: state
+    entity_id: binary_sensor.wardrobe_door
+    to: "on"
+
+conditions: []
+
+actions:
+  - action: notify.google_assistant_sdk
+    data:
+      message: "{{ states('sensor.clothescast_today') }}"
+      target:
+        - Master Bathroom
 ```
 
-### Option B: Music Assistant `mass.announce`
+**Two caveats specific to this path:**
 
-Cast-based, but wraps Cast TTS with state-restoration (it resumes
-whatever the speaker was playing) and is the community-recommended
-modern replacement for ad-hoc `tts.cloud_say` automations. Still rides
-the Cast pipe, so subject to the early-2026 "Nest Mini intermittently
-silent" reports — but Music Assistant's player-state handling masks a
-lot of the flakiness. See the
-[Music Assistant announcement docs](https://www.music-assistant.io/integration/announcements/).
+1. **A Google broadcast preamble is baked into the service** ("There's
+   a message, it says…", or for a targeted broadcast something like
+   "Here's a message for Master Bathroom: …") and there is no flag to
+   suppress it. If you want the speaker to just speak the forecast
+   with no preamble, use Option B below.
+
+2. **The `target:` field is the room name as it appears in Google
+   Home, on its own.** Just `Master Bathroom` — not the combined
+   "Master Bathroom Display - Master Bathroom" string Google Home
+   shows in its device listing, and not the device name on its own.
+   Targeting only routes when HA's interface language resolves to
+   English (US). Settings → System → General → Language: **"English"**
+   (no country suffix) resolves to en-US under the hood — that's the
+   one that works, and matches what most installs default to.
+   "English (United Kingdom)" is a *distinct* option in HA's language
+   picker — if you've explicitly chosen that one, the integration
+   silently appends the target string to the broadcast text instead
+   of routing, and you'll hear "to master bathroom" spoken out loud
+   followed by the forecast going to every speaker.
+
+   (HA's **Country** field on the Home Information page is separate
+   metadata — sun position, currency, etc. — and doesn't affect the
+   SDK locale.)
+
+   If you've intentionally picked "English (United Kingdom)" for date
+   / number formatting and want to keep it, use Option B below; it
+   routes via `media_player.*` entities and is locale-independent.
+
+### Option B (preamble-free, locale-independent): Music Assistant `mass.announce`
+
+Drives speakers via their HA `media_player.*` entities directly,
+bypassing Google's broadcast pipeline — so no "There's a message, it
+says…" preamble, and targeting works regardless of HA's language.
+Music Assistant additionally wraps Cast TTS with state-restoration
+(resumes whatever was playing on the speaker before the announcement).
+
+The price of admission is one add-on install: **Settings → Add-ons →
+Add-on Store → Music Assistant → Install → Start**. Once running, it
+auto-discovers your Cast devices and exposes them as
+`media_player.*` entities. Then:
+
+```yaml
+alias: Speak forecast when wardrobe opens
+description: ""
+mode: single
+
+triggers:
+  - trigger: state
+    entity_id: binary_sensor.wardrobe_door
+    to: "on"
+
+conditions: []
+
+actions:
+  - action: mass.announce
+    data:
+      message: "{{ states('sensor.clothescast_today') }}"
+      target_player: media_player.master_bathroom_display
+```
+
+See the
+[Music Assistant announcement docs](https://www.music-assistant.io/integration/announcements/)
+for the full surface (volume override, "use pre-announce chime",
+multiple targets, etc.). Still rides the Cast pipe under the hood, so
+subject to the early-2026 "Nest Mini intermittently silent" reports —
+but Music Assistant's player-state handling masks a lot of the
+flakiness, and Nest Hubs (with displays) generally behave better on
+the Cast path than the smaller Minis do.
 
 ### Option C: `tts.cloud_say` → `media_player.*` Cast
 
 The classic, simplest setup — but currently the **least** reliable on
 Nest Mini specifically. Listed for completeness; not recommended as
 the first thing to try. If it works on your hardware, great; if it
-doesn't, jump to Option A.
+doesn't, jump to Option A or B.
+
+```yaml
+alias: Speak forecast when wardrobe opens
+description: ""
+mode: single
+
+triggers:
+  - trigger: state
+    entity_id: binary_sensor.wardrobe_door
+    to: "on"
+
+conditions: []
+
+actions:
+  - action: tts.cloud_say
+    data:
+      entity_id: media_player.master_bathroom_display
+      message: "{{ states('sensor.clothescast_today') }}"
+```
+
+(`tts.google_translate_say` is the free alternative if you don't have
+Nabu Casa — same shape, robot-Google-Translate voice.)
 
 ## Troubleshooting
 


### PR DESCRIPTION
Docs-only PR — caught up after walking a real setup through the
existing guide. Three concrete fixes plus a forward-looking TODOs
section so the next round of Smart Home work is scoped.

## `docs/smart-home.md`

**Comparison table at the top of the speaking-the-sensor section.**
At-a-glance trade-offs for the three TTS paths
(`notify.google_assistant_sdk` / Music Assistant `mass.announce` /
`tts.cloud_say` / `tts.google_translate_say`) along the dimensions
that actually matter when picking: setup cost, preamble vs no
preamble, can-you-target-a-specific-speaker, target value format,
Nest-Mini vs Nest-Hub reliability, state restoration. Followed by a
rough decision tree.

**Modernised YAML format.** All three example automations now use
the **UI-editor shape** Home Assistant 2024.10+ writes:

```yaml
alias: …
description: ""
mode: single

triggers:
  - trigger: state
    entity_id: …
    to: "on"

conditions: []

actions:
  - action: notify.google_assistant_sdk
    data:
      message: "{{ states('sensor.clothescast_today') }}"
```

The previous `automation: - alias: …` / `trigger: platform: state` /
`action: service: …` form is the pre-2024 `configuration.yaml`
shape, which the UI editor doesn't generate any more. A callout
explains how to convert back if you still maintain `configuration.yaml`
by hand.

**Targeting + locale, corrected.** The earlier doc said "non-en-US
broadcasts to all speakers" without explaining what counts as en-US.
The actual rule: HA's Settings → System → General → Language
**"English"** (no country suffix) is the entry that resolves to
en-US under the hood — that's the one where `target:` routes via the
structured field. The explicit "English (United Kingdom)" /
"English (Australia)" / etc. entries are *distinct* items in the
language picker and trigger the silent-append-target-to-text
fallback. HA's **Country** field on the Home Information page is
separate metadata (sun position, currency) and doesn't affect the
SDK locale at all. The target value itself is the bare room name as
shown in Google Home (`Master Bathroom`), not the combined
"`Master Bathroom Display - Master Bathroom`" string from the device
listing.

**Preamble caveat.** Google's broadcast service prepends a fixed
framing ("There's a message, it says…" / "Here's a message for X:
…") and there's no SDK flag to suppress it. Now called out in the
SDK section, with users who want no preamble pointed at Option B.

**Option B fleshed out.** Music Assistant `mass.announce` gets a
real install path (Settings → Add-ons → Music Assistant), the
locale-independence story, and a concrete `target_player:
media_player.<entity>` example. With Nest Hubs in the picture this
is often the better default than the SDK.

## `docs/TODO.md`

New **"Smart Home / Home Assistant bridge"** section between
Calendar and Forecast & alerts. Done list links the chain of PRs
(#504 → #506 → #508 → #509 → #510) so the R8-keep-rule archaeology
is traceable. Open items captured:

- **"Publish now" button + persistent last-error card** on the Smart
  Home settings page. The bridge's failure modes (broker unreachable,
  IPv6 link-local mDNS, TLS-on-plain-only-broker, wrong creds) only
  surface today via the diag log after a Refresh + Share-bug-report
  round-trip. One-tap repro collapses that loop.
- **Outfit image publishing.** Nest Hubs have displays — rasterise
  the OutfitWidget composition to PNG, publish to a binary MQTT
  topic, HA's `image.mqtt` platform consumes it, downstream
  automation pushes to the Hub via `media_player.play_media`.
  ~50 LoC new code; voice + visual on the kitchen Hub at 07:00 is a
  big UX upgrade vs a disembodied broadcast.
- **HA MQTT discovery** for the sensor (and the image when that
  lands) so a fresh install picks up `sensor.clothescast_today`
  without the user editing `configuration.yaml`. "Drop in Mosquitto
  + flip the toggle in ClothesCast" zero-YAML setup.
- **Music Assistant quick-start** in the docs.
- **Standalone Mosquitto walkthrough** expansion — currently a
  one-sentence aside.

## Out of scope here

No code changes; this is docs-only and will be filtered out of the
Play Store changelog per the `docs/` path filter in `ci.yml`.

https://claude.ai/code/session_01VJAatDSm5xC1dWwQRP8dqB

---
_Generated by [Claude Code](https://claude.ai/code/session_01VJAatDSm5xC1dWwQRP8dqB)_