### PR TITLE
test: stop flaky SettingsViewModelTest voice-enumeration dispatcher leak

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsViewModel.kt
@@ -49,6 +49,7 @@ import app.clothescast.work.FetchAndNotifyWorker
 import app.clothescast.tts.TtsVoiceEnumerator
 import app.clothescast.tts.resolve
 import app.clothescast.tts.toJavaLocale
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -80,6 +81,17 @@ class SettingsViewModel(
     private val cancelAlarm: (ForecastPeriod) -> Unit,
     private val geocodingClient: OpenMeteoGeocodingClient,
     private val voiceEnumerator: TtsVoiceEnumerator,
+    /**
+     * Dispatcher the device-voice enumeration hops to for its JNI engine
+     * binds (see [refreshDeviceVoices]). Defaults to [Dispatchers.IO] in
+     * production; tests inject their own test dispatcher so the enumeration
+     * stays on the test scheduler and can be drained deterministically in
+     * teardown — otherwise the real-IO hop outlives the test, resumes after
+     * `Dispatchers.resetMain()`, and crashes trying to dispatch back onto the
+     * now-missing Main dispatcher (surfacing as a flaky
+     * `UncaughtExceptionsBeforeTest` against the next test).
+     */
+    private val voiceEnumerationDispatcher: CoroutineDispatcher = Dispatchers.IO,
     /**
      * Pokes the home-screen widget after a settings change so the launcher
      * icon catches up in the same frame as the Today screen. The cache no
@@ -370,7 +382,7 @@ class SettingsViewModel(
             // All three enumerator calls bind the engine, which is JNI work
             // — keep them off the main dispatcher.
             val resolvedLocale = locale.resolve(_state.value.region.toJavaLocale() ?: Locale.getDefault())
-            val voices = withContext(Dispatchers.IO) {
+            val voices = withContext(voiceEnumerationDispatcher) {
                 runCatching { voiceEnumerator.listVoices(resolvedLocale) }.getOrDefault(emptyList())
             }
             val pinnedId = pinnedIdOverride
@@ -382,11 +394,11 @@ class SettingsViewModel(
                 // misses, which is rare — most pins match the current
                 // locale.
                 voices.firstOrNull { it.id == pinnedId }
-                    ?: withContext(Dispatchers.IO) {
+                    ?: withContext(voiceEnumerationDispatcher) {
                         runCatching { voiceEnumerator.findVoice(pinnedId) }.getOrNull()
                     }
             } else {
-                withContext(Dispatchers.IO) {
+                withContext(voiceEnumerationDispatcher) {
                     runCatching { voiceEnumerator.resolveAutoPick(resolvedLocale) }.getOrNull()
                 }
             }

--- a/app/src/test/kotlin/app/clothescast/ui/settings/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/app/clothescast/ui/settings/SettingsViewModelTest.kt
@@ -136,6 +136,7 @@ class SettingsViewModelTest {
                 cancelAlarm = { _ -> },
                 geocodingClient = OpenMeteoGeocodingClient(emptyGeocoding),
                 voiceEnumerator = EmptyVoiceEnumerator,
+                voiceEnumerationDispatcher = dispatcher,
             ),
         )
     }
@@ -339,6 +340,7 @@ class SettingsViewModelTest {
                     },
                 ),
                 voiceEnumerator = EmptyVoiceEnumerator,
+                voiceEnumerationDispatcher = dispatcher,
                 calendarEventReader = reader,
             ),
         )
@@ -395,6 +397,7 @@ class SettingsViewModelTest {
                     },
                 ),
                 voiceEnumerator = EmptyVoiceEnumerator,
+                voiceEnumerationDispatcher = dispatcher,
                 refreshLocationCache = { refreshCount++ },
             ),
         )
@@ -428,6 +431,7 @@ class SettingsViewModelTest {
                     },
                 ),
                 voiceEnumerator = EmptyVoiceEnumerator,
+                voiceEnumerationDispatcher = dispatcher,
                 refreshOutfitWidget = { refreshCount++ },
             ),
         )
@@ -511,6 +515,7 @@ class SettingsViewModelTest {
                         },
                     ),
                     voiceEnumerator = countingEnumerator,
+                    voiceEnumerationDispatcher = dispatcher,
                 ),
             )
             // Drain the initial enumeration triggered by the first prefs
@@ -665,6 +670,7 @@ class SettingsViewModelTest {
             cancelAlarm = { _ -> },
             geocodingClient = OpenMeteoGeocodingClient(emptyGeocoding),
             voiceEnumerator = EmptyVoiceEnumerator,
+            voiceEnumerationDispatcher = dispatcher,
             discovery = discovery,
         )
     }


### PR DESCRIPTION
## Symptom

`./gradlew :app:testDebugUnitTest` intermittently failed the full suite with exactly one failing test:

```
kotlinx.coroutines.test.UncaughtExceptionsBeforeTest: There were uncaught
exceptions before the test started...
  at app.clothescast.ui.settings.SettingsViewModelTest
     .loadCalendarCelebrations collapses only true duplicates...(SettingsViewModelTest.kt:306)
```

`loadCalendarCelebrations` was the **victim**, not the culprit — `UncaughtExceptionsBeforeTest` means a coroutine launched by an *earlier* test threw after its `runTest` ended and the leak surfaced at the start of the next test. The class passed in isolation, so reproduction needed the full suite.

## Root cause

`SettingsViewModel.refreshDeviceVoices` — fired by **every** test via the `preferences.collect` started in `init {}` — hopped to `Dispatchers.IO` with `withContext(Dispatchers.IO)` to run the voice enumerator's JNI engine binds.

The test harness is careful: it bounds `viewModelScope`, the DataStore scope, and the main dispatcher to each test by cancelling them and draining the test scheduler *before* `Dispatchers.resetMain()`. But `dispatcher.scheduler.advanceUntilIdle()` only drains work **on that scheduler**. The `withContext(Dispatchers.IO)` hop runs on real threads the scheduler can't see, so the enumeration could still be parked when teardown reset `Main`, then resume and crash trying to dispatch back onto the now-missing Main dispatcher ("Module with the Main dispatcher is missing"). kotlinx-coroutines-test's global `ExceptionCollector` captured that exception and, because it landed between tests, reported it against the *next* test as `UncaughtExceptionsBeforeTest` — order-dependent and flaky.

This is exactly the failure mode the harness's own teardown comments describe (and already guard against for DataStore + `viewModelScope`); the `withContext(Dispatchers.IO)` escape was the one remaining hole.

## Fix

Inject the enumeration dispatcher:

- `SettingsViewModel` gains a `voiceEnumerationDispatcher: CoroutineDispatcher = Dispatchers.IO` constructor parameter — **production behaviour is unchanged** (same default, same `Factory`).
- `refreshDeviceVoices`'s three `withContext(Dispatchers.IO)` calls now use it.
- The tests pass their existing test dispatcher, so the enumeration stays on the test scheduler that teardown drains — closing the real-thread escape.

No production code path or shipped behaviour changes; this is a test-determinism seam, hence the `test:` subject prefix (filtered from the Play "What's new").

## Test plan

- `:app:testDebugUnitTest --tests "*SettingsViewModelTest"` → green in isolation.
- Repeated full `:app:testDebugUnitTest` runs → green, no `UncaughtExceptionsBeforeTest`.

https://claude.ai/code/session_01STf7UvxH4SVLcknKeorPme

---
_Generated by [Claude Code](https://claude.ai/code/session_01STf7UvxH4SVLcknKeorPme)_