### PR TITLE
test: cover FetchAndNotifyWorker's gate and enqueue contracts

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -391,6 +391,9 @@ dependencies {
     testImplementation(libs.kotest.assertions.core)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.androidx.datastore.preferences.core)
+    // TestListenableWorkerBuilder + WorkManagerTestInitHelper for unit-testing
+    // FetchAndNotifyWorker's doWork() path and its enqueue companion methods.
+    testImplementation(libs.androidx.work.testing)
     // SettingsViewModelTest stubs the geocoding client with a Ktor MockEngine so the
     // tests don't need network. Same library that :core:data already uses.
     testImplementation(libs.ktor.client.mock)

--- a/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
@@ -1270,7 +1270,7 @@ class FetchAndNotifyWorker(
          * the run reached `Result.success()` without delivering anything, so
          * the daily_refresh event should be suppressed for it.
          */
-        private const val KEY_SKIP_TELEMETRY = "skip_telemetry"
+        internal const val KEY_SKIP_TELEMETRY = "skip_telemetry"
 
         // Cap unhandled-error detail so the "Show details" pane stays readable.
         private const val MAX_DETAIL_LEN = 240
@@ -1290,7 +1290,7 @@ class FetchAndNotifyWorker(
         private const val EARTH_RADIUS_KM = 6371.0
 
         /** Set true via [enqueueOneShot] when the user explicitly taps Refresh. */
-        private const val KEY_FORCE_REFRESH = "force_refresh"
+        internal const val KEY_FORCE_REFRESH = "force_refresh"
 
         /**
          * Wall-clock millis at which the alarm fired. Set by [AlarmReceiver] for
@@ -1346,10 +1346,10 @@ class FetchAndNotifyWorker(
          * to drop a stale force flag if the worker only runs after midnight (e.g. a
          * tap at 23:59 that retried offline until 00:05).
          */
-        private const val KEY_REQUESTED_EPOCH_DAY = "requested_epoch_day"
+        internal const val KEY_REQUESTED_EPOCH_DAY = "requested_epoch_day"
 
         /** Which slice of the day this run is for; defaults to TODAY when absent. */
-        private const val KEY_PERIOD = "period"
+        internal const val KEY_PERIOD = "period"
 
         /**
          * Set true via [enqueueLocationCacheRefresh] when the user toggles
@@ -1358,7 +1358,7 @@ class FetchAndNotifyWorker(
          * doesn't get a duplicate notification at e.g. 10am after the
          * morning run already fired at 7am.
          */
-        private const val KEY_CACHE_LOCATION_ONLY = "cache_location_only"
+        internal const val KEY_CACHE_LOCATION_ONLY = "cache_location_only"
 
         /**
          * Set true via [enqueueSilentRefresh] for the opportunistic app-open
@@ -1368,7 +1368,7 @@ class FetchAndNotifyWorker(
          * fires because it's already on the user's launcher and would
          * otherwise sit on the stale outfit.
          */
-        private const val KEY_SILENT_REFRESH = "silent_refresh"
+        internal const val KEY_SILENT_REFRESH = "silent_refresh"
 
         /**
          * Min staleness before app-open triggers a silent refresh — anything

--- a/app/src/test/kotlin/app/clothescast/work/FetchAndNotifyWorkerTest.kt
+++ b/app/src/test/kotlin/app/clothescast/work/FetchAndNotifyWorkerTest.kt
@@ -1,0 +1,263 @@
+package app.clothescast.work
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.work.Configuration
+import androidx.work.ListenableWorker.Result
+import androidx.work.WorkInfo
+import androidx.work.WorkManager
+import androidx.work.testing.SynchronousExecutor
+import androidx.work.testing.TestListenableWorkerBuilder
+import androidx.work.testing.WorkManagerTestInitHelper
+import androidx.work.workDataOf
+import app.clothescast.ClothesCastApplication
+import app.clothescast.core.domain.model.ForecastPeriod
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.longs.shouldBeGreaterThan
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.runBlocking
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import java.time.LocalDate
+
+/**
+ * Drives the [FetchAndNotifyWorker]'s `doWork()` decision tree along the
+ * branches reachable without network or LocationManager — gate behaviour,
+ * input-data parsing, and the terminal-result stamping contract — plus the
+ * companion enqueue helpers' unique-work-name routing.
+ *
+ * The deep-path scenarios (forecast fetch, insight generation, notification +
+ * TTS + MQTT + cast fan-out) intentionally aren't covered here: they pull in
+ * the upstream Open-Meteo API, a real LocationResolver, the on-device TTS
+ * engine, and the MQTT broker, none of which are realistic to stand up under
+ * unit tests. The pre-existing branch coverage (DeliveryGatesTest,
+ * InsightFormatterTest, InsightNotifierTest, MqttPublisherTest, …) carries
+ * those concerns; this class pins the worker's *own* decisions.
+ *
+ * Setup clears the user's location and disables tonight delivery so each
+ * `doWork()` call lands deterministically on a no-network branch. The
+ * WorkManager test driver is wired with a [SynchronousExecutor] so the
+ * `NetworkType.CONNECTED` constraint keeps the enqueue assertions in
+ * `ENQUEUED` state (the worker never actually runs against the network).
+ */
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [33])
+class FetchAndNotifyWorkerTest {
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val app = context.applicationContext as ClothesCastApplication
+
+    @Before
+    fun resetPrefsAndWorkManager() {
+        runBlocking {
+            app.settingsRepository.setUseDeviceLocation(false)
+            app.settingsRepository.clearLocation()
+            app.settingsRepository.setTonightEnabled(false)
+        }
+        // SynchronousExecutor keeps WorkManager off the real background
+        // thread pool — combined with the NetworkType.CONNECTED constraint
+        // the worker's enqueue methods set, enqueued work stays in
+        // ENQUEUED state instead of being dispatched (which would try to
+        // hit Open-Meteo).
+        WorkManagerTestInitHelper.initializeTestWorkManager(
+            context,
+            Configuration.Builder().setExecutor(SynchronousExecutor()).build(),
+        )
+    }
+
+    // --- doWork() branches ----------------------------------------------
+
+    @Test
+    fun `tonight disabled with TONIGHT period returns success with skip_telemetry`() {
+        runBlocking {
+            val worker = TestListenableWorkerBuilder<FetchAndNotifyWorker>(context)
+                .setInputData(workDataOf(FetchAndNotifyWorker.KEY_PERIOD to ForecastPeriod.TONIGHT.name))
+                .build()
+
+            val result = worker.doWork()
+
+            result.shouldBeInstanceOf<Result.Success>()
+            result.outputData.getBoolean(FetchAndNotifyWorker.KEY_SKIP_TELEMETRY, false) shouldBe true
+        }
+    }
+
+    @Test
+    fun `same-day force refresh bypasses the tonight-disabled gate`() {
+        // Force refresh enqueued *today* — the gate is meant to honour the
+        // user's recent tap. Without a saved location the run then falls
+        // through to the no-location failure, which is exactly what proves
+        // the gate was bypassed (otherwise we'd see the skip_telemetry
+        // success path).
+        runBlocking {
+            val today = LocalDate.now().toEpochDay()
+            val worker = TestListenableWorkerBuilder<FetchAndNotifyWorker>(context)
+                .setInputData(
+                    workDataOf(
+                        FetchAndNotifyWorker.KEY_PERIOD to ForecastPeriod.TONIGHT.name,
+                        FetchAndNotifyWorker.KEY_FORCE_REFRESH to true,
+                        FetchAndNotifyWorker.KEY_REQUESTED_EPOCH_DAY to today,
+                    )
+                )
+                .build()
+
+            val result = worker.doWork()
+
+            result.shouldBeInstanceOf<Result.Failure>()
+            result.outputData.getString(FetchAndNotifyWorker.KEY_REASON) shouldBe
+                FetchAndNotifyWorker.REASON_NO_LOCATION
+        }
+    }
+
+    @Test
+    fun `stale force refresh from a previous day is dropped and the tonight gate still fires`() {
+        runBlocking {
+            val yesterday = LocalDate.now().minusDays(1).toEpochDay()
+            val worker = TestListenableWorkerBuilder<FetchAndNotifyWorker>(context)
+                .setInputData(
+                    workDataOf(
+                        FetchAndNotifyWorker.KEY_PERIOD to ForecastPeriod.TONIGHT.name,
+                        FetchAndNotifyWorker.KEY_FORCE_REFRESH to true,
+                        FetchAndNotifyWorker.KEY_REQUESTED_EPOCH_DAY to yesterday,
+                    )
+                )
+                .build()
+
+            val result = worker.doWork()
+
+            result.shouldBeInstanceOf<Result.Success>()
+            result.outputData.getBoolean(FetchAndNotifyWorker.KEY_SKIP_TELEMETRY, false) shouldBe true
+        }
+    }
+
+    @Test
+    fun `missing period defaults to TODAY`() {
+        // No KEY_PERIOD → falls back to TODAY, so the tonight gate doesn't
+        // apply and we land on the no-location failure path. That path
+        // surfacing here pins the default; if the worker silently defaulted
+        // to TONIGHT instead, the gate would short-circuit to success.
+        runBlocking {
+            val worker = TestListenableWorkerBuilder<FetchAndNotifyWorker>(context).build()
+
+            val result = worker.doWork()
+
+            result.shouldBeInstanceOf<Result.Failure>()
+            result.outputData.getString(FetchAndNotifyWorker.KEY_REASON) shouldBe
+                FetchAndNotifyWorker.REASON_NO_LOCATION
+        }
+    }
+
+    @Test
+    fun `invalid period string falls back to TODAY`() {
+        runBlocking {
+            val worker = TestListenableWorkerBuilder<FetchAndNotifyWorker>(context)
+                .setInputData(workDataOf(FetchAndNotifyWorker.KEY_PERIOD to "NOT_A_PERIOD"))
+                .build()
+
+            val result = worker.doWork()
+
+            result.shouldBeInstanceOf<Result.Failure>()
+            result.outputData.getString(FetchAndNotifyWorker.KEY_REASON) shouldBe
+                FetchAndNotifyWorker.REASON_NO_LOCATION
+        }
+    }
+
+    @Test
+    fun `no location yields failure with REASON_NO_LOCATION and a completed_at stamp`() {
+        runBlocking {
+            val before = System.currentTimeMillis()
+            val worker = TestListenableWorkerBuilder<FetchAndNotifyWorker>(context)
+                .setInputData(workDataOf(FetchAndNotifyWorker.KEY_PERIOD to ForecastPeriod.TODAY.name))
+                .build()
+
+            val result = worker.doWork()
+
+            result.shouldBeInstanceOf<Result.Failure>()
+            result.outputData.getString(FetchAndNotifyWorker.KEY_REASON) shouldBe
+                FetchAndNotifyWorker.REASON_NO_LOCATION
+            result.outputData.getLong(FetchAndNotifyWorker.KEY_COMPLETED_AT, 0L) shouldBeGreaterThan
+                before - 1
+        }
+    }
+
+    @Test
+    fun `cache-only refresh returns success even with no fallback location`() {
+        // The cache-only path is meant to be a no-op when there's nothing to
+        // cache — resolveLocation returning null is fine and shouldn't escalate
+        // to the REASON_NO_LOCATION failure that the forecast pipeline does.
+        runBlocking {
+            val before = System.currentTimeMillis()
+            val worker = TestListenableWorkerBuilder<FetchAndNotifyWorker>(context)
+                .setInputData(workDataOf(FetchAndNotifyWorker.KEY_CACHE_LOCATION_ONLY to true))
+                .build()
+
+            val result = worker.doWork()
+
+            result.shouldBeInstanceOf<Result.Success>()
+            // No skip_telemetry on this branch — the cache-only run is filtered
+            // higher up in doWork() via its own `skipTelemetry` local, not via
+            // the output-data flag.
+            result.outputData.getBoolean(FetchAndNotifyWorker.KEY_SKIP_TELEMETRY, false) shouldBe false
+            result.outputData.getLong(FetchAndNotifyWorker.KEY_COMPLETED_AT, 0L) shouldBeGreaterThan
+                before - 1
+        }
+    }
+
+    @Test
+    fun `tonight-disabled success result carries a completed_at stamp`() {
+        runBlocking {
+            val before = System.currentTimeMillis()
+            val worker = TestListenableWorkerBuilder<FetchAndNotifyWorker>(context)
+                .setInputData(workDataOf(FetchAndNotifyWorker.KEY_PERIOD to ForecastPeriod.TONIGHT.name))
+                .build()
+
+            val result = worker.doWork()
+
+            result.shouldBeInstanceOf<Result.Success>()
+            result.outputData.getLong(FetchAndNotifyWorker.KEY_COMPLETED_AT, 0L) shouldBeGreaterThan
+                before - 1
+        }
+    }
+
+    // --- companion enqueue routing --------------------------------------
+
+    @Test
+    fun `enqueueOneShot for TODAY enqueues under the daily unique work name`() {
+        FetchAndNotifyWorker.enqueueOneShot(context, period = ForecastPeriod.TODAY)
+
+        workInfosFor(FetchAndNotifyWorker.UNIQUE_WORK_NAME).map { it.state } shouldContainExactlyInAnyOrder
+            listOf(WorkInfo.State.ENQUEUED)
+        workInfosFor(FetchAndNotifyWorker.UNIQUE_WORK_NAME_TONIGHT) shouldHaveSize 0
+    }
+
+    @Test
+    fun `enqueueOneShot for TONIGHT enqueues under the tonight unique work name`() {
+        FetchAndNotifyWorker.enqueueOneShot(context, period = ForecastPeriod.TONIGHT)
+
+        workInfosFor(FetchAndNotifyWorker.UNIQUE_WORK_NAME_TONIGHT).map { it.state } shouldContainExactlyInAnyOrder
+            listOf(WorkInfo.State.ENQUEUED)
+        workInfosFor(FetchAndNotifyWorker.UNIQUE_WORK_NAME) shouldHaveSize 0
+    }
+
+    @Test
+    fun `enqueueLocationCacheRefresh enqueues under the cache-only unique work name`() {
+        FetchAndNotifyWorker.enqueueLocationCacheRefresh(context)
+
+        workInfosFor(FetchAndNotifyWorker.UNIQUE_WORK_NAME_LOCATION_CACHE).map { it.state } shouldContainExactlyInAnyOrder
+            listOf(WorkInfo.State.ENQUEUED)
+    }
+
+    @Test
+    fun `enqueueSilentRefresh enqueues under the silent unique work name`() {
+        FetchAndNotifyWorker.enqueueSilentRefresh(context)
+
+        workInfosFor(FetchAndNotifyWorker.UNIQUE_WORK_NAME_SILENT).map { it.state } shouldContainExactlyInAnyOrder
+            listOf(WorkInfo.State.ENQUEUED)
+    }
+
+    private fun workInfosFor(name: String): List<WorkInfo> =
+        WorkManager.getInstance(context).getWorkInfosForUniqueWork(name).get()
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -112,6 +112,7 @@ androidx-datastore-preferences = { group = "androidx.datastore", name = "datasto
 androidx-datastore-preferences-core = { group = "androidx.datastore", name = "datastore-preferences-core", version.ref = "datastore" }
 
 androidx-work-runtime-ktx = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "work" }
+androidx-work-testing = { group = "androidx.work", name = "work-testing", version.ref = "work" }
 
 androidx-glance-appwidget = { group = "androidx.glance", name = "glance-appwidget", version.ref = "glance" }
 androidx-glance-material3 = { group = "androidx.glance", name = "glance-material3", version.ref = "glance" }


### PR DESCRIPTION
## Summary

Adds `FetchAndNotifyWorkerTest` with 12 cases exercising the parts of the worker reachable without standing up Open-Meteo, the LocationResolver, or the TTS / MQTT / cast fan-out.

### `doWork()` gates and parsing
- Tonight-disabled with `TONIGHT` input returns success carrying `skip_telemetry`.
- Same-day `force_refresh` bypasses the tonight-disabled gate.
- A stale `force_refresh` from a previous day (`requested_epoch_day != today`) is dropped — the gate still fires.
- Missing and invalid `KEY_PERIOD` values both fall back to `TODAY` (pinned via the no-location failure surfacing, which only happens on the `TODAY` path).
- The no-location branch surfaces `REASON_NO_LOCATION` in the failure's output data.
- Cache-only refreshes return success even without a fallback location.
- Every terminal `Result` is stamped with `KEY_COMPLETED_AT`.

### Companion enqueue routing
- `enqueueOneShot(period = TODAY)` lands under `UNIQUE_WORK_NAME`.
- `enqueueOneShot(period = TONIGHT)` lands under `UNIQUE_WORK_NAME_TONIGHT`.
- `enqueueLocationCacheRefresh` lands under `UNIQUE_WORK_NAME_LOCATION_CACHE`.
- `enqueueSilentRefresh` lands under `UNIQUE_WORK_NAME_SILENT`.

### Mechanics
Tests run through Robolectric (matching the existing alarm tests) so the real `ClothesCastApplication` wires up. The worker itself is driven by `TestListenableWorkerBuilder` for `doWork()` paths and by `WorkManagerTestInitHelper` for the enqueue paths. A `SynchronousExecutor` combined with the worker's `NetworkType.CONNECTED` constraint keeps the enqueue assertions deterministic (work stays `ENQUEUED` rather than running against the real network).

The deeper paths — forecast fetch, insight generation, notification + TTS + MQTT + cast fan-out — intentionally aren't covered here: they pull in Open-Meteo, a real `LocationResolver`, the on-device TTS engine, and an MQTT broker, none of which are realistic to stand up under unit tests. Existing test classes (`DeliveryGatesTest`, `InsightFormatterTest`, `InsightNotifierTest`, `MqttPublisherTest`, …) carry those concerns.

### Production-code change
Visibility-only: six companion-object `KEY_*` constants used for the worker's input/output data flip from `private` to `internal` so the test can build worker input and assert on output without re-deriving their string literals. No runtime behaviour change.

### Build wiring
Adds `androidx.work:work-testing` (same `work` version reference as `work-runtime-ktx`) as a `testImplementation` of `:app` for `TestListenableWorkerBuilder` and `WorkManagerTestInitHelper`.

## Test plan
- [x] `./gradlew :core:domain:test :core:data:test :app:testDebugUnitTest` — all green, including the 12 new cases.
- [x] `./gradlew :app:assembleDebug` — debug APK still builds.

https://claude.ai/code/session_01NNAtWe5u8bvCHYGskmfqHJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01NNAtWe5u8bvCHYGskmfqHJ)_