### PR TITLE
Add rule on careful exception handling to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -256,6 +256,27 @@ new rule the first time something bites you, not the third.
   If you see "no tests found" after adding a `@Test`-annotated JUnit 4
   class, check that `vintage-engine` is on the test classpath.
 
+## Error handling
+
+- **Don't silently swallow exceptions.** A bare `catch (_: Throwable) {}` or
+  `catch (e: Exception) { /* ignore */ }` hides real failures in the field
+  and burns hours when something eventually breaks. Every catch block needs
+  to do three things: **log** the exception with enough context for a reader
+  to identify the failed call and its inputs (route through the usual
+  logger, not `println` or `Log.e` with a bare message); **clean up** what
+  the `try` block acquired — closeables, network handles, partial writes,
+  in-progress UI state — so a failure doesn't leak resources or leave the
+  app half-mutated (`use { … }` / `finally` blocks for closeables);
+  and **handle the edge case explicitly** — pick how the caller sees this
+  failure (default value, null, sentinel error result, rethrow as a domain
+  exception) rather than letting control fall through. Catching
+  `Throwable` (or `Exception` blanket) also swallows `CancellationException`
+  in coroutine code, which breaks structured concurrency — narrow the type,
+  or rethrow `CancellationException` first. If you genuinely do want to
+  ignore a specific failure, name the reason in a one-line comment
+  ("Open-Meteo returns 4xx for unknown geocodes, treat as empty result")
+  and still log at debug so it's traceable.
+
 ## Privacy
 
 - **Surface any change to what we send off device.** When a change touches


### PR DESCRIPTION
## Summary

Adds a new "Error handling" section to `AGENTS.md` (and via the symlink, `CLAUDE.md`), sitting between the Kotlin / Compose gotchas and Privacy sections.

The rule covers what every `catch` block needs to do:
- **Log** with enough context for a reader to identify the failed call and inputs (via the usual logger, not `println`/bare `Log.e`).
- **Clean up** what the `try` block acquired — closeables, network handles, partial writes, in-progress UI state — using `use { … }` / `finally`.
- **Handle the edge case explicitly** — pick a caller-visible outcome (default, null, sentinel error, rethrow as a domain exception) rather than letting control silently fall through.

It also calls out the coroutine gotcha that catching `Throwable`/`Exception` broadly swallows `CancellationException` and breaks structured concurrency — narrow the type or rethrow `CancellationException` first.

If a failure genuinely should be ignored, the rule asks for a one-line comment naming the specific reason and still logging at debug.

## Test plan

- [ ] Docs-only change; no build or test impact expected.
- [ ] CI (JVM unit tests + Android debug build) should pass unchanged.
- [ ] `whatsnew-en-US` should *not* gain a bullet for this commit (docs-only `*.md` change, filtered by the "Prepare release notes" step in `ci.yml`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01SjhiPqa9LrkHTSxYqYsdYZ)_