### PR TITLE
Surface a warmer evening top even in the same layer

### DIFF
--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Garment.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Garment.kt
@@ -64,6 +64,20 @@ enum class Garment(
     PANTS("pants", Slot.BOTTOM),
     JEANS("jeans", Slot.BOTTOM);
 
+    /**
+     * Canonical relative warmth for outfit comparisons — "is the evening's top
+     * warmer than the day's?" and the like. Higher is warmer; bottoms report 0.
+     *
+     * Currently the same rating as [layerCount] (which, despite its name, is
+     * already a perceived-warmth value rather than a literal garment count), but
+     * named for the comparison so call sites read by intent. The catalog
+     * redesign will give garments a deliberate warmth and align the layerReduce
+     * / icon priority order ([TOP_LAYER_PRIORITY], today coldest-first
+     * coat → puffer → jacket) to it, so the warmth signals can't disagree on
+     * e.g. coat vs puffer the way they do now.
+     */
+    val warmth: Int get() = layerCount
+
     /** Which outfit slot this garment occupies. Drives "does any matched rule
      *  cover this slot?" decisions in [EvaluateClothesRules] and "what
      *  temperature window does the fallback apply in?" in [FallbackRange],

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/DeriveInsight.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/DeriveInsight.kt
@@ -299,33 +299,35 @@ class DeriveInsight(
      * that fires when nothing else covers the slot, so it belongs in the outfit
      * on both sides of the comparison).
      *
-     * Tops are layer-aware: an evening top is "extra" only when its [Garment.Layer]
-     * is heavier than the day's heaviest top — wearing a jacket by day already
-     * implies the lighter layers under it, so a lighter evening top isn't worth
-     * mentioning. Bottoms substitute rather than stack, so an evening bottom is
-     * extra when it's a different garment than the day's. Items we can't place in
-     * a slot (legacy free-form rules, accessories like an umbrella) are left to
-     * the prose / rain paths rather than the clothes delta.
+     * Tops are warmth-aware: an evening top is "extra" only when it's warmer than
+     * the day's warmest top — wearing a jacket by day already implies the lighter
+     * layers under it, so a lighter evening top isn't worth mentioning. Warmth is
+     * [Garment.warmth], not the [Garment.Layer] band, so same-band upgrades still
+     * surface: a day `jacket` doesn't suppress a warmer evening `puffer`. Bottoms
+     * substitute rather than stack, so an evening bottom is extra when it's a
+     * different garment than the day's. Items we can't place in a slot (legacy
+     * free-form rules, accessories like an umbrella) are left to the prose / rain
+     * paths rather than the clothes delta.
      */
     private fun eveningClothesDelta(
         eveningItems: List<String>,
         dayItems: List<String>,
     ): List<String> {
         val dayGarments = dayItems.mapNotNull { Garment.fromKey(it) }
-        val dayTopLayer: Garment.Layer? = dayGarments
+        // Warmest top worn by day, by [Garment.warmth] (not the layer band), so a
+        // same-band-but-warmer evening top (jacket → puffer) still counts — the
+        // goal is to name the warmest top the evening actually needs. The
+        // coat-vs-puffer warmth inconsistency is tracked on [Garment.warmth].
+        val dayTopWarmth = dayGarments
             .filter { it.slot == Garment.Slot.TOP }
-            .mapNotNull { it.layer }
-            .maxByOrNull { it.ordinal }
+            .maxOfOrNull { it.warmth } ?: 0
         val dayBottomKeys = dayGarments
             .filter { it.slot == Garment.Slot.BOTTOM }
             .mapTo(mutableSetOf()) { it.itemKey }
         return eveningItems.filter { item ->
             val g = Garment.fromKey(item) ?: return@filter false
             when (g.slot) {
-                Garment.Slot.TOP -> {
-                    val layer = g.layer ?: return@filter false
-                    dayTopLayer == null || layer.ordinal > dayTopLayer.ordinal
-                }
+                Garment.Slot.TOP -> g.warmth > dayTopWarmth
                 Garment.Slot.BOTTOM -> g.itemKey !in dayBottomKeys
             }
         }

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsightTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsightTest.kt
@@ -1311,6 +1311,55 @@ class GenerateDailyInsightTest {
     }
 
     @Test
+    fun `evening tie-in surfaces a warmer same-layer default top`() = runTest {
+        // defaultTop = PUFFER. A cold morning fires the jacket rule (day top =
+        // jacket); the milder evening fires no top rule, so the night falls back
+        // to the default puffer. Jacket and puffer are both SHELL, but the puffer
+        // is warmer (layerCount 4 vs 3) — a genuine upgrade the day didn't wear,
+        // so it must surface. A layer-band-only check would wrongly stay silent.
+        val zone = ZoneId.of("Europe/London")
+        val daytime = listOf(
+            HourlyForecast(LocalTime.of(8, 0), 9.0, 8.0, 5.0, WeatherCondition.CLEAR),
+            HourlyForecast(LocalTime.of(15, 0), 11.0, 10.0, 5.0, WeatherCondition.CLEAR),
+        )
+        val evening = listOf(
+            HourlyForecast(LocalTime.of(19, 0), 16.0, 15.0, 5.0, WeatherCondition.CLEAR),
+            HourlyForecast(LocalTime.of(21, 0), 15.0, 14.0, 5.0, WeatherCondition.CLEAR),
+        )
+        val baseHourly = today.copy(
+            hourly = daytime + evening,
+            precipitationProbabilityMaxPct = 5.0,
+            condition = WeatherCondition.CLEAR,
+        )
+        val diner = CalendarEvent(
+            title = "dinner",
+            start = LocalTime.of(21, 0),
+            end = LocalTime.of(23, 0),
+            location = "Restaurant",
+        )
+        val weather = FakeWeatherRepository(ForecastBundle(baseHourly, yesterday))
+        val calendar = FakeCalendarEventReader(events = listOf(diner))
+        val subject = GenerateDailyInsight(weather, calendarEventReader = calendar, clock = clock)
+
+        val jacketRule = listOf(ClothesRule("jacket", ClothesRule.TemperatureBelow(12.0)))
+        val result = subject(
+            location = london,
+            prefs = prefs.copy(
+                clothesRules = jacketRule,
+                defaultTop = OutfitSuggestion.Top.PUFFER_JACKET,
+                useCalendarEvents = true,
+                schedule = Schedule.default(zone),
+            ),
+            period = ForecastPeriod.TODAY,
+        )
+
+        val tie = result.insight.summary.eveningEventTieIn
+        tie.shouldNotBeNull()
+        tie!!.items shouldBe listOf("puffer")
+        tie.rainTime.shouldBeNull()
+    }
+
+    @Test
     fun `evening tie-in is silent when the night top resolves to a default the day was wearing as a rule`() = runTest {
         // Cold day with a sweater rule, mild night where no threshold rule
         // matches → the night's top tier resolves to the default top


### PR DESCRIPTION
## What

Follow-up to #807 (merged), addressing a Codex review point: the evening tie-in's top comparison used the `Garment.Layer` *band* (`Layer.ordinal`), which treats `jacket`, `coat`, and `puffer` as equal (all `SHELL`). So a day `jacket` wrongly suppressed a warmer evening `puffer` — a same-band upgrade the user hadn't worn by day.

The tie-in now compares tops by **warmth** rather than the layer band, so an evening top surfaces iff it's warmer than the day's warmest top — naming the warmest garment the evening actually needs.

## `Garment.warmth`

Adds a named `Garment.warmth` accessor and points the tie-in at it, so the comparison reads by intent rather than reusing `layerCount` (which is *named* for the "wear N layers" prose tier, even though its doc already defines it as a perceived-warmth rating). `warmth` currently returns that same rating; the catalog redesign will give garments deliberate warmth values.

## Known inconsistency, deferred

The catalog carries two warmth signals that disagree on **coat vs puffer**: `layerCount`/`warmth` (puffer 4 > coat 3) vs `TOP_LAYER_PRIORITY[SHELL]` (labelled coldest-first `coat → puffer → jacket`, so `layerReduce`/the icon treat coat as the warmest shell). Per maintainer discussion, the tie-in follows warmth ("surface the warmer evening top") for now; reconciling the priority order with warmth — so the icon winner and this comparison can't disagree — is deferred to the catalog redesign and tracked as `TODO(catalog-warmth)`.

## Behaviour

- **Fixes**: day `jacket` → warmer evening `puffer` now surfaces.
- **Preserved**: a lighter evening top is still suppressed; #807's cross-band cases are unchanged.

## Test plan

- New `GenerateDailyInsightTest` case `evening tie-in surfaces a warmer same-layer default top` (jacket day → puffer evening default → surfaced).
- All existing tie-in + `OutfitSuggestionTest` cases green; `:core:domain:test` + `:core:data:test` green.

https://claude.ai/code/session_01VXwdXGVTmemr6QiP85iDHu