### PR TITLE
Show gloves on the daily notification too

### DIFF
--- a/app/src/main/kotlin/app/clothescast/notification/InsightNotifier.kt
+++ b/app/src/main/kotlin/app/clothescast/notification/InsightNotifier.kt
@@ -9,9 +9,7 @@ import app.clothescast.MainActivity
 import app.clothescast.R
 import app.clothescast.core.domain.model.Insight
 import app.clothescast.core.domain.model.OutfitSuggestion
-import app.clothescast.ui.garment.outfitTopDefaults
-import app.clothescast.ui.garment.renderOutfitBitmap
-import app.clothescast.ui.garment.topDrawable
+import app.clothescast.ui.garment.renderTopWithHandsBitmap
 
 /**
  * Posts the daily insight as a system notification. Tapping the notification opens
@@ -48,6 +46,7 @@ class InsightNotifier(private val context: Context) {
                 largeIconForTop(
                     context = context,
                     top = top,
+                    hands = insight.outfit?.hands,
                     customFillArgb = top?.let { topColors[it] },
                     customStrokeArgb = top?.let { topStrokes[it] },
                 ),
@@ -91,14 +90,17 @@ class InsightNotifier(private val context: Context) {
          * Reuses the full-colour `ic_outfit_tshirt` / `ic_outfit_sweater` /
          * `ic_outfit_thick_jacket` drawables from `OutfitPreviewCard` so the
          * notification visual matches the home-screen card — including any
-         * user-picked colour override passed in via [customFillArgb], and
-         * the tricolour-holiday accent passed in via [customStrokeArgb].
-         * Returns null when [top] is missing (older cached payloads),
+         * user-picked colour override passed in via [customFillArgb], the
+         * tricolour-holiday accent passed in via [customStrokeArgb], and the
+         * optional gloves overlay when [hands] is set (so the notification
+         * shows the same extremity gear the card and widget do on a freezing
+         * day). Returns null when [top] is missing (older cached payloads),
          * letting the system fall back to no large icon.
          */
         internal fun largeIconForTop(
             context: Context,
             top: OutfitSuggestion.Top?,
+            hands: OutfitSuggestion.Hands? = null,
             customFillArgb: Long? = null,
             customStrokeArgb: Long? = null,
         ): Bitmap? {
@@ -106,13 +108,13 @@ class InsightNotifier(private val context: Context) {
             val sizePx = context.resources.getDimensionPixelSize(android.R.dimen.notification_large_icon_width)
                 .takeIf { it > 0 }
                 ?: LARGE_ICON_FALLBACK_PX
-            return renderOutfitBitmap(
+            return renderTopWithHandsBitmap(
                 context = context,
-                drawableRes = topDrawable(top),
-                defaults = outfitTopDefaults.getValue(top),
-                customFillArgb = customFillArgb,
+                top = top,
+                hands = hands,
                 sizePx = sizePx,
-                customStrokeArgb = customStrokeArgb,
+                topFillArgb = customFillArgb,
+                topStrokeArgb = customStrokeArgb,
             )
         }
 

--- a/app/src/main/kotlin/app/clothescast/notification/TonightInsightNotifier.kt
+++ b/app/src/main/kotlin/app/clothescast/notification/TonightInsightNotifier.kt
@@ -50,6 +50,7 @@ class TonightInsightNotifier(private val context: Context) {
                 InsightNotifier.largeIconForTop(
                     context = context,
                     top = top,
+                    hands = insight.outfit?.hands,
                     customFillArgb = top?.let { topColors[it] },
                     customStrokeArgb = top?.let { topStrokes[it] },
                 ),

--- a/app/src/test/kotlin/app/clothescast/notification/InsightNotifierTest.kt
+++ b/app/src/test/kotlin/app/clothescast/notification/InsightNotifierTest.kt
@@ -109,6 +109,21 @@ class InsightNotifierTest {
         check(bitmap.width > 0 && bitmap.height > 0) { "expected a non-empty bitmap" }
     }
 
+    @Test
+    fun `largeIconForTop composites the gloves overlay when the hands slot is set`() {
+        // Exercises the hands != null branch of renderTopWithHandsBitmap — it
+        // reads outfitHandsDefaults.getValue(GLOVES), so a missing entry would
+        // throw here. The overlaid pixels are pixel-verified by the NATIVE
+        // cast-card snapshot; this just guards the notification wiring.
+        val bitmap = InsightNotifier.largeIconForTop(
+            context,
+            OutfitSuggestion.Top.THICK_COAT,
+            hands = OutfitSuggestion.Hands.GLOVES,
+        )
+        bitmap.shouldNotBeNull()
+        check(bitmap.width > 0 && bitmap.height > 0) { "expected a non-empty bitmap" }
+    }
+
     private fun sampleInsight(
         outfit: OutfitSuggestion? = OutfitSuggestion(
             top = OutfitSuggestion.Top.TSHIRT,


### PR DESCRIPTION
## What

Wires the gloves overlay into the **daily / tonight notification** large icon — the last surface that showed the outfit top without it. On a freezing day the notification now matches the Today card, widget, and cast card instead of dropping the gloves.

## Why

You asked for gloves "in the notification and anywhere we show a top." Audit of every top-icon render site:
- Today card (`OutfitPreviewCard`), home-screen widget, Nest-Hub cast card — already gloves-aware (#826).
- 7-day outlook — reuses `OutfitPreviewCard`/`OutfitPreviewRow`, so already covered.
- "Why this outfit?" rationale dialog — text only, no garment icon (and gloves aren't a rationale fact), so nothing to draw.
- Notification **small** status-bar icon — a monochrome silhouette with no gloves variant; left as-is.
- Notification **large** icon — the one gap, fixed here.

## How

`InsightNotifier.largeIconForTop` gains an optional `hands` param and routes through the shared `renderTopWithHandsBitmap` helper (the same compositing path the card/widget/cast use). Both callers (`InsightNotifier`, `TonightInsightNotifier`) pass `insight.outfit?.hands`. When there are no gloves the helper returns the cached top bitmap untouched, so non-gloves notifications render byte-for-byte as before.

## Scope / deferred

Gloves render in their baked colours; the hands **colour picker** in Settings (`outfitHandsColors`) is the next follow-up — the notification's `customFillArgb`/`customStrokeArgb` plumbing already exists, so it'll thread through cleanly when that lands.

## Tests

New `InsightNotifierTest` case renders a coat + gloves large icon, exercising the `hands != null` composite branch (which reads `outfitHandsDefaults.getValue(GLOVES)` — would throw if the entry were missing). The overlay pixels themselves are already pixel-verified by the NATIVE cast-card snapshot from #826. `:app:testDebugUnitTest --tests "*InsightNotifierTest"` green locally.

## Privacy

No change to anything leaving the device — on-device icon rendering only.

https://claude.ai/code/session_01HMjFrx4mng9MUrQ4ZDdKLX

---
_Generated by [Claude Code](https://claude.ai/code/session_01HMjFrx4mng9MUrQ4ZDdKLX)_