### PR TITLE
Tap a chart to scrub it; drags scroll the page or swipe between days

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/today/ChartScrubber.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/ChartScrubber.kt
@@ -39,6 +39,30 @@ import kotlin.math.abs
 import kotlin.math.roundToInt
 
 /**
+ * Coordinates per-model-spread visibility with scrub-mode entry and exit.
+ * Wired by [TodayPage] when per-model data is available; left null when
+ * it isn't (older cached payloads), in which case [ChartScrubController]
+ * leaves spread state alone and the chart just scrubs.
+ *
+ * Contract:
+ *  - [isSpreadVisible] reads the live spread state (the same `state.showModelSpread`
+ *    the charts render from). The controller calls this at scrub-mode entry to
+ *    decide whether to auto-reveal.
+ *  - [revealSpread] / [hideSpread] route to the view-model's `revealModelSpread` /
+ *    `hideModelSpread`. Both are one-way setters — see those for rationale.
+ *
+ * The controller pairs every auto-reveal with a corresponding auto-hide on
+ * [ChartScrubController.reset], so a restore-to-now also undoes the spread
+ * reveal that scrub-mode entry triggered. Spread state the user enabled
+ * themselves via the confidence chip is left untouched.
+ */
+internal interface SpreadCoordinator {
+    fun isSpreadVisible(): Boolean
+    fun revealSpread()
+    fun hideSpread()
+}
+
+/**
  * Shared indicator/scrub controller. One instance lives on each page of
  * the Today/Tomorrow pager (via `remember` in `TodayPage`) and is read
  * by every chart on that page through [LocalChartScrub].
@@ -48,6 +72,13 @@ import kotlin.math.roundToInt
  * and the pager swiping back to this page — until the user navigates
  * away from the screen (state dies with the composable), taps refresh
  * ([reset]), or hits the per-chart restore icon ([reset]).
+ *
+ * Scrub-mode entry (the first [scrubTo] in a session — when [isScrubbed]
+ * transitions from false to true) doubles as the per-model-spread reveal
+ * trigger: if [spreadCoordinator] is wired and the spread isn't already
+ * visible, we flip it on and remember that we did so. The matching
+ * [reset] flips it back off. Spread state the user toggled on themselves
+ * via the confidence chip is left alone — we only undo what we did.
  *
  * [setNow] is called once a minute by `TodayPage` so the indicator keeps
  * tracking the clock in the idle state. Charts on the Tomorrow page get
@@ -65,37 +96,50 @@ internal class ChartScrubController {
 
     private var nowTime: LocalDateTime? = null
 
+    /**
+     * Optional bridge to per-model-spread state. See [SpreadCoordinator].
+     * Wired from the host page on every recomposition (the lambdas inside
+     * the coordinator close over the latest spread state and view-model
+     * methods); the gesture handler calls [scrubTo] / [reset] obliviously.
+     */
+    var spreadCoordinator: SpreadCoordinator? = null
+
+    /**
+     * True when we revealed the per-model spread as part of scrub-mode
+     * entry, so [reset] should undo it. Cleared by [reset] regardless of
+     * outcome so a second scrub session starts fresh.
+     */
+    private var autoRevealedSpread = false
+
     fun setNow(now: LocalDateTime?) {
         nowTime = now
         if (!isScrubbed) activeTime = now
     }
 
     fun scrubTo(time: LocalDateTime) {
+        val firstScrub = !isScrubbed
         activeTime = time
         isScrubbed = true
+        if (firstScrub) {
+            val coord = spreadCoordinator
+            if (coord != null && !coord.isSpreadVisible()) {
+                coord.revealSpread()
+                autoRevealedSpread = true
+            }
+        }
     }
 
     fun reset() {
         isScrubbed = false
         activeTime = nowTime
+        if (autoRevealedSpread) {
+            spreadCoordinator?.hideSpread()
+            autoRevealedSpread = false
+        }
     }
 }
 
 internal val LocalChartScrub = compositionLocalOf<ChartScrubController?> { null }
-
-/**
- * Optional handoff hook: when the user starts a horizontal scrub gesture
- * inside a chart and drags far enough past the left / right plot-grid edge,
- * [Modifier.chartScrub] calls this with `toNextPage = true` for "drag
- * continues toward the next page" (finger exited the leading edge in LTR /
- * trailing edge in RTL) or `false` for the opposite direction. The caller
- * — wired in `TodayScreen` around the page pager — animates the pager
- * accordingly, so swiping from inside a chart all the way across feels
- * continuous with a normal page swipe instead of bumping against an
- * invisible wall once the pointer leaves the chart. Null disables the
- * handoff (e.g. previews, single-page layouts).
- */
-internal val LocalChartPageSwipe = compositionLocalOf<((toNextPage: Boolean) -> Unit)?> { null }
 
 @Composable
 internal fun rememberChartScrubController(): ChartScrubController =
@@ -187,43 +231,42 @@ internal fun chartXToTime(
 }
 
 /**
- * Pointer handler. A down event that lands inside the chart's plot grid
- * (between the y- and x-axis labels) starts a candidate gesture. From
- * there we wait to see what the user is actually doing:
+ * Pointer handler. Scrub-mode entry is explicit: the user has to *tap*
+ * the chart's plot grid (down + release with no meaningful movement) to
+ * start scrubbing. Until then, drags pass through to the parent — a
+ * vertical drag scrolls the page, a horizontal drag swipes the pager.
+ * Once the controller is in scrub mode, taps and drags inside the plot
+ * grid scrub the indicator; tap the restore icon to exit.
  *
- *  - **Tap** (release before any meaningful movement): publish a scrub
- *    at the down position. Preserves the tap-to-jump behaviour.
- *  - **Clearly vertical drag** (vertical movement exceeds touch slop
- *    and dominates the horizontal component): return without consuming
- *    so the parent `verticalScroll` picks the gesture up — the user
- *    can scroll the page even when their finger started inside a chart.
- *  - **Clearly horizontal drag** (horizontal movement exceeds touch
- *    slop): claim the gesture for scrubbing, publish at the down
- *    position, then track each move.
+ * Gesture flow on a down inside the plot grid:
  *
- * Once we've claimed a horizontal drag, if the pointer keeps moving and
- * exits the chart's left or right plot-grid edge by more than
- * [edgeHandoffDp], we hand the gesture off to [onSwipeAcross] (typically
- * the page pager) and stop scrubbing — so a wide cross-chart swipe
- * flows continuously into a page turn instead of bumping against an
- * invisible wall. The handoff is one-shot: once we've called
- * [onSwipeAcross], the gesture is done and the page animation takes
- * over even if the finger keeps moving.
+ *  - **Tap** (release before any meaningful movement, in either mode):
+ *    publish a scrub at the down position. In idle mode this enters
+ *    scrub mode and the controller's [SpreadCoordinator] flips on the
+ *    per-model spread (if it wasn't already).
+ *  - **Clearly vertical drag**: return without consuming so the parent
+ *    `verticalScroll` picks the gesture up — the user can scroll the
+ *    page even when their finger started inside a chart, regardless of
+ *    scrub mode.
+ *  - **Clearly horizontal drag**:
+ *      - In idle mode: return without consuming so the pager can swipe
+ *        between Today and Tomorrow. We do not auto-enter scrub mode on
+ *        a drag — that would re-introduce the trap-the-page-swipe
+ *        problem the previous design had.
+ *      - In scrub mode (the user already tapped the chart): claim the
+ *        gesture and scrub continuously as the finger moves.
  *
  * Down events *outside* the plot grid — on Vico's axis labels, on the
  * card padding above/below the chart, on the legend strip — are left
- * unconsumed exactly as before.
+ * unconsumed in both modes.
  */
 internal fun Modifier.chartScrub(
     controller: ChartScrubController,
     bounds: ChartScrubBounds,
     hourly: List<HourlyForecast>,
     startDate: LocalDate,
-    onFirstContact: () -> Unit,
-    onSwipeAcross: ((toNextPage: Boolean) -> Unit)? = null,
-): Modifier = pointerInput(controller, bounds, hourly, startDate, onSwipeAcross) {
+): Modifier = pointerInput(controller, bounds, hourly, startDate) {
     val touchSlop = viewConfiguration.touchSlop
-    val edgeHandoffPx = edgeHandoffDp.toPx()
     awaitEachGesture {
         val down = awaitFirstDown(requireUnconsumed = true)
         val downPos = down.position
@@ -242,10 +285,12 @@ internal fun Modifier.chartScrub(
             downPos.x in bounds.layerLeftPx..bounds.layerRightPx &&
             downPos.y in bounds.layerTopPx..bounds.layerBottomPx
         if (!inGrid) return@awaitEachGesture
-        // Don't consume the down yet — we need movement (or lack of it)
-        // to decide whether this is a tap, a vertical scroll, or a
-        // horizontal scrub. Consuming early traps every drag inside
-        // the chart and blocks page scroll entirely.
+        // Capture scrub-mode state once at the start of the gesture.
+        // Reading [isScrubbed] mid-gesture would lock in a stale answer
+        // if the user taps to enter and drags in the same motion (which
+        // doesn't happen — a tap requires release first — but the
+        // snapshot at gesture start is the cleanest invariant either way).
+        val startedInScrubMode = controller.isScrubbed
         var totalDx = 0f
         var totalDy = 0f
         var claimed = false
@@ -260,17 +305,28 @@ internal fun Modifier.chartScrub(
                 val absDy = abs(totalDy)
                 if (absDy > touchSlop && absDy > absDx) {
                     // Clear vertical drag — let the parent verticalScroll
-                    // handle it by leaving events unconsumed and bailing
-                    // out of the gesture entirely.
+                    // handle it. Applies in both modes: once the user has
+                    // entered scrub mode they can still scroll the page
+                    // vertically; tap restore (or any other chart) to
+                    // re-target the indicator afterwards.
                     return@awaitEachGesture
                 }
                 if (absDx > touchSlop) {
-                    // Clear horizontal drag — claim the gesture.
+                    if (!startedInScrubMode) {
+                        // Idle + horizontal drag — let the pager handle
+                        // it. Scrub mode requires an explicit tap to
+                        // enter, deliberately, so dragging the chart
+                        // doesn't trap a page-swipe attempt.
+                        return@awaitEachGesture
+                    }
+                    // Already in scrub mode — claim the horizontal drag
+                    // and scrub continuously. Publish the down position
+                    // first so the indicator snaps to the finger before
+                    // tracking the move.
                     claimed = true
                     down.consume()
                     change.consume()
                     publishScrub(controller, bounds, hourly, startDate, downPos.x)
-                    onFirstContact()
                     publishScrub(controller, bounds, hourly, startDate, change.position.x)
                 }
                 // Otherwise ambiguous: stay uncommitted and watch the
@@ -279,44 +335,21 @@ internal fun Modifier.chartScrub(
             } else {
                 change.consume()
                 publishScrub(controller, bounds, hourly, startDate, change.position.x)
-                if (onSwipeAcross != null) {
-                    val px = change.position.x
-                    val exitedRight = px > bounds.layerRightPx + edgeHandoffPx
-                    val exitedLeft = px < bounds.layerLeftPx - edgeHandoffPx
-                    if (exitedLeft || exitedRight) {
-                        // Pointer dragged well past the plot edge — hand
-                        // off to the pager. In LTR the chart draws
-                        // left-to-right (positive pxPerUnit) and exiting
-                        // the left edge means the finger is moving toward
-                        // the *next* page (rightward content scrolls in);
-                        // in RTL the chart and the pager both flip, so
-                        // exiting the right edge means next-page. Using
-                        // `bounds.pxPerUnit`'s sign avoids importing
-                        // LayoutDirection — it's already direction-aware.
-                        val ltr = bounds.pxPerUnit >= 0f
-                        val toNextPage = (exitedLeft && ltr) || (exitedRight && !ltr)
-                        onSwipeAcross(toNextPage)
-                        return@awaitEachGesture
-                    }
-                }
             }
             if (!change.pressed) {
                 if (!claimed) {
-                    // Released before reaching touch slop — treat as a
-                    // tap and publish a scrub at the original down
-                    // position. Preserves tap-to-scrub even though we
-                    // deferred consumption to disambiguate from scroll.
+                    // Released before reaching touch slop — a tap.
+                    // Publish a scrub at the original down position; in
+                    // idle this enters scrub mode (and the controller's
+                    // coordinator reveals the per-model spread), in
+                    // scrub mode it just retargets the indicator.
                     publishScrub(controller, bounds, hourly, startDate, downPos.x)
-                    onFirstContact()
                 }
                 break
             }
         }
     }
 }
-
-/** Pointer distance past the chart's left / right edge that triggers a page-swipe handoff. */
-private val edgeHandoffDp = 32.dp
 
 private fun publishScrub(
     controller: ChartScrubController,

--- a/app/src/main/kotlin/app/clothescast/ui/today/ForecastChart.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/ForecastChart.kt
@@ -121,10 +121,6 @@ fun ForecastChart(
     // wrap. Falls back to today's date for previews / non-screen callers
     // that don't drive the indicator from a real insight.
     startDate: LocalDate = LocalDate.now(),
-    // Fires once on the first pointer-down of a scrub gesture — wired in
-    // [TodayScreen] to reveal the per-model spread overlay so tapping
-    // any chart both sets the indicator time and lights up the lines.
-    onFirstContact: () -> Unit = {},
     modifier: Modifier = Modifier,
     // Optional per-model data. When non-null, used to size the y-axis to the
     // full envelope regardless of [showModelSpread] so the toggle only adds /
@@ -242,7 +238,6 @@ fun ForecastChart(
     val lineProvider = rememberPinnedLineProvider(visibleModels, mainLineColor, modelColors)
 
     val scrubController = LocalChartScrub.current
-    val pageSwipe = LocalChartPageSwipe.current
     val scrubBounds = rememberChartScrubBounds()
     val scrubIndicator = rememberChartScrubIndicator(scrubController, scrubBounds, hourly, startDate)
     val decorations = listOf(scrubIndicator)
@@ -253,7 +248,7 @@ fun ForecastChart(
             .height(180.dp)
             .let { mod ->
                 if (scrubController != null) {
-                    mod.chartScrub(scrubController, scrubBounds, hourly, startDate, onFirstContact, pageSwipe)
+                    mod.chartScrub(scrubController, scrubBounds, hourly, startDate)
                 } else {
                     mod
                 }

--- a/app/src/main/kotlin/app/clothescast/ui/today/PerModelDiagnosticCard.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/PerModelDiagnosticCard.kt
@@ -97,12 +97,6 @@ internal fun PerModelDiagnosticCard(
      * doesn't shift the axis labels.
      */
     showOverlay: Boolean = false,
-    /**
-     * Fires on the first pointer-down of a scrub gesture on this card's
-     * chart. Wired in [TodayScreen] to reveal the per-model spread overlay
-     * — same affordance as the temp / precip cards.
-     */
-    onFirstContact: (() -> Unit)? = null,
 ) {
     val times = remember(hourly) { hourly.map { it.time } }
     // Build (originalIndex, value) pairs per model so a sparse series plots at
@@ -157,7 +151,6 @@ internal fun PerModelDiagnosticCard(
                     seriesByModel = seriesByModel,
                     overlayModels = if (showOverlay) availableModels else emptyList(),
                     yAxis = yAxis,
-                    onFirstContact = onFirstContact ?: {},
                 )
                 ModelSpreadLegend(
                     visibleModelIds = if (showOverlay) availableModels else emptyList(),
@@ -192,7 +185,6 @@ private fun PerModelDiagnosticChart(
     seriesByModel: Map<String, List<Pair<Int, Double>>>,
     overlayModels: List<String>,
     yAxis: YAxis,
-    onFirstContact: () -> Unit,
 ) {
     val times = remember(hourly) { hourly.map { it.time } }
     val mainLineColor = AppTheme.mainLineColor
@@ -285,7 +277,6 @@ private fun PerModelDiagnosticChart(
     val lineProvider = rememberPinnedLineProvider(overlayModels, mainLineColor)
 
     val scrubController = LocalChartScrub.current
-    val pageSwipe = LocalChartPageSwipe.current
     val scrubBounds = rememberChartScrubBounds()
     val scrubIndicator = rememberChartScrubIndicator(scrubController, scrubBounds, hourly, startDate)
     val decorations = listOf(scrubIndicator)
@@ -296,7 +287,7 @@ private fun PerModelDiagnosticChart(
             .height(140.dp)
             .let { mod ->
                 if (scrubController != null) {
-                    mod.chartScrub(scrubController, scrubBounds, hourly, startDate, onFirstContact, pageSwipe)
+                    mod.chartScrub(scrubController, scrubBounds, hourly, startDate)
                 } else {
                     mod
                 }

--- a/app/src/main/kotlin/app/clothescast/ui/today/PrecipitationAmountChart.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/PrecipitationAmountChart.kt
@@ -49,7 +49,6 @@ import kotlin.math.roundToInt
 fun PrecipitationAmountChart(
     hourly: List<HourlyForecast>,
     startDate: LocalDate = LocalDate.now(),
-    onFirstContact: () -> Unit = {},
     modifier: Modifier = Modifier,
     perModelHourly: PerModelHourly? = null,
     showModelSpread: Boolean = false,
@@ -137,7 +136,7 @@ fun PrecipitationAmountChart(
             .height(140.dp)
             .let { mod ->
                 if (scrubController != null) {
-                    mod.chartScrub(scrubController, scrubBounds, hourly, startDate, onFirstContact)
+                    mod.chartScrub(scrubController, scrubBounds, hourly, startDate)
                 } else {
                     mod
                 }

--- a/app/src/main/kotlin/app/clothescast/ui/today/PrecipitationChart.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/PrecipitationChart.kt
@@ -46,9 +46,6 @@ fun PrecipitationChart(
     // Date of `hourly[0]` — needed by the shared scrub indicator. See
     // [ForecastChart] for the same parameter.
     startDate: LocalDate = LocalDate.now(),
-    // Fires on first pointer-down of a scrub gesture — wired in
-    // [TodayScreen] to reveal the per-model spread overlay.
-    onFirstContact: () -> Unit = {},
     modifier: Modifier = Modifier,
     // Optional per-model data; see [ForecastChart] for the same pattern.
     perModelHourly: PerModelHourly? = null,
@@ -153,7 +150,6 @@ fun PrecipitationChart(
     val lineProvider = rememberPinnedLineProvider(visibleModels, mainLineColor)
 
     val scrubController = LocalChartScrub.current
-    val pageSwipe = LocalChartPageSwipe.current
     val scrubBounds = rememberChartScrubBounds()
     val scrubIndicator = rememberChartScrubIndicator(scrubController, scrubBounds, hourly, startDate)
     val decorations = listOf(scrubIndicator)
@@ -167,7 +163,7 @@ fun PrecipitationChart(
             .height(140.dp)
             .let { mod ->
                 if (scrubController != null) {
-                    mod.chartScrub(scrubController, scrubBounds, hourly, startDate, onFirstContact, pageSwipe)
+                    mod.chartScrub(scrubController, scrubBounds, hourly, startDate)
                 } else {
                     mod
                 }

--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
@@ -52,6 +52,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -273,6 +274,7 @@ fun TodayScreen(
             onNavigateToFormat = onNavigateToFormat,
             onToggleModelSpread = viewModel::toggleModelSpread,
             onRevealModelSpread = viewModel::revealModelSpread,
+            onHideModelSpread = viewModel::hideModelSpread,
             onLongPressDate = onNavigateToDeveloper,
         )
     }
@@ -310,6 +312,7 @@ private fun TodayContent(
     onNavigateToFormat: () -> Unit,
     onToggleModelSpread: () -> Unit,
     onRevealModelSpread: () -> Unit,
+    onHideModelSpread: () -> Unit,
     onLongPressDate: () -> Unit,
 ) {
     val context = LocalContext.current
@@ -409,66 +412,51 @@ private fun TodayContent(
             // the rain chart on Today, swiping to Tomorrow keeps them
             // on the rain chart rather than snapping back to the top.
             val scrollState = rememberScrollState()
-            // Hands a wide horizontal scrub off to the pager: if the user
-            // starts dragging inside a chart and the pointer keeps going
-            // past the plot-grid edge, [Modifier.chartScrub] calls this
-            // and we animate the pager to the neighbouring page. Clamped
-            // to the page range so a swipe past the first / last page is
-            // a no-op rather than an error.
-            val pageSwipe: (Boolean) -> Unit = remember(pagerState, pagerScope) {
-                { toNextPage ->
-                    val target = pagerState.currentPage + if (toNextPage) 1 else -1
-                    if (target in 0 until pagerState.pageCount) {
-                        pagerScope.launch { pagerState.animateScrollToPage(target) }
-                    }
-                }
-            }
             // Placeholder period for page 2 when its slot is empty —
             // whatever the next 12-hour window after `thisPeriodInsight` is.
             // The worker writes [InsightCache.Slot.NEXT_PERIOD] paired with
             // each delivery, so this fallback only fires before the first
             // post-upgrade worker run.
             val nextPeriodFallback = state.thisPeriodInsight.period.opposite()
-            CompositionLocalProvider(LocalChartPageSwipe provides pageSwipe) {
-                HorizontalPager(
-                    state = pagerState,
-                    modifier = Modifier
-                        .weight(1f)
-                        .fillMaxWidth(),
-                ) { page ->
-                    val pageInsight = if (page == 0) state.thisPeriodInsight else state.nextPeriodInsight
-                    val pagePeriod = if (page == 0) state.thisPeriodInsight.period else nextPeriodFallback
-                    TodayPage(
-                        insight = pageInsight,
-                        fallbackPeriod = pagePeriod,
-                        state = state,
-                        scrollState = scrollState,
-                        // Same outfit row on both pages — page 2 shows this
-                        // period's pair too, not the page-2 period's pair. We
-                        // don't surface a 3rd period (tomorrow) on page 2; the
-                        // outfit row stays the at-a-glance today+tonight summary.
-                        outfitInsight = state.thisPeriodInsight,
-                        showChevronRight = (page == 0),
-                        showChevronLeft = (page == 1),
-                        workStatusToShow = workStatusToShow,
-                        locationActionRequired = locationActionRequired,
-                        onChevronTap = {
-                            pagerScope.launch {
-                                pagerState.animateScrollToPage(if (page == 0) 1 else 0)
-                            }
-                        },
-                        onAdjustThreshold = onAdjustThreshold,
-                        onNavigateToClothes = onNavigateToClothes,
-                        onNavigateToFormat = onNavigateToFormat,
-                        onToggleModelSpread = onToggleModelSpread,
-                        onRevealModelSpread = onRevealModelSpread,
-                        onLongPressDate = onLongPressDate,
-                        onSetUpLocation = onSetUpLocation,
-                        onOpenPrivacy = onOpenPrivacy,
-                        onOpenCalendarSettings = onOpenCalendarSettings,
-                        onDismissCelebrationCard = onDismissCelebrationCard,
-                    )
-                }
+            HorizontalPager(
+                state = pagerState,
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxWidth(),
+            ) { page ->
+                val pageInsight = if (page == 0) state.thisPeriodInsight else state.nextPeriodInsight
+                val pagePeriod = if (page == 0) state.thisPeriodInsight.period else nextPeriodFallback
+                TodayPage(
+                    insight = pageInsight,
+                    fallbackPeriod = pagePeriod,
+                    state = state,
+                    scrollState = scrollState,
+                    // Same outfit row on both pages — page 2 shows this
+                    // period's pair too, not the page-2 period's pair. We
+                    // don't surface a 3rd period (tomorrow) on page 2; the
+                    // outfit row stays the at-a-glance today+tonight summary.
+                    outfitInsight = state.thisPeriodInsight,
+                    showChevronRight = (page == 0),
+                    showChevronLeft = (page == 1),
+                    workStatusToShow = workStatusToShow,
+                    locationActionRequired = locationActionRequired,
+                    onChevronTap = {
+                        pagerScope.launch {
+                            pagerState.animateScrollToPage(if (page == 0) 1 else 0)
+                        }
+                    },
+                    onAdjustThreshold = onAdjustThreshold,
+                    onNavigateToClothes = onNavigateToClothes,
+                    onNavigateToFormat = onNavigateToFormat,
+                    onToggleModelSpread = onToggleModelSpread,
+                    onRevealModelSpread = onRevealModelSpread,
+                    onHideModelSpread = onHideModelSpread,
+                    onLongPressDate = onLongPressDate,
+                    onSetUpLocation = onSetUpLocation,
+                    onOpenPrivacy = onOpenPrivacy,
+                    onOpenCalendarSettings = onOpenCalendarSettings,
+                    onDismissCelebrationCard = onDismissCelebrationCard,
+                )
             }
         }
     }
@@ -559,6 +547,7 @@ private fun TodayPage(
     onNavigateToFormat: () -> Unit,
     onToggleModelSpread: () -> Unit,
     onRevealModelSpread: () -> Unit,
+    onHideModelSpread: () -> Unit,
     onLongPressDate: () -> Unit,
     onSetUpLocation: () -> Unit,
     onOpenPrivacy: () -> Unit,
@@ -634,19 +623,21 @@ private fun TodayPage(
             //    "tap to show / hide" toggle (wired through [onChipTap] →
             //    [onToggleModelSpread]). That's the explicit on/off control.
             //
-            //  - The plot grid of every chart drives the shared
-            //    [ChartScrubController] — first contact also fires
-            //    [onRevealModelSpread], a one-way set so dragging the
-            //    indicator can't accidentally hide the spread mid-drag.
-            //    The user takes the spread back off via the chip.
+            //  - Tapping the plot grid of any chart enters scrub mode on
+            //    the shared [ChartScrubController], which (via the
+            //    [SpreadCoordinator] wired below) reveals the per-model
+            //    spread if it isn't already on. The matching restore
+            //    icon exits scrub mode and undoes only that auto-reveal
+            //    — spread state the user enabled via the chip is left
+            //    alone.
             //
-            // [chartReveal] / [chipToggle] are null when there's no per-model
-            // data in the cache (e.g. older payloads) — in that case the
-            // chip stays as a static confidence summary and the chart
-            // gestures just scrub without touching spread state.
+            // [chipToggle] is null when there's no per-model data in
+            // the cache (e.g. older payloads) — in that case the chip
+            // stays as a static confidence summary and the controller's
+            // [spreadCoordinator] stays null so chart gestures just
+            // scrub without touching spread state.
             val perModelAvailable = insight.perModelHourly != null
             val chipToggle = onToggleModelSpread.takeIf { perModelAvailable }
-            val chartReveal: (() -> Unit)? = onRevealModelSpread.takeIf { perModelAvailable }
             InsightCard(
                 insight = insight,
                 region = state.region,
@@ -727,6 +718,24 @@ private fun TodayPage(
                         delay(60_000L)
                     }
                 }
+                // Bridge the controller to the per-model-spread state so a
+                // tap-to-scrub gesture reveals the spread (and tapping
+                // restore undoes that reveal). Reassigned on every
+                // recomposition so the closures see the live
+                // [state.showModelSpread] value — the controller itself is
+                // remembered across compositions, only its callbacks change.
+                // Stays null when there's no per-model data (older cached
+                // payloads) so the controller skips the reveal entirely.
+                val showSpread = state.showModelSpread
+                SideEffect {
+                    scrubController.spreadCoordinator = if (!perModelAvailable) null else {
+                        object : SpreadCoordinator {
+                            override fun isSpreadVisible(): Boolean = showSpread
+                            override fun revealSpread() = onRevealModelSpread()
+                            override fun hideSpread() = onHideModelSpread()
+                        }
+                    }
+                }
                 CompositionLocalProvider(LocalChartScrub provides scrubController) {
                     ForecastCard(
                         hourly = insight.hourly,
@@ -735,7 +744,6 @@ private fun TodayPage(
                         startDate = insight.forDate,
                         perModelHourly = perModelData,
                         showModelSpread = state.showModelSpread,
-                        onFirstContact = chartReveal,
                     )
                     AirTemperatureCard(
                         hourly = insight.hourly,
@@ -743,14 +751,12 @@ private fun TodayPage(
                         startDate = insight.forDate,
                         perModelHourly = perModelData,
                         showModelSpread = state.showModelSpread,
-                        onFirstContact = chartReveal,
                     )
                     PrecipitationCard(
                         hourly = insight.hourly,
                         startDate = insight.forDate,
                         perModelHourly = perModelData,
                         showModelSpread = state.showModelSpread,
-                        onFirstContact = chartReveal,
                     )
                     PrecipitationAmountCard(
                         hourly = insight.hourly,
@@ -758,7 +764,6 @@ private fun TodayPage(
                         period = insight.period,
                         perModelHourly = perModelData,
                         showModelSpread = state.showModelSpread,
-                        onFirstContact = chartReveal,
                     )
                     // Diagnostic cards below the headline temp + rain pair. Each
                     // draws a consensus main line by default and overlays the
@@ -777,35 +782,30 @@ private fun TodayPage(
                             windSpeedUnit = state.distanceUnit.windSpeedUnit(),
                             startDate = insight.forDate,
                             showModelSpread = state.showModelSpread,
-                            onFirstContact = chartReveal,
                         )
                         HumidityCard(
                             hourly = insight.hourly,
                             perModelHourly = perModelData,
                             startDate = insight.forDate,
                             showModelSpread = state.showModelSpread,
-                            onFirstContact = chartReveal,
                         )
                         CloudCard(
                             hourly = insight.hourly,
                             perModelHourly = perModelData,
                             startDate = insight.forDate,
                             showModelSpread = state.showModelSpread,
-                            onFirstContact = chartReveal,
                         )
                         SolarRadiationCard(
                             hourly = insight.hourly,
                             perModelHourly = perModelData,
                             startDate = insight.forDate,
                             showModelSpread = state.showModelSpread,
-                            onFirstContact = chartReveal,
                         )
                         UvIndexCard(
                             hourly = insight.hourly,
                             perModelHourly = perModelData,
                             startDate = insight.forDate,
                             showModelSpread = state.showModelSpread,
-                            onFirstContact = chartReveal,
                         )
                         SunshineCard(
                             hourly = insight.hourly,
@@ -813,7 +813,6 @@ private fun TodayPage(
                             forDate = insight.forDate,
                             period = insight.period,
                             showModelSpread = state.showModelSpread,
-                            onFirstContact = chartReveal,
                         )
                     }
                 }
@@ -1892,7 +1891,6 @@ internal fun ForecastCard(
     startDate: java.time.LocalDate = java.time.LocalDate.now(),
     perModelHourly: PerModelHourly? = null,
     showModelSpread: Boolean = false,
-    onFirstContact: (() -> Unit)? = null,
 ) {
     val symbol = temperatureUnit.symbol()
     val feelsLikeMinMax = remember(hourly, temperatureUnit) {
@@ -1927,7 +1925,6 @@ internal fun ForecastCard(
                     temperatureUnit = temperatureUnit,
                     showFeelsLike = true,
                     startDate = startDate,
-                    onFirstContact = onFirstContact ?: {},
                     perModelHourly = perModelHourly,
                     showModelSpread = showModelSpread,
                 )
@@ -1958,7 +1955,6 @@ internal fun AirTemperatureCard(
     startDate: java.time.LocalDate = java.time.LocalDate.now(),
     perModelHourly: PerModelHourly? = null,
     showModelSpread: Boolean = false,
-    onFirstContact: (() -> Unit)? = null,
 ) {
     val symbol = temperatureUnit.symbol()
     val airMinMax = remember(hourly, temperatureUnit) {
@@ -1993,7 +1989,6 @@ internal fun AirTemperatureCard(
                     temperatureUnit = temperatureUnit,
                     showFeelsLike = false,
                     startDate = startDate,
-                    onFirstContact = onFirstContact ?: {},
                     perModelHourly = perModelHourly,
                     showModelSpread = showModelSpread,
                 )
@@ -2104,7 +2099,6 @@ internal fun WindCard(
     windSpeedUnit: WindSpeedUnit = WindSpeedUnit.KMH,
     startDate: java.time.LocalDate = java.time.LocalDate.now(),
     showModelSpread: Boolean = false,
-    onFirstContact: (() -> Unit)? = null,
 ) {
     val times = remember(hourly) { hourly.map { it.time } }
     // 10 km/h floor on the y-range so a near-still day doesn't get zoomed
@@ -2144,7 +2138,6 @@ internal fun WindCard(
         // overlay payload is unchanged.
         pickerKey = windSpeedUnit,
         showOverlay = showModelSpread,
-        onFirstContact = onFirstContact,
     )
 }
 
@@ -2161,7 +2154,6 @@ internal fun CloudCard(
     perModelHourly: PerModelHourly,
     startDate: java.time.LocalDate = java.time.LocalDate.now(),
     showModelSpread: Boolean = false,
-    onFirstContact: (() -> Unit)? = null,
 ) {
     val range = remember(perModelHourly) {
         perModelConsensusRange(perModelHourly) { it.cloudCoverPct }
@@ -2179,7 +2171,6 @@ internal fun CloudCard(
         yAxis = YAxis.Percent,
         tooltipValueFormat = { "${it.roundToInt()}%" },
         showOverlay = showModelSpread,
-        onFirstContact = onFirstContact,
     )
 }
 
@@ -2196,7 +2187,6 @@ internal fun HumidityCard(
     perModelHourly: PerModelHourly,
     startDate: java.time.LocalDate = java.time.LocalDate.now(),
     showModelSpread: Boolean = false,
-    onFirstContact: (() -> Unit)? = null,
 ) {
     val range = remember(perModelHourly) {
         perModelConsensusRange(perModelHourly) { it.relativeHumidityPct }
@@ -2214,7 +2204,6 @@ internal fun HumidityCard(
         yAxis = YAxis.Percent,
         tooltipValueFormat = { "${it.roundToInt()}%" },
         showOverlay = showModelSpread,
-        onFirstContact = onFirstContact,
     )
 }
 
@@ -2231,7 +2220,6 @@ internal fun SolarRadiationCard(
     perModelHourly: PerModelHourly,
     startDate: java.time.LocalDate = java.time.LocalDate.now(),
     showModelSpread: Boolean = false,
-    onFirstContact: (() -> Unit)? = null,
 ) {
     val times = remember(hourly) { hourly.map { it.time } }
     // Peak irradiance across the cross-model consensus series — same blend
@@ -2266,7 +2254,6 @@ internal fun SolarRadiationCard(
         yAxis = YAxis.AutoZeroBased(minSpan = 100.0),
         tooltipValueFormat = { "${it.roundToInt()} W/m²" },
         showOverlay = showModelSpread,
-        onFirstContact = onFirstContact,
     )
 }
 
@@ -2287,7 +2274,6 @@ internal fun SunshineCard(
     forDate: java.time.LocalDate,
     period: ForecastPeriod = ForecastPeriod.TODAY,
     showModelSpread: Boolean = false,
-    onFirstContact: (() -> Unit)? = null,
 ) {
     // TONIGHT's slice spans [tonightStart, next morning) and so straddles
     // midnight; the per-date filter would drop pre-alarm tomorrow-morning sun
@@ -2316,7 +2302,6 @@ internal fun SunshineCard(
         yAxis = YAxis.AutoZeroBased(minSpan = 60.0),
         tooltipValueFormat = { "${it.roundToInt()} min" },
         showOverlay = showModelSpread,
-        onFirstContact = onFirstContact,
     )
 }
 
@@ -2355,7 +2340,6 @@ internal fun UvIndexCard(
     perModelHourly: PerModelHourly,
     startDate: java.time.LocalDate = java.time.LocalDate.now(),
     showModelSpread: Boolean = false,
-    onFirstContact: (() -> Unit)? = null,
 ) {
     val times = remember(hourly) { hourly.map { it.time } }
     // Peak UV across the cross-model consensus series — same blend the chart
@@ -2392,7 +2376,6 @@ internal fun UvIndexCard(
         // the metric, and the readout sits right next to that subtitle.
         tooltipValueFormat = { "${it.roundToInt()}" },
         showOverlay = showModelSpread,
-        onFirstContact = onFirstContact,
     )
 }
 
@@ -2402,7 +2385,6 @@ internal fun PrecipitationCard(
     startDate: java.time.LocalDate = java.time.LocalDate.now(),
     perModelHourly: PerModelHourly? = null,
     showModelSpread: Boolean = false,
-    onFirstContact: (() -> Unit)? = null,
 ) {
     // Always render the chart, even on dry days — keeps the card height stable
     // across days so the cards below don't shift, and the flat baseline is its
@@ -2447,7 +2429,6 @@ internal fun PrecipitationCard(
                 PrecipitationChart(
                     hourly = hourly,
                     startDate = startDate,
-                    onFirstContact = onFirstContact ?: {},
                     perModelHourly = perModelHourly,
                     showModelSpread = showModelSpread,
                 )
@@ -2494,7 +2475,6 @@ internal fun PrecipitationAmountCard(
     period: ForecastPeriod = ForecastPeriod.TODAY,
     perModelHourly: PerModelHourly? = null,
     showModelSpread: Boolean = false,
-    onFirstContact: (() -> Unit)? = null,
 ) {
     // Same series the chart plots for its "Combined" main line — sourced
     // from the consensus mean per hour when per-model data is available,
@@ -2550,7 +2530,6 @@ internal fun PrecipitationAmountCard(
                 PrecipitationAmountChart(
                     hourly = hourly,
                     startDate = forDate,
-                    onFirstContact = onFirstContact ?: {},
                     perModelHourly = perModelHourly,
                     showModelSpread = showModelSpread,
                 )

--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayViewModel.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayViewModel.kt
@@ -483,6 +483,18 @@ class TodayViewModel(
     }
 
     /**
+     * One-way hide — paired with [revealModelSpread]. Wired to the chart's
+     * restore action: when the user exits scrub mode and we revealed the
+     * per-model spread as part of entering it, undo that reveal so the
+     * spread doesn't linger past the scrub session. If the user had the
+     * spread on already (via the confidence chip) the restore path leaves
+     * it alone — the controller tracks that on its side.
+     */
+    fun hideModelSpread() {
+        showModelSpread.value = false
+    }
+
+    /**
      * Nudges the temperature threshold of the [ClothesRule] keyed [ruleItem] by
      * [deltaC] degrees Celsius. Wired to the rationale dialog's `−1°` / `+1°`
      * controls. The read-modify-write is delegated to


### PR DESCRIPTION
## Summary

Follow-up to #682 (which was merged but the sideways-drag-past-chart-edge handoff didn't feel great). This switches chart scrubbing to an explicit two-mode model so chart gestures stop fighting with page scroll and pager swipe.

**New gesture model:**

- **Idle (default).** Drags inside the plot grid pass through completely. A vertical drag scrolls the page; a horizontal drag swipes between Today and Tomorrow. Tap a chart to enter scrub mode — the indicator snaps to the tap position, the per-model spread reveals, and the restore icon appears.
- **Scrub mode.** Taps and horizontal drags scrub the indicator across all charts on the page in lock-step. Vertical drags still scroll the page so you can compare other charts without leaving scrub mode. Tap restore to exit; the per-model spread reverts to whatever it was before scrub mode started — explicit enables via the confidence chip are preserved, only the scrub-mode auto-reveal is undone.

**Implementation:**

- Per-model-spread coordination moves onto `ChartScrubController` via a new `SpreadCoordinator` interface. `scrubTo` auto-reveals on first scrub of a session (and remembers it did); `reset` auto-hides iff that auto-reveal fired. Wired from `TodayPage` in a `SideEffect` so the closures read the live `state.showModelSpread`.
- Adds `TodayViewModel.hideModelSpread()` as the one-way counterpart to `revealModelSpread()`.
- Drops the sideways-drag-past-chart-edge pager handoff from #682, along with `LocalChartPageSwipe`. With explicit tap-to-scrub the pager already receives horizontal drags naturally, no programmatic handoff needed.
- Drops the now-unused `onFirstContact` callback from every chart card and the seven intermediate `*Card` wrappers — the controller's coordinator replaces it.

Restore icon visibility is unchanged: it's gated on `controller.isScrubbed`, so it appears only when the user has actively tapped to enter scrub mode, not whenever the per-model spread happens to be on via the confidence chip.

Privacy: no change. Touch handling and a one-way local boolean toggle; nothing leaves the device.

## Test plan

Scrub-mode entry / exit:
- [ ] Default state: drag vertically on a chart → page scrolls. Drag horizontally on a chart → pager swipes between Today and Tomorrow.
- [ ] Tap a chart in idle → indicator appears at the tap position; per-model spread reveals; restore icon appears.
- [ ] Tap the restore icon → indicator hides; per-model spread reverts to off; restore icon disappears.
- [ ] In scrub mode, tap a different chart → indicator jumps to that position (all charts move in lock-step). Spread stays on.
- [ ] In scrub mode, horizontal drag on a chart → scrubs smoothly along the day.
- [ ] In scrub mode, vertical drag on a chart → page scrolls; scrub mode stays on.

Per-model spread coordination:
- [ ] Spread off → tap chart → spread on → tap restore → spread off (auto-reveal undone).
- [ ] Spread on via confidence chip → tap chart → spread stays on → tap restore → spread stays on (we didn't auto-reveal, so we don't auto-hide).
- [ ] Tapping the confidence chip toggles spread on/off independently of scrub mode (unchanged behaviour).
- [ ] Restore icon shows iff scrub mode is active, not whenever spread is on.

Cache / data:
- [ ] On an older insight without per-model data: chart gestures still scrub (no spread coordinator wired); restore icon still appears and clears the indicator.

https://claude.ai/code/session_012bPHDEeUgbWkwwgsr65VNs

---
_Generated by [Claude Code](https://claude.ai/code/session_012bPHDEeUgbWkwwgsr65VNs)_