### PR TITLE
Document the Gemini TTS WAV path; fix the outfit-image recipe

### DIFF
--- a/docs/smart-home.md
+++ b/docs/smart-home.md
@@ -230,7 +230,7 @@ Hub stays in lockstep with the phone without HA re-synthesising the
 prose through its own TTS stack — same Gemini voice, same prosody,
 no Google-broadcast preamble.
 
-Two things to know before you wire anything up:
+Three things to know before you wire anything up:
 
 - **Gemini-only.** Device TTS doesn't expose its audio buffer before
   playback, so the audio topic stays empty when the on-device engine
@@ -240,6 +240,29 @@ Two things to know before you wire anything up:
   forecast at home" is on and you're at home, neither the phone nor
   the Hub gets the clip. Toggle that off if you want the Hub to speak
   even when you're home.
+- **The retained WAV doesn't auto-clear on a skipped publish.** MQTT
+  keeps the last WAV on the topic until something overwrites it. So
+  if a later refresh doesn't generate audio (skip-TTS-at-home
+  suppressed it, Gemini synthesis hit an error and fell back to
+  Device TTS, etc.), an HA automation playing the cached file will
+  speak **yesterday's** briefing rather than staying silent. The
+  simplest HA-side guard is a template condition gating on the prose
+  sensor's `last_changed` being recent — prose publishes on every
+  successful refresh, so:
+
+  ```yaml
+  conditions:
+    - condition: template
+      value_template: >
+        {{ (now() - states.sensor.clothescast_today.last_changed).total_seconds() < 1800 }}
+  ```
+
+  catches the "ClothesCast didn't fire at all" case. It does **not**
+  catch the "refreshed but audio missing" case (prose updates, audio
+  doesn't) — for that, the cleanest fix is at the publisher, and
+  there's currently no app-side flag to detect it from HA. If matching
+  the spoken bytes to the prose matters, keep Gemini selected and
+  skip-TTS-at-home off for the periods this automation runs.
 
 If you'd rather have HA re-synthesise the prose sensor through its
 own TTS (Google Translate, Nabu Casa, etc.), skip this section and

--- a/docs/smart-home.md
+++ b/docs/smart-home.md
@@ -101,6 +101,35 @@ only constrains the ClothesCast publisher — it doesn't break HA's
 ability to subscribe to the topic for the automation that speaks the
 forecast.
 
+> **Heads-up if you wire up the audio-topic bridge below.** The
+> Node-RED / `shell_command` audio bridge documented further down
+> subscribes to `clothescast/insight/.../audio` to copy the WAV to
+> `www/`, and by default the example uses `-u clothescast` for those
+> credentials. With the write-only ACL above in place, Mosquitto
+> rejects the SUBSCRIBE and the WAV file never refreshes. Two ways
+> to handle it:
+>
+> - **Switch the ACL to `readwrite`** for the same `clothescast`
+>   user — simplest, gives the phone-side publisher unnecessary
+>   read access but that's a minor concern on a personal LAN:
+>   ```
+>   user clothescast
+>   topic readwrite clothescast/insight/#
+>   ```
+> - **Or add a separate read-only user** for the bridge, keeping
+>   the phone-side credential publish-only:
+>   ```
+>   user clothescast
+>   topic write clothescast/insight/#
+>
+>   user clothescast-reader
+>   topic read clothescast/insight/#
+>   ```
+>   Create the reader user the same way you created `clothescast`
+>   (HA users page or `mosquitto_passwd`), and use *its* credentials
+>   in the `shell_command` examples (`-u clothescast-reader`) and
+>   Node-RED's MQTT-in broker config.
+
 > If you're running a **standalone Mosquitto** outside Home Assistant
 > instead of the HA add-on, the user creation step uses
 > `mosquitto_passwd -c /etc/mosquitto/passwd clothescast` and the

--- a/docs/smart-home.md
+++ b/docs/smart-home.md
@@ -190,7 +190,7 @@ actions:
       entity_id: media_player.kitchen_hub
     data:
       media_content_id: "http://192.168.x.x:8123/api/camera_proxy/camera.clothescast_today_outfit?token=<access_token>"
-      media_content_type: image/jpeg
+      media_content_type: image/png
 ```
 
 Replace `media_player.kitchen_hub` with your actual Nest Hub entity ID
@@ -628,11 +628,11 @@ actions:
       entity_id: media_player.kitchen_hub
     data:
       media_content_id: "http://192.168.x.x:8123/api/camera_proxy/camera.clothescast_today_outfit?token=<access_token>"
-      media_content_type: image/jpeg
+      media_content_type: image/png
 ```
 
 **Serial — speak first, then show.** Cast's `media_player.play_media`
-with `image/jpeg` interrupts whatever's currently rendering, including
+with `image/png` interrupts whatever's currently rendering, including
 in-flight TTS, so for the serial pattern you wait for the speech to
 finish before pushing the picture. A fixed `delay:` sized to your
 longest spoken briefing is the simplest reliable wait, and works
@@ -668,7 +668,7 @@ actions:
       entity_id: media_player.kitchen_hub
     data:
       media_content_id: "http://192.168.x.x:8123/api/camera_proxy/camera.clothescast_today_outfit?token=<access_token>"
-      media_content_type: image/jpeg
+      media_content_type: image/png
 ```
 
 **Picker — swapping in Option B or C.** Replace the step-1 action
@@ -719,7 +719,7 @@ actions:
       entity_id: media_player.kitchen_hub
     data:
       media_content_id: "http://192.168.x.x:8123/api/camera_proxy/camera.clothescast_today_outfit?token=<access_token>"
-      media_content_type: image/jpeg
+      media_content_type: image/png
 ```
 
 > **Edge case — speaker was already playing music (Option B

--- a/docs/smart-home.md
+++ b/docs/smart-home.md
@@ -167,9 +167,25 @@ Reload MQTT (Developer Tools → YAML → Reload MQTT) or restart HA so
 the entities appear as `camera.clothescast_today_outfit` and
 `camera.clothescast_tonight_outfit`.
 
-Then find each entity's access token in Developer Tools → States →
-search `camera.clothescast` → open Details. Copy the `access_token`
-value — you'll need it in the automation below.
+Then find the Cast **device ID** for the Hub you want to push to:
+Settings → Devices & Services → **Google Cast** → tap your Hub —
+the browser URL bar now shows `…/config/devices/device/<id>`. Copy
+the hex string after `/device/` — that's what the automation will
+target.
+
+> **Why device, not entity?** Audio play_media on a Nest Hub works
+> fine targeted at the Hub's `media_player.*` entity, but images
+> only render when the action targets the underlying *device*. HA's
+> Cast integration routes image content through a separate
+> device-level Cast API; `entity_id:` targeting silently no-ops on
+> the display (the action "succeeds", the picture never appears).
+> If you ever see "URL works in a browser, image stays blank on the
+> Hub", swapping `entity_id:` for `device_id:` is the fix.
+
+You don't need to copy the camera entity's `access_token` — the
+automation pulls it dynamically with `state_attr(…, 'access_token')`
+at fire-time, so token rotation across HA restarts is handled
+automatically.
 
 ### Automation to push the image to the Hub
 
@@ -187,30 +203,30 @@ conditions: []
 actions:
   - action: media_player.play_media
     target:
-      entity_id: media_player.kitchen_hub
+      device_id: <your-hub-device-id>
     data:
-      media_content_id: "http://192.168.x.x:8123/api/camera_proxy/camera.clothescast_today_outfit?token=<access_token>"
+      media_content_id: >-
+        http://192.168.x.x:8123/api/camera_proxy/camera.clothescast_today_outfit?token={{
+        state_attr('camera.clothescast_today_outfit', 'access_token') }}
       media_content_type: image/png
 ```
 
-Replace `media_player.kitchen_hub` with your actual Nest Hub entity ID
-(find it under Settings → Devices & Services → Google Cast),
-`192.168.x.x` with your HA instance's local IP address, and
-`<access_token>` with the token you copied from the entity details.
+Replace `<your-hub-device-id>` with the device ID you copied above
+and `192.168.x.x` with your HA instance's local IP address. The
+`access_token` template is resolved at fire-time, so you don't paste
+a captured value — HA reads the live attribute off the camera entity
+each time the automation runs.
 
 **Use the IP address, not `homeassistant.local`.** mDNS does not
 resolve across VLANs or subnets, so the Hub will fail to fetch the
 image if you use a hostname. The IP address works regardless of network
 topology as long as the Hub can reach your HA instance on port 8123.
 
-The access token is long-lived and stable across refreshes — unlike the
-`entity_picture` session token it does not rotate on each payload
-change, so you only need to paste it once. You can combine this action
-with Option A/B/C below in a single automation so the Hub shows the
-picture *and* speaks the forecast — either at the same moment, or
-serially (speak first, then show the picture). See "Chaining the
-spoken forecast and the outfit image" further down for the YAML
-shape.
+You can combine this action with Option A/B/C below in a single
+automation so the Hub shows the picture *and* speaks the forecast —
+either at the same moment, or serially (speak first, then show the
+picture). See "Chaining the spoken forecast and the outfit image"
+further down for the YAML shape.
 
 > **Note on external URLs.** If your Nest Hub cannot reach your HA
 > instance's local IP directly, use HA's external URL
@@ -247,17 +263,20 @@ Three things to know before you wire anything up:
   Device TTS, etc.), an HA automation playing the cached file will
   speak **yesterday's** briefing rather than staying silent. The
   simplest HA-side guard is a template condition gating on the prose
-  sensor's `last_changed` being recent — prose publishes on every
-  successful refresh, so:
+  sensor's `last_updated` being recent — prose publishes on every
+  successful refresh, and `last_updated` advances on every MQTT
+  receive (unlike `last_changed`, which only fires when the state
+  *value* changes and would silently reject a fresh WAV on a
+  back-to-back identical briefing):
 
   ```yaml
   conditions:
     - condition: template
       value_template: >
-        {{ (now() - states.sensor.clothescast_today.last_changed).total_seconds() < 1800 }}
+        {{ (now() - states.sensor.clothescast_today.last_updated).total_seconds() < 1800 }}
   ```
 
-  catches the "ClothesCast didn't fire at all" case. It does **not**
+  This catches the "ClothesCast didn't fire at all" case. It does **not**
   catch the "refreshed but audio missing" case (prose updates, audio
   doesn't) — for that, the cleanest fix is at the publisher, and
   there's currently no app-side flag to detect it from HA. If matching
@@ -679,9 +698,11 @@ actions:
         - Kitchen
   - action: media_player.play_media
     target:
-      entity_id: media_player.kitchen_hub
+      device_id: <your-hub-device-id>
     data:
-      media_content_id: "http://192.168.x.x:8123/api/camera_proxy/camera.clothescast_today_outfit?token=<access_token>"
+      media_content_id: >-
+        http://192.168.x.x:8123/api/camera_proxy/camera.clothescast_today_outfit?token={{
+        state_attr('camera.clothescast_today_outfit', 'access_token') }}
       media_content_type: image/png
 ```
 
@@ -719,9 +740,11 @@ actions:
   # 3. Push the outfit picture.
   - action: media_player.play_media
     target:
-      entity_id: media_player.kitchen_hub
+      device_id: <your-hub-device-id>
     data:
-      media_content_id: "http://192.168.x.x:8123/api/camera_proxy/camera.clothescast_today_outfit?token=<access_token>"
+      media_content_id: >-
+        http://192.168.x.x:8123/api/camera_proxy/camera.clothescast_today_outfit?token={{
+        state_attr('camera.clothescast_today_outfit', 'access_token') }}
       media_content_type: image/png
 ```
 
@@ -765,9 +788,11 @@ actions:
   # 3. Push the outfit picture.
   - action: media_player.play_media
     target:
-      entity_id: media_player.kitchen_hub
+      device_id: <your-hub-device-id>
     data:
-      media_content_id: "http://192.168.x.x:8123/api/camera_proxy/camera.clothescast_today_outfit?token=<access_token>"
+      media_content_id: >-
+        http://192.168.x.x:8123/api/camera_proxy/camera.clothescast_today_outfit?token={{
+        state_attr('camera.clothescast_today_outfit', 'access_token') }}
       media_content_type: image/png
 ```
 

--- a/docs/smart-home.md
+++ b/docs/smart-home.md
@@ -382,14 +382,22 @@ shell_command:
   fetch_clothescast_today_audio: >
     mosquitto_sub -h <broker-host> -u clothescast -P '<pass>'
     -t 'clothescast/insight/today/audio' -C 1 -W 5 -N
-    > /config/clothescast_today.wav.part
-    && mv /config/clothescast_today.wav.part /config/www/clothescast_today.wav
+    > clothescast_today.wav.part
+    && mv clothescast_today.wav.part www/clothescast_today.wav
   fetch_clothescast_tonight_audio: >
     mosquitto_sub -h <broker-host> -u clothescast -P '<pass>'
     -t 'clothescast/insight/tonight/audio' -C 1 -W 5 -N
-    > /config/clothescast_tonight.wav.part
-    && mv /config/clothescast_tonight.wav.part /config/www/clothescast_tonight.wav
+    > clothescast_tonight.wav.part
+    && mv clothescast_tonight.wav.part www/clothescast_tonight.wav
 ```
+
+The paths are **relative** on purpose. `shell_command:` runs with
+HA's config directory as the working directory, which is `/config/`
+on HAOS / HA Container but typically `~/.homeassistant/` on HA Core
+(or wherever you passed to `hass --config`). Relative paths
+(`clothescast_today.wav.part`, `www/clothescast_today.wav`) land
+correctly under whichever config directory HA is using; absolute
+`/config/…` paths only work on the container installs.
 
 A few small but important details in that command:
 
@@ -409,15 +417,14 @@ A few small but important details in that command:
   lands a stray byte after the `data` chunk that stricter players
   reject.
 - **The `> ….part && mv …` pattern matters.** A plain
-  `> /config/www/clothescast_today.wav` would truncate the live
-  file *before* `mosquitto_sub` ran, so a broker timeout or
-  unreachable host would leave HA serving a 0-byte WAV until the
-  next successful fetch. Writing to a `.part` file in `/config/`
-  (same filesystem as `/config/www/`, so `mv` is atomic) and only
-  renaming on `mosquitto_sub` exit 0 keeps the previous good WAV in
-  place when a fetch fails. `chmod` isn't needed — HA's default
-  umask gives the new file the same permissions as the rest of
-  `/config/www/`.
+  `> www/clothescast_today.wav` would truncate the live file
+  *before* `mosquitto_sub` ran, so a broker timeout or unreachable
+  host would leave HA serving a 0-byte WAV until the next successful
+  fetch. Writing to a `.part` file in the config-dir root (same
+  filesystem as `www/`, so `mv` is atomic) and only renaming on
+  `mosquitto_sub` exit 0 keeps the previous good WAV in place when
+  a fetch fails. `chmod` isn't needed — HA's default umask gives
+  the new file the same permissions as the rest of `www/`.
 
 Call `shell_command.fetch_clothescast_today_audio` as the first
 action of any automation that wants to play the latest audio (see

--- a/docs/smart-home.md
+++ b/docs/smart-home.md
@@ -287,9 +287,26 @@ directory, which HA serves at `http://<ha-ip>:8123/local/<filename>`.
 you don't already have it. The flow needs two nodes per period:
 
 ```
-[mqtt-in: clothescast/insight/today/audio]   → [file: /config/www/clothescast_today.wav   (overwrite, no newline)]
-[mqtt-in: clothescast/insight/tonight/audio] → [file: /config/www/clothescast_tonight.wav (overwrite, no newline)]
+[mqtt-in: clothescast/insight/today/audio]   → [file: <ha-config>/www/clothescast_today.wav   (overwrite, no newline)]
+[mqtt-in: clothescast/insight/tonight/audio] → [file: <ha-config>/www/clothescast_tonight.wav (overwrite, no newline)]
 ```
+
+Where `<ha-config>` is HA's config directory as the Node-RED add-on
+container sees it — which **depends on the add-on**:
+
+- Community add-on (`hassio-addons/addon-node-red`, the dominant one):
+  HA's config is mounted at `/config/`, so the file path is
+  `/config/www/clothescast_today.wav`.
+- Official Node-RED add-on (newer container framework): HA's config
+  is mounted at `/homeassistant/`, so the path is
+  `/homeassistant/www/clothescast_today.wav`. The add-on's own
+  config lives at `/config/` separately — writing there would put the
+  WAV under add-on storage, not where HA's `/local/` serves from.
+
+If unsure which you have, the add-on's "Documentation" tab on its
+add-on page lists its mount points; or try writing a small text file
+through Node-RED and check from HA's File Editor add-on whether it
+appears under `/config/www/` (HA-side path).
 
 In each MQTT-in node, set **Output: a Buffer** — not "auto-detect",
 which tries to JSON-decode the WAV and corrupts the file. In each
@@ -298,11 +315,25 @@ each payload". That's the whole bridge: every refresh ClothesCast
 publishes to the topic, Node-RED rewrites the file in place, and HA
 serves the new bytes from the same URL.
 
-**Alternative — `shell_command` + `mosquitto_sub`.** If you don't
-want Node-RED and your HA install has the Mosquitto client tools on
-the PATH HA sees (HAOS users may need to install them via the SSH
-& Web Terminal add-on with "Protection mode" off), add to
-`configuration.yaml`:
+**Alternative — `shell_command` + `mosquitto_sub`.** HA's
+`shell_command:` runs inside the `homeassistant` container, so
+`mosquitto_sub` must exist *there* — installing it via the SSH /
+Terminal add-on doesn't help, because that add-on is a separate
+container. This effectively limits the path to:
+
+- **HA Core installs**, where HA runs directly on the host and you
+  can install `mosquitto-clients` via the host's package manager
+  (`apt install mosquitto-clients`, etc.).
+- **HA Container installs** with a custom image that bakes
+  `mosquitto-clients` in (e.g. a `Dockerfile` that adds
+  `RUN apk add --no-cache mosquitto-clients` on top of
+  `ghcr.io/home-assistant/home-assistant`).
+
+**HAOS / HA Supervised installs can't reach `mosquitto_sub` from
+`shell_command`** — the `homeassistant` container is managed by
+Supervisor and not user-editable. Use the Node-RED bridge above
+instead. With that in mind, on a Core or custom-Container install,
+add to `configuration.yaml`:
 
 ```yaml
 shell_command:
@@ -694,12 +725,7 @@ triggers:
     at: "07:01:00"
 
 actions:
-  # 1. (Optional, shell_command bridge only.) Refresh the WAV from
-  #    the retained MQTT payload. Skip if you're using the Node-RED
-  #    bridge — it rewrites the file on every publish already.
-  - action: shell_command.fetch_clothescast_today_audio
-
-  # 2. Speak the Gemini-rendered briefing.
+  # 1. Speak the Gemini-rendered briefing.
   - action: media_player.play_media
     target:
       entity_id: media_player.kitchen_hub
@@ -707,13 +733,13 @@ actions:
       media_content_id: "http://192.168.x.x:8123/local/clothescast_today.wav"
       media_content_type: music
 
-  # 3. Wait for the audio to finish before swapping in the picture.
+  # 2. Wait for the audio to finish before swapping in the picture.
   #    No SDK preamble on this path, so 15 s is usually plenty for a
   #    full briefing. Pad longer if you've enabled the calendar
   #    tie-in clause and your evenings get talky.
   - delay: "00:00:15"
 
-  # 4. Push the outfit picture.
+  # 3. Push the outfit picture.
   - action: media_player.play_media
     target:
       entity_id: media_player.kitchen_hub
@@ -721,6 +747,22 @@ actions:
       media_content_id: "http://192.168.x.x:8123/api/camera_proxy/camera.clothescast_today_outfit?token=<access_token>"
       media_content_type: image/png
 ```
+
+The YAML above assumes the Node-RED bridge is keeping the WAV at
+`/local/clothescast_today.wav` fresh. **If you went with the
+`shell_command` bridge instead**, prepend a refresh step *before*
+the `play_media` audio call so the retained MQTT payload is copied
+to the live file first:
+
+```yaml
+actions:
+  - action: shell_command.fetch_clothescast_today_audio
+  # …then the same three steps from above (speak / delay / image)
+```
+
+Don't paste that line in if you're not running the `shell_command`
+bridge — HA errors on the unknown action and the automation stops
+before the speaker plays anything.
 
 > **Edge case — speaker was already playing music (Option B
 > specifically).** Music Assistant restores the prior playback

--- a/docs/smart-home.md
+++ b/docs/smart-home.md
@@ -196,21 +196,6 @@ Reload MQTT (Developer Tools → YAML → Reload MQTT) or restart HA so
 the entities appear as `camera.clothescast_today_outfit` and
 `camera.clothescast_tonight_outfit`.
 
-Then find the Cast **device ID** for the Hub you want to push to:
-Settings → Devices & Services → **Google Cast** → tap your Hub —
-the browser URL bar now shows `…/config/devices/device/<id>`. Copy
-the hex string after `/device/` — that's what the automation will
-target.
-
-> **Why device, not entity?** Audio play_media on a Nest Hub works
-> fine targeted at the Hub's `media_player.*` entity, but images
-> only render when the action targets the underlying *device*. HA's
-> Cast integration routes image content through a separate
-> device-level Cast API; `entity_id:` targeting silently no-ops on
-> the display (the action "succeeds", the picture never appears).
-> If you ever see "URL works in a browser, image stays blank on the
-> Hub", swapping `entity_id:` for `device_id:` is the fix.
-
 You don't need to copy the camera entity's `access_token` — the
 automation pulls it dynamically with `state_attr(…, 'access_token')`
 at fire-time, so token rotation across HA restarts is handled
@@ -232,7 +217,7 @@ conditions: []
 actions:
   - action: media_player.play_media
     target:
-      device_id: <your-hub-device-id>
+      entity_id: media_player.kitchen_hub
     data:
       media_content_id: >-
         http://192.168.x.x:8123/api/camera_proxy/camera.clothescast_today_outfit?token={{
@@ -240,8 +225,9 @@ actions:
       media_content_type: image/png
 ```
 
-Replace `<your-hub-device-id>` with the device ID you copied above
-and `192.168.x.x` with your HA instance's local IP address. The
+Replace `media_player.kitchen_hub` with your actual Nest Hub entity
+ID (find it under Settings → Devices & Services → Google Cast) and
+`192.168.x.x` with your HA instance's local IP address. The
 `access_token` template is resolved at fire-time, so you don't paste
 a captured value — HA reads the live attribute off the camera entity
 each time the automation runs.
@@ -734,7 +720,7 @@ actions:
         - Kitchen
   - action: media_player.play_media
     target:
-      device_id: <your-hub-device-id>
+      entity_id: media_player.kitchen_hub
     data:
       media_content_id: >-
         http://192.168.x.x:8123/api/camera_proxy/camera.clothescast_today_outfit?token={{
@@ -776,7 +762,7 @@ actions:
   # 3. Push the outfit picture.
   - action: media_player.play_media
     target:
-      device_id: <your-hub-device-id>
+      entity_id: media_player.kitchen_hub
     data:
       media_content_id: >-
         http://192.168.x.x:8123/api/camera_proxy/camera.clothescast_today_outfit?token={{
@@ -824,7 +810,7 @@ actions:
   # 3. Push the outfit picture.
   - action: media_player.play_media
     target:
-      device_id: <your-hub-device-id>
+      entity_id: media_player.kitchen_hub
     data:
       media_content_id: >-
         http://192.168.x.x:8123/api/camera_proxy/camera.clothescast_today_outfit?token={{

--- a/docs/smart-home.md
+++ b/docs/smart-home.md
@@ -225,10 +225,10 @@ ClothesCast publishes the synthesised audio as a WAV clip to
 The payload is signed 16-bit mono PCM at the sample rate Gemini
 returned, wrapped in a canonical 44-byte RIFF/WAVE header — playable
 as-is by ffmpeg, browsers, and `media_player.play_media` when handed
-via an HTTP fetch (HA doesn't read MQTT binary payloads directly into
-the media player). It's exactly the bytes the phone speaks, so any
-"speak it on the Hub" automation built around the prose sensor or one
-of the TTS options below stays in lockstep with the phone.
+via an HTTP fetch. It's exactly the bytes the phone speaks, so the
+Hub stays in lockstep with the phone without HA re-synthesising the
+prose through its own TTS stack — same Gemini voice, same prosody,
+no Google-broadcast preamble.
 
 Two things to know before you wire anything up:
 
@@ -241,13 +241,150 @@ Two things to know before you wire anything up:
   the Hub gets the clip. Toggle that off if you want the Hub to speak
   even when you're home.
 
-The simplest way to make the Hub actually speak is still options A /
-B / C below: trigger an automation on the prose sensor's update and
-let HA's TTS service synthesise — that path is already paved end to
-end. The audio topic is here for setups that already prefer a fixed
-voice clip over re-synthesising in HA (e.g. `music_assistant.play_announcement`
-→ media URL flows), and for users who want to capture the rendered
-briefing for their own pipelines.
+If you'd rather have HA re-synthesise the prose sensor through its
+own TTS (Google Translate, Nabu Casa, etc.), skip this section and
+use options A / B / C below — those paths key off the prose sensor
+and don't need the audio topic at all. This section is the path for
+playing **the same bytes the phone speaks**.
+
+### Bridging the WAV bytes to an HTTP URL
+
+HA's `media_player.play_media` action takes a URL it can fetch over
+HTTP, not an MQTT topic — there's no `mqtt.audio` platform analogous
+to `mqtt.camera`. So the first step is a small bridge that copies
+the retained MQTT WAV payload to a file under HA's `/config/www/`
+directory, which HA serves at `http://<ha-ip>:8123/local/<filename>`.
+
+> **Privacy: `/local/` is unauthenticated.** Unlike the
+> `camera_proxy?token=…` URL the outfit-image recipe uses, files under
+> `/config/www/` are served by HA's static-file route with **no auth**.
+> Anyone who can reach the URL — anyone on the LAN, or anyone on the
+> internet if you've exposed HA externally — can fetch the latest
+> briefing if they know (or guess) the filename. The audio is the
+> rendered insight prose your phone speaks, including any
+> calendar-tie-in clause you've enabled, so treat it like the same
+> sensitivity class as the prose topic itself (see
+> [PRIVACY.md](../PRIVACY.md)). Recommendations:
+>
+> - **Keep this on the LAN.** Don't swap the IP for HA's external URL
+>   on the WAV's `media_content_id` the way the outfit-image example
+>   does — the camera-proxy URL has a per-entity access token; the
+>   `/local/` URL doesn't.
+> - **Pick a non-guessable filename** if the LAN itself is shared
+>   (housemates, guest Wi-Fi on the same VLAN). e.g.
+>   `/config/www/cc-<random-hex>.wav`. The URL still has to be a fixed
+>   string in the automation, but it's no longer a guessable default.
+> - **Or skip this section entirely** and use options A / B / C below.
+>   Those don't expose a fetchable WAV on the LAN at all — but they
+>   don't keep the prose on-device either; A sends it to Google's
+>   broadcast service, B to whichever HA TTS engine you've
+>   configured (Nabu Casa, Google Translate), C the same. That's a
+>   separate privacy surface (TTS-provider logging) to weigh against
+>   the on-LAN fetch surface this section opens.
+
+**Recommended — Node-RED.** Install the **Node-RED** add-on
+(Settings → Add-ons → Add-on Store → Node-RED → Install → Start) if
+you don't already have it. The flow needs two nodes per period:
+
+```
+[mqtt-in: clothescast/insight/today/audio]   → [file: /config/www/clothescast_today.wav   (overwrite, no newline)]
+[mqtt-in: clothescast/insight/tonight/audio] → [file: /config/www/clothescast_tonight.wav (overwrite, no newline)]
+```
+
+In each MQTT-in node, set **Output: a Buffer** — not "auto-detect",
+which tries to JSON-decode the WAV and corrupts the file. In each
+File node, set Action to "overwrite file" and untick "Add newline to
+each payload". That's the whole bridge: every refresh ClothesCast
+publishes to the topic, Node-RED rewrites the file in place, and HA
+serves the new bytes from the same URL.
+
+**Alternative — `shell_command` + `mosquitto_sub`.** If you don't
+want Node-RED and your HA install has the Mosquitto client tools on
+the PATH HA sees (HAOS users may need to install them via the SSH
+& Web Terminal add-on with "Protection mode" off), add to
+`configuration.yaml`:
+
+```yaml
+shell_command:
+  fetch_clothescast_today_audio: >
+    mosquitto_sub -h <broker-host> -u clothescast -P '<pass>'
+    -t 'clothescast/insight/today/audio' -C 1 -W 5 -N
+    > /config/clothescast_today.wav.part
+    && mv /config/clothescast_today.wav.part /config/www/clothescast_today.wav
+  fetch_clothescast_tonight_audio: >
+    mosquitto_sub -h <broker-host> -u clothescast -P '<pass>'
+    -t 'clothescast/insight/tonight/audio' -C 1 -W 5 -N
+    > /config/clothescast_tonight.wav.part
+    && mv /config/clothescast_tonight.wav.part /config/www/clothescast_tonight.wav
+```
+
+A few small but important details in that command:
+
+- **Single-quote the password substitution.** The `<pass>` placeholder
+  is wrapped in single quotes (`-P '<pass>'`) so a strong password
+  containing shell metacharacters — `&`, `$`, spaces, `|`, etc. — is
+  passed to `mosquitto_sub` literally instead of being expanded or
+  split by HA's shell. If your actual password contains a literal
+  single quote, escape it the standard way (`'\''`) or rotate to a
+  password that doesn't.
+- `-C 1` exits after the first message; `-W 5` caps the wait at 5
+  seconds. The audio topic is retained, so the broker hands you the
+  latest WAV the moment you subscribe — no need to subscribe
+  continuously.
+- **`-N` is essential.** Without it, `mosquitto_sub` appends a
+  trailing `\n` to every printed message, which for a binary WAV
+  lands a stray byte after the `data` chunk that stricter players
+  reject.
+- **The `> ….part && mv …` pattern matters.** A plain
+  `> /config/www/clothescast_today.wav` would truncate the live
+  file *before* `mosquitto_sub` ran, so a broker timeout or
+  unreachable host would leave HA serving a 0-byte WAV until the
+  next successful fetch. Writing to a `.part` file in `/config/`
+  (same filesystem as `/config/www/`, so `mv` is atomic) and only
+  renaming on `mosquitto_sub` exit 0 keeps the previous good WAV in
+  place when a fetch fails. `chmod` isn't needed — HA's default
+  umask gives the new file the same permissions as the rest of
+  `/config/www/`.
+
+Call `shell_command.fetch_clothescast_today_audio` as the first
+action of any automation that wants to play the latest audio (see
+the chaining example further down).
+
+### Playing the WAV on a Nest Hub or other speaker
+
+Once `/config/www/clothescast_today.wav` exists, point
+`media_player.play_media` at it via the `/local/` HTTP path. Use
+`media_content_type: music` so Cast treats it as audio rather than
+guessing from the URL:
+
+```yaml
+alias: Speak Gemini forecast on kitchen Hub at 07:01
+description: ""
+mode: single
+
+triggers:
+  - trigger: time
+    at: "07:01:00"
+
+actions:
+  - action: media_player.play_media
+    target:
+      entity_id: media_player.kitchen_hub
+    data:
+      media_content_id: "http://192.168.x.x:8123/local/clothescast_today.wav"
+      media_content_type: music
+```
+
+One URL caveat carries over from the camera-proxy automation — use
+the IP, not `homeassistant.local` (mDNS doesn't cross VLANs). The
+other one does **not**: don't substitute HA's external URL here the
+way the image example allows. The camera-proxy URL carries an access
+token; `/local/` doesn't, so swapping in `https://your-ha.duckdns.org`
+would publish the latest briefing at an unauthenticated
+internet-reachable URL. If your Hub can't reach the LAN IP, keep the
+audio path on the LAN and use one of the HA-TTS options (A / B / C)
+for the spoken briefing instead. The chaining example below combines
+the local-IP play with the outfit-image push.
 
 ## Home Assistant — speaking the sensor on Google Home
 
@@ -458,12 +595,14 @@ at the same moment or one after the other.
 Both examples below use the Option A (`notify.google_assistant_sdk`)
 shape, since that's the path verified end-to-end on this project's
 own setup. The picker below the serial example covers what to swap
-in if you're on Option B or C instead. Each TTS service expects a
-different `data:` shape — `target:` for Option A,
-`media_player_entity_id:` for B, `entity_id:` for C — so don't
-hot-swap the service inside an example; copy the YAML for the
-service you're actually using from the option section above and
-slot it into the chaining shape.
+in if you're on Option B or C, plus a variant for playing the
+Gemini-rendered WAV from the audio topic instead of having HA
+re-synthesise the prose. Each TTS service expects a different
+`data:` shape — `target:` for Option A, `media_player_entity_id:`
+for B, `entity_id:` for C, `media_content_id:` for the audio-topic
+variant — so don't hot-swap the service inside an example; copy the
+YAML for the path you're actually using from the option section
+above and slot it into the chaining shape.
 
 **Parallel — speak and show together.** Drop both actions in the same
 `actions:` list with no wait between them. Cast pipes the TTS to the
@@ -537,6 +676,52 @@ with the Option B or Option C YAML from those sections. The fixed
 `delay:` in step 2 stays as-is — it works for any TTS service that
 takes roughly a known time to speak.
 
+**Variant — Gemini-rendered audio in place of HA TTS.** If you've
+set up the audio-topic bridge from "TTS audio clip on the audio
+topic" above, swap step 1 for a `media_player.play_media` call
+against the `/local/clothescast_today.wav` URL. The result speaks
+the same Gemini voice as the phone, with no broadcast preamble — but
+the audio rides the same Cast pipe as the image push, so parallel
+isn't safe here; the second `play_media` call would overwrite the
+first. Use the serial shape only:
+
+```yaml
+alias: ClothesCast (Gemini audio + image) on kitchen Hub at 07:01
+mode: single
+
+triggers:
+  - trigger: time
+    at: "07:01:00"
+
+actions:
+  # 1. (Optional, shell_command bridge only.) Refresh the WAV from
+  #    the retained MQTT payload. Skip if you're using the Node-RED
+  #    bridge — it rewrites the file on every publish already.
+  - action: shell_command.fetch_clothescast_today_audio
+
+  # 2. Speak the Gemini-rendered briefing.
+  - action: media_player.play_media
+    target:
+      entity_id: media_player.kitchen_hub
+    data:
+      media_content_id: "http://192.168.x.x:8123/local/clothescast_today.wav"
+      media_content_type: music
+
+  # 3. Wait for the audio to finish before swapping in the picture.
+  #    No SDK preamble on this path, so 15 s is usually plenty for a
+  #    full briefing. Pad longer if you've enabled the calendar
+  #    tie-in clause and your evenings get talky.
+  - delay: "00:00:15"
+
+  # 4. Push the outfit picture.
+  - action: media_player.play_media
+    target:
+      entity_id: media_player.kitchen_hub
+    data:
+      media_content_id: "http://192.168.x.x:8123/api/camera_proxy/camera.clothescast_today_outfit?token=<access_token>"
+      media_content_type: image/jpeg
+```
+
 > **Edge case — speaker was already playing music (Option B
 > specifically).** Music Assistant restores the prior playback
 > *after* the announcement finishes, so if the Hub was playing
@@ -574,9 +759,10 @@ property that applies to any wait shape.)
 
 > **What's verified.** The Option A (`notify.google_assistant_sdk`)
 > path above is the one this project's author runs day-to-day. The
-> Option B and C variants follow current HA service shapes but
-> haven't been tested end-to-end on this setup — if you wire one up
-> and find a wrinkle, a PR-fix is welcome.
+> Option B / C and Gemini-audio variants follow current HA service
+> shapes and the audio topic's documented payload, but haven't been
+> tested end-to-end on this setup — if you wire one up and find a
+> wrinkle, a PR-fix is welcome.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

The PR has grown beyond the original "document the Gemini TTS audio
topic" scope as real-world wiring surfaced several latent bugs in the
existing outfit-image recipe and review feedback caught a stack of
related cleanups. Five commits, each landable as a unit:

1. **`6d2162f` — Document how to play the Gemini TTS WAV.** The
   "TTS audio clip on the audio topic" section used to describe the
   payload then punt to options A/B/C for actually making a Hub
   speak. Replaced with a concrete Node-RED bridge recipe
   (`<ha-config>/www/clothescast_*.wav`, Buffer-output gotcha
   called out) and a `shell_command` + `mosquitto_sub` fallback
   (single-quoted password, `-N` to suppress trailing newline,
   temp-file + `mv` so a broker timeout doesn't truncate the live
   WAV). Includes the privacy callout for `/local/` being
   unauthenticated, and a Gemini-audio variant in the chaining
   section. Six rounds of Codex P2 feedback addressed and squashed
   into this commit.

2. **`d061c89` — Fix outfit-image content type.** The bytes are PNG
   (`GarmentRender.kt:370` is `Bitmap.CompressFormat.PNG`); every
   `media_player.play_media` example was declaring `image/jpeg`,
   which some Hub firmware silently refuses to render. Restored
   `image/png` for all four image play_media calls and the one
   prose mention.

3. **`5716c4e` — Tighten Node-RED path, shell_command caveats,
   and chaining example.** Three Codex P2s: the Node-RED add-on's
   `/config` mount differs between the community add-on (mounts
   HA's config there) and the newer official add-on (HA's config
   moves to `/homeassistant/`); HA's `shell_command:` runs in the
   `homeassistant` container — installing mosquitto-clients via the
   SSH/Terminal add-on doesn't help, so HAOS users are now steered
   to Node-RED; the Gemini-audio chaining example's
   `shell_command.fetch_*` line is now a separate "prepend if you
   used the shell bridge" snippet, since HA doesn't honour YAML
   comments and a copy-pasted block with an undefined action errors
   on the first step.

4. **`72694eb` — Note the retained-WAV staleness gotcha.** When a
   refresh doesn't generate audio (skip-TTS-at-home suppressed it,
   Gemini fell back to Device TTS), the publisher never overwrites
   the retained MQTT WAV. A fixed-time HA automation playing the
   cached file would speak yesterday's briefing. Added a third
   bullet to the "Things to know" intro with a template-condition
   freshness guard and an honest caveat that catching "refreshed
   but audio missing" needs a publisher-side fix that's out of
   scope here.

5. **`7db5de3c` — Target Hub by device_id; template the access_token;
   `last_changed` → `last_updated`.** Three more real-world findings:

   - Cast image play_media silently no-ops when targeted at the
     Hub's `media_player.*` entity. HA routes image content through
     a device-level Cast API. Targeting `device_id:` (not
     `entity_id:`) reaches it and the picture renders. Audio
     play_media keeps `entity_id:` — it works fine there.
   - Camera `access_token` is not actually stable across HA
     restarts. Templating it directly into the URL with
     `?token={{ state_attr(..., 'access_token') }}` sidesteps
     rotation entirely.
   - Codex P2: `last_changed` only advances when the state value
     changes, so a back-to-back identical briefing would keep the
     freshness guard stale; swapped to `last_updated` which
     advances on every MQTT receive.

Eleven Codex P2 threads addressed across the branch — all replied
to on the threads themselves. No production code change, no Play
changelog impact (docs paths are filtered by CI).

## Test plan

- [x] `git diff` reads cleanly; rendered Markdown structure intact.
- [x] PNG-fix + device_id + token-template combination verified by
      the author against a real Nest Hub.
- [ ] Reviewer: spot-check the Node-RED node-config wording against
      the current Node-RED palette.
- [ ] Reviewer: confirm the `shell_command` recipe matches your HA
      install's `mosquitto_sub` availability (HA Core or custom HA
      Container; not HAOS).
- [ ] Follow-up code change (separate PR): publish a sentinel /
      clear the retained audio topic when a refresh doesn't
      generate audio, so the HA-side freshness guard catches the
      "refreshed but audio missing" case too.
