### PR TITLE
Rethrow cancellation in the widget chart render

### DIFF
--- a/app/src/main/kotlin/app/clothescast/widget/ComposeRender.kt
+++ b/app/src/main/kotlin/app/clothescast/widget/ComposeRender.kt
@@ -25,6 +25,7 @@ import app.clothescast.diag.DiagLog
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
+import kotlin.coroutines.cancellation.CancellationException
 
 private const val TAG = "WidgetRender"
 
@@ -130,6 +131,11 @@ internal suspend fun renderComposableToBitmap(
         }
         result
     } catch (t: Throwable) {
+        // Don't convert a coroutine cancellation (e.g. WorkManager/Glance
+        // stopping the update while delay() is suspended) into a logged null —
+        // that breaks structured concurrency. Rethrow it before the blanket
+        // catch, per AGENTS.md's error-handling rule.
+        if (t is CancellationException) throw t
         DiagLog.e(TAG, "Off-screen widget chart render failed", t)
         null
     } finally {


### PR DESCRIPTION
## Problem

`renderComposableToBitmap`'s blanket `catch (t: Throwable)` swallows `CancellationException`. When the widget update coroutine is cancelled while the render is suspended in `delay()` (e.g. WorkManager/Glance stopping the update, or a future caller timeout), the cancellation gets converted into a logged null result and the caller continues — breaking structured concurrency. The repo's `AGENTS.md` error-handling rule explicitly calls out rethrowing `CancellationException` before blanket catches.

## Fix

Rethrow `CancellationException` at the top of the catch block before the diagnostic log + null fallback:

```kotlin
} catch (t: Throwable) {
    if (t is CancellationException) throw t
    DiagLog.e(TAG, "Off-screen widget chart render failed", t)
    null
}
```

(`kotlin.coroutines.cancellation.CancellationException`, which `kotlinx.coroutines.CancellationException` aliases, so `JobCancellationException` is covered.)

## Verification

- [x] `:app:compileDebugKotlin` — green; no behaviour change beyond propagating cancellation.

https://claude.ai/code/session_01HLC4RxAvLfBzEqJ1NbNSHn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HLC4RxAvLfBzEqJ1NbNSHn)_