### PR TITLE
Add a closed-umbrella outfit drawable

### DIFF
--- a/app/src/main/res/drawable/ic_outfit_umbrella.xml
+++ b/app/src/main/res/drawable/ic_outfit_umbrella.xml
@@ -1,0 +1,22 @@
+<?xml version='1.0' encoding='utf-8'?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:width="96dp" android:height="96dp" android:viewportWidth="96" android:viewportHeight="96">
+
+    <!-- Crook handle: a wooden cane hook the figure grips, drawn first so the
+         furled canopy's gathered top tucks over its base. -->
+    <path android:strokeColor="#4E342E" android:strokeWidth="5" android:strokeLineJoin="round" android:strokeLineCap="round" android:pathData="M48,45 L48,20 Q48,12 41,12 Q34,12 34,19" />
+
+    <!-- Furled canopy: gathered fabric at the top, bulging then tapering to a
+         soft point above the ferrule. -->
+    <path android:fillColor="#2D6CDF" android:strokeColor="#163F7E" android:strokeWidth="2.25" android:strokeLineJoin="round" android:strokeLineCap="round" android:pathData="M43,45 Q40,43 43,42 Q48,40 53,42 Q56,43 53,45 L57,62 Q58,71 50,80 L48,87 L46,80 Q38,71 39,62 Z" />
+
+    <!-- Ferrule tip: the metal spike poking out below the furled point. -->
+    <path android:fillColor="#546E7A" android:strokeColor="#37474F" android:strokeWidth="2" android:strokeLineJoin="round" android:strokeLineCap="round" android:pathData="M45,85 L48,93 L51,85 Z" />
+
+    <!-- Two furl lines hinting at the rolled-up panels. -->
+    <path android:strokeColor="#163F7E" android:strokeWidth="2" android:strokeLineCap="round" android:pathData="M46,45 Q44,64 48,85" />
+    <path android:strokeColor="#163F7E" android:strokeWidth="2" android:strokeLineCap="round" android:pathData="M50,45 Q52,64 48,85" />
+
+    <!-- Closure strap wrapping the bundle — a strong "it's closed" cue. -->
+    <path android:fillColor="#14366B" android:strokeColor="#0E2A55" android:strokeWidth="1.5" android:strokeLineJoin="round" android:pathData="M40,53 L56,53 Q58,55 56,57 L40,57 Q38,55 40,53 Z" />
+
+</vector>


### PR DESCRIPTION
## What

Adds a closed/furled **umbrella** drawable (`ic_outfit_umbrella.xml`) for the rain-accessory slot. `RainAccessory.UMBRELLA` already exists in the domain (prose only); this gives it a visual.

The icon follows the existing `ic_outfit_*` conventions — 96-unit viewport, two-tone fill + darker stroke, `strokeWidth="2.25"`, round caps/joins — and is composed of:

- **Crook handle** — a stroked wooden cane hook at the top (the clearest "umbrella" cue).
- **Furled canopy** — a tapered blue bundle, gathered at the top, narrowing to a soft point.
- **Closure strap** — a dark band wrapping the bundle (reinforces "closed/compact").
- **Two furl lines** — hint at the rolled-up panels.
- **Ferrule tip** — a small metal spike for the pointed tip.

It's drawn vertically so it reads as held and hanging down — intended to sit at the hand/glove position when later composed onto the outfit figure (a small gap from the sleeve when no gloves are present).

## Scope

**Asset only.** It is not yet wired into the figure rendering (no `RainAccessory.UMBRELLA` → overlay mapping in the Today card / widget / Nest Hub render), and it isn't snapshotted yet, so there are no PNG diffs in this PR. Still iterating on the shape with the maintainer; wiring + a `GarmentDrawablePreviews` snapshot can follow once the look is settled.

Rasterized previews (the icon alone and a mockup of it held at the right hand) are in the chat thread, since GitHub renders the committed file as XML rather than an image.

https://claude.ai/code/session_013y5JfKqhPiUcXX6e5ig4Nk