### PR TITLE
internal: add an optional gloves slot to the outfit suggestion

### DIFF
--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/OutfitSuggestion.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/OutfitSuggestion.kt
@@ -3,9 +3,9 @@ package app.clothescast.core.domain.model
 import java.time.LocalTime
 
 /**
- * A glanceable two-piece outfit pairing — one [Top] and one [Bottom] — derived from the
- * forecast so the home screen can render two big icons instead of a comma-separated word
- * list.
+ * A glanceable outfit pairing — one [Top] and one [Bottom], plus an optional [Hands]
+ * accessory — derived from the forecast so the home screen can render big icons instead
+ * of a comma-separated word list.
  *
  * The picker is driven entirely by the user's [ClothesRule] list — the same rules that
  * populate [Insight.recommendedItems]. Top tier (coldest first): a firing `jacket` rule
@@ -23,13 +23,26 @@ import java.time.LocalTime
  * card lets the user point each fallback at any catalog garment so the home-screen
  * icon matches what they actually wear when no rule fires.
  *
+ * [hands] is the odd one out: it is **nullable and has no default**. Unlike a top or a
+ * bottom — which the user always wears, so an uncovered slot falls through to a sensible
+ * default icon — extremity gear is opt-in. A firing `gloves` rule sets [hands] to
+ * [Hands.GLOVES]; with no firing hands rule it stays null and no glove icon is shown.
+ * That mirrors the prose, which surfaces gloves only as an "extra cold" escalation and
+ * never recommends an accessory the user didn't ask for (see the comment on
+ * [ClothesRule.DEFAULTS]).
+ *
  * Rule conditions are checked against feels-like temperatures (wind chill / humidity
  * adjusted) — that's what people experience on the way out the door, and it's already
  * what [ClothesRule.appliesTo] does.
+ *
+ * Note: [hands] is computed here today but the icon render surfaces (home-screen card,
+ * widget, Nest-Hub cast card) still draw only [top] + [bottom]; wiring the glove icon
+ * into those surfaces is a follow-up.
  */
 data class OutfitSuggestion(
     val top: Top,
     val bottom: Bottom,
+    val hands: Hands? = null,
 ) {
     enum class Top {
         TSHIRT, POLO, SWEATER, THIN_JACKET, THICK_JACKET, THICK_COAT, PUFFER_JACKET;
@@ -62,6 +75,22 @@ data class OutfitSuggestion(
         }
     }
 
+    /**
+     * Optional extremity gear worn alongside the top/bottom stack — today just
+     * gloves, the `Garment.Slot.HANDS` member. A single tier rather than a
+     * default-bearing slot: it's present only when a hands rule fires (see the
+     * `hands` note on [OutfitSuggestion]), so there's no "fallback hands" the
+     * way there's a `defaultTop` / `defaultBottom`.
+     */
+    enum class Hands {
+        GLOVES;
+
+        /** Catalog key (matches [Garment.itemKey]) for prose / persistence. */
+        fun itemKey(): String = when (this) {
+            GLOVES -> "gloves"
+        }
+    }
+
     companion object {
         // Catalog item keys (see [Garment.itemKey]) that drive each icon tier.
         // Top tiers (coldest first): coat → THICK_COAT, puffer → PUFFER_JACKET,
@@ -88,6 +117,11 @@ data class OutfitSuggestion(
         private val SHORT_SKIRT_KEYS = listOf(Garment.SHORT_SKIRT)
         private val LONG_SKIRT_KEYS = listOf(Garment.SKIRT)
         private val JEANS_KEYS = listOf(Garment.JEANS)
+        // Hands tier: a firing `gloves` rule lights the optional glove icon.
+        // No fallback tier — uncovered hands stay null (see the `hands` note on
+        // OutfitSuggestion), so this never promotes to a default the way the top
+        // and bottom slots do.
+        private val GLOVES_KEYS = listOf(Garment.GLOVES)
 
         /**
          * Two-piece icon outfit for [forecast] given the user's [clothesRules].
@@ -155,7 +189,9 @@ data class OutfitSuggestion(
                 firingRules.hasKeyIn(JEANS_KEYS) -> Bottom.JEANS
                 else -> defaultBottom
             }
-            return OutfitSuggestion(top, bottom)
+            // Optional, no fallback: null unless a hands rule actually fired.
+            val hands = if (firingRules.hasKeyIn(GLOVES_KEYS)) Hands.GLOVES else null
+            return OutfitSuggestion(top, bottom, hands)
         }
 
         /** True when any rule in the list is keyed on a garment in [keys]. */

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/model/OutfitSuggestionTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/model/OutfitSuggestionTest.kt
@@ -442,4 +442,54 @@ class OutfitSuggestionTest {
             coatOnly,
         ).top.facts.single().ruleItem shouldBe Garment.COAT
     }
+
+    @Test
+    fun `a firing gloves rule sets the hands slot`() {
+        // The gloves default fires below 4°C: a freezing day lights the optional
+        // hands tier alongside the top/bottom pick.
+        val outfit = OutfitSuggestion.fromForecast(
+            forecast(feelsLikeMin = -2.0, feelsLikeMax = 2.0),
+            rules,
+        )
+        outfit.hands shouldBe OutfitSuggestion.Hands.GLOVES
+    }
+
+    @Test
+    fun `hands stays null when no gloves rule fires`() {
+        // Hands is opt-in with no fallback: a cool-but-not-freezing day leaves it
+        // null rather than promoting to a default the way top/bottom do, so no
+        // glove icon shows when the user hasn't earned one.
+        val outfit = OutfitSuggestion.fromForecast(
+            forecast(feelsLikeMin = 8.0, feelsLikeMax = 14.0),
+            rules,
+        )
+        outfit.hands shouldBe null
+    }
+
+    @Test
+    fun `fromTriggeredOutfit carries the hands slot from a firing gloves rule`() {
+        // The icon derives from the same TriggeredOutfit the prose uses, so a
+        // firing gloves rule has to reach the hands slot through this path too.
+        val triggered = TriggeredOutfit(
+            rules = listOf(
+                ClothesRule(Garment.COAT, ClothesRule.TemperatureBelow(5.0)),
+                ClothesRule(Garment.GLOVES, ClothesRule.TemperatureBelow(4.0)),
+            ),
+            fallbacks = emptyList(),
+        )
+        OutfitSuggestion.fromTriggeredOutfit(triggered) shouldBe OutfitSuggestion(
+            OutfitSuggestion.Top.THICK_COAT,
+            OutfitSuggestion.Bottom.LONG_PANTS,
+            OutfitSuggestion.Hands.GLOVES,
+        )
+    }
+
+    @Test
+    fun `hands itemKey round-trips through the garment catalog`() {
+        // The slot's catalog key must resolve back to the HANDS-slot garment so
+        // prose / persistence / a future glove icon all key off the same string.
+        OutfitSuggestion.Hands.entries.forEach { hands ->
+            Garment.fromKey(hands.itemKey())?.slot shouldBe Garment.Slot.HANDS
+        }
+    }
 }


### PR DESCRIPTION
## What

Adds a nullable `hands: Hands?` slot to `OutfitSuggestion` plus the picker logic and tests. This is the **domain-first** step toward rendering a gloves icon — it makes the suggestion model carry the hands tier, with the render surfaces (Today card, widget, Nest-Hub cast card) wiring it up in follow-ups.

## Why

Gloves are fully wired through the *logic and prose* — catalog (`Garment.GLOVES`, `Slot.HANDS`), a freezing-day default rule, the rule engine, the insight text ("Wear 3 layers and gloves"), localized labels, and telemetry. But `OutfitSuggestion` only modelled `top` + `bottom`, so gloves could never become a glanceable *icon*. This adds the missing slot at the source so each render surface can pick it up.

## How

- `OutfitSuggestion` gains `val hands: Hands? = null` and a `Hands { GLOVES }` tier with an `itemKey()` mirroring `Top`/`Bottom`.
- **Nullable, no fallback.** Unlike `top`/`bottom` — which fall through to a `defaultTop`/`defaultBottom` icon when no rule fires — extremity gear is opt-in: `hands` is set to `Hands.GLOVES` only when a hands rule actually fires, and stays `null` otherwise. That mirrors the prose, which surfaces gloves only as an "extra cold" escalation and never recommends an accessory the user didn't ask for (see the comment on `ClothesRule.DEFAULTS`).
- Both entry points (`fromForecast`, `fromTriggeredOutfit`) flow through `pickOutfit`, so the icon stays in step with the same matched-rule set the clothes prose uses — no second forecast walk to drift against.
- The `hands: Hands? = null` default keeps every existing `OutfitSuggestion(top, bottom)` call site (render code, snapshot tests) compiling and behaving unchanged.

## Scope

Domain + domain tests only. **No user-visible change** — the slot is computed but the icon render surfaces still draw only `top` + `bottom`, so the commit carries the `internal:` prefix (filtered from the Play "What's new"). Wiring the glove icon into the card/widget/cast surfaces — `outfitHandsDefaults` map, `handsDrawable`, a `GarmentHandsIcon`, the 2→3 icon card layout, and a Settings colour picker — is the planned follow-up.

## Test plan

`./gradlew :core:domain:test :core:data:test :app:testDebugUnitTest` — green locally against the Android SDK. New `OutfitSuggestionTest` cases cover: gloves firing sets `hands`, no firing rule leaves it `null`, `fromTriggeredOutfit` carries it too, and the `Hands` key round-trips back to a `Slot.HANDS` garment. Verified the existing full-`OutfitSuggestion` equality assertions are all non-freezing (mins ≥ 4 °C), so `hands` stays `null` and they're unaffected.

https://claude.ai/code/session_01HMjFrx4mng9MUrQ4ZDdKLX

---
_Generated by [Claude Code](https://claude.ai/code/session_01HMjFrx4mng9MUrQ4ZDdKLX)_