### PR TITLE
Fix the Smart Home setting's name and subhead

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -363,7 +363,7 @@
     <string name="settings_root_calendar">Calendar</string>
     <string name="settings_root_holidays">Celebrations</string>
     <string name="settings_root_forecasters">Forecasters</string>
-    <string name="settings_root_smart_home">Smart Displays and Home Automation</string>
+    <string name="settings_root_smart_home">Smart Home</string>
     <string name="settings_root_privacy">Privacy</string>
     <string name="settings_root_about">About</string>
 
@@ -398,7 +398,7 @@
     <string name="settings_root_calendar_subtitle">Today\'s events</string>
     <string name="settings_root_holidays_subtitle">Holidays and Birthdays</string>
     <string name="settings_root_forecasters_subtitle">Weather Sources and Models</string>
-    <string name="settings_root_smart_home_subtitle">Cast to smart displays, Home Assistant, MQTT</string>
+    <string name="settings_root_smart_home_subtitle">Smart Displays and Home Automation</string>
     <string name="settings_root_privacy_subtitle">Crash + usage reports</string>
 
     <!-- Forecasters sub-page: lets the user pick which numerical weather


### PR DESCRIPTION
## Summary

The previous change to the Smart Home section labels swapped the two values. Restoring the intended split:

- **Row name** in the settings root list: `Smart Home` (short, matches the rest of the root list's one- or two-word entries).
- **Subhead** below the row: `Smart Displays and Home Automation` (expands what the section covers without burying the short name).

Pre-fix (after the original rename): `Smart Displays and Home Automation` / `Cast to smart displays, Home Assistant, MQTT`. Post-fix: as above.

Settings root list snapshot will regenerate via the CI bot on this push.

## Test plan

- [x] `:app:compileDebugKotlin` — strings-only change.
- [ ] Settings root list snapshot regen lands correctly via CI bot.

https://claude.ai/code/session_01UzW8WNWEw7x4oPJVG9zmyP

---
_Generated by [Claude Code](https://claude.ai/code/session_01UzW8WNWEw7x4oPJVG9zmyP)_