### PR TITLE
Show the right top icon when the forecast calls for a t-shirt

### DIFF
--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/OutfitSuggestion.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/OutfitSuggestion.kt
@@ -11,7 +11,11 @@ import java.time.LocalTime
  * populate [Insight.recommendedItems]. Top tier (coldest first): a firing `jacket` rule
  * promotes to [Top.THICK_JACKET]; a firing `coat` rule promotes to [Top.THICK_COAT]; a
  * firing `sweater`/`hoodie` rule promotes to [Top.SWEATER]; a firing `polo` rule lands
- * on [Top.POLO]; otherwise the user's chosen `defaultTop` ([Top.TSHIRT] by default).
+ * on [Top.POLO]; a firing `t-shirt` rule lands on [Top.TSHIRT]; otherwise the user's
+ * chosen `defaultTop` ([Top.TSHIRT] by default). The explicit `t-shirt` tier keeps the
+ * icon in step with the prose — [EvaluateClothesRules] already treats a firing `t-shirt`
+ * rule as a matched top, so without it the bullet text would name a t-shirt while the
+ * icon fell through to whatever `defaultTop` the user picked (e.g. POLO).
  * Bottom tier: a firing `shorts` rule picks [Bottom.SHORTS]; `short-skirt` picks
  * [Bottom.SHORT_SKIRT]; `skirt` picks [Bottom.LONG_SKIRT]; `jeans` picks
  * [Bottom.JEANS]; otherwise the user's chosen
@@ -62,8 +66,10 @@ data class OutfitSuggestion(
         // Catalog item keys (see [Garment.itemKey]) that drive each icon tier.
         // Top tiers (coldest first): coat → THICK_COAT, puffer → PUFFER_JACKET,
         // jacket → THICK_JACKET, thin-jacket/sweater/hoodie → mid-layer, polo → POLO,
-        // fallback → user's chosen defaultTop (TSHIRT by default). Colder tiers
-        // are checked before warmer ones so that when multiple rules fire
+        // t-shirt → TSHIRT, fallback → user's chosen defaultTop (TSHIRT by default).
+        // (`shirt` has no icon tier yet, so a firing shirt rule still falls to
+        // the default — add a Top.SHIRT + drawable when the catalog grows one.)
+        // Colder tiers are checked before warmer ones so that when multiple rules fire
         // simultaneously (e.g. both coat ≤4°C and jacket ≤10°C fire at 3°C),
         // the heavier garment icon wins rather than the first match.
         // Bottom tiers: shorts → SHORTS, short-skirt → SHORT_SKIRT, skirt →
@@ -77,6 +83,7 @@ data class OutfitSuggestion(
         private val THIN_JACKET_KEYS = listOf("thin-jacket")
         private val SWEATER_KEYS = listOf("sweater", "hoodie")
         private val POLO_KEYS = listOf("polo")
+        private val TSHIRT_KEYS = listOf("t-shirt")
         private val SHORTS_KEYS = listOf("shorts")
         private val SHORT_SKIRT_KEYS = listOf("short-skirt")
         private val LONG_SKIRT_KEYS = listOf("skirt")
@@ -95,6 +102,7 @@ data class OutfitSuggestion(
                 clothesRules.firstFiring(forecast, THIN_JACKET_KEYS) != null -> Top.THIN_JACKET
                 clothesRules.firstFiring(forecast, SWEATER_KEYS) != null -> Top.SWEATER
                 clothesRules.firstFiring(forecast, POLO_KEYS) != null -> Top.POLO
+                clothesRules.firstFiring(forecast, TSHIRT_KEYS) != null -> Top.TSHIRT
                 else -> defaultTop
             }
             val bottom = when {
@@ -124,8 +132,8 @@ data class OutfitSuggestion(
             val coldestHour = forecast.hourly.minByOrNull { it.feelsLikeC }?.time
             val warmestHour = forecast.hourly.maxByOrNull { it.feelsLikeC }?.time
             return OutfitRationale(
-                top = GarmentReason(facts = listOf(topFact(forecast, clothesRules, coldestHour))),
-                bottom = GarmentReason(facts = listOf(bottomFact(forecast, clothesRules, warmestHour))),
+                top = GarmentReason(facts = listOf(topFact(forecast, clothesRules, coldestHour, warmestHour))),
+                bottom = GarmentReason(facts = listOf(bottomFact(forecast, clothesRules, coldestHour, warmestHour))),
             )
         }
 
@@ -133,53 +141,90 @@ data class OutfitSuggestion(
             forecast: DailyForecast,
             rules: List<ClothesRule>,
             coldestHour: LocalTime?,
+            warmestHour: LocalTime?,
         ): Fact {
+            // Only temperature rules can produce a fact — it needs a threshold
+            // and an observed temperature to compare against. A user may key any
+            // garment (a top included) off precipitation instead; such a rule
+            // can fire and drive the icon, but it has no temperature threshold,
+            // so exclude it from the rationale's deciding-rule search and fall
+            // through to the nearest temperature rule (or the catalog default)
+            // rather than crash in toFact.
+            val tempRules = rules.temperatureRules()
             // The deciding rule, in priority order across all top tiers. If no
             // cold rule fires (TSHIRT/POLO), cite the sweater threshold that
             // wasn't crossed so the rationale dialog still has something to show.
-            val rule = rules.firstFiring(forecast, THICK_COAT_KEYS)
-                ?: rules.firstFiring(forecast, PUFFER_JACKET_KEYS)
-                ?: rules.firstFiring(forecast, THICK_JACKET_KEYS)
-                ?: rules.firstFiring(forecast, THIN_JACKET_KEYS)
-                ?: rules.firstFiring(forecast, SWEATER_KEYS)
-                ?: rules.firstFiring(forecast, POLO_KEYS)
-                ?: rules.firstByKey(SWEATER_KEYS)
-                ?: rules.firstByKey(THIN_JACKET_KEYS)
-                ?: rules.firstByKey(THICK_JACKET_KEYS)
-                ?: rules.firstByKey(THICK_COAT_KEYS)
-                ?: rules.firstByKey(PUFFER_JACKET_KEYS)
+            val rule = tempRules.firstFiring(forecast, THICK_COAT_KEYS)
+                ?: tempRules.firstFiring(forecast, PUFFER_JACKET_KEYS)
+                ?: tempRules.firstFiring(forecast, THICK_JACKET_KEYS)
+                ?: tempRules.firstFiring(forecast, THIN_JACKET_KEYS)
+                ?: tempRules.firstFiring(forecast, SWEATER_KEYS)
+                ?: tempRules.firstFiring(forecast, POLO_KEYS)
+                ?: tempRules.firstFiring(forecast, TSHIRT_KEYS)
+                ?: tempRules.firstByKey(SWEATER_KEYS)
+                ?: tempRules.firstByKey(THIN_JACKET_KEYS)
+                ?: tempRules.firstByKey(THICK_JACKET_KEYS)
+                ?: tempRules.firstByKey(THICK_COAT_KEYS)
+                ?: tempRules.firstByKey(PUFFER_JACKET_KEYS)
                 ?: ClothesRule.DEFAULTS.first { it.item == "sweater" }
-            return rule.toMinFact(forecast, coldestHour)
+            return rule.toConditionFact(forecast, coldestHour, warmestHour)
         }
 
         private fun bottomFact(
             forecast: DailyForecast,
             rules: List<ClothesRule>,
+            coldestHour: LocalTime?,
             warmestHour: LocalTime?,
         ): Fact {
+            // Temperature rules only — a precipitation-keyed bottom rule can
+            // fire and drive the icon but has no threshold to explain, so skip
+            // it here (see [topFact]) rather than crash in toFact.
+            val tempRules = rules.temperatureRules()
             // The deciding rule across all bottom tiers. If no warm rule fires
             // (LONG_PANTS), cite the shorts threshold that wasn't crossed.
-            val rule = rules.firstFiring(forecast, SHORTS_KEYS)
-                ?: rules.firstFiring(forecast, SHORT_SKIRT_KEYS)
-                ?: rules.firstFiring(forecast, LONG_SKIRT_KEYS)
-                ?: rules.firstFiring(forecast, JEANS_KEYS)
-                ?: rules.firstByKey(SHORTS_KEYS)
-                ?: rules.firstByKey(SHORT_SKIRT_KEYS)
-                ?: rules.firstByKey(LONG_SKIRT_KEYS)
-                ?: rules.firstByKey(JEANS_KEYS)
+            val rule = tempRules.firstFiring(forecast, SHORTS_KEYS)
+                ?: tempRules.firstFiring(forecast, SHORT_SKIRT_KEYS)
+                ?: tempRules.firstFiring(forecast, LONG_SKIRT_KEYS)
+                ?: tempRules.firstFiring(forecast, JEANS_KEYS)
+                ?: tempRules.firstByKey(SHORTS_KEYS)
+                ?: tempRules.firstByKey(SHORT_SKIRT_KEYS)
+                ?: tempRules.firstByKey(LONG_SKIRT_KEYS)
+                ?: tempRules.firstByKey(JEANS_KEYS)
                 ?: ClothesRule.DEFAULTS.first { it.item == "shorts" }
-            return rule.toMaxFact(forecast, warmestHour)
+            return rule.toConditionFact(forecast, coldestHour, warmestHour)
         }
 
         private fun List<ClothesRule>.firstFiring(
             forecast: DailyForecast,
             keys: List<String>,
         ): ClothesRule? = keys.firstNotNullOfOrNull { key ->
-            firstOrNull { it.item == key && it.appliesTo(forecast) }
+            firstOrNull { it.matchesKey(key) && it.appliesTo(forecast) }
         }
 
         private fun List<ClothesRule>.firstByKey(keys: List<String>): ClothesRule? =
-            keys.firstNotNullOfOrNull { key -> firstOrNull { it.item == key } }
+            keys.firstNotNullOfOrNull { key -> firstOrNull { it.matchesKey(key) } }
+
+        /**
+         * Whether a rule names the catalog garment [key], canonicalised the
+         * same way the prose path canonicalises it. [Garment.fromKey] folds
+         * the supported legacy spellings and case / whitespace variants
+         * ("tshirt" / " T-Shirt " → t-shirt, "jumper" → sweater) onto their
+         * catalog [Garment.itemKey], so a stored legacy rule drives the icon
+         * tier it already drives in the bullets — matching on the raw
+         * `item` string would leave the icon on the default while the prose
+         * named the garment. Falls back to a trimmed, case-insensitive
+         * compare for items outside the catalog so nothing regresses.
+         */
+        private fun ClothesRule.matchesKey(key: String): Boolean {
+            Garment.fromKey(item)?.let { return it.itemKey == key }
+            return item.trim().equals(key, ignoreCase = true)
+        }
+
+        /** The rules with a Celsius threshold — i.e. those the rationale can
+         *  turn into a [Fact]. Drops precipitation-keyed rules, whose
+         *  [thresholdC] is null. */
+        private fun List<ClothesRule>.temperatureRules(): List<ClothesRule> =
+            filter { it.thresholdC() != null }
 
         private fun ClothesRule.toFact(
             metric: Fact.Metric,
@@ -207,6 +252,30 @@ data class OutfitSuggestion(
 
         private fun ClothesRule.toMaxFact(forecast: DailyForecast, observedAt: LocalTime?): Fact =
             toFact(Fact.Metric.FEELS_LIKE_MAX, forecast.feelsLikeMaxC, observedAt)
+
+        /**
+         * Builds the rationale [Fact] from the rule's *condition*, not its
+         * slot. A [ClothesRule.TemperatureAbove] rule fires on the day's high,
+         * so it compares against the feels-like max at the warmest hour; a
+         * [ClothesRule.TemperatureBelow] rule fires on the day's low, so it
+         * compares against the feels-like min at the coldest hour. This matters
+         * for warm base-layer tops (a `t-shirt`/`polo` rule configured as
+         * `> N°C` lives in the top slot but keys off the high): a slot-fixed
+         * metric would explain a firing warm top against the day's minimum and
+         * report its threshold as uncrossed even though it drove the icon — and
+         * the dialog's ±1° controls would attach to that misleading fact.
+         */
+        private fun ClothesRule.toConditionFact(
+            forecast: DailyForecast,
+            coldestHour: LocalTime?,
+            warmestHour: LocalTime?,
+        ): Fact = when (condition) {
+            is ClothesRule.TemperatureAbove -> toMaxFact(forecast, warmestHour)
+            // TemperatureBelow keys off the low; the precipitation case is
+            // unreachable here (toFact rejects non-temperature rules) but falls
+            // through to the low as a harmless default.
+            else -> toMinFact(forecast, coldestHour)
+        }
     }
 }
 

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/model/OutfitSuggestionTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/model/OutfitSuggestionTest.kt
@@ -13,13 +13,14 @@ class OutfitSuggestionTest {
         feelsLikeMin: Double,
         feelsLikeMax: Double,
         hourly: List<HourlyForecast> = emptyList(),
+        precipMaxPct: Double = 0.0,
     ): DailyForecast = DailyForecast(
         date = date,
         temperatureMinC = feelsLikeMin,
         temperatureMaxC = feelsLikeMax,
         feelsLikeMinC = feelsLikeMin,
         feelsLikeMaxC = feelsLikeMax,
-        precipitationProbabilityMaxPct = 0.0,
+        precipitationProbabilityMaxPct = precipMaxPct,
         precipitationMmTotal = 0.0,
         condition = WeatherCondition.CLEAR,
         hourly = hourly,
@@ -317,6 +318,117 @@ class OutfitSuggestionTest {
             defaultTop = OutfitSuggestion.Top.POLO,
         )
         outfit.top shouldBe OutfitSuggestion.Top.SWEATER
+    }
+
+    @Test
+    fun `firing t-shirt rule lands on TSHIRT even when defaultTop is POLO`() {
+        // Reproduces the field bug: a "t-shirt above 24°C" rule fires on a warm
+        // day, so the prose and recommended items name a t-shirt — but the icon
+        // picker had no t-shirt tier and fell through to the configured
+        // defaultTop (POLO), leaving the outfit card's icon contradicting its
+        // text ("Wear a t-shirt" next to a polo silhouette).
+        val rules = listOf(
+            ClothesRule("t-shirt", ClothesRule.TemperatureAbove(24.0)),
+            ClothesRule("shorts", ClothesRule.TemperatureAbove(24.0)),
+        )
+        val outfit = OutfitSuggestion.fromForecast(
+            forecast(feelsLikeMin = 17.9, feelsLikeMax = 27.9),
+            rules,
+            defaultTop = OutfitSuggestion.Top.POLO,
+        )
+        outfit.top shouldBe OutfitSuggestion.Top.TSHIRT
+        outfit.bottom shouldBe OutfitSuggestion.Bottom.SHORTS
+    }
+
+    @Test
+    fun `polo rule outranks t-shirt rule when both fire`() {
+        // Within the base layer the catalog ranks POLO ahead of TSHIRT, so when
+        // a user has both rules firing the polo wins — matching the prose's
+        // layer-reduction, which keeps the polo and drops the t-shirt.
+        val rules = listOf(
+            ClothesRule("t-shirt", ClothesRule.TemperatureAbove(24.0)),
+            ClothesRule("polo", ClothesRule.TemperatureAbove(24.0)),
+        )
+        val outfit = OutfitSuggestion.fromForecast(
+            forecast(feelsLikeMin = 17.9, feelsLikeMax = 27.9),
+            rules,
+        )
+        outfit.top shouldBe OutfitSuggestion.Top.POLO
+    }
+
+    @Test
+    fun `t-shirt rule drives the top rationale against the day's high`() {
+        // A warm "t-shirt above 24°C" rule lives in the top slot but keys off
+        // the day's high. The rationale must compare against the feels-like max
+        // at the warmest hour — not the min — or the sheet would show the
+        // threshold as uncrossed (18°C < 24°C) on a day the rule actually fired
+        // (max 28°C), and wire its ±1° controls to that misleading fact.
+        val hourly = listOf(hour(LocalTime.of(7, 0), 18.0), hour(LocalTime.of(15, 0), 28.0))
+        val rules = listOf(ClothesRule("t-shirt", ClothesRule.TemperatureAbove(24.0)))
+        val fact = OutfitSuggestion.explainFromForecast(
+            forecast(feelsLikeMin = 18.0, feelsLikeMax = 28.0, hourly = hourly),
+            rules,
+        ).top.facts.single()
+        fact.ruleItem shouldBe "t-shirt"
+        fact.metric shouldBe Fact.Metric.FEELS_LIKE_MAX
+        fact.observedC shouldBe 28.0
+        fact.observedAt shouldBe LocalTime.of(15, 0)
+        fact.thresholdC shouldBe 24.0
+        fact.comparison shouldBe Fact.Comparison.AT_OR_ABOVE
+    }
+
+    @Test
+    fun `legacy and variant t-shirt spellings still drive the TSHIRT icon`() {
+        // Garment.fromKey canonicalises "tshirt" and case / whitespace variants
+        // to TSHIRT, and the prose path relies on that. The icon picker must
+        // canonicalise the same way — otherwise a stored legacy rule fires for
+        // the bullets but the icon falls through to defaultTop (POLO), the very
+        // mismatch this change fixes.
+        listOf("tshirt", " T-Shirt ").forEach { spelling ->
+            val rules = listOf(ClothesRule(spelling, ClothesRule.TemperatureAbove(24.0)))
+            val outfit = OutfitSuggestion.fromForecast(
+                forecast(feelsLikeMin = 17.9, feelsLikeMax = 27.9),
+                rules,
+                defaultTop = OutfitSuggestion.Top.POLO,
+            )
+            outfit.top shouldBe OutfitSuggestion.Top.TSHIRT
+        }
+    }
+
+    @Test
+    fun `legacy jumper spelling drives the SWEATER icon`() {
+        // "jumper" canonicalises to SWEATER via Garment.fromKey; the icon tier
+        // matches on the canonical key, so the en-GB legacy spelling lands on
+        // the sweater silhouette rather than the default top.
+        val rules = listOf(ClothesRule("jumper", ClothesRule.TemperatureBelow(16.0)))
+        val outfit = OutfitSuggestion.fromForecast(
+            forecast(feelsLikeMin = 12.0, feelsLikeMax = 15.0),
+            rules,
+            defaultTop = OutfitSuggestion.Top.POLO,
+        )
+        outfit.top shouldBe OutfitSuggestion.Top.SWEATER
+    }
+
+    @Test
+    fun `precipitation-keyed t-shirt rule drives the icon without crashing the rationale`() {
+        // Settings lets a user key any garment — a top included — off
+        // precipitation. On a rainy day such a rule fires and drives the icon
+        // (TSHIRT here, beating the POLO default), but it carries no temperature
+        // threshold: the rationale must skip it and fall back to a temperature
+        // rule rather than throw in toFact.
+        val rules = listOf(ClothesRule("t-shirt", ClothesRule.PrecipitationProbabilityAbove(50.0)))
+        val rainy = forecast(feelsLikeMin = 12.0, feelsLikeMax = 20.0, precipMaxPct = 60.0)
+
+        OutfitSuggestion.fromForecast(
+            rainy,
+            rules,
+            defaultTop = OutfitSuggestion.Top.POLO,
+        ).top shouldBe OutfitSuggestion.Top.TSHIRT
+
+        val fact = OutfitSuggestion.explainFromForecast(rainy, rules).top.facts.single()
+        fact.ruleItem shouldBe "sweater"
+        fact.metric shouldBe Fact.Metric.FEELS_LIKE_MIN
+        fact.thresholdC shouldBe 16.0
     }
 
     @Test


### PR DESCRIPTION
## Problem

A field bug report showed the outfit-card icon disagreeing with the bullet text and prose. With a firing `t-shirt` rule (the reporter had `t-shirt above 24°C`, which fired on a warm day, max 27.9°C), the text read **"Wear a t-shirt and shorts"** and `recommendedItems` was `[t-shirt, shorts]`, but the **icon showed POLO + SHORTS**.

## Root cause

It is **not** a day/night period mix-up (one hypothesis worth ruling out): both `recommendedItems` and `outfit` are computed from the *same* `periodView.forecast` on adjacent lines in `DeriveInsight`, and the bottom slot agreed (SHORTS) — only the top diverged.

The two code paths that are supposed to agree had drifted on the top slot:

- `EvaluateClothesRules` (feeds `recommendedItems` + prose) treats a firing `t-shirt` rule as a matched **top**, so it names a t-shirt and suppresses the `defaultTop` fallback.
- `OutfitSuggestion.fromForecast` (feeds the icon) had tiers for coat / puffer / jacket / sweater / **polo** but **no `t-shirt` tier**, so a firing `t-shirt` rule was invisible to it and it fell through to the user's configured `defaultTop` (POLO).

## Fix

- Add an explicit `t-shirt` tier to the icon picker, slotted in BASE-layer priority order (**polo ahead of t-shirt**) to mirror the prose's `Garment.layerReduce`.
- Extend the rationale's deciding-rule chain (`topFact`) so the "Why this outfit?" sheet cites the `t-shirt` rule when it's the one that fired.
- **Match rules to tiers by canonical garment key** (`matchesKey` → `Garment.fromKey`), the same canonicalisation the prose path uses. The tiers compared `item` strings literally, so a stored legacy/variant spelling (`"tshirt"`, `" T-Shirt "`, `"jumper"`) fired for the bullets but left the icon on the default — the exact mismatch this PR targets. Falls back to a trimmed, case-insensitive compare for items outside the catalog. (Caught in review.)
- **Make the rationale metric condition-driven** (`toConditionFact`, top + bottom): a `TemperatureAbove` rule compares against the feels-like **max** at the warmest hour, a `TemperatureBelow` rule against the **min** at the coldest hour. Without this, a warm top rule (`t-shirt`/`polo` `> N°C`) was explained against the day's *low* and reported as uncrossed even though it drove the icon, with the ±1° controls attached to that misleading fact. (Caught in review; also covers a cold-configured bottom rule.)
- **Guard the rationale against non-temperature rules** (`temperatureRules()` filter): a precipitation-keyed garment rule can fire and drive the icon, but has no temperature threshold — the rationale skips it and falls through to the nearest temperature rule or the catalog default instead of throwing in `toFact` and breaking insight derivation on a rainy day. (Caught in review.)
- `shirt` still has no `Top` icon tier (no drawable yet); left a code comment for a follow-up that adds `Top.SHIRT` + the vector.

## Tests

Added regression tests in `OutfitSuggestionTest`:
- a firing `t-shirt` rule lands on `Top.TSHIRT` even when `defaultTop` is POLO (the reported scenario);
- a `polo` rule still outranks a `t-shirt` rule when both fire;
- legacy/variant spellings `tshirt` / `" T-Shirt "` → `Top.TSHIRT`, and en-GB `jumper` → `Top.SWEATER`, with `defaultTop = POLO`;
- the rationale for a firing `t-shirt > 24°C` rule reports `FEELS_LIKE_MAX` (28°C) at the warmest hour, AT_OR_ABOVE (min 18 / max 28);
- a precipitation-keyed `t-shirt` rule drives `Top.TSHIRT` on a rainy day while `explainFromForecast` returns a temperature-rule fact instead of throwing.

Validated locally: `:core:domain:test`, `:core:data:test`, and `:app:testDebugUnitTest` (Roborazzi snapshots included — no snapshots changed).

## Privacy

No change to what leaves the device.