### PR TITLE
Mention evening clothes you didn't wear by day, even your default

### DIFF
--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/DeriveInsight.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/DeriveInsight.kt
@@ -238,17 +238,6 @@ class DeriveInsight(
         )
     }
 
-    // TODO(evening-tiein-split): this one function fuses two emission paths
-    //   behind a single `if (deltaItems.isEmpty() && precip == null) return null`
-    //   gate — the evening clothes-delta (topDelta/bottomDelta below) and the
-    //   bare rain warning (`precip`). The top delta reads from
-    //   triggeredOutfit.rules (layer-reduced) while the bottom reads from
-    //   triggeredOutfit.items; that asymmetry looks like a bug but is
-    //   load-bearing (see TriggeredOutfit's doc on why the per-tier default
-    //   must not count as an evening "extra"). Split into eveningClothesDelta()
-    //   + eveningRainWarning() so the either/or emission and the top/bottom
-    //   source asymmetry are explicit. Behaviour-preserving; covered by
-    //   GenerateDailyInsightTest — diff the prose before/after.
     private fun buildEveningEventTieIn(
         bundle: ForecastBundle,
         prefs: UserPreferences,
@@ -284,34 +273,62 @@ class DeriveInsight(
             deltaFormat = prefs.deltaFormat,
             todayRuleItems = Garment.layerReduce(nightView.triggeredOutfit.rules).map { it.item },
         )
-        val precip = nightSummary.precip
-        val dayKeysBySlot = todayItems
-            .mapNotNull { Garment.fromKey(it) }
-            .groupBy({ it.slot }, { it.itemKey })
-            .mapValues { it.value.toSet() }
-        val dayTopKey = dayKeysBySlot[Garment.Slot.TOP].orEmpty()
-        val dayBottomKey = dayKeysBySlot[Garment.Slot.BOTTOM].orEmpty()
-        val topDelta = Garment.layerReduce(nightView.triggeredOutfit.rules)
-            .map { it.item }
-            .filter { item ->
-                val g = Garment.fromKey(item)
-                g?.slot == Garment.Slot.TOP && g.itemKey !in dayTopKey
-            }
-        val bottomDelta = nightView.triggeredOutfit.items
-            .filter { item ->
-                val g = Garment.fromKey(item)
-                g?.slot == Garment.Slot.BOTTOM && g.itemKey !in dayBottomKey
-            }
-        val deltaItems = topDelta + bottomDelta
 
-        if (deltaItems.isEmpty() && precip == null) return null
+        // Two emission paths, either of which fires the clause: extra clothing
+        // the evening needs beyond the morning outfit (clothesDelta), or rain to
+        // flag for the event (precip). Both are computed independently below.
+        val clothesDelta = eveningClothesDelta(
+            eveningItems = nightView.triggeredOutfit.items,
+            dayItems = todayItems,
+        )
+        val precip = nightSummary.precip
+        if (clothesDelta.isEmpty() && precip == null) return null
 
         return EveningEventTieInClause(
-            items = deltaItems,
+            items = clothesDelta,
             rainTime = precip?.time,
             likelihood = precip?.likelihood ?: PrecipLikelihood.LIKELY,
             precipCondition = precip?.condition,
         )
+    }
+
+    /**
+     * The garments the evening outfit adds beyond what the morning already
+     * announced. Both sides are the full, layer-reduced [TriggeredOutfit.items]
+     * — threshold matches *and* the per-slot default (a default is just the rule
+     * that fires when nothing else covers the slot, so it belongs in the outfit
+     * on both sides of the comparison).
+     *
+     * Tops are layer-aware: an evening top is "extra" only when its [Garment.Layer]
+     * is heavier than the day's heaviest top — wearing a jacket by day already
+     * implies the lighter layers under it, so a lighter evening top isn't worth
+     * mentioning. Bottoms substitute rather than stack, so an evening bottom is
+     * extra when it's a different garment than the day's. Items we can't place in
+     * a slot (legacy free-form rules, accessories like an umbrella) are left to
+     * the prose / rain paths rather than the clothes delta.
+     */
+    private fun eveningClothesDelta(
+        eveningItems: List<String>,
+        dayItems: List<String>,
+    ): List<String> {
+        val dayGarments = dayItems.mapNotNull { Garment.fromKey(it) }
+        val dayTopLayer: Garment.Layer? = dayGarments
+            .filter { it.slot == Garment.Slot.TOP }
+            .mapNotNull { it.layer }
+            .maxByOrNull { it.ordinal }
+        val dayBottomKeys = dayGarments
+            .filter { it.slot == Garment.Slot.BOTTOM }
+            .mapTo(mutableSetOf()) { it.itemKey }
+        return eveningItems.filter { item ->
+            val g = Garment.fromKey(item) ?: return@filter false
+            when (g.slot) {
+                Garment.Slot.TOP -> {
+                    val layer = g.layer ?: return@filter false
+                    dayTopLayer == null || layer.ordinal > dayTopLayer.ordinal
+                }
+                Garment.Slot.BOTTOM -> g.itemKey !in dayBottomKeys
+            }
+        }
     }
 
     private fun filterEventsForPeriod(

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsightTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsightTest.kt
@@ -1260,6 +1260,57 @@ class GenerateDailyInsightTest {
     }
 
     @Test
+    fun `evening tie-in surfaces a heavier default top the day didn't need`() = runTest {
+        // defaultTop = SWEATER for someone who runs cold. A warm afternoon fires
+        // their t-shirt rule, so the day's top is the lighter t-shirt; the mild
+        // evening fires no top rule, so the night falls back to the default
+        // sweater. The sweater is a heavier layer than the day's t-shirt, so the
+        // evening genuinely needs it — "Bring a sweater tonight." (Previously the
+        // tie-in only looked at fired night *rules* and silently dropped the
+        // fallback top, so this user got no evening cue at all.)
+        val zone = ZoneId.of("Europe/London")
+        val daytime = listOf(
+            HourlyForecast(LocalTime.of(8, 0), 24.0, 24.0, 5.0, WeatherCondition.CLEAR),
+            HourlyForecast(LocalTime.of(15, 0), 26.0, 25.0, 5.0, WeatherCondition.CLEAR),
+        )
+        val evening = listOf(
+            HourlyForecast(LocalTime.of(19, 0), 16.0, 15.0, 5.0, WeatherCondition.CLEAR),
+            HourlyForecast(LocalTime.of(21, 0), 15.0, 14.0, 5.0, WeatherCondition.CLEAR),
+        )
+        val baseHourly = today.copy(
+            hourly = daytime + evening,
+            precipitationProbabilityMaxPct = 5.0,
+            condition = WeatherCondition.CLEAR,
+        )
+        val diner = CalendarEvent(
+            title = "dinner",
+            start = LocalTime.of(21, 0),
+            end = LocalTime.of(23, 0),
+            location = "Restaurant",
+        )
+        val weather = FakeWeatherRepository(ForecastBundle(baseHourly, yesterday))
+        val calendar = FakeCalendarEventReader(events = listOf(diner))
+        val subject = GenerateDailyInsight(weather, calendarEventReader = calendar, clock = clock)
+
+        val tshirtRule = listOf(ClothesRule("t-shirt", ClothesRule.TemperatureAbove(20.0)))
+        val result = subject(
+            location = london,
+            prefs = prefs.copy(
+                clothesRules = tshirtRule,
+                defaultTop = OutfitSuggestion.Top.SWEATER,
+                useCalendarEvents = true,
+                schedule = Schedule.default(zone),
+            ),
+            period = ForecastPeriod.TODAY,
+        )
+
+        val tie = result.insight.summary.eveningEventTieIn
+        tie.shouldNotBeNull()
+        tie!!.items shouldBe listOf("sweater")
+        tie.rainTime.shouldBeNull()
+    }
+
+    @Test
     fun `evening tie-in is silent when the night top resolves to a default the day was wearing as a rule`() = runTest {
         // Cold day with a sweater rule, mild night where no threshold rule
         // matches → the night's top tier resolves to the default top


### PR DESCRIPTION
## What

Fix the morning insight's evening-event tie-in (the "…tonight" clause) so it correctly accounts for the **full** evening outfit, including the per-slot default.

The tie-in computes the extra clothing the evening needs beyond the day's outfit. It was reading two different things per slot:
- **top**: `layerReduce(triggeredOutfit.rules)` — threshold-rule matches only, **dropping the fallback/default top**
- **bottom**: `triggeredOutfit.items` — the full outfit, including the default

So an evening top that resolved to the user's *default* (because no threshold rule fired at night) was silently dropped. A cold-running user whose default top is a sweater got **no** evening cue when a warm day had put them in a t-shirt — even though they'd want the sweater for the evening.

## The fix

Compute the delta uniformly from the full evening outfit (`triggeredOutfit.items` — matches *and* the per-slot default, which is just the rule that fires when nothing else covers the slot) minus the day's outfit, for both slots, in one `eveningClothesDelta(...)` helper:

- **Tops are layer-aware**: an evening top is surfaced only when its `Garment.Layer` is heavier than the day's heaviest top. Wearing a jacket by day implies the lighter layers under it, so a *lighter* evening top isn't mentioned (a day jacket still suppresses an evening sweater).
- **Bottoms substitute** rather than stack, so an evening bottom is surfaced when it's a different garment than the day's — unchanged from before.

This also removes the top/bottom asymmetry the old code carried (and the `TODO(evening-tiein-split)` that documented it).

## Behaviour change

User-visible, in the evening-event tie-in only:
- **now mentions** a heavier default top the day didn't need (the bug fix above), and
- **still suppresses** a lighter evening top the day already covered (existing behaviour, now via explicit layer comparison rather than the rule/items asymmetry).

Common configs (default top = t-shirt) are unaffected — the fallback-inclusion and layer-coverage cancel out there.

## Privacy

No change to what leaves the device — same rendered insight prose surface, computed from the same forecast/calendar inputs.

## Test plan

- New `GenerateDailyInsightTest` case `evening tie-in surfaces a heavier default top the day didn't need` — fails on the old code (returned no tie-in), passes now.
- All existing `GenerateDailyInsightTest` evening tie-in cases stay green, including the layer-coverage suppression case (cold day sweater → mild night t-shirt → silent).
- `:core:domain:test` + `:core:data:test` green; `:app:testDebugUnitTest` (incl. Roborazzi snapshots) running.

https://claude.ai/code/session_01VXwdXGVTmemr6QiP85iDHu

---
_Generated by [Claude Code](https://claude.ai/code/session_01VXwdXGVTmemr6QiP85iDHu)_