### PR TITLE
Prototype: migrate navigation to Jetpack Navigation Compose

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -312,6 +312,7 @@ dependencies {
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     implementation(libs.androidx.lifecycle.viewmodel.ktx)
     implementation(libs.androidx.activity.compose)
+    implementation(libs.androidx.navigation.compose)
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.compose.ui)
     implementation(libs.androidx.compose.ui.tooling.preview)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -66,6 +66,7 @@
         android:name=".ClothesCastApplication"
         android:allowBackup="false"
         android:banner="@drawable/tv_banner"
+        android:enableOnBackInvokedCallback="true"
         android:icon="${launcherIconRes}"
         android:label="@string/app_name"
         android:localeConfig="@xml/locales_config"

--- a/app/src/main/kotlin/app/clothescast/MainActivity.kt
+++ b/app/src/main/kotlin/app/clothescast/MainActivity.kt
@@ -2,6 +2,7 @@ package app.clothescast
 
 import android.content.Context
 import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import android.view.Gravity
 import android.widget.TextView
@@ -15,7 +16,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -32,14 +33,12 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.runBlocking
 
 class MainActivity : ComponentActivity() {
-    // Incremented every time a notification tap delivers EXTRA_NAVIGATE_TO_TODAY —
-    // both via onNewIntent (activity already running) and via the launching intent
-    // in onCreate (cold start / activity recreated after process death, where
-    // rememberSaveable would otherwise restore the previously-saved screen, e.g.
-    // Settings). ClothesCastNavHost observes this counter and snaps back to Today
-    // whenever it ticks, so a notification tap reliably lands the user on Today
-    // regardless of cold/warm start.
-    private var navigateToTodayVersion by mutableIntStateOf(0)
+    // The latest intent delivered while the activity is already running (a
+    // notification tap → onNewIntent). ClothesCastNavHost forwards it to the
+    // NavController, which matches the Today deep link and navigates there.
+    // Cold-start / post-process-death intents are handled automatically by the
+    // NavController from the launch intent, so they don't go through here.
+    private var deepLinkIntent by mutableStateOf<Intent?>(null)
 
     override fun attachBaseContext(newBase: Context) {
         // Wrap with the persisted per-app locale so Activity Resources render
@@ -56,7 +55,6 @@ class MainActivity : ComponentActivity() {
         // our light background, or vice versa.
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
-        consumeNavigateToTodayExtra(intent)
         val app = application as ClothesCastApplication
         // Read the persisted theme synchronously so the first frame already
         // matches the user's pick — same flicker-avoidance pattern used in
@@ -118,7 +116,7 @@ class MainActivity : ComponentActivity() {
                         modifier = Modifier.fillMaxSize(),
                         color = MaterialTheme.colorScheme.background,
                     ) {
-                        ClothesCastNavHost(app, navigateToTodayVersion, startOnboarding)
+                        ClothesCastNavHost(app, startOnboarding, deepLinkIntent)
                     }
                 }
             }
@@ -159,26 +157,24 @@ class MainActivity : ComponentActivity() {
 
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
-        // Update the stored intent so a later configuration change replays this
-        // (already-consumed) intent rather than the original launching one.
+        // Replace the stored intent (so a later config-change replays this one,
+        // already marked handled by the NavController) and hand it to the nav
+        // host to match against the Today deep link.
         setIntent(intent)
-        consumeNavigateToTodayExtra(intent)
-    }
-
-    // Removes the extra after handling so a later onCreate (rotation, process
-    // recreation) replaying the same intent doesn't snap the user back to Today
-    // after they've navigated away.
-    private fun consumeNavigateToTodayExtra(intent: Intent?) {
-        if (intent?.getBooleanExtra(EXTRA_NAVIGATE_TO_TODAY, false) == true) {
-            navigateToTodayVersion++
-            intent.removeExtra(EXTRA_NAVIGATE_TO_TODAY)
-        }
+        deepLinkIntent = intent
     }
 
     companion object {
-        /** Extra set by all notification tap intents. MainActivity increments its
-         *  navigation counter when this is present so the nav host snaps to Today. */
-        const val EXTRA_NAVIGATE_TO_TODAY = "navigate_to_today"
+        /** Deep-link URI that lands on the Today screen. Notification taps target
+         *  this; ClothesCastNavHost declares a matching navDeepLink on TodayRoute. */
+        const val DEEP_LINK_TODAY = "clothescast://today"
+
+        /** Tap intent for notifications: opens (or brings forward) MainActivity and
+         *  deep-links to Today. SINGLE_TOP/CLEAR_TOP reuses a running task. */
+        fun todayTapIntent(context: Context): Intent =
+            Intent(Intent.ACTION_VIEW, Uri.parse(DEEP_LINK_TODAY), context, MainActivity::class.java).apply {
+                flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
+            }
     }
 }
 

--- a/app/src/main/kotlin/app/clothescast/MainActivity.kt
+++ b/app/src/main/kotlin/app/clothescast/MainActivity.kt
@@ -1,76 +1,42 @@
 package app.clothescast
 
-import android.app.Activity
 import android.content.Context
 import android.content.Intent
-import android.os.Build
 import android.os.Bundle
 import android.view.Gravity
 import android.widget.TextView
 import androidx.activity.ComponentActivity
 import androidx.activity.SystemBarStyle
-import androidx.activity.compose.BackHandler
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.core.os.LocaleListCompat
-import app.clothescast.cast.castCurrentInsight
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
-import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
-import androidx.glance.appwidget.updateAll
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.lifecycle.viewmodel.compose.viewModel
-import androidx.work.WorkManager
-import app.clothescast.calendar.resolveHolidayTheme
-import app.clothescast.core.domain.model.OutfitSuggestion
 import app.clothescast.core.domain.model.ThemeMode
 import app.clothescast.locale.AppLocale
-import app.clothescast.location.LocationResolver
 import app.clothescast.notification.NotificationPermission
 import app.clothescast.ui.isTelevision
-import app.clothescast.ui.onboarding.OnboardingScreen
-import app.clothescast.ui.onboarding.OnboardingViewModel
-import app.clothescast.ui.pairing.PairingScreen
-import app.clothescast.ui.pairing.PairingViewModel
-import app.clothescast.core.domain.model.ForecastPeriod
-import app.clothescast.insight.InsightFormatter
-import app.clothescast.mqtt.MqttPublishOutcome
-import app.clothescast.ui.garment.outfitCardInfoLines
-import app.clothescast.ui.garment.renderOutfitCard
-import app.clothescast.ui.settings.SettingsRoute
-import app.clothescast.ui.settings.SettingsScreen
-import app.clothescast.ui.settings.SettingsViewModel
+import app.clothescast.ui.nav.ClothesCastNavHost
 import app.clothescast.ui.theme.ClothesCastTheme
-import app.clothescast.ui.today.TodayScreen
-import app.clothescast.ui.today.TodayViewModel
-import app.clothescast.widget.OutfitWidget
-import app.clothescast.work.FetchAndNotifyWorker
 import com.google.firebase.FirebaseApp
 import com.google.firebase.crashlytics.FirebaseCrashlytics
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.runBlocking
 
-private enum class Screen { Today, Settings, Onboarding, Pairing }
-
 class MainActivity : ComponentActivity() {
     // Incremented every time a notification tap delivers EXTRA_NAVIGATE_TO_TODAY —
     // both via onNewIntent (activity already running) and via the launching intent
     // in onCreate (cold start / activity recreated after process death, where
     // rememberSaveable would otherwise restore the previously-saved screen, e.g.
-    // Settings). ClothesCastNav observes this counter and snaps back to Today
+    // Settings). ClothesCastNavHost observes this counter and snaps back to Today
     // whenever it ticks, so a notification tap reliably lands the user on Today
     // regardless of cold/warm start.
     private var navigateToTodayVersion by mutableIntStateOf(0)
@@ -94,12 +60,17 @@ class MainActivity : ComponentActivity() {
         val app = application as ClothesCastApplication
         // Read the persisted theme synchronously so the first frame already
         // matches the user's pick — same flicker-avoidance pattern used in
-        // ClothesCastNav for the initial-screen decision.
+        // shouldStartOnboarding for the initial-screen decision.
         val initialPrefs = runBlocking {
             app.settingsRepository.preferences.first().let {
                 it.themeMode to it.colorPalette
             }
         }
+        // Decide the start destination once, synchronously, so the first frame
+        // is already correct (no flash of Today before snapping to Onboarding).
+        // NavHost ignores this after process death — it restores its own saved
+        // back stack — so it only governs a genuine first launch.
+        val startOnboarding = shouldStartOnboarding(this, app)
         try {
             setContent {
                 val themeMode by app.settingsRepository.preferences
@@ -147,7 +118,7 @@ class MainActivity : ComponentActivity() {
                         modifier = Modifier.fillMaxSize(),
                         color = MaterialTheme.colorScheme.background,
                     ) {
-                        ClothesCastNav(app, navigateToTodayVersion)
+                        ClothesCastNavHost(app, navigateToTodayVersion, startOnboarding)
                     }
                 }
             }
@@ -206,299 +177,33 @@ class MainActivity : ComponentActivity() {
 
     companion object {
         /** Extra set by all notification tap intents. MainActivity increments its
-         *  navigation counter when this is present so ClothesCastNav snaps to Today. */
+         *  navigation counter when this is present so the nav host snaps to Today. */
         const val EXTRA_NAVIGATE_TO_TODAY = "navigate_to_today"
     }
 }
 
-@Composable
-private fun ClothesCastNav(app: ClothesCastApplication, navigateToTodayVersion: Int) {
-    val context = LocalContext.current
-
-    // Decide initial screen once on first composition. Permission checks are sync;
-    // DataStore reads (Gemini key + preferences) go through one Preferences fetch
-    // each, microseconds in practice — runBlocking here keeps the UX flicker-free
-    // (no flash of Today before snapping to Onboarding) at a negligible startup cost.
-    val initialScreen = remember {
-        val tv = isTelevision(context)
-        // TV OS does not expose POST_NOTIFICATIONS or GPS-based location; skip
-        // both checks so a configured-key + city TV install goes straight to Today.
-        val notificationOk = tv || NotificationPermission.isGranted(context)
-        val keyOk = runBlocking { app.secureKeyStore.geminiKeyConfiguredFlow.first() }
-        val prefs = runBlocking { app.settingsRepository.preferences.first() }
-        val locationOk = if (tv) {
-            // On TV only a manually picked city counts — device location is unavailable.
-            prefs.location != null
-        } else {
-            // Location is "configured" if either branch is filled in — device-location
-            // toggle on (with permission) or a manual city stored.
-            val coarseGranted = androidx.core.content.ContextCompat.checkSelfPermission(
-                context,
-                android.Manifest.permission.ACCESS_COARSE_LOCATION,
-            ) == android.content.pm.PackageManager.PERMISSION_GRANTED
-            (prefs.useDeviceLocation && coarseGranted) || prefs.location != null
-        }
-        if (notificationOk && keyOk && locationOk) Screen.Today else Screen.Onboarding
+// Decide the start destination once, synchronously. Permission checks are sync;
+// DataStore reads (Gemini key + preferences) go through one Preferences fetch
+// each, microseconds in practice — runBlocking here keeps the UX flicker-free
+// (no flash of Today before snapping to Onboarding) at a negligible startup cost.
+private fun shouldStartOnboarding(context: Context, app: ClothesCastApplication): Boolean {
+    val tv = isTelevision(context)
+    // TV OS does not expose POST_NOTIFICATIONS or GPS-based location; skip
+    // both checks so a configured-key + city TV install goes straight to Today.
+    val notificationOk = tv || NotificationPermission.isGranted(context)
+    val keyOk = runBlocking { app.secureKeyStore.geminiKeyConfiguredFlow.first() }
+    val prefs = runBlocking { app.settingsRepository.preferences.first() }
+    val locationOk = if (tv) {
+        // On TV only a manually picked city counts — device location is unavailable.
+        prefs.location != null
+    } else {
+        // Location is "configured" if either branch is filled in — device-location
+        // toggle on (with permission) or a manual city stored.
+        val coarseGranted = androidx.core.content.ContextCompat.checkSelfPermission(
+            context,
+            android.Manifest.permission.ACCESS_COARSE_LOCATION,
+        ) == android.content.pm.PackageManager.PERMISSION_GRANTED
+        (prefs.useDeviceLocation && coarseGranted) || prefs.location != null
     }
-
-    var screen by rememberSaveable { mutableStateOf(initialScreen) }
-    // Holds the SettingsRoute we want to land on when entering Settings programmatically
-    // (e.g. from onboarding's "Continue"). Saved as a name string so rememberSaveable
-    // doesn't need a custom Saver. Consumed once and reset to null on the way out.
-    var settingsInitialRoute by rememberSaveable { mutableStateOf<String?>(null) }
-
-    // When the user taps a notification while the app is already running, MainActivity
-    // increments navigateToTodayVersion via onNewIntent. Snap back to Today so the
-    // user always lands on the screen that actually shows the insight/alert they tapped.
-    LaunchedEffect(navigateToTodayVersion) {
-        if (navigateToTodayVersion > 0) {
-            screen = Screen.Today
-            settingsInitialRoute = null
-        }
-    }
-
-    BackHandler(enabled = screen == Screen.Settings) {
-        screen = Screen.Today
-        settingsInitialRoute = null
-    }
-
-    when (screen) {
-        Screen.Today -> {
-            val today: TodayViewModel = viewModel(
-                factory = TodayViewModel.Factory(
-                    insightCache = app.insightCache,
-                    workManager = WorkManager.getInstance(app),
-                    settingsRepository = app.settingsRepository,
-                    refreshOutfitWidget = {
-                        runCatching { OutfitWidget().updateAll(context.applicationContext) }
-                    },
-                    calendarEventReader = app.calendarEventReader,
-                ),
-            )
-            TodayScreen(
-                viewModel = today,
-                onNavigateToSettings = {
-                    settingsInitialRoute = null
-                    screen = Screen.Settings
-                },
-                onNavigateToAbout = {
-                    settingsInitialRoute = SettingsRoute.About.name
-                    screen = Screen.Settings
-                },
-                onNavigateToLocation = {
-                    settingsInitialRoute = SettingsRoute.Location.name
-                    screen = Screen.Settings
-                },
-                onNavigateToPrivacy = {
-                    settingsInitialRoute = SettingsRoute.Privacy.name
-                    screen = Screen.Settings
-                },
-                onNavigateToClothes = {
-                    settingsInitialRoute = SettingsRoute.Clothes.name
-                    screen = Screen.Settings
-                },
-                onNavigateToHolidays = {
-                    settingsInitialRoute = SettingsRoute.Holidays.name
-                    screen = Screen.Settings
-                },
-            )
-        }
-        Screen.Settings -> {
-            val settings: SettingsViewModel = viewModel(
-                factory = SettingsViewModel.Factory(
-                    settingsRepository = app.settingsRepository,
-                    keyStore = app.secureKeyStore,
-                    rearmAlarm = app.dailyAlarmScheduler::schedule,
-                    cancelAlarm = app.dailyAlarmScheduler::cancel,
-                    geocodingClient = app.geocodingClient,
-                    voiceEnumerator = app.androidTtsVoiceEnumerator,
-                    applyAppLocale = { region ->
-                        AppLocale.apply(app, region)
-                        // API 33+ recreates Activities automatically when
-                        // applicationLocales changes; below that we have to
-                        // do it ourselves so the currently visible screen
-                        // re-renders in the new language instead of waiting
-                        // until the user navigates away and back.
-                        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
-                            (context as? Activity)?.recreate()
-                        }
-                    },
-                    refreshLocationCache = {
-                        // Eager device-location populate when the user flips
-                        // device-location ON. Cache-only path — resolves the
-                        // fix and writes through to settings without running
-                        // the insight / notify / TTS pipeline, so toggling at
-                        // 10am after the morning run already fired doesn't
-                        // double-notify.
-                        FetchAndNotifyWorker.enqueueLocationCacheRefresh(context)
-                    },
-                    refreshCachedOutfits = {
-                        // Re-pick the home-screen outfit against the just-written
-                        // clothes-rule preferences so the icon flips immediately
-                        // when the user edits a rule or the default-bottom
-                        // picker. The cache is the canonical source for the
-                        // Today screen and the widget; mutating it here means
-                        // the user doesn't have to wait for the next scheduled
-                        // or manual refresh to see their choice take effect.
-                        // We also push the widget update — the cache flow
-                        // wakes the Today screen automatically, but the widget
-                        // only refreshes when we explicitly tell it to.
-                        val prefs = app.settingsRepository.preferences.first()
-                        app.insightCache.recomputeOutfits(prefs.clothesRules, prefs.defaultBottom)
-                        runCatching { OutfitWidget().updateAll(context.applicationContext) }
-                    },
-                    resolveDeviceLocationWithCity = {
-                        // "Use my current location" tap on the home-pin card.
-                        // We want a precise lat/lon (not a geocoder centroid)
-                        // so the at-home gate's 1 km radius actually fires;
-                        // resolveFresh enforces the same 5-minute ceiling
-                        // the worker uses, so a stale "I was at work
-                        // yesterday" cache miss can't silently land as the
-                        // user's home — better to no-op the button and let
-                        // them retry than save the wrong coordinate.
-                        // Reverse-geocode labels the fix for UI display and
-                        // captures the country code for the holiday filter.
-                        // Both swallow failures internally — null falls
-                        // through to a no-op in the VM.
-                        app.locationResolver.resolveFresh(
-                            LocationResolver.FRESH_FIX_MAX_AGE_MS,
-                        )?.let { fix ->
-                            val geo = app.reverseGeocoder.resolve(fix.latitude, fix.longitude)
-                            fix.copy(
-                                displayName = geo.city ?: fix.displayName,
-                                countryCode = geo.countryCode ?: fix.countryCode,
-                            )
-                        }
-                    },
-                    workManager = WorkManager.getInstance(app),
-                    mqttPublisher = app.mqttPublisher,
-                    fullPublish = {
-                        val prefs = app.settingsRepository.preferences.first()
-                        val insight = app.insightCache.thisPeriod.first()
-                            ?: return@Factory app.mqttPublisher.publishTest()
-                        val formatter = InsightFormatter.forRegion(context, prefs.region, prefs.temperatureUnit)
-                        val prose = formatter.format(insight.summary)
-                        // Render the outfit card up-front so the bundle publish
-                        // can co-ordinate prose + image and emit a consistent
-                        // /now/* set. A render failure degrades to a prose-only
-                        // bundle rather than skipping the publish entirely.
-                        val png: ByteArray? = insight.outfit?.let { outfit ->
-                            runCatching {
-                                val info = outfitCardInfoLines(
-                                    context = context,
-                                    formatter = formatter,
-                                    hourly = insight.hourly,
-                                    temperatureUnit = prefs.temperatureUnit,
-                                )
-                                val header = context.getString(
-                                    if (insight.period == ForecastPeriod.TODAY) R.string.outfit_card_header_today
-                                    else R.string.outfit_card_header_tonight
-                                )
-                                // Apply today's holiday / birthday theme on
-                                // top of the user's outfit colours — same
-                                // merge FetchAndNotifyWorker.deliver does for
-                                // the scheduled publish. Without it the
-                                // user-initiated refresh would overwrite the
-                                // worker's themed retained image with an
-                                // unthemed one.
-                                val theme = resolveHolidayTheme(prefs, app.calendarEventReader)
-                                val topColors: Map<OutfitSuggestion.Top, Long> =
-                                    prefs.outfitTopColors + (theme?.topOverrides ?: emptyMap())
-                                val bottomColors: Map<OutfitSuggestion.Bottom, Long> =
-                                    prefs.outfitBottomColors + (theme?.bottomOverrides ?: emptyMap())
-                                val topStrokes: Map<OutfitSuggestion.Top, Long> =
-                                    theme?.topStrokeOverrides ?: emptyMap()
-                                val bottomStrokes: Map<OutfitSuggestion.Bottom, Long> =
-                                    theme?.bottomStrokeOverrides ?: emptyMap()
-                                renderOutfitCard(
-                                    context = context,
-                                    outfit = outfit,
-                                    header = header,
-                                    prose = prose,
-                                    tempLine = info.tempLine,
-                                    rainLine = info.rainLine,
-                                    tempFillFraction = info.tempFillFraction,
-                                    rainFillFraction = info.rainFillFraction,
-                                    topColors = topColors,
-                                    bottomColors = bottomColors,
-                                    topStrokes = topStrokes,
-                                    bottomStrokes = bottomStrokes,
-                                )
-                            }.getOrNull()
-                        }
-                        app.mqttPublisher.publishIfEnabled(insight.period, prose, image = png)
-                    },
-                    discovery = app.homeAssistantDiscovery,
-                    castRouteDiscovery = app.castRouteDiscovery,
-                    castAvailable = app.castContext != null,
-                    castNowAction = app.castInsightController?.let { controller ->
-                        {
-                            castCurrentInsight(
-                                context = context,
-                                settingsRepository = app.settingsRepository,
-                                insightCache = app.insightCache,
-                                calendarEventReader = app.calendarEventReader,
-                                controller = controller,
-                                locale = LocaleListCompat.getAdjustedDefault().get(0)
-                                    ?: java.util.Locale.getDefault(),
-                            )
-                        }
-                    },
-                ),
-            )
-            SettingsScreen(
-                viewModel = settings,
-                onNavigateBack = {
-                    screen = Screen.Today
-                    settingsInitialRoute = null
-                },
-                initialRoute = settingsInitialRoute
-                    ?.let { runCatching { SettingsRoute.valueOf(it) }.getOrNull() },
-            )
-        }
-        Screen.Onboarding -> {
-            val onboarding: OnboardingViewModel = viewModel(
-                factory = OnboardingViewModel.Factory(
-                    secureKeyStore = app.secureKeyStore,
-                    settingsRepository = app.settingsRepository,
-                    geocodingClient = app.geocodingClient,
-                    refreshLocationCache = {
-                        // Eager device-location populate when the user grants
-                        // location permission during onboarding. Cache-only
-                        // path — same worker used by Settings — so the
-                        // resolved city surfaces in seconds and the user can
-                        // tell at a glance whether they need to enter a
-                        // manual fallback instead.
-                        FetchAndNotifyWorker.enqueueLocationCacheRefresh(context)
-                    },
-                    workManager = WorkManager.getInstance(app),
-                ),
-            )
-            OnboardingScreen(
-                viewModel = onboarding,
-                onPairFromPhone = { screen = Screen.Pairing },
-                onContinue = {
-                    settingsInitialRoute = SettingsRoute.Schedule.name
-                    screen = Screen.Settings
-                },
-                onSkip = {
-                    settingsInitialRoute = null
-                    screen = Screen.Today
-                },
-            )
-        }
-        Screen.Pairing -> {
-            val pairing: PairingViewModel = viewModel(
-                factory = PairingViewModel.Factory(
-                    secureKeyStore = app.secureKeyStore,
-                    settingsRepository = app.settingsRepository,
-                ),
-            )
-            PairingScreen(
-                viewModel = pairing,
-                onSuccess = { screen = Screen.Onboarding },
-                onCancel = { screen = Screen.Onboarding },
-            )
-        }
-    }
+    return !(notificationOk && keyOk && locationOk)
 }

--- a/app/src/main/kotlin/app/clothescast/notification/InsightNotifier.kt
+++ b/app/src/main/kotlin/app/clothescast/notification/InsightNotifier.kt
@@ -2,7 +2,6 @@ package app.clothescast.notification
 
 import android.app.PendingIntent
 import android.content.Context
-import android.content.Intent
 import android.graphics.Bitmap
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
@@ -30,14 +29,10 @@ class InsightNotifier(private val context: Context) {
     ) {
         if (!NotificationPermission.isGranted(context)) return
 
-        val tapIntent = Intent(context, MainActivity::class.java).apply {
-            flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
-            putExtra(MainActivity.EXTRA_NAVIGATE_TO_TODAY, true)
-        }
         val pendingIntent = PendingIntent.getActivity(
             context,
             REQUEST_OPEN_APP,
-            tapIntent,
+            MainActivity.todayTapIntent(context),
             PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
         )
 

--- a/app/src/main/kotlin/app/clothescast/notification/TonightInsightNotifier.kt
+++ b/app/src/main/kotlin/app/clothescast/notification/TonightInsightNotifier.kt
@@ -2,7 +2,6 @@ package app.clothescast.notification
 
 import android.app.PendingIntent
 import android.content.Context
-import android.content.Intent
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import app.clothescast.MainActivity
@@ -34,14 +33,10 @@ class TonightInsightNotifier(private val context: Context) {
     ) {
         if (!NotificationPermission.isGranted(context)) return
 
-        val tapIntent = Intent(context, MainActivity::class.java).apply {
-            flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
-            putExtra(MainActivity.EXTRA_NAVIGATE_TO_TODAY, true)
-        }
         val pendingIntent = PendingIntent.getActivity(
             context,
             REQUEST_OPEN_APP,
-            tapIntent,
+            MainActivity.todayTapIntent(context),
             PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
         )
 

--- a/app/src/main/kotlin/app/clothescast/notification/WeatherAlertNotifier.kt
+++ b/app/src/main/kotlin/app/clothescast/notification/WeatherAlertNotifier.kt
@@ -2,7 +2,6 @@ package app.clothescast.notification
 
 import android.app.PendingIntent
 import android.content.Context
-import android.content.Intent
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import app.clothescast.MainActivity
@@ -23,14 +22,10 @@ class WeatherAlertNotifier(private val context: Context) {
     fun notify(alert: WeatherAlert) {
         if (!NotificationPermission.isGranted(context)) return
 
-        val tapIntent = Intent(context, MainActivity::class.java).apply {
-            flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
-            putExtra(MainActivity.EXTRA_NAVIGATE_TO_TODAY, true)
-        }
         val pendingIntent = PendingIntent.getActivity(
             context,
             REQUEST_OPEN_APP,
-            tapIntent,
+            MainActivity.todayTapIntent(context),
             PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
         )
 

--- a/app/src/main/kotlin/app/clothescast/ui/nav/ClothesCastNavHost.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/nav/ClothesCastNavHost.kt
@@ -2,6 +2,7 @@ package app.clothescast.ui.nav
 
 import android.app.Activity
 import android.content.Context
+import android.content.Intent
 import android.os.Build
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -16,10 +17,12 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.navigation
 import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navDeepLink
 import androidx.navigation.toRoute
 import androidx.glance.appwidget.updateAll
 import androidx.work.WorkManager
 import app.clothescast.ClothesCastApplication
+import app.clothescast.MainActivity
 import app.clothescast.R
 import app.clothescast.calendar.resolveHolidayTheme
 import app.clothescast.cast.castCurrentInsight
@@ -34,9 +37,21 @@ import app.clothescast.ui.onboarding.OnboardingScreen
 import app.clothescast.ui.onboarding.OnboardingViewModel
 import app.clothescast.ui.pairing.PairingScreen
 import app.clothescast.ui.pairing.PairingViewModel
-import app.clothescast.ui.settings.SettingsRoute
-import app.clothescast.ui.settings.SettingsSubPage
+import app.clothescast.ui.settings.AboutPage
+import app.clothescast.ui.settings.CalendarPage
+import app.clothescast.ui.settings.ClothesPage
+import app.clothescast.ui.settings.DisplayPage
+import app.clothescast.ui.settings.ForecastersPage
+import app.clothescast.ui.settings.HolidaysPage
+import app.clothescast.ui.settings.LocationPage
+import app.clothescast.ui.settings.PrivacyPage
+import app.clothescast.ui.settings.RegionPage
+import app.clothescast.ui.settings.SchedulePage
+import app.clothescast.ui.settings.SettingsMenuItem
+import app.clothescast.ui.settings.SettingsRootPage
 import app.clothescast.ui.settings.SettingsViewModel
+import app.clothescast.ui.settings.SmartHomePage
+import app.clothescast.ui.settings.VoicePage
 import app.clothescast.ui.today.TodayScreen
 import app.clothescast.ui.today.TodayViewModel
 import app.clothescast.widget.OutfitWidget
@@ -69,47 +84,30 @@ import kotlinx.serialization.Serializable
 @Serializable internal object PrivacyDest
 @Serializable internal object AboutDest
 
-private fun SettingsRoute.toDestination(): Any = when (this) {
-    SettingsRoute.Root -> SettingsRootDest
-    SettingsRoute.Schedule -> ScheduleDest()
-    SettingsRoute.Clothes -> ClothesDest
-    SettingsRoute.Region -> RegionDest
-    SettingsRoute.Voice -> VoiceDest
-    SettingsRoute.Display -> DisplayDest
-    SettingsRoute.Holidays -> HolidaysDest
-    SettingsRoute.Location -> LocationDest
-    SettingsRoute.Calendar -> CalendarDest
-    SettingsRoute.Forecasters -> ForecastersDest
-    SettingsRoute.SmartHome -> SmartHomeDest
-    SettingsRoute.Privacy -> PrivacyDest
-    SettingsRoute.About -> AboutDest
-}
-
 @Composable
 fun ClothesCastNavHost(
     app: ClothesCastApplication,
-    navigateToTodayVersion: Int,
     startOnboarding: Boolean,
+    newIntent: Intent?,
 ) {
     val nav = rememberNavController()
 
-    // Notification taps snap to Today regardless of where the user was. The
-    // back stack is cleared so a subsequent back exits the app rather than
-    // walking back into a half-finished settings drill-down.
-    LaunchedEffect(navigateToTodayVersion) {
-        if (navigateToTodayVersion > 0) {
-            nav.navigate(TodayRoute) {
-                popUpTo(nav.graph.id) { inclusive = true }
-                launchSingleTop = true
-            }
-        }
+    // Intents that arrive while the activity is already running (a notification
+    // tap → onNewIntent) are forwarded here and matched against the Today deep
+    // link below, so the user lands on Today regardless of where they were.
+    // Cold-start / post-process-death intents are handled automatically by the
+    // NavController from the launch intent, so they don't need this path.
+    LaunchedEffect(newIntent) {
+        if (newIntent != null) nav.handleDeepLink(newIntent)
     }
 
     NavHost(
         navController = nav,
         startDestination = if (startOnboarding) OnboardingRoute else TodayRoute,
     ) {
-        composable<TodayRoute> {
+        composable<TodayRoute>(
+            deepLinks = listOf(navDeepLink<TodayRoute>(basePath = MainActivity.DEEP_LINK_TODAY)),
+        ) {
             val context = LocalContext.current
             val today: TodayViewModel = viewModel(factory = todayViewModelFactory(app, context))
             TodayScreen(
@@ -175,36 +173,64 @@ private fun NavGraphBuilder.settingsGraph(nav: NavController, app: ClothesCastAp
             popUpTo(nav.graph.id) { inclusive = true }
         }
     }
-    val onNavigate: (SettingsRoute) -> Unit = { nav.navigate(it.toDestination()) }
     val onBack: () -> Unit = { nav.popBackStack() }
 
     navigation<SettingsGraph>(startDestination = SettingsRootDest) {
-        composable<SettingsRootDest> { entry ->
-            SettingsSubPage(SettingsRoute.Root, entry.settingsViewModel(nav, app), onBack, onNavigate)
-        }
-        composable<ScheduleDest> { entry ->
-            SettingsSubPage(
-                route = SettingsRoute.Schedule,
-                viewModel = entry.settingsViewModel(nav, app),
+        composable<SettingsRootDest> { e ->
+            SettingsRootPage(
+                viewModel = e.settingsViewModel(nav, app),
+                items = settingsMenu(nav),
                 onBack = onBack,
-                onNavigate = onNavigate,
-                onboardingLanding = entry.toRoute<ScheduleDest>().fromOnboarding,
+                onOpenLocation = { nav.navigate(LocationDest) },
+            )
+        }
+        composable<ScheduleDest> { e ->
+            SchedulePage(
+                viewModel = e.settingsViewModel(nav, app),
+                onBack = onBack,
+                onboardingLanding = e.toRoute<ScheduleDest>().fromOnboarding,
                 onFinishOnboarding = finishOnboarding,
             )
         }
-        composable<ClothesDest> { e -> SettingsSubPage(SettingsRoute.Clothes, e.settingsViewModel(nav, app), onBack, onNavigate) }
-        composable<RegionDest> { e -> SettingsSubPage(SettingsRoute.Region, e.settingsViewModel(nav, app), onBack, onNavigate) }
-        composable<VoiceDest> { e -> SettingsSubPage(SettingsRoute.Voice, e.settingsViewModel(nav, app), onBack, onNavigate) }
-        composable<DisplayDest> { e -> SettingsSubPage(SettingsRoute.Display, e.settingsViewModel(nav, app), onBack, onNavigate) }
-        composable<HolidaysDest> { e -> SettingsSubPage(SettingsRoute.Holidays, e.settingsViewModel(nav, app), onBack, onNavigate) }
-        composable<LocationDest> { e -> SettingsSubPage(SettingsRoute.Location, e.settingsViewModel(nav, app), onBack, onNavigate) }
-        composable<CalendarDest> { e -> SettingsSubPage(SettingsRoute.Calendar, e.settingsViewModel(nav, app), onBack, onNavigate) }
-        composable<ForecastersDest> { e -> SettingsSubPage(SettingsRoute.Forecasters, e.settingsViewModel(nav, app), onBack, onNavigate) }
-        composable<SmartHomeDest> { e -> SettingsSubPage(SettingsRoute.SmartHome, e.settingsViewModel(nav, app), onBack, onNavigate) }
-        composable<PrivacyDest> { e -> SettingsSubPage(SettingsRoute.Privacy, e.settingsViewModel(nav, app), onBack, onNavigate) }
-        composable<AboutDest> { e -> SettingsSubPage(SettingsRoute.About, e.settingsViewModel(nav, app), onBack, onNavigate) }
+        composable<ClothesDest> { e -> ClothesPage(e.settingsViewModel(nav, app), onBack) }
+        composable<RegionDest> { e -> RegionPage(e.settingsViewModel(nav, app), onBack) }
+        composable<VoiceDest> { e -> VoicePage(e.settingsViewModel(nav, app), onBack) }
+        composable<DisplayDest> { e -> DisplayPage(e.settingsViewModel(nav, app), onBack) }
+        composable<HolidaysDest> { e ->
+            HolidaysPage(
+                viewModel = e.settingsViewModel(nav, app),
+                onBack = onBack,
+                onNavigateToRegion = { nav.navigate(RegionDest) },
+                onNavigateToLocation = { nav.navigate(LocationDest) },
+                onNavigateToCalendar = { nav.navigate(CalendarDest) },
+            )
+        }
+        composable<LocationDest> { e -> LocationPage(e.settingsViewModel(nav, app), onBack) }
+        composable<CalendarDest> { e -> CalendarPage(e.settingsViewModel(nav, app), onBack) }
+        composable<ForecastersDest> { e -> ForecastersPage(e.settingsViewModel(nav, app), onBack) }
+        composable<SmartHomeDest> { e -> SmartHomePage(e.settingsViewModel(nav, app), onBack) }
+        composable<PrivacyDest> { e -> PrivacyPage(e.settingsViewModel(nav, app), onBack) }
+        composable<AboutDest> { AboutPage(onBack) }
     }
 }
+
+// The ordered Settings root menu. Title + subtitle live here next to the
+// destination each row opens; Root and About aren't listed (Root is the menu
+// itself, About is reached only from Today's overflow). Order matches the list
+// the user sees: most-tweaked rules first, set-once config next, data sources last.
+private fun settingsMenu(nav: NavController): List<SettingsMenuItem> = listOf(
+    SettingsMenuItem(R.string.settings_root_schedule, R.string.settings_root_schedule_subtitle) { nav.navigate(ScheduleDest()) },
+    SettingsMenuItem(R.string.settings_root_clothes, R.string.settings_root_clothes_subtitle) { nav.navigate(ClothesDest) },
+    SettingsMenuItem(R.string.settings_root_region, R.string.settings_root_region_subtitle) { nav.navigate(RegionDest) },
+    SettingsMenuItem(R.string.settings_root_voice, R.string.settings_root_voice_subtitle) { nav.navigate(VoiceDest) },
+    SettingsMenuItem(R.string.settings_root_display, R.string.settings_root_display_subtitle) { nav.navigate(DisplayDest) },
+    SettingsMenuItem(R.string.settings_root_holidays, R.string.settings_root_holidays_subtitle) { nav.navigate(HolidaysDest) },
+    SettingsMenuItem(R.string.settings_root_location, R.string.settings_root_location_subtitle) { nav.navigate(LocationDest) },
+    SettingsMenuItem(R.string.settings_root_forecasters, R.string.settings_root_forecasters_subtitle) { nav.navigate(ForecastersDest) },
+    SettingsMenuItem(R.string.settings_root_calendar, R.string.settings_root_calendar_subtitle) { nav.navigate(CalendarDest) },
+    SettingsMenuItem(R.string.settings_root_smart_home, R.string.settings_root_smart_home_subtitle) { nav.navigate(SmartHomeDest) },
+    SettingsMenuItem(R.string.settings_root_privacy, R.string.settings_root_privacy_subtitle) { nav.navigate(PrivacyDest) },
+)
 
 // One SettingsViewModel shared across every settings destination, scoped to the
 // SettingsGraph back-stack entry. Replaces the single VM the old monolithic

--- a/app/src/main/kotlin/app/clothescast/ui/nav/ClothesCastNavHost.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/nav/ClothesCastNavHost.kt
@@ -1,0 +1,329 @@
+package app.clothescast.ui.nav
+
+import android.app.Activity
+import android.content.Context
+import android.os.Build
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.os.LocaleListCompat
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavBackStackEntry
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.navigation
+import androidx.navigation.compose.rememberNavController
+import androidx.navigation.toRoute
+import androidx.glance.appwidget.updateAll
+import androidx.work.WorkManager
+import app.clothescast.ClothesCastApplication
+import app.clothescast.R
+import app.clothescast.calendar.resolveHolidayTheme
+import app.clothescast.cast.castCurrentInsight
+import app.clothescast.core.domain.model.ForecastPeriod
+import app.clothescast.core.domain.model.OutfitSuggestion
+import app.clothescast.insight.InsightFormatter
+import app.clothescast.locale.AppLocale
+import app.clothescast.location.LocationResolver
+import app.clothescast.ui.garment.outfitCardInfoLines
+import app.clothescast.ui.garment.renderOutfitCard
+import app.clothescast.ui.onboarding.OnboardingScreen
+import app.clothescast.ui.onboarding.OnboardingViewModel
+import app.clothescast.ui.pairing.PairingScreen
+import app.clothescast.ui.pairing.PairingViewModel
+import app.clothescast.ui.settings.SettingsRoute
+import app.clothescast.ui.settings.SettingsSubPage
+import app.clothescast.ui.settings.SettingsViewModel
+import app.clothescast.ui.today.TodayScreen
+import app.clothescast.ui.today.TodayViewModel
+import app.clothescast.widget.OutfitWidget
+import app.clothescast.work.FetchAndNotifyWorker
+import kotlinx.coroutines.flow.first
+import kotlinx.serialization.Serializable
+
+// Type-safe destinations. The four top-level screens plus a nested graph for
+// Settings — each settings sub-page is its own destination so the framework's
+// back stack handles up-navigation. No hand-maintained "current route" state,
+// no goBackOrUp(), no per-screen BackHandler.
+@Serializable internal object TodayRoute
+@Serializable internal object OnboardingRoute
+@Serializable internal object PairingRoute
+
+@Serializable internal object SettingsGraph
+@Serializable internal object SettingsRootDest
+// fromOnboarding rides as a typed nav argument (was a stringly-typed
+// `settingsInitialRoute` round-trip through MainActivity before).
+@Serializable internal data class ScheduleDest(val fromOnboarding: Boolean = false)
+@Serializable internal object ClothesDest
+@Serializable internal object RegionDest
+@Serializable internal object VoiceDest
+@Serializable internal object DisplayDest
+@Serializable internal object HolidaysDest
+@Serializable internal object LocationDest
+@Serializable internal object CalendarDest
+@Serializable internal object ForecastersDest
+@Serializable internal object SmartHomeDest
+@Serializable internal object PrivacyDest
+@Serializable internal object AboutDest
+
+private fun SettingsRoute.toDestination(): Any = when (this) {
+    SettingsRoute.Root -> SettingsRootDest
+    SettingsRoute.Schedule -> ScheduleDest()
+    SettingsRoute.Clothes -> ClothesDest
+    SettingsRoute.Region -> RegionDest
+    SettingsRoute.Voice -> VoiceDest
+    SettingsRoute.Display -> DisplayDest
+    SettingsRoute.Holidays -> HolidaysDest
+    SettingsRoute.Location -> LocationDest
+    SettingsRoute.Calendar -> CalendarDest
+    SettingsRoute.Forecasters -> ForecastersDest
+    SettingsRoute.SmartHome -> SmartHomeDest
+    SettingsRoute.Privacy -> PrivacyDest
+    SettingsRoute.About -> AboutDest
+}
+
+@Composable
+fun ClothesCastNavHost(
+    app: ClothesCastApplication,
+    navigateToTodayVersion: Int,
+    startOnboarding: Boolean,
+) {
+    val nav = rememberNavController()
+
+    // Notification taps snap to Today regardless of where the user was. The
+    // back stack is cleared so a subsequent back exits the app rather than
+    // walking back into a half-finished settings drill-down.
+    LaunchedEffect(navigateToTodayVersion) {
+        if (navigateToTodayVersion > 0) {
+            nav.navigate(TodayRoute) {
+                popUpTo(nav.graph.id) { inclusive = true }
+                launchSingleTop = true
+            }
+        }
+    }
+
+    NavHost(
+        navController = nav,
+        startDestination = if (startOnboarding) OnboardingRoute else TodayRoute,
+    ) {
+        composable<TodayRoute> {
+            val context = LocalContext.current
+            val today: TodayViewModel = viewModel(factory = todayViewModelFactory(app, context))
+            TodayScreen(
+                viewModel = today,
+                onNavigateToSettings = { nav.navigate(SettingsGraph) },
+                // Deep links push the target page straight onto Today, so a
+                // single back returns to Today (no detour through the root list).
+                onNavigateToAbout = { nav.navigate(AboutDest) },
+                onNavigateToLocation = { nav.navigate(LocationDest) },
+                onNavigateToPrivacy = { nav.navigate(PrivacyDest) },
+                onNavigateToClothes = { nav.navigate(ClothesDest) },
+                onNavigateToHolidays = { nav.navigate(HolidaysDest) },
+            )
+        }
+
+        composable<OnboardingRoute> {
+            val context = LocalContext.current
+            val onboarding: OnboardingViewModel = viewModel(
+                factory = OnboardingViewModel.Factory(
+                    secureKeyStore = app.secureKeyStore,
+                    settingsRepository = app.settingsRepository,
+                    geocodingClient = app.geocodingClient,
+                    refreshLocationCache = {
+                        FetchAndNotifyWorker.enqueueLocationCacheRefresh(context)
+                    },
+                    workManager = WorkManager.getInstance(app),
+                ),
+            )
+            OnboardingScreen(
+                viewModel = onboarding,
+                onPairFromPhone = { nav.navigate(PairingRoute) },
+                onContinue = { nav.navigate(ScheduleDest(fromOnboarding = true)) },
+                onSkip = {
+                    nav.navigate(TodayRoute) {
+                        popUpTo(nav.graph.id) { inclusive = true }
+                    }
+                },
+            )
+        }
+
+        composable<PairingRoute> {
+            val pairing: PairingViewModel = viewModel(
+                factory = PairingViewModel.Factory(
+                    secureKeyStore = app.secureKeyStore,
+                    settingsRepository = app.settingsRepository,
+                ),
+            )
+            PairingScreen(
+                viewModel = pairing,
+                onSuccess = { nav.popBackStack() },
+                onCancel = { nav.popBackStack() },
+            )
+        }
+
+        settingsGraph(nav, app)
+    }
+}
+
+private fun NavGraphBuilder.settingsGraph(nav: NavController, app: ClothesCastApplication) {
+    // Finishing onboarding lands the user on Today as a fresh root.
+    val finishOnboarding: () -> Unit = {
+        nav.navigate(TodayRoute) {
+            popUpTo(nav.graph.id) { inclusive = true }
+        }
+    }
+    val onNavigate: (SettingsRoute) -> Unit = { nav.navigate(it.toDestination()) }
+    val onBack: () -> Unit = { nav.popBackStack() }
+
+    navigation<SettingsGraph>(startDestination = SettingsRootDest) {
+        composable<SettingsRootDest> { entry ->
+            SettingsSubPage(SettingsRoute.Root, entry.settingsViewModel(nav, app), onBack, onNavigate)
+        }
+        composable<ScheduleDest> { entry ->
+            SettingsSubPage(
+                route = SettingsRoute.Schedule,
+                viewModel = entry.settingsViewModel(nav, app),
+                onBack = onBack,
+                onNavigate = onNavigate,
+                onboardingLanding = entry.toRoute<ScheduleDest>().fromOnboarding,
+                onFinishOnboarding = finishOnboarding,
+            )
+        }
+        composable<ClothesDest> { e -> SettingsSubPage(SettingsRoute.Clothes, e.settingsViewModel(nav, app), onBack, onNavigate) }
+        composable<RegionDest> { e -> SettingsSubPage(SettingsRoute.Region, e.settingsViewModel(nav, app), onBack, onNavigate) }
+        composable<VoiceDest> { e -> SettingsSubPage(SettingsRoute.Voice, e.settingsViewModel(nav, app), onBack, onNavigate) }
+        composable<DisplayDest> { e -> SettingsSubPage(SettingsRoute.Display, e.settingsViewModel(nav, app), onBack, onNavigate) }
+        composable<HolidaysDest> { e -> SettingsSubPage(SettingsRoute.Holidays, e.settingsViewModel(nav, app), onBack, onNavigate) }
+        composable<LocationDest> { e -> SettingsSubPage(SettingsRoute.Location, e.settingsViewModel(nav, app), onBack, onNavigate) }
+        composable<CalendarDest> { e -> SettingsSubPage(SettingsRoute.Calendar, e.settingsViewModel(nav, app), onBack, onNavigate) }
+        composable<ForecastersDest> { e -> SettingsSubPage(SettingsRoute.Forecasters, e.settingsViewModel(nav, app), onBack, onNavigate) }
+        composable<SmartHomeDest> { e -> SettingsSubPage(SettingsRoute.SmartHome, e.settingsViewModel(nav, app), onBack, onNavigate) }
+        composable<PrivacyDest> { e -> SettingsSubPage(SettingsRoute.Privacy, e.settingsViewModel(nav, app), onBack, onNavigate) }
+        composable<AboutDest> { e -> SettingsSubPage(SettingsRoute.About, e.settingsViewModel(nav, app), onBack, onNavigate) }
+    }
+}
+
+// One SettingsViewModel shared across every settings destination, scoped to the
+// SettingsGraph back-stack entry. Replaces the single VM the old monolithic
+// SettingsScreen held; surviving config changes and process death the same way.
+@Composable
+private fun NavBackStackEntry.settingsViewModel(
+    nav: NavController,
+    app: ClothesCastApplication,
+): SettingsViewModel {
+    val context = LocalContext.current
+    val parentEntry = remember(this) { nav.getBackStackEntry<SettingsGraph>() }
+    return viewModel(viewModelStoreOwner = parentEntry, factory = settingsViewModelFactory(app, context))
+}
+
+private fun todayViewModelFactory(app: ClothesCastApplication, context: Context) =
+    TodayViewModel.Factory(
+        insightCache = app.insightCache,
+        workManager = WorkManager.getInstance(app),
+        settingsRepository = app.settingsRepository,
+        refreshOutfitWidget = {
+            runCatching { OutfitWidget().updateAll(context.applicationContext) }
+        },
+        calendarEventReader = app.calendarEventReader,
+    )
+
+private fun settingsViewModelFactory(app: ClothesCastApplication, context: Context) =
+    SettingsViewModel.Factory(
+        settingsRepository = app.settingsRepository,
+        keyStore = app.secureKeyStore,
+        rearmAlarm = app.dailyAlarmScheduler::schedule,
+        cancelAlarm = app.dailyAlarmScheduler::cancel,
+        geocodingClient = app.geocodingClient,
+        voiceEnumerator = app.androidTtsVoiceEnumerator,
+        applyAppLocale = { region ->
+            AppLocale.apply(app, region)
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+                (context as? Activity)?.recreate()
+            }
+        },
+        refreshLocationCache = {
+            FetchAndNotifyWorker.enqueueLocationCacheRefresh(context)
+        },
+        refreshCachedOutfits = {
+            val prefs = app.settingsRepository.preferences.first()
+            app.insightCache.recomputeOutfits(prefs.clothesRules, prefs.defaultBottom)
+            runCatching { OutfitWidget().updateAll(context.applicationContext) }
+        },
+        resolveDeviceLocationWithCity = {
+            app.locationResolver.resolveFresh(
+                LocationResolver.FRESH_FIX_MAX_AGE_MS,
+            )?.let { fix ->
+                val geo = app.reverseGeocoder.resolve(fix.latitude, fix.longitude)
+                fix.copy(
+                    displayName = geo.city ?: fix.displayName,
+                    countryCode = geo.countryCode ?: fix.countryCode,
+                )
+            }
+        },
+        workManager = WorkManager.getInstance(app),
+        mqttPublisher = app.mqttPublisher,
+        fullPublish = {
+            val prefs = app.settingsRepository.preferences.first()
+            val insight = app.insightCache.thisPeriod.first()
+                ?: return@Factory app.mqttPublisher.publishTest()
+            val formatter = InsightFormatter.forRegion(context, prefs.region, prefs.temperatureUnit)
+            val prose = formatter.format(insight.summary)
+            val png: ByteArray? = insight.outfit?.let { outfit ->
+                runCatching {
+                    val info = outfitCardInfoLines(
+                        context = context,
+                        formatter = formatter,
+                        hourly = insight.hourly,
+                        temperatureUnit = prefs.temperatureUnit,
+                    )
+                    val header = context.getString(
+                        if (insight.period == ForecastPeriod.TODAY) R.string.outfit_card_header_today
+                        else R.string.outfit_card_header_tonight
+                    )
+                    val theme = resolveHolidayTheme(prefs, app.calendarEventReader)
+                    val topColors: Map<OutfitSuggestion.Top, Long> =
+                        prefs.outfitTopColors + (theme?.topOverrides ?: emptyMap())
+                    val bottomColors: Map<OutfitSuggestion.Bottom, Long> =
+                        prefs.outfitBottomColors + (theme?.bottomOverrides ?: emptyMap())
+                    val topStrokes: Map<OutfitSuggestion.Top, Long> =
+                        theme?.topStrokeOverrides ?: emptyMap()
+                    val bottomStrokes: Map<OutfitSuggestion.Bottom, Long> =
+                        theme?.bottomStrokeOverrides ?: emptyMap()
+                    renderOutfitCard(
+                        context = context,
+                        outfit = outfit,
+                        header = header,
+                        prose = prose,
+                        tempLine = info.tempLine,
+                        rainLine = info.rainLine,
+                        tempFillFraction = info.tempFillFraction,
+                        rainFillFraction = info.rainFillFraction,
+                        topColors = topColors,
+                        bottomColors = bottomColors,
+                        topStrokes = topStrokes,
+                        bottomStrokes = bottomStrokes,
+                    )
+                }.getOrNull()
+            }
+            app.mqttPublisher.publishIfEnabled(insight.period, prose, image = png)
+        },
+        discovery = app.homeAssistantDiscovery,
+        castRouteDiscovery = app.castRouteDiscovery,
+        castAvailable = app.castContext != null,
+        castNowAction = app.castInsightController?.let { controller ->
+            {
+                castCurrentInsight(
+                    context = context,
+                    settingsRepository = app.settingsRepository,
+                    insightCache = app.insightCache,
+                    calendarEventReader = app.calendarEventReader,
+                    controller = controller,
+                    locale = LocaleListCompat.getAdjustedDefault().get(0)
+                        ?: java.util.Locale.getDefault(),
+                )
+            }
+        },
+    )

--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsPreviews.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsPreviews.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import app.clothescast.R
 import app.clothescast.core.domain.model.ClothesRule
 import app.clothescast.core.domain.model.ColorPalette
 import app.clothescast.core.domain.model.DeliveryMode
@@ -58,8 +59,21 @@ internal fun SettingsRootPreview() {
     SettingsFrame {
         SettingsRoot(
             useDeviceLocation = false,
+            items = listOf(
+                SettingsMenuItem(R.string.settings_root_schedule, R.string.settings_root_schedule_subtitle) {},
+                SettingsMenuItem(R.string.settings_root_clothes, R.string.settings_root_clothes_subtitle) {},
+                SettingsMenuItem(R.string.settings_root_region, R.string.settings_root_region_subtitle) {},
+                SettingsMenuItem(R.string.settings_root_voice, R.string.settings_root_voice_subtitle) {},
+                SettingsMenuItem(R.string.settings_root_display, R.string.settings_root_display_subtitle) {},
+                SettingsMenuItem(R.string.settings_root_holidays, R.string.settings_root_holidays_subtitle) {},
+                SettingsMenuItem(R.string.settings_root_location, R.string.settings_root_location_subtitle) {},
+                SettingsMenuItem(R.string.settings_root_forecasters, R.string.settings_root_forecasters_subtitle) {},
+                SettingsMenuItem(R.string.settings_root_calendar, R.string.settings_root_calendar_subtitle) {},
+                SettingsMenuItem(R.string.settings_root_smart_home, R.string.settings_root_smart_home_subtitle) {},
+                SettingsMenuItem(R.string.settings_root_privacy, R.string.settings_root_privacy_subtitle) {},
+            ),
             padding = PaddingValues(0.dp),
-            onNavigate = {},
+            onOpenLocation = {},
         )
     }
 }

--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsScreen.kt
@@ -30,66 +30,42 @@ import app.clothescast.tts.toJavaLocale
 import app.clothescast.ui.EdgeFadeOverlay
 
 /**
- * One sub-page per concern. Order in the enum matches the order shown in the
- * root list: the most-frequently-tweaked rules at the top, set-once
- * configuration in the middle, and data sources at the bottom. BYOK keys live
- * inside Voice — the only thing they gate is cloud TTS.
- *
- * About is reachable as a deep-link target only — it's surfaced from Today's
- * overflow menu, not from the settings root list.
- *
- * Each entry maps to a navigation destination in the Settings nested graph
- * (see ClothesCastNavHost); the framework's back stack owns up-navigation.
+ * A row on the Settings root menu: a label, subtitle, and the navigation it
+ * triggers. The nav host (ClothesCastNavHost) builds the ordered list and
+ * attaches each row's navigation; this type carries no navigation dependency so
+ * previews can render the menu standalone.
  */
-enum class SettingsRoute(@StringRes val titleRes: Int, @StringRes val subtitleRes: Int? = null) {
-    Root(R.string.settings_title),
-    Schedule(R.string.settings_root_schedule, R.string.settings_root_schedule_subtitle),
-    Clothes(R.string.settings_root_clothes, R.string.settings_root_clothes_subtitle),
-    Region(R.string.settings_root_region, R.string.settings_root_region_subtitle),
-    Voice(R.string.settings_root_voice, R.string.settings_root_voice_subtitle),
-    Display(R.string.settings_root_display, R.string.settings_root_display_subtitle),
-    Holidays(R.string.settings_root_holidays, R.string.settings_root_holidays_subtitle),
-    Location(R.string.settings_root_location, R.string.settings_root_location_subtitle),
-    Forecasters(R.string.settings_root_forecasters, R.string.settings_root_forecasters_subtitle),
-    Calendar(R.string.settings_root_calendar, R.string.settings_root_calendar_subtitle),
-    SmartHome(R.string.settings_root_smart_home, R.string.settings_root_smart_home_subtitle),
-    Privacy(R.string.settings_root_privacy, R.string.settings_root_privacy_subtitle),
-    About(R.string.settings_root_about),
-}
+data class SettingsMenuItem(
+    @StringRes val titleRes: Int,
+    @StringRes val subtitleRes: Int,
+    val onClick: () -> Unit,
+)
 
 /**
- * Renders one Settings sub-page. Each [SettingsRoute] is its own navigation
- * destination, so there's no internal route state and no custom back handling
- * here — [onBack] just pops the nav back stack and the framework restores the
- * previous destination. Cross-page links (and the root list) call [onNavigate].
- *
- * [onboardingLanding] marks the Schedule page when it's the onboarding
- * "Continue" target, surfacing a Done button that calls [onFinishOnboarding].
+ * Shared chrome for a Settings sub-page: a top bar showing [titleRes] with a back
+ * arrow wired to [onBack] (which pops the nav back stack), plus edge-to-edge
+ * content insets. Every destination in the Settings nested graph renders through
+ * this — there's no central route state or custom back handling; the framework's
+ * back stack owns up-navigation.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun SettingsSubPage(
-    route: SettingsRoute,
-    viewModel: SettingsViewModel,
+internal fun SettingsScaffold(
+    @StringRes titleRes: Int,
     onBack: () -> Unit,
-    onNavigate: (SettingsRoute) -> Unit,
-    onboardingLanding: Boolean = false,
-    onFinishOnboarding: () -> Unit = {},
+    content: @Composable (PaddingValues) -> Unit,
 ) {
-    val state by viewModel.state.collectAsStateWithLifecycle()
-
     Scaffold(
         // Drop the default `safeDrawing` content insets so each sub-screen's
-        // scroll viewport extends edge-to-edge under the (transparent) nav
-        // bar. Each sub-screen's inner Column adds
-        // `windowInsetsPadding(WindowInsets.navigationBars)` as content
-        // padding so the last item can scroll above the nav bar; the bottom
-        // fade in `EdgeFadeOverlay` does the same so it sits just above
-        // the bar.
+        // scroll viewport extends edge-to-edge under the (transparent) nav bar.
+        // Each sub-screen's inner Column adds
+        // `windowInsetsPadding(WindowInsets.navigationBars)` as content padding
+        // so the last item can scroll above the nav bar; the bottom fade in
+        // `EdgeFadeOverlay` does the same so it sits just above the bar.
         contentWindowInsets = WindowInsets(0),
         topBar = {
             TopAppBar(
-                title = { Text(stringResource(route.titleRes)) },
+                title = { Text(stringResource(titleRes)) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(
@@ -100,197 +76,303 @@ fun SettingsSubPage(
                 },
             )
         },
-    ) { padding ->
-        when (route) {
-            SettingsRoute.Root -> SettingsRoot(
-                useDeviceLocation = state.useDeviceLocation,
-                padding = padding,
-                onNavigate = onNavigate,
-            )
-            SettingsRoute.Schedule -> ScheduleContent(
-                time = state.scheduleTime,
-                days = state.scheduleDays,
-                tonightTime = state.tonightTime,
-                tonightDays = state.tonightDays,
-                tonightEnabled = state.tonightEnabled,
-                tonightNotifyOnlyOnEvents = state.tonightNotifyOnlyOnEvents,
-                dailyMentionEveningEvents = state.dailyMentionEveningEvents,
-                deliveryMode = state.deliveryMode,
-                tonightDeliveryMode = state.tonightDeliveryMode,
-                skipTtsAtHome = state.skipTtsAtHome,
-                homeLocationConfigured = state.homeLocation != null,
-                padding = padding,
-                onSetSchedule = viewModel::setSchedule,
-                onSetTonightSchedule = viewModel::setTonightSchedule,
-                onSetTonightEnabled = viewModel::setTonightEnabled,
-                onSetTonightNotifyOnlyOnEvents = viewModel::setTonightNotifyOnlyOnEvents,
-                onSetDailyMentionEveningEvents = viewModel::setDailyMentionEveningEvents,
-                onSetDeliveryMode = viewModel::setDeliveryMode,
-                onSetTonightDeliveryMode = viewModel::setTonightDeliveryMode,
-                onSetSkipTtsAtHome = viewModel::setSkipTtsAtHome,
-                // Show a Done button only when this page is the deep-link
-                // landing from onboarding's "Continue" — gives the user an
-                // obvious way to finish setup and reach Today. In the regular
-                // settings flow they exit via the top-bar back arrow.
-                onDone = if (onboardingLanding) onFinishOnboarding else null,
-            )
-            SettingsRoute.Clothes -> ClothesContent(
-                rules = state.clothesRules,
-                defaultBottom = state.defaultBottom,
-                temperatureUnit = state.temperatureUnit,
-                outfitTopColors = state.outfitTopColors,
-                outfitBottomColors = state.outfitBottomColors,
-                padding = padding,
-                onAdd = viewModel::addClothesRule,
-                onReplace = viewModel::replaceClothesRule,
-                onDelete = viewModel::deleteClothesRule,
-                onSetDefaultBottom = viewModel::setDefaultBottom,
-                onSetOutfitTopColor = viewModel::setOutfitTopColor,
-                onSetOutfitBottomColor = viewModel::setOutfitBottomColor,
-            )
-            SettingsRoute.Region -> RegionContent(
-                region = state.region,
-                temperatureUnitSetting = state.temperatureUnitSetting,
-                distanceUnitSetting = state.distanceUnitSetting,
-                resolvedTemperatureUnit = state.temperatureUnit,
-                resolvedDistanceUnit = state.distanceUnit,
-                padding = padding,
-                onSetRegion = viewModel::setRegion,
-                onSetTemperatureUnit = viewModel::setTemperatureUnitSetting,
-                onSetDistanceUnit = viewModel::setDistanceUnitSetting,
-            )
-            SettingsRoute.Voice -> VoiceContent(
-                selected = state.ttsEngine,
-                geminiVoice = state.geminiVoice,
-                ttsStyle = state.ttsStyle,
-                deviceVoice = state.deviceVoice,
-                deviceVoices = state.deviceVoices,
-                effectiveDeviceVoice = state.effectiveDeviceVoice,
-                geminiKeyConfigured = state.apiKeyConfigured,
-                voiceLocale = state.voiceLocale,
-                region = state.region,
-                padding = padding,
-                onSetTtsEngine = viewModel::setTtsEngine,
-                onSetGeminiVoice = viewModel::setGeminiVoice,
-                onSetTtsStyle = viewModel::setTtsStyle,
-                onSetDeviceVoice = viewModel::setDeviceVoice,
-                onSetVoiceLocale = viewModel::setVoiceLocale,
-                onSetGeminiKey = viewModel::setApiKey,
-                onClearGeminiKey = viewModel::clearApiKey,
-            )
-            SettingsRoute.Display -> DisplayContent(
-                themeMode = state.themeMode,
-                colorPalette = state.colorPalette,
-                padding = padding,
-                onSetThemeMode = viewModel::setThemeMode,
-                onSetColorPalette = viewModel::setColorPalette,
-            )
-            SettingsRoute.Holidays -> HolidaysContent(
-                holidayCountrySelection = state.holidayCountrySelection,
-                holidayOverrides = state.holidayOverrides,
-                effectiveEnabledHolidayCountries = state.effectiveEnabledHolidayCountries,
-                localeCountry = state.region.toJavaLocale()?.country
-                    ?: java.util.Locale.getDefault().country,
-                weatherLocationCountry = state.location?.countryCode,
-                themeFromCalendarHolidays = state.themeFromCalendarHolidays,
-                themeFromCalendarBirthdays = state.themeFromCalendarBirthdays,
-                padding = padding,
-                onSetCountryHome = viewModel::setHolidayCountryHome,
-                onSetCountryCurrent = viewModel::setHolidayCountryCurrent,
-                onSetCountryGlobal = viewModel::setHolidayCountryGlobal,
-                onSetCountryAll = viewModel::setHolidayCountryAll,
-                onSetCountryOverride = viewModel::setHolidayCountryOverride,
-                onSetHolidayOverride = viewModel::setHolidayOverride,
-                onSetThemeFromCalendarHolidays = viewModel::setThemeFromCalendarHolidays,
-                onSetThemeFromCalendarBirthdays = viewModel::setThemeFromCalendarBirthdays,
-                onCalendarPermissionRechecked = viewModel::markCalendarPermissionRechecked,
-                onNavigateToRegionSettings = { onNavigate(SettingsRoute.Region) },
-                onNavigateToLocationSettings = { onNavigate(SettingsRoute.Location) },
-                onNavigateToCalendarSettings = { onNavigate(SettingsRoute.Calendar) },
-            )
-            SettingsRoute.Location -> LocationContent(
-                location = state.location,
-                useDeviceLocation = state.useDeviceLocation,
-                homeLocation = state.homeLocation,
-                homeLocationResolving = state.homeLocationResolving,
-                locationDetecting = state.locationDetecting,
-                padding = padding,
-                onSetUseDeviceLocation = viewModel::setUseDeviceLocation,
-                onSelectLocation = viewModel::selectLocation,
-                onClearLocation = viewModel::clearLocation,
-                onSelectHomeLocation = viewModel::selectHomeLocation,
-                onClearHomeLocation = viewModel::clearHomeLocation,
-                onUseCurrentLocationForHome = viewModel::useCurrentLocationForHome,
-                onSearchLocations = viewModel::searchLocations,
-            )
-            SettingsRoute.Calendar -> CalendarContent(
-                useCalendarEvents = state.useCalendarEvents,
-                padding = padding,
-                onSetUseCalendarEvents = viewModel::setUseCalendarEvents,
-            )
-            SettingsRoute.Forecasters -> ForecastersContent(
-                forecastModels = state.forecastModels,
-                location = state.location,
-                padding = padding,
-                onSetForecastModels = viewModel::setForecastModels,
-            )
-            SettingsRoute.SmartHome -> SmartHomeContent(
-                bridgeEnabled = state.mqttBridgeEnabled,
-                host = state.mqttHost,
-                port = state.mqttPort,
-                useTls = state.mqttUseTls,
-                username = state.mqttUsername,
-                topic = state.mqttTopic,
-                passwordSet = state.mqttPasswordSet,
-                lastError = state.mqttLastError,
-                lastErrorAt = state.mqttLastErrorAt,
-                lastPublishAt = state.mqttLastPublishAt,
-                publishing = state.mqttPublishing,
-                discoveryRunning = state.discoveryRunning,
-                discoveredServices = state.discoveredServices,
-                castAvailable = state.castAvailable,
-                castRouteName = state.castRouteName,
-                castPickerOpen = state.castPickerOpen,
-                castDiscoveredRoutes = state.castDiscoveredRoutes,
-                castInProgress = state.castInProgress,
-                castLastError = state.castLastError,
-                castLastErrorAt = state.castLastErrorAt,
-                castLastSuccessAt = state.castLastSuccessAt,
-                castMorning = state.castMorning,
-                castTonight = state.castTonight,
-                castSkipPhoneSpeech = state.castSkipPhoneSpeech,
-                padding = padding,
-                onSetBridgeEnabled = viewModel::setMqttBridgeEnabled,
-                onSaveConfig = viewModel::setMqttConfig,
-                onClearPassword = viewModel::clearMqttPassword,
-                onPublishNow = viewModel::publishNow,
-                onStartDiscovery = viewModel::startDiscovery,
-                onStopDiscovery = viewModel::stopDiscovery,
-                onUseDiscoveredService = viewModel::useDiscoveredService,
-                onOpenCastPicker = viewModel::openCastPicker,
-                onCloseCastPicker = viewModel::closeCastPicker,
-                onPickCastRoute = viewModel::pickCastRoute,
-                onClearCastRoute = viewModel::clearCastRoute,
-                onCastNow = viewModel::castNow,
-                onSetCastMorning = viewModel::setCastMorning,
-                onSetCastTonight = viewModel::setCastTonight,
-                onSetCastSkipPhoneSpeech = viewModel::setCastSkipPhoneSpeech,
-            )
-            SettingsRoute.Privacy -> PrivacyContent(
-                telemetryEnabled = state.telemetryEnabled,
-                padding = padding,
-                onSetTelemetryEnabled = viewModel::setTelemetryEnabled,
-            )
-            SettingsRoute.About -> AboutContent(padding = padding)
-        }
+        content = content,
+    )
+}
+
+@Composable
+internal fun SettingsRootPage(
+    viewModel: SettingsViewModel,
+    items: List<SettingsMenuItem>,
+    onBack: () -> Unit,
+    onOpenLocation: () -> Unit,
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    SettingsScaffold(R.string.settings_title, onBack) { padding ->
+        SettingsRoot(
+            useDeviceLocation = state.useDeviceLocation,
+            items = items,
+            padding = padding,
+            onOpenLocation = onOpenLocation,
+        )
+    }
+}
+
+@Composable
+internal fun SchedulePage(
+    viewModel: SettingsViewModel,
+    onBack: () -> Unit,
+    onboardingLanding: Boolean,
+    onFinishOnboarding: () -> Unit,
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    SettingsScaffold(R.string.settings_root_schedule, onBack) { padding ->
+        ScheduleContent(
+            time = state.scheduleTime,
+            days = state.scheduleDays,
+            tonightTime = state.tonightTime,
+            tonightDays = state.tonightDays,
+            tonightEnabled = state.tonightEnabled,
+            tonightNotifyOnlyOnEvents = state.tonightNotifyOnlyOnEvents,
+            dailyMentionEveningEvents = state.dailyMentionEveningEvents,
+            deliveryMode = state.deliveryMode,
+            tonightDeliveryMode = state.tonightDeliveryMode,
+            skipTtsAtHome = state.skipTtsAtHome,
+            homeLocationConfigured = state.homeLocation != null,
+            padding = padding,
+            onSetSchedule = viewModel::setSchedule,
+            onSetTonightSchedule = viewModel::setTonightSchedule,
+            onSetTonightEnabled = viewModel::setTonightEnabled,
+            onSetTonightNotifyOnlyOnEvents = viewModel::setTonightNotifyOnlyOnEvents,
+            onSetDailyMentionEveningEvents = viewModel::setDailyMentionEveningEvents,
+            onSetDeliveryMode = viewModel::setDeliveryMode,
+            onSetTonightDeliveryMode = viewModel::setTonightDeliveryMode,
+            onSetSkipTtsAtHome = viewModel::setSkipTtsAtHome,
+            // Show a Done button only when this page is the deep-link landing from
+            // onboarding's "Continue" — gives the user an obvious way to finish
+            // setup and reach Today. In the regular settings flow they exit via
+            // the top-bar back arrow.
+            onDone = if (onboardingLanding) onFinishOnboarding else null,
+        )
+    }
+}
+
+@Composable
+internal fun ClothesPage(viewModel: SettingsViewModel, onBack: () -> Unit) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    SettingsScaffold(R.string.settings_root_clothes, onBack) { padding ->
+        ClothesContent(
+            rules = state.clothesRules,
+            defaultBottom = state.defaultBottom,
+            temperatureUnit = state.temperatureUnit,
+            outfitTopColors = state.outfitTopColors,
+            outfitBottomColors = state.outfitBottomColors,
+            padding = padding,
+            onAdd = viewModel::addClothesRule,
+            onReplace = viewModel::replaceClothesRule,
+            onDelete = viewModel::deleteClothesRule,
+            onSetDefaultBottom = viewModel::setDefaultBottom,
+            onSetOutfitTopColor = viewModel::setOutfitTopColor,
+            onSetOutfitBottomColor = viewModel::setOutfitBottomColor,
+        )
+    }
+}
+
+@Composable
+internal fun RegionPage(viewModel: SettingsViewModel, onBack: () -> Unit) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    SettingsScaffold(R.string.settings_root_region, onBack) { padding ->
+        RegionContent(
+            region = state.region,
+            temperatureUnitSetting = state.temperatureUnitSetting,
+            distanceUnitSetting = state.distanceUnitSetting,
+            resolvedTemperatureUnit = state.temperatureUnit,
+            resolvedDistanceUnit = state.distanceUnit,
+            padding = padding,
+            onSetRegion = viewModel::setRegion,
+            onSetTemperatureUnit = viewModel::setTemperatureUnitSetting,
+            onSetDistanceUnit = viewModel::setDistanceUnitSetting,
+        )
+    }
+}
+
+@Composable
+internal fun VoicePage(viewModel: SettingsViewModel, onBack: () -> Unit) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    SettingsScaffold(R.string.settings_root_voice, onBack) { padding ->
+        VoiceContent(
+            selected = state.ttsEngine,
+            geminiVoice = state.geminiVoice,
+            ttsStyle = state.ttsStyle,
+            deviceVoice = state.deviceVoice,
+            deviceVoices = state.deviceVoices,
+            effectiveDeviceVoice = state.effectiveDeviceVoice,
+            geminiKeyConfigured = state.apiKeyConfigured,
+            voiceLocale = state.voiceLocale,
+            region = state.region,
+            padding = padding,
+            onSetTtsEngine = viewModel::setTtsEngine,
+            onSetGeminiVoice = viewModel::setGeminiVoice,
+            onSetTtsStyle = viewModel::setTtsStyle,
+            onSetDeviceVoice = viewModel::setDeviceVoice,
+            onSetVoiceLocale = viewModel::setVoiceLocale,
+            onSetGeminiKey = viewModel::setApiKey,
+            onClearGeminiKey = viewModel::clearApiKey,
+        )
+    }
+}
+
+@Composable
+internal fun DisplayPage(viewModel: SettingsViewModel, onBack: () -> Unit) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    SettingsScaffold(R.string.settings_root_display, onBack) { padding ->
+        DisplayContent(
+            themeMode = state.themeMode,
+            colorPalette = state.colorPalette,
+            padding = padding,
+            onSetThemeMode = viewModel::setThemeMode,
+            onSetColorPalette = viewModel::setColorPalette,
+        )
+    }
+}
+
+@Composable
+internal fun HolidaysPage(
+    viewModel: SettingsViewModel,
+    onBack: () -> Unit,
+    onNavigateToRegion: () -> Unit,
+    onNavigateToLocation: () -> Unit,
+    onNavigateToCalendar: () -> Unit,
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    SettingsScaffold(R.string.settings_root_holidays, onBack) { padding ->
+        HolidaysContent(
+            holidayCountrySelection = state.holidayCountrySelection,
+            holidayOverrides = state.holidayOverrides,
+            effectiveEnabledHolidayCountries = state.effectiveEnabledHolidayCountries,
+            localeCountry = state.region.toJavaLocale()?.country
+                ?: java.util.Locale.getDefault().country,
+            weatherLocationCountry = state.location?.countryCode,
+            themeFromCalendarHolidays = state.themeFromCalendarHolidays,
+            themeFromCalendarBirthdays = state.themeFromCalendarBirthdays,
+            padding = padding,
+            onSetCountryHome = viewModel::setHolidayCountryHome,
+            onSetCountryCurrent = viewModel::setHolidayCountryCurrent,
+            onSetCountryGlobal = viewModel::setHolidayCountryGlobal,
+            onSetCountryAll = viewModel::setHolidayCountryAll,
+            onSetCountryOverride = viewModel::setHolidayCountryOverride,
+            onSetHolidayOverride = viewModel::setHolidayOverride,
+            onSetThemeFromCalendarHolidays = viewModel::setThemeFromCalendarHolidays,
+            onSetThemeFromCalendarBirthdays = viewModel::setThemeFromCalendarBirthdays,
+            onCalendarPermissionRechecked = viewModel::markCalendarPermissionRechecked,
+            onNavigateToRegionSettings = onNavigateToRegion,
+            onNavigateToLocationSettings = onNavigateToLocation,
+            onNavigateToCalendarSettings = onNavigateToCalendar,
+        )
+    }
+}
+
+@Composable
+internal fun LocationPage(viewModel: SettingsViewModel, onBack: () -> Unit) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    SettingsScaffold(R.string.settings_root_location, onBack) { padding ->
+        LocationContent(
+            location = state.location,
+            useDeviceLocation = state.useDeviceLocation,
+            homeLocation = state.homeLocation,
+            homeLocationResolving = state.homeLocationResolving,
+            locationDetecting = state.locationDetecting,
+            padding = padding,
+            onSetUseDeviceLocation = viewModel::setUseDeviceLocation,
+            onSelectLocation = viewModel::selectLocation,
+            onClearLocation = viewModel::clearLocation,
+            onSelectHomeLocation = viewModel::selectHomeLocation,
+            onClearHomeLocation = viewModel::clearHomeLocation,
+            onUseCurrentLocationForHome = viewModel::useCurrentLocationForHome,
+            onSearchLocations = viewModel::searchLocations,
+        )
+    }
+}
+
+@Composable
+internal fun CalendarPage(viewModel: SettingsViewModel, onBack: () -> Unit) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    SettingsScaffold(R.string.settings_root_calendar, onBack) { padding ->
+        CalendarContent(
+            useCalendarEvents = state.useCalendarEvents,
+            padding = padding,
+            onSetUseCalendarEvents = viewModel::setUseCalendarEvents,
+        )
+    }
+}
+
+@Composable
+internal fun ForecastersPage(viewModel: SettingsViewModel, onBack: () -> Unit) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    SettingsScaffold(R.string.settings_root_forecasters, onBack) { padding ->
+        ForecastersContent(
+            forecastModels = state.forecastModels,
+            location = state.location,
+            padding = padding,
+            onSetForecastModels = viewModel::setForecastModels,
+        )
+    }
+}
+
+@Composable
+internal fun SmartHomePage(viewModel: SettingsViewModel, onBack: () -> Unit) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    SettingsScaffold(R.string.settings_root_smart_home, onBack) { padding ->
+        SmartHomeContent(
+            bridgeEnabled = state.mqttBridgeEnabled,
+            host = state.mqttHost,
+            port = state.mqttPort,
+            useTls = state.mqttUseTls,
+            username = state.mqttUsername,
+            topic = state.mqttTopic,
+            passwordSet = state.mqttPasswordSet,
+            lastError = state.mqttLastError,
+            lastErrorAt = state.mqttLastErrorAt,
+            lastPublishAt = state.mqttLastPublishAt,
+            publishing = state.mqttPublishing,
+            discoveryRunning = state.discoveryRunning,
+            discoveredServices = state.discoveredServices,
+            castAvailable = state.castAvailable,
+            castRouteName = state.castRouteName,
+            castPickerOpen = state.castPickerOpen,
+            castDiscoveredRoutes = state.castDiscoveredRoutes,
+            castInProgress = state.castInProgress,
+            castLastError = state.castLastError,
+            castLastErrorAt = state.castLastErrorAt,
+            castLastSuccessAt = state.castLastSuccessAt,
+            castMorning = state.castMorning,
+            castTonight = state.castTonight,
+            castSkipPhoneSpeech = state.castSkipPhoneSpeech,
+            padding = padding,
+            onSetBridgeEnabled = viewModel::setMqttBridgeEnabled,
+            onSaveConfig = viewModel::setMqttConfig,
+            onClearPassword = viewModel::clearMqttPassword,
+            onPublishNow = viewModel::publishNow,
+            onStartDiscovery = viewModel::startDiscovery,
+            onStopDiscovery = viewModel::stopDiscovery,
+            onUseDiscoveredService = viewModel::useDiscoveredService,
+            onOpenCastPicker = viewModel::openCastPicker,
+            onCloseCastPicker = viewModel::closeCastPicker,
+            onPickCastRoute = viewModel::pickCastRoute,
+            onClearCastRoute = viewModel::clearCastRoute,
+            onCastNow = viewModel::castNow,
+            onSetCastMorning = viewModel::setCastMorning,
+            onSetCastTonight = viewModel::setCastTonight,
+            onSetCastSkipPhoneSpeech = viewModel::setCastSkipPhoneSpeech,
+        )
+    }
+}
+
+@Composable
+internal fun PrivacyPage(viewModel: SettingsViewModel, onBack: () -> Unit) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    SettingsScaffold(R.string.settings_root_privacy, onBack) { padding ->
+        PrivacyContent(
+            telemetryEnabled = state.telemetryEnabled,
+            padding = padding,
+            onSetTelemetryEnabled = viewModel::setTelemetryEnabled,
+        )
+    }
+}
+
+@Composable
+internal fun AboutPage(onBack: () -> Unit) {
+    SettingsScaffold(R.string.settings_root_about, onBack) { padding ->
+        AboutContent(padding = padding)
     }
 }
 
 @Composable
 internal fun SettingsRoot(
     useDeviceLocation: Boolean,
+    items: List<SettingsMenuItem>,
     padding: PaddingValues,
-    onNavigate: (SettingsRoute) -> Unit,
+    onOpenLocation: () -> Unit,
 ) {
     val scrollState = rememberScrollState()
     EdgeFadeOverlay(
@@ -312,17 +394,15 @@ internal fun SettingsRoot(
             // rationale dialogs live.
             BackgroundLocationWarningCard(
                 useDeviceLocation = useDeviceLocation,
-                onClick = { onNavigate(SettingsRoute.Location) },
+                onClick = onOpenLocation,
             )
-            SettingsRoute.entries
-                .filter { it != SettingsRoute.Root && it != SettingsRoute.About }
-                .forEach { destination ->
-                    SettingsNavRow(
-                        title = stringResource(destination.titleRes),
-                        subtitle = destination.subtitleRes?.let { stringResource(it) },
-                        onClick = { onNavigate(destination) },
-                    )
-                }
+            items.forEach { item ->
+                SettingsNavRow(
+                    title = stringResource(item.titleRes),
+                    subtitle = stringResource(item.subtitleRes),
+                    onClick = item.onClick,
+                )
+            }
         }
     }
 }

--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsScreen.kt
@@ -1,6 +1,5 @@
 package app.clothescast.ui.settings
 
-import androidx.activity.compose.BackHandler
 import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -22,10 +21,6 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.Saver
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -43,8 +38,8 @@ import app.clothescast.ui.EdgeFadeOverlay
  * About is reachable as a deep-link target only — it's surfaced from Today's
  * overflow menu, not from the settings root list.
  *
- * Public so callers (e.g. the onboarding flow, Today's overflow) can deep-link
- * into a specific sub-page via [SettingsScreen]'s `initialRoute` param.
+ * Each entry maps to a navigation destination in the Settings nested graph
+ * (see ClothesCastNavHost); the framework's back stack owns up-navigation.
  */
 enum class SettingsRoute(@StringRes val titleRes: Int, @StringRes val subtitleRes: Int? = null) {
     Root(R.string.settings_title),
@@ -62,56 +57,26 @@ enum class SettingsRoute(@StringRes val titleRes: Int, @StringRes val subtitleRe
     About(R.string.settings_root_about),
 }
 
-// Saved as a comma-joined list of enum names (innermost page last) so the full
-// in-Settings back stack survives process death, not just the visible page.
-// Each name is restored with a runCatching skip so an old install that had a
-// now-removed route on the stack (e.g. the old `DataSources`) doesn't crash —
-// unknown entries are dropped and an empty result falls back to Root. A value
-// saved by the previous single-enum saver (a bare name like "Calendar")
-// restores cleanly as a one-element stack.
-private val SettingsBackStackSaver: Saver<List<SettingsRoute>, String> = Saver(
-    save = { stack -> stack.joinToString(",") { it.name } },
-    restore = { saved ->
-        saved.split(",")
-            .mapNotNull { name -> runCatching { SettingsRoute.valueOf(name) }.getOrNull() }
-            .ifEmpty { listOf(SettingsRoute.Root) }
-    },
-)
-
+/**
+ * Renders one Settings sub-page. Each [SettingsRoute] is its own navigation
+ * destination, so there's no internal route state and no custom back handling
+ * here — [onBack] just pops the nav back stack and the framework restores the
+ * previous destination. Cross-page links (and the root list) call [onNavigate].
+ *
+ * [onboardingLanding] marks the Schedule page when it's the onboarding
+ * "Continue" target, surfacing a Done button that calls [onFinishOnboarding].
+ */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun SettingsScreen(
+fun SettingsSubPage(
+    route: SettingsRoute,
     viewModel: SettingsViewModel,
-    onNavigateBack: () -> Unit,
-    initialRoute: SettingsRoute? = null,
+    onBack: () -> Unit,
+    onNavigate: (SettingsRoute) -> Unit,
+    onboardingLanding: Boolean = false,
+    onFinishOnboarding: () -> Unit = {},
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
-    // The in-Settings navigation back stack, innermost page last. Navigating
-    // deeper pushes; back pops; popping the last entry exits Settings. A deep
-    // link seeds the stack with just its target (not Root underneath), so back
-    // from the landing page exits straight to the caller — onboarding's
-    // "Continue → Schedule" reaches Today in one back, not two.
-    var backStack by rememberSaveable(stateSaver = SettingsBackStackSaver) {
-        val start = initialRoute?.takeIf { it != SettingsRoute.Root } ?: SettingsRoute.Root
-        mutableStateOf(listOf(start))
-    }
-    val route = backStack.last()
-
-    fun navigateTo(destination: SettingsRoute) {
-        backStack = backStack + destination
-    }
-
-    fun goBackOrUp() {
-        if (backStack.size > 1) {
-            backStack = backStack.dropLast(1)
-        } else {
-            onNavigateBack()
-        }
-    }
-
-    BackHandler(enabled = backStack.size > 1 || initialRoute != null) {
-        goBackOrUp()
-    }
 
     Scaffold(
         // Drop the default `safeDrawing` content insets so each sub-screen's
@@ -126,7 +91,7 @@ fun SettingsScreen(
             TopAppBar(
                 title = { Text(stringResource(route.titleRes)) },
                 navigationIcon = {
-                    IconButton(onClick = ::goBackOrUp) {
+                    IconButton(onClick = onBack) {
                         Icon(
                             imageVector = Icons.AutoMirrored.Filled.ArrowBack,
                             contentDescription = stringResource(R.string.settings_back),
@@ -140,7 +105,7 @@ fun SettingsScreen(
             SettingsRoute.Root -> SettingsRoot(
                 useDeviceLocation = state.useDeviceLocation,
                 padding = padding,
-                onNavigate = ::navigateTo,
+                onNavigate = onNavigate,
             )
             SettingsRoute.Schedule -> ScheduleContent(
                 time = state.scheduleTime,
@@ -167,7 +132,7 @@ fun SettingsScreen(
                 // landing from onboarding's "Continue" — gives the user an
                 // obvious way to finish setup and reach Today. In the regular
                 // settings flow they exit via the top-bar back arrow.
-                onDone = if (initialRoute == SettingsRoute.Schedule) onNavigateBack else null,
+                onDone = if (onboardingLanding) onFinishOnboarding else null,
             )
             SettingsRoute.Clothes -> ClothesContent(
                 rules = state.clothesRules,
@@ -239,9 +204,9 @@ fun SettingsScreen(
                 onSetThemeFromCalendarHolidays = viewModel::setThemeFromCalendarHolidays,
                 onSetThemeFromCalendarBirthdays = viewModel::setThemeFromCalendarBirthdays,
                 onCalendarPermissionRechecked = viewModel::markCalendarPermissionRechecked,
-                onNavigateToRegionSettings = { navigateTo(SettingsRoute.Region) },
-                onNavigateToLocationSettings = { navigateTo(SettingsRoute.Location) },
-                onNavigateToCalendarSettings = { navigateTo(SettingsRoute.Calendar) },
+                onNavigateToRegionSettings = { onNavigate(SettingsRoute.Region) },
+                onNavigateToLocationSettings = { onNavigate(SettingsRoute.Location) },
+                onNavigateToCalendarSettings = { onNavigate(SettingsRoute.Calendar) },
             )
             SettingsRoute.Location -> LocationContent(
                 location = state.location,

--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsState.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsState.kt
@@ -28,7 +28,7 @@ import java.time.DayOfWeek
 import java.time.LocalTime
 import java.util.Locale
 
-/** What [SettingsSubPage] needs to render. */
+/** What the Settings sub-pages need to render. */
 data class SettingsState(
     val scheduleTime: LocalTime = LocalTime.of(7, 0),
     val scheduleDays: Set<DayOfWeek> = Schedule.EVERY_DAY,

--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsState.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsState.kt
@@ -28,7 +28,7 @@ import java.time.DayOfWeek
 import java.time.LocalTime
 import java.util.Locale
 
-/** What [SettingsScreen] needs to render. */
+/** What [SettingsSubPage] needs to render. */
 data class SettingsState(
     val scheduleTime: LocalTime = LocalTime.of(7, 0),
     val scheduleDays: Set<DayOfWeek> = Schedule.EVERY_DAY,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,11 @@ coreKtx = "1.15.0"
 lifecycle = "2.8.7"
 activityCompose = "1.9.3"
 composeBom = "2026.03.00"
+# Navigation Compose — type-safe routes (@Serializable destinations) require
+# 2.8.0+. Aligned with lifecycle 2.8.x (the repo is on 2.8.7); 2.8.x keeps the
+# androidx.core baseline at 1.13–1.15 so it doesn't force a compileSdk lift the
+# way Vico/Glance bumps would. Bump in lockstep with any AGP/compileSdk upgrade.
+navigation = "2.8.5"
 junit5 = "5.11.3"
 mockk = "1.13.13"
 kotest = "5.9.1"
@@ -72,6 +77,7 @@ androidx-lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lif
 androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycle" }
 androidx-lifecycle-viewmodel-ktx = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-ktx", version.ref = "lifecycle" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
+androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigation" }
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
 androidx-compose-ui = { group = "androidx.compose.ui", name = "ui" }
 androidx-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }


### PR DESCRIPTION
## What this is

A **prototype** migrating the app's navigation to **Jetpack Navigation Compose** (`androidx.navigation:navigation-compose` 2.8.5, type-safe `@Serializable` routes). Draft, for review of the approach.

> **Note:** `main` already fixes the nested-Settings back bug (commit `67e014ac`) by hand-rolling an in-Settings back stack (`List<SettingsRoute>`). This PR is rebased on top and is the **framework alternative for comparison** — it replaces that hand-rolled stack with the navigation library. Not a behavior fix; the bug is already resolved on main.

## Commits

1. **Migrate navigation to Jetpack Navigation Compose** — all 4 top-level screens + 13 Settings sub-pages become `NavController` destinations (nested graph for Settings). Removes the `Screen` enum + `when` router and `goBackOrUp()` + both `BackHandler`s. `MainActivity` sheds ~360 lines.
2. **Complete the migration** — removes the last hand-rolled nav plumbing:
   - **Deep-link notifications (B):** taps open a `clothescast://today` intent matched by a `navDeepLink` on `TodayRoute`, replacing the `EXTRA_NAVIGATE_TO_TODAY` counter + `onNewIntent` bookkeeping.
   - **Flat Settings graph (C):** each sub-page is its own `composable` destination rendering its `*Content` through a shared `SettingsScaffold` — drops the `SettingsRoute` enum, the `when(route)` selector, and the enum→destination mapping. The root menu is an explicit ordered `SettingsMenuItem` list.
   - **Predictive back (D):** `android:enableOnBackInvokedCallback` turns on Android 14+ predictive-back animations across the back stack.

## Notification deep-link handling (lifecycle)

Notification routing is covered by two composing paths, so a config change can't drop the tap (raised in review):
- **Warm, no recreation:** `onNewIntent` stores the intent in Compose state; a `LaunchedEffect` calls `nav.handleDeepLink(...)`, which marks the intent handled.
- **Any (re)creation** (cold start, process death, or rotation mid-handling): `onNewIntent` also calls `setIntent(...)`, so the recreated Activity relaunches with that intent and `rememberNavController`'s `setGraph` auto-handles `activity.intent` during `onGraphCreated` — navigating to Today *after* restoring the saved back stack. If the warm effect already marked the intent, the auto-handle correctly skips it.

This is the same robustness the old counter had (which re-consumed its extra in `onCreate`), now via `setIntent` + the NavController's built-in handling. Still flagged for on-device verification below.

## Framework vs. the hand-rolled stack on main

| | main (`67e014ac`) | this PR |
|---|---|---|
| Back stack | hand-maintained `List<SettingsRoute>` + custom `Saver` | framework `NavController` back stack |
| Up-navigation | `goBackOrUp()` + `BackHandler` | system-owned, no custom code |
| Notification routing | n/a (separate counter) | real `navDeepLink` |
| Settings routing | `when(route)` on an enum | one `composable` per destination |
| Scope | Settings only | whole-app navigation |

## Privacy

Navigation only. No change to what leaves the device — the `clothescast://today` deep-link URI is an internal app scheme carrying no data; MQTT / Gemini TTS / weather payload paths are untouched.

## Test plan

- [x] `:app:compileDebugKotlin` — clean, no new warnings
- [x] `:app:testDebugUnitTest` — pass (incl. R8 `minifyDebugWithR8` + Roborazzi snapshots, no pixel changes)
- [x] `:app:assembleDebug` — debug APK assembles
- [ ] **On-device check of the notification deep link** — not exercisable by JVM tests: cold tap, warm tap from a Settings sub-page, tap after process death, and **rotation immediately after a tap while in a Settings sub-page** should all land on Today.
- [ ] On-device check of predictive-back animations.

## Open question for review

- The bug is already fixed on main with a small hand-rolled stack. Is the framework worth adopting at this size (4 top-level + 13 settings destinations)? This PR exists to make that call with a concrete diff in hand.
- `navigation` is pinned to 2.8.5 to stay aligned with the lifecycle 2.8.x / core-ktx 1.15 baseline (avoids forcing a compileSdk lift). Confirm before any AGP/compileSdk bump.

## Review notes

- **Onboarding back from Schedule** (Codex P2): pressing Back from the onboarding Schedule landing returns to onboarding, not Today. Intentional — the **Done** button is the deliberate forward "finish" affordance; back isn't a setup-finish shortcut. Won't-fix.
- **Deep-link config-change race** (Codex P2): covered by the two-path handling documented above; flagged for on-device verification.