### PR TITLE
test: guard every Garment resolves a localized label

### DIFF
--- a/app/src/test/kotlin/app/clothescast/insight/GarmentLabelResolutionTest.kt
+++ b/app/src/test/kotlin/app/clothescast/insight/GarmentLabelResolutionTest.kt
@@ -1,0 +1,36 @@
+package app.clothescast.insight
+
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import app.clothescast.core.domain.model.Garment
+import io.kotest.matchers.collections.shouldBeEmpty
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Exhaustiveness guard for the hand-maintained garment → label wiring.
+ *
+ * [GARMENT_RES_IDS] in [ClothesPhraser] is a manual `Map<Garment, Int>`, and
+ * [localizedGarmentLabel] returns null for any garment missing from it — at which
+ * point the phraser silently falls back to the raw English item key in otherwise
+ * localized prose. That's exactly the bug PR #812 shipped (gloves was absent from
+ * the map even though its `garment_gloves` strings existed), so this test drives
+ * the check off [Garment.entries]: the next garment that skips the map fails here
+ * rather than reaching users as a stray English word. Runs under Robolectric so it
+ * resolves real `R.string.*` resources, not a hand-rolled copy.
+ */
+@RunWith(AndroidJUnit4::class)
+class GarmentLabelResolutionTest {
+    private val resources =
+        ApplicationProvider.getApplicationContext<android.content.Context>().resources
+
+    @Test
+    fun `every Garment resolves to a non-blank localized label`() {
+        val unresolved = Garment.entries.filter {
+            resources.localizedGarmentLabel(it.itemKey).isNullOrBlank()
+        }
+        // A non-empty list names the garment(s) missing from GARMENT_RES_IDS (or
+        // whose garment_* string is blank) — add the mapping / resource for each.
+        unresolved.shouldBeEmpty()
+    }
+}


### PR DESCRIPTION
## What

Adds a `Garment.entries`-driven exhaustiveness test so a new garment can't silently skip the hand-maintained `GARMENT_RES_IDS` map in `ClothesPhraser`.

## Why

`GARMENT_RES_IDS` is a manual `Map<Garment, Int>`, and `localizedGarmentLabel` returns `null` for any garment missing from it — at which point the phraser falls back to the **raw English item key** in otherwise-localized prose. That's exactly the regression #812 shipped: the `garment_gloves` strings existed in every locale, but the map entry didn't, so non-English freezing-day casts read a stray English "gloves". Codex caught it in review; nothing in the build would have.

This was the same failure mode (a new garment missing from a hand-maintained parallel structure) that bit #812 more than once. The `garmentLabelRes` `when` in settings is already compiler-guarded by exhaustiveness; the phraser map is the unguarded one, so this closes that gap.

## How

The test drives off `Garment.entries` through the **real public path** (`localizedGarmentLabel(garment.itemKey)`) rather than poking the private map, so it also catches a present-but-blank string resource. A non-empty result names the offending garment(s). Runs under Robolectric to resolve real `R.string.*` resources.

## Scope

Test-only (one new file under `src/test/`) — `test:` subject prefix, so CI filters it from the Play "What's new". No production code changes.

## Test plan

`:app:testDebugUnitTest --tests "*GarmentLabelResolutionTest"` — green (all 15 garments resolve, incl. gloves). The check would have failed on the pre-fix #812 state where gloves was absent from the map.

https://claude.ai/code/session_01VXwdXGVTmemr6QiP85iDHu

---
_Generated by [Claude Code](https://claude.ai/code/session_01VXwdXGVTmemr6QiP85iDHu)_