### PR TITLE
Remove transitive AD_ID permission from merged manifest

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,6 +13,14 @@
         android:name="android.hardware.touchscreen"
         android:required="false" />
 
+    <!-- play-services-ads-identifier (pulled in transitively by firebase-analytics)
+         declares AD_ID in its own manifest; that merges into ours and triggers
+         Play's advertising-ID declaration requirement even though we never use it.
+         Remove it explicitly so the merged APK manifest is clean. -->
+    <uses-permission
+        android:name="com.google.android.gms.permission.AD_ID"
+        tools:node="remove" />
+
     <!-- Network for Open-Meteo + Gemini. -->
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -110,6 +110,15 @@
                 android:resource="@xml/file_paths" />
         </provider>
 
+        <!-- Opt out of Firebase Analytics advertising-ID (GAID) collection.
+             The app's privacy policy explicitly states no advertising identifiers
+             are collected; this flag enforces that at the SDK level on all API
+             levels, not just Android 13+ where the missing AD_ID permission
+             already blocks access. -->
+        <meta-data
+            android:name="google_analytics_adid_collection_enabled"
+            android:value="false" />
+
         <!-- Home-screen App Widget showing the current period's outfit.
              exported=true is required for the OS launcher to bind. -->
         <receiver


### PR DESCRIPTION
## Summary

- `play-services-ads-identifier:18.0.0` (pulled in transitively by `firebase-analytics:22.1.2`) declares `com.google.android.gms.permission.AD_ID` in its own manifest.
- AGP's manifest merger folds that into our app's merged manifest, and Google Play scans the merged APK manifest — not our source manifest. Play sees the permission and requires an advertising-ID declaration even though we never use it.
- The `google_analytics_adid_collection_enabled=false` metadata flag (added in the previous PR) only suppresses Firebase Analytics' *runtime* collection; it doesn't touch the merged permission.
- Adding `tools:node="remove"` strips the permission from the merged output so Play's scanner never sees it.

## Privacy relevance

This is a further narrowing: the previous PR stopped the SDK from *using* the advertising ID; this PR removes the *permission* so the APK makes no claim to it at all. Together they make the code fully consistent with the privacy policy promise of "no advertising identifiers."

## Test plan

- [x] `./gradlew :app:assembleDebug` passes with the `tools:node="remove"` entry
- [ ] Verify in the merged manifest (`app/build/intermediates/merged_manifests/`) that `AD_ID` no longer appears when built with `google-services.json` present

---
_Generated by [Claude Code](https://claude.ai/code/session_01Szj5aJyjbcAoJn5uMBsxqt)_