### PR TITLE
Content now extends edge-to-edge under the system bars

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/EdgeFadeOverlay.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/EdgeFadeOverlay.kt
@@ -4,9 +4,12 @@ import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -66,6 +69,16 @@ internal fun EdgeFadeOverlay(
             modifier = Modifier
                 .align(Alignment.BottomCenter)
                 .fillMaxWidth()
+                // The nav-bar inset wraps the 32 dp fade — outer height is
+                // (32 dp + nav-bar height), aligned to the screen bottom by
+                // `align(BottomCenter)`, with the painted gradient occupying
+                // the inner 32 dp at the *top* of that outer box. Net: the
+                // fade sits in the band just above the translucent nav bar,
+                // so it marks the visible-content edge rather than hiding
+                // behind the bar. In contexts with no nav-bar inset (e.g.
+                // Robolectric snapshots), this is a no-op and the fade still
+                // sits at the absolute bottom edge.
+                .windowInsetsPadding(WindowInsets.navigationBars)
                 .height(32.dp)
                 .alpha(bottomAlpha)
                 .background(

--- a/app/src/main/kotlin/app/clothescast/ui/onboarding/OnboardingScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/onboarding/OnboardingScreen.kt
@@ -8,7 +8,10 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -70,7 +73,13 @@ fun OnboardingScreen(
     val context = LocalContext.current
     val isTV = remember(context) { isTelevision(context) }
 
-    Scaffold { padding ->
+    Scaffold(
+        // Drop the default `safeDrawing` content insets so the onboarding
+        // content extends edge-to-edge. The inner Column adds
+        // `windowInsetsPadding(WindowInsets.navigationBars)` so its content
+        // can scroll above the nav bar.
+        contentWindowInsets = WindowInsets(0),
+    ) { padding ->
         OnboardingContent(
             geminiKeyConfigured = state.geminiKeyConfigured,
             location = state.location,
@@ -114,6 +123,12 @@ internal fun OnboardingContent(
             modifier = Modifier
                 .fillMaxSize()
                 .verticalScroll(scrollState)
+                // Onboarding has no TopAppBar to consume the status-bar /
+                // cutout insets, so use `safeDrawing` (= status + navigation
+                // + cutout + IME) here rather than just `navigationBars`.
+                // Without the top inset the title can start under the
+                // status bar on devices with a tall bar or a display cutout.
+                .windowInsetsPadding(WindowInsets.safeDrawing)
                 .padding(horizontal = 16.dp, vertical = 24.dp),
             verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {

--- a/app/src/main/kotlin/app/clothescast/ui/settings/AboutSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/AboutSettings.kt
@@ -10,7 +10,10 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
@@ -49,6 +52,7 @@ internal fun AboutContent(padding: PaddingValues) {
             modifier = Modifier
                 .fillMaxSize()
                 .verticalScroll(scrollState)
+                .windowInsetsPadding(WindowInsets.navigationBars)
                 .padding(horizontal = 16.dp, vertical = 8.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {

--- a/app/src/main/kotlin/app/clothescast/ui/settings/CalendarSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/CalendarSettings.kt
@@ -8,7 +8,10 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
@@ -49,6 +52,7 @@ internal fun CalendarContent(
             modifier = Modifier
                 .fillMaxSize()
                 .verticalScroll(scrollState)
+                .windowInsetsPadding(WindowInsets.navigationBars)
                 .padding(horizontal = 16.dp, vertical = 8.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {

--- a/app/src/main/kotlin/app/clothescast/ui/settings/ClothesSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/ClothesSettings.kt
@@ -11,7 +11,10 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
@@ -90,6 +93,7 @@ internal fun ClothesContent(
             modifier = Modifier
                 .fillMaxSize()
                 .verticalScroll(scrollState)
+                .windowInsetsPadding(WindowInsets.navigationBars)
                 .padding(horizontal = 16.dp, vertical = 8.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {

--- a/app/src/main/kotlin/app/clothescast/ui/settings/DisplaySettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/DisplaySettings.kt
@@ -4,7 +4,10 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
@@ -35,6 +38,7 @@ internal fun DisplayContent(
             modifier = Modifier
                 .fillMaxSize()
                 .verticalScroll(scrollState)
+                .windowInsetsPadding(WindowInsets.navigationBars)
                 .padding(horizontal = 16.dp, vertical = 8.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {

--- a/app/src/main/kotlin/app/clothescast/ui/settings/ForecasterSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/ForecasterSettings.kt
@@ -6,7 +6,10 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.verticalScroll
@@ -76,6 +79,7 @@ internal fun ForecastersContent(
             modifier = Modifier
                 .fillMaxSize()
                 .verticalScroll(scrollState)
+                .windowInsetsPadding(WindowInsets.navigationBars)
                 .padding(horizontal = 16.dp, vertical = 8.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {

--- a/app/src/main/kotlin/app/clothescast/ui/settings/LocationSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/LocationSettings.kt
@@ -9,7 +9,10 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
@@ -69,6 +72,7 @@ internal fun LocationContent(
             modifier = Modifier
                 .fillMaxSize()
                 .verticalScroll(scrollState)
+                .windowInsetsPadding(WindowInsets.navigationBars)
                 .padding(horizontal = 16.dp, vertical = 8.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {

--- a/app/src/main/kotlin/app/clothescast/ui/settings/PrivacySettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/PrivacySettings.kt
@@ -6,7 +6,10 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
@@ -40,6 +43,7 @@ internal fun PrivacyContent(
             modifier = Modifier
                 .fillMaxSize()
                 .verticalScroll(scrollState)
+                .windowInsetsPadding(WindowInsets.navigationBars)
                 .padding(horizontal = 16.dp, vertical = 8.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {

--- a/app/src/main/kotlin/app/clothescast/ui/settings/RegionSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/RegionSettings.kt
@@ -6,7 +6,10 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
@@ -54,6 +57,7 @@ internal fun RegionContent(
             modifier = Modifier
                 .fillMaxSize()
                 .verticalScroll(scrollState)
+                .windowInsetsPadding(WindowInsets.navigationBars)
                 .padding(horizontal = 16.dp, vertical = 8.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {

--- a/app/src/main/kotlin/app/clothescast/ui/settings/ScheduleSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/ScheduleSettings.kt
@@ -8,7 +8,10 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.selection.toggleable
@@ -87,6 +90,7 @@ internal fun ScheduleContent(
             modifier = Modifier
                 .fillMaxSize()
                 .verticalScroll(scrollState)
+                .windowInsetsPadding(WindowInsets.navigationBars)
                 .padding(horizontal = 16.dp, vertical = 8.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {

--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsScreen.kt
@@ -5,8 +5,11 @@ import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -93,6 +96,14 @@ fun SettingsScreen(
     }
 
     Scaffold(
+        // Drop the default `safeDrawing` content insets so each sub-screen's
+        // scroll viewport extends edge-to-edge under the (transparent) nav
+        // bar. Each sub-screen's inner Column adds
+        // `windowInsetsPadding(WindowInsets.navigationBars)` as content
+        // padding so the last item can scroll above the nav bar; the bottom
+        // fade in `EdgeFadeOverlay` does the same so it sits just above
+        // the bar.
+        contentWindowInsets = WindowInsets(0),
         topBar = {
             TopAppBar(
                 title = { Text(stringResource(route.titleRes)) },
@@ -264,6 +275,7 @@ internal fun SettingsRoot(
             modifier = Modifier
                 .fillMaxSize()
                 .verticalScroll(scrollState)
+                .windowInsetsPadding(WindowInsets.navigationBars)
                 .padding(horizontal = 16.dp, vertical = 8.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {

--- a/app/src/main/kotlin/app/clothescast/ui/settings/SmartHomeSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SmartHomeSettings.kt
@@ -6,7 +6,10 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
@@ -85,6 +88,7 @@ internal fun SmartHomeContent(
             modifier = Modifier
                 .fillMaxSize()
                 .verticalScroll(scrollState)
+                .windowInsetsPadding(WindowInsets.navigationBars)
                 .padding(horizontal = 16.dp, vertical = 8.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {

--- a/app/src/main/kotlin/app/clothescast/ui/settings/VoiceSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/VoiceSettings.kt
@@ -7,7 +7,10 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -126,6 +129,7 @@ internal fun VoiceContent(
             modifier = Modifier
                 .fillMaxSize()
                 .verticalScroll(scrollState)
+                .windowInsetsPadding(WindowInsets.navigationBars)
                 .padding(horizontal = 16.dp, vertical = 8.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {

--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
@@ -12,9 +12,12 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
@@ -160,6 +163,14 @@ fun TodayScreen(
     )
 
     Scaffold(
+        // Drop the default `safeDrawing` content insets so the pager extends
+        // edge-to-edge under the (transparent) nav bar. The padding lambda
+        // below still includes the TopAppBar's height; the empty-state Column
+        // and each TodayPage's scrolling Column add
+        // `windowInsetsPadding(WindowInsets.navigationBars)` themselves so
+        // content stays reachable above the nav bar, and the bottom fade in
+        // `EdgeFadeOverlay` does the same so it sits just above the bar.
+        contentWindowInsets = WindowInsets(0),
         topBar = {
             TopAppBar(
                 title = { Text(stringResource(titleRes)) },
@@ -344,6 +355,13 @@ private fun TodayContent(
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
+                    // Match the nav-bar inset added inside each TodayPage's
+                    // scroll viewport — this branch isn't scrollable, so the
+                    // Fetch-now button has to be padded out of the nav-bar
+                    // zone directly. Without this the button would sit under
+                    // the (translucent) nav bar on devices where banners
+                    // push it down to the bottom of the screen.
+                    .windowInsetsPadding(WindowInsets.navigationBars)
                     .padding(horizontal = 16.dp)
                     .padding(top = 16.dp, bottom = 24.dp),
             ) {
@@ -442,6 +460,11 @@ private fun TodayPage(
             modifier = Modifier
                 .fillMaxSize()
                 .verticalScroll(scrollState)
+                // Nav-bar inset goes here — *inside* the scroll viewport, as
+                // content padding — so the last diagnostic card can scroll
+                // fully above the (translucent) nav bar while the viewport
+                // itself still extends to the screen edge.
+                .windowInsetsPadding(WindowInsets.navigationBars)
                 .padding(horizontal = 16.dp)
                 .padding(top = 16.dp, bottom = 24.dp),
             verticalArrangement = Arrangement.spacedBy(16.dp),


### PR DESCRIPTION
## Summary

`enableEdgeToEdge()` has been enabled in `MainActivity` for a while (with `SystemBarStyle.auto(TRANSPARENT, TRANSPARENT)` on both bars), but the visible result was still "windowed":

- All three Scaffolds (Today + Settings + Onboarding) used the Material 3 default `contentWindowInsets = WindowInsets.safeDrawing`.
- Each content slot consumed that via `.padding(padding)` on an outer Column, pushing everything inside the safe area.

Net effect: the bars were transparent but no content ever extended under them. This PR lands the canonical modern-Android look — scrolling content slides under a translucent nav bar.

## What changes

### `EdgeFadeOverlay` (shared composable)

`EdgeFadeOverlay.kt`'s bottom-fade Box gets `windowInsetsPadding(WindowInsets.navigationBars)` on its modifier chain, between `fillMaxWidth()` and `height(32.dp)`. The 32 dp gradient band now sits in the space just above the translucent nav bar rather than hiding behind it — fade marks the visible-content edge, translucent bar shows the content sliding through. In contexts with no nav-bar inset (Robolectric snapshots), the modifier is a no-op and the fade still sits at the absolute bottom edge. Top fade is unchanged.

### Today (`TodayScreen.kt`)

- Scaffold: `contentWindowInsets = WindowInsets(0)` — the pager extends edge-to-edge.
- `TodayPage`'s scrolling Column gets `windowInsetsPadding(WindowInsets.navigationBars)` **inside** the `verticalScroll` (as content padding). The viewport reaches the screen bottom; the bottom diagnostic card can scroll fully above the nav bar.
- **Empty-state Column** (Codex catch — when `state.thisPeriodInsight == null`, content takes a non-scrollable branch that bypasses `TodayPage`) gets `windowInsetsPadding(WindowInsets.navigationBars)` directly, so the Fetch-now button stays above the nav bar when banners stack up on small devices.

### Settings (`SettingsScreen.kt` + 11 sub-routes)

- Scaffold: same `contentWindowInsets = WindowInsets(0)`.
- Each sub-route's scrolling Column gets `windowInsetsPadding(WindowInsets.navigationBars)` after `verticalScroll(scrollState)`, before the existing inner padding. Mechanical, identical pattern across all 12 files.

Sub-routes touched: `SettingsScreen` (root list) + `SmartHomeSettings`, `DisplaySettings`, `ForecasterSettings`, `ScheduleSettings`, `AboutSettings`, `PrivacySettings`, `CalendarSettings`, `RegionSettings`, `LocationSettings`, `ClothesSettings`, `VoiceSettings`.

Dialog-internal `verticalScroll` instances aren't touched — AlertDialogs sit inside the safe area on their own.

### Onboarding (`OnboardingScreen.kt`)

- Scaffold: `contentWindowInsets = WindowInsets(0)`.
- Inner Column gets the same `windowInsetsPadding(WindowInsets.navigationBars)` after its `verticalScroll`.

### Unchanged

- Status-bar treatment: `TopAppBar`'s container colour paints up under the status bar through the transparent scrim; icon contrast still flipped by `SystemBarStyle.auto(...) { darkTheme }` in `MainActivity.kt:118-127`.
- Top fade: TopAppBar already insets its title; the pager / Settings / onboarding content sits below the bar; the top fade renders inside that content area.

## Rebased onto main

Rebased on top of `73b5a7e3` ("Soft scroll-fade hints on Settings and onboarding too"), which lifted `EdgeFadeOverlay` into its own file and wrapped every Settings/onboarding screen with it. The rebase composes cleanly with that work — the nav-bar inset goes on the inner Column the new commit introduced.

## Snapshots

Robolectric runs without simulated system bars, so `WindowInsets.navigationBars` resolves to zero in tests and the existing PNGs are byte-identical. No regen needed.

## Privacy

No change. Layout-only.

## Test plan

- [x] `./gradlew :app:compileDebugKotlin` clean.
- [x] `./gradlew :core:domain:test :core:data:test :app:testDebugUnitTest` green; zero PNG diffs.
- [x] `./gradlew :app:assembleDebug` succeeds.
- [ ] CI green (both jobs).
- [ ] Manual / visual on running APK:
  - Today, gesture nav: content slides under translucent nav bar; bottom fade sits just above the bar; last diagnostic card reachable above the bar.
  - Today, button (3-button) nav: same with the thicker inset.
  - Today, empty state (clear cache): Fetch-now button stays above the nav bar.
  - Today, status bar: TopAppBar colour tints status bar zone; icon contrast flips with theme.
  - Settings: each sub-screen's last item scrolls fully above the nav bar.
  - Onboarding: bottom of content reachable above the nav bar.
  - Drag gestures through the fade region still scroll content.