### PR TITLE
Stop truncating shared bug reports and trim noisy logs

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -111,20 +111,6 @@
             </intent-filter>
         </receiver>
 
-        <!-- Bug-report screenshot sharing. The PNG is written to cacheDir/bug-reports/
-             and exposed read-only to the app the user picks in the share sheet.
-             Authority follows the ${applicationId}.fileprovider convention so the
-             debug build's `.debug` suffix doesn't collide with the release build. -->
-        <provider
-            android:name="androidx.core.content.FileProvider"
-            android:authorities="${applicationId}.fileprovider"
-            android:exported="false"
-            android:grantUriPermissions="true">
-            <meta-data
-                android:name="android.support.FILE_PROVIDER_PATHS"
-                android:resource="@xml/file_paths" />
-        </provider>
-
         <!-- Opt out of Firebase Analytics advertising-ID (GAID) collection.
              The app's privacy policy explicitly states no advertising identifiers
              are collected; this flag enforces that at the SDK level on all API

--- a/app/src/main/kotlin/app/clothescast/calendar/CalendarContractEventReader.kt
+++ b/app/src/main/kotlin/app/clothescast/calendar/CalendarContractEventReader.kt
@@ -33,6 +33,9 @@ import java.time.ZoneOffset
  */
 class CalendarContractEventReader(private val context: Context) : CalendarEventReader {
 
+    @Volatile
+    private var eventTypeProjectionRejected: Boolean = false
+
     override suspend fun eventsForDay(date: LocalDate, zoneId: ZoneId): List<CalendarEvent> {
         if (!CalendarPermission.isGranted(context)) {
             DiagLog.i(TAG, "READ_CALENDAR not granted; skipping calendar read.")
@@ -150,11 +153,21 @@ class CalendarContractEventReader(private val context: Context) : CalendarEventR
 
         val rows = mutableListOf<Row>()
         val calendarIds = mutableSetOf<Long>()
-        val rawCursor = try {
-            context.contentResolver.query(uri, withEventType, selection, null, sortOrder)
-        } catch (e: IllegalArgumentException) {
-            DiagLog.i(TAG, "Provider rejected `eventType` column; retrying without it.", e)
+        // Once a provider has rejected `eventType` we know the rest of this
+        // process's queries will too — skip the speculative first attempt
+        // (and the stack-trace log it produces) thereafter.
+        val rawCursor = if (eventTypeProjectionRejected) {
             context.contentResolver.query(uri, baseProjection, selection, null, sortOrder)
+        } else {
+            try {
+                context.contentResolver.query(uri, withEventType, selection, null, sortOrder)
+            } catch (e: IllegalArgumentException) {
+                if (!eventTypeProjectionRejected) {
+                    eventTypeProjectionRejected = true
+                    DiagLog.i(TAG, "Provider rejected `eventType` column; future queries will skip it.", e)
+                }
+                context.contentResolver.query(uri, baseProjection, selection, null, sortOrder)
+            }
         }
         rawCursor?.use { cursor ->
             val titleIdx = cursor.getColumnIndex(CalendarContract.Instances.TITLE)
@@ -208,7 +221,14 @@ class CalendarContractEventReader(private val context: Context) : CalendarEventR
 
         val ownerByCalendarId = ownerAccountsFor(calendarIds)
 
-        return rows.mapNotNull { row ->
+        // Tally classifications across the query so we can log one summary line
+        // instead of one per row — a year-long upcomingCelebrations() over a
+        // dense Google account otherwise floods the 300-line diag buffer with
+        // dozens of repeated "Classified calendarId=X as Y" lines that all carry
+        // the same per-calendar verdict. Title and owner stay out of the log
+        // (both are PII); the summary names only the kind+reason counts.
+        val classificationTally = mutableMapOf<Pair<EventKind, String>, Int>()
+        val events = rows.mapNotNull { row ->
             val owner = ownerByCalendarId[row.calendarId]
             val result = CalendarEventClassifier.classify(row.title, owner, row.eventType)
             // FREE rows are typically calendar holds the user doesn't want surfaced
@@ -218,13 +238,8 @@ class CalendarContractEventReader(private val context: Context) : CalendarEventR
             if (result.kind == EventKind.NORMAL && row.availability == CalendarContract.Instances.AVAILABILITY_FREE) {
                 return@mapNotNull null
             }
-            // Log the deduction path (kind + reason) without the title or owner —
-            // both are PII. calendarId is a row-local integer, safe.
-            DiagLog.i(
-                TAG,
-                "Classified calendarId=${row.calendarId} as ${result.kind} via ${result.reason}" +
-                    (row.eventType?.let { " (eventType=$it)" } ?: " (eventType column unavailable)"),
-            )
+            val key = result.kind to result.reason.toString()
+            classificationTally[key] = (classificationTally[key] ?: 0) + 1
             DatedEvent(
                 date = row.date,
                 event = CalendarEvent(
@@ -238,6 +253,14 @@ class CalendarContractEventReader(private val context: Context) : CalendarEventR
                 ),
             )
         }
+
+        if (events.isNotEmpty()) {
+            val summary = classificationTally.entries
+                .sortedByDescending { it.value }
+                .joinToString(", ") { (key, count) -> "$count ${key.first} via ${key.second}" }
+            DiagLog.i(TAG, "Classified ${events.size} events: $summary")
+        }
+        return events
     }
 
     /**

--- a/app/src/main/kotlin/app/clothescast/diag/BugReport.kt
+++ b/app/src/main/kotlin/app/clothescast/diag/BugReport.kt
@@ -6,16 +6,7 @@ import android.content.ClipboardManager
 import android.content.Context
 import android.content.ContextWrapper
 import android.content.Intent
-import android.graphics.Bitmap
-import android.graphics.Rect
-import android.net.Uri
 import android.os.Build
-import android.os.Handler
-import android.os.Looper
-import android.view.PixelCopy
-import android.view.View
-import android.view.Window
-import androidx.core.content.FileProvider
 import app.clothescast.BuildConfig
 import app.clothescast.ClothesCastApplication
 import app.clothescast.core.domain.model.ClothesFormat
@@ -31,9 +22,6 @@ import app.clothescast.core.domain.model.symbol
 import app.clothescast.data.SettingsRepository
 import app.clothescast.insight.InsightFormatter
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.suspendCancellableCoroutine
-import java.io.File
-import java.io.FileOutputStream
 import java.text.SimpleDateFormat
 import java.time.Duration
 import java.time.Instant
@@ -41,7 +29,6 @@ import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.util.Date
 import java.util.Locale
-import kotlin.coroutines.resume
 
 /**
  * Builds a "paste-into-Claude" bug-report payload (version, device, settings,
@@ -51,21 +38,23 @@ import kotlin.coroutines.resume
  * clipboard as a paste fallback.
  */
 object BugReport {
-    private const val FILE_PROVIDER_AUTHORITY_SUFFIX = ".fileprovider"
     private val STATUS_TIMESTAMP_FORMAT: DateTimeFormatter =
         DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss zzz")
 
     /**
-     * Captures the screen, builds the text payload, copies the text to the
-     * clipboard, and fires the share-sheet chooser. When [includeScreenshot] is
-     * false (or the capture fails), shares text only.
+     * Builds the text payload, copies it to the clipboard, and fires the
+     * share-sheet chooser as a pure-text intent. No screenshot is attached:
+     * an image-typed intent makes the chooser surface image-share targets that
+     * treat `EXTRA_TEXT` as a *caption* with a hard character cap, which
+     * silently truncated long bug reports mid-line. The text payload already
+     * carries everything the recipient needs (settings, cached insights,
+     * recent log).
      */
-    suspend fun share(activity: Activity, includeScreenshot: Boolean) {
+    suspend fun share(activity: Activity) {
         val app = activity.application as ClothesCastApplication
         val text = buildPayload(activity, app)
-        val screenshotUri: Uri? = if (includeScreenshot) captureAndPersistScreenshot(activity) else null
         copyToClipboard(activity, text)
-        startShare(activity, text, screenshotUri)
+        startShare(activity, text)
     }
 
     private suspend fun buildPayload(context: Context, app: ClothesCastApplication): String {
@@ -331,78 +320,13 @@ object BugReport {
         }
     }
 
-    private suspend fun captureAndPersistScreenshot(activity: Activity): Uri? {
-        val bitmap = runCatching { captureWindow(activity) }.getOrNull() ?: return null
-        return runCatching {
-            val dir = File(activity.cacheDir, "bug-reports").apply { mkdirs() }
-            // Wipe older screenshots — keep only the freshest one to avoid cache bloat.
-            dir.listFiles()?.forEach { it.delete() }
-            val file = File(dir, "screenshot-${System.currentTimeMillis()}.png")
-            FileOutputStream(file).use { out ->
-                bitmap.compress(Bitmap.CompressFormat.PNG, 100, out)
-            }
-            FileProvider.getUriForFile(
-                activity,
-                activity.packageName + FILE_PROVIDER_AUTHORITY_SUFFIX,
-                file,
-            )
-        }.getOrNull()
-    }
-
-    private suspend fun captureWindow(activity: Activity): Bitmap? {
-        val window = activity.window ?: return null
-        val view: View = window.decorView
-        if (view.width <= 0 || view.height <= 0) return null
-        val bitmap = Bitmap.createBitmap(view.width, view.height, Bitmap.Config.ARGB_8888)
-        return suspendCancellableCoroutine { cont ->
-            val location = IntArray(2)
-            view.getLocationInWindow(location)
-            val rect = Rect(
-                location[0],
-                location[1],
-                location[0] + view.width,
-                location[1] + view.height,
-            )
-            try {
-                requestPixelCopy(window, rect, bitmap) { ok ->
-                    cont.resume(if (ok) bitmap else null)
-                }
-            } catch (t: Throwable) {
-                DiagLog.w("BugReport", "PixelCopy.request threw", t)
-                cont.resume(null)
-            }
-        }
-    }
-
-    private fun requestPixelCopy(
-        window: Window,
-        rect: Rect,
-        bitmap: Bitmap,
-        onResult: (Boolean) -> Unit,
-    ) {
-        val handler = Handler(Looper.getMainLooper())
-        PixelCopy.request(window, rect, bitmap, { result ->
-            onResult(result == PixelCopy.SUCCESS)
-        }, handler)
-    }
-
-    private fun startShare(activity: Activity, text: String, screenshotUri: Uri?) {
+    private fun startShare(activity: Activity, text: String) {
         val send = Intent(Intent.ACTION_SEND).apply {
+            type = "text/plain"
             putExtra(Intent.EXTRA_SUBJECT, "ClothesCast bug report — ${BuildConfig.VERSION_NAME}")
             putExtra(Intent.EXTRA_TEXT, text)
-            if (screenshotUri != null) {
-                type = "image/png"
-                putExtra(Intent.EXTRA_STREAM, screenshotUri)
-                clipData = ClipData.newRawUri("ClothesCast screenshot", screenshotUri)
-                addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-            } else {
-                type = "text/plain"
-            }
         }
         val chooser = Intent.createChooser(send, "Share bug report")
-        if (screenshotUri != null) {
-            chooser.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-        }
         runCatching { activity.startActivity(chooser) }
             .onFailure { DiagLog.w("BugReport", "share intent failed", it) }
     }

--- a/app/src/main/kotlin/app/clothescast/mqtt/MqttPublisher.kt
+++ b/app/src/main/kotlin/app/clothescast/mqtt/MqttPublisher.kt
@@ -267,11 +267,19 @@ class MqttPublisher(
                 )
             }
         } else {
+            // The per-topic failures already logged their cause; here we only
+            // need to note that the /now mirror is being held back so a reader
+            // can correlate "no /now update" with "primary publishes failed."
+            val failed = listOfNotNull(
+                if (proseOutcome !is MqttPublishOutcome.Success) "prose" else null,
+                if (imageOutcome != null && imageOutcome !is MqttPublishOutcome.Success) "image" else null,
+                if (audioOutcome != null && audioOutcome !is MqttPublishOutcome.Success) "audio" else null,
+                if (videoOutcome != null && videoOutcome !is MqttPublishOutcome.Success) "video" else null,
+            ).joinToString("/")
             DiagLog.i(
                 TAG,
                 "Skipping /now mirror for ${period.name.lowercase()} bundle " +
-                    "(prose=$proseOutcome, image=$imageOutcome, audio=$audioOutcome); " +
-                    "previous retained /now bundle stays intact.",
+                    "($failed failed); previous retained /now bundle stays intact.",
             )
         }
         proseOutcome
@@ -400,8 +408,14 @@ class MqttPublisher(
             // shadowed by a misleading "MQTT publish failed" line.
             throw ce
         } catch (t: Throwable) {
+            // Carry the throwable's class+message text on the Failure outcome
+            // (it's surfaced on the Settings status row and in the bug report)
+            // but don't attach `t` to the log line: the HiveMQ/Netty trace it
+            // produces is ~4 lines per topic per attempt — 32 lines for one
+            // unreachable-broker bundle — and the message string already names
+            // the cause (`AnnotatedNoRouteToHostException: No route to host`).
             val msg = "${t.javaClass.simpleName}: ${t.message ?: "unknown error"}".take(250)
-            DiagLog.w(TAG, "MQTT publish failed to ${prepared.scheme}://${prepared.host}:${prepared.port}/$topic", t)
+            DiagLog.w(TAG, "MQTT publish failed to ${prepared.scheme}://${prepared.host}:${prepared.port}/$topic ($msg)")
             result = MqttPublishOutcome.Failure(msg)
         }
         result

--- a/app/src/main/kotlin/app/clothescast/ui/settings/AboutSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/AboutSettings.kt
@@ -76,11 +76,7 @@ private fun AboutCard() {
 
     val launchBugReport: () -> Unit = launchBugReport@{
         val act = activity ?: return@launchBugReport
-        coroutineScope.launch {
-            // No screenshot from About — the About page itself isn't useful
-            // to capture; Today's overflow menu owns the screenshot path.
-            BugReport.share(act, includeScreenshot = false)
-        }
+        coroutineScope.launch { BugReport.share(act) }
     }
 
     SectionCard(title = stringResource(R.string.settings_about_title)) {

--- a/app/src/main/kotlin/app/clothescast/ui/today/LastCrashBanner.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/LastCrashBanner.kt
@@ -77,10 +77,7 @@ internal fun LastCrashBanner(modifier: Modifier = Modifier) {
     val shareCrashReport: () -> Unit = shareCrashReport@{
         val act = activity ?: return@shareCrashReport
         coroutineScope.launch {
-            // includeScreenshot=false: the visible screen is *now*, but the
-            // crash is from a previous run, so a current screenshot would be
-            // misleading.
-            BugReport.share(act, includeScreenshot = false)
+            BugReport.share(act)
             DiagLog.acknowledgePersistedCrash()
             hasCrash = false
         }

--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
@@ -165,7 +165,7 @@ fun TodayScreen(
 
     val launchBugReport: () -> Unit = launchBugReport@{
         val act = activity ?: return@launchBugReport
-        coroutineScope.launch { BugReport.share(act, includeScreenshot = true) }
+        coroutineScope.launch { BugReport.share(act) }
     }
 
     // Hoisted out of TodayContent so the TopAppBar title can swap with the

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<paths>
-    <!-- Bug-report screenshots are written to cacheDir/bug-reports/ and shared via
-         FileProvider. Scoped to that subdir so we don't expose the rest of the cache. -->
-    <cache-path
-        name="bug_reports"
-        path="bug-reports/" />
-</paths>


### PR DESCRIPTION
## Summary

Bug reports shared from the Today screen were silently truncating mid-line (the user saw the body cut off partway through `com.hivemq.clie`). Two compounding causes:

1. **The screenshot attachment flipped the share intent's MIME from `text/plain` to `image/png`.** That changed the chooser's target list to image-share apps, many of which treat `EXTRA_TEXT` as a caption with a hard character cap. Drop the screenshot entirely — the text payload already carries every field we've used for debugging (settings, cached insights, log, last crash). Also removes the now-unused `FileProvider` declaration and `file_paths.xml`.
2. **The 300-line log buffer was dominated by two callers.** `CalendarReader` was logging one "Classified" line per event row (80+ per `upcomingCelebrations()` query) and dumping a 4-line stack trace on every query because this provider rejects the `eventType` column. `MqttPublisher` was dumping a 3-line HiveMQ/Netty stack trace per topic per attempt — ~24 lines per unreachable-broker bundle, all with the same root cause already in the `Failure` message.

   - `CalendarReader`: collapse "Classified..." to one summary per query; remember the `eventType` rejection per-process and skip the speculative attempt thereafter.
   - `MqttPublisher`: drop the throwable from the per-topic failure log line (message text is preserved on the `Failure` outcome and the Settings status row); trim the verbose "Skipping /now mirror" line.

No privacy boundary change — title/owner stay out of the calendar log; MQTT failure messages already crossed the share boundary.

## Test plan

- [x] `:core:domain:test :core:data:test :app:testDebugUnitTest` pass locally
- [x] `CalendarContractEventReaderTest` (incl. "provider rejecting eventType column retries with stable projection") still green
- [x] `MqttPublisherTest` still green
- [ ] Verify on device: share a bug report from the Today screen, confirm the share sheet shows text targets only and the receiving app gets the full body
- [ ] After a calendar read with the rejecting provider, confirm only the first "Provider rejected" log line appears


---
_Generated by [Claude Code](https://claude.ai/code/session_01EYbsZSJh73nPjDV2RSfKas)_