### PR TITLE
Give promo card body text a right margin matching the left

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/today/CelebrationThemesCard.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/CelebrationThemesCard.kt
@@ -83,6 +83,7 @@ internal fun CelebrationThemesCardContent(
             Text(
                 text = stringResource(R.string.today_celebration_card_body),
                 style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier.padding(end = 12.dp),
             )
             Row(
                 modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/kotlin/app/clothescast/ui/today/ClothesPromoCard.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/ClothesPromoCard.kt
@@ -88,6 +88,7 @@ internal fun ClothesPromoCardContent(
             Text(
                 text = stringResource(R.string.today_clothes_promo_body),
                 style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier.padding(end = 12.dp),
             )
             Row(
                 modifier = Modifier.fillMaxWidth(),


### PR DESCRIPTION
## Summary

The Today-screen "Customize your clothes" and "Celebration themes" promo cards previously let body text extend to ~4dp from the right edge of the card, well past the 16dp left margin. The card's outer `Column` uses `end = 4.dp` so the close `IconButton` sits near the edge — but that same padding was also bounding the wrapped body text.

Add `Modifier.padding(end = 12.dp)` to each card's body `Text` so its right margin matches the 16dp left margin without nudging the close button inward.

## Test plan

- [ ] CI green (JVM + Android debug build)
- [ ] Snapshot regen bot will redraw `ClothesPromoCardPreview` / celebration card preview — verify the body text now wraps with symmetric left/right margins
- [ ] Eyeball on device: both cards' body copy no longer touches the right edge


---
_Generated by [Claude Code](https://claude.ai/code/session_019XfYg8WHuXm67C9guEhrBx)_