### PR TITLE
Make the location refresh button actually fetch a fresh fix

### DIFF
--- a/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
@@ -160,7 +160,7 @@ class FetchAndNotifyWorker(
         // later in the day, after the morning run already fired.
         if (inputData.getBoolean(KEY_CACHE_LOCATION_ONLY, false)) {
             DiagLog.i(TAG, "Cache-only location refresh; skipping insight pipeline.")
-            resolveLocation(prefs)
+            resolveLocation(prefs, forceFresh = true)
             return Result.success()
         }
 
@@ -588,12 +588,27 @@ class FetchAndNotifyWorker(
         return if (joined.length <= MAX_DETAIL_LEN) joined else joined.take(MAX_DETAIL_LEN - 1) + "…"
     }
 
-    private suspend fun resolveLocation(prefs: UserPreferences): Location? {
+    private suspend fun resolveLocation(prefs: UserPreferences, forceFresh: Boolean = false): Location? {
         if (prefs.useDeviceLocation) {
             // resolve() catches and DiagLog-warns about the actual failures
             // (SecurityException from a missing background grant, disabled
             // providers, timeouts) — don't double-wrap and lose the cause.
-            val device = app.locationResolver.resolve()
+            //
+            // forceFresh=true is the user-tapped "Refresh location" path:
+            // resolve()'s default 1-hour cache window would silently return
+            // the morning alarm's fix even if the user has since moved a
+            // few km, defeating the whole point of the button. resolveFresh
+            // with FRESH_FIX_MAX_AGE_MS forces a live request when the
+            // cached fix is older than 5 minutes — short enough to surface
+            // a recent move, long enough that a co-located app's fresh
+            // read still counts. If no fresh fix is reachable, fall
+            // through to prefs.location (a no-op write here) rather than
+            // clobbering the cache with stale coordinates.
+            val device = if (forceFresh) {
+                app.locationResolver.resolveFresh(LocationResolver.FRESH_FIX_MAX_AGE_MS)
+            } else {
+                app.locationResolver.resolve()
+            }
             if (device != null) {
                 DiagLog.i(TAG, "Using device-resolved location at ${device.latitude}, ${device.longitude}.")
                 // Best-effort reverse geocode so the home screen can show a


### PR DESCRIPTION
## Bug

Tapping "Refresh location" in Settings after moving a short distance doesn't update the displayed coordinates — the app keeps showing the morning's fix.

## Root cause

`FetchAndNotifyWorker.resolveLocation()` calls `LocationResolver.resolve()`, which short-circuits to the OS's last-known fix if it's < 1 hour old:

```kotlin
val cached = lastKnown(manager)
if (cached != null && cached.isFresh(maxAgeMillis)) {
    return cached.toDomain()
}
```

After the daily alarm runs, that's almost always true for the rest of the morning. So tapping "Refresh location" later in the day silently returns the cached fix instead of requesting a new one.

The resolver already has a `resolveFresh()` variant for exactly this case (the at-home TTS gate uses it), with a shared `FRESH_FIX_MAX_AGE_MS = 5 min` ceiling.

## Fix

Route the cache-only path (the "Refresh location" button + the device-location toggle on) through `resolveFresh(FRESH_FIX_MAX_AGE_MS)` instead of `resolve()`. A live request fires whenever the OS's fix is older than 5 minutes — short enough to surface a recent move, long enough that a co-located app's recent read still counts.

Other `resolveLocation` callers — the regular forecast pipeline — keep the 1-hour stale-OK behaviour: weather doesn't need 5-minute precision, and the daily alarm shouldn't pay a live-fix latency cost every morning.

If `resolveFresh()` returns null (no provider / timeout), we fall through to `prefs.location` as before — that's a no-op write on the cache-only path, so the displayed coordinates stay as they were rather than getting clobbered.

## Test plan

- [x] `:app:compileDebugKotlin` — clean
- [x] `:app:testDebugUnitTest --tests LocationResolverTest` — pre-existing `resolveFresh` coverage still passes
- [x] `:app:testDebugUnitTest --tests FetchAndNotifyWorkerTest` — cache-only path still returns Result.success
- [ ] Manually verify on device: move a few hundred metres, tap "Refresh location" in Settings, confirm the displayed coordinates change