### PR TITLE
test: cover non-cancellation error paths in MqttPublisher.preparePublish

### DIFF
--- a/app/src/test/kotlin/app/clothescast/mqtt/MqttPublisherTest.kt
+++ b/app/src/test/kotlin/app/clothescast/mqtt/MqttPublisherTest.kt
@@ -792,6 +792,53 @@ class MqttPublisherTest {
     }
 
     @Test
+    fun `preferences flow throwing non-cancellation error skips publish and returns NotConfigured`() = runTest {
+        // The catch around preferences.first() must swallow a non-cancellation
+        // throwable and return NotConfigured so a transient DataStore read
+        // failure doesn't crash the worker — the publish is silently skipped
+        // until the next refresh.
+        var publishCalls = 0
+        val subject = MqttPublisher(
+            preferences = flow { throw IllegalStateException("DataStore IO failure") },
+            passwordProvider = { null },
+            publish = { _, _, _ -> publishCalls++ },
+        )
+
+        val outcome = subject.publishIfEnabled(ForecastPeriod.TODAY, "x")
+
+        outcome shouldBe MqttPublishOutcome.NotConfigured
+        publishCalls shouldBe 0
+    }
+
+    @Test
+    fun `password provider throwing non-cancellation error falls back to anonymous connect`() = runTest {
+        // The catch around passwordProvider() must swallow a non-cancellation
+        // throwable and fall through with a null password — a keystore read
+        // failure shouldn't block the publish entirely; some brokers accept
+        // an anonymous connect, and a clean publish failure later is more
+        // useful than a silently-dropped delivery.
+        val captured = mutableListOf<PublishCall>()
+        val subject = MqttPublisher(
+            preferences = flowOf(
+                basePrefs.copy(
+                    mqttBridgeEnabled = true,
+                    mqttHost = "broker.local",
+                    mqttUsername = "mqtt-user",
+                ),
+            ),
+            passwordProvider = { throw RuntimeException("keystore unavailable") },
+            publish = capturing(captured),
+        )
+
+        val outcome = subject.publishIfEnabled(ForecastPeriod.TODAY, "x")
+
+        outcome shouldBe MqttPublishOutcome.Success
+        captured.shouldNotBeEmpty()
+        captured.first().config.username shouldBe "mqtt-user"
+        captured.first().config.password shouldBe null
+    }
+
+    @Test
     fun `password provider throwing CancellationException propagates upward`() = runTest {
         val subject = MqttPublisher(
             preferences = flowOf(


### PR DESCRIPTION
## Summary

Two `try`/`catch` blocks in `MqttPublisher.preparePublish` swallow non-`CancellationException` throwables and recover — one around `preferences.first()` (skip the publish on a DataStore read failure → `NotConfigured`), one around `passwordProvider()` (fall back to anonymous connect on a keystore read failure). The existing suite covers the `CancellationException` re-raise paths for both, but not the recover branches — so a regression that started crashing the worker on a transient settings read, or silently dropping deliveries on a keystore failure, would slip through.

Two new tests close that gap:

- `preferences flow throwing non-cancellation error skips publish and returns NotConfigured` — a `flow { throw IllegalStateException(...) }` preference source produces `MqttPublishOutcome.NotConfigured` and never invokes `publish`.
- `password provider throwing non-cancellation error falls back to anonymous connect` — a `passwordProvider` that throws `RuntimeException` still publishes, with `username` preserved on the config and `password = null`.

No production code change; only `app/src/test/kotlin/app/clothescast/mqtt/MqttPublisherTest.kt` is touched. No change to what crosses the device boundary.

## Test plan

- [x] `./gradlew :app:testDebugUnitTest --tests "app.clothescast.mqtt.MqttPublisherTest"` — all tests (including the two new ones) pass locally on this VM
- [ ] CI `JVM unit tests` job green
- [ ] CI `Android debug build` job green


---
_Generated by [Claude Code](https://claude.ai/code/session_01UkUpK5VM8d4gtoBWeVexvy)_