### PR TITLE
Only show one Today promo card at a time

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayViewModel.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayViewModel.kt
@@ -448,6 +448,8 @@ class TodayViewModel(
         val bottomColors = prefs.outfitBottomColors + (theme?.bottomOverrides ?: emptyMap())
         val topStrokes = theme?.topStrokeOverrides ?: emptyMap()
         val bottomStrokes = theme?.bottomStrokeOverrides ?: emptyMap()
+        val clothesPromoVisible = !prefs.clothesPromoCardDismissed &&
+            prefs.clothesRules == ClothesRule.DEFAULTS
         TodayState(
             thisPeriodInsight = thisPeriodInsight,
             nextPeriodInsight = nextPeriodInsight,
@@ -472,11 +474,15 @@ class TodayViewModel(
             outfitTopStrokes = topStrokes,
             outfitBottomStrokes = bottomStrokes,
             activeHoliday = theme,
-            celebrationCardVisible = !prefs.celebrationCardDismissed &&
+            // Promo cards stack one at a time: the higher-priority clothes
+            // card wins while it's eligible, and only when it's gone does
+            // the celebration card get a turn. Keeps the Today screen from
+            // stacking two nudges on top of each other.
+            clothesPromoCardVisible = clothesPromoVisible,
+            celebrationCardVisible = !clothesPromoVisible &&
+                !prefs.celebrationCardDismissed &&
                 !prefs.calendarHolidayThemingActive &&
                 !prefs.calendarBirthdayThemingActive,
-            clothesPromoCardVisible = !prefs.clothesPromoCardDismissed &&
-                prefs.clothesRules == ClothesRule.DEFAULTS,
             usesCalendarThemes = prefs.calendarHolidayThemingActive || prefs.calendarBirthdayThemingActive,
         )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), TodayState())


### PR DESCRIPTION
## Summary

The Today screen currently can stack two promo banners back-to-back: the
"Customize your clothes" nudge and the "Celebration themes" nudge. Both
share the same visual treatment and the same "tap to configure" call to
action, so seeing both at once is more noise than help.

This change derives a single `clothesPromoVisible` flag in `TodayViewModel`
and gates the celebration card on it being `false`. So at most one promo
card is visible at a time — the higher-priority clothes card while it's
eligible, then the celebration card once the user has customised their
rules or dismissed the clothes card.

Priority order matches the existing display order in `BannerStack` and
the in-code comment that says clothes "sits before the celebration-themes
promo because clothes rules are the core setting." No new state, no new
preference; only the derivation in `TodayViewModel.state` changes.

## Test plan

- [x] `:app:testDebugUnitTest` passes locally
- [x] `:app:compileDebugKotlin` clean
- [ ] CI green
- [ ] Eyeball on a device: with both cards eligible, only the clothes
  card shows; tapping its X reveals the celebration card; customising
  clothes rules likewise reveals the celebration card


---
_Generated by [Claude Code](https://claude.ai/code/session_01VWrJz4xb3Krn1wFKPYeM5T)_