### PR TITLE
Drop "Refresh to see the new outfit" hint from rationale dialog

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
@@ -1467,7 +1467,6 @@ internal fun OutfitRationaleDialog(
     onNavigateToClothes: () -> Unit,
     onDismiss: () -> Unit,
 ) {
-    var thresholdsTouched by remember { mutableStateOf(false) }
     AlertDialog(
         onDismissRequest = onDismiss,
         title = { Text(stringResource(R.string.today_rationale_title)) },
@@ -1484,28 +1483,15 @@ internal fun OutfitRationaleDialog(
                         reason = rationale.top,
                         temperatureUnit = temperatureUnit,
                         clothesRules = clothesRules,
-                        onAdjustThreshold = { ruleItem, delta ->
-                            thresholdsTouched = true
-                            onAdjustThreshold(ruleItem, delta)
-                        },
+                        onAdjustThreshold = onAdjustThreshold,
                     )
                     GarmentReasonBlock(
                         title = stringResource(bottomLabelRes(outfit.bottom)),
                         reason = rationale.bottom,
                         temperatureUnit = temperatureUnit,
                         clothesRules = clothesRules,
-                        onAdjustThreshold = { ruleItem, delta ->
-                            thresholdsTouched = true
-                            onAdjustThreshold(ruleItem, delta)
-                        },
+                        onAdjustThreshold = onAdjustThreshold,
                     )
-                    if (thresholdsTouched) {
-                        Text(
-                            text = stringResource(R.string.today_rationale_threshold_changed_hint),
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-                    }
                 }
             }
         },

--- a/app/src/main/res/values-am/strings.xml
+++ b/app/src/main/res/values-am/strings.xml
@@ -80,7 +80,6 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="today_rationale_dismiss">ገባኝ</string>
     <string name="today_rationale_threshold_decrease">ደረጃን በ1 ዲግሪ ቀንስ</string>
     <string name="today_rationale_threshold_increase">ደረጃን በ1 ዲግሪ ጨምር</string>
-    <string name="today_rationale_threshold_changed_hint">አዲሱን ልብስ ለማየት አድስ።</string>
     <string name="today_rationale_unavailable">ምንም ምክንያት የለም — ከሚቀጥለው ዳግም ሙከራ በኋላ መተግበሪያውን ይክፈቱ።</string>
     <string name="today_rationale_min_below_with_time">ዝቅተኛ የሚሰማ ሙቀት %1$s%2$s በ%3$s ሰዓት፣ ከ%4$s%2$s በታች</string>
     <string name="today_rationale_min_below">ዝቅተኛ የሚሰማ ሙቀት %1$s%2$s፣ ከ%3$s%2$s በታች</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -133,7 +133,6 @@ they work correctly in both the single-band and range templates.
     <string name="today_rationale_dismiss">فهمت</string>
     <string name="today_rationale_threshold_decrease">خفض العتبة بدرجة واحدة</string>
     <string name="today_rationale_threshold_increase">رفع العتبة بدرجة واحدة</string>
-    <string name="today_rationale_threshold_changed_hint">حدّث لترى الزي الجديد.</string>
     <string name="today_rationale_unavailable">لا يتوفر تبرير — افتح التطبيق بعد التحديث التالي.</string>
     <string name="today_rationale_min_below_with_time">أدنى درجة حرارة محسوسة %1$s%2$s الساعة %3$s، أقل من %4$s%2$s</string>
     <string name="today_rationale_min_below">أدنى درجة حرارة محسوسة %1$s%2$s، أقل من %3$s%2$s</string>

--- a/app/src/main/res/values-b+sr+Latn/strings.xml
+++ b/app/src/main/res/values-b+sr+Latn/strings.xml
@@ -454,7 +454,6 @@ default English (matching values-pl / values-uk).
     <string name="today_rationale_dismiss">Razumeo</string>
     <string name="today_rationale_threshold_decrease">Smanji prag za 1 stepen</string>
     <string name="today_rationale_threshold_increase">Povećaj prag za 1 stepen</string>
-    <string name="today_rationale_threshold_changed_hint">Osveži da vidiš novu kombinaciju.</string>
     <string name="today_rationale_unavailable">Nema dostupnog objašnjenja — otvori aplikaciju posle sledećeg osvežavanja.</string>
     <string name="today_rationale_min_below_with_time">Osećajna minimalna %1$s%2$s u %3$s, ispod %4$s%2$s</string>
     <string name="today_rationale_min_below">Osećajna minimalna %1$s%2$s, ispod %3$s%2$s</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -141,7 +141,6 @@ What is NOT overridden, by design:
     <string name="today_rationale_dismiss">Разбрах</string>
     <string name="today_rationale_threshold_decrease">Намали прага с 1 градус</string>
     <string name="today_rationale_threshold_increase">Увеличи прага с 1 градус</string>
-    <string name="today_rationale_threshold_changed_hint">Обнови, за да видиш новия тоалет.</string>
     <string name="today_rationale_unavailable">Няма налично обяснение — отвори приложението след следващото обновяване.</string>
     <string name="today_rationale_min_below_with_time">Усещана минимална температура %1$s%2$s в %3$s, под %4$s%2$s</string>
     <string name="today_rationale_min_below">Усещана минимална температура %1$s%2$s, под %3$s%2$s</string>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -135,7 +135,6 @@ West Bengal vocabulary differences in a future PR.
     <string name="today_rationale_dismiss">বুঝেছি</string>
     <string name="today_rationale_threshold_decrease">সীমা ১ ডিগ্রি কমান</string>
     <string name="today_rationale_threshold_increase">সীমা ১ ডিগ্রি বাড়ান</string>
-    <string name="today_rationale_threshold_changed_hint">নতুন পোশাক দেখতে রিফ্রেশ করুন।</string>
     <string name="today_rationale_unavailable">কোনো ব্যাখ্যা নেই — পরবর্তী রিফ্রেশের পর অ্যাপ খুলুন।</string>
     <string name="today_rationale_min_below_with_time">%3$s-এ অনুভূত সর্বনিম্ন %1$s%2$s, %4$s%2$s-এর নিচে</string>
     <string name="today_rationale_min_below">অনুভূত সর্বনিম্ন %1$s%2$s, %3$s%2$s-এর নিচে</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -43,7 +43,6 @@ the in-app clock is digit-driven and reads consistently across locales.
     <string name="today_rationale_dismiss">Entès</string>
     <string name="today_rationale_threshold_decrease">Redueix el llindar 1 grau</string>
     <string name="today_rationale_threshold_increase">Augmenta el llindar 1 grau</string>
-    <string name="today_rationale_threshold_changed_hint">Actualitza per veure el nou conjunt.</string>
     <string name="today_rationale_unavailable">Cap justificació disponible — obre l\'aplicació després de la pròxima actualització.</string>
     <string name="today_rationale_min_below_with_time">Sensació mínima de %1$s%2$s a les %3$s, per sota de %4$s%2$s</string>
     <string name="today_rationale_min_below">Sensació mínima de %1$s%2$s, per sota de %3$s%2$s</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -418,7 +418,6 @@ locale (Angličtina (USA), Francouzština (Francie), Němčina (Německo), …).
     <string name="today_rationale_dismiss">Rozumím</string>
     <string name="today_rationale_threshold_decrease">Snížit práh o 1 stupeň</string>
     <string name="today_rationale_threshold_increase">Zvýšit práh o 1 stupeň</string>
-    <string name="today_rationale_threshold_changed_hint">Obnovit pro zobrazení nového outfitu.</string>
     <string name="today_rationale_unavailable">Zdůvodnění není k dispozici — otevři aplikaci po příštím obnovení.</string>
     <string name="today_rationale_min_below_with_time">Pocitové minimum %1$s%2$s v %3$s h, pod %4$s%2$s</string>
     <string name="today_rationale_min_below">Pocitové minimum %1$s%2$s, pod %3$s%2$s</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -419,7 +419,6 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrig)").
     <string name="today_rationale_dismiss">Forstået</string>
     <string name="today_rationale_threshold_decrease">Sænk tærsklen med 1 grad</string>
     <string name="today_rationale_threshold_increase">Hæv tærsklen med 1 grad</string>
-    <string name="today_rationale_threshold_changed_hint">Opdater for at se det nye outfit.</string>
     <string name="today_rationale_unavailable">Ingen begrundelse tilgængelig — åbn appen efter næste opdatering.</string>
     <string name="today_rationale_min_below_with_time">Følt minimumstemperatur %1$s%2$s klokken %3$s, under %4$s%2$s</string>
     <string name="today_rationale_min_below">Følt minimumstemperatur %1$s%2$s, under %3$s%2$s</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -552,7 +552,6 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="today_rationale_dismiss">Verstanden</string>
     <string name="today_rationale_threshold_decrease">Schwellenwert um 1 Grad senken</string>
     <string name="today_rationale_threshold_increase">Schwellenwert um 1 Grad erhöhen</string>
-    <string name="today_rationale_threshold_changed_hint">Aktualisieren, um das neue Outfit zu sehen.</string>
     <string name="today_rationale_unavailable">Keine Begründung verfügbar — öffne die App nach der nächsten Aktualisierung.</string>
     <string name="today_rationale_min_below_with_time">Gefühlte Tiefsttemperatur %1$s%2$s um %3$s Uhr, unter %4$s%2$s</string>
     <string name="today_rationale_min_below">Gefühlte Tiefsttemperatur %1$s%2$s, unter %3$s%2$s</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -564,7 +564,6 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="today_rationale_dismiss">Κατάλαβα</string>
     <string name="today_rationale_threshold_decrease">Μείωση ορίου κατά 1 βαθμό</string>
     <string name="today_rationale_threshold_increase">Αύξηση ορίου κατά 1 βαθμό</string>
-    <string name="today_rationale_threshold_changed_hint">Ανανέωσε για να δεις τη νέα ένδυση.</string>
     <string name="today_rationale_unavailable">Δεν υπάρχει διαθέσιμη αιτιολογία — άνοιξε την εφαρμογή μετά την επόμενη ανανέωση.</string>
     <string name="today_rationale_min_below_with_time">Αίσθηση ελάχιστης %1$s%2$s στις %3$s, κάτω από %4$s%2$s</string>
     <string name="today_rationale_min_below">Αίσθηση ελάχιστης %1$s%2$s, κάτω από %3$s%2$s</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -531,7 +531,6 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="today_rationale_dismiss">Entendido</string>
     <string name="today_rationale_threshold_decrease">Bajar umbral 1 grado</string>
     <string name="today_rationale_threshold_increase">Subir umbral 1 grado</string>
-    <string name="today_rationale_threshold_changed_hint">Actualiza para ver el nuevo conjunto.</string>
     <string name="today_rationale_unavailable">No hay justificación disponible — abre la app después de la próxima actualización.</string>
     <string name="today_rationale_min_below_with_time">Sensación mínima de %1$s%2$s a las %3$s, por debajo de %4$s%2$s</string>
     <string name="today_rationale_min_below">Sensación mínima de %1$s%2$s, por debajo de %3$s%2$s</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -43,7 +43,6 @@ Tone is informal "sina"-form throughout ("Pane … selga", "Võta … kaasa",
     <string name="today_rationale_dismiss">Selge</string>
     <string name="today_rationale_threshold_decrease">Alanda läve 1 kraadi võrra</string>
     <string name="today_rationale_threshold_increase">Tõsta läve 1 kraadi võrra</string>
-    <string name="today_rationale_threshold_changed_hint">Värskenda, et näha uut riietust.</string>
     <string name="today_rationale_unavailable">Põhjendus puudub — ava rakendus pärast järgmist värskendust.</string>
     <string name="today_rationale_min_below_with_time">Tunnetatav miinimum %1$s%2$s kell %3$s, alla %4$s%2$s</string>
     <string name="today_rationale_min_below">Tunnetatav miinimum %1$s%2$s, alla %3$s%2$s</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -133,7 +133,6 @@ Western Arabic numerals (0-9) are used for TTS compatibility.
     <string name="today_rationale_dismiss">متوجه شدم</string>
     <string name="today_rationale_threshold_decrease">کاهش آستانه ۱ درجه</string>
     <string name="today_rationale_threshold_increase">افزایش آستانه ۱ درجه</string>
-    <string name="today_rationale_threshold_changed_hint">بازخوانی کنید تا لباس جدید را ببینید.</string>
     <string name="today_rationale_unavailable">توضیحی در دسترس نیست — پس از به‌روزرسانی بعدی برنامه را باز کنید.</string>
     <string name="today_rationale_min_below_with_time">حداقل دمای احساس‌شده %1$s%2$s در ساعت %3$s، کمتر از %4$s%2$s</string>
     <string name="today_rationale_min_below">حداقل دمای احساس‌شده %1$s%2$s، کمتر از %3$s%2$s</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -445,7 +445,6 @@ displayed label localizes.
     <string name="today_rationale_dismiss">Selvä</string>
     <string name="today_rationale_threshold_decrease">Laske raja-arvoa 1 asteella</string>
     <string name="today_rationale_threshold_increase">Nosta raja-arvoa 1 asteella</string>
-    <string name="today_rationale_threshold_changed_hint">Päivitä nähdäksesi uuden asun.</string>
     <string name="today_rationale_unavailable">Perustelua ei saatavilla — avaa sovellus seuraavan päivityksen jälkeen.</string>
     <string name="today_rationale_min_below_with_time">Tuntuva miimilämpötila %1$s%2$s kello %3$s, alle %4$s%2$s</string>
     <string name="today_rationale_min_below">Tuntuva minimilämpötila %1$s%2$s, alle %3$s%2$s</string>

--- a/app/src/main/res/values-fil/strings.xml
+++ b/app/src/main/res/values-fil/strings.xml
@@ -125,7 +125,6 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="today_rationale_dismiss">Nakuha ko</string>
     <string name="today_rationale_threshold_decrease">Ibaba ang threshold ng 1 degree</string>
     <string name="today_rationale_threshold_increase">Itaas ang threshold ng 1 degree</string>
-    <string name="today_rationale_threshold_changed_hint">I-refresh para makita ang bagong outfit.</string>
     <string name="today_rationale_unavailable">Walang available na dahilan — buksan ang app pagkatapos ng susunod na refresh.</string>
     <string name="today_rationale_min_below_with_time">Pinakamababang nararamdamang temperatura na %1$s%2$s ng %3$s, mas mababa sa %4$s%2$s</string>
     <string name="today_rationale_min_below">Pinakamababang nararamdamang temperatura na %1$s%2$s, mas mababa sa %3$s%2$s</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -528,7 +528,6 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="today_rationale_dismiss">Compris</string>
     <string name="today_rationale_threshold_decrease">Baisser le seuil de 1 degré</string>
     <string name="today_rationale_threshold_increase">Augmenter le seuil de 1 degré</string>
-    <string name="today_rationale_threshold_changed_hint">Actualise pour voir la nouvelle tenue.</string>
     <string name="today_rationale_unavailable">Aucune justification disponible — ouvre l\'app après la prochaine actualisation.</string>
     <string name="today_rationale_min_below_with_time">Ressenti bas de %1$s%2$s à %3$s, sous %4$s%2$s</string>
     <string name="today_rationale_min_below">Ressenti bas de %1$s%2$s, sous %3$s%2$s</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -360,7 +360,6 @@ Not overridden by design:
     <string name="today_rationale_dismiss">समझ गया</string>
     <string name="today_rationale_threshold_decrease">सीमा 1 डिग्री घटाएँ</string>
     <string name="today_rationale_threshold_increase">सीमा 1 डिग्री बढ़ाएँ</string>
-    <string name="today_rationale_threshold_changed_hint">नई पोशाक देखने के लिए रीफ़्रेश करें।</string>
     <string name="today_rationale_unavailable">कोई कारण उपलब्ध नहीं — अगले रीफ़्रेश के बाद ऐप खोलें।</string>
     <string name="today_rationale_min_below_with_time">महसूस न्यूनतम %1$s%2$s, %3$s को, %4$s%2$s से कम</string>
     <string name="today_rationale_min_below">महसूस न्यूनतम %1$s%2$s, %3$s%2$s से कम</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -496,7 +496,6 @@ spousal register), matching the existing insight prose ("Ponesi …",
     <string name="today_rationale_dismiss">Razumijem</string>
     <string name="today_rationale_threshold_decrease">Smanji prag za 1 stupanj</string>
     <string name="today_rationale_threshold_increase">Povećaj prag za 1 stupanj</string>
-    <string name="today_rationale_threshold_changed_hint">Osvježi da vidiš novu odjevnu kombinaciju.</string>
     <string name="today_rationale_unavailable">Nema dostupnog objašnjenja — otvori aplikaciju nakon sljedećeg osvježavanja.</string>
     <string name="today_rationale_min_below_with_time">Osjetna minimalna %1$s%2$s u %3$s, ispod %4$s%2$s</string>
     <string name="today_rationale_min_below">Osjetna minimalna %1$s%2$s, ispod %3$s%2$s</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -420,7 +420,6 @@ locale (Angol (Egyesült Államok), Francia (Franciaország), Német
     <string name="today_rationale_dismiss">Értem</string>
     <string name="today_rationale_threshold_decrease">Küszöb csökkentése 1 fokkal</string>
     <string name="today_rationale_threshold_increase">Küszöb növelése 1 fokkal</string>
-    <string name="today_rationale_threshold_changed_hint">Frissítsd az új outfit megtekintéséhez.</string>
     <string name="today_rationale_unavailable">Az indoklás nem elérhető — nyisd meg az alkalmazást a következő frissítés után.</string>
     <string name="today_rationale_min_below_with_time">Érzet-minimum %1$s%2$s %3$s órakor, %4$s%2$s alatt</string>
     <string name="today_rationale_min_below">Érzet-minimum %1$s%2$s, %3$s%2$s alatt</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -131,7 +131,6 @@ to values/strings.xml (English).
     <string name="today_rationale_dismiss">Mengerti</string>
     <string name="today_rationale_threshold_decrease">Turunkan ambang batas 1 derajat</string>
     <string name="today_rationale_threshold_increase">Naikkan ambang batas 1 derajat</string>
-    <string name="today_rationale_threshold_changed_hint">Perbarui untuk melihat pakaian baru.</string>
     <string name="today_rationale_unavailable">Tidak ada penjelasan tersedia — buka aplikasi setelah pembaruan berikutnya.</string>
     <string name="today_rationale_min_below_with_time">Suhu terasa minimum %1$s%2$s pukul %3$s, di bawah %4$s%2$s</string>
     <string name="today_rationale_min_below">Suhu terasa minimum %1$s%2$s, di bawah %3$s%2$s</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -514,7 +514,6 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="today_rationale_dismiss">Ho capito</string>
     <string name="today_rationale_threshold_decrease">Abbassa soglia di 1 grado</string>
     <string name="today_rationale_threshold_increase">Alza soglia di 1 grado</string>
-    <string name="today_rationale_threshold_changed_hint">Aggiorna per vedere il nuovo outfit.</string>
     <string name="today_rationale_unavailable">Nessuna spiegazione disponibile — apri l\'app dopo il prossimo aggiornamento.</string>
     <string name="today_rationale_min_below_with_time">Percepito minimo %1$s%2$s alle %3$s, sotto %4$s%2$s</string>
     <string name="today_rationale_min_below">Percepito minimo %1$s%2$s, sotto %3$s%2$s</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -133,7 +133,6 @@ standard in Israeli digital communication.
     <string name="today_rationale_dismiss">הבנתי</string>
     <string name="today_rationale_threshold_decrease">הורד/י סף ב-1 מעלה</string>
     <string name="today_rationale_threshold_increase">העלה/י סף ב-1 מעלה</string>
-    <string name="today_rationale_threshold_changed_hint">רענן/י כדי לראות את הלבוש החדש.</string>
     <string name="today_rationale_unavailable">אין הסבר זמין — פתח/י את האפליקציה לאחר הרענון הבא.</string>
     <string name="today_rationale_min_below_with_time">מינימום טמפ׳ מורגשת %1$s%2$s בשעה %3$s, מתחת ל-%4$s%2$s</string>
     <string name="today_rationale_min_below">מינימום טמפ׳ מורגשת %1$s%2$s, מתחת ל-%3$s%2$s</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -530,7 +530,6 @@ the displayed label localizes.
     <string name="today_rationale_dismiss">了解</string>
     <string name="today_rationale_threshold_decrease">しきい値を1度下げる</string>
     <string name="today_rationale_threshold_increase">しきい値を1度上げる</string>
-    <string name="today_rationale_threshold_changed_hint">更新して新しい服装を確認してください。</string>
     <string name="today_rationale_unavailable">根拠がありません — 次の更新後にアプリを開いてください。</string>
     <string name="today_rationale_min_below_with_time">体感最低気温 %1$s%2$s（%3$s）、%4$s%2$s未満</string>
     <string name="today_rationale_min_below">体感最低気温 %1$s%2$s、%3$s%2$s未満</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -534,7 +534,6 @@ displayed label localizes.
     <string name="today_rationale_dismiss">알겠습니다</string>
     <string name="today_rationale_threshold_decrease">임계값 1도 낮추기</string>
     <string name="today_rationale_threshold_increase">임계값 1도 높이기</string>
-    <string name="today_rationale_threshold_changed_hint">새 의상을 보려면 새로고침하세요.</string>
     <string name="today_rationale_unavailable">사용 가능한 근거가 없습니다 — 다음 새로고침 후 앱을 열어보세요.</string>
     <string name="today_rationale_min_below_with_time">체감 최저 %1$s%2$s(%3$s), %4$s%2$s 미만</string>
     <string name="today_rationale_min_below">체감 최저 %1$s%2$s, %3$s%2$s 미만</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -128,7 +128,6 @@ What is NOT overridden, by design:
     <string name="today_rationale_dismiss">Supratau</string>
     <string name="today_rationale_threshold_decrease">Sumažinti ribą 1 laipsniu</string>
     <string name="today_rationale_threshold_increase">Padidinti ribą 1 laipsniu</string>
-    <string name="today_rationale_threshold_changed_hint">Atnaujink, kad pamatytum naują aprangos rinkinį.</string>
     <string name="today_rationale_unavailable">Pagrindimas nepasiekiamas — atidaryti programą po kito atnaujinimo.</string>
     <string name="today_rationale_min_below_with_time">Pojūčio min. %1$s%2$s %3$s val., žemiau %4$s%2$s</string>
     <string name="today_rationale_min_below">Pojūčio min. %1$s%2$s, žemiau %3$s%2$s</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -130,7 +130,6 @@ informal "tu"-form throughout ("Apģērb …", "Paņem … līdzi").
     <string name="today_rationale_dismiss">Sapratu</string>
     <string name="today_rationale_threshold_decrease">Pazemināt slieksni par 1 grādu</string>
     <string name="today_rationale_threshold_increase">Paaugstināt slieksni par 1 grādu</string>
-    <string name="today_rationale_threshold_changed_hint">Atjaunini, lai redzētu jauno apģērbu.</string>
     <string name="today_rationale_unavailable">Pamatojums nav pieejams — atver lietotni pēc nākamās atjaunināšanas.</string>
     <string name="today_rationale_min_below_with_time">Sajustā minimālā temperatūra %1$s%2$s plkst. %3$s, zem %4$s%2$s</string>
     <string name="today_rationale_min_below">Sajustā minimālā temperatūra %1$s%2$s, zem %3$s%2$s</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -126,7 +126,6 @@ vs "kemungkinan", "padam" vs "hapus").
     <string name="today_rationale_dismiss">Faham</string>
     <string name="today_rationale_threshold_decrease">Kurangkan ambang 1 darjah</string>
     <string name="today_rationale_threshold_increase">Naikkan ambang 1 darjah</string>
-    <string name="today_rationale_threshold_changed_hint">Muat semula untuk melihat pakaian baharu.</string>
     <string name="today_rationale_unavailable">Tiada sebab tersedia — buka aplikasi selepas muat semula berikutnya.</string>
     <string name="today_rationale_min_below_with_time">Terasa rendah %1$s%2$s pada %3$s, di bawah %4$s%2$s</string>
     <string name="today_rationale_min_below">Terasa rendah %1$s%2$s, di bawah %3$s%2$s</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -419,7 +419,6 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrike)").
     <string name="today_rationale_dismiss">Forstått</string>
     <string name="today_rationale_threshold_decrease">Senk terskelen med 1 grad</string>
     <string name="today_rationale_threshold_increase">Øk terskelen med 1 grad</string>
-    <string name="today_rationale_threshold_changed_hint">Oppdater for å se det nye antrekket.</string>
     <string name="today_rationale_unavailable">Ingen begrunnelse tilgjengelig — åpne appen etter neste oppdatering.</string>
     <string name="today_rationale_min_below_with_time">Følt minimumstemperatur %1$s%2$s klokken %3$s, under %4$s%2$s</string>
     <string name="today_rationale_min_below">Følt minimumstemperatur %1$s%2$s, under %3$s%2$s</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -488,7 +488,6 @@ the displayed label localizes.
     <string name="today_rationale_dismiss">Begrepen</string>
     <string name="today_rationale_threshold_decrease">Drempel met 1 graad verlagen</string>
     <string name="today_rationale_threshold_increase">Drempel met 1 graad verhogen</string>
-    <string name="today_rationale_threshold_changed_hint">Vernieuwen om het nieuwe outfit te zien.</string>
     <string name="today_rationale_unavailable">Geen onderbouwing beschikbaar — open de app na de volgende vernieuwing.</string>
     <string name="today_rationale_min_below_with_time">Minimale gevoelstemperatuur %1$s%2$s om %3$s uur, onder %4$s%2$s</string>
     <string name="today_rationale_min_below">Minimale gevoelstemperatuur %1$s%2$s, onder %3$s%2$s</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -486,7 +486,6 @@ is unchanged; only the displayed label localizes.
     <string name="today_rationale_dismiss">Rozumiem</string>
     <string name="today_rationale_threshold_decrease">Obniż próg o 1 stopień</string>
     <string name="today_rationale_threshold_increase">Podnieś próg o 1 stopień</string>
-    <string name="today_rationale_threshold_changed_hint">Odśwież, aby zobaczyć nowy outfit.</string>
     <string name="today_rationale_unavailable">Brak uzasadnienia — otwórz aplikację po następnym odświeżeniu.</string>
     <string name="today_rationale_min_below_with_time">Minimalna temperatura odczuwalna %1$s%2$s o %3$s, poniżej %4$s%2$s</string>
     <string name="today_rationale_min_below">Minimalna temperatura odczuwalna %1$s%2$s, poniżej %3$s%2$s</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -532,7 +532,6 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="today_rationale_dismiss">Entendi</string>
     <string name="today_rationale_threshold_decrease">Diminuir limite em 1 grau</string>
     <string name="today_rationale_threshold_increase">Aumentar limite em 1 grau</string>
-    <string name="today_rationale_threshold_changed_hint">Atualize para ver a nova roupa.</string>
     <string name="today_rationale_unavailable">Nenhuma justificativa disponível — abra o app após a próxima atualização.</string>
     <string name="today_rationale_min_below_with_time">Sensação mínima de %1$s%2$s às %3$s, abaixo de %4$s%2$s</string>
     <string name="today_rationale_min_below">Sensação mínima de %1$s%2$s, abaixo de %3$s%2$s</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -494,7 +494,6 @@ they diverge from BR ("Polonês" → "Polaco", "Holandês" →
     <string name="today_rationale_dismiss">Entendido</string>
     <string name="today_rationale_threshold_decrease">Diminuir limite em 1 grau</string>
     <string name="today_rationale_threshold_increase">Aumentar limite em 1 grau</string>
-    <string name="today_rationale_threshold_changed_hint">Atualiza para ver a nova roupa.</string>
     <string name="today_rationale_unavailable">Nenhuma justificação disponível — abre a aplicação após a próxima atualização.</string>
     <string name="today_rationale_min_below_with_time">Sensação mínima de %1$s%2$s às %3$s, abaixo de %4$s%2$s</string>
     <string name="today_rationale_min_below">Sensação mínima de %1$s%2$s, abaixo de %3$s%2$s</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -128,7 +128,6 @@ surfaces fall back to default English (matching values-pl / values-uk).
     <string name="today_rationale_dismiss">Am înțeles</string>
     <string name="today_rationale_threshold_decrease">Scade pragul cu 1 grad</string>
     <string name="today_rationale_threshold_increase">Crește pragul cu 1 grad</string>
-    <string name="today_rationale_threshold_changed_hint">Reîmprospătează pentru a vedea noua ținută.</string>
     <string name="today_rationale_unavailable">Nicio explicație disponibilă — deschide aplicația după următoarea reîmprospătare.</string>
     <string name="today_rationale_min_below_with_time">Temperatura resimțită minimă %1$s%2$s la %3$s, sub %4$s%2$s</string>
     <string name="today_rationale_min_below">Temperatura resimțită minimă %1$s%2$s, sub %3$s%2$s</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -539,7 +539,6 @@ only the displayed label localizes.
     <string name="today_rationale_dismiss">Понятно</string>
     <string name="today_rationale_threshold_decrease">Снизить порог на 1 градус</string>
     <string name="today_rationale_threshold_increase">Повысить порог на 1 градус</string>
-    <string name="today_rationale_threshold_changed_hint">Обновить, чтобы увидеть новый наряд.</string>
     <string name="today_rationale_unavailable">Объяснение недоступно — открой приложение после следующего обновления.</string>
     <string name="today_rationale_min_below_with_time">Ощущается минимум %1$s%2$s в %3$s, ниже %4$s%2$s</string>
     <string name="today_rationale_min_below">Ощущается минимум %1$s%2$s, ниже %3$s%2$s</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -430,7 +430,6 @@ What is NOT overridden, by design:
     <string name="today_rationale_dismiss">Rozumiem</string>
     <string name="today_rationale_threshold_decrease">Znížiť prah o 1 stupeň</string>
     <string name="today_rationale_threshold_increase">Zvýšiť prah o 1 stupeň</string>
-    <string name="today_rationale_threshold_changed_hint">Obnov pre zobrazenie nového outfitu.</string>
     <string name="today_rationale_unavailable">Zdôvodnenie nie je k dispozícii — otvor aplikáciu po ďalšom obnovení.</string>
     <string name="today_rationale_min_below_with_time">Pocitové minimum %1$s%2$s o %3$s, pod %4$s%2$s</string>
     <string name="today_rationale_min_below">Pocitové minimum %1$s%2$s, pod %3$s%2$s</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -136,7 +136,6 @@ informal "ti"-form throughout, mirroring the Croatian / Serbian pass.
     <string name="today_rationale_dismiss">Razumem</string>
     <string name="today_rationale_threshold_decrease">Znižaj prag za 1 stopinjo</string>
     <string name="today_rationale_threshold_increase">Zvišaj prag za 1 stopinjo</string>
-    <string name="today_rationale_threshold_changed_hint">Osveži za novo obleko.</string>
     <string name="today_rationale_unavailable">Pojasnilo ni na voljo — odpri aplikacijo po naslednjem osveževanju.</string>
     <string name="today_rationale_min_below_with_time">Občutena minimalna %1$s%2$s ob %3$s, pod %4$s%2$s</string>
     <string name="today_rationale_min_below">Občutena minimalna %1$s%2$s, pod %3$s%2$s</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -419,7 +419,6 @@ native names for all locales (e.g. "Tyska (Tyskland)", "Franska (Frankrike)").
     <string name="today_rationale_dismiss">Förstått</string>
     <string name="today_rationale_threshold_decrease">Sänk tröskeln med 1 grad</string>
     <string name="today_rationale_threshold_increase">Höj tröskeln med 1 grad</string>
-    <string name="today_rationale_threshold_changed_hint">Uppdatera för att se det nya outfitet.</string>
     <string name="today_rationale_unavailable">Ingen motivering tillgänglig — öppna appen efter nästa uppdatering.</string>
     <string name="today_rationale_min_below_with_time">Upplevd lägstatemperatur %1$s%2$s klockan %3$s, under %4$s%2$s</string>
     <string name="today_rationale_min_below">Upplevd lägstatemperatur %1$s%2$s, under %3$s%2$s</string>

--- a/app/src/main/res/values-sw/strings.xml
+++ b/app/src/main/res/values-sw/strings.xml
@@ -122,7 +122,6 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="today_rationale_dismiss">Sawa</string>
     <string name="today_rationale_threshold_decrease">Punguza kiwango kwa digrii 1</string>
     <string name="today_rationale_threshold_increase">Ongeza kiwango kwa digrii 1</string>
-    <string name="today_rationale_threshold_changed_hint">Onyesha upya ili kuona mavazi mapya.</string>
     <string name="today_rationale_unavailable">Hakuna maelezo — fungua programu baada ya kusasisha ijayo.</string>
     <string name="today_rationale_min_below_with_time">Kiwango cha chini kinachohisi %1$s%2$s saa %3$s, chini ya %4$s%2$s</string>
     <string name="today_rationale_min_below">Kiwango cha chini kinachohisi %1$s%2$s, chini ya %3$s%2$s</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -132,7 +132,6 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="today_rationale_dismiss">เข้าใจแล้ว</string>
     <string name="today_rationale_threshold_decrease">ลดค่าเกณฑ์ลง 1 องศา</string>
     <string name="today_rationale_threshold_increase">เพิ่มค่าเกณฑ์ขึ้น 1 องศา</string>
-    <string name="today_rationale_threshold_changed_hint">รีเฟรชเพื่อดูชุดใหม่</string>
     <string name="today_rationale_unavailable">ไม่มีข้อมูลเหตุผล — เปิดแอปหลังจากรีเฟรชครั้งถัดไป</string>
     <string name="today_rationale_min_below_with_time">อุณหภูมิที่รู้สึกต่ำสุด %1$s%2$s เวลา %3$s ต่ำกว่า %4$s%2$s</string>
     <string name="today_rationale_min_below">อุณหภูมิที่รู้สึกต่ำสุด %1$s%2$s ต่ำกว่า %3$s%2$s</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -444,7 +444,6 @@ displayed label localizes.
     <string name="today_rationale_dismiss">Anladım</string>
     <string name="today_rationale_threshold_decrease">Eşiği 1 derece düşür</string>
     <string name="today_rationale_threshold_increase">Eşiği 1 derece artır</string>
-    <string name="today_rationale_threshold_changed_hint">Yeni kıyafeti görmek için yenile.</string>
     <string name="today_rationale_unavailable">Gerekçe mevcut değil — bir sonraki güncellemeden sonra uygulamayı açın.</string>
     <string name="today_rationale_min_below_with_time">Hissedilen minimum sıcaklık saat %3$s\'de %1$s%2$s, %4$s%2$s altında</string>
     <string name="today_rationale_min_below">Hissedilen minimum sıcaklık %1$s%2$s, %3$s%2$s altında</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -410,7 +410,6 @@ only the displayed label localizes.
     <string name="today_rationale_dismiss">Зрозуміло</string>
     <string name="today_rationale_threshold_decrease">Знизити поріг на 1 градус</string>
     <string name="today_rationale_threshold_increase">Підвищити поріг на 1 градус</string>
-    <string name="today_rationale_threshold_changed_hint">Оновіть, щоб побачити нове вбрання.</string>
     <string name="today_rationale_unavailable">Пояснення недоступне — відкрийте застосунок після наступного оновлення.</string>
     <string name="today_rationale_min_below_with_time">Відчувається мінімум %1$s%2$s о %3$s, нижче %4$s%2$s</string>
     <string name="today_rationale_min_below">Відчувається мінімум %1$s%2$s, нижче %3$s%2$s</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -131,7 +131,6 @@ Skipped intentionally: app_name (brand), insight_time_am/pm/midnight/noon
     <string name="today_rationale_dismiss">Đã hiểu</string>
     <string name="today_rationale_threshold_decrease">Giảm ngưỡng 1 độ</string>
     <string name="today_rationale_threshold_increase">Tăng ngưỡng 1 độ</string>
-    <string name="today_rationale_threshold_changed_hint">Làm mới để xem trang phục mới.</string>
     <string name="today_rationale_unavailable">Không có lý do — hãy mở ứng dụng sau lần làm mới tiếp theo.</string>
     <string name="today_rationale_min_below_with_time">Cảm giác thấp nhất %1$s%2$s lúc %3$s, dưới %4$s%2$s</string>
     <string name="today_rationale_min_below">Cảm giác thấp nhất %1$s%2$s, dưới %3$s%2$s</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -522,7 +522,6 @@ label localizes.
     <string name="today_rationale_dismiss">明白了</string>
     <string name="today_rationale_threshold_decrease">将阈值降低 1 度</string>
     <string name="today_rationale_threshold_increase">将阈值提高 1 度</string>
-    <string name="today_rationale_threshold_changed_hint">刷新以查看新穿搭。</string>
     <string name="today_rationale_unavailable">暂无说明 — 下次刷新后打开应用查看。</string>
     <string name="today_rationale_min_below_with_time">体感最低气温 %1$s%2$s（%3$s），低于 %4$s%2$s</string>
     <string name="today_rationale_min_below">体感最低气温 %1$s%2$s，低于 %3$s%2$s</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -475,7 +475,6 @@ label localises.
     <string name="today_rationale_dismiss">了解</string>
     <string name="today_rationale_threshold_decrease">閾值降低 1 度</string>
     <string name="today_rationale_threshold_increase">閾值提高 1 度</string>
-    <string name="today_rationale_threshold_changed_hint">重新整理以查看新穿搭。</string>
     <string name="today_rationale_unavailable">暫無說明 — 下次重新整理後開啟應用程式查看。</string>
     <string name="today_rationale_min_below_with_time">體感最低氣溫 %1$s%2$s（%3$s），低於 %4$s%2$s</string>
     <string name="today_rationale_min_below">體感最低氣溫 %1$s%2$s，低於 %3$s%2$s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -65,7 +65,6 @@
     <string name="today_rationale_open_clothes_settings">Clothes settings</string>
     <string name="today_rationale_threshold_decrease">Lower threshold by 1 degree</string>
     <string name="today_rationale_threshold_increase">Raise threshold by 1 degree</string>
-    <string name="today_rationale_threshold_changed_hint">Refresh to see the new outfit.</string>
     <string name="today_rationale_unavailable">No rationale available — open the app after the next refresh.</string>
     <!-- "Feels-like low 13°C at 6am, under 18°C" -->
     <string name="today_rationale_min_below_with_time">Feels-like low %1$s%2$s at %3$s, under %4$s%2$s</string>


### PR DESCRIPTION
## Summary

- Removes the "Refresh to see the new outfit." hint that appeared in the outfit rationale dialog after a threshold tap. Threshold changes already take effect live, so the hint was misleading.
- Drops the `today_rationale_threshold_changed_hint` string from `values/` and all 44 translated locales, plus the `thresholdsTouched` state and its wrapping lambdas in `OutfitRationaleDialog`.

## Test plan

- [x] `./gradlew :app:assembleDebug`
- [x] `./gradlew :app:testDebugUnitTest`
- [ ] Manually: open the outfit rationale dialog, tap a threshold adjuster, confirm no stale "refresh" hint appears and the next insight reflects the change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RJssbXWJTpDbZonJqbhaYy)_