### PR TITLE
Show solar radiation peak in the card subtitle

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
@@ -2198,9 +2198,29 @@ internal fun SolarRadiationCard(
     showModelSpread: Boolean = false,
     onFirstContact: (() -> Unit)? = null,
 ) {
+    val times = remember(hourly) { hourly.map { it.time } }
+    // Peak irradiance across the cross-model consensus series — same blend
+    // the chart draws. Suppressed when the rounded peak is below 10 W/m²
+    // (night view, deep-polar winter) so the subtitle doesn't read
+    // "Peak 3 W/m² at 12:00".
+    val peak = remember(perModelHourly, times) {
+        perModelConsensusSeries(perModelHourly) { it.shortwaveRadiationWm2 }
+            .maxByOrNull { it.second }
+            ?.takeIf { it.second.roundToInt() >= 10 }
+            ?.let { (idx, value) ->
+                times.getOrNull(idx)?.let { time -> time to value }
+            }
+    }
+    val subtitle = peak?.let { (time, value) ->
+        stringResource(
+            R.string.today_solar_peak,
+            value.roundToInt(),
+            formatScrubHour(time),
+        )
+    } ?: stringResource(R.string.today_solar_subtitle)
     PerModelDiagnosticCard(
         title = stringResource(R.string.today_solar_title),
-        subtitle = stringResource(R.string.today_solar_subtitle),
+        subtitle = subtitle,
         hourly = hourly,
         startDate = startDate,
         perModelHourly = perModelHourly,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -213,6 +213,14 @@
          bright" days more honestly than cloud cover alone. -->
     <string name="today_solar_title">Solar radiation</string>
     <string name="today_solar_subtitle">Surface irradiance (W/m²)</string>
+    <!-- Replaces [today_solar_subtitle] when the consensus series has a
+         meaningful peak: peak rounded irradiance and the hour it occurs at.
+         %1$d = peak value in W/m², %2$s = hour formatted as HH:00. Below
+         10 W/m² we keep the static subtitle — a "Peak 3 W/m² at 12:00"
+         reading on the night view or a deep-polar-winter day is
+         information-free. Units stay in the format string because the
+         card title ("Solar radiation") doesn't name them. -->
+    <string name="today_solar_peak">Peak %1$d W/m² at %2$s</string>
 
     <!-- Sunshine-duration diagnostic card. The chart plots minutes of sun
          per hour (0..60) per model; the card's subtitle replaces the static


### PR DESCRIPTION
## Summary

Replaces the solar-radiation card's static "Surface irradiance (W/m²)" subtitle with a consensus peak readout — e.g. **"Peak 820 W/m² at 12:00"** — mirroring the existing UV-index card pattern. The summary now answers "how bright did it get, when?" at a glance instead of just naming the unit.

- New string `today_solar_peak` (`Peak %1$d W/m² at %2$s`); falls back to the static subtitle when the rounded peak is below 10 W/m² (night view / deep-polar winter) so we don't surface a "Peak 3 W/m² at 12:00" reading on an information-free day.
- Units stay in the format string because the card title ("Solar radiation") doesn't name them, unlike "UV index" where the metric is already in the title.
- Peak is computed from `perModelConsensusSeries { it.shortwaveRadiationWm2 }` — same blend the chart draws.

## Test plan

- [ ] CI green (`:app:testDebugUnitTest`, `:app:assembleDebug`)
- [ ] Snapshot bot regenerates `solar_radiation_card_consensus.png` and `solar_radiation_card_with_model_spread.png`; visually confirm new subtitle reads "Peak X W/m² at HH:00"
- [ ] Spot-check on device: morning view shows the peak; night view falls back to the static subtitle


---
_Generated by [Claude Code](https://claude.ai/code/session_01UfxKipBpnoYEkFgKqa65dx)_