### PR TITLE
Fix bugs and inconsistencies

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -527,7 +527,6 @@ OEMs we may revisit with a separate placeholder FGS notification.
   `BOOT_COMPLETED` / `MY_PACKAGE_REPLACED` / `TIMEZONE_CHANGED` /
   `LOCALE_CHANGED`.
 - **`OutfitWidgetReceiver`** — exported app-widget provider.
-- **`FileProvider`** — internal-only, for the bug-report share path.
 - **Cast SDK threading.** `MediaRouter.addCallback` /
   `selectRoute`, `SessionManager.addSessionManagerListener`, and
   `RemoteMediaClient.load` are documented main-thread-only. The

--- a/app/src/main/kotlin/app/clothescast/calendar/CalendarContractEventReader.kt
+++ b/app/src/main/kotlin/app/clothescast/calendar/CalendarContractEventReader.kt
@@ -51,7 +51,10 @@ class CalendarContractEventReader(private val context: Context) : CalendarEventR
                     .filterNot { it.event.allDay && it.date != date }
                     .map { it.event }
             }
-                .onFailure { DiagLog.w(TAG, "Calendar query failed; degrading to no events.", it) }
+                .onFailure {
+                    if (it is kotlinx.coroutines.CancellationException) throw it
+                    DiagLog.w(TAG, "Calendar query failed; degrading to no events.", it)
+                }
                 .getOrDefault(emptyList())
         }
     }
@@ -88,7 +91,7 @@ class CalendarContractEventReader(private val context: Context) : CalendarEventR
                     .map { UpcomingCalendarEvent(it.date, it.event.title, it.event.kind) }
                     .sortedWith(compareBy({ it.date }, { it.title }))
             }
-                .onFailure { DiagLog.w(TAG, "Calendar query failed; degrading to no events.", it) }
+                .onFailure { if (it is kotlinx.coroutines.CancellationException) throw it; DiagLog.w(TAG, "Calendar query failed; degrading to no events.", it) }
                 .getOrDefault(emptyList())
         }
     }
@@ -298,7 +301,10 @@ class CalendarContractEventReader(private val context: Context) : CalendarEventR
                     result[id] = owner
                 }
             }
-        }.onFailure { DiagLog.w(TAG, "Owner-account lookup failed; classification falls back to NORMAL.", it) }
+        }.onFailure {
+            if (it is kotlinx.coroutines.CancellationException) throw it
+            DiagLog.w(TAG, "Owner-account lookup failed; classification falls back to NORMAL.", it)
+        }
         return result
     }
 

--- a/app/src/main/kotlin/app/clothescast/location/LocationResolver.kt
+++ b/app/src/main/kotlin/app/clothescast/location/LocationResolver.kt
@@ -55,6 +55,8 @@ class LocationResolver(
      */
     suspend fun resolve(): Location? = try {
         resolveInner(maxAgeMillis = this.maxAgeMillis, allowStaleFallback = true)
+    } catch (t: kotlinx.coroutines.CancellationException) {
+        throw t
     } catch (t: Throwable) {
         DiagLog.w(TAG, "Unexpected ${t.javaClass.simpleName} from resolve(); returning null.", t)
         null
@@ -77,6 +79,8 @@ class LocationResolver(
      */
     suspend fun resolveFresh(maxAgeMillis: Long): Location? = try {
         resolveInner(maxAgeMillis = maxAgeMillis, allowStaleFallback = false)
+    } catch (t: kotlinx.coroutines.CancellationException) {
+        throw t
     } catch (t: Throwable) {
         DiagLog.w(TAG, "Unexpected ${t.javaClass.simpleName} from resolveFresh(); returning null.", t)
         null
@@ -143,6 +147,8 @@ class LocationResolver(
     } catch (t: SecurityException) {
         DiagLog.w(TAG, "SecurityException reading last-known location (background grant?).", t)
         null
+    } catch (t: kotlinx.coroutines.CancellationException) {
+        throw t
     } catch (t: Throwable) {
         DiagLog.w(TAG, "Failed to read last-known location: ${t.javaClass.simpleName}", t)
         null
@@ -159,6 +165,8 @@ class LocationResolver(
             // coroutine via exception.
             val providerEnabled = try {
                 manager.isProviderEnabled(provider)
+            } catch (t: kotlinx.coroutines.CancellationException) {
+                throw t
             } catch (t: Throwable) {
                 DiagLog.w(TAG, "isProviderEnabled threw ${t.javaClass.simpleName}; treating as disabled.", t)
                 false
@@ -192,6 +200,8 @@ class LocationResolver(
             } catch (t: SecurityException) {
                 DiagLog.w(TAG, "SecurityException requesting location update (background grant?).", t)
                 cont.resume(null)
+            } catch (t: kotlinx.coroutines.CancellationException) {
+                throw t
             } catch (t: Throwable) {
                 DiagLog.w(TAG, "Failed to request location update: ${t.javaClass.simpleName}", t)
                 cont.resume(null)

--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsViewModel.kt
@@ -680,7 +680,9 @@ class SettingsViewModel(
     suspend fun calendarEventsForDay(date: LocalDate): List<CalendarEvent> {
         val reader = calendarEventReader ?: return emptyList()
         val zone = settingsRepository.preferences.first().schedule.zoneId
-        return runCatching { reader.eventsForDay(date, zone) }.getOrDefault(emptyList())
+        return runCatching { reader.eventsForDay(date, zone) }
+            .onFailure { if (it is kotlinx.coroutines.CancellationException) throw it }
+            .getOrDefault(emptyList())
     }
 
     fun setTelemetryEnabled(enabled: Boolean) {

--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayViewModel.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayViewModel.kt
@@ -340,6 +340,8 @@ class TodayViewModel(
                 val events: List<CalendarEvent> = if (needEvents) {
                     runCatching {
                         calendarEventReader!!.eventsForDay(date, prefs.schedule.zoneId)
+                    }.onFailure {
+                        if (it is kotlinx.coroutines.CancellationException) throw it
                     }.getOrDefault(emptyList())
                 } else {
                     emptyList()

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsight.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsight.kt
@@ -94,6 +94,8 @@ class GenerateDailyInsight(
         if (!prefs.calendarEventMentionsActive || reader == null) return emptyList()
         return runCatching {
             reader.eventsForDay(date, prefs.schedule.zoneId)
+        }.onFailure {
+            if (it is kotlinx.coroutines.CancellationException) throw it
         }.getOrDefault(emptyList())
     }
 }


### PR DESCRIPTION
This commit addresses the requested issues found during exploration:

1. `CalendarContractEventReader.kt` and `runCatching` for Calendar events:
   - `eventsForDay` and `ownerAccountsFor` use `runCatching`.
   - Update `CalendarContractEventReader.kt` to rethrow `CancellationException` in the `runCatching` blocks.
   - Update `GenerateDailyInsight.kt` to rethrow `CancellationException` if `runCatching` catches it.
   - Update `TodayViewModel.kt` to rethrow `CancellationException` if `runCatching` catches it.
   - Update `SettingsViewModel.kt` to rethrow `CancellationException` if `runCatching` catches it.

2. `LocationResolver.kt` `try-catch` blocks swallowing `CancellationException`:
   - `LocationResolver.resolve()`, `resolveFresh()`, `lastKnown`, and `requestSingle` catch `Throwable`.
   - Update these `catch` blocks to catch and rethrow `CancellationException`.

3. `BugReport.kt` / `SPEC.md` `FileProvider` inconsistency:
   - Update `SPEC.md` to remove the line about `FileProvider` to match the actual implementation.

---
*PR created automatically by Jules for task [13154928317053679869](https://jules.google.com/task/13154928317053679869) started by @mikelward*