### PR TITLE
Silently refresh the forecast on app open when the cached one is over an hour old

### DIFF
--- a/app/src/main/kotlin/app/clothescast/MainActivity.kt
+++ b/app/src/main/kotlin/app/clothescast/MainActivity.kt
@@ -20,17 +20,22 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.lifecycleScope
 import app.clothescast.core.domain.model.ThemeMode
+import app.clothescast.diag.DiagLog
 import app.clothescast.locale.AppLocale
 import app.clothescast.notification.NotificationPermission
 import app.clothescast.ui.isTelevision
 import app.clothescast.ui.nav.ClothesCastNavHost
 import app.clothescast.ui.theme.ClothesCastTheme
+import app.clothescast.work.FetchAndNotifyWorker
 import com.google.firebase.FirebaseApp
 import com.google.firebase.crashlytics.FirebaseCrashlytics
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import java.time.Instant
 
 class MainActivity : ComponentActivity() {
     // The latest intent delivered while the activity is already running (a
@@ -164,7 +169,33 @@ class MainActivity : ComponentActivity() {
         deepLinkIntent = intent
     }
 
+    override fun onStart() {
+        super.onStart()
+        // Opportunistic refresh: when the user opens the app to a cached
+        // insight that's gone stale (>= SILENT_REFRESH_MIN_AGE since the
+        // last fetch), kick a silent background fetch so the screen
+        // re-renders off fresh data without waiting for the next scheduled
+        // alarm. The worker picks the period itself based on the user's
+        // schedule + wall-clock time (see [FetchAndNotifyWorker.currentPeriodForSchedule]),
+        // so a cache stuck in the wrong window after a missed alarm gets
+        // corrected on the next open. KEEP-deduped on the worker side, so
+        // the per-recreate onStart fires (config changes, returning from a
+        // permission dialog) coalesce into the one in-flight run.
+        val app = application as ClothesCastApplication
+        lifecycleScope.launch {
+            val snapshot = runCatching { app.insightCache.thisPeriod.first() }
+                .getOrElse {
+                    DiagLog.w(TAG, "App-open freshness check failed; skipping silent refresh.", it)
+                    return@launch
+                } ?: return@launch
+            if (!FetchAndNotifyWorker.shouldSilentlyRefresh(snapshot, Instant.now())) return@launch
+            FetchAndNotifyWorker.enqueueSilentRefresh(applicationContext)
+        }
+    }
+
     companion object {
+        private const val TAG = "MainActivity"
+
         /** Deep-link URI that lands on the Today screen. Notification taps target
          *  this; ClothesCastNavHost declares a matching navDeepLink on TodayRoute. */
         const val DEEP_LINK_TODAY = "clothescast://today"

--- a/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
@@ -66,7 +66,10 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import java.io.IOException
+import java.time.Duration
+import java.time.Instant
 import java.time.LocalDate
+import java.time.LocalTime
 import java.util.concurrent.TimeUnit
 import kotlin.math.cos
 import kotlin.math.sqrt
@@ -92,19 +95,22 @@ class FetchAndNotifyWorker(
 
     override suspend fun doWork(): Result {
         val isCacheOnly = inputData.getBoolean(KEY_CACHE_LOCATION_ONLY, false)
+        val isSilent = inputData.getBoolean(KEY_SILENT_REFRESH, false)
         val period = inputData.getString(KEY_PERIOD)
             ?.let { runCatching { ForecastPeriod.valueOf(it) }.getOrNull() }
             ?: ForecastPeriod.TODAY
         val startMs = System.currentTimeMillis()
-        // The cache-only path doesn't deliver an insight, so don't count it
-        // as a refresh outcome — that would skew the success-rate dashboard
-        // with no-op runs every time the user toggles device location.
+        // The cache-only and silent-refresh paths don't deliver a
+        // notification, so don't count them as refresh outcomes — they'd
+        // skew the success-rate dashboard with runs the user never
+        // perceived as a "daily refresh".
+        val skipTelemetry = isCacheOnly || isSilent
         return try {
             val result = stamped(doWorkInternal())
-            if (!isCacheOnly) recordDailyRefreshOutcome(period, result, startMs)
+            if (!skipTelemetry) recordDailyRefreshOutcome(period, result, startMs)
             result
         } catch (ce: CancellationException) {
-            if (!isCacheOnly) {
+            if (!skipTelemetry) {
                 Telemetry.logDailyRefresh(
                     slot = slotName(period),
                     outcome = OUTCOME_CANCELLED,
@@ -160,9 +166,20 @@ class FetchAndNotifyWorker(
             return Result.success()
         }
 
-        val period = inputData.getString(KEY_PERIOD)
-            ?.let { runCatching { ForecastPeriod.valueOf(it) }.getOrNull() }
-            ?: ForecastPeriod.TODAY
+        val isSilentRefresh = inputData.getBoolean(KEY_SILENT_REFRESH, false)
+        // Silent app-open refreshes derive the period from the user's
+        // schedule against wall-clock time — same logic the Today screen's
+        // manual Refresh button uses — so a cached snapshot left in the
+        // wrong window after a missed alarm (e.g. yesterday-evening
+        // TONIGHT carried into morning) gets corrected to the current
+        // window on the next open, not perpetuated.
+        val period = if (isSilentRefresh) {
+            currentPeriodForSchedule(prefs)
+        } else {
+            inputData.getString(KEY_PERIOD)
+                ?.let { runCatching { ForecastPeriod.valueOf(it) }.getOrNull() }
+                ?: ForecastPeriod.TODAY
+        }
 
         // Honour force-refresh only when it's still the day the user tapped on. If
         // the request was enqueued near midnight and only ran after the date rolled
@@ -173,8 +190,11 @@ class FetchAndNotifyWorker(
         val today = LocalDate.now()
         val requestedEpochDay = inputData.getLong(KEY_REQUESTED_EPOCH_DAY, Long.MIN_VALUE)
         val isUserForcedRefresh = inputData.getBoolean(KEY_FORCE_REFRESH, false)
-        val forceRefresh = isUserForcedRefresh && requestedEpochDay == today.toEpochDay()
-        if (isUserForcedRefresh && !forceRefresh) {
+        // Silent app-open refreshes fire precisely *because* the cached
+        // snapshot is stale, so they always bypass the same-day cache.
+        val forceRefresh = (isUserForcedRefresh && requestedEpochDay == today.toEpochDay()) ||
+            isSilentRefresh
+        if (isUserForcedRefresh && requestedEpochDay != today.toEpochDay()) {
             DiagLog.i(TAG, "Ignoring force refresh from a previous day (requested=$requestedEpochDay, today=${today.toEpochDay()}).")
         }
 
@@ -241,12 +261,9 @@ class FetchAndNotifyWorker(
         // The Today screen's Refresh button sets [KEY_FORCE_REFRESH] = true so an
         // explicit user tap always regenerates — without that flag, tapping Refresh
         // on the same calendar day just redelivers the same cached payload, which
-        // is surprising for the user.
-        //
-        // TODO: opportunistic auto-refresh — when the user opens the app and the
-        // cached insight is more than ~1h old, regenerate (bypassing the same-day
-        // cache). Avoids a full Refresh tap when the clothes / forecast has moved
-        // since the morning generation.
+        // is surprising for the user. Silent app-open refreshes likewise set
+        // [forceRefresh] above so they bypass this cache and pull fresh data
+        // when the stored snapshot is over [SILENT_REFRESH_MIN_AGE] old.
         val cached = if (forceRefresh) {
             DiagLog.i(TAG, "Force refresh requested; bypassing today's cache.")
             null
@@ -309,12 +326,21 @@ class FetchAndNotifyWorker(
             // one we deliver on this run.
             val snapshot = capturedSnapshot(location, prefs, period, dayOffset = 0)
             val result = app.deriveInsight(snapshot, prefs, diagLog = { DiagLog.i(TAG, it) })
+            val isSilentRun = inputData.getBoolean(KEY_SILENT_REFRESH, false)
             // Severe alerts are out-of-band: post them as separate high-priority
             // notifications on every fresh fetch, regardless of whether the daily
-            // summary itself is blank or suppressed.
-            result.alerts.filter { it.isHighPriority() }.forEach { alert ->
-                runCatching { app.weatherAlertNotifier.notify(alert) }
-                    .onFailure { DiagLog.w(TAG, "Severe alert notification failed for ${alert.event}.", it) }
+            // summary itself is blank or suppressed. Silent app-open refreshes
+            // skip this — re-issuing the morning alarm's already-posted alert
+            // with the same stable notification ID re-fires its HUN (heads-up
+            // sound / banner) on every app open with a stale cache, which is
+            // exactly the surprise the silent contract is meant to avoid. New
+            // alerts that landed since the last scheduled run will be picked
+            // up by the next morning / tonight alarm.
+            if (!isSilentRun) {
+                result.alerts.filter { it.isHighPriority() }.forEach { alert ->
+                    runCatching { app.weatherAlertNotifier.notify(alert) }
+                        .onFailure { DiagLog.w(TAG, "Severe alert notification failed for ${alert.event}.", it) }
+                }
             }
             val insight = result.insight
             runCatching { app.insightCache.store(InsightCache.Slot.THIS_PERIOD, snapshot) }
@@ -354,8 +380,17 @@ class FetchAndNotifyWorker(
             // all share the same string and we don't reconfigure the
             // Configuration-overridden Resources three times per fire.
             val prose = formatProse(insight, prefs)
-            deliver(insight, prefs, prose)
-            DiagLog.i(TAG, "Insight delivered for ${insight.forDate}: $prose")
+            // Silent app-open refreshes update the cache (so the Today screen
+            // re-renders off fresh data) but skip the notification / TTS /
+            // MQTT / cast fan-out — the user is already in the app looking at
+            // it, a new banner / chime / cast load on top of that is exactly
+            // the surprise this flag exists to avoid.
+            if (isSilentRun) {
+                DiagLog.i(TAG, "Silent refresh updated cache for ${insight.forDate}: $prose")
+            } else {
+                deliver(insight, prefs, prose)
+                DiagLog.i(TAG, "Insight delivered for ${insight.forDate}: $prose")
+            }
             recordDailyHistory(insight)
             Result.success()
         } catch (e: ResponseException) {
@@ -1200,6 +1235,11 @@ class FetchAndNotifyWorker(
         // it (and vice versa). Cache-only runs are idempotent and skip the
         // insight pipeline entirely.
         const val UNIQUE_WORK_NAME_LOCATION_CACHE = "location_cache_refresh"
+        // Distinct queue from the alarm-driven daily / tonight runs so a
+        // silent app-open refresh in flight doesn't get cancelled by an
+        // alarm fire (and vice versa). KEEP-deduped so config-change
+        // re-triggers on app open coalesce into the one in-flight worker.
+        const val UNIQUE_WORK_NAME_SILENT = "silent_insight_refresh"
 
         // Output Data keys for surfacing failure reasons in the UI.
         const val KEY_REASON = "reason"
@@ -1320,6 +1360,24 @@ class FetchAndNotifyWorker(
          */
         private const val KEY_CACHE_LOCATION_ONLY = "cache_location_only"
 
+        /**
+         * Set true via [enqueueSilentRefresh] for the opportunistic app-open
+         * refresh: fetch + update the cache so the Today screen re-renders
+         * off fresh data, but skip everything user-facing — no notification,
+         * no TTS, no MQTT publish, no cast load. The widget update still
+         * fires because it's already on the user's launcher and would
+         * otherwise sit on the stale outfit.
+         */
+        private const val KEY_SILENT_REFRESH = "silent_refresh"
+
+        /**
+         * Min staleness before app-open triggers a silent refresh — anything
+         * within the hour is "still good enough", matches CachingWeatherRepository's
+         * own 1h TTL so we don't burn an Open-Meteo call just to read the
+         * same bundle out of the in-memory cache.
+         */
+        val SILENT_REFRESH_MIN_AGE: Duration = Duration.ofHours(1)
+
         fun enqueueOneShot(
             context: Context,
             force: Boolean = false,
@@ -1393,6 +1451,80 @@ class FetchAndNotifyWorker(
                     ExistingWorkPolicy.REPLACE,
                     request,
                 )
+        }
+
+        /**
+         * Opportunistic refresh fired on app open when the cached insight is
+         * older than [SILENT_REFRESH_MIN_AGE]. Runs the full fetch + cache
+         * pipeline but skips notification, TTS, MQTT, and cast — the Today
+         * screen re-renders silently when the new snapshot lands in
+         * [InsightCache.thisPeriod]. KEEP so config-change retriggers on the
+         * same app-open coalesce into the one in-flight run.
+         *
+         * The period is resolved inside the worker via [currentPeriodForSchedule]
+         * so we refresh whichever window the user is *currently* in — not
+         * whichever window a previously cached snapshot happens to label
+         * itself as. This corrects the slot when an alarm was missed and the
+         * cache crossed a period boundary while stale.
+         */
+        fun enqueueSilentRefresh(context: Context) {
+            val constraints = Constraints.Builder()
+                .setRequiredNetworkType(NetworkType.CONNECTED)
+                .build()
+
+            val request = OneTimeWorkRequestBuilder<FetchAndNotifyWorker>()
+                .setConstraints(constraints)
+                .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, 10, TimeUnit.SECONDS)
+                .setInputData(
+                    workDataOf(
+                        KEY_SILENT_REFRESH to true,
+                        KEY_REQUESTED_EPOCH_DAY to LocalDate.now().toEpochDay(),
+                    )
+                )
+                .build()
+
+            WorkManager.getInstance(context)
+                .enqueueUniqueWork(
+                    UNIQUE_WORK_NAME_SILENT,
+                    ExistingWorkPolicy.KEEP,
+                    request,
+                )
+        }
+
+        /**
+         * App-open freshness predicate: true when [snapshot] is non-null and
+         * its [ForecastSnapshot.generatedAt] is at least [SILENT_REFRESH_MIN_AGE]
+         * before [now]. Null snapshot returns false — the app hasn't
+         * successfully fetched yet, so there's nothing user-visible to
+         * silently replace (the alarm or onboarding flow drives the first
+         * fetch).
+         */
+        fun shouldSilentlyRefresh(snapshot: ForecastSnapshot?, now: Instant): Boolean {
+            if (snapshot == null) return false
+            return Duration.between(snapshot.generatedAt, now) >= SILENT_REFRESH_MIN_AGE
+        }
+
+        /**
+         * The 12-hour window we should refresh for *right now*, based on the
+         * user's schedule and wall-clock time. Mirrors the period selection
+         * the Today screen's manual Refresh button uses so a silent refresh
+         * lands in the same slot the user would otherwise have to tap to
+         * regenerate. Returns TODAY whenever tonight delivery is disabled —
+         * the tonight slot is off, so there's nothing useful to refresh there.
+         */
+        fun currentPeriodForSchedule(
+            prefs: UserPreferences,
+            now: LocalTime = LocalTime.now(),
+        ): ForecastPeriod {
+            if (!prefs.tonightEnabled) return ForecastPeriod.TODAY
+            val morning = prefs.schedule.time
+            val tonight = prefs.tonightSchedule.time
+            val inTonightWindow = if (tonight > morning) {
+                now >= tonight || now < morning
+            } else {
+                now >= tonight && now < morning
+            }
+            return if (inTonightWindow) ForecastPeriod.TONIGHT else ForecastPeriod.TODAY
         }
     }
 }

--- a/app/src/test/kotlin/app/clothescast/work/SilentRefreshFreshnessTest.kt
+++ b/app/src/test/kotlin/app/clothescast/work/SilentRefreshFreshnessTest.kt
@@ -1,0 +1,133 @@
+package app.clothescast.work
+
+import app.clothescast.core.domain.model.ClothesFormat
+import app.clothescast.core.domain.model.ClothesMentionMode
+import app.clothescast.core.domain.model.ClothesRule
+import app.clothescast.core.domain.model.DailyForecast
+import app.clothescast.core.domain.model.DeliveryMode
+import app.clothescast.core.domain.model.DistanceUnit
+import app.clothescast.core.domain.model.ForecastPeriod
+import app.clothescast.core.domain.model.ForecastSnapshot
+import app.clothescast.core.domain.model.Location
+import app.clothescast.core.domain.model.OutfitSuggestion
+import app.clothescast.core.domain.model.RangeFormat
+import app.clothescast.core.domain.model.Schedule
+import app.clothescast.core.domain.model.TemperatureUnit
+import app.clothescast.core.domain.model.UserPreferences
+import app.clothescast.core.domain.model.WeatherCondition
+import app.clothescast.core.domain.repository.ForecastBundle
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalTime
+import java.time.ZoneId
+
+/**
+ * Drives the app-open opportunistic-refresh decision used by
+ * [app.clothescast.MainActivity.onStart]. The predicate has to fail closed in
+ * the no-cache case (nothing to silently replace) and only kick a fresh fetch
+ * once the stored snapshot's age has crossed the documented threshold —
+ * otherwise routine app re-opens would burn Open-Meteo calls (and the
+ * Gemini-keyed TTS budget on a forced-refresh equivalent).
+ */
+class SilentRefreshFreshnessTest {
+    private val now = Instant.parse("2026-04-25T09:00:00Z")
+    private val today = LocalDate.of(2026, 4, 25)
+    private val yesterday = today.minusDays(1)
+
+    private fun dailyFor(date: LocalDate) = DailyForecast(
+        date = date,
+        temperatureMinC = 10.0,
+        temperatureMaxC = 18.0,
+        feelsLikeMinC = 9.0,
+        feelsLikeMaxC = 17.0,
+        precipitationProbabilityMaxPct = 0.0,
+        precipitationMmTotal = 0.0,
+        condition = WeatherCondition.CLEAR,
+        hourly = emptyList(),
+    )
+
+    private fun snapshotGeneratedAt(generatedAt: Instant) = ForecastSnapshot(
+        bundle = ForecastBundle(
+            today = dailyFor(today),
+            yesterday = dailyFor(yesterday),
+            forecastZone = ZoneId.of("UTC"),
+        ),
+        events = emptyList(),
+        location = Location(latitude = 51.5, longitude = -0.1, displayName = "London"),
+        period = ForecastPeriod.TODAY,
+        generatedAt = generatedAt,
+    )
+
+    @Test
+    fun `null snapshot does not trigger a silent refresh`() {
+        FetchAndNotifyWorker.shouldSilentlyRefresh(snapshot = null, now = now) shouldBe false
+    }
+
+    @Test
+    fun `snapshot just under the staleness threshold stays put`() {
+        val justBefore = now.minus(FetchAndNotifyWorker.SILENT_REFRESH_MIN_AGE).plusSeconds(1)
+        FetchAndNotifyWorker.shouldSilentlyRefresh(snapshotGeneratedAt(justBefore), now) shouldBe false
+    }
+
+    @Test
+    fun `snapshot exactly at the staleness threshold refreshes`() {
+        val atThreshold = now.minus(FetchAndNotifyWorker.SILENT_REFRESH_MIN_AGE)
+        FetchAndNotifyWorker.shouldSilentlyRefresh(snapshotGeneratedAt(atThreshold), now) shouldBe true
+    }
+
+    @Test
+    fun `snapshot well past the staleness threshold refreshes`() {
+        val yesterdayMorning = now.minusSeconds(24 * 3600)
+        FetchAndNotifyWorker.shouldSilentlyRefresh(snapshotGeneratedAt(yesterdayMorning), now) shouldBe true
+    }
+
+    private val zone = ZoneId.of("UTC")
+    private val basePrefs = UserPreferences(
+        schedule = Schedule(time = LocalTime.of(7, 0), days = Schedule.EVERY_DAY, zoneId = zone),
+        tonightSchedule = Schedule(time = LocalTime.of(19, 0), days = Schedule.EVERY_DAY, zoneId = zone),
+        deliveryMode = DeliveryMode.NOTIFICATION_ONLY,
+        temperatureUnit = TemperatureUnit.CELSIUS,
+        distanceUnit = DistanceUnit.KILOMETERS,
+        clothesRules = ClothesRule.DEFAULTS,
+        defaultBottom = OutfitSuggestion.Bottom.LONG_PANTS,
+        defaultTop = OutfitSuggestion.Top.TSHIRT,
+        clothesMentionMode = ClothesMentionMode.ALWAYS,
+        rangeFormat = RangeFormat.DEGREES,
+        clothesFormat = ClothesFormat.ITEMS,
+        deltaThresholdC = 3.0,
+        tonightEnabled = true,
+    )
+
+    @Test
+    fun `morning inside daytime window picks TODAY`() {
+        val prefs = basePrefs
+        FetchAndNotifyWorker.currentPeriodForSchedule(prefs, LocalTime.of(9, 0)) shouldBe ForecastPeriod.TODAY
+    }
+
+    @Test
+    fun `evening inside tonight window picks TONIGHT`() {
+        val prefs = basePrefs
+        FetchAndNotifyWorker.currentPeriodForSchedule(prefs, LocalTime.of(21, 0)) shouldBe ForecastPeriod.TONIGHT
+    }
+
+    @Test
+    fun `after midnight before morning still picks TONIGHT`() {
+        // The tonight window wraps midnight (19:00 inclusive → 07:00 exclusive)
+        // — 02:00 lands inside it, so the cached snapshot stays in the tonight
+        // slot until the morning alarm fires.
+        val prefs = basePrefs
+        FetchAndNotifyWorker.currentPeriodForSchedule(prefs, LocalTime.of(2, 0)) shouldBe ForecastPeriod.TONIGHT
+    }
+
+    @Test
+    fun `tonight disabled always picks TODAY regardless of time`() {
+        // The tonight slot is off, so refreshing it would never surface
+        // anywhere — anchor to TODAY so the silent refresh updates the only
+        // slot the user can see.
+        val prefs = basePrefs.copy(tonightEnabled = false)
+        FetchAndNotifyWorker.currentPeriodForSchedule(prefs, LocalTime.of(21, 0)) shouldBe ForecastPeriod.TODAY
+        FetchAndNotifyWorker.currentPeriodForSchedule(prefs, LocalTime.of(2, 0)) shouldBe ForecastPeriod.TODAY
+    }
+}


### PR DESCRIPTION
## Summary

Implements the opportunistic auto-refresh TODO that previously lived next
to the same-day cache short-circuit in `FetchAndNotifyWorker` — so the
Today screen catches up on the latest forecast without the user having
to tap Refresh, while staying silent (no notification, no TTS, no MQTT
publish, no cast load, no severe-alert re-buzz).

## How it's wired

- **Trigger**: `MainActivity.onStart` reads the `THIS_PERIOD` snapshot's
  `generatedAt`, compares against `SILENT_REFRESH_MIN_AGE` (1h, matching
  `CachingWeatherRepository`'s own in-memory TTL so a sub-1h re-fetch
  wouldn't hit the network anyway), and enqueues a unique-named
  WorkManager job when stale.
- **Period resolution**: the worker decides on the refresh window itself
  via `currentPeriodForSchedule`, applying the same wall-clock vs.
  user-schedule logic the manual Refresh button uses
  (`TodayScreen.kt:2452`). So a cache stuck in the wrong window after a
  missed alarm (cached `TONIGHT` carried into morning, or vice versa)
  gets corrected to the current window on the next open, not
  perpetuated. Tonight-disabled anchors to `TODAY` regardless of time so
  we don't refresh a slot the user can't see.
- **Dedup**: New `UNIQUE_WORK_NAME_SILENT` with `ExistingWorkPolicy.KEEP`
  so config-change re-fires of `onStart` (rotation, returning from a
  permission dialog) coalesce into the one in-flight run.
- **Null cache fails closed**: nothing to silently replace — the alarm /
  onboarding flow is the right place to handle the never-fetched case.
- **Worker side**: a single `KEY_SILENT_REFRESH` flag. The run goes
  through the same fetch + snapshot + paired-insight + recordDailyHistory
  path as a force refresh, just skipping the `deliver()` fan-out **and**
  the severe-alert re-emission at the end so the Today screen
  re-renders off the new `InsightCache` state without anything
  user-visible firing on top. Severe alerts are gated because
  `WeatherAlertNotifier` uses a stable ID per `(event, onset)` without
  `setOnlyAlertOnce`: re-issuing the morning alarm's already-posted
  alert from every silent refresh would re-fire its HUN sound / banner
  on each app open with a stale cache. New severe alerts still surface
  on the next scheduled alarm — same coverage as before this PR.
- **Telemetry**: silent runs are suppressed from `daily_refresh` outcomes
  (same treatment as the cache-only location path) so the success-rate
  dashboard isn't skewed by runs the user never perceived as a delivery.

## Privacy

No change to what we send off-device — the silent path makes the same
Open-Meteo request the morning alarm and the manual Refresh button
already do. No new fields are forwarded, no new endpoints called.

## Test plan

- [x] New `SilentRefreshFreshnessTest` covers `shouldSilentlyRefresh`
  (null snapshot, just-under threshold, exactly-at threshold,
  well-past threshold) and `currentPeriodForSchedule` (daytime,
  evening, after-midnight wrap, tonight-disabled).
- [x] `./gradlew :app:testDebugUnitTest` green locally.
- [x] `./gradlew :app:assembleDebug` green locally.
- [x] `./gradlew :core:domain:test :core:data:test` green locally.
- [ ] Manual: install on device, leave the app overnight (or backdate the
  cache via Settings → Clear cache + an old alarm fire), reopen — Today
  page should re-render with a fresh `generatedAt` within a few seconds,
  no notification or chime.
- [ ] Manual: open, rotate the device quickly — confirm only one silent
  worker fires (KEEP dedup).
- [ ] Manual: open the app within an hour of the last fetch — confirm
  no worker enqueues (check Logcat for `Silent refresh updated cache`
  absence).
- [ ] Manual: cache a `TONIGHT` snapshot, then sleep through the morning
  alarm (skip wifi) and open the app at 9am — silent refresh should
  land in the `TODAY` slot, not perpetuate `TONIGHT`.

https://claude.ai/code/session_01KosAGPrHx8o5om6JG82kAS