### PR TITLE
Prepare to cast outfits to your smart displays

### DIFF
--- a/app/src/main/kotlin/app/clothescast/cast/CastMediaServer.kt
+++ b/app/src/main/kotlin/app/clothescast/cast/CastMediaServer.kt
@@ -1,0 +1,162 @@
+package app.clothescast.cast
+
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.call
+import io.ktor.server.cio.CIO
+import io.ktor.server.engine.EmbeddedServer
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.response.respond
+import io.ktor.server.response.respondBytes
+import io.ktor.server.routing.get
+import io.ktor.server.routing.routing
+import java.net.ServerSocket
+import java.security.SecureRandom
+
+/**
+ * Tiny HTTP server that exposes one outfit PNG and one TTS WAV to a Cast
+ * receiver on the same LAN. Cast receivers fetch media by URL — they
+ * don't accept raw bytes pushed from the sender — so the phone briefly
+ * hosts the two payloads at per-publish, token-gated paths while the
+ * cast is active.
+ *
+ * Lifecycle:
+ *   1. [publish] writes the audio + image buffers into memory, rotates a
+ *      128-bit path token, and lazily starts the server. Returns HTTP
+ *      URLs the receiver can fetch.
+ *   2. The caller hands those URLs to a `MediaInfo` and loads them via
+ *      `RemoteMediaClient.load(...)`.
+ *   3. Subsequent [publish] calls swap the buffers and the path token in
+ *      place — old URLs stop serving and the receiver picks up the new
+ *      ones from the next `load(...)`.
+ *   4. [stop] when the cast ends; the server thread exits, the buffers
+ *      drop out of scope, and the token is cleared so any straggling
+ *      request 404s.
+ *
+ * Privacy / threat model:
+ *   - The server binds to the LAN interface the OS already grants the
+ *     app via [android.Manifest.permission.INTERNET]. There's no NAT
+ *     traversal and no auth beyond the per-publish path token.
+ *   - **Path-token gating.** Each [publish] mints a fresh 128-bit
+ *     [SecureRandom] secret and embeds it as the first path segment
+ *     (e.g. `/<32 hex chars>/insight.wav`). Anything else — including
+ *     known-suffix probes and the previous publish's token — returns
+ *     404. A co-LAN device that scans the ephemeral port for open
+ *     services can't enumerate the buffers without observing the
+ *     issued URL.
+ *   - Cleartext HTTP-to-LAN is the standard Cast path (receivers won't
+ *     trust a self-signed cert).
+ *   - Nothing is persisted: the buffers live entirely in heap, are
+ *     dropped on [stop], and rotate on every [publish].
+ *
+ * Threading:
+ *   - Ktor CIO runs its accept / handler loop on its own threads. The
+ *     buffer references and the token are `@Volatile` so a handler
+ *     racing a [publish] sees one set or the other, never a torn write.
+ *   - [start] / [stop] / [publish] are intended to be called from a
+ *     single thread (the cast session listener); concurrent calls
+ *     aren't guarded.
+ */
+class CastMediaServer {
+
+    private var server: EmbeddedServer<*, *>? = null
+    private var port: Int = 0
+
+    @Volatile
+    private var audio: ByteArray? = null
+
+    @Volatile
+    private var image: ByteArray? = null
+
+    @Volatile
+    private var pathToken: String = ""
+
+    /**
+     * Replaces the in-memory audio + image buffers, rotates the path
+     * token, ensures the server is running, and returns the URLs the
+     * receiver should fetch.
+     *
+     * @param host the LAN address the receiver should reach the phone on
+     *   (e.g. "192.168.1.42"). The caller resolves it from
+     *   `ConnectivityManager.getLinkProperties`.
+     */
+    fun publish(host: String, audio: ByteArray, image: ByteArray): MediaUrls {
+        this.audio = audio
+        this.image = image
+        this.pathToken = generateToken()
+        if (server == null) start()
+        return MediaUrls(
+            audio = "http://$host:$port/$pathToken$AUDIO_SUFFIX",
+            image = "http://$host:$port/$pathToken$IMAGE_SUFFIX",
+        )
+    }
+
+    /** Stops the server, if running, and clears all buffered media + the path token. */
+    fun stop() {
+        server?.stop(gracePeriodMillis = 0, timeoutMillis = 500)
+        server = null
+        audio = null
+        image = null
+        pathToken = ""
+        port = 0
+    }
+
+    /** Currently-bound port, or 0 if the server isn't running. Test hook. */
+    internal fun port(): Int = port
+
+    private fun start() {
+        port = ServerSocket(0).use { it.localPort }
+        val srv = embeddedServer(CIO, port = port) {
+            routing {
+                get("/{token}/insight.wav") {
+                    val buf = audio
+                    val incoming = call.parameters["token"]
+                    if (buf != null && tokenMatches(incoming)) {
+                        call.respondBytes(buf, AUDIO_CONTENT_TYPE)
+                    } else {
+                        call.respond(HttpStatusCode.NotFound)
+                    }
+                }
+                get("/{token}/outfit.png") {
+                    val buf = image
+                    val incoming = call.parameters["token"]
+                    if (buf != null && tokenMatches(incoming)) {
+                        call.respondBytes(buf, ContentType.Image.PNG)
+                    } else {
+                        call.respond(HttpStatusCode.NotFound)
+                    }
+                }
+            }
+        }
+        srv.start(wait = false)
+        server = srv
+    }
+
+    /**
+     * Constant-time-ish token check. Plain `==` works on Kotlin/JVM
+     * strings, and the LAN-only attack surface doesn't warrant a
+     * MessageDigest.isEqual dance, but require both sides be non-empty
+     * so a cleared token (post-[stop]) doesn't accidentally accept an
+     * empty path segment from a wildcard URL.
+     */
+    private fun tokenMatches(incoming: String?): Boolean =
+        !incoming.isNullOrEmpty() && pathToken.isNotEmpty() && incoming == pathToken
+
+    private fun generateToken(): String {
+        val bytes = ByteArray(TOKEN_BYTES)
+        SecureRandom().nextBytes(bytes)
+        return bytes.joinToString("") { "%02x".format(it) }
+    }
+
+    data class MediaUrls(val audio: String, val image: String)
+
+    companion object {
+        // 128 bits of entropy in the URL path. Enough that scanning the
+        // open ephemeral port for the buffers is computationally hopeless
+        // even on a fast LAN; same order as a UUID4.
+        private const val TOKEN_BYTES = 16
+        private const val AUDIO_SUFFIX = "/insight.wav"
+        private const val IMAGE_SUFFIX = "/outfit.png"
+        private val AUDIO_CONTENT_TYPE = ContentType("audio", "wav")
+    }
+}

--- a/app/src/main/kotlin/app/clothescast/cast/WavEncoder.kt
+++ b/app/src/main/kotlin/app/clothescast/cast/WavEncoder.kt
@@ -1,0 +1,57 @@
+package app.clothescast.cast
+
+import app.clothescast.core.data.tts.PcmAudio
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+/**
+ * Wraps the raw PCM buffer returned by Gemini TTS in a RIFF/WAVE container so
+ * a Cast receiver (and any other plain media client) can play it without
+ * first having to be told the sample rate / channel layout out of band.
+ *
+ * Gemini TTS returns signed 16-bit mono little-endian PCM at a per-response
+ * sample rate (24000 Hz at time of writing). Those parameters are hard-coded
+ * into the header below; if Gemini ever starts returning stereo or a different
+ * bit depth, [PcmAudio] would need to grow channel / bit-depth fields and
+ * this encoder would need to follow.
+ *
+ * The output is a single contiguous `ByteArray` (header + samples) of size
+ * `44 + audio.bytes.size`. Cast's Default Media Receiver streams it as
+ * `audio/wav`.
+ */
+object WavEncoder {
+
+    private const val HEADER_SIZE = 44
+    private const val FORMAT_PCM: Short = 1
+    private const val CHANNELS: Short = 1
+    private const val BITS_PER_SAMPLE: Short = 16
+
+    fun encode(audio: PcmAudio): ByteArray {
+        val pcm = audio.bytes
+        val sampleRate = audio.sampleRate
+        val byteRate = sampleRate * CHANNELS * BITS_PER_SAMPLE / 8
+        val blockAlign: Short = (CHANNELS * BITS_PER_SAMPLE / 8).toShort()
+
+        val out = ByteArray(HEADER_SIZE + pcm.size)
+        val buf = ByteBuffer.wrap(out).order(ByteOrder.LITTLE_ENDIAN)
+
+        buf.put("RIFF".toByteArray(Charsets.US_ASCII))
+        buf.putInt(36 + pcm.size)
+        buf.put("WAVE".toByteArray(Charsets.US_ASCII))
+
+        buf.put("fmt ".toByteArray(Charsets.US_ASCII))
+        buf.putInt(16)
+        buf.putShort(FORMAT_PCM)
+        buf.putShort(CHANNELS)
+        buf.putInt(sampleRate)
+        buf.putInt(byteRate)
+        buf.putShort(blockAlign)
+        buf.putShort(BITS_PER_SAMPLE)
+
+        buf.put("data".toByteArray(Charsets.US_ASCII))
+        buf.putInt(pcm.size)
+        buf.put(pcm)
+
+        return out
+    }
+}

--- a/app/src/test/kotlin/app/clothescast/cast/CastMediaServerTest.kt
+++ b/app/src/test/kotlin/app/clothescast/cast/CastMediaServerTest.kt
@@ -1,0 +1,138 @@
+package app.clothescast.cast
+
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldMatch
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import java.net.HttpURLConnection
+import java.net.URL
+
+class CastMediaServerTest {
+
+    private val server = CastMediaServer()
+
+    @AfterEach
+    fun tearDown() {
+        server.stop()
+    }
+
+    @Test
+    fun `serves the published WAV at the audio path`() {
+        val wav = byteArrayOf(0x52, 0x49, 0x46, 0x46, 1, 2, 3, 4)
+        val urls = server.publish(host = "127.0.0.1", audio = wav, image = ByteArray(0))
+
+        val resp = fetch(urls.audio)
+        resp.status shouldBe 200
+        resp.contentType shouldBe "audio/wav"
+        resp.body shouldBe wav
+    }
+
+    @Test
+    fun `serves the published PNG at the image path`() {
+        val png = byteArrayOf(0x89.toByte(), 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A)
+        val urls = server.publish(host = "127.0.0.1", audio = ByteArray(0), image = png)
+
+        val resp = fetch(urls.image)
+        resp.status shouldBe 200
+        resp.contentType shouldBe "image/png"
+        resp.body shouldBe png
+    }
+
+    @Test
+    fun `URLs carry a 32 hex character path token`() {
+        val urls = server.publish(host = "127.0.0.1", audio = ByteArray(0), image = ByteArray(0))
+        // http://127.0.0.1:<port>/<32 hex>/insight.wav
+        urls.audio shouldMatch Regex("""http://127\.0\.0\.1:\d+/[0-9a-f]{32}/insight\.wav""")
+        urls.image shouldMatch Regex("""http://127\.0\.0\.1:\d+/[0-9a-f]{32}/outfit\.png""")
+    }
+
+    @Test
+    fun `republish rotates the path token and old URLs stop serving`() {
+        val first = server.publish(
+            host = "127.0.0.1",
+            audio = "first-audio".toByteArray(),
+            image = "first-image".toByteArray(),
+        )
+        val second = server.publish(
+            host = "127.0.0.1",
+            audio = "second-audio".toByteArray(),
+            image = "second-image".toByteArray(),
+        )
+
+        second.audio shouldNotBe first.audio
+        second.image shouldNotBe first.image
+
+        // Old URLs 404 — the previous publish's token no longer matches.
+        fetch(first.audio).status shouldBe 404
+        fetch(first.image).status shouldBe 404
+
+        // New URLs serve the new buffers on the same port.
+        fetch(second.audio).body shouldBe "second-audio".toByteArray()
+        fetch(second.image).body shouldBe "second-image".toByteArray()
+        URL(second.audio).port shouldBe URL(first.audio).port
+    }
+
+    @Test
+    fun `requests with a wrong token return 404`() {
+        val wav = byteArrayOf(1, 2, 3, 4)
+        val urls = server.publish(host = "127.0.0.1", audio = wav, image = byteArrayOf(5, 6))
+        val origin = URL(urls.audio).let { "http://${it.host}:${it.port}" }
+
+        fetch("$origin/deadbeefdeadbeefdeadbeefdeadbeef/insight.wav").status shouldBe 404
+        fetch("$origin/deadbeefdeadbeefdeadbeefdeadbeef/outfit.png").status shouldBe 404
+    }
+
+    @Test
+    fun `unknown paths return 404`() {
+        val urls = server.publish(host = "127.0.0.1", audio = ByteArray(0), image = ByteArray(0))
+        val origin = URL(urls.audio).let { "http://${it.host}:${it.port}" }
+
+        fetch("$origin/nope").status shouldBe 404
+    }
+
+    @Test
+    fun `stop releases the port`() {
+        val urls = server.publish(host = "127.0.0.1", audio = ByteArray(0), image = ByteArray(0))
+        val port = server.port()
+        (port > 0) shouldBe true
+        URL(urls.audio).port shouldBe port
+
+        server.stop()
+        server.port() shouldBe 0
+    }
+
+    private data class Response(val status: Int, val contentType: String?, val body: ByteArray)
+
+    private fun fetch(url: String): Response {
+        // CIO binds asynchronously after start(wait = false); retry briefly so
+        // the test isn't racing the accept loop coming up.
+        var lastError: Exception? = null
+        repeat(20) { attempt ->
+            try {
+                val conn = URL(url).openConnection() as HttpURLConnection
+                conn.connectTimeout = 1_000
+                conn.readTimeout = 1_000
+                try {
+                    val status = conn.responseCode
+                    val body = if (status in 200..299) {
+                        conn.inputStream.use { it.readBytes() }
+                    } else {
+                        ByteArray(0)
+                    }
+                    return Response(
+                        status = status,
+                        contentType = conn.contentType?.substringBefore(';'),
+                        body = body,
+                    )
+                } finally {
+                    conn.disconnect()
+                }
+            } catch (e: Exception) {
+                lastError = e
+                Thread.sleep(25L * (attempt + 1))
+            }
+        }
+        throw IllegalStateException("server did not accept connections in time", lastError)
+    }
+}

--- a/app/src/test/kotlin/app/clothescast/cast/WavEncoderTest.kt
+++ b/app/src/test/kotlin/app/clothescast/cast/WavEncoderTest.kt
@@ -1,0 +1,56 @@
+package app.clothescast.cast
+
+import app.clothescast.core.data.tts.PcmAudio
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+class WavEncoderTest {
+
+    @Test
+    fun `header describes signed 16-bit mono PCM at the audio's sample rate`() {
+        val pcm = ByteArray(8) { (it + 1).toByte() }
+        val wav = WavEncoder.encode(PcmAudio(bytes = pcm, sampleRate = 24_000))
+
+        // 44 byte header + PCM payload.
+        wav.size shouldBe 44 + pcm.size
+
+        val buf = ByteBuffer.wrap(wav).order(ByteOrder.LITTLE_ENDIAN)
+        val read4 = { i: Int -> String(wav, i, 4, Charsets.US_ASCII) }
+
+        read4(0) shouldBe "RIFF"
+        buf.getInt(4) shouldBe 36 + pcm.size       // RIFF chunk size
+        read4(8) shouldBe "WAVE"
+
+        read4(12) shouldBe "fmt "
+        buf.getInt(16) shouldBe 16                  // fmt chunk size for PCM
+        buf.getShort(20) shouldBe 1.toShort()       // PCM
+        buf.getShort(22) shouldBe 1.toShort()       // mono
+        buf.getInt(24) shouldBe 24_000              // sample rate
+        buf.getInt(28) shouldBe 24_000 * 2          // byte rate
+        buf.getShort(32) shouldBe 2.toShort()       // block align
+        buf.getShort(34) shouldBe 16.toShort()      // bits per sample
+
+        read4(36) shouldBe "data"
+        buf.getInt(40) shouldBe pcm.size
+
+        // PCM payload follows the header unchanged.
+        wav.copyOfRange(44, wav.size) shouldBe pcm
+    }
+
+    @Test
+    fun `sample rate is taken from the audio buffer`() {
+        val wav = WavEncoder.encode(PcmAudio(bytes = ByteArray(2), sampleRate = 48_000))
+        val buf = ByteBuffer.wrap(wav).order(ByteOrder.LITTLE_ENDIAN)
+        buf.getInt(24) shouldBe 48_000
+        buf.getInt(28) shouldBe 48_000 * 2
+    }
+
+    @Test
+    fun `empty PCM still produces a valid header`() {
+        val wav = WavEncoder.encode(PcmAudio(bytes = ByteArray(0), sampleRate = 24_000))
+        wav.size shouldBe 44
+        ByteBuffer.wrap(wav).order(ByteOrder.LITTLE_ENDIAN).getInt(40) shouldBe 0
+    }
+}


### PR DESCRIPTION
PR 1 of 2 for casting today's outfit picture + spoken insight to a Cast receiver on your LAN. This one adds the media-hosting plumbing only; the Settings → Cast picker and the worker-driven trigger follow in a stacked PR on top.

## Scope

- **`cast/CastMediaServer.kt`** — a small Ktor CIO HTTP server mirroring the existing `PairingServer` lifecycle. `publish()` rotates a 128-bit path token, swaps the in-memory PNG / WAV buffers, and lazily starts the server; `stop()` releases the buffers, clears the token, and closes the port.
- **`cast/WavEncoder.kt`** — 44-byte RIFF/WAVE header for the signed-16-bit-mono little-endian PCM that `GeminiTtsClient` already returns, so a Cast receiver can stream it as `audio/wav`.
- Unit tests for both, exercising a real bound port via `HttpURLConnection` with a small retry against CIO's async accept loop.

## Why a local server

Cast receivers fetch media by URL — they don't accept raw bytes pushed from the sender. The phone briefly hosts the two payloads on the LAN for the duration of the cast.

## Security

The server's two routes match `/{token}/insight.wav` and `/{token}/outfit.png`. Each `publish()` mints a fresh 128-bit `SecureRandom` secret and embeds it in the URL; stale tokens, unknown tokens, and known suffixes without a token all return 404. A device on the same LAN that scans the ephemeral port for open services can't enumerate the buffers without first observing the issued URL.

## Privacy

No new data leaves the device. The audio bytes are the same insight prose the phone already speaks aloud, and the PNG is the same outfit card the widget renders; both are served only over LAN to the Cast device the user has explicitly selected. Cleartext HTTP-to-LAN is the standard Cast path (receivers won't trust a self-signed cert), and Android's outgoing-only `NetworkSecurityConfig` doesn't apply to incoming server traffic, so no manifest changes were needed.

## What's intentionally **not** here

- No Cast SDK dependency yet, no Cast button in the app, no `CastContext` init — those land in PR 2 along with the Settings → Cast picker and the worker integration.
- No `LanAddress` resolver — also PR 2, when there's a caller for it.
- No foreground service — PR 2 concern.

## Test plan

- [x] `:core:domain:test`
- [x] `:core:data:test`
- [x] `:app:testDebugUnitTest` (includes the new `cast/*` tests, with token-rotation + wrong-token coverage)
- [x] `:app:assembleDebug`