### PR TITLE
Skip the speech setup prompt for smart home when Gemini is already set up

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/settings/SmartHomeSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SmartHomeSettings.kt
@@ -140,7 +140,17 @@ internal fun SmartHomeContent(
     }
     val onEnableDelivery: () -> Unit = {
         requestNotificationPermission()
-        speechSheetOpen = true
+        // The Speech setup sheet is just-in-time setup for a working spoken
+        // path, which on smart-home destinations means the Gemini engine AND a
+        // key — device TTS is silent on Cast / MQTT, and audio only synthesizes
+        // when ttsEngine == GEMINI with a key set (see geminiAvailable in
+        // FetchAndNotifyWorker / DeliveryGates). When both hold there's nothing
+        // left to set up, so skip the sheet rather than re-prompting. Otherwise
+        // show it: a key-less user can add one, and a key-holding user still on
+        // device TTS can switch the engine so smart-home audio actually plays.
+        // The notification request above still fires (it no-ops when granted).
+        val geminiReady = geminiKeyConfigured && ttsEngine == TtsEngine.GEMINI
+        if (!geminiReady) speechSheetOpen = true
     }
     val onSetCastEnabledGated: (Boolean) -> Unit = { enabled ->
         onSetCastEnabled(enabled)


### PR DESCRIPTION
## Problem

Enabling smart home publishing (Cast or the MQTT bridge) opened the Speech
setup sheet unconditionally. When Gemini was already set up, this re-prompted
the user for setup they'd already done — the "Gemini card" appearing when
there was nothing left to do.

## Fix

In `SmartHomeContent`, the `onEnableDelivery` wrapper already carried a comment
promising the just-in-time prompts "no-op when already satisfied," but the
speech sheet opened every time. This makes that true.

Smart-home audio only synthesizes when **both** the Gemini engine is selected
**and** a key is configured (`geminiAvailable = isGeminiEngineSelected(prefs)
&& keyConfigured`, consumed by the `DeliveryGates` algebra). So the sheet is
now skipped only when `ttsEngine == GEMINI` with a key set:

- **Fully set up (Gemini engine + key)** → sheet skipped (the reported bug).
- **Key set but still on device TTS** → sheet still shown, so the user can
  switch the engine; otherwise smart-home audio would stay silent.
- **No key** → sheet still shown, so the user can add one.

The notification-permission request still fires on every enable (it no-ops
when already granted), so that behavior is unchanged.

`app/src/main/kotlin/app/clothescast/ui/settings/SmartHomeSettings.kt`

## Test plan

- `./gradlew :app:compileDebugKotlin` — passes.
- The change only narrows when a UI sheet appears; no data crosses the device
  boundary.

## Privacy

No change to what leaves the device.