### PR TITLE
Remove AD_ID permission from merged manifest

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -48,6 +48,15 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SHORT_SERVICE" />
 
+    <!-- Strip the AD_ID permission that Firebase Analytics injects transitively.
+         google_analytics_adid_collection_enabled=false suppresses runtime collection,
+         but Play still scans the merged manifest for the permission declaration itself.
+         tools:node="remove" removes it from the merged manifest so Play doesn't require
+         an advertising-ID policy declaration. -->
+    <uses-permission
+        android:name="com.google.android.gms.permission.AD_ID"
+        tools:node="remove" />
+
     <application
         android:name=".ClothesCastApplication"
         android:allowBackup="false"


### PR DESCRIPTION
## Summary

- The existing `google_analytics_adid_collection_enabled=false` metadata suppresses Firebase Analytics' runtime GAID collection, but Play's manifest scanner still sees the `com.google.android.gms.permission.AD_ID` permission that `firebase-analytics` injects transitively into the merged manifest
- This was causing the Play upload failure: _"This release includes the com.google.android.gms.permission.AD_ID permission but your declaration on Play Console says your app doesn't use advertising ID"_
- Added `<uses-permission android:name="com.google.android.gms.permission.AD_ID" tools:node="remove" />` at the manifest level to strip the transitive entry at build time

Both defences are now in place: the SDK flag (suppresses runtime collection) and the manifest removal (strips the permission declaration so Play's scanner is satisfied).

## Test plan

- [ ] Build passes: `./gradlew :app:assembleDebug` ✅ (verified locally)
- [ ] Upload to Play internal track and confirm the AD_ID policy warning is gone
- [ ] Verify `AD_ID` does not appear in the merged manifest: `build/intermediates/merged_manifest/debug/AndroidManifest.xml`

---
_Generated by [Claude Code](https://claude.ai/code/session_01WFNvw2mzhDivMyVxBak7ty)_