### PR TITLE
Add TODO to standardise 7-day chart tap behaviour with per-period pages

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/today/SevenDayPage.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/SevenDayPage.kt
@@ -82,6 +82,24 @@ import kotlinx.coroutines.delay
  * itself (see [onToggleModelSpread]), since this page has no confidence
  * chip to drive the toggle the way the per-period pages do.
  *
+ * TODO: standardise chart-tap behaviour across the per-period pages and
+ * this one. Today the two diverge: per-period pages wire a
+ * [SpreadCoordinator] into the [ChartScrubController] so a tap on the
+ * chart plot enters scrub mode *and* auto-reveals the per-model spread
+ * (with the matching restore tap auto-hiding it again), while the
+ * confidence chip above the charts is the explicit on/off control. This
+ * page has no chip, so a tap on the chart plot only scrubs and a tap on
+ * the surrounding card flips the spread independently — two gestures on
+ * the same widget that do different things. Pick one shape and apply it
+ * everywhere: either wire the [SpreadCoordinator] here too (drop the
+ * card-level [clickable], keep the tap-hint card as the equivalent of
+ * the chip) so chart taps reveal the spread on every page, or back the
+ * per-period pages out of the auto-reveal coupling so chart taps only
+ * ever scrub and an explicit chip / hint card carries the toggle. The
+ * coupled-reveal version is the richer interaction; the decoupled
+ * version is easier to reason about. Whichever wins, remove the
+ * divergence — and update the matching doc on [ChartScrubController].
+ *
  * Empty / short [days] (e.g. legacy cached snapshots from before the
  * 7-day fetch) collapse to a short stand-in message so the page still
  * has a back button instead of going blank.


### PR DESCRIPTION
## Summary

Adds a KDoc TODO on `SevenDayPage` calling out the inconsistency between how chart taps work here vs. on the per-period (today / tonight) pages, and asks for a follow-up to pick one shape and apply it everywhere.

The divergence today:

- **Per-period pages**: a tap on the chart plot enters scrub mode *and* auto-reveals the per-model spread (via `ChartScrubController.spreadCoordinator`). The matching restore-tap auto-hides it. The confidence chip above the charts is the explicit on/off control.
- **`SevenDayPage`**: a tap on the chart plot only scrubs. The surrounding card has its own `Modifier.clickable` that toggles the spread independently of scrub. A tap-hint card at the top of the deck stands in for the absent confidence chip.

Net effect: tapping a chart on the 7-day page does *not* reveal the spread the way it does on the per-period pages, and the card-level tap is a second gesture on the same widget that does a different thing.

The TODO names the two possible standardisations and the trade-off:

- **Coupled-reveal everywhere** — wire `SpreadCoordinator` here too, drop the card-level `clickable`, keep the tap-hint card as the chip's equivalent. Richer interaction, matches the existing per-period behaviour.
- **Decoupled everywhere** — back the per-period pages out of the auto-reveal coupling so chart taps only ever scrub, and let the chip / hint card carry the toggle on its own. Easier to reason about.

Pure doc comment, no behaviour change. Pushed as a draft so the decision and the actual standardisation can land in a follow-up PR.

## Test plan

- [ ] No code paths changed; existing test suite should be green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AuteJvzwzaJyBrsYACuzw7)_