### PR TITLE
Smart Home outfit image honours birthday and holiday themes

### DIFF
--- a/app/src/main/kotlin/app/clothescast/MainActivity.kt
+++ b/app/src/main/kotlin/app/clothescast/MainActivity.kt
@@ -31,6 +31,8 @@ import androidx.glance.appwidget.updateAll
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.work.WorkManager
+import app.clothescast.calendar.resolveHolidayTheme
+import app.clothescast.core.domain.model.OutfitSuggestion
 import app.clothescast.core.domain.model.ThemeMode
 import app.clothescast.locale.AppLocale
 import app.clothescast.location.LocationResolver
@@ -387,6 +389,22 @@ private fun ClothesCastNav(app: ClothesCastApplication, navigateToTodayVersion: 
                                     if (insight.period == ForecastPeriod.TODAY) R.string.outfit_card_header_today
                                     else R.string.outfit_card_header_tonight
                                 )
+                                // Apply today's holiday / birthday theme on
+                                // top of the user's outfit colours — same
+                                // merge FetchAndNotifyWorker.deliver does for
+                                // the scheduled publish. Without it the
+                                // user-initiated refresh would overwrite the
+                                // worker's themed retained image with an
+                                // unthemed one.
+                                val theme = resolveHolidayTheme(prefs, app.calendarEventReader)
+                                val topColors: Map<OutfitSuggestion.Top, Long> =
+                                    prefs.outfitTopColors + (theme?.topOverrides ?: emptyMap())
+                                val bottomColors: Map<OutfitSuggestion.Bottom, Long> =
+                                    prefs.outfitBottomColors + (theme?.bottomOverrides ?: emptyMap())
+                                val topStrokes: Map<OutfitSuggestion.Top, Long> =
+                                    theme?.topStrokeOverrides ?: emptyMap()
+                                val bottomStrokes: Map<OutfitSuggestion.Bottom, Long> =
+                                    theme?.bottomStrokeOverrides ?: emptyMap()
                                 val png = renderOutfitCard(
                                     context = context,
                                     outfit = outfit,
@@ -396,8 +414,10 @@ private fun ClothesCastNav(app: ClothesCastApplication, navigateToTodayVersion: 
                                     rainLine = info.rainLine,
                                     tempFillFraction = info.tempFillFraction,
                                     rainFillFraction = info.rainFillFraction,
-                                    topColors = prefs.outfitTopColors,
-                                    bottomColors = prefs.outfitBottomColors,
+                                    topColors = topColors,
+                                    bottomColors = bottomColors,
+                                    topStrokes = topStrokes,
+                                    bottomStrokes = bottomStrokes,
                                 )
                                 app.mqttPublisher.publishImageIfEnabled(insight.period, png)
                             }

--- a/app/src/main/kotlin/app/clothescast/calendar/HolidayThemeResolver.kt
+++ b/app/src/main/kotlin/app/clothescast/calendar/HolidayThemeResolver.kt
@@ -1,0 +1,52 @@
+package app.clothescast.calendar
+
+import app.clothescast.core.domain.model.HolidayCatalog
+import app.clothescast.core.domain.model.HolidayTheme
+import app.clothescast.core.domain.model.UserPreferences
+import app.clothescast.core.domain.repository.CalendarEventReader
+import app.clothescast.core.domain.usecase.ThemeForToday
+import app.clothescast.tts.toJavaLocale
+import java.time.LocalDate
+import java.util.Locale
+
+/**
+ * Resolves today's holiday / birthday theme for off-screen renderers (the
+ * notification large icon, the Home-Assistant outfit card published over
+ * MQTT, the widget). Mirrors the same merge [app.clothescast.ui.today.TodayViewModel]
+ * performs at composition time so background and manual publishes share
+ * the Today screen's palette — without it, themed days silently fall back
+ * to the user's default outfit colours.
+ *
+ * Calendar events are only read when the user has opted into
+ * calendar-sourced theming; the read is wrapped in [runCatching] so a
+ * missing READ_CALENDAR permission silently falls through to "no events".
+ */
+suspend fun resolveHolidayTheme(
+    prefs: UserPreferences,
+    calendarEventReader: CalendarEventReader,
+): HolidayTheme? {
+    val today = LocalDate.now(prefs.schedule.zoneId)
+    val needEvents = prefs.themeFromCalendarHolidays || prefs.themeFromCalendarBirthdays
+    val events = if (needEvents) {
+        runCatching {
+            calendarEventReader.eventsForDay(today, prefs.schedule.zoneId)
+        }.getOrDefault(emptyList())
+    } else {
+        emptyList()
+    }
+    val localeCountry = prefs.region.toJavaLocale()?.country
+        ?: Locale.getDefault().country
+    val effectiveCountries = prefs.holidayCountrySelection.resolveEnabledCountries(
+        localeCountry = localeCountry,
+        weatherLocationCountry = prefs.location?.countryCode,
+        allCountries = HolidayCatalog.allCountries,
+    )
+    return ThemeForToday().resolve(
+        date = today,
+        overrides = prefs.holidayOverrides,
+        enabledCountries = effectiveCountries,
+        events = events,
+        themeFromCalendarHolidays = prefs.themeFromCalendarHolidays,
+        themeFromCalendarBirthdays = prefs.themeFromCalendarBirthdays,
+    )
+}

--- a/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
@@ -18,16 +18,13 @@ import androidx.work.workDataOf
 import app.clothescast.ClothesCastApplication
 import app.clothescast.core.domain.model.DeliveryMode
 import app.clothescast.core.domain.model.ForecastPeriod
-import app.clothescast.core.domain.model.HolidayCatalog
-import app.clothescast.core.domain.model.HolidayTheme
 import app.clothescast.core.domain.model.Insight
 import app.clothescast.core.domain.model.Location
 import app.clothescast.core.domain.model.OutfitSuggestion
 import app.clothescast.core.domain.model.TtsEngine
 import app.clothescast.core.domain.model.UserPreferences
-import app.clothescast.core.domain.usecase.ThemeForToday
+import app.clothescast.calendar.resolveHolidayTheme
 import app.clothescast.core.domain.usecase.shouldSpeak
-import app.clothescast.tts.toJavaLocale
 import app.clothescast.core.data.tts.WavEncoder
 import app.clothescast.data.InsightCache
 import app.clothescast.mqtt.MqttPublishOutcome
@@ -55,7 +52,6 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import java.io.IOException
 import java.time.LocalDate
-import java.util.Locale
 import java.util.concurrent.TimeUnit
 import kotlin.math.cos
 import kotlin.math.sqrt
@@ -556,40 +552,6 @@ class FetchAndNotifyWorker(
         }
     }
 
-    /**
-     * Mirrors [TodayViewModel]'s holiday-theme resolution so the worker's
-     * notification / MQTT card pick up the same palette the Today screen
-     * draws. Calendar events are only read when the user has opted into
-     * calendar-sourced theming; the read is wrapped in [runCatching] so a
-     * missing READ_CALENDAR permission silently falls through to "no events".
-     */
-    private suspend fun resolveHolidayTheme(prefs: UserPreferences): HolidayTheme? {
-        val today = LocalDate.now(prefs.schedule.zoneId)
-        val needEvents = prefs.themeFromCalendarHolidays || prefs.themeFromCalendarBirthdays
-        val events = if (needEvents) {
-            runCatching {
-                app.calendarEventReader.eventsForDay(today, prefs.schedule.zoneId)
-            }.getOrDefault(emptyList())
-        } else {
-            emptyList()
-        }
-        val localeCountry = prefs.region.toJavaLocale()?.country
-            ?: Locale.getDefault().country
-        val effectiveCountries = prefs.holidayCountrySelection.resolveEnabledCountries(
-            localeCountry = localeCountry,
-            weatherLocationCountry = prefs.location?.countryCode,
-            allCountries = HolidayCatalog.allCountries,
-        )
-        return ThemeForToday().resolve(
-            date = today,
-            overrides = prefs.holidayOverrides,
-            enabledCountries = effectiveCountries,
-            events = events,
-            themeFromCalendarHolidays = prefs.themeFromCalendarHolidays,
-            themeFromCalendarBirthdays = prefs.themeFromCalendarBirthdays,
-        )
-    }
-
     private suspend fun deliver(insight: Insight, prefs: UserPreferences, prose: String) {
         // Apply today's holiday theme on top of the user's persisted outfit
         // colour customisations so the notification's large icon and the
@@ -599,8 +561,10 @@ class FetchAndNotifyWorker(
         // New Year's. The screen's TodayViewModel does the same merge;
         // without it the off-screen renderers would silently fall back to
         // user defaults (or the auto-derived darker-shade stroke) on
-        // themed days.
-        val theme = resolveHolidayTheme(prefs)
+        // themed days. The manual "Publish now" path in MainActivity uses
+        // the same helper so the retained MQTT image stays themed after a
+        // user-initiated refresh too.
+        val theme = resolveHolidayTheme(prefs, app.calendarEventReader)
         val topColors: Map<OutfitSuggestion.Top, Long> =
             prefs.outfitTopColors + (theme?.topOverrides ?: emptyMap())
         val bottomColors: Map<OutfitSuggestion.Bottom, Long> =

--- a/app/src/test/kotlin/app/clothescast/calendar/HolidayThemeResolverTest.kt
+++ b/app/src/test/kotlin/app/clothescast/calendar/HolidayThemeResolverTest.kt
@@ -1,0 +1,86 @@
+package app.clothescast.calendar
+
+import app.clothescast.core.domain.model.CalendarEvent
+import app.clothescast.core.domain.model.DeliveryMode
+import app.clothescast.core.domain.model.DistanceUnit
+import app.clothescast.core.domain.model.EventKind
+import app.clothescast.core.domain.model.HolidayId
+import app.clothescast.core.domain.model.Schedule
+import app.clothescast.core.domain.model.TemperatureUnit
+import app.clothescast.core.domain.model.UserPreferences
+import app.clothescast.core.domain.repository.CalendarEventReader
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import java.time.LocalDate
+import java.time.LocalTime
+import java.time.ZoneId
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+
+/**
+ * Covers the shared theme-resolver used by [app.clothescast.work.FetchAndNotifyWorker]
+ * (scheduled MQTT image publish) and [app.clothescast.MainActivity] (manual
+ * "Publish now" button). Before the helper existed the manual path skipped
+ * theme resolution entirely, so a user's birthday calendar event made the
+ * notification yellow/magenta but pressing "Publish now" overwrote the
+ * retained MQTT image with the unthemed user defaults.
+ */
+class HolidayThemeResolverTest {
+    private val basePrefs = UserPreferences(
+        schedule = Schedule(time = LocalTime.of(7, 0), days = Schedule.EVERY_DAY, zoneId = ZoneId.of("UTC")),
+        deliveryMode = DeliveryMode.NOTIFICATION_AND_TTS,
+        temperatureUnit = TemperatureUnit.CELSIUS,
+        distanceUnit = DistanceUnit.KILOMETERS,
+        clothesRules = emptyList(),
+    )
+
+    @Test
+    fun `birthday event resolves to a synthetic birthday theme`() = runBlocking {
+        val prefs = basePrefs.copy(themeFromCalendarBirthdays = true)
+        val reader = object : CalendarEventReader {
+            override suspend fun eventsForDay(date: LocalDate, zoneId: ZoneId): List<CalendarEvent> =
+                listOf(
+                    CalendarEvent(
+                        title = "Alex's birthday",
+                        start = LocalTime.MIDNIGHT,
+                        end = LocalTime.MIDNIGHT,
+                        allDay = true,
+                        kind = EventKind.BIRTHDAY,
+                    ),
+                )
+        }
+
+        val theme = resolveHolidayTheme(prefs, reader)
+
+        theme.shouldNotBeNull()
+        theme.id shouldBe HolidayId.BIRTHDAY
+        (theme.topOverrides.isNotEmpty()) shouldBe true
+        (theme.bottomOverrides.isNotEmpty()) shouldBe true
+    }
+
+    @Test
+    fun `calendar reader is skipped when both toggles are off`() = runBlocking {
+        val prefs = basePrefs.copy(
+            themeFromCalendarBirthdays = false,
+            themeFromCalendarHolidays = false,
+        )
+        val reader = object : CalendarEventReader {
+            override suspend fun eventsForDay(date: LocalDate, zoneId: ZoneId): List<CalendarEvent> =
+                error("reader must not be queried when both calendar toggles are off")
+        }
+
+        resolveHolidayTheme(prefs, reader).shouldBeNull()
+    }
+
+    @Test
+    fun `reader failure falls through to no theme rather than propagating`() = runBlocking {
+        val prefs = basePrefs.copy(themeFromCalendarBirthdays = true)
+        val reader = object : CalendarEventReader {
+            override suspend fun eventsForDay(date: LocalDate, zoneId: ZoneId): List<CalendarEvent> =
+                throw SecurityException("READ_CALENDAR not granted")
+        }
+
+        resolveHolidayTheme(prefs, reader).shouldBeNull()
+    }
+}


### PR DESCRIPTION
## Summary

- The scheduled MQTT image publish (`FetchAndNotifyWorker.deliver`) already merged today's `HolidayTheme` overrides onto the user's outfit colours, so notifications and the Home-Assistant retained image went birthday yellow / Christmas red on themed days. The Settings → Smart Home → **Publish now** button took a different code path (`MainActivity.fullPublish`) that skipped the theme merge entirely.
- Result: a user-initiated refresh overwrote the worker's themed retained image with the unthemed user defaults. Birthday and holiday themes appeared to vanish after the user asked for a fresh push, and because MQTT publishes are retained, the topic stayed unthemed (or "stale" — same image, wrong palette) until the next scheduled worker run.
- Fix: extracted the worker's private `resolveHolidayTheme` into a shared top-level suspend function (`app.clothescast.calendar.resolveHolidayTheme`) and routed both call sites through it. Three new unit tests cover the birthday-resolves-to-theme, both-toggles-off-skips-reader, and reader-failure-falls-through cases.

## Privacy

No new data crosses the device boundary. The calendar read was already happening on the scheduled path; the manual path now does the same on-device classification (event title → `EventKind.BIRTHDAY` / `PUBLIC_HOLIDAY`) and only the resulting palette flows into the PNG. The PNG itself was already being published — the change only fixes the colours inside it.

## Test plan

- [x] `./gradlew :core:domain:test :core:data:test :app:testDebugUnitTest :app:assembleDebug` (full CI-equivalent, locally green)
- [x] New `HolidayThemeResolverTest` covers the helper's three branches
- [ ] On a device with `themeFromCalendarBirthdays` on and a calendar birthday today, press Settings → Smart Home → Publish now and confirm the HA `image.*` entity flips to the birthday palette (yellow top + magenta bottom)
- [ ] With both toggles off, confirm the manual publish still emits the user's default outfit colours (no theme merge attempted)

https://claude.ai/code/session_01Cv6jCnTi4MDrS4beBqkgwR

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cv6jCnTi4MDrS4beBqkgwR)_