### PR TITLE
Tomorrow card now ignores hours outside your scheduled times

### DIFF
--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsight.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsight.kt
@@ -220,9 +220,18 @@ class GenerateDailyInsight(
         // extra API call. Null when the underlying data isn't there (e.g.
         // evening insight on a legacy bundle without tomorrow's daily
         // aggregates) — the screen falls back to a single card.
+        //
+        // Slice tomorrow to the user's daytime window so the "Why this
+        // outfit?" rationale (and the outfit picker) cite an in-window
+        // hour — otherwise a pre-dawn 06:00 trough drives "Feels-like low
+        // 5.8°C at 06:00" on the Tomorrow card for a user who won't be
+        // outside until 07:00.
         val nextForecast = when (period) {
             ForecastPeriod.TODAY -> tonightForecast.takeIf { it.hourly.isNotEmpty() }
-            ForecastPeriod.TONIGHT -> bundle.tomorrow
+            ForecastPeriod.TONIGHT -> bundle.tomorrow?.slicedForToday(
+                morningStart = morningStart,
+                eveningEnd = tonightStart,
+            )
         }
         val triggeredRules = evaluateClothesRules(periodForecast, prefs.clothesRules)
         val perModelForRender = bundle.perModelHourly?.slicedTo(

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsightTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsightTest.kt
@@ -1128,6 +1128,48 @@ class GenerateDailyInsightTest {
     }
 
     @Test
+    fun `tonight period slices tomorrow to the user's daytime window for nextOutfit and rationale`() = runTest {
+        // Regression: a pre-dawn 06:00 trough was leaking into the
+        // "Tomorrow" card's "Why this outfit?" rationale ("Feels-like
+        // low 5.8°C at 06:00") even though the user's schedule kept
+        // them indoors until 07:00. The unsliced tomorrow forecast
+        // also let that 06:00 low drive a heavier outfit pick than
+        // the user's actual daytime experience.
+        val tomorrowHourly = listOf(
+            // Pre-dawn trough — must be excluded by the daytime slice.
+            HourlyForecast(LocalTime.of(6, 0), 6.0, 5.8, 0.0, WeatherCondition.CLEAR),
+            // In-window hours stay above the jacket cutoff (12°C).
+            HourlyForecast(LocalTime.of(9, 0), 14.0, 13.0, 0.0, WeatherCondition.CLEAR),
+            HourlyForecast(LocalTime.of(15, 0), 22.0, 21.0, 0.0, WeatherCondition.CLEAR),
+        )
+        val tomorrow = DailyForecast(
+            date = LocalDate.of(2026, 4, 26),
+            temperatureMinC = 6.0,
+            temperatureMaxC = 22.0,
+            feelsLikeMinC = 5.8,
+            feelsLikeMaxC = 21.0,
+            precipitationProbabilityMaxPct = 0.0,
+            precipitationMmTotal = 0.0,
+            condition = WeatherCondition.CLEAR,
+            hourly = tomorrowHourly,
+        )
+        val weather = FakeWeatherRepository(
+            ForecastBundle(today, yesterday, tomorrow = tomorrow),
+        )
+        val subject = GenerateDailyInsight(weather, clock = clock)
+
+        val result = subject(london, prefs, ForecastPeriod.TONIGHT)
+
+        // In-window min is 13°C at 09:00, not 5.8°C at 06:00 — so the
+        // jacket rule (12°C) doesn't fire and the rationale cites the
+        // 09:00 hour.
+        val topFact = result.insight.nextOutfitRationale!!.top.facts.single()
+        topFact.observedAt shouldBe LocalTime.of(9, 0)
+        topFact.observedC shouldBe 13.0
+        result.insight.nextOutfit!!.top shouldBe OutfitSuggestion.Top.SWEATER
+    }
+
+    @Test
     fun `tonight period leaves nextOutfit null when tomorrow daily is unavailable`() = runTest {
         val weather = FakeWeatherRepository(ForecastBundle(today, yesterday))
         val subject = GenerateDailyInsight(weather, clock = clock)


### PR DESCRIPTION
## Summary

The "Why this outfit?" sheet on the Tomorrow card was citing the
coldest hour of tomorrow's full 24h, so a 06:00 trough surfaced as
"Feels-like low 5.8°C at 06:00" for a user whose morning notif time
kept them indoors until 07:00. The outfit pick itself ran against
the same unsliced tomorrow forecast and could be driven to a heavier
garment by hours the user wouldn't actually experience.

Fix: slice `bundle.tomorrow` with the user's daytime window
(`morningStart` → `tonightStart`) in `GenerateDailyInsight.buildPeriodView`
before computing the next-period outfit and rationale, mirroring how
today's daytime is already windowed for the morning insight via
`slicedForToday`. Tomorrow's pre-dawn and post-bedtime hours fall
out of the min/max aggregates and out of the rationale's coldest /
warmest hour citation.

## Why TODAY worked but TONIGHT didn't

In `buildPeriodView`, the morning insight already routed its next
forecast (tonight's preview) through `slicedForTonight`. The evening
insight's branch handed `bundle.tomorrow` through unmodified — the
single line that this PR fixes.

## Test plan

- [x] Added `tonight period slices tomorrow to the user's daytime
  window for nextOutfit and rationale` — asserts a pre-dawn 06:00
  hour at 5.8°C is excluded; the rationale cites the in-window 09:00
  / 13°C hour and the jacket rule (12°C) no longer fires.
- [x] `./gradlew :core:domain:test :core:data:test :app:testDebugUnitTest`
  all green.
- [x] `./gradlew :app:assembleDebug` green.

## Privacy

No change to what leaves the device — pure rendering logic over data
already in hand.


---
_Generated by [Claude Code](https://claude.ai/code/session_016SiXNCG7gxrSFZAp8TuKfH)_