### PR TITLE
Shorten the nightly "Only when there are evening events" toggle label

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -673,7 +673,7 @@
     <string name="settings_tonight_title">Nightly ClothesCast</string>
     <string name="settings_tonight_enabled">Nightly ClothesCast</string>
     <string name="settings_tonight_time_label">Time</string>
-    <string name="settings_tonight_notify_only_on_events">Only notify when there are evening events</string>
+    <string name="settings_tonight_notify_only_on_events">Only when there are evening events</string>
 
     <!-- Format settings: choose how each clause of the ClothesCast prose reads. -->
     <string name="settings_format_preview_example_title">Example</string>


### PR DESCRIPTION
## Summary

Trims the Nightly ClothesCast toggle from "Only notify when there are evening events" to "Only when there are evening events". The toggle sits inside the Nightly ClothesCast section, which already makes clear it's about notifications, so "notify" is redundant.

Only the English source string (`values/strings.xml`) is updated — the existing translations in the other `values-*/strings.xml` files still read with the longer phrasing and will be retranslated separately.

## Test plan

- [x] `./gradlew :app:testDebugUnitTest` (passes; no test references the literal string)
- [ ] Eyeball the Nightly ClothesCast section on the Schedule page in a debug build

---
_Generated by [Claude Code](https://claude.ai/code/session_01VCY71xjDCWuv7VvvBPJD8c)_