### PR TITLE
Emit snapshot debug even when insight is missing

### DIFF
--- a/app/src/main/kotlin/app/clothescast/diag/BugReport.kt
+++ b/app/src/main/kotlin/app/clothescast/diag/BugReport.kt
@@ -255,34 +255,33 @@ object BugReport {
         appendLine("$label:")
         if (insight == null) {
             appendLine("  (no cached insight)")
-            appendLine()
-            return
-        }
-        val prose = runCatching {
-            InsightFormatter.forRegion(context, region, temperatureUnit, rangeFormat, clothesFormat, rainAccessory)
-                .format(insight.summary)
-        }
-            .getOrElse { "(prose render failed: ${it.javaClass.simpleName})" }
-        appendLine("  Prose: $prose")
-        appendLine("  Generated: ${insight.generatedAt} (${humanAge(insight.generatedAt)})")
-        appendLine("  For date: ${insight.forDate}")
-        insight.confidence?.let {
-            appendLine("  Confidence: ${it.level} (tempSpread=${it.tempSpreadC}°C, " +
-                "precipSpread=${it.precipSpreadPp}pp, ${it.modelsConsulted.size} models)")
-        }
-        insight.outfit?.let { appendLine("  Outfit: ${it.top} + ${it.bottom}") }
-        insight.nextOutfit?.let { appendLine("  Next outfit: ${it.top} + ${it.bottom}") }
-        appendLine("  Has events: ${insight.hasEvents}")
-        if (insight.recommendedItems.isNotEmpty()) {
-            appendLine("  Recommended items: ${insight.recommendedItems.joinToString(", ")}")
-        }
-        if (insight.hourly.isNotEmpty()) {
-            appendLine("  Hourly (${insight.hourly.size} entries) feels-like min/max: " +
-                "%.1f / %.1f °C".format(
-                    Locale.US,
-                    insight.hourly.minOf { it.feelsLikeC },
-                    insight.hourly.maxOf { it.feelsLikeC },
-                ))
+        } else {
+            val prose = runCatching {
+                InsightFormatter.forRegion(context, region, temperatureUnit, rangeFormat, clothesFormat, rainAccessory)
+                    .format(insight.summary)
+            }
+                .getOrElse { "(prose render failed: ${it.javaClass.simpleName})" }
+            appendLine("  Prose: $prose")
+            appendLine("  Generated: ${insight.generatedAt} (${humanAge(insight.generatedAt)})")
+            appendLine("  For date: ${insight.forDate}")
+            insight.confidence?.let {
+                appendLine("  Confidence: ${it.level} (tempSpread=${it.tempSpreadC}°C, " +
+                    "precipSpread=${it.precipSpreadPp}pp, ${it.modelsConsulted.size} models)")
+            }
+            insight.outfit?.let { appendLine("  Outfit: ${it.top} + ${it.bottom}") }
+            insight.nextOutfit?.let { appendLine("  Next outfit: ${it.top} + ${it.bottom}") }
+            appendLine("  Has events: ${insight.hasEvents}")
+            if (insight.recommendedItems.isNotEmpty()) {
+                appendLine("  Recommended items: ${insight.recommendedItems.joinToString(", ")}")
+            }
+            if (insight.hourly.isNotEmpty()) {
+                appendLine("  Hourly (${insight.hourly.size} entries) feels-like min/max: " +
+                    "%.1f / %.1f °C".format(
+                        Locale.US,
+                        insight.hourly.minOf { it.feelsLikeC },
+                        insight.hourly.maxOf { it.feelsLikeC },
+                    ))
+            }
         }
         snapshot?.let { appendSnapshotDebug(it, prefs) }
         appendLine()


### PR DESCRIPTION
## Summary

Follow-up to #641. The snapshot diagnostics (`Snapshot location:` + `Yesterday(…)` blocks) were emitted after the `if (insight == null) return` early return in `appendInsight`, so they never appeared in exactly the failure cases where raw cached weather data is most useful — when derivation throws, when preferences can't be loaded, or when the snapshot is present but `DeriveInsight` produces no insight.

Restructure so the insight-prose / outfit / hourly block is wrapped in an `else` branch and the snapshot dump always runs when a snapshot exists. Snapshot reads directly off `InsightCache.thisPeriod` / `nextPeriod` flows, independent of prefs / derivation success, so it's well-defined to print on its own.

## Test plan
- [x] `:app:compileDebugKotlin` passes locally
- [ ] CI green
- [ ] Force a derive failure (e.g. clear prefs while a snapshot is cached) and verify the bug report still emits the `Yesterday (…)` block under "(no cached insight)"

https://claude.ai/code/session_01B62ma26Vv4t2Xm8PfvTJzb

---
_Generated by [Claude Code](https://claude.ai/code/session_01B62ma26Vv4t2Xm8PfvTJzb)_