### PR TITLE
Fix white corners on the feels-like widget chart in dark mode

### DIFF
--- a/app/src/main/kotlin/app/clothescast/widget/FeelsLikeWidget.kt
+++ b/app/src/main/kotlin/app/clothescast/widget/FeelsLikeWidget.kt
@@ -207,7 +207,7 @@ private suspend fun buildChartBitmap(context: Context, weekly: Boolean): Bitmap?
     val bitmap = withTimeoutOrNull(RENDER_TIMEOUT_MS) {
         renderComposableToBitmap(context, RENDER_WIDTH_PX, RENDER_HEIGHT_PX) {
             ClothesCastTheme(darkTheme = darkTheme, colorPalette = palette) {
-                WidgetForecastChart(
+                WidgetForecastChartCanvas(
                     hourly = hourly,
                     days = days,
                     temperatureUnit = prefs.temperatureUnit,

--- a/app/src/main/kotlin/app/clothescast/widget/FeelsLikeWidgetChart.kt
+++ b/app/src/main/kotlin/app/clothescast/widget/FeelsLikeWidgetChart.kt
@@ -1,9 +1,14 @@
 package app.clothescast.widget
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.ProvidedValue
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
 import app.clothescast.core.domain.model.DailyForecast
 import app.clothescast.core.domain.model.HourlyForecast
 import app.clothescast.core.domain.model.TemperatureUnit
@@ -88,6 +93,44 @@ internal fun WidgetForecastChart(
                 showLegend = false,
             )
         }
+    }
+}
+
+/**
+ * Runtime-only wrapper that paints the theme background behind
+ * [WidgetForecastChart] before it's rasterised to the widget bitmap.
+ *
+ * The off-screen [renderComposableToBitmap] hosts the chart in a `Presentation`
+ * window whose default background is light, so in dark mode that white bled
+ * through the card's rounded corners (and any letterbox around the card) in the
+ * captured bitmap — the gap the home-screen widget showed. Filling the render
+ * surface with `colorScheme.background` — the same surface the previews sit on
+ * via `WidgetFrame` — makes the corners match the app instead of flashing white.
+ *
+ * This lives apart from [WidgetForecastChart] (rather than wrapping it inline)
+ * so the snapshot previews, which already supply their own themed background and
+ * render at wrap-content height, stay untouched: `fillMaxSize` here fills the
+ * fixed render size at runtime but would balloon the bounded-height preview
+ * canvas with empty space.
+ */
+@Composable
+internal fun WidgetForecastChartCanvas(
+    hourly: List<HourlyForecast>,
+    days: List<DailyForecast>?,
+    temperatureUnit: TemperatureUnit,
+    timeFormat: TimeFormat,
+    startDate: LocalDate,
+    now: LocalDateTime?,
+) {
+    Box(modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.background)) {
+        WidgetForecastChart(
+            hourly = hourly,
+            days = days,
+            temperatureUnit = temperatureUnit,
+            timeFormat = timeFormat,
+            startDate = startDate,
+            now = now,
+        )
     }
 }
 


### PR DESCRIPTION
## Problem

In dark mode, the home-screen feels-like chart widget showed a white background bleeding through the chart card's rounded corners (visible in the reported screenshot).

## Cause

The widget chart is a bitmap rasterised off-screen by `renderComposableToBitmap`, which hosts the chart in a `Presentation` window. That window's default background is light. At runtime the rendered content was just `ClothesCastTheme { WidgetForecastChart(...) }` with no background of its own, so the window's white showed through the `Card`'s rounded corners (and any letterbox around the card) in the captured bitmap. The previews never reproduced it because `WidgetFrame` wraps them in a `Surface(color = colorScheme.background)`.

## Fix

Wrap the chart in a new runtime-only `WidgetForecastChartCanvas` that fills the render surface with `colorScheme.background` — the same themed surface the previews already sit on — so the corners match the app instead of flashing white.

The fill is deliberately kept out of the shared `WidgetForecastChart`: that composable is also driven by the Roborazzi snapshot previews, which render at wrap-content height with their own themed background. A `fillMaxSize` there balloons the bounded-height preview canvas with empty space, whereas at runtime it correctly fills the fixed 720×560 render size. Keeping it in a separate wrapper leaves the snapshots byte-for-byte unchanged.

## Testing

- `./gradlew :app:testDebugUnitTest` — pass (widget snapshots unchanged, confirming previews untouched)
- `./gradlew :app:assembleDebug` — pass

The off-screen render path can't be exercised by Robolectric (no real display/window), so the dark-mode appearance is verified on-device.

https://claude.ai/code/session_01KU29sum73J67jG7191Ec99

---
_Generated by [Claude Code](https://claude.ai/code/session_01KU29sum73J67jG7191Ec99)_