### PR TITLE
Show the play promo before the schedule promo on Today

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/today/PromoBanners.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/PromoBanners.kt
@@ -6,12 +6,12 @@ package app.clothescast.ui.today
  * operational banners (update / crash / work-status / holiday), which aren't
  * capped.
  */
-internal enum class PromoBanner { LOCATION, TELEMETRY, CLOTHES, SCHEDULE, PLAY, GEMINI, CELEBRATION }
+internal enum class PromoBanner { LOCATION, TELEMETRY, CLOTHES, PLAY, SCHEDULE, GEMINI, CELEBRATION }
 
 /**
  * Decides which promo cards the Today screen shows, capping the stack so a
  * fresh user isn't buried under "set this up" noise. Eligible cards are taken
- * in priority order (location > privacy > clothes > schedule > play > gemini > celebration) up
+ * in priority order (location > privacy > clothes > play > schedule > gemini > celebration) up
  * to [maxVisible]; the rest wait until a higher one is resolved or dismissed.
  *
  * The five customization nudges — clothes ([clothesPromoEligible]),
@@ -43,8 +43,8 @@ internal fun promoBannersToShow(
         if (locationActionRequired && hasForecast) add(PromoBanner.LOCATION)
         if (telemetryNoticeVisible) add(PromoBanner.TELEMETRY)
         if (clothesPromoEligible && hasForecast) add(PromoBanner.CLOTHES)
-        if (schedulePromoEligible && hasForecast) add(PromoBanner.SCHEDULE)
         if (playPromoEligible && hasForecast) add(PromoBanner.PLAY)
+        if (schedulePromoEligible && hasForecast) add(PromoBanner.SCHEDULE)
         if (geminiPromoEligible && hasForecast) add(PromoBanner.GEMINI)
         if (celebrationEligible && hasForecast) add(PromoBanner.CELEBRATION)
     }

--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
@@ -730,25 +730,12 @@ private fun BannerStack(
         onDismiss = onDismissClothesPromoCard,
         modifier = bannerModifier,
     )
-    // "Set up a schedule" nudge — scheduled casts don't fire until the user
-    // enables a slot, so a fresh install gets nothing on a timer. Gated
-    // upstream on neither master switch being on (plus the user not having
-    // dismissed), and held back by [promoBannersToShow] until a forecast
-    // exists and there's room under the cap. Sits between the clothes promo
-    // and the celebration promo. The CTA only routes to Schedule settings
-    // (where the notification-permission prompt lives); enabling a slot there
-    // auto-hides the card, so unlike the clothes card the CTA doesn't dismiss.
-    SchedulePromoCard(
-        visible = PromoBanner.SCHEDULE in shownPromos,
-        onOpenSchedule = onOpenSchedule,
-        onDismiss = onDismissSchedulePromoCard,
-        modifier = bannerModifier,
-    )
     // "Preview your ClothesCast" nudge — let the user hear the cast on demand
     // instead of waiting for the alarm. Gated upstream on a cast slot being
-    // enabled (true by default for the morning cast) plus not dismissed. Its
-    // Play button mirrors the top-bar one: same window derivation, same
-    // play-retires-the-promo behavior.
+    // enabled (true by default for the morning cast) plus not dismissed. Sits
+    // between the clothes promo and the schedule promo. Its Play button mirrors
+    // the top-bar one: same window derivation, same play-retires-the-promo
+    // behavior.
     val playPromoContext = LocalContext.current
     PlayPromoCard(
         visible = PromoBanner.PLAY in shownPromos,
@@ -770,6 +757,20 @@ private fun BannerStack(
             if (state.thisPeriodInsight != null) onDismissPlayPromoCard()
         },
         onDismiss = onDismissPlayPromoCard,
+        modifier = bannerModifier,
+    )
+    // "Set up a schedule" nudge — scheduled casts don't fire until the user
+    // enables a slot, so a fresh install gets nothing on a timer. Gated
+    // upstream on neither master switch being on (plus the user not having
+    // dismissed), and held back by [promoBannersToShow] until a forecast
+    // exists and there's room under the cap. Sits between the play promo
+    // and the Gemini-voices promo. The CTA only routes to Schedule settings
+    // (where the notification-permission prompt lives); enabling a slot there
+    // auto-hides the card, so unlike the clothes card the CTA doesn't dismiss.
+    SchedulePromoCard(
+        visible = PromoBanner.SCHEDULE in shownPromos,
+        onOpenSchedule = onOpenSchedule,
+        onDismiss = onDismissSchedulePromoCard,
         modifier = bannerModifier,
     )
     // "Try high quality voices" nudge — point users who haven't set up Gemini

--- a/app/src/test/kotlin/app/clothescast/ui/today/PromoBannersTest.kt
+++ b/app/src/test/kotlin/app/clothescast/ui/today/PromoBannersTest.kt
@@ -174,6 +174,21 @@ class PromoBannersTest {
     }
 
     @Test
+    fun `play promo outranks schedule under the cap`() {
+        promoBannersToShow(
+            locationActionRequired = false,
+            telemetryNoticeVisible = false,
+            clothesPromoEligible = false,
+            schedulePromoEligible = true,
+            playPromoEligible = true,
+            geminiPromoEligible = false,
+            celebrationEligible = false,
+            hasForecast = true,
+            maxVisible = 1,
+        ) shouldContainExactlyInAnyOrder listOf(PromoBanner.PLAY)
+    }
+
+    @Test
     fun `play promo is held back until a forecast exists`() {
         promoBannersToShow(
             locationActionRequired = false,


### PR DESCRIPTION
## What

Reorders the Today screen promo stack so the **"Preview your daily ClothesCast"** (play) card sits ahead of the **"Automatic ClothesCasts"** (schedule) card.

The change touches two places that have to agree:

- **Render order** in `TodayScreen.kt` — the `PlayPromoCard` block now renders before the `SchedulePromoCard` block (comments updated to match).
- **Priority order** in `promoBannersToShow` (`PromoBanners.kt`) — `PLAY` moves ahead of `SCHEDULE` in both the `PromoBanner` enum and the `buildList` ordering, so play also wins the slot when the two-card cap (`maxVisible = 2`) forces a choice between them.

New priority: location > privacy > clothes > **play > schedule** > gemini > celebration.

## Why

Hearing the cast on demand is the more immediate payoff for a new user, so the play nudge should lead the schedule nudge.

## Test plan

- Added `play promo outranks schedule under the cap` to `PromoBannersTest`.
- `./gradlew :app:testDebugUnitTest` — BUILD SUCCESSFUL (existing promo-priority tests use order-insensitive assertions, so the existing pairings still hold).
- Promo previews are per-card, so no snapshot changes.

No change to what leaves the device.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GdGcXz7Xet8mjAF9QwrhGo)_