### PR TITLE
Log timestamps in UTC so they line up across timezone changes

### DIFF
--- a/app/src/main/kotlin/app/clothescast/diag/DiagLog.kt
+++ b/app/src/main/kotlin/app/clothescast/diag/DiagLog.kt
@@ -9,6 +9,7 @@ import java.io.StringWriter
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
+import java.util.TimeZone
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -51,8 +52,14 @@ object DiagLog {
     private val executor = Executors.newSingleThreadExecutor { r ->
         Thread(r, "DiagLog-writer").apply { isDaemon = true }
     }
+    // UTC so log lines from different testers (and the same tester across
+    // timezone changes mid-session) line up on a single timeline. The literal
+    // `Z` suffix keeps that visible in every line — the format omits the year
+    // and offset characters to stay compact within the 200KB rotation budget.
     private val timestampFormat = ThreadLocal.withInitial {
-        SimpleDateFormat("MM-dd HH:mm:ss.SSS", Locale.US)
+        SimpleDateFormat("MM-dd HH:mm:ss.SSS'Z'", Locale.US).apply {
+            timeZone = TimeZone.getTimeZone("UTC")
+        }
     }
 
     @Volatile


### PR DESCRIPTION
## Summary

`DiagLog`'s rotating file timestamps used `SimpleDateFormat("MM-dd HH:mm:ss.SSS")` with the default device timezone and no offset in the format. When testing across timezone changes, log lines couldn't be placed on a single timeline.

This change:
- Pins the `DiagLog` formatter to UTC.
- Appends a literal `'Z'` to every formatted timestamp so the timezone is visible in every log line (e.g. `05-26 14:23:45.123Z I MyTag: hello`).

Affects every line written to `diag.log` / `diag.log.1`, the "process start" marker, and the `=== … ===` header at the top of `last-crash.txt`.

`BugReport.kt`'s `Captured:` header and the MQTT publish-status timestamps already include explicit offsets (`Z` / `zzz`), so they stay as-is — knowing the user's local time when they submitted a report is useful context.

## Test plan
- [x] `:app:testDebugUnitTest` (incl. `DiagLogTest`) passes locally.
- [ ] Eyeball a fresh diag log on device / bug report to confirm `Z` suffix renders and the time matches `date -u`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UN31Fik4WeS3R5wuHGAcP6)_