### PR TITLE
Drop the obsolete SettingsViewModelTest locale-flake note

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -367,11 +367,6 @@ new rule the first time something bites you, not the third.
   ./gradlew :core:domain:test :core:data:test :app:testDebugUnitTest
   ./gradlew :app:assembleDebug
   ```
-- **Pre-existing flaky test:** `SettingsViewModelTest > initial state reflects
-  repository defaults` may fail with `expected:<CELSIUS> but was:<FAHRENHEIT>`
-  depending on the JVM's default locale. This is a pre-existing issue, not
-  caused by your changes. CI passes this test because the GitHub runner locale
-  defaults differently.
 - **Android Lint is available** for the `:app` module via AGP; run
   `./gradlew :app:lintDebug` when app-side validation needs lint coverage.
   There is no separate `ktlint` plugin wired, so Kotlin style checks are not


### PR DESCRIPTION
## Summary
- Removes the stale **"Pre-existing flaky test"** bullet from the Cursor Cloud section of `AGENTS.md` (`CLAUDE.md` is a symlink to it). It claimed `SettingsViewModelTest > initial state reflects repository defaults` flakes `CELSIUS`/`FAHRENHEIT` on en-US JVMs and that failures should be treated as pre-existing.
- That stopped being true once commit `5cdb00d6` ("Stabilise the settings view-model tests") pinned `Locale.setDefault(Locale.FRANCE)` in the test's `setUp`. The note was added **before** that fix and never updated, so it now risks masking a genuine regression of that test as an "expected" flake.

## Why the flake is already fixed
- The test asserts on the initial `SettingsState()` value, whose `temperatureUnit` / `distanceUnit` defaults read `Locale.getDefault()` directly. The `setUp` pin to `Locale.FRANCE` makes the host JVM locale irrelevant (FR → Celsius + kilometres).
- `SettingsRepositoryTest` already controls locale the clean way — injected `systemLocaleProvider = { Locale.UK }` — and no other `:app` test asserts on locale-derived unit defaults without pinning or injecting. So pinning is complete.

## Verification (ran under a forced en-US JVM: `-Duser.language=en -Duser.country=US`)
- `SettingsViewModelTest` passes **5/5** with the pin.
- Full `:app:testDebugUnitTest` suite passes **3/3** with the pin.
- Temporarily removing the pin reproduces the failure at `SettingsViewModelTest.kt:161` under en-US, confirming the pin is load-bearing and the note is obsolete.

## Test plan
- [x] `SettingsViewModelTest` green 5× under en-US
- [x] Full `:app` unit suite green 3× under en-US
- [x] Working tree contains only the doc change (verification scaffolding reverted)

Docs-only change (`*.md`), so it's filtered from the Play "What's new" changelog.

https://claude.ai/code/session_017TNgwYgwVws3mEP39Uhyrs

---
_Generated by [Claude Code](https://claude.ai/code/session_017TNgwYgwVws3mEP39Uhyrs)_