### PR TITLE
Show the widget background through the chart's rounded corners

### DIFF
--- a/app/src/main/kotlin/app/clothescast/widget/ComposeRender.kt
+++ b/app/src/main/kotlin/app/clothescast/widget/ComposeRender.kt
@@ -3,7 +3,9 @@ package app.clothescast.widget
 import android.app.Presentation
 import android.content.Context
 import android.graphics.Bitmap
+import android.graphics.Color
 import android.graphics.PixelFormat
+import android.graphics.drawable.ColorDrawable
 import android.hardware.display.DisplayManager
 import android.hardware.display.VirtualDisplay
 import android.media.Image
@@ -84,7 +86,18 @@ internal suspend fun renderComposableToBitmap(
                 DisplayManager.VIRTUAL_DISPLAY_FLAG_PRESENTATION,
         )
         presentation = Presentation(context.applicationContext, virtualDisplay.display).apply {
-            window?.setLayout(widthPx, heightPx)
+            // Render onto a transparent window so only the content's own opaque
+            // pixels (the chart card) land in the bitmap; everything around it —
+            // and the card's rounded-corner cutouts — stays transparent, letting
+            // the Glance widgetBackground show through when the bitmap is drawn
+            // (matching how the Outfit widget composites its transparent icons).
+            // The Presentation's default window background is opaque and light,
+            // which previously baked white corners into the dark-mode widget.
+            // The RGBA_8888 ImageReader preserves the alpha channel.
+            window?.apply {
+                setLayout(widthPx, heightPx)
+                setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
+            }
         }
         val composeView = ComposeView(presentation.context).apply {
             setViewTreeLifecycleOwner(owner)

--- a/app/src/main/kotlin/app/clothescast/widget/FeelsLikeWidget.kt
+++ b/app/src/main/kotlin/app/clothescast/widget/FeelsLikeWidget.kt
@@ -207,7 +207,7 @@ private suspend fun buildChartBitmap(context: Context, weekly: Boolean): Bitmap?
     val bitmap = withTimeoutOrNull(RENDER_TIMEOUT_MS) {
         renderComposableToBitmap(context, RENDER_WIDTH_PX, RENDER_HEIGHT_PX) {
             ClothesCastTheme(darkTheme = darkTheme, colorPalette = palette) {
-                WidgetForecastChartCanvas(
+                WidgetForecastChart(
                     hourly = hourly,
                     days = days,
                     temperatureUnit = prefs.temperatureUnit,

--- a/app/src/main/kotlin/app/clothescast/widget/FeelsLikeWidgetChart.kt
+++ b/app/src/main/kotlin/app/clothescast/widget/FeelsLikeWidgetChart.kt
@@ -1,14 +1,9 @@
 package app.clothescast.widget
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.ProvidedValue
 import androidx.compose.runtime.remember
-import androidx.compose.ui.Modifier
 import app.clothescast.core.domain.model.DailyForecast
 import app.clothescast.core.domain.model.HourlyForecast
 import app.clothescast.core.domain.model.TemperatureUnit
@@ -93,44 +88,6 @@ internal fun WidgetForecastChart(
                 showLegend = false,
             )
         }
-    }
-}
-
-/**
- * Runtime-only wrapper that paints the theme background behind
- * [WidgetForecastChart] before it's rasterised to the widget bitmap.
- *
- * The off-screen [renderComposableToBitmap] hosts the chart in a `Presentation`
- * window whose default background is light, so in dark mode that white bled
- * through the card's rounded corners (and any letterbox around the card) in the
- * captured bitmap — the gap the home-screen widget showed. Filling the render
- * surface with `colorScheme.background` — the same surface the previews sit on
- * via `WidgetFrame` — makes the corners match the app instead of flashing white.
- *
- * This lives apart from [WidgetForecastChart] (rather than wrapping it inline)
- * so the snapshot previews, which already supply their own themed background and
- * render at wrap-content height, stay untouched: `fillMaxSize` here fills the
- * fixed render size at runtime but would balloon the bounded-height preview
- * canvas with empty space.
- */
-@Composable
-internal fun WidgetForecastChartCanvas(
-    hourly: List<HourlyForecast>,
-    days: List<DailyForecast>?,
-    temperatureUnit: TemperatureUnit,
-    timeFormat: TimeFormat,
-    startDate: LocalDate,
-    now: LocalDateTime?,
-) {
-    Box(modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.background)) {
-        WidgetForecastChart(
-            hourly = hourly,
-            days = days,
-            temperatureUnit = temperatureUnit,
-            timeFormat = timeFormat,
-            startDate = startDate,
-            now = now,
-        )
     }
 }
 


### PR DESCRIPTION
## Follow-up to #784

#784 stopped the dark-mode chart widget showing **white** corners by filling the off-screen render with the theme background. But that fill was opaque `colorScheme.background` (near-black), while the chart `Card`'s surface is a lighter charcoal — so the rounded-corner cutouts read as flat black against the card.

## Fix

Render the chart onto a **transparent** `Presentation` window instead of baking in a background colour. Only the chart card's own pixels are opaque; the area around it — and the card's rounded-corner cutouts — stays transparent in the captured bitmap. The Glance `widgetBackground` then shows through, exactly how the Outfit widget composites its transparent icons, so the two widgets stay visually consistent.

This also removes the `WidgetForecastChartCanvas` wrapper added in #784 (no longer needed) and reverts `FeelsLikeWidget` to render `WidgetForecastChart` directly. The original white-corners root cause — the `Presentation`'s opaque, light default window background being baked into the bitmap — is now addressed at the source by setting that window background transparent. The `RGBA_8888` `ImageReader` preserves the alpha channel.

## Testing

- `./gradlew :app:testDebugUnitTest` — pass (widget snapshots unchanged; `ComposeRender`/`provideGlance` aren't exercised by Roborazzi)
- `./gradlew :app:assembleDebug` — pass

The off-screen render path can't be exercised by Robolectric (no real display/window), so the transparent-corner result needs an on-device check. Note: in dark mode `widgetBackground` is itself near-black, so the corners will read dark — but they'll match the rest of the widget frame and the Outfit widget rather than appearing as a separate black box.

https://claude.ai/code/session_01KU29sum73J67jG7191Ec99

---
_Generated by [Claude Code](https://claude.ai/code/session_01KU29sum73J67jG7191Ec99)_