### PR TITLE
Translate the updated clothes promo card into all locales

### DIFF
--- a/app/src/main/res/values-am/strings.xml
+++ b/app/src/main/res/values-am/strings.xml
@@ -1159,10 +1159,10 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="settings_tts_style_spooky_narrator">አስፈሪ ተራኪ</string>
     <string name="today_chart_readout">%1$s · %2$s</string>
     <string name="today_chart_reset_to_now">አሁንን አሳይ</string>
-    <string name="today_clothes_promo_body">ClothesCast ከደንቦች ስብስብ ልብሶችን ይመርጣል። የሙቀት መጠኖችን አስተካክል፣ ሽፋኖችን ጨምር ወይም በልብስ ቅንብር ውስጥ የቀረቡትን ለውጥ።</string>
+    <string name="today_clothes_promo_body">ClothesCast ከደንቦች ስብስብ ልብሶችን ይመርጣል። የሙቀት መጠኖችን አስተካክል እና በልብስ ቅንብር ውስጥ ልብስህን አበጅ።</string>
     <string name="today_clothes_promo_cta">የልብስ ቅንብር</string>
     <string name="today_clothes_promo_dismiss">ዝጋ</string>
-    <string name="today_clothes_promo_title">ደንቦቹን የራስህ አድርግ</string>
+    <string name="today_clothes_promo_title">ልብሶቹን የራስህ አድርግ</string>
     <string name="today_insight_format_link">ቅርጸት</string>
     <string name="today_play">አጫውት</string>
     <string name="today_play_toast_daily">ዕለታዊ ClothesCastህን እያጫወትኩ ነው።</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -1193,10 +1193,10 @@ they work correctly in both the single-band and range templates.
     <string name="settings_tts_style_spooky_narrator">راوي مخيف</string>
     <string name="today_chart_readout">%1$s · %2$s</string>
     <string name="today_chart_reset_to_now">عرض الآن</string>
-    <string name="today_clothes_promo_body">يختار ClothesCast الملابس بناءً على مجموعة قواعد. عدّل درجات الحرارة، أضف طبقات أو غيّر ما يُقترح في إعدادات الملابس.</string>
+    <string name="today_clothes_promo_body">يختار ClothesCast الملابس بناءً على مجموعة قواعد. عدّل درجات الحرارة وخصّص خزانة ملابسك في إعدادات الملابس.</string>
     <string name="today_clothes_promo_cta">إعدادات الملابس</string>
     <string name="today_clothes_promo_dismiss">إغلاق</string>
-    <string name="today_clothes_promo_title">اجعل القواعد ملكك</string>
+    <string name="today_clothes_promo_title">اجعل الملابس ملكك</string>
     <string name="today_insight_format_link">التنسيق</string>
     <string name="today_play">تشغيل</string>
     <string name="today_play_toast_daily">جاري تشغيل ClothesCast اليومي.</string>

--- a/app/src/main/res/values-b+sr+Latn/strings.xml
+++ b/app/src/main/res/values-b+sr+Latn/strings.xml
@@ -1178,10 +1178,10 @@ default English (matching values-pl / values-uk).
     <string name="settings_tts_style_spooky_narrator">Jezivi pripovedač</string>
     <string name="today_chart_readout">%1$s · %2$s</string>
     <string name="today_chart_reset_to_now">Prikaži sada</string>
-    <string name="today_clothes_promo_body">ClothesCast bira odeću po pravilima. Promeni temperature, dodaj slojeve ili izmeni predloge u podešavanjima Odeća.</string>
+    <string name="today_clothes_promo_body">ClothesCast bira odeću po pravilima. Promeni temperature i prilagodi svoju garderobu u podešavanjima Odeća.</string>
     <string name="today_clothes_promo_cta">Podešavanja odeće</string>
     <string name="today_clothes_promo_dismiss">Odbaci</string>
-    <string name="today_clothes_promo_title">Prilagodi pravila sebi</string>
+    <string name="today_clothes_promo_title">Prilagodi odeću sebi</string>
     <string name="today_insight_format_link">Format</string>
     <string name="today_play">Pusti</string>
     <string name="today_play_toast_daily">Puštam tvoj jutarnji ClothesCast.</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -1175,10 +1175,10 @@ What is NOT overridden, by design:
     <string name="settings_tts_style_spooky_narrator">Зловещ разказвач</string>
     <string name="today_chart_readout">%1$s · %2$s</string>
     <string name="today_chart_reset_to_now">Покажи сега</string>
-    <string name="today_clothes_promo_body">ClothesCast избира облекло по правила. Промени температурите, добави слоеве или промени предложенията в настройките за Дрехи.</string>
+    <string name="today_clothes_promo_body">ClothesCast избира облекло по правила. Промени температурите и персонализирай гардероба си в настройките за Дрехи.</string>
     <string name="today_clothes_promo_cta">Настройки за дрехи</string>
     <string name="today_clothes_promo_dismiss">Затвори</string>
-    <string name="today_clothes_promo_title">Направи правилата свои</string>
+    <string name="today_clothes_promo_title">Направи дрехите свои</string>
     <string name="today_insight_format_link">Формат</string>
     <string name="today_play">Възпроизведи</string>
     <string name="today_play_toast_daily">Възпроизвеждам твоя сутрешен ClothesCast.</string>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -1260,10 +1260,10 @@ West Bengal vocabulary differences in a future PR.
     <string name="settings_tts_style_spooky_narrator">ভৌতিক কথক</string>
     <string name="today_chart_readout">%1$s · %2$s</string>
     <string name="today_chart_reset_to_now">এখন দেখাও</string>
-    <string name="today_clothes_promo_body">ClothesCast নিয়মের একটি সেট থেকে পোশাক বেছে নেয়। তাপমাত্রা পরিবর্তন করো, স্তর যোগ করো বা পোশাক সেটিংসে পরামর্শ পরিবর্তন করো।</string>
+    <string name="today_clothes_promo_body">ClothesCast নিয়মের একটি সেট থেকে পোশাক বেছে নেয়। তাপমাত্রা পরিবর্তন করো এবং পোশাক সেটিংসে তোমার পোশাক কাস্টমাইজ করো।</string>
     <string name="today_clothes_promo_cta">পোশাক সেটিংস</string>
     <string name="today_clothes_promo_dismiss">বন্ধ</string>
-    <string name="today_clothes_promo_title">নিয়মগুলোকে নিজের করো</string>
+    <string name="today_clothes_promo_title">পোশাককে নিজের করো</string>
     <string name="today_insight_format_link">ফর্ম্যাট</string>
     <string name="today_play">চালাও</string>
     <string name="today_play_toast_daily">তোমার দৈনিক ClothesCast চালাচ্ছি।</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -1128,10 +1128,10 @@ the in-app clock is digit-driven and reads consistently across locales.
     <string name="settings_tts_style_spooky_narrator">Narrador esgarrifós</string>
     <string name="today_chart_readout">%1$s · %2$s</string>
     <string name="today_chart_reset_to_now">Mostra ara</string>
-    <string name="today_clothes_promo_body">ClothesCast tria conjunts a partir d\'unes regles. Ajusta les temperatures, afegeix capes o canvia el que se suggereix a la configuració de Roba.</string>
+    <string name="today_clothes_promo_body">ClothesCast tria conjunts a partir d\'unes regles. Ajusta les temperatures i personalitza el teu vestuari a la configuració de Roba.</string>
     <string name="today_clothes_promo_cta">Configuració de Roba</string>
     <string name="today_clothes_promo_dismiss">Descarta</string>
-    <string name="today_clothes_promo_title">Fes teves les regles</string>
+    <string name="today_clothes_promo_title">Fes teva la roba</string>
     <string name="today_insight_format_link">Format</string>
     <string name="today_play">Reprodueix</string>
     <string name="today_play_toast_daily">Reproduint el teu ClothesCast diari.</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -1198,10 +1198,10 @@ locale (Angličtina (USA), Francouzština (Francie), Němčina (Německo), …).
     <string name="settings_tts_style_spooky_narrator">Strašidelný vypravěč</string>
     <string name="today_chart_readout">%1$s · %2$s</string>
     <string name="today_chart_reset_to_now">Zobrazit nyní</string>
-    <string name="today_clothes_promo_body">ClothesCast vybírá outfity podle sady pravidel. Uprav teploty, přidej vrstvy nebo změň, co se navrhuje, v nastavení Oblečení.</string>
+    <string name="today_clothes_promo_body">ClothesCast vybírá outfity podle sady pravidel. Uprav teploty a přizpůsob si šatník v nastavení Oblečení.</string>
     <string name="today_clothes_promo_cta">Nastavení oblečení</string>
     <string name="today_clothes_promo_dismiss">Zavřít</string>
-    <string name="today_clothes_promo_title">Přizpůsob si pravidla</string>
+    <string name="today_clothes_promo_title">Přizpůsob si oblečení</string>
     <string name="today_insight_format_link">Formát</string>
     <string name="today_play">Přehrát</string>
     <string name="today_play_toast_daily">Přehrávám tvůj denní ClothesCast.</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -1218,10 +1218,10 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrig)").
     <string name="settings_tts_style_spooky_narrator">Uhyggelig fortæller</string>
     <string name="today_chart_readout">%1$s · %2$s</string>
     <string name="today_chart_reset_to_now">Vis nu</string>
-    <string name="today_clothes_promo_body">ClothesCast vælger outfits ud fra et sæt regler. Juster temperaturerne, tilføj lag eller skift forslag i tøjindstillingerne.</string>
+    <string name="today_clothes_promo_body">ClothesCast vælger outfits ud fra et sæt regler. Juster temperaturerne og tilpas din garderobe i tøjindstillingerne.</string>
     <string name="today_clothes_promo_cta">Tøjindstillinger</string>
     <string name="today_clothes_promo_dismiss">Afvis</string>
-    <string name="today_clothes_promo_title">Gør reglerne til dine egne</string>
+    <string name="today_clothes_promo_title">Gør tøjet til dit eget</string>
     <string name="today_insight_format_link">Format</string>
     <string name="today_play">Afspil</string>
     <string name="today_play_toast_daily">Afspiller din daglige ClothesCast.</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1340,10 +1340,10 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_tts_style_spooky_narrator">Gruseliger Erzähler</string>
     <string name="today_chart_readout">%1$s · %2$s</string>
     <string name="today_chart_reset_to_now">Jetzt anzeigen</string>
-    <string name="today_clothes_promo_body">ClothesCast wählt Outfits anhand von Regeln aus. Passe die Temperaturen an, füge Lagen hinzu oder ändere die Vorschläge in den Kleidungseinstellungen.</string>
+    <string name="today_clothes_promo_body">ClothesCast wählt Outfits anhand von Regeln aus. Passe die Temperaturen und deine Garderobe in den Kleidungseinstellungen an.</string>
     <string name="today_clothes_promo_cta">Kleidungseinstellungen</string>
     <string name="today_clothes_promo_dismiss">Schließen</string>
-    <string name="today_clothes_promo_title">Mach die Regeln zu deinen</string>
+    <string name="today_clothes_promo_title">Mach die Kleidung zu deiner</string>
     <string name="today_insight_format_link">Format</string>
     <string name="today_play">Abspielen</string>
     <string name="today_play_toast_daily">Dein täglicher ClothesCast wird abgespielt.</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -1310,10 +1310,10 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_tts_style_spooky_narrator">Τρομακτικός αφηγητής</string>
     <string name="today_chart_readout">%1$s · %2$s</string>
     <string name="today_chart_reset_to_now">Τώρα</string>
-    <string name="today_clothes_promo_body">Το ClothesCast επιλέγει ρούχα με βάση κανόνες. Άλλαξε τις θερμοκρασίες, πρόσθεσε στρώσεις ή τροποποίησε τι προτείνεται στις ρυθμίσεις Ρούχων.</string>
+    <string name="today_clothes_promo_body">Το ClothesCast επιλέγει ρούχα με βάση κανόνες. Άλλαξε τις θερμοκρασίες και προσάρμοσε την γκαρνταρόμπα σου στις ρυθμίσεις Ρούχων.</string>
     <string name="today_clothes_promo_cta">Ρυθμίσεις Ρούχων</string>
     <string name="today_clothes_promo_dismiss">Απόρριψη</string>
-    <string name="today_clothes_promo_title">Κάνε τους κανόνες δικούς σου</string>
+    <string name="today_clothes_promo_title">Κάνε τα ρούχα δικά σου</string>
     <string name="today_insight_format_link">Μορφή</string>
     <string name="today_play">Αναπαραγωγή</string>
     <string name="today_play_toast_daily">Αναπαραγωγή του ημερήσιου ClothesCast σου.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1316,10 +1316,10 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_tts_style_spooky_narrator">Narrador escalofriante</string>
     <string name="today_chart_readout">%1$s · %2$s</string>
     <string name="today_chart_reset_to_now">Ver ahora</string>
-    <string name="today_clothes_promo_body">ClothesCast elige los conjuntos a partir de un conjunto de reglas. Ajusta las temperaturas, añade capas o cambia lo que se sugiere en los ajustes de Ropa.</string>
+    <string name="today_clothes_promo_body">ClothesCast elige los conjuntos a partir de un conjunto de reglas. Ajusta las temperaturas y personaliza tu armario en los ajustes de Ropa.</string>
     <string name="today_clothes_promo_cta">Ajustes de Ropa</string>
     <string name="today_clothes_promo_dismiss">Descartar</string>
-    <string name="today_clothes_promo_title">Haz tuyas las reglas</string>
+    <string name="today_clothes_promo_title">Haz tuya la ropa</string>
     <string name="today_insight_format_link">Formato</string>
     <string name="today_play">Reproducir</string>
     <string name="today_play_toast_daily">Reproduciendo tu ClothesCast diario.</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -1132,10 +1132,10 @@ Tone is informal "sina"-form throughout ("Pane … selga", "Võta … kaasa",
     <string name="settings_tts_style_spooky_narrator">Õudne jutustaja</string>
     <string name="today_chart_readout">%1$s · %2$s</string>
     <string name="today_chart_reset_to_now">Näita praegu</string>
-    <string name="today_clothes_promo_body">ClothesCast valib riided reeglite järgi. Muuda temperatuure, lisa kihte või muuda soovitusi Riiete seadetes.</string>
+    <string name="today_clothes_promo_body">ClothesCast valib riided reeglite järgi. Muuda temperatuure ja kohanda oma garderoobi Riiete seadetes.</string>
     <string name="today_clothes_promo_cta">Riiete seaded</string>
     <string name="today_clothes_promo_dismiss">Sulge</string>
-    <string name="today_clothes_promo_title">Tee reeglid enda omaks</string>
+    <string name="today_clothes_promo_title">Tee riided enda omaks</string>
     <string name="today_insight_format_link">Vorming</string>
     <string name="today_play">Esita</string>
     <string name="today_play_toast_daily">Esitan sinu päevast ClothesCasti.</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -1180,10 +1180,10 @@ Western Arabic numerals (0-9) are used for TTS compatibility.
     <string name="settings_tts_style_spooky_narrator">راوی ترسناک</string>
     <string name="today_chart_readout">%1$s · %2$s</string>
     <string name="today_chart_reset_to_now">اکنون را نشان بده</string>
-    <string name="today_clothes_promo_body">ClothesCast لباس‌ها را بر اساس قوانینی انتخاب می‌کند. در تنظیمات لباس، دماها را تنظیم کن، لایه اضافه کن یا پیشنهادها را تغییر بده.</string>
+    <string name="today_clothes_promo_body">ClothesCast لباس‌ها را بر اساس قوانینی انتخاب می‌کند. در تنظیمات لباس، دماها را تنظیم کن و کمد لباست را شخصی‌سازی کن.</string>
     <string name="today_clothes_promo_cta">تنظیمات لباس</string>
     <string name="today_clothes_promo_dismiss">رد کردن</string>
-    <string name="today_clothes_promo_title">قوانین را مال خودت کن</string>
+    <string name="today_clothes_promo_title">لباس را مال خودت کن</string>
     <string name="today_insight_format_link">قالب</string>
     <string name="today_play">پخش</string>
     <string name="today_play_toast_daily">در حال پخش ClothesCast روزانه‌ات.</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -1197,10 +1197,10 @@ displayed label localizes.
     <string name="settings_tts_style_spooky_narrator">Aavemainen kertoja</string>
     <string name="today_chart_readout">%1$s · %2$s</string>
     <string name="today_chart_reset_to_now">Näytä nyt</string>
-    <string name="today_clothes_promo_body">ClothesCast valitsee asut sääntöjen perusteella. Säädä lämpötiloja, lisää kerroksia tai muuta ehdotuksia Vaatteet-asetuksissa.</string>
+    <string name="today_clothes_promo_body">ClothesCast valitsee asut sääntöjen perusteella. Säädä lämpötiloja ja mukauta vaatekaappiasi Vaatteet-asetuksissa.</string>
     <string name="today_clothes_promo_cta">Vaatteet-asetukset</string>
     <string name="today_clothes_promo_dismiss">Sulje</string>
-    <string name="today_clothes_promo_title">Tee säännöistä omasi</string>
+    <string name="today_clothes_promo_title">Tee vaatteista omasi</string>
     <string name="today_insight_format_link">Muoto</string>
     <string name="today_play">Toista</string>
     <string name="today_play_toast_daily">Toistetaan päivän ClothesCastia.</string>

--- a/app/src/main/res/values-fil/strings.xml
+++ b/app/src/main/res/values-fil/strings.xml
@@ -1239,10 +1239,10 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="settings_tts_style_spooky_narrator">Nakatatakot na tagapagsalaysay</string>
     <string name="today_chart_readout">%1$s · %2$s</string>
     <string name="today_chart_reset_to_now">Ipakita ngayon</string>
-    <string name="today_clothes_promo_body">Pumipili ang ClothesCast ng mga damit mula sa isang set ng mga panuntunan. Baguhin ang mga temperatura, magdagdag ng layer, o palitan ang mga mungkahi sa mga setting ng Damit.</string>
+    <string name="today_clothes_promo_body">Pumipili ang ClothesCast ng mga damit mula sa isang set ng mga panuntunan. Baguhin ang mga temperatura at i-customize ang iyong wardrobe sa mga setting ng Damit.</string>
     <string name="today_clothes_promo_cta">Mga setting ng damit</string>
     <string name="today_clothes_promo_dismiss">Isara</string>
-    <string name="today_clothes_promo_title">Gawing sariling iyo ang mga panuntunan</string>
+    <string name="today_clothes_promo_title">Gawing sariling iyo ang mga damit</string>
     <string name="today_insight_format_link">Format</string>
     <string name="today_play">I-play</string>
     <string name="today_play_toast_daily">Pino-play ang iyong araw-araw na ClothesCast.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1315,10 +1315,10 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_tts_style_spooky_narrator">Narrateur effrayant</string>
     <string name="today_chart_readout">%1$s · %2$s</string>
     <string name="today_chart_reset_to_now">Voir maintenant</string>
-    <string name="today_clothes_promo_body">ClothesCast choisit les tenues à partir d\'un ensemble de règles. Ajuste les températures, ajoute des couches ou change ce qui est suggéré dans les paramètres Vêtements.</string>
+    <string name="today_clothes_promo_body">ClothesCast choisit les tenues à partir d\'un ensemble de règles. Ajuste les températures et personnalise ta garde-robe dans les paramètres Vêtements.</string>
     <string name="today_clothes_promo_cta">Paramètres Vêtements</string>
     <string name="today_clothes_promo_dismiss">Ignorer</string>
-    <string name="today_clothes_promo_title">Adapte les règles à ton goût</string>
+    <string name="today_clothes_promo_title">Adapte les vêtements à ton goût</string>
     <string name="today_insight_format_link">Format</string>
     <string name="today_play">Lecture</string>
     <string name="today_play_toast_daily">Lecture de ton ClothesCast du matin.</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -1220,10 +1220,10 @@ Not overridden by design:
     <string name="settings_tts_style_spooky_narrator">डरावना वक्ता</string>
     <string name="today_chart_readout">%1$s · %2$s</string>
     <string name="today_chart_reset_to_now">अभी दिखाएँ</string>
-    <string name="today_clothes_promo_body">ClothesCast नियमों के एक सेट से कपड़े चुनता है। तापमान बदलें, परतें जोड़ें या कपड़े सेटिंग्स में सुझाव बदलें।</string>
+    <string name="today_clothes_promo_body">ClothesCast नियमों के एक सेट से कपड़े चुनता है। तापमान बदलें और कपड़े सेटिंग्स में अपना वॉर्डरोब कस्टमाइज़ करें।</string>
     <string name="today_clothes_promo_cta">कपड़े सेटिंग्स</string>
     <string name="today_clothes_promo_dismiss">बंद करें</string>
-    <string name="today_clothes_promo_title">नियमों को अपना बनाएँ</string>
+    <string name="today_clothes_promo_title">कपड़ों को अपना बनाएँ</string>
     <string name="today_insight_format_link">प्रारूप</string>
     <string name="today_play">चलाएँ</string>
     <string name="today_play_toast_daily">आपका दैनिक ClothesCast चला रहे हैं।</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -1258,10 +1258,10 @@ spousal register), matching the existing insight prose ("Ponesi …",
     <string name="settings_tts_style_spooky_narrator">Sablasni pripovjedač</string>
     <string name="today_chart_readout">%1$s · %2$s</string>
     <string name="today_chart_reset_to_now">Prikaži sada</string>
-    <string name="today_clothes_promo_body">ClothesCast bira outfite po skupu pravila. Podesi temperature, dodaj slojeve ili promijeni što se predlaže u postavkama Odjeće.</string>
+    <string name="today_clothes_promo_body">ClothesCast bira outfite po skupu pravila. Podesi temperature i prilagodi svoju garderobu u postavkama Odjeće.</string>
     <string name="today_clothes_promo_cta">Postavke odjeće</string>
     <string name="today_clothes_promo_dismiss">Odbaci</string>
-    <string name="today_clothes_promo_title">Prilagodi pravila sebi</string>
+    <string name="today_clothes_promo_title">Prilagodi odjeću sebi</string>
     <string name="today_insight_format_link">Format</string>
     <string name="today_play">Pusti</string>
     <string name="today_play_toast_daily">Puštam tvoj jutarnji ClothesCast.</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -1181,10 +1181,10 @@ locale (Angol (Egyesült Államok), Francia (Franciaország), Német
     <string name="settings_tts_style_spooky_narrator">Hátborzongató narrátor</string>
     <string name="today_chart_readout">%1$s · %2$s</string>
     <string name="today_chart_reset_to_now">Most</string>
-    <string name="today_clothes_promo_body">A ClothesCast szabályok alapján választ ruhákat. Állítsd be a hőmérsékleteket, adj hozzá rétegeket vagy módosítsd a javaslatokat a Ruhák beállításokban.</string>
+    <string name="today_clothes_promo_body">A ClothesCast szabályok alapján választ ruhákat. Állítsd be a hőmérsékleteket, és szabd testre a ruhatárad a Ruhák beállításokban.</string>
     <string name="today_clothes_promo_cta">Ruhák beállításai</string>
     <string name="today_clothes_promo_dismiss">Elvetés</string>
-    <string name="today_clothes_promo_title">Tedd magadévá a szabályokat</string>
+    <string name="today_clothes_promo_title">Tedd magadévá a ruhákat</string>
     <string name="today_insight_format_link">Formátum</string>
     <string name="today_play">Lejátszás</string>
     <string name="today_play_toast_daily">Lejátszom a napi ClothesCastod.</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -1188,10 +1188,10 @@ to values/strings.xml (English).
     <string name="settings_tts_style_spooky_narrator">Pencerita menyeramkan</string>
     <string name="today_chart_readout">%1$s · %2$s</string>
     <string name="today_chart_reset_to_now">Tampilkan sekarang</string>
-    <string name="today_clothes_promo_body">ClothesCast memilih pakaian berdasarkan serangkaian aturan. Ubah suhu, tambahkan lapisan, atau ubah saran di pengaturan Pakaian.</string>
+    <string name="today_clothes_promo_body">ClothesCast memilih pakaian berdasarkan serangkaian aturan. Ubah suhu dan sesuaikan lemari pakaianmu di pengaturan Pakaian.</string>
     <string name="today_clothes_promo_cta">Pengaturan pakaian</string>
     <string name="today_clothes_promo_dismiss">Tutup</string>
-    <string name="today_clothes_promo_title">Buat aturan sendiri</string>
+    <string name="today_clothes_promo_title">Buat pakaian sendiri</string>
     <string name="today_insight_format_link">Format</string>
     <string name="today_play">Putar</string>
     <string name="today_play_toast_daily">Memutar ClothesCast harianmu.</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1301,10 +1301,10 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_tts_style_spooky_narrator">Narratore inquietante</string>
     <string name="today_chart_readout">%1$s · %2$s</string>
     <string name="today_chart_reset_to_now">Mostra ora</string>
-    <string name="today_clothes_promo_body">ClothesCast sceglie gli outfit da una serie di regole. Modifica le temperature, aggiungi strati o cambia ciò che viene suggerito nelle impostazioni Abbigliamento.</string>
+    <string name="today_clothes_promo_body">ClothesCast sceglie gli outfit da una serie di regole. Modifica le temperature e personalizza il tuo guardaroba nelle impostazioni Abbigliamento.</string>
     <string name="today_clothes_promo_cta">Impostazioni Abbigliamento</string>
     <string name="today_clothes_promo_dismiss">Ignora</string>
-    <string name="today_clothes_promo_title">Personalizza le regole</string>
+    <string name="today_clothes_promo_title">Personalizza l\'abbigliamento</string>
     <string name="today_insight_format_link">Formato</string>
     <string name="today_play">Riproduci</string>
     <string name="today_play_toast_daily">Riproduzione del tuo ClothesCast quotidiano.</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -1190,10 +1190,10 @@ standard in Israeli digital communication.
     <string name="settings_tts_style_spooky_narrator">מספר מפחיד</string>
     <string name="today_chart_readout">%1$s · %2$s</string>
     <string name="today_chart_reset_to_now">הצג עכשיו</string>
-    <string name="today_clothes_promo_body">ClothesCast בוחר תלבושות לפי כללים. שנה את הטמפרטורות, הוסף שכבות או שנה את ההצעות בהגדרות בגדים.</string>
+    <string name="today_clothes_promo_body">ClothesCast בוחר תלבושות לפי כללים. שנה את הטמפרטורות והתאם אישית את המלתחה שלך בהגדרות בגדים.</string>
     <string name="today_clothes_promo_cta">הגדרות בגדים</string>
     <string name="today_clothes_promo_dismiss">סגור</string>
-    <string name="today_clothes_promo_title">התאם את הכללים אישית</string>
+    <string name="today_clothes_promo_title">התאם את הבגדים אישית</string>
     <string name="today_insight_format_link">פורמט</string>
     <string name="today_play">הפעל</string>
     <string name="today_play_toast_daily">מפעיל את ClothesCast היומי שלך.</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1338,10 +1338,10 @@ the displayed label localizes.
     <string name="settings_tts_style_spooky_narrator">不気味なナレーター</string>
     <string name="today_chart_readout">%1$s · %2$s</string>
     <string name="today_chart_reset_to_now">現在を表示</string>
-    <string name="today_clothes_promo_body">ClothesCastはルールに基づいて服装を選びます。設定の「服装」で温度を調整したり、レイヤーを追加したり、提案内容を変更できます。</string>
+    <string name="today_clothes_promo_body">ClothesCastはルールに基づいて服装を選びます。設定の「服装」で温度を調整したり、ワードローブをカスタマイズしたりできます。</string>
     <string name="today_clothes_promo_cta">服装の設定</string>
     <string name="today_clothes_promo_dismiss">閉じる</string>
-    <string name="today_clothes_promo_title">ルールを自分好みに</string>
+    <string name="today_clothes_promo_title">服装を自分好みに</string>
     <string name="today_insight_format_link">形式</string>
     <string name="today_play">再生</string>
     <string name="today_play_toast_daily">デイリーClothesCastを再生中。</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1342,10 +1342,10 @@ displayed label localizes.
     <string name="settings_tts_style_spooky_narrator">으스스한 내레이터</string>
     <string name="today_chart_readout">%1$s · %2$s</string>
     <string name="today_chart_reset_to_now">지금 표시</string>
-    <string name="today_clothes_promo_body">ClothesCast는 규칙에 따라 옷을 추천합니다. 옷 설정에서 온도를 조정하거나, 레이어를 추가하거나, 추천 항목을 변경해 보세요.</string>
+    <string name="today_clothes_promo_body">ClothesCast는 규칙에 따라 옷을 추천합니다. 옷 설정에서 온도를 조정하고 옷장을 맞춤 설정해 보세요.</string>
     <string name="today_clothes_promo_cta">옷 설정</string>
     <string name="today_clothes_promo_dismiss">닫기</string>
-    <string name="today_clothes_promo_title">규칙을 내 것으로</string>
+    <string name="today_clothes_promo_title">옷을 내 것으로</string>
     <string name="today_insight_format_link">형식</string>
     <string name="today_play">재생</string>
     <string name="today_play_toast_daily">데일리 ClothesCast를 재생 중.</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -1178,10 +1178,10 @@ What is NOT overridden, by design:
     <string name="settings_tts_style_spooky_narrator">Šiurpus pasakotojas</string>
     <string name="today_chart_readout">%1$s · %2$s</string>
     <string name="today_chart_reset_to_now">Rodyti dabar</string>
-    <string name="today_clothes_promo_body">ClothesCast renka aprangą pagal taisykles. Pakeisk temperatūras, pridėk sluoksnių arba pakeisk siūlymus Drabužių nustatymuose.</string>
+    <string name="today_clothes_promo_body">ClothesCast renka aprangą pagal taisykles. Pakeisk temperatūras ir pritaikyk savo garderobą Drabužių nustatymuose.</string>
     <string name="today_clothes_promo_cta">Drabužių nustatymai</string>
     <string name="today_clothes_promo_dismiss">Atmesti</string>
-    <string name="today_clothes_promo_title">Pritaikyk taisykles sau</string>
+    <string name="today_clothes_promo_title">Pritaikyk drabužius sau</string>
     <string name="today_insight_format_link">Formatas</string>
     <string name="today_play">Leisti</string>
     <string name="today_play_toast_daily">Leidžiu tavo dieninį ClothesCast.</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -1130,10 +1130,10 @@ informal "tu"-form throughout ("Apģērb …", "Paņem … līdzi").
     <string name="settings_tts_style_spooky_narrator">Spokainais stāstītājs</string>
     <string name="today_chart_readout">%1$s · %2$s</string>
     <string name="today_chart_reset_to_now">Rādīt tagad</string>
-    <string name="today_clothes_promo_body">ClothesCast izvēlas apģērbu pēc noteikumiem. Pielāgo temperatūras, pievieno kārtas vai mainī ieteikumus Apģērba iestatījumos.</string>
+    <string name="today_clothes_promo_body">ClothesCast izvēlas apģērbu pēc noteikumiem. Pielāgo temperatūras un personalizē savu garderobi Apģērba iestatījumos.</string>
     <string name="today_clothes_promo_cta">Apģērba iestatījumi</string>
     <string name="today_clothes_promo_dismiss">Aizvērt</string>
-    <string name="today_clothes_promo_title">Padari noteikumus par savējiem</string>
+    <string name="today_clothes_promo_title">Padari apģērbu par savējo</string>
     <string name="today_insight_format_link">Formāts</string>
     <string name="today_play">Atskaņot</string>
     <string name="today_play_toast_daily">Atskaņoju tavu ikdienas ClothesCast.</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -1194,10 +1194,10 @@ vs "kemungkinan", "padam" vs "hapus").
     <string name="settings_tts_style_spooky_narrator">Pencerita menyeramkan</string>
     <string name="today_chart_readout">%1$s · %2$s</string>
     <string name="today_chart_reset_to_now">Tunjukkan sekarang</string>
-    <string name="today_clothes_promo_body">ClothesCast memilih pakaian berdasarkan satu set peraturan. Ubah suhu, tambah lapisan atau ubah cadangan dalam tetapan Pakaian.</string>
+    <string name="today_clothes_promo_body">ClothesCast memilih pakaian berdasarkan satu set peraturan. Ubah suhu dan sesuaikan almari pakaian anda dalam tetapan Pakaian.</string>
     <string name="today_clothes_promo_cta">Tetapan pakaian</string>
     <string name="today_clothes_promo_dismiss">Tutup</string>
-    <string name="today_clothes_promo_title">Jadikan peraturan milik anda</string>
+    <string name="today_clothes_promo_title">Jadikan pakaian milik anda</string>
     <string name="today_insight_format_link">Format</string>
     <string name="today_play">Putar</string>
     <string name="today_play_toast_daily">Memainkan ClothesCast harian anda.</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -1217,10 +1217,10 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrike)").
     <string name="settings_tts_style_spooky_narrator">Skummel forteller</string>
     <string name="today_chart_readout">%1$s · %2$s</string>
     <string name="today_chart_reset_to_now">Vis nå</string>
-    <string name="today_clothes_promo_body">ClothesCast velger antrekk ut fra et sett regler. Juster temperaturene, legg til lag eller endre hva som foreslås i Klesinnstillinger.</string>
+    <string name="today_clothes_promo_body">ClothesCast velger antrekk ut fra et sett regler. Juster temperaturene og tilpass garderoben din i Klesinnstillinger.</string>
     <string name="today_clothes_promo_cta">Klesinnstillinger</string>
     <string name="today_clothes_promo_dismiss">Avvis</string>
-    <string name="today_clothes_promo_title">Gjør reglene til dine egne</string>
+    <string name="today_clothes_promo_title">Gjør klærne til dine egne</string>
     <string name="today_insight_format_link">Format</string>
     <string name="today_play">Spill av</string>
     <string name="today_play_toast_daily">Spiller av din daglige ClothesCast.</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -1237,10 +1237,10 @@ the displayed label localizes.
     <string name="settings_tts_style_spooky_narrator">Griezelige verteller</string>
     <string name="today_chart_readout">%1$s · %2$s</string>
     <string name="today_chart_reset_to_now">Toon nu</string>
-    <string name="today_clothes_promo_body">ClothesCast kiest outfits op basis van een set regels. Pas de temperaturen aan, voeg lagen toe of verander wat wordt voorgesteld in Kledinginstellingen.</string>
+    <string name="today_clothes_promo_body">ClothesCast kiest outfits op basis van een set regels. Pas de temperaturen aan en personaliseer je garderobe in Kledinginstellingen.</string>
     <string name="today_clothes_promo_cta">Kledinginstellingen</string>
     <string name="today_clothes_promo_dismiss">Sluiten</string>
-    <string name="today_clothes_promo_title">Maak de regels van jou</string>
+    <string name="today_clothes_promo_title">Maak de kleding van jou</string>
     <string name="today_insight_format_link">Formaat</string>
     <string name="today_play">Afspelen</string>
     <string name="today_play_toast_daily">Je dagelijkse ClothesCast wordt afgespeeld.</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -1237,10 +1237,10 @@ is unchanged; only the displayed label localizes.
     <string name="settings_tts_style_spooky_narrator">Straszny narrator</string>
     <string name="today_chart_readout">%1$s · %2$s</string>
     <string name="today_chart_reset_to_now">Pokaż teraz</string>
-    <string name="today_clothes_promo_body">ClothesCast wybiera stroje na podstawie zestawu reguł. Dostosuj temperatury, dodaj warstwy lub zmień sugestie w ustawieniach Ubrania.</string>
+    <string name="today_clothes_promo_body">ClothesCast wybiera stroje na podstawie zestawu reguł. Dostosuj temperatury i spersonalizuj swoją garderobę w ustawieniach Ubrania.</string>
     <string name="today_clothes_promo_cta">Ustawienia ubrań</string>
     <string name="today_clothes_promo_dismiss">Odrzuć</string>
-    <string name="today_clothes_promo_title">Dostosuj reguły do siebie</string>
+    <string name="today_clothes_promo_title">Dostosuj ubrania do siebie</string>
     <string name="today_insight_format_link">Format</string>
     <string name="today_play">Odtwórz</string>
     <string name="today_play_toast_daily">Odtwarzanie twojego porannego ClothesCasta.</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1273,10 +1273,10 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_tts_style_spooky_narrator">Narrador assustador</string>
     <string name="today_chart_readout">%1$s · %2$s</string>
     <string name="today_chart_reset_to_now">Mostrar agora</string>
-    <string name="today_clothes_promo_body">ClothesCast escolhe os looks a partir de um conjunto de regras. Ajuste as temperaturas, adicione camadas ou mude o que é sugerido em configurações de Roupas.</string>
+    <string name="today_clothes_promo_body">ClothesCast escolhe os looks a partir de um conjunto de regras. Ajuste as temperaturas e personalize seu guarda-roupa em configurações de Roupas.</string>
     <string name="today_clothes_promo_cta">Configurações de Roupas</string>
     <string name="today_clothes_promo_dismiss">Dispensar</string>
-    <string name="today_clothes_promo_title">Personalize as regras</string>
+    <string name="today_clothes_promo_title">Personalize as roupas</string>
     <string name="today_insight_format_link">Formato</string>
     <string name="today_play">Reproduzir</string>
     <string name="today_play_toast_daily">Reproduzindo seu ClothesCast diário.</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -1316,10 +1316,10 @@ they diverge from BR ("Polonês" → "Polaco", "Holandês" →
     <string name="settings_tts_style_spooky_narrator">Narrador arrepiante</string>
     <string name="today_chart_readout">%1$s · %2$s</string>
     <string name="today_chart_reset_to_now">Mostrar agora</string>
-    <string name="today_clothes_promo_body">ClothesCast escolhe os conjuntos a partir de um conjunto de regras. Ajusta as temperaturas, adiciona camadas ou muda o que é sugerido em definições de Roupa.</string>
+    <string name="today_clothes_promo_body">ClothesCast escolhe os conjuntos a partir de um conjunto de regras. Ajusta as temperaturas e personaliza o teu guarda-roupa em definições de Roupa.</string>
     <string name="today_clothes_promo_cta">Definições de Roupa</string>
     <string name="today_clothes_promo_dismiss">Dispensar</string>
-    <string name="today_clothes_promo_title">Faz as regras tuas</string>
+    <string name="today_clothes_promo_title">Faz a roupa tua</string>
     <string name="today_insight_format_link">Formato</string>
     <string name="today_play">Reproduzir</string>
     <string name="today_play_toast_daily">A reproduzir o teu ClothesCast diário.</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -1166,10 +1166,10 @@ surfaces fall back to default English (matching values-pl / values-uk).
     <string name="settings_tts_style_spooky_narrator">Narator înfricoșător</string>
     <string name="today_chart_readout">%1$s · %2$s</string>
     <string name="today_chart_reset_to_now">Acum</string>
-    <string name="today_clothes_promo_body">ClothesCast alege ținute pe baza unui set de reguli. Modifică temperaturile, adaugă straturi sau schimbă ce se sugerează în setările Haine.</string>
+    <string name="today_clothes_promo_body">ClothesCast alege ținute pe baza unui set de reguli. Modifică temperaturile și personalizează-ți garderoba în setările Haine.</string>
     <string name="today_clothes_promo_cta">Setări haine</string>
     <string name="today_clothes_promo_dismiss">Închide</string>
-    <string name="today_clothes_promo_title">Fă regulile ale tale</string>
+    <string name="today_clothes_promo_title">Fă hainele ale tale</string>
     <string name="today_insight_format_link">Format</string>
     <string name="today_play">Redă</string>
     <string name="today_play_toast_daily">Redau ClothesCast-ul tău zilnic.</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1244,10 +1244,10 @@ only the displayed label localizes.
     <string name="settings_tts_style_spooky_narrator">Жуткий рассказчик</string>
     <string name="today_chart_readout">%1$s · %2$s</string>
     <string name="today_chart_reset_to_now">Сейчас</string>
-    <string name="today_clothes_promo_body">ClothesCast подбирает наряды по набору правил. Настрой температуры, добавь слои или измени предложения в настройках одежды.</string>
+    <string name="today_clothes_promo_body">ClothesCast подбирает наряды по набору правил. Настрой температуры и персонализируй свой гардероб в настройках одежды.</string>
     <string name="today_clothes_promo_cta">Настройки одежды</string>
     <string name="today_clothes_promo_dismiss">Скрыть</string>
-    <string name="today_clothes_promo_title">Настрой правила под себя</string>
+    <string name="today_clothes_promo_title">Настрой одежду под себя</string>
     <string name="today_insight_format_link">Формат</string>
     <string name="today_play">Воспроизвести</string>
     <string name="today_play_toast_daily">Воспроизвожу твой ClothesCast.</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -1212,10 +1212,10 @@ What is NOT overridden, by design:
     <string name="settings_tts_style_spooky_narrator">Strašidelný rozprávač</string>
     <string name="today_chart_readout">%1$s · %2$s</string>
     <string name="today_chart_reset_to_now">Zobraziť teraz</string>
-    <string name="today_clothes_promo_body">ClothesCast vyberá oblečenie podľa sady pravidiel. Uprav teploty, pridaj vrstvy alebo zmeň, čo sa navrhuje, v nastaveniach Oblečenia.</string>
+    <string name="today_clothes_promo_body">ClothesCast vyberá oblečenie podľa sady pravidiel. Uprav teploty a prispôsob si šatník v nastaveniach Oblečenia.</string>
     <string name="today_clothes_promo_cta">Nastavenia oblečenia</string>
     <string name="today_clothes_promo_dismiss">Zavrieť</string>
-    <string name="today_clothes_promo_title">Prispôsob si pravidlá</string>
+    <string name="today_clothes_promo_title">Prispôsob si oblečenie</string>
     <string name="today_insight_format_link">Formát</string>
     <string name="today_play">Prehrať</string>
     <string name="today_play_toast_daily">Prehrávam tvoj denný ClothesCast.</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -1175,10 +1175,10 @@ informal "ti"-form throughout, mirroring the Croatian / Serbian pass.
     <string name="settings_tts_style_spooky_narrator">Strašljiv pripovedovalec</string>
     <string name="today_chart_readout">%1$s · %2$s</string>
     <string name="today_chart_reset_to_now">Pokaži zdaj</string>
-    <string name="today_clothes_promo_body">ClothesCast izbira obleke po pravilih. Prilagodi temperature, dodaj plasti ali spremeni predloge v nastavitvah Oblačila.</string>
+    <string name="today_clothes_promo_body">ClothesCast izbira obleke po pravilih. Prilagodi temperature in svojo garderobo v nastavitvah Oblačila.</string>
     <string name="today_clothes_promo_cta">Nastavitve oblačil</string>
     <string name="today_clothes_promo_dismiss">Zapri</string>
-    <string name="today_clothes_promo_title">Prilagodi pravila sebi</string>
+    <string name="today_clothes_promo_title">Prilagodi oblačila sebi</string>
     <string name="today_insight_format_link">Oblika</string>
     <string name="today_play">Predvajaj</string>
     <string name="today_play_toast_daily">Predvajam tvoj jutranji ClothesCast.</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -1217,10 +1217,10 @@ native names for all locales (e.g. "Tyska (Tyskland)", "Franska (Frankrike)").
     <string name="settings_tts_style_spooky_narrator">Kuslig berättare</string>
     <string name="today_chart_readout">%1$s · %2$s</string>
     <string name="today_chart_reset_to_now">Visa nu</string>
-    <string name="today_clothes_promo_body">ClothesCast väljer outfits utifrån en uppsättning regler. Justera temperaturerna, lägg till lager eller ändra vad som föreslås i Klädinställningar.</string>
+    <string name="today_clothes_promo_body">ClothesCast väljer outfits utifrån en uppsättning regler. Justera temperaturerna och anpassa din garderob i Klädinställningar.</string>
     <string name="today_clothes_promo_cta">Klädinställningar</string>
     <string name="today_clothes_promo_dismiss">Stäng</string>
-    <string name="today_clothes_promo_title">Gör reglerna till dina egna</string>
+    <string name="today_clothes_promo_title">Gör kläderna till dina egna</string>
     <string name="today_insight_format_link">Format</string>
     <string name="today_play">Spela upp</string>
     <string name="today_play_toast_daily">Spelar upp din dagliga ClothesCast.</string>

--- a/app/src/main/res/values-sw/strings.xml
+++ b/app/src/main/res/values-sw/strings.xml
@@ -1160,10 +1160,10 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="settings_tts_style_spooky_narrator">Mtangazaji wa kutisha</string>
     <string name="today_chart_readout">%1$s · %2$s</string>
     <string name="today_chart_reset_to_now">Onyesha sasa</string>
-    <string name="today_clothes_promo_body">ClothesCast huchagua nguo kutoka kwa seti ya kanuni. Rekebisha viwango vya joto, ongeza tabaka, au badilisha kinachopendekezwa katika mipangilio ya Nguo.</string>
+    <string name="today_clothes_promo_body">ClothesCast huchagua nguo kutoka kwa seti ya kanuni. Rekebisha viwango vya joto na ubinafsishe nguo zako katika mipangilio ya Nguo.</string>
     <string name="today_clothes_promo_cta">Mipangilio ya nguo</string>
     <string name="today_clothes_promo_dismiss">Funga</string>
-    <string name="today_clothes_promo_title">Fanya kanuni ziwe zako</string>
+    <string name="today_clothes_promo_title">Fanya nguo ziwe zako</string>
     <string name="today_insight_format_link">Umbo</string>
     <string name="today_play">Cheza</string>
     <string name="today_play_toast_daily">Ninacheza ClothesCast yako ya kila siku.</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -1188,10 +1188,10 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="settings_tts_style_spooky_narrator">ผู้บรรยายน่าขนลุก</string>
     <string name="today_chart_readout">%1$s · %2$s</string>
     <string name="today_chart_reset_to_now">แสดงตอนนี้</string>
-    <string name="today_clothes_promo_body">ClothesCast เลือกชุดตามชุดของกฎ ปรับอุณหภูมิ เพิ่มชั้นเสื้อ หรือเปลี่ยนสิ่งที่แนะนำในการตั้งค่าเสื้อผ้า</string>
+    <string name="today_clothes_promo_body">ClothesCast เลือกชุดตามชุดของกฎ ปรับอุณหภูมิและปรับแต่งตู้เสื้อผ้าของคุณในการตั้งค่าเสื้อผ้า</string>
     <string name="today_clothes_promo_cta">การตั้งค่าเสื้อผ้า</string>
     <string name="today_clothes_promo_dismiss">ปิด</string>
-    <string name="today_clothes_promo_title">ปรับกฎให้เป็นของคุณ</string>
+    <string name="today_clothes_promo_title">ปรับเสื้อผ้าให้เป็นของคุณ</string>
     <string name="today_insight_format_link">รูปแบบ</string>
     <string name="today_play">เล่น</string>
     <string name="today_play_toast_daily">กำลังเล่น ClothesCast ประจำวันของคุณ</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -1190,10 +1190,10 @@ displayed label localizes.
     <string name="settings_tts_style_spooky_narrator">Korkutucu anlatıcı</string>
     <string name="today_chart_readout">%1$s · %2$s</string>
     <string name="today_chart_reset_to_now">Şu anı göster</string>
-    <string name="today_clothes_promo_body">ClothesCast kıyafetleri bir dizi kurala göre seçer. Sıcaklıkları ayarla, kat ekle veya Kıyafet ayarlarından önerileri değiştir.</string>
+    <string name="today_clothes_promo_body">ClothesCast kıyafetleri bir dizi kurala göre seçer. Sıcaklıkları ayarla ve Kıyafet ayarlarından gardırobunu özelleştir.</string>
     <string name="today_clothes_promo_cta">Kıyafet ayarları</string>
     <string name="today_clothes_promo_dismiss">Kapat</string>
-    <string name="today_clothes_promo_title">Kuralları kendine göre ayarla</string>
+    <string name="today_clothes_promo_title">Kıyafetleri kendine göre ayarla</string>
     <string name="today_insight_format_link">Biçim</string>
     <string name="today_play">Oynat</string>
     <string name="today_play_toast_daily">Günlük ClothesCast\'in oynatılıyor.</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -1187,10 +1187,10 @@ only the displayed label localizes.
     <string name="settings_tts_style_spooky_narrator">Моторошний розповідач</string>
     <string name="today_chart_readout">%1$s · %2$s</string>
     <string name="today_chart_reset_to_now">Показати зараз</string>
-    <string name="today_clothes_promo_body">ClothesCast обирає одяг за правилами. Зміни температури, додай шари або зміни пропозиції в налаштуваннях Одяг.</string>
+    <string name="today_clothes_promo_body">ClothesCast обирає одяг за правилами. Зміни температури та персоналізуй свій гардероб у налаштуваннях Одяг.</string>
     <string name="today_clothes_promo_cta">Налаштування одягу</string>
     <string name="today_clothes_promo_dismiss">Закрити</string>
-    <string name="today_clothes_promo_title">Зроби правила своїми</string>
+    <string name="today_clothes_promo_title">Зроби одяг своїм</string>
     <string name="today_insight_format_link">Формат</string>
     <string name="today_play">Відтворити</string>
     <string name="today_play_toast_daily">Відтворюю твій ранковий ClothesCast.</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -1249,10 +1249,10 @@ Skipped intentionally: app_name (brand), insight_time_am/pm/midnight/noon
     <string name="settings_tts_style_spooky_narrator">Người dẫn truyện rùng rợn</string>
     <string name="today_chart_readout">%1$s · %2$s</string>
     <string name="today_chart_reset_to_now">Hiện bây giờ</string>
-    <string name="today_clothes_promo_body">ClothesCast chọn trang phục dựa trên một bộ quy tắc. Điều chỉnh nhiệt độ, thêm lớp hoặc thay đổi gợi ý trong cài đặt Quần áo.</string>
+    <string name="today_clothes_promo_body">ClothesCast chọn trang phục dựa trên một bộ quy tắc. Điều chỉnh nhiệt độ và tùy chỉnh tủ quần áo của bạn trong cài đặt Quần áo.</string>
     <string name="today_clothes_promo_cta">Cài đặt quần áo</string>
     <string name="today_clothes_promo_dismiss">Bỏ qua</string>
-    <string name="today_clothes_promo_title">Tạo quy tắc của riêng bạn</string>
+    <string name="today_clothes_promo_title">Biến quần áo thành của riêng bạn</string>
     <string name="today_insight_format_link">Định dạng</string>
     <string name="today_play">Phát</string>
     <string name="today_play_toast_daily">Đang phát ClothesCast hằng ngày của bạn.</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1336,10 +1336,10 @@ label localizes.
     <string name="settings_tts_style_spooky_narrator">诡异旁白</string>
     <string name="today_chart_readout">%1$s · %2$s</string>
     <string name="today_chart_reset_to_now">显示当前</string>
-    <string name="today_clothes_promo_body">ClothesCast 根据一组规则挑选搭配。在服装设置中调整温度、添加层数或更改建议。</string>
+    <string name="today_clothes_promo_body">ClothesCast 根据一组规则挑选搭配。在服装设置中调整温度并自定义你的衣橱。</string>
     <string name="today_clothes_promo_cta">服装设置</string>
     <string name="today_clothes_promo_dismiss">关闭</string>
-    <string name="today_clothes_promo_title">把规则变成你的</string>
+    <string name="today_clothes_promo_title">把服装变成你的</string>
     <string name="today_insight_format_link">格式</string>
     <string name="today_play">播放</string>
     <string name="today_play_toast_daily">正在播放每日 ClothesCast。</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1352,10 +1352,10 @@ label localises.
     <string name="settings_tts_style_spooky_narrator">詭異旁白</string>
     <string name="today_chart_readout">%1$s · %2$s</string>
     <string name="today_chart_reset_to_now">顯示目前</string>
-    <string name="today_clothes_promo_body">ClothesCast 根據一組規則挑選搭配。在服裝設定中調整溫度、新增層數或變更建議。</string>
+    <string name="today_clothes_promo_body">ClothesCast 根據一組規則挑選搭配。在服裝設定中調整溫度並自訂你的衣櫥。</string>
     <string name="today_clothes_promo_cta">服裝設定</string>
     <string name="today_clothes_promo_dismiss">關閉</string>
-    <string name="today_clothes_promo_title">把規則變成你的</string>
+    <string name="today_clothes_promo_title">把服裝變成你的</string>
     <string name="today_insight_format_link">格式</string>
     <string name="today_play">播放</string>
     <string name="today_play_toast_daily">正在播放每日 ClothesCast。</string>


### PR DESCRIPTION
## Summary

Follow-up to #764, which reworded the English Today-screen "clothes" promo card but left the 44 localized copies stale. This syncs every `values-*/strings.xml` with the new English wording:

- **Title:** the rules → clothes noun swap, e.g. `Make the rules your own` → `Make the clothes your own` (de: `Mach die Kleidung zu deiner`, ja: `服装を自分好みに`, ru: `Настрой одежду под себя`, …)
- **Body:** the second sentence changes from "add layers, or change what gets suggested" to "and customize your wardrobe", e.g. `…Tweak the temperatures and customize your wardrobe in Clothes settings.`

Each locale keeps its own existing phrasing and the exact term it already uses for the **Clothes settings** section — only the noun in the title and the second body sentence were touched. The unchanged first sentence (and its escaped apostrophes in `ca`/`fr`) is preserved verbatim.

## Scope

44 locale files, 2 strings each (`today_clothes_promo_title`, `today_clothes_promo_body`). No English (`values/`) change — that already shipped in #764. No snapshot change: the Roborazzi promo-card snapshot renders the default (English) locale only.

## Privacy

Static UI copy only — nothing here changes what leaves the device.

## Test plan

- [x] Bulk edit applied via a one-off script that asserted each old string matched exactly once per file (script not committed)
- [x] `./gradlew :app:assembleDebug` passes — every locale's resources compile, including the escaped apostrophe in `it` (`Personalizza l\'abbigliamento`)
- [ ] CI green (will un-draft once it is)

https://claude.ai/code/session_016C5NNRFwXMSpvCjxxRuXJ1

---
_Generated by [Claude Code](https://claude.ai/code/session_016C5NNRFwXMSpvCjxxRuXJ1)_