### PR TITLE
Let scroll and swipe gestures work from inside the charts

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/today/ChartScrubber.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/ChartScrubber.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.input.pointer.positionChange
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -34,6 +35,7 @@ import com.patrykandpatrick.vico.core.common.component.LineComponent
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
+import kotlin.math.abs
 import kotlin.math.roundToInt
 
 /**
@@ -80,6 +82,20 @@ internal class ChartScrubController {
 }
 
 internal val LocalChartScrub = compositionLocalOf<ChartScrubController?> { null }
+
+/**
+ * Optional handoff hook: when the user starts a horizontal scrub gesture
+ * inside a chart and drags far enough past the left / right plot-grid edge,
+ * [Modifier.chartScrub] calls this with `toNextPage = true` for "drag
+ * continues toward the next page" (finger exited the leading edge in LTR /
+ * trailing edge in RTL) or `false` for the opposite direction. The caller
+ * — wired in `TodayScreen` around the page pager — animates the pager
+ * accordingly, so swiping from inside a chart all the way across feels
+ * continuous with a normal page swipe instead of bumping against an
+ * invisible wall once the pointer leaves the chart. Null disables the
+ * handoff (e.g. previews, single-page layouts).
+ */
+internal val LocalChartPageSwipe = compositionLocalOf<((toNextPage: Boolean) -> Unit)?> { null }
 
 @Composable
 internal fun rememberChartScrubController(): ChartScrubController =
@@ -171,17 +187,32 @@ internal fun chartXToTime(
 }
 
 /**
- * Pointer handler. A down event that falls inside the chart's plot
- * grid (between the y- and x-axis labels) claims the gesture: publish
- * the pointer's wall-clock time to [controller], fire [onFirstContact]
- * (used to reveal model spread), and keep updating on every move.
- * Release leaves the indicator sticky — no snap-back.
+ * Pointer handler. A down event that lands inside the chart's plot grid
+ * (between the y- and x-axis labels) starts a candidate gesture. From
+ * there we wait to see what the user is actually doing:
+ *
+ *  - **Tap** (release before any meaningful movement): publish a scrub
+ *    at the down position. Preserves the tap-to-jump behaviour.
+ *  - **Clearly vertical drag** (vertical movement exceeds touch slop
+ *    and dominates the horizontal component): return without consuming
+ *    so the parent `verticalScroll` picks the gesture up — the user
+ *    can scroll the page even when their finger started inside a chart.
+ *  - **Clearly horizontal drag** (horizontal movement exceeds touch
+ *    slop): claim the gesture for scrubbing, publish at the down
+ *    position, then track each move.
+ *
+ * Once we've claimed a horizontal drag, if the pointer keeps moving and
+ * exits the chart's left or right plot-grid edge by more than
+ * [edgeHandoffDp], we hand the gesture off to [onSwipeAcross] (typically
+ * the page pager) and stop scrubbing — so a wide cross-chart swipe
+ * flows continuously into a page turn instead of bumping against an
+ * invisible wall. The handoff is one-shot: once we've called
+ * [onSwipeAcross], the gesture is done and the page animation takes
+ * over even if the finger keeps moving.
  *
  * Down events *outside* the plot grid — on Vico's axis labels, on the
  * card padding above/below the chart, on the legend strip — are left
- * unconsumed so they bubble to the parent `verticalScroll` and the
- * page keeps scrolling normally. The plot grid is the only area where
- * vertical drag is repurposed.
+ * unconsumed exactly as before.
  */
 internal fun Modifier.chartScrub(
     controller: ChartScrubController,
@@ -189,10 +220,13 @@ internal fun Modifier.chartScrub(
     hourly: List<HourlyForecast>,
     startDate: LocalDate,
     onFirstContact: () -> Unit,
-): Modifier = pointerInput(controller, bounds, hourly, startDate) {
+    onSwipeAcross: ((toNextPage: Boolean) -> Unit)? = null,
+): Modifier = pointerInput(controller, bounds, hourly, startDate, onSwipeAcross) {
+    val touchSlop = viewConfiguration.touchSlop
+    val edgeHandoffPx = edgeHandoffDp.toPx()
     awaitEachGesture {
         val down = awaitFirstDown(requireUnconsumed = true)
-        val pos = down.position
+        val downPos = down.position
         // Hit-test against the plot *layer* (left/right edges of
         // Vico's chart area, including its start/end padding) rather
         // than the tighter data extent — that's the visible empty
@@ -200,26 +234,89 @@ internal fun Modifier.chartScrub(
         // where a tap should map to a fractional time just outside
         // the period's hour boundaries instead of getting filtered
         // out. [publishScrub] handles the chart-x → time math from
-        // here; [chartXToTime] clamps to a hour of leading / trailing
+        // here; [chartXToTime] clamps to an hour of leading / trailing
         // slack so taps far outside the chart don't produce
         // pathological times.
         val inGrid = bounds.layerRightPx > bounds.layerLeftPx &&
             bounds.layerBottomPx > bounds.layerTopPx &&
-            pos.x in bounds.layerLeftPx..bounds.layerRightPx &&
-            pos.y in bounds.layerTopPx..bounds.layerBottomPx
+            downPos.x in bounds.layerLeftPx..bounds.layerRightPx &&
+            downPos.y in bounds.layerTopPx..bounds.layerBottomPx
         if (!inGrid) return@awaitEachGesture
-        down.consume()
-        publishScrub(controller, bounds, hourly, startDate, pos.x)
-        onFirstContact()
+        // Don't consume the down yet — we need movement (or lack of it)
+        // to decide whether this is a tap, a vertical scroll, or a
+        // horizontal scrub. Consuming early traps every drag inside
+        // the chart and blocks page scroll entirely.
+        var totalDx = 0f
+        var totalDy = 0f
+        var claimed = false
         while (true) {
             val event = awaitPointerEvent()
             val change = event.changes.firstOrNull { it.id == down.id } ?: break
-            change.consume()
-            if (!change.pressed) break
-            publishScrub(controller, bounds, hourly, startDate, change.position.x)
+            if (!claimed) {
+                val delta = change.positionChange()
+                totalDx += delta.x
+                totalDy += delta.y
+                val absDx = abs(totalDx)
+                val absDy = abs(totalDy)
+                if (absDy > touchSlop && absDy > absDx) {
+                    // Clear vertical drag — let the parent verticalScroll
+                    // handle it by leaving events unconsumed and bailing
+                    // out of the gesture entirely.
+                    return@awaitEachGesture
+                }
+                if (absDx > touchSlop) {
+                    // Clear horizontal drag — claim the gesture.
+                    claimed = true
+                    down.consume()
+                    change.consume()
+                    publishScrub(controller, bounds, hourly, startDate, downPos.x)
+                    onFirstContact()
+                    publishScrub(controller, bounds, hourly, startDate, change.position.x)
+                }
+                // Otherwise ambiguous: stay uncommitted and watch the
+                // next event. If the finger lifts here, the `pressed`
+                // check below catches it and we fall through to tap.
+            } else {
+                change.consume()
+                publishScrub(controller, bounds, hourly, startDate, change.position.x)
+                if (onSwipeAcross != null) {
+                    val px = change.position.x
+                    val exitedRight = px > bounds.layerRightPx + edgeHandoffPx
+                    val exitedLeft = px < bounds.layerLeftPx - edgeHandoffPx
+                    if (exitedLeft || exitedRight) {
+                        // Pointer dragged well past the plot edge — hand
+                        // off to the pager. In LTR the chart draws
+                        // left-to-right (positive pxPerUnit) and exiting
+                        // the left edge means the finger is moving toward
+                        // the *next* page (rightward content scrolls in);
+                        // in RTL the chart and the pager both flip, so
+                        // exiting the right edge means next-page. Using
+                        // `bounds.pxPerUnit`'s sign avoids importing
+                        // LayoutDirection — it's already direction-aware.
+                        val ltr = bounds.pxPerUnit >= 0f
+                        val toNextPage = (exitedLeft && ltr) || (exitedRight && !ltr)
+                        onSwipeAcross(toNextPage)
+                        return@awaitEachGesture
+                    }
+                }
+            }
+            if (!change.pressed) {
+                if (!claimed) {
+                    // Released before reaching touch slop — treat as a
+                    // tap and publish a scrub at the original down
+                    // position. Preserves tap-to-scrub even though we
+                    // deferred consumption to disambiguate from scroll.
+                    publishScrub(controller, bounds, hourly, startDate, downPos.x)
+                    onFirstContact()
+                }
+                break
+            }
         }
     }
 }
+
+/** Pointer distance past the chart's left / right edge that triggers a page-swipe handoff. */
+private val edgeHandoffDp = 32.dp
 
 private fun publishScrub(
     controller: ChartScrubController,

--- a/app/src/main/kotlin/app/clothescast/ui/today/ForecastChart.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/ForecastChart.kt
@@ -242,6 +242,7 @@ fun ForecastChart(
     val lineProvider = rememberPinnedLineProvider(visibleModels, mainLineColor, modelColors)
 
     val scrubController = LocalChartScrub.current
+    val pageSwipe = LocalChartPageSwipe.current
     val scrubBounds = rememberChartScrubBounds()
     val scrubIndicator = rememberChartScrubIndicator(scrubController, scrubBounds, hourly, startDate)
     val decorations = listOf(scrubIndicator)
@@ -252,7 +253,7 @@ fun ForecastChart(
             .height(180.dp)
             .let { mod ->
                 if (scrubController != null) {
-                    mod.chartScrub(scrubController, scrubBounds, hourly, startDate, onFirstContact)
+                    mod.chartScrub(scrubController, scrubBounds, hourly, startDate, onFirstContact, pageSwipe)
                 } else {
                     mod
                 }

--- a/app/src/main/kotlin/app/clothescast/ui/today/PerModelDiagnosticCard.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/PerModelDiagnosticCard.kt
@@ -285,6 +285,7 @@ private fun PerModelDiagnosticChart(
     val lineProvider = rememberPinnedLineProvider(overlayModels, mainLineColor)
 
     val scrubController = LocalChartScrub.current
+    val pageSwipe = LocalChartPageSwipe.current
     val scrubBounds = rememberChartScrubBounds()
     val scrubIndicator = rememberChartScrubIndicator(scrubController, scrubBounds, hourly, startDate)
     val decorations = listOf(scrubIndicator)
@@ -295,7 +296,7 @@ private fun PerModelDiagnosticChart(
             .height(140.dp)
             .let { mod ->
                 if (scrubController != null) {
-                    mod.chartScrub(scrubController, scrubBounds, hourly, startDate, onFirstContact)
+                    mod.chartScrub(scrubController, scrubBounds, hourly, startDate, onFirstContact, pageSwipe)
                 } else {
                     mod
                 }

--- a/app/src/main/kotlin/app/clothescast/ui/today/PrecipitationChart.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/PrecipitationChart.kt
@@ -153,6 +153,7 @@ fun PrecipitationChart(
     val lineProvider = rememberPinnedLineProvider(visibleModels, mainLineColor)
 
     val scrubController = LocalChartScrub.current
+    val pageSwipe = LocalChartPageSwipe.current
     val scrubBounds = rememberChartScrubBounds()
     val scrubIndicator = rememberChartScrubIndicator(scrubController, scrubBounds, hourly, startDate)
     val decorations = listOf(scrubIndicator)
@@ -166,7 +167,7 @@ fun PrecipitationChart(
             .height(140.dp)
             .let { mod ->
                 if (scrubController != null) {
-                    mod.chartScrub(scrubController, scrubBounds, hourly, startDate, onFirstContact)
+                    mod.chartScrub(scrubController, scrubBounds, hourly, startDate, onFirstContact, pageSwipe)
                 } else {
                     mod
                 }

--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
@@ -409,50 +409,66 @@ private fun TodayContent(
             // the rain chart on Today, swiping to Tomorrow keeps them
             // on the rain chart rather than snapping back to the top.
             val scrollState = rememberScrollState()
+            // Hands a wide horizontal scrub off to the pager: if the user
+            // starts dragging inside a chart and the pointer keeps going
+            // past the plot-grid edge, [Modifier.chartScrub] calls this
+            // and we animate the pager to the neighbouring page. Clamped
+            // to the page range so a swipe past the first / last page is
+            // a no-op rather than an error.
+            val pageSwipe: (Boolean) -> Unit = remember(pagerState, pagerScope) {
+                { toNextPage ->
+                    val target = pagerState.currentPage + if (toNextPage) 1 else -1
+                    if (target in 0 until pagerState.pageCount) {
+                        pagerScope.launch { pagerState.animateScrollToPage(target) }
+                    }
+                }
+            }
             // Placeholder period for page 2 when its slot is empty —
             // whatever the next 12-hour window after `thisPeriodInsight` is.
             // The worker writes [InsightCache.Slot.NEXT_PERIOD] paired with
             // each delivery, so this fallback only fires before the first
             // post-upgrade worker run.
             val nextPeriodFallback = state.thisPeriodInsight.period.opposite()
-            HorizontalPager(
-                state = pagerState,
-                modifier = Modifier
-                    .weight(1f)
-                    .fillMaxWidth(),
-            ) { page ->
-                val pageInsight = if (page == 0) state.thisPeriodInsight else state.nextPeriodInsight
-                val pagePeriod = if (page == 0) state.thisPeriodInsight.period else nextPeriodFallback
-                TodayPage(
-                    insight = pageInsight,
-                    fallbackPeriod = pagePeriod,
-                    state = state,
-                    scrollState = scrollState,
-                    // Same outfit row on both pages — page 2 shows this
-                    // period's pair too, not the page-2 period's pair. We
-                    // don't surface a 3rd period (tomorrow) on page 2; the
-                    // outfit row stays the at-a-glance today+tonight summary.
-                    outfitInsight = state.thisPeriodInsight,
-                    showChevronRight = (page == 0),
-                    showChevronLeft = (page == 1),
-                    workStatusToShow = workStatusToShow,
-                    locationActionRequired = locationActionRequired,
-                    onChevronTap = {
-                        pagerScope.launch {
-                            pagerState.animateScrollToPage(if (page == 0) 1 else 0)
-                        }
-                    },
-                    onAdjustThreshold = onAdjustThreshold,
-                    onNavigateToClothes = onNavigateToClothes,
-                    onNavigateToFormat = onNavigateToFormat,
-                    onToggleModelSpread = onToggleModelSpread,
-                    onRevealModelSpread = onRevealModelSpread,
-                    onLongPressDate = onLongPressDate,
-                    onSetUpLocation = onSetUpLocation,
-                    onOpenPrivacy = onOpenPrivacy,
-                    onOpenCalendarSettings = onOpenCalendarSettings,
-                    onDismissCelebrationCard = onDismissCelebrationCard,
-                )
+            CompositionLocalProvider(LocalChartPageSwipe provides pageSwipe) {
+                HorizontalPager(
+                    state = pagerState,
+                    modifier = Modifier
+                        .weight(1f)
+                        .fillMaxWidth(),
+                ) { page ->
+                    val pageInsight = if (page == 0) state.thisPeriodInsight else state.nextPeriodInsight
+                    val pagePeriod = if (page == 0) state.thisPeriodInsight.period else nextPeriodFallback
+                    TodayPage(
+                        insight = pageInsight,
+                        fallbackPeriod = pagePeriod,
+                        state = state,
+                        scrollState = scrollState,
+                        // Same outfit row on both pages — page 2 shows this
+                        // period's pair too, not the page-2 period's pair. We
+                        // don't surface a 3rd period (tomorrow) on page 2; the
+                        // outfit row stays the at-a-glance today+tonight summary.
+                        outfitInsight = state.thisPeriodInsight,
+                        showChevronRight = (page == 0),
+                        showChevronLeft = (page == 1),
+                        workStatusToShow = workStatusToShow,
+                        locationActionRequired = locationActionRequired,
+                        onChevronTap = {
+                            pagerScope.launch {
+                                pagerState.animateScrollToPage(if (page == 0) 1 else 0)
+                            }
+                        },
+                        onAdjustThreshold = onAdjustThreshold,
+                        onNavigateToClothes = onNavigateToClothes,
+                        onNavigateToFormat = onNavigateToFormat,
+                        onToggleModelSpread = onToggleModelSpread,
+                        onRevealModelSpread = onRevealModelSpread,
+                        onLongPressDate = onLongPressDate,
+                        onSetUpLocation = onSetUpLocation,
+                        onOpenPrivacy = onOpenPrivacy,
+                        onOpenCalendarSettings = onOpenCalendarSettings,
+                        onDismissCelebrationCard = onDismissCelebrationCard,
+                    )
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

The chart scrub gesture used to consume the down event the moment a finger touched the plot grid, so every subsequent move was trapped inside the chart. Vertical swipes started inside a chart never reached the parent `verticalScroll` — the page felt stuck — and a horizontal scrub that kept going past the chart edge pinned silently against an invisible wall instead of turning the page.

This PR makes both gestures pass through:

- **Vertical pass-through.** Defer the consumption decision: hit-test on down but don't consume; wait for movement; use touch slop to disambiguate. A clear vertical drag bails out without consuming so the parent's `verticalScroll` picks it up naturally. A clear horizontal drag claims the gesture and scrubs as today. Release-before-slop is still treated as a tap-to-scrub at the down position, so tap-to-jump is unchanged.

- **Sideways handoff to the page pager.** Once we've claimed a horizontal scrub, if the pointer keeps going past the chart's left or right plot-grid edge by more than 32 dp, animate the pager to the neighbouring page (Today ↔ Tomorrow) instead of pinning the scrub at the edge — a wide cross-chart drag now flows continuously into a page turn. Plumbed through a new `LocalChartPageSwipe` composition local supplied around the pager in `TodayScreen`, so the gesture handler doesn't need direct access to pager state. Direction is derived from `ChartScrubBounds.pxPerUnit`'s sign so LTR and RTL both work.

Drags that start *outside* the plot grid (axis labels, card padding, legend strip) behave exactly as before — they're never consumed by the chart, so the parent scroll / pager handles them.

Privacy: no change. Touch handling only; nothing new leaves the device.

## Test plan

- [ ] Tap inside a chart → indicator jumps to that hour (unchanged).
- [ ] Vertical swipe that starts inside a chart's plot grid → page scrolls smoothly.
- [ ] Vertical swipe inside a chart further down the stack → page still scrolls; the second-or-later chart doesn't trap it either.
- [ ] Horizontal scrub inside a chart → scrubs hours as before; indicator follows finger and stays at the released position.
- [ ] Horizontal scrub that drags past the right edge of the chart by ≥32 dp (LTR) → pager animates toward the previous page.
- [ ] Horizontal scrub that drags past the left edge of the chart by ≥32 dp (LTR) → pager animates toward the next page.
- [ ] At page boundaries (page 0 / page 1) the handoff is a no-op rather than animating off the end.
- [ ] Drags starting outside the plot grid (axis labels, card padding, legend) still scroll the page as today.

https://claude.ai/code/session_012bPHDEeUgbWkwwgsr65VNs