### PR TITLE
Log delta-clause inputs from the worker on every delivery

### DIFF
--- a/app/src/main/kotlin/app/clothescast/data/InsightCache.kt
+++ b/app/src/main/kotlin/app/clothescast/data/InsightCache.kt
@@ -146,10 +146,17 @@ class InsightCache(
         period: ForecastPeriod,
         prefs: UserPreferences,
         now: Instant? = null,
+        // Forwarded to [DeriveInsight] so cache-hit deliveries (debug-tap
+        // redelivery later in the day, alarm re-fires) emit the same
+        // `delta:` diagnostic line a fresh fetch would. The 300-line
+        // DiagLog ring buffer can evict the morning's original entry by
+        // the time a same-day redelivery happens, so logging it again on
+        // each delivery is the only way to keep the trail.
+        diagLog: (String) -> Unit = {},
     ): DailyInsightResult? {
         val snapshot = thisPeriod.first() ?: return null
         if (snapshot.bundle.today.date != today || snapshot.period != period) return null
-        return deriveInsight(snapshot, prefs, now ?: snapshot.generatedAt)
+        return deriveInsight(snapshot, prefs, now ?: snapshot.generatedAt, diagLog = diagLog)
     }
 
     suspend fun clear() {

--- a/app/src/main/kotlin/app/clothescast/diag/BugReport.kt
+++ b/app/src/main/kotlin/app/clothescast/diag/BugReport.kt
@@ -255,34 +255,33 @@ object BugReport {
         appendLine("$label:")
         if (insight == null) {
             appendLine("  (no cached insight)")
-            appendLine()
-            return
-        }
-        val prose = runCatching {
-            InsightFormatter.forRegion(context, region, temperatureUnit, rangeFormat, clothesFormat, rainAccessory)
-                .format(insight.summary)
-        }
-            .getOrElse { "(prose render failed: ${it.javaClass.simpleName})" }
-        appendLine("  Prose: $prose")
-        appendLine("  Generated: ${insight.generatedAt} (${humanAge(insight.generatedAt)})")
-        appendLine("  For date: ${insight.forDate}")
-        insight.confidence?.let {
-            appendLine("  Confidence: ${it.level} (tempSpread=${it.tempSpreadC}°C, " +
-                "precipSpread=${it.precipSpreadPp}pp, ${it.modelsConsulted.size} models)")
-        }
-        insight.outfit?.let { appendLine("  Outfit: ${it.top} + ${it.bottom}") }
-        insight.nextOutfit?.let { appendLine("  Next outfit: ${it.top} + ${it.bottom}") }
-        appendLine("  Has events: ${insight.hasEvents}")
-        if (insight.recommendedItems.isNotEmpty()) {
-            appendLine("  Recommended items: ${insight.recommendedItems.joinToString(", ")}")
-        }
-        if (insight.hourly.isNotEmpty()) {
-            appendLine("  Hourly (${insight.hourly.size} entries) feels-like min/max: " +
-                "%.1f / %.1f °C".format(
-                    Locale.US,
-                    insight.hourly.minOf { it.feelsLikeC },
-                    insight.hourly.maxOf { it.feelsLikeC },
-                ))
+        } else {
+            val prose = runCatching {
+                InsightFormatter.forRegion(context, region, temperatureUnit, rangeFormat, clothesFormat, rainAccessory)
+                    .format(insight.summary)
+            }
+                .getOrElse { "(prose render failed: ${it.javaClass.simpleName})" }
+            appendLine("  Prose: $prose")
+            appendLine("  Generated: ${insight.generatedAt} (${humanAge(insight.generatedAt)})")
+            appendLine("  For date: ${insight.forDate}")
+            insight.confidence?.let {
+                appendLine("  Confidence: ${it.level} (tempSpread=${it.tempSpreadC}°C, " +
+                    "precipSpread=${it.precipSpreadPp}pp, ${it.modelsConsulted.size} models)")
+            }
+            insight.outfit?.let { appendLine("  Outfit: ${it.top} + ${it.bottom}") }
+            insight.nextOutfit?.let { appendLine("  Next outfit: ${it.top} + ${it.bottom}") }
+            appendLine("  Has events: ${insight.hasEvents}")
+            if (insight.recommendedItems.isNotEmpty()) {
+                appendLine("  Recommended items: ${insight.recommendedItems.joinToString(", ")}")
+            }
+            if (insight.hourly.isNotEmpty()) {
+                appendLine("  Hourly (${insight.hourly.size} entries) feels-like min/max: " +
+                    "%.1f / %.1f °C".format(
+                        Locale.US,
+                        insight.hourly.minOf { it.feelsLikeC },
+                        insight.hourly.maxOf { it.feelsLikeC },
+                    ))
+            }
         }
         snapshot?.let { appendSnapshotDebug(it, prefs) }
         appendLine()

--- a/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
@@ -249,7 +249,9 @@ class FetchAndNotifyWorker(
             DiagLog.i(TAG, "Force refresh requested; bypassing today's cache.")
             null
         } else {
-            runCatching { app.insightCache.deliveredForToday(today, period, prefs) }.getOrNull()
+            runCatching {
+                app.insightCache.deliveredForToday(today, period, prefs, diagLog = { DiagLog.i(TAG, it) })
+            }.getOrNull()
         }
         if (cached != null) {
             val cachedInsight = cached.insight

--- a/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
@@ -301,7 +301,7 @@ class FetchAndNotifyWorker(
             // off the same upstream data for free; the derive call here is the
             // one we deliver on this run.
             val snapshot = app.generateDailyInsight.snapshot(location, prefs, period)
-            val result = app.deriveInsight(snapshot, prefs)
+            val result = app.deriveInsight(snapshot, prefs, diagLog = { DiagLog.i(TAG, it) })
             // Severe alerts are out-of-band: post them as separate high-priority
             // notifications on every fresh fetch, regardless of whether the daily
             // summary itself is blank or suppressed.

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/DeriveInsight.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/DeriveInsight.kt
@@ -56,6 +56,11 @@ class DeriveInsight(
         snapshot: ForecastSnapshot,
         prefs: UserPreferences,
         now: Instant = snapshot.generatedAt,
+        // Diagnostic hook forwarded to [RenderInsightSummary] for the
+        // delta-clause one-liner. Only the worker delivery path passes a
+        // DiagLog adapter; cache re-derives (Today screen, widget, format
+        // preview) leave it null so prefs-flip log churn stays nil.
+        diagLog: (String) -> Unit = {},
     ): DailyInsightResult {
         val bundle = snapshot.bundle
         val activeAlerts = bundle.alerts.filter { it.expires.isAfter(now) }
@@ -104,6 +109,7 @@ class DeriveInsight(
             clothesMentionMode = prefs.clothesMentionMode,
             yesterdayTriggeredItems = periodView.yesterdayTriggeredItems,
             todayRuleItems = Garment.layerReduce(periodView.triggeredOutfit.rules).map { it.item },
+            diagLog = diagLog,
         )
 
         val insight = Insight(

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/RenderInsightSummary.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/RenderInsightSummary.kt
@@ -109,13 +109,21 @@ class RenderInsightSummary {
         // emit "Bring a t-shirt." purely because TriggeredOutfit has
         // baseline items.
         todayRuleItems: List<String> = todayItems,
+        // Diagnostic hook called once per render with a one-line summary
+        // of the delta clause decision (today / yesterday inputs, picked
+        // side, outcome). Pure-Kotlin module → no DiagLog dependency;
+        // :app's worker wiring passes a DiagLog adapter so a single
+        // bug-report-less log line is enough to diagnose a "5° warmer
+        // than yesterday" surprise, while tests / previews / cache
+        // re-derives keep the no-op default and pay nothing.
+        diagLog: (String) -> Unit = {},
     ): InsightSummary {
         val peak = peakPrecip(today, perModelHourly)
         return InsightSummary(
             period = period,
             alert = alertClause(alerts),
             band = bandClause(today),
-            delta = if (period == ForecastPeriod.TODAY) deltaClause(todayForDelta, yesterday, deltaThresholdC) else null,
+            delta = if (period == ForecastPeriod.TODAY) deltaClause(todayForDelta, yesterday, deltaThresholdC, diagLog) else null,
             clothes = clothesClause(todayItems, period, clothesMentionMode, yesterdayTriggeredItems),
             precip = peak?.let { PrecipClause(it.condition, it.time, it.likelihood) },
             // Calendar tie-in only fires on TONIGHT — pairing the precip peak
@@ -150,17 +158,38 @@ class RenderInsightSummary {
         feelsLikeMaxC = today.feelsLikeMaxC,
     )
 
-    private fun deltaClause(today: DailyForecast, yesterday: DailyForecast, thresholdC: Double?): DeltaClause? {
-        if (thresholdC == null) return null
+    private fun deltaClause(
+        today: DailyForecast,
+        yesterday: DailyForecast,
+        thresholdC: Double?,
+        diagLog: (String) -> Unit,
+    ): DeltaClause? {
+        if (thresholdC == null) {
+            diagLog("delta: threshold disabled, no clause")
+            return null
+        }
         val highDelta = today.feelsLikeMaxC - yesterday.feelsLikeMaxC
         val lowDelta = today.feelsLikeMinC - yesterday.feelsLikeMinC
-        val biggest = if (abs(highDelta) >= abs(lowDelta)) highDelta else lowDelta
+        val pickedHigh = abs(highDelta) >= abs(lowDelta)
+        val biggest = if (pickedHigh) highDelta else lowDelta
+        val inputs = "today min/max=%.1f/%.1f yesterday min/max=%.1f/%.1f highDelta=%+.1f lowDelta=%+.1f picked=%s biggest=%+.1f threshold=%.1f".format(
+            Locale.US,
+            today.feelsLikeMinC, today.feelsLikeMaxC,
+            yesterday.feelsLikeMinC, yesterday.feelsLikeMaxC,
+            highDelta, lowDelta,
+            if (pickedHigh) "high" else "low",
+            biggest, thresholdC,
+        )
         // Apply the threshold against the *unrounded* delta. Otherwise 2.6°C rounds
         // to 3 and would emit a clause even though the actual delta is under the
         // configured rule.
-        if (abs(biggest) < thresholdC) return null
+        if (abs(biggest) < thresholdC) {
+            diagLog("delta: $inputs → under threshold, no clause")
+            return null
+        }
         val rounded = biggest.roundToInt()
         val direction = if (rounded > 0) DeltaClause.Direction.WARMER else DeltaClause.Direction.COOLER
+        diagLog("delta: $inputs → ${abs(rounded)}° $direction")
         return DeltaClause(degrees = abs(rounded), direction = direction)
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #641 / #642. Adds a one-line per-delivery log capturing the delta-clause decision so a future "5° warmer than I expected" report can be diagnosed straight from `DiagLog` without needing a full bug-report snapshot.

Example line:
```
delta: today min/max=12.0/22.6 yesterday min/max=7.0/17.6 highDelta=+5.0 lowDelta=+5.0 picked=high biggest=+5.0 threshold=3.0 → 5° WARMER
```

A `diagLog: (String) -> Unit = {}` parameter threads `RenderInsightSummary` → `DeriveInsight` (both pure-Kotlin), defaulting to a no-op so tests / previews stay quiet. Only the worker's `app.deriveInsight(snapshot, prefs, diagLog = …)` call wires a DiagLog adapter; cache re-derives (Today screen, widget, format preview) keep the no-op default so prefs-flip log churn stays nil.

Three failure-mode lines, all emitted from the same site:
- `delta: threshold disabled, no clause` — when `prefs.deltaThresholdC == null`
- `delta: <inputs> → under threshold, no clause` — biggest delta below threshold
- `delta: <inputs> → N° WARMER|COOLER` — clause emitted

## Privacy

No new data crosses the device boundary. The line is local-only, written through the same `DiagLog` ring buffer the bug-report consent flow already covers.

## Test plan
- [x] `:core:domain:test` passes locally
- [x] `:app:testDebugUnitTest` passes locally
- [x] `:app:compileDebugKotlin` passes locally
- [ ] CI green
- [ ] Fire a morning insight on a debug build and confirm a single `delta:` line lands in the log, matching the surfaced prose

https://claude.ai/code/session_01B62ma26Vv4t2Xm8PfvTJzb

---
_Generated by [Claude Code](https://claude.ai/code/session_01B62ma26Vv4t2Xm8PfvTJzb)_