### PR TITLE
Compact stack traces in the diag log so the bug-report buffer covers more events

### DIFF
--- a/app/src/main/kotlin/app/clothescast/diag/DiagLog.kt
+++ b/app/src/main/kotlin/app/clothescast/diag/DiagLog.kt
@@ -34,6 +34,17 @@ object DiagLog {
     private const val MAX_BYTES = 200L * 1024L
     private const val SYNC_TIMEOUT_MS = 2_000L
 
+    /**
+     * How many `at …` frames per Throwable in the chain to keep in diag-log
+     * entries. The full trace still goes to `last-crash.txt` for uncaught
+     * exceptions, so the snapshot just needs the call site. One frame
+     * trims a typical `MqttPublisher: publish failed` block from 13 lines
+     * to 4 — the cause chain text + the top frame for each link is enough
+     * to read on its own, and the ten-deep Netty / executor noise that
+     * otherwise dominates the 300-line buffer goes away.
+     */
+    private const val COMPACT_STACK_FRAMES = 1
+
     private val executor = Executors.newSingleThreadExecutor { r ->
         Thread(r, "DiagLog-writer").apply { isDaemon = true }
     }
@@ -182,12 +193,59 @@ object DiagLog {
         StringWriter().also { sw -> PrintWriter(sw).use { t.printStackTrace(it) } }
             .toString().trimEnd()
 
+    /**
+     * Formats [t] like [Throwable.printStackTrace] but keeps only the top
+     * [maxFrames] frames per Throwable in the cause chain. The dropped
+     * deeper frames aren't summarised — the omitted-count line `... N more`
+     * is intentionally absent so each Throwable costs `1 + maxFrames` lines
+     * flat, maximising how much pre-failure history fits in the 300-line
+     * snapshot budget. The full trace still goes to `last-crash.txt` via
+     * [writeCrashLog] for uncaught exceptions, so post-mortem debugging
+     * loses nothing.
+     *
+     * Cyclic cause chains (`a.cause = b; b.cause = a`) are guarded via an
+     * identity set so a pathological Throwable can't spin the calling
+     * thread before the executor submit runs — printStackTrace does the
+     * same. Suppressed exceptions surface as a one-line `Suppressed: …`
+     * summary per parent so try-with-resources / `.use` close failures
+     * aren't silently lost; their frames are intentionally dropped to
+     * keep the budget tight. Visible for tests.
+     */
+    internal fun compactStackTraceString(t: Throwable, maxFrames: Int = COMPACT_STACK_FRAMES): String {
+        val sb = StringBuilder()
+        val seen = java.util.IdentityHashMap<Throwable, Boolean>()
+        var current: Throwable? = t
+        var depth = 0
+        while (current != null) {
+            if (seen.put(current, true) != null) {
+                sb.append('\n').append("\t[CIRCULAR REFERENCE: ")
+                    .append(current.javaClass.name).append(']')
+                break
+            }
+            if (depth > 0) sb.append('\n').append("Caused by: ")
+            sb.append(current.javaClass.name)
+            current.message?.let { sb.append(": ").append(it) }
+            val frames = current.stackTrace
+            val keep = minOf(maxFrames, frames.size)
+            for (i in 0 until keep) {
+                sb.append('\n').append("\tat ").append(frames[i])
+            }
+            for (suppressed in current.suppressed) {
+                sb.append('\n').append("\tSuppressed: ").append(suppressed.javaClass.name)
+                suppressed.message?.let { sb.append(": ").append(it) }
+            }
+            current = current.cause
+            depth++
+        }
+        return sb.toString()
+    }
+
     private fun log(level: Char, tag: String, msg: String, t: Throwable?) {
         val timestamp = timestampFormat.get().format(Date())
         val formatted = if (t == null) {
             "$timestamp $level $tag: $msg"
         } else {
-            "$timestamp $level $tag: $msg\n${stackTraceString(t)}"
+            "$timestamp $level $tag: $msg\n${compactStackTraceString(t)}"
         }
         val file = diagFileProvider?.invoke() ?: return
         val rotated = diagRotatedProvider?.invoke() ?: return

--- a/app/src/test/kotlin/app/clothescast/diag/DiagLogTest.kt
+++ b/app/src/test/kotlin/app/clothescast/diag/DiagLogTest.kt
@@ -1,6 +1,9 @@
 package app.clothescast.diag
 
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import io.kotest.matchers.string.shouldStartWith
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.io.File
@@ -108,6 +111,79 @@ class DiagLogTest {
         file.writeText("only-current\n")
         rotated.exists() shouldBe false
         DiagLog.readTail(file, rotated, maxLines = 100) shouldBe listOf("only-current")
+    }
+
+    @Test
+    fun `compactStackTraceString starts with exception class and message`() {
+        val t = IllegalStateException("simulated broker rejection")
+        val s = DiagLog.compactStackTraceString(t)
+        s shouldStartWith "java.lang.IllegalStateException: simulated broker rejection"
+    }
+
+    @Test
+    fun `compactStackTraceString caps frames per throwable and drops the rest silently`() {
+        val t = makeWithStackDepth(10)
+        val s = DiagLog.compactStackTraceString(t, maxFrames = 1)
+        // Exactly one retained `at` line; no `... N more` summary so each
+        // Throwable costs a flat `1 + maxFrames` lines in the snapshot.
+        s.lines().count { it.startsWith("\tat ") } shouldBe 1
+        s shouldNotContain "more"
+    }
+
+    @Test
+    fun `compactStackTraceString preserves the cause chain with a 'Caused by' prefix`() {
+        val cause = RuntimeException("inner")
+        val outer = IllegalStateException("outer", cause)
+        val s = DiagLog.compactStackTraceString(outer, maxFrames = 1)
+        s shouldContain "java.lang.IllegalStateException: outer"
+        s shouldContain "Caused by: java.lang.RuntimeException: inner"
+    }
+
+    @Test
+    fun `compactStackTraceString does not duplicate frames for empty traces`() {
+        // A Throwable whose stack we've cleared (mirrors R8-stripped wrappers
+        // that arrive with no frames — common with HiveMQ's
+        // ConnectionFailedException in release builds).
+        val t = IllegalStateException("no frames here").apply { stackTrace = emptyArray() }
+        val s = DiagLog.compactStackTraceString(t, maxFrames = 3)
+        s shouldNotContain "\tat "
+        s shouldNotContain "... "
+    }
+
+    @Test
+    fun `compactStackTraceString terminates on a circular cause chain`() {
+        // a.cause = b, b.cause = a — printStackTrace handles this by tracking
+        // already-seen throwables; the compact formatter must do the same so a
+        // pathological Throwable can't spin the calling thread.
+        val a = IllegalStateException("a")
+        val b = IllegalStateException("b")
+        a.initCause(b)
+        b.initCause(a)
+        val s = DiagLog.compactStackTraceString(a, maxFrames = 1)
+        s shouldContain "java.lang.IllegalStateException: a"
+        s shouldContain "Caused by: java.lang.IllegalStateException: b"
+        s shouldContain "[CIRCULAR REFERENCE: java.lang.IllegalStateException]"
+    }
+
+    @Test
+    fun `compactStackTraceString surfaces suppressed exceptions as a one-line summary`() {
+        // try-with-resources / .use add a close failure as a suppressed
+        // exception on the primary throwable. Drop frames to keep the budget
+        // tight, but keep class + message so the actionable bit isn't lost.
+        val primary = IllegalStateException("primary")
+        primary.addSuppressed(RuntimeException("close failed"))
+        val s = DiagLog.compactStackTraceString(primary, maxFrames = 1)
+        s shouldContain "java.lang.IllegalStateException: primary"
+        s shouldContain "\tSuppressed: java.lang.RuntimeException: close failed"
+    }
+
+    /**
+     * Builds a Throwable whose `stackTrace` has exactly [depth] entries — no
+     * implicit dependency on the test runner's actual call depth (which
+     * differs between JUnit and IDE).
+     */
+    private fun makeWithStackDepth(depth: Int): Throwable = IllegalStateException("deep").apply {
+        stackTrace = Array(depth) { i -> StackTraceElement("Foo$i", "bar", "Foo$i.kt", i + 1) }
     }
 
     private fun files(dir: Path): Pair<File, File> =


### PR DESCRIPTION
## Summary

Realised reading a real bug report that the `300 of max 300` log lines claim is technically true and practically misleading: each routine `MqttPublisher: publish failed` call writes ~13 newline-separated lines (1 message + a 12-frame trace of Netty / executor noise — no app code), so a single 80-second storm of retries chews through a third of the buffer and shoves the relevant history out. The retained frames don't help — they're all framework internals.

This PR routes `DiagLog.log`'s Throwables through a new `compactStackTraceString` that walks the cause chain like `printStackTrace` does but keeps only the **top frame per Throwable**. Each Throwable in the chain costs a flat two lines (class + message, plus the top `at …`); the deeper frames aren't summarised with `... N more` either — that line is dead weight at 1 frame and the budget is the bottleneck. `last-crash.txt` still gets the unchanged full trace via `writeCrashLog` for uncaught exceptions, so post-mortem debugging loses nothing.

### Before / after, one `MqttPublisher: publish failed` event

Before — 14 lines:

```
05-17 06:53:09.396 W MqttPublisher: MQTT publish failed to mqtt://192.168.0.240:1883/...
com.hivemq.client.mqtt.exceptions.ConnectionFailedException: io.netty.channel.ConnectTimeoutException: ...
Caused by: io.netty.channel.ConnectTimeoutException: connection timed out: /192.168.0.240:1883
	at io.netty.channel.nio.AbstractNioChannel$AbstractNioUnsafe$1.run(Unknown Source:34)
	at io.netty.util.concurrent.PromiseTask.runTask(Unknown Source:15)
	at io.netty.util.concurrent.ScheduledFutureTask.run(Unknown Source:50)
	at io.netty.util.concurrent.AbstractEventExecutor.runTask(Unknown Source:0)
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(Unknown Source:0)
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SourceFile:9)
	at io.netty.channel.nio.NioEventLoop.run(Unknown Source:168)
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(Unknown Source:41)
	at io.netty.util.internal.ThreadExecutorMap$2.run(Unknown Source:8)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(Unknown Source:2)
	at java.lang.Thread.run(Thread.java:1564)
```

After — 4 lines:

```
05-17 06:53:09.396 W MqttPublisher: MQTT publish failed to mqtt://192.168.0.240:1883/...
com.hivemq.client.mqtt.exceptions.ConnectionFailedException: io.netty.channel.ConnectTimeoutException: connection timed out: /192.168.0.240:1883
Caused by: io.netty.channel.ConnectTimeoutException: connection timed out: /192.168.0.240:1883
	at io.netty.channel.nio.AbstractNioChannel$AbstractNioUnsafe$1.run(Unknown Source:34)
```

~70 % reduction on this shape, ~3× more logical events fit in the same 300-line budget, the call-site frame is still preserved at the top of each cause. (The outer `ConnectionFailedException` arrives with zero frames after R8 — its `at …` line is correctly omitted.)

### Defensive guards mirroring `printStackTrace`

- **Cyclic cause chains** (`a.cause = b; b.cause = a`) terminate via an `IdentityHashMap` and emit a `[CIRCULAR REFERENCE: …]` marker. Without this a pathological Throwable would spin the calling thread before the executor submit even happens. (Codex P2 — addressed in 18dbcee7.)
- **Suppressed exceptions** surface as a one-line `Suppressed: <class>: <message>` per parent, so try-with-resources / `.use` close failures aren't silently dropped. Frames are dropped to keep the budget tight; the class + message is enough to spot. (Codex P2 — addressed in 18dbcee7.)

## Test plan

- [x] `./gradlew :app:testDebugUnitTest --tests "app.clothescast.diag.DiagLogTest"`
- [x] New `DiagLogTest` cases cover: starts-with class+message; one-frame cap with no `more` summary; multi-throwable cause chain with `Caused by` prefix; empty-stack edge case (R8-stripped HiveMQ wrappers); cycle protection; suppressed-as-one-line summary
- [ ] CI: JVM unit tests + Android debug build green
- [ ] On a build of this branch: share a bug report after a few MQTT failures, confirm each trace block is 3 lines (class+message, `Caused by` line, `at …`) and that more pre-failure history is retained

https://claude.ai/code/session_01QiXz6VZ3Qg9SZJBdtRLaea