### PR TITLE
docs: note that an unattached ComposeView renders blank

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -255,6 +255,16 @@ new rule the first time something bites you, not the third.
   which is JUnit 4. The bridge is `junit-vintage-engine` as `testRuntimeOnly`.
   If you see "no tests found" after adding a `@Test`-annotated JUnit 4
   class, check that `vintage-engine` is on the test classpath.
+- **An unattached `ComposeView` composes but never paints.** To rasterise a
+  composable to a `Bitmap` off-screen from a non-Activity context (e.g. a
+  Glance widget — Glance emits RemoteViews and can't host Compose/Vico), a
+  detached `ComposeView` with `setContent` + `measure`/`layout`/`draw` yields
+  a *blank* bitmap. It needs a real window: host the `ComposeView` in a
+  `Presentation` on a `VirtualDisplay` backed by an `ImageReader`, set the
+  ViewTree lifecycle / savedstate / viewmodel owners, `show()`, and sample the
+  reader until the frame settles — Vico (and any async content) draws a few
+  frames *after* first composition, so capturing too early misses the chart.
+  See `widget/ComposeRender.kt`; don't "simplify" it back to a detached view.
 
 ## Error handling
 


### PR DESCRIPTION
## Why

Capturing the gotcha that cost a device round-trip on the feels-like widget (#775): the first off-screen render used a detached `ComposeView`, which composes but never paints → blank bitmap → empty widget. A fresh session has no memory of that, and I demonstrably got it wrong on the first try, so it belongs in the guide ("add a rule the first time something bites you").

## Change

One bullet in the **Kotlin / Compose gotchas** section of `AGENTS.md` (symlinked to `CLAUDE.md`):

> An unattached `ComposeView` composes but never paints. To rasterise off-screen from a non-Activity context (e.g. a Glance widget) you need a real window — `Presentation` on a `VirtualDisplay` backed by an `ImageReader`, with the ViewTree owners set, sampling until the frame settles (Vico draws a few frames after first composition). See `widget/ComposeRender.kt`; don't simplify it back to a detached view.

Documents *why* `ComposeRender.kt` is shaped the way it is (so it doesn't get "simplified" back) and captures the Vico-settles-late timing.

Docs-only (`docs:` prefix + `.md`), so it's filtered out of the Play "What's new" changelog.

https://claude.ai/code/session_01HLC4RxAvLfBzEqJ1NbNSHn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HLC4RxAvLfBzEqJ1NbNSHn)_