### PR TITLE
Celebrations settings subhead now reads "Holidays and Birthdays"

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -396,7 +396,7 @@
 
     <string name="settings_root_location_subtitle">Automatic and Manual Location</string>
     <string name="settings_root_calendar_subtitle">Today\'s events</string>
-    <string name="settings_root_holidays_subtitle">Themes for holidays and birthdays</string>
+    <string name="settings_root_holidays_subtitle">Holidays and Birthdays</string>
     <string name="settings_root_forecasters_subtitle">Weather Sources and Models</string>
     <string name="settings_root_smart_home_subtitle">Home Assistant, MQTT, voice announcements</string>
     <string name="settings_root_privacy_subtitle">Crash + usage reports</string>


### PR DESCRIPTION
## Summary
- Drops the `Themes for ` prefix from the Celebrations row subhead on the settings root, so it just reads `Holidays and Birthdays` — matching the more direct tone of neighbouring rows like `Today's events` and `Weather Sources and Models`.

## Test plan
- [ ] Open Settings; the Celebrations row's subhead should read `Holidays and Birthdays`.
- [ ] CI green on `:app:testDebugUnitTest` and `:app:assembleDebug`.


---
_Generated by [Claude Code](https://claude.ai/code/session_011fx9MuveKW1NBwHmJYLB9d)_