### PR TITLE
docs: forbid user PII in GitHub artifacts and other off-device output

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -279,6 +279,19 @@ new rule the first time something bites you, not the third.
 
 ## Privacy
 
+- **Never put user PII in any artifact that leaves this machine.** That
+  includes commit subjects and bodies, PR titles / descriptions / comments,
+  review replies, issue text, branch names, code comments, test fixtures,
+  snapshot data, and anything else that ends up on GitHub, the Play
+  Console, or in logs. PII covers — but isn't limited to — the user's
+  real name, email address, home / work / current location, GPS
+  coordinates, addresses, phone numbers, calendar event titles or
+  attendees, contact names, device identifiers, BYOK API keys, and the
+  contents of `google-services.json`. Use generic placeholders
+  (`alice@example.com`, "City A", `lat = 0.0`, "Morning standup") in
+  examples, fixtures, and reproductions. If a user-supplied bug report
+  contains PII, paraphrase it in the commit / PR — don't quote verbatim.
+  When in doubt, ask before pushing.
 - **Surface any change to what we send off device.** When a change touches
   data that crosses the device boundary — anything in the rendered insight
   prose (it's fed to Gemini TTS over BYOK keys),


### PR DESCRIPTION
## Summary

Adds a new rule at the top of the **Privacy** section in `AGENTS.md` (and `CLAUDE.md`, which symlinks to it) covering what counts as user PII and which artifacts it must stay out of.

- **PII categories (non-exhaustive):** real name, email address, home / work / current location, GPS coordinates, addresses, phone numbers, calendar event titles or attendees, contact names, device identifiers, BYOK API keys, `google-services.json` contents.
- **Out-of-scope artifacts:** commit subjects + bodies, PR titles / descriptions / comments, review replies, issue text, branch names, code comments, test fixtures, snapshot data, logs.
- Guidance to use generic placeholders (`alice@example.com`, "City A", `lat = 0.0`, "Morning standup") in examples / fixtures / reproductions, and to paraphrase user-supplied bug reports rather than quoting verbatim. "When in doubt, ask before pushing."

Slots in ahead of the existing "Surface any change to what we send off device" bullet so the strict no-PII-in-artifacts contract reads first; the off-device-data rules that follow are the runtime / data-flow counterpart.

## Privacy

Pure docs change to agent-facing guidance. Nothing in the APK changes; nothing about what the app sends off device changes. `docs:` prefix keeps it out of the Play "What's new" changelog.

## Test plan

- [x] `git diff` reviewed — single 13-line addition under `## Privacy`, no other edits.
- [x] No code paths touched, so no Gradle build / test runs needed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01V6VREpb2Cb5YNwyV4iqcio)_