### PR TITLE
Don't show 'Last attempt failed' before the first forecast arrives

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
@@ -287,14 +287,11 @@ private fun TodayContent(
     // know what to tap.
     val locationActionRequired = !state.hasFallbackLocation &&
         !(state.useDeviceLocation && coarseGranted && backgroundGranted)
-    // Suppress the redundant generic failure card when the action banner
-    // already explains the no-location case; other failure reasons still
-    // show through.
-    val workStatusToShow = if (
-        locationActionRequired &&
-        state.workStatus is WorkStatus.Failed &&
-        (state.workStatus as WorkStatus.Failed).reason == FetchAndNotifyWorker.REASON_NO_LOCATION
-    ) WorkStatus.Idle else state.workStatus
+    val workStatusToShow = bannerStatus(
+        workStatus = state.workStatus,
+        hasInsight = state.thisPeriodInsight != null,
+        locationActionRequired = locationActionRequired,
+    )
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -641,6 +638,38 @@ internal fun LocationActionRequiredBanner(onSetUpLocation: () -> Unit) {
             ) { Text(stringResource(R.string.today_location_required_action)) }
         }
     }
+}
+
+/**
+ * Picks the [WorkStatus] the Today screen's banner should render, given the
+ * raw status from WorkManager plus the local UI predicates that suppress or
+ * soften it.
+ *
+ *  - **No-location failure with the location-required banner already showing.**
+ *    Hide the generic failure card — the action banner above already explains
+ *    the cause and offers the fix.
+ *  - **Retrying with nothing in the cache yet (cold open).** "Last attempt
+ *    failed — retrying" reads as a real error to the user, but WorkManager
+ *    bumps `runAttemptCount` and parks the work back in ENQUEUED whenever a
+ *    run is interrupted — not just when our code returned `Result.retry()`.
+ *    An OS-initiated kill (process death during an app update, low-memory
+ *    eviction, the JobScheduler rescheduling around doze) leaves the same
+ *    state on disk as a real transient failure. With no prior insight on
+ *    screen to anchor "last attempt", the error framing is misleading; treat
+ *    it as a generic "Fetching" so the user just sees that work is in flight.
+ *    When an existing insight *is* on screen, the "retrying" framing helps
+ *    the user understand why what they're looking at is stale, so we keep it.
+ */
+internal fun bannerStatus(
+    workStatus: WorkStatus,
+    hasInsight: Boolean,
+    locationActionRequired: Boolean,
+): WorkStatus = when {
+    locationActionRequired &&
+        workStatus is WorkStatus.Failed &&
+        workStatus.reason == FetchAndNotifyWorker.REASON_NO_LOCATION -> WorkStatus.Idle
+    !hasInsight && workStatus is WorkStatus.Retrying -> WorkStatus.Running
+    else -> workStatus
 }
 
 @Composable

--- a/app/src/test/kotlin/app/clothescast/ui/today/TodayWorkStatusSelectionTest.kt
+++ b/app/src/test/kotlin/app/clothescast/ui/today/TodayWorkStatusSelectionTest.kt
@@ -144,6 +144,80 @@ class TodayWorkStatusSelectionTest {
         mergeWorkStatus(WorkStatus.Idle, WorkStatus.Idle) shouldBe WorkStatus.Idle
     }
 
+    @Test
+    fun `cold-open retry without an insight reads as Running`() {
+        // WorkManager parks work back in ENQUEUED with runAttemptCount > 1
+        // whenever a run is interrupted — not just when our code returned
+        // Result.retry(). Killing the process during an app update leaves
+        // the same on-disk state as a real transient failure, so on first
+        // open after an update the banner would shout "Last attempt failed
+        // — retrying" even though nothing went wrong. With no insight on
+        // screen for the user to anchor "last attempt" against, soften the
+        // status to Running so the banner reads as plain "Fetching".
+        bannerStatus(
+            workStatus = WorkStatus.Retrying,
+            hasInsight = false,
+            locationActionRequired = false,
+        ) shouldBe WorkStatus.Running
+    }
+
+    @Test
+    fun `retry with an existing insight keeps the retrying framing`() {
+        // When there's a previous insight on screen, "retrying" tells the
+        // user why what they're looking at might be stale — keep it.
+        bannerStatus(
+            workStatus = WorkStatus.Retrying,
+            hasInsight = true,
+            locationActionRequired = false,
+        ) shouldBe WorkStatus.Retrying
+    }
+
+    @Test
+    fun `failed status passes through on a cold open`() {
+        // A real terminal failure isn't going to auto-retry — keep the
+        // failure card so the user knows to act (tap Refresh, check
+        // settings, etc.) rather than burying it as a spinner.
+        val failed = WorkStatus.Failed(
+            reason = FetchAndNotifyWorker.REASON_UNEXPECTED_HTTP,
+            detail = "503",
+        )
+        bannerStatus(
+            workStatus = failed,
+            hasInsight = false,
+            locationActionRequired = false,
+        ) shouldBe failed
+    }
+
+    @Test
+    fun `no-location failure is suppressed when the action banner is showing`() {
+        // The LocationActionRequiredBanner already explains the cause and
+        // offers the fix; the generic failure card would just duplicate it.
+        bannerStatus(
+            workStatus = WorkStatus.Failed(
+                reason = FetchAndNotifyWorker.REASON_NO_LOCATION,
+                detail = null,
+            ),
+            hasInsight = false,
+            locationActionRequired = true,
+        ) shouldBe WorkStatus.Idle
+    }
+
+    @Test
+    fun `other failures still surface when the action banner is showing`() {
+        // The suppression is keyed specifically to REASON_NO_LOCATION —
+        // unrelated failures still need to reach the user even when the
+        // location-required banner is also up.
+        val failed = WorkStatus.Failed(
+            reason = FetchAndNotifyWorker.REASON_UNEXPECTED_HTTP,
+            detail = "503",
+        )
+        bannerStatus(
+            workStatus = failed,
+            hasInsight = false,
+            locationActionRequired = true,
+        ) shouldBe failed
+    }
+
     private fun active(state: WorkInfo.State, runAttemptCount: Int): WorkInfoLite =
         WorkInfoLite(state = state, runAttemptCount = runAttemptCount, outputData = Data.EMPTY)
 


### PR DESCRIPTION
## Summary

On cold open with an empty cache, the Today screen would surface "Last attempt failed — retrying" whenever WorkManager had parked a fetch in `ENQUEUED` with `runAttemptCount > 1`. With no previous insight on screen for the user to anchor "last attempt" against, the error framing was misleading.

Extracted the banner-status selection out of `TodayContent` into a testable internal helper (`bannerStatus`) and added the cold-open case: when there's no cached insight, soften `Retrying` to `Running` so the banner reads as "Working — fetching your ClothesCast…". When an existing insight is on screen the "retrying" framing still helps the user understand why what they're looking at might be stale, so we keep it there.

## Why "Last attempt failed" wasn't always a real failure

The user's bug report (2026-05-16) showed the alarming banner on cold open with an empty cache and no fetch-error lines in the diag log. Two of the cases the user asked about:

1. **Empty cache** — handled by this PR: the banner now reads "Fetching" instead of an error.
2. **Was there really an error?** — likely not. `runAttemptCount > 1` reaches `ENQUEUED` from more paths than just our own `Result.retry()`:
   - Process death during an app update (the user's report came right after `MY_PACKAGE_REPLACED` — Android killed the running worker, WorkManager re-enqueued it).
   - Low-memory eviction.
   - Doze / JobScheduler reschedules.
   - Genuinely transient network failures (no WiFi at 07:00, 5xx from Open-Meteo, 429 from a same-IP burst) — but those auto-retry and self-heal, exactly what backoff is for.

   In every one of those cases WorkManager bumps `runAttemptCount` and parks the work back in `ENQUEUED`. From `selectStatus`'s point of view they're indistinguishable, and most of them aren't a "fetch failure" the user needs to know about — the next attempt will succeed on its own.

The terminal `Failed` status still passes through on empty cache: those won't auto-retry, so the user needs to see the failure card to know to tap Refresh or check settings. The existing no-location suppression (`Failed` + `REASON_NO_LOCATION` + location-required banner already showing) is unchanged.

## Test plan

- [x] `./gradlew :app:testDebugUnitTest` — passes (`TodayWorkStatusSelectionTest` + `WorkStatusBannerTest`).
- [x] New `bannerStatus` cases cover cold-open retry → Running, retry-with-insight → Retrying, failed pass-through with and without the location-required banner, and the existing no-location suppression.
- [ ] Manual check on a device: after a fresh debug-APK reinstall (which triggers `MY_PACKAGE_REPLACED`), open the app. Verify the banner reads "Working — fetching your ClothesCast…" rather than "Last attempt failed — retrying…".


---
_Generated by [Claude Code](https://claude.ai/code/session_01XoJFPSQWjAojecnQBcKJNx)_