### PR TITLE
Preview each holiday's own voice on the Developer screen

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/settings/DeveloperSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/DeveloperSettings.kt
@@ -42,6 +42,7 @@ import app.clothescast.core.domain.model.InsightSummary
 import app.clothescast.core.domain.model.OutfitSuggestion
 import app.clothescast.core.domain.model.Region
 import app.clothescast.core.domain.model.TemperatureBand
+import app.clothescast.core.domain.model.TtsStyle
 import app.clothescast.core.domain.usecase.ThemeForToday
 import app.clothescast.tts.resolveHolidayVoice
 import app.clothescast.ui.today.HolidayBanner
@@ -97,8 +98,15 @@ internal fun DeveloperPage(viewModel: SettingsViewModel, onBack: () -> Unit) {
                 isSpeaking = true
                 // Speak the picked day in its holiday voice so the preview
                 // demonstrates the auto-selected persona, not just the
-                // user's default voice.
-                val selection = resolveHolidayVoice(holidayId, state.geminiVoice, state.ttsStyle)
+                // user's default voice. Resolve against the everyday
+                // forecaster style, not the user's saved one: a deliberate
+                // persona pick (e.g. Father Christmas) wins over the holiday
+                // in the real briefing, but here that would mask the day's
+                // own persona — every previewed day would speak in the
+                // saved voice (Towel Day saying "Ho ho ho"), defeating the
+                // point of the preview.
+                val selection =
+                    resolveHolidayVoice(holidayId, state.geminiVoice, TtsStyle.WEATHER_FORECASTER)
                 scope.launch {
                     try {
                         runTtsPreview(


### PR DESCRIPTION
## Summary

The Developer screen's **Speak** preview was meant to demonstrate each
themed day's auto-selected persona ("not just the user's default voice",
per its own comment). But it resolved the voice against `state.ttsStyle`
— the user's *saved* TTS style.

`resolveHolidayVoice` deliberately lets a non-default persona pick win
over a holiday's auto-persona (the right call for the real daily
briefing — your chosen voice should stand). So if you'd set your style
to **Father Christmas** on the Voice screen, the Developer preview spoke
*every* day in that voice — including Towel Day, which read its briefing
with a Santa "Ho ho ho" instead of the intended dry sci-fi narrator.

The fix: resolve the preview against `TtsStyle.WEATHER_FORECASTER` (the
everyday baseline) instead of the saved style, so the holiday's own
persona always applies and the preview does what it advertises. Towel
Day → sci-fi narrator, Presidents' Day → president, etc., regardless of
what voice you've saved.

Scope: `:app` only, Developer settings screen. No change to the real
briefing path (`FetchAndNotifyWorker`), which still honours a deliberate
persona pick. No privacy-relevant changes — nothing new crosses the
device boundary.

## Test plan

- [x] `:app:compileDebugKotlin` + `HolidayVoiceTest` pass locally (the
  existing `towel day speaks as a male sci-fi narrator` case already
  pins `resolveHolidayVoice(TOWEL_DAY, …, WEATHER_FORECASTER)` →
  sci-fi narrator).
- [ ] Manually: set TTS style to Father Christmas, open Developer →
  pick May 25 (Towel Day) → **Speak** → hear the sci-fi narrator, not
  "Ho ho ho".

https://claude.ai/code/session_0133CPNTczkhy9u8JQVC3fi2

---
_Generated by [Claude Code](https://claude.ai/code/session_0133CPNTczkhy9u8JQVC3fi2)_