### PR TITLE
Trim the dawn and dusk hour from the day's clothing recommendation

### DIFF
--- a/app/src/test/kotlin/app/clothescast/data/InsightCacheTest.kt
+++ b/app/src/test/kotlin/app/clothescast/data/InsightCacheTest.kt
@@ -63,11 +63,16 @@ class InsightCacheTest {
     private val now = Instant.parse("2026-04-25T07:00:00Z")
 
     private val mildHourly = listOf(
+        // 08:00 sits inside the exposure window, so the cold edge still drives
+        // the band's min — the 07:00 hour is dropped from min/max by the
+        // exposure-buffer trim (see `slicedForToday`).
         HourlyForecast(LocalTime.of(7, 0), 14.0, 13.0, 5.0, WeatherCondition.CLEAR),
+        HourlyForecast(LocalTime.of(8, 0), 14.0, 13.0, 5.0, WeatherCondition.CLEAR),
         HourlyForecast(LocalTime.of(14, 0), 19.0, 18.0, 5.0, WeatherCondition.CLEAR),
     )
     private val mildYesterdayHourly = listOf(
         HourlyForecast(LocalTime.of(7, 0), 13.0, 12.0, 5.0, WeatherCondition.CLEAR),
+        HourlyForecast(LocalTime.of(8, 0), 13.0, 12.0, 5.0, WeatherCondition.CLEAR),
         HourlyForecast(LocalTime.of(14, 0), 18.0, 17.0, 5.0, WeatherCondition.CLEAR),
     )
 

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/DeriveInsight.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/DeriveInsight.kt
@@ -18,6 +18,7 @@ import app.clothescast.core.domain.model.UserPreferences
 import app.clothescast.core.domain.model.WeatherAlert
 import app.clothescast.core.domain.model.WeatherCondition
 import app.clothescast.core.domain.repository.ForecastBundle
+import java.time.Duration
 import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -362,6 +363,23 @@ internal fun tonightWindow(
     LocalDateTime.of(date, entry.time)
 }
 
+// Buffer trimmed off each end of the daytime window when computing feels-like /
+// temperature min/max for clothes rules and the displayed band. The notification
+// time (default 07:00) is when the user gets the morning insight, not when they
+// step outside — the pre-dawn hour at the leading edge drags the day's coldest
+// reading toward heavier clothes than they'll need by the time they leave home,
+// and the post-dusk hour at the trailing edge has the symmetric effect on warm-
+// weather days. Hourly list, peak-precip detection, and condition resolution
+// still use the full sliced window: an in-window 7:30 shower is exactly what the
+// rain mention exists to surface, even if the user isn't outside until 8.
+//
+// TODO(window): expose this in settings. Options worth weighing: a separate
+// "leave home" / "back home" pair distinct from the notification times, or a
+// single "exposure buffer" duration applied to both edges. Until then every
+// user gets the 1-hour default — coarse but better than the dawn-dip dragging
+// every cold-morning recommendation toward a jacket.
+private val CLOTHES_EXPOSURE_BUFFER: Duration = Duration.ofHours(1)
+
 internal fun DailyForecast.slicedForToday(
     morningStart: LocalTime,
     eveningEnd: LocalTime,
@@ -369,12 +387,27 @@ internal fun DailyForecast.slicedForToday(
     if (!morningStart.isBefore(eveningEnd)) return this
     val sliced = hourly.filter { it.time >= morningStart && it.time < eveningEnd }
     if (sliced.isEmpty()) return copy(hourly = sliced)
+    val exposureStart = morningStart.plus(CLOTHES_EXPOSURE_BUFFER)
+    val exposureEnd = eveningEnd.minus(CLOTHES_EXPOSURE_BUFFER)
+    // Wrap-around guard: LocalTime.plus / minus rolls past midnight, so a
+    // notification time near the day boundary would silently invert the window.
+    // Fall back to the full slice when the trim would either invert the order
+    // or shrink to nothing.
+    val canTrim = !exposureStart.isBefore(morningStart) &&
+        !exposureEnd.isAfter(eveningEnd) &&
+        exposureStart.isBefore(exposureEnd)
+    val minMaxSource = if (canTrim) {
+        sliced.filter { it.time >= exposureStart && it.time < exposureEnd }
+            .ifEmpty { sliced }
+    } else {
+        sliced
+    }
     return copy(
         hourly = sliced,
-        temperatureMinC = sliced.minOf { it.temperatureC },
-        temperatureMaxC = sliced.maxOf { it.temperatureC },
-        feelsLikeMinC = sliced.minOf { it.feelsLikeC },
-        feelsLikeMaxC = sliced.maxOf { it.feelsLikeC },
+        temperatureMinC = minMaxSource.minOf { it.temperatureC },
+        temperatureMaxC = minMaxSource.maxOf { it.temperatureC },
+        feelsLikeMinC = minMaxSource.minOf { it.feelsLikeC },
+        feelsLikeMaxC = minMaxSource.maxOf { it.feelsLikeC },
         precipitationProbabilityMaxPct = sliced.maxOf { it.precipitationProbabilityPct },
         condition = sliced.maxByOrNull { it.precipitationProbabilityPct }
             ?.condition

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsightTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsightTest.kt
@@ -506,6 +506,54 @@ class GenerateDailyInsightTest {
     }
 
     @Test
+    fun `today period trims a one-hour exposure buffer off each edge of the band min and max`() = runTest {
+        // Notification window is [07:00, 19:00) by default, but the user isn't outside
+        // at 7am — they're getting dressed. A sharp pre-dawn dip at 07:00 (feels-like
+        // 4°C) and a still-warm reading at 18:00 (24°C) would otherwise widen the
+        // band to COLD..WARM, dragging the recommendation toward a jacket the user
+        // doesn't need by 8am. The exposure buffer trims those edge hours, so the
+        // band reflects what the user actually feels between 08:00 and 18:00.
+        val todayHourly = listOf(
+            HourlyForecast(LocalTime.of(7, 0), 6.0, 4.0, 5.0, WeatherCondition.CLEAR),
+            HourlyForecast(LocalTime.of(9, 0), 14.0, 12.0, 5.0, WeatherCondition.CLEAR),
+            HourlyForecast(LocalTime.of(15, 0), 22.0, 20.0, 5.0, WeatherCondition.CLEAR),
+            HourlyForecast(LocalTime.of(18, 0), 26.0, 24.0, 5.0, WeatherCondition.CLEAR),
+        )
+        val todayWithHourly = today.copy(hourly = todayHourly)
+        val weather = FakeWeatherRepository(ForecastBundle(todayWithHourly, yesterday))
+        val subject = GenerateDailyInsight(weather, clock = clock)
+
+        val result = subject(london, prefs)
+
+        result.insight.summary.band.feelsLikeMinC shouldBe 12.0
+        result.insight.summary.band.feelsLikeMaxC shouldBe 20.0
+        result.insight.summary.band.low shouldBe TemperatureBand.COOL
+        result.insight.summary.band.high shouldBe TemperatureBand.MILD
+    }
+
+    @Test
+    fun `today period still surfaces rain in the buffered edge hours`() = runTest {
+        // The exposure buffer narrows the band's min/max, but peak precipitation
+        // still walks the full [morningStart, eveningEnd) slice. A 7:30am-ish
+        // shower (7am hour, 80% rain) is exactly the warning the morning insight
+        // exists to deliver, even though the user isn't outside until 8.
+        val todayHourly = listOf(
+            HourlyForecast(LocalTime.of(7, 0), 12.0, 11.0, 80.0, WeatherCondition.RAIN),
+            HourlyForecast(LocalTime.of(9, 0), 14.0, 12.0, 5.0, WeatherCondition.CLEAR),
+            HourlyForecast(LocalTime.of(15, 0), 22.0, 20.0, 5.0, WeatherCondition.CLEAR),
+        )
+        val todayWithHourly = today.copy(hourly = todayHourly)
+        val weather = FakeWeatherRepository(ForecastBundle(todayWithHourly, yesterday))
+        val subject = GenerateDailyInsight(weather, clock = clock)
+
+        val result = subject(london, prefs)
+
+        result.insight.summary.precip.shouldNotBeNull()
+        result.insight.summary.precip!!.time shouldBe LocalTime.of(7, 0)
+        result.insight.summary.precip!!.condition shouldBe WeatherCondition.RAIN
+    }
+
+    @Test
     fun `today period falls back to day-level fields when no hourly is available`() = runTest {
         // The default fixture has no hourly array; the slice is empty and the band
         // sentence should still come through from the daily aggregates rather than


### PR DESCRIPTION
## Summary

- Trim a one-hour exposure buffer off each edge of the "today" window (default 07:00–19:00 → 08:00–18:00) when computing `feelsLikeMinC` / `feelsLikeMaxC` and `temperatureMinC` / `temperatureMaxC` in `slicedForToday`. The notification time is when the user *gets* the morning insight, not when they actually step outside, so the pre-dawn dip was dragging recommendations toward heavier clothes than the user needed by the time they left home; the post-dusk reading does the symmetric thing on warm-weather days.
- Rain detection (`peakPrecip` + condition resolution) and the displayed `hourly` series still walk the full `[morningStart, eveningEnd)` slice — so an in-window 07:30 shower still surfaces as a rain mention. Being warned about rain while walking out the door at 08:00 is exactly the value-add the morning insight exists for, and silencing it because 07:30 falls outside the narrower exposure window would be a regression.
- Buffer is currently a hard-coded `Duration.ofHours(1)` with a `TODO(window)` to expose it through settings (the obvious options are a separate "leave home" / "back home" pair distinct from the notification times, or a single "exposure buffer" duration).

## Tests

- New `today period trims a one-hour exposure buffer off each edge of the band min and max` confirms a 07:00 cold dip and 18:00 warm tail are excluded from min/max; the band reflects 08:00–17:00 only.
- New `today period still surfaces rain in the buffered edge hours` confirms a 07:00 rain spike still drives `summary.precip`.
- Adjusted `InsightCacheTest` fixture so the in-window cold reading is at 08:00 as well as 07:00 — the test is verifying prefs-flow logic, not the specific cold hour.

## Privacy

- No change to what crosses the device boundary.

## Test plan

- [x] `./gradlew :core:domain:test :core:data:test :app:testDebugUnitTest`
- [x] `./gradlew :app:assembleDebug`
- [ ] Sanity-check the live morning insight against a real cold-dawn forecast once the change is in a build.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QeGvxAFLTrLCQZPrK56kkJ)_