### PR TITLE
System back button steps back through forecast pages

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.widget.Toast
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
@@ -184,6 +185,14 @@ fun TodayScreen(
         period = state.thisPeriodInsight?.period,
         page = pagerState.currentPage,
     )
+    // System back on page 1 or 2 steps back one page instead of exiting the
+    // app — matches the on-screen left chevron. Page 0 falls through to the
+    // platform default (finish the activity).
+    BackHandler(enabled = pagerState.currentPage > 0) {
+        coroutineScope.launch {
+            pagerState.animateScrollToPage(pagerState.currentPage - 1)
+        }
+    }
 
     Scaffold(
         // Drop the default `safeDrawing` content insets so the pager extends


### PR DESCRIPTION
## Summary

When the Today screen is paged forward to the next-period (page 1) or 7-day (page 2) view, the Android system back button (gesture or hardware) now scrolls back one page instead of exiting the app. Page 0 still falls through to the platform default (finish the activity).

Mirrors what the on-screen left chevron already does — keeps both back affordances consistent.

## Implementation

- `BackHandler(enabled = pagerState.currentPage > 0)` in `TodayScreen`, hoisted next to where `pagerState` is declared so the enabled flag tracks the current page.
- On invocation: `pagerState.animateScrollToPage(pagerState.currentPage - 1)` via the existing `coroutineScope`.

## Test plan

- [ ] Build assembles
- [ ] Page 0 → system back exits the app (unchanged behaviour)
- [ ] Page 1 → system back animates to page 0
- [ ] Page 2 → system back animates to page 1, then again to page 0, then exits

https://claude.ai/code/session_01YM6vFn8qTHf1K8eQ3fKUGL

---
_Generated by [Claude Code](https://claude.ai/code/session_01YM6vFn8qTHf1K8eQ3fKUGL)_