### PR TITLE
Keep the preview tip until your first ClothesCast is ready

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
@@ -276,9 +276,16 @@ fun TodayScreen(
                             triggerPlay(context, playPeriod)
                             // Using Play is the user acting on the "Preview your
                             // ClothesCast" promo, so retire it — they've found
-                            // the button it points at. Guarded so a tap when the
-                            // card isn't showing doesn't write to DataStore.
-                            if (state.playPromoCardVisible) viewModel.dismissPlayPromoCard()
+                            // the button it points at. Require a delivered
+                            // forecast (thisPeriodInsight != null), matching the
+                            // hasForecast gate promoBannersToShow uses to render
+                            // the card: otherwise a fresh install (daily on by
+                            // default) tapping Play before any forecast exists
+                            // would persist the dismissal and the promo would
+                            // never get its chance to show.
+                            if (state.playPromoCardVisible && state.thisPeriodInsight != null) {
+                                viewModel.dismissPlayPromoCard()
+                            }
                         },
                         enabled = !state.anyWorkActive,
                     ) {


### PR DESCRIPTION
## What & why

Fixes the review finding on #798. The dismiss-on-Play guard used `state.playPromoCardVisible` — the raw eligibility flag from preferences — not whether the card is *actually rendered*. `BannerStack` runs eligibility through `promoBannersToShow(...)`, which withholds the play card until `hasForecast` is true (and caps it behind higher-priority promos).

So on a **fresh install** with the default daily slot enabled, tapping Play before any forecast existed would persist `play_card_dismissed = true`, and the user would never see the promo once a forecast made it eligible to show.

## How

The guard now additionally requires a delivered forecast — `state.thisPeriodInsight != null` — which is exactly the `hasForecast` condition `promoBannersToShow` uses to render the card. Per discussion with @mikelward, gating on `hasForecast` is sufficient: if a forecast has been delivered, the user has genuinely received and acted on a cast, so retiring the tip then is correct. (The rarer "eligible + hasForecast but capped behind higher-priority promos" window isn't specially handled — a deliberate light-touch choice over hoisting the full rendered-promo computation up to the top bar.)

## Test plan

- `:app:testDebugUnitTest`, `:app:assembleDebug` green locally; zero snapshot drift (no visual change).

Follow-up to #794 / #796 / #798. No data / device-boundary changes.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JiCH2kD3R3NjYMiKvoiAJY)_