### PR TITLE
Refresh now updates the screen without posting a notification

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
@@ -2883,9 +2883,14 @@ private fun triggerRefresh(
     tonightTime: java.time.LocalTime,
 ) {
     // force=true so an explicit user tap bypasses the same-day cache and
-    // actually regenerates. Without this, Refresh on the same calendar day
-    // just redelivers the morning's payload — surprising when the user has
+    // re-fetches fresh data. Without this, Refresh on the same calendar day
+    // just re-renders the morning's payload — surprising when the user has
     // changed clothes rules, location, or the underlying forecast has moved.
+    //
+    // silent=true so Refresh updates the on-screen Today card but skips the
+    // delivery fan-out (notification, TTS, MQTT, cast) — the user is already
+    // in the app looking at it. The top progress banner is the only feedback,
+    // so there's no toast either.
     //
     // Period follows wall-clock time so an evening tap inside the user's
     // tonight window regenerates the tonight insight — that's the one whose
@@ -2899,12 +2904,7 @@ private fun triggerRefresh(
     } else {
         ForecastPeriod.TODAY
     }
-    FetchAndNotifyWorker.enqueueOneShot(context.applicationContext, force = true, period = period)
-    val toastRes = when (period) {
-        ForecastPeriod.TODAY -> R.string.today_refresh_toast_daily
-        ForecastPeriod.TONIGHT -> R.string.today_refresh_toast_nightly
-    }
-    Toast.makeText(context, context.getString(toastRes), Toast.LENGTH_SHORT).show()
+    FetchAndNotifyWorker.enqueueOneShot(context.applicationContext, force = true, silent = true, period = period)
 }
 
 private fun triggerPlay(context: android.content.Context, period: ForecastPeriod) {

--- a/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
@@ -1482,12 +1482,19 @@ class FetchAndNotifyWorker(
         internal const val KEY_CACHE_LOCATION_ONLY = "cache_location_only"
 
         /**
-         * Set true via [enqueueSilentRefresh] for the opportunistic app-open
-         * refresh: fetch + update the cache so the Today screen re-renders
-         * off fresh data, but skip everything user-facing — no notification,
-         * no TTS, no MQTT publish, no cast load. The widget update still
-         * fires because it's already on the user's launcher and would
-         * otherwise sit on the stale outfit.
+         * Set true for refreshes that fetch + update the cache so the Today
+         * screen re-renders off fresh data, but skip everything user-facing —
+         * no notification, no TTS, no MQTT publish, no cast load. The widget
+         * update still fires because it's already on the user's launcher and
+         * would otherwise sit on the stale outfit.
+         *
+         * Sources: the opportunistic app-open refresh ([enqueueSilentRefresh]),
+         * the first-run onboarding fetch ([enqueueOnboardingRefresh]), and the
+         * Today screen's manual Refresh button ([enqueueOneShot] with
+         * `silent = true`) — the user is already looking at the screen the
+         * fetch updates, so a banner / chime / cast on top of that is exactly
+         * the surprise this flag avoids. The top progress banner is the only
+         * feedback.
          */
         internal const val KEY_SILENT_REFRESH = "silent_refresh"
 
@@ -1513,6 +1520,7 @@ class FetchAndNotifyWorker(
         fun enqueueOneShot(
             context: Context,
             force: Boolean = false,
+            silent: Boolean = false,
             period: ForecastPeriod = ForecastPeriod.TODAY,
             alarmScheduledAtMs: Long = 0L,
             alarmFiredAtMs: Long = 0L,
@@ -1533,6 +1541,7 @@ class FetchAndNotifyWorker(
                 .setInputData(
                     workDataOf(
                         KEY_FORCE_REFRESH to force,
+                        KEY_SILENT_REFRESH to silent,
                         KEY_REQUESTED_EPOCH_DAY to LocalDate.now().toEpochDay(),
                         KEY_PERIOD to period.name,
                         KEY_ALARM_SCHEDULED_AT_MS to alarmScheduledAtMs,

--- a/app/src/main/res/values-am/strings.xml
+++ b/app/src/main/res/values-am/strings.xml
@@ -64,8 +64,6 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="today_more_options">ተጨማሪ አማራጮች</string>
     <string name="today_report_a_bug">ስህተት ሪፖርት አድርግ</string>
     <string name="today_refresh">አድስ</string>
-    <string name="today_refresh_toast_daily">ዕለታዊ ClothesCast እያዳሰ ነው — ብዙም ሳይቆይ ይታያል።</string>
-    <string name="today_refresh_toast_nightly">ምሽታዊ ClothesCast እያዳሰ ነው — ብዙም ሳይቆይ ይታያል።</string>
     <string name="today_empty_title">እስካሁን ClothesCast የለም</string>
     <string name="today_empty_subtitle">የጠዋቱ ClothesCast ከተሰራ በኋላ እዚህ ይታያል።</string>
     <string name="today_fetch_now">አሁን አምጣ</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -107,8 +107,6 @@ they work correctly in both the single-band and range templates.
     <string name="today_more_options">المزيد من الخيارات</string>
     <string name="today_report_a_bug">الإبلاغ عن خطأ</string>
     <string name="today_refresh">تحديث</string>
-    <string name="today_refresh_toast_daily">جارٍ تحديث ClothesCast اليومي — سيظهر قريبًا.</string>
-    <string name="today_refresh_toast_nightly">جارٍ تحديث ClothesCast الليلي — سيظهر قريبًا.</string>
     <string name="today_empty_title">لا يوجد ClothesCast بعد</string>
     <string name="today_empty_subtitle">سيظهر ClothesCast الصباحي هنا بعد إنشائه.</string>
     <string name="today_fetch_now">جلب الآن</string>

--- a/app/src/main/res/values-b+sr+Latn/strings.xml
+++ b/app/src/main/res/values-b+sr+Latn/strings.xml
@@ -434,8 +434,6 @@ default English (matching values-pl / values-uk).
     <string name="today_more_options">Više opcija</string>
     <string name="today_report_a_bug">Prijavi grešku</string>
     <string name="today_refresh">Osveži</string>
-    <string name="today_refresh_toast_daily">Osvežavam tvoj dnevni ClothesCast — pojaviće se uskoro.</string>
-    <string name="today_refresh_toast_nightly">Osvežavam tvoj noćni ClothesCast — pojaviće se uskoro.</string>
     <string name="today_empty_title">Još nema ClothesCasta</string>
     <string name="today_empty_subtitle">Tvoj jutarnji ClothesCast pojaviće se ovde čim bude generisan.</string>
     <string name="today_fetch_now">Preuzmi odmah</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -115,8 +115,6 @@ What is NOT overridden, by design:
     <string name="today_more_options">Още опции</string>
     <string name="today_report_a_bug">Докладвай грешка</string>
     <string name="today_refresh">Обнови</string>
-    <string name="today_refresh_toast_daily">Обновявам твоя дневен ClothesCast — ще се появи скоро.</string>
-    <string name="today_refresh_toast_nightly">Обновявам твоя нощен ClothesCast — ще се появи скоро.</string>
     <string name="today_empty_title">Все още няма ClothesCast</string>
     <string name="today_empty_subtitle">Сутрешният ти ClothesCast ще се появи тук, след като бъде генериран.</string>
     <string name="today_fetch_now">Вземи сега</string>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -109,8 +109,6 @@ West Bengal vocabulary differences in a future PR.
     <string name="today_more_options">আরও বিকল্প</string>
     <string name="today_report_a_bug">বাগ রিপোর্ট করুন</string>
     <string name="today_refresh">রিফ্রেশ</string>
-    <string name="today_refresh_toast_daily">আপনার দৈনিক ClothesCast রিফ্রেশ হচ্ছে — শীঘ্রই দেখা যাবে।</string>
-    <string name="today_refresh_toast_nightly">আপনার রাতের ClothesCast রিফ্রেশ হচ্ছে — শীঘ্রই দেখা যাবে।</string>
     <string name="today_empty_title">এখনো কোনো ClothesCast নেই</string>
     <string name="today_empty_subtitle">আপনার সকালের ClothesCast তৈরি হলে এখানে দেখা যাবে।</string>
     <string name="today_fetch_now">এখনই আনুন</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -14,8 +14,6 @@ the in-app clock is digit-driven and reads consistently across locales.
     <string name="today_more_options">Més opcions</string>
     <string name="today_report_a_bug">Informar d\'un error</string>
     <string name="today_refresh">Actualitza</string>
-    <string name="today_refresh_toast_daily">Actualitzant el teu ClothesCast diari — apareixerà en breu.</string>
-    <string name="today_refresh_toast_nightly">Actualitzant el teu ClothesCast nocturn — apareixerà en breu.</string>
     <string name="today_empty_title">Encara no hi ha ClothesCast</string>
     <string name="today_empty_subtitle">El teu ClothesCast matinal apareixerà aquí un cop generat.</string>
     <string name="today_fetch_now">Obtén ara</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -361,8 +361,6 @@ locale (Angličtina (USA), Francouzština (Francie), Němčina (Německo), …).
     <string name="today_more_options">Více možností</string>
     <string name="today_report_a_bug">Nahlásit chybu</string>
     <string name="today_refresh">Obnovit</string>
-    <string name="today_refresh_toast_daily">Tvůj denní ClothesCast se aktualizuje — za chvíli se zobrazí.</string>
-    <string name="today_refresh_toast_nightly">Tvůj noční ClothesCast se aktualizuje — za chvíli se zobrazí.</string>
     <string name="today_empty_title">Zatím žádný ClothesCast</string>
     <string name="today_empty_subtitle">Tvůj ranní ClothesCast se zde zobrazí, jakmile bude vytvořen.</string>
     <string name="today_fetch_now">Načíst nyní</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -362,8 +362,6 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrig)").
     <string name="today_more_options">Flere muligheder</string>
     <string name="today_report_a_bug">Rapportér en fejl</string>
     <string name="today_refresh">Opdater</string>
-    <string name="today_refresh_toast_daily">Dit daglige ClothesCast opdateres — det kommer straks.</string>
-    <string name="today_refresh_toast_nightly">Dit aftenvise ClothesCast opdateres — det kommer straks.</string>
     <string name="today_empty_title">Intet ClothesCast endnu</string>
     <string name="today_empty_subtitle">Dit morgenvise ClothesCast dukker op her, når det er genereret.</string>
     <string name="today_fetch_now">Hent nu</string>

--- a/app/src/main/res/values-de-rAT/strings.xml
+++ b/app/src/main/res/values-de-rAT/strings.xml
@@ -349,8 +349,6 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="today_more_options">Mehr Optionen</string>
     <string name="today_report_a_bug">Fehler melden</string>
     <string name="today_refresh">Aktualisieren</string>
-    <string name="today_refresh_toast_daily">Dein täglicher ClothesCast wird aktualisiert — er erscheint gleich.</string>
-    <string name="today_refresh_toast_nightly">Dein nächtlicher ClothesCast wird aktualisiert — er erscheint gleich.</string>
     <string name="today_empty_title">Noch kein ClothesCast</string>
     <string name="today_empty_subtitle">Dein morgendlicher ClothesCast erscheint hier, sobald er erstellt wurde.</string>
     <string name="today_fetch_now">Jetzt abrufen</string>

--- a/app/src/main/res/values-de-rCH/strings.xml
+++ b/app/src/main/res/values-de-rCH/strings.xml
@@ -354,8 +354,6 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="today_more_options">Mehr Optionen</string>
     <string name="today_report_a_bug">Fehler melden</string>
     <string name="today_refresh">Aktualisieren</string>
-    <string name="today_refresh_toast_daily">Dein täglicher ClothesCast wird aktualisiert — er erscheint gleich.</string>
-    <string name="today_refresh_toast_nightly">Dein nächtlicher ClothesCast wird aktualisiert — er erscheint gleich.</string>
     <string name="today_empty_title">Noch kein ClothesCast</string>
     <string name="today_empty_subtitle">Dein morgendlicher ClothesCast erscheint hier, sobald er erstellt wurde.</string>
     <string name="today_fetch_now">Jetzt abrufen</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -346,8 +346,6 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="today_more_options">Mehr Optionen</string>
     <string name="today_report_a_bug">Fehler melden</string>
     <string name="today_refresh">Aktualisieren</string>
-    <string name="today_refresh_toast_daily">Dein täglicher ClothesCast wird aktualisiert — er erscheint gleich.</string>
-    <string name="today_refresh_toast_nightly">Dein nächtlicher ClothesCast wird aktualisiert — er erscheint gleich.</string>
     <string name="today_empty_title">Noch kein ClothesCast</string>
     <string name="today_empty_subtitle">Dein morgendlicher ClothesCast erscheint hier, sobald er erstellt wurde.</string>
     <string name="today_fetch_now">Jetzt abrufen</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -394,8 +394,6 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="today_more_options">Περισσότερες επιλογές</string>
     <string name="today_report_a_bug">Αναφορά σφάλματος</string>
     <string name="today_refresh">Ανανέωση</string>
-    <string name="today_refresh_toast_daily">Ανανέωση του καθημερινού σου ClothesCast — θα εμφανιστεί σύντομα.</string>
-    <string name="today_refresh_toast_nightly">Ανανέωση του νυχτερινού σου ClothesCast — θα εμφανιστεί σύντομα.</string>
     <string name="today_empty_title">Δεν υπάρχει ακόμη ClothesCast</string>
     <string name="today_empty_subtitle">Ο πρωινός σου ClothesCast θα εμφανιστεί εδώ μόλις δημιουργηθεί.</string>
     <string name="today_fetch_now">Ανάκτηση τώρα</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -344,8 +344,6 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="today_more_options">Más opciones</string>
     <string name="today_report_a_bug">Informar de un error</string>
     <string name="today_refresh">Actualizar</string>
-    <string name="today_refresh_toast_daily">Actualizando tu ClothesCast diario — aparecerá enseguida.</string>
-    <string name="today_refresh_toast_nightly">Actualizando tu ClothesCast nocturno — aparecerá enseguida.</string>
     <string name="today_empty_title">Aún no hay ClothesCast</string>
     <string name="today_empty_subtitle">Tu ClothesCast matutino aparecerá aquí cuando se genere.</string>
     <string name="today_fetch_now">Obtener ahora</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -14,8 +14,6 @@ Tone is informal "sina"-form throughout ("Pane … selga", "Võta … kaasa",
     <string name="today_more_options">Rohkem valikuid</string>
     <string name="today_report_a_bug">Teata veast</string>
     <string name="today_refresh">Värskenda</string>
-    <string name="today_refresh_toast_daily">Värskendatakse sinu igapäevast ClothesCast\'i — ilmub varsti.</string>
-    <string name="today_refresh_toast_nightly">Värskendatakse sinu õhtust ClothesCast\'i — ilmub varsti.</string>
     <string name="today_empty_title">ClothesCast puudub veel</string>
     <string name="today_empty_subtitle">Sinu hommikune ClothesCast ilmub siia, kui see on genereeritud.</string>
     <string name="today_fetch_now">Laadi kohe</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -107,8 +107,6 @@ Western Arabic numerals (0-9) are used for TTS compatibility.
     <string name="today_more_options">گزینه‌های بیشتر</string>
     <string name="today_report_a_bug">گزارش خطا</string>
     <string name="today_refresh">بازخوانی</string>
-    <string name="today_refresh_toast_daily">در حال به‌روزرسانی ClothesCast روزانه شما — به زودی نمایش داده می‌شود.</string>
-    <string name="today_refresh_toast_nightly">در حال به‌روزرسانی ClothesCast شبانه شما — به زودی نمایش داده می‌شود.</string>
     <string name="today_empty_title">هنوز ClothesCast وجود ندارد</string>
     <string name="today_empty_subtitle">ClothesCast صبحگاهی شما پس از تولید اینجا نمایش داده می‌شود.</string>
     <string name="today_fetch_now">دریافت اکنون</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -275,8 +275,6 @@ displayed label localizes.
     <string name="today_more_options">Lisää vaihtoehtoja</string>
     <string name="today_report_a_bug">Ilmoita virheestä</string>
     <string name="today_refresh">Päivitä</string>
-    <string name="today_refresh_toast_daily">Päivittäinen ClothesCastisi päivitetään — se ilmestyy pian.</string>
-    <string name="today_refresh_toast_nightly">Iltainen ClothesCastisi päivitetään — se ilmestyy pian.</string>
     <string name="today_empty_title">Ei ClothesCastia vielä</string>
     <string name="today_empty_subtitle">Aamuinen ClothesCastisi ilmestyy tähän, kun se on luotu.</string>
     <string name="today_fetch_now">Hae nyt</string>

--- a/app/src/main/res/values-fil/strings.xml
+++ b/app/src/main/res/values-fil/strings.xml
@@ -100,8 +100,6 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="today_more_options">Higit pang mga opsyon</string>
     <string name="today_report_a_bug">Mag-ulat ng bug</string>
     <string name="today_refresh">I-refresh</string>
-    <string name="today_refresh_toast_daily">Ina-refresh ang iyong pang-araw na ClothesCast — lilitaw ito nang ilang sandali.</string>
-    <string name="today_refresh_toast_nightly">Ina-refresh ang iyong pang-gabing ClothesCast — lilitaw ito nang ilang sandali.</string>
     <string name="today_empty_title">Wala pang ClothesCast</string>
     <string name="today_empty_subtitle">Lilitaw dito ang iyong umaga na ClothesCast kapag nagawa na ito.</string>
     <string name="today_fetch_now">Kunin ngayon</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -346,8 +346,6 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="today_more_options">Plus d\'options</string>
     <string name="today_report_a_bug">Signaler un bug</string>
     <string name="today_refresh">Actualiser</string>
-    <string name="today_refresh_toast_daily">Actualisation de ton ClothesCast quotidien — il apparaîtra bientôt.</string>
-    <string name="today_refresh_toast_nightly">Actualisation de ton ClothesCast nocturne — il apparaîtra bientôt.</string>
     <string name="today_empty_title">Pas encore de ClothesCast</string>
     <string name="today_empty_subtitle">Ton ClothesCast matinal apparaîtra ici dès qu\'il sera généré.</string>
     <string name="today_fetch_now">Récupérer maintenant</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -334,8 +334,6 @@ Not overridden by design:
     <string name="today_more_options">और विकल्प</string>
     <string name="today_report_a_bug">बग रिपोर्ट करें</string>
     <string name="today_refresh">रीफ़्रेश करें</string>
-    <string name="today_refresh_toast_daily">आपका दैनिक ClothesCast रीफ़्रेश हो रहा है — कुछ ही देर में दिखेगा।</string>
-    <string name="today_refresh_toast_nightly">आपका रात्रि ClothesCast रीफ़्रेश हो रहा है — कुछ ही देर में दिखेगा।</string>
     <string name="today_empty_title">अभी कोई ClothesCast नहीं</string>
     <string name="today_empty_subtitle">आपका सुबह का ClothesCast तैयार होने पर यहाँ दिखेगा।</string>
     <string name="today_fetch_now">अभी लाएँ</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -318,8 +318,6 @@ spousal register), matching the existing insight prose ("Ponesi …",
     <string name="today_more_options">Više opcija</string>
     <string name="today_report_a_bug">Prijavi grešku</string>
     <string name="today_refresh">Osvježi</string>
-    <string name="today_refresh_toast_daily">Osvježavam tvoj dnevni ClothesCast — pojavit će se uskoro.</string>
-    <string name="today_refresh_toast_nightly">Osvježavam tvoj noćni ClothesCast — pojavit će se uskoro.</string>
     <string name="today_empty_title">Još nema ClothesCasta</string>
     <string name="today_empty_subtitle">Tvoj jutarnji ClothesCast pojavit će se ovdje čim bude generiran.</string>
     <string name="today_fetch_now">Dohvati sada</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -363,8 +363,6 @@ locale (Angol (Egyesült Államok), Francia (Franciaország), Német
     <string name="today_more_options">További lehetőségek</string>
     <string name="today_report_a_bug">Hiba bejelentése</string>
     <string name="today_refresh">Frissítés</string>
-    <string name="today_refresh_toast_daily">A napi ClothesCastod frissül — hamarosan megjelenik.</string>
-    <string name="today_refresh_toast_nightly">Az esti ClothesCastod frissül — hamarosan megjelenik.</string>
     <string name="today_empty_title">Még nincs ClothesCast</string>
     <string name="today_empty_subtitle">A reggeli ClothesCastod itt jelenik meg, amint elkészül.</string>
     <string name="today_fetch_now">Betöltés most</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -105,8 +105,6 @@ to values/strings.xml (English).
     <string name="today_more_options">Opsi lainnya</string>
     <string name="today_report_a_bug">Laporkan bug</string>
     <string name="today_refresh">Perbarui</string>
-    <string name="today_refresh_toast_daily">Memperbarui ClothesCast harian Anda — sebentar lagi akan muncul.</string>
-    <string name="today_refresh_toast_nightly">Memperbarui ClothesCast malam Anda — sebentar lagi akan muncul.</string>
     <string name="today_empty_title">Belum ada ClothesCast</string>
     <string name="today_empty_subtitle">ClothesCast pagi Anda akan muncul di sini setelah dibuat.</string>
     <string name="today_fetch_now">Ambil sekarang</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -336,8 +336,6 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="today_more_options">Altre opzioni</string>
     <string name="today_report_a_bug">Segnala un bug</string>
     <string name="today_refresh">Aggiorna</string>
-    <string name="today_refresh_toast_daily">Sto aggiornando il tuo ClothesCast quotidiano — apparirà a momenti.</string>
-    <string name="today_refresh_toast_nightly">Sto aggiornando il tuo ClothesCast serale — apparirà a momenti.</string>
     <string name="today_empty_title">Ancora nessun ClothesCast</string>
     <string name="today_empty_subtitle">Il tuo ClothesCast mattutino apparirà qui una volta generato.</string>
     <string name="today_fetch_now">Aggiorna ora</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -107,8 +107,6 @@ standard in Israeli digital communication.
     <string name="today_more_options">אפשרויות נוספות</string>
     <string name="today_report_a_bug">דווח/י על תקלה</string>
     <string name="today_refresh">רענן/י</string>
-    <string name="today_refresh_toast_daily">מרענן את ClothesCast היומי שלך — יופיע בקרוב.</string>
-    <string name="today_refresh_toast_nightly">מרענן את ClothesCast הלילי שלך — יופיע בקרוב.</string>
     <string name="today_empty_title">אין ClothesCast עדיין</string>
     <string name="today_empty_subtitle">ClothesCast הבוקר שלך יופיע כאן לאחר שייווצר.</string>
     <string name="today_fetch_now">טען עכשיו</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -347,8 +347,6 @@ the displayed label localizes.
     <string name="today_more_options">その他のオプション</string>
     <string name="today_report_a_bug">バグを報告</string>
     <string name="today_refresh">更新</string>
-    <string name="today_refresh_toast_daily">毎日の ClothesCast を更新中です — もうすぐ表示されます。</string>
-    <string name="today_refresh_toast_nightly">夜間の ClothesCast を更新中です — もうすぐ表示されます。</string>
     <string name="today_empty_title">まだ ClothesCast がありません</string>
     <string name="today_empty_subtitle">朝の ClothesCast が生成されるとここに表示されます。</string>
     <string name="today_fetch_now">今すぐ取得</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -362,8 +362,6 @@ displayed label localizes.
     <string name="today_more_options">더 보기</string>
     <string name="today_report_a_bug">버그 신고</string>
     <string name="today_refresh">새로고침</string>
-    <string name="today_refresh_toast_daily">매일 ClothesCast를 새로고침하고 있어요 — 곧 표시됩니다.</string>
-    <string name="today_refresh_toast_nightly">야간 ClothesCast를 새로고침하고 있어요 — 곧 표시됩니다.</string>
     <string name="today_empty_title">아직 ClothesCast가 없어요</string>
     <string name="today_empty_subtitle">아침 ClothesCast가 생성되면 여기에 표시됩니다.</string>
     <string name="today_fetch_now">지금 가져오기</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -102,8 +102,6 @@ What is NOT overridden, by design:
     <string name="today_more_options">Daugiau parinkčių</string>
     <string name="today_report_a_bug">Pranešti apie klaidą</string>
     <string name="today_refresh">Atnaujinti</string>
-    <string name="today_refresh_toast_daily">Atnaujinamas dienos ClothesCast — netrukus pasirodys.</string>
-    <string name="today_refresh_toast_nightly">Atnaujinamas nakties ClothesCast — netrukus pasirodys.</string>
     <string name="today_empty_title">ClothesCast dar nėra</string>
     <string name="today_empty_subtitle">Ryto ClothesCast pasirodys čia, kai bus sugeneruotas.</string>
     <string name="today_fetch_now">Gauti dabar</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -114,8 +114,6 @@ informal "tu"-form throughout ("Apģērb …", "Paņem … līdzi").
     <string name="today_more_options">Vairāk opciju</string>
     <string name="today_report_a_bug">Ziņot par kļūdu</string>
     <string name="today_refresh">Atjaunināt</string>
-    <string name="today_refresh_toast_daily">Atjaunina ikdienas ClothesCast — tas parādīsies drīzumā.</string>
-    <string name="today_refresh_toast_nightly">Atjaunina nakts ClothesCast — tas parādīsies drīzumā.</string>
     <string name="today_empty_title">ClothesCast vēl nav</string>
     <string name="today_empty_subtitle">Tavs rīta ClothesCast parādīsies šeit, tiklīdz tas tiks ģenerēts.</string>
     <string name="today_fetch_now">Ielādēt tagad</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -100,8 +100,6 @@ vs "kemungkinan", "padam" vs "hapus").
     <string name="today_more_options">Pilihan lain</string>
     <string name="today_report_a_bug">Laporkan pepijat</string>
     <string name="today_refresh">Muat semula</string>
-    <string name="today_refresh_toast_daily">Memuat semula ClothesCast harian anda — ia akan muncul sebentar lagi.</string>
-    <string name="today_refresh_toast_nightly">Memuat semula ClothesCast malam anda — ia akan muncul sebentar lagi.</string>
     <string name="today_empty_title">Tiada ClothesCast lagi</string>
     <string name="today_empty_subtitle">ClothesCast pagi anda akan muncul di sini setelah dijana.</string>
     <string name="today_fetch_now">Ambil sekarang</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -362,8 +362,6 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrike)").
     <string name="today_more_options">Flere alternativer</string>
     <string name="today_report_a_bug">Rapporter en feil</string>
     <string name="today_refresh">Oppdater</string>
-    <string name="today_refresh_toast_daily">Ditt daglige ClothesCast oppdateres — det kommer straks.</string>
-    <string name="today_refresh_toast_nightly">Ditt kveldslige ClothesCast oppdateres — det kommer straks.</string>
     <string name="today_empty_title">Ingen ClothesCast ennå</string>
     <string name="today_empty_subtitle">Ditt morgenvise ClothesCast dukker opp her når det er generert.</string>
     <string name="today_fetch_now">Hent nå</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -313,8 +313,6 @@ the displayed label localizes.
     <string name="today_more_options">Meer opties</string>
     <string name="today_report_a_bug">Bug melden</string>
     <string name="today_refresh">Vernieuwen</string>
-    <string name="today_refresh_toast_daily">Je dagelijkse ClothesCast wordt vernieuwd — hij verschijnt zo meteen.</string>
-    <string name="today_refresh_toast_nightly">Je avondlijkse ClothesCast wordt vernieuwd — hij verschijnt zo meteen.</string>
     <string name="today_empty_title">Nog geen ClothesCast</string>
     <string name="today_empty_subtitle">Je ochtendlijkse ClothesCast verschijnt hier zodra hij is aangemaakt.</string>
     <string name="today_fetch_now">Nu ophalen</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -313,8 +313,6 @@ is unchanged; only the displayed label localizes.
     <string name="today_more_options">Więcej opcji</string>
     <string name="today_report_a_bug">Zgłoś błąd</string>
     <string name="today_refresh">Odśwież</string>
-    <string name="today_refresh_toast_daily">Twój codzienny ClothesCast jest odświeżany — pojawi się za chwilę.</string>
-    <string name="today_refresh_toast_nightly">Twój wieczorny ClothesCast jest odświeżany — pojawi się za chwilę.</string>
     <string name="today_empty_title">Brak ClothesCastu</string>
     <string name="today_empty_subtitle">Twój poranny ClothesCast pojawi się tutaj po utworzeniu.</string>
     <string name="today_fetch_now">Pobierz teraz</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -350,8 +350,6 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="today_more_options">Mais opções</string>
     <string name="today_report_a_bug">Reportar um bug</string>
     <string name="today_refresh">Atualizar</string>
-    <string name="today_refresh_toast_daily">Atualizando seu ClothesCast diário — ele aparecerá em breve.</string>
-    <string name="today_refresh_toast_nightly">Atualizando seu ClothesCast noturno — ele aparecerá em breve.</string>
     <string name="today_empty_title">Nenhum ClothesCast ainda</string>
     <string name="today_empty_subtitle">Seu ClothesCast matinal aparecerá aqui assim que for gerado.</string>
     <string name="today_fetch_now">Buscar agora</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -368,8 +368,6 @@ they diverge from BR ("Polonês" → "Polaco", "Holandês" →
     <string name="today_more_options">Mais opções</string>
     <string name="today_report_a_bug">Reportar um erro</string>
     <string name="today_refresh">Atualizar</string>
-    <string name="today_refresh_toast_daily">A atualizar o teu ClothesCast diário — vai aparecer em breve.</string>
-    <string name="today_refresh_toast_nightly">A atualizar o teu ClothesCast noturno — vai aparecer em breve.</string>
     <string name="today_empty_title">Ainda sem ClothesCast</string>
     <string name="today_empty_subtitle">O teu ClothesCast matinal aparece aqui assim que for gerado.</string>
     <string name="today_fetch_now">Obter agora</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -102,8 +102,6 @@ surfaces fall back to default English (matching values-pl / values-uk).
     <string name="today_more_options">Mai multe opțiuni</string>
     <string name="today_report_a_bug">Raportează un bug</string>
     <string name="today_refresh">Reîmprospătează</string>
-    <string name="today_refresh_toast_daily">Se reîmprospătează ClothesCast-ul zilnic — va apărea în scurt timp.</string>
-    <string name="today_refresh_toast_nightly">Se reîmprospătează ClothesCast-ul de seară — va apărea în scurt timp.</string>
     <string name="today_empty_title">Niciun ClothesCast încă</string>
     <string name="today_empty_subtitle">ClothesCast-ul tău de dimineață va apărea aici odată generat.</string>
     <string name="today_fetch_now">Aduce acum</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -430,8 +430,6 @@ only the displayed label localizes.
     <string name="today_more_options">Ещё</string>
     <string name="today_report_a_bug">Сообщить об ошибке</string>
     <string name="today_refresh">Обновить</string>
-    <string name="today_refresh_toast_daily">Обновляю твой ежедневный ClothesCast — скоро появится.</string>
-    <string name="today_refresh_toast_nightly">Обновляю твой вечерний ClothesCast — скоро появится.</string>
     <string name="today_empty_title">ClothesCast пока нет</string>
     <string name="today_empty_subtitle">Твой утренний ClothesCast появится здесь, как только сгенерируется.</string>
     <string name="today_fetch_now">Получить сейчас</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -374,8 +374,6 @@ What is NOT overridden, by design:
     <string name="today_more_options">Ďalšie možnosti</string>
     <string name="today_report_a_bug">Nahlásiť chybu</string>
     <string name="today_refresh">Obnoviť</string>
-    <string name="today_refresh_toast_daily">Tvoj denný ClothesCast sa aktualizuje — za chvíľu sa zobrazí.</string>
-    <string name="today_refresh_toast_nightly">Tvoj nočný ClothesCast sa aktualizuje — za chvíľu sa zobrazí.</string>
     <string name="today_empty_title">Zatiaľ žiadny ClothesCast</string>
     <string name="today_empty_subtitle">Tvoj ranný ClothesCast sa tu zobrazí, keď bude vytvorený.</string>
     <string name="today_fetch_now">Načítať teraz</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -104,8 +104,6 @@ informal "ti"-form throughout, mirroring the Croatian / Serbian pass.
     <string name="today_more_options">Več možnosti</string>
     <string name="today_report_a_bug">Prijavi napako</string>
     <string name="today_refresh">Osveži</string>
-    <string name="today_refresh_toast_daily">Osvežujem tvoj dnevni ClothesCast — kmalu se bo prikazal.</string>
-    <string name="today_refresh_toast_nightly">Osvežujem tvoj nočni ClothesCast — kmalu se bo prikazal.</string>
     <string name="today_empty_title">Še ni ClothesCasta</string>
     <string name="today_empty_subtitle">Tvoj jutranji ClothesCast se bo prikazal tukaj, ko bo ustvarjen.</string>
     <string name="today_fetch_now">Pridobi zdaj</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -362,8 +362,6 @@ native names for all locales (e.g. "Tyska (Tyskland)", "Franska (Frankrike)").
     <string name="today_more_options">Fler alternativ</string>
     <string name="today_report_a_bug">Rapportera ett fel</string>
     <string name="today_refresh">Uppdatera</string>
-    <string name="today_refresh_toast_daily">Ditt dagliga ClothesCast uppdateras — det kommer strax.</string>
-    <string name="today_refresh_toast_nightly">Ditt kvällsvisa ClothesCast uppdateras — det kommer strax.</string>
     <string name="today_empty_title">Inget ClothesCast ännu</string>
     <string name="today_empty_subtitle">Ditt morgonliga ClothesCast dyker upp här när det har genererats.</string>
     <string name="today_fetch_now">Hämta nu</string>

--- a/app/src/main/res/values-sw/strings.xml
+++ b/app/src/main/res/values-sw/strings.xml
@@ -98,8 +98,6 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="today_more_options">Chaguo zaidi</string>
     <string name="today_report_a_bug">Ripoti hitilafu</string>
     <string name="today_refresh">Onyesha upya</string>
-    <string name="today_refresh_toast_daily">Inasasisha ClothesCast yako ya kila siku — itaonekana hivi karibuni.</string>
-    <string name="today_refresh_toast_nightly">Inasasisha ClothesCast yako ya usiku — itaonekana hivi karibuni.</string>
     <string name="today_empty_title">Hakuna ClothesCast bado</string>
     <string name="today_empty_subtitle">ClothesCast yako ya asubuhi itaonekana hapa baada ya kuundwa.</string>
     <string name="today_fetch_now">Pakua sasa</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -114,8 +114,6 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="today_more_options">ตัวเลือกเพิ่มเติม</string>
     <string name="today_report_a_bug">รายงานข้อผิดพลาด</string>
     <string name="today_refresh">รีเฟรช</string>
-    <string name="today_refresh_toast_daily">กำลังรีเฟรช ClothesCast รายวัน — จะปรากฏในไม่ช้า</string>
-    <string name="today_refresh_toast_nightly">กำลังรีเฟรช ClothesCast รายคืน — จะปรากฏในไม่ช้า</string>
     <string name="today_empty_title">ยังไม่มี ClothesCast</string>
     <string name="today_empty_subtitle">ClothesCast ช่วงเช้าจะปรากฏที่นี่เมื่อสร้างเสร็จแล้ว</string>
     <string name="today_fetch_now">ดึงข้อมูลเดี๋ยวนี้</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -275,8 +275,6 @@ displayed label localizes.
     <string name="today_more_options">Daha fazla seçenek</string>
     <string name="today_report_a_bug">Hata bildir</string>
     <string name="today_refresh">Yenile</string>
-    <string name="today_refresh_toast_daily">Günlük ClothesCast\'ın güncelleniyor — birazdan görünecek.</string>
-    <string name="today_refresh_toast_nightly">Gecelik ClothesCast\'ın güncelleniyor — birazdan görünecek.</string>
     <string name="today_empty_title">Henüz ClothesCast yok</string>
     <string name="today_empty_subtitle">Sabah ClothesCast\'ın oluşturulduğunda burada görünecek.</string>
     <string name="today_fetch_now">Şimdi al</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -378,8 +378,6 @@ only the displayed label localizes.
     <string name="today_more_options">Більше</string>
     <string name="today_report_a_bug">Повідомити про помилку</string>
     <string name="today_refresh">Оновити</string>
-    <string name="today_refresh_toast_daily">Оновлення вашого щоденного ClothesCast — з\'явиться невдовзі.</string>
-    <string name="today_refresh_toast_nightly">Оновлення вашого вечірнього ClothesCast — з\'явиться невдовзі.</string>
     <string name="today_empty_title">ClothesCast ще немає</string>
     <string name="today_empty_subtitle">Ваш ранковий ClothesCast з\'явиться тут, щойно буде згенеровано.</string>
     <string name="today_fetch_now">Отримати зараз</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -105,8 +105,6 @@ Skipped intentionally: app_name (brand), insight_time_am/pm/midnight/noon
     <string name="today_more_options">Thêm tùy chọn</string>
     <string name="today_report_a_bug">Báo lỗi</string>
     <string name="today_refresh">Làm mới</string>
-    <string name="today_refresh_toast_daily">Đang làm mới ClothesCast hàng ngày — sẽ hiển thị ngay.</string>
-    <string name="today_refresh_toast_nightly">Đang làm mới ClothesCast buổi tối — sẽ hiển thị ngay.</string>
     <string name="today_empty_title">Chưa có ClothesCast</string>
     <string name="today_empty_subtitle">ClothesCast buổi sáng sẽ xuất hiện ở đây sau khi được tạo.</string>
     <string name="today_fetch_now">Tải ngay</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -340,8 +340,6 @@ label localizes.
     <string name="today_more_options">更多选项</string>
     <string name="today_report_a_bug">报告问题</string>
     <string name="today_refresh">刷新</string>
-    <string name="today_refresh_toast_daily">正在刷新你的每日 ClothesCast — 稍后即可看到。</string>
-    <string name="today_refresh_toast_nightly">正在刷新你的夜间 ClothesCast — 稍后即可看到。</string>
     <string name="today_empty_title">还没有 ClothesCast</string>
     <string name="today_empty_subtitle">你的早晨 ClothesCast 生成后会显示在这里。</string>
     <string name="today_fetch_now">立即获取</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -330,8 +330,6 @@ label localises.
     <string name="today_more_options">更多選項</string>
     <string name="today_report_a_bug">回報問題</string>
     <string name="today_refresh">重新整理</string>
-    <string name="today_refresh_toast_daily">正在重新整理你的每日 ClothesCast — 稍後即可看到。</string>
-    <string name="today_refresh_toast_nightly">正在重新整理你的夜間 ClothesCast — 稍後即可看到。</string>
     <string name="today_empty_title">還沒有 ClothesCast</string>
     <string name="today_empty_subtitle">你的早晨 ClothesCast 產生後會顯示在這裡。</string>
     <string name="today_fetch_now">立即取得</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -14,8 +14,6 @@
     <string name="today_more_options">More options</string>
     <string name="today_report_a_bug">Report a bug</string>
     <string name="today_refresh">Refresh</string>
-    <string name="today_refresh_toast_daily">Refreshing your daily ClothesCast — it\'ll appear shortly.</string>
-    <string name="today_refresh_toast_nightly">Refreshing your nightly ClothesCast — it\'ll appear shortly.</string>
     <string name="today_play">Play</string>
     <string name="today_play_toast_daily">Playing your daily ClothesCast.</string>
     <string name="today_play_toast_nightly">Playing your nightly ClothesCast.</string>


### PR DESCRIPTION
## Summary

The Today screen's **Refresh** button reran the full delivery pipeline — notification + TTS + MQTT + Cast — the same path the scheduled morning/evening alarm uses. Since the user is already in the app looking at the screen, a fresh notification / chime / cast on top of that is a surprise, not feedback.

Refresh now reuses the **existing** silent-refresh path (`KEY_SILENT_REFRESH`, already used by the app-open and onboarding refreshes): it fetches fresh data and updates the on-screen Today card and home-screen widget, but skips the user-facing fan-out. The top progress banner is the only feedback, so the "Refreshing…" toast is gone too.

## Changes

- `FetchAndNotifyWorker.enqueueOneShot` gains a `silent: Boolean = false` parameter wired to `KEY_SILENT_REFRESH`; `triggerRefresh` passes `silent = true`.
- Default `false` means the scheduled alarm fires (`AlarmReceiver`) and the About-screen test fetch are unchanged and still deliver.
- Refresh stays on the period-specific work queues the Today screen observes (`UNIQUE_WORK_NAME` / `UNIQUE_WORK_NAME_TONIGHT`), so the working spinner + top banner still show during the fetch and hide on success — mirroring how `enqueueOnboardingRefresh` already pairs the silent flag with an observed queue.
- Removed the now-unused `today_refresh_toast_daily` / `today_refresh_toast_nightly` strings from the default and all translated locales (~47 files). `today_play_toast_*` is kept (Play button still toasts).

## Privacy

A manual Refresh no longer sends anything off-device — **no TTS request, no Cast load, no MQTT publish** — where it previously did. This narrows, not broadens, what crosses the device boundary.

## Test plan

- [x] `./gradlew :app:testDebugUnitTest` — passes
- [x] `./gradlew :app:assembleDebug` — passes
- [ ] Manual on emulator: tap Refresh (daytime) → top banner shows, Today card updates with fresh data, **no** notification / TTS / Cast / MQTT / toast
- [ ] Manual: tap Refresh inside the tonight window → tonight card refreshes silently
- [ ] Sanity: a scheduled alarm fire still posts its notification (default `silent = false` path unchanged)

Note: `:app:lintDebug` currently crashes locally with an unrelated lint-tooling bug (`IncompatibleClassChangeError` in Compose's `RememberInCompositionDetector`) that predates this change; CI runs JVM tests + `assembleDebug`, both green here.

https://claude.ai/code/session_01D8CkTfVdfn76eQMQwBFaJf

---
_Generated by [Claude Code](https://claude.ai/code/session_01D8CkTfVdfn76eQMQwBFaJf)_