### PR TITLE
Show smart-home and cast delivery failures as a dismissible banner

### DIFF
--- a/app/src/main/kotlin/app/clothescast/data/SettingsRepository.kt
+++ b/app/src/main/kotlin/app/clothescast/data/SettingsRepository.kt
@@ -499,6 +499,8 @@ class SettingsRepository(
         val recordedAtMs: Long,
         val lastPublishedAtMs: Long = 0L,
         val lastFetchedAtMs: Long = 0L,
+        /** Mirrors [MqttPublishStatus.dismissedAtMs] for the cast destination. */
+        val dismissedAtMs: Long = 0L,
     )
 
     /** Null until the first cast attempt is recorded; thereafter always non-null. */
@@ -509,6 +511,7 @@ class SettingsRepository(
             recordedAtMs = ms,
             lastPublishedAtMs = prefs[CAST_LAST_PUBLISHED_AT_MS] ?: 0L,
             lastFetchedAtMs = prefs[CAST_LAST_FETCHED_AT_MS] ?: 0L,
+            dismissedAtMs = prefs[CAST_ERROR_DISMISSED_AT_MS] ?: 0L,
         )
     }
 
@@ -583,6 +586,15 @@ class SettingsRepository(
         val errorMessage: String?,
         val recordedAtMs: Long,
         val lastSuccessAtMs: Long = 0L,
+        /**
+         * Epoch-ms of the most recent error the user dismissed from the Today
+         * banner (0 = none dismissed). The banner hides while
+         * [recordedAtMs] <= [dismissedAtMs]; a strictly-newer failure
+         * ([recordedAtMs] > [dismissedAtMs]) shows again. Lets a user clear a
+         * stale failure that no scheduled run will ever retry, without
+         * suppressing a genuinely new one.
+         */
+        val dismissedAtMs: Long = 0L,
     )
 
     /**
@@ -597,6 +609,7 @@ class SettingsRepository(
             errorMessage = msg,
             recordedAtMs = ms,
             lastSuccessAtMs = prefs[MQTT_LAST_SUCCESS_AT_MS] ?: 0L,
+            dismissedAtMs = prefs[MQTT_ERROR_DISMISSED_AT_MS] ?: 0L,
         )
     }
 
@@ -615,6 +628,21 @@ class SettingsRepository(
                 prefs[MQTT_LAST_SUCCESS_AT_MS] = atMs
             }
         }
+    }
+
+    /**
+     * Records that the user dismissed the current MQTT publish error from the
+     * Today banner. Pass the [recordedAtMs] of the error they saw so any
+     * strictly-newer failure still surfaces. A success ([setMqttLastError] with
+     * a null message) doesn't touch this — the banner hides on null anyway.
+     */
+    suspend fun setMqttErrorDismissedAt(atMs: Long) {
+        dataStore.edit { it[MQTT_ERROR_DISMISSED_AT_MS] = atMs }
+    }
+
+    /** Mirrors [setMqttErrorDismissedAt] for the cast destination. */
+    suspend fun setCastErrorDismissedAt(atMs: Long) {
+        dataStore.edit { it[CAST_ERROR_DISMISSED_AT_MS] = atMs }
     }
 
     /**
@@ -1281,6 +1309,7 @@ class SettingsRepository(
         private val MQTT_LAST_ERROR_MSG = stringPreferencesKey("mqtt_last_error_msg")
         private val MQTT_LAST_ERROR_AT_MS = longPreferencesKey("mqtt_last_error_at_ms")
         private val MQTT_LAST_SUCCESS_AT_MS = longPreferencesKey("mqtt_last_success_at_ms")
+        private val MQTT_ERROR_DISMISSED_AT_MS = longPreferencesKey("mqtt_error_dismissed_at_ms")
         // "Smart-home bridge speaks, mute the phone" — the MQTT mirror of
         // [CAST_SKIP_PHONE_SPEECH]. Default true on first read (mirrors the
         // data-class default).
@@ -1302,6 +1331,7 @@ class SettingsRepository(
         // receiver→phone direction.
         private val CAST_LAST_PUBLISHED_AT_MS = longPreferencesKey("cast_last_published_at_ms")
         private val CAST_LAST_FETCHED_AT_MS = longPreferencesKey("cast_last_fetched_at_ms")
+        private val CAST_ERROR_DISMISSED_AT_MS = longPreferencesKey("cast_error_dismissed_at_ms")
         // Master switch for scheduled casting + per-period cast toggles +
         // the "smart display speaks, mute the phone" suppression. Stored
         // separately from CAST_ROUTE_ID so the user's picked display

--- a/app/src/main/kotlin/app/clothescast/ui/today/SevenDayPage.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/SevenDayPage.kt
@@ -127,6 +127,8 @@ internal fun SevenDayPage(
     onDismissPlayPromoCard: () -> Unit = {},
     onOpenVoice: () -> Unit = {},
     onDismissGeminiTtsPromoCard: () -> Unit = {},
+    onDismissMqttError: () -> Unit = {},
+    onDismissCastError: () -> Unit = {},
 ) {
     // Shared display settings come from [TodayState]; the chart deck and the
     // week-ahead headline below read these locals so sourcing them from state
@@ -231,6 +233,8 @@ internal fun SevenDayPage(
         onOpenVoice = onOpenVoice,
         onDismissGeminiTtsPromoCard = onDismissGeminiTtsPromoCard,
         onNavigateToClothes = onNavigateToClothes,
+        onDismissMqttError = onDismissMqttError,
+        onDismissCastError = onDismissCastError,
     ) {
         // Page header — same visual treatment as [InsightCard] on pages 0 / 1:
         // a 20.dp-padded Card with the chevron in a 28.dp slot on the left,

--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Refresh
@@ -340,6 +341,8 @@ fun TodayScreen(
             pagerState = pagerState,
             onRefresh = { triggerRefresh(context, state.morningTime, state.tonightTime) },
             onSetUpLocation = onNavigateToLocation,
+            onDismissMqttError = viewModel::dismissMqttPublishError,
+            onDismissCastError = viewModel::dismissCastPublishError,
             onOpenPrivacy = onNavigateToPrivacy,
             onOpenCalendarSettings = onNavigateToCalendar,
             onOpenSchedule = {
@@ -388,6 +391,8 @@ private fun TodayContent(
     pagerState: PagerState,
     onRefresh: () -> Unit,
     onSetUpLocation: () -> Unit,
+    onDismissMqttError: () -> Unit,
+    onDismissCastError: () -> Unit,
     onOpenPrivacy: () -> Unit,
     onOpenCalendarSettings: () -> Unit,
     onOpenSchedule: () -> Unit,
@@ -481,6 +486,8 @@ private fun TodayContent(
                     onDismissPlayPromoCard = onDismissPlayPromoCard,
                     onOpenVoice = onOpenVoice,
                     onDismissGeminiTtsPromoCard = onDismissGeminiTtsPromoCard,
+                    onDismissMqttError = onDismissMqttError,
+                    onDismissCastError = onDismissCastError,
                     onOpenCalendarSettings = onOpenCalendarSettings,
                     onDismissCelebrationCard = onDismissCelebrationCard,
                     onSetUpLocation = onSetUpLocation,
@@ -563,6 +570,8 @@ private fun TodayContent(
                         onDismissPlayPromoCard = onDismissPlayPromoCard,
                         onOpenVoice = onOpenVoice,
                         onDismissGeminiTtsPromoCard = onDismissGeminiTtsPromoCard,
+                    onDismissMqttError = onDismissMqttError,
+                    onDismissCastError = onDismissCastError,
                     )
                     return@HorizontalPager
                 }
@@ -621,6 +630,8 @@ private fun TodayContent(
                     onDismissPlayPromoCard = onDismissPlayPromoCard,
                     onOpenVoice = onOpenVoice,
                     onDismissGeminiTtsPromoCard = onDismissGeminiTtsPromoCard,
+                    onDismissMqttError = onDismissMqttError,
+                    onDismissCastError = onDismissCastError,
                 )
             }
         }
@@ -656,6 +667,8 @@ private fun BannerStack(
     onOpenCalendarSettings: () -> Unit,
     onDismissCelebrationCard: () -> Unit,
     onSetUpLocation: () -> Unit,
+    onDismissMqttError: () -> Unit,
+    onDismissCastError: () -> Unit,
 ) {
     val bannerModifier = Modifier.fillMaxWidth()
     // Cap the setup/promo stack so a fresh user isn't buried under "set this
@@ -765,6 +778,28 @@ private fun BannerStack(
         modifier = bannerModifier,
     )
     WorkStatusBanner(status = workStatusToShow, modifier = bannerModifier)
+    // Delivery-destination failures sit just under the fetch / work-status
+    // banner: the forecast may have fetched fine, but if the cast to the
+    // smart display or the publish to the Home Assistant bridge failed, the
+    // user should see it here rather than only in Smart Home settings. Each
+    // clears itself once a later run succeeds (the worker records a null
+    // error), so no dismiss affordance is needed — same as WorkStatusBanner.
+    if (!state.mqttPublishError.isNullOrBlank()) {
+        PublishErrorBanner(
+            title = stringResource(R.string.today_mqtt_failed_title),
+            detail = state.mqttPublishError,
+            onDismiss = onDismissMqttError,
+            modifier = bannerModifier,
+        )
+    }
+    if (!state.castPublishError.isNullOrBlank()) {
+        PublishErrorBanner(
+            title = stringResource(R.string.today_cast_failed_title),
+            detail = state.castPublishError,
+            onDismiss = onDismissCastError,
+            modifier = bannerModifier,
+        )
+    }
     HolidayBanner(
         theme = state.activeHoliday,
         region = state.region,
@@ -792,6 +827,8 @@ internal fun HomePageScaffold(
     locationActionRequired: Boolean,
     outfitInsight: Insight?,
     onSetUpLocation: () -> Unit,
+    onDismissMqttError: () -> Unit,
+    onDismissCastError: () -> Unit,
     onOpenPrivacy: () -> Unit,
     onOpenCalendarSettings: () -> Unit,
     onOpenSchedule: () -> Unit,
@@ -839,6 +876,8 @@ internal fun HomePageScaffold(
                     onDismissPlayPromoCard = onDismissPlayPromoCard,
                     onOpenVoice = onOpenVoice,
                     onDismissGeminiTtsPromoCard = onDismissGeminiTtsPromoCard,
+                    onDismissMqttError = onDismissMqttError,
+                    onDismissCastError = onDismissCastError,
                     onOpenCalendarSettings = onOpenCalendarSettings,
                     onDismissCelebrationCard = onDismissCelebrationCard,
                     onSetUpLocation = onSetUpLocation,
@@ -898,6 +937,8 @@ private fun TodayPage(
     onHideModelSpread: () -> Unit,
     onLongPressDate: () -> Unit,
     onSetUpLocation: () -> Unit,
+    onDismissMqttError: () -> Unit,
+    onDismissCastError: () -> Unit,
     onOpenPrivacy: () -> Unit,
     onOpenCalendarSettings: () -> Unit,
     onOpenSchedule: () -> Unit,
@@ -930,6 +971,8 @@ private fun TodayPage(
         onOpenVoice = onOpenVoice,
         onDismissGeminiTtsPromoCard = onDismissGeminiTtsPromoCard,
         onNavigateToClothes = onNavigateToClothes,
+        onDismissMqttError = onDismissMqttError,
+        onDismissCastError = onDismissCastError,
     ) {
         if (insight == null) {
             MissingPeriodPlaceholder(
@@ -1449,6 +1492,83 @@ internal fun WorkStatusBanner(
                             )
                         }
                     }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Top-of-page error card for a failed delivery to a smart-home destination
+ * (MQTT bridge or Cast display). Styled like [WorkStatusBanner]'s failed state
+ * — error-container card, a friendly title + "we'll retry" body, and the raw
+ * failure reason tucked behind a Show details toggle so the technical string
+ * (broker error, cast load rejection) is available without dominating the card.
+ *
+ * Unlike the fetch-failure banner this one carries a dismiss (X). A delivery
+ * failure can outlive the config that would retry it — e.g. a failed on-demand
+ * Play, or the user turning the destination off afterwards — so there has to be
+ * a way to clear a failure the user has seen. Dismissal is recorded against the
+ * failure's timestamp upstream ([TodayViewModel.dismissMqttPublishError] /
+ * [TodayViewModel.dismissCastPublishError]), so a strictly-newer failure still
+ * surfaces.
+ */
+@Composable
+private fun PublishErrorBanner(
+    title: String,
+    detail: String?,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.errorContainer,
+            contentColor = MaterialTheme.colorScheme.onErrorContainer,
+        ),
+    ) {
+        Column(
+            modifier = Modifier.padding(start = 16.dp, top = 16.dp, end = 4.dp, bottom = 16.dp),
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.titleSmall,
+                    modifier = Modifier.weight(1f),
+                )
+                IconButton(onClick = onDismiss) {
+                    Icon(
+                        imageVector = Icons.Default.Close,
+                        contentDescription = stringResource(R.string.today_publish_failed_dismiss),
+                    )
+                }
+            }
+            Text(
+                text = stringResource(R.string.today_publish_failed_body),
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier.padding(end = 12.dp),
+            )
+            if (!detail.isNullOrBlank()) {
+                var showDetails by rememberSaveable(detail) { mutableStateOf(false) }
+                Text(
+                    text = stringResource(
+                        if (showDetails) R.string.today_failed_hide_details
+                        else R.string.today_failed_show_details,
+                    ),
+                    style = MaterialTheme.typography.labelMedium,
+                    modifier = Modifier
+                        .padding(top = 8.dp)
+                        .clickable { showDetails = !showDetails },
+                )
+                if (showDetails) {
+                    Text(
+                        text = detail,
+                        style = MaterialTheme.typography.bodySmall,
+                        modifier = Modifier.padding(top = 4.dp),
+                    )
                 }
             }
         }

--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayViewModel.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayViewModel.kt
@@ -207,6 +207,26 @@ data class TodayState(
      * read that wouldn't fire anyway.
      */
     val usesCalendarThemes: Boolean = false,
+    /**
+     * Human-readable reason the most recent MQTT bridge publish failed, or null
+     * when the last attempt succeeded, none has run, or the user dismissed it.
+     * The Today banner stack surfaces this as a top-of-page error card —
+     * mirroring the fetch-failure banner — so a broken Home Assistant bridge is
+     * visible without opening Smart Home settings. Shown for any failed delivery
+     * attempt (scheduled or on-demand Play); cleared the moment a later publish
+     * succeeds (the worker records a null error) or the user taps dismiss.
+     */
+    val mqttPublishError: String? = null,
+    /**
+     * [SettingsRepository.MqttPublishStatus.recordedAtMs] of the failure backing
+     * [mqttPublishError], so [TodayViewModel.dismissMqttPublishError] can mark
+     * exactly the on-screen failure as seen (and let a newer one resurface).
+     */
+    val mqttPublishErrorAt: Long = 0L,
+    /** Sibling of [mqttPublishError] for the Cast / smart-display destination. */
+    val castPublishError: String? = null,
+    /** Sibling of [mqttPublishErrorAt] for the cast destination. */
+    val castPublishErrorAt: Long = 0L,
 )
 
 sealed class WorkStatus {
@@ -343,6 +363,26 @@ internal fun mergeWorkStatus(a: WorkStatus, b: WorkStatus): WorkStatus = when {
 internal data class WorkSignals(
     val status: WorkStatus,
     val anyWorkActive: Boolean,
+)
+
+/**
+ * Per-tick bundle of the odds-and-ends signals folded into
+ * [TodayViewModel.state] so the outer combine stays at its five-flow
+ * typed-overload cap: the session-scoped model-spread toggle, the "Gemini key
+ * configured" mirror, and the latest MQTT / Cast publish-error messages (null
+ * when the last attempt succeeded or none has run yet).
+ */
+internal data class MiscSignals(
+    val showModelSpread: Boolean,
+    val geminiKeyConfigured: Boolean,
+    /** Latest MQTT publish failure to show (null when none / dismissed). */
+    val mqttError: String?,
+    /** [recordedAtMs] of the latest MQTT failure, so dismiss can mark it seen. */
+    val mqttErrorAt: Long,
+    /** Sibling of [mqttError] for the cast destination. */
+    val castError: String?,
+    /** Sibling of [mqttErrorAt] for the cast destination. */
+    val castErrorAt: Long,
 )
 
 /**
@@ -491,22 +531,46 @@ class TodayViewModel(
             }
         }
 
-    // Fuse the session-scoped spread toggle with the external "Gemini key
-    // configured" signal into one input so the outer [state] combine stays at
-    // five flows (the typed-overload cap). Both are simple booleans that only
-    // feed the final state; pairing them keeps us off the loosely-typed vararg
-    // `combine` overload.
-    private val spreadAndGeminiKey: Flow<Pair<Boolean, Boolean>> =
-        combine(showModelSpread, geminiKeyConfigured, ::Pair)
+    // Fuse the session-scoped spread toggle, the external "Gemini key
+    // configured" signal, and the latest MQTT / Cast publish-error messages
+    // into one input so the outer [state] combine stays at five flows (the
+    // typed-overload cap). The publish errors ride here so a failed cast or
+    // smart-home publish surfaces as a top-of-page banner alongside the
+    // fetch-failure card, without adding a sixth combine input.
+    private val miscSignals: Flow<MiscSignals> =
+        combine(
+            showModelSpread,
+            geminiKeyConfigured,
+            settingsRepository.mqttPublishStatus,
+            settingsRepository.castStatus,
+        ) { spread, geminiKey, mqtt, cast ->
+            // Hide an error the user has already dismissed from the banner
+            // (recordedAt <= dismissedAt); a strictly-newer failure resurfaces.
+            val mqttError = mqtt?.takeIf {
+                it.errorMessage != null && it.recordedAtMs > it.dismissedAtMs
+            }?.errorMessage
+            val castError = cast?.takeIf {
+                it.errorMessage != null && it.recordedAtMs > it.dismissedAtMs
+            }?.errorMessage
+            MiscSignals(
+                showModelSpread = spread,
+                geminiKeyConfigured = geminiKey,
+                mqttError = mqttError,
+                mqttErrorAt = mqtt?.recordedAtMs ?: 0L,
+                castError = castError,
+                castErrorAt = cast?.recordedAtMs ?: 0L,
+            )
+        }
 
     val state: StateFlow<TodayState> = combine(
         insightCache.thisPeriod,
         insightCache.nextPeriod,
         workStatusFlow,
         preferencesDateEvents,
-        spreadAndGeminiKey,
-    ) { thisPeriodSnapshot, nextPeriodSnapshot, workSignals, prefsDateEvents, spreadAndKey ->
-        val (spread, geminiKeyConfigured) = spreadAndKey
+        miscSignals,
+    ) { thisPeriodSnapshot, nextPeriodSnapshot, workSignals, prefsDateEvents, misc ->
+        val spread = misc.showModelSpread
+        val geminiKeyConfigured = misc.geminiKeyConfigured
         val (prefs, today, events) = prefsDateEvents
         // Derive each cached snapshot against the *current* prefs so a settings
         // change re-renders the prose / outfit / bullets in the same frame as
@@ -588,6 +652,21 @@ class TodayViewModel(
             geminiTtsPromoCardVisible = !prefs.geminiPromoCardDismissed && !geminiKeyConfigured,
             telemetryNoticeVisible = !prefs.telemetryNoticeAcked,
             usesCalendarThemes = prefs.calendarHolidayThemingActive || prefs.calendarBirthdayThemingActive,
+            // Surface a publish error for any failed delivery attempt — a
+            // scheduled run or an on-demand Play — regardless of the current
+            // destination config. We deliberately don't gate on whether the
+            // destination is still "live" (master toggle / host / route): a
+            // Play-button delivery is a real attempt that can fail even when no
+            // schedule would retry it, and a later config change that stops
+            // future attempts shouldn't silently bury a failure the user hasn't
+            // seen. Instead the banner carries a dismiss action; [miscSignals]
+            // filters out an error the user dismissed, and a strictly-newer
+            // failure resurfaces. The *At fields ride along so dismiss knows
+            // which failure was on screen.
+            mqttPublishError = misc.mqttError,
+            mqttPublishErrorAt = misc.mqttErrorAt,
+            castPublishError = misc.castError,
+            castPublishErrorAt = misc.castErrorAt,
         )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), TodayState())
 
@@ -664,6 +743,28 @@ class TodayViewModel(
     fun notifyCalendarPermissionChanged() {
         viewModelScope.launch {
             settingsRepository.markCalendarPermissionRechecked()
+        }
+    }
+
+    /**
+     * Records that the user dismissed the MQTT publish-error banner. Marks the
+     * on-screen failure ([TodayState.mqttPublishErrorAt]) as seen so it hides;
+     * a strictly-newer failure resurfaces. No-op when nothing is shown.
+     */
+    fun dismissMqttPublishError() {
+        val at = state.value.mqttPublishErrorAt
+        if (at <= 0L) return
+        viewModelScope.launch {
+            settingsRepository.setMqttErrorDismissedAt(at)
+        }
+    }
+
+    /** Mirrors [dismissMqttPublishError] for the cast banner. */
+    fun dismissCastPublishError() {
+        val at = state.value.castPublishErrorAt
+        if (at <= 0L) return
+        viewModelScope.launch {
+            settingsRepository.setCastErrorDismissedAt(at)
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -307,6 +307,12 @@
     <string name="today_failed_no_location">We couldn\'t get your location. Grant always-on location permission, or set a city in Settings.</string>
     <string name="today_failed_show_details">Show details</string>
     <string name="today_failed_hide_details">Hide details</string>
+    <!-- Top-of-page banners shown when a forecast was fetched but couldn't be
+         delivered to a smart-home destination. -->
+    <string name="today_mqtt_failed_title">Couldn\'t send to your smart home</string>
+    <string name="today_cast_failed_title">Couldn\'t cast to your display</string>
+    <string name="today_publish_failed_body">We\'ll try again on the next update.</string>
+    <string name="today_publish_failed_dismiss">Dismiss</string>
 
     <string name="today_location_required_title">Set up your location</string>
     <string name="today_location_required_body">ClothesCast needs to know where you are to fetch the forecast. Grant always-on location permission, or pick a city.</string>


### PR DESCRIPTION
## What

When a scheduled run **or an on-demand Play** fetches the forecast fine but then fails to publish to the Home Assistant MQTT bridge or cast to a smart display, surface it the same way fetch failures already are: an **error card at the top of the Today / Tonight / 7-day pages**, in the shared `BannerStack`, with the raw broker / cast reason behind a **Show details** toggle.

The banner:
- Shows for **any failed delivery attempt**, regardless of the current destination config.
- Carries a **dismiss (X)**.
- Clears automatically when a later publish succeeds (the worker already records a `null` error on success).

## Why a dismiss button instead of config-gating

A delivery failure can outlive the config that would retry it — a failed on-demand Play, or the user turning the destination off afterwards. Earlier revisions gated the banner on whether the destination was still "live" (master toggle / host / route / period toggle), but that's the wrong tool: a Play-button delivery is a real attempt that can fail even when no schedule would retry it, and gating it away would silently bury a failure the user hasn't seen.

So instead the banner is **always shown for a real failure** and the user can dismiss it. Dismissal is recorded against the failure's timestamp (`dismissedAtMs`), so:
- A **strictly-newer** failure resurfaces (`recordedAtMs > dismissedAtMs`).
- A dismissed failure stays gone across app restarts (persisted in DataStore).

This resolves the "stale error shouts forever" concern from the Codex reviews without the brittle config-gating.

## How

- `TodayViewModel` folds the existing `SettingsRepository.mqttPublishStatus` / `castStatus` flows into the `state` combine (bundled with the model-spread + Gemini-key signals as `MiscSignals` so the outer combine stays at its five-flow cap). The dismissal filter lives in `miscSignals`.
- New `mqttPublishError` / `mqttPublishErrorAt` / `castPublishError` / `castPublishErrorAt` fields on `TodayState`; `dismissMqttPublishError()` / `dismissCastPublishError()` on the ViewModel.
- `SettingsRepository` gains per-destination `mqtt_error_dismissed_at_ms` / `cast_error_dismissed_at_ms` timestamps + setters, threaded through `MqttPublishStatus.dismissedAtMs` / `CastStatus.dismissedAtMs`.
- New private `PublishErrorBanner` composable in `TodayScreen.kt` (error-container card + dismiss X + Show details toggle), wired through `TodayContent` → `HomePageScaffold` / `SevenDayPage` → `BannerStack`.
- Strings: `today_mqtt_failed_title`, `today_cast_failed_title`, `today_publish_failed_body`, `today_publish_failed_dismiss`.

## Privacy

No change to what leaves the device. The error strings come from the local MQTT / Cast layers (broker connection errors, cast load rejections) and were already persisted on-device and shown in Smart Home settings; this only relocates that existing on-device text to a more visible surface.

## Test plan

- `./gradlew :core:domain:test :core:data:test :app:testDebugUnitTest` — green
- `./gradlew :app:assembleDebug` — green
- Banners are additive `TodayState` fields with `null` defaults, so existing previews/snapshots render unchanged.

https://claude.ai/code/session_01BCdgkSPetCxDH6xYP5Wddn