### PR TITLE
Themed banners for Muslim, Jewish, and Hindu holidays from your calendar

### DIFF
--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/HolidayTheme.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/HolidayTheme.kt
@@ -2998,15 +2998,54 @@ private const val MEXICO_DEAD_WHITE = 0xFFF5F5F5L
 // Synthetic themes used by [FestiveThemes] when the user has opted into
 // calendar-sourced theming and a row arrives carrying [EventKind.PUBLIC_HOLIDAY]
 // or [EventKind.BIRTHDAY]. Generic festive gold/purple for a holiday name we
-// don't recognise (Diwali, Eid, Lunar New Year — catalog gaps), and a confetti
-// yellow/magenta for a detected birthday — gender-neutral, maximum party pop,
-// and visually distinct from every catalog holiday and the generic-holiday
-// fallback above so a "Bob's birthday" in the banner never gets mistaken
-// for a recognised holiday.
+// don't recognise (catalog gaps); religion-specific palettes when the owner
+// account identifies one of Google's religion-keyed holiday calendars
+// (Eid from "Muslim Holidays", Yom Kippur from "Jewish Holidays", Diwali
+// from "Hindu Holidays"); and a confetti yellow/magenta for a detected
+// birthday — gender-neutral, maximum party pop, and visually distinct from
+// every catalog holiday and the generic-holiday fallback above so a "Bob's
+// birthday" in the banner never gets mistaken for a recognised holiday.
 private const val FESTIVE_GOLD = 0xFFD4AF37L
 private const val FESTIVE_PURPLE = 0xFF6A1B9AL
+private const val ISLAMIC_GREEN = 0xFF1B8A4BL
+private const val ISLAMIC_GOLD = 0xFFD4AF37L
+private const val JUDAISM_BLUE = 0xFF0038B8L
+private const val JUDAISM_WHITE = 0xFFFAFAFAL
+private const val HINDU_SAFFRON = 0xFFFF9933L
+private const val HINDU_MAGENTA = 0xFFC2185BL
 private const val BIRTHDAY_YELLOW = 0xFFFFD54FL
 private const val BIRTHDAY_MAGENTA = 0xFFD81B60L
+
+/**
+ * Religion of a calendar-sourced public holiday, inferred from the source
+ * calendar's owner account. Detection is locale-stable: Google localises the
+ * locale prefix (`en.`, `de.`, `fr.`, …) and the event titles, but the
+ * religion key (`judaism`, `islamic`, `hinduism`) stays fixed, so a French
+ * phone seeing "Aïd el-Fitr" still themes green/gold. Region-keyed calendars
+ * (`en.usa`, `en.indian`, `en.australian`) and any non-Google source fall
+ * through to `null` and pick up the generic gold/purple fallback.
+ *
+ * The set is intentionally small. Adding more religions is cheap (one regex
+ * arm + one palette) but each one is a colour-design call, so leave it to a
+ * follow-up when there's a concrete user asking for it.
+ */
+private enum class HolidayReligion { ISLAMIC, JUDAISM, HINDUISM }
+
+private val RELIGION_OWNER_REGEX = Regex(
+    "\\.(judaism|islamic|hinduism)#holiday@group\\.v\\.calendar\\.google\\.com$",
+    RegexOption.IGNORE_CASE,
+)
+
+private fun religionFromOwnerAccount(ownerAccount: String?): HolidayReligion? {
+    if (ownerAccount == null) return null
+    val match = RELIGION_OWNER_REGEX.find(ownerAccount) ?: return null
+    return when (match.groupValues[1].lowercase()) {
+        "islamic" -> HolidayReligion.ISLAMIC
+        "judaism" -> HolidayReligion.JUDAISM
+        "hinduism" -> HolidayReligion.HINDUISM
+        else -> null
+    }
+}
 
 /**
  * Cleans up a calendar-sourced public-holiday title for display in the
@@ -3049,16 +3088,29 @@ fun normalizeCalendarHolidayTitle(raw: String): String =
  * as [CalendarEvent.title].
  */
 object FestiveThemes {
-    fun publicHoliday(title: String): HolidayTheme {
+    fun publicHoliday(title: String, ownerAccount: String? = null): HolidayTheme {
         val display = normalizeCalendarHolidayTitle(title)
+        val religion = religionFromOwnerAccount(ownerAccount)
+        val emoji = when (religion) {
+            HolidayReligion.ISLAMIC -> "🌙"
+            HolidayReligion.JUDAISM -> "✡️"
+            HolidayReligion.HINDUISM -> "🪔"
+            null -> "🎊"
+        }
+        val (top, bottom) = when (religion) {
+            HolidayReligion.ISLAMIC -> ISLAMIC_GREEN to ISLAMIC_GOLD
+            HolidayReligion.JUDAISM -> JUDAISM_BLUE to JUDAISM_WHITE
+            HolidayReligion.HINDUISM -> HINDU_SAFFRON to HINDU_MAGENTA
+            null -> FESTIVE_GOLD to FESTIVE_PURPLE
+        }
         return HolidayTheme(
             id = HolidayId.GENERIC_PUBLIC_HOLIDAY,
             displayNameKey = display,
             bannerTextKey = display,
-            emoji = "🎊",
-            topOverrides = topPaletteAll(FESTIVE_GOLD),
-            bottomOverrides = bottomPaletteAll(FESTIVE_PURPLE),
-            bannerArgb = FESTIVE_GOLD,
+            emoji = emoji,
+            topOverrides = topPaletteAll(top),
+            bottomOverrides = bottomPaletteAll(bottom),
+            bannerArgb = top,
             countries = emptySet(),
             isSynthetic = true,
             displayTitleOverride = display,

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/ThemeForToday.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/ThemeForToday.kt
@@ -57,7 +57,7 @@ class ThemeForToday(
             !holidayResolver.hasCatalogMatch(date, enabledCountries)
         ) {
             events.firstOrNull { it.kind == EventKind.PUBLIC_HOLIDAY }
-                ?.let { listOf(FestiveThemes.publicHoliday(it.title)) }
+                ?.let { listOf(FestiveThemes.publicHoliday(it.title, it.ownerAccount)) }
                 .orEmpty()
         } else {
             emptyList()

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/ThemeForTodayTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/ThemeForTodayTest.kt
@@ -20,12 +20,13 @@ class ThemeForTodayTest {
     private val random = LocalDate.of(2026, Month.MAY, 18)
     private val christmas = LocalDate.of(2026, Month.DECEMBER, 25)
 
-    private fun publicHoliday(title: String) = CalendarEvent(
+    private fun publicHoliday(title: String, ownerAccount: String? = null) = CalendarEvent(
         title = title,
         start = LocalTime.MIDNIGHT,
         end = LocalTime.MIDNIGHT,
         allDay = true,
         kind = EventKind.PUBLIC_HOLIDAY,
+        ownerAccount = ownerAccount,
     )
 
     private fun birthday(title: String) = CalendarEvent(
@@ -324,6 +325,91 @@ class ThemeForTodayTest {
             themeFromCalendarHolidays = true,
             themeFromCalendarBirthdays = true,
         ).shouldBeNull()
+    }
+
+    @Test
+    fun `Muslim Holidays calendar gets the Islamic green-gold palette`() {
+        val theme = subject.resolve(
+            date = random,
+            overrides = noOverrides,
+            enabledCountries = allCountries,
+            events = listOf(publicHoliday("Eid al-Fitr", "en.islamic#holiday@group.v.calendar.google.com")),
+            themeFromCalendarHolidays = true,
+            themeFromCalendarBirthdays = false,
+        )
+        theme.shouldNotBeNull()
+        theme.id shouldBe HolidayId.GENERIC_PUBLIC_HOLIDAY
+        theme.emoji shouldBe "🌙"
+        theme.bannerArgb shouldBe 0xFF1B8A4BL
+        theme.displayTitleOverride shouldBe "Eid al-Fitr"
+    }
+
+    @Test
+    fun `Jewish Holidays calendar gets the Judaism blue-white palette`() {
+        val theme = subject.resolve(
+            date = random,
+            overrides = noOverrides,
+            enabledCountries = allCountries,
+            events = listOf(publicHoliday("Yom Kippur", "en.judaism#holiday@group.v.calendar.google.com")),
+            themeFromCalendarHolidays = true,
+            themeFromCalendarBirthdays = false,
+        )
+        theme.shouldNotBeNull()
+        theme.emoji shouldBe "✡️"
+        theme.bannerArgb shouldBe 0xFF0038B8L
+        theme.displayTitleOverride shouldBe "Yom Kippur"
+    }
+
+    @Test
+    fun `Hindu Holidays calendar gets the saffron-magenta palette`() {
+        val theme = subject.resolve(
+            date = random,
+            overrides = noOverrides,
+            enabledCountries = allCountries,
+            events = listOf(publicHoliday("Diwali", "en.hinduism#holiday@group.v.calendar.google.com")),
+            themeFromCalendarHolidays = true,
+            themeFromCalendarBirthdays = false,
+        )
+        theme.shouldNotBeNull()
+        theme.emoji shouldBe "🪔"
+        theme.bannerArgb shouldBe 0xFFFF9933L
+    }
+
+    @Test
+    fun `non-locale-en religion calendar still themes by religion`() {
+        // Detection is locale-stable: a French phone subscribed to Muslim
+        // Holidays surfaces "Aïd el-Fitr" via `fr.islamic#holiday@…`. Religion
+        // key is fixed regardless of locale prefix.
+        val theme = subject.resolve(
+            date = random,
+            overrides = noOverrides,
+            enabledCountries = allCountries,
+            events = listOf(publicHoliday("Aïd el-Fitr", "fr.islamic#holiday@group.v.calendar.google.com")),
+            themeFromCalendarHolidays = true,
+            themeFromCalendarBirthdays = false,
+        )
+        theme.shouldNotBeNull()
+        theme.emoji shouldBe "🌙"
+        theme.bannerArgb shouldBe 0xFF1B8A4BL
+    }
+
+    @Test
+    fun `region-keyed holiday calendar keeps the generic festive palette`() {
+        // `en.usa#holiday@…` is a country calendar, not a religion calendar —
+        // no religion-specific palette, falls through to the generic 🎊
+        // gold/purple so a Thanksgiving from the catalog-gap path still
+        // themes neutrally.
+        val theme = subject.resolve(
+            date = random,
+            overrides = noOverrides,
+            enabledCountries = allCountries,
+            events = listOf(publicHoliday("Some Holiday", "en.usa#holiday@group.v.calendar.google.com")),
+            themeFromCalendarHolidays = true,
+            themeFromCalendarBirthdays = false,
+        )
+        theme.shouldNotBeNull()
+        theme.emoji shouldBe "🎊"
+        theme.bannerArgb shouldBe 0xFFD4AF37L
     }
 
     @Test


### PR DESCRIPTION
## Summary

When the user has "Theme from calendar holidays" on and an event arrives from one of Google's religion-keyed holiday calendars (Muslim Holidays / Jewish Holidays / Hindu Holidays), the synthetic banner now picks a religion-specific palette + emoji instead of the generic gold/purple 🎊 that every non-Gregorian holiday previously shared:

- **Islamic 🌙** — green over gold (Eid al-Fitr, Eid al-Adha, Ramadan, …)
- **Judaism ✡️** — blue over white (Yom Kippur, Rosh Hashanah, Hanukkah, …)
- **Hinduism 🪔** — saffron over magenta (Diwali, Holi, …)

Detection keys off the calendar's owner account (Google publishes `<locale>.judaism|islamic|hinduism#holiday@group.v.calendar.google.com` feeds), which is locale-stable: a French phone subscribed to "Muslim Holidays" sees "Aïd el-Fitr" with the same green/gold treatment. Region-keyed calendars (`en.usa`, `en.indian`, `en.australian`) and any unrecognised owner fall through to the existing generic festive palette, so no behaviour change for users without a religion-keyed calendar subscribed.

Title-keyed matching ("Ramadan" → Islamic) was considered and rejected for v1: Google localises holiday titles, false positives are common (personal names, "Diwali sale"), and most observant users who want themed banners are already subscribed to the relevant Google holiday calendar. Cheap to revisit later if a real user reports their non-Google calendar going un-themed.

## Privacy

No change to what crosses the device boundary. The calendar title and owner account stay on-device exactly as before; the synthetic theme is still consumed only by the Today banner and never flows into insight prose, TTS, or Firebase (existing rule on `CalendarEvent.title` / `FestiveThemes` is unchanged).

## Test plan

- [x] `:core:domain:test` — four new `ThemeForTodayTest` cases cover the three religions plus the locale-stable case (`fr.islamic#holiday@…` still themes Islamic) and the region-keyed fallthrough (`en.usa#holiday@…` keeps the generic palette).
- [x] `:core:data:test` — unchanged, still green.
- [x] `:app:testDebugUnitTest` — `FestiveThemes.publicHoliday("Diwali")` callers (TTS test) still compile via the new optional `ownerAccount` default.
- [x] `:app:assembleDebug` — green locally.
- [ ] Live device check with a Google holiday calendar subscribed — deferred to a real test build; logic is locale-stable so the inner build's tests cover it.

https://claude.ai/code/session_01ChWrHVDkAfXk64pXD3ZUbe

---
_Generated by [Claude Code](https://claude.ai/code/session_01ChWrHVDkAfXk64pXD3ZUbe)_