### PR TITLE
Translate the new Settings strings into all locales

### DIFF
--- a/app/src/main/res/values-am/strings.xml
+++ b/app/src/main/res/values-am/strings.xml
@@ -865,4 +865,84 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="today_rationale_open_clothes_settings">የልብስ ቅንብሮች</string>
     <string name="settings_calendar_birthdays">የቀን መቁጠሪያ ልደቶች</string>
     <string name="settings_calendar_public_holidays">የቀን መቁጠሪያ በዓሎች</string>
+
+    <!-- Settings strings added in 2026-05: Smart Home, Developer, Format, Calendar, Schedule, Default outfit. -->
+
+    <!-- Settings root labels — Developer, Format -->
+    <string name="settings_root_developer">ገንቢ</string>
+    <string name="settings_root_developer_subtitle">መሞከርና ማስተካከል</string>
+    <string name="settings_root_format">ቅርጸት</string>
+
+    <!-- Developer settings page -->
+    <string name="settings_developer_preview_day_title">አንድ ቀን ቅድመ-እይታ</string>
+    <string name="settings_developer_preview_day_subtitle">ለማንኛውም ቀን ልብስ፣ ባነር እና ድምፅ፣ የተወሰነ ምቹ-የአየር ሁኔታ ናሙና በመጠቀም።</string>
+    <string name="settings_developer_pick_date">ቀን ምረጥ</string>
+    <string name="settings_developer_today">ዛሬ</string>
+    <string name="settings_developer_no_theme">ለዚህ ቀን የበዓል ጭብጥ የለም።</string>
+    <string name="settings_developer_resolved_label">ተፈቷል: %1$s</string>
+    <string name="settings_developer_speak">ተናገር</string>
+
+    <!-- Smart Home — newer keys -->
+    <string name="settings_smart_home_cast_label">ትንበያ ወደ ስማርት ማሳያ ላክ</string>
+    <string name="settings_smart_home_cast_last_published">በመጨረሻ የታተመው %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched">በመጨረሻ የተወሰደው %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched_never">ማሳያው እስካሁን ClothesCast አልወሰደም</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_title">የስልክ ንግግር ዝለል</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_description">በቤት ውስጥ ድርብ ማስታወቂያዎችን ያስወግዱ።</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_title">የስልክ ንግግር ዝለል</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_description">በቤት ውስጥ ድርብ ማስታወቂያዎችን ያስወግዱ።</string>
+    <string name="settings_smart_home_mqtt_topic_hint">%1$s/now/text, %1$s/now/audio, ወዘተ</string>
+
+    <!-- Schedule settings — Daily ClothesCast -->
+    <string name="settings_schedule_enabled">ዕለታዊ ClothesCast</string>
+    <string name="settings_delivery_notification">አሳውቅ</string>
+    <string name="settings_delivery_tts">ተናገር</string>
+
+    <!-- Clothes-mention picker -->
+    <string name="settings_clothes_mention_label">ልብስ</string>
+    <string name="settings_clothes_mention_always">ሁልጊዜ</string>
+    <string name="settings_clothes_mention_if_changed">ሲቀየር</string>
+    <string name="settings_clothes_mention_never">በፍፁም</string>
+
+    <!-- Format settings page -->
+    <string name="settings_format_preview_example_title">ምሳሌ</string>
+    <string name="settings_format_preview_current_title">አሁን ያለ ትንበያ</string>
+    <string name="settings_format_preview_current_empty">እስካሁን ምንም ትንበያ የለም — ከሚቀጥለው ClothesCast በኋላ ይመለሱ።</string>
+    <string name="settings_format_what_to_say">ምን እንደሚባል</string>
+    <string name="settings_format_range_label">የሙቀት ክልል</string>
+    <string name="settings_format_range_none">ምንም</string>
+    <string name="settings_format_range_degrees">ዲግሪዎች</string>
+    <string name="settings_format_range_bands">ደረጃዎች</string>
+    <string name="settings_format_change_label">የሙቀት ለውጥ</string>
+    <string name="settings_format_change_off">ጠፍቷል</string>
+    <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_clothes_label">የልብስ ቃላት</string>
+    <string name="settings_format_clothes_items">ልብሶች</string>
+    <string name="settings_format_clothes_layer_count">የመጠቅለያ ብዛት</string>
+    <string name="settings_format_bottoms_label">ታችኞቹ ልብሶች</string>
+    <string name="settings_format_bottoms_always">ሁልጊዜ</string>
+    <string name="settings_format_bottoms_if_garments">ልብስ ካለ</string>
+    <string name="settings_format_bottoms_never">በፍፁም</string>
+    <string name="settings_format_rain_accessory_label">የዝናብ መለዋወጫ</string>
+    <string name="settings_format_rain_accessory_none">ጠፍቷል</string>
+    <string name="settings_format_rain_accessory_umbrella">ጃንጥላ</string>
+
+    <!-- Fallback clothes rules — "If no rules match" -->
+    <string name="settings_default_outfit_title">ምንም ህግ ካልተዛመደ</string>
+    <string name="settings_default_top_edit_title">ነባሪ የላይኛው ልብስ</string>
+    <string name="settings_default_bottom_edit_title">ነባሪ የታችኛው ልብስ</string>
+    <string name="settings_default_outfit_range_above">ሙቀቱ ከ%1$s በላይ ሲሆን</string>
+    <string name="settings_default_outfit_range_below">ሙቀቱ ከ%1$s በታች ሲሆን</string>
+    <string name="settings_default_outfit_range_between">ሙቀቱ ከ%1$s እና %2$s መካከል ሲሆን</string>
+    <string name="settings_default_outfit_range_never">በፍፁም</string>
+
+    <!-- Calendar settings — master switch + per-feature toggles -->
+    <string name="settings_calendar_master">የእኔን የቀን መቁጠሪያ ተጠቀም</string>
+    <string name="settings_calendar_master_description">ትንበያዎችንና ልብሶችን ለማበጀት ClothesCast የቀን መቁጠሪያዎችዎን እንዲያነብ ይፍቀዱ። ምንም ከመሳሪያው አይወጣም።</string>
+    <string name="settings_calendar_features_title">የግል የቀን መቁጠሪያዎች</string>
+    <string name="settings_calendar_evening_tie_ins">የምሽት ግንኙነቶች</string>
+    <string name="settings_calendar_evening_tie_ins_description">ምሽት ላይ ቢወጡ የጠዋቱ ትንበያ ተጨማሪ ነገር ይዘው መሄድ አለመሄድዎን ይነግርዎታል።</string>
+    <string name="settings_calendar_birthdays_description">በቀን መቁጠሪያዎ ውስጥ ላሉ ልደቶች ልዩ ቀለሞችንና መልዕክቶችን ይጠቀሙ።</string>
+    <string name="settings_calendar_public_holidays_description">በቀን መቁጠሪያዎ ውስጥ ላሉ የህዝብ በዓሎች ልዩ ቀለሞችንና መልዕክቶችን ይጠቀሙ።</string>
+    <string name="settings_calendar_open_system_settings">የስርዓት ቅንብሮችን ክፈት</string>
 </resources>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -896,4 +896,83 @@ they work correctly in both the single-band and range templates.
     <string name="today_rationale_open_clothes_settings">إعدادات الملابس</string>
     <string name="settings_calendar_birthdays">أعياد ميلاد التقويم</string>
     <string name="settings_calendar_public_holidays">أعياد التقويم</string>
+
+    <!-- Settings strings added in 2026-05: Smart Home, Developer, Format, Calendar, Schedule, Default outfit. -->
+    <!-- Settings root labels — Smart Home, Developer, Format -->
+    <string name="settings_root_developer">المطور</string>
+    <string name="settings_root_developer_subtitle">الاختبار وتصحيح الأخطاء</string>
+    <string name="settings_root_format">الصياغة</string>
+
+    <!-- Developer settings page (Settings → Developer → Preview a day) -->
+    <string name="settings_developer_preview_day_title">معاينة يوم</string>
+    <string name="settings_developer_preview_day_subtitle">الزي واللافتة والصوت لأي تاريخ، باستخدام عيّنة طقس معتدل ثابتة.</string>
+    <string name="settings_developer_pick_date">اختر تاريخًا</string>
+    <string name="settings_developer_today">اليوم</string>
+    <string name="settings_developer_no_theme">لا توجد سمة عطلة لهذا اليوم.</string>
+    <string name="settings_developer_resolved_label">تم الحل: %1$s</string>
+    <string name="settings_developer_speak">تشغيل</string>
+
+    <!-- Smart Home — newer keys -->
+    <string name="settings_smart_home_cast_label">إرسال التوقعات إلى الشاشة الذكية</string>
+    <string name="settings_smart_home_cast_last_published">آخر نشر %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched">آخر جلب %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched_never">لم تجلب الشاشة ClothesCast بعد</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_title">تخطي صوت الهاتف</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_description">تجنب التكرار في الإعلانات داخل المنزل.</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_title">تخطي صوت الهاتف</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_description">تجنب التكرار في الإعلانات داخل المنزل.</string>
+    <string name="settings_smart_home_mqtt_topic_hint">%1$s/now/text، %1$s/now/audio، إلخ</string>
+
+    <!-- Schedule settings -->
+    <string name="settings_schedule_enabled">ClothesCast اليومي</string>
+    <string name="settings_delivery_notification">إشعار</string>
+    <string name="settings_delivery_tts">قراءة</string>
+
+    <!-- Clothes-mention picker on Format / Schedule -->
+    <string name="settings_clothes_mention_label">الملابس</string>
+    <string name="settings_clothes_mention_always">دائمًا</string>
+    <string name="settings_clothes_mention_if_changed">عند التغيير</string>
+    <string name="settings_clothes_mention_never">أبدًا</string>
+
+    <!-- Format settings page -->
+    <string name="settings_format_preview_example_title">مثال</string>
+    <string name="settings_format_preview_current_title">التوقعات الحالية</string>
+    <string name="settings_format_preview_current_empty">لا توجد توقعات بعد — تحقق بعد ClothesCast التالي.</string>
+    <string name="settings_format_what_to_say">ماذا يُقال</string>
+    <string name="settings_format_range_label">مدى درجة الحرارة</string>
+    <string name="settings_format_range_none">بدون</string>
+    <string name="settings_format_range_degrees">درجات</string>
+    <string name="settings_format_range_bands">نطاقات</string>
+    <string name="settings_format_change_label">تغير درجة الحرارة</string>
+    <string name="settings_format_change_off">إيقاف</string>
+    <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_clothes_label">صياغة الملابس</string>
+    <string name="settings_format_clothes_items">قطع الملابس</string>
+    <string name="settings_format_clothes_layer_count">عدد الطبقات</string>
+    <string name="settings_format_bottoms_label">الملابس السفلية</string>
+    <string name="settings_format_bottoms_always">دائمًا</string>
+    <string name="settings_format_bottoms_if_garments">عند وجود ملابس</string>
+    <string name="settings_format_bottoms_never">أبدًا</string>
+    <string name="settings_format_rain_accessory_label">إكسسوار المطر</string>
+    <string name="settings_format_rain_accessory_none">إيقاف</string>
+    <string name="settings_format_rain_accessory_umbrella">مظلة</string>
+
+    <!-- Fallback clothes rules — "If no rules match" -->
+    <string name="settings_default_outfit_title">إذا لم تنطبق أي قاعدة</string>
+    <string name="settings_default_top_edit_title">القطعة العلوية الافتراضية</string>
+    <string name="settings_default_bottom_edit_title">القطعة السفلية الافتراضية</string>
+    <string name="settings_default_outfit_range_above">عندما تكون درجة الحرارة أعلى من %1$s</string>
+    <string name="settings_default_outfit_range_below">عندما تكون درجة الحرارة أقل من %1$s</string>
+    <string name="settings_default_outfit_range_between">عندما تكون درجة الحرارة بين %1$s و%2$s</string>
+    <string name="settings_default_outfit_range_never">أبدًا</string>
+
+    <!-- Calendar settings — master switch + per-feature toggles -->
+    <string name="settings_calendar_master">استخدام تقويمي</string>
+    <string name="settings_calendar_master_description">اسمح لـ ClothesCast بقراءة تقاويمك لتخصيص التوقعات والأزياء. لا يغادر شيء الجهاز.</string>
+    <string name="settings_calendar_features_title">التقاويم الشخصية</string>
+    <string name="settings_calendar_evening_tie_ins">روابط المساء</string>
+    <string name="settings_calendar_evening_tie_ins_description">إذا كنت ستخرج في المساء، تخبرك توقعات الصباح بما إذا كنت بحاجة إلى إحضار أي شيء إضافي.</string>
+    <string name="settings_calendar_birthdays_description">استخدم ألوانًا ورسائل خاصة لأعياد الميلاد في تقاويمك.</string>
+    <string name="settings_calendar_public_holidays_description">استخدم ألوانًا ورسائل خاصة للعطلات الرسمية في تقاويمك.</string>
+    <string name="settings_calendar_open_system_settings">فتح إعدادات النظام</string>
 </resources>

--- a/app/src/main/res/values-b+sr+Latn/strings.xml
+++ b/app/src/main/res/values-b+sr+Latn/strings.xml
@@ -884,4 +884,83 @@ default English (matching values-pl / values-uk).
     <string name="cast_error_unknown">Prenos nije uspeo.</string>
     <string name="settings_calendar_birthdays">Rođendani iz kalendara</string>
     <string name="settings_calendar_public_holidays">Praznici iz kalendara</string>
+
+    <!-- Settings strings added in 2026-05: Smart Home, Developer, Format, Calendar, Schedule, Default outfit. -->
+    <!-- Settings root labels — Developer, Format. -->
+    <string name="settings_root_developer">Programer</string>
+    <string name="settings_root_developer_subtitle">Testiranje i otklanjanje grešaka</string>
+    <string name="settings_root_format">Format</string>
+
+    <!-- Developer settings page (Settings → Developer → Preview a day) -->
+    <string name="settings_developer_preview_day_title">Pregled dana</string>
+    <string name="settings_developer_preview_day_subtitle">Outfit, baner i glas za bilo koji datum, koristeći fiksni uzorak blagog vremena.</string>
+    <string name="settings_developer_pick_date">Izaberi datum</string>
+    <string name="settings_developer_today">Danas</string>
+    <string name="settings_developer_no_theme">Nema prazničke teme za ovaj dan.</string>
+    <string name="settings_developer_resolved_label">Razrešeno: %1$s</string>
+    <string name="settings_developer_speak">Pročitaj</string>
+
+    <!-- Smart Home — newer keys. -->
+    <string name="settings_smart_home_cast_label">Pošalji prognozu na pametni ekran</string>
+    <string name="settings_smart_home_cast_last_published">Poslednja objava %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched">Poslednje preuzimanje %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched_never">Ekran još nije preuzeo nijedan ClothesCast</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_title">Preskoči govor na telefonu</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_description">Izbegni dvostruke obaveštaje kod kuće.</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_title">Preskoči govor na telefonu</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_description">Izbegni dvostruke obaveštaje kod kuće.</string>
+    <string name="settings_smart_home_mqtt_topic_hint">%1$s/now/text, %1$s/now/audio, itd.</string>
+
+    <!-- Schedule settings — Daily ClothesCast -->
+    <string name="settings_schedule_enabled">Dnevni ClothesCast</string>
+    <string name="settings_delivery_notification">Obavesti</string>
+    <string name="settings_delivery_tts">Pročitaj</string>
+
+    <!-- Clothes-mention picker on Format / Schedule -->
+    <string name="settings_clothes_mention_label">Odeća</string>
+    <string name="settings_clothes_mention_always">Uvek</string>
+    <string name="settings_clothes_mention_if_changed">Promena</string>
+    <string name="settings_clothes_mention_never">Nikad</string>
+
+    <!-- Format settings page -->
+    <string name="settings_format_preview_example_title">Primer</string>
+    <string name="settings_format_preview_current_title">Trenutna prognoza</string>
+    <string name="settings_format_preview_current_empty">Još nema prognoze — proveri nakon sledećeg ClothesCasta.</string>
+    <string name="settings_format_what_to_say">Šta reći</string>
+    <string name="settings_format_range_label">Raspon temperatura</string>
+    <string name="settings_format_range_none">Bez</string>
+    <string name="settings_format_range_degrees">Stepeni</string>
+    <string name="settings_format_range_bands">Pojasevi</string>
+    <string name="settings_format_change_label">Promena temperature</string>
+    <string name="settings_format_change_off">Isključeno</string>
+    <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_clothes_label">Formulacija odeće</string>
+    <string name="settings_format_clothes_items">Komadi odeće</string>
+    <string name="settings_format_clothes_layer_count">Broj slojeva</string>
+    <string name="settings_format_bottoms_label">Donji delovi</string>
+    <string name="settings_format_bottoms_always">Uvek</string>
+    <string name="settings_format_bottoms_if_garments">Ako ima komada</string>
+    <string name="settings_format_bottoms_never">Nikad</string>
+    <string name="settings_format_rain_accessory_label">Dodatak za kišu</string>
+    <string name="settings_format_rain_accessory_none">Isključeno</string>
+    <string name="settings_format_rain_accessory_umbrella">Kišobran</string>
+
+    <!-- Fallback clothes rules — "If no rules match" section -->
+    <string name="settings_default_outfit_title">Ako se nijedno pravilo ne podudara</string>
+    <string name="settings_default_top_edit_title">Podrazumevani gornji deo</string>
+    <string name="settings_default_bottom_edit_title">Podrazumevani donji deo</string>
+    <string name="settings_default_outfit_range_above">kad je temperatura iznad %1$s</string>
+    <string name="settings_default_outfit_range_below">kad je temperatura ispod %1$s</string>
+    <string name="settings_default_outfit_range_between">kad je temperatura između %1$s i %2$s</string>
+    <string name="settings_default_outfit_range_never">nikad</string>
+
+    <!-- Calendar settings — master switch + per-feature toggles -->
+    <string name="settings_calendar_master">Koristi moj kalendar</string>
+    <string name="settings_calendar_master_description">Dozvoli ClothesCastu da čita tvoje kalendare radi personalizacije prognoza i outfita. Ništa ne napušta uređaj.</string>
+    <string name="settings_calendar_features_title">Lični kalendari</string>
+    <string name="settings_calendar_evening_tie_ins">Večernje poveznice</string>
+    <string name="settings_calendar_evening_tie_ins_description">Ako uveče izlaziš, jutarnja prognoza ti kaže da li treba da poneseš nešto dodatno.</string>
+    <string name="settings_calendar_birthdays_description">Koristi posebne boje i poruke za rođendane u tvojim kalendarima.</string>
+    <string name="settings_calendar_public_holidays_description">Koristi posebne boje i poruke za državne praznike u tvojim kalendarima.</string>
+    <string name="settings_calendar_open_system_settings">Otvori sistemska podešavanja</string>
 </resources>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -882,4 +882,83 @@ What is NOT overridden, by design:
     <string name="cast_error_unknown">Предаването се провали.</string>
     <string name="settings_calendar_birthdays">Рождени дни от календара</string>
     <string name="settings_calendar_public_holidays">Празници от календара</string>
+
+    <!-- Settings strings added in 2026-05: Smart Home, Developer, Format, Calendar, Schedule, Default outfit. -->
+    <!-- Settings root labels — Developer, Format. -->
+    <string name="settings_root_developer">Разработчик</string>
+    <string name="settings_root_developer_subtitle">Тестване и отстраняване на грешки</string>
+    <string name="settings_root_format">Формат</string>
+
+    <!-- Developer settings page (Settings → Developer → Preview a day) -->
+    <string name="settings_developer_preview_day_title">Преглед на ден</string>
+    <string name="settings_developer_preview_day_subtitle">Облекло, банер и глас за произволна дата с фиксирана извадка за меко време.</string>
+    <string name="settings_developer_pick_date">Избери дата</string>
+    <string name="settings_developer_today">Днес</string>
+    <string name="settings_developer_no_theme">Няма празнична тема за този ден.</string>
+    <string name="settings_developer_resolved_label">Разрешено: %1$s</string>
+    <string name="settings_developer_speak">Прочети</string>
+
+    <!-- Smart Home — newer keys. -->
+    <string name="settings_smart_home_cast_label">Изпрати прогноза към умен дисплей</string>
+    <string name="settings_smart_home_cast_last_published">Последно публикувано %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched">Последно изтеглено %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched_never">Дисплеят още не е изтеглял ClothesCast</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_title">Пропусни говор на телефона</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_description">Избягвай дублирани известия вкъщи.</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_title">Пропусни говор на телефона</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_description">Избягвай дублирани известия вкъщи.</string>
+    <string name="settings_smart_home_mqtt_topic_hint">%1$s/now/text, %1$s/now/audio, и т.н.</string>
+
+    <!-- Schedule settings — Daily ClothesCast -->
+    <string name="settings_schedule_enabled">Ежедневен ClothesCast</string>
+    <string name="settings_delivery_notification">Известяване</string>
+    <string name="settings_delivery_tts">Прочети</string>
+
+    <!-- Clothes-mention picker on Format / Schedule -->
+    <string name="settings_clothes_mention_label">Облекло</string>
+    <string name="settings_clothes_mention_always">Винаги</string>
+    <string name="settings_clothes_mention_if_changed">Промяна</string>
+    <string name="settings_clothes_mention_never">Никога</string>
+
+    <!-- Format settings page -->
+    <string name="settings_format_preview_example_title">Пример</string>
+    <string name="settings_format_preview_current_title">Текуща прогноза</string>
+    <string name="settings_format_preview_current_empty">Все още няма прогноза — провери след следващия си ClothesCast.</string>
+    <string name="settings_format_what_to_say">Какво да каже</string>
+    <string name="settings_format_range_label">Температурен диапазон</string>
+    <string name="settings_format_range_none">Без</string>
+    <string name="settings_format_range_degrees">Градуси</string>
+    <string name="settings_format_range_bands">Ленти</string>
+    <string name="settings_format_change_label">Промяна на температурата</string>
+    <string name="settings_format_change_off">Изключено</string>
+    <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_clothes_label">Формулировка на облеклото</string>
+    <string name="settings_format_clothes_items">Дрехи</string>
+    <string name="settings_format_clothes_layer_count">Брой слоеве</string>
+    <string name="settings_format_bottoms_label">Долни части</string>
+    <string name="settings_format_bottoms_always">Винаги</string>
+    <string name="settings_format_bottoms_if_garments">Ако има дрехи</string>
+    <string name="settings_format_bottoms_never">Никога</string>
+    <string name="settings_format_rain_accessory_label">Аксесоар за дъжд</string>
+    <string name="settings_format_rain_accessory_none">Изключено</string>
+    <string name="settings_format_rain_accessory_umbrella">Чадър</string>
+
+    <!-- Fallback clothes rules — "If no rules match" section -->
+    <string name="settings_default_outfit_title">Ако никое правило не съвпада</string>
+    <string name="settings_default_top_edit_title">Горна част по подразбиране</string>
+    <string name="settings_default_bottom_edit_title">Долна част по подразбиране</string>
+    <string name="settings_default_outfit_range_above">когато температурата е над %1$s</string>
+    <string name="settings_default_outfit_range_below">когато температурата е под %1$s</string>
+    <string name="settings_default_outfit_range_between">когато температурата е между %1$s и %2$s</string>
+    <string name="settings_default_outfit_range_never">никога</string>
+
+    <!-- Calendar settings — master switch + per-feature toggles -->
+    <string name="settings_calendar_master">Използвай моя календар</string>
+    <string name="settings_calendar_master_description">Позволи на ClothesCast да чете календарите ти, за да персонализира прогнози и облекла. Нищо не напуска устройството.</string>
+    <string name="settings_calendar_features_title">Лични календари</string>
+    <string name="settings_calendar_evening_tie_ins">Вечерни връзки</string>
+    <string name="settings_calendar_evening_tie_ins_description">Ако излизаш вечерта, сутрешната прогноза ти казва дали трябва да вземеш нещо допълнително.</string>
+    <string name="settings_calendar_birthdays_description">Използвай специални цветове и съобщения за рождени дни в твоите календари.</string>
+    <string name="settings_calendar_public_holidays_description">Използвай специални цветове и съобщения за официални празници в твоите календари.</string>
+    <string name="settings_calendar_open_system_settings">Отвори системните настройки</string>
 </resources>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -966,4 +966,84 @@ West Bengal vocabulary differences in a future PR.
     <string name="today_rationale_open_clothes_settings">পোশাক সেটিংস</string>
     <string name="settings_calendar_birthdays">ক্যালেন্ডার জন্মদিন</string>
     <string name="settings_calendar_public_holidays">ক্যালেন্ডার ছুটি</string>
+
+    <!-- Settings strings added in 2026-05: Smart Home, Developer, Format, Calendar, Schedule, Default outfit. -->
+
+    <!-- Settings root labels — Developer, Format -->
+    <string name="settings_root_developer">ডেভেলপার</string>
+    <string name="settings_root_developer_subtitle">পরীক্ষা ও ডিবাগিং</string>
+    <string name="settings_root_format">ফর্ম্যাট</string>
+
+    <!-- Developer settings page -->
+    <string name="settings_developer_preview_day_title">একটি দিনের প্রাকদর্শন</string>
+    <string name="settings_developer_preview_day_subtitle">যেকোনো তারিখের জন্য পোশাক, ব্যানার ও ভয়েস, একটি স্থির মৃদু-আবহাওয়ার নমুনা ব্যবহার করে।</string>
+    <string name="settings_developer_pick_date">একটি তারিখ বাছুন</string>
+    <string name="settings_developer_today">আজ</string>
+    <string name="settings_developer_no_theme">এই দিনের জন্য কোনো ছুটির থিম নেই।</string>
+    <string name="settings_developer_resolved_label">সমাধান: %1$s</string>
+    <string name="settings_developer_speak">পড়ুন</string>
+
+    <!-- Smart Home — newer keys -->
+    <string name="settings_smart_home_cast_label">স্মার্ট ডিসপ্লেতে পূর্বাভাস পাঠান</string>
+    <string name="settings_smart_home_cast_last_published">সর্বশেষ প্রকাশিত %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched">সর্বশেষ আনা হয়েছে %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched_never">ডিসপ্লে এখনো কোনো ClothesCast আনেনি</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_title">ফোনের ভয়েস বাদ দিন</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_description">বাড়িতে দ্বৈত ঘোষণা এড়ান।</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_title">ফোনের ভয়েস বাদ দিন</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_description">বাড়িতে দ্বৈত ঘোষণা এড়ান।</string>
+    <string name="settings_smart_home_mqtt_topic_hint">%1$s/now/text, %1$s/now/audio, ইত্যাদি</string>
+
+    <!-- Schedule settings — Daily ClothesCast -->
+    <string name="settings_schedule_enabled">দৈনিক ClothesCast</string>
+    <string name="settings_delivery_notification">জানান</string>
+    <string name="settings_delivery_tts">পড়ুন</string>
+
+    <!-- Clothes-mention picker -->
+    <string name="settings_clothes_mention_label">পোশাক</string>
+    <string name="settings_clothes_mention_always">সবসময়</string>
+    <string name="settings_clothes_mention_if_changed">পরিবর্তন হলে</string>
+    <string name="settings_clothes_mention_never">কখনো না</string>
+
+    <!-- Format settings page -->
+    <string name="settings_format_preview_example_title">উদাহরণ</string>
+    <string name="settings_format_preview_current_title">বর্তমান পূর্বাভাস</string>
+    <string name="settings_format_preview_current_empty">এখনো কোনো পূর্বাভাস নেই — পরবর্তী ClothesCast-এর পরে আবার দেখুন।</string>
+    <string name="settings_format_what_to_say">কী বলা হবে</string>
+    <string name="settings_format_range_label">তাপমাত্রার পরিসীমা</string>
+    <string name="settings_format_range_none">কিছু না</string>
+    <string name="settings_format_range_degrees">ডিগ্রি</string>
+    <string name="settings_format_range_bands">শ্রেণি</string>
+    <string name="settings_format_change_label">তাপমাত্রার পরিবর্তন</string>
+    <string name="settings_format_change_off">বন্ধ</string>
+    <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_clothes_label">পোশাকের শব্দচয়ন</string>
+    <string name="settings_format_clothes_items">পোশাক</string>
+    <string name="settings_format_clothes_layer_count">স্তরের সংখ্যা</string>
+    <string name="settings_format_bottoms_label">নিম্নাঙ্গের পোশাক</string>
+    <string name="settings_format_bottoms_always">সবসময়</string>
+    <string name="settings_format_bottoms_if_garments">যদি পোশাক থাকে</string>
+    <string name="settings_format_bottoms_never">কখনো না</string>
+    <string name="settings_format_rain_accessory_label">বৃষ্টির সরঞ্জাম</string>
+    <string name="settings_format_rain_accessory_none">বন্ধ</string>
+    <string name="settings_format_rain_accessory_umbrella">ছাতা</string>
+
+    <!-- Fallback clothes rules — "If no rules match" -->
+    <string name="settings_default_outfit_title">কোনো নিয়ম না মিললে</string>
+    <string name="settings_default_top_edit_title">ডিফল্ট উপরের পোশাক</string>
+    <string name="settings_default_bottom_edit_title">ডিফল্ট নিম্নাঙ্গের পোশাক</string>
+    <string name="settings_default_outfit_range_above">যখন তাপমাত্রা %1$s-এর উপরে</string>
+    <string name="settings_default_outfit_range_below">যখন তাপমাত্রা %1$s-এর নিচে</string>
+    <string name="settings_default_outfit_range_between">যখন তাপমাত্রা %1$s এবং %2$s-এর মধ্যে</string>
+    <string name="settings_default_outfit_range_never">কখনো না</string>
+
+    <!-- Calendar settings — master switch + per-feature toggles -->
+    <string name="settings_calendar_master">আমার ক্যালেন্ডার ব্যবহার করুন</string>
+    <string name="settings_calendar_master_description">পূর্বাভাস ও পোশাক ব্যক্তিগত করতে ClothesCast-কে আপনার ক্যালেন্ডার পড়ার সুযোগ দিন। কিছুই ডিভাইস ছাড়ে না।</string>
+    <string name="settings_calendar_features_title">ব্যক্তিগত ক্যালেন্ডার</string>
+    <string name="settings_calendar_evening_tie_ins">সন্ধ্যার যোগসূত্র</string>
+    <string name="settings_calendar_evening_tie_ins_description">যদি আপনি সন্ধ্যায় বাইরে যান, সকালের পূর্বাভাস আপনাকে জানায় যে কিছু অতিরিক্ত আনার প্রয়োজন আছে কিনা।</string>
+    <string name="settings_calendar_birthdays_description">আপনার ক্যালেন্ডারের জন্মদিনের জন্য বিশেষ রঙ ও বার্তা ব্যবহার করুন।</string>
+    <string name="settings_calendar_public_holidays_description">আপনার ক্যালেন্ডারের সরকারি ছুটির জন্য বিশেষ রঙ ও বার্তা ব্যবহার করুন।</string>
+    <string name="settings_calendar_open_system_settings">সিস্টেম সেটিংস খুলুন</string>
 </resources>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -834,4 +834,84 @@ the in-app clock is digit-driven and reads consistently across locales.
     <string name="holiday_banner_st_andrews_day">Feliç Dia de Sant Andreu</string>
     <string name="settings_calendar_birthdays">Aniversaris del calendari</string>
     <string name="settings_calendar_public_holidays">Festius del calendari</string>
+
+    <!-- Settings strings added in 2026-05: Smart Home, Developer, Format, Calendar, Schedule, Default outfit. -->
+
+    <!-- Settings root labels — Developer, Format -->
+    <string name="settings_root_developer">Desenvolupador</string>
+    <string name="settings_root_developer_subtitle">Proves i depuració</string>
+    <string name="settings_root_format">Format</string>
+
+    <!-- Developer settings page -->
+    <string name="settings_developer_preview_day_title">Previsualitza un dia</string>
+    <string name="settings_developer_preview_day_subtitle">Vestimenta, bàner i veu per a qualsevol data, amb una mostra meteorològica suau fixa.</string>
+    <string name="settings_developer_pick_date">Tria una data</string>
+    <string name="settings_developer_today">Avui</string>
+    <string name="settings_developer_no_theme">Cap tema festiu per a aquest dia.</string>
+    <string name="settings_developer_resolved_label">Resolt: %1$s</string>
+    <string name="settings_developer_speak">Llegeix en veu alta</string>
+
+    <!-- Smart Home — newer keys -->
+    <string name="settings_smart_home_cast_label">Envia la previsió a la pantalla intel·ligent</string>
+    <string name="settings_smart_home_cast_last_published">Última publicació %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched">Última obtenció %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched_never">La pantalla encara no ha obtingut cap ClothesCast</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_title">Omet la lectura al telèfon</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_description">Evita anuncis duplicats a casa.</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_title">Omet la lectura al telèfon</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_description">Evita anuncis duplicats a casa.</string>
+    <string name="settings_smart_home_mqtt_topic_hint">%1$s/now/text, %1$s/now/audio, etc.</string>
+
+    <!-- Schedule settings -->
+    <string name="settings_schedule_enabled">ClothesCast diari</string>
+    <string name="settings_delivery_notification">Notifica</string>
+    <string name="settings_delivery_tts">Llegeix en veu alta</string>
+
+    <!-- Clothes-mention picker on Format / Schedule -->
+    <string name="settings_clothes_mention_label">Roba</string>
+    <string name="settings_clothes_mention_always">Sempre</string>
+    <string name="settings_clothes_mention_if_changed">Canvi</string>
+    <string name="settings_clothes_mention_never">Mai</string>
+
+    <!-- Format settings page -->
+    <string name="settings_format_preview_example_title">Exemple</string>
+    <string name="settings_format_preview_current_title">Previsió actual</string>
+    <string name="settings_format_preview_current_empty">Encara no hi ha previsió — torna després del teu pròxim ClothesCast.</string>
+    <string name="settings_format_what_to_say">Què dir</string>
+    <string name="settings_format_range_label">Interval de temperatura</string>
+    <string name="settings_format_range_none">Cap</string>
+    <string name="settings_format_range_degrees">Graus</string>
+    <string name="settings_format_range_bands">Categories</string>
+    <string name="settings_format_change_label">Variació de temperatura</string>
+    <string name="settings_format_change_off">Desactivat</string>
+    <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_clothes_label">Redacció de la roba</string>
+    <string name="settings_format_clothes_items">Peces</string>
+    <string name="settings_format_clothes_layer_count">Nombre de capes</string>
+    <string name="settings_format_bottoms_label">Pantalons</string>
+    <string name="settings_format_bottoms_always">Sempre</string>
+    <string name="settings_format_bottoms_if_garments">Si hi ha peces</string>
+    <string name="settings_format_bottoms_never">Mai</string>
+    <string name="settings_format_rain_accessory_label">Accessori per a la pluja</string>
+    <string name="settings_format_rain_accessory_none">Desactivat</string>
+    <string name="settings_format_rain_accessory_umbrella">Paraigua</string>
+
+    <!-- Fallback clothes rules — "If no rules match" section -->
+    <string name="settings_default_outfit_title">Si no coincideix cap regla</string>
+    <string name="settings_default_top_edit_title">Peça superior per defecte</string>
+    <string name="settings_default_bottom_edit_title">Pantalons per defecte</string>
+    <string name="settings_default_outfit_range_above">quan la temperatura és superior a %1$s</string>
+    <string name="settings_default_outfit_range_below">quan la temperatura és inferior a %1$s</string>
+    <string name="settings_default_outfit_range_between">quan la temperatura és entre %1$s i %2$s</string>
+    <string name="settings_default_outfit_range_never">mai</string>
+
+    <!-- Calendar settings — master switch + per-feature toggles -->
+    <string name="settings_calendar_master">Utilitza el meu calendari</string>
+    <string name="settings_calendar_master_description">Permet que ClothesCast llegeixi els teus calendaris per personalitzar previsions i vestits. Res no surt del dispositiu.</string>
+    <string name="settings_calendar_features_title">Calendaris personals</string>
+    <string name="settings_calendar_evening_tie_ins">Referències al vespre</string>
+    <string name="settings_calendar_evening_tie_ins_description">Si surts al vespre, la previsió del matí t\'indica si has de portar alguna cosa extra.</string>
+    <string name="settings_calendar_birthdays_description">Utilitza colors i missatges especials per als aniversaris dels teus calendaris.</string>
+    <string name="settings_calendar_public_holidays_description">Utilitza colors i missatges especials per als festius dels teus calendaris.</string>
+    <string name="settings_calendar_open_system_settings">Obre la configuració del sistema</string>
 </resources>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -903,4 +903,83 @@ locale (Angličtina (USA), Francouzština (Francie), Němčina (Německo), …).
     <string name="holiday_banner_st_andrews_day">Šťastný Den svatého Ondřeje</string>
     <string name="settings_calendar_birthdays">Narozeniny z kalendáře</string>
     <string name="settings_calendar_public_holidays">Svátky z kalendáře</string>
+
+    <!-- Settings strings added in 2026-05: Smart Home, Developer, Format, Calendar, Schedule, Default outfit. -->
+    <!-- Settings root labels — Developer, Format. -->
+    <string name="settings_root_developer">Vývojář</string>
+    <string name="settings_root_developer_subtitle">Testování a ladění</string>
+    <string name="settings_root_format">Formát</string>
+
+    <!-- Developer settings page (Settings → Developer → Preview a day) -->
+    <string name="settings_developer_preview_day_title">Náhled dne</string>
+    <string name="settings_developer_preview_day_subtitle">Outfit, banner a hlas pro libovolný den s pevně daným vzorkem mírného počasí.</string>
+    <string name="settings_developer_pick_date">Vyber datum</string>
+    <string name="settings_developer_today">Dnes</string>
+    <string name="settings_developer_no_theme">Pro tento den není žádné sváteční téma.</string>
+    <string name="settings_developer_resolved_label">Vyhodnoceno: %1$s</string>
+    <string name="settings_developer_speak">Přečíst</string>
+
+    <!-- Smart Home — newer keys. -->
+    <string name="settings_smart_home_cast_label">Odeslat předpověď na chytrý displej</string>
+    <string name="settings_smart_home_cast_last_published">Naposledy publikováno %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched">Naposledy načteno %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched_never">Displej zatím nenačetl žádný ClothesCast</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_title">Přeskočit mluvený výstup v telefonu</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_description">Vyhneš se duplicitním oznámením doma.</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_title">Přeskočit mluvený výstup v telefonu</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_description">Vyhneš se duplicitním oznámením doma.</string>
+    <string name="settings_smart_home_mqtt_topic_hint">%1$s/now/text, %1$s/now/audio, atd.</string>
+
+    <!-- Schedule settings — Daily ClothesCast -->
+    <string name="settings_schedule_enabled">Denní ClothesCast</string>
+    <string name="settings_delivery_notification">Oznámit</string>
+    <string name="settings_delivery_tts">Přečíst</string>
+
+    <!-- Clothes-mention picker on Format / Schedule -->
+    <string name="settings_clothes_mention_label">Oblečení</string>
+    <string name="settings_clothes_mention_always">Vždy</string>
+    <string name="settings_clothes_mention_if_changed">Změna</string>
+    <string name="settings_clothes_mention_never">Nikdy</string>
+
+    <!-- Format settings page -->
+    <string name="settings_format_preview_example_title">Příklad</string>
+    <string name="settings_format_preview_current_title">Aktuální předpověď</string>
+    <string name="settings_format_preview_current_empty">Zatím žádná předpověď — zkontroluj to po svém příštím ClothesCastu.</string>
+    <string name="settings_format_what_to_say">Co říkat</string>
+    <string name="settings_format_range_label">Rozsah teplot</string>
+    <string name="settings_format_range_none">Žádný</string>
+    <string name="settings_format_range_degrees">Stupně</string>
+    <string name="settings_format_range_bands">Pásma</string>
+    <string name="settings_format_change_label">Změna teploty</string>
+    <string name="settings_format_change_off">Vypnuto</string>
+    <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_clothes_label">Formulace oblečení</string>
+    <string name="settings_format_clothes_items">Kusy oblečení</string>
+    <string name="settings_format_clothes_layer_count">Počet vrstev</string>
+    <string name="settings_format_bottoms_label">Spodní díly</string>
+    <string name="settings_format_bottoms_always">Vždy</string>
+    <string name="settings_format_bottoms_if_garments">Pokud jsou kusy</string>
+    <string name="settings_format_bottoms_never">Nikdy</string>
+    <string name="settings_format_rain_accessory_label">Doplněk pro déšť</string>
+    <string name="settings_format_rain_accessory_none">Vypnuto</string>
+    <string name="settings_format_rain_accessory_umbrella">Deštník</string>
+
+    <!-- Fallback clothes rules — "If no rules match" section -->
+    <string name="settings_default_outfit_title">Pokud žádná pravidla neodpovídají</string>
+    <string name="settings_default_top_edit_title">Výchozí horní díl</string>
+    <string name="settings_default_bottom_edit_title">Výchozí spodní díl</string>
+    <string name="settings_default_outfit_range_above">když je teplota nad %1$s</string>
+    <string name="settings_default_outfit_range_below">když je teplota pod %1$s</string>
+    <string name="settings_default_outfit_range_between">když je teplota mezi %1$s a %2$s</string>
+    <string name="settings_default_outfit_range_never">nikdy</string>
+
+    <!-- Calendar settings — master switch + per-feature toggles -->
+    <string name="settings_calendar_master">Použít můj kalendář</string>
+    <string name="settings_calendar_master_description">Povol ClothesCastu číst tvé kalendáře, aby mohl přizpůsobit předpovědi a outfity. Nic neopustí zařízení.</string>
+    <string name="settings_calendar_features_title">Osobní kalendáře</string>
+    <string name="settings_calendar_evening_tie_ins">Večerní propojení</string>
+    <string name="settings_calendar_evening_tie_ins_description">Pokud jdeš večer ven, ranní předpověď ti řekne, jestli si máš vzít něco navíc.</string>
+    <string name="settings_calendar_birthdays_description">Použij speciální barvy a zprávy pro narozeniny ve tvých kalendářích.</string>
+    <string name="settings_calendar_public_holidays_description">Použij speciální barvy a zprávy pro státní svátky ve tvých kalendářích.</string>
+    <string name="settings_calendar_open_system_settings">Otevřít systémová nastavení</string>
 </resources>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -924,4 +924,84 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrig)").
     <string name="holiday_banner_waitangi_day">Glædelig Waitangi Day</string>
     <string name="settings_calendar_birthdays">Kalenderfødseldage</string>
     <string name="settings_calendar_public_holidays">Kalenderhelligdage</string>
+
+    <!-- Settings strings added in 2026-05: Smart Home, Developer, Format, Calendar, Schedule, Default outfit. -->
+
+    <!-- Settings root labels — Developer, Format -->
+    <string name="settings_root_developer">Udvikler</string>
+    <string name="settings_root_developer_subtitle">Test og fejlfinding</string>
+    <string name="settings_root_format">Format</string>
+
+    <!-- Developer settings page -->
+    <string name="settings_developer_preview_day_title">Forhåndsvis en dag</string>
+    <string name="settings_developer_preview_day_subtitle">Outfit, banner og stemme for en hvilken som helst dato, baseret på en fast prøve med mildt vejr.</string>
+    <string name="settings_developer_pick_date">Vælg en dato</string>
+    <string name="settings_developer_today">I dag</string>
+    <string name="settings_developer_no_theme">Intet helligdagstema for denne dag.</string>
+    <string name="settings_developer_resolved_label">Løst: %1$s</string>
+    <string name="settings_developer_speak">Læs op</string>
+
+    <!-- Smart Home — additional keys -->
+    <string name="settings_smart_home_cast_label">Send prognose til smart display</string>
+    <string name="settings_smart_home_cast_last_published">Senest udgivet %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched">Senest hentet %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched_never">Displayet har ikke hentet et ClothesCast endnu</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_title">Spring telefonens tale over</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_description">Undgå dobbelte annonceringer derhjemme.</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_title">Spring telefonens tale over</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_description">Undgå dobbelte annonceringer derhjemme.</string>
+    <string name="settings_smart_home_mqtt_topic_hint">%1$s/now/text, %1$s/now/audio osv.</string>
+
+    <!-- Schedule settings — Daily ClothesCast -->
+    <string name="settings_schedule_enabled">Dagligt ClothesCast</string>
+    <string name="settings_delivery_notification">Underret</string>
+    <string name="settings_delivery_tts">Læs op</string>
+
+    <!-- Clothes-mention picker on Format / Schedule -->
+    <string name="settings_clothes_mention_label">Tøj</string>
+    <string name="settings_clothes_mention_always">Altid</string>
+    <string name="settings_clothes_mention_if_changed">Ved ændring</string>
+    <string name="settings_clothes_mention_never">Aldrig</string>
+
+    <!-- Format settings page -->
+    <string name="settings_format_preview_example_title">Eksempel</string>
+    <string name="settings_format_preview_current_title">Aktuel prognose</string>
+    <string name="settings_format_preview_current_empty">Ingen prognose endnu — kom tilbage efter dit næste ClothesCast.</string>
+    <string name="settings_format_what_to_say">Hvad der skal siges</string>
+    <string name="settings_format_range_label">Temperaturinterval</string>
+    <string name="settings_format_range_none">Ingen</string>
+    <string name="settings_format_range_degrees">Grader</string>
+    <string name="settings_format_range_bands">Niveauer</string>
+    <string name="settings_format_change_label">Temperaturændring</string>
+    <string name="settings_format_change_off">Fra</string>
+    <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_clothes_label">Tøjformulering</string>
+    <string name="settings_format_clothes_items">Tøjstykker</string>
+    <string name="settings_format_clothes_layer_count">Antal lag</string>
+    <string name="settings_format_bottoms_label">Underdele</string>
+    <string name="settings_format_bottoms_always">Altid</string>
+    <string name="settings_format_bottoms_if_garments">Ved tøjstykker</string>
+    <string name="settings_format_bottoms_never">Aldrig</string>
+    <string name="settings_format_rain_accessory_label">Regntilbehør</string>
+    <string name="settings_format_rain_accessory_none">Fra</string>
+    <string name="settings_format_rain_accessory_umbrella">Paraply</string>
+
+    <!-- Fallback clothes rules — "If no rules match" section -->
+    <string name="settings_default_outfit_title">Hvis ingen regler passer</string>
+    <string name="settings_default_top_edit_title">Standard overdel</string>
+    <string name="settings_default_bottom_edit_title">Standard underdel</string>
+    <string name="settings_default_outfit_range_above">når temperaturen er over %1$s</string>
+    <string name="settings_default_outfit_range_below">når temperaturen er under %1$s</string>
+    <string name="settings_default_outfit_range_between">når temperaturen er mellem %1$s og %2$s</string>
+    <string name="settings_default_outfit_range_never">aldrig</string>
+
+    <!-- Calendar settings — master switch + per-feature toggles -->
+    <string name="settings_calendar_master">Brug min kalender</string>
+    <string name="settings_calendar_master_description">Lad ClothesCast læse dine kalendere for at tilpasse prognoser og outfits. Intet forlader enheden.</string>
+    <string name="settings_calendar_features_title">Personlige kalendere</string>
+    <string name="settings_calendar_evening_tie_ins">Aftenforbindelser</string>
+    <string name="settings_calendar_evening_tie_ins_description">Hvis du går ud om aftenen, fortæller morgenprognoserne dig, om du skal tage noget ekstra med.</string>
+    <string name="settings_calendar_birthdays_description">Brug særlige farver og beskeder til fødselsdage i dine kalendere.</string>
+    <string name="settings_calendar_public_holidays_description">Brug særlige farver og beskeder til helligdage i dine kalendere.</string>
+    <string name="settings_calendar_open_system_settings">Åbn systemindstillinger</string>
 </resources>

--- a/app/src/main/res/values-de-rAT/strings.xml
+++ b/app/src/main/res/values-de-rAT/strings.xml
@@ -629,4 +629,85 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="cast_error_unknown">Übertragung fehlgeschlagen.</string>
     <string name="settings_calendar_birthdays">Kalender-Geburtstage</string>
     <string name="settings_calendar_public_holidays">Kalender-Feiertage</string>
+
+    <!-- Settings strings added in 2026-05: Smart Home, Developer, Format, Calendar, Schedule, Default outfit. -->
+
+    <!-- Settings root labels — Developer, Format -->
+    <string name="settings_root_developer">Entwickler</string>
+    <string name="settings_root_developer_subtitle">Tests und Fehlersuche</string>
+    <string name="settings_root_format">Format</string>
+    <string name="settings_root_format_subtitle">Wortwahl und Ausführlichkeit</string>
+
+    <!-- Developer settings page -->
+    <string name="settings_developer_preview_day_title">Tag vorab anzeigen</string>
+    <string name="settings_developer_preview_day_subtitle">Outfit, Banner und Stimme für ein beliebiges Datum mit einem festen Beispiel bei mildem Wetter.</string>
+    <string name="settings_developer_pick_date">Datum wählen</string>
+    <string name="settings_developer_today">Heute</string>
+    <string name="settings_developer_no_theme">Kein Feiertagsthema für diesen Tag.</string>
+    <string name="settings_developer_resolved_label">Aufgelöst: %1$s</string>
+    <string name="settings_developer_speak">Sprechen</string>
+
+    <!-- Smart Home — additional keys -->
+    <string name="settings_smart_home_cast_label">Vorhersage an Smart Display senden</string>
+    <string name="settings_smart_home_cast_last_published">Zuletzt veröffentlicht %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched">Zuletzt abgerufen %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched_never">Das Display hat noch keinen ClothesCast abgerufen</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_title">Sprachausgabe am Handy überspringen</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_description">Doppelte Ansagen zu Hause vermeiden.</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_title">Sprachausgabe am Handy überspringen</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_description">Doppelte Ansagen zu Hause vermeiden.</string>
+    <string name="settings_smart_home_mqtt_topic_hint">%1$s/now/text, %1$s/now/audio usw.</string>
+
+    <!-- Schedule settings — Daily ClothesCast -->
+    <string name="settings_schedule_enabled">Täglicher ClothesCast</string>
+    <string name="settings_delivery_notification">Benachrichtigen</string>
+    <string name="settings_delivery_tts">Sprechen</string>
+
+    <!-- Clothes-mention picker on Format / Schedule -->
+    <string name="settings_clothes_mention_label">Kleidung</string>
+    <string name="settings_clothes_mention_always">Immer</string>
+    <string name="settings_clothes_mention_if_changed">Bei Änderung</string>
+    <string name="settings_clothes_mention_never">Nie</string>
+
+    <!-- Format settings page -->
+    <string name="settings_format_preview_example_title">Beispiel</string>
+    <string name="settings_format_preview_current_title">Aktuelle Vorhersage</string>
+    <string name="settings_format_preview_current_empty">Noch keine Vorhersage — schau nach deinem nächsten ClothesCast wieder vorbei.</string>
+    <string name="settings_format_what_to_say">Was gesagt wird</string>
+    <string name="settings_format_range_label">Temperaturbereich</string>
+    <string name="settings_format_range_none">Keiner</string>
+    <string name="settings_format_range_degrees">Grad</string>
+    <string name="settings_format_range_bands">Stufen</string>
+    <string name="settings_format_change_label">Temperaturänderung</string>
+    <string name="settings_format_change_off">Aus</string>
+    <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_clothes_label">Kleidungs-Formulierung</string>
+    <string name="settings_format_clothes_items">Kleidungsstücke</string>
+    <string name="settings_format_clothes_layer_count">Anzahl der Schichten</string>
+    <string name="settings_format_bottoms_label">Hosen</string>
+    <string name="settings_format_bottoms_always">Immer</string>
+    <string name="settings_format_bottoms_if_garments">Wenn Kleidungsstücke</string>
+    <string name="settings_format_bottoms_never">Nie</string>
+    <string name="settings_format_rain_accessory_label">Regenutensil</string>
+    <string name="settings_format_rain_accessory_none">Aus</string>
+    <string name="settings_format_rain_accessory_umbrella">Regenschirm</string>
+
+    <!-- Fallback clothes rules — "If no rules match" section -->
+    <string name="settings_default_outfit_title">Wenn keine Regel passt</string>
+    <string name="settings_default_top_edit_title">Standard-Oberteil</string>
+    <string name="settings_default_bottom_edit_title">Standard-Hose</string>
+    <string name="settings_default_outfit_range_above">wenn die Temperatur über %1$s liegt</string>
+    <string name="settings_default_outfit_range_below">wenn die Temperatur unter %1$s liegt</string>
+    <string name="settings_default_outfit_range_between">wenn die Temperatur zwischen %1$s und %2$s liegt</string>
+    <string name="settings_default_outfit_range_never">nie</string>
+
+    <!-- Calendar settings — master switch + per-feature toggles -->
+    <string name="settings_calendar_master">Meinen Kalender verwenden</string>
+    <string name="settings_calendar_master_description">Erlaubt ClothesCast, deine Kalender zu lesen, um Vorhersagen und Outfits zu personalisieren. Nichts verlässt das Gerät.</string>
+    <string name="settings_calendar_features_title">Persönliche Kalender</string>
+    <string name="settings_calendar_evening_tie_ins">Abendliche Verknüpfungen</string>
+    <string name="settings_calendar_evening_tie_ins_description">Wenn du abends ausgehst, sagt dir die Morgenvorhersage, ob du etwas mitnehmen solltest.</string>
+    <string name="settings_calendar_birthdays_description">Verwende besondere Farben und Nachrichten für Geburtstage in deinen Kalendern.</string>
+    <string name="settings_calendar_public_holidays_description">Verwende besondere Farben und Nachrichten für Feiertage in deinen Kalendern.</string>
+    <string name="settings_calendar_open_system_settings">Systemeinstellungen öffnen</string>
 </resources>

--- a/app/src/main/res/values-de-rCH/strings.xml
+++ b/app/src/main/res/values-de-rCH/strings.xml
@@ -634,4 +634,85 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="cast_error_unknown">Übertragung fehlgeschlagen.</string>
     <string name="settings_calendar_birthdays">Kalender-Geburtstage</string>
     <string name="settings_calendar_public_holidays">Kalender-Feiertage</string>
+
+    <!-- Settings strings added in 2026-05: Smart Home, Developer, Format, Calendar, Schedule, Default outfit. -->
+
+    <!-- Settings root labels — Developer, Format -->
+    <string name="settings_root_developer">Entwickler</string>
+    <string name="settings_root_developer_subtitle">Tests und Fehlersuche</string>
+    <string name="settings_root_format">Format</string>
+    <string name="settings_root_format_subtitle">Wortwahl und Ausführlichkeit</string>
+
+    <!-- Developer settings page -->
+    <string name="settings_developer_preview_day_title">Tag vorab anzeigen</string>
+    <string name="settings_developer_preview_day_subtitle">Outfit, Banner und Stimme für ein beliebiges Datum mit einem festen Beispiel bei mildem Wetter.</string>
+    <string name="settings_developer_pick_date">Datum wählen</string>
+    <string name="settings_developer_today">Heute</string>
+    <string name="settings_developer_no_theme">Kein Feiertagsthema für diesen Tag.</string>
+    <string name="settings_developer_resolved_label">Aufgelöst: %1$s</string>
+    <string name="settings_developer_speak">Sprechen</string>
+
+    <!-- Smart Home — additional keys -->
+    <string name="settings_smart_home_cast_label">Vorhersage an Smart Display senden</string>
+    <string name="settings_smart_home_cast_last_published">Zuletzt veröffentlicht %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched">Zuletzt abgerufen %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched_never">Das Display hat noch keinen ClothesCast abgerufen</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_title">Sprachausgabe am Natel überspringen</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_description">Doppelte Ansagen zu Hause vermeiden.</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_title">Sprachausgabe am Natel überspringen</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_description">Doppelte Ansagen zu Hause vermeiden.</string>
+    <string name="settings_smart_home_mqtt_topic_hint">%1$s/now/text, %1$s/now/audio usw.</string>
+
+    <!-- Schedule settings — Daily ClothesCast -->
+    <string name="settings_schedule_enabled">Täglicher ClothesCast</string>
+    <string name="settings_delivery_notification">Benachrichtigen</string>
+    <string name="settings_delivery_tts">Sprechen</string>
+
+    <!-- Clothes-mention picker on Format / Schedule -->
+    <string name="settings_clothes_mention_label">Kleidung</string>
+    <string name="settings_clothes_mention_always">Immer</string>
+    <string name="settings_clothes_mention_if_changed">Bei Änderung</string>
+    <string name="settings_clothes_mention_never">Nie</string>
+
+    <!-- Format settings page -->
+    <string name="settings_format_preview_example_title">Beispiel</string>
+    <string name="settings_format_preview_current_title">Aktuelle Vorhersage</string>
+    <string name="settings_format_preview_current_empty">Noch keine Vorhersage — schau nach deinem nächsten ClothesCast wieder vorbei.</string>
+    <string name="settings_format_what_to_say">Was gesagt wird</string>
+    <string name="settings_format_range_label">Temperaturbereich</string>
+    <string name="settings_format_range_none">Keiner</string>
+    <string name="settings_format_range_degrees">Grad</string>
+    <string name="settings_format_range_bands">Stufen</string>
+    <string name="settings_format_change_label">Temperaturänderung</string>
+    <string name="settings_format_change_off">Aus</string>
+    <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_clothes_label">Kleidungs-Formulierung</string>
+    <string name="settings_format_clothes_items">Kleidungsstücke</string>
+    <string name="settings_format_clothes_layer_count">Anzahl der Schichten</string>
+    <string name="settings_format_bottoms_label">Hosen</string>
+    <string name="settings_format_bottoms_always">Immer</string>
+    <string name="settings_format_bottoms_if_garments">Wenn Kleidungsstücke</string>
+    <string name="settings_format_bottoms_never">Nie</string>
+    <string name="settings_format_rain_accessory_label">Regenutensil</string>
+    <string name="settings_format_rain_accessory_none">Aus</string>
+    <string name="settings_format_rain_accessory_umbrella">Regenschirm</string>
+
+    <!-- Fallback clothes rules — "If no rules match" section -->
+    <string name="settings_default_outfit_title">Wenn keine Regel passt</string>
+    <string name="settings_default_top_edit_title">Standard-Oberteil</string>
+    <string name="settings_default_bottom_edit_title">Standard-Hose</string>
+    <string name="settings_default_outfit_range_above">wenn die Temperatur über %1$s liegt</string>
+    <string name="settings_default_outfit_range_below">wenn die Temperatur unter %1$s liegt</string>
+    <string name="settings_default_outfit_range_between">wenn die Temperatur zwischen %1$s und %2$s liegt</string>
+    <string name="settings_default_outfit_range_never">nie</string>
+
+    <!-- Calendar settings — master switch + per-feature toggles -->
+    <string name="settings_calendar_master">Meinen Kalender verwenden</string>
+    <string name="settings_calendar_master_description">Erlaubt ClothesCast, deine Kalender zu lesen, um Vorhersagen und Outfits zu personalisieren. Nichts verlässt das Gerät.</string>
+    <string name="settings_calendar_features_title">Persönliche Kalender</string>
+    <string name="settings_calendar_evening_tie_ins">Abendliche Verknüpfungen</string>
+    <string name="settings_calendar_evening_tie_ins_description">Wenn du abends ausgehst, sagt dir die Morgenvorhersage, ob du etwas mitnehmen solltest.</string>
+    <string name="settings_calendar_birthdays_description">Verwende besondere Farben und Nachrichten für Geburtstage in deinen Kalendern.</string>
+    <string name="settings_calendar_public_holidays_description">Verwende besondere Farben und Nachrichten für Feiertage in deinen Kalendern.</string>
+    <string name="settings_calendar_open_system_settings">Systemeinstellungen öffnen</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1050,4 +1050,84 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="cast_error_unknown">Übertragung fehlgeschlagen.</string>
     <string name="settings_calendar_birthdays">Kalender-Geburtstage</string>
     <string name="settings_calendar_public_holidays">Kalender-Feiertage</string>
+
+    <!-- Settings strings added in 2026-05: Smart Home, Developer, Format, Calendar, Schedule, Default outfit. -->
+
+    <!-- Settings root labels — Developer, Format -->
+    <string name="settings_root_developer">Entwickler</string>
+    <string name="settings_root_developer_subtitle">Tests und Fehlersuche</string>
+    <string name="settings_root_format">Format</string>
+
+    <!-- Developer settings page -->
+    <string name="settings_developer_preview_day_title">Tag vorab anzeigen</string>
+    <string name="settings_developer_preview_day_subtitle">Outfit, Banner und Stimme für ein beliebiges Datum mit einem festen Beispiel bei mildem Wetter.</string>
+    <string name="settings_developer_pick_date">Datum wählen</string>
+    <string name="settings_developer_today">Heute</string>
+    <string name="settings_developer_no_theme">Kein Feiertagsthema für diesen Tag.</string>
+    <string name="settings_developer_resolved_label">Aufgelöst: %1$s</string>
+    <string name="settings_developer_speak">Sprechen</string>
+
+    <!-- Smart Home — additional keys -->
+    <string name="settings_smart_home_cast_label">Vorhersage an Smart Display senden</string>
+    <string name="settings_smart_home_cast_last_published">Zuletzt veröffentlicht %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched">Zuletzt abgerufen %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched_never">Das Display hat noch keinen ClothesCast abgerufen</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_title">Sprachausgabe am Telefon überspringen</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_description">Doppelte Ansagen zu Hause vermeiden.</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_title">Sprachausgabe am Telefon überspringen</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_description">Doppelte Ansagen zu Hause vermeiden.</string>
+    <string name="settings_smart_home_mqtt_topic_hint">%1$s/now/text, %1$s/now/audio usw.</string>
+
+    <!-- Schedule settings — Daily ClothesCast -->
+    <string name="settings_schedule_enabled">Täglicher ClothesCast</string>
+    <string name="settings_delivery_notification">Benachrichtigen</string>
+    <string name="settings_delivery_tts">Sprechen</string>
+
+    <!-- Clothes-mention picker on Format / Schedule -->
+    <string name="settings_clothes_mention_label">Kleidung</string>
+    <string name="settings_clothes_mention_always">Immer</string>
+    <string name="settings_clothes_mention_if_changed">Bei Änderung</string>
+    <string name="settings_clothes_mention_never">Nie</string>
+
+    <!-- Format settings page -->
+    <string name="settings_format_preview_example_title">Beispiel</string>
+    <string name="settings_format_preview_current_title">Aktuelle Vorhersage</string>
+    <string name="settings_format_preview_current_empty">Noch keine Vorhersage — schau nach deinem nächsten ClothesCast wieder vorbei.</string>
+    <string name="settings_format_what_to_say">Was gesagt wird</string>
+    <string name="settings_format_range_label">Temperaturbereich</string>
+    <string name="settings_format_range_none">Keiner</string>
+    <string name="settings_format_range_degrees">Grad</string>
+    <string name="settings_format_range_bands">Stufen</string>
+    <string name="settings_format_change_label">Temperaturänderung</string>
+    <string name="settings_format_change_off">Aus</string>
+    <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_clothes_label">Kleidungs-Formulierung</string>
+    <string name="settings_format_clothes_items">Kleidungsstücke</string>
+    <string name="settings_format_clothes_layer_count">Anzahl der Schichten</string>
+    <string name="settings_format_bottoms_label">Hosen</string>
+    <string name="settings_format_bottoms_always">Immer</string>
+    <string name="settings_format_bottoms_if_garments">Wenn Kleidungsstücke</string>
+    <string name="settings_format_bottoms_never">Nie</string>
+    <string name="settings_format_rain_accessory_label">Regenutensil</string>
+    <string name="settings_format_rain_accessory_none">Aus</string>
+    <string name="settings_format_rain_accessory_umbrella">Regenschirm</string>
+
+    <!-- Fallback clothes rules — "If no rules match" section -->
+    <string name="settings_default_outfit_title">Wenn keine Regel passt</string>
+    <string name="settings_default_top_edit_title">Standard-Oberteil</string>
+    <string name="settings_default_bottom_edit_title">Standard-Hose</string>
+    <string name="settings_default_outfit_range_above">wenn die Temperatur über %1$s liegt</string>
+    <string name="settings_default_outfit_range_below">wenn die Temperatur unter %1$s liegt</string>
+    <string name="settings_default_outfit_range_between">wenn die Temperatur zwischen %1$s und %2$s liegt</string>
+    <string name="settings_default_outfit_range_never">nie</string>
+
+    <!-- Calendar settings — master switch + per-feature toggles -->
+    <string name="settings_calendar_master">Meinen Kalender verwenden</string>
+    <string name="settings_calendar_master_description">Erlaubt ClothesCast, deine Kalender zu lesen, um Vorhersagen und Outfits zu personalisieren. Nichts verlässt das Gerät.</string>
+    <string name="settings_calendar_features_title">Persönliche Kalender</string>
+    <string name="settings_calendar_evening_tie_ins">Abendliche Verknüpfungen</string>
+    <string name="settings_calendar_evening_tie_ins_description">Wenn du abends ausgehst, sagt dir die Morgenvorhersage, ob du etwas mitnehmen solltest.</string>
+    <string name="settings_calendar_birthdays_description">Verwende besondere Farben und Nachrichten für Geburtstage in deinen Kalendern.</string>
+    <string name="settings_calendar_public_holidays_description">Verwende besondere Farben und Nachrichten für Feiertage in deinen Kalendern.</string>
+    <string name="settings_calendar_open_system_settings">Systemeinstellungen öffnen</string>
 </resources>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -1017,4 +1017,83 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="cast_error_unknown">Η μετάδοση απέτυχε.</string>
     <string name="settings_calendar_birthdays">Γενέθλια ημερολογίου</string>
     <string name="settings_calendar_public_holidays">Αργίες ημερολογίου</string>
+
+    <!-- Settings strings added in 2026-05: Smart Home, Developer, Format, Calendar, Schedule, Default outfit. -->
+    <!-- Settings root labels — Developer, Format. -->
+    <string name="settings_root_developer">Προγραμματιστής</string>
+    <string name="settings_root_developer_subtitle">Δοκιμή και αποσφαλμάτωση</string>
+    <string name="settings_root_format">Μορφή</string>
+
+    <!-- Developer settings page (Settings → Developer → Preview a day) -->
+    <string name="settings_developer_preview_day_title">Προεπισκόπηση ημέρας</string>
+    <string name="settings_developer_preview_day_subtitle">Στολή, banner και φωνή για οποιαδήποτε ημερομηνία, χρησιμοποιώντας σταθερό δείγμα ήπιου καιρού.</string>
+    <string name="settings_developer_pick_date">Επίλεξε ημερομηνία</string>
+    <string name="settings_developer_today">Σήμερα</string>
+    <string name="settings_developer_no_theme">Δεν υπάρχει εορταστικό θέμα για αυτήν την ημέρα.</string>
+    <string name="settings_developer_resolved_label">Αναλύθηκε: %1$s</string>
+    <string name="settings_developer_speak">Εκφώνηση</string>
+
+    <!-- Smart Home — newer keys. -->
+    <string name="settings_smart_home_cast_label">Στείλε την πρόγνωση σε έξυπνη οθόνη</string>
+    <string name="settings_smart_home_cast_last_published">Τελευταία δημοσίευση %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched">Τελευταία ανάκτηση %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched_never">Η οθόνη δεν έχει ανακτήσει ακόμα ClothesCast</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_title">Παράλειψη εκφώνησης στο τηλέφωνο</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_description">Απόφυγε διπλές ανακοινώσεις στο σπίτι.</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_title">Παράλειψη εκφώνησης στο τηλέφωνο</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_description">Απόφυγε διπλές ανακοινώσεις στο σπίτι.</string>
+    <string name="settings_smart_home_mqtt_topic_hint">%1$s/now/text, %1$s/now/audio, κ.λπ.</string>
+
+    <!-- Schedule settings — Daily ClothesCast -->
+    <string name="settings_schedule_enabled">Καθημερινό ClothesCast</string>
+    <string name="settings_delivery_notification">Ειδοποίηση</string>
+    <string name="settings_delivery_tts">Εκφώνηση</string>
+
+    <!-- Clothes-mention picker on Format / Schedule -->
+    <string name="settings_clothes_mention_label">Ρούχα</string>
+    <string name="settings_clothes_mention_always">Πάντα</string>
+    <string name="settings_clothes_mention_if_changed">Αλλαγή</string>
+    <string name="settings_clothes_mention_never">Ποτέ</string>
+
+    <!-- Format settings page -->
+    <string name="settings_format_preview_example_title">Παράδειγμα</string>
+    <string name="settings_format_preview_current_title">Τρέχουσα πρόγνωση</string>
+    <string name="settings_format_preview_current_empty">Δεν υπάρχει ακόμα πρόγνωση — έλεγξε ξανά μετά το επόμενο ClothesCast σου.</string>
+    <string name="settings_format_what_to_say">Τι να πει</string>
+    <string name="settings_format_range_label">Εύρος θερμοκρασίας</string>
+    <string name="settings_format_range_none">Κανένα</string>
+    <string name="settings_format_range_degrees">Βαθμοί</string>
+    <string name="settings_format_range_bands">Ζώνες</string>
+    <string name="settings_format_change_label">Μεταβολή θερμοκρασίας</string>
+    <string name="settings_format_change_off">Ανενεργό</string>
+    <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_clothes_label">Διατύπωση ρούχων</string>
+    <string name="settings_format_clothes_items">Είδη ρούχων</string>
+    <string name="settings_format_clothes_layer_count">Αριθμός στρώσεων</string>
+    <string name="settings_format_bottoms_label">Κάτω μέρος</string>
+    <string name="settings_format_bottoms_always">Πάντα</string>
+    <string name="settings_format_bottoms_if_garments">Αν υπάρχουν είδη</string>
+    <string name="settings_format_bottoms_never">Ποτέ</string>
+    <string name="settings_format_rain_accessory_label">Αξεσουάρ για βροχή</string>
+    <string name="settings_format_rain_accessory_none">Ανενεργό</string>
+    <string name="settings_format_rain_accessory_umbrella">Ομπρέλα</string>
+
+    <!-- Fallback clothes rules — "If no rules match" section -->
+    <string name="settings_default_outfit_title">Αν δεν ταιριάζει κανένας κανόνας</string>
+    <string name="settings_default_top_edit_title">Προεπιλεγμένο πάνω μέρος</string>
+    <string name="settings_default_bottom_edit_title">Προεπιλεγμένο κάτω μέρος</string>
+    <string name="settings_default_outfit_range_above">όταν η θερμοκρασία είναι πάνω από %1$s</string>
+    <string name="settings_default_outfit_range_below">όταν η θερμοκρασία είναι κάτω από %1$s</string>
+    <string name="settings_default_outfit_range_between">όταν η θερμοκρασία είναι μεταξύ %1$s και %2$s</string>
+    <string name="settings_default_outfit_range_never">ποτέ</string>
+
+    <!-- Calendar settings — master switch + per-feature toggles -->
+    <string name="settings_calendar_master">Χρήση του ημερολογίου μου</string>
+    <string name="settings_calendar_master_description">Άφησε το ClothesCast να διαβάζει τα ημερολόγιά σου για να προσαρμόζει προγνώσεις και στολές. Τίποτα δεν φεύγει από τη συσκευή.</string>
+    <string name="settings_calendar_features_title">Προσωπικά ημερολόγια</string>
+    <string name="settings_calendar_evening_tie_ins">Βραδινές συνδέσεις</string>
+    <string name="settings_calendar_evening_tie_ins_description">Αν βγαίνεις το βράδυ, η πρωινή πρόγνωση σου λέει αν πρέπει να πάρεις κάτι επιπλέον.</string>
+    <string name="settings_calendar_birthdays_description">Χρήση ειδικών χρωμάτων και μηνυμάτων για γενέθλια στα ημερολόγιά σου.</string>
+    <string name="settings_calendar_public_holidays_description">Χρήση ειδικών χρωμάτων και μηνυμάτων για επίσημες αργίες στα ημερολόγιά σου.</string>
+    <string name="settings_calendar_open_system_settings">Άνοιξε τις ρυθμίσεις συστήματος</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1022,4 +1022,84 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="cast_error_unknown">Emisión fallida.</string>
     <string name="settings_calendar_birthdays">Cumpleaños del calendario</string>
     <string name="settings_calendar_public_holidays">Festivos del calendario</string>
+
+    <!-- Settings strings added in 2026-05: Smart Home, Developer, Format, Calendar, Schedule, Default outfit. -->
+
+    <!-- Settings root labels — Developer, Format -->
+    <string name="settings_root_developer">Desarrollador</string>
+    <string name="settings_root_developer_subtitle">Pruebas y depuración</string>
+    <string name="settings_root_format">Formato</string>
+
+    <!-- Developer settings page -->
+    <string name="settings_developer_preview_day_title">Previsualizar un día</string>
+    <string name="settings_developer_preview_day_subtitle">Atuendo, banner y voz para cualquier fecha, usando una muestra fija de tiempo templado.</string>
+    <string name="settings_developer_pick_date">Elige una fecha</string>
+    <string name="settings_developer_today">Hoy</string>
+    <string name="settings_developer_no_theme">Sin tema festivo para este día.</string>
+    <string name="settings_developer_resolved_label">Resuelto: %1$s</string>
+    <string name="settings_developer_speak">Leer en voz alta</string>
+
+    <!-- Smart Home — newer keys -->
+    <string name="settings_smart_home_cast_label">Enviar previsión a la pantalla inteligente</string>
+    <string name="settings_smart_home_cast_last_published">Última publicación %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched">Última obtención %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched_never">La pantalla aún no ha obtenido ningún ClothesCast</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_title">Omitir lectura en el teléfono</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_description">Evita anuncios duplicados en casa.</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_title">Omitir lectura en el teléfono</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_description">Evita anuncios duplicados en casa.</string>
+    <string name="settings_smart_home_mqtt_topic_hint">%1$s/now/text, %1$s/now/audio, etc.</string>
+
+    <!-- Schedule settings -->
+    <string name="settings_schedule_enabled">ClothesCast diario</string>
+    <string name="settings_delivery_notification">Notificar</string>
+    <string name="settings_delivery_tts">Leer en voz alta</string>
+
+    <!-- Clothes-mention picker on Format / Schedule -->
+    <string name="settings_clothes_mention_label">Ropa</string>
+    <string name="settings_clothes_mention_always">Siempre</string>
+    <string name="settings_clothes_mention_if_changed">Cambio</string>
+    <string name="settings_clothes_mention_never">Nunca</string>
+
+    <!-- Format settings page -->
+    <string name="settings_format_preview_example_title">Ejemplo</string>
+    <string name="settings_format_preview_current_title">Previsión actual</string>
+    <string name="settings_format_preview_current_empty">Aún no hay previsión — vuelve después de tu próximo ClothesCast.</string>
+    <string name="settings_format_what_to_say">Qué decir</string>
+    <string name="settings_format_range_label">Rango de temperatura</string>
+    <string name="settings_format_range_none">Ninguno</string>
+    <string name="settings_format_range_degrees">Grados</string>
+    <string name="settings_format_range_bands">Categorías</string>
+    <string name="settings_format_change_label">Variación de temperatura</string>
+    <string name="settings_format_change_off">Desactivado</string>
+    <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_clothes_label">Redacción de la ropa</string>
+    <string name="settings_format_clothes_items">Prendas</string>
+    <string name="settings_format_clothes_layer_count">Número de capas</string>
+    <string name="settings_format_bottoms_label">Pantalón</string>
+    <string name="settings_format_bottoms_always">Siempre</string>
+    <string name="settings_format_bottoms_if_garments">Si hay prendas</string>
+    <string name="settings_format_bottoms_never">Nunca</string>
+    <string name="settings_format_rain_accessory_label">Accesorio para lluvia</string>
+    <string name="settings_format_rain_accessory_none">Desactivado</string>
+    <string name="settings_format_rain_accessory_umbrella">Paraguas</string>
+
+    <!-- Fallback clothes rules — "If no rules match" section -->
+    <string name="settings_default_outfit_title">Si no coincide ninguna regla</string>
+    <string name="settings_default_top_edit_title">Prenda superior predeterminada</string>
+    <string name="settings_default_bottom_edit_title">Pantalón predeterminado</string>
+    <string name="settings_default_outfit_range_above">cuando la temperatura sea superior a %1$s</string>
+    <string name="settings_default_outfit_range_below">cuando la temperatura sea inferior a %1$s</string>
+    <string name="settings_default_outfit_range_between">cuando la temperatura esté entre %1$s y %2$s</string>
+    <string name="settings_default_outfit_range_never">nunca</string>
+
+    <!-- Calendar settings — master switch + per-feature toggles -->
+    <string name="settings_calendar_master">Usar mi calendario</string>
+    <string name="settings_calendar_master_description">Permite que ClothesCast lea tus calendarios para personalizar previsiones y atuendos. Nada sale del dispositivo.</string>
+    <string name="settings_calendar_features_title">Calendarios personales</string>
+    <string name="settings_calendar_evening_tie_ins">Referencias a la tarde</string>
+    <string name="settings_calendar_evening_tie_ins_description">Si sales por la tarde, la previsión de la mañana te dice si necesitas llevar algo extra.</string>
+    <string name="settings_calendar_birthdays_description">Usa colores y mensajes especiales para los cumpleaños de tus calendarios.</string>
+    <string name="settings_calendar_public_holidays_description">Usa colores y mensajes especiales para los festivos de tus calendarios.</string>
+    <string name="settings_calendar_open_system_settings">Abrir ajustes del sistema</string>
 </resources>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -839,4 +839,83 @@ Tone is informal "sina"-form throughout ("Pane … selga", "Võta … kaasa",
     <string name="holiday_banner_st_andrews_day">Head Püha Andrease päeva</string>
     <string name="settings_calendar_birthdays">Kalendri sünnipäevad</string>
     <string name="settings_calendar_public_holidays">Kalendripühad</string>
+
+    <!-- Settings strings added in 2026-05: Smart Home, Developer, Format, Calendar, Schedule, Default outfit. -->
+    <!-- Settings root labels -->
+    <string name="settings_root_developer">Arendaja</string>
+    <string name="settings_root_developer_subtitle">Testimine ja silumine</string>
+    <string name="settings_root_format">Vorming</string>
+
+    <!-- Developer settings page -->
+    <string name="settings_developer_preview_day_title">Päeva eelvaade</string>
+    <string name="settings_developer_preview_day_subtitle">Riietus, bänner ja hääl mis tahes kuupäevale, kasutades fikseeritud mahedat ilmanäidet.</string>
+    <string name="settings_developer_pick_date">Vali kuupäev</string>
+    <string name="settings_developer_today">Täna</string>
+    <string name="settings_developer_no_theme">Selle päeva jaoks pühadeteemat pole.</string>
+    <string name="settings_developer_resolved_label">Lahendatud: %1$s</string>
+    <string name="settings_developer_speak">Loe ette</string>
+
+    <!-- Smart Home — newer keys -->
+    <string name="settings_smart_home_cast_label">Saada prognoos nutiekraanile</string>
+    <string name="settings_smart_home_cast_last_published">Viimane avaldamine %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched">Viimane allalaadimine %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched_never">Ekraan pole veel ClothesCast\'i alla laadinud</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_title">Jäta telefoni hääl vahele</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_description">Väldi kodus topelt teateid.</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_title">Jäta telefoni hääl vahele</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_description">Väldi kodus topelt teateid.</string>
+    <string name="settings_smart_home_mqtt_topic_hint">%1$s/now/text, %1$s/now/audio, jne</string>
+
+    <!-- Schedule settings -->
+    <string name="settings_schedule_enabled">Igapäevane ClothesCast</string>
+    <string name="settings_delivery_notification">Teavita</string>
+    <string name="settings_delivery_tts">Loe ette</string>
+
+    <!-- Clothes-mention picker on Format / Schedule -->
+    <string name="settings_clothes_mention_label">Riided</string>
+    <string name="settings_clothes_mention_always">Alati</string>
+    <string name="settings_clothes_mention_if_changed">Muutuse korral</string>
+    <string name="settings_clothes_mention_never">Mitte kunagi</string>
+
+    <!-- Format settings page -->
+    <string name="settings_format_preview_example_title">Näide</string>
+    <string name="settings_format_preview_current_title">Praegune prognoos</string>
+    <string name="settings_format_preview_current_empty">Prognoosi veel pole — tule tagasi pärast järgmist ClothesCast\'i.</string>
+    <string name="settings_format_what_to_say">Mida öelda</string>
+    <string name="settings_format_range_label">Temperatuurivahemik</string>
+    <string name="settings_format_range_none">Puudub</string>
+    <string name="settings_format_range_degrees">Kraadid</string>
+    <string name="settings_format_range_bands">Vahemikud</string>
+    <string name="settings_format_change_label">Temperatuuri muutus</string>
+    <string name="settings_format_change_off">Väljas</string>
+    <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_clothes_label">Riietuse sõnastus</string>
+    <string name="settings_format_clothes_items">Rõivad</string>
+    <string name="settings_format_clothes_layer_count">Kihtide arv</string>
+    <string name="settings_format_bottoms_label">Alaosa</string>
+    <string name="settings_format_bottoms_always">Alati</string>
+    <string name="settings_format_bottoms_if_garments">Kui on ülaosa</string>
+    <string name="settings_format_bottoms_never">Mitte kunagi</string>
+    <string name="settings_format_rain_accessory_label">Vihmatarvik</string>
+    <string name="settings_format_rain_accessory_none">Väljas</string>
+    <string name="settings_format_rain_accessory_umbrella">Vihmavari</string>
+
+    <!-- Fallback clothes rules — "If no rules match" section -->
+    <string name="settings_default_outfit_title">Kui ükski reegel ei sobi</string>
+    <string name="settings_default_top_edit_title">Vaikimisi ülaosa</string>
+    <string name="settings_default_bottom_edit_title">Vaikimisi alaosa</string>
+    <string name="settings_default_outfit_range_above">kui temperatuur on üle %1$s</string>
+    <string name="settings_default_outfit_range_below">kui temperatuur on alla %1$s</string>
+    <string name="settings_default_outfit_range_between">kui temperatuur on %1$s ja %2$s vahel</string>
+    <string name="settings_default_outfit_range_never">mitte kunagi</string>
+
+    <!-- Calendar settings — master switch + per-feature toggles -->
+    <string name="settings_calendar_master">Kasuta minu kalendrit</string>
+    <string name="settings_calendar_master_description">Luba ClothesCast\'il lugeda sinu kalendreid, et kohandada prognoose ja riietust. Midagi ei lahku seadmest.</string>
+    <string name="settings_calendar_features_title">Isiklikud kalendrid</string>
+    <string name="settings_calendar_evening_tie_ins">Õhtused sidemed</string>
+    <string name="settings_calendar_evening_tie_ins_description">Kui sa lähed õhtul välja, ütleb hommikuprognoos sulle, kas pead midagi lisaks kaasa võtma.</string>
+    <string name="settings_calendar_birthdays_description">Eripärased värvid ja sõnumid sinu kalendrite sünnipäevadele.</string>
+    <string name="settings_calendar_public_holidays_description">Eripärased värvid ja sõnumid sinu kalendrite riigipühadele.</string>
+    <string name="settings_calendar_open_system_settings">Ava süsteemiseaded</string>
 </resources>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -887,4 +887,83 @@ Western Arabic numerals (0-9) are used for TTS compatibility.
     <string name="today_rationale_open_clothes_settings">تنظیمات لباس</string>
     <string name="settings_calendar_birthdays">تولدهای تقویم</string>
     <string name="settings_calendar_public_holidays">تعطیلات تقویم</string>
+
+    <!-- Settings strings added in 2026-05: Smart Home, Developer, Format, Calendar, Schedule, Default outfit. -->
+    <!-- Settings root labels — Smart Home, Developer, Format -->
+    <string name="settings_root_developer">توسعه‌دهنده</string>
+    <string name="settings_root_developer_subtitle">آزمایش و اشکال‌زدایی</string>
+    <string name="settings_root_format">قالب‌بندی</string>
+
+    <!-- Developer settings page (Settings → Developer → Preview a day) -->
+    <string name="settings_developer_preview_day_title">پیش‌نمایش یک روز</string>
+    <string name="settings_developer_preview_day_subtitle">لباس، بنر و صدا برای هر تاریخی، با استفاده از نمونه‌ای ثابت از هوای معتدل.</string>
+    <string name="settings_developer_pick_date">یک تاریخ انتخاب کنید</string>
+    <string name="settings_developer_today">امروز</string>
+    <string name="settings_developer_no_theme">هیچ تم تعطیلاتی برای این روز وجود ندارد.</string>
+    <string name="settings_developer_resolved_label">یافت شد: %1$s</string>
+    <string name="settings_developer_speak">پخش</string>
+
+    <!-- Smart Home — newer keys -->
+    <string name="settings_smart_home_cast_label">ارسال پیش‌بینی به نمایشگر هوشمند</string>
+    <string name="settings_smart_home_cast_last_published">آخرین انتشار %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched">آخرین دریافت %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched_never">نمایشگر هنوز ClothesCast دریافت نکرده است</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_title">صرف‌نظر از گفتار گوشی</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_description">از اعلان‌های تکراری در خانه جلوگیری کنید.</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_title">صرف‌نظر از گفتار گوشی</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_description">از اعلان‌های تکراری در خانه جلوگیری کنید.</string>
+    <string name="settings_smart_home_mqtt_topic_hint">%1$s/now/text، %1$s/now/audio و غیره</string>
+
+    <!-- Schedule settings -->
+    <string name="settings_schedule_enabled">ClothesCast روزانه</string>
+    <string name="settings_delivery_notification">اعلان</string>
+    <string name="settings_delivery_tts">خواندن</string>
+
+    <!-- Clothes-mention picker on Format / Schedule -->
+    <string name="settings_clothes_mention_label">لباس</string>
+    <string name="settings_clothes_mention_always">همیشه</string>
+    <string name="settings_clothes_mention_if_changed">هنگام تغییر</string>
+    <string name="settings_clothes_mention_never">هرگز</string>
+
+    <!-- Format settings page -->
+    <string name="settings_format_preview_example_title">مثال</string>
+    <string name="settings_format_preview_current_title">پیش‌بینی فعلی</string>
+    <string name="settings_format_preview_current_empty">هنوز پیش‌بینی وجود ندارد — پس از ClothesCast بعدی بررسی کنید.</string>
+    <string name="settings_format_what_to_say">چه گفته شود</string>
+    <string name="settings_format_range_label">محدوده دما</string>
+    <string name="settings_format_range_none">هیچ‌کدام</string>
+    <string name="settings_format_range_degrees">درجه</string>
+    <string name="settings_format_range_bands">طیف‌ها</string>
+    <string name="settings_format_change_label">تغییر دما</string>
+    <string name="settings_format_change_off">خاموش</string>
+    <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_clothes_label">عبارت لباس</string>
+    <string name="settings_format_clothes_items">قطعه‌ها</string>
+    <string name="settings_format_clothes_layer_count">تعداد لایه‌ها</string>
+    <string name="settings_format_bottoms_label">لباس‌های پایین‌تنه</string>
+    <string name="settings_format_bottoms_always">همیشه</string>
+    <string name="settings_format_bottoms_if_garments">اگر قطعه‌ای وجود داشت</string>
+    <string name="settings_format_bottoms_never">هرگز</string>
+    <string name="settings_format_rain_accessory_label">لوازم باران</string>
+    <string name="settings_format_rain_accessory_none">خاموش</string>
+    <string name="settings_format_rain_accessory_umbrella">چتر</string>
+
+    <!-- Fallback clothes rules — "If no rules match" -->
+    <string name="settings_default_outfit_title">اگر هیچ قانونی مطابقت نداشت</string>
+    <string name="settings_default_top_edit_title">بالاتنه پیش‌فرض</string>
+    <string name="settings_default_bottom_edit_title">پایین‌تنه پیش‌فرض</string>
+    <string name="settings_default_outfit_range_above">وقتی دما بالاتر از %1$s است</string>
+    <string name="settings_default_outfit_range_below">وقتی دما پایین‌تر از %1$s است</string>
+    <string name="settings_default_outfit_range_between">وقتی دما بین %1$s و %2$s است</string>
+    <string name="settings_default_outfit_range_never">هرگز</string>
+
+    <!-- Calendar settings — master switch + per-feature toggles -->
+    <string name="settings_calendar_master">از تقویم من استفاده کن</string>
+    <string name="settings_calendar_master_description">به ClothesCast اجازه دهید تقویم‌های شما را بخواند تا پیش‌بینی‌ها و لباس‌ها را شخصی‌سازی کند. هیچ چیز از دستگاه خارج نمی‌شود.</string>
+    <string name="settings_calendar_features_title">تقویم‌های شخصی</string>
+    <string name="settings_calendar_evening_tie_ins">پیوندهای عصرگاهی</string>
+    <string name="settings_calendar_evening_tie_ins_description">اگر در عصر بیرون می‌روید، پیش‌بینی صبحگاهی به شما می‌گوید که آیا چیز اضافه‌ای باید همراه ببرید.</string>
+    <string name="settings_calendar_birthdays_description">از رنگ‌ها و پیام‌های ویژه برای تولدها در تقویم‌های خود استفاده کنید.</string>
+    <string name="settings_calendar_public_holidays_description">از رنگ‌ها و پیام‌های ویژه برای تعطیلات رسمی در تقویم‌های خود استفاده کنید.</string>
+    <string name="settings_calendar_open_system_settings">باز کردن تنظیمات سیستم</string>
 </resources>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -904,4 +904,83 @@ displayed label localizes.
     <string name="holiday_banner_waitangi_day">Hyvää Waitangi-päivää</string>
     <string name="settings_calendar_birthdays">Kalenterin syntymäpäivät</string>
     <string name="settings_calendar_public_holidays">Kalenterin juhlapyhät</string>
+
+    <!-- Settings strings added in 2026-05: Smart Home, Developer, Format, Calendar, Schedule, Default outfit. -->
+    <!-- Settings root labels -->
+    <string name="settings_root_developer">Kehittäjä</string>
+    <string name="settings_root_developer_subtitle">Testaus ja virheenkorjaus</string>
+    <string name="settings_root_format">Muoto</string>
+
+    <!-- Developer settings page -->
+    <string name="settings_developer_preview_day_title">Esikatsele päivää</string>
+    <string name="settings_developer_preview_day_subtitle">Vaatteet, banneri ja ääni mille tahansa päivämäärän kohdalla kiinteällä leudon sään esimerkillä.</string>
+    <string name="settings_developer_pick_date">Valitse päivämäärä</string>
+    <string name="settings_developer_today">Tänään</string>
+    <string name="settings_developer_no_theme">Tälle päivälle ei ole juhlateemaa.</string>
+    <string name="settings_developer_resolved_label">Tulos: %1$s</string>
+    <string name="settings_developer_speak">Lue ääneen</string>
+
+    <!-- Smart Home — newer keys -->
+    <string name="settings_smart_home_cast_label">Lähetä ennuste älykkääseen näyttöön</string>
+    <string name="settings_smart_home_cast_last_published">Viimeisin julkaisu %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched">Viimeisin haku %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched_never">Näyttö ei ole vielä hakenut ClothesCastia</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_title">Ohita puhelimen puhe</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_description">Vältä päällekkäisiä ilmoituksia kotona.</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_title">Ohita puhelimen puhe</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_description">Vältä päällekkäisiä ilmoituksia kotona.</string>
+    <string name="settings_smart_home_mqtt_topic_hint">%1$s/now/text, %1$s/now/audio, jne.</string>
+
+    <!-- Schedule settings -->
+    <string name="settings_schedule_enabled">Päivittäinen ClothesCast</string>
+    <string name="settings_delivery_notification">Ilmoita</string>
+    <string name="settings_delivery_tts">Lue ääneen</string>
+
+    <!-- Clothes-mention picker on Format / Schedule -->
+    <string name="settings_clothes_mention_label">Vaatteet</string>
+    <string name="settings_clothes_mention_always">Aina</string>
+    <string name="settings_clothes_mention_if_changed">Kun muuttuu</string>
+    <string name="settings_clothes_mention_never">Ei koskaan</string>
+
+    <!-- Format settings page -->
+    <string name="settings_format_preview_example_title">Esimerkki</string>
+    <string name="settings_format_preview_current_title">Nykyinen ennuste</string>
+    <string name="settings_format_preview_current_empty">Ei vielä ennustetta — tarkista uudelleen seuraavan ClothesCastin jälkeen.</string>
+    <string name="settings_format_what_to_say">Mitä sanoa</string>
+    <string name="settings_format_range_label">Lämpötila-alue</string>
+    <string name="settings_format_range_none">Ei mitään</string>
+    <string name="settings_format_range_degrees">Asteet</string>
+    <string name="settings_format_range_bands">Vyöhykkeet</string>
+    <string name="settings_format_change_label">Lämpötilan muutos</string>
+    <string name="settings_format_change_off">Pois</string>
+    <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_clothes_label">Vaatteiden sanamuoto</string>
+    <string name="settings_format_clothes_items">Vaatekappaleet</string>
+    <string name="settings_format_clothes_layer_count">Kerrosten määrä</string>
+    <string name="settings_format_bottoms_label">Alaosa</string>
+    <string name="settings_format_bottoms_always">Aina</string>
+    <string name="settings_format_bottoms_if_garments">Jos yläosa</string>
+    <string name="settings_format_bottoms_never">Ei koskaan</string>
+    <string name="settings_format_rain_accessory_label">Sadeasuste</string>
+    <string name="settings_format_rain_accessory_none">Pois</string>
+    <string name="settings_format_rain_accessory_umbrella">Sateenvarjo</string>
+
+    <!-- Fallback clothes rules — "If no rules match" section -->
+    <string name="settings_default_outfit_title">Kun mikään sääntö ei sovi</string>
+    <string name="settings_default_top_edit_title">Oletusyläosa</string>
+    <string name="settings_default_bottom_edit_title">Oletusalaosa</string>
+    <string name="settings_default_outfit_range_above">kun lämpötila on yli %1$s</string>
+    <string name="settings_default_outfit_range_below">kun lämpötila on alle %1$s</string>
+    <string name="settings_default_outfit_range_between">kun lämpötila on välillä %1$s – %2$s</string>
+    <string name="settings_default_outfit_range_never">ei koskaan</string>
+
+    <!-- Calendar settings — master switch + per-feature toggles -->
+    <string name="settings_calendar_master">Käytä kalenteriani</string>
+    <string name="settings_calendar_master_description">Anna ClothesCastin lukea kalenterisi ennusteiden ja vaatteiden räätälöintiä varten. Mikään ei poistu laitteelta.</string>
+    <string name="settings_calendar_features_title">Henkilökohtaiset kalenterit</string>
+    <string name="settings_calendar_evening_tie_ins">Iltatapahtumien sidonnat</string>
+    <string name="settings_calendar_evening_tie_ins_description">Jos lähdet illalla ulos, aamuennuste kertoo, tarvitsetko ottaa jotain ylimääräistä mukaan.</string>
+    <string name="settings_calendar_birthdays_description">Erityisiä värejä ja viestejä kalentereidesi syntymäpäiville.</string>
+    <string name="settings_calendar_public_holidays_description">Erityisiä värejä ja viestejä kalentereidesi virallisille juhlapyhille.</string>
+    <string name="settings_calendar_open_system_settings">Avaa järjestelmäasetukset</string>
 </resources>

--- a/app/src/main/res/values-fil/strings.xml
+++ b/app/src/main/res/values-fil/strings.xml
@@ -946,4 +946,83 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="today_rationale_open_clothes_settings">Mga setting ng damit</string>
     <string name="settings_calendar_birthdays">Mga Kaarawan sa Kalendaryo</string>
     <string name="settings_calendar_public_holidays">Mga Holiday sa Kalendaryo</string>
+
+    <!-- Settings strings added in 2026-05: Smart Home, Developer, Format, Calendar, Schedule, Default outfit. -->
+    <!-- Settings root labels -->
+    <string name="settings_root_developer">Developer</string>
+    <string name="settings_root_developer_subtitle">Pagsubok at Debugging</string>
+    <string name="settings_root_format">Format</string>
+
+    <!-- Developer settings page -->
+    <string name="settings_developer_preview_day_title">I-preview ang isang araw</string>
+    <string name="settings_developer_preview_day_subtitle">Outfit, banner, at boses para sa kahit anong petsa, gamit ang isang nakatakdang sample ng katamtamang panahon.</string>
+    <string name="settings_developer_pick_date">Pumili ng petsa</string>
+    <string name="settings_developer_today">Ngayon</string>
+    <string name="settings_developer_no_theme">Walang holiday theme para sa araw na ito.</string>
+    <string name="settings_developer_resolved_label">Naresolba: %1$s</string>
+    <string name="settings_developer_speak">Bigkasin</string>
+
+    <!-- Smart Home additional keys -->
+    <string name="settings_smart_home_cast_label">Ipadala ang forecast sa smart display</string>
+    <string name="settings_smart_home_cast_last_published">Huling na-publish %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched">Huling kinuha %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched_never">Hindi pa kumukuha ng ClothesCast ang display</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_title">Laktawan ang pagbigkas sa telepono</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_description">Iwasan ang dobleng anunsyo sa bahay.</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_title">Laktawan ang pagbigkas sa telepono</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_description">Iwasan ang dobleng anunsyo sa bahay.</string>
+    <string name="settings_smart_home_mqtt_topic_hint">%1$s/now/text, %1$s/now/audio, atbp.</string>
+
+    <!-- Schedule settings — Daily ClothesCast -->
+    <string name="settings_schedule_enabled">Pang-araw na ClothesCast</string>
+    <string name="settings_delivery_notification">Mag-abiso</string>
+    <string name="settings_delivery_tts">Bigkasin</string>
+
+    <!-- Clothes-mention picker -->
+    <string name="settings_clothes_mention_label">Damit</string>
+    <string name="settings_clothes_mention_always">Palagi</string>
+    <string name="settings_clothes_mention_if_changed">Pagbabago</string>
+    <string name="settings_clothes_mention_never">Hindi kailanman</string>
+
+    <!-- Format settings page -->
+    <string name="settings_format_preview_example_title">Halimbawa</string>
+    <string name="settings_format_preview_current_title">Kasalukuyang forecast</string>
+    <string name="settings_format_preview_current_empty">Wala pang forecast — bumalik pagkatapos ng susunod mong ClothesCast.</string>
+    <string name="settings_format_what_to_say">Ano ang sasabihin</string>
+    <string name="settings_format_range_label">Saklaw ng temperatura</string>
+    <string name="settings_format_range_none">Wala</string>
+    <string name="settings_format_range_degrees">Mga degree</string>
+    <string name="settings_format_range_bands">Mga banda</string>
+    <string name="settings_format_change_label">Pagbabago ng temperatura</string>
+    <string name="settings_format_change_off">Naka-off</string>
+    <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_clothes_label">Pananalita sa damit</string>
+    <string name="settings_format_clothes_items">Mga damit</string>
+    <string name="settings_format_clothes_layer_count">Bilang ng layer</string>
+    <string name="settings_format_bottoms_label">Pantalon</string>
+    <string name="settings_format_bottoms_always">Palagi</string>
+    <string name="settings_format_bottoms_if_garments">Kung may damit</string>
+    <string name="settings_format_bottoms_never">Hindi kailanman</string>
+    <string name="settings_format_rain_accessory_label">Aksesorya sa ulan</string>
+    <string name="settings_format_rain_accessory_none">Naka-off</string>
+    <string name="settings_format_rain_accessory_umbrella">Payong</string>
+
+    <!-- Fallback clothes rules — "If no rules match" -->
+    <string name="settings_default_outfit_title">Kung walang panuntunang tumutugma</string>
+    <string name="settings_default_top_edit_title">Default na pang-itaas</string>
+    <string name="settings_default_bottom_edit_title">Default na pantalon</string>
+    <string name="settings_default_outfit_range_above">kapag ang temperatura ay higit sa %1$s</string>
+    <string name="settings_default_outfit_range_below">kapag ang temperatura ay mas mababa sa %1$s</string>
+    <string name="settings_default_outfit_range_between">kapag ang temperatura ay nasa pagitan ng %1$s at %2$s</string>
+    <string name="settings_default_outfit_range_never">hindi kailanman</string>
+
+    <!-- Calendar settings — master switch + per-feature toggles -->
+    <string name="settings_calendar_master">Gamitin ang aking kalendaryo</string>
+    <string name="settings_calendar_master_description">Payagan ang ClothesCast na basahin ang iyong mga kalendaryo upang ipersonalisa ang mga forecast at outfit. Walang lumalabas sa device.</string>
+    <string name="settings_calendar_features_title">Mga personal na kalendaryo</string>
+    <string name="settings_calendar_evening_tie_ins">Pagdurugtong sa gabi</string>
+    <string name="settings_calendar_evening_tie_ins_description">Kung lumalabas ka sa gabi, sasabihin ng forecast sa umaga kung kailangan mong magdala ng anumang dagdag.</string>
+    <string name="settings_calendar_birthdays_description">Gumamit ng mga espesyal na kulay at mensahe para sa mga kaarawan sa iyong mga kalendaryo.</string>
+    <string name="settings_calendar_public_holidays_description">Gumamit ng mga espesyal na kulay at mensahe para sa mga public holiday sa iyong mga kalendaryo.</string>
+    <string name="settings_calendar_open_system_settings">Buksan ang mga setting ng system</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1021,4 +1021,84 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="cast_error_unknown">Diffusion échouée.</string>
     <string name="settings_calendar_birthdays">Anniversaires du calendrier</string>
     <string name="settings_calendar_public_holidays">Jours fériés du calendrier</string>
+
+    <!-- Settings strings added in 2026-05: Smart Home, Developer, Format, Calendar, Schedule, Default outfit. -->
+
+    <!-- Settings root labels — Developer, Format -->
+    <string name="settings_root_developer">Développeur</string>
+    <string name="settings_root_developer_subtitle">Tests et débogage</string>
+    <string name="settings_root_format">Format</string>
+
+    <!-- Developer settings page -->
+    <string name="settings_developer_preview_day_title">Prévisualiser un jour</string>
+    <string name="settings_developer_preview_day_subtitle">Tenue, bannière et voix pour n\'importe quelle date, à partir d\'un échantillon météo doux fixe.</string>
+    <string name="settings_developer_pick_date">Choisir une date</string>
+    <string name="settings_developer_today">Aujourd\'hui</string>
+    <string name="settings_developer_no_theme">Aucun thème festif pour ce jour.</string>
+    <string name="settings_developer_resolved_label">Résolu : %1$s</string>
+    <string name="settings_developer_speak">Lire à voix haute</string>
+
+    <!-- Smart Home — newer keys -->
+    <string name="settings_smart_home_cast_label">Envoyer les prévisions à l\'écran connecté</string>
+    <string name="settings_smart_home_cast_last_published">Dernière publication %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched">Dernière récupération %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched_never">L\'écran n\'a pas encore récupéré de ClothesCast</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_title">Ne pas lire sur le téléphone</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_description">Évite les annonces en double à la maison.</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_title">Ne pas lire sur le téléphone</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_description">Évite les annonces en double à la maison.</string>
+    <string name="settings_smart_home_mqtt_topic_hint">%1$s/now/text, %1$s/now/audio, etc</string>
+
+    <!-- Schedule settings -->
+    <string name="settings_schedule_enabled">ClothesCast quotidien</string>
+    <string name="settings_delivery_notification">Notifier</string>
+    <string name="settings_delivery_tts">Lire à voix haute</string>
+
+    <!-- Clothes-mention picker on Format / Schedule -->
+    <string name="settings_clothes_mention_label">Vêtements</string>
+    <string name="settings_clothes_mention_always">Toujours</string>
+    <string name="settings_clothes_mention_if_changed">Changement</string>
+    <string name="settings_clothes_mention_never">Jamais</string>
+
+    <!-- Format settings page -->
+    <string name="settings_format_preview_example_title">Exemple</string>
+    <string name="settings_format_preview_current_title">Prévision actuelle</string>
+    <string name="settings_format_preview_current_empty">Pas encore de prévision — reviens après ton prochain ClothesCast.</string>
+    <string name="settings_format_what_to_say">Que dire</string>
+    <string name="settings_format_range_label">Plage de température</string>
+    <string name="settings_format_range_none">Aucune</string>
+    <string name="settings_format_range_degrees">Degrés</string>
+    <string name="settings_format_range_bands">Catégories</string>
+    <string name="settings_format_change_label">Variation de température</string>
+    <string name="settings_format_change_off">Désactivé</string>
+    <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_clothes_label">Formulation des vêtements</string>
+    <string name="settings_format_clothes_items">Vêtements</string>
+    <string name="settings_format_clothes_layer_count">Nombre de couches</string>
+    <string name="settings_format_bottoms_label">Bas</string>
+    <string name="settings_format_bottoms_always">Toujours</string>
+    <string name="settings_format_bottoms_if_garments">Si vêtements</string>
+    <string name="settings_format_bottoms_never">Jamais</string>
+    <string name="settings_format_rain_accessory_label">Accessoire pluie</string>
+    <string name="settings_format_rain_accessory_none">Désactivé</string>
+    <string name="settings_format_rain_accessory_umbrella">Parapluie</string>
+
+    <!-- Fallback clothes rules — "If no rules match" section -->
+    <string name="settings_default_outfit_title">Si aucune règle ne correspond</string>
+    <string name="settings_default_top_edit_title">Haut par défaut</string>
+    <string name="settings_default_bottom_edit_title">Bas par défaut</string>
+    <string name="settings_default_outfit_range_above">quand la température est au-dessus de %1$s</string>
+    <string name="settings_default_outfit_range_below">quand la température est en dessous de %1$s</string>
+    <string name="settings_default_outfit_range_between">quand la température est entre %1$s et %2$s</string>
+    <string name="settings_default_outfit_range_never">jamais</string>
+
+    <!-- Calendar settings — master switch + per-feature toggles -->
+    <string name="settings_calendar_master">Utiliser mon calendrier</string>
+    <string name="settings_calendar_master_description">Laisse ClothesCast lire tes calendriers pour personnaliser les prévisions et les tenues. Rien ne quitte l\'appareil.</string>
+    <string name="settings_calendar_features_title">Calendriers personnels</string>
+    <string name="settings_calendar_evening_tie_ins">Mentions du soir</string>
+    <string name="settings_calendar_evening_tie_ins_description">Si tu sors le soir, la prévision du matin t\'indique si tu dois prendre quelque chose en plus.</string>
+    <string name="settings_calendar_birthdays_description">Utilise des couleurs et messages spéciaux pour les anniversaires de tes calendriers.</string>
+    <string name="settings_calendar_public_holidays_description">Utilise des couleurs et messages spéciaux pour les jours fériés de tes calendriers.</string>
+    <string name="settings_calendar_open_system_settings">Ouvrir les paramètres système</string>
 </resources>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -926,4 +926,84 @@ Not overridden by design:
     <string name="today_rationale_open_clothes_settings">कपड़ों की सेटिंग</string>
     <string name="settings_calendar_birthdays">कैलेंडर जन्मदिन</string>
     <string name="settings_calendar_public_holidays">कैलेंडर छुट्टियाँ</string>
+
+    <!-- Settings strings added in 2026-05: Smart Home, Developer, Format, Calendar, Schedule, Default outfit. -->
+
+    <!-- Settings root labels — Developer, Format -->
+    <string name="settings_root_developer">डेवलपर</string>
+    <string name="settings_root_developer_subtitle">परीक्षण और डीबगिंग</string>
+    <string name="settings_root_format">प्रारूप</string>
+
+    <!-- Developer settings page -->
+    <string name="settings_developer_preview_day_title">किसी दिन का पूर्वावलोकन</string>
+    <string name="settings_developer_preview_day_subtitle">किसी भी तारीख के लिए पोशाक, बैनर और आवाज़, एक तय हल्के मौसम के नमूने के साथ।</string>
+    <string name="settings_developer_pick_date">तारीख चुनें</string>
+    <string name="settings_developer_today">आज</string>
+    <string name="settings_developer_no_theme">इस दिन के लिए कोई त्योहार थीम नहीं।</string>
+    <string name="settings_developer_resolved_label">हल हुआ: %1$s</string>
+    <string name="settings_developer_speak">बोलें</string>
+
+    <!-- Smart Home — newer keys -->
+    <string name="settings_smart_home_cast_label">स्मार्ट डिस्प्ले पर पूर्वानुमान भेजें</string>
+    <string name="settings_smart_home_cast_last_published">अंतिम बार %1$s को प्रकाशित</string>
+    <string name="settings_smart_home_cast_last_fetched">अंतिम बार %1$s को लाया गया</string>
+    <string name="settings_smart_home_cast_last_fetched_never">डिस्प्ले ने अभी तक कोई ClothesCast नहीं लाया है</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_title">फ़ोन की आवाज़ छोड़ें</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_description">घर पर दोहरी घोषणाओं से बचें।</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_title">फ़ोन की आवाज़ छोड़ें</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_description">घर पर दोहरी घोषणाओं से बचें।</string>
+    <string name="settings_smart_home_mqtt_topic_hint">%1$s/now/text, %1$s/now/audio, आदि</string>
+
+    <!-- Schedule settings — Daily ClothesCast -->
+    <string name="settings_schedule_enabled">दैनिक ClothesCast</string>
+    <string name="settings_delivery_notification">सूचित करें</string>
+    <string name="settings_delivery_tts">बोलें</string>
+
+    <!-- Clothes-mention picker -->
+    <string name="settings_clothes_mention_label">कपड़े</string>
+    <string name="settings_clothes_mention_always">हमेशा</string>
+    <string name="settings_clothes_mention_if_changed">बदलाव पर</string>
+    <string name="settings_clothes_mention_never">कभी नहीं</string>
+
+    <!-- Format settings page -->
+    <string name="settings_format_preview_example_title">उदाहरण</string>
+    <string name="settings_format_preview_current_title">मौजूदा पूर्वानुमान</string>
+    <string name="settings_format_preview_current_empty">अभी कोई पूर्वानुमान नहीं — अगले ClothesCast के बाद देखें।</string>
+    <string name="settings_format_what_to_say">क्या कहना है</string>
+    <string name="settings_format_range_label">तापमान सीमा</string>
+    <string name="settings_format_range_none">कोई नहीं</string>
+    <string name="settings_format_range_degrees">डिग्री</string>
+    <string name="settings_format_range_bands">श्रेणियाँ</string>
+    <string name="settings_format_change_label">तापमान परिवर्तन</string>
+    <string name="settings_format_change_off">बंद</string>
+    <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_clothes_label">कपड़ों के शब्द</string>
+    <string name="settings_format_clothes_items">कपड़े</string>
+    <string name="settings_format_clothes_layer_count">परतों की संख्या</string>
+    <string name="settings_format_bottoms_label">निचले कपड़े</string>
+    <string name="settings_format_bottoms_always">हमेशा</string>
+    <string name="settings_format_bottoms_if_garments">अगर कपड़े हों</string>
+    <string name="settings_format_bottoms_never">कभी नहीं</string>
+    <string name="settings_format_rain_accessory_label">बारिश का सामान</string>
+    <string name="settings_format_rain_accessory_none">बंद</string>
+    <string name="settings_format_rain_accessory_umbrella">छाता</string>
+
+    <!-- Fallback clothes rules — "If no rules match" -->
+    <string name="settings_default_outfit_title">यदि कोई नियम लागू नहीं हो</string>
+    <string name="settings_default_top_edit_title">डिफ़ॉल्ट ऊपरी कपड़ा</string>
+    <string name="settings_default_bottom_edit_title">डिफ़ॉल्ट निचला कपड़ा</string>
+    <string name="settings_default_outfit_range_above">जब तापमान %1$s से ऊपर हो</string>
+    <string name="settings_default_outfit_range_below">जब तापमान %1$s से नीचे हो</string>
+    <string name="settings_default_outfit_range_between">जब तापमान %1$s और %2$s के बीच हो</string>
+    <string name="settings_default_outfit_range_never">कभी नहीं</string>
+
+    <!-- Calendar settings — master switch + per-feature toggles -->
+    <string name="settings_calendar_master">मेरे कैलेंडर का उपयोग करें</string>
+    <string name="settings_calendar_master_description">ClothesCast को आपके कैलेंडर पढ़ने दें ताकि पूर्वानुमान और पोशाक व्यक्तिगत बनाई जा सके। कुछ भी डिवाइस से बाहर नहीं जाता।</string>
+    <string name="settings_calendar_features_title">व्यक्तिगत कैलेंडर</string>
+    <string name="settings_calendar_evening_tie_ins">शाम की घटनाओं का जिक्र</string>
+    <string name="settings_calendar_evening_tie_ins_description">यदि आप शाम को बाहर जा रहे हैं, तो सुबह का पूर्वानुमान बताता है कि कुछ अतिरिक्त साथ लेना है या नहीं।</string>
+    <string name="settings_calendar_birthdays_description">अपने कैलेंडर में जन्मदिनों के लिए विशेष रंग और संदेश उपयोग करें।</string>
+    <string name="settings_calendar_public_holidays_description">अपने कैलेंडर में सार्वजनिक छुट्टियों के लिए विशेष रंग और संदेश उपयोग करें।</string>
+    <string name="settings_calendar_open_system_settings">सिस्टम सेटिंग खोलें</string>
 </resources>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -964,4 +964,83 @@ spousal register), matching the existing insight prose ("Ponesi …",
     <string name="cast_error_unknown">Prenošenje nije uspjelo.</string>
     <string name="settings_calendar_birthdays">Rođendani iz kalendara</string>
     <string name="settings_calendar_public_holidays">Blagdani iz kalendara</string>
+
+    <!-- Settings strings added in 2026-05: Smart Home, Developer, Format, Calendar, Schedule, Default outfit. -->
+    <!-- Settings root labels — Developer, Format. -->
+    <string name="settings_root_developer">Razvojni programer</string>
+    <string name="settings_root_developer_subtitle">Testiranje i otklanjanje pogrešaka</string>
+    <string name="settings_root_format">Format</string>
+
+    <!-- Developer settings page (Settings → Developer → Preview a day) -->
+    <string name="settings_developer_preview_day_title">Pregled dana</string>
+    <string name="settings_developer_preview_day_subtitle">Outfit, baner i glas za bilo koji datum, koristeći fiksni uzorak blagog vremena.</string>
+    <string name="settings_developer_pick_date">Odaberi datum</string>
+    <string name="settings_developer_today">Danas</string>
+    <string name="settings_developer_no_theme">Nema blagdanske teme za ovaj dan.</string>
+    <string name="settings_developer_resolved_label">Razriješeno: %1$s</string>
+    <string name="settings_developer_speak">Pročitaj</string>
+
+    <!-- Smart Home — newer keys. -->
+    <string name="settings_smart_home_cast_label">Pošalji prognozu na pametni zaslon</string>
+    <string name="settings_smart_home_cast_last_published">Posljednja objava %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched">Posljednje preuzimanje %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched_never">Zaslon još nije preuzeo nijedan ClothesCast</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_title">Preskoči govor na telefonu</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_description">Izbjegni dvostruke obavijesti kod kuće.</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_title">Preskoči govor na telefonu</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_description">Izbjegni dvostruke obavijesti kod kuće.</string>
+    <string name="settings_smart_home_mqtt_topic_hint">%1$s/now/text, %1$s/now/audio, itd.</string>
+
+    <!-- Schedule settings — Daily ClothesCast -->
+    <string name="settings_schedule_enabled">Dnevni ClothesCast</string>
+    <string name="settings_delivery_notification">Obavijesti</string>
+    <string name="settings_delivery_tts">Pročitaj</string>
+
+    <!-- Clothes-mention picker on Format / Schedule -->
+    <string name="settings_clothes_mention_label">Odjeća</string>
+    <string name="settings_clothes_mention_always">Uvijek</string>
+    <string name="settings_clothes_mention_if_changed">Promjena</string>
+    <string name="settings_clothes_mention_never">Nikad</string>
+
+    <!-- Format settings page -->
+    <string name="settings_format_preview_example_title">Primjer</string>
+    <string name="settings_format_preview_current_title">Trenutna prognoza</string>
+    <string name="settings_format_preview_current_empty">Još nema prognoze — provjeri nakon sljedećeg ClothesCasta.</string>
+    <string name="settings_format_what_to_say">Što reći</string>
+    <string name="settings_format_range_label">Raspon temperatura</string>
+    <string name="settings_format_range_none">Bez</string>
+    <string name="settings_format_range_degrees">Stupnjevi</string>
+    <string name="settings_format_range_bands">Pojasi</string>
+    <string name="settings_format_change_label">Promjena temperature</string>
+    <string name="settings_format_change_off">Isključeno</string>
+    <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_clothes_label">Formulacija odjeće</string>
+    <string name="settings_format_clothes_items">Komadi odjeće</string>
+    <string name="settings_format_clothes_layer_count">Broj slojeva</string>
+    <string name="settings_format_bottoms_label">Donji dijelovi</string>
+    <string name="settings_format_bottoms_always">Uvijek</string>
+    <string name="settings_format_bottoms_if_garments">Ako ima komada</string>
+    <string name="settings_format_bottoms_never">Nikad</string>
+    <string name="settings_format_rain_accessory_label">Dodatak za kišu</string>
+    <string name="settings_format_rain_accessory_none">Isključeno</string>
+    <string name="settings_format_rain_accessory_umbrella">Kišobran</string>
+
+    <!-- Fallback clothes rules — "If no rules match" section -->
+    <string name="settings_default_outfit_title">Ako se nijedno pravilo ne podudara</string>
+    <string name="settings_default_top_edit_title">Zadani gornji dio</string>
+    <string name="settings_default_bottom_edit_title">Zadani donji dio</string>
+    <string name="settings_default_outfit_range_above">kad je temperatura iznad %1$s</string>
+    <string name="settings_default_outfit_range_below">kad je temperatura ispod %1$s</string>
+    <string name="settings_default_outfit_range_between">kad je temperatura između %1$s i %2$s</string>
+    <string name="settings_default_outfit_range_never">nikad</string>
+
+    <!-- Calendar settings — master switch + per-feature toggles -->
+    <string name="settings_calendar_master">Koristi moj kalendar</string>
+    <string name="settings_calendar_master_description">Dopusti ClothesCastu čitanje tvojih kalendara za prilagodbu prognoza i outfita. Ništa ne napušta uređaj.</string>
+    <string name="settings_calendar_features_title">Osobni kalendari</string>
+    <string name="settings_calendar_evening_tie_ins">Večernje poveznice</string>
+    <string name="settings_calendar_evening_tie_ins_description">Ako navečer izlaziš, jutarnja prognoza ti kaže trebaš li ponijeti nešto dodatno.</string>
+    <string name="settings_calendar_birthdays_description">Koristi posebne boje i poruke za rođendane u tvojim kalendarima.</string>
+    <string name="settings_calendar_public_holidays_description">Koristi posebne boje i poruke za državne blagdane u tvojim kalendarima.</string>
+    <string name="settings_calendar_open_system_settings">Otvori sistemske postavke</string>
 </resources>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -888,4 +888,83 @@ locale (Angol (Egyesült Államok), Francia (Franciaország), Német
     <string name="cast_error_unknown">A közvetítés sikertelen volt.</string>
     <string name="settings_calendar_birthdays">Naptárbeli születésnapok</string>
     <string name="settings_calendar_public_holidays">Naptárbeli ünnepek</string>
+
+    <!-- Settings strings added in 2026-05: Smart Home, Developer, Format, Calendar, Schedule, Default outfit. -->
+    <!-- Settings root labels — Smart Home, Developer, Format -->
+    <string name="settings_root_developer">Fejlesztő</string>
+    <string name="settings_root_developer_subtitle">Tesztelés és hibakeresés</string>
+    <string name="settings_root_format">Formátum</string>
+
+    <!-- Developer settings page (Settings → Developer → Preview a day) -->
+    <string name="settings_developer_preview_day_title">Nap előnézete</string>
+    <string name="settings_developer_preview_day_subtitle">Öltözék, banner és hang bármely dátumra, rögzített enyhe időjárás-minta alapján.</string>
+    <string name="settings_developer_pick_date">Válassz dátumot</string>
+    <string name="settings_developer_today">Ma</string>
+    <string name="settings_developer_no_theme">Erre a napra nincs ünnep-téma.</string>
+    <string name="settings_developer_resolved_label">Feloldva: %1$s</string>
+    <string name="settings_developer_speak">Mondja ki</string>
+
+    <!-- Smart Home — newer keys -->
+    <string name="settings_smart_home_cast_label">Előrejelzés küldése az okos kijelzőre</string>
+    <string name="settings_smart_home_cast_last_published">Utoljára közzétéve: %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched">Utoljára letöltve: %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched_never">A kijelző még nem töltött le ClothesCastot</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_title">Telefonos beszéd kihagyása</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_description">Kerüld az ismétlődő bemondásokat otthon.</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_title">Telefonos beszéd kihagyása</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_description">Kerüld az ismétlődő bemondásokat otthon.</string>
+    <string name="settings_smart_home_mqtt_topic_hint">%1$s/now/text, %1$s/now/audio stb.</string>
+
+    <!-- Schedule settings -->
+    <string name="settings_schedule_enabled">Napi ClothesCast</string>
+    <string name="settings_delivery_notification">Értesítés</string>
+    <string name="settings_delivery_tts">Felolvasás</string>
+
+    <!-- Clothes-mention picker on Format / Schedule -->
+    <string name="settings_clothes_mention_label">Ruházat</string>
+    <string name="settings_clothes_mention_always">Mindig</string>
+    <string name="settings_clothes_mention_if_changed">Változáskor</string>
+    <string name="settings_clothes_mention_never">Soha</string>
+
+    <!-- Format settings page -->
+    <string name="settings_format_preview_example_title">Példa</string>
+    <string name="settings_format_preview_current_title">Jelenlegi előrejelzés</string>
+    <string name="settings_format_preview_current_empty">Még nincs előrejelzés — nézz vissza a következő ClothesCastod után.</string>
+    <string name="settings_format_what_to_say">Mit mondjon</string>
+    <string name="settings_format_range_label">Hőmérséklet-tartomány</string>
+    <string name="settings_format_range_none">Nincs</string>
+    <string name="settings_format_range_degrees">Fokok</string>
+    <string name="settings_format_range_bands">Sávok</string>
+    <string name="settings_format_change_label">Hőmérséklet-változás</string>
+    <string name="settings_format_change_off">Ki</string>
+    <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_clothes_label">Ruházat megfogalmazása</string>
+    <string name="settings_format_clothes_items">Ruhadarabok</string>
+    <string name="settings_format_clothes_layer_count">Rétegek száma</string>
+    <string name="settings_format_bottoms_label">Alsó ruházat</string>
+    <string name="settings_format_bottoms_always">Mindig</string>
+    <string name="settings_format_bottoms_if_garments">Ha van ruhadarab</string>
+    <string name="settings_format_bottoms_never">Soha</string>
+    <string name="settings_format_rain_accessory_label">Esőkellék</string>
+    <string name="settings_format_rain_accessory_none">Ki</string>
+    <string name="settings_format_rain_accessory_umbrella">Esernyő</string>
+
+    <!-- Fallback clothes rules — "If no rules match" -->
+    <string name="settings_default_outfit_title">Ha egyik szabály sem illik</string>
+    <string name="settings_default_top_edit_title">Alapértelmezett felső</string>
+    <string name="settings_default_bottom_edit_title">Alapértelmezett alsó</string>
+    <string name="settings_default_outfit_range_above">ha a hőmérséklet %1$s fölött van</string>
+    <string name="settings_default_outfit_range_below">ha a hőmérséklet %1$s alatt van</string>
+    <string name="settings_default_outfit_range_between">ha a hőmérséklet %1$s és %2$s között van</string>
+    <string name="settings_default_outfit_range_never">soha</string>
+
+    <!-- Calendar settings — master switch + per-feature toggles -->
+    <string name="settings_calendar_master">Használja a naptáramat</string>
+    <string name="settings_calendar_master_description">Engedd, hogy a ClothesCast olvassa a naptáraidat az előrejelzések és öltözékek személyre szabásához. Semmi sem hagyja el az eszközt.</string>
+    <string name="settings_calendar_features_title">Személyes naptárak</string>
+    <string name="settings_calendar_evening_tie_ins">Esti utalások</string>
+    <string name="settings_calendar_evening_tie_ins_description">Ha este elmész valahova, a reggeli előrejelzés megmondja, kell-e bármi extrát magaddal vinned.</string>
+    <string name="settings_calendar_birthdays_description">Különleges színek és üzenetek használata a naptáraidban szereplő születésnapokra.</string>
+    <string name="settings_calendar_public_holidays_description">Különleges színek és üzenetek használata a naptáraidban szereplő ünnepnapokra.</string>
+    <string name="settings_calendar_open_system_settings">Rendszerbeállítások megnyitása</string>
 </resources>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -896,4 +896,83 @@ to values/strings.xml (English).
     <string name="today_rationale_open_clothes_settings">Pengaturan pakaian</string>
     <string name="settings_calendar_birthdays">Ulang Tahun Kalender</string>
     <string name="settings_calendar_public_holidays">Hari Libur Kalender</string>
+
+    <!-- Settings strings added in 2026-05: Smart Home, Developer, Format, Calendar, Schedule, Default outfit. -->
+    <!-- Settings root labels -->
+    <string name="settings_root_developer">Pengembang</string>
+    <string name="settings_root_developer_subtitle">Pengujian dan Debugging</string>
+    <string name="settings_root_format">Format</string>
+
+    <!-- Developer settings page -->
+    <string name="settings_developer_preview_day_title">Pratinjau hari</string>
+    <string name="settings_developer_preview_day_subtitle">Pakaian, banner, dan suara untuk tanggal apa pun, menggunakan contoh cuaca sejuk tetap.</string>
+    <string name="settings_developer_pick_date">Pilih tanggal</string>
+    <string name="settings_developer_today">Hari ini</string>
+    <string name="settings_developer_no_theme">Tidak ada tema hari libur untuk hari ini.</string>
+    <string name="settings_developer_resolved_label">Diselesaikan: %1$s</string>
+    <string name="settings_developer_speak">Bacakan</string>
+
+    <!-- Smart Home additional keys -->
+    <string name="settings_smart_home_cast_label">Kirim prakiraan ke layar pintar</string>
+    <string name="settings_smart_home_cast_last_published">Terakhir diterbitkan %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched">Terakhir diambil %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched_never">Layar belum mengambil ClothesCast</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_title">Lewati pengucapan di ponsel</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_description">Hindari pengumuman ganda di rumah.</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_title">Lewati pengucapan di ponsel</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_description">Hindari pengumuman ganda di rumah.</string>
+    <string name="settings_smart_home_mqtt_topic_hint">%1$s/now/text, %1$s/now/audio, dll</string>
+
+    <!-- Schedule settings — Daily ClothesCast -->
+    <string name="settings_schedule_enabled">ClothesCast Harian</string>
+    <string name="settings_delivery_notification">Beri tahu</string>
+    <string name="settings_delivery_tts">Bacakan</string>
+
+    <!-- Clothes-mention picker -->
+    <string name="settings_clothes_mention_label">Pakaian</string>
+    <string name="settings_clothes_mention_always">Selalu</string>
+    <string name="settings_clothes_mention_if_changed">Berubah</string>
+    <string name="settings_clothes_mention_never">Tidak pernah</string>
+
+    <!-- Format settings page -->
+    <string name="settings_format_preview_example_title">Contoh</string>
+    <string name="settings_format_preview_current_title">Prakiraan saat ini</string>
+    <string name="settings_format_preview_current_empty">Belum ada prakiraan — periksa lagi setelah ClothesCast berikutnya.</string>
+    <string name="settings_format_what_to_say">Apa yang dikatakan</string>
+    <string name="settings_format_range_label">Rentang suhu</string>
+    <string name="settings_format_range_none">Tidak ada</string>
+    <string name="settings_format_range_degrees">Derajat</string>
+    <string name="settings_format_range_bands">Tingkatan</string>
+    <string name="settings_format_change_label">Perubahan suhu</string>
+    <string name="settings_format_change_off">Mati</string>
+    <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_clothes_label">Susunan kata pakaian</string>
+    <string name="settings_format_clothes_items">Pakaian</string>
+    <string name="settings_format_clothes_layer_count">Jumlah lapisan</string>
+    <string name="settings_format_bottoms_label">Bawahan</string>
+    <string name="settings_format_bottoms_always">Selalu</string>
+    <string name="settings_format_bottoms_if_garments">Jika ada pakaian</string>
+    <string name="settings_format_bottoms_never">Tidak pernah</string>
+    <string name="settings_format_rain_accessory_label">Aksesori hujan</string>
+    <string name="settings_format_rain_accessory_none">Mati</string>
+    <string name="settings_format_rain_accessory_umbrella">Payung</string>
+
+    <!-- Fallback clothes rules — "If no rules match" -->
+    <string name="settings_default_outfit_title">Jika tidak ada aturan yang cocok</string>
+    <string name="settings_default_top_edit_title">Atasan default</string>
+    <string name="settings_default_bottom_edit_title">Bawahan default</string>
+    <string name="settings_default_outfit_range_above">ketika suhu di atas %1$s</string>
+    <string name="settings_default_outfit_range_below">ketika suhu di bawah %1$s</string>
+    <string name="settings_default_outfit_range_between">ketika suhu antara %1$s dan %2$s</string>
+    <string name="settings_default_outfit_range_never">tidak pernah</string>
+
+    <!-- Calendar settings — master switch + per-feature toggles -->
+    <string name="settings_calendar_master">Gunakan kalender saya</string>
+    <string name="settings_calendar_master_description">Izinkan ClothesCast membaca kalender Anda untuk mempersonalisasi prakiraan dan pakaian. Tidak ada yang meninggalkan perangkat.</string>
+    <string name="settings_calendar_features_title">Kalender pribadi</string>
+    <string name="settings_calendar_evening_tie_ins">Keterhubungan acara malam</string>
+    <string name="settings_calendar_evening_tie_ins_description">Jika Anda keluar di malam hari, prakiraan pagi akan memberi tahu apakah Anda perlu membawa sesuatu yang lain.</string>
+    <string name="settings_calendar_birthdays_description">Gunakan warna dan pesan khusus untuk ulang tahun di kalender Anda.</string>
+    <string name="settings_calendar_public_holidays_description">Gunakan warna dan pesan khusus untuk hari libur nasional di kalender Anda.</string>
+    <string name="settings_calendar_open_system_settings">Buka pengaturan sistem</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1007,4 +1007,84 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="cast_error_unknown">Trasmissione fallita.</string>
     <string name="settings_calendar_birthdays">Compleanni del calendario</string>
     <string name="settings_calendar_public_holidays">Festività del calendario</string>
+
+    <!-- Settings strings added in 2026-05: Smart Home, Developer, Format, Calendar, Schedule, Default outfit. -->
+
+    <!-- Settings root labels — Developer, Format -->
+    <string name="settings_root_developer">Sviluppatore</string>
+    <string name="settings_root_developer_subtitle">Test e debug</string>
+    <string name="settings_root_format">Formato</string>
+
+    <!-- Developer settings page -->
+    <string name="settings_developer_preview_day_title">Anteprima di un giorno</string>
+    <string name="settings_developer_preview_day_subtitle">Outfit, banner e voce per qualsiasi data, usando un campione meteo mite fisso.</string>
+    <string name="settings_developer_pick_date">Scegli una data</string>
+    <string name="settings_developer_today">Oggi</string>
+    <string name="settings_developer_no_theme">Nessun tema festivo per questo giorno.</string>
+    <string name="settings_developer_resolved_label">Risolto: %1$s</string>
+    <string name="settings_developer_speak">Riproduci voce</string>
+
+    <!-- Smart Home — newer keys -->
+    <string name="settings_smart_home_cast_label">Invia le previsioni al display intelligente</string>
+    <string name="settings_smart_home_cast_last_published">Ultima pubblicazione %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched">Ultimo recupero %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched_never">Il display non ha ancora recuperato un ClothesCast</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_title">Salta la lettura sul telefono</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_description">Evita annunci duplicati a casa.</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_title">Salta la lettura sul telefono</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_description">Evita annunci duplicati a casa.</string>
+    <string name="settings_smart_home_mqtt_topic_hint">%1$s/now/text, %1$s/now/audio, ecc.</string>
+
+    <!-- Schedule settings -->
+    <string name="settings_schedule_enabled">ClothesCast quotidiano</string>
+    <string name="settings_delivery_notification">Notifica</string>
+    <string name="settings_delivery_tts">Riproduci voce</string>
+
+    <!-- Clothes-mention picker on Format / Schedule -->
+    <string name="settings_clothes_mention_label">Abbigliamento</string>
+    <string name="settings_clothes_mention_always">Sempre</string>
+    <string name="settings_clothes_mention_if_changed">Cambio</string>
+    <string name="settings_clothes_mention_never">Mai</string>
+
+    <!-- Format settings page -->
+    <string name="settings_format_preview_example_title">Esempio</string>
+    <string name="settings_format_preview_current_title">Previsione attuale</string>
+    <string name="settings_format_preview_current_empty">Ancora nessuna previsione — controlla dopo il prossimo ClothesCast.</string>
+    <string name="settings_format_what_to_say">Cosa dire</string>
+    <string name="settings_format_range_label">Intervallo di temperatura</string>
+    <string name="settings_format_range_none">Nessuno</string>
+    <string name="settings_format_range_degrees">Gradi</string>
+    <string name="settings_format_range_bands">Categorie</string>
+    <string name="settings_format_change_label">Variazione di temperatura</string>
+    <string name="settings_format_change_off">Disattivato</string>
+    <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_clothes_label">Formulazione abbigliamento</string>
+    <string name="settings_format_clothes_items">Capi</string>
+    <string name="settings_format_clothes_layer_count">Numero di strati</string>
+    <string name="settings_format_bottoms_label">Pantaloni</string>
+    <string name="settings_format_bottoms_always">Sempre</string>
+    <string name="settings_format_bottoms_if_garments">Se ci sono capi</string>
+    <string name="settings_format_bottoms_never">Mai</string>
+    <string name="settings_format_rain_accessory_label">Accessorio pioggia</string>
+    <string name="settings_format_rain_accessory_none">Disattivato</string>
+    <string name="settings_format_rain_accessory_umbrella">Ombrello</string>
+
+    <!-- Fallback clothes rules — "If no rules match" section -->
+    <string name="settings_default_outfit_title">Se nessuna regola corrisponde</string>
+    <string name="settings_default_top_edit_title">Capo superiore predefinito</string>
+    <string name="settings_default_bottom_edit_title">Pantaloni predefiniti</string>
+    <string name="settings_default_outfit_range_above">quando la temperatura è sopra %1$s</string>
+    <string name="settings_default_outfit_range_below">quando la temperatura è sotto %1$s</string>
+    <string name="settings_default_outfit_range_between">quando la temperatura è tra %1$s e %2$s</string>
+    <string name="settings_default_outfit_range_never">mai</string>
+
+    <!-- Calendar settings — master switch + per-feature toggles -->
+    <string name="settings_calendar_master">Usa il mio calendario</string>
+    <string name="settings_calendar_master_description">Consenti a ClothesCast di leggere i tuoi calendari per personalizzare previsioni e outfit. Nulla lascia il dispositivo.</string>
+    <string name="settings_calendar_features_title">Calendari personali</string>
+    <string name="settings_calendar_evening_tie_ins">Riferimenti alla serata</string>
+    <string name="settings_calendar_evening_tie_ins_description">Se esci la sera, la previsione del mattino ti dice se devi portare qualcosa in più.</string>
+    <string name="settings_calendar_birthdays_description">Usa colori e messaggi speciali per i compleanni nei tuoi calendari.</string>
+    <string name="settings_calendar_public_holidays_description">Usa colori e messaggi speciali per le festività nei tuoi calendari.</string>
+    <string name="settings_calendar_open_system_settings">Apri impostazioni di sistema</string>
 </resources>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -895,4 +895,83 @@ standard in Israeli digital communication.
     <string name="today_rationale_open_clothes_settings">הגדרות לבוש</string>
     <string name="settings_calendar_birthdays">ימי הולדת מיומן</string>
     <string name="settings_calendar_public_holidays">חגים מיומן</string>
+
+    <!-- Settings strings added in 2026-05: Smart Home, Developer, Format, Calendar, Schedule, Default outfit. -->
+    <!-- Settings root labels — Smart Home, Developer, Format -->
+    <string name="settings_root_developer">מפתח</string>
+    <string name="settings_root_developer_subtitle">בדיקות וניפוי שגיאות</string>
+    <string name="settings_root_format">ניסוח</string>
+
+    <!-- Developer settings page (Settings → Developer → Preview a day) -->
+    <string name="settings_developer_preview_day_title">תצוגה מקדימה של יום</string>
+    <string name="settings_developer_preview_day_subtitle">לבוש, באנר וקול לכל תאריך, באמצעות דוגמת מזג אוויר מתון קבועה.</string>
+    <string name="settings_developer_pick_date">בחר/י תאריך</string>
+    <string name="settings_developer_today">היום</string>
+    <string name="settings_developer_no_theme">אין נושא חג ליום זה.</string>
+    <string name="settings_developer_resolved_label">נפתר: %1$s</string>
+    <string name="settings_developer_speak">השמע/י</string>
+
+    <!-- Smart Home — newer keys -->
+    <string name="settings_smart_home_cast_label">שלח/י תחזית למסך חכם</string>
+    <string name="settings_smart_home_cast_last_published">פורסם לאחרונה %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched">נשלף לאחרונה %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched_never">המסך עדיין לא שלף ClothesCast</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_title">דלג/י על דיבור הטלפון</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_description">הימנע/י מהכרזות כפולות בבית.</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_title">דלג/י על דיבור הטלפון</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_description">הימנע/י מהכרזות כפולות בבית.</string>
+    <string name="settings_smart_home_mqtt_topic_hint">%1$s/now/text, %1$s/now/audio, וכו׳</string>
+
+    <!-- Schedule settings -->
+    <string name="settings_schedule_enabled">ClothesCast יומי</string>
+    <string name="settings_delivery_notification">התראה</string>
+    <string name="settings_delivery_tts">קריאה</string>
+
+    <!-- Clothes-mention picker on Format / Schedule -->
+    <string name="settings_clothes_mention_label">לבוש</string>
+    <string name="settings_clothes_mention_always">תמיד</string>
+    <string name="settings_clothes_mention_if_changed">שינוי</string>
+    <string name="settings_clothes_mention_never">אף פעם</string>
+
+    <!-- Format settings page -->
+    <string name="settings_format_preview_example_title">דוגמה</string>
+    <string name="settings_format_preview_current_title">תחזית נוכחית</string>
+    <string name="settings_format_preview_current_empty">אין תחזית עדיין — בדוק/י שוב אחרי ה-ClothesCast הבא שלך.</string>
+    <string name="settings_format_what_to_say">מה לומר</string>
+    <string name="settings_format_range_label">טווח טמפרטורה</string>
+    <string name="settings_format_range_none">ללא</string>
+    <string name="settings_format_range_degrees">מעלות</string>
+    <string name="settings_format_range_bands">רצועות</string>
+    <string name="settings_format_change_label">שינוי טמפרטורה</string>
+    <string name="settings_format_change_off">כבוי</string>
+    <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_clothes_label">ניסוח לבוש</string>
+    <string name="settings_format_clothes_items">פריטי לבוש</string>
+    <string name="settings_format_clothes_layer_count">מספר שכבות</string>
+    <string name="settings_format_bottoms_label">לבוש תחתון</string>
+    <string name="settings_format_bottoms_always">תמיד</string>
+    <string name="settings_format_bottoms_if_garments">אם יש פריטים</string>
+    <string name="settings_format_bottoms_never">אף פעם</string>
+    <string name="settings_format_rain_accessory_label">אביזר גשם</string>
+    <string name="settings_format_rain_accessory_none">כבוי</string>
+    <string name="settings_format_rain_accessory_umbrella">מטרייה</string>
+
+    <!-- Fallback clothes rules — "If no rules match" -->
+    <string name="settings_default_outfit_title">אם אף חוק לא מתאים</string>
+    <string name="settings_default_top_edit_title">פריט עליון ברירת מחדל</string>
+    <string name="settings_default_bottom_edit_title">פריט תחתון ברירת מחדל</string>
+    <string name="settings_default_outfit_range_above">כשהטמפרטורה מעל %1$s</string>
+    <string name="settings_default_outfit_range_below">כשהטמפרטורה מתחת ל-%1$s</string>
+    <string name="settings_default_outfit_range_between">כשהטמפרטורה בין %1$s ל-%2$s</string>
+    <string name="settings_default_outfit_range_never">אף פעם</string>
+
+    <!-- Calendar settings — master switch + per-feature toggles -->
+    <string name="settings_calendar_master">השתמש/י ביומן שלי</string>
+    <string name="settings_calendar_master_description">אפשר/י ל-ClothesCast לקרוא את היומנים שלך כדי להתאים אישית תחזיות ולבוש. שום דבר לא יוצא מהמכשיר.</string>
+    <string name="settings_calendar_features_title">יומנים אישיים</string>
+    <string name="settings_calendar_evening_tie_ins">קישורי ערב</string>
+    <string name="settings_calendar_evening_tie_ins_description">אם את/ה יוצא/ת בערב, תחזית הבוקר אומרת לך אם צריך לקחת משהו נוסף.</string>
+    <string name="settings_calendar_birthdays_description">השתמש/י בצבעים ובהודעות מיוחדים לימי הולדת ביומנים שלך.</string>
+    <string name="settings_calendar_public_holidays_description">השתמש/י בצבעים ובהודעות מיוחדים לחגים ביומנים שלך.</string>
+    <string name="settings_calendar_open_system_settings">פתח/י הגדרות מערכת</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1045,4 +1045,84 @@ the displayed label localizes.
     <string name="today_rationale_open_clothes_settings">服装設定を開く</string>
     <string name="settings_calendar_birthdays">カレンダーの誕生日</string>
     <string name="settings_calendar_public_holidays">カレンダーの祝日</string>
+
+    <!-- Settings strings added in 2026-05: Smart Home, Developer, Format, Calendar, Schedule, Default outfit. -->
+
+    <!-- Settings root labels — Developer, Format. -->
+    <string name="settings_root_developer">開発者</string>
+    <string name="settings_root_developer_subtitle">テストとデバッグ</string>
+    <string name="settings_root_format">フォーマット</string>
+
+    <!-- Developer settings page — preview-a-day -->
+    <string name="settings_developer_preview_day_title">日付をプレビュー</string>
+    <string name="settings_developer_preview_day_subtitle">固定の穏やかな天気サンプルを使って、任意の日付の服装、バナー、音声をプレビューします。</string>
+    <string name="settings_developer_pick_date">日付を選択</string>
+    <string name="settings_developer_today">今日</string>
+    <string name="settings_developer_no_theme">この日には祝日のテーマがありません。</string>
+    <string name="settings_developer_resolved_label">該当：%1$s</string>
+    <string name="settings_developer_speak">読み上げ</string>
+
+    <!-- Smart Home — additional cast / mqtt keys. -->
+    <string name="settings_smart_home_cast_label">予報をスマートディスプレイに送信</string>
+    <string name="settings_smart_home_cast_last_published">前回の送信 %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched">前回の取得 %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched_never">ディスプレイはまだ ClothesCast を取得していません</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_title">スマホの読み上げをスキップ</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_description">自宅での重複アナウンスを避けます。</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_title">スマホの読み上げをスキップ</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_description">自宅での重複アナウンスを避けます。</string>
+    <string name="settings_smart_home_mqtt_topic_hint">%1$s/now/text、%1$s/now/audio など</string>
+
+    <!-- Schedule settings — Daily ClothesCast -->
+    <string name="settings_schedule_enabled">毎日の ClothesCast</string>
+    <string name="settings_delivery_notification">通知</string>
+    <string name="settings_delivery_tts">読み上げ</string>
+
+    <!-- Clothes-mention picker on Format / Schedule -->
+    <string name="settings_clothes_mention_label">服装</string>
+    <string name="settings_clothes_mention_always">常に</string>
+    <string name="settings_clothes_mention_if_changed">変更時</string>
+    <string name="settings_clothes_mention_never">なし</string>
+
+    <!-- Format settings page -->
+    <string name="settings_format_preview_example_title">例</string>
+    <string name="settings_format_preview_current_title">現在の予報</string>
+    <string name="settings_format_preview_current_empty">まだ予報がありません — 次回の ClothesCast 後にもう一度ご確認ください。</string>
+    <string name="settings_format_what_to_say">伝える内容</string>
+    <string name="settings_format_range_label">温度範囲</string>
+    <string name="settings_format_range_none">なし</string>
+    <string name="settings_format_range_degrees">度</string>
+    <string name="settings_format_range_bands">区分</string>
+    <string name="settings_format_change_label">気温変化</string>
+    <string name="settings_format_change_off">オフ</string>
+    <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_clothes_label">服装の言い回し</string>
+    <string name="settings_format_clothes_items">衣類</string>
+    <string name="settings_format_clothes_layer_count">レイヤー数</string>
+    <string name="settings_format_bottoms_label">ボトムス</string>
+    <string name="settings_format_bottoms_always">常に</string>
+    <string name="settings_format_bottoms_if_garments">衣類があるとき</string>
+    <string name="settings_format_bottoms_never">なし</string>
+    <string name="settings_format_rain_accessory_label">雨具</string>
+    <string name="settings_format_rain_accessory_none">オフ</string>
+    <string name="settings_format_rain_accessory_umbrella">傘</string>
+
+    <!-- Fallback clothes rules — "If no rules match" -->
+    <string name="settings_default_outfit_title">一致するルールがないとき</string>
+    <string name="settings_default_top_edit_title">既定のトップス</string>
+    <string name="settings_default_bottom_edit_title">既定のボトムス</string>
+    <string name="settings_default_outfit_range_above">気温が %1$s を超えるとき</string>
+    <string name="settings_default_outfit_range_below">気温が %1$s 未満のとき</string>
+    <string name="settings_default_outfit_range_between">気温が %1$s から %2$s の間のとき</string>
+    <string name="settings_default_outfit_range_never">なし</string>
+
+    <!-- Calendar settings — master switch + per-feature toggles -->
+    <string name="settings_calendar_master">カレンダーを使用</string>
+    <string name="settings_calendar_master_description">ClothesCast がカレンダーを読み取り、予報と服装をパーソナライズします。端末から外に出るものは何もありません。</string>
+    <string name="settings_calendar_features_title">個人のカレンダー</string>
+    <string name="settings_calendar_evening_tie_ins">夜の予定との連動</string>
+    <string name="settings_calendar_evening_tie_ins_description">夜に外出する場合、朝の予報で追加で持っていくべきものがあるかをお知らせします。</string>
+    <string name="settings_calendar_birthdays_description">カレンダーの誕生日に特別な色とメッセージを使用します。</string>
+    <string name="settings_calendar_public_holidays_description">カレンダーの祝日に特別な色とメッセージを使用します。</string>
+    <string name="settings_calendar_open_system_settings">システム設定を開く</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1049,4 +1049,84 @@ displayed label localizes.
     <string name="today_rationale_open_clothes_settings">옷 설정</string>
     <string name="settings_calendar_birthdays">캘린더 생일</string>
     <string name="settings_calendar_public_holidays">캘린더 공휴일</string>
+
+    <!-- Settings strings added in 2026-05: Smart Home, Developer, Format, Calendar, Schedule, Default outfit. -->
+
+    <!-- Settings root labels — Developer, Format. -->
+    <string name="settings_root_developer">개발자</string>
+    <string name="settings_root_developer_subtitle">테스트 및 디버깅</string>
+    <string name="settings_root_format">형식</string>
+
+    <!-- Developer settings page — preview-a-day -->
+    <string name="settings_developer_preview_day_title">날짜 미리보기</string>
+    <string name="settings_developer_preview_day_subtitle">고정된 온화한 날씨 샘플을 사용해 임의의 날짜에 대한 옷, 배너, 음성을 미리 봅니다.</string>
+    <string name="settings_developer_pick_date">날짜 선택</string>
+    <string name="settings_developer_today">오늘</string>
+    <string name="settings_developer_no_theme">이날은 공휴일 테마가 없습니다.</string>
+    <string name="settings_developer_resolved_label">해석됨: %1$s</string>
+    <string name="settings_developer_speak">읽기</string>
+
+    <!-- Smart Home — additional cast / mqtt keys. -->
+    <string name="settings_smart_home_cast_label">예보를 스마트 디스플레이로 전송</string>
+    <string name="settings_smart_home_cast_last_published">마지막 전송 %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched">마지막 가져오기 %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched_never">디스플레이가 아직 ClothesCast를 가져오지 않았어요</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_title">전화기 음성 건너뛰기</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_description">집에서 중복 안내를 피해요.</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_title">전화기 음성 건너뛰기</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_description">집에서 중복 안내를 피해요.</string>
+    <string name="settings_smart_home_mqtt_topic_hint">%1$s/now/text, %1$s/now/audio 등</string>
+
+    <!-- Schedule settings — Daily ClothesCast -->
+    <string name="settings_schedule_enabled">매일 ClothesCast</string>
+    <string name="settings_delivery_notification">알림</string>
+    <string name="settings_delivery_tts">읽기</string>
+
+    <!-- Clothes-mention picker on Format / Schedule -->
+    <string name="settings_clothes_mention_label">옷</string>
+    <string name="settings_clothes_mention_always">항상</string>
+    <string name="settings_clothes_mention_if_changed">변경 시</string>
+    <string name="settings_clothes_mention_never">사용 안 함</string>
+
+    <!-- Format settings page -->
+    <string name="settings_format_preview_example_title">예시</string>
+    <string name="settings_format_preview_current_title">현재 예보</string>
+    <string name="settings_format_preview_current_empty">아직 예보가 없어요 — 다음 ClothesCast 후에 다시 확인하세요.</string>
+    <string name="settings_format_what_to_say">전달 내용</string>
+    <string name="settings_format_range_label">온도 범위</string>
+    <string name="settings_format_range_none">없음</string>
+    <string name="settings_format_range_degrees">도</string>
+    <string name="settings_format_range_bands">구간</string>
+    <string name="settings_format_change_label">온도 변화</string>
+    <string name="settings_format_change_off">끔</string>
+    <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_clothes_label">옷 표현</string>
+    <string name="settings_format_clothes_items">의류</string>
+    <string name="settings_format_clothes_layer_count">레이어 수</string>
+    <string name="settings_format_bottoms_label">하의</string>
+    <string name="settings_format_bottoms_always">항상</string>
+    <string name="settings_format_bottoms_if_garments">의류가 있을 때</string>
+    <string name="settings_format_bottoms_never">사용 안 함</string>
+    <string name="settings_format_rain_accessory_label">우천용품</string>
+    <string name="settings_format_rain_accessory_none">끔</string>
+    <string name="settings_format_rain_accessory_umbrella">우산</string>
+
+    <!-- Fallback clothes rules — "If no rules match" -->
+    <string name="settings_default_outfit_title">일치하는 규칙이 없을 때</string>
+    <string name="settings_default_top_edit_title">기본 상의</string>
+    <string name="settings_default_bottom_edit_title">기본 하의</string>
+    <string name="settings_default_outfit_range_above">온도가 %1$s 초과일 때</string>
+    <string name="settings_default_outfit_range_below">온도가 %1$s 미만일 때</string>
+    <string name="settings_default_outfit_range_between">온도가 %1$s에서 %2$s 사이일 때</string>
+    <string name="settings_default_outfit_range_never">사용 안 함</string>
+
+    <!-- Calendar settings — master switch + per-feature toggles -->
+    <string name="settings_calendar_master">내 캘린더 사용</string>
+    <string name="settings_calendar_master_description">ClothesCast가 캘린더를 읽어 예보와 옷차림을 개인화해요. 어떤 정보도 기기 밖으로 나가지 않습니다.</string>
+    <string name="settings_calendar_features_title">개인 캘린더</string>
+    <string name="settings_calendar_evening_tie_ins">저녁 연계</string>
+    <string name="settings_calendar_evening_tie_ins_description">저녁에 외출할 경우, 아침 예보에서 추가로 챙길 것이 있는지 알려드려요.</string>
+    <string name="settings_calendar_birthdays_description">캘린더의 생일에 특별한 색상과 메시지를 사용해요.</string>
+    <string name="settings_calendar_public_holidays_description">캘린더의 공휴일에 특별한 색상과 메시지를 사용해요.</string>
+    <string name="settings_calendar_open_system_settings">시스템 설정 열기</string>
 </resources>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -883,4 +883,83 @@ What is NOT overridden, by design:
     <string name="holiday_banner_st_andrews_day">Su šv. Andriejaus diena</string>
     <string name="settings_calendar_birthdays">Kalendoriaus gimtadieniai</string>
     <string name="settings_calendar_public_holidays">Kalendoriaus šventės</string>
+
+    <!-- Settings strings added in 2026-05: Smart Home, Developer, Format, Calendar, Schedule, Default outfit. -->
+    <!-- Settings root labels -->
+    <string name="settings_root_developer">Kūrėjas</string>
+    <string name="settings_root_developer_subtitle">Testavimas ir derinimas</string>
+    <string name="settings_root_format">Formatas</string>
+
+    <!-- Developer settings page -->
+    <string name="settings_developer_preview_day_title">Peržiūrėti dieną</string>
+    <string name="settings_developer_preview_day_subtitle">Apranga, baneris ir balsas bet kuriai datai pagal fiksuotą švelnaus oro pavyzdį.</string>
+    <string name="settings_developer_pick_date">Pasirink datą</string>
+    <string name="settings_developer_today">Šiandien</string>
+    <string name="settings_developer_no_theme">Šiai dienai šventinės temos nėra.</string>
+    <string name="settings_developer_resolved_label">Išspręsta: %1$s</string>
+    <string name="settings_developer_speak">Įgarsinti</string>
+
+    <!-- Smart Home — newer keys -->
+    <string name="settings_smart_home_cast_label">Siųsti prognozę į išmanųjį ekraną</string>
+    <string name="settings_smart_home_cast_last_published">Paskutinė publikacija %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched">Paskutinis atsisiuntimas %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched_never">Ekranas dar nėra atsisiuntęs ClothesCast</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_title">Praleisti telefono balsą</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_description">Venk dvigubų pranešimų namuose.</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_title">Praleisti telefono balsą</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_description">Venk dvigubų pranešimų namuose.</string>
+    <string name="settings_smart_home_mqtt_topic_hint">%1$s/now/text, %1$s/now/audio, ir kt.</string>
+
+    <!-- Schedule settings -->
+    <string name="settings_schedule_enabled">Dienos ClothesCast</string>
+    <string name="settings_delivery_notification">Pranešti</string>
+    <string name="settings_delivery_tts">Įgarsinti</string>
+
+    <!-- Clothes-mention picker on Format / Schedule -->
+    <string name="settings_clothes_mention_label">Apranga</string>
+    <string name="settings_clothes_mention_always">Visada</string>
+    <string name="settings_clothes_mention_if_changed">Kai keičiasi</string>
+    <string name="settings_clothes_mention_never">Niekada</string>
+
+    <!-- Format settings page -->
+    <string name="settings_format_preview_example_title">Pavyzdys</string>
+    <string name="settings_format_preview_current_title">Dabartinė prognozė</string>
+    <string name="settings_format_preview_current_empty">Prognozės dar nėra — užsuk po kito ClothesCast.</string>
+    <string name="settings_format_what_to_say">Ką sakyti</string>
+    <string name="settings_format_range_label">Temperatūros intervalas</string>
+    <string name="settings_format_range_none">Nėra</string>
+    <string name="settings_format_range_degrees">Laipsniai</string>
+    <string name="settings_format_range_bands">Intervalai</string>
+    <string name="settings_format_change_label">Temperatūros pokytis</string>
+    <string name="settings_format_change_off">Išjungta</string>
+    <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_clothes_label">Aprangos formuluotė</string>
+    <string name="settings_format_clothes_items">Drabužiai</string>
+    <string name="settings_format_clothes_layer_count">Sluoksnių skaičius</string>
+    <string name="settings_format_bottoms_label">Apatinė dalis</string>
+    <string name="settings_format_bottoms_always">Visada</string>
+    <string name="settings_format_bottoms_if_garments">Jei yra viršus</string>
+    <string name="settings_format_bottoms_never">Niekada</string>
+    <string name="settings_format_rain_accessory_label">Lietaus aksesuaras</string>
+    <string name="settings_format_rain_accessory_none">Išjungta</string>
+    <string name="settings_format_rain_accessory_umbrella">Skėtis</string>
+
+    <!-- Fallback clothes rules — "If no rules match" section -->
+    <string name="settings_default_outfit_title">Jei nė viena taisyklė neatitinka</string>
+    <string name="settings_default_top_edit_title">Numatytasis viršus</string>
+    <string name="settings_default_bottom_edit_title">Numatytoji apatinė dalis</string>
+    <string name="settings_default_outfit_range_above">kai temperatūra aukštesnė nei %1$s</string>
+    <string name="settings_default_outfit_range_below">kai temperatūra žemesnė nei %1$s</string>
+    <string name="settings_default_outfit_range_between">kai temperatūra nuo %1$s iki %2$s</string>
+    <string name="settings_default_outfit_range_never">niekada</string>
+
+    <!-- Calendar settings — master switch + per-feature toggles -->
+    <string name="settings_calendar_master">Naudoti mano kalendorių</string>
+    <string name="settings_calendar_master_description">Leisk ClothesCast skaityti tavo kalendorius, kad pritaikytų prognozes ir aprangą. Niekas nepalieka įrenginio.</string>
+    <string name="settings_calendar_features_title">Asmeniniai kalendoriai</string>
+    <string name="settings_calendar_evening_tie_ins">Vakaro įvykių sąsajos</string>
+    <string name="settings_calendar_evening_tie_ins_description">Jei vakare kažkur eini, ryto prognozė pasakys, ar reikia pasiimti kažką papildomai.</string>
+    <string name="settings_calendar_birthdays_description">Naudoti specialias spalvas ir žinutes tavo kalendorių gimtadieniams.</string>
+    <string name="settings_calendar_public_holidays_description">Naudoti specialias spalvas ir žinutes tavo kalendorių valstybinėms šventėms.</string>
+    <string name="settings_calendar_open_system_settings">Atidaryti sistemos nustatymus</string>
 </resources>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -836,4 +836,83 @@ informal "tu"-form throughout ("Apģērb …", "Paņem … līdzi").
     <string name="holiday_banner_st_andrews_day">Priecīgu Svētā Andreja dienu</string>
     <string name="settings_calendar_birthdays">Kalendāra dzimšanas dienas</string>
     <string name="settings_calendar_public_holidays">Kalendāra svētki</string>
+
+    <!-- Settings strings added in 2026-05: Smart Home, Developer, Format, Calendar, Schedule, Default outfit. -->
+    <!-- Settings root labels -->
+    <string name="settings_root_developer">Izstrādātājs</string>
+    <string name="settings_root_developer_subtitle">Testēšana un atkļūdošana</string>
+    <string name="settings_root_format">Formāts</string>
+
+    <!-- Developer settings page -->
+    <string name="settings_developer_preview_day_title">Priekšskatīt dienu</string>
+    <string name="settings_developer_preview_day_subtitle">Apģērbs, baneris un balss jebkurai datumam, izmantojot fiksētu mēreni silta laika paraugu.</string>
+    <string name="settings_developer_pick_date">Izvēlies datumu</string>
+    <string name="settings_developer_today">Šodien</string>
+    <string name="settings_developer_no_theme">Šai dienai nav svētku tēmas.</string>
+    <string name="settings_developer_resolved_label">Atrisināts: %1$s</string>
+    <string name="settings_developer_speak">Nolasīt</string>
+
+    <!-- Smart Home — newer keys -->
+    <string name="settings_smart_home_cast_label">Sūtīt prognozi uz viedo displeju</string>
+    <string name="settings_smart_home_cast_last_published">Pēdējā publikācija %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched">Pēdējā ielāde %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched_never">Displejs vēl nav ielādējis ClothesCast</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_title">Izlaist telefona balsi</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_description">Izvairies no dubultiem paziņojumiem mājās.</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_title">Izlaist telefona balsi</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_description">Izvairies no dubultiem paziņojumiem mājās.</string>
+    <string name="settings_smart_home_mqtt_topic_hint">%1$s/now/text, %1$s/now/audio, utt.</string>
+
+    <!-- Schedule settings -->
+    <string name="settings_schedule_enabled">Ikdienas ClothesCast</string>
+    <string name="settings_delivery_notification">Paziņot</string>
+    <string name="settings_delivery_tts">Nolasīt</string>
+
+    <!-- Clothes-mention picker on Format / Schedule -->
+    <string name="settings_clothes_mention_label">Apģērbs</string>
+    <string name="settings_clothes_mention_always">Vienmēr</string>
+    <string name="settings_clothes_mention_if_changed">Ja mainās</string>
+    <string name="settings_clothes_mention_never">Nekad</string>
+
+    <!-- Format settings page -->
+    <string name="settings_format_preview_example_title">Piemērs</string>
+    <string name="settings_format_preview_current_title">Pašreizējā prognoze</string>
+    <string name="settings_format_preview_current_empty">Prognozes vēl nav — apskaties pēc nākamā ClothesCast.</string>
+    <string name="settings_format_what_to_say">Ko teikt</string>
+    <string name="settings_format_range_label">Temperatūras diapazons</string>
+    <string name="settings_format_range_none">Nav</string>
+    <string name="settings_format_range_degrees">Grādi</string>
+    <string name="settings_format_range_bands">Diapazoni</string>
+    <string name="settings_format_change_label">Temperatūras izmaiņas</string>
+    <string name="settings_format_change_off">Izsl.</string>
+    <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_clothes_label">Apģērba formulējums</string>
+    <string name="settings_format_clothes_items">Apģērba gabali</string>
+    <string name="settings_format_clothes_layer_count">Slāņu skaits</string>
+    <string name="settings_format_bottoms_label">Apakša</string>
+    <string name="settings_format_bottoms_always">Vienmēr</string>
+    <string name="settings_format_bottoms_if_garments">Ja ir augša</string>
+    <string name="settings_format_bottoms_never">Nekad</string>
+    <string name="settings_format_rain_accessory_label">Lietus piederums</string>
+    <string name="settings_format_rain_accessory_none">Izsl.</string>
+    <string name="settings_format_rain_accessory_umbrella">Lietussargs</string>
+
+    <!-- Fallback clothes rules — "If no rules match" section -->
+    <string name="settings_default_outfit_title">Ja neviens noteikums neatbilst</string>
+    <string name="settings_default_top_edit_title">Noklusējuma augša</string>
+    <string name="settings_default_bottom_edit_title">Noklusējuma apakša</string>
+    <string name="settings_default_outfit_range_above">kad temperatūra ir virs %1$s</string>
+    <string name="settings_default_outfit_range_below">kad temperatūra ir zem %1$s</string>
+    <string name="settings_default_outfit_range_between">kad temperatūra ir no %1$s līdz %2$s</string>
+    <string name="settings_default_outfit_range_never">nekad</string>
+
+    <!-- Calendar settings — master switch + per-feature toggles -->
+    <string name="settings_calendar_master">Izmantot manu kalendāru</string>
+    <string name="settings_calendar_master_description">Ļauj ClothesCast lasīt tavus kalendārus, lai pielāgotu prognozes un apģērbu. Nekas nepamet ierīci.</string>
+    <string name="settings_calendar_features_title">Personīgie kalendāri</string>
+    <string name="settings_calendar_evening_tie_ins">Vakara notikumu sasaiste</string>
+    <string name="settings_calendar_evening_tie_ins_description">Ja vakarā kaut kur dodies, rīta prognoze pateiks, vai jāņem kas papildus.</string>
+    <string name="settings_calendar_birthdays_description">Īpašas krāsas un ziņojumi tavu kalendāru dzimšanas dienām.</string>
+    <string name="settings_calendar_public_holidays_description">Īpašas krāsas un ziņojumi tavu kalendāru valsts svētkiem.</string>
+    <string name="settings_calendar_open_system_settings">Atvērt sistēmas iestatījumus</string>
 </resources>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -902,4 +902,83 @@ vs "kemungkinan", "padam" vs "hapus").
     <string name="today_rationale_open_clothes_settings">Tetapan pakaian</string>
     <string name="settings_calendar_birthdays">Hari Jadi Kalendar</string>
     <string name="settings_calendar_public_holidays">Hari Kelepasan Kalendar</string>
+
+    <!-- Settings strings added in 2026-05: Smart Home, Developer, Format, Calendar, Schedule, Default outfit. -->
+    <!-- Settings root labels -->
+    <string name="settings_root_developer">Pembangun</string>
+    <string name="settings_root_developer_subtitle">Pengujian dan Penyahpepijatan</string>
+    <string name="settings_root_format">Format</string>
+
+    <!-- Developer settings page -->
+    <string name="settings_developer_preview_day_title">Pratonton hari</string>
+    <string name="settings_developer_preview_day_subtitle">Pakaian, sepanduk, dan suara untuk tarikh apa pun, menggunakan sampel cuaca sederhana yang tetap.</string>
+    <string name="settings_developer_pick_date">Pilih tarikh</string>
+    <string name="settings_developer_today">Hari ini</string>
+    <string name="settings_developer_no_theme">Tiada tema hari kelepasan untuk hari ini.</string>
+    <string name="settings_developer_resolved_label">Diselesaikan: %1$s</string>
+    <string name="settings_developer_speak">Sebut</string>
+
+    <!-- Smart Home additional keys -->
+    <string name="settings_smart_home_cast_label">Hantar ramalan ke paparan pintar</string>
+    <string name="settings_smart_home_cast_last_published">Terakhir diterbitkan %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched">Terakhir diambil %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched_never">Paparan belum mengambil ClothesCast</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_title">Langkau sebutan pada telefon</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_description">Elakkan pengumuman berulang di rumah.</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_title">Langkau sebutan pada telefon</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_description">Elakkan pengumuman berulang di rumah.</string>
+    <string name="settings_smart_home_mqtt_topic_hint">%1$s/now/text, %1$s/now/audio, dll</string>
+
+    <!-- Schedule settings — Daily ClothesCast -->
+    <string name="settings_schedule_enabled">ClothesCast Harian</string>
+    <string name="settings_delivery_notification">Beritahu</string>
+    <string name="settings_delivery_tts">Sebut</string>
+
+    <!-- Clothes-mention picker -->
+    <string name="settings_clothes_mention_label">Pakaian</string>
+    <string name="settings_clothes_mention_always">Sentiasa</string>
+    <string name="settings_clothes_mention_if_changed">Berubah</string>
+    <string name="settings_clothes_mention_never">Tidak pernah</string>
+
+    <!-- Format settings page -->
+    <string name="settings_format_preview_example_title">Contoh</string>
+    <string name="settings_format_preview_current_title">Ramalan semasa</string>
+    <string name="settings_format_preview_current_empty">Belum ada ramalan — periksa semula selepas ClothesCast seterusnya.</string>
+    <string name="settings_format_what_to_say">Apa yang hendak disebut</string>
+    <string name="settings_format_range_label">Julat suhu</string>
+    <string name="settings_format_range_none">Tiada</string>
+    <string name="settings_format_range_degrees">Darjah</string>
+    <string name="settings_format_range_bands">Tahap</string>
+    <string name="settings_format_change_label">Perubahan suhu</string>
+    <string name="settings_format_change_off">Mati</string>
+    <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_clothes_label">Susunan kata pakaian</string>
+    <string name="settings_format_clothes_items">Pakaian</string>
+    <string name="settings_format_clothes_layer_count">Bilangan lapisan</string>
+    <string name="settings_format_bottoms_label">Bawahan</string>
+    <string name="settings_format_bottoms_always">Sentiasa</string>
+    <string name="settings_format_bottoms_if_garments">Jika ada pakaian</string>
+    <string name="settings_format_bottoms_never">Tidak pernah</string>
+    <string name="settings_format_rain_accessory_label">Aksesori hujan</string>
+    <string name="settings_format_rain_accessory_none">Mati</string>
+    <string name="settings_format_rain_accessory_umbrella">Payung</string>
+
+    <!-- Fallback clothes rules — "If no rules match" -->
+    <string name="settings_default_outfit_title">Jika tiada peraturan sepadan</string>
+    <string name="settings_default_top_edit_title">Atasan lalai</string>
+    <string name="settings_default_bottom_edit_title">Bawahan lalai</string>
+    <string name="settings_default_outfit_range_above">apabila suhu melebihi %1$s</string>
+    <string name="settings_default_outfit_range_below">apabila suhu di bawah %1$s</string>
+    <string name="settings_default_outfit_range_between">apabila suhu antara %1$s dan %2$s</string>
+    <string name="settings_default_outfit_range_never">tidak pernah</string>
+
+    <!-- Calendar settings — master switch + per-feature toggles -->
+    <string name="settings_calendar_master">Gunakan kalendar saya</string>
+    <string name="settings_calendar_master_description">Benarkan ClothesCast membaca kalendar anda untuk memperibadikan ramalan dan pakaian. Tiada apa yang meninggalkan peranti.</string>
+    <string name="settings_calendar_features_title">Kalendar peribadi</string>
+    <string name="settings_calendar_evening_tie_ins">Kaitan acara petang</string>
+    <string name="settings_calendar_evening_tie_ins_description">Jika anda keluar pada waktu petang, ramalan pagi akan memberitahu anda jika anda perlu membawa sesuatu yang tambahan.</string>
+    <string name="settings_calendar_birthdays_description">Gunakan warna dan mesej khas untuk hari jadi dalam kalendar anda.</string>
+    <string name="settings_calendar_public_holidays_description">Gunakan warna dan mesej khas untuk hari kelepasan am dalam kalendar anda.</string>
+    <string name="settings_calendar_open_system_settings">Buka tetapan sistem</string>
 </resources>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -923,4 +923,84 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrike)").
     <string name="holiday_banner_waitangi_day">God Waitangi Day</string>
     <string name="settings_calendar_birthdays">Kalenderbursdag</string>
     <string name="settings_calendar_public_holidays">Kalenderhelligdager</string>
+
+    <!-- Settings strings added in 2026-05: Smart Home, Developer, Format, Calendar, Schedule, Default outfit. -->
+
+    <!-- Settings root labels — Developer, Format -->
+    <string name="settings_root_developer">Utvikler</string>
+    <string name="settings_root_developer_subtitle">Testing og feilsøking</string>
+    <string name="settings_root_format">Format</string>
+
+    <!-- Developer settings page -->
+    <string name="settings_developer_preview_day_title">Forhåndsvis en dag</string>
+    <string name="settings_developer_preview_day_subtitle">Antrekk, banner og stemme for en valgfri dato, basert på et fast prøvevær med mildt vær.</string>
+    <string name="settings_developer_pick_date">Velg en dato</string>
+    <string name="settings_developer_today">I dag</string>
+    <string name="settings_developer_no_theme">Ingen helligdagstema for denne dagen.</string>
+    <string name="settings_developer_resolved_label">Løst: %1$s</string>
+    <string name="settings_developer_speak">Les opp</string>
+
+    <!-- Smart Home — additional keys -->
+    <string name="settings_smart_home_cast_label">Send prognose til smartskjerm</string>
+    <string name="settings_smart_home_cast_last_published">Sist publisert %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched">Sist hentet %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched_never">Skjermen har ikke hentet en ClothesCast ennå</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_title">Hopp over tale på telefonen</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_description">Unngå doble kunngjøringer hjemme.</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_title">Hopp over tale på telefonen</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_description">Unngå doble kunngjøringer hjemme.</string>
+    <string name="settings_smart_home_mqtt_topic_hint">%1$s/now/text, %1$s/now/audio osv.</string>
+
+    <!-- Schedule settings — Daily ClothesCast -->
+    <string name="settings_schedule_enabled">Daglig ClothesCast</string>
+    <string name="settings_delivery_notification">Varsle</string>
+    <string name="settings_delivery_tts">Les opp</string>
+
+    <!-- Clothes-mention picker on Format / Schedule -->
+    <string name="settings_clothes_mention_label">Klær</string>
+    <string name="settings_clothes_mention_always">Alltid</string>
+    <string name="settings_clothes_mention_if_changed">Ved endring</string>
+    <string name="settings_clothes_mention_never">Aldri</string>
+
+    <!-- Format settings page -->
+    <string name="settings_format_preview_example_title">Eksempel</string>
+    <string name="settings_format_preview_current_title">Gjeldende prognose</string>
+    <string name="settings_format_preview_current_empty">Ingen prognose ennå — kom tilbake etter ditt neste ClothesCast.</string>
+    <string name="settings_format_what_to_say">Hva som skal sies</string>
+    <string name="settings_format_range_label">Temperaturområde</string>
+    <string name="settings_format_range_none">Ingen</string>
+    <string name="settings_format_range_degrees">Grader</string>
+    <string name="settings_format_range_bands">Nivåer</string>
+    <string name="settings_format_change_label">Temperaturendring</string>
+    <string name="settings_format_change_off">Av</string>
+    <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_clothes_label">Klesformulering</string>
+    <string name="settings_format_clothes_items">Plagg</string>
+    <string name="settings_format_clothes_layer_count">Antall lag</string>
+    <string name="settings_format_bottoms_label">Underdeler</string>
+    <string name="settings_format_bottoms_always">Alltid</string>
+    <string name="settings_format_bottoms_if_garments">Ved plagg</string>
+    <string name="settings_format_bottoms_never">Aldri</string>
+    <string name="settings_format_rain_accessory_label">Regntilbehør</string>
+    <string name="settings_format_rain_accessory_none">Av</string>
+    <string name="settings_format_rain_accessory_umbrella">Paraply</string>
+
+    <!-- Fallback clothes rules — "If no rules match" section -->
+    <string name="settings_default_outfit_title">Hvis ingen regler passer</string>
+    <string name="settings_default_top_edit_title">Standard overdel</string>
+    <string name="settings_default_bottom_edit_title">Standard underdel</string>
+    <string name="settings_default_outfit_range_above">når temperaturen er over %1$s</string>
+    <string name="settings_default_outfit_range_below">når temperaturen er under %1$s</string>
+    <string name="settings_default_outfit_range_between">når temperaturen er mellom %1$s og %2$s</string>
+    <string name="settings_default_outfit_range_never">aldri</string>
+
+    <!-- Calendar settings — master switch + per-feature toggles -->
+    <string name="settings_calendar_master">Bruk kalenderen min</string>
+    <string name="settings_calendar_master_description">La ClothesCast lese kalenderne dine for å tilpasse prognoser og antrekk. Ingenting forlater enheten.</string>
+    <string name="settings_calendar_features_title">Personlige kalendere</string>
+    <string name="settings_calendar_evening_tie_ins">Kveldskoblinger</string>
+    <string name="settings_calendar_evening_tie_ins_description">Hvis du går ut på kvelden, forteller morgenprognosen deg om du må ta med noe ekstra.</string>
+    <string name="settings_calendar_birthdays_description">Bruk spesielle farger og meldinger for bursdager i kalenderne dine.</string>
+    <string name="settings_calendar_public_holidays_description">Bruk spesielle farger og meldinger for helligdager i kalenderne dine.</string>
+    <string name="settings_calendar_open_system_settings">Åpne systeminnstillinger</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -943,4 +943,84 @@ the displayed label localizes.
     <string name="holiday_banner_waitangi_day">Fijne Waitangidag</string>
     <string name="settings_calendar_birthdays">Kalenderverjaardagen</string>
     <string name="settings_calendar_public_holidays">Kalenderfeestdagen</string>
+
+    <!-- Settings strings added in 2026-05: Smart Home, Developer, Format, Calendar, Schedule, Default outfit. -->
+
+    <!-- Settings root labels — Developer, Format -->
+    <string name="settings_root_developer">Ontwikkelaar</string>
+    <string name="settings_root_developer_subtitle">Testen en foutopsporing</string>
+    <string name="settings_root_format">Format</string>
+
+    <!-- Developer settings page -->
+    <string name="settings_developer_preview_day_title">Een dag bekijken</string>
+    <string name="settings_developer_preview_day_subtitle">Outfit, banner en stem voor een willekeurige datum, op basis van een vast mild-weervoorbeeld.</string>
+    <string name="settings_developer_pick_date">Kies een datum</string>
+    <string name="settings_developer_today">Vandaag</string>
+    <string name="settings_developer_no_theme">Geen feestdagthema voor deze dag.</string>
+    <string name="settings_developer_resolved_label">Opgelost: %1$s</string>
+    <string name="settings_developer_speak">Voorlezen</string>
+
+    <!-- Smart Home — additional keys -->
+    <string name="settings_smart_home_cast_label">Voorspelling naar smart display sturen</string>
+    <string name="settings_smart_home_cast_last_published">Laatst gepubliceerd %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched">Laatst opgehaald %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched_never">Display heeft nog geen ClothesCast opgehaald</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_title">Telefoonspraak overslaan</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_description">Vermijd dubbele aankondigingen thuis.</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_title">Telefoonspraak overslaan</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_description">Vermijd dubbele aankondigingen thuis.</string>
+    <string name="settings_smart_home_mqtt_topic_hint">%1$s/now/text, %1$s/now/audio enz.</string>
+
+    <!-- Schedule settings — Daily ClothesCast -->
+    <string name="settings_schedule_enabled">Dagelijkse ClothesCast</string>
+    <string name="settings_delivery_notification">Meld</string>
+    <string name="settings_delivery_tts">Voorlezen</string>
+
+    <!-- Clothes-mention picker on Format / Schedule -->
+    <string name="settings_clothes_mention_label">Kleding</string>
+    <string name="settings_clothes_mention_always">Altijd</string>
+    <string name="settings_clothes_mention_if_changed">Bij wijziging</string>
+    <string name="settings_clothes_mention_never">Nooit</string>
+
+    <!-- Format settings page -->
+    <string name="settings_format_preview_example_title">Voorbeeld</string>
+    <string name="settings_format_preview_current_title">Huidige voorspelling</string>
+    <string name="settings_format_preview_current_empty">Nog geen voorspelling — kom terug na je volgende ClothesCast.</string>
+    <string name="settings_format_what_to_say">Wat te zeggen</string>
+    <string name="settings_format_range_label">Temperatuurbereik</string>
+    <string name="settings_format_range_none">Geen</string>
+    <string name="settings_format_range_degrees">Graden</string>
+    <string name="settings_format_range_bands">Niveaus</string>
+    <string name="settings_format_change_label">Temperatuurverandering</string>
+    <string name="settings_format_change_off">Uit</string>
+    <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_clothes_label">Kledingformulering</string>
+    <string name="settings_format_clothes_items">Kledingstukken</string>
+    <string name="settings_format_clothes_layer_count">Aantal lagen</string>
+    <string name="settings_format_bottoms_label">Onderkleding</string>
+    <string name="settings_format_bottoms_always">Altijd</string>
+    <string name="settings_format_bottoms_if_garments">Bij kledingstukken</string>
+    <string name="settings_format_bottoms_never">Nooit</string>
+    <string name="settings_format_rain_accessory_label">Regenaccessoire</string>
+    <string name="settings_format_rain_accessory_none">Uit</string>
+    <string name="settings_format_rain_accessory_umbrella">Paraplu</string>
+
+    <!-- Fallback clothes rules — "If no rules match" section -->
+    <string name="settings_default_outfit_title">Als geen enkele regel past</string>
+    <string name="settings_default_top_edit_title">Standaard bovenkleding</string>
+    <string name="settings_default_bottom_edit_title">Standaard onderkleding</string>
+    <string name="settings_default_outfit_range_above">wanneer de temperatuur boven %1$s is</string>
+    <string name="settings_default_outfit_range_below">wanneer de temperatuur onder %1$s is</string>
+    <string name="settings_default_outfit_range_between">wanneer de temperatuur tussen %1$s en %2$s ligt</string>
+    <string name="settings_default_outfit_range_never">nooit</string>
+
+    <!-- Calendar settings — master switch + per-feature toggles -->
+    <string name="settings_calendar_master">Mijn agenda gebruiken</string>
+    <string name="settings_calendar_master_description">Laat ClothesCast je agenda\'s lezen om voorspellingen en outfits te personaliseren. Niets verlaat het apparaat.</string>
+    <string name="settings_calendar_features_title">Persoonlijke agenda\'s</string>
+    <string name="settings_calendar_evening_tie_ins">Avondkoppelingen</string>
+    <string name="settings_calendar_evening_tie_ins_description">Als je \'s avonds uitgaat, vertelt de ochtendvoorspelling je of je iets extra\'s moet meenemen.</string>
+    <string name="settings_calendar_birthdays_description">Gebruik speciale kleuren en berichten voor verjaardagen in je agenda\'s.</string>
+    <string name="settings_calendar_public_holidays_description">Gebruik speciale kleuren en berichten voor feestdagen in je agenda\'s.</string>
+    <string name="settings_calendar_open_system_settings">Systeeminstellingen openen</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -942,4 +942,83 @@ is unchanged; only the displayed label localizes.
     <string name="holiday_banner_st_andrews_day">Wesołego Dnia Świętego Andrzeja</string>
     <string name="settings_calendar_birthdays">Urodziny z kalendarza</string>
     <string name="settings_calendar_public_holidays">Święta z kalendarza</string>
+
+    <!-- Settings strings added in 2026-05: Smart Home, Developer, Format, Calendar, Schedule, Default outfit. -->
+    <!-- Settings root labels — Developer, Format. -->
+    <string name="settings_root_developer">Deweloper</string>
+    <string name="settings_root_developer_subtitle">Testowanie i debugowanie</string>
+    <string name="settings_root_format">Format</string>
+
+    <!-- Developer settings page (Settings → Developer → Preview a day) -->
+    <string name="settings_developer_preview_day_title">Podgląd dnia</string>
+    <string name="settings_developer_preview_day_subtitle">Strój, baner i głos dla dowolnej daty, z użyciem stałej próbki łagodnej pogody.</string>
+    <string name="settings_developer_pick_date">Wybierz datę</string>
+    <string name="settings_developer_today">Dziś</string>
+    <string name="settings_developer_no_theme">Brak motywu świątecznego dla tego dnia.</string>
+    <string name="settings_developer_resolved_label">Rozwiązane: %1$s</string>
+    <string name="settings_developer_speak">Przeczytaj</string>
+
+    <!-- Smart Home — newer keys. -->
+    <string name="settings_smart_home_cast_label">Wyślij prognozę na inteligentny wyświetlacz</string>
+    <string name="settings_smart_home_cast_last_published">Ostatnio opublikowano %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched">Ostatnio pobrano %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched_never">Wyświetlacz nie pobrał jeszcze żadnego ClothesCasta</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_title">Pomiń mowę w telefonie</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_description">Unikniesz zduplikowanych powiadomień w domu.</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_title">Pomiń mowę w telefonie</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_description">Unikniesz zduplikowanych powiadomień w domu.</string>
+    <string name="settings_smart_home_mqtt_topic_hint">%1$s/now/text, %1$s/now/audio, itp.</string>
+
+    <!-- Schedule settings — Daily ClothesCast -->
+    <string name="settings_schedule_enabled">Codzienny ClothesCast</string>
+    <string name="settings_delivery_notification">Powiadom</string>
+    <string name="settings_delivery_tts">Przeczytaj</string>
+
+    <!-- Clothes-mention picker on Format / Schedule -->
+    <string name="settings_clothes_mention_label">Ubrania</string>
+    <string name="settings_clothes_mention_always">Zawsze</string>
+    <string name="settings_clothes_mention_if_changed">Zmiana</string>
+    <string name="settings_clothes_mention_never">Nigdy</string>
+
+    <!-- Format settings page -->
+    <string name="settings_format_preview_example_title">Przykład</string>
+    <string name="settings_format_preview_current_title">Aktualna prognoza</string>
+    <string name="settings_format_preview_current_empty">Brak prognozy — sprawdź po kolejnym ClothesCaście.</string>
+    <string name="settings_format_what_to_say">Co mówić</string>
+    <string name="settings_format_range_label">Zakres temperatur</string>
+    <string name="settings_format_range_none">Brak</string>
+    <string name="settings_format_range_degrees">Stopnie</string>
+    <string name="settings_format_range_bands">Pasma</string>
+    <string name="settings_format_change_label">Zmiana temperatury</string>
+    <string name="settings_format_change_off">Wyłączone</string>
+    <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_clothes_label">Opis ubrań</string>
+    <string name="settings_format_clothes_items">Elementy garderoby</string>
+    <string name="settings_format_clothes_layer_count">Liczba warstw</string>
+    <string name="settings_format_bottoms_label">Dolne części</string>
+    <string name="settings_format_bottoms_always">Zawsze</string>
+    <string name="settings_format_bottoms_if_garments">Gdy są części</string>
+    <string name="settings_format_bottoms_never">Nigdy</string>
+    <string name="settings_format_rain_accessory_label">Akcesorium na deszcz</string>
+    <string name="settings_format_rain_accessory_none">Wyłączone</string>
+    <string name="settings_format_rain_accessory_umbrella">Parasol</string>
+
+    <!-- Fallback clothes rules — "If no rules match" section -->
+    <string name="settings_default_outfit_title">Gdy żadna reguła nie pasuje</string>
+    <string name="settings_default_top_edit_title">Domyślna góra</string>
+    <string name="settings_default_bottom_edit_title">Domyślny dół</string>
+    <string name="settings_default_outfit_range_above">gdy temperatura jest powyżej %1$s</string>
+    <string name="settings_default_outfit_range_below">gdy temperatura jest poniżej %1$s</string>
+    <string name="settings_default_outfit_range_between">gdy temperatura jest między %1$s a %2$s</string>
+    <string name="settings_default_outfit_range_never">nigdy</string>
+
+    <!-- Calendar settings — master switch + per-feature toggles -->
+    <string name="settings_calendar_master">Użyj mojego kalendarza</string>
+    <string name="settings_calendar_master_description">Pozwól ClothesCastowi czytać twoje kalendarze, aby spersonalizować prognozy i stroje. Nic nie opuszcza urządzenia.</string>
+    <string name="settings_calendar_features_title">Osobiste kalendarze</string>
+    <string name="settings_calendar_evening_tie_ins">Wieczorne powiązania</string>
+    <string name="settings_calendar_evening_tie_ins_description">Jeśli wieczorem wychodzisz, poranna prognoza powie ci, czy potrzebujesz wziąć coś dodatkowego.</string>
+    <string name="settings_calendar_birthdays_description">Używaj specjalnych kolorów i komunikatów dla urodzin w twoich kalendarzach.</string>
+    <string name="settings_calendar_public_holidays_description">Używaj specjalnych kolorów i komunikatów dla świąt państwowych w twoich kalendarzach.</string>
+    <string name="settings_calendar_open_system_settings">Otwórz ustawienia systemowe</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -979,4 +979,84 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="holiday_banner_st_andrews_day">Feliz Dia de Santo André</string>
     <string name="settings_calendar_birthdays">Aniversários do Calendário</string>
     <string name="settings_calendar_public_holidays">Feriados do Calendário</string>
+
+    <!-- Settings strings added in 2026-05: Smart Home, Developer, Format, Calendar, Schedule, Default outfit. -->
+
+    <!-- Settings root labels — Developer, Format -->
+    <string name="settings_root_developer">Desenvolvedor</string>
+    <string name="settings_root_developer_subtitle">Teste e depuração</string>
+    <string name="settings_root_format">Formato</string>
+
+    <!-- Developer settings page -->
+    <string name="settings_developer_preview_day_title">Pré-visualizar um dia</string>
+    <string name="settings_developer_preview_day_subtitle">Roupa, banner e voz para qualquer data, usando uma amostra fixa de tempo ameno.</string>
+    <string name="settings_developer_pick_date">Escolha uma data</string>
+    <string name="settings_developer_today">Hoje</string>
+    <string name="settings_developer_no_theme">Sem tema festivo para este dia.</string>
+    <string name="settings_developer_resolved_label">Resolvido: %1$s</string>
+    <string name="settings_developer_speak">Reproduzir voz</string>
+
+    <!-- Smart Home — newer keys -->
+    <string name="settings_smart_home_cast_label">Enviar previsão para a tela inteligente</string>
+    <string name="settings_smart_home_cast_last_published">Última publicação %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched">Última obtenção %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched_never">A tela ainda não obteve nenhum ClothesCast</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_title">Ignorar leitura no celular</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_description">Evite anúncios duplicados em casa.</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_title">Ignorar leitura no celular</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_description">Evite anúncios duplicados em casa.</string>
+    <string name="settings_smart_home_mqtt_topic_hint">%1$s/now/text, %1$s/now/audio, etc.</string>
+
+    <!-- Schedule settings -->
+    <string name="settings_schedule_enabled">ClothesCast diário</string>
+    <string name="settings_delivery_notification">Notificar</string>
+    <string name="settings_delivery_tts">Reproduzir voz</string>
+
+    <!-- Clothes-mention picker on Format / Schedule -->
+    <string name="settings_clothes_mention_label">Roupa</string>
+    <string name="settings_clothes_mention_always">Sempre</string>
+    <string name="settings_clothes_mention_if_changed">Mudança</string>
+    <string name="settings_clothes_mention_never">Nunca</string>
+
+    <!-- Format settings page -->
+    <string name="settings_format_preview_example_title">Exemplo</string>
+    <string name="settings_format_preview_current_title">Previsão atual</string>
+    <string name="settings_format_preview_current_empty">Ainda sem previsão — volte após o seu próximo ClothesCast.</string>
+    <string name="settings_format_what_to_say">O que dizer</string>
+    <string name="settings_format_range_label">Intervalo de temperatura</string>
+    <string name="settings_format_range_none">Nenhum</string>
+    <string name="settings_format_range_degrees">Graus</string>
+    <string name="settings_format_range_bands">Categorias</string>
+    <string name="settings_format_change_label">Variação de temperatura</string>
+    <string name="settings_format_change_off">Desativado</string>
+    <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_clothes_label">Redação das roupas</string>
+    <string name="settings_format_clothes_items">Peças</string>
+    <string name="settings_format_clothes_layer_count">Número de camadas</string>
+    <string name="settings_format_bottoms_label">Calça</string>
+    <string name="settings_format_bottoms_always">Sempre</string>
+    <string name="settings_format_bottoms_if_garments">Se houver peças</string>
+    <string name="settings_format_bottoms_never">Nunca</string>
+    <string name="settings_format_rain_accessory_label">Acessório de chuva</string>
+    <string name="settings_format_rain_accessory_none">Desativado</string>
+    <string name="settings_format_rain_accessory_umbrella">Guarda-chuva</string>
+
+    <!-- Fallback clothes rules — "If no rules match" section -->
+    <string name="settings_default_outfit_title">Se nenhuma regra corresponder</string>
+    <string name="settings_default_top_edit_title">Peça superior padrão</string>
+    <string name="settings_default_bottom_edit_title">Calça padrão</string>
+    <string name="settings_default_outfit_range_above">quando a temperatura estiver acima de %1$s</string>
+    <string name="settings_default_outfit_range_below">quando a temperatura estiver abaixo de %1$s</string>
+    <string name="settings_default_outfit_range_between">quando a temperatura estiver entre %1$s e %2$s</string>
+    <string name="settings_default_outfit_range_never">nunca</string>
+
+    <!-- Calendar settings — master switch + per-feature toggles -->
+    <string name="settings_calendar_master">Usar meu calendário</string>
+    <string name="settings_calendar_master_description">Permita que o ClothesCast leia seus calendários para personalizar previsões e roupas. Nada sai do dispositivo.</string>
+    <string name="settings_calendar_features_title">Calendários pessoais</string>
+    <string name="settings_calendar_evening_tie_ins">Menções à noite</string>
+    <string name="settings_calendar_evening_tie_ins_description">Se você for sair à noite, a previsão da manhã avisa se precisa levar algo a mais.</string>
+    <string name="settings_calendar_birthdays_description">Use cores e mensagens especiais para os aniversários nos seus calendários.</string>
+    <string name="settings_calendar_public_holidays_description">Use cores e mensagens especiais para os feriados nos seus calendários.</string>
+    <string name="settings_calendar_open_system_settings">Abrir configurações do sistema</string>
 </resources>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -1022,4 +1022,84 @@ they diverge from BR ("Polonês" → "Polaco", "Holandês" →
     <string name="holiday_banner_st_andrews_day">Feliz Dia de Santo André</string>
     <string name="settings_calendar_birthdays">Aniversários do Calendário</string>
     <string name="settings_calendar_public_holidays">Feriados do Calendário</string>
+
+    <!-- Settings strings added in 2026-05: Smart Home, Developer, Format, Calendar, Schedule, Default outfit. -->
+
+    <!-- Settings root labels — Developer, Format. -->
+    <string name="settings_root_developer">Programador</string>
+    <string name="settings_root_developer_subtitle">Testes e depuração</string>
+    <string name="settings_root_format">Formato</string>
+
+    <!-- Developer settings page -->
+    <string name="settings_developer_preview_day_title">Pré-visualizar um dia</string>
+    <string name="settings_developer_preview_day_subtitle">Vestuário, banner e voz para qualquer data, com uma amostra fixa de tempo ameno.</string>
+    <string name="settings_developer_pick_date">Escolhe uma data</string>
+    <string name="settings_developer_today">Hoje</string>
+    <string name="settings_developer_no_theme">Sem tema festivo para este dia.</string>
+    <string name="settings_developer_resolved_label">Resolvido: %1$s</string>
+    <string name="settings_developer_speak">Ler em voz alta</string>
+
+    <!-- Smart Home — newer keys. -->
+    <string name="settings_smart_home_cast_label">Enviar previsão para o ecrã inteligente</string>
+    <string name="settings_smart_home_cast_last_published">Última publicação %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched">Última obtenção %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched_never">O ecrã ainda não obteve nenhum ClothesCast</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_title">Ignorar leitura no telemóvel</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_description">Evita anúncios em duplicado em casa.</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_title">Ignorar leitura no telemóvel</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_description">Evita anúncios em duplicado em casa.</string>
+    <string name="settings_smart_home_mqtt_topic_hint">%1$s/now/text, %1$s/now/audio, etc</string>
+
+    <!-- Schedule settings — Daily ClothesCast -->
+    <string name="settings_schedule_enabled">ClothesCast diário</string>
+    <string name="settings_delivery_notification">Notificar</string>
+    <string name="settings_delivery_tts">Ler em voz alta</string>
+
+    <!-- Clothes-mention picker on Format / Schedule -->
+    <string name="settings_clothes_mention_label">Vestuário</string>
+    <string name="settings_clothes_mention_always">Sempre</string>
+    <string name="settings_clothes_mention_if_changed">Mudança</string>
+    <string name="settings_clothes_mention_never">Nunca</string>
+
+    <!-- Format settings page -->
+    <string name="settings_format_preview_example_title">Exemplo</string>
+    <string name="settings_format_preview_current_title">Previsão atual</string>
+    <string name="settings_format_preview_current_empty">Ainda sem previsão — volta após o teu próximo ClothesCast.</string>
+    <string name="settings_format_what_to_say">O que dizer</string>
+    <string name="settings_format_range_label">Intervalo de temperatura</string>
+    <string name="settings_format_range_none">Nenhum</string>
+    <string name="settings_format_range_degrees">Graus</string>
+    <string name="settings_format_range_bands">Bandas</string>
+    <string name="settings_format_change_label">Variação de temperatura</string>
+    <string name="settings_format_change_off">Desligado</string>
+    <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_clothes_label">Redação do vestuário</string>
+    <string name="settings_format_clothes_items">Peças</string>
+    <string name="settings_format_clothes_layer_count">Número de camadas</string>
+    <string name="settings_format_bottoms_label">Parte de baixo</string>
+    <string name="settings_format_bottoms_always">Sempre</string>
+    <string name="settings_format_bottoms_if_garments">Se houver peças</string>
+    <string name="settings_format_bottoms_never">Nunca</string>
+    <string name="settings_format_rain_accessory_label">Acessório de chuva</string>
+    <string name="settings_format_rain_accessory_none">Desligado</string>
+    <string name="settings_format_rain_accessory_umbrella">Chapéu de chuva</string>
+
+    <!-- Fallback clothes rules — "If no rules match" section -->
+    <string name="settings_default_outfit_title">Se nenhuma regra corresponder</string>
+    <string name="settings_default_top_edit_title">Peça superior predefinida</string>
+    <string name="settings_default_bottom_edit_title">Peça inferior predefinida</string>
+    <string name="settings_default_outfit_range_above">quando a temperatura for superior a %1$s</string>
+    <string name="settings_default_outfit_range_below">quando a temperatura for inferior a %1$s</string>
+    <string name="settings_default_outfit_range_between">quando a temperatura estiver entre %1$s e %2$s</string>
+    <string name="settings_default_outfit_range_never">nunca</string>
+
+    <!-- Calendar settings — master switch + per-feature toggles -->
+    <string name="settings_calendar_master">Usar o meu calendário</string>
+    <string name="settings_calendar_master_description">Permite ao ClothesCast ler os teus calendários para personalizar previsões e vestuário. Nada sai do dispositivo.</string>
+    <string name="settings_calendar_features_title">Calendários pessoais</string>
+    <string name="settings_calendar_evening_tie_ins">Ligações com a noite</string>
+    <string name="settings_calendar_evening_tie_ins_description">Se vais sair à noite, a previsão matinal diz-te se precisas de levar algo extra.</string>
+    <string name="settings_calendar_birthdays_description">Usa cores e mensagens especiais para aniversários nos teus calendários.</string>
+    <string name="settings_calendar_public_holidays_description">Usa cores e mensagens especiais para feriados nos teus calendários.</string>
+    <string name="settings_calendar_open_system_settings">Abrir definições do sistema</string>
 </resources>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -871,4 +871,84 @@ surfaces fall back to default English (matching values-pl / values-uk).
     <string name="cast_error_unknown">Transmisia a eșuat.</string>
     <string name="settings_calendar_birthdays">Zile de naștere din calendar</string>
     <string name="settings_calendar_public_holidays">Sărbători din calendar</string>
+
+    <!-- Settings strings added in 2026-05: Smart Home, Developer, Format, Calendar, Schedule, Default outfit. -->
+
+    <!-- Settings root labels — Developer, Format. -->
+    <string name="settings_root_developer">Dezvoltator</string>
+    <string name="settings_root_developer_subtitle">Testare și depanare</string>
+    <string name="settings_root_format">Format</string>
+
+    <!-- Developer settings page -->
+    <string name="settings_developer_preview_day_title">Previzualizează o zi</string>
+    <string name="settings_developer_preview_day_subtitle">Ținută, banner și voce pentru orice dată, folosind un eșantion fix de vreme blândă.</string>
+    <string name="settings_developer_pick_date">Alege o dată</string>
+    <string name="settings_developer_today">Astăzi</string>
+    <string name="settings_developer_no_theme">Nicio temă de sărbătoare pentru această zi.</string>
+    <string name="settings_developer_resolved_label">Rezolvat: %1$s</string>
+    <string name="settings_developer_speak">Citește</string>
+
+    <!-- Smart Home — newer keys. -->
+    <string name="settings_smart_home_cast_label">Trimite prognoza la afișajul inteligent</string>
+    <string name="settings_smart_home_cast_last_published">Ultima publicare %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched">Ultima preluare %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched_never">Afișajul nu a preluat încă niciun ClothesCast</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_title">Omite citirea pe telefon</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_description">Evită anunțurile duplicate acasă.</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_title">Omite citirea pe telefon</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_description">Evită anunțurile duplicate acasă.</string>
+    <string name="settings_smart_home_mqtt_topic_hint">%1$s/now/text, %1$s/now/audio, etc</string>
+
+    <!-- Schedule settings — Daily ClothesCast -->
+    <string name="settings_schedule_enabled">ClothesCast zilnic</string>
+    <string name="settings_delivery_notification">Notifică</string>
+    <string name="settings_delivery_tts">Citește</string>
+
+    <!-- Clothes-mention picker on Format / Schedule -->
+    <string name="settings_clothes_mention_label">Îmbrăcăminte</string>
+    <string name="settings_clothes_mention_always">Mereu</string>
+    <string name="settings_clothes_mention_if_changed">La schimbare</string>
+    <string name="settings_clothes_mention_never">Niciodată</string>
+
+    <!-- Format settings page -->
+    <string name="settings_format_preview_example_title">Exemplu</string>
+    <string name="settings_format_preview_current_title">Prognoza curentă</string>
+    <string name="settings_format_preview_current_empty">Nicio prognoză încă — revino după următorul ClothesCast.</string>
+    <string name="settings_format_what_to_say">Ce să spună</string>
+    <string name="settings_format_range_label">Interval de temperatură</string>
+    <string name="settings_format_range_none">Niciunul</string>
+    <string name="settings_format_range_degrees">Grade</string>
+    <string name="settings_format_range_bands">Benzi</string>
+    <string name="settings_format_change_label">Variație de temperatură</string>
+    <string name="settings_format_change_off">Oprit</string>
+    <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_clothes_label">Formulare pentru îmbrăcăminte</string>
+    <string name="settings_format_clothes_items">Articole</string>
+    <string name="settings_format_clothes_layer_count">Numărul de straturi</string>
+    <string name="settings_format_bottoms_label">Pantaloni</string>
+    <string name="settings_format_bottoms_always">Mereu</string>
+    <string name="settings_format_bottoms_if_garments">Dacă există articole</string>
+    <string name="settings_format_bottoms_never">Niciodată</string>
+    <string name="settings_format_rain_accessory_label">Accesoriu pentru ploaie</string>
+    <string name="settings_format_rain_accessory_none">Oprit</string>
+    <string name="settings_format_rain_accessory_umbrella">Umbrelă</string>
+
+    <!-- Fallback clothes rules — "If no rules match" section -->
+    <string name="settings_default_outfit_title">Dacă nicio regulă nu se potrivește</string>
+    <string name="settings_default_top_edit_title">Articol implicit pentru sus</string>
+    <string name="settings_default_bottom_edit_title">Articol implicit pentru jos</string>
+    <string name="settings_default_outfit_range_above">când temperatura este peste %1$s</string>
+    <string name="settings_default_outfit_range_below">când temperatura este sub %1$s</string>
+    <string name="settings_default_outfit_range_between">când temperatura este între %1$s și %2$s</string>
+    <string name="settings_default_outfit_range_never">niciodată</string>
+
+    <!-- Calendar settings — master switch + per-feature toggles -->
+    <string name="settings_calendar_master">Folosește calendarul meu</string>
+    <string name="settings_calendar_master_description">Permite ClothesCast să citească calendarele tale pentru a personaliza prognozele și ținutele. Nimic nu părăsește dispozitivul.</string>
+    <string name="settings_calendar_features_title">Calendare personale</string>
+    <string name="settings_calendar_evening_tie_ins">Legături cu evenimentele de seară</string>
+    <string name="settings_calendar_evening_tie_ins_description">Dacă ieși seara, prognoza de dimineață îți spune dacă trebuie să iei ceva în plus.</string>
+    <string name="settings_calendar_birthdays_description">Folosește culori și mesaje speciale pentru zilele de naștere din calendarele tale.</string>
+    <string name="settings_calendar_public_holidays_description">Folosește culori și mesaje speciale pentru sărbătorile din calendarele tale.</string>
+    <string name="settings_calendar_open_system_settings">Deschide setările sistemului</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -949,4 +949,83 @@ only the displayed label localizes.
     <string name="holiday_banner_st_andrews_day">С Днём святого Андрея</string>
     <string name="settings_calendar_birthdays">Дни рождения в календаре</string>
     <string name="settings_calendar_public_holidays">Праздники в календаре</string>
+
+    <!-- Settings strings added in 2026-05: Smart Home, Developer, Format, Calendar, Schedule, Default outfit. -->
+    <!-- Settings root labels -->
+    <string name="settings_root_developer">Разработчик</string>
+    <string name="settings_root_developer_subtitle">Тестирование и отладка</string>
+    <string name="settings_root_format">Формат</string>
+
+    <!-- Developer settings page -->
+    <string name="settings_developer_preview_day_title">Предпросмотр дня</string>
+    <string name="settings_developer_preview_day_subtitle">Образ, баннер и голос для любой даты на основе фиксированного примера мягкой погоды.</string>
+    <string name="settings_developer_pick_date">Выбери дату</string>
+    <string name="settings_developer_today">Сегодня</string>
+    <string name="settings_developer_no_theme">Нет праздничной темы для этого дня.</string>
+    <string name="settings_developer_resolved_label">Разрешено: %1$s</string>
+    <string name="settings_developer_speak">Озвучить</string>
+
+    <!-- Smart Home — newer keys -->
+    <string name="settings_smart_home_cast_label">Отправить прогноз на умный дисплей</string>
+    <string name="settings_smart_home_cast_last_published">Последняя публикация %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched">Последняя загрузка %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched_never">Дисплей ещё не загружал ClothesCast</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_title">Не озвучивать на телефоне</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_description">Избегай двойных объявлений дома.</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_title">Не озвучивать на телефоне</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_description">Избегай двойных объявлений дома.</string>
+    <string name="settings_smart_home_mqtt_topic_hint">%1$s/now/text, %1$s/now/audio, и т. д.</string>
+
+    <!-- Schedule settings -->
+    <string name="settings_schedule_enabled">Ежедневный ClothesCast</string>
+    <string name="settings_delivery_notification">Уведомить</string>
+    <string name="settings_delivery_tts">Озвучить</string>
+
+    <!-- Clothes-mention picker on Format / Schedule -->
+    <string name="settings_clothes_mention_label">Одежда</string>
+    <string name="settings_clothes_mention_always">Всегда</string>
+    <string name="settings_clothes_mention_if_changed">При изменении</string>
+    <string name="settings_clothes_mention_never">Никогда</string>
+
+    <!-- Format settings page -->
+    <string name="settings_format_preview_example_title">Пример</string>
+    <string name="settings_format_preview_current_title">Текущий прогноз</string>
+    <string name="settings_format_preview_current_empty">Прогноза пока нет — загляни после следующего ClothesCast.</string>
+    <string name="settings_format_what_to_say">Что говорить</string>
+    <string name="settings_format_range_label">Диапазон температур</string>
+    <string name="settings_format_range_none">Нет</string>
+    <string name="settings_format_range_degrees">Градусы</string>
+    <string name="settings_format_range_bands">Диапазоны</string>
+    <string name="settings_format_change_label">Изменение температуры</string>
+    <string name="settings_format_change_off">Выкл.</string>
+    <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_clothes_label">Описание одежды</string>
+    <string name="settings_format_clothes_items">Предметы</string>
+    <string name="settings_format_clothes_layer_count">Количество слоёв</string>
+    <string name="settings_format_bottoms_label">Низ</string>
+    <string name="settings_format_bottoms_always">Всегда</string>
+    <string name="settings_format_bottoms_if_garments">Если есть верх</string>
+    <string name="settings_format_bottoms_never">Никогда</string>
+    <string name="settings_format_rain_accessory_label">Аксессуар от дождя</string>
+    <string name="settings_format_rain_accessory_none">Выкл.</string>
+    <string name="settings_format_rain_accessory_umbrella">Зонт</string>
+
+    <!-- Fallback clothes rules — "If no rules match" section -->
+    <string name="settings_default_outfit_title">Если ни одно правило не подходит</string>
+    <string name="settings_default_top_edit_title">Верх по умолчанию</string>
+    <string name="settings_default_bottom_edit_title">Низ по умолчанию</string>
+    <string name="settings_default_outfit_range_above">когда температура выше %1$s</string>
+    <string name="settings_default_outfit_range_below">когда температура ниже %1$s</string>
+    <string name="settings_default_outfit_range_between">когда температура от %1$s до %2$s</string>
+    <string name="settings_default_outfit_range_never">никогда</string>
+
+    <!-- Calendar settings — master switch + per-feature toggles -->
+    <string name="settings_calendar_master">Использовать мой календарь</string>
+    <string name="settings_calendar_master_description">Разреши ClothesCast читать твои календари, чтобы подбирать прогнозы и наряды под тебя. Ничего не покидает устройство.</string>
+    <string name="settings_calendar_features_title">Личные календари</string>
+    <string name="settings_calendar_evening_tie_ins">Привязка к вечерним событиям</string>
+    <string name="settings_calendar_evening_tie_ins_description">Если ты собираешься куда-то вечером, утренний прогноз подскажет, нужно ли взять что-то с собой.</string>
+    <string name="settings_calendar_birthdays_description">Особые цвета и сообщения для дней рождения из твоих календарей.</string>
+    <string name="settings_calendar_public_holidays_description">Особые цвета и сообщения для государственных праздников из твоих календарей.</string>
+    <string name="settings_calendar_open_system_settings">Открыть системные настройки</string>
 </resources>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -917,4 +917,83 @@ What is NOT overridden, by design:
     <string name="holiday_banner_st_andrews_day">Šťastný Deň svätého Ondreja</string>
     <string name="settings_calendar_birthdays">Narodeniny z kalendára</string>
     <string name="settings_calendar_public_holidays">Sviatky z kalendára</string>
+
+    <!-- Settings strings added in 2026-05: Smart Home, Developer, Format, Calendar, Schedule, Default outfit. -->
+    <!-- Settings root labels — Developer, Format. -->
+    <string name="settings_root_developer">Vývojár</string>
+    <string name="settings_root_developer_subtitle">Testovanie a ladenie</string>
+    <string name="settings_root_format">Formát</string>
+
+    <!-- Developer settings page (Settings → Developer → Preview a day) -->
+    <string name="settings_developer_preview_day_title">Náhľad dňa</string>
+    <string name="settings_developer_preview_day_subtitle">Outfit, banner a hlas pre ľubovoľný dátum s pevne daným vzorkou mierneho počasia.</string>
+    <string name="settings_developer_pick_date">Vyber dátum</string>
+    <string name="settings_developer_today">Dnes</string>
+    <string name="settings_developer_no_theme">Pre tento deň nie je žiadna sviatočná téma.</string>
+    <string name="settings_developer_resolved_label">Vyhodnotené: %1$s</string>
+    <string name="settings_developer_speak">Prečítať</string>
+
+    <!-- Smart Home — newer keys. -->
+    <string name="settings_smart_home_cast_label">Odoslať predpoveď na inteligentný displej</string>
+    <string name="settings_smart_home_cast_last_published">Naposledy publikované %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched">Naposledy načítané %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched_never">Displej zatiaľ nenačítal žiadny ClothesCast</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_title">Preskočiť hlasový výstup v telefóne</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_description">Vyhneš sa duplicitným oznamom doma.</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_title">Preskočiť hlasový výstup v telefóne</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_description">Vyhneš sa duplicitným oznamom doma.</string>
+    <string name="settings_smart_home_mqtt_topic_hint">%1$s/now/text, %1$s/now/audio, atď.</string>
+
+    <!-- Schedule settings — Daily ClothesCast -->
+    <string name="settings_schedule_enabled">Denný ClothesCast</string>
+    <string name="settings_delivery_notification">Upozorniť</string>
+    <string name="settings_delivery_tts">Prečítať</string>
+
+    <!-- Clothes-mention picker on Format / Schedule -->
+    <string name="settings_clothes_mention_label">Oblečenie</string>
+    <string name="settings_clothes_mention_always">Vždy</string>
+    <string name="settings_clothes_mention_if_changed">Zmena</string>
+    <string name="settings_clothes_mention_never">Nikdy</string>
+
+    <!-- Format settings page -->
+    <string name="settings_format_preview_example_title">Príklad</string>
+    <string name="settings_format_preview_current_title">Aktuálna predpoveď</string>
+    <string name="settings_format_preview_current_empty">Zatiaľ žiadna predpoveď — pozri sa po svojom najbližšom ClothesCaste.</string>
+    <string name="settings_format_what_to_say">Čo hovoriť</string>
+    <string name="settings_format_range_label">Rozsah teplôt</string>
+    <string name="settings_format_range_none">Žiadny</string>
+    <string name="settings_format_range_degrees">Stupne</string>
+    <string name="settings_format_range_bands">Pásma</string>
+    <string name="settings_format_change_label">Zmena teploty</string>
+    <string name="settings_format_change_off">Vypnuté</string>
+    <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_clothes_label">Formulácia oblečenia</string>
+    <string name="settings_format_clothes_items">Kusy oblečenia</string>
+    <string name="settings_format_clothes_layer_count">Počet vrstiev</string>
+    <string name="settings_format_bottoms_label">Spodné diely</string>
+    <string name="settings_format_bottoms_always">Vždy</string>
+    <string name="settings_format_bottoms_if_garments">Ak sú kusy</string>
+    <string name="settings_format_bottoms_never">Nikdy</string>
+    <string name="settings_format_rain_accessory_label">Doplnok do dažďa</string>
+    <string name="settings_format_rain_accessory_none">Vypnuté</string>
+    <string name="settings_format_rain_accessory_umbrella">Dáždnik</string>
+
+    <!-- Fallback clothes rules — "If no rules match" section -->
+    <string name="settings_default_outfit_title">Ak žiadne pravidlá nevyhovujú</string>
+    <string name="settings_default_top_edit_title">Predvolený horný diel</string>
+    <string name="settings_default_bottom_edit_title">Predvolený spodný diel</string>
+    <string name="settings_default_outfit_range_above">keď je teplota nad %1$s</string>
+    <string name="settings_default_outfit_range_below">keď je teplota pod %1$s</string>
+    <string name="settings_default_outfit_range_between">keď je teplota medzi %1$s a %2$s</string>
+    <string name="settings_default_outfit_range_never">nikdy</string>
+
+    <!-- Calendar settings — master switch + per-feature toggles -->
+    <string name="settings_calendar_master">Použiť môj kalendár</string>
+    <string name="settings_calendar_master_description">Povoľ ClothesCastu čítať tvoje kalendáre, aby mohol prispôsobiť predpovede a outfity. Nič neopustí zariadenie.</string>
+    <string name="settings_calendar_features_title">Osobné kalendáre</string>
+    <string name="settings_calendar_evening_tie_ins">Večerné prepojenia</string>
+    <string name="settings_calendar_evening_tie_ins_description">Ak ideš večer von, ranná predpoveď ti povie, či si máš vziať niečo navyše.</string>
+    <string name="settings_calendar_birthdays_description">Použi špeciálne farby a správy pre narodeniny v tvojich kalendároch.</string>
+    <string name="settings_calendar_public_holidays_description">Použi špeciálne farby a správy pre štátne sviatky v tvojich kalendároch.</string>
+    <string name="settings_calendar_open_system_settings">Otvoriť systémové nastavenia</string>
 </resources>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -880,4 +880,83 @@ informal "ti"-form throughout, mirroring the Croatian / Serbian pass.
     <string name="cast_error_unknown">Predvajanje ni uspelo.</string>
     <string name="settings_calendar_birthdays">Rojstni dnevi iz koledarja</string>
     <string name="settings_calendar_public_holidays">Prazniki iz koledarja</string>
+
+    <!-- Settings strings added in 2026-05: Smart Home, Developer, Format, Calendar, Schedule, Default outfit. -->
+    <!-- Settings root labels — Developer, Format. -->
+    <string name="settings_root_developer">Razvijalec</string>
+    <string name="settings_root_developer_subtitle">Testiranje in razhroščevanje</string>
+    <string name="settings_root_format">Oblika</string>
+
+    <!-- Developer settings page (Settings → Developer → Preview a day) -->
+    <string name="settings_developer_preview_day_title">Predogled dneva</string>
+    <string name="settings_developer_preview_day_subtitle">Obleka, pasica in glas za poljubni datum z uporabo stalnega vzorca milega vremena.</string>
+    <string name="settings_developer_pick_date">Izberi datum</string>
+    <string name="settings_developer_today">Danes</string>
+    <string name="settings_developer_no_theme">Za ta dan ni praznične teme.</string>
+    <string name="settings_developer_resolved_label">Razrešeno: %1$s</string>
+    <string name="settings_developer_speak">Preberi</string>
+
+    <!-- Smart Home — newer keys. -->
+    <string name="settings_smart_home_cast_label">Pošlji napoved na pametni zaslon</string>
+    <string name="settings_smart_home_cast_last_published">Nazadnje objavljeno %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched">Nazadnje prevzeto %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched_never">Zaslon še ni prevzel nobenega ClothesCasta</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_title">Preskoči govor v telefonu</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_description">Izogni se podvojenim obvestilom doma.</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_title">Preskoči govor v telefonu</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_description">Izogni se podvojenim obvestilom doma.</string>
+    <string name="settings_smart_home_mqtt_topic_hint">%1$s/now/text, %1$s/now/audio, itd.</string>
+
+    <!-- Schedule settings — Daily ClothesCast -->
+    <string name="settings_schedule_enabled">Dnevni ClothesCast</string>
+    <string name="settings_delivery_notification">Obvesti</string>
+    <string name="settings_delivery_tts">Preberi</string>
+
+    <!-- Clothes-mention picker on Format / Schedule -->
+    <string name="settings_clothes_mention_label">Oblačila</string>
+    <string name="settings_clothes_mention_always">Vedno</string>
+    <string name="settings_clothes_mention_if_changed">Sprememba</string>
+    <string name="settings_clothes_mention_never">Nikoli</string>
+
+    <!-- Format settings page -->
+    <string name="settings_format_preview_example_title">Primer</string>
+    <string name="settings_format_preview_current_title">Trenutna napoved</string>
+    <string name="settings_format_preview_current_empty">Še ni napovedi — preveri po naslednjem ClothesCastu.</string>
+    <string name="settings_format_what_to_say">Kaj povedati</string>
+    <string name="settings_format_range_label">Razpon temperature</string>
+    <string name="settings_format_range_none">Brez</string>
+    <string name="settings_format_range_degrees">Stopinje</string>
+    <string name="settings_format_range_bands">Pasovi</string>
+    <string name="settings_format_change_label">Sprememba temperature</string>
+    <string name="settings_format_change_off">Izklopljeno</string>
+    <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_clothes_label">Ubeseditev oblačil</string>
+    <string name="settings_format_clothes_items">Kosi oblačil</string>
+    <string name="settings_format_clothes_layer_count">Število plasti</string>
+    <string name="settings_format_bottoms_label">Spodnji deli</string>
+    <string name="settings_format_bottoms_always">Vedno</string>
+    <string name="settings_format_bottoms_if_garments">Če so kosi</string>
+    <string name="settings_format_bottoms_never">Nikoli</string>
+    <string name="settings_format_rain_accessory_label">Dodatek za dež</string>
+    <string name="settings_format_rain_accessory_none">Izklopljeno</string>
+    <string name="settings_format_rain_accessory_umbrella">Dežnik</string>
+
+    <!-- Fallback clothes rules — "If no rules match" section -->
+    <string name="settings_default_outfit_title">Če se nobeno pravilo ne ujema</string>
+    <string name="settings_default_top_edit_title">Privzeti zgornji del</string>
+    <string name="settings_default_bottom_edit_title">Privzeti spodnji del</string>
+    <string name="settings_default_outfit_range_above">ko je temperatura nad %1$s</string>
+    <string name="settings_default_outfit_range_below">ko je temperatura pod %1$s</string>
+    <string name="settings_default_outfit_range_between">ko je temperatura med %1$s in %2$s</string>
+    <string name="settings_default_outfit_range_never">nikoli</string>
+
+    <!-- Calendar settings — master switch + per-feature toggles -->
+    <string name="settings_calendar_master">Uporabi moj koledar</string>
+    <string name="settings_calendar_master_description">Dovoli ClothesCastu branje tvojih koledarjev za prilagajanje napovedi in oblek. Nič ne zapusti naprave.</string>
+    <string name="settings_calendar_features_title">Osebni koledarji</string>
+    <string name="settings_calendar_evening_tie_ins">Večerne povezave</string>
+    <string name="settings_calendar_evening_tie_ins_description">Če greš zvečer ven, ti jutranja napoved pove, ali moraš s seboj vzeti kaj dodatnega.</string>
+    <string name="settings_calendar_birthdays_description">Uporabi posebne barve in sporočila za rojstne dneve v tvojih koledarjih.</string>
+    <string name="settings_calendar_public_holidays_description">Uporabi posebne barve in sporočila za državne praznike v tvojih koledarjih.</string>
+    <string name="settings_calendar_open_system_settings">Odpri sistemske nastavitve</string>
 </resources>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -923,4 +923,84 @@ native names for all locales (e.g. "Tyska (Tyskland)", "Franska (Frankrike)").
     <string name="holiday_banner_waitangi_day">Glad Waitangidagen</string>
     <string name="settings_calendar_birthdays">Kalenderfödelsedagar</string>
     <string name="settings_calendar_public_holidays">Kalenderhelgdagar</string>
+
+    <!-- Settings strings added in 2026-05: Smart Home, Developer, Format, Calendar, Schedule, Default outfit. -->
+
+    <!-- Settings root labels — Developer, Format -->
+    <string name="settings_root_developer">Utvecklare</string>
+    <string name="settings_root_developer_subtitle">Test och felsökning</string>
+    <string name="settings_root_format">Format</string>
+
+    <!-- Developer settings page -->
+    <string name="settings_developer_preview_day_title">Förhandsgranska en dag</string>
+    <string name="settings_developer_preview_day_subtitle">Outfit, banner och röst för valfritt datum, baserat på ett fast prov med milt väder.</string>
+    <string name="settings_developer_pick_date">Välj ett datum</string>
+    <string name="settings_developer_today">Idag</string>
+    <string name="settings_developer_no_theme">Inget helgdagstema för denna dag.</string>
+    <string name="settings_developer_resolved_label">Löst: %1$s</string>
+    <string name="settings_developer_speak">Läs upp</string>
+
+    <!-- Smart Home — additional keys -->
+    <string name="settings_smart_home_cast_label">Skicka prognos till smart skärm</string>
+    <string name="settings_smart_home_cast_last_published">Senast publicerad %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched">Senast hämtad %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched_never">Skärmen har inte hämtat något ClothesCast ännu</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_title">Hoppa över telefonens tal</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_description">Undvik dubbla meddelanden hemma.</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_title">Hoppa över telefonens tal</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_description">Undvik dubbla meddelanden hemma.</string>
+    <string name="settings_smart_home_mqtt_topic_hint">%1$s/now/text, %1$s/now/audio osv.</string>
+
+    <!-- Schedule settings — Daily ClothesCast -->
+    <string name="settings_schedule_enabled">Dagligt ClothesCast</string>
+    <string name="settings_delivery_notification">Avisera</string>
+    <string name="settings_delivery_tts">Läs upp</string>
+
+    <!-- Clothes-mention picker on Format / Schedule -->
+    <string name="settings_clothes_mention_label">Kläder</string>
+    <string name="settings_clothes_mention_always">Alltid</string>
+    <string name="settings_clothes_mention_if_changed">Vid ändring</string>
+    <string name="settings_clothes_mention_never">Aldrig</string>
+
+    <!-- Format settings page -->
+    <string name="settings_format_preview_example_title">Exempel</string>
+    <string name="settings_format_preview_current_title">Aktuell prognos</string>
+    <string name="settings_format_preview_current_empty">Ingen prognos ännu — kom tillbaka efter ditt nästa ClothesCast.</string>
+    <string name="settings_format_what_to_say">Vad som ska sägas</string>
+    <string name="settings_format_range_label">Temperaturintervall</string>
+    <string name="settings_format_range_none">Inget</string>
+    <string name="settings_format_range_degrees">Grader</string>
+    <string name="settings_format_range_bands">Nivåer</string>
+    <string name="settings_format_change_label">Temperaturförändring</string>
+    <string name="settings_format_change_off">Av</string>
+    <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_clothes_label">Klädformulering</string>
+    <string name="settings_format_clothes_items">Plagg</string>
+    <string name="settings_format_clothes_layer_count">Antal lager</string>
+    <string name="settings_format_bottoms_label">Underdelar</string>
+    <string name="settings_format_bottoms_always">Alltid</string>
+    <string name="settings_format_bottoms_if_garments">Vid plagg</string>
+    <string name="settings_format_bottoms_never">Aldrig</string>
+    <string name="settings_format_rain_accessory_label">Regnaccessoar</string>
+    <string name="settings_format_rain_accessory_none">Av</string>
+    <string name="settings_format_rain_accessory_umbrella">Paraply</string>
+
+    <!-- Fallback clothes rules — "If no rules match" section -->
+    <string name="settings_default_outfit_title">Om inga regler matchar</string>
+    <string name="settings_default_top_edit_title">Standardöverdel</string>
+    <string name="settings_default_bottom_edit_title">Standardunderdel</string>
+    <string name="settings_default_outfit_range_above">när temperaturen är över %1$s</string>
+    <string name="settings_default_outfit_range_below">när temperaturen är under %1$s</string>
+    <string name="settings_default_outfit_range_between">när temperaturen är mellan %1$s och %2$s</string>
+    <string name="settings_default_outfit_range_never">aldrig</string>
+
+    <!-- Calendar settings — master switch + per-feature toggles -->
+    <string name="settings_calendar_master">Använd min kalender</string>
+    <string name="settings_calendar_master_description">Låt ClothesCast läsa dina kalendrar för att anpassa prognoser och outfits. Inget lämnar enheten.</string>
+    <string name="settings_calendar_features_title">Personliga kalendrar</string>
+    <string name="settings_calendar_evening_tie_ins">Kvällskopplingar</string>
+    <string name="settings_calendar_evening_tie_ins_description">Om du går ut på kvällen berättar morgonprognosen om du behöver ta med något extra.</string>
+    <string name="settings_calendar_birthdays_description">Använd särskilda färger och meddelanden för födelsedagar i dina kalendrar.</string>
+    <string name="settings_calendar_public_holidays_description">Använd särskilda färger och meddelanden för helgdagar i dina kalendrar.</string>
+    <string name="settings_calendar_open_system_settings">Öppna systeminställningar</string>
 </resources>

--- a/app/src/main/res/values-sw/strings.xml
+++ b/app/src/main/res/values-sw/strings.xml
@@ -866,4 +866,84 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="today_rationale_open_clothes_settings">Mipangilio ya mavazi</string>
     <string name="settings_calendar_birthdays">Siku za Kuzaliwa za Kalenda</string>
     <string name="settings_calendar_public_holidays">Likizo za Kalenda</string>
+
+    <!-- Settings strings added in 2026-05: Smart Home, Developer, Format, Calendar, Schedule, Default outfit. -->
+
+    <!-- Settings root labels — Developer, Format -->
+    <string name="settings_root_developer">Msanidi programu</string>
+    <string name="settings_root_developer_subtitle">Majaribio na utatuzi</string>
+    <string name="settings_root_format">Umbizo</string>
+
+    <!-- Developer settings page -->
+    <string name="settings_developer_preview_day_title">Hakiki siku</string>
+    <string name="settings_developer_preview_day_subtitle">Mavazi, bango, na sauti kwa tarehe yoyote, ukitumia sampuli ya hali ya hewa ya wastani iliyowekwa.</string>
+    <string name="settings_developer_pick_date">Chagua tarehe</string>
+    <string name="settings_developer_today">Leo</string>
+    <string name="settings_developer_no_theme">Hakuna mada ya likizo kwa siku hii.</string>
+    <string name="settings_developer_resolved_label">Imetatuliwa: %1$s</string>
+    <string name="settings_developer_speak">Soma</string>
+
+    <!-- Smart Home — newer keys -->
+    <string name="settings_smart_home_cast_label">Tuma utabiri kwa onyesho mahiri</string>
+    <string name="settings_smart_home_cast_last_published">Imechapishwa mwisho %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched">Imepakuliwa mwisho %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched_never">Onyesho halijapakua ClothesCast bado</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_title">Ruka usemaji wa simu</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_description">Epuka matangazo ya marudufu nyumbani.</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_title">Ruka usemaji wa simu</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_description">Epuka matangazo ya marudufu nyumbani.</string>
+    <string name="settings_smart_home_mqtt_topic_hint">%1$s/now/text, %1$s/now/audio, n.k.</string>
+
+    <!-- Schedule settings — Daily ClothesCast -->
+    <string name="settings_schedule_enabled">ClothesCast ya kila siku</string>
+    <string name="settings_delivery_notification">Arifu</string>
+    <string name="settings_delivery_tts">Soma</string>
+
+    <!-- Clothes-mention picker -->
+    <string name="settings_clothes_mention_label">Mavazi</string>
+    <string name="settings_clothes_mention_always">Daima</string>
+    <string name="settings_clothes_mention_if_changed">Mabadiliko</string>
+    <string name="settings_clothes_mention_never">Kamwe</string>
+
+    <!-- Format settings page -->
+    <string name="settings_format_preview_example_title">Mfano</string>
+    <string name="settings_format_preview_current_title">Utabiri wa sasa</string>
+    <string name="settings_format_preview_current_empty">Hakuna utabiri bado — angalia tena baada ya ClothesCast yako ijayo.</string>
+    <string name="settings_format_what_to_say">Cha kusema</string>
+    <string name="settings_format_range_label">Wigo wa halijoto</string>
+    <string name="settings_format_range_none">Hakuna</string>
+    <string name="settings_format_range_degrees">Digrii</string>
+    <string name="settings_format_range_bands">Vikundi</string>
+    <string name="settings_format_change_label">Mabadiliko ya halijoto</string>
+    <string name="settings_format_change_off">Imezimwa</string>
+    <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_clothes_label">Maneno ya mavazi</string>
+    <string name="settings_format_clothes_items">Mavazi</string>
+    <string name="settings_format_clothes_layer_count">Idadi ya tabaka</string>
+    <string name="settings_format_bottoms_label">Mavazi ya chini</string>
+    <string name="settings_format_bottoms_always">Daima</string>
+    <string name="settings_format_bottoms_if_garments">Ikiwa kuna mavazi</string>
+    <string name="settings_format_bottoms_never">Kamwe</string>
+    <string name="settings_format_rain_accessory_label">Kifaa cha mvua</string>
+    <string name="settings_format_rain_accessory_none">Imezimwa</string>
+    <string name="settings_format_rain_accessory_umbrella">Mwavuli</string>
+
+    <!-- Fallback clothes rules — "If no rules match" -->
+    <string name="settings_default_outfit_title">Ikiwa hakuna sheria inayofaa</string>
+    <string name="settings_default_top_edit_title">Vazi la juu la chaguo-msingi</string>
+    <string name="settings_default_bottom_edit_title">Vazi la chini la chaguo-msingi</string>
+    <string name="settings_default_outfit_range_above">wakati halijoto iko juu ya %1$s</string>
+    <string name="settings_default_outfit_range_below">wakati halijoto iko chini ya %1$s</string>
+    <string name="settings_default_outfit_range_between">wakati halijoto iko kati ya %1$s na %2$s</string>
+    <string name="settings_default_outfit_range_never">kamwe</string>
+
+    <!-- Calendar settings — master switch + per-feature toggles -->
+    <string name="settings_calendar_master">Tumia kalenda yangu</string>
+    <string name="settings_calendar_master_description">Ruhusu ClothesCast kusoma kalenda zako ili kubinafsisha utabiri na mavazi. Hakuna kinachoacha kifaa.</string>
+    <string name="settings_calendar_features_title">Kalenda za kibinafsi</string>
+    <string name="settings_calendar_evening_tie_ins">Mafungamano ya jioni</string>
+    <string name="settings_calendar_evening_tie_ins_description">Ikiwa unaenda nje jioni, utabiri wa asubuhi unakuambia ikiwa unahitaji kuchukua kitu chochote zaidi.</string>
+    <string name="settings_calendar_birthdays_description">Tumia rangi na ujumbe maalum kwa siku za kuzaliwa katika kalenda zako.</string>
+    <string name="settings_calendar_public_holidays_description">Tumia rangi na ujumbe maalum kwa likizo za umma katika kalenda zako.</string>
+    <string name="settings_calendar_open_system_settings">Fungua mipangilio ya mfumo</string>
 </resources>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -896,4 +896,83 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="today_rationale_open_clothes_settings">การตั้งค่าเสื้อผ้า</string>
     <string name="settings_calendar_birthdays">วันเกิดในปฏิทิน</string>
     <string name="settings_calendar_public_holidays">วันหยุดในปฏิทิน</string>
+
+    <!-- Settings strings added in 2026-05: Smart Home, Developer, Format, Calendar, Schedule, Default outfit. -->
+    <!-- Settings root labels -->
+    <string name="settings_root_developer">นักพัฒนา</string>
+    <string name="settings_root_developer_subtitle">การทดสอบและดีบัก</string>
+    <string name="settings_root_format">รูปแบบ</string>
+
+    <!-- Developer settings page -->
+    <string name="settings_developer_preview_day_title">ดูตัวอย่างวัน</string>
+    <string name="settings_developer_preview_day_subtitle">ชุดแต่งกาย แบนเนอร์ และเสียงสำหรับวันที่ใดก็ได้ โดยใช้ตัวอย่างสภาพอากาศที่อ่อนโยนคงที่</string>
+    <string name="settings_developer_pick_date">เลือกวันที่</string>
+    <string name="settings_developer_today">วันนี้</string>
+    <string name="settings_developer_no_theme">ไม่มีธีมวันหยุดสำหรับวันนี้</string>
+    <string name="settings_developer_resolved_label">แก้ไขเป็น: %1$s</string>
+    <string name="settings_developer_speak">พูด</string>
+
+    <!-- Smart Home additional keys -->
+    <string name="settings_smart_home_cast_label">ส่งพยากรณ์ไปยังสมาร์ทดิสเพลย์</string>
+    <string name="settings_smart_home_cast_last_published">เผยแพร่ล่าสุด %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched">ดึงล่าสุด %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched_never">สมาร์ทดิสเพลย์ยังไม่ได้ดึง ClothesCast</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_title">ข้ามการอ่านบนโทรศัพท์</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_description">หลีกเลี่ยงการแจ้งเตือนซ้ำซ้อนที่บ้าน</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_title">ข้ามการอ่านบนโทรศัพท์</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_description">หลีกเลี่ยงการแจ้งเตือนซ้ำซ้อนที่บ้าน</string>
+    <string name="settings_smart_home_mqtt_topic_hint">%1$s/now/text, %1$s/now/audio ฯลฯ</string>
+
+    <!-- Schedule settings — Daily ClothesCast -->
+    <string name="settings_schedule_enabled">ClothesCast รายวัน</string>
+    <string name="settings_delivery_notification">แจ้งเตือน</string>
+    <string name="settings_delivery_tts">พูด</string>
+
+    <!-- Clothes-mention picker -->
+    <string name="settings_clothes_mention_label">เสื้อผ้า</string>
+    <string name="settings_clothes_mention_always">เสมอ</string>
+    <string name="settings_clothes_mention_if_changed">เปลี่ยนแปลง</string>
+    <string name="settings_clothes_mention_never">ไม่เลย</string>
+
+    <!-- Format settings page -->
+    <string name="settings_format_preview_example_title">ตัวอย่าง</string>
+    <string name="settings_format_preview_current_title">พยากรณ์ปัจจุบัน</string>
+    <string name="settings_format_preview_current_empty">ยังไม่มีพยากรณ์ — กลับมาดูหลังจาก ClothesCast ครั้งถัดไป</string>
+    <string name="settings_format_what_to_say">สิ่งที่จะพูด</string>
+    <string name="settings_format_range_label">ช่วงอุณหภูมิ</string>
+    <string name="settings_format_range_none">ไม่มี</string>
+    <string name="settings_format_range_degrees">องศา</string>
+    <string name="settings_format_range_bands">ระดับ</string>
+    <string name="settings_format_change_label">การเปลี่ยนแปลงอุณหภูมิ</string>
+    <string name="settings_format_change_off">ปิด</string>
+    <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_clothes_label">การใช้คำเกี่ยวกับเสื้อผ้า</string>
+    <string name="settings_format_clothes_items">เสื้อผ้า</string>
+    <string name="settings_format_clothes_layer_count">จำนวนชั้น</string>
+    <string name="settings_format_bottoms_label">กางเกง</string>
+    <string name="settings_format_bottoms_always">เสมอ</string>
+    <string name="settings_format_bottoms_if_garments">หากมีเสื้อผ้า</string>
+    <string name="settings_format_bottoms_never">ไม่เลย</string>
+    <string name="settings_format_rain_accessory_label">อุปกรณ์กันฝน</string>
+    <string name="settings_format_rain_accessory_none">ปิด</string>
+    <string name="settings_format_rain_accessory_umbrella">ร่ม</string>
+
+    <!-- Fallback clothes rules — "If no rules match" -->
+    <string name="settings_default_outfit_title">หากไม่มีกฎใดตรงกัน</string>
+    <string name="settings_default_top_edit_title">เสื้อท่อนบนเริ่มต้น</string>
+    <string name="settings_default_bottom_edit_title">เสื้อท่อนล่างเริ่มต้น</string>
+    <string name="settings_default_outfit_range_above">เมื่ออุณหภูมิสูงกว่า %1$s</string>
+    <string name="settings_default_outfit_range_below">เมื่ออุณหภูมิต่ำกว่า %1$s</string>
+    <string name="settings_default_outfit_range_between">เมื่ออุณหภูมิอยู่ระหว่าง %1$s และ %2$s</string>
+    <string name="settings_default_outfit_range_never">ไม่เลย</string>
+
+    <!-- Calendar settings — master switch + per-feature toggles -->
+    <string name="settings_calendar_master">ใช้ปฏิทินของฉัน</string>
+    <string name="settings_calendar_master_description">ให้ ClothesCast อ่านปฏิทินของคุณเพื่อปรับแต่งพยากรณ์และชุดแต่งกาย ไม่มีข้อมูลออกนอกอุปกรณ์</string>
+    <string name="settings_calendar_features_title">ปฏิทินส่วนตัว</string>
+    <string name="settings_calendar_evening_tie_ins">การเชื่อมโยงตอนเย็น</string>
+    <string name="settings_calendar_evening_tie_ins_description">หากคุณออกไปข้างนอกในตอนเย็น พยากรณ์ตอนเช้าจะบอกว่าคุณต้องนำสิ่งของพิเศษอะไรไปบ้าง</string>
+    <string name="settings_calendar_birthdays_description">ใช้สีและข้อความพิเศษสำหรับวันเกิดในปฏิทินของคุณ</string>
+    <string name="settings_calendar_public_holidays_description">ใช้สีและข้อความพิเศษสำหรับวันหยุดราชการในปฏิทินของคุณ</string>
+    <string name="settings_calendar_open_system_settings">เปิดการตั้งค่าระบบ</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -897,4 +897,83 @@ displayed label localizes.
     <string name="today_rationale_open_clothes_settings">Kıyafet ayarları</string>
     <string name="settings_calendar_birthdays">Takvim Doğum Günleri</string>
     <string name="settings_calendar_public_holidays">Takvim Tatilleri</string>
+
+    <!-- Settings strings added in 2026-05: Smart Home, Developer, Format, Calendar, Schedule, Default outfit. -->
+    <!-- Settings root labels — Smart Home, Developer, Format -->
+    <string name="settings_root_developer">Geliştirici</string>
+    <string name="settings_root_developer_subtitle">Test ve Hata Ayıklama</string>
+    <string name="settings_root_format">Biçim</string>
+
+    <!-- Developer settings page (Settings → Developer → Preview a day) -->
+    <string name="settings_developer_preview_day_title">Bir günü önizle</string>
+    <string name="settings_developer_preview_day_subtitle">Sabit ılıman hava örneği kullanarak herhangi bir tarih için kıyafet, banner ve ses.</string>
+    <string name="settings_developer_pick_date">Bir tarih seç</string>
+    <string name="settings_developer_today">Bugün</string>
+    <string name="settings_developer_no_theme">Bu gün için tatil teması yok.</string>
+    <string name="settings_developer_resolved_label">Çözüldü: %1$s</string>
+    <string name="settings_developer_speak">Seslendir</string>
+
+    <!-- Smart Home — newer keys -->
+    <string name="settings_smart_home_cast_label">Tahmini akıllı ekrana gönder</string>
+    <string name="settings_smart_home_cast_last_published">Son yayımlanma %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched">Son alınma %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched_never">Ekran henüz ClothesCast almadı</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_title">Telefon seslendirmesini atla</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_description">Evde tekrarlanan duyuruları önle.</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_title">Telefon seslendirmesini atla</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_description">Evde tekrarlanan duyuruları önle.</string>
+    <string name="settings_smart_home_mqtt_topic_hint">%1$s/now/text, %1$s/now/audio vb.</string>
+
+    <!-- Schedule settings -->
+    <string name="settings_schedule_enabled">Günlük ClothesCast</string>
+    <string name="settings_delivery_notification">Bildir</string>
+    <string name="settings_delivery_tts">Seslendir</string>
+
+    <!-- Clothes-mention picker on Format / Schedule -->
+    <string name="settings_clothes_mention_label">Kıyafetler</string>
+    <string name="settings_clothes_mention_always">Her zaman</string>
+    <string name="settings_clothes_mention_if_changed">Değişince</string>
+    <string name="settings_clothes_mention_never">Asla</string>
+
+    <!-- Format settings page -->
+    <string name="settings_format_preview_example_title">Örnek</string>
+    <string name="settings_format_preview_current_title">Güncel tahmin</string>
+    <string name="settings_format_preview_current_empty">Henüz tahmin yok — bir sonraki ClothesCast\'ından sonra tekrar bak.</string>
+    <string name="settings_format_what_to_say">Ne söylensin</string>
+    <string name="settings_format_range_label">Sıcaklık aralığı</string>
+    <string name="settings_format_range_none">Yok</string>
+    <string name="settings_format_range_degrees">Derece</string>
+    <string name="settings_format_range_bands">Bantlar</string>
+    <string name="settings_format_change_label">Sıcaklık değişimi</string>
+    <string name="settings_format_change_off">Kapalı</string>
+    <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_clothes_label">Kıyafet ifadesi</string>
+    <string name="settings_format_clothes_items">Giysiler</string>
+    <string name="settings_format_clothes_layer_count">Katman sayısı</string>
+    <string name="settings_format_bottoms_label">Alt giyim</string>
+    <string name="settings_format_bottoms_always">Her zaman</string>
+    <string name="settings_format_bottoms_if_garments">Giysi varsa</string>
+    <string name="settings_format_bottoms_never">Asla</string>
+    <string name="settings_format_rain_accessory_label">Yağmur aksesuarı</string>
+    <string name="settings_format_rain_accessory_none">Kapalı</string>
+    <string name="settings_format_rain_accessory_umbrella">Şemsiye</string>
+
+    <!-- Fallback clothes rules — "If no rules match" -->
+    <string name="settings_default_outfit_title">Hiçbir kural eşleşmezse</string>
+    <string name="settings_default_top_edit_title">Varsayılan üst</string>
+    <string name="settings_default_bottom_edit_title">Varsayılan alt</string>
+    <string name="settings_default_outfit_range_above">sıcaklık %1$s üzerindeyken</string>
+    <string name="settings_default_outfit_range_below">sıcaklık %1$s altındayken</string>
+    <string name="settings_default_outfit_range_between">sıcaklık %1$s ile %2$s arasındayken</string>
+    <string name="settings_default_outfit_range_never">asla</string>
+
+    <!-- Calendar settings — master switch + per-feature toggles -->
+    <string name="settings_calendar_master">Takvimimi kullan</string>
+    <string name="settings_calendar_master_description">ClothesCast\'ın tahminleri ve kıyafetleri kişiselleştirmek için takvimlerini okumasına izin ver. Hiçbir şey cihazdan çıkmaz.</string>
+    <string name="settings_calendar_features_title">Kişisel takvimler</string>
+    <string name="settings_calendar_evening_tie_ins">Akşam bağlantıları</string>
+    <string name="settings_calendar_evening_tie_ins_description">Akşam dışarı çıkacaksan sabah tahmini sana yanına fazladan bir şey alman gerekip gerekmediğini söyler.</string>
+    <string name="settings_calendar_birthdays_description">Takvimlerindeki doğum günleri için özel renkler ve mesajlar kullan.</string>
+    <string name="settings_calendar_public_holidays_description">Takvimlerindeki resmi tatiller için özel renkler ve mesajlar kullan.</string>
+    <string name="settings_calendar_open_system_settings">Sistem ayarlarını aç</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -892,4 +892,83 @@ only the displayed label localizes.
     <string name="holiday_banner_st_andrews_day">З Днем святого Андрія</string>
     <string name="settings_calendar_birthdays">Дні народження в календарі</string>
     <string name="settings_calendar_public_holidays">Свята в календарі</string>
+
+    <!-- Settings strings added in 2026-05: Smart Home, Developer, Format, Calendar, Schedule, Default outfit. -->
+    <!-- Settings root labels -->
+    <string name="settings_root_developer">Розробник</string>
+    <string name="settings_root_developer_subtitle">Тестування й налагодження</string>
+    <string name="settings_root_format">Формат</string>
+
+    <!-- Developer settings page -->
+    <string name="settings_developer_preview_day_title">Попередній перегляд дня</string>
+    <string name="settings_developer_preview_day_subtitle">Образ, банер і голос для будь-якої дати на основі фіксованого прикладу м\'якої погоди.</string>
+    <string name="settings_developer_pick_date">Виберіть дату</string>
+    <string name="settings_developer_today">Сьогодні</string>
+    <string name="settings_developer_no_theme">Для цього дня немає святкової теми.</string>
+    <string name="settings_developer_resolved_label">Розв\'язано: %1$s</string>
+    <string name="settings_developer_speak">Озвучити</string>
+
+    <!-- Smart Home — newer keys -->
+    <string name="settings_smart_home_cast_label">Надіслати прогноз на розумний дисплей</string>
+    <string name="settings_smart_home_cast_last_published">Остання публікація %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched">Останнє завантаження %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched_never">Дисплей ще не завантажував ClothesCast</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_title">Не озвучувати на телефоні</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_description">Уникайте подвійних оголошень удома.</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_title">Не озвучувати на телефоні</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_description">Уникайте подвійних оголошень удома.</string>
+    <string name="settings_smart_home_mqtt_topic_hint">%1$s/now/text, %1$s/now/audio, тощо</string>
+
+    <!-- Schedule settings -->
+    <string name="settings_schedule_enabled">Щоденний ClothesCast</string>
+    <string name="settings_delivery_notification">Сповістити</string>
+    <string name="settings_delivery_tts">Озвучити</string>
+
+    <!-- Clothes-mention picker on Format / Schedule -->
+    <string name="settings_clothes_mention_label">Одяг</string>
+    <string name="settings_clothes_mention_always">Завжди</string>
+    <string name="settings_clothes_mention_if_changed">При зміні</string>
+    <string name="settings_clothes_mention_never">Ніколи</string>
+
+    <!-- Format settings page -->
+    <string name="settings_format_preview_example_title">Приклад</string>
+    <string name="settings_format_preview_current_title">Поточний прогноз</string>
+    <string name="settings_format_preview_current_empty">Прогнозу ще немає — загляньте після наступного ClothesCast.</string>
+    <string name="settings_format_what_to_say">Що казати</string>
+    <string name="settings_format_range_label">Діапазон температур</string>
+    <string name="settings_format_range_none">Немає</string>
+    <string name="settings_format_range_degrees">Градуси</string>
+    <string name="settings_format_range_bands">Діапазони</string>
+    <string name="settings_format_change_label">Зміна температури</string>
+    <string name="settings_format_change_off">Вимк.</string>
+    <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_clothes_label">Опис одягу</string>
+    <string name="settings_format_clothes_items">Предмети</string>
+    <string name="settings_format_clothes_layer_count">Кількість шарів</string>
+    <string name="settings_format_bottoms_label">Низ</string>
+    <string name="settings_format_bottoms_always">Завжди</string>
+    <string name="settings_format_bottoms_if_garments">Якщо є верх</string>
+    <string name="settings_format_bottoms_never">Ніколи</string>
+    <string name="settings_format_rain_accessory_label">Аксесуар від дощу</string>
+    <string name="settings_format_rain_accessory_none">Вимк.</string>
+    <string name="settings_format_rain_accessory_umbrella">Парасоля</string>
+
+    <!-- Fallback clothes rules — "If no rules match" section -->
+    <string name="settings_default_outfit_title">Якщо жодне правило не підходить</string>
+    <string name="settings_default_top_edit_title">Верх за замовчуванням</string>
+    <string name="settings_default_bottom_edit_title">Низ за замовчуванням</string>
+    <string name="settings_default_outfit_range_above">коли температура вища за %1$s</string>
+    <string name="settings_default_outfit_range_below">коли температура нижча за %1$s</string>
+    <string name="settings_default_outfit_range_between">коли температура від %1$s до %2$s</string>
+    <string name="settings_default_outfit_range_never">ніколи</string>
+
+    <!-- Calendar settings — master switch + per-feature toggles -->
+    <string name="settings_calendar_master">Використовувати мій календар</string>
+    <string name="settings_calendar_master_description">Дозвольте ClothesCast читати ваші календарі, щоб персоналізувати прогнози та образи. Нічого не покидає пристрій.</string>
+    <string name="settings_calendar_features_title">Особисті календарі</string>
+    <string name="settings_calendar_evening_tie_ins">Прив\'язка до вечірніх подій</string>
+    <string name="settings_calendar_evening_tie_ins_description">Якщо ви кудись ідете ввечері, ранковий прогноз підкаже, чи потрібно взяти щось додатково.</string>
+    <string name="settings_calendar_birthdays_description">Спеціальні кольори та повідомлення для днів народження у ваших календарях.</string>
+    <string name="settings_calendar_public_holidays_description">Спеціальні кольори та повідомлення для державних свят у ваших календарях.</string>
+    <string name="settings_calendar_open_system_settings">Відкрити системні налаштування</string>
 </resources>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -957,4 +957,83 @@ Skipped intentionally: app_name (brand), insight_time_am/pm/midnight/noon
     <string name="today_rationale_open_clothes_settings">Cài đặt quần áo</string>
     <string name="settings_calendar_birthdays">Sinh nhật trong lịch</string>
     <string name="settings_calendar_public_holidays">Ngày lễ trong lịch</string>
+
+    <!-- Settings strings added in 2026-05: Smart Home, Developer, Format, Calendar, Schedule, Default outfit. -->
+    <!-- Settings root labels -->
+    <string name="settings_root_developer">Nhà phát triển</string>
+    <string name="settings_root_developer_subtitle">Kiểm thử và gỡ lỗi</string>
+    <string name="settings_root_format">Định dạng</string>
+
+    <!-- Developer settings page -->
+    <string name="settings_developer_preview_day_title">Xem trước một ngày</string>
+    <string name="settings_developer_preview_day_subtitle">Trang phục, biểu ngữ và giọng nói cho bất kỳ ngày nào, sử dụng mẫu thời tiết dễ chịu cố định.</string>
+    <string name="settings_developer_pick_date">Chọn ngày</string>
+    <string name="settings_developer_today">Hôm nay</string>
+    <string name="settings_developer_no_theme">Không có chủ đề ngày lễ cho ngày này.</string>
+    <string name="settings_developer_resolved_label">Đã giải quyết: %1$s</string>
+    <string name="settings_developer_speak">Đọc</string>
+
+    <!-- Smart Home additional keys -->
+    <string name="settings_smart_home_cast_label">Gửi dự báo đến màn hình thông minh</string>
+    <string name="settings_smart_home_cast_last_published">Xuất bản lần cuối %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched">Tải lần cuối %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched_never">Màn hình chưa tải ClothesCast nào</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_title">Bỏ qua đọc trên điện thoại</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_description">Tránh thông báo trùng lặp ở nhà.</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_title">Bỏ qua đọc trên điện thoại</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_description">Tránh thông báo trùng lặp ở nhà.</string>
+    <string name="settings_smart_home_mqtt_topic_hint">%1$s/now/text, %1$s/now/audio, v.v.</string>
+
+    <!-- Schedule settings — Daily ClothesCast -->
+    <string name="settings_schedule_enabled">ClothesCast hàng ngày</string>
+    <string name="settings_delivery_notification">Thông báo</string>
+    <string name="settings_delivery_tts">Đọc</string>
+
+    <!-- Clothes-mention picker -->
+    <string name="settings_clothes_mention_label">Quần áo</string>
+    <string name="settings_clothes_mention_always">Luôn luôn</string>
+    <string name="settings_clothes_mention_if_changed">Thay đổi</string>
+    <string name="settings_clothes_mention_never">Không bao giờ</string>
+
+    <!-- Format settings page -->
+    <string name="settings_format_preview_example_title">Ví dụ</string>
+    <string name="settings_format_preview_current_title">Dự báo hiện tại</string>
+    <string name="settings_format_preview_current_empty">Chưa có dự báo — hãy quay lại sau ClothesCast tiếp theo.</string>
+    <string name="settings_format_what_to_say">Nội dung cần nói</string>
+    <string name="settings_format_range_label">Khoảng nhiệt độ</string>
+    <string name="settings_format_range_none">Không có</string>
+    <string name="settings_format_range_degrees">Độ</string>
+    <string name="settings_format_range_bands">Mức</string>
+    <string name="settings_format_change_label">Thay đổi nhiệt độ</string>
+    <string name="settings_format_change_off">Tắt</string>
+    <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_clothes_label">Cách diễn đạt quần áo</string>
+    <string name="settings_format_clothes_items">Trang phục</string>
+    <string name="settings_format_clothes_layer_count">Số lớp</string>
+    <string name="settings_format_bottoms_label">Quần</string>
+    <string name="settings_format_bottoms_always">Luôn luôn</string>
+    <string name="settings_format_bottoms_if_garments">Nếu có trang phục</string>
+    <string name="settings_format_bottoms_never">Không bao giờ</string>
+    <string name="settings_format_rain_accessory_label">Phụ kiện đi mưa</string>
+    <string name="settings_format_rain_accessory_none">Tắt</string>
+    <string name="settings_format_rain_accessory_umbrella">Ô</string>
+
+    <!-- Fallback clothes rules — "If no rules match" -->
+    <string name="settings_default_outfit_title">Nếu không có quy tắc nào khớp</string>
+    <string name="settings_default_top_edit_title">Áo mặc mặc định</string>
+    <string name="settings_default_bottom_edit_title">Quần mặc mặc định</string>
+    <string name="settings_default_outfit_range_above">khi nhiệt độ trên %1$s</string>
+    <string name="settings_default_outfit_range_below">khi nhiệt độ dưới %1$s</string>
+    <string name="settings_default_outfit_range_between">khi nhiệt độ từ %1$s đến %2$s</string>
+    <string name="settings_default_outfit_range_never">không bao giờ</string>
+
+    <!-- Calendar settings — master switch + per-feature toggles -->
+    <string name="settings_calendar_master">Dùng lịch của tôi</string>
+    <string name="settings_calendar_master_description">Cho phép ClothesCast đọc lịch của bạn để cá nhân hóa dự báo và trang phục. Không có gì rời khỏi thiết bị.</string>
+    <string name="settings_calendar_features_title">Lịch cá nhân</string>
+    <string name="settings_calendar_evening_tie_ins">Kết nối sự kiện buổi tối</string>
+    <string name="settings_calendar_evening_tie_ins_description">Nếu bạn ra ngoài vào buổi tối, dự báo buổi sáng sẽ cho bạn biết có cần mang thêm gì không.</string>
+    <string name="settings_calendar_birthdays_description">Dùng màu sắc và thông điệp đặc biệt cho sinh nhật trong lịch của bạn.</string>
+    <string name="settings_calendar_public_holidays_description">Dùng màu sắc và thông điệp đặc biệt cho ngày lễ công cộng trong lịch của bạn.</string>
+    <string name="settings_calendar_open_system_settings">Mở cài đặt hệ thống</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1043,4 +1043,84 @@ label localizes.
     <string name="today_rationale_open_clothes_settings">服装设置</string>
     <string name="settings_calendar_birthdays">日历生日</string>
     <string name="settings_calendar_public_holidays">日历节假日</string>
+
+    <!-- Settings strings added in 2026-05: Smart Home, Developer, Format, Calendar, Schedule, Default outfit. -->
+
+    <!-- Settings root labels — Developer, Format. -->
+    <string name="settings_root_developer">开发者</string>
+    <string name="settings_root_developer_subtitle">测试和调试</string>
+    <string name="settings_root_format">格式</string>
+
+    <!-- Developer settings page — preview-a-day -->
+    <string name="settings_developer_preview_day_title">预览某一天</string>
+    <string name="settings_developer_preview_day_subtitle">使用固定的温和天气样本，预览任意日期的穿搭、横幅和语音。</string>
+    <string name="settings_developer_pick_date">选择日期</string>
+    <string name="settings_developer_today">今天</string>
+    <string name="settings_developer_no_theme">这一天没有节日主题。</string>
+    <string name="settings_developer_resolved_label">解析为：%1$s</string>
+    <string name="settings_developer_speak">朗读</string>
+
+    <!-- Smart Home — additional cast / mqtt keys. -->
+    <string name="settings_smart_home_cast_label">将预报发送到智能显示器</string>
+    <string name="settings_smart_home_cast_last_published">上次发送 %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched">上次获取 %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched_never">显示器尚未获取过 ClothesCast</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_title">跳过手机语音</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_description">避免在家时重复播报。</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_title">跳过手机语音</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_description">避免在家时重复播报。</string>
+    <string name="settings_smart_home_mqtt_topic_hint">%1$s/now/text、%1$s/now/audio 等</string>
+
+    <!-- Schedule settings — Daily ClothesCast -->
+    <string name="settings_schedule_enabled">每日 ClothesCast</string>
+    <string name="settings_delivery_notification">通知</string>
+    <string name="settings_delivery_tts">朗读</string>
+
+    <!-- Clothes-mention picker on Format / Schedule -->
+    <string name="settings_clothes_mention_label">服装</string>
+    <string name="settings_clothes_mention_always">始终</string>
+    <string name="settings_clothes_mention_if_changed">变化时</string>
+    <string name="settings_clothes_mention_never">从不</string>
+
+    <!-- Format settings page -->
+    <string name="settings_format_preview_example_title">示例</string>
+    <string name="settings_format_preview_current_title">当前预报</string>
+    <string name="settings_format_preview_current_empty">还没有预报 — 下次 ClothesCast 后再来看看。</string>
+    <string name="settings_format_what_to_say">说什么</string>
+    <string name="settings_format_range_label">温度范围</string>
+    <string name="settings_format_range_none">无</string>
+    <string name="settings_format_range_degrees">度数</string>
+    <string name="settings_format_range_bands">区间</string>
+    <string name="settings_format_change_label">温度变化</string>
+    <string name="settings_format_change_off">关闭</string>
+    <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_clothes_label">服装措辞</string>
+    <string name="settings_format_clothes_items">衣物</string>
+    <string name="settings_format_clothes_layer_count">层数</string>
+    <string name="settings_format_bottoms_label">下装</string>
+    <string name="settings_format_bottoms_always">始终</string>
+    <string name="settings_format_bottoms_if_garments">有衣物时</string>
+    <string name="settings_format_bottoms_never">从不</string>
+    <string name="settings_format_rain_accessory_label">雨具</string>
+    <string name="settings_format_rain_accessory_none">关闭</string>
+    <string name="settings_format_rain_accessory_umbrella">雨伞</string>
+
+    <!-- Fallback clothes rules — "If no rules match" -->
+    <string name="settings_default_outfit_title">没有规则匹配时</string>
+    <string name="settings_default_top_edit_title">默认上装</string>
+    <string name="settings_default_bottom_edit_title">默认下装</string>
+    <string name="settings_default_outfit_range_above">当温度高于 %1$s 时</string>
+    <string name="settings_default_outfit_range_below">当温度低于 %1$s 时</string>
+    <string name="settings_default_outfit_range_between">当温度在 %1$s 至 %2$s 之间时</string>
+    <string name="settings_default_outfit_range_never">从不</string>
+
+    <!-- Calendar settings — master switch + per-feature toggles -->
+    <string name="settings_calendar_master">使用我的日历</string>
+    <string name="settings_calendar_master_description">让 ClothesCast 读取你的日历，以便个性化预报和穿搭。不会有任何信息离开设备。</string>
+    <string name="settings_calendar_features_title">个人日历</string>
+    <string name="settings_calendar_evening_tie_ins">晚间衔接</string>
+    <string name="settings_calendar_evening_tie_ins_description">如果你晚上要外出，早晨预报会告诉你是否需要额外带点什么。</string>
+    <string name="settings_calendar_birthdays_description">为日历中的生日使用特别的颜色和提示。</string>
+    <string name="settings_calendar_public_holidays_description">为日历中的公共假日使用特别的颜色和提示。</string>
+    <string name="settings_calendar_open_system_settings">打开系统设置</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1059,4 +1059,84 @@ label localises.
     <string name="today_rationale_open_clothes_settings">服裝設定</string>
     <string name="settings_calendar_birthdays">行事曆生日</string>
     <string name="settings_calendar_public_holidays">行事曆節假日</string>
+
+    <!-- Settings strings added in 2026-05: Smart Home, Developer, Format, Calendar, Schedule, Default outfit. -->
+
+    <!-- Settings root labels — Developer, Format. -->
+    <string name="settings_root_developer">開發者</string>
+    <string name="settings_root_developer_subtitle">測試與除錯</string>
+    <string name="settings_root_format">格式</string>
+
+    <!-- Developer settings page — preview-a-day -->
+    <string name="settings_developer_preview_day_title">預覽某一天</string>
+    <string name="settings_developer_preview_day_subtitle">使用固定的溫和天氣樣本，預覽任意日期的穿搭、橫幅與語音。</string>
+    <string name="settings_developer_pick_date">選擇日期</string>
+    <string name="settings_developer_today">今天</string>
+    <string name="settings_developer_no_theme">這一天沒有節日主題。</string>
+    <string name="settings_developer_resolved_label">解析為：%1$s</string>
+    <string name="settings_developer_speak">朗讀</string>
+
+    <!-- Smart Home — additional cast / mqtt keys. -->
+    <string name="settings_smart_home_cast_label">將預報傳送到智慧顯示器</string>
+    <string name="settings_smart_home_cast_last_published">上次傳送 %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched">上次取得 %1$s</string>
+    <string name="settings_smart_home_cast_last_fetched_never">顯示器尚未取得過 ClothesCast</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_title">略過手機語音</string>
+    <string name="settings_smart_home_cast_skip_phone_speech_description">避免在家時重複播報。</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_title">略過手機語音</string>
+    <string name="settings_smart_home_mqtt_skip_phone_speech_description">避免在家時重複播報。</string>
+    <string name="settings_smart_home_mqtt_topic_hint">%1$s/now/text、%1$s/now/audio 等</string>
+
+    <!-- Schedule settings — Daily ClothesCast -->
+    <string name="settings_schedule_enabled">每日 ClothesCast</string>
+    <string name="settings_delivery_notification">通知</string>
+    <string name="settings_delivery_tts">朗讀</string>
+
+    <!-- Clothes-mention picker on Format / Schedule -->
+    <string name="settings_clothes_mention_label">服裝</string>
+    <string name="settings_clothes_mention_always">總是</string>
+    <string name="settings_clothes_mention_if_changed">變化時</string>
+    <string name="settings_clothes_mention_never">從不</string>
+
+    <!-- Format settings page -->
+    <string name="settings_format_preview_example_title">範例</string>
+    <string name="settings_format_preview_current_title">目前預報</string>
+    <string name="settings_format_preview_current_empty">還沒有預報 — 下次 ClothesCast 後再來看看。</string>
+    <string name="settings_format_what_to_say">說什麼</string>
+    <string name="settings_format_range_label">溫度範圍</string>
+    <string name="settings_format_range_none">無</string>
+    <string name="settings_format_range_degrees">度數</string>
+    <string name="settings_format_range_bands">區間</string>
+    <string name="settings_format_change_label">溫度變化</string>
+    <string name="settings_format_change_off">關閉</string>
+    <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_clothes_label">服裝措辭</string>
+    <string name="settings_format_clothes_items">衣物</string>
+    <string name="settings_format_clothes_layer_count">層數</string>
+    <string name="settings_format_bottoms_label">下著</string>
+    <string name="settings_format_bottoms_always">總是</string>
+    <string name="settings_format_bottoms_if_garments">有衣物時</string>
+    <string name="settings_format_bottoms_never">從不</string>
+    <string name="settings_format_rain_accessory_label">雨具</string>
+    <string name="settings_format_rain_accessory_none">關閉</string>
+    <string name="settings_format_rain_accessory_umbrella">雨傘</string>
+
+    <!-- Fallback clothes rules — "If no rules match" -->
+    <string name="settings_default_outfit_title">沒有規則符合時</string>
+    <string name="settings_default_top_edit_title">預設上著</string>
+    <string name="settings_default_bottom_edit_title">預設下著</string>
+    <string name="settings_default_outfit_range_above">當溫度高於 %1$s 時</string>
+    <string name="settings_default_outfit_range_below">當溫度低於 %1$s 時</string>
+    <string name="settings_default_outfit_range_between">當溫度在 %1$s 至 %2$s 之間時</string>
+    <string name="settings_default_outfit_range_never">從不</string>
+
+    <!-- Calendar settings — master switch + per-feature toggles -->
+    <string name="settings_calendar_master">使用我的行事曆</string>
+    <string name="settings_calendar_master_description">讓 ClothesCast 讀取你的行事曆，以個人化預報和穿搭。不會有任何資料離開裝置。</string>
+    <string name="settings_calendar_features_title">個人行事曆</string>
+    <string name="settings_calendar_evening_tie_ins">晚間銜接</string>
+    <string name="settings_calendar_evening_tie_ins_description">如果你晚上要外出，早晨預報會告訴你是否需要額外帶點什麼。</string>
+    <string name="settings_calendar_birthdays_description">為行事曆中的生日使用特別的顏色與訊息。</string>
+    <string name="settings_calendar_public_holidays_description">為行事曆中的國定假日使用特別的顏色與訊息。</string>
+    <string name="settings_calendar_open_system_settings">開啟系統設定</string>
 </resources>


### PR DESCRIPTION
## Summary

Backfills missing translations across all 46 full-translation locale files for Settings strings that had landed in English-only.

Covers the areas you flagged:

- **Smart Home** — newer keys: master cast switch (`settings_smart_home_cast_label`), "Skip phone speech" toggles for both cast and MQTT bridges, last-fetched / last-published timestamps, the MQTT topic-prefix placeholder hint, "Display hasn't fetched a ClothesCast yet".
- **Developer settings** — root entry + subtitle, plus the entire "Preview a day" tool (date picker, today button, no-theme message, resolved label, speak button).
- **Format page title & headings** — root entry (`settings_root_format`) and every picker on the page: temperature range (none/degrees/bands), temperature change (off/degrees), clothes wording (garments/layer-count), bottoms (always/if-garments/never), rain accessory (off/umbrella), plus the example / current-forecast preview titles and the "What to say" / "Clothes" labels.
- **Daily ClothesCast on Schedule settings** — `settings_schedule_enabled`, the Notify / Speak delivery labels, and the clothes-mention picker (always/change/never).
- **Calendar settings** — master switch + description, "Personal calendars" section, evening tie-ins, birthdays / public-holidays descriptions, "Open system settings" button.
- **Fallback clothes rules** — "If no rules match" section heading, default top / default bottom slot titles, and the `when temperature is above / below / between %1$s and %2$s / never` range strings.

## Mechanics

- Touched only the 46 full-translation files. The 6 narrow regional overrides (`values-en-rGB`, `values-en-rAU`, `values-en-rCA`, `values-en-rZA`, `values-fr-rCA`, `values-es-rMX`) are intentionally minimal vocabulary swaps that fall through to their base locale, so they stay untouched.
- Brand name "ClothesCast" preserved verbatim across every locale (no transliteration to katakana, Cyrillic, Arabic, etc).
- Placeholders `%1$s`, `%2$s`, `%1$d` preserved verbatim.
- Each locale keeps its existing register (du / Sie, tu / vous, ты / ви, 你 / 您, ます-form, etc) and follows the file's house-style comment header where one exists.
- Added a single section comment per file (`Settings strings added in 2026-05: …`) so the new block is easy to spot.

## Off-device data

No change to what leaves the device — this is UI-string work only.

## Test plan

- [x] `:app:mergeDebugResources` passes (one early run flagged duplicate `settings_root_smart_home` keys in 10 files where the parent locale already had them; deduped before commit).
- [x] `:app:assembleDebug` passes.
- [x] `:app:testDebugUnitTest` passes.
- [x] All 53 `values-*/strings.xml` files validate as well-formed XML.
- [x] No duplicate `<string name="…">` keys across any locale file.
- [ ] CI green on the pushed branch.
- [ ] Spot-check the new strings render correctly in at least one non-Latin locale (e.g. zh-CN or ar) before un-drafting.

https://claude.ai/code/session_01Xrucm7aW6S2vDqbScwdoKY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xrucm7aW6S2vDqbScwdoKY)_