### PR TITLE
Preview a day now shows calendar birthdays and holidays

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/settings/DeveloperSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/DeveloperSettings.kt
@@ -20,6 +20,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -33,6 +34,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.clothescast.R
 import app.clothescast.core.domain.model.BandClause
+import app.clothescast.core.domain.model.CalendarEvent
 import app.clothescast.core.domain.model.ClothesClause
 import app.clothescast.core.domain.model.ForecastPeriod
 import app.clothescast.core.domain.model.HolidayId
@@ -91,6 +93,9 @@ internal fun DeveloperPage(viewModel: SettingsViewModel, onBack: () -> Unit) {
             region = state.region,
             holidayOverrides = state.holidayOverrides,
             enabledCountries = state.effectiveEnabledHolidayCountries,
+            themeFromCalendarHolidays = state.calendarEnabled && state.themeFromCalendarHolidays,
+            themeFromCalendarBirthdays = state.calendarEnabled && state.themeFromCalendarBirthdays,
+            loadEventsForDay = viewModel::calendarEventsForDay,
             padding = padding,
             speaking = isSpeaking,
             onSpeak = onSpeak@{ holidayId ->
@@ -135,6 +140,9 @@ internal fun DeveloperContent(
     enabledCountries: Set<String>,
     padding: PaddingValues,
     onSpeak: (HolidayId?) -> Unit,
+    themeFromCalendarHolidays: Boolean = false,
+    themeFromCalendarBirthdays: Boolean = false,
+    loadEventsForDay: suspend (LocalDate) -> List<CalendarEvent> = { emptyList() },
     speaking: Boolean = false,
     initialDate: LocalDate = LocalDate.now(),
 ) {
@@ -142,14 +150,35 @@ internal fun DeveloperContent(
     val selectedDate = LocalDate.ofEpochDay(epochDay)
     var showPicker by rememberSaveable { mutableStateOf(false) }
 
-    val theme = remember(selectedDate, holidayOverrides, enabledCountries) {
+    // Pull the picked day's calendar events so the preview themes from
+    // calendar holidays / birthdays the same way the Today screen does. Only
+    // read when a calendar-sourced toggle is on — matches the Today screen's
+    // gate and avoids a needless calendar query (and permission surprise)
+    // otherwise.
+    var events by remember { mutableStateOf<List<CalendarEvent>>(emptyList()) }
+    LaunchedEffect(selectedDate, themeFromCalendarHolidays, themeFromCalendarBirthdays) {
+        events = if (themeFromCalendarHolidays || themeFromCalendarBirthdays) {
+            loadEventsForDay(selectedDate)
+        } else {
+            emptyList()
+        }
+    }
+
+    val theme = remember(
+        selectedDate,
+        holidayOverrides,
+        enabledCountries,
+        events,
+        themeFromCalendarHolidays,
+        themeFromCalendarBirthdays,
+    ) {
         ThemeForToday().resolve(
             date = selectedDate,
             overrides = holidayOverrides,
             enabledCountries = enabledCountries,
-            events = emptyList(),
-            themeFromCalendarHolidays = false,
-            themeFromCalendarBirthdays = false,
+            events = events,
+            themeFromCalendarHolidays = themeFromCalendarHolidays,
+            themeFromCalendarBirthdays = themeFromCalendarBirthdays,
         )
     }
 

--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.viewModelScope
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import app.clothescast.core.data.location.OpenMeteoGeocodingClient
+import app.clothescast.core.domain.model.CalendarEvent
 import app.clothescast.core.domain.model.ClothesMentionMode
 import app.clothescast.core.domain.model.ClothesRule
 import app.clothescast.core.domain.model.ColorPalette
@@ -648,6 +649,19 @@ class SettingsViewModel(
                 .distinctBy { Triple(it.date, it.title, it.kind) }
             _state.update { it.copy(calendarCelebrations = events) }
         }
+    }
+
+    /**
+     * Reads the calendar events for a single [date] so the Developer
+     * "Preview a day" screen can theme an arbitrary date exactly as the Today
+     * screen would. Returns an empty list when no reader is wired (pure-VM
+     * tests) or the read fails (e.g. READ_CALENDAR not granted), so the
+     * preview degrades to curated-catalog theming only.
+     */
+    suspend fun calendarEventsForDay(date: LocalDate): List<CalendarEvent> {
+        val reader = calendarEventReader ?: return emptyList()
+        val zone = settingsRepository.preferences.first().schedule.zoneId
+        return runCatching { reader.eventsForDay(date, zone) }.getOrDefault(emptyList())
     }
 
     fun setTelemetryEnabled(enabled: Boolean) {


### PR DESCRIPTION
## Summary

The Developer → **Preview a day** screen resolved themes only from the curated holiday catalog. It passed `events = emptyList()` and forced both calendar holiday/birthday theming flags `false` (`DeveloperSettings.kt`), so picking a date never surfaced any calendar-sourced celebration (a synced birthday or holiday) — even with calendar birthday theming enabled.

That was the cause of the report: the Developer preview only ever showed curated catalog holidays, never calendar-sourced ones. Classification (`CalendarEventClassifier`) and the real Today-screen theming were already working — the preview just never read the calendar.

## Changes

- `SettingsViewModel.calendarEventsForDay(date)` — reads the picked day's calendar events via the injected `CalendarEventReader`; returns empty when no reader is wired or the read fails (e.g. permission not granted).
- `DeveloperContent` now loads events for the selected date in a `LaunchedEffect` and resolves the theme using the user's **actual** calendar-theming toggles (`calendarEnabled && themeFromCalendar{Holidays,Birthdays}`), mirroring `TodayViewModel` / `HolidayThemeResolver`. The read is gated on those toggles, so a user who hasn't opted into calendar theming sees no behaviour change and triggers no calendar query.

Recurrence note: the reader queries `CalendarContract.Instances`, so yearly-repeating events are expanded into per-occurrence instances by the platform; the per-day query works for any picked date, past or future.

## Privacy

The preview now issues an **on-device** calendar read for the selected date when a calendar-theming toggle is on (previously it never read the calendar). Nothing leaves the device — events are used only to resolve the on-screen theme, exactly as the Today screen already does.

## Test plan

- [x] `:app:compileDebugKotlin` — passes
- [x] `:app:testDebugUnitTest` — passes (Developer snapshot preview unchanged: it uses the empty-events defaults)
- [x] CI green (JVM unit tests + Android debug build)
- [ ] Manual: on a device with a synced calendar birthday and birthday theming enabled, open Developer → Preview a day, pick the birthday's date, confirm the banner now includes the birthday alongside any curated holiday.
