### PR TITLE
Say "Wear a t-shirt and shorts" instead of "Wear shorts and t-shirt"

### DIFF
--- a/app/src/main/kotlin/app/clothescast/insight/ClothesPhraser.kt
+++ b/app/src/main/kotlin/app/clothescast/insight/ClothesPhraser.kt
@@ -42,8 +42,23 @@ internal interface ClothesPhraser {
  *  - Items ending in 's' are treated as plural (shorts, boots, gloves) and take
  *    no article.
  *  - Items starting with a vowel letter take "an"; everything else takes "a".
- * Subsequent items in the list are emitted bare per the user-preferred phrasing
- * "Wear a sweater and jacket." rather than fully grammatical "a sweater and a jacket."
+ *
+ * For the join, "a"/"an" lands on (a) the first item that takes an article,
+ * and (b) in an Oxford-comma list of three or more, also on the *last* item
+ * if it takes one. Middle items render bare, and plurals never take an
+ * article anywhere. Concretely:
+ *  - "Wear a sweater."
+ *  - "Wear a sweater and jacket." (two items — first only)
+ *  - "Wear shorts and a t-shirt." (first article-taking item)
+ *  - "Wear a sweater, jacket, and a coat." (three items — first + last)
+ *  - "Wear a sweater, jacket, scarf, and gloves." (last is plural, so no
+ *    trailing article)
+ *  - "Wear shorts, gloves, and a scarf." (first article-taking item is also
+ *    the Oxford-last, so just one article)
+ *
+ * This is the existing two-item "Wear a sweater and jacket" style extended
+ * to the Oxford case, so the final singular in a longer list keeps its
+ * article rather than reading as a bare noun ("…, and jacket.").
  */
 internal class EnglishClothesPhraser(private val resources: Resources) : ClothesPhraser {
     override fun withArticle(item: String): String = prefixArticle(translate(item))
@@ -53,18 +68,31 @@ internal class EnglishClothesPhraser(private val resources: Resources) : Clothes
             .map(::translate)
             .filter { it.isNotBlank() }
             .toList()
-        return when (translated.size) {
-            0 -> ""
-            1 -> prefixArticle(translated[0])
-            2 -> resources.getString(R.string.insight_clothes_join_two, prefixArticle(translated[0]), translated[1])
+        if (translated.isEmpty()) return ""
+        val firstArticleIdx = translated.indexOfFirst(::takesArticle)
+        val lastIdx = translated.lastIndex
+        val rendered = translated.mapIndexed { i, item ->
+            val articleHere = when {
+                i == firstArticleIdx -> true
+                translated.size >= 3 && i == lastIdx && takesArticle(item) -> true
+                else -> false
+            }
+            if (articleHere) prefixArticle(item) else item
+        }
+        return when (rendered.size) {
+            1 -> rendered[0]
+            2 -> resources.getString(R.string.insight_clothes_join_two, rendered[0], rendered[1])
             else -> resources.getString(
                 R.string.insight_clothes_join_many,
-                prefixArticle(translated[0]),
-                translated.subList(1, translated.size - 1).joinToString(", "),
-                translated.last(),
+                rendered[0],
+                rendered.subList(1, rendered.size - 1).joinToString(", "),
+                rendered.last(),
             )
         }
     }
+
+    private fun takesArticle(display: String): Boolean =
+        !display.endsWith("s", ignoreCase = true)
 
     private fun prefixArticle(display: String): String = when {
         display.endsWith("s", ignoreCase = true) -> display

--- a/app/src/test/kotlin/app/clothescast/insight/InsightFormatterTest.kt
+++ b/app/src/test/kotlin/app/clothescast/insight/InsightFormatterTest.kt
@@ -166,22 +166,44 @@ class InsightFormatterTest {
     }
 
     @Test
-    fun `clothes joins two items with 'and' and only the first item gets an article`() {
+    fun `clothes joins two items with 'and' and only the first article-taking item gets an article`() {
         subject.format(summary(clothes = ClothesClause(listOf("sweater", "jacket")))) shouldBe
             "Today, it will be 21°. Wear a sweater and jacket."
     }
 
     @Test
-    fun `clothes Oxford-joins three garments with article only on the first`() {
+    fun `clothes articles the first article-taking item when a plural comes first`() {
+        // Drives the warm-day shorts-rule + t-shirt-fallback case: the older
+        // "first item only" rule swallowed the article on "t-shirt" (it
+        // wasn't first) and read as "Wear shorts and t-shirt."; the article
+        // now lands on the first item that can take one.
+        subject.format(summary(clothes = ClothesClause(listOf("shorts", "t-shirt")))) shouldBe
+            "Today, it will be 21°. Wear shorts and a t-shirt."
+    }
+
+    @Test
+    fun `clothes Oxford-joins three garments articling the first and Oxford-last`() {
+        // Three-or-more lists also article the last item (if it takes one),
+        // so the Oxford-last reads as a noun ("…and a coat.") rather than a
+        // bare fragment ("…and coat.").
         subject.format(summary(clothes = ClothesClause(listOf("sweater", "jacket", "coat")))) shouldBe
-            "Today, it will be 21°. Wear a sweater, jacket, and coat."
+            "Today, it will be 21°. Wear a sweater, jacket, and a coat."
     }
 
     @Test
     fun `clothes Oxford-joins four garments`() {
         subject.format(
             summary(clothes = ClothesClause(listOf("sweater", "jacket", "shorts", "coat"))),
-        ) shouldBe "Today, it will be 21°. Wear a sweater, jacket, shorts, and coat."
+        ) shouldBe "Today, it will be 21°. Wear a sweater, jacket, shorts, and a coat."
+    }
+
+    @Test
+    fun `clothes Oxford-last plural emits no trailing article`() {
+        // Last item is plural so the Oxford-last position picks nothing —
+        // we don't reach into the middle for a singular to article.
+        subject.format(
+            summary(clothes = ClothesClause(listOf("sweater", "jacket", "scarf", "gloves"))),
+        ) shouldBe "Today, it will be 21°. Wear a sweater, jacket, scarf, and gloves."
     }
 
     @Test
@@ -231,6 +253,14 @@ class InsightFormatterTest {
     fun `layer-count format names bottoms alongside the layer count`() {
         layerCountSubject.format(summary(clothes = ClothesClause(listOf("sweater", "shorts")))) shouldBe
             "Today, it will be 21°. Wear 2 layers and shorts."
+    }
+
+    @Test
+    fun `layer-count format names a t-shirt as 1 layer alongside shorts`() {
+        // The warm-day fallback scenario in layer-count mode: t-shirt from
+        // the default top, shorts from the user's threshold rule.
+        layerCountSubject.format(summary(clothes = ClothesClause(listOf("t-shirt", "shorts")))) shouldBe
+            "Today, it will be 21°. Wear 1 layer and shorts."
     }
 
     @Test
@@ -582,7 +612,7 @@ class InsightFormatterTest {
                 eveningEventTieIn = EveningEventTieInClause(items = listOf("sweater", "jacket", "scarf")),
             ),
         )
-        out shouldBe "Today, it will be 21°. Tonight, bring a sweater, jacket, and scarf."
+        out shouldBe "Today, it will be 21°. Tonight, bring a sweater, jacket, and a scarf."
     }
 
     @Test
@@ -761,9 +791,10 @@ class InsightFormatterTest {
     }
 
     @Test
-    fun `en-GB — multi-item list translates each item, article only on the first`() {
+    fun `en-GB — multi-item list translates each item and articles each singular`() {
         // Umbrella is silenced; the surviving garments stay joined with en-GB
-        // vocabulary.
+        // vocabulary. "Trousers" reads as plural so it picks no article — the
+        // jumper still gets its "a" without dragging one onto the trousers.
         britishSubject.format(
             summary(clothes = ClothesClause(listOf("sweater", "pants", "umbrella"))),
         ) shouldBe "Today, it will be 21°. Wear a jumper and trousers."

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/TriggeredOutfit.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/TriggeredOutfit.kt
@@ -36,11 +36,32 @@ data class TriggeredOutfit(
     val fallbacks: List<String>,
 ) {
     /**
-     * Every item the user is wearing today — layer-reduced threshold matches
-     * first, defaults second. The layer reduction picks at most one top per
-     * [Garment.Layer] and drops [Garment.Layer.BASE] when MID or SHELL also
-     * fired, so the prose reads "Wear a sweater and jacket." instead of
-     * "Wear a sweater, jacket, and t-shirt." See [Garment.layerReduce].
+     * Every item the user is wearing today, ordered tops → bottoms → unknown
+     * (accessories, free-form). Tops always lead so the prose's article picker
+     * applies to a singular top ("a t-shirt") rather than a leading bare-plural
+     * bottom ("shorts"), and so a t-shirt sourced from the default fallback
+     * reads the same as one sourced from a user rule — the user's mental
+     * model is "what am I wearing", not "which clause produced it".
+     *
+     * Within each slot, layer-reduced threshold matches keep their input
+     * order, then defaults follow in the order [EvaluateClothesRules] queued
+     * them. The layer reduction picks at most one top per [Garment.Layer]
+     * and drops [Garment.Layer.BASE] when MID or SHELL also fired, so the
+     * prose reads "Wear a sweater and jacket." instead of "Wear a sweater,
+     * jacket, and a t-shirt." See [Garment.layerReduce].
      */
-    val items: List<String> get() = Garment.layerReduce(rules).map { it.item } + fallbacks
+    val items: List<String>
+        get() {
+            val raw = Garment.layerReduce(rules).map { it.item } + fallbacks
+            // Stable sort that floats bottoms to the end. Tops and unclassified
+            // items (accessories, free-form) keep their input order; only the
+            // top↔bottom flip — which happens when a bottom rule fires and the
+            // top comes from the default fallback (shorts rule + t-shirt
+            // default on a warm day) — is corrected. Accessories are filtered
+            // out before prose rendering anyway, so their slot is left at 0
+            // to preserve their position relative to tops.
+            return raw.sortedBy {
+                if (Garment.fromKey(it)?.slot == Garment.Slot.BOTTOM) 1 else 0
+            }
+        }
 }

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/EvaluateClothesRulesTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/EvaluateClothesRulesTest.kt
@@ -62,10 +62,13 @@ class EvaluateClothesRulesTest {
     fun `matching bottom-tier threshold rule replaces the default bottom, top still defaults`() {
         // Hot day — shorts matches, no top-tier threshold rule does.
         // Bottom slot gets the matching rule's item; top slot gets the default.
+        // items orders tops before bottoms so the prose reads
+        // "Wear a t-shirt and shorts." regardless of which clause produced
+        // the t-shirt (rule vs default fallback).
         val out = subject(forecast(min = 22.0, max = 28.0), ClothesRule.DEFAULTS)
         out.rules.map { it.item }.shouldContainExactly("shorts")
         out.fallbacks.shouldContainExactly("t-shirt")
-        out.items.shouldContainExactly("shorts", "t-shirt")
+        out.items.shouldContainExactly("t-shirt", "shorts")
     }
 
     @Test

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsightTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsightTest.kt
@@ -249,6 +249,31 @@ class GenerateDailyInsightTest {
     }
 
     @Test
+    fun `warm day with shorts rule and t-shirt fallback lists the t-shirt first`() = runTest {
+        // Feels-like 22-28°C trips the shorts >24°C threshold but no top
+        // threshold rule fires, so the t-shirt comes from the default
+        // fallback. Items put tops before bottoms regardless of which
+        // clause produced them, so the prose's article picker lands on the
+        // singular t-shirt ("Wear a t-shirt and shorts.") rather than the
+        // leading plural shorts ("Wear shorts and t-shirt." — the regression
+        // this guards against).
+        val hotToday = today.copy(
+            temperatureMinC = 22.0,
+            temperatureMaxC = 28.0,
+            feelsLikeMinC = 22.0,
+            feelsLikeMaxC = 28.0,
+            precipitationProbabilityMaxPct = 10.0,
+        )
+        val weather = FakeWeatherRepository(ForecastBundle(hotToday, yesterday))
+        val subject = GenerateDailyInsight(weather, clock = clock)
+
+        val insight = subject(london, prefs).insight
+
+        insight.summary.clothes!!.items.shouldContainExactly("t-shirt", "shorts")
+        insight.recommendedItems.shouldContainExactly("t-shirt", "shorts")
+    }
+
+    @Test
     fun `outfit baseline honours the user-selected default bottom`() = runTest {
         // A denim-everyday user flips defaultBottom to JEANS in Settings; the
         // default rule that resolves the bottom slot should match the


### PR DESCRIPTION
## Summary

On a warm day the shorts rule fires (>24°C) and the t-shirt comes from the
default-top fallback, so `TriggeredOutfit.items` emitted `[shorts, t-shirt]` —
bottom first, because rules came before fallbacks in the union. The English
phraser only articled the *first* item, leaving the singular t-shirt bare:
**"Wear shorts and t-shirt."**

Two cousin fixes:

- **`TriggeredOutfit.items` stable-sorts bottoms to the end** so a t-shirt
  sourced from the default reads the same as one sourced from a user
  rule. The user's mental model is "what am I wearing", not "which
  clause produced it" — warm + default should look like any other
  temperature + rule.

- **`EnglishClothesPhraser.joinItems` articles the first item that takes
  an article**, and — in an Oxford-comma list of three or more — also
  the last item if it takes one. Middle items stay bare; plurals never
  take an article anywhere.

| Items | Prose |
| --- | --- |
| `[sweater]` | "Wear a sweater." |
| `[shorts]` | "Wear shorts." |
| `[sweater, jacket]` | "Wear a sweater and jacket." *(unchanged from before bug)* |
| `[shorts, t-shirt]` | "Wear shorts and a t-shirt." *(the fix)* |
| `[sweater, jacket, coat]` | "Wear a sweater, jacket, and a coat." *(Oxford-last)* |
| `[sweater, jacket, scarf, gloves]` | "Wear a sweater, jacket, scarf, and gloves." *(last is plural)* |
| `[shorts, gloves, scarf]` | "Wear shorts, gloves, and a scarf." *(first article-taking is also Oxford-last)* |

## Out of scope

The user also flagged that the cached `InsightSummary` bakes in
`ClothesMentionMode` and the delta threshold at generation time
(`FormatSettings.kt:213-219`), so toggling those settings doesn't take
effect until the next forecast fetch. That's a separate caching
refactor — moving the suppression from `RenderInsightSummary` to
`InsightFormatter` so only the weather provider response is cached and
text regenerates on every settings change. Follow-up PR.

## Test plan

- [x] `./gradlew :core:domain:test :core:data:test :app:testDebugUnitTest`
- [x] `./gradlew :app:assembleDebug`
- [ ] CI green
- [ ] Manual check on a warm-day forecast in items mode + layers mode

https://claude.ai/code/session_018wv7aukBtLtZuxsnYMutM9