### PR TITLE
Restore localized labels for calendar event sections

### DIFF
--- a/app/src/main/res/values-am/strings.xml
+++ b/app/src/main/res/values-am/strings.xml
@@ -886,4 +886,6 @@ The rest of the UI falls through to values/strings.xml (English).
 
     <!-- Today rationale extras -->
     <string name="today_rationale_open_clothes_settings">የልብስ ቅንብሮች</string>
+    <string name="settings_calendar_birthdays">የቀን መቁጠሪያ ልደቶች</string>
+    <string name="settings_calendar_public_holidays">የቀን መቁጠሪያ በዓሎች</string>
 </resources>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -917,4 +917,6 @@ they work correctly in both the single-band and range templates.
 
     <!-- Today — rationale -->
     <string name="today_rationale_open_clothes_settings">إعدادات الملابس</string>
+    <string name="settings_calendar_birthdays">أعياد ميلاد التقويم</string>
+    <string name="settings_calendar_public_holidays">أعياد التقويم</string>
 </resources>

--- a/app/src/main/res/values-b+sr+Latn/strings.xml
+++ b/app/src/main/res/values-b+sr+Latn/strings.xml
@@ -905,4 +905,6 @@ default English (matching values-pl / values-uk).
     <string name="cast_error_no_route_picked">Prvo odaberi pametni ekran.</string>
     <string name="cast_error_no_insight_yet">Prognoza još nije dostupna. Sačekaj sledeće planirano pokretanje ili dodirni Osveži na ekranu Danas.</string>
     <string name="cast_error_unknown">Prenos nije uspeo.</string>
+    <string name="settings_calendar_birthdays">Rođendani iz kalendara</string>
+    <string name="settings_calendar_public_holidays">Praznici iz kalendara</string>
 </resources>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -903,4 +903,6 @@ What is NOT overridden, by design:
     <string name="cast_error_no_route_picked">Първо избери умен дисплей.</string>
     <string name="cast_error_no_insight_yet">Все още няма налична прогноза. Изчакай следващото планирано изпълнение или докосни Обнови на екрана Днес.</string>
     <string name="cast_error_unknown">Предаването се провали.</string>
+    <string name="settings_calendar_birthdays">Рождени дни от календара</string>
+    <string name="settings_calendar_public_holidays">Празници от календара</string>
 </resources>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -987,4 +987,6 @@ West Bengal vocabulary differences in a future PR.
 
     <!-- Today — Rationale: open clothes settings. -->
     <string name="today_rationale_open_clothes_settings">পোশাক সেটিংস</string>
+    <string name="settings_calendar_birthdays">ক্যালেন্ডার জন্মদিন</string>
+    <string name="settings_calendar_public_holidays">ক্যালেন্ডার ছুটি</string>
 </resources>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -855,4 +855,6 @@ the in-app clock is digit-driven and reads consistently across locales.
     <string name="holiday_banner_fr_armistice_day">Per no oblidar</string>
     <string name="holiday_banner_us_thanksgiving">Feliç Dia d\'Acció de Gràcies</string>
     <string name="holiday_banner_st_andrews_day">Feliç Dia de Sant Andreu</string>
+    <string name="settings_calendar_birthdays">Aniversaris del calendari</string>
+    <string name="settings_calendar_public_holidays">Festius del calendari</string>
 </resources>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -924,4 +924,6 @@ locale (Angličtina (USA), Francouzština (Francie), Němčina (Německo), …).
     <string name="holiday_banner_fr_armistice_day">Uctíváme padlé</string>
     <string name="holiday_banner_us_thanksgiving">Šťastný Den díkůvzdání</string>
     <string name="holiday_banner_st_andrews_day">Šťastný Den svatého Ondřeje</string>
+    <string name="settings_calendar_birthdays">Narozeniny z kalendáře</string>
+    <string name="settings_calendar_public_holidays">Svátky z kalendáře</string>
 </resources>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -945,4 +945,6 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrig)").
     <string name="holiday_banner_us_thanksgiving">Glædelig Thanksgiving</string>
     <string name="holiday_banner_us_veterans_day">Vi ærer vores veteraner</string>
     <string name="holiday_banner_waitangi_day">Glædelig Waitangi Day</string>
+    <string name="settings_calendar_birthdays">Kalenderfødseldage</string>
+    <string name="settings_calendar_public_holidays">Kalenderhelligdage</string>
 </resources>

--- a/app/src/main/res/values-de-rAT/strings.xml
+++ b/app/src/main/res/values-de-rAT/strings.xml
@@ -648,4 +648,6 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="cast_error_no_route_picked">Zuerst ein Smart Display auswählen.</string>
     <string name="cast_error_no_insight_yet">Noch keine Vorhersage verfügbar. Warte auf die nächste geplante Ausführung oder tippe auf der Startseite auf Aktualisieren.</string>
     <string name="cast_error_unknown">Übertragung fehlgeschlagen.</string>
+    <string name="settings_calendar_birthdays">Kalender-Geburtstage</string>
+    <string name="settings_calendar_public_holidays">Kalender-Feiertage</string>
 </resources>

--- a/app/src/main/res/values-de-rCH/strings.xml
+++ b/app/src/main/res/values-de-rCH/strings.xml
@@ -653,4 +653,6 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="cast_error_no_route_picked">Zuerst ein Smart Display auswählen.</string>
     <string name="cast_error_no_insight_yet">Noch keine Vorhersage verfügbar. Warte auf die nächste geplante Ausführung oder tippe auf der Startseite auf Aktualisieren.</string>
     <string name="cast_error_unknown">Übertragung fehlgeschlagen.</string>
+    <string name="settings_calendar_birthdays">Kalender-Geburtstage</string>
+    <string name="settings_calendar_public_holidays">Kalender-Feiertage</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1071,4 +1071,6 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="cast_error_no_route_picked">Zuerst ein Smart Display auswählen.</string>
     <string name="cast_error_no_insight_yet">Noch keine Vorhersage verfügbar. Warte auf die nächste geplante Ausführung oder tippe auf der Startseite auf Aktualisieren.</string>
     <string name="cast_error_unknown">Übertragung fehlgeschlagen.</string>
+    <string name="settings_calendar_birthdays">Kalender-Geburtstage</string>
+    <string name="settings_calendar_public_holidays">Kalender-Feiertage</string>
 </resources>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -1038,4 +1038,6 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="cast_error_no_route_picked">Επίλεξε πρώτα έξυπνη οθόνη.</string>
     <string name="cast_error_no_insight_yet">Δεν υπάρχει ακόμα διαθέσιμη πρόγνωση. Περίμενε την επόμενη προγραμματισμένη εκτέλεση ή πάτησε Ανανέωση στην οθόνη Σήμερα.</string>
     <string name="cast_error_unknown">Η μετάδοση απέτυχε.</string>
+    <string name="settings_calendar_birthdays">Γενέθλια ημερολογίου</string>
+    <string name="settings_calendar_public_holidays">Αργίες ημερολογίου</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1043,4 +1043,6 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="cast_error_no_route_picked">Elige primero una pantalla inteligente.</string>
     <string name="cast_error_no_insight_yet">Aún no hay previsión disponible. Espera la siguiente ejecución programada o toca Actualizar en la pantalla de Hoy.</string>
     <string name="cast_error_unknown">Emisión fallida.</string>
+    <string name="settings_calendar_birthdays">Cumpleaños del calendario</string>
+    <string name="settings_calendar_public_holidays">Festivos del calendario</string>
 </resources>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -860,4 +860,6 @@ Tone is informal "sina"-form throughout ("Pane … selga", "Võta … kaasa",
     <string name="holiday_banner_fr_armistice_day">Mäletame</string>
     <string name="holiday_banner_us_thanksgiving">Head tänupüha</string>
     <string name="holiday_banner_st_andrews_day">Head Püha Andrease päeva</string>
+    <string name="settings_calendar_birthdays">Kalendri sünnipäevad</string>
+    <string name="settings_calendar_public_holidays">Kalendripühad</string>
 </resources>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -908,4 +908,6 @@ Western Arabic numerals (0-9) are used for TTS compatibility.
 
     <!-- Today — rationale -->
     <string name="today_rationale_open_clothes_settings">تنظیمات لباس</string>
+    <string name="settings_calendar_birthdays">تولدهای تقویم</string>
+    <string name="settings_calendar_public_holidays">تعطیلات تقویم</string>
 </resources>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -925,4 +925,6 @@ displayed label localizes.
     <string name="holiday_banner_us_thanksgiving">Hyvää Thanksgiving-päivää</string>
     <string name="holiday_banner_us_veterans_day">Kunnioitamme veteraanejamme</string>
     <string name="holiday_banner_waitangi_day">Hyvää Waitangi-päivää</string>
+    <string name="settings_calendar_birthdays">Kalenterin syntymäpäivät</string>
+    <string name="settings_calendar_public_holidays">Kalenterin juhlapyhät</string>
 </resources>

--- a/app/src/main/res/values-fil/strings.xml
+++ b/app/src/main/res/values-fil/strings.xml
@@ -967,4 +967,6 @@ The rest of the UI falls through to values/strings.xml (English).
 
     <!-- Rationale open clothes settings -->
     <string name="today_rationale_open_clothes_settings">Mga setting ng damit</string>
+    <string name="settings_calendar_birthdays">Mga Kaarawan sa Kalendaryo</string>
+    <string name="settings_calendar_public_holidays">Mga Holiday sa Kalendaryo</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1042,4 +1042,6 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="cast_error_no_route_picked">Sélectionne d\'abord un affichage intelligent.</string>
     <string name="cast_error_no_insight_yet">Aucune prévision disponible. Attends la prochaine exécution programmée ou appuie sur Actualiser sur l\'écran Aujourd\'hui.</string>
     <string name="cast_error_unknown">Diffusion échouée.</string>
+    <string name="settings_calendar_birthdays">Anniversaires du calendrier</string>
+    <string name="settings_calendar_public_holidays">Jours fériés du calendrier</string>
 </resources>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -947,4 +947,6 @@ Not overridden by design:
 
     <!-- Today — Rationale: open clothes settings. -->
     <string name="today_rationale_open_clothes_settings">कपड़ों की सेटिंग</string>
+    <string name="settings_calendar_birthdays">कैलेंडर जन्मदिन</string>
+    <string name="settings_calendar_public_holidays">कैलेंडर छुट्टियाँ</string>
 </resources>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -985,4 +985,6 @@ spousal register), matching the existing insight prose ("Ponesi …",
     <string name="cast_error_no_route_picked">Prvo odaberite pametni zaslon.</string>
     <string name="cast_error_no_insight_yet">Prognoza još nije dostupna. Pričekajte sljedeće planirano pokretanje ili dodirnite Osvježi na zaslonu Danas.</string>
     <string name="cast_error_unknown">Prenošenje nije uspjelo.</string>
+    <string name="settings_calendar_birthdays">Rođendani iz kalendara</string>
+    <string name="settings_calendar_public_holidays">Blagdani iz kalendara</string>
 </resources>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -909,4 +909,6 @@ locale (Angol (Egyesült Államok), Francia (Franciaország), Német
     <string name="cast_error_no_route_picked">Először válasszon okos kijelzőt.</string>
     <string name="cast_error_no_insight_yet">Még nem áll rendelkezésre előrejelzés. Várjon a következő ütemezett futásra, vagy koppintson a Frissítés gombra a Mai képernyőn.</string>
     <string name="cast_error_unknown">A közvetítés sikertelen volt.</string>
+    <string name="settings_calendar_birthdays">Naptárbeli születésnapok</string>
+    <string name="settings_calendar_public_holidays">Naptárbeli ünnepek</string>
 </resources>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -917,4 +917,6 @@ to values/strings.xml (English).
 
     <!-- Rationale open clothes settings -->
     <string name="today_rationale_open_clothes_settings">Pengaturan pakaian</string>
+    <string name="settings_calendar_birthdays">Ulang Tahun Kalender</string>
+    <string name="settings_calendar_public_holidays">Hari Libur Kalender</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1028,4 +1028,6 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="cast_error_no_route_picked">Scegli prima un display intelligente.</string>
     <string name="cast_error_no_insight_yet">Nessuna previsione ancora disponibile. Attendi la prossima esecuzione programmata o tocca Aggiorna nella schermata Oggi.</string>
     <string name="cast_error_unknown">Trasmissione fallita.</string>
+    <string name="settings_calendar_birthdays">Compleanni del calendario</string>
+    <string name="settings_calendar_public_holidays">Festività del calendario</string>
 </resources>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -916,4 +916,6 @@ standard in Israeli digital communication.
 
     <!-- Today — rationale -->
     <string name="today_rationale_open_clothes_settings">הגדרות לבוש</string>
+    <string name="settings_calendar_birthdays">ימי הולדת מיומן</string>
+    <string name="settings_calendar_public_holidays">חגים מיומן</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1066,4 +1066,6 @@ the displayed label localizes.
 
     <!-- Today screen — rationale: open clothes settings link. -->
     <string name="today_rationale_open_clothes_settings">服装設定を開く</string>
+    <string name="settings_calendar_birthdays">カレンダーの誕生日</string>
+    <string name="settings_calendar_public_holidays">カレンダーの祝日</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1070,4 +1070,6 @@ displayed label localizes.
 
     <!-- Today screen — Rationale: open clothes settings link. -->
     <string name="today_rationale_open_clothes_settings">옷 설정</string>
+    <string name="settings_calendar_birthdays">캘린더 생일</string>
+    <string name="settings_calendar_public_holidays">캘린더 공휴일</string>
 </resources>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -904,4 +904,6 @@ What is NOT overridden, by design:
     <string name="holiday_banner_fr_armistice_day">Tegul neužmirštama</string>
     <string name="holiday_banner_us_thanksgiving">Su padėkos diena</string>
     <string name="holiday_banner_st_andrews_day">Su šv. Andriejaus diena</string>
+    <string name="settings_calendar_birthdays">Kalendoriaus gimtadieniai</string>
+    <string name="settings_calendar_public_holidays">Kalendoriaus šventės</string>
 </resources>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -857,4 +857,6 @@ informal "tu"-form throughout ("Apģērb …", "Paņem … līdzi").
     <string name="holiday_banner_fr_armistice_day">Lai neaizmirstu</string>
     <string name="holiday_banner_us_thanksgiving">Priecīgu Pateicības dienu</string>
     <string name="holiday_banner_st_andrews_day">Priecīgu Svētā Andreja dienu</string>
+    <string name="settings_calendar_birthdays">Kalendāra dzimšanas dienas</string>
+    <string name="settings_calendar_public_holidays">Kalendāra svētki</string>
 </resources>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -923,4 +923,6 @@ vs "kemungkinan", "padam" vs "hapus").
 
     <!-- Rationale open clothes settings -->
     <string name="today_rationale_open_clothes_settings">Tetapan pakaian</string>
+    <string name="settings_calendar_birthdays">Hari Jadi Kalendar</string>
+    <string name="settings_calendar_public_holidays">Hari Kelepasan Kalendar</string>
 </resources>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -944,4 +944,6 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrike)").
     <string name="holiday_banner_us_thanksgiving">God Thanksgiving</string>
     <string name="holiday_banner_us_veterans_day">Vi hedrer våre veteraner</string>
     <string name="holiday_banner_waitangi_day">God Waitangi Day</string>
+    <string name="settings_calendar_birthdays">Kalenderbursdag</string>
+    <string name="settings_calendar_public_holidays">Kalenderhelligdager</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -964,4 +964,6 @@ the displayed label localizes.
     <string name="holiday_banner_us_thanksgiving">Fijn Thanksgiving</string>
     <string name="holiday_banner_us_veterans_day">Ter ere van onze veteranen</string>
     <string name="holiday_banner_waitangi_day">Fijne Waitangidag</string>
+    <string name="settings_calendar_birthdays">Kalenderverjaardagen</string>
+    <string name="settings_calendar_public_holidays">Kalenderfeestdagen</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -963,4 +963,6 @@ is unchanged; only the displayed label localizes.
     <string name="holiday_banner_fr_armistice_day">Wspominamy poległych</string>
     <string name="holiday_banner_us_thanksgiving">Wesołego Dnia Dziękczynienia</string>
     <string name="holiday_banner_st_andrews_day">Wesołego Dnia Świętego Andrzeja</string>
+    <string name="settings_calendar_birthdays">Urodziny z kalendarza</string>
+    <string name="settings_calendar_public_holidays">Święta z kalendarza</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1000,4 +1000,6 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="holiday_banner_fr_armistice_day">Que nunca esqueçamos</string>
     <string name="holiday_banner_us_thanksgiving">Feliz Dia de Ação de Graças</string>
     <string name="holiday_banner_st_andrews_day">Feliz Dia de Santo André</string>
+    <string name="settings_calendar_birthdays">Aniversários do Calendário</string>
+    <string name="settings_calendar_public_holidays">Feriados do Calendário</string>
 </resources>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -1043,4 +1043,6 @@ they diverge from BR ("Polonês" → "Polaco", "Holandês" →
     <string name="holiday_banner_fr_armistice_day">Que nunca esqueçamos</string>
     <string name="holiday_banner_us_thanksgiving">Feliz Dia de Ação de Graças</string>
     <string name="holiday_banner_st_andrews_day">Feliz Dia de Santo André</string>
+    <string name="settings_calendar_birthdays">Aniversários do Calendário</string>
+    <string name="settings_calendar_public_holidays">Feriados do Calendário</string>
 </resources>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -892,4 +892,6 @@ surfaces fall back to default English (matching values-pl / values-uk).
     <string name="cast_error_no_route_picked">Selectează mai întâi un afișaj inteligent.</string>
     <string name="cast_error_no_insight_yet">Nu este disponibilă nicio prognoză încă. Așteaptă următoarea rulare programată sau atinge Reîmprospătează pe ecranul Astăzi.</string>
     <string name="cast_error_unknown">Transmisia a eșuat.</string>
+    <string name="settings_calendar_birthdays">Zile de naștere din calendar</string>
+    <string name="settings_calendar_public_holidays">Sărbători din calendar</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -970,4 +970,6 @@ only the displayed label localizes.
     <string name="holiday_banner_fr_armistice_day">Помним</string>
     <string name="holiday_banner_us_thanksgiving">С Днём благодарения</string>
     <string name="holiday_banner_st_andrews_day">С Днём святого Андрея</string>
+    <string name="settings_calendar_birthdays">Дни рождения в календаре</string>
+    <string name="settings_calendar_public_holidays">Праздники в календаре</string>
 </resources>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -938,4 +938,6 @@ What is NOT overridden, by design:
     <string name="holiday_banner_fr_armistice_day">Uctievame padlých</string>
     <string name="holiday_banner_us_thanksgiving">Šťastný Deň vďakyvzdania</string>
     <string name="holiday_banner_st_andrews_day">Šťastný Deň svätého Ondreja</string>
+    <string name="settings_calendar_birthdays">Narodeniny z kalendára</string>
+    <string name="settings_calendar_public_holidays">Sviatky z kalendára</string>
 </resources>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -901,4 +901,6 @@ informal "ti"-form throughout, mirroring the Croatian / Serbian pass.
     <string name="cast_error_no_route_picked">Najprej izberi pametni zaslon.</string>
     <string name="cast_error_no_insight_yet">Napoved še ni na voljo. Počakaj na naslednje načrtovano izvajanje ali se dotakni Osveži na zaslonu Danes.</string>
     <string name="cast_error_unknown">Predvajanje ni uspelo.</string>
+    <string name="settings_calendar_birthdays">Rojstni dnevi iz koledarja</string>
+    <string name="settings_calendar_public_holidays">Prazniki iz koledarja</string>
 </resources>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -944,4 +944,6 @@ native names for all locales (e.g. "Tyska (Tyskland)", "Franska (Frankrike)").
     <string name="holiday_banner_us_thanksgiving">Glad Thanksgiving</string>
     <string name="holiday_banner_us_veterans_day">Hedrar våra veteraner</string>
     <string name="holiday_banner_waitangi_day">Glad Waitangidagen</string>
+    <string name="settings_calendar_birthdays">Kalenderfödelsedagar</string>
+    <string name="settings_calendar_public_holidays">Kalenderhelgdagar</string>
 </resources>

--- a/app/src/main/res/values-sw/strings.xml
+++ b/app/src/main/res/values-sw/strings.xml
@@ -887,4 +887,6 @@ The rest of the UI falls through to values/strings.xml (English).
 
     <!-- Today rationale extras -->
     <string name="today_rationale_open_clothes_settings">Mipangilio ya mavazi</string>
+    <string name="settings_calendar_birthdays">Siku za Kuzaliwa za Kalenda</string>
+    <string name="settings_calendar_public_holidays">Likizo za Kalenda</string>
 </resources>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -917,4 +917,6 @@ The rest of the UI falls through to values/strings.xml (English).
 
     <!-- Today — Rationale dialog -->
     <string name="today_rationale_open_clothes_settings">การตั้งค่าเสื้อผ้า</string>
+    <string name="settings_calendar_birthdays">วันเกิดในปฏิทิน</string>
+    <string name="settings_calendar_public_holidays">วันหยุดในปฏิทิน</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -918,4 +918,6 @@ displayed label localizes.
 
     <!-- Today rationale extras -->
     <string name="today_rationale_open_clothes_settings">Kıyafet ayarları</string>
+    <string name="settings_calendar_birthdays">Takvim Doğum Günleri</string>
+    <string name="settings_calendar_public_holidays">Takvim Tatilleri</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -913,4 +913,6 @@ only the displayed label localizes.
     <string name="holiday_banner_fr_armistice_day">Пам\'ятаємо</string>
     <string name="holiday_banner_us_thanksgiving">З Днем подяки</string>
     <string name="holiday_banner_st_andrews_day">З Днем святого Андрія</string>
+    <string name="settings_calendar_birthdays">Дні народження в календарі</string>
+    <string name="settings_calendar_public_holidays">Свята в календарі</string>
 </resources>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -978,4 +978,6 @@ Skipped intentionally: app_name (brand), insight_time_am/pm/midnight/noon
 
     <!-- Today — Rationale dialog -->
     <string name="today_rationale_open_clothes_settings">Cài đặt quần áo</string>
+    <string name="settings_calendar_birthdays">Sinh nhật trong lịch</string>
+    <string name="settings_calendar_public_holidays">Ngày lễ trong lịch</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1064,4 +1064,6 @@ label localizes.
 
     <!-- Today screen — rationale open clothes settings. -->
     <string name="today_rationale_open_clothes_settings">服装设置</string>
+    <string name="settings_calendar_birthdays">日历生日</string>
+    <string name="settings_calendar_public_holidays">日历节假日</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1080,4 +1080,6 @@ label localises.
 
     <!-- Today screen — rationale open clothes settings. -->
     <string name="today_rationale_open_clothes_settings">服裝設定</string>
+    <string name="settings_calendar_birthdays">行事曆生日</string>
+    <string name="settings_calendar_public_holidays">行事曆節假日</string>
 </resources>


### PR DESCRIPTION
## Summary

Fixes an i18n regression introduced by #697.

That PR renamed the upcoming-events "Calendar holidays" / "Calendar birthdays" section headers to "Public holidays" / "Birthdays" by pointing them at the existing `settings_calendar_public_holidays` / `settings_calendar_birthdays` resources used by the toggles in the Personal calendars card above. Those resources are only defined in the default `values/strings.xml` — no locale variant has a translation — so the section headers (and the toggle labels, separately) fall back to English on every non-English build. The same PR also dropped the previously-localized `settings_holidays_source_calendar_*` translations from all 46 locale files, so the prior localized text is no longer reachable either.

This PR restores the localized strings under the new resource IDs by copying each locale's previous translation of `settings_holidays_source_calendar_birthdays` to `settings_calendar_birthdays`, and the previous translation of `settings_holidays_source_calendar_holidays` to `settings_calendar_public_holidays`. The 46 affected locale files each gain two `<string>` entries; English is unchanged.

This also incidentally pulls the Personal-calendars-card toggle labels into translated coverage (they shared the new IDs but had no locale entries before).

### Caveat

Localized text reads the localized "Calendar birthdays" / "Calendar holidays" form rather than a short "Birthdays" / "Public holidays" — semantically slightly longer than the post-rename English label, but localized, which is what #697 lost. A follow-up translation pass can shorten the locale strings to match the English brevity if desired.

### Privacy

No change to what leaves the device — translation-only fix.

## Test plan

- [x] `./gradlew :app:testDebugUnitTest` passes locally
- [ ] CI: `JVM unit tests` green
- [ ] CI: `Android debug build` green
- [ ] Visually verify on a device set to Spanish (or any non-English locale): the Calendar settings page should now show localized labels for both the Personal-calendars toggles (Birthdays / Public holidays) and the two expandable event-listing sections immediately below.

https://claude.ai/code/session_0167RsHEpfabN3rSnCBYrk7q

---
_Generated by [Claude Code](https://claude.ai/code/session_0167RsHEpfabN3rSnCBYrk7q)_