### PR TITLE
Open Calendar settings when the holiday banner is tapped

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
@@ -516,7 +516,12 @@ private fun BannerStack(
         )
     }
     WorkStatusBanner(status = workStatusToShow, modifier = bannerModifier)
-    HolidayBanner(theme = state.activeHoliday, region = state.region, modifier = bannerModifier)
+    HolidayBanner(
+        theme = state.activeHoliday,
+        region = state.region,
+        onClick = onOpenCalendarSettings,
+        modifier = bannerModifier,
+    )
 }
 
 /**
@@ -963,6 +968,7 @@ internal fun bannerStatus(
 internal fun HolidayBanner(
     theme: HolidayTheme?,
     region: Region = Region.SYSTEM,
+    onClick: (() -> Unit)? = null,
     modifier: Modifier = Modifier,
 ) {
     if (theme == null) return
@@ -1005,13 +1011,12 @@ internal fun HolidayBanner(
         val luminance = 0.299f * r + 0.587f * g + 0.114f * b
         if (luminance > 0.55f) Color.Black else Color.White
     }
-    Card(
-        modifier = modifier.fillMaxWidth(),
-        colors = CardDefaults.cardColors(
-            containerColor = bannerColor,
-            contentColor = textColor,
-        ),
-    ) {
+    val cardColors = CardDefaults.cardColors(
+        containerColor = bannerColor,
+        contentColor = textColor,
+    )
+    val cardModifier = modifier.fillMaxWidth()
+    val content: @Composable () -> Unit = {
         Text(
             text = "${theme.emoji}  $bannerText",
             style = MaterialTheme.typography.titleSmall,
@@ -1021,6 +1026,13 @@ internal fun HolidayBanner(
                 .padding(horizontal = 16.dp, vertical = 12.dp),
             textAlign = TextAlign.Center,
         )
+    }
+    // Material3's `Card(onClick = …)` overload carries the right semantics
+    // for accessibility tooling — matches OutfitPreviewCard's pattern.
+    if (onClick != null) {
+        Card(onClick = onClick, modifier = cardModifier, colors = cardColors) { content() }
+    } else {
+        Card(modifier = cardModifier, colors = cardColors) { content() }
     }
 }
 


### PR DESCRIPTION
## Summary

The holiday banner already explains the day's outfit palette ("Merry Christmas", "Happy Diwali", etc.), and the calendar/holidays toggles live in Settings → Calendar. Wiring the banner as the entry point shortens the path for "how do I turn this off / change which holidays fire" and matches the discoverability of the CelebrationThemesCard CTA on the same screen.

## Changes

- `HolidayBanner` gains an optional `onClick`; when non-null it uses Material3's `Card(onClick = …)` overload so the tap target gets the right accessibility semantics (`Role.Button`, "double-tap to activate").
- `BannerStack` wires the existing `onOpenCalendarSettings` callback (already plumbed through `TodayScreen → TodayContent → TodayPage` for the CelebrationThemesCard) through to the banner.
- Other call sites (`DeveloperSettings`, the two `TodayPreviews` showcases) keep the default `null` and render unchanged.

## Test plan

- [x] `./gradlew :app:compileDebugKotlin` — green
- [x] `./gradlew :app:testDebugUnitTest` — green (Roborazzi snapshots unchanged)
- [ ] Manual: tap holiday banner on Today screen → Calendar settings opens
- [ ] Manual: TalkBack announces banner as a button
- [ ] Manual: DeveloperSettings preview still renders the banner non-clickable

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q7qd4BzAwL6xq42cbgzMuN)_