### PR TITLE
Remove the white line at the top of the navigation bar

### DIFF
--- a/app/src/main/kotlin/app/clothescast/MainActivity.kt
+++ b/app/src/main/kotlin/app/clothescast/MainActivity.kt
@@ -125,6 +125,17 @@ class MainActivity : ComponentActivity() {
                             android.graphics.Color.TRANSPARENT,
                         ) { darkTheme },
                     )
+                    // enableEdgeToEdge with SystemBarStyle.auto leaves
+                    // isNavigationBarContrastEnforced = true (the AUTO night-mode
+                    // path), so the system overlays its own translucent scrim
+                    // across the nav-bar area "for contrast." With gesture nav
+                    // the inset is only ~16-24 dp tall, so the top edge of that
+                    // scrim reads as a sharp horizontal line on top of our
+                    // content — especially against the scroll-fade gradient that
+                    // lands at the same vertical position. The app already paints
+                    // its own uniform background through that band, so the system
+                    // scrim is both unnecessary and visually jarring.
+                    window.isNavigationBarContrastEnforced = false
                     onDispose {}
                 }
                 ClothesCastTheme(darkTheme = darkTheme, colorPalette = colorPalette) {

--- a/app/src/main/kotlin/app/clothescast/ui/EdgeFadeOverlay.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/EdgeFadeOverlay.kt
@@ -51,6 +51,12 @@ internal fun EdgeFadeOverlay(
         targetValue = if (bottomFadeVisible) 1f else 0f,
         label = "bottomFade",
     )
+    // Color.Transparent is fully transparent *black*, so a linear gradient
+    // between it and the (light) background colour passes through a darker
+    // mid-tone — a faint band the eye picks up where it crosses the cards.
+    // Keep RGB constant through the gradient by fading the same colour's
+    // alpha instead.
+    val transparentColor = color.copy(alpha = 0f)
     Box(modifier = modifier.fillMaxSize()) {
         content()
         Box(
@@ -61,7 +67,7 @@ internal fun EdgeFadeOverlay(
                 .alpha(topAlpha)
                 .background(
                     Brush.verticalGradient(
-                        colors = listOf(color, Color.Transparent),
+                        colors = listOf(color, transparentColor),
                     ),
                 ),
         )
@@ -83,7 +89,7 @@ internal fun EdgeFadeOverlay(
                 .alpha(bottomAlpha)
                 .background(
                     Brush.verticalGradient(
-                        colors = listOf(Color.Transparent, color),
+                        colors = listOf(transparentColor, color),
                     ),
                 ),
         )


### PR DESCRIPTION
## Summary

Fixes the jarring horizontal line that shows up on top of content right at the top of the system navigation area, especially with gesture navigation.

Two contributing factors, both addressed:

1. **System-drawn nav-bar contrast scrim** (the primary cause). `enableEdgeToEdge(SystemBarStyle.auto(...))` leaves `Window.isNavigationBarContrastEnforced = true` on API 29+ (the AUTO night-mode path takes that branch), so even though we pass `Color.TRANSPARENT` scrims, the system overlays its own translucent scrim across the nav-bar area "for contrast." With gesture nav the inset is only ~16-24 dp tall, so the top edge of that scrim reads as a sharp horizontal line on top of our content — and it lines up with the bottom of the `EdgeFadeOverlay` gradient, compounding the effect. The app already paints its own uniform background through the nav-bar band, so the system scrim is unnecessary; disable it explicitly.

2. **Scroll-fade gradient interpolation.** `Color.Transparent` is fully transparent *black*, so a linear gradient between it and the (light) background colour passes through a darker mid-tone — a faint band the eye picks up where the fade crosses the cards. Fade the same colour's alpha instead (`color.copy(alpha = 0f)`) so the RGB stays constant across the gradient.

## Test plan

- [x] `:app:testDebugUnitTest` passes
- [x] `:app:assembleDebug` succeeds, no new compiler warnings
- [ ] Visually verify on a device with gesture navigation that the line above the gesture pill is gone
- [ ] Visually verify on a device with 3-button navigation that the nav bar still has enough contrast against light backgrounds
- [ ] Verify dark mode also looks clean

## Privacy

No off-device data is added or changed.

---
_Generated by [Claude Code](https://claude.ai/code/session_019tfet22jVFynzQ2x4XLrdG)_