### PR TITLE
Stamp log timestamps with a numeric UTC offset

### DIFF
--- a/app/src/main/kotlin/app/clothescast/diag/BugReport.kt
+++ b/app/src/main/kotlin/app/clothescast/diag/BugReport.kt
@@ -23,12 +23,10 @@ import app.clothescast.core.domain.model.symbol
 import app.clothescast.data.SettingsRepository
 import app.clothescast.insight.InsightFormatter
 import kotlinx.coroutines.flow.first
-import java.text.SimpleDateFormat
 import java.time.Duration
 import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
-import java.util.Date
 import java.util.Locale
 
 /**
@@ -39,8 +37,8 @@ import java.util.Locale
  * clipboard as a paste fallback.
  */
 object BugReport {
-    private val STATUS_TIMESTAMP_FORMAT: DateTimeFormatter =
-        DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss zzz")
+    private val TIMESTAMP_FORMAT: DateTimeFormatter =
+        DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss Z").withZone(ZoneId.systemDefault())
 
     /**
      * Builds the text payload, copies it to the clipboard, and fires the
@@ -83,7 +81,7 @@ object BugReport {
         } else null
         val crash = DiagLog.readPersistedCrash()
         val recent = DiagLog.snapshot()
-        val now = SimpleDateFormat("yyyy-MM-dd HH:mm:ss Z", Locale.US).format(Date())
+        val now = TIMESTAMP_FORMAT.format(Instant.now())
 
         return buildString {
             appendLine("ClothesCast bug report")
@@ -197,9 +195,7 @@ object BugReport {
     }
 
     private fun formatTimestamp(epochMs: Long): String =
-        Instant.ofEpochMilli(epochMs)
-            .atZone(ZoneId.systemDefault())
-            .format(STATUS_TIMESTAMP_FORMAT)
+        TIMESTAMP_FORMAT.format(Instant.ofEpochMilli(epochMs))
 
     /**
      * Humanises age relative to now so a glance at the bug report tells you

--- a/app/src/main/kotlin/app/clothescast/diag/DiagLog.kt
+++ b/app/src/main/kotlin/app/clothescast/diag/DiagLog.kt
@@ -52,7 +52,7 @@ object DiagLog {
         Thread(r, "DiagLog-writer").apply { isDaemon = true }
     }
     private val timestampFormat = ThreadLocal.withInitial {
-        SimpleDateFormat("MM-dd HH:mm:ss.SSS", Locale.US)
+        SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS Z", Locale.US)
     }
 
     @Volatile


### PR DESCRIPTION
## Summary

Diag-log lines were rendered in the device's local time with no zone marker (e.g. `05-27 07:20:43.123`), and the bug-report header / MQTT-publish status used a mix of `-0400` (RFC 822) and `PDT` (named zone) suffixes. Reading a shared report meant guessing the phone's zone and what abbreviation a recipient's locale mapped `PDT` to.

Normalise both to a sortable ISO-ish pattern with a numeric offset:

- `DiagLog.timestampFormat`: `MM-dd HH:mm:ss.SSS` (local, no zone) → `yyyy-MM-dd HH:mm:ss.SSS Z`, e.g. `2026-05-27 07:20:43.123 -0400`. Also picks up the `last-crash.txt` header.
- `BugReport.TIMESTAMP_FORMAT`: new single formatter (`yyyy-MM-dd HH:mm:ss Z`) replacing the two previous patterns (`yyyy-MM-dd HH:mm:ss Z` Captured + `yyyy-MM-dd HH:mm:ss zzz` MQTT-status). Second precision is enough for one-shot timestamps; ms only matters on the per-line log for ordering bursty events.

UI-facing local-time displays (`TodayScreen`, `SmartHomeSettings`, `CastDestinationCard`) are intentionally left alone — those should stay in the user's local time.

## Privacy

No change to what leaves the device. Timestamps that already shipped in the bug-report payload are just being reformatted.

## Test plan

- [x] `./gradlew :core:domain:test :core:data:test`
- [x] `./gradlew :app:testDebugUnitTest`
- [ ] Share a real bug report on device, confirm `Captured:` line and recent log lines render as `yyyy-MM-dd HH:mm:ss[.SSS] ±HHMM` in local time
- [ ] CI green