### PR TITLE
More accurate location math near the poles and antimeridian

### DIFF
--- a/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
@@ -33,6 +33,7 @@ import app.clothescast.core.domain.usecase.computeDeliveryGates
 import app.clothescast.core.domain.usecase.isGeminiEngineSelected
 import app.clothescast.core.domain.usecase.isMqttPublishable
 import app.clothescast.core.domain.usecase.shouldSpeak
+import app.clothescast.core.domain.util.isWithin
 import app.clothescast.core.data.tts.PcmAudio
 import app.clothescast.core.data.tts.WavEncoder
 import app.clothescast.data.InsightCache
@@ -71,8 +72,6 @@ import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalTime
 import java.util.concurrent.TimeUnit
-import kotlin.math.cos
-import kotlin.math.sqrt
 import kotlin.random.Random
 
 /**
@@ -640,19 +639,7 @@ class FetchAndNotifyWorker(
         val priorName = prior.displayName
             ?.takeUnless { it.isBlank() || it == DEVICE_LOCATION_PLACEHOLDER }
             ?: return null
-        return if (approxDistanceKm(prior, device) < REUSE_LABEL_RADIUS_KM) priorName else null
-    }
-
-    // Equirectangular approximation. Accurate to well under a kilometre
-    // at temperate latitudes for sub-100km separations — fine for "is
-    // the cached city name still meaningful?". TODO: switch to haversine
-    // if we ever need correctness near the poles or across the
-    // antimeridian; neither applies to current users.
-    private fun approxDistanceKm(a: Location, b: Location): Double {
-        val avgLatRad = (a.latitude + b.latitude) / 2 * Math.PI / 180
-        val dLat = (a.latitude - b.latitude) * Math.PI / 180
-        val dLon = (a.longitude - b.longitude) * Math.PI / 180 * cos(avgLatRad)
-        return EARTH_RADIUS_KM * sqrt(dLat * dLat + dLon * dLon)
+        return if (prior.isWithin(REUSE_LABEL_RADIUS_METERS, of = device)) priorName else null
     }
 
     // Mirrors the providers LocationResolver itself queries — NETWORK +
@@ -1285,9 +1272,7 @@ class FetchAndNotifyWorker(
         // when reverse-geo fails. ~25km is generous enough to cover a
         // commute or weekend outing without keeping yesterday's "Paris"
         // glued to today's "London" fix.
-        private const val REUSE_LABEL_RADIUS_KM = 25.0
-
-        private const val EARTH_RADIUS_KM = 6371.0
+        private const val REUSE_LABEL_RADIUS_METERS = 25_000.0
 
         /** Set true via [enqueueOneShot] when the user explicitly taps Refresh. */
         internal const val KEY_FORCE_REFRESH = "force_refresh"


### PR DESCRIPTION
## Summary

Switches `FetchAndNotifyWorker.reuseNearbyDisplayName` over to the shared haversine util (`Location.isWithin` from `core/domain/util/Geo.kt`) and deletes the private equirectangular `approxDistanceKm` helper. Resolves the long-standing `TODO: switch to haversine` comment on the helper.

Why this is safe to call a no-op for current users: for the realistic input range (sub-100 km fixes at temperate latitudes), haversine and the equirectangular approximation agree to well under a kilometre — far inside the 25 km reuse threshold. The win is correctness at the poles and across the antimeridian (where the equirectangular form breaks down), plus removing the duplicated math.

## Changes

- `app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt`:
  - Use `prior.isWithin(REUSE_LABEL_RADIUS_METERS, of = device)` from the shared util instead of the private `approxDistanceKm` + `< REUSE_LABEL_RADIUS_KM` check.
  - Delete the `approxDistanceKm` helper and its TODO.
  - Rename `REUSE_LABEL_RADIUS_KM = 25.0` → `REUSE_LABEL_RADIUS_METERS = 25_000.0` (shared util takes metres).
  - Drop the now-unused `EARTH_RADIUS_KM` constant and the `kotlin.math.cos` / `kotlin.math.sqrt` imports.

The shared util is already tested in `core/domain/src/test/kotlin/app/clothescast/core/domain/util/GeoTest.kt` (zero-distance, London↔Paris, antipodes, antimeridian, `isWithin` boundary) and already in production use via `ShouldSpeak`.

## Privacy

No change to what leaves the device. The reuse-radius check is a local-only decision about which previously-cached city name to display in the header; same inputs and outputs as before, just better math behind the comparison.

## Test plan

- [x] `cd core && ../gradlew :core:domain:test` — `GeoTest` passes (sanity-check on the shared util we're now leaning on).
- [x] `./gradlew :app:testDebugUnitTest` — passes; worker compiles against the new import + call site.
- [x] `./gradlew :app:assembleDebug` — passes.
- [ ] CI green on push.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DjnSdMrmCzigj6ECfawiEN)_