### PR TITLE
Home Assistant sensors register automatically — no YAML needed

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -155,6 +155,16 @@ The source code is at <https://github.com/mikelward/clothescast>.
   calendar tie-in enabled, because that clause is part of the
   rendered sentence. No coordinates, no API keys, no settings values,
   no device identifiers travel with the message.
+- **MQTT Discovery configs:** Alongside each forecast push, the bridge
+  also publishes two retained Home Assistant MQTT Discovery config
+  messages to `homeassistant/sensor/clothescast_today/config` and
+  `homeassistant/sensor/clothescast_tonight/config`, so HA can
+  auto-register the sensors without a hand-edited YAML block. These
+  payloads are static metadata — entity names ("Today" / "Tonight"),
+  the device card label ("ClothesCast"), and the state topic path
+  itself — and contain no user content, location, or device
+  identifier. They go to the same broker as the forecast strings
+  above; nothing leaves your network.
 - **Authentication:** If you set a broker username, the bridge sends
   it on connect; the corresponding password is stored on your device
   encrypted at rest (same Tink-AEAD pattern as the Gemini API key

--- a/app/src/main/kotlin/app/clothescast/mqtt/MqttPublisher.kt
+++ b/app/src/main/kotlin/app/clothescast/mqtt/MqttPublisher.kt
@@ -30,11 +30,44 @@ sealed interface MqttPublishOutcome {
 }
 
 /**
- * Publishes the rendered insight prose to a user-hosted MQTT broker as a
- * retained message, so Home Assistant (or any other MQTT consumer) can read
- * the latest "what to wear today" sentence and speak it on a trigger of the
- * user's choice. The bridge is opt-in and configured in
- * Settings → Smart Home; see PRIVACY.md for the data-handling boundary.
+ * One retained MQTT message in a publish batch. The publisher bundles the
+ * Home Assistant discovery config and the state (prose or PNG) into a single
+ * connection so a refresh costs one TCP/MQTT round-trip rather than two.
+ * Payload is [ByteArray] so the same plumbing carries UTF-8 text and binary
+ * image data without duplication.
+ */
+data class MqttMessage(val topic: String, val payload: ByteArray, val retain: Boolean = true) {
+    // ByteArray's default equals/hashCode are reference-identity; override so
+    // the data-class contract is meaningful when tests / callers compare
+    // captured publish batches.
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is MqttMessage) return false
+        return topic == other.topic && retain == other.retain && payload.contentEquals(other.payload)
+    }
+    override fun hashCode(): Int {
+        var result = topic.hashCode()
+        result = 31 * result + payload.contentHashCode()
+        result = 31 * result + retain.hashCode()
+        return result
+    }
+}
+
+/**
+ * Publishes the rendered insight prose and outfit-card PNG to a user-hosted
+ * MQTT broker as retained messages, so Home Assistant (or any other MQTT
+ * consumer) can read the latest forecast and either speak it on a trigger
+ * of the user's choice or push the image to a Nest Hub. The bridge is opt-in
+ * and configured in Settings → Smart Home; see PRIVACY.md for the
+ * data-handling boundary.
+ *
+ * Each refresh also re-publishes the Home Assistant MQTT Discovery configs
+ * for the today / tonight sensor and image entities (retained on
+ * `homeassistant/<component>/clothescast_<period>[_image]/config`) so HA's
+ * MQTT integration auto-creates the entities — users don't need to hand-add
+ * any `mqtt:` blocks to `configuration.yaml`. Discovery payloads are config
+ * metadata only (topic name, entity label, device card name); no user content
+ * rides along.
  *
  * The publisher reads the latest [UserPreferences] from the injected flow on
  * every call so settings edits take effect on the next refresh without
@@ -45,7 +78,7 @@ sealed interface MqttPublishOutcome {
 class MqttPublisher(
     private val preferences: Flow<UserPreferences>,
     private val passwordProvider: suspend () -> String?,
-    private val publish: suspend (config: MqttConfig, topic: String, payload: ByteArray) -> Unit = ::publishWithHiveMq,
+    private val publish: suspend (config: MqttConfig, messages: List<MqttMessage>) -> Unit = ::publishWithHiveMq,
     private val publishTimeoutMs: Long = DEFAULT_PUBLISH_TIMEOUT_MS,
 ) {
 
@@ -60,35 +93,25 @@ class MqttPublisher(
      */
     suspend fun publishIfEnabled(period: ForecastPeriod, prose: String): MqttPublishOutcome {
         val prepared = preparePublish(context = period.name.lowercase()) ?: return MqttPublishOutcome.NotConfigured
-        val topic = topicFor(prepared.baseTopic, period)
+        val stateTopic = topicFor(prepared.baseTopic, period)
+        val discoveryTopic = discoveryTopicFor(period, Component.SENSOR)
+        val discoveryPayload = sensorDiscoveryPayloadFor(period, stateTopic)
         DiagLog.i(
             TAG,
             "MQTT bridge enabled; publishing ${period.name.lowercase()} insight to " +
-                "${prepared.scheme}://${prepared.host}:${prepared.port}/$topic " +
+                "${prepared.scheme}://${prepared.host}:${prepared.port}/$stateTopic " +
                 "(auth=${!prepared.config.username.isNullOrBlank()}, " +
                 "password=${if (prepared.config.password != null) "set" else "none"}, " +
-                "payload=${prose.length} chars).",
+                "payload=${prose.length} chars, +HA discovery).",
         )
-        return executePublish(prepared, topic, prose.toByteArray(Charsets.UTF_8))
-    }
-
-    /**
-     * Publishes a test message to `${baseTopic}/test` and returns the outcome.
-     * Intended for the "Publish now" button — uses a dedicated topic suffix so
-     * the retained forecast on `${baseTopic}/today` and `tonight` is never
-     * overwritten by a connectivity probe. Returns
-     * [MqttPublishOutcome.NotConfigured] when the bridge is disabled or no host
-     * is configured.
-     */
-    suspend fun publishTest(): MqttPublishOutcome {
-        val prepared = preparePublish(context = "test") ?: return MqttPublishOutcome.NotConfigured
-        val baseTrimmed = prepared.baseTopic.trim().trim('/').ifBlank { UserPreferences.DEFAULT_MQTT_TOPIC }
-        val topic = "$baseTrimmed/test"
-        DiagLog.i(
-            TAG,
-            "MQTT test publish to ${prepared.scheme}://${prepared.host}:${prepared.port}/$topic.",
+        return executePublish(
+            prepared,
+            messages = listOf(
+                MqttMessage(topic = discoveryTopic, payload = discoveryPayload.toByteArray(Charsets.UTF_8)),
+                MqttMessage(topic = stateTopic, payload = prose.toByteArray(Charsets.UTF_8)),
+            ),
+            describeTopic = stateTopic,
         )
-        return executePublish(prepared, topic, "ClothesCast: connection test".toByteArray(Charsets.UTF_8))
     }
 
     /**
@@ -97,18 +120,77 @@ class MqttPublisher(
      * MQTT bridge toggle as [publishIfEnabled] — no separate setting needed.
      * HA's `image.mqtt` integration subscribes to this topic and surfaces
      * the outfit as an `image.*` entity, which a downstream automation can
-     * push to a Nest Hub via `media_player.play_media`.
+     * push to a Nest Hub via `media_player.play_media`. The image entity's
+     * discovery config is re-emitted alongside the bytes so HA auto-creates
+     * the entity without a hand-edited YAML block.
      */
     suspend fun publishImageIfEnabled(period: ForecastPeriod, imageBytes: ByteArray) {
         val prepared = preparePublish(context = "${period.name.lowercase()} outfit image") ?: return
-        val topic = imageTopicFor(prepared.baseTopic, period)
+        val imageTopic = imageTopicFor(prepared.baseTopic, period)
+        val discoveryTopic = discoveryTopicFor(period, Component.IMAGE)
+        val discoveryPayload = imageDiscoveryPayloadFor(period, imageTopic)
         DiagLog.i(
             TAG,
             "MQTT bridge enabled; publishing ${period.name.lowercase()} outfit image " +
                 "(${imageBytes.size} bytes) to " +
-                "${prepared.scheme}://${prepared.host}:${prepared.port}/$topic.",
+                "${prepared.scheme}://${prepared.host}:${prepared.port}/$imageTopic (+HA discovery).",
         )
-        executePublish(prepared, topic, imageBytes)
+        executePublish(
+            prepared,
+            messages = listOf(
+                MqttMessage(topic = discoveryTopic, payload = discoveryPayload.toByteArray(Charsets.UTF_8)),
+                MqttMessage(topic = imageTopic, payload = imageBytes),
+            ),
+            describeTopic = imageTopic,
+        )
+    }
+
+    /**
+     * Publishes a test message to `${baseTopic}/test` and returns the outcome.
+     * Intended for the "Publish now" button — uses a dedicated topic suffix so
+     * the retained forecast on `${baseTopic}/today` and `tonight` is never
+     * overwritten by a connectivity probe. Also re-publishes the HA discovery
+     * configs for every sensor + image entity so a freshly-configured bridge
+     * surfaces its entities in HA immediately, without waiting for the next
+     * scheduled refresh. Returns [MqttPublishOutcome.NotConfigured] when the
+     * bridge is disabled or no host is configured.
+     */
+    suspend fun publishTest(): MqttPublishOutcome {
+        val prepared = preparePublish(context = "test") ?: return MqttPublishOutcome.NotConfigured
+        val baseTrimmed = prepared.baseTopic.trim().trim('/').ifBlank { UserPreferences.DEFAULT_MQTT_TOPIC }
+        val testTopic = "$baseTrimmed/test"
+        val messages = buildList {
+            for (period in ForecastPeriod.entries) {
+                val stateTopic = topicFor(prepared.baseTopic, period)
+                add(
+                    MqttMessage(
+                        topic = discoveryTopicFor(period, Component.SENSOR),
+                        payload = sensorDiscoveryPayloadFor(period, stateTopic).toByteArray(Charsets.UTF_8),
+                    ),
+                )
+            }
+            for (period in ForecastPeriod.entries) {
+                val imageTopic = imageTopicFor(prepared.baseTopic, period)
+                add(
+                    MqttMessage(
+                        topic = discoveryTopicFor(period, Component.IMAGE),
+                        payload = imageDiscoveryPayloadFor(period, imageTopic).toByteArray(Charsets.UTF_8),
+                    ),
+                )
+            }
+            add(
+                MqttMessage(
+                    topic = testTopic,
+                    payload = "ClothesCast: connection test".toByteArray(Charsets.UTF_8),
+                ),
+            )
+        }
+        DiagLog.i(
+            TAG,
+            "MQTT test publish to ${prepared.scheme}://${prepared.host}:${prepared.port}/$testTopic " +
+                "(+HA discovery for ${ForecastPeriod.entries.size * 2} entities).",
+        )
+        return executePublish(prepared, messages = messages, describeTopic = testTopic)
     }
 
     /**
@@ -170,13 +252,13 @@ class MqttPublisher(
 
     private suspend fun executePublish(
         prepared: PreparedPublish,
-        topic: String,
-        payload: ByteArray,
+        messages: List<MqttMessage>,
+        describeTopic: String,
     ): MqttPublishOutcome = withTimeoutOrNull(publishTimeoutMs) {
         var result: MqttPublishOutcome = MqttPublishOutcome.Success
         try {
-            publish(prepared.config, topic, payload)
-            DiagLog.i(TAG, "Published to ${prepared.scheme}://${prepared.host}:${prepared.port}/$topic")
+            publish(prepared.config, messages)
+            DiagLog.i(TAG, "Published to ${prepared.scheme}://${prepared.host}:${prepared.port}/$describeTopic")
         } catch (ce: CancellationException) {
             // Re-raise so withTimeoutOrNull sees a timeout (returns null
             // and we return Failure below) and so a WorkManager-issued
@@ -185,12 +267,12 @@ class MqttPublisher(
             throw ce
         } catch (t: Throwable) {
             val msg = "${t.javaClass.simpleName}: ${t.message ?: "unknown error"}".take(250)
-            DiagLog.w(TAG, "MQTT publish failed to ${prepared.scheme}://${prepared.host}:${prepared.port}/$topic", t)
+            DiagLog.w(TAG, "MQTT publish failed to ${prepared.scheme}://${prepared.host}:${prepared.port}/$describeTopic", t)
             result = MqttPublishOutcome.Failure(msg)
         }
         result
     } ?: run {
-        DiagLog.w(TAG, "MQTT publish timed out after ${publishTimeoutMs}ms to ${prepared.scheme}://${prepared.host}:${prepared.port}/$topic")
+        DiagLog.w(TAG, "MQTT publish timed out after ${publishTimeoutMs}ms to ${prepared.scheme}://${prepared.host}:${prepared.port}/$describeTopic")
         MqttPublishOutcome.Failure("Connection timed out (>${publishTimeoutMs}ms)")
     }
 
@@ -201,6 +283,13 @@ class MqttPublisher(
         val host: String,
         val port: Int,
     )
+
+    /**
+     * HA MQTT Discovery component domain — `sensor` for the prose entity,
+     * `image` for the outfit-card PNG entity. The component name slots into
+     * the discovery topic shape `<prefix>/<component>/<object_id>/config`.
+     */
+    enum class Component(val ha: String) { SENSOR("sensor"), IMAGE("image") }
 
     companion object {
         private const val TAG = "MqttPublisher"
@@ -215,6 +304,23 @@ class MqttPublisher(
         internal const val SOCKET_CONNECT_TIMEOUT_MS = 4_000L
         internal const val MQTT_CONNECT_TIMEOUT_MS = 4_000L
 
+        /**
+         * Home Assistant MQTT Discovery prefix. HA defaults to `homeassistant`
+         * and only power users change it; we publish under that fixed prefix.
+         * If a user has remapped their discovery prefix in HA, they'll need to
+         * fall back to the manual YAML setup until we add a setting.
+         */
+        const val DISCOVERY_PREFIX = "homeassistant"
+
+        /**
+         * Stable HA device identifier the discovery payloads use to group every
+         * sensor and image entity under one "ClothesCast" device card.
+         * Single-tenant: one ClothesCast install per HA. Multiple phones
+         * publishing to the same broker would collide — acceptable for a
+         * single-household app.
+         */
+        const val DEVICE_IDENTIFIER = "clothescast"
+
         fun topicFor(baseTopic: String, period: ForecastPeriod): String {
             val trimmed = baseTopic.trim().trim('/').ifBlank { UserPreferences.DEFAULT_MQTT_TOPIC }
             return "$trimmed/${period.name.lowercase()}"
@@ -222,6 +328,72 @@ class MqttPublisher(
 
         fun imageTopicFor(baseTopic: String, period: ForecastPeriod): String =
             "${topicFor(baseTopic, period)}/image"
+
+        /**
+         * Discovery config topic per HA's `<prefix>/<component>/<object_id>/config`
+         * shape — e.g. `homeassistant/sensor/clothescast_today/config` for the
+         * prose entity, `homeassistant/image/clothescast_today_image/config` for
+         * the outfit PNG. Retained payload on this topic is what HA's MQTT
+         * integration consumes to register the entity.
+         */
+        fun discoveryTopicFor(period: ForecastPeriod, component: Component): String {
+            val suffix = when (component) {
+                Component.SENSOR -> period.name.lowercase()
+                Component.IMAGE -> "${period.name.lowercase()}_image"
+            }
+            return "$DISCOVERY_PREFIX/${component.ha}/${DEVICE_IDENTIFIER}_$suffix/config"
+        }
+
+        /**
+         * Hand-rolled JSON payload describing the prose sensor — kept inline so
+         * the publisher doesn't need a serializable model just for two static
+         * shapes. HA composes the entity name as `<device name> <name>`, so
+         * the entities surface as "ClothesCast Today" / "ClothesCast Tonight"
+         * in the HA UI.
+         *
+         * The `unique_id` matches the value the previous manual-YAML
+         * instructions used (`clothescast_today` / `clothescast_tonight`).
+         * Users who hand-added that YAML will see the discovery message
+         * conflict with their existing entity and HA will keep the YAML
+         * version; they can remove their YAML to migrate to the discovered
+         * entity at any time.
+         */
+        internal fun sensorDiscoveryPayloadFor(period: ForecastPeriod, stateTopic: String): String {
+            val periodLabel = when (period) {
+                ForecastPeriod.TODAY -> "Today"
+                ForecastPeriod.TONIGHT -> "Tonight"
+            }
+            val objectId = "${DEVICE_IDENTIFIER}_${period.name.lowercase()}"
+            // JSON keys / static strings only — no user content interpolated,
+            // so naive string concatenation is safe (no escaping needed). The
+            // state-topic value is the user-configured prefix + a literal
+            // suffix; MQTT topics permit JSON-safe characters by spec.
+            return """{"name":"$periodLabel","unique_id":"$objectId","state_topic":"$stateTopic","value_template":"{{ value }}","device":${deviceBlock()}}"""
+        }
+
+        /**
+         * Hand-rolled JSON payload describing the outfit-card image entity. HA's
+         * `image.mqtt` schema uses `image_topic` (raw bytes; the alternative
+         * `url_topic` is for fetched URLs) and `content_type` for the MIME so HA
+         * can render the binary blob.
+         *
+         * The `unique_id` matches the value the previous manual-YAML
+         * instructions used (`clothescast_today_outfit` /
+         * `clothescast_tonight_outfit`) so existing automations that target
+         * `image.clothescast_today_outfit` keep working when the user removes
+         * their manual YAML to migrate to the discovered entity.
+         */
+        internal fun imageDiscoveryPayloadFor(period: ForecastPeriod, imageTopic: String): String {
+            val periodLabel = when (period) {
+                ForecastPeriod.TODAY -> "Today outfit"
+                ForecastPeriod.TONIGHT -> "Tonight outfit"
+            }
+            val objectId = "${DEVICE_IDENTIFIER}_${period.name.lowercase()}_outfit"
+            return """{"name":"$periodLabel","unique_id":"$objectId","image_topic":"$imageTopic","content_type":"image/png","device":${deviceBlock()}}"""
+        }
+
+        private fun deviceBlock(): String =
+            """{"identifiers":["$DEVICE_IDENTIFIER"],"manufacturer":"ClothesCast","model":"Forecast bridge","name":"ClothesCast"}"""
     }
 }
 
@@ -240,9 +412,9 @@ data class MqttConfig(
 
 private suspend fun publishWithHiveMq(
     config: MqttConfig,
-    topic: String,
-    payload: ByteArray,
+    messages: List<MqttMessage>,
 ) {
+    if (messages.isEmpty()) return
     // Async client + awaited CompletableFutures (rather than the blocking
     // client wrapped in Dispatchers.IO) so the outer withTimeoutOrNull and any
     // WorkManager-issued cancel actually unwind the publish path. Coroutine
@@ -271,13 +443,15 @@ private suspend fun publishWithHiveMq(
                 .applySimpleAuth()
         }
         connect.send().await()
-        client.publishWith()
-            .topic(topic)
-            .payload(payload)
-            .qos(MqttQos.AT_LEAST_ONCE)
-            .retain(true)
-            .send()
-            .await()
+        for (message in messages) {
+            client.publishWith()
+                .topic(message.topic)
+                .payload(message.payload)
+                .qos(MqttQos.AT_LEAST_ONCE)
+                .retain(message.retain)
+                .send()
+                .await()
+        }
     } finally {
         // Run disconnect in a NonCancellable context so that when the outer
         // coroutine is cancelled mid-publish we still send a clean DISCONNECT

--- a/app/src/test/kotlin/app/clothescast/mqtt/MqttPublisherTest.kt
+++ b/app/src/test/kotlin/app/clothescast/mqtt/MqttPublisherTest.kt
@@ -8,8 +8,10 @@ import app.clothescast.core.domain.model.TemperatureUnit
 import app.clothescast.core.domain.model.UserPreferences
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -64,11 +66,65 @@ class MqttPublisherTest {
 
         captured shouldHaveSize 1
         val call = captured.single()
-        call.topic shouldBe "clothescast/insight/today"
-        call.payload.decodeToString() shouldBe "Today, cool and mild. Wear a sweater."
+        val state = call.messages.single { it.topic == "clothescast/insight/today" }
+        state.payload.decodeToString() shouldBe "Today, cool and mild. Wear a sweater."
+        state.retain shouldBe true
         call.config.host shouldBe "192.168.1.10"
         call.config.port shouldBe 1883
         call.config.useTls shouldBe false
+    }
+
+    @Test
+    fun `each refresh re-publishes the HA sensor discovery config alongside the state`() = runTest {
+        val captured = mutableListOf<PublishCall>()
+        val subject = MqttPublisher(
+            preferences = flowOf(
+                basePrefs.copy(mqttBridgeEnabled = true, mqttHost = "broker.local"),
+            ),
+            passwordProvider = { null },
+            publish = capturing(captured),
+        )
+
+        subject.publishIfEnabled(ForecastPeriod.TODAY, "Today, cool and mild.")
+
+        val messages = captured.single().messages
+        messages shouldHaveSize 2
+        val discovery = messages.single { it.topic.startsWith("homeassistant/") }
+        discovery.topic shouldBe "homeassistant/sensor/clothescast_today/config"
+        discovery.retain shouldBe true
+        val discoveryJson = discovery.payload.decodeToString()
+        discoveryJson shouldContain "\"state_topic\":\"clothescast/insight/today\""
+        discoveryJson shouldContain "\"unique_id\":\"clothescast_today\""
+        discoveryJson shouldContain "\"name\":\"Today\""
+        discoveryJson shouldContain "\"identifiers\":[\"clothescast\"]"
+        discoveryJson shouldContain "\"manufacturer\":\"ClothesCast\""
+    }
+
+    @Test
+    fun `discovery state_topic mirrors the user's custom prefix`() = runTest {
+        val captured = mutableListOf<PublishCall>()
+        val subject = MqttPublisher(
+            preferences = flowOf(
+                basePrefs.copy(
+                    mqttBridgeEnabled = true,
+                    mqttHost = "broker.local",
+                    mqttTopic = "home/forecast",
+                ),
+            ),
+            passwordProvider = { null },
+            publish = capturing(captured),
+        )
+
+        subject.publishIfEnabled(ForecastPeriod.TONIGHT, "Tonight, clear and cool.")
+
+        val messages = captured.single().messages
+        val discovery = messages.single { it.topic == "homeassistant/sensor/clothescast_tonight/config" }
+        val discoveryJson = discovery.payload.decodeToString()
+        discoveryJson shouldContain "\"state_topic\":\"home/forecast/tonight\""
+        discoveryJson shouldContain "\"unique_id\":\"clothescast_tonight\""
+        discoveryJson shouldContain "\"name\":\"Tonight\""
+        messages.single { it.topic == "home/forecast/tonight" }
+            .payload.decodeToString() shouldBe "Tonight, clear and cool."
     }
 
     @Test
@@ -88,7 +144,10 @@ class MqttPublisherTest {
 
         subject.publishIfEnabled(ForecastPeriod.TONIGHT, "Tonight, clear and cool.")
 
-        captured.single().topic shouldBe "home/forecast/tonight"
+        captured.single().messages.map { it.topic } shouldContainExactly listOf(
+            "homeassistant/sensor/clothescast_tonight/config",
+            "home/forecast/tonight",
+        )
     }
 
     @Test
@@ -187,7 +246,7 @@ class MqttPublisherTest {
                 ),
             ),
             passwordProvider = { null },
-            publish = { _, _, _ ->
+            publish = { _, _ ->
                 attempted = true
                 error("simulated broker rejection")
             },
@@ -219,7 +278,7 @@ class MqttPublisherTest {
         val subject = MqttPublisher(
             preferences = flowOf(basePrefs.copy(mqttBridgeEnabled = false, mqttHost = "broker.local")),
             passwordProvider = { null },
-            publish = { _, _, _ -> },
+            publish = { _, _ -> },
         )
 
         subject.publishIfEnabled(ForecastPeriod.TODAY, "x") shouldBe MqttPublishOutcome.NotConfigured
@@ -230,7 +289,7 @@ class MqttPublisherTest {
         val subject = MqttPublisher(
             preferences = flowOf(basePrefs.copy(mqttBridgeEnabled = true, mqttHost = null)),
             passwordProvider = { null },
-            publish = { _, _, _ -> },
+            publish = { _, _ -> },
         )
 
         subject.publishIfEnabled(ForecastPeriod.TODAY, "x") shouldBe MqttPublishOutcome.NotConfigured
@@ -241,7 +300,7 @@ class MqttPublisherTest {
         val subject = MqttPublisher(
             preferences = flowOf(basePrefs.copy(mqttBridgeEnabled = true, mqttHost = "broker.local")),
             passwordProvider = { null },
-            publish = { _, _, _ -> error("simulated broker rejection") },
+            publish = { _, _ -> error("simulated broker rejection") },
         )
 
         val outcome = subject.publishIfEnabled(ForecastPeriod.TODAY, "x")
@@ -255,7 +314,7 @@ class MqttPublisherTest {
         val subject = MqttPublisher(
             preferences = flowOf(basePrefs.copy(mqttBridgeEnabled = true, mqttHost = "broker.local")),
             passwordProvider = { null },
-            publish = { _, _, _ ->
+            publish = { _, _ ->
                 while (true) {
                     coroutineContext.ensureActive()
                     kotlinx.coroutines.delay(1_000)
@@ -270,7 +329,7 @@ class MqttPublisherTest {
     }
 
     @Test
-    fun `publishTest routes to test topic, not today or tonight`() = runTest {
+    fun `publishTest routes to test topic and emits discovery for every sensor and image entity`() = runTest {
         val captured = mutableListOf<PublishCall>()
         val subject = MqttPublisher(
             preferences = flowOf(
@@ -287,8 +346,14 @@ class MqttPublisherTest {
         val outcome = subject.publishTest()
 
         outcome shouldBe MqttPublishOutcome.Success
-        captured shouldHaveSize 1
-        captured.single().topic shouldBe "home/forecast/test"
+        val messages = captured.single().messages
+        messages.map { it.topic } shouldContainExactly listOf(
+            "homeassistant/sensor/clothescast_today/config",
+            "homeassistant/sensor/clothescast_tonight/config",
+            "homeassistant/image/clothescast_today_image/config",
+            "homeassistant/image/clothescast_tonight_image/config",
+            "home/forecast/test",
+        )
     }
 
     @Test
@@ -314,7 +379,19 @@ class MqttPublisherTest {
     }
 
     @Test
-    fun `publishImageIfEnabled publishes PNG bytes to image topic`() = runTest {
+    fun `discovery topic shapes match the HA-standard config-topic layout`() {
+        MqttPublisher.discoveryTopicFor(ForecastPeriod.TODAY, MqttPublisher.Component.SENSOR) shouldBe
+            "homeassistant/sensor/clothescast_today/config"
+        MqttPublisher.discoveryTopicFor(ForecastPeriod.TONIGHT, MqttPublisher.Component.SENSOR) shouldBe
+            "homeassistant/sensor/clothescast_tonight/config"
+        MqttPublisher.discoveryTopicFor(ForecastPeriod.TODAY, MqttPublisher.Component.IMAGE) shouldBe
+            "homeassistant/image/clothescast_today_image/config"
+        MqttPublisher.discoveryTopicFor(ForecastPeriod.TONIGHT, MqttPublisher.Component.IMAGE) shouldBe
+            "homeassistant/image/clothescast_tonight_image/config"
+    }
+
+    @Test
+    fun `publishImageIfEnabled publishes PNG bytes alongside image-entity discovery config`() = runTest {
         val captured = mutableListOf<PublishCall>()
         val subject = MqttPublisher(
             preferences = flowOf(
@@ -332,9 +409,17 @@ class MqttPublisherTest {
         subject.publishImageIfEnabled(ForecastPeriod.TODAY, fakeImage)
 
         captured shouldHaveSize 1
-        val call = captured.single()
-        call.topic shouldBe "clothescast/insight/today/image"
-        (call.payload contentEquals fakeImage).shouldBeTrue()
+        val messages = captured.single().messages
+        messages.map { it.topic } shouldContainExactly listOf(
+            "homeassistant/image/clothescast_today_image/config",
+            "clothescast/insight/today/image",
+        )
+        val imageMessage = messages.last()
+        imageMessage.payload contentEquals fakeImage shouldBe true
+        val discoveryJson = messages.first().payload.decodeToString()
+        discoveryJson shouldContain "\"image_topic\":\"clothescast/insight/today/image\""
+        discoveryJson shouldContain "\"content_type\":\"image/png\""
+        discoveryJson shouldContain "\"unique_id\":\"clothescast_today_outfit\""
     }
 
     @Test
@@ -358,7 +443,7 @@ class MqttPublisherTest {
                 basePrefs.copy(mqttBridgeEnabled = true, mqttHost = "broker.local"),
             ),
             passwordProvider = { null },
-            publish = { _, _, _ -> throw CancellationException("simulated worker cancel") },
+            publish = { _, _ -> throw CancellationException("simulated worker cancel") },
         )
 
         // Without explicit CancellationException rethrow inside the publish
@@ -375,7 +460,7 @@ class MqttPublisherTest {
         val subject = MqttPublisher(
             preferences = flow { throw CancellationException("flow cancelled") },
             passwordProvider = { null },
-            publish = { _, _, _ -> error("must not run when prefs read is cancelled") },
+            publish = { _, _ -> error("must not run when prefs read is cancelled") },
         )
 
         shouldThrow<CancellationException> {
@@ -394,7 +479,7 @@ class MqttPublisherTest {
                 ),
             ),
             passwordProvider = { throw CancellationException("keystore read cancelled") },
-            publish = { _, _, _ -> error("must not run when password read is cancelled") },
+            publish = { _, _ -> error("must not run when password read is cancelled") },
         )
 
         shouldThrow<CancellationException> {
@@ -412,7 +497,7 @@ class MqttPublisherTest {
                 ),
             ),
             passwordProvider = { null },
-            publish = { _, _, _ ->
+            publish = { _, _ ->
                 // Hang past the configured timeout. Yields so withTimeoutOrNull
                 // can fire; runTest's virtual time skips ahead deterministically.
                 while (true) {
@@ -428,10 +513,10 @@ class MqttPublisherTest {
         // a TimeoutCancellationException — the contract the worker relies on.
     }
 
-    private data class PublishCall(val config: MqttConfig, val topic: String, val payload: ByteArray)
+    private data class PublishCall(val config: MqttConfig, val messages: List<MqttMessage>)
 
-    private fun capturing(into: MutableList<PublishCall>): suspend (MqttConfig, String, ByteArray) -> Unit =
-        { config, topic, payload -> into.add(PublishCall(config, topic, payload)) }
+    private fun capturing(into: MutableList<PublishCall>): suspend (MqttConfig, List<MqttMessage>) -> Unit =
+        { config, messages -> into.add(PublishCall(config, messages)) }
 
     private val basePrefs = UserPreferences(
         schedule = Schedule(time = LocalTime.of(7, 0), days = Schedule.EVERY_DAY, zoneId = ZoneId.of("UTC")),

--- a/docs/smart-home.md
+++ b/docs/smart-home.md
@@ -106,26 +106,39 @@ forecast.
 
 ## Home Assistant — reading the sensor
 
-Add the following to `configuration.yaml` (or anywhere your
-`mqtt:` block lives):
+ClothesCast publishes [MQTT Discovery](https://www.home-assistant.io/integrations/mqtt/#mqtt-discovery)
+config alongside each forecast push, so the sensors register themselves
+automatically — no YAML required. On the next refresh after you save
+your broker settings (or right after tapping **Publish now**), look in
+HA under **Settings → Devices & services → MQTT → ClothesCast**: two
+entities will appear, `sensor.clothescast_today` and
+`sensor.clothescast_tonight`. Both surface the rendered forecast prose
+as their state, ready for automations to read.
 
-```yaml
-mqtt:
-  sensor:
-    - name: "Clothescast today"
-      unique_id: clothescast_today
-      state_topic: "clothescast/insight/today"
-      value_template: "{{ value }}"
-    - name: "Clothescast tonight"
-      unique_id: clothescast_tonight
-      state_topic: "clothescast/insight/tonight"
-      value_template: "{{ value }}"
-```
+If you'd previously hand-added a `mqtt:` block to `configuration.yaml`
+to expose these sensors, the discovery message will collide with your
+manual entity registration and HA will keep the YAML version. You can
+remove the YAML block on your own schedule — the discovery-managed
+entity will take over once the manual one is gone.
 
-Restart Home Assistant or reload MQTT entries; the sensors should
-populate within seconds of the next ClothesCast refresh (or instantly,
-if you've already done one — retained messages are delivered to new
-subscribers on connect).
+> If your Home Assistant install uses a non-default MQTT discovery
+> prefix (the **MQTT Discovery prefix** field on the MQTT integration's
+> options page — almost always left at `homeassistant`), the
+> auto-registered entities won't appear; fall back to the manual YAML
+> below by un-commenting it:
+>
+> ```yaml
+> mqtt:
+>   sensor:
+>     - name: "Clothescast today"
+>       unique_id: clothescast_today
+>       state_topic: "clothescast/insight/today"
+>       value_template: "{{ value }}"
+>     - name: "Clothescast tonight"
+>       unique_id: clothescast_tonight
+>       state_topic: "clothescast/insight/tonight"
+>       value_template: "{{ value }}"
+> ```
 
 ## Home Assistant — outfit image on Nest Hub
 
@@ -145,23 +158,30 @@ The result: at your morning alarm time the Hub shows the outfit picture
 alongside the spoken briefing — "T-shirt and shorts" on screen while
 the voice reads the full forecast.
 
-### Add the image sensors to `configuration.yaml`
+### Image entities (auto-registered)
 
-```yaml
-mqtt:
-  image:
-    - name: "Clothescast today outfit"
-      unique_id: clothescast_today_outfit
-      image_topic: "clothescast/insight/today/image"
-      content_type: "image/png"
-    - name: "Clothescast tonight outfit"
-      unique_id: clothescast_tonight_outfit
-      image_topic: "clothescast/insight/tonight/image"
-      content_type: "image/png"
-```
+The outfit-card entities — `image.clothescast_today_outfit` and
+`image.clothescast_tonight_outfit` — register themselves via the same
+[MQTT Discovery](https://www.home-assistant.io/integrations/mqtt/#mqtt-discovery)
+mechanism the prose sensors use, alongside each forecast push. They
+land under the same **ClothesCast** device card in HA — no
+`configuration.yaml` block required.
 
-Restart HA (or reload MQTT) so the entities appear as
-`image.clothescast_today_outfit` and `image.clothescast_tonight_outfit`.
+> If your HA install uses a non-default MQTT discovery prefix, fall
+> back to a manual `mqtt: image:` block:
+>
+> ```yaml
+> mqtt:
+>   image:
+>     - name: "Clothescast today outfit"
+>       unique_id: clothescast_today_outfit
+>       image_topic: "clothescast/insight/today/image"
+>       content_type: "image/png"
+>     - name: "Clothescast tonight outfit"
+>       unique_id: clothescast_tonight_outfit
+>       image_topic: "clothescast/insight/tonight/image"
+>       content_type: "image/png"
+> ```
 
 ### Automation to push the image to the Hub
 


### PR DESCRIPTION
## Summary

ClothesCast now publishes Home Assistant MQTT Discovery configs alongside each forecast and image push:

- `homeassistant/sensor/clothescast_<period>/config` for the prose sensors
- `homeassistant/image/clothescast_<period>_image/config` for the outfit-card image entities

HA's MQTT integration auto-creates the four entities — `sensor.clothescast_today` / `_tonight` and `image.clothescast_today_outfit` / `_tonight_outfit` — under a single **ClothesCast** device card. The manual `mqtt: sensor:` and `mqtt: image:` blocks in `configuration.yaml` from the previous setup guide are no longer required.

## Implementation

- `MqttPublisher`'s inner publish lambda changes from `(MqttConfig, String, ByteArray)` to a list of `MqttMessage`s, so the discovery config and the state publish (or the image bytes) share one TCP/MQTT round-trip per refresh instead of two. `MqttMessage` carries a `ByteArray` payload so the same plumbing covers UTF-8 prose and binary PNGs without duplication.
- `publishIfEnabled` emits `[sensor_discovery, prose_state]` for the period being refreshed. `publishImageIfEnabled` emits `[image_discovery, image_bytes]`. `publishTest` re-emits all four discovery configs so a freshly-saved bridge can light up HA immediately via the **Publish now** button rather than waiting for the next scheduled refresh.
- Discovery topic + payload helpers live on the companion object (hand-rolled JSON for two static shapes — no serializable model), parameterised by a new `Component` enum (`SENSOR` / `IMAGE`).
- The HiveMQ implementation iterates the message list inside one connect/disconnect pair; the inner `MqttMessage` also gets explicit `equals` / `hashCode` so its `ByteArray` field compares by content.

## Migration

Users who hand-added either the sensor YAML or the image YAML will see HA log a `unique_id` conflict and keep the manual entity (the discovery message loses). They can remove the YAML on their own schedule to switch to the discovered entity — the `unique_id` values (`clothescast_today`, `clothescast_today_outfit`, …) match the manual-YAML examples, so automations targeting `image.clothescast_today_outfit` keep working post-migration. `docs/smart-home.md` recommends auto-discovery as the default and documents the manual fallback for installs that have remapped the discovery prefix.

## Privacy

Discovery payloads are static metadata only — entity labels (`Today` / `Tonight` / `Today outfit` / `Tonight outfit`), the device card name (`ClothesCast`), and the state / image topic paths. No coordinates, no user content, no device identifier travels with them. They go to the same user-configured broker as the forecast strings and image bytes; nothing leaves your network. PRIVACY.md's Smart Home section is updated to note the additional retained-config writes.

## Test plan

- [x] `:app:testDebugUnitTest` — `MqttPublisherTest` covers the new contract: sensor + image discovery topic shapes, payload JSON, prefix-aware state/image topics, `publishTest` emitting discovery for every entity, `publishImageIfEnabled` bundling discovery with PNG bytes.
- [x] `:app:assembleDebug` — green locally.
- [ ] On-device smoke: enable the bridge against a Mosquitto instance, confirm **Settings → Devices & services → MQTT → ClothesCast** surfaces both sensors *and* both image entities after one refresh or **Publish now** tap.