### PR TITLE
Say it will be the same as yesterday when nothing else changed

### DIFF
--- a/app/src/main/kotlin/app/clothescast/insight/InsightFormatter.kt
+++ b/app/src/main/kotlin/app/clothescast/insight/InsightFormatter.kt
@@ -67,8 +67,20 @@ class InsightFormatter(
      * and rendering "Today, …" would be wrong. The TONIGHT lead is left alone:
      * the worker never pairs a primary insight with tomorrow night, so the only
      * tomorrow-shaped payload that reaches the formatter is a daytime one.
+     *
+     * When no clause produces any prose (only reachable with [RangeFormat.NONE],
+     * where the temperature range is dropped and nothing else fired),
+     * [placeholderWhenEmpty] decides what comes back. Display surfaces (Today
+     * screen, smart-display / cast card, notification) want a visible
+     * "Today, it will be the same as yesterday." line so the card never renders
+     * blank; the spoken TTS path passes `false` to stay silent rather than read
+     * out a content-free filler line.
      */
-    fun format(summary: InsightSummary, isFutureDay: Boolean = false): String {
+    fun format(
+        summary: InsightSummary,
+        isFutureDay: Boolean = false,
+        placeholderWhenEmpty: Boolean = true,
+    ): String {
         // Accessories (umbrella, etc.) are filtered out of the rendered prose
         // entirely — we only surface temperature-driven clothing for now. The
         // user's umbrella rule still triggers and the precip clause still
@@ -129,7 +141,19 @@ class InsightFormatter(
         } else {
             (primaryClauses + tieInClauses).joinToString(" ")
         }
-        return listOfNotNull(alert, body.ifBlank { null }).joinToString(" ")
+        val rendered = listOfNotNull(alert, body.ifBlank { null }).joinToString(" ")
+        if (rendered.isNotBlank()) return rendered
+        // Nothing fired. Display surfaces show a "Today, it will be the same as
+        // yesterday." line so the card isn't blank; TTS opts out via
+        // placeholderWhenEmpty=false to stay silent.
+        if (!placeholderWhenEmpty) return ""
+        return resources.getString(unchangedRes(summary.period, isFutureDay))
+    }
+
+    private fun unchangedRes(period: ForecastPeriod, isFutureDay: Boolean): Int = when (period) {
+        ForecastPeriod.TODAY ->
+            if (isFutureDay) R.string.insight_unchanged_tomorrow else R.string.insight_unchanged_today
+        ForecastPeriod.TONIGHT -> R.string.insight_unchanged_tonight
     }
 
     /**
@@ -140,7 +164,9 @@ class InsightFormatter(
      * they already front their own "Tonight, …" lead, so prepending the day
      * lead would double it. When there's no daytime clause the tie-ins stand
      * on their own ("Tonight, bring a jacket."); when nothing survives at all
-     * the lead stands alone as "Today." so the prose is never empty.
+     * the body is empty — [format] turns that into "Today, it will be the same
+     * as yesterday." for display or an empty string for TTS, so we never emit a
+     * bare "Today." that tells the user nothing.
      */
     private fun renderLeadOnly(
         period: ForecastPeriod,
@@ -151,7 +177,6 @@ class InsightFormatter(
     ): String {
         val lead = resources.getString(leadRes(period, isFutureDay))
         if (primaryClauses.isEmpty()) {
-            if (tieInClauses.isEmpty()) return resources.getString(R.string.insight_lead_only, lead)
             return tieInClauses.joinToString(" ")
         }
         // A self-leading first clause (a localized full-sentence delta) already

--- a/app/src/main/kotlin/app/clothescast/tts/InsightTtsUtterance.kt
+++ b/app/src/main/kotlin/app/clothescast/tts/InsightTtsUtterance.kt
@@ -38,12 +38,14 @@ internal fun insightTtsUtterance(
     val regionLocale = region.toJavaLocale() ?: fallbackLocale
     val locale = voiceLocale.resolve(regionLocale)
     val forecast = InsightFormatter.forContext(context, locale, temperatureUnit, rangeFormat)
-        .format(summary)
+        // Spoken playback stays silent when nothing fired — no "it will be the
+        // same as yesterday." filler read aloud — unlike the display surfaces.
+        .format(summary, placeholderWhenEmpty = false)
     // Override country tracks the app region (mirrors HolidayBanner) while the
     // greeting's language follows the voice locale.
     val greeting = holidayTtsGreeting(context, holidayTheme, locale, regionLocale.country)
     return InsightTtsUtterance(
-        text = if (greeting == null) forecast else "$greeting $forecast",
+        text = listOfNotNull(greeting, forecast.ifBlank { null }).joinToString(" "),
         locale = locale,
     )
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -975,9 +975,15 @@
          ("Today"), %2$s = the following clause with its first letter lowercased
          ("wear a sweater."), giving "Today, wear a sweater.". -->
     <string name="insight_lead_continues">%1$s, %2$s</string>
-    <!-- Lead with nothing to introduce (range omitted and no other clause fired):
-         %1$s = lead-in, rendered as a standalone "Today.". -->
-    <string name="insight_lead_only">%1$s.</string>
+    <!-- Shown on display surfaces (Today screen, smart-display / cast card,
+         notification) when the range is omitted and no other clause fired, so
+         the card isn't blank. The spoken TTS path stays silent instead. The
+         comparison reference tracks the period: "yesterday" for the daytime
+         pass, "last night" for the evening pass, "today" for the page-2
+         tomorrow pass. -->
+    <string name="insight_unchanged_today">Today, it will be the same as yesterday.</string>
+    <string name="insight_unchanged_tonight">Tonight, it will be the same as last night.</string>
+    <string name="insight_unchanged_tomorrow">Tomorrow, it will be the same as today.</string>
 
     <!-- Band labels — used inside the band-sentence templates above. -->
     <string name="insight_band_freezing">freezing</string>

--- a/app/src/test/kotlin/app/clothescast/insight/InsightFormatterTest.kt
+++ b/app/src/test/kotlin/app/clothescast/insight/InsightFormatterTest.kt
@@ -350,8 +350,35 @@ class InsightFormatterTest {
     }
 
     @Test
-    fun `omit range with no other clause leaves a bare lead`() {
-        omitSubject.format(summary()) shouldBe "Today."
+    fun `omit range with no other clause shows the unchanged line by default`() {
+        // A lone period word ("Today.") carries no information; display surfaces
+        // get a full "the same as yesterday." line instead so the card isn't blank.
+        omitSubject.format(summary()) shouldBe "Today, it will be the same as yesterday."
+    }
+
+    @Test
+    fun `omit range with no other clause compares to last night for tonight`() {
+        omitSubject.format(summary(period = ForecastPeriod.TONIGHT)) shouldBe
+            "Tonight, it will be the same as last night."
+    }
+
+    @Test
+    fun `omit range with no other clause compares to today on a future day`() {
+        omitSubject.format(summary(), isFutureDay = true) shouldBe
+            "Tomorrow, it will be the same as today."
+    }
+
+    @Test
+    fun `omit range with no other clause emits nothing when placeholder is opted out`() {
+        // The TTS path opts out so spoken playback stays silent rather than
+        // reading out a content-free filler line.
+        omitSubject.format(summary(), placeholderWhenEmpty = false) shouldBe ""
+    }
+
+    @Test
+    fun `omit range with no clause but an alert still emits the alert`() {
+        omitSubject.format(summary(alert = AlertClause("Tornado Warning"))) shouldBe
+            "Alert: Tornado Warning."
     }
 
     @Test

--- a/app/src/test/kotlin/app/clothescast/tts/InsightTtsUtteranceTest.kt
+++ b/app/src/test/kotlin/app/clothescast/tts/InsightTtsUtteranceTest.kt
@@ -9,6 +9,7 @@ import app.clothescast.core.domain.model.ForecastPeriod
 import app.clothescast.core.domain.model.HolidayCatalog
 import app.clothescast.core.domain.model.HolidayId
 import app.clothescast.core.domain.model.InsightSummary
+import app.clothescast.core.domain.model.RangeFormat
 import app.clothescast.core.domain.model.Region
 import app.clothescast.core.domain.model.TemperatureBand
 import app.clothescast.core.domain.model.VoiceLocale
@@ -125,6 +126,44 @@ class InsightTtsUtteranceTest {
         )
 
         utterance.text shouldBe "Honoring our Veterans. Today, it will be 8° to 15°. Wear a jumper and jacket."
+    }
+
+    @Test
+    fun `nothing-to-say insight stays silent rather than speaking a placeholder`() {
+        // RangeFormat.NONE drops the band; with no other clause the spoken
+        // briefing is empty (the display card shows "Today, it will be the same
+        // as yesterday.").
+        val utterance = insightTtsUtterance(
+            context = context,
+            summary = InsightSummary(
+                period = ForecastPeriod.TODAY,
+                band = BandClause(TemperatureBand.COLD, TemperatureBand.COOL),
+            ),
+            region = Region.EN_GB,
+            voiceLocale = VoiceLocale.SYSTEM,
+            fallbackLocale = Locale.US,
+            rangeFormat = RangeFormat.NONE,
+        )
+
+        utterance.text shouldBe ""
+    }
+
+    @Test
+    fun `nothing-to-say insight still speaks the holiday greeting alone`() {
+        val utterance = insightTtsUtterance(
+            context = context,
+            summary = InsightSummary(
+                period = ForecastPeriod.TODAY,
+                band = BandClause(TemperatureBand.COLD, TemperatureBand.COOL),
+            ),
+            region = Region.EN_GB,
+            voiceLocale = VoiceLocale.SYSTEM,
+            fallbackLocale = Locale.US,
+            rangeFormat = RangeFormat.NONE,
+            holidayTheme = christmas,
+        )
+
+        utterance.text shouldBe "Merry Christmas!"
     }
 
     private companion object {


### PR DESCRIPTION
## Summary

When the temperature range is omitted (`RangeFormat.NONE`) and no other clause fires, the insight previously collapsed to a bare lead word — `Today.` / `Tonight.` — which tells the user nothing.

- **Display surfaces** (Today screen, smart-display / cast card, notification) now render a full sentence so the card never reads as a lone period word:
  - daytime → `Today, it will be the same as yesterday.`
  - evening → `Tonight, it will be the same as last night.`
  - page-2 tomorrow → `Tomorrow, it will be the same as today.`
- **Spoken TTS** stays silent instead — a new `placeholderWhenEmpty` flag on `InsightFormatter.format()` (default `true` for display) is set to `false` by the TTS path, so the briefing reads nothing rather than the content-free filler line.
- Drops the now-unused `insight_lead_only` string.

## Privacy

Net reduction in what leaves the device: the TTS path now sends *less* prose to the off-device TTS engine (nothing, rather than a filler line) in this case. No new fields cross the device boundary.

## Localization

The new `insight_unchanged_*` strings are added to the default `values/` only; other locales fall back to English, matching the prior English-only `insight_lead_only`.

## Test plan

- [x] `InsightFormatterTest` — new cases cover the today / tonight / tomorrow display lines and the TTS opt-out returning empty
- [x] `InsightTtsUtteranceTest` — nothing-to-say insight stays silent; holiday greeting still speaks alone
- [x] Full `:app:testDebugUnitTest` green locally
- [ ] CI: JVM unit tests + Android debug build

https://claude.ai/code/session_01G6XUPpxTP1gWSexCVHKr5i

---
_Generated by [Claude Code](https://claude.ai/code/session_01G6XUPpxTP1gWSexCVHKr5i)_