### PR TITLE
Sort holidays by date within each Settings group

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/settings/HolidaySettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/HolidaySettings.kt
@@ -44,6 +44,7 @@ import app.clothescast.core.domain.model.HolidayOverride
 import app.clothescast.core.domain.model.HolidayTheme
 import app.clothescast.ui.EdgeFadeOverlay
 import java.text.Collator
+import java.time.LocalDate
 import java.util.Locale
 
 /**
@@ -88,10 +89,25 @@ internal fun HolidaysContent(
         context.resources.configuration.locales.get(0) ?: Locale.getDefault()
     }
 
+    // Sort holidays chronologically within each bucket. Movable holidays
+    // (NthWeekday / LastWeekday) are materialised against [sortYear] —
+    // today's year — and the comparator reads only (month, dayOfMonth)
+    // so the relative ordering is effectively year-agnostic. We re-derive
+    // when the year ticks over (a midnight-on-Dec-31 edge case in
+    // practice, but cheap to key on).
+    val sortYear = remember { LocalDate.now().year }
+    val sortedCatalog = remember(sortYear) {
+        HolidayCatalog.all.sortedWith(
+            compareBy(
+                { (date, _) -> date.dateIn(sortYear).monthValue },
+                { (date, _) -> date.dateIn(sortYear).dayOfMonth },
+            ),
+        )
+    }
     // Globals (countries = {GLOBAL_COUNTRY}) live in their own collapsible
     // above the ISO list, no longer folded into every country's bucket.
-    val globalThemes = remember {
-        HolidayCatalog.all
+    val globalThemes = remember(sortedCatalog) {
+        sortedCatalog
             .map { it.second }
             .filter { HolidayCatalog.GLOBAL_COUNTRY in it.countries }
     }
@@ -100,15 +116,15 @@ internal fun HolidaysContent(
             .filter { it != HolidayCatalog.GLOBAL_COUNTRY }
             .sortedForDisplay(context, uiLocale)
     }
-    val themesByCountry = remember {
+    val themesByCountry = remember(sortedCatalog) {
         isoCountries.associateWith { code ->
-            HolidayCatalog.all
+            sortedCatalog
                 .map { it.second }
                 .filter { code in it.countries }
         }
     }
-    val allThemes = remember {
-        HolidayCatalog.all.map { it.second }
+    val allThemes = remember(sortedCatalog) {
+        sortedCatalog.map { it.second }
     }
 
     EdgeFadeOverlay(

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/HolidayTheme.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/HolidayTheme.kt
@@ -91,9 +91,24 @@ enum class HolidayId {
 sealed interface HolidayDate {
     fun matches(date: LocalDate): Boolean
 
+    /**
+     * Materialises the predicate into the actual [LocalDate] the holiday
+     * falls on in [year]. Used by the Settings UI to sort entries within
+     * each country bucket chronologically; the caller picks a
+     * representative year (typically the current one) and the sort
+     * comparison reads only month + day, so the relative ordering is
+     * effectively year-agnostic for the vast majority of catalog
+     * entries (movable holidays that straddle a neighbouring fixed
+     * date are the only edge cases, and they're still locally
+     * coherent).
+     */
+    fun dateIn(year: Int): LocalDate
+
     data class Fixed(val month: Month, val day: Int) : HolidayDate {
         override fun matches(date: LocalDate): Boolean =
             date.month == month && date.dayOfMonth == day
+
+        override fun dateIn(year: Int): LocalDate = LocalDate.of(year, month, day)
     }
 
     /**
@@ -106,6 +121,12 @@ sealed interface HolidayDate {
             // 1st of the month's day-of-month is 1..7; 2nd is 8..14; etc.
             // Equivalent to: ((dayOfMonth - 1) / 7) + 1 == nth.
             return (date.dayOfMonth - 1) / 7 + 1 == nth
+        }
+
+        override fun dateIn(year: Int): LocalDate {
+            val first = LocalDate.of(year, month, 1)
+            val shift = (day.value - first.dayOfWeek.value + 7) % 7
+            return first.plusDays(shift.toLong() + (nth - 1) * 7L)
         }
     }
 
@@ -122,6 +143,13 @@ sealed interface HolidayDate {
             // crosses into the next month — i.e. there's no further
             // occurrence of the same weekday inside [month].
             return date.plusDays(7).month != month
+        }
+
+        override fun dateIn(year: Int): LocalDate {
+            val lastOfMonth = LocalDate.of(year, month, 1)
+                .with(java.time.temporal.TemporalAdjusters.lastDayOfMonth())
+            val shiftBack = (lastOfMonth.dayOfWeek.value - day.value + 7) % 7
+            return lastOfMonth.minusDays(shiftBack.toLong())
         }
     }
 }

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/model/HolidayThemeTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/model/HolidayThemeTest.kt
@@ -1,6 +1,9 @@
 package app.clothescast.core.domain.model
 
 import io.kotest.matchers.shouldBe
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.Month
 import org.junit.jupiter.api.Test
 
 class HolidayThemeTest {
@@ -54,5 +57,36 @@ class HolidayThemeTest {
             ?: error("CHRISTMAS_DAY missing from catalog")
         theme.bannerTextKeyFor("US") shouldBe "holiday_banner_christmas_day"
         theme.bannerTextKeyFor("GB") shouldBe "holiday_banner_christmas_day"
+    }
+
+    @Test
+    fun `dateIn materialises Fixed at month and day`() {
+        HolidayDate.Fixed(Month.JULY, 4).dateIn(2026) shouldBe LocalDate.of(2026, 7, 4)
+        HolidayDate.Fixed(Month.DECEMBER, 25).dateIn(2027) shouldBe LocalDate.of(2027, 12, 25)
+    }
+
+    @Test
+    fun `dateIn materialises NthWeekday correctly`() {
+        // 2026 — May 10 is 2nd Sunday (May 3 is 1st), Nov 26 is 4th Thursday.
+        HolidayDate.NthWeekday(Month.MAY, 2, DayOfWeek.SUNDAY).dateIn(2026) shouldBe
+            LocalDate.of(2026, 5, 10)
+        HolidayDate.NthWeekday(Month.NOVEMBER, 4, DayOfWeek.THURSDAY).dateIn(2026) shouldBe
+            LocalDate.of(2026, 11, 26)
+        // First-of-month edge: when month starts on the target weekday, nth=1 IS day 1.
+        HolidayDate.NthWeekday(Month.NOVEMBER, 1, DayOfWeek.SUNDAY).dateIn(2026) shouldBe
+            LocalDate.of(2026, 11, 1)
+    }
+
+    @Test
+    fun `dateIn materialises LastWeekday correctly`() {
+        // 2026 — May 25 (Mon) is the last Monday of May; Feb 28 (Sat) the last
+        // Saturday of February in a non-leap year.
+        HolidayDate.LastWeekday(Month.MAY, DayOfWeek.MONDAY).dateIn(2026) shouldBe
+            LocalDate.of(2026, 5, 25)
+        HolidayDate.LastWeekday(Month.FEBRUARY, DayOfWeek.SATURDAY).dateIn(2026) shouldBe
+            LocalDate.of(2026, 2, 28)
+        // 2024 was a leap year — Feb 29 was a Thursday, so the last Thursday is the 29th.
+        HolidayDate.LastWeekday(Month.FEBRUARY, DayOfWeek.THURSDAY).dateIn(2024) shouldBe
+            LocalDate.of(2024, 2, 29)
     }
 }


### PR DESCRIPTION
## Summary

Each country's expandable in Settings → Holidays — plus the new
Global section — now lists its holidays in calendar order (Jan →
Dec). Previously they followed `HolidayCatalog.all`'s declared
ordering, which is *approximately* calendar order but slips on the
handful of movable-date holidays whose materialised position
sometimes lands ahead of or behind a neighbouring fixed-date entry
in the source list.

- New `HolidayDate.dateIn(year: Int): LocalDate` materialises Fixed
  / NthWeekday / LastWeekday predicates into the actual `LocalDate`
  for the given year. Pure-Kotlin and JVM-testable; lives in
  `:core:domain` alongside the existing `matches()` half of the
  predicate API.
- `HolidaysContent` sorts the catalog once per composition (keyed
  on the year so a midnight-on-Dec-31 tick refreshes) using
  `LocalDate.now().year` to anchor the movable predicates. The
  comparator reads only `monthValue` and `dayOfMonth`, so the year
  itself never enters the comparison.

## Test plan

- [x] `cd core && ../gradlew :core:domain:test` — green, including
      new coverage for `dateIn` across Fixed / NthWeekday /
      LastWeekday and a leap-year Feb edge case
- [x] `./gradlew :app:testDebugUnitTest` — green (snapshot
      unchanged: the preview keeps all sections collapsed, so the
      sort is invisible at the snapshot layer)
- [x] `./gradlew :app:assembleDebug` — green
- [ ] Manual: open Settings → Holidays, expand the Global section
      and a few country sections, verify Jan → Dec ordering (NY → V-
      Day → Halloween → Christmas for Global; Australia Day → Anzac
      → Mother's Day → Father's Day → Remembrance for Australia)

## Privacy

Local-only sort; no off-device payload change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WhtoSS66ZnEbSpQU7KcMiR)_