### PR TITLE
Settings sub-pages now slide in from the leading edge

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/nav/ClothesCastNavHost.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/nav/ClothesCastNavHost.kt
@@ -4,6 +4,8 @@ import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.os.Build
+import androidx.compose.animation.AnimatedContentTransitionScope.SlideDirection
+import androidx.compose.animation.core.tween
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
@@ -59,6 +61,11 @@ import app.clothescast.work.FetchAndNotifyWorker
 import kotlinx.coroutines.flow.first
 import kotlinx.serialization.Serializable
 
+// Duration of the push/pop slide between destinations. Short enough to feel
+// snappy (and to keep the can't-tap-yet window small), long enough to read as a
+// directional transition rather than a jump.
+private const val NAV_ANIM_MS = 200
+
 // Type-safe destinations. The four top-level screens plus a nested graph for
 // Settings — each settings sub-page is its own destination so the framework's
 // back stack handles up-navigation. No hand-maintained "current route" state,
@@ -104,6 +111,18 @@ fun ClothesCastNavHost(
     NavHost(
         navController = nav,
         startDestination = if (startOnboarding) OnboardingRoute else TodayRoute,
+        // Push/pop slide so sub-pages animate in from the leading edge (and back
+        // out the same way on up-navigation). The library default is a 700ms
+        // crossfade, which both reads as "appearing from nowhere" and overlaps the
+        // outgoing and incoming screens in the same spot — a low-alpha layer still
+        // eats touches, so a quick tap on a freshly-shown list can hit the wrong
+        // screen. A short directional slide fixes the look and stops the screens
+        // sitting on top of each other. Start/End (not Left/Right) so the motion
+        // mirrors correctly in RTL locales (ar/fa/iw).
+        enterTransition = { slideIntoContainer(SlideDirection.Start, tween(NAV_ANIM_MS)) },
+        exitTransition = { slideOutOfContainer(SlideDirection.Start, tween(NAV_ANIM_MS)) },
+        popEnterTransition = { slideIntoContainer(SlideDirection.End, tween(NAV_ANIM_MS)) },
+        popExitTransition = { slideOutOfContainer(SlideDirection.End, tween(NAV_ANIM_MS)) },
     ) {
         composable<TodayRoute>(
             deepLinks = listOf(navDeepLink<TodayRoute>(basePath = MainActivity.DEEP_LINK_TODAY)),


### PR DESCRIPTION
## Summary

Two related complaints after the Jetpack Navigation migration (`5b4e6de`):

1. **Sub-pages "animate in from nowhere."** `NavHost` was using navigation-compose's default transition — a 700ms crossfade — so pages faded in place rather than sliding.
2. **Tapping a settings category sometimes does nothing, especially right after the list opens.** Pre-migration, navigation was an instant in-composition state swap, so a row tap always took effect. The migration replaced that with a real `NavController` + the long crossfade: the outgoing and incoming screens sit in the same spot for 700ms, and a low-alpha layer still consumes touches, so a quick tap can land on the wrong screen / before the destination entry reaches `RESUMED`.

## Change

Set `enterTransition` / `exitTransition` / `popEnterTransition` / `popExitTransition` on the `NavHost` (applies to every destination, including all settings sub-pages):

- Forward navigation slides the new screen in from the leading edge; the old one slides out the other way. Up/back reverses it.
- Uses `SlideDirection.Start`/`End` (not `Left`/`Right`) so the motion mirrors correctly in RTL locales (ar/fa/iw) — per Codex review feedback.
- Duration dropped from the 700ms default to 200ms.

The short, directional slide fixes the "from nowhere" look **and** stops the two screens overlapping, which is the main dropped-tap cause; the shorter duration also shrinks the pre-`RESUMED` window. Note this is a strong mitigation, not a hard guarantee for an arbitrarily-fast tap — see discussion below.

## Scope

Global — confirmed with the user the slide should apply app-wide (Today ↔ Settings, onboarding, pairing, all settings sub-pages) for a consistent feel.

## Not in scope

- The Today ↔ Tonight swap is a `HorizontalPager`, not navigation, and is already animated; any sluggishness there is target-page render cost (the full chart stack), addressable separately with `beyondViewportPageCount`.

## Test plan

- [x] `./gradlew :app:assembleDebug` — BUILD SUCCESSFUL
- [ ] CI green (JVM unit tests + Android debug build)
- [ ] Manual: open Settings, tap a category immediately as the list appears — navigation fires and the sub-page slides in from the leading edge; back slides it out the other way.
- [ ] Manual (RTL): switch to Arabic and confirm forward navigation slides from the correct (right) edge.

No change to what leaves the device; UI-transition-only.

https://claude.ai/code/session_01EsUFs22gwHJ3D8vnpjPkPf