### PR TITLE
Compare today's prose against the day you actually lived

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ClothesCastApplication.kt
+++ b/app/src/main/kotlin/app/clothescast/ClothesCastApplication.kt
@@ -19,6 +19,7 @@ import app.clothescast.core.domain.repository.CalendarEventReader
 import app.clothescast.core.domain.repository.WeatherRepository
 import app.clothescast.core.domain.usecase.DeriveInsight
 import app.clothescast.core.domain.usecase.GenerateDailyInsight
+import app.clothescast.data.DailyHistoryStore
 import app.clothescast.data.InsightCache
 import app.clothescast.data.SecureKeyStore
 import app.clothescast.data.SettingsRepository
@@ -66,6 +67,7 @@ class ClothesCastApplication : Application() {
     val settingsRepository: SettingsRepository by lazy { SettingsRepository.create(this) }
     val deriveInsight: DeriveInsight by lazy { DeriveInsight() }
     val insightCache: InsightCache by lazy { InsightCache.create(this, deriveInsight) }
+    val dailyHistoryStore: DailyHistoryStore by lazy { DailyHistoryStore.create(this) }
     val locationResolver: LocationResolver by lazy { LocationResolver(this) }
     val reverseGeocoder: ReverseGeocoder by lazy { ReverseGeocoder(this) }
     val insightNotifier: InsightNotifier by lazy { InsightNotifier(this) }

--- a/app/src/main/kotlin/app/clothescast/data/DailyHistoryStore.kt
+++ b/app/src/main/kotlin/app/clothescast/data/DailyHistoryStore.kt
@@ -1,0 +1,106 @@
+package app.clothescast.data
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import app.clothescast.core.domain.model.DailyHistoryEntry
+import kotlinx.coroutines.flow.first
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import java.time.LocalDate
+
+/**
+ * A small rolling store of the feels-like daytime aggregates we actually
+ * delivered each day. See [DailyHistoryEntry] for the rationale — short
+ * version: Open-Meteo's `forecast?past_days=1` returns model output, not
+ * observations, and was observed to be wildly wrong for the past day
+ * (Liverpool 2026-05-23 came back as a flat 14..18 °C when reality was 29 °C).
+ * Comparing today's forecast against the prior delivered aggregate sidesteps
+ * the upstream miss and also matches what the user actually dressed for
+ * yesterday morning, which is what they remember.
+ *
+ * Storage: a single JSON-serialized list of entries under one DataStore key,
+ * sorted oldest-first. `DeriveInsight` only ever consults exactly
+ * `today.minusDays(1)`, so entries older than that are dead weight — every
+ * write prunes anything below `entry.date - 1`, leaving at most two records
+ * in the store (yesterday + today, transitioning to today + tomorrow on the
+ * next morning's write). At ~30 bytes per entry the file is sub-100 bytes.
+ *
+ * Concurrency: DataStore's `edit` serializes writes, and read-modify-write
+ * runs inside the same transaction, so concurrent worker runs can't race a
+ * duplicate-day write into the list.
+ */
+class DailyHistoryStore(
+    private val dataStore: DataStore<Preferences>,
+    private val json: Json = Json { ignoreUnknownKeys = true },
+) {
+    /**
+     * Returns the entry recorded for [date], or null when nothing was stored
+     * for that day (day-one install, app disabled / device off that day, or
+     * the entry was pruned by retention).
+     */
+    suspend fun entryFor(date: LocalDate): DailyHistoryEntry? {
+        val list = read()
+        return list.firstOrNull { it.date == date }
+    }
+
+    /**
+     * Records [entry] for [DailyHistoryEntry.date]. If an entry for the same
+     * day already exists it's overwritten (a same-day refresh delivers an
+     * updated aggregate). Anything older than `entry.date - 1` is dropped —
+     * `DeriveInsight` only ever consults `today.minusDays(1)`, so two-day-old
+     * records are unreachable from the read path and don't earn their bytes.
+     */
+    suspend fun put(entry: DailyHistoryEntry) {
+        dataStore.edit { prefs ->
+            val cutoff = entry.date.minusDays(1)
+            val existing = decode(prefs[HISTORY_KEY])
+            val merged = (existing.filter { it.date != entry.date && !it.date.isBefore(cutoff) } + entry)
+                .sortedBy { it.date }
+            prefs[HISTORY_KEY] = json.encodeToString(merged.map { it.toDto() })
+        }
+    }
+
+    private suspend fun read(): List<DailyHistoryEntry> =
+        decode(dataStore.data.first()[HISTORY_KEY])
+
+    private fun decode(raw: String?): List<DailyHistoryEntry> {
+        if (raw.isNullOrEmpty()) return emptyList()
+        return runCatching {
+            json.decodeFromString<List<EntryDto>>(raw).map { it.toDomain() }
+        }.getOrDefault(emptyList())
+    }
+
+    @Serializable
+    private data class EntryDto(
+        val dateEpochDays: Long,
+        val feelsLikeMinC: Double,
+        val feelsLikeMaxC: Double,
+    ) {
+        fun toDomain(): DailyHistoryEntry = DailyHistoryEntry(
+            date = LocalDate.ofEpochDay(dateEpochDays),
+            feelsLikeMinC = feelsLikeMinC,
+            feelsLikeMaxC = feelsLikeMaxC,
+        )
+    }
+
+    private fun DailyHistoryEntry.toDto(): EntryDto = EntryDto(
+        dateEpochDays = date.toEpochDay(),
+        feelsLikeMinC = feelsLikeMinC,
+        feelsLikeMaxC = feelsLikeMaxC,
+    )
+
+    companion object {
+        private val HISTORY_KEY = stringPreferencesKey("daily_history_v1")
+
+        fun create(context: Context): DailyHistoryStore =
+            DailyHistoryStore(context.dailyHistoryDataStore)
+    }
+}
+
+private val Context.dailyHistoryDataStore: DataStore<Preferences> by preferencesDataStore(name = "daily_history")

--- a/app/src/main/kotlin/app/clothescast/data/InsightCache.kt
+++ b/app/src/main/kotlin/app/clothescast/data/InsightCache.kt
@@ -10,6 +10,7 @@ import app.clothescast.core.domain.model.AlertSeverity
 import app.clothescast.core.domain.model.CalendarEvent
 import app.clothescast.core.domain.model.ConfidenceInfo
 import app.clothescast.core.domain.model.DailyForecast
+import app.clothescast.core.domain.model.DailyHistoryEntry
 import app.clothescast.core.domain.model.EventKind
 import app.clothescast.core.domain.model.ForecastConfidence
 import app.clothescast.core.domain.model.ForecastPeriod
@@ -184,6 +185,7 @@ class InsightCache(
         val location: LocationDto? = null,
         val period: String = ForecastPeriod.TODAY.name,
         val generatedAtEpochMillis: Long,
+        val historicYesterday: DailyHistoryDto? = null,
     ) {
         fun toDomain(): ForecastSnapshot = ForecastSnapshot(
             bundle = bundle.toDomain(),
@@ -191,6 +193,20 @@ class InsightCache(
             location = location?.toDomain(),
             period = runCatching { ForecastPeriod.valueOf(period) }.getOrDefault(ForecastPeriod.TODAY),
             generatedAt = Instant.ofEpochMilli(generatedAtEpochMillis),
+            historicYesterday = historicYesterday?.toDomain(),
+        )
+    }
+
+    @Serializable
+    private data class DailyHistoryDto(
+        val dateEpochDays: Long,
+        val feelsLikeMinC: Double,
+        val feelsLikeMaxC: Double,
+    ) {
+        fun toDomain(): DailyHistoryEntry = DailyHistoryEntry(
+            date = LocalDate.ofEpochDay(dateEpochDays),
+            feelsLikeMinC = feelsLikeMinC,
+            feelsLikeMaxC = feelsLikeMaxC,
         )
     }
 
@@ -409,6 +425,13 @@ class InsightCache(
         },
         period = period.name,
         generatedAtEpochMillis = generatedAt.toEpochMilli(),
+        historicYesterday = historicYesterday?.let {
+            DailyHistoryDto(
+                dateEpochDays = it.date.toEpochDay(),
+                feelsLikeMinC = it.feelsLikeMinC,
+                feelsLikeMaxC = it.feelsLikeMaxC,
+            )
+        },
     )
 
     private fun ForecastBundle.toDto(): ForecastBundleDto = ForecastBundleDto(

--- a/app/src/main/kotlin/app/clothescast/diag/BugReport.kt
+++ b/app/src/main/kotlin/app/clothescast/diag/BugReport.kt
@@ -286,6 +286,17 @@ object BugReport {
                 Locale.US, loc.latitude, loc.longitude, name,
             ))
         }
+        val historic = snapshot.historicYesterday
+        if (historic != null) {
+            val expected = snapshot.bundle.today.date.minusDays(1)
+            val freshness = if (historic.date == expected) "matches" else "stale (expected $expected)"
+            appendLine("  Historic yesterday (${historic.date}, $freshness) feels-like min/max: " +
+                "%.1f / %.1f °C".format(
+                    Locale.US, historic.feelsLikeMinC, historic.feelsLikeMaxC,
+                ))
+        } else {
+            appendLine("  Historic yesterday: (none recorded — delta falls back to upstream)")
+        }
         val yesterday = snapshot.bundle.yesterday
         appendLine("  Yesterday (${yesterday.date}) feels-like min/max: " +
             "%.1f / %.1f °C (24h aggregate)".format(

--- a/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
@@ -16,8 +16,10 @@ import androidx.work.WorkerParameters
 import androidx.glance.appwidget.updateAll
 import androidx.work.workDataOf
 import app.clothescast.ClothesCastApplication
+import app.clothescast.core.domain.model.DailyHistoryEntry
 import app.clothescast.core.domain.model.DeliveryMode
 import app.clothescast.core.domain.model.ForecastPeriod
+import app.clothescast.core.domain.model.ForecastSnapshot
 import app.clothescast.core.domain.model.HolidayTheme
 import app.clothescast.core.domain.model.Insight
 import app.clothescast.core.domain.model.Location
@@ -257,7 +259,10 @@ class FetchAndNotifyWorker(
             val cachedInsight = cached.insight
             DiagLog.i(TAG, "Using cached $period insight for ${cachedInsight.forDate}.")
             return runCatching { deliver(cachedInsight, prefs, formatProse(cachedInsight, prefs)) }
-                .map { Result.success() }
+                .map {
+                    recordDailyHistory(cachedInsight)
+                    Result.success()
+                }
                 .getOrElse {
                     if (it is CancellationException) throw it
                     DiagLog.e(TAG, "Cached delivery failed; falling through to fresh generate.", it)
@@ -302,7 +307,7 @@ class FetchAndNotifyWorker(
             // lands in the cache so any later settings change re-renders
             // off the same upstream data for free; the derive call here is the
             // one we deliver on this run.
-            val snapshot = app.generateDailyInsight.snapshot(location, prefs, period)
+            val snapshot = capturedSnapshot(location, prefs, period, dayOffset = 0)
             val result = app.deriveInsight(snapshot, prefs, diagLog = { DiagLog.i(TAG, it) })
             // Severe alerts are out-of-band: post them as separate high-priority
             // notifications on every fresh fetch, regardless of whether the daily
@@ -351,6 +356,7 @@ class FetchAndNotifyWorker(
             val prose = formatProse(insight, prefs)
             deliver(insight, prefs, prose)
             DiagLog.i(TAG, "Insight delivered for ${insight.forDate}: $prose")
+            recordDailyHistory(insight)
             Result.success()
         } catch (e: ResponseException) {
             // OpenMeteo 4xx → fail; 5xx → retry with backoff. 429 is the one
@@ -430,13 +436,59 @@ class FetchAndNotifyWorker(
         }
         val dayOffset = if (primaryPeriod == ForecastPeriod.TONIGHT) 1 else 0
         runCatching {
-            val snapshot = app.generateDailyInsight.snapshot(location, prefs, nextWindowPeriod, dayOffset)
+            val snapshot = capturedSnapshot(location, prefs, nextWindowPeriod, dayOffset)
             app.insightCache.store(InsightCache.Slot.NEXT_PERIOD, snapshot)
             DiagLog.i(TAG, "Next-window $nextWindowPeriod snapshot cached for ${snapshot.bundle.today.date}.")
         }.onFailure {
             if (it is CancellationException) throw it
             DiagLog.w(TAG, "Next-window $nextWindowPeriod insight generation failed; not blocking $primaryPeriod delivery.", it)
         }
+    }
+
+    /**
+     * Wraps [GenerateDailyInsight.snapshot] with a lookup for yesterday's
+     * delivered daytime aggregate, baking the result into the snapshot's
+     * [ForecastSnapshot.historicYesterday]. Every downstream consumer
+     * (this worker's delivery, the cache redeliver path, the Today screen's
+     * reactive re-derive, the format-preview, the home-screen widget) then
+     * sees the same record without each having to read from
+     * [DailyHistoryStore] themselves. Lookup failures degrade to no historic
+     * value — the delta clause falls back to `bundle.yesterday`, which is
+     * the legacy behaviour.
+     */
+    private suspend fun capturedSnapshot(
+        location: Location,
+        prefs: UserPreferences,
+        period: ForecastPeriod,
+        dayOffset: Int,
+    ): ForecastSnapshot {
+        val raw = app.generateDailyInsight.snapshot(location, prefs, period, dayOffset)
+        val historic = runCatching {
+            app.dailyHistoryStore.entryFor(raw.bundle.today.date.minusDays(1))
+        }.getOrNull()
+        return raw.copy(historicYesterday = historic)
+    }
+
+    /**
+     * Persists today's delivered daytime aggregate to [DailyHistoryStore] so
+     * tomorrow's delta clause can compare against what we actually told the
+     * user about today (see [DailyHistoryEntry]). Only TODAY-period
+     * deliveries write: TONIGHT covers the evening slice, which isn't a
+     * meaningful "yesterday" comparison for tomorrow's daytime forecast.
+     */
+    private suspend fun recordDailyHistory(insight: Insight) {
+        if (insight.period != ForecastPeriod.TODAY) return
+        if (insight.hourly.isEmpty()) return
+        val entry = DailyHistoryEntry(
+            date = insight.forDate,
+            feelsLikeMinC = insight.hourly.minOf { it.feelsLikeC },
+            feelsLikeMaxC = insight.hourly.maxOf { it.feelsLikeC },
+        )
+        runCatching { app.dailyHistoryStore.put(entry) }
+            .onFailure {
+                if (it is CancellationException) throw it
+                DiagLog.w(TAG, "Daily history write failed; tomorrow's delta will fall back to upstream past-days data.", it)
+            }
     }
 
     private fun reason(code: String, detail: String? = null) =

--- a/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
@@ -465,7 +465,21 @@ class FetchAndNotifyWorker(
         val raw = app.generateDailyInsight.snapshot(location, prefs, period, dayOffset)
         val historic = runCatching {
             app.dailyHistoryStore.entryFor(raw.bundle.today.date.minusDays(1))
-        }.getOrNull()
+        }.getOrElse {
+            // Preserve structured cancellation. Without this, a WorkManager
+            // cancel during the read would be swallowed and the run would
+            // fall through to a normal success path — fetching, derivation,
+            // delivery and cache writes would still execute under a worker
+            // the framework already gave up on. Matches the rethrow pattern
+            // every other catch in this file uses.
+            if (it is CancellationException) throw it
+            DiagLog.w(
+                TAG,
+                "Daily history read failed; delta will fall back to upstream past-days data.",
+                it,
+            )
+            null
+        }
         return raw.copy(historicYesterday = historic)
     }
 

--- a/app/src/test/kotlin/app/clothescast/data/DailyHistoryStoreTest.kt
+++ b/app/src/test/kotlin/app/clothescast/data/DailyHistoryStoreTest.kt
@@ -1,0 +1,97 @@
+package app.clothescast.data
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import app.clothescast.core.domain.model.DailyHistoryEntry
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.nio.file.Path
+import java.time.LocalDate
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DailyHistoryStoreTest {
+    @TempDir lateinit var tempDir: Path
+
+    private lateinit var dataStore: DataStore<Preferences>
+    private lateinit var subject: DailyHistoryStore
+
+    @BeforeEach
+    fun setUp() {
+        Dispatchers.setMain(UnconfinedTestDispatcher(TestCoroutineScheduler()))
+        dataStore = PreferenceDataStoreFactory.create(
+            produceFile = { File(tempDir.toFile(), "history.preferences_pb") },
+        )
+        subject = DailyHistoryStore(dataStore)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `entryFor returns null when no entry stored for that date`() = runTest {
+        subject.entryFor(LocalDate.of(2026, 5, 23)).shouldBeNull()
+    }
+
+    @Test
+    fun `put and entryFor round-trip a single entry`() = runTest {
+        val entry = DailyHistoryEntry(
+            date = LocalDate.of(2026, 5, 23),
+            feelsLikeMinC = 14.0,
+            feelsLikeMaxC = 28.5,
+        )
+        subject.put(entry)
+        subject.entryFor(entry.date) shouldBe entry
+    }
+
+    @Test
+    fun `put replaces a same-day entry rather than duplicating it`() = runTest {
+        val date = LocalDate.of(2026, 5, 23)
+        subject.put(DailyHistoryEntry(date, 10.0, 20.0))
+        subject.put(DailyHistoryEntry(date, 12.0, 22.0))
+        subject.entryFor(date) shouldBe DailyHistoryEntry(date, 12.0, 22.0)
+    }
+
+    @Test
+    fun `put prunes anything older than entry date minus one day`() = runTest {
+        // Three days running: only the latest two should survive, because the
+        // delta clause only ever reads today.minusDays(1).
+        val d1 = LocalDate.of(2026, 5, 21)
+        val d2 = d1.plusDays(1)
+        val d3 = d1.plusDays(2)
+        subject.put(DailyHistoryEntry(d1, 10.0, 20.0))
+        subject.put(DailyHistoryEntry(d2, 11.0, 21.0))
+        subject.put(DailyHistoryEntry(d3, 12.0, 22.0))
+
+        subject.entryFor(d1).shouldBeNull()
+        subject.entryFor(d2) shouldBe DailyHistoryEntry(d2, 11.0, 21.0)
+        subject.entryFor(d3) shouldBe DailyHistoryEntry(d3, 12.0, 22.0)
+    }
+
+    @Test
+    fun `put dropping an entry across a multi-day gap leaves only the new one`() = runTest {
+        // User skipped a few days (app disabled, phone off, on holiday). When
+        // they come back, the prior record is too stale to be "yesterday" so
+        // it's pruned the moment a new entry lands.
+        subject.put(DailyHistoryEntry(LocalDate.of(2026, 5, 21), 10.0, 20.0))
+        subject.put(DailyHistoryEntry(LocalDate.of(2026, 5, 24), 14.0, 28.0))
+
+        subject.entryFor(LocalDate.of(2026, 5, 21)).shouldBeNull()
+        subject.entryFor(LocalDate.of(2026, 5, 24)) shouldBe
+            DailyHistoryEntry(LocalDate.of(2026, 5, 24), 14.0, 28.0)
+    }
+}

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/DailyHistoryEntry.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/DailyHistoryEntry.kt
@@ -1,0 +1,31 @@
+package app.clothescast.core.domain.model
+
+import java.time.LocalDate
+
+/**
+ * A snapshot of the feels-like aggregates we actually delivered for a past day,
+ * persisted across runs in a small rolling store. Preferred over Open-Meteo's
+ * `forecast?past_days=N` data as the yesterday side of the delta clause because:
+ *
+ *  - `past_days=N` returns the forecast model's hindcast — its retroactive guess
+ *    at yesterday from its latest run — not actual observations. When the model
+ *    under-called a clear-sky high (as observed in the bug we're addressing),
+ *    today's prose ends up comparing today's forecast against yesterday's
+ *    missed forecast, which user-facingly reads as a confidently wrong delta.
+ *  - The aggregate reflects the forecast we actually told the user about
+ *    yesterday morning, so "4° warmer than yesterday" matches what they were
+ *    dressed for rather than what some reanalysis decided yesterday was.
+ *  - The aggregate naturally tracks the *location they were at* yesterday: we
+ *    wrote whatever the snapshot's location resolved to. A user who wakes up in
+ *    a different city today still gets a comparison against the day they
+ *    actually lived rather than against the new city's past-day model output.
+ *
+ * Aggregates are for the daytime slice the morning insight runs against
+ * (07:00..19:00 by default; whatever the user's notification schedule defines).
+ * Hourly values aren't stored — the delta clause reads min and max only.
+ */
+data class DailyHistoryEntry(
+    val date: LocalDate,
+    val feelsLikeMinC: Double,
+    val feelsLikeMaxC: Double,
+)

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/ForecastSnapshot.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/ForecastSnapshot.kt
@@ -33,4 +33,18 @@ data class ForecastSnapshot(
     val location: Location?,
     val period: ForecastPeriod,
     val generatedAt: Instant,
+    /**
+     * Yesterday's delivered daytime aggregate, read from the rolling
+     * `DailyHistoryStore` at snapshot-capture time and baked in so every
+     * downstream consumer (worker delivery, cache redelivery, Today screen
+     * reactive re-derive, format-preview, widget) sees the same record.
+     * When present and its date matches `bundle.today.date.minusDays(1)`,
+     * the delta clause prefers it over `bundle.yesterday` — see
+     * [DailyHistoryEntry] for the rationale (upstream past-days data is
+     * model output, not observations, and was wrong in a reproducible
+     * case). Null on day-one installs, when the previous day's delivery
+     * never happened (app disabled), or when the snapshot was captured by
+     * a path that doesn't have a store wired (tests, previews).
+     */
+    val historicYesterday: DailyHistoryEntry? = null,
 )

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/DeriveInsight.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/DeriveInsight.kt
@@ -95,9 +95,31 @@ class DeriveInsight(
         val defaultBottom = prefs.defaultBottom
         val defaultTop = prefs.defaultTop
 
+        // Prefer the day we actually delivered to the user yesterday over the
+        // upstream past-days hindcast (see [DailyHistoryEntry] for why). Only
+        // accepted when the recorded date is exactly the day before the
+        // snapshot's today — a stale record from two days ago is more
+        // misleading than no clause at all.
+        val deltaYesterdayForRender = snapshot.historicYesterday
+            ?.takeIf { it.date == bundle.today.date.minusDays(1) }
+            ?.let { entry ->
+                diagLog(
+                    "delta-source: using historic yesterday (date=${entry.date}, " +
+                        "feels-like min/max=${entry.feelsLikeMinC}/${entry.feelsLikeMaxC}) " +
+                        "in place of bundle.yesterday min/max=" +
+                        "${periodView.deltaYesterday.feelsLikeMinC}/" +
+                        "${periodView.deltaYesterday.feelsLikeMaxC}",
+                )
+                periodView.deltaYesterday.copy(
+                    feelsLikeMinC = entry.feelsLikeMinC,
+                    feelsLikeMaxC = entry.feelsLikeMaxC,
+                )
+            }
+            ?: periodView.deltaYesterday
+
         val summary = renderInsightSummary(
             today = periodView.forecast,
-            yesterday = periodView.deltaYesterday,
+            yesterday = deltaYesterdayForRender,
             todayItems = periodView.triggeredOutfit.items,
             alerts = activeAlerts,
             events = periodView.events,

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/DeriveInsightHistoricYesterdayTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/DeriveInsightHistoricYesterdayTest.kt
@@ -1,0 +1,145 @@
+package app.clothescast.core.domain.usecase
+
+import app.clothescast.core.domain.model.ClothesRule
+import app.clothescast.core.domain.model.DailyForecast
+import app.clothescast.core.domain.model.DailyHistoryEntry
+import app.clothescast.core.domain.model.DeliveryMode
+import app.clothescast.core.domain.model.DeltaClause
+import app.clothescast.core.domain.model.DistanceUnit
+import app.clothescast.core.domain.model.ForecastPeriod
+import app.clothescast.core.domain.model.ForecastSnapshot
+import app.clothescast.core.domain.model.Location
+import app.clothescast.core.domain.model.Schedule
+import app.clothescast.core.domain.model.TemperatureUnit
+import app.clothescast.core.domain.model.UserPreferences
+import app.clothescast.core.domain.model.WeatherCondition
+import app.clothescast.core.domain.repository.ForecastBundle
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneOffset
+
+/**
+ * Covers [DeriveInsight]'s "prefer our own history over upstream past-days data"
+ * override for the delta clause. Motivating bug: Open-Meteo's
+ * `forecast?past_days=1` for Liverpool 2026-05-23 returned a flat 14.0..17.8 °C
+ * full-day swing when the user observed a 29 °C high in person, so the morning
+ * insight confidently emitted "4° warmer than yesterday" when it should have
+ * been the other direction. The fix records the daytime aggregate we actually
+ * delivered each day and prefers that for the next morning's comparison.
+ */
+class DeriveInsightHistoricYesterdayTest {
+    private val today = DailyForecast(
+        date = LocalDate.of(2026, 5, 24),
+        temperatureMinC = 12.0,
+        temperatureMaxC = 23.0,
+        feelsLikeMinC = 12.0,
+        feelsLikeMaxC = 22.0,
+        precipitationProbabilityMaxPct = 0.0,
+        precipitationMmTotal = 0.0,
+        condition = WeatherCondition.CLOUDY,
+    )
+
+    // Bogus upstream past-days data — flat 14..18, much lower than what was
+    // actually delivered yesterday morning, mirrors the observed Open-Meteo
+    // failure mode.
+    private val bogusBundleYesterday = DailyForecast(
+        date = LocalDate.of(2026, 5, 23),
+        temperatureMinC = 14.0,
+        temperatureMaxC = 18.0,
+        feelsLikeMinC = 14.0,
+        feelsLikeMaxC = 18.0,
+        precipitationProbabilityMaxPct = 0.0,
+        precipitationMmTotal = 0.0,
+        condition = WeatherCondition.CLOUDY,
+    )
+
+    private val prefs = UserPreferences(
+        schedule = Schedule.default(ZoneOffset.UTC),
+        deliveryMode = DeliveryMode.NOTIFICATION_ONLY,
+        temperatureUnit = TemperatureUnit.CELSIUS,
+        distanceUnit = DistanceUnit.KILOMETERS,
+        clothesRules = ClothesRule.DEFAULTS,
+    )
+
+    private fun snapshot(historic: DailyHistoryEntry?): ForecastSnapshot = ForecastSnapshot(
+        bundle = ForecastBundle(today = today, yesterday = bogusBundleYesterday),
+        events = emptyList(),
+        location = Location(latitude = 53.4054, longitude = -2.9924, displayName = "Liverpool"),
+        period = ForecastPeriod.TODAY,
+        generatedAt = Instant.parse("2026-05-24T07:00:00Z"),
+        historicYesterday = historic,
+    )
+
+    @Test
+    fun `historic yesterday override flips the delta direction when upstream data was wrong`() {
+        // The day we actually delivered: feels-like 15..28 in Liverpool. With
+        // today's 12..22 that's a -6 max delta — today should read as cooler.
+        val historic = DailyHistoryEntry(
+            date = LocalDate.of(2026, 5, 23),
+            feelsLikeMinC = 15.0,
+            feelsLikeMaxC = 28.0,
+        )
+
+        val withOverride = DeriveInsight()(snapshot(historic), prefs)
+        val withoutOverride = DeriveInsight()(snapshot(historic = null), prefs)
+
+        // Without the override: bogus upstream feels-like max 18.0 vs today
+        // 22.0 → +4 warmer.
+        withoutOverride.insight.summary.delta.shouldNotBeNull()
+        withoutOverride.insight.summary.delta!!.degrees shouldBe 4
+        withoutOverride.insight.summary.delta!!.direction shouldBe DeltaClause.Direction.WARMER
+
+        // With the override: real delivered max 28.0 vs today 22.0 → 6 cooler.
+        withOverride.insight.summary.delta.shouldNotBeNull()
+        withOverride.insight.summary.delta!!.degrees shouldBe 6
+        withOverride.insight.summary.delta!!.direction shouldBe DeltaClause.Direction.COOLER
+    }
+
+    @Test
+    fun `historic yesterday with a non-adjacent date is ignored`() {
+        // An entry from two days ago — likely because the app didn't run
+        // yesterday — must not be used; the user would read "vs two days ago"
+        // as "vs yesterday". Fall back to bundle.yesterday (here, the bogus
+        // upstream value), which is the same as the unguarded behaviour.
+        val staleHistoric = DailyHistoryEntry(
+            date = LocalDate.of(2026, 5, 22),
+            feelsLikeMinC = 15.0,
+            feelsLikeMaxC = 28.0,
+        )
+
+        val result = DeriveInsight()(snapshot(staleHistoric), prefs)
+
+        result.insight.summary.delta.shouldNotBeNull()
+        result.insight.summary.delta!!.degrees shouldBe 4
+        result.insight.summary.delta!!.direction shouldBe DeltaClause.Direction.WARMER
+    }
+
+    @Test
+    fun `historic yesterday absent falls through to bundle yesterday cleanly`() {
+        val result = DeriveInsight()(snapshot(historic = null), prefs)
+        result.insight.summary.delta.shouldNotBeNull()
+        result.insight.summary.delta!!.degrees shouldBe 4
+    }
+
+    @Test
+    fun `historic yesterday delta below threshold yields no clause`() {
+        // Today 22 vs delivered yesterday 23 → only 1° cooler, under the 3°
+        // default threshold. Clause must be null. Without the override the
+        // upstream data (18.0 max) would trigger a +4 warmer clause — easy
+        // failure mode if the override silently fell back to upstream when
+        // its own delta is too small.
+        val historic = DailyHistoryEntry(
+            date = LocalDate.of(2026, 5, 23),
+            feelsLikeMinC = 11.0,
+            feelsLikeMaxC = 23.0,
+        )
+
+        val result = DeriveInsight()(snapshot(historic), prefs)
+
+        result.insight.summary.delta.shouldBeNull()
+    }
+}


### PR DESCRIPTION
## Summary

Bug captured in this branch's diagnostic dump: Open-Meteo's `forecast?past_days=1` for Liverpool 2026-05-23 returned a flat 14.0..17.8 °C across the full 24h when the user observed a 29 °C high in person — model hindcast, not observations. The morning insight then confidently emitted "4° warmer than yesterday" when it should have been the other direction.

Fix: prefer a small rolling record of the daytime feels-like aggregate we actually delivered each day over the upstream past-days hindcast. Three things land together:

- **`DailyHistoryStore`** persists yesterday + today's feels-like daytime min/max under one DataStore key. `DeriveInsight` only ever consults `today.minusDays(1)`, so every `put` prunes anything older — the file stays at two records max.
- **`ForecastSnapshot.historicYesterday`** new field. The worker reads from the store at snapshot-capture time and bakes it in, so every downstream consumer (worker delivery, cache redeliver, Today screen reactive re-derive, format preview, widget) sees the same record without each having to know the store exists.
- **`DeriveInsight`** uses `historicYesterday` for the delta clause when its date matches `today.minusDays(1)`; falls back to `bundle.yesterday` on day-one installs, multi-day gaps, or any read failure. The `delta:` diagLog line widens to note when the override fired and what it replaced.

Side benefit: the comparison naturally tracks the location the user was at yesterday (we wrote whatever the snapshot's location resolved to), so a user who wakes up in a different city today still gets a comparison against the day they actually lived — partially addresses the London → Liverpool mid-stack location-jump scenario.

`BugReport.kt` picks up a one-line "Historic yesterday" entry so the diagnostic dump shows both the historic record and the upstream `bundle.yesterday` for side-by-side comparison.

## Privacy

Feels-like min/max for the daytime slice are local-only — they don't cross the device boundary. No new payload, no new permission, no new network call.

## Test plan
- [x] `:core:domain:test` passes — 4 new tests in `DeriveInsightHistoricYesterdayTest` cover override-flips-direction, stale-date-ignored, absent-falls-through, and under-threshold cases
- [x] `:app:testDebugUnitTest` passes — 4 new tests in `DailyHistoryStoreTest` cover empty-store, round-trip, same-day-replace, and multi-day-gap pruning
- [x] `:app:assembleDebug` passes
- [ ] CI green
- [ ] On a fresh-install debug build: fire morning alarm, confirm "Historic yesterday: (none recorded — delta falls back to upstream)" in the bug-report dump. Tomorrow morning's bug-report should show "Historic yesterday (matches today-1)" and the `delta:` log should include the `delta-source: using historic yesterday` line.

https://claude.ai/code/session_01B62ma26Vv4t2Xm8PfvTJzb

---
_Generated by [Claude Code](https://claude.ai/code/session_01B62ma26Vv4t2Xm8PfvTJzb)_