### PR TITLE
Extend the scroll-fade gradient through the nav-bar inset

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/EdgeFadeOverlay.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/EdgeFadeOverlay.kt
@@ -5,11 +5,11 @@ import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBars
-import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -71,25 +71,34 @@ internal fun EdgeFadeOverlay(
                     ),
                 ),
         )
+        // Bottom fade: a 32 dp gradient in the content area, *continued* as a
+        // solid band of [color] through the nav-bar inset down to the screen
+        // edge. The fade marks the visible-content edge (transparent → opaque
+        // across 32 dp just above the nav bar), and the solid extension keeps
+        // any scrollable content that's been clipped at the viewport bottom
+        // from bleeding through behind the translucent nav bar — without it,
+        // the boundary where the gradient stops and the unfaded card surface
+        // resumes reads as a hard horizontal line right at the top of the nav
+        // area. In contexts with no nav-bar inset (e.g. Robolectric snapshots),
+        // the extension collapses to zero height and the fade behaves the same
+        // as a plain 32 dp gradient anchored to the bottom edge.
+        val navBarBottom = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
+        val fadeHeight = 32.dp
+        val totalHeight = fadeHeight + navBarBottom
+        val fadeFraction = if (navBarBottom > 0.dp) fadeHeight.value / totalHeight.value else 1f
         Box(
             modifier = Modifier
                 .align(Alignment.BottomCenter)
                 .fillMaxWidth()
-                // The nav-bar inset wraps the 32 dp fade — outer height is
-                // (32 dp + nav-bar height), aligned to the screen bottom by
-                // `align(BottomCenter)`, with the painted gradient occupying
-                // the inner 32 dp at the *top* of that outer box. Net: the
-                // fade sits in the band just above the translucent nav bar,
-                // so it marks the visible-content edge rather than hiding
-                // behind the bar. In contexts with no nav-bar inset (e.g.
-                // Robolectric snapshots), this is a no-op and the fade still
-                // sits at the absolute bottom edge.
-                .windowInsetsPadding(WindowInsets.navigationBars)
-                .height(32.dp)
+                .height(totalHeight)
                 .alpha(bottomAlpha)
                 .background(
                     Brush.verticalGradient(
-                        colors = listOf(transparentColor, color),
+                        colorStops = arrayOf(
+                            0f to transparentColor,
+                            fadeFraction to color,
+                            1f to color,
+                        ),
                     ),
                 ),
         )


### PR DESCRIPTION
## Summary

Follow-up to #539. That PR removed the system contrast scrim (helped, but didn't fully fix the line). The remaining "white line at the top of the nav area" was actually our own scroll-fade overlay's geometry — independent of the system scrim, which is why it showed up in both gesture and 3-button nav.

**Root cause.** `EdgeFadeOverlay`'s bottom fade used `windowInsetsPadding(navigationBars)` to sit above the translucent nav bar, with no overlay in the nav-bar area itself. That works when the user is scrolled to the very bottom of the column (the 24 dp + nav-bar bottom padding is empty there, so the inset area is just page background). But at any intermediate scroll position — e.g. the chart card visible at the bottom of the viewport with more cards clipped below — the unfaded card surface bleeds through the inset area behind the translucent nav bar. The boundary where the gradient hits fully opaque page-background (at the top of the inset) and the card surface picks up again right below reads as a hard horizontal line on top of our content. Especially obvious with gesture nav where the inset is only ~16–24 dp tall and the seam sits right up against the cards.

**Fix.** Make the bottom overlay one box that's `(32 dp + nav-bar height)` tall, with a 3-stop gradient: transparent at the top, opaque after 32 dp, opaque all the way to the screen edge. The first 32 dp still does the same fade-out hint as before; the remainder paints solid page-background, so the nav-bar inset area no longer reveals whatever card was clipped behind it.

## Test plan

- [x] `:app:testDebugUnitTest` passes
- [ ] Visually verify on a device with gesture navigation that the line is gone at any scroll position
- [ ] Visually verify on a device with 3-button navigation that the line is gone
- [ ] Verify dark mode also looks clean (the solid extension uses `MaterialTheme.colorScheme.background`)
- [ ] Verify Roborazzi snapshots still render correctly — the `if (navBarBottom > 0.dp)` branch should make the fade behave identically to the previous 32 dp gradient when no inset is present

---
_Generated by [Claude Code](https://claude.ai/code/session_019tfet22jVFynzQ2x4XLrdG)_