### PR TITLE
Translate new Today, widget, and settings strings into all languages

### DIFF
--- a/app/src/main/res/values-am/strings.xml
+++ b/app/src/main/res/values-am/strings.xml
@@ -21,6 +21,7 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="garment_pants">ሱሪ</string>
     <string name="garment_jeans">ጂንስ</string>
     <string name="garment_gloves">ጓንቶች</string>
+    <string name="garment_umbrella">ጃንጥላ</string>
     <string name="garment_puffer">ፑፈር ጃኬት</string>
     <string name="garment_thin_jacket">ቀጭን ጃኬት</string>
     <string name="garment_skirt">ቀሚስ</string>
@@ -34,6 +35,7 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="settings_clothes_dialog_add_title">የልብስ ህግ ጨምር</string>
     <string name="settings_clothes_dialog_edit_title">የልብስ ህግ አርትዕ</string>
     <string name="settings_clothes_item_label">ልብስ</string>
+    <string name="settings_clothes_color_label">ቀለም</string>
     <string name="settings_clothes_condition_label">ሁኔታ</string>
     <string name="settings_clothes_value_label_temp">ደረጃ (%1$s)</string>
     <string name="settings_clothes_value_label_precip">ደረጃ (%%)</string>
@@ -67,6 +69,8 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="today_refresh">አድስ</string>
     <string name="today_empty_title">እስካሁን ClothesCast የለም</string>
     <string name="today_empty_subtitle">የጠዋቱ ClothesCast ከተሰራ በኋላ እዚህ ይታያል።</string>
+    <string name="today_empty_location_title">አካባቢ ያስፈልጋል</string>
+    <string name="today_empty_location_subtitle">የእርስዎን ClothesCast ለማግኘት አካባቢዎን ያዋቅሩ።</string>
     <string name="today_fetch_now">አሁን አምጣ</string>
     <string name="today_generated_at">በ%1$s ሰዓት ተሰርቷል</string>
     <string name="today_location_unknown">ቦታዎ</string>
@@ -123,6 +127,10 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="today_failed_no_location">ቦታዎን ማግኘት አልቻልንም። ሁልጊዜ ያለ ቦታ ፍቃድ ይስጡ፣ ወይም ከተማ በቅንብሮች ውስጥ ያስቀምጡ።</string>
     <string name="today_failed_show_details">ዝርዝሮችን አሳይ</string>
     <string name="today_failed_hide_details">ዝርዝሮችን ደብቅ</string>
+    <string name="today_mqtt_failed_title">ወደ ስማርት ቤትዎ መላክ አልተቻለም</string>
+    <string name="today_cast_failed_title">ወደ ማሳያዎ ማስተላለፍ አልተቻለም</string>
+    <string name="today_publish_failed_body">በሚቀጥለው ዝመና እንደገና እንሞክራለን።</string>
+    <string name="today_publish_failed_dismiss">ዝጋ</string>
     <string name="today_location_required_title">ቦታዎን ያዋቅሩ</string>
     <string name="today_location_required_body">ClothesCast ትንበያ ለማምጣት ቦታዎን ማወቅ ያስፈልጋል። ሁልጊዜ ያለ ቦታ ፍቃድ ይስጡ፣ ወይም ከተማ ይምረጡ።</string>
     <string name="today_location_required_action">የቦታ ቅንብሮችን ክፈት</string>
@@ -154,6 +162,11 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="feels_like_week_widget_label">የሚሰማ ሙቀት (7 ቀናት)</string>
     <string name="feels_like_week_widget_description">በሚቀጥሉት 7 ቀናት ውስጥ የሚሰማ ሙቀት።</string>
     <string name="feels_like_widget_empty_title">እስካሁን ትንበያ የለም</string>
+    <string name="conditions_widget_label">ሁኔታዎች</string>
+    <string name="conditions_widget_description">የሙቀት፣ ዝናብ፣ ነፋስ እና UV በጨረፍታ።</string>
+    <string name="conditions_rain_pct">%1$d%%</string>
+    <string name="conditions_wind">%1$d %2$s</string>
+    <string name="conditions_uv">UV %1$d</string>
 
     <!-- Onboarding -->
     <string name="onboarding_title">እንኳን ወደ ClothesCast መጡ</string>
@@ -268,6 +281,7 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="settings_schedule_time_label">ጊዜ</string>
     <string name="settings_schedule_days_label">የሳምንቱ ቀናት</string>
     <string name="settings_daily_mention_evening_events">የምሽት ዝግጅቶችን ጥቀስ</string>
+    <string name="settings_schedule_preview">አሁን አጫውት</string>
     <string name="settings_tonight_title">ምሽታዊ ClothesCast</string>
     <string name="settings_tonight_description">ዛሬ ምሽቱን ሁኔታ የሚሸፍን ምሽታዊ ሁለተኛ ClothesCast። ጸጥ ባሉ ምሽቶች ዝም ይላል፣ ዝግጅት ባለባቸው ምሽቶች ድምፅ ያሰማና ራሱን ያነባል።</string>
     <string name="settings_tonight_enabled">ምሽታዊ ClothesCast አሳይ</string>
@@ -1183,6 +1197,13 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="today_schedule_promo_body">ማሳወቂያዎችንና ማስታወቂያዎችን መቼ እንደምታገኝ ምረጥ።</string>
     <string name="today_schedule_promo_cta">የመርሐ ግብር ቅንብር</string>
     <string name="today_schedule_promo_dismiss">ዝጋ</string>
+    <string name="today_play_promo_title">ዕለታዊ ClothesCast ዎን ይስሙ</string>
+    <string name="today_play_promo_body">የእርስዎን ClothesCast ለመስማት የማጫወቻ አዝራሩን ይንኩ።</string>
+    <string name="today_play_promo_dismiss">ዝጋ</string>
+    <string name="today_gemini_promo_title">ከፍተኛ ጥራት ያላቸውን ድምፆች ይሞክሩ</string>
+    <string name="today_gemini_promo_body">የእርስዎን ClothesCast በተፈጥሯዊ፣ ሕያው ድምፆች ለመስማት Gemini ን ያብሩ።</string>
+    <string name="today_gemini_promo_cta">የድምፅ ቅንብሮች</string>
+    <string name="today_gemini_promo_dismiss">ዝጋ</string>
     <string name="today_clothes_promo_title">ልብሶቹን የራስህ አድርግ</string>
     <string name="today_insight_format_link">ቅርጸት</string>
     <string name="today_play">አጫውት</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -26,6 +26,7 @@ they work correctly in both the single-band and range templates.
     <string name="garment_pants">بنطلون</string>
     <string name="garment_jeans">جينز</string>
     <string name="garment_gloves">قفازات</string>
+    <string name="garment_umbrella">مظلة</string>
 
     <string name="settings_clothes_empty">لا توجد قواعد. اضغط على إضافة لإنشاء واحدة.</string>
     <string name="settings_clothes_add">إضافة</string>
@@ -34,6 +35,7 @@ they work correctly in both the single-band and range templates.
     <string name="settings_clothes_dialog_add_title">إضافة قاعدة ملابس</string>
     <string name="settings_clothes_dialog_edit_title">تعديل قاعدة الملابس</string>
     <string name="settings_clothes_item_label">الملابس</string>
+    <string name="settings_clothes_color_label">اللون</string>
     <string name="settings_clothes_condition_label">الشرط</string>
     <string name="settings_clothes_value_label_temp">العتبة (%1$s)</string>
     <string name="settings_clothes_value_label_precip">العتبة (%%)</string>
@@ -118,6 +120,8 @@ they work correctly in both the single-band and range templates.
     <string name="today_refresh">تحديث</string>
     <string name="today_empty_title">لا يوجد ClothesCast بعد</string>
     <string name="today_empty_subtitle">سيظهر ClothesCast الصباحي هنا بعد إنشائه.</string>
+    <string name="today_empty_location_title">الموقع مطلوب</string>
+    <string name="today_empty_location_subtitle">قم بإعداد موقعك للحصول على ClothesCast.</string>
     <string name="today_fetch_now">جلب الآن</string>
     <string name="today_generated_at">تم الإنشاء في %1$s</string>
     <string name="today_location_unknown">موقعك</string>
@@ -158,6 +162,11 @@ they work correctly in both the single-band and range templates.
     <string name="feels_like_week_widget_label">درجة الحرارة المحسوسة (7 أيام)</string>
     <string name="feels_like_week_widget_description">درجة الحرارة المحسوسة خلال الأيام السبعة القادمة.</string>
     <string name="feels_like_widget_empty_title">لا توجد توقعات بعد</string>
+    <string name="conditions_widget_label">الأحوال الجوية</string>
+    <string name="conditions_widget_description">درجة الحرارة والمطر والرياح وUV في لمحة.</string>
+    <string name="conditions_rain_pct">%1$d%%</string>
+    <string name="conditions_wind">%1$d %2$s</string>
+    <string name="conditions_uv">UV %1$d</string>
 
     <!-- Today — forecast / temperature chart -->
     <string name="today_forecast_title">درجة الحرارة المحسوسة</string>
@@ -206,6 +215,10 @@ they work correctly in both the single-band and range templates.
     <string name="today_failed_no_location">تعذّر تحديد موقعك. امنح إذن الموقع الدائم، أو حدد مدينة في الإعدادات.</string>
     <string name="today_failed_show_details">إظهار التفاصيل</string>
     <string name="today_failed_hide_details">إخفاء التفاصيل</string>
+    <string name="today_mqtt_failed_title">تعذّر الإرسال إلى منزلك الذكي</string>
+    <string name="today_cast_failed_title">تعذّر البث إلى شاشتك</string>
+    <string name="today_publish_failed_body">سنحاول مرة أخرى في التحديث التالي.</string>
+    <string name="today_publish_failed_dismiss">إغلاق</string>
     <string name="today_location_required_title">إعداد موقعك</string>
     <string name="today_location_required_body">تحتاج ClothesCast إلى معرفة موقعك لجلب التوقعات. امنح إذن الموقع الدائم، أو اختر مدينة.</string>
     <string name="today_location_required_action">فتح إعدادات الموقع</string>
@@ -345,6 +358,7 @@ they work correctly in both the single-band and range templates.
     <string name="settings_schedule_time_label">الوقت</string>
     <string name="settings_schedule_days_label">أيام الأسبوع</string>
     <string name="settings_daily_mention_evening_events">ذكر أحداث المساء</string>
+    <string name="settings_schedule_preview">تشغيل الآن</string>
     <string name="settings_tonight_title">ClothesCast الليلي</string>
     <string name="settings_tonight_description">ClothesCast ثانٍ مسائي يغطي طقس الليلة. في المساء الهادئ يبقى صامتًا؛ في مساء الأحداث يُصدر صوتًا ويقرأ نفسه.</string>
     <string name="settings_tonight_enabled">إظهار ClothesCast الليلي</string>
@@ -1217,6 +1231,13 @@ they work correctly in both the single-band and range templates.
     <string name="today_schedule_promo_body">اختر متى تتلقى الإشعارات والإعلانات.</string>
     <string name="today_schedule_promo_cta">إعدادات الجدول</string>
     <string name="today_schedule_promo_dismiss">إغلاق</string>
+    <string name="today_play_promo_title">استمع إلى ClothesCast اليومي</string>
+    <string name="today_play_promo_body">انقر على زر التشغيل لسماع ClothesCast.</string>
+    <string name="today_play_promo_dismiss">إغلاق</string>
+    <string name="today_gemini_promo_title">جرّب أصواتًا عالية الجودة</string>
+    <string name="today_gemini_promo_body">فعّل Gemini لسماع ClothesCast بأصوات طبيعية وواقعية.</string>
+    <string name="today_gemini_promo_cta">إعدادات الصوت</string>
+    <string name="today_gemini_promo_dismiss">إغلاق</string>
     <string name="today_clothes_promo_title">اجعل الملابس ملكك</string>
     <string name="today_insight_format_link">التنسيق</string>
     <string name="today_play">تشغيل</string>

--- a/app/src/main/res/values-b+sr+Latn/strings.xml
+++ b/app/src/main/res/values-b+sr+Latn/strings.xml
@@ -34,6 +34,7 @@ default English (matching values-pl / values-uk).
     <string name="garment_pants">Pantalone</string>
     <string name="garment_jeans">Farmerke</string>
     <string name="garment_gloves">Rukavice</string>
+    <string name="garment_umbrella">Kišobran</string>
     <string name="garment_polo">Polo</string>
     <string name="garment_thin_jacket">Tanka jakna</string>
     <string name="garment_puffer">Puffer jakna</string>
@@ -46,6 +47,7 @@ default English (matching values-pl / values-uk).
     <string name="settings_clothes_dialog_add_title">Dodaj pravilo odevanja</string>
     <string name="settings_clothes_dialog_edit_title">Izmeni pravilo odevanja</string>
     <string name="settings_clothes_item_label">Odevni predmet</string>
+    <string name="settings_clothes_color_label">Boja</string>
     <string name="settings_clothes_condition_label">Uslov</string>
     <string name="settings_clothes_value_label_temp">Prag (%1$s)</string>
     <string name="settings_clothes_value_label_precip">Prag (%%)</string>
@@ -204,6 +206,7 @@ default English (matching values-pl / values-uk).
     <string name="settings_schedule_time_label">Vreme</string>
     <string name="settings_schedule_days_label">Dani u sedmici</string>
     <string name="settings_daily_mention_evening_events">Pomeni večernje događaje</string>
+    <string name="settings_schedule_preview">Pusti sada</string>
 
     <string name="settings_tonight_title">Noćni ClothesCast</string>
     <string name="settings_tonight_description">Drugi ClothesCast uveče koji pokriva vremensku prognozu za večeras. Mirnih večeri ostaje tih ili se uopšte ne pojavljuje ako je uključeno „Obavesti samo kad ima večernjih događaja"; večerima sa događajima reproducira zvuk i (ako je uključen govorni prikaz) čita se naglas.</string>
@@ -445,6 +448,8 @@ default English (matching values-pl / values-uk).
     <string name="today_refresh">Osveži</string>
     <string name="today_empty_title">Još nema ClothesCasta</string>
     <string name="today_empty_subtitle">Tvoj jutarnji ClothesCast pojaviće se ovde čim bude generisan.</string>
+    <string name="today_empty_location_title">Potrebna je lokacija</string>
+    <string name="today_empty_location_subtitle">Podesite svoju lokaciju da biste dobili svoj ClothesCast.</string>
     <string name="today_fetch_now">Preuzmi odmah</string>
     <string name="today_generated_at">Generisano u %1$s</string>
     <string name="today_location_unknown">Tvoja lokacija</string>
@@ -478,6 +483,11 @@ default English (matching values-pl / values-uk).
     <string name="feels_like_week_widget_label">Osećajna (7 dana)</string>
     <string name="feels_like_week_widget_description">Osećajna temperatura za narednih 7 dana.</string>
     <string name="feels_like_widget_empty_title">Još nema prognoze</string>
+    <string name="conditions_widget_label">Uslovi</string>
+    <string name="conditions_widget_description">Temperatura, kiša, vetar i UV na prvi pogled.</string>
+    <string name="conditions_rain_pct">%1$d%%</string>
+    <string name="conditions_wind">%1$d %2$s</string>
+    <string name="conditions_uv">UV %1$d</string>
 
     <!-- Hourly forecast card. -->
     <string name="today_forecast_title">Prognoza po satu</string>
@@ -526,6 +536,10 @@ default English (matching values-pl / values-uk).
     <string name="today_failed_no_location">Nismo mogli da dobijemo tvoju lokaciju. Dozvoli trajni pristup lokaciji ili podesi grad u podešavanjima.</string>
     <string name="today_failed_show_details">Prikaži detalje</string>
     <string name="today_failed_hide_details">Sakrij detalje</string>
+    <string name="today_mqtt_failed_title">Slanje u vaš pametni dom nije uspelo</string>
+    <string name="today_cast_failed_title">Prebacivanje na vaš ekran nije uspelo</string>
+    <string name="today_publish_failed_body">Pokušaćemo ponovo pri sledećem ažuriranju.</string>
+    <string name="today_publish_failed_dismiss">Odbaci</string>
 
     <!-- Location required banner. -->
     <string name="today_location_required_title">Podesi svoju lokaciju</string>
@@ -1202,6 +1216,13 @@ default English (matching values-pl / values-uk).
     <string name="today_schedule_promo_body">Izaberi kada primaš obaveštenja i najave.</string>
     <string name="today_schedule_promo_cta">Podešavanja rasporeda</string>
     <string name="today_schedule_promo_dismiss">Odbaci</string>
+    <string name="today_play_promo_title">Slušajte svoj dnevni ClothesCast</string>
+    <string name="today_play_promo_body">Dodirnite dugme za reprodukciju da čujete svoj ClothesCast.</string>
+    <string name="today_play_promo_dismiss">Odbaci</string>
+    <string name="today_gemini_promo_title">Isprobajte glasove visokog kvaliteta</string>
+    <string name="today_gemini_promo_body">Uključite Gemini da čujete svoj ClothesCast prirodnim, životnim glasovima.</string>
+    <string name="today_gemini_promo_cta">Podešavanja glasa</string>
+    <string name="today_gemini_promo_dismiss">Odbaci</string>
     <string name="today_clothes_promo_title">Prilagodi odeću sebi</string>
     <string name="today_insight_format_link">Format</string>
     <string name="today_play">Pusti</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -30,6 +30,7 @@ What is NOT overridden, by design:
     <string name="garment_pants">Панталон</string>
     <string name="garment_jeans">Дънки</string>
     <string name="garment_gloves">Ръкавици</string>
+    <string name="garment_umbrella">Чадър</string>
     <string name="garment_polo">Поло</string>
     <string name="garment_thin_jacket">Тънко яке</string>
     <string name="garment_puffer">Зимно яке</string>
@@ -42,6 +43,7 @@ What is NOT overridden, by design:
     <string name="settings_clothes_dialog_add_title">Добави правило за обличане</string>
     <string name="settings_clothes_dialog_edit_title">Редактирай правило за обличане</string>
     <string name="settings_clothes_item_label">Дреха</string>
+    <string name="settings_clothes_color_label">Цвят</string>
     <string name="settings_clothes_condition_label">Условие</string>
     <string name="settings_clothes_value_label_temp">Праг (%1$s)</string>
     <string name="settings_clothes_value_label_precip">Праг (%)</string>
@@ -126,6 +128,8 @@ What is NOT overridden, by design:
     <string name="today_refresh">Обнови</string>
     <string name="today_empty_title">Все още няма ClothesCast</string>
     <string name="today_empty_subtitle">Сутрешният ти ClothesCast ще се появи тук, след като бъде генериран.</string>
+    <string name="today_empty_location_title">Изисква се местоположение</string>
+    <string name="today_empty_location_subtitle">Настройте местоположението си, за да получите своя ClothesCast.</string>
     <string name="today_fetch_now">Вземи сега</string>
     <string name="today_generated_at">Генерирано в %1$s</string>
     <string name="today_location_unknown">Твоето местоположение</string>
@@ -166,6 +170,11 @@ What is NOT overridden, by design:
     <string name="feels_like_week_widget_label">Усещана температура (7 дни)</string>
     <string name="feels_like_week_widget_description">Усещаната температура през следващите 7 дни.</string>
     <string name="feels_like_widget_empty_title">Все още няма прогноза</string>
+    <string name="conditions_widget_label">Условия</string>
+    <string name="conditions_widget_description">Температура, дъжд, вятър и UV с един поглед.</string>
+    <string name="conditions_rain_pct">%1$d%%</string>
+    <string name="conditions_wind">%1$d %2$s</string>
+    <string name="conditions_uv">UV %1$d</string>
 
     <!-- Hourly forecast card. -->
     <string name="today_forecast_title">Почасова прогноза</string>
@@ -214,6 +223,10 @@ What is NOT overridden, by design:
     <string name="today_failed_no_location">Не успяхме да получим твоето местоположение. Разреши постоянен достъп до местоположение или задай град в Настройките.</string>
     <string name="today_failed_show_details">Покажи подробности</string>
     <string name="today_failed_hide_details">Скрий подробности</string>
+    <string name="today_mqtt_failed_title">Изпращането към умния ви дом не бе успешно</string>
+    <string name="today_cast_failed_title">Предаването към дисплея ви не бе успешно</string>
+    <string name="today_publish_failed_body">Ще опитаме отново при следващото обновяване.</string>
+    <string name="today_publish_failed_dismiss">Затвори</string>
 
     <!-- Location-required prompt. -->
     <string name="today_location_required_title">Настрой местоположението си</string>
@@ -355,6 +368,7 @@ What is NOT overridden, by design:
     <string name="settings_schedule_time_label">Час</string>
     <string name="settings_schedule_days_label">Дни от седмицата</string>
     <string name="settings_daily_mention_evening_events">Споменавай вечерни събития</string>
+    <string name="settings_schedule_preview">Пусни сега</string>
 
     <!-- Nightly ClothesCast. -->
     <string name="settings_tonight_title">Нощен ClothesCast</string>
@@ -1199,6 +1213,13 @@ What is NOT overridden, by design:
     <string name="today_schedule_promo_body">Избери кога да получаваш известия и съобщения.</string>
     <string name="today_schedule_promo_cta">Настройки на разписанието</string>
     <string name="today_schedule_promo_dismiss">Затвори</string>
+    <string name="today_play_promo_title">Чуйте своя ежедневен ClothesCast</string>
+    <string name="today_play_promo_body">Докоснете бутона за възпроизвеждане, за да чуете своя ClothesCast.</string>
+    <string name="today_play_promo_dismiss">Затвори</string>
+    <string name="today_gemini_promo_title">Изпробвайте висококачествени гласове</string>
+    <string name="today_gemini_promo_body">Включете Gemini, за да чувате своя ClothesCast с естествени, реалистични гласове.</string>
+    <string name="today_gemini_promo_cta">Настройки на гласа</string>
+    <string name="today_gemini_promo_dismiss">Затвори</string>
     <string name="today_clothes_promo_title">Направи дрехите свои</string>
     <string name="today_insight_format_link">Формат</string>
     <string name="today_play">Възпроизведи</string>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -22,6 +22,7 @@ West Bengal vocabulary differences in a future PR.
     <string name="garment_pants">প্যান্ট</string>
     <string name="garment_jeans">জিন্স</string>
     <string name="garment_gloves">দস্তানা</string>
+    <string name="garment_umbrella">ছাতা</string>
 
     <string name="settings_clothes_empty">কোনো নিয়ম নেই। একটি তৈরি করতে যোগ করুন-এ ট্যাপ করুন।</string>
     <string name="settings_clothes_add">যোগ করুন</string>
@@ -30,6 +31,7 @@ West Bengal vocabulary differences in a future PR.
     <string name="settings_clothes_dialog_add_title">পোশাকের নিয়ম যোগ করুন</string>
     <string name="settings_clothes_dialog_edit_title">পোশাকের নিয়ম সম্পাদনা করুন</string>
     <string name="settings_clothes_item_label">পোশাক</string>
+    <string name="settings_clothes_color_label">রং</string>
     <string name="settings_clothes_condition_label">শর্ত</string>
     <string name="settings_clothes_value_label_temp">সীমা (%1$s)</string>
     <string name="settings_clothes_value_label_precip">সীমা (%%)</string>
@@ -120,6 +122,8 @@ West Bengal vocabulary differences in a future PR.
     <string name="today_refresh">রিফ্রেশ</string>
     <string name="today_empty_title">এখনো কোনো ClothesCast নেই</string>
     <string name="today_empty_subtitle">আপনার সকালের ClothesCast তৈরি হলে এখানে দেখা যাবে।</string>
+    <string name="today_empty_location_title">অবস্থান প্রয়োজন</string>
+    <string name="today_empty_location_subtitle">আপনার ClothesCast পেতে আপনার অবস্থান সেট আপ করুন।</string>
     <string name="today_fetch_now">এখনই আনুন</string>
     <string name="today_generated_at">%1$s-এ তৈরি</string>
     <string name="today_location_unknown">আপনার অবস্থান</string>
@@ -195,6 +199,10 @@ West Bengal vocabulary differences in a future PR.
     <string name="today_failed_no_location">আপনার অবস্থান পাওয়া যায়নি। সর্বদা অবস্থান অনুমতি দিন, অথবা সেটিংসে একটি শহর নির্ধারণ করুন।</string>
     <string name="today_failed_show_details">বিবরণ দেখুন</string>
     <string name="today_failed_hide_details">বিবরণ লুকান</string>
+    <string name="today_mqtt_failed_title">আপনার স্মার্ট হোমে পাঠানো যায়নি</string>
+    <string name="today_cast_failed_title">আপনার ডিসপ্লেতে কাস্ট করা যায়নি</string>
+    <string name="today_publish_failed_body">পরবর্তী আপডেটে আমরা আবার চেষ্টা করব।</string>
+    <string name="today_publish_failed_dismiss">বন্ধ</string>
 
     <!-- Location required -->
     <string name="today_location_required_title">আপনার অবস্থান নির্ধারণ করুন</string>
@@ -234,6 +242,11 @@ West Bengal vocabulary differences in a future PR.
     <string name="feels_like_week_widget_label">অনুভূত তাপমাত্রা (৭ দিন)</string>
     <string name="feels_like_week_widget_description">আগামী ৭ দিনের অনুভূত তাপমাত্রা।</string>
     <string name="feels_like_widget_empty_title">এখনো কোনো পূর্বাভাস নেই</string>
+    <string name="conditions_widget_label">অবস্থা</string>
+    <string name="conditions_widget_description">তাপমাত্রা, বৃষ্টি, বাতাস ও UV এক নজরে।</string>
+    <string name="conditions_rain_pct">%1$d%%</string>
+    <string name="conditions_wind">%1$d %2$s</string>
+    <string name="conditions_uv">UV %1$d</string>
 
     <!-- ============================================================
          Onboarding
@@ -318,6 +331,7 @@ West Bengal vocabulary differences in a future PR.
     <string name="settings_schedule_time_label">সময়</string>
     <string name="settings_schedule_days_label">সপ্তাহের দিন</string>
     <string name="settings_daily_mention_evening_events">সন্ধ্যার ইভেন্ট উল্লেখ করুন</string>
+    <string name="settings_schedule_preview">এখন চালান</string>
     <string name="settings_tonight_title">রাতের ClothesCast</string>
     <string name="settings_tonight_description">সন্ধ্যায় একটি দ্বিতীয় ClothesCast যা আজ রাতের আবহাওয়া জানায়। শান্ত সন্ধ্যায় এটি নীরব থাকে, বা যদি "শুধুমাত্র সন্ধ্যার ইভেন্ট থাকলে বিজ্ঞপ্তি দিন" চালু থাকে তবে একদমই দেখা নাও যেতে পারে; ইভেন্টের সন্ধ্যায় এটি শব্দ করে এবং (কথ্য বিতরণ চালু থাকলে) পড়ে শোনায়।</string>
     <string name="settings_tonight_enabled">রাতের ClothesCast দেখান</string>
@@ -1284,6 +1298,13 @@ West Bengal vocabulary differences in a future PR.
     <string name="today_schedule_promo_body">তুমি কখন বিজ্ঞপ্তি ও ঘোষণা পাবে তা বেছে নাও।</string>
     <string name="today_schedule_promo_cta">সময়সূচি সেটিংস</string>
     <string name="today_schedule_promo_dismiss">বন্ধ</string>
+    <string name="today_play_promo_title">আপনার দৈনিক ClothesCast শুনুন</string>
+    <string name="today_play_promo_body">আপনার ClothesCast শুনতে প্লে বোতামে ট্যাপ করুন।</string>
+    <string name="today_play_promo_dismiss">বন্ধ</string>
+    <string name="today_gemini_promo_title">উচ্চ মানের কণ্ঠ ব্যবহার করে দেখুন</string>
+    <string name="today_gemini_promo_body">স্বাভাবিক, প্রাণবন্ত কণ্ঠে আপনার ClothesCast শুনতে Gemini চালু করুন।</string>
+    <string name="today_gemini_promo_cta">ভয়েস সেটিংস</string>
+    <string name="today_gemini_promo_dismiss">বন্ধ</string>
     <string name="today_clothes_promo_title">পোশাককে নিজের করো</string>
     <string name="today_insight_format_link">ফর্ম্যাট</string>
     <string name="today_play">চালাও</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -16,6 +16,8 @@ the in-app clock is digit-driven and reads consistently across locales.
     <string name="today_refresh">Actualitza</string>
     <string name="today_empty_title">Encara no hi ha ClothesCast</string>
     <string name="today_empty_subtitle">El teu ClothesCast matinal apareixerà aquí un cop generat.</string>
+    <string name="today_empty_location_title">Cal una ubicació</string>
+    <string name="today_empty_location_subtitle">Configura la teva ubicació per obtenir el teu ClothesCast.</string>
     <string name="today_fetch_now">Obtén ara</string>
     <string name="today_generated_at">Generat a les %1$s</string>
     <string name="today_location_unknown">La teva ubicació</string>
@@ -58,6 +60,11 @@ the in-app clock is digit-driven and reads consistently across locales.
     <string name="feels_like_week_widget_label">Sensació (7 dies)</string>
     <string name="feels_like_week_widget_description">La temperatura percebuda durant els pròxims 7 dies.</string>
     <string name="feels_like_widget_empty_title">Encara no hi ha previsió</string>
+    <string name="conditions_widget_label">Condicions</string>
+    <string name="conditions_widget_description">Temperatura, pluja, vent i UV d\'un cop d\'ull.</string>
+    <string name="conditions_rain_pct">%1$d%%</string>
+    <string name="conditions_wind">%1$d %2$s</string>
+    <string name="conditions_uv">UV %1$d</string>
 
     <string name="today_forecast_title">Previsió per hores</string>
     <string name="today_forecast_min_max">Sensació %1$d – %2$d%3$s</string>
@@ -100,6 +107,10 @@ the in-app clock is digit-driven and reads consistently across locales.
     <string name="today_failed_no_location">No hem pogut obtenir la teva ubicació. Concedeix permís d\'ubicació permanent o estableix una ciutat a Configuració.</string>
     <string name="today_failed_show_details">Mostra els detalls</string>
     <string name="today_failed_hide_details">Amaga els detalls</string>
+    <string name="today_mqtt_failed_title">No s\'ha pogut enviar a la teva llar intel·ligent</string>
+    <string name="today_cast_failed_title">No s\'ha pogut emetre a la pantalla</string>
+    <string name="today_publish_failed_body">Ho tornarem a provar a la pròxima actualització.</string>
+    <string name="today_publish_failed_dismiss">Descarta</string>
 
     <string name="today_location_required_title">Configura la teva ubicació</string>
     <string name="today_location_required_body">ClothesCast necessita saber on ets per obtenir la previsió. Concedeix permís d\'ubicació permanent o tria una ciutat.</string>
@@ -230,6 +241,7 @@ the in-app clock is digit-driven and reads consistently across locales.
     <string name="settings_schedule_time_label">Hora</string>
     <string name="settings_schedule_days_label">Dies de la setmana</string>
     <string name="settings_daily_mention_evening_events">Menciona els esdeveniments del vespre</string>
+    <string name="settings_schedule_preview">Reprodueix ara</string>
 
     <string name="settings_tonight_title">ClothesCast nocturn</string>
     <string name="settings_tonight_description">Un segon ClothesCast al vespre que cobreix el temps per aquesta nit. En vespres tranquils roman silenciós, o no apareix si «Notifica només quan hi ha esdeveniments al vespre» és actiu; en vespres amb esdeveniments toca un so i (si has activat la lectura en veu alta) es llegeix sol.</string>
@@ -426,6 +438,7 @@ the in-app clock is digit-driven and reads consistently across locales.
     <string name="garment_pants">Pantalons</string>
     <string name="garment_jeans">Texans</string>
     <string name="garment_gloves">Guants</string>
+    <string name="garment_umbrella">Paraigua</string>
 
     <string name="settings_clothes_empty">Sense regles. Toca Afegir per crear-ne una.</string>
     <string name="settings_clothes_add">Afegir</string>
@@ -434,6 +447,7 @@ the in-app clock is digit-driven and reads consistently across locales.
     <string name="settings_clothes_dialog_add_title">Afegir regla de roba</string>
     <string name="settings_clothes_dialog_edit_title">Editar regla de roba</string>
     <string name="settings_clothes_item_label">Peça de roba</string>
+    <string name="settings_clothes_color_label">Color</string>
     <string name="settings_clothes_condition_label">Condició</string>
     <string name="settings_clothes_value_label_temp">Llindar (%1$s)</string>
     <string name="settings_clothes_value_label_precip">Llindar (%)</string>
@@ -1152,6 +1166,13 @@ the in-app clock is digit-driven and reads consistently across locales.
     <string name="today_schedule_promo_body">Tria quan reps notificacions i anuncis.</string>
     <string name="today_schedule_promo_cta">Configuració de la programació</string>
     <string name="today_schedule_promo_dismiss">Descarta</string>
+    <string name="today_play_promo_title">Escolta el teu ClothesCast diari</string>
+    <string name="today_play_promo_body">Toca el botó de reproducció per escoltar el teu ClothesCast.</string>
+    <string name="today_play_promo_dismiss">Descarta</string>
+    <string name="today_gemini_promo_title">Prova veus d\'alta qualitat</string>
+    <string name="today_gemini_promo_body">Activa Gemini per escoltar el teu ClothesCast amb veus naturals i realistes.</string>
+    <string name="today_gemini_promo_cta">Configuració de veu</string>
+    <string name="today_gemini_promo_dismiss">Descarta</string>
     <string name="today_clothes_promo_title">Fes teva la roba</string>
     <string name="today_insight_format_link">Format</string>
     <string name="today_play">Reprodueix</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -170,6 +170,7 @@ locale (Angličtina (USA), Francouzština (Francie), Němčina (Německo), …).
     <string name="garment_pants">Kalhoty</string>
     <string name="garment_jeans">Džíny</string>
     <string name="garment_gloves">Rukavice</string>
+    <string name="garment_umbrella">Deštník</string>
     <string name="garment_polo">Polo tričko</string>
     <string name="garment_thin_jacket">Lehká bunda</string>
     <string name="garment_puffer">Péřová bunda</string>
@@ -185,6 +186,7 @@ locale (Angličtina (USA), Francouzština (Francie), Němčina (Německo), …).
     <string name="settings_clothes_dialog_add_title">Přidat pravidlo oblékání</string>
     <string name="settings_clothes_dialog_edit_title">Upravit pravidlo oblékání</string>
     <string name="settings_clothes_item_label">Oblečení</string>
+    <string name="settings_clothes_color_label">Barva</string>
     <string name="settings_clothes_condition_label">Podmínka</string>
     <string name="settings_clothes_value_label_temp">Práh (%1$s)</string>
     <string name="settings_clothes_value_label_precip">Práh (%%)</string>
@@ -200,6 +202,7 @@ locale (Angličtina (USA), Francouzština (Francie), Němčina (Německo), …).
     <string name="settings_schedule_time_label">Čas</string>
     <string name="settings_schedule_days_label">Dny v týdnu</string>
     <string name="settings_daily_mention_evening_events">Zmiňovat večerní události</string>
+    <string name="settings_schedule_preview">Přehrát nyní</string>
 
     <string name="settings_tonight_title">Noční ClothesCast</string>
     <string name="settings_tonight_description">Druhý ClothesCast večer pro počasí dnešní noci. V klidných večerech zůstane tichý nebo se vůbec nezobrazí, pokud je aktivní „Upozorňovat jen při večerních událostech"; ve večerech s událostmi přehraje zvuk a (pokud máš zapnutý mluvený výstup) přečte se sám nahlas.</string>
@@ -364,6 +367,8 @@ locale (Angličtina (USA), Francouzština (Francie), Němčina (Německo), …).
     <string name="today_refresh">Obnovit</string>
     <string name="today_empty_title">Zatím žádný ClothesCast</string>
     <string name="today_empty_subtitle">Tvůj ranní ClothesCast se zde zobrazí, jakmile bude vytvořen.</string>
+    <string name="today_empty_location_title">Vyžadována poloha</string>
+    <string name="today_empty_location_subtitle">Nastavte svou polohu a získejte svůj ClothesCast.</string>
     <string name="today_fetch_now">Načíst nyní</string>
     <string name="today_generated_at">Vytvořeno v %1$s</string>
 
@@ -402,6 +407,10 @@ locale (Angličtina (USA), Francouzština (Francie), Němčina (Německo), …).
     <string name="today_failed_unhandled">Došlo k neočekávané chybě.</string>
     <string name="today_failed_show_details">Zobrazit podrobnosti</string>
     <string name="today_failed_hide_details">Skrýt podrobnosti</string>
+    <string name="today_mqtt_failed_title">Odeslání do chytré domácnosti se nezdařilo</string>
+    <string name="today_cast_failed_title">Odeslání na displej se nezdařilo</string>
+    <string name="today_publish_failed_body">Zkusíme to znovu při příští aktualizaci.</string>
+    <string name="today_publish_failed_dismiss">Zavřít</string>
     <string name="today_failed_no_location">Nepodařilo se zjistit tvou polohu. Udělej trvalé oprávnění k poloze nebo nastav město v nastavení.</string>
 
     <string name="today_location_required_title">Nastav svou polohu</string>
@@ -480,6 +489,11 @@ locale (Angličtina (USA), Francouzština (Francie), Němčina (Německo), …).
     <string name="feels_like_week_widget_label">Pocitová (7 dní)</string>
     <string name="feels_like_week_widget_description">Pocitová teplota na příštích 7 dní.</string>
     <string name="feels_like_widget_empty_title">Zatím žádná předpověď</string>
+    <string name="conditions_widget_label">Podmínky</string>
+    <string name="conditions_widget_description">Teplota, déšť, vítr a UV na první pohled.</string>
+    <string name="conditions_rain_pct">%1$d%%</string>
+    <string name="conditions_wind">%1$d %2$s</string>
+    <string name="conditions_uv">UV %1$d</string>
 
     <!-- Onboarding. -->
     <string name="onboarding_title">Vítej v ClothesCastu</string>
@@ -1222,6 +1236,13 @@ locale (Angličtina (USA), Francouzština (Francie), Němčina (Německo), …).
     <string name="today_schedule_promo_body">Vyber, kdy dostáváš oznámení a hlášení.</string>
     <string name="today_schedule_promo_cta">Nastavení plánu</string>
     <string name="today_schedule_promo_dismiss">Zavřít</string>
+    <string name="today_play_promo_title">Poslechněte si svůj denní ClothesCast</string>
+    <string name="today_play_promo_body">Klepnutím na tlačítko přehrávání si poslechněte svůj ClothesCast.</string>
+    <string name="today_play_promo_dismiss">Zavřít</string>
+    <string name="today_gemini_promo_title">Vyzkoušejte vysoce kvalitní hlasy</string>
+    <string name="today_gemini_promo_body">Zapněte Gemini a poslechněte si svůj ClothesCast přirozenými, věrnými hlasy.</string>
+    <string name="today_gemini_promo_cta">Nastavení hlasu</string>
+    <string name="today_gemini_promo_dismiss">Zavřít</string>
     <string name="today_clothes_promo_title">Přizpůsob si oblečení</string>
     <string name="today_insight_format_link">Formát</string>
     <string name="today_play">Přehrát</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -55,6 +55,7 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrig)").
     <string name="garment_pants">Bukser</string>
     <string name="garment_jeans">Jeans</string>
     <string name="garment_gloves">Handsker</string>
+    <string name="garment_umbrella">Paraply</string>
     <string name="garment_polo">Polo/Poloshirt</string>
     <string name="garment_thin_jacket">Tynd jakke</string>
     <string name="garment_puffer">Dunjakke</string>
@@ -70,6 +71,7 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrig)").
     <string name="settings_clothes_dialog_add_title">Tilføj tøjregel</string>
     <string name="settings_clothes_dialog_edit_title">Rediger tøjregel</string>
     <string name="settings_clothes_item_label">Tøjstykke</string>
+    <string name="settings_clothes_color_label">Farve</string>
     <string name="settings_clothes_condition_label">Betingelse</string>
     <string name="settings_clothes_value_label_temp">Tærskel (%1$s)</string>
     <string name="settings_clothes_value_label_precip">Tærskel (%%)</string>
@@ -85,6 +87,7 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrig)").
     <string name="settings_schedule_time_label">Tidspunkt</string>
     <string name="settings_schedule_days_label">Ugedage</string>
     <string name="settings_daily_mention_evening_events">Nævn aftenbegivenheder</string>
+    <string name="settings_schedule_preview">Afspil nu</string>
 
     <string name="settings_tonight_title">Aftenens ClothesCast</string>
     <string name="settings_tonight_description">Et andet ClothesCast om aftenen for vejret i aften. På rolige aftener er det stille eller vises slet ikke, hvis "Giv kun besked ved aftenbegivenheder" er aktiveret; på aftener med begivenheder afspiller det en lyd og (hvis du har talesyntese aktiveret) læser sig selv op.</string>
@@ -365,6 +368,8 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrig)").
     <string name="today_refresh">Opdater</string>
     <string name="today_empty_title">Intet ClothesCast endnu</string>
     <string name="today_empty_subtitle">Dit morgenvise ClothesCast dukker op her, når det er genereret.</string>
+    <string name="today_empty_location_title">Placering kræves</string>
+    <string name="today_empty_location_subtitle">Konfigurer din placering for at få din ClothesCast.</string>
     <string name="today_fetch_now">Hent nu</string>
     <string name="today_generated_at">Genereret klokken %1$s</string>
 
@@ -402,6 +407,10 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrig)").
     <string name="today_failed_unhandled">En uventet fejl opstod.</string>
     <string name="today_failed_show_details">Vis detaljer</string>
     <string name="today_failed_hide_details">Skjul detaljer</string>
+    <string name="today_mqtt_failed_title">Kunne ikke sende til dit smarte hjem</string>
+    <string name="today_cast_failed_title">Kunne ikke caste til din skærm</string>
+    <string name="today_publish_failed_body">Vi prøver igen ved næste opdatering.</string>
+    <string name="today_publish_failed_dismiss">Afvis</string>
     <string name="today_failed_no_location">Din placering kunne ikke fastslås. Giv permanent placeringsadgang, eller angiv en by i indstillingerne.</string>
 
     <string name="today_location_required_title">Angiv din placering</string>
@@ -481,6 +490,11 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrig)").
     <string name="feels_like_week_widget_label">Følt temperatur (7 dage)</string>
     <string name="feels_like_week_widget_description">Den følte temperatur over de næste 7 dage.</string>
     <string name="feels_like_widget_empty_title">Ingen prognose endnu</string>
+    <string name="conditions_widget_label">Forhold</string>
+    <string name="conditions_widget_description">Temperatur, regn, vind og UV på et øjeblik.</string>
+    <string name="conditions_rain_pct">%1$d%%</string>
+    <string name="conditions_wind">%1$d %2$s</string>
+    <string name="conditions_uv">UV %1$d</string>
 
     <!-- Onboarding. -->
     <string name="onboarding_title">Velkommen til ClothesCast</string>
@@ -1242,6 +1256,13 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrig)").
     <string name="today_schedule_promo_body">Vælg, hvornår du får notifikationer og oplæsninger.</string>
     <string name="today_schedule_promo_cta">Tidsplanindstillinger</string>
     <string name="today_schedule_promo_dismiss">Afvis</string>
+    <string name="today_play_promo_title">Hør din daglige ClothesCast</string>
+    <string name="today_play_promo_body">Tryk på afspilningsknappen for at høre din ClothesCast.</string>
+    <string name="today_play_promo_dismiss">Afvis</string>
+    <string name="today_gemini_promo_title">Prøv stemmer i høj kvalitet</string>
+    <string name="today_gemini_promo_body">Slå Gemini til for at høre din ClothesCast med naturlige, livagtige stemmer.</string>
+    <string name="today_gemini_promo_cta">Stemmeindstillinger</string>
+    <string name="today_gemini_promo_dismiss">Afvis</string>
     <string name="today_clothes_promo_title">Gør tøjet til dit eget</string>
     <string name="today_insight_format_link">Format</string>
     <string name="today_play">Afspil</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -58,6 +58,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="garment_pants">Lange Hose</string>
     <string name="garment_jeans">Jeans</string>
     <string name="garment_gloves">Handschuhe</string>
+    <string name="garment_umbrella">Regenschirm</string>
 
     <!-- Clothes settings — top of the screen. -->
     <string name="settings_clothes_title">Kleidungsregeln</string>
@@ -71,6 +72,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_clothes_dialog_add_title">Kleidungsregel hinzufügen</string>
     <string name="settings_clothes_dialog_edit_title">Kleidungsregel bearbeiten</string>
     <string name="settings_clothes_item_label">Kleidungsstück</string>
+    <string name="settings_clothes_color_label">Farbe</string>
     <string name="settings_clothes_condition_label">Auslöser</string>
     <string name="settings_clothes_value_label_temp">Schwelle (%1$s)</string>
     <string name="settings_clothes_value_label_precip">Schwelle (%%)</string>
@@ -93,6 +95,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_schedule_time_label">Uhrzeit</string>
     <string name="settings_schedule_days_label">Wochentage</string>
     <string name="settings_daily_mention_evening_events">Abendtermine erwähnen</string>
+    <string name="settings_schedule_preview">Jetzt abspielen</string>
 
     <string name="settings_tonight_title">Nächtlicher ClothesCast</string>
     <string name="settings_tonight_description">Ein zweiter ClothesCast am Abend für das Wetter heute Nacht. An ruhigen Abenden bleibt er stumm oder erscheint gar nicht, wenn „Nur benachrichtigen, wenn Abendtermine anstehen“ aktiv ist; an Abenden mit Terminen spielt er einen Ton ab und (wenn du gesprochene Ausgabe aktiviert hast) liest sich selbst vor.</string>
@@ -349,6 +352,8 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="today_refresh">Aktualisieren</string>
     <string name="today_empty_title">Noch kein ClothesCast</string>
     <string name="today_empty_subtitle">Dein morgendlicher ClothesCast erscheint hier, sobald er erstellt wurde.</string>
+    <string name="today_empty_location_title">Standort erforderlich</string>
+    <string name="today_empty_location_subtitle">Richte deinen Standort ein, um deinen ClothesCast zu erhalten.</string>
     <string name="today_fetch_now">Jetzt abrufen</string>
     <string name="today_generated_at">Erstellt um %1$s</string>
 
@@ -384,6 +389,10 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="today_failed_unhandled">Ein unerwarteter Fehler ist aufgetreten.</string>
     <string name="today_failed_show_details">Details anzeigen</string>
     <string name="today_failed_hide_details">Details ausblenden</string>
+    <string name="today_mqtt_failed_title">Senden an dein Smart Home fehlgeschlagen</string>
+    <string name="today_cast_failed_title">Übertragung an dein Display fehlgeschlagen</string>
+    <string name="today_publish_failed_body">Wir versuchen es bei der nächsten Aktualisierung erneut.</string>
+    <string name="today_publish_failed_dismiss">Schließen</string>
 
     <!-- Home-screen App Widget. -->
     <string name="widget_label">Outfit</string>
@@ -395,6 +404,11 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="feels_like_week_widget_label">Gefühlte Temperatur (7 Tage)</string>
     <string name="feels_like_week_widget_description">Die gefühlte Temperatur für die nächsten 7 Tage.</string>
     <string name="feels_like_widget_empty_title">Noch keine Vorhersage</string>
+    <string name="conditions_widget_label">Bedingungen</string>
+    <string name="conditions_widget_description">Temperatur, Regen, Wind und UV auf einen Blick.</string>
+    <string name="conditions_rain_pct">%1$d%%</string>
+    <string name="conditions_wind">%1$d %2$s</string>
+    <string name="conditions_uv">UV %1$d</string>
 
     <!--
     Onboarding flow — first-run welcome, two permission steps (notifications
@@ -1364,6 +1378,13 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="today_schedule_promo_body">Wähle, wann du Benachrichtigungen und Ansagen erhältst.</string>
     <string name="today_schedule_promo_cta">Zeitplan-Einstellungen</string>
     <string name="today_schedule_promo_dismiss">Schließen</string>
+    <string name="today_play_promo_title">Höre deinen täglichen ClothesCast</string>
+    <string name="today_play_promo_body">Tippe auf die Wiedergabetaste, um deinen ClothesCast zu hören.</string>
+    <string name="today_play_promo_dismiss">Schließen</string>
+    <string name="today_gemini_promo_title">Hochwertige Stimmen ausprobieren</string>
+    <string name="today_gemini_promo_body">Aktiviere Gemini, um deinen ClothesCast mit natürlichen, lebensechten Stimmen zu hören.</string>
+    <string name="today_gemini_promo_cta">Spracheinstellungen</string>
+    <string name="today_gemini_promo_dismiss">Schließen</string>
     <string name="today_clothes_promo_title">Mach die Kleidung zu deiner</string>
     <string name="today_insight_format_link">Format</string>
     <string name="today_play">Abspielen</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -71,6 +71,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="garment_pants">Παντελόνι</string>
     <string name="garment_jeans">Τζιν</string>
     <string name="garment_gloves">Γάντια</string>
+    <string name="garment_umbrella">Ομπρέλα</string>
 
     <!-- Clothes settings — top of the screen. εσύ-form imperatives
          throughout ("Πάτησε Προσθήκη για να δημιουργήσεις"). The
@@ -87,6 +88,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_clothes_dialog_add_title">Προσθήκη κανόνα ένδυσης</string>
     <string name="settings_clothes_dialog_edit_title">Επεξεργασία κανόνα ένδυσης</string>
     <string name="settings_clothes_item_label">Ρούχο</string>
+    <string name="settings_clothes_color_label">Χρώμα</string>
     <string name="settings_clothes_condition_label">Συνθήκη</string>
     <string name="settings_clothes_value_label_temp">Όριο (%1$s)</string>
     <string name="settings_clothes_value_label_precip">Όριο (%)</string>
@@ -111,6 +113,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_schedule_time_label">Ώρα</string>
     <string name="settings_schedule_days_label">Ημέρες της εβδομάδας</string>
     <string name="settings_daily_mention_evening_events">Αναφορά βραδινών συμβάντων</string>
+    <string name="settings_schedule_preview">Αναπαραγωγή τώρα</string>
 
     <string name="settings_tonight_title">Νυχτερινός ClothesCast</string>
     <string name="settings_tonight_description">Ένας δεύτερος ClothesCast το βράδυ που καλύπτει τον καιρό για απόψε. Σε ήσυχα βράδια παραμένει σιωπηλός, ή δεν εμφανίζεται καθόλου αν είναι ενεργό το «Ειδοποίηση μόνο όταν υπάρχουν βραδινά συμβάντα»· σε βράδια με συμβάντα παίζει έναν ήχο και (αν έχεις ενεργοποιήσει την ανάγνωση φωνητικά) διαβάζεται μόνος του.</string>
@@ -397,6 +400,8 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="today_refresh">Ανανέωση</string>
     <string name="today_empty_title">Δεν υπάρχει ακόμη ClothesCast</string>
     <string name="today_empty_subtitle">Ο πρωινός σου ClothesCast θα εμφανιστεί εδώ μόλις δημιουργηθεί.</string>
+    <string name="today_empty_location_title">Απαιτείται τοποθεσία</string>
+    <string name="today_empty_location_subtitle">Ρυθμίστε την τοποθεσία σας για να λάβετε το ClothesCast σας.</string>
     <string name="today_fetch_now">Ανάκτηση τώρα</string>
     <string name="today_generated_at">Δημιουργήθηκε στις %1$s</string>
 
@@ -428,6 +433,10 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="today_failed_no_location">Δεν μπορέσαμε να βρούμε την τοποθεσία σου. Παραχώρησε άδεια τοποθεσίας πάντα ενεργής, ή όρισε μια πόλη στις Ρυθμίσεις.</string>
     <string name="today_failed_show_details">Εμφάνιση λεπτομερειών</string>
     <string name="today_failed_hide_details">Απόκρυψη λεπτομερειών</string>
+    <string name="today_mqtt_failed_title">Δεν ήταν δυνατή η αποστολή στο έξυπνο σπίτι σας</string>
+    <string name="today_cast_failed_title">Δεν ήταν δυνατή η μετάδοση στην οθόνη σας</string>
+    <string name="today_publish_failed_body">Θα προσπαθήσουμε ξανά στην επόμενη ενημέρωση.</string>
+    <string name="today_publish_failed_dismiss">Απόρριψη</string>
 
     <string name="today_location_required_title">Όρισε την τοποθεσία σου</string>
     <string name="today_location_required_body">Ο ClothesCast πρέπει να γνωρίζει πού βρίσκεσαι για να ανακτήσει την πρόβλεψη. Παραχώρησε άδεια τοποθεσίας πάντα ενεργής, ή επίλεξε μια πόλη.</string>
@@ -445,6 +454,11 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="feels_like_week_widget_label">Αισθητή θερμοκρασία (7 ημέρες)</string>
     <string name="feels_like_week_widget_description">Η αισθητή θερμοκρασία για τις επόμενες 7 ημέρες.</string>
     <string name="feels_like_widget_empty_title">Δεν υπάρχει ακόμη πρόβλεψη</string>
+    <string name="conditions_widget_label">Συνθήκες</string>
+    <string name="conditions_widget_description">Θερμοκρασία, βροχή, άνεμος και UV με μια ματιά.</string>
+    <string name="conditions_rain_pct">%1$d%%</string>
+    <string name="conditions_wind">%1$d %2$s</string>
+    <string name="conditions_uv">UV %1$d</string>
 
     <!--
     Onboarding flow — first-run welcome, two permission steps (notifs +
@@ -1334,6 +1348,13 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="today_schedule_promo_body">Επίλεξε πότε λαμβάνεις ειδοποιήσεις και ανακοινώσεις.</string>
     <string name="today_schedule_promo_cta">Ρυθμίσεις προγράμματος</string>
     <string name="today_schedule_promo_dismiss">Απόρριψη</string>
+    <string name="today_play_promo_title">Ακούστε το καθημερινό σας ClothesCast</string>
+    <string name="today_play_promo_body">Πατήστε το κουμπί αναπαραγωγής για να ακούσετε το ClothesCast σας.</string>
+    <string name="today_play_promo_dismiss">Απόρριψη</string>
+    <string name="today_gemini_promo_title">Δοκιμάστε φωνές υψηλής ποιότητας</string>
+    <string name="today_gemini_promo_body">Ενεργοποιήστε το Gemini για να ακούτε το ClothesCast σας με φυσικές, ρεαλιστικές φωνές.</string>
+    <string name="today_gemini_promo_cta">Ρυθμίσεις φωνής</string>
+    <string name="today_gemini_promo_dismiss">Απόρριψη</string>
     <string name="today_clothes_promo_title">Κάνε τα ρούχα δικά σου</string>
     <string name="today_insight_format_link">Μορφή</string>
     <string name="today_play">Αναπαραγωγή</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -62,6 +62,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="garment_pants">Pantalones</string>
     <string name="garment_jeans">Vaqueros</string>
     <string name="garment_gloves">Guantes</string>
+    <string name="garment_umbrella">Paraguas</string>
 
     <!-- Clothes settings — top of the screen. -->
     <string name="settings_clothes_title">Reglas de ropa</string>
@@ -74,6 +75,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_clothes_dialog_add_title">Añadir regla de ropa</string>
     <string name="settings_clothes_dialog_edit_title">Editar regla de ropa</string>
     <string name="settings_clothes_item_label">Prenda</string>
+    <string name="settings_clothes_color_label">Color</string>
     <string name="settings_clothes_condition_label">Condición</string>
     <string name="settings_clothes_value_label_temp">Umbral (%1$s)</string>
     <string name="settings_clothes_value_label_precip">Umbral (%%)</string>
@@ -95,6 +97,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_schedule_time_label">Hora</string>
     <string name="settings_schedule_days_label">Días de la semana</string>
     <string name="settings_daily_mention_evening_events">Mencionar eventos de la tarde</string>
+    <string name="settings_schedule_preview">Reproducir ahora</string>
 
     <string name="settings_tonight_title">ClothesCast nocturno</string>
     <string name="settings_tonight_description">Un segundo ClothesCast por la tarde que cubre el tiempo de esta noche. En tardes tranquilas se queda silencioso, o no aparece en absoluto si „Notificar solo cuando haya eventos de la tarde“ está activado; en tardes con eventos reproduce un sonido y (si has activado la lectura en voz alta) se lee solo.</string>
@@ -347,6 +350,8 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="today_refresh">Actualizar</string>
     <string name="today_empty_title">Aún no hay ClothesCast</string>
     <string name="today_empty_subtitle">Tu ClothesCast matutino aparecerá aquí cuando se genere.</string>
+    <string name="today_empty_location_title">Se requiere ubicación</string>
+    <string name="today_empty_location_subtitle">Configura tu ubicación para obtener tu ClothesCast.</string>
     <string name="today_fetch_now">Obtener ahora</string>
     <string name="today_generated_at">Generado a las %1$s</string>
 
@@ -377,6 +382,10 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="today_failed_unhandled">Se ha producido un error inesperado.</string>
     <string name="today_failed_show_details">Mostrar detalles</string>
     <string name="today_failed_hide_details">Ocultar detalles</string>
+    <string name="today_mqtt_failed_title">No se pudo enviar a tu hogar inteligente</string>
+    <string name="today_cast_failed_title">No se pudo enviar a tu pantalla</string>
+    <string name="today_publish_failed_body">Lo intentaremos de nuevo en la próxima actualización.</string>
+    <string name="today_publish_failed_dismiss">Descartar</string>
 
     <!-- Home-screen App Widget. "Outfit" stays as the loanword (in
          common Spanish use, fits the casual register and matches the
@@ -390,6 +399,11 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="feels_like_week_widget_label">Sensación térmica (7 días)</string>
     <string name="feels_like_week_widget_description">La sensación térmica durante los próximos 7 días.</string>
     <string name="feels_like_widget_empty_title">Aún no hay previsión</string>
+    <string name="conditions_widget_label">Condiciones</string>
+    <string name="conditions_widget_description">Temperatura, lluvia, viento y UV de un vistazo.</string>
+    <string name="conditions_rain_pct">%1$d%%</string>
+    <string name="conditions_wind">%1$d %2$s</string>
+    <string name="conditions_uv">UV %1$d</string>
 
     <!--
     Onboarding flow — first-run welcome, two permission steps, Gemini
@@ -1340,6 +1354,13 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="today_schedule_promo_body">Elige cuándo recibes notificaciones y anuncios.</string>
     <string name="today_schedule_promo_cta">Ajustes de programación</string>
     <string name="today_schedule_promo_dismiss">Descartar</string>
+    <string name="today_play_promo_title">Escucha tu ClothesCast diario</string>
+    <string name="today_play_promo_body">Toca el botón de reproducción para escuchar tu ClothesCast.</string>
+    <string name="today_play_promo_dismiss">Descartar</string>
+    <string name="today_gemini_promo_title">Prueba voces de alta calidad</string>
+    <string name="today_gemini_promo_body">Activa Gemini para escuchar tu ClothesCast con voces naturales y realistas.</string>
+    <string name="today_gemini_promo_cta">Ajustes de voz</string>
+    <string name="today_gemini_promo_dismiss">Descartar</string>
     <string name="today_clothes_promo_title">Haz tuya la ropa</string>
     <string name="today_insight_format_link">Formato</string>
     <string name="today_play">Reproducir</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -16,6 +16,8 @@ Tone is informal "sina"-form throughout ("Pane … selga", "Võta … kaasa",
     <string name="today_refresh">Värskenda</string>
     <string name="today_empty_title">ClothesCast puudub veel</string>
     <string name="today_empty_subtitle">Sinu hommikune ClothesCast ilmub siia, kui see on genereeritud.</string>
+    <string name="today_empty_location_title">Asukoht on vajalik</string>
+    <string name="today_empty_location_subtitle">Seadistage oma asukoht, et saada oma ClothesCast.</string>
     <string name="today_fetch_now">Laadi kohe</string>
     <string name="today_generated_at">Genereeritud kell %1$s</string>
     <string name="today_location_unknown">Sinu asukoht</string>
@@ -58,6 +60,11 @@ Tone is informal "sina"-form throughout ("Pane … selga", "Võta … kaasa",
     <string name="feels_like_week_widget_label">Tunnetatav temperatuur (7 päeva)</string>
     <string name="feels_like_week_widget_description">Tunnetatav temperatuur järgmise 7 päeva jooksul.</string>
     <string name="feels_like_widget_empty_title">Prognoosi veel pole</string>
+    <string name="conditions_widget_label">Tingimused</string>
+    <string name="conditions_widget_description">Temperatuur, vihm, tuul ja UV ühe pilguga.</string>
+    <string name="conditions_rain_pct">%1$d%%</string>
+    <string name="conditions_wind">%1$d %2$s</string>
+    <string name="conditions_uv">UV %1$d</string>
 
     <string name="today_forecast_title">Tunnipõhine ilmaprognoos</string>
     <string name="today_forecast_min_max">Tundub %1$d – %2$d%3$s</string>
@@ -100,6 +107,10 @@ Tone is informal "sina"-form throughout ("Pane … selga", "Võta … kaasa",
     <string name="today_failed_no_location">Asukoha tuvastamine ebaõnnestus. Anna alati-sees asukohaluba või määra linn seadetes.</string>
     <string name="today_failed_show_details">Näita üksikasju</string>
     <string name="today_failed_hide_details">Peida üksikasjad</string>
+    <string name="today_mqtt_failed_title">Saatmine teie nutikodusse ebaõnnestus</string>
+    <string name="today_cast_failed_title">Ülekanne ekraanile ebaõnnestus</string>
+    <string name="today_publish_failed_body">Proovime järgmisel värskendusel uuesti.</string>
+    <string name="today_publish_failed_dismiss">Sulge</string>
 
     <string name="today_location_required_title">Seadista oma asukoht</string>
     <string name="today_location_required_body">ClothesCast peab teadma, kus sa oled, et laadida ilmaprognoos. Anna alati-sees asukohaluba või vali linn.</string>
@@ -232,6 +243,7 @@ Tone is informal "sina"-form throughout ("Pane … selga", "Võta … kaasa",
     <string name="settings_schedule_time_label">Kellaaeg</string>
     <string name="settings_schedule_days_label">Nädalapäevad</string>
     <string name="settings_daily_mention_evening_events">Maini õhtuseid sündmusi</string>
+    <string name="settings_schedule_preview">Esita kohe</string>
 
     <string name="settings_tonight_title">Õhtune ClothesCast</string>
     <string name="settings_tonight_description">Teine ClothesCast õhtul, mis käsitleb tänase õhtu ilma. Vaiksetel õhtutel jääb vaikseks või ei ilmu üldse, kui „Teavita ainult õhtuste sündmuste korral" on sees; sündmustega õhtutel esitab heli ja (kui kõvalugemise edastus on lubatud) loeb ise ette.</string>
@@ -432,6 +444,7 @@ Tone is informal "sina"-form throughout ("Pane … selga", "Võta … kaasa",
     <string name="garment_pants">Püksid</string>
     <string name="garment_jeans">Teksad</string>
     <string name="garment_gloves">Kindad</string>
+    <string name="garment_umbrella">Vihmavari</string>
 
     <string name="settings_clothes_empty">Reegleid pole. Lisa uus puudutades Lisa.</string>
     <string name="settings_clothes_add">Lisa</string>
@@ -440,6 +453,7 @@ Tone is informal "sina"-form throughout ("Pane … selga", "Võta … kaasa",
     <string name="settings_clothes_dialog_add_title">Lisa riietusereegel</string>
     <string name="settings_clothes_dialog_edit_title">Muuda riietusereeglit</string>
     <string name="settings_clothes_item_label">Riietusese</string>
+    <string name="settings_clothes_color_label">Värv</string>
     <string name="settings_clothes_condition_label">Tingimus</string>
     <string name="settings_clothes_value_label_temp">Lävi (%1$s)</string>
     <string name="settings_clothes_value_label_precip">Lävi (%%)</string>
@@ -1156,6 +1170,13 @@ Tone is informal "sina"-form throughout ("Pane … selga", "Võta … kaasa",
     <string name="today_schedule_promo_body">Vali, millal saad teavitusi ja teadaandeid.</string>
     <string name="today_schedule_promo_cta">Ajakava seaded</string>
     <string name="today_schedule_promo_dismiss">Sulge</string>
+    <string name="today_play_promo_title">Kuulake oma igapäevast ClothesCasti</string>
+    <string name="today_play_promo_body">Puudutage esitusnuppu, et kuulata oma ClothesCasti.</string>
+    <string name="today_play_promo_dismiss">Sulge</string>
+    <string name="today_gemini_promo_title">Proovige kvaliteetseid hääli</string>
+    <string name="today_gemini_promo_body">Lülitage Gemini sisse, et kuulata oma ClothesCasti loomulike, elutruude häältega.</string>
+    <string name="today_gemini_promo_cta">Hääle seaded</string>
+    <string name="today_gemini_promo_dismiss">Sulge</string>
     <string name="today_clothes_promo_title">Tee riided enda omaks</string>
     <string name="today_insight_format_link">Vorming</string>
     <string name="today_play">Esita</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -24,6 +24,7 @@ Western Arabic numerals (0-9) are used for TTS compatibility.
     <string name="garment_pants">شلوار</string>
     <string name="garment_jeans">جین</string>
     <string name="garment_gloves">دستکش</string>
+    <string name="garment_umbrella">چتر</string>
 
     <string name="settings_clothes_empty">قانونی وجود ندارد. برای ایجاد یک قانون روی افزودن ضربه بزنید.</string>
     <string name="settings_clothes_add">افزودن</string>
@@ -32,6 +33,7 @@ Western Arabic numerals (0-9) are used for TTS compatibility.
     <string name="settings_clothes_dialog_add_title">افزودن قانون لباس</string>
     <string name="settings_clothes_dialog_edit_title">ویرایش قانون لباس</string>
     <string name="settings_clothes_item_label">لباس</string>
+    <string name="settings_clothes_color_label">رنگ</string>
     <string name="settings_clothes_condition_label">شرط</string>
     <string name="settings_clothes_value_label_temp">آستانه (%1$s)</string>
     <string name="settings_clothes_value_label_precip">آستانه (%%)</string>
@@ -118,6 +120,8 @@ Western Arabic numerals (0-9) are used for TTS compatibility.
     <string name="today_refresh">بازخوانی</string>
     <string name="today_empty_title">هنوز ClothesCast وجود ندارد</string>
     <string name="today_empty_subtitle">ClothesCast صبحگاهی شما پس از تولید اینجا نمایش داده می‌شود.</string>
+    <string name="today_empty_location_title">موقعیت مکانی لازم است</string>
+    <string name="today_empty_location_subtitle">برای دریافت ClothesCast خود، موقعیت مکانی‌تان را تنظیم کنید.</string>
     <string name="today_fetch_now">دریافت اکنون</string>
     <string name="today_generated_at">تولید شده در %1$s</string>
     <string name="today_location_unknown">موقعیت شما</string>
@@ -158,6 +162,11 @@ Western Arabic numerals (0-9) are used for TTS compatibility.
     <string name="feels_like_week_widget_label">دمای احساس‌شده (7 روز)</string>
     <string name="feels_like_week_widget_description">دمای احساس‌شده طی 7 روز آینده.</string>
     <string name="feels_like_widget_empty_title">هنوز پیش‌بینی‌ای نیست</string>
+    <string name="conditions_widget_label">شرایط</string>
+    <string name="conditions_widget_description">دما، باران، باد و UV در یک نگاه.</string>
+    <string name="conditions_rain_pct">%1$d%%</string>
+    <string name="conditions_wind">%1$d %2$s</string>
+    <string name="conditions_uv">UV %1$d</string>
 
     <!-- Today — forecast charts -->
     <string name="today_forecast_title">دمای احساس‌شده</string>
@@ -196,6 +205,10 @@ Western Arabic numerals (0-9) are used for TTS compatibility.
     <string name="today_failed_no_location">موقعیت شما را نمی‌توانیم دریافت کنیم. مجوز موقعیت دائمی بدهید، یا یک شهر در تنظیمات تنظیم کنید.</string>
     <string name="today_failed_show_details">نمایش جزئیات</string>
     <string name="today_failed_hide_details">پنهان کردن جزئیات</string>
+    <string name="today_mqtt_failed_title">ارسال به خانه هوشمند شما ممکن نشد</string>
+    <string name="today_cast_failed_title">ارسال به نمایشگر شما ممکن نشد</string>
+    <string name="today_publish_failed_body">در به‌روزرسانی بعدی دوباره تلاش می‌کنیم.</string>
+    <string name="today_publish_failed_dismiss">رد کردن</string>
 
     <!-- Today — location required -->
     <string name="today_location_required_title">موقعیت خود را تنظیم کنید</string>
@@ -335,6 +348,7 @@ Western Arabic numerals (0-9) are used for TTS compatibility.
     <string name="settings_schedule_time_label">زمان</string>
     <string name="settings_schedule_days_label">روزهای هفته</string>
     <string name="settings_daily_mention_evening_events">ذکر رویدادهای عصر</string>
+    <string name="settings_schedule_preview">اکنون پخش کن</string>
     <string name="settings_tonight_title">ClothesCast شبانه</string>
     <string name="settings_tonight_description">یک ClothesCast دوم در عصر که آب‌وهوای امشب را پوشش می‌دهد. شب‌های آرام ساکت می‌ماند؛ شب‌های رویداد صدا پخش می‌کند و خودش را می‌خواند.</string>
     <string name="settings_tonight_enabled">نمایش ClothesCast شبانه</string>
@@ -1204,6 +1218,13 @@ Western Arabic numerals (0-9) are used for TTS compatibility.
     <string name="today_schedule_promo_body">انتخاب کنید چه زمانی اعلان‌ها و اعلام‌ها را دریافت کنید.</string>
     <string name="today_schedule_promo_cta">تنظیمات برنامه</string>
     <string name="today_schedule_promo_dismiss">رد کردن</string>
+    <string name="today_play_promo_title">ClothesCast روزانه خود را بشنوید</string>
+    <string name="today_play_promo_body">برای شنیدن ClothesCast خود، روی دکمه پخش ضربه بزنید.</string>
+    <string name="today_play_promo_dismiss">رد کردن</string>
+    <string name="today_gemini_promo_title">صداهای باکیفیت را امتحان کنید</string>
+    <string name="today_gemini_promo_body">برای شنیدن ClothesCast خود با صداهای طبیعی و واقعی، Gemini را روشن کنید.</string>
+    <string name="today_gemini_promo_cta">تنظیمات صدا</string>
+    <string name="today_gemini_promo_dismiss">رد کردن</string>
     <string name="today_clothes_promo_title">لباس را مال خودت کن</string>
     <string name="today_insight_format_link">قالب</string>
     <string name="today_play">پخش</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -44,6 +44,7 @@ displayed label localizes.
     <string name="garment_pants">Housut</string>
     <string name="garment_jeans">Farkut</string>
     <string name="garment_gloves">Hanskat</string>
+    <string name="garment_umbrella">Sateenvarjo</string>
 
     <string name="settings_clothes_title">Vaatesäännöt</string>
     <string name="settings_clothes_description">Kun ennuste ylittää jonkin näistä raja-arvoista, vaatekappale ilmestyy päivittäiseen ClothesCast-tiedotteeseen.</string>
@@ -55,6 +56,7 @@ displayed label localizes.
     <string name="settings_clothes_dialog_add_title">Lisää vaatesääntö</string>
     <string name="settings_clothes_dialog_edit_title">Muokkaa vaatesääntöä</string>
     <string name="settings_clothes_item_label">Vaatekappale</string>
+    <string name="settings_clothes_color_label">Väri</string>
     <string name="settings_clothes_condition_label">Ehto</string>
     <string name="settings_clothes_value_label_temp">Raja-arvo (%1$s)</string>
     <string name="settings_clothes_value_label_precip">Raja-arvo (%%)</string>
@@ -70,6 +72,7 @@ displayed label localizes.
     <string name="settings_schedule_time_label">Aika</string>
     <string name="settings_schedule_days_label">Viikonpäivät</string>
     <string name="settings_daily_mention_evening_events">Mainitse iltatapahtumat</string>
+    <string name="settings_schedule_preview">Toista nyt</string>
 
     <string name="settings_tonight_title">Iltainen ClothesCast</string>
     <string name="settings_tonight_description">Toinen ClothesCast illalla tämän yön säätä varten. Hiljaisina iltoina se on äänettömänä tai ei näy lainkaan, jos "Ilmoita vain illan tapahtumista" on käytössä. Tapahtumia sisältävinä iltoina se soittaa äänen ja (jos puhelähtö on käytössä) lukee itsensä ääneen.</string>
@@ -278,6 +281,8 @@ displayed label localizes.
     <string name="today_refresh">Päivitä</string>
     <string name="today_empty_title">Ei ClothesCastia vielä</string>
     <string name="today_empty_subtitle">Aamuinen ClothesCastisi ilmestyy tähän, kun se on luotu.</string>
+    <string name="today_empty_location_title">Sijainti vaaditaan</string>
+    <string name="today_empty_location_subtitle">Määritä sijaintisi saadaksesi ClothesCastisi.</string>
     <string name="today_fetch_now">Hae nyt</string>
     <string name="today_generated_at">Luotu kello %1$s</string>
 
@@ -308,6 +313,10 @@ displayed label localizes.
     <string name="today_failed_unhandled">Tapahtui odottamaton virhe.</string>
     <string name="today_failed_show_details">Näytä tiedot</string>
     <string name="today_failed_hide_details">Piilota tiedot</string>
+    <string name="today_mqtt_failed_title">Lähetys älykotiisi epäonnistui</string>
+    <string name="today_cast_failed_title">Lähetys näytöllesi epäonnistui</string>
+    <string name="today_publish_failed_body">Yritämme uudelleen seuraavan päivityksen yhteydessä.</string>
+    <string name="today_publish_failed_dismiss">Sulje</string>
 
     <string name="widget_label">Asu</string>
     <string name="widget_description">Tämän hetkisen päiväosan asu yhdellä silmäyksellä.</string>
@@ -318,6 +327,11 @@ displayed label localizes.
     <string name="feels_like_week_widget_label">Tuntuva lämpötila (7 päivää)</string>
     <string name="feels_like_week_widget_description">Tuntuva lämpötila seuraavan 7 päivän ajalle.</string>
     <string name="feels_like_widget_empty_title">Ei ennustetta vielä</string>
+    <string name="conditions_widget_label">Olosuhteet</string>
+    <string name="conditions_widget_description">Lämpötila, sade, tuuli ja UV yhdellä silmäyksellä.</string>
+    <string name="conditions_rain_pct">%1$d%%</string>
+    <string name="conditions_wind">%1$d %2$s</string>
+    <string name="conditions_uv">UV %1$d</string>
 
     <string name="onboarding_title">Tervetuloa ClothesCastiin</string>
     <string name="onboarding_subtitle">Kaksi nopeaa valintaa ja olet valmis. Kaikella muulla on järkevä oletusarvo, jonka voit myöhemmin muuttaa asetuksissa.</string>
@@ -1221,6 +1235,13 @@ displayed label localizes.
     <string name="today_schedule_promo_body">Valitse, milloin saat ilmoitukset ja kuulutukset.</string>
     <string name="today_schedule_promo_cta">Aikataulun asetukset</string>
     <string name="today_schedule_promo_dismiss">Sulje</string>
+    <string name="today_play_promo_title">Kuuntele päivittäinen ClothesCastisi</string>
+    <string name="today_play_promo_body">Napauta toistopainiketta kuullaksesi ClothesCastisi.</string>
+    <string name="today_play_promo_dismiss">Sulje</string>
+    <string name="today_gemini_promo_title">Kokeile korkealaatuisia ääniä</string>
+    <string name="today_gemini_promo_body">Ota Gemini käyttöön kuullaksesi ClothesCastisi luonnollisilla, eloisilla äänillä.</string>
+    <string name="today_gemini_promo_cta">Ääniasetukset</string>
+    <string name="today_gemini_promo_dismiss">Sulje</string>
     <string name="today_clothes_promo_title">Tee vaatteista omasi</string>
     <string name="today_insight_format_link">Muoto</string>
     <string name="today_play">Toista</string>

--- a/app/src/main/res/values-fil/strings.xml
+++ b/app/src/main/res/values-fil/strings.xml
@@ -20,6 +20,7 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="garment_pants">Mahabang pantalon</string>
     <string name="garment_jeans">Maong</string>
     <string name="garment_gloves">Guwantes</string>
+    <string name="garment_umbrella">Payong</string>
 
     <string name="settings_clothes_empty">Wala pang panuntunan. I-tap ang Magdagdag para lumikha.</string>
     <string name="settings_clothes_add">Magdagdag</string>
@@ -28,6 +29,7 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="settings_clothes_dialog_add_title">Magdagdag ng panuntunan sa damit</string>
     <string name="settings_clothes_dialog_edit_title">I-edit ang panuntunan sa damit</string>
     <string name="settings_clothes_item_label">Damit</string>
+    <string name="settings_clothes_color_label">Kulay</string>
     <string name="settings_clothes_condition_label">Kondisyon</string>
     <string name="settings_clothes_value_label_temp">Limitasyon (%1$s)</string>
     <string name="settings_clothes_value_label_precip">Limitasyon (%%)</string>
@@ -111,6 +113,8 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="today_refresh">I-refresh</string>
     <string name="today_empty_title">Wala pang ClothesCast</string>
     <string name="today_empty_subtitle">Lilitaw dito ang iyong umaga na ClothesCast kapag nagawa na ito.</string>
+    <string name="today_empty_location_title">Kailangan ng lokasyon</string>
+    <string name="today_empty_location_subtitle">I-set up ang iyong lokasyon para makuha ang iyong ClothesCast.</string>
     <string name="today_fetch_now">Kunin ngayon</string>
     <string name="today_generated_at">Nagawa noong %1$s</string>
     <string name="today_location_unknown">Ang iyong lokasyon</string>
@@ -150,6 +154,11 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="feels_like_week_widget_label">Nararamdamang temperatura (7 araw)</string>
     <string name="feels_like_week_widget_description">Ang nararamdamang temperatura sa susunod na 7 araw.</string>
     <string name="feels_like_widget_empty_title">Wala pang forecast</string>
+    <string name="conditions_widget_label">Mga kondisyon</string>
+    <string name="conditions_widget_description">Temperatura, ulan, hangin at UV sa isang sulyap.</string>
+    <string name="conditions_rain_pct">%1$d%%</string>
+    <string name="conditions_wind">%1$d %2$s</string>
+    <string name="conditions_uv">UV %1$d</string>
 
     <!-- Forecast card -->
     <string name="today_forecast_title">Oras-orasang hula</string>
@@ -196,6 +205,10 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="today_failed_no_location">Hindi namin makuha ang iyong lokasyon. Ibigay ang palaging naka-on na pahintulot sa lokasyon, o magtakda ng lungsod sa Mga Setting.</string>
     <string name="today_failed_show_details">Ipakita ang mga detalye</string>
     <string name="today_failed_hide_details">Itago ang mga detalye</string>
+    <string name="today_mqtt_failed_title">Hindi maipadala sa iyong smart home</string>
+    <string name="today_cast_failed_title">Hindi ma-cast sa iyong display</string>
+    <string name="today_publish_failed_body">Susubukan naming muli sa susunod na update.</string>
+    <string name="today_publish_failed_dismiss">Isara</string>
 
     <string name="today_location_required_title">Itakda ang iyong lokasyon</string>
     <string name="today_location_required_body">Kailangan ng ClothesCast na malaman kung nasaan ka para makuha ang hula. Ibigay ang palaging naka-on na pahintulot sa lokasyon, o pumili ng lungsod.</string>
@@ -353,6 +366,7 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="settings_schedule_time_label">Oras</string>
     <string name="settings_schedule_days_label">Mga araw ng linggo</string>
     <string name="settings_daily_mention_evening_events">Banggitin ang mga gabi na evento</string>
+    <string name="settings_schedule_preview">I-play ngayon</string>
 
     <string name="settings_tonight_title">Pang-gabing ClothesCast</string>
     <string name="settings_tonight_description">Pangalawang ClothesCast sa gabi na sumasaklaw sa panahon ngayong gabi. Sa mga tahimik na gabi ay nananatiling tahimik ito, o hindi lumilitaw kung naka-on ang "Mag-notify lamang kapag may mga gabi na evento"; sa mga gabi na may evento ay nagpapatugtog ng tunog at (kung pinagana mo ang pagbabasa nang malakas) binabasa ang sarili nito.</string>
@@ -1263,6 +1277,13 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="today_schedule_promo_body">Piliin kung kailan ka makakatanggap ng mga notification at anunsyo.</string>
     <string name="today_schedule_promo_cta">Mga setting ng schedule</string>
     <string name="today_schedule_promo_dismiss">Isara</string>
+    <string name="today_play_promo_title">Pakinggan ang iyong pang-araw-araw na ClothesCast</string>
+    <string name="today_play_promo_body">I-tap ang play button para marinig ang iyong ClothesCast.</string>
+    <string name="today_play_promo_dismiss">Isara</string>
+    <string name="today_gemini_promo_title">Subukan ang mga de-kalidad na boses</string>
+    <string name="today_gemini_promo_body">I-on ang Gemini para marinig ang iyong ClothesCast sa natural at totoong-tunog na mga boses.</string>
+    <string name="today_gemini_promo_cta">Mga setting ng boses</string>
+    <string name="today_gemini_promo_dismiss">Isara</string>
     <string name="today_clothes_promo_title">Gawing sariling iyo ang mga damit</string>
     <string name="today_insight_format_link">Format</string>
     <string name="today_play">I-play</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -62,6 +62,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="garment_pants">Pantalon</string>
     <string name="garment_jeans">Jean</string>
     <string name="garment_gloves">Gants</string>
+    <string name="garment_umbrella">Parapluie</string>
 
     <!-- Clothes settings — top of the screen. -->
     <string name="settings_clothes_title">Règles vestimentaires</string>
@@ -74,6 +75,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_clothes_dialog_add_title">Ajouter une règle vestimentaire</string>
     <string name="settings_clothes_dialog_edit_title">Modifier la règle vestimentaire</string>
     <string name="settings_clothes_item_label">Vêtement</string>
+    <string name="settings_clothes_color_label">Couleur</string>
     <string name="settings_clothes_condition_label">Déclencheur</string>
     <string name="settings_clothes_value_label_temp">Seuil (%1$s)</string>
     <string name="settings_clothes_value_label_precip">Seuil (%%)</string>
@@ -95,6 +97,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_schedule_time_label">Heure</string>
     <string name="settings_schedule_days_label">Jours de la semaine</string>
     <string name="settings_daily_mention_evening_events">Mentionner les événements du soir</string>
+    <string name="settings_schedule_preview">Lire maintenant</string>
 
     <string name="settings_tonight_title">ClothesCast nocturne</string>
     <string name="settings_tonight_description">Un second ClothesCast le soir qui couvre la météo de ce soir. Les soirs tranquilles, il reste silencieux, ou n\'apparaît pas du tout si „Notifier uniquement les soirs avec événements“ est activé ; les soirs avec événements, il joue un son et (si tu as activé la lecture à voix haute) se lit tout seul.</string>
@@ -349,6 +352,8 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="today_refresh">Actualiser</string>
     <string name="today_empty_title">Pas encore de ClothesCast</string>
     <string name="today_empty_subtitle">Ton ClothesCast matinal apparaîtra ici dès qu\'il sera généré.</string>
+    <string name="today_empty_location_title">Position requise</string>
+    <string name="today_empty_location_subtitle">Configurez votre position pour obtenir votre ClothesCast.</string>
     <string name="today_fetch_now">Récupérer maintenant</string>
     <string name="today_generated_at">Généré à %1$s</string>
 
@@ -379,6 +384,10 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="today_failed_unhandled">Une erreur inattendue s\'est produite.</string>
     <string name="today_failed_show_details">Afficher les détails</string>
     <string name="today_failed_hide_details">Masquer les détails</string>
+    <string name="today_mqtt_failed_title">Impossible d\'envoyer à votre maison connectée</string>
+    <string name="today_cast_failed_title">Impossible de diffuser sur votre écran</string>
+    <string name="today_publish_failed_body">Nous réessaierons lors de la prochaine mise à jour.</string>
+    <string name="today_publish_failed_dismiss">Ignorer</string>
 
     <!-- Home-screen App Widget. "Tenue" is the standard French word
          (French generally translates rather than loanwords for
@@ -393,6 +402,11 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="feels_like_week_widget_label">Ressenti (7 jours)</string>
     <string name="feels_like_week_widget_description">La température ressentie sur les 7 prochains jours.</string>
     <string name="feels_like_widget_empty_title">Pas encore de prévisions</string>
+    <string name="conditions_widget_label">Conditions</string>
+    <string name="conditions_widget_description">Température, pluie, vent et UV en un coup d\'œil.</string>
+    <string name="conditions_rain_pct">%1$d%%</string>
+    <string name="conditions_wind">%1$d %2$s</string>
+    <string name="conditions_uv">UV %1$d</string>
 
     <!--
     Onboarding flow — first-run welcome, two permission steps, Gemini
@@ -1339,6 +1353,13 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="today_schedule_promo_body">Choisis quand tu reçois les notifications et les annonces.</string>
     <string name="today_schedule_promo_cta">Paramètres de planification</string>
     <string name="today_schedule_promo_dismiss">Ignorer</string>
+    <string name="today_play_promo_title">Écoutez votre ClothesCast quotidien</string>
+    <string name="today_play_promo_body">Appuyez sur le bouton de lecture pour écouter votre ClothesCast.</string>
+    <string name="today_play_promo_dismiss">Ignorer</string>
+    <string name="today_gemini_promo_title">Essayez des voix de haute qualité</string>
+    <string name="today_gemini_promo_body">Activez Gemini pour écouter votre ClothesCast avec des voix naturelles et réalistes.</string>
+    <string name="today_gemini_promo_cta">Paramètres vocaux</string>
+    <string name="today_gemini_promo_dismiss">Ignorer</string>
     <string name="today_clothes_promo_title">Adapte les vêtements à ton goût</string>
     <string name="today_insight_format_link">Format</string>
     <string name="today_play">Lecture</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -53,6 +53,7 @@ Not overridden by design:
     <string name="garment_pants">पैंट</string>
     <string name="garment_jeans">जींस</string>
     <string name="garment_gloves">दस्ताने</string>
+    <string name="garment_umbrella">छाता</string>
 
     <!-- Clothes rules screen. -->
     <string name="settings_clothes_title">कपड़ों के नियम</string>
@@ -64,6 +65,7 @@ Not overridden by design:
     <string name="settings_clothes_dialog_add_title">कपड़ों का नियम जोड़ें</string>
     <string name="settings_clothes_dialog_edit_title">कपड़ों का नियम संपादित करें</string>
     <string name="settings_clothes_item_label">कपड़ा</string>
+    <string name="settings_clothes_color_label">रंग</string>
     <string name="settings_clothes_condition_label">शर्त</string>
     <string name="settings_clothes_value_label_temp">सीमा (%1$s)</string>
     <string name="settings_clothes_value_label_precip">सीमा (%%)</string>
@@ -79,6 +81,7 @@ Not overridden by design:
     <string name="settings_schedule_time_label">समय</string>
     <string name="settings_schedule_days_label">सप्ताह के दिन</string>
     <string name="settings_daily_mention_evening_events">शाम की घटनाओं का उल्लेख करें</string>
+    <string name="settings_schedule_preview">अभी चलाएँ</string>
 
     <string name="settings_tonight_title">रात्रि ClothesCast</string>
     <string name="settings_tonight_description">एक दूसरा ClothesCast शाम को जो आज रात के मौसम को कवर करता है। शांत शामों पर यह चुप रहता है, या यदि "केवल शाम की घटनाएँ होने पर सूचित करें" चालू है तो दिखता नहीं; घटनाओं वाली शामों पर यह आवाज़ करता है और (यदि बोलकर पढ़ने की सुविधा चालू हो) खुद पढ़ता है।</string>
@@ -337,6 +340,8 @@ Not overridden by design:
     <string name="today_refresh">रीफ़्रेश करें</string>
     <string name="today_empty_title">अभी कोई ClothesCast नहीं</string>
     <string name="today_empty_subtitle">आपका सुबह का ClothesCast तैयार होने पर यहाँ दिखेगा।</string>
+    <string name="today_empty_location_title">स्थान आवश्यक है</string>
+    <string name="today_empty_location_subtitle">अपना ClothesCast पाने के लिए अपना स्थान सेट करें।</string>
     <string name="today_fetch_now">अभी लाएँ</string>
     <string name="today_generated_at">%1$s को बनाया गया</string>
     <string name="today_location_unknown">आपका स्थान</string>
@@ -387,6 +392,10 @@ Not overridden by design:
     <string name="today_failed_no_location">आपका स्थान नहीं मिला। हमेशा-चालू स्थान अनुमति दें, या सेटिंग में कोई शहर सेट करें।</string>
     <string name="today_failed_show_details">विवरण दिखाएँ</string>
     <string name="today_failed_hide_details">विवरण छुपाएँ</string>
+    <string name="today_mqtt_failed_title">आपके स्मार्ट होम पर नहीं भेजा जा सका</string>
+    <string name="today_cast_failed_title">आपके डिस्प्ले पर कास्ट नहीं किया जा सका</string>
+    <string name="today_publish_failed_body">हम अगले अपडेट पर फिर से कोशिश करेंगे।</string>
+    <string name="today_publish_failed_dismiss">बंद करें</string>
 
     <!-- Location required empty state. -->
     <string name="today_location_required_title">अपना स्थान सेट करें</string>
@@ -417,6 +426,11 @@ Not overridden by design:
     <string name="feels_like_week_widget_label">महसूस तापमान (7 दिन)</string>
     <string name="feels_like_week_widget_description">अगले 7 दिनों का महसूस तापमान।</string>
     <string name="feels_like_widget_empty_title">अभी कोई पूर्वानुमान नहीं</string>
+    <string name="conditions_widget_label">स्थितियाँ</string>
+    <string name="conditions_widget_description">तापमान, बारिश, हवा और UV एक नज़र में।</string>
+    <string name="conditions_rain_pct">%1$d%%</string>
+    <string name="conditions_wind">%1$d %2$s</string>
+    <string name="conditions_uv">UV %1$d</string>
 
     <!-- Onboarding. -->
     <string name="onboarding_title">ClothesCast में आपका स्वागत है</string>
@@ -1244,6 +1258,13 @@ Not overridden by design:
     <string name="today_schedule_promo_body">चुनें कि आपको सूचनाएँ और घोषणाएँ कब मिलें।</string>
     <string name="today_schedule_promo_cta">समय-सारणी सेटिंग</string>
     <string name="today_schedule_promo_dismiss">बंद करें</string>
+    <string name="today_play_promo_title">अपना दैनिक ClothesCast सुनें</string>
+    <string name="today_play_promo_body">अपना ClothesCast सुनने के लिए प्ले बटन पर टैप करें।</string>
+    <string name="today_play_promo_dismiss">बंद करें</string>
+    <string name="today_gemini_promo_title">उच्च गुणवत्ता वाली आवाज़ें आज़माएँ</string>
+    <string name="today_gemini_promo_body">प्राकृतिक, सजीव आवाज़ों में अपना ClothesCast सुनने के लिए Gemini चालू करें।</string>
+    <string name="today_gemini_promo_cta">आवाज़ सेटिंग</string>
+    <string name="today_gemini_promo_dismiss">बंद करें</string>
     <string name="today_clothes_promo_title">कपड़ों को अपना बनाएँ</string>
     <string name="today_insight_format_link">प्रारूप</string>
     <string name="today_play">चलाएँ</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -32,6 +32,7 @@ spousal register), matching the existing insight prose ("Ponesi …",
     <string name="garment_pants">Hlače</string>
     <string name="garment_jeans">Traperice</string>
     <string name="garment_gloves">Rukavice</string>
+    <string name="garment_umbrella">Kišobran</string>
 
     <!-- Clothes settings — top of the screen. -->
     <string name="settings_clothes_title">Pravila odijevanja</string>
@@ -44,6 +45,7 @@ spousal register), matching the existing insight prose ("Ponesi …",
     <string name="settings_clothes_dialog_add_title">Dodaj pravilo odijevanja</string>
     <string name="settings_clothes_dialog_edit_title">Uredi pravilo odijevanja</string>
     <string name="settings_clothes_item_label">Odjevni predmet</string>
+    <string name="settings_clothes_color_label">Boja</string>
     <string name="settings_clothes_condition_label">Uvjet</string>
     <string name="settings_clothes_value_label_temp">Prag (%1$s)</string>
     <string name="settings_clothes_value_label_precip">Prag (%%)</string>
@@ -66,6 +68,7 @@ spousal register), matching the existing insight prose ("Ponesi …",
     <string name="settings_schedule_time_label">Vrijeme</string>
     <string name="settings_schedule_days_label">Dani u tjednu</string>
     <string name="settings_daily_mention_evening_events">Spomeni večernje događaje</string>
+    <string name="settings_schedule_preview">Reproduciraj sada</string>
 
     <string name="settings_tonight_title">Noćni ClothesCast</string>
     <string name="settings_tonight_description">Drugi ClothesCast navečer koji pokriva vrijeme za večeras. Tihim večerima ostaje bez zvuka ili se uopće ne pojavi ako je „Obavijesti samo kad ima večernjih događaja“ uključeno; večerima s događajima reproducira zvuk i (ako je uključen izgovor) sam se čita.</string>
@@ -321,6 +324,8 @@ spousal register), matching the existing insight prose ("Ponesi …",
     <string name="today_refresh">Osvježi</string>
     <string name="today_empty_title">Još nema ClothesCasta</string>
     <string name="today_empty_subtitle">Tvoj jutarnji ClothesCast pojavit će se ovdje čim bude generiran.</string>
+    <string name="today_empty_location_title">Potrebna je lokacija</string>
+    <string name="today_empty_location_subtitle">Postavite svoju lokaciju da biste dobili svoj ClothesCast.</string>
     <string name="today_fetch_now">Dohvati sada</string>
     <string name="today_generated_at">Generirano u %1$s</string>
 
@@ -351,6 +356,10 @@ spousal register), matching the existing insight prose ("Ponesi …",
     <string name="today_failed_unhandled">Došlo je do neočekivane greške.</string>
     <string name="today_failed_show_details">Prikaži detalje</string>
     <string name="today_failed_hide_details">Sakrij detalje</string>
+    <string name="today_mqtt_failed_title">Slanje u vaš pametni dom nije uspjelo</string>
+    <string name="today_cast_failed_title">Emitiranje na vaš zaslon nije uspjelo</string>
+    <string name="today_publish_failed_body">Pokušat ćemo ponovno pri sljedećem ažuriranju.</string>
+    <string name="today_publish_failed_dismiss">Odbaci</string>
 
     <!-- Home-screen App Widget. "Outfit" is in common Croatian use as a
          loanword and matches the casual register; the empty state
@@ -364,6 +373,11 @@ spousal register), matching the existing insight prose ("Ponesi …",
     <string name="feels_like_week_widget_label">Osjećajna (7 dana)</string>
     <string name="feels_like_week_widget_description">Osjećajna temperatura za sljedećih 7 dana.</string>
     <string name="feels_like_widget_empty_title">Još nema prognoze</string>
+    <string name="conditions_widget_label">Uvjeti</string>
+    <string name="conditions_widget_description">Temperatura, kiša, vjetar i UV na prvi pogled.</string>
+    <string name="conditions_rain_pct">%1$d%%</string>
+    <string name="conditions_wind">%1$d %2$s</string>
+    <string name="conditions_uv">UV %1$d</string>
 
     <!--
     Onboarding flow — first-run welcome, two permission steps, Gemini
@@ -1282,6 +1296,13 @@ spousal register), matching the existing insight prose ("Ponesi …",
     <string name="today_schedule_promo_body">Odaberi kada primaš obavijesti i najave.</string>
     <string name="today_schedule_promo_cta">Postavke rasporeda</string>
     <string name="today_schedule_promo_dismiss">Odbaci</string>
+    <string name="today_play_promo_title">Poslušajte svoj dnevni ClothesCast</string>
+    <string name="today_play_promo_body">Dodirnite gumb za reprodukciju da čujete svoj ClothesCast.</string>
+    <string name="today_play_promo_dismiss">Odbaci</string>
+    <string name="today_gemini_promo_title">Isprobajte glasove visoke kvalitete</string>
+    <string name="today_gemini_promo_body">Uključite Gemini da čujete svoj ClothesCast prirodnim, životnim glasovima.</string>
+    <string name="today_gemini_promo_cta">Postavke glasa</string>
+    <string name="today_gemini_promo_dismiss">Odbaci</string>
     <string name="today_clothes_promo_title">Prilagodi odjeću sebi</string>
     <string name="today_insight_format_link">Format</string>
     <string name="today_play">Pusti</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -172,6 +172,7 @@ locale (Angol (Egyesült Államok), Francia (Franciaország), Német
     <string name="garment_pants">Nadrág</string>
     <string name="garment_jeans">Farmer</string>
     <string name="garment_gloves">Kesztyű</string>
+    <string name="garment_umbrella">Esernyő</string>
     <string name="garment_polo">Galléros póló</string>
     <string name="garment_thin_jacket">Könnyű dzseki</string>
     <string name="garment_puffer">Steppelt kabát</string>
@@ -187,6 +188,7 @@ locale (Angol (Egyesült Államok), Francia (Franciaország), Német
     <string name="settings_clothes_dialog_add_title">Öltözködési szabály hozzáadása</string>
     <string name="settings_clothes_dialog_edit_title">Öltözködési szabály szerkesztése</string>
     <string name="settings_clothes_item_label">Ruhadarab</string>
+    <string name="settings_clothes_color_label">Szín</string>
     <string name="settings_clothes_condition_label">Feltétel</string>
     <string name="settings_clothes_value_label_temp">Küszöb (%1$s)</string>
     <string name="settings_clothes_value_label_precip">Küszöb (%%)</string>
@@ -202,6 +204,7 @@ locale (Angol (Egyesült Államok), Francia (Franciaország), Német
     <string name="settings_schedule_time_label">Időpont</string>
     <string name="settings_schedule_days_label">Hét napjai</string>
     <string name="settings_daily_mention_evening_events">Esti események megemlítése</string>
+    <string name="settings_schedule_preview">Lejátszás most</string>
 
     <string name="settings_tonight_title">Esti ClothesCast</string>
     <string name="settings_tonight_description">Egy második ClothesCast este a mai éjszakai időjáráshoz. Csendes estéken néma marad, vagy egyáltalán nem jelenik meg, ha az „Értesítés csak esti eseményeknél" aktív; eseményes estéken hangot ad, és (ha bekapcsoltad a hangos kimenetelt) felolvassa magát.</string>
@@ -366,6 +369,8 @@ locale (Angol (Egyesült Államok), Francia (Franciaország), Német
     <string name="today_refresh">Frissítés</string>
     <string name="today_empty_title">Még nincs ClothesCast</string>
     <string name="today_empty_subtitle">A reggeli ClothesCastod itt jelenik meg, amint elkészül.</string>
+    <string name="today_empty_location_title">Hely szükséges</string>
+    <string name="today_empty_location_subtitle">Állítsa be a helyét, hogy megkapja a ClothesCastját.</string>
     <string name="today_fetch_now">Betöltés most</string>
     <string name="today_generated_at">Létrehozva: %1$s</string>
 
@@ -404,6 +409,10 @@ locale (Angol (Egyesült Államok), Francia (Franciaország), Német
     <string name="today_failed_unhandled">Váratlan hiba történt.</string>
     <string name="today_failed_show_details">Részletek megjelenítése</string>
     <string name="today_failed_hide_details">Részletek elrejtése</string>
+    <string name="today_mqtt_failed_title">Nem sikerült elküldeni az okosotthonába</string>
+    <string name="today_cast_failed_title">Nem sikerült a kijelzőre küldeni</string>
+    <string name="today_publish_failed_body">A következő frissítéskor újra próbálkozunk.</string>
+    <string name="today_publish_failed_dismiss">Elvetés</string>
     <string name="today_failed_no_location">Nem sikerült meghatározni a helyszínedet. Adj állandó helyszín-engedélyt, vagy állíts be egy várost a beállításokban.</string>
 
     <string name="today_location_required_title">Állítsd be a helyszínedet</string>
@@ -482,6 +491,11 @@ locale (Angol (Egyesült Államok), Francia (Franciaország), Német
     <string name="feels_like_week_widget_label">Hőérzet (7 nap)</string>
     <string name="feels_like_week_widget_description">A hőérzet a következő 7 napra.</string>
     <string name="feels_like_widget_empty_title">Még nincs előrejelzés</string>
+    <string name="conditions_widget_label">Körülmények</string>
+    <string name="conditions_widget_description">Hőmérséklet, eső, szél és UV egy pillantással.</string>
+    <string name="conditions_rain_pct">%1$d%%</string>
+    <string name="conditions_wind">%1$d %2$s</string>
+    <string name="conditions_uv">UV %1$d</string>
 
     <!-- Onboarding. -->
     <string name="onboarding_title">Üdvözöl a ClothesCast</string>
@@ -1205,6 +1219,13 @@ locale (Angol (Egyesült Államok), Francia (Franciaország), Német
     <string name="today_schedule_promo_body">Válaszd ki, mikor kapsz értesítéseket és bejelentéseket.</string>
     <string name="today_schedule_promo_cta">Ütemezés beállításai</string>
     <string name="today_schedule_promo_dismiss">Elvetés</string>
+    <string name="today_play_promo_title">Hallgassa meg napi ClothesCastját</string>
+    <string name="today_play_promo_body">Koppintson a lejátszás gombra a ClothesCast meghallgatásához.</string>
+    <string name="today_play_promo_dismiss">Elvetés</string>
+    <string name="today_gemini_promo_title">Próbáljon ki kiváló minőségű hangokat</string>
+    <string name="today_gemini_promo_body">Kapcsolja be a Geminit, hogy természetes, élethű hangokon hallgassa a ClothesCastját.</string>
+    <string name="today_gemini_promo_cta">Hangbeállítások</string>
+    <string name="today_gemini_promo_dismiss">Elvetés</string>
     <string name="today_clothes_promo_title">Tedd magadévá a ruhákat</string>
     <string name="today_insight_format_link">Formátum</string>
     <string name="today_play">Lejátszás</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -22,6 +22,7 @@ to values/strings.xml (English).
     <string name="garment_pants">Celana panjang</string>
     <string name="garment_jeans">Celana jeans</string>
     <string name="garment_gloves">Sarung tangan</string>
+    <string name="garment_umbrella">Payung</string>
 
     <string name="settings_clothes_empty">Belum ada aturan. Ketuk Tambah untuk membuat satu.</string>
     <string name="settings_clothes_add">Tambah</string>
@@ -30,6 +31,7 @@ to values/strings.xml (English).
     <string name="settings_clothes_dialog_add_title">Tambah aturan pakaian</string>
     <string name="settings_clothes_dialog_edit_title">Edit aturan pakaian</string>
     <string name="settings_clothes_item_label">Pakaian</string>
+    <string name="settings_clothes_color_label">Warna</string>
     <string name="settings_clothes_condition_label">Pemicu</string>
     <string name="settings_clothes_value_label_temp">Ambang batas (%1$s)</string>
     <string name="settings_clothes_value_label_precip">Ambang batas (%%)</string>
@@ -116,6 +118,8 @@ to values/strings.xml (English).
     <string name="today_refresh">Perbarui</string>
     <string name="today_empty_title">Belum ada ClothesCast</string>
     <string name="today_empty_subtitle">ClothesCast pagi Anda akan muncul di sini setelah dibuat.</string>
+    <string name="today_empty_location_title">Lokasi diperlukan</string>
+    <string name="today_empty_location_subtitle">Atur lokasi Anda untuk mendapatkan ClothesCast Anda.</string>
     <string name="today_fetch_now">Ambil sekarang</string>
     <string name="today_generated_at">Dibuat pukul %1$s</string>
     <string name="today_location_unknown">Lokasi Anda</string>
@@ -156,6 +160,11 @@ to values/strings.xml (English).
     <string name="feels_like_week_widget_label">Suhu terasa (7 hari)</string>
     <string name="feels_like_week_widget_description">Suhu terasa selama 7 hari ke depan.</string>
     <string name="feels_like_widget_empty_title">Belum ada prakiraan</string>
+    <string name="conditions_widget_label">Kondisi</string>
+    <string name="conditions_widget_description">Suhu, hujan, angin, dan UV sekilas.</string>
+    <string name="conditions_rain_pct">%1$d%%</string>
+    <string name="conditions_wind">%1$d %2$s</string>
+    <string name="conditions_uv">UV %1$d</string>
 
     <!-- Forecast cards -->
     <string name="today_forecast_title">Prakiraan per jam</string>
@@ -198,6 +207,10 @@ to values/strings.xml (English).
     <string name="today_failed_no_location">Kami tidak dapat menemukan lokasi Anda. Izinkan akses lokasi setiap saat, atau atur kota di Pengaturan.</string>
     <string name="today_failed_show_details">Tampilkan detail</string>
     <string name="today_failed_hide_details">Sembunyikan detail</string>
+    <string name="today_mqtt_failed_title">Tidak dapat mengirim ke rumah pintar Anda</string>
+    <string name="today_cast_failed_title">Tidak dapat menampilkan ke layar Anda</string>
+    <string name="today_publish_failed_body">Kami akan mencoba lagi pada pembaruan berikutnya.</string>
+    <string name="today_publish_failed_dismiss">Tutup</string>
 
     <!-- Location required prompt -->
     <string name="today_location_required_title">Atur lokasi Anda</string>
@@ -337,6 +350,7 @@ to values/strings.xml (English).
     <string name="settings_schedule_time_label">Waktu</string>
     <string name="settings_schedule_days_label">Hari dalam seminggu</string>
     <string name="settings_daily_mention_evening_events">Sebutkan acara malam</string>
+    <string name="settings_schedule_preview">Putar sekarang</string>
     <string name="settings_tonight_title">ClothesCast Malam</string>
     <string name="settings_tonight_description">ClothesCast kedua di malam hari yang mencakup cuaca malam ini. Di malam yang tenang, notifikasi tidak muncul, atau sama sekali tidak muncul jika "Hanya beri tahu saat ada acara malam" diaktifkan; di malam dengan acara, notifikasi berbunyi dan (jika pengiriman dengan suara diaktifkan) dibacakan.</string>
     <string name="settings_tonight_enabled">Tampilkan ClothesCast malam</string>
@@ -1212,6 +1226,13 @@ to values/strings.xml (English).
     <string name="today_schedule_promo_body">Pilih kapan Anda menerima notifikasi dan pengumuman.</string>
     <string name="today_schedule_promo_cta">Pengaturan jadwal</string>
     <string name="today_schedule_promo_dismiss">Tutup</string>
+    <string name="today_play_promo_title">Dengarkan ClothesCast harian Anda</string>
+    <string name="today_play_promo_body">Ketuk tombol putar untuk mendengar ClothesCast Anda.</string>
+    <string name="today_play_promo_dismiss">Tutup</string>
+    <string name="today_gemini_promo_title">Coba suara berkualitas tinggi</string>
+    <string name="today_gemini_promo_body">Aktifkan Gemini untuk mendengar ClothesCast Anda dengan suara alami yang hidup.</string>
+    <string name="today_gemini_promo_cta">Setelan suara</string>
+    <string name="today_gemini_promo_dismiss">Tutup</string>
     <string name="today_clothes_promo_title">Buat pakaian sendiri</string>
     <string name="today_insight_format_link">Format</string>
     <string name="today_play">Putar</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -50,6 +50,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="garment_pants">Pantaloni</string>
     <string name="garment_jeans">Jeans</string>
     <string name="garment_gloves">Guanti</string>
+    <string name="garment_umbrella">Ombrello</string>
 
     <!-- Clothes settings — top of the screen. -->
     <string name="settings_clothes_title">Regole abbigliamento</string>
@@ -62,6 +63,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_clothes_dialog_add_title">Aggiungi regola abbigliamento</string>
     <string name="settings_clothes_dialog_edit_title">Modifica regola abbigliamento</string>
     <string name="settings_clothes_item_label">Capo</string>
+    <string name="settings_clothes_color_label">Colore</string>
     <string name="settings_clothes_condition_label">Condizione</string>
     <string name="settings_clothes_value_label_temp">Soglia (%1$s)</string>
     <string name="settings_clothes_value_label_precip">Soglia (%%)</string>
@@ -83,6 +85,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_schedule_time_label">Ora</string>
     <string name="settings_schedule_days_label">Giorni della settimana</string>
     <string name="settings_daily_mention_evening_events">Cita gli eventi serali</string>
+    <string name="settings_schedule_preview">Riproduci ora</string>
 
     <string name="settings_tonight_title">ClothesCast serale</string>
     <string name="settings_tonight_description">Un secondo ClothesCast la sera che copre il tempo di stasera. Nelle serate tranquille resta silenzioso, o non appare affatto se „Avvisa solo quando ci sono eventi serali“ è attivo; nelle serate con eventi riproduce un suono e (se hai attivato la lettura vocale) si legge da solo.</string>
@@ -339,6 +342,8 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="today_refresh">Aggiorna</string>
     <string name="today_empty_title">Ancora nessun ClothesCast</string>
     <string name="today_empty_subtitle">Il tuo ClothesCast mattutino apparirà qui una volta generato.</string>
+    <string name="today_empty_location_title">Posizione richiesta</string>
+    <string name="today_empty_location_subtitle">Configura la tua posizione per ottenere il tuo ClothesCast.</string>
     <string name="today_fetch_now">Aggiorna ora</string>
     <string name="today_generated_at">Generato alle %1$s</string>
 
@@ -369,6 +374,10 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="today_failed_unhandled">Si è verificato un errore imprevisto.</string>
     <string name="today_failed_show_details">Mostra dettagli</string>
     <string name="today_failed_hide_details">Nascondi dettagli</string>
+    <string name="today_mqtt_failed_title">Impossibile inviare alla tua casa intelligente</string>
+    <string name="today_cast_failed_title">Impossibile trasmettere al tuo display</string>
+    <string name="today_publish_failed_body">Riproveremo al prossimo aggiornamento.</string>
+    <string name="today_publish_failed_dismiss">Ignora</string>
 
     <!-- Home-screen App Widget. "Outfit" is in common Italian use as a
          loanword; the empty state localises naturally. -->
@@ -381,6 +390,11 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="feels_like_week_widget_label">Percepita (7 giorni)</string>
     <string name="feels_like_week_widget_description">La temperatura percepita nei prossimi 7 giorni.</string>
     <string name="feels_like_widget_empty_title">Ancora nessuna previsione</string>
+    <string name="conditions_widget_label">Condizioni</string>
+    <string name="conditions_widget_description">Temperatura, pioggia, vento e UV a colpo d\'occhio.</string>
+    <string name="conditions_rain_pct">%1$d%%</string>
+    <string name="conditions_wind">%1$d %2$s</string>
+    <string name="conditions_uv">UV %1$d</string>
 
     <!--
     Onboarding flow — first-run welcome, two permission steps, Gemini
@@ -1325,6 +1339,13 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="today_schedule_promo_body">Scegli quando ricevere notifiche e annunci.</string>
     <string name="today_schedule_promo_cta">Impostazioni programmazione</string>
     <string name="today_schedule_promo_dismiss">Ignora</string>
+    <string name="today_play_promo_title">Ascolta il tuo ClothesCast quotidiano</string>
+    <string name="today_play_promo_body">Tocca il pulsante di riproduzione per ascoltare il tuo ClothesCast.</string>
+    <string name="today_play_promo_dismiss">Ignora</string>
+    <string name="today_gemini_promo_title">Prova voci di alta qualità</string>
+    <string name="today_gemini_promo_body">Attiva Gemini per ascoltare il tuo ClothesCast con voci naturali e realistiche.</string>
+    <string name="today_gemini_promo_cta">Impostazioni voce</string>
+    <string name="today_gemini_promo_dismiss">Ignora</string>
     <string name="today_clothes_promo_title">Personalizza l\'abbigliamento</string>
     <string name="today_insight_format_link">Formato</string>
     <string name="today_play">Riproduci</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -25,6 +25,7 @@ standard in Israeli digital communication.
     <string name="garment_pants">מכנסיים ארוכים</string>
     <string name="garment_jeans">ג׳ינס</string>
     <string name="garment_gloves">כפפות</string>
+    <string name="garment_umbrella">מטרייה</string>
 
     <string name="settings_clothes_empty">אין חוקים. הקש על הוספה כדי ליצור אחד.</string>
     <string name="settings_clothes_add">הוספה</string>
@@ -33,6 +34,7 @@ standard in Israeli digital communication.
     <string name="settings_clothes_dialog_add_title">הוספת חוק לגדים</string>
     <string name="settings_clothes_dialog_edit_title">עריכת חוק לגדים</string>
     <string name="settings_clothes_item_label">פריט לבוש</string>
+    <string name="settings_clothes_color_label">צבע</string>
     <string name="settings_clothes_condition_label">תנאי</string>
     <string name="settings_clothes_value_label_temp">סף (%1$s)</string>
     <string name="settings_clothes_value_label_precip">סף (%%)</string>
@@ -118,6 +120,8 @@ standard in Israeli digital communication.
     <string name="today_refresh">רענן/י</string>
     <string name="today_empty_title">אין ClothesCast עדיין</string>
     <string name="today_empty_subtitle">ClothesCast הבוקר שלך יופיע כאן לאחר שייווצר.</string>
+    <string name="today_empty_location_title">נדרש מיקום</string>
+    <string name="today_empty_location_subtitle">הגדר את המיקום שלך כדי לקבל את ה-ClothesCast שלך.</string>
     <string name="today_fetch_now">טען עכשיו</string>
     <string name="today_generated_at">נוצר ב-%1$s</string>
     <string name="today_location_unknown">המיקום שלך</string>
@@ -158,6 +162,11 @@ standard in Israeli digital communication.
     <string name="feels_like_week_widget_label">טמפרטורה מורגשת (7 ימים)</string>
     <string name="feels_like_week_widget_description">הטמפרטורה המורגשת ב-7 הימים הקרובים.</string>
     <string name="feels_like_widget_empty_title">אין עדיין תחזית</string>
+    <string name="conditions_widget_label">תנאים</string>
+    <string name="conditions_widget_description">טמפרטורה, גשם, רוח ו-UV במבט אחד.</string>
+    <string name="conditions_rain_pct">%1$d%%</string>
+    <string name="conditions_wind">%1$d %2$s</string>
+    <string name="conditions_uv">UV %1$d</string>
 
     <!-- Today — forecast chart -->
     <string name="today_forecast_title">טמפרטורה מורגשת</string>
@@ -202,6 +211,10 @@ standard in Israeli digital communication.
     <string name="today_failed_no_location">לא הצלחנו לאתר את מיקומך. הענק/י הרשאת מיקום תמידית, או הגדר/י עיר בהגדרות.</string>
     <string name="today_failed_show_details">הצג/י פרטים</string>
     <string name="today_failed_hide_details">הסתר/י פרטים</string>
+    <string name="today_mqtt_failed_title">לא ניתן היה לשלוח לבית החכם שלך</string>
+    <string name="today_cast_failed_title">לא ניתן היה להעביר למסך שלך</string>
+    <string name="today_publish_failed_body">ננסה שוב בעדכון הבא.</string>
+    <string name="today_publish_failed_dismiss">סגור</string>
 
     <!-- Today — location required -->
     <string name="today_location_required_title">הגדר/י את מיקומך</string>
@@ -341,6 +354,7 @@ standard in Israeli digital communication.
     <string name="settings_schedule_time_label">שעה</string>
     <string name="settings_schedule_days_label">ימות השבוע</string>
     <string name="settings_daily_mention_evening_events">ציין/י אירועי ערב</string>
+    <string name="settings_schedule_preview">הפעל עכשיו</string>
     <string name="settings_tonight_title">ClothesCast לילי</string>
     <string name="settings_tonight_description">ClothesCast שני בערב המכסה את מזג האוויר הלילי. בערבים שקטים נשאר שקט; בערבי אירועים משמיע צליל וקורא את עצמו.</string>
     <string name="settings_tonight_enabled">הצג/י ClothesCast לילי</string>
@@ -1214,6 +1228,13 @@ standard in Israeli digital communication.
     <string name="today_schedule_promo_body">בחר/י מתי לקבל התראות והכרזות.</string>
     <string name="today_schedule_promo_cta">הגדרות לוח זמנים</string>
     <string name="today_schedule_promo_dismiss">סגור</string>
+    <string name="today_play_promo_title">האזן ל-ClothesCast היומי שלך</string>
+    <string name="today_play_promo_body">הקש על לחצן ההפעלה כדי לשמוע את ה-ClothesCast שלך.</string>
+    <string name="today_play_promo_dismiss">סגור</string>
+    <string name="today_gemini_promo_title">נסה קולות באיכות גבוהה</string>
+    <string name="today_gemini_promo_body">הפעל את Gemini כדי לשמוע את ה-ClothesCast שלך בקולות טבעיים וחיים.</string>
+    <string name="today_gemini_promo_cta">הגדרות קול</string>
+    <string name="today_gemini_promo_dismiss">סגור</string>
     <string name="today_clothes_promo_title">התאם את הבגדים אישית</string>
     <string name="today_insight_format_link">פורמט</string>
     <string name="today_play">הפעל</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -60,6 +60,7 @@ the displayed label localizes.
     <string name="garment_pants">ズボン</string>
     <string name="garment_jeans">ジーンズ</string>
     <string name="garment_gloves">手袋</string>
+    <string name="garment_umbrella">傘</string>
 
     <!-- Clothes settings — top of the screen. -->
     <string name="settings_clothes_title">服のルール</string>
@@ -72,6 +73,7 @@ the displayed label localizes.
     <string name="settings_clothes_dialog_add_title">服のルールを追加</string>
     <string name="settings_clothes_dialog_edit_title">服のルールを編集</string>
     <string name="settings_clothes_item_label">衣類</string>
+    <string name="settings_clothes_color_label">色</string>
     <string name="settings_clothes_condition_label">条件</string>
     <string name="settings_clothes_value_label_temp">しきい値 (%1$s)</string>
     <string name="settings_clothes_value_label_precip">しきい値 (%%)</string>
@@ -93,6 +95,7 @@ the displayed label localizes.
     <string name="settings_schedule_time_label">時刻</string>
     <string name="settings_schedule_days_label">曜日</string>
     <string name="settings_daily_mention_evening_events">夜の予定に言及する</string>
+    <string name="settings_schedule_preview">今すぐ再生</string>
 
     <string name="settings_tonight_title">夜間の ClothesCast</string>
     <string name="settings_tonight_description">今夜の天気を伝える、夜のもう1つの ClothesCast です。予定のない夜は無音のまま、または「夜に予定があるときのみ通知」がオンの場合は表示されません。予定のある夜は音を鳴らし、（音声読み上げを有効にしている場合は）自動で読み上げます。</string>
@@ -350,6 +353,8 @@ the displayed label localizes.
     <string name="today_refresh">更新</string>
     <string name="today_empty_title">まだ ClothesCast がありません</string>
     <string name="today_empty_subtitle">朝の ClothesCast が生成されるとここに表示されます。</string>
+    <string name="today_empty_location_title">位置情報が必要です</string>
+    <string name="today_empty_location_subtitle">ClothesCastを取得するには位置情報を設定してください。</string>
     <string name="today_fetch_now">今すぐ取得</string>
     <string name="today_generated_at">生成時刻：%1$s</string>
 
@@ -380,6 +385,10 @@ the displayed label localizes.
     <string name="today_failed_unhandled">予期しないエラーが発生しました。</string>
     <string name="today_failed_show_details">詳細を表示</string>
     <string name="today_failed_hide_details">詳細を隠す</string>
+    <string name="today_mqtt_failed_title">スマートホームに送信できませんでした</string>
+    <string name="today_cast_failed_title">ディスプレイにキャストできませんでした</string>
+    <string name="today_publish_failed_body">次回の更新時に再試行します。</string>
+    <string name="today_publish_failed_dismiss">閉じる</string>
 
     <!-- Home-screen App Widget. "コーデ" (short for コーディネート) is the
          standard Japanese fashion-vocab word for an outfit / day's
@@ -393,6 +402,11 @@ the displayed label localizes.
     <string name="feels_like_week_widget_label">体感温度（7日間）</string>
     <string name="feels_like_week_widget_description">今後7日間の体感温度です。</string>
     <string name="feels_like_widget_empty_title">まだ予報がありません</string>
+    <string name="conditions_widget_label">コンディション</string>
+    <string name="conditions_widget_description">気温、雨、風、UVをひと目で。</string>
+    <string name="conditions_rain_pct">%1$d%%</string>
+    <string name="conditions_wind">%1$d %2$s</string>
+    <string name="conditions_uv">UV %1$d</string>
 
     <!--
     Onboarding flow — first-run welcome, two permission steps, Gemini
@@ -1362,6 +1376,13 @@ the displayed label localizes.
     <string name="today_schedule_promo_body">通知やアナウンスを受け取るタイミングを選べます。</string>
     <string name="today_schedule_promo_cta">スケジュール設定</string>
     <string name="today_schedule_promo_dismiss">閉じる</string>
+    <string name="today_play_promo_title">毎日のClothesCastを聞く</string>
+    <string name="today_play_promo_body">再生ボタンをタップしてClothesCastを聞きましょう。</string>
+    <string name="today_play_promo_dismiss">閉じる</string>
+    <string name="today_gemini_promo_title">高品質な音声を試す</string>
+    <string name="today_gemini_promo_body">Geminiをオンにして、自然でリアルな音声でClothesCastを聞きましょう。</string>
+    <string name="today_gemini_promo_cta">音声設定</string>
+    <string name="today_gemini_promo_dismiss">閉じる</string>
     <string name="today_clothes_promo_title">服装を自分好みに</string>
     <string name="today_insight_format_link">形式</string>
     <string name="today_play">再生</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -64,6 +64,7 @@ displayed label localizes.
     <string name="garment_pants">긴바지</string>
     <string name="garment_jeans">청바지</string>
     <string name="garment_gloves">장갑</string>
+    <string name="garment_umbrella">우산</string>
 
     <!-- Clothes settings — top of the screen. -->
     <string name="settings_clothes_title">옷 규칙</string>
@@ -76,6 +77,7 @@ displayed label localizes.
     <string name="settings_clothes_dialog_add_title">옷 규칙 추가</string>
     <string name="settings_clothes_dialog_edit_title">옷 규칙 편집</string>
     <string name="settings_clothes_item_label">의류</string>
+    <string name="settings_clothes_color_label">색상</string>
     <string name="settings_clothes_condition_label">조건</string>
     <string name="settings_clothes_value_label_temp">기준값 (%1$s)</string>
     <string name="settings_clothes_value_label_precip">기준값 (%%)</string>
@@ -97,6 +99,7 @@ displayed label localizes.
     <string name="settings_schedule_time_label">시간</string>
     <string name="settings_schedule_days_label">요일</string>
     <string name="settings_daily_mention_evening_events">저녁 일정 언급</string>
+    <string name="settings_schedule_preview">지금 재생</string>
 
     <string name="settings_tonight_title">야간 ClothesCast</string>
     <string name="settings_tonight_description">오늘 밤 날씨를 알려주는 두 번째 ClothesCast입니다. 일정이 없는 저녁에는 무음으로 유지되거나 「저녁 일정이 있을 때만 알림」이 켜져 있으면 아예 표시되지 않아요. 일정이 있는 저녁에는 소리를 재생하고 (음성 읽기를 활성화한 경우) 자동으로 읽어줍니다.</string>
@@ -365,6 +368,8 @@ displayed label localizes.
     <string name="today_refresh">새로고침</string>
     <string name="today_empty_title">아직 ClothesCast가 없어요</string>
     <string name="today_empty_subtitle">아침 ClothesCast가 생성되면 여기에 표시됩니다.</string>
+    <string name="today_empty_location_title">위치가 필요합니다</string>
+    <string name="today_empty_location_subtitle">ClothesCast를 받으려면 위치를 설정하세요.</string>
     <string name="today_fetch_now">지금 가져오기</string>
     <string name="today_generated_at">생성 시각: %1$s</string>
 
@@ -395,6 +400,10 @@ displayed label localizes.
     <string name="today_failed_unhandled">예상치 못한 오류가 발생했어요.</string>
     <string name="today_failed_show_details">자세히 보기</string>
     <string name="today_failed_hide_details">자세히 숨기기</string>
+    <string name="today_mqtt_failed_title">스마트 홈으로 전송할 수 없습니다</string>
+    <string name="today_cast_failed_title">디스플레이로 전송할 수 없습니다</string>
+    <string name="today_publish_failed_body">다음 업데이트 때 다시 시도합니다.</string>
+    <string name="today_publish_failed_dismiss">닫기</string>
 
     <!-- Home-screen App Widget. "코디" (short for 코디네이션) is the
          standard Korean fashion-vocab word for an outfit / day's
@@ -408,6 +417,11 @@ displayed label localizes.
     <string name="feels_like_week_widget_label">체감 온도 (7일)</string>
     <string name="feels_like_week_widget_description">앞으로 7일간의 체감 온도입니다.</string>
     <string name="feels_like_widget_empty_title">아직 예보가 없어요</string>
+    <string name="conditions_widget_label">날씨 상태</string>
+    <string name="conditions_widget_description">온도, 비, 바람, UV를 한눈에.</string>
+    <string name="conditions_rain_pct">%1$d%%</string>
+    <string name="conditions_wind">%1$d %2$s</string>
+    <string name="conditions_uv">UV %1$d</string>
 
     <!--
     Onboarding flow — first-run welcome, two permission steps, Gemini
@@ -1366,6 +1380,13 @@ displayed label localizes.
     <string name="today_schedule_promo_body">알림과 안내를 받을 시간을 선택하세요.</string>
     <string name="today_schedule_promo_cta">일정 설정</string>
     <string name="today_schedule_promo_dismiss">닫기</string>
+    <string name="today_play_promo_title">매일의 ClothesCast 듣기</string>
+    <string name="today_play_promo_body">재생 버튼을 탭하여 ClothesCast를 들어보세요.</string>
+    <string name="today_play_promo_dismiss">닫기</string>
+    <string name="today_gemini_promo_title">고품질 음성 사용해 보기</string>
+    <string name="today_gemini_promo_body">자연스럽고 생생한 음성으로 ClothesCast를 들으려면 Gemini를 켜세요.</string>
+    <string name="today_gemini_promo_cta">음성 설정</string>
+    <string name="today_gemini_promo_dismiss">닫기</string>
     <string name="today_clothes_promo_title">옷을 내 것으로</string>
     <string name="today_insight_format_link">형식</string>
     <string name="today_play">재생</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -27,6 +27,7 @@ What is NOT overridden, by design:
     <string name="garment_pants">Kelnės</string>
     <string name="garment_jeans">Džinsai</string>
     <string name="garment_gloves">Pirštinės</string>
+    <string name="garment_umbrella">Skėtis</string>
 
     <string name="settings_clothes_empty">Taisyklių nėra. Paliesk Pridėti, kad sukurtum naują.</string>
     <string name="settings_clothes_add">Pridėti</string>
@@ -35,6 +36,7 @@ What is NOT overridden, by design:
     <string name="settings_clothes_dialog_add_title">Pridėti aprangos taisyklę</string>
     <string name="settings_clothes_dialog_edit_title">Redaguoti aprangos taisyklę</string>
     <string name="settings_clothes_item_label">Drabužis</string>
+    <string name="settings_clothes_color_label">Spalva</string>
     <string name="settings_clothes_condition_label">Sąlyga</string>
     <string name="settings_clothes_value_label_temp">Riba (%1$s)</string>
     <string name="settings_clothes_value_label_precip">Riba (%%)</string>
@@ -113,6 +115,8 @@ What is NOT overridden, by design:
     <string name="today_refresh">Atnaujinti</string>
     <string name="today_empty_title">ClothesCast dar nėra</string>
     <string name="today_empty_subtitle">Ryto ClothesCast pasirodys čia, kai bus sugeneruotas.</string>
+    <string name="today_empty_location_title">Reikalinga vieta</string>
+    <string name="today_empty_location_subtitle">Nustatykite savo vietą, kad gautumėte savo ClothesCast.</string>
     <string name="today_fetch_now">Gauti dabar</string>
     <string name="today_generated_at">Sugeneruota %1$s</string>
     <string name="today_location_unknown">Tavo vieta</string>
@@ -153,6 +157,11 @@ What is NOT overridden, by design:
     <string name="feels_like_week_widget_label">Juntama temperatūra (7 dienos)</string>
     <string name="feels_like_week_widget_description">Juntama temperatūra artimiausias 7 dienas.</string>
     <string name="feels_like_widget_empty_title">Prognozės dar nėra</string>
+    <string name="conditions_widget_label">Sąlygos</string>
+    <string name="conditions_widget_description">Temperatūra, lietus, vėjas ir UV vienu žvilgsniu.</string>
+    <string name="conditions_rain_pct">%1$d%%</string>
+    <string name="conditions_wind">%1$d %2$s</string>
+    <string name="conditions_uv">UV %1$d</string>
 
     <!-- Hourly forecast card. -->
     <string name="today_forecast_title">Valandos prognozė</string>
@@ -201,6 +210,10 @@ What is NOT overridden, by design:
     <string name="today_failed_no_location">Nepavyko gauti tavo vietos. Suteik nuolatinį buvimo vietos leidimą arba nustatymuose pasirink miestą.</string>
     <string name="today_failed_show_details">Rodyti išsamią informaciją</string>
     <string name="today_failed_hide_details">Slėpti išsamią informaciją</string>
+    <string name="today_mqtt_failed_title">Nepavyko išsiųsti į jūsų išmaniuosius namus</string>
+    <string name="today_cast_failed_title">Nepavyko perduoti į jūsų ekraną</string>
+    <string name="today_publish_failed_body">Bandysime dar kartą kito atnaujinimo metu.</string>
+    <string name="today_publish_failed_dismiss">Atmesti</string>
 
     <!-- Location required card. -->
     <string name="today_location_required_title">Nustatyk savo vietą</string>
@@ -344,6 +357,7 @@ What is NOT overridden, by design:
     <string name="settings_schedule_time_label">Laikas</string>
     <string name="settings_schedule_days_label">Savaitės dienos</string>
     <string name="settings_daily_mention_evening_events">Minėti vakaro renginius</string>
+    <string name="settings_schedule_preview">Leisti dabar</string>
 
     <!-- Nightly ClothesCast. -->
     <string name="settings_tonight_title">Nakties ClothesCast</string>
@@ -1202,6 +1216,13 @@ What is NOT overridden, by design:
     <string name="today_schedule_promo_body">Pasirink, kada gauti pranešimus ir skelbimus.</string>
     <string name="today_schedule_promo_cta">Tvarkaraščio nustatymai</string>
     <string name="today_schedule_promo_dismiss">Atmesti</string>
+    <string name="today_play_promo_title">Klausykite savo kasdienio ClothesCast</string>
+    <string name="today_play_promo_body">Palieskite leidimo mygtuką, kad išgirstumėte savo ClothesCast.</string>
+    <string name="today_play_promo_dismiss">Atmesti</string>
+    <string name="today_gemini_promo_title">Išbandykite aukštos kokybės balsus</string>
+    <string name="today_gemini_promo_body">Įjunkite Gemini, kad išgirstumėte savo ClothesCast natūraliais, gyvais balsais.</string>
+    <string name="today_gemini_promo_cta">Balso nustatymai</string>
+    <string name="today_gemini_promo_dismiss">Atmesti</string>
     <string name="today_clothes_promo_title">Pritaikyk drabužius sau</string>
     <string name="today_insight_format_link">Formatas</string>
     <string name="today_play">Leisti</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -20,6 +20,7 @@ informal "tu"-form throughout ("Apģērb …", "Paņem … līdzi").
     <string name="garment_pants">Bikses</string>
     <string name="garment_jeans">Džinsi</string>
     <string name="garment_gloves">Cimdi</string>
+    <string name="garment_umbrella">Lietussargs</string>
     <string name="garment_puffer">Pūķa jaka</string>
     <string name="garment_thin_jacket">Plāna jaka</string>
     <string name="garment_skirt">Svārki</string>
@@ -32,6 +33,7 @@ informal "tu"-form throughout ("Apģērb …", "Paņem … līdzi").
     <string name="settings_clothes_dialog_add_title">Pievienot apģērba noteikumu</string>
     <string name="settings_clothes_dialog_edit_title">Rediģēt apģērba noteikumu</string>
     <string name="settings_clothes_item_label">Apģērba gabals</string>
+    <string name="settings_clothes_color_label">Krāsa</string>
     <string name="settings_clothes_condition_label">Nosacījums</string>
     <string name="settings_clothes_value_label_temp">Slieksnis (%1$s)</string>
     <string name="settings_clothes_value_label_precip">Slieksnis (%%)</string>
@@ -125,6 +127,8 @@ informal "tu"-form throughout ("Apģērb …", "Paņem … līdzi").
     <string name="today_refresh">Atjaunināt</string>
     <string name="today_empty_title">ClothesCast vēl nav</string>
     <string name="today_empty_subtitle">Tavs rīta ClothesCast parādīsies šeit, tiklīdz tas tiks ģenerēts.</string>
+    <string name="today_empty_location_title">Nepieciešama atrašanās vieta</string>
+    <string name="today_empty_location_subtitle">Iestatiet savu atrašanās vietu, lai saņemtu savu ClothesCast.</string>
     <string name="today_fetch_now">Ielādēt tagad</string>
     <string name="today_generated_at">Ģenerēts plkst. %1$s</string>
     <string name="today_location_unknown">Tava atrašanās vieta</string>
@@ -155,6 +159,11 @@ informal "tu"-form throughout ("Apģērb …", "Paņem … līdzi").
     <string name="feels_like_week_widget_label">Sajustā temperatūra (7 dienas)</string>
     <string name="feels_like_week_widget_description">Sajustā temperatūra nākamajās 7 dienās.</string>
     <string name="feels_like_widget_empty_title">Prognozes vēl nav</string>
+    <string name="conditions_widget_label">Apstākļi</string>
+    <string name="conditions_widget_description">Temperatūra, lietus, vējš un UV vienā mirklī.</string>
+    <string name="conditions_rain_pct">%1$d%%</string>
+    <string name="conditions_wind">%1$d %2$s</string>
+    <string name="conditions_uv">UV %1$d</string>
 
     <!-- Today forecast / charts -->
     <string name="today_forecast_title">Stundas prognoze</string>
@@ -189,6 +198,10 @@ informal "tu"-form throughout ("Apģērb …", "Paņem … līdzi").
     <string name="today_failed_no_location">Nevarējām noteikt tavu atrašanās vietu. Piešķir pastāvīgu atrašanās vietas atļauju vai norādi pilsētu iestatījumos.</string>
     <string name="today_failed_show_details">Rādīt detaļas</string>
     <string name="today_failed_hide_details">Slēpt detaļas</string>
+    <string name="today_mqtt_failed_title">Neizdevās nosūtīt uz jūsu viedmāju</string>
+    <string name="today_cast_failed_title">Neizdevās pārraidīt uz jūsu displeju</string>
+    <string name="today_publish_failed_body">Mēģināsim vēlreiz nākamajā atjauninājumā.</string>
+    <string name="today_publish_failed_dismiss">Aizvērt</string>
     <string name="today_location_required_title">Norādi atrašanās vietu</string>
     <string name="today_location_required_body">ClothesCast jāzina, kur tu atrodies, lai iegūtu prognozi. Piešķir pastāvīgu atrašanās vietas atļauju vai izvēlies pilsētu.</string>
     <string name="today_location_required_action">Atvērt atrašanās vietas iestatījumus</string>
@@ -320,6 +333,7 @@ informal "tu"-form throughout ("Apģērb …", "Paņem … līdzi").
     <string name="settings_schedule_time_label">Laiks</string>
     <string name="settings_schedule_days_label">Nedēļas dienas</string>
     <string name="settings_daily_mention_evening_events">Pieminēt vakara notikumus</string>
+    <string name="settings_schedule_preview">Atskaņot tagad</string>
     <string name="settings_tonight_title">Nakts ClothesCast</string>
     <string name="settings_tonight_description">Otrs ClothesCast vakarā, kas aptver šovakarējā laika apstākļus. Klusās vakaros tas paliek klusēdams vai vispār neparādās, ja ir ieslēgta opcija "Paziņot tikai tad, kad ir vakara notikumi"; notikumu vakaros tas atskaņo skaņu un (ja esi iespējojis balss piegādi) nolasa sevi skaļi.</string>
     <string name="settings_tonight_enabled">Rādīt nakts ClothesCast</string>
@@ -1154,6 +1168,13 @@ informal "tu"-form throughout ("Apģērb …", "Paņem … līdzi").
     <string name="today_schedule_promo_body">Izvēlieties, kad saņemt paziņojumus un izziņojumus.</string>
     <string name="today_schedule_promo_cta">Grafika iestatījumi</string>
     <string name="today_schedule_promo_dismiss">Aizvērt</string>
+    <string name="today_play_promo_title">Klausieties savu ikdienas ClothesCast</string>
+    <string name="today_play_promo_body">Pieskarieties atskaņošanas pogai, lai klausītos savu ClothesCast.</string>
+    <string name="today_play_promo_dismiss">Aizvērt</string>
+    <string name="today_gemini_promo_title">Izmēģiniet augstas kvalitātes balsis</string>
+    <string name="today_gemini_promo_body">Ieslēdziet Gemini, lai klausītos savu ClothesCast dabiskās, dzīvīgās balsīs.</string>
+    <string name="today_gemini_promo_cta">Balss iestatījumi</string>
+    <string name="today_gemini_promo_dismiss">Aizvērt</string>
     <string name="today_clothes_promo_title">Padari apģērbu par savējo</string>
     <string name="today_insight_format_link">Formāts</string>
     <string name="today_play">Atskaņot</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -22,6 +22,7 @@ vs "kemungkinan", "padam" vs "hapus").
     <string name="garment_pants">Seluar panjang</string>
     <string name="garment_jeans">Seluar jean</string>
     <string name="garment_gloves">Sarung tangan</string>
+    <string name="garment_umbrella">Payung</string>
 
     <string name="settings_clothes_empty">Belum ada peraturan. Ketik Tambah untuk membuat satu.</string>
     <string name="settings_clothes_add">Tambah</string>
@@ -30,6 +31,7 @@ vs "kemungkinan", "padam" vs "hapus").
     <string name="settings_clothes_dialog_add_title">Tambah peraturan pakaian</string>
     <string name="settings_clothes_dialog_edit_title">Sunting peraturan pakaian</string>
     <string name="settings_clothes_item_label">Pakaian</string>
+    <string name="settings_clothes_color_label">Warna</string>
     <string name="settings_clothes_condition_label">Pencetus</string>
     <string name="settings_clothes_value_label_temp">Ambang (%1$s)</string>
     <string name="settings_clothes_value_label_precip">Ambang (%%)</string>
@@ -111,6 +113,8 @@ vs "kemungkinan", "padam" vs "hapus").
     <string name="today_refresh">Muat semula</string>
     <string name="today_empty_title">Tiada ClothesCast lagi</string>
     <string name="today_empty_subtitle">ClothesCast pagi anda akan muncul di sini setelah dijana.</string>
+    <string name="today_empty_location_title">Lokasi diperlukan</string>
+    <string name="today_empty_location_subtitle">Sediakan lokasi anda untuk mendapatkan ClothesCast anda.</string>
     <string name="today_fetch_now">Ambil sekarang</string>
     <string name="today_generated_at">Dijana pada %1$s</string>
     <string name="today_location_unknown">Lokasi anda</string>
@@ -151,6 +155,11 @@ vs "kemungkinan", "padam" vs "hapus").
     <string name="feels_like_week_widget_label">Suhu terasa (7 hari)</string>
     <string name="feels_like_week_widget_description">Suhu terasa untuk 7 hari akan datang.</string>
     <string name="feels_like_widget_empty_title">Tiada ramalan lagi</string>
+    <string name="conditions_widget_label">Keadaan</string>
+    <string name="conditions_widget_description">Suhu, hujan, angin dan UV sepintas lalu.</string>
+    <string name="conditions_rain_pct">%1$d%%</string>
+    <string name="conditions_wind">%1$d %2$s</string>
+    <string name="conditions_uv">UV %1$d</string>
 
     <!-- Forecast card -->
     <string name="today_forecast_title">Ramalan setiap jam</string>
@@ -197,6 +206,10 @@ vs "kemungkinan", "padam" vs "hapus").
     <string name="today_failed_no_location">Kami tidak dapat mendapatkan lokasi anda. Benarkan kebenaran lokasi sentiasa aktif, atau tetapkan bandar dalam Tetapan.</string>
     <string name="today_failed_show_details">Tunjukkan butiran</string>
     <string name="today_failed_hide_details">Sembunyikan butiran</string>
+    <string name="today_mqtt_failed_title">Tidak dapat menghantar ke rumah pintar anda</string>
+    <string name="today_cast_failed_title">Tidak dapat menghantar ke paparan anda</string>
+    <string name="today_publish_failed_body">Kami akan cuba lagi pada kemas kini seterusnya.</string>
+    <string name="today_publish_failed_dismiss">Tutup</string>
 
     <!-- Location required banner -->
     <string name="today_location_required_title">Sediakan lokasi anda</string>
@@ -338,6 +351,7 @@ vs "kemungkinan", "padam" vs "hapus").
     <string name="settings_schedule_time_label">Masa</string>
     <string name="settings_schedule_days_label">Hari dalam seminggu</string>
     <string name="settings_daily_mention_evening_events">Sebut acara petang</string>
+    <string name="settings_schedule_preview">Main sekarang</string>
     <string name="settings_tonight_title">ClothesCast Malam</string>
     <string name="settings_tonight_description">ClothesCast kedua pada waktu petang yang merangkumi cuaca malam ini. Pada malam yang tenang ia kekal senyap, atau tidak muncul langsung jika "Hanya beritahu apabila ada acara petang" diaktifkan; pada malam beracara ia memainkan bunyi dan (jika anda telah mengaktifkan penghantaran secara lisan) membacakan sendiri.</string>
     <string name="settings_tonight_enabled">Tunjukkan ClothesCast malam</string>
@@ -1218,6 +1232,13 @@ vs "kemungkinan", "padam" vs "hapus").
     <string name="today_schedule_promo_body">Pilih masa anda menerima pemberitahuan dan pengumuman.</string>
     <string name="today_schedule_promo_cta">Tetapan jadual</string>
     <string name="today_schedule_promo_dismiss">Tutup</string>
+    <string name="today_play_promo_title">Dengar ClothesCast harian anda</string>
+    <string name="today_play_promo_body">Ketik butang main untuk mendengar ClothesCast anda.</string>
+    <string name="today_play_promo_dismiss">Tutup</string>
+    <string name="today_gemini_promo_title">Cuba suara berkualiti tinggi</string>
+    <string name="today_gemini_promo_body">Hidupkan Gemini untuk mendengar ClothesCast anda dengan suara semula jadi yang hidup.</string>
+    <string name="today_gemini_promo_cta">Tetapan suara</string>
+    <string name="today_gemini_promo_dismiss">Tutup</string>
     <string name="today_clothes_promo_title">Jadikan pakaian milik anda</string>
     <string name="today_insight_format_link">Format</string>
     <string name="today_play">Putar</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -55,6 +55,7 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrike)").
     <string name="garment_pants">Bukse</string>
     <string name="garment_jeans">Jeans</string>
     <string name="garment_gloves">Hansker</string>
+    <string name="garment_umbrella">Paraply</string>
     <string name="garment_polo">Polo/Poloskjorte</string>
     <string name="garment_thin_jacket">Tynn jakke</string>
     <string name="garment_puffer">Dunjacke</string>
@@ -70,6 +71,7 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrike)").
     <string name="settings_clothes_dialog_add_title">Legg til klesregel</string>
     <string name="settings_clothes_dialog_edit_title">Rediger klesregel</string>
     <string name="settings_clothes_item_label">Klesplagg</string>
+    <string name="settings_clothes_color_label">Farge</string>
     <string name="settings_clothes_condition_label">Vilkår</string>
     <string name="settings_clothes_value_label_temp">Terskel (%1$s)</string>
     <string name="settings_clothes_value_label_precip">Terskel (%%)</string>
@@ -85,6 +87,7 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrike)").
     <string name="settings_schedule_time_label">Tidspunkt</string>
     <string name="settings_schedule_days_label">Ukedager</string>
     <string name="settings_daily_mention_evening_events">Nevn kveldshendelser</string>
+    <string name="settings_schedule_preview">Spill av nå</string>
 
     <string name="settings_tonight_title">Kveldens ClothesCast</string>
     <string name="settings_tonight_description">En ekstra ClothesCast om kvelden for været i kveld. På rolige kvelder er den stille eller vises ikke i det hele tatt hvis "Varsle bare ved kveldshendelser" er aktivert; på kvelder med hendelser spiller den av en lyd og (hvis du har talesyntese aktivert) leser seg selv opp.</string>
@@ -365,6 +368,8 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrike)").
     <string name="today_refresh">Oppdater</string>
     <string name="today_empty_title">Ingen ClothesCast ennå</string>
     <string name="today_empty_subtitle">Ditt morgenvise ClothesCast dukker opp her når det er generert.</string>
+    <string name="today_empty_location_title">Plassering kreves</string>
+    <string name="today_empty_location_subtitle">Konfigurer plasseringen din for å få din ClothesCast.</string>
     <string name="today_fetch_now">Hent nå</string>
     <string name="today_generated_at">Generert klokken %1$s</string>
 
@@ -402,6 +407,10 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrike)").
     <string name="today_failed_unhandled">En uventet feil oppstod.</string>
     <string name="today_failed_show_details">Vis detaljer</string>
     <string name="today_failed_hide_details">Skjul detaljer</string>
+    <string name="today_mqtt_failed_title">Kunne ikke sende til ditt smarthjem</string>
+    <string name="today_cast_failed_title">Kunne ikke caste til skjermen din</string>
+    <string name="today_publish_failed_body">Vi prøver igjen ved neste oppdatering.</string>
+    <string name="today_publish_failed_dismiss">Avvis</string>
     <string name="today_failed_no_location">Stedet ditt kunne ikke fastslås. Gi permanent plasseringstilgang, eller angi en by i innstillingene.</string>
 
     <string name="today_location_required_title">Angi stedet ditt</string>
@@ -481,6 +490,11 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrike)").
     <string name="feels_like_week_widget_label">Følt temperatur (7 dager)</string>
     <string name="feels_like_week_widget_description">Den følte temperaturen de neste 7 dagene.</string>
     <string name="feels_like_widget_empty_title">Ingen prognose ennå</string>
+    <string name="conditions_widget_label">Forhold</string>
+    <string name="conditions_widget_description">Temperatur, regn, vind og UV med et øyekast.</string>
+    <string name="conditions_rain_pct">%1$d%%</string>
+    <string name="conditions_wind">%1$d %2$s</string>
+    <string name="conditions_uv">UV %1$d</string>
 
     <!-- Onboarding. -->
     <string name="onboarding_title">Velkommen til ClothesCast</string>
@@ -1241,6 +1255,13 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrike)").
     <string name="today_schedule_promo_body">Velg når du får varsler og opplesninger.</string>
     <string name="today_schedule_promo_cta">Tidsplaninnstillinger</string>
     <string name="today_schedule_promo_dismiss">Avvis</string>
+    <string name="today_play_promo_title">Hør din daglige ClothesCast</string>
+    <string name="today_play_promo_body">Trykk på avspillingsknappen for å høre din ClothesCast.</string>
+    <string name="today_play_promo_dismiss">Avvis</string>
+    <string name="today_gemini_promo_title">Prøv stemmer av høy kvalitet</string>
+    <string name="today_gemini_promo_body">Slå på Gemini for å høre din ClothesCast med naturlige, livaktige stemmer.</string>
+    <string name="today_gemini_promo_cta">Stemmeinnstillinger</string>
+    <string name="today_gemini_promo_dismiss">Avvis</string>
     <string name="today_clothes_promo_title">Gjør klærne til dine egne</string>
     <string name="today_insight_format_link">Format</string>
     <string name="today_play">Spill av</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -48,6 +48,7 @@ the displayed label localizes.
     <string name="garment_pants">Broek</string>
     <string name="garment_jeans">Spijkerbroek</string>
     <string name="garment_gloves">Handschoenen</string>
+    <string name="garment_umbrella">Paraplu</string>
 
     <!-- Clothes settings. -->
     <string name="settings_clothes_title">Kledingregels</string>
@@ -60,6 +61,7 @@ the displayed label localizes.
     <string name="settings_clothes_dialog_add_title">Kledingsregel toevoegen</string>
     <string name="settings_clothes_dialog_edit_title">Kledingsregel bewerken</string>
     <string name="settings_clothes_item_label">Kledingstuk</string>
+    <string name="settings_clothes_color_label">Kleur</string>
     <string name="settings_clothes_condition_label">Voorwaarde</string>
     <string name="settings_clothes_value_label_temp">Drempel (%1$s)</string>
     <string name="settings_clothes_value_label_precip">Drempel (%%)</string>
@@ -77,6 +79,7 @@ the displayed label localizes.
     <string name="settings_schedule_time_label">Tijdstip</string>
     <string name="settings_schedule_days_label">Weekdagen</string>
     <string name="settings_daily_mention_evening_events">Avondafspraken vermelden</string>
+    <string name="settings_schedule_preview">Nu afspelen</string>
 
     <string name="settings_tonight_title">Avondlijkse ClothesCast</string>
     <string name="settings_tonight_description">Een tweede ClothesCast \'s avonds voor het weer van vanavond. Op rustige avonden blijft hij stil of verschijnt hij helemaal niet als \'Alleen meldingen bij avondafspraken\' is ingeschakeld; op avonden met afspraken speelt hij een geluid af en (als je gesproken uitvoer hebt ingeschakeld) leest hij zichzelf voor.</string>
@@ -316,6 +319,8 @@ the displayed label localizes.
     <string name="today_refresh">Vernieuwen</string>
     <string name="today_empty_title">Nog geen ClothesCast</string>
     <string name="today_empty_subtitle">Je ochtendlijkse ClothesCast verschijnt hier zodra hij is aangemaakt.</string>
+    <string name="today_empty_location_title">Locatie vereist</string>
+    <string name="today_empty_location_subtitle">Stel je locatie in om je ClothesCast te krijgen.</string>
     <string name="today_fetch_now">Nu ophalen</string>
     <string name="today_generated_at">Aangemaakt om %1$s</string>
 
@@ -347,6 +352,10 @@ the displayed label localizes.
     <string name="today_failed_unhandled">Er is een onverwachte fout opgetreden.</string>
     <string name="today_failed_show_details">Details weergeven</string>
     <string name="today_failed_hide_details">Details verbergen</string>
+    <string name="today_mqtt_failed_title">Verzenden naar je slimme huis is mislukt</string>
+    <string name="today_cast_failed_title">Casten naar je scherm is mislukt</string>
+    <string name="today_publish_failed_body">We proberen het opnieuw bij de volgende update.</string>
+    <string name="today_publish_failed_dismiss">Sluiten</string>
 
     <!-- Home-screen App Widget. -->
     <string name="widget_label">Outfit</string>
@@ -358,6 +367,11 @@ the displayed label localizes.
     <string name="feels_like_week_widget_label">Gevoelstemperatuur (7 dagen)</string>
     <string name="feels_like_week_widget_description">De gevoelstemperatuur voor de komende 7 dagen.</string>
     <string name="feels_like_widget_empty_title">Nog geen voorspelling</string>
+    <string name="conditions_widget_label">Omstandigheden</string>
+    <string name="conditions_widget_description">Temperatuur, regen, wind en UV in één oogopslag.</string>
+    <string name="conditions_rain_pct">%1$d%%</string>
+    <string name="conditions_wind">%1$d %2$s</string>
+    <string name="conditions_uv">UV %1$d</string>
 
     <!--
     Onboarding flow.
@@ -1261,6 +1275,13 @@ the displayed label localizes.
     <string name="today_schedule_promo_body">Kies wanneer je meldingen en aankondigingen krijgt.</string>
     <string name="today_schedule_promo_cta">Schema-instellingen</string>
     <string name="today_schedule_promo_dismiss">Sluiten</string>
+    <string name="today_play_promo_title">Luister naar je dagelijkse ClothesCast</string>
+    <string name="today_play_promo_body">Tik op de afspeelknop om je ClothesCast te horen.</string>
+    <string name="today_play_promo_dismiss">Sluiten</string>
+    <string name="today_gemini_promo_title">Probeer hoogwaardige stemmen</string>
+    <string name="today_gemini_promo_body">Schakel Gemini in om je ClothesCast te horen met natuurlijke, levensechte stemmen.</string>
+    <string name="today_gemini_promo_cta">Spraakinstellingen</string>
+    <string name="today_gemini_promo_dismiss">Sluiten</string>
     <string name="today_clothes_promo_title">Maak de kleding van jou</string>
     <string name="today_insight_format_link">Formaat</string>
     <string name="today_play">Afspelen</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -48,6 +48,7 @@ is unchanged; only the displayed label localizes.
     <string name="garment_pants">Spodnie</string>
     <string name="garment_jeans">Dżinsy</string>
     <string name="garment_gloves">Rękawiczki</string>
+    <string name="garment_umbrella">Parasol</string>
 
     <!-- Clothes settings. -->
     <string name="settings_clothes_title">Reguły ubioru</string>
@@ -60,6 +61,7 @@ is unchanged; only the displayed label localizes.
     <string name="settings_clothes_dialog_add_title">Dodaj regułę ubioru</string>
     <string name="settings_clothes_dialog_edit_title">Edytuj regułę ubioru</string>
     <string name="settings_clothes_item_label">Ubranie</string>
+    <string name="settings_clothes_color_label">Kolor</string>
     <string name="settings_clothes_condition_label">Warunek</string>
     <string name="settings_clothes_value_label_temp">Próg (%1$s)</string>
     <string name="settings_clothes_value_label_precip">Próg (%%)</string>
@@ -77,6 +79,7 @@ is unchanged; only the displayed label localizes.
     <string name="settings_schedule_time_label">Godzina</string>
     <string name="settings_schedule_days_label">Dni tygodnia</string>
     <string name="settings_daily_mention_evening_events">Wspominaj wieczorne wydarzenia</string>
+    <string name="settings_schedule_preview">Odtwórz teraz</string>
 
     <string name="settings_tonight_title">Wieczorny ClothesCast</string>
     <string name="settings_tonight_description">Drugi ClothesCast wieczorem dotyczący pogody tej nocy. W spokojne wieczory milczy lub wcale się nie pojawia, gdy włączone jest „Powiadamiaj tylko przy wieczornych wydarzeniach"; w wieczory z wydarzeniami odtwarza dźwięk i (jeśli włączone jest czytanie na głos) odczytuje się sam.</string>
@@ -316,6 +319,8 @@ is unchanged; only the displayed label localizes.
     <string name="today_refresh">Odśwież</string>
     <string name="today_empty_title">Brak ClothesCastu</string>
     <string name="today_empty_subtitle">Twój poranny ClothesCast pojawi się tutaj po utworzeniu.</string>
+    <string name="today_empty_location_title">Wymagana lokalizacja</string>
+    <string name="today_empty_location_subtitle">Skonfiguruj swoją lokalizację, aby otrzymać swój ClothesCast.</string>
     <string name="today_fetch_now">Pobierz teraz</string>
     <string name="today_generated_at">Utworzono o %1$s</string>
 
@@ -347,6 +352,10 @@ is unchanged; only the displayed label localizes.
     <string name="today_failed_unhandled">Wystąpił nieoczekiwany błąd.</string>
     <string name="today_failed_show_details">Pokaż szczegóły</string>
     <string name="today_failed_hide_details">Ukryj szczegóły</string>
+    <string name="today_mqtt_failed_title">Nie udało się wysłać do inteligentnego domu</string>
+    <string name="today_cast_failed_title">Nie udało się przesłać na ekran</string>
+    <string name="today_publish_failed_body">Spróbujemy ponownie przy następnej aktualizacji.</string>
+    <string name="today_publish_failed_dismiss">Odrzuć</string>
 
     <!-- Home-screen App Widget. -->
     <string name="widget_label">Outfit</string>
@@ -358,6 +367,11 @@ is unchanged; only the displayed label localizes.
     <string name="feels_like_week_widget_label">Odczuwalna (7 dni)</string>
     <string name="feels_like_week_widget_description">Temperatura odczuwalna na najbliższe 7 dni.</string>
     <string name="feels_like_widget_empty_title">Brak prognozy</string>
+    <string name="conditions_widget_label">Warunki</string>
+    <string name="conditions_widget_description">Temperatura, deszcz, wiatr i UV w skrócie.</string>
+    <string name="conditions_rain_pct">%1$d%%</string>
+    <string name="conditions_wind">%1$d %2$s</string>
+    <string name="conditions_uv">UV %1$d</string>
 
     <!--
     Onboarding flow.
@@ -1261,6 +1275,13 @@ is unchanged; only the displayed label localizes.
     <string name="today_schedule_promo_body">Wybierz, kiedy otrzymujesz powiadomienia i komunikaty.</string>
     <string name="today_schedule_promo_cta">Ustawienia harmonogramu</string>
     <string name="today_schedule_promo_dismiss">Odrzuć</string>
+    <string name="today_play_promo_title">Posłuchaj swojego codziennego ClothesCast</string>
+    <string name="today_play_promo_body">Dotknij przycisku odtwarzania, aby usłyszeć swój ClothesCast.</string>
+    <string name="today_play_promo_dismiss">Odrzuć</string>
+    <string name="today_gemini_promo_title">Wypróbuj głosy wysokiej jakości</string>
+    <string name="today_gemini_promo_body">Włącz Gemini, aby słuchać swojego ClothesCast naturalnymi, realistycznymi głosami.</string>
+    <string name="today_gemini_promo_cta">Ustawienia głosu</string>
+    <string name="today_gemini_promo_dismiss">Odrzuć</string>
     <string name="today_clothes_promo_title">Dostosuj ubrania do siebie</string>
     <string name="today_insight_format_link">Format</string>
     <string name="today_play">Odtwórz</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -67,6 +67,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="garment_pants">Calças</string>
     <string name="garment_jeans">Jeans</string>
     <string name="garment_gloves">Luvas</string>
+    <string name="garment_umbrella">Guarda-chuva</string>
 
     <!-- Clothes settings — top of the screen. -->
     <string name="settings_clothes_title">Regras de roupa</string>
@@ -79,6 +80,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_clothes_dialog_add_title">Adicionar regra de roupa</string>
     <string name="settings_clothes_dialog_edit_title">Editar regra de roupa</string>
     <string name="settings_clothes_item_label">Peça</string>
+    <string name="settings_clothes_color_label">Cor</string>
     <string name="settings_clothes_condition_label">Condição</string>
     <string name="settings_clothes_value_label_temp">Limite (%1$s)</string>
     <string name="settings_clothes_value_label_precip">Limite (%)</string>
@@ -100,6 +102,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_schedule_time_label">Horário</string>
     <string name="settings_schedule_days_label">Dias da semana</string>
     <string name="settings_daily_mention_evening_events">Mencionar eventos da noite</string>
+    <string name="settings_schedule_preview">Reproduzir agora</string>
 
     <string name="settings_tonight_title">ClothesCast noturno</string>
     <string name="settings_tonight_description">Um segundo ClothesCast à noite cobrindo o tempo para esta noite. Em noites tranquilas, ele fica silencioso, ou não aparece se „Notificar apenas quando houver eventos noturnos“ estiver ativado; em noites com eventos, toca um som e (se você ativou a leitura em voz alta) lê sozinho.</string>
@@ -353,6 +356,8 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="today_refresh">Atualizar</string>
     <string name="today_empty_title">Nenhum ClothesCast ainda</string>
     <string name="today_empty_subtitle">Seu ClothesCast matinal aparecerá aqui assim que for gerado.</string>
+    <string name="today_empty_location_title">Localização necessária</string>
+    <string name="today_empty_location_subtitle">Configure sua localização para receber seu ClothesCast.</string>
     <string name="today_fetch_now">Buscar agora</string>
     <string name="today_generated_at">Gerado às %1$s</string>
 
@@ -383,6 +388,10 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="today_failed_unhandled">Ocorreu um erro inesperado.</string>
     <string name="today_failed_show_details">Mostrar detalhes</string>
     <string name="today_failed_hide_details">Ocultar detalhes</string>
+    <string name="today_mqtt_failed_title">Não foi possível enviar para sua casa inteligente</string>
+    <string name="today_cast_failed_title">Não foi possível transmitir para sua tela</string>
+    <string name="today_publish_failed_body">Tentaremos novamente na próxima atualização.</string>
+    <string name="today_publish_failed_dismiss">Dispensar</string>
 
     <!-- Home-screen App Widget. "Look" is the standard Brazilian
          Portuguese word for an outfit / day's clothing combination —
@@ -397,6 +406,11 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="feels_like_week_widget_label">Sensação térmica (7 dias)</string>
     <string name="feels_like_week_widget_description">A sensação térmica ao longo dos próximos 7 dias.</string>
     <string name="feels_like_widget_empty_title">Nenhuma previsão ainda</string>
+    <string name="conditions_widget_label">Condições</string>
+    <string name="conditions_widget_description">Temperatura, chuva, vento e UV em um relance.</string>
+    <string name="conditions_rain_pct">%1$d%%</string>
+    <string name="conditions_wind">%1$d %2$s</string>
+    <string name="conditions_uv">UV %1$d</string>
 
     <!--
     Onboarding flow — first-run welcome, two permission steps, Gemini
@@ -1297,6 +1311,13 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="today_schedule_promo_body">Escolha quando você recebe notificações e anúncios.</string>
     <string name="today_schedule_promo_cta">Configurações de agendamento</string>
     <string name="today_schedule_promo_dismiss">Dispensar</string>
+    <string name="today_play_promo_title">Ouça seu ClothesCast diário</string>
+    <string name="today_play_promo_body">Toque no botão de reprodução para ouvir seu ClothesCast.</string>
+    <string name="today_play_promo_dismiss">Dispensar</string>
+    <string name="today_gemini_promo_title">Experimente vozes de alta qualidade</string>
+    <string name="today_gemini_promo_body">Ative o Gemini para ouvir seu ClothesCast com vozes naturais e realistas.</string>
+    <string name="today_gemini_promo_cta">Configurações de voz</string>
+    <string name="today_gemini_promo_dismiss">Dispensar</string>
     <string name="today_clothes_promo_title">Personalize as roupas</string>
     <string name="today_insight_format_link">Formato</string>
     <string name="today_play">Reproduzir</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -78,6 +78,7 @@ they diverge from BR ("Polonês" → "Polaco", "Holandês" →
     <string name="garment_pants">Calças</string>
     <string name="garment_jeans">Calças de ganga</string>
     <string name="garment_gloves">Luvas</string>
+    <string name="garment_umbrella">Guarda-chuva</string>
 
     <!-- Clothes settings — top of the screen. Tu-form imperatives
          throughout ("Toca em Adicionar", "Eliminar"). pt-PT uses
@@ -95,6 +96,7 @@ they diverge from BR ("Polonês" → "Polaco", "Holandês" →
     <string name="settings_clothes_dialog_add_title">Adicionar regra de vestuário</string>
     <string name="settings_clothes_dialog_edit_title">Editar regra de vestuário</string>
     <string name="settings_clothes_item_label">Peça</string>
+    <string name="settings_clothes_color_label">Cor</string>
     <string name="settings_clothes_condition_label">Condição</string>
     <string name="settings_clothes_value_label_temp">Limite (%1$s)</string>
     <string name="settings_clothes_value_label_precip">Limite (%)</string>
@@ -117,6 +119,7 @@ they diverge from BR ("Polonês" → "Polaco", "Holandês" →
     <string name="settings_schedule_time_label">Hora</string>
     <string name="settings_schedule_days_label">Dias da semana</string>
     <string name="settings_daily_mention_evening_events">Mencionar eventos da noite</string>
+    <string name="settings_schedule_preview">Reproduzir agora</string>
 
     <string name="settings_tonight_title">ClothesCast noturno</string>
     <string name="settings_tonight_description">Um segundo ClothesCast à noite que cobre o tempo para esta noite. Em noites tranquilas fica silencioso, ou nem aparece se «Notificar apenas quando houver eventos noturnos» estiver ativo; em noites com eventos toca um som e (se ativaste a leitura em voz alta) lê-se sozinho.</string>
@@ -371,6 +374,8 @@ they diverge from BR ("Polonês" → "Polaco", "Holandês" →
     <string name="today_refresh">Atualizar</string>
     <string name="today_empty_title">Ainda sem ClothesCast</string>
     <string name="today_empty_subtitle">O teu ClothesCast matinal aparece aqui assim que for gerado.</string>
+    <string name="today_empty_location_title">Localização necessária</string>
+    <string name="today_empty_location_subtitle">Configure a sua localização para obter o seu ClothesCast.</string>
     <string name="today_fetch_now">Obter agora</string>
     <string name="today_generated_at">Gerado às %1$s</string>
 
@@ -401,6 +406,10 @@ they diverge from BR ("Polonês" → "Polaco", "Holandês" →
     <string name="today_failed_unhandled">Ocorreu um erro inesperado.</string>
     <string name="today_failed_show_details">Mostrar detalhes</string>
     <string name="today_failed_hide_details">Ocultar detalhes</string>
+    <string name="today_mqtt_failed_title">Não foi possível enviar para a sua casa inteligente</string>
+    <string name="today_cast_failed_title">Não foi possível transmitir para o seu ecrã</string>
+    <string name="today_publish_failed_body">Tentaremos novamente na próxima atualização.</string>
+    <string name="today_publish_failed_dismiss">Dispensar</string>
 
     <!-- Home-screen App Widget. "Visual" (PT) for the widget label
          where pt-BR uses the loanword "Look" — both languages know
@@ -416,6 +425,11 @@ they diverge from BR ("Polonês" → "Polaco", "Holandês" →
     <string name="feels_like_week_widget_label">Sensação térmica (7 dias)</string>
     <string name="feels_like_week_widget_description">A sensação térmica ao longo dos próximos 7 dias.</string>
     <string name="feels_like_widget_empty_title">Ainda sem previsão</string>
+    <string name="conditions_widget_label">Condições</string>
+    <string name="conditions_widget_description">Temperatura, chuva, vento e UV num relance.</string>
+    <string name="conditions_rain_pct">%1$d%%</string>
+    <string name="conditions_wind">%1$d %2$s</string>
+    <string name="conditions_uv">UV %1$d</string>
 
     <!--
     Onboarding flow — first-run welcome, two permission steps, Gemini
@@ -1340,6 +1354,13 @@ they diverge from BR ("Polonês" → "Polaco", "Holandês" →
     <string name="today_schedule_promo_body">Escolhe quando recebes notificações e anúncios.</string>
     <string name="today_schedule_promo_cta">Definições de agendamento</string>
     <string name="today_schedule_promo_dismiss">Dispensar</string>
+    <string name="today_play_promo_title">Ouça o seu ClothesCast diário</string>
+    <string name="today_play_promo_body">Toque no botão de reprodução para ouvir o seu ClothesCast.</string>
+    <string name="today_play_promo_dismiss">Dispensar</string>
+    <string name="today_gemini_promo_title">Experimente vozes de alta qualidade</string>
+    <string name="today_gemini_promo_body">Ative o Gemini para ouvir o seu ClothesCast com vozes naturais e realistas.</string>
+    <string name="today_gemini_promo_cta">Definições de voz</string>
+    <string name="today_gemini_promo_dismiss">Dispensar</string>
     <string name="today_clothes_promo_title">Faz a roupa tua</string>
     <string name="today_insight_format_link">Formato</string>
     <string name="today_play">Reproduzir</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -21,6 +21,7 @@ surfaces fall back to default English (matching values-pl / values-uk).
     <string name="garment_pants">Pantaloni</string>
     <string name="garment_jeans">Blugi</string>
     <string name="garment_gloves">Mănuși</string>
+    <string name="garment_umbrella">Umbrelă</string>
 
     <string name="settings_clothes_empty">Nicio regulă. Atinge Adaugă pentru a crea.</string>
     <string name="settings_clothes_add">Adaugă</string>
@@ -29,6 +30,7 @@ surfaces fall back to default English (matching values-pl / values-uk).
     <string name="settings_clothes_dialog_add_title">Adaugă regulă de îmbrăcăminte</string>
     <string name="settings_clothes_dialog_edit_title">Editează regula de îmbrăcăminte</string>
     <string name="settings_clothes_item_label">Articol</string>
+    <string name="settings_clothes_color_label">Culoare</string>
     <string name="settings_clothes_condition_label">Condiție</string>
     <string name="settings_clothes_value_label_temp">Prag (%1$s)</string>
     <string name="settings_clothes_value_label_precip">Prag (%%)</string>
@@ -113,6 +115,8 @@ surfaces fall back to default English (matching values-pl / values-uk).
     <string name="today_refresh">Reîmprospătează</string>
     <string name="today_empty_title">Niciun ClothesCast încă</string>
     <string name="today_empty_subtitle">ClothesCast-ul tău de dimineață va apărea aici odată generat.</string>
+    <string name="today_empty_location_title">Locație necesară</string>
+    <string name="today_empty_location_subtitle">Configurează-ți locația pentru a primi ClothesCast-ul tău.</string>
     <string name="today_fetch_now">Aduce acum</string>
     <string name="today_generated_at">Generat la %1$s</string>
     <string name="today_location_unknown">Locația ta</string>
@@ -153,6 +157,11 @@ surfaces fall back to default English (matching values-pl / values-uk).
     <string name="feels_like_week_widget_label">Temperatură resimțită (7 zile)</string>
     <string name="feels_like_week_widget_description">Temperatura resimțită pentru următoarele 7 zile.</string>
     <string name="feels_like_widget_empty_title">Nicio prognoză încă</string>
+    <string name="conditions_widget_label">Condiții</string>
+    <string name="conditions_widget_description">Temperatură, ploaie, vânt și UV dintr-o privire.</string>
+    <string name="conditions_rain_pct">%1$d%%</string>
+    <string name="conditions_wind">%1$d %2$s</string>
+    <string name="conditions_uv">UV %1$d</string>
 
     <!-- Forecast card. -->
     <string name="today_forecast_title">Prognoză orară</string>
@@ -201,6 +210,10 @@ surfaces fall back to default English (matching values-pl / values-uk).
     <string name="today_failed_no_location">Nu am putut determina locația ta. Acordă permisiune permanentă de locație sau setează un oraș în Setări.</string>
     <string name="today_failed_show_details">Arată detalii</string>
     <string name="today_failed_hide_details">Ascunde detalii</string>
+    <string name="today_mqtt_failed_title">Nu s-a putut trimite către casa ta inteligentă</string>
+    <string name="today_cast_failed_title">Nu s-a putut transmite pe afișajul tău</string>
+    <string name="today_publish_failed_body">Vom încerca din nou la următoarea actualizare.</string>
+    <string name="today_publish_failed_dismiss">Închide</string>
 
     <!-- Location required. -->
     <string name="today_location_required_title">Configurează locația</string>
@@ -340,6 +353,7 @@ surfaces fall back to default English (matching values-pl / values-uk).
     <string name="settings_schedule_time_label">Oră</string>
     <string name="settings_schedule_days_label">Zile ale săptămânii</string>
     <string name="settings_daily_mention_evening_events">Menționează evenimentele de seară</string>
+    <string name="settings_schedule_preview">Redă acum</string>
 
     <!-- Tonight settings. -->
     <string name="settings_tonight_title">ClothesCast nocturn</string>
@@ -1190,6 +1204,13 @@ surfaces fall back to default English (matching values-pl / values-uk).
     <string name="today_schedule_promo_body">Alege când primești notificări și anunțuri.</string>
     <string name="today_schedule_promo_cta">Setări program</string>
     <string name="today_schedule_promo_dismiss">Închide</string>
+    <string name="today_play_promo_title">Ascultă ClothesCast-ul tău zilnic</string>
+    <string name="today_play_promo_body">Atinge butonul de redare pentru a-ți auzi ClothesCast-ul.</string>
+    <string name="today_play_promo_dismiss">Închide</string>
+    <string name="today_gemini_promo_title">Încearcă voci de înaltă calitate</string>
+    <string name="today_gemini_promo_body">Activează Gemini pentru a-ți auzi ClothesCast-ul cu voci naturale, realiste.</string>
+    <string name="today_gemini_promo_cta">Setări de voce</string>
+    <string name="today_gemini_promo_dismiss">Închide</string>
     <string name="today_clothes_promo_title">Fă hainele ale tale</string>
     <string name="today_insight_format_link">Format</string>
     <string name="today_play">Redă</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -69,6 +69,7 @@ only the displayed label localizes.
     <string name="garment_pants">Брюки</string>
     <string name="garment_jeans">Джинсы</string>
     <string name="garment_gloves">Перчатки</string>
+    <string name="garment_umbrella">Зонт</string>
     <string name="garment_polo">Поло</string>
     <string name="garment_thin_jacket">Лёгкая куртка</string>
     <string name="garment_puffer">Пуховик</string>
@@ -85,6 +86,7 @@ only the displayed label localizes.
     <string name="settings_clothes_dialog_add_title">Добавить правило одежды</string>
     <string name="settings_clothes_dialog_edit_title">Изменить правило одежды</string>
     <string name="settings_clothes_item_label">Одежда</string>
+    <string name="settings_clothes_color_label">Цвет</string>
     <string name="settings_clothes_condition_label">Условие</string>
     <string name="settings_clothes_value_label_temp">Порог (%1$s)</string>
     <string name="settings_clothes_value_label_precip">Порог (%%)</string>
@@ -105,6 +107,7 @@ only the displayed label localizes.
     <string name="settings_schedule_time_label">Время</string>
     <string name="settings_schedule_days_label">Дни недели</string>
     <string name="settings_daily_mention_evening_events">Упоминать вечерние события</string>
+    <string name="settings_schedule_preview">Воспроизвести</string>
 
     <string name="settings_tonight_title">Вечерний ClothesCast</string>
     <string name="settings_tonight_description">Второй ClothesCast вечером, охватывающий погоду на сегодня вечером. В тихие вечера остаётся беззвучным или вообще не появляется, если включено «Уведомлять только при вечерних событиях»; в вечера с событиями издаёт звук и (если включено озвучивание) читает себя вслух.</string>
@@ -433,6 +436,8 @@ only the displayed label localizes.
     <string name="today_refresh">Обновить</string>
     <string name="today_empty_title">ClothesCast пока нет</string>
     <string name="today_empty_subtitle">Твой утренний ClothesCast появится здесь, как только сгенерируется.</string>
+    <string name="today_empty_location_title">Требуется местоположение</string>
+    <string name="today_empty_location_subtitle">Настройте местоположение, чтобы получить ClothesCast.</string>
     <string name="today_fetch_now">Получить сейчас</string>
     <string name="today_generated_at">Создано в %1$s</string>
 
@@ -527,6 +532,10 @@ only the displayed label localizes.
     <string name="today_failed_unhandled">Произошла непредвиденная ошибка.</string>
     <string name="today_failed_show_details">Показать подробности</string>
     <string name="today_failed_hide_details">Скрыть подробности</string>
+    <string name="today_mqtt_failed_title">Не удалось отправить в умный дом</string>
+    <string name="today_cast_failed_title">Не удалось транслировать на дисплей</string>
+    <string name="today_publish_failed_body">Мы повторим попытку при следующем обновлении.</string>
+    <string name="today_publish_failed_dismiss">Скрыть</string>
     <string name="today_failed_no_location">Не удалось определить твоё местоположение. Предоставь постоянный доступ к местоположению или укажи город в Настройках.</string>
     <string name="today_location_required_title">Настрой своё местоположение</string>
     <string name="today_location_required_body">ClothesCast должен знать, где ты находишься, чтобы получить прогноз. Предоставь постоянный доступ к местоположению или выбери город.</string>
@@ -557,6 +566,11 @@ only the displayed label localizes.
     <string name="feels_like_week_widget_label">Ощущаемая температура (7 дней)</string>
     <string name="feels_like_week_widget_description">Ощущаемая температура на ближайшие 7 дней.</string>
     <string name="feels_like_widget_empty_title">Прогноза пока нет</string>
+    <string name="conditions_widget_label">Условия</string>
+    <string name="conditions_widget_description">Температура, дождь, ветер и UV с первого взгляда.</string>
+    <string name="conditions_rain_pct">%1$d%%</string>
+    <string name="conditions_wind">%1$d %2$s</string>
+    <string name="conditions_uv">UV %1$d</string>
 
     <!--
     Onboarding flow — first-run welcome, two permission steps, Gemini
@@ -1268,6 +1282,13 @@ only the displayed label localizes.
     <string name="today_schedule_promo_body">Выбери, когда получать уведомления и объявления.</string>
     <string name="today_schedule_promo_cta">Настройки расписания</string>
     <string name="today_schedule_promo_dismiss">Скрыть</string>
+    <string name="today_play_promo_title">Слушайте свой ежедневный ClothesCast</string>
+    <string name="today_play_promo_body">Нажмите кнопку воспроизведения, чтобы услышать ClothesCast.</string>
+    <string name="today_play_promo_dismiss">Скрыть</string>
+    <string name="today_gemini_promo_title">Попробуйте высококачественные голоса</string>
+    <string name="today_gemini_promo_body">Включите Gemini, чтобы слушать ClothesCast естественными, живыми голосами.</string>
+    <string name="today_gemini_promo_cta">Настройки голоса</string>
+    <string name="today_gemini_promo_dismiss">Скрыть</string>
     <string name="today_clothes_promo_title">Настрой одежду под себя</string>
     <string name="today_insight_format_link">Формат</string>
     <string name="today_play">Воспроизвести</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -173,6 +173,7 @@ What is NOT overridden, by design:
     <string name="garment_pants">Nohavice</string>
     <string name="garment_jeans">Rifle</string>
     <string name="garment_gloves">Rukavice</string>
+    <string name="garment_umbrella">Dáždnik</string>
     <string name="garment_polo">Polo tričko</string>
     <string name="garment_thin_jacket">Ľahká bunda</string>
     <string name="garment_puffer">Páperová bunda</string>
@@ -188,6 +189,7 @@ What is NOT overridden, by design:
     <string name="settings_clothes_dialog_add_title">Pridať pravidlo obliekania</string>
     <string name="settings_clothes_dialog_edit_title">Upraviť pravidlo obliekania</string>
     <string name="settings_clothes_item_label">Oblečenie</string>
+    <string name="settings_clothes_color_label">Farba</string>
     <string name="settings_clothes_condition_label">Podmienka</string>
     <string name="settings_clothes_value_label_temp">Prah (%1$s)</string>
     <string name="settings_clothes_value_label_precip">Prah (%%)</string>
@@ -205,6 +207,7 @@ What is NOT overridden, by design:
     <string name="settings_schedule_time_label">Čas</string>
     <string name="settings_schedule_days_label">Dni v týždni</string>
     <string name="settings_daily_mention_evening_events">Spomínať večerné udalosti</string>
+    <string name="settings_schedule_preview">Prehrať teraz</string>
 
     <string name="settings_tonight_title">Nočný ClothesCast</string>
     <string name="settings_tonight_description">Druhý ClothesCast večer pre počasie tejto noci. V pokojné večery zostane tichý alebo sa vôbec nezobrazí, ak je aktívne „Upozorňovať len pri večerných udalostiach"; vo večery s udalosťami prehrá zvuk a (ak máš zapnuté hlasové čítanie) prečíta sa nahlas.</string>
@@ -377,6 +380,8 @@ What is NOT overridden, by design:
     <string name="today_refresh">Obnoviť</string>
     <string name="today_empty_title">Zatiaľ žiadny ClothesCast</string>
     <string name="today_empty_subtitle">Tvoj ranný ClothesCast sa tu zobrazí, keď bude vytvorený.</string>
+    <string name="today_empty_location_title">Vyžaduje sa poloha</string>
+    <string name="today_empty_location_subtitle">Nastavte svoju polohu, aby ste získali svoj ClothesCast.</string>
     <string name="today_fetch_now">Načítať teraz</string>
     <string name="today_generated_at">Vytvorené o %1$s</string>
     <string name="today_location_unknown">Tvoja poloha</string>
@@ -417,6 +422,10 @@ What is NOT overridden, by design:
     <string name="today_failed_no_location">Nepodarilo sa zistiť tvoju polohu. Udeľ trvalé oprávnenie k polohe alebo nastav mesto v nastaveniach.</string>
     <string name="today_failed_show_details">Zobraziť podrobnosti</string>
     <string name="today_failed_hide_details">Skryť podrobnosti</string>
+    <string name="today_mqtt_failed_title">Odoslanie do inteligentnej domácnosti zlyhalo</string>
+    <string name="today_cast_failed_title">Odoslanie na displej zlyhalo</string>
+    <string name="today_publish_failed_body">Skúsime to znova pri ďalšej aktualizácii.</string>
+    <string name="today_publish_failed_dismiss">Zavrieť</string>
 
     <string name="today_location_required_title">Nastav svoju polohu</string>
     <string name="today_location_required_body">ClothesCast potrebuje vedieť, kde sa nachádzaš, aby mohol načítať predpoveď. Udeľ trvalé oprávnenie k polohe alebo vyber mesto.</string>
@@ -492,6 +501,11 @@ What is NOT overridden, by design:
     <string name="feels_like_week_widget_label">Pocitová (7 dní)</string>
     <string name="feels_like_week_widget_description">Pocitová teplota na nasledujúcich 7 dní.</string>
     <string name="feels_like_widget_empty_title">Zatiaľ žiadna predpoveď</string>
+    <string name="conditions_widget_label">Podmienky</string>
+    <string name="conditions_widget_description">Teplota, dážď, vietor a UV na prvý pohľad.</string>
+    <string name="conditions_rain_pct">%1$d%%</string>
+    <string name="conditions_wind">%1$d %2$s</string>
+    <string name="conditions_uv">UV %1$d</string>
 
     <!--
     Onboarding flow.
@@ -1236,6 +1250,13 @@ What is NOT overridden, by design:
     <string name="today_schedule_promo_body">Vyber, kedy dostávaš oznámenia a hlásenia.</string>
     <string name="today_schedule_promo_cta">Nastavenia plánu</string>
     <string name="today_schedule_promo_dismiss">Zavrieť</string>
+    <string name="today_play_promo_title">Vypočujte si svoj denný ClothesCast</string>
+    <string name="today_play_promo_body">Klepnutím na tlačidlo prehrávania si vypočujte svoj ClothesCast.</string>
+    <string name="today_play_promo_dismiss">Zavrieť</string>
+    <string name="today_gemini_promo_title">Vyskúšajte vysokokvalitné hlasy</string>
+    <string name="today_gemini_promo_body">Zapnite Gemini a počúvajte svoj ClothesCast prirodzenými, vernými hlasmi.</string>
+    <string name="today_gemini_promo_cta">Nastavenia hlasu</string>
+    <string name="today_gemini_promo_dismiss">Zavrieť</string>
     <string name="today_clothes_promo_title">Prispôsob si oblečenie</string>
     <string name="today_insight_format_link">Formát</string>
     <string name="today_play">Prehrať</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -20,6 +20,7 @@ informal "ti"-form throughout, mirroring the Croatian / Serbian pass.
     <string name="garment_pants">Hlače</string>
     <string name="garment_jeans">Kavbojke</string>
     <string name="garment_gloves">Rokavice</string>
+    <string name="garment_umbrella">Dežnik</string>
 
     <string name="settings_clothes_empty">Ni pravil. Pritisni Dodaj za novo.</string>
     <string name="settings_clothes_add">Dodaj</string>
@@ -28,6 +29,7 @@ informal "ti"-form throughout, mirroring the Croatian / Serbian pass.
     <string name="settings_clothes_dialog_add_title">Dodaj pravilo oblačil</string>
     <string name="settings_clothes_dialog_edit_title">Uredi pravilo oblačil</string>
     <string name="settings_clothes_item_label">Oblačilo</string>
+    <string name="settings_clothes_color_label">Barva</string>
     <string name="settings_clothes_condition_label">Pogoj</string>
     <string name="settings_clothes_value_label_temp">Prag (%1$s)</string>
     <string name="settings_clothes_value_label_precip">Prag (%%)</string>
@@ -115,6 +117,8 @@ informal "ti"-form throughout, mirroring the Croatian / Serbian pass.
     <string name="today_refresh">Osveži</string>
     <string name="today_empty_title">Še ni ClothesCasta</string>
     <string name="today_empty_subtitle">Tvoj jutranji ClothesCast se bo prikazal tukaj, ko bo ustvarjen.</string>
+    <string name="today_empty_location_title">Zahtevana je lokacija</string>
+    <string name="today_empty_location_subtitle">Nastavite svojo lokacijo, da prejmete svoj ClothesCast.</string>
     <string name="today_fetch_now">Pridobi zdaj</string>
     <string name="today_generated_at">Ustvarjeno ob %1$s</string>
     <string name="today_location_unknown">Tvoja lokacija</string>
@@ -161,6 +165,11 @@ informal "ti"-form throughout, mirroring the Croatian / Serbian pass.
     <string name="feels_like_week_widget_label">Občutena (7 dni)</string>
     <string name="feels_like_week_widget_description">Občutena temperatura za naslednjih 7 dni.</string>
     <string name="feels_like_widget_empty_title">Še ni napovedi</string>
+    <string name="conditions_widget_label">Pogoji</string>
+    <string name="conditions_widget_description">Temperatura, dež, veter in UV na prvi pogled.</string>
+    <string name="conditions_rain_pct">%1$d%%</string>
+    <string name="conditions_wind">%1$d %2$s</string>
+    <string name="conditions_uv">UV %1$d</string>
 
     <!-- Hourly forecast card. -->
     <string name="today_forecast_title">Urna napoved</string>
@@ -209,6 +218,10 @@ informal "ti"-form throughout, mirroring the Croatian / Serbian pass.
     <string name="today_failed_no_location">Ni bilo mogoče pridobiti tvoje lokacije. Dovoli trajni dostop do lokacije ali nastavi mesto v Nastavitvah.</string>
     <string name="today_failed_show_details">Prikaži podrobnosti</string>
     <string name="today_failed_hide_details">Skrij podrobnosti</string>
+    <string name="today_mqtt_failed_title">Pošiljanje v vaš pametni dom ni uspelo</string>
+    <string name="today_cast_failed_title">Predvajanja na zaslon ni bilo mogoče izvesti</string>
+    <string name="today_publish_failed_body">Poskusili bomo znova ob naslednji posodobitvi.</string>
+    <string name="today_publish_failed_dismiss">Zapri</string>
 
     <!-- Location required card. -->
     <string name="today_location_required_title">Nastavi svojo lokacijo</string>
@@ -352,6 +365,7 @@ informal "ti"-form throughout, mirroring the Croatian / Serbian pass.
     <string name="settings_schedule_time_label">Čas</string>
     <string name="settings_schedule_days_label">Dni v tednu</string>
     <string name="settings_daily_mention_evening_events">Omeni večerne dogodke</string>
+    <string name="settings_schedule_preview">Predvajaj zdaj</string>
 
     <string name="settings_tonight_title">Nočni ClothesCast</string>
     <string name="settings_tonight_description">Drugi ClothesCast zvečer, ki pokriva nocojšnje vreme. Na mirnih večerih ostane tih ali se sploh ne prikaže, če je vklopljeno »Obvesti le ob večernih dogodkih«; na večerih z dogodki predvaja zvok in (če je vklopljeno glasno branje) se prebere sam.</string>
@@ -1199,6 +1213,13 @@ informal "ti"-form throughout, mirroring the Croatian / Serbian pass.
     <string name="today_schedule_promo_body">Izberi, kdaj prejemaš obvestila in objave.</string>
     <string name="today_schedule_promo_cta">Nastavitve urnika</string>
     <string name="today_schedule_promo_dismiss">Zapri</string>
+    <string name="today_play_promo_title">Poslušajte svoj dnevni ClothesCast</string>
+    <string name="today_play_promo_body">Tapnite gumb za predvajanje in poslušajte svoj ClothesCast.</string>
+    <string name="today_play_promo_dismiss">Zapri</string>
+    <string name="today_gemini_promo_title">Preizkusite visokokakovostne glasove</string>
+    <string name="today_gemini_promo_body">Vklopite Gemini in poslušajte svoj ClothesCast z naravnimi, življenjskimi glasovi.</string>
+    <string name="today_gemini_promo_cta">Nastavitve glasu</string>
+    <string name="today_gemini_promo_dismiss">Zapri</string>
     <string name="today_clothes_promo_title">Prilagodi oblačila sebi</string>
     <string name="today_insight_format_link">Oblika</string>
     <string name="today_play">Predvajaj</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -55,6 +55,7 @@ native names for all locales (e.g. "Tyska (Tyskland)", "Franska (Frankrike)").
     <string name="garment_pants">Byxor</string>
     <string name="garment_jeans">Jeans</string>
     <string name="garment_gloves">Handskar</string>
+    <string name="garment_umbrella">Paraply</string>
     <string name="garment_polo">Piké/Pikétröja</string>
     <string name="garment_thin_jacket">Tunn jacka</string>
     <string name="garment_puffer">Dunjacka</string>
@@ -70,6 +71,7 @@ native names for all locales (e.g. "Tyska (Tyskland)", "Franska (Frankrike)").
     <string name="settings_clothes_dialog_add_title">Lägg till klädregel</string>
     <string name="settings_clothes_dialog_edit_title">Redigera klädregel</string>
     <string name="settings_clothes_item_label">Klädesplagg</string>
+    <string name="settings_clothes_color_label">Färg</string>
     <string name="settings_clothes_condition_label">Villkor</string>
     <string name="settings_clothes_value_label_temp">Tröskel (%1$s)</string>
     <string name="settings_clothes_value_label_precip">Tröskel (%%)</string>
@@ -85,6 +87,7 @@ native names for all locales (e.g. "Tyska (Tyskland)", "Franska (Frankrike)").
     <string name="settings_schedule_time_label">Tid</string>
     <string name="settings_schedule_days_label">Veckodagar</string>
     <string name="settings_daily_mention_evening_events">Nämn kvällshändelser</string>
+    <string name="settings_schedule_preview">Spela upp nu</string>
 
     <string name="settings_tonight_title">Kvällens ClothesCast</string>
     <string name="settings_tonight_description">Ett andra ClothesCast på kvällen för vädret ikväll. På lugna kvällar är det tyst eller visas inte alls om "Avisera bara vid kvällshändelser" är aktiverat; på kvällar med händelser spelar det upp ett ljud och (om du har röstutläsning aktiverat) läser upp sig självt.</string>
@@ -365,6 +368,8 @@ native names for all locales (e.g. "Tyska (Tyskland)", "Franska (Frankrike)").
     <string name="today_refresh">Uppdatera</string>
     <string name="today_empty_title">Inget ClothesCast ännu</string>
     <string name="today_empty_subtitle">Ditt morgonliga ClothesCast dyker upp här när det har genererats.</string>
+    <string name="today_empty_location_title">Plats krävs</string>
+    <string name="today_empty_location_subtitle">Konfigurera din plats för att få din ClothesCast.</string>
     <string name="today_fetch_now">Hämta nu</string>
     <string name="today_generated_at">Genererat klockan %1$s</string>
 
@@ -402,6 +407,10 @@ native names for all locales (e.g. "Tyska (Tyskland)", "Franska (Frankrike)").
     <string name="today_failed_unhandled">Ett oväntat fel uppstod.</string>
     <string name="today_failed_show_details">Visa detaljer</string>
     <string name="today_failed_hide_details">Dölj detaljer</string>
+    <string name="today_mqtt_failed_title">Det gick inte att skicka till ditt smarta hem</string>
+    <string name="today_cast_failed_title">Det gick inte att casta till din skärm</string>
+    <string name="today_publish_failed_body">Vi försöker igen vid nästa uppdatering.</string>
+    <string name="today_publish_failed_dismiss">Stäng</string>
     <string name="today_failed_no_location">Din plats kunde inte fastställas. Bevilja permanent platsåtkomst eller ange en stad i inställningarna.</string>
 
     <string name="today_location_required_title">Ange din plats</string>
@@ -481,6 +490,11 @@ native names for all locales (e.g. "Tyska (Tyskland)", "Franska (Frankrike)").
     <string name="feels_like_week_widget_label">Upplevd temperatur (7 dagar)</string>
     <string name="feels_like_week_widget_description">Den upplevda temperaturen under de kommande 7 dagarna.</string>
     <string name="feels_like_widget_empty_title">Ingen prognos ännu</string>
+    <string name="conditions_widget_label">Förhållanden</string>
+    <string name="conditions_widget_description">Temperatur, regn, vind och UV med en blick.</string>
+    <string name="conditions_rain_pct">%1$d%%</string>
+    <string name="conditions_wind">%1$d %2$s</string>
+    <string name="conditions_uv">UV %1$d</string>
 
     <!-- Onboarding. -->
     <string name="onboarding_title">Välkommen till ClothesCast</string>
@@ -1241,6 +1255,13 @@ native names for all locales (e.g. "Tyska (Tyskland)", "Franska (Frankrike)").
     <string name="today_schedule_promo_body">Välj när du får aviseringar och uppläsningar.</string>
     <string name="today_schedule_promo_cta">Schemainställningar</string>
     <string name="today_schedule_promo_dismiss">Stäng</string>
+    <string name="today_play_promo_title">Lyssna på din dagliga ClothesCast</string>
+    <string name="today_play_promo_body">Tryck på uppspelningsknappen för att höra din ClothesCast.</string>
+    <string name="today_play_promo_dismiss">Stäng</string>
+    <string name="today_gemini_promo_title">Prova röster av hög kvalitet</string>
+    <string name="today_gemini_promo_body">Aktivera Gemini för att höra din ClothesCast med naturliga, verklighetstrogna röster.</string>
+    <string name="today_gemini_promo_cta">Röstinställningar</string>
+    <string name="today_gemini_promo_dismiss">Stäng</string>
     <string name="today_clothes_promo_title">Gör kläderna till dina egna</string>
     <string name="today_insight_format_link">Format</string>
     <string name="today_play">Spela upp</string>

--- a/app/src/main/res/values-sw/strings.xml
+++ b/app/src/main/res/values-sw/strings.xml
@@ -20,6 +20,7 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="garment_pants">Suruali ndefu</string>
     <string name="garment_jeans">Jins</string>
     <string name="garment_gloves">Glavu</string>
+    <string name="garment_umbrella">Mwavuli</string>
 
     <string name="settings_clothes_empty">Hakuna sheria bado. Gonga Ongeza ili kuunda.</string>
     <string name="settings_clothes_add">Ongeza</string>
@@ -28,6 +29,7 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="settings_clothes_dialog_add_title">Ongeza sheria ya mavazi</string>
     <string name="settings_clothes_dialog_edit_title">Hariri sheria ya mavazi</string>
     <string name="settings_clothes_item_label">Vazi</string>
+    <string name="settings_clothes_color_label">Rangi</string>
     <string name="settings_clothes_condition_label">Hali</string>
     <string name="settings_clothes_value_label_temp">Kiwango (%1$s)</string>
     <string name="settings_clothes_value_label_precip">Kiwango (%%)</string>
@@ -109,6 +111,8 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="today_refresh">Onyesha upya</string>
     <string name="today_empty_title">Hakuna ClothesCast bado</string>
     <string name="today_empty_subtitle">ClothesCast yako ya asubuhi itaonekana hapa baada ya kuundwa.</string>
+    <string name="today_empty_location_title">Eneo linahitajika</string>
+    <string name="today_empty_location_subtitle">Sanidi eneo lako ili kupata ClothesCast yako.</string>
     <string name="today_fetch_now">Pakua sasa</string>
     <string name="today_generated_at">Imetayarishwa saa %1$s</string>
     <string name="today_location_unknown">Mahali pako</string>
@@ -147,6 +151,11 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="feels_like_week_widget_label">Joto linalohisi (siku 7)</string>
     <string name="feels_like_week_widget_description">Joto linalohisi kwa siku 7 zijazo.</string>
     <string name="feels_like_widget_empty_title">Hakuna utabiri bado</string>
+    <string name="conditions_widget_label">Hali</string>
+    <string name="conditions_widget_description">Halijoto, mvua, upepo na UV kwa mtazamo mmoja.</string>
+    <string name="conditions_rain_pct">%1$d%%</string>
+    <string name="conditions_wind">%1$d %2$s</string>
+    <string name="conditions_uv">UV %1$d</string>
 
     <!-- Today forecast / charts -->
     <string name="today_forecast_title">Joto linalohisi</string>
@@ -183,6 +192,10 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="today_failed_no_location">Hatukuweza kupata mahali pako. Toa ruhusa ya mahali daima, au weka mji katika Mipangilio.</string>
     <string name="today_failed_show_details">Onyesha maelezo</string>
     <string name="today_failed_hide_details">Ficha maelezo</string>
+    <string name="today_mqtt_failed_title">Imeshindwa kutuma kwenye nyumba yako ya kisasa</string>
+    <string name="today_cast_failed_title">Imeshindwa kutuma kwenye skrini yako</string>
+    <string name="today_publish_failed_body">Tutajaribu tena kwenye sasisho linalofuata.</string>
+    <string name="today_publish_failed_dismiss">Funga</string>
     <string name="today_location_required_title">Weka mahali pako</string>
     <string name="today_location_required_body">ClothesCast inahitaji kujua uko wapi ili kupata utabiri. Toa ruhusa ya mahali daima, au chagua mji.</string>
     <string name="today_location_required_action">Fungua mipangilio ya mahali</string>
@@ -298,6 +311,7 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="settings_schedule_time_label">Wakati</string>
     <string name="settings_schedule_days_label">Siku za wiki</string>
     <string name="settings_daily_mention_evening_events">Taja matukio ya jioni</string>
+    <string name="settings_schedule_preview">Cheza sasa</string>
     <string name="settings_tonight_title">ClothesCast ya usiku</string>
     <string name="settings_tonight_description">ClothesCast ya pili jioni inayoshughulikia hali ya hewa ya usiku huu. Jioni tulivu inabaki kimya; jioni za matukio inacheza sauti na kusoma yenyewe.</string>
     <string name="settings_tonight_enabled">Onyesha ClothesCast ya usiku</string>
@@ -1184,6 +1198,13 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="today_schedule_promo_body">Chagua wakati unapopokea arifa na matangazo.</string>
     <string name="today_schedule_promo_cta">Mipangilio ya ratiba</string>
     <string name="today_schedule_promo_dismiss">Funga</string>
+    <string name="today_play_promo_title">Sikiliza ClothesCast yako ya kila siku</string>
+    <string name="today_play_promo_body">Gusa kitufe cha kucheza ili kusikia ClothesCast yako.</string>
+    <string name="today_play_promo_dismiss">Funga</string>
+    <string name="today_gemini_promo_title">Jaribu sauti za ubora wa juu</string>
+    <string name="today_gemini_promo_body">Washa Gemini ili kusikia ClothesCast yako kwa sauti za asili, zinazofanana na halisi.</string>
+    <string name="today_gemini_promo_cta">Mipangilio ya sauti</string>
+    <string name="today_gemini_promo_dismiss">Funga</string>
     <string name="today_clothes_promo_title">Fanya nguo ziwe zako</string>
     <string name="today_insight_format_link">Umbo</string>
     <string name="today_play">Cheza</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -20,6 +20,7 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="garment_pants">กางเกงขายาว</string>
     <string name="garment_jeans">กางเกงยีนส์</string>
     <string name="garment_gloves">ถุงมือ</string>
+    <string name="garment_umbrella">ร่ม</string>
 
     <string name="settings_clothes_empty">ยังไม่มีกฎ แตะ เพิ่ม เพื่อสร้างใหม่</string>
     <string name="settings_clothes_add">เพิ่ม</string>
@@ -28,6 +29,7 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="settings_clothes_dialog_add_title">เพิ่มกฎเสื้อผ้า</string>
     <string name="settings_clothes_dialog_edit_title">แก้ไขกฎเสื้อผ้า</string>
     <string name="settings_clothes_item_label">เสื้อผ้า</string>
+    <string name="settings_clothes_color_label">สี</string>
     <string name="settings_clothes_condition_label">เงื่อนไข</string>
     <string name="settings_clothes_value_label_temp">ค่าเกณฑ์ (%1$s)</string>
     <string name="settings_clothes_value_label_precip">ค่าเกณฑ์ (%%)</string>
@@ -125,6 +127,8 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="today_refresh">รีเฟรช</string>
     <string name="today_empty_title">ยังไม่มี ClothesCast</string>
     <string name="today_empty_subtitle">ClothesCast ช่วงเช้าจะปรากฏที่นี่เมื่อสร้างเสร็จแล้ว</string>
+    <string name="today_empty_location_title">ต้องระบุตำแหน่ง</string>
+    <string name="today_empty_location_subtitle">ตั้งค่าตำแหน่งของคุณเพื่อรับ ClothesCast ของคุณ</string>
     <string name="today_fetch_now">ดึงข้อมูลเดี๋ยวนี้</string>
     <string name="today_generated_at">สร้างเมื่อ %1$s</string>
     <string name="today_location_unknown">ตำแหน่งของคุณ</string>
@@ -157,6 +161,11 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="feels_like_week_widget_label">อุณหภูมิที่รู้สึก (7 วัน)</string>
     <string name="feels_like_week_widget_description">อุณหภูมิที่รู้สึกในช่วง 7 วันข้างหน้า</string>
     <string name="feels_like_widget_empty_title">ยังไม่มีพยากรณ์</string>
+    <string name="conditions_widget_label">สภาพอากาศ</string>
+    <string name="conditions_widget_description">อุณหภูมิ ฝน ลม และ UV ในพริบตา</string>
+    <string name="conditions_rain_pct">%1$d%%</string>
+    <string name="conditions_wind">%1$d %2$s</string>
+    <string name="conditions_uv">UV %1$d</string>
 
     <!-- Forecast / charts -->
     <string name="today_forecast_title">พยากรณ์รายชั่วโมง</string>
@@ -201,6 +210,10 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="today_failed_no_location">ไม่สามารถรับตำแหน่งของคุณได้ อนุญาตการเข้าถึงตำแหน่งตลอดเวลา หรือตั้งค่าเมืองในการตั้งค่า</string>
     <string name="today_failed_show_details">แสดงรายละเอียด</string>
     <string name="today_failed_hide_details">ซ่อนรายละเอียด</string>
+    <string name="today_mqtt_failed_title">ไม่สามารถส่งไปยังสมาร์ทโฮมของคุณได้</string>
+    <string name="today_cast_failed_title">ไม่สามารถแคสต์ไปยังจอแสดงผลของคุณได้</string>
+    <string name="today_publish_failed_body">เราจะลองอีกครั้งในการอัปเดตครั้งถัดไป</string>
+    <string name="today_publish_failed_dismiss">ปิด</string>
 
     <!-- Location required -->
     <string name="today_location_required_title">ตั้งค่าตำแหน่งของคุณ</string>
@@ -340,6 +353,7 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="settings_schedule_time_label">เวลา</string>
     <string name="settings_schedule_days_label">วันในสัปดาห์</string>
     <string name="settings_daily_mention_evening_events">กล่าวถึงกิจกรรมตอนเย็น</string>
+    <string name="settings_schedule_preview">เล่นเลย</string>
 
     <!-- Nightly ClothesCast settings -->
     <string name="settings_tonight_title">ClothesCast รายคืน</string>
@@ -1212,6 +1226,13 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="today_schedule_promo_body">เลือกเวลาที่คุณจะได้รับการแจ้งเตือนและการประกาศ</string>
     <string name="today_schedule_promo_cta">การตั้งค่ากำหนดการ</string>
     <string name="today_schedule_promo_dismiss">ปิด</string>
+    <string name="today_play_promo_title">ฟัง ClothesCast ประจำวันของคุณ</string>
+    <string name="today_play_promo_body">แตะปุ่มเล่นเพื่อฟัง ClothesCast ของคุณ</string>
+    <string name="today_play_promo_dismiss">ปิด</string>
+    <string name="today_gemini_promo_title">ลองใช้เสียงคุณภาพสูง</string>
+    <string name="today_gemini_promo_body">เปิด Gemini เพื่อฟัง ClothesCast ของคุณด้วยเสียงที่เป็นธรรมชาติและสมจริง</string>
+    <string name="today_gemini_promo_cta">การตั้งค่าเสียง</string>
+    <string name="today_gemini_promo_dismiss">ปิด</string>
     <string name="today_clothes_promo_title">ปรับเสื้อผ้าให้เป็นของคุณ</string>
     <string name="today_insight_format_link">รูปแบบ</string>
     <string name="today_play">เล่น</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -44,6 +44,7 @@ displayed label localizes.
     <string name="garment_pants">Pantolon</string>
     <string name="garment_jeans">Kot pantolon</string>
     <string name="garment_gloves">Eldiven</string>
+    <string name="garment_umbrella">Şemsiye</string>
 
     <string name="settings_clothes_title">Kıyafet Kuralları</string>
     <string name="settings_clothes_description">Bir tahmin bu eşiklerden birini aşarsa, kıyafet günlük ClothesCast\'ında görünür.</string>
@@ -55,6 +56,7 @@ displayed label localizes.
     <string name="settings_clothes_dialog_add_title">Giysi kuralı ekle</string>
     <string name="settings_clothes_dialog_edit_title">Giysi kuralını düzenle</string>
     <string name="settings_clothes_item_label">Giysi</string>
+    <string name="settings_clothes_color_label">Renk</string>
     <string name="settings_clothes_condition_label">Koşul</string>
     <string name="settings_clothes_value_label_temp">Eşik (%1$s)</string>
     <string name="settings_clothes_value_label_precip">Eşik (%%)</string>
@@ -70,6 +72,7 @@ displayed label localizes.
     <string name="settings_schedule_time_label">Saat</string>
     <string name="settings_schedule_days_label">Haftanın günleri</string>
     <string name="settings_daily_mention_evening_events">Akşam etkinliklerinden bahset</string>
+    <string name="settings_schedule_preview">Şimdi oynat</string>
 
     <string name="settings_tonight_title">Gecelik ClothesCast</string>
     <string name="settings_tonight_description">Bu gecenin hava durumu için akşam ikinci bir ClothesCast. Sakin akşamlarda sessiz kalır veya "Yalnızca akşam etkinlikleri varsa bildir" etkinse hiç görünmez; etkinlikleri olan akşamlarda ses çıkarır ve (sesli çıkış etkinse) kendini sesli okur.</string>
@@ -278,6 +281,8 @@ displayed label localizes.
     <string name="today_refresh">Yenile</string>
     <string name="today_empty_title">Henüz ClothesCast yok</string>
     <string name="today_empty_subtitle">Sabah ClothesCast\'ın oluşturulduğunda burada görünecek.</string>
+    <string name="today_empty_location_title">Konum gerekli</string>
+    <string name="today_empty_location_subtitle">ClothesCast\'inizi almak için konumunuzu ayarlayın.</string>
     <string name="today_fetch_now">Şimdi al</string>
     <string name="today_generated_at">Saat %1$s\'de oluşturuldu</string>
 
@@ -308,6 +313,10 @@ displayed label localizes.
     <string name="today_failed_unhandled">Beklenmedik bir hata oluştu.</string>
     <string name="today_failed_show_details">Ayrıntıları göster</string>
     <string name="today_failed_hide_details">Ayrıntıları gizle</string>
+    <string name="today_mqtt_failed_title">Akıllı evinize gönderilemedi</string>
+    <string name="today_cast_failed_title">Ekranınıza yayınlanamadı</string>
+    <string name="today_publish_failed_body">Bir sonraki güncellemede tekrar deneyeceğiz.</string>
+    <string name="today_publish_failed_dismiss">Kapat</string>
 
     <string name="widget_label">Kıyafet</string>
     <string name="widget_description">Mevcut günün dilimindeki kıyafete bir bakış.</string>
@@ -318,6 +327,11 @@ displayed label localizes.
     <string name="feels_like_week_widget_label">Hissedilen sıcaklık (7 gün)</string>
     <string name="feels_like_week_widget_description">Önümüzdeki 7 gün boyunca hissedilen sıcaklık.</string>
     <string name="feels_like_widget_empty_title">Henüz tahmin yok</string>
+    <string name="conditions_widget_label">Koşullar</string>
+    <string name="conditions_widget_description">Sıcaklık, yağmur, rüzgar ve UV bir bakışta.</string>
+    <string name="conditions_rain_pct">%1$d%%</string>
+    <string name="conditions_wind">%1$d %2$s</string>
+    <string name="conditions_uv">UV %1$d</string>
 
     <string name="onboarding_title">ClothesCast\'a Hoş Geldiniz</string>
     <string name="onboarding_subtitle">İki hızlı seçim ve hazırsın. Diğer her şeyin daha sonra ayarlardan değiştirebileceğin makul bir varsayılanı var.</string>
@@ -1214,6 +1228,13 @@ displayed label localizes.
     <string name="today_schedule_promo_body">Bildirimleri ve duyuruları ne zaman alacağını seç.</string>
     <string name="today_schedule_promo_cta">Program ayarları</string>
     <string name="today_schedule_promo_dismiss">Kapat</string>
+    <string name="today_play_promo_title">Günlük ClothesCast\'inizi dinleyin</string>
+    <string name="today_play_promo_body">ClothesCast\'inizi duymak için oynat düğmesine dokunun.</string>
+    <string name="today_play_promo_dismiss">Kapat</string>
+    <string name="today_gemini_promo_title">Yüksek kaliteli sesleri deneyin</string>
+    <string name="today_gemini_promo_body">ClothesCast\'inizi doğal, gerçekçi seslerle duymak için Gemini\'yi açın.</string>
+    <string name="today_gemini_promo_cta">Ses ayarları</string>
+    <string name="today_gemini_promo_dismiss">Kapat</string>
     <string name="today_clothes_promo_title">Kıyafetleri kendine göre ayarla</string>
     <string name="today_insight_format_link">Biçim</string>
     <string name="today_play">Oynat</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -62,6 +62,7 @@ only the displayed label localizes.
     <string name="garment_pants">Штани</string>
     <string name="garment_jeans">Джинси</string>
     <string name="garment_gloves">Рукавички</string>
+    <string name="garment_umbrella">Парасолька</string>
     <string name="garment_polo">Поло</string>
     <string name="garment_thin_jacket">Легка куртка</string>
     <string name="garment_puffer">Пуховик</string>
@@ -78,6 +79,7 @@ only the displayed label localizes.
     <string name="settings_clothes_dialog_add_title">Додати правило одягу</string>
     <string name="settings_clothes_dialog_edit_title">Редагувати правило одягу</string>
     <string name="settings_clothes_item_label">Одяг</string>
+    <string name="settings_clothes_color_label">Колір</string>
     <string name="settings_clothes_condition_label">Умова</string>
     <string name="settings_clothes_value_label_temp">Поріг (%1$s)</string>
     <string name="settings_clothes_value_label_precip">Поріг (%)</string>
@@ -93,6 +95,7 @@ only the displayed label localizes.
     <string name="settings_schedule_time_label">Час</string>
     <string name="settings_schedule_days_label">Дні тижня</string>
     <string name="settings_daily_mention_evening_events">Згадувати вечірні події</string>
+    <string name="settings_schedule_preview">Відтворити зараз</string>
 
     <string name="settings_tonight_title">Вечірній ClothesCast</string>
     <string name="settings_tonight_description">Другий ClothesCast увечері, що охоплює погоду на сьогоднішній вечір. У тихі вечори залишається беззвучним або не з\'являється зовсім, якщо увімкнено «Сповіщати лише при вечірніх подіях»; у вечори з подіями видає звук і (якщо увімкнено озвучення) читає себе вголос.</string>
@@ -381,6 +384,8 @@ only the displayed label localizes.
     <string name="today_refresh">Оновити</string>
     <string name="today_empty_title">ClothesCast ще немає</string>
     <string name="today_empty_subtitle">Ваш ранковий ClothesCast з\'явиться тут, щойно буде згенеровано.</string>
+    <string name="today_empty_location_title">Потрібне місцезнаходження</string>
+    <string name="today_empty_location_subtitle">Налаштуйте своє місцезнаходження, щоб отримати свій ClothesCast.</string>
     <string name="today_fetch_now">Отримати зараз</string>
     <string name="today_generated_at">Згенеровано о %1$s</string>
     <string name="today_location_unknown">Ваше місцезнаходження</string>
@@ -426,6 +431,11 @@ only the displayed label localizes.
     <string name="feels_like_week_widget_label">Відчувана температура (7 днів)</string>
     <string name="feels_like_week_widget_description">Відчувана температура на наступні 7 днів.</string>
     <string name="feels_like_widget_empty_title">Прогнозу ще немає</string>
+    <string name="conditions_widget_label">Умови</string>
+    <string name="conditions_widget_description">Температура, дощ, вітер і UV з першого погляду.</string>
+    <string name="conditions_rain_pct">%1$d%%</string>
+    <string name="conditions_wind">%1$d %2$s</string>
+    <string name="conditions_uv">UV %1$d</string>
 
     <!-- Hourly forecast card. -->
     <string name="today_forecast_title">Погодинний прогноз</string>
@@ -474,6 +484,10 @@ only the displayed label localizes.
     <string name="today_failed_no_location">Не вдалося визначити ваше місцезнаходження. Надайте постійний дозвіл на місцезнаходження або вкажіть місто в налаштуваннях.</string>
     <string name="today_failed_show_details">Показати подробиці</string>
     <string name="today_failed_hide_details">Приховати подробиці</string>
+    <string name="today_mqtt_failed_title">Не вдалося надіслати до вашого розумного дому</string>
+    <string name="today_cast_failed_title">Не вдалося транслювати на ваш дисплей</string>
+    <string name="today_publish_failed_body">Ми спробуємо знову під час наступного оновлення.</string>
+    <string name="today_publish_failed_dismiss">Закрити</string>
 
     <!-- Location-required prompt. -->
     <string name="today_location_required_title">Налаштуйте місцезнаходження</string>
@@ -1211,6 +1225,13 @@ only the displayed label localizes.
     <string name="today_schedule_promo_body">Оберіть, коли отримувати сповіщення та оголошення.</string>
     <string name="today_schedule_promo_cta">Налаштування розкладу</string>
     <string name="today_schedule_promo_dismiss">Закрити</string>
+    <string name="today_play_promo_title">Слухайте свій щоденний ClothesCast</string>
+    <string name="today_play_promo_body">Торкніться кнопки відтворення, щоб почути свій ClothesCast.</string>
+    <string name="today_play_promo_dismiss">Закрити</string>
+    <string name="today_gemini_promo_title">Спробуйте високоякісні голоси</string>
+    <string name="today_gemini_promo_body">Увімкніть Gemini, щоб слухати свій ClothesCast природними, живими голосами.</string>
+    <string name="today_gemini_promo_cta">Налаштування голосу</string>
+    <string name="today_gemini_promo_dismiss">Закрити</string>
     <string name="today_clothes_promo_title">Зроби одяг своїм</string>
     <string name="today_insight_format_link">Формат</string>
     <string name="today_play">Відтворити</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -25,6 +25,7 @@ Skipped intentionally: app_name (brand), insight_time_am/pm/midnight/noon
     <string name="garment_pants">Quần dài</string>
     <string name="garment_jeans">Quần jean</string>
     <string name="garment_gloves">Găng tay</string>
+    <string name="garment_umbrella">Ô</string>
 
     <string name="settings_clothes_empty">Chưa có quy tắc. Nhấn Thêm để tạo mới.</string>
     <string name="settings_clothes_add">Thêm</string>
@@ -33,6 +34,7 @@ Skipped intentionally: app_name (brand), insight_time_am/pm/midnight/noon
     <string name="settings_clothes_dialog_add_title">Thêm quy tắc quần áo</string>
     <string name="settings_clothes_dialog_edit_title">Sửa quy tắc quần áo</string>
     <string name="settings_clothes_item_label">Trang phục</string>
+    <string name="settings_clothes_color_label">Màu</string>
     <string name="settings_clothes_condition_label">Điều kiện</string>
     <string name="settings_clothes_value_label_temp">Ngưỡng (%1$s)</string>
     <string name="settings_clothes_value_label_precip">Ngưỡng (%%)</string>
@@ -116,6 +118,8 @@ Skipped intentionally: app_name (brand), insight_time_am/pm/midnight/noon
     <string name="today_refresh">Làm mới</string>
     <string name="today_empty_title">Chưa có ClothesCast</string>
     <string name="today_empty_subtitle">ClothesCast buổi sáng sẽ xuất hiện ở đây sau khi được tạo.</string>
+    <string name="today_empty_location_title">Cần có vị trí</string>
+    <string name="today_empty_location_subtitle">Thiết lập vị trí của bạn để nhận ClothesCast của bạn.</string>
     <string name="today_fetch_now">Tải ngay</string>
     <string name="today_generated_at">Được tạo lúc %1$s</string>
     <string name="today_location_unknown">Vị trí của bạn</string>
@@ -156,6 +160,11 @@ Skipped intentionally: app_name (brand), insight_time_am/pm/midnight/noon
     <string name="feels_like_week_widget_label">Cảm giác (7 ngày)</string>
     <string name="feels_like_week_widget_description">Nhiệt độ cảm nhận trong 7 ngày tới.</string>
     <string name="feels_like_widget_empty_title">Chưa có dự báo</string>
+    <string name="conditions_widget_label">Điều kiện</string>
+    <string name="conditions_widget_description">Nhiệt độ, mưa, gió và UV trong nháy mắt.</string>
+    <string name="conditions_rain_pct">%1$d%%</string>
+    <string name="conditions_wind">%1$d %2$s</string>
+    <string name="conditions_uv">UV %1$d</string>
 
     <!-- Forecast chart -->
     <string name="today_forecast_title">Dự báo theo giờ</string>
@@ -202,6 +211,10 @@ Skipped intentionally: app_name (brand), insight_time_am/pm/midnight/noon
     <string name="today_failed_no_location">Không thể lấy vị trí của bạn. Hãy cấp quyền vị trí luôn bật, hoặc đặt thành phố trong Cài đặt.</string>
     <string name="today_failed_show_details">Xem chi tiết</string>
     <string name="today_failed_hide_details">Ẩn chi tiết</string>
+    <string name="today_mqtt_failed_title">Không thể gửi tới nhà thông minh của bạn</string>
+    <string name="today_cast_failed_title">Không thể truyền tới màn hình của bạn</string>
+    <string name="today_publish_failed_body">Chúng tôi sẽ thử lại trong lần cập nhật tiếp theo.</string>
+    <string name="today_publish_failed_dismiss">Bỏ qua</string>
 
     <!-- Location required -->
     <string name="today_location_required_title">Thiết lập vị trí</string>
@@ -359,6 +372,7 @@ Skipped intentionally: app_name (brand), insight_time_am/pm/midnight/noon
     <string name="settings_schedule_time_label">Giờ</string>
     <string name="settings_schedule_days_label">Ngày trong tuần</string>
     <string name="settings_daily_mention_evening_events">Đề cập sự kiện buổi tối</string>
+    <string name="settings_schedule_preview">Phát ngay</string>
 
     <string name="settings_tonight_title">ClothesCast buổi tối</string>
     <string name="settings_tonight_description">ClothesCast thứ hai vào buổi tối, dự báo thời tiết tối nay. Vào buổi tối yên tĩnh sẽ im lặng, hoặc không xuất hiện nếu "Chỉ thông báo khi có sự kiện buổi tối" được bật; vào buổi tối có sự kiện sẽ phát âm thanh và (nếu bật đọc to) tự đọc ra.</string>
@@ -1273,6 +1287,13 @@ Skipped intentionally: app_name (brand), insight_time_am/pm/midnight/noon
     <string name="today_schedule_promo_body">Chọn thời điểm bạn nhận thông báo và thông tin.</string>
     <string name="today_schedule_promo_cta">Cài đặt lịch</string>
     <string name="today_schedule_promo_dismiss">Bỏ qua</string>
+    <string name="today_play_promo_title">Nghe ClothesCast hằng ngày của bạn</string>
+    <string name="today_play_promo_body">Nhấn nút phát để nghe ClothesCast của bạn.</string>
+    <string name="today_play_promo_dismiss">Bỏ qua</string>
+    <string name="today_gemini_promo_title">Thử các giọng nói chất lượng cao</string>
+    <string name="today_gemini_promo_body">Bật Gemini để nghe ClothesCast của bạn bằng giọng nói tự nhiên, sống động.</string>
+    <string name="today_gemini_promo_cta">Cài đặt giọng nói</string>
+    <string name="today_gemini_promo_dismiss">Bỏ qua</string>
     <string name="today_clothes_promo_title">Biến quần áo thành của riêng bạn</string>
     <string name="today_insight_format_link">Định dạng</string>
     <string name="today_play">Phát</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -58,6 +58,7 @@ label localizes.
     <string name="garment_pants">长裤</string>
     <string name="garment_jeans">牛仔裤</string>
     <string name="garment_gloves">手套</string>
+    <string name="garment_umbrella">雨伞</string>
 
     <!-- Clothes settings — top of the screen. -->
     <string name="settings_clothes_title">穿衣规则</string>
@@ -70,6 +71,7 @@ label localizes.
     <string name="settings_clothes_dialog_add_title">添加穿衣规则</string>
     <string name="settings_clothes_dialog_edit_title">编辑穿衣规则</string>
     <string name="settings_clothes_item_label">服装</string>
+    <string name="settings_clothes_color_label">颜色</string>
     <string name="settings_clothes_condition_label">触发条件</string>
     <string name="settings_clothes_value_label_temp">阈值 (%1$s)</string>
     <string name="settings_clothes_value_label_precip">阈值 (%%)</string>
@@ -91,6 +93,7 @@ label localizes.
     <string name="settings_schedule_time_label">时间</string>
     <string name="settings_schedule_days_label">星期</string>
     <string name="settings_daily_mention_evening_events">提及晚间日程</string>
+    <string name="settings_schedule_preview">立即播放</string>
 
     <string name="settings_tonight_title">夜间 ClothesCast</string>
     <string name="settings_tonight_description">晚间的第二份 ClothesCast，覆盖今晚的天气。在没有日程的夜晚保持静音，或者如果开启了“仅在有晚间日程时通知”则完全不出现；在有日程的夜晚会播放提示音，并且（如果你启用了语音朗读）会自动朗读。</string>
@@ -343,6 +346,8 @@ label localizes.
     <string name="today_refresh">刷新</string>
     <string name="today_empty_title">还没有 ClothesCast</string>
     <string name="today_empty_subtitle">你的早晨 ClothesCast 生成后会显示在这里。</string>
+    <string name="today_empty_location_title">需要位置信息</string>
+    <string name="today_empty_location_subtitle">设置您的位置以获取您的 ClothesCast。</string>
     <string name="today_fetch_now">立即获取</string>
     <string name="today_generated_at">生成时间：%1$s</string>
 
@@ -373,6 +378,10 @@ label localizes.
     <string name="today_failed_unhandled">发生了意外错误。</string>
     <string name="today_failed_show_details">显示详情</string>
     <string name="today_failed_hide_details">隐藏详情</string>
+    <string name="today_mqtt_failed_title">无法发送到您的智能家居</string>
+    <string name="today_cast_failed_title">无法投送到您的显示屏</string>
+    <string name="today_publish_failed_body">我们将在下次更新时重试。</string>
+    <string name="today_publish_failed_dismiss">关闭</string>
 
     <!-- Home-screen App Widget. "穿搭" is the standard zh-CN fashion-vocab
          word for an outfit / day's clothing combination, more native
@@ -386,6 +395,11 @@ label localizes.
     <string name="feels_like_week_widget_label">体感温度（7 天）</string>
     <string name="feels_like_week_widget_description">未来 7 天的体感温度。</string>
     <string name="feels_like_widget_empty_title">还没有预报</string>
+    <string name="conditions_widget_label">天气状况</string>
+    <string name="conditions_widget_description">温度、降雨、风力和 UV 一目了然。</string>
+    <string name="conditions_rain_pct">%1$d%%</string>
+    <string name="conditions_wind">%1$d %2$s</string>
+    <string name="conditions_uv">UV %1$d</string>
 
     <!--
     Onboarding flow — first-run welcome, two permission steps, Gemini
@@ -1360,6 +1374,13 @@ label localizes.
     <string name="today_schedule_promo_body">选择何时收到通知和播报。</string>
     <string name="today_schedule_promo_cta">计划设置</string>
     <string name="today_schedule_promo_dismiss">关闭</string>
+    <string name="today_play_promo_title">收听您的每日 ClothesCast</string>
+    <string name="today_play_promo_body">点按播放按钮即可收听您的 ClothesCast。</string>
+    <string name="today_play_promo_dismiss">关闭</string>
+    <string name="today_gemini_promo_title">试用高品质语音</string>
+    <string name="today_gemini_promo_body">开启 Gemini，以自然逼真的语音收听您的 ClothesCast。</string>
+    <string name="today_gemini_promo_cta">语音设置</string>
+    <string name="today_gemini_promo_dismiss">关闭</string>
     <string name="today_clothes_promo_title">把服装变成你的</string>
     <string name="today_insight_format_link">格式</string>
     <string name="today_play">播放</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -67,6 +67,7 @@ label localises.
     <string name="garment_pants">長褲</string>
     <string name="garment_jeans">牛仔褲</string>
     <string name="garment_gloves">手套</string>
+    <string name="garment_umbrella">雨傘</string>
 
     <!-- Clothes settings — top of the screen. -->
     <string name="settings_clothes_title">穿衣規則</string>
@@ -79,6 +80,7 @@ label localises.
     <string name="settings_clothes_dialog_add_title">新增穿衣規則</string>
     <string name="settings_clothes_dialog_edit_title">編輯穿衣規則</string>
     <string name="settings_clothes_item_label">服裝</string>
+    <string name="settings_clothes_color_label">顏色</string>
     <string name="settings_clothes_condition_label">觸發條件</string>
     <string name="settings_clothes_value_label_temp">閾值 (%1$s)</string>
     <string name="settings_clothes_value_label_precip">閾值 (%%)</string>
@@ -99,6 +101,7 @@ label localises.
     <string name="settings_schedule_time_label">時間</string>
     <string name="settings_schedule_days_label">星期</string>
     <string name="settings_daily_mention_evening_events">提及晚間行程</string>
+    <string name="settings_schedule_preview">立即播放</string>
 
     <string name="settings_tonight_title">夜間 ClothesCast</string>
     <string name="settings_tonight_description">晚間的第二份 ClothesCast，涵蓋今晚的天氣。在沒有行程的夜晚保持靜音，或者如果開啟了「僅在有晚間行程時通知」就完全不出現；在有行程的夜晚會播放提示音，並且（如果你啟用了語音朗讀）會自動朗讀。</string>
@@ -333,6 +336,8 @@ label localises.
     <string name="today_refresh">重新整理</string>
     <string name="today_empty_title">還沒有 ClothesCast</string>
     <string name="today_empty_subtitle">你的早晨 ClothesCast 產生後會顯示在這裡。</string>
+    <string name="today_empty_location_title">需要位置資訊</string>
+    <string name="today_empty_location_subtitle">設定您的位置以取得您的 ClothesCast。</string>
     <string name="today_fetch_now">立即取得</string>
     <string name="today_generated_at">產生時間：%1$s</string>
 
@@ -363,6 +368,10 @@ label localises.
     <string name="today_failed_unhandled">發生了非預期的錯誤。</string>
     <string name="today_failed_show_details">顯示詳細資料</string>
     <string name="today_failed_hide_details">隱藏詳細資料</string>
+    <string name="today_mqtt_failed_title">無法傳送到您的智慧家庭</string>
+    <string name="today_cast_failed_title">無法投放到您的顯示器</string>
+    <string name="today_publish_failed_body">我們將在下次更新時重試。</string>
+    <string name="today_publish_failed_dismiss">關閉</string>
 
     <!-- Home-screen App Widget. "穿搭" is a fashion-vocab word for an
          outfit / day's clothing combination, idiomatic in both
@@ -377,6 +386,11 @@ label localises.
     <string name="feels_like_week_widget_label">體感溫度（7 天）</string>
     <string name="feels_like_week_widget_description">未來 7 天的體感溫度。</string>
     <string name="feels_like_widget_empty_title">還沒有預報</string>
+    <string name="conditions_widget_label">天氣狀況</string>
+    <string name="conditions_widget_description">溫度、降雨、風力和 UV 一目了然。</string>
+    <string name="conditions_rain_pct">%1$d%%</string>
+    <string name="conditions_wind">%1$d %2$s</string>
+    <string name="conditions_uv">UV %1$d</string>
 
     <!--
     Onboarding flow — first-run welcome, two permission steps, Gemini
@@ -1376,6 +1390,13 @@ label localises.
     <string name="today_schedule_promo_body">選擇何時收到通知和播報。</string>
     <string name="today_schedule_promo_cta">排程設定</string>
     <string name="today_schedule_promo_dismiss">關閉</string>
+    <string name="today_play_promo_title">聆聽您的每日 ClothesCast</string>
+    <string name="today_play_promo_body">輕觸播放按鈕即可聆聽您的 ClothesCast。</string>
+    <string name="today_play_promo_dismiss">關閉</string>
+    <string name="today_gemini_promo_title">試用高品質語音</string>
+    <string name="today_gemini_promo_body">開啟 Gemini，以自然逼真的語音聆聽您的 ClothesCast。</string>
+    <string name="today_gemini_promo_cta">語音設定</string>
+    <string name="today_gemini_promo_dismiss">關閉</string>
     <string name="today_clothes_promo_title">把服裝變成你的</string>
     <string name="today_insight_format_link">格式</string>
     <string name="today_play">播放</string>


### PR DESCRIPTION
## What

Twenty-one base strings had landed in `values/strings.xml` without translations. This adds them to every full locale.

The strings:
- **Conditions widget** — `conditions_widget_label`, `conditions_widget_description`, plus the `conditions_rain_pct` / `conditions_wind` / `conditions_uv` format labels
- **Today promo cards** — `today_play_promo_*` and `today_gemini_promo_*` (title/body/cta/dismiss)
- **Today failure titles** — `today_mqtt_failed_title`, `today_cast_failed_title`, `today_publish_failed_body`/`_dismiss`
- **Empty-location prompt** — `today_empty_location_title`, `today_empty_location_subtitle`
- **Settings / misc** — `settings_schedule_preview` (Play now), `settings_clothes_color_label` (Color), `garment_umbrella` (Umbrella)

## Scope

- Covers all **44 full locales**.
- The **8 regional overlay locales** (`de-rAT`, `de-rCH`, `en-rAU`, `en-rCA`, `en-rGB`, `en-rZA`, `es-rMX`, `fr-rCA`) are deliberately partial overlays that inherit from their parent locale via Android's API 24+ locale fallback, so they're left untouched — adding these keys there would just duplicate the parent.
- Brand names (**ClothesCast**, **Gemini**) and the **UV** label are kept verbatim. The three positional format strings reuse the base `%1$d` / `%2$s` args unchanged. The reused "Dismiss" strings mirror each locale's existing `today_clothes_promo_dismiss` wording for consistency.
- Each string is inserted at its logical position (next to its base-file neighbors), not appended, so the diffs read cleanly.

## Privacy

No change to what leaves the device — UI strings only.

## Test plan

- All 44 files parse as valid XML.
- `./gradlew :app:assembleDebug` — **BUILD SUCCESSFUL** (resources compile and merge cleanly across all locales).

---
_Generated by [Claude Code](https://claude.ai/code/session_01QrZwXZHpRB15wwaeGrH69T)_