### PR TITLE
Add a tap-hint card to the 7-day page

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/today/SevenDayPage.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/SevenDayPage.kt
@@ -366,6 +366,29 @@ internal fun SevenDayPage(
             LocalChartScrub provides scrubController,
             LocalScrubMomentFormat provides ScrubMomentFormat.DayPlusHour,
         ) {
+            // Tap-hint card matching the affordance the per-period pages
+            // surface inside the confidence chip ("Tap to see / hide each
+            // model's forecast"). The page has no chip to carry that line
+            // itself, and the chart cards don't carry it either (the
+            // hint would compete with each chart's own subtitle / legend
+            // row), so a dedicated hint card sits at the top of the
+            // chart deck. Reuses the same toggleModifier so tapping the
+            // hint also flips the spread — and skipped entirely when
+            // per-model data isn't available (nothing for the user to
+            // toggle).
+            if (weekPerModelDiagnostics != null) {
+                Card(modifier = Modifier.fillMaxWidth().then(toggleModifier)) {
+                    Text(
+                        text = stringResource(
+                            if (showModelSpread) R.string.today_confidence_tap_to_hide
+                            else R.string.today_confidence_tap_to_show,
+                        ),
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(horizontal = 20.dp, vertical = 16.dp),
+                    )
+                }
+            }
             Box(toggleModifier) {
                 ForecastCard(
                     hourly = flatHourly,


### PR DESCRIPTION
## Summary

- Follow-up to #711. The per-period pages surface "Tap to see each model's forecast" inside the confidence chip, which is what makes the toggle discoverable there. The 7-day page has no chip, so the new tap-to-toggle gesture landed silently — nothing on screen told the user the chart cards were tappable.
- Add a thin `Card` at the top of the 7-day chart deck carrying the same line (and the inverse "Tap to hide model forecasts" when the spread is on). Reuses the existing `today_confidence_tap_to_show` / `_hide` strings, and the same `toggleModifier` from #711 so tapping the hint card also toggles the spread.
- Hidden when per-model data isn't available (legacy cache, side-band fetch failed, or coverage gate rejected the data) — nothing to toggle in that state.

## Privacy

No change to what crosses the device boundary. Same `MutableStateFlow<Boolean>` on `TodayViewModel` that #711 already wired.

## Test plan

- [x] `./gradlew :app:testDebugUnitTest :app:assembleDebug` — passes locally. Existing `SevenDayPagePreview` passes `weekPerModelHourly = null`, so the hint card is gated off there and snapshot output is byte-identical.
- [ ] Manual on-device: swipe to 7-day page → the hint card reads "Tap to see each model's forecast" above the chart deck. Tap it (or any chart) → flips to "Tap to hide model forecasts" and per-model lines appear. Tap again → reverts.
- [ ] CI green.


---
_Generated by [Claude Code](https://claude.ai/code/session_01R8nfZtqSxZkHRijK6hFbSx)_