### PR TITLE
Drop the repeated lead-in from the temperature-change line

### DIFF
--- a/app/src/main/kotlin/app/clothescast/insight/InsightFormatter.kt
+++ b/app/src/main/kotlin/app/clothescast/insight/InsightFormatter.kt
@@ -250,11 +250,14 @@ class InsightFormatter(
                 }
             }
             // When the range is omitted there's no band sentence ahead of the
-            // delta, so it leads the temperature content and must introduce
-            // itself ("it will be 5° warmer than yesterday.") rather than ride
-            // as a bare fragment that the period lead folds into subject-less
-            // ("Today, 5° warmer than yesterday.").
-            numericDelta?.let { add(formatDelta(it, leadsTemperature = rangeFormat == RangeFormat.NONE)) }
+            // delta, so it leads the temperature content and introduces itself
+            // ("Today, it will be 5° warmer than yesterday.") rather than riding
+            // as a subject-less fragment ("Today, 5° warmer than yesterday.").
+            // [formatDelta] handles the lead-dropped case (where "it will be"
+            // collapses into the dropped preamble) per locale.
+            numericDelta?.let {
+                add(formatDelta(it, leadsTemperature = rangeFormat == RangeFormat.NONE, omitLead = omitLead))
+            }
             if (wearItems.isNotEmpty()) formatClothesWear(wearItems, wearMode)?.let(::add)
             // The carried accessory (umbrella) now comes from the user's fired
             // rule — it lands in the recommended items as a Slot.CARRIED garment
@@ -495,19 +498,7 @@ class InsightFormatter(
         TemperatureBand.HOT -> R.string.insight_band_hot
     }
 
-    private fun formatDelta(delta: DeltaClause, leadsTemperature: Boolean = false): String {
-        // The delta is normally a bare fragment ("5° warmer than yesterday.")
-        // built to trail a band sentence. When it instead leads the temperature
-        // content (range omitted) it needs the self-introducing "it will be …"
-        // form, which every locale ships as insight_delta_*_lead; the period
-        // lead is then folded in front of it by [renderLeadOnly].
-        val lead = leadsTemperature
-        val template = when (delta.direction) {
-            DeltaClause.Direction.WARMER ->
-                if (lead) R.string.insight_delta_warmer_lead else R.string.insight_delta_warmer
-            DeltaClause.Direction.COOLER ->
-                if (lead) R.string.insight_delta_cooler_lead else R.string.insight_delta_cooler
-        }
+    private fun formatDelta(delta: DeltaClause, leadsTemperature: Boolean = false, omitLead: Boolean = false): String {
         // DeltaClause.degrees is the absolute Celsius delta. Temperature
         // *differences* convert with the ratio only (no +32 offset), so
         // 5°C of warming surfaces as 9°F to a Fahrenheit user — without
@@ -517,7 +508,43 @@ class InsightFormatter(
             TemperatureUnit.CELSIUS -> delta.degrees
             TemperatureUnit.FAHRENHEIT -> (delta.degrees * 9.0 / 5.0).roundToInt()
         }
-        return resources.getString(template, degrees)
+        val bareTemplate = when (delta.direction) {
+            DeltaClause.Direction.WARMER -> R.string.insight_delta_warmer
+            DeltaClause.Direction.COOLER -> R.string.insight_delta_cooler
+        }
+        val bare = resources.getString(bareTemplate, degrees)
+        // Trailing a band sentence: a subject-less comparison fragment ("5°
+        // warmer than yesterday.") — the preceding sentence already supplied the
+        // subject. It opens a new sentence after the band sentence's full stop,
+        // so capitalize its first letter. For locales whose fragment starts with
+        // the degree number (English, German) this is a no-op; for those that
+        // open with a word or particle (Polish "o 5°…" → "O 5°…", Russian "на
+        // 5°…" → "На 5°…") it restores sentence case.
+        if (!leadsTemperature) return capitalize(bare)
+        // Range omitted: the delta leads the temperature content, so it needs a
+        // self-introducing subject ("it will be …"), shipped per-locale as
+        // insight_delta_*_lead.
+        val leadTemplate = when (delta.direction) {
+            DeltaClause.Direction.WARMER -> R.string.insight_delta_warmer_lead
+            DeltaClause.Direction.COOLER -> R.string.insight_delta_cooler_lead
+        }
+        val withSubject = resources.getString(leadTemplate, degrees)
+        // With the period lead present, [renderLeadOnly] folds it in front of
+        // the self-introducing form ("Today, it will be 5° warmer than
+        // yesterday."). With the lead dropped, that subject is part of the
+        // dropped scaffold and should go too — *if* the locale's _lead form is
+        // just the bare fragment with the subject prepended (English "it will
+        // be " + "5° warmer than yesterday.", German "es wird " + "5° wärmer als
+        // gestern.", and the other SVO locales whose _lead leads with a verb).
+        // [renderLeadOnly] then capitalizes the bare fragment. Where the two
+        // diverge — locales whose delta is verb-final or otherwise can't expose
+        // a leading-subject prefix (the bare form doesn't tail the _lead form) —
+        // keep the _lead form on the no-lead surface, since its bare form would
+        // re-introduce the period word the no-lead surface exists to hide. This
+        // also lets the Speech-only preview parenthesise the whole "(Today, it
+        // will be) …" preamble.
+        if (omitLead && withSubject.endsWith(bare)) return bare
+        return withSubject
     }
 
     /**

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -76,8 +76,8 @@ they work correctly in both the single-band and range templates.
     <string name="insight_band_mild">معتدل</string>
     <string name="insight_band_warm">دافئ</string>
     <string name="insight_band_hot">حار</string>
-    <string name="insight_delta_warmer">سيكون اليوم أدفأ بـ %1$d°.</string>
-    <string name="insight_delta_cooler">سيكون اليوم أبرد بـ %1$d°.</string>
+    <string name="insight_delta_warmer">%1$d° أدفأ من الأمس.</string>
+    <string name="insight_delta_cooler">%1$d° أبرد من الأمس.</string>
     <string name="insight_alert">تنبيه: %1$s.</string>
     <string name="insight_clothes_wear">ارتدِ %1$s.</string>
     <string name="insight_clothes_bare">%1$s.</string>

--- a/app/src/main/res/values-b+sr+Latn/strings.xml
+++ b/app/src/main/res/values-b+sr+Latn/strings.xml
@@ -97,8 +97,8 @@ default English (matching values-pl / values-uk).
     <string name="insight_band_mild">blago</string>
     <string name="insight_band_warm">toplo</string>
     <string name="insight_band_hot">vruće</string>
-    <string name="insight_delta_warmer">Danas će biti %1$d° toplije.</string>
-    <string name="insight_delta_cooler">Danas će biti %1$d° hladnije.</string>
+    <string name="insight_delta_warmer">%1$d° toplije nego juče.</string>
+    <string name="insight_delta_cooler">%1$d° hladnije nego juče.</string>
     <string name="insight_alert">Upozorenje: %1$s.</string>
     <string name="insight_clothes_wear">Obuci %1$s.</string>
     <string name="insight_clothes_bare">%1$s.</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -83,8 +83,8 @@ What is NOT overridden, by design:
     <string name="insight_band_mild">меко</string>
     <string name="insight_band_warm">топло</string>
     <string name="insight_band_hot">горещо</string>
-    <string name="insight_delta_warmer">Днес ще бъде с %1$d° по-топло.</string>
-    <string name="insight_delta_cooler">Днес ще бъде с %1$d° по-студено.</string>
+    <string name="insight_delta_warmer">с %1$d° по-топло от вчера.</string>
+    <string name="insight_delta_cooler">с %1$d° по-хладно от вчера.</string>
     <string name="insight_alert">Предупреждение: %1$s.</string>
     <string name="insight_clothes_wear">Облечи %1$s.</string>
     <string name="insight_clothes_bare">%1$s.</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -526,8 +526,8 @@ the in-app clock is digit-driven and reads consistently across locales.
     <string name="insight_band_mild">bon temps</string>
     <string name="insight_band_warm">calor</string>
     <string name="insight_band_hot">molta calor</string>
-    <string name="insight_delta_warmer">Avui farà %1$d° més de calor.</string>
-    <string name="insight_delta_cooler">Avui farà %1$d° més de fred.</string>
+    <string name="insight_delta_warmer">%1$d° més que ahir.</string>
+    <string name="insight_delta_cooler">%1$d° menys que ahir.</string>
     <string name="insight_alert">Alerta: %1$s.</string>
     <!-- Reflexive imperative "tu": "Posa't el jersei." -->
     <string name="insight_clothes_wear">Posa\'t %1$s.</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -575,8 +575,8 @@ locale (Angličtina (USA), Francouzština (Francie), Němčina (Německo), …).
     <string name="insight_band_mild">mírně</string>
     <string name="insight_band_warm">teplo</string>
     <string name="insight_band_hot">horko</string>
-    <string name="insight_delta_warmer">Dnes bude o %1$d° tepleji.</string>
-    <string name="insight_delta_cooler">Dnes bude o %1$d° chladněji.</string>
+    <string name="insight_delta_warmer">o %1$d° tepleji než včera.</string>
+    <string name="insight_delta_cooler">o %1$d° chladněji než včera.</string>
     <string name="insight_alert">Výstraha: %1$s.</string>
     <string name="insight_clothes_wear">Obleč si %1$s.</string>
     <string name="insight_clothes_bare">%1$s.</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -581,8 +581,8 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrig)").
     <string name="insight_band_warm">varmt</string>
     <string name="insight_band_hot">meget varmt</string>
 
-    <string name="insight_delta_warmer">Det bliver %1$d° varmere i dag.</string>
-    <string name="insight_delta_cooler">Det bliver %1$d° koldere i dag.</string>
+    <string name="insight_delta_warmer">%1$d° varmere end i går.</string>
+    <string name="insight_delta_cooler">%1$d° koldere end i går.</string>
 
     <string name="insight_alert">Advarsel: %1$s.</string>
 

--- a/app/src/main/res/values-de-rAT/strings.xml
+++ b/app/src/main/res/values-de-rAT/strings.xml
@@ -437,8 +437,11 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="insight_band_warm">warm</string>
     <string name="insight_band_hot">heiß</string>
 
-    <string name="insight_delta_warmer">Heute wird es %1$d° wärmer.</string>
-    <string name="insight_delta_cooler">Heute wird es %1$d° kälter.</string>
+    <!-- Subject-less comparison fragment (see values-de): keep it equal to
+         insight_delta_*_lead minus the leading "es wird " so the no-lead
+         surface drops that subject the way English drops "it will be". -->
+    <string name="insight_delta_warmer">%1$d° wärmer als gestern.</string>
+    <string name="insight_delta_cooler">%1$d° kühler als gestern.</string>
 
     <string name="insight_alert">Warnung: %1$s.</string>
 

--- a/app/src/main/res/values-de-rCH/strings.xml
+++ b/app/src/main/res/values-de-rCH/strings.xml
@@ -442,8 +442,11 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="insight_band_warm">warm</string>
     <string name="insight_band_hot">heiss</string>
 
-    <string name="insight_delta_warmer">Heute wird es %1$d° wärmer.</string>
-    <string name="insight_delta_cooler">Heute wird es %1$d° kälter.</string>
+    <!-- Subject-less comparison fragment (see values-de): keep it equal to
+         insight_delta_*_lead minus the leading "es wird " so the no-lead
+         surface drops that subject the way English drops "it will be". -->
+    <string name="insight_delta_warmer">%1$d° wärmer als gestern.</string>
+    <string name="insight_delta_cooler">%1$d° kühler als gestern.</string>
 
     <string name="insight_alert">Warnung: %1$s.</string>
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -461,8 +461,14 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="insight_band_warm">warm</string>
     <string name="insight_band_hot">heiß</string>
 
-    <string name="insight_delta_warmer">Heute wird es %1$d° wärmer.</string>
-    <string name="insight_delta_cooler">Heute wird es %1$d° kälter.</string>
+    <!-- Subject-less comparison fragment, like the English "%1$d° warmer than
+         yesterday." It trails a band sentence ("Heute wird es kühl. 5° wärmer
+         als gestern.") and, when the range is hidden, becomes the bare no-lead
+         form. Keep it equal to insight_delta_*_lead minus the leading "es wird "
+         so the no-lead surface drops that subject the same way English drops
+         "it will be". -->
+    <string name="insight_delta_warmer">%1$d° wärmer als gestern.</string>
+    <string name="insight_delta_cooler">%1$d° kühler als gestern.</string>
 
     <string name="insight_alert">Warnung: %1$s.</string>
 

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -516,8 +516,8 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="insight_band_mild">ήπιος καιρός</string>
     <string name="insight_band_warm">ζέστη</string>
     <string name="insight_band_hot">καύσωνας</string>
-    <string name="insight_delta_warmer">Σήμερα θα είναι %1$d° πιο ζεστό από χθες.</string>
-    <string name="insight_delta_cooler">Σήμερα θα είναι %1$d° πιο κρύο από χθες.</string>
+    <string name="insight_delta_warmer">%1$d° πιο ζεστά από χθες.</string>
+    <string name="insight_delta_cooler">%1$d° πιο δροσερά από χθες.</string>
     <string name="insight_alert">Ειδοποίηση: %1$s.</string>
     <string name="insight_clothes_wear">Φόρεσε %1$s.</string>
     <string name="insight_clothes_bare">%1$s.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -455,8 +455,8 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="insight_band_mild">templado</string>
     <string name="insight_band_warm">cálido</string>
     <string name="insight_band_hot">muy caluroso</string>
-    <string name="insight_delta_warmer">Hará %1$d° más hoy.</string>
-    <string name="insight_delta_cooler">Hará %1$d° menos hoy.</string>
+    <string name="insight_delta_warmer">%1$d° más que ayer.</string>
+    <string name="insight_delta_cooler">%1$d° menos que ayer.</string>
     <string name="insight_alert">Alerta: %1$s.</string>
     <string name="insight_clothes_wear">Lleva %1$s.</string>
     <string name="insight_clothes_bare">%1$s.</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -532,8 +532,8 @@ Tone is informal "sina"-form throughout ("Pane … selga", "Võta … kaasa",
     <string name="insight_band_mild">mahe</string>
     <string name="insight_band_warm">soe</string>
     <string name="insight_band_hot">kuum</string>
-    <string name="insight_delta_warmer">Täna on %1$d° soojem.</string>
-    <string name="insight_delta_cooler">Täna on %1$d° külmem.</string>
+    <string name="insight_delta_warmer">%1$d° soojem kui eile.</string>
+    <string name="insight_delta_cooler">%1$d° jahedam kui eile.</string>
     <string name="insight_alert">Hoiatus: %1$s.</string>
     <!-- "Pane selga" = idiomatic "put on" with split verb. -->
     <string name="insight_clothes_wear">Pane selga %1$s.</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -74,8 +74,8 @@ Western Arabic numerals (0-9) are used for TTS compatibility.
     <string name="insight_band_mild">معتدل</string>
     <string name="insight_band_warm">گرم</string>
     <string name="insight_band_hot">داغ</string>
-    <string name="insight_delta_warmer">امروز %1$d° گرم‌تر خواهد بود.</string>
-    <string name="insight_delta_cooler">امروز %1$d° سردتر خواهد بود.</string>
+    <string name="insight_delta_warmer">%1$d° گرم‌تر از دیروز خواهد بود.</string>
+    <string name="insight_delta_cooler">%1$d° خنک‌تر از دیروز خواهد بود.</string>
     <string name="insight_alert">هشدار: %1$s.</string>
     <!-- SOV: "%1$s را بپوشید" = "[item] را (object marker) wear". -->
     <string name="insight_clothes_wear">%1$s را بپوشید.</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -378,8 +378,8 @@ displayed label localizes.
     <string name="insight_band_warm">lämmintä</string>
     <string name="insight_band_hot">kuumaa</string>
 
-    <string name="insight_delta_warmer">Tänään on %1$d° lämpimämpi.</string>
-    <string name="insight_delta_cooler">Tänään on %1$d° kylmempi.</string>
+    <string name="insight_delta_warmer">%1$d° lämpimämpi kuin eilen.</string>
+    <string name="insight_delta_cooler">%1$d° viileämpi kuin eilen.</string>
 
     <string name="insight_alert">Varoitus: %1$s.</string>
 

--- a/app/src/main/res/values-fil/strings.xml
+++ b/app/src/main/res/values-fil/strings.xml
@@ -70,8 +70,8 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="insight_band_mild">katamtaman</string>
     <string name="insight_band_warm">mainit-init</string>
     <string name="insight_band_hot">mainit</string>
-    <string name="insight_delta_warmer">Ngayon ay %1$d° mas mainit.</string>
-    <string name="insight_delta_cooler">Ngayon ay %1$d° mas malamig.</string>
+    <string name="insight_delta_warmer">%1$d° na mas mainit kaysa kahapon.</string>
+    <string name="insight_delta_cooler">%1$d° na mas malamig kaysa kahapon.</string>
     <string name="insight_alert">Babala: %1$s.</string>
     <string name="insight_clothes_wear">Magsuot ng %1$s.</string>
     <string name="insight_clothes_bare">%1$s.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -457,8 +457,8 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="insight_band_mild">doux</string>
     <string name="insight_band_warm">chaud</string>
     <string name="insight_band_hot">très chaud</string>
-    <string name="insight_delta_warmer">Il fera %1$d° de plus aujourd\'hui.</string>
-    <string name="insight_delta_cooler">Il fera %1$d° de moins aujourd\'hui.</string>
+    <string name="insight_delta_warmer">%1$d° de plus qu\'hier.</string>
+    <string name="insight_delta_cooler">%1$d° de moins qu\'hier.</string>
     <string name="insight_alert">Alerte : %1$s.</string>
     <string name="insight_clothes_wear">Porte %1$s.</string>
     <string name="insight_clothes_bare">%1$s.</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -427,8 +427,8 @@ spousal register), matching the existing insight prose ("Ponesi …",
     <string name="insight_band_mild">blago</string>
     <string name="insight_band_warm">toplo</string>
     <string name="insight_band_hot">vruće</string>
-    <string name="insight_delta_warmer">Danas će biti %1$d° toplije.</string>
-    <string name="insight_delta_cooler">Danas će biti %1$d° hladnije.</string>
+    <string name="insight_delta_warmer">%1$d° toplije nego jučer.</string>
+    <string name="insight_delta_cooler">%1$d° hladnije nego jučer.</string>
     <string name="insight_alert">Upozorenje: %1$s.</string>
     <string name="insight_clothes_wear">Obuci %1$s.</string>
     <string name="insight_clothes_bare">%1$s.</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -578,8 +578,8 @@ locale (Angol (Egyesült Államok), Francia (Franciaország), Német
     <string name="insight_band_mild">enyhe</string>
     <string name="insight_band_warm">meleg</string>
     <string name="insight_band_hot">forró</string>
-    <string name="insight_delta_warmer">Ma %1$d°-kal melegebb lesz.</string>
-    <string name="insight_delta_cooler">Ma %1$d°-kal hidegebb lesz.</string>
+    <string name="insight_delta_warmer">%1$d°-kal melegebb lesz, mint tegnap.</string>
+    <string name="insight_delta_cooler">%1$d°-kal hűvösebb lesz, mint tegnap.</string>
     <string name="insight_alert">Figyelmeztetés: %1$s.</string>
     <string name="insight_clothes_wear">Vegyél fel %1$s.</string>
     <string name="insight_clothes_bare">%1$s.</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -72,8 +72,8 @@ to values/strings.xml (English).
     <string name="insight_band_mild">hangat sedang</string>
     <string name="insight_band_warm">hangat</string>
     <string name="insight_band_hot">panas</string>
-    <string name="insight_delta_warmer">Hari ini %1$d° lebih panas.</string>
-    <string name="insight_delta_cooler">Hari ini %1$d° lebih dingin.</string>
+    <string name="insight_delta_warmer">%1$d° lebih hangat dari kemarin.</string>
+    <string name="insight_delta_cooler">%1$d° lebih dingin dari kemarin.</string>
     <string name="insight_alert">Peringatan: %1$s.</string>
     <string name="insight_clothes_wear">Kenakan %1$s.</string>
     <string name="insight_clothes_bare">%1$s.</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -444,8 +444,8 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="insight_band_mild">mite</string>
     <string name="insight_band_warm">caldo</string>
     <string name="insight_band_hot">molto caldo</string>
-    <string name="insight_delta_warmer">Oggi farà %1$d° in più.</string>
-    <string name="insight_delta_cooler">Oggi farà %1$d° in meno.</string>
+    <string name="insight_delta_warmer">%1$d° in più rispetto a ieri.</string>
+    <string name="insight_delta_cooler">%1$d° in meno rispetto a ieri.</string>
     <string name="insight_alert">Allerta: %1$s.</string>
     <string name="insight_clothes_wear">Indossa %1$s.</string>
     <string name="insight_clothes_bare">%1$s.</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -77,8 +77,8 @@ What is NOT overridden, by design:
     <string name="insight_band_mild">švelnu</string>
     <string name="insight_band_warm">šilta</string>
     <string name="insight_band_hot">karšta</string>
-    <string name="insight_delta_warmer">Šiandien bus %1$d° šilčiau.</string>
-    <string name="insight_delta_cooler">Šiandien bus %1$d° šalčiau.</string>
+    <string name="insight_delta_warmer">%1$d° šilčiau nei vakar.</string>
+    <string name="insight_delta_cooler">%1$d° vėsiau nei vakar.</string>
     <string name="insight_alert">Įspėjimas: %1$s.</string>
     <string name="insight_clothes_wear">Apsivilk %1$s.</string>
     <string name="insight_clothes_bare">%1$s.</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -83,8 +83,8 @@ informal "tu"-form throughout ("Apģērb …", "Paņem … līdzi").
     <string name="insight_band_mild">mērens</string>
     <string name="insight_band_warm">silts</string>
     <string name="insight_band_hot">karsts</string>
-    <string name="insight_delta_warmer">Šodien būs par %1$d° siltāks.</string>
-    <string name="insight_delta_cooler">Šodien būs par %1$d° aukstāks.</string>
+    <string name="insight_delta_warmer">%1$d° siltāks nekā vakar.</string>
+    <string name="insight_delta_cooler">%1$d° vēsāks nekā vakar.</string>
     <string name="insight_alert">Brīdinājums: %1$s.</string>
     <string name="insight_clothes_wear">Apģērb %1$s.</string>
     <string name="insight_clothes_bare">%1$s.</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -72,8 +72,8 @@ vs "kemungkinan", "padam" vs "hapus").
     <string name="insight_band_mild">sederhana</string>
     <string name="insight_band_warm">hangat</string>
     <string name="insight_band_hot">panas</string>
-    <string name="insight_delta_warmer">Hari ini %1$d° lebih panas.</string>
-    <string name="insight_delta_cooler">Hari ini %1$d° lebih sejuk.</string>
+    <string name="insight_delta_warmer">%1$d° lebih panas daripada semalam.</string>
+    <string name="insight_delta_cooler">%1$d° lebih sejuk daripada semalam.</string>
     <string name="insight_alert">Amaran: %1$s.</string>
     <string name="insight_clothes_wear">Pakai %1$s.</string>
     <string name="insight_clothes_bare">%1$s.</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -581,8 +581,8 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrike)").
     <string name="insight_band_warm">varmt</string>
     <string name="insight_band_hot">veldig varmt</string>
 
-    <string name="insight_delta_warmer">Det blir %1$d° varmere i dag.</string>
-    <string name="insight_delta_cooler">Det blir %1$d° kaldere i dag.</string>
+    <string name="insight_delta_warmer">%1$d° varmere enn i går.</string>
+    <string name="insight_delta_cooler">%1$d° kaldere enn i går.</string>
 
     <string name="insight_alert">Advarsel: %1$s.</string>
 

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -422,8 +422,8 @@ the displayed label localizes.
     <string name="insight_band_warm">warm</string>
     <string name="insight_band_hot">erg warm</string>
 
-    <string name="insight_delta_warmer">Het wordt vandaag %1$d° warmer.</string>
-    <string name="insight_delta_cooler">Het wordt vandaag %1$d° kouder.</string>
+    <string name="insight_delta_warmer">%1$d° warmer dan gisteren.</string>
+    <string name="insight_delta_cooler">%1$d° kouder dan gisteren.</string>
 
     <string name="insight_alert">Waarschuwing: %1$s.</string>
 

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -421,8 +421,8 @@ is unchanged; only the displayed label localizes.
     <string name="insight_band_warm">ciepło</string>
     <string name="insight_band_hot">gorąco</string>
 
-    <string name="insight_delta_warmer">Dziś będzie o %1$d° cieplej.</string>
-    <string name="insight_delta_cooler">Dziś będzie o %1$d° chłodniej.</string>
+    <string name="insight_delta_warmer">o %1$d° cieplej niż wczoraj.</string>
+    <string name="insight_delta_cooler">o %1$d° chłodniej niż wczoraj.</string>
 
     <string name="insight_alert">Ostrzeżenie: %1$s.</string>
 

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -462,8 +462,8 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="insight_band_mild">ameno</string>
     <string name="insight_band_warm">quente</string>
     <string name="insight_band_hot">muito quente</string>
-    <string name="insight_delta_warmer">Hoje estará %1$d° mais quente.</string>
-    <string name="insight_delta_cooler">Hoje estará %1$d° mais frio.</string>
+    <string name="insight_delta_warmer">%1$d° mais quente que ontem.</string>
+    <string name="insight_delta_cooler">%1$d° mais frio que ontem.</string>
     <string name="insight_alert">Alerta: %1$s.</string>
     <string name="insight_clothes_wear">Vista %1$s.</string>
     <string name="insight_clothes_bare">%1$s.</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -486,8 +486,8 @@ they diverge from BR ("Polonês" → "Polaco", "Holandês" →
     <string name="insight_band_mild">ameno</string>
     <string name="insight_band_warm">quente</string>
     <string name="insight_band_hot">muito quente</string>
-    <string name="insight_delta_warmer">Hoje estará %1$d° mais quente.</string>
-    <string name="insight_delta_cooler">Hoje estará %1$d° mais frio.</string>
+    <string name="insight_delta_warmer">%1$d° mais quente do que ontem.</string>
+    <string name="insight_delta_cooler">%1$d° mais frio do que ontem.</string>
     <string name="insight_alert">Alerta: %1$s.</string>
     <string name="insight_clothes_wear">Veste %1$s.</string>
     <string name="insight_clothes_bare">%1$s.</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -70,8 +70,8 @@ surfaces fall back to default English (matching values-pl / values-uk).
     <string name="insight_band_mild">blând</string>
     <string name="insight_band_warm">cald</string>
     <string name="insight_band_hot">cald tare</string>
-    <string name="insight_delta_warmer">Astăzi va fi cu %1$d° mai cald.</string>
-    <string name="insight_delta_cooler">Astăzi va fi cu %1$d° mai rece.</string>
+    <string name="insight_delta_warmer">cu %1$d° mai cald decât ieri.</string>
+    <string name="insight_delta_cooler">cu %1$d° mai rece decât ieri.</string>
     <string name="insight_alert">Avertisment: %1$s.</string>
     <string name="insight_clothes_wear">Poartă %1$s.</string>
     <string name="insight_clothes_bare">%1$s.</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -646,8 +646,8 @@ only the displayed label localizes.
     <string name="insight_band_mild">тепло</string>
     <string name="insight_band_warm">жарко</string>
     <string name="insight_band_hot">очень жарко</string>
-    <string name="insight_delta_warmer">Сегодня на %1$d° теплее.</string>
-    <string name="insight_delta_cooler">Сегодня на %1$d° холоднее.</string>
+    <string name="insight_delta_warmer">на %1$d° теплее, чем вчера.</string>
+    <string name="insight_delta_cooler">на %1$d° холоднее, чем вчера.</string>
     <string name="insight_alert">Предупреждение: %1$s.</string>
     <string name="insight_clothes_wear">Надень %1$s.</string>
     <string name="insight_clothes_bare">%1$s.</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -589,8 +589,8 @@ What is NOT overridden, by design:
     <string name="insight_band_mild">mierne</string>
     <string name="insight_band_warm">teplo</string>
     <string name="insight_band_hot">horúco</string>
-    <string name="insight_delta_warmer">Dnes bude o %1$d° teplejšie.</string>
-    <string name="insight_delta_cooler">Dnes bude o %1$d° chladnejšie.</string>
+    <string name="insight_delta_warmer">o %1$d° teplejšie ako včera.</string>
+    <string name="insight_delta_cooler">o %1$d° chladnejšie ako včera.</string>
     <string name="insight_alert">Výstraha: %1$s.</string>
     <string name="insight_clothes_wear">Obleč si %1$s.</string>
     <string name="insight_clothes_bare">%1$s.</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -70,8 +70,8 @@ informal "ti"-form throughout, mirroring the Croatian / Serbian pass.
     <string name="insight_band_mild">mlačno</string>
     <string name="insight_band_warm">toplo</string>
     <string name="insight_band_hot">vroče</string>
-    <string name="insight_delta_warmer">Danes bo %1$d° topleje.</string>
-    <string name="insight_delta_cooler">Danes bo %1$d° hladneje.</string>
+    <string name="insight_delta_warmer">%1$d° topleje kot včeraj.</string>
+    <string name="insight_delta_cooler">%1$d° hladneje kot včeraj.</string>
     <string name="insight_alert">Opozorilo: %1$s.</string>
     <!-- Informal "ti": "Obleci …", "Vzemi … s seboj". -->
     <string name="insight_clothes_wear">Obleci %1$s.</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -581,8 +581,8 @@ native names for all locales (e.g. "Tyska (Tyskland)", "Franska (Frankrike)").
     <string name="insight_band_warm">varmt</string>
     <string name="insight_band_hot">mycket varmt</string>
 
-    <string name="insight_delta_warmer">Det blir %1$d° varmare idag.</string>
-    <string name="insight_delta_cooler">Det blir %1$d° kallare idag.</string>
+    <string name="insight_delta_warmer">%1$d° varmare än igår.</string>
+    <string name="insight_delta_cooler">%1$d° kallare än igår.</string>
 
     <string name="insight_alert">Varning: %1$s.</string>
 

--- a/app/src/main/res/values-sw/strings.xml
+++ b/app/src/main/res/values-sw/strings.xml
@@ -70,8 +70,8 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="insight_band_mild">ya wastani</string>
     <string name="insight_band_warm">joto kidogo</string>
     <string name="insight_band_hot">joto</string>
-    <string name="insight_delta_warmer">Itakuwa %1$d° ya joto zaidi kuliko jana.</string>
-    <string name="insight_delta_cooler">Itakuwa %1$d° baridi zaidi kuliko jana.</string>
+    <string name="insight_delta_warmer">moto zaidi kwa %1$d° kuliko jana.</string>
+    <string name="insight_delta_cooler">baridi zaidi kwa %1$d° kuliko jana.</string>
     <string name="insight_alert">Tahadhari: %1$s.</string>
     <string name="insight_clothes_wear">Vaa %1$s.</string>
     <string name="insight_clothes_bare">%1$s.</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -587,8 +587,8 @@ only the displayed label localizes.
     <string name="insight_band_mild">тепло</string>
     <string name="insight_band_warm">жарко</string>
     <string name="insight_band_hot">дуже спекотно</string>
-    <string name="insight_delta_warmer">Сьогодні на %1$d° тепліше.</string>
-    <string name="insight_delta_cooler">Сьогодні на %1$d° холодніше.</string>
+    <string name="insight_delta_warmer">на %1$d° тепліше, ніж вчора.</string>
+    <string name="insight_delta_cooler">на %1$d° прохолодніше, ніж вчора.</string>
     <string name="insight_alert">Попередження: %1$s.</string>
     <string name="insight_clothes_wear">Одягніть %1$s.</string>
     <string name="insight_clothes_bare">%1$s.</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -75,8 +75,8 @@ Skipped intentionally: app_name (brand), insight_time_am/pm/midnight/noon
     <string name="insight_band_mild">dễ chịu</string>
     <string name="insight_band_warm">ấm</string>
     <string name="insight_band_hot">nóng</string>
-    <string name="insight_delta_warmer">Hôm nay ấm hơn %1$d°.</string>
-    <string name="insight_delta_cooler">Hôm nay lạnh hơn %1$d°.</string>
+    <string name="insight_delta_warmer">ấm hơn hôm qua %1$d°.</string>
+    <string name="insight_delta_cooler">mát hơn hôm qua %1$d°.</string>
     <string name="insight_alert">Cảnh báo: %1$s.</string>
     <string name="insight_clothes_wear">Mặc %1$s.</string>
     <string name="insight_clothes_bare">%1$s.</string>

--- a/app/src/test/kotlin/app/clothescast/insight/InsightFormatterTest.kt
+++ b/app/src/test/kotlin/app/clothescast/insight/InsightFormatterTest.kt
@@ -749,10 +749,25 @@ class InsightFormatterTest {
     }
 
     @Test
-    fun `omit range on the visual surface gives the leading delta a capitalised it-will-be`() {
+    fun `omit range on the visual surface drops the leading delta's it-will-be subject`() {
+        // With the period lead dropped, "it will be" goes with it — the delta
+        // collapses to the bare fragment, mirroring how the band sentence
+        // collapses to a bare "14° to 20°." on the same surface, rather than
+        // reading the redundant "It will be …" beneath the card's "Today" header.
         omitCardSubject.format(
             summary(delta = DeltaClause(5, DeltaClause.Direction.WARMER)),
-        ) shouldBe "It will be 5° warmer than yesterday."
+        ) shouldBe "5° warmer than yesterday."
+    }
+
+    @Test
+    fun `omit range preview parenthesises the whole leading-delta preamble`() {
+        // Speech-only preview: the dropped preamble is the full "Today, it will
+        // be" that fronts the temperature field — the same parenthesised
+        // preamble the band sentence shows ("(Today, it will be) 14° to 20°.").
+        omitCardSubject.format(
+            summary(delta = DeltaClause(5, DeltaClause.Direction.WARMER)),
+            surface = InsightSurface.SETTINGS_PREVIEW,
+        ) shouldBe "(Today, it will be) 5° warmer than yesterday."
     }
 
     @Test
@@ -1602,11 +1617,12 @@ class InsightFormatterTest {
     }
 
     @Test
-    fun `de — no-lead leading delta uses the self-introducing German fragment`() {
+    fun `de — no-lead leading delta drops the it-will-be subject like English`() {
         // Range omitted + a numeric delta: the delta leads the temperature
-        // content, so it uses insight_delta_warmer_lead ("es wird … wärmer als
-        // gestern.") capitalised, rather than the trailing "Heute wird es …"
-        // fragment.
+        // content. With the lead dropped, the "es wird" subject goes with it
+        // (German's insight_delta_warmer is the bare "%d° wärmer als gestern."
+        // comparison fragment, just as English drops "it will be"), rather than
+        // the self-introducing "Es wird …" form.
         val germanNoLead = InsightFormatter.forContext(
             context,
             Locale.GERMAN,
@@ -1615,7 +1631,107 @@ class InsightFormatterTest {
         )
         germanNoLead.format(
             summary(delta = DeltaClause(5, DeltaClause.Direction.WARMER)),
-        ) shouldBe "Es wird 5° wärmer als gestern."
+        ) shouldBe "5° wärmer als gestern."
+    }
+
+    @Test
+    fun `de — omit-range preview parenthesises the whole leading-delta preamble`() {
+        // Like English's "(Today, it will be) 5° warmer than yesterday.": the
+        // dropped preamble is the full "Heute, es wird" that fronts the
+        // temperature field, not just "Heute,".
+        val germanPreview = InsightFormatter.forContext(
+            context,
+            Locale.GERMAN,
+            rangeFormat = RangeFormat.NONE,
+            periodPreamble = PreambleVisibility.SPEECH_ONLY,
+        )
+        germanPreview.format(
+            summary(delta = DeltaClause(5, DeltaClause.Direction.WARMER)),
+            surface = InsightSurface.SETTINGS_PREVIEW,
+        ) shouldBe "(Heute, es wird) 5° wärmer als gestern."
+    }
+
+    @Test
+    fun `de — trailing delta after a band sentence drops the repeated Heute`() {
+        // With a band sentence ahead supplying the subject, the delta is the
+        // bare comparison fragment — no second "Heute wird es …" stutter.
+        germanSubject.format(
+            summary(delta = DeltaClause(5, DeltaClause.Direction.WARMER)),
+        ) shouldBe "Heute wird es 21°. 5° wärmer als gestern."
+    }
+
+    // ---------------------------------------------------------------------
+    // Other-locale leading-delta coverage: every SVO locale whose
+    // insight_delta_*_lead fronts a verb now behaves like English — the verb
+    // joins the dropped preamble on the no-lead surface and the preview
+    // parenthesises it. French exercises a number-initial fragment (no
+    // capitalisation needed); Polish exercises a particle-initial fragment,
+    // pinning the trailing/leading sentence-case fix ("o …" → "O …").
+    // ---------------------------------------------------------------------
+
+    @Test
+    fun `fr — omit-range no-lead drops the verb like English`() {
+        val frNoLead = InsightFormatter.forContext(
+            context,
+            Locale.FRENCH,
+            rangeFormat = RangeFormat.NONE,
+            periodPreamble = PreambleVisibility.NEVER,
+        )
+        frNoLead.format(
+            summary(delta = DeltaClause(5, DeltaClause.Direction.WARMER)),
+        ) shouldBe "5° de plus qu'hier."
+    }
+
+    @Test
+    fun `fr — omit-range preview parenthesises the leading-delta preamble`() {
+        val frPreview = InsightFormatter.forContext(
+            context,
+            Locale.FRENCH,
+            rangeFormat = RangeFormat.NONE,
+            periodPreamble = PreambleVisibility.SPEECH_ONLY,
+        )
+        frPreview.format(
+            summary(delta = DeltaClause(5, DeltaClause.Direction.WARMER)),
+            surface = InsightSurface.SETTINGS_PREVIEW,
+        ) shouldBe "(Aujourd'hui, il fera) 5° de plus qu'hier."
+    }
+
+    @Test
+    fun `pl — omit-range no-lead capitalises the particle-initial fragment`() {
+        val plNoLead = InsightFormatter.forContext(
+            context,
+            Locale.forLanguageTag("pl"),
+            rangeFormat = RangeFormat.NONE,
+            periodPreamble = PreambleVisibility.NEVER,
+        )
+        plNoLead.format(
+            summary(delta = DeltaClause(5, DeltaClause.Direction.WARMER)),
+        ) shouldBe "O 5° cieplej niż wczoraj."
+    }
+
+    @Test
+    fun `pl — trailing delta after a band sentence opens with a capital`() {
+        // The bare fragment opens "o 5° cieplej …"; trailing a band sentence it
+        // starts a new sentence, so formatDelta capitalises it to "O 5° …"
+        // rather than leaving a lowercase letter after the full stop.
+        val plSubject = InsightFormatter.forContext(context, Locale.forLanguageTag("pl"))
+        plSubject.format(
+            summary(delta = DeltaClause(5, DeltaClause.Direction.WARMER)),
+        ) shouldBe "Dziś będzie 21°. O 5° cieplej niż wczoraj."
+    }
+
+    @Test
+    fun `pl — omit-range preview parenthesises the leading-delta preamble`() {
+        val plPreview = InsightFormatter.forContext(
+            context,
+            Locale.forLanguageTag("pl"),
+            rangeFormat = RangeFormat.NONE,
+            periodPreamble = PreambleVisibility.SPEECH_ONLY,
+        )
+        plPreview.format(
+            summary(delta = DeltaClause(5, DeltaClause.Direction.WARMER)),
+            surface = InsightSurface.SETTINGS_PREVIEW,
+        ) shouldBe "(Dziś, będzie) o 5° cieplej niż wczoraj."
     }
 
     // ---------------------------------------------------------------------


### PR DESCRIPTION
## Problem

When the temperature range is hidden (`RangeFormat.NONE`) and the day's only temperature field is the day-on-day change, the leading delta clause carried a redundant subject that the band sentence drops on the same surface:

- Today card (no-lead): English read **"It will be 5° warmer than yesterday."** — but the band sentence on the same surface is the bare **"14° to 20°."**.
- Settings preview: the parenthesized preamble hint stranded the verb *outside* the parens — `(Today,) it will be 5° warmer than yesterday.` instead of `(Today, it will be) 5° warmer than yesterday.`.

## Fix

The card now reads the bare comparison **"5° warmer than yesterday."**, and the preview brackets the whole `(Today, it will be) 5° warmer than yesterday.` preamble — matching the band sentence's `(Today, it will be) 14° to 20°.` and the wear preview `(Wear a) sweater.`.

This now applies in **every language whose self-introducing delta template fronts a verb** — the verb joins the dropped preamble on the no-lead card and the preview brackets it:

| Locale | No-lead card | Preview |
|---|---|---|
| en | `5° warmer than yesterday.` | `(Today, it will be) 5° warmer than yesterday.` |
| de | `5° wärmer als gestern.` | `(Heute, es wird) 5° wärmer als gestern.` |
| fr | `5° de plus qu'hier.` | `(Aujourd'hui, il fera) 5° de plus qu'hier.` |
| pl | `O 5° cieplej niż wczoraj.` | `(Dziś, będzie) o 5° cieplej niż wczoraj.` |

…and likewise across the Latin/Cyrillic/Greek/Arabic SVO locales (es, ca, it, nl, da, nb, sv, el, hr, sr-Latn, sl, et, lt, lv, fi, fa, hu, in, ms, fil, ar, pt-rBR, pt-rPT, cs, sk, ro, ru, uk, bg, vi, sw).

**Out of scope (left unchanged):** verb-final / topic-first locales — **ja, ko, zh-rCN, zh-rTW, th, hi, bn, am, tr, iw(he)**. Their delta can't expose a leading-subject prefix to drop (the verb is at the end, or the comparison opens the sentence), so they keep their existing self-introducing form. Forcing the pattern there would either re-introduce the day word or require new translations rather than reusing existing text.

## Implementation

- **Strings:** each locale's bare delta (`insight_delta_warmer` / `_cooler`) is now the subject-less comparison fragment, reusing the already-translated wording from its `_lead` string minus the leading verb — so no new vocabulary was invented. As a bonus this drops the repeated "today" stutter when the delta trails a band sentence (German `Heute wird es kühl. 5° wärmer als gestern.`).
- **`formatDelta`:** picks the bare form for the no-lead leading delta only when the locale's `_lead` form *ends with* it (the dropped subject is exactly the prefix) — a generic check, no per-locale gate. Verb-final locales fail this check and keep the `_lead` form.
- **Trailing capitalization:** the trailing delta opens a new sentence, so its first letter is capitalized — a no-op for number-initial fragments (en, de), and it restores sentence case for particle-initial ones (Polish `o 5°…` → `O 5°…`, Russian `на 5°…` → `На 5°…`).

## Privacy

No change to what leaves the device. The rendered prose feeds Gemini TTS over BYOK keys; this only ever makes that text *shorter* (drops the leading verb scaffold), and the spoken surface keeps its full lead under the "Speech only" setting.

## Test plan

- `./gradlew :core:domain:test :core:data:test :app:testDebugUnitTest` — green.
- `./gradlew :app:assembleDebug` — green; aapt validated all 33 changed locale files.
- `InsightFormatterTest`: English no-lead now asserts the bare fragment + a settings-preview case; German no-lead/with-lead/preview/trailing; French (number-initial) + Polish (particle-initial, pinning the trailing/leading sentence-case fix) no-lead, preview, and trailing.

https://claude.ai/code/session_01Duqdbdz9WKviw5YqLQzZcm