### PR TITLE
Refresh refetches the forecast, Play replays the announcement

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.AlertDialog
@@ -204,15 +205,24 @@ fun TodayScreen(
             TopAppBar(
                 title = { Text(stringResource(titleRes)) },
                 actions = {
-                    // While the worker is enqueued or running we disable Refresh and swap
-                    // the icon for a spinner. The work makes a billed Gemini insight call
-                    // and (depending on the engine) a billed TTS call; re-tapping Refresh
-                    // while one is in flight uses ExistingWorkPolicy.REPLACE, which kills
-                    // the in-flight worker and starts another — re-issuing both requests.
-                    // Disabling the button removes the foot-gun.
+                    // While anything's active on the alarm or replay queues we
+                    // disable Refresh and (during the fetch phase) swap the icon
+                    // for a spinner. The work makes a billed Gemini insight call
+                    // and (depending on the engine) a billed TTS call; re-tapping
+                    // Refresh while one is in flight uses ExistingWorkPolicy.REPLACE,
+                    // which kills the in-flight worker and starts another —
+                    // re-issuing both requests. And since replays now live on
+                    // their own unique-work queue, WorkManager no longer
+                    // serializes a Refresh tap against a pending / mid-delivery
+                    // Replay — without [anyWorkActive] gating both buttons,
+                    // tapping Refresh during a Replay's TTS would deliver the
+                    // refresh and the replay concurrently. The spinner icon
+                    // still keys off [isWorking] so it shows during fetch but
+                    // not during the post-fetch TTS / MQTT / Cast window
+                    // (no fetching happening, no spinner).
                     IconButton(
                         onClick = { triggerRefresh(context, state.morningTime, state.tonightTime) },
-                        enabled = !isWorking,
+                        enabled = !state.anyWorkActive,
                     ) {
                         if (isWorking) {
                             CircularProgressIndicator(
@@ -225,6 +235,30 @@ fun TodayScreen(
                                 contentDescription = stringResource(R.string.today_refresh),
                             )
                         }
+                    }
+                    // Play replays the cached this-period insight through the
+                    // full deliver() pipeline — notification, phone-speaker
+                    // TTS, MQTT publish, cast — without a fetch. Disabled
+                    // when there's nothing to play (no cached insight) or
+                    // anything is active on the alarm / replay queues
+                    // (state.anyWorkActive). The latter is broader than
+                    // [isWorking]: it stays true through the post-fetch
+                    // TTS / MQTT / Cast window that the spinner-banner
+                    // logic intentionally treats as Idle, so a tap during
+                    // a Refresh's announcement (or a Replay's own) can't
+                    // start a second concurrent delivery now that Play
+                    // runs on its own unique-work queue.
+                    val playPeriod = state.thisPeriodInsight?.period
+                    IconButton(
+                        onClick = {
+                            playPeriod?.let { triggerPlay(context, it) }
+                        },
+                        enabled = !state.anyWorkActive && playPeriod != null,
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.PlayArrow,
+                            contentDescription = stringResource(R.string.today_play),
+                        )
                     }
                     IconButton(onClick = onNavigateToSettings) {
                         Icon(
@@ -2867,6 +2901,20 @@ private fun triggerRefresh(
     val toastRes = when (period) {
         ForecastPeriod.TODAY -> R.string.today_refresh_toast_daily
         ForecastPeriod.TONIGHT -> R.string.today_refresh_toast_nightly
+    }
+    Toast.makeText(context, context.getString(toastRes), Toast.LENGTH_SHORT).show()
+}
+
+private fun triggerPlay(context: android.content.Context, period: ForecastPeriod) {
+    // Replay against the cached snapshot's period (not wall-clock) so a
+    // morning insight still in the cache at noon replays as TODAY, and a
+    // tonight insight viewed before its tonight-window starts replays as
+    // TONIGHT. The unique work name is keyed on this so a Refresh and a
+    // Play can't run concurrently for the same slot.
+    FetchAndNotifyWorker.enqueueReplay(context.applicationContext, period)
+    val toastRes = when (period) {
+        ForecastPeriod.TODAY -> R.string.today_play_toast_daily
+        ForecastPeriod.TONIGHT -> R.string.today_play_toast_nightly
     }
     Toast.makeText(context, context.getString(toastRes), Toast.LENGTH_SHORT).show()
 }

--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayViewModel.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayViewModel.kt
@@ -63,6 +63,17 @@ data class TodayState(
      */
     val nextPeriodInsight: Insight? = null,
     val workStatus: WorkStatus = WorkStatus.Idle,
+    /**
+     * True iff any worker on the daily / tonight / replay queues is in an
+     * active state (ENQUEUED / RUNNING / BLOCKED) — independent of the
+     * [FetchAndNotifyWorker.KEY_FETCH_COMPLETE] progress flag that
+     * [workStatus] suppresses. The Today screen reads this on the Play
+     * button so a tap can't double-deliver against an in-flight Refresh
+     * (now in a separate queue from replay), can't kick off a second
+     * concurrent Replay, and can't race a scheduled alarm fire that's
+     * actively writing to [InsightCache.thisPeriod].
+     */
+    val anyWorkActive: Boolean = false,
     val temperatureUnit: TemperatureUnit = TemperatureUnit.CELSIUS,
     /**
      * Feels-like delta (°C) the today / tonight delta clause and the 7-day
@@ -288,6 +299,33 @@ internal fun mergeWorkStatus(a: WorkStatus, b: WorkStatus): WorkStatus = when {
     else -> WorkStatus.Idle
 }
 
+/**
+ * Per-tick snapshot of the worker queues the Today state pulls — the
+ * banner-driving [WorkStatus] plus the broader "is anything happening on
+ * the alarm or replay queues right now?" flag. Bundled together so the
+ * outer state combine stays at the 5-input cap.
+ */
+internal data class WorkSignals(
+    val status: WorkStatus,
+    val anyWorkActive: Boolean,
+)
+
+/**
+ * True iff any of [infos] is in an active WorkManager state
+ * (ENQUEUED / RUNNING / BLOCKED). Doesn't consult progress data — the
+ * point is to catch every phase, including the post-KEY_FETCH_COMPLETE
+ * delivery window where [selectStatus] returns Idle so the spinner
+ * banner can hide. The Today screen's Play button uses this to avoid
+ * starting a Replay while a Refresh is still mid-delivery (the two now
+ * run on separate unique-work queues, so WorkManager won't serialize
+ * them for us), and vice versa.
+ */
+internal fun anyActive(infos: List<WorkInfoLite>): Boolean = infos.any { info ->
+    info.state == WorkInfo.State.ENQUEUED ||
+        info.state == WorkInfo.State.RUNNING ||
+        info.state == WorkInfo.State.BLOCKED
+}
+
 class TodayViewModel(
     private val insightCache: InsightCache,
     workManager: WorkManager,
@@ -341,17 +379,28 @@ class TodayViewModel(
      */
     private val showModelSpread = MutableStateFlow(false)
 
-    // Combine status across both unique-work names so the spinner / failure
-    // banner reflects an in-flight tonight refresh too — the Refresh button
-    // routes to TONIGHT when it's tapped between 19:00 and 07:00. Collapsed
-    // upstream into a single flow so [state]'s `combine` stays under the
-    // 5-flow overload cap now that the pager reads both period slots
-    // separately.
+    // Combine status across both alarm queues so the spinner / failure
+    // banner reflects an in-flight tonight refresh too — the Refresh
+    // button routes to TONIGHT when it's tapped between 19:00 and 07:00.
+    // The replay queue rides alongside but doesn't feed [workStatus]: a
+    // replay isn't a fetch, so it has no business surfacing the
+    // "fetching" spinner. It only contributes to [anyWorkActive] —
+    // the broader gate the Play button reads to avoid double delivery
+    // against a still-running Refresh or alarm. Collapsed upstream
+    // into a single flow so [state]'s `combine` stays under the 5-flow
+    // overload cap now that the pager reads both period slots separately.
     private val workStatusFlow = combine(
         workManager.getWorkInfosForUniqueWorkFlow(FetchAndNotifyWorker.UNIQUE_WORK_NAME),
         workManager.getWorkInfosForUniqueWorkFlow(FetchAndNotifyWorker.UNIQUE_WORK_NAME_TONIGHT),
-    ) { todayInfos, tonightInfos ->
-        mergeWorkStatus(selectStatus(todayInfos.toLite()), selectStatus(tonightInfos.toLite()))
+        workManager.getWorkInfosForUniqueWorkFlow(FetchAndNotifyWorker.UNIQUE_WORK_NAME_REPLAY),
+    ) { todayInfos, tonightInfos, replayInfos ->
+        val todayLite = todayInfos.toLite()
+        val tonightLite = tonightInfos.toLite()
+        val replayLite = replayInfos.toLite()
+        WorkSignals(
+            status = mergeWorkStatus(selectStatus(todayLite), selectStatus(tonightLite)),
+            anyWorkActive = anyActive(todayLite) || anyActive(tonightLite) || anyActive(replayLite),
+        )
     }
 
     /**
@@ -404,7 +453,7 @@ class TodayViewModel(
         workStatusFlow,
         preferencesDateEvents,
         showModelSpread,
-    ) { thisPeriodSnapshot, nextPeriodSnapshot, workStatus, prefsDateEvents, spread ->
+    ) { thisPeriodSnapshot, nextPeriodSnapshot, workSignals, prefsDateEvents, spread ->
         val (prefs, today, events) = prefsDateEvents
         // Derive each cached snapshot against the *current* prefs so a settings
         // change re-renders the prose / outfit / bullets in the same frame as
@@ -451,7 +500,8 @@ class TodayViewModel(
         TodayState(
             thisPeriodInsight = thisPeriodInsight,
             nextPeriodInsight = nextPeriodInsight,
-            workStatus = workStatus,
+            workStatus = workSignals.status,
+            anyWorkActive = workSignals.anyWorkActive,
             temperatureUnit = prefs.temperatureUnit,
             deltaThresholdC = prefs.deltaThresholdC,
             rangeFormat = prefs.rangeFormat,

--- a/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
@@ -94,15 +94,16 @@ class FetchAndNotifyWorker(
     override suspend fun doWork(): Result {
         val isCacheOnly = inputData.getBoolean(KEY_CACHE_LOCATION_ONLY, false)
         val isSilent = inputData.getBoolean(KEY_SILENT_REFRESH, false)
+        val isReplay = inputData.getBoolean(KEY_REPLAY_ONLY, false)
         val period = inputData.getString(KEY_PERIOD)
             ?.let { runCatching { ForecastPeriod.valueOf(it) }.getOrNull() }
             ?: ForecastPeriod.TODAY
         val startMs = System.currentTimeMillis()
-        // The cache-only and silent-refresh paths don't deliver a
-        // notification, so don't count them as refresh outcomes — they'd
-        // skew the success-rate dashboard with runs the user never
+        // The cache-only, silent-refresh, and replay paths don't fetch /
+        // re-derive a fresh insight, so don't count them as refresh outcomes
+        // — they'd skew the success-rate dashboard with runs the user never
         // perceived as a "daily refresh".
-        val skipTelemetry = isCacheOnly || isSilent
+        val skipTelemetry = isCacheOnly || isSilent || isReplay
         return try {
             val result = stamped(doWorkInternal())
             if (!skipTelemetry) recordDailyRefreshOutcome(period, result, startMs)
@@ -151,6 +152,19 @@ class FetchAndNotifyWorker(
         } catch (t: Throwable) {
             DiagLog.e(TAG, "Failed to read user preferences; retrying", t)
             return Result.retry()
+        }
+
+        // Replay path triggered by the Today screen's Play button. Re-runs
+        // the full deliver() fan-out (notification + TTS + MQTT + cast) on
+        // the cached this-period snapshot, derived against the current prefs
+        // so any Format / clothes-rules changes since the last fetch are
+        // reflected. No fetch — Play is about hearing the announcement
+        // again, not about pulling fresh data.
+        if (inputData.getBoolean(KEY_REPLAY_ONLY, false)) {
+            val requestedPeriod = inputData.getString(KEY_PERIOD)
+                ?.let { runCatching { ForecastPeriod.valueOf(it) }.getOrNull() }
+                ?: ForecastPeriod.TODAY
+            return replayCachedInsight(prefs, requestedPeriod)
         }
 
         // Cache-only path triggered by the Settings location toggle. Just
@@ -290,6 +304,53 @@ class FetchAndNotifyWorker(
         }
 
         return fresh(location, prefs, period)
+    }
+
+    private suspend fun replayCachedInsight(
+        prefs: UserPreferences,
+        requestedPeriod: ForecastPeriod,
+    ): Result {
+        val snapshot = app.insightCache.thisPeriod.first()
+        if (snapshot == null) {
+            DiagLog.i(TAG, "Replay requested but cache is empty; nothing to deliver.")
+            return Result.success(workDataOf(KEY_SKIP_TELEMETRY to true))
+        }
+        // Honour the period the user tapped Play for. If the cache rolled
+        // between the tap and this run (a queued replay survived a network
+        // blip until the morning alarm overwrote THIS_PERIOD with a fresh
+        // TODAY snapshot, or any other in-between rewrite), the snapshot
+        // now in cache isn't the announcement the user asked to hear —
+        // skip rather than deliver the wrong one. The next tap on whichever
+        // period is current will play that one normally.
+        if (snapshot.period != requestedPeriod) {
+            DiagLog.i(
+                TAG,
+                "Replay requested for $requestedPeriod but cache holds ${snapshot.period}; skipping.",
+            )
+            return Result.success(workDataOf(KEY_SKIP_TELEMETRY to true))
+        }
+        // Replay never fetches; signal "fetch is done" up-front so any
+        // future code path that combines this queue into a banner observer
+        // sees the worker as past the fetching phase. Play stays disabled
+        // throughout delivery via TodayState.anyWorkActive, which keys
+        // off WorkInfo.state directly and doesn't need a progress flag.
+        setProgress(workDataOf(KEY_FETCH_COMPLETE to true))
+        val insight = app.deriveInsight(snapshot, prefs, diagLog = { DiagLog.i(TAG, it) }).insight
+        val prose = formatProse(insight, prefs)
+        return try {
+            deliver(insight, prefs, prose)
+            DiagLog.i(TAG, "Replayed insight for ${insight.forDate}: $prose")
+            Result.success(workDataOf(KEY_SKIP_TELEMETRY to true))
+        } catch (ce: CancellationException) {
+            throw ce
+        } catch (t: Throwable) {
+            // Log and report success: replay is best-effort, and a delivery
+            // failure here shouldn't surface as a refresh failure banner —
+            // the cached insight is still on screen, and the next genuine
+            // refresh will retry the delivery pipeline.
+            DiagLog.e(TAG, "Replay delivery failed.", t)
+            Result.success(workDataOf(KEY_SKIP_TELEMETRY to true))
+        }
     }
 
     private suspend fun fresh(
@@ -1266,6 +1327,14 @@ class FetchAndNotifyWorker(
         // alarm fire (and vice versa). KEEP-deduped so config-change
         // re-triggers on app open coalesce into the one in-flight worker.
         const val UNIQUE_WORK_NAME_SILENT = "silent_insight_refresh"
+        // Distinct queue from the daily / tonight runs so an offline Play
+        // tap sitting in the queue can't block the morning alarm: alarm
+        // enqueues use ExistingWorkPolicy.KEEP and would otherwise be
+        // dropped in favour of the pending replay, leaving the user
+        // listening to yesterday's cached insight at 7am instead of the
+        // fresh forecast. Race vs. concurrent replays is handled in the
+        // UI gate — see TodayState.anyWorkActive.
+        const val UNIQUE_WORK_NAME_REPLAY = "insight_replay"
 
         // Output Data keys for surfacing failure reasons in the UI.
         const val KEY_REASON = "reason"
@@ -1413,6 +1482,17 @@ class FetchAndNotifyWorker(
          */
         val SILENT_REFRESH_MIN_AGE: Duration = Duration.ofHours(1)
 
+        /**
+         * Set true via [enqueueReplay] when the user taps the Today screen's
+         * Play button. The worker re-runs the full deliver() fan-out
+         * (notification + TTS + MQTT + cast) on the cached this-period
+         * snapshot — no fetch, no Open-Meteo call, no Gemini insight call.
+         * The cached snapshot is derived against the *current* prefs so any
+         * Format / clothes-rules changes since the snapshot was captured are
+         * spoken too.
+         */
+        internal const val KEY_REPLAY_ONLY = "replay_only"
+
         fun enqueueOneShot(
             context: Context,
             force: Boolean = false,
@@ -1454,6 +1534,38 @@ class FetchAndNotifyWorker(
             }
             WorkManager.getInstance(context)
                 .enqueueUniqueWork(workName, policy, request)
+        }
+
+        /**
+         * Replay the cached this-period insight via the full delivery
+         * fan-out — Today's Play button. Runs on its own
+         * [UNIQUE_WORK_NAME_REPLAY] queue so an offline Play tap sitting
+         * here can't block a later scheduled alarm fire (which uses KEEP
+         * on [UNIQUE_WORK_NAME] / [UNIQUE_WORK_NAME_TONIGHT] and would
+         * otherwise get dropped in favour of the pending replay).
+         * REPLACE because the user's most-recent Play tap is the one
+         * that matters; concurrent Refresh+Play double-delivery is
+         * prevented by the UI gate (see [TodayState.anyWorkActive]),
+         * not by sharing a queue.
+         */
+        fun enqueueReplay(context: Context, period: ForecastPeriod) {
+            val constraints = Constraints.Builder()
+                .setRequiredNetworkType(NetworkType.CONNECTED)
+                .build()
+
+            val request = OneTimeWorkRequestBuilder<FetchAndNotifyWorker>()
+                .setConstraints(constraints)
+                .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, 10, TimeUnit.SECONDS)
+                .setInputData(
+                    workDataOf(
+                        KEY_REPLAY_ONLY to true,
+                        KEY_PERIOD to period.name,
+                    )
+                )
+                .build()
+
+            WorkManager.getInstance(context)
+                .enqueueUniqueWork(UNIQUE_WORK_NAME_REPLAY, ExistingWorkPolicy.REPLACE, request)
         }
 
         /**

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,6 +16,9 @@
     <string name="today_refresh">Refresh</string>
     <string name="today_refresh_toast_daily">Refreshing your daily ClothesCast — it\'ll appear shortly.</string>
     <string name="today_refresh_toast_nightly">Refreshing your nightly ClothesCast — it\'ll appear shortly.</string>
+    <string name="today_play">Play</string>
+    <string name="today_play_toast_daily">Playing your daily ClothesCast.</string>
+    <string name="today_play_toast_nightly">Playing your nightly ClothesCast.</string>
     <string name="today_empty_title">No ClothesCast yet</string>
     <string name="today_empty_subtitle">Your morning ClothesCast will appear here once it has been generated. Set your location in Settings, then tap Fetch now.</string>
     <string name="today_fetch_now">Fetch now</string>

--- a/app/src/test/kotlin/app/clothescast/ui/today/TodayWorkStatusSelectionTest.kt
+++ b/app/src/test/kotlin/app/clothescast/ui/today/TodayWorkStatusSelectionTest.kt
@@ -294,6 +294,72 @@ class TodayWorkStatusSelectionTest {
     }
 
     @Test
+    fun `anyActive is false on an empty list`() {
+        anyActive(emptyList()) shouldBe false
+    }
+
+    @Test
+    fun `anyActive catches an enqueued worker`() {
+        anyActive(
+            listOf(
+                WorkInfoLite(
+                    state = WorkInfo.State.ENQUEUED,
+                    runAttemptCount = 0,
+                    outputData = Data.EMPTY,
+                ),
+            ),
+        ) shouldBe true
+    }
+
+    @Test
+    fun `anyActive ignores terminal entries`() {
+        // SUCCEEDED / FAILED / CANCELLED WorkInfos can linger in the
+        // WorkManager DB for a while; they aren't "active" for the
+        // Play-disable gate and shouldn't keep the button locked out
+        // forever.
+        anyActive(
+            listOf(
+                WorkInfoLite(
+                    state = WorkInfo.State.SUCCEEDED,
+                    runAttemptCount = 1,
+                    outputData = Data.EMPTY,
+                ),
+                WorkInfoLite(
+                    state = WorkInfo.State.FAILED,
+                    runAttemptCount = 1,
+                    outputData = Data.EMPTY,
+                ),
+                WorkInfoLite(
+                    state = WorkInfo.State.CANCELLED,
+                    runAttemptCount = 0,
+                    outputData = Data.EMPTY,
+                ),
+            ),
+        ) shouldBe false
+    }
+
+    @Test
+    fun `anyActive catches a running worker that has already signalled fetch_complete`() {
+        // The critical post-fetch window: the worker has hidden the
+        // spinner banner via KEY_FETCH_COMPLETE and is now mid TTS /
+        // MQTT / Cast. selectStatus reads as Idle on this entry, but
+        // anyActive has to keep the Play button disabled — otherwise a
+        // tap here would start a second delivery alongside the first.
+        anyActive(
+            listOf(
+                WorkInfoLite(
+                    state = WorkInfo.State.RUNNING,
+                    runAttemptCount = 1,
+                    outputData = Data.EMPTY,
+                    progress = Data.Builder()
+                        .putBoolean(FetchAndNotifyWorker.KEY_FETCH_COMPLETE, true)
+                        .build(),
+                ),
+            ),
+        ) shouldBe true
+    }
+
+    @Test
     fun `other failures still surface when the action banner is showing`() {
         // The suppression is keyed specifically to REASON_NO_LOCATION —
         // unrelated failures still need to reach the user even when the

--- a/app/src/test/kotlin/app/clothescast/work/FetchAndNotifyWorkerTest.kt
+++ b/app/src/test/kotlin/app/clothescast/work/FetchAndNotifyWorkerTest.kt
@@ -12,7 +12,13 @@ import androidx.work.testing.TestListenableWorkerBuilder
 import androidx.work.testing.WorkManagerTestInitHelper
 import androidx.work.workDataOf
 import app.clothescast.ClothesCastApplication
+import app.clothescast.core.domain.model.DailyForecast
 import app.clothescast.core.domain.model.ForecastPeriod
+import app.clothescast.core.domain.model.ForecastSnapshot
+import app.clothescast.core.domain.model.Location
+import app.clothescast.core.domain.model.WeatherCondition
+import app.clothescast.core.domain.repository.ForecastBundle
+import app.clothescast.data.InsightCache
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.longs.shouldBeGreaterThan
@@ -23,7 +29,9 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
+import java.time.Instant
 import java.time.LocalDate
+import java.time.ZoneId
 
 /**
  * Drives the [FetchAndNotifyWorker]'s `doWork()` decision tree along the
@@ -57,6 +65,11 @@ class FetchAndNotifyWorkerTest {
             app.settingsRepository.setUseDeviceLocation(false)
             app.settingsRepository.clearLocation()
             app.settingsRepository.setTonightEnabled(false)
+            // The insight cache is process-shared across tests via the real
+            // application DataStore; a snapshot leaked from a previous case
+            // would let the replay branch deliver against it. Reset it so
+            // each test starts from a clean cache.
+            app.insightCache.clear()
         }
         // SynchronousExecutor keeps WorkManager off the real background
         // thread pool — combined with the NetworkType.CONNECTED constraint
@@ -258,6 +271,106 @@ class FetchAndNotifyWorkerTest {
             listOf(WorkInfo.State.ENQUEUED)
     }
 
+    @Test
+    fun `enqueueReplay uses its own unique work queue so it can't block scheduled refreshes`() {
+        // Play sits on UNIQUE_WORK_NAME_REPLAY rather than the alarm
+        // queues; otherwise an offline Play tap parked behind the
+        // network constraint would let WorkManager's KEEP policy on
+        // the next alarm fire drop the scheduled morning refresh in
+        // favour of the pending replay — the user would wake up to a
+        // stale cached announcement instead of a fresh forecast.
+        FetchAndNotifyWorker.enqueueReplay(context, period = ForecastPeriod.TODAY)
+
+        workInfosFor(FetchAndNotifyWorker.UNIQUE_WORK_NAME_REPLAY).map { it.state } shouldContainExactlyInAnyOrder
+            listOf(WorkInfo.State.ENQUEUED)
+        workInfosFor(FetchAndNotifyWorker.UNIQUE_WORK_NAME) shouldHaveSize 0
+        workInfosFor(FetchAndNotifyWorker.UNIQUE_WORK_NAME_TONIGHT) shouldHaveSize 0
+    }
+
+    @Test
+    fun `enqueueReplay for TONIGHT also lands on the replay queue, not the tonight queue`() {
+        FetchAndNotifyWorker.enqueueReplay(context, period = ForecastPeriod.TONIGHT)
+
+        workInfosFor(FetchAndNotifyWorker.UNIQUE_WORK_NAME_REPLAY).map { it.state } shouldContainExactlyInAnyOrder
+            listOf(WorkInfo.State.ENQUEUED)
+        workInfosFor(FetchAndNotifyWorker.UNIQUE_WORK_NAME) shouldHaveSize 0
+        workInfosFor(FetchAndNotifyWorker.UNIQUE_WORK_NAME_TONIGHT) shouldHaveSize 0
+    }
+
+    @Test
+    fun `replay whose requested period no longer matches the cached snapshot is dropped`() {
+        // User taps Play at 11pm (TONIGHT) while offline; the replay
+        // request sits in the queue under UNIQUE_WORK_NAME_TONIGHT. Before
+        // it runs, the morning alarm fires and overwrites THIS_PERIOD
+        // with a fresh TODAY snapshot. When the queued replay finally
+        // executes, the snapshot in cache no longer matches the period
+        // the user actually tapped Play for — drop it rather than
+        // delivering the wrong announcement.
+        runBlocking {
+            app.insightCache.store(
+                InsightCache.Slot.THIS_PERIOD,
+                sampleSnapshot(period = ForecastPeriod.TODAY),
+            )
+            val worker = TestListenableWorkerBuilder<FetchAndNotifyWorker>(context)
+                .setInputData(
+                    workDataOf(
+                        FetchAndNotifyWorker.KEY_REPLAY_ONLY to true,
+                        FetchAndNotifyWorker.KEY_PERIOD to ForecastPeriod.TONIGHT.name,
+                    )
+                )
+                .build()
+
+            val result = worker.doWork()
+
+            result.shouldBeInstanceOf<Result.Success>()
+            result.outputData.getBoolean(FetchAndNotifyWorker.KEY_SKIP_TELEMETRY, false) shouldBe true
+        }
+    }
+
+    @Test
+    fun `replay with empty cache succeeds and skips telemetry without falling through to fetch`() {
+        // The Today screen disables Play when the cache is empty, but a
+        // racing cache-clear (or a stale enqueued tap surviving a process
+        // death) could still land here. The branch must no-op rather than
+        // escalating to the no-location failure the fetch path would hit.
+        runBlocking {
+            val worker = TestListenableWorkerBuilder<FetchAndNotifyWorker>(context)
+                .setInputData(workDataOf(FetchAndNotifyWorker.KEY_REPLAY_ONLY to true))
+                .build()
+
+            val result = worker.doWork()
+
+            result.shouldBeInstanceOf<Result.Success>()
+            result.outputData.getBoolean(FetchAndNotifyWorker.KEY_SKIP_TELEMETRY, false) shouldBe true
+        }
+    }
+
     private fun workInfosFor(name: String): List<WorkInfo> =
         WorkManager.getInstance(context).getWorkInfosForUniqueWork(name).get()
+
+    private fun sampleSnapshot(period: ForecastPeriod): ForecastSnapshot {
+        val today = LocalDate.of(2026, 5, 27)
+        val daily = DailyForecast(
+            date = today,
+            temperatureMinC = 10.0,
+            temperatureMaxC = 18.0,
+            feelsLikeMinC = 9.0,
+            feelsLikeMaxC = 17.0,
+            precipitationProbabilityMaxPct = 0.0,
+            precipitationMmTotal = 0.0,
+            condition = WeatherCondition.CLEAR,
+            hourly = emptyList(),
+        )
+        return ForecastSnapshot(
+            bundle = ForecastBundle(
+                today = daily,
+                yesterday = daily.copy(date = today.minusDays(1)),
+                forecastZone = ZoneId.of("UTC"),
+            ),
+            events = emptyList(),
+            location = Location(latitude = 51.5, longitude = -0.1, displayName = "London"),
+            period = period,
+            generatedAt = Instant.parse("2026-05-27T07:00:00Z"),
+        )
+    }
 }


### PR DESCRIPTION
## Summary

Replaces the Today screen's single Refresh action with two top-app-bar buttons, each doing exactly one thing:

- **Refresh** — refetches the forecast and regenerates the insight, then redelivers it. Billable Open-Meteo + Gemini insight call.
- **Play** — redelivers the cached insight (notification, phone-speaker TTS, MQTT publish, Cast load) without refetching. No Open-Meteo call, no Gemini insight call.

Before this change, Refresh always did both — there was no way to hear the announcement again without burning a new API call, and no way to pull a fresh forecast without also re-running delivery. Splitting them lets the user pick the intent without paying for the other.

Either button runs the full delivery fan-out, so the announcement reaches the same destinations (notification, TTS, MQTT, Cast) in both cases. Play derives the cached snapshot against the *current* prefs, so Format / clothes-rules tweaks since the last fetch show up the next time it's tapped.

The Play button is disabled when there's nothing to replay (cache empty) and stays disabled whenever any worker is active on the daily / tonight / replay queues — that includes the post-fetch TTS / MQTT / Cast window that the spinner-banner logic deliberately hides, so a tap during a Refresh's announcement can't start a second concurrent delivery.

## Implementation notes

- New worker mode `KEY_REPLAY_ONLY`, handled in `doWorkInternal` ahead of the cache-only / location / fetch branches. The replay branch reads `InsightCache.thisPeriod`, signals `KEY_FETCH_COMPLETE` (so any future code combining this queue into a banner observer sees the worker as past the fetch phase), derives against current prefs, and calls `deliver()`. Empty cache → `Result.success` with `KEY_SKIP_TELEMETRY` (no fall-through to `fresh()`).
- Replay runs on its own `UNIQUE_WORK_NAME_REPLAY` queue, separate from `UNIQUE_WORK_NAME` (TODAY) and `UNIQUE_WORK_NAME_TONIGHT`. Sharing the alarm queue would have let an offline Play tap park behind the network constraint and then block the next morning alarm's `KEEP`-policied enqueue, leaving the user waking up to a stale cached replay instead of a fresh forecast.
- The replay branch threads the user's `KEY_PERIOD` into `replayCachedInsight` and early-returns with skip-telemetry success when `snapshot.period` doesn't match — covers the edge case where a queued replay survives a network blip until a morning alarm has overwritten `THIS_PERIOD` with a different-period snapshot. Without this guard, a queued TONIGHT replay would deliver the freshly-rewritten TODAY announcement.
- New companion `enqueueReplay(context, period)` — REPLACE on `UNIQUE_WORK_NAME_REPLAY`. The UI passes `state.thisPeriodInsight.period` so Play always pairs with whatever's currently shown on screen.
- `TodayViewModel` exposes a parallel `anyWorkActive: Boolean` derived from `WorkInfo.state ∈ {ENQUEUED, RUNNING, BLOCKED}` across all three queues, ignoring progress flags. The Play button gates on `!anyWorkActive && playPeriod != null`; that catches the post-`KEY_FETCH_COMPLETE` TTS window on any queue, including a Refresh that's still mid-delivery now that the queues no longer serialize for us.
- Replay outcomes skip the `daily_refresh` telemetry stream — it isn't a daily refresh, and counting it would skew the success-rate dashboard.
- New strings: `today_play` (icon contentDescription), `today_play_toast_daily`, `today_play_toast_nightly`. Translations will follow the project's normal localisation flow.

## Privacy

No change. Both buttons run the same delivery pipeline (notification text, TTS prose, MQTT image + audio + video, Cast media) that Refresh already ran — no new data crosses the device boundary, no new Firebase / Crashlytics payload keys.

## Test plan

- [x] `./gradlew :app:testDebugUnitTest` — new `FetchAndNotifyWorkerTest` cases pin enqueue routing to `UNIQUE_WORK_NAME_REPLAY` (never touching the alarm queues, for TODAY and TONIGHT taps alike), the empty-cache no-op (replay never escalates to `REASON_NO_LOCATION`), and the period-mismatch drop (TODAY snapshot + TONIGHT replay request → skip-telemetry success). New `TodayWorkStatusSelectionTest` cases pin `anyActive` (false on empty / terminal-only lists, true on enqueued workers, true on a running worker that's already past `KEY_FETCH_COMPLETE`).
- [x] `./gradlew :app:assembleDebug`.
- [ ] Manual: tap Refresh on Today → fresh fetch + redelivery, notification re-fires, TTS speaks, MQTT publish, Cast load (if configured).
- [ ] Manual: tap Play with a fresh insight cached → redelivery only, same destinations, no API call. Play stays disabled until TTS / MQTT / Cast all land.
- [ ] Manual: tap Play before any fetch → button is disabled.
- [ ] Manual: tap Play mid-Refresh-TTS → button is still disabled (anyWorkActive covers the post-fetch-complete window).
- [ ] Manual: airplane-mode + tap Play, wait, take airplane mode off → replay delivers; the next morning alarm still fires its scheduled refresh on its own queue.

https://claude.ai/code/session_01TMLfbJXbSLcjqyJbao9Etw