### PR TITLE
ci: auto-discover snapshot test sources for orphan-cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,18 +254,20 @@ jobs:
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           if [ -d app/snapshots ]; then
             # Remove PNGs for deleted or renamed @Test methods (orphaned snapshots).
-            # The expected set is the @Test method names in PreviewSnapshots.kt, since
-            # captureRoboImage uses testName.methodName as the output filename.
+            # Auto-discover every Kotlin test source — snapshot tests write to
+            # "$outputDir/<methodName>.png", so a PNG whose basename matches no
+            # @Test method anywhere in app/src/test is genuinely orphaned. The
+            # previous version hard-coded a snapshot_sources list and silently
+            # deleted PNGs whose test file wasn't on it (db7aaf8 → 25cfc6d:
+            # SettingsClothesFullSnapshot.kt's snapshot survived the test pass
+            # only to be wiped here on the way to commit). Scanning every test
+            # file zero-configures any future snapshot file.
             # Slurped perl match handles both `@Test fun foo()` and
             # multi-line `@Test\n@Config(...)\nfun foo()` styles — a single-line
             # `(?<=@Test fun )` regex misses the latter and would prune the PNG
             # as orphaned even though the test still runs.
-            snapshot_sources=(
-              "app/src/test/kotlin/app/clothescast/ui/today/PreviewSnapshots.kt"
-              "app/src/test/kotlin/app/clothescast/ui/garment/OutfitCardSnapshotTest.kt"
-              "app/src/test/kotlin/app/clothescast/ui/today/SettingsClothesFullSnapshot.kt"
-            )
-            expected=$(perl -0777 -ne 'while (/\@Test\b(?:\s|\@\w+(?:\([^)]*\))?)*?\bfun\s+(\w+)/g) { print "$1\n" }' "${snapshot_sources[@]}")
+            expected=$(find app/src/test -name '*.kt' -print0 \
+              | xargs -0 perl -0777 -ne 'while (/\@Test\b(?:\s|\@\w+(?:\([^)]*\))?)*?\bfun\s+(\w+)/g) { print "$1\n" }')
             for png in app/snapshots/*.png; do
               [ -f "$png" ] || continue
               name=$(basename "$png" .png)


### PR DESCRIPTION
## Summary

The snapshot-regen workflow's orphan-cleanup step used a hard-coded
list of files to scan for `@Test` method names. Any snapshot test in
a file outside that list had its PNG silently deleted on the way to
the auto-commit, even though the test itself had just produced it.

That's the exact failure mode that ate `settings_clothes_full.png`
between db7aaf8 (test added in a new file, `SettingsClothesFullSnapshot.kt`)
and 25cfc6d (the CI regen step deleted the PNG because the new file
wasn't on the `snapshot_sources` list). PR #663 patched the immediate
case by appending the file to the list, but the underlying fragility
stayed — the next new snapshot test file gets the same treatment until
someone notices and adds it.

This PR replaces the `snapshot_sources` list with
`find app/src/test -name '*.kt'`. A snapshot test is anything that
writes `"$outputDir/<methodName>.png"`, so a PNG whose basename
matches no `@Test` method anywhere under `app/src/test` is genuinely
orphaned. Non-snapshot tests contributing their `@Test` names to the
"expected" set is harmless — extra entries just mean fewer false
orphans, not more.

## Verification

Locally:

- Scanning all 41 test files yields 192 `@Test` names.
- Every one of the 47 PNGs in `app/snapshots/` maps to one of them
  (no false orphans).
- Re-running `:app:testDebugUnitTest --tests SettingsClothesFullSnapshot`
  produces a byte-identical `settings_clothes_full.png`
  (md5 `182a6d048…`) to what's already committed on `main`.

## Test plan

- [x] Local dry-run of the auto-discover logic — `settings_clothes_full`
      now matches without needing a hardcoded list entry; no current
      PNG is flagged orphan.
- [x] `:app:testDebugUnitTest --tests "app.clothescast.ui.today.SettingsClothesFullSnapshot"`
      passes locally and regenerates the same PNG.
- [ ] CI green on this branch — the regen step itself runs the new
      auto-discover logic and should commit no spurious deletions.
- [ ] (Implicit) any future snapshot test file added in a fresh `.kt`
      now has its PNG protected automatically.

## Privacy

No change to anything that crosses the device boundary. CI workflow
only.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FN1mktVxu6NUE5h8jqMniG)_