### PR TITLE
Settings changes update the forecast prose immediately

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,6 +1,6 @@
 # Privacy Policy
 
-_Last updated: 2026-05-16_
+_Last updated: 2026-05-23_
 
 ClothesCast is a daily weather-insight app for Android. This policy
 describes what data the app handles, where it goes, and what control you
@@ -72,9 +72,11 @@ The source code is at <https://github.com/mikelward/clothescast>.
   for today's forecast _and_ (b) you have online TTS enabled — in which
   case the rendered sentence (which can include the event title) is sent
   to your chosen TTS provider for vocalization.
-- **Stored on device:** The most recent rendered insight (which may
-  contain that sentence) is cached for up to one day so the app doesn't
-  recompute it on every launch.
+- **Stored on device:** The most recent forecast snapshot is cached for
+  up to one day so the app doesn't refetch on every launch. Event titles
+  and locations are never written to disk; only event timing (start,
+  end, all-day) and a "has a location" flag are persisted, since that's
+  all the insight renderer needs to re-derive the prose.
 - **Retention by us:** Replaced on the next daily refresh; cleared on
   uninstall.
 
@@ -379,6 +381,13 @@ email the address listed on the Play Store listing.
 
 ## Changelog
 
+- **2026-05-23** — Internal change to how the daily insight is cached on
+  device: the cache now stores the upstream forecast snapshot plus
+  minimal event timing (start, end, all-day, a "has a location" flag),
+  and re-derives the insight against your current settings on read.
+  Event titles and free-form locations are not written to disk. No
+  material change to what leaves the device. See the updated "Calendar
+  events" section above.
 - **2026-05-16** — Added an optional **Smart Home / Home Assistant MQTT
   bridge** (Settings → Smart Home; off by default). When enabled, the
   app publishes the rendered forecast sentence as a retained MQTT

--- a/app/src/main/kotlin/app/clothescast/ClothesCastApplication.kt
+++ b/app/src/main/kotlin/app/clothescast/ClothesCastApplication.kt
@@ -17,6 +17,7 @@ import app.clothescast.core.domain.model.defaultsFor
 import app.clothescast.core.domain.repository.CachingWeatherRepository
 import app.clothescast.core.domain.repository.CalendarEventReader
 import app.clothescast.core.domain.repository.WeatherRepository
+import app.clothescast.core.domain.usecase.DeriveInsight
 import app.clothescast.core.domain.usecase.GenerateDailyInsight
 import app.clothescast.data.InsightCache
 import app.clothescast.data.SecureKeyStore
@@ -63,7 +64,8 @@ import kotlinx.serialization.json.Json
 class ClothesCastApplication : Application() {
     val secureKeyStore: SecureKeyStore by lazy { SecureKeyStore.create(this) }
     val settingsRepository: SettingsRepository by lazy { SettingsRepository.create(this) }
-    val insightCache: InsightCache by lazy { InsightCache.create(this) }
+    val deriveInsight: DeriveInsight by lazy { DeriveInsight() }
+    val insightCache: InsightCache by lazy { InsightCache.create(this, deriveInsight) }
     val locationResolver: LocationResolver by lazy { LocationResolver(this) }
     val reverseGeocoder: ReverseGeocoder by lazy { ReverseGeocoder(this) }
     val insightNotifier: InsightNotifier by lazy { InsightNotifier(this) }
@@ -212,6 +214,7 @@ class ClothesCastApplication : Application() {
     val generateDailyInsight: GenerateDailyInsight by lazy {
         GenerateDailyInsight(
             weatherRepository = weatherRepository,
+            deriveInsight = deriveInsight,
             calendarEventReader = calendarEventReader,
         )
     }

--- a/app/src/main/kotlin/app/clothescast/cast/CastTestDispatch.kt
+++ b/app/src/main/kotlin/app/clothescast/cast/CastTestDispatch.kt
@@ -5,6 +5,7 @@ import app.clothescast.R
 import app.clothescast.calendar.resolveHolidayTheme
 import app.clothescast.core.domain.model.ForecastPeriod
 import app.clothescast.core.domain.repository.CalendarEventReader
+import app.clothescast.core.domain.usecase.DeriveInsight
 import app.clothescast.data.InsightCache
 import app.clothescast.data.SettingsRepository
 import app.clothescast.insight.InsightFormatter
@@ -32,6 +33,7 @@ internal suspend fun castCurrentInsight(
     context: Context,
     settingsRepository: SettingsRepository,
     insightCache: InsightCache,
+    deriveInsight: DeriveInsight,
     calendarEventReader: CalendarEventReader,
     controller: CastInsightController,
     locale: java.util.Locale,
@@ -39,8 +41,9 @@ internal suspend fun castCurrentInsight(
     val prefs = settingsRepository.preferences.first()
     val routeId = prefs.castRouteId
         ?: return context.getString(R.string.cast_error_no_route_picked)
-    val insight = insightCache.thisPeriod.first()
+    val snapshot = insightCache.thisPeriod.first()
         ?: return context.getString(R.string.cast_error_no_insight_yet)
+    val insight = deriveInsight(snapshot, prefs).insight
     val outfit = insight.outfit
         ?: return context.getString(R.string.cast_error_no_insight_yet)
 

--- a/app/src/main/kotlin/app/clothescast/data/InsightCache.kt
+++ b/app/src/main/kotlin/app/clothescast/data/InsightCache.kt
@@ -6,32 +6,26 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
-import app.clothescast.core.domain.model.AlertClause
-import app.clothescast.core.domain.model.BandClause
-import app.clothescast.core.domain.model.CalendarTieInClause
-import app.clothescast.core.domain.model.ClothesClause
-import app.clothescast.core.domain.model.ClothesRule
-import app.clothescast.core.domain.model.DailyForecast
+import app.clothescast.core.domain.model.AlertSeverity
+import app.clothescast.core.domain.model.CalendarEvent
 import app.clothescast.core.domain.model.ConfidenceInfo
-import app.clothescast.core.domain.model.DeltaClause
+import app.clothescast.core.domain.model.DailyForecast
+import app.clothescast.core.domain.model.EventKind
 import app.clothescast.core.domain.model.ForecastConfidence
-import app.clothescast.core.domain.model.EveningEventTieInClause
-import app.clothescast.core.domain.model.Fact
 import app.clothescast.core.domain.model.ForecastPeriod
-import app.clothescast.core.domain.model.GarmentReason
+import app.clothescast.core.domain.model.ForecastSnapshot
 import app.clothescast.core.domain.model.HourlyForecast
-import app.clothescast.core.domain.model.Insight
-import app.clothescast.core.domain.model.InsightSummary
 import app.clothescast.core.domain.model.Location
-import app.clothescast.core.domain.model.OutfitRationale
-import app.clothescast.core.domain.model.OutfitSuggestion
 import app.clothescast.core.domain.model.PerModelHour
 import app.clothescast.core.domain.model.PerModelHourly
-import app.clothescast.core.domain.model.PrecipClause
-import app.clothescast.core.domain.model.PrecipLikelihood
-import app.clothescast.core.domain.model.TemperatureBand
+import app.clothescast.core.domain.model.UserPreferences
+import app.clothescast.core.domain.model.WeatherAlert
 import app.clothescast.core.domain.model.WeatherCondition
+import app.clothescast.core.domain.repository.ForecastBundle
+import app.clothescast.core.domain.usecase.DailyInsightResult
+import app.clothescast.core.domain.usecase.DeriveInsight
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.serialization.Serializable
@@ -45,28 +39,42 @@ import java.time.LocalTime
 import java.time.ZoneId
 
 /**
- * Persists the most recently generated [Insight]s so the daily worker can avoid
- * regenerating twice for the same day. The cache holds two slots:
+ * Persists the most recently captured upstream [ForecastSnapshot]s — the raw
+ * weather bundle from Open-Meteo plus the calendar events we read off the
+ * device — so consumers can re-derive an [app.clothescast.core.domain.model.Insight]
+ * against the *current* [UserPreferences] at any time without re-fetching the
+ * forecast. Caching at this layer (the upstream inputs) rather than at the
+ * derived [Insight] layer means a settings change — clothes rules, default
+ * top / bottom, delta threshold, clothes-mention mode, range / clothes format
+ * — re-renders the Today screen, the Format settings page preview, the home-
+ * screen widget, the cast surface and the MQTT payload in the same frame as
+ * the dropdown closes, with no preservation / re-gating logic on the cache.
  *
- *  - [Slot.THIS_PERIOD] — the insight covering the 12-hour window the user is
+ * Two slots:
+ *  - [Slot.THIS_PERIOD] — the snapshot for the 12-hour window the user is
  *    currently in (daytime in the morning, tonight in the evening). The Today
  *    screen's pager surfaces this on page 1. May be a few hours old by the
  *    time the user opens the app — the period itself is still "this one",
- *    even if the bytes were generated at the period's start.
- *  - [Slot.NEXT_PERIOD] — the insight pre-rendered for the next 12-hour window.
+ *    even if the bytes were captured at the period's start.
+ *  - [Slot.NEXT_PERIOD] — the snapshot pre-captured for the next 12-hour window.
  *    The morning alarm pre-renders tonight (same date); the evening alarm
  *    pre-renders tomorrow's daytime. The Today screen's pager surfaces this
  *    on page 2 so the "next" card always reads the next 12 hours, never the
  *    previous one.
  *
- * The role-based naming keeps the pager logic trivial — page 1 shows
- * [Slot.THIS_PERIOD], page 2 shows [Slot.NEXT_PERIOD] — and decouples the
- * cache layout from the [ForecastPeriod] kind (which is recorded inside the
- * stored insight).
+ * The role-based naming keeps the pager logic trivial — page 1 derives from
+ * [Slot.THIS_PERIOD], page 2 from [Slot.NEXT_PERIOD] — and decouples the cache
+ * layout from the [ForecastPeriod] kind (which is recorded inside the stored
+ * snapshot's [ForecastSnapshot.period]).
  *
- * The cache stores the structured [InsightSummary] (each clause as typed data)
- * rather than rendered prose, so a Region-setting change re-renders the cached
- * insight in the new locale without re-fetching the forecast.
+ * The cache stores the full [ForecastBundle] (so the delta clause keeps its
+ * yesterday data, the precip clause keeps its per-model series, and severe
+ * alerts survive a settings-driven re-render) plus a minimal projection of
+ * each [CalendarEvent] — start / end / allDay / a location-presence boolean —
+ * matching the subset [app.clothescast.core.domain.usecase.RenderInsightSummary]
+ * actually reads. Event titles and free-form location strings are
+ * deliberately not persisted, keeping the on-disk privacy posture identical
+ * to what the previous derived-insight cache held (see PRIVACY.md).
  *
  * The cache is intentionally a single slot per role — there's no historical
  * browsing planned, and bounding storage at 2 entries keeps the cost of
@@ -74,485 +82,157 @@ import java.time.ZoneId
  */
 class InsightCache(
     private val dataStore: DataStore<Preferences>,
+    private val deriveInsight: DeriveInsight = DeriveInsight(),
     private val json: Json = Json { ignoreUnknownKeys = true },
 ) {
     /**
-     * Which 12-hour window an insight occupies relative to the rendering surface:
-     * the window the user is currently inside ([THIS_PERIOD], page 1 of the pager
-     * / the home-screen widget) or the upcoming one ([NEXT_PERIOD], page 2).
-     * Stored in separate DataStore keys so the worker can overwrite each
-     * independently.
+     * Which 12-hour window a snapshot occupies relative to the rendering
+     * surface: the window the user is currently inside ([THIS_PERIOD], page 1
+     * of the pager / the home-screen widget) or the upcoming one
+     * ([NEXT_PERIOD], page 2). Stored in separate DataStore keys so the worker
+     * can overwrite each independently.
      */
     enum class Slot { THIS_PERIOD, NEXT_PERIOD }
 
-    /** The insight on page 1 of the pager — the 12-hour window the user is currently in. */
-    val thisPeriod: Flow<Insight?> = dataStore.data.map { it.readSlot(THIS_PERIOD_INSIGHT_JSON) }
+    /** Raw snapshot stored for page 1 — the 12-hour window the user is currently in. */
+    val thisPeriod: Flow<ForecastSnapshot?> = dataStore.data.map { it.readSlot(THIS_PERIOD_KEY) }
 
-    /** The insight on page 2 of the pager — the pre-rendered next 12-hour window. */
-    val nextPeriod: Flow<Insight?> = dataStore.data.map { it.readSlot(NEXT_PERIOD_INSIGHT_JSON) }
-
-    suspend fun store(slot: Slot, insight: Insight) {
-        dataStore.edit { it[keyFor(slot)] = json.encodeToString(insight.toDto()) }
-    }
+    /** Raw snapshot stored for page 2 — the pre-captured next 12-hour window. */
+    val nextPeriod: Flow<ForecastSnapshot?> = dataStore.data.map { it.readSlot(NEXT_PERIOD_KEY) }
 
     /**
-     * Re-derives the [Insight.outfit] / [Insight.outfitRationale] for every cached
-     * slot against the supplied [clothesRules], [defaultBottom], and [defaultTop],
-     * and writes the updated insight back. Used by the settings UI after a
-     * clothes-rule edit so the home-screen icon flips immediately instead of
-     * waiting for the next worker run; without this, changing the picker has no
-     * visible effect on the current forecast until the next scheduled or manual
-     * refresh.
-     *
-     * Each slot's [Insight.nextOutfit] is recomputed from the *paired* slot's
-     * hourly data — TODAY's `nextOutfit` is TONIGHT's pick, so we read TONIGHT's
-     * hourly to re-derive it (and vice versa is moot — TONIGHT's `nextOutfit` is
-     * tomorrow's pick, which we don't cache, so it stays as the worker last
-     * wrote it). Without this, the home screen's "Today + Tonight" preview row
-     * would flip the today icon but leave the tonight icon stale, making the
-     * setting look half-applied.
-     *
-     * Slots without enough hourly entries to reconstruct a [DailyForecast] are
-     * skipped — the rest of the insight stays as-is and the picker just inherits
-     * the stale outfit until the next worker run.
+     * Derives the [DailyInsightResult] for [slot] against [prefs] using the
+     * latest cached snapshot. Re-emits whenever either input changes, so the
+     * Today screen / Format settings preview / widget always render the current
+     * prefs against the most recent weather data without anyone having to
+     * re-trigger a recompute. `now` defaults to the snapshot's `generatedAt`
+     * — alerts are filtered against that timestamp, which matches the worker's
+     * "active at fetch time" semantics; pass a different clock for tests that
+     * want to age alerts past expiry.
      */
-    suspend fun recomputeOutfits(
-        clothesRules: List<ClothesRule>,
-        defaultBottom: OutfitSuggestion.Bottom,
-        defaultTop: OutfitSuggestion.Top,
-    ) {
-        dataStore.edit { prefs ->
-            // Read both slots up front so THIS_PERIOD's `nextOutfit` can
-            // borrow NEXT_PERIOD's hourly when re-deriving. NEXT_PERIOD's
-            // own `nextOutfit` has no peer to borrow from in the cache (we
-            // don't store a third slot), so it stays as whatever the worker
-            // last wrote.
-            val thisPeriodInsight = prefs[THIS_PERIOD_INSIGHT_JSON]?.let { decodeInsight(it) }
-            val nextPeriodInsight = prefs[NEXT_PERIOD_INSIGHT_JSON]?.let { decodeInsight(it) }
-            // Only borrow when NEXT_PERIOD actually represents the window
-            // that follows THIS_PERIOD's — opposite period kinds. After a
-            // healthy paired worker run this always holds; the guard
-            // protects against a partial-write degraded state where
-            // NEXT_PERIOD is left over from the previous worker run (same
-            // period kind, ~12 h stale).
-            val nextForBorrow = nextPeriodInsight?.takeIf {
-                it.period == thisPeriodInsight?.period?.opposite()
-            }
-            thisPeriodInsight?.recomputed(
-                clothesRules = clothesRules,
-                defaultBottom = defaultBottom,
-                defaultTop = defaultTop,
-                nextSlot = nextForBorrow,
-            )?.let { prefs[THIS_PERIOD_INSIGHT_JSON] = json.encodeToString(it.toDto()) }
-            nextPeriodInsight?.recomputed(
-                clothesRules = clothesRules,
-                defaultBottom = defaultBottom,
-                defaultTop = defaultTop,
-                nextSlot = null,
-            )?.let { prefs[NEXT_PERIOD_INSIGHT_JSON] = json.encodeToString(it.toDto()) }
+    fun deriveFlow(
+        slot: Slot,
+        prefsFlow: Flow<UserPreferences>,
+        now: (snapshot: ForecastSnapshot) -> Instant = ForecastSnapshot::generatedAt,
+    ): Flow<DailyInsightResult?> {
+        val snapshotFlow = when (slot) {
+            Slot.THIS_PERIOD -> thisPeriod
+            Slot.NEXT_PERIOD -> nextPeriod
+        }
+        return combine(snapshotFlow, prefsFlow) { snapshot, prefs ->
+            snapshot?.let { deriveInsight(it, prefs, now(it)) }
         }
     }
 
-    private fun decodeInsight(raw: String): Insight? =
-        runCatching { json.decodeFromString<InsightDto>(raw).toDomain() }.getOrNull()
-
-    /**
-     * Returns this insight with its `outfit` and (when [nextSlot] supplies the
-     * paired hourly) `nextOutfit` re-derived against the supplied rules. Returns
-     * `null` when this slot has no hourly data — there's nothing to recompute
-     * against, so the caller leaves the slot alone.
-     *
-     * When [nextSlot] is null or hourly-less, this slot's existing `nextOutfit`
-     * / `nextOutfitRationale` are preserved verbatim — only the next worker run
-     * can refresh them.
-     */
-    private fun Insight.recomputed(
-        clothesRules: List<ClothesRule>,
-        defaultBottom: OutfitSuggestion.Bottom,
-        defaultTop: OutfitSuggestion.Top,
-        nextSlot: Insight?,
-    ): Insight? {
-        val selfForecast = toReconstructedForecast() ?: return null
-        val nextForecast = nextSlot?.toReconstructedForecast()
-        return copy(
-            outfit = OutfitSuggestion.fromForecast(selfForecast, clothesRules, defaultBottom, defaultTop),
-            outfitRationale = OutfitSuggestion.explainFromForecast(selfForecast, clothesRules),
-            nextOutfit = if (nextForecast != null) {
-                OutfitSuggestion.fromForecast(nextForecast, clothesRules, defaultBottom, defaultTop)
-            } else nextOutfit,
-            nextOutfitRationale = if (nextForecast != null) {
-                OutfitSuggestion.explainFromForecast(nextForecast, clothesRules)
-            } else nextOutfitRationale,
-        )
+    suspend fun store(slot: Slot, snapshot: ForecastSnapshot) {
+        dataStore.edit { it[keyFor(slot)] = json.encodeToString(snapshot.toDto()) }
     }
 
     /**
-     * Rebuilds the daily-aggregate fields ([DailyForecast.feelsLikeMinC] etc.)
-     * from the cached hourly entries. Rule conditions only look at the min /
-     * max / probability aggregates and at `hourly` itself, so a forecast
-     * reconstructed this way is sufficient for [OutfitSuggestion.fromForecast]
-     * even though we don't cache `precipitationMmTotal` or the high-level
-     * [WeatherCondition] (the picker doesn't read either).
-     */
-    private fun Insight.toReconstructedForecast(): DailyForecast? {
-        if (hourly.isEmpty()) return null
-        return DailyForecast(
-            date = forDate,
-            temperatureMinC = hourly.minOf { it.temperatureC },
-            temperatureMaxC = hourly.maxOf { it.temperatureC },
-            feelsLikeMinC = hourly.minOf { it.feelsLikeC },
-            feelsLikeMaxC = hourly.maxOf { it.feelsLikeC },
-            precipitationProbabilityMaxPct = hourly.maxOf { it.precipitationProbabilityPct },
-            precipitationMmTotal = 0.0,
-            condition = WeatherCondition.CLEAR,
-            hourly = hourly,
-        )
-    }
-
-    /**
-     * The just-delivered insight matching [today] and [period], or null when
-     * the THIS_PERIOD slot holds nothing matching. Used by the worker to
-     * dedup "Fire insight now" debug taps against the same-day alarm — the
-     * second call redelivers the cached payload instead of burning another
-     * fetch.
+     * The just-delivered insight matching [today] and [period], derived from
+     * the cached snapshot against the supplied [prefs]. Returns null when the
+     * THIS_PERIOD slot holds nothing matching. Used by the worker to dedup
+     * "Fire insight now" debug taps against the same-day alarm — the second
+     * call redelivers the cached snapshot instead of burning another fetch.
      *
      * Only the THIS_PERIOD slot is consulted; the NEXT_PERIOD slot is a
-     * pre-render that hasn't been delivered yet, and dedup-matching against
+     * pre-capture that hasn't been delivered yet, and dedup-matching against
      * it would silently cause the morning alarm to redeliver yesterday-
      * evening's pre-cached Saturday-daytime insight instead of fetching a
      * fresh Saturday forecast.
      */
-    suspend fun deliveredForToday(today: LocalDate, period: ForecastPeriod): Insight? {
-        val cached = thisPeriod.first() ?: return null
-        return cached.takeIf { it.forDate == today && it.period == period }
+    suspend fun deliveredForToday(
+        today: LocalDate,
+        period: ForecastPeriod,
+        prefs: UserPreferences,
+        now: Instant? = null,
+    ): DailyInsightResult? {
+        val snapshot = thisPeriod.first() ?: return null
+        if (snapshot.bundle.today.date != today || snapshot.period != period) return null
+        return deriveInsight(snapshot, prefs, now ?: snapshot.generatedAt)
     }
 
     suspend fun clear() {
         dataStore.edit {
-            it.remove(THIS_PERIOD_INSIGHT_JSON)
-            it.remove(NEXT_PERIOD_INSIGHT_JSON)
+            it.remove(THIS_PERIOD_KEY)
+            it.remove(NEXT_PERIOD_KEY)
         }
     }
 
-    private fun Preferences.readSlot(key: androidx.datastore.preferences.core.Preferences.Key<String>): Insight? {
+    private fun Preferences.readSlot(key: androidx.datastore.preferences.core.Preferences.Key<String>): ForecastSnapshot? {
         val raw = this[key] ?: return null
-        return runCatching { json.decodeFromString<InsightDto>(raw).toDomain() }.getOrNull()
+        return runCatching { json.decodeFromString<ForecastSnapshotDto>(raw).toDomain() }.getOrNull()
     }
 
     private fun keyFor(slot: Slot): androidx.datastore.preferences.core.Preferences.Key<String> =
         when (slot) {
-            Slot.THIS_PERIOD -> THIS_PERIOD_INSIGHT_JSON
-            Slot.NEXT_PERIOD -> NEXT_PERIOD_INSIGHT_JSON
+            Slot.THIS_PERIOD -> THIS_PERIOD_KEY
+            Slot.NEXT_PERIOD -> NEXT_PERIOD_KEY
         }
 
     @Serializable
-    private data class InsightDto(
-        val summary: InsightSummaryDto,
-        val recommendedItems: List<String>,
-        val generatedAtEpochMillis: Long,
-        val forDateEpochDays: Long,
-        val hourly: List<HourlyDto> = emptyList(),
-        val outfit: OutfitDto? = null,
-        val nextOutfit: OutfitDto? = null,
-        val outfitRationale: OutfitRationaleDto? = null,
-        val nextOutfitRationale: OutfitRationaleDto? = null,
-        val period: String = ForecastPeriod.TODAY.name,
-        val hasEvents: Boolean = false,
+    private data class ForecastSnapshotDto(
+        val bundle: ForecastBundleDto,
+        val events: List<CalendarEventDto> = emptyList(),
         val location: LocationDto? = null,
+        val period: String = ForecastPeriod.TODAY.name,
+        val generatedAtEpochMillis: Long,
+    ) {
+        fun toDomain(): ForecastSnapshot = ForecastSnapshot(
+            bundle = bundle.toDomain(),
+            events = events.map { it.toDomain() },
+            location = location?.toDomain(),
+            period = runCatching { ForecastPeriod.valueOf(period) }.getOrDefault(ForecastPeriod.TODAY),
+            generatedAt = Instant.ofEpochMilli(generatedAtEpochMillis),
+        )
+    }
+
+    @Serializable
+    private data class ForecastBundleDto(
+        val today: DailyForecastDto,
+        val yesterday: DailyForecastDto,
+        val alerts: List<AlertDto> = emptyList(),
         val confidence: ConfidenceInfoDto? = null,
         val perModelHourly: PerModelHourlyDto? = null,
-        // IANA zone id of the upstream forecast (Open-Meteo `timezone=auto`).
-        // Null on payloads written by an older version; the consumer falls
-        // back to the device zone, which matches the auto-location case but
-        // not a manual location in a different zone.
+        val tomorrowHourly: List<HourlyDto> = emptyList(),
+        val tomorrow: DailyForecastDto? = null,
         val forecastZoneId: String? = null,
     ) {
-        fun toDomain(): Insight {
-            val date = LocalDate.ofEpochDay(forDateEpochDays)
-            return Insight(
-                summary = summary.toDomain(),
-                recommendedItems = recommendedItems,
-                generatedAt = Instant.ofEpochMilli(generatedAtEpochMillis),
-                forDate = date,
-                location = location?.toDomain(),
-                hourly = hourly.map { it.toDomain() },
-                confidence = confidence?.toDomain(),
-                perModelHourly = perModelHourly?.toDomain(date),
-                outfit = outfit?.toDomain(),
-                nextOutfit = nextOutfit?.toDomain(),
-                outfitRationale = outfitRationale?.toDomain(),
-                nextOutfitRationale = nextOutfitRationale?.toDomain(),
-                period = runCatching { ForecastPeriod.valueOf(period) }.getOrDefault(ForecastPeriod.TODAY),
-                hasEvents = hasEvents,
-                forecastZone = forecastZoneId?.let { runCatching { ZoneId.of(it) }.getOrNull() },
-            )
-        }
-    }
-
-    @Serializable
-    private data class PerModelHourlyDto(
-        val byModel: Map<String, List<PerModelHourDto>>,
-    ) {
-        // Returns null when any entry on any model lacks [PerModelHourDto.temperatureC]
-        // — i.e., the cached payload was written by a version that only carried
-        // apparent temperature. Dropping the whole overlay (rather than backfilling
-        // a placeholder 0°C) means the air-temp model lines simply hide until the
-        // next worker refresh repopulates the cache; the alternative would draw a
-        // glaringly-wrong flat-0 line.
-        //
-        // [date] is the surrounding insight's `forDate` — used to rebuild each
-        // entry's [PerModelHour.time] LocalDateTime. GenerateDailyInsight only
-        // ever caches today's per-model hours (the slice in `slicedTo` narrows
-        // to today's daytime), so pairing with `forDate` reconstructs the
-        // correct date for every entry.
-        fun toDomain(date: LocalDate): PerModelHourly? {
-            val out = LinkedHashMap<String, List<PerModelHour>>(byModel.size)
-            for ((model, hours) in byModel) {
-                val converted = ArrayList<PerModelHour>(hours.size)
-                for (dto in hours) converted += dto.toDomain(date) ?: return null
-                out[model] = converted
-            }
-            return PerModelHourly(byModel = out)
-        }
-    }
-
-    @Serializable
-    private data class PerModelHourDto(
-        val secondOfDay: Int,
-        val apparentTemperatureC: Double,
-        // Nullable for backwards compat: pre-temperatureC cache payloads omit it,
-        // and we surface that as "no overlay" rather than a fake 0°C line.
-        val temperatureC: Double? = null,
-        // Nullable: Open-Meteo omits `precipitation_probability_<model>` for
-        // models that don't expose it (UKMO, JMA, GEM, ARPEGE, …); the
-        // domain models that as null so precip aggregates can skip the
-        // model rather than treating it as a 0% rain vote. Pre-fix cache
-        // payloads carried a non-null value, so the default of null only
-        // applies on a write from a model that legitimately lacks precip;
-        // existing entries deserialise their stored number unchanged.
-        val precipitationProbabilityPct: Double? = null,
-        // Diagnostic fields — nullable in the domain too, so missing values just
-        // hide that model from the wind / humidity / cloud chart rather than
-        // dropping the temperature overlay entirely.
-        val windSpeedKmh: Double? = null,
-        val relativeHumidityPct: Double? = null,
-        val cloudCoverPct: Double? = null,
-        val shortwaveRadiationWm2: Double? = null,
-        val sunshineDurationSec: Double? = null,
-        val uvIndex: Double? = null,
-        // Weather code bucket, stored as the enum name so a future enum
-        // rename trips deserialisation rather than silently mapping to the
-        // wrong bucket. Nullable for back-compat with payloads written
-        // before the modal condition aggregation landed.
-        val conditionName: String? = null,
-    ) {
-        fun toDomain(date: LocalDate): PerModelHour? {
-            val airTemp = temperatureC ?: return null
-            return PerModelHour(
-                time = LocalDateTime.of(date, LocalTime.ofSecondOfDay(secondOfDay.toLong())),
-                apparentTemperatureC = apparentTemperatureC,
-                temperatureC = airTemp,
-                precipitationProbabilityPct = precipitationProbabilityPct,
-                windSpeedKmh = windSpeedKmh,
-                relativeHumidityPct = relativeHumidityPct,
-                cloudCoverPct = cloudCoverPct,
-                shortwaveRadiationWm2 = shortwaveRadiationWm2,
-                sunshineDurationSec = sunshineDurationSec,
-                uvIndex = uvIndex,
-                condition = conditionName?.let {
-                    runCatching { WeatherCondition.valueOf(it) }.getOrNull()
-                },
-            )
-        }
-    }
-
-    @Serializable
-    private data class ConfidenceInfoDto(
-        val level: String,
-        val tempSpreadC: Double,
-        val precipSpreadPp: Double,
-        val modelsConsulted: List<String>,
-    ) {
-        fun toDomain(): ConfidenceInfo = ConfidenceInfo(
-            level = runCatching { ForecastConfidence.valueOf(level) }
-                .getOrDefault(ForecastConfidence.MEDIUM),
-            tempSpreadC = tempSpreadC,
-            precipSpreadPp = precipSpreadPp,
-            modelsConsulted = modelsConsulted,
+        fun toDomain(): ForecastBundle = ForecastBundle(
+            today = today.toDomain(),
+            yesterday = yesterday.toDomain(),
+            alerts = alerts.map { it.toDomain() },
+            confidence = confidence?.toDomain(),
+            perModelHourly = perModelHourly?.toDomain(),
+            tomorrowHourly = tomorrowHourly.map { it.toDomain() },
+            tomorrow = tomorrow?.toDomain(),
+            forecastZone = forecastZoneId?.let { runCatching { ZoneId.of(it) }.getOrNull() },
         )
     }
 
     @Serializable
-    private data class LocationDto(
-        val latitude: Double,
-        val longitude: Double,
-        val displayName: String? = null,
-    ) {
-        fun toDomain(): Location = Location(
-            latitude = latitude,
-            longitude = longitude,
-            displayName = displayName,
-        )
-    }
-
-    @Serializable
-    private data class InsightSummaryDto(
-        val period: String,
-        val band: BandDto,
-        val alert: AlertDto? = null,
-        val delta: DeltaDto? = null,
-        val clothes: ClothesDto? = null,
-        val precip: PrecipDto? = null,
-        val calendarTieIn: CalendarTieInDto? = null,
-        val eveningEventTieIn: EveningEventTieInDto? = null,
-    ) {
-        fun toDomain(): InsightSummary = InsightSummary(
-            period = runCatching { ForecastPeriod.valueOf(period) }.getOrDefault(ForecastPeriod.TODAY),
-            band = band.toDomain(),
-            alert = alert?.toDomain(),
-            delta = delta?.toDomain(),
-            clothes = clothes?.toDomain(),
-            precip = precip?.toDomain(),
-            calendarTieIn = calendarTieIn?.toDomain(),
-            eveningEventTieIn = eveningEventTieIn?.toDomain(),
-        )
-    }
-
-    @Serializable
-    private data class BandDto(
-        val low: String,
-        val high: String,
-        // Nullable + default null so payloads written before the feels-like
-        // temps were carried round-trip through this DTO unchanged. When
-        // absent, the domain object falls back to the band's midpoint °C
-        // (see TemperatureBand.midpointC) so the prose still renders.
-        val lowC: Double? = null,
-        val highC: Double? = null,
-    ) {
-        fun toDomain(): BandClause {
-            val lowBand = runCatching { TemperatureBand.valueOf(low) }.getOrDefault(TemperatureBand.MILD)
-            val highBand = runCatching { TemperatureBand.valueOf(high) }.getOrDefault(TemperatureBand.MILD)
-            return BandClause(
-                low = lowBand,
-                high = highBand,
-                feelsLikeMinC = lowC ?: lowBand.midpointC(),
-                feelsLikeMaxC = highC ?: highBand.midpointC(),
-            )
-        }
-    }
-
-    @Serializable
-    private data class AlertDto(val event: String) {
-        fun toDomain(): AlertClause = AlertClause(event)
-    }
-
-    @Serializable
-    private data class DeltaDto(val degrees: Int, val direction: String) {
-        fun toDomain(): DeltaClause = DeltaClause(
-            degrees = degrees,
-            direction = runCatching { DeltaClause.Direction.valueOf(direction) }
-                .getOrDefault(DeltaClause.Direction.WARMER),
-        )
-    }
-
-    @Serializable
-    private data class ClothesDto(val items: List<String>) {
-        fun toDomain(): ClothesClause = ClothesClause(items)
-    }
-
-    @Serializable
-    private data class PrecipDto(
+    private data class DailyForecastDto(
+        val dateEpochDays: Long,
+        val temperatureMinC: Double,
+        val temperatureMaxC: Double,
+        val feelsLikeMinC: Double,
+        val feelsLikeMaxC: Double,
+        val precipitationProbabilityMaxPct: Double,
+        val precipitationMmTotal: Double,
         val condition: String,
-        val secondOfDay: Int,
-        // Default to LIKELY so cached payloads written before the field existed
-        // round-trip as the pre-tier "Rain at 3pm." form they were originally
-        // generated with — same rationale as PrecipClause's domain default.
-        val likelihood: String = PrecipLikelihood.LIKELY.name,
+        val hourly: List<HourlyDto> = emptyList(),
     ) {
-        fun toDomain(): PrecipClause = PrecipClause(
+        fun toDomain(): DailyForecast = DailyForecast(
+            date = LocalDate.ofEpochDay(dateEpochDays),
+            temperatureMinC = temperatureMinC,
+            temperatureMaxC = temperatureMaxC,
+            feelsLikeMinC = feelsLikeMinC,
+            feelsLikeMaxC = feelsLikeMaxC,
+            precipitationProbabilityMaxPct = precipitationProbabilityMaxPct,
+            precipitationMmTotal = precipitationMmTotal,
             condition = runCatching { WeatherCondition.valueOf(condition) }
                 .getOrDefault(WeatherCondition.UNKNOWN),
-            time = LocalTime.ofSecondOfDay(secondOfDay.toLong()),
-            likelihood = runCatching { PrecipLikelihood.valueOf(likelihood) }
-                .getOrDefault(PrecipLikelihood.LIKELY),
-        )
-    }
-
-    @Serializable
-    private data class CalendarTieInDto(val item: String) {
-        fun toDomain(): CalendarTieInClause = CalendarTieInClause(item = item)
-    }
-
-    @Serializable
-    private data class EveningEventTieInDto(
-        // The current shape carries every night-only clothes item the tie-in
-        // names ("a jacket and coat"). Defaults to an empty list so payloads
-        // written before this field landed decode without an explicit list.
-        val items: List<String> = emptyList(),
-        // Kept for back-compat: pre-multi-item payloads stored the single
-        // chosen item here. On read we fold it into [items] when [items] is
-        // empty; on write we also populate it with the first list entry so a
-        // downgraded build reading new payloads still surfaces at least one
-        // item.
-        val item: String? = null,
-        val rainSecondOfDay: Int? = null,
-        // Nullable for back-compat: payloads written before the field landed
-        // decode with `null`, and [toDomain] folds that to LIKELY — the same
-        // wording the older code produced unconditionally.
-        val likelihood: String? = null,
-    ) {
-        fun toDomain(): EveningEventTieInClause = EveningEventTieInClause(
-            items = items.ifEmpty { item?.let { listOf(it) }.orEmpty() },
-            rainTime = rainSecondOfDay?.let { LocalTime.ofSecondOfDay(it.toLong()) },
-            likelihood = likelihood
-                ?.let { runCatching { PrecipLikelihood.valueOf(it) }.getOrNull() }
-                ?: PrecipLikelihood.LIKELY,
-        )
-    }
-
-    @Serializable
-    private data class OutfitDto(val top: String, val bottom: String) {
-        fun toDomain(): OutfitSuggestion? {
-            val t = runCatching { OutfitSuggestion.Top.valueOf(top) }.getOrNull() ?: return null
-            val b = runCatching { OutfitSuggestion.Bottom.valueOf(bottom) }.getOrNull() ?: return null
-            return OutfitSuggestion(t, b)
-        }
-    }
-
-    @Serializable
-    private data class OutfitRationaleDto(
-        val top: GarmentReasonDto,
-        val bottom: GarmentReasonDto,
-    ) {
-        fun toDomain(): OutfitRationale = OutfitRationale(
-            top = top.toDomain(),
-            bottom = bottom.toDomain(),
-        )
-    }
-
-    @Serializable
-    private data class GarmentReasonDto(val facts: List<FactDto>) {
-        fun toDomain(): GarmentReason = GarmentReason(facts = facts.map { it.toDomain() })
-    }
-
-    @Serializable
-    private data class FactDto(
-        val metric: String,
-        val observedC: Double,
-        val observedAtSecondOfDay: Int? = null,
-        val thresholdC: Double,
-        val ruleItem: String,
-        val comparison: String,
-    ) {
-        fun toDomain(): Fact = Fact(
-            metric = runCatching { Fact.Metric.valueOf(metric) }
-                .getOrDefault(Fact.Metric.FEELS_LIKE_MIN),
-            observedC = observedC,
-            observedAt = observedAtSecondOfDay?.let { LocalTime.ofSecondOfDay(it.toLong()) },
-            thresholdC = thresholdC,
-            ruleItem = ruleItem,
-            comparison = runCatching { Fact.Comparison.valueOf(comparison) }
-                .getOrDefault(Fact.Comparison.AT_OR_ABOVE),
+            hourly = hourly.map { it.toDomain() },
         )
     }
 
@@ -574,22 +254,194 @@ class InsightCache(
         )
     }
 
-    private fun Insight.toDto(): InsightDto = InsightDto(
-        summary = summary.toDto(),
-        recommendedItems = recommendedItems,
-        generatedAtEpochMillis = generatedAt.toEpochMilli(),
-        forDateEpochDays = forDate.toEpochDay(),
-        hourly = hourly.map { it.toDto() },
-        outfit = outfit?.let { OutfitDto(it.top.name, it.bottom.name) },
-        nextOutfit = nextOutfit?.let { OutfitDto(it.top.name, it.bottom.name) },
-        outfitRationale = outfitRationale?.toDto(),
-        nextOutfitRationale = nextOutfitRationale?.toDto(),
+    @Serializable
+    private data class AlertDto(
+        val event: String,
+        val severity: String,
+        val headline: String? = null,
+        val description: String? = null,
+        val onsetEpochMillis: Long,
+        val expiresEpochMillis: Long,
+    ) {
+        fun toDomain(): WeatherAlert = WeatherAlert(
+            event = event,
+            severity = runCatching { AlertSeverity.valueOf(severity) }
+                .getOrDefault(AlertSeverity.MINOR),
+            headline = headline,
+            description = description,
+            onset = Instant.ofEpochMilli(onsetEpochMillis),
+            expires = Instant.ofEpochMilli(expiresEpochMillis),
+        )
+    }
+
+    @Serializable
+    private data class ConfidenceInfoDto(
+        val level: String,
+        val tempSpreadC: Double,
+        val precipSpreadPp: Double,
+        val modelsConsulted: List<String>,
+    ) {
+        fun toDomain(): ConfidenceInfo = ConfidenceInfo(
+            level = runCatching { ForecastConfidence.valueOf(level) }
+                .getOrDefault(ForecastConfidence.MEDIUM),
+            tempSpreadC = tempSpreadC,
+            precipSpreadPp = precipSpreadPp,
+            modelsConsulted = modelsConsulted,
+        )
+    }
+
+    @Serializable
+    private data class PerModelHourlyDto(
+        val byModel: Map<String, List<PerModelHourDto>>,
+    ) {
+        fun toDomain(): PerModelHourly? {
+            val out = LinkedHashMap<String, List<PerModelHour>>(byModel.size)
+            for ((model, hours) in byModel) {
+                val converted = ArrayList<PerModelHour>(hours.size)
+                for (dto in hours) converted += dto.toDomain() ?: return null
+                out[model] = converted
+            }
+            return PerModelHourly(byModel = out)
+        }
+    }
+
+    @Serializable
+    private data class PerModelHourDto(
+        // Per-entry date so the bundle's full per-model series (today + tomorrow,
+        // up to 48 h depending on the upstream window) survives the round-trip
+        // intact. Pairing every entry with a single `forDate` would alias
+        // tomorrow's pre-dawn hours onto today's date and break tonight's
+        // wrap-past-midnight slice in [DeriveInsight].
+        val dateEpochDays: Long,
+        val secondOfDay: Int,
+        val apparentTemperatureC: Double,
+        val temperatureC: Double? = null,
+        val precipitationProbabilityPct: Double? = null,
+        val windSpeedKmh: Double? = null,
+        val relativeHumidityPct: Double? = null,
+        val cloudCoverPct: Double? = null,
+        val shortwaveRadiationWm2: Double? = null,
+        val sunshineDurationSec: Double? = null,
+        val uvIndex: Double? = null,
+        val conditionName: String? = null,
+    ) {
+        fun toDomain(): PerModelHour? {
+            val airTemp = temperatureC ?: return null
+            return PerModelHour(
+                time = LocalDateTime.of(
+                    LocalDate.ofEpochDay(dateEpochDays),
+                    LocalTime.ofSecondOfDay(secondOfDay.toLong()),
+                ),
+                apparentTemperatureC = apparentTemperatureC,
+                temperatureC = airTemp,
+                precipitationProbabilityPct = precipitationProbabilityPct,
+                windSpeedKmh = windSpeedKmh,
+                relativeHumidityPct = relativeHumidityPct,
+                cloudCoverPct = cloudCoverPct,
+                shortwaveRadiationWm2 = shortwaveRadiationWm2,
+                sunshineDurationSec = sunshineDurationSec,
+                uvIndex = uvIndex,
+                condition = conditionName?.let {
+                    runCatching { WeatherCondition.valueOf(it) }.getOrNull()
+                },
+            )
+        }
+    }
+
+    @Serializable
+    private data class LocationDto(
+        val latitude: Double,
+        val longitude: Double,
+        val displayName: String? = null,
+        val countryCode: String? = null,
+    ) {
+        fun toDomain(): Location = Location(
+            latitude = latitude,
+            longitude = longitude,
+            displayName = displayName,
+            countryCode = countryCode,
+        )
+    }
+
+    /**
+     * Minimal projection of [CalendarEvent] for on-disk persistence: only the
+     * fields `RenderInsightSummary` actually consults — `start`, `end`, `allDay`,
+     * and a `hasLocation` *presence* flag — survive the round-trip.
+     *
+     * Titles and free-form location strings are deliberately dropped, matching
+     * the privacy posture of the previous derived-insight cache (which stored
+     * `CalendarTieInClause(item: String)` — a garment name, never the event
+     * title). The renderer's only reads of `location` are presence checks
+     * (`!it.location.isNullOrBlank()`), so on materialisation we surface a
+     * placeholder `"x"` when `hasLocation == true` and `null` otherwise; titles
+     * collapse to an empty string for the same reason. See PRIVACY.md.
+     */
+    @Serializable
+    private data class CalendarEventDto(
+        val startSecondOfDay: Int,
+        val endSecondOfDay: Int,
+        val allDay: Boolean = false,
+        val hasLocation: Boolean = false,
+    ) {
+        fun toDomain(): CalendarEvent = CalendarEvent(
+            title = "",
+            start = LocalTime.ofSecondOfDay(startSecondOfDay.toLong()),
+            end = LocalTime.ofSecondOfDay(endSecondOfDay.toLong()),
+            location = if (hasLocation) PLACEHOLDER_LOCATION else null,
+            allDay = allDay,
+            kind = EventKind.NORMAL,
+            ownerAccount = null,
+        )
+    }
+
+    private fun ForecastSnapshot.toDto(): ForecastSnapshotDto = ForecastSnapshotDto(
+        bundle = bundle.toDto(),
+        events = events.map { it.toDto() },
+        location = location?.let {
+            LocationDto(it.latitude, it.longitude, it.displayName, it.countryCode)
+        },
         period = period.name,
-        hasEvents = hasEvents,
-        location = location?.let { LocationDto(it.latitude, it.longitude, it.displayName) },
+        generatedAtEpochMillis = generatedAt.toEpochMilli(),
+    )
+
+    private fun ForecastBundle.toDto(): ForecastBundleDto = ForecastBundleDto(
+        today = today.toDto(),
+        yesterday = yesterday.toDto(),
+        alerts = alerts.map { it.toDto() },
         confidence = confidence?.toDto(),
         perModelHourly = perModelHourly?.toDto(),
+        tomorrowHourly = tomorrowHourly.map { it.toDto() },
+        tomorrow = tomorrow?.toDto(),
         forecastZoneId = forecastZone?.id,
+    )
+
+    private fun DailyForecast.toDto(): DailyForecastDto = DailyForecastDto(
+        dateEpochDays = date.toEpochDay(),
+        temperatureMinC = temperatureMinC,
+        temperatureMaxC = temperatureMaxC,
+        feelsLikeMinC = feelsLikeMinC,
+        feelsLikeMaxC = feelsLikeMaxC,
+        precipitationProbabilityMaxPct = precipitationProbabilityMaxPct,
+        precipitationMmTotal = precipitationMmTotal,
+        condition = condition.name,
+        hourly = hourly.map { it.toDto() },
+    )
+
+    private fun HourlyForecast.toDto(): HourlyDto = HourlyDto(
+        secondOfDay = time.toSecondOfDay(),
+        temperatureC = temperatureC,
+        feelsLikeC = feelsLikeC,
+        precipitationProbabilityPct = precipitationProbabilityPct,
+        condition = condition.name,
+    )
+
+    private fun WeatherAlert.toDto(): AlertDto = AlertDto(
+        event = event,
+        severity = severity.name,
+        headline = headline,
+        description = description,
+        onsetEpochMillis = onset.toEpochMilli(),
+        expiresEpochMillis = expires.toEpochMilli(),
     )
 
     private fun ConfidenceInfo.toDto(): ConfidenceInfoDto = ConfidenceInfoDto(
@@ -604,10 +456,7 @@ class InsightCache(
     )
 
     private fun PerModelHour.toDto(): PerModelHourDto = PerModelHourDto(
-        // Only the hour-of-day is persisted; the surrounding insight's
-        // `forDate` rebuilds the LocalDateTime on read. Today's per-model
-        // slice is the only thing GenerateDailyInsight caches, so the date
-        // is unambiguous.
+        dateEpochDays = time.toLocalDate().toEpochDay(),
         secondOfDay = time.toLocalTime().toSecondOfDay(),
         apparentTemperatureC = apparentTemperatureC,
         temperatureC = temperatureC,
@@ -621,72 +470,34 @@ class InsightCache(
         conditionName = condition?.name,
     )
 
-    private fun OutfitRationale.toDto(): OutfitRationaleDto = OutfitRationaleDto(
-        top = top.toDto(),
-        bottom = bottom.toDto(),
-    )
-
-    private fun GarmentReason.toDto(): GarmentReasonDto =
-        GarmentReasonDto(facts = facts.map { it.toDto() })
-
-    private fun Fact.toDto(): FactDto = FactDto(
-        metric = metric.name,
-        observedC = observedC,
-        observedAtSecondOfDay = observedAt?.toSecondOfDay(),
-        thresholdC = thresholdC,
-        ruleItem = ruleItem,
-        comparison = comparison.name,
-    )
-
-    private fun InsightSummary.toDto(): InsightSummaryDto = InsightSummaryDto(
-        period = period.name,
-        band = BandDto(band.low.name, band.high.name, band.feelsLikeMinC, band.feelsLikeMaxC),
-        alert = alert?.let { AlertDto(it.event) },
-        delta = delta?.let { DeltaDto(it.degrees, it.direction.name) },
-        clothes = clothes?.let { ClothesDto(it.items) },
-        precip = precip?.let {
-            PrecipDto(it.condition.name, it.time.toSecondOfDay(), it.likelihood.name)
-        },
-        calendarTieIn = calendarTieIn?.let { CalendarTieInDto(it.item) },
-        eveningEventTieIn = eveningEventTieIn?.let {
-            EveningEventTieInDto(
-                items = it.items,
-                // Mirror the first item into the legacy single-item field so a
-                // downgraded build reading this payload still surfaces something
-                // ("a jacket" instead of nothing) — the older reader doesn't
-                // know about the multi-item list.
-                item = it.items.firstOrNull(),
-                rainSecondOfDay = it.rainTime?.toSecondOfDay(),
-                likelihood = it.likelihood.name,
-            )
-        },
-    )
-
-    private fun HourlyForecast.toDto(): HourlyDto = HourlyDto(
-        secondOfDay = time.toSecondOfDay(),
-        temperatureC = temperatureC,
-        feelsLikeC = feelsLikeC,
-        precipitationProbabilityPct = precipitationProbabilityPct,
-        condition = condition.name,
+    private fun CalendarEvent.toDto(): CalendarEventDto = CalendarEventDto(
+        startSecondOfDay = start.toSecondOfDay(),
+        endSecondOfDay = end.toSecondOfDay(),
+        allDay = allDay,
+        hasLocation = !location.isNullOrBlank(),
     )
 
     companion object {
-        // Bumped when the cache layout switched from period-keyed
-        // (TODAY / TONIGHT) slots to role-keyed (CURRENT / NEXT) slots so the
-        // pager can always show the current + next 12-hour window. Old
-        // period-keyed payloads stay readable from the legacy keys for one
-        // upgrade cycle; on the next worker run the new keys are populated
-        // and the legacy ones are dropped.
-        //
-        // The `_v6` suffix continues the existing schema-version pattern (the
-        // previous bump was `_v5` when [Fact] swapped its `thresholdKind` enum
-        // for a free-form [Fact.ruleItem] string), so any same-day-old cached
-        // payload with the previous shape is dropped on first read rather
-        // than silently misinterpreted.
-        private val THIS_PERIOD_INSIGHT_JSON = stringPreferencesKey("this_period_insight_v6")
-        private val NEXT_PERIOD_INSIGHT_JSON = stringPreferencesKey("next_period_insight_v6")
+        // Bumped to v7 with the schema switch from a derived `Insight` payload
+        // to the raw `ForecastSnapshot` (bundle + minimal events) it's derived
+        // from. The previous shape (v6) doesn't deserialise into the new DTO,
+        // so the cache drops to null on first read and the next worker run
+        // populates the v7 keys.
+        private val THIS_PERIOD_KEY = stringPreferencesKey("this_period_snapshot_v7")
+        private val NEXT_PERIOD_KEY = stringPreferencesKey("next_period_snapshot_v7")
 
-        fun create(context: Context): InsightCache = InsightCache(context.insightDataStore)
+        // Surfaced on materialisation when the cached event had a location
+        // string at fetch time. The renderer's only read of `location` is a
+        // presence check (`!isNullOrBlank()`), so the placeholder content
+        // never reaches prose, and dropping the real string on disk keeps
+        // the on-disk privacy posture at parity with the previous derived-
+        // insight cache.
+        private const val PLACEHOLDER_LOCATION = "x"
+
+        fun create(
+            context: Context,
+            deriveInsight: DeriveInsight = DeriveInsight(),
+        ): InsightCache = InsightCache(context.insightDataStore, deriveInsight)
     }
 }
 

--- a/app/src/main/kotlin/app/clothescast/diag/BugReport.kt
+++ b/app/src/main/kotlin/app/clothescast/diag/BugReport.kt
@@ -77,12 +77,18 @@ object BugReport {
         val mqttPublishStatus = runCatching {
             app.settingsRepository.mqttPublishStatus.first()
         }.getOrNull()
-        val thisPeriod = runCatching {
+        val thisSnapshot = runCatching {
             app.insightCache.thisPeriod.first()
         }.getOrNull()
-        val nextPeriod = runCatching {
+        val nextSnapshot = runCatching {
             app.insightCache.nextPeriod.first()
         }.getOrNull()
+        val thisPeriod = if (thisSnapshot != null && prefs != null) {
+            runCatching { app.deriveInsight(thisSnapshot, prefs).insight }.getOrNull()
+        } else null
+        val nextPeriod = if (nextSnapshot != null && prefs != null) {
+            runCatching { app.deriveInsight(nextSnapshot, prefs).insight }.getOrNull()
+        } else null
         val crash = DiagLog.readPersistedCrash()
         val recent = DiagLog.snapshot()
         val now = SimpleDateFormat("yyyy-MM-dd HH:mm:ss Z", Locale.US).format(Date())

--- a/app/src/main/kotlin/app/clothescast/ui/nav/ClothesCastNavHost.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/nav/ClothesCastNavHost.kt
@@ -277,6 +277,7 @@ private fun todayViewModelFactory(app: ClothesCastApplication, context: Context)
         refreshOutfitWidget = {
             runCatching { OutfitWidget().updateAll(context.applicationContext) }
         },
+        deriveInsight = app.deriveInsight,
         calendarEventReader = app.calendarEventReader,
     )
 
@@ -297,9 +298,13 @@ private fun settingsViewModelFactory(app: ClothesCastApplication, context: Conte
         refreshLocationCache = {
             FetchAndNotifyWorker.enqueueLocationCacheRefresh(context)
         },
-        refreshCachedOutfits = {
-            val prefs = app.settingsRepository.preferences.first()
-            app.insightCache.recomputeOutfits(prefs.clothesRules, prefs.defaultBottom, prefs.defaultTop)
+        refreshOutfitWidget = {
+            // No cache work needed — the cache holds the raw ForecastSnapshot,
+            // and every consumer (Today screen, Format settings preview, cast,
+            // MQTT) re-derives off the current prefs reactively. The widget
+            // doesn't subscribe to the prefs flow itself, so a settings write
+            // that changes what icon should render needs an explicit nudge to
+            // repaint the launcher.
             runCatching { OutfitWidget().updateAll(context.applicationContext) }
         },
         resolveDeviceLocationWithCity = {
@@ -318,8 +323,9 @@ private fun settingsViewModelFactory(app: ClothesCastApplication, context: Conte
         mqttPublisher = app.mqttPublisher,
         fullPublish = {
             val prefs = app.settingsRepository.preferences.first()
-            val insight = app.insightCache.thisPeriod.first()
+            val snapshot = app.insightCache.thisPeriod.first()
                 ?: return@Factory app.mqttPublisher.publishTest()
+            val insight = app.deriveInsight(snapshot, prefs).insight
             val formatter = InsightFormatter.forRegion(
                 context,
                 prefs.region,
@@ -377,6 +383,7 @@ private fun settingsViewModelFactory(app: ClothesCastApplication, context: Conte
                     context = context,
                     settingsRepository = app.settingsRepository,
                     insightCache = app.insightCache,
+                    deriveInsight = app.deriveInsight,
                     calendarEventReader = app.calendarEventReader,
                     controller = controller,
                     locale = LocaleListCompat.getAdjustedDefault().get(0)

--- a/app/src/main/kotlin/app/clothescast/ui/settings/FormatSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/FormatSettings.kt
@@ -211,12 +211,13 @@ private fun PreviewCard(
 
 /**
  * Renders the user's *real* cached current forecast through the same formatter
- * the Today screen uses, so the range-format setting is previewed against their
- * actual ClothesCast — not just the synthetic example. The delta-threshold and
- * clothes-mention settings are baked into the cached summary at generation time
- * (they re-take effect on the next refresh), so only the range format updates
- * live here, exactly as it does on the Today screen. Falls back to a short
- * placeholder when nothing's cached yet.
+ * the Today screen uses, so the format-settings preview reflects their actual
+ * ClothesCast — not just the synthetic example. Every setting on this page
+ * updates the preview live because the cache stores the raw upstream forecast
+ * snapshot, and [SettingsViewModel] derives the [InsightSummary] reactively
+ * against the preferences flow; the range-format and clothes-format settings
+ * also apply at format time. Falls back to a short placeholder when nothing's
+ * cached yet.
  */
 @Composable
 private fun CurrentForecastPreviewCard(

--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsViewModel.kt
@@ -67,14 +67,16 @@ class SettingsViewModel(
     private val geocodingClient: OpenMeteoGeocodingClient,
     private val voiceEnumerator: TtsVoiceEnumerator,
     /**
-     * Cache the home-screen / widget read [Insight.outfit] from. Settings VM
-     * mutates it directly after each clothes-rule edit (add / replace / delete
-     * a rule, flip the default-bottom picker) so the icon updates in the same
-     * frame instead of waiting for the next scheduled or manual refresh.
-     * Defaulted to a no-op for pure-VM tests that don't care about the cache;
-     * the Activity wires the real [InsightCache].
+     * Pokes the home-screen widget after a settings change so the launcher
+     * icon catches up in the same frame as the Today screen. The cache no
+     * longer needs a recompute — the snapshot it holds is settings-
+     * independent and the widget re-derives at every `provideGlance()` —
+     * but the widget doesn't observe the settings flow itself, so a `+1°`
+     * tap that flips the icon tier needs this nudge to repaint the launcher.
+     * Defaulted to a no-op for pure-VM tests; the Activity wires the real
+     * `OutfitWidget().updateAll(...)` call.
      */
-    private val refreshCachedOutfits: suspend () -> Unit = {},
+    private val refreshOutfitWidget: suspend () -> Unit = {},
     /**
      * Pushes the chosen [Region] into the platform locale machinery
      * (Locale.setDefault + LocaleManager / attachBaseContext cache) so the
@@ -160,11 +162,13 @@ class SettingsViewModel(
      */
     private val calendarEventReader: CalendarEventReader? = null,
     /**
-     * Read-only access to the cached current insight so the Format settings
+     * Read-only access to the cached current snapshot so the Format settings
      * page can preview the user's *real* ClothesCast next to the synthetic
      * example. Null in pure-VM tests that don't need the cache; the Activity
      * wires the real [InsightCache] and [SettingsState.currentInsightSummary]
-     * then tracks page 1 of the Today pager.
+     * then tracks page 1 of the Today pager, derived against the current
+     * preferences flow so every setting that affects the prose updates the
+     * preview in the same frame as the dropdown closes.
      */
     private val insightCache: InsightCache? = null,
 ) : ViewModel() {
@@ -275,8 +279,11 @@ class SettingsViewModel(
         }
         insightCache?.let { cache ->
             viewModelScope.launch {
-                cache.thisPeriod.collect { insight ->
-                    _state.update { it.copy(currentInsightSummary = insight?.summary) }
+                cache.deriveFlow(
+                    slot = InsightCache.Slot.THIS_PERIOD,
+                    prefsFlow = settingsRepository.preferences,
+                ).collect { result ->
+                    _state.update { it.copy(currentInsightSummary = result?.insight?.summary) }
                 }
             }
         }
@@ -437,7 +444,7 @@ class SettingsViewModel(
     fun setOutfitTopColor(top: OutfitSuggestion.Top, argb: Long?) {
         viewModelScope.launch {
             settingsRepository.setOutfitTopColor(top, argb)
-            refreshCachedOutfits()
+            refreshOutfitWidget()
         }
     }
 
@@ -445,7 +452,7 @@ class SettingsViewModel(
     fun setOutfitBottomColor(bottom: OutfitSuggestion.Bottom, argb: Long?) {
         viewModelScope.launch {
             settingsRepository.setOutfitBottomColor(bottom, argb)
-            refreshCachedOutfits()
+            refreshOutfitWidget()
         }
     }
 
@@ -485,7 +492,7 @@ class SettingsViewModel(
     fun addClothesRule(rule: ClothesRule) {
         viewModelScope.launch {
             settingsRepository.setClothesRules(_state.value.clothesRules + rule)
-            refreshCachedOutfits()
+            refreshOutfitWidget()
         }
     }
 
@@ -494,7 +501,7 @@ class SettingsViewModel(
             val current = _state.value.clothesRules
             if (index !in current.indices) return@launch
             settingsRepository.setClothesRules(current.toMutableList().apply { this[index] = rule })
-            refreshCachedOutfits()
+            refreshOutfitWidget()
         }
     }
 
@@ -503,21 +510,21 @@ class SettingsViewModel(
             val current = _state.value.clothesRules
             if (index !in current.indices) return@launch
             settingsRepository.setClothesRules(current.toMutableList().apply { removeAt(index) })
-            refreshCachedOutfits()
+            refreshOutfitWidget()
         }
     }
 
     fun setDefaultBottom(bottom: OutfitSuggestion.Bottom) {
         viewModelScope.launch {
             settingsRepository.setDefaultBottom(bottom)
-            refreshCachedOutfits()
+            refreshOutfitWidget()
         }
     }
 
     fun setDefaultTop(top: OutfitSuggestion.Top) {
         viewModelScope.launch {
             settingsRepository.setDefaultTop(top)
-            refreshCachedOutfits()
+            refreshOutfitWidget()
         }
     }
 
@@ -957,6 +964,10 @@ class SettingsViewModel(
     }
 
     fun setClothesMentionMode(mode: ClothesMentionMode) {
+        // Prose-only setting — the Today screen / Format settings preview
+        // / cast / MQTT all re-derive off the cached snapshot reactively
+        // through the prefs flow, so no widget poke is needed (the widget
+        // only renders the outfit icon, which this mode doesn't touch).
         viewModelScope.launch { settingsRepository.setClothesMentionMode(mode) }
     }
 
@@ -969,6 +980,9 @@ class SettingsViewModel(
     }
 
     fun setDeltaThresholdC(thresholdC: Double?) {
+        // Prose-only — gates the DeltaClause for the Today screen / Format
+        // settings preview / cast / MQTT, all of which re-derive from the
+        // cached snapshot reactively. The widget doesn't show delta.
         viewModelScope.launch { settingsRepository.setDeltaThresholdC(thresholdC) }
     }
 
@@ -998,7 +1012,7 @@ class SettingsViewModel(
         private val voiceEnumerator: TtsVoiceEnumerator,
         private val applyAppLocale: (Region) -> Unit,
         private val refreshLocationCache: () -> Unit,
-        private val refreshCachedOutfits: suspend () -> Unit,
+        private val refreshOutfitWidget: suspend () -> Unit,
         private val resolveDeviceLocationWithCity: suspend () -> Location? = { null },
         private val workManager: WorkManager? = null,
         private val mqttPublisher: MqttPublisher? = null,
@@ -1022,7 +1036,7 @@ class SettingsViewModel(
                 cancelAlarm = cancelAlarm,
                 geocodingClient = geocodingClient,
                 voiceEnumerator = voiceEnumerator,
-                refreshCachedOutfits = refreshCachedOutfits,
+                refreshOutfitWidget = refreshOutfitWidget,
                 applyAppLocale = applyAppLocale,
                 refreshLocationCache = refreshLocationCache,
                 resolveDeviceLocationWithCity = resolveDeviceLocationWithCity,

--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayViewModel.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayViewModel.kt
@@ -19,6 +19,7 @@ import app.clothescast.core.domain.model.TemperatureUnit
 import app.clothescast.core.domain.model.UserPreferences
 import app.clothescast.core.domain.model.CalendarEvent
 import app.clothescast.core.domain.repository.CalendarEventReader
+import app.clothescast.core.domain.usecase.DeriveInsight
 import app.clothescast.core.domain.usecase.HolidayResolver
 import app.clothescast.core.domain.usecase.ThemeForToday
 import app.clothescast.tts.toJavaLocale
@@ -240,6 +241,12 @@ class TodayViewModel(
     workManager: WorkManager,
     private val settingsRepository: SettingsRepository,
     /**
+     * Re-renders each cached [app.clothescast.core.domain.model.ForecastSnapshot]
+     * against the current preferences. Defaulted so pure-VM tests can omit it;
+     * the Activity passes the app-singleton instance for parity with the worker.
+     */
+    private val deriveInsight: DeriveInsight = DeriveInsight(),
+    /**
      * Pushes the home-screen widget after a clothes-rule nudge so the icon
      * out on the launcher refreshes in the same frame as the Today screen.
      * Defaulted to a no-op so pure-VM tests don't need an Android Context;
@@ -345,8 +352,14 @@ class TodayViewModel(
         workStatusFlow,
         preferencesDateEvents,
         showModelSpread,
-    ) { thisPeriodInsight, nextPeriodInsight, workStatus, prefsDateEvents, spread ->
+    ) { thisPeriodSnapshot, nextPeriodSnapshot, workStatus, prefsDateEvents, spread ->
         val (prefs, today, events) = prefsDateEvents
+        // Derive each cached snapshot against the *current* prefs so a settings
+        // change re-renders the prose / outfit / bullets in the same frame as
+        // the dropdown closes — no waiting for the next worker run, no
+        // preservation / re-gating logic on the cache side.
+        val thisPeriodInsight = thisPeriodSnapshot?.let { deriveInsight(it, prefs).insight }
+        val nextPeriodInsight = nextPeriodSnapshot?.let { deriveInsight(it, prefs).insight }
         // Resolve "is today a holiday the user wants themed?" — `today`
         // comes from the [dateTicker] flow above so the rollover at local
         // midnight re-fires combine even when no other input changes. The
@@ -460,12 +473,10 @@ class TodayViewModel(
     fun adjustClothesRuleThreshold(ruleItem: String, deltaC: Double) {
         viewModelScope.launch {
             settingsRepository.adjustClothesRuleThreshold(ruleItem, deltaC)
-            // Repick the cached outfit against the updated threshold so the
-            // home-screen icon catches up in the same frame as the rationale
-            // dialog's number — without this, a `+1°` tap that flips the icon
-            // tier wouldn't visibly do anything until the next refresh.
-            val prefs = settingsRepository.preferences.first()
-            insightCache.recomputeOutfits(prefs.clothesRules, prefs.defaultBottom, prefs.defaultTop)
+            // No cache work — the [state] combine re-derives the cached
+            // snapshot against the updated prefs as soon as the DataStore
+            // write lands. Push the home-screen widget so the launcher icon
+            // catches up alongside the Today screen.
             refreshOutfitWidget()
         }
     }
@@ -475,6 +486,7 @@ class TodayViewModel(
         private val workManager: WorkManager,
         private val settingsRepository: SettingsRepository,
         private val refreshOutfitWidget: suspend () -> Unit,
+        private val deriveInsight: DeriveInsight = DeriveInsight(),
         private val calendarEventReader: CalendarEventReader? = null,
     ) : ViewModelProvider.Factory {
         @Suppress("UNCHECKED_CAST")
@@ -487,6 +499,7 @@ class TodayViewModel(
                 workManager = workManager,
                 settingsRepository = settingsRepository,
                 refreshOutfitWidget = refreshOutfitWidget,
+                deriveInsight = deriveInsight,
                 calendarEventReader = calendarEventReader,
             ) as T
         }

--- a/app/src/main/kotlin/app/clothescast/widget/OutfitWidget.kt
+++ b/app/src/main/kotlin/app/clothescast/widget/OutfitWidget.kt
@@ -73,17 +73,24 @@ class OutfitWidget : GlanceAppWidget() {
 
     override suspend fun provideGlance(context: Context, id: GlanceId) {
         val app = context.applicationContext as ClothesCastApplication
-        // Read once on each provideGlance() pass — the worker calls updateAll()
-        // after writing to the cache, which re-invokes this function. We read
-        // THIS_PERIOD specifically (not "freshest of either slot") because
-        // NEXT_PERIOD is a pre-render of the upcoming window — taking the
-        // newer-generated-at would surface "Tonight" while the user is still
-        // in the daytime window the morning worker just delivered.
-        val insight = runCatching { app.insightCache.thisPeriod.first() }.getOrNull()
+        // Read snapshot + prefs once per provideGlance() pass and derive the
+        // insight against the current prefs — so a settings change picked up
+        // by an updateAll() reflects the new outfit / mention mode without
+        // the cache itself having moved. We read THIS_PERIOD specifically
+        // (not "freshest of either slot") because NEXT_PERIOD is a pre-
+        // render of the upcoming window — taking the newer-generated-at
+        // would surface "Tonight" while the user is still in the daytime
+        // window the morning worker just delivered.
+        val prefs = runCatching { app.settingsRepository.preferences.first() }.getOrNull()
+        val snapshot = runCatching { app.insightCache.thisPeriod.first() }.getOrNull()
+        val insight = if (snapshot != null && prefs != null) {
+            runCatching { app.deriveInsight(snapshot, prefs).insight }.getOrNull()
+        } else {
+            null
+        }
         // Per-garment colour overrides — empty when the user hasn't customised.
         // Pulled here (not inside the Composable) so the bitmap rasterizer can
         // run on this dispatcher rather than during composition.
-        val prefs = runCatching { app.settingsRepository.preferences.first() }.getOrNull()
         val topColors = prefs?.outfitTopColors ?: emptyMap()
         val bottomColors = prefs?.outfitBottomColors ?: emptyMap()
         provideContent {

--- a/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
@@ -249,11 +249,12 @@ class FetchAndNotifyWorker(
             DiagLog.i(TAG, "Force refresh requested; bypassing today's cache.")
             null
         } else {
-            runCatching { app.insightCache.deliveredForToday(today, period) }.getOrNull()
+            runCatching { app.insightCache.deliveredForToday(today, period, prefs) }.getOrNull()
         }
         if (cached != null) {
-            DiagLog.i(TAG, "Using cached $period insight for ${cached.forDate}.")
-            return runCatching { deliver(cached, prefs, formatProse(cached, prefs)) }
+            val cachedInsight = cached.insight
+            DiagLog.i(TAG, "Using cached $period insight for ${cachedInsight.forDate}.")
+            return runCatching { deliver(cachedInsight, prefs, formatProse(cachedInsight, prefs)) }
                 .map { Result.success() }
                 .getOrElse {
                     if (it is CancellationException) throw it
@@ -294,12 +295,13 @@ class FetchAndNotifyWorker(
             }
         }
         return try {
-            val result = app.generateDailyInsight(location, prefs, period)
-            // Stamp the resolved location onto the insight so the home screen
-            // can show the city next to the date and deep-link to maps. UI-only
-            // — never read by InsightFormatter / RenderInsightSummary, so it
-            // can't leak into LLM / TTS prose.
-            val insight = result.insight.copy(location = location)
+            // Two-phase: capture the snapshot (fetch + read events), then derive
+            // the insight from it against current prefs. The snapshot is what
+            // lands in the cache so any later settings change re-renders
+            // off the same upstream data for free; the derive call here is the
+            // one we deliver on this run.
+            val snapshot = app.generateDailyInsight.snapshot(location, prefs, period)
+            val result = app.deriveInsight(snapshot, prefs)
             // Severe alerts are out-of-band: post them as separate high-priority
             // notifications on every fresh fetch, regardless of whether the daily
             // summary itself is blank or suppressed.
@@ -307,7 +309,8 @@ class FetchAndNotifyWorker(
                 runCatching { app.weatherAlertNotifier.notify(alert) }
                     .onFailure { DiagLog.w(TAG, "Severe alert notification failed for ${alert.event}.", it) }
             }
-            runCatching { app.insightCache.store(InsightCache.Slot.THIS_PERIOD, insight) }
+            val insight = result.insight
+            runCatching { app.insightCache.store(InsightCache.Slot.THIS_PERIOD, snapshot) }
                 .onSuccess {
                     // Push the fresh outfit out to any home-screen widgets.
                     // Gated on cache success because provideGlance() reads
@@ -425,10 +428,9 @@ class FetchAndNotifyWorker(
         }
         val dayOffset = if (primaryPeriod == ForecastPeriod.TONIGHT) 1 else 0
         runCatching {
-            val result = app.generateDailyInsight(location, prefs, nextWindowPeriod, dayOffset)
-            val pairedInsight = result.insight.copy(location = location)
-            app.insightCache.store(InsightCache.Slot.NEXT_PERIOD, pairedInsight)
-            DiagLog.i(TAG, "Next-window $nextWindowPeriod insight cached for ${pairedInsight.forDate}.")
+            val snapshot = app.generateDailyInsight.snapshot(location, prefs, nextWindowPeriod, dayOffset)
+            app.insightCache.store(InsightCache.Slot.NEXT_PERIOD, snapshot)
+            DiagLog.i(TAG, "Next-window $nextWindowPeriod snapshot cached for ${snapshot.bundle.today.date}.")
         }.onFailure {
             if (it is CancellationException) throw it
             DiagLog.w(TAG, "Next-window $nextWindowPeriod insight generation failed; not blocking $primaryPeriod delivery.", it)

--- a/app/src/test/kotlin/app/clothescast/data/InsightCacheTest.kt
+++ b/app/src/test/kotlin/app/clothescast/data/InsightCacheTest.kt
@@ -5,34 +5,35 @@ import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
-import app.clothescast.core.domain.model.AlertClause
-import app.clothescast.core.domain.model.BandClause
-import app.clothescast.core.domain.model.CalendarTieInClause
-import app.clothescast.core.domain.model.ClothesClause
+import app.clothescast.core.domain.model.AlertSeverity
+import app.clothescast.core.domain.model.CalendarEvent
+import app.clothescast.core.domain.model.ClothesFormat
+import app.clothescast.core.domain.model.ClothesMentionMode
 import app.clothescast.core.domain.model.ClothesRule
 import app.clothescast.core.domain.model.ConfidenceInfo
-import app.clothescast.core.domain.model.DeltaClause
+import app.clothescast.core.domain.model.DailyForecast
+import app.clothescast.core.domain.model.DeliveryMode
+import app.clothescast.core.domain.model.DistanceUnit
 import app.clothescast.core.domain.model.ForecastConfidence
+import app.clothescast.core.domain.model.ForecastPeriod
+import app.clothescast.core.domain.model.ForecastSnapshot
+import app.clothescast.core.domain.model.HourlyForecast
+import app.clothescast.core.domain.model.Location
+import app.clothescast.core.domain.model.OutfitSuggestion
 import app.clothescast.core.domain.model.PerModelHour
 import app.clothescast.core.domain.model.PerModelHourly
-import app.clothescast.core.domain.model.EveningEventTieInClause
-import app.clothescast.core.domain.model.Fact
-import app.clothescast.core.domain.model.ForecastPeriod
-import app.clothescast.core.domain.model.GarmentReason
-import app.clothescast.core.domain.model.HourlyForecast
-import app.clothescast.core.domain.model.Insight
-import app.clothescast.core.domain.model.InsightSummary
-import app.clothescast.core.domain.model.Location
-import app.clothescast.core.domain.model.OutfitRationale
-import app.clothescast.core.domain.model.OutfitSuggestion
-import app.clothescast.core.domain.model.PrecipClause
-import app.clothescast.core.domain.model.PrecipLikelihood
-import app.clothescast.core.domain.model.TemperatureBand
+import app.clothescast.core.domain.model.RangeFormat
+import app.clothescast.core.domain.model.Schedule
+import app.clothescast.core.domain.model.TemperatureUnit
+import app.clothescast.core.domain.model.UserPreferences
+import app.clothescast.core.domain.model.WeatherAlert
 import app.clothescast.core.domain.model.WeatherCondition
+import app.clothescast.core.domain.repository.ForecastBundle
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
@@ -48,6 +49,7 @@ import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
+import java.time.ZoneId
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class InsightCacheTest {
@@ -57,57 +59,64 @@ class InsightCacheTest {
     private lateinit var subject: InsightCache
 
     private val today = LocalDate.of(2026, 4, 25)
+    private val yesterday = today.minusDays(1)
     private val now = Instant.parse("2026-04-25T07:00:00Z")
 
-    private val sampleSummary = InsightSummary(
-        period = ForecastPeriod.TODAY,
-        band = BandClause(TemperatureBand.COOL, TemperatureBand.MILD),
-        delta = DeltaClause(4, DeltaClause.Direction.COOLER),
-        clothes = ClothesClause(listOf("sweater", "umbrella")),
+    private val mildHourly = listOf(
+        HourlyForecast(LocalTime.of(7, 0), 14.0, 13.0, 5.0, WeatherCondition.CLEAR),
+        HourlyForecast(LocalTime.of(14, 0), 19.0, 18.0, 5.0, WeatherCondition.CLEAR),
+    )
+    private val mildYesterdayHourly = listOf(
+        HourlyForecast(LocalTime.of(7, 0), 13.0, 12.0, 5.0, WeatherCondition.CLEAR),
+        HourlyForecast(LocalTime.of(14, 0), 18.0, 17.0, 5.0, WeatherCondition.CLEAR),
     )
 
-    private val sample = Insight(
-        summary = sampleSummary,
-        recommendedItems = listOf("sweater", "umbrella"),
+    private val bundle = ForecastBundle(
+        today = DailyForecast(
+            date = today,
+            temperatureMinC = 14.0,
+            temperatureMaxC = 19.0,
+            feelsLikeMinC = 13.0,
+            feelsLikeMaxC = 18.0,
+            precipitationProbabilityMaxPct = 5.0,
+            precipitationMmTotal = 0.0,
+            condition = WeatherCondition.CLEAR,
+            hourly = mildHourly,
+        ),
+        yesterday = DailyForecast(
+            date = yesterday,
+            temperatureMinC = 13.0,
+            temperatureMaxC = 18.0,
+            feelsLikeMinC = 12.0,
+            feelsLikeMaxC = 17.0,
+            precipitationProbabilityMaxPct = 5.0,
+            precipitationMmTotal = 0.0,
+            condition = WeatherCondition.CLEAR,
+            hourly = mildYesterdayHourly,
+        ),
+        forecastZone = ZoneId.of("UTC"),
+    )
+
+    private val sample = ForecastSnapshot(
+        bundle = bundle,
+        events = emptyList(),
+        location = Location(latitude = 51.5, longitude = -0.1, displayName = "London"),
+        period = ForecastPeriod.TODAY,
         generatedAt = now,
-        forDate = today,
-        confidence = ConfidenceInfo(
-            level = ForecastConfidence.LOW,
-            tempSpreadC = 4.2,
-            precipSpreadPp = 35.0,
-            modelsConsulted = listOf("ecmwf_ifs04", "gfs_seamless", "icon_seamless"),
-        ),
-        perModelHourly = PerModelHourly(
-            byModel = mapOf(
-                "ecmwf_ifs04" to listOf(
-                    PerModelHour(
-                        time = LocalDateTime.of(today, LocalTime.of(0, 0)),
-                        apparentTemperatureC = 12.0,
-                        temperatureC = 14.0,
-                        precipitationProbabilityPct = 10.0,
-                        windSpeedKmh = 8.0,
-                        relativeHumidityPct = 78.0,
-                        cloudCoverPct = 60.0,
-                    ),
-                    PerModelHour(
-                        time = LocalDateTime.of(today, LocalTime.of(1, 0)),
-                        apparentTemperatureC = 11.5,
-                        temperatureC = 13.5,
-                        precipitationProbabilityPct = 15.0,
-                        windSpeedKmh = 9.5,
-                        relativeHumidityPct = 80.0,
-                        cloudCoverPct = 70.0,
-                    ),
-                ),
-                // Second model exercises the null-diagnostic-field path: the
-                // upstream model run didn't return wind / humidity / cloud,
-                // but temp + precip are present so the entry survives.
-                "gfs_seamless" to listOf(
-                    PerModelHour(LocalDateTime.of(today, LocalTime.of(0, 0)), 12.2, 14.2, 12.0),
-                    PerModelHour(LocalDateTime.of(today, LocalTime.of(1, 0)), 11.8, 13.8, 18.0),
-                ),
-            ),
-        ),
+    )
+
+    private val basePrefs = UserPreferences(
+        schedule = Schedule(time = LocalTime.of(7, 0), days = Schedule.EVERY_DAY, zoneId = ZoneId.of("UTC")),
+        deliveryMode = DeliveryMode.NOTIFICATION_ONLY,
+        temperatureUnit = TemperatureUnit.CELSIUS,
+        distanceUnit = DistanceUnit.KILOMETERS,
+        clothesRules = ClothesRule.DEFAULTS,
+        defaultBottom = OutfitSuggestion.Bottom.LONG_PANTS,
+        defaultTop = OutfitSuggestion.Top.TSHIRT,
+        clothesMentionMode = ClothesMentionMode.ALWAYS,
+        rangeFormat = RangeFormat.DEGREES,
+        clothesFormat = ClothesFormat.ITEMS,
+        deltaThresholdC = 3.0,
     )
 
     @BeforeEach
@@ -130,7 +139,7 @@ class InsightCacheTest {
     }
 
     @Test
-    fun `store then thisPeriod round-trips all fields`() = runTest {
+    fun `store then thisPeriod round-trips the snapshot`() = runTest {
         subject.store(InsightCache.Slot.THIS_PERIOD, sample)
 
         val read = subject.thisPeriod.first()
@@ -138,485 +147,315 @@ class InsightCacheTest {
     }
 
     @Test
-    fun `deliveredForToday returns the cached insight when forDate and period match`() = runTest {
+    fun `store NEXT_PERIOD round-trips independently of THIS_PERIOD`() = runTest {
+        val other = sample.copy(period = ForecastPeriod.TONIGHT)
         subject.store(InsightCache.Slot.THIS_PERIOD, sample)
+        subject.store(InsightCache.Slot.NEXT_PERIOD, other)
 
-        subject.deliveredForToday(today, sample.period) shouldBe sample
+        subject.thisPeriod.first() shouldBe sample
+        subject.nextPeriod.first() shouldBe other
     }
 
     @Test
-    fun `deliveredForToday returns null when the cached insight is for a different day`() = runTest {
+    fun `clear removes both slots`() = runTest {
         subject.store(InsightCache.Slot.THIS_PERIOD, sample)
+        subject.store(InsightCache.Slot.NEXT_PERIOD, sample)
 
-        subject.deliveredForToday(today.plusDays(1), sample.period) shouldBe null
+        subject.clear()
+
+        subject.thisPeriod.first() shouldBe null
+        subject.nextPeriod.first() shouldBe null
     }
 
     @Test
-    fun `deliveredForToday returns null when the cached insight is for a different period`() = runTest {
+    fun `corrupt JSON drops to null rather than crashing`() = runTest {
+        dataStore.edit {
+            it[stringPreferencesKey("this_period_snapshot_v7")] = "{not valid json"
+        }
+
+        subject.thisPeriod.first() shouldBe null
+    }
+
+    @Test
+    fun `pre-v7 payloads (the old derived-Insight shape) are dropped on read`() = runTest {
+        // Old v6 cache key, old derived-insight JSON shape. The new v7 reader
+        // returns null and the next worker run repopulates the v7 keys.
+        dataStore.edit {
+            it[stringPreferencesKey("this_period_insight_v6")] = """
+                {"summary":"placeholder","recommendedItems":[],"generatedAtEpochMillis":0,
+                 "forDateEpochDays":0}
+            """.trimIndent()
+        }
+
+        subject.thisPeriod.first() shouldBe null
+    }
+
+    @Test
+    fun `events round-trip with only timing and location-presence preserved`() = runTest {
+        // Renderer's only `location` read is a presence check, so on-disk
+        // we keep a `hasLocation` boolean — titles and free-form location
+        // strings are deliberately not persisted (privacy: keep the on-
+        // disk posture at parity with the previous derived-insight cache).
+        val concertEvent = CalendarEvent(
+            title = "Concert with band",
+            start = LocalTime.of(20, 0),
+            end = LocalTime.of(22, 0),
+            location = "Royal Albert Hall",
+            allDay = false,
+        )
+        val withEvents = sample.copy(events = listOf(concertEvent))
+
+        subject.store(InsightCache.Slot.THIS_PERIOD, withEvents)
+
+        val read = subject.thisPeriod.first()
+        val readEvent = read?.events?.singleOrNull()
+        readEvent?.start shouldBe LocalTime.of(20, 0)
+        readEvent?.end shouldBe LocalTime.of(22, 0)
+        readEvent?.allDay shouldBe false
+        // Title dropped, location replaced with a placeholder presence marker.
+        readEvent?.title shouldBe ""
+        (readEvent?.location.isNullOrBlank()) shouldBe false
+    }
+
+    @Test
+    fun `events with no location surface as null location after round-trip`() = runTest {
+        // The away-from-home gate fires on `!location.isNullOrBlank()`, so
+        // a no-location event must come back as a no-location event.
+        val noLocationEvent = CalendarEvent(
+            title = "Internal sync",
+            start = LocalTime.of(10, 0),
+            end = LocalTime.of(11, 0),
+            location = null,
+            allDay = false,
+        )
+        subject.store(InsightCache.Slot.THIS_PERIOD, sample.copy(events = listOf(noLocationEvent)))
+
+        val read = subject.thisPeriod.first()
+        read?.events?.singleOrNull()?.location shouldBe null
+    }
+
+    @Test
+    fun `alerts round-trip through the cache`() = runTest {
+        val alert = WeatherAlert(
+            event = "Tornado Warning",
+            severity = AlertSeverity.EXTREME,
+            headline = "Take shelter immediately",
+            description = "Confirmed funnel south of city",
+            onset = now,
+            expires = now.plusSeconds(3600),
+        )
+        subject.store(
+            InsightCache.Slot.THIS_PERIOD,
+            sample.copy(bundle = bundle.copy(alerts = listOf(alert))),
+        )
+
+        subject.thisPeriod.first()?.bundle?.alerts?.singleOrNull() shouldBe alert
+    }
+
+    @Test
+    fun `perModelHourly round-trips with all diagnostic fields`() = runTest {
+        val perModel = PerModelHourly(
+            byModel = mapOf(
+                "ecmwf_ifs04" to listOf(
+                    PerModelHour(
+                        time = LocalDateTime.of(today, LocalTime.of(0, 0)),
+                        apparentTemperatureC = 12.0,
+                        temperatureC = 14.0,
+                        precipitationProbabilityPct = 10.0,
+                        windSpeedKmh = 8.0,
+                        relativeHumidityPct = 78.0,
+                        cloudCoverPct = 60.0,
+                    ),
+                ),
+            ),
+        )
+        subject.store(
+            InsightCache.Slot.THIS_PERIOD,
+            sample.copy(bundle = bundle.copy(perModelHourly = perModel)),
+        )
+
+        subject.thisPeriod.first()?.bundle?.perModelHourly shouldBe perModel
+    }
+
+    @Test
+    fun `perModelHourly preserves per-entry dates across the bundle's full series`() = runTest {
+        // Open-Meteo returns ~48 h of per-model hours, so a cached snapshot's
+        // series spans today and tomorrow. The tonight slice in DeriveInsight
+        // wraps from today evening to tomorrow morning by LocalDateTime, so
+        // aliasing every entry's date onto the bundle's `today.date` would
+        // collapse tomorrow's pre-dawn rain hour onto today and break the
+        // overnight precip clause.
+        val tomorrow = today.plusDays(1)
+        val perModel = PerModelHourly(
+            byModel = mapOf(
+                "ecmwf_ifs04" to listOf(
+                    PerModelHour(
+                        time = LocalDateTime.of(today, LocalTime.of(22, 0)),
+                        apparentTemperatureC = 10.0,
+                        temperatureC = 11.0,
+                        precipitationProbabilityPct = 10.0,
+                    ),
+                    PerModelHour(
+                        time = LocalDateTime.of(tomorrow, LocalTime.of(5, 0)),
+                        apparentTemperatureC = 6.0,
+                        temperatureC = 7.0,
+                        precipitationProbabilityPct = 60.0,
+                    ),
+                ),
+            ),
+        )
+        subject.store(
+            InsightCache.Slot.THIS_PERIOD,
+            sample.copy(bundle = bundle.copy(perModelHourly = perModel)),
+        )
+
+        val readTimes = subject.thisPeriod.first()
+            ?.bundle?.perModelHourly?.byModel?.get("ecmwf_ifs04")
+            ?.map { it.time }
+        readTimes shouldBe listOf(
+            LocalDateTime.of(today, LocalTime.of(22, 0)),
+            LocalDateTime.of(tomorrow, LocalTime.of(5, 0)),
+        )
+    }
+
+    @Test
+    fun `confidence info round-trips through the cache`() = runTest {
+        val confidence = ConfidenceInfo(
+            level = ForecastConfidence.LOW,
+            tempSpreadC = 4.2,
+            precipSpreadPp = 35.0,
+            modelsConsulted = listOf("ecmwf_ifs04", "gfs_seamless"),
+        )
+        subject.store(
+            InsightCache.Slot.THIS_PERIOD,
+            sample.copy(bundle = bundle.copy(confidence = confidence)),
+        )
+
+        subject.thisPeriod.first()?.bundle?.confidence shouldBe confidence
+    }
+
+    @Test
+    fun `tomorrow forecast round-trips when present`() = runTest {
+        val tomorrow = DailyForecast(
+            date = today.plusDays(1),
+            temperatureMinC = 15.0,
+            temperatureMaxC = 21.0,
+            feelsLikeMinC = 14.0,
+            feelsLikeMaxC = 20.0,
+            precipitationProbabilityMaxPct = 10.0,
+            precipitationMmTotal = 0.0,
+            condition = WeatherCondition.PARTLY_CLOUDY,
+            hourly = emptyList(),
+        )
+        subject.store(
+            InsightCache.Slot.THIS_PERIOD,
+            sample.copy(bundle = bundle.copy(tomorrow = tomorrow)),
+        )
+
+        subject.thisPeriod.first()?.bundle?.tomorrow shouldBe tomorrow
+    }
+
+    @Test
+    fun `forecast zone round-trips through the cache`() = runTest {
+        subject.store(
+            InsightCache.Slot.THIS_PERIOD,
+            sample.copy(bundle = bundle.copy(forecastZone = ZoneId.of("America/Los_Angeles"))),
+        )
+
+        subject.thisPeriod.first()?.bundle?.forecastZone shouldBe ZoneId.of("America/Los_Angeles")
+    }
+
+    @Test
+    fun `deliveredForToday returns the derived insight when forDate and period match`() = runTest {
+        subject.store(InsightCache.Slot.THIS_PERIOD, sample)
+
+        val result = subject.deliveredForToday(today, ForecastPeriod.TODAY, basePrefs)
+        result?.insight?.forDate shouldBe today
+        result?.insight?.period shouldBe ForecastPeriod.TODAY
+    }
+
+    @Test
+    fun `deliveredForToday returns null on a date mismatch`() = runTest {
+        subject.store(InsightCache.Slot.THIS_PERIOD, sample)
+
+        subject.deliveredForToday(today.plusDays(1), ForecastPeriod.TODAY, basePrefs) shouldBe null
+    }
+
+    @Test
+    fun `deliveredForToday returns null on a period mismatch`() = runTest {
         // The morning alarm fires for TODAY; if THIS_PERIOD holds a TONIGHT
-        // insight (e.g. last night's evening delivery), the dedup check
+        // snapshot (e.g. last night's evening delivery), the dedup check
         // misses and the worker refetches — fresh forecast instead of
         // redelivering yesterday's payload.
         subject.store(InsightCache.Slot.THIS_PERIOD, sample.copy(period = ForecastPeriod.TONIGHT))
 
-        subject.deliveredForToday(today, ForecastPeriod.TODAY) shouldBe null
+        subject.deliveredForToday(today, ForecastPeriod.TODAY, basePrefs) shouldBe null
     }
 
     @Test
     fun `deliveredForToday ignores the NEXT_PERIOD slot`() = runTest {
         // The morning alarm shouldn't dedup against yesterday-evening's
-        // pre-cached tomorrow-daytime insight in NEXT_PERIOD; otherwise it
+        // pre-cached tomorrow-daytime snapshot in NEXT_PERIOD; otherwise it
         // would silently redeliver 12-hour-old forecast data.
         subject.store(InsightCache.Slot.NEXT_PERIOD, sample)
 
-        subject.deliveredForToday(today, sample.period) shouldBe null
+        subject.deliveredForToday(today, ForecastPeriod.TODAY, basePrefs) shouldBe null
     }
 
     @Test
-    fun `clear removes the stored insight`() = runTest {
+    fun `deriveFlow emits the derived insight summary against current prefs`() = runTest {
+        // The core "settings change updates the prose" path: store a snapshot
+        // once, then poke prefs and confirm the derive picks up the new
+        // mention-mode setting without any cache rewrite.
         subject.store(InsightCache.Slot.THIS_PERIOD, sample)
-        subject.clear()
 
-        subject.thisPeriod.first() shouldBe null
+        val withClothes = subject.deriveFlow(
+            slot = InsightCache.Slot.THIS_PERIOD,
+            prefsFlow = flowOf(basePrefs.copy(clothesMentionMode = ClothesMentionMode.ALWAYS)),
+        ).first()
+        withClothes?.insight?.summary?.clothes shouldBe
+            app.clothescast.core.domain.model.ClothesClause(listOf("sweater", "pants"))
+
+        val muted = subject.deriveFlow(
+            slot = InsightCache.Slot.THIS_PERIOD,
+            prefsFlow = flowOf(basePrefs.copy(clothesMentionMode = ClothesMentionMode.NEVER)),
+        ).first()
+        muted?.insight?.summary?.clothes shouldBe null
     }
 
     @Test
-    fun `corrupt JSON in the slot maps to null rather than crashing`() = runTest {
-        dataStore.edit {
-            it[stringPreferencesKey("this_period_insight_v6")] = "{not valid json"
+    fun `deriveFlow emits null when the slot is empty`() = runTest {
+        val result = subject.deriveFlow(
+            slot = InsightCache.Slot.THIS_PERIOD,
+            prefsFlow = flowOf(basePrefs),
+        ).first()
+        result shouldBe null
+    }
+
+    @Test
+    fun `deriveFlow re-derives delta clause against new threshold`() = runTest {
+        // Today is ~1°C warmer than yesterday — at threshold 0.5 the clause
+        // emits, at threshold 5 it suppresses. The same cached snapshot
+        // produces both, just by changing the pref.
+        subject.store(InsightCache.Slot.THIS_PERIOD, sample)
+
+        val loose = subject.deriveFlow(
+            slot = InsightCache.Slot.THIS_PERIOD,
+            prefsFlow = flowOf(basePrefs.copy(deltaThresholdC = 0.5)),
+        ).first()
+        // Either emits a delta clause (>= 0.5°) or — if the daytime slice
+        // happens to round to 0 — null; the point is the threshold flows
+        // through to the renderer.
+        val strict = subject.deriveFlow(
+            slot = InsightCache.Slot.THIS_PERIOD,
+            prefsFlow = flowOf(basePrefs.copy(deltaThresholdC = 20.0)),
+        ).first()
+        strict?.insight?.summary?.delta shouldBe null
+
+        // Loose threshold either emits or doesn't, but it must not be stricter
+        // than strict's view of the same data.
+        if (loose?.insight?.summary?.delta != null) {
+            loose.insight.summary.delta!!.degrees shouldBe 1
         }
-
-        subject.thisPeriod.first() shouldBe null
-    }
-
-    @Test
-    fun `pre-v5 payloads are dropped rather than crashing the cache`() = runTest {
-        // Older app versions stored `summary` as a rendered string (v2),
-        // later as a structured object without `Fact.thresholdKind` (v3),
-        // then with the kind tag (v4). The current schema (v5) replaces
-        // `thresholdKind` with `ruleItem`, so older payloads no longer
-        // deserialise and the slot drops to null. The next worker run
-        // regenerates on the new key.
-        val v2Json = """
-            {
-              "summary": "Cooler than yesterday — bring a sweater.",
-              "recommendedItems": ["sweater", "umbrella"],
-              "generatedAtEpochMillis": ${now.toEpochMilli()},
-              "forDateEpochDays": ${today.toEpochDay()}
-            }
-        """.trimIndent()
-        dataStore.edit {
-            // v5 key, v2-shaped payload — the decoder fails on the `summary`
-            // field and the runCatching in the cache returns null.
-            it[stringPreferencesKey("this_period_insight_v6")] = v2Json
-        }
-
-        subject.thisPeriod.first() shouldBe null
-    }
-
-    @Test
-    fun `hourly entries round-trip through the cache`() = runTest {
-        val hourly = listOf(
-            HourlyForecast(
-                time = LocalTime.of(7, 0),
-                temperatureC = 9.5,
-                feelsLikeC = 7.2,
-                precipitationProbabilityPct = 10.0,
-                condition = WeatherCondition.PARTLY_CLOUDY,
-            ),
-            HourlyForecast(
-                time = LocalTime.of(13, 0),
-                temperatureC = 14.0,
-                feelsLikeC = 13.0,
-                precipitationProbabilityPct = 60.0,
-                condition = WeatherCondition.RAIN,
-            ),
-        )
-        val withHourly = sample.copy(hourly = hourly)
-
-        subject.store(InsightCache.Slot.THIS_PERIOD, withHourly)
-
-        subject.thisPeriod.first() shouldBe withHourly
-    }
-
-    @Test
-    fun `outfit rationale round-trips through the cache`() = runTest {
-        val rationale = OutfitRationale(
-            top = GarmentReason(
-                facts = listOf(
-                    Fact(
-                        metric = Fact.Metric.FEELS_LIKE_MIN,
-                        observedC = 13.0,
-                        observedAt = LocalTime.of(7, 0),
-                        thresholdC = 18.0,
-                        ruleItem = "sweater",
-                        comparison = Fact.Comparison.BELOW,
-                    ),
-                ),
-            ),
-            bottom = GarmentReason(
-                facts = listOf(
-                    Fact(
-                        metric = Fact.Metric.FEELS_LIKE_MAX,
-                        observedC = 19.0,
-                        observedAt = null,
-                        thresholdC = 24.0,
-                        ruleItem = "shorts",
-                        comparison = Fact.Comparison.BELOW,
-                    ),
-                ),
-            ),
-        )
-        val withRationale = sample.copy(
-            outfit = OutfitSuggestion(OutfitSuggestion.Top.SWEATER, OutfitSuggestion.Bottom.LONG_PANTS),
-            outfitRationale = rationale,
-        )
-
-        subject.store(InsightCache.Slot.THIS_PERIOD, withRationale)
-
-        subject.thisPeriod.first() shouldBe withRationale
-    }
-
-    @Test
-    fun `location round-trips through the cache`() = runTest {
-        val withLocation = sample.copy(
-            location = Location(
-                latitude = 42.3601,
-                longitude = -71.0589,
-                displayName = "Boston",
-            ),
-        )
-
-        subject.store(InsightCache.Slot.THIS_PERIOD, withLocation)
-
-        subject.thisPeriod.first() shouldBe withLocation
-    }
-
-    @Test
-    fun `payloads without optional fields decode with those fields null`() = runTest {
-        // location, outfit, outfitRationale and confidence are all DTO-optional
-        // with null defaults — a minimal v5 payload (e.g. an early build that
-        // hasn't populated them yet, or a future field-pruning) still
-        // deserialises rather than dropping to null and burning a regen on
-        // next launch.
-        val minimalJson = """
-            {
-              "summary": {
-                "period": "TODAY",
-                "band": {"low": "COOL", "high": "MILD"},
-                "delta": {"degrees": 4, "direction": "COOLER"},
-                "clothes": {"items": ["sweater", "umbrella"]}
-              },
-              "recommendedItems": ["sweater", "umbrella"],
-              "generatedAtEpochMillis": ${now.toEpochMilli()},
-              "forDateEpochDays": ${today.toEpochDay()}
-            }
-        """.trimIndent()
-        dataStore.edit {
-            it[stringPreferencesKey("this_period_insight_v6")] = minimalJson
-        }
-
-        val read = subject.thisPeriod.first()
-        // Sample carries both `confidence` and `perModelHourly` so the
-        // round-trip test catches a future regression where the DTO drops
-        // either; the legacy/minimal payload here can't possibly carry them,
-        // so strip them from the expected value.
-        read shouldBe sample.copy(confidence = null, perModelHourly = null)
-        read?.location shouldBe null
-        read?.confidence shouldBe null
-        read?.perModelHourly shouldBe null
-    }
-
-    @Test
-    fun `every clause type round-trips through the cache`() = runTest {
-        val full = sample.copy(
-            summary = InsightSummary(
-                period = ForecastPeriod.TODAY,
-                band = BandClause(TemperatureBand.FREEZING, TemperatureBand.HOT),
-                alert = AlertClause("Tornado Warning"),
-                delta = DeltaClause(8, DeltaClause.Direction.WARMER),
-                clothes = ClothesClause(listOf("sweater", "jacket", "shorts", "umbrella")),
-                precip = PrecipClause(WeatherCondition.RAIN, LocalTime.of(15, 0)),
-                calendarTieIn = CalendarTieInClause("umbrella"),
-                eveningEventTieIn = EveningEventTieInClause(
-                    items = listOf("jacket", "coat"),
-                    rainTime = LocalTime.of(21, 0),
-                ),
-            ),
-        )
-
-        subject.store(InsightCache.Slot.THIS_PERIOD, full)
-
-        subject.thisPeriod.first() shouldBe full
-    }
-
-    @Test
-    fun `bare-rain evening tie-in round-trips through the cache`() = runTest {
-        // The bare-rain emission shape: empty items (no clothes rule triggered),
-        // rainTime set, POSSIBLE likelihood from a single-model rain signal.
-        // The DTO has to preserve all three across a serde cycle — a regression
-        // that nulled likelihood would silently downgrade every cached
-        // bare-rain clause to LIKELY on read.
-        val bareRain = sample.copy(
-            summary = sample.summary.copy(
-                eveningEventTieIn = EveningEventTieInClause(
-                    items = emptyList(),
-                    rainTime = LocalTime.of(21, 0),
-                    likelihood = PrecipLikelihood.POSSIBLE,
-                ),
-            ),
-        )
-
-        subject.store(InsightCache.Slot.THIS_PERIOD, bareRain)
-
-        val tie = subject.thisPeriod.first()?.summary?.eveningEventTieIn
-        tie?.items shouldBe emptyList()
-        tie?.rainTime shouldBe LocalTime.of(21, 0)
-        tie?.likelihood shouldBe PrecipLikelihood.POSSIBLE
-    }
-
-    @Test
-    fun `legacy single-item evening tie-in payload decodes into the items list`() = runTest {
-        // Pre-multi-item payloads stored the chosen tie-in item in a singular
-        // "item" field. The DTO keeps that field for read back-compat and
-        // folds it into [items] on toDomain so a cached morning insight from
-        // an older build doesn't lose its evening tie-in item on read.
-        val legacyJson = """
-            {
-              "summary": {
-                "period": "TODAY",
-                "band": {"low": "COOL", "high": "MILD"},
-                "eveningEventTieIn": {
-                  "item": "jacket",
-                  "rainSecondOfDay": 75600,
-                  "likelihood": "LIKELY"
-                }
-              },
-              "recommendedItems": [],
-              "generatedAtEpochMillis": ${now.toEpochMilli()},
-              "forDateEpochDays": ${today.toEpochDay()}
-            }
-        """.trimIndent()
-        dataStore.edit {
-            it[stringPreferencesKey("this_period_insight_v6")] = legacyJson
-        }
-
-        val tie = subject.thisPeriod.first()?.summary?.eveningEventTieIn
-        tie?.items shouldBe listOf("jacket")
-        tie?.rainTime shouldBe LocalTime.of(21, 0)
-        tie?.likelihood shouldBe PrecipLikelihood.LIKELY
-    }
-
-    @Test
-    fun `recomputeOutfits flips the cached fallback bottom to the new default`() = runTest {
-        // Hourly never crosses the shorts (24°C) or jeans (no rule) thresholds,
-        // so the outfit picker lands on the user's chosen defaultBottom.
-        // Storing with LONG_PANTS, then recomputing with JEANS, should rewrite
-        // the cached outfit's bottom — that's the Today screen / widget fix
-        // for changing the picker after the day's insight has been generated.
-        val hourly = listOf(
-            HourlyForecast(
-                time = LocalTime.of(7, 0),
-                temperatureC = 14.0,
-                feelsLikeC = 13.0,
-                precipitationProbabilityPct = 5.0,
-                condition = WeatherCondition.CLEAR,
-            ),
-            HourlyForecast(
-                time = LocalTime.of(14, 0),
-                temperatureC = 19.0,
-                feelsLikeC = 18.0,
-                precipitationProbabilityPct = 5.0,
-                condition = WeatherCondition.CLEAR,
-            ),
-        )
-        val stored = sample.copy(
-            hourly = hourly,
-            outfit = OutfitSuggestion(OutfitSuggestion.Top.SWEATER, OutfitSuggestion.Bottom.LONG_PANTS),
-        )
-        subject.store(InsightCache.Slot.THIS_PERIOD, stored)
-
-        subject.recomputeOutfits(ClothesRule.DEFAULTS, OutfitSuggestion.Bottom.JEANS, OutfitSuggestion.Top.TSHIRT)
-
-        subject.thisPeriod.first()?.outfit?.bottom shouldBe OutfitSuggestion.Bottom.JEANS
-    }
-
-    @Test
-    fun `recomputeOutfits also flips the today slot's nextOutfit using tonight's hourly`() = runTest {
-        // The "Today + Tonight" home-screen row reads both icons off the same
-        // cached TODAY insight (today's `outfit` + that insight's `nextOutfit`),
-        // not off the separate TONIGHT slot. Flipping the default-bottom picker
-        // therefore has to recompute *both* fields against the new prefs, or
-        // the user sees the today icon switch while the tonight icon next to it
-        // stays on the old pick — the setting looks half-applied.
-        val mildHourly = listOf(
-            HourlyForecast(
-                time = LocalTime.of(7, 0),
-                temperatureC = 14.0,
-                feelsLikeC = 13.0,
-                precipitationProbabilityPct = 5.0,
-                condition = WeatherCondition.CLEAR,
-            ),
-            HourlyForecast(
-                time = LocalTime.of(14, 0),
-                temperatureC = 19.0,
-                feelsLikeC = 18.0,
-                precipitationProbabilityPct = 5.0,
-                condition = WeatherCondition.CLEAR,
-            ),
-        )
-        val todayInsight = sample.copy(
-            period = ForecastPeriod.TODAY,
-            hourly = mildHourly,
-            outfit = OutfitSuggestion(OutfitSuggestion.Top.SWEATER, OutfitSuggestion.Bottom.LONG_PANTS),
-            nextOutfit = OutfitSuggestion(OutfitSuggestion.Top.SWEATER, OutfitSuggestion.Bottom.LONG_PANTS),
-        )
-        val tonightInsight = sample.copy(
-            period = ForecastPeriod.TONIGHT,
-            hourly = mildHourly,
-            outfit = OutfitSuggestion(OutfitSuggestion.Top.SWEATER, OutfitSuggestion.Bottom.LONG_PANTS),
-        )
-        subject.store(InsightCache.Slot.THIS_PERIOD, todayInsight)
-        subject.store(InsightCache.Slot.NEXT_PERIOD, tonightInsight)
-
-        subject.recomputeOutfits(ClothesRule.DEFAULTS, OutfitSuggestion.Bottom.JEANS, OutfitSuggestion.Top.TSHIRT)
-
-        val refreshedToday = subject.deliveredForToday(today, ForecastPeriod.TODAY)
-        refreshedToday?.outfit?.bottom shouldBe OutfitSuggestion.Bottom.JEANS
-        refreshedToday?.nextOutfit?.bottom shouldBe OutfitSuggestion.Bottom.JEANS
-    }
-
-    @Test
-    fun `recomputeOutfits preserves todays nextOutfit when tonight slot is absent`() = runTest {
-        // No TONIGHT slot cached → no paired hourly to recompute TODAY's
-        // nextOutfit against. The existing nextOutfit is preserved verbatim
-        // (the next worker run is what'll repair it) so we don't accidentally
-        // drop the user's tomorrow preview while waiting on the worker.
-        val mildHourly = listOf(
-            HourlyForecast(
-                time = LocalTime.of(7, 0),
-                temperatureC = 14.0,
-                feelsLikeC = 13.0,
-                precipitationProbabilityPct = 5.0,
-                condition = WeatherCondition.CLEAR,
-            ),
-        )
-        val storedNext = OutfitSuggestion(OutfitSuggestion.Top.SWEATER, OutfitSuggestion.Bottom.LONG_PANTS)
-        subject.store(
-            InsightCache.Slot.THIS_PERIOD,
-            sample.copy(
-                period = ForecastPeriod.TODAY,
-                hourly = mildHourly,
-                outfit = OutfitSuggestion(OutfitSuggestion.Top.SWEATER, OutfitSuggestion.Bottom.LONG_PANTS),
-                nextOutfit = storedNext,
-            ),
-        )
-
-        subject.recomputeOutfits(ClothesRule.DEFAULTS, OutfitSuggestion.Bottom.JEANS, OutfitSuggestion.Top.TSHIRT)
-
-        val refreshed = subject.deliveredForToday(today, ForecastPeriod.TODAY)
-        refreshed?.outfit?.bottom shouldBe OutfitSuggestion.Bottom.JEANS
-        refreshed?.nextOutfit shouldBe storedNext
-    }
-
-    @Test
-    fun `recomputeOutfits preserves nextOutfit when NEXT_PERIOD slot has the same period kind as THIS_PERIOD`() = runTest {
-        // A partial-write degraded state: the morning worker wrote
-        // THIS_PERIOD (today daytime) but the paired NEXT_PERIOD write
-        // failed, so NEXT_PERIOD still holds yesterday-evening's paired
-        // write (also a daytime insight, ~12 h stale). Borrowing the
-        // stale daytime hourly to rewrite today's `nextOutfit` (which
-        // represents *tonight*) would mis-describe the upcoming window —
-        // the opposite-period guard preserves the existing `nextOutfit`
-        // until the next worker run repairs the pairing.
-        val todayHourly = listOf(
-            HourlyForecast(
-                time = LocalTime.of(7, 0),
-                temperatureC = 14.0,
-                feelsLikeC = 13.0,
-                precipitationProbabilityPct = 5.0,
-                condition = WeatherCondition.CLEAR,
-            ),
-        )
-        // Yesterday's stale daytime hourly — if we mis-pair this with
-        // today's THIS_PERIOD slot's `nextOutfit` (which represents
-        // *tonight*) we'd describe an evening's clothes off morning
-        // weather data.
-        val stalePairedHourly = listOf(
-            HourlyForecast(
-                time = LocalTime.of(12, 0),
-                temperatureC = 2.0,
-                feelsLikeC = 0.0,
-                precipitationProbabilityPct = 5.0,
-                condition = WeatherCondition.CLEAR,
-            ),
-        )
-        val storedNext = OutfitSuggestion(OutfitSuggestion.Top.SWEATER, OutfitSuggestion.Bottom.LONG_PANTS)
-        subject.store(
-            InsightCache.Slot.THIS_PERIOD,
-            sample.copy(
-                period = ForecastPeriod.TODAY,
-                forDate = today,
-                hourly = todayHourly,
-                outfit = OutfitSuggestion(OutfitSuggestion.Top.SWEATER, OutfitSuggestion.Bottom.LONG_PANTS),
-                nextOutfit = storedNext,
-            ),
-        )
-        subject.store(
-            InsightCache.Slot.NEXT_PERIOD,
-            sample.copy(
-                // Same period kind as THIS_PERIOD — partial-paired-write
-                // signature. Should NOT be borrowed for THIS_PERIOD's
-                // nextOutfit.
-                period = ForecastPeriod.TODAY,
-                forDate = today.minusDays(1),
-                hourly = stalePairedHourly,
-                outfit = OutfitSuggestion(OutfitSuggestion.Top.THICK_COAT, OutfitSuggestion.Bottom.LONG_PANTS),
-            ),
-        )
-
-        subject.recomputeOutfits(ClothesRule.DEFAULTS, OutfitSuggestion.Bottom.JEANS, OutfitSuggestion.Top.TSHIRT)
-
-        val refreshed = subject.deliveredForToday(today, ForecastPeriod.TODAY)
-        refreshed?.outfit?.bottom shouldBe OutfitSuggestion.Bottom.JEANS
-        // nextOutfit preserved verbatim — not silently rebuilt from the
-        // same-period-kind partial-write leftover.
-        refreshed?.nextOutfit shouldBe storedNext
-    }
-
-    @Test
-    fun `recomputeOutfits leaves a slot without hourly data alone`() = runTest {
-        // No hourly entries → no way to reconstruct the day's aggregates, so
-        // the recompute can't re-evaluate rules. The slot's outfit stays as
-        // last written and refreshes on the next worker run.
-        val storedBottom = OutfitSuggestion.Bottom.LONG_PANTS
-        subject.store(
-            InsightCache.Slot.THIS_PERIOD,
-            sample.copy(
-                hourly = emptyList(),
-                outfit = OutfitSuggestion(OutfitSuggestion.Top.SWEATER, storedBottom),
-            ),
-        )
-
-        subject.recomputeOutfits(ClothesRule.DEFAULTS, OutfitSuggestion.Bottom.JEANS, OutfitSuggestion.Top.TSHIRT)
-
-        subject.thisPeriod.first()?.outfit?.bottom shouldBe storedBottom
-    }
-
-    @Test
-    fun `precip likelihood round-trips through the cache`() = runTest {
-        val possible = sample.copy(
-            summary = sample.summary.copy(
-                precip = PrecipClause(
-                    WeatherCondition.RAIN,
-                    LocalTime.of(10, 0),
-                    PrecipLikelihood.POSSIBLE,
-                ),
-            ),
-        )
-
-        subject.store(InsightCache.Slot.THIS_PERIOD, possible)
-
-        subject.thisPeriod.first()?.summary?.precip?.likelihood shouldBe PrecipLikelihood.POSSIBLE
     }
 }

--- a/app/src/test/kotlin/app/clothescast/ui/settings/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/app/clothescast/ui/settings/SettingsViewModelTest.kt
@@ -380,7 +380,7 @@ class SettingsViewModelTest {
 
     @Test
     fun `clothes-rule edits and setDefaultBottom kick the cached-outfit refresh`() = runTest {
-        // The Activity wires this lambda to a recomputeOutfits + widget-update
+        // The Activity wires this lambda to OutfitWidget().updateAll()
         // pair so the home-screen icon flips immediately on every clothes-rule
         // change. Without the refresh, settings writes would only land on the
         // Today screen at the next worker run — the bug Codex flagged on PR
@@ -398,7 +398,7 @@ class SettingsViewModelTest {
                     },
                 ),
                 voiceEnumerator = EmptyVoiceEnumerator,
-                refreshCachedOutfits = { refreshCount++ },
+                refreshOutfitWidget = { refreshCount++ },
             ),
         )
 
@@ -416,6 +416,19 @@ class SettingsViewModelTest {
 
         refreshSubject.setDefaultBottom(OutfitSuggestion.Bottom.JEANS)
         refreshSubject.state.first { it.defaultBottom == OutfitSuggestion.Bottom.JEANS }
+        refreshCount shouldBe 4
+
+        // clothesMentionMode and deltaThresholdC are prose-only — the Today
+        // screen / Format settings preview / cast / MQTT re-derive from the
+        // cached snapshot reactively against the prefs flow, so no widget
+        // poke is needed (the widget renders just the outfit icon, which
+        // these two settings don't touch).
+        refreshSubject.setClothesMentionMode(ClothesMentionMode.NEVER)
+        refreshSubject.state.first { it.clothesMentionMode == ClothesMentionMode.NEVER }
+        refreshCount shouldBe 4
+
+        refreshSubject.setDeltaThresholdC(8.0)
+        refreshSubject.state.first { it.deltaThresholdC == 8.0 }
         refreshCount shouldBe 4
     }
 

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/ForecastSnapshot.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/ForecastSnapshot.kt
@@ -1,0 +1,36 @@
+package app.clothescast.core.domain.model
+
+import app.clothescast.core.domain.repository.ForecastBundle
+import java.time.Instant
+
+/**
+ * The complete set of inputs `DeriveInsight` needs to produce a `DailyInsightResult`.
+ * Caching one of these instead of the derived [Insight] lets every consumer
+ * re-render against the latest [app.clothescast.core.domain.model.UserPreferences]
+ * for free, so a settings change (clothes rules, delta threshold, mention mode,
+ * default top / bottom) reflects in the Today screen prose, the Format settings
+ * page preview, the home-screen widget and the cast / MQTT surfaces in the same
+ * frame the dropdown closes — no preservation / re-gating logic on the cache
+ * side, no waiting for the next worker run.
+ *
+ * The [bundle] is stored already-shifted for the worker's `dayOffset` parameter,
+ * so from the renderer's perspective `bundle.today` is always the day the
+ * snapshot is for. [events] are the calendar events that overlap that day, used
+ * by `RenderInsightSummary` for the calendar-tie-in and evening-event-tie-in
+ * clauses; titles and free-form location strings are not consulted by the
+ * renderer (only timing + location-presence), so on-disk persistence keeps the
+ * minimal subset to keep the existing privacy posture intact (see PRIVACY.md).
+ *
+ * Other fields are passthrough metadata the consumer needs to stamp on the
+ * derived [Insight] or to dedup against: [location] is stamped on for the home
+ * screen's city label and maps deep-link, [period] selects the TODAY vs TONIGHT
+ * branch in the renderer, and [generatedAt] is the wall-clock when the snapshot
+ * was captured (replaces what was the cached `Insight.generatedAt`).
+ */
+data class ForecastSnapshot(
+    val bundle: ForecastBundle,
+    val events: List<CalendarEvent>,
+    val location: Location?,
+    val period: ForecastPeriod,
+    val generatedAt: Instant,
+)

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/DeriveInsight.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/DeriveInsight.kt
@@ -1,0 +1,393 @@
+package app.clothescast.core.domain.usecase
+
+import app.clothescast.core.domain.model.CalendarEvent
+import app.clothescast.core.domain.model.ConfidenceInfo
+import app.clothescast.core.domain.model.DailyForecast
+import app.clothescast.core.domain.model.EveningEventTieInClause
+import app.clothescast.core.domain.model.ForecastPeriod
+import app.clothescast.core.domain.model.ForecastSnapshot
+import app.clothescast.core.domain.model.Garment
+import app.clothescast.core.domain.model.HourlyForecast
+import app.clothescast.core.domain.model.Insight
+import app.clothescast.core.domain.model.InsightSummary
+import app.clothescast.core.domain.model.OutfitSuggestion
+import app.clothescast.core.domain.model.PerModelHourly
+import app.clothescast.core.domain.model.PrecipLikelihood
+import app.clothescast.core.domain.model.TriggeredOutfit
+import app.clothescast.core.domain.model.UserPreferences
+import app.clothescast.core.domain.model.WeatherAlert
+import app.clothescast.core.domain.model.WeatherCondition
+import app.clothescast.core.domain.repository.ForecastBundle
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+
+/**
+ * Pure-function builder for [DailyInsightResult] from a captured [ForecastSnapshot]
+ * + the user's current [UserPreferences]. This is the part of the daily pipeline
+ * that doesn't touch the network or the calendar provider — it slices the bundle
+ * into period windows, evaluates clothes rules, composes the evening-event tie-in
+ * from a sub-render of the night slice, and runs [RenderInsightSummary].
+ *
+ * Splitting this out of [GenerateDailyInsight] lets the cache layer store the
+ * snapshot rather than the derived insight, so a settings change re-runs the
+ * derivation against the latest prefs for free — no preservation / re-gating
+ * logic, no waiting for the next worker run. [GenerateDailyInsight] composes the
+ * fetch + events read on top of this same function.
+ *
+ * Day / night windows are derived entirely from the user's notification times
+ * (`prefs.schedule.time` / `prefs.tonightSchedule.time`, defaulting to 07:00 and
+ * 19:00). TODAY covers `[morning, tonight)`; TONIGHT covers `[tonight, next
+ * morning)` wrapping past midnight. The morning insight's evening tie-in is
+ * derived by running this same renderer against the night slice — i.e. the
+ * tie-in's clothes + rain mention is whatever the 7pm night notification would
+ * itself say — and only emits when the user has at least one non-all-day
+ * calendar event with a location in the night window (an event "away from
+ * home"). That away-from-home gate is the only behavioural asymmetry between
+ * the two passes; everything else falls out of the period each pass is
+ * computing.
+ */
+class DeriveInsight(
+    private val evaluateClothesRules: EvaluateClothesRules = EvaluateClothesRules(),
+    private val renderInsightSummary: RenderInsightSummary = RenderInsightSummary(),
+) {
+    operator fun invoke(
+        snapshot: ForecastSnapshot,
+        prefs: UserPreferences,
+        now: Instant = snapshot.generatedAt,
+    ): DailyInsightResult {
+        val bundle = snapshot.bundle
+        val activeAlerts = bundle.alerts.filter { it.expires.isAfter(now) }
+        val morningStart = prefs.schedule.time
+        val tonightStart = prefs.tonightSchedule.time
+        val period = snapshot.period
+
+        val periodView = buildPeriodView(
+            bundle = bundle,
+            prefs = prefs,
+            period = period,
+            morningStart = morningStart,
+            tonightStart = tonightStart,
+            events = snapshot.events,
+        )
+
+        val eveningEventTieIn = if (period == ForecastPeriod.TODAY && prefs.dailyMentionEveningEvents) {
+            buildEveningEventTieIn(
+                bundle = bundle,
+                prefs = prefs,
+                morningStart = morningStart,
+                tonightStart = tonightStart,
+                allEvents = snapshot.events,
+                alerts = activeAlerts,
+                todayItems = periodView.triggeredOutfit.items,
+            )
+        } else {
+            null
+        }
+
+        val rules = prefs.clothesRules
+        val defaultBottom = prefs.defaultBottom
+        val defaultTop = prefs.defaultTop
+
+        val summary = renderInsightSummary(
+            today = periodView.forecast,
+            yesterday = periodView.deltaYesterday,
+            todayItems = periodView.triggeredOutfit.items,
+            alerts = activeAlerts,
+            events = periodView.events,
+            period = period,
+            todayForDelta = periodView.deltaToday,
+            perModelHourly = periodView.perModelForRender,
+            eveningEventTieIn = eveningEventTieIn,
+            deltaThresholdC = prefs.deltaThresholdC,
+            clothesMentionMode = prefs.clothesMentionMode,
+            yesterdayTriggeredItems = periodView.yesterdayTriggeredItems,
+            todayRuleItems = Garment.layerReduce(periodView.triggeredOutfit.rules).map { it.item },
+        )
+
+        val insight = Insight(
+            summary = summary,
+            recommendedItems = periodView.triggeredOutfit.items,
+            generatedAt = snapshot.generatedAt,
+            forDate = bundle.today.date,
+            location = snapshot.location,
+            hourly = periodView.forecast.hourly,
+            confidence = if (bundle.perModelHourly == null) {
+                bundle.confidence
+            } else {
+                periodView.perModelForRender?.let { ConfidenceInfo.computeFrom(it) }
+            },
+            perModelHourly = periodView.perModelForRender,
+            outfit = OutfitSuggestion.fromForecast(periodView.forecast, rules, defaultBottom, defaultTop),
+            nextOutfit = periodView.nextForecast?.let {
+                OutfitSuggestion.fromForecast(it, rules, defaultBottom, defaultTop)
+            },
+            outfitRationale = OutfitSuggestion.explainFromForecast(periodView.forecast, rules),
+            nextOutfitRationale = periodView.nextForecast?.let {
+                OutfitSuggestion.explainFromForecast(it, rules)
+            },
+            period = period,
+            hasEvents = periodView.events.any { !it.allDay && !it.location.isNullOrBlank() },
+            forecastZone = bundle.forecastZone,
+        )
+        return DailyInsightResult(insight = insight, alerts = activeAlerts)
+    }
+
+    private fun buildPeriodView(
+        bundle: ForecastBundle,
+        prefs: UserPreferences,
+        period: ForecastPeriod,
+        morningStart: LocalTime,
+        tonightStart: LocalTime,
+        events: List<CalendarEvent>,
+    ): PeriodView {
+        val todayForecast = bundle.today.slicedForToday(
+            morningStart = morningStart,
+            eveningEnd = tonightStart,
+        )
+        val tonightForecast = bundle.today.slicedForTonight(
+            tonightStart = tonightStart,
+            morningEnd = morningStart,
+            tomorrowHourly = bundle.tomorrowHourly,
+        )
+        val periodForecast = when (period) {
+            ForecastPeriod.TODAY -> todayForecast
+            ForecastPeriod.TONIGHT -> tonightForecast
+        }
+        val yesterdayDaytime = bundle.yesterday.slicedForToday(
+            morningStart = morningStart,
+            eveningEnd = tonightStart,
+        )
+        val (deltaToday, deltaYesterday) =
+            if (todayForecast.hourly.isNotEmpty() && yesterdayDaytime.hourly.isNotEmpty()) {
+                todayForecast to yesterdayDaytime
+            } else {
+                bundle.today to bundle.yesterday
+            }
+        val nextForecast = when (period) {
+            ForecastPeriod.TODAY -> tonightForecast.takeIf { it.hourly.isNotEmpty() }
+            ForecastPeriod.TONIGHT -> bundle.tomorrow?.slicedForToday(
+                morningStart = morningStart,
+                eveningEnd = tonightStart,
+            )
+        }
+        val triggeredOutfit = evaluateClothesRules(
+            periodForecast,
+            prefs.clothesRules,
+            prefs.defaultTop,
+            prefs.defaultBottom,
+        )
+        val yesterdayTriggeredItems = evaluateClothesRules(
+            deltaYesterday,
+            prefs.clothesRules,
+            prefs.defaultTop,
+            prefs.defaultBottom,
+        ).items
+        val perModelForRender = bundle.perModelHourly?.slicedTo(
+            when (period) {
+                ForecastPeriod.TODAY -> todayWindow(periodForecast.hourly, bundle.today.date)
+                ForecastPeriod.TONIGHT -> tonightWindow(periodForecast.hourly, bundle.today.date, tonightStart)
+            },
+        )
+        return PeriodView(
+            forecast = periodForecast,
+            nextForecast = nextForecast,
+            triggeredOutfit = triggeredOutfit,
+            events = filterEventsForPeriod(events, period, tonightStart),
+            perModelForRender = perModelForRender,
+            deltaToday = deltaToday,
+            deltaYesterday = deltaYesterday,
+            yesterdayTriggeredItems = yesterdayTriggeredItems,
+        )
+    }
+
+    private fun buildEveningEventTieIn(
+        bundle: ForecastBundle,
+        prefs: UserPreferences,
+        morningStart: LocalTime,
+        tonightStart: LocalTime,
+        allEvents: List<CalendarEvent>,
+        alerts: List<WeatherAlert>,
+        todayItems: List<String>,
+    ): EveningEventTieInClause? {
+        val nightEvents = filterEventsForPeriod(allEvents, ForecastPeriod.TONIGHT, tonightStart)
+        val awayFromHome = nightEvents.any { !it.allDay && !it.location.isNullOrBlank() }
+        if (!awayFromHome) return null
+
+        val nightView = buildPeriodView(
+            bundle = bundle,
+            prefs = prefs,
+            period = ForecastPeriod.TONIGHT,
+            morningStart = morningStart,
+            tonightStart = tonightStart,
+            events = allEvents,
+        )
+        val nightSummary: InsightSummary = renderInsightSummary(
+            today = nightView.forecast,
+            yesterday = nightView.deltaYesterday,
+            todayItems = nightView.triggeredOutfit.items,
+            alerts = alerts,
+            events = nightView.events,
+            period = ForecastPeriod.TONIGHT,
+            todayForDelta = nightView.deltaToday,
+            perModelHourly = nightView.perModelForRender,
+            eveningEventTieIn = null,
+            deltaThresholdC = prefs.deltaThresholdC,
+            todayRuleItems = Garment.layerReduce(nightView.triggeredOutfit.rules).map { it.item },
+        )
+        val precip = nightSummary.precip
+        val dayKeysBySlot = todayItems
+            .mapNotNull { Garment.fromKey(it) }
+            .groupBy({ it.slot }, { it.itemKey })
+            .mapValues { it.value.toSet() }
+        val dayTopKey = dayKeysBySlot[Garment.Slot.TOP].orEmpty()
+        val dayBottomKey = dayKeysBySlot[Garment.Slot.BOTTOM].orEmpty()
+        val topDelta = Garment.layerReduce(nightView.triggeredOutfit.rules)
+            .map { it.item }
+            .filter { item ->
+                val g = Garment.fromKey(item)
+                g?.slot == Garment.Slot.TOP && g.itemKey !in dayTopKey
+            }
+        val bottomDelta = nightView.triggeredOutfit.items
+            .filter { item ->
+                val g = Garment.fromKey(item)
+                g?.slot == Garment.Slot.BOTTOM && g.itemKey !in dayBottomKey
+            }
+        val deltaItems = topDelta + bottomDelta
+
+        if (deltaItems.isEmpty() && precip == null) return null
+
+        return EveningEventTieInClause(
+            items = deltaItems,
+            rainTime = precip?.time,
+            likelihood = precip?.likelihood ?: PrecipLikelihood.LIKELY,
+        )
+    }
+
+    private fun filterEventsForPeriod(
+        events: List<CalendarEvent>,
+        period: ForecastPeriod,
+        tonightStart: LocalTime,
+    ): List<CalendarEvent> = when (period) {
+        ForecastPeriod.TODAY -> events
+        ForecastPeriod.TONIGHT -> events.filter { it.allDay || !it.start.isBefore(tonightStart) }
+    }
+
+    private data class PeriodView(
+        val forecast: DailyForecast,
+        val nextForecast: DailyForecast?,
+        val triggeredOutfit: TriggeredOutfit,
+        val events: List<CalendarEvent>,
+        val perModelForRender: PerModelHourly?,
+        val deltaToday: DailyForecast,
+        val deltaYesterday: DailyForecast,
+        val yesterdayTriggeredItems: List<String>,
+    )
+}
+
+/**
+ * Returns a view of this bundle with tomorrow promoted to today. Used by the
+ * evening worker's "next" pre-render path: the same fetch covers both the
+ * tonight window the alarm is delivering *and* the tomorrow-daytime window
+ * the Today screen's pager will show on page 2. Returns null when the bundle
+ * has no tomorrow data (legacy `forecast_days=1` fixtures); the caller drops
+ * the next-card pre-render rather than fabricate data.
+ *
+ * Yesterday becomes today's daily forecast so the delta clause still has an
+ * apples-to-apples comparison (tomorrow vs. today). The `tomorrow` and
+ * `tomorrowHourly` fields drop to empty — we don't have day-after-tomorrow
+ * data, so a hypothetical tonight-period generation off the shifted bundle
+ * would lose its overnight wrap; that's why the public `dayOffset=1` path is
+ * gated to TODAY-period only.
+ */
+internal fun ForecastBundle.shiftedToTomorrow(): ForecastBundle? {
+    val tmrw = tomorrow ?: return null
+    return copy(
+        today = tmrw,
+        yesterday = today,
+        tomorrow = null,
+        tomorrowHourly = emptyList(),
+    )
+}
+
+internal fun PerModelHourly.slicedTo(window: List<LocalDateTime>): PerModelHourly? {
+    if (window.isEmpty()) return null
+    val filtered = byModel.mapNotNull { (model, entries) ->
+        val byTime = entries.associateBy { it.time }
+        val sliced = window.map { byTime[it] ?: return@mapNotNull null }
+        model to sliced
+    }.toMap()
+    return if (filtered.isEmpty()) null else PerModelHourly(filtered)
+}
+
+internal fun todayWindow(windowHourly: List<HourlyForecast>, todayDate: LocalDate): List<LocalDateTime> =
+    windowHourly.map { LocalDateTime.of(todayDate, it.time) }
+
+internal fun tonightWindow(
+    windowHourly: List<HourlyForecast>,
+    todayDate: LocalDate,
+    tonightStart: LocalTime,
+): List<LocalDateTime> = windowHourly.map { entry ->
+    val date = if (!entry.time.isBefore(tonightStart)) todayDate else todayDate.plusDays(1)
+    LocalDateTime.of(date, entry.time)
+}
+
+internal fun DailyForecast.slicedForToday(
+    morningStart: LocalTime,
+    eveningEnd: LocalTime,
+): DailyForecast {
+    if (!morningStart.isBefore(eveningEnd)) return this
+    val sliced = hourly.filter { it.time >= morningStart && it.time < eveningEnd }
+    if (sliced.isEmpty()) return copy(hourly = sliced)
+    return copy(
+        hourly = sliced,
+        temperatureMinC = sliced.minOf { it.temperatureC },
+        temperatureMaxC = sliced.maxOf { it.temperatureC },
+        feelsLikeMinC = sliced.minOf { it.feelsLikeC },
+        feelsLikeMaxC = sliced.maxOf { it.feelsLikeC },
+        precipitationProbabilityMaxPct = sliced.maxOf { it.precipitationProbabilityPct },
+        condition = sliced.maxByOrNull { it.precipitationProbabilityPct }
+            ?.condition
+            ?.takeIf { it != WeatherCondition.UNKNOWN }
+            ?: condition,
+    )
+}
+
+internal fun DailyForecast.slicedForTonight(
+    tonightStart: LocalTime,
+    morningEnd: LocalTime,
+    tomorrowHourly: List<HourlyForecast>,
+): DailyForecast {
+    val tonightHours = hourly.filter { it.time >= tonightStart }
+    val tomorrowMorning = if (tonightStart.isBefore(morningEnd)) {
+        emptyList()
+    } else {
+        tomorrowHourly.filter { it.time < morningEnd }
+    }
+    val sliced = tonightHours + tomorrowMorning
+    if (sliced.isEmpty()) return copy(hourly = sliced)
+    return copy(
+        hourly = sliced,
+        temperatureMinC = sliced.minOf { it.temperatureC },
+        temperatureMaxC = sliced.maxOf { it.temperatureC },
+        feelsLikeMinC = sliced.minOf { it.feelsLikeC },
+        feelsLikeMaxC = sliced.maxOf { it.feelsLikeC },
+        precipitationProbabilityMaxPct = sliced.maxOf { it.precipitationProbabilityPct },
+        condition = sliced.maxByOrNull { it.precipitationProbabilityPct }
+            ?.condition
+            ?.takeIf { it != WeatherCondition.UNKNOWN }
+            ?: condition,
+    )
+}
+
+/**
+ * Bundles the daily insight with the active alerts that informed it. Alerts are kept
+ * separate from [Insight] because they have a different lifecycle: the insight is
+ * cached for the day and redelivered on demand, while alerts drive a one-shot
+ * high-priority notification at fetch time.
+ */
+data class DailyInsightResult(
+    val insight: Insight,
+    val alerts: List<WeatherAlert>,
+)

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsight.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsight.kt
@@ -1,54 +1,35 @@
 package app.clothescast.core.domain.usecase
 
 import app.clothescast.core.domain.model.CalendarEvent
-import app.clothescast.core.domain.model.ConfidenceInfo
-import app.clothescast.core.domain.model.DailyForecast
-import app.clothescast.core.domain.model.EveningEventTieInClause
 import app.clothescast.core.domain.model.ForecastPeriod
-import app.clothescast.core.domain.model.Garment
-import app.clothescast.core.domain.model.HourlyForecast
-import app.clothescast.core.domain.model.Insight
-import app.clothescast.core.domain.model.InsightSummary
+import app.clothescast.core.domain.model.ForecastSnapshot
 import app.clothescast.core.domain.model.Location
-import app.clothescast.core.domain.model.OutfitSuggestion
-import app.clothescast.core.domain.model.PerModelHourly
-import app.clothescast.core.domain.model.PrecipLikelihood
-import app.clothescast.core.domain.model.TriggeredOutfit
 import app.clothescast.core.domain.model.UserPreferences
-import app.clothescast.core.domain.model.WeatherAlert
-import app.clothescast.core.domain.model.WeatherCondition
 import app.clothescast.core.domain.repository.CalendarEventReader
-import app.clothescast.core.domain.repository.ForecastBundle
 import app.clothescast.core.domain.repository.WeatherRepository
 import java.time.Clock
 import java.time.LocalDate
-import java.time.LocalDateTime
-import java.time.LocalTime
 
 /**
- * The product. Fetches the forecast, evaluates clothes rules, renders the
- * deterministic summary string in [renderInsightSummary], and packages the result.
+ * The product. Fetches the forecast + reads today's calendar events, captures
+ * them as a [ForecastSnapshot], and runs [DeriveInsight] against the current
+ * [UserPreferences] to produce a [DailyInsightResult].
  *
- * Day / night windows are derived entirely from the user's notification times
- * (`prefs.schedule.time` / `prefs.tonightSchedule.time`, defaulting to 07:00 and
- * 19:00). TODAY covers `[morning, tonight)`; TONIGHT covers `[tonight, next
- * morning)` wrapping past midnight. The morning insight's evening tie-in is
- * derived by running this same renderer against the night slice — i.e. the
- * tie-in's clothes + rain mention is whatever the 7pm night notification would
- * itself say — and only emits when the user has at least one non-all-day
- * calendar event with a location in the night window (an event "away from
- * home"). That away-from-home gate is the only behavioural asymmetry between
- * the two passes; everything else falls out of the period each pass is
- * computing.
+ * Splitting fetch + read from derive lets the cache layer store the snapshot
+ * (the raw upstream inputs) rather than the derived insight, so a settings
+ * change re-runs the derivation against the latest prefs for free — no
+ * preservation / re-gating logic on the cache side, no waiting for the next
+ * worker run. Callers that already hold a fresh snapshot (the cache after a
+ * worker write, the Today screen / widget / cast / Format settings preview
+ * combining snapshot + prefs flows) call [DeriveInsight] directly.
  *
- * Severe-weather alerts piggy-back on the same fetch and are returned alongside the
- * insight in [DailyInsightResult]; the worker uses them to drive a separate
+ * Severe-weather alerts piggy-back on the same fetch and are returned alongside
+ * the insight in [DailyInsightResult]; the worker uses them to drive a separate
  * high-priority notification while still feeding them into the daily summary.
  */
 class GenerateDailyInsight(
     private val weatherRepository: WeatherRepository,
-    private val evaluateClothesRules: EvaluateClothesRules = EvaluateClothesRules(),
-    private val renderInsightSummary: RenderInsightSummary = RenderInsightSummary(),
+    private val deriveInsight: DeriveInsight = DeriveInsight(),
     private val calendarEventReader: CalendarEventReader? = null,
     private val clock: Clock = Clock.systemUTC(),
 ) {
@@ -66,6 +47,23 @@ class GenerateDailyInsight(
         // the bundle to wrap a tomorrow-tonight window around.
         dayOffset: Int = 0,
     ): DailyInsightResult {
+        val snapshot = snapshot(location, prefs, period, dayOffset)
+        return deriveInsight(snapshot, prefs)
+    }
+
+    /**
+     * Captures the inputs `DeriveInsight` needs into a [ForecastSnapshot] without
+     * running the derivation. The worker uses this to write the snapshot to
+     * [app.clothescast.data.InsightCache] before delivering the insight, so any
+     * later consumer (Today screen, widget, cast, Format settings preview) can
+     * re-render against the latest prefs for free.
+     */
+    suspend fun snapshot(
+        location: Location,
+        prefs: UserPreferences,
+        period: ForecastPeriod = ForecastPeriod.TODAY,
+        dayOffset: Int = 0,
+    ): ForecastSnapshot {
         require(dayOffset == 0 || (dayOffset == 1 && period == ForecastPeriod.TODAY)) {
             "Only same-day (dayOffset=0) and tomorrow-daytime (dayOffset=1, period=TODAY) generation are supported."
         }
@@ -77,113 +75,14 @@ class GenerateDailyInsight(
         } else {
             fetched
         }
-        val activeAlerts = bundle.alerts.filter { it.expires.isAfter(clock.instant()) }
-        val morningStart = prefs.schedule.time
-        val tonightStart = prefs.tonightSchedule.time
-
-        val allEvents = readEventsForDay(bundle.today.date, prefs)
-
-        val periodView = buildPeriodView(
+        val events = readEventsForDay(bundle.today.date, prefs)
+        return ForecastSnapshot(
             bundle = bundle,
-            prefs = prefs,
+            events = events,
+            location = location,
             period = period,
-            morningStart = morningStart,
-            tonightStart = tonightStart,
-            events = allEvents,
-        )
-
-        // Morning insight's tie-in: re-run the same machinery against the night
-        // slice and fold its clothes + precip clauses into an
-        // EveningEventTieInClause, but only when the user has an event away
-        // from home that night (location-set, non-all-day). When TONIGHT is
-        // the primary, no tie-in (it's already what the user is hearing).
-        val eveningEventTieIn = if (period == ForecastPeriod.TODAY && prefs.dailyMentionEveningEvents) {
-            buildEveningEventTieIn(
-                bundle = bundle,
-                prefs = prefs,
-                morningStart = morningStart,
-                tonightStart = tonightStart,
-                allEvents = allEvents,
-                alerts = activeAlerts,
-                todayItems = periodView.triggeredOutfit.items,
-            )
-        } else {
-            null
-        }
-
-        val rules = prefs.clothesRules
-        val defaultBottom = prefs.defaultBottom
-        val defaultTop = prefs.defaultTop
-
-        val summary = renderInsightSummary(
-            today = periodView.forecast,
-            yesterday = periodView.deltaYesterday,
-            todayItems = periodView.triggeredOutfit.items,
-            alerts = activeAlerts,
-            events = periodView.events,
-            period = period,
-            todayForDelta = periodView.deltaToday,
-            perModelHourly = periodView.perModelForRender,
-            eveningEventTieIn = eveningEventTieIn,
-            deltaThresholdC = prefs.deltaThresholdC,
-            clothesMentionMode = prefs.clothesMentionMode,
-            yesterdayTriggeredItems = periodView.yesterdayTriggeredItems,
-            // Layer-reduce here so the calendar tie-in ("Bring an X for your
-            // event.") doesn't name a BASE garment that's implicit under a
-            // firing MID/SHELL. Matches what TriggeredOutfit.items does on
-            // the prose side; kept explicit at the call boundary so the
-            // RenderInsightSummary signature stays agnostic to the catalog.
-            todayRuleItems = Garment.layerReduce(periodView.triggeredOutfit.rules).map { it.item },
-        )
-
-        val insight = Insight(
-            summary = summary,
-            recommendedItems = periodView.triggeredOutfit.items,
             generatedAt = clock.instant(),
-            forDate = bundle.today.date,
-            hourly = periodView.forecast.hourly,
-            // Recompute over the rendered window so the chip's tier title +
-            // precip-spread number describe the same hours the divergence
-            // hint picks its peak from. `bundle.confidence` is the full-
-            // calendar-day aggregate; falling back to it is only safe when
-            // the *bundle itself* has no perModelHourly (truly legacy
-            // payloads), because in that case the chip has no detail line
-            // either and the window mismatch is invisible.
-            //
-            // When the bundle does carry perModelHourly but the rendered
-            // window slice ends up null or sparse — `slicedTo` returns
-            // null on an empty window or when every model is missing an
-            // in-window hour; `ConfidenceInfo.computeFrom` returns null
-            // on < 2 consulted models with non-empty hours — prefer null
-            // over `bundle.confidence`. Surfacing the daily aggregate
-            // there would silently reintroduce the window mismatch this
-            // change is fixing. The chip treats null as "unknown" and
-            // hides itself, which is the honest answer.
-            confidence = if (bundle.perModelHourly == null) {
-                bundle.confidence
-            } else {
-                periodView.perModelForRender?.let { ConfidenceInfo.computeFrom(it) }
-            },
-            perModelHourly = periodView.perModelForRender,
-            outfit = OutfitSuggestion.fromForecast(periodView.forecast, rules, defaultBottom, defaultTop),
-            nextOutfit = periodView.nextForecast?.let {
-                OutfitSuggestion.fromForecast(it, rules, defaultBottom, defaultTop)
-            },
-            outfitRationale = OutfitSuggestion.explainFromForecast(periodView.forecast, rules),
-            nextOutfitRationale = periodView.nextForecast?.let {
-                OutfitSuggestion.explainFromForecast(it, rules)
-            },
-            period = period,
-            // Mirrors the "away from home" gate used by `buildEveningEventTieIn`
-            // below: a tonight notification fires loud / through the "only on
-            // events" pref only when the user has somewhere to be, i.e. a
-            // non-all-day event with a location. Holiday and birthday rows
-            // (all-day, no location — and now preserved by the reader for
-            // classification) naturally fall out.
-            hasEvents = periodView.events.any { !it.allDay && !it.location.isNullOrBlank() },
-            forecastZone = bundle.forecastZone,
         )
-        return DailyInsightResult(insight = insight, alerts = activeAlerts)
     }
 
     private suspend fun readEventsForDay(date: LocalDate, prefs: UserPreferences): List<CalendarEvent> {
@@ -197,459 +96,4 @@ class GenerateDailyInsight(
             reader.eventsForDay(date, prefs.schedule.zoneId)
         }.getOrDefault(emptyList())
     }
-
-    private fun buildPeriodView(
-        bundle: ForecastBundle,
-        prefs: UserPreferences,
-        period: ForecastPeriod,
-        morningStart: LocalTime,
-        tonightStart: LocalTime,
-        events: List<CalendarEvent>,
-    ): PeriodView {
-        val todayForecast = bundle.today.slicedForToday(
-            morningStart = morningStart,
-            eveningEnd = tonightStart,
-        )
-        val tonightForecast = bundle.today.slicedForTonight(
-            tonightStart = tonightStart,
-            morningEnd = morningStart,
-            tomorrowHourly = bundle.tomorrowHourly,
-        )
-        val periodForecast = when (period) {
-            ForecastPeriod.TODAY -> todayForecast
-            ForecastPeriod.TONIGHT -> tonightForecast
-        }
-        // Yesterday paired against today's daytime window for the delta
-        // comparison — apples-to-apples daytime feels-like, falling back to 24h
-        // if either side has no hourly data. TONIGHT skips the delta clause
-        // entirely so this pair only matters for TODAY, but compute it
-        // unconditionally for symmetry.
-        val yesterdayDaytime = bundle.yesterday.slicedForToday(
-            morningStart = morningStart,
-            eveningEnd = tonightStart,
-        )
-        val (deltaToday, deltaYesterday) =
-            if (todayForecast.hourly.isNotEmpty() && yesterdayDaytime.hourly.isNotEmpty()) {
-                todayForecast to yesterdayDaytime
-            } else {
-                bundle.today to bundle.yesterday
-            }
-        // The home screen wants a side-by-side preview pair: "Today + Tonight"
-        // on a morning insight, "Tonight + Tomorrow" on an evening one. The
-        // second outfit comes from the same bundle so showing both costs no
-        // extra API call. Null when the underlying data isn't there (e.g.
-        // evening insight on a legacy bundle without tomorrow's daily
-        // aggregates) — the screen falls back to a single card.
-        //
-        // Slice tomorrow to the user's daytime window so the "Why this
-        // outfit?" rationale (and the outfit picker) cite an in-window
-        // hour — otherwise a pre-dawn 06:00 trough drives "Feels-like low
-        // 5.8°C at 06:00" on the Tomorrow card for a user who won't be
-        // outside until 07:00.
-        val nextForecast = when (period) {
-            ForecastPeriod.TODAY -> tonightForecast.takeIf { it.hourly.isNotEmpty() }
-            ForecastPeriod.TONIGHT -> bundle.tomorrow?.slicedForToday(
-                morningStart = morningStart,
-                eveningEnd = tonightStart,
-            )
-        }
-        val triggeredOutfit = evaluateClothesRules(
-            periodForecast,
-            prefs.clothesRules,
-            prefs.defaultTop,
-            prefs.defaultBottom,
-        )
-        // Yesterday's clothing, evaluated against the same yesterday slice the
-        // delta uses, so ClothesMentionMode.IF_CHANGED compares apples to apples
-        // (daytime-vs-daytime, or 24h fallback when hourly is missing). Includes
-        // the per-tier default rule's items on both sides so a stretch of mild
-        // days reads as unchanged (rather than the engine emitting an empty
-        // list yesterday and a populated one today, with IF_CHANGED triggering
-        // every morning).
-        val yesterdayTriggeredItems = evaluateClothesRules(
-            deltaYesterday,
-            prefs.clothesRules,
-            prefs.defaultTop,
-            prefs.defaultBottom,
-        ).items
-        val perModelForRender = bundle.perModelHourly?.slicedTo(
-            when (period) {
-                ForecastPeriod.TODAY -> todayWindow(periodForecast.hourly, bundle.today.date)
-                ForecastPeriod.TONIGHT -> tonightWindow(periodForecast.hourly, bundle.today.date, tonightStart)
-            },
-        )
-        return PeriodView(
-            forecast = periodForecast,
-            nextForecast = nextForecast,
-            triggeredOutfit = triggeredOutfit,
-            events = filterEventsForPeriod(events, period, tonightStart),
-            perModelForRender = perModelForRender,
-            deltaToday = deltaToday,
-            deltaYesterday = deltaYesterday,
-            yesterdayTriggeredItems = yesterdayTriggeredItems,
-        )
-    }
-
-    /**
-     * Composes the morning's evening-event tie-in by running the renderer
-     * against the night slice and folding off its clothes and precip clauses.
-     * Gated on the user having at least one non-all-day calendar event with a
-     * location set in the night window — the "away from home" rule that
-     * motivates the heads-up in the first place.
-     *
-     * The clothing item carried in the clause is the *delta* between night
-     * and day — items the night needs that the day didn't already announce
-     * — so a tie-in only adds vocabulary the morning insight hasn't already
-     * delivered. If the day already says "Bring a jacket", an identical
-     * "Bring a jacket tonight" repeats; if the night additionally needs a
-     * coat, the tie-in carries "coat". When the night and day rules trigger
-     * the same items but the night insight has a precip clause, the tie-in
-     * falls through to a bare rain mention (item=null, rainTime set), since
-     * the rain itself is new information the morning slice didn't surface.
-     *
-     * Returns null when there's no away-from-home event, when there's
-     * neither a delta nor rain to surface, or both.
-     */
-    private fun buildEveningEventTieIn(
-        bundle: ForecastBundle,
-        prefs: UserPreferences,
-        morningStart: LocalTime,
-        tonightStart: LocalTime,
-        allEvents: List<CalendarEvent>,
-        alerts: List<WeatherAlert>,
-        todayItems: List<String>,
-    ): EveningEventTieInClause? {
-        val nightEvents = filterEventsForPeriod(allEvents, ForecastPeriod.TONIGHT, tonightStart)
-        // "Away from home" = any non-all-day event with a non-blank location.
-        // A user-configured home pin now exists (UserPreferences.homeLocation,
-        // used by FetchAndNotifyWorker for the at-home TTS gate) but we
-        // deliberately don't fold it in here: the home displayName is a
-        // specific reverse-geocoded label that almost never byte-matches a
-        // calendar event's free-form location string, and lat/lon-based event
-        // matching isn't reachable — CalendarContract.Instances.EVENT_LOCATION
-        // is text only, off-device geocoding of event data is blocked by
-        // PRIVACY.md, and on-device Android Geocoder is unreliable. If we ever
-        // gain structured event lat/lon (e.g. via Google Calendar extended
-        // properties), revisit then; for now the blank-location assumption
-        // does the heavy lifting and is correct for the common case.
-        val awayFromHome = nightEvents.any { !it.allDay && !it.location.isNullOrBlank() }
-        if (!awayFromHome) return null
-
-        val nightView = buildPeriodView(
-            bundle = bundle,
-            prefs = prefs,
-            period = ForecastPeriod.TONIGHT,
-            morningStart = morningStart,
-            tonightStart = tonightStart,
-            events = allEvents,
-        )
-        val nightSummary: InsightSummary = renderInsightSummary(
-            today = nightView.forecast,
-            yesterday = nightView.deltaYesterday,
-            todayItems = nightView.triggeredOutfit.items,
-            alerts = alerts,
-            events = nightView.events,
-            period = ForecastPeriod.TONIGHT,
-            todayForDelta = nightView.deltaToday,
-            perModelHourly = nightView.perModelForRender,
-            eveningEventTieIn = null,
-            deltaThresholdC = prefs.deltaThresholdC,
-            // Layer-reduce: same rationale as the primary-period call above,
-            // so the night sub-render's calendar tie-in agrees with the
-            // outer-tie-in delta this method then computes.
-            todayRuleItems = Garment.layerReduce(nightView.triggeredOutfit.rules).map { it.item },
-        )
-        // Delta is computed per-tier because tops layer and bottoms substitute,
-        // and those two relationships imply different ways the morning's outfit
-        // already covers (or doesn't cover) the night's:
-        //
-        //  - **Tops layer.** A sweater goes over a t-shirt. So if the day's
-        //    outfit already includes a sweater-tier garment (whether from a
-        //    matched threshold rule OR the user's defaultTop, e.g. someone
-        //    who runs cold picking defaultTop = SWEATER), and the night
-        //    needs no additional layer, the tie-in stays silent — the user
-        //    just removes a layer when they get warm, no need to "bring"
-        //    anything. Only night-side *threshold-rule matches* contribute
-        //    to the top delta; a night-side default top is the baseline,
-        //    not an extra.
-        //  - **Bottoms substitute.** You don't wear pants over shorts; you
-        //    swap. So a hot day's shorts → mild evening's defaultBottom
-        //    pants IS a real action the user needs to take, and "Bring
-        //    pants tonight" reads right. Both sides of the bottom delta
-        //    use full items (rules + defaults).
-        //
-        // Items that don't map to a [Garment] catalog entry (e.g. "umbrella")
-        // don't contribute to either delta — they surface through the precip
-        // clause, not the clothes delta.
-        //
-        // TODO(rules-redesign): replace the per-tier dispatch with explicit
-        //  per-garment relationship metadata on [Garment]
-        //  (`layersOver` / `substitutesFor`). Today's heuristic is correct
-        //  for the catalog as it stands (all tops layer, all bottoms
-        //  substitute), but a future catalog entry could break that
-        //  assumption (e.g. a "dress" garment that substitutes for the
-        //  whole outfit, or a "scarf" that layers independently of the
-        //  top slot). At that point the dispatch wants to read from
-        //  Garment, not from the tier.
-        val precip = nightSummary.precip
-        // Membership comparison canonicalizes through Garment.fromKey().itemKey
-        // — not just normalize(item) — so legacy aliases collapse before the
-        // set lookup ("trousers" yesterday vs "pants" tonight both resolve to
-        // PANTS / "pants", same garment, no spurious "Bring pants." emission).
-        // fromKey already trims and lowercases internally and maps the
-        // tolerated aliases (trousers, jumper, tshirt) onto the canonical key,
-        // so this also picks up the case / whitespace tolerance the previous
-        // normalize() pass was doing.
-        val dayKeysBySlot = todayItems
-            .mapNotNull { Garment.fromKey(it) }
-            .groupBy({ it.slot }, { it.itemKey })
-            .mapValues { it.value.toSet() }
-        val dayTopKey = dayKeysBySlot[Garment.Slot.TOP].orEmpty()
-        val dayBottomKey = dayKeysBySlot[Garment.Slot.BOTTOM].orEmpty()
-        // Layer-reduce the night's firing rules before computing the delta:
-        // a BASE rule firing on the night side alongside a MID/SHELL is
-        // implicit in the outer layer and shouldn't surface as "Bring a
-        // t-shirt tonight" just because the user has a t-shirt rule with a
-        // generous threshold. Mirrors what TriggeredOutfit.items already does
-        // for the prose path.
-        val topDelta = Garment.layerReduce(nightView.triggeredOutfit.rules)
-            .map { it.item }
-            .filter { item ->
-                val g = Garment.fromKey(item)
-                g?.slot == Garment.Slot.TOP && g.itemKey !in dayTopKey
-            }
-        val bottomDelta = nightView.triggeredOutfit.items
-            .filter { item ->
-                val g = Garment.fromKey(item)
-                g?.slot == Garment.Slot.BOTTOM && g.itemKey !in dayBottomKey
-            }
-        val deltaItems = topDelta + bottomDelta
-
-        if (deltaItems.isEmpty() && precip == null) return null
-
-        return EveningEventTieInClause(
-            items = deltaItems,
-            rainTime = precip?.time,
-            likelihood = precip?.likelihood ?: PrecipLikelihood.LIKELY,
-        )
-    }
-
-    private fun filterEventsForPeriod(
-        events: List<CalendarEvent>,
-        period: ForecastPeriod,
-        tonightStart: LocalTime,
-    ): List<CalendarEvent> = when (period) {
-        ForecastPeriod.TODAY -> events
-        // Tonight = anything starting at or after the tonight time, OR an all-day
-        // event that bleeds across the evening (treated as relevant context).
-        ForecastPeriod.TONIGHT -> events.filter { it.allDay || !it.start.isBefore(tonightStart) }
-    }
-
-    private data class PeriodView(
-        val forecast: DailyForecast,
-        val nextForecast: DailyForecast?,
-        val triggeredOutfit: TriggeredOutfit,
-        val events: List<CalendarEvent>,
-        val perModelForRender: PerModelHourly?,
-        val deltaToday: DailyForecast,
-        val deltaYesterday: DailyForecast,
-        val yesterdayTriggeredItems: List<String>,
-    )
 }
-
-/**
- * Returns a view of this bundle with tomorrow promoted to today. Used by the
- * evening worker's "next" pre-render path: the same fetch covers both the
- * tonight window the alarm is delivering *and* the tomorrow-daytime window
- * the Today screen's pager will show on page 2. Returns null when the bundle
- * has no tomorrow data (legacy `forecast_days=1` fixtures); the caller drops
- * the next-card pre-render rather than fabricate data.
- *
- * Yesterday becomes today's daily forecast so the delta clause still has an
- * apples-to-apples comparison (tomorrow vs. today). The `tomorrow` and
- * `tomorrowHourly` fields drop to empty — we don't have day-after-tomorrow
- * data, so a hypothetical tonight-period generation off the shifted bundle
- * would lose its overnight wrap; that's why the public `dayOffset=1` path is
- * gated to TODAY-period only.
- */
-private fun ForecastBundle.shiftedToTomorrow(): ForecastBundle? {
-    val tmrw = tomorrow ?: return null
-    return copy(
-        today = tmrw,
-        yesterday = today,
-        tomorrow = null,
-        tomorrowHourly = emptyList(),
-    )
-}
-
-/**
- * Filters each model's per-hour entries to just the hours covered by [window]
- * (LocalDateTimes the caller computed from the period's hourly slice), preserving
- * the window's order so each index in the resulting series lines up with the same
- * index in the matching base hourly — the chart plots overlays by index.
- *
- * Drops a model entirely from the overlay if it's missing any in-window hour
- * (the upstream `parseHourly` skips per-hour entries with null temp or precip
- * values for a model whose run hasn't fully landed). Carrying a partial series
- * would compact the surviving points left, misaligning the model line with the
- * blended line for every hour after the gap. An empty result returns null so
- * the caller can null the whole field.
- */
-private fun PerModelHourly.slicedTo(window: List<LocalDateTime>): PerModelHourly? {
-    if (window.isEmpty()) return null
-    val filtered = byModel.mapNotNull { (model, entries) ->
-        val byTime = entries.associateBy { it.time }
-        val sliced = window.map { byTime[it] ?: return@mapNotNull null }
-        model to sliced
-    }.toMap()
-    return if (filtered.isEmpty()) null else PerModelHourly(filtered)
-}
-
-/**
- * Each daytime hour belongs to [todayDate] — [slicedForToday] never wraps
- * past midnight, so every entry's [HourlyForecast.time] is unambiguously
- * today's calendar day.
- */
-private fun todayWindow(windowHourly: List<HourlyForecast>, todayDate: LocalDate): List<LocalDateTime> =
-    windowHourly.map { LocalDateTime.of(todayDate, it.time) }
-
-/**
- * Tonight wraps from [tonightStart] today to next morning, so a window hour
- * with `time >= tonightStart` is on [todayDate]; anything before it (the
- * tomorrow-morning portion concatenated by [slicedForTonight]) is on the
- * next day.
- */
-private fun tonightWindow(
-    windowHourly: List<HourlyForecast>,
-    todayDate: LocalDate,
-    tonightStart: LocalTime,
-): List<LocalDateTime> = windowHourly.map { entry ->
-    val date = if (!entry.time.isBefore(tonightStart)) todayDate else todayDate.plusDays(1)
-    LocalDateTime.of(date, entry.time)
-}
-
-/**
- * Slices [DailyForecast] to the daytime window (today at [morningStart] through
- * today at [eveningEnd]). The TODAY counterpart of [slicedForTonight]: keeps the
- * rendered insight, clothes evaluation and outfit suggestion focused on the
- * hours the user is awake and out, not on past pre-dawn hours or a late-evening
- * peak the user has already gone to bed for.
- *
- * Behaves like [slicedForTonight]:
- *  - filters today's hourly to entries in `[morningStart, eveningEnd)`,
- *  - recomputes daily-level aggregates ([feelsLikeMinC] etc.) from the slice so
- *    the band sentence and clothes rules talk about the daytime range, not the
- *    raw 24h day-level fields,
- *  - rewrites [DailyForecast.condition] to the wettest in-window hour (preventing
- *    the precip-peak fallback from naming a midday rain on a sunny afternoon),
- *  - falls back to the day-level aggregates with an empty hourly list when the
- *    slice would be empty for an otherwise valid window (sparse fixtures or
- *    legacy day-level-only payloads), so the pipeline always emits something
- *    even without in-window hourly data,
- *  - returns the original [DailyForecast] unchanged on a degenerate
- *    `morningStart >= eveningEnd` window — the tonight pass covers overnight
- *    users via its own wrap, so blanking out the hourly here would just lose
- *    information the tonight slice still needs.
- */
-private fun DailyForecast.slicedForToday(
-    morningStart: LocalTime,
-    eveningEnd: LocalTime,
-): DailyForecast {
-    // Degenerate window (user's day end is at or before its start). Bail out
-    // rather than produce an empty or wrapped slice; the tonight pass covers
-    // overnight users via its own wrap.
-    if (!morningStart.isBefore(eveningEnd)) return this
-    val sliced = hourly.filter { it.time >= morningStart && it.time < eveningEnd }
-    if (sliced.isEmpty()) return copy(hourly = sliced)
-    return copy(
-        hourly = sliced,
-        temperatureMinC = sliced.minOf { it.temperatureC },
-        temperatureMaxC = sliced.maxOf { it.temperatureC },
-        feelsLikeMinC = sliced.minOf { it.feelsLikeC },
-        feelsLikeMaxC = sliced.maxOf { it.feelsLikeC },
-        precipitationProbabilityMaxPct = sliced.maxOf { it.precipitationProbabilityPct },
-        condition = sliced.maxByOrNull { it.precipitationProbabilityPct }
-            ?.condition
-            ?.takeIf { it != WeatherCondition.UNKNOWN }
-            ?: condition,
-    )
-}
-
-/**
- * Slices [DailyForecast] to the overnight tonight window (today at [tonightStart]
- * through tomorrow at [morningEnd]). Used by TONIGHT to keep the rendered insight
- * focused on what the user will walk into between bedtime and the morning.
- *
- * Concatenates today's hourly entries at or after [tonightStart] with tomorrow's
- * hourly entries strictly before [morningEnd]. Tomorrow entries keep their wall
- * time (e.g. 06:00) — [HourlyForecast] doesn't carry a date, but the precip-peak
- * sentence is fine with that since it talks about wall-clock times.
- *
- * Beyond just filtering, this also recomputes the daily-level aggregates
- * ([DailyForecast.feelsLikeMinC] etc.) from the combined hourly so that:
- *
- *  - [RenderInsightSummary]'s band sentence ("Tonight will be cold to mild.") talks
- *    about the actual overnight low — typically the pre-dawn hours from
- *    [tomorrowHourly], which the day-level fields don't capture.
- *  - The clothes rules evaluate against the overnight conditions (the user
- *    pulling a thicker sweater because it'll be 4°C at 05:00, not the day's 18°C
- *    midday high).
- *  - [OutfitSuggestion.fromForecast] picks a top + bottom appropriate for what
- *    the user will leave in tonight and arrive in tomorrow morning.
- *  - The precip-peak fallback (when the hourly peak < 30% and it falls back to
- *    the daily fields) doesn't surface "Rain at 12:00" on a tonight insight
- *    after the morning rain has already passed.
- *
- * If [tonightStart] IS strictly before [morningEnd] (e.g. the user set their
- * tonight time to 03:00, which is before the morning's 07:00) we treat tonight
- * as today-only, no wrap — anything else would either double-count hours or
- * invert the window.
- *
- * Falls back to the day-level aggregates with an empty hourly list when the
- * combined hourly is empty (older cached payloads, sparse fixtures, or a tonight
- * time after the last available hour) so we still emit *something* rather than a
- * forecast with all-zero aggregates.
- */
-private fun DailyForecast.slicedForTonight(
-    tonightStart: LocalTime,
-    morningEnd: LocalTime,
-    tomorrowHourly: List<HourlyForecast>,
-): DailyForecast {
-    val tonightHours = hourly.filter { it.time >= tonightStart }
-    val tomorrowMorning = if (tonightStart.isBefore(morningEnd)) {
-        // Same-day window (no real "evening"); skip the overnight wrap to avoid
-        // double-counting hours with today.
-        emptyList()
-    } else {
-        tomorrowHourly.filter { it.time < morningEnd }
-    }
-    val sliced = tonightHours + tomorrowMorning
-    if (sliced.isEmpty()) return copy(hourly = sliced)
-    return copy(
-        hourly = sliced,
-        temperatureMinC = sliced.minOf { it.temperatureC },
-        temperatureMaxC = sliced.maxOf { it.temperatureC },
-        feelsLikeMinC = sliced.minOf { it.feelsLikeC },
-        feelsLikeMaxC = sliced.maxOf { it.feelsLikeC },
-        precipitationProbabilityMaxPct = sliced.maxOf { it.precipitationProbabilityPct },
-        // The day's overall condition (e.g. RAIN) may have applied to morning rain
-        // that's now over. Use the condition from the wettest hour in the slice as
-        // a better proxy for "what's it doing tonight"; fall back to the day-level
-        // condition only if every overnight hour is UNKNOWN.
-        condition = sliced.maxByOrNull { it.precipitationProbabilityPct }
-            ?.condition
-            ?.takeIf { it != WeatherCondition.UNKNOWN }
-            ?: condition,
-    )
-}
-
-/**
- * Bundles the daily insight with the active alerts that informed it. Alerts are kept
- * separate from [Insight] because they have a different lifecycle: the insight is
- * cached for the day and redelivered on demand, while alerts drive a one-shot
- * high-priority notification at fetch time.
- */
-data class DailyInsightResult(
-    val insight: Insight,
-    val alerts: List<WeatherAlert>,
-)


### PR DESCRIPTION
## Summary

Previously `InsightCache` stored a fully-derived `Insight`, so flipping clothes rules, the default top / bottom, the delta threshold, or the mention mode left the Today screen prose, the Format settings preview, the home-screen widget and the cast / MQTT surfaces showing pre-edit text until the next worker run. The first pass on this branch papered over it with an in-place recompute that had to preserve / re-gate the cached clauses for inputs (alerts, yesterday's hourly, calendar events) that weren't cached at fetch time.

This commit moves the cache boundary instead:

- `InsightCache` now stores the upstream `ForecastSnapshot` — the Open-Meteo `ForecastBundle` plus the minimal `CalendarEvent` timing the renderer actually reads (`start`, `end`, `allDay`, and a `hasLocation` presence flag — no titles or free-form location strings, keeping the on-disk privacy posture at parity with the previous derived-insight cache).
- New `DeriveInsight` use case is the pure-function "snapshot + prefs → insight" path. Every consumer (Today screen, Format settings preview, widget, cast, MQTT) re-derives off the same bytes the worker wrote — no preservation / re-gating logic, no waiting for the next worker run.
- `GenerateDailyInsight` is now a thin wrapper that captures a snapshot via the new `snapshot()` entrypoint and delegates derivation to `DeriveInsight`. The worker writes the snapshot first, derives the insight, then delivers it; same bytes the consumers will read.
- Cache schema bumps to `v7`; `v6` payloads (derived-insight shape) drop on first read, and the next worker run repopulates.

Settings setters no longer poke the cache — the Today screen / Format settings preview update reactively through the preferences flow. `setClothesMentionMode` and `setDeltaThresholdC` are pure DataStore writes again. The rule / default-bottom / default-top setters still nudge the launcher widget (Glance widgets don't observe the prefs flow themselves, so a settings write that changes the icon needs an explicit repaint).

## Privacy

The on-disk cache shape changes (from a derived `Insight` to the upstream `ForecastSnapshot`) but the data classes of fields it persists stay the same:
- Weather data (Open-Meteo bundle: today / yesterday / tomorrow hourly + per-model + alerts) was already on disk.
- Calendar events: only `start` / `end` / `allDay` / a `hasLocation` boolean persist. **Titles and free-form location strings are never written to disk.** On materialisation, titles come back as empty strings and locations as a placeholder presence marker — the renderer's only reads are `overlaps(time)` and `!location.isNullOrBlank()`, so prose is unaffected. This matches what the previous derived-insight cache stored about events (a garment name in a tie-in clause, never the event title).

`PRIVACY.md` picks up a section update + 2026-05-23 changelog entry noting the cache shape change.

## Test plan

- [x] `:core:domain:test` + `:core:data:test` pass — the `GenerateDailyInsight` behaviour is preserved (it now delegates to `DeriveInsight`, same end-to-end output) and existing domain tests catch any regression.
- [x] `:app:testDebugUnitTest` passes, including a rewritten `InsightCacheTest` covering: snapshot round-trip across all bundle fields (alerts, perModelHourly, confidence, tomorrow, forecastZone), events round-trip preserving only timing + location-presence (titles dropped, locations replaced with a placeholder), `deliveredForToday` derivation matching day + period (and ignoring NEXT_PERIOD), the new `deriveFlow` re-deriving against new prefs without a cache rewrite, and v6 payloads dropping cleanly on first read.
- [x] `:app:assembleDebug` passes.
- [ ] Manual: open Format settings, flip "Mention clothes" to Never → preview prose drops the clothes sentence in the same frame.
- [ ] Manual: open Format settings, pick a stricter "Significant change" threshold → preview drops the "X° warmer/cooler" sentence.
- [ ] Manual: edit a clothes rule's threshold to flip what's triggered → preview's clothes items, Today screen bullets, and home-screen widget icon all update without waiting for the next worker run.