### PR TITLE
Spell "colour" the British way for en-GB

### DIFF
--- a/app/src/main/res/values-en-rGB/strings.xml
+++ b/app/src/main/res/values-en-rGB/strings.xml
@@ -22,4 +22,9 @@ full re-translation.
          (en-AU / en-CA / en-ZA) inherit this en-rGB form via CLDR
          locale-similarity — they all descend from en-001 the same way. -->
     <string name="settings_distance_unit_kilometers">Kilometres</string>
+
+    <!-- "Colours" with the British -our ending. en-AU / en-CA / en-ZA
+         inherit this via the same CLDR cascade as Kilometres above. -->
+    <string name="settings_root_display_subtitle">Themes and Colours</string>
+    <string name="today_celebration_card_body">Enable special colours and messages for holidays and birthdays.</string>
 </resources>


### PR DESCRIPTION
## Summary

Two user-facing strings were still showing the en-US "color" spelling on devices set to British English:

- The celebration-themes promo body on Today: "Enable special **colors** and messages for holidays and birthdays."
- The Display section's subtitle on the root settings list: "Themes and **Colors**"

Adds en-rGB overrides for both with the British "colour" spelling. en-AU, en-CA, and en-ZA inherit these automatically via the same CLDR locale-similarity cascade already documented for the existing `Kilometres` override — all three descend from `en-001`, so they pick `values-en-rGB` over the en-US default. (Canadian English uses "colour" too, so en-CA wants the en-GB inheritance here, not a block.)

## Test plan

- [x] `./gradlew :app:assembleDebug` passes locally
- [ ] CI green
- [ ] Visually verify on an en-GB device: the celebration promo card on Today and the Display row in Settings both show "colour(s)"


---
_Generated by [Claude Code](https://claude.ai/code/session_013UoijurFjunxCRkJtTckHP)_