### PR TITLE
Fix crash on launch in the release build

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -7,6 +7,25 @@
 -dontwarn io.ktor.util.debug.**
 -dontwarn java.lang.management.**
 
+# Type-safe Navigation Compose routes. Each NavHost destination is a top-level
+# @Serializable object / data class in app.clothescast.ui.nav (TodayRoute,
+# OnboardingRoute, PairingRoute, the Settings*Dest objects, SettingsGraph).
+# Compose Navigation resolves a route's KSerializer *reflectively, by KClass*,
+# while building the graph at NavHost composition. R8's optimizing+obfuscating
+# release build strips the synthetic serializer() / INSTANCE members of the
+# parameterless @Serializable objects — the kotlinx-serialization bundled rules
+# only keep a serializer that's otherwise statically reachable, and a route used
+# solely via composable<Route> / navigate(Route) isn't — so the reflective
+# lookup throws "Serializer for class <obfuscated> is not found" and the app
+# dies on launch. (TodayRoute survives because its data-class $$serializer is
+# directly referenced; the bare object routes don't.) Keep every route type and
+# its generated serialization machinery; the classes are tiny.
+-keep @kotlinx.serialization.Serializable class app.clothescast.ui.nav.** { *; }
+-keep class app.clothescast.ui.nav.**$$serializer { *; }
+-keep class app.clothescast.ui.nav.**$Companion {
+    kotlinx.serialization.KSerializer serializer(...);
+}
+
 # Compose's FontWeightAdjustmentHelper uses reflection to safely access
 # Configuration.fontWeightAdjustment on API 31+ devices. Some OEM Android 12
 # builds omit this field despite reporting API 31. Without this keep rule, R8


### PR DESCRIPTION
## What

The minified **release** build crashed on launch with:

```
kotlinx.serialization.SerializationException: Serializer for class 't' is not found.
Please ensure that class is marked as '@Serializable' and that the serialization
compiler plugin is applied.
```

`class 't'` is an obfuscated, parameterless `@Serializable` Navigation Compose **route object**.

## Root cause

The type-safe Navigation routes in `app.clothescast.ui.nav` are `@Serializable`. Compose Navigation resolves each route's `KSerializer` **reflectively, by `KClass`**, while building the graph at `NavHost` composition.

R8 (release = shrink + obfuscate + optimize) stripped the synthetic `serializer()` / `INSTANCE` members from the **parameterless object routes** (`OnboardingRoute`, `PairingRoute`, the `Settings*Dest` objects, `SettingsGraph`). The kotlinx-serialization bundled keep rules only retain a serializer that's *otherwise statically reachable*, and a route used solely via `composable<Route>` / `navigate(Route)` isn't — so the reflective lookup threw on the first frame.

`TodayRoute` (a **data class**) survived because its generated `$$serializer` is referenced directly. That's why the crash only surfaced after the start destination unconditionally became `TodayRoute()` (commit "Open straight to the Today screen on first launch"): the new graph eagerly serializes its sibling object routes on launch.

I confirmed both the cause and the fix against the R8 `mapping.txt`:
- **Before:** `OnboardingRoute -> E3.t`, block has no `serializer()` / `INSTANCE`.
- **After:** `OnboardingRoute` kept (not renamed), retains `serializer()` + cached-serializer delegate.

## Fix

Explicit `-keep` rules in `app/proguard-rules.pro` for every `@Serializable` route type in the nav package and its generated serialization machinery (`$$serializer`, `Companion.serializer()`). The classes are tiny — negligible size cost.

## Test plan

- R8 mapping verification as above (the only thing that exercises the minified path).
- This is a ProGuard-rules-only change: no Kotlin sources touched, so unit tests / `assembleDebug` are unaffected.
- ⚠️ Could not run the assembled APK on a device/emulator in this sandbox — see the PR discussion about adding a launch smoke test on the minified variant so this class of bug is caught in CI rather than on-device.

> Note: `assembleRelease` separately trips a pre-existing AGP lint detector bug (`NonNullableMutableLiveDataDetector` → `IncompatibleClassChangeError`) in `lintVitalRelease`, unrelated to this fix. CI only runs `assembleDebug`, so it's not blocking.

https://claude.ai/code/session_01UPNunrZyWBNEL5hgmGvyut

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPNunrZyWBNEL5hgmGvyut)_