### PR TITLE
TODO the remaining unification opportunities

### DIFF
--- a/app/src/main/kotlin/app/clothescast/data/DailyHistoryStore.kt
+++ b/app/src/main/kotlin/app/clothescast/data/DailyHistoryStore.kt
@@ -39,6 +39,16 @@ class DailyHistoryStore(
     private val dataStore: DataStore<Preferences>,
     private val json: Json = Json { ignoreUnknownKeys = true },
 ) {
+    // TODO(datastore-json-plumbing): this read-flow / edit / runCatching-decode
+    //   / Dto<->domain pattern is duplicated across DailyHistoryStore,
+    //   InsightCache, and SettingsRepository. Extract a JsonPreferenceStore base
+    //   for the I/O plumbing (readJson/writeJson) — but KEEP the per-store DTOs:
+    //   they're a deliberate schema boundary (versioned `_v1` keys,
+    //   ignoreUnknownKeys) decoupling on-disk format from the domain model, so
+    //   collapsing them into @Serializable domain types would couple wire format
+    //   to domain shape. This is the cleanest store to migrate first as the
+    //   proof; then InsightCache, then SettingsRepository — one per PR.
+
     /**
      * Returns the entry recorded for [date], or null when nothing was stored
      * for that day (day-one install, app disabled / device off that day, or

--- a/app/src/main/kotlin/app/clothescast/data/InsightCache.kt
+++ b/app/src/main/kotlin/app/clothescast/data/InsightCache.kt
@@ -86,6 +86,10 @@ class InsightCache(
     private val deriveInsight: DeriveInsight = DeriveInsight(),
     private val json: Json = Json { ignoreUnknownKeys = true },
 ) {
+    // TODO(datastore-json-plumbing): see DailyHistoryStore — shared
+    //   JSON-preference I/O plumbing opportunity across this, SettingsRepository,
+    //   and DailyHistoryStore (extract readJson/writeJson; keep the DTOs).
+
     /**
      * Which 12-hour window a snapshot occupies relative to the rendering
      * surface: the window the user is currently inside ([THIS_PERIOD], page 1

--- a/app/src/main/kotlin/app/clothescast/data/SettingsRepository.kt
+++ b/app/src/main/kotlin/app/clothescast/data/SettingsRepository.kt
@@ -79,6 +79,10 @@ class SettingsRepository(
     private val systemLocaleProvider: () -> Locale = { Locale.getDefault() },
     private val json: Json = Json { ignoreUnknownKeys = true },
 ) {
+    // TODO(datastore-json-plumbing): see DailyHistoryStore — shared
+    //   JSON-preference I/O plumbing opportunity across this, InsightCache, and
+    //   DailyHistoryStore (extract readJson/writeJson; keep the DTOs).
+
     val preferences: Flow<UserPreferences> = dataStore.data.map { prefs -> prefs.toUserPreferences() }
 
     /**

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/OutfitSuggestion.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/OutfitSuggestion.kt
@@ -89,6 +89,15 @@ data class OutfitSuggestion(
         private val LONG_SKIRT_KEYS = listOf("skirt")
         private val JEANS_KEYS = listOf("jeans")
 
+        // TODO(outfit-from-triggered): fromForecast re-walks the raw clothesRules
+        //   against the forecast (firstFiring per icon tier), duplicating the rule
+        //   evaluation EvaluateClothesRules already did to build TriggeredOutfit and
+        //   encoding the coat>puffer>jacket>… priority a second time alongside
+        //   Garment.layerReduce. Derive OutfitSuggestion from the already-computed
+        //   TriggeredOutfit instead, so there's a single rule evaluation and one
+        //   priority order. Watch the icon-only tiers (the explicit t-shirt tier;
+        //   shorter-skirt-wins) and the defaultTop/defaultBottom vs fallbacks
+        //   mapping; home-screen icons are Roborazzi-snapshotted, so diff them.
         fun fromForecast(
             forecast: DailyForecast,
             clothesRules: List<ClothesRule>,

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/PerModelHourly.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/PerModelHourly.kt
@@ -121,7 +121,13 @@ data class PerModelHour(
 )
 
 // TODO(model-spread-stat): cross-model spread is currently reported as
-//   `max - min` (see [ConfidenceInfo.tempSpreadC]). One outlying model
-//   swings that disproportionately; explore RMSE / std-dev across the
-//   consulted models as an alternative confidence input, plotted
-//   alongside the existing spread so we can A/B them before switching.
+//   `max - min`, computed independently in two places —
+//   [ConfidenceInfo.computeFrom] (tier title, excludes best_match) and
+//   [ModelDivergenceSummary.computeFrom] (peak-hour factor attribution,
+//   includes best_match). One outlying model swings max-min
+//   disproportionately; explore RMSE / std-dev across the consulted models
+//   as an alternative confidence input, plotted alongside the existing
+//   spread so we can A/B them before switching. When that lands, factor the
+//   feels-like spread into one shared helper both call sites use (the
+//   *policy* — which models, which threshold, what to emit — stays separate;
+//   only the spread primitive is shared).

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/DeriveInsight.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/DeriveInsight.kt
@@ -234,6 +234,17 @@ class DeriveInsight(
         )
     }
 
+    // TODO(evening-tiein-split): this one function fuses two emission paths
+    //   behind a single `if (deltaItems.isEmpty() && precip == null) return null`
+    //   gate — the evening clothes-delta (topDelta/bottomDelta below) and the
+    //   bare rain warning (`precip`). The top delta reads from
+    //   triggeredOutfit.rules (layer-reduced) while the bottom reads from
+    //   triggeredOutfit.items; that asymmetry looks like a bug but is
+    //   load-bearing (see TriggeredOutfit's doc on why the per-tier default
+    //   must not count as an evening "extra"). Split into eveningClothesDelta()
+    //   + eveningRainWarning() so the either/or emission and the top/bottom
+    //   source asymmetry are explicit. Behaviour-preserving; covered by
+    //   GenerateDailyInsightTest — diff the prose before/after.
     private fun buildEveningEventTieIn(
         bundle: ForecastBundle,
         prefs: UserPreferences,


### PR DESCRIPTION
## What

Document the four parallel/duplicated-logic cleanups deferred from the unification audit as greppable `TODO(tag)` comments, so a future reader lands on the context and the recommended approach right at the code.

| Tag | Location | Opportunity |
|---|---|---|
| `TODO(evening-tiein-split)` | `DeriveInsight.buildEveningEventTieIn` | Split the fused clothes-delta / rain-warning emission paths into two named helpers; document the load-bearing `.rules` vs `.items` top/bottom asymmetry. |
| `TODO(outfit-from-triggered)` | `OutfitSuggestion.fromForecast` | Derive the icon outfit from the already-computed `TriggeredOutfit` instead of re-walking the rules and re-encoding the garment priority. **Next up.** |
| `TODO(model-spread-stat)` | `PerModelHourly` (extended existing TODO) | Note the duplicated max−min feels-like spread in `ConfidenceInfo.computeFrom` / `ModelDivergenceSummary.computeFrom`; share the spread primitive when the RMSE/std-dev exploration lands. |
| `TODO(datastore-json-plumbing)` | `DailyHistoryStore` (detailed) + `InsightCache` / `SettingsRepository` (pointers) | Extract a shared JSON-preference I/O base — but keep the per-store DTOs, which are a deliberate schema boundary. Migrate one store per PR. |

## Why

These came out of the same audit that landed #803/#804. They each carry a judgment call (behaviour-touching, snapshot-sensitive, or structurally large), so rather than rush them, this captures the analysis at the call site where it's useful. `TODO(outfit-from-triggered)` is the agreed next change — it's already bitten us (the icon falling out of step with the prose).

## Notes

Comment-only — no behaviour change. Uses the `internal:` prefix so it's filtered from the Play Store changelog (per #803).

## Test plan

`:core:domain:compileKotlin` green locally; CI covers the rest. No logic touched.

https://claude.ai/code/session_01VXwdXGVTmemr6QiP85iDHu

---
_Generated by [Claude Code](https://claude.ai/code/session_01VXwdXGVTmemr6QiP85iDHu)_