### PR TITLE
Add coRunCatching helper and re-throw cancellation through resolvers

### DIFF
--- a/app/src/main/kotlin/app/clothescast/calendar/CalendarContractEventReader.kt
+++ b/app/src/main/kotlin/app/clothescast/calendar/CalendarContractEventReader.kt
@@ -11,6 +11,7 @@ import app.clothescast.core.domain.model.EventKind
 import app.clothescast.core.domain.model.UpcomingCalendarEvent
 import app.clothescast.core.domain.repository.CalendarEventReader
 import app.clothescast.core.domain.usecase.CalendarEventClassifier
+import app.clothescast.core.domain.util.coRunCatching
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.time.Instant
@@ -42,7 +43,7 @@ class CalendarContractEventReader(private val context: Context) : CalendarEventR
             return emptyList()
         }
         return withContext(Dispatchers.IO) {
-            runCatching {
+            coRunCatching {
                 // Drop all-day rows whose UTC date isn't today: in zones east of
                 // UTC, yesterday's all-day event overlaps the start of today's
                 // local-day window and would otherwise bleed in. Timed rows are
@@ -66,7 +67,7 @@ class CalendarContractEventReader(private val context: Context) : CalendarEventR
             return emptyList()
         }
         return withContext(Dispatchers.IO) {
-            runCatching {
+            coRunCatching {
                 // Narrow the year-long window to all-day rows at the provider
                 // level: birthdays (Contacts / the Birthday event type) and the
                 // synced "Holidays in <country>" calendars are all-day, so this

--- a/app/src/main/kotlin/app/clothescast/location/LocationResolver.kt
+++ b/app/src/main/kotlin/app/clothescast/location/LocationResolver.kt
@@ -12,6 +12,7 @@ import app.clothescast.diag.DiagLog
 import androidx.core.content.ContextCompat
 import androidx.core.content.getSystemService
 import app.clothescast.core.domain.model.Location
+import app.clothescast.core.domain.util.coRunCatching
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlin.coroutines.resume
@@ -53,12 +54,11 @@ class LocationResolver(
      * close enough to "current" for forecast purposes) but wrong for
      * callers that need to detect movement — use [resolveFresh] for those.
      */
-    suspend fun resolve(): Location? = try {
+    suspend fun resolve(): Location? = coRunCatching {
         resolveInner(maxAgeMillis = this.maxAgeMillis, allowStaleFallback = true)
-    } catch (t: Throwable) {
-        DiagLog.w(TAG, "Unexpected ${t.javaClass.simpleName} from resolve(); returning null.", t)
-        null
     }
+        .onFailure { DiagLog.w(TAG, "Unexpected ${it.javaClass.simpleName} from resolve(); returning null.", it) }
+        .getOrNull()
 
     /**
      * Strict variant of [resolve] for callers that must distinguish "user has
@@ -75,12 +75,11 @@ class LocationResolver(
      * Same provider strategy and [timeoutMillis] as [resolve]; only the
      * staleness semantics differ.
      */
-    suspend fun resolveFresh(maxAgeMillis: Long): Location? = try {
+    suspend fun resolveFresh(maxAgeMillis: Long): Location? = coRunCatching {
         resolveInner(maxAgeMillis = maxAgeMillis, allowStaleFallback = false)
-    } catch (t: Throwable) {
-        DiagLog.w(TAG, "Unexpected ${t.javaClass.simpleName} from resolveFresh(); returning null.", t)
-        null
     }
+        .onFailure { DiagLog.w(TAG, "Unexpected ${it.javaClass.simpleName} from resolveFresh(); returning null.", it) }
+        .getOrNull()
 
     private suspend fun resolveInner(maxAgeMillis: Long, allowStaleFallback: Boolean): Location? {
         if (!hasCoarsePermission()) {

--- a/app/src/main/kotlin/app/clothescast/location/ReverseGeocoder.kt
+++ b/app/src/main/kotlin/app/clothescast/location/ReverseGeocoder.kt
@@ -4,8 +4,8 @@ import android.content.Context
 import android.location.Address
 import android.location.Geocoder
 import android.os.Build
+import app.clothescast.core.domain.util.coRunCatching
 import app.clothescast.diag.DiagLog
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.suspendCancellableCoroutine
@@ -53,18 +53,11 @@ class ReverseGeocoder(
 
     /** Best-effort city name + country code, or [Result.EMPTY] if the
      *  geocoder is unavailable / times out / returns nothing useful. */
-    suspend fun resolve(latitude: Double, longitude: Double): Result = try {
+    suspend fun resolve(latitude: Double, longitude: Double): Result = coRunCatching {
         resolveInner(latitude, longitude)
-    } catch (t: CancellationException) {
-        // Coroutine cancellation must propagate — otherwise a Settings
-        // toggle that cancels the cache-refresh worker mid-retry would
-        // sail through and let the caller still write a stale
-        // setLocation. The broad catch below would otherwise swallow it.
-        throw t
-    } catch (t: Throwable) {
-        DiagLog.w(TAG, "Unexpected ${t.javaClass.simpleName} from resolve; returning empty.", t)
-        Result.EMPTY
     }
+        .onFailure { DiagLog.w(TAG, "Unexpected ${it.javaClass.simpleName} from resolve; returning empty.", it) }
+        .getOrDefault(Result.EMPTY)
 
     private suspend fun resolveInner(latitude: Double, longitude: Double): Result {
         if (!Geocoder.isPresent()) {

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsight.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsight.kt
@@ -7,6 +7,7 @@ import app.clothescast.core.domain.model.Location
 import app.clothescast.core.domain.model.UserPreferences
 import app.clothescast.core.domain.repository.CalendarEventReader
 import app.clothescast.core.domain.repository.WeatherRepository
+import app.clothescast.core.domain.util.coRunCatching
 import java.time.Clock
 import java.time.LocalDate
 
@@ -87,13 +88,12 @@ class GenerateDailyInsight(
 
     private suspend fun readEventsForDay(date: LocalDate, prefs: UserPreferences): List<CalendarEvent> {
         // Failures (missing permission, provider crash) degrade to no events so
-        // a misbehaving reader can never fail the insight pipeline. Capture the
-        // property as a local so the smart-cast survives across the runCatching
-        // lambda boundary.
+        // a misbehaving reader can never fail the insight pipeline. Reader
+        // implementations are expected to log their own failures before
+        // throwing; we don't have a logger in pure-Kotlin :core:domain.
         val reader = calendarEventReader
         if (!prefs.calendarEventMentionsActive || reader == null) return emptyList()
-        return runCatching {
-            reader.eventsForDay(date, prefs.schedule.zoneId)
-        }.getOrDefault(emptyList())
+        return coRunCatching { reader.eventsForDay(date, prefs.schedule.zoneId) }
+            .getOrDefault(emptyList())
     }
 }

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/util/CoRunCatching.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/util/CoRunCatching.kt
@@ -1,0 +1,22 @@
+package app.clothescast.core.domain.util
+
+import kotlinx.coroutines.CancellationException
+
+/**
+ * Coroutine-aware [runCatching]. Identical to the stdlib version except that
+ * [CancellationException] is re-thrown rather than wrapped into a failed
+ * [Result] — keeping the body cooperatively cancellable instead of letting
+ * a `withTimeout`, `Job.cancel`, or `WorkManager` stop request sail through
+ * to a stale write.
+ *
+ * Use this anywhere you'd reach for `runCatching` inside a `suspend` function
+ * or a coroutine builder. See KT-58938 for why the stdlib version is unsafe
+ * here.
+ */
+inline fun <R> coRunCatching(block: () -> R): Result<R> = try {
+    Result.success(block())
+} catch (c: CancellationException) {
+    throw c
+} catch (t: Throwable) {
+    Result.failure(t)
+}

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/util/CoRunCatchingTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/util/CoRunCatchingTest.kt
@@ -1,0 +1,42 @@
+package app.clothescast.core.domain.util
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.async
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+class CoRunCatchingTest {
+
+    @Test
+    fun `success wraps the value`() {
+        coRunCatching { 42 }.getOrNull() shouldBe 42
+    }
+
+    @Test
+    fun `non-cancellation throwable is captured as a failed Result`() {
+        val result = coRunCatching { error("boom") }
+        result.isFailure shouldBe true
+        result.exceptionOrNull()!!.message shouldBe "boom"
+    }
+
+    @Test
+    fun `CancellationException is re-thrown rather than wrapped`() {
+        shouldThrow<CancellationException> {
+            coRunCatching { throw CancellationException("cancelled") }
+        }
+    }
+
+    @Test
+    fun `cancellation of the surrounding coroutine still cancels the parent`() = runTest {
+        // Sanity check that using coRunCatching inside an async block lets
+        // structured cancellation work: if the helper swallowed
+        // CancellationException, awaiting the cancelled deferred would not
+        // throw.
+        val deferred = async {
+            coRunCatching { throw CancellationException("inner") }
+        }
+        shouldThrow<CancellationException> { deferred.await() }
+    }
+}


### PR DESCRIPTION
## Summary

`runCatching` in `suspend` code is unsafe: it catches every `Throwable` including `CancellationException`, which silently breaks structured concurrency. A WorkManager job cancelled mid-fix (settings change, constraint loss) would still complete and write stale data. Several sites had this bug:

- `LocationResolver.resolve` / `resolveFresh` — broad `catch (Throwable)`
- `CalendarContractEventReader.eventsForDay` / `upcomingCelebrations` — `runCatching`
- `GenerateDailyInsight.readEventsForDay` — `runCatching`, additionally not even logging the failure
- `ReverseGeocoder.resolve` already had the explicit `CancellationException` re-throw — included here so the pattern is uniform

### Changes
- **New helper** `app.clothescast.core.domain.util.coRunCatching` — identical to stdlib `runCatching` except it re-throws `CancellationException` before wrapping. Drop-in replacement for the `runCatching` → `.onFailure { … }` → `.getOrDefault(…)` chain.
- All five resolver sites routed through the helper. Logging + degradation behaviour unchanged on the failure paths the catch was actually intended for.
- **New test** `CoRunCatchingTest` pins the contract: success wraps the value, non-cancellation throwables become failed `Result`s, `CancellationException` is re-thrown, and `async { coRunCatching { throw CancellationException(…) } }.await()` still cancels.

### Privacy
No change to what leaves the device.

## Test plan
- [x] `./gradlew :core:domain:test :core:data:test :app:testDebugUnitTest` — all pass
- [x] `./gradlew :app:assembleDebug` — succeeds
- [x] Existing test `calendar reader failure degrades to no events without failing the insight` still passes (the fake throws `SecurityException`, which isn't a `CancellationException`, so the failure path still degrades to `emptyList()`)
- [ ] CI green