### PR TITLE
Holiday colours now reach the thick-coat icon and notifications

### DIFF
--- a/app/src/main/kotlin/app/clothescast/notification/InsightNotifier.kt
+++ b/app/src/main/kotlin/app/clothescast/notification/InsightNotifier.kt
@@ -26,6 +26,7 @@ class InsightNotifier(private val context: Context) {
         insight: Insight,
         prose: String,
         topColors: Map<OutfitSuggestion.Top, Long> = emptyMap(),
+        topStrokes: Map<OutfitSuggestion.Top, Long> = emptyMap(),
     ) {
         if (!NotificationPermission.isGranted(context)) return
 
@@ -48,7 +49,14 @@ class InsightNotifier(private val context: Context) {
         val top = insight.outfit?.top
         val notification = NotificationCompat.Builder(context, CHANNEL_DAILY_INSIGHT)
             .setSmallIcon(smallIconFor(top))
-            .setLargeIcon(largeIconForTop(context, top, top?.let { topColors[it] }))
+            .setLargeIcon(
+                largeIconForTop(
+                    context = context,
+                    top = top,
+                    customFillArgb = top?.let { topColors[it] },
+                    customStrokeArgb = top?.let { topStrokes[it] },
+                ),
+            )
             .setContentTitle(context.getString(R.string.notification_daily_insight_title))
             .setContentText(prose)
             .setStyle(NotificationCompat.BigTextStyle().bigText(prose))
@@ -88,14 +96,16 @@ class InsightNotifier(private val context: Context) {
          * Reuses the full-colour `ic_outfit_tshirt` / `ic_outfit_sweater` /
          * `ic_outfit_thick_jacket` drawables from `OutfitPreviewCard` so the
          * notification visual matches the home-screen card — including any
-         * user-picked colour override passed in via [customFillArgb]. Returns
-         * null when [top] is missing (older cached payloads), letting the
-         * system fall back to no large icon.
+         * user-picked colour override passed in via [customFillArgb], and
+         * the tricolour-holiday accent passed in via [customStrokeArgb].
+         * Returns null when [top] is missing (older cached payloads),
+         * letting the system fall back to no large icon.
          */
         internal fun largeIconForTop(
             context: Context,
             top: OutfitSuggestion.Top?,
             customFillArgb: Long? = null,
+            customStrokeArgb: Long? = null,
         ): Bitmap? {
             if (top == null) return null
             val sizePx = context.resources.getDimensionPixelSize(android.R.dimen.notification_large_icon_width)
@@ -107,6 +117,7 @@ class InsightNotifier(private val context: Context) {
                 defaults = outfitTopDefaults.getValue(top),
                 customFillArgb = customFillArgb,
                 sizePx = sizePx,
+                customStrokeArgb = customStrokeArgb,
             )
         }
 

--- a/app/src/main/kotlin/app/clothescast/notification/TonightInsightNotifier.kt
+++ b/app/src/main/kotlin/app/clothescast/notification/TonightInsightNotifier.kt
@@ -30,6 +30,7 @@ class TonightInsightNotifier(private val context: Context) {
         insight: Insight,
         prose: String,
         topColors: Map<OutfitSuggestion.Top, Long> = emptyMap(),
+        topStrokes: Map<OutfitSuggestion.Top, Long> = emptyMap(),
     ) {
         if (!NotificationPermission.isGranted(context)) return
 
@@ -50,7 +51,14 @@ class TonightInsightNotifier(private val context: Context) {
         val top = insight.outfit?.top
         val notification = NotificationCompat.Builder(context, channel)
             .setSmallIcon(InsightNotifier.smallIconFor(top))
-            .setLargeIcon(InsightNotifier.largeIconForTop(context, top, top?.let { topColors[it] }))
+            .setLargeIcon(
+                InsightNotifier.largeIconForTop(
+                    context = context,
+                    top = top,
+                    customFillArgb = top?.let { topColors[it] },
+                    customStrokeArgb = top?.let { topStrokes[it] },
+                ),
+            )
             .setContentTitle(context.getString(R.string.notification_tonight_insight_title))
             .setContentText(prose)
             .setStyle(NotificationCompat.BigTextStyle().bigText(prose))

--- a/app/src/main/kotlin/app/clothescast/ui/garment/GarmentColors.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/garment/GarmentColors.kt
@@ -31,7 +31,7 @@ internal val outfitTopDefaults: Map<OutfitSuggestion.Top, GarmentDefaults> = map
     OutfitSuggestion.Top.SWEATER to GarmentDefaults(0xFF8D6E63.toInt(), 0xFF5D4037.toInt()),
     OutfitSuggestion.Top.THIN_JACKET to GarmentDefaults(0xFF3949AB.toInt(), 0xFF1A237E.toInt()),
     OutfitSuggestion.Top.THICK_JACKET to GarmentDefaults(0xFF7E57C2.toInt(), 0xFF4527A0.toInt()),
-    OutfitSuggestion.Top.THICK_COAT to GarmentDefaults(0xFFFFB74D.toInt(), 0xFFEF6C00.toInt()),
+    OutfitSuggestion.Top.THICK_COAT to GarmentDefaults(0xFF8D6E63.toInt(), 0xFF4E342E.toInt()),
     OutfitSuggestion.Top.PUFFER_JACKET to GarmentDefaults(0xFFF5F7FA.toInt(), 0xFF90A4AE.toInt()),
 )
 

--- a/app/src/main/kotlin/app/clothescast/ui/garment/GarmentRender.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/garment/GarmentRender.kt
@@ -199,8 +199,11 @@ private fun Paint.Join.toComposeJoin(): StrokeJoin = when (this) {
  * can't render Compose composables — notification large icons (via
  * [androidx.core.app.NotificationCompat.Builder.setLargeIcon]) and the
  * Glance widget (via [androidx.glance.ImageProvider]). Memoised by
- * `(drawableRes, fillArgb, sizePx)` so rapid widget refreshes don't
- * re-rasterize. [customFillArgb] = null preserves the baked-in two-tone.
+ * `(drawableRes, fillArgb, strokeArgb, sizePx)` so rapid widget refreshes
+ * don't re-rasterize. [customFillArgb] = null preserves the baked-in
+ * two-tone; [customStrokeArgb] when non-null overrides the auto-derived
+ * darker stroke with a chosen accent colour (e.g. the contrasting third
+ * colour in tricolour holiday themes).
  */
 internal fun renderOutfitBitmap(
     context: Context,
@@ -208,17 +211,18 @@ internal fun renderOutfitBitmap(
     defaults: GarmentDefaults,
     customFillArgb: Long?,
     sizePx: Int,
+    customStrokeArgb: Long? = null,
 ): Bitmap {
     require(sizePx > 0) { "sizePx must be positive, got $sizePx" }
-    val cacheKey = BitmapCacheKey(drawableRes, customFillArgb, sizePx)
+    val cacheKey = BitmapCacheKey(drawableRes, customFillArgb, customStrokeArgb, sizePx)
     bitmapCache[cacheKey]?.let { return it }
-    val bitmap = if (customFillArgb == null) {
+    val bitmap = if (customFillArgb == null && customStrokeArgb == null) {
         // Default-colour fast path: lean on the platform's VectorDrawable
         // rasterizer so the bitmap matches what users have always seen on
         // notifications + widgets pre-customisation.
         renderDefaultBitmap(context, drawableRes, sizePx)
     } else {
-        renderRecoloredBitmap(context, drawableRes, defaults, customFillArgb, sizePx)
+        renderRecoloredBitmap(context, drawableRes, defaults, customFillArgb, customStrokeArgb, sizePx)
     }
     bitmapCache[cacheKey] = bitmap
     return bitmap
@@ -238,11 +242,16 @@ private fun renderRecoloredBitmap(
     context: Context,
     @DrawableRes drawableRes: Int,
     defaults: GarmentDefaults,
-    customFillArgb: Long,
+    customFillArgb: Long?,
+    customStrokeArgb: Long?,
     sizePx: Int,
 ): Bitmap {
     val vector = loadOutfitVector(context, drawableRes)
-    val recolor = buildRecolorMap(defaults, Color(customFillArgb.toInt()))
+    val recolor = buildRecolorMap(
+        defaults,
+        customFillArgb?.let { Color(it.toInt()) },
+        customStrokeArgb?.let { Color(it.toInt()) },
+    )
     val bitmap = Bitmap.createBitmap(sizePx, sizePx, Bitmap.Config.ARGB_8888)
     val canvas = Canvas(bitmap)
     val scaleX = sizePx / vector.viewportWidth
@@ -271,6 +280,7 @@ private fun renderRecoloredBitmap(
 private data class BitmapCacheKey(
     @DrawableRes val drawableRes: Int,
     val customFillArgb: Long?,
+    val customStrokeArgb: Long?,
     val sizePx: Int,
 )
 
@@ -304,6 +314,8 @@ internal fun renderOutfitCard(
     rainFillFraction: Float?,
     topColors: Map<OutfitSuggestion.Top, Long>,
     bottomColors: Map<OutfitSuggestion.Bottom, Long>,
+    topStrokes: Map<OutfitSuggestion.Top, Long> = emptyMap(),
+    bottomStrokes: Map<OutfitSuggestion.Bottom, Long> = emptyMap(),
 ): ByteArray {
     val bmp = Bitmap.createBitmap(CARD_W, CARD_H, Bitmap.Config.ARGB_8888)
     val canvas = Canvas(bmp)
@@ -313,8 +325,22 @@ internal fun renderOutfitCard(
 
     // Icons go in the left column from the top, independent of the header
     // which lives above the prose on the right.
-    val topBmp = renderOutfitBitmap(context, topDrawable(outfit.top), outfitTopDefaults.getValue(outfit.top), topColors[outfit.top], ICON_PX)
-    val botBmp = renderOutfitBitmap(context, bottomDrawable(outfit.bottom), outfitBottomDefaults.getValue(outfit.bottom), bottomColors[outfit.bottom], ICON_PX)
+    val topBmp = renderOutfitBitmap(
+        context = context,
+        drawableRes = topDrawable(outfit.top),
+        defaults = outfitTopDefaults.getValue(outfit.top),
+        customFillArgb = topColors[outfit.top],
+        sizePx = ICON_PX,
+        customStrokeArgb = topStrokes[outfit.top],
+    )
+    val botBmp = renderOutfitBitmap(
+        context = context,
+        drawableRes = bottomDrawable(outfit.bottom),
+        defaults = outfitBottomDefaults.getValue(outfit.bottom),
+        customFillArgb = bottomColors[outfit.bottom],
+        sizePx = ICON_PX,
+        customStrokeArgb = bottomStrokes[outfit.bottom],
+    )
     canvas.drawBitmap(topBmp, CARD_PAD.toFloat(), CARD_PAD.toFloat(), null)
     canvas.drawBitmap(botBmp, CARD_PAD.toFloat(), (CARD_PAD + ICON_PX + ICON_V_GAP).toFloat(), null)
 

--- a/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
@@ -18,11 +18,16 @@ import androidx.work.workDataOf
 import app.clothescast.ClothesCastApplication
 import app.clothescast.core.domain.model.DeliveryMode
 import app.clothescast.core.domain.model.ForecastPeriod
+import app.clothescast.core.domain.model.HolidayCatalog
+import app.clothescast.core.domain.model.HolidayTheme
 import app.clothescast.core.domain.model.Insight
 import app.clothescast.core.domain.model.Location
+import app.clothescast.core.domain.model.OutfitSuggestion
 import app.clothescast.core.domain.model.TtsEngine
 import app.clothescast.core.domain.model.UserPreferences
+import app.clothescast.core.domain.usecase.ThemeForToday
 import app.clothescast.core.domain.usecase.shouldSpeak
+import app.clothescast.tts.toJavaLocale
 import app.clothescast.core.data.tts.WavEncoder
 import app.clothescast.data.InsightCache
 import app.clothescast.mqtt.MqttPublishOutcome
@@ -50,6 +55,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import java.io.IOException
 import java.time.LocalDate
+import java.util.Locale
 import java.util.concurrent.TimeUnit
 import kotlin.math.cos
 import kotlin.math.sqrt
@@ -550,7 +556,59 @@ class FetchAndNotifyWorker(
         }
     }
 
+    /**
+     * Mirrors [TodayViewModel]'s holiday-theme resolution so the worker's
+     * notification / MQTT card pick up the same palette the Today screen
+     * draws. Calendar events are only read when the user has opted into
+     * calendar-sourced theming; the read is wrapped in [runCatching] so a
+     * missing READ_CALENDAR permission silently falls through to "no events".
+     */
+    private suspend fun resolveHolidayTheme(prefs: UserPreferences): HolidayTheme? {
+        val today = LocalDate.now(prefs.schedule.zoneId)
+        val needEvents = prefs.themeFromCalendarHolidays || prefs.themeFromCalendarBirthdays
+        val events = if (needEvents) {
+            runCatching {
+                app.calendarEventReader.eventsForDay(today, prefs.schedule.zoneId)
+            }.getOrDefault(emptyList())
+        } else {
+            emptyList()
+        }
+        val localeCountry = prefs.region.toJavaLocale()?.country
+            ?: Locale.getDefault().country
+        val effectiveCountries = prefs.holidayCountrySelection.resolveEnabledCountries(
+            localeCountry = localeCountry,
+            weatherLocationCountry = prefs.location?.countryCode,
+            allCountries = HolidayCatalog.allCountries,
+        )
+        return ThemeForToday().resolve(
+            date = today,
+            overrides = prefs.holidayOverrides,
+            enabledCountries = effectiveCountries,
+            events = events,
+            themeFromCalendarHolidays = prefs.themeFromCalendarHolidays,
+            themeFromCalendarBirthdays = prefs.themeFromCalendarBirthdays,
+        )
+    }
+
     private suspend fun deliver(insight: Insight, prefs: UserPreferences, prose: String) {
+        // Apply today's holiday theme on top of the user's persisted outfit
+        // colour customisations so the notification's large icon and the
+        // Home-Assistant outfit card match what the Today screen renders —
+        // birthday yellows / Christmas reds, plus the tricolour stroke
+        // accents on themes like July 4 / Bastille Day / Italy / Germany /
+        // New Year's. The screen's TodayViewModel does the same merge;
+        // without it the off-screen renderers would silently fall back to
+        // user defaults (or the auto-derived darker-shade stroke) on
+        // themed days.
+        val theme = resolveHolidayTheme(prefs)
+        val topColors: Map<OutfitSuggestion.Top, Long> =
+            prefs.outfitTopColors + (theme?.topOverrides ?: emptyMap())
+        val bottomColors: Map<OutfitSuggestion.Bottom, Long> =
+            prefs.outfitBottomColors + (theme?.bottomOverrides ?: emptyMap())
+        val topStrokes: Map<OutfitSuggestion.Top, Long> =
+            theme?.topStrokeOverrides ?: emptyMap()
+        val bottomStrokes: Map<OutfitSuggestion.Bottom, Long> =
+            theme?.bottomStrokeOverrides ?: emptyMap()
         // Publish to MQTT before waiting for the delivery-alignment delay so
         // that retained topics are current by the time HA automations fire.
         // deliverToday/Tonight both start with awaitDeliveryAlignment() (60 s
@@ -585,8 +643,10 @@ class FetchAndNotifyWorker(
                     rainLine = info.rainLine,
                     tempFillFraction = info.tempFillFraction,
                     rainFillFraction = info.rainFillFraction,
-                    topColors = prefs.outfitTopColors,
-                    bottomColors = prefs.outfitBottomColors,
+                    topColors = topColors,
+                    bottomColors = bottomColors,
+                    topStrokes = topStrokes,
+                    bottomStrokes = bottomStrokes,
                 )
                 app.mqttPublisher.publishImageIfEnabled(insight.period, png)
             }.onFailure { t ->
@@ -595,8 +655,8 @@ class FetchAndNotifyWorker(
             }
         }
         when (insight.period) {
-            ForecastPeriod.TODAY -> deliverToday(insight, prefs, prose)
-            ForecastPeriod.TONIGHT -> deliverTonight(insight, prefs, prose)
+            ForecastPeriod.TODAY -> deliverToday(insight, prefs, prose, topColors, topStrokes)
+            ForecastPeriod.TONIGHT -> deliverTonight(insight, prefs, prose, topColors, topStrokes)
         }
         // Status persistence is best-effort: a DataStore I/O failure here must
         // not surface as a deliver() exception, which would cause the
@@ -611,11 +671,17 @@ class FetchAndNotifyWorker(
         }
     }
 
-    private suspend fun deliverToday(insight: Insight, prefs: UserPreferences, prose: String) {
+    private suspend fun deliverToday(
+        insight: Insight,
+        prefs: UserPreferences,
+        prose: String,
+        topColors: Map<OutfitSuggestion.Top, Long>,
+        topStrokes: Map<OutfitSuggestion.Top, Long>,
+    ) {
         awaitDeliveryAlignment()
         val mode = prefs.deliveryMode
         if (mode == DeliveryMode.NOTIFICATION_ONLY || mode == DeliveryMode.NOTIFICATION_AND_TTS) {
-            app.insightNotifier.notify(insight, prose, prefs.outfitTopColors)
+            app.insightNotifier.notify(insight, prose, topColors, topStrokes)
             recordDeliveryDelay(ForecastPeriod.TODAY)
         }
         val ttsRequested = mode == DeliveryMode.TTS_ONLY || mode == DeliveryMode.NOTIFICATION_AND_TTS
@@ -731,7 +797,13 @@ class FetchAndNotifyWorker(
             temperatureUnit = prefs.temperatureUnit,
         )
 
-    private suspend fun deliverTonight(insight: Insight, prefs: UserPreferences, prose: String) {
+    private suspend fun deliverTonight(
+        insight: Insight,
+        prefs: UserPreferences,
+        prose: String,
+        topColors: Map<OutfitSuggestion.Top, Long>,
+        topStrokes: Map<OutfitSuggestion.Top, Long>,
+    ) {
         awaitDeliveryAlignment()
         val mode = prefs.tonightDeliveryMode
         val canNotify = mode == DeliveryMode.NOTIFICATION_ONLY || mode == DeliveryMode.NOTIFICATION_AND_TTS
@@ -743,7 +815,7 @@ class FetchAndNotifyWorker(
         if (skipEmptyEveningNotification) {
             DiagLog.i(TAG, "Tonight insight has no events and notify-only-on-events is on; skipping notification.")
         } else if (canNotify) {
-            app.tonightInsightNotifier.notify(insight, prose, prefs.outfitTopColors)
+            app.tonightInsightNotifier.notify(insight, prose, topColors, topStrokes)
             recordDeliveryDelay(ForecastPeriod.TONIGHT)
         }
         if (!insight.hasEvents) {


### PR DESCRIPTION
## Summary

Three regressions kept holiday themes from rendering everywhere they should — visible in the user-reported screenshot where a refresh flipped the morning outfit to **Thick coat · Jeans** with brown coat + magenta jeans (the yellow vanished), and the matching notification showed default-coloured clothes too:

- **`THICK_COAT` defaults didn't match the drawable.** `outfitTopDefaults` listed `#FFB74D / #EF6C00`, but `ic_outfit_thick_coat.xml` actually paints `#8D6E63 / #4E342E`. `buildRecolorMap` keys substitutions by the *original* SVG colour, so the recolour silently no-op'd on the coat. Every other top mapped correctly, but a colder forecast that promoted the top to `THICK_COAT` (e.g. the 6–10 °C case in the screenshot) flashed back to brown the instant the new outfit arrived. Updated the defaults to match what's in the drawable. The default-colour fast path in `GarmentRender` bypasses this table entirely, so the no-customisation render stays byte-identical — only themed / user-customised renders change.

- **The worker passed `prefs.outfitTopColors` straight through, skipping the holiday merge.** `TodayViewModel` overlays `theme.topOverrides + theme.bottomOverrides` onto the user's persisted colours before handing them to the icons; `FetchAndNotifyWorker.deliver` was just forwarding the raw prefs to `InsightNotifier.notify` / `TonightInsightNotifier.notify` / `renderOutfitCard`. That's why the screen was (mostly) themed but the morning + tonight notifications still showed default wardrobe colour. Mirrored TodayViewModel's resolution path (curated `HolidayCatalog` + optional calendar-sourced themes via the shared `ThemeForToday`), merged the overrides, and threaded the merged map through `deliverToday` / `deliverTonight`.

- **Off-screen renderers couldn't accept stroke overrides** ([Codex review](https://github.com/mikelward/clothescast/pull/573#discussion_r3260526297)). `TodayViewModel` already plumbs `theme.topStrokeOverrides` / `bottomStrokeOverrides` to the Compose path, but `renderOutfitBitmap` / `renderOutfitCard` auto-derived strokes from the fill — so even with the fill merge above, the third colour in tricolour themes (July 4, Bastille Day, Italy, Croatia, Pan-African, etc.) still vanished from notifications and the MQTT card. Widened `renderOutfitBitmap` (with a new defaulted `customStrokeArgb` and matching bitmap-cache-key field), `renderOutfitCard`, and both notifiers' `notify` / `largeIconForTop` to accept stroke maps, then threaded `theme?.topStrokeOverrides` / `bottomStrokeOverrides` through the worker alongside the fill maps.

## Privacy

No new data leaves the device. The worker now consults the same prefs + calendar events the Today screen already does (gated on the existing `themeFromCalendarHolidays` / `themeFromCalendarBirthdays` toggles via the same `runCatching` fallthrough). Notification payload text is unchanged — only the large-icon bitmap's recoloured fill + stroke change.

## Test plan

- [x] `./gradlew :core:domain:test :core:data:test` — green.
- [x] `./gradlew :app:testDebugUnitTest` — green (no snapshot regen needed; no existing snapshot exercises `THICK_COAT` with custom/theme colours, and the renderer's default-colour fast path is byte-identical for un-customised + un-themed outfits).
- [x] `./gradlew :app:assembleDebug` — green.
- [ ] Manual: on the user's birthday, refresh and confirm the `Thick coat` icon picks up birthday yellow (and the notification's large icon matches).
- [ ] Manual: on July 4 / Bastille Day (or a force-enabled tricolour theme), confirm the notification's large icon shows fill + accent stroke from the theme — not the auto-derived darker shade of the fill.
- [ ] Manual: un-themed cold day still renders the coat in its default brown (fast-path unchanged).
