### PR TITLE
Remove stale FileProvider mention from SPEC

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -527,7 +527,6 @@ OEMs we may revisit with a separate placeholder FGS notification.
   `BOOT_COMPLETED` / `MY_PACKAGE_REPLACED` / `TIMEZONE_CHANGED` /
   `LOCALE_CHANGED`.
 - **`OutfitWidgetReceiver`** — exported app-widget provider.
-- **`FileProvider`** — internal-only, for the bug-report share path.
 - **Cast SDK threading.** `MediaRouter.addCallback` /
   `selectRoute`, `SessionManager.addSessionManagerListener`, and
   `RemoteMediaClient.load` are documented main-thread-only. The


### PR DESCRIPTION
## Summary

SPEC.md's "Services and threading" list claimed a `FileProvider` exists "for the bug-report share path," but that's stale. Commit 6212432 ("Stop truncating shared bug reports") moved the share to pure `Intent.ACTION_SEND` with `type = "text/plain"` and dropped the `<provider>` element from `AndroidManifest.xml` plus `res/xml/file_paths.xml`. The spec wasn't updated in that commit.

Confirmed there's no `androidx.core.content.FileProvider` reference anywhere in the codebase (the `*FileProvider` matches in `diag/DiagLog.kt` are local `() -> File` supplier lambdas — `diagFileProvider`, `crashFileProvider`, `ackFileProvider` — not Android's content provider).

This PR removes the one stale bullet from SPEC.md. No code or behaviour changes.

## Test plan
- [x] `grep -rn "FileProvider\|file_paths" SPEC.md AGENTS.md PRIVACY.md README.md` — no remaining mentions
- Docs-only change; CI's "Prepare release notes" step filters `*.md` commits, so no Play changelog impact

https://claude.ai/code/session_REWMl

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sg1cT7EvtFc9v8ST4U6G8f)_