### PR TITLE
Coarsen the cached insight location on read

### DIFF
--- a/app/src/main/kotlin/app/clothescast/data/InsightCache.kt
+++ b/app/src/main/kotlin/app/clothescast/data/InsightCache.kt
@@ -384,12 +384,16 @@ class InsightCache(
         val displayName: String? = null,
         val countryCode: String? = null,
     ) {
+        // Coarsen on read so cache files written before the privacy-grid
+        // change surface at neighbourhood precision too — mirrors
+        // SettingsRepository.parseLocation. Without this the tappable city
+        // label on the insight card opens Maps at the user's exact home.
         fun toDomain(): Location = Location(
             latitude = latitude,
             longitude = longitude,
             displayName = displayName,
             countryCode = countryCode,
-        )
+        ).coarsened()
     }
 
     /**


### PR DESCRIPTION
## Summary

Tapping the city label on the Today insight card was opening Maps at the
user's exact home address, not the ~1 km grid coords be76626 was meant
to enforce. The fix is one line.

`InsightCache.LocationDto.toDomain()` was the ingestion point the
privacy-grid commit missed: every other place that brings a `Location`
into the app (`LocationResolver.toDomain`, `OpenMeteoGeocodingClient.toDomain`,
`SettingsRepository.parseLocation`) calls `.coarsened()` so legacy
fine-precision values surface at neighbourhood precision. The insight
cache deserialiser didn't, so any cache file written before the
coarsen change kept the fine-precision lat / lon — and that's the
location the `geo:` URI was built from when the user tapped "Boston".

Mirror the SettingsRepository pattern and call `.coarsened()` at the
DTO → domain boundary. Cache files written after this still round-trip
identically; legacy ones now match the ~1 km grid every other read
surfaces.

## Privacy

Closes a residual leak from the coarsen-the-location PR (be76626): the
tappable city label was still launching Maps with the user's pre-coarsen
home coords from the insight cache. After this change, the map intent
uses the same 2-decimal grid as the Open-Meteo request and bug-report
payload.

## Test plan

- [x] `cd core && ../gradlew :core:domain:test :core:data:test` — green
- [x] `./gradlew :app:testDebugUnitTest` — green
- [ ] Eyeball on device: tap the city label on the insight card with a
      cache file that predates be76626 (e.g. install the previous build,
      let it run a day, install this build) — Maps opens at the ~1 km
      grid centre, not the precise home address.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SVZUCcJpDiEyN3RUYkWC7r)_