### PR TITLE
Add holiday translations for Japanese, Korean, and Chinese locales

### DIFF
--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -784,4 +784,100 @@ the displayed label localizes.
     <string name="settings_forecasters_jma_subtitle">日本（気象庁）— アジア・太平洋に強い。オープンフィードでは3〜6時間ごと。</string>
     <string name="settings_forecasters_bom">BOM</string>
     <string name="settings_forecasters_bom_subtitle">オーストラリア — メンテナンス中。できるだけ早く復旧する予定です。</string>
+
+    <!-- Settings root — Holidays row and subtitle. -->
+    <string name="settings_root_holidays">祝日</string>
+    <string name="settings_root_holidays_subtitle">テーマカラーとバナー</string>
+
+    <!--
+    Holidays sub-page — page title, country picker controls,
+    expand/collapse toggles, and per-holiday override states.
+    -->
+    <string name="settings_holidays_title">祝日</string>
+    <string name="settings_holiday_country_home">ホーム（%1$s）</string>
+    <string name="settings_holiday_country_current">現在地（%1$s）</string>
+    <string name="settings_holiday_country_unknown">不明</string>
+    <string name="settings_holiday_country_global_label">グローバル</string>
+    <string name="settings_holiday_country_all_label">すべて</string>
+    <string name="settings_holiday_all_section_title">すべて</string>
+    <string name="settings_holidays_expand">展開</string>
+    <string name="settings_holidays_collapse">折りたたむ</string>
+    <string name="settings_holiday_override_auto_on">自動（オン）</string>
+    <string name="settings_holiday_override_auto_off">自動（オフ）</string>
+    <string name="settings_holiday_override_on">オン</string>
+    <string name="settings_holiday_override_off">オフ</string>
+
+    <!-- Country names for the holiday country picker. -->
+    <string name="settings_holiday_country_at">オーストリア</string>
+    <string name="settings_holiday_country_au">オーストラリア</string>
+    <string name="settings_holiday_country_br">ブラジル</string>
+    <string name="settings_holiday_country_ca">カナダ</string>
+    <string name="settings_holiday_country_de">ドイツ</string>
+    <string name="settings_holiday_country_es">スペイン</string>
+    <string name="settings_holiday_country_fr">フランス</string>
+    <string name="settings_holiday_country_gb">イギリス</string>
+    <string name="settings_holiday_country_hr">クロアチア</string>
+    <string name="settings_holiday_country_ie">アイルランド</string>
+    <string name="settings_holiday_country_it">イタリア</string>
+    <string name="settings_holiday_country_jp">日本</string>
+    <string name="settings_holiday_country_kr">韓国</string>
+    <string name="settings_holiday_country_nz">ニュージーランド</string>
+    <string name="settings_holiday_country_us">アメリカ</string>
+
+    <!-- Holiday display names (shown in Settings → Holidays list). -->
+    <string name="holiday_name_new_years_day">元日</string>
+    <string name="holiday_name_epiphany">公現祭</string>
+    <string name="holiday_name_japan_coming_of_age_day">成人の日</string>
+    <string name="holiday_name_mlk_day">キング牧師記念日</string>
+    <string name="holiday_name_burns_night">バーンズナイト</string>
+    <string name="holiday_name_australia_day">オーストラリアデー</string>
+    <string name="holiday_name_waitangi_day">ワイタンギデー</string>
+    <string name="holiday_name_valentines_day">バレンタインデー</string>
+    <string name="holiday_name_st_davids_day">聖デイビッズの日</string>
+    <string name="holiday_name_korean_independence_movement_day">三一節（韓国）</string>
+    <string name="holiday_name_st_patricks_day">聖パトリックの日</string>
+    <string name="holiday_name_uk_mothering_sunday">母の日（英国）</string>
+    <string name="holiday_name_good_friday">聖金曜日</string>
+    <string name="holiday_name_easter_sunday">復活の主日</string>
+    <string name="holiday_name_easter_monday">復活節月曜日</string>
+    <string name="holiday_name_st_georges_day">聖ジョージの日</string>
+    <string name="holiday_name_anzac_day">アンザックデー</string>
+    <string name="holiday_name_labour_day">労働祭</string>
+    <string name="holiday_name_uk_early_may_bank_holiday">5月初旬の祝日（英国）</string>
+    <string name="holiday_name_mothers_day">母の日</string>
+    <string name="holiday_name_japan_greenery_day">みどりの日</string>
+    <string name="holiday_name_croatia_statehood_day">クロアチア建国記念日</string>
+    <string name="holiday_name_us_memorial_day">戦没将兵記念日（米）</string>
+    <string name="holiday_name_uk_spring_bank_holiday">春季祝日（英国）</string>
+    <string name="holiday_name_italy_republic_day">共和国記念日（伊）</string>
+    <string name="holiday_name_korean_memorial_day">顕忠日（韓国）</string>
+    <string name="holiday_name_uk_kings_birthday">国王誕生日</string>
+    <string name="holiday_name_juneteenth">ジューンティーンス</string>
+    <string name="holiday_name_fathers_day_jun">父の日（6月）</string>
+    <string name="holiday_name_canada_day">カナダデー</string>
+    <string name="holiday_name_us_independence_day">独立記念日（米）</string>
+    <string name="holiday_name_bastille_day">フランス革命記念日</string>
+    <string name="holiday_name_japan_marine_day">海の日</string>
+    <string name="holiday_name_croatia_victory_day">戦勝記念日（クロアチア）</string>
+    <string name="holiday_name_uk_summer_bank_holiday">夏季祝日（英国）</string>
+    <string name="holiday_name_korean_liberation_day">光復節（韓国）</string>
+    <string name="holiday_name_assumption">聖母被昇天</string>
+    <string name="holiday_name_fathers_day_sep">父の日（9月）</string>
+    <string name="holiday_name_brazil_independence_day">ブラジル独立記念日</string>
+    <string name="holiday_name_german_unity_day">ドイツ統一の日</string>
+    <string name="holiday_name_croatia_independence_day">独立記念日（クロアチア）</string>
+    <string name="holiday_name_korean_hangeul_day">ハングルの日（韓国）</string>
+    <string name="holiday_name_canadian_thanksgiving">カナダの感謝祭</string>
+    <string name="holiday_name_spain_hispanic_day">スペイン国民の日</string>
+    <string name="holiday_name_austria_national_day">国民の日（オーストリア）</string>
+    <string name="holiday_name_halloween">ハロウィン</string>
+    <string name="holiday_name_all_saints_day">諸聖人の日</string>
+    <string name="holiday_name_japan_culture_day">文化の日</string>
+    <string name="holiday_name_bonfire_night">ガイ・フォークスの夜</string>
+    <string name="holiday_name_remembrance_day">戦没者追悼記念日 / 退役軍人の日</string>
+    <string name="holiday_name_us_thanksgiving">感謝祭（米）</string>
+    <string name="holiday_name_st_andrews_day">聖アンドリューの日</string>
+    <string name="holiday_name_immaculate_conception">無原罪の御宿り</string>
+    <string name="holiday_name_christmas_day">クリスマス</string>
+    <string name="holiday_name_boxing_day">ボクシングデー</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -788,4 +788,100 @@ displayed label localizes.
     <string name="settings_forecasters_jma_subtitle">일본 — 아시아 태평양에 강함. 오픈 피드에서는 3~6시간 간격.</string>
     <string name="settings_forecasters_bom">BOM</string>
     <string name="settings_forecasters_bom_subtitle">호주 — 점검 중입니다. 가능한 한 빨리 복구됩니다.</string>
+
+    <!-- Settings root — Holidays row and subtitle. -->
+    <string name="settings_root_holidays">공휴일</string>
+    <string name="settings_root_holidays_subtitle">테마 색상 및 배너</string>
+
+    <!--
+    Holidays sub-page — page title, country picker controls,
+    expand/collapse toggles, and per-holiday override states.
+    -->
+    <string name="settings_holidays_title">공휴일</string>
+    <string name="settings_holiday_country_home">홈 (%1$s)</string>
+    <string name="settings_holiday_country_current">현재 위치 (%1$s)</string>
+    <string name="settings_holiday_country_unknown">알 수 없음</string>
+    <string name="settings_holiday_country_global_label">글로벌</string>
+    <string name="settings_holiday_country_all_label">전체</string>
+    <string name="settings_holiday_all_section_title">전체</string>
+    <string name="settings_holidays_expand">펼치기</string>
+    <string name="settings_holidays_collapse">접기</string>
+    <string name="settings_holiday_override_auto_on">자동 (켜짐)</string>
+    <string name="settings_holiday_override_auto_off">자동 (꺼짐)</string>
+    <string name="settings_holiday_override_on">켜짐</string>
+    <string name="settings_holiday_override_off">꺼짐</string>
+
+    <!-- Country names for the holiday country picker. -->
+    <string name="settings_holiday_country_at">오스트리아</string>
+    <string name="settings_holiday_country_au">호주</string>
+    <string name="settings_holiday_country_br">브라질</string>
+    <string name="settings_holiday_country_ca">캐나다</string>
+    <string name="settings_holiday_country_de">독일</string>
+    <string name="settings_holiday_country_es">스페인</string>
+    <string name="settings_holiday_country_fr">프랑스</string>
+    <string name="settings_holiday_country_gb">영국</string>
+    <string name="settings_holiday_country_hr">크로아티아</string>
+    <string name="settings_holiday_country_ie">아일랜드</string>
+    <string name="settings_holiday_country_it">이탈리아</string>
+    <string name="settings_holiday_country_jp">일본</string>
+    <string name="settings_holiday_country_kr">대한민국</string>
+    <string name="settings_holiday_country_nz">뉴질랜드</string>
+    <string name="settings_holiday_country_us">미국</string>
+
+    <!-- Holiday display names (shown in Settings → Holidays list). -->
+    <string name="holiday_name_new_years_day">새해 첫날</string>
+    <string name="holiday_name_epiphany">주현절</string>
+    <string name="holiday_name_japan_coming_of_age_day">성인의 날 (일본)</string>
+    <string name="holiday_name_mlk_day">마틴 루서 킹의 날</string>
+    <string name="holiday_name_burns_night">번스 나이트</string>
+    <string name="holiday_name_australia_day">호주의 날</string>
+    <string name="holiday_name_waitangi_day">와이탕이 데이</string>
+    <string name="holiday_name_valentines_day">발렌타인데이</string>
+    <string name="holiday_name_st_davids_day">성 다윗의 날</string>
+    <string name="holiday_name_korean_independence_movement_day">삼일절</string>
+    <string name="holiday_name_st_patricks_day">성 패트릭의 날</string>
+    <string name="holiday_name_uk_mothering_sunday">어머니 주일 (영국)</string>
+    <string name="holiday_name_good_friday">성금요일</string>
+    <string name="holiday_name_easter_sunday">부활주일</string>
+    <string name="holiday_name_easter_monday">부활절 월요일</string>
+    <string name="holiday_name_st_georges_day">성 조지의 날</string>
+    <string name="holiday_name_anzac_day">안작 데이</string>
+    <string name="holiday_name_labour_day">노동절</string>
+    <string name="holiday_name_uk_early_may_bank_holiday">5월 초 공휴일 (영국)</string>
+    <string name="holiday_name_mothers_day">어버이날</string>
+    <string name="holiday_name_japan_greenery_day">녹색의 날 (일본)</string>
+    <string name="holiday_name_croatia_statehood_day">크로아티아 건국기념일</string>
+    <string name="holiday_name_us_memorial_day">전몰장병 추모일 (미국)</string>
+    <string name="holiday_name_uk_spring_bank_holiday">봄 공휴일 (영국)</string>
+    <string name="holiday_name_italy_republic_day">이탈리아 공화국의 날</string>
+    <string name="holiday_name_korean_memorial_day">현충일</string>
+    <string name="holiday_name_uk_kings_birthday">국왕 생일</string>
+    <string name="holiday_name_juneteenth">준틴스</string>
+    <string name="holiday_name_fathers_day_jun">아버지의 날 (6월)</string>
+    <string name="holiday_name_canada_day">캐나다 데이</string>
+    <string name="holiday_name_us_independence_day">미국 독립기념일</string>
+    <string name="holiday_name_bastille_day">바스티유 데이</string>
+    <string name="holiday_name_japan_marine_day">바다의 날 (일본)</string>
+    <string name="holiday_name_croatia_victory_day">크로아티아 전승기념일</string>
+    <string name="holiday_name_uk_summer_bank_holiday">여름 공휴일 (영국)</string>
+    <string name="holiday_name_korean_liberation_day">광복절</string>
+    <string name="holiday_name_assumption">성모 승천 대축일</string>
+    <string name="holiday_name_fathers_day_sep">아버지의 날 (9월)</string>
+    <string name="holiday_name_brazil_independence_day">브라질 독립기념일</string>
+    <string name="holiday_name_german_unity_day">독일 통일의 날</string>
+    <string name="holiday_name_croatia_independence_day">크로아티아 독립기념일</string>
+    <string name="holiday_name_korean_hangeul_day">한글날</string>
+    <string name="holiday_name_canadian_thanksgiving">캐나다 추수감사절</string>
+    <string name="holiday_name_spain_hispanic_day">스페인 국경일</string>
+    <string name="holiday_name_austria_national_day">오스트리아 국경일</string>
+    <string name="holiday_name_halloween">핼러윈</string>
+    <string name="holiday_name_all_saints_day">만성절</string>
+    <string name="holiday_name_japan_culture_day">문화의 날 (일본)</string>
+    <string name="holiday_name_bonfire_night">가이 포크스의 밤</string>
+    <string name="holiday_name_remembrance_day">현충일 / 재향군인의 날</string>
+    <string name="holiday_name_us_thanksgiving">미국 추수감사절</string>
+    <string name="holiday_name_st_andrews_day">성 앤드루스의 날</string>
+    <string name="holiday_name_immaculate_conception">원죄 없는 잉태</string>
+    <string name="holiday_name_christmas_day">크리스마스</string>
+    <string name="holiday_name_boxing_day">박싱 데이</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -776,4 +776,100 @@ label localizes.
     <string name="settings_forecasters_jma_subtitle">日本——亚太地区表现出色。开放数据源为每 3 至 6 小时。</string>
     <string name="settings_forecasters_bom">BOM</string>
     <string name="settings_forecasters_bom_subtitle">澳大利亚——维护中，将尽快恢复。</string>
+
+    <!-- Settings root — Holidays row and subtitle. -->
+    <string name="settings_root_holidays">节假日</string>
+    <string name="settings_root_holidays_subtitle">主题色和横幅</string>
+
+    <!--
+    Holidays sub-page — page title, country picker controls,
+    expand/collapse toggles, and per-holiday override states.
+    -->
+    <string name="settings_holidays_title">节假日</string>
+    <string name="settings_holiday_country_home">家乡（%1$s）</string>
+    <string name="settings_holiday_country_current">当前位置（%1$s）</string>
+    <string name="settings_holiday_country_unknown">未知</string>
+    <string name="settings_holiday_country_global_label">全球</string>
+    <string name="settings_holiday_country_all_label">全部</string>
+    <string name="settings_holiday_all_section_title">全部</string>
+    <string name="settings_holidays_expand">展开</string>
+    <string name="settings_holidays_collapse">收起</string>
+    <string name="settings_holiday_override_auto_on">自动（开启）</string>
+    <string name="settings_holiday_override_auto_off">自动（关闭）</string>
+    <string name="settings_holiday_override_on">开启</string>
+    <string name="settings_holiday_override_off">关闭</string>
+
+    <!-- Country names for the holiday country picker. -->
+    <string name="settings_holiday_country_at">奥地利</string>
+    <string name="settings_holiday_country_au">澳大利亚</string>
+    <string name="settings_holiday_country_br">巴西</string>
+    <string name="settings_holiday_country_ca">加拿大</string>
+    <string name="settings_holiday_country_de">德国</string>
+    <string name="settings_holiday_country_es">西班牙</string>
+    <string name="settings_holiday_country_fr">法国</string>
+    <string name="settings_holiday_country_gb">英国</string>
+    <string name="settings_holiday_country_hr">克罗地亚</string>
+    <string name="settings_holiday_country_ie">爱尔兰</string>
+    <string name="settings_holiday_country_it">意大利</string>
+    <string name="settings_holiday_country_jp">日本</string>
+    <string name="settings_holiday_country_kr">韩国</string>
+    <string name="settings_holiday_country_nz">新西兰</string>
+    <string name="settings_holiday_country_us">美国</string>
+
+    <!-- Holiday display names (shown in Settings → Holidays list). -->
+    <string name="holiday_name_new_years_day">元旦</string>
+    <string name="holiday_name_epiphany">主显节</string>
+    <string name="holiday_name_japan_coming_of_age_day">成人节（日本）</string>
+    <string name="holiday_name_mlk_day">马丁·路德·金纪念日</string>
+    <string name="holiday_name_burns_night">彭斯之夜</string>
+    <string name="holiday_name_australia_day">澳大利亚日</string>
+    <string name="holiday_name_waitangi_day">怀唐伊日</string>
+    <string name="holiday_name_valentines_day">情人节</string>
+    <string name="holiday_name_st_davids_day">圣大卫节</string>
+    <string name="holiday_name_korean_independence_movement_day">三一节（韩国）</string>
+    <string name="holiday_name_st_patricks_day">圣帕特里克节</string>
+    <string name="holiday_name_uk_mothering_sunday">母亲节（英国）</string>
+    <string name="holiday_name_good_friday">耶稣受难日</string>
+    <string name="holiday_name_easter_sunday">复活节</string>
+    <string name="holiday_name_easter_monday">复活节星期一</string>
+    <string name="holiday_name_st_georges_day">圣乔治节</string>
+    <string name="holiday_name_anzac_day">澳新军团纪念日</string>
+    <string name="holiday_name_labour_day">劳动节</string>
+    <string name="holiday_name_uk_early_may_bank_holiday">五月初公假日（英国）</string>
+    <string name="holiday_name_mothers_day">母亲节</string>
+    <string name="holiday_name_japan_greenery_day">绿之日（日本）</string>
+    <string name="holiday_name_croatia_statehood_day">克罗地亚建国纪念日</string>
+    <string name="holiday_name_us_memorial_day">阵亡将士纪念日（美国）</string>
+    <string name="holiday_name_uk_spring_bank_holiday">春季公假日（英国）</string>
+    <string name="holiday_name_italy_republic_day">意大利共和国纪念日</string>
+    <string name="holiday_name_korean_memorial_day">显忠日（韩国）</string>
+    <string name="holiday_name_uk_kings_birthday">国王生日</string>
+    <string name="holiday_name_juneteenth">六月节</string>
+    <string name="holiday_name_fathers_day_jun">父亲节（6月）</string>
+    <string name="holiday_name_canada_day">加拿大日</string>
+    <string name="holiday_name_us_independence_day">独立日（美国）</string>
+    <string name="holiday_name_bastille_day">法国国庆日</string>
+    <string name="holiday_name_japan_marine_day">海之日（日本）</string>
+    <string name="holiday_name_croatia_victory_day">克罗地亚胜利纪念日</string>
+    <string name="holiday_name_uk_summer_bank_holiday">夏季公假日（英国）</string>
+    <string name="holiday_name_korean_liberation_day">光复节（韩国）</string>
+    <string name="holiday_name_assumption">圣母升天节</string>
+    <string name="holiday_name_fathers_day_sep">父亲节（9月）</string>
+    <string name="holiday_name_brazil_independence_day">巴西独立纪念日</string>
+    <string name="holiday_name_german_unity_day">德国统一日</string>
+    <string name="holiday_name_croatia_independence_day">克罗地亚独立纪念日</string>
+    <string name="holiday_name_korean_hangeul_day">韩文节（韩国）</string>
+    <string name="holiday_name_canadian_thanksgiving">加拿大感恩节</string>
+    <string name="holiday_name_spain_hispanic_day">西班牙国庆日</string>
+    <string name="holiday_name_austria_national_day">奥地利国庆日</string>
+    <string name="holiday_name_halloween">万圣节前夜</string>
+    <string name="holiday_name_all_saints_day">万圣节</string>
+    <string name="holiday_name_japan_culture_day">文化节（日本）</string>
+    <string name="holiday_name_bonfire_night">盖伊·福克斯之夜</string>
+    <string name="holiday_name_remembrance_day">阵亡将士纪念日 / 退伍军人节</string>
+    <string name="holiday_name_us_thanksgiving">感恩节（美国）</string>
+    <string name="holiday_name_st_andrews_day">圣安德鲁节</string>
+    <string name="holiday_name_immaculate_conception">圣母无染原罪</string>
+    <string name="holiday_name_christmas_day">圣诞节</string>
+    <string name="holiday_name_boxing_day">节礼日</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -792,4 +792,100 @@ label localises.
     <string name="settings_forecasters_jma_subtitle">日本——亞太地區表現出色。開放資料來源為每 3 至 6 小時。</string>
     <string name="settings_forecasters_bom">BOM</string>
     <string name="settings_forecasters_bom_subtitle">澳洲——維護中，將盡快恢復。</string>
+
+    <!-- Settings root — Holidays row and subtitle. -->
+    <string name="settings_root_holidays">節日</string>
+    <string name="settings_root_holidays_subtitle">主題色彩和橫幅</string>
+
+    <!--
+    Holidays sub-page — page title, country picker controls,
+    expand/collapse toggles, and per-holiday override states.
+    -->
+    <string name="settings_holidays_title">節日</string>
+    <string name="settings_holiday_country_home">家鄉（%1$s）</string>
+    <string name="settings_holiday_country_current">目前位置（%1$s）</string>
+    <string name="settings_holiday_country_unknown">未知</string>
+    <string name="settings_holiday_country_global_label">全球</string>
+    <string name="settings_holiday_country_all_label">全部</string>
+    <string name="settings_holiday_all_section_title">全部</string>
+    <string name="settings_holidays_expand">展開</string>
+    <string name="settings_holidays_collapse">收合</string>
+    <string name="settings_holiday_override_auto_on">自動（開啟）</string>
+    <string name="settings_holiday_override_auto_off">自動（關閉）</string>
+    <string name="settings_holiday_override_on">開啟</string>
+    <string name="settings_holiday_override_off">關閉</string>
+
+    <!-- Country names for the holiday country picker. -->
+    <string name="settings_holiday_country_at">奧地利</string>
+    <string name="settings_holiday_country_au">澳洲</string>
+    <string name="settings_holiday_country_br">巴西</string>
+    <string name="settings_holiday_country_ca">加拿大</string>
+    <string name="settings_holiday_country_de">德國</string>
+    <string name="settings_holiday_country_es">西班牙</string>
+    <string name="settings_holiday_country_fr">法國</string>
+    <string name="settings_holiday_country_gb">英國</string>
+    <string name="settings_holiday_country_hr">克羅埃西亞</string>
+    <string name="settings_holiday_country_ie">愛爾蘭</string>
+    <string name="settings_holiday_country_it">義大利</string>
+    <string name="settings_holiday_country_jp">日本</string>
+    <string name="settings_holiday_country_kr">韓國</string>
+    <string name="settings_holiday_country_nz">紐西蘭</string>
+    <string name="settings_holiday_country_us">美國</string>
+
+    <!-- Holiday display names (shown in Settings → Holidays list). -->
+    <string name="holiday_name_new_years_day">元旦</string>
+    <string name="holiday_name_epiphany">主顯節</string>
+    <string name="holiday_name_japan_coming_of_age_day">成人節（日本）</string>
+    <string name="holiday_name_mlk_day">馬丁·路德·金紀念日</string>
+    <string name="holiday_name_burns_night">彭斯之夜</string>
+    <string name="holiday_name_australia_day">澳洲日</string>
+    <string name="holiday_name_waitangi_day">懷唐伊日</string>
+    <string name="holiday_name_valentines_day">情人節</string>
+    <string name="holiday_name_st_davids_day">聖大衛節</string>
+    <string name="holiday_name_korean_independence_movement_day">三一節（韓國）</string>
+    <string name="holiday_name_st_patricks_day">聖派翠克節</string>
+    <string name="holiday_name_uk_mothering_sunday">母親節（英國）</string>
+    <string name="holiday_name_good_friday">耶穌受難日</string>
+    <string name="holiday_name_easter_sunday">復活節</string>
+    <string name="holiday_name_easter_monday">復活節星期一</string>
+    <string name="holiday_name_st_georges_day">聖喬治節</string>
+    <string name="holiday_name_anzac_day">澳紐軍團紀念日</string>
+    <string name="holiday_name_labour_day">勞動節</string>
+    <string name="holiday_name_uk_early_may_bank_holiday">五月初公假日（英國）</string>
+    <string name="holiday_name_mothers_day">母親節</string>
+    <string name="holiday_name_japan_greenery_day">綠之日（日本）</string>
+    <string name="holiday_name_croatia_statehood_day">克羅埃西亞建國紀念日</string>
+    <string name="holiday_name_us_memorial_day">陣亡將士紀念日（美國）</string>
+    <string name="holiday_name_uk_spring_bank_holiday">春季公假日（英國）</string>
+    <string name="holiday_name_italy_republic_day">義大利共和國紀念日</string>
+    <string name="holiday_name_korean_memorial_day">顯忠日（韓國）</string>
+    <string name="holiday_name_uk_kings_birthday">國王生日</string>
+    <string name="holiday_name_juneteenth">六月節</string>
+    <string name="holiday_name_fathers_day_jun">父親節（6月）</string>
+    <string name="holiday_name_canada_day">加拿大日</string>
+    <string name="holiday_name_us_independence_day">獨立日（美國）</string>
+    <string name="holiday_name_bastille_day">法國國慶日</string>
+    <string name="holiday_name_japan_marine_day">海之日（日本）</string>
+    <string name="holiday_name_croatia_victory_day">克羅埃西亞勝利紀念日</string>
+    <string name="holiday_name_uk_summer_bank_holiday">夏季公假日（英國）</string>
+    <string name="holiday_name_korean_liberation_day">光復節（韓國）</string>
+    <string name="holiday_name_assumption">聖母升天節</string>
+    <string name="holiday_name_fathers_day_sep">父親節（9月）</string>
+    <string name="holiday_name_brazil_independence_day">巴西獨立紀念日</string>
+    <string name="holiday_name_german_unity_day">德國統一日</string>
+    <string name="holiday_name_croatia_independence_day">克羅埃西亞獨立紀念日</string>
+    <string name="holiday_name_korean_hangeul_day">韓文節（韓國）</string>
+    <string name="holiday_name_canadian_thanksgiving">加拿大感恩節</string>
+    <string name="holiday_name_spain_hispanic_day">西班牙國慶日</string>
+    <string name="holiday_name_austria_national_day">奧地利國慶日</string>
+    <string name="holiday_name_halloween">萬聖節前夕</string>
+    <string name="holiday_name_all_saints_day">萬聖節</string>
+    <string name="holiday_name_japan_culture_day">文化節（日本）</string>
+    <string name="holiday_name_bonfire_night">蓋伊·福克斯之夜</string>
+    <string name="holiday_name_remembrance_day">陣亡將士紀念日 / 退伍軍人節</string>
+    <string name="holiday_name_us_thanksgiving">感恩節（美國）</string>
+    <string name="holiday_name_st_andrews_day">聖安德魯節</string>
+    <string name="holiday_name_immaculate_conception">聖母無染原罪</string>
+    <string name="holiday_name_christmas_day">聖誕節</string>
+    <string name="holiday_name_boxing_day">節禮日</string>
 </resources>


### PR DESCRIPTION
## Summary

- Adds `settings_root_holidays` / `settings_root_holidays_subtitle` (Settings navigation row) to all four CJK locale files
- Adds all holiday settings page UI strings: page title, country picker controls (`home`, `current`, `unknown`, `global_label`, `all_label`), expand/collapse toggles, and per-holiday override states (`auto_on`, `auto_off`, `on`, `off`) — in ja, ko, zh-rCN, zh-rTW
- Adds localised country names for the 15 countries in the holiday picker (AT, AU, BR, CA, DE, ES, FR, GB, HR, IE, IT, JP, KR, NZ, US) for each locale
- Adds all 49 `holiday_name_*` display strings (shown in the Settings → Holidays list) for each locale

Holiday banner strings (`holiday_banner_*`) are intentionally **not** overridden. The Japan- and Korea-specific banners (成人の日, 삼일절, 現忠日, etc.) are already in native script in the base `values/strings.xml`, matching the author's intent that these display in the local language for all users regardless of app locale. Generic English banners (Happy New Year, Merry Christmas, etc.) follow the same pattern as other non-English locales (de, fr, etc.) which also leave banners untranslated.

## Test plan

- [ ] Build app with device locale set to `ja`, `ko`, `zh-CN`, `zh-TW` and verify Settings → Holidays shows localised text
- [ ] Confirm holiday names in the per-holiday toggle list are in the correct language for each locale
- [ ] Confirm country picker labels (Japan, South Korea / 日本, 韓国, 일본, 대한민국, etc.) display correctly
- [ ] CI green

---
_Generated by [Claude Code](https://claude.ai/code/session_015Wep8ELPKCCC6Cej5qDCEo)_