### PR TITLE
Show the structured Geocoder fields in the reverse-geocode tester

### DIFF
--- a/app/src/main/kotlin/app/clothescast/location/ReverseGeocoder.kt
+++ b/app/src/main/kotlin/app/clothescast/location/ReverseGeocoder.kt
@@ -65,19 +65,27 @@ class ReverseGeocoder(
     }
 
     /**
-     * Diagnostic-only return value pairing the raw `addressLines` from the
-     * platform Geocoder with the [Result] derived from them. Surfaced to
-     * the Developer settings page's reverse-geocode tester so a developer
-     * can see exactly what the Geocoder returned for a given coord and
-     * how [buildAddressDetail] folded the structured fields into the
-     * displayed addressDetail.
+     * Diagnostic-only return value pairing what the platform Geocoder
+     * returned for a coord — both the raw formatted [addressLines] and
+     * the structured [parts] (the same `AddressParts` that
+     * [buildAddressDetail] consumes) — with the [Result] we'd derive
+     * from them in production. Surfaced to the Developer settings
+     * page's reverse-geocode tester so a developer can see exactly
+     * which field a misbehaving addressDetail traces back to (a null
+     * subLocality? a duplicated locality? a missing postalCode?)
+     * without instrumenting log lines.
      */
     data class DiagnosticResult(
         val addressLines: List<String>,
+        val parts: AddressParts,
         val derived: Result,
     ) {
         companion object {
-            val EMPTY = DiagnosticResult(addressLines = emptyList(), derived = Result.EMPTY)
+            val EMPTY = DiagnosticResult(
+                addressLines = emptyList(),
+                parts = AddressParts(),
+                derived = Result.EMPTY,
+            )
         }
     }
 
@@ -110,7 +118,11 @@ class ReverseGeocoder(
         val addresses = withTimeoutOrNull(timeoutMillis) { fetch(geocoder, latitude, longitude) }
             ?: return@coRunCatching DiagnosticResult.EMPTY
         val address = addresses.firstOrNull() ?: return@coRunCatching DiagnosticResult.EMPTY
-        DiagnosticResult(addressLines = address.extractLines(), derived = address.toResult())
+        DiagnosticResult(
+            addressLines = address.extractLines(),
+            parts = address.toParts(),
+            derived = address.toResult(),
+        )
     }
         .onFailure { DiagLog.w(TAG, "Unexpected ${it.javaClass.simpleName} from resolveDiagnostic; returning empty.", it) }
         .getOrDefault(DiagnosticResult.EMPTY)
@@ -199,6 +211,15 @@ class ReverseGeocoder(
         else (0..maxIdx).mapNotNull { getAddressLine(it) }
     }
 
+    private fun Address.toParts(): AddressParts = AddressParts(
+        subLocality = subLocality,
+        locality = locality,
+        adminArea = adminArea,
+        postalCode = postalCode,
+        countryName = countryName,
+        countryCode = countryCode,
+    )
+
     private fun Address.toResult(): Result {
         val lines = extractLines()
         val city = pickCityName(
@@ -228,15 +249,7 @@ class ReverseGeocoder(
             city = city,
             countryCode = normalisedCountry,
             addressDetail = buildAddressDetail(
-                AddressParts(
-                    subLocality = subLocality,
-                    locality = locality,
-                    recoveredCity = city,
-                    adminArea = adminArea,
-                    postalCode = postalCode,
-                    countryName = countryName,
-                    countryCode = countryCode,
-                ),
+                toParts().copy(recoveredCity = city),
             ),
         )
     }
@@ -250,9 +263,11 @@ class ReverseGeocoder(
  * Subset of the platform [android.location.Address] fields we use to
  * build the Location settings page's neighbourhood-level line. Lifted
  * out as a data class so [buildAddressDetail] is testable on the JVM
- * without instantiating an Android `Address`.
+ * without instantiating an Android `Address`, and so the Developer
+ * settings page's reverse-geocode tester can surface each field for
+ * debugging — both reachable via [ReverseGeocoder.DiagnosticResult].
  */
-internal data class AddressParts(
+data class AddressParts(
     val subLocality: String? = null,
     val locality: String? = null,
     /**

--- a/app/src/main/kotlin/app/clothescast/ui/settings/DeveloperSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/DeveloperSettings.kt
@@ -292,6 +292,22 @@ internal fun DeveloperContent(
 }
 
 /**
+ * One line of the structured-fields block in the reverse-geocode
+ * tester: a name + a value (rendered as `(null)` / `(blank)` so an
+ * empty value isn't a silent gap), styled the same way regardless of
+ * which field it is.
+ */
+@Composable
+private fun StructuredFieldRow(name: String, value: String?) {
+    val display = when {
+        value == null -> "(null)"
+        value.isBlank() -> "(blank)"
+        else -> value
+    }
+    Text("$name: $display", style = MaterialTheme.typography.bodySmall)
+}
+
+/**
  * Parses a `"lat, lon"` string — comma-separated, whitespace around the
  * comma optional — into a coordinate pair, or null if either half is
  * unparseable or out of range. Accepts the format Google Maps' "What's
@@ -392,6 +408,13 @@ private fun ReverseGeocodeTesterCard(
                         Text("[$i] $line", style = MaterialTheme.typography.bodySmall)
                     }
                 }
+                Text("structured fields:", style = MaterialTheme.typography.labelMedium)
+                StructuredFieldRow("subLocality", r.parts.subLocality)
+                StructuredFieldRow("locality", r.parts.locality)
+                StructuredFieldRow("adminArea", r.parts.adminArea)
+                StructuredFieldRow("postalCode", r.parts.postalCode)
+                StructuredFieldRow("countryName", r.parts.countryName)
+                StructuredFieldRow("countryCode", r.parts.countryCode)
                 Text("derived addressDetail:", style = MaterialTheme.typography.labelMedium)
                 Text(
                     r.derived.addressDetail ?: "(null)",


### PR DESCRIPTION
## Summary

Stacked on top of #747 (the structured-fields rewrite of `buildAddressDetail`). After that change, most "the displayed addressDetail looks wrong" debugging questions are really "which structured field caused this?" — was `subLocality` null? did the Geocoder duplicate `locality` into `subLocality`? was `countryName` populated, or just the ISO code? This PR surfaces each field directly in the Developer reverse-geocode tester so the answer is one tap away.

## Design notes

- `ReverseGeocoder.DiagnosticResult` grows an `AddressParts` field carrying the exact same parts `buildAddressDetail` was handed. Populated from `android.location.Address` via a small `Address.toParts()` helper shared with `toResult()` (no double-extraction).
- `AddressParts` promoted from `internal` to `public`. It was already a pure data carrier with no behaviour to hide; this just lets `DiagnosticResult` (a public type) expose it without leaking an internal symbol.
- Tester card grows a "structured fields" block — six rows, one per field, rendered through a `StructuredFieldRow` helper that distinguishes `null` (`"(null)"`) from blank (`"(blank)"`) so an empty value isn't a silent gap.

## Privacy

No production behaviour change; only the debug surface widens. The Geocoder fields surfaced were already reachable in the previous diagnostic call's `derived` result for city / country; this just lays them out individually for debugging. Nothing new leaves the device.

## Test plan

- [x] `./gradlew :app:assembleDebug :app:testDebugUnitTest` — clean on top of #747's branch
- [x] Static `settings_developer.png` snapshot unchanged (the result block only renders after a Resolve tap, which the snapshot doesn't perform)
- [ ] Manual: paste `40.70, -74.01`, confirm `locality=New York`, `subLocality=(null)`, `adminArea=NY`, `postalCode=10004`, `countryName=United States`, `countryCode=US`

## Notes

PR base is `claude/address-truncation-bug-VIuIM`. Once #747 merges, this branch will rebase onto `main` and the diff will shrink to just the tester changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Pic8zscaoVvZHBtdPZi9cu)_