### PR TITLE
Drop bottoms from the layer-count wording

### DIFF
--- a/app/src/main/kotlin/app/clothescast/insight/InsightFormatter.kt
+++ b/app/src/main/kotlin/app/clothescast/insight/InsightFormatter.kt
@@ -64,7 +64,9 @@ class InsightFormatter(
      * How the clothes clause is rendered. [ClothesFormat.ITEMS] (default) names
      * each triggered garment as before; [ClothesFormat.LAYER_COUNT] collapses
      * the firing tops to a perceived-warmth count via [Garment.layerCount] and
-     * names the bottom (if one fired) alongside — "Wear 2 layers and shorts."
+     * drops bottoms from the wear clause entirely — "Wear 2 layers." — so the
+     * mode reads as a single warmth signal. Bottoms are filtered out in
+     * [format] before the wear clause is rendered; see [isBottom].
      */
     private val clothesFormat: ClothesFormat = ClothesFormat.ITEMS,
     /**
@@ -111,7 +113,12 @@ class InsightFormatter(
         // and the rain mention already implies the umbrella for the typical
         // precip-keyed rule. The accessory TODO below is the proper home for
         // a re-introduction.
-        val wearItems = summary.clothes?.items.orEmpty().filterNot(::isAccessory)
+        val wearItems = summary.clothes?.items.orEmpty()
+            .filterNot(::isAccessory)
+            // Layer-count mode is a single warmth signal: bottoms add noise,
+            // so suppress them before the wear clause renders. An only-bottom
+            // firing therefore emits no wear clause at all in this mode.
+            .filterNot { clothesFormat == ClothesFormat.LAYER_COUNT && isBottom(it) }
         // Items already in the wear sentence shouldn't be repeated by a
         // tie-in — a calendar tie-in that picks "sweater" when the wear
         // sentence already said "Wear a sweater" adds nothing. Dedup on the
@@ -241,6 +248,9 @@ class InsightFormatter(
     private fun isAccessory(item: String): Boolean =
         item.trim().equals("umbrella", ignoreCase = true)
 
+    private fun isBottom(item: String): Boolean =
+        Garment.fromKey(item)?.slot == Garment.Slot.BOTTOM
+
     private fun normalizeItemKey(item: String): String = item.trim().lowercase(Locale.ROOT)
 
     private fun formatAlert(alert: AlertClause): String =
@@ -329,28 +339,22 @@ class InsightFormatter(
     /**
      * Render the body of the wear sentence in layer-count mode. Tops collapse
      * to the max [Garment.layerCount] across firing rules (the heaviest tier
-     * defines the warmth, layering a sweater under a jacket lands at 3 not 5);
-     * bottoms still get named — "2 layers and shorts" — via the locale's
-     * phraser so the user hears their bottom rule too. Returns `null` when no
-     * top is classifiable, letting the caller fall back to the items
+     * defines the warmth, layering a sweater under a jacket lands at 3 not 5).
+     * Bottoms are already filtered out before this runs — see [format] — so
+     * the phrase is purely about top warmth ("Wear 2 layers."). Returns `null`
+     * when no top is classifiable, letting the caller fall back to the items
      * rendering (free-form user-typed garments don't map to a layer count).
      */
     private fun layerCountPhrase(items: List<String>): String? {
         var topCount = 0
-        val bottomKeys = mutableListOf<String>()
         for (item in items) {
             val garment = Garment.fromKey(item) ?: return null
-            when (garment.slot) {
-                Garment.Slot.TOP -> if (garment.layerCount > topCount) topCount = garment.layerCount
-                Garment.Slot.BOTTOM -> bottomKeys += item
+            if (garment.slot == Garment.Slot.TOP && garment.layerCount > topCount) {
+                topCount = garment.layerCount
             }
         }
         if (topCount == 0) return null
-        val layers = resources.getQuantityString(R.plurals.insight_clothes_layer_count, topCount, topCount)
-        if (bottomKeys.isEmpty()) return layers
-        val bottoms = phraser.joinItems(bottomKeys)
-        if (bottoms.isBlank()) return layers
-        return resources.getString(R.string.insight_clothes_join_two, layers, bottoms)
+        return resources.getQuantityString(R.plurals.insight_clothes_layer_count, topCount, topCount)
     }
 
     private fun formatPrecip(precip: PrecipClause): String {

--- a/app/src/test/kotlin/app/clothescast/insight/InsightFormatterTest.kt
+++ b/app/src/test/kotlin/app/clothescast/insight/InsightFormatterTest.kt
@@ -217,7 +217,9 @@ class InsightFormatterTest {
 
     // ClothesFormat.LAYER_COUNT collapses the firing tops to a perceived-warmth
     // count (see Garment.layerCount) — the heaviest single top defines the
-    // count, not the sum. Bottoms are named alongside via the locale's phraser.
+    // count, not the sum. Bottoms are suppressed in this mode (see
+    // InsightFormatter.format) so the wear clause is a single warmth signal;
+    // an only-bottom firing therefore emits no wear clause at all.
     private val layerCountSubject = InsightFormatter.forContext(
         context = context,
         locale = Locale.ENGLISH,
@@ -251,17 +253,29 @@ class InsightFormatterTest {
     }
 
     @Test
-    fun `layer-count format names bottoms alongside the layer count`() {
+    fun `layer-count format suppresses bottoms alongside the layer count`() {
+        // The trailing "and shorts" adds nothing on top of the warmth count, so
+        // layer-count mode drops bottoms entirely — leaving just the count.
         layerCountSubject.format(summary(clothes = ClothesClause(listOf("sweater", "shorts")))) shouldBe
-            "Today, it will be 21°. Wear 2 layers and shorts."
+            "Today, it will be 21°. Wear 2 layers."
     }
 
     @Test
-    fun `layer-count format names a t-shirt as 1 layer alongside shorts`() {
+    fun `layer-count format suppresses bottoms on warm-day t-shirt plus shorts`() {
         // The warm-day fallback scenario in layer-count mode: t-shirt from
-        // the default top, shorts from the user's threshold rule.
+        // the default top, shorts from the user's threshold rule — bottoms
+        // are filtered before the wear clause runs.
         layerCountSubject.format(summary(clothes = ClothesClause(listOf("t-shirt", "shorts")))) shouldBe
-            "Today, it will be 21°. Wear 1 layer and shorts."
+            "Today, it will be 21°. Wear 1 layer."
+    }
+
+    @Test
+    fun `layer-count format drops the wear clause when only a bottom fires`() {
+        // No top means no warmth count to render, and bottoms are suppressed
+        // in this mode — so the whole wear sentence disappears rather than
+        // falling through to the items rendering ("Wear shorts.").
+        layerCountSubject.format(summary(clothes = ClothesClause(listOf("shorts")))) shouldBe
+            "Today, it will be 21°."
     }
 
     @Test

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Settings.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Settings.kt
@@ -178,12 +178,13 @@ enum class RangeFormat { NONE, DEGREES, BANDS }
  *  - [ITEMS] (default) names each triggered garment — the historical
  *    behaviour: "Wear a sweater.", "Wear a sweater and shorts."
  *  - [LAYER_COUNT] collapses the top garments to a perceived-warmth count
- *    (see [Garment.layerCount]) and renders "Wear 2 layers." A bottom
- *    garment, if one triggered, is named alongside the count ("Wear 2
- *    layers and shorts.") so the user still hears it. The count is the
- *    *max* layer count across firing tops, not a sum — wearing a sweater
- *    (2) under a jacket (3) lands at 3 because the jacket defines the
- *    warmth tier, not 5.
+ *    (see [Garment.layerCount]) and renders "Wear 2 layers." Bottoms are
+ *    suppressed in this mode — the whole point is a single warmth signal,
+ *    so a trailing "and shorts" adds noise. The wear clause is dropped
+ *    entirely when only a bottom rule fires (no top to count). The count
+ *    is the *max* layer count across firing tops, not a sum — wearing a
+ *    sweater (2) under a jacket (3) lands at 3 because the jacket defines
+ *    the warmth tier, not 5.
  */
 enum class ClothesFormat { ITEMS, LAYER_COUNT }
 


### PR DESCRIPTION
## Summary

When the **Clothes wording** format is set to **Layer count**, the wear clause used to read "Wear 2 layers and shorts." — the tops collapsed to a perceived-warmth count but the bottom tagged along. The trailing bottom adds noise to a setting whose whole point is a single warmth signal, so this drops bottoms from the wear clause entirely in layer-count mode.

| Firing                | Before                          | After                |
|-----------------------|---------------------------------|----------------------|
| Top + bottom          | `Wear 2 layers and shorts.`     | `Wear 2 layers.`     |
| Bottom only           | `Wear shorts.` (items fallback) | _wear clause omitted_ |
| Top only              | `Wear 2 layers.`                | unchanged             |
| **Garments** mode     | `Wear a sweater and shorts.`    | unchanged (lists all) |

## Implementation

Filtered out `Slot.BOTTOM` items in `InsightFormatter.format()` before the wear clause renders, which keeps the rule in one place and lets `layerCountPhrase` simplify to top-only logic. The domain still emits the same `ClothesClause` including bottoms — only the rendered prose changes, so:

- Today's outfit card / icon and the home-screen widget aren't affected
- Bottom rules still drive the home-screen bottom-icon picker
- Bottoms still appear in **Garments** wording mode

## Test plan

- [x] `:core:domain:test` (KDoc-only change in `Settings.kt`)
- [x] `:app:testDebugUnitTest` — updated two existing layer-count assertions and added a "drops the wear clause when only a bottom fires" test
- [x] `:app:assembleDebug`
- [ ] CI green
- [ ] Manual: Settings → Format → switch **Clothes wording** to **Layer count**, confirm the live "Current forecast" preview no longer ends in "and \<bottom\>" on a day a bottom rule has fired

## Privacy

No change — this only adjusts which words appear in the on-device prose; the same prose still flows to the same destinations (TTS, optional MQTT) for users who already opted in.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BAaKPXpjwE457vgrPmZcAo)_