### PR TITLE
Fetch a forecast right after you grant location access

### DIFF
--- a/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
@@ -11,6 +11,7 @@ import androidx.work.Data
 import androidx.work.ExistingWorkPolicy
 import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import androidx.work.WorkerParameters
 import androidx.work.workDataOf
@@ -53,6 +54,8 @@ import app.clothescast.tts.InsightTtsUtterance
 import app.clothescast.tts.insightTtsUtterance
 import app.clothescast.tts.resolveHolidayVoice
 import app.clothescast.tts.withSpeechAudioFocus
+import app.clothescast.ui.today.WorkInfoLite
+import app.clothescast.ui.today.toLite
 import app.clothescast.R
 import app.clothescast.ui.garment.outfitCardInfoLines
 import app.clothescast.ui.garment.renderOutfitCard
@@ -169,14 +172,55 @@ class FetchAndNotifyWorker(
             return playInsight(prefs, requestedPeriod)
         }
 
-        // Cache-only path triggered by the Settings location toggle. Just
-        // resolves the device fix and writes it back via setLocation; skips
-        // the forecast / insight / deliver pipeline so the user doesn't get
-        // a duplicate notification (or TTS) when they enable device location
-        // later in the day, after the morning run already fired.
+        // Cache-only path triggered by the Settings / onboarding location
+        // toggle. Resolves the device fix and writes it back via setLocation,
+        // then skips the forecast / insight / deliver pipeline so the user
+        // doesn't get a duplicate notification (or TTS) when they enable device
+        // location later in the day, after the morning run already fired.
+        //
+        // Exception: when there's no cached insight to duplicate — the common
+        // case being the scheduled run having failed for lack of a location
+        // ("No location available; failing run"), then the user granting it —
+        // there's nothing for the Today screen to show, and it would sit on its
+        // empty state until the next alarm. Kick a silent refresh (same
+        // no-notification / no-TTS / no-MQTT / no-cast contract) so a forecast
+        // actually populates the screen the user just unblocked.
         if (inputData.getBoolean(KEY_CACHE_LOCATION_ONLY, false)) {
-            DiagLog.i(TAG, "Cache-only location refresh; skipping insight pipeline.")
-            resolveLocation(prefs, forceFresh = true)
+            val resolved = resolveLocation(prefs, forceFresh = true)
+            if (resolved != null && !hasCachedThisPeriodInsight()) {
+                // Route the recovery through the *observed* daily / tonight
+                // queue (silent = no notification / TTS), not the silent-refresh
+                // queue. The scheduled run that failed for lack of a location
+                // left a terminal REASON_NO_LOCATION WorkInfo on an observed
+                // queue, and the Today banner only suppresses it while the
+                // location-action banner is showing — which stops the moment
+                // resolveLocation() saves a fallback here. A success on the
+                // unobserved silent queue can't supersede that stale failure
+                // (TodayViewModel.workStatusFlow doesn't watch it), so the screen
+                // would populate the forecast yet still show the "no location"
+                // error. enqueueOneShot's REPLACE on the observed queue both
+                // clears the stale failure and shows a "Fetching" spinner while
+                // it runs.
+                //
+                // Recover the current window for the actual fetch. But the
+                // failure may sit on the *other* observed queue: if this
+                // morning's daily run failed and the user only grants location
+                // after the tonight window opens, the current period is TONIGHT
+                // while the stale REASON_NO_LOCATION lives on the daily queue.
+                // mergeWorkStatus surfaces a failure on *either* queue, so also
+                // kick a (silent) recovery on the other queue when it carries
+                // that stale failure — a no-op in the common same-window case.
+                val period = currentPeriodForSchedule(prefs)
+                val other = otherPeriod(period)
+                val periods = buildList {
+                    add(period)
+                    if (hasStaleNoLocationFailure(observedWorkName(other))) add(other)
+                }
+                DiagLog.i(TAG, "Cache-only refresh resolved a location with nothing cached; kicking $periods refresh.")
+                periods.forEach { enqueueOneShot(applicationContext, silent = true, period = it) }
+            } else {
+                DiagLog.i(TAG, "Cache-only location refresh; skipping insight pipeline.")
+            }
             return Result.success()
         }
 
@@ -714,6 +758,41 @@ class FetchAndNotifyWorker(
         val joined = if (firstLine.isNullOrEmpty()) t.javaClass.simpleName
         else "${t.javaClass.simpleName}: $firstLine"
         return if (joined.length <= MAX_DETAIL_LEN) joined else joined.take(MAX_DETAIL_LEN - 1) + "…"
+    }
+
+    // True when the current-window slot already holds a snapshot. The
+    // cache-only refresh uses this to decide whether enabling device location
+    // needs to kick a first fetch (empty cache) or can stay a cheap
+    // location-only write (a forecast is already on screen). A read failure
+    // degrades to "nothing cached" so we err towards fetching rather than
+    // leaving the user on a blank Today screen.
+    private suspend fun hasCachedThisPeriodInsight(): Boolean =
+        runCatching { app.insightCache.thisPeriod.first() }.getOrNull() != null
+
+    // The observed unique-work queue (the ones TodayViewModel.workStatusFlow
+    // watches) that a [period]'s scheduled run lands on.
+    private fun observedWorkName(period: ForecastPeriod): String = when (period) {
+        ForecastPeriod.TODAY -> UNIQUE_WORK_NAME
+        ForecastPeriod.TONIGHT -> UNIQUE_WORK_NAME_TONIGHT
+    }
+
+    private fun otherPeriod(period: ForecastPeriod): ForecastPeriod = when (period) {
+        ForecastPeriod.TODAY -> ForecastPeriod.TONIGHT
+        ForecastPeriod.TONIGHT -> ForecastPeriod.TODAY
+    }
+
+    // True when [workName]'s most-recent terminal run failed for lack of a
+    // location and nothing's currently active on it — i.e. a stale
+    // REASON_NO_LOCATION WorkInfo the banner would surface once the saved
+    // fallback drops the location-action suppression. A query failure degrades
+    // to false — we'd rather skip the extra recovery than throw out of the
+    // cache-only path. The decision itself lives in [staleNoLocationFailure]
+    // so it can be unit-tested without WorkManager.
+    private fun hasStaleNoLocationFailure(workName: String): Boolean {
+        val infos = runCatching {
+            WorkManager.getInstance(applicationContext).getWorkInfosForUniqueWork(workName).get()
+        }.getOrElse { return false }
+        return staleNoLocationFailure(infos.toLite())
     }
 
     private suspend fun resolveLocation(prefs: UserPreferences, forceFresh: Boolean = false): Location? {
@@ -1870,4 +1949,30 @@ class FetchAndNotifyWorker(
             }
         }
     }
+}
+
+/**
+ * True when [infos] (one observed queue's WorkManager history) shows a *stale*
+ * no-location failure: nothing currently active, and the most-recent terminal
+ * run is a [FetchAndNotifyWorker.REASON_NO_LOCATION] failure. Mirrors
+ * [app.clothescast.ui.today.selectStatus]'s "latest terminal by completed-at,
+ * active runs win" rule so the cache-only recovery clears exactly the failure
+ * the Today banner would otherwise surface.
+ *
+ * Top-level + [WorkInfoLite]-based (rather than a private method querying
+ * WorkManager) so it's directly unit-testable — same pattern as `selectStatus`.
+ */
+internal fun staleNoLocationFailure(infos: List<WorkInfoLite>): Boolean {
+    val active = infos.any {
+        it.state == WorkInfo.State.ENQUEUED ||
+            it.state == WorkInfo.State.RUNNING ||
+            it.state == WorkInfo.State.BLOCKED
+    }
+    if (active) return false
+    val latest = infos
+        .filter { it.state == WorkInfo.State.SUCCEEDED || it.state == WorkInfo.State.FAILED }
+        .maxByOrNull { it.outputData.getLong(FetchAndNotifyWorker.KEY_COMPLETED_AT, 0L) }
+        ?: return false
+    return latest.state == WorkInfo.State.FAILED &&
+        latest.outputData.getString(FetchAndNotifyWorker.KEY_REASON) == FetchAndNotifyWorker.REASON_NO_LOCATION
 }

--- a/app/src/test/kotlin/app/clothescast/work/FetchAndNotifyWorkerTest.kt
+++ b/app/src/test/kotlin/app/clothescast/work/FetchAndNotifyWorkerTest.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.work.Configuration
+import androidx.work.Data
 import androidx.work.ListenableWorker.Result
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
@@ -19,6 +20,7 @@ import app.clothescast.core.domain.model.Location
 import app.clothescast.core.domain.model.WeatherCondition
 import app.clothescast.core.domain.repository.ForecastBundle
 import app.clothescast.data.InsightCache
+import app.clothescast.ui.today.WorkInfoLite
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.longs.shouldBeGreaterThan
@@ -195,7 +197,113 @@ class FetchAndNotifyWorkerTest {
             result.outputData.getBoolean(FetchAndNotifyWorker.KEY_SKIP_TELEMETRY, false) shouldBe false
             result.outputData.getLong(FetchAndNotifyWorker.KEY_COMPLETED_AT, 0L) shouldBeGreaterThan
                 before - 1
+            // Nothing resolved → nothing to fetch a forecast for; don't spin up
+            // a recovery run that would just fail the same way.
+            recoveryWorkInfos() shouldHaveSize 0
         }
+    }
+
+    @Test
+    fun `cache-only refresh with a resolvable location but empty cache kicks an observed recovery refresh`() {
+        // The reported bug: the scheduled run failed for lack of a location, the
+        // user then grants it, and the cache-only refresh resolves a fix but —
+        // with nothing cached — leaves the Today screen empty until the next
+        // alarm. A saved fallback city makes resolveLocation return non-null
+        // here; with an empty cache the branch should kick a recovery refresh so
+        // a forecast actually populates the screen.
+        //
+        // It must land on the *observed* daily / tonight queue (not the
+        // unobserved silent queue) so its success supersedes the stale
+        // REASON_NO_LOCATION failure the scheduled run left there — otherwise
+        // the forecast populates but the "no location" banner lingers once the
+        // saved fallback drops the location-required suppression.
+        runBlocking {
+            app.settingsRepository.setLocation(
+                Location(latitude = 51.5, longitude = -0.1, displayName = "London"),
+            )
+            val worker = TestListenableWorkerBuilder<FetchAndNotifyWorker>(context)
+                .setInputData(workDataOf(FetchAndNotifyWorker.KEY_CACHE_LOCATION_ONLY to true))
+                .build()
+
+            val result = worker.doWork()
+
+            result.shouldBeInstanceOf<Result.Success>()
+            // Exactly one recovery run, on one of the two observed queues
+            // (which one depends on the current schedule window).
+            observedRefreshWorkInfos().map { it.state } shouldContainExactlyInAnyOrder
+                listOf(WorkInfo.State.ENQUEUED)
+            workInfosFor(FetchAndNotifyWorker.UNIQUE_WORK_NAME_SILENT) shouldHaveSize 0
+        }
+    }
+
+    @Test
+    fun `cache-only refresh with a forecast already cached stays a location-only write`() {
+        // When a forecast is already on screen there's nothing to populate, so
+        // the cache-only refresh stays cheap (location write only) rather than
+        // burning a fresh fetch — that's the whole reason the path exists apart
+        // from the recovery refresh.
+        runBlocking {
+            app.settingsRepository.setLocation(
+                Location(latitude = 51.5, longitude = -0.1, displayName = "London"),
+            )
+            app.insightCache.store(
+                InsightCache.Slot.THIS_PERIOD,
+                sampleSnapshot(period = ForecastPeriod.TODAY),
+            )
+            val worker = TestListenableWorkerBuilder<FetchAndNotifyWorker>(context)
+                .setInputData(workDataOf(FetchAndNotifyWorker.KEY_CACHE_LOCATION_ONLY to true))
+                .build()
+
+            val result = worker.doWork()
+
+            result.shouldBeInstanceOf<Result.Success>()
+            recoveryWorkInfos() shouldHaveSize 0
+        }
+    }
+
+    // --- staleNoLocationFailure (cross-queue recovery predicate) --------
+
+    @Test
+    fun `staleNoLocationFailure is false for an empty history`() {
+        staleNoLocationFailure(emptyList()) shouldBe false
+    }
+
+    @Test
+    fun `staleNoLocationFailure is true when the latest terminal is a no-location failure`() {
+        staleNoLocationFailure(
+            listOf(lite(WorkInfo.State.FAILED, completedAt = 100, reason = FetchAndNotifyWorker.REASON_NO_LOCATION)),
+        ) shouldBe true
+    }
+
+    @Test
+    fun `staleNoLocationFailure ignores the failure while a run is active`() {
+        // A pending / running recovery on the queue means the failure isn't
+        // stale — it's about to be superseded — so don't kick another.
+        staleNoLocationFailure(
+            listOf(
+                lite(WorkInfo.State.FAILED, completedAt = 100, reason = FetchAndNotifyWorker.REASON_NO_LOCATION),
+                lite(WorkInfo.State.ENQUEUED),
+            ),
+        ) shouldBe false
+    }
+
+    @Test
+    fun `staleNoLocationFailure is false when a newer success supersedes the failure`() {
+        staleNoLocationFailure(
+            listOf(
+                lite(WorkInfo.State.FAILED, completedAt = 100, reason = FetchAndNotifyWorker.REASON_NO_LOCATION),
+                lite(WorkInfo.State.SUCCEEDED, completedAt = 200),
+            ),
+        ) shouldBe false
+    }
+
+    @Test
+    fun `staleNoLocationFailure is false for a failure with a different reason`() {
+        // A network / HTTP failure isn't cleared by saving a location, so it's
+        // not ours to supersede from the cache-only path.
+        staleNoLocationFailure(
+            listOf(lite(WorkInfo.State.FAILED, completedAt = 100, reason = FetchAndNotifyWorker.REASON_UNHANDLED)),
+        ) shouldBe false
     }
 
     @Test
@@ -349,8 +457,32 @@ class FetchAndNotifyWorkerTest {
         target(ForecastPeriod.TONIGHT, LocalTime.of(2, 0)) shouldBe date.minusDays(1)
     }
 
+    // Minimal WorkInfoLite for the staleNoLocationFailure pure-function tests.
+    private fun lite(
+        state: WorkInfo.State,
+        completedAt: Long = 0L,
+        reason: String? = null,
+    ): WorkInfoLite {
+        val data = Data.Builder()
+            .putLong(FetchAndNotifyWorker.KEY_COMPLETED_AT, completedAt)
+            .apply { if (reason != null) putString(FetchAndNotifyWorker.KEY_REASON, reason) }
+            .build()
+        return WorkInfoLite(state = state, runAttemptCount = 1, outputData = data)
+    }
+
     private fun workInfosFor(name: String): List<WorkInfo> =
         WorkManager.getInstance(context).getWorkInfosForUniqueWork(name).get()
+
+    // The two observed refresh queues the Today banner watches; the cache-only
+    // recovery lands on whichever matches the current schedule window.
+    private fun observedRefreshWorkInfos(): List<WorkInfo> =
+        workInfosFor(FetchAndNotifyWorker.UNIQUE_WORK_NAME) +
+            workInfosFor(FetchAndNotifyWorker.UNIQUE_WORK_NAME_TONIGHT)
+
+    // Every queue a cache-only recovery could plausibly enqueue on — used to
+    // assert the branch *didn't* kick one.
+    private fun recoveryWorkInfos(): List<WorkInfo> =
+        observedRefreshWorkInfos() + workInfosFor(FetchAndNotifyWorker.UNIQUE_WORK_NAME_SILENT)
 
     private fun sampleSnapshot(period: ForecastPeriod): ForecastSnapshot {
         val today = LocalDate.of(2026, 5, 27)


### PR DESCRIPTION
## Problem

A bug report ("it didn't auto fetch a clothescast after the user provided location access") showed this sequence:

```
W FetchAndNotifyWorker: No location available; failing run.
I FetchAndNotifyWorker: Cache-only location refresh; skipping insight pipeline.
I FetchAndNotifyWorker: Using device-resolved location at <lat>, <lon>.
```

The scheduled run failed because no location was available yet. The user then granted location access, which fired the **cache-only** location refresh. That path resolves the device fix and writes it back, but deliberately **skips the forecast / insight / deliver pipeline** — so no ClothesCast was fetched, and the Today screen sat on its empty state until the next alarm (armed for the following morning).

## Fix

The cache-only path's "don't re-fire today's notification / TTS" rationale only holds when a forecast was *already* delivered. When the current-window cache is empty — the common trigger being a scheduled run that failed for lack of a location, then the user granting it — there's nothing to duplicate and nothing for the screen to show.

So in the cache-only branch, after resolving the location: if a fix resolved **and** the current-window slot has no cached insight, kick a recovery refresh so a forecast populates the screen. When a forecast is already cached, the path stays a cheap location-only write — no wasted fetch. When nothing resolves, it stays a no-op.

**Observed-queue routing.** The recovery runs **silently** (no notification / TTS / MQTT / cast) but is routed through the **observed** daily / tonight queue rather than the unobserved silent-refresh queue. The failed scheduled run left a terminal `REASON_NO_LOCATION` WorkInfo on the observed queue, and the Today banner only suppresses that failure while the location-action banner is showing — which stops the moment the resolved fallback is saved. Enqueuing the recovery on the observed queue (`enqueueOneShot(silent = true)`, `REPLACE`) supersedes the stale failure and shows a "Fetching" spinner while it runs.

**Cross-window failures.** The stale failure can sit on the *other* observed queue: if this morning's daily run failed and the user grants location after the tonight window opens, the current window is `TONIGHT` while the stale `REASON_NO_LOCATION` lives on the daily queue — and `mergeWorkStatus` surfaces a failure on *either* observed queue. So the recovery also supersedes the other queue when it carries a stale no-location failure (a no-op in the common same-window case). The predicate is extracted as a pure, unit-tested `staleNoLocationFailure(List<WorkInfoLite>)`, mirroring `selectStatus`.

(Thanks to the Codex review for catching both the unobserved-queue gap and the cross-window case.)

## Privacy

No change to what leaves the device — the recovery issues the same Open-Meteo request the scheduled run would have made.

## Test plan

`:app:testDebugUnitTest` — green. Coverage in `FetchAndNotifyWorkerTest`:
- cache-only refresh with a resolvable location but empty cache → enqueues a recovery on an **observed** queue, not the silent queue
- cache-only refresh with a forecast already cached → stays a location-only write (no recovery enqueued)
- cache-only refresh with no resolvable location → no recovery enqueued
- `staleNoLocationFailure` predicate: empty history, latest-terminal no-location failure, active-run-wins, newer-success-supersedes, different-reason

https://claude.ai/code/session_013y5JfKqhPiUcXX6e5ig4Nk