### PR TITLE
Speak the morning briefing on the Hub by publishing the TTS clip

### DIFF
--- a/app/src/main/kotlin/app/clothescast/mqtt/MqttPublisher.kt
+++ b/app/src/main/kotlin/app/clothescast/mqtt/MqttPublisher.kt
@@ -112,6 +112,27 @@ class MqttPublisher(
     }
 
     /**
+     * Fire-and-forget publish of a WAV-wrapped TTS clip to
+     * `${baseTopic}/${period.lowercased()}/audio`. Same bridge toggle as the
+     * prose and image topics — no separate setting. Only emitted when the
+     * Gemini engine actually synthesised audio for local playback (device
+     * TTS doesn't expose bytes), so the published clip matches what the
+     * phone speaks. The companion HA automation can either fetch this as a
+     * media URL or use the retained payload to trigger `media_player`.
+     */
+    suspend fun publishAudioIfEnabled(period: ForecastPeriod, wavBytes: ByteArray) {
+        val prepared = preparePublish(context = "${period.name.lowercase()} TTS audio") ?: return
+        val topic = audioTopicFor(prepared.baseTopic, period)
+        DiagLog.i(
+            TAG,
+            "MQTT bridge enabled; publishing ${period.name.lowercase()} TTS audio " +
+                "(${wavBytes.size} bytes) to " +
+                "${prepared.scheme}://${prepared.host}:${prepared.port}/$topic.",
+        )
+        executePublish(prepared, topic, wavBytes)
+    }
+
+    /**
      * Reads the current preferences and resolves credentials; returns null
      * (with appropriate logging) when the bridge is not configured. [context]
      * is a short label used in warning messages only (e.g. "today", "test").
@@ -222,6 +243,9 @@ class MqttPublisher(
 
         fun imageTopicFor(baseTopic: String, period: ForecastPeriod): String =
             "${topicFor(baseTopic, period)}/image"
+
+        fun audioTopicFor(baseTopic: String, period: ForecastPeriod): String =
+            "${topicFor(baseTopic, period)}/audio"
     }
 }
 

--- a/app/src/main/kotlin/app/clothescast/tts/GeminiTtsSpeaker.kt
+++ b/app/src/main/kotlin/app/clothescast/tts/GeminiTtsSpeaker.kt
@@ -2,6 +2,7 @@ package app.clothescast.tts
 
 import app.clothescast.core.data.tts.DEFAULT_GEMINI_TTS_VOICE
 import app.clothescast.core.data.tts.GeminiTtsClient
+import app.clothescast.core.data.tts.PcmAudio
 import app.clothescast.core.domain.model.TtsStyle
 import java.util.Locale
 
@@ -12,6 +13,10 @@ import java.util.Locale
  * Voice is configurable; defaults to `Despina` (smooth). Other prebuilt voices
  * are surfaced via the Settings voice picker.
  *
+ * Synthesis and playback are split into [synthesize] and [play] so the worker
+ * can capture the same audio buffer for an MQTT publish to the Smart Home
+ * bridge between the two — the Hub gets the exact clip the phone speaks.
+ *
  * Fallback is the caller's responsibility — see [app.clothescast.work.FetchAndNotifyWorker]
  * which retries with [AndroidTtsSpeaker] when this throws.
  */
@@ -21,13 +26,19 @@ class GeminiTtsSpeaker(
     private val style: TtsStyle = TtsStyle.WEATHER_FORECASTER,
 ) : TtsSpeaker {
 
-    override suspend fun speak(text: String, locale: Locale) {
-        val audio = client.synthesize(
+    suspend fun synthesize(text: String, locale: Locale = Locale.getDefault()): PcmAudio =
+        client.synthesize(
             text = prepareForTts(text),
             voiceName = voiceName,
             locale = locale,
             style = style,
         )
+
+    suspend fun play(audio: PcmAudio) {
         PcmAudioPlayer.play(audio)
+    }
+
+    override suspend fun speak(text: String, locale: Locale) {
+        play(synthesize(text, locale))
     }
 }

--- a/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
@@ -23,6 +23,7 @@ import app.clothescast.core.domain.model.Location
 import app.clothescast.core.domain.model.TtsEngine
 import app.clothescast.core.domain.model.UserPreferences
 import app.clothescast.core.domain.usecase.shouldSpeak
+import app.clothescast.core.data.tts.WavEncoder
 import app.clothescast.data.InsightCache
 import app.clothescast.mqtt.MqttPublishOutcome
 import app.clothescast.diag.Telemetry
@@ -588,7 +589,7 @@ class FetchAndNotifyWorker(
         }
         val ttsRequested = mode == DeliveryMode.TTS_ONLY || mode == DeliveryMode.NOTIFICATION_AND_TTS
         if (shouldSpeakNow(ttsRequested, prefs)) {
-            speakWithFallback(ttsUtterance(insight, prefs), prefs)
+            speakWithFallback(insight.period, ttsUtterance(insight, prefs), prefs)
         }
     }
 
@@ -718,7 +719,7 @@ class FetchAndNotifyWorker(
         }
         val ttsRequested = mode == DeliveryMode.TTS_ONLY || mode == DeliveryMode.NOTIFICATION_AND_TTS
         if (shouldSpeakNow(ttsRequested, prefs)) {
-            speakWithFallback(ttsUtterance(insight, prefs), prefs)
+            speakWithFallback(insight.period, ttsUtterance(insight, prefs), prefs)
         }
     }
 
@@ -755,16 +756,36 @@ class FetchAndNotifyWorker(
      * something. We never let a TTS error fail the worker — the notification
      * path is the primary delivery channel and has already fired by this point.
      */
-    private suspend fun speakWithFallback(utterance: InsightTtsUtterance, prefs: UserPreferences) {
+    private suspend fun speakWithFallback(
+        period: ForecastPeriod,
+        utterance: InsightTtsUtterance,
+        prefs: UserPreferences,
+    ) {
         withSpeechAudioFocus(applicationContext) {
             when (prefs.ttsEngine) {
                 TtsEngine.GEMINI -> {
                     try {
-                        GeminiTtsSpeaker(
+                        val speaker = GeminiTtsSpeaker(
                             app.geminiTtsClient,
                             voiceName = prefs.geminiVoice,
                             style = prefs.ttsStyle,
-                        ).speak(utterance.text, utterance.locale)
+                        )
+                        val audio = speaker.synthesize(utterance.text, utterance.locale)
+                        // Publish before local playback so a Hub speaking off
+                        // the retained audio topic doesn't trail the phone.
+                        // Mirrors the image publish in deliver(): the call is
+                        // capped at MqttPublisher.DEFAULT_PUBLISH_TIMEOUT_MS,
+                        // so a broker outage costs at most that 5 s budget.
+                        runCatching {
+                            app.mqttPublisher.publishAudioIfEnabled(
+                                period,
+                                WavEncoder.encode(audio),
+                            )
+                        }.onFailure { t ->
+                            if (t is CancellationException) throw t
+                            DiagLog.w(TAG, "TTS audio MQTT publish failed.", t)
+                        }
+                        speaker.play(audio)
                         return@withSpeechAudioFocus
                     } catch (t: Throwable) {
                         DiagLog.w(TAG, "Gemini TTS failed; falling back to device TTS.", t)

--- a/app/src/test/kotlin/app/clothescast/mqtt/MqttPublisherTest.kt
+++ b/app/src/test/kotlin/app/clothescast/mqtt/MqttPublisherTest.kt
@@ -314,6 +314,16 @@ class MqttPublisherTest {
     }
 
     @Test
+    fun `audioTopicFor appends audio suffix to prose topic`() {
+        MqttPublisher.audioTopicFor("clothescast/insight", ForecastPeriod.TODAY) shouldBe
+            "clothescast/insight/today/audio"
+        MqttPublisher.audioTopicFor("home/forecast", ForecastPeriod.TONIGHT) shouldBe
+            "home/forecast/tonight/audio"
+        MqttPublisher.audioTopicFor("", ForecastPeriod.TODAY) shouldBe
+            "clothescast/insight/today/audio"
+    }
+
+    @Test
     fun `publishImageIfEnabled publishes PNG bytes to image topic`() = runTest {
         val captured = mutableListOf<PublishCall>()
         val subject = MqttPublisher(
@@ -347,6 +357,44 @@ class MqttPublisherTest {
         )
 
         subject.publishImageIfEnabled(ForecastPeriod.TODAY, byteArrayOf(1, 2, 3))
+
+        captured shouldHaveSize 0
+    }
+
+    @Test
+    fun `publishAudioIfEnabled publishes WAV bytes to audio topic`() = runTest {
+        val captured = mutableListOf<PublishCall>()
+        val subject = MqttPublisher(
+            preferences = flowOf(
+                basePrefs.copy(
+                    mqttBridgeEnabled = true,
+                    mqttHost = "broker.local",
+                    mqttTopic = "clothescast/insight",
+                ),
+            ),
+            passwordProvider = { null },
+            publish = capturing(captured),
+        )
+        val fakeWav = byteArrayOf(0x52, 0x49, 0x46, 0x46) // "RIFF" header magic
+
+        subject.publishAudioIfEnabled(ForecastPeriod.TONIGHT, fakeWav)
+
+        captured shouldHaveSize 1
+        val call = captured.single()
+        call.topic shouldBe "clothescast/insight/tonight/audio"
+        (call.payload contentEquals fakeWav).shouldBeTrue()
+    }
+
+    @Test
+    fun `publishAudioIfEnabled no-op when bridge disabled`() = runTest {
+        val captured = mutableListOf<PublishCall>()
+        val subject = MqttPublisher(
+            preferences = flowOf(basePrefs.copy(mqttBridgeEnabled = false, mqttHost = "broker.local")),
+            passwordProvider = { null },
+            publish = capturing(captured),
+        )
+
+        subject.publishAudioIfEnabled(ForecastPeriod.TODAY, byteArrayOf(1, 2, 3))
 
         captured shouldHaveSize 0
     }

--- a/core/data/src/main/kotlin/app/clothescast/core/data/tts/WavEncoder.kt
+++ b/core/data/src/main/kotlin/app/clothescast/core/data/tts/WavEncoder.kt
@@ -1,0 +1,47 @@
+package app.clothescast.core.data.tts
+
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+/**
+ * Wraps signed 16-bit mono PCM (as produced by [GeminiTtsClient.synthesize]) in a
+ * canonical 44-byte RIFF/WAVE header so the payload can be played by any standard
+ * audio player. HiveMQ has no notion of "this is PCM at 24 kHz" — handing
+ * downstream consumers (Home Assistant's `media_player`, ffmpeg, browsers) a raw
+ * PCM blob makes them guess at sample rate / channel layout and usually fail.
+ * A WAV wrapper makes the payload self-describing.
+ */
+object WavEncoder {
+
+    private const val HEADER_BYTES = 44
+    private const val CHANNELS: Short = 1
+    private const val BITS_PER_SAMPLE: Short = 16
+    private const val PCM_FORMAT: Short = 1
+
+    fun encode(audio: PcmAudio): ByteArray {
+        val pcm = audio.bytes
+        val sampleRate = audio.sampleRate
+        val byteRate = sampleRate * CHANNELS * (BITS_PER_SAMPLE / 8)
+        val blockAlign: Short = (CHANNELS * (BITS_PER_SAMPLE / 8)).toShort()
+
+        val out = ByteBuffer.allocate(HEADER_BYTES + pcm.size).order(ByteOrder.LITTLE_ENDIAN)
+        // RIFF chunk descriptor
+        out.put("RIFF".toByteArray(Charsets.US_ASCII))
+        out.putInt(36 + pcm.size)
+        out.put("WAVE".toByteArray(Charsets.US_ASCII))
+        // fmt sub-chunk
+        out.put("fmt ".toByteArray(Charsets.US_ASCII))
+        out.putInt(16)
+        out.putShort(PCM_FORMAT)
+        out.putShort(CHANNELS)
+        out.putInt(sampleRate)
+        out.putInt(byteRate)
+        out.putShort(blockAlign)
+        out.putShort(BITS_PER_SAMPLE)
+        // data sub-chunk
+        out.put("data".toByteArray(Charsets.US_ASCII))
+        out.putInt(pcm.size)
+        out.put(pcm)
+        return out.array()
+    }
+}

--- a/core/data/src/test/kotlin/app/clothescast/core/data/tts/WavEncoderTest.kt
+++ b/core/data/src/test/kotlin/app/clothescast/core/data/tts/WavEncoderTest.kt
@@ -1,0 +1,59 @@
+package app.clothescast.core.data.tts
+
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+class WavEncoderTest {
+
+    @Test
+    fun `encodes a canonical 44-byte header for 16-bit mono PCM`() {
+        val pcm = byteArrayOf(0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07)
+        val wav = WavEncoder.encode(PcmAudio(bytes = pcm, sampleRate = 24_000))
+
+        wav.size shouldBe (44 + pcm.size)
+
+        val buf = ByteBuffer.wrap(wav).order(ByteOrder.LITTLE_ENDIAN)
+        val riff = ByteArray(4).also { buf.get(it) }
+        riff.toString(Charsets.US_ASCII) shouldBe "RIFF"
+        buf.int shouldBe (36 + pcm.size) // chunk size
+
+        val wave = ByteArray(4).also { buf.get(it) }
+        wave.toString(Charsets.US_ASCII) shouldBe "WAVE"
+
+        val fmt = ByteArray(4).also { buf.get(it) }
+        fmt.toString(Charsets.US_ASCII) shouldBe "fmt "
+        buf.int shouldBe 16 // fmt sub-chunk size
+        buf.short shouldBe 1.toShort() // PCM format
+        buf.short shouldBe 1.toShort() // mono
+        buf.int shouldBe 24_000 // sample rate
+        buf.int shouldBe 24_000 * 2 // byte rate (sampleRate * channels * bytesPerSample)
+        buf.short shouldBe 2.toShort() // block align (channels * bytesPerSample)
+        buf.short shouldBe 16.toShort() // bits per sample
+
+        val data = ByteArray(4).also { buf.get(it) }
+        data.toString(Charsets.US_ASCII) shouldBe "data"
+        buf.int shouldBe pcm.size
+
+        val tail = ByteArray(pcm.size).also { buf.get(it) }
+        (tail contentEquals pcm).shouldBeTrue()
+    }
+
+    @Test
+    fun `byte rate scales with sample rate`() {
+        val wav = WavEncoder.encode(PcmAudio(bytes = ByteArray(0), sampleRate = 48_000))
+        // Byte rate sits at offset 28 (little-endian int).
+        val byteRate = ByteBuffer.wrap(wav, 28, 4).order(ByteOrder.LITTLE_ENDIAN).int
+        byteRate shouldBe 48_000 * 2
+    }
+
+    @Test
+    fun `empty PCM still produces a valid header`() {
+        val wav = WavEncoder.encode(PcmAudio(bytes = ByteArray(0), sampleRate = 24_000))
+        wav.size shouldBe 44
+        ByteBuffer.wrap(wav, 4, 4).order(ByteOrder.LITTLE_ENDIAN).int shouldBe 36
+        ByteBuffer.wrap(wav, 40, 4).order(ByteOrder.LITTLE_ENDIAN).int shouldBe 0
+    }
+}

--- a/docs/smart-home.md
+++ b/docs/smart-home.md
@@ -210,6 +210,38 @@ picture *and* speaks the forecast at the same moment.
 > (`https://your-ha.duckdns.org`) instead. The camera proxy path and
 > access token are the same either way.
 
+## Home Assistant — TTS audio clip on the audio topic
+
+When the Gemini TTS engine is selected (Settings → Voice → Gemini),
+ClothesCast publishes the synthesised audio as a WAV clip to
+`<prefix>/<period>/audio` (e.g. `clothescast/insight/today/audio`).
+The payload is signed 16-bit mono PCM at the sample rate Gemini
+returned, wrapped in a canonical 44-byte RIFF/WAVE header — playable
+as-is by ffmpeg, browsers, and `media_player.play_media` when handed
+via an HTTP fetch (HA doesn't read MQTT binary payloads directly into
+the media player). It's exactly the bytes the phone speaks, so any
+"speak it on the Hub" automation built around the prose sensor or one
+of the TTS options below stays in lockstep with the phone.
+
+Two things to know before you wire anything up:
+
+- **Gemini-only.** Device TTS doesn't expose its audio buffer before
+  playback, so the audio topic stays empty when the on-device engine
+  is selected. Switch to Gemini in Settings → Voice to populate it.
+- **Skip-TTS-at-home applies.** The audio is published from the same
+  code path that plays it on the phone, so if "Don't speak the
+  forecast at home" is on and you're at home, neither the phone nor
+  the Hub gets the clip. Toggle that off if you want the Hub to speak
+  even when you're home.
+
+The simplest way to make the Hub actually speak is still options A /
+B / C below: trigger an automation on the prose sensor's update and
+let HA's TTS service synthesise — that path is already paved end to
+end. The audio topic is here for setups that already prefer a fixed
+voice clip over re-synthesising in HA (e.g. mass.announce → media URL
+flows), and for users who want to capture the rendered briefing for
+their own pipelines.
+
 ## Home Assistant — speaking the sensor on Google Home
 
 As of mid-2026, getting Google Home / Nest devices to actually *speak*


### PR DESCRIPTION
## Summary

Adds a third MQTT topic — `<prefix>/<period>/audio` — alongside the existing prose (`/today` / `/tonight`) and image (`/.../image`) topics. When the Gemini TTS engine is selected, the worker captures the PCM buffer that `GeminiTtsSpeaker` already synthesises for local playback, wraps it in a canonical RIFF/WAVE header, and publishes the WAV bytes before playing them on the phone. Same content the phone speaks, same bridge toggle, same fire-and-forget timing budget as the image publish — so a Hub reading off the retained audio topic stays in lockstep with the phone.

## What's new on each topic

| topic | payload | toggle |
|---|---|---|
| `<prefix>/<period>` | UTF-8 prose | MQTT bridge enabled |
| `<prefix>/<period>/image` | PNG outfit card | MQTT bridge enabled |
| **`<prefix>/<period>/audio`** | **WAV (16-bit mono PCM)** | **MQTT bridge enabled + Gemini engine** |

## Scope and trade-offs

- **Gemini-only.** Android's `TextToSpeech` doesn't expose its audio buffer before playback, so the audio topic stays empty when the on-device engine is selected. Documented in `smart-home.md`.
- **Skip-TTS-at-home applies.** Audio publish runs from the same code path that plays locally — if the user is at home with "Don't speak the forecast at home" on, neither phone nor Hub gets the clip. Same gate, both consumers; documented.
- **Sequential, not parallel publish.** Mirrors the existing `publishImageIfEnabled` pattern in `deliver()`: capped at `MqttPublisher.DEFAULT_PUBLISH_TIMEOUT_MS` (5 s), so a broker outage costs at most that 5 s before local TTS proceeds.

## Privacy

The published audio is the same insight prose already crossing to the user-hosted MQTT broker as text, just rendered as Gemini-voice WAV. No new data class crosses the device boundary; destination is unchanged. The bridge stays opt-in and gated on `mqttBridgeEnabled`.

## Files

- `core/data/.../tts/WavEncoder.kt` — pure-Kotlin RIFF/WAVE wrapper over `PcmAudio`.
- `core/data/.../tts/WavEncoderTest.kt` — header layout + byte-rate scaling + empty-PCM tests.
- `app/.../mqtt/MqttPublisher.kt` — adds `publishAudioIfEnabled()` + `audioTopicFor()`.
- `app/.../mqtt/MqttPublisherTest.kt` — audio publish + audio-topic-routing + bridge-disabled tests.
- `app/.../tts/GeminiTtsSpeaker.kt` — split `speak()` into `synthesize()` + `play()`; the existing `speak()` wrapper preserves the Voice-preview call site.
- `app/.../work/FetchAndNotifyWorker.kt` — capture the synthesised buffer, publish, play.
- `docs/smart-home.md` — documents the audio topic, the Gemini-only / skip-at-home caveats, and points users at the existing A/B/C TTS options as the simplest "speak it on the Hub" path.

## Test plan

- [x] `:core:domain:test :core:data:test :app:testDebugUnitTest` green locally (CI parity).
- [x] `:app:assembleDebug` green locally.
- [ ] CI green on push.
- [ ] Manual: bridge enabled, Gemini engine — verify retained payload appears on `<prefix>/today/audio` via `mosquitto_sub -t '<prefix>/+/audio' -v` after a fetch.
- [ ] Manual: bridge enabled, on-device engine — verify the audio topic stays unchanged after a fetch (no publish).
- [ ] Manual: bridge enabled, skip-at-home on, phone at home, Gemini engine — verify no publish to `audio` (phone also silent).
- [ ] Manual: pipe a published payload through ffplay / browser to confirm the WAV header is well-formed at 24 kHz.

https://claude.ai/code/session_01LjtduvUT11Cv5o3GrNYwRb

---
_Generated by [Claude Code](https://claude.ai/code/session_01LjtduvUT11Cv5o3GrNYwRb)_