### PR TITLE
Standardise MQTT topics: clothescast/default with text/image/audio siblings

### DIFF
--- a/app/src/main/kotlin/app/clothescast/mqtt/MqttPublisher.kt
+++ b/app/src/main/kotlin/app/clothescast/mqtt/MqttPublisher.kt
@@ -53,7 +53,7 @@ class MqttPublisher(
 ) {
 
     /**
-     * Publishes to `${baseTopic}/${period.lowercased()}` and returns an
+     * Publishes to `${baseTopic}/${period.lowercased()}/text` and returns an
      * [MqttPublishOutcome] so the caller can persist the result for display.
      * Returns [MqttPublishOutcome.NotConfigured] (silently) when the bridge is
      * disabled or no host is set. Any network failure (DNS, connection, broker
@@ -78,7 +78,7 @@ class MqttPublisher(
     /**
      * Publishes a test message to `${baseTopic}/test` and returns the outcome.
      * Intended for the "Publish now" button — uses a dedicated topic suffix so
-     * the retained forecast on `${baseTopic}/today` and `tonight` is never
+     * the retained forecast on `${baseTopic}/<period>/text` is never
      * overwritten by a connectivity probe. Returns
      * [MqttPublishOutcome.NotConfigured] when the bridge is disabled or no host
      * is configured.
@@ -96,7 +96,8 @@ class MqttPublisher(
 
     /**
      * Fire-and-forget publish of a PNG outfit image to
-     * `${baseTopic}/${period.lowercased()}/image`. Piggybacks on the same
+     * `${baseTopic}/${period.lowercased()}/image`, sibling of the prose
+     * (`/text`) and audio (`/audio`) topics. Piggybacks on the same
      * MQTT bridge toggle as [publishIfEnabled] — no separate setting needed.
      * HA's `image.mqtt` integration subscribes to this topic and surfaces
      * the outfit as an `image.*` entity, which a downstream automation can
@@ -116,7 +117,8 @@ class MqttPublisher(
 
     /**
      * Fire-and-forget publish of a WAV-wrapped TTS clip to
-     * `${baseTopic}/${period.lowercased()}/audio`. Same bridge toggle as the
+     * `${baseTopic}/${period.lowercased()}/audio`, sibling of the prose
+     * (`/text`) and image (`/image`) topics. Same bridge toggle as the
      * prose and image topics — no separate setting. Only emitted when the
      * Gemini engine actually synthesised audio for local playback (device
      * TTS doesn't expose bytes), so the published clip matches what the
@@ -278,16 +280,23 @@ class MqttPublisher(
         internal const val SOCKET_CONNECT_TIMEOUT_MS = 4_000L
         internal const val MQTT_CONNECT_TIMEOUT_MS = 4_000L
 
-        fun topicFor(baseTopic: String, period: ForecastPeriod): String {
-            val trimmed = baseTopic.trim().trim('/').ifBlank { UserPreferences.DEFAULT_MQTT_TOPIC }
-            return "$trimmed/${period.name.lowercase()}"
-        }
+        // Prose / image / audio all live under `<base>/<period>/<kind>` so
+        // each payload modality is independently subscribable from HA. The
+        // text suffix keeps the prose topic symmetrical with its image and
+        // audio siblings rather than living at a bare `<base>/<period>`.
+        fun topicFor(baseTopic: String, period: ForecastPeriod): String =
+            periodTopicFor(baseTopic, period, "text")
 
         fun imageTopicFor(baseTopic: String, period: ForecastPeriod): String =
-            "${topicFor(baseTopic, period)}/image"
+            periodTopicFor(baseTopic, period, "image")
 
         fun audioTopicFor(baseTopic: String, period: ForecastPeriod): String =
-            "${topicFor(baseTopic, period)}/audio"
+            periodTopicFor(baseTopic, period, "audio")
+
+        private fun periodTopicFor(baseTopic: String, period: ForecastPeriod, kind: String): String {
+            val trimmed = baseTopic.trim().trim('/').ifBlank { UserPreferences.DEFAULT_MQTT_TOPIC }
+            return "$trimmed/${period.name.lowercase()}/$kind"
+        }
     }
 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -490,7 +490,7 @@
     <string name="settings_smart_home_mqtt_password_replace">Replace password</string>
     <string name="settings_smart_home_mqtt_password_clear">Clear saved password</string>
     <string name="settings_smart_home_mqtt_topic">Topic prefix</string>
-    <string name="settings_smart_home_mqtt_topic_hint">Today publishes to {prefix}/today; tonight to {prefix}/tonight.</string>
+    <string name="settings_smart_home_mqtt_topic_hint">Today publishes to {prefix}/today/text; tonight to {prefix}/tonight/text. Image and audio land on {prefix}/&lt;period&gt;/image and /audio.</string>
     <string name="settings_smart_home_mqtt_save">Save</string>
     <string name="settings_smart_home_mqtt_publish_now">Publish now</string>
     <string name="settings_smart_home_mqtt_publishing">Publishing…</string>

--- a/app/src/test/kotlin/app/clothescast/mqtt/MqttPublisherTest.kt
+++ b/app/src/test/kotlin/app/clothescast/mqtt/MqttPublisherTest.kt
@@ -46,7 +46,7 @@ class MqttPublisherTest {
     }
 
     @Test
-    fun `publishes today insight to today topic with retained payload`() = runTest {
+    fun `publishes today insight to today text topic with retained payload`() = runTest {
         val captured = mutableListOf<PublishCall>()
         val subject = MqttPublisher(
             preferences = flowOf(
@@ -64,7 +64,7 @@ class MqttPublisherTest {
 
         captured shouldHaveSize 1
         val call = captured.single()
-        call.topic shouldBe "clothescast/insight/today"
+        call.topic shouldBe "clothescast/default/today/text"
         call.payload.decodeToString() shouldBe "Today, cool and mild. Wear a sweater."
         call.config.host shouldBe "192.168.1.10"
         call.config.port shouldBe 1883
@@ -72,7 +72,7 @@ class MqttPublisherTest {
     }
 
     @Test
-    fun `tonight period publishes to tonight topic`() = runTest {
+    fun `tonight period publishes to tonight text topic`() = runTest {
         val captured = mutableListOf<PublishCall>()
         val subject = MqttPublisher(
             preferences = flowOf(
@@ -88,7 +88,7 @@ class MqttPublisherTest {
 
         subject.publishIfEnabled(ForecastPeriod.TONIGHT, "Tonight, clear and cool.")
 
-        captured.single().topic shouldBe "home/forecast/tonight"
+        captured.single().topic shouldBe "home/forecast/tonight/text"
     }
 
     @Test
@@ -293,34 +293,34 @@ class MqttPublisherTest {
 
     @Test
     fun `topic prefix is sanitised — leading and trailing slashes trimmed`() {
-        MqttPublisher.topicFor("/clothescast/insight/", ForecastPeriod.TODAY) shouldBe
-            "clothescast/insight/today"
+        MqttPublisher.topicFor("/clothescast/default/", ForecastPeriod.TODAY) shouldBe
+            "clothescast/default/today/text"
         MqttPublisher.topicFor("home/forecast", ForecastPeriod.TONIGHT) shouldBe
-            "home/forecast/tonight"
+            "home/forecast/tonight/text"
         // Empty / blank base falls back to the documented default so a
-        // hand-edited DataStore can't produce a bare "/today" topic.
-        MqttPublisher.topicFor("", ForecastPeriod.TODAY) shouldBe "clothescast/insight/today"
-        MqttPublisher.topicFor("   ", ForecastPeriod.TONIGHT) shouldBe "clothescast/insight/tonight"
+        // hand-edited DataStore can't produce a bare "/today/text" topic.
+        MqttPublisher.topicFor("", ForecastPeriod.TODAY) shouldBe "clothescast/default/today/text"
+        MqttPublisher.topicFor("   ", ForecastPeriod.TONIGHT) shouldBe "clothescast/default/tonight/text"
     }
 
     @Test
-    fun `imageTopicFor appends image suffix to prose topic`() {
-        MqttPublisher.imageTopicFor("clothescast/insight", ForecastPeriod.TODAY) shouldBe
-            "clothescast/insight/today/image"
+    fun `imageTopicFor builds image-suffixed topic`() {
+        MqttPublisher.imageTopicFor("clothescast/default", ForecastPeriod.TODAY) shouldBe
+            "clothescast/default/today/image"
         MqttPublisher.imageTopicFor("home/forecast", ForecastPeriod.TONIGHT) shouldBe
             "home/forecast/tonight/image"
         MqttPublisher.imageTopicFor("", ForecastPeriod.TODAY) shouldBe
-            "clothescast/insight/today/image"
+            "clothescast/default/today/image"
     }
 
     @Test
-    fun `audioTopicFor appends audio suffix to prose topic`() {
-        MqttPublisher.audioTopicFor("clothescast/insight", ForecastPeriod.TODAY) shouldBe
-            "clothescast/insight/today/audio"
+    fun `audioTopicFor builds audio-suffixed topic`() {
+        MqttPublisher.audioTopicFor("clothescast/default", ForecastPeriod.TODAY) shouldBe
+            "clothescast/default/today/audio"
         MqttPublisher.audioTopicFor("home/forecast", ForecastPeriod.TONIGHT) shouldBe
             "home/forecast/tonight/audio"
         MqttPublisher.audioTopicFor("", ForecastPeriod.TODAY) shouldBe
-            "clothescast/insight/today/audio"
+            "clothescast/default/today/audio"
     }
 
     @Test
@@ -331,7 +331,7 @@ class MqttPublisherTest {
                 basePrefs.copy(
                     mqttBridgeEnabled = true,
                     mqttHost = "broker.local",
-                    mqttTopic = "clothescast/insight",
+                    mqttTopic = "clothescast/default",
                 ),
             ),
             passwordProvider = { null },
@@ -343,7 +343,7 @@ class MqttPublisherTest {
 
         captured shouldHaveSize 1
         val call = captured.single()
-        call.topic shouldBe "clothescast/insight/today/image"
+        call.topic shouldBe "clothescast/default/today/image"
         (call.payload contentEquals fakeImage).shouldBeTrue()
     }
 
@@ -369,7 +369,7 @@ class MqttPublisherTest {
                 basePrefs.copy(
                     mqttBridgeEnabled = true,
                     mqttHost = "broker.local",
-                    mqttTopic = "clothescast/insight",
+                    mqttTopic = "clothescast/default",
                 ),
             ),
             passwordProvider = { null },
@@ -381,7 +381,7 @@ class MqttPublisherTest {
 
         captured shouldHaveSize 1
         val call = captured.single()
-        call.topic shouldBe "clothescast/insight/tonight/audio"
+        call.topic shouldBe "clothescast/default/tonight/audio"
         (call.payload contentEquals fakeWav).shouldBeTrue()
     }
 

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Settings.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Settings.kt
@@ -610,9 +610,11 @@ data class UserPreferences(
      * inline privacy note that links to PRIVACY.md.
      *
      * Topics are derived from [mqttTopic] as the prefix + the lowercased
-     * [ForecastPeriod] name (e.g. `clothescast/insight/today` and
-     * `clothescast/insight/tonight`), so morning and evening insights are
-     * separately addressable from HA automations.
+     * [ForecastPeriod] name + a payload-kind suffix (`text`, `image`,
+     * `audio`), so morning and evening insights are separately addressable
+     * from HA automations and each modality lives on its own retained
+     * topic — e.g. `clothescast/default/today/text`,
+     * `clothescast/default/today/image`, `clothescast/default/today/audio`.
      */
     val mqttBridgeEnabled: Boolean = false,
     val mqttHost: String? = null,
@@ -642,7 +644,7 @@ data class UserPreferences(
         const val DEFAULT_GEMINI_VOICE = "Despina"
         const val DEFAULT_MQTT_PORT = 1883
         const val DEFAULT_MQTT_TLS_PORT = 8883
-        const val DEFAULT_MQTT_TOPIC = "clothescast/insight"
+        const val DEFAULT_MQTT_TOPIC = "clothescast/default"
     }
 }
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -74,8 +74,8 @@ PRIVACY.md.
 Done:
 
 - [x] **MQTT publisher in the worker.** Twice-daily refresh publishes
-      `clothescast/insight/today` and `clothescast/insight/tonight` as
-      retained QoS 1 messages. Configured from a new Settings → Smart
+      `clothescast/default/today/text` and
+      `clothescast/default/tonight/text` as retained QoS 1 messages. Configured from a new Settings → Smart
       Home page (host, port, TLS, username, password, topic prefix).
       Password stored in SecureKeyStore under a separate Tink AEAD
       slot from the Gemini key. Initial PR #504, hardened against R8
@@ -112,7 +112,7 @@ Open:
       them as `image.*` entities. The shape: rasterise the
       OutfitWidget composition (top + bottom icons, ~1280x800 for
       Hub Max scaling) to PNG, publish to
-      `clothescast/insight/<period>/image` as a retained binary
+      `clothescast/default/<period>/image` as a retained binary
       payload. HA picks it up via `mqtt: image: - state_topic:` and a
       downstream automation calls `media_player.play_media` with the
       entity's `entity_picture` URL targeting the Hub's

--- a/docs/smart-home.md
+++ b/docs/smart-home.md
@@ -30,8 +30,10 @@ yourself; no developer-operated service ever sees the payload.
 4. Optionally enter a username + password. The password is stored
    encrypted on-device under the same Tink-AEAD slot the Gemini API
    key uses.
-5. Topic prefix defaults to `clothescast/insight`. Today's forecast
-   publishes to `<prefix>/today`; tonight's to `<prefix>/tonight`.
+5. Topic prefix defaults to `clothescast/default`. Today's forecast
+   publishes to `<prefix>/today/text`; tonight's to `<prefix>/tonight/text`.
+   The outfit image and TTS audio (when published) land on
+   `<prefix>/<period>/image` and `<prefix>/<period>/audio` respectively.
 6. Tap **Save**.
 
 The next scheduled refresh (07:00 by default for today, 19:00 for
@@ -81,7 +83,7 @@ topics ClothesCast actually writes:
    add-on, the **Studio Code Server** add-on, or SSH) with:
    ```
    user clothescast
-   topic write clothescast/insight/#
+   topic write clothescast/default/#
    ```
    That grants write-only access on the topic prefix and nothing else.
    Adjust the topic if you customised the prefix in the ClothesCast
@@ -118,11 +120,11 @@ mqtt:
   sensor:
     - name: "Clothescast today"
       unique_id: clothescast_today
-      state_topic: "clothescast/insight/today"
+      state_topic: "clothescast/default/today/text"
       value_template: "{{ value }}"
     - name: "Clothescast tonight"
       unique_id: clothescast_tonight
-      state_topic: "clothescast/insight/tonight"
+      state_topic: "clothescast/default/tonight/text"
       value_template: "{{ value }}"
 ```
 
@@ -134,7 +136,7 @@ subscribers on connect).
 ## Home Assistant — outfit image on Nest Hub
 
 Alongside the prose sensor, ClothesCast publishes a PNG outfit card to
-`<prefix>/<period>/image` (e.g. `clothescast/insight/today/image`). The
+`<prefix>/<period>/image` (e.g. `clothescast/default/today/image`). The
 card is 800 × 480 px (Nest Hub 7" native resolution) and shows:
 
 - Period label ("TODAY" / "TONIGHT") in Roboto Bold at the top
@@ -158,9 +160,9 @@ is implied when the entry sits under `mqtt:`):
 mqtt:
   camera:
     - name: "Clothescast today outfit"
-      topic: "clothescast/insight/today/image"
+      topic: "clothescast/default/today/image"
     - name: "Clothescast tonight outfit"
-      topic: "clothescast/insight/tonight/image"
+      topic: "clothescast/default/tonight/image"
 ```
 
 Reload MQTT (Developer Tools → YAML → Reload MQTT) or restart HA so
@@ -221,7 +223,7 @@ shape.
 
 When the Gemini TTS engine is selected (Settings → Voice → Gemini),
 ClothesCast publishes the synthesised audio as a WAV clip to
-`<prefix>/<period>/audio` (e.g. `clothescast/insight/today/audio`).
+`<prefix>/<period>/audio` (e.g. `clothescast/default/today/audio`).
 The payload is signed 16-bit mono PCM at the sample rate Gemini
 returned, wrapped in a canonical 44-byte RIFF/WAVE header — playable
 as-is by ffmpeg, browsers, and `media_player.play_media` when handed
@@ -583,7 +585,7 @@ property that applies to any wait shape.)
 - **No payload arriving.** Subscribe from a terminal that's on the
   same network as the broker:
   ```
-  mosquitto_sub -h <broker-host> -u <user> -P <pass> -t 'clothescast/insight/#' -v
+  mosquitto_sub -h <broker-host> -u <user> -P <pass> -t 'clothescast/default/#' -v
   ```
   Then trigger a refresh from the ClothesCast Today screen. The
   payload should appear within ~5 seconds of the


### PR DESCRIPTION
## Summary

- **Default prefix** moves from `clothescast/insight` to
  `clothescast/default` — the prefix isn't insight-prose-only now that
  image and audio share it, so a name that doesn't pre-commit to one
  modality reads better.
- **Prose topic** moves from a bare `<prefix>/<period>` to
  `<prefix>/<period>/text`, sitting symmetrically alongside the
  existing `<prefix>/<period>/image` and `<prefix>/<period>/audio`
  siblings rather than living at the period root.
- `topicFor` / `imageTopicFor` / `audioTopicFor` now delegate to a
  shared `periodTopicFor(base, period, kind)` builder so image / audio
  don't depend on the prose path.
- Docs (`smart-home.md`, `TODO.md`), the Settings → Smart Home
  topic-prefix hint, and the publisher tests all move to the new
  paths.

Image and audio topic *structures* are unchanged (still
`<prefix>/<period>/image` / `…/audio`); only the default prefix
value shifts.

## Test plan

- [x] `:core:domain:test :core:data:test :app:testDebugUnitTest` — green;
      `MqttPublisherTest` asserts the new paths
      (`clothescast/default/today/text`, `…/today/image`,
      `…/today/audio`, plus the custom-prefix `home/forecast/…`
      variants).
- [x] `:app:assembleDebug` — green; covers the `strings.xml` hint change.
- [ ] CI parity (waiting on the run from the latest push).
