### PR TITLE
Record optional usage analytics more reliably

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -407,6 +407,12 @@ email the address listed on the Play Store listing.
 
 ## Changelog
 
+- **2026-05-29** — The optional usage-analytics settings snapshot now
+  records one analytics event per Settings page (Schedule, Clothes,
+  Format, Region, Display, Calendar) instead of a single combined event.
+  Content-neutral: the same coarsened settings values are reported, just
+  grouped by page; nothing new leaves the device and the same privacy
+  toggle still gates it.
 - **2026-05-23** — Internal change to how the daily insight is cached on
   device: the cache now stores the upstream forecast snapshot plus
   minimal event timing (start, end, all-day, a "has a location" flag),

--- a/app/src/main/kotlin/app/clothescast/diag/SettingsSnapshot.kt
+++ b/app/src/main/kotlin/app/clothescast/diag/SettingsSnapshot.kt
@@ -1,14 +1,19 @@
 package app.clothescast.diag
 
 /**
- * Aggregate-analytics view of the non-voice user settings, intended as the
- * params of a Firebase Analytics `settings_snapshot` event.
+ * Aggregate-analytics view of the non-voice user settings. Fanned out by
+ * [app.clothescast.diag.Telemetry] into one Firebase Analytics event per
+ * Settings page — `settings_schedule`, `settings_clothes`, `settings_format`,
+ * `settings_region`, `settings_display`, `settings_calendar` — so each event
+ * name mirrors the screen the user edited. The split keeps each event under
+ * Firebase's 25-param-per-event cap, which a single combined event had
+ * reached; this type stays one cohesive snapshot regardless.
  *
  * The voice / region / TTS-engine settings live separately in
  * [SettingsAnalyticsSnapshot] as user properties so reports can break every
  * event down by them. The settings captured here are emitted as event params
  * instead because Firebase Analytics caps custom user properties at 25 per
- * app — comprehensive configuration breakdowns belong on a periodic event.
+ * app — comprehensive configuration breakdowns belong on periodic events.
  *
  * Schedule times are bucketed to the hour ("00".."23") rather than exact
  * local times; the day-of-week shape is captured only as a count. No user

--- a/app/src/main/kotlin/app/clothescast/diag/Telemetry.kt
+++ b/app/src/main/kotlin/app/clothescast/diag/Telemetry.kt
@@ -178,35 +178,48 @@ object Telemetry {
     }
 
     /**
-     * Emits a `settings_snapshot` event whose params mirror the non-voice user
-     * settings. Fires once per process start (the DataStore-backed flow
-     * replays its current value to each new subscriber) and again every time
-     * the resolved snapshot's `equals` changes within the process — i.e.
-     * whenever the user toggles a setting. The per-launch baseline is
-     * intentional: it lets reports see "what's the default-vs-customised
-     * mix across the population?" without requiring the user to interact.
+     * Emits the user's non-voice settings as one event per Settings page —
+     * `settings_schedule`, `settings_clothes`, `settings_format`,
+     * `settings_region`, `settings_display`, and `settings_calendar` — so each
+     * event name mirrors the screen the user actually edited, and a new
+     * setting lands in the event for its own page.
+     *
+     * Why per-page events instead of one combined event: a Firebase Analytics
+     * event caps at 25 params, and the combined snapshot had reached exactly
+     * that, leaving no room for the next setting (Firebase silently drops
+     * params over the cap). Splitting by page gives each screen its own
+     * 25-param budget to grow into and keeps every dimension natively
+     * sliceable in reports. The split is content-neutral — the same
+     * already-coarsened values cross the device boundary, just grouped under
+     * different event names; no new field is sent (see PRIVACY.md).
+     *
+     * Fires once per process start (the DataStore-backed flow replays its
+     * current value to each new subscriber) and again every time the resolved
+     * snapshot's `equals` changes within the process — i.e. whenever the user
+     * toggles a setting. The per-launch baseline is intentional: it lets
+     * reports see "what's the default-vs-customised mix across the
+     * population?" without requiring the user to interact.
      */
     private fun logSettingsSnapshot(snapshot: SettingsSnapshot) {
         val analytics = analyticsRef ?: return
-        val params = Bundle().apply {
-            putString("temperature_unit_setting", snapshot.temperatureUnitSetting)
-            putString("temperature_unit_effective", snapshot.temperatureUnitEffective)
-            putString("distance_unit_setting", snapshot.distanceUnitSetting)
-            putString("distance_unit_effective", snapshot.distanceUnitEffective)
-            putString("delivery_mode_daily", snapshot.deliveryModeDaily)
-            putString("delivery_mode_tonight", snapshot.deliveryModeTonight)
-            putString("theme_mode", snapshot.themeMode)
-            putString("color_palette", snapshot.colorPalette)
-            putString("default_bottom", snapshot.defaultBottom)
-            putString("default_top", snapshot.defaultTop)
+        // Event order mirrors the Settings root menu order (see SettingsDest).
+        analytics.logEvent(EVENT_SETTINGS_SCHEDULE, Bundle().apply {
             putLong("daily_enabled", snapshot.dailyEnabled.toLongFlag())
             putString("daily_time_bucket_hour", snapshot.dailyTimeBucketHour)
             putLong("daily_days_count", snapshot.dailyDaysCount.toLong())
+            putString("delivery_mode_daily", snapshot.deliveryModeDaily)
             putLong("tonight_enabled", snapshot.tonightEnabled.toLongFlag())
             putString("tonight_time_bucket_hour", snapshot.tonightTimeBucketHour)
             putLong("tonight_days_count", snapshot.tonightDaysCount.toLong())
+            putString("delivery_mode_tonight", snapshot.deliveryModeTonight)
             putLong("tonight_notify_only_on_events", snapshot.tonightNotifyOnlyOnEvents.toLongFlag())
             putLong("daily_mention_evening_events", snapshot.dailyMentionEveningEvents.toLongFlag())
+        })
+        analytics.logEvent(EVENT_SETTINGS_CLOTHES, Bundle().apply {
+            putString("default_bottom", snapshot.defaultBottom)
+            putString("default_top", snapshot.defaultTop)
+        })
+        analytics.logEvent(EVENT_SETTINGS_FORMAT, Bundle().apply {
             putString("clothes_mention_mode", snapshot.clothesMentionMode)
             putString("range_format", snapshot.rangeFormat)
             putString("clothes_format", snapshot.clothesFormat)
@@ -214,9 +227,20 @@ object Telemetry {
             putString("rain_accessory", snapshot.rainAccessory)
             putLong("delta_threshold_c", snapshot.deltaThresholdC.toLong())
             putString("delta_format", snapshot.deltaFormat)
+        })
+        analytics.logEvent(EVENT_SETTINGS_REGION, Bundle().apply {
+            putString("temperature_unit_setting", snapshot.temperatureUnitSetting)
+            putString("temperature_unit_effective", snapshot.temperatureUnitEffective)
+            putString("distance_unit_setting", snapshot.distanceUnitSetting)
+            putString("distance_unit_effective", snapshot.distanceUnitEffective)
+        })
+        analytics.logEvent(EVENT_SETTINGS_DISPLAY, Bundle().apply {
+            putString("theme_mode", snapshot.themeMode)
+            putString("color_palette", snapshot.colorPalette)
+        })
+        analytics.logEvent(EVENT_SETTINGS_CALENDAR, Bundle().apply {
             putLong("use_calendar_events", snapshot.useCalendarEvents.toLongFlag())
-        }
-        analytics.logEvent(EVENT_SETTINGS_SNAPSHOT, params)
+        })
     }
 
     /**
@@ -252,7 +276,15 @@ object Telemetry {
     private const val EVENT_API_CALL = "api_call"
     private const val EVENT_NOTIFICATION_DELIVERY = "notification_delivery"
     private const val EVENT_DAILY_REFRESH = "daily_refresh"
-    private const val EVENT_SETTINGS_SNAPSHOT = "settings_snapshot"
+    // The non-voice settings snapshot is split into one event per Settings
+    // page (names mirror the screen titles) so each stays well under
+    // Firebase's 25-param-per-event cap; see logSettingsSnapshot.
+    private const val EVENT_SETTINGS_SCHEDULE = "settings_schedule"
+    private const val EVENT_SETTINGS_CLOTHES = "settings_clothes"
+    private const val EVENT_SETTINGS_FORMAT = "settings_format"
+    private const val EVENT_SETTINGS_REGION = "settings_region"
+    private const val EVENT_SETTINGS_DISPLAY = "settings_display"
+    private const val EVENT_SETTINGS_CALENDAR = "settings_calendar"
     private const val EVENT_CLOTHES_RULES_SNAPSHOT = "clothes_rules_snapshot"
     private const val PARAM_ENDPOINT = "endpoint"
     private const val PARAM_OUTCOME = "outcome"

--- a/app/src/test/kotlin/app/clothescast/diag/TelemetryPrivacyContractTest.kt
+++ b/app/src/test/kotlin/app/clothescast/diag/TelemetryPrivacyContractTest.kt
@@ -25,7 +25,15 @@ class TelemetryPrivacyContractTest {
         "api_call",
         "notification_delivery",
         "daily_refresh",
-        "settings_snapshot",
+        // The non-voice settings snapshot fans out into one event per Settings
+        // page (one combined event would exceed Firebase's 25-param cap); the
+        // param-key allowlist below is unchanged — same keys, regrouped.
+        "settings_schedule",
+        "settings_clothes",
+        "settings_format",
+        "settings_region",
+        "settings_display",
+        "settings_calendar",
         "clothes_rules_snapshot",
     )
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -180,8 +180,11 @@ PRIVACY.md and is mirrored inline in the Settings → Privacy card.
 
 Live events: `api_call` (endpoint, outcome, status, latency;
 offline-filtered), `notification_delivery` (slot, alarm delay, total
-delay), `daily_refresh` (slot, outcome, latency), `settings_snapshot`
-(non-voice configuration), and `clothes_rules_snapshot` (customisation
+delay), `daily_refresh` (slot, outcome, latency), the non-voice
+configuration split into one event per Settings page (`settings_schedule`
+/ `settings_clothes` / `settings_format` / `settings_region` /
+`settings_display` / `settings_calendar` — one combined event would
+exceed Firebase's 25-param cap), and `clothes_rules_snapshot` (customisation
 summary + per-category integer Celsius delta from default, clamped to
 ±5°C). Live user properties: language / region / TTS-engine / TTS-style
 / voice settings as default / override / effective triples — kept to a


### PR DESCRIPTION
## Problem

The non-voice settings were reported as a single Firebase Analytics `settings_snapshot` event whose parameter list had reached Firebase's **hard cap of 25 parameters per event**. The next setting would push the event over the cap, at which point Firebase silently drops the overflow parameters by insertion order — so a newly added dimension (or an existing trailing one such as `use_calendar_events`) would stop being recorded on any telemetry-enabled run.

## Change

Split the one event into **one event per Settings page**, so each event name mirrors the screen the user actually edited and a new setting lands in the event for its own page. Each is well under the cap with independent room to grow:

| event | Settings page | params |
|-------|---------------|--------|
| `settings_schedule` | Schedule | 10 |
| `settings_clothes` | Clothes | 2 |
| `settings_format` | Format | 6 |
| `settings_region` | Region | 4 |
| `settings_display` | Display | 2 |
| `settings_calendar` | Calendar | 1 |

`SettingsSnapshot` stays one cohesive snapshot type; only its fan-out into Analytics events changed (`Telemetry.logSettingsSnapshot`). Event order mirrors the Settings root menu order.

## Privacy

**Content-neutral restructure — nothing new leaves the device.** The same already-coarsened values (enum names, hour buckets, day *counts*, on/off flags) are sent, just grouped under different event names. No new field is emitted, and the Settings → Privacy telemetry toggle still gates everything.

The `TelemetryPrivacyContractTest` param-key allowlist is **unchanged** (same keys, regrouped); only the event-name allowlist gains the six per-page names, so the regression gate still proves no new field crosses the boundary. Deliberately did **not** move settings to user properties — that would attach them to every event and broaden the segmentable surface; the event split keeps the privacy posture identical.

Note: existing Firebase dashboards keyed on `settings_snapshot` will orphan under the retired event name.

## Test plan

- `./gradlew :app:testDebugUnitTest --tests "app.clothescast.diag.TelemetryPrivacyContractTest"` — BUILD SUCCESSFUL (event-name allowlist updated, param-key allowlist verified unchanged).

https://claude.ai/code/session_01USjf7hBKJQQPFrBjk82DDT