### PR TITLE
Type clothing rules to the garment catalog

### DIFF
--- a/app/src/main/kotlin/app/clothescast/data/ClothesRuleDto.kt
+++ b/app/src/main/kotlin/app/clothescast/data/ClothesRuleDto.kt
@@ -1,6 +1,7 @@
 package app.clothescast.data
 
 import app.clothescast.core.domain.model.ClothesRule
+import app.clothescast.core.domain.model.Garment
 import app.clothescast.core.domain.model.TemperatureUnit
 import kotlinx.serialization.Serializable
 
@@ -8,6 +9,13 @@ import kotlinx.serialization.Serializable
  * On-disk representation of a [ClothesRule]. The domain type uses a sealed interface
  * for [ClothesRule.Condition], which is awkward to serialize directly — this DTO
  * flattens it to (type, value, unit) and round-trips through [toDomain] / [toDto].
+ *
+ * [item] is stored as a string key so JSON stays stable, but the domain type is a
+ * typed [Garment]: [toDomain] resolves the key via [Garment.fromKey] (which folds
+ * legacy spellings / case / whitespace onto the canonical catalog key) and returns
+ * `null` for any key not in the catalog — a legacy free-form item from before the
+ * catalog existed. Callers drop those nulls, so unrecognised stored rules are
+ * silently discarded rather than kept as untyped strings.
  *
  * `type` strings are intentionally non-camelCase so they're stable identifiers in JSON
  * even if class names are renamed. [unit] is nullable so JSON written by app versions
@@ -21,15 +29,19 @@ internal data class ClothesRuleDto(
     val value: Double,
     val unit: String? = null,
 ) {
-    fun toDomain(): ClothesRule = ClothesRule(
-        item = item,
-        condition = when (type) {
-            TYPE_TEMP_BELOW -> ClothesRule.TemperatureBelow(value, parseUnit(unit))
-            TYPE_TEMP_ABOVE -> ClothesRule.TemperatureAbove(value, parseUnit(unit))
-            TYPE_PRECIP_ABOVE -> ClothesRule.PrecipitationProbabilityAbove(value)
-            else -> error("Unknown clothes rule type: $type")
-        },
-    )
+    /** Returns the domain rule, or `null` if [item] isn't a catalog [Garment]. */
+    fun toDomain(): ClothesRule? {
+        val garment = Garment.fromKey(item) ?: return null
+        return ClothesRule(
+            item = garment,
+            condition = when (type) {
+                TYPE_TEMP_BELOW -> ClothesRule.TemperatureBelow(value, parseUnit(unit))
+                TYPE_TEMP_ABOVE -> ClothesRule.TemperatureAbove(value, parseUnit(unit))
+                TYPE_PRECIP_ABOVE -> ClothesRule.PrecipitationProbabilityAbove(value)
+                else -> error("Unknown clothes rule type: $type")
+            },
+        )
+    }
 
     companion object {
         const val TYPE_TEMP_BELOW = "temp_below"
@@ -45,9 +57,9 @@ internal data class ClothesRuleDto(
 
 internal fun ClothesRule.toDto(): ClothesRuleDto = when (val c = condition) {
     is ClothesRule.TemperatureBelow ->
-        ClothesRuleDto(item, ClothesRuleDto.TYPE_TEMP_BELOW, c.value, c.unit.name)
+        ClothesRuleDto(item.itemKey, ClothesRuleDto.TYPE_TEMP_BELOW, c.value, c.unit.name)
     is ClothesRule.TemperatureAbove ->
-        ClothesRuleDto(item, ClothesRuleDto.TYPE_TEMP_ABOVE, c.value, c.unit.name)
+        ClothesRuleDto(item.itemKey, ClothesRuleDto.TYPE_TEMP_ABOVE, c.value, c.unit.name)
     is ClothesRule.PrecipitationProbabilityAbove ->
-        ClothesRuleDto(item, ClothesRuleDto.TYPE_PRECIP_ABOVE, c.percent)
+        ClothesRuleDto(item.itemKey, ClothesRuleDto.TYPE_PRECIP_ABOVE, c.percent)
 }

--- a/app/src/main/kotlin/app/clothescast/data/SettingsRepository.kt
+++ b/app/src/main/kotlin/app/clothescast/data/SettingsRepository.kt
@@ -44,7 +44,6 @@ import app.clothescast.core.domain.model.UserPreferences
 import app.clothescast.core.domain.model.VoiceLocale
 import app.clothescast.core.domain.model.containsTwelveHourPatternField
 import app.clothescast.core.domain.model.thresholdC
-import app.clothescast.core.domain.model.withThresholdC
 import app.clothescast.diag.ClothesRulesSnapshot
 import app.clothescast.diag.SettingsAnalyticsSnapshot
 import app.clothescast.diag.SettingsSnapshot
@@ -749,58 +748,6 @@ class SettingsRepository(
         dataStore.edit { it[TELEMETRY_NOTICE_ACKED] = acked }
     }
 
-    /**
-     * Atomically nudges the temperature threshold of the [ClothesRule] keyed
-     * `ruleItem` by [deltaC] degrees Celsius. Used by the rationale dialog's
-     * `+1°` / `−1°` buttons.
-     *
-     * Read-modify-write happens inside a single [dataStore.edit] so a tap-spam
-     * can't drop intermediate writes — DataStore serialises edits, and each tap
-     * reads the latest persisted rule list rather than the same pre-update
-     * snapshot. The resulting Celsius value is clamped to
-     * [ClothesRule.THRESHOLD_MIN_C] / [ClothesRule.THRESHOLD_MAX_C], then written
-     * back in the rule's existing unit so a Fahrenheit-typed rule stays in °F.
-     *
-     * Falls back to [ClothesRule.DEFAULTS] when the user has no matching rule
-     * on file (e.g. they previously deleted it) and appends a new rule with the
-     * adjusted threshold; that way the dialog's controls stay live even on a
-     * deleted rule and the next refresh re-evaluates against the recreated cut.
-     * No-ops if [ruleItem] isn't a temperature rule (e.g. precipitation).
-     */
-    suspend fun adjustClothesRuleThreshold(ruleItem: String, deltaC: Double) {
-        dataStore.edit { prefs ->
-            val current = parseRules(prefs[CLOTHES_RULES])
-            val updated = current.adjustOrAddTemperatureRule(ruleItem, deltaC) ?: return@edit
-            prefs[CLOTHES_RULES] = json.encodeToString(updated.map { it.toDto() })
-        }
-    }
-
-    private fun List<ClothesRule>.adjustOrAddTemperatureRule(
-        ruleItem: String,
-        deltaC: Double,
-    ): List<ClothesRule>? {
-        val idx = indexOfFirst { it.item == ruleItem && it.thresholdC() != null }
-        if (idx >= 0) {
-            val rule = this[idx]
-            val newC = ((rule.thresholdC() ?: return null) + deltaC).clampThreshold()
-            val updated = rule.withThresholdC(newC) ?: return null
-            return toMutableList().also { it[idx] = updated }
-        }
-        // No matching rule on disk — recreate it from the catalog default if there
-        // is one. The dialog only ever shows facts for rules that fromForecast can
-        // pick (sweater / jacket / coat / shorts), all of which have a default,
-        // so this branch covers the "user deleted it, then nudged from the dialog"
-        // case rather than a request to invent a rule from nothing.
-        val template = ClothesRule.DEFAULTS.firstOrNull { it.item == ruleItem } ?: return null
-        val templateC = template.thresholdC() ?: return null
-        val newC = (templateC + deltaC).clampThreshold()
-        val recreated = template.withThresholdC(newC) ?: return null
-        return this + recreated
-    }
-
-    private fun Double.clampThreshold(): Double =
-        coerceIn(ClothesRule.THRESHOLD_MIN_C, ClothesRule.THRESHOLD_MAX_C)
-
     private fun Preferences.toUserPreferences(): UserPreferences {
         val time = this[SCHEDULE_TIME]?.let { LocalTime.parse(it, TIME_FORMAT) }
             ?: DEFAULT_TIME
@@ -1240,7 +1187,9 @@ class SettingsRepository(
     private fun parseRules(raw: String?): List<ClothesRule> {
         if (raw.isNullOrBlank()) return ClothesRule.DEFAULTS
         return runCatching {
-            json.decodeFromString<List<ClothesRuleDto>>(raw).map { it.toDomain() }
+            // Drop any stored rule whose item isn't a catalog garment (legacy
+            // free-form items from before the catalog) — see [ClothesRuleDto.toDomain].
+            json.decodeFromString<List<ClothesRuleDto>>(raw).mapNotNull { it.toDomain() }
         }.getOrDefault(ClothesRule.DEFAULTS)
             // An empty stored list is also treated as "no rules configured" rather
             // than honoured as an intentional zero — with editing locked

--- a/app/src/main/kotlin/app/clothescast/diag/BugReport.kt
+++ b/app/src/main/kotlin/app/clothescast/diag/BugReport.kt
@@ -261,7 +261,7 @@ object BugReport {
             is ClothesRule.TemperatureAbove -> "feelsLikeMax > ${c.value}${c.unit.symbol()}"
             is ClothesRule.PrecipitationProbabilityAbove -> "precipMaxPct > ${c.percent}"
         }
-        return "${rule.item} when $cond"
+        return "${rule.item.itemKey} when $cond"
     }
 
     private fun StringBuilder.appendInsight(

--- a/app/src/main/kotlin/app/clothescast/diag/ClothesRulesSnapshot.kt
+++ b/app/src/main/kotlin/app/clothescast/diag/ClothesRulesSnapshot.kt
@@ -44,8 +44,8 @@ data class ClothesRulesSnapshot(
          * [extraRulesCount] but don't appear individually.
          */
         fun from(rules: List<ClothesRule>): ClothesRulesSnapshot {
-            val defaults = ClothesRule.DEFAULTS.associateBy { it.item }
-            val byItem = rules.associateBy { it.item }
+            val defaults = ClothesRule.DEFAULTS.associateBy { it.item.itemKey }
+            val byItem = rules.associateBy { it.item.itemKey }
             val perCategory: Map<String, String> = defaults.mapValues { (item, defaultRule) ->
                 val userRule = byItem[item]
                 if (userRule == null) MISSING else deltaBucket(userRule, defaultRule)
@@ -54,7 +54,7 @@ data class ClothesRulesSnapshot(
                 .filter { it.value != "0" }
                 .map { it.key }
                 .sorted()
-            val extras = rules.count { it.item !in defaults }
+            val extras = rules.count { it.item.itemKey !in defaults }
             return ClothesRulesSnapshot(
                 customisedCount = customisedKeys.size,
                 extraRulesCount = extras,

--- a/app/src/main/kotlin/app/clothescast/ui/settings/ClothesSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/ClothesSettings.kt
@@ -490,11 +490,7 @@ private fun ClothesRuleRow(
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Column(modifier = Modifier.weight(1f)) {
-            // Show the localised garment name for catalog items; fall back to
-            // the raw stored key for any older / custom items so the user can
-            // still see and delete them.
-            val garment = Garment.fromKey(rule.item)
-            val label = if (garment != null) stringResource(garmentLabelRes(garment)) else rule.item
+            val label = stringResource(garmentLabelRes(rule.item))
             Text(text = label, style = MaterialTheme.typography.titleSmall)
             Text(
                 text = describeCondition(rule.condition, temperatureUnit),
@@ -587,7 +583,7 @@ private fun ClothesRuleDialog(
     // (older free-form rules) preselect SWEATER too — the user can pick any
     // catalog garment and confirm to migrate the rule onto a known key.
     var garment by remember {
-        mutableStateOf(initial?.item?.let(Garment::fromKey) ?: Garment.SWEATER)
+        mutableStateOf(initial?.item ?: Garment.SWEATER)
     }
     val initialType = when (initial?.condition) {
         is ClothesRule.TemperatureBelow -> ConditionType.TEMP_BELOW
@@ -649,7 +645,7 @@ private fun ClothesRuleDialog(
                             if (unchanged && initialCond is ClothesRule.PrecipitationProbabilityAbove) initialCond
                             else ClothesRule.PrecipitationProbabilityAbove(v)
                     }
-                    onConfirm(ClothesRule(garment.itemKey, condition))
+                    onConfirm(ClothesRule(garment, condition))
                 },
             ) { Text(stringResource(android.R.string.ok)) }
         },

--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsPreviews.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsPreviews.kt
@@ -375,7 +375,7 @@ internal fun SettingsClothesFahrenheitPreview() {
     SettingsFrame {
         ClothesContent(
             rules = ClothesRule.DEFAULTS + ClothesRule(
-                Garment.TSHIRT.itemKey,
+                Garment.TSHIRT,
                 ClothesRule.TemperatureAbove(75.0, TemperatureUnit.FAHRENHEIT),
             ),
             defaultBottom = OutfitSuggestion.Bottom.LONG_PANTS,

--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayPreviews.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayPreviews.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
+import app.clothescast.core.domain.model.Garment
 import app.clothescast.core.domain.model.BandClause
 import app.clothescast.core.domain.model.ClothesClause
 import app.clothescast.core.domain.model.ClothesRule
@@ -304,7 +305,7 @@ internal fun OutfitRationaleDialogTunedPreview() {
             ),
             temperatureUnit = TemperatureUnit.CELSIUS,
             clothesRules = ClothesRule.DEFAULTS.map {
-                if (it.item == "sweater") it.copy(condition = ClothesRule.TemperatureBelow(13.0)) else it
+                if (it.item == Garment.SWEATER) it.copy(condition = ClothesRule.TemperatureBelow(13.0)) else it
             },
             onNavigateToClothes = {},
             onDismiss = {},

--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
@@ -1778,7 +1778,7 @@ private fun GarmentReasonBlock(
             // insight was cached — that way the dialog still has *something* to
             // render while the next refresh re-creates the rule from the
             // catalog default.
-            val liveC = clothesRules.firstOrNull { it.item == fact.ruleItem }?.thresholdC()
+            val liveC = clothesRules.firstOrNull { it.item.itemKey == fact.ruleItem }?.thresholdC()
                 ?: fact.thresholdC
             FactRow(
                 fact = fact,

--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayViewModel.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayViewModel.kt
@@ -702,27 +702,6 @@ class TodayViewModel(
         showModelSpread.value = false
     }
 
-    /**
-     * Nudges the temperature threshold of the [ClothesRule] keyed [ruleItem] by
-     * [deltaC] degrees Celsius. Wired to the rationale dialog's `−1°` / `+1°`
-     * controls. The read-modify-write is delegated to
-     * [SettingsRepository.adjustClothesRuleThreshold] which performs it inside a
-     * single `DataStore.edit { … }` transaction — rapid taps each read the latest
-     * persisted value, so taps don't collapse into one even when several coroutines
-     * are in flight. Final value is clamped to the documented sanity range and
-     * persisted in the rule's existing unit.
-     */
-    fun adjustClothesRuleThreshold(ruleItem: String, deltaC: Double) {
-        viewModelScope.launch {
-            settingsRepository.adjustClothesRuleThreshold(ruleItem, deltaC)
-            // No cache work — the [state] combine re-derives the cached
-            // snapshot against the updated prefs as soon as the DataStore
-            // write lands. Push the home-screen widget so the launcher icon
-            // catches up alongside the Today screen.
-            refreshOutfitWidget()
-        }
-    }
-
     class Factory(
         private val insightCache: InsightCache,
         private val workManager: WorkManager,

--- a/app/src/test/kotlin/app/clothescast/data/SettingsRepositoryTest.kt
+++ b/app/src/test/kotlin/app/clothescast/data/SettingsRepositoryTest.kt
@@ -9,6 +9,7 @@ import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.core.mutablePreferencesOf
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.core.stringSetPreferencesKey
+import app.clothescast.core.domain.model.Garment
 import app.clothescast.core.domain.model.BottomsFormat
 import app.clothescast.core.domain.model.DeltaFormat
 import app.clothescast.core.domain.model.ClothesMentionMode
@@ -410,9 +411,9 @@ class SettingsRepositoryTest {
     @Test
     fun `setClothesRules round-trips all three condition types`() = runTest {
         val rules = listOf(
-            ClothesRule("hat", ClothesRule.TemperatureBelow(5.0)),
-            ClothesRule("shorts", ClothesRule.TemperatureAbove(28.5)),
-            ClothesRule("brolly", ClothesRule.PrecipitationProbabilityAbove(40.0)),
+            ClothesRule(Garment.SWEATER, ClothesRule.TemperatureBelow(5.0)),
+            ClothesRule(Garment.SHORTS, ClothesRule.TemperatureAbove(28.5)),
+            ClothesRule(Garment.JACKET, ClothesRule.PrecipitationProbabilityAbove(40.0)),
         )
 
         subject.setClothesRules(rules)
@@ -421,12 +422,29 @@ class SettingsRepositoryTest {
     }
 
     @Test
+    fun `legacy free-form rules are dropped on load`() = runTest {
+        // Stored JSON from before the Garment catalog may carry free-form items
+        // ("cardigan") that aren't in the catalog. item is typed now, so the
+        // repository drops them on read rather than surfacing untyped rules.
+        dataStore.edit {
+            it[stringPreferencesKey("clothes_rules_json")] = """
+                [{"item":"cardigan","type":"temp_below","value":15.0},
+                 {"item":"sweater","type":"temp_below","value":18.0}]
+            """.trimIndent()
+        }
+
+        subject.preferences.first().clothesRules shouldContainExactly listOf(
+            ClothesRule(Garment.SWEATER, ClothesRule.TemperatureBelow(18.0)),
+        )
+    }
+
+    @Test
     fun `setClothesRules round-trips a fahrenheit-typed threshold`() = runTest {
         // The rule remembers what the user typed (65°F), not a converted Celsius
         // approximation — switching unit at display time is reversible.
         val rules = listOf(
-            ClothesRule("sweater", ClothesRule.TemperatureBelow(65.0, TemperatureUnit.FAHRENHEIT)),
-            ClothesRule("shorts", ClothesRule.TemperatureAbove(80.0, TemperatureUnit.FAHRENHEIT)),
+            ClothesRule(Garment.SWEATER, ClothesRule.TemperatureBelow(65.0, TemperatureUnit.FAHRENHEIT)),
+            ClothesRule(Garment.SHORTS, ClothesRule.TemperatureAbove(80.0, TemperatureUnit.FAHRENHEIT)),
         )
 
         subject.setClothesRules(rules)
@@ -448,8 +466,8 @@ class SettingsRepositoryTest {
 
         val rules = subject.preferences.first().clothesRules
         rules shouldContainExactly listOf(
-            ClothesRule("sweater", ClothesRule.TemperatureBelow(18.0, TemperatureUnit.CELSIUS)),
-            ClothesRule("shorts", ClothesRule.TemperatureAbove(24.0, TemperatureUnit.CELSIUS)),
+            ClothesRule(Garment.SWEATER, ClothesRule.TemperatureBelow(18.0, TemperatureUnit.CELSIUS)),
+            ClothesRule(Garment.SHORTS, ClothesRule.TemperatureAbove(24.0, TemperatureUnit.CELSIUS)),
         )
     }
 
@@ -668,74 +686,6 @@ class SettingsRepositoryTest {
 
         subject.setUseCalendarEvents(false)
         subject.preferences.first().useCalendarEvents shouldBe false
-    }
-
-    @Test
-    fun `adjustClothesRuleThreshold serialises rapid taps so none are dropped`() = runTest {
-        // Five concurrent `−1°` taps must each see the prior write — final
-        // value is the starting threshold minus 5°C, not a single 1°C step
-        // from the same pre-update snapshot. DataStore.edit serialises edits,
-        // so this exercises the atomic read-modify-write path that protects
-        // tap-spam from collapsing into one.
-        val starting = ClothesRule.DEFAULTS.first { it.item == "sweater" }.thresholdC()!!
-        coroutineScope {
-            repeat(5) {
-                launch { subject.adjustClothesRuleThreshold("sweater", -1.0) }
-            }
-        }
-        subject.preferences.first()
-            .clothesRules.first { it.item == "sweater" }
-            .thresholdC() shouldBe (starting - 5.0)
-    }
-
-    @Test
-    fun `adjustClothesRuleThreshold clamps to the documented sanity range`() = runTest {
-        // Even a relentless tap-spam can't escape the documented bounds.
-        repeat(100) { subject.adjustClothesRuleThreshold("sweater", -1.0) }
-        subject.preferences.first()
-            .clothesRules.first { it.item == "sweater" }
-            .thresholdC() shouldBe ClothesRule.THRESHOLD_MIN_C
-    }
-
-    @Test
-    fun `adjustClothesRuleThreshold preserves Fahrenheit-typed rules`() = runTest {
-        // A 75°F shorts rule (≈ 23.89°C) bumped by +1°C lands at 25.69°F — the
-        // unit on disk doesn't switch under the user's feet.
-        subject.setClothesRules(
-            listOf(ClothesRule("shorts", ClothesRule.TemperatureAbove(75.0, TemperatureUnit.FAHRENHEIT))),
-        )
-        subject.adjustClothesRuleThreshold("shorts", 1.0)
-
-        val updated = subject.preferences.first().clothesRules.first { it.item == "shorts" }
-        val cond = updated.condition as ClothesRule.TemperatureAbove
-        cond.unit shouldBe TemperatureUnit.FAHRENHEIT
-        // 75°F = 23.888…°C; +1°C = 24.888…°C; back to °F = 76.8°F.
-        cond.value shouldBe 76.8.plusOrMinus(1e-9)
-    }
-
-    @Test
-    fun `adjustClothesRuleThreshold recreates a deleted rule from the catalog default`() = runTest {
-        // User previously deleted the shorts rule; the rationale dialog's
-        // `+1°` should bring it back rather than silently no-op.
-        subject.setClothesRules(ClothesRule.DEFAULTS.filterNot { it.item == "shorts" })
-        subject.adjustClothesRuleThreshold("shorts", -1.0)
-
-        val rules = subject.preferences.first().clothesRules
-        val recreated = rules.first { it.item == "shorts" }
-        recreated.thresholdC() shouldBe 22.0
-        // Catalog default's unit (°C) is preserved on the recreated rule.
-        (recreated.condition as ClothesRule.TemperatureAbove).unit shouldBe TemperatureUnit.CELSIUS
-    }
-
-    @Test
-    fun `adjustClothesRuleThreshold leaves precipitation rules alone`() = runTest {
-        // No temperature condition to nudge → the call is a no-op rather than
-        // mutating a precipitation rule's percent into degrees.
-        val precipRule = ClothesRule("umbrella", ClothesRule.PrecipitationProbabilityAbove(60.0))
-        subject.setClothesRules(listOf(precipRule))
-        subject.adjustClothesRuleThreshold("umbrella", 5.0)
-
-        subject.preferences.first().clothesRules shouldContainExactly listOf(precipRule)
     }
 
     @Test
@@ -967,7 +917,7 @@ class SettingsRepositoryTest {
         // Nudge jacket from default 10°C down to 8°C — delta should report
         // as "-2" and the customised count should land at exactly 1.
         val edited = ClothesRule.DEFAULTS.map { rule ->
-            if (rule.item == "jacket") rule.copy(condition = ClothesRule.TemperatureBelow(8.0))
+            if (rule.item.itemKey == "jacket") rule.copy(condition = ClothesRule.TemperatureBelow(8.0))
             else rule
         }
         subject.setClothesRules(edited)
@@ -999,7 +949,7 @@ class SettingsRepositoryTest {
     @Test
     fun `clothesRulesSnapshot deleted category surfaces as MISSING`() = runTest {
         // User wiped coat from their list — every other default unchanged.
-        subject.setClothesRules(ClothesRule.DEFAULTS.filter { it.item != "coat" })
+        subject.setClothesRules(ClothesRule.DEFAULTS.filter { it.item.itemKey != "coat" })
 
         val snap = subject.clothesRulesSnapshot.first()
 

--- a/app/src/test/kotlin/app/clothescast/diag/ClothesRulesSnapshotTest.kt
+++ b/app/src/test/kotlin/app/clothescast/diag/ClothesRulesSnapshotTest.kt
@@ -1,5 +1,6 @@
 package app.clothescast.diag
 
+import app.clothescast.core.domain.model.Garment
 import app.clothescast.core.domain.model.ClothesRule
 import app.clothescast.core.domain.model.TemperatureUnit
 import io.kotest.matchers.shouldBe
@@ -25,7 +26,7 @@ class ClothesRulesSnapshotTest {
     fun `single category nudged reports signed integer delta`() {
         // Default jacket is TemperatureBelow(10.0); nudge to 8°C → delta of -2.
         val rules = ClothesRule.DEFAULTS.map { rule ->
-            if (rule.item == "jacket") rule.copy(condition = ClothesRule.TemperatureBelow(8.0))
+            if (rule.item.itemKey == "jacket") rule.copy(condition = ClothesRule.TemperatureBelow(8.0))
             else rule
         }
 
@@ -43,7 +44,7 @@ class ClothesRulesSnapshotTest {
     fun `positive delta is sign-prefixed`() {
         // Default shorts is TemperatureAbove(23.0); nudge to 26°C → delta of +3.
         val rules = ClothesRule.DEFAULTS.map { rule ->
-            if (rule.item == "shorts") rule.copy(condition = ClothesRule.TemperatureAbove(26.0))
+            if (rule.item.itemKey == "shorts") rule.copy(condition = ClothesRule.TemperatureAbove(26.0))
             else rule
         }
 
@@ -58,7 +59,7 @@ class ClothesRulesSnapshotTest {
         // jacket default 10, set to 30 → delta +20 → clamps to "+5+";
         // coat default 4, set to 50 → delta +46 → clamps to "+5+".
         val rules = ClothesRule.DEFAULTS.map { rule ->
-            when (rule.item) {
+            when (rule.item.itemKey) {
                 "jacket" -> rule.copy(condition = ClothesRule.TemperatureBelow(30.0))
                 "coat" -> rule.copy(condition = ClothesRule.TemperatureBelow(50.0))
                 else -> rule
@@ -75,7 +76,7 @@ class ClothesRulesSnapshotTest {
 
     @Test
     fun `deleted category is reported as MISSING`() {
-        val rules = ClothesRule.DEFAULTS.filter { it.item != "coat" }
+        val rules = ClothesRule.DEFAULTS.filter { it.item.itemKey != "coat" }
 
         val snap = ClothesRulesSnapshot.from(rules)
 
@@ -91,7 +92,7 @@ class ClothesRulesSnapshotTest {
     fun `extra non-default rule increments extra count without affecting default deltas`() {
         // Hat isn't in DEFAULTS; should bump extraRulesCount but not customisedCount.
         val rules = ClothesRule.DEFAULTS + ClothesRule(
-            item = "hat",
+            item = Garment.PUFFER,
             condition = ClothesRule.TemperatureBelow(5.0),
         )
 
@@ -108,7 +109,7 @@ class ClothesRulesSnapshotTest {
         // 50°F = 10°C exactly; delta from default 10°C is 0. Confirms that
         // thresholdC() does the unit conversion under the bucket math.
         val rules = ClothesRule.DEFAULTS.map { rule ->
-            if (rule.item == "jacket") rule.copy(
+            if (rule.item.itemKey == "jacket") rule.copy(
                 condition = ClothesRule.TemperatureBelow(50.0, TemperatureUnit.FAHRENHEIT),
             ) else rule
         }
@@ -123,7 +124,7 @@ class ClothesRulesSnapshotTest {
     fun `categories_customised is sorted alphabetically`() {
         // Customise shorts and jacket; expect "jacket,shorts" not "shorts,jacket".
         val rules = ClothesRule.DEFAULTS.map { rule ->
-            when (rule.item) {
+            when (rule.item.itemKey) {
                 "shorts" -> rule.copy(condition = ClothesRule.TemperatureAbove(26.0))
                 "jacket" -> rule.copy(condition = ClothesRule.TemperatureBelow(8.0))
                 else -> rule

--- a/app/src/test/kotlin/app/clothescast/ui/settings/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/app/clothescast/ui/settings/SettingsViewModelTest.kt
@@ -6,6 +6,7 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelStore
 import app.clothescast.core.data.location.OpenMeteoGeocodingClient
+import app.clothescast.core.domain.model.Garment
 import app.clothescast.core.domain.model.CalendarEvent
 import app.clothescast.core.domain.model.ClothesMentionMode
 import app.clothescast.core.domain.model.PreambleVisibility
@@ -431,16 +432,16 @@ class SettingsViewModelTest {
             ),
         )
 
-        refreshSubject.addClothesRule(ClothesRule("hat", ClothesRule.TemperatureBelow(0.0)))
-        refreshSubject.state.first { it.clothesRules.any { rule -> rule.item == "hat" } }
+        refreshSubject.addClothesRule(ClothesRule(Garment.HOODIE, ClothesRule.TemperatureBelow(0.0)))
+        refreshSubject.state.first { it.clothesRules.any { rule -> rule.item == Garment.HOODIE } }
         refreshCount shouldBe 1
 
-        refreshSubject.replaceClothesRule(0, ClothesRule("scarf", ClothesRule.TemperatureBelow(0.0)))
-        refreshSubject.state.first { it.clothesRules.first().item == "scarf" }
+        refreshSubject.replaceClothesRule(0, ClothesRule(Garment.PUFFER, ClothesRule.TemperatureBelow(0.0)))
+        refreshSubject.state.first { it.clothesRules.first().item == Garment.PUFFER }
         refreshCount shouldBe 2
 
         refreshSubject.deleteClothesRule(0)
-        refreshSubject.state.first { it.clothesRules.none { rule -> rule.item == "scarf" } }
+        refreshSubject.state.first { it.clothesRules.none { rule -> rule.item == Garment.PUFFER } }
         refreshCount shouldBe 3
 
         refreshSubject.setDefaultBottom(OutfitSuggestion.Bottom.JEANS)

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/ClothesRule.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/ClothesRule.kt
@@ -9,13 +9,15 @@ package app.clothescast.core.domain.model
  * outside, factoring in wind chill and humidity. Precipitation rules check the day's
  * peak probability.
  *
- * TODO(rules-redesign): `item` is still a free-form string on disk so existing
- * stored rules round-trip, but the editor now picks from the fixed [Garment]
- * catalog instead of free text — translation works because every catalog key
- * has a `garment_<key>` resource and a German phraser entry. Future: migrate
- * `item` to `Garment` directly (typed field, no fallback string), broaden the
- * catalog beyond tops + bottoms (headwear, scarf / gloves, footwear, rain /
- * sun gear), and add a "user-defined" path with an explicit translation hook.
+ * [item] is a typed [Garment]; the on-disk DTO stores its key as a string and
+ * drops any stored rule whose key isn't in the catalog (legacy free-form items
+ * from before the catalog existed). The editor picks from the fixed catalog, so
+ * new rules are always catalog garments.
+ *
+ * TODO(rules-redesign): broaden the [Garment] catalog beyond tops + bottoms
+ * (headwear, scarf / gloves, footwear, rain / sun gear — gated on the outfit
+ * display model), and add a "user-defined" path with an explicit translation
+ * hook for items outside the catalog.
  *
  * TODO(rules-in-layers): companion to [ClothesFormat.LAYER_COUNT] — let the
  * user *author* rules in layer-count terms too ("below 12°C → 3 layers")
@@ -28,7 +30,7 @@ package app.clothescast.core.domain.model
  * matching phrasing.
  */
 data class ClothesRule(
-    val item: String,
+    val item: Garment,
     val condition: Condition,
 ) {
     fun appliesTo(forecast: DailyForecast): Boolean = condition.matches(forecast)
@@ -81,10 +83,10 @@ data class ClothesRule(
         //  UMBRELLA (rain jacket, hood, rain boots, …) once the resource
         //  strings and per-locale phrasers cover them.
         val DEFAULTS: List<ClothesRule> = listOf(
-            ClothesRule("sweater", TemperatureBelow(16.0)),
-            ClothesRule("jacket", TemperatureBelow(10.0)),
-            ClothesRule("coat", TemperatureBelow(4.0)),
-            ClothesRule("shorts", TemperatureAbove(23.0)),
+            ClothesRule(Garment.SWEATER, TemperatureBelow(16.0)),
+            ClothesRule(Garment.JACKET, TemperatureBelow(10.0)),
+            ClothesRule(Garment.COAT, TemperatureBelow(4.0)),
+            ClothesRule(Garment.SHORTS, TemperatureAbove(23.0)),
         )
 
         /** Sanity bounds in °C for the rationale dialog's `+1°` / `−1°` taps. Wide enough
@@ -107,13 +109,3 @@ fun ClothesRule.thresholdC(): Double? = when (val c = condition) {
     is ClothesRule.PrecipitationProbabilityAbove -> null
 }
 
-/**
- * Returns a copy of this rule with its temperature threshold set to [newC] (Celsius),
- * preserved in the rule's existing unit so a Fahrenheit user's `75°F` rule stays
- * Fahrenheit on disk. Returns `null` for non-temperature rules.
- */
-fun ClothesRule.withThresholdC(newC: Double): ClothesRule? = when (val c = condition) {
-    is ClothesRule.TemperatureBelow -> copy(condition = c.copy(value = newC.toUnit(c.unit)))
-    is ClothesRule.TemperatureAbove -> copy(condition = c.copy(value = newC.toUnit(c.unit)))
-    is ClothesRule.PrecipitationProbabilityAbove -> null
-}

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/FallbackRange.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/FallbackRange.kt
@@ -44,7 +44,7 @@ fun fallbackRange(rules: List<ClothesRule>, tier: FallbackTier): FallbackRange {
     var lower: Double? = null
     var upper: Double? = null
     for (rule in rules) {
-        if (Garment.fromKey(rule.item)?.slot != expectedSlot) continue
+        if (rule.item.slot != expectedSlot) continue
         val threshold = rule.thresholdC() ?: continue
         when (rule.condition) {
             is ClothesRule.TemperatureBelow -> {

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Garment.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Garment.kt
@@ -208,7 +208,7 @@ enum class Garment(
             val classifiedTops = mutableListOf<IndexedTop>()
             val classifiedBottoms = mutableListOf<IndexedBottom>()
             rules.forEachIndexed { index, rule ->
-                val g = fromKey(rule.item) ?: return@forEachIndexed
+                val g = rule.item
                 when (g.slot) {
                     Slot.TOP -> {
                         val layer = g.layer ?: return@forEachIndexed
@@ -242,10 +242,10 @@ enum class Garment(
             // configured ordering — the prose phraser, the tie-in delta —
             // see the same sequence they'd have seen before the reduction.
             return rules.filterIndexed { index, rule ->
-                val g = fromKey(rule.item)
+                val g = rule.item
                 when {
-                    g?.slot == Slot.TOP && g.layer != null -> index in keepTopIndices
-                    g?.slot == Slot.BOTTOM -> index == keepBottomIndex
+                    g.slot == Slot.TOP && g.layer != null -> index in keepTopIndices
+                    g.slot == Slot.BOTTOM -> index == keepBottomIndex
                     else -> true
                 }
             }

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/OutfitSuggestion.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/OutfitSuggestion.kt
@@ -77,17 +77,17 @@ data class OutfitSuggestion(
         // (LONG_PANTS by default). Within the skirt family, the shorter
         // garment is checked first so that when both a `short-skirt` and a
         // `skirt` rule fire on the same warm day, the mini icon wins.
-        private val THICK_JACKET_KEYS = listOf("jacket")
-        private val THICK_COAT_KEYS = listOf("coat")
-        private val PUFFER_JACKET_KEYS = listOf("puffer")
-        private val THIN_JACKET_KEYS = listOf("thin-jacket")
-        private val SWEATER_KEYS = listOf("sweater", "hoodie")
-        private val POLO_KEYS = listOf("polo")
-        private val TSHIRT_KEYS = listOf("t-shirt")
-        private val SHORTS_KEYS = listOf("shorts")
-        private val SHORT_SKIRT_KEYS = listOf("short-skirt")
-        private val LONG_SKIRT_KEYS = listOf("skirt")
-        private val JEANS_KEYS = listOf("jeans")
+        private val THICK_JACKET_KEYS = listOf(Garment.JACKET)
+        private val THICK_COAT_KEYS = listOf(Garment.COAT)
+        private val PUFFER_JACKET_KEYS = listOf(Garment.PUFFER)
+        private val THIN_JACKET_KEYS = listOf(Garment.THIN_JACKET)
+        private val SWEATER_KEYS = listOf(Garment.SWEATER, Garment.HOODIE)
+        private val POLO_KEYS = listOf(Garment.POLO)
+        private val TSHIRT_KEYS = listOf(Garment.TSHIRT)
+        private val SHORTS_KEYS = listOf(Garment.SHORTS)
+        private val SHORT_SKIRT_KEYS = listOf(Garment.SHORT_SKIRT)
+        private val LONG_SKIRT_KEYS = listOf(Garment.SKIRT)
+        private val JEANS_KEYS = listOf(Garment.JEANS)
 
         /**
          * Two-piece icon outfit for [forecast] given the user's [clothesRules].
@@ -158,10 +158,9 @@ data class OutfitSuggestion(
             return OutfitSuggestion(top, bottom)
         }
 
-        /** True when any rule in the list names a catalog garment in [keys],
-         *  using the same canonicalisation as the prose path ([matchesKey]). */
-        private fun List<ClothesRule>.hasKeyIn(keys: List<String>): Boolean =
-            keys.any { key -> any { it.matchesKey(key) } }
+        /** True when any rule in the list is keyed on a garment in [keys]. */
+        private fun List<ClothesRule>.hasKeyIn(keys: List<Garment>): Boolean =
+            keys.any { garment -> any { it.item == garment } }
 
         /**
          * Returns the human-readable reasons that [fromForecast] picked this outfit —
@@ -214,7 +213,7 @@ data class OutfitSuggestion(
                 ?: tempRules.firstByKey(THICK_JACKET_KEYS)
                 ?: tempRules.firstByKey(THICK_COAT_KEYS)
                 ?: tempRules.firstByKey(PUFFER_JACKET_KEYS)
-                ?: ClothesRule.DEFAULTS.first { it.item == "sweater" }
+                ?: ClothesRule.DEFAULTS.first { it.item == Garment.SWEATER }
             return rule.toConditionFact(forecast, coldestHour, warmestHour)
         }
 
@@ -238,35 +237,21 @@ data class OutfitSuggestion(
                 ?: tempRules.firstByKey(SHORT_SKIRT_KEYS)
                 ?: tempRules.firstByKey(LONG_SKIRT_KEYS)
                 ?: tempRules.firstByKey(JEANS_KEYS)
-                ?: ClothesRule.DEFAULTS.first { it.item == "shorts" }
+                ?: ClothesRule.DEFAULTS.first { it.item == Garment.SHORTS }
             return rule.toConditionFact(forecast, coldestHour, warmestHour)
         }
 
+        // Walks [keys] in priority order (warmest tier first) and returns the
+        // first rule keyed on one of them that fires for the forecast.
         private fun List<ClothesRule>.firstFiring(
             forecast: DailyForecast,
-            keys: List<String>,
-        ): ClothesRule? = keys.firstNotNullOfOrNull { key ->
-            firstOrNull { it.matchesKey(key) && it.appliesTo(forecast) }
+            keys: List<Garment>,
+        ): ClothesRule? = keys.firstNotNullOfOrNull { garment ->
+            firstOrNull { it.item == garment && it.appliesTo(forecast) }
         }
 
-        private fun List<ClothesRule>.firstByKey(keys: List<String>): ClothesRule? =
-            keys.firstNotNullOfOrNull { key -> firstOrNull { it.matchesKey(key) } }
-
-        /**
-         * Whether a rule names the catalog garment [key], canonicalised the
-         * same way the prose path canonicalises it. [Garment.fromKey] folds
-         * the supported legacy spellings and case / whitespace variants
-         * ("tshirt" / " T-Shirt " → t-shirt, "jumper" → sweater) onto their
-         * catalog [Garment.itemKey], so a stored legacy rule drives the icon
-         * tier it already drives in the bullets — matching on the raw
-         * `item` string would leave the icon on the default while the prose
-         * named the garment. Falls back to a trimmed, case-insensitive
-         * compare for items outside the catalog so nothing regresses.
-         */
-        private fun ClothesRule.matchesKey(key: String): Boolean {
-            Garment.fromKey(item)?.let { return it.itemKey == key }
-            return item.trim().equals(key, ignoreCase = true)
-        }
+        private fun List<ClothesRule>.firstByKey(keys: List<Garment>): ClothesRule? =
+            keys.firstNotNullOfOrNull { garment -> firstOrNull { it.item == garment } }
 
         /** The rules with a Celsius threshold — i.e. those the rationale can
          *  turn into a [Fact]. Drops precipitation-keyed rules, whose
@@ -286,7 +271,7 @@ data class OutfitSuggestion(
                 observedC = observedC,
                 observedAt = observedAt,
                 thresholdC = thresholdC,
-                ruleItem = item,
+                ruleItem = item.itemKey,
                 comparison = if (observedC < thresholdC) {
                     Fact.Comparison.BELOW
                 } else {

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/TriggeredOutfit.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/TriggeredOutfit.kt
@@ -55,7 +55,7 @@ data class TriggeredOutfit(
      */
     val items: List<String>
         get() {
-            val raw = Garment.layerReduce(rules).map { it.item } + fallbacks
+            val raw = Garment.layerReduce(rules).map { it.item.itemKey } + fallbacks
             // Stable sort that floats bottoms to the end. Tops and unclassified
             // items (accessories, free-form) keep their input order; only the
             // top↔bottom flip — which happens when a bottom rule fires and the

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/DeriveInsight.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/DeriveInsight.kt
@@ -131,7 +131,7 @@ class DeriveInsight(
             deltaFormat = prefs.deltaFormat,
             clothesMentionMode = prefs.clothesMentionMode,
             yesterdayTriggeredItems = periodView.yesterdayTriggeredItems,
-            todayRuleItems = Garment.layerReduce(periodView.triggeredOutfit.rules).map { it.item },
+            todayRuleItems = Garment.layerReduce(periodView.triggeredOutfit.rules).map { it.item.itemKey },
             diagLog = diagLog,
         )
 
@@ -271,7 +271,7 @@ class DeriveInsight(
             eveningEventTieIn = null,
             deltaThresholdC = prefs.deltaThresholdC,
             deltaFormat = prefs.deltaFormat,
-            todayRuleItems = Garment.layerReduce(nightView.triggeredOutfit.rules).map { it.item },
+            todayRuleItems = Garment.layerReduce(nightView.triggeredOutfit.rules).map { it.item.itemKey },
         )
 
         // Two emission paths, either of which fires the clause: extra clothing

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/EvaluateClothesRules.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/EvaluateClothesRules.kt
@@ -13,12 +13,10 @@ import app.clothescast.core.domain.model.TriggeredOutfit
  * home-screen icon, the bulleted recommendations, and the prose clothes
  * clause all read from the same place and agree on what the user is wearing.
  *
- * Slot membership goes through [Garment.fromKey], which absorbs case /
- * whitespace / alias differences ("Jacket" / " jacket " → JACKET,
- * "trousers" → PANTS), so a matched rule whose item is the same garment
- * as the user's default — or any other top-slot garment, including
- * `t-shirt` — suppresses the default for that slot rather than landing
- * alongside it as a duplicate.
+ * Each [ClothesRule.item] is a typed [Garment] with a known slot, so a matched
+ * rule whose item is the same garment as the user's default — or any other
+ * garment in that slot, including `t-shirt` — suppresses the default for that
+ * slot rather than landing alongside it as a duplicate.
  *
  * Input order of [rules] is preserved in [TriggeredOutfit.rules]; the
  * per-tier default rule contributes its item to [TriggeredOutfit.fallbacks]
@@ -36,29 +34,13 @@ class EvaluateClothesRules {
         defaultBottom: OutfitSuggestion.Bottom = OutfitSuggestion.Bottom.LONG_PANTS,
     ): TriggeredOutfit {
         val matched = rules.filter { it.appliesTo(forecast) }
-        val matchedSlots = matched.mapNotNullTo(mutableSetOf()) { Garment.fromKey(it.item)?.slot }
-        // A matched threshold rule whose item isn't in the [Garment] catalog
-        // (e.g. a legacy free-form "cardigan" rule from before the catalog
-        // landed) still represents a garment the user is wearing — we just
-        // can't tell which slot it occupies. Suppress both fallbacks rather
-        // than appending them on top, otherwise the prose contradicts itself
-        // ("Today, wear a cardigan, a t-shirt, and pants."). Precipitation
-        // rules are exempt: they describe carried accessories (umbrella, etc.)
-        // that don't claim an outfit slot, so they shouldn't suppress either
-        // default.
-        val hasUnclassifiedGarmentRule = matched.any { rule ->
-            Garment.fromKey(rule.item) == null && when (rule.condition) {
-                is ClothesRule.TemperatureBelow, is ClothesRule.TemperatureAbove -> true
-                is ClothesRule.PrecipitationProbabilityAbove -> false
-            }
-        }
+        // Every [ClothesRule.item] is a catalog [Garment], so each matched rule
+        // claims a known slot. A slot covered by a matched rule (whether keyed
+        // on temperature or precipitation) doesn't also get its per-tier default.
+        val matchedSlots = matched.mapTo(mutableSetOf()) { it.item.slot }
         val fallbacks = buildList {
-            if (!hasUnclassifiedGarmentRule && Garment.Slot.TOP !in matchedSlots) {
-                add(defaultTop.itemKey())
-            }
-            if (!hasUnclassifiedGarmentRule && Garment.Slot.BOTTOM !in matchedSlots) {
-                add(defaultBottom.itemKey())
-            }
+            if (Garment.Slot.TOP !in matchedSlots) add(defaultTop.itemKey())
+            if (Garment.Slot.BOTTOM !in matchedSlots) add(defaultBottom.itemKey())
         }
         return TriggeredOutfit(rules = matched, fallbacks = fallbacks)
     }

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/model/ClothesRuleTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/model/ClothesRuleTest.kt
@@ -30,32 +30,32 @@ class ClothesRuleTest {
 
     @Test
     fun `temperature below applies when feels-like min is colder`() {
-        val rule = ClothesRule("sweater", ClothesRule.TemperatureBelow(18.0))
+        val rule = ClothesRule(Garment.SWEATER, ClothesRule.TemperatureBelow(18.0))
         rule.appliesTo(forecast(min = 14.0, max = 22.0)) shouldBe true
     }
 
     @Test
     fun `temperature below uses feels-like, not raw temperature`() {
         // Raw min is 20°C (above threshold) but wind chill makes it feel like 14°C.
-        val rule = ClothesRule("sweater", ClothesRule.TemperatureBelow(18.0))
+        val rule = ClothesRule(Garment.SWEATER, ClothesRule.TemperatureBelow(18.0))
         rule.appliesTo(forecast(min = 20.0, max = 24.0, feelsLikeMin = 14.0, feelsLikeMax = 22.0)) shouldBe true
     }
 
     @Test
     fun `temperature below does not apply when feels-like min meets threshold`() {
-        val rule = ClothesRule("sweater", ClothesRule.TemperatureBelow(18.0))
+        val rule = ClothesRule(Garment.SWEATER, ClothesRule.TemperatureBelow(18.0))
         rule.appliesTo(forecast(min = 18.0, max = 22.0)) shouldBe false
     }
 
     @Test
     fun `temperature above applies when feels-like max is warmer`() {
-        val rule = ClothesRule("shorts", ClothesRule.TemperatureAbove(24.0))
+        val rule = ClothesRule(Garment.SHORTS, ClothesRule.TemperatureAbove(24.0))
         rule.appliesTo(forecast(min = 12.0, max = 26.5)) shouldBe true
     }
 
     @Test
     fun `temperature above does not apply when feels-like max meets threshold`() {
-        val rule = ClothesRule("shorts", ClothesRule.TemperatureAbove(24.0))
+        val rule = ClothesRule(Garment.SHORTS, ClothesRule.TemperatureAbove(24.0))
         rule.appliesTo(forecast(min = 12.0, max = 24.0)) shouldBe false
     }
 
@@ -63,7 +63,7 @@ class ClothesRuleTest {
     fun `fahrenheit-typed below threshold compares against the converted value`() {
         // 65°F ≈ 18.33°C. A feels-like min of 17°C should trigger; 19°C should not.
         val rule = ClothesRule(
-            "sweater",
+            Garment.SWEATER,
             ClothesRule.TemperatureBelow(65.0, TemperatureUnit.FAHRENHEIT),
         )
         rule.appliesTo(forecast(min = 17.0, max = 22.0)) shouldBe true
@@ -74,7 +74,7 @@ class ClothesRuleTest {
     fun `fahrenheit-typed above threshold compares against the converted value`() {
         // 80°F ≈ 26.67°C.
         val rule = ClothesRule(
-            "shorts",
+            Garment.SHORTS,
             ClothesRule.TemperatureAbove(80.0, TemperatureUnit.FAHRENHEIT),
         )
         rule.appliesTo(forecast(min = 12.0, max = 27.0)) shouldBe true
@@ -91,7 +91,7 @@ class ClothesRuleTest {
 
     @Test
     fun `precipitation rule uses peak probability`() {
-        val rule = ClothesRule("umbrella", ClothesRule.PrecipitationProbabilityAbove(50.0))
+        val rule = ClothesRule(Garment.JACKET, ClothesRule.PrecipitationProbabilityAbove(50.0))
         rule.appliesTo(forecast(min = 10.0, max = 18.0, precip = 65.0)) shouldBe true
         rule.appliesTo(forecast(min = 10.0, max = 18.0, precip = 30.0)) shouldBe false
     }
@@ -100,7 +100,7 @@ class ClothesRuleTest {
     fun `defaults cover the temperature-driven MVP cases`() {
         // Umbrella was deliberately dropped: the precip clause already names rain,
         // and the wet-weather accessory is going to become a personalised setting.
-        val items = ClothesRule.DEFAULTS.map { it.item }
+        val items = ClothesRule.DEFAULTS.map { it.item.itemKey }
         items shouldBe listOf("sweater", "jacket", "coat", "shorts")
     }
 
@@ -109,7 +109,7 @@ class ClothesRuleTest {
         // Realistic spring day: chilly start, warm peak. Min stays above the
         // coat threshold (4°C), so coat shouldn't fire.
         val day = forecast(min = 8.0, max = 25.0)
-        val triggered = ClothesRule.DEFAULTS.filter { it.appliesTo(day) }.map { it.item }
+        val triggered = ClothesRule.DEFAULTS.filter { it.appliesTo(day) }.map { it.item.itemKey }
         triggered shouldBe listOf("sweater", "jacket", "shorts")
     }
 
@@ -117,7 +117,7 @@ class ClothesRuleTest {
     fun `freezing morning triggers coat alongside sweater and jacket`() {
         // Sub-zero feels-like crosses every cold-weather threshold including coat.
         val day = forecast(min = -2.0, max = 4.0)
-        val triggered = ClothesRule.DEFAULTS.filter { it.appliesTo(day) }.map { it.item }
+        val triggered = ClothesRule.DEFAULTS.filter { it.appliesTo(day) }.map { it.item.itemKey }
         triggered shouldBe listOf("sweater", "jacket", "coat")
     }
 }

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/model/FallbackRangeTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/model/FallbackRangeTest.kt
@@ -32,11 +32,11 @@ class FallbackRangeTest {
         // A bottom-tier `shorts` rule doesn't gate the top fallback, and a
         // top-tier `sweater` rule doesn't gate the bottom fallback.
         fallbackRange(
-            listOf(ClothesRule("shorts", ClothesRule.TemperatureAbove(24.0))),
+            listOf(ClothesRule(Garment.SHORTS, ClothesRule.TemperatureAbove(24.0))),
             FallbackTier.TOP,
         ) shouldBe FallbackRange(null, null)
         fallbackRange(
-            listOf(ClothesRule("sweater", ClothesRule.TemperatureBelow(18.0))),
+            listOf(ClothesRule(Garment.SWEATER, ClothesRule.TemperatureBelow(18.0))),
             FallbackTier.BOTTOM,
         ) shouldBe FallbackRange(null, null)
     }
@@ -44,7 +44,7 @@ class FallbackRangeTest {
     @Test
     fun `precipitation rules are ignored`() {
         fallbackRange(
-            listOf(ClothesRule("sweater", ClothesRule.PrecipitationProbabilityAbove(30.0))),
+            listOf(ClothesRule(Garment.SWEATER, ClothesRule.PrecipitationProbabilityAbove(30.0))),
             FallbackTier.TOP,
         ) shouldBe FallbackRange(null, null)
     }
@@ -56,8 +56,8 @@ class FallbackRangeTest {
         // match" row reads "never" so the Settings UI surfaces the conflict.
         val range = fallbackRange(
             listOf(
-                ClothesRule("sweater", ClothesRule.TemperatureBelow(25.0)),
-                ClothesRule("polo", ClothesRule.TemperatureAbove(10.0)),
+                ClothesRule(Garment.SWEATER, ClothesRule.TemperatureBelow(25.0)),
+                ClothesRule(Garment.POLO, ClothesRule.TemperatureAbove(10.0)),
             ),
             FallbackTier.TOP,
         )
@@ -67,7 +67,7 @@ class FallbackRangeTest {
     @Test
     fun `Fahrenheit-stored thresholds normalize to Celsius`() {
         val range = fallbackRange(
-            listOf(ClothesRule("sweater", ClothesRule.TemperatureBelow(65.0, TemperatureUnit.FAHRENHEIT))),
+            listOf(ClothesRule(Garment.SWEATER, ClothesRule.TemperatureBelow(65.0, TemperatureUnit.FAHRENHEIT))),
             FallbackTier.TOP,
         )
         range.lowerC shouldBe (65.0 - 32.0) * 5.0 / 9.0
@@ -80,8 +80,8 @@ class FallbackRangeTest {
         // fires once the warmer rule stops firing.
         fallbackRange(
             listOf(
-                ClothesRule("jacket", ClothesRule.TemperatureBelow(12.0)),
-                ClothesRule("sweater", ClothesRule.TemperatureBelow(18.0)),
+                ClothesRule(Garment.JACKET, ClothesRule.TemperatureBelow(12.0)),
+                ClothesRule(Garment.SWEATER, ClothesRule.TemperatureBelow(18.0)),
             ),
             FallbackTier.TOP,
         ).lowerC shouldBe 18.0

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/model/GarmentTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/model/GarmentTest.kt
@@ -12,9 +12,8 @@ class GarmentTest {
         // if a default's item key isn't a Garment, the editor would have no way
         // to round-trip it through the dropdown.
         ClothesRule.DEFAULTS.forEach { rule ->
-            val garment = Garment.fromKey(rule.item)
-            (garment != null) shouldBe true
-            garment!!.itemKey shouldBe rule.item
+            // The stored key round-trips back to the same catalog garment.
+            Garment.fromKey(rule.item.itemKey) shouldBe rule.item
         }
     }
 

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/model/OutfitSuggestionTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/model/OutfitSuggestionTest.kt
@@ -175,7 +175,7 @@ class OutfitSuggestionTest {
         // bottom falls to the supplied default — the per-tier default is not an
         // icon tier of its own, matching fromForecast.
         val triggered = TriggeredOutfit(
-            rules = listOf(ClothesRule("coat", ClothesRule.TemperatureBelow(5.0))),
+            rules = listOf(ClothesRule(Garment.COAT, ClothesRule.TemperatureBelow(5.0))),
             fallbacks = listOf("pants"),
         )
         OutfitSuggestion.fromTriggeredOutfit(
@@ -189,7 +189,7 @@ class OutfitSuggestionTest {
         // With the default 23°C shorts rule, max 22°C lands on LONG_PANTS.
         // Lower the rule to 20°C and the same forecast picks SHORTS — the
         // home-screen icon and the bullet text now share the same threshold.
-        val warmer = listOf(ClothesRule("shorts", ClothesRule.TemperatureAbove(20.0)))
+        val warmer = listOf(ClothesRule(Garment.SHORTS, ClothesRule.TemperatureAbove(20.0)))
         val outfit = OutfitSuggestion.fromForecast(
             forecast(feelsLikeMin = 18.0, feelsLikeMax = 22.0),
             warmer,
@@ -200,7 +200,7 @@ class OutfitSuggestionTest {
     @Test
     fun `Fahrenheit-typed rule converts to Celsius for the comparison`() {
         // The rule says "shorts above 75°F" (≈ 23.89°C). A 24°C max fires it.
-        val rule = ClothesRule("shorts", ClothesRule.TemperatureAbove(75.0, TemperatureUnit.FAHRENHEIT))
+        val rule = ClothesRule(Garment.SHORTS, ClothesRule.TemperatureAbove(75.0, TemperatureUnit.FAHRENHEIT))
         val outfit = OutfitSuggestion.fromForecast(
             forecast(feelsLikeMin = 18.0, feelsLikeMax = 24.0),
             listOf(rule),
@@ -219,7 +219,7 @@ class OutfitSuggestionTest {
         // No shorts rule → the home screen never picks shorts, no matter how
         // hot. The rationale still has something to cite (catalog default) so
         // the dialog renders coherently.
-        val noShorts = ClothesRule.DEFAULTS.filterNot { it.item == "shorts" }
+        val noShorts = ClothesRule.DEFAULTS.filterNot { it.item == Garment.SHORTS }
         val outfit = OutfitSuggestion.fromForecast(
             forecast(feelsLikeMin = 22.0, feelsLikeMax = 30.0),
             noShorts,
@@ -265,7 +265,7 @@ class OutfitSuggestionTest {
         // A user adds a "short-skirt > 22°C" rule. A warm day fires it, and
         // the home-screen icon shows the mini-skirt silhouette rather than
         // the full-length one.
-        val rule = ClothesRule("short-skirt", ClothesRule.TemperatureAbove(22.0))
+        val rule = ClothesRule(Garment.SHORT_SKIRT, ClothesRule.TemperatureAbove(22.0))
         val outfit = OutfitSuggestion.fromForecast(
             forecast(feelsLikeMin = 18.0, feelsLikeMax = 25.0),
             listOf(rule),
@@ -279,8 +279,8 @@ class OutfitSuggestionTest {
         // the right pick on a warmer day, and the priority order mirrors
         // SHORTS-over-LONG_SKIRT on the bottom tier.
         val rules = listOf(
-            ClothesRule("short-skirt", ClothesRule.TemperatureAbove(22.0)),
-            ClothesRule("skirt", ClothesRule.TemperatureAbove(16.0)),
+            ClothesRule(Garment.SHORT_SKIRT, ClothesRule.TemperatureAbove(22.0)),
+            ClothesRule(Garment.SKIRT, ClothesRule.TemperatureAbove(16.0)),
         )
         val outfit = OutfitSuggestion.fromForecast(
             forecast(feelsLikeMin = 18.0, feelsLikeMax = 25.0),
@@ -294,8 +294,8 @@ class OutfitSuggestionTest {
         // The short-skirt rule sits at a hotter threshold than skirt; on a
         // mild day only the skirt rule fires and LONG_SKIRT is the right pick.
         val rules = listOf(
-            ClothesRule("short-skirt", ClothesRule.TemperatureAbove(22.0)),
-            ClothesRule("skirt", ClothesRule.TemperatureAbove(16.0)),
+            ClothesRule(Garment.SHORT_SKIRT, ClothesRule.TemperatureAbove(22.0)),
+            ClothesRule(Garment.SKIRT, ClothesRule.TemperatureAbove(16.0)),
         )
         val outfit = OutfitSuggestion.fromForecast(
             forecast(feelsLikeMin = 15.0, feelsLikeMax = 20.0),
@@ -357,8 +357,8 @@ class OutfitSuggestionTest {
         // defaultTop (POLO), leaving the outfit card's icon contradicting its
         // text ("Wear a t-shirt" next to a polo silhouette).
         val rules = listOf(
-            ClothesRule("t-shirt", ClothesRule.TemperatureAbove(24.0)),
-            ClothesRule("shorts", ClothesRule.TemperatureAbove(24.0)),
+            ClothesRule(Garment.TSHIRT, ClothesRule.TemperatureAbove(24.0)),
+            ClothesRule(Garment.SHORTS, ClothesRule.TemperatureAbove(24.0)),
         )
         val outfit = OutfitSuggestion.fromForecast(
             forecast(feelsLikeMin = 17.9, feelsLikeMax = 27.9),
@@ -375,8 +375,8 @@ class OutfitSuggestionTest {
         // a user has both rules firing the polo wins — matching the prose's
         // layer-reduction, which keeps the polo and drops the t-shirt.
         val rules = listOf(
-            ClothesRule("t-shirt", ClothesRule.TemperatureAbove(24.0)),
-            ClothesRule("polo", ClothesRule.TemperatureAbove(24.0)),
+            ClothesRule(Garment.TSHIRT, ClothesRule.TemperatureAbove(24.0)),
+            ClothesRule(Garment.POLO, ClothesRule.TemperatureAbove(24.0)),
         )
         val outfit = OutfitSuggestion.fromForecast(
             forecast(feelsLikeMin = 17.9, feelsLikeMax = 27.9),
@@ -393,7 +393,7 @@ class OutfitSuggestionTest {
         // threshold as uncrossed (18°C < 24°C) on a day the rule actually fired
         // (max 28°C), and wire its ±1° controls to that misleading fact.
         val hourly = listOf(hour(LocalTime.of(7, 0), 18.0), hour(LocalTime.of(15, 0), 28.0))
-        val rules = listOf(ClothesRule("t-shirt", ClothesRule.TemperatureAbove(24.0)))
+        val rules = listOf(ClothesRule(Garment.TSHIRT, ClothesRule.TemperatureAbove(24.0)))
         val fact = OutfitSuggestion.explainFromForecast(
             forecast(feelsLikeMin = 18.0, feelsLikeMax = 28.0, hourly = hourly),
             rules,
@@ -407,45 +407,13 @@ class OutfitSuggestionTest {
     }
 
     @Test
-    fun `legacy and variant t-shirt spellings still drive the TSHIRT icon`() {
-        // Garment.fromKey canonicalises "tshirt" and case / whitespace variants
-        // to TSHIRT, and the prose path relies on that. The icon picker must
-        // canonicalise the same way — otherwise a stored legacy rule fires for
-        // the bullets but the icon falls through to defaultTop (POLO), the very
-        // mismatch this change fixes.
-        listOf("tshirt", " T-Shirt ").forEach { spelling ->
-            val rules = listOf(ClothesRule(spelling, ClothesRule.TemperatureAbove(24.0)))
-            val outfit = OutfitSuggestion.fromForecast(
-                forecast(feelsLikeMin = 17.9, feelsLikeMax = 27.9),
-                rules,
-                defaultTop = OutfitSuggestion.Top.POLO,
-            )
-            outfit.top shouldBe OutfitSuggestion.Top.TSHIRT
-        }
-    }
-
-    @Test
-    fun `legacy jumper spelling drives the SWEATER icon`() {
-        // "jumper" canonicalises to SWEATER via Garment.fromKey; the icon tier
-        // matches on the canonical key, so the en-GB legacy spelling lands on
-        // the sweater silhouette rather than the default top.
-        val rules = listOf(ClothesRule("jumper", ClothesRule.TemperatureBelow(16.0)))
-        val outfit = OutfitSuggestion.fromForecast(
-            forecast(feelsLikeMin = 12.0, feelsLikeMax = 15.0),
-            rules,
-            defaultTop = OutfitSuggestion.Top.POLO,
-        )
-        outfit.top shouldBe OutfitSuggestion.Top.SWEATER
-    }
-
-    @Test
     fun `precipitation-keyed t-shirt rule drives the icon without crashing the rationale`() {
         // Settings lets a user key any garment — a top included — off
         // precipitation. On a rainy day such a rule fires and drives the icon
         // (TSHIRT here, beating the POLO default), but it carries no temperature
         // threshold: the rationale must skip it and fall back to a temperature
         // rule rather than throw in toFact.
-        val rules = listOf(ClothesRule("t-shirt", ClothesRule.PrecipitationProbabilityAbove(50.0)))
+        val rules = listOf(ClothesRule(Garment.TSHIRT, ClothesRule.PrecipitationProbabilityAbove(50.0)))
         val rainy = forecast(feelsLikeMin = 12.0, feelsLikeMax = 20.0, precipMaxPct = 60.0)
 
         OutfitSuggestion.fromForecast(
@@ -463,7 +431,7 @@ class OutfitSuggestionTest {
     @Test
     fun `coat rule alone drives THICK_COAT when it fires`() {
         // Coat has its own icon tier (THICK_COAT) separate from jacket (THICK_JACKET).
-        val coatOnly = listOf(ClothesRule("coat", ClothesRule.TemperatureBelow(6.0)))
+        val coatOnly = listOf(ClothesRule(Garment.COAT, ClothesRule.TemperatureBelow(6.0)))
         val outfit = OutfitSuggestion.fromForecast(
             forecast(feelsLikeMin = 3.0, feelsLikeMax = 8.0),
             coatOnly,

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/EvaluateClothesRulesTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/EvaluateClothesRulesTest.kt
@@ -1,5 +1,6 @@
 package app.clothescast.core.domain.usecase
 
+import app.clothescast.core.domain.model.Garment
 import app.clothescast.core.domain.model.ClothesRule
 import app.clothescast.core.domain.model.DailyForecast
 import app.clothescast.core.domain.model.OutfitSuggestion
@@ -53,7 +54,7 @@ class EvaluateClothesRulesTest {
         // threshold rule does. Top slot gets the matching rule's item; bottom
         // slot gets the default.
         val out = subject(forecast(min = 14.0, max = 20.0), ClothesRule.DEFAULTS)
-        out.rules.map { it.item }.shouldContainExactly("sweater")
+        out.rules.map { it.item.itemKey }.shouldContainExactly("sweater")
         out.fallbacks.shouldContainExactly("pants")
         out.items.shouldContainExactly("sweater", "pants")
     }
@@ -66,7 +67,7 @@ class EvaluateClothesRulesTest {
         // "Wear a t-shirt and shorts." regardless of which clause produced
         // the t-shirt (rule vs default fallback).
         val out = subject(forecast(min = 22.0, max = 28.0), ClothesRule.DEFAULTS)
-        out.rules.map { it.item }.shouldContainExactly("shorts")
+        out.rules.map { it.item.itemKey }.shouldContainExactly("shorts")
         out.fallbacks.shouldContainExactly("t-shirt")
         out.items.shouldContainExactly("t-shirt", "shorts")
     }
@@ -77,7 +78,7 @@ class EvaluateClothesRulesTest {
         // warm afternoon. Both tiers have a matching threshold rule → no
         // default contributes.
         val out = subject(forecast(min = 8.0, max = 25.0), ClothesRule.DEFAULTS)
-        out.rules.map { it.item }.shouldContainExactly("sweater", "jacket", "shorts")
+        out.rules.map { it.item.itemKey }.shouldContainExactly("sweater", "jacket", "shorts")
         out.fallbacks.shouldBeEmpty()
     }
 
@@ -86,22 +87,10 @@ class EvaluateClothesRulesTest {
         // Defaults no longer include umbrella — the precip clause announces rain,
         // and the wet-weather accessory will become a personalised setting.
         val out = subject(forecast(min = 9.0, max = 15.0, precip = 70.0), ClothesRule.DEFAULTS)
-        out.rules.map { it.item }.shouldContainExactly("sweater", "jacket")
+        out.rules.map { it.item.itemKey }.shouldContainExactly("sweater", "jacket")
         out.items.shouldContainExactly("sweater", "jacket", "pants")
     }
 
-    @Test
-    fun `matching non-tier threshold rule does not displace either tier default`() {
-        // Umbrella is a precip-keyed threshold rule and doesn't claim either
-        // outfit tier, so a mild rainy day still resolves to both tier
-        // defaults alongside it.
-        val rules = listOf(
-            ClothesRule("umbrella", ClothesRule.PrecipitationProbabilityAbove(50.0)),
-        )
-        val out = subject(forecast(min = 18.0, max = 22.0, precip = 80.0), rules)
-        out.rules.map { it.item }.shouldContainExactly("umbrella")
-        out.items.shouldContainExactly("umbrella", "t-shirt", "pants")
-    }
 
     @Test
     fun `user-selected default rules flow through to the resolved items`() {
@@ -123,9 +112,9 @@ class EvaluateClothesRulesTest {
         // Both shouldn't land in the items list — the rule covers the top
         // slot, so the top default sits this one out (bottom default still
         // fires because no bottom-slot rule matched).
-        val rules = listOf(ClothesRule("t-shirt", ClothesRule.TemperatureAbove(20.0)))
+        val rules = listOf(ClothesRule(Garment.TSHIRT, ClothesRule.TemperatureAbove(20.0)))
         val out = subject(forecast(min = 21.0, max = 25.0), rules)
-        out.rules.map { it.item }.shouldContainExactly("t-shirt")
+        out.rules.map { it.item.itemKey }.shouldContainExactly("t-shirt")
         // Top slot covered by the rule; only the bottom default contributes.
         out.fallbacks.shouldContainExactly("pants")
         out.items.shouldContainExactly("t-shirt", "pants")
@@ -138,72 +127,13 @@ class EvaluateClothesRulesTest {
         // any of them still covers the top slot, so the default shouldn't
         // also fire — otherwise the user gets "wear a shirt and a t-shirt"
         // for a single tier.
-        val rules = listOf(ClothesRule("shirt", ClothesRule.TemperatureAbove(15.0)))
+        val rules = listOf(ClothesRule(Garment.SHIRT, ClothesRule.TemperatureAbove(15.0)))
         val out = subject(forecast(min = 16.0, max = 22.0), rules)
-        out.rules.map { it.item }.shouldContainExactly("shirt")
+        out.rules.map { it.item.itemKey }.shouldContainExactly("shirt")
         // Top covered by "shirt", bottom slot has no firing rule → defaults to pants.
         out.items.shouldContainExactly("shirt", "pants")
     }
 
-    @Test
-    fun `legacy case and whitespace variants normalize for tier membership`() {
-        // Pre-catalog rules saved with capitalized or whitespace-padded items
-        // ("Jacket", " jacket ") still fire on the forecast, and they should
-        // also be recognized as top-slot for default-suppression — Garment.fromKey
-        // already normalizes for the rest of the pipeline (tie-in delta,
-        // formatter), and the evaluator follows the same contract.
-        val rules = listOf(ClothesRule("Jacket", ClothesRule.TemperatureBelow(12.0)))
-        val out = subject(forecast(min = 5.0, max = 10.0), rules)
-        out.rules.map { it.item }.shouldContainExactly("Jacket")
-        // Without normalization, the engine would add "t-shirt" on top of
-        // "Jacket" — contradictory advice. With normalization the top slot
-        // is correctly covered.
-        out.items.shouldContainExactly("Jacket", "pants")
-    }
-
-    @Test
-    fun `unclassified temperature rule suppresses both fallbacks instead of duplicating them`() {
-        // Codex-flagged: a legacy free-form temperature rule like "cardigan"
-        // (typed before the Garment catalog landed and not recognized today)
-        // still represents a garment the user is wearing — we just can't
-        // tell which slot it occupies. Pre-fix: the engine couldn't classify
-        // it and appended both defaults on top, producing the contradictory
-        // "cardigan + t-shirt + pants" prose. Now: suppress both fallbacks
-        // so the user's rule stands as written.
-        val rules = listOf(ClothesRule("cardigan", ClothesRule.TemperatureBelow(15.0)))
-        val out = subject(forecast(min = 8.0, max = 14.0), rules)
-        out.rules.map { it.item }.shouldContainExactly("cardigan")
-        out.fallbacks.shouldBeEmpty()
-        out.items.shouldContainExactly("cardigan")
-    }
-
-    @Test
-    fun `unclassified precipitation rule does not suppress slot fallbacks`() {
-        // An unclassified precipitation rule (umbrella-style) describes a
-        // carried accessory, not a garment that takes up an outfit slot.
-        // It shouldn't suppress either default — the user still needs the
-        // baseline t-shirt + pants alongside it.
-        val rules = listOf(ClothesRule("umbrella", ClothesRule.PrecipitationProbabilityAbove(50.0)))
-        val out = subject(forecast(min = 18.0, max = 22.0, precip = 80.0), rules)
-        out.rules.map { it.item }.shouldContainExactly("umbrella")
-        out.fallbacks.shouldContainExactly("t-shirt", "pants")
-        out.items.shouldContainExactly("umbrella", "t-shirt", "pants")
-    }
-
-    @Test
-    fun `classified rule covers its slot even when an unclassified accessory rule also fires`() {
-        // Mixed-condition cold rainy day: sweater rule (classified, TOP) +
-        // umbrella rule (unclassified, precip). Top slot is covered by
-        // sweater so its default doesn't fire; umbrella is an accessory so
-        // it doesn't claim a slot; bottom default still applies normally.
-        val rules = listOf(
-            ClothesRule("sweater", ClothesRule.TemperatureBelow(18.0)),
-            ClothesRule("umbrella", ClothesRule.PrecipitationProbabilityAbove(50.0)),
-        )
-        val out = subject(forecast(min = 10.0, max = 16.0, precip = 70.0), rules)
-        out.rules.map { it.item }.shouldContainExactly("sweater", "umbrella")
-        out.items.shouldContainExactly("sweater", "umbrella", "pants")
-    }
 
     @Test
     fun `firing base-layer rule is dropped when a mid-layer rule also fires`() {
@@ -214,12 +144,12 @@ class EvaluateClothesRulesTest {
         // keeps every firing rule (the rationale + tie-in delta logic still
         // need access to all matches).
         val rules = listOf(
-            ClothesRule("t-shirt", ClothesRule.TemperatureBelow(30.0)),
-            ClothesRule("sweater", ClothesRule.TemperatureBelow(18.0)),
-            ClothesRule("jeans", ClothesRule.TemperatureBelow(20.0)),
+            ClothesRule(Garment.TSHIRT, ClothesRule.TemperatureBelow(30.0)),
+            ClothesRule(Garment.SWEATER, ClothesRule.TemperatureBelow(18.0)),
+            ClothesRule(Garment.JEANS, ClothesRule.TemperatureBelow(20.0)),
         )
         val out = subject(forecast(min = 10.0, max = 14.0), rules)
-        out.rules.map { it.item }.shouldContainExactly("t-shirt", "sweater", "jeans")
+        out.rules.map { it.item.itemKey }.shouldContainExactly("t-shirt", "sweater", "jeans")
         out.items.shouldContainExactly("sweater", "jeans")
     }
 
@@ -229,11 +159,11 @@ class EvaluateClothesRulesTest {
         // makes the BASE layer implicit. Here only the t-shirt and jacket
         // rules fire; the sweater rule doesn't because the minimum is 14°C.
         val rules = listOf(
-            ClothesRule("t-shirt", ClothesRule.TemperatureBelow(30.0)),
-            ClothesRule("jacket", ClothesRule.TemperatureBelow(15.0)),
+            ClothesRule(Garment.TSHIRT, ClothesRule.TemperatureBelow(30.0)),
+            ClothesRule(Garment.JACKET, ClothesRule.TemperatureBelow(15.0)),
         )
         val out = subject(forecast(min = 12.0, max = 14.0), rules)
-        out.rules.map { it.item }.shouldContainExactly("t-shirt", "jacket")
+        out.rules.map { it.item.itemKey }.shouldContainExactly("t-shirt", "jacket")
         out.items.shouldContainExactly("jacket", "pants")
     }
 
@@ -243,9 +173,9 @@ class EvaluateClothesRulesTest {
         // only the polo rule (BASE) crosses. The base layer stays — there's
         // nothing covering it.
         val rules = listOf(
-            ClothesRule("polo", ClothesRule.TemperatureBelow(30.0)),
-            ClothesRule("sweater", ClothesRule.TemperatureBelow(15.0)),
-            ClothesRule("jacket", ClothesRule.TemperatureBelow(10.0)),
+            ClothesRule(Garment.POLO, ClothesRule.TemperatureBelow(30.0)),
+            ClothesRule(Garment.SWEATER, ClothesRule.TemperatureBelow(15.0)),
+            ClothesRule(Garment.JACKET, ClothesRule.TemperatureBelow(10.0)),
         )
         val out = subject(forecast(min = 18.0, max = 22.0), rules)
         out.items.shouldContainExactly("polo", "pants")
@@ -259,7 +189,7 @@ class EvaluateClothesRulesTest {
         // a real outfit ("sweater under a coat") rather than naming every
         // also-ran.
         val out = subject(forecast(min = 2.0, max = 8.0), ClothesRule.DEFAULTS)
-        out.rules.map { it.item }.shouldContainExactly("sweater", "jacket", "coat")
+        out.rules.map { it.item.itemKey }.shouldContainExactly("sweater", "jacket", "coat")
         out.items.shouldContainExactly("sweater", "coat", "pants")
     }
 
@@ -272,11 +202,11 @@ class EvaluateClothesRulesTest {
         // prose would read "Wear a sweater, sweater, and pants." The
         // earlier-listed instance wins; the duplicate is silently dropped.
         val rules = listOf(
-            ClothesRule("sweater", ClothesRule.TemperatureBelow(18.0)),
-            ClothesRule("sweater", ClothesRule.TemperatureBelow(18.0)),
+            ClothesRule(Garment.SWEATER, ClothesRule.TemperatureBelow(18.0)),
+            ClothesRule(Garment.SWEATER, ClothesRule.TemperatureBelow(18.0)),
         )
         val out = subject(forecast(min = 12.0, max = 16.0), rules)
-        out.rules.map { it.item }.shouldContainExactly("sweater", "sweater")
+        out.rules.map { it.item.itemKey }.shouldContainExactly("sweater", "sweater")
         out.items.shouldContainExactly("sweater", "pants")
     }
 
@@ -286,11 +216,11 @@ class EvaluateClothesRulesTest {
         // and a thin-jacket rule). Thin-jacket leads the MID priority order,
         // so it's the one that shows up in the outfit.
         val rules = listOf(
-            ClothesRule("sweater", ClothesRule.TemperatureBelow(18.0)),
-            ClothesRule("thin-jacket", ClothesRule.TemperatureBelow(20.0)),
+            ClothesRule(Garment.SWEATER, ClothesRule.TemperatureBelow(18.0)),
+            ClothesRule(Garment.THIN_JACKET, ClothesRule.TemperatureBelow(20.0)),
         )
         val out = subject(forecast(min = 14.0, max = 17.0), rules)
-        out.rules.map { it.item }.shouldContainExactly("sweater", "thin-jacket")
+        out.rules.map { it.item.itemKey }.shouldContainExactly("sweater", "thin-jacket")
         out.items.shouldContainExactly("thin-jacket", "pants")
     }
 
@@ -302,11 +232,11 @@ class EvaluateClothesRulesTest {
         // icon (already picked shorts via OutfitSuggestion.fromForecast).
         // Now: the warmer / more exposed garment wins, matching the icon.
         val rules = listOf(
-            ClothesRule("shorts", ClothesRule.TemperatureAbove(24.0)),
-            ClothesRule("jeans", ClothesRule.TemperatureAbove(18.0)),
+            ClothesRule(Garment.SHORTS, ClothesRule.TemperatureAbove(24.0)),
+            ClothesRule(Garment.JEANS, ClothesRule.TemperatureAbove(18.0)),
         )
         val out = subject(forecast(min = 20.0, max = 26.0), rules)
-        out.rules.map { it.item }.shouldContainExactly("shorts", "jeans")
+        out.rules.map { it.item.itemKey }.shouldContainExactly("shorts", "jeans")
         out.items.shouldContainExactly("t-shirt", "shorts")
     }
 
@@ -317,11 +247,11 @@ class EvaluateClothesRulesTest {
         // both fire on a warm day, the mini wins on both the home-screen
         // icon and in the prose.
         val rules = listOf(
-            ClothesRule("short-skirt", ClothesRule.TemperatureAbove(22.0)),
-            ClothesRule("skirt", ClothesRule.TemperatureAbove(16.0)),
+            ClothesRule(Garment.SHORT_SKIRT, ClothesRule.TemperatureAbove(22.0)),
+            ClothesRule(Garment.SKIRT, ClothesRule.TemperatureAbove(16.0)),
         )
         val out = subject(forecast(min = 18.0, max = 25.0), rules)
-        out.rules.map { it.item }.shouldContainExactly("short-skirt", "skirt")
+        out.rules.map { it.item.itemKey }.shouldContainExactly("short-skirt", "skirt")
         out.items.shouldContainExactly("t-shirt", "short-skirt")
     }
 
@@ -331,7 +261,7 @@ class EvaluateClothesRulesTest {
         // items alongside the top default. Regression net for the
         // bottom-reduction code path: a single bottom shouldn't accidentally
         // get dropped.
-        val rules = listOf(ClothesRule("jeans", ClothesRule.TemperatureAbove(18.0)))
+        val rules = listOf(ClothesRule(Garment.JEANS, ClothesRule.TemperatureAbove(18.0)))
         val out = subject(forecast(min = 18.0, max = 22.0), rules)
         out.items.shouldContainExactly("t-shirt", "jeans")
     }
@@ -341,11 +271,11 @@ class EvaluateClothesRulesTest {
         // Same as before — the user picks presentation order via input order
         // of their threshold rules.
         val rules = listOf(
-            ClothesRule("umbrella", ClothesRule.PrecipitationProbabilityAbove(50.0)),
-            ClothesRule("sweater", ClothesRule.TemperatureBelow(18.0)),
-            ClothesRule("jacket", ClothesRule.TemperatureBelow(12.0)),
+            ClothesRule(Garment.JEANS, ClothesRule.TemperatureBelow(20.0)),
+            ClothesRule(Garment.SWEATER, ClothesRule.TemperatureBelow(18.0)),
+            ClothesRule(Garment.JACKET, ClothesRule.TemperatureBelow(12.0)),
         )
         val out = subject(forecast(min = 5.0, max = 12.0, precip = 80.0), rules)
-        out.rules.map { it.item }.shouldContainExactly("umbrella", "sweater", "jacket")
+        out.rules.map { it.item.itemKey }.shouldContainExactly("jeans", "sweater", "jacket")
     }
 }

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsightTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsightTest.kt
@@ -14,6 +14,7 @@ import app.clothescast.core.domain.model.DeliveryMode
 import app.clothescast.core.domain.model.DeltaClause
 import app.clothescast.core.domain.model.DistanceUnit
 import app.clothescast.core.domain.model.EventKind
+import app.clothescast.core.domain.model.Garment
 import app.clothescast.core.domain.model.ForecastPeriod
 import app.clothescast.core.domain.model.HourlyForecast
 import app.clothescast.core.domain.model.Location
@@ -317,9 +318,9 @@ class GenerateDailyInsightTest {
             precipitationProbabilityMaxPct = 10.0,
         )
         val rules = listOf(
-            ClothesRule("t-shirt", ClothesRule.TemperatureBelow(30.0)),
-            ClothesRule("sweater", ClothesRule.TemperatureBelow(18.0)),
-            ClothesRule("jeans", ClothesRule.TemperatureBelow(20.0)),
+            ClothesRule(Garment.TSHIRT, ClothesRule.TemperatureBelow(30.0)),
+            ClothesRule(Garment.SWEATER, ClothesRule.TemperatureBelow(18.0)),
+            ClothesRule(Garment.JEANS, ClothesRule.TemperatureBelow(20.0)),
         )
         val weather = FakeWeatherRepository(ForecastBundle(coldToday, yesterday))
         val subject = GenerateDailyInsight(weather, clock = clock)
@@ -845,7 +846,7 @@ class GenerateDailyInsightTest {
         // Only-the-jacket rule isolates the assertion: with no other rule
         // triggering, todayItems is empty and evening items = [jacket] —
         // not a subset of today's, so the tie-in is not suppressed.
-        val jacketOnly = listOf(ClothesRule("jacket", ClothesRule.TemperatureBelow(12.0)))
+        val jacketOnly = listOf(ClothesRule(Garment.JACKET, ClothesRule.TemperatureBelow(12.0)))
         val result = subject(
             location = london,
             prefs = prefs.copy(
@@ -914,7 +915,7 @@ class GenerateDailyInsightTest {
         val calendar = FakeCalendarEventReader(events = listOf(diner))
         val subject = GenerateDailyInsight(weather, calendarEventReader = calendar, clock = clock)
 
-        val jacketOnly = listOf(ClothesRule("jacket", ClothesRule.TemperatureBelow(12.0)))
+        val jacketOnly = listOf(ClothesRule(Garment.JACKET, ClothesRule.TemperatureBelow(12.0)))
         val result = subject(
             location = london,
             prefs = prefs.copy(
@@ -957,7 +958,7 @@ class GenerateDailyInsightTest {
         val calendar = FakeCalendarEventReader(events = listOf(unlocated))
         val subject = GenerateDailyInsight(weather, calendarEventReader = calendar, clock = clock)
 
-        val jacketOnly = listOf(ClothesRule("jacket", ClothesRule.TemperatureBelow(12.0)))
+        val jacketOnly = listOf(ClothesRule(Garment.JACKET, ClothesRule.TemperatureBelow(12.0)))
         val result = subject(
             location = london,
             prefs = prefs.copy(
@@ -1000,7 +1001,7 @@ class GenerateDailyInsightTest {
         val calendar = FakeCalendarEventReader(events = listOf(diner))
         val subject = GenerateDailyInsight(weather, calendarEventReader = calendar, clock = clock)
 
-        val jacketOnly = listOf(ClothesRule("jacket", ClothesRule.TemperatureBelow(12.0)))
+        val jacketOnly = listOf(ClothesRule(Garment.JACKET, ClothesRule.TemperatureBelow(12.0)))
         val result = subject(
             location = london,
             prefs = prefs.copy(
@@ -1048,8 +1049,8 @@ class GenerateDailyInsightTest {
         val subject = GenerateDailyInsight(weather, calendarEventReader = calendar, clock = clock)
 
         val rules = listOf(
-            ClothesRule("sweater", ClothesRule.TemperatureBelow(18.0)),
-            ClothesRule("jacket", ClothesRule.TemperatureBelow(12.0)),
+            ClothesRule(Garment.SWEATER, ClothesRule.TemperatureBelow(18.0)),
+            ClothesRule(Garment.JACKET, ClothesRule.TemperatureBelow(12.0)),
         )
         val result = subject(
             location = london,
@@ -1103,9 +1104,9 @@ class GenerateDailyInsightTest {
         val subject = GenerateDailyInsight(weather, calendarEventReader = calendar, clock = clock)
 
         val rules = listOf(
-            ClothesRule("sweater", ClothesRule.TemperatureBelow(18.0)),
-            ClothesRule("jeans", ClothesRule.TemperatureBelow(20.0)),
-            ClothesRule("shorts", ClothesRule.TemperatureAbove(24.0)),
+            ClothesRule(Garment.SWEATER, ClothesRule.TemperatureBelow(18.0)),
+            ClothesRule(Garment.JEANS, ClothesRule.TemperatureBelow(20.0)),
+            ClothesRule(Garment.SHORTS, ClothesRule.TemperatureAbove(24.0)),
         )
         val result = subject(
             location = london,
@@ -1153,7 +1154,7 @@ class GenerateDailyInsightTest {
         val calendar = FakeCalendarEventReader(events = listOf(diner))
         val subject = GenerateDailyInsight(weather, calendarEventReader = calendar, clock = clock)
 
-        val jacketOnly = listOf(ClothesRule("jacket", ClothesRule.TemperatureBelow(12.0)))
+        val jacketOnly = listOf(ClothesRule(Garment.JACKET, ClothesRule.TemperatureBelow(12.0)))
         val result = subject(
             location = london,
             prefs = prefs.copy(
@@ -1197,7 +1198,7 @@ class GenerateDailyInsightTest {
         val calendar = FakeCalendarEventReader(events = listOf(diner))
         val subject = GenerateDailyInsight(weather, calendarEventReader = calendar, clock = clock)
 
-        val jacketOnly = listOf(ClothesRule("jacket", ClothesRule.TemperatureBelow(12.0)))
+        val jacketOnly = listOf(ClothesRule(Garment.JACKET, ClothesRule.TemperatureBelow(12.0)))
         val result = subject(
             location = london,
             prefs = prefs.copy(
@@ -1244,7 +1245,7 @@ class GenerateDailyInsightTest {
         val calendar = FakeCalendarEventReader(events = listOf(diner))
         val subject = GenerateDailyInsight(weather, calendarEventReader = calendar, clock = clock)
 
-        val sweaterRule = listOf(ClothesRule("sweater", ClothesRule.TemperatureBelow(18.0)))
+        val sweaterRule = listOf(ClothesRule(Garment.SWEATER, ClothesRule.TemperatureBelow(18.0)))
         val result = subject(
             location = london,
             prefs = prefs.copy(
@@ -1292,7 +1293,7 @@ class GenerateDailyInsightTest {
         val calendar = FakeCalendarEventReader(events = listOf(diner))
         val subject = GenerateDailyInsight(weather, calendarEventReader = calendar, clock = clock)
 
-        val tshirtRule = listOf(ClothesRule("t-shirt", ClothesRule.TemperatureAbove(20.0)))
+        val tshirtRule = listOf(ClothesRule(Garment.TSHIRT, ClothesRule.TemperatureAbove(20.0)))
         val result = subject(
             location = london,
             prefs = prefs.copy(
@@ -1341,7 +1342,7 @@ class GenerateDailyInsightTest {
         val calendar = FakeCalendarEventReader(events = listOf(diner))
         val subject = GenerateDailyInsight(weather, calendarEventReader = calendar, clock = clock)
 
-        val jacketRule = listOf(ClothesRule("jacket", ClothesRule.TemperatureBelow(12.0)))
+        val jacketRule = listOf(ClothesRule(Garment.JACKET, ClothesRule.TemperatureBelow(12.0)))
         val result = subject(
             location = london,
             prefs = prefs.copy(
@@ -1390,7 +1391,7 @@ class GenerateDailyInsightTest {
         val calendar = FakeCalendarEventReader(events = listOf(diner))
         val subject = GenerateDailyInsight(weather, calendarEventReader = calendar, clock = clock)
 
-        val sweaterRule = listOf(ClothesRule("sweater", ClothesRule.TemperatureBelow(18.0)))
+        val sweaterRule = listOf(ClothesRule(Garment.SWEATER, ClothesRule.TemperatureBelow(18.0)))
         val result = subject(
             location = london,
             prefs = prefs.copy(
@@ -1435,7 +1436,7 @@ class GenerateDailyInsightTest {
         val calendar = FakeCalendarEventReader(events = listOf(diner))
         val subject = GenerateDailyInsight(weather, calendarEventReader = calendar, clock = clock)
 
-        val shortsRule = listOf(ClothesRule("shorts", ClothesRule.TemperatureAbove(24.0)))
+        val shortsRule = listOf(ClothesRule(Garment.SHORTS, ClothesRule.TemperatureAbove(24.0)))
         val result = subject(
             location = london,
             prefs = prefs.copy(
@@ -1483,8 +1484,8 @@ class GenerateDailyInsightTest {
         val subject = GenerateDailyInsight(weather, calendarEventReader = calendar, clock = clock)
 
         val rules = listOf(
-            ClothesRule("sweater", ClothesRule.TemperatureBelow(18.0)),
-            ClothesRule("jacket", ClothesRule.TemperatureBelow(12.0)),
+            ClothesRule(Garment.SWEATER, ClothesRule.TemperatureBelow(18.0)),
+            ClothesRule(Garment.JACKET, ClothesRule.TemperatureBelow(12.0)),
         )
         val result = subject(
             location = london,
@@ -1502,7 +1503,7 @@ class GenerateDailyInsightTest {
     }
 
     @Test
-    fun `evening tie-in canonicalizes legacy aliases so trousers and pants don't cross-fire`() = runTest {
+    fun `evening tie-in stays silent when a bottom rule matches the default garment`() = runTest {
         // Codex-flagged: a legacy rule item like "trousers" (a recognized
         // Garment alias for PANTS) shouldn't surface as different from the
         // night's default "pants" — the user is already wearing the same
@@ -1532,9 +1533,8 @@ class GenerateDailyInsightTest {
         val calendar = FakeCalendarEventReader(events = listOf(diner))
         val subject = GenerateDailyInsight(weather, calendarEventReader = calendar, clock = clock)
 
-        // A legacy free-form rule typed as "trousers" — recognized by
-        // Garment.fromKey as PANTS but stored verbatim on disk.
-        val rules = listOf(ClothesRule("trousers", ClothesRule.TemperatureBelow(20.0)))
+        // A PANTS rule whose garment is the same as the bottom default.
+        val rules = listOf(ClothesRule(Garment.PANTS, ClothesRule.TemperatureBelow(20.0)))
         val result = subject(
             location = london,
             prefs = prefs.copy(
@@ -1545,8 +1545,8 @@ class GenerateDailyInsightTest {
             period = ForecastPeriod.TODAY,
         )
 
-        // The day fires "trousers" (PANTS), night defaults to "pants"
-        // (PANTS). Same garment — no tie-in should emit "Bring pants."
+        // The day fires the PANTS rule, night defaults to PANTS too. Same
+        // garment — no tie-in should emit "Bring pants."
         result.insight.summary.eveningEventTieIn.shouldBeNull()
     }
 
@@ -1948,8 +1948,8 @@ class GenerateDailyInsightTest {
         // No precip-keyed rule on the books — only temperature rules, none
         // of which trigger on a mild evening.
         val tempOnly = listOf(
-            ClothesRule("jacket", ClothesRule.TemperatureBelow(12.0)),
-            ClothesRule("coat", ClothesRule.TemperatureBelow(6.0)),
+            ClothesRule(Garment.JACKET, ClothesRule.TemperatureBelow(12.0)),
+            ClothesRule(Garment.COAT, ClothesRule.TemperatureBelow(6.0)),
         )
         val result = subject(
             location = london,


### PR DESCRIPTION
## What

First foundation step for broadening the clothing catalog: `ClothesRule.item` was a free-form `String`; the editor has long picked only from the fixed `Garment` catalog, so the domain type now matches — **`item` is a typed `Garment`**.

This is `TODO(rules-redesign)` point 1. It removes the scattered `Garment.fromKey(item)` lookups (and the null/unclassified handling they guarded) throughout the resolution pipeline: every rule now has a known slot, so the evaluator, layer reducer, fallback ranges, and outfit tiers compare garments directly.

## Legacy data: strict typing, drop on load

Per discussion, `item` is a **strict `Garment`** (no escape hatch). The on-disk JSON still stores the garment key for stability:
- `ClothesRuleDto.toDomain()` resolves the key via `Garment.fromKey` (which still folds legacy spellings / case / whitespace, e.g. `"trousers"`/`"Jacket"`) and returns `null` for any key not in the catalog.
- `SettingsRepository` **drops** those nulls on load — a legacy free-form rule (e.g. an old `"cardigan"`) is silently discarded rather than kept as an untyped string.
- Alias/case canonicalization now happens once, at the persistence boundary, instead of being re-derived in the evaluator / icon picker / tie-in.

## Dead-code removal (folded in)

While migrating the tests, the `adjustClothesRuleThreshold` chain turned out to be orphaned — commit `17b895d8` ("…drop the parallel Thresholds knob") removed the rationale dialog's ±1° control (it now just links to Settings → Clothes), leaving the whole read-modify-write path with no callers. Removed:
- `SettingsRepository.adjustClothesRuleThreshold` + the private `adjustOrAddTemperatureRule` / `clampThreshold` helpers
- `TodayViewModel.adjustClothesRuleThreshold` wrapper
- the now-unused `ClothesRule.withThresholdC` domain extension
- their tests

(`Fact.ruleItem` is still live — it keys the rationale's live-threshold *display* at `TodayScreen`, no mutation.)

## Behaviour changes

- Legacy free-form rules from before the catalog (and any precip rule keyed on a non-garment like `"umbrella"`) no longer round-trip — they're dropped on load. New rules are always catalog garments (the editor enforces this), so this only affects very old stored data. Wet-weather umbrellas are a separate `RainAccessory` concern, unaffected.
- `EvaluateClothesRules` loses its `hasUnclassifiedGarmentRule` branch — unclassified items can't exist anymore, so the "suppress both fallbacks for an unknown garment" path is gone (it only ever fired for dropped legacy data).

## Tests

- ~90 fixtures migrated from `ClothesRule("sweater", …)` to `ClothesRule(Garment.SWEATER, …)`; `.item` assertions compare `.item.itemKey`.
- Deleted tests that exercised now-impossible states (domain-level alias canonicalization, unclassified-temperature/precip-accessory rules) — that behaviour moved to the DTO boundary by design.
- Added `legacy free-form rules are dropped on load` (`SettingsRepositoryTest`) covering the new drop behaviour.
- `:core:domain:test`, `:core:data:test`, `:app:testDebugUnitTest` (incl. Roborazzi snapshots), `:app:assembleDebug` all green locally (snapshot bot confirms no pixel changes).

## Follow-ups (unchanged, still tracked)

`TODO(rules-redesign)` now covers only catalog-broadening (headwear/gloves/footwear/rain gear, gated on the deferred display-model decision) + a user-defined path. `TODO(catalog-warmth)` (coat-vs-puffer warmth) is independent.

https://claude.ai/code/session_01VXwdXGVTmemr6QiP85iDHu