### PR TITLE
Add seasonal and novelty voices like Father Christmas and a sci-fi narrator

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/settings/VoiceSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/VoiceSettings.kt
@@ -409,6 +409,7 @@ private fun ttsStyleLabel(style: TtsStyle): Int = when (style) {
     TtsStyle.WEATHER_FORECASTER -> R.string.settings_tts_style_weather_forecaster
     TtsStyle.PIRATE -> R.string.settings_tts_style_pirate
     TtsStyle.COWBOY -> R.string.settings_tts_style_cowboy
+    TtsStyle.SCIFI_NARRATOR -> R.string.settings_tts_style_scifi_narrator
     TtsStyle.SCIENCE_TEACHER -> R.string.settings_tts_style_science_teacher
     TtsStyle.HISTORIAN -> R.string.settings_tts_style_historian
     TtsStyle.SPORTSCASTER -> R.string.settings_tts_style_sportscaster
@@ -416,6 +417,13 @@ private fun ttsStyleLabel(style: TtsStyle): Int = when (style) {
     TtsStyle.STORYTELLER -> R.string.settings_tts_style_storyteller
     TtsStyle.FITNESS_INSTRUCTOR -> R.string.settings_tts_style_fitness_instructor
     TtsStyle.MORNING_PRESENTER -> R.string.settings_tts_style_morning_presenter
+    TtsStyle.FATHER_CHRISTMAS -> R.string.settings_tts_style_father_christmas
+    TtsStyle.SPOOKY_NARRATOR -> R.string.settings_tts_style_spooky_narrator
+    TtsStyle.NEW_YEARS_HOST -> R.string.settings_tts_style_new_years_host
+    TtsStyle.LEPRECHAUN -> R.string.settings_tts_style_leprechaun
+    TtsStyle.KING -> R.string.settings_tts_style_king
+    TtsStyle.QUEEN -> R.string.settings_tts_style_queen
+    TtsStyle.PRESIDENT -> R.string.settings_tts_style_president
 }
 
 @Composable

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -604,6 +604,7 @@
     <string name="settings_tts_style_weather_forecaster">Weather Forecaster</string>
     <string name="settings_tts_style_pirate">Pirate</string>
     <string name="settings_tts_style_cowboy">Cowboy</string>
+    <string name="settings_tts_style_scifi_narrator">Sci-fi narrator</string>
     <string name="settings_tts_style_shakespearean">Shakespearean</string>
     <string name="settings_tts_style_surfer">Surfer</string>
     <string name="settings_tts_style_parent">Parent</string>
@@ -620,6 +621,13 @@
     <string name="settings_tts_style_storyteller">Storyteller</string>
     <string name="settings_tts_style_fitness_instructor">Fitness instructor</string>
     <string name="settings_tts_style_morning_presenter">Morning radio presenter</string>
+    <string name="settings_tts_style_father_christmas">Father Christmas</string>
+    <string name="settings_tts_style_spooky_narrator">Spooky narrator</string>
+    <string name="settings_tts_style_new_years_host">New Year\'s host</string>
+    <string name="settings_tts_style_leprechaun">Leprechaun</string>
+    <string name="settings_tts_style_king">King</string>
+    <string name="settings_tts_style_queen">Queen</string>
+    <string name="settings_tts_style_president">President</string>
     <string name="settings_tts_style_custom">Custom…</string>
     <string name="settings_tts_style_custom_label">Custom directive</string>
     <string name="settings_tts_style_custom_placeholder">e.g. Read the following as a stern librarian whispering</string>

--- a/core/data/src/main/kotlin/app/clothescast/core/data/tts/GeminiTtsClient.kt
+++ b/core/data/src/main/kotlin/app/clothescast/core/data/tts/GeminiTtsClient.kt
@@ -96,6 +96,57 @@ internal const val GEMINI_TTS_STYLE_DIRECTIVE_COWBOY: String =
         "add brief in-character exclamations such as 'Howdy' or 'Well, partner'. " +
         "No audio effects, background noise, or vinyl-style texture.\n\n"
 
+internal const val GEMINI_TTS_STYLE_DIRECTIVE_SCIFI_NARRATOR: String =
+    "Read the following as a dry, witty British science-fiction narrator — the " +
+        "wry, deadpan voice of an omniscient interstellar guidebook, delivering " +
+        "everyday facts with cosmic grandeur and a knowing twinkle. No audio " +
+        "effects, background noise, or vinyl-style texture.\n\n"
+
+internal const val GEMINI_TTS_STYLE_DIRECTIVE_FATHER_CHRISTMAS: String =
+    "Read the following as a jolly, warm-hearted Father Christmas — a deep, " +
+        "booming, good-natured voice brimming with festive cheer. You may add " +
+        "brief in-character exclamations such as 'Ho ho ho' or 'Merry " +
+        "Christmas'. No audio effects, background noise, or vinyl-style " +
+        "texture.\n\n"
+
+internal const val GEMINI_TTS_STYLE_DIRECTIVE_SPOOKY_NARRATOR: String =
+    "Read the following as a spooky Halloween narrator — hushed, eerie, and " +
+        "theatrically sinister, savouring each ominous pause. Brief in-character " +
+        "interjections such as a low, ghostly laugh are fine. No audio effects, " +
+        "background noise, or vinyl-style texture.\n\n"
+
+internal const val GEMINI_TTS_STYLE_DIRECTIVE_NEW_YEARS_HOST: String =
+    "Read the following as an exuberant New Year's Eve party host counting down " +
+        "to midnight — celebratory, building excitement, full of warmth and " +
+        "anticipation. Brief in-character interjections such as 'Happy New " +
+        "Year!' are fine. No audio effects, background noise, or vinyl-style " +
+        "texture.\n\n"
+
+internal const val GEMINI_TTS_STYLE_DIRECTIVE_LEPRECHAUN: String =
+    "Read the following as a playful, mischievous leprechaun with a lilting " +
+        "Irish brogue and a twinkle in the eye. You may add brief in-character " +
+        "exclamations such as 'Top o' the morning'. No audio effects, " +
+        "background noise, or vinyl-style texture.\n\n"
+
+internal const val GEMINI_TTS_STYLE_DIRECTIVE_KING: String =
+    "Read the following in the style of King Charles III delivering a formal " +
+        "royal address — measured, dignified Received Pronunciation, warm yet " +
+        "reserved, with a gentle gravitas at the close of each sentence. No " +
+        "audio effects, background noise, or vinyl-style texture.\n\n"
+
+internal const val GEMINI_TTS_STYLE_DIRECTIVE_QUEEN: String =
+    "Read the following in the style of Queen Elizabeth II giving her Christmas " +
+        "broadcast — crisp, precise Received Pronunciation, poised and gracious, " +
+        "with quiet warmth. No audio effects, background noise, or vinyl-style " +
+        "texture.\n\n"
+
+internal const val GEMINI_TTS_STYLE_DIRECTIVE_PRESIDENT: String =
+    "Read the following in the style of a revered American president addressing " +
+        "the nation — the solemn oratory of George Washington or Abraham " +
+        "Lincoln, stately and resolute, with weighty pauses and quiet " +
+        "conviction. No audio effects, background noise, or vinyl-style " +
+        "texture.\n\n"
+
 internal const val GEMINI_TTS_STYLE_DIRECTIVE_STADIUM_ANNOUNCER: String =
     "Read the following as a booming stadium announcer — big voice, dramatic " +
         "pauses, each fact delivered like a headline moment. Brief interjections " +
@@ -140,6 +191,7 @@ internal fun styleDirectiveFor(style: TtsStyle): String = when (style) {
     TtsStyle.WEATHER_FORECASTER -> GEMINI_TTS_STYLE_DIRECTIVE_WEATHER_FORECASTER
     TtsStyle.PIRATE -> GEMINI_TTS_STYLE_DIRECTIVE_PIRATE
     TtsStyle.COWBOY -> GEMINI_TTS_STYLE_DIRECTIVE_COWBOY
+    TtsStyle.SCIFI_NARRATOR -> GEMINI_TTS_STYLE_DIRECTIVE_SCIFI_NARRATOR
     TtsStyle.SCIENCE_TEACHER -> GEMINI_TTS_STYLE_DIRECTIVE_SCIENCE_TEACHER
     TtsStyle.HISTORIAN -> GEMINI_TTS_STYLE_DIRECTIVE_HISTORIAN
     TtsStyle.SPORTSCASTER -> GEMINI_TTS_STYLE_DIRECTIVE_SPORTSCASTER
@@ -147,6 +199,13 @@ internal fun styleDirectiveFor(style: TtsStyle): String = when (style) {
     TtsStyle.STORYTELLER -> GEMINI_TTS_STYLE_DIRECTIVE_STORYTELLER
     TtsStyle.FITNESS_INSTRUCTOR -> GEMINI_TTS_STYLE_DIRECTIVE_FITNESS_INSTRUCTOR
     TtsStyle.MORNING_PRESENTER -> GEMINI_TTS_STYLE_DIRECTIVE_MORNING_PRESENTER
+    TtsStyle.FATHER_CHRISTMAS -> GEMINI_TTS_STYLE_DIRECTIVE_FATHER_CHRISTMAS
+    TtsStyle.SPOOKY_NARRATOR -> GEMINI_TTS_STYLE_DIRECTIVE_SPOOKY_NARRATOR
+    TtsStyle.NEW_YEARS_HOST -> GEMINI_TTS_STYLE_DIRECTIVE_NEW_YEARS_HOST
+    TtsStyle.LEPRECHAUN -> GEMINI_TTS_STYLE_DIRECTIVE_LEPRECHAUN
+    TtsStyle.KING -> GEMINI_TTS_STYLE_DIRECTIVE_KING
+    TtsStyle.QUEEN -> GEMINI_TTS_STYLE_DIRECTIVE_QUEEN
+    TtsStyle.PRESIDENT -> GEMINI_TTS_STYLE_DIRECTIVE_PRESIDENT
 }
 
 /**

--- a/core/data/src/test/kotlin/app/clothescast/core/data/tts/GeminiTtsClientTest.kt
+++ b/core/data/src/test/kotlin/app/clothescast/core/data/tts/GeminiTtsClientTest.kt
@@ -573,6 +573,7 @@ class GeminiTtsClientTest {
         val signatures: Map<TtsStyle, String> = mapOf(
             TtsStyle.PIRATE to "swaggering pirate",
             TtsStyle.COWBOY to "Old West drawl",
+            TtsStyle.SCIFI_NARRATOR to "British science-fiction narrator",
             TtsStyle.SCIENCE_TEACHER to "high school science teacher",
             TtsStyle.HISTORIAN to "history documentary",
             TtsStyle.SPORTSCASTER to "animated sportscaster",
@@ -580,6 +581,13 @@ class GeminiTtsClientTest {
             TtsStyle.STORYTELLER to "storyteller",
             TtsStyle.FITNESS_INSTRUCTOR to "fitness instructor",
             TtsStyle.MORNING_PRESENTER to "morning radio presenter",
+            TtsStyle.FATHER_CHRISTMAS to "Father Christmas",
+            TtsStyle.SPOOKY_NARRATOR to "spooky Halloween narrator",
+            TtsStyle.NEW_YEARS_HOST to "New Year's Eve party host",
+            TtsStyle.LEPRECHAUN to "mischievous leprechaun",
+            TtsStyle.KING to "King Charles III",
+            TtsStyle.QUEEN to "Queen Elizabeth II",
+            TtsStyle.PRESIDENT to "revered American president",
         )
 
         for ((style, signature) in signatures) {

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Settings.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Settings.kt
@@ -172,9 +172,19 @@ enum class TtsEngine { DEVICE, GEMINI }
  * - [SCIENCE_TEACHER], [HISTORIAN], [SPORTSCASTER], [STADIUM_ANNOUNCER],
  *   [STORYTELLER], [FITNESS_INSTRUCTOR], [MORNING_PRESENTER] — persona
  *   registers that shape *delivery* without rewriting the text.
- * - [PIRATE] and [COWBOY] are novelty registers at the end of the picker;
- *   their directives permit brief in-character exclamations ("Arrr",
- *   "Howdy") so the result is more obviously playful.
+ * - [PIRATE], [COWBOY] and [SCIFI_NARRATOR] are non-seasonal novelty
+ *   registers; the playful ones permit brief in-character exclamations
+ *   ("Arrr", "Howdy") and [SCIFI_NARRATOR] is a dry, deadpan British
+ *   science-fiction guidebook voice (no named IP — just the register).
+ * - [FATHER_CHRISTMAS], [SPOOKY_NARRATOR], [NEW_YEARS_HOST], [LEPRECHAUN],
+ *   [KING], [QUEEN] and [PRESIDENT] are seasonal novelty registers ([KING] /
+ *   [QUEEN] evoke King Charles III / Queen Elizabeth II for occasions with a
+ *   royal in the name; [PRESIDENT] evokes the solemn oratory of George
+ *   Washington / Abraham Lincoln for Presidents' Day and the like). For now
+ *   they're always available in the picker; TODO: surface each one
+ *   automatically around its holiday (Christmas, Halloween, New Year's Eve,
+ *   St Patrick's Day, royal occasions, Presidents' Day) once the Celebrations
+ *   calendar wiring can drive a default style.
  *
  * Only consulted when [TtsEngine] == [TtsEngine.GEMINI]; the on-device engine
  * doesn't accept style prompts.
@@ -190,6 +200,14 @@ enum class TtsStyle {
     MORNING_PRESENTER,
     PIRATE,
     COWBOY,
+    SCIFI_NARRATOR,
+    FATHER_CHRISTMAS,
+    SPOOKY_NARRATOR,
+    NEW_YEARS_HOST,
+    LEPRECHAUN,
+    KING,
+    QUEEN,
+    PRESIDENT,
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds eight novelty `TtsStyle` registers to the voice **Style** picker, alongside the existing Pirate / Cowboy ones:

- **Sci-fi narrator** — dry, deadpan British interstellar-guidebook voice (non-seasonal)
- **Father Christmas** — jolly, festive ("Ho ho ho")
- **Spooky narrator** — eerie Halloween delivery
- **New Year's host** — countdown party energy
- **Leprechaun** — lilting Irish brogue
- **King** — in the style of King Charles III
- **Queen** — in the style of Queen Elizabeth II
- **President** — solemn oratory of Washington / Lincoln

## Scope

Each style adds a Gemini TTS delivery directive in `GeminiTtsClient`, wired through the exhaustive `styleDirectiveFor()` and `ttsStyleLabel()` `when`s, plus an English label string and a per-style signature assertion in `GeminiTtsClientTest`. The picker enumerates `TtsStyle.entries`, so the new rows appear automatically; persistence round-trips them via the existing `TtsStyle.entries` loop in `SettingsRepositoryTest`.

The seasonal ones are **always available** for now. A TODO on the enum notes the follow-up to auto-surface each around its holiday (Christmas, Halloween, New Year's Eve, St Patrick's Day, royal occasions, Presidents' Day) once the Celebrations calendar wiring can drive a default style. The sci-fi narrator is non-seasonal.

## IP

The sci-fi narrator evokes a well-known interstellar-guidebook register **without naming any IP, characters, or author** — it's described purely as a "dry, witty British science-fiction narrator … omniscient interstellar guidebook".

## Privacy

Each style prepends a **static** delivery directive to the text sent to Gemini TTS. Some directives name public figures (King Charles III, Queen Elizabeth II, Washington/Lincoln) purely as a stylistic register — **no user or calendar data is added** to what leaves the device.

## Localisation

Only the default (English) labels are added; other locales fall back to English until translations are backfilled, matching the repo's existing translation-lag pattern (locale files already trail the default by ~10 strings).

## Test plan

- [x] `:core:domain:test` `:core:data:test` — pass (incl. new per-style directive assertions)
- [x] `:app:testDebugUnitTest` — pass (incl. `SettingsRepository` style round-trip over all entries)
- [x] `:app:assembleDebug` — pass
- [ ] CI green
- [ ] Manually audition each new voice via the Test Voice button

https://claude.ai/code/session_018P1LZyaWSeyBKU11RA7G8d