### PR TITLE
Derive the outfit icon from the matched-rule set

### DIFF
--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/OutfitSuggestion.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/OutfitSuggestion.kt
@@ -89,40 +89,79 @@ data class OutfitSuggestion(
         private val LONG_SKIRT_KEYS = listOf("skirt")
         private val JEANS_KEYS = listOf("jeans")
 
-        // TODO(outfit-from-triggered): fromForecast re-walks the raw clothesRules
-        //   against the forecast (firstFiring per icon tier), duplicating the rule
-        //   evaluation EvaluateClothesRules already did to build TriggeredOutfit and
-        //   encoding the coat>puffer>jacket>… priority a second time alongside
-        //   Garment.layerReduce. Derive OutfitSuggestion from the already-computed
-        //   TriggeredOutfit instead, so there's a single rule evaluation and one
-        //   priority order. Watch the icon-only tiers (the explicit t-shirt tier;
-        //   shorter-skirt-wins) and the defaultTop/defaultBottom vs fallbacks
-        //   mapping; home-screen icons are Roborazzi-snapshotted, so diff them.
+        /**
+         * Two-piece icon outfit for [forecast] given the user's [clothesRules].
+         * Evaluates the rules against the forecast once and maps the firing
+         * rules to icon tiers via [pickOutfit].
+         *
+         * Prefer [fromTriggeredOutfit] at call sites that already hold the day's
+         * [TriggeredOutfit] (the prose / recommendations path): reading the icon
+         * from the same matched-rule set the prose uses keeps the two from
+         * drifting apart. This forecast-driven entry point stays for callers
+         * (and tests) that only have a forecast and rules in hand.
+         */
         fun fromForecast(
             forecast: DailyForecast,
             clothesRules: List<ClothesRule>,
             defaultBottom: Bottom = Bottom.LONG_PANTS,
             defaultTop: Top = Top.TSHIRT,
+        ): OutfitSuggestion =
+            pickOutfit(clothesRules.filter { it.appliesTo(forecast) }, defaultTop, defaultBottom)
+
+        /**
+         * Two-piece icon outfit derived from an already-evaluated
+         * [TriggeredOutfit] — the same object that drives the bulleted
+         * recommendations and the prose clothes clause. Only the firing
+         * threshold rules ([TriggeredOutfit.rules]) drive the tier; uncovered
+         * slots fall through to [defaultTop] / [defaultBottom], exactly as
+         * [fromForecast] does (the per-tier default is not itself an icon tier).
+         *
+         * This is the preferred entry point: a new garment tier or a
+         * rule-matching tweak then lands in one place ([pickOutfit]) instead of
+         * having to be mirrored across a second forecast walk — the divergence
+         * that previously let the icon fall to the default while the prose named
+         * the garment.
+         */
+        fun fromTriggeredOutfit(
+            triggered: TriggeredOutfit,
+            defaultBottom: Bottom = Bottom.LONG_PANTS,
+            defaultTop: Top = Top.TSHIRT,
+        ): OutfitSuggestion = pickOutfit(triggered.rules, defaultTop, defaultBottom)
+
+        // Maps the firing rules (those already known to apply to the forecast)
+        // to icon tiers. The single source of the coldest-first / shorter-first
+        // tier priority both entry points share: colder (or briefer) tiers are
+        // checked first so the heavier garment / mini skirt wins when several
+        // rules fire at once.
+        private fun pickOutfit(
+            firingRules: List<ClothesRule>,
+            defaultTop: Top,
+            defaultBottom: Bottom,
         ): OutfitSuggestion {
             val top = when {
-                clothesRules.firstFiring(forecast, THICK_COAT_KEYS) != null -> Top.THICK_COAT
-                clothesRules.firstFiring(forecast, PUFFER_JACKET_KEYS) != null -> Top.PUFFER_JACKET
-                clothesRules.firstFiring(forecast, THICK_JACKET_KEYS) != null -> Top.THICK_JACKET
-                clothesRules.firstFiring(forecast, THIN_JACKET_KEYS) != null -> Top.THIN_JACKET
-                clothesRules.firstFiring(forecast, SWEATER_KEYS) != null -> Top.SWEATER
-                clothesRules.firstFiring(forecast, POLO_KEYS) != null -> Top.POLO
-                clothesRules.firstFiring(forecast, TSHIRT_KEYS) != null -> Top.TSHIRT
+                firingRules.hasKeyIn(THICK_COAT_KEYS) -> Top.THICK_COAT
+                firingRules.hasKeyIn(PUFFER_JACKET_KEYS) -> Top.PUFFER_JACKET
+                firingRules.hasKeyIn(THICK_JACKET_KEYS) -> Top.THICK_JACKET
+                firingRules.hasKeyIn(THIN_JACKET_KEYS) -> Top.THIN_JACKET
+                firingRules.hasKeyIn(SWEATER_KEYS) -> Top.SWEATER
+                firingRules.hasKeyIn(POLO_KEYS) -> Top.POLO
+                firingRules.hasKeyIn(TSHIRT_KEYS) -> Top.TSHIRT
                 else -> defaultTop
             }
             val bottom = when {
-                clothesRules.firstFiring(forecast, SHORTS_KEYS) != null -> Bottom.SHORTS
-                clothesRules.firstFiring(forecast, SHORT_SKIRT_KEYS) != null -> Bottom.SHORT_SKIRT
-                clothesRules.firstFiring(forecast, LONG_SKIRT_KEYS) != null -> Bottom.LONG_SKIRT
-                clothesRules.firstFiring(forecast, JEANS_KEYS) != null -> Bottom.JEANS
+                firingRules.hasKeyIn(SHORTS_KEYS) -> Bottom.SHORTS
+                firingRules.hasKeyIn(SHORT_SKIRT_KEYS) -> Bottom.SHORT_SKIRT
+                firingRules.hasKeyIn(LONG_SKIRT_KEYS) -> Bottom.LONG_SKIRT
+                firingRules.hasKeyIn(JEANS_KEYS) -> Bottom.JEANS
                 else -> defaultBottom
             }
             return OutfitSuggestion(top, bottom)
         }
+
+        /** True when any rule in the list names a catalog garment in [keys],
+         *  using the same canonicalisation as the prose path ([matchesKey]). */
+        private fun List<ClothesRule>.hasKeyIn(keys: List<String>): Boolean =
+            keys.any { key -> any { it.matchesKey(key) } }
 
         /**
          * Returns the human-readable reasons that [fromForecast] picked this outfit —

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/DeriveInsight.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/DeriveInsight.kt
@@ -148,7 +148,11 @@ class DeriveInsight(
                 periodView.perModelForRender?.let { ConfidenceInfo.computeFrom(it) }
             },
             perModelHourly = periodView.perModelForRender,
-            outfit = OutfitSuggestion.fromForecast(periodView.forecast, rules, defaultBottom, defaultTop),
+            // Derive the displayed icon from the *same* TriggeredOutfit that
+            // drives the prose / recommendations, so the two can't drift apart.
+            // nextForecast has no pre-evaluated outfit, so it still goes through
+            // the forecast-driven path (same tier logic underneath).
+            outfit = OutfitSuggestion.fromTriggeredOutfit(periodView.triggeredOutfit, defaultBottom, defaultTop),
             nextOutfit = periodView.nextForecast?.let {
                 OutfitSuggestion.fromForecast(it, rules, defaultBottom, defaultTop)
             },

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/model/OutfitSuggestionTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/model/OutfitSuggestionTest.kt
@@ -1,5 +1,6 @@
 package app.clothescast.core.domain.model
 
+import app.clothescast.core.domain.usecase.EvaluateClothesRules
 import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
@@ -153,6 +154,34 @@ class OutfitSuggestionTest {
         cases.forEach { (min, max, expected) ->
             OutfitSuggestion.fromForecast(forecast(min, max), rules) shouldBe expected
         }
+    }
+
+    @Test
+    fun `fromTriggeredOutfit agrees with fromForecast for the same rules and forecast`() {
+        // The displayed icon derives from the TriggeredOutfit the prose uses
+        // (see DeriveInsight), so the two entry points must agree — otherwise
+        // the icon and the bullet text drift apart, the bug this split prevents.
+        val evaluate = EvaluateClothesRules()
+        listOf(7.5 to 9.0, 10.0 to 16.0, 16.0 to 21.0, 19.0 to 26.0, 15.0 to 23.0).forEach { (min, max) ->
+            val fc = forecast(min, max)
+            OutfitSuggestion.fromTriggeredOutfit(evaluate(fc, rules)) shouldBe
+                OutfitSuggestion.fromForecast(fc, rules)
+        }
+    }
+
+    @Test
+    fun `fromTriggeredOutfit reads firing rules and falls through to defaults`() {
+        // A firing coat rule drives the top tier; with no bottom rule firing the
+        // bottom falls to the supplied default — the per-tier default is not an
+        // icon tier of its own, matching fromForecast.
+        val triggered = TriggeredOutfit(
+            rules = listOf(ClothesRule("coat", ClothesRule.TemperatureBelow(5.0))),
+            fallbacks = listOf("pants"),
+        )
+        OutfitSuggestion.fromTriggeredOutfit(
+            triggered,
+            defaultBottom = OutfitSuggestion.Bottom.JEANS,
+        ) shouldBe OutfitSuggestion(OutfitSuggestion.Top.THICK_COAT, OutfitSuggestion.Bottom.JEANS)
     }
 
     @Test


### PR DESCRIPTION
## What

Derive the home-screen outfit **icon** from the same `TriggeredOutfit` that drives the bulleted recommendations and the prose clothes clause, instead of re-walking the raw rules against the forecast a second time.

- `OutfitSuggestion.fromForecast` previously re-evaluated the rules per icon tier (`firstFiring(forecast, KEYS)`), duplicating the matching `EvaluateClothesRules` already did and encoding the `coat > puffer > jacket > …` tier priority a second time.
- The tier priority now lives in one private `pickOutfit(firingRules, …)`, shared by `fromForecast` and a new `fromTriggeredOutfit(triggered, …)`.
- `DeriveInsight` builds the displayed icon via `fromTriggeredOutfit(periodView.triggeredOutfit, …)`, so the icon and the prose are driven by the **same** matched-rule set and can't drift apart. `nextForecast` (which has no pre-evaluated outfit) still uses the forecast-driven path — same tier logic underneath.

Resolves the `TODO(outfit-from-triggered)` that landed via the earlier TODO PR.

## Why

This is the divergence that's bitten us before: a garment the prose counted as covering the top slot while the icon fell through to the default (the t-shirt tier was added to the picker at the time to paper over exactly that). Reading the icon from the shared `TriggeredOutfit` makes a new tier or a rule-matching tweak land in one place instead of needing to be mirrored across two evaluations.

## Behaviour

**Output-identical.** `periodView.triggeredOutfit` is built by `EvaluateClothesRules(periodForecast, rules, …)` — the same forecast and rules `fromForecast` was re-evaluating — so the derived `OutfitSuggestion` is unchanged. Verified locally:
- two new `OutfitSuggestionTest` cases (`fromTriggeredOutfit` agrees with `fromForecast` across the boundary cases; reads firing rules + falls through to defaults),
- existing `OutfitSuggestionTest` / `EvaluateClothesRulesTest` / `GenerateDailyInsightTest` suites unchanged and green,
- `:app:testDebugUnitTest` green incl. Roborazzi — **no pixel changes**.

_Rebased onto `main` after the TODO PR merged; the diff is now the single outfit-derivation commit._

## Test plan

```
./gradlew :core:domain:test :core:data:test :app:testDebugUnitTest
./gradlew :app:assembleDebug
```
All run locally and green.

https://claude.ai/code/session_01VXwdXGVTmemr6QiP85iDHu