### PR TITLE
Auto-name sessions from the current work via a hook

### DIFF
--- a/.claude/hooks/session-title.sh
+++ b/.claude/hooks/session-title.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# UserPromptSubmit hook: keep the session title in sync with the current work.
+#
+# Asks a fast model for a short, hyphenated label (<=16 chars) derived from
+# the latest prompt and emits it via the `sessionTitle` hook output field
+# (Claude Code >= ~2.1.96). The name evolves as the conversation pivots.
+#
+# Recursion guard (two layers): the naming call is itself `claude -p`, and
+# UserPromptSubmit hooks run under `claude -p` too, so a naive call would
+# re-enter this hook and loop until timeouts. We (1) run the inner call from
+# an empty temp dir so it never discovers this project's .claude/settings.json
+# (no project hooks, and no CLAUDE.md / git status to distract the namer), and
+# (2) export CC_TITLE_HOOK_ACTIVE and bail at entry when it's set.
+#
+# "Never clobber a manual name" is best-effort: it works only on builds that
+# pass `session_title` on UserPromptSubmit input. Per the current docs that
+# field is SessionStart-only, so where it's absent `cur_title` reads empty and
+# the title will keep auto-updating even after a manual /rename.
+#
+# Degrades silently: missing jq/claude, an unauthenticated or timed-out
+# headless call, or empty output all leave the title unchanged.
+set -uo pipefail
+
+# Layer 2 of the recursion guard: an inner `claude -p` re-enters this hook.
+[ -n "${CC_TITLE_HOOK_ACTIVE:-}" ] && exit 0
+
+input="$(cat)"
+
+# Need jq to parse the hook payload; without it, do nothing rather than guess.
+command -v jq >/dev/null 2>&1 || exit 0
+command -v claude >/dev/null 2>&1 || exit 0
+
+prompt="$(printf '%s' "$input" | jq -r '.prompt // ""')"
+session_id="$(printf '%s' "$input" | jq -r '.session_id // "default"')"
+cur_title="$(printf '%s' "$input" | jq -r '.session_title // ""')"
+
+# Nothing to name from.
+[ -n "$prompt" ] || exit 0
+
+marker="${TMPDIR:-/tmp}/cc-autotitle-${session_id//[^A-Za-z0-9_-]/_}"
+last_set=""
+[ -f "$marker" ] && last_set="$(cat "$marker" 2>/dev/null)"
+
+# Respect a human-set name (only observable when the build supplies
+# session_title): if a title exists and it isn't the one we last wrote,
+# someone renamed it deliberately. Back off for the rest of the session.
+if [ -n "$cur_title" ] && [ "$cur_title" != "$last_set" ]; then
+  printf 'backed-off' >"$marker" 2>/dev/null || true
+  exit 0
+fi
+[ "$last_set" = "backed-off" ] && exit 0
+
+# Ask a fast model for a label. Run from a fresh, private temp dir (layer 1 of
+# the recursion guard) so the inner call discovers no .claude/settings.json or
+# CLAUDE.md — neither this project's nor stale leftovers from a previous run.
+# A `mktemp -d` per invocation guarantees that; CC_TITLE_HOOK_ACTIVE is layer 2.
+# Keep it short so prompt submission isn't noticeably delayed; on timeout/
+# failure we emit nothing.
+namedir="$(mktemp -d "${TMPDIR:-/tmp}/cc-title.XXXXXX" 2>/dev/null)" || exit 0
+trap 'rm -rf "$namedir"' EXIT
+
+# Portable timeout: GNU `timeout` isn't on a stock macOS PATH (Homebrew
+# coreutils installs it as `gtimeout`). Prefer whichever exists; if neither
+# does, run unwrapped rather than failing the hook into a silent no-op. Use a
+# plain string (not an array) so word-splitting works under set -u on macOS's
+# bash 3.2, where "${arr[@]}" on an empty array is an "unbound variable" error.
+to=""
+if command -v timeout >/dev/null 2>&1; then to="timeout 25"
+elif command -v gtimeout >/dev/null 2>&1; then to="gtimeout 25"
+fi
+
+# Model: `haiku` is fast and cheap and resolves on current Claude Code CLIs.
+# The docs only spell out `sonnet`/`opus` aliases, so on a build where `haiku`
+# doesn't resolve, point CC_TITLE_MODEL at a full Haiku id (e.g.
+# claude-haiku-4-5) instead of editing this file. A bad value just makes the
+# call fail and the title is left unchanged.
+model="${CC_TITLE_MODEL:-haiku}"
+
+# shellcheck disable=SC2086  # intentional word-split of $to into cmd + arg
+raw="$(cd "$namedir" && CC_TITLE_HOOK_ACTIVE=1 $to claude -p --model "$model" \
+  "Name this coding task as a short kebab-case label, <=16 characters, \
+lowercase. Prefer short punchy words (kill not delete, fix not repair). \
+Reply with ONLY the label, no quotes or other text: $prompt" 2>/dev/null)" || exit 0
+
+# Sanitize: lowercase, keep [a-z0-9-], collapse repeats, trim.
+name="$(printf '%s' "$raw" \
+  | tr '[:upper:]' '[:lower:]' \
+  | tr -c 'a-z0-9-' '-' \
+  | sed -E 's/-+/-/g; s/^-+//; s/-+$//')"
+
+# Fit to <=16 chars on whole-word (hyphen) boundaries where possible.
+limit=16
+if [ "${#name}" -gt "$limit" ]; then
+  fitted=""
+  IFS='-' read -ra words <<< "$name"
+  for w in "${words[@]}"; do
+    [ -z "$w" ] && continue
+    cand="$w"; [ -n "$fitted" ] && cand="$fitted-$w"
+    if [ "${#cand}" -le "$limit" ]; then fitted="$cand"; else break; fi
+  done
+  # First word already too long: hard cut.
+  [ -z "$fitted" ] && fitted="$(printf '%s' "$name" | cut -c1-"$limit" | sed -E 's/-+$//')"
+  name="$fitted"
+fi
+
+[ -n "$name" ] || exit 0
+
+printf '%s' "$name" >"$marker" 2>/dev/null || true
+
+jq -n --arg t "$name" \
+  '{hookSpecificOutput: {hookEventName: "UserPromptSubmit", sessionTitle: $t}}'

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,6 +9,16 @@
           }
         ]
       }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-title.sh"
+          }
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
## What

Adds a `UserPromptSubmit` hook that keeps the Claude Code **session title in sync with whatever's being worked on**, so parallel sessions are findable in the picker without manual `/rename`. Answers "how are session names chosen, and can we auto-pick a short name that evolves?" — the answer is the `sessionTitle` hook output field, wired up here.

## How it works

- **`.claude/hooks/session-title.sh`** — on each prompt, asks `claude -p` for a short kebab-case label (**≤16 chars**, trimmed on whole-word boundaries, short punchy words preferred — `kill` over `delete`), and emits it via the `sessionTitle` field of `hookSpecificOutput`. The name **evolves** as the conversation pivots.
- **Registered in `.claude/settings.json`** alongside the existing `SessionStart` hook (both preserved).
- **Recursion guard (two layers).** The naming call is itself `claude -p`, and `UserPromptSubmit` hooks run under `claude -p`, so a naive call would re-enter this hook and loop. (1) The inner call runs from a fresh per-invocation `mktemp -d` (cleaned up on exit), so it never discovers any `.claude/settings.json` / `CLAUDE.md` — no hooks load, and the namer isn't distracted by repo context. (2) `CC_TITLE_HOOK_ACTIVE` is exported before the inner call and short-circuits the hook at entry.
- **Portable timeout.** Prefers `timeout`, falls back to `gtimeout` (Homebrew coreutils on macOS), and if neither exists runs the call unwrapped rather than failing the hook into a silent no-op.
- **Configurable model.** Defaults to the `haiku` alias (cheap + fast, resolves on current CLIs); override with `CC_TITLE_MODEL=<full-id>` for builds where the alias doesn't resolve.
- **Manual-name protection is best-effort.** Per the docs, `session_title` is a `SessionStart` input, not `UserPromptSubmit`. Where a build supplies it, a marker file lets the hook detect a manual `/rename` and back off; where it's absent, the title keeps auto-updating — an accepted trade-off in favor of the evolving behavior.
- **Degrades silently.** Missing `jq`/`claude`, an unauthenticated/timed-out/failed headless call, or empty output all leave the title unchanged — never blocks or errors the prompt.

## Caveats

- **Per-prompt cost:** every prompt triggers a short, blocking model call before submission. Deliberate trade-off for meaningful names over a cheap heuristic. Remove the `UserPromptSubmit` block from `.claude/settings.json` to opt out.
- **Engine version:** `sessionTitle` requires a recent Claude Code (≈ v2.1.96+). Verified on v2.1.158.

## Notes

- Rebased onto latest `main` (which already gitignores `.claude/settings.local.json`), so the branch is a clean single-commit diff with no `.gitignore` churn.

## Test plan

Verified with a deterministic mock `claude` on `PATH` plus payloads on stdin:

- `bash -n` syntax check.
- Recursion guard (`CC_TITLE_HOOK_ACTIVE=1`) → silent, ~0s, no inner call.
- Multi-word output → trimmed to ≤16 on a hyphen boundary (`fix-the-feels`), no trailing hyphen.
- Single over-long word → hard-cut to 16 (`supercalifragili`).
- Short label → passes through unchanged (`kill-flake`).
- Simulated manual `/rename` (current title ≠ last-set marker) → silent, marker flips to backed-off.
- Model selector: default sends `--model haiku`; `CC_TITLE_MODEL` override honored.
- Fresh `mktemp -d` per run, cleaned up afterward (no temp leak).
- `settings.json` validated with `jq`, contains both `SessionStart` and `UserPromptSubmit`.