### PR TITLE
Ignore dotfiles by default, allowlist the ones we track

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,17 @@
+# Dotfiles: ignore every dotfile / dot-directory by default, then allowlist the
+# ones we deliberately track. New tooling drops config like .env, .vscode/,
+# .DS_Store, .gradle/, .idea/ — all caught here until someone allowlists it.
+.*
+!.editorconfig
+!.gitattributes
+!.gitignore
+!.github/
+!.claude/
+
+# ...but keep ignoring machine-local bits inside the allowlisted dot-dirs.
+.claude/settings.local.json
+
 # Gradle
-.gradle/
-.kotlin/
 build/
 !gradle/wrapper/gradle-wrapper.jar
 local.properties
@@ -11,16 +22,11 @@ local.properties
 *.ap_
 *.dex
 captures/
-.cxx/
 
 # IDE
-.idea/
 *.iml
-.vscode/
-.fleet/
 
 # OS
-.DS_Store
 Thumbs.db
 
 # Keystore / secrets


### PR DESCRIPTION
## What

Reworks `.gitignore` to deny dotfiles by default and allowlist the ones we deliberately track, instead of enumerating each tool's dotfile/dot-directory as it bites us.

```
.*
!.editorconfig
!.gitattributes
!.gitignore
!.github/
!.claude/
```

Removed the now-redundant per-tool dotfile entries (`.gradle/`, `.kotlin/`, `.cxx/`, `.idea/`, `.vscode/`, `.fleet/`, `.DS_Store`) since the blanket `.*` covers them. Non-dotfile rules are unchanged (`build/`, `*.apk`, keystore/secrets, `*.iml`, `Thumbs.db`, logs, etc.). `.gitattributes` is allowlisted preemptively so a future one is tracked.

`.claude/settings.local.json` is re-ignored explicitly so machine-local settings don't get committed even though `.claude/` is allowlisted.

## Why

A new tool dropping a stray `.env`, `.npmrc`, or editor config is now ignored until someone opts it in — safer default than discovering an accidental commit later.

## Verification

`git check-ignore` confirms:
- Ignored: `.env`, `.vscode/settings.json`, `.DS_Store`, `.gradle/…`, `.idea/…`, `.npmrc`, `app/.env`, `.claude/settings.local.json`
- Still tracked: `.gitignore`, `.editorconfig`, `.gitattributes`, `.github/workflows/ci.yml`, `.claude/settings.json`, `.claude/hooks/session-start.sh`, `functions/.gitignore`, `gradle/wrapper/gradle-wrapper.jar`

Piping `git ls-files` through `git check-ignore --stdin` returns nothing — no currently-tracked file becomes ignored.

Repo tooling only; nothing user-visible ships in the APK.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HbpdUg6xMY3W87vwT4hK6s)_