### PR TITLE
Hide the clothes-rules promo once the user has customised them

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/today/ClothesPromoCard.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/ClothesPromoCard.kt
@@ -22,19 +22,20 @@ import androidx.compose.ui.unit.dp
 import app.clothescast.R
 
 /**
- * One-time Today-screen promo card surfaced after onboarding to nudge the
- * user at Clothes settings — the per-temperature clothing rules are the
- * core thing that makes outfits "theirs", but the path to them isn't
- * obvious from the Today screen. Sits between the telemetry-notice
- * banner and the celebration-themes promo so a fresh-installed user
- * sees: privacy disclosure → "customise your clothes" → celebration
- * themes.
+ * Today-screen promo card nudging the user at Clothes settings — the
+ * per-temperature clothing rules are the core thing that makes outfits
+ * "theirs", but the path to them isn't obvious from the Today screen.
+ * Sits between the telemetry-notice banner and the celebration-themes
+ * promo.
  *
  * Visibility is decided upstream in [TodayViewModel] via
  * [TodayState.clothesPromoCardVisible] — true iff the user hasn't
- * dismissed it. Dismissal (X tap *or* "Clothes settings" tap) persists
- * via [SettingsRepository.setClothesPromoCardDismissed] so the card
- * never re-surfaces.
+ * dismissed it AND their clothes rules still match
+ * [ClothesRule.DEFAULTS]. Any edit / add / delete / threshold-nudge
+ * auto-hides the card (the user found the thing the card was pointing
+ * at, so the promo's done). Dismissal (X tap *or* "Clothes settings"
+ * tap) persists via [SettingsRepository.setClothesPromoCardDismissed]
+ * so the card never re-surfaces.
  */
 @Composable
 internal fun ClothesPromoCard(

--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
@@ -559,10 +559,11 @@ private fun BannerStack(
     // crash banner: that's a current problem to action; this is just
     // disclosure.
     TelemetryNoticeBanner(onOpenPrivacy = onOpenPrivacy, modifier = bannerModifier)
-    // One-time "Customize your clothes" nudge shown after onboarding so the
-    // user knows the per-temperature rules are theirs to tune. Sits before
-    // the celebration-themes promo because clothes rules are the core
-    // setting; celebration themes are a finishing touch.
+    // "Customize your clothes" nudge so the user knows the per-temperature
+    // rules are theirs to tune. Gated upstream on [clothesRules] still
+    // matching [ClothesRule.DEFAULTS] (plus the user not having dismissed)
+    // so a user who has already customised never sees it. Sits before the
+    // celebration-themes promo because clothes rules are the core setting.
     ClothesPromoCard(
         visible = state.clothesPromoCardVisible,
         onOpenClothes = {

--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayViewModel.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayViewModel.kt
@@ -146,9 +146,11 @@ data class TodayState(
     val celebrationCardVisible: Boolean = false,
     /**
      * Whether the Today-screen "Customize your clothes" promo card
-     * should render. True iff the user hasn't dismissed it (or followed
-     * through to Clothes settings from it). One-time only, same shape
-     * as [telemetryNoticeAcked].
+     * should render. True iff the user hasn't dismissed it AND their
+     * clothes rules still match [ClothesRule.DEFAULTS] — the moment
+     * they edit, add, delete, or nudge a rule's threshold, the card
+     * auto-hides regardless of dismissal state (they've found the
+     * thing the card was pointing at).
      */
     val clothesPromoCardVisible: Boolean = false,
     /**
@@ -473,7 +475,8 @@ class TodayViewModel(
             celebrationCardVisible = !prefs.celebrationCardDismissed &&
                 !prefs.calendarHolidayThemingActive &&
                 !prefs.calendarBirthdayThemingActive,
-            clothesPromoCardVisible = !prefs.clothesPromoCardDismissed,
+            clothesPromoCardVisible = !prefs.clothesPromoCardDismissed &&
+                prefs.clothesRules == ClothesRule.DEFAULTS,
             usesCalendarThemes = prefs.calendarHolidayThemingActive || prefs.calendarBirthdayThemingActive,
         )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), TodayState())

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -342,11 +342,12 @@
     <string name="today_telemetry_notice_open_settings">Privacy settings</string>
     <string name="today_telemetry_notice_dismiss">Dismiss</string>
 
-    <!-- One-time promo card on the Today screen shown after onboarding,
-         pointing the user at Clothes settings so they know the per-
-         temperature clothing rules are theirs to tune. Sits between the
-         telemetry-notice banner and the celebration-themes promo; auto-
-         hides once dismissed or followed through. -->
+    <!-- Promo card on the Today screen pointing the user at Clothes
+         settings so they know the per-temperature clothing rules are
+         theirs to tune. Sits between the telemetry-notice banner and the
+         celebration-themes promo; auto-hides once the user has either
+         dismissed it OR diverged any rule from ClothesRule.DEFAULTS
+         (they've found what the card was pointing at). -->
     <string name="today_clothes_promo_title">Make the rules your own</string>
     <string name="today_clothes_promo_body">ClothesCast picks outfits from a set of rules. Tweak the temperatures, add layers, or change what gets suggested in Clothes settings.</string>
     <string name="today_clothes_promo_cta">Clothes settings</string>

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Settings.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Settings.kt
@@ -619,10 +619,12 @@ data class UserPreferences(
     val celebrationCardDismissed: Boolean = false,
     /**
      * Set to true once the user dismisses (or follows through on) the
-     * Today-screen "Customize your clothes" promo card — a one-time nudge
-     * shown after onboarding pointing the user at Clothes settings so they
-     * know the per-temperature rules are theirs to tune. Same dismiss-once
-     * contract as [telemetryNoticeAcked] / [celebrationCardDismissed].
+     * Today-screen "Customize your clothes" promo card, which points the
+     * user at Clothes settings so they know the per-temperature rules
+     * are theirs to tune. The card also auto-hides the moment
+     * [clothesRules] diverges from [ClothesRule.DEFAULTS] — the user
+     * has clearly found the thing the card was pointing at, so the
+     * promo's done its job regardless of this flag.
      */
     val clothesPromoCardDismissed: Boolean = false,
     /**


### PR DESCRIPTION
## Summary

Follow-up to #731.

The Today-screen "Make the rules your own" promo card now also auto-hides the moment `clothesRules` diverges from `ClothesRule.DEFAULTS` — the user has clearly found the page the card was pointing at, so the promo's done its job regardless of whether they ever tapped the X. Dismissal still hides it permanently (the two conditions are AND-ed).

Visibility logic:

```kotlin
clothesPromoCardVisible = !prefs.clothesPromoCardDismissed &&
    prefs.clothesRules == ClothesRule.DEFAULTS
```

So:

- **Default rules + not dismissed** → shown
- **Default rules + dismissed** → hidden (forever)
- **Customised rules** → hidden (regardless of dismissal)

Also straightens out the comments. The previous KDoc framed the card as a "one-time card surfaced after onboarding", but it actually fires for any install whose clothes rules are still at the shipped defaults — existing users who'd never seen the card pick it up too, until they edit a rule.

## Privacy

No new data leaves the device. The visibility decision is a local equality check against the in-process `ClothesRule.DEFAULTS` constant.

## Test plan

- [x] `./gradlew :core:domain:test :core:data:test :app:testDebugUnitTest` passes locally.
- [x] Card snapshot unchanged (UI is identical; only the gating logic and comments changed).
- [ ] Manually verify:
  - Fresh install (default rules, not dismissed) → card appears.
  - Edit any rule's threshold via the rationale dialog's ±1° → card disappears.
  - Tap X → card stays hidden even after restoring defaults.

## Reference

The new card (visual unchanged from #731):

![clothes_promo_card](https://github.com/mikelward/clothescast/raw/main/app/snapshots/clothes_promo_card.png)


---
_Generated by [Claude Code](https://claude.ai/code/session_01FPSeU3i9ttY15Dm5m9W2B7)_