### PR TITLE
Show the Schedule switches' real state on the first frame

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsState.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsState.kt
@@ -43,17 +43,23 @@ import java.util.Locale
 data class SettingsState(
     val scheduleTime: LocalTime = LocalTime.of(7, 0),
     val scheduleDays: Set<DayOfWeek> = Schedule.EVERY_DAY,
-    // Off by default to mirror the repository (see UserPreferences.dailyEnabled):
-    // the first render before DataStore emits must not show the switches on, or
-    // the user could leave Schedule believing casts are enabled when they aren't.
-    val dailyEnabled: Boolean = false,
+    // On by default to mirror the repository (see UserPreferences.dailyEnabled,
+    // where an absent key resolves to enabled): the morning cast ships on out of
+    // the box, so the first render before DataStore emits must not show the
+    // switch off, or the user could leave Schedule believing the morning cast is
+    // off while the app has already scheduled it.
+    val dailyEnabled: Boolean = true,
     val tonightTime: LocalTime = LocalTime.of(19, 0),
     val tonightDays: Set<DayOfWeek> = Schedule.EVERY_DAY,
     val tonightEnabled: Boolean = false,
     val tonightNotifyOnlyOnEvents: Boolean = false,
     val deliveryMode: DeliveryMode = DeliveryMode.NOTIFICATION_AND_TTS,
     val tonightDeliveryMode: DeliveryMode = DeliveryMode.NOTIFICATION_AND_TTS,
-    val dailyMentionEveningEvents: Boolean = true,
+    // Off by default to mirror the repository (see
+    // UserPreferences.dailyMentionEveningEvents, where an absent key resolves to
+    // disabled): the evening tie-in stays opt-in, so the first render before
+    // DataStore emits must not show the switch on.
+    val dailyMentionEveningEvents: Boolean = false,
     val clothesMentionMode: ClothesMentionMode = ClothesMentionMode.ALWAYS,
     val rangeFormat: RangeFormat = RangeFormat.DEGREES,
     val clothesFormat: ClothesFormat = ClothesFormat.ITEMS,


### PR DESCRIPTION
## Problem

`SettingsState`'s initial defaults were the *inverse* of the values `SettingsRepository` resolves for an absent key, so the Schedule page's switches could flash the wrong state on a cold render — before the DataStore `preferences` collection publishes its first emission into `SettingsViewModel`'s `MutableStateFlow(SettingsState())`.

Concretely, the repository / `UserPreferences` defaults are:

- `dailyEnabled` — absent morning key resolves to **enabled** (`SettingsRepository.kt`: `this[DAILY_ENABLED] != false`; `UserPreferences.dailyEnabled = true`)
- `dailyMentionEveningEvents` — absent evening-tie-in key resolves to **disabled** (`this[DAILY_MENTION_EVENING_EVENTS] == true`; `UserPreferences.dailyMentionEveningEvents = false`)

But `SettingsState` started with `dailyEnabled = false` and `dailyMentionEveningEvents = true` — both flipped. On the first frame a user could see the morning cast switch off (and back out believing it's off) while the app had already scheduled it, and see the evening tie-in switch on when it's actually opt-in/off.

The stale doc comment on `dailyEnabled` even claimed it was "off by default to mirror the repository," which stopped being true once the morning slot was flipped on by default.

## Fix

Flip both `SettingsState` initial defaults to match the repository:

- `dailyEnabled = true`
- `dailyMentionEveningEvents = false`

and rewrite the now-stale comments to describe the real contract.

## Privacy

No change to what leaves the device — UI-state defaults only.

## Test plan

- `./gradlew :app:testDebugUnitTest --tests "app.clothescast.ui.settings.*"` — green.

https://claude.ai/code/session_01BvYdYd1nLqcdmSRkSBghob

---
_Generated by [Claude Code](https://claude.ai/code/session_01BvYdYd1nLqcdmSRkSBghob)_