### PR TITLE
Disable Firebase Analytics advertising ID collection

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -110,6 +110,15 @@
                 android:resource="@xml/file_paths" />
         </provider>
 
+        <!-- Opt out of Firebase Analytics advertising-ID (GAID) collection.
+             The app's privacy policy explicitly states no advertising identifiers
+             are collected; this flag enforces that at the SDK level on all API
+             levels, not just Android 13+ where the missing AD_ID permission
+             already blocks access. -->
+        <meta-data
+            android:name="google_analytics_adid_collection_enabled"
+            android:value="false" />
+
         <!-- Home-screen App Widget showing the current period's outfit.
              exported=true is required for the OS launcher to bind. -->
         <receiver


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds `google_analytics_adid_collection_enabled=false` to `AndroidManifest.xml` so Firebase Analytics never reads or sends the Google Advertising ID (GAID).
- Firebase Analytics collects GAID by default. The missing `AD_ID` permission only blocks this on Android 13+; on Android ≤12 the SDK can read GAID without it.
- Our privacy policy already promises "no advertising identifiers" — this flag enforces that promise at the SDK level on all API levels unconditionally.

## Privacy relevance

This is a narrowing of what leaves the device (we're plugging a gap, not broadening). The `TelemetryPrivacyContractTest` already bans `advertisingId`/`adId` as Crashlytics custom keys and asserts PRIVACY.md still names "advertising identifiers" in its hard-limits section; no test changes are needed.

## Test plan

- [x] `./gradlew :app:assembleDebug` passes with the new manifest entry
- [ ] Verify in a Firebase Analytics debug view that no `advertising_id` field appears in events from a test device running Android 12 or below
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Szj5aJyjbcAoJn5uMBsxqt)_