### PR TITLE
test: cover styleDirectiveFor's TtsStyle → directive mapping directly

### DIFF
--- a/core/data/src/test/kotlin/app/clothescast/core/data/tts/GeminiTtsClientTest.kt
+++ b/core/data/src/test/kotlin/app/clothescast/core/data/tts/GeminiTtsClientTest.kt
@@ -614,6 +614,62 @@ class GeminiTtsClientTest {
     }
 
     @Test
+    fun `styleDirectiveFor maps every TtsStyle to its directive constant`() {
+        // Direct unit test of the pure `when` mapping. The integration-style
+        // test above (`request body uses each character-register directive
+        // for the matching TtsStyle`) exercises this through the full HTTP
+        // path; this one pins each arm without spinning up an HttpClient so
+        // a broken mapping fails fast and points at the right function.
+        //
+        // The map's keys double as an exhaustiveness check: when a new
+        // TtsStyle is added, the `when` compile error in styleDirectiveFor
+        // fires first, but if someone defaults the new arm to a
+        // placeholder the `expected.keys shouldBe TtsStyle.entries.toSet()`
+        // assertion below surfaces the gap.
+        val expected: Map<TtsStyle, String> = mapOf(
+            TtsStyle.WEATHER_FORECASTER to GEMINI_TTS_STYLE_DIRECTIVE_WEATHER_FORECASTER,
+            TtsStyle.SCIENCE_TEACHER to GEMINI_TTS_STYLE_DIRECTIVE_SCIENCE_TEACHER,
+            TtsStyle.HISTORIAN to GEMINI_TTS_STYLE_DIRECTIVE_HISTORIAN,
+            TtsStyle.SPORTSCASTER to GEMINI_TTS_STYLE_DIRECTIVE_SPORTSCASTER,
+            TtsStyle.STADIUM_ANNOUNCER to GEMINI_TTS_STYLE_DIRECTIVE_STADIUM_ANNOUNCER,
+            TtsStyle.STORYTELLER to GEMINI_TTS_STYLE_DIRECTIVE_STORYTELLER,
+            TtsStyle.FITNESS_INSTRUCTOR to GEMINI_TTS_STYLE_DIRECTIVE_FITNESS_INSTRUCTOR,
+            TtsStyle.MORNING_PRESENTER to GEMINI_TTS_STYLE_DIRECTIVE_MORNING_PRESENTER,
+            TtsStyle.PIRATE to GEMINI_TTS_STYLE_DIRECTIVE_PIRATE,
+            TtsStyle.COWBOY to GEMINI_TTS_STYLE_DIRECTIVE_COWBOY,
+            TtsStyle.SCIFI_NARRATOR to GEMINI_TTS_STYLE_DIRECTIVE_SCIFI_NARRATOR,
+            TtsStyle.FATHER_CHRISTMAS to GEMINI_TTS_STYLE_DIRECTIVE_FATHER_CHRISTMAS,
+            TtsStyle.SPOOKY_NARRATOR to GEMINI_TTS_STYLE_DIRECTIVE_SPOOKY_NARRATOR,
+            TtsStyle.NEW_YEARS_HOST to GEMINI_TTS_STYLE_DIRECTIVE_NEW_YEARS_HOST,
+            TtsStyle.LEPRECHAUN to GEMINI_TTS_STYLE_DIRECTIVE_LEPRECHAUN,
+            TtsStyle.KING to GEMINI_TTS_STYLE_DIRECTIVE_KING,
+            TtsStyle.QUEEN to GEMINI_TTS_STYLE_DIRECTIVE_QUEEN,
+            TtsStyle.PRESIDENT to GEMINI_TTS_STYLE_DIRECTIVE_PRESIDENT,
+        )
+
+        expected.keys shouldBe TtsStyle.entries.toSet()
+
+        for ((style, directive) in expected) {
+            withClue("style=$style") {
+                styleDirectiveFor(style) shouldBe directive
+            }
+        }
+    }
+
+    @Test
+    fun `styleDirectiveFor returns the B2 weather-forecaster variant for WEATHER_FORECASTER`() {
+        // Pin the WEATHER_FORECASTER arm on the B2 (no-register) directive
+        // specifically — directiveFor() upgrades en-AU to the _REGISTER
+        // variant, but styleDirectiveFor() itself is locale-agnostic and
+        // must return the bare B2 wording so that routing decision stays
+        // in directiveFor where the per-locale comment lives.
+        val directive = styleDirectiveFor(TtsStyle.WEATHER_FORECASTER)
+
+        directive shouldBe GEMINI_TTS_STYLE_DIRECTIVE_WEATHER_FORECASTER
+        directive.shouldNotContain("standard variety, not a regional dialect")
+    }
+
+    @Test
     fun `throws GeminiTtsEmptyResponseException when response has no inline audio`() = runTest {
         val client = GeminiTtsClient(
             httpClient = mockClient("""{"candidates":[]}"""),


### PR DESCRIPTION
## Summary

`styleDirectiveFor` in `GeminiTtsClient.kt:190` is the simple `when` that maps each `TtsStyle` to a directive constant. It was only exercised indirectly via the `request body uses each character-register directive…` test that goes through the full HTTP path with `MockEngine`. This adds fast, isolated direct tests so a broken arm fails closer to the bug.

Two new tests in `core/data/src/test/.../GeminiTtsClientTest.kt`:

1. **`styleDirectiveFor maps every TtsStyle to its directive constant`** — builds a `Map<TtsStyle, String>` of expected `TtsStyle → constant` pairs, then asserts each call returns the matching constant. The map's keys are compared against `TtsStyle.entries.toSet()` as an exhaustiveness reminder (Kotlin's exhaustive `when` already forbids missing arms in `styleDirectiveFor`, but if someone routed a new value to a placeholder constant the test would surface the gap).
2. **`styleDirectiveFor returns the B2 weather-forecaster variant for WEATHER_FORECASTER`** — pins `WEATHER_FORECASTER` on `GEMINI_TTS_STYLE_DIRECTIVE_WEATHER_FORECASTER` (the no-register B2 variant) specifically, so the per-locale upgrade to the `_REGISTER` variant for en-AU stays in `directiveFor` (where the routing comment lives) rather than leaking into `styleDirectiveFor`.

Both tests are pure-function checks — no `HttpClient`, no `runTest`, no mock engine — so they run instantly.

## Test plan

- [x] `cd core && ../gradlew :core:data:test --tests "app.clothescast.core.data.tts.GeminiTtsClientTest"` — all 25 tests pass, including the two new ones.
- [ ] CI `JVM unit tests` job green on the pushed commit.

## Privacy

No change to what leaves the device — test-only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NqDKj6ypYfpqRqjwWv3WYz)_