### PR TITLE
Fix punycode and url.parse deprecation warnings in Play upload step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -871,18 +871,18 @@ jobs:
         # completes CI. Ordered AFTER the release-AAB artifact upload so a
         # Play API failure (e.g. listing not yet approved, versionCode
         # collision) doesn't gate the artifact behind `success()`. Pinned to
-        # the v1.1.5 commit SHA — bump deliberately.
+        # a specific commit SHA — bump deliberately.
         if: |
           success() &&
           (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
           github.ref == 'refs/heads/main' &&
           env.PLAY_AVAILABLE == 'true'
-        uses: r0adkll/upload-google-play@e738b9dd8f2476ea806d921b64aacd24f34515a5 # v1.1.5
+        uses: r0adkll/upload-google-play@a80b0bcdcfdfcc2d026f2bc73f726760b2cbc967 # post-v1.1.5: fixes DEP0040/DEP0169 Node.js deprecation warnings
         with:
           serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
           packageName: app.clothescast
           releaseFiles: app/build/outputs/bundle/release/app-release.aab
-          track: internal
+          tracks: internal
           status: completed
           whatsNewDirectory: ${{ runner.temp }}/whatsnew
 


### PR DESCRIPTION
## Summary

- Bumps `r0adkll/upload-google-play` from v1.1.5 (`e738b9d`) to the post-v1.1.5 master tip (`a80b0bc`), which updates `fast-glob`, `p-timeout`, and `@actions/core` to versions that don't pull in Node's built-in `punycode` module or call `url.parse()` — silencing **DEP0040** and **DEP0169** on Node 22+.
- Renames the deprecated `track: internal` input to `tracks: internal` per the action's own warning: `'track' is deprecated and will be removed in a future release. Please migrate to 'tracks'`.

## Test plan

- [ ] Confirm CI passes on this PR
- [ ] Confirm the next push-to-main Play upload step runs without the DEP0040/DEP0169 warnings in the action log

https://claude.ai/code/session_011P9SzAczJwtarp5tJPK4Lw