### PR TITLE
Today banners now scroll with the page instead of pinning to the top

### DIFF
--- a/app/src/main/kotlin/app/clothescast/diag/DiagLog.kt
+++ b/app/src/main/kotlin/app/clothescast/diag/DiagLog.kt
@@ -11,6 +11,9 @@ import java.util.Date
 import java.util.Locale
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 
 /**
  * Process-wide diagnostic log that mirrors every call to [android.util.Log]
@@ -25,7 +28,7 @@ import java.util.concurrent.TimeUnit
  * fsync. Non-error calls queue and return immediately.
  *
  * The legacy uncaught-crash channel ([readPersistedCrash] /
- * [hasUnacknowledgedCrash]) is preserved unchanged; uncaught exceptions
+ * [unacknowledgedCrash]) is preserved unchanged; uncaught exceptions
  * still spill the recent log plus the stack to `last-crash.txt` on the
  * dying thread for the post-crash banner.
  */
@@ -63,6 +66,24 @@ object DiagLog {
 
     @Volatile
     private var ackFileProvider: (() -> File)? = null
+
+    private val unacknowledgedCrashState = MutableStateFlow(false)
+
+    /**
+     * Observable mirror of "is there an uncaught-crash file on disk from a
+     * previous run that the user hasn't yet acted on?" — backs the Today
+     * screen's crash banner. Single source of truth shared across every
+     * `LastCrashBanner` instance, so an acknowledgement on one (e.g. on the
+     * pager's page 0) flips the flow and the page 1 instance hides itself
+     * immediately rather than carrying stale local state.
+     *
+     * Seeded by [install] from disk at process start; updated by
+     * [writeCrashLog] when a fresh crash is captured, by
+     * [acknowledgePersistedCrash] when the user dismisses or shares, and
+     * by [refreshUnacknowledgedCrash] on lifecycle ON_RESUME (covers a
+     * crash written by a sibling process while the app was backgrounded).
+     */
+    val unacknowledgedCrash: StateFlow<Boolean> = unacknowledgedCrashState.asStateFlow()
 
     fun v(tag: String, msg: String, t: Throwable? = null) = log('V', tag, msg, t).also {
         if (t == null) Log.v(tag, msg) else Log.v(tag, msg, t)
@@ -123,6 +144,7 @@ object DiagLog {
             runCatching { writeCrashLog(thread, throwable) }
             previous?.uncaughtException(thread, throwable)
         }
+        refreshUnacknowledgedCrash()
         i("DiagLog", "---- process start ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE}) ----")
     }
 
@@ -133,25 +155,29 @@ object DiagLog {
         ?.getOrNull()
 
     /**
-     * True iff a crash from the previous process is on disk and the user hasn't
-     * acknowledged it yet. The Today screen polls this on launch / resume to
-     * surface a "share crash report" banner; tapping either button on the
-     * banner calls [acknowledgePersistedCrash].
+     * Re-reads the crash + ack files from disk and republishes
+     * [unacknowledgedCrash]. Called once from [install] to seed the flow,
+     * and from the crash banner's lifecycle observer on ON_RESUME so a
+     * crash captured while the app was backgrounded (e.g. by a sibling
+     * process sharing the same `cacheDir`) surfaces without needing a
+     * process restart.
      *
-     * Identity is the crash file's last-modified time, so a fresh crash bumps
-     * mtime and the banner re-appears even if the previous one was acked.
+     * Identity is the crash file's last-modified time, so a fresh crash
+     * bumps mtime and the flow flips back to true even if the previous
+     * one was acked.
      */
-    fun hasUnacknowledgedCrash(): Boolean {
-        val crash = crashFileProvider?.invoke() ?: return false
-        val ack = ackFileProvider?.invoke() ?: return false
-        return isCrashUnacknowledged(crash, ack)
+    fun refreshUnacknowledgedCrash() {
+        val crash = crashFileProvider?.invoke() ?: return
+        val ack = ackFileProvider?.invoke() ?: return
+        unacknowledgedCrashState.value = isCrashUnacknowledged(crash, ack)
     }
 
-    /** Records the currently persisted crash as seen — see [hasUnacknowledgedCrash]. */
+    /** Records the currently persisted crash as seen — see [unacknowledgedCrash]. */
     fun acknowledgePersistedCrash() {
         val crash = crashFileProvider?.invoke() ?: return
         val ack = ackFileProvider?.invoke() ?: return
         writeCrashAcknowledgement(crash, ack)
+        unacknowledgedCrashState.value = false
     }
 
     internal fun isCrashUnacknowledged(crashFile: File, ackFile: File): Boolean {
@@ -187,6 +213,7 @@ object DiagLog {
             appendLine("--- recent log ---")
             append(recent)
         })
+        unacknowledgedCrashState.value = true
     }
 
     private fun stackTraceString(t: Throwable): String =

--- a/app/src/main/kotlin/app/clothescast/ui/today/LastCrashBanner.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/LastCrashBanner.kt
@@ -43,12 +43,17 @@ import kotlinx.coroutines.launch
  *
  * Both buttons mark the crash as acknowledged so the banner doesn't keep
  * reappearing. A *new* crash bumps the on-disk file's mtime, which
- * [DiagLog.hasUnacknowledgedCrash] uses as identity, so the banner
- * surfaces again next launch.
+ * [DiagLog.unacknowledgedCrash] uses as identity, so the banner surfaces
+ * again next launch.
  *
- * Re-checks the file on lifecycle ON_RESUME so a backgrounded app coming
- * forward after a crash in another process surfaces the banner without
- * requiring a process restart.
+ * State comes from [DiagLog.unacknowledgedCrash] (a process-wide
+ * [kotlinx.coroutines.flow.StateFlow]) so multiple banner instances —
+ * e.g. the two pager pages on the Today screen — share a single source of
+ * truth: dismissing on one page hides the other immediately too.
+ *
+ * Calls [DiagLog.refreshUnacknowledgedCrash] on lifecycle ON_RESUME so a
+ * backgrounded app coming forward after a crash in another process
+ * surfaces the banner without requiring a process restart.
  */
 @Composable
 internal fun LastCrashBanner(modifier: Modifier = Modifier) {
@@ -58,14 +63,14 @@ internal fun LastCrashBanner(modifier: Modifier = Modifier) {
     val app = context.applicationContext as ClothesCastApplication
     val bugReportConsentAcked by app.settingsRepository.bugReportConsentAcknowledged
         .collectAsStateWithLifecycle(initialValue = false)
-    var hasCrash by remember { mutableStateOf(DiagLog.hasUnacknowledgedCrash()) }
+    val hasCrash by DiagLog.unacknowledgedCrash.collectAsStateWithLifecycle()
     var consentVisible by remember { mutableStateOf(false) }
 
     val lifecycleOwner = LocalLifecycleOwner.current
     DisposableEffect(lifecycleOwner) {
         val observer = LifecycleEventObserver { _, event ->
             if (event == Lifecycle.Event.ON_RESUME) {
-                hasCrash = DiagLog.hasUnacknowledgedCrash()
+                DiagLog.refreshUnacknowledgedCrash()
             }
         }
         lifecycleOwner.lifecycle.addObserver(observer)
@@ -79,7 +84,6 @@ internal fun LastCrashBanner(modifier: Modifier = Modifier) {
         coroutineScope.launch {
             BugReport.share(act)
             DiagLog.acknowledgePersistedCrash()
-            hasCrash = false
         }
     }
 
@@ -90,7 +94,6 @@ internal fun LastCrashBanner(modifier: Modifier = Modifier) {
         },
         onDismiss = {
             DiagLog.acknowledgePersistedCrash()
-            hasCrash = false
         },
     )
 

--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
@@ -361,71 +361,29 @@ private fun TodayContent(
             .fillMaxSize()
             .padding(padding),
     ) {
-        // Pinned banners — outside the pager so critical banners (update
-        // available, crash report, telemetry notice, location required,
-        // work status) aren't duplicated per page. The outfit row used to
-        // live here too, but it pinned a lot of vertical space at the top
-        // regardless of which page was in view; it now scrolls with each
-        // page (rendered inside TodayPage below) so more chart cards fit
-        // in a single screen of scroll.
-        //
-        // Each banner carries its own top + horizontal padding so that
-        // hidden banners (every banner here early-returns when its
-        // condition isn't met) contribute zero vertical space — that's
-        // what keeps the outfit row from sitting under a permanent 40dp
-        // blank strip in the steady state. Adjacent visible banners are
-        // 16dp apart (the top padding of the lower one).
-        //
-        // UpdateAvailableBanner is first on purpose: a stale build is
-        // the upstream cause of many bug reports, so giving the user
-        // the chance to update before they notice anything else is the
-        // highest-leverage placement.
-        val bannerModifier = Modifier.padding(top = 16.dp, start = 16.dp, end = 16.dp)
-        UpdateAvailableBanner(modifier = bannerModifier)
-        LocalBuildBanner(modifier = bannerModifier)
-        LastCrashBanner(modifier = bannerModifier)
-        // One-shot privacy disclosure for the default-on Firebase
-        // telemetry, so the default isn't silent. Auto-hides once the
-        // user dismisses it (or taps through to Privacy from it).
-        // Stays out of the way of the crash banner: that's a current
-        // problem to action; this is just disclosure.
-        TelemetryNoticeBanner(onOpenPrivacy = onOpenPrivacy, modifier = bannerModifier)
-        // Promo card for the calendar-sourced holiday + birthday theming.
-        // Driven by [TodayState.celebrationCardVisible] (gated upstream on
-        // toggles + dismissal) so it disappears the moment either toggle
-        // goes on or the X is tapped.
-        CelebrationThemesCard(
-            visible = state.celebrationCardVisible,
-            onOpenCalendarSettings = onOpenCalendarSettings,
-            onDismiss = onDismissCelebrationCard,
-            modifier = bannerModifier,
-        )
-        if (locationActionRequired) {
-            LocationActionRequiredBanner(
-                onSetUpLocation = onSetUpLocation,
-                modifier = bannerModifier,
-            )
-        }
-        WorkStatusBanner(status = workStatusToShow, modifier = bannerModifier)
-        // Holiday banner sits last in the banner stack so it ends up closest
-        // to the outfit row whose palette it explains. Hidden on days with
-        // no enabled holiday match — `HolidayBanner` early-returns on null
-        // so the stack contributes zero vertical space in the steady state.
-        HolidayBanner(theme = state.activeHoliday, region = state.region, modifier = bannerModifier)
         if (state.thisPeriodInsight == null) {
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
                     // Match the nav-bar inset added inside each TodayPage's
-                    // scroll viewport — this branch isn't scrollable, so the
-                    // Fetch-now button has to be padded out of the nav-bar
-                    // zone directly. Without this the button would sit under
-                    // the (translucent) nav bar on devices where banners
-                    // push it down to the bottom of the screen.
+                    // scroll viewport so the Fetch-now button isn't hidden
+                    // by the (translucent) nav bar when the banner stack
+                    // pushes it down.
                     .windowInsetsPadding(WindowInsets.navigationBars)
+                    .verticalScroll(rememberScrollState())
                     .padding(horizontal = 16.dp)
                     .padding(top = 16.dp, bottom = 24.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
             ) {
+                BannerStack(
+                    state = state,
+                    workStatusToShow = workStatusToShow,
+                    locationActionRequired = locationActionRequired,
+                    onOpenPrivacy = onOpenPrivacy,
+                    onOpenCalendarSettings = onOpenCalendarSettings,
+                    onDismissCelebrationCard = onDismissCelebrationCard,
+                    onSetUpLocation = onSetUpLocation,
+                )
                 EmptyState(onRefresh = onRefresh, isWorking = isWorking)
             }
         } else {
@@ -476,6 +434,8 @@ private fun TodayContent(
                     outfitInsight = state.thisPeriodInsight,
                     showChevronRight = (page == 0),
                     showChevronLeft = (page == 1),
+                    workStatusToShow = workStatusToShow,
+                    locationActionRequired = locationActionRequired,
                     onChevronTap = {
                         pagerScope.launch {
                             pagerState.animateScrollToPage(if (page == 0) 1 else 0)
@@ -487,10 +447,71 @@ private fun TodayContent(
                     onToggleModelSpread = onToggleModelSpread,
                     onRevealModelSpread = onRevealModelSpread,
                     onLongPressDate = onLongPressDate,
+                    onSetUpLocation = onSetUpLocation,
+                    onOpenPrivacy = onOpenPrivacy,
+                    onOpenCalendarSettings = onOpenCalendarSettings,
+                    onDismissCelebrationCard = onDismissCelebrationCard,
                 )
             }
         }
     }
+}
+
+/**
+ * Stack of top-of-screen banners: update available, local-build / crash /
+ * telemetry disclosures, celebration-themes promo, location-required prompt,
+ * work-status spinner, and the day's holiday banner. None are pinned — the
+ * caller embeds this in its scroll viewport so banners scroll with the
+ * content underneath rather than hogging vertical space at the top of the
+ * screen in the steady state. Each banner early-returns when its condition
+ * isn't met, so the enclosing Column's spacedBy arrangement collapses to
+ * zero between hidden entries.
+ *
+ * HolidayBanner is last on purpose: it ends up adjacent to the outfit row
+ * whose palette it explains.
+ */
+@Composable
+private fun BannerStack(
+    state: TodayState,
+    workStatusToShow: WorkStatus,
+    locationActionRequired: Boolean,
+    onOpenPrivacy: () -> Unit,
+    onOpenCalendarSettings: () -> Unit,
+    onDismissCelebrationCard: () -> Unit,
+    onSetUpLocation: () -> Unit,
+) {
+    val bannerModifier = Modifier.fillMaxWidth()
+    // UpdateAvailableBanner is first on purpose: a stale build is the
+    // upstream cause of many bug reports, so giving the user the chance
+    // to update before they notice anything else is the highest-leverage
+    // placement.
+    UpdateAvailableBanner(modifier = bannerModifier)
+    LocalBuildBanner(modifier = bannerModifier)
+    LastCrashBanner(modifier = bannerModifier)
+    // One-shot privacy disclosure for the default-on Firebase telemetry,
+    // so the default isn't silent. Auto-hides once the user dismisses it
+    // (or taps through to Privacy from it). Stays out of the way of the
+    // crash banner: that's a current problem to action; this is just
+    // disclosure.
+    TelemetryNoticeBanner(onOpenPrivacy = onOpenPrivacy, modifier = bannerModifier)
+    // Promo card for the calendar-sourced holiday + birthday theming.
+    // Driven by [TodayState.celebrationCardVisible] (gated upstream on
+    // toggles + dismissal) so it disappears the moment either toggle goes
+    // on or the X is tapped.
+    CelebrationThemesCard(
+        visible = state.celebrationCardVisible,
+        onOpenCalendarSettings = onOpenCalendarSettings,
+        onDismiss = onDismissCelebrationCard,
+        modifier = bannerModifier,
+    )
+    if (locationActionRequired) {
+        LocationActionRequiredBanner(
+            onSetUpLocation = onSetUpLocation,
+            modifier = bannerModifier,
+        )
+    }
+    WorkStatusBanner(status = workStatusToShow, modifier = bannerModifier)
+    HolidayBanner(theme = state.activeHoliday, region = state.region, modifier = bannerModifier)
 }
 
 /**
@@ -513,6 +534,8 @@ private fun TodayPage(
     outfitInsight: Insight,
     showChevronRight: Boolean,
     showChevronLeft: Boolean,
+    workStatusToShow: WorkStatus,
+    locationActionRequired: Boolean,
     onChevronTap: () -> Unit,
     onAdjustThreshold: (String, Double) -> Unit,
     onNavigateToClothes: () -> Unit,
@@ -520,6 +543,10 @@ private fun TodayPage(
     onToggleModelSpread: () -> Unit,
     onRevealModelSpread: () -> Unit,
     onLongPressDate: () -> Unit,
+    onSetUpLocation: () -> Unit,
+    onOpenPrivacy: () -> Unit,
+    onOpenCalendarSettings: () -> Unit,
+    onDismissCelebrationCard: () -> Unit,
 ) {
     val scrollScope = rememberCoroutineScope()
     // Captured via onGloballyPositioned on the ConfidenceChip below so the
@@ -544,6 +571,20 @@ private fun TodayPage(
                 .padding(top = 16.dp, bottom = 24.dp),
             verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
+            // Banner stack sits at the top of the scroll viewport (rather
+            // than pinned above the pager) so nothing hogs vertical space
+            // on the steady-state screen. HolidayBanner is last in the
+            // stack so it ends up adjacent to the outfit row whose palette
+            // it explains.
+            BannerStack(
+                state = state,
+                workStatusToShow = workStatusToShow,
+                locationActionRequired = locationActionRequired,
+                onOpenPrivacy = onOpenPrivacy,
+                onOpenCalendarSettings = onOpenCalendarSettings,
+                onDismissCelebrationCard = onDismissCelebrationCard,
+                onSetUpLocation = onSetUpLocation,
+            )
             // Outfit row sits above the null-insight short-circuit so it
             // also renders on page 2 when [insight] (the next-period
             // insight) is null and we fall back to MissingPeriodPlaceholder.

--- a/app/src/test/kotlin/app/clothescast/diag/CrashAckTest.kt
+++ b/app/src/test/kotlin/app/clothescast/diag/CrashAckTest.kt
@@ -8,7 +8,7 @@ import java.nio.file.Path
 
 /**
  * Validates the file-based ack tracking that backs the post-crash banner on
- * the Today screen — see [DiagLog.hasUnacknowledgedCrash] and
+ * the Today screen — see [DiagLog.unacknowledgedCrash] and
  * [DiagLog.acknowledgePersistedCrash]. Identity of "the current crash" is
  * the crash file's last-modified time, so a fresh crash bumps mtime and the
  * banner re-surfaces even when an older crash was already acked.


### PR DESCRIPTION
## Summary

The full banner stack on the Today screen (update available, local-build / crash / telemetry disclosures, celebration-themes promo, location-required prompt, work-status spinner, holiday banner) used to live above the pager, fixed at the top of the screen. They now sit at the top of each page's scroll viewport — including the empty-state branch, which becomes scrollable too — so a "Working" or holiday-themed bar moves naturally with the content as the user scrolls into the charts below the outfit row. The holiday banner ends up as a bar directly above the outfit row whose palette it explains.

Internally, the stack is now a private `BannerStack` composable called from both the empty-state Column and from inside `TodayPage` (above `OutfitPreviewRow`). Each banner still early-returns when its condition isn't met, so the parent Column's `spacedBy` collapses to zero between hidden entries and the steady state shows just outfit + charts.

Because `BannerStack` is now instantiated per page, the two pager pages produce two `LastCrashBanner` instances. To keep acknowledgement consistent across them, the crash-banner source of truth moves into `DiagLog.unacknowledgedCrash` — a process-wide `StateFlow<Boolean>` seeded by `install()`, flipped to `true` by `writeCrashLog()` when a fresh crash lands, flipped to `false` by `acknowledgePersistedCrash()`, and re-read from disk by a new `refreshUnacknowledgedCrash()` called from the banner's ON_RESUME observer. `LastCrashBanner` `collectAsStateWithLifecycle`s the flow, so dismissing on one page hides the other instance the same frame.

## Test plan

- [x] `:app:testDebugUnitTest` green locally (Roborazzi snapshots, `WorkStatusBanner`, `bannerStatus`, and the existing `CrashAckTest` file-level ack helpers all still pass).
- [ ] Eyeball on-device: scroll the Today screen and confirm a visible banner (e.g. "Working", a holiday banner, the telemetry notice) moves up with the content instead of staying glued to the top.
- [ ] Eyeball the empty-state branch (uninstall + reinstall, or temporarily clear the insight cache) and confirm any visible banner stack sits above the centered EmptyState and scrolls if there's not enough room.
- [ ] Force a crash, relaunch, swipe to page 1, swipe back, then "Dismiss" on page 0 — page 1 should also hide the crash banner without a lifecycle event.
- [ ] Swipe between the two pager pages — banners (where visible) appear on both pages with no flicker / no stale state.

## Privacy

No change to what leaves the device — pure UI / state-plumbing.
