### PR TITLE
Theme birthdays with trailing punctuation and across calendars

### DIFF
--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/CalendarEventClassifier.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/CalendarEventClassifier.kt
@@ -42,8 +42,10 @@ object CalendarEventClassifier {
         RegexOption.IGNORE_CASE,
     )
 
+    // Trailing punctuation ("Eva's birthday!", "Eva's birthday...") is common
+    // in user-entered titles, so allow it after the match.
     private val BIRTHDAY_TITLE_REGEX = Regex(
-        "^(?:.+['’]s birthday|birthday\\s*[:\\-]\\s*.+)$",
+        "^(?:.+['’]s birthday|birthday\\s*[:\\-]\\s*.+)[\\s!?.]*$",
         RegexOption.IGNORE_CASE,
     )
 

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/ThemeForToday.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/ThemeForToday.kt
@@ -63,9 +63,17 @@ class ThemeForToday(
             emptyList()
         }
         val birthdays = if (themeFromCalendarBirthdays) {
-            events.firstOrNull { it.kind == EventKind.BIRTHDAY }
-                ?.let { listOf(FestiveThemes.birthday(it.title)) }
-                .orEmpty()
+            // The same birthday often lands in more than one synced calendar
+            // (e.g. a personal "Eva's birthday" and a shared "Eva's birthday!"),
+            // and two different people can share a day. Collect every distinct
+            // birthday — deduped on a punctuation/case-insensitive key so the
+            // same person across calendars merges instead of doubling up — and
+            // keep the first-seen title for display.
+            events.asSequence()
+                .filter { it.kind == EventKind.BIRTHDAY }
+                .distinctBy { birthdayDedupeKey(it.title) }
+                .map { FestiveThemes.birthday(it.title) }
+                .toList()
         } else {
             emptyList()
         }
@@ -99,4 +107,13 @@ class ThemeForToday(
         }
         return colourSource.copy(bannerSegments = segments)
     }
+
+    // Normalises a birthday title so the same person syncing in from several
+    // calendars collapses to one contributor: lower-cased, curly apostrophe
+    // folded to straight, trailing whitespace and punctuation stripped.
+    private fun birthdayDedupeKey(title: String): String =
+        title.lowercase()
+            .replace('’', '\'')
+            .trim()
+            .trimEnd('!', '?', '.', ',', ' ')
 }

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/CalendarEventClassifierTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/CalendarEventClassifierTest.kt
@@ -29,6 +29,17 @@ class CalendarEventClassifierTest {
     }
 
     @Test
+    fun `trailing exclamation mark still classifies as BIRTHDAY`() {
+        CalendarEventClassifier.classify("Eva's birthday!", ownerAccount = null).kind shouldBe EventKind.BIRTHDAY
+    }
+
+    @Test
+    fun `trailing punctuation and whitespace still classifies as BIRTHDAY`() {
+        CalendarEventClassifier.classify("Eva's birthday...", ownerAccount = null).kind shouldBe EventKind.BIRTHDAY
+        CalendarEventClassifier.classify("Eva's birthday! ", ownerAccount = null).kind shouldBe EventKind.BIRTHDAY
+    }
+
+    @Test
     fun `birthday classification is case-insensitive`() {
         CalendarEventClassifier.classify("ALICE'S BIRTHDAY", ownerAccount = null).kind shouldBe EventKind.BIRTHDAY
     }

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/ThemeForTodayTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/ThemeForTodayTest.kt
@@ -183,6 +183,43 @@ class ThemeForTodayTest {
     }
 
     @Test
+    fun `same birthday synced from two calendars dedupes to one contributor`() {
+        // Eva's birthday lives in both the personal calendar ("Eva's birthday")
+        // and a shared one ("Eva's birthday!"). They should collapse to a single
+        // standalone birthday banner, not double up as "Eva and Eva".
+        val theme = subject.resolve(
+            date = random,
+            overrides = noOverrides,
+            enabledCountries = allCountries,
+            events = listOf(birthday("Eva's birthday"), birthday("Eva's birthday!")),
+            themeFromCalendarHolidays = false,
+            themeFromCalendarBirthdays = true,
+        )
+        theme.shouldNotBeNull()
+        theme.id shouldBe HolidayId.BIRTHDAY
+        // A single contributor renders its standalone banner (no join segments).
+        theme.bannerSegments.shouldBeNull()
+        theme.displayTitleOverride shouldBe "Eva's birthday"
+    }
+
+    @Test
+    fun `two different people with birthdays today both surface`() {
+        val theme = subject.resolve(
+            date = random,
+            overrides = noOverrides,
+            enabledCountries = allCountries,
+            events = listOf(birthday("Alice's birthday"), birthday("Bob's birthday")),
+            themeFromCalendarHolidays = false,
+            themeFromCalendarBirthdays = true,
+        )
+        theme.shouldNotBeNull()
+        theme.id shouldBe HolidayId.BIRTHDAY
+        val segments = theme.bannerSegments
+        segments.shouldNotBeNull()
+        segments.map { it.literalText } shouldBe listOf("Alice's birthday", "Bob's birthday")
+    }
+
+    @Test
     fun `public holiday and birthday on the same day join into one banner`() {
         val theme = subject.resolve(
             date = random,


### PR DESCRIPTION
## Summary

Birthday calendar events weren't reliably theming the Today screen. Two root causes, both fixed here:

- **Trailing punctuation broke the title regex.** `BIRTHDAY_TITLE_REGEX` anchored `$` immediately after `birthday`, so a user-entered title like `Eva's birthday!` failed to match (while `Eva's birthday` matched). The regex now allows trailing whitespace and punctuation (`! ? . ,`), so emphatic titles still classify as `BIRTHDAY`.

- **Only the first birthday surfaced.** `ThemeForToday.resolve()` used `events.firstOrNull { it.kind == BIRTHDAY }`. The same birthday commonly syncs from more than one calendar (a personal `Eva's birthday` and a shared `Eva's birthday!`), and two different people can share a day. It now collects **every distinct** birthday, deduped on a case/punctuation/apostrophe-insensitive key so the same person across calendars merges into one banner rather than doubling up ("Eva and Eva"), while genuinely different people both surface via the existing "and"-join banner composition.

## Privacy

No change to what leaves the device — this only affects local classification and on-screen theming.

## Test plan

- [x] `CalendarEventClassifierTest`: new cases for trailing `!` and `...`/trailing whitespace.
- [x] `ThemeForTodayTest`: same person across two calendars dedupes to one standalone banner; two different people both surface in the joined banner.
- [x] `./gradlew :core:domain:test` green locally (inner build).
- [ ] CI (JVM unit tests + Android debug build).

https://claude.ai/code/session_012ixHjfMqs9MTfVw4F2Wecq

---
_Generated by [Claude Code](https://claude.ai/code/session_012ixHjfMqs9MTfVw4F2Wecq)_