### PR TITLE
Fix the feels-like widget rendering empty

### DIFF
--- a/app/src/main/kotlin/app/clothescast/widget/ComposeRender.kt
+++ b/app/src/main/kotlin/app/clothescast/widget/ComposeRender.kt
@@ -1,13 +1,15 @@
 package app.clothescast.widget
 
+import android.app.Presentation
 import android.content.Context
 import android.graphics.Bitmap
-import android.graphics.Canvas
-import android.view.View
+import android.graphics.PixelFormat
+import android.hardware.display.DisplayManager
+import android.hardware.display.VirtualDisplay
+import android.media.Image
+import android.media.ImageReader
+import android.view.ViewGroup
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.Recomposer
-import androidx.compose.runtime.withFrameNanos
-import androidx.compose.ui.platform.AndroidUiDispatcher
 import androidx.compose.ui.platform.ComposeView
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleRegistry
@@ -19,88 +21,143 @@ import androidx.savedstate.SavedStateRegistry
 import androidx.savedstate.SavedStateRegistryController
 import androidx.savedstate.SavedStateRegistryOwner
 import androidx.savedstate.setViewTreeSavedStateRegistryOwner
-import kotlinx.coroutines.launch
+import app.clothescast.diag.DiagLog
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 
-// Cap on frames pumped while waiting for the render to settle. Vico loads its
-// line series via a coroutine the first composed frame doesn't cover and then
-// animates the line in, so we draw each frame and stop once two consecutive
-// frames are byte-identical. ~60 frames ≈ 1s of real frames is plenty for the
-// data load + draw-in animation; the caller also wraps this in a timeout.
-private const val MAX_FRAMES = 60
+private const val TAG = "WidgetRender"
 
-// Require the picture to hold steady for this many consecutive frames before
-// accepting it — guards against catching a mid-animation frame that happens to
-// repeat once.
-private const val STABLE_FRAMES = 2
+// How long to keep pulling frames while the chart loads its data and the line
+// animates in, and how often to sample. The caller also imposes a hard timeout.
+private const val RENDER_BUDGET_MS = 2500L
+private const val FRAME_INTERVAL_MS = 50L
+
+// Accept the picture once it holds steady for this many consecutive samples.
+private const val STABLE_SAMPLES = 2
 
 /**
- * Rasterises a Compose [content] to a [Bitmap] off-screen, with no Activity or
- * attached window — the path the home-screen widgets use to show the real
- * [WidgetForecastChart] (Glance emits RemoteViews and can't host Compose/Vico).
+ * Rasterises a Compose [content] to a [Bitmap] from a non-Activity context (the
+ * widget worker), returning null if it can't produce a non-blank frame.
  *
- * Composition runs against a self-managed [Recomposer] on the Android UI
- * dispatcher (which supplies the frame clock Vico's animations need). We pump
- * frames, drawing each one, until the output stops changing — the runtime
- * analogue of the snapshot harness's `captureUntilStable`, which solves the same
- * "Vico's series arrives a frame or two after first composition" race. Must run
- * inside a timeout: a composable that never settles would otherwise pump all
- * [MAX_FRAMES] and, if the frame clock stalls, block.
+ * Unlike an unattached `ComposeView` — which composes but never actually paints,
+ * the cause of the blank widget — this renders into a **real window**: a
+ * [Presentation] hosted on a [VirtualDisplay] backed by an [ImageReader]. That
+ * gives Compose a live window + frame clock, so `LaunchedEffect`s run, Vico
+ * loads its series, and the chart draws. We sample the ImageReader until the
+ * frame stabilises (Vico's async load + draw-in animation settle a few frames
+ * after first composition).
  *
- * Note: this can't be exercised by Robolectric (no real frame clock / window),
- * so the *visual* is validated by the `WidgetForecastChart` snapshots and this
- * harness is verified on-device.
+ * Every failure path logs via [DiagLog] (tag `$TAG`) — a blank widget must never
+ * fail silently again.
+ *
+ * Can't be exercised by Robolectric (no real display/window), so it's verified
+ * on-device; the chart's *appearance* is locked by the WidgetForecastChart
+ * snapshots.
  */
 internal suspend fun renderComposableToBitmap(
     context: Context,
     widthPx: Int,
     heightPx: Int,
     content: @Composable () -> Unit,
-): Bitmap = withContext(AndroidUiDispatcher.Main) {
+): Bitmap? = withContext(Dispatchers.Main) {
     require(widthPx > 0 && heightPx > 0) { "render size must be positive, got ${widthPx}x$heightPx" }
+    val imageReader = ImageReader.newInstance(widthPx, heightPx, PixelFormat.RGBA_8888, 2)
+    val displayManager = context.getSystemService(Context.DISPLAY_SERVICE) as? DisplayManager
+        ?: run {
+            DiagLog.e(TAG, "No DisplayManager; cannot render widget chart")
+            imageReader.close()
+            return@withContext null
+        }
     val owner = HeadlessOwner().also { it.create() }
-    val recomposer = Recomposer(coroutineContext)
-    val composeView = ComposeView(context).also { view ->
-        view.setViewTreeLifecycleOwner(owner)
-        view.setViewTreeSavedStateRegistryOwner(owner)
-        view.setViewTreeViewModelStoreOwner(owner)
-        view.setParentCompositionContext(recomposer)
-        view.setContent(content)
-    }
-    val recomposeJob = launch { recomposer.runRecomposeAndApplyChanges() }
+    var virtualDisplay: VirtualDisplay? = null
+    var presentation: Presentation? = null
     try {
-        composeView.createComposition()
-        val wSpec = View.MeasureSpec.makeMeasureSpec(widthPx, View.MeasureSpec.EXACTLY)
-        val hSpec = View.MeasureSpec.makeMeasureSpec(heightPx, View.MeasureSpec.EXACTLY)
-        val bitmap = Bitmap.createBitmap(widthPx, heightPx, Bitmap.Config.ARGB_8888)
-        val canvas = Canvas(bitmap)
+        virtualDisplay = displayManager.createVirtualDisplay(
+            "clothescast-widget-chart",
+            widthPx,
+            heightPx,
+            context.resources.displayMetrics.densityDpi,
+            imageReader.surface,
+            DisplayManager.VIRTUAL_DISPLAY_FLAG_OWN_CONTENT_ONLY or
+                DisplayManager.VIRTUAL_DISPLAY_FLAG_PRESENTATION,
+        )
+        presentation = Presentation(context.applicationContext, virtualDisplay.display).apply {
+            window?.setLayout(widthPx, heightPx)
+        }
+        val composeView = ComposeView(presentation.context).apply {
+            setViewTreeLifecycleOwner(owner)
+            setViewTreeSavedStateRegistryOwner(owner)
+            setViewTreeViewModelStoreOwner(owner)
+            setContent(content)
+        }
+        presentation.setContentView(composeView, ViewGroup.LayoutParams(widthPx, heightPx))
+        presentation.show()
+
+        var result: Bitmap? = null
         var lastHash = 0
         var stable = 0
-        repeat(MAX_FRAMES) {
-            withFrameNanos { /* let recomposition apply + Vico's coroutine run */ }
-            composeView.measure(wSpec, hSpec)
-            composeView.layout(0, 0, widthPx, heightPx)
-            bitmap.eraseColor(0)
-            composeView.draw(canvas)
-            val hash = bitmap.coarseHash()
-            if (hash == lastHash) {
-                if (++stable >= STABLE_FRAMES) return@repeat
+        var frames = 0
+        val deadline = System.currentTimeMillis() + RENDER_BUDGET_MS
+        while (System.currentTimeMillis() < deadline) {
+            delay(FRAME_INTERVAL_MS)
+            val image = imageReader.acquireLatestImage() ?: continue
+            frames++
+            val frame = runCatching { image.toBitmap(widthPx, heightPx) }
+                .onFailure { DiagLog.w(TAG, "Failed to copy ImageReader frame", it) }
+                .getOrNull()
+            image.close()
+            if (frame == null) continue
+            val hash = frame.coarseHash()
+            if (hash == lastHash && hash != 0) {
+                if (++stable >= STABLE_SAMPLES) {
+                    result = frame
+                    break
+                }
             } else {
                 stable = 0
                 lastHash = hash
             }
+            result = frame
         }
-        bitmap
+        when {
+            result == null -> DiagLog.w(TAG, "No frame produced in ${RENDER_BUDGET_MS}ms ($frames seen)")
+            result.isBlank() -> {
+                DiagLog.w(TAG, "Rendered frame blank after $frames frames (${widthPx}x$heightPx)")
+                result = null
+            }
+            else -> DiagLog.i(TAG, "Rendered widget chart in $frames frames")
+        }
+        result
+    } catch (t: Throwable) {
+        DiagLog.e(TAG, "Off-screen widget chart render failed", t)
+        null
     } finally {
-        composeView.disposeComposition()
-        recomposer.cancel()
-        recomposeJob.cancel()
+        runCatching { presentation?.dismiss() }
+        runCatching { virtualDisplay?.release() }
+        runCatching { imageReader.close() }
         owner.destroy()
     }
 }
 
-// Cheap fingerprint of the rendered frame: XOR of a sparse pixel grid. Enough to
-// tell "still animating" from "settled" without hashing every pixel each frame.
+// Copies an RGBA_8888 ImageReader frame into an ARGB_8888 bitmap, handling the
+// reader's row padding (rowStride can exceed width * pixelStride).
+private fun Image.toBitmap(width: Int, height: Int): Bitmap {
+    val plane = planes[0]
+    val pixelStride = plane.pixelStride
+    val rowStride = plane.rowStride
+    val rowPadding = rowStride - pixelStride * width
+    val padded = Bitmap.createBitmap(
+        width + rowPadding / pixelStride,
+        height,
+        Bitmap.Config.ARGB_8888,
+    )
+    padded.copyPixelsFromBuffer(plane.buffer)
+    return if (rowPadding == 0) padded else Bitmap.createBitmap(padded, 0, 0, width, height)
+}
+
+// Coarse fingerprint of a frame (sparse pixel grid) — cheap "still changing vs
+// settled" check between samples.
 private fun Bitmap.coarseHash(): Int {
     var hash = 17
     val stepX = (width / 24).coerceAtLeast(1)
@@ -117,8 +174,26 @@ private fun Bitmap.coarseHash(): Int {
     return hash
 }
 
-// Minimal owner trio Compose requires to compose off a real window: a RESUMED
-// lifecycle, a restored SavedStateRegistry, and a ViewModelStore.
+// True when every sampled pixel matches the first — a fully transparent or
+// single-colour frame, i.e. nothing meaningful drew.
+private fun Bitmap.isBlank(): Boolean {
+    val first = getPixel(0, 0)
+    val stepX = (width / 16).coerceAtLeast(1)
+    val stepY = (height / 16).coerceAtLeast(1)
+    var y = 0
+    while (y < height) {
+        var x = 0
+        while (x < width) {
+            if (getPixel(x, y) != first) return false
+            x += stepX
+        }
+        y += stepY
+    }
+    return true
+}
+
+// Minimal owner trio Compose requires to host a composition in the Presentation
+// window: a RESUMED lifecycle, a restored SavedStateRegistry, a ViewModelStore.
 private class HeadlessOwner : SavedStateRegistryOwner, ViewModelStoreOwner {
     private val lifecycleRegistry = LifecycleRegistry(this)
     private val savedStateController = SavedStateRegistryController.create(this)

--- a/app/src/main/kotlin/app/clothescast/widget/FeelsLikeWidget.kt
+++ b/app/src/main/kotlin/app/clothescast/widget/FeelsLikeWidget.kt
@@ -204,29 +204,45 @@ private suspend fun buildChartBitmap(context: Context, weekly: Boolean): Bitmap?
     val darkTheme = resolveDarkTheme(context, prefs.themeMode)
     val palette = prefs.colorPalette
 
-    return runCatching {
-        withTimeoutOrNull(RENDER_TIMEOUT_MS) {
-            renderComposableToBitmap(context, RENDER_WIDTH_PX, RENDER_HEIGHT_PX) {
-                ClothesCastTheme(darkTheme = darkTheme, colorPalette = palette) {
-                    WidgetForecastChart(
-                        hourly = hourly,
-                        days = days,
-                        temperatureUnit = prefs.temperatureUnit,
-                        timeFormat = prefs.timeFormat,
-                        startDate = startDate,
-                        now = now,
-                    )
-                }
+    val bitmap = withTimeoutOrNull(RENDER_TIMEOUT_MS) {
+        renderComposableToBitmap(context, RENDER_WIDTH_PX, RENDER_HEIGHT_PX) {
+            ClothesCastTheme(darkTheme = darkTheme, colorPalette = palette) {
+                WidgetForecastChart(
+                    hourly = hourly,
+                    days = days,
+                    temperatureUnit = prefs.temperatureUnit,
+                    timeFormat = prefs.timeFormat,
+                    startDate = startDate,
+                    now = now,
+                )
             }
         }
-    }.getOrNull()
+    }
+    if (bitmap == null) {
+        DiagLog.w(
+            TAG,
+            "Chart bitmap null for ${if (weekly) "7-day" else "period"} widget " +
+                "(${hourly.size} hourly pts) — render failed/blank/timeout; showing empty state",
+        )
+    }
+    return bitmap
 }
 
 private suspend fun loadInsight(context: Context): Pair<Insight, UserPreferences>? {
     val app = context.applicationContext as ClothesCastApplication
-    val prefs = runCatching { app.settingsRepository.preferences.first() }.getOrNull() ?: return null
-    val snapshot = runCatching { app.insightCache.thisPeriod.first() }.getOrNull() ?: return null
-    val insight = runCatching { app.deriveInsight(snapshot, prefs).insight }.getOrNull() ?: return null
+    val prefs = runCatching { app.settingsRepository.preferences.first() }
+        .onFailure { DiagLog.w(TAG, "Widget: reading preferences failed", it) }
+        .getOrNull() ?: return null
+    val snapshot = runCatching { app.insightCache.thisPeriod.first() }
+        .onFailure { DiagLog.w(TAG, "Widget: reading cached snapshot failed", it) }
+        .getOrNull()
+    if (snapshot == null) {
+        DiagLog.i(TAG, "Widget: no cached forecast yet — showing empty state")
+        return null
+    }
+    val insight = runCatching { app.deriveInsight(snapshot, prefs).insight }
+        .onFailure { DiagLog.w(TAG, "Widget: deriveInsight failed", it) }
+        .getOrNull() ?: return null
     return insight to prefs
 }
 


### PR DESCRIPTION
## Problem

The feels-like widgets render empty on-device, with nothing in the log.

Two causes:
1. The off-screen chart render used an **unattached `ComposeView`** — which composes but never actually paints — so it produced a blank bitmap and the widget fell back to its empty state.
2. The failure was swallowed by `runCatching {}.getOrNull()`, so nothing was logged (also against the repo's "don't silently swallow exceptions" rule).

## Fix

Render into a **real window**: a `Presentation` on a `VirtualDisplay` backed by an `ImageReader`. That gives Compose a live window + frame clock, so `LaunchedEffect`s run, Vico loads its series, and the chart draws. We sample the `ImageReader` until the frame settles (Vico's async load + draw-in animation take a few frames), then copy it to a bitmap.

Every failure path now logs via `DiagLog` (tags `WidgetRender` / `Widget`): no cached forecast, `deriveInsight` failure, render exception, no frame produced, and a blank-frame guard — so a blank widget can't fail silently again.

This doesn't touch `WidgetForecastChart` or its snapshots — the chart's appearance is unchanged; this is purely the runtime rasterization path.

## Verification

- [x] `:app:testDebugUnitTest` + `:app:assembleDebug` — green
- [ ] **Needs on-device check** (can't be exercised by Robolectric — no real display/window). If it's still empty, the new `WidgetRender`/`Widget` logcat lines will pinpoint where (render exception vs blank frame vs no cached forecast) — please grab those and I'll fix precisely.

https://claude.ai/code/session_01HLC4RxAvLfBzEqJ1NbNSHn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HLC4RxAvLfBzEqJ1NbNSHn)_