### PR TITLE
Tighten the empty space above the outfit card on Today

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
@@ -303,45 +303,48 @@ private fun TodayContent(
             .fillMaxSize()
             .padding(padding),
     ) {
-        // Pinned header — banners only. Outside the pager so critical
-        // banners (update available, crash report, telemetry notice,
-        // location required, work status) aren't duplicated per page.
-        // The outfit row used to live here too, but it pinned a lot of
-        // vertical space at the top regardless of which page was in
-        // view; it now scrolls with each page (rendered inside TodayPage
-        // below) so more chart cards fit in a single screen of scroll.
+        // Pinned banners — outside the pager so critical banners (update
+        // available, crash report, telemetry notice, location required,
+        // work status) aren't duplicated per page. The outfit row used to
+        // live here too, but it pinned a lot of vertical space at the top
+        // regardless of which page was in view; it now scrolls with each
+        // page (rendered inside TodayPage below) so more chart cards fit
+        // in a single screen of scroll.
+        //
+        // Each banner carries its own top + horizontal padding so that
+        // hidden banners (every banner here early-returns when its
+        // condition isn't met) contribute zero vertical space — that's
+        // what keeps the outfit row from sitting under a permanent 40dp
+        // blank strip in the steady state. Adjacent visible banners are
+        // 16dp apart (the top padding of the lower one).
         //
         // UpdateAvailableBanner is first on purpose: a stale build is
         // the upstream cause of many bug reports, so giving the user
         // the chance to update before they notice anything else is the
         // highest-leverage placement.
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp)
-                .padding(top = 24.dp, bottom = 16.dp),
-            verticalArrangement = Arrangement.spacedBy(16.dp),
-        ) {
-            UpdateAvailableBanner()
-            LocalBuildBanner()
-            LastCrashBanner()
-            // One-shot privacy disclosure for the default-on Firebase
-            // telemetry, so the default isn't silent. Auto-hides once the
-            // user dismisses it (or taps through to Privacy from it).
-            // Stays out of the way of the crash banner: that's a current
-            // problem to action; this is just disclosure.
-            TelemetryNoticeBanner(onOpenPrivacy = onOpenPrivacy)
-            if (locationActionRequired) {
-                LocationActionRequiredBanner(onSetUpLocation = onSetUpLocation)
-            }
-            WorkStatusBanner(status = workStatusToShow)
+        val bannerModifier = Modifier.padding(top = 16.dp, start = 16.dp, end = 16.dp)
+        UpdateAvailableBanner(modifier = bannerModifier)
+        LocalBuildBanner(modifier = bannerModifier)
+        LastCrashBanner(modifier = bannerModifier)
+        // One-shot privacy disclosure for the default-on Firebase
+        // telemetry, so the default isn't silent. Auto-hides once the
+        // user dismisses it (or taps through to Privacy from it).
+        // Stays out of the way of the crash banner: that's a current
+        // problem to action; this is just disclosure.
+        TelemetryNoticeBanner(onOpenPrivacy = onOpenPrivacy, modifier = bannerModifier)
+        if (locationActionRequired) {
+            LocationActionRequiredBanner(
+                onSetUpLocation = onSetUpLocation,
+                modifier = bannerModifier,
+            )
         }
+        WorkStatusBanner(status = workStatusToShow, modifier = bannerModifier)
         if (state.thisPeriodInsight == null) {
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(horizontal = 16.dp)
-                    .padding(bottom = 24.dp),
+                    .padding(top = 16.dp, bottom = 24.dp),
             ) {
                 EmptyState(onRefresh = onRefresh, isWorking = isWorking)
             }
@@ -435,7 +438,7 @@ private fun TodayPage(
             .fillMaxSize()
             .verticalScroll(scrollState)
             .padding(horizontal = 16.dp)
-            .padding(bottom = 24.dp),
+            .padding(top = 16.dp, bottom = 24.dp),
         verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
         // Outfit row sits above the null-insight short-circuit so it
@@ -644,9 +647,12 @@ internal fun MissingPeriodPlaceholder(
 }
 
 @Composable
-internal fun LocationActionRequiredBanner(onSetUpLocation: () -> Unit) {
+internal fun LocationActionRequiredBanner(
+    onSetUpLocation: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
     Card(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = modifier.fillMaxWidth(),
         colors = CardDefaults.cardColors(
             containerColor = MaterialTheme.colorScheme.errorContainer,
             contentColor = MaterialTheme.colorScheme.onErrorContainer,
@@ -702,14 +708,17 @@ internal fun bannerStatus(
 }
 
 @Composable
-internal fun WorkStatusBanner(status: WorkStatus) {
+internal fun WorkStatusBanner(
+    status: WorkStatus,
+    modifier: Modifier = Modifier,
+) {
     when (status) {
         is WorkStatus.Idle -> Unit
-        is WorkStatus.Running -> SpinnerBanner(stringResource(R.string.today_working))
-        is WorkStatus.Retrying -> SpinnerBanner(stringResource(R.string.today_retrying))
+        is WorkStatus.Running -> SpinnerBanner(stringResource(R.string.today_working), modifier)
+        is WorkStatus.Retrying -> SpinnerBanner(stringResource(R.string.today_retrying), modifier)
         is WorkStatus.Failed -> {
             Card(
-                modifier = Modifier.fillMaxWidth(),
+                modifier = modifier.fillMaxWidth(),
                 colors = CardDefaults.cardColors(
                     containerColor = MaterialTheme.colorScheme.errorContainer,
                     contentColor = MaterialTheme.colorScheme.onErrorContainer,
@@ -751,8 +760,8 @@ internal fun WorkStatusBanner(status: WorkStatus) {
 }
 
 @Composable
-private fun SpinnerBanner(message: String) {
-    Card(modifier = Modifier.fillMaxWidth()) {
+private fun SpinnerBanner(message: String, modifier: Modifier = Modifier) {
+    Card(modifier = modifier.fillMaxWidth()) {
         Row(
             modifier = Modifier.padding(16.dp).fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically,


### PR DESCRIPTION
## Summary

When no banners had anything to show (no update available, not a local build, no crash to report, telemetry notice already acked, location working, work status `Idle`), the Today screen reserved ~40dp of blank space above the outfit card — visible as an empty white strip between the TopAppBar and the outfit row.

Root cause: `TodayScreen.kt:318-338` wrapped the banners in a `Column` with `padding(top = 24.dp, bottom = 16.dp)`. Every banner inside short-circuits with `return` when its condition isn't met, so the Column held zero rendered children but still laid out its 40dp of padding.

## Approach

Drop the wrapper Column and let each banner contribute its own top + horizontal padding via the `modifier` parameter. Hidden banners contribute zero vertical space; visible banners get 16dp above and 16dp inset from the screen edges. Adjacent visible banners are 16dp apart (the top padding of the lower one) — same spacing as before.

- `UpdateAvailableBanner`, `LocalBuildBanner`, `LastCrashBanner`, `TelemetryNoticeBanner` already accepted a `modifier` parameter; just pass it from the call site.
- `LocationActionRequiredBanner` and `WorkStatusBanner` (defined inline in `TodayScreen.kt`) gain a `modifier` parameter for symmetry. `SpinnerBanner` too, so `WorkStatusBanner` can propagate it.
- `TodayPage`'s scrollable Column and the `EmptyState` fallback each pick up `padding(top = 16.dp)` so they sit 16dp below the TopAppBar in the no-banners case (or 16dp below the last visible banner).

## Visual delta

| State                | Today (top → outfit) | After             |
|----------------------|----------------------|-------------------|
| No banners (steady)  | 40dp blank           | 16dp              |
| 1 banner visible     | 24 + banner + 16     | 16 + banner + 16  |
| N banners visible    | 24 + banners + 16    | 16 + banners + 16 |

The with-banner case loses 8dp at the top (24→16). The no-banners case (which is what most users see most of the time) loses the full 24dp of unused space.

## Privacy

No change. No data crossing the device boundary, no Firebase payloads touched.

## Test plan

- [x] `:app:assembleDebug` builds clean
- [x] `:app:testDebugUnitTest` passes (non-Roborazzi tests). Roborazzi snapshot tests can't be verified in this sandbox (pre-existing font/render differences vs CI — clean-tree `verifyRoborazziDebug` also fails); CI is the source of truth and snapshots will need regeneration.
- [ ] Manual: install debug APK and confirm on the Today screen that:
  - Steady state shows the outfit card ~16dp below the TopAppBar with no blank strip.
  - A visible banner (e.g. telemetry notice not yet acked) sits 16dp above + 16dp below.
  - First-launch `EmptyState` still has comfortable headroom.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LY9yw4cj9ZuGhhAJFkc6bs)_