### PR TITLE
Pair from phone to add a Gemini key, and scroll charts on TV

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/UiModeExt.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/UiModeExt.kt
@@ -2,6 +2,7 @@ package app.clothescast.ui
 
 import android.app.UiModeManager
 import android.content.Context
+import android.content.pm.PackageManager
 import android.content.res.Configuration
 
 /** Returns `true` when the app is running on an Android TV / Google TV device. */
@@ -9,3 +10,15 @@ fun isTelevision(context: Context): Boolean {
     val uiModeManager = context.getSystemService(Context.UI_MODE_SERVICE) as UiModeManager
     return uiModeManager.currentModeType == Configuration.UI_MODE_TYPE_TELEVISION
 }
+
+/**
+ * True when typing a long API key directly on this device is painful, so the
+ * "Pair from phone" handoff is worth surfacing: an Android TV, or any device
+ * with no touchscreen (typically driven by a D-pad / remote, where on-screen
+ * keyboard entry of a 39-char key is slow and error-prone). Touch devices
+ * (phones, tablets) can paste or type a key easily, so they don't need the
+ * extra affordance.
+ */
+fun prefersRemoteKeyEntry(context: Context): Boolean =
+    isTelevision(context) ||
+        !context.packageManager.hasSystemFeature(PackageManager.FEATURE_TOUCHSCREEN)

--- a/app/src/main/kotlin/app/clothescast/ui/nav/ClothesCastNavHost.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/nav/ClothesCastNavHost.kt
@@ -237,7 +237,13 @@ private fun NavGraphBuilder.settingsGraph(nav: NavController, app: ClothesCastAp
         composable<FormatDest> { e -> FormatPage(e.settingsViewModel(nav, app), onBack) }
         composable<ClothesDest> { e -> ClothesPage(e.settingsViewModel(nav, app), onBack) }
         composable<RegionDest> { e -> RegionPage(e.settingsViewModel(nav, app), onBack) }
-        composable<VoiceDest> { e -> VoicePage(e.settingsViewModel(nav, app), onBack) }
+        composable<VoiceDest> { e ->
+            VoicePage(
+                viewModel = e.settingsViewModel(nav, app),
+                onBack = onBack,
+                onPairFromPhone = { nav.navigate(PairingRoute) },
+            )
+        }
         composable<DisplayDest> { e -> DisplayPage(e.settingsViewModel(nav, app), onBack) }
         composable<LocationDest> { e -> LocationPage(e.settingsViewModel(nav, app), onBack) }
         composable<CalendarDest> { e ->

--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsPreviews.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsPreviews.kt
@@ -446,6 +446,7 @@ internal fun SettingsVoiceDevicePreview() {
             onSetVoiceLocale = {},
             onSetGeminiKey = {},
             onClearGeminiKey = {},
+            onPairFromPhone = {},
         )
     }
 }
@@ -476,6 +477,7 @@ internal fun SettingsVoiceGeminiPreview() {
             onSetVoiceLocale = {},
             onSetGeminiKey = {},
             onClearGeminiKey = {},
+            onPairFromPhone = {},
         )
     }
 }

--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsScreen.kt
@@ -213,7 +213,11 @@ internal fun RegionPage(viewModel: SettingsViewModel, onBack: () -> Unit) {
 }
 
 @Composable
-internal fun VoicePage(viewModel: SettingsViewModel, onBack: () -> Unit) {
+internal fun VoicePage(
+    viewModel: SettingsViewModel,
+    onBack: () -> Unit,
+    onPairFromPhone: () -> Unit,
+) {
     val state by viewModel.state.collectAsStateWithLifecycle()
     SettingsScaffold(R.string.settings_root_voice, onBack) { padding ->
         VoiceContent(
@@ -238,6 +242,7 @@ internal fun VoicePage(viewModel: SettingsViewModel, onBack: () -> Unit) {
             onSetVoiceLocale = viewModel::setVoiceLocale,
             onSetGeminiKey = viewModel::setApiKey,
             onClearGeminiKey = viewModel::clearApiKey,
+            onPairFromPhone = onPairFromPhone,
         )
     }
 }

--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsViewModel.kt
@@ -313,7 +313,25 @@ class SettingsViewModel(
                 }
             }
         }
-        viewModelScope.launch { refreshApiKeyStatus() }
+        // Re-validate the API-key status whenever the stored ciphertext appears
+        // or disappears. Collecting the flow (rather than a one-shot
+        // refreshApiKeyStatus() at init) is what lets a key written *outside*
+        // this ViewModel flip the flag — notably the phone-pairing flow now
+        // reachable from Voice settings, which persists the key through a
+        // separate PairingViewModel; without it, returning to the still-alive
+        // SettingsViewModel via popBackStack() would keep showing the key as
+        // unset until the ViewModel was recreated. We re-run refreshApiKeyStatus()
+        // (which decrypts via keyStore.get()) on each emission rather than
+        // trusting the flow's presence-only boolean: get() clears corrupt
+        // ciphertext and returns false, so a key that exists but can no longer
+        // be decrypted (e.g. after a Keystore restore/rotation) surfaces as
+        // unset and prompts re-entry, instead of reading "configured" until the
+        // next TTS attempt fails. Emissions are distinctUntilChanged on
+        // presence, so the decrypt only runs when the stored key actually
+        // changes — not a hot path.
+        viewModelScope.launch {
+            keyStore.geminiKeyConfiguredFlow.collect { refreshApiKeyStatus() }
+        }
         viewModelScope.launch {
             keyStore.mqttPasswordConfiguredFlow.collect { set ->
                 _state.update { it.copy(mqttPasswordSet = set) }

--- a/app/src/main/kotlin/app/clothescast/ui/settings/VoiceSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/VoiceSettings.kt
@@ -61,6 +61,7 @@ import app.clothescast.tts.resolve
 import app.clothescast.tts.toJavaLocale
 import app.clothescast.tts.withSpeechAudioFocus
 import app.clothescast.ui.EdgeFadeOverlay
+import app.clothescast.ui.prefersRemoteKeyEntry
 import java.text.Collator
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
@@ -90,8 +91,12 @@ internal fun VoiceContent(
     onSetVoiceLocale: (VoiceLocale) -> Unit,
     onSetGeminiKey: (String) -> Unit,
     onClearGeminiKey: () -> Unit,
+    onPairFromPhone: () -> Unit,
 ) {
     val context = LocalContext.current
+    // Only surface the "Pair from phone" handoff where typing a key directly is
+    // hard (TV / no touchscreen) — see prefersRemoteKeyEntry.
+    val showPairFromPhone = remember(context) { prefersRemoteKeyEntry(context) }
     val coroutineScope = rememberCoroutineScope()
     // While a preview is in flight (synthesis + playback) we lock the whole
     // voice section. Cloud TTS calls are billed per-character and the in-flight
@@ -199,6 +204,18 @@ internal fun VoiceContent(
                             onSave = onSetGeminiKey,
                             onClear = onClearGeminiKey,
                         )
+                        // Entering a long API key with a remote is painful, so
+                        // offer the same phone-pairing handoff (QR + local web
+                        // form) onboarding uses — but only on devices where
+                        // direct entry is actually hard (TV / no touchscreen).
+                        // Touch devices can paste or type the key fine, so the
+                        // extra button would just be noise there.
+                        if (showPairFromPhone) {
+                            TextButton(
+                                onClick = onPairFromPhone,
+                                modifier = Modifier.fillMaxWidth(),
+                            ) { Text(stringResource(R.string.onboarding_pair_from_phone)) }
+                        }
                         VoicePicker(
                             title = stringResource(R.string.settings_tts_voice_label),
                             voices = GEMINI_VOICES,

--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
@@ -30,6 +30,14 @@ import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.gestures.animateScrollBy
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onKeyEvent
+import androidx.compose.ui.input.key.type
+import app.clothescast.ui.isTelevision
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
@@ -892,6 +900,10 @@ internal fun HomePageScaffold(
     // Reuses the exact helper the conditions widget and outfit card feed off so
     // every surface reads the same indicators in the same order.
     val context = LocalContext.current
+    // D-pad scrolling support for Android TV (see the Column modifier below).
+    val isTv = remember(context) { isTelevision(context) }
+    val tvScrollScope = rememberCoroutineScope()
+    val tvScrollStepPx = with(LocalDensity.current) { 240.dp.toPx() }
     val conditionsInfo: OutfitCardInfoLines? = remember(
         conditionsHourly,
         state.region,
@@ -931,6 +943,45 @@ internal fun HomePageScaffold(
             Column(
                 modifier = Modifier
                     .fillMaxSize()
+                    // On TV the home page is a mostly read-only card stack with
+                    // little focusable content, so D-pad presses can't move focus
+                    // past the confidence chip and the chart deck below it stays
+                    // unreachable. Make the scroll container focusable and turn
+                    // D-pad up/down into a scroll so the whole page is navigable
+                    // with a remote. Gated on TV so phone / touch is unchanged.
+                    .then(
+                        if (isTv) {
+                            Modifier
+                                .focusable()
+                                .onKeyEvent { event ->
+                                    if (event.type != KeyEventType.KeyDown) {
+                                        false
+                                    } else when (event.key) {
+                                        Key.DirectionDown ->
+                                            if (scrollState.canScrollForward) {
+                                                tvScrollScope.launch {
+                                                    scrollState.animateScrollBy(tvScrollStepPx)
+                                                }
+                                                true
+                                            } else {
+                                                false
+                                            }
+                                        Key.DirectionUp ->
+                                            if (scrollState.canScrollBackward) {
+                                                tvScrollScope.launch {
+                                                    scrollState.animateScrollBy(-tvScrollStepPx)
+                                                }
+                                                true
+                                            } else {
+                                                false
+                                            }
+                                        else -> false
+                                    }
+                                }
+                        } else {
+                            Modifier
+                        },
+                    )
                     .verticalScroll(scrollState)
                     // Nav-bar inset goes here — *inside* the scroll viewport, as
                     // content padding — so the last card can scroll fully above


### PR DESCRIPTION
Two Android TV usability fixes requested together.

## 1. "Pair from phone" for the Gemini key
Entering a long API key with a remote is painful. Onboarding already has a phone-pairing handoff (QR code + local web form, `PairingRoute`); this surfaces the same **"Pair from phone instead"** button on the Voice settings page, reusing the existing string and pairing flow.

- `VoiceContent` gains an `onPairFromPhone` callback → `VoicePage` → nav `navigate(PairingRoute)`, mirroring the onboarding wiring.
- **Only shown where direct entry is hard** — Android TV or any device with no touchscreen (`prefersRemoteKeyEntry`). Touch phones/tablets can paste or type a key fine, so they don't get the extra button. (No snapshot change as a result — the Voice preview runs on a touchscreen Robolectric env where the button is hidden.)
- **Live, validated key-status refresh:** `SettingsViewModel` now *collects* `keyStore.geminiKeyConfiguredFlow` and re-runs `refreshApiKeyStatus()` on each emission, instead of seeding the flag once with a one-shot at init. The pairing flow persists the key through a separate `PairingViewModel`, so without this the still-alive `SettingsViewModel` would keep showing the key as unset after `popBackStack()`. Re-running `refreshApiKeyStatus()` (which decrypts via `keyStore.get()`) rather than trusting the flow's presence-only boolean preserves the recovery path: corrupt/undecryptable ciphertext is cleared and reported as unset, prompting re-entry. (Both points caught by Codex review.)

## 2. D-pad scrolling on the Today home page
The home page is a mostly read-only card stack with little focusable content, so on TV the D-pad couldn't move focus past the confidence chip — the chart deck below it was unreachable. The scroll container is now made `focusable()` and D-pad up/down is translated into an animated scroll.

- Gated on `isTelevision()` so phone / touch behavior is unchanged.
- Lives in `HomePageScaffold`, so it covers all three pager pages (today / next period / 7-day).

## Privacy
No change to what leaves the device. The pairing flow is the existing LAN-only QR + local web form; no new data crosses the device boundary.

## Test plan
- `./gradlew :app:testDebugUnitTest` — pass (no snapshot changes).
- `./gradlew :app:assembleDebug` — pass.
- TV D-pad scroll / no-touchscreen gating verified by logic; not exercised on physical TV hardware in this environment.

https://claude.ai/code/session_011NkChBTLZvBVAVRLnykhCW