### PR TITLE
Refresh button now works in the evening even with tonight off

### DIFF
--- a/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
@@ -147,16 +147,32 @@ class FetchAndNotifyWorker(
             ?.let { runCatching { ForecastPeriod.valueOf(it) }.getOrNull() }
             ?: ForecastPeriod.TODAY
 
+        // Honour force-refresh only when it's still the day the user tapped on. If
+        // the request was enqueued near midnight and only ran after the date rolled
+        // over (offline retries, deferred backoff), the *new* day's cache should
+        // win — otherwise we'd silently bypass it and burn an extra Gemini call on
+        // a stale tap. The tonight gate below also keys off this same-day check so
+        // a stale tap from yesterday can't bypass a tonight-disabled toggle either.
+        val today = LocalDate.now()
+        val requestedEpochDay = inputData.getLong(KEY_REQUESTED_EPOCH_DAY, Long.MIN_VALUE)
+        val isUserForcedRefresh = inputData.getBoolean(KEY_FORCE_REFRESH, false)
+        val forceRefresh = isUserForcedRefresh && requestedEpochDay == today.toEpochDay()
+        if (isUserForcedRefresh && !forceRefresh) {
+            DiagLog.i(TAG, "Ignoring force refresh from a previous day (requested=$requestedEpochDay, today=${today.toEpochDay()}).")
+        }
+
         // The tonight alarm rearms blindly via AlarmReceiver; the user's enable
         // toggle is honoured here so a stale alarm doesn't ship a tonight insight
-        // after the user disabled the feature.
-        if (period == ForecastPeriod.TONIGHT && !prefs.tonightEnabled) {
+        // after the user disabled the feature. Same-day manual Refresh taps from
+        // the Today screen bypass this gate — a user inside the tonight window
+        // who taps Refresh wants fresh data regardless of whether the scheduled
+        // tonight notification is on, otherwise the screen sits on stale morning
+        // insights all evening with no way to update them. A force-refresh that
+        // crossed midnight loses its bypass: by then the user's "evening tap"
+        // intent is stale, and delivering a tonight insight after midnight with
+        // tonight disabled is exactly the surprise the gate exists to prevent.
+        if (period == ForecastPeriod.TONIGHT && !prefs.tonightEnabled && !forceRefresh) {
             DiagLog.i(TAG, "Tonight insight is disabled; skipping.")
-            // Stamp KEY_SKIP_TELEMETRY so the daily_refresh outcome event
-            // doesn't count this as a success. TodayScreen.triggerRefresh
-            // enqueues a TONIGHT run purely on the clock, so any user who
-            // turned the feature off would otherwise show a steady stream
-            // of "successful" tonight refreshes that delivered nothing.
             return Result.success(workDataOf(KEY_SKIP_TELEMETRY to true))
         }
 
@@ -200,19 +216,6 @@ class FetchAndNotifyWorker(
                 DiagLog.w(TAG, "No location available; failing run.")
                 return Result.failure(reason(REASON_NO_LOCATION))
             }
-        val today = LocalDate.now()
-
-        // Honour force-refresh only when it's still the day the user tapped on. If
-        // the request was enqueued near midnight and only ran after the date rolled
-        // over (offline retries, deferred backoff), the *new* day's cache should
-        // win — otherwise we'd silently bypass it and burn an extra Gemini call on
-        // a stale tap.
-        val requestedEpochDay = inputData.getLong(KEY_REQUESTED_EPOCH_DAY, Long.MIN_VALUE)
-        val forceRequested = inputData.getBoolean(KEY_FORCE_REFRESH, false)
-        val forceRefresh = forceRequested && requestedEpochDay == today.toEpochDay()
-        if (forceRequested && !forceRefresh) {
-            DiagLog.i(TAG, "Ignoring force refresh from a previous day (requested=$requestedEpochDay, today=${today.toEpochDay()}).")
-        }
 
         // 24h cost cap: if we already generated an insight for today, redeliver it
         // rather than refetching. Same path serves the morning alarm and any


### PR DESCRIPTION
## Summary

A manual Refresh tap from the Today screen enqueues a force-refresh, with the period derived from wall-clock time (`triggerRefresh` in `TodayScreen.kt:2242-2270`): any tap inside the user's tonight window — default 7pm–7am — asks for `ForecastPeriod.TONIGHT`.

The worker's `tonightEnabled` gate was bouncing those force-refresh runs as silent no-ops alongside the alarm-driven runs it was meant to catch. Per the bug report: a user with "Tonight" disabled (or who never armed it) couldn't update the Today screen at all in the evening — the pager kept showing the 6am morning insight until the next 7am alarm rolled around.

This PR restricts the gate to non-force runs. To keep the gate honest, the same-day validity check (`requestedEpochDay == today.toEpochDay()`) is hoisted above the gate so a stale force-refresh that crossed midnight (offline retries, deferred backoff) loses its bypass — at that point the user's "evening tap" intent is stale and we shouldn't be delivering a tonight insight at 00:30 to a user with tonight disabled.

`AlarmReceiver` already has its own `tonightEnabled` check at line 58, so this worker gate is now belt-and-braces for stale OS-scheduled alarms.

## Behaviour matrix

| Trigger | tonightEnabled | Before | After |
|---|---|---|---|
| 7pm scheduled alarm | true | fetches | fetches |
| 7pm scheduled alarm | false | gated (correct) | gated (correct) |
| Manual Refresh tap at 8pm | true | fetches | fetches |
| **Manual Refresh tap at 8pm** | **false** | **silent no-op** | **fetches** |
| Stale force-refresh crossing midnight | false | (would have bypassed gate with v1) | gated (correct) |

## Privacy

No change. Same Open-Meteo + (optional) Gemini calls; no new fields cross the device boundary.

## Test plan

- [x] `./gradlew :app:compileDebugKotlin` — compiles
- [x] `./gradlew :core:domain:test :core:data:test :app:testDebugUnitTest` — all green
- [ ] On device: with `Tonight enabled: false`, open app at 8pm, tap Refresh, verify the pager updates to show "Tonight" as current period and "Tomorrow" as next period (instead of stale "Today"/"Tonight").
- [ ] Verify scheduled 7am alarm still fires for the morning slot (untouched).
- [ ] Verify scheduled 7pm alarm stays gated when `Tonight enabled: false` (untouched — `AlarmReceiver` handles it).

https://claude.ai/code/session_01XSq6bNvXYxdzzNdTmvzmXt