### PR TITLE
Translate the new schedule card, widgets, and settings into all locales

### DIFF
--- a/app/src/main/res/values-am/strings.xml
+++ b/app/src/main/res/values-am/strings.xml
@@ -150,6 +150,11 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="widget_description">የአሁኑ ወቅት ልብስ በፍጥነት ለማየት።</string>
     <string name="widget_empty_title">እስካሁን ልብስ የለም</string>
     <string name="widget_empty_subtitle">ClothesCastን ለመክፈት ይጫኑ</string>
+    <string name="feels_like_widget_label">የሚሰማ ሙቀት ቻርት</string>
+    <string name="feels_like_widget_description">የአሁኑ ወቅት የሚሰማ ሙቀት።</string>
+    <string name="feels_like_week_widget_label">የሚሰማ ሙቀት (7 ቀናት)</string>
+    <string name="feels_like_week_widget_description">በሚቀጥሉት 7 ቀናት ውስጥ የሚሰማ ሙቀት።</string>
+    <string name="feels_like_widget_empty_title">እስካሁን ትንበያ የለም</string>
 
     <!-- Onboarding -->
     <string name="onboarding_title">እንኳን ወደ ClothesCast መጡ</string>
@@ -895,6 +900,10 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="settings_schedule_enabled">ዕለታዊ ClothesCast</string>
     <string name="settings_delivery_notification">አሳውቅ</string>
     <string name="settings_delivery_tts">ተናገር</string>
+    <string name="speech_setup_title">በድምፅ የሚነበቡ ClothesCast ያዋቅሩ</string>
+    <string name="speech_setup_description">ClothesCast በድምፅ እንዴት እንደሚነበብ ይምረጡ። ነፃውን የመሳሪያ ድምፅ ይጠቀሙ፣ ወይም ለከፍተኛ ጥራት ድምፆች የGemini API ቁልፍ ያክሉ።</string>
+    <string name="speech_setup_smart_home_note">የስማርት ቤት ንግግር የGemini API ቁልፍ ይፈልጋል። ያለ እሱም ካስቲንግ አሁንም ልብስዎን ያሳያል።</string>
+    <string name="speech_setup_done">ተጠናቀቀ</string>
 
     <!-- Clothes-mention picker -->
     <string name="settings_clothes_mention_label">ልብስ</string>
@@ -924,6 +933,11 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="settings_format_rain_accessory_label">የዝናብ መለዋወጫ</string>
     <string name="settings_format_rain_accessory_none">ጠፍቷል</string>
     <string name="settings_format_rain_accessory_umbrella">ጃንጥላ</string>
+    <string name="settings_format_period_preamble_label">መግቢያ</string>
+    <string name="settings_format_wear_preamble_label">“ልበስ” መግቢያ</string>
+    <string name="settings_format_preamble_always">ሁልጊዜ</string>
+    <string name="settings_format_preamble_speech_only">በንግግር ብቻ</string>
+    <string name="settings_format_preamble_never">በፍፁም</string>
 
     <!-- Fallback clothes rules — "If no rules match" -->
     <string name="settings_default_outfit_title">ምንም ህግ ካልተዛመደ</string>
@@ -1160,6 +1174,10 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="today_clothes_promo_body">ClothesCast ከደንቦች ስብስብ ልብሶችን ይመርጣል። የሙቀት መጠኖችን አስተካክል እና በልብስ ቅንብር ውስጥ ልብስህን አበጅ።</string>
     <string name="today_clothes_promo_cta">የልብስ ቅንብር</string>
     <string name="today_clothes_promo_dismiss">ዝጋ</string>
+    <string name="today_schedule_promo_title">ራስ-ሰር ClothesCast</string>
+    <string name="today_schedule_promo_body">ማሳወቂያዎችንና ማስታወቂያዎችን መቼ እንደምታገኝ ምረጥ።</string>
+    <string name="today_schedule_promo_cta">የመርሐ ግብር ቅንብር</string>
+    <string name="today_schedule_promo_dismiss">ዝጋ</string>
     <string name="today_clothes_promo_title">ልብሶቹን የራስህ አድርግ</string>
     <string name="today_insight_format_link">ቅርጸት</string>
     <string name="today_play">አጫውት</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -146,6 +146,11 @@ they work correctly in both the single-band and range templates.
     <string name="widget_description">زي الفترة الحالية في لمحة.</string>
     <string name="widget_empty_title">لا يوجد زي بعد</string>
     <string name="widget_empty_subtitle">اضغط لفتح ClothesCast</string>
+    <string name="feels_like_widget_label">مخطط درجة الحرارة المحسوسة</string>
+    <string name="feels_like_widget_description">درجة الحرارة المحسوسة للفترة الحالية.</string>
+    <string name="feels_like_week_widget_label">درجة الحرارة المحسوسة (7 أيام)</string>
+    <string name="feels_like_week_widget_description">درجة الحرارة المحسوسة خلال الأيام السبعة القادمة.</string>
+    <string name="feels_like_widget_empty_title">لا توجد توقعات بعد</string>
 
     <!-- Today — forecast / temperature chart -->
     <string name="today_forecast_title">درجة الحرارة المحسوسة</string>
@@ -925,6 +930,10 @@ they work correctly in both the single-band and range templates.
     <string name="settings_schedule_enabled">ClothesCast اليومي</string>
     <string name="settings_delivery_notification">إشعار</string>
     <string name="settings_delivery_tts">قراءة</string>
+    <string name="speech_setup_title">إعداد عمليات ClothesCast المنطوقة</string>
+    <string name="speech_setup_description">اختر طريقة قراءة ClothesCast بصوت عالٍ. استخدم صوت الجهاز المجاني، أو أضِف مفتاح Gemini API للحصول على أصوات عالية الجودة.</string>
+    <string name="speech_setup_smart_home_note">يتطلب كلام المنزل الذكي مفتاح Gemini API. يعرض البث ملابسك بدونه أيضًا.</string>
+    <string name="speech_setup_done">تم</string>
 
     <!-- Clothes-mention picker on Format / Schedule -->
     <string name="settings_clothes_mention_label">الملابس</string>
@@ -954,6 +963,11 @@ they work correctly in both the single-band and range templates.
     <string name="settings_format_rain_accessory_label">إكسسوار المطر</string>
     <string name="settings_format_rain_accessory_none">إيقاف</string>
     <string name="settings_format_rain_accessory_umbrella">مظلة</string>
+    <string name="settings_format_period_preamble_label">المقدمة</string>
+    <string name="settings_format_wear_preamble_label">مقدمة "ارتدِ"</string>
+    <string name="settings_format_preamble_always">دائمًا</string>
+    <string name="settings_format_preamble_speech_only">في الكلام فقط</string>
+    <string name="settings_format_preamble_never">أبدًا</string>
 
     <!-- Fallback clothes rules — "If no rules match" -->
     <string name="settings_default_outfit_title">إذا لم تنطبق أي قاعدة</string>
@@ -1194,6 +1208,10 @@ they work correctly in both the single-band and range templates.
     <string name="today_clothes_promo_body">يختار ClothesCast الملابس بناءً على مجموعة قواعد. عدّل درجات الحرارة وخصّص خزانة ملابسك في إعدادات الملابس.</string>
     <string name="today_clothes_promo_cta">إعدادات الملابس</string>
     <string name="today_clothes_promo_dismiss">إغلاق</string>
+    <string name="today_schedule_promo_title">عمليات ClothesCast التلقائية</string>
+    <string name="today_schedule_promo_body">اختر متى تتلقى الإشعارات والإعلانات.</string>
+    <string name="today_schedule_promo_cta">إعدادات الجدول</string>
+    <string name="today_schedule_promo_dismiss">إغلاق</string>
     <string name="today_clothes_promo_title">اجعل الملابس ملكك</string>
     <string name="today_insight_format_link">التنسيق</string>
     <string name="today_play">تشغيل</string>

--- a/app/src/main/res/values-b+sr+Latn/strings.xml
+++ b/app/src/main/res/values-b+sr+Latn/strings.xml
@@ -466,6 +466,11 @@ default English (matching values-pl / values-uk).
     <string name="widget_description">Kombinacija za trenutni period na prvi pogled.</string>
     <string name="widget_empty_title">Još nema kombinacije</string>
     <string name="widget_empty_subtitle">Dodirni za otvaranje ClothesCasta</string>
+    <string name="feels_like_widget_label">Grafikon osećajne temperature</string>
+    <string name="feels_like_widget_description">Osećajna temperatura za trenutni period.</string>
+    <string name="feels_like_week_widget_label">Osećajna (7 dana)</string>
+    <string name="feels_like_week_widget_description">Osećajna temperatura za narednih 7 dana.</string>
+    <string name="feels_like_widget_empty_title">Još nema prognoze</string>
 
     <!-- Hourly forecast card. -->
     <string name="today_forecast_title">Prognoza po satu</string>
@@ -913,6 +918,10 @@ default English (matching values-pl / values-uk).
     <string name="settings_schedule_enabled">Dnevni ClothesCast</string>
     <string name="settings_delivery_notification">Obavesti</string>
     <string name="settings_delivery_tts">Pročitaj</string>
+    <string name="speech_setup_title">Podesi izgovorene ClothesCastove</string>
+    <string name="speech_setup_description">Izaberi kako se tvoj ClothesCast čita naglas. Koristi besplatni glas uređaja ili dodaj Gemini API ključ za glasove visokog kvaliteta.</string>
+    <string name="speech_setup_smart_home_note">Govor u pametnom domu zahteva Gemini API ključ. Emitovanje i bez njega prikazuje tvoju kombinaciju.</string>
+    <string name="speech_setup_done">Gotovo</string>
 
     <!-- Clothes-mention picker on Format / Schedule -->
     <string name="settings_clothes_mention_label">Odeća</string>
@@ -942,6 +951,11 @@ default English (matching values-pl / values-uk).
     <string name="settings_format_rain_accessory_label">Dodatak za kišu</string>
     <string name="settings_format_rain_accessory_none">Isključeno</string>
     <string name="settings_format_rain_accessory_umbrella">Kišobran</string>
+    <string name="settings_format_period_preamble_label">Uvod</string>
+    <string name="settings_format_wear_preamble_label">Uvod „Obuci"</string>
+    <string name="settings_format_preamble_always">Uvek</string>
+    <string name="settings_format_preamble_speech_only">Samo govor</string>
+    <string name="settings_format_preamble_never">Nikad</string>
 
     <!-- Fallback clothes rules — "If no rules match" section -->
     <string name="settings_default_outfit_title">Ako se nijedno pravilo ne podudara</string>
@@ -1179,6 +1193,10 @@ default English (matching values-pl / values-uk).
     <string name="today_clothes_promo_body">ClothesCast bira odeću po pravilima. Promeni temperature i prilagodi svoju garderobu u podešavanjima Odeća.</string>
     <string name="today_clothes_promo_cta">Podešavanja odeće</string>
     <string name="today_clothes_promo_dismiss">Odbaci</string>
+    <string name="today_schedule_promo_title">Automatski ClothesCastovi</string>
+    <string name="today_schedule_promo_body">Izaberi kada primaš obaveštenja i najave.</string>
+    <string name="today_schedule_promo_cta">Podešavanja rasporeda</string>
+    <string name="today_schedule_promo_dismiss">Odbaci</string>
     <string name="today_clothes_promo_title">Prilagodi odeću sebi</string>
     <string name="today_insight_format_link">Format</string>
     <string name="today_play">Pusti</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -154,6 +154,11 @@ What is NOT overridden, by design:
     <string name="widget_description">Тоалетът за текущия период с един поглед.</string>
     <string name="widget_empty_title">Все още няма тоалет</string>
     <string name="widget_empty_subtitle">Докосни, за да отвориш ClothesCast</string>
+    <string name="feels_like_widget_label">Графика на усещаната температура</string>
+    <string name="feels_like_widget_description">Усещаната температура за текущия период.</string>
+    <string name="feels_like_week_widget_label">Усещана температура (7 дни)</string>
+    <string name="feels_like_week_widget_description">Усещаната температура през следващите 7 дни.</string>
+    <string name="feels_like_widget_empty_title">Все още няма прогноза</string>
 
     <!-- Hourly forecast card. -->
     <string name="today_forecast_title">Почасова прогноза</string>
@@ -911,6 +916,10 @@ What is NOT overridden, by design:
     <string name="settings_schedule_enabled">Ежедневен ClothesCast</string>
     <string name="settings_delivery_notification">Известяване</string>
     <string name="settings_delivery_tts">Прочети</string>
+    <string name="speech_setup_title">Настрой изговарянето на ClothesCast</string>
+    <string name="speech_setup_description">Избери как твоят ClothesCast да се изговаря на глас. Използвай безплатния глас на устройството или добави ключ за API на Gemini за гласове с високо качество.</string>
+    <string name="speech_setup_smart_home_note">Изговарянето в умния дом изисква ключ за API на Gemini. Предаването пак показва тоалета ти и без него.</string>
+    <string name="speech_setup_done">Готово</string>
 
     <!-- Clothes-mention picker on Format / Schedule -->
     <string name="settings_clothes_mention_label">Облекло</string>
@@ -940,6 +949,11 @@ What is NOT overridden, by design:
     <string name="settings_format_rain_accessory_label">Аксесоар за дъжд</string>
     <string name="settings_format_rain_accessory_none">Изключено</string>
     <string name="settings_format_rain_accessory_umbrella">Чадър</string>
+    <string name="settings_format_period_preamble_label">Въведение</string>
+    <string name="settings_format_wear_preamble_label">Въведение „Облечи“</string>
+    <string name="settings_format_preamble_always">Винаги</string>
+    <string name="settings_format_preamble_speech_only">Само в речта</string>
+    <string name="settings_format_preamble_never">Никога</string>
 
     <!-- Fallback clothes rules — "If no rules match" section -->
     <string name="settings_default_outfit_title">Ако никое правило не съвпада</string>
@@ -1176,6 +1190,10 @@ What is NOT overridden, by design:
     <string name="today_clothes_promo_body">ClothesCast избира облекло по правила. Промени температурите и персонализирай гардероба си в настройките за Дрехи.</string>
     <string name="today_clothes_promo_cta">Настройки за дрехи</string>
     <string name="today_clothes_promo_dismiss">Затвори</string>
+    <string name="today_schedule_promo_title">Автоматични ClothesCast</string>
+    <string name="today_schedule_promo_body">Избери кога да получаваш известия и съобщения.</string>
+    <string name="today_schedule_promo_cta">Настройки на разписанието</string>
+    <string name="today_schedule_promo_dismiss">Затвори</string>
     <string name="today_clothes_promo_title">Направи дрехите свои</string>
     <string name="today_insight_format_link">Формат</string>
     <string name="today_play">Възпроизведи</string>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -222,6 +222,11 @@ West Bengal vocabulary differences in a future PR.
     <string name="widget_description">বর্তমান সময়কালের পোশাক এক নজরে।</string>
     <string name="widget_empty_title">এখনো কোনো পোশাক নেই</string>
     <string name="widget_empty_subtitle">ClothesCast খুলতে ট্যাপ করুন</string>
+    <string name="feels_like_widget_label">অনুভূত তাপমাত্রার চার্ট</string>
+    <string name="feels_like_widget_description">বর্তমান সময়কালের অনুভূত তাপমাত্রা।</string>
+    <string name="feels_like_week_widget_label">অনুভূত তাপমাত্রা (৭ দিন)</string>
+    <string name="feels_like_week_widget_description">আগামী ৭ দিনের অনুভূত তাপমাত্রা।</string>
+    <string name="feels_like_widget_empty_title">এখনো কোনো পূর্বাভাস নেই</string>
 
     <!-- ============================================================
          Onboarding
@@ -996,6 +1001,10 @@ West Bengal vocabulary differences in a future PR.
     <string name="settings_schedule_enabled">দৈনিক ClothesCast</string>
     <string name="settings_delivery_notification">জানান</string>
     <string name="settings_delivery_tts">পড়ুন</string>
+    <string name="speech_setup_title">কথ্য ClothesCast সেট আপ করুন</string>
+    <string name="speech_setup_description">আপনার ClothesCast কীভাবে পড়ে শোনানো হবে তা বেছে নিন। বিনামূল্যের ডিভাইস ভয়েস ব্যবহার করুন, অথবা উচ্চমানের ভয়েসের জন্য একটি Gemini API কী যোগ করুন।</string>
+    <string name="speech_setup_smart_home_note">স্মার্ট হোমে কথা বলার জন্য একটি Gemini API কী প্রয়োজন। এটি ছাড়াও কাস্টিং আপনার পোশাক দেখায়।</string>
+    <string name="speech_setup_done">সম্পন্ন</string>
 
     <!-- Clothes-mention picker -->
     <string name="settings_clothes_mention_label">পোশাক</string>
@@ -1025,6 +1034,11 @@ West Bengal vocabulary differences in a future PR.
     <string name="settings_format_rain_accessory_label">বৃষ্টির সরঞ্জাম</string>
     <string name="settings_format_rain_accessory_none">বন্ধ</string>
     <string name="settings_format_rain_accessory_umbrella">ছাতা</string>
+    <string name="settings_format_period_preamble_label">ভূমিকা</string>
+    <string name="settings_format_wear_preamble_label">“পরো” ভূমিকা</string>
+    <string name="settings_format_preamble_always">সবসময়</string>
+    <string name="settings_format_preamble_speech_only">শুধু কথায়</string>
+    <string name="settings_format_preamble_never">কখনো না</string>
 
     <!-- Fallback clothes rules — "If no rules match" -->
     <string name="settings_default_outfit_title">কোনো নিয়ম না মিললে</string>
@@ -1261,6 +1275,10 @@ West Bengal vocabulary differences in a future PR.
     <string name="today_clothes_promo_body">ClothesCast নিয়মের একটি সেট থেকে পোশাক বেছে নেয়। তাপমাত্রা পরিবর্তন করো এবং পোশাক সেটিংসে তোমার পোশাক কাস্টমাইজ করো।</string>
     <string name="today_clothes_promo_cta">পোশাক সেটিংস</string>
     <string name="today_clothes_promo_dismiss">বন্ধ</string>
+    <string name="today_schedule_promo_title">স্বয়ংক্রিয় ClothesCast</string>
+    <string name="today_schedule_promo_body">তুমি কখন বিজ্ঞপ্তি ও ঘোষণা পাবে তা বেছে নাও।</string>
+    <string name="today_schedule_promo_cta">সময়সূচি সেটিংস</string>
+    <string name="today_schedule_promo_dismiss">বন্ধ</string>
     <string name="today_clothes_promo_title">পোশাককে নিজের করো</string>
     <string name="today_insight_format_link">ফর্ম্যাট</string>
     <string name="today_play">চালাও</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -55,6 +55,11 @@ the in-app clock is digit-driven and reads consistently across locales.
     <string name="widget_description">El conjunt del moment, d\'un cop d\'ull.</string>
     <string name="widget_empty_title">Encara no hi ha conjunt</string>
     <string name="widget_empty_subtitle">Toca per obrir ClothesCast</string>
+    <string name="feels_like_widget_label">Gràfic de sensació</string>
+    <string name="feels_like_widget_description">La temperatura percebuda per al període actual.</string>
+    <string name="feels_like_week_widget_label">Sensació (7 dies)</string>
+    <string name="feels_like_week_widget_description">La temperatura percebuda durant els pròxims 7 dies.</string>
+    <string name="feels_like_widget_empty_title">Encara no hi ha previsió</string>
 
     <string name="today_forecast_title">Previsió per hores</string>
     <string name="today_forecast_min_max">Sensació %1$d – %2$d%3$s</string>
@@ -864,6 +869,10 @@ the in-app clock is digit-driven and reads consistently across locales.
     <string name="settings_schedule_enabled">ClothesCast diari</string>
     <string name="settings_delivery_notification">Notifica</string>
     <string name="settings_delivery_tts">Llegeix en veu alta</string>
+    <string name="speech_setup_title">Configura els ClothesCast parlats</string>
+    <string name="speech_setup_description">Tria com es llegeix en veu alta el teu ClothesCast. Fes servir la veu gratuïta del dispositiu, o afegeix una clau API de Gemini per a veus d\'alta qualitat.</string>
+    <string name="speech_setup_smart_home_note">La veu a la llar intel·ligent requereix una clau API de Gemini. L\'emissió mostra igualment el teu conjunt sense ella.</string>
+    <string name="speech_setup_done">Fet</string>
 
     <!-- Clothes-mention picker on Format / Schedule -->
     <string name="settings_clothes_mention_label">Roba</string>
@@ -893,6 +902,11 @@ the in-app clock is digit-driven and reads consistently across locales.
     <string name="settings_format_rain_accessory_label">Accessori per a la pluja</string>
     <string name="settings_format_rain_accessory_none">Desactivat</string>
     <string name="settings_format_rain_accessory_umbrella">Paraigua</string>
+    <string name="settings_format_period_preamble_label">Introducció</string>
+    <string name="settings_format_wear_preamble_label">Introducció «Posa\'t»</string>
+    <string name="settings_format_preamble_always">Sempre</string>
+    <string name="settings_format_preamble_speech_only">Només veu</string>
+    <string name="settings_format_preamble_never">Mai</string>
 
     <!-- Fallback clothes rules — "If no rules match" section -->
     <string name="settings_default_outfit_title">Si no coincideix cap regla</string>
@@ -1129,6 +1143,10 @@ the in-app clock is digit-driven and reads consistently across locales.
     <string name="today_clothes_promo_body">ClothesCast tria conjunts a partir d\'unes regles. Ajusta les temperatures i personalitza el teu vestuari a la configuració de Roba.</string>
     <string name="today_clothes_promo_cta">Configuració de Roba</string>
     <string name="today_clothes_promo_dismiss">Descarta</string>
+    <string name="today_schedule_promo_title">ClothesCast automàtics</string>
+    <string name="today_schedule_promo_body">Tria quan reps notificacions i anuncis.</string>
+    <string name="today_schedule_promo_cta">Configuració de la programació</string>
+    <string name="today_schedule_promo_dismiss">Descarta</string>
     <string name="today_clothes_promo_title">Fes teva la roba</string>
     <string name="today_insight_format_link">Format</string>
     <string name="today_play">Reprodueix</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -476,6 +476,11 @@ locale (Angličtina (USA), Francouzština (Francie), Němčina (Německo), …).
     <string name="widget_description">Outfit pro aktuální část dne na první pohled.</string>
     <string name="widget_empty_title">Zatím žádný outfit</string>
     <string name="widget_empty_subtitle">Klepni pro otevření ClothesCastu</string>
+    <string name="feels_like_widget_label">Graf pocitové teploty</string>
+    <string name="feels_like_widget_description">Pocitová teplota pro aktuální období.</string>
+    <string name="feels_like_week_widget_label">Pocitová (7 dní)</string>
+    <string name="feels_like_week_widget_description">Pocitová teplota na příštích 7 dní.</string>
+    <string name="feels_like_widget_empty_title">Zatím žádná předpověď</string>
 
     <!-- Onboarding. -->
     <string name="onboarding_title">Vítej v ClothesCastu</string>
@@ -932,6 +937,10 @@ locale (Angličtina (USA), Francouzština (Francie), Němčina (Německo), …).
     <string name="settings_schedule_enabled">Denní ClothesCast</string>
     <string name="settings_delivery_notification">Oznámit</string>
     <string name="settings_delivery_tts">Přečíst</string>
+    <string name="speech_setup_title">Nastav mluvené ClothesCasty</string>
+    <string name="speech_setup_description">Vyber, jak se tvůj ClothesCast čte nahlas. Použij bezplatný hlas zařízení, nebo přidej Gemini API klíč pro hlasy ve vysoké kvalitě.</string>
+    <string name="speech_setup_smart_home_note">Mluvený výstup v chytré domácnosti vyžaduje Gemini API klíč. Casting tvůj outfit ukáže i bez něj.</string>
+    <string name="speech_setup_done">Hotovo</string>
 
     <!-- Clothes-mention picker on Format / Schedule -->
     <string name="settings_clothes_mention_label">Oblečení</string>
@@ -961,6 +970,11 @@ locale (Angličtina (USA), Francouzština (Francie), Němčina (Německo), …).
     <string name="settings_format_rain_accessory_label">Doplněk pro déšť</string>
     <string name="settings_format_rain_accessory_none">Vypnuto</string>
     <string name="settings_format_rain_accessory_umbrella">Deštník</string>
+    <string name="settings_format_period_preamble_label">Úvod</string>
+    <string name="settings_format_wear_preamble_label">Úvod „Obleč si"</string>
+    <string name="settings_format_preamble_always">Vždy</string>
+    <string name="settings_format_preamble_speech_only">Jen mluvené</string>
+    <string name="settings_format_preamble_never">Nikdy</string>
 
     <!-- Fallback clothes rules — "If no rules match" section -->
     <string name="settings_default_outfit_title">Pokud žádná pravidla neodpovídají</string>
@@ -1199,6 +1213,10 @@ locale (Angličtina (USA), Francouzština (Francie), Němčina (Německo), …).
     <string name="today_clothes_promo_body">ClothesCast vybírá outfity podle sady pravidel. Uprav teploty a přizpůsob si šatník v nastavení Oblečení.</string>
     <string name="today_clothes_promo_cta">Nastavení oblečení</string>
     <string name="today_clothes_promo_dismiss">Zavřít</string>
+    <string name="today_schedule_promo_title">Automatické ClothesCasty</string>
+    <string name="today_schedule_promo_body">Vyber, kdy dostáváš oznámení a hlášení.</string>
+    <string name="today_schedule_promo_cta">Nastavení plánu</string>
+    <string name="today_schedule_promo_dismiss">Zavřít</string>
     <string name="today_clothes_promo_title">Přizpůsob si oblečení</string>
     <string name="today_insight_format_link">Formát</string>
     <string name="today_play">Přehrát</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -477,6 +477,11 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrig)").
     <string name="widget_description">Et hurtigt blik på outfittet for den aktuelle del af dagen.</string>
     <string name="widget_empty_title">Intet outfit endnu</string>
     <string name="widget_empty_subtitle">Tryk for at åbne ClothesCast</string>
+    <string name="feels_like_widget_label">Diagram over følt temperatur</string>
+    <string name="feels_like_widget_description">Den følte temperatur for den aktuelle periode.</string>
+    <string name="feels_like_week_widget_label">Følt temperatur (7 dage)</string>
+    <string name="feels_like_week_widget_description">Den følte temperatur over de næste 7 dage.</string>
+    <string name="feels_like_widget_empty_title">Ingen prognose endnu</string>
 
     <!-- Onboarding. -->
     <string name="onboarding_title">Velkommen til ClothesCast</string>
@@ -954,6 +959,10 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrig)").
     <string name="settings_schedule_enabled">Dagligt ClothesCast</string>
     <string name="settings_delivery_notification">Underret</string>
     <string name="settings_delivery_tts">Læs op</string>
+    <string name="speech_setup_title">Konfigurer talte ClothesCasts</string>
+    <string name="speech_setup_description">Vælg, hvordan dit ClothesCast læses op. Brug den gratis enhedsstemme, eller tilføj en Gemini-API-nøgle for stemmer i høj kvalitet.</string>
+    <string name="speech_setup_smart_home_note">Tale i smart home kræver en Gemini-API-nøgle. Casting viser stadig dit outfit uden den.</string>
+    <string name="speech_setup_done">Færdig</string>
 
     <!-- Clothes-mention picker on Format / Schedule -->
     <string name="settings_clothes_mention_label">Tøj</string>
@@ -983,6 +992,11 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrig)").
     <string name="settings_format_rain_accessory_label">Regntilbehør</string>
     <string name="settings_format_rain_accessory_none">Fra</string>
     <string name="settings_format_rain_accessory_umbrella">Paraply</string>
+    <string name="settings_format_period_preamble_label">Indledning</string>
+    <string name="settings_format_wear_preamble_label">\"Tag på\"-indledning</string>
+    <string name="settings_format_preamble_always">Altid</string>
+    <string name="settings_format_preamble_speech_only">Kun tale</string>
+    <string name="settings_format_preamble_never">Aldrig</string>
 
     <!-- Fallback clothes rules — "If no rules match" section -->
     <string name="settings_default_outfit_title">Hvis ingen regler passer</string>
@@ -1219,6 +1233,10 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrig)").
     <string name="today_clothes_promo_body">ClothesCast vælger outfits ud fra et sæt regler. Juster temperaturerne og tilpas din garderobe i tøjindstillingerne.</string>
     <string name="today_clothes_promo_cta">Tøjindstillinger</string>
     <string name="today_clothes_promo_dismiss">Afvis</string>
+    <string name="today_schedule_promo_title">Automatiske ClothesCasts</string>
+    <string name="today_schedule_promo_body">Vælg, hvornår du får notifikationer og oplæsninger.</string>
+    <string name="today_schedule_promo_cta">Tidsplanindstillinger</string>
+    <string name="today_schedule_promo_dismiss">Afvis</string>
     <string name="today_clothes_promo_title">Gør tøjet til dit eget</string>
     <string name="today_insight_format_link">Format</string>
     <string name="today_play">Afspil</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -389,6 +389,11 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="widget_description">Das Outfit für den aktuellen Tagesabschnitt auf einen Blick.</string>
     <string name="widget_empty_title">Noch kein Outfit</string>
     <string name="widget_empty_subtitle">Tippe, um ClothesCast zu öffnen</string>
+    <string name="feels_like_widget_label">Gefühlte-Temperatur-Diagramm</string>
+    <string name="feels_like_widget_description">Die gefühlte Temperatur für den aktuellen Zeitraum.</string>
+    <string name="feels_like_week_widget_label">Gefühlte Temperatur (7 Tage)</string>
+    <string name="feels_like_week_widget_description">Die gefühlte Temperatur für die nächsten 7 Tage.</string>
+    <string name="feels_like_widget_empty_title">Noch keine Vorhersage</string>
 
     <!--
     Onboarding flow — first-run welcome, two permission steps (notifications
@@ -1080,6 +1085,10 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_schedule_enabled">Täglicher ClothesCast</string>
     <string name="settings_delivery_notification">Benachrichtigen</string>
     <string name="settings_delivery_tts">Sprechen</string>
+    <string name="speech_setup_title">Gesprochene ClothesCasts einrichten</string>
+    <string name="speech_setup_description">Wähle, wie dein ClothesCast vorgelesen wird. Nutze die kostenlose Gerätestimme oder füge einen Gemini-API-Schlüssel für hochwertige Stimmen hinzu.</string>
+    <string name="speech_setup_smart_home_note">Sprache im Smart Home benötigt einen Gemini-API-Schlüssel. Das Übertragen zeigt dein Outfit auch ohne ihn.</string>
+    <string name="speech_setup_done">Fertig</string>
 
     <!-- Clothes-mention picker on Format / Schedule -->
     <string name="settings_clothes_mention_label">Kleidung</string>
@@ -1109,6 +1118,11 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_format_rain_accessory_label">Regenutensil</string>
     <string name="settings_format_rain_accessory_none">Aus</string>
     <string name="settings_format_rain_accessory_umbrella">Regenschirm</string>
+    <string name="settings_format_period_preamble_label">Einleitung</string>
+    <string name="settings_format_wear_preamble_label">„Tragen“-Einleitung</string>
+    <string name="settings_format_preamble_always">Immer</string>
+    <string name="settings_format_preamble_speech_only">Nur gesprochen</string>
+    <string name="settings_format_preamble_never">Nie</string>
 
     <!-- Fallback clothes rules — "If no rules match" section -->
     <string name="settings_default_outfit_title">Wenn keine Regel passt</string>
@@ -1341,6 +1355,10 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="today_clothes_promo_body">ClothesCast wählt Outfits anhand von Regeln aus. Passe die Temperaturen und deine Garderobe in den Kleidungseinstellungen an.</string>
     <string name="today_clothes_promo_cta">Kleidungseinstellungen</string>
     <string name="today_clothes_promo_dismiss">Schließen</string>
+    <string name="today_schedule_promo_title">Automatische ClothesCasts</string>
+    <string name="today_schedule_promo_body">Wähle, wann du Benachrichtigungen und Ansagen erhältst.</string>
+    <string name="today_schedule_promo_cta">Zeitplan-Einstellungen</string>
+    <string name="today_schedule_promo_dismiss">Schließen</string>
     <string name="today_clothes_promo_title">Mach die Kleidung zu deiner</string>
     <string name="today_insight_format_link">Format</string>
     <string name="today_play">Abspielen</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -439,6 +439,11 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="widget_description">Το σύνολο της τρέχουσας περιόδου με μια ματιά.</string>
     <string name="widget_empty_title">Δεν υπάρχει ακόμη σύνολο</string>
     <string name="widget_empty_subtitle">Πάτησε για άνοιγμα του ClothesCast</string>
+    <string name="feels_like_widget_label">Γράφημα αισθητής θερμοκρασίας</string>
+    <string name="feels_like_widget_description">Η αισθητή θερμοκρασία για την τρέχουσα περίοδο.</string>
+    <string name="feels_like_week_widget_label">Αισθητή θερμοκρασία (7 ημέρες)</string>
+    <string name="feels_like_week_widget_description">Η αισθητή θερμοκρασία για τις επόμενες 7 ημέρες.</string>
+    <string name="feels_like_widget_empty_title">Δεν υπάρχει ακόμη πρόβλεψη</string>
 
     <!--
     Onboarding flow — first-run welcome, two permission steps (notifs +
@@ -1046,6 +1051,10 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_schedule_enabled">Καθημερινό ClothesCast</string>
     <string name="settings_delivery_notification">Ειδοποίηση</string>
     <string name="settings_delivery_tts">Εκφώνηση</string>
+    <string name="speech_setup_title">Ρύθμιση εκφωνούμενων ClothesCast</string>
+    <string name="speech_setup_description">Επίλεξε πώς εκφωνείται ο ClothesCast σου. Χρησιμοποίησε τη δωρεάν φωνή της συσκευής ή πρόσθεσε ένα Gemini API key για φωνές υψηλής ποιότητας.</string>
+    <string name="speech_setup_smart_home_note">Η εκφώνηση στο έξυπνο σπίτι απαιτεί Gemini API key. Η μετάδοση δείχνει το σύνολό σου ακόμη και χωρίς αυτό.</string>
+    <string name="speech_setup_done">Έγινε</string>
 
     <!-- Clothes-mention picker on Format / Schedule -->
     <string name="settings_clothes_mention_label">Ρούχα</string>
@@ -1075,6 +1084,11 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_format_rain_accessory_label">Αξεσουάρ για βροχή</string>
     <string name="settings_format_rain_accessory_none">Ανενεργό</string>
     <string name="settings_format_rain_accessory_umbrella">Ομπρέλα</string>
+    <string name="settings_format_period_preamble_label">Εισαγωγή</string>
+    <string name="settings_format_wear_preamble_label">Εισαγωγή «Φόρεσε»</string>
+    <string name="settings_format_preamble_always">Πάντα</string>
+    <string name="settings_format_preamble_speech_only">Μόνο εκφώνηση</string>
+    <string name="settings_format_preamble_never">Ποτέ</string>
 
     <!-- Fallback clothes rules — "If no rules match" section -->
     <string name="settings_default_outfit_title">Αν δεν ταιριάζει κανένας κανόνας</string>
@@ -1311,6 +1325,10 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="today_clothes_promo_body">Το ClothesCast επιλέγει ρούχα με βάση κανόνες. Άλλαξε τις θερμοκρασίες και προσάρμοσε την γκαρνταρόμπα σου στις ρυθμίσεις Ρούχων.</string>
     <string name="today_clothes_promo_cta">Ρυθμίσεις Ρούχων</string>
     <string name="today_clothes_promo_dismiss">Απόρριψη</string>
+    <string name="today_schedule_promo_title">Αυτόματα ClothesCast</string>
+    <string name="today_schedule_promo_body">Επίλεξε πότε λαμβάνεις ειδοποιήσεις και ανακοινώσεις.</string>
+    <string name="today_schedule_promo_cta">Ρυθμίσεις προγράμματος</string>
+    <string name="today_schedule_promo_dismiss">Απόρριψη</string>
     <string name="today_clothes_promo_title">Κάνε τα ρούχα δικά σου</string>
     <string name="today_insight_format_link">Μορφή</string>
     <string name="today_play">Αναπαραγωγή</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -384,6 +384,11 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="widget_description">El outfit del periodo actual de un vistazo.</string>
     <string name="widget_empty_title">Aún no hay outfit</string>
     <string name="widget_empty_subtitle">Toca para abrir ClothesCast</string>
+    <string name="feels_like_widget_label">Gráfico de sensación térmica</string>
+    <string name="feels_like_widget_description">La sensación térmica para el periodo actual.</string>
+    <string name="feels_like_week_widget_label">Sensación térmica (7 días)</string>
+    <string name="feels_like_week_widget_description">La sensación térmica durante los próximos 7 días.</string>
+    <string name="feels_like_widget_empty_title">Aún no hay previsión</string>
 
     <!--
     Onboarding flow — first-run welcome, two permission steps, Gemini
@@ -1052,6 +1057,10 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_schedule_enabled">ClothesCast diario</string>
     <string name="settings_delivery_notification">Notificar</string>
     <string name="settings_delivery_tts">Leer en voz alta</string>
+    <string name="speech_setup_title">Configurar ClothesCasts en voz alta</string>
+    <string name="speech_setup_description">Elige cómo se lee en voz alta tu ClothesCast. Usa la voz gratuita del dispositivo o añade una clave API de Gemini para voces de alta calidad.</string>
+    <string name="speech_setup_smart_home_note">La voz en el hogar inteligente requiere una clave API de Gemini. La emisión sigue mostrando tu conjunto sin ella.</string>
+    <string name="speech_setup_done">Hecho</string>
 
     <!-- Clothes-mention picker on Format / Schedule -->
     <string name="settings_clothes_mention_label">Ropa</string>
@@ -1081,6 +1090,11 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_format_rain_accessory_label">Accesorio para lluvia</string>
     <string name="settings_format_rain_accessory_none">Desactivado</string>
     <string name="settings_format_rain_accessory_umbrella">Paraguas</string>
+    <string name="settings_format_period_preamble_label">Introducción</string>
+    <string name="settings_format_wear_preamble_label">Introducción „Lleva“</string>
+    <string name="settings_format_preamble_always">Siempre</string>
+    <string name="settings_format_preamble_speech_only">Solo voz</string>
+    <string name="settings_format_preamble_never">Nunca</string>
 
     <!-- Fallback clothes rules — "If no rules match" section -->
     <string name="settings_default_outfit_title">Si no coincide ninguna regla</string>
@@ -1317,6 +1331,10 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="today_clothes_promo_body">ClothesCast elige los conjuntos a partir de un conjunto de reglas. Ajusta las temperaturas y personaliza tu armario en los ajustes de Ropa.</string>
     <string name="today_clothes_promo_cta">Ajustes de Ropa</string>
     <string name="today_clothes_promo_dismiss">Descartar</string>
+    <string name="today_schedule_promo_title">ClothesCasts automáticos</string>
+    <string name="today_schedule_promo_body">Elige cuándo recibes notificaciones y anuncios.</string>
+    <string name="today_schedule_promo_cta">Ajustes de programación</string>
+    <string name="today_schedule_promo_dismiss">Descartar</string>
     <string name="today_clothes_promo_title">Haz tuya la ropa</string>
     <string name="today_insight_format_link">Formato</string>
     <string name="today_play">Reproducir</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -55,6 +55,11 @@ Tone is informal "sina"-form throughout ("Pane … selga", "Võta … kaasa",
     <string name="widget_description">Praeguse perioodi riietus ühel pilgul.</string>
     <string name="widget_empty_title">Riietust veel pole</string>
     <string name="widget_empty_subtitle">Puuduta, et avada ClothesCast</string>
+    <string name="feels_like_widget_label">Tunnetatava temperatuuri graafik</string>
+    <string name="feels_like_widget_description">Tunnetatav temperatuur praeguseks perioodiks.</string>
+    <string name="feels_like_week_widget_label">Tunnetatav temperatuur (7 päeva)</string>
+    <string name="feels_like_week_widget_description">Tunnetatav temperatuur järgmise 7 päeva jooksul.</string>
+    <string name="feels_like_widget_empty_title">Prognoosi veel pole</string>
 
     <string name="today_forecast_title">Tunnipõhine ilmaprognoos</string>
     <string name="today_forecast_min_max">Tundub %1$d – %2$d%3$s</string>
@@ -868,6 +873,10 @@ Tone is informal "sina"-form throughout ("Pane … selga", "Võta … kaasa",
     <string name="settings_schedule_enabled">Igapäevane ClothesCast</string>
     <string name="settings_delivery_notification">Teavita</string>
     <string name="settings_delivery_tts">Loe ette</string>
+    <string name="speech_setup_title">Seadista räägitavad ClothesCastid</string>
+    <string name="speech_setup_description">Vali, kuidas su ClothesCast ette loetakse. Kasuta tasuta seadme häält või lisa kõrge kvaliteediga häälte jaoks Gemini API võti.</string>
+    <string name="speech_setup_smart_home_note">Kõne nutikodus nõuab Gemini API võtit. Ülekanne näitab su riietust ka ilma selleta.</string>
+    <string name="speech_setup_done">Valmis</string>
 
     <!-- Clothes-mention picker on Format / Schedule -->
     <string name="settings_clothes_mention_label">Riided</string>
@@ -897,6 +906,11 @@ Tone is informal "sina"-form throughout ("Pane … selga", "Võta … kaasa",
     <string name="settings_format_rain_accessory_label">Vihmatarvik</string>
     <string name="settings_format_rain_accessory_none">Väljas</string>
     <string name="settings_format_rain_accessory_umbrella">Vihmavari</string>
+    <string name="settings_format_period_preamble_label">Sissejuhatus</string>
+    <string name="settings_format_wear_preamble_label">„Pane selga“ sissejuhatus</string>
+    <string name="settings_format_preamble_always">Alati</string>
+    <string name="settings_format_preamble_speech_only">Ainult kõnes</string>
+    <string name="settings_format_preamble_never">Mitte kunagi</string>
 
     <!-- Fallback clothes rules — "If no rules match" section -->
     <string name="settings_default_outfit_title">Kui ükski reegel ei sobi</string>
@@ -1133,6 +1147,10 @@ Tone is informal "sina"-form throughout ("Pane … selga", "Võta … kaasa",
     <string name="today_clothes_promo_body">ClothesCast valib riided reeglite järgi. Muuda temperatuure ja kohanda oma garderoobi Riiete seadetes.</string>
     <string name="today_clothes_promo_cta">Riiete seaded</string>
     <string name="today_clothes_promo_dismiss">Sulge</string>
+    <string name="today_schedule_promo_title">Automaatsed ClothesCastid</string>
+    <string name="today_schedule_promo_body">Vali, millal saad teavitusi ja teadaandeid.</string>
+    <string name="today_schedule_promo_cta">Ajakava seaded</string>
+    <string name="today_schedule_promo_dismiss">Sulge</string>
     <string name="today_clothes_promo_title">Tee riided enda omaks</string>
     <string name="today_insight_format_link">Vorming</string>
     <string name="today_play">Esita</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -146,6 +146,11 @@ Western Arabic numerals (0-9) are used for TTS compatibility.
     <string name="widget_description">لباس دوره جاری در یک نگاه.</string>
     <string name="widget_empty_title">هنوز لباسی نیست</string>
     <string name="widget_empty_subtitle">برای باز کردن ClothesCast ضربه بزنید</string>
+    <string name="feels_like_widget_label">نمودار دمای احساس‌شده</string>
+    <string name="feels_like_widget_description">دمای احساس‌شده برای بازه فعلی.</string>
+    <string name="feels_like_week_widget_label">دمای احساس‌شده (7 روز)</string>
+    <string name="feels_like_week_widget_description">دمای احساس‌شده طی 7 روز آینده.</string>
+    <string name="feels_like_widget_empty_title">هنوز پیش‌بینی‌ای نیست</string>
 
     <!-- Today — forecast charts -->
     <string name="today_forecast_title">دمای احساس‌شده</string>
@@ -916,6 +921,10 @@ Western Arabic numerals (0-9) are used for TTS compatibility.
     <string name="settings_schedule_enabled">ClothesCast روزانه</string>
     <string name="settings_delivery_notification">اعلان</string>
     <string name="settings_delivery_tts">خواندن</string>
+    <string name="speech_setup_title">راه‌اندازی ClothesCastهای گفتاری</string>
+    <string name="speech_setup_description">انتخاب کنید ClothesCast شما چگونه با صدای بلند خوانده شود. از صدای رایگان دستگاه استفاده کنید، یا برای صداهای باکیفیت یک کلید Gemini API اضافه کنید.</string>
+    <string name="speech_setup_smart_home_note">گفتار خانه هوشمند به یک کلید Gemini API نیاز دارد. ارسال تصویری حتی بدون آن هم لباس شما را نمایش می‌دهد.</string>
+    <string name="speech_setup_done">انجام شد</string>
 
     <!-- Clothes-mention picker on Format / Schedule -->
     <string name="settings_clothes_mention_label">لباس</string>
@@ -945,6 +954,11 @@ Western Arabic numerals (0-9) are used for TTS compatibility.
     <string name="settings_format_rain_accessory_label">لوازم باران</string>
     <string name="settings_format_rain_accessory_none">خاموش</string>
     <string name="settings_format_rain_accessory_umbrella">چتر</string>
+    <string name="settings_format_period_preamble_label">مقدمه</string>
+    <string name="settings_format_wear_preamble_label">مقدمه «بپوشید»</string>
+    <string name="settings_format_preamble_always">همیشه</string>
+    <string name="settings_format_preamble_speech_only">فقط در گفتار</string>
+    <string name="settings_format_preamble_never">هرگز</string>
 
     <!-- Fallback clothes rules — "If no rules match" -->
     <string name="settings_default_outfit_title">اگر هیچ قانونی مطابقت نداشت</string>
@@ -1181,6 +1195,10 @@ Western Arabic numerals (0-9) are used for TTS compatibility.
     <string name="today_clothes_promo_body">ClothesCast لباس‌ها را بر اساس قوانینی انتخاب می‌کند. در تنظیمات لباس، دماها را تنظیم کن و کمد لباست را شخصی‌سازی کن.</string>
     <string name="today_clothes_promo_cta">تنظیمات لباس</string>
     <string name="today_clothes_promo_dismiss">رد کردن</string>
+    <string name="today_schedule_promo_title">ClothesCastهای خودکار</string>
+    <string name="today_schedule_promo_body">انتخاب کنید چه زمانی اعلان‌ها و اعلام‌ها را دریافت کنید.</string>
+    <string name="today_schedule_promo_cta">تنظیمات برنامه</string>
+    <string name="today_schedule_promo_dismiss">رد کردن</string>
     <string name="today_clothes_promo_title">لباس را مال خودت کن</string>
     <string name="today_insight_format_link">قالب</string>
     <string name="today_play">پخش</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -312,6 +312,11 @@ displayed label localizes.
     <string name="widget_description">Tämän hetkisen päiväosan asu yhdellä silmäyksellä.</string>
     <string name="widget_empty_title">Ei asua vielä</string>
     <string name="widget_empty_subtitle">Napauta avataksesi ClothesCastin</string>
+    <string name="feels_like_widget_label">Tuntuvan lämpötilan kaavio</string>
+    <string name="feels_like_widget_description">Tuntuva lämpötila tälle ajanjaksolle.</string>
+    <string name="feels_like_week_widget_label">Tuntuva lämpötila (7 päivää)</string>
+    <string name="feels_like_week_widget_description">Tuntuva lämpötila seuraavan 7 päivän ajalle.</string>
+    <string name="feels_like_widget_empty_title">Ei ennustetta vielä</string>
 
     <string name="onboarding_title">Tervetuloa ClothesCastiin</string>
     <string name="onboarding_subtitle">Kaksi nopeaa valintaa ja olet valmis. Kaikella muulla on järkevä oletusarvo, jonka voit myöhemmin muuttaa asetuksissa.</string>
@@ -933,6 +938,10 @@ displayed label localizes.
     <string name="settings_schedule_enabled">Päivittäinen ClothesCast</string>
     <string name="settings_delivery_notification">Ilmoita</string>
     <string name="settings_delivery_tts">Lue ääneen</string>
+    <string name="speech_setup_title">Määritä puhutut ClothesCastit</string>
+    <string name="speech_setup_description">Valitse, miten ClothesCast luetaan ääneen. Käytä ilmaista laitteen ääntä tai lisää Gemini API -avain korkealaatuisia ääniä varten.</string>
+    <string name="speech_setup_smart_home_note">Älykodin puhe vaatii Gemini API -avaimen. Lähetys näyttää asusi silti ilman sitä.</string>
+    <string name="speech_setup_done">Valmis</string>
 
     <!-- Clothes-mention picker on Format / Schedule -->
     <string name="settings_clothes_mention_label">Vaatteet</string>
@@ -962,6 +971,11 @@ displayed label localizes.
     <string name="settings_format_rain_accessory_label">Sadeasuste</string>
     <string name="settings_format_rain_accessory_none">Pois</string>
     <string name="settings_format_rain_accessory_umbrella">Sateenvarjo</string>
+    <string name="settings_format_period_preamble_label">Aloitus</string>
+    <string name="settings_format_wear_preamble_label">”Pue”-aloitus</string>
+    <string name="settings_format_preamble_always">Aina</string>
+    <string name="settings_format_preamble_speech_only">Vain puhe</string>
+    <string name="settings_format_preamble_never">Ei koskaan</string>
 
     <!-- Fallback clothes rules — "If no rules match" section -->
     <string name="settings_default_outfit_title">Kun mikään sääntö ei sovi</string>
@@ -1198,6 +1212,10 @@ displayed label localizes.
     <string name="today_clothes_promo_body">ClothesCast valitsee asut sääntöjen perusteella. Säädä lämpötiloja ja mukauta vaatekaappiasi Vaatteet-asetuksissa.</string>
     <string name="today_clothes_promo_cta">Vaatteet-asetukset</string>
     <string name="today_clothes_promo_dismiss">Sulje</string>
+    <string name="today_schedule_promo_title">Automaattiset ClothesCastit</string>
+    <string name="today_schedule_promo_body">Valitse, milloin saat ilmoitukset ja kuulutukset.</string>
+    <string name="today_schedule_promo_cta">Aikataulun asetukset</string>
+    <string name="today_schedule_promo_dismiss">Sulje</string>
     <string name="today_clothes_promo_title">Tee vaatteista omasi</string>
     <string name="today_insight_format_link">Muoto</string>
     <string name="today_play">Toista</string>

--- a/app/src/main/res/values-fil/strings.xml
+++ b/app/src/main/res/values-fil/strings.xml
@@ -138,6 +138,11 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="widget_description">Ang outfit ng kasalukuyang panahon sa isang tingin.</string>
     <string name="widget_empty_title">Wala pang outfit</string>
     <string name="widget_empty_subtitle">I-tap para buksan ang ClothesCast</string>
+    <string name="feels_like_widget_label">Tsart ng nararamdamang temperatura</string>
+    <string name="feels_like_widget_description">Ang nararamdamang temperatura para sa kasalukuyang panahon.</string>
+    <string name="feels_like_week_widget_label">Nararamdamang temperatura (7 araw)</string>
+    <string name="feels_like_week_widget_description">Ang nararamdamang temperatura sa susunod na 7 araw.</string>
+    <string name="feels_like_widget_empty_title">Wala pang forecast</string>
 
     <!-- Forecast card -->
     <string name="today_forecast_title">Oras-orasang hula</string>
@@ -975,6 +980,10 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="settings_schedule_enabled">Pang-araw na ClothesCast</string>
     <string name="settings_delivery_notification">Mag-abiso</string>
     <string name="settings_delivery_tts">Bigkasin</string>
+    <string name="speech_setup_title">I-set up ang binibigkas na ClothesCast</string>
+    <string name="speech_setup_description">Piliin kung paano binibigkas nang malakas ang iyong ClothesCast. Gamitin ang libreng boses ng device, o magdagdag ng Gemini API key para sa mga de-kalidad na boses.</string>
+    <string name="speech_setup_smart_home_note">Kailangan ng Gemini API key ang pagbigkas sa smart home. Ipinapakita pa rin ng Cast ang iyong outfit kahit wala ito.</string>
+    <string name="speech_setup_done">Tapos na</string>
 
     <!-- Clothes-mention picker -->
     <string name="settings_clothes_mention_label">Damit</string>
@@ -1004,6 +1013,11 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="settings_format_rain_accessory_label">Aksesorya sa ulan</string>
     <string name="settings_format_rain_accessory_none">Naka-off</string>
     <string name="settings_format_rain_accessory_umbrella">Payong</string>
+    <string name="settings_format_period_preamble_label">Panimula</string>
+    <string name="settings_format_wear_preamble_label">Panimulang "Magsuot"</string>
+    <string name="settings_format_preamble_always">Palagi</string>
+    <string name="settings_format_preamble_speech_only">Pagsasalita lamang</string>
+    <string name="settings_format_preamble_never">Hindi kailanman</string>
 
     <!-- Fallback clothes rules — "If no rules match" -->
     <string name="settings_default_outfit_title">Kung walang panuntunang tumutugma</string>
@@ -1240,6 +1254,10 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="today_clothes_promo_body">Pumipili ang ClothesCast ng mga damit mula sa isang set ng mga panuntunan. Baguhin ang mga temperatura at i-customize ang iyong wardrobe sa mga setting ng Damit.</string>
     <string name="today_clothes_promo_cta">Mga setting ng damit</string>
     <string name="today_clothes_promo_dismiss">Isara</string>
+    <string name="today_schedule_promo_title">Mga awtomatikong ClothesCast</string>
+    <string name="today_schedule_promo_body">Piliin kung kailan ka makakatanggap ng mga notification at anunsyo.</string>
+    <string name="today_schedule_promo_cta">Mga setting ng schedule</string>
+    <string name="today_schedule_promo_dismiss">Isara</string>
     <string name="today_clothes_promo_title">Gawing sariling iyo ang mga damit</string>
     <string name="today_insight_format_link">Format</string>
     <string name="today_play">I-play</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -387,6 +387,11 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="widget_description">La tenue de la période actuelle en un coup d\'œil.</string>
     <string name="widget_empty_title">Pas encore de tenue</string>
     <string name="widget_empty_subtitle">Appuie pour ouvrir ClothesCast</string>
+    <string name="feels_like_widget_label">Graphique du ressenti</string>
+    <string name="feels_like_widget_description">La température ressentie pour la période en cours.</string>
+    <string name="feels_like_week_widget_label">Ressenti (7 jours)</string>
+    <string name="feels_like_week_widget_description">La température ressentie sur les 7 prochains jours.</string>
+    <string name="feels_like_widget_empty_title">Pas encore de prévisions</string>
 
     <!--
     Onboarding flow — first-run welcome, two permission steps, Gemini
@@ -1051,6 +1056,10 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_schedule_enabled">ClothesCast quotidien</string>
     <string name="settings_delivery_notification">Notifier</string>
     <string name="settings_delivery_tts">Lire à voix haute</string>
+    <string name="speech_setup_title">Configurer les ClothesCasts à voix haute</string>
+    <string name="speech_setup_description">Choisis comment ton ClothesCast est lu à voix haute. Utilise la voix gratuite de l\'appareil, ou ajoute une clé API Gemini pour des voix de haute qualité.</string>
+    <string name="speech_setup_smart_home_note">La lecture sur la maison connectée nécessite une clé API Gemini. La diffusion affiche quand même ta tenue sans elle.</string>
+    <string name="speech_setup_done">Terminé</string>
 
     <!-- Clothes-mention picker on Format / Schedule -->
     <string name="settings_clothes_mention_label">Vêtements</string>
@@ -1080,6 +1089,11 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_format_rain_accessory_label">Accessoire pluie</string>
     <string name="settings_format_rain_accessory_none">Désactivé</string>
     <string name="settings_format_rain_accessory_umbrella">Parapluie</string>
+    <string name="settings_format_period_preamble_label">Introduction</string>
+    <string name="settings_format_wear_preamble_label">Introduction „Porte“</string>
+    <string name="settings_format_preamble_always">Toujours</string>
+    <string name="settings_format_preamble_speech_only">Voix seulement</string>
+    <string name="settings_format_preamble_never">Jamais</string>
 
     <!-- Fallback clothes rules — "If no rules match" section -->
     <string name="settings_default_outfit_title">Si aucune règle ne correspond</string>
@@ -1316,6 +1330,10 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="today_clothes_promo_body">ClothesCast choisit les tenues à partir d\'un ensemble de règles. Ajuste les températures et personnalise ta garde-robe dans les paramètres Vêtements.</string>
     <string name="today_clothes_promo_cta">Paramètres Vêtements</string>
     <string name="today_clothes_promo_dismiss">Ignorer</string>
+    <string name="today_schedule_promo_title">ClothesCasts automatiques</string>
+    <string name="today_schedule_promo_body">Choisis quand tu reçois les notifications et les annonces.</string>
+    <string name="today_schedule_promo_cta">Paramètres de planification</string>
+    <string name="today_schedule_promo_dismiss">Ignorer</string>
     <string name="today_clothes_promo_title">Adapte les vêtements à ton goût</string>
     <string name="today_insight_format_link">Format</string>
     <string name="today_play">Lecture</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -413,6 +413,11 @@ Not overridden by design:
     <string name="widget_description">मौजूदा समय की पोशाक एक नज़र में।</string>
     <string name="widget_empty_title">अभी कोई पोशाक नहीं</string>
     <string name="widget_empty_subtitle">ClothesCast खोलने के लिए टैप करें</string>
+    <string name="feels_like_widget_label">महसूस तापमान चार्ट</string>
+    <string name="feels_like_widget_description">मौजूदा समय का महसूस तापमान।</string>
+    <string name="feels_like_week_widget_label">महसूस तापमान (7 दिन)</string>
+    <string name="feels_like_week_widget_description">अगले 7 दिनों का महसूस तापमान।</string>
+    <string name="feels_like_widget_empty_title">अभी कोई पूर्वानुमान नहीं</string>
 
     <!-- Onboarding. -->
     <string name="onboarding_title">ClothesCast में आपका स्वागत है</string>
@@ -956,6 +961,10 @@ Not overridden by design:
     <string name="settings_schedule_enabled">दैनिक ClothesCast</string>
     <string name="settings_delivery_notification">सूचित करें</string>
     <string name="settings_delivery_tts">बोलें</string>
+    <string name="speech_setup_title">बोले जाने वाले ClothesCast सेट करें</string>
+    <string name="speech_setup_description">चुनें कि आपका ClothesCast कैसे बोलकर पढ़ा जाए। मुफ़्त डिवाइस आवाज़ उपयोग करें, या उच्च-गुणवत्ता वाली आवाज़ों के लिए Gemini API कुंजी जोड़ें।</string>
+    <string name="speech_setup_smart_home_note">स्मार्ट होम पर बोलने के लिए Gemini API कुंजी ज़रूरी है। इसके बिना भी कास्टिंग आपकी पोशाक दिखाती है।</string>
+    <string name="speech_setup_done">हो गया</string>
 
     <!-- Clothes-mention picker -->
     <string name="settings_clothes_mention_label">कपड़े</string>
@@ -985,6 +994,11 @@ Not overridden by design:
     <string name="settings_format_rain_accessory_label">बारिश का सामान</string>
     <string name="settings_format_rain_accessory_none">बंद</string>
     <string name="settings_format_rain_accessory_umbrella">छाता</string>
+    <string name="settings_format_period_preamble_label">प्रस्तावना</string>
+    <string name="settings_format_wear_preamble_label">"पहनें" प्रस्तावना</string>
+    <string name="settings_format_preamble_always">हमेशा</string>
+    <string name="settings_format_preamble_speech_only">केवल बोली में</string>
+    <string name="settings_format_preamble_never">कभी नहीं</string>
 
     <!-- Fallback clothes rules — "If no rules match" -->
     <string name="settings_default_outfit_title">यदि कोई नियम लागू नहीं हो</string>
@@ -1221,6 +1235,10 @@ Not overridden by design:
     <string name="today_clothes_promo_body">ClothesCast नियमों के एक सेट से कपड़े चुनता है। तापमान बदलें और कपड़े सेटिंग्स में अपना वॉर्डरोब कस्टमाइज़ करें।</string>
     <string name="today_clothes_promo_cta">कपड़े सेटिंग्स</string>
     <string name="today_clothes_promo_dismiss">बंद करें</string>
+    <string name="today_schedule_promo_title">स्वचालित ClothesCast</string>
+    <string name="today_schedule_promo_body">चुनें कि आपको सूचनाएँ और घोषणाएँ कब मिलें।</string>
+    <string name="today_schedule_promo_cta">समय-सारणी सेटिंग</string>
+    <string name="today_schedule_promo_dismiss">बंद करें</string>
     <string name="today_clothes_promo_title">कपड़ों को अपना बनाएँ</string>
     <string name="today_insight_format_link">प्रारूप</string>
     <string name="today_play">चलाएँ</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -358,6 +358,11 @@ spousal register), matching the existing insight prose ("Ponesi …",
     <string name="widget_description">Outfit za trenutni period na prvi pogled.</string>
     <string name="widget_empty_title">Još nema outfita</string>
     <string name="widget_empty_subtitle">Dodirni za otvaranje ClothesCasta</string>
+    <string name="feels_like_widget_label">Grafikon osjećajne temperature</string>
+    <string name="feels_like_widget_description">Osjećajna temperatura za trenutni period.</string>
+    <string name="feels_like_week_widget_label">Osjećajna (7 dana)</string>
+    <string name="feels_like_week_widget_description">Osjećajna temperatura za sljedećih 7 dana.</string>
+    <string name="feels_like_widget_empty_title">Još nema prognoze</string>
 
     <!--
     Onboarding flow — first-run welcome, two permission steps, Gemini
@@ -993,6 +998,10 @@ spousal register), matching the existing insight prose ("Ponesi …",
     <string name="settings_schedule_enabled">Dnevni ClothesCast</string>
     <string name="settings_delivery_notification">Obavijesti</string>
     <string name="settings_delivery_tts">Pročitaj</string>
+    <string name="speech_setup_title">Postavi izgovorene ClothesCastove</string>
+    <string name="speech_setup_description">Odaberi kako se tvoj ClothesCast čita naglas. Koristi besplatni glas uređaja ili dodaj Gemini API ključ za glasove visoke kvalitete.</string>
+    <string name="speech_setup_smart_home_note">Izgovor u pametnom domu zahtijeva Gemini API ključ. Emitiranje i bez njega prikazuje tvoj outfit.</string>
+    <string name="speech_setup_done">Gotovo</string>
 
     <!-- Clothes-mention picker on Format / Schedule -->
     <string name="settings_clothes_mention_label">Odjeća</string>
@@ -1022,6 +1031,11 @@ spousal register), matching the existing insight prose ("Ponesi …",
     <string name="settings_format_rain_accessory_label">Dodatak za kišu</string>
     <string name="settings_format_rain_accessory_none">Isključeno</string>
     <string name="settings_format_rain_accessory_umbrella">Kišobran</string>
+    <string name="settings_format_period_preamble_label">Uvod</string>
+    <string name="settings_format_wear_preamble_label">Uvod „Obuci“</string>
+    <string name="settings_format_preamble_always">Uvijek</string>
+    <string name="settings_format_preamble_speech_only">Samo izgovor</string>
+    <string name="settings_format_preamble_never">Nikad</string>
 
     <!-- Fallback clothes rules — "If no rules match" section -->
     <string name="settings_default_outfit_title">Ako se nijedno pravilo ne podudara</string>
@@ -1259,6 +1273,10 @@ spousal register), matching the existing insight prose ("Ponesi …",
     <string name="today_clothes_promo_body">ClothesCast bira outfite po skupu pravila. Podesi temperature i prilagodi svoju garderobu u postavkama Odjeće.</string>
     <string name="today_clothes_promo_cta">Postavke odjeće</string>
     <string name="today_clothes_promo_dismiss">Odbaci</string>
+    <string name="today_schedule_promo_title">Automatski ClothesCastovi</string>
+    <string name="today_schedule_promo_body">Odaberi kada primaš obavijesti i najave.</string>
+    <string name="today_schedule_promo_cta">Postavke rasporeda</string>
+    <string name="today_schedule_promo_dismiss">Odbaci</string>
     <string name="today_clothes_promo_title">Prilagodi odjeću sebi</string>
     <string name="today_insight_format_link">Format</string>
     <string name="today_play">Pusti</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -478,6 +478,11 @@ locale (Angol (Egyesült Államok), Francia (Franciaország), Német
     <string name="widget_description">Az aktuális napszak outfitje egy pillantásra.</string>
     <string name="widget_empty_title">Még nincs outfit</string>
     <string name="widget_empty_subtitle">Koppints a ClothesCast megnyitásához</string>
+    <string name="feels_like_widget_label">Hőérzet diagram</string>
+    <string name="feels_like_widget_description">A hőérzet az aktuális időszakra.</string>
+    <string name="feels_like_week_widget_label">Hőérzet (7 nap)</string>
+    <string name="feels_like_week_widget_description">A hőérzet a következő 7 napra.</string>
+    <string name="feels_like_widget_empty_title">Még nincs előrejelzés</string>
 
     <!-- Onboarding. -->
     <string name="onboarding_title">Üdvözöl a ClothesCast</string>
@@ -917,6 +922,10 @@ locale (Angol (Egyesült Államok), Francia (Franciaország), Német
     <string name="settings_schedule_enabled">Napi ClothesCast</string>
     <string name="settings_delivery_notification">Értesítés</string>
     <string name="settings_delivery_tts">Felolvasás</string>
+    <string name="speech_setup_title">Beszélt ClothesCastok beállítása</string>
+    <string name="speech_setup_description">Válaszd ki, hogyan olvassa fel a ClothesCast. Használd az ingyenes eszközhangot, vagy adj hozzá egy Gemini API-kulcsot a kiváló minőségű hangokhoz.</string>
+    <string name="speech_setup_smart_home_note">Az okosotthoni beszédhez Gemini API-kulcs szükséges. A küldés enélkül is megjeleníti az öltözékedet.</string>
+    <string name="speech_setup_done">Kész</string>
 
     <!-- Clothes-mention picker on Format / Schedule -->
     <string name="settings_clothes_mention_label">Ruházat</string>
@@ -946,6 +955,11 @@ locale (Angol (Egyesült Államok), Francia (Franciaország), Német
     <string name="settings_format_rain_accessory_label">Esőkellék</string>
     <string name="settings_format_rain_accessory_none">Ki</string>
     <string name="settings_format_rain_accessory_umbrella">Esernyő</string>
+    <string name="settings_format_period_preamble_label">Bevezető</string>
+    <string name="settings_format_wear_preamble_label">„Vegyél fel” bevezető</string>
+    <string name="settings_format_preamble_always">Mindig</string>
+    <string name="settings_format_preamble_speech_only">Csak beszéd</string>
+    <string name="settings_format_preamble_never">Soha</string>
 
     <!-- Fallback clothes rules — "If no rules match" -->
     <string name="settings_default_outfit_title">Ha egyik szabály sem illik</string>
@@ -1182,6 +1196,10 @@ locale (Angol (Egyesült Államok), Francia (Franciaország), Német
     <string name="today_clothes_promo_body">A ClothesCast szabályok alapján választ ruhákat. Állítsd be a hőmérsékleteket, és szabd testre a ruhatárad a Ruhák beállításokban.</string>
     <string name="today_clothes_promo_cta">Ruhák beállításai</string>
     <string name="today_clothes_promo_dismiss">Elvetés</string>
+    <string name="today_schedule_promo_title">Automatikus ClothesCastok</string>
+    <string name="today_schedule_promo_body">Válaszd ki, mikor kapsz értesítéseket és bejelentéseket.</string>
+    <string name="today_schedule_promo_cta">Ütemezés beállításai</string>
+    <string name="today_schedule_promo_dismiss">Elvetés</string>
     <string name="today_clothes_promo_title">Tedd magadévá a ruhákat</string>
     <string name="today_insight_format_link">Formátum</string>
     <string name="today_play">Lejátszás</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -144,6 +144,11 @@ to values/strings.xml (English).
     <string name="widget_description">Pakaian periode saat ini sekilas.</string>
     <string name="widget_empty_title">Belum ada pakaian</string>
     <string name="widget_empty_subtitle">Ketuk untuk membuka ClothesCast</string>
+    <string name="feels_like_widget_label">Grafik suhu terasa</string>
+    <string name="feels_like_widget_description">Suhu terasa untuk periode saat ini.</string>
+    <string name="feels_like_week_widget_label">Suhu terasa (7 hari)</string>
+    <string name="feels_like_week_widget_description">Suhu terasa selama 7 hari ke depan.</string>
+    <string name="feels_like_widget_empty_title">Belum ada prakiraan</string>
 
     <!-- Forecast cards -->
     <string name="today_forecast_title">Prakiraan per jam</string>
@@ -925,6 +930,10 @@ to values/strings.xml (English).
     <string name="settings_schedule_enabled">ClothesCast Harian</string>
     <string name="settings_delivery_notification">Beri tahu</string>
     <string name="settings_delivery_tts">Bacakan</string>
+    <string name="speech_setup_title">Siapkan ClothesCast bersuara</string>
+    <string name="speech_setup_description">Pilih cara ClothesCast Anda dibacakan dengan keras. Gunakan suara perangkat gratis, atau tambahkan Gemini API key untuk suara berkualitas tinggi.</string>
+    <string name="speech_setup_smart_home_note">Suara rumah pintar memerlukan Gemini API key. Cast tetap menampilkan pakaian Anda tanpanya.</string>
+    <string name="speech_setup_done">Selesai</string>
 
     <!-- Clothes-mention picker -->
     <string name="settings_clothes_mention_label">Pakaian</string>
@@ -954,6 +963,11 @@ to values/strings.xml (English).
     <string name="settings_format_rain_accessory_label">Aksesori hujan</string>
     <string name="settings_format_rain_accessory_none">Mati</string>
     <string name="settings_format_rain_accessory_umbrella">Payung</string>
+    <string name="settings_format_period_preamble_label">Pembuka</string>
+    <string name="settings_format_wear_preamble_label">Pembuka "Kenakan"</string>
+    <string name="settings_format_preamble_always">Selalu</string>
+    <string name="settings_format_preamble_speech_only">Suara saja</string>
+    <string name="settings_format_preamble_never">Tidak pernah</string>
 
     <!-- Fallback clothes rules — "If no rules match" -->
     <string name="settings_default_outfit_title">Jika tidak ada aturan yang cocok</string>
@@ -1189,6 +1203,10 @@ to values/strings.xml (English).
     <string name="today_clothes_promo_body">ClothesCast memilih pakaian berdasarkan serangkaian aturan. Ubah suhu dan sesuaikan lemari pakaianmu di pengaturan Pakaian.</string>
     <string name="today_clothes_promo_cta">Pengaturan pakaian</string>
     <string name="today_clothes_promo_dismiss">Tutup</string>
+    <string name="today_schedule_promo_title">ClothesCast otomatis</string>
+    <string name="today_schedule_promo_body">Pilih kapan Anda menerima notifikasi dan pengumuman.</string>
+    <string name="today_schedule_promo_cta">Pengaturan jadwal</string>
+    <string name="today_schedule_promo_dismiss">Tutup</string>
     <string name="today_clothes_promo_title">Buat pakaian sendiri</string>
     <string name="today_insight_format_link">Format</string>
     <string name="today_play">Putar</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -375,6 +375,11 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="widget_description">L\'outfit del momento attuale a colpo d\'occhio.</string>
     <string name="widget_empty_title">Ancora nessun outfit</string>
     <string name="widget_empty_subtitle">Tocca per aprire ClothesCast</string>
+    <string name="feels_like_widget_label">Grafico percepita</string>
+    <string name="feels_like_widget_description">La temperatura percepita per il periodo corrente.</string>
+    <string name="feels_like_week_widget_label">Percepita (7 giorni)</string>
+    <string name="feels_like_week_widget_description">La temperatura percepita nei prossimi 7 giorni.</string>
+    <string name="feels_like_widget_empty_title">Ancora nessuna previsione</string>
 
     <!--
     Onboarding flow — first-run welcome, two permission steps, Gemini
@@ -1037,6 +1042,10 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_schedule_enabled">ClothesCast quotidiano</string>
     <string name="settings_delivery_notification">Notifica</string>
     <string name="settings_delivery_tts">Riproduci voce</string>
+    <string name="speech_setup_title">Configura i ClothesCast parlati</string>
+    <string name="speech_setup_description">Scegli come viene letto ad alta voce il tuo ClothesCast. Usa la voce gratuita del dispositivo, oppure aggiungi una chiave API Gemini per voci di alta qualità.</string>
+    <string name="speech_setup_smart_home_note">La voce sulla casa intelligente richiede una chiave API Gemini. La trasmissione mostra comunque il tuo outfit anche senza.</string>
+    <string name="speech_setup_done">Fatto</string>
 
     <!-- Clothes-mention picker on Format / Schedule -->
     <string name="settings_clothes_mention_label">Abbigliamento</string>
@@ -1066,6 +1075,11 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_format_rain_accessory_label">Accessorio pioggia</string>
     <string name="settings_format_rain_accessory_none">Disattivato</string>
     <string name="settings_format_rain_accessory_umbrella">Ombrello</string>
+    <string name="settings_format_period_preamble_label">Introduzione</string>
+    <string name="settings_format_wear_preamble_label">Introduzione „Indossa“</string>
+    <string name="settings_format_preamble_always">Sempre</string>
+    <string name="settings_format_preamble_speech_only">Solo voce</string>
+    <string name="settings_format_preamble_never">Mai</string>
 
     <!-- Fallback clothes rules — "If no rules match" section -->
     <string name="settings_default_outfit_title">Se nessuna regola corrisponde</string>
@@ -1302,6 +1316,10 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="today_clothes_promo_body">ClothesCast sceglie gli outfit da una serie di regole. Modifica le temperature e personalizza il tuo guardaroba nelle impostazioni Abbigliamento.</string>
     <string name="today_clothes_promo_cta">Impostazioni Abbigliamento</string>
     <string name="today_clothes_promo_dismiss">Ignora</string>
+    <string name="today_schedule_promo_title">ClothesCast automatici</string>
+    <string name="today_schedule_promo_body">Scegli quando ricevere notifiche e annunci.</string>
+    <string name="today_schedule_promo_cta">Impostazioni programmazione</string>
+    <string name="today_schedule_promo_dismiss">Ignora</string>
     <string name="today_clothes_promo_title">Personalizza l\'abbigliamento</string>
     <string name="today_insight_format_link">Formato</string>
     <string name="today_play">Riproduci</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -146,6 +146,11 @@ standard in Israeli digital communication.
     <string name="widget_description">הלבוש של התקופה הנוכחית במבט מהיר.</string>
     <string name="widget_empty_title">אין לבוש עדיין</string>
     <string name="widget_empty_subtitle">הקש/י לפתיחת ClothesCast</string>
+    <string name="feels_like_widget_label">תרשים טמפרטורה מורגשת</string>
+    <string name="feels_like_widget_description">הטמפרטורה המורגשת לתקופה הנוכחית.</string>
+    <string name="feels_like_week_widget_label">טמפרטורה מורגשת (7 ימים)</string>
+    <string name="feels_like_week_widget_description">הטמפרטורה המורגשת ב-7 הימים הקרובים.</string>
+    <string name="feels_like_widget_empty_title">אין עדיין תחזית</string>
 
     <!-- Today — forecast chart -->
     <string name="today_forecast_title">טמפרטורה מורגשת</string>
@@ -924,6 +929,10 @@ standard in Israeli digital communication.
     <string name="settings_schedule_enabled">ClothesCast יומי</string>
     <string name="settings_delivery_notification">התראה</string>
     <string name="settings_delivery_tts">קריאה</string>
+    <string name="speech_setup_title">הגדרת ClothesCast מדוברים</string>
+    <string name="speech_setup_description">בחר/י כיצד ClothesCast שלך ייקרא בקול. השתמש/י בקול המכשיר החינמי, או הוסף/י מפתח Gemini API לקולות באיכות גבוהה.</string>
+    <string name="speech_setup_smart_home_note">דיבור בבית חכם דורש מפתח Gemini API. השידור מציג את הלבוש שלך גם בלעדיו.</string>
+    <string name="speech_setup_done">סיום</string>
 
     <!-- Clothes-mention picker on Format / Schedule -->
     <string name="settings_clothes_mention_label">לבוש</string>
@@ -953,6 +962,11 @@ standard in Israeli digital communication.
     <string name="settings_format_rain_accessory_label">אביזר גשם</string>
     <string name="settings_format_rain_accessory_none">כבוי</string>
     <string name="settings_format_rain_accessory_umbrella">מטרייה</string>
+    <string name="settings_format_period_preamble_label">פתיח</string>
+    <string name="settings_format_wear_preamble_label">פתיח "לבש/י"</string>
+    <string name="settings_format_preamble_always">תמיד</string>
+    <string name="settings_format_preamble_speech_only">דיבור בלבד</string>
+    <string name="settings_format_preamble_never">אף פעם</string>
 
     <!-- Fallback clothes rules — "If no rules match" -->
     <string name="settings_default_outfit_title">אם אף חוק לא מתאים</string>
@@ -1191,6 +1205,10 @@ standard in Israeli digital communication.
     <string name="today_clothes_promo_body">ClothesCast בוחר תלבושות לפי כללים. שנה את הטמפרטורות והתאם אישית את המלתחה שלך בהגדרות בגדים.</string>
     <string name="today_clothes_promo_cta">הגדרות בגדים</string>
     <string name="today_clothes_promo_dismiss">סגור</string>
+    <string name="today_schedule_promo_title">ClothesCast אוטומטיים</string>
+    <string name="today_schedule_promo_body">בחר/י מתי לקבל התראות והכרזות.</string>
+    <string name="today_schedule_promo_cta">הגדרות לוח זמנים</string>
+    <string name="today_schedule_promo_dismiss">סגור</string>
     <string name="today_clothes_promo_title">התאם את הבגדים אישית</string>
     <string name="today_insight_format_link">פורמט</string>
     <string name="today_play">הפעל</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -387,6 +387,11 @@ the displayed label localizes.
     <string name="widget_description">現在の時間帯のコーデを一目で。</string>
     <string name="widget_empty_title">まだコーデがありません</string>
     <string name="widget_empty_subtitle">タップして ClothesCast を開く</string>
+    <string name="feels_like_widget_label">体感温度グラフ</string>
+    <string name="feels_like_widget_description">現在の時間帯の体感温度です。</string>
+    <string name="feels_like_week_widget_label">体感温度（7日間）</string>
+    <string name="feels_like_week_widget_description">今後7日間の体感温度です。</string>
+    <string name="feels_like_widget_empty_title">まだ予報がありません</string>
 
     <!--
     Onboarding flow — first-run welcome, two permission steps, Gemini
@@ -1075,6 +1080,10 @@ the displayed label localizes.
     <string name="settings_schedule_enabled">毎日の ClothesCast</string>
     <string name="settings_delivery_notification">通知</string>
     <string name="settings_delivery_tts">読み上げ</string>
+    <string name="speech_setup_title">音声で読み上げる ClothesCast の設定</string>
+    <string name="speech_setup_description">ClothesCast を音声で読み上げる方法を選べます。無料の端末の音声を使うか、Gemini API キーを追加して高品質な音声を利用できます。</string>
+    <string name="speech_setup_smart_home_note">スマートホームでの読み上げには Gemini API キーが必要です。キーがなくてもキャスト時にコーデは表示されます。</string>
+    <string name="speech_setup_done">完了</string>
 
     <!-- Clothes-mention picker on Format / Schedule -->
     <string name="settings_clothes_mention_label">服装</string>
@@ -1104,6 +1113,11 @@ the displayed label localizes.
     <string name="settings_format_rain_accessory_label">雨具</string>
     <string name="settings_format_rain_accessory_none">オフ</string>
     <string name="settings_format_rain_accessory_umbrella">傘</string>
+    <string name="settings_format_period_preamble_label">導入</string>
+    <string name="settings_format_wear_preamble_label">「着る」の導入</string>
+    <string name="settings_format_preamble_always">常に</string>
+    <string name="settings_format_preamble_speech_only">読み上げのみ</string>
+    <string name="settings_format_preamble_never">なし</string>
 
     <!-- Fallback clothes rules — "If no rules match" -->
     <string name="settings_default_outfit_title">一致するルールがないとき</string>
@@ -1339,6 +1353,10 @@ the displayed label localizes.
     <string name="today_clothes_promo_body">ClothesCastはルールに基づいて服装を選びます。設定の「服装」で温度を調整したり、ワードローブをカスタマイズしたりできます。</string>
     <string name="today_clothes_promo_cta">服装の設定</string>
     <string name="today_clothes_promo_dismiss">閉じる</string>
+    <string name="today_schedule_promo_title">自動の ClothesCast</string>
+    <string name="today_schedule_promo_body">通知やアナウンスを受け取るタイミングを選べます。</string>
+    <string name="today_schedule_promo_cta">スケジュール設定</string>
+    <string name="today_schedule_promo_dismiss">閉じる</string>
     <string name="today_clothes_promo_title">服装を自分好みに</string>
     <string name="today_insight_format_link">形式</string>
     <string name="today_play">再生</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -402,6 +402,11 @@ displayed label localizes.
     <string name="widget_description">현재 시간대의 코디를 한눈에.</string>
     <string name="widget_empty_title">아직 코디가 없어요</string>
     <string name="widget_empty_subtitle">탭하여 ClothesCast 열기</string>
+    <string name="feels_like_widget_label">체감 온도 차트</string>
+    <string name="feels_like_widget_description">현재 시간대의 체감 온도입니다.</string>
+    <string name="feels_like_week_widget_label">체감 온도 (7일)</string>
+    <string name="feels_like_week_widget_description">앞으로 7일간의 체감 온도입니다.</string>
+    <string name="feels_like_widget_empty_title">아직 예보가 없어요</string>
 
     <!--
     Onboarding flow — first-run welcome, two permission steps, Gemini
@@ -1079,6 +1084,10 @@ displayed label localizes.
     <string name="settings_schedule_enabled">매일 ClothesCast</string>
     <string name="settings_delivery_notification">알림</string>
     <string name="settings_delivery_tts">읽기</string>
+    <string name="speech_setup_title">음성 ClothesCast 설정</string>
+    <string name="speech_setup_description">ClothesCast를 음성으로 읽어주는 방식을 선택하세요. 무료 기기 음성을 사용하거나, Gemini API 키를 추가해 고품질 음성을 사용할 수 있어요.</string>
+    <string name="speech_setup_smart_home_note">스마트홈 음성에는 Gemini API 키가 필요해요. 키가 없어도 캐스팅할 때 코디는 표시됩니다.</string>
+    <string name="speech_setup_done">완료</string>
 
     <!-- Clothes-mention picker on Format / Schedule -->
     <string name="settings_clothes_mention_label">옷</string>
@@ -1108,6 +1117,11 @@ displayed label localizes.
     <string name="settings_format_rain_accessory_label">우천용품</string>
     <string name="settings_format_rain_accessory_none">끔</string>
     <string name="settings_format_rain_accessory_umbrella">우산</string>
+    <string name="settings_format_period_preamble_label">도입부</string>
+    <string name="settings_format_wear_preamble_label">「입기」 도입부</string>
+    <string name="settings_format_preamble_always">항상</string>
+    <string name="settings_format_preamble_speech_only">음성만</string>
+    <string name="settings_format_preamble_never">사용 안 함</string>
 
     <!-- Fallback clothes rules — "If no rules match" -->
     <string name="settings_default_outfit_title">일치하는 규칙이 없을 때</string>
@@ -1343,6 +1357,10 @@ displayed label localizes.
     <string name="today_clothes_promo_body">ClothesCast는 규칙에 따라 옷을 추천합니다. 옷 설정에서 온도를 조정하고 옷장을 맞춤 설정해 보세요.</string>
     <string name="today_clothes_promo_cta">옷 설정</string>
     <string name="today_clothes_promo_dismiss">닫기</string>
+    <string name="today_schedule_promo_title">자동 ClothesCast</string>
+    <string name="today_schedule_promo_body">알림과 안내를 받을 시간을 선택하세요.</string>
+    <string name="today_schedule_promo_cta">일정 설정</string>
+    <string name="today_schedule_promo_dismiss">닫기</string>
     <string name="today_clothes_promo_title">옷을 내 것으로</string>
     <string name="today_insight_format_link">형식</string>
     <string name="today_play">재생</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -141,6 +141,11 @@ What is NOT overridden, by design:
     <string name="widget_description">Dabartinio laikotarpio aprangos rinkinys iš pirmo žvilgsnio.</string>
     <string name="widget_empty_title">Aprangos rinkinio dar nėra</string>
     <string name="widget_empty_subtitle">Palieski, kad atidarytum ClothesCast</string>
+    <string name="feels_like_widget_label">Juntamos temperatūros grafikas</string>
+    <string name="feels_like_widget_description">Juntama temperatūra dabartiniam laikotarpiui.</string>
+    <string name="feels_like_week_widget_label">Juntama temperatūra (7 dienos)</string>
+    <string name="feels_like_week_widget_description">Juntama temperatūra artimiausias 7 dienas.</string>
+    <string name="feels_like_widget_empty_title">Prognozės dar nėra</string>
 
     <!-- Hourly forecast card. -->
     <string name="today_forecast_title">Valandos prognozė</string>
@@ -912,6 +917,10 @@ What is NOT overridden, by design:
     <string name="settings_schedule_enabled">Dienos ClothesCast</string>
     <string name="settings_delivery_notification">Pranešti</string>
     <string name="settings_delivery_tts">Įgarsinti</string>
+    <string name="speech_setup_title">Nustatyk įgarsintus ClothesCast</string>
+    <string name="speech_setup_description">Pasirink, kaip tavo ClothesCast bus skaitomas balsu. Naudok nemokamą įrenginio balsą arba pridėk Gemini API raktą aukštos kokybės balsams.</string>
+    <string name="speech_setup_smart_home_note">Įgarsinimui išmaniuosiuose namuose reikia Gemini API rakto. Transliavimas vis tiek rodo tavo aprangą ir be jo.</string>
+    <string name="speech_setup_done">Atlikta</string>
 
     <!-- Clothes-mention picker on Format / Schedule -->
     <string name="settings_clothes_mention_label">Apranga</string>
@@ -941,6 +950,11 @@ What is NOT overridden, by design:
     <string name="settings_format_rain_accessory_label">Lietaus aksesuaras</string>
     <string name="settings_format_rain_accessory_none">Išjungta</string>
     <string name="settings_format_rain_accessory_umbrella">Skėtis</string>
+    <string name="settings_format_period_preamble_label">Įžanga</string>
+    <string name="settings_format_wear_preamble_label">„Apsivilk“ įžanga</string>
+    <string name="settings_format_preamble_always">Visada</string>
+    <string name="settings_format_preamble_speech_only">Tik kalboje</string>
+    <string name="settings_format_preamble_never">Niekada</string>
 
     <!-- Fallback clothes rules — "If no rules match" section -->
     <string name="settings_default_outfit_title">Jei nė viena taisyklė neatitinka</string>
@@ -1179,6 +1193,10 @@ What is NOT overridden, by design:
     <string name="today_clothes_promo_body">ClothesCast renka aprangą pagal taisykles. Pakeisk temperatūras ir pritaikyk savo garderobą Drabužių nustatymuose.</string>
     <string name="today_clothes_promo_cta">Drabužių nustatymai</string>
     <string name="today_clothes_promo_dismiss">Atmesti</string>
+    <string name="today_schedule_promo_title">Automatiniai ClothesCast</string>
+    <string name="today_schedule_promo_body">Pasirink, kada gauti pranešimus ir skelbimus.</string>
+    <string name="today_schedule_promo_cta">Tvarkaraščio nustatymai</string>
+    <string name="today_schedule_promo_dismiss">Atmesti</string>
     <string name="today_clothes_promo_title">Pritaikyk drabužius sau</string>
     <string name="today_insight_format_link">Formatas</string>
     <string name="today_play">Leisti</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -143,6 +143,11 @@ informal "tu"-form throughout ("Apģērb …", "Paņem … līdzi").
     <string name="widget_description">Pašreizējā perioda apģērbs vienā skatienā.</string>
     <string name="widget_empty_title">Apģērba ieteikuma vēl nav</string>
     <string name="widget_empty_subtitle">Pieskarieties, lai atvērtu ClothesCast</string>
+    <string name="feels_like_widget_label">Sajustās temperatūras grafiks</string>
+    <string name="feels_like_widget_description">Sajustā temperatūra pašreizējam periodam.</string>
+    <string name="feels_like_week_widget_label">Sajustā temperatūra (7 dienas)</string>
+    <string name="feels_like_week_widget_description">Sajustā temperatūra nākamajās 7 dienās.</string>
+    <string name="feels_like_widget_empty_title">Prognozes vēl nav</string>
 
     <!-- Today forecast / charts -->
     <string name="today_forecast_title">Stundas prognoze</string>
@@ -865,6 +870,10 @@ informal "tu"-form throughout ("Apģērb …", "Paņem … līdzi").
     <string name="settings_schedule_enabled">Ikdienas ClothesCast</string>
     <string name="settings_delivery_notification">Paziņot</string>
     <string name="settings_delivery_tts">Nolasīt</string>
+    <string name="speech_setup_title">Iestatiet runāto ClothesCast</string>
+    <string name="speech_setup_description">Izvēlieties, kā jūsu ClothesCast tiek nolasīts skaļi. Izmantojiet bezmaksas ierīces balsi vai pievienojiet Gemini API atslēgu augstas kvalitātes balsīm.</string>
+    <string name="speech_setup_smart_home_note">Runai viedajās mājās nepieciešama Gemini API atslēga. Apraide joprojām rāda jūsu apģērbu arī bez tās.</string>
+    <string name="speech_setup_done">Gatavs</string>
 
     <!-- Clothes-mention picker on Format / Schedule -->
     <string name="settings_clothes_mention_label">Apģērbs</string>
@@ -894,6 +903,11 @@ informal "tu"-form throughout ("Apģērb …", "Paņem … līdzi").
     <string name="settings_format_rain_accessory_label">Lietus piederums</string>
     <string name="settings_format_rain_accessory_none">Izsl.</string>
     <string name="settings_format_rain_accessory_umbrella">Lietussargs</string>
+    <string name="settings_format_period_preamble_label">Ievads</string>
+    <string name="settings_format_wear_preamble_label">„Apģērb“ ievads</string>
+    <string name="settings_format_preamble_always">Vienmēr</string>
+    <string name="settings_format_preamble_speech_only">Tikai runā</string>
+    <string name="settings_format_preamble_never">Nekad</string>
 
     <!-- Fallback clothes rules — "If no rules match" section -->
     <string name="settings_default_outfit_title">Ja neviens noteikums neatbilst</string>
@@ -1131,6 +1145,10 @@ informal "tu"-form throughout ("Apģērb …", "Paņem … līdzi").
     <string name="today_clothes_promo_body">ClothesCast izvēlas apģērbu pēc noteikumiem. Pielāgo temperatūras un personalizē savu garderobi Apģērba iestatījumos.</string>
     <string name="today_clothes_promo_cta">Apģērba iestatījumi</string>
     <string name="today_clothes_promo_dismiss">Aizvērt</string>
+    <string name="today_schedule_promo_title">Automātiskie ClothesCast</string>
+    <string name="today_schedule_promo_body">Izvēlieties, kad saņemt paziņojumus un izziņojumus.</string>
+    <string name="today_schedule_promo_cta">Grafika iestatījumi</string>
+    <string name="today_schedule_promo_dismiss">Aizvērt</string>
     <string name="today_clothes_promo_title">Padari apģērbu par savējo</string>
     <string name="today_insight_format_link">Formāts</string>
     <string name="today_play">Atskaņot</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -139,6 +139,11 @@ vs "kemungkinan", "padam" vs "hapus").
     <string name="widget_description">Pakaian untuk tempoh semasa secara ringkas.</string>
     <string name="widget_empty_title">Tiada pakaian lagi</string>
     <string name="widget_empty_subtitle">Ketik untuk membuka ClothesCast</string>
+    <string name="feels_like_widget_label">Carta suhu terasa</string>
+    <string name="feels_like_widget_description">Suhu terasa untuk tempoh semasa.</string>
+    <string name="feels_like_week_widget_label">Suhu terasa (7 hari)</string>
+    <string name="feels_like_week_widget_description">Suhu terasa untuk 7 hari akan datang.</string>
+    <string name="feels_like_widget_empty_title">Tiada ramalan lagi</string>
 
     <!-- Forecast card -->
     <string name="today_forecast_title">Ramalan setiap jam</string>
@@ -931,6 +936,10 @@ vs "kemungkinan", "padam" vs "hapus").
     <string name="settings_schedule_enabled">ClothesCast Harian</string>
     <string name="settings_delivery_notification">Beritahu</string>
     <string name="settings_delivery_tts">Sebut</string>
+    <string name="speech_setup_title">Sediakan ClothesCast bersuara</string>
+    <string name="speech_setup_description">Pilih cara ClothesCast anda disebut dengan kuat. Gunakan suara peranti percuma, atau tambah Gemini API key untuk suara berkualiti tinggi.</string>
+    <string name="speech_setup_smart_home_note">Sebutan rumah pintar memerlukan Gemini API key. Cast tetap menunjukkan pakaian anda tanpanya.</string>
+    <string name="speech_setup_done">Selesai</string>
 
     <!-- Clothes-mention picker -->
     <string name="settings_clothes_mention_label">Pakaian</string>
@@ -960,6 +969,11 @@ vs "kemungkinan", "padam" vs "hapus").
     <string name="settings_format_rain_accessory_label">Aksesori hujan</string>
     <string name="settings_format_rain_accessory_none">Mati</string>
     <string name="settings_format_rain_accessory_umbrella">Payung</string>
+    <string name="settings_format_period_preamble_label">Pembuka</string>
+    <string name="settings_format_wear_preamble_label">Pembuka "Pakai"</string>
+    <string name="settings_format_preamble_always">Sentiasa</string>
+    <string name="settings_format_preamble_speech_only">Sebutan sahaja</string>
+    <string name="settings_format_preamble_never">Tidak pernah</string>
 
     <!-- Fallback clothes rules — "If no rules match" -->
     <string name="settings_default_outfit_title">Jika tiada peraturan sepadan</string>
@@ -1195,6 +1209,10 @@ vs "kemungkinan", "padam" vs "hapus").
     <string name="today_clothes_promo_body">ClothesCast memilih pakaian berdasarkan satu set peraturan. Ubah suhu dan sesuaikan almari pakaian anda dalam tetapan Pakaian.</string>
     <string name="today_clothes_promo_cta">Tetapan pakaian</string>
     <string name="today_clothes_promo_dismiss">Tutup</string>
+    <string name="today_schedule_promo_title">ClothesCast automatik</string>
+    <string name="today_schedule_promo_body">Pilih masa anda menerima pemberitahuan dan pengumuman.</string>
+    <string name="today_schedule_promo_cta">Tetapan jadual</string>
+    <string name="today_schedule_promo_dismiss">Tutup</string>
     <string name="today_clothes_promo_title">Jadikan pakaian milik anda</string>
     <string name="today_insight_format_link">Format</string>
     <string name="today_play">Putar</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -477,6 +477,11 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrike)").
     <string name="widget_description">En rask titt på antrekket for den gjeldende delen av dagen.</string>
     <string name="widget_empty_title">Ingen antrekk ennå</string>
     <string name="widget_empty_subtitle">Trykk for å åpne ClothesCast</string>
+    <string name="feels_like_widget_label">Diagram over følt temperatur</string>
+    <string name="feels_like_widget_description">Den følte temperaturen for den gjeldende perioden.</string>
+    <string name="feels_like_week_widget_label">Følt temperatur (7 dager)</string>
+    <string name="feels_like_week_widget_description">Den følte temperaturen de neste 7 dagene.</string>
+    <string name="feels_like_widget_empty_title">Ingen prognose ennå</string>
 
     <!-- Onboarding. -->
     <string name="onboarding_title">Velkommen til ClothesCast</string>
@@ -953,6 +958,10 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrike)").
     <string name="settings_schedule_enabled">Daglig ClothesCast</string>
     <string name="settings_delivery_notification">Varsle</string>
     <string name="settings_delivery_tts">Les opp</string>
+    <string name="speech_setup_title">Konfigurer talte ClothesCasts</string>
+    <string name="speech_setup_description">Velg hvordan ClothesCast-en din leses opp. Bruk den gratis enhetsstemmen, eller legg til en Gemini-API-nøkkel for stemmer i høy kvalitet.</string>
+    <string name="speech_setup_smart_home_note">Tale i smarthjemmet krever en Gemini-API-nøkkel. Casting viser antrekket ditt også uten den.</string>
+    <string name="speech_setup_done">Ferdig</string>
 
     <!-- Clothes-mention picker on Format / Schedule -->
     <string name="settings_clothes_mention_label">Klær</string>
@@ -982,6 +991,11 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrike)").
     <string name="settings_format_rain_accessory_label">Regntilbehør</string>
     <string name="settings_format_rain_accessory_none">Av</string>
     <string name="settings_format_rain_accessory_umbrella">Paraply</string>
+    <string name="settings_format_period_preamble_label">Innledning</string>
+    <string name="settings_format_wear_preamble_label">\"Ha på\"-innledning</string>
+    <string name="settings_format_preamble_always">Alltid</string>
+    <string name="settings_format_preamble_speech_only">Bare tale</string>
+    <string name="settings_format_preamble_never">Aldri</string>
 
     <!-- Fallback clothes rules — "If no rules match" section -->
     <string name="settings_default_outfit_title">Hvis ingen regler passer</string>
@@ -1218,6 +1232,10 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrike)").
     <string name="today_clothes_promo_body">ClothesCast velger antrekk ut fra et sett regler. Juster temperaturene og tilpass garderoben din i Klesinnstillinger.</string>
     <string name="today_clothes_promo_cta">Klesinnstillinger</string>
     <string name="today_clothes_promo_dismiss">Avvis</string>
+    <string name="today_schedule_promo_title">Automatiske ClothesCasts</string>
+    <string name="today_schedule_promo_body">Velg når du får varsler og opplesninger.</string>
+    <string name="today_schedule_promo_cta">Tidsplaninnstillinger</string>
+    <string name="today_schedule_promo_dismiss">Avvis</string>
     <string name="today_clothes_promo_title">Gjør klærne til dine egne</string>
     <string name="today_insight_format_link">Format</string>
     <string name="today_play">Spill av</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -352,6 +352,11 @@ the displayed label localizes.
     <string name="widget_description">De outfit voor het huidige dagdeel in één oogopslag.</string>
     <string name="widget_empty_title">Nog geen outfit</string>
     <string name="widget_empty_subtitle">Tik om ClothesCast te openen</string>
+    <string name="feels_like_widget_label">Gevoelstemperatuurgrafiek</string>
+    <string name="feels_like_widget_description">De gevoelstemperatuur voor de huidige periode.</string>
+    <string name="feels_like_week_widget_label">Gevoelstemperatuur (7 dagen)</string>
+    <string name="feels_like_week_widget_description">De gevoelstemperatuur voor de komende 7 dagen.</string>
+    <string name="feels_like_widget_empty_title">Nog geen voorspelling</string>
 
     <!--
     Onboarding flow.
@@ -973,6 +978,10 @@ the displayed label localizes.
     <string name="settings_schedule_enabled">Dagelijkse ClothesCast</string>
     <string name="settings_delivery_notification">Meld</string>
     <string name="settings_delivery_tts">Voorlezen</string>
+    <string name="speech_setup_title">Gesproken ClothesCasts instellen</string>
+    <string name="speech_setup_description">Kies hoe je ClothesCast wordt voorgelezen. Gebruik de gratis apparaatstem of voeg een Gemini-API-sleutel toe voor stemmen van hoge kwaliteit.</string>
+    <string name="speech_setup_smart_home_note">Spraak in het smart home vereist een Gemini-API-sleutel. Uitzenden toont je outfit ook zonder sleutel.</string>
+    <string name="speech_setup_done">Klaar</string>
 
     <!-- Clothes-mention picker on Format / Schedule -->
     <string name="settings_clothes_mention_label">Kleding</string>
@@ -1002,6 +1011,11 @@ the displayed label localizes.
     <string name="settings_format_rain_accessory_label">Regenaccessoire</string>
     <string name="settings_format_rain_accessory_none">Uit</string>
     <string name="settings_format_rain_accessory_umbrella">Paraplu</string>
+    <string name="settings_format_period_preamble_label">Inleiding</string>
+    <string name="settings_format_wear_preamble_label">\"Draag\"-inleiding</string>
+    <string name="settings_format_preamble_always">Altijd</string>
+    <string name="settings_format_preamble_speech_only">Alleen gesproken</string>
+    <string name="settings_format_preamble_never">Nooit</string>
 
     <!-- Fallback clothes rules — "If no rules match" section -->
     <string name="settings_default_outfit_title">Als geen enkele regel past</string>
@@ -1238,6 +1252,10 @@ the displayed label localizes.
     <string name="today_clothes_promo_body">ClothesCast kiest outfits op basis van een set regels. Pas de temperaturen aan en personaliseer je garderobe in Kledinginstellingen.</string>
     <string name="today_clothes_promo_cta">Kledinginstellingen</string>
     <string name="today_clothes_promo_dismiss">Sluiten</string>
+    <string name="today_schedule_promo_title">Automatische ClothesCasts</string>
+    <string name="today_schedule_promo_body">Kies wanneer je meldingen en aankondigingen krijgt.</string>
+    <string name="today_schedule_promo_cta">Schema-instellingen</string>
+    <string name="today_schedule_promo_dismiss">Sluiten</string>
     <string name="today_clothes_promo_title">Maak de kleding van jou</string>
     <string name="today_insight_format_link">Formaat</string>
     <string name="today_play">Afspelen</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -352,6 +352,11 @@ is unchanged; only the displayed label localizes.
     <string name="widget_description">Outfit na bieżącą porę dnia w jednym spojrzeniu.</string>
     <string name="widget_empty_title">Brak outfitu</string>
     <string name="widget_empty_subtitle">Dotknij, aby otworzyć ClothesCast</string>
+    <string name="feels_like_widget_label">Wykres temperatury odczuwalnej</string>
+    <string name="feels_like_widget_description">Temperatura odczuwalna dla bieżącej pory.</string>
+    <string name="feels_like_week_widget_label">Odczuwalna (7 dni)</string>
+    <string name="feels_like_week_widget_description">Temperatura odczuwalna na najbliższe 7 dni.</string>
+    <string name="feels_like_widget_empty_title">Brak prognozy</string>
 
     <!--
     Onboarding flow.
@@ -971,6 +976,10 @@ is unchanged; only the displayed label localizes.
     <string name="settings_schedule_enabled">Codzienny ClothesCast</string>
     <string name="settings_delivery_notification">Powiadom</string>
     <string name="settings_delivery_tts">Przeczytaj</string>
+    <string name="speech_setup_title">Skonfiguruj mówione ClothesCasty</string>
+    <string name="speech_setup_description">Wybierz sposób odczytywania Twojego ClothesCasta na głos. Użyj bezpłatnego głosu urządzenia lub dodaj klucz API Gemini, aby uzyskać głosy wysokiej jakości.</string>
+    <string name="speech_setup_smart_home_note">Mowa w inteligentnym domu wymaga klucza API Gemini. Przesyłanie i tak pokazuje Twój strój nawet bez niego.</string>
+    <string name="speech_setup_done">Gotowe</string>
 
     <!-- Clothes-mention picker on Format / Schedule -->
     <string name="settings_clothes_mention_label">Ubrania</string>
@@ -1000,6 +1009,11 @@ is unchanged; only the displayed label localizes.
     <string name="settings_format_rain_accessory_label">Akcesorium na deszcz</string>
     <string name="settings_format_rain_accessory_none">Wyłączone</string>
     <string name="settings_format_rain_accessory_umbrella">Parasol</string>
+    <string name="settings_format_period_preamble_label">Wprowadzenie</string>
+    <string name="settings_format_wear_preamble_label">Wprowadzenie „Załóż"</string>
+    <string name="settings_format_preamble_always">Zawsze</string>
+    <string name="settings_format_preamble_speech_only">Tylko mowa</string>
+    <string name="settings_format_preamble_never">Nigdy</string>
 
     <!-- Fallback clothes rules — "If no rules match" section -->
     <string name="settings_default_outfit_title">Gdy żadna reguła nie pasuje</string>
@@ -1238,6 +1252,10 @@ is unchanged; only the displayed label localizes.
     <string name="today_clothes_promo_body">ClothesCast wybiera stroje na podstawie zestawu reguł. Dostosuj temperatury i spersonalizuj swoją garderobę w ustawieniach Ubrania.</string>
     <string name="today_clothes_promo_cta">Ustawienia ubrań</string>
     <string name="today_clothes_promo_dismiss">Odrzuć</string>
+    <string name="today_schedule_promo_title">Automatyczne ClothesCasty</string>
+    <string name="today_schedule_promo_body">Wybierz, kiedy otrzymujesz powiadomienia i komunikaty.</string>
+    <string name="today_schedule_promo_cta">Ustawienia harmonogramu</string>
+    <string name="today_schedule_promo_dismiss">Odrzuć</string>
     <string name="today_clothes_promo_title">Dostosuj ubrania do siebie</string>
     <string name="today_insight_format_link">Format</string>
     <string name="today_play">Odtwórz</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -391,6 +391,11 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="widget_description">O look do momento, num relance.</string>
     <string name="widget_empty_title">Nenhum look ainda</string>
     <string name="widget_empty_subtitle">Toque para abrir ClothesCast</string>
+    <string name="feels_like_widget_label">Gráfico de sensação térmica</string>
+    <string name="feels_like_widget_description">A sensação térmica do período atual.</string>
+    <string name="feels_like_week_widget_label">Sensação térmica (7 dias)</string>
+    <string name="feels_like_week_widget_description">A sensação térmica ao longo dos próximos 7 dias.</string>
+    <string name="feels_like_widget_empty_title">Nenhuma previsão ainda</string>
 
     <!--
     Onboarding flow — first-run welcome, two permission steps, Gemini
@@ -1009,6 +1014,10 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_schedule_enabled">ClothesCast diário</string>
     <string name="settings_delivery_notification">Notificar</string>
     <string name="settings_delivery_tts">Reproduzir voz</string>
+    <string name="speech_setup_title">Configurar ClothesCasts falados</string>
+    <string name="speech_setup_description">Escolha como seu ClothesCast é lido em voz alta. Use a voz gratuita do aparelho ou adicione uma chave API Gemini para vozes de alta qualidade.</string>
+    <string name="speech_setup_smart_home_note">A fala na casa inteligente requer uma chave API Gemini. A transmissão continua mostrando seu look sem ela.</string>
+    <string name="speech_setup_done">Concluído</string>
 
     <!-- Clothes-mention picker on Format / Schedule -->
     <string name="settings_clothes_mention_label">Roupa</string>
@@ -1038,6 +1047,11 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_format_rain_accessory_label">Acessório de chuva</string>
     <string name="settings_format_rain_accessory_none">Desativado</string>
     <string name="settings_format_rain_accessory_umbrella">Guarda-chuva</string>
+    <string name="settings_format_period_preamble_label">Introdução</string>
+    <string name="settings_format_wear_preamble_label">Introdução „Vista“</string>
+    <string name="settings_format_preamble_always">Sempre</string>
+    <string name="settings_format_preamble_speech_only">Apenas em voz alta</string>
+    <string name="settings_format_preamble_never">Nunca</string>
 
     <!-- Fallback clothes rules — "If no rules match" section -->
     <string name="settings_default_outfit_title">Se nenhuma regra corresponder</string>
@@ -1274,6 +1288,10 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="today_clothes_promo_body">ClothesCast escolhe os looks a partir de um conjunto de regras. Ajuste as temperaturas e personalize seu guarda-roupa em configurações de Roupas.</string>
     <string name="today_clothes_promo_cta">Configurações de Roupas</string>
     <string name="today_clothes_promo_dismiss">Dispensar</string>
+    <string name="today_schedule_promo_title">ClothesCasts automáticos</string>
+    <string name="today_schedule_promo_body">Escolha quando você recebe notificações e anúncios.</string>
+    <string name="today_schedule_promo_cta">Configurações de agendamento</string>
+    <string name="today_schedule_promo_dismiss">Dispensar</string>
     <string name="today_clothes_promo_title">Personalize as roupas</string>
     <string name="today_insight_format_link">Formato</string>
     <string name="today_play">Reproduzir</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -410,6 +410,11 @@ they diverge from BR ("Polonês" → "Polaco", "Holandês" →
     <string name="widget_description">O visual do momento, num relance.</string>
     <string name="widget_empty_title">Ainda sem visual</string>
     <string name="widget_empty_subtitle">Toca para abrir o ClothesCast</string>
+    <string name="feels_like_widget_label">Gráfico de sensação térmica</string>
+    <string name="feels_like_widget_description">A sensação térmica do período atual.</string>
+    <string name="feels_like_week_widget_label">Sensação térmica (7 dias)</string>
+    <string name="feels_like_week_widget_description">A sensação térmica ao longo dos próximos 7 dias.</string>
+    <string name="feels_like_widget_empty_title">Ainda sem previsão</string>
 
     <!--
     Onboarding flow — first-run welcome, two permission steps, Gemini
@@ -1052,6 +1057,10 @@ they diverge from BR ("Polonês" → "Polaco", "Holandês" →
     <string name="settings_schedule_enabled">ClothesCast diário</string>
     <string name="settings_delivery_notification">Notificar</string>
     <string name="settings_delivery_tts">Ler em voz alta</string>
+    <string name="speech_setup_title">Configurar ClothesCasts em voz alta</string>
+    <string name="speech_setup_description">Escolhe como o teu ClothesCast é lido em voz alta. Usa a voz gratuita do dispositivo ou adiciona uma chave API Gemini para vozes de alta qualidade.</string>
+    <string name="speech_setup_smart_home_note">A fala na casa inteligente requer uma chave API Gemini. A transmissão continua a mostrar o teu visual sem ela.</string>
+    <string name="speech_setup_done">Concluído</string>
 
     <!-- Clothes-mention picker on Format / Schedule -->
     <string name="settings_clothes_mention_label">Vestuário</string>
@@ -1081,6 +1090,11 @@ they diverge from BR ("Polonês" → "Polaco", "Holandês" →
     <string name="settings_format_rain_accessory_label">Acessório de chuva</string>
     <string name="settings_format_rain_accessory_none">Desligado</string>
     <string name="settings_format_rain_accessory_umbrella">Chapéu de chuva</string>
+    <string name="settings_format_period_preamble_label">Introdução</string>
+    <string name="settings_format_wear_preamble_label">Introdução «Veste»</string>
+    <string name="settings_format_preamble_always">Sempre</string>
+    <string name="settings_format_preamble_speech_only">Apenas em voz alta</string>
+    <string name="settings_format_preamble_never">Nunca</string>
 
     <!-- Fallback clothes rules — "If no rules match" section -->
     <string name="settings_default_outfit_title">Se nenhuma regra corresponder</string>
@@ -1317,6 +1331,10 @@ they diverge from BR ("Polonês" → "Polaco", "Holandês" →
     <string name="today_clothes_promo_body">ClothesCast escolhe os conjuntos a partir de um conjunto de regras. Ajusta as temperaturas e personaliza o teu guarda-roupa em definições de Roupa.</string>
     <string name="today_clothes_promo_cta">Definições de Roupa</string>
     <string name="today_clothes_promo_dismiss">Dispensar</string>
+    <string name="today_schedule_promo_title">ClothesCasts automáticos</string>
+    <string name="today_schedule_promo_body">Escolhe quando recebes notificações e anúncios.</string>
+    <string name="today_schedule_promo_cta">Definições de agendamento</string>
+    <string name="today_schedule_promo_dismiss">Dispensar</string>
     <string name="today_clothes_promo_title">Faz a roupa tua</string>
     <string name="today_insight_format_link">Formato</string>
     <string name="today_play">Reproduzir</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -141,6 +141,11 @@ surfaces fall back to default English (matching values-pl / values-uk).
     <string name="widget_description">Ținuta pentru perioada curentă, la o privire.</string>
     <string name="widget_empty_title">Nicio ținută încă</string>
     <string name="widget_empty_subtitle">Atinge pentru a deschide ClothesCast</string>
+    <string name="feels_like_widget_label">Grafic temperatură resimțită</string>
+    <string name="feels_like_widget_description">Temperatura resimțită pentru perioada curentă.</string>
+    <string name="feels_like_week_widget_label">Temperatură resimțită (7 zile)</string>
+    <string name="feels_like_week_widget_description">Temperatura resimțită pentru următoarele 7 zile.</string>
+    <string name="feels_like_widget_empty_title">Nicio prognoză încă</string>
 
     <!-- Forecast card. -->
     <string name="today_forecast_title">Prognoză orară</string>
@@ -901,6 +906,10 @@ surfaces fall back to default English (matching values-pl / values-uk).
     <string name="settings_schedule_enabled">ClothesCast zilnic</string>
     <string name="settings_delivery_notification">Notifică</string>
     <string name="settings_delivery_tts">Citește</string>
+    <string name="speech_setup_title">Configurează ClothesCast-uri citite cu voce tare</string>
+    <string name="speech_setup_description">Alege cum este citit cu voce tare ClothesCast-ul tău. Folosește vocea gratuită a dispozitivului sau adaugă o cheie API Gemini pentru voci de înaltă calitate.</string>
+    <string name="speech_setup_smart_home_note">Citirea în casa inteligentă necesită o cheie API Gemini. Transmiterea îți arată ținuta și fără ea.</string>
+    <string name="speech_setup_done">Gata</string>
 
     <!-- Clothes-mention picker on Format / Schedule -->
     <string name="settings_clothes_mention_label">Îmbrăcăminte</string>
@@ -930,6 +939,11 @@ surfaces fall back to default English (matching values-pl / values-uk).
     <string name="settings_format_rain_accessory_label">Accesoriu pentru ploaie</string>
     <string name="settings_format_rain_accessory_none">Oprit</string>
     <string name="settings_format_rain_accessory_umbrella">Umbrelă</string>
+    <string name="settings_format_period_preamble_label">Introducere</string>
+    <string name="settings_format_wear_preamble_label">Introducere „Poartă"</string>
+    <string name="settings_format_preamble_always">Mereu</string>
+    <string name="settings_format_preamble_speech_only">Doar vocal</string>
+    <string name="settings_format_preamble_never">Niciodată</string>
 
     <!-- Fallback clothes rules — "If no rules match" section -->
     <string name="settings_default_outfit_title">Dacă nicio regulă nu se potrivește</string>
@@ -1167,6 +1181,10 @@ surfaces fall back to default English (matching values-pl / values-uk).
     <string name="today_clothes_promo_body">ClothesCast alege ținute pe baza unui set de reguli. Modifică temperaturile și personalizează-ți garderoba în setările Haine.</string>
     <string name="today_clothes_promo_cta">Setări haine</string>
     <string name="today_clothes_promo_dismiss">Închide</string>
+    <string name="today_schedule_promo_title">ClothesCast-uri automate</string>
+    <string name="today_schedule_promo_body">Alege când primești notificări și anunțuri.</string>
+    <string name="today_schedule_promo_cta">Setări program</string>
+    <string name="today_schedule_promo_dismiss">Închide</string>
     <string name="today_clothes_promo_title">Fă hainele ale tale</string>
     <string name="today_insight_format_link">Format</string>
     <string name="today_play">Redă</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -553,6 +553,11 @@ only the displayed label localizes.
     <string name="widget_description">Образ для текущего периода — с одного взгляда.</string>
     <string name="widget_empty_title">Образа пока нет</string>
     <string name="widget_empty_subtitle">Нажми, чтобы открыть ClothesCast</string>
+    <string name="feels_like_widget_label">График ощущаемой температуры</string>
+    <string name="feels_like_widget_description">Ощущаемая температура для текущего периода.</string>
+    <string name="feels_like_week_widget_label">Ощущаемая температура (7 дней)</string>
+    <string name="feels_like_week_widget_description">Ощущаемая температура на ближайшие 7 дней.</string>
+    <string name="feels_like_widget_empty_title">Прогноза пока нет</string>
 
     <!--
     Onboarding flow — first-run welcome, two permission steps, Gemini
@@ -978,6 +983,10 @@ only the displayed label localizes.
     <string name="settings_schedule_enabled">Ежедневный ClothesCast</string>
     <string name="settings_delivery_notification">Уведомить</string>
     <string name="settings_delivery_tts">Озвучить</string>
+    <string name="speech_setup_title">Настрой озвучивание ClothesCast</string>
+    <string name="speech_setup_description">Выбери, как твой ClothesCast будет озвучиваться. Используй бесплатный голос устройства или добавь ключ API Gemini для голосов высокого качества.</string>
+    <string name="speech_setup_smart_home_note">Для озвучивания в умном доме нужен ключ API Gemini. Трансляция всё равно показывает твой образ и без него.</string>
+    <string name="speech_setup_done">Готово</string>
 
     <!-- Clothes-mention picker on Format / Schedule -->
     <string name="settings_clothes_mention_label">Одежда</string>
@@ -1007,6 +1016,11 @@ only the displayed label localizes.
     <string name="settings_format_rain_accessory_label">Аксессуар от дождя</string>
     <string name="settings_format_rain_accessory_none">Выкл.</string>
     <string name="settings_format_rain_accessory_umbrella">Зонт</string>
+    <string name="settings_format_period_preamble_label">Вступление</string>
+    <string name="settings_format_wear_preamble_label">Вступление «Надень»</string>
+    <string name="settings_format_preamble_always">Всегда</string>
+    <string name="settings_format_preamble_speech_only">Только в озвучке</string>
+    <string name="settings_format_preamble_never">Никогда</string>
 
     <!-- Fallback clothes rules — "If no rules match" section -->
     <string name="settings_default_outfit_title">Если ни одно правило не подходит</string>
@@ -1245,6 +1259,10 @@ only the displayed label localizes.
     <string name="today_clothes_promo_body">ClothesCast подбирает наряды по набору правил. Настрой температуры и персонализируй свой гардероб в настройках одежды.</string>
     <string name="today_clothes_promo_cta">Настройки одежды</string>
     <string name="today_clothes_promo_dismiss">Скрыть</string>
+    <string name="today_schedule_promo_title">Автоматические ClothesCast</string>
+    <string name="today_schedule_promo_body">Выбери, когда получать уведомления и объявления.</string>
+    <string name="today_schedule_promo_cta">Настройки расписания</string>
+    <string name="today_schedule_promo_dismiss">Скрыть</string>
     <string name="today_clothes_promo_title">Настрой одежду под себя</string>
     <string name="today_insight_format_link">Формат</string>
     <string name="today_play">Воспроизвести</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -488,6 +488,11 @@ What is NOT overridden, by design:
     <string name="widget_description">Outfit pre aktuálnu časť dňa na prvý pohľad.</string>
     <string name="widget_empty_title">Zatiaľ žiadny outfit</string>
     <string name="widget_empty_subtitle">Klepni pre otvorenie ClothesCastu</string>
+    <string name="feels_like_widget_label">Graf pocitovej teploty</string>
+    <string name="feels_like_widget_description">Pocitová teplota pre aktuálne obdobie.</string>
+    <string name="feels_like_week_widget_label">Pocitová (7 dní)</string>
+    <string name="feels_like_week_widget_description">Pocitová teplota na nasledujúcich 7 dní.</string>
+    <string name="feels_like_widget_empty_title">Zatiaľ žiadna predpoveď</string>
 
     <!--
     Onboarding flow.
@@ -946,6 +951,10 @@ What is NOT overridden, by design:
     <string name="settings_schedule_enabled">Denný ClothesCast</string>
     <string name="settings_delivery_notification">Upozorniť</string>
     <string name="settings_delivery_tts">Prečítať</string>
+    <string name="speech_setup_title">Nastav hovorené ClothesCasty</string>
+    <string name="speech_setup_description">Vyber, ako sa tvoj ClothesCast číta nahlas. Použi bezplatný hlas zariadenia, alebo pridaj Gemini API kľúč pre hlasy vo vysokej kvalite.</string>
+    <string name="speech_setup_smart_home_note">Hovorený výstup v inteligentnej domácnosti vyžaduje Gemini API kľúč. Casting tvoj outfit ukáže aj bez neho.</string>
+    <string name="speech_setup_done">Hotovo</string>
 
     <!-- Clothes-mention picker on Format / Schedule -->
     <string name="settings_clothes_mention_label">Oblečenie</string>
@@ -975,6 +984,11 @@ What is NOT overridden, by design:
     <string name="settings_format_rain_accessory_label">Doplnok do dažďa</string>
     <string name="settings_format_rain_accessory_none">Vypnuté</string>
     <string name="settings_format_rain_accessory_umbrella">Dáždnik</string>
+    <string name="settings_format_period_preamble_label">Úvod</string>
+    <string name="settings_format_wear_preamble_label">Úvod „Obleč si"</string>
+    <string name="settings_format_preamble_always">Vždy</string>
+    <string name="settings_format_preamble_speech_only">Iba hovorené</string>
+    <string name="settings_format_preamble_never">Nikdy</string>
 
     <!-- Fallback clothes rules — "If no rules match" section -->
     <string name="settings_default_outfit_title">Ak žiadne pravidlá nevyhovujú</string>
@@ -1213,6 +1227,10 @@ What is NOT overridden, by design:
     <string name="today_clothes_promo_body">ClothesCast vyberá oblečenie podľa sady pravidiel. Uprav teploty a prispôsob si šatník v nastaveniach Oblečenia.</string>
     <string name="today_clothes_promo_cta">Nastavenia oblečenia</string>
     <string name="today_clothes_promo_dismiss">Zavrieť</string>
+    <string name="today_schedule_promo_title">Automatické ClothesCasty</string>
+    <string name="today_schedule_promo_body">Vyber, kedy dostávaš oznámenia a hlásenia.</string>
+    <string name="today_schedule_promo_cta">Nastavenia plánu</string>
+    <string name="today_schedule_promo_dismiss">Zavrieť</string>
     <string name="today_clothes_promo_title">Prispôsob si oblečenie</string>
     <string name="today_insight_format_link">Formát</string>
     <string name="today_play">Prehrať</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -149,6 +149,11 @@ informal "ti"-form throughout, mirroring the Croatian / Serbian pass.
     <string name="widget_description">Obleka za trenutno obdobje na prvi pogled.</string>
     <string name="widget_empty_title">Še ni obleke</string>
     <string name="widget_empty_subtitle">Pritisni za odpiranje ClothesCasta</string>
+    <string name="feels_like_widget_label">Graf občutene temperature</string>
+    <string name="feels_like_widget_description">Občutena temperatura za trenutno obdobje.</string>
+    <string name="feels_like_week_widget_label">Občutena (7 dni)</string>
+    <string name="feels_like_week_widget_description">Občutena temperatura za naslednjih 7 dni.</string>
+    <string name="feels_like_widget_empty_title">Še ni napovedi</string>
 
     <!-- Hourly forecast card. -->
     <string name="today_forecast_title">Urna napoved</string>
@@ -909,6 +914,10 @@ informal "ti"-form throughout, mirroring the Croatian / Serbian pass.
     <string name="settings_schedule_enabled">Dnevni ClothesCast</string>
     <string name="settings_delivery_notification">Obvesti</string>
     <string name="settings_delivery_tts">Preberi</string>
+    <string name="speech_setup_title">Nastavi izgovorjene ClothesCaste</string>
+    <string name="speech_setup_description">Izberi, kako se tvoj ClothesCast prebere na glas. Uporabi brezplačni glas naprave ali dodaj Gemini API ključ za glasove visoke kakovosti.</string>
+    <string name="speech_setup_smart_home_note">Govor v pametnem domu zahteva Gemini API ključ. Predvajanje na zaslon tudi brez njega prikaže tvojo obleko.</string>
+    <string name="speech_setup_done">Končano</string>
 
     <!-- Clothes-mention picker on Format / Schedule -->
     <string name="settings_clothes_mention_label">Oblačila</string>
@@ -938,6 +947,11 @@ informal "ti"-form throughout, mirroring the Croatian / Serbian pass.
     <string name="settings_format_rain_accessory_label">Dodatek za dež</string>
     <string name="settings_format_rain_accessory_none">Izklopljeno</string>
     <string name="settings_format_rain_accessory_umbrella">Dežnik</string>
+    <string name="settings_format_period_preamble_label">Uvod</string>
+    <string name="settings_format_wear_preamble_label">Uvod »Obleci«</string>
+    <string name="settings_format_preamble_always">Vedno</string>
+    <string name="settings_format_preamble_speech_only">Samo govor</string>
+    <string name="settings_format_preamble_never">Nikoli</string>
 
     <!-- Fallback clothes rules — "If no rules match" section -->
     <string name="settings_default_outfit_title">Če se nobeno pravilo ne ujema</string>
@@ -1176,6 +1190,10 @@ informal "ti"-form throughout, mirroring the Croatian / Serbian pass.
     <string name="today_clothes_promo_body">ClothesCast izbira obleke po pravilih. Prilagodi temperature in svojo garderobo v nastavitvah Oblačila.</string>
     <string name="today_clothes_promo_cta">Nastavitve oblačil</string>
     <string name="today_clothes_promo_dismiss">Zapri</string>
+    <string name="today_schedule_promo_title">Samodejni ClothesCasti</string>
+    <string name="today_schedule_promo_body">Izberi, kdaj prejemaš obvestila in objave.</string>
+    <string name="today_schedule_promo_cta">Nastavitve urnika</string>
+    <string name="today_schedule_promo_dismiss">Zapri</string>
     <string name="today_clothes_promo_title">Prilagodi oblačila sebi</string>
     <string name="today_insight_format_link">Oblika</string>
     <string name="today_play">Predvajaj</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -477,6 +477,11 @@ native names for all locales (e.g. "Tyska (Tyskland)", "Franska (Frankrike)").
     <string name="widget_description">En snabb titt på outfitet för den aktuella delen av dagen.</string>
     <string name="widget_empty_title">Inget outfit ännu</string>
     <string name="widget_empty_subtitle">Tryck för att öppna ClothesCast</string>
+    <string name="feels_like_widget_label">Diagram över upplevd temperatur</string>
+    <string name="feels_like_widget_description">Den upplevda temperaturen för den aktuella perioden.</string>
+    <string name="feels_like_week_widget_label">Upplevd temperatur (7 dagar)</string>
+    <string name="feels_like_week_widget_description">Den upplevda temperaturen under de kommande 7 dagarna.</string>
+    <string name="feels_like_widget_empty_title">Ingen prognos ännu</string>
 
     <!-- Onboarding. -->
     <string name="onboarding_title">Välkommen till ClothesCast</string>
@@ -953,6 +958,10 @@ native names for all locales (e.g. "Tyska (Tyskland)", "Franska (Frankrike)").
     <string name="settings_schedule_enabled">Dagligt ClothesCast</string>
     <string name="settings_delivery_notification">Avisera</string>
     <string name="settings_delivery_tts">Läs upp</string>
+    <string name="speech_setup_title">Konfigurera talade ClothesCasts</string>
+    <string name="speech_setup_description">Välj hur din ClothesCast läses upp. Använd den kostnadsfria enhetsrösten, eller lägg till en Gemini-API-nyckel för röster av hög kvalitet.</string>
+    <string name="speech_setup_smart_home_note">Tal i smarta hemmet kräver en Gemini-API-nyckel. Casting visar ändå din outfit utan den.</string>
+    <string name="speech_setup_done">Klar</string>
 
     <!-- Clothes-mention picker on Format / Schedule -->
     <string name="settings_clothes_mention_label">Kläder</string>
@@ -982,6 +991,11 @@ native names for all locales (e.g. "Tyska (Tyskland)", "Franska (Frankrike)").
     <string name="settings_format_rain_accessory_label">Regnaccessoar</string>
     <string name="settings_format_rain_accessory_none">Av</string>
     <string name="settings_format_rain_accessory_umbrella">Paraply</string>
+    <string name="settings_format_period_preamble_label">Inledning</string>
+    <string name="settings_format_wear_preamble_label">\"Ta på\"-inledning</string>
+    <string name="settings_format_preamble_always">Alltid</string>
+    <string name="settings_format_preamble_speech_only">Endast tal</string>
+    <string name="settings_format_preamble_never">Aldrig</string>
 
     <!-- Fallback clothes rules — "If no rules match" section -->
     <string name="settings_default_outfit_title">Om inga regler matchar</string>
@@ -1218,6 +1232,10 @@ native names for all locales (e.g. "Tyska (Tyskland)", "Franska (Frankrike)").
     <string name="today_clothes_promo_body">ClothesCast väljer outfits utifrån en uppsättning regler. Justera temperaturerna och anpassa din garderob i Klädinställningar.</string>
     <string name="today_clothes_promo_cta">Klädinställningar</string>
     <string name="today_clothes_promo_dismiss">Stäng</string>
+    <string name="today_schedule_promo_title">Automatiska ClothesCasts</string>
+    <string name="today_schedule_promo_body">Välj när du får aviseringar och uppläsningar.</string>
+    <string name="today_schedule_promo_cta">Schemainställningar</string>
+    <string name="today_schedule_promo_dismiss">Stäng</string>
     <string name="today_clothes_promo_title">Gör kläderna till dina egna</string>
     <string name="today_insight_format_link">Format</string>
     <string name="today_play">Spela upp</string>

--- a/app/src/main/res/values-sw/strings.xml
+++ b/app/src/main/res/values-sw/strings.xml
@@ -135,6 +135,11 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="widget_description">Mavazi ya kipindi cha sasa kwa muhtasari.</string>
     <string name="widget_empty_title">Hakuna mavazi bado</string>
     <string name="widget_empty_subtitle">Gonga ili kufungua ClothesCast</string>
+    <string name="feels_like_widget_label">Chati ya joto linalohisi</string>
+    <string name="feels_like_widget_description">Joto linalohisi kwa kipindi cha sasa.</string>
+    <string name="feels_like_week_widget_label">Joto linalohisi (siku 7)</string>
+    <string name="feels_like_week_widget_description">Joto linalohisi kwa siku 7 zijazo.</string>
+    <string name="feels_like_widget_empty_title">Hakuna utabiri bado</string>
 
     <!-- Today forecast / charts -->
     <string name="today_forecast_title">Joto linalohisi</string>
@@ -896,6 +901,10 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="settings_schedule_enabled">ClothesCast ya kila siku</string>
     <string name="settings_delivery_notification">Arifu</string>
     <string name="settings_delivery_tts">Soma</string>
+    <string name="speech_setup_title">Sanidi ClothesCast zinazosomwa kwa sauti</string>
+    <string name="speech_setup_description">Chagua jinsi ClothesCast yako inavyosomwa kwa sauti. Tumia sauti ya bure ya kifaa, au ongeza ufunguo wa API wa Gemini kwa sauti za ubora wa juu.</string>
+    <string name="speech_setup_smart_home_note">Usemaji wa nyumba mahiri unahitaji ufunguo wa API wa Gemini. Kutuma kwenye skrini bado huonyesha mavazi yako bila huo.</string>
+    <string name="speech_setup_done">Imekamilika</string>
 
     <!-- Clothes-mention picker -->
     <string name="settings_clothes_mention_label">Mavazi</string>
@@ -925,6 +934,11 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="settings_format_rain_accessory_label">Kifaa cha mvua</string>
     <string name="settings_format_rain_accessory_none">Imezimwa</string>
     <string name="settings_format_rain_accessory_umbrella">Mwavuli</string>
+    <string name="settings_format_period_preamble_label">Utangulizi</string>
+    <string name="settings_format_wear_preamble_label">Utangulizi wa \"Vaa\"</string>
+    <string name="settings_format_preamble_always">Daima</string>
+    <string name="settings_format_preamble_speech_only">Kwa sauti pekee</string>
+    <string name="settings_format_preamble_never">Kamwe</string>
 
     <!-- Fallback clothes rules — "If no rules match" -->
     <string name="settings_default_outfit_title">Ikiwa hakuna sheria inayofaa</string>
@@ -1161,6 +1175,10 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="today_clothes_promo_body">ClothesCast huchagua nguo kutoka kwa seti ya kanuni. Rekebisha viwango vya joto na ubinafsishe nguo zako katika mipangilio ya Nguo.</string>
     <string name="today_clothes_promo_cta">Mipangilio ya nguo</string>
     <string name="today_clothes_promo_dismiss">Funga</string>
+    <string name="today_schedule_promo_title">ClothesCast za kiotomatiki</string>
+    <string name="today_schedule_promo_body">Chagua wakati unapopokea arifa na matangazo.</string>
+    <string name="today_schedule_promo_cta">Mipangilio ya ratiba</string>
+    <string name="today_schedule_promo_dismiss">Funga</string>
     <string name="today_clothes_promo_title">Fanya nguo ziwe zako</string>
     <string name="today_insight_format_link">Umbo</string>
     <string name="today_play">Cheza</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -145,6 +145,11 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="widget_description">ชุดแต่งกายของช่วงเวลาปัจจุบันโดยสังเขป</string>
     <string name="widget_empty_title">ยังไม่มีชุดแต่งกาย</string>
     <string name="widget_empty_subtitle">แตะเพื่อเปิด ClothesCast</string>
+    <string name="feels_like_widget_label">กราฟอุณหภูมิที่รู้สึก</string>
+    <string name="feels_like_widget_description">อุณหภูมิที่รู้สึกสำหรับช่วงเวลาปัจจุบัน</string>
+    <string name="feels_like_week_widget_label">อุณหภูมิที่รู้สึก (7 วัน)</string>
+    <string name="feels_like_week_widget_description">อุณหภูมิที่รู้สึกในช่วง 7 วันข้างหน้า</string>
+    <string name="feels_like_widget_empty_title">ยังไม่มีพยากรณ์</string>
 
     <!-- Forecast / charts -->
     <string name="today_forecast_title">พยากรณ์รายชั่วโมง</string>
@@ -925,6 +930,10 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="settings_schedule_enabled">ClothesCast รายวัน</string>
     <string name="settings_delivery_notification">แจ้งเตือน</string>
     <string name="settings_delivery_tts">พูด</string>
+    <string name="speech_setup_title">ตั้งค่า ClothesCast แบบพูด</string>
+    <string name="speech_setup_description">เลือกวิธีอ่านออกเสียง ClothesCast ของคุณ ใช้เสียงอุปกรณ์ฟรี หรือเพิ่ม Gemini API key เพื่อรับเสียงคุณภาพสูง</string>
+    <string name="speech_setup_smart_home_note">เสียงพูดบนสมาร์ทโฮมต้องใช้ Gemini API key การ Cast ยังคงแสดงชุดแต่งกายของคุณได้แม้ไม่มีคีย์</string>
+    <string name="speech_setup_done">เสร็จสิ้น</string>
 
     <!-- Clothes-mention picker -->
     <string name="settings_clothes_mention_label">เสื้อผ้า</string>
@@ -954,6 +963,11 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="settings_format_rain_accessory_label">อุปกรณ์กันฝน</string>
     <string name="settings_format_rain_accessory_none">ปิด</string>
     <string name="settings_format_rain_accessory_umbrella">ร่ม</string>
+    <string name="settings_format_period_preamble_label">คำนำ</string>
+    <string name="settings_format_wear_preamble_label">คำนำ "สวม"</string>
+    <string name="settings_format_preamble_always">เสมอ</string>
+    <string name="settings_format_preamble_speech_only">เฉพาะเสียงพูด</string>
+    <string name="settings_format_preamble_never">ไม่เลย</string>
 
     <!-- Fallback clothes rules — "If no rules match" -->
     <string name="settings_default_outfit_title">หากไม่มีกฎใดตรงกัน</string>
@@ -1189,6 +1203,10 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="today_clothes_promo_body">ClothesCast เลือกชุดตามชุดของกฎ ปรับอุณหภูมิและปรับแต่งตู้เสื้อผ้าของคุณในการตั้งค่าเสื้อผ้า</string>
     <string name="today_clothes_promo_cta">การตั้งค่าเสื้อผ้า</string>
     <string name="today_clothes_promo_dismiss">ปิด</string>
+    <string name="today_schedule_promo_title">ClothesCast อัตโนมัติ</string>
+    <string name="today_schedule_promo_body">เลือกเวลาที่คุณจะได้รับการแจ้งเตือนและการประกาศ</string>
+    <string name="today_schedule_promo_cta">การตั้งค่ากำหนดการ</string>
+    <string name="today_schedule_promo_dismiss">ปิด</string>
     <string name="today_clothes_promo_title">ปรับเสื้อผ้าให้เป็นของคุณ</string>
     <string name="today_insight_format_link">รูปแบบ</string>
     <string name="today_play">เล่น</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -312,6 +312,11 @@ displayed label localizes.
     <string name="widget_description">Mevcut günün dilimindeki kıyafete bir bakış.</string>
     <string name="widget_empty_title">Henüz kıyafet yok</string>
     <string name="widget_empty_subtitle">ClothesCast\'ı açmak için dokun</string>
+    <string name="feels_like_widget_label">Hissedilen sıcaklık grafiği</string>
+    <string name="feels_like_widget_description">Mevcut dönem için hissedilen sıcaklık.</string>
+    <string name="feels_like_week_widget_label">Hissedilen sıcaklık (7 gün)</string>
+    <string name="feels_like_week_widget_description">Önümüzdeki 7 gün boyunca hissedilen sıcaklık.</string>
+    <string name="feels_like_widget_empty_title">Henüz tahmin yok</string>
 
     <string name="onboarding_title">ClothesCast\'a Hoş Geldiniz</string>
     <string name="onboarding_subtitle">İki hızlı seçim ve hazırsın. Diğer her şeyin daha sonra ayarlardan değiştirebileceğin makul bir varsayılanı var.</string>
@@ -926,6 +931,10 @@ displayed label localizes.
     <string name="settings_schedule_enabled">Günlük ClothesCast</string>
     <string name="settings_delivery_notification">Bildir</string>
     <string name="settings_delivery_tts">Seslendir</string>
+    <string name="speech_setup_title">Sesli ClothesCast\'ları ayarla</string>
+    <string name="speech_setup_description">ClothesCast\'ının nasıl seslendirileceğini seç. Ücretsiz cihaz sesini kullan veya yüksek kaliteli sesler için bir Gemini API anahtarı ekle.</string>
+    <string name="speech_setup_smart_home_note">Akıllı ev seslendirmesi bir Gemini API anahtarı gerektirir. Yayınlama, anahtar olmadan da kıyafetini gösterir.</string>
+    <string name="speech_setup_done">Tamam</string>
 
     <!-- Clothes-mention picker on Format / Schedule -->
     <string name="settings_clothes_mention_label">Kıyafetler</string>
@@ -955,6 +964,11 @@ displayed label localizes.
     <string name="settings_format_rain_accessory_label">Yağmur aksesuarı</string>
     <string name="settings_format_rain_accessory_none">Kapalı</string>
     <string name="settings_format_rain_accessory_umbrella">Şemsiye</string>
+    <string name="settings_format_period_preamble_label">Giriş</string>
+    <string name="settings_format_wear_preamble_label">"Giy" girişi</string>
+    <string name="settings_format_preamble_always">Her zaman</string>
+    <string name="settings_format_preamble_speech_only">Yalnızca sesli</string>
+    <string name="settings_format_preamble_never">Asla</string>
 
     <!-- Fallback clothes rules — "If no rules match" -->
     <string name="settings_default_outfit_title">Hiçbir kural eşleşmezse</string>
@@ -1191,6 +1205,10 @@ displayed label localizes.
     <string name="today_clothes_promo_body">ClothesCast kıyafetleri bir dizi kurala göre seçer. Sıcaklıkları ayarla ve Kıyafet ayarlarından gardırobunu özelleştir.</string>
     <string name="today_clothes_promo_cta">Kıyafet ayarları</string>
     <string name="today_clothes_promo_dismiss">Kapat</string>
+    <string name="today_schedule_promo_title">Otomatik ClothesCast\'lar</string>
+    <string name="today_schedule_promo_body">Bildirimleri ve duyuruları ne zaman alacağını seç.</string>
+    <string name="today_schedule_promo_cta">Program ayarları</string>
+    <string name="today_schedule_promo_dismiss">Kapat</string>
     <string name="today_clothes_promo_title">Kıyafetleri kendine göre ayarla</string>
     <string name="today_insight_format_link">Biçim</string>
     <string name="today_play">Oynat</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -422,6 +422,11 @@ only the displayed label localizes.
     <string name="widget_description">Вбрання для поточного періоду з першого погляду.</string>
     <string name="widget_empty_title">Вбрання ще немає</string>
     <string name="widget_empty_subtitle">Натисніть, щоб відкрити ClothesCast</string>
+    <string name="feels_like_widget_label">Графік відчуваної температури</string>
+    <string name="feels_like_widget_description">Відчувана температура для поточного періоду.</string>
+    <string name="feels_like_week_widget_label">Відчувана температура (7 днів)</string>
+    <string name="feels_like_week_widget_description">Відчувана температура на наступні 7 днів.</string>
+    <string name="feels_like_widget_empty_title">Прогнозу ще немає</string>
 
     <!-- Hourly forecast card. -->
     <string name="today_forecast_title">Погодинний прогноз</string>
@@ -921,6 +926,10 @@ only the displayed label localizes.
     <string name="settings_schedule_enabled">Щоденний ClothesCast</string>
     <string name="settings_delivery_notification">Сповістити</string>
     <string name="settings_delivery_tts">Озвучити</string>
+    <string name="speech_setup_title">Налаштуйте озвучення ClothesCast</string>
+    <string name="speech_setup_description">Оберіть, як ваш ClothesCast читатиметься вголос. Використовуйте безкоштовний голос пристрою або додайте ключ API Gemini для голосів високої якості.</string>
+    <string name="speech_setup_smart_home_note">Озвучення в розумному домі потребує ключа API Gemini. Трансляція все одно показує ваше вбрання й без нього.</string>
+    <string name="speech_setup_done">Готово</string>
 
     <!-- Clothes-mention picker on Format / Schedule -->
     <string name="settings_clothes_mention_label">Одяг</string>
@@ -950,6 +959,11 @@ only the displayed label localizes.
     <string name="settings_format_rain_accessory_label">Аксесуар від дощу</string>
     <string name="settings_format_rain_accessory_none">Вимк.</string>
     <string name="settings_format_rain_accessory_umbrella">Парасоля</string>
+    <string name="settings_format_period_preamble_label">Вступ</string>
+    <string name="settings_format_wear_preamble_label">Вступ «Одягніть»</string>
+    <string name="settings_format_preamble_always">Завжди</string>
+    <string name="settings_format_preamble_speech_only">Лише в озвученні</string>
+    <string name="settings_format_preamble_never">Ніколи</string>
 
     <!-- Fallback clothes rules — "If no rules match" section -->
     <string name="settings_default_outfit_title">Якщо жодне правило не підходить</string>
@@ -1188,6 +1202,10 @@ only the displayed label localizes.
     <string name="today_clothes_promo_body">ClothesCast обирає одяг за правилами. Зміни температури та персоналізуй свій гардероб у налаштуваннях Одяг.</string>
     <string name="today_clothes_promo_cta">Налаштування одягу</string>
     <string name="today_clothes_promo_dismiss">Закрити</string>
+    <string name="today_schedule_promo_title">Автоматичні ClothesCast</string>
+    <string name="today_schedule_promo_body">Оберіть, коли отримувати сповіщення та оголошення.</string>
+    <string name="today_schedule_promo_cta">Налаштування розкладу</string>
+    <string name="today_schedule_promo_dismiss">Закрити</string>
     <string name="today_clothes_promo_title">Зроби одяг своїм</string>
     <string name="today_insight_format_link">Формат</string>
     <string name="today_play">Відтворити</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -144,6 +144,11 @@ Skipped intentionally: app_name (brand), insight_time_am/pm/midnight/noon
     <string name="widget_description">Trang phục giai đoạn hiện tại nhìn nhanh.</string>
     <string name="widget_empty_title">Chưa có trang phục</string>
     <string name="widget_empty_subtitle">Nhấn để mở ClothesCast</string>
+    <string name="feels_like_widget_label">Biểu đồ cảm giác</string>
+    <string name="feels_like_widget_description">Nhiệt độ cảm nhận cho giai đoạn hiện tại.</string>
+    <string name="feels_like_week_widget_label">Cảm giác (7 ngày)</string>
+    <string name="feels_like_week_widget_description">Nhiệt độ cảm nhận trong 7 ngày tới.</string>
+    <string name="feels_like_widget_empty_title">Chưa có dự báo</string>
 
     <!-- Forecast chart -->
     <string name="today_forecast_title">Dự báo theo giờ</string>
@@ -986,6 +991,10 @@ Skipped intentionally: app_name (brand), insight_time_am/pm/midnight/noon
     <string name="settings_schedule_enabled">ClothesCast hàng ngày</string>
     <string name="settings_delivery_notification">Thông báo</string>
     <string name="settings_delivery_tts">Đọc</string>
+    <string name="speech_setup_title">Thiết lập ClothesCast nói</string>
+    <string name="speech_setup_description">Chọn cách đọc to ClothesCast của bạn. Dùng giọng nói miễn phí của thiết bị, hoặc thêm khóa API Gemini để có giọng nói chất lượng cao.</string>
+    <string name="speech_setup_smart_home_note">Giọng nói trên nhà thông minh cần khóa API Gemini. Việc truyền hình vẫn hiển thị trang phục của bạn mà không cần khóa.</string>
+    <string name="speech_setup_done">Xong</string>
 
     <!-- Clothes-mention picker -->
     <string name="settings_clothes_mention_label">Quần áo</string>
@@ -1015,6 +1024,11 @@ Skipped intentionally: app_name (brand), insight_time_am/pm/midnight/noon
     <string name="settings_format_rain_accessory_label">Phụ kiện đi mưa</string>
     <string name="settings_format_rain_accessory_none">Tắt</string>
     <string name="settings_format_rain_accessory_umbrella">Ô</string>
+    <string name="settings_format_period_preamble_label">Câu mở đầu</string>
+    <string name="settings_format_wear_preamble_label">Câu mở đầu \"Mặc\"</string>
+    <string name="settings_format_preamble_always">Luôn luôn</string>
+    <string name="settings_format_preamble_speech_only">Chỉ khi đọc</string>
+    <string name="settings_format_preamble_never">Không bao giờ</string>
 
     <!-- Fallback clothes rules — "If no rules match" -->
     <string name="settings_default_outfit_title">Nếu không có quy tắc nào khớp</string>
@@ -1250,6 +1264,10 @@ Skipped intentionally: app_name (brand), insight_time_am/pm/midnight/noon
     <string name="today_clothes_promo_body">ClothesCast chọn trang phục dựa trên một bộ quy tắc. Điều chỉnh nhiệt độ và tùy chỉnh tủ quần áo của bạn trong cài đặt Quần áo.</string>
     <string name="today_clothes_promo_cta">Cài đặt quần áo</string>
     <string name="today_clothes_promo_dismiss">Bỏ qua</string>
+    <string name="today_schedule_promo_title">ClothesCast tự động</string>
+    <string name="today_schedule_promo_body">Chọn thời điểm bạn nhận thông báo và thông tin.</string>
+    <string name="today_schedule_promo_cta">Cài đặt lịch</string>
+    <string name="today_schedule_promo_dismiss">Bỏ qua</string>
     <string name="today_clothes_promo_title">Biến quần áo thành của riêng bạn</string>
     <string name="today_insight_format_link">Định dạng</string>
     <string name="today_play">Phát</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -380,6 +380,11 @@ label localizes.
     <string name="widget_description">当前时段的穿搭一目了然。</string>
     <string name="widget_empty_title">还没有穿搭</string>
     <string name="widget_empty_subtitle">点击打开 ClothesCast</string>
+    <string name="feels_like_widget_label">体感温度图表</string>
+    <string name="feels_like_widget_description">当前时段的体感温度。</string>
+    <string name="feels_like_week_widget_label">体感温度（7 天）</string>
+    <string name="feels_like_week_widget_description">未来 7 天的体感温度。</string>
+    <string name="feels_like_widget_empty_title">还没有预报</string>
 
     <!--
     Onboarding flow — first-run welcome, two permission steps, Gemini
@@ -1073,6 +1078,10 @@ label localizes.
     <string name="settings_schedule_enabled">每日 ClothesCast</string>
     <string name="settings_delivery_notification">通知</string>
     <string name="settings_delivery_tts">朗读</string>
+    <string name="speech_setup_title">设置语音 ClothesCast</string>
+    <string name="speech_setup_description">选择如何朗读你的 ClothesCast。使用免费的设备语音，或添加 Gemini API 密钥以获得高质量语音。</string>
+    <string name="speech_setup_smart_home_note">智能家居语音需要 Gemini API 密钥。即使没有它，投屏时仍会显示你的穿搭。</string>
+    <string name="speech_setup_done">完成</string>
 
     <!-- Clothes-mention picker on Format / Schedule -->
     <string name="settings_clothes_mention_label">服装</string>
@@ -1102,6 +1111,11 @@ label localizes.
     <string name="settings_format_rain_accessory_label">雨具</string>
     <string name="settings_format_rain_accessory_none">关闭</string>
     <string name="settings_format_rain_accessory_umbrella">雨伞</string>
+    <string name="settings_format_period_preamble_label">开场语</string>
+    <string name="settings_format_wear_preamble_label">“穿”的开场语</string>
+    <string name="settings_format_preamble_always">始终</string>
+    <string name="settings_format_preamble_speech_only">仅语音</string>
+    <string name="settings_format_preamble_never">从不</string>
 
     <!-- Fallback clothes rules — "If no rules match" -->
     <string name="settings_default_outfit_title">没有规则匹配时</string>
@@ -1337,6 +1351,10 @@ label localizes.
     <string name="today_clothes_promo_body">ClothesCast 根据一组规则挑选搭配。在服装设置中调整温度并自定义你的衣橱。</string>
     <string name="today_clothes_promo_cta">服装设置</string>
     <string name="today_clothes_promo_dismiss">关闭</string>
+    <string name="today_schedule_promo_title">自动 ClothesCast</string>
+    <string name="today_schedule_promo_body">选择何时收到通知和播报。</string>
+    <string name="today_schedule_promo_cta">计划设置</string>
+    <string name="today_schedule_promo_dismiss">关闭</string>
     <string name="today_clothes_promo_title">把服装变成你的</string>
     <string name="today_insight_format_link">格式</string>
     <string name="today_play">播放</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -371,6 +371,11 @@ label localises.
     <string name="widget_description">當前時段的穿搭一目瞭然。</string>
     <string name="widget_empty_title">還沒有穿搭</string>
     <string name="widget_empty_subtitle">點一下開啟 ClothesCast</string>
+    <string name="feels_like_widget_label">體感溫度圖表</string>
+    <string name="feels_like_widget_description">當前時段的體感溫度。</string>
+    <string name="feels_like_week_widget_label">體感溫度（7 天）</string>
+    <string name="feels_like_week_widget_description">未來 7 天的體感溫度。</string>
+    <string name="feels_like_widget_empty_title">還沒有預報</string>
 
     <!--
     Onboarding flow — first-run welcome, two permission steps, Gemini
@@ -1089,6 +1094,10 @@ label localises.
     <string name="settings_schedule_enabled">每日 ClothesCast</string>
     <string name="settings_delivery_notification">通知</string>
     <string name="settings_delivery_tts">朗讀</string>
+    <string name="speech_setup_title">設定語音 ClothesCast</string>
+    <string name="speech_setup_description">選擇如何朗讀你的 ClothesCast。使用免費的裝置語音，或新增 Gemini API 金鑰以獲得高品質語音。</string>
+    <string name="speech_setup_smart_home_note">智慧家庭語音需要 Gemini API 金鑰。即使沒有它，投放時仍會顯示你的穿搭。</string>
+    <string name="speech_setup_done">完成</string>
 
     <!-- Clothes-mention picker on Format / Schedule -->
     <string name="settings_clothes_mention_label">服裝</string>
@@ -1118,6 +1127,11 @@ label localises.
     <string name="settings_format_rain_accessory_label">雨具</string>
     <string name="settings_format_rain_accessory_none">關閉</string>
     <string name="settings_format_rain_accessory_umbrella">雨傘</string>
+    <string name="settings_format_period_preamble_label">開場語</string>
+    <string name="settings_format_wear_preamble_label">「穿」的開場語</string>
+    <string name="settings_format_preamble_always">總是</string>
+    <string name="settings_format_preamble_speech_only">僅語音</string>
+    <string name="settings_format_preamble_never">從不</string>
 
     <!-- Fallback clothes rules — "If no rules match" -->
     <string name="settings_default_outfit_title">沒有規則符合時</string>
@@ -1353,6 +1367,10 @@ label localises.
     <string name="today_clothes_promo_body">ClothesCast 根據一組規則挑選搭配。在服裝設定中調整溫度並自訂你的衣櫥。</string>
     <string name="today_clothes_promo_cta">服裝設定</string>
     <string name="today_clothes_promo_dismiss">關閉</string>
+    <string name="today_schedule_promo_title">自動 ClothesCast</string>
+    <string name="today_schedule_promo_body">選擇何時收到通知和播報。</string>
+    <string name="today_schedule_promo_cta">排程設定</string>
+    <string name="today_schedule_promo_dismiss">關閉</string>
     <string name="today_clothes_promo_title">把服裝變成你的</string>
     <string name="today_insight_format_link">格式</string>
     <string name="today_play">播放</string>


### PR DESCRIPTION
## What

Adds translations for the recently-added user-facing strings that were still English-only across the localized resource files. 18 strings × 44 full locales = 792 new lines.

### Strings translated
- **Schedule promo card** (Today screen): `today_schedule_promo_title`, `_body`, `_cta`, `_dismiss`
- **Feels-like chart widgets** (home screen): `feels_like_widget_label`, `_description`, `feels_like_week_widget_label`, `_description`, `feels_like_widget_empty_title`
- **Speech setup card**: `speech_setup_title`, `_description`, `_smart_home_note`, `_done`
- **Lead-in / "Wear" lead-in settings**: `settings_format_period_preamble_label`, `settings_format_wear_preamble_label`, `settings_format_preamble_always`, `_speech_only`, `_never`

### Scope
- Covers all **44 full locales**. The 8 sparse regional overlays (`de-rAT`, `de-rCH`, `en-rAU`, `en-rCA`, `en-rGB`, `en-rZA`, `es-rMX`, `fr-rCA`) inherit from their parent language and are intentionally left untouched.
- Shared labels (Dismiss / Always / Never / Done) **reuse each locale's existing sibling translation** (`today_clothes_promo_dismiss`, `settings_format_bottoms_always`/`_never`, `onboarding_step_done`) so identical UI labels stay identical.
- Brand names (**ClothesCast**, **Gemini**, **Open-Meteo**) kept verbatim per each file's documented house style; "feels-like" wording reuses each locale's existing term.

### Deliberately not translated
The English-only insight lead-in variants — `insight_*_no_lead` and `insight_clothes_bare` — are left out on purpose. `InsightFormatter.supportsNoLead()` gates that code path to `locale.language == "en"`; other locales keep the full lead-in. Translating them would create dead strings unless `supportsNoLead()` is also widened, which is a separate behaviour change with per-language grammar implications.

## Privacy
No change to what leaves the device — these are display-only UI strings. Nothing in the weather/geocoding requests, insight prose sent to TTS, or telemetry payloads changes.

## Test plan
- `python` audit across all 44 locales: each of the 18 keys present **exactly once**, no duplicate names, REUSE values match their source verbatim, no `_no_lead`/`insight_clothes_bare` leakage, all files parse as well-formed XML.
- `./gradlew :app:processDebugResources` → **BUILD SUCCESSFUL** (resource compilation, same path as CI).
- `git diff --numstat`: +792 / -0, exactly +18 per locale file, only `values-*/strings.xml` touched.

https://claude.ai/code/session_01JiPQGVqPcUemeUd4MFhcHB

---
_Generated by [Claude Code](https://claude.ai/code/session_01JiPQGVqPcUemeUd4MFhcHB)_