### PR TITLE
Read holiday briefings in a fitting voice, like a president on Presidents' Day

### DIFF
--- a/app/src/main/kotlin/app/clothescast/tts/TtsVoices.kt
+++ b/app/src/main/kotlin/app/clothescast/tts/TtsVoices.kt
@@ -1,5 +1,11 @@
 package app.clothescast.tts
 
+import app.clothescast.core.domain.model.HolidayId
+import app.clothescast.core.domain.model.TtsStyle
+import app.clothescast.core.domain.model.VoiceGender
+import app.clothescast.core.domain.model.holidayTtsStyle
+import app.clothescast.core.domain.model.suggestedVoiceGender
+
 /**
  * Curated voice list for the user-facing voice picker. Only Gemini's prebuilt
  * voices need a curated list — the on-device engine enumerates voices via
@@ -7,11 +13,14 @@ package app.clothescast.tts
  *
  * The [id] is what's persisted and sent to the API. The [displayName] is shown
  * in the dropdown and is intentionally English-only for v1; if/when we
- * localize, these move to strings.xml.
+ * localize, these move to strings.xml. [gender] is consulted only when a
+ * holiday auto-selects a gendered persona (see [resolveHolidayVoice]); it
+ * never filters the user-facing picker.
  */
 data class TtsVoiceOption(
     val id: String,
     val displayName: String,
+    val gender: VoiceGender = VoiceGender.NEUTRAL,
 )
 
 // Curated from listening tests across en-GB, en-AU, en-US, and de-* under the
@@ -31,11 +40,57 @@ data class TtsVoiceOption(
 // Orus (theatrical), Achird (vowel issues), Zephyr / Puck / Fenrir
 // (theatrical / excitable). See docs/voice-evals.md for the data.
 val GEMINI_VOICES: List<TtsVoiceOption> = listOf(
-    TtsVoiceOption("Despina", "Despina — Smooth"),
-    TtsVoiceOption("Charon", "Charon — Informative"),
-    TtsVoiceOption("Iapetus", "Iapetus — Clear"),
-    TtsVoiceOption("Kore", "Kore — Firm"),
-    TtsVoiceOption("Erinome", "Erinome — Clear"),
-    TtsVoiceOption("Aoede", "Aoede — Breezy"),
-    TtsVoiceOption("Leda", "Leda — Youthful"),
+    TtsVoiceOption("Despina", "Despina — Smooth", VoiceGender.FEMALE),
+    TtsVoiceOption("Charon", "Charon — Informative", VoiceGender.MALE),
+    TtsVoiceOption("Iapetus", "Iapetus — Clear", VoiceGender.MALE),
+    TtsVoiceOption("Kore", "Kore — Firm", VoiceGender.FEMALE),
+    TtsVoiceOption("Erinome", "Erinome — Clear", VoiceGender.FEMALE),
+    TtsVoiceOption("Aoede", "Aoede — Breezy", VoiceGender.FEMALE),
+    TtsVoiceOption("Leda", "Leda — Youthful", VoiceGender.FEMALE),
 )
+
+/** Gender of the named Gemini voice, or [VoiceGender.NEUTRAL] if unknown. */
+private fun voiceGenderOf(voiceId: String): VoiceGender =
+    GEMINI_VOICES.firstOrNull { it.id == voiceId }?.gender ?: VoiceGender.NEUTRAL
+
+/**
+ * First curated voice matching [gender], falling back to the first voice in the
+ * list (the default) when none match — keeps a sensible voice rather than
+ * throwing if the catalog ever loses a gender.
+ */
+private fun defaultVoiceForGender(gender: VoiceGender): String =
+    GEMINI_VOICES.firstOrNull { it.gender == gender }?.id ?: GEMINI_VOICES.first().id
+
+/** Effective Gemini voice + persona after applying any holiday auto-selection. */
+data class GeminiVoiceSelection(val voiceName: String, val style: TtsStyle)
+
+/**
+ * Resolves the voice and persona to speak today's briefing in, auto-switching
+ * to a seasonal persona (and a matching-gender voice) when [holidayId] maps to
+ * one — e.g. Presidents' Day → a male president, Towel Day → a male sci-fi
+ * narrator.
+ *
+ * A deliberate non-default persona pick wins: if the user has chosen any
+ * [TtsStyle] other than [TtsStyle.WEATHER_FORECASTER], their choice stands and
+ * the holiday is ignored. Only the everyday forecaster default yields to the
+ * day. The voice is only swapped when the persona implies a gender the user's
+ * current voice doesn't already have, so a user already on a male voice keeps
+ * it for a male persona.
+ */
+fun resolveHolidayVoice(
+    holidayId: HolidayId?,
+    userVoice: String,
+    userStyle: TtsStyle,
+): GeminiVoiceSelection {
+    val persona = holidayId?.let { holidayTtsStyle(it) }
+    if (persona == null || userStyle != TtsStyle.WEATHER_FORECASTER) {
+        return GeminiVoiceSelection(userVoice, userStyle)
+    }
+    val gender = persona.suggestedVoiceGender
+    val voice = if (gender == VoiceGender.NEUTRAL || voiceGenderOf(userVoice) == gender) {
+        userVoice
+    } else {
+        defaultVoiceForGender(gender)
+    }
+    return GeminiVoiceSelection(voice, persona)
+}

--- a/app/src/main/kotlin/app/clothescast/ui/settings/DeveloperSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/DeveloperSettings.kt
@@ -43,6 +43,7 @@ import app.clothescast.core.domain.model.OutfitSuggestion
 import app.clothescast.core.domain.model.Region
 import app.clothescast.core.domain.model.TemperatureBand
 import app.clothescast.core.domain.usecase.ThemeForToday
+import app.clothescast.tts.resolveHolidayVoice
 import app.clothescast.ui.today.HolidayBanner
 import app.clothescast.ui.today.OutfitPreviewRow
 import kotlinx.coroutines.launch
@@ -91,16 +92,20 @@ internal fun DeveloperPage(viewModel: SettingsViewModel, onBack: () -> Unit) {
             enabledCountries = state.effectiveEnabledHolidayCountries,
             padding = padding,
             speaking = isSpeaking,
-            onSpeak = onSpeak@{
+            onSpeak = onSpeak@{ holidayId ->
                 if (isSpeaking) return@onSpeak
                 isSpeaking = true
+                // Speak the picked day in its holiday voice so the preview
+                // demonstrates the auto-selected persona, not just the
+                // user's default voice.
+                val selection = resolveHolidayVoice(holidayId, state.geminiVoice, state.ttsStyle)
                 scope.launch {
                     try {
                         runTtsPreview(
                             context = context,
                             engine = state.ttsEngine,
-                            geminiVoice = state.geminiVoice,
-                            ttsStyle = state.ttsStyle,
+                            geminiVoice = selection.voiceName,
+                            ttsStyle = selection.style,
                             deviceVoice = state.deviceVoice,
                             voiceLocale = state.voiceLocale,
                             region = state.region,
@@ -121,7 +126,7 @@ internal fun DeveloperContent(
     holidayOverrides: Map<HolidayId, HolidayOverride>,
     enabledCountries: Set<String>,
     padding: PaddingValues,
-    onSpeak: () -> Unit,
+    onSpeak: (HolidayId?) -> Unit,
     speaking: Boolean = false,
     initialDate: LocalDate = LocalDate.now(),
 ) {
@@ -205,7 +210,7 @@ internal fun DeveloperContent(
         )
 
         Button(
-            onClick = onSpeak,
+            onClick = { onSpeak(theme?.id) },
             enabled = !speaking,
             modifier = Modifier.fillMaxWidth(),
         ) {

--- a/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
@@ -18,6 +18,7 @@ import androidx.work.workDataOf
 import app.clothescast.ClothesCastApplication
 import app.clothescast.core.domain.model.DeliveryMode
 import app.clothescast.core.domain.model.ForecastPeriod
+import app.clothescast.core.domain.model.HolidayId
 import app.clothescast.core.domain.model.Insight
 import app.clothescast.core.domain.model.Location
 import app.clothescast.core.domain.model.OutfitSuggestion
@@ -47,6 +48,7 @@ import app.clothescast.location.hasCoarseLocationPermission
 import app.clothescast.tts.GeminiTtsSpeaker
 import app.clothescast.tts.InsightTtsUtterance
 import app.clothescast.tts.insightTtsUtterance
+import app.clothescast.tts.resolveHolidayVoice
 import app.clothescast.tts.withSpeechAudioFocus
 import app.clothescast.R
 import app.clothescast.ui.garment.outfitCardInfoLines
@@ -622,7 +624,7 @@ class FetchAndNotifyWorker(
         // propagates so WorkManager stops unwind cleanly.
         supervisorScope {
             val synthDeferred: Deferred<PcmAudio?>? = if (gates.needsSynth) {
-                async(Dispatchers.IO) { synthesizeForDelivery(insight, prefs) }
+                async(Dispatchers.IO) { synthesizeForDelivery(insight, prefs, theme?.id) }
             } else null
 
             val renderDeferred: Deferred<ByteArray?> = async(Dispatchers.Default) {
@@ -715,13 +717,21 @@ class FetchAndNotifyWorker(
      * to the device engine. Logs the failure with enough context to
      * diagnose without spamming successes.
      */
-    private suspend fun synthesizeForDelivery(insight: Insight, prefs: UserPreferences): PcmAudio? {
+    private suspend fun synthesizeForDelivery(
+        insight: Insight,
+        prefs: UserPreferences,
+        holidayId: HolidayId?,
+    ): PcmAudio? {
         val utterance = ttsUtterance(insight, prefs)
+        // On a themed day with no deliberate persona pick, speak in the
+        // holiday's voice (Father Christmas on Dec 25, a president on
+        // Presidents' Day, …) and switch to a matching-gender voice.
+        val selection = resolveHolidayVoice(holidayId, prefs.geminiVoice, prefs.ttsStyle)
         return runCatching {
             GeminiTtsSpeaker(
                 app.geminiTtsClient,
-                voiceName = prefs.geminiVoice,
-                style = prefs.ttsStyle,
+                voiceName = selection.voiceName,
+                style = selection.style,
             ).synthesize(utterance.text, utterance.locale)
         }
             .onFailure { t ->

--- a/app/src/test/kotlin/app/clothescast/tts/HolidayVoiceTest.kt
+++ b/app/src/test/kotlin/app/clothescast/tts/HolidayVoiceTest.kt
@@ -1,0 +1,69 @@
+package app.clothescast.tts
+
+import app.clothescast.core.domain.model.HolidayId
+import app.clothescast.core.domain.model.TtsStyle
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+class HolidayVoiceTest {
+
+    @Test
+    fun `no holiday keeps the user's voice and style`() {
+        resolveHolidayVoice(null, "Despina", TtsStyle.WEATHER_FORECASTER) shouldBe
+            GeminiVoiceSelection("Despina", TtsStyle.WEATHER_FORECASTER)
+    }
+
+    @Test
+    fun `presidents day switches a default female voice to a male president`() {
+        val selection = resolveHolidayVoice(
+            HolidayId.US_PRESIDENTS_DAY,
+            "Despina",
+            TtsStyle.WEATHER_FORECASTER,
+        )
+        selection.style shouldBe TtsStyle.PRESIDENT
+        selection.voiceName shouldBe "Charon"
+    }
+
+    @Test
+    fun `towel day speaks as a male sci-fi narrator`() {
+        val selection = resolveHolidayVoice(
+            HolidayId.TOWEL_DAY,
+            "Kore",
+            TtsStyle.WEATHER_FORECASTER,
+        )
+        selection.style shouldBe TtsStyle.SCIFI_NARRATOR
+        selection.voiceName shouldBe "Charon"
+    }
+
+    @Test
+    fun `a male persona keeps a voice that is already male`() {
+        val selection = resolveHolidayVoice(
+            HolidayId.US_PRESIDENTS_DAY,
+            "Iapetus",
+            TtsStyle.WEATHER_FORECASTER,
+        )
+        selection.style shouldBe TtsStyle.PRESIDENT
+        selection.voiceName shouldBe "Iapetus"
+    }
+
+    @Test
+    fun `a neutral persona leaves the voice untouched`() {
+        val selection = resolveHolidayVoice(
+            HolidayId.HALLOWEEN,
+            "Despina",
+            TtsStyle.WEATHER_FORECASTER,
+        )
+        selection.style shouldBe TtsStyle.SPOOKY_NARRATOR
+        selection.voiceName shouldBe "Despina"
+    }
+
+    @Test
+    fun `a deliberate persona pick overrides the holiday`() {
+        val selection = resolveHolidayVoice(
+            HolidayId.CHRISTMAS_DAY,
+            "Leda",
+            TtsStyle.PIRATE,
+        )
+        selection shouldBe GeminiVoiceSelection("Leda", TtsStyle.PIRATE)
+    }
+}

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/HolidayVoice.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/HolidayVoice.kt
@@ -1,0 +1,52 @@
+package app.clothescast.core.domain.model
+
+/**
+ * Speaker gender a [TtsStyle] persona implies, used to pick a matching Gemini
+ * voice when a holiday auto-selects the persona. [NEUTRAL] means "no
+ * preference" — keep whatever voice the user already has, since the register
+ * reads fine in any voice.
+ */
+enum class VoiceGender { MALE, FEMALE, NEUTRAL }
+
+/**
+ * The seasonal persona a holiday should speak in, or null when the holiday
+ * carries no special voice (the user's own style and voice stand).
+ *
+ * Only a handful of days have an obvious persona fit — the seasonal registers
+ * called out in [TtsStyle]'s doc plus the two novelty days the registers were
+ * built for (Talk Like a Pirate Day → [TtsStyle.PIRATE], Towel Day →
+ * [TtsStyle.SCIFI_NARRATOR]). Everything else returns null so the everyday
+ * forecaster voice (or the user's deliberate pick) keeps speaking.
+ */
+fun holidayTtsStyle(id: HolidayId): TtsStyle? = when (id) {
+    HolidayId.NEW_YEARS_DAY -> TtsStyle.NEW_YEARS_HOST
+    HolidayId.US_PRESIDENTS_DAY -> TtsStyle.PRESIDENT
+    HolidayId.ST_PATRICKS_DAY -> TtsStyle.LEPRECHAUN
+    HolidayId.TOWEL_DAY -> TtsStyle.SCIFI_NARRATOR
+    HolidayId.TALK_LIKE_A_PIRATE_DAY -> TtsStyle.PIRATE
+    HolidayId.UK_KINGS_BIRTHDAY -> TtsStyle.KING
+    HolidayId.HALLOWEEN -> TtsStyle.SPOOKY_NARRATOR
+    HolidayId.CHRISTMAS_DAY, HolidayId.BOXING_DAY -> TtsStyle.FATHER_CHRISTMAS
+    else -> null
+}
+
+/**
+ * Speaker gender a persona evokes. Drives the holiday voice switch: a male
+ * persona on a female default voice (or vice versa) picks a matching-gender
+ * voice so the register lands — a booming Father Christmas in a youthful
+ * female voice reads wrong. Most personas are [VoiceGender.NEUTRAL] and keep
+ * the user's voice untouched.
+ */
+val TtsStyle.suggestedVoiceGender: VoiceGender
+    get() = when (this) {
+        TtsStyle.PRESIDENT,
+        TtsStyle.KING,
+        TtsStyle.FATHER_CHRISTMAS,
+        TtsStyle.SCIFI_NARRATOR,
+        TtsStyle.PIRATE,
+        TtsStyle.COWBOY,
+        TtsStyle.LEPRECHAUN,
+        -> VoiceGender.MALE
+        TtsStyle.QUEEN -> VoiceGender.FEMALE
+        else -> VoiceGender.NEUTRAL
+    }

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Settings.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Settings.kt
@@ -187,11 +187,12 @@ enum class TtsEngine { DEVICE, GEMINI }
  *   [KING], [QUEEN] and [PRESIDENT] are seasonal novelty registers ([KING] /
  *   [QUEEN] evoke King Charles III / Queen Elizabeth II for occasions with a
  *   royal in the name; [PRESIDENT] evokes the solemn oratory of George
- *   Washington / Abraham Lincoln for Presidents' Day and the like). For now
- *   they're always available in the picker; TODO: surface each one
- *   automatically around its holiday (Christmas, Halloween, New Year's Eve,
- *   St Patrick's Day, royal occasions, Presidents' Day) once the Celebrations
- *   calendar wiring can drive a default style.
+ *   Washington / Abraham Lincoln for Presidents' Day and the like). They're
+ *   always available in the picker, and `holidayTtsStyle` (see HolidayVoice.kt)
+ *   auto-selects the matching one around its holiday (Christmas, Halloween,
+ *   New Year's, St Patrick's Day, the King's birthday, Presidents' Day, plus
+ *   Talk Like a Pirate Day and Towel Day) for users who haven't picked a
+ *   deliberate non-default style.
  *
  * Only consulted when [TtsEngine] == [TtsEngine.GEMINI]; the on-device engine
  * doesn't accept style prompts.

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/model/HolidayVoiceTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/model/HolidayVoiceTest.kt
@@ -1,0 +1,46 @@
+package app.clothescast.core.domain.model
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+class HolidayVoiceTest {
+
+    @Test
+    fun `seasonal holidays map to their persona`() {
+        holidayTtsStyle(HolidayId.US_PRESIDENTS_DAY) shouldBe TtsStyle.PRESIDENT
+        holidayTtsStyle(HolidayId.TOWEL_DAY) shouldBe TtsStyle.SCIFI_NARRATOR
+        holidayTtsStyle(HolidayId.TALK_LIKE_A_PIRATE_DAY) shouldBe TtsStyle.PIRATE
+        holidayTtsStyle(HolidayId.ST_PATRICKS_DAY) shouldBe TtsStyle.LEPRECHAUN
+        holidayTtsStyle(HolidayId.HALLOWEEN) shouldBe TtsStyle.SPOOKY_NARRATOR
+        holidayTtsStyle(HolidayId.NEW_YEARS_DAY) shouldBe TtsStyle.NEW_YEARS_HOST
+        holidayTtsStyle(HolidayId.UK_KINGS_BIRTHDAY) shouldBe TtsStyle.KING
+        holidayTtsStyle(HolidayId.CHRISTMAS_DAY) shouldBe TtsStyle.FATHER_CHRISTMAS
+        holidayTtsStyle(HolidayId.BOXING_DAY) shouldBe TtsStyle.FATHER_CHRISTMAS
+    }
+
+    @Test
+    fun `ordinary holidays carry no special voice`() {
+        holidayTtsStyle(HolidayId.VALENTINES_DAY) shouldBe null
+        holidayTtsStyle(HolidayId.AUSTRALIA_DAY) shouldBe null
+        holidayTtsStyle(HolidayId.US_INDEPENDENCE_DAY) shouldBe null
+    }
+
+    @Test
+    fun `the president is male and towel day's narrator is male`() {
+        TtsStyle.PRESIDENT.suggestedVoiceGender shouldBe VoiceGender.MALE
+        TtsStyle.SCIFI_NARRATOR.suggestedVoiceGender shouldBe VoiceGender.MALE
+    }
+
+    @Test
+    fun `the queen is female and the king is male`() {
+        TtsStyle.QUEEN.suggestedVoiceGender shouldBe VoiceGender.FEMALE
+        TtsStyle.KING.suggestedVoiceGender shouldBe VoiceGender.MALE
+    }
+
+    @Test
+    fun `everyday registers leave the voice gender unconstrained`() {
+        TtsStyle.WEATHER_FORECASTER.suggestedVoiceGender shouldBe VoiceGender.NEUTRAL
+        TtsStyle.MORNING_PRESENTER.suggestedVoiceGender shouldBe VoiceGender.NEUTRAL
+        TtsStyle.SPOOKY_NARRATOR.suggestedVoiceGender shouldBe VoiceGender.NEUTRAL
+    }
+}


### PR DESCRIPTION
## Summary

On a themed day, the morning briefing now speaks in a matching persona and voice instead of the everyday forecaster register. The seasonal personas already existed in the picker; this wires them to fire automatically around their holiday (the long-standing TODO in `TtsStyle`'s doc).

- **Presidents' Day** → solemn male **president**
- **Towel Day** → dry male **sci-fi narrator**
- **Christmas / Boxing Day** → **Father Christmas**
- **Halloween** → spooky narrator
- **New Year's Day** → New Year's host
- **St Patrick's Day** → leprechaun
- **King's Birthday** → the King
- **Talk Like a Pirate Day** → pirate

Everything else keeps the everyday forecaster voice.

## How it works

- **`:core:domain` `HolidayVoice.kt`** — `holidayTtsStyle(HolidayId): TtsStyle?` maps a day to its seasonal persona (null for ordinary days), and `TtsStyle.suggestedVoiceGender` tags each persona MALE / FEMALE / NEUTRAL.
- **`:app` `resolveHolidayVoice()`** — resolves the effective `(voice, style)`:
  - A **deliberate non-default persona pick wins**: only the `WEATHER_FORECASTER` default yields to the holiday, so a user who chose e.g. PIRATE keeps it.
  - The voice is only switched to a matching-gender Gemini voice when the persona implies a gender the user's current voice lacks (a male persona on an already-male voice keeps it; a NEUTRAL persona never touches the voice).
- **Wiring** — `FetchAndNotifyWorker` delivery reuses the already-resolved holiday theme (`theme.id`) to pick the voice; the **Developer preview page** applies the same resolution, so picking a date previews that day's voice.

## Privacy

No new data crosses the device boundary. The auto-selected style directive is a fixed register string that already existed and was already sent to Gemini when a user picked the persona manually. Only the briefing prose is user-derived, and it is unchanged.

## Test plan

- [x] `:core:domain:test` — `HolidayVoiceTest` covers the holiday→persona map and per-persona gender.
- [x] `:app:testDebugUnitTest` — `tts.HolidayVoiceTest` covers voice/style resolution (gender switch, already-matching voice, neutral persona, deliberate-pick override).
- [x] Full local run: `:core:domain:test :core:data:test :app:testDebugUnitTest` + `:app:assembleDebug` all green.
- [ ] CI green.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CeEFpPEiSqPPTcwNYYY78S)_