### PR TITLE
Greet you with the holiday before the forecast on themed days

### DIFF
--- a/app/src/main/kotlin/app/clothescast/tts/HolidayGreeting.kt
+++ b/app/src/main/kotlin/app/clothescast/tts/HolidayGreeting.kt
@@ -1,0 +1,73 @@
+package app.clothescast.tts
+
+import android.content.Context
+import android.content.res.Configuration
+import app.clothescast.R
+import app.clothescast.core.domain.model.HolidayId
+import app.clothescast.core.domain.model.HolidayTheme
+import app.clothescast.core.domain.model.bannerTextKeyFor
+import java.util.Locale
+
+/**
+ * The spoken greeting prepended to the TTS briefing on a themed day. String
+ * language follows [locale] (the voice locale, not necessarily the app region —
+ * so a de-AT voice greets in German), while the per-country holiday-name
+ * override is keyed off [country] (the app/effective region country) so the
+ * spoken greeting mirrors the Today banner: a US-region user with an en-GB
+ * voice still hears "Veterans Day", not "Remembrance Day".
+ *
+ * Privacy: a synthetic theme's title is calendar-sourced and must never cross
+ * the device boundary into TTS (the prose is sent to Gemini over the BYOK key —
+ * see PRIVACY.md). So birthdays collapse to a generic "Happy birthday!" that
+ * drops the name the banner shows, calendar public holidays are skipped
+ * entirely, and composed multi-celebration banners speak only their catalog
+ * pieces. Returns null when there's nothing safe to greet, leaving the plain
+ * forecast unchanged.
+ */
+internal fun holidayTtsGreeting(
+    context: Context,
+    theme: HolidayTheme?,
+    locale: Locale,
+    country: String,
+): String? {
+    if (theme == null) return null
+    val config = Configuration(context.resources.configuration).apply { setLocale(locale) }
+    val localized = context.createConfigurationContext(config)
+
+    val segments = theme.bannerSegments
+    val core: String? = when {
+        !segments.isNullOrEmpty() -> {
+            val and = localized.getString(R.string.holiday_banner_and)
+            segments
+                // Skip synthetic literal segments (calendar titles); speak only
+                // the catalog/Funny pieces, which resolve from string resources.
+                .mapNotNull { segment ->
+                    val key = segment.textKeyByCountry[country.uppercase()] ?: segment.textKey
+                    key?.let { localized.resolveStringByName(it) }
+                }
+                .takeIf { it.isNotEmpty() }
+                ?.joinToString(separator = " $and ")
+        }
+        theme.isSynthetic ->
+            if (theme.id == HolidayId.BIRTHDAY) {
+                localized.getString(R.string.tts_greeting_birthday)
+            } else {
+                null
+            }
+        else -> localized.resolveStringByName(theme.bannerTextKeyFor(country))
+    }
+
+    val trimmed = core?.trim().orEmpty()
+    if (trimmed.isEmpty()) return null
+    if (trimmed.last() in TERMINAL_PUNCTUATION) return trimmed
+    // Solemn remembrance days take a flat full stop; festive days an
+    // exclamation, matching their banner copy's tone ("Merry Christmas!").
+    return trimmed + if (theme.solemn) "." else "!"
+}
+
+private val TERMINAL_PUNCTUATION = setOf('.', '!', '?')
+
+private fun Context.resolveStringByName(name: String): String? {
+    val resId = resources.getIdentifier(name, "string", packageName)
+    return if (resId == 0) null else getString(resId)
+}

--- a/app/src/main/kotlin/app/clothescast/tts/InsightTtsUtterance.kt
+++ b/app/src/main/kotlin/app/clothescast/tts/InsightTtsUtterance.kt
@@ -1,6 +1,7 @@
 package app.clothescast.tts
 
 import android.content.Context
+import app.clothescast.core.domain.model.HolidayTheme
 import app.clothescast.core.domain.model.InsightSummary
 import app.clothescast.core.domain.model.Region
 import app.clothescast.core.domain.model.TemperatureUnit
@@ -18,6 +19,10 @@ internal data class InsightTtsUtterance(
  * app-display region. This keeps notifications in the UI language while a
  * de-AT voice request speaks Austrian German text instead of English prose with
  * an Austrian accent.
+ *
+ * On a themed day [holidayTheme] prepends a spoken greeting ("Merry Christmas!
+ * Today, it will be …") localised to the same voice locale. See
+ * [holidayTtsGreeting] for the privacy rules around calendar-sourced titles.
  */
 internal fun insightTtsUtterance(
     context: Context,
@@ -26,10 +31,16 @@ internal fun insightTtsUtterance(
     voiceLocale: VoiceLocale,
     temperatureUnit: TemperatureUnit = TemperatureUnit.CELSIUS,
     fallbackLocale: Locale = Locale.getDefault(),
+    holidayTheme: HolidayTheme? = null,
 ): InsightTtsUtterance {
-    val locale = voiceLocale.resolve(region.toJavaLocale() ?: fallbackLocale)
+    val regionLocale = region.toJavaLocale() ?: fallbackLocale
+    val locale = voiceLocale.resolve(regionLocale)
+    val forecast = InsightFormatter.forContext(context, locale, temperatureUnit).format(summary)
+    // Override country tracks the app region (mirrors HolidayBanner) while the
+    // greeting's language follows the voice locale.
+    val greeting = holidayTtsGreeting(context, holidayTheme, locale, regionLocale.country)
     return InsightTtsUtterance(
-        text = InsightFormatter.forContext(context, locale, temperatureUnit).format(summary),
+        text = if (greeting == null) forecast else "$greeting $forecast",
         locale = locale,
     )
 }

--- a/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
@@ -18,7 +18,7 @@ import androidx.work.workDataOf
 import app.clothescast.ClothesCastApplication
 import app.clothescast.core.domain.model.DeliveryMode
 import app.clothescast.core.domain.model.ForecastPeriod
-import app.clothescast.core.domain.model.HolidayId
+import app.clothescast.core.domain.model.HolidayTheme
 import app.clothescast.core.domain.model.Insight
 import app.clothescast.core.domain.model.Location
 import app.clothescast.core.domain.model.OutfitSuggestion
@@ -624,7 +624,7 @@ class FetchAndNotifyWorker(
         // propagates so WorkManager stops unwind cleanly.
         supervisorScope {
             val synthDeferred: Deferred<PcmAudio?>? = if (gates.needsSynth) {
-                async(Dispatchers.IO) { synthesizeForDelivery(insight, prefs, theme?.id) }
+                async(Dispatchers.IO) { synthesizeForDelivery(insight, prefs, theme) }
             } else null
 
             val renderDeferred: Deferred<ByteArray?> = async(Dispatchers.Default) {
@@ -677,7 +677,7 @@ class FetchAndNotifyWorker(
             }
 
             val phoneSpeakerJob = launch {
-                playPhoneSpeaker(insight, prefs, gates, pcm, wav = wav, castDeferred = castDeferred)
+                playPhoneSpeaker(insight, prefs, gates, pcm, wav = wav, castDeferred = castDeferred, theme = theme)
             }
 
             notifyJob.join()
@@ -720,13 +720,13 @@ class FetchAndNotifyWorker(
     private suspend fun synthesizeForDelivery(
         insight: Insight,
         prefs: UserPreferences,
-        holidayId: HolidayId?,
+        theme: HolidayTheme?,
     ): PcmAudio? {
-        val utterance = ttsUtterance(insight, prefs)
+        val utterance = ttsUtterance(insight, prefs, theme)
         // On a themed day with no deliberate persona pick, speak in the
         // holiday's voice (Father Christmas on Dec 25, a president on
         // Presidents' Day, …) and switch to a matching-gender voice.
-        val selection = resolveHolidayVoice(holidayId, prefs.geminiVoice, prefs.ttsStyle)
+        val selection = resolveHolidayVoice(theme?.id, prefs.geminiVoice, prefs.ttsStyle)
         return runCatching {
             GeminiTtsSpeaker(
                 app.geminiTtsClient,
@@ -904,6 +904,7 @@ class FetchAndNotifyWorker(
         pcm: PcmAudio?,
         wav: ByteArray?,
         castDeferred: Deferred<CastInsightController.CastWorkerOutcome>?,
+        theme: HolidayTheme?,
     ) {
         if (gates.emptyEveningSkip) {
             DiagLog.i(TAG, "Tonight insight has no events and notify-only-on-events is on; skipping TTS.")
@@ -926,7 +927,7 @@ class FetchAndNotifyWorker(
             }
         }
 
-        val utterance = ttsUtterance(insight, prefs)
+        val utterance = ttsUtterance(insight, prefs, theme)
         withSpeechAudioFocus(applicationContext) {
             if (prefs.ttsEngine == TtsEngine.GEMINI && pcm != null) {
                 runCatching {
@@ -1040,13 +1041,18 @@ class FetchAndNotifyWorker(
     // preview's phrasing settles — the brand-name pronunciation check that the
     // per-locale settings_tts_test_sample used to give us is currently absent
     // from both the preview and the real briefing.
-    private fun ttsUtterance(insight: Insight, prefs: UserPreferences): InsightTtsUtterance =
+    private fun ttsUtterance(
+        insight: Insight,
+        prefs: UserPreferences,
+        theme: HolidayTheme?,
+    ): InsightTtsUtterance =
         insightTtsUtterance(
             context = applicationContext,
             summary = insight.summary,
             region = prefs.region,
             voiceLocale = prefs.voiceLocale,
             temperatureUnit = prefs.temperatureUnit,
+            holidayTheme = theme,
         )
 
     /**

--- a/app/src/main/res/values-am/strings.xml
+++ b/app/src/main/res/values-am/strings.xml
@@ -665,6 +665,7 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="holiday_banner_labour_day">የሰራተኞች ቀን</string>
     <string name="holiday_banner_mlk_day">ለዶ/ር ኪንግ መስዋዕትነት</string>
     <string name="holiday_banner_mothers_day">የእናቶች ቀን</string>
+    <string name="tts_greeting_birthday">መልካም ልደት</string>
     <string name="holiday_banner_new_years_day">መልካም አዲስ ዓመት</string>
     <string name="holiday_banner_remembrance_day">አንዘ ቀን</string>
     <string name="holiday_banner_spain_hispanic_day">ሂስፓኒዳድ ቀን</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -692,6 +692,7 @@ they work correctly in both the single-band and range templates.
     <string name="holiday_banner_labour_day">عيد العمال المبارك</string>
     <string name="holiday_banner_mlk_day">تكريماً للدكتور كينج</string>
     <string name="holiday_banner_mothers_day">عيد الأم المبارك</string>
+    <string name="tts_greeting_birthday">عيد ميلاد سعيد</string>
     <string name="holiday_banner_new_years_day">سنة جديدة سعيدة</string>
     <string name="holiday_banner_remembrance_day">لا ننسى</string>
     <string name="holiday_banner_spain_hispanic_day">يوم الهيسبانية المبارك</string>

--- a/app/src/main/res/values-b+sr+Latn/strings.xml
+++ b/app/src/main/res/values-b+sr+Latn/strings.xml
@@ -745,6 +745,7 @@ default English (matching values-pl / values-uk).
     <string name="holiday_name_immaculate_conception">Bezgrešno začeće</string>
     <string name="holiday_name_christmas_day">Božić</string>
     <string name="holiday_name_boxing_day">Drugi dan Božića</string>
+    <string name="tts_greeting_birthday">Srećan rođendan</string>
     <string name="holiday_banner_new_years_day">Srećna Nova Godina</string>
     <string name="holiday_banner_epiphany">Srećno Bogojavljenje</string>
     <string name="holiday_banner_valentines_day">Srećan Dan zaljubljenih</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -743,6 +743,7 @@ What is NOT overridden, by design:
     <string name="holiday_name_immaculate_conception">Непорочното зачатие</string>
     <string name="holiday_name_christmas_day">Коледа</string>
     <string name="holiday_name_boxing_day">Втори ден на Коледа</string>
+    <string name="tts_greeting_birthday">Честит рожден ден</string>
     <string name="holiday_banner_new_years_day">Честита Нова Година</string>
     <string name="holiday_banner_epiphany">Честито Богоявление</string>
     <string name="holiday_banner_valentines_day">Честит Свети Валентин</string>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -849,6 +849,7 @@ West Bengal vocabulary differences in a future PR.
     <string name="holiday_banner_labour_day">শ্রম দিবসের শুভেচ্ছা</string>
     <string name="holiday_banner_mlk_day">ড. কিংয়ের প্রতি শ্রদ্ধা</string>
     <string name="holiday_banner_mothers_day">শুভ মা দিবস</string>
+    <string name="tts_greeting_birthday">শুভ জন্মদিন</string>
     <string name="holiday_banner_new_years_day">শুভ নববর্ষ</string>
     <string name="holiday_banner_remembrance_day">আমরা ভুলি না</string>
     <string name="holiday_banner_spain_hispanic_day">শুভ Día de la Hispanidad</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -699,6 +699,7 @@ the in-app clock is digit-driven and reads consistently across locales.
     <string name="holiday_name_immaculate_conception">Immaculada Concepció</string>
     <string name="holiday_name_christmas_day">Nadal</string>
     <string name="holiday_name_boxing_day">Sant Esteve</string>
+    <string name="tts_greeting_birthday">Bon aniversari</string>
     <string name="holiday_banner_new_years_day">Feliç Any Nou</string>
     <string name="holiday_banner_epiphany">Feliços Reis Mags</string>
     <string name="holiday_banner_valentines_day">Feliç Sant Valentí</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -746,6 +746,7 @@ locale (Angličtina (USA), Francouzština (Francie), Němčina (Německo), …).
     <string name="holiday_name_immaculate_conception">Neposkvrněné početí</string>
     <string name="holiday_name_christmas_day">Vánoce</string>
     <string name="holiday_name_boxing_day">Druhý svátek vánoční</string>
+    <string name="tts_greeting_birthday">Všechno nejlepší k narozeninám</string>
     <string name="holiday_banner_new_years_day">Šťastný nový rok</string>
     <string name="holiday_banner_epiphany">Veselé Tři krále</string>
     <string name="holiday_banner_valentines_day">Šťastný Valentýn</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -759,6 +759,7 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrig)").
     <string name="holiday_name_immaculate_conception">Ubesmittet undfangelse</string>
     <string name="holiday_name_christmas_day">Juledag</string>
     <string name="holiday_name_boxing_day">Anden juledag</string>
+    <string name="tts_greeting_birthday">Tillykke med fødselsdagen</string>
     <string name="holiday_banner_new_years_day">Godt nytår</string>
     <string name="holiday_banner_epiphany">Glædelig Helligtrekonger</string>
     <string name="holiday_banner_valentines_day">Glædelig Valentinsdag</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -880,6 +880,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="holiday_name_immaculate_conception">Mariä Empfängnis</string>
     <string name="holiday_name_christmas_day">1. Weihnachtstag</string>
     <string name="holiday_name_boxing_day">2. Weihnachtstag</string>
+    <string name="tts_greeting_birthday">Alles Gute zum Geburtstag</string>
     <string name="holiday_banner_new_years_day">Frohes neues Jahr</string>
     <string name="holiday_banner_epiphany">Frohe Heilige Drei Könige</string>
     <string name="holiday_banner_valentines_day">Frohen Valentinstag</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -878,6 +878,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="holiday_name_immaculate_conception">Αμώμητη Σύλληψη</string>
     <string name="holiday_name_christmas_day">Χριστούγεννα</string>
     <string name="holiday_name_boxing_day">Δεύτερη μέρα Χριστουγέννων</string>
+    <string name="tts_greeting_birthday">Χρόνια πολλά</string>
     <string name="holiday_banner_new_years_day">Καλή Χρονιά</string>
     <string name="holiday_banner_epiphany">Χρόνια Πολλά για τα Θεοφάνια</string>
     <string name="holiday_banner_valentines_day">Χρόνια Πολλά Αγίου Βαλεντίνου</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -857,6 +857,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="holiday_name_immaculate_conception">Inmaculada Concepción</string>
     <string name="holiday_name_christmas_day">Navidad</string>
     <string name="holiday_name_boxing_day">Boxing Day</string>
+    <string name="tts_greeting_birthday">Feliz cumpleaños</string>
     <string name="holiday_banner_new_years_day">Feliz Año Nuevo</string>
     <string name="holiday_banner_epiphany">Felices Reyes Magos</string>
     <string name="holiday_banner_valentines_day">Feliz San Valentín</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -704,6 +704,7 @@ Tone is informal "sina"-form throughout ("Pane … selga", "Võta … kaasa",
     <string name="holiday_name_immaculate_conception">Neitsi Maarja laitmatu sünni püha</string>
     <string name="holiday_name_christmas_day">Jõulupüha</string>
     <string name="holiday_name_boxing_day">Teine jõulupüha</string>
+    <string name="tts_greeting_birthday">Palju õnne sünnipäevaks</string>
     <string name="holiday_banner_new_years_day">Head uut aastat</string>
     <string name="holiday_banner_epiphany">Head kolmekuningapäeva</string>
     <string name="holiday_banner_valentines_day">Head sõbrapäeva</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -683,6 +683,7 @@ Western Arabic numerals (0-9) are used for TTS compatibility.
     <string name="holiday_banner_labour_day">روز کارگر مبارک</string>
     <string name="holiday_banner_mlk_day">گرامی‌داشت دکتر کینگ</string>
     <string name="holiday_banner_mothers_day">روز مادر مبارک</string>
+    <string name="tts_greeting_birthday">تولدت مبارک</string>
     <string name="holiday_banner_new_years_day">سال نو مبارک</string>
     <string name="holiday_banner_remembrance_day">فراموش نمی‌کنیم</string>
     <string name="holiday_banner_spain_hispanic_day">روز هیسپانیداد مبارک</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -739,6 +739,7 @@ displayed label localizes.
     <string name="holiday_name_immaculate_conception">Neitsyt Marian sikiäminen</string>
     <string name="holiday_name_christmas_day">Joulupäivä</string>
     <string name="holiday_name_boxing_day">Tapaninpäivä</string>
+    <string name="tts_greeting_birthday">Hyvää syntymäpäivää</string>
     <string name="holiday_banner_new_years_day">Hyvää uutta vuotta</string>
     <string name="holiday_banner_epiphany">Hyvää loppiaista</string>
     <string name="holiday_banner_valentines_day">Hyvää ystävänpäivää</string>

--- a/app/src/main/res/values-fil/strings.xml
+++ b/app/src/main/res/values-fil/strings.xml
@@ -829,6 +829,7 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="holiday_banner_labour_day">Maligayang Araw ng Manggagawa</string>
     <string name="holiday_banner_mlk_day">Nagbibigay-pugay kay Dr. King</string>
     <string name="holiday_banner_mothers_day">Maligayang Araw ng Ina</string>
+    <string name="tts_greeting_birthday">Maligayang kaarawan</string>
     <string name="holiday_banner_new_years_day">Maligayang Bagong Taon</string>
     <string name="holiday_banner_remembrance_day">Lest we forget</string>
     <string name="holiday_banner_spain_hispanic_day">Maligayang Día de la Hispanidad</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -856,6 +856,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="holiday_name_immaculate_conception">Immaculée Conception</string>
     <string name="holiday_name_christmas_day">Noël</string>
     <string name="holiday_name_boxing_day">Lendemain de Noël</string>
+    <string name="tts_greeting_birthday">Joyeux anniversaire</string>
     <string name="holiday_banner_new_years_day">Bonne année</string>
     <string name="holiday_banner_epiphany">Bonne Épiphanie</string>
     <string name="holiday_banner_valentines_day">Bonne Saint-Valentin</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -809,6 +809,7 @@ Not overridden by design:
     <string name="holiday_banner_labour_day">मज़दूर दिवस की शुभकामनाएँ</string>
     <string name="holiday_banner_mlk_day">डॉ. किंग को नमन</string>
     <string name="holiday_banner_mothers_day">मातृ दिवस की शुभकामनाएँ</string>
+    <string name="tts_greeting_birthday">जन्मदिन मुबारक</string>
     <string name="holiday_banner_new_years_day">नव वर्ष की शुभकामनाएँ</string>
     <string name="holiday_banner_remembrance_day">हम नहीं भूलेंगे</string>
     <string name="holiday_banner_spain_hispanic_day">Día de la Hispanidad की शुभकामनाएँ</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -825,6 +825,7 @@ spousal register), matching the existing insight prose ("Ponesi …",
     <string name="holiday_name_immaculate_conception">Bezgrješno začeće</string>
     <string name="holiday_name_christmas_day">Božić</string>
     <string name="holiday_name_boxing_day">Drugi dan Božića</string>
+    <string name="tts_greeting_birthday">Sretan rođendan</string>
     <string name="holiday_banner_new_years_day">Sretna Nova Godina</string>
     <string name="holiday_banner_epiphany">Sretna Sveta Tri Kralja</string>
     <string name="holiday_banner_valentines_day">Sretan Valentinovo</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -749,6 +749,7 @@ locale (Angol (Egyesült Államok), Francia (Franciaország), Német
     <string name="holiday_name_immaculate_conception">Szeplőtelen fogantatás napja</string>
     <string name="holiday_name_christmas_day">Karácsony</string>
     <string name="holiday_name_boxing_day">Karácsony másnapja</string>
+    <string name="tts_greeting_birthday">Boldog születésnapot</string>
     <string name="holiday_banner_new_years_day">Boldog új évet</string>
     <string name="holiday_banner_epiphany">Boldog Vízkeresztet</string>
     <string name="holiday_banner_valentines_day">Boldog Valentin-napot</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -779,6 +779,7 @@ to values/strings.xml (English).
     <string name="holiday_banner_labour_day">Selamat Hari Buruh</string>
     <string name="holiday_banner_mlk_day">Menghormati Dr. King</string>
     <string name="holiday_banner_mothers_day">Selamat Hari Ibu</string>
+    <string name="tts_greeting_birthday">Selamat ulang tahun</string>
     <string name="holiday_banner_new_years_day">Selamat Tahun Baru</string>
     <string name="holiday_banner_remembrance_day">Lest we forget</string>
     <string name="holiday_banner_spain_hispanic_day">Selamat Día de la Hispanidad</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -842,6 +842,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="holiday_name_immaculate_conception">Immacolata Concezione</string>
     <string name="holiday_name_christmas_day">Natale</string>
     <string name="holiday_name_boxing_day">Santo Stefano</string>
+    <string name="tts_greeting_birthday">Buon compleanno</string>
     <string name="holiday_banner_new_years_day">Felice Anno Nuovo</string>
     <string name="holiday_banner_epiphany">Buona Epifania</string>
     <string name="holiday_banner_valentines_day">Buon San Valentino</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -691,6 +691,7 @@ standard in Israeli digital communication.
     <string name="holiday_banner_labour_day">יום העמל שמח</string>
     <string name="holiday_banner_mlk_day">מכבדים את ד״ר קינג</string>
     <string name="holiday_banner_mothers_day">יום האם שמח</string>
+    <string name="tts_greeting_birthday">יום הולדת שמח</string>
     <string name="holiday_banner_new_years_day">שנה טובה</string>
     <string name="holiday_banner_remembrance_day">לא נשכח</string>
     <string name="holiday_banner_spain_hispanic_day">יום ההיספניות שמח</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -921,6 +921,7 @@ the displayed label localizes.
     <string name="holiday_banner_labour_day">労働祭おめでとうございます</string>
     <string name="holiday_banner_mlk_day">キング博士の遺志を讃えます</string>
     <string name="holiday_banner_mothers_day">母の日おめでとうございます</string>
+    <string name="tts_greeting_birthday">お誕生日おめでとうございます</string>
     <string name="holiday_banner_new_years_day">明けましておめでとうございます</string>
     <string name="holiday_banner_remembrance_day">忘れまじ</string>
     <string name="holiday_banner_spain_hispanic_day">スペイン国民の日おめでとうございます</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -925,6 +925,7 @@ displayed label localizes.
     <string name="holiday_banner_labour_day">노동절을 기념합니다</string>
     <string name="holiday_banner_mlk_day">킹 박사를 기립니다</string>
     <string name="holiday_banner_mothers_day">어머니의 날을 기념합니다</string>
+    <string name="tts_greeting_birthday">생일 축하합니다</string>
     <string name="holiday_banner_new_years_day">새해 복 많이 받으세요</string>
     <string name="holiday_banner_remembrance_day">우리는 기억합니다</string>
     <string name="holiday_banner_spain_hispanic_day">Día de la Hispanidad을 기념합니다</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -748,6 +748,7 @@ What is NOT overridden, by design:
     <string name="holiday_name_immaculate_conception">Nekaltasis Prasidėjimas</string>
     <string name="holiday_name_christmas_day">Kalėdos</string>
     <string name="holiday_name_boxing_day">Antroji Kalėdų diena</string>
+    <string name="tts_greeting_birthday">Su gimtadieniu</string>
     <string name="holiday_banner_new_years_day">Laimingų Naujųjų metų</string>
     <string name="holiday_banner_epiphany">Linksmų Trijų Karalių</string>
     <string name="holiday_banner_valentines_day">Laimingos Valentino dienos</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -701,6 +701,7 @@ informal "tu"-form throughout ("Apģērb …", "Paņem … līdzi").
     <string name="holiday_name_immaculate_conception">Bezvainīgā ieņemšana</string>
     <string name="holiday_name_christmas_day">Ziemassvētki</string>
     <string name="holiday_name_boxing_day">Otrie Ziemassvētki</string>
+    <string name="tts_greeting_birthday">Daudz laimes dzimšanas dienā</string>
     <string name="holiday_banner_new_years_day">Laimīgu Jauno gadu</string>
     <string name="holiday_banner_epiphany">Priecīgus Trīs Karaļu svētkus</string>
     <string name="holiday_banner_valentines_day">Laimīgu Valentīndienu</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -785,6 +785,7 @@ vs "kemungkinan", "padam" vs "hapus").
     <string name="holiday_banner_labour_day">Selamat Hari Pekerja</string>
     <string name="holiday_banner_mlk_day">Menghormati Dr. King</string>
     <string name="holiday_banner_mothers_day">Selamat Hari Ibu</string>
+    <string name="tts_greeting_birthday">Selamat hari lahir</string>
     <string name="holiday_banner_new_years_day">Selamat Tahun Baru</string>
     <string name="holiday_banner_remembrance_day">Lest we forget</string>
     <string name="holiday_banner_spain_hispanic_day">Selamat Día de la Hispanidad</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -758,6 +758,7 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrike)").
     <string name="holiday_name_immaculate_conception">Ubesmittet unnfangelse</string>
     <string name="holiday_name_christmas_day">Juledag</string>
     <string name="holiday_name_boxing_day">Andre juledag</string>
+    <string name="tts_greeting_birthday">Gratulerer med dagen</string>
     <string name="holiday_banner_new_years_day">Godt nyttår</string>
     <string name="holiday_banner_epiphany">God Helligtrekongersdag</string>
     <string name="holiday_banner_valentines_day">God Valentinsdag</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -805,6 +805,7 @@ the displayed label localizes.
     <string name="holiday_name_immaculate_conception">Onbevlekte Ontvangenis</string>
     <string name="holiday_name_christmas_day">Eerste Kerstdag</string>
     <string name="holiday_name_boxing_day">Tweede Kerstdag</string>
+    <string name="tts_greeting_birthday">Gefeliciteerd met je verjaardag</string>
     <string name="holiday_banner_new_years_day">Gelukkig Nieuwjaar</string>
     <string name="holiday_banner_epiphany">Vrolijk Driekoningen</string>
     <string name="holiday_banner_valentines_day">Fijne Valentijnsdag</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -803,6 +803,7 @@ is unchanged; only the displayed label localizes.
     <string name="holiday_name_immaculate_conception">Niepokalane Poczęcie</string>
     <string name="holiday_name_christmas_day">Boże Narodzenie</string>
     <string name="holiday_name_boxing_day">Drugi Dzień Świąt</string>
+    <string name="tts_greeting_birthday">Wszystkiego najlepszego z okazji urodzin</string>
     <string name="holiday_banner_new_years_day">Szczęśliwego Nowego Roku</string>
     <string name="holiday_banner_epiphany">Wesołych Trzech Króli</string>
     <string name="holiday_banner_valentines_day">Wesołych Walentynek</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -845,6 +845,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="holiday_name_immaculate_conception">Imaculada Conceição</string>
     <string name="holiday_name_christmas_day">Natal</string>
     <string name="holiday_name_boxing_day">Dia de São Estêvão</string>
+    <string name="tts_greeting_birthday">Feliz aniversário</string>
     <string name="holiday_banner_new_years_day">Feliz Ano Novo</string>
     <string name="holiday_banner_epiphany">Feliz Epifania</string>
     <string name="holiday_banner_valentines_day">Feliz Dia dos Namorados</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -886,6 +886,7 @@ they diverge from BR ("Polonês" → "Polaco", "Holandês" →
     <string name="holiday_name_immaculate_conception">Imaculada Conceição</string>
     <string name="holiday_name_christmas_day">Natal</string>
     <string name="holiday_name_boxing_day">Dia de Santo Estêvão</string>
+    <string name="tts_greeting_birthday">Feliz aniversário</string>
     <string name="holiday_banner_new_years_day">Feliz Ano Novo</string>
     <string name="holiday_banner_epiphany">Feliz Epifania</string>
     <string name="holiday_banner_valentines_day">Feliz Dia de São Valentim</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -732,6 +732,7 @@ surfaces fall back to default English (matching values-pl / values-uk).
     <string name="holiday_name_immaculate_conception">Zămislirea Maicii Domnului</string>
     <string name="holiday_name_christmas_day">Crăciun</string>
     <string name="holiday_name_boxing_day">A doua zi de Crăciun</string>
+    <string name="tts_greeting_birthday">La mulți ani</string>
     <string name="holiday_banner_new_years_day">La mulți ani</string>
     <string name="holiday_banner_epiphany">Bobotează fericită</string>
     <string name="holiday_banner_valentines_day">Ziua Îndrăgostiților fericită</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -814,6 +814,7 @@ only the displayed label localizes.
     <string name="holiday_name_immaculate_conception">Непорочное зачатие</string>
     <string name="holiday_name_christmas_day">Рождество</string>
     <string name="holiday_name_boxing_day">Второй день Рождества</string>
+    <string name="tts_greeting_birthday">С днём рождения</string>
     <string name="holiday_banner_new_years_day">С Новым Годом</string>
     <string name="holiday_banner_epiphany">С Крещением</string>
     <string name="holiday_banner_valentines_day">С Днём святого Валентина</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -760,6 +760,7 @@ What is NOT overridden, by design:
     <string name="holiday_name_immaculate_conception">Nepoškvrnené počatie</string>
     <string name="holiday_name_christmas_day">Vianoce</string>
     <string name="holiday_name_boxing_day">Druhý sviatok vianočný</string>
+    <string name="tts_greeting_birthday">Všetko najlepšie k narodeninám</string>
     <string name="holiday_banner_new_years_day">Šťastný nový rok</string>
     <string name="holiday_banner_epiphany">Veselých Troch kráľov</string>
     <string name="holiday_banner_valentines_day">Šťastný Valentín</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -741,6 +741,7 @@ informal "ti"-form throughout, mirroring the Croatian / Serbian pass.
     <string name="holiday_name_immaculate_conception">Marijino brezmadežno spočetje</string>
     <string name="holiday_name_christmas_day">Božič</string>
     <string name="holiday_name_boxing_day">Štefanovo</string>
+    <string name="tts_greeting_birthday">Vse najboljše za rojstni dan</string>
     <string name="holiday_banner_new_years_day">Srečno novo leto</string>
     <string name="holiday_banner_epiphany">Srečno sveto trije kralji</string>
     <string name="holiday_banner_valentines_day">Srečno Valentinovo</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -758,6 +758,7 @@ native names for all locales (e.g. "Tyska (Tyskland)", "Franska (Frankrike)").
     <string name="holiday_name_immaculate_conception">Obefläckade avlelsen</string>
     <string name="holiday_name_christmas_day">Juldagen</string>
     <string name="holiday_name_boxing_day">Annandag jul</string>
+    <string name="tts_greeting_birthday">Grattis på födelsedagen</string>
     <string name="holiday_banner_new_years_day">Gott nytt år</string>
     <string name="holiday_banner_epiphany">Glad Trettondag</string>
     <string name="holiday_banner_valentines_day">Glad Alla hjärtans dag</string>

--- a/app/src/main/res/values-sw/strings.xml
+++ b/app/src/main/res/values-sw/strings.xml
@@ -666,6 +666,7 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="holiday_banner_labour_day">Siku ya Wafanyakazi</string>
     <string name="holiday_banner_mlk_day">Heshima kwa Dk. King</string>
     <string name="holiday_banner_mothers_day">Siku ya Mama</string>
+    <string name="tts_greeting_birthday">Heri ya siku ya kuzaliwa</string>
     <string name="holiday_banner_new_years_day">Heri ya Mwaka Mpya</string>
     <string name="holiday_banner_remembrance_day">Tusisahau</string>
     <string name="holiday_banner_spain_hispanic_day">Heri ya Día de la Hispanidad</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -779,6 +779,7 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="holiday_banner_labour_day">สุขสันต์วันแรงงาน</string>
     <string name="holiday_banner_mlk_day">รำลึกถึง ดร. คิง</string>
     <string name="holiday_banner_mothers_day">สุขสันต์วันแม่</string>
+    <string name="tts_greeting_birthday">สุขสันต์วันเกิด</string>
     <string name="holiday_banner_new_years_day">สุขสันต์วันปีใหม่</string>
     <string name="holiday_banner_remembrance_day">อย่าลืมพวกเขา</string>
     <string name="holiday_banner_spain_hispanic_day">สุขสันต์ Día de la Hispanidad</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -697,6 +697,7 @@ displayed label localizes.
     <string name="holiday_banner_labour_day">İşçi Bayramın kutlu olsun</string>
     <string name="holiday_banner_mlk_day">Dr. King\'i anıyoruz</string>
     <string name="holiday_banner_mothers_day">Anneler Günün kutlu olsun</string>
+    <string name="tts_greeting_birthday">Doğum günün kutlu olsun</string>
     <string name="holiday_banner_new_years_day">Mutlu Yıllar</string>
     <string name="holiday_banner_remembrance_day">Unutmayalım</string>
     <string name="holiday_banner_spain_hispanic_day">Día de la Hispanidad kutlu olsun</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -757,6 +757,7 @@ only the displayed label localizes.
     <string name="holiday_name_immaculate_conception">Непорочне зачаття</string>
     <string name="holiday_name_christmas_day">Різдво Христове</string>
     <string name="holiday_name_boxing_day">Другий день Різдва</string>
+    <string name="tts_greeting_birthday">З днем народження</string>
     <string name="holiday_banner_new_years_day">З Новим Роком</string>
     <string name="holiday_banner_epiphany">З Богоявленням</string>
     <string name="holiday_banner_valentines_day">З Днем святого Валентина</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -840,6 +840,7 @@ Skipped intentionally: app_name (brand), insight_time_am/pm/midnight/noon
     <string name="holiday_banner_labour_day">Chúc mừng Ngày Lao động</string>
     <string name="holiday_banner_mlk_day">Tưởng nhớ Tiến sĩ King</string>
     <string name="holiday_banner_mothers_day">Chúc mừng Ngày của Mẹ</string>
+    <string name="tts_greeting_birthday">Chúc mừng sinh nhật</string>
     <string name="holiday_banner_new_years_day">Chúc mừng Năm Mới</string>
     <string name="holiday_banner_remembrance_day">Lest we forget</string>
     <string name="holiday_banner_spain_hispanic_day">Chúc mừng Día de la Hispanidad</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -918,6 +918,7 @@ label localizes.
     <string name="holiday_banner_labour_day">劳动节快乐</string>
     <string name="holiday_banner_mlk_day">缅怀马丁·路德·金博士</string>
     <string name="holiday_banner_mothers_day">母亲节快乐</string>
+    <string name="tts_greeting_birthday">生日快乐</string>
     <string name="holiday_banner_new_years_day">新年快乐</string>
     <string name="holiday_banner_remembrance_day">铭记历史</string>
     <string name="holiday_banner_spain_hispanic_day">西班牙国庆节快乐</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -934,6 +934,7 @@ label localises.
     <string name="holiday_banner_labour_day">勞動節快樂</string>
     <string name="holiday_banner_mlk_day">緬懷馬丁·路德·金博士</string>
     <string name="holiday_banner_mothers_day">母親節快樂</string>
+    <string name="tts_greeting_birthday">生日快樂</string>
     <string name="holiday_banner_new_years_day">新年快樂</string>
     <string name="holiday_banner_remembrance_day">銘記歷史</string>
     <string name="holiday_banner_spain_hispanic_day">西班牙國慶節快樂</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1269,6 +1269,11 @@
          celebration falls on the same day ("Merry Christmas and Alice\'s
          birthday"). A bare word, padded with spaces in code. -->
     <string name="holiday_banner_and">and</string>
+    <!-- Spoken greeting prepended to the TTS briefing on a calendar-sourced
+         birthday. Deliberately generic — the birthday event\'s title (e.g.
+         "Alice\'s birthday") must never reach off-device TTS, so the spoken
+         greeting drops the name the on-screen banner shows. -->
+    <string name="tts_greeting_birthday">Happy birthday</string>
     <string name="holiday_banner_new_years_day">Happy New Year</string>
     <string name="holiday_banner_epiphany">Happy Epiphany</string>
     <string name="holiday_banner_japan_coming_of_age_day">Happy Japanese Coming of Age Day</string>

--- a/app/src/test/kotlin/app/clothescast/tts/InsightTtsUtteranceTest.kt
+++ b/app/src/test/kotlin/app/clothescast/tts/InsightTtsUtteranceTest.kt
@@ -4,12 +4,16 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import app.clothescast.core.domain.model.BandClause
 import app.clothescast.core.domain.model.ClothesClause
+import app.clothescast.core.domain.model.FestiveThemes
 import app.clothescast.core.domain.model.ForecastPeriod
+import app.clothescast.core.domain.model.HolidayCatalog
+import app.clothescast.core.domain.model.HolidayId
 import app.clothescast.core.domain.model.InsightSummary
 import app.clothescast.core.domain.model.Region
 import app.clothescast.core.domain.model.TemperatureBand
 import app.clothescast.core.domain.model.VoiceLocale
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldNotContain
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.util.Locale
@@ -48,7 +52,85 @@ class InsightTtsUtteranceTest {
         utterance.text shouldBe "Today, it will be 8° to 15°. Wear a jumper and jacket."
     }
 
+    @Test
+    fun `catalog holiday prepends a localised greeting to the briefing`() {
+        val utterance = insightTtsUtterance(
+            context = context,
+            summary = sampleSummary,
+            region = Region.EN_GB,
+            voiceLocale = VoiceLocale.SYSTEM,
+            fallbackLocale = Locale.US,
+            holidayTheme = christmas,
+        )
+
+        utterance.text shouldBe "Merry Christmas! Today, it will be 8° to 15°. Wear a jumper and jacket."
+    }
+
+    @Test
+    fun `birthday speaks a generic greeting and never the calendar event title`() {
+        val utterance = insightTtsUtterance(
+            context = context,
+            summary = sampleSummary,
+            region = Region.EN_GB,
+            voiceLocale = VoiceLocale.SYSTEM,
+            fallbackLocale = Locale.US,
+            holidayTheme = FestiveThemes.birthday("Alice's birthday"),
+        )
+
+        utterance.text shouldBe "Happy birthday! Today, it will be 8° to 15°. Wear a jumper and jacket."
+        utterance.text shouldNotContain "Alice"
+    }
+
+    @Test
+    fun `birthday greeting is spoken in the voice locale's language`() {
+        val utterance = insightTtsUtterance(
+            context = context,
+            summary = sampleSummary,
+            region = Region.EN_GB,
+            voiceLocale = VoiceLocale.DE_AT,
+            fallbackLocale = Locale.US,
+            holidayTheme = FestiveThemes.birthday("Alice's birthday"),
+        )
+
+        utterance.text shouldBe "Alles Gute zum Geburtstag! Heute wird es 8° bis 15°. Trag Pullover und Jacke."
+        utterance.text shouldNotContain "Alice"
+    }
+
+    @Test
+    fun `calendar public holiday is not greeted to keep its title off-device`() {
+        val utterance = insightTtsUtterance(
+            context = context,
+            summary = sampleSummary,
+            region = Region.EN_GB,
+            voiceLocale = VoiceLocale.SYSTEM,
+            fallbackLocale = Locale.US,
+            holidayTheme = FestiveThemes.publicHoliday("Diwali"),
+        )
+
+        utterance.text shouldBe "Today, it will be 8° to 15°. Wear a jumper and jacket."
+    }
+
+    @Test
+    fun `holiday-name override follows the app region, not the voice locale`() {
+        // US region with an en-GB voice: the spoken greeting should mirror the
+        // Today banner's US variant ("Veterans Day"), not the en-GB-locale
+        // default ("Remembrance Day").
+        val utterance = insightTtsUtterance(
+            context = context,
+            summary = sampleSummary,
+            region = Region.EN_US,
+            voiceLocale = VoiceLocale.EN_GB,
+            fallbackLocale = Locale.US,
+            holidayTheme = remembranceDay,
+        )
+
+        utterance.text shouldBe "Honoring our Veterans. Today, it will be 8° to 15°. Wear a jumper and jacket."
+    }
+
     private companion object {
+        val christmas = HolidayCatalog.all.first { it.second.id == HolidayId.CHRISTMAS_DAY }.second
+        val remembranceDay = HolidayCatalog.all.first { it.second.id == HolidayId.REMEMBRANCE_DAY }.second
+
         val sampleSummary = InsightSummary(
             period = ForecastPeriod.TODAY,
             band = BandClause(TemperatureBand.COLD, TemperatureBand.COOL),


### PR DESCRIPTION
## Summary

On a themed day the spoken briefing now opens with the day's greeting before the forecast — e.g. *"Merry Christmas! Today, it will be 14°."* — mirroring the on-screen Today banner. The greeting is rendered in the same **voice locale** as the rest of the briefing (so a de-AT voice greets in German), and is prepended to the TTS input only; the visible Today banner stays the sole on-screen surface (no change to displayed insight prose).

Both delivery paths get it: the pre-aligned Gemini synth and the device-engine fallback share the same `insightTtsUtterance` text, so the greeting is consistent across Gemini audio, the device speaker, the cast/MQTT audio bundle (which reuses the Gemini PCM), and any persona voice already selected for the day.

## What changed

- New `tts/HolidayGreeting.kt` — `holidayTtsGreeting(context, theme, locale)` resolves the spoken greeting from the resolved `HolidayTheme`, localised to the voice locale. Catalog holidays speak their banner copy; festive days get an exclamation, solemn remembrance days a flat full stop.
- `insightTtsUtterance` takes an optional `holidayTheme` and prepends the greeting (default `null` → unchanged behaviour).
- `FetchAndNotifyWorker` threads the already-resolved `theme` (it was only passing `theme?.id` for the persona voice) into both the synth and phone-speaker TTS paths.
- New generic `tts_greeting_birthday` string ("Happy birthday").

## Privacy

A synthetic theme's title is **calendar-sourced** and must never cross the device boundary into TTS (the prose is sent to Gemini over the BYOK key — see PRIVACY.md). So:
- **Birthdays** collapse to a generic *"Happy birthday!"*, dropping the name the on-screen banner shows.
- **Calendar public holidays** (the "Holidays in <country>" feed) are **skipped entirely** — no greeting, since their title can't be safely spoken.
- **Composed multi-celebration** banners speak only their catalog/Funny pieces; any synthetic literal segment is dropped.

A test asserts the spoken text for a birthday never contains the calendar event's name.

## Test plan

- [x] `:app:testDebugUnitTest` — new `InsightTtsUtteranceTest` cases: catalog holiday prepends localised greeting, birthday speaks the generic greeting and never the title, calendar public holiday is not greeted. Existing locale tests still pass.
- [x] `:app:assembleDebug`
- [ ] CI green


---
_Generated by [Claude Code](https://claude.ai/code/session_01Phox3pPYKxVjQ4WVC9Y1Ab)_