### PR TITLE
Show yesterday's stored weather in bug reports

### DIFF
--- a/app/src/main/kotlin/app/clothescast/diag/BugReport.kt
+++ b/app/src/main/kotlin/app/clothescast/diag/BugReport.kt
@@ -20,6 +20,7 @@ import app.clothescast.BuildConfig
 import app.clothescast.ClothesCastApplication
 import app.clothescast.core.domain.model.ClothesFormat
 import app.clothescast.core.domain.model.ClothesRule
+import app.clothescast.core.domain.model.ForecastSnapshot
 import app.clothescast.core.domain.model.RainAccessory
 import app.clothescast.core.domain.model.Insight
 import app.clothescast.core.domain.model.RangeFormat
@@ -122,8 +123,8 @@ object BugReport {
             val rangeFormat = prefs?.rangeFormat ?: RangeFormat.DEGREES
             val clothesFormat = prefs?.clothesFormat ?: ClothesFormat.ITEMS
             val rainAccessory = prefs?.rainAccessory ?: RainAccessory.NONE
-            appendInsight("This period", thisPeriod, context, region, tempUnit, rangeFormat, clothesFormat, rainAccessory)
-            appendInsight("Next period", nextPeriod, context, region, tempUnit, rangeFormat, clothesFormat, rainAccessory)
+            appendInsight("This period", thisPeriod, thisSnapshot, prefs, context, region, tempUnit, rangeFormat, clothesFormat, rainAccessory)
+            appendInsight("Next period", nextPeriod, nextSnapshot, prefs, context, region, tempUnit, rangeFormat, clothesFormat, rainAccessory)
             if (!crash.isNullOrBlank()) {
                 appendLine("--- Last crash (from previous run) ---")
                 appendLine(crash.trim())
@@ -242,6 +243,8 @@ object BugReport {
     private fun StringBuilder.appendInsight(
         label: String,
         insight: Insight?,
+        snapshot: ForecastSnapshot?,
+        prefs: UserPreferences?,
         context: Context,
         region: Region,
         temperatureUnit: TemperatureUnit,
@@ -281,7 +284,52 @@ object BugReport {
                     insight.hourly.maxOf { it.feelsLikeC },
                 ))
         }
+        snapshot?.let { appendSnapshotDebug(it, prefs) }
         appendLine()
+    }
+
+    private fun StringBuilder.appendSnapshotDebug(
+        snapshot: ForecastSnapshot,
+        prefs: UserPreferences?,
+    ) {
+        snapshot.location?.let { loc ->
+            val name = loc.displayName ?: "(unnamed)"
+            appendLine("  Snapshot location: %.4f, %.4f — %s".format(
+                Locale.US, loc.latitude, loc.longitude, name,
+            ))
+        }
+        val yesterday = snapshot.bundle.yesterday
+        appendLine("  Yesterday (${yesterday.date}) feels-like min/max: " +
+            "%.1f / %.1f °C (24h aggregate)".format(
+                Locale.US, yesterday.feelsLikeMinC, yesterday.feelsLikeMaxC,
+            ))
+        if (yesterday.hourly.isEmpty()) {
+            appendLine("  Yesterday hourly: 0 entries")
+        } else {
+            appendLine("  Yesterday hourly: ${yesterday.hourly.size} entries, " +
+                "${yesterday.hourly.first().time}..${yesterday.hourly.last().time}, " +
+                "feels-like min/max %.1f / %.1f °C".format(
+                    Locale.US,
+                    yesterday.hourly.minOf { it.feelsLikeC },
+                    yesterday.hourly.maxOf { it.feelsLikeC },
+                ))
+            val morningStart = prefs?.schedule?.time
+            val eveningEnd = prefs?.tonightSchedule?.time
+            if (morningStart != null && eveningEnd != null && morningStart.isBefore(eveningEnd)) {
+                val slice = yesterday.hourly.filter { it.time >= morningStart && it.time < eveningEnd }
+                if (slice.isEmpty()) {
+                    appendLine("    daytime [$morningStart..$eveningEnd) slice: 0 entries " +
+                        "(delta falls back to 24h aggregate)")
+                } else {
+                    appendLine("    daytime [$morningStart..$eveningEnd) slice: ${slice.size} entries, " +
+                        "feels-like min/max %.1f / %.1f °C".format(
+                            Locale.US,
+                            slice.minOf { it.feelsLikeC },
+                            slice.maxOf { it.feelsLikeC },
+                        ))
+                }
+            }
+        }
     }
 
     private suspend fun captureAndPersistScreenshot(activity: Activity): Uri? {


### PR DESCRIPTION
## Summary

Triaging a temp-delta-clause report ("today is reported X° warmer/cooler than I remember") right now hits a wall — the bug-report dump prints today's hourly slice but never yesterday's stored values. There's no way to tell whether the upstream API gave us garbage for yesterday or `DeriveInsight`'s slicing fallback is mangling it on the way through.

This adds two diagnostic blocks per cached period:
- Snapshot's stored location (lat/lon + display name **at fetch time**, which can differ from the user's current location pref if they moved between fetches)
- Yesterday's stored daily aggregates, hourly count + time range, and the daytime slice `RenderInsightSummary.deltaClause` actually compares against (so we can see if the slice is empty and the 24h-vs-24h fallback kicked in)

Motivating report on this branch: a "5° warmer than yesterday" insight delivered in Liverpool where the user observed yesterday's actual high at ~29 °C. The current dump shows today's slice (12.0 / 22.6 °C) but the inferred yesterday value (~17.6 °C) was invisible — we couldn't tell if Open-Meteo's `past_days=1` data was off or the slicing was. Next bug report off this build will tell us at a glance.

## Privacy

No new data crosses the device boundary. Bug reports already require an explicit share intent. The snapshot location is the same lat/lon Open-Meteo was queried with, which the user's location pref already exposes one line up; only divergence (snapshot newer than pref or user moved between fetch and report) is new info, and it's still the same user's own coordinates.

## Test plan
- [x] `:app:compileDebugKotlin` passes locally
- [ ] CI green
- [ ] Fire a bug report on a debug build and verify the new `Yesterday (...)` and `Snapshot location:` lines appear under both "This period" and "Next period", and that the daytime-slice line shows non-empty slice content matching the today-side numbers

https://claude.ai/code/session_01B62ma26Vv4t2Xm8PfvTJzb

---
_Generated by [Claude Code](https://claude.ai/code/session_01B62ma26Vv4t2Xm8PfvTJzb)_