### PR TITLE
Play button now speaks and notifies even on silent delivery

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
@@ -3054,7 +3054,13 @@ private fun triggerPlay(context: android.content.Context, period: ForecastPeriod
     // rather than silently no-opping (see FetchAndNotifyWorker.playInsight).
     // The unique work name is keyed on the play queue so a Refresh and a
     // Play can't run concurrently for the same slot.
-    FetchAndNotifyWorker.enqueuePlay(context.applicationContext, period)
+    //
+    // forceNotifyAndSpeak: tapping Play is an explicit "do it now," so it
+    // posts the notification and speaks regardless of the delivery mode — a
+    // SILENT / notification-only user still sees and hears their forecast.
+    // (The Schedule "Play now" preview leaves this off to simulate the
+    // configured mode.)
+    FetchAndNotifyWorker.enqueuePlay(context.applicationContext, period, forceNotifyAndSpeak = true)
     val toastRes = when (period) {
         ForecastPeriod.TODAY -> R.string.today_play_toast_daily
         ForecastPeriod.TONIGHT -> R.string.today_play_toast_nightly

--- a/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
@@ -300,6 +300,10 @@ class FetchAndNotifyWorker(
         prefs: UserPreferences,
         requestedPeriod: ForecastPeriod,
     ): Result {
+        // The Today screen's Play button forces notify + speak; the
+        // Schedule "Play now" preview leaves this false to simulate the
+        // configured delivery mode (see enqueuePlay).
+        val forceNotifyAndSpeak = inputData.getBoolean(KEY_PLAY_FORCE, false)
         val now = LocalDateTime.now()
         val currentPeriod = currentPeriodForSchedule(prefs, now.toLocalTime())
         // The calendar date the [requestedPeriod] cast the user wants is dated
@@ -334,7 +338,7 @@ class FetchAndNotifyWorker(
             setProgress(workDataOf(KEY_FETCH_COMPLETE to true))
             val insight = app.deriveInsight(cached, prefs, diagLog = { DiagLog.i(TAG, it) }).insight
             val prose = formatProse(insight, prefs)
-            return deliverBestEffort(insight, prefs, prose, "Replayed")
+            return deliverBestEffort(insight, prefs, prose, "Replayed", forceNotifyAndSpeak)
         }
 
         // Cache miss — fetch fresh for the requested period.
@@ -374,7 +378,7 @@ class FetchAndNotifyWorker(
             val snapshot = capturedSnapshot(location, prefs, requestedPeriod, fetchDayOffset)
             val insight = app.deriveInsight(snapshot, prefs, diagLog = { DiagLog.i(TAG, it) }).insight
             val prose = formatProse(insight, prefs)
-            deliverBestEffort(insight, prefs, prose, "Previewed")
+            deliverBestEffort(insight, prefs, prose, "Previewed", forceNotifyAndSpeak)
         } catch (ce: CancellationException) {
             throw ce
         } catch (t: Throwable) {
@@ -389,14 +393,19 @@ class FetchAndNotifyWorker(
      * refresh failure banner — whatever's on screen is still valid, and the
      * next genuine refresh will retry the pipeline. [verb] tags the success log
      * ("Replayed" / "Previewed").
+     *
+     * [forceNotifyAndSpeak] carries the Today Play button's "do it now"
+     * intent through to [deliver]; the Schedule "Play now" preview passes
+     * false so it simulates the configured delivery mode.
      */
     private suspend fun deliverBestEffort(
         insight: Insight,
         prefs: UserPreferences,
         prose: String,
         verb: String,
+        forceNotifyAndSpeak: Boolean,
     ): Result = try {
-        deliver(insight, prefs, prose)
+        deliver(insight, prefs, prose, forceNotifyAndSpeak = forceNotifyAndSpeak)
         DiagLog.i(TAG, "$verb insight for ${insight.forDate}: $prose")
         Result.success(workDataOf(KEY_SKIP_TELEMETRY to true))
     } catch (ce: CancellationException) {
@@ -513,7 +522,12 @@ class FetchAndNotifyWorker(
                 // longer in the "fetching" phase; a deliver-side failure
                 // still surfaces via the terminal FAILED entry.
                 setProgress(workDataOf(KEY_FETCH_COMPLETE to true))
-                deliver(insight, prefs, prose)
+                // A current-window Today Play tap with an empty/stale cache
+                // lands here (playInsight → fresh). Carry its "notify + speak
+                // now" intent through so delivery fires regardless of the
+                // mode; scheduled runs and the Schedule preview leave
+                // KEY_PLAY_FORCE unset and keep honouring the mode.
+                deliver(insight, prefs, prose, forceNotifyAndSpeak = inputData.getBoolean(KEY_PLAY_FORCE, false))
                 DiagLog.i(TAG, "Insight delivered for ${insight.forDate}: $prose")
             }
             recordDailyHistory(insight)
@@ -815,7 +829,21 @@ class FetchAndNotifyWorker(
         }
     }
 
-    private suspend fun deliver(insight: Insight, prefs: UserPreferences, prose: String) {
+    /**
+     * @param forceNotifyAndSpeak the user tapped the Today screen's Play
+     *   button, an explicit "do it now" that posts the notification *and*
+     *   speaks regardless of the period's delivery mode — a SILENT /
+     *   notification-only user still sees and hears a tapped forecast.
+     *   Defaults to false so scheduled runs and the Schedule "Play now"
+     *   preview (which deliberately simulates the configured mode) honour
+     *   the delivery mode exactly as before.
+     */
+    private suspend fun deliver(
+        insight: Insight,
+        prefs: UserPreferences,
+        prose: String,
+        forceNotifyAndSpeak: Boolean = false,
+    ) {
         // Apply today's holiday theme on top of the user's persisted outfit
         // colour customisations so the notification's large icon and the
         // Home-Assistant outfit card match what the Today screen renders —
@@ -849,6 +877,7 @@ class FetchAndNotifyWorker(
             insightHasEvents = insight.hasEvents,
             geminiAvailable = geminiAvailable,
             mqttPublishable = isMqttPublishable(prefs),
+            forcePhoneSpeech = forceNotifyAndSpeak,
         )
 
         // Two-phase fan-out per SPEC.md §Sequencing:
@@ -916,7 +945,7 @@ class FetchAndNotifyWorker(
 
             awaitDeliveryAlignment()
 
-            val notifyJob = launch { postPeriodNotification(insight, prefs, prose, topColors, topStrokes, gates) }
+            val notifyJob = launch { postPeriodNotification(insight, prefs, prose, topColors, topStrokes, gates, forceNotify = forceNotifyAndSpeak) }
 
             // Cast load — runs in parallel with notification + MQTT.
             // The phone speaker awaits this when castWillHaveAudio so
@@ -1158,6 +1187,7 @@ class FetchAndNotifyWorker(
         topColors: Map<OutfitSuggestion.Top, Long>,
         topStrokes: Map<OutfitSuggestion.Top, Long>,
         gates: app.clothescast.core.domain.usecase.DeliveryGates,
+        forceNotify: Boolean = false,
     ) {
         if (gates.emptyEveningSkip) {
             DiagLog.i(TAG, "Tonight insight has no events and notify-only-on-events is on; skipping notification.")
@@ -1167,7 +1197,10 @@ class FetchAndNotifyWorker(
             ForecastPeriod.TODAY -> prefs.deliveryMode
             ForecastPeriod.TONIGHT -> prefs.tonightDeliveryMode
         }
-        val canNotify = mode == DeliveryMode.NOTIFICATION_ONLY ||
+        // forceNotify: the Today screen's Play button posts the notification
+        // even on SILENT / TTS-only — an explicit tap means "show it now."
+        val canNotify = forceNotify ||
+            mode == DeliveryMode.NOTIFICATION_ONLY ||
             mode == DeliveryMode.NOTIFICATION_AND_TTS
         if (!canNotify) return
         when (insight.period) {
@@ -1563,6 +1596,16 @@ class FetchAndNotifyWorker(
          */
         internal const val KEY_PLAY = "play"
 
+        /**
+         * Set true via [enqueuePlay] when the on-demand play should post the
+         * notification *and* speak regardless of the period's delivery mode
+         * — the Today screen's Play button, an explicit "do it now." Left
+         * false for the Schedule settings "Play now" preview, which
+         * deliberately simulates the configured delivery mode (SILENT plays
+         * nothing, TTS-only speaks without a banner, etc.).
+         */
+        internal const val KEY_PLAY_FORCE = "play_force"
+
         fun enqueueOneShot(
             context: Context,
             silent: Boolean = false,
@@ -1617,8 +1660,18 @@ class FetchAndNotifyWorker(
          * user's most-recent tap is the one that matters; concurrent
          * Refresh+Play double-delivery is prevented by the UI gate (see
          * [TodayState.anyWorkActive]), not by sharing a queue.
+         *
+         * @param forceNotifyAndSpeak true for the Today Play button — post
+         *   the notification and speak regardless of the delivery mode, so a
+         *   SILENT user still sees and hears the tapped forecast. False (the
+         *   default) for the Schedule "Play now" preview, which simulates the
+         *   configured mode.
          */
-        fun enqueuePlay(context: Context, period: ForecastPeriod) {
+        fun enqueuePlay(
+            context: Context,
+            period: ForecastPeriod,
+            forceNotifyAndSpeak: Boolean = false,
+        ) {
             val constraints = Constraints.Builder()
                 .setRequiredNetworkType(NetworkType.CONNECTED)
                 .build()
@@ -1630,6 +1683,7 @@ class FetchAndNotifyWorker(
                     workDataOf(
                         KEY_PLAY to true,
                         KEY_PERIOD to period.name,
+                        KEY_PLAY_FORCE to forceNotifyAndSpeak,
                     )
                 )
                 .build()

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/DeliveryGates.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/DeliveryGates.kt
@@ -54,6 +54,11 @@ data class DeliveryGates(
      * evening window. Suppresses notification, phone speaker, **and
      * cast**. Does not suppress MQTT publishes — HA still wants
      * fresh retained topics on every run.
+     *
+     * Cleared by [forcePhoneSpeech]: an explicit Play tap is a "deliver
+     * this period now" request, so the empty-evening suppression doesn't
+     * apply — the user gets the notification, speech, and cast they asked
+     * for even on an eventless evening.
      */
     val emptyEveningSkip: Boolean,
     /**
@@ -89,6 +94,16 @@ data class DeliveryGates(
  *   through (no buffer to publish).
  * @param mqttPublishable bridge enabled AND host non-empty (see
  *   [isMqttPublishable]).
+ * @param forcePhoneSpeech the user explicitly asked the phone to speak
+ *   *now* (the Today screen's Play button), independent of the scheduled
+ *   delivery mode. Overrides `phoneTtsConfigured` so a SILENT /
+ *   notification-only user still hears a tapped forecast, and — because
+ *   Gemini is the only PCM producer — pulls the phone-speaker term into
+ *   `needsSynth` so the buffer exists when the speaker reaches for it.
+ *   Also clears `emptyEveningSkip`: an explicit "deliver now" tap is
+ *   never suppressed by the tonight "only notify on events" rule.
+ *   Defaults to false: scheduled runs and the Schedule "Play now"
+ *   preview keep honouring the delivery mode exactly as before.
  */
 fun computeDeliveryGates(
     prefs: UserPreferences,
@@ -96,12 +111,14 @@ fun computeDeliveryGates(
     insightHasEvents: Boolean,
     geminiAvailable: Boolean,
     mqttPublishable: Boolean,
+    forcePhoneSpeech: Boolean = false,
 ): DeliveryGates {
     val mode = when (period) {
         ForecastPeriod.TODAY -> prefs.deliveryMode
         ForecastPeriod.TONIGHT -> prefs.tonightDeliveryMode
     }
-    val phoneTtsConfigured = mode == DeliveryMode.TTS_ONLY ||
+    val phoneTtsConfigured = forcePhoneSpeech ||
+        mode == DeliveryMode.TTS_ONLY ||
         mode == DeliveryMode.NOTIFICATION_AND_TTS
 
     val castPeriodEnabled = when (period) {
@@ -112,8 +129,10 @@ fun computeDeliveryGates(
     val castWillHaveAudio = willCast && geminiAvailable
 
     // Empty-evening only applies to TONIGHT. TODAY is never skipped
-    // here regardless of `tonightNotifyOnlyOnEvents`.
-    val emptyEveningSkip = period == ForecastPeriod.TONIGHT &&
+    // here regardless of `tonightNotifyOnlyOnEvents`. A forced Play
+    // ("deliver now") never skips — the user explicitly asked for it.
+    val emptyEveningSkip = !forcePhoneSpeech &&
+        period == ForecastPeriod.TONIGHT &&
         prefs.tonightNotifyOnlyOnEvents &&
         !insightHasEvents
 

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/DeliveryGatesTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/DeliveryGatesTest.kt
@@ -183,6 +183,69 @@ class DeliveryGatesTest {
     }
 
     @Test
+    fun `force phone speech overrides SILENT delivery — phone speaks and synth fires`() {
+        // The Today screen's Play button is an explicit "speak now"
+        // request. It must override the scheduled delivery mode: a user
+        // on SILENT (no automatic chime) who taps Play still wants to
+        // hear the forecast, and on Gemini that means synth has to run
+        // so the phone speaker has a buffer to play.
+        val gates = computeDeliveryGates(
+            prefs = basePrefs.copy(
+                ttsEngine = TtsEngine.GEMINI,
+                deliveryMode = DeliveryMode.SILENT,
+            ),
+            period = ForecastPeriod.TODAY,
+            insightHasEvents = false,
+            geminiAvailable = true,
+            mqttPublishable = false,
+            forcePhoneSpeech = true,
+        )
+        gates.phoneTtsConfigured shouldBe true
+        gates.needsSynth shouldBe true
+    }
+
+    @Test
+    fun `force phone speech clears emptyEveningSkip — Play delivers on an eventless tonight`() {
+        // A Play tap is an explicit "deliver this period now," so the
+        // tonight "only notify on events" suppression doesn't apply: the
+        // user gets the notification, speech, and synth even with no
+        // evening events.
+        val gates = computeDeliveryGates(
+            prefs = basePrefs.copy(
+                ttsEngine = TtsEngine.GEMINI,
+                tonightDeliveryMode = DeliveryMode.SILENT,
+                tonightNotifyOnlyOnEvents = true,
+            ),
+            period = ForecastPeriod.TONIGHT,
+            insightHasEvents = false,
+            geminiAvailable = true,
+            mqttPublishable = false,
+            forcePhoneSpeech = true,
+        )
+        gates.emptyEveningSkip shouldBe false
+        gates.phoneTtsConfigured shouldBe true
+        gates.needsSynth shouldBe true
+    }
+
+    @Test
+    fun `force phone speech is off by default — SILENT stays silent on scheduled runs`() {
+        // Without the explicit Play request, SILENT must keep the phone
+        // quiet on a scheduled run — forcePhoneSpeech defaults to false.
+        val gates = computeDeliveryGates(
+            prefs = basePrefs.copy(
+                ttsEngine = TtsEngine.GEMINI,
+                deliveryMode = DeliveryMode.SILENT,
+            ),
+            period = ForecastPeriod.TODAY,
+            insightHasEvents = false,
+            geminiAvailable = true,
+            mqttPublishable = false,
+        )
+        gates.phoneTtsConfigured shouldBe false
+        gates.needsSynth shouldBe false
+    }
+
+    @Test
     fun `isMqttPublishable — toggle on but blank host is not publishable`() {
         isMqttPublishable(
             basePrefs.copy(mqttBridgeEnabled = true, mqttHost = null),


### PR DESCRIPTION
## Problem

Bug report: tapping the Today screen's **Play** button did nothing — no audible TTS, no banner. Reporter's settings: `Delivery (morning): SILENT`, `Delivery (tonight): SILENT`, TTS engine `GEMINI`, Gemini key set. The diag log showed only `Replayed insight for 2026-05-29: …` on tap, then nothing.

## Root cause

The Play button routes through the same `deliver()` pipeline as scheduled alarm runs, so it honoured the period's delivery mode. With SILENT (or notification-only) delivery, `computeDeliveryGates` sets `phoneTtsConfigured = false`, which:

1. makes `playPhoneSpeaker` `return` early (`FetchAndNotifyWorker.kt`), and
2. leaves `needsSynth = false`, so no Gemini PCM buffer is even produced.

Result: an explicit Play tap silently no-ops for any SILENT / notification-only user.

## Fix

Thread an explicit "do it now" intent from the Play button through the worker:

- `enqueuePlay` gains a `forceNotifyAndSpeak` flag (carried as `KEY_PLAY_FORCE`), defaulting to **false**.
- The Today **Play** button (`triggerPlay`) passes `true` — post the notification *and* speak regardless of the configured delivery mode, so a SILENT user still sees and hears the tapped forecast.
- `computeDeliveryGates` gains `forcePhoneSpeech`, OR'd into `phoneTtsConfigured` (which also pulls the phone-speaker term into `needsSynth` so the Gemini buffer is synthesized). It **also clears `emptyEveningSkip`**, so an explicit Play tap delivers even on an eventless tonight under "only notify on events" — a forced "deliver now" is never suppressed.
- `postPeriodNotification` gains `forceNotify`, OR'd into `canNotify` so the banner posts too.

The Schedule settings **"Play now"** preview (`triggerPreview`) keeps the default `false`, so it still **simulates the user's configured delivery mode** exactly — SILENT previews stay silent, notification-only shows just the banner, etc. (matching its existing documented intent).

## Privacy

No change to what leaves the device on scheduled runs. Synth still only happens for a user-initiated Play (or the existing configured destinations), over the user's own BYOK Gemini key. Forcing notify/speak on Play doesn't broaden any automatic off-device data flow.

## Test plan

- New regression coverage in `DeliveryGatesTest` (`:core:domain`):
  - force overrides SILENT → `phoneTtsConfigured` + `needsSynth` both true
  - force clears `emptyEveningSkip` on an eventless tonight (still notifies/speaks/synths)
  - force is off by default → SILENT stays silent on scheduled runs
- `./gradlew :core:domain:test :core:data:test :app:testDebugUnitTest` — green
- `./gradlew :app:assembleDebug` — green
