### PR TITLE
test: guard every default category has a snapshot delta field

### DIFF
--- a/app/src/test/kotlin/app/clothescast/diag/ClothesRulesSnapshotTest.kt
+++ b/app/src/test/kotlin/app/clothescast/diag/ClothesRulesSnapshotTest.kt
@@ -151,4 +151,30 @@ class ClothesRulesSnapshotTest {
 
         snap.categoriesCustomised shouldBe "jacket,shorts"
     }
+
+    @Test
+    fun `every default category is wired to its own delta field`() {
+        // [ClothesRulesSnapshot.from] builds perCategory from all of
+        // [ClothesRule.DEFAULTS], so a new default feeds customisedCount /
+        // categoriesCustomised automatically — but each `*DeltaC` field is
+        // hand-listed, so a new default with no matching field is silently
+        // unmeasurable in Firebase (exactly the gloves gap in #812). Guard the
+        // two against drift: there must be one delta field per default, and for
+        // an unmodified default list every one must read "0" (proving the field
+        // is wired to its category, not stuck on the MISSING fallback through a
+        // typo'd key). Fields are read via Java reflection — no kotlin-reflect
+        // dependency needed — so this stays a plain JVM test.
+        val snap = ClothesRulesSnapshot.from(ClothesRule.DEFAULTS)
+        val deltaFields = ClothesRulesSnapshot::class.java.declaredFields
+            .filter { it.name.endsWith("DeltaC") }
+            .onEach { it.isAccessible = true }
+
+        // One delta field per shipped default — adding a default without its
+        // field (or vice versa) trips this.
+        deltaFields.size shouldBe ClothesRule.DEFAULTS.size
+        // Each wired field resolves its category for a pure-default list.
+        deltaFields.forEach { field ->
+            field.get(snap) shouldBe "0"
+        }
+    }
 }


### PR DESCRIPTION
## What

Adds a guard so a new `ClothesRule.DEFAULTS` garment can't be added without its corresponding `*DeltaC` field in `ClothesRulesSnapshot`.

## Why

`ClothesRulesSnapshot.from` builds `perCategory` from **all** of `DEFAULTS`, so a new default automatically feeds `customisedCount` / `categoriesCustomised` / `allDefaults`. But the per-category `sweaterDeltaC` / `jacketDeltaC` / … fields are **hand-listed**, so a new default with no matching field is silently unmeasurable in Firebase — analytics would report the category as customised without ever emitting its delta.

That was the *second* hand-maintained-parallel-structure gap in the gloves work (#812): gloves fed the counts but had no `glovesDeltaC` until review caught it. This is the sibling of #813 (which guarded the phraser's `GARMENT_RES_IDS` map) — same failure mode, the other unguarded structure.

## How

Drives off `ClothesRule.DEFAULTS`:
- **One delta field per default** — `declaredFields` ending in `DeltaC` must number `DEFAULTS.size`. Adding a default without its field (or vice versa) trips this.
- **Each field reads `"0"` for an unmodified default list** — proves the field is actually wired to its category rather than stuck on the `MISSING` fallback via a typo'd `perCategory[...]` key.

Fields are read via **Java reflection** (`declaredFields`), so no `kotlin-reflect` dependency is added — stays a plain JVM test.

## Scope

Test-only (one method appended to `ClothesRulesSnapshotTest`) — `test:` subject prefix, filtered from the Play "What's new". No production change.

## Test plan

`:app:testDebugUnitTest --tests "*ClothesRulesSnapshotTest"` — green. Counts are currently 5 fields / 5 defaults, so the assertion is meaningful (not `0 == 0`).

https://claude.ai/code/session_01VXwdXGVTmemr6QiP85iDHu

---
_Generated by [Claude Code](https://claude.ai/code/session_01VXwdXGVTmemr6QiP85iDHu)_