### PR TITLE
Refreshing in the evening now updates the Tonight outfit

### DIFF
--- a/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
@@ -179,36 +179,39 @@ class FetchAndNotifyWorker(
         }
 
         val isSilentRefresh = inputData.getBoolean(KEY_SILENT_REFRESH, false)
-        // Silent app-open refreshes derive the period from the user's
-        // schedule against wall-clock time — same logic the Today screen's
-        // manual Refresh button uses — so a cached snapshot left in the
-        // wrong window after a missed alarm (e.g. yesterday-evening
-        // TONIGHT carried into morning) gets corrected to the current
-        // window on the next open, not perpetuated.
-        val period = if (isSilentRefresh) {
-            currentPeriodForSchedule(prefs)
-        } else {
-            inputData.getString(KEY_PERIOD)
-                ?.let { runCatching { ForecastPeriod.valueOf(it) }.getOrNull() }
-                ?: ForecastPeriod.TODAY
-        }
-
-        // Honour force-refresh only when it's still the day the user tapped on. If
-        // the request was enqueued near midnight and only ran after the date rolled
-        // over (offline retries, deferred backoff), the *new* day's cache should
-        // win — otherwise we'd silently bypass it and burn an extra Gemini call on
-        // a stale tap. The tonight gate below also keys off this same-day check so
-        // a stale tap from yesterday can't bypass a tonight-disabled toggle either.
+        val isUserForcedRefresh = inputData.getBoolean(KEY_FORCE_REFRESH, false)
+        // A force-refresh only counts while it's still the day the user tapped.
+        // If the request was enqueued near midnight and only ran after the date
+        // rolled over (offline retries, deferred backoff), the *new* day's cache
+        // should win — otherwise we'd silently bypass it and burn an extra Gemini
+        // call on a stale tap. Both the period choice and the tonight gate below
+        // key off this same-day check, so a tap from yesterday neither honours
+        // its stale requested window nor bypasses a tonight-disabled toggle.
         val today = LocalDate.now()
         val requestedEpochDay = inputData.getLong(KEY_REQUESTED_EPOCH_DAY, Long.MIN_VALUE)
-        val isUserForcedRefresh = inputData.getBoolean(KEY_FORCE_REFRESH, false)
-        // Silent app-open refreshes fire precisely *because* the cached
-        // snapshot is stale, so they always bypass the same-day cache.
-        val forceRefresh = (isUserForcedRefresh && requestedEpochDay == today.toEpochDay()) ||
-            isSilentRefresh
-        if (isUserForcedRefresh && requestedEpochDay != today.toEpochDay()) {
+        val isSameDayForced = isUserForcedRefresh && requestedEpochDay == today.toEpochDay()
+        if (isUserForcedRefresh && !isSameDayForced) {
             DiagLog.i(TAG, "Ignoring force refresh from a previous day (requested=$requestedEpochDay, today=${today.toEpochDay()}).")
         }
+
+        // Opportunistic silent refreshes (app-open / onboarding) and stale manual
+        // taps carry no live window intent, so they derive the period from the
+        // user's schedule against wall-clock time — correcting a snapshot left in
+        // the wrong slot and steering clear of a disabled tonight slot. A live
+        // (same-day) manual Refresh tap is silent + forced and carries the window
+        // the user is actually in; honour it so an evening tap with tonight
+        // delivery disabled still refreshes TONIGHT.
+        val period = resolveRefreshPeriod(
+            isSilent = isSilentRefresh,
+            isSameDayForced = isSameDayForced,
+            requestedPeriod = inputData.getString(KEY_PERIOD)
+                ?.let { runCatching { ForecastPeriod.valueOf(it) }.getOrNull() },
+            prefs = prefs,
+        )
+
+        // Silent app-open refreshes fire precisely *because* the cached
+        // snapshot is stale, so they always bypass the same-day cache.
+        val forceRefresh = isSameDayForced || isSilentRefresh
 
         // The tonight alarm rearms blindly via AlarmReceiver; the user's enable
         // toggle is honoured here so a stale alarm doesn't ship a tonight insight
@@ -1736,5 +1739,32 @@ class FetchAndNotifyWorker(
             }
             return if (inTonightWindow) ForecastPeriod.TONIGHT else ForecastPeriod.TODAY
         }
+
+        /**
+         * The window a run should refresh. Opportunistic silent refreshes
+         * (app-open [enqueueSilentRefresh], onboarding [enqueueOnboardingRefresh])
+         * and stale manual taps auto-correct to the current schedule window via
+         * [currentPeriodForSchedule] — fixing a snapshot left in the wrong slot
+         * after a missed alarm and steering clear of a disabled tonight slot.
+         * Only a *live* manual Refresh tap — silent and forced on the day it was
+         * tapped ([isSameDayForced]) — or a scheduled alarm (not silent) honours
+         * the explicit [requestedPeriod], so an evening tap still targets TONIGHT
+         * even when tonight delivery is disabled ([currentPeriodForSchedule] would
+         * force TODAY there, leaving the Tonight card stale). A force tap that
+         * crossed midnight is no longer live, so it falls back with the
+         * opportunistic refreshes rather than caching the stale TONIGHT slot.
+         */
+        internal fun resolveRefreshPeriod(
+            isSilent: Boolean,
+            isSameDayForced: Boolean,
+            requestedPeriod: ForecastPeriod?,
+            prefs: UserPreferences,
+            now: LocalTime = LocalTime.now(),
+        ): ForecastPeriod =
+            if (isSilent && !isSameDayForced) {
+                currentPeriodForSchedule(prefs, now)
+            } else {
+                requestedPeriod ?: ForecastPeriod.TODAY
+            }
     }
 }

--- a/app/src/test/kotlin/app/clothescast/work/SilentRefreshFreshnessTest.kt
+++ b/app/src/test/kotlin/app/clothescast/work/SilentRefreshFreshnessTest.kt
@@ -130,4 +130,85 @@ class SilentRefreshFreshnessTest {
         FetchAndNotifyWorker.currentPeriodForSchedule(prefs, LocalTime.of(21, 0)) shouldBe ForecastPeriod.TODAY
         FetchAndNotifyWorker.currentPeriodForSchedule(prefs, LocalTime.of(2, 0)) shouldBe ForecastPeriod.TODAY
     }
+
+    @Test
+    fun `live manual refresh honours the requested period even when tonight is disabled`() {
+        // A same-day evening Refresh tap is silent + forced and carries TONIGHT.
+        // It must refresh TONIGHT even with tonight delivery off — otherwise
+        // resolveRefreshPeriod falls through to currentPeriodForSchedule, which
+        // forces TODAY there and leaves the Tonight card stale.
+        val prefs = basePrefs.copy(tonightEnabled = false)
+        FetchAndNotifyWorker.resolveRefreshPeriod(
+            isSilent = true,
+            isSameDayForced = true,
+            requestedPeriod = ForecastPeriod.TONIGHT,
+            prefs = prefs,
+            now = LocalTime.of(21, 0),
+        ) shouldBe ForecastPeriod.TONIGHT
+    }
+
+    @Test
+    fun `live manual refresh honours a requested TODAY`() {
+        FetchAndNotifyWorker.resolveRefreshPeriod(
+            isSilent = true,
+            isSameDayForced = true,
+            requestedPeriod = ForecastPeriod.TODAY,
+            prefs = basePrefs,
+            now = LocalTime.of(21, 0),
+        ) shouldBe ForecastPeriod.TODAY
+    }
+
+    @Test
+    fun `stale manual refresh that crossed midnight falls back to the schedule`() {
+        // A forced tap enqueued before midnight but run after the date rolled
+        // over is no longer live (isSameDayForced = false). With tonight
+        // disabled it must steer to TODAY via the schedule rather than caching
+        // the stale, disabled TONIGHT slot it originally requested.
+        val prefs = basePrefs.copy(tonightEnabled = false)
+        FetchAndNotifyWorker.resolveRefreshPeriod(
+            isSilent = true,
+            isSameDayForced = false,
+            requestedPeriod = ForecastPeriod.TONIGHT,
+            prefs = prefs,
+            now = LocalTime.of(21, 0),
+        ) shouldBe ForecastPeriod.TODAY
+    }
+
+    @Test
+    fun `opportunistic silent refresh ignores the requested period and follows the schedule`() {
+        // App-open / onboarding refreshes aren't same-day-forced; they
+        // auto-correct to the current schedule window and ignore any requested
+        // period.
+        FetchAndNotifyWorker.resolveRefreshPeriod(
+            isSilent = true,
+            isSameDayForced = false,
+            requestedPeriod = ForecastPeriod.TODAY,
+            prefs = basePrefs,
+            now = LocalTime.of(21, 0),
+        ) shouldBe ForecastPeriod.TONIGHT
+    }
+
+    @Test
+    fun `scheduled alarm honours the requested period`() {
+        // Alarms are neither silent nor force-flagged; the requested period
+        // (set by AlarmReceiver) is taken verbatim.
+        FetchAndNotifyWorker.resolveRefreshPeriod(
+            isSilent = false,
+            isSameDayForced = false,
+            requestedPeriod = ForecastPeriod.TONIGHT,
+            prefs = basePrefs,
+            now = LocalTime.of(9, 0),
+        ) shouldBe ForecastPeriod.TONIGHT
+    }
+
+    @Test
+    fun `a run with no requested period defaults to TODAY`() {
+        FetchAndNotifyWorker.resolveRefreshPeriod(
+            isSilent = false,
+            isSameDayForced = false,
+            requestedPeriod = null,
+            prefs = basePrefs,
+            now = LocalTime.of(21, 0),
+        ) shouldBe ForecastPeriod.TODAY
+    }
 }


### PR DESCRIPTION
## Summary

Follow-up to #763. Making the manual Refresh button a *silent* refresh introduced a period-resolution regression: the worker resolved the window for **every** silent run via `currentPeriodForSchedule`, which returns `TODAY` whenever `prefs.tonightEnabled` is `false`.

So an evening Refresh tap, with scheduled tonight notifications disabled, regenerated the **daytime** window and left the **Tonight** card stale — regressing the prior behaviour where a manual tap inside the tonight window updated Tonight regardless of the toggle.

## Fix

Split the decision into `resolveRefreshPeriod(isSilent, isSameDayForced, requestedPeriod, prefs, now)`, gated on whether the run carries a *live* window intent:

- **Opportunistic** silent refreshes (app-open `enqueueSilentRefresh`, onboarding `enqueueOnboardingRefresh`) **and stale manual taps that crossed midnight** aren't same-day-forced, so they auto-correct to the current schedule window via `currentPeriodForSchedule`. A stale evening tap with tonight disabled therefore falls back to `TODAY` instead of caching the disabled `TONIGHT` slot it originally requested.
- **Live** runs — a same-day manual Refresh tap (silent **+** forced) and scheduled alarms (non-silent) — honour the explicitly-passed `KEY_PERIOD`. An evening Refresh tap therefore still targets `TONIGHT` even with tonight delivery off.

`isSameDayForced` (`isUserForcedRefresh && requestedEpochDay == today`) is lifted above the period resolution so it gates **both** the window choice and the existing same-day force-refresh / midnight-rollover logic. That gate's behaviour (`forceRefresh = isSameDayForced || isSilentRefresh`) is unchanged.

## Tests

`SilentRefreshFreshnessTest` covers the caller shapes:
- live manual refresh honours requested TONIGHT even with tonight disabled (the headline fix)
- live manual refresh honours requested TODAY
- **stale manual refresh that crossed midnight falls back to the schedule** (avoids the disabled TONIGHT slot)
- opportunistic silent refresh ignores the requested period and follows the schedule
- scheduled alarm honours the requested period
- no requested period defaults to TODAY

## Test plan

- [x] `./gradlew :app:testDebugUnitTest` — passes (incl. new `resolveRefreshPeriod` cases)
- [x] `./gradlew :app:assembleDebug` — passes
- [ ] Manual: with tonight delivery off, tap Refresh inside the tonight window → Tonight card updates silently (no notification/TTS/Cast/MQTT)

https://claude.ai/code/session_01D8CkTfVdfn76eQMQwBFaJf