### PR TITLE
Skip internal:-prefixed commits in release notes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -549,8 +549,10 @@ jobs:
         # Per-commit filter: a commit's subject is skipped if it would read
         # as noise to a non-engineer — anything prefixed `ci:` (the
         # snapshot-regen bot commits "ci: regenerate UI snapshots", workflow
-        # tweaks, etc.) or `test:` (test-only changes that ship nothing in
-        # the APK), and changes whose paths are all under `docs/`, all
+        # tweaks, etc.), `test:` (test-only changes that ship nothing in
+        # the APK), or `internal:` (internal-only changes that ship nothing
+        # user-visible — refactors, renames, dependency bumps), and changes
+        # whose paths are all under `docs/`, all
         # top-level dotfiles or hidden directories (`.github/`, `.claude/`,
         # `.gitignore`, `.editorconfig`, …), or top-level `*.md`. PRIVACY.md
         # is treated as non-docs so that privacy-policy updates still surface
@@ -654,7 +656,7 @@ jobs:
             local sha="$1" subject non_doc_count
             subject=$(git log -1 --pretty=%s "$sha")
             case "$subject" in
-              ci:*|test:*) return 0 ;;
+              ci:*|test:*|internal:*) return 0 ;;
             esac
             non_doc_count=$(git show --no-renames --name-only --pretty=format: "$sha" \
               | sed '/^$/d' \


### PR DESCRIPTION
## What

Teach CI's "Prepare release notes" changelog filter (`.github/workflows/ci.yml`) to skip commits whose subject is prefixed `internal:`, alongside the existing `ci:` and `test:` prefixes.

## Why

The changelog step turns every landed commit subject into a Play Store "What's new" bullet, and the repo rebase-merges (linear history) so each commit ships individually. Today only `ci:` / `test:` subjects and docs-only commits are filtered out — there's no prefix for pure internal cleanups (refactors, renames, dependency bumps) that ship no user-visible change. Without one, such commits leak into the release notes as noise.

`internal:` is intentionally broader and more intent-revealing than `refactor:`: it means "ships nothing user-visible," composing cleanly with the existing `ci:` / `test:` categories.

This is the infra half of a stacked pair — the follow-up PR (#TBD) uses the new prefix for three behaviour-preserving unification commits.

## Changes

- `is_noise()` predicate: `ci:*|test:*)` → `ci:*|test:*|internal:*)`
- Updated the explanatory comment block documenting the filtered prefixes.

## Test plan

Shell predicate inside the workflow YAML; no build impact. The `internal:` filtering is exercised on the next merge to `main`. (This PR's own commit is `ci:`-prefixed and `.github/`-only, so it is itself filtered from the changelog.)

https://claude.ai/code/session_01VXwdXGVTmemr6QiP85iDHu

---
_Generated by [Claude Code](https://claude.ai/code/session_01VXwdXGVTmemr6QiP85iDHu)_