### PR TITLE
Cap per-entry continuation lines in the bug-report snapshot

### DIFF
--- a/app/src/main/kotlin/app/clothescast/diag/DiagLog.kt
+++ b/app/src/main/kotlin/app/clothescast/diag/DiagLog.kt
@@ -48,6 +48,26 @@ object DiagLog {
      */
     private const val COMPACT_STACK_FRAMES = 1
 
+    /**
+     * Snapshot-side defence against an individual log entry dominating the
+     * 300-line buffer. Limits the consecutive continuation lines (anything
+     * not starting with a timestamp digit — stack frames, `Caused by:`,
+     * `Suppressed:`) that any one entry contributes, then summarises the
+     * dropped tail as `\t... [N lines elided]`.
+     *
+     * The current writer already routes throwables through
+     * [compactStackTraceString], so freshly-written entries cost at most a
+     * handful of continuation lines. The cap exists because `cacheDir`
+     * survives app upgrades, so `diag.log.1` can retain fat
+     * `Throwable.printStackTrace`-style entries written by an older build
+     * (pre-`compactStackTraceString`) until natural rotation flushes them,
+     * and a single 60-line entry from that era used to eat 20% of the
+     * snapshot budget. Sized to comfortably fit a 3-4-deep
+     * compact cause chain with a couple of `Suppressed:` lines per level
+     * (~8 continuation lines), with headroom.
+     */
+    private const val MAX_CONTINUATION_LINES_PER_ENTRY = 10
+
     private val executor = Executors.newSingleThreadExecutor { r ->
         Thread(r, "DiagLog-writer").apply { isDaemon = true }
     }
@@ -116,7 +136,12 @@ object DiagLog {
         runCatching {
             executor.submit { }.get(SYNC_TIMEOUT_MS, TimeUnit.MILLISECONDS)
         }
-        return readTail(file, rotated, MAX_SNAPSHOT_LINES)
+        // Read with headroom so the cap pass below can drop fat entries
+        // and the final `takeLast` still has [MAX_SNAPSHOT_LINES] worth of
+        // distinct entries to surface.
+        val raw = readTail(file, rotated, MAX_SNAPSHOT_LINES * 10)
+        return capEntryContinuations(raw, MAX_CONTINUATION_LINES_PER_ENTRY)
+            .takeLast(MAX_SNAPSHOT_LINES)
     }
 
     /**
@@ -314,5 +339,42 @@ object DiagLog {
             runCatching { file.readLines() }.getOrDefault(emptyList())
         } else emptyList()
         return (prev + curr).takeLast(maxLines)
+    }
+
+    /**
+     * Groups [lines] into entries (leading line + subsequent non-leading
+     * "continuation" lines) and truncates each entry's continuation tail
+     * past [maxContinuation], replacing the dropped lines with a single
+     * `\t... [N lines elided]` marker. A leading line is one starting with
+     * a digit (the log timestamp); anything else — `\tat …` stack frames,
+     * `Caused by: …`, `\tSuppressed: …`, or an orphan continuation at
+     * the start of the snapshot whose header was rotated out — is a
+     * continuation. The cap resets at every leading line. Visible for
+     * tests.
+     */
+    internal fun capEntryContinuations(lines: List<String>, maxContinuation: Int): List<String> {
+        val result = mutableListOf<String>()
+        var continuationCount = 0
+        var elidedCount = 0
+        for (line in lines) {
+            val isLeading = line.isNotEmpty() && line[0].isDigit()
+            if (isLeading) {
+                if (elidedCount > 0) {
+                    result += "\t... [$elidedCount lines elided]"
+                    elidedCount = 0
+                }
+                continuationCount = 0
+                result += line
+            } else if (continuationCount < maxContinuation) {
+                result += line
+                continuationCount++
+            } else {
+                elidedCount++
+            }
+        }
+        if (elidedCount > 0) {
+            result += "\t... [$elidedCount lines elided]"
+        }
+        return result
     }
 }

--- a/app/src/test/kotlin/app/clothescast/diag/DiagLogTest.kt
+++ b/app/src/test/kotlin/app/clothescast/diag/DiagLogTest.kt
@@ -186,6 +186,66 @@ class DiagLogTest {
         stackTrace = Array(depth) { i -> StackTraceElement("Foo$i", "bar", "Foo$i.kt", i + 1) }
     }
 
+    @Test
+    fun `capEntryContinuations passes through entries within the cap`() {
+        val input = listOf(
+            "2026-05-27 12:00:00.000 -0400 I Foo: msg",
+            "\tat com.example.A.run(A.kt:1)",
+            "Caused by: java.io.IOException: boom",
+            "\tat com.example.B.run(B.kt:2)",
+        )
+        DiagLog.capEntryContinuations(input, maxContinuation = 6) shouldBe input
+    }
+
+    @Test
+    fun `capEntryContinuations elides continuation lines beyond the cap`() {
+        val input = listOf(
+            "2026-05-27 12:00:00.000 -0400 W ConfidenceFetcher: fetch failed",
+            "\tat 1", "\tat 2", "\tat 3", "\tat 4",
+            "\tat 5", "\tat 6", "\tat 7", "\tat 8",
+        )
+        DiagLog.capEntryContinuations(input, maxContinuation = 4) shouldBe listOf(
+            "2026-05-27 12:00:00.000 -0400 W ConfidenceFetcher: fetch failed",
+            "\tat 1", "\tat 2", "\tat 3", "\tat 4",
+            "\t... [4 lines elided]",
+        )
+    }
+
+    @Test
+    fun `capEntryContinuations resets the counter at the next leading line`() {
+        // Each timestamp-prefixed entry gets its own continuation budget so
+        // an over-long earlier entry can't starve a later one's frames.
+        val input = listOf(
+            "2026-05-27 12:00:00.000 -0400 W Foo: first",
+            "\tat 1", "\tat 2", "\tat 3", "\tat 4", "\tat 5",
+            "2026-05-27 12:00:01.000 -0400 W Bar: second",
+            "\tat 1", "\tat 2",
+        )
+        DiagLog.capEntryContinuations(input, maxContinuation = 2) shouldBe listOf(
+            "2026-05-27 12:00:00.000 -0400 W Foo: first",
+            "\tat 1", "\tat 2",
+            "\t... [3 lines elided]",
+            "2026-05-27 12:00:01.000 -0400 W Bar: second",
+            "\tat 1", "\tat 2",
+        )
+    }
+
+    @Test
+    fun `capEntryContinuations caps orphan continuations at the start`() {
+        // The snapshot can begin mid-entry when the rotated file's tail is
+        // chopped — those leading continuation lines lack a header and must
+        // not be allowed to dominate the buffer either.
+        val input = listOf(
+            "\tat 1", "\tat 2", "\tat 3", "\tat 4", "\tat 5",
+            "2026-05-27 12:00:00.000 -0400 I Foo: ok",
+        )
+        DiagLog.capEntryContinuations(input, maxContinuation = 2) shouldBe listOf(
+            "\tat 1", "\tat 2",
+            "\t... [3 lines elided]",
+            "2026-05-27 12:00:00.000 -0400 I Foo: ok",
+        )
+    }
+
     private fun files(dir: Path): Pair<File, File> =
         dir.resolve("diag.log").toFile() to dir.resolve("diag.log.1").toFile()
 }


### PR DESCRIPTION
## Summary

A fresh bug-report dump still contained 60+-line stack traces with `... 14 more` markers (output of `Throwable.printStackTrace`) — not what `compactStackTraceString` (limit 1 frame per throwable) emits. The current writer is correct; those fat entries are leftovers in `diag.log.1` from an older build (pre-`compactStackTraceString`, landed in `18b122f8` on 2026-05-17) that hasn't yet rotated out. `cacheDir` survives app upgrades, so historical entries hang around until natural rotation flushes them.

Add a defensive snapshot-side cap so a single fat entry can't dominate the 300-line buffer regardless of when or by which build version it was written.

`snapshot()` now reads with headroom (`MAX_SNAPSHOT_LINES * 10`) and pipes the lines through `capEntryContinuations`, which groups them into entries (leading line = starts with a timestamp digit; everything else = continuation) and truncates each entry's continuation tail past `MAX_CONTINUATION_LINES_PER_ENTRY = 10`, summarising the dropped tail as a single `\t... [N lines elided]` marker. Orphan continuations at the start of the snapshot (their header was rotated out) are subject to the same cap. Compact entries with 3-4-deep cause chains and a few `Suppressed:` lines fit comfortably; pre-compact 60-line entries collapse to 11 lines.

`readTail` stays unchanged as the file-IO primitive — the cap sits in `snapshot()` so the existing read-+-tail tests don't change shape.

## Why this fix instead of wiping on upgrade

Considered force-clearing `diag.log{,.1}` when the version code changes, but the existing design intentionally preserves cross-upgrade context (see DiagLog.kt:132 — "without the marker a post-upgrade report would interleave lines from two versions under one header"). The snapshot cap keeps that history while preventing any single entry from starving the buffer.

## Privacy

No change to what leaves the device. Same content, less of it.

## Test plan

- [x] `./gradlew :app:testDebugUnitTest` (full suite)
- [x] 4 new tests covering the cap: pass-through, elide-beyond-cap, reset-at-leading-line, orphan-continuation-at-start
- [ ] Share a real bug report on device after this lands, confirm any historical fat entries in `diag.log.1` render with `\t... [N lines elided]` markers and the snapshot covers more distinct entries
- [ ] CI green

---
_Generated by [Claude Code](https://claude.ai/code/session_01FDtrBrDrWMkf93ctNyukTz)_