### PR TITLE
Relabel the Format settings subhead as "Wording and Verbosity"

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -411,7 +411,7 @@
     <string name="settings_root_developer">Developer</string>
 
     <string name="settings_root_schedule_subtitle">Notifications and Times</string>
-    <string name="settings_root_format_subtitle">What to say</string>
+    <string name="settings_root_format_subtitle">Wording and Verbosity</string>
     <string name="settings_root_clothes_subtitle">Temperatures and Outfits</string>
     <string name="settings_root_region_subtitle">Languages and Units</string>
     <string name="settings_root_voice_subtitle">Voices and Accents</string>


### PR DESCRIPTION
## Summary

Renames the Format settings menu subtitle from "What to say" to "Wording and Verbosity".

The old subtitle only hinted at the inclusion toggles (range, change threshold, clothes mention, bottoms, umbrella) and glossed over the *how-it's-phrased* toggles (clothes as items vs layer count, range as degrees vs bands). "Wording and Verbosity" names both axes — how to phrase it and how much to include — and matches the "X and Y" cadence of the other settings subtitles ("Notifications and Times", "Languages and Units", "Voices and Accents", etc.).

The two words also translate to distinct target words in most major languages, unlike near-synonyms ("Wording and Phrasing") which collapse to a single concept in German (`Formulierung`), French (`formulation`), and Spanish (`formulación`).

Single string change in `app/src/main/res/values/strings.xml`. The inner section-card title "What to say" on the Format page itself (`settings_format_what_to_say`) is unchanged.

## Test plan

- [ ] Open the Settings menu, verify the row under "Format" reads "Wording and Verbosity"
- [ ] Tap into Format — page contents unchanged
