### PR TITLE
Reword the Cast section's description to reference scheduled ClothesCasts

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -455,7 +455,7 @@
          either test a cast manually now (this PR) or have the worker
          send each scheduled forecast there automatically (next PR). -->
     <string name="settings_smart_home_cast_title">Cast</string>
-    <string name="settings_smart_home_cast_description">Send today\'s outfit and forecast to a smart display on your home network.</string>
+    <string name="settings_smart_home_cast_description">Send scheduled ClothesCasts to a smart display on your home network.</string>
     <string name="settings_smart_home_cast_privacy_note">Audio and image are served from your phone over your local network. They don\'t leave your home.</string>
     <string name="settings_smart_home_cast_device_label">Smart display</string>
     <string name="settings_smart_home_cast_device_none">No display picked</string>


### PR DESCRIPTION
## Summary

Updates the Cast settings card description in `app/src/main/res/values/strings.xml`:

- before: `Send today's outfit and forecast to a smart display on your home network.`
- after: `Send scheduled ClothesCasts to a smart display on your home network.`

The previous copy described the manual test-cast case from before the worker started dispatching scheduled casts automatically. Now that scheduled casting is wired up, "scheduled ClothesCasts" is a more accurate description of what the saved smart display actually receives.

## Privacy

No change to what leaves the device — this is a wording change only.

## Test plan

- [ ] CI green (`:core:*:test`, `:app:testDebugUnitTest`, `:app:assembleDebug`)
- [ ] Roborazzi snapshots regenerated by the bot for the Cast section card


---
_Generated by [Claude Code](https://claude.ai/code/session_012pc4W3db1theCLi1Hv5bjJ)_