### PR TITLE
Retry MQTT publish on first-attempt timeout, and put broker details in bug reports

### DIFF
--- a/app/src/main/kotlin/app/clothescast/diag/BugReport.kt
+++ b/app/src/main/kotlin/app/clothescast/diag/BugReport.kt
@@ -24,6 +24,7 @@ import app.clothescast.core.domain.model.Region
 import app.clothescast.core.domain.model.TemperatureUnit
 import app.clothescast.core.domain.model.UserPreferences
 import app.clothescast.core.domain.model.symbol
+import app.clothescast.data.SettingsRepository
 import app.clothescast.insight.InsightFormatter
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.suspendCancellableCoroutine
@@ -32,6 +33,8 @@ import java.io.FileOutputStream
 import java.text.SimpleDateFormat
 import java.time.Duration
 import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 import java.util.Date
 import java.util.Locale
 import kotlin.coroutines.resume
@@ -45,6 +48,8 @@ import kotlin.coroutines.resume
  */
 object BugReport {
     private const val FILE_PROVIDER_AUTHORITY_SUFFIX = ".fileprovider"
+    private val STATUS_TIMESTAMP_FORMAT: DateTimeFormatter =
+        DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss zzz")
 
     /**
      * Captures the screen, builds the text payload, copies the text to the
@@ -64,6 +69,12 @@ object BugReport {
         val geminiKeyConfigured = runCatching {
             app.secureKeyStore.geminiKeyConfiguredFlow.first()
         }.getOrDefault(false)
+        val mqttPasswordConfigured = runCatching {
+            app.secureKeyStore.mqttPasswordConfiguredFlow.first()
+        }.getOrDefault(false)
+        val mqttPublishStatus = runCatching {
+            app.settingsRepository.mqttPublishStatus.first()
+        }.getOrNull()
         val thisPeriod = runCatching {
             app.insightCache.thisPeriod.first()
         }.getOrNull()
@@ -92,7 +103,7 @@ object BugReport {
             if (prefs == null) {
                 appendLine("(failed to read preferences)")
             } else {
-                appendPreferences(prefs)
+                appendPreferences(prefs, mqttPasswordConfigured, mqttPublishStatus)
             }
             appendLine("API keys: Gemini=${if (geminiKeyConfigured) "set" else "unset"}")
             appendLine()
@@ -115,7 +126,11 @@ object BugReport {
         }
     }
 
-    private fun StringBuilder.appendPreferences(prefs: UserPreferences) {
+    private fun StringBuilder.appendPreferences(
+        prefs: UserPreferences,
+        mqttPasswordConfigured: Boolean,
+        mqttPublishStatus: SettingsRepository.MqttPublishStatus?,
+    ) {
         appendLine("Region: ${prefs.region.name} (${prefs.region.bcp47 ?: "system"})")
         appendLine("Temperature unit: ${prefs.temperatureUnit.name}")
         appendLine("Distance unit: ${prefs.distanceUnit.name}")
@@ -145,7 +160,34 @@ object BugReport {
         appendLine("Use calendar events: ${prefs.useCalendarEvents}")
         appendLine("Clothes rules (${prefs.clothesRules.size}):")
         prefs.clothesRules.forEach { appendLine("  - ${describeRule(it)}") }
+        appendMqttSettings(prefs, mqttPasswordConfigured, mqttPublishStatus)
     }
+
+    private fun StringBuilder.appendMqttSettings(
+        prefs: UserPreferences,
+        mqttPasswordConfigured: Boolean,
+        mqttPublishStatus: SettingsRepository.MqttPublishStatus?,
+    ) {
+        appendLine("MQTT bridge enabled: ${prefs.mqttBridgeEnabled}")
+        val hostLine = prefs.mqttHost?.takeIf { it.isNotBlank() }?.let { "$it:${prefs.mqttPort}" }
+            ?: "(unset)"
+        appendLine("MQTT broker: $hostLine")
+        appendLine("MQTT TLS: ${prefs.mqttUseTls}")
+        appendLine("MQTT topic: ${prefs.mqttTopic}")
+        appendLine("MQTT username: ${if (!prefs.mqttUsername.isNullOrBlank()) "set" else "unset"}")
+        appendLine("MQTT password: ${if (mqttPasswordConfigured) "set" else "unset"}")
+        val statusLine = when {
+            mqttPublishStatus == null -> "(no publish attempted)"
+            mqttPublishStatus.errorMessage == null -> "success at ${formatTimestamp(mqttPublishStatus.recordedAtMs)}"
+            else -> "failed at ${formatTimestamp(mqttPublishStatus.recordedAtMs)} — ${mqttPublishStatus.errorMessage}"
+        }
+        appendLine("MQTT last publish: $statusLine")
+    }
+
+    private fun formatTimestamp(epochMs: Long): String =
+        Instant.ofEpochMilli(epochMs)
+            .atZone(ZoneId.systemDefault())
+            .format(STATUS_TIMESTAMP_FORMAT)
 
     /**
      * Humanises age relative to now so a glance at the bug report tells you

--- a/app/src/main/kotlin/app/clothescast/mqtt/MqttPublisher.kt
+++ b/app/src/main/kotlin/app/clothescast/mqtt/MqttPublisher.kt
@@ -7,6 +7,7 @@ import com.hivemq.client.mqtt.MqttClient
 import com.hivemq.client.mqtt.datatypes.MqttQos
 import com.hivemq.client.mqtt.mqtt3.Mqtt3AsyncClient
 import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.future.await
@@ -47,6 +48,8 @@ class MqttPublisher(
     private val passwordProvider: suspend () -> String?,
     private val publish: suspend (config: MqttConfig, topic: String, payload: ByteArray) -> Unit = ::publishWithHiveMq,
     private val publishTimeoutMs: Long = DEFAULT_PUBLISH_TIMEOUT_MS,
+    private val retryDelayMs: Long = DEFAULT_RETRY_DELAY_MS,
+    private val maxAttempts: Int = DEFAULT_MAX_PUBLISH_ATTEMPTS,
 ) {
 
     /**
@@ -193,6 +196,37 @@ class MqttPublisher(
         prepared: PreparedPublish,
         topic: String,
         payload: ByteArray,
+    ): MqttPublishOutcome {
+        // Retry once on failure to absorb transient broker unreachability —
+        // the most common report path is the morning alarm firing while
+        // Wi-Fi is still re-associating from doze, where the first connect
+        // times out but the second a second later succeeds. A
+        // CancellationException still unwinds the worker immediately because
+        // attemptPublish re-raises it before this loop sees an outcome.
+        var lastFailure: MqttPublishOutcome.Failure? = null
+        repeat(maxAttempts.coerceAtLeast(1)) { attempt ->
+            if (attempt > 0) {
+                DiagLog.i(
+                    TAG,
+                    "Retrying MQTT publish (attempt ${attempt + 1}/$maxAttempts) to " +
+                        "${prepared.scheme}://${prepared.host}:${prepared.port}/$topic " +
+                        "after ${retryDelayMs}ms",
+                )
+                delay(retryDelayMs)
+            }
+            when (val outcome = attemptPublish(prepared, topic, payload)) {
+                is MqttPublishOutcome.Success -> return outcome
+                is MqttPublishOutcome.Failure -> lastFailure = outcome
+                is MqttPublishOutcome.NotConfigured -> return outcome
+            }
+        }
+        return lastFailure ?: MqttPublishOutcome.Failure("no attempts")
+    }
+
+    private suspend fun attemptPublish(
+        prepared: PreparedPublish,
+        topic: String,
+        payload: ByteArray,
     ): MqttPublishOutcome = withTimeoutOrNull(publishTimeoutMs) {
         var result: MqttPublishOutcome = MqttPublishOutcome.Success
         try {
@@ -226,6 +260,14 @@ class MqttPublisher(
     companion object {
         private const val TAG = "MqttPublisher"
         const val DEFAULT_PUBLISH_TIMEOUT_MS = 5_000L
+
+        // Two attempts caps the cost of a permanently-down broker at
+        // ~2 × DEFAULT_PUBLISH_TIMEOUT_MS + DEFAULT_RETRY_DELAY_MS (~11 s) per
+        // publish — still within the 60-second alignment window the worker
+        // uses before notification delivery, even with subsequent image / TTS
+        // publishes on the same hot path.
+        const val DEFAULT_MAX_PUBLISH_ATTEMPTS = 2
+        const val DEFAULT_RETRY_DELAY_MS = 750L
 
         // Inner HiveMQ timeouts kept tighter than [DEFAULT_PUBLISH_TIMEOUT_MS]
         // so the connect phase fails cleanly (with a ConnectionFailedException

--- a/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
@@ -543,8 +543,10 @@ class FetchAndNotifyWorker(
         // deliverToday/Tonight both start with awaitDeliveryAlignment() (60 s
         // window) and then await TTS — Home Assistant automations timed to the
         // scheduled alarm would race with the retained topics if we published
-        // after that. The 5-second publish timeout means an unreachable broker
-        // delays notification by at most 5 s, which is within the 60-second window.
+        // after that. The publisher caps each prose / image / audio publish at
+        // ~11 s (two attempts × the 5-second timeout + a short retry delay), so
+        // a permanently-down broker delays notification by at most that, well
+        // within the 60-second alignment window.
         // Prose publish — outcome persisted for the Smart Home settings UI.
         val mqttOutcome = app.mqttPublisher.publishIfEnabled(insight.period, prose)
         // Image publish — fire-and-forget alongside the prose.
@@ -790,8 +792,9 @@ class FetchAndNotifyWorker(
                         // Publish before local playback so a Hub speaking off
                         // the retained audio topic doesn't trail the phone.
                         // Mirrors the image publish in deliver(): the call is
-                        // capped at MqttPublisher.DEFAULT_PUBLISH_TIMEOUT_MS,
-                        // so a broker outage costs at most that 5 s budget.
+                        // capped at two attempts × MqttPublisher.DEFAULT_PUBLISH_TIMEOUT_MS
+                        // plus the retry delay, so a broker outage costs at
+                        // most ~11 s of TTS-path latency.
                         runCatching {
                             app.mqttPublisher.publishAudioIfEnabled(
                                 period,

--- a/app/src/test/kotlin/app/clothescast/mqtt/MqttPublisherTest.kt
+++ b/app/src/test/kotlin/app/clothescast/mqtt/MqttPublisherTest.kt
@@ -451,6 +451,65 @@ class MqttPublisherTest {
     }
 
     @Test
+    fun `failed first attempt is retried and a successful second attempt returns Success`() = runTest {
+        val attempts = mutableListOf<PublishCall>()
+        val subject = MqttPublisher(
+            preferences = flowOf(
+                basePrefs.copy(mqttBridgeEnabled = true, mqttHost = "broker.local"),
+            ),
+            passwordProvider = { null },
+            publish = { config, topic, payload ->
+                attempts.add(PublishCall(config, topic, payload))
+                if (attempts.size == 1) error("first-attempt failure")
+            },
+            retryDelayMs = 1L,
+        )
+
+        val outcome = subject.publishIfEnabled(ForecastPeriod.TODAY, "x")
+
+        outcome shouldBe MqttPublishOutcome.Success
+        attempts shouldHaveSize 2
+    }
+
+    @Test
+    fun `both attempts failing returns the last attempt's Failure message`() = runTest {
+        var attempts = 0
+        val subject = MqttPublisher(
+            preferences = flowOf(
+                basePrefs.copy(mqttBridgeEnabled = true, mqttHost = "broker.local"),
+            ),
+            passwordProvider = { null },
+            publish = { _, _, _ ->
+                attempts += 1
+                error("attempt $attempts failure")
+            },
+            retryDelayMs = 1L,
+        )
+
+        val outcome = subject.publishIfEnabled(ForecastPeriod.TODAY, "x")
+
+        val failure = outcome.shouldBeInstanceOf<MqttPublishOutcome.Failure>()
+        attempts shouldBe 2
+        failure.message shouldBe "IllegalStateException: attempt 2 failure"
+    }
+
+    @Test
+    fun `successful first attempt does not retry`() = runTest {
+        var attempts = 0
+        val subject = MqttPublisher(
+            preferences = flowOf(
+                basePrefs.copy(mqttBridgeEnabled = true, mqttHost = "broker.local"),
+            ),
+            passwordProvider = { null },
+            publish = { _, _, _ -> attempts += 1 },
+            retryDelayMs = 1L,
+        )
+
+        subject.publishIfEnabled(ForecastPeriod.TODAY, "x") shouldBe MqttPublishOutcome.Success
+        attempts shouldBe 1
+    }
+
+    @Test
     fun `publish timeout triggers a no-throw fallthrough`() = runTest {
         val subject = MqttPublisher(
             preferences = flowOf(


### PR DESCRIPTION
## Summary

Reproduced bug: the Smart Home card shows a fresh "Last publish failed — ConnectionFailedException: connection timed out: /192.168.0.240:1883" right after the morning alarm fires (07:01), and "Publish now" reproduces it. Two changes, one per concern:

- **Retry once on first-attempt timeout.** `MqttPublisher.executePublish` now wraps `attemptPublish` in a two-attempt loop with a 750 ms gap between tries. The most common report shape is the morning-alarm path where the first TCP connect to the LAN broker times out because Wi-Fi is still re-associating from doze and a second attempt a moment later succeeds. `CancellationException` still short-circuits the loop so a WorkManager stop unwinds cleanly. Permanently-down brokers now cost ~11 s of publish-path latency (2 × 5 s timeout + retry delay) — still well within the 60 s delivery-alignment window the worker takes before notification. Worker comments updated to match.
- **Surface MQTT details in the shareable bug report.** `BugReport.appendPreferences` now writes an MQTT block (enabled flag, host:port, TLS, topic, username/password presence — no plaintext) and a "last publish" line carrying the persisted timestamp and error message. Password presence reads `SecureKeyStore.mqttPasswordConfiguredFlow`, status reads `SettingsRepository.mqttPublishStatus` — no new state, just plumbing the existing card-facing data into the payload.

## Privacy

Bug-report payload broadens to include the user's MQTT broker host (parity with the existing `Location: 51.5856, -0.1450 — London` line), topic, and the *presence* of username/password — never the values. The error message persisted to the publish-status flow already only contains a Throwable class name + sanitised message (capped at 250 chars in `MqttPublisher`), so no payload bytes leak through that path either. Nothing leaves the device until the user shares the report from the system share sheet.

## Test plan

- [x] `./gradlew :app:testDebugUnitTest` (mqtt + full suite passes locally)
- [x] New `MqttPublisherTest` cases cover retry-then-succeed, both-attempts-fail (last-attempt message surfaces), and no-retry-on-first-success
- [ ] CI: JVM unit tests + Android debug build go green
- [ ] On a build of this branch: tap "Publish now" with the broker reachable → still succeeds; with the broker stopped → card shows the error and the bug report's "MQTT last publish" line carries the same timestamp + message

https://claude.ai/code/session_01QiXz6VZ3Qg9SZJBdtRLaea

---
_Generated by [Claude Code](https://claude.ai/code/session_01QiXz6VZ3Qg9SZJBdtRLaea)_