### PR TITLE
test: cover LocationResolver permission, cache, and fallback paths

### DIFF
--- a/app/src/test/kotlin/app/clothescast/location/LocationResolverTest.kt
+++ b/app/src/test/kotlin/app/clothescast/location/LocationResolverTest.kt
@@ -1,0 +1,156 @@
+package app.clothescast.location
+
+import android.Manifest
+import android.app.Application
+import android.content.Context
+import android.location.Location as AndroidLocation
+import android.location.LocationManager
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.runBlocking
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+
+/**
+ * Exercises [LocationResolver]'s deterministic paths through Robolectric's
+ * [LocationManager] shadow: permission denial, fresh-cache shortcut, the
+ * NETWORK→PASSIVE fallback for [LocationManager.getLastKnownLocation], and the
+ * difference between [LocationResolver.resolve] (stale fallback allowed) and
+ * [LocationResolver.resolveFresh] (stale treated as unavailable).
+ *
+ * Tests that need a live single-update to *not* arrive disable the NETWORK
+ * provider so [LocationResolver]'s inner `requestSingle()` short-circuits
+ * before registering a listener — that keeps the suspension free of looper
+ * timing and the timeout path entirely deterministic.
+ */
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [33])
+class LocationResolverTest {
+    private val application: Application = ApplicationProvider.getApplicationContext()
+    private val context: Context = application
+    private val locationManager: LocationManager =
+        context.getSystemService(Context.LOCATION_SERVICE) as LocationManager
+
+    @Before
+    fun grantLocationPermissions() {
+        // Robolectric auto-grants manifest-declared permissions, but per-Application
+        // state leaks across tests, so the "denied" case revokes and any later test
+        // would start with permission missing. Re-grant in setup.
+        shadowOf(application).grantPermissions(
+            Manifest.permission.ACCESS_COARSE_LOCATION,
+            Manifest.permission.ACCESS_BACKGROUND_LOCATION,
+        )
+        shadowOf(locationManager).setProviderEnabled(LocationManager.NETWORK_PROVIDER, true)
+        shadowOf(locationManager).setProviderEnabled(LocationManager.PASSIVE_PROVIDER, true)
+    }
+
+    @Test
+    fun `returns null when coarse location is not granted`() {
+        shadowOf(application).denyPermissions(Manifest.permission.ACCESS_COARSE_LOCATION)
+        runBlocking {
+            resolver().resolve() shouldBe null
+            resolver().resolveFresh(maxAgeMillis = 60_000L) shouldBe null
+        }
+    }
+
+    @Test
+    fun `returns the fresh NETWORK last-known fix without firing a live request`() {
+        shadowOf(locationManager).setLastKnownLocation(
+            LocationManager.NETWORK_PROVIDER,
+            androidLocation(LocationManager.NETWORK_PROVIDER, lat = 51.5, lon = -0.1, ageMs = 5_000L),
+        )
+        // Disabling the provider after seeding last-known would have masked a bug
+        // where the resolver requests a live update even with a fresh cache — leave
+        // it enabled and rely on the fresh-cache early return.
+        val resolved = runBlocking { resolver().resolve() }
+        resolved?.latitude shouldBe 51.5
+        resolved?.longitude shouldBe -0.1
+        resolved?.displayName shouldBe "Device location"
+    }
+
+    @Test
+    fun `falls back to PASSIVE last-known when NETWORK provider is disabled`() {
+        shadowOf(locationManager).setProviderEnabled(LocationManager.NETWORK_PROVIDER, false)
+        shadowOf(locationManager).setLastKnownLocation(
+            LocationManager.PASSIVE_PROVIDER,
+            androidLocation(LocationManager.PASSIVE_PROVIDER, lat = 40.7, lon = -74.0, ageMs = 5_000L),
+        )
+        val resolved = runBlocking { resolver().resolve() }
+        resolved?.latitude shouldBe 40.7
+        resolved?.longitude shouldBe -74.0
+    }
+
+    @Test
+    fun `resolve falls back to the stale cached fix when a live request cannot fire`() {
+        // NETWORK disabled → requestSingle() short-circuits to null; with
+        // allowStaleFallback the cached PASSIVE value still wins even though it's
+        // older than the default 1h maxAgeMillis.
+        shadowOf(locationManager).setProviderEnabled(LocationManager.NETWORK_PROVIDER, false)
+        val staleAge = 2 * 60 * 60 * 1000L
+        shadowOf(locationManager).setLastKnownLocation(
+            LocationManager.PASSIVE_PROVIDER,
+            androidLocation(LocationManager.PASSIVE_PROVIDER, lat = 35.0, lon = 139.0, ageMs = staleAge),
+        )
+        val resolved = runBlocking { resolver().resolve() }
+        resolved?.latitude shouldBe 35.0
+        resolved?.longitude shouldBe 139.0
+    }
+
+    @Test
+    fun `resolveFresh returns null when only a stale cached fix is available`() {
+        // Same shape as the resolve() test above, but resolveFresh's contract
+        // forbids serving a stale fix: the live request can't fire, the cache is
+        // too old, the function must surface null so the caller can fail open
+        // (e.g. the at-home TTS gate falls back to speaking).
+        shadowOf(locationManager).setProviderEnabled(LocationManager.NETWORK_PROVIDER, false)
+        shadowOf(locationManager).setLastKnownLocation(
+            LocationManager.PASSIVE_PROVIDER,
+            androidLocation(LocationManager.PASSIVE_PROVIDER, lat = 35.0, lon = 139.0, ageMs = 10 * 60 * 1000L),
+        )
+        runBlocking {
+            resolver().resolveFresh(maxAgeMillis = 60_000L) shouldBe null
+        }
+    }
+
+    @Test
+    fun `returns null when no cached fix exists and no live request can fire`() {
+        shadowOf(locationManager).setProviderEnabled(LocationManager.NETWORK_PROVIDER, false)
+        shadowOf(locationManager).setProviderEnabled(LocationManager.PASSIVE_PROVIDER, false)
+        runBlocking {
+            resolver().resolve() shouldBe null
+            resolver().resolveFresh(maxAgeMillis = 60_000L) shouldBe null
+        }
+    }
+
+    @Test
+    fun `still resolves when the background grant is missing but coarse is granted`() {
+        // hasBackgroundPermission() only logs a warning when missing; the actual
+        // gate is hasCoarsePermission(). A user who's granted "while in use" but
+        // not "all the time" should still see a foreground resolve succeed —
+        // important for MainActivity's "Use my current location" home-pin capture.
+        shadowOf(application).denyPermissions(Manifest.permission.ACCESS_BACKGROUND_LOCATION)
+        shadowOf(locationManager).setLastKnownLocation(
+            LocationManager.NETWORK_PROVIDER,
+            androidLocation(LocationManager.NETWORK_PROVIDER, lat = 48.8, lon = 2.35, ageMs = 5_000L),
+        )
+        val resolved = runBlocking { resolver().resolve() }
+        resolved?.latitude shouldBe 48.8
+        resolved?.longitude shouldBe 2.35
+    }
+
+    private fun resolver(): LocationResolver = LocationResolver(
+        context = context,
+        timeoutMillis = 50L,
+    )
+
+    private fun androidLocation(provider: String, lat: Double, lon: Double, ageMs: Long): AndroidLocation =
+        AndroidLocation(provider).apply {
+            latitude = lat
+            longitude = lon
+            time = System.currentTimeMillis() - ageMs
+        }
+}


### PR DESCRIPTION
## Summary

Adds a Robolectric-backed `LocationResolverTest` covering the deterministic, listener-free paths of `app/src/main/kotlin/app/clothescast/location/LocationResolver.kt`. Until now this class had no unit tests despite being the firewall the daily Worker depends on for "never throw, never crash, always return null on failure."

Covered branches:

| Path | Test |
|---|---|
| `ACCESS_COARSE_LOCATION` denied → null | `returns null when coarse location is not granted` |
| Fresh cached fix on `NETWORK_PROVIDER` → returned without firing a live request | `returns the fresh NETWORK last-known fix without firing a live request` |
| `NETWORK_PROVIDER` disabled → `lastKnown()` falls back to `PASSIVE_PROVIDER` | `falls back to PASSIVE last-known when NETWORK provider is disabled` |
| Stale cached fix + live request can't fire + `allowStaleFallback=true` → cached value returned | `resolve falls back to the stale cached fix when a live request cannot fire` |
| Stale cached fix + live request can't fire + `allowStaleFallback=false` (`resolveFresh`) → null | `resolveFresh returns null when only a stale cached fix is available` |
| No cached fix + no provider available → null | `returns null when no cached fix exists and no live request can fire` |
| Coarse granted, background revoked → still resolves (background is a warn, not a gate) | `still resolves when the background grant is missing but coarse is granted` |

Each test disables `NETWORK_PROVIDER` whenever it wants to avoid a live `requestSingleUpdate` — `LocationResolver.requestSingle()` short-circuits on the `isProviderEnabled` check before registering a `LocationListener`, so the suspension is free of shadow-looper timing and the result is deterministic.

The listener-driven paths (live update arrives, `withTimeoutOrNull` expires with a pending listener) are out of scope here: Robolectric's coverage of the deprecated `requestSingleUpdate` API is fiddly enough that adding it would have meant more test infrastructure than the bug-risk justifies. Worth a follow-up if a regression slips through the current set.

Constructor `timeoutMillis` is set to 50ms in tests so the no-cache-and-no-live case completes promptly instead of padding each invocation by the production 10s default.

## Notes

- Branch name is `claude/shouldspeak-unit-tests-Plk13` from an earlier assignment, but the actual change is to `LocationResolver` — `ShouldSpeak` and `FallbackRange` already had comprehensive test files on `main`, so no work was needed there.
- No privacy-relevant changes (test code only; never ships in the APK).
- `test:` prefix means CI filters this commit out of the Play "What's new" changelog.

## Test plan

- [x] `./gradlew :app:testDebugUnitTest --tests "app.clothescast.location.LocationResolverTest"` passes locally (7/7, ~9s of which ~9s is Robolectric cold start; subsequent tests average ~40ms each)
- [ ] CI green on `JVM unit tests` job

---
_Generated by [Claude Code](https://claude.ai/code/session_01UXwYNsrSUa1UkoXurJMjGx)_