### PR TITLE
Hide the preview tip once you tap the play button

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/today/PlayPromoCard.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/PlayPromoCard.kt
@@ -29,8 +29,10 @@ import app.clothescast.R
  * Visibility is decided upstream in [TodayViewModel] via
  * [TodayState.playPromoCardVisible] — true iff the user hasn't dismissed it AND
  * at least one cast slot is enabled (so "your ClothesCast" is meaningful; the
- * morning slot is on by default, so this normally holds). Dismissal persists
- * via [SettingsRepository.setPlayCardDismissed].
+ * morning slot is on by default, so this normally holds). It's retired (via
+ * [SettingsRepository.setPlayCardDismissed]) both by the dismiss X and by the
+ * user tapping the top-bar Play button it points at — once they've used Play,
+ * the card has served its purpose.
  */
 @Composable
 internal fun PlayPromoCard(

--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
@@ -273,6 +273,11 @@ fun TodayScreen(
                                     ForecastPeriod.TODAY
                                 }
                             triggerPlay(context, playPeriod)
+                            // Using Play is the user acting on the "Preview your
+                            // ClothesCast" promo, so retire it — they've found
+                            // the button it points at. Guarded so a tap when the
+                            // card isn't showing doesn't write to DataStore.
+                            if (state.playPromoCardVisible) viewModel.dismissPlayPromoCard()
                         },
                         enabled = !state.anyWorkActive,
                     ) {

--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayViewModel.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayViewModel.kt
@@ -600,9 +600,10 @@ class TodayViewModel(
     }
 
     /**
-     * Persists the user's dismissal of the Today-screen "Preview your daily
-     * ClothesCast now" promo card. Called on the X-tap; the card hides on the
-     * next state emission. Mirrors [dismissSchedulePromoCard].
+     * Retires the Today-screen "Preview your daily ClothesCast now" promo card.
+     * Called on the X-tap *and* when the user taps the top-bar Play button the
+     * card points at — once they've used Play the card has done its job. The
+     * card hides on the next state emission. Mirrors [dismissSchedulePromoCard].
      */
     fun dismissPlayPromoCard() {
         viewModelScope.launch {


### PR DESCRIPTION
## What & why

The Today-screen "Preview your daily ClothesCast now" promo card points users at the top-bar Play button. Tapping that button *is* the user acting on the promo, so the card should retire itself at that point — same pattern as the "Customize your clothes" promo dismissing on its CTA — rather than lingering until it's explicitly X-ed out.

## How

The top-bar Play button's `onClick` now calls `viewModel.dismissPlayPromoCard()` (which persists `setPlayCardDismissed(true)`, the same flag the X uses) after triggering playback. Guarded by `if (state.playPromoCardVisible)` so a Play tap when the card isn't showing doesn't write to DataStore. Updated the `dismissPlayPromoCard` / `PlayPromoCard` docs to note the second retirement path.

## Test plan

- `:core:domain:test`, `:core:data:test`, `:app:testDebugUnitTest`, `:app:assembleDebug` all green locally; zero snapshot drift (no visual change — the card simply stops appearing after Play is used).

Follow-up to #794 / #796. No data / device-boundary changes.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JiCH2kD3R3NjYMiKvoiAJY)_