### PR TITLE
Say "it will be 5 degrees warmer than yesterday" when the range is hidden

### DIFF
--- a/app/src/main/kotlin/app/clothescast/insight/InsightFormatter.kt
+++ b/app/src/main/kotlin/app/clothescast/insight/InsightFormatter.kt
@@ -98,7 +98,12 @@ class InsightFormatter(
                 RangeFormat.DEGREES -> add(formatBand(summary.period, summary.band, isFutureDay))
                 RangeFormat.BANDS -> add(formatBandWords(summary.period, summary.band, isFutureDay))
             }
-            summary.delta?.let { add(formatDelta(it)) }
+            // When the range is omitted there's no band sentence ahead of the
+            // delta, so it leads the temperature content and must introduce
+            // itself ("it will be 5° warmer than yesterday.") rather than ride
+            // as a bare fragment that the period lead folds into subject-less
+            // ("Today, 5° warmer than yesterday.").
+            summary.delta?.let { add(formatDelta(it, leadsTemperature = rangeFormat == RangeFormat.NONE)) }
             if (wearItems.isNotEmpty()) formatClothesWear(wearItems)?.let(::add)
             summary.precip?.let { add(formatPrecip(it)) }
         }
@@ -209,10 +214,22 @@ class InsightFormatter(
         TemperatureBand.HOT -> R.string.insight_band_hot
     }
 
-    private fun formatDelta(delta: DeltaClause): String {
+    private fun formatDelta(delta: DeltaClause, leadsTemperature: Boolean = false): String {
+        // The English delta is a bare fragment ("5° warmer than yesterday.")
+        // built to trail a band sentence; when it instead leads the temperature
+        // content it needs the "it will be …" subject. That self-introducing
+        // form has a localized template (insight_delta_*_lead) only for English
+        // so far. Other locales phrase their own delta as a full sentence
+        // already (German "Heute wird es 5° wärmer."), so they keep their
+        // existing string rather than have English spliced into localized
+        // prose — same en-only gating as spokenTime(). Widen the gate per
+        // locale as the _lead keys get translated.
+        val lead = leadsTemperature && locale.language == "en"
         val template = when (delta.direction) {
-            DeltaClause.Direction.WARMER -> R.string.insight_delta_warmer
-            DeltaClause.Direction.COOLER -> R.string.insight_delta_cooler
+            DeltaClause.Direction.WARMER ->
+                if (lead) R.string.insight_delta_warmer_lead else R.string.insight_delta_warmer
+            DeltaClause.Direction.COOLER ->
+                if (lead) R.string.insight_delta_cooler_lead else R.string.insight_delta_cooler
         }
         // DeltaClause.degrees is the absolute Celsius delta. Temperature
         // *differences* convert with the ratio only (no +32 offset), so

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -994,6 +994,13 @@
          delta line stands as a short factual addendum. -->
     <string name="insight_delta_warmer">%1$d° warmer than yesterday.</string>
     <string name="insight_delta_cooler">%1$d° cooler than yesterday.</string>
+    <!-- Delta as the leading temperature field: when the range is omitted there's
+         no band sentence ahead to supply the subject, so the delta introduces
+         itself with "it will be …". %1$d is the rounded degree difference. The
+         renderLeadOnly path folds the period lead in front, giving
+         "Today, it will be 5° warmer than yesterday.". -->
+    <string name="insight_delta_warmer_lead">it will be %1$d° warmer than yesterday.</string>
+    <string name="insight_delta_cooler_lead">it will be %1$d° cooler than yesterday.</string>
 
     <!-- Severe-weather alert prefix. %1$s = event name (e.g. "Tornado Warning"). -->
     <string name="insight_alert">Alert: %1$s.</string>

--- a/app/src/test/kotlin/app/clothescast/insight/InsightFormatterTest.kt
+++ b/app/src/test/kotlin/app/clothescast/insight/InsightFormatterTest.kt
@@ -18,6 +18,7 @@ import app.clothescast.core.domain.model.Region
 import app.clothescast.core.domain.model.TemperatureBand
 import app.clothescast.core.domain.model.WeatherCondition
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldNotContain
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.time.LocalTime
@@ -311,9 +312,26 @@ class InsightFormatterTest {
     }
 
     @Test
-    fun `omit range leaves a non-letter first clause untouched`() {
+    fun `omit range gives the leading delta an it-will-be subject`() {
+        // With the band sentence dropped, the delta is the first temperature
+        // field, so it introduces itself rather than reading as a bare
+        // fragment ("Today, 5° warmer than yesterday.").
         omitSubject.format(summary(delta = DeltaClause(5, DeltaClause.Direction.WARMER))) shouldBe
-            "Today, 5° warmer than yesterday."
+            "Today, it will be 5° warmer than yesterday."
+    }
+
+    @Test
+    fun `omit range keeps the leading delta localized for non-English`() {
+        // The "it will be …" lead template is English-only; a non-English
+        // locale must keep its own localized delta string rather than splice
+        // the English clause into otherwise-localized prose.
+        val germanOmit = InsightFormatter.forContext(
+            context,
+            Locale.GERMAN,
+            rangeFormat = RangeFormat.NONE,
+        )
+        germanOmit.format(summary(delta = DeltaClause(5, DeltaClause.Direction.WARMER)))
+            .shouldNotContain("it will be")
     }
 
     @Test


### PR DESCRIPTION
## Summary

When the user opts to omit the temperature range (`RangeFormat.NONE`), the band sentence ("Today, it will be 14°.") is dropped and the day-on-day delta becomes the **first** temperature field in the insight. But the delta was still rendered with the trailing-fragment template designed to follow a band sentence, so the lead folded into a subject-less sentence:

> Today, 5° warmer than yesterday.

This adds lead-form delta templates that introduce themselves when the delta leads the temperature content:

> Today, it will be 5° warmer than yesterday.

The `formatDelta` helper now takes a `lead` flag, set when `rangeFormat == NONE` (the only path where the delta isn't preceded by a band). Clothes-led leads ("Today, wear a sweater.") are untouched — "it will be" only ever introduces a temperature field, never clothing.

## Changes

- `strings.xml`: new `insight_delta_warmer_lead` / `insight_delta_cooler_lead` ("it will be %1$d° …"). Other locales fall back to the default until translated.
- `InsightFormatter`: `formatDelta(delta, lead)` picks the lead template; `format()` passes `lead = rangeFormat == NONE`.
- `InsightFormatterTest`: updated the omit-range delta test to assert the new subject-bearing prose.

No change to what leaves the device.

## Test plan

- [x] `:app:testDebugUnitTest --tests InsightFormatterTest` passes locally
- [ ] CI green


---
_Generated by [Claude Code](https://claude.ai/code/session_012Quzk9SDaGQcvsvFRwtfdL)_