### PR TITLE
Remind to sync PR title and body after git push

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,6 +9,19 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "if": "Bash(git push:*)",
+            "suppressOutput": true,
+            "command": "printf '%s' '{\"hookSpecificOutput\":{\"hookEventName\":\"PostToolUse\",\"additionalContext\":\"git push detected. Re-read the full branch diff vs the base branch and check whether the PR title and body still describe what is landing. If anything significant changed since the PR opened (scope grew, narrowed, or pivoted), update them via mcp__github__update_pull_request: title stays Play-Store-ready (sentence case, end-user copy, <= 80 chars, matches the squash-merge subject); body covers scope, rationale, privacy-relevant changes, and test plan. If nothing material changed, no update needed.\"}}'"
+          }
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
## Summary

Adds a `PostToolUse` hook to `.claude/settings.json` that fires after a Bash `git push` (filtered via the `if: Bash(git push:*)` rule) and injects a reminder to re-read the branch diff vs. base and, if anything significant changed since the PR opened, update the PR title and body via `mcp__github__update_pull_request`.

## Why

AGENTS.md already carries the rule *"Keep PR title and body in sync with the branch on every push"* — but a prose rule is easy to miss (stale PR titles have slipped through). A "whenever I push, do X" automated behavior belongs in a harness hook, where it fires deterministically, not in memory/prose. This backs the existing rule with an enforced nudge.

## What changed

- `.claude/settings.json`: new `PostToolUse` entry (matcher `Bash`, `if: Bash(git push:*)`, `suppressOutput: true`). Emits `hookSpecificOutput.additionalContext` reminding the agent to check title/body and update via `mcp__github__update_pull_request` when scope grew/narrowed/pivoted, keeping the title Play-Store-ready and the body covering scope, rationale, privacy, and test plan.

## Privacy

No change to what leaves the device. Agent-tooling config only; ships nothing in the APK.

## Test plan

- [x] Hook command emits valid JSON (`jq -e` on the `additionalContext`)
- [x] `settings.json` schema/matcher validates (`jq -e` on the `PostToolUse[].hooks[].command`)
- [x] Verified live: the hook fired on the push that created this branch, injecting the reminder context

The `ci:` commit prefix keeps this dotfile change out of the Play "What's new".

---
_Generated by [Claude Code](https://claude.ai/code/session_01FSSW4d6B6S3KrJ8wy6DtS3)_