### PR TITLE
Hide the repeated day lead-in in every language, not just English

### DIFF
--- a/app/src/main/kotlin/app/clothescast/insight/InsightFormatter.kt
+++ b/app/src/main/kotlin/app/clothescast/insight/InsightFormatter.kt
@@ -116,7 +116,7 @@ class InsightFormatter(
      * Where the period preamble ("Today, it will be …") is allowed to survive.
      * See [PreambleVisibility]. Combined with the per-call [InsightSurface] to
      * decide whether the lead is included, omitted, or shown parenthesised.
-     * English-only (see [supportsNoLead]); other locales always include it.
+     * Applies in every locale — all ship `insight_*_no_lead` templates.
      *
      * Defaults to [PreambleVisibility.ALWAYS] — the *renderer's* default is to
      * show the full prose. The app's product default (drop the lead on visual
@@ -128,7 +128,8 @@ class InsightFormatter(
     /**
      * Where the wear preamble ("Wear " + leading article) is allowed to
      * survive. See [PreambleVisibility]. Dropping it turns "Wear a sweater."
-     * into "Sweater."; the preview shows "(Wear a) sweater.". English-only.
+     * into "Sweater."; the preview shows "(Wear a) sweater.". Applies in
+     * every locale.
      * Defaults to [PreambleVisibility.ALWAYS] (full prose), as above.
      */
     private val wearPreamble: PreambleVisibility = PreambleVisibility.ALWAYS,
@@ -158,8 +159,8 @@ class InsightFormatter(
      * [surface]. Under [PreambleVisibility.SPEECH_ONLY] the spoken ([
      * InsightSurface.SPEECH]) path keeps a preamble, every visual surface drops
      * it, and the Format-settings preview shows it parenthesised ("(Today, it
-     * will be) 14° to 20°."). All dropping / parenthesising is English-only (see
-     * [supportsNoLead]); other locales render the full forms regardless.
+     * will be) 14° to 20°."). Dropping / parenthesising applies in every locale
+     * — each ships its own `insight_*_no_lead` templates.
      */
     fun format(
         summary: InsightSummary,
@@ -186,9 +187,8 @@ class InsightFormatter(
      * Render the insight body for a single lead treatment ([omitLead]) and wear
      * treatment ([wearMode]). [format] calls this once for [LeadMode.INCLUDE] /
      * [LeadMode.OMIT] and twice for [LeadMode.PAREN] (the with- and without-lead
-     * forms it then splices). The "it will be" connective + first-clause
-     * re-capitalisation that dropping the lead entails are English-specific;
-     * [format] only ever passes `omitLead = true` when [supportsNoLead] holds.
+     * forms it then splices). Dropping the lead swaps in each locale's
+     * `insight_*_no_lead` templates and re-capitalises the first clause.
      */
     private fun renderInsight(
         summary: InsightSummary,
@@ -290,15 +290,10 @@ class InsightFormatter(
         val hasTemperatureSentence = bandCallout != null || rangeFormat != RangeFormat.NONE
         val body = if (!hasTemperatureSentence) {
             // In NONE mode the band is dropped, so when a numeric delta is
-            // present it's the first primary clause. English renders it as the
-            // self-introducing "it will be …" fragment that the period lead
-            // folds into ("Today, it will be 5° warmer …"); every other locale
-            // keeps its full, self-leading delta sentence ("Heute wird es 5°
-            // wärmer."), which already carries its own "today" word and must
-            // NOT have a second lead prepended — otherwise the prose doubles it
-            // ("Heute, heute wird es 5° wärmer.").
-            val firstClauseSelfLeads = numericDelta != null && !deltaHasLeadFragment()
-            renderLeadOnly(summary.period, isFutureDay, primaryClauses, tieInClauses, firstClauseSelfLeads, omitLead)
+            // present it's the first primary clause. It renders as the
+            // self-introducing "it will be …" fragment (insight_delta_*_lead)
+            // that the period lead folds into ("Today, it will be 5° warmer …").
+            renderLeadOnly(summary.period, isFutureDay, primaryClauses, tieInClauses, omitLead)
         } else {
             (primaryClauses + tieInClauses).joinToString(" ")
         }
@@ -339,7 +334,6 @@ class InsightFormatter(
         isFutureDay: Boolean,
         primaryClauses: List<String>,
         tieInClauses: List<String>,
-        firstClauseSelfLeads: Boolean,
         omitLead: Boolean,
     ): String {
         if (primaryClauses.isEmpty()) {
@@ -355,18 +349,11 @@ class InsightFormatter(
             return (listOf(first) + primaryClauses.drop(1) + tieInClauses).joinToString(" ")
         }
         val lead = resources.getString(leadRes(period, isFutureDay))
-        // A self-leading first clause (a localized full-sentence delta) already
-        // opens with its own "today" word, so emit it verbatim instead of
-        // folding the period lead in front of it.
-        val first = if (firstClauseSelfLeads) {
-            primaryClauses.first()
-        } else {
-            resources.getString(
-                R.string.insight_lead_continues,
-                lead,
-                decapitalize(primaryClauses.first()),
-            )
-        }
+        val first = resources.getString(
+            R.string.insight_lead_continues,
+            lead,
+            decapitalize(primaryClauses.first()),
+        )
         return (listOf(first) + primaryClauses.drop(1) + tieInClauses).joinToString(" ")
     }
 
@@ -382,17 +369,6 @@ class InsightFormatter(
         return text.substring(0, 1).uppercase(locale) + text.substring(1)
     }
 
-    /**
-     * Whether this locale supports dropping the "Today, it will be …" lead-in
-     * (used by the Today card, whose header already names the period). Stripping
-     * the lead means removing the "it will be" connective and re-capitalising
-     * the next word — both English-specific surgery. Locales that fuse the lead
-     * into the sentence ("Heute wird es …") have no no-lead templates and keep
-     * the full lead-in. English only for now; widen as the `_no_lead` keys get
-     * translated. Mirrors the [deltaHasLeadFragment] gate.
-     */
-    private fun supportsNoLead(): Boolean = locale.language == "en"
-
     /** How the period lead is rendered for a clause (see [leadMode]). */
     private enum class LeadMode { INCLUDE, OMIT, PAREN }
 
@@ -401,11 +377,11 @@ class InsightFormatter(
 
     /**
      * Resolve the period-preamble treatment for [surface] under the user's
-     * [periodPreamble]. Non-English locales always [LeadMode.INCLUDE] (the
-     * no-lead surgery is English-only, like [supportsNoLead]).
+     * [periodPreamble]. Every locale ships no-lead templates (the
+     * `insight_*_no_lead` strings), so dropping / parenthesising applies
+     * across languages.
      */
     private fun leadMode(surface: InsightSurface): LeadMode {
-        if (!supportsNoLead()) return LeadMode.INCLUDE
         return when (periodPreamble) {
             PreambleVisibility.ALWAYS -> LeadMode.INCLUDE
             PreambleVisibility.NEVER -> LeadMode.OMIT
@@ -419,11 +395,11 @@ class InsightFormatter(
 
     /**
      * Resolve the wear-preamble treatment for [surface] under the user's
-     * [wearPreamble]. Non-English locales always [WearMode.FULL] (dropping
-     * "Wear" + the leading article is English-only surgery).
+     * [wearPreamble]. Dropping "Wear" + the leading article reduces the clause
+     * to the (capitalised) garment body via `insight_clothes_bare`, which every
+     * locale now ships, so it applies across languages.
      */
     private fun wearMode(surface: InsightSurface): WearMode {
-        if (!supportsNoLead()) return WearMode.FULL
         return when (wearPreamble) {
             PreambleVisibility.ALWAYS -> WearMode.FULL
             PreambleVisibility.NEVER -> WearMode.BARE
@@ -526,16 +502,12 @@ class InsightFormatter(
     }
 
     private fun formatDelta(delta: DeltaClause, leadsTemperature: Boolean = false): String {
-        // The English delta is a bare fragment ("5° warmer than yesterday.")
-        // built to trail a band sentence; when it instead leads the temperature
-        // content it needs the "it will be …" subject. That self-introducing
-        // form has a localized template (insight_delta_*_lead) only for English
-        // so far. Other locales phrase their own delta as a full sentence
-        // already (German "Heute wird es 5° wärmer."), so they keep their
-        // existing string rather than have English spliced into localized
-        // prose — same en-only gating as spokenTime(). Widen the gate per
-        // locale as the _lead keys get translated.
-        val lead = leadsTemperature && deltaHasLeadFragment()
+        // The delta is normally a bare fragment ("5° warmer than yesterday.")
+        // built to trail a band sentence. When it instead leads the temperature
+        // content (range omitted) it needs the self-introducing "it will be …"
+        // form, which every locale ships as insight_delta_*_lead; the period
+        // lead is then folded in front of it by [renderLeadOnly].
+        val lead = leadsTemperature
         val template = when (delta.direction) {
             DeltaClause.Direction.WARMER ->
                 if (lead) R.string.insight_delta_warmer_lead else R.string.insight_delta_warmer
@@ -581,17 +553,6 @@ class InsightFormatter(
         val lead = resources.getString(leadRes(period, isFutureDay))
         return resources.getString(R.string.insight_band_words_single, lead, word)
     }
-
-    /**
-     * Whether this locale ships the self-introducing `insight_delta_*_lead`
-     * fragment ("it will be 5° warmer …"). Only English does so far; every
-     * other locale phrases its delta as a full self-leading sentence
-     * ("Heute wird es 5° wärmer."). [format] uses the inverse to decide
-     * whether [renderLeadOnly] should fold the period lead in front of the
-     * delta — keep the two in sync, and widen this gate as the `_lead` keys
-     * get translated.
-     */
-    private fun deltaHasLeadFragment(): Boolean = locale.language == "en"
 
     private fun formatClothesWear(items: List<String>, wearMode: WearMode): String? {
         return when (wearMode) {

--- a/app/src/main/res/values-am/strings.xml
+++ b/app/src/main/res/values-am/strings.xml
@@ -375,14 +375,21 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="insight_lead_today">ዛሬ</string>
     <string name="insight_lead_tomorrow">ነገ</string>
     <string name="insight_unchanged_today">ዛሬ እንደ ትናንቱ ይሆናል።</string>
+    <string name="insight_unchanged_today_no_lead">እንደ ትናንቱ።</string>
     <string name="insight_unchanged_tonight">ዛሬ ምሽት እንደ ትናንት ምሽቱ ይሆናል።</string>
+    <string name="insight_unchanged_tonight_no_lead">እንደ ትናንት ምሽቱ።</string>
     <string name="insight_unchanged_tomorrow">ነገ እንደ ዛሬው ይሆናል።</string>
+    <string name="insight_unchanged_tomorrow_no_lead">እንደ ዛሬው።</string>
     <string name="insight_lead_tonight">ዛሬ ምሽት</string>
     <!-- Amharic: "ዛሬ ምቹ ይሆናል።" -->
     <string name="insight_band_single">%1$s %2$d° ይሆናል።</string>
+    <string name="insight_band_single_no_lead">%1$d°.</string>
     <string name="insight_band_range">%1$s ከ%2$d° እስከ %3$d° ይሆናል።</string>
+    <string name="insight_band_range_no_lead">%1$d° እስከ %2$d° ይሆናል።</string>
     <string name="insight_band_words_single">%1$s %2$s ይሆናል።</string>
+    <string name="insight_band_words_single_no_lead">%1$s.</string>
     <string name="insight_band_words_range">%1$s ከ%2$s እስከ %3$s ይሆናል።</string>
+    <string name="insight_band_words_range_no_lead">%1$s እስከ %2$s ይሆናል።</string>
     <string name="insight_band_freezing">በጣም ቀዝቃዛ</string>
     <string name="insight_band_cold">ቀዝቃዛ</string>
     <string name="insight_band_cool">ትንሽ ቀዝቃዛ</string>
@@ -393,6 +400,7 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="insight_delta_cooler">ከትናንት %1$d° ቀዝቃዛ ይሆናል።</string>
     <string name="insight_alert">ማስጠንቀቂያ: %1$s።</string>
     <string name="insight_clothes_wear">%1$s ይልበሱ።</string>
+    <string name="insight_clothes_bare">%1$s.</string>
     <!-- Amharic has no grammatical articles; pass through bare. -->
     <string name="insight_clothes_article_a">%1$s</string>
     <string name="insight_clothes_article_an">%1$s</string>
@@ -923,6 +931,7 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="settings_format_change_label">የሙቀት ለውጥ</string>
     <string name="settings_format_change_off">ጠፍቷል</string>
     <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_change_band">ደረጃ</string>
     <string name="settings_format_clothes_label">የልብስ ቃላት</string>
     <string name="settings_format_clothes_items">ልብሶች</string>
     <string name="settings_format_clothes_layer_count">የመጠቅለያ ብዛት</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -52,14 +52,21 @@ they work correctly in both the single-band and range templates.
     <string name="insight_lead_today">اليوم</string>
     <string name="insight_lead_tomorrow">غدًا</string>
     <string name="insight_unchanged_today">اليوم سيكون الجو مثل الأمس.</string>
+    <string name="insight_unchanged_today_no_lead">مثل الأمس.</string>
     <string name="insight_unchanged_tonight">الليلة سيكون الجو مثل الليلة الماضية.</string>
+    <string name="insight_unchanged_tonight_no_lead">مثل الليلة الماضية.</string>
     <string name="insight_unchanged_tomorrow">غدًا سيكون الجو مثل اليوم.</string>
+    <string name="insight_unchanged_tomorrow_no_lead">مثل اليوم.</string>
     <string name="insight_lead_tonight">الليلة</string>
     <!-- "اليوم سيكون الجو معتدل." -->
     <string name="insight_band_single">%1$s سيكون الجو %2$d°.</string>
+    <string name="insight_band_single_no_lead">%1$d°.</string>
     <string name="insight_band_range">%1$s سيكون الجو بين %2$d° و%3$d°.</string>
+    <string name="insight_band_range_no_lead">%1$d° إلى %2$d°.</string>
     <string name="insight_band_words_single">%1$s سيكون الجو %2$s.</string>
+    <string name="insight_band_words_single_no_lead">%1$s.</string>
     <string name="insight_band_words_range">%1$s سيكون الجو بين %2$s و%3$s.</string>
+    <string name="insight_band_words_range_no_lead">%1$s إلى %2$s.</string>
     <string name="insight_band_freezing">شديد البرودة</string>
     <string name="insight_band_cold">بارد</string>
     <string name="insight_band_cool">لطيف</string>
@@ -70,6 +77,7 @@ they work correctly in both the single-band and range templates.
     <string name="insight_delta_cooler">سيكون اليوم أبرد بـ %1$d°.</string>
     <string name="insight_alert">تنبيه: %1$s.</string>
     <string name="insight_clothes_wear">ارتدِ %1$s.</string>
+    <string name="insight_clothes_bare">%1$s.</string>
     <!-- Arabic has no indefinite article equivalent to English "a/an". -->
     <string name="insight_clothes_article_a">%1$s</string>
     <string name="insight_clothes_article_an">%1$s</string>
@@ -953,6 +961,7 @@ they work correctly in both the single-band and range templates.
     <string name="settings_format_change_label">تغير درجة الحرارة</string>
     <string name="settings_format_change_off">إيقاف</string>
     <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_change_band">نطاق</string>
     <string name="settings_format_clothes_label">صياغة الملابس</string>
     <string name="settings_format_clothes_items">قطع الملابس</string>
     <string name="settings_format_clothes_layer_count">عدد الطبقات</string>

--- a/app/src/main/res/values-b+sr+Latn/strings.xml
+++ b/app/src/main/res/values-b+sr+Latn/strings.xml
@@ -74,13 +74,20 @@ default English (matching values-pl / values-uk).
     <string name="insight_lead_today">Danas</string>
     <string name="insight_lead_tomorrow">Sutra</string>
     <string name="insight_unchanged_today">Danas će biti isto kao juče.</string>
+    <string name="insight_unchanged_today_no_lead">Kao juče.</string>
     <string name="insight_unchanged_tonight">Večeras će biti isto kao sinoć.</string>
+    <string name="insight_unchanged_tonight_no_lead">Kao sinoć.</string>
     <string name="insight_unchanged_tomorrow">Sutra će biti isto kao danas.</string>
+    <string name="insight_unchanged_tomorrow_no_lead">Kao danas.</string>
     <string name="insight_lead_tonight">Večeras</string>
     <string name="insight_band_single">%1$s će biti %2$d°.</string>
+    <string name="insight_band_single_no_lead">%1$d°.</string>
     <string name="insight_band_range">%1$s će biti od %2$d° do %3$d°.</string>
+    <string name="insight_band_range_no_lead">%1$d° do %2$d°.</string>
     <string name="insight_band_words_single">%1$s će biti %2$s.</string>
+    <string name="insight_band_words_single_no_lead">%1$s.</string>
     <string name="insight_band_words_range">%1$s će biti od %2$s do %3$s.</string>
+    <string name="insight_band_words_range_no_lead">%1$s do %2$s.</string>
     <string name="insight_band_freezing">ledeno</string>
     <string name="insight_band_cold">hladno</string>
     <string name="insight_band_cool">sveže</string>
@@ -91,6 +98,7 @@ default English (matching values-pl / values-uk).
     <string name="insight_delta_cooler">Danas će biti %1$d° hladnije.</string>
     <string name="insight_alert">Upozorenje: %1$s.</string>
     <string name="insight_clothes_wear">Obuci %1$s.</string>
+    <string name="insight_clothes_bare">%1$s.</string>
     <string name="insight_clothes_article_a">%1$s</string>
     <string name="insight_clothes_article_an">%1$s</string>
     <string name="insight_clothes_join_two">%1$s i %2$s</string>
@@ -941,6 +949,7 @@ default English (matching values-pl / values-uk).
     <string name="settings_format_change_label">Promena temperature</string>
     <string name="settings_format_change_off">Isključeno</string>
     <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_change_band">Pojas</string>
     <string name="settings_format_clothes_label">Formulacija odeće</string>
     <string name="settings_format_clothes_items">Komadi odeće</string>
     <string name="settings_format_clothes_layer_count">Broj slojeva</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -60,13 +60,20 @@ What is NOT overridden, by design:
     <string name="insight_lead_today">Днес</string>
     <string name="insight_lead_tomorrow">Утре</string>
     <string name="insight_unchanged_today">Днес ще бъде същото като вчера.</string>
+    <string name="insight_unchanged_today_no_lead">Като вчера.</string>
     <string name="insight_unchanged_tonight">Тази вечер ще бъде същото като снощи.</string>
+    <string name="insight_unchanged_tonight_no_lead">Като снощи.</string>
     <string name="insight_unchanged_tomorrow">Утре ще бъде същото като днес.</string>
+    <string name="insight_unchanged_tomorrow_no_lead">Като днес.</string>
     <string name="insight_lead_tonight">Тази вечер</string>
     <string name="insight_band_single">%1$s ще бъде %2$d°.</string>
+    <string name="insight_band_single_no_lead">%1$d°.</string>
     <string name="insight_band_range">%1$s ще бъде от %2$d° до %3$d°.</string>
+    <string name="insight_band_range_no_lead">%1$d° до %2$d°.</string>
     <string name="insight_band_words_single">%1$s ще бъде %2$s.</string>
+    <string name="insight_band_words_single_no_lead">%1$s.</string>
     <string name="insight_band_words_range">%1$s ще бъде от %2$s до %3$s.</string>
+    <string name="insight_band_words_range_no_lead">%1$s до %2$s.</string>
     <string name="insight_band_freezing">мразовито</string>
     <string name="insight_band_cold">студено</string>
     <string name="insight_band_cool">хладно</string>
@@ -77,6 +84,7 @@ What is NOT overridden, by design:
     <string name="insight_delta_cooler">Днес ще бъде с %1$d° по-студено.</string>
     <string name="insight_alert">Предупреждение: %1$s.</string>
     <string name="insight_clothes_wear">Облечи %1$s.</string>
+    <string name="insight_clothes_bare">%1$s.</string>
     <string name="insight_clothes_article_a">%1$s</string>
     <string name="insight_clothes_article_an">%1$s</string>
     <string name="insight_clothes_join_two">%1$s и %2$s</string>
@@ -939,6 +947,7 @@ What is NOT overridden, by design:
     <string name="settings_format_change_label">Промяна на температурата</string>
     <string name="settings_format_change_off">Изключено</string>
     <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_change_band">Лента</string>
     <string name="settings_format_clothes_label">Формулировка на облеклото</string>
     <string name="settings_format_clothes_items">Дрехи</string>
     <string name="settings_format_clothes_layer_count">Брой слоеве</string>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -48,14 +48,21 @@ West Bengal vocabulary differences in a future PR.
     <string name="insight_lead_today">আজ</string>
     <string name="insight_lead_tomorrow">আগামীকাল</string>
     <string name="insight_unchanged_today">আজ আবহাওয়া গতকালের মতোই থাকবে।</string>
+    <string name="insight_unchanged_today_no_lead">গতকালের মতোই।</string>
     <string name="insight_unchanged_tonight">আজ রাতে আবহাওয়া গত রাতের মতোই থাকবে।</string>
+    <string name="insight_unchanged_tonight_no_lead">গত রাতের মতোই।</string>
     <string name="insight_unchanged_tomorrow">আগামীকাল আবহাওয়া আজকের মতোই থাকবে।</string>
+    <string name="insight_unchanged_tomorrow_no_lead">আজকের মতোই।</string>
     <string name="insight_lead_tonight">আজ রাতে</string>
     <!-- "আজ আবহাওয়া মনোরম থাকবে।" -->
     <string name="insight_band_single">%1$s আবহাওয়া %2$d° থাকবে।</string>
+    <string name="insight_band_single_no_lead">%1$d°.</string>
     <string name="insight_band_range">%1$s আবহাওয়া %2$d° থেকে %3$d° থাকবে।</string>
+    <string name="insight_band_range_no_lead">%1$d° থেকে %2$d° থাকবে।</string>
     <string name="insight_band_words_single">%1$s আবহাওয়া %2$s থাকবে।</string>
+    <string name="insight_band_words_single_no_lead">%1$s.</string>
     <string name="insight_band_words_range">%1$s আবহাওয়া %2$s থেকে %3$s থাকবে।</string>
+    <string name="insight_band_words_range_no_lead">%1$s থেকে %2$s থাকবে।</string>
     <string name="insight_band_freezing">হিমশীতল</string>
     <string name="insight_band_cold">ঠান্ডা</string>
     <string name="insight_band_cool">শীতল</string>
@@ -66,6 +73,7 @@ West Bengal vocabulary differences in a future PR.
     <string name="insight_delta_cooler">আজ %1$d° বেশি ঠান্ডা।</string>
     <string name="insight_alert">সতর্কতা: %1$s।</string>
     <string name="insight_clothes_wear">%1$s পরুন।</string>
+    <string name="insight_clothes_bare">%1$s.</string>
     <!-- Bengali has no grammatical articles. -->
     <string name="insight_clothes_article_a">%1$s</string>
     <string name="insight_clothes_article_an">%1$s</string>
@@ -1024,6 +1032,7 @@ West Bengal vocabulary differences in a future PR.
     <string name="settings_format_change_label">তাপমাত্রার পরিবর্তন</string>
     <string name="settings_format_change_off">বন্ধ</string>
     <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_change_band">শ্রেণি</string>
     <string name="settings_format_clothes_label">পোশাকের শব্দচয়ন</string>
     <string name="settings_format_clothes_items">পোশাক</string>
     <string name="settings_format_clothes_layer_count">স্তরের সংখ্যা</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -492,14 +492,21 @@ the in-app clock is digit-driven and reads consistently across locales.
     <string name="insight_lead_today">Avui</string>
     <string name="insight_lead_tomorrow">Demà</string>
     <string name="insight_unchanged_today">Avui farà el mateix temps que ahir.</string>
+    <string name="insight_unchanged_today_no_lead">Com ahir.</string>
     <string name="insight_unchanged_tonight">Aquesta nit farà el mateix temps que anit.</string>
+    <string name="insight_unchanged_tonight_no_lead">Com anit.</string>
     <string name="insight_unchanged_tomorrow">Demà farà el mateix temps que avui.</string>
+    <string name="insight_unchanged_tomorrow_no_lead">Com avui.</string>
     <string name="insight_lead_tonight">Aquesta nit</string>
     <!-- Catalan weather-as-verb: "Avui farà fred." (today will-make cold). -->
     <string name="insight_band_single">%1$s farà %2$d°.</string>
+    <string name="insight_band_single_no_lead">%1$d°.</string>
     <string name="insight_band_range">%1$s farà de %2$d° a %3$d°.</string>
+    <string name="insight_band_range_no_lead">%1$d° a %2$d°.</string>
     <string name="insight_band_words_single">%1$s farà %2$s.</string>
+    <string name="insight_band_words_single_no_lead">%1$s.</string>
     <string name="insight_band_words_range">%1$s farà de %2$s a %3$s.</string>
+    <string name="insight_band_words_range_no_lead">%1$s a %2$s.</string>
     <string name="insight_band_freezing">fred polar</string>
     <string name="insight_band_cold">fred</string>
     <string name="insight_band_cool">fresc</string>
@@ -511,6 +518,7 @@ the in-app clock is digit-driven and reads consistently across locales.
     <string name="insight_alert">Alerta: %1$s.</string>
     <!-- Reflexive imperative "tu": "Posa't el jersei." -->
     <string name="insight_clothes_wear">Posa\'t %1$s.</string>
+    <string name="insight_clothes_bare">%1$s.</string>
     <string name="insight_clothes_article_a">%1$s</string>
     <string name="insight_clothes_article_an">%1$s</string>
     <string name="insight_clothes_join_two">%1$s i %2$s</string>
@@ -892,6 +900,7 @@ the in-app clock is digit-driven and reads consistently across locales.
     <string name="settings_format_change_label">Variació de temperatura</string>
     <string name="settings_format_change_off">Desactivat</string>
     <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_change_band">Categoria</string>
     <string name="settings_format_clothes_label">Redacció de la roba</string>
     <string name="settings_format_clothes_items">Peces</string>
     <string name="settings_format_clothes_layer_count">Nombre de capes</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -542,13 +542,20 @@ locale (Angličtina (USA), Francouzština (Francie), Němčina (Německo), …).
     <string name="insight_lead_today">Dnes</string>
     <string name="insight_lead_tomorrow">Zítra</string>
     <string name="insight_unchanged_today">Dnes bude stejně jako včera.</string>
+    <string name="insight_unchanged_today_no_lead">Jako včera.</string>
     <string name="insight_unchanged_tonight">Dnes večer bude stejně jako včera večer.</string>
+    <string name="insight_unchanged_tonight_no_lead">Jako včera večer.</string>
     <string name="insight_unchanged_tomorrow">Zítra bude stejně jako dnes.</string>
+    <string name="insight_unchanged_tomorrow_no_lead">Jako dnes.</string>
     <string name="insight_lead_tonight">Dnes večer</string>
     <string name="insight_band_single">%1$s bude %2$d°.</string>
+    <string name="insight_band_single_no_lead">%1$d°.</string>
     <string name="insight_band_range">%1$s bude od %2$d° do %3$d°.</string>
+    <string name="insight_band_range_no_lead">%1$d° do %2$d°.</string>
     <string name="insight_band_words_single">%1$s bude %2$s.</string>
+    <string name="insight_band_words_single_no_lead">%1$s.</string>
     <string name="insight_band_words_range">%1$s bude od %2$s do %3$s.</string>
+    <string name="insight_band_words_range_no_lead">%1$s do %2$s.</string>
     <string name="insight_band_freezing">mrazivo</string>
     <string name="insight_band_cold">chladno</string>
     <string name="insight_band_cool">svěže</string>
@@ -559,6 +566,7 @@ locale (Angličtina (USA), Francouzština (Francie), Němčina (Německo), …).
     <string name="insight_delta_cooler">Dnes bude o %1$d° chladněji.</string>
     <string name="insight_alert">Výstraha: %1$s.</string>
     <string name="insight_clothes_wear">Obleč si %1$s.</string>
+    <string name="insight_clothes_bare">%1$s.</string>
     <string name="insight_clothes_article_a">%1$s</string>
     <string name="insight_clothes_article_an">%1$s</string>
     <string name="insight_clothes_join_two">%1$s a %2$s</string>
@@ -960,6 +968,7 @@ locale (Angličtina (USA), Francouzština (Francie), Němčina (Německo), …).
     <string name="settings_format_change_label">Změna teploty</string>
     <string name="settings_format_change_off">Vypnuto</string>
     <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_change_band">Pásmo</string>
     <string name="settings_format_clothes_label">Formulace oblečení</string>
     <string name="settings_format_clothes_items">Kusy oblečení</string>
     <string name="settings_format_clothes_layer_count">Počet vrstev</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -545,14 +545,21 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrig)").
     <string name="insight_lead_today">I dag</string>
     <string name="insight_lead_tomorrow">I morgen</string>
     <string name="insight_unchanged_today">I dag bliver det det samme som i går.</string>
+    <string name="insight_unchanged_today_no_lead">Som i går.</string>
     <string name="insight_unchanged_tonight">I aften bliver det det samme som i går aftes.</string>
+    <string name="insight_unchanged_tonight_no_lead">Som i går aftes.</string>
     <string name="insight_unchanged_tomorrow">I morgen bliver det det samme som i dag.</string>
+    <string name="insight_unchanged_tomorrow_no_lead">Som i dag.</string>
     <string name="insight_lead_tonight">I aften</string>
     <!-- Danish V2 word order: "I dag bliver det mildt." -->
     <string name="insight_band_single">%1$s bliver det %2$d°.</string>
+    <string name="insight_band_single_no_lead">%1$d°.</string>
     <string name="insight_band_range">%1$s bliver det %2$d° til %3$d°.</string>
+    <string name="insight_band_range_no_lead">%1$d° til %2$d°.</string>
     <string name="insight_band_words_single">%1$s bliver det %2$s.</string>
+    <string name="insight_band_words_single_no_lead">%1$s.</string>
     <string name="insight_band_words_range">%1$s bliver det %2$s til %3$s.</string>
+    <string name="insight_band_words_range_no_lead">%1$s til %2$s.</string>
 
     <string name="insight_band_freezing">iskoldt</string>
     <string name="insight_band_cold">koldt</string>
@@ -568,6 +575,7 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrig)").
 
     <!-- Split-verb "tag … på" = put on. -->
     <string name="insight_clothes_wear">Tag %1$s på.</string>
+    <string name="insight_clothes_bare">%1$s.</string>
     <string name="insight_clothes_article_a">%1$s</string>
     <string name="insight_clothes_article_an">%1$s</string>
     <string name="insight_clothes_join_two">%1$s og %2$s</string>
@@ -982,6 +990,7 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrig)").
     <string name="settings_format_change_label">Temperaturændring</string>
     <string name="settings_format_change_off">Fra</string>
     <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_change_band">Niveau</string>
     <string name="settings_format_clothes_label">Tøjformulering</string>
     <string name="settings_format_clothes_items">Tøjstykker</string>
     <string name="settings_format_clothes_layer_count">Antal lag</string>

--- a/app/src/main/res/values-de-rAT/strings.xml
+++ b/app/src/main/res/values-de-rAT/strings.xml
@@ -679,6 +679,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_format_change_label">Temperaturänderung</string>
     <string name="settings_format_change_off">Aus</string>
     <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_change_band">Stufe</string>
     <string name="settings_format_clothes_label">Kleidungs-Formulierung</string>
     <string name="settings_format_clothes_items">Kleidungsstücke</string>
     <string name="settings_format_clothes_layer_count">Anzahl der Schichten</string>

--- a/app/src/main/res/values-de-rCH/strings.xml
+++ b/app/src/main/res/values-de-rCH/strings.xml
@@ -684,6 +684,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_format_change_label">Temperaturänderung</string>
     <string name="settings_format_change_off">Aus</string>
     <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_change_band">Stufe</string>
     <string name="settings_format_clothes_label">Kleidungs-Formulierung</string>
     <string name="settings_format_clothes_items">Kleidungsstücke</string>
     <string name="settings_format_clothes_layer_count">Anzahl der Schichten</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -421,16 +421,23 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="insight_lead_today">Heute</string>
     <string name="insight_lead_tomorrow">Morgen</string>
     <string name="insight_unchanged_today">Heute wird es genauso wie gestern.</string>
+    <string name="insight_unchanged_today_no_lead">Wie gestern.</string>
     <string name="insight_unchanged_tonight">Heute Abend wird es genauso wie gestern Abend.</string>
+    <string name="insight_unchanged_tonight_no_lead">Wie gestern Abend.</string>
     <string name="insight_unchanged_tomorrow">Morgen wird es genauso wie heute.</string>
+    <string name="insight_unchanged_tomorrow_no_lead">Wie heute.</string>
     <string name="insight_lead_tonight">Heute Abend</string>
 
     <!-- "Heute wird es mild." / "Heute wird es kühl bis mild." Subject-second
          word order means the lead-in flows into "wird es ...". -->
     <string name="insight_band_single">%1$s wird es %2$d°.</string>
+    <string name="insight_band_single_no_lead">%1$d°.</string>
     <string name="insight_band_range">%1$s wird es %2$d° bis %3$d°.</string>
+    <string name="insight_band_range_no_lead">%1$d° bis %2$d°.</string>
     <string name="insight_band_words_single">%1$s wird es %2$s.</string>
+    <string name="insight_band_words_single_no_lead">%1$s.</string>
     <string name="insight_band_words_range">%1$s wird es %2$s bis %3$s.</string>
+    <string name="insight_band_words_range_no_lead">%1$s bis %2$s.</string>
 
     <string name="insight_band_freezing">eiskalt</string>
     <string name="insight_band_cold">kalt</string>
@@ -453,6 +460,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     wrong article. A future PR could add a gender hint to ClothesRule.
     -->
     <string name="insight_clothes_wear">Trag %1$s.</string>
+    <string name="insight_clothes_bare">%1$s.</string>
     <!-- Articles unused by GermanClothesPhraser (defined for parity / future use). -->
     <string name="insight_clothes_article_a">%1$s</string>
     <string name="insight_clothes_article_an">%1$s</string>
@@ -1108,6 +1116,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_format_change_label">Temperaturänderung</string>
     <string name="settings_format_change_off">Aus</string>
     <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_change_band">Stufe</string>
     <string name="settings_format_clothes_label">Kleidungs-Formulierung</string>
     <string name="settings_format_clothes_items">Kleidungsstücke</string>
     <string name="settings_format_clothes_layer_count">Anzahl der Schichten</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -481,13 +481,20 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="insight_lead_today">Σήμερα</string>
     <string name="insight_lead_tomorrow">Αύριο</string>
     <string name="insight_unchanged_today">Σήμερα θα είναι όπως χθες.</string>
+    <string name="insight_unchanged_today_no_lead">Όπως χθες.</string>
     <string name="insight_unchanged_tonight">Απόψε θα είναι όπως χθες το βράδυ.</string>
+    <string name="insight_unchanged_tonight_no_lead">Όπως χθες το βράδυ.</string>
     <string name="insight_unchanged_tomorrow">Αύριο θα είναι όπως σήμερα.</string>
+    <string name="insight_unchanged_tomorrow_no_lead">Όπως σήμερα.</string>
     <string name="insight_lead_tonight">Απόψε</string>
     <string name="insight_band_single">%1$s θα κάνει %2$d°.</string>
+    <string name="insight_band_single_no_lead">%1$d°.</string>
     <string name="insight_band_range">%1$s θα έχει %2$d° έως %3$d°.</string>
+    <string name="insight_band_range_no_lead">%1$d° έως %2$d°.</string>
     <string name="insight_band_words_single">%1$s θα κάνει %2$s.</string>
+    <string name="insight_band_words_single_no_lead">%1$s.</string>
     <string name="insight_band_words_range">%1$s θα έχει %2$s έως %3$s.</string>
+    <string name="insight_band_words_range_no_lead">%1$s έως %2$s.</string>
     <string name="insight_band_freezing">παγωνιά</string>
     <string name="insight_band_cold">κρύο</string>
     <string name="insight_band_cool">δροσιά</string>
@@ -498,6 +505,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="insight_delta_cooler">Σήμερα θα είναι %1$d° πιο κρύο από χθες.</string>
     <string name="insight_alert">Ειδοποίηση: %1$s.</string>
     <string name="insight_clothes_wear">Φόρεσε %1$s.</string>
+    <string name="insight_clothes_bare">%1$s.</string>
     <!-- Articles omitted — Greek garments carry grammatical gender
          (το πουλόβερ neuter, η μπλούζα feminine, το παντελόνι neuter,
          τα τζιν neuter plural) which would require per-rule metadata
@@ -1074,6 +1082,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_format_change_label">Μεταβολή θερμοκρασίας</string>
     <string name="settings_format_change_off">Ανενεργό</string>
     <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_change_band">Ζώνη</string>
     <string name="settings_format_clothes_label">Διατύπωση ρούχων</string>
     <string name="settings_format_clothes_items">Είδη ρούχων</string>
     <string name="settings_format_clothes_layer_count">Αριθμός στρώσεων</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -420,13 +420,20 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="insight_lead_today">Hoy</string>
     <string name="insight_lead_tomorrow">Mañana</string>
     <string name="insight_unchanged_today">Hoy hará el mismo tiempo que ayer.</string>
+    <string name="insight_unchanged_today_no_lead">Como ayer.</string>
     <string name="insight_unchanged_tonight">Esta noche hará el mismo tiempo que anoche.</string>
+    <string name="insight_unchanged_tonight_no_lead">Como anoche.</string>
     <string name="insight_unchanged_tomorrow">Mañana hará el mismo tiempo que hoy.</string>
+    <string name="insight_unchanged_tomorrow_no_lead">Como hoy.</string>
     <string name="insight_lead_tonight">Esta noche</string>
     <string name="insight_band_single">%1$s hará %2$d°.</string>
+    <string name="insight_band_single_no_lead">%1$d°.</string>
     <string name="insight_band_range">%1$s hará entre %2$d° y %3$d°.</string>
+    <string name="insight_band_range_no_lead">%1$d° a %2$d°.</string>
     <string name="insight_band_words_single">%1$s hará %2$s.</string>
+    <string name="insight_band_words_single_no_lead">%1$s.</string>
     <string name="insight_band_words_range">%1$s hará entre %2$s y %3$s.</string>
+    <string name="insight_band_words_range_no_lead">%1$s a %2$s.</string>
     <string name="insight_band_freezing">helada</string>
     <string name="insight_band_cold">frío</string>
     <string name="insight_band_cool">fresco</string>
@@ -437,6 +444,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="insight_delta_cooler">Hará %1$d° menos hoy.</string>
     <string name="insight_alert">Alerta: %1$s.</string>
     <string name="insight_clothes_wear">Lleva %1$s.</string>
+    <string name="insight_clothes_bare">%1$s.</string>
     <!-- Articles omitted — Spanish gender agreement requires per-garment metadata. -->
     <string name="insight_clothes_article_a">%1$s</string>
     <string name="insight_clothes_article_an">%1$s</string>
@@ -1080,6 +1088,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_format_change_label">Variación de temperatura</string>
     <string name="settings_format_change_off">Desactivado</string>
     <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_change_band">Categoría</string>
     <string name="settings_format_clothes_label">Redacción de la ropa</string>
     <string name="settings_format_clothes_items">Prendas</string>
     <string name="settings_format_clothes_layer_count">Número de capas</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -498,14 +498,21 @@ Tone is informal "sina"-form throughout ("Pane … selga", "Võta … kaasa",
     <string name="insight_lead_today">Täna</string>
     <string name="insight_lead_tomorrow">Homme</string>
     <string name="insight_unchanged_today">Täna on sama ilm kui eile.</string>
+    <string name="insight_unchanged_today_no_lead">Nagu eile.</string>
     <string name="insight_unchanged_tonight">Täna õhtul on sama ilm kui eile õhtul.</string>
+    <string name="insight_unchanged_tonight_no_lead">Nagu eile õhtul.</string>
     <string name="insight_unchanged_tomorrow">Homme on sama ilm kui täna.</string>
+    <string name="insight_unchanged_tomorrow_no_lead">Nagu täna.</string>
     <string name="insight_lead_tonight">Täna õhtul</string>
     <!-- Estonian copular shape: "Täna on külm." -->
     <string name="insight_band_single">%1$s on %2$d°.</string>
+    <string name="insight_band_single_no_lead">%1$d°.</string>
     <string name="insight_band_range">%1$s on %2$d° kuni %3$d°.</string>
+    <string name="insight_band_range_no_lead">%1$d° kuni %2$d°.</string>
     <string name="insight_band_words_single">%1$s on %2$s.</string>
+    <string name="insight_band_words_single_no_lead">%1$s.</string>
     <string name="insight_band_words_range">%1$s on %2$s kuni %3$s.</string>
+    <string name="insight_band_words_range_no_lead">%1$s kuni %2$s.</string>
     <string name="insight_band_freezing">jäine</string>
     <string name="insight_band_cold">külm</string>
     <string name="insight_band_cool">jahe</string>
@@ -517,6 +524,7 @@ Tone is informal "sina"-form throughout ("Pane … selga", "Võta … kaasa",
     <string name="insight_alert">Hoiatus: %1$s.</string>
     <!-- "Pane selga" = idiomatic "put on" with split verb. -->
     <string name="insight_clothes_wear">Pane selga %1$s.</string>
+    <string name="insight_clothes_bare">%1$s.</string>
     <string name="insight_clothes_article_a">%1$s</string>
     <string name="insight_clothes_article_an">%1$s</string>
     <string name="insight_clothes_join_two">%1$s ja %2$s</string>
@@ -896,6 +904,7 @@ Tone is informal "sina"-form throughout ("Pane … selga", "Võta … kaasa",
     <string name="settings_format_change_label">Temperatuuri muutus</string>
     <string name="settings_format_change_off">Väljas</string>
     <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_change_band">Vahemik</string>
     <string name="settings_format_clothes_label">Riietuse sõnastus</string>
     <string name="settings_format_clothes_items">Rõivad</string>
     <string name="settings_format_clothes_layer_count">Kihtide arv</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -50,14 +50,21 @@ Western Arabic numerals (0-9) are used for TTS compatibility.
     <string name="insight_lead_today">امروز</string>
     <string name="insight_lead_tomorrow">فردا</string>
     <string name="insight_unchanged_today">امروز هوا مثل دیروز خواهد بود.</string>
+    <string name="insight_unchanged_today_no_lead">مثل دیروز.</string>
     <string name="insight_unchanged_tonight">امشب هوا مثل دیشب خواهد بود.</string>
+    <string name="insight_unchanged_tonight_no_lead">مثل دیشب.</string>
     <string name="insight_unchanged_tomorrow">فردا هوا مثل امروز خواهد بود.</string>
+    <string name="insight_unchanged_tomorrow_no_lead">مثل امروز.</string>
     <string name="insight_lead_tonight">امشب</string>
     <!-- "امروز هوا معتدل خواهد بود." — SOV with lead first. -->
     <string name="insight_band_single">%1$s هوا %2$d° خواهد بود.</string>
+    <string name="insight_band_single_no_lead">%1$d°.</string>
     <string name="insight_band_range">%1$s هوا بین %2$d° و %3$d° خواهد بود.</string>
+    <string name="insight_band_range_no_lead">%1$d° تا %2$d° خواهد بود.</string>
     <string name="insight_band_words_single">%1$s هوا %2$s خواهد بود.</string>
+    <string name="insight_band_words_single_no_lead">%1$s.</string>
     <string name="insight_band_words_range">%1$s هوا بین %2$s و %3$s خواهد بود.</string>
+    <string name="insight_band_words_range_no_lead">%1$s تا %2$s خواهد بود.</string>
     <string name="insight_band_freezing">یخ‌زده</string>
     <string name="insight_band_cold">سرد</string>
     <string name="insight_band_cool">خنک</string>
@@ -69,6 +76,7 @@ Western Arabic numerals (0-9) are used for TTS compatibility.
     <string name="insight_alert">هشدار: %1$s.</string>
     <!-- SOV: "%1$s را بپوشید" = "[item] را (object marker) wear". -->
     <string name="insight_clothes_wear">%1$s را بپوشید.</string>
+    <string name="insight_clothes_bare">%1$s.</string>
     <!-- Persian has no indefinite article equivalent to English "a/an". -->
     <string name="insight_clothes_article_a">%1$s</string>
     <string name="insight_clothes_article_an">%1$s</string>
@@ -944,6 +952,7 @@ Western Arabic numerals (0-9) are used for TTS compatibility.
     <string name="settings_format_change_label">تغییر دما</string>
     <string name="settings_format_change_off">خاموش</string>
     <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_change_band">طیف</string>
     <string name="settings_format_clothes_label">عبارت لباس</string>
     <string name="settings_format_clothes_items">قطعه‌ها</string>
     <string name="settings_format_clothes_layer_count">تعداد لایه‌ها</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -339,15 +339,22 @@ displayed label localizes.
     <string name="insight_lead_today">Tänään</string>
     <string name="insight_lead_tomorrow">Huomenna</string>
     <string name="insight_unchanged_today">Tänään on sama sää kuin eilen.</string>
+    <string name="insight_unchanged_today_no_lead">Kuten eilen.</string>
     <string name="insight_unchanged_tonight">Tänä iltana on sama sää kuin eilen illalla.</string>
+    <string name="insight_unchanged_tonight_no_lead">Kuten eilen illalla.</string>
     <string name="insight_unchanged_tomorrow">Huomenna on sama sää kuin tänään.</string>
+    <string name="insight_unchanged_tomorrow_no_lead">Kuten tänään.</string>
     <string name="insight_lead_tonight">Tänä iltana</string>
 
     <!-- Finnish predicative-partitive: "Tänään on kylmää." -->
     <string name="insight_band_single">%1$s on %2$d°.</string>
+    <string name="insight_band_single_no_lead">%1$d°.</string>
     <string name="insight_band_range">%1$s on %2$d° tai %3$d°.</string>
+    <string name="insight_band_range_no_lead">%1$d° tai %2$d°.</string>
     <string name="insight_band_words_single">%1$s on %2$s.</string>
+    <string name="insight_band_words_single_no_lead">%1$s.</string>
     <string name="insight_band_words_range">%1$s on %2$s tai %3$s.</string>
+    <string name="insight_band_words_range_no_lead">%1$s tai %2$s.</string>
 
     <string name="insight_band_freezing">pakkasta</string>
     <string name="insight_band_cold">kylmää</string>
@@ -363,6 +370,7 @@ displayed label localizes.
 
     <!-- "Pue" = imperative "put on"; clothing nouns appear in partitive case. -->
     <string name="insight_clothes_wear">Pue %1$s.</string>
+    <string name="insight_clothes_bare">%1$s.</string>
     <string name="insight_clothes_article_a">%1$s</string>
     <string name="insight_clothes_article_an">%1$s</string>
     <string name="insight_clothes_join_two">%1$s ja %2$s</string>
@@ -961,6 +969,7 @@ displayed label localizes.
     <string name="settings_format_change_label">Lämpötilan muutos</string>
     <string name="settings_format_change_off">Pois</string>
     <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_change_band">Vyöhyke</string>
     <string name="settings_format_clothes_label">Vaatteiden sanamuoto</string>
     <string name="settings_format_clothes_items">Vaatekappaleet</string>
     <string name="settings_format_clothes_layer_count">Kerrosten määrä</string>

--- a/app/src/main/res/values-fil/strings.xml
+++ b/app/src/main/res/values-fil/strings.xml
@@ -46,14 +46,21 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="insight_lead_today">Ngayon</string>
     <string name="insight_lead_tomorrow">Bukas</string>
     <string name="insight_unchanged_today">Ngayon, magiging katulad ng kahapon.</string>
+    <string name="insight_unchanged_today_no_lead">Katulad ng kahapon.</string>
     <string name="insight_unchanged_tonight">Ngayong gabi, magiging katulad ng kagabi.</string>
+    <string name="insight_unchanged_tonight_no_lead">Katulad ng kagabi.</string>
     <string name="insight_unchanged_tomorrow">Bukas, magiging katulad ng ngayon.</string>
+    <string name="insight_unchanged_tomorrow_no_lead">Katulad ng ngayon.</string>
     <string name="insight_lead_tonight">Ngayong gabi</string>
     <!-- Filipino: "Ngayon, magiging malamig." -->
     <string name="insight_band_single">%1$s, magiging %2$d°.</string>
+    <string name="insight_band_single_no_lead">%1$d°.</string>
     <string name="insight_band_range">%1$s, magiging %2$d° hanggang %3$d°.</string>
+    <string name="insight_band_range_no_lead">%1$d° hanggang %2$d°.</string>
     <string name="insight_band_words_single">%1$s, magiging %2$s.</string>
+    <string name="insight_band_words_single_no_lead">%1$s.</string>
     <string name="insight_band_words_range">%1$s, magiging %2$s hanggang %3$s.</string>
+    <string name="insight_band_words_range_no_lead">%1$s hanggang %2$s.</string>
     <string name="insight_band_freezing">napakalamig</string>
     <string name="insight_band_cold">malamig</string>
     <string name="insight_band_cool">medyo malamig</string>
@@ -64,6 +71,7 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="insight_delta_cooler">Ngayon ay %1$d° mas malamig.</string>
     <string name="insight_alert">Babala: %1$s.</string>
     <string name="insight_clothes_wear">Magsuot ng %1$s.</string>
+    <string name="insight_clothes_bare">%1$s.</string>
     <!-- Filipino particles ("ng") are omitted in list context for naturalness. -->
     <string name="insight_clothes_article_a">%1$s</string>
     <string name="insight_clothes_article_an">%1$s</string>
@@ -1003,6 +1011,7 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="settings_format_change_label">Pagbabago ng temperatura</string>
     <string name="settings_format_change_off">Naka-off</string>
     <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_change_band">Banda</string>
     <string name="settings_format_clothes_label">Pananalita sa damit</string>
     <string name="settings_format_clothes_items">Mga damit</string>
     <string name="settings_format_clothes_layer_count">Bilang ng layer</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -422,13 +422,20 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="insight_lead_today">Aujourd\'hui</string>
     <string name="insight_lead_tomorrow">Demain</string>
     <string name="insight_unchanged_today">Aujourd\'hui, il fera le même temps qu\'hier.</string>
+    <string name="insight_unchanged_today_no_lead">Comme hier.</string>
     <string name="insight_unchanged_tonight">Ce soir, il fera le même temps qu\'hier soir.</string>
+    <string name="insight_unchanged_tonight_no_lead">Comme hier soir.</string>
     <string name="insight_unchanged_tomorrow">Demain, il fera le même temps qu\'aujourd\'hui.</string>
+    <string name="insight_unchanged_tomorrow_no_lead">Comme aujourd\'hui.</string>
     <string name="insight_lead_tonight">Ce soir</string>
     <string name="insight_band_single">%1$s, il fera %2$d°.</string>
+    <string name="insight_band_single_no_lead">%1$d°.</string>
     <string name="insight_band_range">%1$s, il fera entre %2$d° et %3$d°.</string>
+    <string name="insight_band_range_no_lead">%1$d° à %2$d°.</string>
     <string name="insight_band_words_single">%1$s, il fera %2$s.</string>
+    <string name="insight_band_words_single_no_lead">%1$s.</string>
     <string name="insight_band_words_range">%1$s, il fera entre %2$s et %3$s.</string>
+    <string name="insight_band_words_range_no_lead">%1$s à %2$s.</string>
     <string name="insight_band_freezing">très froid</string>
     <string name="insight_band_cold">froid</string>
     <string name="insight_band_cool">frais</string>
@@ -439,6 +446,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="insight_delta_cooler">Il fera %1$d° de moins aujourd\'hui.</string>
     <string name="insight_alert">Alerte : %1$s.</string>
     <string name="insight_clothes_wear">Porte %1$s.</string>
+    <string name="insight_clothes_bare">%1$s.</string>
     <!-- Articles omitted — French gender agreement can\'t be resolved without
          per-garment metadata; a flat list reads naturally ("Portez pull, veste"). -->
     <string name="insight_clothes_article_a">%1$s</string>
@@ -1079,6 +1087,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_format_change_label">Variation de température</string>
     <string name="settings_format_change_off">Désactivé</string>
     <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_change_band">Catégorie</string>
     <string name="settings_format_clothes_label">Formulation des vêtements</string>
     <string name="settings_format_clothes_items">Vêtements</string>
     <string name="settings_format_clothes_layer_count">Nombre de couches</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -458,14 +458,21 @@ Not overridden by design:
     <string name="insight_lead_today">आज</string>
     <string name="insight_lead_tomorrow">कल</string>
     <string name="insight_unchanged_today">आज मौसम कल जैसा रहेगा।</string>
+    <string name="insight_unchanged_today_no_lead">कल जैसा।</string>
     <string name="insight_unchanged_tonight">आज रात मौसम बीती रात जैसा रहेगा।</string>
+    <string name="insight_unchanged_tonight_no_lead">बीती रात जैसा।</string>
     <string name="insight_unchanged_tomorrow">कल मौसम आज जैसा रहेगा।</string>
+    <string name="insight_unchanged_tomorrow_no_lead">आज जैसा।</string>
     <string name="insight_lead_tonight">आज रात</string>
     <!-- "आज मौसम सुहाना रहेगा।" -->
     <string name="insight_band_single">%1$s मौसम %2$d° रहेगा।</string>
+    <string name="insight_band_single_no_lead">%1$d°.</string>
     <string name="insight_band_range">%1$s मौसम %2$d° से %3$d° रहेगा।</string>
+    <string name="insight_band_range_no_lead">%1$d° से %2$d° रहेगा।</string>
     <string name="insight_band_words_single">%1$s मौसम %2$s रहेगा।</string>
+    <string name="insight_band_words_single_no_lead">%1$s.</string>
     <string name="insight_band_words_range">%1$s मौसम %2$s से %3$s रहेगा।</string>
+    <string name="insight_band_words_range_no_lead">%1$s से %2$s रहेगा।</string>
     <string name="insight_band_freezing">बेहद ठंडा</string>
     <string name="insight_band_cold">ठंडा</string>
     <string name="insight_band_cool">ठंडक भरा</string>
@@ -476,6 +483,7 @@ Not overridden by design:
     <string name="insight_delta_cooler">आज %1$d° ज़्यादा ठंडा।</string>
     <string name="insight_alert">चेतावनी: %1$s।</string>
     <string name="insight_clothes_wear">%1$s पहनें।</string>
+    <string name="insight_clothes_bare">%1$s.</string>
     <!-- Hindi has no grammatical articles. -->
     <string name="insight_clothes_article_a">%1$s</string>
     <string name="insight_clothes_article_an">%1$s</string>
@@ -984,6 +992,7 @@ Not overridden by design:
     <string name="settings_format_change_label">तापमान परिवर्तन</string>
     <string name="settings_format_change_off">बंद</string>
     <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_change_band">श्रेणी</string>
     <string name="settings_format_clothes_label">कपड़ों के शब्द</string>
     <string name="settings_format_clothes_items">कपड़े</string>
     <string name="settings_format_clothes_layer_count">परतों की संख्या</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -392,13 +392,20 @@ spousal register), matching the existing insight prose ("Ponesi …",
     <string name="insight_lead_today">Danas</string>
     <string name="insight_lead_tomorrow">Sutra</string>
     <string name="insight_unchanged_today">Danas će biti isto kao jučer.</string>
+    <string name="insight_unchanged_today_no_lead">Kao jučer.</string>
     <string name="insight_unchanged_tonight">Večeras će biti isto kao sinoć.</string>
+    <string name="insight_unchanged_tonight_no_lead">Kao sinoć.</string>
     <string name="insight_unchanged_tomorrow">Sutra će biti isto kao danas.</string>
+    <string name="insight_unchanged_tomorrow_no_lead">Kao danas.</string>
     <string name="insight_lead_tonight">Večeras</string>
     <string name="insight_band_single">%1$s će biti %2$d°.</string>
+    <string name="insight_band_single_no_lead">%1$d°.</string>
     <string name="insight_band_range">%1$s će biti od %2$d° do %3$d°.</string>
+    <string name="insight_band_range_no_lead">%1$d° do %2$d°.</string>
     <string name="insight_band_words_single">%1$s će biti %2$s.</string>
+    <string name="insight_band_words_single_no_lead">%1$s.</string>
     <string name="insight_band_words_range">%1$s će biti od %2$s do %3$s.</string>
+    <string name="insight_band_words_range_no_lead">%1$s do %2$s.</string>
     <string name="insight_band_freezing">ledeno</string>
     <string name="insight_band_cold">hladno</string>
     <string name="insight_band_cool">svježe</string>
@@ -409,6 +416,7 @@ spousal register), matching the existing insight prose ("Ponesi …",
     <string name="insight_delta_cooler">Danas će biti %1$d° hladnije.</string>
     <string name="insight_alert">Upozorenje: %1$s.</string>
     <string name="insight_clothes_wear">Obuci %1$s.</string>
+    <string name="insight_clothes_bare">%1$s.</string>
     <string name="insight_clothes_article_a">%1$s</string>
     <string name="insight_clothes_article_an">%1$s</string>
     <string name="insight_clothes_join_two">%1$s i %2$s</string>
@@ -1021,6 +1029,7 @@ spousal register), matching the existing insight prose ("Ponesi …",
     <string name="settings_format_change_label">Promjena temperature</string>
     <string name="settings_format_change_off">Isključeno</string>
     <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_change_band">Pojas</string>
     <string name="settings_format_clothes_label">Formulacija odjeće</string>
     <string name="settings_format_clothes_items">Komadi odjeće</string>
     <string name="settings_format_clothes_layer_count">Broj slojeva</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -544,14 +544,21 @@ locale (Angol (Egyesült Államok), Francia (Franciaország), Német
     <string name="insight_lead_today">Ma</string>
     <string name="insight_lead_tomorrow">Holnap</string>
     <string name="insight_unchanged_today">Ma ugyanolyan lesz, mint tegnap.</string>
+    <string name="insight_unchanged_today_no_lead">Mint tegnap.</string>
     <string name="insight_unchanged_tonight">Ma este ugyanolyan lesz, mint tegnap este.</string>
+    <string name="insight_unchanged_tonight_no_lead">Mint tegnap este.</string>
     <string name="insight_unchanged_tomorrow">Holnap ugyanolyan lesz, mint ma.</string>
+    <string name="insight_unchanged_tomorrow_no_lead">Mint ma.</string>
     <string name="insight_lead_tonight">Ma este</string>
     <!-- "%1$s %2$s lesz." → "Ma hideg lesz." Lead first, then band, copula at end. -->
     <string name="insight_band_single">%1$s %2$d° lesz.</string>
+    <string name="insight_band_single_no_lead">%1$d°.</string>
     <string name="insight_band_range">%1$s %2$d° és %3$d° között lesz.</string>
+    <string name="insight_band_range_no_lead">%1$d° és %2$d° között lesz.</string>
     <string name="insight_band_words_single">%1$s %2$s lesz.</string>
+    <string name="insight_band_words_single_no_lead">%1$s.</string>
     <string name="insight_band_words_range">%1$s %2$s és %3$s között lesz.</string>
+    <string name="insight_band_words_range_no_lead">%1$s és %2$s között lesz.</string>
     <string name="insight_band_freezing">fagyos</string>
     <string name="insight_band_cold">hideg</string>
     <string name="insight_band_cool">hűvös</string>
@@ -562,6 +569,7 @@ locale (Angol (Egyesült Államok), Francia (Franciaország), Német
     <string name="insight_delta_cooler">Ma %1$d°-kal hidegebb lesz.</string>
     <string name="insight_alert">Figyelmeztetés: %1$s.</string>
     <string name="insight_clothes_wear">Vegyél fel %1$s.</string>
+    <string name="insight_clothes_bare">%1$s.</string>
     <string name="insight_clothes_article_a">%1$s</string>
     <string name="insight_clothes_article_an">%1$s</string>
     <string name="insight_clothes_join_two">%1$s és %2$s</string>
@@ -945,6 +953,7 @@ locale (Angol (Egyesült Államok), Francia (Franciaország), Német
     <string name="settings_format_change_label">Hőmérséklet-változás</string>
     <string name="settings_format_change_off">Ki</string>
     <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_change_band">Sáv</string>
     <string name="settings_format_clothes_label">Ruházat megfogalmazása</string>
     <string name="settings_format_clothes_items">Ruhadarabok</string>
     <string name="settings_format_clothes_layer_count">Rétegek száma</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -48,14 +48,21 @@ to values/strings.xml (English).
     <string name="insight_lead_today">Hari ini</string>
     <string name="insight_lead_tomorrow">Besok</string>
     <string name="insight_unchanged_today">Hari ini cuacanya sama seperti kemarin.</string>
+    <string name="insight_unchanged_today_no_lead">Seperti kemarin.</string>
     <string name="insight_unchanged_tonight">Malam ini cuacanya sama seperti tadi malam.</string>
+    <string name="insight_unchanged_tonight_no_lead">Seperti tadi malam.</string>
     <string name="insight_unchanged_tomorrow">Besok cuacanya sama seperti hari ini.</string>
+    <string name="insight_unchanged_tomorrow_no_lead">Seperti hari ini.</string>
     <string name="insight_lead_tonight">Malam ini</string>
     <!-- Indonesian SVO: "Hari ini cuacanya sejuk." -->
     <string name="insight_band_single">%1$s cuacanya %2$d°.</string>
+    <string name="insight_band_single_no_lead">%1$d°.</string>
     <string name="insight_band_range">%1$s cuacanya antara %2$d° hingga %3$d°.</string>
+    <string name="insight_band_range_no_lead">%1$d° hingga %2$d°.</string>
     <string name="insight_band_words_single">%1$s cuacanya %2$s.</string>
+    <string name="insight_band_words_single_no_lead">%1$s.</string>
     <string name="insight_band_words_range">%1$s cuacanya antara %2$s hingga %3$s.</string>
+    <string name="insight_band_words_range_no_lead">%1$s hingga %2$s.</string>
     <string name="insight_band_freezing">sangat dingin</string>
     <string name="insight_band_cold">dingin</string>
     <string name="insight_band_cool">sejuk</string>
@@ -66,6 +73,7 @@ to values/strings.xml (English).
     <string name="insight_delta_cooler">Hari ini %1$d° lebih dingin.</string>
     <string name="insight_alert">Peringatan: %1$s.</string>
     <string name="insight_clothes_wear">Kenakan %1$s.</string>
+    <string name="insight_clothes_bare">%1$s.</string>
     <!-- Indonesian has no grammatical articles. -->
     <string name="insight_clothes_article_a">%1$s</string>
     <string name="insight_clothes_article_an">%1$s</string>
@@ -953,6 +961,7 @@ to values/strings.xml (English).
     <string name="settings_format_change_label">Perubahan suhu</string>
     <string name="settings_format_change_off">Mati</string>
     <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_change_band">Tingkatan</string>
     <string name="settings_format_clothes_label">Susunan kata pakaian</string>
     <string name="settings_format_clothes_items">Pakaian</string>
     <string name="settings_format_clothes_layer_count">Jumlah lapisan</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -409,13 +409,20 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="insight_lead_today">Oggi</string>
     <string name="insight_lead_tomorrow">Domani</string>
     <string name="insight_unchanged_today">Oggi sarà come ieri.</string>
+    <string name="insight_unchanged_today_no_lead">Come ieri.</string>
     <string name="insight_unchanged_tonight">Stasera sarà come ieri sera.</string>
+    <string name="insight_unchanged_tonight_no_lead">Come ieri sera.</string>
     <string name="insight_unchanged_tomorrow">Domani sarà come oggi.</string>
+    <string name="insight_unchanged_tomorrow_no_lead">Come oggi.</string>
     <string name="insight_lead_tonight">Stasera</string>
     <string name="insight_band_single">%1$s sarà %2$d°.</string>
+    <string name="insight_band_single_no_lead">%1$d°.</string>
     <string name="insight_band_range">%1$s sarà tra %2$d° e %3$d°.</string>
+    <string name="insight_band_range_no_lead">%1$d° a %2$d°.</string>
     <string name="insight_band_words_single">%1$s sarà %2$s.</string>
+    <string name="insight_band_words_single_no_lead">%1$s.</string>
     <string name="insight_band_words_range">%1$s sarà tra %2$s e %3$s.</string>
+    <string name="insight_band_words_range_no_lead">%1$s a %2$s.</string>
     <string name="insight_band_freezing">gelido</string>
     <string name="insight_band_cold">freddo</string>
     <string name="insight_band_cool">fresco</string>
@@ -426,6 +433,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="insight_delta_cooler">Oggi farà %1$d° in meno.</string>
     <string name="insight_alert">Allerta: %1$s.</string>
     <string name="insight_clothes_wear">Indossa %1$s.</string>
+    <string name="insight_clothes_bare">%1$s.</string>
     <!-- Articles omitted — Italian gender agreement requires per-garment metadata. -->
     <string name="insight_clothes_article_a">%1$s</string>
     <string name="insight_clothes_article_an">%1$s</string>
@@ -1065,6 +1073,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_format_change_label">Variazione di temperatura</string>
     <string name="settings_format_change_off">Disattivato</string>
     <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_change_band">Categoria</string>
     <string name="settings_format_clothes_label">Formulazione abbigliamento</string>
     <string name="settings_format_clothes_items">Capi</string>
     <string name="settings_format_clothes_layer_count">Numero di strati</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -51,14 +51,21 @@ standard in Israeli digital communication.
     <string name="insight_lead_today">היום</string>
     <string name="insight_lead_tomorrow">מחר</string>
     <string name="insight_unchanged_today">היום יהיה כמו אתמול.</string>
+    <string name="insight_unchanged_today_no_lead">כמו אתמול.</string>
     <string name="insight_unchanged_tonight">הלילה יהיה כמו אתמול בלילה.</string>
+    <string name="insight_unchanged_tonight_no_lead">כמו אתמול בלילה.</string>
     <string name="insight_unchanged_tomorrow">מחר יהיה כמו היום.</string>
+    <string name="insight_unchanged_tomorrow_no_lead">כמו היום.</string>
     <string name="insight_lead_tonight">הלילה</string>
     <!-- "היום יהיה נעים." -->
     <string name="insight_band_single">%1$s יהיה %2$d°.</string>
+    <string name="insight_band_single_no_lead">%1$d°.</string>
     <string name="insight_band_range">%1$s יהיה %2$d° עד %3$d°.</string>
+    <string name="insight_band_range_no_lead">%1$d° עד %2$d°.</string>
     <string name="insight_band_words_single">%1$s יהיה %2$s.</string>
+    <string name="insight_band_words_single_no_lead">%1$s.</string>
     <string name="insight_band_words_range">%1$s יהיה %2$s עד %3$s.</string>
+    <string name="insight_band_words_range_no_lead">%1$s עד %2$s.</string>
     <string name="insight_band_freezing">קפוא</string>
     <string name="insight_band_cold">קר</string>
     <string name="insight_band_cool">קריר</string>
@@ -70,6 +77,7 @@ standard in Israeli digital communication.
     <string name="insight_alert">אזהרה: %1$s.</string>
     <!-- Slash notation for gender-neutral imperative (standard in Israeli digital text). -->
     <string name="insight_clothes_wear">לבש/י %1$s.</string>
+    <string name="insight_clothes_bare">%1$s.</string>
     <!-- Hebrew articles function differently from English "a/an" — no direct equivalent. -->
     <string name="insight_clothes_article_a">%1$s</string>
     <string name="insight_clothes_article_an">%1$s</string>
@@ -952,6 +960,7 @@ standard in Israeli digital communication.
     <string name="settings_format_change_label">שינוי טמפרטורה</string>
     <string name="settings_format_change_off">כבוי</string>
     <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_change_band">רצועה</string>
     <string name="settings_format_clothes_label">ניסוח לבוש</string>
     <string name="settings_format_clothes_items">פריטי לבוש</string>
     <string name="settings_format_clothes_layer_count">מספר שכבות</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -420,14 +420,21 @@ the displayed label localizes.
     <string name="insight_lead_today">今日</string>
     <string name="insight_lead_tomorrow">明日</string>
     <string name="insight_unchanged_today">今日は昨日と同じでしょう。</string>
+    <string name="insight_unchanged_today_no_lead">昨日と同じ。</string>
     <string name="insight_unchanged_tonight">今夜は昨夜と同じでしょう。</string>
+    <string name="insight_unchanged_tonight_no_lead">昨夜と同じ。</string>
     <string name="insight_unchanged_tomorrow">明日は今日と同じでしょう。</string>
+    <string name="insight_unchanged_tomorrow_no_lead">今日と同じ。</string>
     <string name="insight_lead_tonight">今夜</string>
     <!-- "今日は穏やかでしょう。" — は marks the topic. -->
     <string name="insight_band_single">%1$sは%2$d°でしょう。</string>
+    <string name="insight_band_single_no_lead">%1$d°.</string>
     <string name="insight_band_range">%1$sは%2$d°から%3$d°でしょう。</string>
+    <string name="insight_band_range_no_lead">%1$d°から%2$d°でしょう。</string>
     <string name="insight_band_words_single">%1$sは%2$sでしょう。</string>
+    <string name="insight_band_words_single_no_lead">%1$s.</string>
     <string name="insight_band_words_range">%1$sは%2$sから%3$sでしょう。</string>
+    <string name="insight_band_words_range_no_lead">%1$sから%2$sでしょう。</string>
     <string name="insight_band_freezing">氷点下</string>
     <string name="insight_band_cold">寒い</string>
     <string name="insight_band_cool">涼しい</string>
@@ -439,6 +446,7 @@ the displayed label localizes.
     <string name="insight_alert">警報：%1$s。</string>
     <!-- を is the universal object marker in Japanese, works after any noun. -->
     <string name="insight_clothes_wear">%1$sを着ていきましょう。</string>
+    <string name="insight_clothes_bare">%1$s.</string>
     <!-- Japanese has no grammatical articles. -->
     <string name="insight_clothes_article_a">%1$s</string>
     <string name="insight_clothes_article_an">%1$s</string>
@@ -1103,6 +1111,7 @@ the displayed label localizes.
     <string name="settings_format_change_label">気温変化</string>
     <string name="settings_format_change_off">オフ</string>
     <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_change_band">区分</string>
     <string name="settings_format_clothes_label">服装の言い回し</string>
     <string name="settings_format_clothes_items">衣類</string>
     <string name="settings_format_clothes_layer_count">レイヤー数</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -435,14 +435,21 @@ displayed label localizes.
     <string name="insight_lead_today">오늘</string>
     <string name="insight_lead_tomorrow">내일</string>
     <string name="insight_unchanged_today">오늘은 어제와 같은 날씨입니다.</string>
+    <string name="insight_unchanged_today_no_lead">어제와 같음.</string>
     <string name="insight_unchanged_tonight">오늘 밤은 어젯밤과 같은 날씨입니다.</string>
+    <string name="insight_unchanged_tonight_no_lead">어젯밤과 같음.</string>
     <string name="insight_unchanged_tomorrow">내일은 오늘과 같은 날씨입니다.</string>
+    <string name="insight_unchanged_tomorrow_no_lead">오늘과 같음.</string>
     <string name="insight_lead_tonight">오늘 밤</string>
     <!-- "오늘 포근한 날씨입니다." -->
     <string name="insight_band_single">%1$s %2$d° 날씨입니다.</string>
+    <string name="insight_band_single_no_lead">%1$d°.</string>
     <string name="insight_band_range">%1$s %2$d°에서 %3$d° 사이의 날씨입니다.</string>
+    <string name="insight_band_range_no_lead">%1$d°에서 %2$d° 사이의 날씨입니다.</string>
     <string name="insight_band_words_single">%1$s %2$s 날씨입니다.</string>
+    <string name="insight_band_words_single_no_lead">%1$s.</string>
     <string name="insight_band_words_range">%1$s %2$s에서 %3$s 사이의 날씨입니다.</string>
+    <string name="insight_band_words_range_no_lead">%1$s에서 %2$s 사이의 날씨입니다.</string>
     <string name="insight_band_freezing">매우 추운</string>
     <string name="insight_band_cold">추운</string>
     <string name="insight_band_cool">서늘한</string>
@@ -453,6 +460,7 @@ displayed label localizes.
     <string name="insight_delta_cooler">오늘은 %1$d° 더 춥습니다.</string>
     <string name="insight_alert">경보: %1$s.</string>
     <string name="insight_clothes_wear">%1$s 챙기세요.</string>
+    <string name="insight_clothes_bare">%1$s.</string>
     <!-- Korean has no grammatical articles. -->
     <string name="insight_clothes_article_a">%1$s</string>
     <string name="insight_clothes_article_an">%1$s</string>
@@ -1107,6 +1115,7 @@ displayed label localizes.
     <string name="settings_format_change_label">온도 변화</string>
     <string name="settings_format_change_off">끔</string>
     <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_change_band">구간</string>
     <string name="settings_format_clothes_label">옷 표현</string>
     <string name="settings_format_clothes_items">의류</string>
     <string name="settings_format_clothes_layer_count">레이어 수</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -53,14 +53,21 @@ What is NOT overridden, by design:
     <string name="insight_lead_today">Šiandien</string>
     <string name="insight_lead_tomorrow">Rytoj</string>
     <string name="insight_unchanged_today">Šiandien bus taip pat kaip vakar.</string>
+    <string name="insight_unchanged_today_no_lead">Kaip vakar.</string>
     <string name="insight_unchanged_tonight">Šįvakar bus taip pat kaip vakar vakare.</string>
+    <string name="insight_unchanged_tonight_no_lead">Kaip vakar vakare.</string>
     <string name="insight_unchanged_tomorrow">Rytoj bus taip pat kaip šiandien.</string>
+    <string name="insight_unchanged_tomorrow_no_lead">Kaip šiandien.</string>
     <string name="insight_lead_tonight">Šįvakar</string>
     <!-- Lithuanian neuter short-form weather: "Šiandien bus šalta." -->
     <string name="insight_band_single">%1$s bus %2$d°.</string>
+    <string name="insight_band_single_no_lead">%1$d°.</string>
     <string name="insight_band_range">%1$s bus %2$d° arba %3$d°.</string>
+    <string name="insight_band_range_no_lead">%1$d° arba %2$d°.</string>
     <string name="insight_band_words_single">%1$s bus %2$s.</string>
+    <string name="insight_band_words_single_no_lead">%1$s.</string>
     <string name="insight_band_words_range">%1$s bus %2$s arba %3$s.</string>
+    <string name="insight_band_words_range_no_lead">%1$s arba %2$s.</string>
     <string name="insight_band_freezing">labai šalta</string>
     <string name="insight_band_cold">šalta</string>
     <string name="insight_band_cool">vėsu</string>
@@ -71,6 +78,7 @@ What is NOT overridden, by design:
     <string name="insight_delta_cooler">Šiandien bus %1$d° šalčiau.</string>
     <string name="insight_alert">Įspėjimas: %1$s.</string>
     <string name="insight_clothes_wear">Apsivilk %1$s.</string>
+    <string name="insight_clothes_bare">%1$s.</string>
     <string name="insight_clothes_article_a">%1$s</string>
     <string name="insight_clothes_article_an">%1$s</string>
     <string name="insight_clothes_join_two">%1$s ir %2$s</string>
@@ -940,6 +948,7 @@ What is NOT overridden, by design:
     <string name="settings_format_change_label">Temperatūros pokytis</string>
     <string name="settings_format_change_off">Išjungta</string>
     <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_change_band">Intervalas</string>
     <string name="settings_format_clothes_label">Aprangos formuluotė</string>
     <string name="settings_format_clothes_items">Drabužiai</string>
     <string name="settings_format_clothes_layer_count">Sluoksnių skaičius</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -58,15 +58,22 @@ informal "tu"-form throughout ("Apģērb …", "Paņem … līdzi").
     <string name="insight_lead_today">Šodien</string>
     <string name="insight_lead_tomorrow">Rīt</string>
     <string name="insight_unchanged_today">Šodien būs tāpat kā vakar.</string>
+    <string name="insight_unchanged_today_no_lead">Kā vakar.</string>
     <string name="insight_unchanged_tonight">Šovakar būs tāpat kā vakar vakarā.</string>
+    <string name="insight_unchanged_tonight_no_lead">Kā vakar vakarā.</string>
     <string name="insight_unchanged_tomorrow">Rīt būs tāpat kā šodien.</string>
+    <string name="insight_unchanged_tomorrow_no_lead">Kā šodien.</string>
     <string name="insight_lead_tonight">Šovakar</string>
     <!-- Latvian masculine-nominative agreement (implicit subject "laiks"):
          "Šodien būs auksts." -->
     <string name="insight_band_single">%1$s būs %2$d°.</string>
+    <string name="insight_band_single_no_lead">%1$d°.</string>
     <string name="insight_band_range">%1$s būs %2$d° līdz %3$d°.</string>
+    <string name="insight_band_range_no_lead">%1$d° līdz %2$d°.</string>
     <string name="insight_band_words_single">%1$s būs %2$s.</string>
+    <string name="insight_band_words_single_no_lead">%1$s.</string>
     <string name="insight_band_words_range">%1$s būs %2$s līdz %3$s.</string>
+    <string name="insight_band_words_range_no_lead">%1$s līdz %2$s.</string>
     <string name="insight_band_freezing">ledains</string>
     <string name="insight_band_cold">auksts</string>
     <string name="insight_band_cool">vēss</string>
@@ -77,6 +84,7 @@ informal "tu"-form throughout ("Apģērb …", "Paņem … līdzi").
     <string name="insight_delta_cooler">Šodien būs par %1$d° aukstāks.</string>
     <string name="insight_alert">Brīdinājums: %1$s.</string>
     <string name="insight_clothes_wear">Apģērb %1$s.</string>
+    <string name="insight_clothes_bare">%1$s.</string>
     <string name="insight_clothes_article_a">%1$s</string>
     <string name="insight_clothes_article_an">%1$s</string>
     <string name="insight_clothes_join_two">%1$s un %2$s</string>
@@ -893,6 +901,7 @@ informal "tu"-form throughout ("Apģērb …", "Paņem … līdzi").
     <string name="settings_format_change_label">Temperatūras izmaiņas</string>
     <string name="settings_format_change_off">Izsl.</string>
     <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_change_band">Diapazons</string>
     <string name="settings_format_clothes_label">Apģērba formulējums</string>
     <string name="settings_format_clothes_items">Apģērba gabali</string>
     <string name="settings_format_clothes_layer_count">Slāņu skaits</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -48,14 +48,21 @@ vs "kemungkinan", "padam" vs "hapus").
     <string name="insight_lead_today">Hari ini</string>
     <string name="insight_lead_tomorrow">Esok</string>
     <string name="insight_unchanged_today">Hari ini cuacanya sama seperti semalam.</string>
+    <string name="insight_unchanged_today_no_lead">Seperti semalam.</string>
     <string name="insight_unchanged_tonight">Malam ini cuacanya sama seperti malam tadi.</string>
+    <string name="insight_unchanged_tonight_no_lead">Seperti malam tadi.</string>
     <string name="insight_unchanged_tomorrow">Esok cuacanya sama seperti hari ini.</string>
+    <string name="insight_unchanged_tomorrow_no_lead">Seperti hari ini.</string>
     <string name="insight_lead_tonight">Malam ini</string>
     <!-- Malay topic-comment shape: "Hari ini cuacanya sejuk." -->
     <string name="insight_band_single">%1$s cuacanya %2$d°.</string>
+    <string name="insight_band_single_no_lead">%1$d°.</string>
     <string name="insight_band_range">%1$s cuacanya antara %2$d° hingga %3$d°.</string>
+    <string name="insight_band_range_no_lead">%1$d° hingga %2$d°.</string>
     <string name="insight_band_words_single">%1$s cuacanya %2$s.</string>
+    <string name="insight_band_words_single_no_lead">%1$s.</string>
     <string name="insight_band_words_range">%1$s cuacanya antara %2$s hingga %3$s.</string>
+    <string name="insight_band_words_range_no_lead">%1$s hingga %2$s.</string>
     <string name="insight_band_freezing">amat sejuk</string>
     <string name="insight_band_cold">sejuk</string>
     <string name="insight_band_cool">nyaman</string>
@@ -66,6 +73,7 @@ vs "kemungkinan", "padam" vs "hapus").
     <string name="insight_delta_cooler">Hari ini %1$d° lebih sejuk.</string>
     <string name="insight_alert">Amaran: %1$s.</string>
     <string name="insight_clothes_wear">Pakai %1$s.</string>
+    <string name="insight_clothes_bare">%1$s.</string>
     <!-- Malay has no grammatical articles. -->
     <string name="insight_clothes_article_a">%1$s</string>
     <string name="insight_clothes_article_an">%1$s</string>
@@ -959,6 +967,7 @@ vs "kemungkinan", "padam" vs "hapus").
     <string name="settings_format_change_label">Perubahan suhu</string>
     <string name="settings_format_change_off">Mati</string>
     <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_change_band">Tahap</string>
     <string name="settings_format_clothes_label">Susunan kata pakaian</string>
     <string name="settings_format_clothes_items">Pakaian</string>
     <string name="settings_format_clothes_layer_count">Bilangan lapisan</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -545,14 +545,21 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrike)").
     <string name="insight_lead_today">I dag</string>
     <string name="insight_lead_tomorrow">I morgen</string>
     <string name="insight_unchanged_today">I dag blir det det samme som i går.</string>
+    <string name="insight_unchanged_today_no_lead">Som i går.</string>
     <string name="insight_unchanged_tonight">I kveld blir det det samme som i går kveld.</string>
+    <string name="insight_unchanged_tonight_no_lead">Som i går kveld.</string>
     <string name="insight_unchanged_tomorrow">I morgen blir det det samme som i dag.</string>
+    <string name="insight_unchanged_tomorrow_no_lead">Som i dag.</string>
     <string name="insight_lead_tonight">I kveld</string>
     <!-- Norwegian V2 word order: "I dag blir det mildt." -->
     <string name="insight_band_single">%1$s blir det %2$d°.</string>
+    <string name="insight_band_single_no_lead">%1$d°.</string>
     <string name="insight_band_range">%1$s blir det %2$d° til %3$d°.</string>
+    <string name="insight_band_range_no_lead">%1$d° til %2$d°.</string>
     <string name="insight_band_words_single">%1$s blir det %2$s.</string>
+    <string name="insight_band_words_single_no_lead">%1$s.</string>
     <string name="insight_band_words_range">%1$s blir det %2$s til %3$s.</string>
+    <string name="insight_band_words_range_no_lead">%1$s til %2$s.</string>
 
     <string name="insight_band_freezing">iskaldt</string>
     <string name="insight_band_cold">kaldt</string>
@@ -567,6 +574,7 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrike)").
     <string name="insight_alert">Advarsel: %1$s.</string>
 
     <string name="insight_clothes_wear">Ha på deg %1$s.</string>
+    <string name="insight_clothes_bare">%1$s.</string>
     <string name="insight_clothes_article_a">%1$s</string>
     <string name="insight_clothes_article_an">%1$s</string>
     <string name="insight_clothes_join_two">%1$s og %2$s</string>
@@ -981,6 +989,7 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrike)").
     <string name="settings_format_change_label">Temperaturendring</string>
     <string name="settings_format_change_off">Av</string>
     <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_change_band">Nivå</string>
     <string name="settings_format_clothes_label">Klesformulering</string>
     <string name="settings_format_clothes_items">Plagg</string>
     <string name="settings_format_clothes_layer_count">Antall lag</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -383,15 +383,22 @@ the displayed label localizes.
     <string name="insight_lead_today">Vandaag</string>
     <string name="insight_lead_tomorrow">Morgen</string>
     <string name="insight_unchanged_today">Vandaag wordt het hetzelfde als gisteren.</string>
+    <string name="insight_unchanged_today_no_lead">Als gisteren.</string>
     <string name="insight_unchanged_tonight">Vanavond wordt het hetzelfde als gisteravond.</string>
+    <string name="insight_unchanged_tonight_no_lead">Als gisteravond.</string>
     <string name="insight_unchanged_tomorrow">Morgen wordt het hetzelfde als vandaag.</string>
+    <string name="insight_unchanged_tomorrow_no_lead">Als vandaag.</string>
     <string name="insight_lead_tonight">Vanavond</string>
 
     <!-- Dutch V2 word order: "Vandaag wordt het mild." -->
     <string name="insight_band_single">%1$s wordt het %2$d°.</string>
+    <string name="insight_band_single_no_lead">%1$d°.</string>
     <string name="insight_band_range">%1$s wordt het %2$d° tot %3$d°.</string>
+    <string name="insight_band_range_no_lead">%1$d° tot %2$d°.</string>
     <string name="insight_band_words_single">%1$s wordt het %2$s.</string>
+    <string name="insight_band_words_single_no_lead">%1$s.</string>
     <string name="insight_band_words_range">%1$s wordt het %2$s tot %3$s.</string>
+    <string name="insight_band_words_range_no_lead">%1$s tot %2$s.</string>
 
     <string name="insight_band_freezing">vriezend koud</string>
     <string name="insight_band_cold">koud</string>
@@ -406,6 +413,7 @@ the displayed label localizes.
     <string name="insight_alert">Waarschuwing: %1$s.</string>
 
     <string name="insight_clothes_wear">Draag %1$s.</string>
+    <string name="insight_clothes_bare">%1$s.</string>
     <string name="insight_clothes_article_a">%1$s</string>
     <string name="insight_clothes_article_an">%1$s</string>
     <string name="insight_clothes_join_two">%1$s en %2$s</string>
@@ -1001,6 +1009,7 @@ the displayed label localizes.
     <string name="settings_format_change_label">Temperatuurverandering</string>
     <string name="settings_format_change_off">Uit</string>
     <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_change_band">Niveau</string>
     <string name="settings_format_clothes_label">Kledingformulering</string>
     <string name="settings_format_clothes_items">Kledingstukken</string>
     <string name="settings_format_clothes_layer_count">Aantal lagen</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -383,14 +383,21 @@ is unchanged; only the displayed label localizes.
     <string name="insight_lead_today">Dziś</string>
     <string name="insight_lead_tomorrow">Jutro</string>
     <string name="insight_unchanged_today">Dziś będzie tak samo jak wczoraj.</string>
+    <string name="insight_unchanged_today_no_lead">Jak wczoraj.</string>
     <string name="insight_unchanged_tonight">Wieczorem będzie tak samo jak wczoraj wieczorem.</string>
+    <string name="insight_unchanged_tonight_no_lead">Jak wczoraj wieczorem.</string>
     <string name="insight_unchanged_tomorrow">Jutro będzie tak samo jak dziś.</string>
+    <string name="insight_unchanged_tomorrow_no_lead">Jak dziś.</string>
     <string name="insight_lead_tonight">Wieczorem</string>
 
     <string name="insight_band_single">%1$s będzie %2$d°.</string>
+    <string name="insight_band_single_no_lead">%1$d°.</string>
     <string name="insight_band_range">%1$s będzie od %2$d° do %3$d°.</string>
+    <string name="insight_band_range_no_lead">%1$d° do %2$d°.</string>
     <string name="insight_band_words_single">%1$s będzie %2$s.</string>
+    <string name="insight_band_words_single_no_lead">%1$s.</string>
     <string name="insight_band_words_range">%1$s będzie od %2$s do %3$s.</string>
+    <string name="insight_band_words_range_no_lead">%1$s do %2$s.</string>
 
     <string name="insight_band_freezing">mroźnie</string>
     <string name="insight_band_cold">zimno</string>
@@ -405,6 +412,7 @@ is unchanged; only the displayed label localizes.
     <string name="insight_alert">Ostrzeżenie: %1$s.</string>
 
     <string name="insight_clothes_wear">Załóż %1$s.</string>
+    <string name="insight_clothes_bare">%1$s.</string>
     <string name="insight_clothes_article_a">%1$s</string>
     <string name="insight_clothes_article_an">%1$s</string>
     <string name="insight_clothes_join_two">%1$s i %2$s</string>
@@ -999,6 +1007,7 @@ is unchanged; only the displayed label localizes.
     <string name="settings_format_change_label">Zmiana temperatury</string>
     <string name="settings_format_change_off">Wyłączone</string>
     <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_change_band">Pasmo</string>
     <string name="settings_format_clothes_label">Opis ubrań</string>
     <string name="settings_format_clothes_items">Elementy garderoby</string>
     <string name="settings_format_clothes_layer_count">Liczba warstw</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -427,13 +427,20 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="insight_lead_today">Hoje</string>
     <string name="insight_lead_tomorrow">Amanhã</string>
     <string name="insight_unchanged_today">Hoje será igual a ontem.</string>
+    <string name="insight_unchanged_today_no_lead">Como ontem.</string>
     <string name="insight_unchanged_tonight">Esta noite será igual à noite passada.</string>
+    <string name="insight_unchanged_tonight_no_lead">Como ontem à noite.</string>
     <string name="insight_unchanged_tomorrow">Amanhã será igual a hoje.</string>
+    <string name="insight_unchanged_tomorrow_no_lead">Como hoje.</string>
     <string name="insight_lead_tonight">Esta noite</string>
     <string name="insight_band_single">%1$s será %2$d°.</string>
+    <string name="insight_band_single_no_lead">%1$d°.</string>
     <string name="insight_band_range">%1$s estará entre %2$d° e %3$d°.</string>
+    <string name="insight_band_range_no_lead">%1$d° a %2$d°.</string>
     <string name="insight_band_words_single">%1$s será %2$s.</string>
+    <string name="insight_band_words_single_no_lead">%1$s.</string>
     <string name="insight_band_words_range">%1$s estará entre %2$s e %3$s.</string>
+    <string name="insight_band_words_range_no_lead">%1$s a %2$s.</string>
     <string name="insight_band_freezing">gelado</string>
     <string name="insight_band_cold">frio</string>
     <string name="insight_band_cool">fresco</string>
@@ -444,6 +451,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="insight_delta_cooler">Hoje estará %1$d° mais frio.</string>
     <string name="insight_alert">Alerta: %1$s.</string>
     <string name="insight_clothes_wear">Vista %1$s.</string>
+    <string name="insight_clothes_bare">%1$s.</string>
     <!-- Articles omitted — Portuguese gender agreement requires per-garment metadata. -->
     <string name="insight_clothes_article_a">%1$s</string>
     <string name="insight_clothes_article_an">%1$s</string>
@@ -1037,6 +1045,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_format_change_label">Variação de temperatura</string>
     <string name="settings_format_change_off">Desativado</string>
     <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_change_band">Categoria</string>
     <string name="settings_format_clothes_label">Redação das roupas</string>
     <string name="settings_format_clothes_items">Peças</string>
     <string name="settings_format_clothes_layer_count">Número de camadas</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -451,13 +451,20 @@ they diverge from BR ("Polonês" → "Polaco", "Holandês" →
     <string name="insight_lead_today">Hoje</string>
     <string name="insight_lead_tomorrow">Amanhã</string>
     <string name="insight_unchanged_today">Hoje será igual a ontem.</string>
+    <string name="insight_unchanged_today_no_lead">Como ontem.</string>
     <string name="insight_unchanged_tonight">Esta noite será igual à noite passada.</string>
+    <string name="insight_unchanged_tonight_no_lead">Como ontem à noite.</string>
     <string name="insight_unchanged_tomorrow">Amanhã será igual a hoje.</string>
+    <string name="insight_unchanged_tomorrow_no_lead">Como hoje.</string>
     <string name="insight_lead_tonight">Esta noite</string>
     <string name="insight_band_single">%1$s será %2$d°.</string>
+    <string name="insight_band_single_no_lead">%1$d°.</string>
     <string name="insight_band_range">%1$s estará entre %2$d° e %3$d°.</string>
+    <string name="insight_band_range_no_lead">%1$d° a %2$d°.</string>
     <string name="insight_band_words_single">%1$s será %2$s.</string>
+    <string name="insight_band_words_single_no_lead">%1$s.</string>
     <string name="insight_band_words_range">%1$s estará entre %2$s e %3$s.</string>
+    <string name="insight_band_words_range_no_lead">%1$s a %2$s.</string>
     <string name="insight_band_freezing">gelado</string>
     <string name="insight_band_cold">frio</string>
     <string name="insight_band_cool">fresco</string>
@@ -468,6 +475,7 @@ they diverge from BR ("Polonês" → "Polaco", "Holandês" →
     <string name="insight_delta_cooler">Hoje estará %1$d° mais frio.</string>
     <string name="insight_alert">Alerta: %1$s.</string>
     <string name="insight_clothes_wear">Veste %1$s.</string>
+    <string name="insight_clothes_bare">%1$s.</string>
     <!-- Articles omitted — Portuguese gender agreement requires per-garment metadata. -->
     <string name="insight_clothes_article_a">%1$s</string>
     <string name="insight_clothes_article_an">%1$s</string>
@@ -1080,6 +1088,7 @@ they diverge from BR ("Polonês" → "Polaco", "Holandês" →
     <string name="settings_format_change_label">Variação de temperatura</string>
     <string name="settings_format_change_off">Desligado</string>
     <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_change_band">Banda</string>
     <string name="settings_format_clothes_label">Redação do vestuário</string>
     <string name="settings_format_clothes_items">Peças</string>
     <string name="settings_format_clothes_layer_count">Número de camadas</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -47,13 +47,20 @@ surfaces fall back to default English (matching values-pl / values-uk).
     <string name="insight_lead_today">Astăzi</string>
     <string name="insight_lead_tomorrow">Mâine</string>
     <string name="insight_unchanged_today">Astăzi va fi la fel ca ieri.</string>
+    <string name="insight_unchanged_today_no_lead">Ca ieri.</string>
     <string name="insight_unchanged_tonight">Diseară va fi la fel ca aseară.</string>
+    <string name="insight_unchanged_tonight_no_lead">Ca aseară.</string>
     <string name="insight_unchanged_tomorrow">Mâine va fi la fel ca astăzi.</string>
+    <string name="insight_unchanged_tomorrow_no_lead">Ca astăzi.</string>
     <string name="insight_lead_tonight">Diseară</string>
     <string name="insight_band_single">%1$s va fi %2$d°.</string>
+    <string name="insight_band_single_no_lead">%1$d°.</string>
     <string name="insight_band_range">%1$s va fi între %2$d° și %3$d°.</string>
+    <string name="insight_band_range_no_lead">%1$d° și %2$d°.</string>
     <string name="insight_band_words_single">%1$s va fi %2$s.</string>
+    <string name="insight_band_words_single_no_lead">%1$s.</string>
     <string name="insight_band_words_range">%1$s va fi între %2$s și %3$s.</string>
+    <string name="insight_band_words_range_no_lead">%1$s și %2$s.</string>
     <string name="insight_band_freezing">geros</string>
     <string name="insight_band_cold">frig</string>
     <string name="insight_band_cool">răcoare</string>
@@ -64,6 +71,7 @@ surfaces fall back to default English (matching values-pl / values-uk).
     <string name="insight_delta_cooler">Astăzi va fi cu %1$d° mai rece.</string>
     <string name="insight_alert">Avertisment: %1$s.</string>
     <string name="insight_clothes_wear">Poartă %1$s.</string>
+    <string name="insight_clothes_bare">%1$s.</string>
     <string name="insight_clothes_article_a">%1$s</string>
     <string name="insight_clothes_article_an">%1$s</string>
     <string name="insight_clothes_join_two">%1$s și %2$s</string>
@@ -929,6 +937,7 @@ surfaces fall back to default English (matching values-pl / values-uk).
     <string name="settings_format_change_label">Variație de temperatură</string>
     <string name="settings_format_change_off">Oprit</string>
     <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_change_band">Bandă</string>
     <string name="settings_format_clothes_label">Formulare pentru îmbrăcăminte</string>
     <string name="settings_format_clothes_items">Articole</string>
     <string name="settings_format_clothes_layer_count">Numărul de straturi</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -613,13 +613,20 @@ only the displayed label localizes.
     <string name="insight_lead_today">Сегодня</string>
     <string name="insight_lead_tomorrow">Завтра</string>
     <string name="insight_unchanged_today">Сегодня будет так же, как вчера.</string>
+    <string name="insight_unchanged_today_no_lead">Как вчера.</string>
     <string name="insight_unchanged_tonight">Сегодня вечером будет так же, как вчера вечером.</string>
+    <string name="insight_unchanged_tonight_no_lead">Как вчера вечером.</string>
     <string name="insight_unchanged_tomorrow">Завтра будет так же, как сегодня.</string>
+    <string name="insight_unchanged_tomorrow_no_lead">Как сегодня.</string>
     <string name="insight_lead_tonight">Сегодня вечером</string>
     <string name="insight_band_single">%1$s будет %2$d°.</string>
+    <string name="insight_band_single_no_lead">%1$d°.</string>
     <string name="insight_band_range">%1$s будет от %2$d° до %3$d°.</string>
+    <string name="insight_band_range_no_lead">%1$d° до %2$d°.</string>
     <string name="insight_band_words_single">%1$s будет %2$s.</string>
+    <string name="insight_band_words_single_no_lead">%1$s.</string>
     <string name="insight_band_words_range">%1$s будет от %2$s до %3$s.</string>
+    <string name="insight_band_words_range_no_lead">%1$s до %2$s.</string>
     <string name="insight_band_freezing">морозно</string>
     <string name="insight_band_cold">холодно</string>
     <string name="insight_band_cool">прохладно</string>
@@ -630,6 +637,7 @@ only the displayed label localizes.
     <string name="insight_delta_cooler">Сегодня на %1$d° холоднее.</string>
     <string name="insight_alert">Предупреждение: %1$s.</string>
     <string name="insight_clothes_wear">Надень %1$s.</string>
+    <string name="insight_clothes_bare">%1$s.</string>
     <string name="insight_clothes_article_a">%1$s</string>
     <string name="insight_clothes_article_an">%1$s</string>
     <string name="insight_clothes_join_two">%1$s и %2$s</string>
@@ -1006,6 +1014,7 @@ only the displayed label localizes.
     <string name="settings_format_change_label">Изменение температуры</string>
     <string name="settings_format_change_off">Выкл.</string>
     <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_change_band">Диапазон</string>
     <string name="settings_format_clothes_label">Описание одежды</string>
     <string name="settings_format_clothes_items">Предметы</string>
     <string name="settings_format_clothes_layer_count">Количество слоёв</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -556,13 +556,20 @@ What is NOT overridden, by design:
     <string name="insight_lead_today">Dnes</string>
     <string name="insight_lead_tomorrow">Zajtra</string>
     <string name="insight_unchanged_today">Dnes bude rovnako ako včera.</string>
+    <string name="insight_unchanged_today_no_lead">Ako včera.</string>
     <string name="insight_unchanged_tonight">Dnes večer bude rovnako ako včera večer.</string>
+    <string name="insight_unchanged_tonight_no_lead">Ako včera večer.</string>
     <string name="insight_unchanged_tomorrow">Zajtra bude rovnako ako dnes.</string>
+    <string name="insight_unchanged_tomorrow_no_lead">Ako dnes.</string>
     <string name="insight_lead_tonight">Dnes večer</string>
     <string name="insight_band_single">%1$s bude %2$d°.</string>
+    <string name="insight_band_single_no_lead">%1$d°.</string>
     <string name="insight_band_range">%1$s bude od %2$d° do %3$d°.</string>
+    <string name="insight_band_range_no_lead">%1$d° do %2$d°.</string>
     <string name="insight_band_words_single">%1$s bude %2$s.</string>
+    <string name="insight_band_words_single_no_lead">%1$s.</string>
     <string name="insight_band_words_range">%1$s bude od %2$s do %3$s.</string>
+    <string name="insight_band_words_range_no_lead">%1$s do %2$s.</string>
     <string name="insight_band_freezing">mrazivo</string>
     <string name="insight_band_cold">chladno</string>
     <string name="insight_band_cool">sviežo</string>
@@ -573,6 +580,7 @@ What is NOT overridden, by design:
     <string name="insight_delta_cooler">Dnes bude o %1$d° chladnejšie.</string>
     <string name="insight_alert">Výstraha: %1$s.</string>
     <string name="insight_clothes_wear">Obleč si %1$s.</string>
+    <string name="insight_clothes_bare">%1$s.</string>
     <string name="insight_clothes_article_a">%1$s</string>
     <string name="insight_clothes_article_an">%1$s</string>
     <string name="insight_clothes_join_two">%1$s a %2$s</string>
@@ -974,6 +982,7 @@ What is NOT overridden, by design:
     <string name="settings_format_change_label">Zmena teploty</string>
     <string name="settings_format_change_off">Vypnuté</string>
     <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_change_band">Pásmo</string>
     <string name="settings_format_clothes_label">Formulácia oblečenia</string>
     <string name="settings_format_clothes_items">Kusy oblečenia</string>
     <string name="settings_format_clothes_layer_count">Počet vrstiev</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -46,14 +46,21 @@ informal "ti"-form throughout, mirroring the Croatian / Serbian pass.
     <string name="insight_lead_today">Danes</string>
     <string name="insight_lead_tomorrow">Jutri</string>
     <string name="insight_unchanged_today">Danes bo enako kot včeraj.</string>
+    <string name="insight_unchanged_today_no_lead">Kot včeraj.</string>
     <string name="insight_unchanged_tonight">Nocoj bo enako kot sinoči.</string>
+    <string name="insight_unchanged_tonight_no_lead">Kot sinoči.</string>
     <string name="insight_unchanged_tomorrow">Jutri bo enako kot danes.</string>
+    <string name="insight_unchanged_tomorrow_no_lead">Kot danes.</string>
     <string name="insight_lead_tonight">Nocoj</string>
     <!-- "Danes bo mrzlo." — leading time adverb + "bo" + adjective. -->
     <string name="insight_band_single">%1$s bo %2$d°.</string>
+    <string name="insight_band_single_no_lead">%1$d°.</string>
     <string name="insight_band_range">%1$s bo %2$d° do %3$d°.</string>
+    <string name="insight_band_range_no_lead">%1$d° do %2$d°.</string>
     <string name="insight_band_words_single">%1$s bo %2$s.</string>
+    <string name="insight_band_words_single_no_lead">%1$s.</string>
     <string name="insight_band_words_range">%1$s bo %2$s do %3$s.</string>
+    <string name="insight_band_words_range_no_lead">%1$s do %2$s.</string>
     <string name="insight_band_freezing">ledeno</string>
     <string name="insight_band_cold">mrzlo</string>
     <string name="insight_band_cool">hladno</string>
@@ -65,6 +72,7 @@ informal "ti"-form throughout, mirroring the Croatian / Serbian pass.
     <string name="insight_alert">Opozorilo: %1$s.</string>
     <!-- Informal "ti": "Obleci …", "Vzemi … s seboj". -->
     <string name="insight_clothes_wear">Obleci %1$s.</string>
+    <string name="insight_clothes_bare">%1$s.</string>
     <string name="insight_clothes_article_a">%1$s</string>
     <string name="insight_clothes_article_an">%1$s</string>
     <string name="insight_clothes_join_two">%1$s in %2$s</string>
@@ -937,6 +945,7 @@ informal "ti"-form throughout, mirroring the Croatian / Serbian pass.
     <string name="settings_format_change_label">Sprememba temperature</string>
     <string name="settings_format_change_off">Izklopljeno</string>
     <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_change_band">Pas</string>
     <string name="settings_format_clothes_label">Ubeseditev oblačil</string>
     <string name="settings_format_clothes_items">Kosi oblačil</string>
     <string name="settings_format_clothes_layer_count">Število plasti</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -545,14 +545,21 @@ native names for all locales (e.g. "Tyska (Tyskland)", "Franska (Frankrike)").
     <string name="insight_lead_today">Idag</string>
     <string name="insight_lead_tomorrow">Imorgon</string>
     <string name="insight_unchanged_today">Idag blir det likadant som igår.</string>
+    <string name="insight_unchanged_today_no_lead">Som igår.</string>
     <string name="insight_unchanged_tonight">I kväll blir det likadant som igår kväll.</string>
+    <string name="insight_unchanged_tonight_no_lead">Som igår kväll.</string>
     <string name="insight_unchanged_tomorrow">Imorgon blir det likadant som idag.</string>
+    <string name="insight_unchanged_tomorrow_no_lead">Som idag.</string>
     <string name="insight_lead_tonight">I kväll</string>
     <!-- Swedish V2 word order: "Idag blir det milt." -->
     <string name="insight_band_single">%1$s blir det %2$d°.</string>
+    <string name="insight_band_single_no_lead">%1$d°.</string>
     <string name="insight_band_range">%1$s blir det %2$d° till %3$d°.</string>
+    <string name="insight_band_range_no_lead">%1$d° till %2$d°.</string>
     <string name="insight_band_words_single">%1$s blir det %2$s.</string>
+    <string name="insight_band_words_single_no_lead">%1$s.</string>
     <string name="insight_band_words_range">%1$s blir det %2$s till %3$s.</string>
+    <string name="insight_band_words_range_no_lead">%1$s till %2$s.</string>
 
     <string name="insight_band_freezing">iskallt</string>
     <string name="insight_band_cold">kallt</string>
@@ -567,6 +574,7 @@ native names for all locales (e.g. "Tyska (Tyskland)", "Franska (Frankrike)").
     <string name="insight_alert">Varning: %1$s.</string>
 
     <string name="insight_clothes_wear">Ta på %1$s.</string>
+    <string name="insight_clothes_bare">%1$s.</string>
     <string name="insight_clothes_article_a">%1$s</string>
     <string name="insight_clothes_article_an">%1$s</string>
     <string name="insight_clothes_join_two">%1$s och %2$s</string>
@@ -981,6 +989,7 @@ native names for all locales (e.g. "Tyska (Tyskland)", "Franska (Frankrike)").
     <string name="settings_format_change_label">Temperaturförändring</string>
     <string name="settings_format_change_off">Av</string>
     <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_change_band">Nivå</string>
     <string name="settings_format_clothes_label">Klädformulering</string>
     <string name="settings_format_clothes_items">Plagg</string>
     <string name="settings_format_clothes_layer_count">Antal lager</string>

--- a/app/src/main/res/values-sw/strings.xml
+++ b/app/src/main/res/values-sw/strings.xml
@@ -46,14 +46,21 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="insight_lead_today">Leo</string>
     <string name="insight_lead_tomorrow">Kesho</string>
     <string name="insight_unchanged_today">Leo hali ya hewa itakuwa sawa na jana.</string>
+    <string name="insight_unchanged_today_no_lead">Kama jana.</string>
     <string name="insight_unchanged_tonight">Usiku huu hali ya hewa itakuwa sawa na jana usiku.</string>
+    <string name="insight_unchanged_tonight_no_lead">Kama jana usiku.</string>
     <string name="insight_unchanged_tomorrow">Kesho hali ya hewa itakuwa sawa na leo.</string>
+    <string name="insight_unchanged_tomorrow_no_lead">Kama leo.</string>
     <string name="insight_lead_tonight">Usiku huu</string>
     <!-- Swahili: "Leo itakuwa baridi." -->
     <string name="insight_band_single">%1$s itakuwa %2$d°.</string>
+    <string name="insight_band_single_no_lead">%1$d°.</string>
     <string name="insight_band_range">%1$s itakuwa %2$d° hadi %3$d°.</string>
+    <string name="insight_band_range_no_lead">%1$d° hadi %2$d°.</string>
     <string name="insight_band_words_single">%1$s itakuwa %2$s.</string>
+    <string name="insight_band_words_single_no_lead">%1$s.</string>
     <string name="insight_band_words_range">%1$s itakuwa %2$s hadi %3$s.</string>
+    <string name="insight_band_words_range_no_lead">%1$s hadi %2$s.</string>
     <string name="insight_band_freezing">baridi kali sana</string>
     <string name="insight_band_cold">baridi</string>
     <string name="insight_band_cool">baridi kidogo</string>
@@ -64,6 +71,7 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="insight_delta_cooler">Itakuwa %1$d° baridi zaidi kuliko jana.</string>
     <string name="insight_alert">Tahadhari: %1$s.</string>
     <string name="insight_clothes_wear">Vaa %1$s.</string>
+    <string name="insight_clothes_bare">%1$s.</string>
     <!-- Swahili has no articles; pass through bare. -->
     <string name="insight_clothes_article_a">%1$s</string>
     <string name="insight_clothes_article_an">%1$s</string>
@@ -924,6 +932,7 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="settings_format_change_label">Mabadiliko ya halijoto</string>
     <string name="settings_format_change_off">Imezimwa</string>
     <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_change_band">Kikundi</string>
     <string name="settings_format_clothes_label">Maneno ya mavazi</string>
     <string name="settings_format_clothes_items">Mavazi</string>
     <string name="settings_format_clothes_layer_count">Idadi ya tabaka</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -46,14 +46,21 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="insight_lead_today">วันนี้</string>
     <string name="insight_lead_tomorrow">พรุ่งนี้</string>
     <string name="insight_unchanged_today">วันนี้อากาศเหมือนเมื่อวาน</string>
+    <string name="insight_unchanged_today_no_lead">เหมือนเมื่อวาน</string>
     <string name="insight_unchanged_tonight">คืนนี้อากาศเหมือนเมื่อคืน</string>
+    <string name="insight_unchanged_tonight_no_lead">เหมือนเมื่อคืน</string>
     <string name="insight_unchanged_tomorrow">พรุ่งนี้อากาศเหมือนวันนี้</string>
+    <string name="insight_unchanged_tomorrow_no_lead">เหมือนวันนี้</string>
     <string name="insight_lead_tonight">คืนนี้</string>
     <!-- Thai: "วันนี้อากาศเย็น" (time + topic + predicate, no copula). -->
     <string name="insight_band_single">%1$sอากาศ%2$d°</string>
+    <string name="insight_band_single_no_lead">%1$d°.</string>
     <string name="insight_band_range">%1$sอากาศ%2$d°ถึง%3$d°</string>
+    <string name="insight_band_range_no_lead">%1$d°ถึง%2$d°</string>
     <string name="insight_band_words_single">%1$sอากาศ%2$s</string>
+    <string name="insight_band_words_single_no_lead">%1$s.</string>
     <string name="insight_band_words_range">%1$sอากาศ%2$sถึง%3$s</string>
+    <string name="insight_band_words_range_no_lead">%1$sถึง%2$s</string>
     <string name="insight_band_freezing">หนาวจัด</string>
     <string name="insight_band_cold">หนาว</string>
     <string name="insight_band_cool">เย็น</string>
@@ -64,6 +71,7 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="insight_delta_cooler">วันนี้หนาวกว่าเมื่อวาน %1$d°</string>
     <string name="insight_alert">เตือน: %1$s</string>
     <string name="insight_clothes_wear">สวม%1$s</string>
+    <string name="insight_clothes_bare">%1$s.</string>
     <!-- Thai has no grammatical articles. -->
     <string name="insight_clothes_article_a">%1$s</string>
     <string name="insight_clothes_article_an">%1$s</string>
@@ -953,6 +961,7 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="settings_format_change_label">การเปลี่ยนแปลงอุณหภูมิ</string>
     <string name="settings_format_change_off">ปิด</string>
     <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_change_band">ระดับ</string>
     <string name="settings_format_clothes_label">การใช้คำเกี่ยวกับเสื้อผ้า</string>
     <string name="settings_format_clothes_items">เสื้อผ้า</string>
     <string name="settings_format_clothes_layer_count">จำนวนชั้น</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -339,15 +339,22 @@ displayed label localizes.
     <string name="insight_lead_today">Bugün</string>
     <string name="insight_lead_tomorrow">Yarın</string>
     <string name="insight_unchanged_today">Bugün dünkü gibi olacak.</string>
+    <string name="insight_unchanged_today_no_lead">Dünkü gibi.</string>
     <string name="insight_unchanged_tonight">Bu gece dün geceki gibi olacak.</string>
+    <string name="insight_unchanged_tonight_no_lead">Dün geceki gibi.</string>
     <string name="insight_unchanged_tomorrow">Yarın bugünkü gibi olacak.</string>
+    <string name="insight_unchanged_tomorrow_no_lead">Bugünkü gibi.</string>
     <string name="insight_lead_tonight">Bu gece</string>
 
     <!-- Turkish SOV word order: subject-object-verb; predicate at the end. -->
     <string name="insight_band_single">%1$s %2$d° olacak.</string>
+    <string name="insight_band_single_no_lead">%1$d°.</string>
     <string name="insight_band_range">%1$s %2$d° ile %3$d° arasında olacak.</string>
+    <string name="insight_band_range_no_lead">%1$d° ile %2$d° arasında olacak.</string>
     <string name="insight_band_words_single">%1$s %2$s olacak.</string>
+    <string name="insight_band_words_single_no_lead">%1$s.</string>
     <string name="insight_band_words_range">%1$s %2$s ile %3$s arasında olacak.</string>
+    <string name="insight_band_words_range_no_lead">%1$s ile %2$s arasında olacak.</string>
 
     <string name="insight_band_freezing">dondurucu soğuk</string>
     <string name="insight_band_cold">soğuk</string>
@@ -362,6 +369,7 @@ displayed label localizes.
     <string name="insight_alert">Uyarı: %1$s.</string>
 
     <string name="insight_clothes_wear">%1$s giy.</string>
+    <string name="insight_clothes_bare">%1$s.</string>
     <string name="insight_clothes_article_a">%1$s</string>
     <string name="insight_clothes_article_an">%1$s</string>
     <string name="insight_clothes_join_two">%1$s ve %2$s</string>
@@ -954,6 +962,7 @@ displayed label localizes.
     <string name="settings_format_change_label">Sıcaklık değişimi</string>
     <string name="settings_format_change_off">Kapalı</string>
     <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_change_band">Bant</string>
     <string name="settings_format_clothes_label">Kıyafet ifadesi</string>
     <string name="settings_format_clothes_items">Giysiler</string>
     <string name="settings_format_clothes_layer_count">Katman sayısı</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -554,13 +554,20 @@ only the displayed label localizes.
     <string name="insight_lead_today">Сьогодні</string>
     <string name="insight_lead_tomorrow">Завтра</string>
     <string name="insight_unchanged_today">Сьогодні буде так само, як учора.</string>
+    <string name="insight_unchanged_today_no_lead">Як учора.</string>
     <string name="insight_unchanged_tonight">Сьогодні ввечері буде так само, як учора ввечері.</string>
+    <string name="insight_unchanged_tonight_no_lead">Як учора ввечері.</string>
     <string name="insight_unchanged_tomorrow">Завтра буде так само, як сьогодні.</string>
+    <string name="insight_unchanged_tomorrow_no_lead">Як сьогодні.</string>
     <string name="insight_lead_tonight">Сьогодні ввечері</string>
     <string name="insight_band_single">%1$s буде %2$d°.</string>
+    <string name="insight_band_single_no_lead">%1$d°.</string>
     <string name="insight_band_range">%1$s буде від %2$d° до %3$d°.</string>
+    <string name="insight_band_range_no_lead">%1$d° до %2$d°.</string>
     <string name="insight_band_words_single">%1$s буде %2$s.</string>
+    <string name="insight_band_words_single_no_lead">%1$s.</string>
     <string name="insight_band_words_range">%1$s буде від %2$s до %3$s.</string>
+    <string name="insight_band_words_range_no_lead">%1$s до %2$s.</string>
     <string name="insight_band_freezing">морозно</string>
     <string name="insight_band_cold">холодно</string>
     <string name="insight_band_cool">прохолодно</string>
@@ -571,6 +578,7 @@ only the displayed label localizes.
     <string name="insight_delta_cooler">Сьогодні на %1$d° холодніше.</string>
     <string name="insight_alert">Попередження: %1$s.</string>
     <string name="insight_clothes_wear">Одягніть %1$s.</string>
+    <string name="insight_clothes_bare">%1$s.</string>
     <string name="insight_clothes_article_a">%1$s</string>
     <string name="insight_clothes_article_an">%1$s</string>
     <string name="insight_clothes_join_two">%1$s та %2$s</string>
@@ -949,6 +957,7 @@ only the displayed label localizes.
     <string name="settings_format_change_label">Зміна температури</string>
     <string name="settings_format_change_off">Вимк.</string>
     <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_change_band">Діапазон</string>
     <string name="settings_format_clothes_label">Опис одягу</string>
     <string name="settings_format_clothes_items">Предмети</string>
     <string name="settings_format_clothes_layer_count">Кількість шарів</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -51,14 +51,21 @@ Skipped intentionally: app_name (brand), insight_time_am/pm/midnight/noon
     <string name="insight_lead_today">Hôm nay</string>
     <string name="insight_lead_tomorrow">Ngày mai</string>
     <string name="insight_unchanged_today">Hôm nay trời giống như hôm qua.</string>
+    <string name="insight_unchanged_today_no_lead">Như hôm qua.</string>
     <string name="insight_unchanged_tonight">Tối nay trời giống như tối qua.</string>
+    <string name="insight_unchanged_tonight_no_lead">Như tối qua.</string>
     <string name="insight_unchanged_tomorrow">Ngày mai trời giống như hôm nay.</string>
+    <string name="insight_unchanged_tomorrow_no_lead">Như hôm nay.</string>
     <string name="insight_lead_tonight">Tối nay</string>
     <!-- Vietnamese: "Hôm nay trời mát." (time + topic + predicate) -->
     <string name="insight_band_single">%1$s trời %2$d°.</string>
+    <string name="insight_band_single_no_lead">%1$d°.</string>
     <string name="insight_band_range">%1$s trời từ %2$d° đến %3$d°.</string>
+    <string name="insight_band_range_no_lead">%1$d° đến %2$d°.</string>
     <string name="insight_band_words_single">%1$s trời %2$s.</string>
+    <string name="insight_band_words_single_no_lead">%1$s.</string>
     <string name="insight_band_words_range">%1$s trời từ %2$s đến %3$s.</string>
+    <string name="insight_band_words_range_no_lead">%1$s đến %2$s.</string>
     <string name="insight_band_freezing">đóng băng</string>
     <string name="insight_band_cold">lạnh</string>
     <string name="insight_band_cool">mát</string>
@@ -69,6 +76,7 @@ Skipped intentionally: app_name (brand), insight_time_am/pm/midnight/noon
     <string name="insight_delta_cooler">Hôm nay lạnh hơn %1$d°.</string>
     <string name="insight_alert">Cảnh báo: %1$s.</string>
     <string name="insight_clothes_wear">Mặc %1$s.</string>
+    <string name="insight_clothes_bare">%1$s.</string>
     <!-- Vietnamese has no grammatical articles. -->
     <string name="insight_clothes_article_a">%1$s</string>
     <string name="insight_clothes_article_an">%1$s</string>
@@ -1014,6 +1022,7 @@ Skipped intentionally: app_name (brand), insight_time_am/pm/midnight/noon
     <string name="settings_format_change_label">Thay đổi nhiệt độ</string>
     <string name="settings_format_change_off">Tắt</string>
     <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_change_band">Mức</string>
     <string name="settings_format_clothes_label">Cách diễn đạt quần áo</string>
     <string name="settings_format_clothes_items">Trang phục</string>
     <string name="settings_format_clothes_layer_count">Số lớp</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -413,14 +413,21 @@ label localizes.
     <string name="insight_lead_today">今天</string>
     <string name="insight_lead_tomorrow">明天</string>
     <string name="insight_unchanged_today">今天天气和昨天一样。</string>
+    <string name="insight_unchanged_today_no_lead">和昨天一样。</string>
     <string name="insight_unchanged_tonight">今晚天气和昨晚一样。</string>
+    <string name="insight_unchanged_tonight_no_lead">和昨晚一样。</string>
     <string name="insight_unchanged_tomorrow">明天天气和今天一样。</string>
+    <string name="insight_unchanged_tomorrow_no_lead">和今天一样。</string>
     <string name="insight_lead_tonight">今晚</string>
     <!-- "今天天气温和。" / "今晚天气寒冷至凉爽。" -->
     <string name="insight_band_single">%1$s天气%2$d°。</string>
+    <string name="insight_band_single_no_lead">%1$d°.</string>
     <string name="insight_band_range">%1$s天气%2$d°至%3$d°。</string>
+    <string name="insight_band_range_no_lead">%1$d°至%2$d°。</string>
     <string name="insight_band_words_single">%1$s天气%2$s。</string>
+    <string name="insight_band_words_single_no_lead">%1$s.</string>
     <string name="insight_band_words_range">%1$s天气%2$s至%3$s。</string>
+    <string name="insight_band_words_range_no_lead">%1$s至%2$s。</string>
     <string name="insight_band_freezing">极寒</string>
     <string name="insight_band_cold">寒冷</string>
     <string name="insight_band_cool">凉爽</string>
@@ -431,6 +438,7 @@ label localizes.
     <string name="insight_delta_cooler">今天气温下降%1$d°。</string>
     <string name="insight_alert">警告：%1$s。</string>
     <string name="insight_clothes_wear">穿上%1$s。</string>
+    <string name="insight_clothes_bare">%1$s.</string>
     <!-- Chinese has no grammatical articles. -->
     <string name="insight_clothes_article_a">%1$s</string>
     <string name="insight_clothes_article_an">%1$s</string>
@@ -1101,6 +1109,7 @@ label localizes.
     <string name="settings_format_change_label">温度变化</string>
     <string name="settings_format_change_off">关闭</string>
     <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_change_band">区间</string>
     <string name="settings_format_clothes_label">服装措辞</string>
     <string name="settings_format_clothes_items">衣物</string>
     <string name="settings_format_clothes_layer_count">层数</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -404,14 +404,21 @@ label localises.
     <string name="insight_lead_today">今天</string>
     <string name="insight_lead_tomorrow">明天</string>
     <string name="insight_unchanged_today">今天天氣和昨天一樣。</string>
+    <string name="insight_unchanged_today_no_lead">和昨天一樣。</string>
     <string name="insight_unchanged_tonight">今晚天氣和昨晚一樣。</string>
+    <string name="insight_unchanged_tonight_no_lead">和昨晚一樣。</string>
     <string name="insight_unchanged_tomorrow">明天天氣和今天一樣。</string>
+    <string name="insight_unchanged_tomorrow_no_lead">和今天一樣。</string>
     <string name="insight_lead_tonight">今晚</string>
     <!-- "今天天氣溫和。" / "今晚天氣寒冷至涼爽。" -->
     <string name="insight_band_single">%1$s天氣%2$d°。</string>
+    <string name="insight_band_single_no_lead">%1$d°.</string>
     <string name="insight_band_range">%1$s天氣%2$d°至%3$d°。</string>
+    <string name="insight_band_range_no_lead">%1$d°至%2$d°。</string>
     <string name="insight_band_words_single">%1$s天氣%2$s。</string>
+    <string name="insight_band_words_single_no_lead">%1$s.</string>
     <string name="insight_band_words_range">%1$s天氣%2$s至%3$s。</string>
+    <string name="insight_band_words_range_no_lead">%1$s至%2$s。</string>
     <string name="insight_band_freezing">極寒</string>
     <string name="insight_band_cold">寒冷</string>
     <string name="insight_band_cool">涼爽</string>
@@ -422,6 +429,7 @@ label localises.
     <string name="insight_delta_cooler">今天氣溫下降%1$d°。</string>
     <string name="insight_alert">警示：%1$s。</string>
     <string name="insight_clothes_wear">穿上%1$s。</string>
+    <string name="insight_clothes_bare">%1$s.</string>
     <!-- Chinese has no grammatical articles. -->
     <string name="insight_clothes_article_a">%1$s</string>
     <string name="insight_clothes_article_an">%1$s</string>
@@ -1117,6 +1125,7 @@ label localises.
     <string name="settings_format_change_label">溫度變化</string>
     <string name="settings_format_change_off">關閉</string>
     <string name="settings_format_change_degrees">%1$d°</string>
+    <string name="settings_format_change_band">區間</string>
     <string name="settings_format_clothes_label">服裝措辭</string>
     <string name="settings_format_clothes_items">衣物</string>
     <string name="settings_format_clothes_layer_count">層數</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1102,8 +1102,8 @@
          leaves the bare measurement: "14° to 20°." / "Cool to mild.". The
          degree templates are locale-neutral (digits + °); the band-word
          templates carry a capitalised band word so the sentence still opens
-         like a sentence. English-only for now (see InsightFormatter.supportsNoLead);
-         other locales keep the full lead-in. -->
+         like a sentence. Every locale ships these now, so the no-lead Today
+         card works in all languages. -->
     <string name="insight_band_single_no_lead">%1$d°.</string>
     <string name="insight_band_range_no_lead">%1$d° to %2$d°.</string>
     <string name="insight_band_words_single_no_lead">%1$s.</string>
@@ -1123,8 +1123,7 @@
     <string name="insight_unchanged_tonight">Tonight, it will be the same as last night.</string>
     <string name="insight_unchanged_tomorrow">Tomorrow, it will be the same as today.</string>
     <!-- No-lead variants of the "unchanged" placeholder for the Today card,
-         whose header already carries the period. English-only (see
-         InsightFormatter.supportsNoLead); other locales keep the full lead-in. -->
+         whose header already carries the period. Translated in every locale. -->
     <string name="insight_unchanged_today_no_lead">It will be the same as yesterday.</string>
     <string name="insight_unchanged_tonight_no_lead">It will be the same as last night.</string>
     <string name="insight_unchanged_tomorrow_no_lead">It will be the same as today.</string>
@@ -1166,8 +1165,7 @@
     <string name="insight_clothes_wear">Wear %1$s.</string>
     <!-- Wear preamble dropped (PreambleVisibility): no "Wear" and no leading
          article, just the (capitalised) garment body — "Sweater." / "Shorts.".
-         %1$s is the joined body. English-only path; other locales keep the full
-         "Wear …" wrapper. -->
+         %1$s is the joined body. Translated in every locale. -->
     <string name="insight_clothes_bare">%1$s.</string>
     <!-- Article forms used by EnglishClothesPhraser for the *first* item only. -->
     <string name="insight_clothes_article_a">a %1$s</string>

--- a/app/src/test/kotlin/app/clothescast/insight/InsightFormatterTest.kt
+++ b/app/src/test/kotlin/app/clothescast/insight/InsightFormatterTest.kt
@@ -139,14 +139,15 @@ class InsightFormatterTest {
     }
 
     @Test
-    fun `visual surface keeps the lead-in for non-English locales`() {
-        // Stripping the lead is English-only surgery (it removes the "it will
-        // be" connective and re-capitalises). Other locales fuse the lead into
-        // the sentence and have no no-lead template, so they keep the lead-in.
+    fun `visual surface drops the lead-in for non-English locales too`() {
+        // Every locale now ships insight_*_no_lead templates, so the no-lead
+        // surgery applies across languages: the German visual surface drops
+        // "Heute wird es …" down to the bare measurement, while the speech
+        // surface keeps the full lead-in.
         val germanSubject =
             InsightFormatter.forContext(context, Locale.GERMAN, periodPreamble = PreambleVisibility.SPEECH_ONLY)
-        germanSubject.format(summary(), surface = InsightSurface.VISUAL) shouldBe
-            germanSubject.format(summary(), surface = InsightSurface.SPEECH)
+        germanSubject.format(summary(), surface = InsightSurface.VISUAL) shouldBe "21°."
+        germanSubject.format(summary(), surface = InsightSurface.SPEECH) shouldBe "Heute wird es 21°."
     }
 
     // --- Period preamble (PreambleVisibility) ---
@@ -238,7 +239,10 @@ class InsightFormatterTest {
     }
 
     @Test
-    fun `wear preamble drop is English-only`() {
+    fun `wear preamble drop applies to non-English locales too`() {
+        // insight_clothes_bare ("%1$s.") ships in every locale, so dropping
+        // "Wear" works in German: "Trag Pullover." collapses to "Pullover."
+        // (the band lead stays — only the wear preamble is set to Never here).
         val germanWearNever = InsightFormatter.forContext(
             context,
             Locale.GERMAN,
@@ -247,10 +251,7 @@ class InsightFormatterTest {
         germanWearNever.format(
             summary(clothes = ClothesClause(listOf("sweater"))),
             surface = InsightSurface.VISUAL,
-        ) shouldBe germanWearNever.format(
-            summary(clothes = ClothesClause(listOf("sweater"))),
-            surface = InsightSurface.SPEECH,
-        )
+        ) shouldBe "Heute wird es 21°. Pullover."
     }
 
     @Test
@@ -777,9 +778,9 @@ class InsightFormatterTest {
 
     @Test
     fun `omit range keeps the leading delta localized for non-English`() {
-        // The "it will be …" lead template is English-only; a non-English
-        // locale must keep its own localized delta string rather than splice
-        // the English clause into otherwise-localized prose.
+        // The leading delta uses the locale's own self-introducing fragment
+        // (German insight_delta_warmer_lead), never the English "it will be …"
+        // clause spliced into otherwise-localized prose.
         val germanOmit = InsightFormatter.forContext(
             context,
             Locale.GERMAN,
@@ -790,18 +791,19 @@ class InsightFormatterTest {
     }
 
     @Test
-    fun `omit range does not double the lead on a self-leading localized delta`() {
-        // The German delta string is a full sentence that already opens with
-        // "Heute" ("Heute wird es 5° wärmer."). Folding the period lead in
-        // front of it would double the word ("Heute, heute wird es …"); the
-        // self-leading clause must be emitted verbatim instead.
+    fun `omit range folds the period lead in front of the leading delta`() {
+        // Range omitted: the delta leads, using the self-introducing German
+        // fragment ("es wird … wärmer als gestern.") with the period lead
+        // folded in front via insight_lead_continues — "Heute, es wird …",
+        // mirroring the English "Today, it will be …". The lead appears exactly
+        // once (no "Heute, heute …" doubling).
         val germanOmit = InsightFormatter.forContext(
             context,
             Locale.GERMAN,
             rangeFormat = RangeFormat.NONE,
         )
         germanOmit.format(summary(delta = DeltaClause(5, DeltaClause.Direction.WARMER))) shouldBe
-            "Heute wird es 5° wärmer."
+            "Heute, es wird 5° wärmer als gestern."
     }
 
     @Test
@@ -1497,6 +1499,70 @@ class InsightFormatterTest {
             ),
         )
         out shouldBe "Heute wird es 21°. Denk an Regenschirm für heute Abend, Regen um 21 Uhr."
+    }
+
+    @Test
+    fun `de — no-lead single band drops 'Heute wird es'`() {
+        val germanNoLead =
+            InsightFormatter.forContext(context, Locale.GERMAN, periodPreamble = PreambleVisibility.NEVER)
+        germanNoLead.format(summary()) shouldBe "21°."
+    }
+
+    @Test
+    fun `de — no-lead band range keeps the German 'bis' connector`() {
+        val germanNoLead =
+            InsightFormatter.forContext(context, Locale.GERMAN, periodPreamble = PreambleVisibility.NEVER)
+        germanNoLead.format(
+            summary(band = BandClause(TemperatureBand.COOL, TemperatureBand.MILD)),
+        ) shouldBe "15° bis 21°."
+    }
+
+    @Test
+    fun `de — no-lead unchanged placeholder is the brief German fragment`() {
+        // RangeFormat.NONE with nothing else firing falls back to the
+        // "unchanged" placeholder; the no-lead form drops the whole "Heute wird
+        // es genauso …" scaffold down to the bare comparison, so it stays terse
+        // and matches the card header.
+        val germanNoLead = InsightFormatter.forContext(
+            context,
+            Locale.GERMAN,
+            rangeFormat = RangeFormat.NONE,
+            periodPreamble = PreambleVisibility.NEVER,
+        )
+        germanNoLead.format(summary()) shouldBe "Wie gestern."
+    }
+
+    @Test
+    fun `de — settings preview parenthesises the German lead for the unchanged line`() {
+        // Because the no-lead form is a clean suffix of the full sentence, the
+        // Speech-only preview recovers the dropped lead and parenthesises it
+        // ("(Heute wird es) genauso wie gestern.") rather than falling back to
+        // the un-parenthesised full sentence.
+        val germanPreview = InsightFormatter.forContext(
+            context,
+            Locale.GERMAN,
+            rangeFormat = RangeFormat.NONE,
+            periodPreamble = PreambleVisibility.SPEECH_ONLY,
+        )
+        germanPreview.format(summary(), surface = InsightSurface.SETTINGS_PREVIEW) shouldBe
+            "(Heute wird es genauso) wie gestern."
+    }
+
+    @Test
+    fun `de — no-lead leading delta uses the self-introducing German fragment`() {
+        // Range omitted + a numeric delta: the delta leads the temperature
+        // content, so it uses insight_delta_warmer_lead ("es wird … wärmer als
+        // gestern.") capitalised, rather than the trailing "Heute wird es …"
+        // fragment.
+        val germanNoLead = InsightFormatter.forContext(
+            context,
+            Locale.GERMAN,
+            rangeFormat = RangeFormat.NONE,
+            periodPreamble = PreambleVisibility.NEVER,
+        )
+        germanNoLead.format(
+            summary(delta = DeltaClause(5, DeltaClause.Direction.WARMER)),
+        ) shouldBe "Es wird 5° wärmer als gestern."
     }
 
     // ---------------------------------------------------------------------


### PR DESCRIPTION
## What & why

The "drop the *Today, it will be…* lead-in" option (and the matching **Wear** preamble option) only took effect in English — every other language kept the full lead-in regardless of the setting, because the templates needed to drop the lead weren't translated. This widens the feature to all 44 supported languages.

## Translations

- Added the no-lead insight templates to every full locale:
  - `insight_band_single_no_lead`, `insight_band_range_no_lead`
  - `insight_band_words_single_no_lead`, `insight_band_words_range_no_lead`
  - `insight_unchanged_today/tomorrow/tonight_no_lead`
  - `insight_clothes_bare`
- **No-lead means no lead** — the forms are kept as terse as each language allows, dropping the whole lead scaffold rather than re-flowing it into a fresh sentence:
  - German `Heute wird es genauso wie gestern.` → **`Wie gestern.`**; `Heute wird es heiß.` → **`Heiß.`**
  - Spanish **`Como ayer.`**, French **`Comme hier.`**, Japanese **`昨日と同じ。`**, …
- Range templates reuse each locale's natural range connector (`bis` / `à` / `to` / …).
- Regional overlays (`de-rAT`/`-rCH`, `en-r*`, `es-rMX`, `fr-rCA`) inherit these from their parent locale and are intentionally left sparse.
- Also filled `settings_format_change_band` (the "Band" temperature-change option label) across every locale that ships its siblings — it was added after the last bulk-translation pass and was still showing in English.

## Code

- Removed `InsightFormatter.supportsNoLead()` and `deltaHasLeadFragment()` (the two `locale == "en"` gates) and the now-dead "first clause self-leads" branch. Every locale already ships the `insight_delta_*_lead` fragments, so a range-omitted leading delta now folds the period lead the same way English does (`Heute, es wird 5° wärmer als gestern.`).

## Settings preview

The Format-settings "Speech only" preview recovers the dropped lead by suffix-splicing (`(Today, it will be) 14° to 20°.`). Where the terse form is still a suffix of the full sentence (e.g. German `Wie gestern.`) the preview parenthesises correctly; where the terse form swaps the comparison word (Spanish `Como ayer.`) or trails its verb (Japanese), it hits the existing graceful fallback and shows the lead un-parenthesised — never a garbled splice. On-card brevity is the priority surface.

## Privacy

The rendered insight prose feeds Gemini TTS over BYOK keys. This change only ever makes that text **shorter**; no new data category leaves the device, and the speech surface still keeps the full lead-in under the **Speech only** setting.

## Test plan

- `./gradlew :core:domain:test :core:data:test :app:testDebugUnitTest` — green. `InsightFormatterTest` updated: the two former "English-only" assertions now assert the German no-lead output, plus new German coverage (terse unchanged fragment, parenthesised settings preview, leading delta).
- `./gradlew :app:assembleDebug` — green; `aapt` validated every locale file.

Note: `:app:lintDebug` currently crashes with an internal `IncompatibleClassChangeError` in lint's own Compose detector — unrelated to these string changes and not part of CI.

https://claude.ai/code/session_01XMaFqBocpD2RVzjvYb6yux