### PR TITLE
Open the Format page with a tap on the insight, not a long press

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
@@ -1501,8 +1501,8 @@ internal fun InsightCard(
      */
     onLongPressDate: (() -> Unit)? = null,
     /**
-     * Opens the Format settings page. Wired to two affordances: long-pressing
-     * the prose body (only the prose — not the date / location header or the
+     * Opens the Format settings page. Wired to two affordances: tapping the
+     * prose body (only the prose — not the date / location header or the
      * generated-at footer) and a small "Format" link in the card's bottom-right
      * corner. Null disables both; default null keeps every preview / non-live
      * call site unchanged.
@@ -1590,9 +1590,7 @@ internal fun InsightCard(
                 text = formatter.format(insight.summary, isFutureDay = isFutureDay),
                 style = MaterialTheme.typography.headlineSmall,
                 modifier = if (onNavigateToFormat != null) {
-                    Modifier.pointerInput(onNavigateToFormat) {
-                        detectTapGestures(onLongPress = { onNavigateToFormat() })
-                    }
+                    Modifier.clickable { onNavigateToFormat() }
                 } else {
                     Modifier
                 },


### PR DESCRIPTION
## Summary

- The insight prose on the Today screen now opens the Format settings page on a **regular tap** instead of requiring a long press, making the affordance discoverable.
- The existing "Format" link in the card's bottom-right corner is unchanged.
- The hidden developer date long-press shortcut (`onLongPressDate`) is untouched.

## Detail

In `InsightCard` (`app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt`), the prose body's gesture handler changed from `Modifier.pointerInput { detectTapGestures(onLongPress = …) }` to `Modifier.clickable { onNavigateToFormat() }`. KDoc updated to describe the tap affordance.

## Test plan

- [x] `./gradlew :app:testDebugUnitTest :app:assembleDebug` — BUILD SUCCESSFUL
- [ ] Manually verify a single tap on the insight prose opens the Format page on device


---
_Generated by [Claude Code](https://claude.ai/code/session_01NR83QXW6wPhmHKn4q4H9hq)_