### PR TITLE
test: cover punctuation hidden behind a trailing parenthetical in normalizeCalendarHolidayTitle

### DIFF
--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/model/HolidayThemeTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/model/HolidayThemeTest.kt
@@ -187,4 +187,14 @@ class HolidayThemeTest {
         // the banner never goes blank.
         normalizeCalendarHolidayTitle("(Western Australia)") shouldBe "(Western Australia)"
     }
+
+    @Test
+    fun `normalizeCalendarHolidayTitle trims punctuation that the parenthetical was hiding`() {
+        // Punctuation sits *behind* the region suffix, so the first trimEnd
+        // can't see it (the string ends in ")"). Only after the regex strips
+        // the parenthetical does the trailing "." / "!" become flush with the
+        // end — that's what the second trimEnd in the pipeline catches.
+        normalizeCalendarHolidayTitle("Memorial Day. (Observed)") shouldBe "Memorial Day"
+        normalizeCalendarHolidayTitle("Boxing Day! (most regions)") shouldBe "Boxing Day"
+    }
 }


### PR DESCRIPTION
## Summary

`normalizeCalendarHolidayTitle` runs `.trimEnd(...)` twice — once before the regex strips a trailing parenthetical, and once after. The existing `HolidayThemeTest` coverage exercises the first `trimEnd` (`"Presidents' Day."`, `"King's Birthday (WA)!"`) but never the second.

That second `trimEnd` exists for inputs where punctuation sits *behind* the parenthetical, e.g. `"Memorial Day. (Observed)"`:

1. First `trimEnd` is a no-op — last char is `)`, not in the punctuation set.
2. Regex strips ` (Observed)` → `"Memorial Day."`
3. Second `trimEnd` cleans the now-trailing `.` → `"Memorial Day"`.

Without coverage there, deleting the second `trimEnd` would still leave every existing assertion green. This adds two cases (`"Memorial Day. (Observed)"` and `"Boxing Day! (most regions)"`) so that branch is pinned.

## Privacy

No change to what leaves the device — this is a test-only addition.

## Test plan

- [x] `cd core && ../gradlew :core:domain:test --tests "app.clothescast.core.domain.model.HolidayThemeTest"` — new case `normalizeCalendarHolidayTitle trims punctuation that the parenthetical was hiding` passes alongside the existing tests
- [ ] CI green


---
_Generated by [Claude Code](https://claude.ai/code/session_014ktzG9QafZFFY3HMBfAt5m)_