### PR TITLE
Drop the helper paragraph from the Garment colours picker

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/settings/ClothesSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/ClothesSettings.kt
@@ -137,11 +137,6 @@ private fun GarmentColorsCard(
 ) {
     var pickerTarget by remember { mutableStateOf<GarmentPickerTarget?>(null) }
     SectionCard(title = stringResource(R.string.settings_display_garment_colors_title)) {
-        Text(
-            text = stringResource(R.string.settings_display_garment_colors_description),
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
         // Tops first (in OutfitSuggestion's declaration order — coldest tier
         // last), then bottoms, matching the reading order of the Today
         // screen's stacked icons.

--- a/app/src/main/res/values-am/strings.xml
+++ b/app/src/main/res/values-am/strings.xml
@@ -587,7 +587,6 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="settings_root_forecasters_subtitle">የአየር ሁኔታ ምንጮችና ሞዴሎች</string>
 
     <string name="settings_display_garment_colors_title">የልብስ ቀለሞች</string>
-    <string name="settings_display_garment_colors_description">በዛሬ ማያ፣ በመነሻ ማያ ዊጅት እና በማሳወቂያዎች ላይ ለሚታይ ለእያንዳንዱ የልብስ አዶ ቀለም ይምረጡ። የጠርዙ ቀለም በራሱ ይጠቁራል።</string>
     <string name="settings_garment_color_default">ነባሪ</string>
     <string name="settings_garment_color_picker_title">ቀለም ይምረጡ</string>
     <string name="settings_garment_color_swatch_description">የቀለም ናሙና %1$s</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -614,7 +614,6 @@ they work correctly in both the single-band and range templates.
     <string name="settings_root_forecasters_subtitle">مصادر الطقس والنماذج</string>
 
     <string name="settings_display_garment_colors_title">ألوان الملابس</string>
-    <string name="settings_display_garment_colors_description">اختر لونًا لكل أيقونة ملابس تظهر في شاشة اليوم وفي أداة الشاشة الرئيسية والإشعارات. يصبح الحد الخارجي أغمق تلقائيًا.</string>
     <string name="settings_garment_color_default">افتراضي</string>
     <string name="settings_garment_color_picker_title">اختر لونًا</string>
     <string name="settings_garment_color_swatch_description">عينة لون %1$s</string>

--- a/app/src/main/res/values-b+sr+Latn/strings.xml
+++ b/app/src/main/res/values-b+sr+Latn/strings.xml
@@ -631,7 +631,6 @@ default English (matching values-pl / values-uk).
     <string name="settings_root_forecasters_subtitle">Izvori i modeli vremena</string>
 
     <string name="settings_display_garment_colors_title">Boje odeće</string>
-    <string name="settings_display_garment_colors_description">Izaberi boju za svaku ikonu odeće prikazanu na ekranu Danas, u vidžetu na početnom ekranu i u obaveštenjima. Obrub se automatski zatamnjuje.</string>
     <string name="settings_garment_color_default">Podrazumevano</string>
     <string name="settings_garment_color_picker_title">Izaberi boju</string>
     <string name="settings_garment_color_swatch_description">Uzorak boje %1$s</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -629,7 +629,6 @@ What is NOT overridden, by design:
     <string name="settings_root_forecasters_subtitle">Източници на време и модели</string>
 
     <string name="settings_display_garment_colors_title">Цветове на дрехите</string>
-    <string name="settings_display_garment_colors_description">Избери цвят за всяка икона на дреха на „Днес“, в притурката на началния екран и в известията. Контурът автоматично потъмнява.</string>
     <string name="settings_garment_color_default">По подразбиране</string>
     <string name="settings_garment_color_picker_title">Избери цвят</string>
     <string name="settings_garment_color_swatch_description">Мостра на цвят „%1$s“</string>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -686,7 +686,6 @@ West Bengal vocabulary differences in a future PR.
 
     <!-- Display — per-garment colour picker. -->
     <string name="settings_display_garment_colors_title">পোশাকের রং</string>
-    <string name="settings_display_garment_colors_description">আজ, হোম স্ক্রিন উইজেট এবং বিজ্ঞপ্তিতে দেখানো প্রতিটি পোশাক আইকনের জন্য একটি রং বেছে নিন। আউটলাইন স্বয়ংক্রিয়ভাবে গাঢ় হয়ে যায়।</string>
     <string name="settings_garment_color_default">ডিফল্ট</string>
     <string name="settings_garment_color_picker_title">একটি রং বেছে নিন</string>
     <string name="settings_garment_color_swatch_description">রঙের সোয়াচ %1$s</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -585,7 +585,6 @@ the in-app clock is digit-driven and reads consistently across locales.
     <string name="settings_root_forecasters_subtitle">Fonts i models meteorològics</string>
 
     <string name="settings_display_garment_colors_title">Colors de la roba</string>
-    <string name="settings_display_garment_colors_description">Tria un color per a cada icona de peça de roba que apareix a Avui, al widget de la pantalla d\'inici i a les notificacions. El contorn s\'enfosqueix automàticament.</string>
     <string name="settings_garment_color_default">Per defecte</string>
     <string name="settings_garment_color_picker_title">Tria un color</string>
     <string name="settings_garment_color_swatch_description">Mostra de color %1$s</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -632,7 +632,6 @@ locale (Angličtina (USA), Francouzština (Francie), Němčina (Německo), …).
     <string name="settings_root_forecasters_subtitle">Zdroje a modely počasí</string>
 
     <string name="settings_display_garment_colors_title">Barvy oblečení</string>
-    <string name="settings_display_garment_colors_description">Vyber barvu pro každou ikonu oblečení zobrazenou na obrazovce Dnes, ve widgetu na domovské obrazovce a v oznámeních. Obrys se automaticky ztmaví.</string>
     <string name="settings_garment_color_default">Výchozí</string>
     <string name="settings_garment_color_picker_title">Vyber barvu</string>
     <string name="settings_garment_color_swatch_description">Vzorek barvy %1$s</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -645,7 +645,6 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrig)").
     <string name="settings_root_forecasters_subtitle">Vejrkilder og modeller</string>
 
     <string name="settings_display_garment_colors_title">Tøjfarver</string>
-    <string name="settings_display_garment_colors_description">Vælg en farve til hvert tøjikon, der vises i Dag, på hjemmeskærms-widgetten og i notifikationer. Konturen mørkner automatisk.</string>
     <string name="settings_garment_color_default">Standard</string>
     <string name="settings_garment_color_picker_title">Vælg en farve</string>
     <string name="settings_garment_color_swatch_description">Farveprøve %1$s</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -766,7 +766,6 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_root_forecasters_subtitle">Wetterquellen und Modelle</string>
 
     <string name="settings_display_garment_colors_title">Kleidungsfarben</string>
-    <string name="settings_display_garment_colors_description">Wähle eine Farbe für jedes Kleidungssymbol auf „Heute“, im Homescreen-Widget und in Benachrichtigungen. Die Umrandung wird automatisch dunkler.</string>
     <string name="settings_garment_color_default">Standard</string>
     <string name="settings_garment_color_picker_title">Farbe wählen</string>
     <string name="settings_garment_color_swatch_description">Farbmuster %1$s</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -764,7 +764,6 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_root_forecasters_subtitle">Πηγές καιρού και μοντέλα</string>
 
     <string name="settings_display_garment_colors_title">Χρώματα ρούχων</string>
-    <string name="settings_display_garment_colors_description">Διάλεξε ένα χρώμα για κάθε εικονίδιο ρούχου που εμφανίζεται στο Σήμερα, στο widget της αρχικής οθόνης και στις ειδοποιήσεις. Το περίγραμμα σκουραίνει αυτόματα.</string>
     <string name="settings_garment_color_default">Προεπιλογή</string>
     <string name="settings_garment_color_picker_title">Διάλεξε χρώμα</string>
     <string name="settings_garment_color_swatch_description">Δείγμα χρώματος %1$s</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -743,7 +743,6 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_root_forecasters_subtitle">Fuentes y modelos meteorológicos</string>
 
     <string name="settings_display_garment_colors_title">Colores de la ropa</string>
-    <string name="settings_display_garment_colors_description">Elige un color para cada icono de prenda que aparece en Hoy, en el widget de la pantalla de inicio y en las notificaciones. El contorno se oscurece automáticamente.</string>
     <string name="settings_garment_color_default">Predeterminado</string>
     <string name="settings_garment_color_picker_title">Elige un color</string>
     <string name="settings_garment_color_swatch_description">Muestra de color %1$s</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -590,7 +590,6 @@ Tone is informal "sina"-form throughout ("Pane … selga", "Võta … kaasa",
     <string name="settings_root_forecasters_subtitle">Ilmaallikad ja mudelid</string>
 
     <string name="settings_display_garment_colors_title">Riietuse värvid</string>
-    <string name="settings_display_garment_colors_description">Vali värv igale rõivaikoonile, mida näidatakse vaates „Täna“, avaekraani vidinas ja teavitustes. Kontuur tumeneb automaatselt.</string>
     <string name="settings_garment_color_default">Vaikimisi</string>
     <string name="settings_garment_color_picker_title">Vali värv</string>
     <string name="settings_garment_color_swatch_description">Värvinäidis „%1$s“</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -605,7 +605,6 @@ Western Arabic numerals (0-9) are used for TTS compatibility.
     <string name="settings_root_forecasters_subtitle">منابع و مدل‌های آب‌وهوا</string>
 
     <string name="settings_display_garment_colors_title">رنگ لباس‌ها</string>
-    <string name="settings_display_garment_colors_description">برای هر آیکن لباسی که در امروز، ابزارک صفحه اصلی و اعلان‌ها نمایش داده می‌شود یک رنگ انتخاب کنید. خط دور به‌طور خودکار تیره‌تر می‌شود.</string>
     <string name="settings_garment_color_default">پیش‌فرض</string>
     <string name="settings_garment_color_picker_title">یک رنگ انتخاب کنید</string>
     <string name="settings_garment_color_swatch_description">نمونه رنگ %1$s</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -625,7 +625,6 @@ displayed label localizes.
     <string name="settings_root_forecasters_subtitle">Sääpalvelut ja mallit</string>
 
     <string name="settings_display_garment_colors_title">Vaatteiden värit</string>
-    <string name="settings_display_garment_colors_description">Valitse väri jokaiselle vaatekuvakkeelle, joka näkyy Tänään-näytöllä, aloitusnäytön widgetissä ja ilmoituksissa. Reuna tummenee automaattisesti.</string>
     <string name="settings_garment_color_default">Oletus</string>
     <string name="settings_garment_color_picker_title">Valitse väri</string>
     <string name="settings_garment_color_swatch_description">Värinäyte %1$s</string>

--- a/app/src/main/res/values-fil/strings.xml
+++ b/app/src/main/res/values-fil/strings.xml
@@ -666,7 +666,6 @@ The rest of the UI falls through to values/strings.xml (English).
 
     <!-- Display — per-garment colour picker. -->
     <string name="settings_display_garment_colors_title">Mga kulay ng damit</string>
-    <string name="settings_display_garment_colors_description">Pumili ng kulay para sa bawat icon ng damit na ipinapakita sa Ngayon, sa home-screen widget, at sa mga notification. Awtomatikong pumupusyaw ang gilid.</string>
     <string name="settings_garment_color_default">Default</string>
     <string name="settings_garment_color_picker_title">Pumili ng kulay</string>
     <string name="settings_garment_color_swatch_description">Swatch ng kulay %1$s</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -742,7 +742,6 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_root_forecasters_subtitle">Sources et modèles météo</string>
 
     <string name="settings_display_garment_colors_title">Couleurs des vêtements</string>
-    <string name="settings_display_garment_colors_description">Choisis une couleur pour chaque icône de vêtement affichée sur Aujourd\'hui, sur le widget de l\'écran d\'accueil et dans les notifications. Le contour s\'assombrit automatiquement.</string>
     <string name="settings_garment_color_default">Par défaut</string>
     <string name="settings_garment_color_picker_title">Choisis une couleur</string>
     <string name="settings_garment_color_swatch_description">Échantillon de couleur %1$s</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -646,7 +646,6 @@ Not overridden by design:
 
     <!-- Display — per-garment colour picker. -->
     <string name="settings_display_garment_colors_title">कपड़ों के रंग</string>
-    <string name="settings_display_garment_colors_description">आज स्क्रीन, होम-स्क्रीन विजेट और सूचनाओं पर दिखाए जाने वाले प्रत्येक कपड़े के आइकन के लिए एक रंग चुनें। बाहरी रेखा अपने आप गहरी हो जाती है।</string>
     <string name="settings_garment_color_default">डिफ़ॉल्ट</string>
     <string name="settings_garment_color_picker_title">रंग चुनें</string>
     <string name="settings_garment_color_swatch_description">रंग नमूना %1$s</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -711,7 +711,6 @@ spousal register), matching the existing insight prose ("Ponesi …",
     <string name="settings_root_forecasters_subtitle">Izvori i modeli vremena</string>
 
     <string name="settings_display_garment_colors_title">Boje odjeće</string>
-    <string name="settings_display_garment_colors_description">Odaberi boju za svaku ikonu odjeće prikazanu na Danas, u widgetu na početnom zaslonu i u obavijestima. Obrub se automatski zatamnjuje.</string>
     <string name="settings_garment_color_default">Zadano</string>
     <string name="settings_garment_color_picker_title">Odaberi boju</string>
     <string name="settings_garment_color_swatch_description">Uzorak boje %1$s</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -635,7 +635,6 @@ locale (Angol (Egyesült Államok), Francia (Franciaország), Német
     <string name="settings_root_forecasters_subtitle">Időjárás-források és modellek</string>
 
     <string name="settings_display_garment_colors_title">Ruhák színei</string>
-    <string name="settings_display_garment_colors_description">Válassz színt minden ruhaikonhoz, amely a Ma képernyőn, a kezdőképernyő-modulban és az értesítésekben jelenik meg. A körvonal automatikusan sötétebb lesz.</string>
     <string name="settings_garment_color_default">Alapértelmezett</string>
     <string name="settings_garment_color_picker_title">Válassz színt</string>
     <string name="settings_garment_color_swatch_description">„%1$s” színminta</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -616,7 +616,6 @@ to values/strings.xml (English).
 
     <!-- Display — per-garment colour picker. -->
     <string name="settings_display_garment_colors_title">Warna pakaian</string>
-    <string name="settings_display_garment_colors_description">Pilih warna untuk setiap ikon pakaian yang ditampilkan di Hari Ini, widget layar utama, dan notifikasi. Garis tepi otomatis menjadi lebih gelap.</string>
     <string name="settings_garment_color_default">Default</string>
     <string name="settings_garment_color_picker_title">Pilih warna</string>
     <string name="settings_garment_color_swatch_description">Sampel warna %1$s</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -728,7 +728,6 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_root_forecasters_subtitle">Sorgenti e modelli meteo</string>
 
     <string name="settings_display_garment_colors_title">Colori degli indumenti</string>
-    <string name="settings_display_garment_colors_description">Scegli un colore per ogni icona di indumento mostrata su Oggi, sul widget della schermata Home e nelle notifiche. Il contorno si scurisce automaticamente.</string>
     <string name="settings_garment_color_default">Predefinito</string>
     <string name="settings_garment_color_picker_title">Scegli un colore</string>
     <string name="settings_garment_color_swatch_description">Campione di colore %1$s</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -613,7 +613,6 @@ standard in Israeli digital communication.
     <string name="settings_root_forecasters_subtitle">מקורות ומודלי מזג אוויר</string>
 
     <string name="settings_display_garment_colors_title">צבעי בגדים</string>
-    <string name="settings_display_garment_colors_description">בחר/י צבע לכל אייקון בגד שמופיע במסך היום, בווידג׳ט של מסך הבית ובהתראות. קו המתאר יוכהה אוטומטית.</string>
     <string name="settings_garment_color_default">ברירת מחדל</string>
     <string name="settings_garment_color_picker_title">בחר/י צבע</string>
     <string name="settings_garment_color_swatch_description">דגימת צבע %1$s</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -754,9 +754,8 @@ the displayed label localizes.
     <string name="settings_about_open_meteo">気象データ提供：Open-Meteo</string>
 
     <!-- Display screen — per-garment colour picker. Pick a fill colour for
-         each clothing icon; the stroke darkens automatically. -->
+         each clothing icon. -->
     <string name="settings_display_garment_colors_title">服装の色</string>
-    <string name="settings_display_garment_colors_description">「今日」、ホーム画面のウィジェット、通知に表示される各服装アイコンの色を選びます。輪郭は自動的に濃くなります。</string>
     <string name="settings_garment_color_default">デフォルト</string>
     <string name="settings_garment_color_picker_title">色を選択</string>
     <string name="settings_garment_color_swatch_description">カラーサンプル %1$s</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -758,9 +758,8 @@ displayed label localizes.
     <string name="settings_about_open_meteo">기상 데이터: Open-Meteo</string>
 
     <!-- Display screen — per-garment colour picker. Pick a fill colour for
-         each clothing icon; the stroke darkens automatically. -->
+         each clothing icon. -->
     <string name="settings_display_garment_colors_title">의상 색상</string>
-    <string name="settings_display_garment_colors_description">「오늘」 화면, 홈 화면 위젯, 알림에 표시되는 각 의상 아이콘의 색을 선택하세요. 테두리는 자동으로 어두워집니다.</string>
     <string name="settings_garment_color_default">기본값</string>
     <string name="settings_garment_color_picker_title">색상 선택</string>
     <string name="settings_garment_color_swatch_description">색상 견본 %1$s</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -634,7 +634,6 @@ What is NOT overridden, by design:
     <string name="settings_root_forecasters_subtitle">Orų šaltiniai ir modeliai</string>
 
     <string name="settings_display_garment_colors_title">Drabužių spalvos</string>
-    <string name="settings_display_garment_colors_description">Pasirink spalvą kiekvienai drabužio piktogramai ekrane „Šiandien“, pradžios ekrano valdiklyje ir pranešimuose. Kontūras automatiškai tamsėja.</string>
     <string name="settings_garment_color_default">Numatytoji</string>
     <string name="settings_garment_color_picker_title">Pasirink spalvą</string>
     <string name="settings_garment_color_swatch_description">Spalvos pavyzdys „%1$s“</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -587,7 +587,6 @@ informal "tu"-form throughout ("Apģērb …", "Paņem … līdzi").
     <string name="settings_root_forecasters_subtitle">Laika avoti un modeļi</string>
 
     <string name="settings_display_garment_colors_title">Apģērba krāsas</string>
-    <string name="settings_display_garment_colors_description">Izvēlies krāsu katrai apģērba ikonai, kas redzama sadaļā „Šodien“, mājas ekrāna logrīkā un paziņojumos. Kontūra automātiski kļūst tumšāka.</string>
     <string name="settings_garment_color_default">Noklusējums</string>
     <string name="settings_garment_color_picker_title">Izvēlies krāsu</string>
     <string name="settings_garment_color_swatch_description">Krāsas paraugs „%1$s“</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -622,7 +622,6 @@ vs "kemungkinan", "padam" vs "hapus").
 
     <!-- Display — per-garment colour picker. -->
     <string name="settings_display_garment_colors_title">Warna pakaian</string>
-    <string name="settings_display_garment_colors_description">Pilih warna untuk setiap ikon pakaian yang dipaparkan di Hari Ini, widget skrin utama dan pemberitahuan. Garis luar akan menjadi lebih gelap secara automatik.</string>
     <string name="settings_garment_color_default">Lalai</string>
     <string name="settings_garment_color_picker_title">Pilih warna</string>
     <string name="settings_garment_color_swatch_description">Sampel warna %1$s</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -644,7 +644,6 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrike)").
     <string name="settings_root_forecasters_subtitle">Værkilder og modeller</string>
 
     <string name="settings_display_garment_colors_title">Plaggfarger</string>
-    <string name="settings_display_garment_colors_description">Velg en farge for hvert plaggikon som vises på I dag, i hjemskjermwidgeten og i varsler. Konturen mørkner automatisk.</string>
     <string name="settings_garment_color_default">Standard</string>
     <string name="settings_garment_color_picker_title">Velg en farge</string>
     <string name="settings_garment_color_swatch_description">Fargeprøve %1$s</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -691,7 +691,6 @@ the displayed label localizes.
     <string name="settings_root_forecasters_subtitle">Weerbronnen en modellen</string>
 
     <string name="settings_display_garment_colors_title">Kledingkleuren</string>
-    <string name="settings_display_garment_colors_description">Kies een kleur voor elk kledingicoon op Vandaag, in de homescreen-widget en in meldingen. De rand wordt automatisch donkerder.</string>
     <string name="settings_garment_color_default">Standaard</string>
     <string name="settings_garment_color_picker_title">Kies een kleur</string>
     <string name="settings_garment_color_swatch_description">Kleurstaal %1$s</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -689,7 +689,6 @@ is unchanged; only the displayed label localizes.
     <string name="settings_root_forecasters_subtitle">Źródła i modele pogody</string>
 
     <string name="settings_display_garment_colors_title">Kolory ubrań</string>
-    <string name="settings_display_garment_colors_description">Wybierz kolor dla każdej ikony ubrania pokazywanej na ekranie Dziś, w widżecie ekranu głównego i w powiadomieniach. Obrys automatycznie ciemnieje.</string>
     <string name="settings_garment_color_default">Domyślny</string>
     <string name="settings_garment_color_picker_title">Wybierz kolor</string>
     <string name="settings_garment_color_swatch_description">Próbka koloru %1$s</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -730,7 +730,6 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_root_forecasters_subtitle">Fontes e modelos meteorológicos</string>
 
     <string name="settings_display_garment_colors_title">Cores das roupas</string>
-    <string name="settings_display_garment_colors_description">Escolha uma cor para cada ícone de roupa mostrado em Hoje, no widget da tela inicial e nas notificações. O contorno escurece automaticamente.</string>
     <string name="settings_garment_color_default">Padrão</string>
     <string name="settings_garment_color_picker_title">Escolha uma cor</string>
     <string name="settings_garment_color_swatch_description">Amostra de cor %1$s</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -772,7 +772,6 @@ they diverge from BR ("Polonês" → "Polaco", "Holandês" →
     <string name="settings_root_forecasters_subtitle">Fontes e modelos meteorológicos</string>
 
     <string name="settings_display_garment_colors_title">Cores das peças de roupa</string>
-    <string name="settings_display_garment_colors_description">Escolhe uma cor para cada ícone de peça de roupa mostrado em Hoje, no widget do ecrã inicial e nas notificações. O contorno escurece automaticamente.</string>
     <string name="settings_garment_color_default">Predefinido</string>
     <string name="settings_garment_color_picker_title">Escolhe uma cor</string>
     <string name="settings_garment_color_swatch_description">Amostra de cor %1$s</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -618,7 +618,6 @@ surfaces fall back to default English (matching values-pl / values-uk).
     <string name="settings_root_forecasters_subtitle">Surse și modele meteo</string>
 
     <string name="settings_display_garment_colors_title">Culorile hainelor</string>
-    <string name="settings_display_garment_colors_description">Alege o culoare pentru fiecare pictogramă de haină afișată în Azi, în widgetul de pe ecranul de pornire și în notificări. Conturul se închide automat.</string>
     <string name="settings_garment_color_default">Implicit</string>
     <string name="settings_garment_color_picker_title">Alege o culoare</string>
     <string name="settings_garment_color_swatch_description">Mostră de culoare %1$s</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -700,7 +700,6 @@ only the displayed label localizes.
     <string name="settings_root_forecasters_subtitle">Источники погоды и модели</string>
 
     <string name="settings_display_garment_colors_title">Цвета одежды</string>
-    <string name="settings_display_garment_colors_description">Выбери цвет для каждой иконки одежды на экране «Сегодня», в виджете и в уведомлениях. Контур автоматически становится темнее.</string>
     <string name="settings_garment_color_default">По умолчанию</string>
     <string name="settings_garment_color_picker_title">Выбери цвет</string>
     <string name="settings_garment_color_swatch_description">Образец цвета «%1$s»</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -646,7 +646,6 @@ What is NOT overridden, by design:
     <string name="settings_root_forecasters_subtitle">Zdroje a modely počasia</string>
 
     <string name="settings_display_garment_colors_title">Farby oblečenia</string>
-    <string name="settings_display_garment_colors_description">Vyber farbu pre každú ikonu oblečenia zobrazenú na obrazovke Dnes, vo widgete na domovskej obrazovke a v upozorneniach. Obrys sa automaticky stmaví.</string>
     <string name="settings_garment_color_default">Predvolené</string>
     <string name="settings_garment_color_picker_title">Vyber farbu</string>
     <string name="settings_garment_color_swatch_description">Vzorka farby %1$s</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -627,7 +627,6 @@ informal "ti"-form throughout, mirroring the Croatian / Serbian pass.
     <string name="settings_root_forecasters_subtitle">Viri in modeli vremena</string>
 
     <string name="settings_display_garment_colors_title">Barve oblačil</string>
-    <string name="settings_display_garment_colors_description">Izberi barvo za vsako ikono oblačila, prikazano na zaslonu Danes, v pripomočku domačega zaslona in v obvestilih. Obroba se samodejno potemni.</string>
     <string name="settings_garment_color_default">Privzeto</string>
     <string name="settings_garment_color_picker_title">Izberi barvo</string>
     <string name="settings_garment_color_swatch_description">Barvni vzorec %1$s</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -644,7 +644,6 @@ native names for all locales (e.g. "Tyska (Tyskland)", "Franska (Frankrike)").
     <string name="settings_root_forecasters_subtitle">Väderkällor och modeller</string>
 
     <string name="settings_display_garment_colors_title">Plaggfärger</string>
-    <string name="settings_display_garment_colors_description">Välj en färg för varje plaggikon som visas på Idag, i hemskärmswidgeten och i aviseringar. Konturen mörknar automatiskt.</string>
     <string name="settings_garment_color_default">Standard</string>
     <string name="settings_garment_color_picker_title">Välj en färg</string>
     <string name="settings_garment_color_swatch_description">Färgprov %1$s</string>

--- a/app/src/main/res/values-sw/strings.xml
+++ b/app/src/main/res/values-sw/strings.xml
@@ -588,7 +588,6 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="settings_root_forecasters_subtitle">Vyanzo na modeli za hali ya hewa</string>
 
     <string name="settings_display_garment_colors_title">Rangi za mavazi</string>
-    <string name="settings_display_garment_colors_description">Chagua rangi kwa kila aikoni ya vazi inayoonekana kwenye Leo, kwenye wijeti ya skrini ya nyumbani, na kwenye arifa. Mstari wa nje hutiwa giza moja kwa moja.</string>
     <string name="settings_garment_color_default">Chaguo-msingi</string>
     <string name="settings_garment_color_picker_title">Chagua rangi</string>
     <string name="settings_garment_color_swatch_description">Sampuli ya rangi ya %1$s</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -616,7 +616,6 @@ The rest of the UI falls through to values/strings.xml (English).
 
     <!-- Display — per-garment colour picker. -->
     <string name="settings_display_garment_colors_title">สีของเสื้อผ้า</string>
-    <string name="settings_display_garment_colors_description">เลือกสีให้ไอคอนเสื้อผ้าแต่ละชิ้นที่แสดงในหน้าวันนี้ วิดเจ็ตหน้าจอหลัก และการแจ้งเตือน เส้นขอบจะเข้มขึ้นโดยอัตโนมัติ</string>
     <string name="settings_garment_color_default">ค่าเริ่มต้น</string>
     <string name="settings_garment_color_picker_title">เลือกสี</string>
     <string name="settings_garment_color_swatch_description">ตัวอย่างสี %1$s</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -624,7 +624,6 @@ displayed label localizes.
     <string name="settings_root_forecasters_subtitle">Hava kaynakları ve modeller</string>
 
     <string name="settings_display_garment_colors_title">Giysi renkleri</string>
-    <string name="settings_display_garment_colors_description">Bugün ekranında, ana ekran widget\'ında ve bildirimlerde gösterilen her giysi simgesi için bir renk seç. Kontur otomatik olarak koyulaşır.</string>
     <string name="settings_garment_color_default">Varsayılan</string>
     <string name="settings_garment_color_picker_title">Bir renk seç</string>
     <string name="settings_garment_color_swatch_description">%1$s renk örneği</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -643,7 +643,6 @@ only the displayed label localizes.
     <string name="settings_root_forecasters_subtitle">Джерела погоди та моделі</string>
 
     <string name="settings_display_garment_colors_title">Кольори одягу</string>
-    <string name="settings_display_garment_colors_description">Виберіть колір для кожної піктограми одягу, що відображається на екрані «Сьогодні», у віджеті на головному екрані та у сповіщеннях. Контур автоматично темнішає.</string>
     <string name="settings_garment_color_default">За замовчуванням</string>
     <string name="settings_garment_color_picker_title">Виберіть колір</string>
     <string name="settings_garment_color_swatch_description">Зразок кольору «%1$s»</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -677,7 +677,6 @@ Skipped intentionally: app_name (brand), insight_time_am/pm/midnight/noon
 
     <!-- Display — per-garment colour picker. -->
     <string name="settings_display_garment_colors_title">Màu trang phục</string>
-    <string name="settings_display_garment_colors_description">Chọn màu cho từng biểu tượng trang phục hiển thị trên Hôm nay, tiện ích màn hình chính và thông báo. Đường viền tự động đậm hơn.</string>
     <string name="settings_garment_color_default">Mặc định</string>
     <string name="settings_garment_color_picker_title">Chọn màu</string>
     <string name="settings_garment_color_swatch_description">Mẫu màu %1$s</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -746,9 +746,8 @@ label localizes.
     <string name="settings_about_open_meteo">天气数据来自 Open-Meteo</string>
 
     <!-- Display screen — per-garment colour picker. Pick a fill colour for
-         each clothing icon; the stroke darkens automatically. -->
+         each clothing icon. -->
     <string name="settings_display_garment_colors_title">服装颜色</string>
-    <string name="settings_display_garment_colors_description">为「今日」页面、主屏幕小部件以及通知中显示的每个服装图标选择颜色。描边会自动加深。</string>
     <string name="settings_garment_color_default">默认</string>
     <string name="settings_garment_color_picker_title">选择颜色</string>
     <string name="settings_garment_color_swatch_description">颜色色块 %1$s</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -762,9 +762,8 @@ label localises.
     <string name="settings_about_open_meteo">天氣資料來自 Open-Meteo</string>
 
     <!-- Display screen — per-garment colour picker. Pick a fill colour for
-         each clothing icon; the stroke darkens automatically. -->
+         each clothing icon. -->
     <string name="settings_display_garment_colors_title">服裝顏色</string>
-    <string name="settings_display_garment_colors_description">為「今日」畫面、主畫面小工具以及通知中顯示的每個服裝圖示選擇顏色。外框會自動加深。</string>
     <string name="settings_garment_color_default">預設</string>
     <string name="settings_garment_color_picker_title">選擇顏色</string>
     <string name="settings_garment_color_swatch_description">顏色色塊 %1$s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -404,7 +404,6 @@
     <string name="settings_display_palette_highlighter_description">Magenta, yellow, and cyan chart lines — like highlighter pens on the page. Visibly different from Rainbow at a glance; the light theme uses deeper variants for readability. Safe under red-green colour blindness.</string>
 
     <string name="settings_display_garment_colors_title">Garment colours</string>
-    <string name="settings_display_garment_colors_description">Pick a colour for each clothing icon shown on Today, the home-screen widget, and notifications. The stroke darkens automatically.</string>
     <string name="settings_garment_color_default">Default</string>
     <string name="settings_garment_color_picker_title">Pick a colour</string>
     <string name="settings_garment_color_swatch_description">Colour swatch %1$s</string>


### PR DESCRIPTION
## Summary

The Garment colours section under Settings → Clothes opened with a one-line description: "Pick a colour for each clothing icon shown on Today, the home-screen widget, and notifications. The stroke darkens automatically." The second sentence is an implementation detail (we darken the SVG stroke based on the chosen fill) — too low-level for user-facing copy — and the first sentence restates what the section title and the per-garment rows already make obvious. Drop the whole paragraph.

Changes:
- `app/src/main/kotlin/.../ui/settings/ClothesSettings.kt` — remove the description `Text` from `GarmentColorsCard`; the section title and rows now stand on their own.
- `app/src/main/res/values/strings.xml` — delete `settings_display_garment_colors_description`.
- `app/src/main/res/values-*/strings.xml` (43 locales) — delete the matching translated string.

No code references the resource after this change.

## Privacy

No data sent off device changes.

## Test plan

- [ ] CI: JVM unit tests + Android debug build green
- [ ] Locally: open Settings → Clothes → Garment colours, confirm the section opens straight into the swatch rows with no helper paragraph above them

https://claude.ai/code/session_01EG6fMbkFxtnGQhBaA7qi1c

---
_Generated by [Claude Code](https://claude.ai/code/session_01EG6fMbkFxtnGQhBaA7qi1c)_