### PR TITLE
test: fix flaky UncaughtExceptionsBeforeTest in SettingsViewModelTest

### DIFF
--- a/app/src/test/kotlin/app/clothescast/ui/settings/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/app/clothescast/ui/settings/SettingsViewModelTest.kt
@@ -87,11 +87,12 @@ class SettingsViewModelTest {
     // metric locale for the test class so the defaults are deterministic.
     private lateinit var originalLocale: Locale
     // viewModelScope owns an infinite preferences.collect loop and the device-voice
-    // load job. Without bounding it to the test, those coroutines can outlive
-    // runTest's body and resume with an exception (after the test's DataStore is
-    // cancelled in tearDown), occasionally surfacing as UncaughtExceptionsBeforeTest
-    // on the next test. ViewModelStore.clear() cancels every registered viewmodel's
-    // scope in one call, matching the existing DataStore-scope cleanup pattern above.
+    // load job. Without bounding them to the test, those coroutines can outlive
+    // runTest's body and resume with an exception (after the test's scopes are
+    // cancelled in tearDown), surfacing as UncaughtExceptionsBeforeTest on the next
+    // test. ViewModelStore.clear() cancels every registered viewmodel's scope in one
+    // call; tearDown then drains the scheduler so that cancellation completes before
+    // resetMain(), which closes the race deterministically.
     private val viewModelStore = ViewModelStore()
     private var nextViewModelKey = 0
     private fun <T : ViewModel> track(vm: T): T = vm.also {
@@ -150,8 +151,17 @@ class SettingsViewModelTest {
 
     @AfterEach
     fun tearDown() {
+        // Cancel the viewmodel + DataStore scopes, then drain the shared test
+        // scheduler so their cancellation runs to completion WHILE Main is still
+        // set. The viewmodel's infinite preferences.collect, its device-voice
+        // load job, and DataStore's actor all live on `dispatcher`; if any is
+        // mid-flight when the test body ends, cancelling without draining lets it
+        // resume after resetMain(), fail to dispatch through the now-missing Main
+        // dispatcher, and surface as UncaughtExceptionsBeforeTest against the
+        // next test. Draining before resetMain() makes teardown deterministic.
         viewModelStore.clear()
         dataStoreScope.cancel()
+        dispatcher.scheduler.advanceUntilIdle()
         Dispatchers.resetMain()
         Locale.setDefault(originalLocale)
     }


### PR DESCRIPTION
## Summary

Fixes the intermittent `UncaughtExceptionsBeforeTest: There were uncaught exceptions before the test started` flake in `SettingsViewModelTest` (surfaced during PR #769's CI as a failure attributed to `clearApiKey`).

`SettingsViewModelTest` drives a real `SettingsViewModel` + two `DataStore`s on a class-scoped `CoroutineScope` bound to the test dispatcher. The viewmodel's infinite `preferences.collect` loop, its device-voice load job, and DataStore's internal actor can be suspended mid-flight when a `runTest` body ends. `tearDown` cancelled those scopes and then immediately called `Dispatchers.resetMain()`, leaving a window where a cancelled coroutine resumes **after** `resetMain()`, can't dispatch through the now-missing `Main` dispatcher, and is reported by kotlinx-coroutines-test against whatever test JUnit starts next.

The test file already documented this race (and the locale concern, which is separate and already mitigated by pinning `Locale.FRANCE`).

## Fix

Drain the shared test scheduler (`dispatcher.scheduler.advanceUntilIdle()`) **between** cancelling the scopes and `resetMain()`, so the cancellation runs to completion while `Main` is still set. This closes the window deterministically instead of relying on cancellation finishing in time.

## Notes

- Test-only change (`test:`-prefixed; excluded from the Play "What's new").
- The flake is rare (it did not reproduce in 16 prior runs), so this is a defensive/deterministic hardening rather than a guaranteed-repro fix. Validating with repeated full-suite runs.

## Test plan

- [ ] `./gradlew :app:testDebugUnitTest` green across repeated `--rerun-tasks` runs

https://claude.ai/code/session_01HJP8nFz9B6EHVhNrpYdEyo

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJP8nFz9B6EHVhNrpYdEyo)_