### PR TITLE
Move Good Friday and Easter from Global to Christian holidays

### DIFF
--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/HolidayTheme.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/HolidayTheme.kt
@@ -172,17 +172,6 @@ enum class HolidayId {
     //     predicate level.
     //   Buddhist (TH, LK, MM): Vesak, Asalha Bucha, Khao Phansa.
     //
-    // The Easter cluster ([GOOD_FRIDAY] / [EASTER_SUNDAY] /
-    // [EASTER_MONDAY]) deliberately stays on [HolidayCatalog.GLOBAL_COUNTRY]
-    // even though [HolidayCatalog.CHRISTIAN] now exists. Easter has
-    // become broadly culturally observed across religious / non-religious
-    // households alike (egg hunts, chocolate, the Easter long weekend
-    // as a public holiday in many catalog countries), and a CHRISTIAN-
-    // only tagging would default-mute Easter for users who don't
-    // identify as Christian but still observe the day culturally.
-    // Strictly-liturgical days (Ash Wed, Palm Sun, Maundy Thu) sit
-    // on [HolidayCatalog.CHRISTIAN] as opt-in instead.
-    //
     // TODO(holidays-v5): switch the [REMEMBRANCE_DAY] banner-name
     // lookup from [Region]-derived country to location-derived
     // country once the app's reverse-geocoding plumbing exposes a
@@ -532,17 +521,15 @@ object HolidayCatalog {
      * Sentinel "country" for the Christian-religious bucket — Easter-relative
      * observances and other Christian feasts whose dates / observance cross
      * national boundaries: Ash Wednesday, Mardi Gras / Shrove Tuesday, Palm
-     * Sunday, Maundy Thursday, Ascension Day, Pentecost, Whit Monday, Corpus
-     * Christi. Sits in [HolidayTheme.countries] alongside real ISO codes
-     * (each holiday is also tagged with the countries where it's a public
-     * holiday, so a French user picks up Ascension via FR even without
-     * enabling the Christian bucket). Surfaced in Settings as its own
-     * toggleable bucket, off by default — these are religious-tradition
-     * observances rather than universal civic days, so we don't push them
-     * onto every user. The Easter cluster (Good Friday / Easter Sunday /
-     * Easter Monday) stays on [GLOBAL_COUNTRY] because Easter has become
-     * broadly culturally observed (egg hunts, chocolate); the strictly-
-     * liturgical days (Ash Wed, Palm Sun, Maundy Thu) live here as opt-in.
+     * Sunday, Maundy Thursday, Good Friday, Easter Sunday, Easter Monday,
+     * Ascension Day, Pentecost, Whit Monday, Corpus Christi. Sits in
+     * [HolidayTheme.countries] alongside real ISO codes (each holiday is
+     * also tagged with the countries where it's a public holiday, so a
+     * French user picks up Ascension via FR and a UK user picks up Good
+     * Friday via GB even without enabling the Christian bucket). Surfaced
+     * in Settings as its own toggleable bucket, off by default — these are
+     * religious-tradition observances rather than universal civic days, so
+     * we don't push them onto every user.
      */
     const val CHRISTIAN: String = "CHRISTIAN"
 
@@ -991,8 +978,10 @@ object HolidayCatalog {
         // Easter − 2 — Western Good Friday. Solemn, monochrome aubergine
         // (Passion-week liturgical purple). Same single-colour shape as
         // Anzac / MLK / US Memorial — a celebratory two-colour palette
-        // would read wrong here. Tagged [GLOBAL_COUNTRY] as a v1 punt;
-        // see the Christian-bucket TODO at the top of [HolidayId].
+        // would read wrong here. Tagged CHRISTIAN plus the catalog
+        // countries where it's a public holiday so users in those
+        // countries pick it up via their home / current country without
+        // having to enable the Christian bucket.
         HolidayDate.EasterRelative(-2) to HolidayTheme(
             id = HolidayId.GOOD_FRIDAY,
             displayNameKey = "holiday_name_good_friday",
@@ -1001,12 +990,21 @@ object HolidayCatalog {
             topOverrides = topPaletteAll(GOOD_FRIDAY_AUBERGINE),
             bottomOverrides = bottomPaletteAll(GOOD_FRIDAY_AUBERGINE),
             bannerArgb = GOOD_FRIDAY_AUBERGINE,
-            countries = setOf(GLOBAL_COUNTRY),
+            countries = setOf(
+                CHRISTIAN,
+                "AR", "AU", "BR", "CA", "DE", "ES", "GB", "ID", "IE", "IN",
+                "MX", "NG", "NZ", "PH", "SG", "ZA",
+            ),
         ),
 
         // Easter Sunday. Pastel-lemon top + pastel-mint bottom — egg-
-        // decorating spring-renewal palette, no flag association.
-        // Tagged [GLOBAL_COUNTRY] for the same v1 reason as Good Friday.
+        // decorating spring-renewal palette, no flag association. Tagged
+        // CHRISTIAN plus the catalog countries where the Easter weekend is
+        // observed as a public holiday (the union of the Good Friday and
+        // Easter Monday sets — most countries don't formally gazette
+        // Easter Sunday because it's always a Sunday, but it's the centre
+        // of the weekend wherever either of the other two are public
+        // holidays).
         HolidayDate.EasterRelative(0) to HolidayTheme(
             id = HolidayId.EASTER_SUNDAY,
             displayNameKey = "holiday_name_easter_sunday",
@@ -1015,12 +1013,17 @@ object HolidayCatalog {
             topOverrides = topPaletteAll(EASTER_LEMON),
             bottomOverrides = bottomPaletteAll(EASTER_MINT),
             bannerArgb = EASTER_LEMON,
-            countries = setOf(GLOBAL_COUNTRY),
+            countries = setOf(
+                CHRISTIAN,
+                "AR", "AT", "AU", "BR", "CA", "DE", "ES", "FR", "GB", "HR",
+                "ID", "IE", "IN", "IT", "MX", "NG", "NZ", "PH", "SG", "ZA",
+            ),
         ),
 
         // Easter Monday. Same pastel palette as Easter Sunday so the
         // Sun→Mon weekend reads as a continuous theme rather than two
-        // different days. Tagged [GLOBAL_COUNTRY] like the others above.
+        // different days. Tagged CHRISTIAN plus the catalog countries
+        // where it's a public holiday.
         HolidayDate.EasterRelative(1) to HolidayTheme(
             id = HolidayId.EASTER_MONDAY,
             displayNameKey = "holiday_name_easter_monday",
@@ -1029,7 +1032,11 @@ object HolidayCatalog {
             topOverrides = topPaletteAll(EASTER_LEMON),
             bottomOverrides = bottomPaletteAll(EASTER_MINT),
             bannerArgb = EASTER_LEMON,
-            countries = setOf(GLOBAL_COUNTRY),
+            countries = setOf(
+                CHRISTIAN,
+                "AT", "AU", "CA", "DE", "FR", "GB", "HR", "IE", "IT", "NG",
+                "NZ", "ZA",
+            ),
         ),
 
         // Apr 6 — Chakri Day (Thailand), commemorating the founding of the

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/HolidayResolverTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/HolidayResolverTest.kt
@@ -697,7 +697,8 @@ class HolidayResolverTest {
     @Test
     fun `Christian-bucket holidays fire via Easter-relative predicates`() {
         // 2026: Easter is Apr 5. Ash Wed = Feb 18, Mardi Gras = Feb 17,
-        // Palm Sun = Mar 29, Maundy Thu = Apr 2, Ascension = May 14,
+        // Palm Sun = Mar 29, Maundy Thu = Apr 2, Good Fri = Apr 3,
+        // Easter Sun = Apr 5, Easter Mon = Apr 6, Ascension = May 14,
         // Pentecost = May 24, Whit Mon = May 25, Corpus Christi = Jun 4.
         val christianOnly = setOf(HolidayCatalog.CHRISTIAN)
         subject.resolve(LocalDate.of(2026, 2, 17), noOverrides, christianOnly)?.id shouldBe
@@ -708,6 +709,12 @@ class HolidayResolverTest {
             HolidayId.PALM_SUNDAY
         subject.resolve(LocalDate.of(2026, 4, 2), noOverrides, christianOnly)?.id shouldBe
             HolidayId.MAUNDY_THURSDAY
+        subject.resolve(LocalDate.of(2026, 4, 3), noOverrides, christianOnly)?.id shouldBe
+            HolidayId.GOOD_FRIDAY
+        subject.resolve(LocalDate.of(2026, 4, 5), noOverrides, christianOnly)?.id shouldBe
+            HolidayId.EASTER_SUNDAY
+        subject.resolve(LocalDate.of(2026, 4, 6), noOverrides, christianOnly)?.id shouldBe
+            HolidayId.EASTER_MONDAY
         subject.resolve(LocalDate.of(2026, 5, 14), noOverrides, christianOnly)?.id shouldBe
             HolidayId.ASCENSION_DAY
         subject.resolve(LocalDate.of(2026, 5, 24), noOverrides, christianOnly)?.id shouldBe
@@ -730,6 +737,52 @@ class HolidayResolverTest {
                     HolidayId.ASCENSION_DAY
             }
         }
+    }
+
+    @Test
+    fun `Good Friday also fires per-country without the CHRISTIAN bucket`() {
+        // Apr 3 2026 = Good Friday. Each catalog country where it's a
+        // public holiday resolves the theme via its own country tag, so
+        // a UK / Australian / Indian user picks it up without flipping
+        // the Christian bucket on.
+        val countries = listOf(
+            "AR", "AU", "BR", "CA", "DE", "ES", "GB", "ID", "IE", "IN",
+            "MX", "NG", "NZ", "PH", "SG", "ZA",
+        )
+        countries.forEach { country ->
+            withClue(country) {
+                subject.resolve(LocalDate.of(2026, 4, 3), noOverrides, setOf(country))?.id shouldBe
+                    HolidayId.GOOD_FRIDAY
+            }
+        }
+    }
+
+    @Test
+    fun `Easter Monday also fires per-country without the CHRISTIAN bucket`() {
+        // Apr 6 2026 = Easter Monday. Same pattern as Good Friday — the
+        // catalog countries where it's a public holiday pick it up via
+        // their country tag.
+        val countries = listOf(
+            "AT", "AU", "CA", "DE", "FR", "GB", "HR", "IE", "IT", "NG",
+            "NZ", "ZA",
+        )
+        countries.forEach { country ->
+            withClue(country) {
+                subject.resolve(LocalDate.of(2026, 4, 6), noOverrides, setOf(country))?.id shouldBe
+                    HolidayId.EASTER_MONDAY
+            }
+        }
+    }
+
+    @Test
+    fun `Easter cluster no longer fires for the GLOBAL bucket alone`() {
+        // The Easter cluster moved from GLOBAL to CHRISTIAN + per-country
+        // tags. A user with only Global on (no country, no Christian)
+        // doesn't see Good Friday / Easter Sunday / Easter Monday any more.
+        val globalOnly = setOf(HolidayCatalog.GLOBAL_COUNTRY)
+        subject.resolve(LocalDate.of(2026, 4, 3), noOverrides, globalOnly).shouldBeNull()
+        subject.resolve(LocalDate.of(2026, 4, 5), noOverrides, globalOnly).shouldBeNull()
+        subject.resolve(LocalDate.of(2026, 4, 6), noOverrides, globalOnly).shouldBeNull()
     }
 
     @Test


### PR DESCRIPTION
## Summary

The Easter cluster (Good Friday, Easter Sunday, Easter Monday) previously sat in the **Global** holiday bucket so it fired by default for every user. This PR moves the cluster into the **Christian** bucket and tags each entry with the catalog countries where it's a public holiday, mirroring how Ascension Day / Pentecost / Whit Monday are already tagged.

The net effect:

- Users in countries where these days are public holidays (AU, GB, DE, FR, IE, etc.) still see them by default via their home / current country tag, exactly as before.
- Users in countries where they aren't public holidays (US, JP, KR, RU, TR, etc.) no longer see them by default — they can re-enable by turning on the **Christian** bucket in Settings.
- The Christian collapsible in Settings now lists these three alongside Ash Wednesday, Palm Sunday, Maundy Thursday, etc., which reads as a more coherent grouping.

## Country tags

```
Good Friday:   AR, AU, BR, CA, DE, ES, GB, ID, IE, IN, MX, NG,
               NZ, PH, SG, ZA
Easter Sunday: AR, AT, AU, BR, CA, DE, ES, FR, GB, HR, ID, IE,
               IN, IT, MX, NG, NZ, PH, SG, ZA   (union of the
                                                 Fri / Mon sets)
Easter Monday: AT, AU, CA, DE, FR, GB, HR, IE, IT, NG, NZ, ZA
```

Comment cleanup:

- Removed the obsolete "Easter cluster deliberately stays on `GLOBAL_COUNTRY`" paragraph at the top of `HolidayId`.
- Updated the `CHRISTIAN` constant's KDoc to drop the same claim and add the cluster to its inventory of feasts.
- Rewrote the per-entry comments for Good Friday / Easter Sunday / Easter Monday to explain the new dual CHRISTIAN-plus-per-country tagging.

## Test plan

- [x] `./gradlew :core:domain:test :core:data:test` — passes locally (inner build).
- [x] `./gradlew :app:testDebugUnitTest` — passes locally (Roborazzi snapshots regenerate clean; no diffs to `app/snapshots/`).
- [x] New unit tests cover:
  - All three Easter cluster entries firing via the CHRISTIAN bucket alone.
  - Good Friday firing per-country (16 countries) without the Christian bucket.
  - Easter Monday firing per-country (12 countries) without the Christian bucket.
  - The cluster *not* firing for a Global-only user (the behavior change this PR encodes).
- [ ] Manual check on a US-locale device that Easter weekend banners no longer appear unless Christian bucket is on.
- [ ] Manual check on an AU/GB device that Easter weekend banners still appear by default.


---
_Generated by [Claude Code](https://claude.ai/code/session_015xpUMb7aCuALa7XGsgfg6V)_