### PR TITLE
Mirror MQTT publishes to a /now topic so consumers can subscribe to one "latest" topic

### DIFF
--- a/app/src/main/kotlin/app/clothescast/MainActivity.kt
+++ b/app/src/main/kotlin/app/clothescast/MainActivity.kt
@@ -378,8 +378,11 @@ private fun ClothesCastNav(app: ClothesCastApplication, navigateToTodayVersion: 
                             ?: return@Factory app.mqttPublisher.publishTest()
                         val formatter = InsightFormatter.forRegion(context, prefs.region, prefs.temperatureUnit)
                         val prose = formatter.format(insight.summary)
-                        val outcome = app.mqttPublisher.publishIfEnabled(insight.period, prose)
-                        insight.outfit?.let { outfit ->
+                        // Render the outfit card up-front so the bundle publish
+                        // can co-ordinate prose + image and emit a consistent
+                        // /now/* set. A render failure degrades to a prose-only
+                        // bundle rather than skipping the publish entirely.
+                        val png: ByteArray? = insight.outfit?.let { outfit ->
                             runCatching {
                                 val info = outfitCardInfoLines(
                                     context = context,
@@ -407,7 +410,7 @@ private fun ClothesCastNav(app: ClothesCastApplication, navigateToTodayVersion: 
                                     theme?.topStrokeOverrides ?: emptyMap()
                                 val bottomStrokes: Map<OutfitSuggestion.Bottom, Long> =
                                     theme?.bottomStrokeOverrides ?: emptyMap()
-                                val png = renderOutfitCard(
+                                renderOutfitCard(
                                     context = context,
                                     outfit = outfit,
                                     header = header,
@@ -421,10 +424,9 @@ private fun ClothesCastNav(app: ClothesCastApplication, navigateToTodayVersion: 
                                     topStrokes = topStrokes,
                                     bottomStrokes = bottomStrokes,
                                 )
-                                app.mqttPublisher.publishImageIfEnabled(insight.period, png)
-                            }
+                            }.getOrNull()
                         }
-                        outcome
+                        app.mqttPublisher.publishIfEnabled(insight.period, prose, image = png)
                     },
                     discovery = app.homeAssistantDiscovery,
                     castRouteDiscovery = app.castRouteDiscovery,

--- a/app/src/main/kotlin/app/clothescast/mqtt/MqttPublisher.kt
+++ b/app/src/main/kotlin/app/clothescast/mqtt/MqttPublisher.kt
@@ -7,6 +7,8 @@ import com.hivemq.client.mqtt.MqttClient
 import com.hivemq.client.mqtt.datatypes.MqttQos
 import com.hivemq.client.mqtt.mqtt3.Mqtt3AsyncClient
 import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
@@ -53,26 +55,137 @@ class MqttPublisher(
 ) {
 
     /**
-     * Publishes to `${baseTopic}/${period.lowercased()}/text` and returns an
-     * [MqttPublishOutcome] so the caller can persist the result for display.
-     * Returns [MqttPublishOutcome.NotConfigured] (silently) when the bridge is
-     * disabled or no host is set. Any network failure (DNS, connection, broker
-     * rejection, timeout) is logged, swallowed, and returned as
-     * [MqttPublishOutcome.Failure] — the caller's worker must succeed regardless
-     * of broker reachability.
+     * Publishes a delivery's prose, optional outfit image, and optional TTS
+     * audio as a single coordinated bundle. The period-specific topics
+     * (`${baseTopic}/${period.lowercased()}/{text,image,audio}`) fan out in
+     * parallel — they're independent surfaces and a slow image upload
+     * shouldn't hold up the prose.
+     *
+     * The `${baseTopic}/now/{text,image,audio}` mirrors are treated as an
+     * atomic three-topic bundle. They fire only when **every** submitted
+     * modality's period publish succeeded; then `now/image` and `now/audio`
+     * publish in parallel and `now/text` lands **last**. The text-last
+     * ordering matters because `now/text` is the natural state-change
+     * trigger surface for an HA automation — having it update last
+     * guarantees a consumer subscribing to `now/text` reads a `now/image`
+     * and `now/audio` from the same forecast.
+     *
+     * Modalities absent from the current delivery (e.g. an outfit render
+     * failed, or the user is on device TTS so no audio bytes exist) still
+     * touch their now slot: an empty retained payload is published, the
+     * MQTT convention for "delete the retained message". Without that
+     * clear, a `now/text` consumer would read the previous bundle's image
+     * or audio mixed with the new prose. `now/text` is additionally held
+     * back if either `now/image` or `now/audio` publish fails, so a
+     * `now/text` update always implies a coherent `now/image` and
+     * `now/audio` settled successfully.
+     *
+     * If any submitted modality's *period* publish fails, the entire
+     * `now` mirror is skipped: a stale-but-coherent retained bundle from
+     * the last fully-successful run is more honest than a half-updated mix
+     * of new and old payloads on the unified surface. Mirror failures on
+     * any of the `now` topics themselves do not override the returned
+     * prose outcome — the Settings UI status row continues to reflect only
+     * the authoritative period prose publish, the modality the user
+     * actually sees in notifications.
+     *
+     * **Limit of MQTT-level atomicity.** MQTT has no transactional primitive
+     * across topics: once `now/image` has been accepted by the broker as a
+     * retained message, a subsequent `now/audio` rejection (per-topic ACL,
+     * payload-size limit) cannot un-publish it. For a continuously-
+     * subscribed consumer this is fine — they watch `now/text`, which is
+     * the trigger surface and stays held back when sibling mirrors fail —
+     * but a *fresh-reconnect* consumer that reads all three retained
+     * topics during a partial-failure window may briefly observe a new
+     * `now/image` paired with an old `now/audio` and `now/text`. True
+     * atomicity across the bundle would require a versioned-topic +
+     * pointer protocol (publish to `now/v123/{text,image,audio}`, then
+     * update a `now/version` pointer last) and a corresponding change to
+     * the consumer contract; out of scope for the current "subscribe to
+     * `now/text`" surface.
+     *
+     * Returns the prose primary's outcome. Network failures (DNS,
+     * connection, broker rejection, timeout) are logged, swallowed, and
+     * surfaced as [MqttPublishOutcome.Failure]; the caller's worker must
+     * succeed regardless of broker reachability.
      */
-    suspend fun publishIfEnabled(period: ForecastPeriod, prose: String): MqttPublishOutcome {
-        val prepared = preparePublish(context = period.name.lowercase()) ?: return MqttPublishOutcome.NotConfigured
-        val topic = topicFor(prepared.baseTopic, period)
+    suspend fun publishIfEnabled(
+        period: ForecastPeriod,
+        prose: String,
+        image: ByteArray? = null,
+        audio: ByteArray? = null,
+    ): MqttPublishOutcome = coroutineScope {
+        val prepared = preparePublish(context = period.name.lowercase())
+            ?: return@coroutineScope MqttPublishOutcome.NotConfigured
+        val proseBytes = prose.toByteArray(Charsets.UTF_8)
+        val proseTopic = topicFor(prepared.baseTopic, period)
+        val imageTopic = imageTopicFor(prepared.baseTopic, period)
+        val audioTopic = audioTopicFor(prepared.baseTopic, period)
+        val nowTextTopic = nowTopicFor(prepared.baseTopic)
+        val nowImageTopic = nowImageTopicFor(prepared.baseTopic)
+        val nowAudioTopic = nowAudioTopicFor(prepared.baseTopic)
         DiagLog.i(
             TAG,
-            "MQTT bridge enabled; publishing ${period.name.lowercase()} insight to " +
-                "${prepared.scheme}://${prepared.host}:${prepared.port}/$topic " +
-                "(auth=${!prepared.config.username.isNullOrBlank()}, " +
+            "MQTT bridge enabled; publishing ${period.name.lowercase()} insight bundle to " +
+                "${prepared.scheme}://${prepared.host}:${prepared.port}/$proseTopic " +
+                "(image=${image != null}, audio=${audio != null}, " +
+                "mirrored to $nowTextTopic with $nowImageTopic / $nowAudioTopic landing first, " +
+                "auth=${!prepared.config.username.isNullOrBlank()}, " +
                 "password=${if (prepared.config.password != null) "set" else "none"}, " +
                 "payload=${prose.length} chars).",
         )
-        return executePublish(prepared, topic, prose.toByteArray(Charsets.UTF_8))
+
+        val proseDeferred = async { executePublish(prepared, proseTopic, proseBytes) }
+        val imageDeferred = image?.let { bytes -> async { executePublish(prepared, imageTopic, bytes) } }
+        val audioDeferred = audio?.let { bytes -> async { executePublish(prepared, audioTopic, bytes) } }
+        val proseOutcome = proseDeferred.await()
+        val imageOutcome = imageDeferred?.await()
+        val audioOutcome = audioDeferred?.await()
+
+        val everySubmittedSucceeded = proseOutcome is MqttPublishOutcome.Success &&
+            (imageOutcome == null || imageOutcome is MqttPublishOutcome.Success) &&
+            (audioOutcome == null || audioOutcome is MqttPublishOutcome.Success)
+
+        if (everySubmittedSucceeded) {
+            // The now surface is treated as an atomic three-topic bundle. Any
+            // modality absent from this delivery clears its retained slot via
+            // an empty-payload publish (the MQTT convention for "delete the
+            // retained message") so a now/text-triggered consumer can't read
+            // a stale image or audio left over from a previous bundle that
+            // *did* carry one. now/text is then held back until both image
+            // and audio mirrors settle successfully, so an automation
+            // subscribing to now/text never sees the trigger advance before
+            // the rest of the now bundle is coherent.
+            val emptyPayload = ByteArray(0)
+            val nowImageMirror = async {
+                executePublish(prepared, nowImageTopic, image ?: emptyPayload)
+            }
+            val nowAudioMirror = async {
+                executePublish(prepared, nowAudioTopic, audio ?: emptyPayload)
+            }
+            val nowImageOutcome = nowImageMirror.await()
+            val nowAudioOutcome = nowAudioMirror.await()
+            if (nowImageOutcome is MqttPublishOutcome.Success &&
+                nowAudioOutcome is MqttPublishOutcome.Success
+            ) {
+                executePublish(prepared, nowTextTopic, proseBytes)
+            } else {
+                DiagLog.i(
+                    TAG,
+                    "Holding back $nowTextTopic mirror for ${period.name.lowercase()} " +
+                        "bundle (now/image=$nowImageOutcome, now/audio=$nowAudioOutcome); " +
+                        "trigger topic stays at the previous bundle to keep the now set coherent.",
+                )
+            }
+        } else {
+            DiagLog.i(
+                TAG,
+                "Skipping /now mirror for ${period.name.lowercase()} bundle " +
+                    "(prose=$proseOutcome, image=$imageOutcome, audio=$audioOutcome); " +
+                    "previous retained /now bundle stays intact.",
+            )
+        }
+        proseOutcome
     }
 
     /**
@@ -92,49 +205,6 @@ class MqttPublisher(
             "MQTT test publish to ${prepared.scheme}://${prepared.host}:${prepared.port}/$topic.",
         )
         return executePublish(prepared, topic, "ClothesCast: connection test".toByteArray(Charsets.UTF_8))
-    }
-
-    /**
-     * Fire-and-forget publish of a PNG outfit image to
-     * `${baseTopic}/${period.lowercased()}/image`, sibling of the prose
-     * (`/text`) and audio (`/audio`) topics. Piggybacks on the same
-     * MQTT bridge toggle as [publishIfEnabled] — no separate setting needed.
-     * HA's `image.mqtt` integration subscribes to this topic and surfaces
-     * the outfit as an `image.*` entity, which a downstream automation can
-     * push to a Nest Hub via `media_player.play_media`.
-     */
-    suspend fun publishImageIfEnabled(period: ForecastPeriod, imageBytes: ByteArray) {
-        val prepared = preparePublish(context = "${period.name.lowercase()} outfit image") ?: return
-        val topic = imageTopicFor(prepared.baseTopic, period)
-        DiagLog.i(
-            TAG,
-            "MQTT bridge enabled; publishing ${period.name.lowercase()} outfit image " +
-                "(${imageBytes.size} bytes) to " +
-                "${prepared.scheme}://${prepared.host}:${prepared.port}/$topic.",
-        )
-        executePublish(prepared, topic, imageBytes)
-    }
-
-    /**
-     * Fire-and-forget publish of a WAV-wrapped TTS clip to
-     * `${baseTopic}/${period.lowercased()}/audio`, sibling of the prose
-     * (`/text`) and image (`/image`) topics. Same bridge toggle as the
-     * prose and image topics — no separate setting. Only emitted when the
-     * Gemini engine actually synthesised audio for local playback (device
-     * TTS doesn't expose bytes), so the published clip matches what the
-     * phone speaks. The companion HA automation can either fetch this as a
-     * media URL or use the retained payload to trigger `media_player`.
-     */
-    suspend fun publishAudioIfEnabled(period: ForecastPeriod, wavBytes: ByteArray) {
-        val prepared = preparePublish(context = "${period.name.lowercase()} TTS audio") ?: return
-        val topic = audioTopicFor(prepared.baseTopic, period)
-        DiagLog.i(
-            TAG,
-            "MQTT bridge enabled; publishing ${period.name.lowercase()} TTS audio " +
-                "(${wavBytes.size} bytes) to " +
-                "${prepared.scheme}://${prepared.host}:${prepared.port}/$topic.",
-        )
-        executePublish(prepared, topic, wavBytes)
     }
 
     /**
@@ -293,9 +363,24 @@ class MqttPublisher(
         fun audioTopicFor(baseTopic: String, period: ForecastPeriod): String =
             periodTopicFor(baseTopic, period, "audio")
 
+        // `<base>/now/<kind>` mirrors the most recently published period
+        // payload (today or tonight) so a consumer can subscribe to a single
+        // topic without having to reason about which window is "current" or
+        // chase recency timestamps across the two period topics.
+        fun nowTopicFor(baseTopic: String): String = nowTopicForKind(baseTopic, "text")
+
+        fun nowImageTopicFor(baseTopic: String): String = nowTopicForKind(baseTopic, "image")
+
+        fun nowAudioTopicFor(baseTopic: String): String = nowTopicForKind(baseTopic, "audio")
+
         private fun periodTopicFor(baseTopic: String, period: ForecastPeriod, kind: String): String {
             val trimmed = baseTopic.trim().trim('/').ifBlank { UserPreferences.DEFAULT_MQTT_TOPIC }
             return "$trimmed/${period.name.lowercase()}/$kind"
+        }
+
+        private fun nowTopicForKind(baseTopic: String, kind: String): String {
+            val trimmed = baseTopic.trim().trim('/').ifBlank { UserPreferences.DEFAULT_MQTT_TOPIC }
+            return "$trimmed/now/$kind"
         }
     }
 }

--- a/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
@@ -655,35 +655,23 @@ class FetchAndNotifyWorker(
                     castDestination(insight, prefs, wav = wav, png = png)
                 } else null
 
-            // Prose-publish outcome drives the Smart Home settings
-            // status row; the await + persistence runs after the
-            // sibling jobs join so the call doesn't block them.
-            val mqttProseDeferred: Deferred<MqttPublishOutcome?> = async {
+            // Prose-publish outcome drives the Smart Home settings status
+            // row; the bundle publish handles prose + image + audio for the
+            // period and then mirrors the lot to /now in a coordinated
+            // order (image/audio first, text last) so an HA automation
+            // triggered on `/now/text` sees a consistent `/now/image` /
+            // `/now/audio` from the same forecast rather than a stale
+            // payload from the previous period.
+            val mqttDeferred: Deferred<MqttPublishOutcome?> = async {
                 if (!gates.mqttPublishable) null
-                else runCatching { app.mqttPublisher.publishIfEnabled(insight.period, prose) }
+                else runCatching {
+                    app.mqttPublisher.publishIfEnabled(insight.period, prose, image = png, audio = wav)
+                }
                     .onFailure { t ->
                         if (t is CancellationException) throw t
-                        DiagLog.w(TAG, "MQTT prose publish failed.", t)
+                        DiagLog.w(TAG, "MQTT insight bundle publish failed.", t)
                     }
                     .getOrNull()
-            }
-
-            val mqttImageJob = launch {
-                if (!gates.mqttPublishable || png == null) return@launch
-                runCatching { app.mqttPublisher.publishImageIfEnabled(insight.period, png) }
-                    .onFailure { t ->
-                        if (t is CancellationException) throw t
-                        DiagLog.w(TAG, "MQTT image publish failed.", t)
-                    }
-            }
-
-            val mqttAudioJob = launch {
-                if (!gates.mqttPublishable || wav == null) return@launch
-                runCatching { app.mqttPublisher.publishAudioIfEnabled(insight.period, wav) }
-                    .onFailure { t ->
-                        if (t is CancellationException) throw t
-                        DiagLog.w(TAG, "MQTT audio publish failed.", t)
-                    }
             }
 
             val phoneSpeakerJob = launch {
@@ -691,10 +679,8 @@ class FetchAndNotifyWorker(
             }
 
             notifyJob.join()
-            mqttImageJob.join()
-            mqttAudioJob.join()
             phoneSpeakerJob.join()
-            val mqttOutcome = mqttProseDeferred.await()
+            val mqttOutcome = mqttDeferred.await()
             // Only persist a cast outcome when we actually attempted
             // one — same condition that gates castDeferred above.
             // An empty-evening tonight skip with a picked route still

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -496,7 +496,7 @@
     <string name="settings_smart_home_mqtt_password_replace">Replace password</string>
     <string name="settings_smart_home_mqtt_password_clear">Clear saved password</string>
     <string name="settings_smart_home_mqtt_topic">Topic prefix</string>
-    <string name="settings_smart_home_mqtt_topic_hint">Today publishes to {prefix}/today/text; tonight to {prefix}/tonight/text. Image and audio land on {prefix}/&lt;period&gt;/image and /audio.</string>
+    <string name="settings_smart_home_mqtt_topic_hint">Today publishes to {prefix}/today/text; tonight to {prefix}/tonight/text. Image and audio land on {prefix}/&lt;period&gt;/image and /audio. Each publish is also mirrored to {prefix}/now/&lt;text|image|audio&gt; so a consumer can subscribe to one \"latest\" topic without choosing today vs tonight.</string>
     <string name="settings_smart_home_mqtt_save">Save</string>
     <string name="settings_smart_home_mqtt_publish_now">Publish now</string>
     <string name="settings_smart_home_mqtt_publishing">Publishing…</string>

--- a/app/src/test/kotlin/app/clothescast/mqtt/MqttPublisherTest.kt
+++ b/app/src/test/kotlin/app/clothescast/mqtt/MqttPublisherTest.kt
@@ -8,7 +8,10 @@ import app.clothescast.core.domain.model.TemperatureUnit
 import app.clothescast.core.domain.model.UserPreferences
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldContainAll
 import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.collections.shouldNotBeEmpty
+import io.kotest.matchers.ints.shouldBeGreaterThan
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.Dispatchers
@@ -46,7 +49,7 @@ class MqttPublisherTest {
     }
 
     @Test
-    fun `publishes today insight to today text topic with retained payload`() = runTest {
+    fun `prose-only bundle clears now image and audio with empty payload before now text`() = runTest {
         val captured = mutableListOf<PublishCall>()
         val subject = MqttPublisher(
             preferences = flowOf(
@@ -62,17 +65,28 @@ class MqttPublisherTest {
 
         subject.publishIfEnabled(ForecastPeriod.TODAY, "Today, cool and mild. Wear a sweater.")
 
-        captured shouldHaveSize 1
-        val call = captured.single()
-        call.topic shouldBe "clothescast/default/today/text"
-        call.payload.decodeToString() shouldBe "Today, cool and mild. Wear a sweater."
-        call.config.host shouldBe "192.168.1.10"
-        call.config.port shouldBe 1883
-        call.config.useTls shouldBe false
+        val topics = captured.map { it.topic }
+        topics shouldContainAll listOf(
+            "clothescast/default/today/text",
+            "clothescast/default/now/image",
+            "clothescast/default/now/audio",
+            "clothescast/default/now/text",
+        )
+        // now/image and now/audio land *before* now/text so a now/text-triggered
+        // consumer never reads a stale image/audio from a previous bundle.
+        val nowTextIdx = topics.indexOf("clothescast/default/now/text")
+        nowTextIdx shouldBeGreaterThan topics.indexOf("clothescast/default/now/image")
+        nowTextIdx shouldBeGreaterThan topics.indexOf("clothescast/default/now/audio")
+        // Absent modalities are cleared with an empty retained payload — the
+        // MQTT convention for "delete the retained message".
+        captured.first { it.topic == "clothescast/default/now/image" }.payload.size shouldBe 0
+        captured.first { it.topic == "clothescast/default/now/audio" }.payload.size shouldBe 0
+        captured.first { it.topic == "clothescast/default/now/text" }.payload.decodeToString() shouldBe
+            "Today, cool and mild. Wear a sweater."
     }
 
     @Test
-    fun `tonight period publishes to tonight text topic`() = runTest {
+    fun `tonight period publishes to tonight text topic, mirrored to now`() = runTest {
         val captured = mutableListOf<PublishCall>()
         val subject = MqttPublisher(
             preferences = flowOf(
@@ -88,7 +102,104 @@ class MqttPublisherTest {
 
         subject.publishIfEnabled(ForecastPeriod.TONIGHT, "Tonight, clear and cool.")
 
-        captured.single().topic shouldBe "home/forecast/tonight/text"
+        captured.map { it.topic } shouldContainAll listOf(
+            "home/forecast/tonight/text",
+            "home/forecast/now/image",
+            "home/forecast/now/audio",
+            "home/forecast/now/text",
+        )
+    }
+
+    @Test
+    fun `now mirror is skipped when period publish fails`() = runTest {
+        val captured = mutableListOf<PublishCall>()
+        val subject = MqttPublisher(
+            preferences = flowOf(
+                basePrefs.copy(mqttBridgeEnabled = true, mqttHost = "broker.local"),
+            ),
+            passwordProvider = { null },
+            publish = { config, topic, payload ->
+                captured.add(PublishCall(config, topic, payload))
+                error("simulated broker rejection")
+            },
+            retryDelayMs = 1L,
+        )
+
+        val outcome = subject.publishIfEnabled(ForecastPeriod.TODAY, "x")
+
+        outcome.shouldBeInstanceOf<MqttPublishOutcome.Failure>()
+        // Both retry attempts target the period topic; the /now mirror is
+        // deliberately skipped so a stale-but-truthful retained payload
+        // survives instead of being overwritten by a half-failed run.
+        captured.map { it.topic }.distinct() shouldBe listOf("clothescast/default/today/text")
+    }
+
+    @Test
+    fun `now text mirror failure does not override period success outcome`() = runTest {
+        val captured = mutableListOf<PublishCall>()
+        val subject = MqttPublisher(
+            preferences = flowOf(
+                basePrefs.copy(mqttBridgeEnabled = true, mqttHost = "broker.local"),
+            ),
+            passwordProvider = { null },
+            publish = { config, topic, payload ->
+                captured.add(PublishCall(config, topic, payload))
+                if (topic.endsWith("/now/text")) error("mirror failure")
+            },
+            retryDelayMs = 1L,
+        )
+
+        val outcome = subject.publishIfEnabled(ForecastPeriod.TODAY, "x")
+
+        outcome shouldBe MqttPublishOutcome.Success
+        // /now/text exhausts its retries (broker keeps rejecting it). The
+        // prose primary already succeeded, so the Settings UI status row
+        // continues to surface Success — the mirror is a side channel.
+        captured.count { it.topic == "clothescast/default/now/text" } shouldBe 2
+    }
+
+    @Test
+    fun `now text mirror is held back when now image mirror fails`() = runTest {
+        val captured = mutableListOf<PublishCall>()
+        val subject = MqttPublisher(
+            preferences = flowOf(
+                basePrefs.copy(mqttBridgeEnabled = true, mqttHost = "broker.local"),
+            ),
+            passwordProvider = { null },
+            publish = { config, topic, payload ->
+                captured.add(PublishCall(config, topic, payload))
+                if (topic.endsWith("/now/image")) error("now/image mirror failure")
+            },
+            retryDelayMs = 1L,
+        )
+
+        val outcome = subject.publishIfEnabled(ForecastPeriod.TODAY, "x")
+
+        outcome shouldBe MqttPublishOutcome.Success
+        // /now/text is deliberately held back so consumers triggered on it
+        // don't read a now/image that's still the previous bundle's payload.
+        captured.none { it.topic.endsWith("/now/text") }.shouldBeTrue()
+    }
+
+    @Test
+    fun `now text mirror is held back when now audio mirror fails`() = runTest {
+        val captured = mutableListOf<PublishCall>()
+        val subject = MqttPublisher(
+            preferences = flowOf(
+                basePrefs.copy(mqttBridgeEnabled = true, mqttHost = "broker.local"),
+            ),
+            passwordProvider = { null },
+            publish = { config, topic, payload ->
+                captured.add(PublishCall(config, topic, payload))
+                if (topic.endsWith("/now/audio")) error("now/audio mirror failure")
+            },
+            retryDelayMs = 1L,
+        )
+
+        val outcome = subject.publishIfEnabled(ForecastPeriod.TODAY, "x")
+
+        outcome shouldBe MqttPublishOutcome.Success
+        captured.none { it.topic.endsWith("/now/text") }.shouldBeTrue()
     }
 
     @Test
@@ -151,7 +262,8 @@ class MqttPublisherTest {
         subject.publishIfEnabled(ForecastPeriod.TODAY, "x")
 
         passwordCalls shouldBe 0
-        captured.single().config.password shouldBe null
+        captured.shouldNotBeEmpty()
+        captured.first().config.password shouldBe null
     }
 
     @Test
@@ -171,7 +283,7 @@ class MqttPublisherTest {
 
         subject.publishIfEnabled(ForecastPeriod.TODAY, "x")
 
-        val call = captured.single()
+        val call = captured.first()
         call.config.username shouldBe "mqtt-user"
         call.config.password shouldBe "secret-from-keystore"
     }
@@ -314,6 +426,16 @@ class MqttPublisherTest {
     }
 
     @Test
+    fun `now topic builders use the now segment regardless of period`() {
+        MqttPublisher.nowTopicFor("clothescast/default") shouldBe "clothescast/default/now/text"
+        MqttPublisher.nowImageTopicFor("home/forecast") shouldBe "home/forecast/now/image"
+        MqttPublisher.nowAudioTopicFor("/clothescast/default/") shouldBe "clothescast/default/now/audio"
+        // Empty / blank base falls back to the documented default.
+        MqttPublisher.nowTopicFor("") shouldBe "clothescast/default/now/text"
+        MqttPublisher.nowTopicFor("   ") shouldBe "clothescast/default/now/text"
+    }
+
+    @Test
     fun `audioTopicFor builds audio-suffixed topic`() {
         MqttPublisher.audioTopicFor("clothescast/default", ForecastPeriod.TODAY) shouldBe
             "clothescast/default/today/audio"
@@ -324,7 +446,7 @@ class MqttPublisherTest {
     }
 
     @Test
-    fun `publishImageIfEnabled publishes PNG bytes to image topic`() = runTest {
+    fun `bundle with image publishes period prose and image, mirrors both with text last and audio cleared`() = runTest {
         val captured = mutableListOf<PublishCall>()
         val subject = MqttPublisher(
             preferences = flowOf(
@@ -339,30 +461,29 @@ class MqttPublisherTest {
         )
         val fakeImage = byteArrayOf(0x89.toByte(), 0x50, 0x4E, 0x47) // PNG magic bytes
 
-        subject.publishImageIfEnabled(ForecastPeriod.TODAY, fakeImage)
+        subject.publishIfEnabled(ForecastPeriod.TODAY, "prose", image = fakeImage)
 
-        captured shouldHaveSize 1
-        val call = captured.single()
-        call.topic shouldBe "clothescast/default/today/image"
-        (call.payload contentEquals fakeImage).shouldBeTrue()
-    }
-
-    @Test
-    fun `publishImageIfEnabled no-op when bridge disabled`() = runTest {
-        val captured = mutableListOf<PublishCall>()
-        val subject = MqttPublisher(
-            preferences = flowOf(basePrefs.copy(mqttBridgeEnabled = false, mqttHost = "broker.local")),
-            passwordProvider = { null },
-            publish = capturing(captured),
+        val topics = captured.map { it.topic }
+        topics shouldContainAll listOf(
+            "clothescast/default/today/text",
+            "clothescast/default/today/image",
+            "clothescast/default/now/image",
+            "clothescast/default/now/audio",
+            "clothescast/default/now/text",
         )
-
-        subject.publishImageIfEnabled(ForecastPeriod.TODAY, byteArrayOf(1, 2, 3))
-
-        captured shouldHaveSize 0
+        // /now/text must land *after* both /now/image and /now/audio so a
+        // text-triggered HA automation sees a consistent now bundle.
+        val nowTextIdx = topics.indexOf("clothescast/default/now/text")
+        nowTextIdx shouldBeGreaterThan topics.indexOf("clothescast/default/now/image")
+        nowTextIdx shouldBeGreaterThan topics.indexOf("clothescast/default/now/audio")
+        captured.first { it.topic == "clothescast/default/today/image" }.payload contentEquals fakeImage shouldBe true
+        captured.first { it.topic == "clothescast/default/now/image" }.payload contentEquals fakeImage shouldBe true
+        // Audio absent from the bundle → /now/audio cleared with empty payload.
+        captured.first { it.topic == "clothescast/default/now/audio" }.payload.size shouldBe 0
     }
 
     @Test
-    fun `publishAudioIfEnabled publishes WAV bytes to audio topic`() = runTest {
+    fun `bundle with image and audio sequences now-text last after now-image and now-audio`() = runTest {
         val captured = mutableListOf<PublishCall>()
         val subject = MqttPublisher(
             preferences = flowOf(
@@ -375,18 +496,82 @@ class MqttPublisherTest {
             passwordProvider = { null },
             publish = capturing(captured),
         )
-        val fakeWav = byteArrayOf(0x52, 0x49, 0x46, 0x46) // "RIFF" header magic
+        val fakeImage = byteArrayOf(0x89.toByte(), 0x50, 0x4E, 0x47)
+        val fakeWav = byteArrayOf(0x52, 0x49, 0x46, 0x46) // "RIFF"
 
-        subject.publishAudioIfEnabled(ForecastPeriod.TONIGHT, fakeWav)
+        subject.publishIfEnabled(ForecastPeriod.TONIGHT, "prose", image = fakeImage, audio = fakeWav)
 
-        captured shouldHaveSize 1
-        val call = captured.single()
-        call.topic shouldBe "clothescast/default/tonight/audio"
-        (call.payload contentEquals fakeWav).shouldBeTrue()
+        val topics = captured.map { it.topic }
+        topics shouldContainAll listOf(
+            "clothescast/default/tonight/text",
+            "clothescast/default/tonight/image",
+            "clothescast/default/tonight/audio",
+            "clothescast/default/now/image",
+            "clothescast/default/now/audio",
+            "clothescast/default/now/text",
+        )
+        val nowTextIdx = topics.indexOf("clothescast/default/now/text")
+        nowTextIdx shouldBeGreaterThan topics.indexOf("clothescast/default/now/image")
+        nowTextIdx shouldBeGreaterThan topics.indexOf("clothescast/default/now/audio")
     }
 
     @Test
-    fun `publishAudioIfEnabled no-op when bridge disabled`() = runTest {
+    fun `bundle skips all now mirrors when image primary fails`() = runTest {
+        val captured = mutableListOf<PublishCall>()
+        val subject = MqttPublisher(
+            preferences = flowOf(
+                basePrefs.copy(mqttBridgeEnabled = true, mqttHost = "broker.local"),
+            ),
+            passwordProvider = { null },
+            publish = { config, topic, payload ->
+                captured.add(PublishCall(config, topic, payload))
+                if (topic.endsWith("/today/image")) error("image broker rejection")
+            },
+            retryDelayMs = 1L,
+        )
+
+        val outcome = subject.publishIfEnabled(
+            ForecastPeriod.TODAY,
+            "prose",
+            image = byteArrayOf(0x89.toByte(), 0x50, 0x4E, 0x47),
+        )
+
+        // Prose primary succeeded so the outcome is Success — what the
+        // Settings UI surfaces. The /now bundle is still skipped because
+        // image primary failed, so the previous retained /now bundle stays
+        // intact instead of mixing today's text with last period's image.
+        outcome shouldBe MqttPublishOutcome.Success
+        captured.map { it.topic }.none { "/now/" in it }.shouldBeTrue()
+    }
+
+    @Test
+    fun `bundle skips all now mirrors when audio primary fails`() = runTest {
+        val captured = mutableListOf<PublishCall>()
+        val subject = MqttPublisher(
+            preferences = flowOf(
+                basePrefs.copy(mqttBridgeEnabled = true, mqttHost = "broker.local"),
+            ),
+            passwordProvider = { null },
+            publish = { config, topic, payload ->
+                captured.add(PublishCall(config, topic, payload))
+                if (topic.endsWith("/today/audio")) error("audio broker rejection")
+            },
+            retryDelayMs = 1L,
+        )
+
+        val outcome = subject.publishIfEnabled(
+            ForecastPeriod.TODAY,
+            "prose",
+            image = byteArrayOf(0x89.toByte(), 0x50, 0x4E, 0x47),
+            audio = byteArrayOf(0x52, 0x49, 0x46, 0x46),
+        )
+
+        outcome shouldBe MqttPublishOutcome.Success
+        captured.map { it.topic }.none { "/now/" in it }.shouldBeTrue()
+    }
+
+    @Test
+    fun `bundle with bridge disabled performs no publishes`() = runTest {
         val captured = mutableListOf<PublishCall>()
         val subject = MqttPublisher(
             preferences = flowOf(basePrefs.copy(mqttBridgeEnabled = false, mqttHost = "broker.local")),
@@ -394,7 +579,12 @@ class MqttPublisherTest {
             publish = capturing(captured),
         )
 
-        subject.publishAudioIfEnabled(ForecastPeriod.TODAY, byteArrayOf(1, 2, 3))
+        subject.publishIfEnabled(
+            ForecastPeriod.TODAY,
+            "prose",
+            image = byteArrayOf(1, 2, 3),
+            audio = byteArrayOf(4, 5, 6),
+        )
 
         captured shouldHaveSize 0
     }
@@ -468,7 +658,16 @@ class MqttPublisherTest {
         val outcome = subject.publishIfEnabled(ForecastPeriod.TODAY, "x")
 
         outcome shouldBe MqttPublishOutcome.Success
-        attempts shouldHaveSize 2
+        // Period prose retries once, then the /now bundle (image clear, audio
+        // clear, text) all succeed. First two attempts are the retried period
+        // publish; the remaining three are the coordinated /now mirrors.
+        attempts.map { it.topic } shouldBe listOf(
+            "clothescast/default/today/text",
+            "clothescast/default/today/text",
+            "clothescast/default/now/image",
+            "clothescast/default/now/audio",
+            "clothescast/default/now/text",
+        )
     }
 
     @Test
@@ -495,18 +694,25 @@ class MqttPublisherTest {
 
     @Test
     fun `successful first attempt does not retry`() = runTest {
-        var attempts = 0
+        val attempts = mutableListOf<String>()
         val subject = MqttPublisher(
             preferences = flowOf(
                 basePrefs.copy(mqttBridgeEnabled = true, mqttHost = "broker.local"),
             ),
             passwordProvider = { null },
-            publish = { _, _, _ -> attempts += 1 },
+            publish = { _, topic, _ -> attempts += topic },
             retryDelayMs = 1L,
         )
 
         subject.publishIfEnabled(ForecastPeriod.TODAY, "x") shouldBe MqttPublishOutcome.Success
-        attempts shouldBe 1
+        // No retries on the period publish; the remaining attempts are the
+        // coordinated /now bundle (image clear, audio clear, then text last).
+        attempts shouldBe listOf(
+            "clothescast/default/today/text",
+            "clothescast/default/now/image",
+            "clothescast/default/now/audio",
+            "clothescast/default/now/text",
+        )
     }
 
     @Test

--- a/docs/smart-home.md
+++ b/docs/smart-home.md
@@ -34,6 +34,31 @@ yourself; no developer-operated service ever sees the payload.
    publishes to `<prefix>/today/text`; tonight's to `<prefix>/tonight/text`.
    The outfit image and TTS audio (when published) land on
    `<prefix>/<period>/image` and `<prefix>/<period>/audio` respectively.
+   Each fully-successful publish is also mirrored to `<prefix>/now/<kind>` —
+   `<prefix>/now/text`, `<prefix>/now/image`, `<prefix>/now/audio` —
+   so a consumer can subscribe to a single "latest" topic without
+   having to switch on today vs tonight or chase recency timestamps.
+   Whichever period most recently published is what `now` reflects.
+   The `now` set updates as an atomic bundle: `now/text` is published
+   *last* (after `now/image` / `now/audio`), so an HA automation
+   triggered on `now/text` reads a `now/image` / `now/audio` from the
+   same forecast rather than a stale payload from the previous period.
+   Modalities absent from the current delivery (e.g. an outfit render
+   failed, or you're on device TTS so no audio bytes exist) clear their
+   `now/*` slot with an empty retained payload — MQTT's convention for
+   "delete the retained message" — so a `now/text` consumer never reads
+   a stale image/audio left over from a previous bundle. `now/text` is
+   additionally held back if either `now/image` or `now/audio` mirror
+   publish fails, so a `now/text` update always implies a coherent
+   image/audio pair settled successfully. If any period publish in the
+   bundle fails outright, the entire `now` mirror is skipped — the
+   previous fully-successful `now` set stays intact rather than being
+   half-overwritten. MQTT itself has no transactional primitive across
+   topics, so a fresh-reconnect consumer reading all three retained
+   `now/*` topics during a partial-failure window (e.g. broker accepts
+   `now/image` but rejects `now/audio`) may briefly observe a mismatch;
+   subscribing continuously to `now/text` and gating reads on its
+   updates sidesteps this.
 6. Tap **Save**.
 
 The next scheduled refresh (07:00 by default for today, 19:00 for
@@ -125,6 +150,13 @@ mqtt:
     - name: "Clothescast tonight"
       unique_id: clothescast_tonight
       state_topic: "clothescast/default/tonight/text"
+      value_template: "{{ value }}"
+    # Single "latest" sensor — mirrors whichever period last published, so
+    # an automation can speak the most recent forecast without branching
+    # on today vs tonight or comparing timestamps.
+    - name: "Clothescast now"
+      unique_id: clothescast_now
+      state_topic: "clothescast/default/now/text"
       value_template: "{{ value }}"
 ```
 


### PR DESCRIPTION
## Summary

Adds a `/now/*` MQTT dimension so consumers can subscribe to a single "latest" topic without doing today-vs-tonight or recency logic. After each twice-daily refresh, the rendered insight bundle (prose + optional outfit PNG + optional Gemini TTS WAV) is mirrored to `<prefix>/now/<text|image|audio>` as retained payloads, alongside the existing `<prefix>/<period>/*` topics.

### Implementation

The publisher now exposes a single coordinated entry point — `publishIfEnabled(period, prose, image = null, audio = null)` — that owns publish ordering across all three modalities:

1. **Period topics fan out in parallel.** `<period>/text`, `<period>/image`, `<period>/audio` are independent surfaces and a slow image upload shouldn't hold up the prose.
2. **`/now/*` is an atomic bundle, with deliberate text-last sequencing.** Once every submitted modality's period publish succeeds, `/now/image` and `/now/audio` mirror in parallel; then `/now/text` mirrors **last**. The text-last order matters because `/now/text` is the natural state-change trigger surface for an HA automation — having it land after `/now/image` / `/now/audio` guarantees a `/now/text`-triggered automation reads a consistent image/audio pair from the same forecast.
3. **`/now/*` is all-or-nothing on failure.** If any submitted modality's period publish fails after retries, the entire `/now/*` mirror is skipped — the previous fully-successful `/now` bundle stays intact rather than being half-overwritten with a mix of new and old payloads. Mirror failures on the `/now/*` topics themselves never override the prose outcome the Settings UI reports.

`FetchAndNotifyWorker.deliver()` and `MainActivity`'s "Publish now" path collapse to a single bundle call, replacing the three parallel `launch {}` per-modality publishes. `publishTest()` (connectivity probe) is intentionally **not** mirrored to `/now` so it can't clobber the retained payload.

### Privacy

No change to what leaves the device. The mirrored payload is byte-identical to the period publish, just sent to a second topic on the same broker the user already configured. See `PRIVACY.md` for the full data-handling boundary.

### What's documented

- `settings_smart_home_mqtt_topic_hint` (Settings → Smart Home → MQTT → Topic prefix help text) describes the `/now/*` mirror.
- `docs/smart-home.md` step 5 of "App-side setup" gets a paragraph on the ordering/atomicity guarantees, plus a `Clothescast now` example `mqtt: sensor:` entry in the HA configuration snippet.

## Test plan

- [x] `:core:domain:test :core:data:test :app:testDebugUnitTest` — full JVM suite passes locally (54 tasks, all green).
- [x] `:app:assembleDebug` — debug APK builds.
- [x] Unit tests in `MqttPublisherTest` cover:
  - Today bundle (prose only) publishes `…/today/text` then mirrors to `…/now/text` (and same for tonight).
  - Bundle with prose + image: period topics publish in parallel, then `/now/image`, then `/now/text` last.
  - Bundle with prose + image + audio: `/now/text` lands after both `/now/image` and `/now/audio`.
  - Bundle skips all `/now/*` mirrors when image primary fails.
  - Bundle skips all `/now/*` mirrors when audio primary fails.
  - Bridge-disabled bundle performs zero publishes.
  - `/now/text` mirror failure does not downgrade a successful prose outcome.
  - Topic builders `nowTopicFor` / `nowImageTopicFor` / `nowAudioTopicFor` produce the expected paths and respect the same trim / fallback rules as the period builders.
- [ ] Wait for CI to confirm Android debug build job is also green.