### PR TITLE
Send today's outfit and forecast to your Chromecast

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -343,10 +343,16 @@ dependencies {
     implementation(libs.ktor.client.content.negotiation)
     implementation(libs.ktor.serialization.kotlinx.json)
 
-    // Ktor CIO server for the local phone-pairing HTTP endpoint. TV shows a QR code
-    // encoding the server URL; the phone browser opens the page, pastes the API key,
-    // and POSTs it back — no cloud relay, no new permissions, LAN-local only.
+    // Ktor CIO server for the local phone-pairing HTTP endpoint plus the
+    // Chromecast media-hosting endpoint (the receiver fetches PNG + WAV from a
+    // tiny LAN server on the phone — Cast doesn't accept sender-pushed bytes).
     implementation(libs.ktor.server.cio)
+
+    // Google Cast — adds the MediaRouteButton (via androidx.mediarouter) and
+    // RemoteMediaClient. Initialised lazily in ClothesCastApplication; the
+    // call is wrapped in try/catch so non-Play devices and Cast-less
+    // emulators don't crash on startup.
+    implementation(libs.play.services.cast.framework)
 
     // QR code generation: encodes the pairing URL into a BitMatrix that we render
     // as an Android Bitmap. Pure-Java, no Android SDK dependency.

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -127,6 +127,12 @@
             android:name="google_analytics_adid_collection_enabled"
             android:value="false" />
 
+        <!-- Cast SDK loads CastOptionsProvider via reflection from this name.
+             Receiver app id and discovery filters live in that class. -->
+        <meta-data
+            android:name="com.google.android.gms.cast.framework.OPTIONS_PROVIDER_CLASS_NAME"
+            android:value="app.clothescast.cast.CastOptionsProvider" />
+
         <!-- Home-screen App Widget showing the current period's outfit.
              exported=true is required for the OS launcher to bind. -->
         <receiver

--- a/app/src/main/kotlin/app/clothescast/ClothesCastApplication.kt
+++ b/app/src/main/kotlin/app/clothescast/ClothesCastApplication.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import android.content.Context
 import app.clothescast.alarm.DailyAlarmScheduler
 import app.clothescast.calendar.CalendarContractEventReader
+import app.clothescast.cast.CastInsightController
 import app.clothescast.core.data.diag.ApiCallLogger
 import app.clothescast.core.data.location.OpenMeteoGeocodingClient
 import app.clothescast.core.data.tts.GeminiTtsClient
@@ -36,6 +37,7 @@ import app.clothescast.tts.AndroidTtsSpeaker
 import app.clothescast.tts.AndroidTtsVoiceEnumerator
 import app.clothescast.tts.TtsSpeaker
 import app.clothescast.update.AppUpdateChecker
+import com.google.android.gms.cast.framework.CastContext
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.okhttp.OkHttp
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
@@ -109,6 +111,37 @@ class ClothesCastApplication : Application() {
      */
     val homeAssistantDiscovery: HomeAssistantDiscovery by lazy {
         NsdHomeAssistantDiscovery(this)
+    }
+
+    /**
+     * Cast SDK entry point. Returns `null` when Google Play Services isn't
+     * available (Cast-less emulators, AOSP / GMS-free builds) — the Today
+     * screen hides the Cast button in that case rather than crashing on
+     * [com.google.android.gms.cast.framework.CastContext.getSharedInstance].
+     */
+    val castContext: CastContext? by lazy {
+        try {
+            CastContext.getSharedInstance(this)
+        } catch (t: Throwable) {
+            DiagLog.w(TAG, "CastContext.getSharedInstance failed; Cast disabled", t)
+            null
+        }
+    }
+
+    /**
+     * Orchestrates "cast today's insight" — synth + WAV-wrap + LAN-host the
+     * outfit PNG + load into the active session. Null whenever [castContext]
+     * is, so the UI can skip wiring listeners on Cast-less builds.
+     */
+    val castInsightController: CastInsightController? by lazy {
+        castContext?.let {
+            CastInsightController(
+                context = this,
+                castContext = it,
+                ttsClient = geminiTtsClient,
+                applicationScope = applicationScope,
+            )
+        }
     }
 
     private val httpClient: HttpClient by lazy {

--- a/app/src/main/kotlin/app/clothescast/cast/CastInsightController.kt
+++ b/app/src/main/kotlin/app/clothescast/cast/CastInsightController.kt
@@ -1,0 +1,157 @@
+package app.clothescast.cast
+
+import android.content.Context
+import android.net.Uri
+import app.clothescast.core.data.tts.GeminiTtsClient
+import app.clothescast.core.domain.model.TtsStyle
+import app.clothescast.diag.DiagLog
+import com.google.android.gms.cast.MediaInfo
+import com.google.android.gms.cast.MediaLoadRequestData
+import com.google.android.gms.cast.MediaMetadata
+import com.google.android.gms.cast.framework.CastContext
+import com.google.android.gms.cast.framework.CastSession
+import com.google.android.gms.cast.framework.SessionManager
+import com.google.android.gms.cast.framework.SessionManagerListener
+import com.google.android.gms.common.images.WebImage
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import java.util.Locale
+
+/**
+ * Drives a Cast session for the Today screen: synthesises the insight via
+ * Gemini TTS, wraps the PCM in WAV, hands the buffers to [CastMediaServer]
+ * for LAN hosting, and tells the connected Cast device to load the URLs.
+ *
+ * One instance per [ClothesCastApplication]. The Today screen registers it
+ * via [bind] while in the foreground and calls [cast] from its own session
+ * listener once a Cast session is established.
+ *
+ * The session listener owned here is the *fallback* lifecycle owner: it
+ * just stops the media server when a session ends, so we're not leaving
+ * an open port behind. Auto-publishing on session start happens at the UI
+ * layer because that's where the current Insight state lives.
+ */
+class CastInsightController(
+    private val context: Context,
+    private val castContext: CastContext,
+    private val ttsClient: GeminiTtsClient,
+    private val applicationScope: CoroutineScope,
+    private val resolveLanIp: (Context) -> String? = LanAddress::resolve,
+    private val server: CastMediaServer = CastMediaServer(),
+) {
+
+    private val sessionManager: SessionManager get() = castContext.sessionManager
+
+    private val sessionListener = object : SessionManagerListener<CastSession> {
+        override fun onSessionStarting(session: CastSession) {}
+        override fun onSessionStarted(session: CastSession, sessionId: String) {}
+        override fun onSessionStartFailed(session: CastSession, error: Int) {
+            server.stop()
+        }
+        override fun onSessionEnding(session: CastSession) {}
+        override fun onSessionEnded(session: CastSession, error: Int) {
+            server.stop()
+        }
+        override fun onSessionResuming(session: CastSession, sessionId: String) {}
+        override fun onSessionResumed(session: CastSession, wasSuspended: Boolean) {}
+        override fun onSessionResumeFailed(session: CastSession, error: Int) {
+            server.stop()
+        }
+        override fun onSessionSuspended(session: CastSession, reason: Int) {}
+    }
+
+    private var bound = false
+
+    fun bind() {
+        if (bound) return
+        sessionManager.addSessionManagerListener(sessionListener, CastSession::class.java)
+        bound = true
+    }
+
+    fun unbind() {
+        if (!bound) return
+        sessionManager.removeSessionManagerListener(sessionListener, CastSession::class.java)
+        server.stop()
+        bound = false
+    }
+
+    /**
+     * Casts the given insight to the currently-connected Cast device, if any.
+     * Returns [CastResult] describing why a cast was skipped, or
+     * [CastResult.Loaded] on success. Synthesis runs on [applicationScope] —
+     * the returned [Job] lets the caller observe completion or cancel.
+     */
+    fun cast(
+        prose: String,
+        locale: Locale,
+        voiceName: String,
+        style: TtsStyle,
+        outfitPng: ByteArray,
+        title: String,
+        subtitle: String?,
+    ): CastAttempt {
+        val session = sessionManager.currentCastSession
+        if (session == null || !session.isConnected) {
+            return CastAttempt(CastResult.NoActiveSession, job = null)
+        }
+        val client = session.remoteMediaClient
+            ?: return CastAttempt(CastResult.NoRemoteMediaClient, job = null)
+        val host = resolveLanIp(context)
+            ?: return CastAttempt(CastResult.NoLanAddress, job = null)
+
+        val job = applicationScope.launch {
+            try {
+                val pcm = ttsClient.synthesize(
+                    text = prose,
+                    voiceName = voiceName,
+                    locale = locale,
+                    style = style,
+                )
+                val wav = WavEncoder.encode(pcm)
+                val urls = server.publish(host = host, audio = wav, image = outfitPng)
+                client.load(
+                    MediaLoadRequestData.Builder()
+                        .setMediaInfo(buildMediaInfo(urls, title, subtitle))
+                        .build(),
+                )
+            } catch (t: Throwable) {
+                DiagLog.e(TAG, "Cast publish failed", t)
+                server.stop()
+            }
+        }
+        return CastAttempt(CastResult.Loaded, job = job)
+    }
+
+    sealed interface CastResult {
+        data object Loaded : CastResult
+        data object NoActiveSession : CastResult
+        data object NoRemoteMediaClient : CastResult
+        data object NoLanAddress : CastResult
+    }
+
+    data class CastAttempt(val result: CastResult, val job: Job?)
+
+    companion object {
+        private const val TAG = "CastInsightController"
+
+        internal fun buildMediaInfo(
+            urls: CastMediaServer.MediaUrls,
+            title: String,
+            subtitle: String?,
+        ): MediaInfo {
+            val metadata = MediaMetadata(MediaMetadata.MEDIA_TYPE_GENERIC).apply {
+                putString(MediaMetadata.KEY_TITLE, title)
+                if (!subtitle.isNullOrBlank()) {
+                    putString(MediaMetadata.KEY_SUBTITLE, subtitle)
+                }
+                addImage(WebImage(Uri.parse(urls.image)))
+            }
+            return MediaInfo.Builder(urls.audio)
+                .setContentType("audio/wav")
+                .setStreamType(MediaInfo.STREAM_TYPE_BUFFERED)
+                .setMetadata(metadata)
+                .build()
+        }
+    }
+}

--- a/app/src/main/kotlin/app/clothescast/cast/CastMediaServer.kt
+++ b/app/src/main/kotlin/app/clothescast/cast/CastMediaServer.kt
@@ -1,0 +1,124 @@
+package app.clothescast.cast
+
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.call
+import io.ktor.server.cio.CIO
+import io.ktor.server.engine.EmbeddedServer
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.response.respond
+import io.ktor.server.response.respondBytes
+import io.ktor.server.routing.get
+import io.ktor.server.routing.routing
+import java.net.ServerSocket
+
+/**
+ * Tiny HTTP server that exposes one outfit PNG and one TTS WAV to a Cast
+ * device on the same LAN. Chromecast receivers fetch media by URL — they
+ * don't accept raw bytes pushed from the sender — so the phone briefly hosts
+ * the two payloads at fixed paths while the cast session is active.
+ *
+ * Lifecycle:
+ *   1. [publish] writes the audio + image buffers into memory and lazily
+ *      starts the server. Returns HTTP URLs the Cast device can fetch.
+ *   2. The caller hands those URLs to a Cast `MediaInfo` and loads them via
+ *      `RemoteMediaClient.load(...)`.
+ *   3. Subsequent [publish] calls swap the buffers in place — the same URLs
+ *      keep working, useful when the user refreshes the cast mid-session.
+ *   4. [stop] when the cast session ends; the server thread exits and the
+ *      buffers drop out of scope.
+ *
+ * Privacy / threat model:
+ *   - The server only binds to the LAN interface the OS already grants the
+ *     app via [android.Manifest.permission.INTERNET]. There's no NAT
+ *     traversal, no auth, and unknown paths return 404. The two buffers
+ *     served are the same content the phone already speaks aloud and
+ *     displays in the notification, so any co-LAN observer with the URL
+ *     sees only what's already on the screen. Cleartext is fine here —
+ *     Cast devices won't trust a self-signed cert, and HTTP-to-LAN is the
+ *     standard path for sender-hosted media.
+ *   - Nothing is persisted: the buffers live entirely in heap, are
+ *     dropped on [stop], and rotate on every [publish].
+ *
+ * Threading:
+ *   - Ktor CIO runs its accept / handler loop on its own threads. The two
+ *     buffer references are `@Volatile` so a handler racing a [publish]
+ *     sees one buffer or the other, never a torn write.
+ *   - [start] / [stop] / [publish] are intended to be called from a single
+ *     thread (the cast session listener); concurrent calls aren't guarded.
+ */
+class CastMediaServer {
+
+    private var server: EmbeddedServer<*, *>? = null
+    private var port: Int = 0
+
+    @Volatile
+    private var audio: ByteArray? = null
+
+    @Volatile
+    private var image: ByteArray? = null
+
+    /**
+     * Replaces the in-memory audio + image buffers, ensures the server is
+     * running, and returns the URLs the Cast device should fetch.
+     *
+     * @param host the LAN address the Cast device should reach the phone on
+     *   (e.g. "192.168.1.42"). The caller resolves it from
+     *   `ConnectivityManager.getLinkProperties`.
+     */
+    fun publish(host: String, audio: ByteArray, image: ByteArray): MediaUrls {
+        this.audio = audio
+        this.image = image
+        if (server == null) start()
+        return MediaUrls(
+            audio = "http://$host:$port$AUDIO_PATH",
+            image = "http://$host:$port$IMAGE_PATH",
+        )
+    }
+
+    /** Stops the server, if running, and clears all buffered media. */
+    fun stop() {
+        server?.stop(gracePeriodMillis = 0, timeoutMillis = 500)
+        server = null
+        audio = null
+        image = null
+        port = 0
+    }
+
+    /** Currently-bound port, or 0 if the server isn't running. Test hook. */
+    internal fun port(): Int = port
+
+    private fun start() {
+        port = ServerSocket(0).use { it.localPort }
+        val srv = embeddedServer(CIO, port = port) {
+            routing {
+                get(AUDIO_PATH) {
+                    val buf = audio
+                    if (buf != null) {
+                        call.respondBytes(buf, AUDIO_CONTENT_TYPE)
+                    } else {
+                        call.respond(HttpStatusCode.NotFound)
+                    }
+                }
+                get(IMAGE_PATH) {
+                    val buf = image
+                    if (buf != null) {
+                        call.respondBytes(buf, ContentType.Image.PNG)
+                    } else {
+                        call.respond(HttpStatusCode.NotFound)
+                    }
+                }
+            }
+        }
+        srv.start(wait = false)
+        server = srv
+    }
+
+    data class MediaUrls(val audio: String, val image: String)
+
+    companion object {
+        const val AUDIO_PATH = "/insight.wav"
+        const val IMAGE_PATH = "/outfit.png"
+        private val AUDIO_CONTENT_TYPE = ContentType("audio", "wav")
+    }
+}

--- a/app/src/main/kotlin/app/clothescast/cast/CastOptionsProvider.kt
+++ b/app/src/main/kotlin/app/clothescast/cast/CastOptionsProvider.kt
@@ -1,0 +1,27 @@
+package app.clothescast.cast
+
+import android.content.Context
+import com.google.android.gms.cast.CastMediaControlIntent
+import com.google.android.gms.cast.framework.CastOptions
+import com.google.android.gms.cast.framework.OptionsProvider
+import com.google.android.gms.cast.framework.SessionProvider
+
+/**
+ * Tells the Cast SDK which receiver app to look for. We target Google's
+ * Default Media Receiver — it accepts any HTTP media URL with metadata
+ * (title, subtitle, image) and renders the image as a poster while the
+ * audio plays, which is exactly the shape of "outfit picture + spoken
+ * insight" we want. No custom Web Receiver to register or host.
+ *
+ * The Cast SDK loads this class via reflection from the manifest
+ * `OPTIONS_PROVIDER_CLASS_NAME` meta-data, so the class must stay public
+ * with a no-arg constructor.
+ */
+class CastOptionsProvider : OptionsProvider {
+    override fun getCastOptions(context: Context): CastOptions =
+        CastOptions.Builder()
+            .setReceiverApplicationId(CastMediaControlIntent.DEFAULT_MEDIA_RECEIVER_APPLICATION_ID)
+            .build()
+
+    override fun getAdditionalSessionProviders(context: Context): List<SessionProvider>? = null
+}

--- a/app/src/main/kotlin/app/clothescast/cast/LanAddress.kt
+++ b/app/src/main/kotlin/app/clothescast/cast/LanAddress.kt
@@ -1,0 +1,38 @@
+package app.clothescast.cast
+
+import android.content.Context
+import android.net.ConnectivityManager
+import androidx.core.content.getSystemService
+import java.net.Inet4Address
+import java.net.InetAddress
+
+/**
+ * Picks the phone's LAN IPv4 address — the host string we hand the Cast
+ * device so it can reach [CastMediaServer]. Cast receivers can't dial
+ * loopback / VPN / cellular addresses, so the pick is restricted to
+ * site-local IPv4 (RFC 1918) on the currently-active network.
+ *
+ * Returns `null` when the phone has no LAN-routable address — most
+ * commonly when the user is on cellular, or when the active network is
+ * a VPN that the Cast device isn't on. The caller surfaces that to the
+ * user rather than guessing.
+ */
+object LanAddress {
+
+    fun resolve(context: Context): String? {
+        val cm = context.getSystemService<ConnectivityManager>() ?: return null
+        val active = cm.activeNetwork ?: return null
+        val link = cm.getLinkProperties(active) ?: return null
+        return pickSiteLocal(link.linkAddresses.map { it.address })
+    }
+
+    /**
+     * Picks the first IPv4 site-local address from [addresses]. Pure
+     * helper; the Android-coupled wiring lives in [resolve].
+     */
+    internal fun pickSiteLocal(addresses: List<InetAddress>): String? =
+        addresses
+            .filterIsInstance<Inet4Address>()
+            .firstOrNull { it.isSiteLocalAddress }
+            ?.hostAddress
+}

--- a/app/src/main/kotlin/app/clothescast/cast/WavEncoder.kt
+++ b/app/src/main/kotlin/app/clothescast/cast/WavEncoder.kt
@@ -1,0 +1,57 @@
+package app.clothescast.cast
+
+import app.clothescast.core.data.tts.PcmAudio
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+/**
+ * Wraps the raw PCM buffer returned by Gemini TTS in a RIFF/WAVE container so
+ * Chromecast (and any other plain media client) can play it without first
+ * having to be told the sample rate / channel layout out of band.
+ *
+ * Gemini TTS returns signed 16-bit mono little-endian PCM at a per-response
+ * sample rate (24000 Hz at time of writing). Those parameters are hard-coded
+ * into the header below; if Gemini ever starts returning stereo or a different
+ * bit depth, [PcmAudio] would need to grow channel / bit-depth fields and
+ * this encoder would need to follow.
+ *
+ * The output is a single contiguous `ByteArray` (header + samples) of size
+ * `44 + audio.bytes.size`. Cast's Default Media Receiver streams it as
+ * `audio/wav`.
+ */
+object WavEncoder {
+
+    private const val HEADER_SIZE = 44
+    private const val FORMAT_PCM: Short = 1
+    private const val CHANNELS: Short = 1
+    private const val BITS_PER_SAMPLE: Short = 16
+
+    fun encode(audio: PcmAudio): ByteArray {
+        val pcm = audio.bytes
+        val sampleRate = audio.sampleRate
+        val byteRate = sampleRate * CHANNELS * BITS_PER_SAMPLE / 8
+        val blockAlign: Short = (CHANNELS * BITS_PER_SAMPLE / 8).toShort()
+
+        val out = ByteArray(HEADER_SIZE + pcm.size)
+        val buf = ByteBuffer.wrap(out).order(ByteOrder.LITTLE_ENDIAN)
+
+        buf.put("RIFF".toByteArray(Charsets.US_ASCII))
+        buf.putInt(36 + pcm.size)
+        buf.put("WAVE".toByteArray(Charsets.US_ASCII))
+
+        buf.put("fmt ".toByteArray(Charsets.US_ASCII))
+        buf.putInt(16)
+        buf.putShort(FORMAT_PCM)
+        buf.putShort(CHANNELS)
+        buf.putInt(sampleRate)
+        buf.putInt(byteRate)
+        buf.putShort(blockAlign)
+        buf.putShort(BITS_PER_SAMPLE)
+
+        buf.put("data".toByteArray(Charsets.US_ASCII))
+        buf.putInt(pcm.size)
+        buf.put(pcm)
+
+        return out
+    }
+}

--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayCast.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayCast.kt
@@ -1,0 +1,82 @@
+package app.clothescast.ui.today
+
+import android.content.Context
+import app.clothescast.ClothesCastApplication
+import app.clothescast.R
+import app.clothescast.cast.CastInsightController
+import app.clothescast.core.domain.model.ForecastPeriod
+import app.clothescast.insight.InsightFormatter
+import app.clothescast.ui.garment.outfitCardInfoLines
+import app.clothescast.ui.garment.renderOutfitCard
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.time.LocalDate
+import java.util.Locale
+
+/**
+ * Renders the currently-displayed insight's outfit card to a PNG, formats
+ * the matching prose, and asks [controller] to push them to the connected
+ * Cast device. No-op when there's no insight loaded yet or no outfit
+ * resolved for the current period — the user can re-cast (disconnect /
+ * reconnect, or tap Cast again) once data arrives.
+ *
+ * Mirrors the worker's MQTT image-publish path
+ * ([FetchAndNotifyWorker.deliver]) so the TV sees byte-identical visuals
+ * to what Home Assistant gets — same `renderOutfitCard` call, same
+ * `outfitCardInfoLines` aggregation, same theme-overlaid colour maps.
+ */
+internal fun dispatchCastFromState(
+    scope: CoroutineScope,
+    context: Context,
+    app: ClothesCastApplication,
+    controller: CastInsightController,
+    state: TodayState,
+    locale: Locale,
+) {
+    val insight = state.thisPeriodInsight ?: return
+    val outfit = insight.outfit ?: return
+    scope.launch {
+        val prefs = app.settingsRepository.preferences.first()
+        val formatter = InsightFormatter.forRegion(context, prefs.region, prefs.temperatureUnit)
+        val isFutureDay = insight.forDate.isAfter(LocalDate.now())
+        val prose = formatter.format(insight.summary, isFutureDay = isFutureDay)
+        val info = outfitCardInfoLines(
+            context = context,
+            formatter = formatter,
+            hourly = insight.hourly,
+            temperatureUnit = prefs.temperatureUnit,
+        )
+        val header = context.getString(
+            if (insight.period == ForecastPeriod.TODAY) R.string.outfit_card_header_today
+            else R.string.outfit_card_header_tonight,
+        )
+        val png = withContext(Dispatchers.Default) {
+            renderOutfitCard(
+                context = context,
+                outfit = outfit,
+                header = header,
+                prose = prose,
+                tempLine = info.tempLine,
+                rainLine = info.rainLine,
+                tempFillFraction = info.tempFillFraction,
+                rainFillFraction = info.rainFillFraction,
+                topColors = state.outfitTopColors,
+                bottomColors = state.outfitBottomColors,
+                topStrokes = state.outfitTopStrokes,
+                bottomStrokes = state.outfitBottomStrokes,
+            )
+        }
+        controller.cast(
+            prose = prose,
+            locale = locale,
+            voiceName = prefs.geminiVoice,
+            style = prefs.ttsStyle,
+            outfitPng = png,
+            title = context.getString(R.string.app_name),
+            subtitle = insight.location?.displayName,
+        )
+    }
+}

--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
@@ -109,6 +109,11 @@ import app.clothescast.tts.toJavaLocale
 import app.clothescast.ui.EdgeFadeOverlay
 import app.clothescast.ui.garment.GarmentBottomIcon
 import app.clothescast.ui.garment.GarmentTopIcon
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.mediarouter.app.MediaRouteButton
+import com.google.android.gms.cast.framework.CastButtonFactory
+import com.google.android.gms.cast.framework.CastSession
+import com.google.android.gms.cast.framework.SessionManagerListener
 import app.clothescast.diag.BugReport
 import app.clothescast.diag.BugReportConsentDialog
 import app.clothescast.diag.findActivity
@@ -168,6 +173,62 @@ fun TodayScreen(
         page = pagerState.currentPage,
     )
 
+    // Cast: when the user has paired with a Cast device — i.e. a session
+    // starts or resumes — auto-publish the current insight to the receiver.
+    // [castInsightController] / [castContext] are null on builds without
+    // Google Play Services (Cast-less emulators, GMS-free AOSP); we skip the
+    // listener and hide the toolbar button in that case.
+    val castController = app.castInsightController
+    val castContext = app.castContext
+    val latestState by rememberUpdatedState(state)
+    val configuration = LocalConfiguration.current
+    val deviceLocale = remember(configuration) { configuration.locales[0] }
+    if (castController != null && castContext != null) {
+        DisposableEffect(Unit) {
+            castController.bind()
+            val listener = object : SessionManagerListener<CastSession> {
+                override fun onSessionStarting(session: CastSession) {}
+                override fun onSessionStarted(session: CastSession, sessionId: String) {
+                    dispatchCastFromState(
+                        scope = coroutineScope,
+                        context = context,
+                        app = app,
+                        controller = castController,
+                        state = latestState,
+                        locale = deviceLocale,
+                    )
+                }
+                override fun onSessionStartFailed(session: CastSession, error: Int) {}
+                override fun onSessionEnding(session: CastSession) {}
+                override fun onSessionEnded(session: CastSession, error: Int) {}
+                override fun onSessionResuming(session: CastSession, sessionId: String) {}
+                override fun onSessionResumed(session: CastSession, wasSuspended: Boolean) {
+                    dispatchCastFromState(
+                        scope = coroutineScope,
+                        context = context,
+                        app = app,
+                        controller = castController,
+                        state = latestState,
+                        locale = deviceLocale,
+                    )
+                }
+                override fun onSessionResumeFailed(session: CastSession, error: Int) {}
+                override fun onSessionSuspended(session: CastSession, reason: Int) {}
+            }
+            castContext.sessionManager.addSessionManagerListener(
+                listener,
+                CastSession::class.java,
+            )
+            onDispose {
+                castContext.sessionManager.removeSessionManagerListener(
+                    listener,
+                    CastSession::class.java,
+                )
+                castController.unbind()
+            }
+        }
+    }
+
     Scaffold(
         // Drop the default `safeDrawing` content insets so the pager extends
         // edge-to-edge under the (transparent) nav bar. The padding lambda
@@ -202,6 +263,23 @@ fun TodayScreen(
                                 contentDescription = stringResource(R.string.today_refresh),
                             )
                         }
+                    }
+                    // The MediaRouteButton hides itself when no Cast routes are in
+                    // range, so on phones without a Chromecast on the LAN this
+                    // action is invisible. Cast framework wires the click handler
+                    // in `setUpMediaRouteButton`; we don't get a Compose-level
+                    // callback to override.
+                    if (castContext != null) {
+                        AndroidView(
+                            factory = { ctx ->
+                                MediaRouteButton(ctx).also {
+                                    CastButtonFactory.setUpMediaRouteButton(ctx, it)
+                                }
+                            },
+                            modifier = Modifier
+                                .padding(horizontal = 4.dp)
+                                .size(48.dp),
+                        )
                     }
                     IconButton(onClick = onNavigateToSettings) {
                         Icon(

--- a/app/src/test/kotlin/app/clothescast/cast/CastMediaServerTest.kt
+++ b/app/src/test/kotlin/app/clothescast/cast/CastMediaServerTest.kt
@@ -1,0 +1,113 @@
+package app.clothescast.cast
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import java.net.HttpURLConnection
+import java.net.URL
+
+class CastMediaServerTest {
+
+    private val server = CastMediaServer()
+
+    @AfterEach
+    fun tearDown() {
+        server.stop()
+    }
+
+    @Test
+    fun `serves the published WAV at the audio path`() {
+        val wav = byteArrayOf(0x52, 0x49, 0x46, 0x46, 1, 2, 3, 4)
+        val urls = server.publish(host = "127.0.0.1", audio = wav, image = ByteArray(0))
+
+        val resp = fetch(urls.audio)
+        resp.status shouldBe 200
+        resp.contentType shouldBe "audio/wav"
+        resp.body shouldBe wav
+    }
+
+    @Test
+    fun `serves the published PNG at the image path`() {
+        val png = byteArrayOf(0x89.toByte(), 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A)
+        val urls = server.publish(host = "127.0.0.1", audio = ByteArray(0), image = png)
+
+        val resp = fetch(urls.image)
+        resp.status shouldBe 200
+        resp.contentType shouldBe "image/png"
+        resp.body shouldBe png
+    }
+
+    @Test
+    fun `republish swaps the buffers without changing the URLs`() {
+        val first = server.publish(
+            host = "127.0.0.1",
+            audio = "first-audio".toByteArray(),
+            image = "first-image".toByteArray(),
+        )
+        val second = server.publish(
+            host = "127.0.0.1",
+            audio = "second-audio".toByteArray(),
+            image = "second-image".toByteArray(),
+        )
+
+        // URLs are stable across republishes — fixed paths, same port.
+        second.audio shouldBe first.audio
+        second.image shouldBe first.image
+
+        fetch(second.audio).body shouldBe "second-audio".toByteArray()
+        fetch(second.image).body shouldBe "second-image".toByteArray()
+    }
+
+    @Test
+    fun `unknown paths return 404`() {
+        val urls = server.publish(host = "127.0.0.1", audio = ByteArray(0), image = ByteArray(0))
+        val base = urls.audio.substringBeforeLast('/')
+
+        fetch("$base/nope").status shouldBe 404
+    }
+
+    @Test
+    fun `stop releases the port`() {
+        val urls = server.publish(host = "127.0.0.1", audio = ByteArray(0), image = ByteArray(0))
+        val port = server.port()
+        (port > 0) shouldBe true
+        URL(urls.audio).port shouldBe port
+
+        server.stop()
+        server.port() shouldBe 0
+    }
+
+    private data class Response(val status: Int, val contentType: String?, val body: ByteArray)
+
+    private fun fetch(url: String): Response {
+        // CIO binds asynchronously after start(wait = false); retry briefly so
+        // the test isn't racing the accept loop coming up.
+        var lastError: Exception? = null
+        repeat(20) { attempt ->
+            try {
+                val conn = URL(url).openConnection() as HttpURLConnection
+                conn.connectTimeout = 1_000
+                conn.readTimeout = 1_000
+                try {
+                    val status = conn.responseCode
+                    val body = if (status in 200..299) {
+                        conn.inputStream.use { it.readBytes() }
+                    } else {
+                        ByteArray(0)
+                    }
+                    return Response(
+                        status = status,
+                        contentType = conn.contentType?.substringBefore(';'),
+                        body = body,
+                    )
+                } finally {
+                    conn.disconnect()
+                }
+            } catch (e: Exception) {
+                lastError = e
+                Thread.sleep(25L * (attempt + 1))
+            }
+        }
+        throw IllegalStateException("server did not accept connections in time", lastError)
+    }
+}

--- a/app/src/test/kotlin/app/clothescast/cast/LanAddressTest.kt
+++ b/app/src/test/kotlin/app/clothescast/cast/LanAddressTest.kt
@@ -1,0 +1,41 @@
+package app.clothescast.cast
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import java.net.InetAddress
+
+class LanAddressTest {
+
+    @Test
+    fun `picks the first IPv4 site-local address`() {
+        val pick = LanAddress.pickSiteLocal(
+            listOf(
+                InetAddress.getByName("fe80::1"),       // IPv6 link-local
+                InetAddress.getByName("192.168.1.42"),  // wins
+                InetAddress.getByName("10.0.0.7"),
+            ),
+        )
+        pick shouldBe "192.168.1.42"
+    }
+
+    @Test
+    fun `returns null when only loopback and link-local addresses are available`() {
+        LanAddress.pickSiteLocal(
+            listOf(
+                InetAddress.getByName("127.0.0.1"),
+                InetAddress.getByName("169.254.10.20"),
+            ),
+        ) shouldBe null
+    }
+
+    @Test
+    fun `returns null for an empty list`() {
+        LanAddress.pickSiteLocal(emptyList()) shouldBe null
+    }
+
+    @Test
+    fun `accepts 10 and 172_16 ranges as site-local`() {
+        LanAddress.pickSiteLocal(listOf(InetAddress.getByName("10.1.2.3"))) shouldBe "10.1.2.3"
+        LanAddress.pickSiteLocal(listOf(InetAddress.getByName("172.20.5.6"))) shouldBe "172.20.5.6"
+    }
+}

--- a/app/src/test/kotlin/app/clothescast/cast/WavEncoderTest.kt
+++ b/app/src/test/kotlin/app/clothescast/cast/WavEncoderTest.kt
@@ -1,0 +1,56 @@
+package app.clothescast.cast
+
+import app.clothescast.core.data.tts.PcmAudio
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+class WavEncoderTest {
+
+    @Test
+    fun `header describes signed 16-bit mono PCM at the audio's sample rate`() {
+        val pcm = ByteArray(8) { (it + 1).toByte() }
+        val wav = WavEncoder.encode(PcmAudio(bytes = pcm, sampleRate = 24_000))
+
+        // 44 byte header + PCM payload.
+        wav.size shouldBe 44 + pcm.size
+
+        val buf = ByteBuffer.wrap(wav).order(ByteOrder.LITTLE_ENDIAN)
+        val read4 = { i: Int -> String(wav, i, 4, Charsets.US_ASCII) }
+
+        read4(0) shouldBe "RIFF"
+        buf.getInt(4) shouldBe 36 + pcm.size       // RIFF chunk size
+        read4(8) shouldBe "WAVE"
+
+        read4(12) shouldBe "fmt "
+        buf.getInt(16) shouldBe 16                  // fmt chunk size for PCM
+        buf.getShort(20) shouldBe 1.toShort()       // PCM
+        buf.getShort(22) shouldBe 1.toShort()       // mono
+        buf.getInt(24) shouldBe 24_000              // sample rate
+        buf.getInt(28) shouldBe 24_000 * 2          // byte rate
+        buf.getShort(32) shouldBe 2.toShort()       // block align
+        buf.getShort(34) shouldBe 16.toShort()      // bits per sample
+
+        read4(36) shouldBe "data"
+        buf.getInt(40) shouldBe pcm.size
+
+        // PCM payload follows the header unchanged.
+        wav.copyOfRange(44, wav.size) shouldBe pcm
+    }
+
+    @Test
+    fun `sample rate is taken from the audio buffer`() {
+        val wav = WavEncoder.encode(PcmAudio(bytes = ByteArray(2), sampleRate = 48_000))
+        val buf = ByteBuffer.wrap(wav).order(ByteOrder.LITTLE_ENDIAN)
+        buf.getInt(24) shouldBe 48_000
+        buf.getInt(28) shouldBe 48_000 * 2
+    }
+
+    @Test
+    fun `empty PCM still produces a valid header`() {
+        val wav = WavEncoder.encode(PcmAudio(bytes = ByteArray(0), sampleRate = 24_000))
+        wav.size shouldBe 44
+        ByteBuffer.wrap(wav).order(ByteOrder.LITTLE_ENDIAN).getInt(40) shouldBe 0
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -58,6 +58,12 @@ firebaseCrashlyticsPlugin = "3.0.2"
 # blocking client wrapped in withContext(Dispatchers.IO), so no Reactor /
 # CompletableFuture await plumbing is needed in :app.
 hivemqMqttClient = "1.3.3"
+# Google Cast SDK — pulls in androidx.mediarouter for the MediaRouteButton and
+# `play-services-cast` for device discovery / RemoteMediaClient. Cast itself
+# doesn't need google-services.json; framework init is gated at runtime by
+# Google Play services availability, so CI builds (which lack the JSON) still
+# compile and assemble.
+playServicesCast = "21.5.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -125,6 +131,8 @@ firebase-analytics = { group = "com.google.firebase", name = "firebase-analytics
 firebase-crashlytics = { group = "com.google.firebase", name = "firebase-crashlytics" }
 
 hivemq-mqtt-client = { group = "com.hivemq", name = "hivemq-mqtt-client", version.ref = "hivemqMqttClient" }
+
+play-services-cast-framework = { group = "com.google.android.gms", name = "play-services-cast-framework", version.ref = "playServicesCast" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
PR 2 of 2 (stacked on #577). Adds the Cast button on the Today toolbar and the session controller that drives the embedded media server from PR 1.

## What lands here

- **`play-services-cast-framework`** 21.5.0 added to `:app`.
- **`cast/CastOptionsProvider`** — targets Google's Default Media Receiver. No custom Web Receiver to register; it renders the outfit PNG as a full-screen poster while the WAV audio plays, which is exactly the "picture + spoken insight" shape we want.
- **`cast/LanAddress`** — resolves the phone's IPv4 site-local address via `ConnectivityManager.getLinkProperties` so the receiver can reach the PR 1 media server. Returns `null` on cellular / VPN-only networks.
- **`cast/CastInsightController`** — owns a `CastMediaServer`, listens to `SessionManager` (so the server's buffers are freed when the session ends), and exposes `cast()` which:
  1. synthesises via `GeminiTtsClient`,
  2. WAV-wraps the PCM,
  3. hands PNG + WAV to the media server,
  4. builds `MediaInfo` + `MediaMetadata` (title, subtitle, `addImage(...)` for the poster),
  5. calls `RemoteMediaClient.load()`.
- **`ui/today/TodayCast.dispatchCastFromState`** — mirrors the worker's MQTT-image path (same `renderOutfitCard` + `outfitCardInfoLines` aggregation, same theme-overlaid colour maps) so the TV sees byte-identical visuals to what Home Assistant gets.
- **`TodayScreen`** — `MediaRouteButton` wrapped in `AndroidView` lives in the `TopAppBar` actions row (Cast framework hides it automatically when no routes are in range). A `DisposableEffect`-scoped `SessionManagerListener` dispatches a cast on `onSessionStarted` / `onSessionResumed`.
- **`ClothesCastApplication`** — `castContext` and `castInsightController` are lazy and **null on Cast-less builds** (Cast-less emulators, GMS-free AOSP). The Today screen branches on null so those builds still boot cleanly.

## Privacy

No new data leaves the device beyond what PR 1 already covered. Same insight prose the phone speaks aloud, same outfit card the widget renders, served only to the Cast device the user explicitly picked. Cast SDK's discovery / session control is on-LAN; nothing is uploaded.

## Caveats / out of scope

- **No foreground service yet** — backgrounding the app or leaving the Today screen mid-cast stops the media server and interrupts the receiver. Acceptable for v1; the cast finishes in a few seconds. Foreground-service-lifecycle is a follow-up if it turns out to bite users.
- **LAN-only** — cellular-only users get no Cast button in practice (Cast discovery needs the LAN), and even if the picker did fire, `LanAddress.resolve()` returns null.
- **No unit tests for the controller / dispatcher** — they're glue over already-tested primitives (`CastMediaServer`, `WavEncoder`, `LanAddress`, `renderOutfitCard`). A real integration check would need a Chromecast on the LAN, out of CI reach.

## Test plan

- [x] `:core:domain:test`, `:core:data:test`
- [x] `:app:testDebugUnitTest` (including the new `LanAddressTest`, PR 1's `CastMediaServerTest` + `WavEncoderTest`)
- [x] `:app:assembleDebug`
- [ ] Tap-test on a real Chromecast (out of sandbox reach — needs user verification once the merged APK is installed)


---
_Generated by [Claude Code](https://claude.ai/code/session_01EJcdrqghHyJ9ju3E1RRyKS)_