### PR TITLE
Hide the working banner once the forecast lands, not after TTS finishes

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayViewModel.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayViewModel.kt
@@ -171,10 +171,19 @@ internal data class WorkInfoLite(
     val state: WorkInfo.State,
     val runAttemptCount: Int,
     val outputData: Data,
+    /**
+     * Live [WorkInfo.progress] payload from the running worker. The only
+     * key [selectStatus] inspects is [FetchAndNotifyWorker.KEY_FETCH_COMPLETE]
+     * — set once the fetch + cache write are done and the worker has moved
+     * on to alignment wait / notification post / TTS playback, at which
+     * point the banner should stop saying "fetching" even though the
+     * WorkInfo is still RUNNING.
+     */
+    val progress: Data = Data.EMPTY,
 )
 
 internal fun List<WorkInfo>.toLite(): List<WorkInfoLite> =
-    map { WorkInfoLite(it.state, it.runAttemptCount, it.outputData) }
+    map { WorkInfoLite(it.state, it.runAttemptCount, it.outputData, it.progress) }
 
 /**
  * Maps a WorkManager unique-work history to the state the Today banner cares
@@ -202,10 +211,18 @@ internal fun List<WorkInfo>.toLite(): List<WorkInfoLite> =
  */
 internal fun selectStatus(infos: List<WorkInfoLite>): WorkStatus {
     if (infos.isEmpty()) return WorkStatus.Idle
+    // Only entries still in the "fetching" phase count as active for the
+    // banner. The worker calls setProgress(KEY_FETCH_COMPLETE) once the
+    // fetch + cache are done and it's about to enter deliver() (alignment
+    // wait → notification → TTS); past that point the fresh data is on
+    // screen and the spinner shouldn't keep claiming "Fetching" while
+    // TTS speaks. A terminal SUCCEEDED/FAILED entry from the same run
+    // still surfaces normally below.
     val active = infos.firstOrNull {
-        it.state == WorkInfo.State.ENQUEUED ||
+        (it.state == WorkInfo.State.ENQUEUED ||
             it.state == WorkInfo.State.RUNNING ||
-            it.state == WorkInfo.State.BLOCKED
+            it.state == WorkInfo.State.BLOCKED) &&
+            !it.progress.getBoolean(FetchAndNotifyWorker.KEY_FETCH_COMPLETE, false)
     }
     if (active != null) {
         return if (active.runAttemptCount > 1) WorkStatus.Retrying else WorkStatus.Running

--- a/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
@@ -387,6 +387,16 @@ class FetchAndNotifyWorker(
             if (isSilentRun) {
                 DiagLog.i(TAG, "Silent refresh updated cache for ${insight.forDate}: $prose")
             } else {
+                // Signal "fetch + cache are done" so the Today screen's
+                // working-banner can hide while deliver() handles the
+                // alignment wait, notification, and TTS playback. Without
+                // this, the banner stays visible until the worker returns
+                // — which is after TTS finishes, because deliver() joins
+                // on phoneSpeakerJob. TodayViewModel.selectStatus treats
+                // an active WorkInfo carrying this progress flag as no
+                // longer in the "fetching" phase; a deliver-side failure
+                // still surfaces via the terminal FAILED entry.
+                setProgress(workDataOf(KEY_FETCH_COMPLETE to true))
                 deliver(insight, prefs, prose)
                 DiagLog.i(TAG, "Insight delivered for ${insight.forDate}: $prose")
             }
@@ -1241,6 +1251,17 @@ class FetchAndNotifyWorker(
          * exposes neither a completion time nor a chronological ordering.
          */
         const val KEY_COMPLETED_AT = "completed_at_ms"
+
+        /**
+         * Progress-data flag set once the fetch + insight cache + paired-window
+         * pre-render are complete and the worker is about to enter [deliver]
+         * (alignment wait → notification → TTS playback). Read by
+         * [TodayViewModel.selectStatus]: an active WorkInfo carrying this flag
+         * is treated as past the "fetching" phase, so the Today screen's
+         * spinner banner hides as soon as the fresh data lands rather than
+         * waiting on TTS to finish speaking.
+         */
+        const val KEY_FETCH_COMPLETE = "fetch_complete"
 
         const val REASON_UNEXPECTED_HTTP = "unexpected_http"
         const val REASON_UNHANDLED = "unhandled"

--- a/app/src/test/kotlin/app/clothescast/ui/today/TodayWorkStatusSelectionTest.kt
+++ b/app/src/test/kotlin/app/clothescast/ui/today/TodayWorkStatusSelectionTest.kt
@@ -112,6 +112,73 @@ class TodayWorkStatusSelectionTest {
     }
 
     @Test
+    fun `active entry past fetch_complete reads as Idle`() {
+        // Once the worker has signalled fetch + cache are done (progress
+        // KEY_FETCH_COMPLETE = true), the banner should hide even though
+        // the WorkInfo is still RUNNING — the remaining time is alignment
+        // wait + notification post + TTS playback, and we don't want
+        // "Fetching" to linger while TTS speaks.
+        val infos = listOf(
+            WorkInfoLite(
+                state = WorkInfo.State.RUNNING,
+                runAttemptCount = 1,
+                outputData = Data.EMPTY,
+                progress = Data.Builder()
+                    .putBoolean(FetchAndNotifyWorker.KEY_FETCH_COMPLETE, true)
+                    .build(),
+            ),
+        )
+        selectStatus(infos) shouldBe WorkStatus.Idle
+    }
+
+    @Test
+    fun `active entry before fetch_complete still reads as Running`() {
+        // Sanity-check the inverse: a RUNNING entry with no progress flag
+        // (or the flag absent) keeps the spinner up.
+        selectStatus(
+            listOf(
+                WorkInfoLite(
+                    state = WorkInfo.State.RUNNING,
+                    runAttemptCount = 1,
+                    outputData = Data.EMPTY,
+                    progress = Data.Builder()
+                        .putBoolean(FetchAndNotifyWorker.KEY_FETCH_COMPLETE, false)
+                        .build(),
+                ),
+            ),
+        ) shouldBe WorkStatus.Running
+    }
+
+    @Test
+    fun `fetch_complete active entry lets a prior failure surface`() {
+        // The worker is mid-delivery (fetch done, TTS playing) but the
+        // last terminal run failed: the user should still see the
+        // failure rather than have it masked by the in-flight worker.
+        // This mirrors the existing "active wins over terminal" rule
+        // but with fetch-complete carving the in-flight entry out of
+        // the active set so the terminal entry surfaces.
+        val infos = listOf(
+            terminalFailure(
+                reason = FetchAndNotifyWorker.REASON_UNHANDLED,
+                detail = "kaboom",
+                completedAt = 1_000L,
+            ),
+            WorkInfoLite(
+                state = WorkInfo.State.RUNNING,
+                runAttemptCount = 1,
+                outputData = Data.EMPTY,
+                progress = Data.Builder()
+                    .putBoolean(FetchAndNotifyWorker.KEY_FETCH_COMPLETE, true)
+                    .build(),
+            ),
+        )
+        selectStatus(infos) shouldBe WorkStatus.Failed(
+            reason = FetchAndNotifyWorker.REASON_UNHANDLED,
+            detail = "kaboom",
+        )
+    }
+
+    @Test
     fun `cancelled entries are ignored`() {
         // REPLACE policy cancels the in-flight worker before enqueueing a new
         // one. The transient CANCELLED entry shouldn't clobber the active one


### PR DESCRIPTION
## Summary

The Today screen's spinner banner was staying up until TTS finished playing instead of disappearing once the fetch was complete. That was because banner visibility is driven by WorkManager's `RUNNING` state, and the fetch worker only leaves `RUNNING` after `deliver()` returns — and `deliver()` joins on the phone-speaker job, so the banner persisted through the entire briefing.

- `FetchAndNotifyWorker` now calls `setProgress(KEY_FETCH_COMPLETE = true)` once the fetch, cache write, and paired-window pre-render are done, immediately before entering `deliver()` (alignment wait → notification → MQTT/cast → TTS).
- `TodayViewModel.selectStatus` treats an active `WorkInfo` carrying that progress flag as past the "fetching" phase, so the spinner falls back to `Idle` as soon as the fresh forecast lands on screen.
- Terminal `SUCCEEDED` / `FAILED` entries still surface as before, so a deliver-side failure (notification post, MQTT publish, TTS) still shows the failure card via the terminal entry rather than being hidden.

## Test plan

- [x] `:core:domain:test` + `:core:data:test` + `:app:testDebugUnitTest` green locally
- [x] `:app:assembleDebug` green locally
- [x] New unit tests in `TodayWorkStatusSelectionTest` cover:
  - active + `KEY_FETCH_COMPLETE` → `Idle` (banner hides during TTS)
  - active without the flag → `Running` (banner still up during fetch)
  - active + `KEY_FETCH_COMPLETE` does not mask a prior terminal `Failed`
- [ ] Manual: tap Refresh on Today screen — banner appears, disappears as soon as fresh data shows, TTS still speaks the briefing
- [ ] Manual: simulate a deliver-side failure — failure card still surfaces after the run completes

## Privacy

No change to anything that crosses the device boundary.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JBpBs8AtscTa9Lazgur49B)_