### PR TITLE
Translate the unchanged-forecast line into all supported languages

### DIFF
--- a/app/src/main/res/values-am/strings.xml
+++ b/app/src/main/res/values-am/strings.xml
@@ -372,6 +372,9 @@ The rest of the UI falls through to values/strings.xml (English).
     <!-- Insight prose -->
     <string name="insight_lead_today">ዛሬ</string>
     <string name="insight_lead_tomorrow">ነገ</string>
+    <string name="insight_unchanged_today">ዛሬ እንደ ትናንቱ ይሆናል።</string>
+    <string name="insight_unchanged_tonight">ዛሬ ምሽት እንደ ትናንት ምሽቱ ይሆናል።</string>
+    <string name="insight_unchanged_tomorrow">ነገ እንደ ዛሬው ይሆናል።</string>
     <string name="insight_lead_tonight">ዛሬ ምሽት</string>
     <!-- Amharic: "ዛሬ ምቹ ይሆናል።" -->
     <string name="insight_band_single">%1$s %2$d° ይሆናል።</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -51,6 +51,9 @@ they work correctly in both the single-band and range templates.
 
     <string name="insight_lead_today">اليوم</string>
     <string name="insight_lead_tomorrow">غدًا</string>
+    <string name="insight_unchanged_today">اليوم سيكون الجو مثل الأمس.</string>
+    <string name="insight_unchanged_tonight">الليلة سيكون الجو مثل الليلة الماضية.</string>
+    <string name="insight_unchanged_tomorrow">غدًا سيكون الجو مثل اليوم.</string>
     <string name="insight_lead_tonight">الليلة</string>
     <!-- "اليوم سيكون الجو معتدل." -->
     <string name="insight_band_single">%1$s سيكون الجو %2$d°.</string>

--- a/app/src/main/res/values-b+sr+Latn/strings.xml
+++ b/app/src/main/res/values-b+sr+Latn/strings.xml
@@ -73,6 +73,9 @@ default English (matching values-pl / values-uk).
 
     <string name="insight_lead_today">Danas</string>
     <string name="insight_lead_tomorrow">Sutra</string>
+    <string name="insight_unchanged_today">Danas će biti isto kao juče.</string>
+    <string name="insight_unchanged_tonight">Večeras će biti isto kao sinoć.</string>
+    <string name="insight_unchanged_tomorrow">Sutra će biti isto kao danas.</string>
     <string name="insight_lead_tonight">Večeras</string>
     <string name="insight_band_single">%1$s će biti %2$d°.</string>
     <string name="insight_band_range">%1$s će biti od %2$d° do %3$d°.</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -59,6 +59,9 @@ What is NOT overridden, by design:
 
     <string name="insight_lead_today">Днес</string>
     <string name="insight_lead_tomorrow">Утре</string>
+    <string name="insight_unchanged_today">Днес ще бъде същото като вчера.</string>
+    <string name="insight_unchanged_tonight">Тази вечер ще бъде същото като снощи.</string>
+    <string name="insight_unchanged_tomorrow">Утре ще бъде същото като днес.</string>
     <string name="insight_lead_tonight">Тази вечер</string>
     <string name="insight_band_single">%1$s ще бъде %2$d°.</string>
     <string name="insight_band_range">%1$s ще бъде от %2$d° до %3$d°.</string>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -47,6 +47,9 @@ West Bengal vocabulary differences in a future PR.
 
     <string name="insight_lead_today">আজ</string>
     <string name="insight_lead_tomorrow">আগামীকাল</string>
+    <string name="insight_unchanged_today">আজ আবহাওয়া গতকালের মতোই থাকবে।</string>
+    <string name="insight_unchanged_tonight">আজ রাতে আবহাওয়া গত রাতের মতোই থাকবে।</string>
+    <string name="insight_unchanged_tomorrow">আগামীকাল আবহাওয়া আজকের মতোই থাকবে।</string>
     <string name="insight_lead_tonight">আজ রাতে</string>
     <!-- "আজ আবহাওয়া মনোরম থাকবে।" -->
     <string name="insight_band_single">%1$s আবহাওয়া %2$d° থাকবে।</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -489,6 +489,9 @@ the in-app clock is digit-driven and reads consistently across locales.
 
     <string name="insight_lead_today">Avui</string>
     <string name="insight_lead_tomorrow">Demà</string>
+    <string name="insight_unchanged_today">Avui farà el mateix temps que ahir.</string>
+    <string name="insight_unchanged_tonight">Aquesta nit farà el mateix temps que anit.</string>
+    <string name="insight_unchanged_tomorrow">Demà farà el mateix temps que avui.</string>
     <string name="insight_lead_tonight">Aquesta nit</string>
     <!-- Catalan weather-as-verb: "Avui farà fred." (today will-make cold). -->
     <string name="insight_band_single">%1$s farà %2$d°.</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -539,6 +539,9 @@ locale (Angličtina (USA), Francouzština (Francie), Němčina (Německo), …).
     <!-- Insight prose templates. -->
     <string name="insight_lead_today">Dnes</string>
     <string name="insight_lead_tomorrow">Zítra</string>
+    <string name="insight_unchanged_today">Dnes bude stejně jako včera.</string>
+    <string name="insight_unchanged_tonight">Dnes večer bude stejně jako včera večer.</string>
+    <string name="insight_unchanged_tomorrow">Zítra bude stejně jako dnes.</string>
     <string name="insight_lead_tonight">Dnes večer</string>
     <string name="insight_band_single">%1$s bude %2$d°.</string>
     <string name="insight_band_range">%1$s bude od %2$d° do %3$d°.</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -542,6 +542,9 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrig)").
     <!-- Insight prose templates. -->
     <string name="insight_lead_today">I dag</string>
     <string name="insight_lead_tomorrow">I morgen</string>
+    <string name="insight_unchanged_today">I dag bliver det det samme som i går.</string>
+    <string name="insight_unchanged_tonight">I aften bliver det det samme som i går aftes.</string>
+    <string name="insight_unchanged_tomorrow">I morgen bliver det det samme som i dag.</string>
     <string name="insight_lead_tonight">I aften</string>
     <!-- Danish V2 word order: "I dag bliver det mildt." -->
     <string name="insight_band_single">%1$s bliver det %2$d°.</string>

--- a/app/src/main/res/values-de-rAT/strings.xml
+++ b/app/src/main/res/values-de-rAT/strings.xml
@@ -420,6 +420,9 @@ zh-CN) is unchanged; only the displayed label localizes.
     <!-- Insight prose templates — German equivalents of the keys in values/strings.xml. -->
     <string name="insight_lead_today">Heute</string>
     <string name="insight_lead_tomorrow">Morgen</string>
+    <string name="insight_unchanged_today">Heute wird es genauso wie gestern.</string>
+    <string name="insight_unchanged_tonight">Heute Abend wird es genauso wie gestern Abend.</string>
+    <string name="insight_unchanged_tomorrow">Morgen wird es genauso wie heute.</string>
     <string name="insight_lead_tonight">Heute Abend</string>
 
     <!-- "Heute wird es mild." / "Heute wird es kühl bis mild." Subject-second

--- a/app/src/main/res/values-de-rCH/strings.xml
+++ b/app/src/main/res/values-de-rCH/strings.xml
@@ -425,6 +425,9 @@ zh-CN) is unchanged; only the displayed label localizes.
     <!-- Insight prose templates — German equivalents of the keys in values/strings.xml. -->
     <string name="insight_lead_today">Heute</string>
     <string name="insight_lead_tomorrow">Morgen</string>
+    <string name="insight_unchanged_today">Heute wird es genauso wie gestern.</string>
+    <string name="insight_unchanged_tonight">Heute Abend wird es genauso wie gestern Abend.</string>
+    <string name="insight_unchanged_tomorrow">Morgen wird es genauso wie heute.</string>
     <string name="insight_lead_tonight">Heute Abend</string>
 
     <!-- "Heute wird es mild." / "Heute wird es kühl bis mild." Subject-second

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -417,6 +417,9 @@ zh-CN) is unchanged; only the displayed label localizes.
     <!-- Insight prose templates — German equivalents of the keys in values/strings.xml. -->
     <string name="insight_lead_today">Heute</string>
     <string name="insight_lead_tomorrow">Morgen</string>
+    <string name="insight_unchanged_today">Heute wird es genauso wie gestern.</string>
+    <string name="insight_unchanged_tonight">Heute Abend wird es genauso wie gestern Abend.</string>
+    <string name="insight_unchanged_tomorrow">Morgen wird es genauso wie heute.</string>
     <string name="insight_lead_tonight">Heute Abend</string>
 
     <!-- "Heute wird es mild." / "Heute wird es kühl bis mild." Subject-second

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -476,6 +476,9 @@ zh-CN) is unchanged; only the displayed label localizes.
          Greek 24-hour colon notation ("15:00" / "15:30"). -->
     <string name="insight_lead_today">Σήμερα</string>
     <string name="insight_lead_tomorrow">Αύριο</string>
+    <string name="insight_unchanged_today">Σήμερα θα είναι όπως χθες.</string>
+    <string name="insight_unchanged_tonight">Απόψε θα είναι όπως χθες το βράδυ.</string>
+    <string name="insight_unchanged_tomorrow">Αύριο θα είναι όπως σήμερα.</string>
     <string name="insight_lead_tonight">Απόψε</string>
     <string name="insight_band_single">%1$s θα κάνει %2$d°.</string>
     <string name="insight_band_range">%1$s θα έχει %2$d° έως %3$d°.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -416,6 +416,9 @@ zh-CN) is unchanged; only the displayed label localizes.
 
     <string name="insight_lead_today">Hoy</string>
     <string name="insight_lead_tomorrow">Mañana</string>
+    <string name="insight_unchanged_today">Hoy hará el mismo tiempo que ayer.</string>
+    <string name="insight_unchanged_tonight">Esta noche hará el mismo tiempo que anoche.</string>
+    <string name="insight_unchanged_tomorrow">Mañana hará el mismo tiempo que hoy.</string>
     <string name="insight_lead_tonight">Esta noche</string>
     <string name="insight_band_single">%1$s hará %2$d°.</string>
     <string name="insight_band_range">%1$s hará entre %2$d° y %3$d°.</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -495,6 +495,9 @@ Tone is informal "sina"-form throughout ("Pane … selga", "Võta … kaasa",
 
     <string name="insight_lead_today">Täna</string>
     <string name="insight_lead_tomorrow">Homme</string>
+    <string name="insight_unchanged_today">Täna on sama ilm kui eile.</string>
+    <string name="insight_unchanged_tonight">Täna õhtul on sama ilm kui eile õhtul.</string>
+    <string name="insight_unchanged_tomorrow">Homme on sama ilm kui täna.</string>
     <string name="insight_lead_tonight">Täna õhtul</string>
     <!-- Estonian copular shape: "Täna on külm." -->
     <string name="insight_band_single">%1$s on %2$d°.</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -49,6 +49,9 @@ Western Arabic numerals (0-9) are used for TTS compatibility.
 
     <string name="insight_lead_today">امروز</string>
     <string name="insight_lead_tomorrow">فردا</string>
+    <string name="insight_unchanged_today">امروز هوا مثل دیروز خواهد بود.</string>
+    <string name="insight_unchanged_tonight">امشب هوا مثل دیشب خواهد بود.</string>
+    <string name="insight_unchanged_tomorrow">فردا هوا مثل امروز خواهد بود.</string>
     <string name="insight_lead_tonight">امشب</string>
     <!-- "امروز هوا معتدل خواهد بود." — SOV with lead first. -->
     <string name="insight_band_single">%1$s هوا %2$d° خواهد بود.</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -335,6 +335,9 @@ displayed label localizes.
 
     <string name="insight_lead_today">Tänään</string>
     <string name="insight_lead_tomorrow">Huomenna</string>
+    <string name="insight_unchanged_today">Tänään on sama sää kuin eilen.</string>
+    <string name="insight_unchanged_tonight">Tänä iltana on sama sää kuin eilen illalla.</string>
+    <string name="insight_unchanged_tomorrow">Huomenna on sama sää kuin tänään.</string>
     <string name="insight_lead_tonight">Tänä iltana</string>
 
     <!-- Finnish predicative-partitive: "Tänään on kylmää." -->

--- a/app/src/main/res/values-fil/strings.xml
+++ b/app/src/main/res/values-fil/strings.xml
@@ -45,6 +45,9 @@ The rest of the UI falls through to values/strings.xml (English).
 
     <string name="insight_lead_today">Ngayon</string>
     <string name="insight_lead_tomorrow">Bukas</string>
+    <string name="insight_unchanged_today">Ngayon, magiging katulad ng kahapon.</string>
+    <string name="insight_unchanged_tonight">Ngayong gabi, magiging katulad ng kagabi.</string>
+    <string name="insight_unchanged_tomorrow">Bukas, magiging katulad ng ngayon.</string>
     <string name="insight_lead_tonight">Ngayong gabi</string>
     <!-- Filipino: "Ngayon, magiging malamig." -->
     <string name="insight_band_single">%1$s, magiging %2$d°.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -418,6 +418,9 @@ zh-CN) is unchanged; only the displayed label localizes.
 
     <string name="insight_lead_today">Aujourd\'hui</string>
     <string name="insight_lead_tomorrow">Demain</string>
+    <string name="insight_unchanged_today">Aujourd\'hui, il fera le même temps qu\'hier.</string>
+    <string name="insight_unchanged_tonight">Ce soir, il fera le même temps qu\'hier soir.</string>
+    <string name="insight_unchanged_tomorrow">Demain, il fera le même temps qu\'aujourd\'hui.</string>
     <string name="insight_lead_tonight">Ce soir</string>
     <string name="insight_band_single">%1$s, il fera %2$d°.</string>
     <string name="insight_band_range">%1$s, il fera entre %2$d° et %3$d°.</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -455,6 +455,9 @@ Not overridden by design:
     <!-- Insight prose templates. -->
     <string name="insight_lead_today">आज</string>
     <string name="insight_lead_tomorrow">कल</string>
+    <string name="insight_unchanged_today">आज मौसम कल जैसा रहेगा।</string>
+    <string name="insight_unchanged_tonight">आज रात मौसम बीती रात जैसा रहेगा।</string>
+    <string name="insight_unchanged_tomorrow">कल मौसम आज जैसा रहेगा।</string>
     <string name="insight_lead_tonight">आज रात</string>
     <!-- "आज मौसम सुहाना रहेगा।" -->
     <string name="insight_band_single">%1$s मौसम %2$d° रहेगा।</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -388,6 +388,9 @@ spousal register), matching the existing insight prose ("Ponesi …",
 
     <string name="insight_lead_today">Danas</string>
     <string name="insight_lead_tomorrow">Sutra</string>
+    <string name="insight_unchanged_today">Danas će biti isto kao jučer.</string>
+    <string name="insight_unchanged_tonight">Večeras će biti isto kao sinoć.</string>
+    <string name="insight_unchanged_tomorrow">Sutra će biti isto kao danas.</string>
     <string name="insight_lead_tonight">Večeras</string>
     <string name="insight_band_single">%1$s će biti %2$d°.</string>
     <string name="insight_band_range">%1$s će biti od %2$d° do %3$d°.</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -541,6 +541,9 @@ locale (Angol (Egyesült Államok), Francia (Franciaország), Német
     <!-- Insight prose templates. -->
     <string name="insight_lead_today">Ma</string>
     <string name="insight_lead_tomorrow">Holnap</string>
+    <string name="insight_unchanged_today">Ma ugyanolyan lesz, mint tegnap.</string>
+    <string name="insight_unchanged_tonight">Ma este ugyanolyan lesz, mint tegnap este.</string>
+    <string name="insight_unchanged_tomorrow">Holnap ugyanolyan lesz, mint ma.</string>
     <string name="insight_lead_tonight">Ma este</string>
     <!-- "%1$s %2$s lesz." → "Ma hideg lesz." Lead first, then band, copula at end. -->
     <string name="insight_band_single">%1$s %2$d° lesz.</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -47,6 +47,9 @@ to values/strings.xml (English).
 
     <string name="insight_lead_today">Hari ini</string>
     <string name="insight_lead_tomorrow">Besok</string>
+    <string name="insight_unchanged_today">Hari ini cuacanya sama seperti kemarin.</string>
+    <string name="insight_unchanged_tonight">Malam ini cuacanya sama seperti tadi malam.</string>
+    <string name="insight_unchanged_tomorrow">Besok cuacanya sama seperti hari ini.</string>
     <string name="insight_lead_tonight">Malam ini</string>
     <!-- Indonesian SVO: "Hari ini cuacanya sejuk." -->
     <string name="insight_band_single">%1$s cuacanya %2$d°.</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -405,6 +405,9 @@ zh-CN) is unchanged; only the displayed label localizes.
 
     <string name="insight_lead_today">Oggi</string>
     <string name="insight_lead_tomorrow">Domani</string>
+    <string name="insight_unchanged_today">Oggi sarà come ieri.</string>
+    <string name="insight_unchanged_tonight">Stasera sarà come ieri sera.</string>
+    <string name="insight_unchanged_tomorrow">Domani sarà come oggi.</string>
     <string name="insight_lead_tonight">Stasera</string>
     <string name="insight_band_single">%1$s sarà %2$d°.</string>
     <string name="insight_band_range">%1$s sarà tra %2$d° e %3$d°.</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -50,6 +50,9 @@ standard in Israeli digital communication.
 
     <string name="insight_lead_today">היום</string>
     <string name="insight_lead_tomorrow">מחר</string>
+    <string name="insight_unchanged_today">היום יהיה כמו אתמול.</string>
+    <string name="insight_unchanged_tonight">הלילה יהיה כמו אתמול בלילה.</string>
+    <string name="insight_unchanged_tomorrow">מחר יהיה כמו היום.</string>
     <string name="insight_lead_tonight">הלילה</string>
     <!-- "היום יהיה נעים." -->
     <string name="insight_band_single">%1$s יהיה %2$d°.</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -416,6 +416,9 @@ the displayed label localizes.
 
     <string name="insight_lead_today">今日</string>
     <string name="insight_lead_tomorrow">明日</string>
+    <string name="insight_unchanged_today">今日は昨日と同じでしょう。</string>
+    <string name="insight_unchanged_tonight">今夜は昨夜と同じでしょう。</string>
+    <string name="insight_unchanged_tomorrow">明日は今日と同じでしょう。</string>
     <string name="insight_lead_tonight">今夜</string>
     <!-- "今日は穏やかでしょう。" — は marks the topic. -->
     <string name="insight_band_single">%1$sは%2$d°でしょう。</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -431,6 +431,9 @@ displayed label localizes.
 
     <string name="insight_lead_today">오늘</string>
     <string name="insight_lead_tomorrow">내일</string>
+    <string name="insight_unchanged_today">오늘은 어제와 같은 날씨입니다.</string>
+    <string name="insight_unchanged_tonight">오늘 밤은 어젯밤과 같은 날씨입니다.</string>
+    <string name="insight_unchanged_tomorrow">내일은 오늘과 같은 날씨입니다.</string>
     <string name="insight_lead_tonight">오늘 밤</string>
     <!-- "오늘 포근한 날씨입니다." -->
     <string name="insight_band_single">%1$s %2$d° 날씨입니다.</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -52,6 +52,9 @@ What is NOT overridden, by design:
 
     <string name="insight_lead_today">Šiandien</string>
     <string name="insight_lead_tomorrow">Rytoj</string>
+    <string name="insight_unchanged_today">Šiandien bus taip pat kaip vakar.</string>
+    <string name="insight_unchanged_tonight">Šįvakar bus taip pat kaip vakar vakare.</string>
+    <string name="insight_unchanged_tomorrow">Rytoj bus taip pat kaip šiandien.</string>
     <string name="insight_lead_tonight">Šįvakar</string>
     <!-- Lithuanian neuter short-form weather: "Šiandien bus šalta." -->
     <string name="insight_band_single">%1$s bus %2$d°.</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -57,6 +57,9 @@ informal "tu"-form throughout ("Apģērb …", "Paņem … līdzi").
 
     <string name="insight_lead_today">Šodien</string>
     <string name="insight_lead_tomorrow">Rīt</string>
+    <string name="insight_unchanged_today">Šodien būs tāpat kā vakar.</string>
+    <string name="insight_unchanged_tonight">Šovakar būs tāpat kā vakar vakarā.</string>
+    <string name="insight_unchanged_tomorrow">Rīt būs tāpat kā šodien.</string>
     <string name="insight_lead_tonight">Šovakar</string>
     <!-- Latvian masculine-nominative agreement (implicit subject "laiks"):
          "Šodien būs auksts." -->

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -47,6 +47,9 @@ vs "kemungkinan", "padam" vs "hapus").
 
     <string name="insight_lead_today">Hari ini</string>
     <string name="insight_lead_tomorrow">Esok</string>
+    <string name="insight_unchanged_today">Hari ini cuacanya sama seperti semalam.</string>
+    <string name="insight_unchanged_tonight">Malam ini cuacanya sama seperti malam tadi.</string>
+    <string name="insight_unchanged_tomorrow">Esok cuacanya sama seperti hari ini.</string>
     <string name="insight_lead_tonight">Malam ini</string>
     <!-- Malay topic-comment shape: "Hari ini cuacanya sejuk." -->
     <string name="insight_band_single">%1$s cuacanya %2$d°.</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -542,6 +542,9 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrike)").
     <!-- Insight prose templates. -->
     <string name="insight_lead_today">I dag</string>
     <string name="insight_lead_tomorrow">I morgen</string>
+    <string name="insight_unchanged_today">I dag blir det det samme som i går.</string>
+    <string name="insight_unchanged_tonight">I kveld blir det det samme som i går kveld.</string>
+    <string name="insight_unchanged_tomorrow">I morgen blir det det samme som i dag.</string>
     <string name="insight_lead_tonight">I kveld</string>
     <!-- Norwegian V2 word order: "I dag blir det mildt." -->
     <string name="insight_band_single">%1$s blir det %2$d°.</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -379,6 +379,9 @@ the displayed label localizes.
     <!-- Insight prose templates. -->
     <string name="insight_lead_today">Vandaag</string>
     <string name="insight_lead_tomorrow">Morgen</string>
+    <string name="insight_unchanged_today">Vandaag wordt het hetzelfde als gisteren.</string>
+    <string name="insight_unchanged_tonight">Vanavond wordt het hetzelfde als gisteravond.</string>
+    <string name="insight_unchanged_tomorrow">Morgen wordt het hetzelfde als vandaag.</string>
     <string name="insight_lead_tonight">Vanavond</string>
 
     <!-- Dutch V2 word order: "Vandaag wordt het mild." -->

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -379,6 +379,9 @@ is unchanged; only the displayed label localizes.
     <!-- Insight prose templates. -->
     <string name="insight_lead_today">Dziś</string>
     <string name="insight_lead_tomorrow">Jutro</string>
+    <string name="insight_unchanged_today">Dziś będzie tak samo jak wczoraj.</string>
+    <string name="insight_unchanged_tonight">Wieczorem będzie tak samo jak wczoraj wieczorem.</string>
+    <string name="insight_unchanged_tomorrow">Jutro będzie tak samo jak dziś.</string>
     <string name="insight_lead_tonight">Wieczorem</string>
 
     <string name="insight_band_single">%1$s będzie %2$d°.</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -423,6 +423,9 @@ zh-CN) is unchanged; only the displayed label localizes.
 
     <string name="insight_lead_today">Hoje</string>
     <string name="insight_lead_tomorrow">Amanhã</string>
+    <string name="insight_unchanged_today">Hoje será igual a ontem.</string>
+    <string name="insight_unchanged_tonight">Esta noite será igual à noite passada.</string>
+    <string name="insight_unchanged_tomorrow">Amanhã será igual a hoje.</string>
     <string name="insight_lead_tonight">Esta noite</string>
     <string name="insight_band_single">%1$s será %2$d°.</string>
     <string name="insight_band_range">%1$s estará entre %2$d° e %3$d°.</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -447,6 +447,9 @@ they diverge from BR ("Polonês" → "Polaco", "Holandês" →
          "Tempestade" (BR thunderstorm). -->
     <string name="insight_lead_today">Hoje</string>
     <string name="insight_lead_tomorrow">Amanhã</string>
+    <string name="insight_unchanged_today">Hoje será igual a ontem.</string>
+    <string name="insight_unchanged_tonight">Esta noite será igual à noite passada.</string>
+    <string name="insight_unchanged_tomorrow">Amanhã será igual a hoje.</string>
     <string name="insight_lead_tonight">Esta noite</string>
     <string name="insight_band_single">%1$s será %2$d°.</string>
     <string name="insight_band_range">%1$s estará entre %2$d° e %3$d°.</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -46,6 +46,9 @@ surfaces fall back to default English (matching values-pl / values-uk).
 
     <string name="insight_lead_today">Astăzi</string>
     <string name="insight_lead_tomorrow">Mâine</string>
+    <string name="insight_unchanged_today">Astăzi va fi la fel ca ieri.</string>
+    <string name="insight_unchanged_tonight">Diseară va fi la fel ca aseară.</string>
+    <string name="insight_unchanged_tomorrow">Mâine va fi la fel ca astăzi.</string>
     <string name="insight_lead_tonight">Diseară</string>
     <string name="insight_band_single">%1$s va fi %2$d°.</string>
     <string name="insight_band_range">%1$s va fi între %2$d° și %3$d°.</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -610,6 +610,9 @@ only the displayed label localizes.
     <!-- Insight prose templates. -->
     <string name="insight_lead_today">Сегодня</string>
     <string name="insight_lead_tomorrow">Завтра</string>
+    <string name="insight_unchanged_today">Сегодня будет так же, как вчера.</string>
+    <string name="insight_unchanged_tonight">Сегодня вечером будет так же, как вчера вечером.</string>
+    <string name="insight_unchanged_tomorrow">Завтра будет так же, как сегодня.</string>
     <string name="insight_lead_tonight">Сегодня вечером</string>
     <string name="insight_band_single">%1$s будет %2$d°.</string>
     <string name="insight_band_range">%1$s будет от %2$d° до %3$d°.</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -553,6 +553,9 @@ What is NOT overridden, by design:
     <!-- Insight prose templates. -->
     <string name="insight_lead_today">Dnes</string>
     <string name="insight_lead_tomorrow">Zajtra</string>
+    <string name="insight_unchanged_today">Dnes bude rovnako ako včera.</string>
+    <string name="insight_unchanged_tonight">Dnes večer bude rovnako ako včera večer.</string>
+    <string name="insight_unchanged_tomorrow">Zajtra bude rovnako ako dnes.</string>
     <string name="insight_lead_tonight">Dnes večer</string>
     <string name="insight_band_single">%1$s bude %2$d°.</string>
     <string name="insight_band_range">%1$s bude od %2$d° do %3$d°.</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -45,6 +45,9 @@ informal "ti"-form throughout, mirroring the Croatian / Serbian pass.
 
     <string name="insight_lead_today">Danes</string>
     <string name="insight_lead_tomorrow">Jutri</string>
+    <string name="insight_unchanged_today">Danes bo enako kot včeraj.</string>
+    <string name="insight_unchanged_tonight">Nocoj bo enako kot sinoči.</string>
+    <string name="insight_unchanged_tomorrow">Jutri bo enako kot danes.</string>
     <string name="insight_lead_tonight">Nocoj</string>
     <!-- "Danes bo mrzlo." — leading time adverb + "bo" + adjective. -->
     <string name="insight_band_single">%1$s bo %2$d°.</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -542,6 +542,9 @@ native names for all locales (e.g. "Tyska (Tyskland)", "Franska (Frankrike)").
     <!-- Insight prose templates. -->
     <string name="insight_lead_today">Idag</string>
     <string name="insight_lead_tomorrow">Imorgon</string>
+    <string name="insight_unchanged_today">Idag blir det likadant som igår.</string>
+    <string name="insight_unchanged_tonight">I kväll blir det likadant som igår kväll.</string>
+    <string name="insight_unchanged_tomorrow">Imorgon blir det likadant som idag.</string>
     <string name="insight_lead_tonight">I kväll</string>
     <!-- Swedish V2 word order: "Idag blir det milt." -->
     <string name="insight_band_single">%1$s blir det %2$d°.</string>

--- a/app/src/main/res/values-sw/strings.xml
+++ b/app/src/main/res/values-sw/strings.xml
@@ -45,6 +45,9 @@ The rest of the UI falls through to values/strings.xml (English).
 
     <string name="insight_lead_today">Leo</string>
     <string name="insight_lead_tomorrow">Kesho</string>
+    <string name="insight_unchanged_today">Leo hali ya hewa itakuwa sawa na jana.</string>
+    <string name="insight_unchanged_tonight">Usiku huu hali ya hewa itakuwa sawa na jana usiku.</string>
+    <string name="insight_unchanged_tomorrow">Kesho hali ya hewa itakuwa sawa na leo.</string>
     <string name="insight_lead_tonight">Usiku huu</string>
     <!-- Swahili: "Leo itakuwa baridi." -->
     <string name="insight_band_single">%1$s itakuwa %2$d°.</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -45,6 +45,9 @@ The rest of the UI falls through to values/strings.xml (English).
 
     <string name="insight_lead_today">วันนี้</string>
     <string name="insight_lead_tomorrow">พรุ่งนี้</string>
+    <string name="insight_unchanged_today">วันนี้อากาศเหมือนเมื่อวาน</string>
+    <string name="insight_unchanged_tonight">คืนนี้อากาศเหมือนเมื่อคืน</string>
+    <string name="insight_unchanged_tomorrow">พรุ่งนี้อากาศเหมือนวันนี้</string>
     <string name="insight_lead_tonight">คืนนี้</string>
     <!-- Thai: "วันนี้อากาศเย็น" (time + topic + predicate, no copula). -->
     <string name="insight_band_single">%1$sอากาศ%2$d°</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -335,6 +335,9 @@ displayed label localizes.
 
     <string name="insight_lead_today">Bugün</string>
     <string name="insight_lead_tomorrow">Yarın</string>
+    <string name="insight_unchanged_today">Bugün dünkü gibi olacak.</string>
+    <string name="insight_unchanged_tonight">Bu gece dün geceki gibi olacak.</string>
+    <string name="insight_unchanged_tomorrow">Yarın bugünkü gibi olacak.</string>
     <string name="insight_lead_tonight">Bu gece</string>
 
     <!-- Turkish SOV word order: subject-object-verb; predicate at the end. -->

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -551,6 +551,9 @@ only the displayed label localizes.
 
     <string name="insight_lead_today">Сьогодні</string>
     <string name="insight_lead_tomorrow">Завтра</string>
+    <string name="insight_unchanged_today">Сьогодні буде так само, як учора.</string>
+    <string name="insight_unchanged_tonight">Сьогодні ввечері буде так само, як учора ввечері.</string>
+    <string name="insight_unchanged_tomorrow">Завтра буде так само, як сьогодні.</string>
     <string name="insight_lead_tonight">Сьогодні ввечері</string>
     <string name="insight_band_single">%1$s буде %2$d°.</string>
     <string name="insight_band_range">%1$s буде від %2$d° до %3$d°.</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -50,6 +50,9 @@ Skipped intentionally: app_name (brand), insight_time_am/pm/midnight/noon
 
     <string name="insight_lead_today">Hôm nay</string>
     <string name="insight_lead_tomorrow">Ngày mai</string>
+    <string name="insight_unchanged_today">Hôm nay trời giống như hôm qua.</string>
+    <string name="insight_unchanged_tonight">Tối nay trời giống như tối qua.</string>
+    <string name="insight_unchanged_tomorrow">Ngày mai trời giống như hôm nay.</string>
     <string name="insight_lead_tonight">Tối nay</string>
     <!-- Vietnamese: "Hôm nay trời mát." (time + topic + predicate) -->
     <string name="insight_band_single">%1$s trời %2$d°.</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -409,6 +409,9 @@ label localizes.
 
     <string name="insight_lead_today">今天</string>
     <string name="insight_lead_tomorrow">明天</string>
+    <string name="insight_unchanged_today">今天天气和昨天一样。</string>
+    <string name="insight_unchanged_tonight">今晚天气和昨晚一样。</string>
+    <string name="insight_unchanged_tomorrow">明天天气和今天一样。</string>
     <string name="insight_lead_tonight">今晚</string>
     <!-- "今天天气温和。" / "今晚天气寒冷至凉爽。" -->
     <string name="insight_band_single">%1$s天气%2$d°。</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -400,6 +400,9 @@ label localises.
 
     <string name="insight_lead_today">今天</string>
     <string name="insight_lead_tomorrow">明天</string>
+    <string name="insight_unchanged_today">今天天氣和昨天一樣。</string>
+    <string name="insight_unchanged_tonight">今晚天氣和昨晚一樣。</string>
+    <string name="insight_unchanged_tomorrow">明天天氣和今天一樣。</string>
     <string name="insight_lead_tonight">今晚</string>
     <!-- "今天天氣溫和。" / "今晚天氣寒冷至涼爽。" -->
     <string name="insight_band_single">%1$s天氣%2$d°。</string>


### PR DESCRIPTION
## Summary

Follow-up to #627, which shipped the new `insight_unchanged_today` / `_tonight` / `_tomorrow` strings (the "Today, it will be the same as yesterday." display line) **English-only**. Non-English users currently fall back to English for that line.

This PR adds localized translations to all **46 locales** that maintain their own insight strings. Each translation reuses the locale's existing lead word (`insight_lead_today/tonight/tomorrow`) and "it will be …" phrasing (`insight_band_single`) so the new line matches the surrounding insight prose. The period-appropriate comparison reference is preserved: *yesterday* for the daytime line, *last night* for the evening line, *today* for the page-2 tomorrow line.

Region-only overlay files (`en-rGB/AU/CA/ZA`, `es-rMX`, `fr-rCA`) carry no insight strings and inherit from their base language, so they need no entry.

## Notes

- Display-only strings; no behavior change and nothing new crosses the device boundary (the TTS path stays silent in this case, per #627).
- Translations are best-effort, anchored to each file's existing insight vocabulary — happy to adjust any wording a native speaker flags.

## Test plan

- [x] All 46 changed `strings.xml` files parse as well-formed XML
- [x] `:app:assembleDebug` green locally (aapt2 resource compilation passes, including apostrophe-escaped `fr`)
- [ ] CI: JVM unit tests + Android debug build

https://claude.ai/code/session_01G6XUPpxTP1gWSexCVHKr5i

---
_Generated by [Claude Code](https://claude.ai/code/session_01G6XUPpxTP1gWSexCVHKr5i)_