### PR TITLE
Show fewer setup cards at once on the Today screen

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/today/PromoBanners.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/PromoBanners.kt
@@ -1,0 +1,41 @@
+package app.clothescast.ui.today
+
+/**
+ * The setup / promo cards on the Today screen, in descending priority. Used by
+ * [promoBannersToShow] to decide which of them render — distinct from the
+ * operational banners (update / crash / work-status / holiday), which aren't
+ * capped.
+ */
+internal enum class PromoBanner { LOCATION, TELEMETRY, CLOTHES, CELEBRATION }
+
+/**
+ * Decides which promo cards the Today screen shows, capping the stack so a
+ * fresh user isn't buried under "set this up" noise. Eligible cards are taken
+ * in priority order (location > privacy > clothes > celebration) up to
+ * [maxVisible]; the rest wait until a higher one is resolved or dismissed.
+ *
+ * The two customization nudges — clothes ([clothesPromoEligible]) and
+ * holiday/birthday theming ([celebrationEligible]) — are additionally held
+ * back until [hasForecast]: the user has received at least one forecast
+ * (foreground or background), i.e. is no longer brand-new. So an empty-cache
+ * first-run only ever sees location + privacy; the customization promos join
+ * the (still capped) pool once any forecast lands. Location and privacy aren't
+ * gated this way — a brand-new user with no location needs the location prompt,
+ * and the telemetry disclosure shouldn't be silently withheld.
+ */
+internal fun promoBannersToShow(
+    locationActionRequired: Boolean,
+    telemetryNoticeVisible: Boolean,
+    clothesPromoEligible: Boolean,
+    celebrationEligible: Boolean,
+    hasForecast: Boolean,
+    maxVisible: Int = 2,
+): Set<PromoBanner> {
+    val eligible = buildList {
+        if (locationActionRequired) add(PromoBanner.LOCATION)
+        if (telemetryNoticeVisible) add(PromoBanner.TELEMETRY)
+        if (clothesPromoEligible && hasForecast) add(PromoBanner.CLOTHES)
+        if (celebrationEligible && hasForecast) add(PromoBanner.CELEBRATION)
+    }
+    return eligible.take(maxVisible).toSet()
+}

--- a/app/src/main/kotlin/app/clothescast/ui/today/TelemetryNoticeBanner.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TelemetryNoticeBanner.kt
@@ -15,7 +15,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -23,7 +22,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.clothescast.ClothesCastApplication
 import app.clothescast.R
 import kotlinx.coroutines.launch
@@ -43,20 +41,19 @@ import kotlinx.coroutines.launch
  */
 @Composable
 internal fun TelemetryNoticeBanner(
+    visible: Boolean,
     onOpenPrivacy: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    // The telemetry-notice pref is read via a lifecycle-scoped flow that can't
-    // run in @Preview / snapshot composition — no-op so a full-screen preview
-    // (the scaffold's banner stack) renders cleanly.
+    if (!visible) return
+    // Acking the notice reaches the app's settingsRepository via LocalContext,
+    // which isn't a ClothesCastApplication under @Preview / snapshot
+    // composition — no-op there so a full-screen banner-stack preview renders
+    // cleanly without a live Application.
     if (LocalInspectionMode.current) return
     val context = LocalContext.current
     val settings = (context.applicationContext as ClothesCastApplication).settingsRepository
     val coroutineScope = rememberCoroutineScope()
-
-    val prefs by settings.preferences.collectAsStateWithLifecycle(initialValue = null)
-    val current = prefs ?: return
-    if (current.telemetryNoticeAcked) return
 
     fun ack() {
         coroutineScope.launch { settings.setTelemetryNoticeAcked(true) }

--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
@@ -594,11 +594,23 @@ private fun BannerStack(
     onSetUpLocation: () -> Unit,
 ) {
     val bannerModifier = Modifier.fillMaxWidth()
+    // Cap the setup/promo stack so a fresh user isn't buried under "set this
+    // up" cards. Only the top [maxVisible] eligible promos render (priority
+    // location > privacy > clothes > celebration); the rest wait their turn.
+    // The operational banners below (update / build / crash / work / holiday)
+    // are unaffected and keep their existing positions.
+    val shownPromos = promoBannersToShow(
+        locationActionRequired = locationActionRequired,
+        telemetryNoticeVisible = state.telemetryNoticeVisible,
+        clothesPromoEligible = state.clothesPromoCardVisible,
+        celebrationEligible = state.celebrationCardVisible,
+        hasForecast = state.thisPeriodInsight != null,
+    )
     // LocationActionRequiredBanner is first on purpose: without a resolvable
     // location nothing else on the screen is actionable — no insight will
     // generate, no notification will fire — so the prompt to fix it
     // outranks every other banner, including the update / crash disclosures.
-    if (locationActionRequired) {
+    if (PromoBanner.LOCATION in shownPromos) {
         LocationActionRequiredBanner(
             onSetUpLocation = onSetUpLocation,
             modifier = bannerModifier,
@@ -612,14 +624,19 @@ private fun BannerStack(
     // (or taps through to Privacy from it). Stays out of the way of the
     // crash banner: that's a current problem to action; this is just
     // disclosure.
-    TelemetryNoticeBanner(onOpenPrivacy = onOpenPrivacy, modifier = bannerModifier)
+    TelemetryNoticeBanner(
+        visible = PromoBanner.TELEMETRY in shownPromos,
+        onOpenPrivacy = onOpenPrivacy,
+        modifier = bannerModifier,
+    )
     // "Customize your clothes" nudge so the user knows the per-temperature
     // rules are theirs to tune. Gated upstream on [clothesRules] still
-    // matching [ClothesRule.DEFAULTS] (plus the user not having dismissed)
-    // so a user who has already customised never sees it. Sits before the
-    // celebration-themes promo because clothes rules are the core setting.
+    // matching [ClothesRule.DEFAULTS] (plus the user not having dismissed),
+    // and held back by [promoBannersToShow] until the user has seen a forecast
+    // and there's room under the cap. Sits before the celebration-themes promo
+    // because clothes rules are the more core customization.
     ClothesPromoCard(
-        visible = state.clothesPromoCardVisible,
+        visible = PromoBanner.CLOTHES in shownPromos,
         onOpenClothes = {
             onDismissClothesPromoCard()
             onOpenClothes()
@@ -627,12 +644,13 @@ private fun BannerStack(
         onDismiss = onDismissClothesPromoCard,
         modifier = bannerModifier,
     )
-    // Promo card for the calendar-sourced holiday + birthday theming.
-    // Driven by [TodayState.celebrationCardVisible] (gated upstream on
-    // toggles + dismissal) so it disappears the moment either toggle goes
-    // on or the X is tapped.
+    // Promo card for the calendar-sourced holiday + birthday theming. Gated
+    // upstream on toggles + dismissal ([TodayState.celebrationCardVisible]),
+    // held back by [promoBannersToShow] until the user has seen a forecast
+    // and there's room under the cap — so it disappears the moment either
+    // toggle goes on or the X is tapped, and never crowds a brand-new user.
     CelebrationThemesCard(
-        visible = state.celebrationCardVisible,
+        visible = PromoBanner.CELEBRATION in shownPromos,
         onOpenCalendarSettings = onOpenCalendarSettings,
         onDismiss = onDismissCelebrationCard,
         modifier = bannerModifier,

--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayViewModel.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayViewModel.kt
@@ -165,6 +165,13 @@ data class TodayState(
      */
     val clothesPromoCardVisible: Boolean = false,
     /**
+     * Whether the one-time telemetry/privacy disclosure is still pending
+     * (the user hasn't acked it). Lifted out of the banner so [BannerStack]
+     * can fold it into the capped promo pool alongside the location, clothes,
+     * and celebration prompts.
+     */
+    val telemetryNoticeVisible: Boolean = false,
+    /**
      * True iff either calendar-sourced theming toggle is on. The Today
      * screen reads this to decide whether an ON_RESUME nudge of the
      * permission-recheck tick is worth its DataStore-write cost: if no
@@ -527,6 +534,7 @@ class TodayViewModel(
                 !prefs.calendarBirthdayThemingActive,
             clothesPromoCardVisible = !prefs.clothesPromoCardDismissed &&
                 prefs.clothesRules == ClothesRule.DEFAULTS,
+            telemetryNoticeVisible = !prefs.telemetryNoticeAcked,
             usesCalendarThemes = prefs.calendarHolidayThemingActive || prefs.calendarBirthdayThemingActive,
         )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), TodayState())

--- a/app/src/test/kotlin/app/clothescast/ui/today/PromoBannersTest.kt
+++ b/app/src/test/kotlin/app/clothescast/ui/today/PromoBannersTest.kt
@@ -1,0 +1,89 @@
+package app.clothescast.ui.today
+
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+class PromoBannersTest {
+
+    @Test
+    fun `customization promos are hidden until a forecast has been delivered`() {
+        promoBannersToShow(
+            locationActionRequired = false,
+            telemetryNoticeVisible = false,
+            clothesPromoEligible = true,
+            celebrationEligible = true,
+            hasForecast = false,
+        ) shouldBe emptySet()
+    }
+
+    @Test
+    fun `customization promos show once a forecast exists`() {
+        promoBannersToShow(
+            locationActionRequired = false,
+            telemetryNoticeVisible = false,
+            clothesPromoEligible = true,
+            celebrationEligible = true,
+            hasForecast = true,
+        ) shouldContainExactlyInAnyOrder listOf(PromoBanner.CLOTHES, PromoBanner.CELEBRATION)
+    }
+
+    @Test
+    fun `location and privacy show to a brand-new user with no forecast`() {
+        // Location + telemetry aren't forecast-gated, so they're the only
+        // promos a first-run (empty-cache) user can see.
+        promoBannersToShow(
+            locationActionRequired = true,
+            telemetryNoticeVisible = true,
+            clothesPromoEligible = true,
+            celebrationEligible = true,
+            hasForecast = false,
+        ) shouldContainExactlyInAnyOrder listOf(PromoBanner.LOCATION, PromoBanner.TELEMETRY)
+    }
+
+    @Test
+    fun `at most two promos show, taken in priority order`() {
+        promoBannersToShow(
+            locationActionRequired = true,
+            telemetryNoticeVisible = true,
+            clothesPromoEligible = true,
+            celebrationEligible = true,
+            hasForecast = true,
+        ) shouldContainExactlyInAnyOrder listOf(PromoBanner.LOCATION, PromoBanner.TELEMETRY)
+    }
+
+    @Test
+    fun `dropping a higher promo promotes the next one`() {
+        // Location resolved, telemetry acked: clothes + celebration fill the
+        // two slots that location + privacy would otherwise occupy.
+        promoBannersToShow(
+            locationActionRequired = false,
+            telemetryNoticeVisible = false,
+            clothesPromoEligible = true,
+            celebrationEligible = true,
+            hasForecast = true,
+        ) shouldContainExactlyInAnyOrder listOf(PromoBanner.CLOTHES, PromoBanner.CELEBRATION)
+    }
+
+    @Test
+    fun `location always wins a slot when required`() {
+        promoBannersToShow(
+            locationActionRequired = true,
+            telemetryNoticeVisible = false,
+            clothesPromoEligible = true,
+            celebrationEligible = true,
+            hasForecast = true,
+        ) shouldContainExactlyInAnyOrder listOf(PromoBanner.LOCATION, PromoBanner.CLOTHES)
+    }
+
+    @Test
+    fun `nothing eligible shows nothing`() {
+        promoBannersToShow(
+            locationActionRequired = false,
+            telemetryNoticeVisible = false,
+            clothesPromoEligible = false,
+            celebrationEligible = false,
+            hasForecast = true,
+        ) shouldBe emptySet()
+    }
+}


### PR DESCRIPTION
## Summary

A fresh user landing on the home screen could see a stack of setup/promo cards at once — realistically **Telemetry notice + Clothes promo + Celebration (holiday/birthday) themes**, plus the Location banner. This trims that noise:

- **Cap the promo pool at 2.** Only the top two *eligible* setup/promo cards render, in priority order **Location > Privacy (telemetry) > Clothes > Celebration**. The rest wait until a higher one is resolved or dismissed. Operational/transient banners (Update, Local build, Last crash, Work status, Holiday) are out of scope and keep their existing positions. Since the banner stack is now shared across the Today / Tonight / 7-day pages (`HomePageScaffold`), the cap applies on all of them.
- **Defer both customization nudges (Clothes promo *and* Celebration themes) until any forecast has been delivered** (foreground *or* background) — i.e. the user is no longer brand-new. A first-run, empty-cache screen only ever shows the **Location** and **Privacy** prompts; the customization promos join the (still capped) pool once a forecast lands. This reuses the existing cached-forecast signal (`state.thisPeriodInsight != null`). Because `InsightCache` is DataStore-backed it survives cold starts, so **existing/upgrading users (who already have a cached forecast) see the promos immediately — no timestamp, no migration**.

## Implementation

- New pure helper `promoBannersToShow(...)` + `PromoBanner` enum (`PromoBanners.kt`) holds both the cap and the per-card forecast gate, so the logic is unit-testable without a Compose/ViewModel harness.
- `BannerStack` (`TodayScreen.kt`) computes the visible set once and gates each promo on membership; render order unchanged.
- `TodayState` gains `telemetryNoticeVisible` (`= !telemetryNoticeAcked`) so the telemetry notice can join the capped pool; `TelemetryNoticeBanner` now takes a `visible` flag instead of self-gating (keeping its `LocalInspectionMode` no-op for full-screen previews).

## Privacy

No change to telemetry behaviour or to any data that leaves the device. The telemetry-notice refactor only lifts *where the visibility decision is made* (into `TodayState`); the ack contract and what Firebase receives are untouched.

## Test plan

- [x] `./gradlew :app:testDebugUnitTest` — `PromoBannersTest` covers the forecast gate (both customization promos), the 2-card cap, priority order, and promotion; existing tests and Roborazzi snapshots unchanged (no drift).
- [x] `./gradlew :app:assembleDebug` — green.
- [ ] Live UI not exercised: this headless build sandbox has no emulator, and the existing previews use default `TodayState` (no multiple promos set), so the stacked-cap visuals weren't captured. Worth an eyeball on device: a brand-new state shows ≤2 promos and only Location/Privacy; after a forecast the Clothes and Celebration promos appear, still capped; dismissing a higher card promotes the next.

https://claude.ai/code/session_01UeS52QehaLX8Da23Q7m23y