### PR TITLE
Stop Croatia Statehood Day shadowing US Memorial Day on May 30

### DIFF
--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/HolidayTheme.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/HolidayTheme.kt
@@ -30,8 +30,8 @@ enum class HolidayId {
     ANZAC_DAY,
     MOTHERS_DAY,
     JAPAN_GREENERY_DAY,
-    CROATIA_STATEHOOD_DAY,
     US_MEMORIAL_DAY,
+    CROATIA_STATEHOOD_DAY,
     ITALY_REPUBLIC_DAY,
     KOREAN_MEMORIAL_DAY,
     JUNETEENTH,
@@ -385,6 +385,27 @@ object HolidayCatalog {
             bannerArgb = GREENERY_GREEN,
         ),
 
+        // Last Monday of May — US Memorial Day. Solemn monochrome khaki,
+        // same shape as Anzac. Different from US Veterans Day (Nov 11),
+        // which is the Remembrance Day banner with a US country override.
+        //
+        // Listed before Croatia Statehood Day (May 30, fixed) on purpose:
+        // in years where the last Mon of May *is* May 30 (2033, 2039,
+        // 2044, …), both predicates match and the resolver's first-match
+        // rule would otherwise let Croatia shadow Memorial Day under
+        // allOn — a regression flagged in code review for the merged
+        // 16-holiday addition. Memorial Day is the more globally-
+        // recognised holiday for the app's audience, so it wins the tie.
+        HolidayDate.LastWeekday(Month.MAY, DayOfWeek.MONDAY) to HolidayTheme(
+            id = HolidayId.US_MEMORIAL_DAY,
+            displayNameKey = "holiday_name_us_memorial_day",
+            bannerTextKey = "holiday_banner_us_memorial_day",
+            emoji = "🔺", // 🔺 — match Anzac / Remembrance for visual continuity
+            topOverrides = topPaletteAll(ANZAC_KHAKI),
+            bottomOverrides = bottomPaletteAll(ANZAC_KHAKI),
+            bannerArgb = ANZAC_KHAKI,
+        ),
+
         // May 30 — Croatia Statehood Day. True flag tricolour
         // (red/white/blue, top-middle-bottom). Same option-3 stroke pattern
         // as US July 4 / Bastille: red tops + blue bottoms with white as
@@ -399,19 +420,6 @@ object HolidayCatalog {
             topStrokeOverrides = topStrokeAll(CROATIA_WHITE),
             bottomStrokeOverrides = bottomStrokeAll(CROATIA_WHITE),
             bannerArgb = CROATIA_RED,
-        ),
-
-        // Last Monday of May — US Memorial Day. Solemn monochrome khaki,
-        // same shape as Anzac. Different from US Veterans Day (Nov 11),
-        // which is the Remembrance Day banner with a US country override.
-        HolidayDate.LastWeekday(Month.MAY, DayOfWeek.MONDAY) to HolidayTheme(
-            id = HolidayId.US_MEMORIAL_DAY,
-            displayNameKey = "holiday_name_us_memorial_day",
-            bannerTextKey = "holiday_banner_us_memorial_day",
-            emoji = "🔺", // 🔺 — match Anzac / Remembrance for visual continuity
-            topOverrides = topPaletteAll(ANZAC_KHAKI),
-            bottomOverrides = bottomPaletteAll(ANZAC_KHAKI),
-            bannerArgb = ANZAC_KHAKI,
         ),
 
         // Jun 2 — Italian Republic Day. Green tops + red bottoms with the

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/HolidayResolverTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/HolidayResolverTest.kt
@@ -61,6 +61,23 @@ class HolidayResolverTest {
     }
 
     @Test
+    fun `US Memorial Day wins over Croatia Statehood Day when May 30 is a Monday`() {
+        // 2033-05-30 is a Monday → it's both the last Mon of May (US
+        // Memorial Day) AND Croatia Statehood Day (May 30 fixed). Catalog
+        // order puts Memorial Day first so the more universally-recognised
+        // US holiday doesn't get silently shadowed under allOn — see the
+        // collision note in HolidayTheme.kt's catalog block.
+        val d = LocalDate.of(2033, 5, 30)
+        d.dayOfWeek shouldBe DayOfWeek.MONDAY
+        subject.resolve(d, allOn)?.id shouldBe HolidayId.US_MEMORIAL_DAY
+        // Croatia Statehood Day still fires for a Croatian user with
+        // Memorial Day disabled — the predicate works, it's just the
+        // ordering that decides ties.
+        subject.resolve(d, setOf(HolidayId.CROATIA_STATEHOOD_DAY))?.id shouldBe
+            HolidayId.CROATIA_STATEHOOD_DAY
+    }
+
+    @Test
     fun `Korean Memorial Day matches Jun 6`() {
         subject.resolve(LocalDate.of(2026, 6, 6), allOn)?.id shouldBe HolidayId.KOREAN_MEMORIAL_DAY
     }


### PR DESCRIPTION
## Summary

Follow-up to PR #545. Codex flagged a real but rare collision in the freshly-merged catalog: in years where the last Monday of May falls on May 30 (2033, 2039, 2044, 2050, …), both US Memorial Day (last Mon May) and Croatia Statehood Day (fixed May 30) match, and Croatia silently won under `allOn` because it was earlier in the catalog.

Memorial Day is the more universally-recognised holiday for the app's audience, so swap the two in catalog (and enum) order. Croatian users with Memorial Day disabled still see Croatia Statehood Day in those years.

Adds a regression test pinning the 2033-05-30 case both ways: under `allOn` the resolver picks Memorial Day; with only Croatia enabled it picks Croatia.

## Test plan

- [x] `:core:domain:test` passes — new test covers the collision
- [ ] CI green

https://claude.ai/code/session_01Tu7VWfBp56GgEgY52pqEYm

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tu7VWfBp56GgEgY52pqEYm)_