### PR TITLE
Skipping setup now sticks instead of reappearing

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ClothesCastApplication.kt
+++ b/app/src/main/kotlin/app/clothescast/ClothesCastApplication.kt
@@ -221,7 +221,11 @@ class ClothesCastApplication : Application() {
         )
     }
 
-    private val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    // Process-lifetime scope for fire-and-forget work that must outlive the
+    // component that started it — e.g. a DataStore write kicked off as a screen
+    // is being torn down. Injected into collaborators (CastInsightController,
+    // Telemetry) and read by the nav layer for the onboarding-skip write.
+    internal val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
     override fun attachBaseContext(base: Context) {
         // Re-apply the persisted per-app locale before the framework caches a

--- a/app/src/main/kotlin/app/clothescast/MainActivity.kt
+++ b/app/src/main/kotlin/app/clothescast/MainActivity.kt
@@ -227,6 +227,10 @@ private fun shouldStartOnboarding(context: Context, app: ClothesCastApplication)
     val notificationOk = tv || NotificationPermission.isGranted(context)
     val keyOk = runBlocking { app.secureKeyStore.geminiKeyConfiguredFlow.first() }
     val prefs = runBlocking { app.settingsRepository.preferences.first() }
+    // Once the user has tapped "Skip", honor that for good — don't drag them
+    // back through onboarding on the next cold launch just because a condition
+    // is still unmet. Banners on Today cover whatever they skipped.
+    if (prefs.onboardingSkipped) return false
     val locationOk = if (tv) {
         // On TV only a manually picked city counts — device location is unavailable.
         prefs.location != null

--- a/app/src/main/kotlin/app/clothescast/data/SettingsRepository.kt
+++ b/app/src/main/kotlin/app/clothescast/data/SettingsRepository.kt
@@ -433,6 +433,15 @@ class SettingsRepository(
     }
 
     /**
+     * Records that the user tapped "Skip" on onboarding so it doesn't reappear
+     * on the next cold launch even while its conditions remain unmet. See
+     * [UserPreferences.onboardingSkipped].
+     */
+    suspend fun setOnboardingSkipped(skipped: Boolean) {
+        dataStore.edit { it[ONBOARDING_SKIPPED] = skipped }
+    }
+
+    /**
      * Bumps [UserPreferences.calendarPermissionRecheckTick] to the current
      * wall-clock millis so the preferences flow re-emits. Use after the
      * user re-grants `READ_CALENDAR` from the in-app permission chip so
@@ -868,6 +877,7 @@ class SettingsRepository(
         val scheduleCardDismissed = this[SCHEDULE_CARD_DISMISSED] == true
         val playCardDismissed = this[PLAY_CARD_DISMISSED] == true
         val geminiPromoCardDismissed = this[GEMINI_PROMO_CARD_DISMISSED] == true
+        val onboardingSkipped = this[ONBOARDING_SKIPPED] == true
         val calendarPermissionRecheckTick = this[CALENDAR_PERMISSION_RECHECK_TICK] ?: 0L
         val tonightTime = this[TONIGHT_TIME]?.let { LocalTime.parse(it, TIME_FORMAT) }
             ?: DEFAULT_TONIGHT_TIME
@@ -1015,6 +1025,7 @@ class SettingsRepository(
             scheduleCardDismissed = scheduleCardDismissed,
             playCardDismissed = playCardDismissed,
             geminiPromoCardDismissed = geminiPromoCardDismissed,
+            onboardingSkipped = onboardingSkipped,
             calendarPermissionRecheckTick = calendarPermissionRecheckTick,
             dailyEnabled = dailyEnabled,
             tonightSchedule = Schedule(time = tonightTime, days = tonightDays, zoneId = zone),
@@ -1265,6 +1276,7 @@ class SettingsRepository(
         private val SCHEDULE_CARD_DISMISSED = booleanPreferencesKey("schedule_card_dismissed")
         private val PLAY_CARD_DISMISSED = booleanPreferencesKey("play_card_dismissed")
         private val GEMINI_PROMO_CARD_DISMISSED = booleanPreferencesKey("gemini_promo_card_dismissed")
+        private val ONBOARDING_SKIPPED = booleanPreferencesKey("onboarding_skipped")
         private val CALENDAR_PERMISSION_RECHECK_TICK = longPreferencesKey("calendar_permission_recheck_tick")
         private val DAILY_ENABLED = booleanPreferencesKey("daily_enabled")
         private val TONIGHT_TIME = stringPreferencesKey("tonight_time_hhmm")

--- a/app/src/main/kotlin/app/clothescast/ui/nav/ClothesCastNavHost.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/nav/ClothesCastNavHost.kt
@@ -164,6 +164,7 @@ fun ClothesCastNavHost(
                         FetchAndNotifyWorker.enqueueLocationCacheRefresh(context)
                     },
                     workManager = WorkManager.getInstance(app),
+                    externalScope = app.applicationScope,
                 ),
             )
             // Both footer buttons finish onboarding and land on Today — the
@@ -187,7 +188,13 @@ fun ClothesCastNavHost(
                 viewModel = onboarding,
                 onPairFromPhone = { nav.navigate(PairingRoute) },
                 onContinue = finishOnboarding,
-                onSkip = finishOnboarding,
+                onSkip = {
+                    // Persist the skip (on the app scope, so the write survives
+                    // the pop below clearing the ViewModel), then finish like
+                    // Continue does.
+                    onboarding.markSkipped()
+                    finishOnboarding()
+                },
             )
         }
 

--- a/app/src/main/kotlin/app/clothescast/ui/onboarding/OnboardingScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/onboarding/OnboardingScreen.kt
@@ -59,8 +59,10 @@ import app.clothescast.ui.settings.openAppDetails
  * drops them on Settings → Schedule so they can accept or change the default
  * 7am every-day schedule before reaching Today.
  *
- * "Skip for now" is session-only — the onboarding will reappear on cold launch
- * if the conditions still hold.
+ * "Skip" is sticky — tapping it records a flag so onboarding stays gone on
+ * future cold launches even if its conditions still hold; the Today screen's
+ * banners cover anything the user skipped. "Continue" leaves the flag unset, so
+ * a half-finished setup still re-prompts (its conditions drive that as before).
  */
 @Composable
 fun OnboardingScreen(

--- a/app/src/main/kotlin/app/clothescast/ui/onboarding/OnboardingViewModel.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/onboarding/OnboardingViewModel.kt
@@ -11,6 +11,7 @@ import app.clothescast.core.domain.model.TtsEngine
 import app.clothescast.data.SecureKeyStore
 import app.clothescast.data.SettingsRepository
 import app.clothescast.work.FetchAndNotifyWorker
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -55,6 +56,14 @@ class OnboardingViewModel(
      * stays permanently false.
      */
     private val workManager: WorkManager? = null,
+    /**
+     * Process-lifetime scope for the skip write. [markSkipped] must use this
+     * rather than [viewModelScope]: tapping Skip pops the onboarding
+     * destination, which clears this ViewModel and cancels [viewModelScope]
+     * before a DataStore write could commit. Defaults to [viewModelScope] for
+     * pure-VM tests that don't exercise the teardown race.
+     */
+    private val externalScope: CoroutineScope? = null,
 ) : ViewModel() {
 
     private val locationDetecting = MutableStateFlow(false)
@@ -120,6 +129,19 @@ class OnboardingViewModel(
         viewModelScope.launch { settingsRepository.setLocation(location) }
     }
 
+    /**
+     * Persists that the user chose to skip onboarding so it doesn't reappear on
+     * the next cold launch. Runs on [externalScope] (the app scope) rather than
+     * [viewModelScope] because the caller pops the onboarding destination right
+     * after, clearing this ViewModel — a [viewModelScope] write would be
+     * canceled before it committed.
+     */
+    fun markSkipped() {
+        (externalScope ?: viewModelScope).launch {
+            settingsRepository.setOnboardingSkipped(true)
+        }
+    }
+
     suspend fun searchLocations(query: String): List<Location> = geocodingClient.search(query)
 
     class Factory(
@@ -128,6 +150,7 @@ class OnboardingViewModel(
         private val geocodingClient: OpenMeteoGeocodingClient,
         private val refreshLocationCache: () -> Unit,
         private val workManager: WorkManager?,
+        private val externalScope: CoroutineScope,
     ) : ViewModelProvider.Factory {
         @Suppress("UNCHECKED_CAST")
         override fun <T : ViewModel> create(modelClass: Class<T>): T {
@@ -140,6 +163,7 @@ class OnboardingViewModel(
                 geocodingClient = geocodingClient,
                 refreshLocationCache = refreshLocationCache,
                 workManager = workManager,
+                externalScope = externalScope,
             ) as T
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -478,7 +478,7 @@
     <string name="onboarding_gemini_title">Gemini API key</string>
     <string name="onboarding_gemini_description">Use Gemini to get high quality voices.</string>
     <string name="onboarding_step_done">Done</string>
-    <string name="onboarding_skip">Skip for now</string>
+    <string name="onboarding_skip">Skip</string>
     <string name="onboarding_continue">Continue</string>
     <string name="onboarding_pair_from_phone">Pair from phone instead</string>
 

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Settings.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Settings.kt
@@ -681,6 +681,14 @@ data class UserPreferences(
      */
     val geminiPromoCardDismissed: Boolean = false,
     /**
+     * Set to true when the user taps "Skip" on the first-run onboarding screen.
+     * Onboarding normally reappears on every cold launch while any of its
+     * conditions (notification permission, location, Gemini key) are still
+     * unmet; this flag makes the user's choice to skip stick so they aren't
+     * forced back through it. Cleared only by a fresh install / data wipe.
+     */
+    val onboardingSkipped: Boolean = false,
+    /**
      * Bumped to `System.currentTimeMillis()` whenever the user re-grants
      * `READ_CALENDAR` via the in-app permission flow. Exists purely to
      * force the [SettingsRepository.preferences] flow to re-emit so any


### PR DESCRIPTION
## What

Make tapping **Skip** on first-run onboarding stick, and shorten the button label from "Skip for now" to "Skip".

Previously the footer button was session-only: onboarding reappeared on every cold launch while any of its conditions (notification permission, location, Gemini key) were still unmet. Now tapping Skip records a persisted flag so the user's choice not to finish setup is honored for good — the Today screen's banners cover anything they skipped.

## How

- **`UserPreferences.onboardingSkipped`** (`:core:domain`) — new flag, defaults to `false`.
- **`SettingsRepository`** — persists it under the `onboarding_skipped` DataStore key, with a `setOnboardingSkipped(...)` setter, read into the preferences flow.
- **`MainActivity.shouldStartOnboarding`** — short-circuits to `false` when the flag is set.
- **`OnboardingViewModel.markSkipped()`** — writes the flag on the **application scope**, not `viewModelScope`. The skip path immediately pops the onboarding destination (`popUpTo(...) { inclusive = true }`), which clears the ViewModel and would cancel a `viewModelScope` write before it committed; the process-lifetime `applicationScope` (injected via the Factory, same pattern as `CastInsightController` / `Telemetry`) makes the write durable.
- **`ClothesCastNavHost`** — the skip handler marks-then-finishes. **Continue is unchanged**: it deliberately leaves the flag unset, so a half-finished setup reached via Continue still re-prompts on next launch exactly as before (its condition checks drive that).
- **`strings.xml`** — base `en-US` label `onboarding_skip` changed to "Skip". Translated locales keep their existing strings; the translation pipeline updates those separately.

## Notes

- The flag clears only on a fresh install / data wipe, matching how the other DataStore prefs behave.
- No privacy-relevant changes — nothing new crosses the device boundary.

## Test plan

- `./gradlew :core:domain:test :core:data:test` — pass
- `./gradlew :app:testDebugUnitTest` — pass (no snapshot churn: the footer Skip/Continue row sits below the captured viewport, so the label change isn't visible in any preview — CI confirms 229 snapshots up-to-date)
- `./gradlew :app:assembleDebug` — pass

https://claude.ai/code/session_01QHhq6zFbZyzjynGP3WAuR5