### PR TITLE
Preview the correct ClothesCast in the overnight hours

### DIFF
--- a/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
@@ -68,6 +68,7 @@ import java.io.IOException
 import java.time.Duration
 import java.time.Instant
 import java.time.LocalDate
+import java.time.LocalDateTime
 import java.time.LocalTime
 import java.util.concurrent.TimeUnit
 import kotlin.random.Random
@@ -299,18 +300,22 @@ class FetchAndNotifyWorker(
         prefs: UserPreferences,
         requestedPeriod: ForecastPeriod,
     ): Result {
-        val currentPeriod = currentPeriodForSchedule(prefs)
-        // Which day's [requestedPeriod] window the user means. Everything is
-        // today except previewing the daytime ("Daily") cast once we're already
-        // in the nightly window — today's daytime cast has passed, so "Play now"
-        // on Daily then means *tomorrow's* daytime. Mirrors the next-window
-        // pairing in [generatePairedInsight].
-        val dayOffset = nextOccurrenceDayOffset(requestedPeriod, currentPeriod)
-        val targetDate = LocalDate.now().plusDays(dayOffset.toLong())
+        val now = LocalDateTime.now()
+        val currentPeriod = currentPeriodForSchedule(prefs, now.toLocalTime())
+        // The calendar date the [requestedPeriod] cast the user wants is dated
+        // for. Accounts for the nightly window wrapping past midnight (see
+        // [playTargetDate]): in the post-midnight tail of the night the current
+        // nightly snapshot is still dated *yesterday*, and the next daytime cast
+        // is *this* morning (today), not tomorrow.
+        val targetDate = playTargetDate(
+            requestedPeriod,
+            now,
+            prefs.schedule.time,
+            prefs.tonightSchedule.time,
+        )
         // Look for a snapshot the user actually asked to hear: matching period
         // AND the right day. Both cache slots are eligible — THIS_PERIOD holds
-        // the current window, NEXT_PERIOD the pre-captured next one (after the
-        // nightly alarm fires, NEXT_PERIOD holds tomorrow's daytime), so a
+        // the current window, NEXT_PERIOD the pre-captured next one, so a
         // "Play now" for the not-yet-current window can hit the pre-capture
         // without a fetch. A snapshot for the wrong day — e.g. this morning's
         // already-delivered daytime cast when the user wants tomorrow's daily —
@@ -355,9 +360,18 @@ class FetchAndNotifyWorker(
             DiagLog.i(TAG, "Play cache miss for current window $requestedPeriod; fetching fresh.")
             return fresh(location, prefs, requestedPeriod)
         }
-        DiagLog.i(TAG, "Play cache miss for non-current window $requestedPeriod (+${dayOffset}d); ephemeral fetch.")
+        // capturedSnapshot only supports dayOffset 0 (either period) or 1
+        // (TODAY = tomorrow's daytime). The non-current ephemeral path only ever
+        // needs tomorrow's daytime (+1, when Daily is tapped in the evening);
+        // every other non-current case is today (0). The overnight "current
+        // night dated yesterday" can't be fetched — Open-Meteo anchors to the
+        // real calendar day — but that case is the *current* window, so it goes
+        // through the cache hit or the fresh() branch above, never here.
+        val fetchDayOffset =
+            if (requestedPeriod == ForecastPeriod.TODAY && targetDate.isAfter(now.toLocalDate())) 1 else 0
+        DiagLog.i(TAG, "Play cache miss for non-current window $requestedPeriod (+${fetchDayOffset}d); ephemeral fetch.")
         return try {
-            val snapshot = capturedSnapshot(location, prefs, requestedPeriod, dayOffset)
+            val snapshot = capturedSnapshot(location, prefs, requestedPeriod, fetchDayOffset)
             val insight = app.deriveInsight(snapshot, prefs, diagLog = { DiagLog.i(TAG, it) }).insight
             val prose = formatProse(insight, prefs)
             deliverBestEffort(insight, prefs, prose, "Previewed")
@@ -1765,21 +1779,42 @@ class FetchAndNotifyWorker(
         }
 
         /**
-         * Day offset (0 = today, 1 = tomorrow) of the next occurrence of
-         * [requestedPeriod] given the [currentPeriod] schedule window — used by
-         * on-demand play to target the right day. Only the daytime ("TODAY")
-         * cast previewed once we're already in the nightly window advances to
-         * tomorrow: today's daytime cast has passed, so "Play now" on Daily
-         * means tomorrow's. The nightly cast (still upcoming or ongoing) and any
-         * current-window play stay on today. Mirrors the pairing in
-         * [generatePairedInsight], whose post-nightly NEXT_PERIOD pre-capture is
-         * exactly tomorrow's daytime.
+         * The calendar date the [requestedPeriod] cast that on-demand play
+         * should target is dated for, given wall-clock [now] and the schedule
+         * [morningTime] / [tonightTime]. This is the date the desired snapshot's
+         * [ForecastBundle.today] carries, so it's used directly to match the
+         * cache (and to derive the fetch day-offset).
+         *
+         * The nightly window wraps past midnight (tonightTime today →
+         * morningTime tomorrow), so the date depends on where in the day we are:
+         *
+         *  - **Daytime cast (TODAY):** today's, unless we're already past the
+         *    evening cutoff — then today's daytime cast has gone out and the next
+         *    one is tomorrow's. Crucially, in the post-midnight tail of the night
+         *    (before the morning cutoff) the next daytime cast is *this* morning,
+         *    i.e. today — not tomorrow.
+         *  - **Nightly cast (TONIGHT):** today's, except in that same
+         *    post-midnight tail, where the *current* (ongoing) night began the
+         *    previous evening and so is dated *yesterday*.
+         *
+         * Assumes the usual schedule shape (tonightTime later than morningTime);
+         * the degenerate crossed config falls back to "today", same window the
+         * cache/fetch would otherwise pick.
          */
-        internal fun nextOccurrenceDayOffset(
+        internal fun playTargetDate(
             requestedPeriod: ForecastPeriod,
-            currentPeriod: ForecastPeriod,
-        ): Int = if (
-            requestedPeriod == ForecastPeriod.TODAY && currentPeriod == ForecastPeriod.TONIGHT
-        ) 1 else 0
+            now: LocalDateTime,
+            morningTime: LocalTime,
+            tonightTime: LocalTime,
+        ): LocalDate {
+            val date = now.toLocalDate()
+            val time = now.toLocalTime()
+            return when (requestedPeriod) {
+                ForecastPeriod.TODAY ->
+                    if (tonightTime > morningTime && time >= tonightTime) date.plusDays(1) else date
+                ForecastPeriod.TONIGHT ->
+                    if (tonightTime > morningTime && time < morningTime) date.minusDays(1) else date
+            }
+        }
     }
 }

--- a/app/src/test/kotlin/app/clothescast/work/FetchAndNotifyWorkerTest.kt
+++ b/app/src/test/kotlin/app/clothescast/work/FetchAndNotifyWorkerTest.kt
@@ -31,6 +31,7 @@ import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 import java.time.Instant
 import java.time.LocalDate
+import java.time.LocalTime
 import java.time.ZoneId
 
 /**
@@ -324,27 +325,28 @@ class FetchAndNotifyWorkerTest {
     }
 
     @Test
-    fun `daily preview advances to tomorrow once the nightly window has started`() {
-        // The daytime cast has already passed by the time we're in the nightly
-        // window, so "Play now" on Daily means *tomorrow's* daytime — every
-        // other combination stays on today (tonight is still upcoming/ongoing,
-        // and a current-window play is always today).
-        FetchAndNotifyWorker.nextOccurrenceDayOffset(
-            requestedPeriod = ForecastPeriod.TODAY,
-            currentPeriod = ForecastPeriod.TONIGHT,
-        ) shouldBe 1
-        FetchAndNotifyWorker.nextOccurrenceDayOffset(
-            requestedPeriod = ForecastPeriod.TODAY,
-            currentPeriod = ForecastPeriod.TODAY,
-        ) shouldBe 0
-        FetchAndNotifyWorker.nextOccurrenceDayOffset(
-            requestedPeriod = ForecastPeriod.TONIGHT,
-            currentPeriod = ForecastPeriod.TODAY,
-        ) shouldBe 0
-        FetchAndNotifyWorker.nextOccurrenceDayOffset(
-            requestedPeriod = ForecastPeriod.TONIGHT,
-            currentPeriod = ForecastPeriod.TONIGHT,
-        ) shouldBe 0
+    fun `play target date follows the schedule window across midnight`() {
+        val morning = LocalTime.of(7, 0)
+        val tonight = LocalTime.of(19, 0)
+        val date = LocalDate.of(2026, 5, 27)
+        fun target(period: ForecastPeriod, time: LocalTime) =
+            FetchAndNotifyWorker.playTargetDate(period, date.atTime(time), morning, tonight)
+
+        // Daytime (10:00) — both casts are today's.
+        target(ForecastPeriod.TODAY, LocalTime.of(10, 0)) shouldBe date
+        target(ForecastPeriod.TONIGHT, LocalTime.of(10, 0)) shouldBe date
+
+        // Evening (20:00) — today's daytime has gone out, so Daily means
+        // tomorrow; the nightly cast is the current (today's) one.
+        target(ForecastPeriod.TODAY, LocalTime.of(20, 0)) shouldBe date.plusDays(1)
+        target(ForecastPeriod.TONIGHT, LocalTime.of(20, 0)) shouldBe date
+
+        // Overnight (02:00, past midnight, before the morning cutoff) — the
+        // current ongoing night began the previous evening, so it's dated
+        // yesterday; the next daytime cast is *this* morning, i.e. today (not
+        // tomorrow). This is the midnight-crossing case the offset must handle.
+        target(ForecastPeriod.TODAY, LocalTime.of(2, 0)) shouldBe date
+        target(ForecastPeriod.TONIGHT, LocalTime.of(2, 0)) shouldBe date.minusDays(1)
     }
 
     private fun workInfosFor(name: String): List<WorkInfo> =


### PR DESCRIPTION
## What & why

Follow-up to #794. On-demand Play targeting didn't account for the nightly schedule window wrapping past midnight, so in the **post-midnight tail of the night** (after 00:00, before the morning cutoff) it played the wrong cast.

The old code anchored the target to `LocalDate.now()` with a `0/+1` offset derived only from the current period (`nextOccurrenceDayOffset`). After midnight, `LocalDate.now()` has rolled to the new day while the schedule still reports the previous evening's `TONIGHT` window, so:

- **Top-bar / Nightly "Play now"** — the current nightly snapshot is dated *yesterday* there, so the `date == today` lookup missed it and the worker fetched the *next* evening instead of replaying the ongoing night.
- **Daily "Play now"** — still applied the `+1` offset and targeted *tomorrow's* daytime, skipping the upcoming **same-morning** cast (which is today's).

## How

Replaces the period-only `nextOccurrenceDayOffset` with `playTargetDate(requestedPeriod, now, morningTime, tonightTime)`, which returns the calendar date the desired cast's snapshot is dated for:

- **Daytime (`TODAY`)**: today's, unless we're past the evening cutoff → tomorrow's. (In the post-midnight tail, `now.time < tonightTime`, so it stays *today* = this morning's cast.)
- **Nightly (`TONIGHT`)**: today's, except in the post-midnight tail (`now.time < morningTime`) where the ongoing night began the previous evening → *yesterday*.

The cache lookup matches that date directly (so it finds the cached current-night dated yesterday, and the pre-captured this-morning daytime dated today). The ephemeral fetch maps the target to the only offsets `GenerateDailyInsight.snapshot` supports (`0`, or `+1` for tomorrow's daytime) — the overnight "current night dated yesterday" isn't fetchable (Open-Meteo anchors to the real calendar day), but that's the *current* window, so it's served by the cache hit or the current-window `fresh()` branch, never the ephemeral fetch.

## Test plan

- New `playTargetDate` unit test covers daytime / evening / overnight for both periods (the overnight rows are the regression guard).
- `:core:domain:test`, `:core:data:test`, `:app:testDebugUnitTest`, `:app:assembleDebug` all green locally; zero snapshot drift.

No user-data / device-boundary changes (same `deliver()` pipeline as before).

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JiCH2kD3R3NjYMiKvoiAJY)_