### PR TITLE
Compute a carried-umbrella tier for the outfit icon

### DIFF
--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/OutfitSuggestion.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/OutfitSuggestion.kt
@@ -4,8 +4,8 @@ import java.time.LocalTime
 
 /**
  * A glanceable outfit pairing — one [Top] and one [Bottom], plus an optional [Hands]
- * accessory — derived from the forecast so the home screen can render big icons instead
- * of a comma-separated word list.
+ * accessory and an optional [Carried] accessory (umbrella) — derived from the forecast
+ * so the home screen can render big icons instead of a comma-separated word list.
  *
  * The picker is driven entirely by the user's [ClothesRule] list — the same rules that
  * populate [Insight.recommendedItems]. Top tier (coldest first): a firing `jacket` rule
@@ -43,6 +43,7 @@ data class OutfitSuggestion(
     val top: Top,
     val bottom: Bottom,
     val hands: Hands? = null,
+    val carried: Carried? = null,
 ) {
     enum class Top {
         TSHIRT, POLO, SWEATER, THIN_JACKET, THICK_JACKET, THICK_COAT, PUFFER_JACKET;
@@ -91,6 +92,23 @@ data class OutfitSuggestion(
         }
     }
 
+    /**
+     * Optional carried accessory shown alongside the worn outfit — today just
+     * the umbrella, the `Garment.Slot.CARRIED` member. Like [hands] it's a
+     * single opt-in tier with no fallback: present only when a carried-accessory
+     * rule fires (a rain-keyed umbrella rule), never promoted to a default. It's
+     * independent of [hands], so a cold rainy day can light both the glove icon
+     * and the umbrella.
+     */
+    enum class Carried {
+        UMBRELLA;
+
+        /** Catalog key (matches [Garment.itemKey]) for prose / persistence. */
+        fun itemKey(): String = when (this) {
+            UMBRELLA -> "umbrella"
+        }
+    }
+
     companion object {
         // Catalog item keys (see [Garment.itemKey]) that drive each icon tier.
         // Top tiers (coldest first): coat → THICK_COAT, puffer → PUFFER_JACKET,
@@ -122,6 +140,9 @@ data class OutfitSuggestion(
         // OutfitSuggestion), so this never promotes to a default the way the top
         // and bottom slots do.
         private val GLOVES_KEYS = listOf(Garment.GLOVES)
+        // Carried tier: a firing `umbrella` rule lights the optional umbrella
+        // icon. Like the hands tier it has no fallback — uncovered stays null.
+        private val CARRIED_KEYS = listOf(Garment.UMBRELLA)
 
         /**
          * Two-piece icon outfit for [forecast] given the user's [clothesRules].
@@ -191,7 +212,9 @@ data class OutfitSuggestion(
             }
             // Optional, no fallback: null unless a hands rule actually fired.
             val hands = if (firingRules.hasKeyIn(GLOVES_KEYS)) Hands.GLOVES else null
-            return OutfitSuggestion(top, bottom, hands)
+            // Same shape for carried gear (umbrella): independent of hands.
+            val carried = if (firingRules.hasKeyIn(CARRIED_KEYS)) Carried.UMBRELLA else null
+            return OutfitSuggestion(top, bottom, hands, carried)
         }
 
         /** True when any rule in the list is keyed on a garment in [keys]. */

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/model/OutfitSuggestionTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/model/OutfitSuggestionTest.kt
@@ -492,4 +492,62 @@ class OutfitSuggestionTest {
             Garment.fromKey(hands.itemKey())?.slot shouldBe Garment.Slot.HANDS
         }
     }
+
+    @Test
+    fun `a firing umbrella rule sets the carried slot`() {
+        // An umbrella rule keyed on rain chance lights the optional carried tier
+        // when the day's precip probability crosses its threshold.
+        val umbrellaRules = listOf(
+            ClothesRule(Garment.UMBRELLA, ClothesRule.PrecipitationProbabilityAbove(30.0)),
+        )
+        val outfit = OutfitSuggestion.fromForecast(
+            forecast(feelsLikeMin = 12.0, feelsLikeMax = 18.0, precipMaxPct = 60.0),
+            umbrellaRules,
+        )
+        outfit.carried shouldBe OutfitSuggestion.Carried.UMBRELLA
+    }
+
+    @Test
+    fun `carried stays null when no umbrella rule fires`() {
+        // Carried is opt-in with no fallback: a dry day (or no umbrella rule)
+        // leaves it null rather than promoting to a default, so no umbrella icon
+        // shows when the user hasn't earned one.
+        val umbrellaRules = listOf(
+            ClothesRule(Garment.UMBRELLA, ClothesRule.PrecipitationProbabilityAbove(30.0)),
+        )
+        val outfit = OutfitSuggestion.fromForecast(
+            forecast(feelsLikeMin = 12.0, feelsLikeMax = 18.0, precipMaxPct = 10.0),
+            umbrellaRules,
+        )
+        outfit.carried shouldBe null
+    }
+
+    @Test
+    fun `gloves and umbrella light the hands and carried slots independently`() {
+        // The two opt-in tiers don't compete: a cold, rainy day with both rules
+        // firing lights gloves on the hands slot and the umbrella on carried.
+        val triggered = TriggeredOutfit(
+            rules = listOf(
+                ClothesRule(Garment.COAT, ClothesRule.TemperatureBelow(5.0)),
+                ClothesRule(Garment.GLOVES, ClothesRule.TemperatureBelow(4.0)),
+                ClothesRule(Garment.UMBRELLA, ClothesRule.PrecipitationProbabilityAbove(30.0)),
+            ),
+            fallbacks = emptyList(),
+        )
+        OutfitSuggestion.fromTriggeredOutfit(triggered) shouldBe OutfitSuggestion(
+            OutfitSuggestion.Top.THICK_COAT,
+            OutfitSuggestion.Bottom.LONG_PANTS,
+            OutfitSuggestion.Hands.GLOVES,
+            OutfitSuggestion.Carried.UMBRELLA,
+        )
+    }
+
+    @Test
+    fun `carried itemKey round-trips through the garment catalog`() {
+        // The slot's catalog key must resolve back to the CARRIED-slot garment so
+        // prose / persistence / the umbrella icon all key off the same string.
+        OutfitSuggestion.Carried.entries.forEach { carried ->
+            Garment.fromKey(carried.itemKey())?.slot shouldBe Garment.Slot.CARRIED
+        }
+    }
 }


### PR DESCRIPTION
## What

Adds `OutfitSuggestion.carried` (`Carried.UMBRELLA`), populated by `pickOutfit` when a carried-accessory rule fires. It's the same opt-in, no-fallback shape as the existing `hands`/gloves tier, and **independent of it** — a cold rainy day lights both gloves (hands) and the umbrella (carried).

## Why now / why domain-only

This is the model-side groundwork for drawing the umbrella on the outfit surfaces (home card, widget, notification, Nest-Hub cast card). It mirrors exactly how the `hands` tier was introduced — computed in the model ahead of its render wiring (there's even a standing note on `OutfitSuggestion` to that effect). Keeping it small and behavior-neutral makes the follow-up's diff show *just* the rendering.

**Nothing draws `carried` yet**, so this is behavior-neutral on every surface — no snapshot changes.

## Tests

`:core:domain:test` green (`OutfitSuggestionTest`, 29 tests, 0 failures). Four new cases:
- a firing umbrella rule sets the carried slot;
- carried stays null on a dry day / with no umbrella rule;
- gloves + umbrella light the hands and carried slots independently (via `fromTriggeredOutfit`);
- `Carried.itemKey()` round-trips through the `Garment` catalog to the `CARRIED` slot.

## Follow-up

The icon render across both render paths (`renderTopWithHands` Compose + `renderTopWithHandsBitmap` for widget/notification/cast) and a user color picker (mirroring `outfit_hands_colors`). Agreed layering for that PR: **umbrella (back) → top → gloves (front)**, umbrella anchored to the hands position.

https://claude.ai/code/session_01HMjFrx4mng9MUrQ4ZDdKLX

---
_Generated by [Claude Code](https://claude.ai/code/session_01HMjFrx4mng9MUrQ4ZDdKLX)_