### PR TITLE
Clearer title on the scheduled-ClothesCasts promo card

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -385,7 +385,7 @@
          which requests notification permission when a slot is turned on.
          Auto-hides once either schedule switch is on, OR after the user
          X-dismisses. -->
-    <string name="today_schedule_promo_title">Automatic ClothesCasts</string>
+    <string name="today_schedule_promo_title">Set up automatic ClothesCasts</string>
     <string name="today_schedule_promo_body">Choose when you get notifications and announcements.</string>
     <string name="today_schedule_promo_cta">Schedule settings</string>
     <string name="today_schedule_promo_dismiss">Dismiss</string>


### PR DESCRIPTION
## What

Rephrase the Today-screen schedule promo card title:

- **Before:** "Automatic ClothesCasts"
- **After:** "Set up automatic ClothesCasts"

Reads as an action, consistent with the card's call-to-action intent (the card routes to Schedule settings).

## Scope

Single string-resource change in `app/src/main/res/values/strings.xml` (`today_schedule_promo_title`). The card composable already renders this via `stringResource(R.string.today_schedule_promo_title)` (`SchedulePromoCard.kt:77`), so no code change is needed.

## Snapshots

The `schedule_promo_card` Roborazzi snapshot renders this card, so its PNG will change with the new text. I left the regeneration to CI's snapshot-regen bot rather than committing a locally-rendered PNG (my sandbox renderer diverges from CI's). I'll post the before/after image diff inline once the regen commit lands.

## Privacy

No change to anything that leaves the device — UI label copy only.

## Test plan

- `./gradlew :app:testDebugUnitTest` (verifies/regenerates the promo snapshot)
- CI: JVM unit tests + Android debug build

---
_Generated by [Claude Code](https://claude.ai/code/session_01TwweQRzKaR3UvQSpku1j85)_