### PR TITLE
Build the Location settings address line from structured Geocoder fields

### DIFF
--- a/app/src/main/kotlin/app/clothescast/location/ReverseGeocoder.kt
+++ b/app/src/main/kotlin/app/clothescast/location/ReverseGeocoder.kt
@@ -65,19 +65,27 @@ class ReverseGeocoder(
     }
 
     /**
-     * Diagnostic-only return value pairing the raw `addressLines` from the
-     * platform Geocoder with the [Result] derived from them. Surfaced to
-     * the Developer settings page's reverse-geocode tester so a developer
-     * can see exactly what the Geocoder returned for a given coord and
-     * how [buildAddressDetail] folded the structured fields into the
-     * displayed addressDetail.
+     * Diagnostic-only return value pairing what the platform Geocoder
+     * returned for a coord — both the raw formatted [addressLines] and
+     * the structured [parts] (the same `AddressParts` that
+     * [buildAddressDetail] consumes) — with the [Result] we'd derive
+     * from them in production. Surfaced to the Developer settings
+     * page's reverse-geocode tester so a developer can see exactly
+     * which field a misbehaving addressDetail traces back to (a null
+     * subLocality? a duplicated locality? a missing postalCode?)
+     * without instrumenting log lines.
      */
     data class DiagnosticResult(
         val addressLines: List<String>,
+        val parts: AddressParts,
         val derived: Result,
     ) {
         companion object {
-            val EMPTY = DiagnosticResult(addressLines = emptyList(), derived = Result.EMPTY)
+            val EMPTY = DiagnosticResult(
+                addressLines = emptyList(),
+                parts = AddressParts(),
+                derived = Result.EMPTY,
+            )
         }
     }
 
@@ -110,7 +118,11 @@ class ReverseGeocoder(
         val addresses = withTimeoutOrNull(timeoutMillis) { fetch(geocoder, latitude, longitude) }
             ?: return@coRunCatching DiagnosticResult.EMPTY
         val address = addresses.firstOrNull() ?: return@coRunCatching DiagnosticResult.EMPTY
-        DiagnosticResult(addressLines = address.extractLines(), derived = address.toResult())
+        DiagnosticResult(
+            addressLines = address.extractLines(),
+            parts = address.toParts(),
+            derived = address.toResult(),
+        )
     }
         .onFailure { DiagLog.w(TAG, "Unexpected ${it.javaClass.simpleName} from resolveDiagnostic; returning empty.", it) }
         .getOrDefault(DiagnosticResult.EMPTY)
@@ -199,6 +211,15 @@ class ReverseGeocoder(
         else (0..maxIdx).mapNotNull { getAddressLine(it) }
     }
 
+    private fun Address.toParts(): AddressParts = AddressParts(
+        subLocality = subLocality,
+        locality = locality,
+        adminArea = adminArea,
+        postalCode = postalCode,
+        countryName = countryName,
+        countryCode = countryCode,
+    )
+
     private fun Address.toResult(): Result {
         val lines = extractLines()
         val city = pickCityName(
@@ -228,15 +249,7 @@ class ReverseGeocoder(
             city = city,
             countryCode = normalisedCountry,
             addressDetail = buildAddressDetail(
-                AddressParts(
-                    subLocality = subLocality,
-                    locality = locality,
-                    recoveredCity = city,
-                    adminArea = adminArea,
-                    postalCode = postalCode,
-                    countryName = countryName,
-                    countryCode = countryCode,
-                ),
+                toParts().copy(recoveredCity = city),
             ),
         )
     }
@@ -250,9 +263,11 @@ class ReverseGeocoder(
  * Subset of the platform [android.location.Address] fields we use to
  * build the Location settings page's neighbourhood-level line. Lifted
  * out as a data class so [buildAddressDetail] is testable on the JVM
- * without instantiating an Android `Address`.
+ * without instantiating an Android `Address`, and so the Developer
+ * settings page's reverse-geocode tester can surface each field for
+ * debugging — both reachable via [ReverseGeocoder.DiagnosticResult].
  */
-internal data class AddressParts(
+data class AddressParts(
     val subLocality: String? = null,
     val locality: String? = null,
     /**

--- a/app/src/main/kotlin/app/clothescast/location/ReverseGeocoder.kt
+++ b/app/src/main/kotlin/app/clothescast/location/ReverseGeocoder.kt
@@ -42,13 +42,17 @@ class ReverseGeocoder(
     /**
      * Best-effort city/locality name + country code + address detail. Any
      * field can be null independently (e.g. the geocoder returned a usable
-     * city but the address lacked a country code, or the first address line
-     * was missing/empty so no detail could be derived); callers handle each
-     * as missing data without crashing.
+     * city but the underlying address lacked a country code, or no
+     * structured fields were populated so no detail could be built);
+     * callers handle each as missing data without crashing.
      *
-     * [addressDetail] is the first address line with its leading component
-     * dropped (e.g. "Cambridge, MA 02139, USA" from "1 Vassar St, Cambridge,
-     * MA 02139, USA") — for display on the Location settings page.
+     * [addressDetail] is built from the platform Geocoder's structured
+     * fields (subLocality / locality / adminArea / postalCode /
+     * countryName) by [buildAddressDetail] — for display on the
+     * Location settings page. We deliberately never parse the formatted
+     * `addressLine` string here: that string sometimes carries a POI
+     * prefix or duplicated street that any naïve trim would either
+     * leak or over-strip.
      */
     data class Result(
         val city: String?,
@@ -64,9 +68,9 @@ class ReverseGeocoder(
      * Diagnostic-only return value pairing the raw `addressLines` from the
      * platform Geocoder with the [Result] derived from them. Surfaced to
      * the Developer settings page's reverse-geocode tester so a developer
-     * can see which Geocoder input shape produced an unexpected
-     * addressDetail (e.g. a street that survived [deriveAddressDetail]'s
-     * trim) without having to file a bug report and read DiagLog.
+     * can see exactly what the Geocoder returned for a given coord and
+     * how [buildAddressDetail] folded the structured fields into the
+     * displayed addressDetail.
      */
     data class DiagnosticResult(
         val addressLines: List<String>,
@@ -94,8 +98,8 @@ class ReverseGeocoder(
      * with outputs.
      *
      * Never call from production code paths — the raw lines include
-     * house numbers and other detail we deliberately strip via
-     * [deriveAddressDetail] before display or persistence.
+     * house numbers and other detail we deliberately omit when
+     * [buildAddressDetail] composes the displayed addressDetail.
      */
     suspend fun resolveDiagnostic(latitude: Double, longitude: Double): DiagnosticResult = coRunCatching {
         if (!Geocoder.isPresent()) {
@@ -208,10 +212,32 @@ class ReverseGeocoder(
             addressLines = lines,
         )
         val normalisedCountry = countryCode?.takeIf { it.isNotBlank() }?.uppercase()
+        // Hand the raw structured fields plus pickCityName's resolved
+        // city straight to buildAddressDetail and let it dedup. The
+        // `recoveredCity` slot is what keeps the displayed detail
+        // consistent with the city header when the Geocoder leaves
+        // `locality` blank (inner-London residentials → "London")
+        // or fills it with a hamlet distinct from the post town
+        // (outer-London / UK villages: `locality="Oakley Green"`,
+        // city = "Windsor"). The same slot stays harmless when the
+        // Geocoder's `locality` already matches the recovered city —
+        // dedup collapses it. When both subLocality and locality carry
+        // real values and the city differs from both, all three
+        // survive (`Suburb, Oakley Green, Windsor, …`).
         return Result(
             city = city,
             countryCode = normalisedCountry,
-            addressDetail = deriveAddressDetail(lines),
+            addressDetail = buildAddressDetail(
+                AddressParts(
+                    subLocality = subLocality,
+                    locality = locality,
+                    recoveredCity = city,
+                    adminArea = adminArea,
+                    postalCode = postalCode,
+                    countryName = countryName,
+                    countryCode = countryCode,
+                ),
+            ),
         )
     }
 
@@ -221,20 +247,87 @@ class ReverseGeocoder(
 }
 
 /**
- * Builds the Location settings page's neighbourhood-level address line
- * from a Geocoder Address's [android.location.Address.getAddressLine]
- * outputs. Joins multi-line responses with ", " (some backends split the
- * address across separate lines — street / city-state / country), then
- * drops the leading comma-delimited component (typically the house
- * number and street, e.g. "1 Vassar St") so what remains is suburb +
- * city + postal code + country — ("Cambridge, MA 02139, USA" from
- * "1 Vassar St, Cambridge, MA 02139, USA"). Returns null when there
- * are no lines, no comma to split on, or stripping yields a blank.
+ * Subset of the platform [android.location.Address] fields we use to
+ * build the Location settings page's neighbourhood-level line. Lifted
+ * out as a data class so [buildAddressDetail] is testable on the JVM
+ * without instantiating an Android `Address`.
  */
-internal fun deriveAddressDetail(addressLines: List<String>): String? {
-    if (addressLines.isEmpty()) return null
-    val joined = addressLines.joinToString(", ")
-    val commaIdx = joined.indexOf(',')
-    if (commaIdx < 0) return null
-    return joined.substring(commaIdx + 1).trim().takeIf { it.isNotBlank() }
+internal data class AddressParts(
+    val subLocality: String? = null,
+    val locality: String? = null,
+    /**
+     * The city name `pickCityName` resolved from the same `Address`,
+     * for cases where it can recover something more user-facing than
+     * the structured `locality` — e.g. an inner-London Geocoder result
+     * with blank `locality` but a post town ("London") sitting in the
+     * formatted line, or a hamlet-locality result ("Oakley Green") for
+     * which `pickCityName` pulls the post town ("Windsor") from the
+     * postcode token. [buildAddressDetail] slots it in after `locality`
+     * with the same dedup rules as every other field, so when the
+     * Geocoder + city picker agree it costs nothing.
+     */
+    val recoveredCity: String? = null,
+    val adminArea: String? = null,
+    val postalCode: String? = null,
+    val countryName: String? = null,
+    val countryCode: String? = null,
+)
+
+/**
+ * Builds the Location settings page's neighbourhood-level address line
+ * directly from the platform Geocoder's *structured* fields, rather
+ * than parsing the formatted [android.location.Address.getAddressLine]
+ * string. The formatted line is where Google's backend gets creative —
+ * prepending a POI name when the coordinate lands in water (e.g.
+ * "Governors Island Ferry, 10 South St Slip 7, New York, NY 10004,
+ * USA"), splitting the street across multiple `addressLines` on some
+ * backends, ordering the house number differently in pt-BR / es-* /
+ * many EU formats. Any string-level rule that strips the street ends
+ * up either leaving a POI behind, stripping a meaningful neighbourhood
+ * (Bela Vista from "Street, Bela Vista, São Paulo - SP, 01311-000,
+ * Brazil"), or breaking some country we haven't tested. The structured
+ * fields are the same data the formatter consumes, just without that
+ * lossy formatting step.
+ *
+ * Output format: `subLocality, locality, recoveredCity, adminArea
+ * postalCode, country` — each part skipped if blank or if it would
+ * duplicate an earlier non-null part. The adminArea / postalCode pair
+ * is joined on a single space (so a missing one doesn't leave dangling
+ * whitespace). Country prefers [AddressParts.countryName] and falls
+ * back to the ISO code when only that is set; dropped if it would
+ * duplicate any earlier place name (city-states / SARs like Singapore
+ * and Hong Kong populate every place field with the same string, and
+ * the country-level fallback from `pickCityName` can land in the
+ * recoveredCity slot for SARs).
+ *
+ * Examples (from the platform Geocoder on real coords):
+ *  - NYC water-adjacent: subLocality=null, locality="New York",
+ *    adminArea="NY", postalCode="10004", countryName="United States"
+ *    → "New York, NY 10004, United States"
+ *  - Brazil neighbourhood: subLocality="Bela Vista",
+ *    locality="São Paulo", adminArea="SP", postalCode="01311-000",
+ *    countryName="Brasil"
+ *    → "Bela Vista, São Paulo, SP 01311-000, Brasil"
+ *  - London neighbourhood: subLocality="Muswell Hill",
+ *    locality="London", adminArea="England", postalCode="N10 3BN",
+ *    countryName="United Kingdom"
+ *    → "Muswell Hill, London, England N10 3BN, United Kingdom"
+ *
+ * Returns null when every meaningful field is blank.
+ */
+internal fun buildAddressDetail(parts: AddressParts): String? {
+    val sub = parts.subLocality?.trim()?.takeIf { it.isNotEmpty() }
+    val city = parts.locality?.trim()?.takeIf { it.isNotEmpty() && it != sub }
+    val recovered = parts.recoveredCity?.trim()
+        ?.takeIf { it.isNotEmpty() && it != sub && it != city }
+    val region = listOfNotNull(
+        parts.adminArea?.trim()?.takeIf { it.isNotEmpty() },
+        parts.postalCode?.trim()?.takeIf { it.isNotEmpty() },
+    ).joinToString(" ").takeIf { it.isNotEmpty() }
+    val country = (parts.countryName?.trim()?.takeIf { it.isNotEmpty() }
+        ?: parts.countryCode?.trim()?.takeIf { it.isNotEmpty() })
+        ?.takeIf { it != sub && it != city && it != recovered }
+    return listOfNotNull(sub, city, recovered, region, country)
+        .joinToString(", ")
+        .takeIf { it.isNotBlank() }
 }

--- a/app/src/main/kotlin/app/clothescast/ui/settings/DeveloperSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/DeveloperSettings.kt
@@ -292,6 +292,22 @@ internal fun DeveloperContent(
 }
 
 /**
+ * One line of the structured-fields block in the reverse-geocode
+ * tester: a name + a value (rendered as `(null)` / `(blank)` so an
+ * empty value isn't a silent gap), styled the same way regardless of
+ * which field it is.
+ */
+@Composable
+private fun StructuredFieldRow(name: String, value: String?) {
+    val display = when {
+        value == null -> "(null)"
+        value.isBlank() -> "(blank)"
+        else -> value
+    }
+    Text("$name: $display", style = MaterialTheme.typography.bodySmall)
+}
+
+/**
  * Parses a `"lat, lon"` string — comma-separated, whitespace around the
  * comma optional — into a coordinate pair, or null if either half is
  * unparseable or out of range. Accepts the format Google Maps' "What's
@@ -392,6 +408,13 @@ private fun ReverseGeocodeTesterCard(
                         Text("[$i] $line", style = MaterialTheme.typography.bodySmall)
                     }
                 }
+                Text("structured fields:", style = MaterialTheme.typography.labelMedium)
+                StructuredFieldRow("subLocality", r.parts.subLocality)
+                StructuredFieldRow("locality", r.parts.locality)
+                StructuredFieldRow("adminArea", r.parts.adminArea)
+                StructuredFieldRow("postalCode", r.parts.postalCode)
+                StructuredFieldRow("countryName", r.parts.countryName)
+                StructuredFieldRow("countryCode", r.parts.countryCode)
                 Text("derived addressDetail:", style = MaterialTheme.typography.labelMedium)
                 Text(
                     r.derived.addressDetail ?: "(null)",

--- a/app/src/test/kotlin/app/clothescast/location/DeriveAddressDetailTest.kt
+++ b/app/src/test/kotlin/app/clothescast/location/DeriveAddressDetailTest.kt
@@ -4,69 +4,259 @@ import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
 
 /**
- * Unit tests for [deriveAddressDetail] — the helper that turns a Geocoder
- * Address's `getAddressLine` outputs into the Location settings page's
- * neighbourhood-level line. Pure JVM; no Android deps.
+ * Unit tests for [buildAddressDetail] — the helper that turns a
+ * Geocoder Address's structured fields (subLocality, locality,
+ * adminArea, postalCode, countryName) into the Location settings
+ * page's neighbourhood-level line. Pure JVM; no Android deps.
+ *
+ * The structured-fields approach replaced an earlier formatted-line
+ * parser that stripped the leading comma component; that parser
+ * worked on the common US / UK shapes but broke for any backend that
+ * prepended a POI to the formatted line (Governors Island Ferry in
+ * water-adjacent NYC coords) or for Brazilian addresses where a
+ * meaningful neighbourhood — Bela Vista, for instance — sits between
+ * the street and the city.
  */
 class DeriveAddressDetailTest {
 
     @Test
-    fun `US single-line address drops street and number`() {
-        deriveAddressDetail(listOf("1 Beacon St, Boston, MA 02108, USA")) shouldBe
-            "Boston, MA 02108, USA"
+    fun `US-style address with no neighbourhood collapses to city + state + zip + country`() {
+        buildAddressDetail(
+            AddressParts(
+                locality = "Cambridge",
+                adminArea = "MA",
+                postalCode = "02139",
+                countryName = "United States",
+                countryCode = "US",
+            ),
+        ) shouldBe "Cambridge, MA 02139, United States"
     }
 
     @Test
-    fun `UK single-line address drops street and number`() {
-        deriveAddressDetail(listOf("10 Downing Street, London SW1A 2AA, UK")) shouldBe
-            "London SW1A 2AA, UK"
+    fun `Brazilian address preserves the neighbourhood between street and city`() {
+        // Real-world Geocoder output for São Paulo's Bela Vista bairro.
+        // Earlier "drop leading comma part + cap last 3" rule dropped
+        // Bela Vista — the part the user actually wanted to see.
+        buildAddressDetail(
+            AddressParts(
+                subLocality = "Bela Vista",
+                locality = "São Paulo",
+                adminArea = "SP",
+                postalCode = "01311-000",
+                countryName = "Brasil",
+                countryCode = "BR",
+            ),
+        ) shouldBe "Bela Vista, São Paulo, SP 01311-000, Brasil"
     }
 
     @Test
-    fun `single-line with no comma returns null`() {
-        deriveAddressDetail(listOf("Some Place")) shouldBe null
+    fun `London neighbourhood survives alongside city, postcode, country`() {
+        buildAddressDetail(
+            AddressParts(
+                subLocality = "Muswell Hill",
+                locality = "London",
+                adminArea = "England",
+                postalCode = "N10 3BN",
+                countryName = "United Kingdom",
+                countryCode = "GB",
+            ),
+        ) shouldBe "Muswell Hill, London, England N10 3BN, United Kingdom"
     }
 
     @Test
-    fun `single-line with trailing comma after a single component returns null`() {
-        // "Some Place," → after the comma there's nothing useful left.
-        deriveAddressDetail(listOf("Some Place,")) shouldBe null
+    fun `NYC water-adjacent fix shows city + region + country, no POI`() {
+        // The motivating case: coarsened 2dp coords land in the East
+        // River, Geocoder returns "Governors Island Ferry, 10 South St
+        // Slip 7, …" as the formatted line — but locality / adminArea /
+        // postalCode / countryName are all clean.
+        buildAddressDetail(
+            AddressParts(
+                subLocality = null,
+                locality = "New York",
+                adminArea = "NY",
+                postalCode = "10004",
+                countryName = "United States",
+                countryCode = "US",
+            ),
+        ) shouldBe "New York, NY 10004, United States"
     }
 
     @Test
-    fun `whitespace after the first comma is trimmed`() {
-        deriveAddressDetail(listOf("1 Main St,    Springfield, IL 62701")) shouldBe
-            "Springfield, IL 62701"
+    fun `locality equal to subLocality drops the duplicate, and so does the matching country name`() {
+        // City-states like Singapore populate every place-name field
+        // (subLocality, locality, countryName) with the same string.
+        // Show "Singapore" once — duplicating it twice on the line
+        // ("Singapore, 238801, Singapore") reads as a bug to anyone
+        // who notices.
+        buildAddressDetail(
+            AddressParts(
+                subLocality = "Singapore",
+                locality = "Singapore",
+                postalCode = "238801",
+                countryName = "Singapore",
+                countryCode = "SG",
+            ),
+        ) shouldBe "Singapore, 238801"
     }
 
     @Test
-    fun `unicode characters survive the strip`() {
-        deriveAddressDetail(listOf("Rua Augusta 100, São Paulo, Brazil")) shouldBe
-            "São Paulo, Brazil"
+    fun `Hong Kong shape collapses duplicate place plus country`() {
+        // Hong Kong: structured locality is blank, pickCityName falls
+        // back to the country name ("Hong Kong"). toResult passes it
+        // as recoveredCity. countryName is also "Hong Kong" — drop the
+        // duplicate so the line reads "Sheung Wan, Hong Kong" instead
+        // of "Sheung Wan, Hong Kong, Hong Kong".
+        buildAddressDetail(
+            AddressParts(
+                subLocality = "Sheung Wan",
+                locality = null,
+                recoveredCity = "Hong Kong",
+                countryName = "Hong Kong",
+                countryCode = "HK",
+            ),
+        ) shouldBe "Sheung Wan, Hong Kong"
     }
 
     @Test
-    fun `empty list returns null`() {
-        deriveAddressDetail(emptyList()) shouldBe null
+    fun `missing postalCode leaves a bare adminArea`() {
+        buildAddressDetail(
+            AddressParts(
+                locality = "Reykjavík",
+                adminArea = "Capital Region",
+                countryName = "Iceland",
+                countryCode = "IS",
+            ),
+        ) shouldBe "Reykjavík, Capital Region, Iceland"
     }
 
     @Test
-    fun `multi-line address joins remaining lines after dropping street`() {
-        // Some Geocoder backends split across line 0 (street), line 1
-        // (city/state), and line 2 (country). Join with ", " before
-        // stripping so the user still sees city + state + country.
-        deriveAddressDetail(
-            listOf("1 Vassar St", "Cambridge, MA 02139", "USA"),
-        ) shouldBe "Cambridge, MA 02139, USA"
+    fun `missing adminArea leaves a bare postalCode`() {
+        buildAddressDetail(
+            AddressParts(
+                locality = "London",
+                postalCode = "SW1A 2AA",
+                countryName = "United Kingdom",
+                countryCode = "GB",
+            ),
+        ) shouldBe "London, SW1A 2AA, United Kingdom"
     }
 
     @Test
-    fun `multi-line address with no comma on first line still drops first line`() {
-        // Line 0 has no comma; after joining, the first comma lives at the
-        // boundary between line 0 and line 1 — so "1 Vassar St" is dropped
-        // wholesale, leaving the city + state + country.
-        deriveAddressDetail(
-            listOf("1 Vassar St", "Cambridge MA 02139", "USA"),
-        ) shouldBe "Cambridge MA 02139, USA"
+    fun `countryCode falls back when countryName is missing`() {
+        // Some Geocoder backends populate the ISO code but not the
+        // localised country name — surface the code rather than blank.
+        buildAddressDetail(
+            AddressParts(
+                locality = "Sydney",
+                adminArea = "NSW",
+                postalCode = "2000",
+                countryCode = "AU",
+            ),
+        ) shouldBe "Sydney, NSW 2000, AU"
+    }
+
+    @Test
+    fun `blank strings are treated as missing`() {
+        buildAddressDetail(
+            AddressParts(
+                subLocality = "  ",
+                locality = "Tokyo",
+                adminArea = "",
+                postalCode = " ",
+                countryName = "Japan",
+            ),
+        ) shouldBe "Tokyo, Japan"
+    }
+
+    @Test
+    fun `all fields null returns null`() {
+        buildAddressDetail(AddressParts()) shouldBe null
+    }
+
+    @Test
+    fun `UK inner-London structured locality blank, post town arrives via recoveredCity`() {
+        // Inner-London Geocoder results leave structured locality
+        // blank; pickCityName fishes the post town ("London") out of
+        // addressLines. toResult passes that recovered city in the
+        // recoveredCity slot, so it slots in as a place name alongside
+        // (or in place of) the missing locality.
+        buildAddressDetail(
+            AddressParts(
+                locality = null,
+                recoveredCity = "London",
+                adminArea = "England",
+                postalCode = "SW1A 2AA",
+                countryName = "United Kingdom",
+                countryCode = "GB",
+            ),
+        ) shouldBe "London, England SW1A 2AA, United Kingdom"
+    }
+
+    @Test
+    fun `UK hamlet locality renders alongside the recovered post town`() {
+        // Outer-London villages like Oakley Green fill structured
+        // locality with the hamlet; pickCityName recovers the post
+        // town ("Windsor") from the postcode token. Both survive: the
+        // hamlet sits in the locality slot, the post town in
+        // recoveredCity, and the displayed line keeps both.
+        buildAddressDetail(
+            AddressParts(
+                locality = "Oakley Green",
+                recoveredCity = "Windsor",
+                adminArea = "England",
+                postalCode = "SL4 5XX",
+                countryName = "United Kingdom",
+                countryCode = "GB",
+            ),
+        ) shouldBe "Oakley Green, Windsor, England SL4 5XX, United Kingdom"
+    }
+
+    @Test
+    fun `UK suburb + hamlet + post town all survive when buildAddressDetail receives all three`() {
+        // The trickiest UK shape: Geocoder gives a real subLocality
+        // (residential suburb) AND a hamlet-style locality, while
+        // pickCityName recovers the post town from the postcode. All
+        // three distinct place names slot into the output line — no
+        // demotion, no dedup. The earlier shuffle-based attempt at
+        // post-town recovery silently dropped the post town in this
+        // case; the recoveredCity slot keeps it.
+        buildAddressDetail(
+            AddressParts(
+                subLocality = "Suburb",
+                locality = "Oakley Green",
+                recoveredCity = "Windsor",
+                adminArea = "England",
+                postalCode = "SL4 5XX",
+                countryName = "United Kingdom",
+                countryCode = "GB",
+            ),
+        ) shouldBe "Suburb, Oakley Green, Windsor, England SL4 5XX, United Kingdom"
+    }
+
+    @Test
+    fun `recoveredCity that matches locality is silently deduped`() {
+        // The common case: Geocoder's locality already matches what
+        // pickCityName resolves to. recoveredCity is passed but
+        // collapses, so the line is identical to the no-recovery case.
+        buildAddressDetail(
+            AddressParts(
+                locality = "Cambridge",
+                recoveredCity = "Cambridge",
+                adminArea = "MA",
+                postalCode = "02139",
+                countryName = "United States",
+                countryCode = "US",
+            ),
+        ) shouldBe "Cambridge, MA 02139, United States"
+    }
+
+    @Test
+    fun `only country returns the country alone`() {
+        // Edge case: nothing more granular than the country was
+        // resolvable. Still useful as a header / pin label rather than
+        // showing nothing.
+        buildAddressDetail(
+            AddressParts(countryName = "Antarctica"),
+        ) shouldBe "Antarctica"
     }
 }


### PR DESCRIPTION
## Summary

The Location settings page's neighbourhood-level line was showing a full house number / street prefix for some real-world fixes — e.g. `10 South St Slip 7, New York, NY 10004, USA` instead of `New York, NY 10004, USA`.

The earlier attempt on this branch parsed the formatted `addressLine` string ("drop the leading comma component, cap at the last three"). The Developer reverse-geocode tester (landed via #750) showed the real cause: when the coarsened 2dp pin lands in water just off Manhattan, Google's Geocoder returns the nearest landmark and *prepends* the POI name to the canonical line — `"Governors Island Ferry, 10 South St Slip 7, New York, NY 10004, USA"`. Any string-level trim either leaks part of that prefix or, on shapes like `"Street, Bela Vista, São Paulo - SP, 01311-000, Brazil"`, strips the meaningful **neighbourhood** ("Bela Vista") along with the street.

So this PR stops parsing the formatted line entirely. `buildAddressDetail` composes the address from the platform Geocoder's *structured* fields — `subLocality`, `locality`, `recoveredCity` (the city `pickCityName` resolves), `adminArea`, `postalCode`, `countryName` (with `countryCode` as a fallback). Those are the same fields Google's own formatter consumes; we just skip the lossy formatting step that's prepending POIs and inserting street prefixes.

The `recoveredCity` slot is what keeps the displayed detail consistent with the city header for the awkward UK shapes:
- **Inner-London residentials** where structured `locality` is blank but `pickCityName` fishes the post town ("London") out of `addressLines` / postcode.
- **Hamlet localities** like `locality="Oakley Green"` where `pickCityName` recovers the post town ("Windsor") from the postcode — both survive (`"Oakley Green, Windsor, England SL4 5XX, United Kingdom"`).
- **Suburb + hamlet + post town**: when the Geocoder fills both `subLocality` and a hamlet-style `locality`, all three distinct place names slot in (`"Suburb, Oakley Green, Windsor, …"`) — no demotion, no dedup loss.

When the Geocoder's `locality` already matches the recovered city, dedup collapses the slot and the line is unchanged. Same for country: city-states / SARs (Singapore, Hong Kong) populate every place field with the same string, and the country slot drops to avoid `"Singapore, 238801, Singapore"`.

Same output shape across countries — no per-locale heuristics, no count caps, no shuffle logic:

| Coord | Output |
| --- | --- |
| NYC water-adjacent (motivating case) | `New York, NY 10004, United States` |
| Brazil with neighbourhood | `Bela Vista, São Paulo, SP 01311-000, Brasil` |
| London with neighbourhood | `Muswell Hill, London, England N10 3BN, United Kingdom` |
| London with blank locality (post town recovered) | `London, England SW1A 2AA, United Kingdom` |
| UK hamlet + post town | `Oakley Green, Windsor, England SL4 5XX, United Kingdom` |
| UK suburb + hamlet + post town | `Suburb, Oakley Green, Windsor, England SL4 5XX, United Kingdom` |
| Singapore (city-state) | `Singapore, 238801` |
| Hong Kong (SAR) | `Sheung Wan, Hong Kong` |
| US (no neighbourhood) | `Cambridge, MA 02139, United States` |

## Design notes

- `AddressParts` data class lifts the six raw Geocoder fields out of `android.location.Address` — plus a `recoveredCity` slot for `pickCityName`'s result — so `buildAddressDetail` is JVM-testable without instantiating a platform `Address`.
- `Address.toResult()` builds the parts and calls `buildAddressDetail`. No shuffle, no per-case branching: every input shape goes through the same dedup. `pickCityName` (the header city label) is unchanged.
- `buildAddressDetail` walks the slots in order — `subLocality, locality, recoveredCity, "adminArea postalCode", country` — skipping any slot that's blank or that would duplicate an earlier non-null slot.
- The earlier `deriveAddressDetail(addressLines: List<String>)` and its string-parsing tests are removed.

## Privacy

Nothing new leaves the device. The detail is still derived from the same coarsened 2dp (~1 km grid) coords the rest of the app uses — we're just composing it from the structured Geocoder fields rather than parsing the formatted line on top of them.

## Test plan

- [x] `DeriveAddressDetailTest`: 14 cases — US / Brazil / London-neighbourhood / NYC water / Singapore / HK / missing-postcode / missing-adminArea / countryCode-only fallback / blank-strings / all-null / country-only / inner-London post-town recovery / UK hamlet+post-town / UK suburb+hamlet+post-town / recoveredCity dedup
- [x] Validated against the Developer tester (#750) on `40.70, -74.01` — raw `addressLines` carries the POI prefix, derived addressDetail is clean
- [ ] On-device verification after merge
