### PR TITLE
Add a combined card-and-announcement video to the smart home bridge

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -167,13 +167,22 @@ The source code is at <https://github.com/mikelward/clothescast>.
   values you supply; ClothesCast never sends this payload anywhere you
   haven't pointed it at. The broker is **not** a service the developer
   operates; it's your infrastructure under your control.
-- **What's in the payload:** Only the rendered sentence string,
-  UTF-8 encoded — the same text you see in the notification. The
-  payload includes any calendar-event tie-in clause that fires (e.g.
-  _"Bring a jacket for your concert tonight"_) when you have the
-  calendar tie-in enabled, because that clause is part of the
-  rendered sentence. No coordinates, no API keys, no settings values,
-  no device identifiers travel with the message.
+- **What's in the payload:** The rendered sentence string, UTF-8
+  encoded — the same text you see in the notification — and, on their
+  own sibling topics when available, the outfit-card image (the same
+  800 × 480 PNG shown on a Nest Hub), the spoken TTS audio clip (the
+  same bytes the phone speaks, Gemini engine only), and a combined MP4
+  that simply muxes that image and audio together for one-shot casting.
+  The image and audio carry the same insight — the card renders the
+  sentence, the audio speaks it — so the MP4 introduces no new data; it
+  only repackages what the image and audio topics already publish. A
+  small `now/timestamp` topic carries the epoch-millis time of the most
+  recent publish so a consumer can tell a fresh forecast from a retained
+  one. The payload includes any calendar-event tie-in clause that fires
+  (e.g. _"Bring a jacket for your concert tonight"_) when you have the
+  calendar tie-in enabled, because that clause is part of the rendered
+  sentence. No coordinates, no API keys, no settings values, no device
+  identifiers travel with any of these messages.
 - **Authentication:** If you set a broker username, the bridge sends
   it on connect; the corresponding password is stored on your device
   encrypted at rest (same Tink-AEAD pattern as the Gemini API key

--- a/app/src/main/kotlin/app/clothescast/mqtt/MqttPublisher.kt
+++ b/app/src/main/kotlin/app/clothescast/mqtt/MqttPublisher.kt
@@ -55,20 +55,38 @@ class MqttPublisher(
 ) {
 
     /**
-     * Publishes a delivery's prose, optional outfit image, and optional TTS
-     * audio as a single coordinated bundle. The period-specific topics
-     * (`${baseTopic}/${period.lowercased()}/{text,image,audio}`) fan out in
-     * parallel — they're independent surfaces and a slow image upload
+     * Publishes a delivery's prose, optional outfit image, optional TTS
+     * audio, and optional muxed video (PNG frame + TTS audio as an MP4) as a
+     * single coordinated bundle. The period-specific topics
+     * (`${baseTopic}/${period.lowercased()}/{text,image,audio,video}`) fan out
+     * in parallel — they're independent surfaces and a slow image upload
      * shouldn't hold up the prose.
      *
-     * The `${baseTopic}/now/{text,image,audio}` mirrors are treated as an
-     * atomic three-topic bundle. They fire only when **every** submitted
-     * modality's period publish succeeded; then `now/image` and `now/audio`
-     * publish in parallel and `now/text` lands **last**. The text-last
-     * ordering matters because `now/text` is the natural state-change
-     * trigger surface for an HA automation — having it update last
-     * guarantees a consumer subscribing to `now/text` reads a `now/image`
-     * and `now/audio` from the same forecast.
+     * The `${baseTopic}/now/{text,image,audio,video,timestamp}` mirrors are
+     * treated as an atomic bundle. They fire only when every **gating**
+     * modality's period publish (prose + any submitted image / audio)
+     * succeeded; then `now/image`, `now/audio` and `now/video` publish in
+     * parallel, `now/text` lands after them, and `now/timestamp` lands
+     * **last** of all. `now/timestamp` is the bundle's commit marker —
+     * epoch-millis written only once the gating content mirrors have settled,
+     * so its update is the single signal that the `now` set is in place. A
+     * consumer triggers on `now/timestamp` and dedupes on its value: a new
+     * timestamp guarantees a coherent `now/image` / `now/audio` / `now/text`
+     * from the same forecast, and a value it has already acted on means skip —
+     * so a retained bundle isn't replayed on reconnect. (MQTT 3.1.1 carries no
+     * native publish timestamp, hence the explicit topic.)
+     *
+     * `now/video` **always** gates the commit marker: its payload is the video
+     * when one was produced and an empty "delete retained" clear when not.
+     * Gating on the clear too is what keeps the set coherent — were it
+     * best-effort, a failed clear would leave a stale video from a prior bundle
+     * paired with the fresh timestamp. The cost is that a broker whose ACL
+     * denies `now/video` stalls the bundle; that's a hand-rolled per-topic ACL
+     * the setup guide never recommends (it grants `<prefix>/#`), and any ACL
+     * that ever accepted a real `now/video` accepts the clear too. A timestamp
+     * publish that fails after the content mirrors advanced is logged (the
+     * marker silently lagging its content is the one missed-update case the
+     * trigger contract must surface) but does not change the returned outcome.
      *
      * Modalities absent from the current delivery (e.g. an outfit render
      * failed, or the user is on device TTS so no audio bytes exist) still
@@ -114,6 +132,7 @@ class MqttPublisher(
         prose: String,
         image: ByteArray? = null,
         audio: ByteArray? = null,
+        video: ByteArray? = null,
     ): MqttPublishOutcome = coroutineScope {
         val prepared = preparePublish(context = period.name.lowercase())
             ?: return@coroutineScope MqttPublishOutcome.NotConfigured
@@ -121,15 +140,27 @@ class MqttPublisher(
         val proseTopic = topicFor(prepared.baseTopic, period)
         val imageTopic = imageTopicFor(prepared.baseTopic, period)
         val audioTopic = audioTopicFor(prepared.baseTopic, period)
+        val videoTopic = videoTopicFor(prepared.baseTopic, period)
         val nowTextTopic = nowTopicFor(prepared.baseTopic)
         val nowImageTopic = nowImageTopicFor(prepared.baseTopic)
         val nowAudioTopic = nowAudioTopicFor(prepared.baseTopic)
+        val nowVideoTopic = nowVideoTopicFor(prepared.baseTopic)
+        val nowTimestampTopic = nowTimestampTopicFor(prepared.baseTopic)
+        // MQTT 3.1.1 carries no native publish timestamp (and the MQTT 5
+        // user-property route isn't available on this v3 client), so we
+        // publish one ourselves: epoch-millis as a decimal string on the
+        // /now/timestamp surface. A retained consumer (e.g. HA casting the
+        // video to a Home Hub) reads it to dedupe — on reconnect it sees the
+        // same timestamp it already played and skips replaying the clip
+        // rather than re-announcing a stale bundle.
+        val timestampBytes = System.currentTimeMillis().toString().toByteArray(Charsets.UTF_8)
         DiagLog.i(
             TAG,
             "MQTT bridge enabled; publishing ${period.name.lowercase()} insight bundle to " +
                 "${prepared.scheme}://${prepared.host}:${prepared.port}/$proseTopic " +
-                "(image=${image != null}, audio=${audio != null}, " +
-                "mirrored to $nowTextTopic with $nowImageTopic / $nowAudioTopic landing first, " +
+                "(image=${image != null}, audio=${audio != null}, video=${video != null}, " +
+                "mirrored to /now as $nowImageTopic / $nowAudioTopic / $nowVideoTopic, " +
+                "then $nowTextTopic, then $nowTimestampTopic last as the commit marker, " +
                 "auth=${!prepared.config.username.isNullOrBlank()}, " +
                 "password=${if (prepared.config.password != null) "set" else "none"}, " +
                 "payload=${prose.length} chars).",
@@ -138,13 +169,20 @@ class MqttPublisher(
         val proseDeferred = async { executePublish(prepared, proseTopic, proseBytes) }
         val imageDeferred = image?.let { bytes -> async { executePublish(prepared, imageTopic, bytes) } }
         val audioDeferred = audio?.let { bytes -> async { executePublish(prepared, audioTopic, bytes) } }
+        // The period today/video publish is attempted only when a video was
+        // produced this delivery (videoOutcome stays null otherwise) and gates
+        // the now mirror the same way image/audio do. The now/video clear for a
+        // no-video delivery — and its gating — lives in the now block below.
+        val videoDeferred = video?.let { bytes -> async { executePublish(prepared, videoTopic, bytes) } }
         val proseOutcome = proseDeferred.await()
         val imageOutcome = imageDeferred?.await()
         val audioOutcome = audioDeferred?.await()
+        val videoOutcome = videoDeferred?.await()
 
         val everySubmittedSucceeded = proseOutcome is MqttPublishOutcome.Success &&
             (imageOutcome == null || imageOutcome is MqttPublishOutcome.Success) &&
-            (audioOutcome == null || audioOutcome is MqttPublishOutcome.Success)
+            (audioOutcome == null || audioOutcome is MqttPublishOutcome.Success) &&
+            (videoOutcome == null || videoOutcome is MqttPublishOutcome.Success)
 
         if (everySubmittedSucceeded) {
             // The now surface is treated as an atomic three-topic bundle. Any
@@ -163,18 +201,69 @@ class MqttPublisher(
             val nowAudioMirror = async {
                 executePublish(prepared, nowAudioTopic, audio ?: emptyPayload)
             }
+            // now/video always gates the commit marker: its payload is the
+            // video when we have one and an empty clear (the MQTT "delete
+            // retained" convention) when we don't. Gating on the clear too is
+            // what keeps the set coherent — if a no-video delivery's clear were
+            // best-effort and failed, a stale video from a prior bundle would
+            // outlive it and pair with the fresh timestamp. The cost is that a
+            // broker whose ACL denies now/video stalls the bundle; that's a
+            // hand-rolled per-topic ACL we don't document (the guide grants
+            // `<prefix>/#`), and any ACL that ever accepted a real now/video
+            // accepts the clear too, so the practical blast radius is small.
+            val nowVideoMirror = async {
+                executePublish(prepared, nowVideoTopic, video ?: emptyPayload)
+            }
             val nowImageOutcome = nowImageMirror.await()
             val nowAudioOutcome = nowAudioMirror.await()
+            val nowVideoOutcome = nowVideoMirror.await()
             if (nowImageOutcome is MqttPublishOutcome.Success &&
-                nowAudioOutcome is MqttPublishOutcome.Success
+                nowAudioOutcome is MqttPublishOutcome.Success &&
+                nowVideoOutcome is MqttPublishOutcome.Success
             ) {
-                executePublish(prepared, nowTextTopic, proseBytes)
+                val nowTextOutcome = executePublish(prepared, nowTextTopic, proseBytes)
+                if (nowTextOutcome is MqttPublishOutcome.Success) {
+                    // now/timestamp is the very last write, after every gating
+                    // content mirror (image/audio/text) has settled, so its
+                    // update is the single "bundle complete" marker. A consumer
+                    // triggers on now/timestamp and dedupes on its value: a new
+                    // timestamp guarantees the rest of the now bundle is already
+                    // in place, and the same value it last acted on means skip —
+                    // don't replay a retained announcement on reconnect.
+                    val nowTimestampOutcome = executePublish(prepared, nowTimestampTopic, timestampBytes)
+                    if (nowTimestampOutcome !is MqttPublishOutcome.Success) {
+                        // The content mirrors already advanced but the commit
+                        // marker didn't, so timestamp-triggered consumers won't
+                        // act on this bundle until a later publish moves the
+                        // marker. Surface it: a marker that silently lags its
+                        // content is exactly the missed-update case the trigger
+                        // contract has to make debuggable. (executePublish has
+                        // already retried per its policy.)
+                        DiagLog.w(
+                            TAG,
+                            "Commit marker $nowTimestampTopic failed for " +
+                                "${period.name.lowercase()} bundle ($nowTimestampOutcome); " +
+                                "now/* content advanced but the trigger marker did not, so " +
+                                "timestamp-triggered consumers will skip this bundle until " +
+                                "the next successful publish.",
+                        )
+                    }
+                } else {
+                    DiagLog.i(
+                        TAG,
+                        "Holding back $nowTimestampTopic for ${period.name.lowercase()} " +
+                            "bundle (now/text=$nowTextOutcome); the commit marker stays at the " +
+                            "previous bundle so a consumer doesn't act on a half-updated set.",
+                    )
+                }
             } else {
                 DiagLog.i(
                     TAG,
-                    "Holding back $nowTextTopic mirror for ${period.name.lowercase()} " +
-                        "bundle (now/image=$nowImageOutcome, now/audio=$nowAudioOutcome); " +
-                        "trigger topic stays at the previous bundle to keep the now set coherent.",
+                    "Holding back $nowTextTopic and $nowTimestampTopic mirrors for " +
+                        "${period.name.lowercase()} bundle (now/image=$nowImageOutcome, " +
+                        "now/audio=$nowAudioOutcome, now/video=$nowVideoOutcome, " +
+                        "videoSubmitted=${video != null}); the now set stays at the previous " +
+                        "bundle to keep it coherent.",
                 )
             }
         } else {
@@ -363,6 +452,12 @@ class MqttPublisher(
         fun audioTopicFor(baseTopic: String, period: ForecastPeriod): String =
             periodTopicFor(baseTopic, period, "audio")
 
+        // The muxed PNG-frame + TTS-audio MP4 — a single media item a
+        // consumer (e.g. HA) can hand straight to a Cast receiver / Home Hub
+        // so the outfit card and announcement play together.
+        fun videoTopicFor(baseTopic: String, period: ForecastPeriod): String =
+            periodTopicFor(baseTopic, period, "video")
+
         // `<base>/now/<kind>` mirrors the most recently published period
         // payload (today or tonight) so a consumer can subscribe to a single
         // topic without having to reason about which window is "current" or
@@ -372,6 +467,13 @@ class MqttPublisher(
         fun nowImageTopicFor(baseTopic: String): String = nowTopicForKind(baseTopic, "image")
 
         fun nowAudioTopicFor(baseTopic: String): String = nowTopicForKind(baseTopic, "audio")
+
+        fun nowVideoTopicFor(baseTopic: String): String = nowTopicForKind(baseTopic, "video")
+
+        // Epoch-millis (decimal string) of the most recent /now bundle. Not a
+        // payload modality — it's the recency marker consumers use to dedupe a
+        // retained bundle they've already acted on.
+        fun nowTimestampTopicFor(baseTopic: String): String = nowTopicForKind(baseTopic, "timestamp")
 
         private fun periodTopicFor(baseTopic: String, period: ForecastPeriod, kind: String): String {
             val trimmed = baseTopic.trim().trim('/').ifBlank { UserPreferences.DEFAULT_MQTT_TOPIC }
@@ -431,6 +533,14 @@ private suspend fun publishWithHiveMq(
                 .applySimpleAuth()
         }
         connect.send().await()
+        // TODO: revisit retention / QoS / TTL strategy now that the bundle
+        // carries audio + video. Everything is published QoS 1, retained — good
+        // for the image/text a dashboard reads on reconnect, but a retained
+        // audio/video clip means a freshly-reconnecting consumer can replay a
+        // stale announcement. The /now/timestamp topic is the current dedupe
+        // hook; longer term consider MQTT 5 (message-expiry as a real TTL,
+        // user-property timestamp) and per-kind retain/QoS rather than one
+        // policy for the whole bundle.
         client.publishWith()
             .topic(topic)
             .payload(payload)

--- a/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
@@ -26,6 +26,7 @@ import app.clothescast.core.domain.model.TtsEngine
 import app.clothescast.core.domain.model.UserPreferences
 import app.clothescast.calendar.resolveHolidayTheme
 import app.clothescast.cast.CastInsightController
+import app.clothescast.cast.Mp4Encoder
 import app.clothescast.core.domain.usecase.computeDeliveryGates
 import app.clothescast.core.domain.usecase.isGeminiEngineSelected
 import app.clothescast.core.domain.usecase.isMqttPublishable
@@ -612,8 +613,8 @@ class FetchAndNotifyWorker(
         //    household sees / hears the new forecast at the same
         //    wall-clock instant.
         //
-        //  Post-alignment — notification, MQTT prose / image / audio,
-        //    and the phone speaker fire in parallel. The MQTT publishes
+        //  Post-alignment — notification, MQTT prose / image / audio /
+        //    video, and the phone speaker fire in parallel. The MQTT publishes
         //    moved here from pre-alignment so HA's "speak the prose when
         //    the wardrobe opens" automation fires with the phone
         //    notification, not 30 s ahead of it.
@@ -643,6 +644,26 @@ class FetchAndNotifyWorker(
             val png: ByteArray? = renderDeferred.await()
             val wav: ByteArray? = pcm?.let { WavEncoder.encode(it) }
 
+            // Mux the outfit card + TTS audio into a single MP4 for the MQTT
+            // video topic, so a consumer (e.g. Home Assistant) can hand one
+            // media item to a Cast receiver / Home Hub and get the card and
+            // the announcement together. Muxing runs during the alignment
+            // wait below to stay off the post-alignment hot path, and only
+            // when the bridge will publish and both inputs exist. A mux
+            // failure degrades to a video-less bundle rather than failing the
+            // whole publish.
+            val mqttVideoDeferred: Deferred<ByteArray?>? =
+                if (gates.mqttPublishable && png != null && wav != null) {
+                    async(Dispatchers.Default) {
+                        runCatching { Mp4Encoder.encode(png, wav) }
+                            .onFailure { t ->
+                                if (t is CancellationException) throw t
+                                DiagLog.w(TAG, "MQTT video mux failed; publishing bundle without video.", t)
+                            }
+                            .getOrNull()
+                    }
+                } else null
+
             awaitDeliveryAlignment()
 
             val notifyJob = launch { postPeriodNotification(insight, prefs, prose, topColors, topStrokes, gates) }
@@ -667,7 +688,14 @@ class FetchAndNotifyWorker(
             val mqttDeferred: Deferred<MqttPublishOutcome?> = async {
                 if (!gates.mqttPublishable) null
                 else runCatching {
-                    app.mqttPublisher.publishIfEnabled(insight.period, prose, image = png, audio = wav)
+                    val video = mqttVideoDeferred?.await()
+                    app.mqttPublisher.publishIfEnabled(
+                        insight.period,
+                        prose,
+                        image = png,
+                        audio = wav,
+                        video = video,
+                    )
                 }
                     .onFailure { t ->
                         if (t is CancellationException) throw t

--- a/app/src/test/kotlin/app/clothescast/mqtt/MqttPublisherTest.kt
+++ b/app/src/test/kotlin/app/clothescast/mqtt/MqttPublisherTest.kt
@@ -446,6 +446,27 @@ class MqttPublisherTest {
     }
 
     @Test
+    fun `videoTopicFor and nowVideoTopicFor build video-suffixed topics`() {
+        MqttPublisher.videoTopicFor("clothescast/default", ForecastPeriod.TODAY) shouldBe
+            "clothescast/default/today/video"
+        MqttPublisher.videoTopicFor("home/forecast", ForecastPeriod.TONIGHT) shouldBe
+            "home/forecast/tonight/video"
+        MqttPublisher.videoTopicFor("", ForecastPeriod.TODAY) shouldBe
+            "clothescast/default/today/video"
+        MqttPublisher.nowVideoTopicFor("/clothescast/default/") shouldBe
+            "clothescast/default/now/video"
+    }
+
+    @Test
+    fun `nowTimestampTopicFor builds timestamp-suffixed now topic`() {
+        MqttPublisher.nowTimestampTopicFor("clothescast/default") shouldBe
+            "clothescast/default/now/timestamp"
+        MqttPublisher.nowTimestampTopicFor("home/forecast") shouldBe
+            "home/forecast/now/timestamp"
+        MqttPublisher.nowTimestampTopicFor("") shouldBe "clothescast/default/now/timestamp"
+    }
+
+    @Test
     fun `bundle with image publishes period prose and image, mirrors both with text last and audio cleared`() = runTest {
         val captured = mutableListOf<PublishCall>()
         val subject = MqttPublisher(
@@ -513,6 +534,155 @@ class MqttPublisherTest {
         val nowTextIdx = topics.indexOf("clothescast/default/now/text")
         nowTextIdx shouldBeGreaterThan topics.indexOf("clothescast/default/now/image")
         nowTextIdx shouldBeGreaterThan topics.indexOf("clothescast/default/now/audio")
+    }
+
+    @Test
+    fun `bundle with video publishes period and now video and a fresh now timestamp last`() = runTest {
+        val captured = mutableListOf<PublishCall>()
+        val subject = MqttPublisher(
+            preferences = flowOf(
+                basePrefs.copy(
+                    mqttBridgeEnabled = true,
+                    mqttHost = "broker.local",
+                    mqttTopic = "clothescast/default",
+                ),
+            ),
+            passwordProvider = { null },
+            publish = capturing(captured),
+        )
+        val fakeImage = byteArrayOf(0x89.toByte(), 0x50, 0x4E, 0x47)
+        val fakeWav = byteArrayOf(0x52, 0x49, 0x46, 0x46)
+        val fakeMp4 = byteArrayOf(0x00, 0x00, 0x00, 0x18) // ftyp box size prefix-ish
+
+        subject.publishIfEnabled(
+            ForecastPeriod.TODAY,
+            "prose",
+            image = fakeImage,
+            audio = fakeWav,
+            video = fakeMp4,
+        )
+
+        val topics = captured.map { it.topic }
+        topics shouldContainAll listOf(
+            "clothescast/default/today/video",
+            "clothescast/default/now/video",
+            "clothescast/default/now/timestamp",
+            "clothescast/default/now/text",
+        )
+        // now/video lands before now/text, and now/timestamp lands *last* of
+        // all — it's the commit marker a consumer triggers on, so it must
+        // follow every content mirror including now/text.
+        val nowTextIdx = topics.indexOf("clothescast/default/now/text")
+        nowTextIdx shouldBeGreaterThan topics.indexOf("clothescast/default/now/video")
+        topics.indexOf("clothescast/default/now/timestamp") shouldBeGreaterThan nowTextIdx
+        // Period + now video carry the muxed MP4 bytes verbatim.
+        captured.first { it.topic == "clothescast/default/today/video" }.payload contentEquals fakeMp4 shouldBe true
+        captured.first { it.topic == "clothescast/default/now/video" }.payload contentEquals fakeMp4 shouldBe true
+        // Timestamp is a non-empty decimal epoch-millis string.
+        val ts = captured.first { it.topic == "clothescast/default/now/timestamp" }.payload.decodeToString()
+        ts.toLongOrNull().shouldBeInstanceOf<Long>()
+    }
+
+    @Test
+    fun `video absent clears now video with empty payload`() = runTest {
+        val captured = mutableListOf<PublishCall>()
+        val subject = MqttPublisher(
+            preferences = flowOf(
+                basePrefs.copy(mqttBridgeEnabled = true, mqttHost = "broker.local"),
+            ),
+            passwordProvider = { null },
+            publish = capturing(captured),
+        )
+
+        subject.publishIfEnabled(ForecastPeriod.TODAY, "prose")
+
+        // No period video topic is touched when no video is submitted, but the
+        // now/video mirror is cleared so a stale clip can't outlive its bundle.
+        captured.none { it.topic == "clothescast/default/today/video" }.shouldBeTrue()
+        captured.first { it.topic == "clothescast/default/now/video" }.payload.size shouldBe 0
+    }
+
+    @Test
+    fun `now video clear failure holds back the marker so a stale video can't outlive its bundle`() = runTest {
+        // Even with no video this delivery, now/video carries an empty "delete
+        // retained" clear and still gates the marker: if that clear fails, a
+        // stale video from a prior bundle could otherwise survive and pair with
+        // the fresh timestamp. So now/text and now/timestamp are held back.
+        val captured = mutableListOf<PublishCall>()
+        val subject = MqttPublisher(
+            preferences = flowOf(
+                basePrefs.copy(mqttBridgeEnabled = true, mqttHost = "broker.local"),
+            ),
+            passwordProvider = { null },
+            publish = { config, topic, payload ->
+                captured.add(PublishCall(config, topic, payload))
+                if (topic == "clothescast/default/now/video") error("now/video clear rejected")
+            },
+            retryDelayMs = 1L,
+        )
+
+        val outcome = subject.publishIfEnabled(ForecastPeriod.TODAY, "prose")
+
+        outcome shouldBe MqttPublishOutcome.Success
+        captured.none { it.topic == "clothescast/default/now/text" }.shouldBeTrue()
+        captured.none { it.topic == "clothescast/default/now/timestamp" }.shouldBeTrue()
+    }
+
+    @Test
+    fun `now text and timestamp held back when a submitted video's now mirror fails`() = runTest {
+        // When a video *was* produced this delivery, now/video gates the
+        // commit marker — a consumer that triggers on now/timestamp must not
+        // act on a bundle whose video failed to publish.
+        val captured = mutableListOf<PublishCall>()
+        val subject = MqttPublisher(
+            preferences = flowOf(
+                basePrefs.copy(mqttBridgeEnabled = true, mqttHost = "broker.local"),
+            ),
+            passwordProvider = { null },
+            publish = { config, topic, payload ->
+                captured.add(PublishCall(config, topic, payload))
+                if (topic == "clothescast/default/now/video") error("now/video mirror failure")
+            },
+            retryDelayMs = 1L,
+        )
+
+        val outcome = subject.publishIfEnabled(
+            ForecastPeriod.TODAY,
+            "prose",
+            image = byteArrayOf(0x89.toByte(), 0x50, 0x4E, 0x47),
+            audio = byteArrayOf(0x52, 0x49, 0x46, 0x46),
+            video = byteArrayOf(0x00, 0x00, 0x00, 0x18),
+        )
+
+        outcome shouldBe MqttPublishOutcome.Success
+        captured.none { it.topic == "clothescast/default/now/text" }.shouldBeTrue()
+        captured.none { it.topic == "clothescast/default/now/timestamp" }.shouldBeTrue()
+    }
+
+    @Test
+    fun `now timestamp mirror failure does not override period success outcome`() = runTest {
+        // The commit marker advances last; if it fails the content mirrors have
+        // already settled, so the prose primary's Success still stands (the
+        // failure is logged, not surfaced as the call's outcome).
+        val captured = mutableListOf<PublishCall>()
+        val subject = MqttPublisher(
+            preferences = flowOf(
+                basePrefs.copy(mqttBridgeEnabled = true, mqttHost = "broker.local"),
+            ),
+            passwordProvider = { null },
+            publish = { config, topic, payload ->
+                captured.add(PublishCall(config, topic, payload))
+                if (topic.endsWith("/now/timestamp")) error("commit marker rejected")
+            },
+            retryDelayMs = 1L,
+        )
+
+        val outcome = subject.publishIfEnabled(ForecastPeriod.TODAY, "prose")
+
+        outcome shouldBe MqttPublishOutcome.Success
+        // now/text still landed (content advanced); the marker exhausts retries.
+        captured.any { it.topic == "clothescast/default/now/text" }.shouldBeTrue()
+        captured.count { it.topic == "clothescast/default/now/timestamp" } shouldBe 2
     }
 
     @Test
@@ -658,15 +828,18 @@ class MqttPublisherTest {
         val outcome = subject.publishIfEnabled(ForecastPeriod.TODAY, "x")
 
         outcome shouldBe MqttPublishOutcome.Success
-        // Period prose retries once, then the /now bundle (image clear, audio
-        // clear, text) all succeed. First two attempts are the retried period
-        // publish; the remaining three are the coordinated /now mirrors.
+        // Period prose retries once, then the /now bundle (image/audio/video
+        // clears, text, then timestamp last as the commit marker) all succeed.
+        // First two attempts are the retried period publish; the rest are the
+        // coordinated /now mirrors.
         attempts.map { it.topic } shouldBe listOf(
             "clothescast/default/today/text",
             "clothescast/default/today/text",
             "clothescast/default/now/image",
             "clothescast/default/now/audio",
+            "clothescast/default/now/video",
             "clothescast/default/now/text",
+            "clothescast/default/now/timestamp",
         )
     }
 
@@ -706,12 +879,15 @@ class MqttPublisherTest {
 
         subject.publishIfEnabled(ForecastPeriod.TODAY, "x") shouldBe MqttPublishOutcome.Success
         // No retries on the period publish; the remaining attempts are the
-        // coordinated /now bundle (image clear, audio clear, then text last).
+        // coordinated /now bundle (image/audio/video clears, text, then
+        // timestamp last as the commit marker).
         attempts shouldBe listOf(
             "clothescast/default/today/text",
             "clothescast/default/now/image",
             "clothescast/default/now/audio",
+            "clothescast/default/now/video",
             "clothescast/default/now/text",
+            "clothescast/default/now/timestamp",
         )
     }
 

--- a/docs/smart-home.md
+++ b/docs/smart-home.md
@@ -32,33 +32,45 @@ yourself; no developer-operated service ever sees the payload.
    key uses.
 5. Topic prefix defaults to `clothescast/default`. Today's forecast
    publishes to `<prefix>/today/text`; tonight's to `<prefix>/tonight/text`.
-   The outfit image and TTS audio (when published) land on
-   `<prefix>/<period>/image` and `<prefix>/<period>/audio` respectively.
+   The outfit image, the TTS audio, and a combined card-plus-announcement
+   MP4 (when published) land on `<prefix>/<period>/image`,
+   `<prefix>/<period>/audio`, and `<prefix>/<period>/video` respectively.
    Each fully-successful publish is also mirrored to `<prefix>/now/<kind>` —
-   `<prefix>/now/text`, `<prefix>/now/image`, `<prefix>/now/audio` —
-   so a consumer can subscribe to a single "latest" topic without
-   having to switch on today vs tonight or chase recency timestamps.
-   Whichever period most recently published is what `now` reflects.
-   The `now` set updates as an atomic bundle: `now/text` is published
-   *last* (after `now/image` / `now/audio`), so an HA automation
-   triggered on `now/text` reads a `now/image` / `now/audio` from the
-   same forecast rather than a stale payload from the previous period.
+   `<prefix>/now/text`, `<prefix>/now/image`, `<prefix>/now/audio`,
+   `<prefix>/now/video`, and `<prefix>/now/timestamp` — so a consumer can
+   subscribe to a single "latest" topic without having to switch on today
+   vs tonight. Whichever period most recently published is what `now`
+   reflects.
+
+   **Trigger your automations on `<prefix>/now/timestamp`.** The `now`
+   set updates as an atomic bundle, and `now/timestamp` (epoch
+   milliseconds, as a string) is written *last of all* — only after
+   `now/image`, `now/audio`, `now/video`, and `now/text` have each
+   settled. So a change on `now/timestamp` is the single signal that the
+   whole bundle is in place: trigger on it and read the sibling `now/*`
+   topics, and you'll never pick up a `now/image` / `now/audio` /
+   `now/video` / `now/text` left over from a different forecast. It also
+   doubles as a dedupe key — every topic is **retained**, so a consumer
+   that reconnects (HA restart, network blip) is re-delivered the last
+   bundle on connect; remembering the last `now/timestamp` you acted on
+   lets you skip re-announcing it rather than replaying a stale clip at
+   reboot.
+
    Modalities absent from the current delivery (e.g. an outfit render
    failed, or you're on device TTS so no audio bytes exist) clear their
    `now/*` slot with an empty retained payload — MQTT's convention for
-   "delete the retained message" — so a `now/text` consumer never reads
-   a stale image/audio left over from a previous bundle. `now/text` is
-   additionally held back if either `now/image` or `now/audio` mirror
-   publish fails, so a `now/text` update always implies a coherent
-   image/audio pair settled successfully. If any period publish in the
-   bundle fails outright, the entire `now` mirror is skipped — the
-   previous fully-successful `now` set stays intact rather than being
-   half-overwritten. MQTT itself has no transactional primitive across
-   topics, so a fresh-reconnect consumer reading all three retained
-   `now/*` topics during a partial-failure window (e.g. broker accepts
-   `now/image` but rejects `now/audio`) may briefly observe a mismatch;
-   subscribing continuously to `now/text` and gating reads on its
-   updates sidesteps this.
+   "delete the retained message" — so you never read a stale
+   image/audio/video left over from a previous bundle. `now/text` is held
+   back if any of `now/image` / `now/audio` / `now/video` fails, and
+   `now/timestamp` is held back if `now/text` fails, so a `now/timestamp`
+   update always implies a fully coherent bundle settled successfully. If
+   any period publish in the bundle fails outright, the entire `now`
+   mirror is skipped — the previous fully-successful `now` set stays
+   intact rather than being half-overwritten. MQTT itself has no
+   transactional primitive across topics, so a fresh-reconnect consumer
+   reading the retained `now/*` topics during a partial-failure window may
+   briefly observe a mismatch; triggering on `now/timestamp` — the last
+   write — and gating reads on its updates sidesteps this.
 6. Tap **Save**.
 
 The next scheduled refresh (07:00 by default for today, 19:00 for
@@ -153,17 +165,44 @@ mqtt:
       value_template: "{{ value }}"
     # Single "latest" sensor — mirrors whichever period last published, so
     # an automation can speak the most recent forecast without branching
-    # on today vs tonight or comparing timestamps.
+    # on today vs tonight.
     - name: "Clothescast now"
       unique_id: clothescast_now
       state_topic: "clothescast/default/now/text"
       value_template: "{{ value }}"
+    # Commit marker — epoch-millis written *last* once the whole `now`
+    # bundle is in place. Trigger your automations on a state change of
+    # this sensor (not on the prose sensor) when you want them to fire on
+    # each new forecast: by the time it changes, now/text, now/image,
+    # now/audio, and now/video are all settled and coherent.
+    - name: "Clothescast now updated"
+      unique_id: clothescast_now_updated
+      state_topic: "clothescast/default/now/timestamp"
+      device_class: timestamp
+      # Topic carries epoch milliseconds; the timestamp device_class wants a
+      # timezone-aware datetime, which as_datetime() returns (UTC) for a
+      # numeric unix timestamp in seconds.
+      value_template: "{{ as_datetime((value | int) / 1000) }}"
 ```
 
 Restart Home Assistant or reload MQTT entries; the sensors should
 populate within seconds of the next ClothesCast refresh (or instantly,
 if you've already done one — retained messages are delivered to new
 subscribers on connect).
+
+To fire an automation each time a fresh forecast lands, trigger on the
+commit marker rather than the prose sensor:
+
+```yaml
+triggers:
+  - trigger: state
+    entity_id: sensor.clothescast_now_updated
+```
+
+This guarantees every `now/*` topic is already in place when the
+automation runs, and — because the marker only advances on a genuinely
+new bundle — it won't re-fire when HA reconnects and re-reads the
+retained set.
 
 ## Home Assistant — outfit image on Nest Hub
 
@@ -251,6 +290,49 @@ shape.
 > (`https://your-ha.duckdns.org`) instead. The camera proxy path and
 > access token are the same either way.
 
+## Home Assistant — combined card + announcement video
+
+For a Nest Hub, the tidiest result is one media item that shows the
+outfit card *and* plays the spoken briefing over it, with no parallel
+TTS + image dance. ClothesCast publishes exactly that to
+`<prefix>/<period>/video` (mirrored to `<prefix>/now/video`): an MP4
+with the 800 × 480 outfit card as a static video frame and the Gemini
+TTS audio as the audio track. Hand it to a Cast receiver and the card
+fills the screen while the forecast plays.
+
+This is published only when **both** an outfit image and Gemini TTS
+audio exist for the delivery (Gemini engine selected, audio not
+suppressed by "don't speak at home"); otherwise the slot is cleared
+with an empty retained payload like any other absent modality.
+
+Like the audio clip, `media_player.play_media` needs an HTTP URL and HA
+won't read an MQTT binary payload into the media player directly — so
+the MP4 has to land somewhere HA serves over HTTP (e.g.
+`config/www/clothescast_now.mp4`, fetchable at
+`http://<ha-ip>:8123/local/clothescast_now.mp4`). Use the same
+write-to-file recipe as the audio clip below (Node-RED `mqtt in` →
+`file`, or a `shell_command` running `mosquitto_sub`), pointed at
+`clothescast/default/now/video`, then cast it:
+
+```yaml
+triggers:
+  - trigger: state
+    entity_id: sensor.clothescast_now_updated
+
+actions:
+  - action: media_player.play_media
+    target:
+      entity_id: media_player.kitchen_hub
+    data:
+      media_content_id: "http://192.168.x.x:8123/local/clothescast_now.mp4"
+      media_content_type: video/mp4
+```
+
+> **The card disappears when the clip ends.** A Cast receiver returns to
+> its idle / photo screen once the MP4 finishes, so the card stays up
+> only for the length of the announcement. Keeping it up longer is a
+> known follow-up (a configurable post-speech hold baked into the clip).
+
 ## Home Assistant — TTS audio clip on the audio topic
 
 When the Gemini TTS engine is selected (Settings → Voice → Gemini),
@@ -276,9 +358,11 @@ Two things to know before you wire anything up:
   even when you're home.
 
 The simplest way to make the Hub actually speak is still options A /
-B / C below: trigger an automation on the prose sensor's update and
-let HA's TTS service synthesise — that path is already paved end to
-end. The audio topic is here for setups that already prefer a fixed
+B / C below: trigger an automation on the `now/timestamp` commit marker
+(the `sensor.clothescast_now_updated` sensor above) and let HA's TTS
+service synthesise — that path is already paved end to end. Triggering
+on the commit marker rather than the prose sensor guarantees the audio
+and image are already in place when the automation runs. The audio topic is here for setups that already prefer a fixed
 voice clip over re-synthesising in HA (e.g. `music_assistant.play_announcement`
 → media URL flows), and for users who want to capture the rendered
 briefing for their own pipelines.


### PR DESCRIPTION
## Summary

Lets the MQTT bridge publish the outfit card **and** the spoken announcement as a single MP4, so a consumer (e.g. Home Assistant) can hand one media item to a Cast receiver / Google Home Hub and get the card on screen with the insight playing over it — without the phone doing Cast discovery or hosting an HTTP server.

- `MqttPublisher.publishIfEnabled` gains an optional `video` modality, published to `<base>/<period>/video` and mirrored to `<base>/now/video`.
- Adds `<base>/now/timestamp` (epoch-millis), written **last** in the `now` bundle — after `now/image`, `now/audio`, `now/video`, and `now/text` have all settled. It's the **commit marker**: consumers trigger on it and read the sibling `now/*` topics (guaranteeing a coherent bundle) and dedupe by its value so a reconnecting consumer doesn't replay a stale announcement. (MQTT 3.1.1 has no native publish timestamp.)
- **`now/video` always gates the marker** — its payload is the video when one was produced and an empty "delete retained" clear when not. Gating on the clear too is what keeps the set coherent: the timestamp never advances while a stale video from a prior bundle could still be retained. (Tradeoff: a hand-rolled per-topic ACL that denies `now/video` would stall the bundle — narrow, since the setup guide grants `<prefix>/#`, and logged.)
- A `now/timestamp` publish that fails after the content mirrors advanced is logged at warn (the one missed-update case the trigger contract must surface); it doesn't change the returned outcome, which tracks the prose primary.
- `FetchAndNotifyWorker` reuses the existing `Mp4Encoder` to mux the card PNG + TTS WAV during the alignment wait (off the hot path); a mux failure clears `now/video` and degrades to a video-less bundle rather than failing the publish.
- Left a `TODO` to revisit retain / QoS / TTL now that the bundle carries audio + video (topics stay retained for now).
- **Docs:** `docs/smart-home.md` documents the new `now/video` topic, tells consumers to trigger on `now/timestamp` (ready-to-paste HA timestamp sensor + a `now/video`→Hub cast recipe); `PRIVACY.md`'s payload description now accurately reflects image/audio/video.

## Review follow-ups

- **P1 (Codex):** kept `now/video` gating rather than best-effort — coherence of the `now` set is the priority; rationale on the thread.
- **P2 (Codex):** `now/timestamp` publish failure is now captured and logged.

## Privacy

No new data leaves the device. The MP4 only repackages the outfit-card image and TTS audio the bridge **already** publishes on the `image` and `audio` topics, and the whole bridge stays behind its opt-in toggle.

## Notes / follow-ups

- The card disappears on the Hub when the MP4 ends; a configurable post-speech "hold" tail in `Mp4Encoder` is a natural follow-up to keep it up longer (noted in the docs and the `TODO`).

## Test plan

- [x] `:app:testDebugUnitTest` (incl. `MqttPublisherTest` video/timestamp + gating/coherence cases)
- [x] `:core:domain:test` `:core:data:test`
- [ ] CI green on the latest push
- [ ] End-to-end: HA triggers on `now/timestamp`, casts `now/video` to a Home Hub

https://claude.ai/code/session_01U8YNz6Y4ySP1wjaxAaeK2J