### PR TITLE
Keep the retrying banner up when deliver fails after fetch-complete

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayViewModel.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayViewModel.kt
@@ -218,11 +218,23 @@ internal fun selectStatus(infos: List<WorkInfoLite>): WorkStatus {
     // screen and the spinner shouldn't keep claiming "Fetching" while
     // TTS speaks. A terminal SUCCEEDED/FAILED entry from the same run
     // still surfaces normally below.
+    //
+    // Retry attempts (runAttemptCount > 1) stay in the active set
+    // regardless of the progress flag: if deliver() failed with a
+    // retryable exception after fetch-complete (network blip during
+    // notification/MQTT/cast, transient TTS error), WorkManager
+    // re-enqueues the same WorkSpec for backoff. The next attempt will
+    // refetch — so the user should see "Retrying" rather than have the
+    // banner go silent and pretend nothing's pending. WorkManager's
+    // behaviour around whether progress data is cleared between
+    // attempts isn't something we want to rely on; treating any
+    // post-first-attempt entry as active is the robust answer.
     val active = infos.firstOrNull {
         (it.state == WorkInfo.State.ENQUEUED ||
             it.state == WorkInfo.State.RUNNING ||
             it.state == WorkInfo.State.BLOCKED) &&
-            !it.progress.getBoolean(FetchAndNotifyWorker.KEY_FETCH_COMPLETE, false)
+            (it.runAttemptCount > 1 ||
+                !it.progress.getBoolean(FetchAndNotifyWorker.KEY_FETCH_COMPLETE, false))
     }
     if (active != null) {
         return if (active.runAttemptCount > 1) WorkStatus.Retrying else WorkStatus.Running

--- a/app/src/test/kotlin/app/clothescast/ui/today/TodayWorkStatusSelectionTest.kt
+++ b/app/src/test/kotlin/app/clothescast/ui/today/TodayWorkStatusSelectionTest.kt
@@ -150,6 +150,30 @@ class TodayWorkStatusSelectionTest {
     }
 
     @Test
+    fun `deliver-phase retry with fetch_complete still surfaces as Retrying`() {
+        // Regression guard: if deliver() throws a retryable exception
+        // after the worker called setProgress(KEY_FETCH_COMPLETE=true)
+        // (network blip during notification post / MQTT / cast / TTS),
+        // WorkManager re-enqueues the same WorkSpec with
+        // runAttemptCount > 1. If the progress flag is still in place
+        // and we excluded the entry from the active set on that basis
+        // alone, the "last attempt failed — retrying" banner would
+        // silently disappear while another attempt was actually pending.
+        // The runAttemptCount > 1 carve-out keeps the entry active.
+        val infos = listOf(
+            WorkInfoLite(
+                state = WorkInfo.State.ENQUEUED,
+                runAttemptCount = 2,
+                outputData = Data.EMPTY,
+                progress = Data.Builder()
+                    .putBoolean(FetchAndNotifyWorker.KEY_FETCH_COMPLETE, true)
+                    .build(),
+            ),
+        )
+        selectStatus(infos) shouldBe WorkStatus.Retrying
+    }
+
+    @Test
     fun `fetch_complete active entry lets a prior failure surface`() {
         // The worker is mid-delivery (fetch done, TTS playing) but the
         // last terminal run failed: the user should still see the


### PR DESCRIPTION
## Summary

Regression fix for #688. That PR taught `selectStatus()` to drop a `WorkInfo` from the "active" set when the worker had signalled `KEY_FETCH_COMPLETE=true`, so the banner could disappear as soon as the fresh forecast landed instead of waiting on TTS. The predicate keyed on the progress flag alone, which has a hole:

- Worker fetches data, calls `setProgress(KEY_FETCH_COMPLETE=true)`, enters `deliver()`.
- `deliver()` throws a retryable exception (network blip during notification post, MQTT publish, cast, or TTS).
- WorkManager re-enqueues the same `WorkSpec` with `runAttemptCount > 1` for backoff.
- The progress flag is still in place — so the active predicate excludes the entry, `selectStatus()` falls through to terminal history (or `Idle`), and the "last attempt failed — retrying" banner silently disappears while another attempt is actually pending.

Fix: carve `runAttemptCount > 1` entries back into the active set regardless of the progress flag. A retry attempt always refetches on the next run, so surfacing `Retrying` is the right framing — and not relying on WorkManager's between-attempts progress-clearing behaviour keeps the selector robust either way.

## Test plan

- [x] New regression test `deliver-phase retry with fetch_complete still surfaces as Retrying` (ENQUEUED + `runAttemptCount=2` + `KEY_FETCH_COMPLETE=true` → `Retrying`)
- [x] `:app:testDebugUnitTest --tests "...TodayWorkStatusSelectionTest"` green locally
- [ ] CI green (will wait for events)

## Privacy

No change to anything that crosses the device boundary.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JBpBs8AtscTa9Lazgur49B)_