### PR TITLE
Don't cancel in-progress main runs mid-AAB build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,10 @@ on:
 
 concurrency:
   group: ci-${{ github.ref }}
-  cancel-in-progress: true
+  # Cancel in-progress runs on PR branches (fast-iteration pushes) but let
+  # main runs finish — the AAB build + Play upload only happen on main and
+  # a second push would otherwise cancel the release before the AAB is signed.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   unit-tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,10 +43,13 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ci-${{ github.ref }}
-  # Cancel in-progress runs on PR branches (fast-iteration pushes) but let
-  # main runs finish — the AAB build + Play upload only happen on main and
-  # a second push would otherwise cancel the release before the AAB is signed.
+  # PR branches share a group per-ref so a new push cancels the old run.
+  # Main (and workflow_dispatch) each get a unique group via run_id — no two
+  # main runs compete, so a burst of merges can't cancel each other's pending
+  # AAB builds. GitHub only keeps one pending run per group, so sharing a
+  # group on main would silently drop the queued build when a third merge
+  # arrived, even with cancel-in-progress: false.
+  group: ${{ github.event_name == 'pull_request' && format('ci-{0}', github.ref) || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:


### PR DESCRIPTION
## Summary

- `cancel-in-progress: true` was killing the `bundleRelease` + Play upload steps whenever a second commit landed on `main` before the first run finished — the AAB showed as "cancelled" with a stop sign in the GitHub UI.
- The initial fix (switch to `cancel-in-progress: ${{ github.event_name == 'pull_request' }}`) still had a gap: GitHub only keeps one pending run per concurrency group, so a third merge to `main` would cancel the queued run even with `cancel-in-progress: false`.
- Final fix: main/dispatch runs each get `group: ${{ github.run_id }}` — their own unique slot, so no two main runs ever compete. PRs keep the shared per-ref group so fast-iteration pushes still cancel the previous run.

## Test plan

- [ ] Merge two PRs to main in quick succession — both AAB builds should complete.
- [ ] PR builds still cancel correctly when a new push arrives on the same branch.

https://claude.ai/code/session_01EL5wAGVptTGpMFsjfjCbtL