### PR TITLE
Publish now button and persistent last error in Smart Home settings

### DIFF
--- a/app/src/main/kotlin/app/clothescast/MainActivity.kt
+++ b/app/src/main/kotlin/app/clothescast/MainActivity.kt
@@ -338,6 +338,7 @@ private fun ClothesCastNav(app: ClothesCastApplication, navigateToTodayVersion: 
                         }
                     },
                     workManager = WorkManager.getInstance(app),
+                    mqttPublisher = app.mqttPublisher,
                 ),
             )
             SettingsScreen(

--- a/app/src/main/kotlin/app/clothescast/data/SettingsRepository.kt
+++ b/app/src/main/kotlin/app/clothescast/data/SettingsRepository.kt
@@ -7,6 +7,7 @@ import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.doublePreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.core.stringSetPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
@@ -294,6 +295,40 @@ class SettingsRepository(
 
     suspend fun setMqttBridgeEnabled(enabled: Boolean) {
         dataStore.edit { it[MQTT_BRIDGE_ENABLED] = enabled }
+    }
+
+    /**
+     * Runtime status of the last MQTT publish attempt, separate from user
+     * preferences. [errorMessage] is null on success (or no record yet); non-null
+     * is the human-readable failure reason. [recordedAtMs] is the epoch-ms wall
+     * clock of the attempt (0 when no publish has ever been recorded).
+     */
+    data class MqttPublishStatus(val errorMessage: String?, val recordedAtMs: Long)
+
+    /**
+     * Emits the result of the last MQTT publish attempt. Null until the first
+     * attempt is recorded; thereafter always non-null. Updated by both the daily
+     * worker and the "Publish now" button.
+     */
+    val mqttPublishStatus: Flow<MqttPublishStatus?> = dataStore.data.map { prefs ->
+        val ms = prefs[MQTT_LAST_ERROR_AT_MS] ?: return@map null
+        val msg = prefs[MQTT_LAST_ERROR_MSG]  // null = success
+        MqttPublishStatus(errorMessage = msg, recordedAtMs = ms)
+    }
+
+    /**
+     * Persists the outcome of an MQTT publish attempt. Pass null [errorMessage]
+     * to record a success (clears any displayed error).
+     */
+    suspend fun setMqttLastError(errorMessage: String?, atMs: Long = System.currentTimeMillis()) {
+        dataStore.edit { prefs ->
+            prefs[MQTT_LAST_ERROR_AT_MS] = atMs
+            if (errorMessage != null) {
+                prefs[MQTT_LAST_ERROR_MSG] = errorMessage
+            } else {
+                prefs.remove(MQTT_LAST_ERROR_MSG)
+            }
+        }
     }
 
     /**
@@ -759,6 +794,8 @@ class SettingsRepository(
         private val MQTT_USE_TLS = booleanPreferencesKey("mqtt_use_tls")
         private val MQTT_USER = stringPreferencesKey("mqtt_user")
         private val MQTT_TOPIC = stringPreferencesKey("mqtt_topic")
+        private val MQTT_LAST_ERROR_MSG = stringPreferencesKey("mqtt_last_error_msg")
+        private val MQTT_LAST_ERROR_AT_MS = longPreferencesKey("mqtt_last_error_at_ms")
 
         private val TIME_FORMAT: DateTimeFormatter = DateTimeFormatter.ofPattern("HH:mm")
         private val DEFAULT_TIME: LocalTime = LocalTime.of(7, 0)

--- a/app/src/main/kotlin/app/clothescast/mqtt/MqttPublisher.kt
+++ b/app/src/main/kotlin/app/clothescast/mqtt/MqttPublisher.kt
@@ -17,6 +17,19 @@ import java.util.UUID
 import java.util.concurrent.TimeUnit
 
 /**
+ * Outcome of a [MqttPublisher.publishIfEnabled] call. Callers use this to
+ * persist the last publish result for display in the Smart Home settings UI.
+ */
+sealed interface MqttPublishOutcome {
+    /** Bridge not enabled or no host configured — intentional no-op, not an error. */
+    data object NotConfigured : MqttPublishOutcome
+    /** Message published successfully. */
+    data object Success : MqttPublishOutcome
+    /** Publish was attempted but failed — [message] is a short, user-readable description. */
+    data class Failure(val message: String) : MqttPublishOutcome
+}
+
+/**
  * Publishes the rendered insight prose to a user-hosted MQTT broker as a
  * retained message, so Home Assistant (or any other MQTT consumer) can read
  * the latest "what to wear today" sentence and speak it on a trigger of the
@@ -37,12 +50,53 @@ class MqttPublisher(
 ) {
 
     /**
-     * Fire-and-forget publish to `${baseTopic}/${period.lowercased()}`. No-op
-     * when the bridge is disabled or no host is configured. Any failure (DNS,
-     * connection, broker rejection, timeout) is logged and swallowed — the
-     * caller's worker must succeed regardless of broker reachability.
+     * Publishes to `${baseTopic}/${period.lowercased()}` and returns an
+     * [MqttPublishOutcome] so the caller can persist the result for display.
+     * Returns [MqttPublishOutcome.NotConfigured] (silently) when the bridge is
+     * disabled or no host is set. Any network failure (DNS, connection, broker
+     * rejection, timeout) is logged, swallowed, and returned as
+     * [MqttPublishOutcome.Failure] — the caller's worker must succeed regardless
+     * of broker reachability.
      */
-    suspend fun publishIfEnabled(period: ForecastPeriod, prose: String) {
+    suspend fun publishIfEnabled(period: ForecastPeriod, prose: String): MqttPublishOutcome {
+        val prepared = preparePublish(context = period.name.lowercase()) ?: return MqttPublishOutcome.NotConfigured
+        val topic = topicFor(prepared.baseTopic, period)
+        DiagLog.i(
+            TAG,
+            "MQTT bridge enabled; publishing ${period.name.lowercase()} insight to " +
+                "${prepared.scheme}://${prepared.host}:${prepared.port}/$topic " +
+                "(auth=${!prepared.config.username.isNullOrBlank()}, " +
+                "password=${if (prepared.config.password != null) "set" else "none"}, " +
+                "payload=${prose.length} chars).",
+        )
+        return executePublish(prepared, topic, prose)
+    }
+
+    /**
+     * Publishes a test message to `${baseTopic}/test` and returns the outcome.
+     * Intended for the "Publish now" button — uses a dedicated topic suffix so
+     * the retained forecast on `${baseTopic}/today` and `tonight` is never
+     * overwritten by a connectivity probe. Returns
+     * [MqttPublishOutcome.NotConfigured] when the bridge is disabled or no host
+     * is configured.
+     */
+    suspend fun publishTest(): MqttPublishOutcome {
+        val prepared = preparePublish(context = "test") ?: return MqttPublishOutcome.NotConfigured
+        val baseTrimmed = prepared.baseTopic.trim().trim('/').ifBlank { UserPreferences.DEFAULT_MQTT_TOPIC }
+        val topic = "$baseTrimmed/test"
+        DiagLog.i(
+            TAG,
+            "MQTT test publish to ${prepared.scheme}://${prepared.host}:${prepared.port}/$topic.",
+        )
+        return executePublish(prepared, topic, "ClothesCast: connection test")
+    }
+
+    /**
+     * Reads the current preferences and resolves credentials; returns null
+     * (with appropriate logging) when the bridge is not configured. [context]
+     * is a short label used in warning messages only (e.g. "today", "test").
+     */
+    private suspend fun preparePublish(context: String): PreparedPublish? {
         // CancellationException must propagate at every catch point so a
         // WorkManager stop or withTimeoutOrNull abort unwinds the worker
         // cleanly instead of being silently logged as an MQTT failure (which
@@ -52,20 +106,20 @@ class MqttPublisher(
         } catch (ce: CancellationException) {
             throw ce
         } catch (t: Throwable) {
-            DiagLog.w(TAG, "Failed to read settings for ${period.name.lowercase()} insight MQTT publish; skipping.", t)
-            return
+            DiagLog.w(TAG, "Failed to read settings for $context MQTT publish; skipping.", t)
+            return null
         }
         // Bridge-off is the silent-no-op path for users who haven't opted in;
         // not logged to keep the diag stream clean for the 99% no-bridge case.
-        if (!prefs.mqttBridgeEnabled) return
+        if (!prefs.mqttBridgeEnabled) return null
         val host = prefs.mqttHost?.takeIf { it.isNotBlank() } ?: run {
             DiagLog.w(
                 TAG,
                 "MQTT bridge is enabled but no broker host is configured; " +
-                    "${period.name.lowercase()} insight not published. " +
+                    "$context message not published. " +
                     "Set the host in Settings → Smart Home.",
             )
-            return
+            return null
         }
         val password = if (prefs.mqttUsername.isNullOrBlank()) {
             null
@@ -79,42 +133,54 @@ class MqttPublisher(
                 null
             }
         }
-        val config = MqttConfig(
+        return PreparedPublish(
+            config = MqttConfig(
+                host = host,
+                port = prefs.mqttPort,
+                useTls = prefs.mqttUseTls,
+                username = prefs.mqttUsername,
+                password = password,
+            ),
+            baseTopic = prefs.mqttTopic,
+            scheme = if (prefs.mqttUseTls) "mqtts" else "mqtt",
             host = host,
             port = prefs.mqttPort,
-            useTls = prefs.mqttUseTls,
-            username = prefs.mqttUsername,
-            password = password,
         )
-        val topic = topicFor(prefs.mqttTopic, period)
-        val scheme = if (prefs.mqttUseTls) "mqtts" else "mqtt"
-        // Entry log: fires only when the bridge is enabled and the host is set.
-        // If you see this line in the diag log, the publisher reached the
-        // network attempt; if you don't, the bridge is either off or the host
-        // is blank (and the warn above will tell you which).
-        DiagLog.i(
-            TAG,
-            "MQTT bridge enabled; publishing ${period.name.lowercase()} insight to " +
-                "$scheme://$host:${prefs.mqttPort}/$topic " +
-                "(auth=${!prefs.mqttUsername.isNullOrBlank()}, " +
-                "password=${if (password != null) "set" else "none"}, " +
-                "payload=${prose.length} chars).",
-        )
-        withTimeoutOrNull(publishTimeoutMs) {
-            try {
-                publish(config, topic, prose)
-                DiagLog.i(TAG, "Published ${period.name.lowercase()} insight to $scheme://$host:${prefs.mqttPort}/$topic")
-            } catch (ce: CancellationException) {
-                // Re-raise so withTimeoutOrNull sees a timeout (returns null
-                // and we log "timed out" below) and so a WorkManager-issued
-                // cancel propagates out of the worker rather than being
-                // shadowed by a misleading "MQTT publish failed" line.
-                throw ce
-            } catch (t: Throwable) {
-                DiagLog.w(TAG, "MQTT publish failed to $scheme://$host:${prefs.mqttPort}/$topic", t)
-            }
-        } ?: DiagLog.w(TAG, "MQTT publish timed out after ${publishTimeoutMs}ms to $scheme://$host:${prefs.mqttPort}/$topic")
     }
+
+    private suspend fun executePublish(
+        prepared: PreparedPublish,
+        topic: String,
+        payload: String,
+    ): MqttPublishOutcome = withTimeoutOrNull(publishTimeoutMs) {
+        var result: MqttPublishOutcome = MqttPublishOutcome.Success
+        try {
+            publish(prepared.config, topic, payload)
+            DiagLog.i(TAG, "Published to ${prepared.scheme}://${prepared.host}:${prepared.port}/$topic")
+        } catch (ce: CancellationException) {
+            // Re-raise so withTimeoutOrNull sees a timeout (returns null
+            // and we return Failure below) and so a WorkManager-issued
+            // cancel propagates out of the worker rather than being
+            // shadowed by a misleading "MQTT publish failed" line.
+            throw ce
+        } catch (t: Throwable) {
+            val msg = "${t.javaClass.simpleName}: ${t.message ?: "unknown error"}".take(250)
+            DiagLog.w(TAG, "MQTT publish failed to ${prepared.scheme}://${prepared.host}:${prepared.port}/$topic", t)
+            result = MqttPublishOutcome.Failure(msg)
+        }
+        result
+    } ?: run {
+        DiagLog.w(TAG, "MQTT publish timed out after ${publishTimeoutMs}ms to ${prepared.scheme}://${prepared.host}:${prepared.port}/$topic")
+        MqttPublishOutcome.Failure("Connection timed out (>${publishTimeoutMs}ms)")
+    }
+
+    private data class PreparedPublish(
+        val config: MqttConfig,
+        val baseTopic: String,
+        val scheme: String,
+        val host: String,
+        val port: Int,
+    )
 
     companion object {
         private const val TAG = "MqttPublisher"

--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsScreen.kt
@@ -224,10 +224,14 @@ fun SettingsScreen(
                 username = state.mqttUsername,
                 topic = state.mqttTopic,
                 passwordSet = state.mqttPasswordSet,
+                lastError = state.mqttLastError,
+                lastErrorAt = state.mqttLastErrorAt,
+                publishing = state.mqttPublishing,
                 padding = padding,
                 onSetBridgeEnabled = viewModel::setMqttBridgeEnabled,
                 onSaveConfig = viewModel::setMqttConfig,
                 onClearPassword = viewModel::clearMqttPassword,
+                onPublishNow = viewModel::publishNow,
             )
             SettingsRoute.Privacy -> PrivacyContent(
                 telemetryEnabled = state.telemetryEnabled,

--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsState.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsState.kt
@@ -125,4 +125,15 @@ data class SettingsState(
     val mqttUsername: String = "",
     val mqttTopic: String = UserPreferences.DEFAULT_MQTT_TOPIC,
     val mqttPasswordSet: Boolean = false,
+    /**
+     * Error message from the last MQTT publish attempt, or null if the last
+     * attempt succeeded (or no publish has been attempted yet). Persisted
+     * across app launches so the user can see a previous failure without
+     * waiting for the next scheduled refresh.
+     */
+    val mqttLastError: String? = null,
+    /** Epoch-ms wall-clock of the last recorded publish outcome (0 = no record). */
+    val mqttLastErrorAt: Long = 0L,
+    /** True while a "Publish now" action is in flight. */
+    val mqttPublishing: Boolean = false,
 )

--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsViewModel.kt
@@ -24,6 +24,8 @@ import app.clothescast.core.domain.model.VoiceLocale
 import app.clothescast.data.InsightCache
 import app.clothescast.data.SecureKeyStore
 import app.clothescast.data.SettingsRepository
+import app.clothescast.mqtt.MqttPublishOutcome
+import app.clothescast.mqtt.MqttPublisher
 import app.clothescast.work.FetchAndNotifyWorker
 import app.clothescast.tts.TtsVoiceEnumerator
 import app.clothescast.tts.resolve
@@ -92,6 +94,12 @@ class SettingsViewModel(
      * stays permanently false.
      */
     private val workManager: WorkManager? = null,
+    /**
+     * Publisher used by the "Publish now" button to test the current saved
+     * MQTT configuration on demand. Null in pure-VM tests that don't need
+     * network; the Activity/Application wires the real publisher.
+     */
+    private val mqttPublisher: MqttPublisher? = null,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(SettingsState())
@@ -174,6 +182,16 @@ class SettingsViewModel(
         viewModelScope.launch {
             keyStore.mqttPasswordConfiguredFlow.collect { set ->
                 _state.update { it.copy(mqttPasswordSet = set) }
+            }
+        }
+        viewModelScope.launch {
+            settingsRepository.mqttPublishStatus.collect { status ->
+                _state.update {
+                    it.copy(
+                        mqttLastError = status?.errorMessage,
+                        mqttLastErrorAt = status?.recordedAtMs ?: 0L,
+                    )
+                }
             }
         }
         workManager?.let { wm ->
@@ -477,6 +495,31 @@ class SettingsViewModel(
     }
 
     /**
+     * Publishes a test message to the configured broker immediately, using the
+     * current saved configuration. Intended for the "Publish now" button on the
+     * Smart Home settings page so the user can verify connectivity without
+     * waiting for the next scheduled refresh. Clears or sets the last-error
+     * indicator based on the outcome; [SettingsState.mqttPublishing] is true
+     * for the duration.
+     */
+    fun publishNow() {
+        val publisher = mqttPublisher ?: return
+        if (_state.value.mqttPublishing) return
+        viewModelScope.launch {
+            _state.update { it.copy(mqttPublishing = true) }
+            try {
+                when (val outcome = publisher.publishTest()) {
+                    is MqttPublishOutcome.NotConfigured -> Unit
+                    is MqttPublishOutcome.Success -> settingsRepository.setMqttLastError(null)
+                    is MqttPublishOutcome.Failure -> settingsRepository.setMqttLastError(outcome.message)
+                }
+            } finally {
+                _state.update { it.copy(mqttPublishing = false) }
+            }
+        }
+    }
+
+    /**
      * Persists the user's [ForecastModel] selection. The picker enforces a
      * minimum of two checked entries before calling here (the confidence
      * chip needs at least two models to compute a spread), so an empty
@@ -550,6 +593,7 @@ class SettingsViewModel(
         private val refreshCachedOutfits: suspend () -> Unit,
         private val resolveDeviceLocationWithCity: suspend () -> Location? = { null },
         private val workManager: WorkManager? = null,
+        private val mqttPublisher: MqttPublisher? = null,
     ) : ViewModelProvider.Factory {
         @Suppress("UNCHECKED_CAST")
         override fun <T : ViewModel> create(modelClass: Class<T>): T {
@@ -568,6 +612,7 @@ class SettingsViewModel(
                 refreshLocationCache = refreshLocationCache,
                 resolveDeviceLocationWithCity = resolveDeviceLocationWithCity,
                 workManager = workManager,
+                mqttPublisher = mqttPublisher,
             ) as T
         }
     }

--- a/app/src/main/kotlin/app/clothescast/ui/settings/SmartHomeSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SmartHomeSettings.kt
@@ -14,6 +14,7 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -27,11 +28,15 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import app.clothescast.R
 import app.clothescast.core.domain.model.UserPreferences
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 
 private const val SETUP_GUIDE_URL =
     "https://github.com/mikelward/clothescast/blob/main/docs/smart-home.md"
@@ -47,10 +52,14 @@ internal fun SmartHomeContent(
     username: String,
     topic: String,
     passwordSet: Boolean,
+    lastError: String?,
+    lastErrorAt: Long,
+    publishing: Boolean,
     padding: PaddingValues,
     onSetBridgeEnabled: (Boolean) -> Unit,
     onSaveConfig: (host: String, port: Int, useTls: Boolean, username: String, topic: String, password: String?) -> Unit,
     onClearPassword: () -> Unit,
+    onPublishNow: () -> Unit,
 ) {
     Column(
         modifier = Modifier
@@ -68,9 +77,13 @@ internal fun SmartHomeContent(
             username = username,
             topic = topic,
             passwordSet = passwordSet,
+            lastError = lastError,
+            lastErrorAt = lastErrorAt,
+            publishing = publishing,
             onSetEnabled = onSetBridgeEnabled,
             onSaveConfig = onSaveConfig,
             onClearPassword = onClearPassword,
+            onPublishNow = onPublishNow,
         )
     }
 }
@@ -84,9 +97,13 @@ private fun MqttBridgeCard(
     username: String,
     topic: String,
     passwordSet: Boolean,
+    lastError: String?,
+    lastErrorAt: Long,
+    publishing: Boolean,
     onSetEnabled: (Boolean) -> Unit,
     onSaveConfig: (host: String, port: Int, useTls: Boolean, username: String, topic: String, password: String?) -> Unit,
     onClearPassword: () -> Unit,
+    onPublishNow: () -> Unit,
 ) {
     val context = LocalContext.current
     // Local form state seeded from the persisted prefs, rebuilt whenever the
@@ -247,6 +264,24 @@ private fun MqttBridgeCard(
                 enabled = canSave,
                 modifier = Modifier.fillMaxWidth(),
             ) { Text(stringResource(R.string.settings_smart_home_mqtt_save)) }
+
+            if (lastError != null && lastErrorAt > 0L) {
+                MqttLastErrorBanner(message = lastError, recordedAtMs = lastErrorAt)
+            }
+
+            OutlinedButton(
+                onClick = onPublishNow,
+                enabled = host.isNotBlank() && !publishing,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(
+                    if (publishing) {
+                        stringResource(R.string.settings_smart_home_mqtt_publishing)
+                    } else {
+                        stringResource(R.string.settings_smart_home_mqtt_publish_now)
+                    },
+                )
+            }
         }
 
         TextButton(
@@ -259,3 +294,39 @@ private fun MqttBridgeCard(
         ) { Text(stringResource(R.string.settings_smart_home_mqtt_open_privacy)) }
     }
 }
+
+@Composable
+private fun MqttLastErrorBanner(message: String, recordedAtMs: Long) {
+    val timestamp = remember(recordedAtMs) {
+        Instant.ofEpochMilli(recordedAtMs)
+            .atZone(ZoneId.systemDefault())
+            .format(ERROR_TIMESTAMP_FORMAT)
+    }
+    Surface(
+        color = MaterialTheme.colorScheme.errorContainer,
+        shape = MaterialTheme.shapes.small,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Column(modifier = Modifier.padding(12.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            Text(
+                text = stringResource(R.string.settings_smart_home_mqtt_last_error_title),
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onErrorContainer,
+            )
+            Text(
+                text = message,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onErrorContainer,
+                fontFamily = FontFamily.Monospace,
+            )
+            Text(
+                text = timestamp,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onErrorContainer.copy(alpha = 0.7f),
+            )
+        }
+    }
+}
+
+private val ERROR_TIMESTAMP_FORMAT: DateTimeFormatter =
+    DateTimeFormatter.ofPattern("d MMM yyyy, HH:mm")

--- a/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
@@ -24,6 +24,7 @@ import app.clothescast.core.domain.model.TtsEngine
 import app.clothescast.core.domain.model.UserPreferences
 import app.clothescast.core.domain.usecase.shouldSpeak
 import app.clothescast.data.InsightCache
+import app.clothescast.mqtt.MqttPublishOutcome
 import app.clothescast.diag.Telemetry
 import app.clothescast.diag.classifyDailyRefreshReason
 import app.clothescast.insight.InsightFormatter
@@ -544,8 +545,20 @@ class FetchAndNotifyWorker(
         // The publisher logs and swallows broker / network failures so a
         // dead broker can't break notification or TTS delivery — by the
         // time this runs the user-facing delivery above has already
-        // completed.
-        app.mqttPublisher.publishIfEnabled(insight.period, prose)
+        // completed. The outcome is persisted so the Smart Home settings
+        // page can surface the last error for troubleshooting.
+        val mqttOutcome = app.mqttPublisher.publishIfEnabled(insight.period, prose)
+        // Status persistence is best-effort: a DataStore I/O failure here must
+        // not surface as a deliver() exception, which would cause the
+        // cached-delivery path to fall through to a fresh fetch and duplicate
+        // the user-facing notification.
+        runCatching {
+            when (mqttOutcome) {
+                is MqttPublishOutcome.NotConfigured -> Unit
+                is MqttPublishOutcome.Success -> app.settingsRepository.setMqttLastError(null)
+                is MqttPublishOutcome.Failure -> app.settingsRepository.setMqttLastError(mqttOutcome.message)
+            }
+        }
     }
 
     private suspend fun deliverToday(insight: Insight, prefs: UserPreferences, prose: String) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -445,6 +445,9 @@
     <string name="settings_smart_home_mqtt_topic">Topic prefix</string>
     <string name="settings_smart_home_mqtt_topic_hint">Today publishes to {prefix}/today; tonight to {prefix}/tonight.</string>
     <string name="settings_smart_home_mqtt_save">Save</string>
+    <string name="settings_smart_home_mqtt_publish_now">Publish now</string>
+    <string name="settings_smart_home_mqtt_publishing">Publishing…</string>
+    <string name="settings_smart_home_mqtt_last_error_title">Last publish failed</string>
     <string name="settings_smart_home_mqtt_setup_guide">Setup guide</string>
     <string name="settings_smart_home_mqtt_open_privacy">Read privacy details</string>
 

--- a/app/src/test/kotlin/app/clothescast/mqtt/MqttPublisherTest.kt
+++ b/app/src/test/kotlin/app/clothescast/mqtt/MqttPublisherTest.kt
@@ -10,6 +10,7 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.ensureActive
@@ -196,6 +197,98 @@ class MqttPublisherTest {
         subject.publishIfEnabled(ForecastPeriod.TODAY, "x")
 
         attempted.shouldBeTrue()
+    }
+
+    @Test
+    fun `successful publish returns Success outcome`() = runTest {
+        val subject = MqttPublisher(
+            preferences = flowOf(
+                basePrefs.copy(mqttBridgeEnabled = true, mqttHost = "broker.local"),
+            ),
+            passwordProvider = { null },
+            publish = capturing(mutableListOf()),
+        )
+
+        val outcome = subject.publishIfEnabled(ForecastPeriod.TODAY, "x")
+
+        outcome shouldBe MqttPublishOutcome.Success
+    }
+
+    @Test
+    fun `disabled bridge returns NotConfigured`() = runTest {
+        val subject = MqttPublisher(
+            preferences = flowOf(basePrefs.copy(mqttBridgeEnabled = false, mqttHost = "broker.local")),
+            passwordProvider = { null },
+            publish = { _, _, _ -> },
+        )
+
+        subject.publishIfEnabled(ForecastPeriod.TODAY, "x") shouldBe MqttPublishOutcome.NotConfigured
+    }
+
+    @Test
+    fun `blank host returns NotConfigured`() = runTest {
+        val subject = MqttPublisher(
+            preferences = flowOf(basePrefs.copy(mqttBridgeEnabled = true, mqttHost = null)),
+            passwordProvider = { null },
+            publish = { _, _, _ -> },
+        )
+
+        subject.publishIfEnabled(ForecastPeriod.TODAY, "x") shouldBe MqttPublishOutcome.NotConfigured
+    }
+
+    @Test
+    fun `publish failure returns Failure outcome with message`() = runTest {
+        val subject = MqttPublisher(
+            preferences = flowOf(basePrefs.copy(mqttBridgeEnabled = true, mqttHost = "broker.local")),
+            passwordProvider = { null },
+            publish = { _, _, _ -> error("simulated broker rejection") },
+        )
+
+        val outcome = subject.publishIfEnabled(ForecastPeriod.TODAY, "x")
+
+        val failure = outcome.shouldBeInstanceOf<MqttPublishOutcome.Failure>()
+        failure.message shouldBe "IllegalStateException: simulated broker rejection"
+    }
+
+    @Test
+    fun `timeout returns Failure outcome`() = runTest {
+        val subject = MqttPublisher(
+            preferences = flowOf(basePrefs.copy(mqttBridgeEnabled = true, mqttHost = "broker.local")),
+            passwordProvider = { null },
+            publish = { _, _, _ ->
+                while (true) {
+                    coroutineContext.ensureActive()
+                    kotlinx.coroutines.delay(1_000)
+                }
+            },
+            publishTimeoutMs = 50L,
+        )
+
+        val outcome = subject.publishIfEnabled(ForecastPeriod.TODAY, "x")
+
+        outcome.shouldBeInstanceOf<MqttPublishOutcome.Failure>()
+    }
+
+    @Test
+    fun `publishTest routes to test topic, not today or tonight`() = runTest {
+        val captured = mutableListOf<PublishCall>()
+        val subject = MqttPublisher(
+            preferences = flowOf(
+                basePrefs.copy(
+                    mqttBridgeEnabled = true,
+                    mqttHost = "broker.local",
+                    mqttTopic = "home/forecast",
+                ),
+            ),
+            passwordProvider = { null },
+            publish = capturing(captured),
+        )
+
+        val outcome = subject.publishTest()
+
+        outcome shouldBe MqttPublishOutcome.Success
+        captured shouldHaveSize 1
+        captured.single().topic shouldBe "home/forecast/test"
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Adds a **"Publish now"** button to Settings → Smart Home so users can test their MQTT broker configuration on demand, without waiting for the next scheduled refresh
- Adds a **persistent last-error banner** that survives app restarts — shows the exception class + message verbatim so common misconfigurations (link-local IPv6, wrong TLS port, auth failure, connection refused) are self-diagnosable without the diag log
- The daily worker now records each publish outcome too, so the banner reflects the last automatic-refresh result even when the user opens Settings hours later

## Changes

**`MqttPublisher`**: `publishIfEnabled` now returns a `MqttPublishOutcome` sealed type (`NotConfigured` / `Success` / `Failure(message)`) instead of `Unit`. Both the worker and the new `publishNow()` VM action branch on it to persist the result. Failure message is `ExceptionClass: message` truncated to 250 chars.

**`SettingsRepository`**: Two new DataStore keys (`mqtt_last_error_msg`, `mqtt_last_error_at_ms`) + `mqttPublishStatus: Flow<MqttPublishStatus?>` + `setMqttLastError(errorMessage, atMs)`.

**`SettingsViewModel`**: Subscribes to `mqttPublishStatus`; adds `publishNow()` which calls `MqttPublisher` directly and persists the result. `MqttPublisher` is injected via the Factory (defaulted to null so existing tests are unaffected).

**`SmartHomeSettings`**: Inside the `if (enabled)` block, below the Save button:
- Error banner (error container colours, monospace message, timestamp) when last publish failed
- "Publish now" / "Publishing…" `OutlinedButton`, enabled when a host is saved and no publish is in flight

**`FetchAndNotifyWorker`**: Records `MqttPublishOutcome` to `SettingsRepository` after each daily publish.

**`MqttPublisherTest`**: 5 new tests covering `Success`, `NotConfigured` (bridge off, blank host), `Failure` (exception message content), and timeout `Failure`.

## Privacy note

The "Publish now" payload is the literal string `"ClothesCast: connection test"` — no calendar data, location, or forecast prose.

## Test plan

- [ ] CI green
- [ ] Enable bridge, configure a working broker → "Publish now" clears any existing error banner
- [ ] Configure a wrong host/port → "Publish now" shows an error banner with a useful message
- [ ] Kill app after a failed publish → reopen Settings → error banner is still visible
- [ ] Daily worker runs against a broken broker → Settings page shows the failure without touching "Publish now"

https://claude.ai/code/session_01NJw1ZhdMKpsXnnssZc5JXi

---
_Generated by [Claude Code](https://claude.ai/code/session_01NJw1ZhdMKpsXnnssZc5JXi)_