### PR TITLE
Keep the outfit on the smart display for at least 30 seconds

### DIFF
--- a/app/src/main/kotlin/app/clothescast/cast/CastInsightController.kt
+++ b/app/src/main/kotlin/app/clothescast/cast/CastInsightController.kt
@@ -123,7 +123,7 @@ class CastInsightController(
                     locale = locale,
                     style = style,
                 )
-                val wav = WavEncoder.encode(pcm)
+                val wav = WavEncoder.encode(padPcmToMinimumDuration(pcm))
                 val mp4 = withContext(Dispatchers.Default) { Mp4Encoder.encode(outfitPng, wav) }
                 val urls = server.publish(host = host, video = mp4)
                 client.load(
@@ -188,7 +188,7 @@ class CastInsightController(
             locale = locale,
             style = style,
         )
-        val wav = WavEncoder.encode(pcm)
+        val wav = WavEncoder.encode(padPcmToMinimumDuration(pcm))
         val mp4 = withContext(Dispatchers.Default) { Mp4Encoder.encode(outfitPng, wav) }
         val urls = server.publish(host = host, video = mp4)
         client.load(
@@ -288,7 +288,8 @@ class CastInsightController(
             }
             val host = resolveLanIp(context)
                 ?: return CastWorkerOutcome.Failed(CastFailure.NoLanAddress.message ?: "No LAN IP")
-            val mp4 = withContext(Dispatchers.Default) { Mp4Encoder.encode(png, wav) }
+            val paddedWav = padWavToMinimumDuration(wav)
+            val mp4 = withContext(Dispatchers.Default) { Mp4Encoder.encode(png, paddedWav) }
             val urls = server.publish(host = host, video = mp4)
             val request = MediaLoadRequestData.Builder()
                 .setMediaInfo(buildMediaInfo(urls, title, subtitle))
@@ -456,7 +457,7 @@ class CastInsightController(
         private const val TAG = "CastInsightController"
 
         /**
-         * 24 kHz mono 16-bit PCM, [SILENT_STUB_SECONDS] of zeros,
+         * 24 kHz mono 16-bit PCM, [MIN_CAST_DURATION_SECONDS] of zeros,
          * wrapped in a standard RIFF/WAVE header. Default Media
          * Receiver requires some media to load, so the image-only
          * cast path (Gemini unavailable, or synth failed) uses this
@@ -467,15 +468,50 @@ class CastInsightController(
          */
         val silentWavStub: ByteArray by lazy {
             val sampleRate = 24_000
-            val sampleCount = sampleRate * SILENT_STUB_SECONDS
+            val sampleCount = sampleRate * MIN_CAST_DURATION_SECONDS
             val pcm = ByteArray(sampleCount * 2) // 16-bit
             WavEncoder.encode(PcmAudio(bytes = pcm, sampleRate = sampleRate))
         }
 
-        // Long enough that a glance at the smart display registers
-        // the outfit image, short enough that the receiver returns
-        // to ambient soon after the user looks away.
-        private const val SILENT_STUB_SECONDS = 15
+        /**
+         * Minimum on-display time for any cast. Short TTS audio
+         * gets trailing silence appended so the outfit image stays
+         * on the smart display long enough for a glance from across
+         * the room to register it; audio longer than this plays in
+         * full and the cast naturally runs to the end of the speech.
+         * Also sizes [silentWavStub] for the image-only fallback.
+         */
+        internal const val MIN_CAST_DURATION_SECONDS = 30
+
+        /**
+         * Pads [pcm] with trailing silence so the resulting buffer
+         * carries at least [MIN_CAST_DURATION_SECONDS] of audio.
+         * Returns the input unchanged when it's already long enough.
+         */
+        internal fun padPcmToMinimumDuration(pcm: PcmAudio): PcmAudio {
+            // 16-bit mono → 2 bytes per frame.
+            val minBytes = pcm.sampleRate * MIN_CAST_DURATION_SECONDS * 2
+            if (pcm.bytes.size >= minBytes) return pcm
+            val padded = ByteArray(minBytes)
+            pcm.bytes.copyInto(padded)
+            return PcmAudio(bytes = padded, sampleRate = pcm.sampleRate)
+        }
+
+        /**
+         * WAV-level equivalent of [padPcmToMinimumDuration] for the
+         * worker path, which holds the cast media as already-encoded
+         * WAV bytes shared with MQTT — MQTT consumers want the raw
+         * TTS length, so padding has to happen inside the cast
+         * branch, not upstream.
+         */
+        internal fun padWavToMinimumDuration(wav: ByteArray): ByteArray {
+            val info = Mp4Encoder.WavInfo.parse(wav)
+            val minBytes = info.sampleRate * MIN_CAST_DURATION_SECONDS * 2 * info.channels
+            if (info.pcm.size >= minBytes) return wav
+            val padded = ByteArray(minBytes)
+            info.pcm.copyInto(padded)
+            return WavEncoder.encode(PcmAudio(bytes = padded, sampleRate = info.sampleRate))
+        }
 
         internal fun buildMediaInfo(
             urls: CastMediaServer.MediaUrl,

--- a/app/src/test/kotlin/app/clothescast/cast/CastInsightControllerTest.kt
+++ b/app/src/test/kotlin/app/clothescast/cast/CastInsightControllerTest.kt
@@ -1,0 +1,74 @@
+package app.clothescast.cast
+
+import app.clothescast.core.data.tts.PcmAudio
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+class CastInsightControllerTest {
+
+    @Test
+    fun `padPcmToMinimumDuration pads short audio with trailing silence to the minimum`() {
+        val sampleRate = 24_000
+        val originalSeconds = 5
+        val originalBytes = ByteArray(sampleRate * originalSeconds * 2) { (it % 127).toByte() }
+        val pcm = PcmAudio(bytes = originalBytes, sampleRate = sampleRate)
+
+        val padded = CastInsightController.padPcmToMinimumDuration(pcm)
+
+        padded.sampleRate shouldBe sampleRate
+        padded.bytes.size shouldBe sampleRate * CastInsightController.MIN_CAST_DURATION_SECONDS * 2
+        padded.bytes.copyOfRange(0, originalBytes.size) shouldBe originalBytes
+        // Trailing padding is silent (all zero bytes).
+        padded.bytes.copyOfRange(originalBytes.size, padded.bytes.size)
+            .all { it == 0.toByte() } shouldBe true
+    }
+
+    @Test
+    fun `padPcmToMinimumDuration returns audio at the minimum unchanged`() {
+        val sampleRate = 24_000
+        val bytes = ByteArray(sampleRate * CastInsightController.MIN_CAST_DURATION_SECONDS * 2) { 1 }
+        val pcm = PcmAudio(bytes = bytes, sampleRate = sampleRate)
+
+        val padded = CastInsightController.padPcmToMinimumDuration(pcm)
+
+        padded shouldBe pcm
+    }
+
+    @Test
+    fun `padPcmToMinimumDuration leaves longer audio unchanged`() {
+        val sampleRate = 24_000
+        val bytes = ByteArray(sampleRate * (CastInsightController.MIN_CAST_DURATION_SECONDS + 30) * 2) { 1 }
+        val pcm = PcmAudio(bytes = bytes, sampleRate = sampleRate)
+
+        val padded = CastInsightController.padPcmToMinimumDuration(pcm)
+
+        padded shouldBe pcm
+    }
+
+    @Test
+    fun `padWavToMinimumDuration pads short WAV with trailing silence to the minimum`() {
+        val sampleRate = 24_000
+        val originalSeconds = 5
+        val originalPcm = ByteArray(sampleRate * originalSeconds * 2) { (it % 127).toByte() }
+        val wav = WavEncoder.encode(PcmAudio(bytes = originalPcm, sampleRate = sampleRate))
+
+        val padded = CastInsightController.padWavToMinimumDuration(wav)
+        val paddedInfo = Mp4Encoder.WavInfo.parse(padded)
+
+        paddedInfo.sampleRate shouldBe sampleRate
+        paddedInfo.channels shouldBe 1
+        paddedInfo.pcm.size shouldBe sampleRate * CastInsightController.MIN_CAST_DURATION_SECONDS * 2
+        paddedInfo.pcm.copyOfRange(0, originalPcm.size) shouldBe originalPcm
+        paddedInfo.pcm.copyOfRange(originalPcm.size, paddedInfo.pcm.size)
+            .all { it == 0.toByte() } shouldBe true
+    }
+
+    @Test
+    fun `padWavToMinimumDuration leaves the silent stub unchanged`() {
+        val stub = CastInsightController.silentWavStub
+
+        val padded = CastInsightController.padWavToMinimumDuration(stub)
+
+        padded shouldBe stub
+    }
+}


### PR DESCRIPTION
## Summary
- The Cast MP4 used to run only as long as the TTS audio (often 10-15s) before the receiver returned to ambient — a glance from across the room could miss the outfit entirely.
- Pad the audio track with trailing silence so every cast stays on the smart display for at least 30 seconds; longer briefings play in full as before.
- Padding lives inside the cast path, so MQTT consumers still get the raw TTS length. The silent stub used when Gemini synth is unavailable picks up the same 30-second minimum (was 15s).

## Scope
- `CastInsightController.kt`: new `MIN_CAST_DURATION_SECONDS = 30` constant, `padPcmToMinimumDuration` (used by the "Cast now" test button and `castToSavedRoute`), and `padWavToMinimumDuration` (used by the worker path, which holds the WAV as bytes already shared with MQTT). The previous `SILENT_STUB_SECONDS = 15` is folded into the new constant so the silent stub naturally matches.
- New `CastInsightControllerTest.kt` covers: short audio padded to the minimum with trailing zeros, audio at the minimum returned unchanged, longer audio returned unchanged, and the silent stub being a no-op through the WAV pad path.

## Privacy
- No change to what we send off the device — the padding is silent PCM appended only inside the Cast media flow; MQTT publishes unchanged.

## Test plan
- [x] `./gradlew :core:domain:test :core:data:test :app:testDebugUnitTest` — green
- [ ] Cast a short briefing to a smart display and confirm the outfit stays visible for ≥ 30s
- [ ] Cast with Gemini disabled (image-only path) and confirm the outfit stays for ≥ 30s
- [ ] Cast a long (> 30s) briefing and confirm it still runs to the end of the speech


---
_Generated by [Claude Code](https://claude.ai/code/session_01NnYQqvQCAtDuGGvCjqgZWr)_