### PR TITLE
Stop doubling "Today" in the ClothesCast for most languages

### DIFF
--- a/app/src/main/kotlin/app/clothescast/insight/InsightFormatter.kt
+++ b/app/src/main/kotlin/app/clothescast/insight/InsightFormatter.kt
@@ -116,7 +116,16 @@ class InsightFormatter(
             summary.eveningEventTieIn?.let(::formatEveningEventTieIn)?.let(::add)
         }
         val body = if (rangeFormat == RangeFormat.NONE) {
-            renderLeadOnly(summary.period, isFutureDay, primaryClauses, tieInClauses)
+            // In NONE mode the band is dropped, so when a delta is present it's
+            // the first primary clause. English renders it as the
+            // self-introducing "it will be …" fragment that the period lead
+            // folds into ("Today, it will be 5° warmer …"); every other locale
+            // keeps its full, self-leading delta sentence ("Heute wird es 5°
+            // wärmer."), which already carries its own "today" word and must
+            // NOT have a second lead prepended — otherwise the prose doubles it
+            // ("Heute, heute wird es 5° wärmer.").
+            val firstClauseSelfLeads = summary.delta != null && !deltaHasLeadFragment()
+            renderLeadOnly(summary.period, isFutureDay, primaryClauses, tieInClauses, firstClauseSelfLeads)
         } else {
             (primaryClauses + tieInClauses).joinToString(" ")
         }
@@ -138,17 +147,25 @@ class InsightFormatter(
         isFutureDay: Boolean,
         primaryClauses: List<String>,
         tieInClauses: List<String>,
+        firstClauseSelfLeads: Boolean,
     ): String {
         val lead = resources.getString(leadRes(period, isFutureDay))
         if (primaryClauses.isEmpty()) {
             if (tieInClauses.isEmpty()) return resources.getString(R.string.insight_lead_only, lead)
             return tieInClauses.joinToString(" ")
         }
-        val first = resources.getString(
-            R.string.insight_lead_continues,
-            lead,
-            decapitalize(primaryClauses.first()),
-        )
+        // A self-leading first clause (a localized full-sentence delta) already
+        // opens with its own "today" word, so emit it verbatim instead of
+        // folding the period lead in front of it.
+        val first = if (firstClauseSelfLeads) {
+            primaryClauses.first()
+        } else {
+            resources.getString(
+                R.string.insight_lead_continues,
+                lead,
+                decapitalize(primaryClauses.first()),
+            )
+        }
         return (listOf(first) + primaryClauses.drop(1) + tieInClauses).joinToString(" ")
     }
 
@@ -224,7 +241,7 @@ class InsightFormatter(
         // existing string rather than have English spliced into localized
         // prose — same en-only gating as spokenTime(). Widen the gate per
         // locale as the _lead keys get translated.
-        val lead = leadsTemperature && locale.language == "en"
+        val lead = leadsTemperature && deltaHasLeadFragment()
         val template = when (delta.direction) {
             DeltaClause.Direction.WARMER ->
                 if (lead) R.string.insight_delta_warmer_lead else R.string.insight_delta_warmer
@@ -242,6 +259,17 @@ class InsightFormatter(
         }
         return resources.getString(template, degrees)
     }
+
+    /**
+     * Whether this locale ships the self-introducing `insight_delta_*_lead`
+     * fragment ("it will be 5° warmer …"). Only English does so far; every
+     * other locale phrases its delta as a full self-leading sentence
+     * ("Heute wird es 5° wärmer."). [format] uses the inverse to decide
+     * whether [renderLeadOnly] should fold the period lead in front of the
+     * delta — keep the two in sync, and widen this gate as the `_lead` keys
+     * get translated.
+     */
+    private fun deltaHasLeadFragment(): Boolean = locale.language == "en"
 
     private fun formatClothesWear(items: List<String>): String? {
         val phrase = phraser.joinItems(items)

--- a/app/src/test/kotlin/app/clothescast/insight/InsightFormatterTest.kt
+++ b/app/src/test/kotlin/app/clothescast/insight/InsightFormatterTest.kt
@@ -335,6 +335,21 @@ class InsightFormatterTest {
     }
 
     @Test
+    fun `omit range does not double the lead on a self-leading localized delta`() {
+        // The German delta string is a full sentence that already opens with
+        // "Heute" ("Heute wird es 5° wärmer."). Folding the period lead in
+        // front of it would double the word ("Heute, heute wird es …"); the
+        // self-leading clause must be emitted verbatim instead.
+        val germanOmit = InsightFormatter.forContext(
+            context,
+            Locale.GERMAN,
+            rangeFormat = RangeFormat.NONE,
+        )
+        germanOmit.format(summary(delta = DeltaClause(5, DeltaClause.Direction.WARMER))) shouldBe
+            "Heute wird es 5° wärmer."
+    }
+
+    @Test
     fun `omit range with no other clause leaves a bare lead`() {
         omitSubject.format(summary()) shouldBe "Today."
     }


### PR DESCRIPTION
## Summary

Fixes a localization bug in the insight prose. When the temperature range is hidden (`RangeFormat.NONE`), the day-on-day delta becomes the first sentence of the ClothesCast.

- In **English** the delta renders as a self-introducing fragment that the period lead folds into: `"Today, it will be 5° warmer than yesterday."` (correct, added in the recent "Say it will be 5 degrees warmer" commit).
- In **every other language** the delta string is a full sentence that already opens with its own "today" word — e.g. German `"Heute wird es 5° wärmer."`, and similarly for fr, es, it, pt, ja, ko, zh, ru, pl, nl, cs, sk, hu, tr, and ~30 more locales.

`renderLeadOnly` prepended the period lead **unconditionally**, so for those locales the prose came out doubled and grammatically broken:

> ❌ `Heute, heute wird es 5° wärmer.`

After the fix the self-leading clause is emitted verbatim:

> ✅ `Heute wird es 5° wärmer.`

## How

- `renderLeadOnly` now takes a `firstClauseSelfLeads` flag and skips folding the lead in front of a clause that already self-leads.
- `format()` sets that flag when a delta is present and the locale does **not** ship the English-only `insight_delta_*_lead` fragment.
- The English↔localized gate is centralized in a new `deltaHasLeadFragment()` helper used by both `formatDelta` and `format`, so widening it (as `_lead` keys get translated per locale) stays consistent.

No change to English output, the `DEGREES`/`BANDS` range formats, or any non-`NONE` path.

## Privacy

No change to what leaves the device — this only reshapes locally-rendered prose.

## Test plan

- [x] New regression test `omit range does not double the lead on a self-leading localized delta` asserts the exact German output `"Heute wird es 5° wärmer."` (the prior test only checked the absence of "it will be", which let the doubling through).
- [x] `./gradlew :app:testDebugUnitTest` passes locally (full Android SDK build parity).

https://claude.ai/code/session_01LbUrEa7i99xipqVYnMRFHr

---
_Generated by [Claude Code](https://claude.ai/code/session_01LbUrEa7i99xipqVYnMRFHr)_