### PR TITLE
internal: add umbrella to the garment catalog as carried gear

### DIFF
--- a/app/src/main/kotlin/app/clothescast/insight/ClothesPhraser.kt
+++ b/app/src/main/kotlin/app/clothescast/insight/ClothesPhraser.kt
@@ -279,6 +279,7 @@ private val GARMENT_RES_IDS: Map<Garment, Int> = mapOf(
     Garment.PANTS to R.string.garment_pants,
     Garment.JEANS to R.string.garment_jeans,
     Garment.GLOVES to R.string.garment_gloves,
+    Garment.UMBRELLA to R.string.garment_umbrella,
 )
 
 /**

--- a/app/src/main/kotlin/app/clothescast/ui/settings/ClothesSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/ClothesSettings.kt
@@ -594,6 +594,7 @@ private fun garmentLabelRes(garment: Garment): Int = when (garment) {
     Garment.PANTS -> R.string.garment_pants
     Garment.JEANS -> R.string.garment_jeans
     Garment.GLOVES -> R.string.garment_gloves
+    Garment.UMBRELLA -> R.string.garment_umbrella
 }
 
 @Composable
@@ -757,7 +758,11 @@ private fun GarmentDropdown(
             expanded = expanded,
             onDismissRequest = { expanded = false },
         ) {
-            Garment.entries.forEach { entry ->
+            // UMBRELLA is in the catalog but not yet offered here: the umbrella
+            // rule replaces the RainAccessory toggle in a follow-up, which is
+            // when it joins the picker. Until then it stays hidden so the two
+            // umbrella paths don't compete.
+            Garment.entries.filter { it != Garment.UMBRELLA }.forEach { entry ->
                 DropdownMenuItem(
                     text = { Text(stringResource(garmentLabelRes(entry))) },
                     onClick = {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1003,6 +1003,7 @@
     <string name="garment_pants">Pants</string>
     <string name="garment_jeans">Jeans</string>
     <string name="garment_gloves">Gloves</string>
+    <string name="garment_umbrella">Umbrella</string>
 
     <!-- Editor strings restored from the pre-lockdown UI. Free-form
          garment-name input is gone; the user picks from the garment dropdown

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Garment.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Garment.kt
@@ -12,8 +12,9 @@ import java.util.Locale
  * The catalog is intentionally finite: free-form garment names defeat
  * translation (the German phraser can't translate arbitrary user input), so
  * the editor UI only lets the user pick from this list. Today the list covers
- * tops and bottoms — headwear, accessories, and rain / sun gear can land in a
- * follow-up PR (and will likely come paired with their own outfit-card icons).
+ * tops, bottoms, the gloves hands slot, and one carried accessory (umbrella);
+ * headwear and further rain / sun gear can land in follow-ups (and will likely
+ * come paired with their own outfit-card icons).
  *
  * Stays in `:core:domain` so the rule-evaluation tests and the future
  * `ClothesRule.item` migration to a typed field can reach it without pulling
@@ -70,7 +71,14 @@ enum class Garment(
     // Extremity gear — worn alongside the top/bottom stack, not part of it.
     // Gloves are the "extra cold" signal: they fire below the coat threshold
     // rather than inflating the layer count.
-    GLOVES("gloves", Slot.HANDS);
+    GLOVES("gloves", Slot.HANDS),
+
+    // Carried rain/sun gear — held, not worn. An umbrella is keyed off
+    // precipitation probability rather than temperature; it claims its own
+    // [Slot.CARRIED] so it never competes with the worn top/bottom/hands
+    // stack, and the prose names it with "bring/carry" rather than "wear"
+    // (see [isAccessoryKey]).
+    UMBRELLA("umbrella", Slot.CARRIED);
 
     /**
      * Canonical relative warmth for outfit comparisons — "is the evening's top
@@ -96,6 +104,8 @@ enum class Garment(
         TOP(Reduction.LAYERED),
         BOTTOM(Reduction.SUBSTITUTE),
         HANDS(Reduction.SUBSTITUTE),
+        // Carried, not worn — a single umbrella; you don't carry two.
+        CARRIED(Reduction.SUBSTITUTE),
     }
 
     /**
@@ -155,15 +165,14 @@ enum class Garment(
 
         /**
          * Whether a rule-item key names a *carried* accessory (rather than a
-         * worn garment). Accessories don't live in the [Garment] catalog —
-         * they don't claim a slot, don't layer, and the wear-clause prose
-         * filters them out ("Wear an umbrella" reads wrong; the rain mention
-         * already implies it). Today it's only `umbrella`; the
-         * `accessories-catalog` TODO in the formatter is the long-term home
-         * for a proper kind classification (rain jacket, hood, sunscreen, …).
+         * worn garment). Carried gear sits in [Slot.CARRIED]: it doesn't layer
+         * and the wear-clause prose filters it out of "Wear …" ("Wear an
+         * umbrella" reads wrong — it's named with "bring/carry" instead). Today
+         * it's only `umbrella`; a future rain jacket / hood / sunscreen would
+         * join [Slot.CARRIED] and be picked up here automatically.
          */
         fun isAccessoryKey(key: String): Boolean =
-            key.trim().equals("umbrella", ignoreCase = true)
+            fromKey(key)?.slot == Slot.CARRIED
 
         /**
          * Within-layer priority for top garments — heaviest-tier first. When
@@ -213,6 +222,7 @@ enum class Garment(
             mapOf(
                 Slot.BOTTOM to BOTTOM_PRIORITY,
                 Slot.HANDS to listOf(GLOVES),
+                Slot.CARRIED to listOf(UMBRELLA),
             )
 
         /** Rank of this garment within a priority list — earlier wins; anything

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/model/GarmentTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/model/GarmentTest.kt
@@ -64,6 +64,32 @@ class GarmentTest {
     }
 
     @Test
+    fun `umbrella is a carried accessory that round-trips and reads as an accessory`() {
+        // The umbrella joins the catalog as carried gear: it round-trips via
+        // fromKey, sits in the CARRIED slot (so it never competes with the worn
+        // top/bottom/hands stack), and reads as an accessory so the wear-clause
+        // prose keeps naming it with "bring/carry" rather than "wear".
+        Garment.fromKey("umbrella") shouldBe Garment.UMBRELLA
+        Garment.UMBRELLA.slot shouldBe Garment.Slot.CARRIED
+        Garment.UMBRELLA.layerCount shouldBe 0
+        Garment.isAccessoryKey("umbrella") shouldBe true
+        // Worn garments are not accessories.
+        Garment.isAccessoryKey("sweater") shouldBe false
+    }
+
+    @Test
+    fun `layerReduce keeps a single carried umbrella alongside the worn stack`() {
+        // A firing umbrella rule passes through reduction next to the top stack
+        // — carried gear substitutes within its own slot (you carry one
+        // umbrella) and never displaces a top or bottom.
+        val rules = listOf(
+            ClothesRule(Garment.SWEATER, ClothesRule.TemperatureBelow(16.0)),
+            ClothesRule(Garment.UMBRELLA, ClothesRule.PrecipitationProbabilityAbove(50.0)),
+        )
+        Garment.layerReduce(rules) shouldBe rules
+    }
+
+    @Test
     fun `fromKey does not depend on process locale`() {
         val originalDefault = Locale.getDefault()
         Locale.setDefault(Locale.forLanguageTag("tr-TR"))


### PR DESCRIPTION
## What

First step toward letting users **bring/carry an umbrella** as a configurable rule. Adds `Garment.UMBRELLA` to the catalog in a new `Slot.CARRIED` — the domain foundation the rest of the feature builds on.

This is invisible infra: **no user-visible change**. Umbrella is filtered out of the rule-editor picker and the existing `RainAccessory` toggle still drives the "bring an umbrella" prose. The migration, prose reroute, and editor exposure land in PR 2.

## Why

The umbrella is currently a global render-time format toggle (`RainAccessory.NONE`/`UMBRELLA`), not a rule. The plan (agreed with the user) is to rework it into a configurable clothes rule with a user-set precipitation-% threshold, then migrate the toggle away. `ClothesRule.item` is a `Garment` and the editor already supports `PrecipitationProbabilityAbove` conditions — so the one missing piece was an umbrella in the catalog. This PR adds exactly that, with nothing else changing yet.

## How

- **`Garment.UMBRELLA` in a new `Slot.CARRIED`** — held, not worn; keyed off precipitation rather than temperature; claims its own slot so it never competes with the worn top/bottom/hands stack. `SUBSTITUTE` reduction (you carry one umbrella).
- **`isAccessoryKey` now derives from `Slot.CARRIED`** instead of matching the literal `"umbrella"` string — so the wear-clause prose keeps naming carried gear with "bring/carry" rather than "wear", and a future rain jacket / hood joins that treatment automatically.
- **`layerReduce`** keeps a single umbrella alongside the worn stack without displacing a top or bottom (covered by a new test).
- **Label wiring** — `garment_umbrella` string, the phraser's `GARMENT_RES_IDS` map, and the settings `garmentLabelRes` `when` — satisfies the #813 `Garment.entries` exhaustiveness guard (German already resolves "Regenschirm" via its dedicated phraser map).
- **Picker filter** — `Garment.UMBRELLA` is excluded from the editor dropdown for now, so the two umbrella paths don't compete before the migration.

## Scope / follow-ups

- **PR 2 (the switch):** migrate `RainAccessory.UMBRELLA` users → an umbrella rule at the historical 30% gate, reroute the prose through the fired rule, expose umbrella in the editor, retire the toggle + Format dropdown. Likely also two new format options the user flagged: **Accessories: Always/Never** and an **Accessory lead-in: Always/Speech Only/Never** (reusing the existing `PreamblePlacement`).
- **PR 3 (later):** the visual carried-umbrella icon on the outfit surfaces, mirroring the gloves arc.
- **Localization:** `garment_umbrella` is English-only in `values/` for now; non-German locales fall back to English "Umbrella" (same as the pre-existing raw-key behaviour — not a regression), and German is covered by the phraser map. Per-locale translations follow the project's translation pass, as `garment_gloves` did.

## Test plan

`./gradlew :core:domain:test :app:testDebugUnitTest` green locally. New `GarmentTest` cases: umbrella round-trips via `fromKey`, sits in `Slot.CARRIED`, reads as an accessory, and `layerReduce` keeps it alongside a worn top. The full prose suite passing confirms the existing umbrella-toggle output is unchanged.

## Privacy

No change to what leaves the device.

https://claude.ai/code/session_01HMjFrx4mng9MUrQ4ZDdKLX

---
_Generated by [Claude Code](https://claude.ai/code/session_01HMjFrx4mng9MUrQ4ZDdKLX)_