### PR TITLE
Route the deprecated TTS error callback through the modern one

### DIFF
--- a/app/src/main/kotlin/app/clothescast/tts/AndroidTtsSpeaker.kt
+++ b/app/src/main/kotlin/app/clothescast/tts/AndroidTtsSpeaker.kt
@@ -80,11 +80,12 @@ class AndroidTtsSpeaker(
                     if (id == utteranceId && cont.isActive) cont.resume(Unit)
                 }
 
-                @Deprecated("Required override; modern TTS engines call onError(id, errorCode) instead.")
+                @Deprecated(
+                    "Required override; modern TTS engines call onError(id, errorCode) instead.",
+                    ReplaceWith("onError(id, TextToSpeech.ERROR)"),
+                )
                 override fun onError(id: String?) {
-                    if (id == utteranceId && cont.isActive) {
-                        cont.resumeWithException(IllegalStateException("TTS synthesis failed"))
-                    }
+                    onError(id, TextToSpeech.ERROR)
                 }
 
                 override fun onError(id: String?, errorCode: Int) {


### PR DESCRIPTION
## Summary

`UtteranceProgressListener.onError(String)` was deprecated in API 21 in favour of `onError(String, int)`, but the deprecated overload is still abstract in the framework, so subclasses must still override it. Modern TTS engines call the new overload exclusively; the deprecated one is only reached from legacy engines (or from the platform's default `onError(id, errorCode)` falling back via `onError(id)` when a subclass overrides only the deprecated method).

Previously `AndroidTtsSpeaker.speakAndAwait` overrode both, with two near-duplicate `resumeWithException` blocks. This collapses the deprecated callback into a one-liner that delegates to `onError(id, TextToSpeech.ERROR)`, so the actual error-handling logic lives in exactly one place. Behaviour is unchanged: any legacy callback now surfaces as the same `IllegalStateException` with the generic `ERROR` (-1) code.

## Test plan

- [x] `./gradlew :app:compileDebugKotlin` — passes
- [x] `cd core && ../gradlew :core:domain:test :core:data:test` — passes
- [ ] CI: `:app:testDebugUnitTest`, `:app:assembleDebug`


---
_Generated by [Claude Code](https://claude.ai/code/session_017WNjk8hvsjWjTRXpGm9qoH)_