### PR TITLE
Slimmer, more subtle closed-umbrella icon

### DIFF
--- a/app/src/main/res/drawable/ic_outfit_umbrella.xml
+++ b/app/src/main/res/drawable/ic_outfit_umbrella.xml
@@ -2,21 +2,22 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android" android:width="96dp" android:height="96dp" android:viewportWidth="96" android:viewportHeight="96">
 
     <!-- Crook handle: a wooden cane hook the figure grips, drawn first so the
-         furled canopy's gathered top tucks over its base. -->
-    <path android:strokeColor="#4E342E" android:strokeWidth="5" android:strokeLineJoin="round" android:strokeLineCap="round" android:pathData="M48,45 L48,20 Q48,12 41,12 Q34,12 34,19" />
+         furled canopy's gathered top tucks over its base. Short shaft so the
+         fabric starts high, close under the grip. -->
+    <path android:strokeColor="#4E342E" android:strokeWidth="4.5" android:strokeLineJoin="round" android:strokeLineCap="round" android:pathData="M48,34 L48,20 Q48,12 41,12 Q34,12 34,19" />
 
-    <!-- Furled canopy: gathered fabric at the top, bulging then tapering to a
-         soft point above the ferrule. -->
-    <path android:fillColor="#2D6CDF" android:strokeColor="#163F7E" android:strokeWidth="2.25" android:strokeLineJoin="round" android:strokeLineCap="round" android:pathData="M43,45 Q40,43 43,42 Q48,40 53,42 Q56,43 53,45 L57,62 Q58,71 50,80 L48,87 L46,80 Q38,71 39,62 Z" />
+    <!-- Furled canopy: gathered fabric high under the grip, a slim bulge, then a
+         gentle taper to a soft point above the ferrule. -->
+    <path android:fillColor="#2D6CDF" android:strokeColor="#163F7E" android:strokeWidth="2" android:strokeLineJoin="round" android:strokeLineCap="round" android:pathData="M45,35 Q42,33 45,31 Q48,29 51,31 Q54,33 51,35 L53,53 Q54,66 49,77 L48,85 L47,77 Q42,66 43,53 Z" />
 
-    <!-- Ferrule tip: the metal spike poking out below the furled point. -->
-    <path android:fillColor="#546E7A" android:strokeColor="#37474F" android:strokeWidth="2" android:strokeLineJoin="round" android:strokeLineCap="round" android:pathData="M45,85 L48,93 L51,85 Z" />
+    <!-- Ferrule tip: a small straight metal point poking out below the canopy. -->
+    <path android:fillColor="#546E7A" android:strokeColor="#37474F" android:strokeWidth="1" android:strokeLineJoin="round" android:strokeLineCap="round" android:pathData="M47.3,85 L47.3,90 L48,91.5 L48.7,90 L48.7,85 Z" />
 
     <!-- Two furl lines hinting at the rolled-up panels. -->
-    <path android:strokeColor="#163F7E" android:strokeWidth="2" android:strokeLineCap="round" android:pathData="M46,45 Q44,64 48,85" />
-    <path android:strokeColor="#163F7E" android:strokeWidth="2" android:strokeLineCap="round" android:pathData="M50,45 Q52,64 48,85" />
+    <path android:strokeColor="#163F7E" android:strokeWidth="1.5" android:strokeLineCap="round" android:pathData="M47,35 Q45.5,58 48,83" />
+    <path android:strokeColor="#163F7E" android:strokeWidth="1.5" android:strokeLineCap="round" android:pathData="M49,35 Q50.5,58 48,83" />
 
     <!-- Closure strap wrapping the bundle — a strong "it's closed" cue. -->
-    <path android:fillColor="#14366B" android:strokeColor="#0E2A55" android:strokeWidth="1.5" android:strokeLineJoin="round" android:pathData="M40,53 L56,53 Q58,55 56,57 L40,57 Q38,55 40,53 Z" />
+    <path android:fillColor="#14366B" android:strokeColor="#0E2A55" android:strokeWidth="1.2" android:strokeLineJoin="round" android:pathData="M43.5,41 L52.5,41 Q54,43 52.5,45 L43.5,45 Q42,43 43.5,41 Z" />
 
 </vector>


### PR DESCRIPTION
Tones down the furled-umbrella drawable (`ic_outfit_umbrella.xml`) per feedback:

- **Fabric starts high under the grip** — shorter bare shaft between the crook and the canopy.
- **Slimmer bulge** — the furled canopy is narrower (≈10 units wide vs ≈18), so it reads more compact.
- **Small straight ferrule** — a thin straight metal tip replaces the wider arrowhead.
- Lighter outline / detail strokes (canopy 2, furl lines 1.5) to match the more subtle look.

Asset-only refinement — the drawable isn't wired into a rendered surface yet, so there's no snapshot impact.

## Test plan

No code paths touched. Vector renders correctly (previewed via SVG rasterization). CI's `:app:assembleDebug` will confirm the drawable compiles into resources.

https://claude.ai/code/session_013y5JfKqhPiUcXX6e5ig4Nk

---
_Generated by [Claude Code](https://claude.ai/code/session_013y5JfKqhPiUcXX6e5ig4Nk)_