### PR TITLE
Cap the free voice path at 5 clips per day, then BYO key

### DIFF
--- a/core/data/src/main/kotlin/app/clothescast/core/data/tts/GeminiTtsClient.kt
+++ b/core/data/src/main/kotlin/app/clothescast/core/data/tts/GeminiTtsClient.kt
@@ -547,7 +547,18 @@ class GeminiTtsClient(
         // empty-response exception. Pull the body on a non-success status and
         // surface it.
         if (!httpResponse.status.isSuccess()) {
-            throw GeminiTtsHttpException(httpResponse.status, httpResponse.bodyAsBytes())
+            val body = httpResponse.bodyAsBytes()
+            // 429 from the shared-key proxy carries a structured
+            // `{"error":"daily_quota_exhausted", "limit": N, "resetAtUtc": "…"}`
+            // body distinct from Gemini's `{"error":{"message":…}}` envelope.
+            // Surface it as a typed exception so the diagnostic Toast in
+            // VoiceSettings shows a friendly "free TTS limit reached today"
+            // message instead of the raw "daily_quota_exhausted" token, and
+            // callers can match on the type for future Settings nudges.
+            if (httpResponse.status == HttpStatusCode.TooManyRequests) {
+                parseDailyQuotaExhausted(body)?.let { throw it }
+            }
+            throw GeminiTtsHttpException(httpResponse.status, body)
         }
 
         val response: TtsResponse = httpResponse.body()
@@ -607,6 +618,36 @@ class GeminiTtsBlockedException(message: String) : IllegalStateException(message
  * error envelope; falls back to a truncated raw excerpt when the body isn't
  * shaped that way.
  */
+/**
+ * Surfaced when the shared-key proxy reports the install has used its full
+ * daily allowance (HTTP 429 with `{"error":"daily_quota_exhausted", …}`).
+ * The friendly [message] is what the Voice settings preview Toast shows;
+ * [resetAtUtc] is the ISO-8601 timestamp at which the next slot opens, for
+ * any UI that wants to render "available again at HH:MM your time".
+ *
+ * Callers that want to fall through to device TTS should treat this as the
+ * same recoverable failure mode as other `GeminiTts*Exception`s — but the
+ * type lets a future Settings banner identify the specific case and prompt
+ * the user to add their own Gemini key.
+ */
+class GeminiTtsDailyQuotaExhaustedException(
+    val limit: Int?,
+    val resetAtUtc: String?,
+) : IllegalStateException(
+    "Free TTS limit reached for today. Add your own Gemini key in Settings " +
+        "for unlimited use.",
+)
+
+private fun parseDailyQuotaExhausted(body: ByteArray): GeminiTtsDailyQuotaExhaustedException? {
+    val raw = runCatching { body.toString(Charsets.UTF_8) }.getOrNull() ?: return null
+    val root = runCatching { Json.parseToJsonElement(raw) as? JsonObject }.getOrNull() ?: return null
+    val error = (root["error"] as? JsonPrimitive)?.content ?: return null
+    if (error != "daily_quota_exhausted") return null
+    val limit = (root["limit"] as? JsonPrimitive)?.content?.toIntOrNull()
+    val resetAtUtc = (root["resetAtUtc"] as? JsonPrimitive)?.content
+    return GeminiTtsDailyQuotaExhaustedException(limit = limit, resetAtUtc = resetAtUtc)
+}
+
 class GeminiTtsHttpException(val status: HttpStatusCode, body: ByteArray) :
     IllegalStateException(buildMessage(status, body)) {
 

--- a/core/data/src/test/kotlin/app/clothescast/core/data/tts/GeminiTtsClientTest.kt
+++ b/core/data/src/test/kotlin/app/clothescast/core/data/tts/GeminiTtsClientTest.kt
@@ -593,6 +593,52 @@ class GeminiTtsClientTest {
     }
 
     @Test
+    fun `throws GeminiTtsDailyQuotaExhaustedException on shared-key proxy 429`() = runTest {
+        val client = GeminiTtsClient(
+            httpClient = mockClient(
+                status = HttpStatusCode.TooManyRequests,
+                responseBody = """
+                    {"error":"daily_quota_exhausted","limit":5,"resetAtUtc":"2026-06-01T00:00:00.000Z"}
+                """.trimIndent(),
+            ),
+            callPlanner = directPlanner("test-key"),
+        )
+
+        val ex = shouldThrow<GeminiTtsDailyQuotaExhaustedException> { client.synthesize(text = "hi") }
+
+        ex.limit shouldBe 5
+        ex.resetAtUtc shouldBe "2026-06-01T00:00:00.000Z"
+        // Friendly copy — the Voice settings preview Toast shows this
+        // directly, so it must read as user-facing English, not as a
+        // raw error token.
+        ex.message!!.shouldContain("Free TTS limit reached for today")
+        ex.message!!.shouldNotContain("daily_quota_exhausted")
+    }
+
+    @Test
+    fun `falls back to GeminiTtsHttpException on a non-quota 429 body`() = runTest {
+        // Generic Gemini rate-limit response (BYOK path or proxy forwarding
+        // a Gemini-side 429) keeps the existing path, not the typed quota
+        // exception — surfacing the upstream message in the Toast is more
+        // useful than the friendly "free limit" copy when the user's own
+        // key is the one being throttled.
+        val client = GeminiTtsClient(
+            httpClient = mockClient(
+                status = HttpStatusCode.TooManyRequests,
+                responseBody = """
+                    {"error":{"code":429,"message":"Rate limit exceeded.","status":"RESOURCE_EXHAUSTED"}}
+                """.trimIndent(),
+            ),
+            callPlanner = directPlanner("test-key"),
+        )
+
+        val ex = shouldThrow<GeminiTtsHttpException> { client.synthesize(text = "hi") }
+
+        ex.status shouldBe HttpStatusCode.TooManyRequests
+        ex.message shouldBe "Gemini TTS HTTP 429: Rate limit exceeded."
+    }
+
+    @Test
     fun `request body uses each character-register directive for the matching TtsStyle`() = runTest {
         // One assertion per playful / persona register: pick a phrase that
         // only that directive contains and verify it lands in the prompt

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -243,10 +243,12 @@ Open work:
 ## Deferred to v2 (out of scope for v1)
 
 - iOS port (needs a Mac + KMP-promotion of the core modules).
-- Enforce shared-key TTS trial limit (30 calls or 30 days from first
-  use, whichever first). The Cloud Function (`functions/src/index.ts`)
-  counts already; flip on 429 + `X-Trial-Remaining` and wire the
-  Settings nudge / `SharedTrialExhaustedException` in
-  `core/data/.../tts/GeminiTtsClient.kt`.
+- Settings nudge for `GeminiTtsDailyQuotaExhaustedException`. The
+  proxy now caps the shared-key path at 5 successful syntheses per
+  UTC day and the Voice settings preview Toast shows a friendly
+  message, but the morning worker just degrades silently to device
+  TTS — a Today / Settings banner pointing at the BYOK flow would
+  let users notice and resolve the cap without going hunting in the
+  logs.
 - Google Home / alarm-clock-app integration.
 - Play Store submission. Sideload + FAD only for v1.

--- a/docs/gemini-tts-proxy.md
+++ b/docs/gemini-tts-proxy.md
@@ -12,9 +12,13 @@ Check verifies the request came from a genuine install of the app.
   key and forwards each TTS request to Google.
 - Users who paste their own key in Settings continue to bypass the
   function entirely and pay their own Gemini bill.
-- Per-install usage is counted in Firestore (`installs/<fid>`) so you
-  can later enforce a free-trial limit — currently informational only,
-  see `docs/TODO.md` "Enforce shared-key TTS trial limit".
+- Per-install usage is counted in Firestore (`installs/<fid>`) and
+  capped at 5 successful syntheses per UTC day. Above the cap the
+  function returns `429 daily_quota_exhausted`; the Android client
+  surfaces a friendly "free TTS limit reached" message and the user
+  can drop in their own Gemini key to bypass the proxy entirely. See
+  `functions/README.md` → "Quota enforcement" for the doc shape and
+  rollback semantics.
 - Firebase App Check (Play Integrity in release, Debug provider in
   debug) blocks scraping and modded clients without holding up
   legitimate users.
@@ -182,7 +186,8 @@ End-to-end check after all the above:
    `generativelanguage.googleapis.com`.
 5. In the Firebase console → Firestore → `installs` collection, you
    should see a doc keyed by your Firebase Installation ID with
-   `firstUseAt`, `count: 1`, `lastUseAt`.
+   `firstUseAt`, `count: 1`, `lastUseAt`, `dayKey: "YYYY-MM-DD"`,
+   `dayCount: 1`.
 
 Then paste a real Gemini key into Settings and Test Voice again:
 
@@ -227,11 +232,13 @@ but using one is closer to production behaviour.
   tier covers 50K reads + 20K writes/day. At 1000 users × 2 daily
   insights = ~60K invocations/month — well within free tier on the
   infrastructure side; the Gemini bill is the only one that scales.
-- **Limiting abuse**: App Check stops scrapers but doesn't cap
-  per-install volume. The function already counts every successful
-  call in `installs/<fid>.count` — wiring the limit (30 calls or
-  30 days from first use, return 429) is tracked in
-  `docs/TODO.md` under "Deferred to v2".
+- **Limiting abuse**: App Check stops scrapers; a transactional
+  per-install cap of 5 successful syntheses per UTC day stops a
+  single legitimate install from melting the budget. Above the cap
+  the function returns `429 daily_quota_exhausted` with a
+  `resetAtUtc` timestamp; see `functions/README.md` → "Quota
+  enforcement" for the doc shape and the rollback-on-failure
+  semantics.
 - **Rotating the Gemini key**: `firebase functions:secrets:set
   GEMINI_API_KEY` again, then redeploy. The function picks up the
   new value on cold start.

--- a/functions/README.md
+++ b/functions/README.md
@@ -45,11 +45,42 @@ curl -i -X POST "http://127.0.0.1:5001/<project-id>/us-central1/tts" \
 npm run deploy
 ```
 
-## Counting vs enforcement
+## Quota enforcement
 
-v1 counts every successful call in `installs/<fid>` (`firstUseAt`,
-`count`, `lastUseAt`) but does not enforce any limit — every
-authenticated request is forwarded to Gemini. Enforcement (return
-`429 trial_exhausted` after 30 calls or 30 days, emit
-`X-Trial-Remaining` on success) is tracked under "Deferred to v2" in
-`docs/TODO.md`.
+Each install gets 5 successful syntheses per UTC calendar day. The
+reservation is transactional:
+
+1. Pre-flight transaction reads `installs/<fid>`; if today's
+   `dayCount` is already at 5, the request returns
+   `429 { "error": "daily_quota_exhausted", "limit": 5,
+   "resetAtUtc": "<next-UTC-midnight>" }` without calling Gemini.
+2. Otherwise we increment `dayCount` (and lifetime `count` +
+   `lastUseAt`) before the upstream call.
+3. On a non-success upstream status — or a fetch failure — we
+   transactionally decrement so a Gemini hiccup doesn't burn a
+   slot.
+
+Successful responses carry `X-Daily-Quota-Limit: 5` and
+`X-Daily-Quota-Remaining: <n>` headers. The Android client
+(`core/data/.../tts/GeminiTtsClient.kt`) throws
+`GeminiTtsDailyQuotaExhaustedException` on the 429, which surfaces
+in the Voice settings preview Toast as "Free TTS limit reached for
+today. Add your own Gemini key in Settings for unlimited use."
+
+Firestore document shape:
+
+```
+installs/<fid> {
+  firstUseAt: Timestamp,
+  lastUseAt:  Timestamp,
+  count:      number,   // lifetime
+  dayKey:     string,   // "YYYY-MM-DD" UTC
+  dayCount:   number,   // successful calls within dayKey
+}
+```
+
+If Firestore is unreachable, the function **fails open** (forwards
+the call without recording it) so a backend hiccup doesn't deny
+service. The trade-off is that a sustained outage lets a single
+install exceed the daily cap — acceptable given how expensive
+Gemini TTS is relative to a Firestore read.

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -25,6 +25,13 @@ const GEMINI_API_VERSION = "v1beta";
 
 const INSTALLS_COLLECTION = "installs";
 
+// Per-install daily quota for the shared-key path. Counted by UTC calendar
+// day so the reset moment is global and unambiguous; the Android client's
+// nudge copy ("resets at midnight UTC") matches. Bump when we have a clearer
+// signal of real-world legitimate use — five successful syntheses covers
+// two morning + two evening insights + one preview tap per day.
+const DAILY_LIMIT = 5;
+
 export const tts = onRequest(
   {
     secrets: [GEMINI_API_KEY],
@@ -68,14 +75,33 @@ export const tts = onRequest(
       return;
     }
 
-    // Count usage (v1: count only, do not enforce). The enforcement step
-    // — return 429 when count >= 30 or now - firstUseAt >= 30 days, and
-    // emit `X-Trial-Remaining` on success — lands as a follow-up; see
-    // docs/TODO.md "Enforce shared-key TTS trial limit".
-    //
-    // We do the bookkeeping AFTER a successful Gemini call so failed
-    // attempts don't inflate the count (matches the eventual enforcement
-    // semantics where the trial measures successful syntheses).
+    // Reserve a quota slot transactionally before calling Gemini. A failed
+    // upstream call rolls the slot back below so a Gemini hiccup doesn't
+    // burn a user's daily allowance. Firestore outages fail open
+    // (`reservation.reserved === false` with a logged warning) — better to
+    // serve audio than to block on our own bookkeeping when the upstream
+    // path is the expensive bit.
+    const now = new Date();
+    const today = utcDayKey(now);
+    let reservation: Reservation;
+    try {
+      reservation = await reserveDailySlot(installId, today);
+    } catch (err) {
+      logger.warn("Quota reservation failed; failing open", {
+        code: errorCode(err),
+      });
+      reservation = { reserved: false, remaining: null };
+    }
+    if (reservation.exhausted) {
+      res.setHeader("X-Daily-Quota-Limit", String(DAILY_LIMIT));
+      res.setHeader("X-Daily-Quota-Remaining", "0");
+      res.status(429).json({
+        error: "daily_quota_exhausted",
+        limit: DAILY_LIMIT,
+        resetAtUtc: nextUtcMidnightIso(now),
+      });
+      return;
+    }
 
     const upstreamUrl =
       `https://${GEMINI_HOST}/${GEMINI_API_VERSION}` +
@@ -93,6 +119,11 @@ export const tts = onRequest(
       });
     } catch (err) {
       logger.error("Upstream Gemini fetch failed", { code: errorCode(err) });
+      releaseDailySlot(installId, today).catch((rbErr) => {
+        logger.warn("Quota rollback after fetch failure failed", {
+          code: errorCode(rbErr),
+        });
+      });
       res.status(502).json({ error: "upstream_unreachable" });
       return;
     }
@@ -100,18 +131,22 @@ export const tts = onRequest(
     const upstreamBody = await upstream.arrayBuffer();
 
     if (upstream.ok) {
-      // Fire-and-forget the count update so a Firestore hiccup doesn't
-      // stall the audio response. We accept the small slop this
-      // introduces (a missed write means an undercount, never a charged
-      // user lockout); when enforcement lands the decision must be
-      // synchronous and replace this block.
-      recordCall(installId).catch((err) => {
-        logger.warn("Firestore count update failed", { code: errorCode(err) });
-      });
+      if (reservation.reserved) {
+        res.setHeader("X-Daily-Quota-Limit", String(DAILY_LIMIT));
+        res.setHeader("X-Daily-Quota-Remaining", String(reservation.remaining));
+      }
     } else {
       logger.warn("Gemini returned non-success", {
         status: upstream.status,
         bodyExcerpt: excerpt(upstreamBody),
+      });
+      // Only successful syntheses should burn quota. Roll back the
+      // reservation; clients can retry within the same day without
+      // penalty.
+      releaseDailySlot(installId, today).catch((err) => {
+        logger.warn("Quota rollback after upstream non-success failed", {
+          code: errorCode(err),
+        });
       });
     }
 
@@ -124,24 +159,101 @@ export const tts = onRequest(
   },
 );
 
-async function recordCall(installId: string): Promise<void> {
+interface Reservation {
+  /** True when we successfully reserved a slot (and so should rollback on failure). */
+  reserved: boolean;
+  /** True when the install already exhausted today's allowance. */
+  exhausted?: boolean;
+  /** Remaining slots for today after this call, or null when we failed open. */
+  remaining: number | null;
+}
+
+async function reserveDailySlot(
+  installId: string,
+  today: string,
+): Promise<Reservation> {
   const docRef = getFirestore().collection(INSTALLS_COLLECTION).doc(installId);
-  await getFirestore().runTransaction(async (tx) => {
+  return await getFirestore().runTransaction(async (tx) => {
     const snap = await tx.get(docRef);
     const now = Timestamp.now();
+
+    const data = snap.exists ? (snap.data() ?? {}) : {};
+    const sameDay = data.dayKey === today;
+    const dayCount = sameDay && typeof data.dayCount === "number"
+      ? data.dayCount
+      : 0;
+
+    if (dayCount >= DAILY_LIMIT) {
+      return { reserved: false, exhausted: true, remaining: 0 };
+    }
+
+    const nextDayCount = dayCount + 1;
+    const remaining = DAILY_LIMIT - nextDayCount;
+
     if (snap.exists) {
       tx.update(docRef, {
         count: FieldValue.increment(1),
         lastUseAt: now,
+        dayKey: today,
+        dayCount: nextDayCount,
       });
     } else {
       tx.set(docRef, {
         firstUseAt: now,
-        count: 1,
         lastUseAt: now,
+        count: 1,
+        dayKey: today,
+        dayCount: 1,
       });
     }
+
+    return { reserved: true, remaining };
   });
+}
+
+async function releaseDailySlot(
+  installId: string,
+  today: string,
+): Promise<void> {
+  const docRef = getFirestore().collection(INSTALLS_COLLECTION).doc(installId);
+  await getFirestore().runTransaction(async (tx) => {
+    const snap = await tx.get(docRef);
+    if (!snap.exists) return;
+    const data = snap.data() ?? {};
+    // Day rolled between reserve and rollback: another day's counter would
+    // be wrong to decrement. Lifetime `count` likewise stays as-is — at
+    // most one extra count survives across the day boundary, which is
+    // tolerable.
+    if (data.dayKey !== today) return;
+    const dayCount = typeof data.dayCount === "number" ? data.dayCount : 0;
+    if (dayCount <= 0) return;
+    tx.update(docRef, {
+      count: FieldValue.increment(-1),
+      dayCount: dayCount - 1,
+    });
+  });
+}
+
+function utcDayKey(date: Date): string {
+  const y = date.getUTCFullYear();
+  const m = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const d = String(date.getUTCDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+function nextUtcMidnightIso(date: Date): string {
+  const next = new Date(
+    Date.UTC(
+      date.getUTCFullYear(),
+      date.getUTCMonth(),
+      date.getUTCDate() + 1,
+      0,
+      0,
+      0,
+      0,
+    ),
+  );
+  return next.toISOString();
 }
 
 function headerValue(raw: unknown): string | null {


### PR DESCRIPTION
## Summary

The shared-key Gemini TTS proxy was counting per-install calls in Firestore but forwarding every request unconditionally — a single legitimate (or modded) install could melt the `GEMINI_API_KEY` budget. This PR enforces a daily cap of 5 successful syntheses per install, keyed by UTC calendar day, and surfaces the cap to the client with a friendly nudge toward BYO key.

## Server — `functions/src/index.ts`

- Pre-flight Firestore transaction reserves a slot for the request's UTC day. Limit is `DAILY_LIMIT = 5`.
- Over the cap → `429 {"error":"daily_quota_exhausted","limit":5,"resetAtUtc":"<next-UTC-midnight>"}` without calling Gemini.
- Successful responses carry `X-Daily-Quota-Limit` and `X-Daily-Quota-Remaining` headers.
- Upstream failures (non-success status or fetch throw) transactionally roll the reservation back — a Gemini hiccup doesn't burn the user's allowance. Firestore outages **fail open** so a bookkeeping hiccup doesn't deny service.
- Install doc gains `dayKey` ("YYYY-MM-DD" UTC) and `dayCount` alongside the existing `firstUseAt` / `lastUseAt` / `count`. Legacy docs upgrade lazily on first call.

## Client — `core/data/.../tts/GeminiTtsClient.kt`

- New typed `GeminiTtsDailyQuotaExhaustedException` parses the 429 body (carrying `limit` + `resetAtUtc`) and exposes a friendly message — *"Free TTS limit reached for today. Add your own Gemini key in Settings for unlimited use."* — that the Voice settings preview Toast surfaces directly. Two new unit tests cover the parse-and-throw path and the non-quota-429 fall-through.
- Non-quota 429s (BYOK rate limits, etc.) keep the existing `GeminiTtsHttpException` path so the Toast still shows the Gemini-side message.

## Scope / non-scope

- Worker path keeps its silent degrade to device TTS — the morning insight still speaks via on-device TTS when the cap is hit. A Today / Settings banner that points at the BYOK escape hatch is the obvious follow-up and is tracked in `docs/TODO.md`.
- BYOK requests never touch the proxy, so users with their own key see no change.
- Privacy: nothing new leaves the device. The 429 response carries only `limit` and `resetAtUtc` (a calendar moment, not PII). The Firestore doc keeps the install-ID-only shape.

## Docs

- `functions/README.md` → "Quota enforcement" — Firestore doc shape, fail-open trade-off, header contract.
- `docs/gemini-tts-proxy.md` — operational notes + the "Verifying it works" Firestore checklist mention `dayKey` / `dayCount`.
- `docs/TODO.md` — old "Enforce shared-key TTS trial limit" item replaced with the Settings-nudge follow-up.

## Test plan

- [x] `cd core && ../gradlew :core:data:test` — passes, including the two new quota-exception tests.
- [x] `./gradlew :app:testDebugUnitTest` — passes.
- [x] `npx tsc --noEmit` in `functions/` — clean.
- [ ] Manual emulator round-trip via `npm run serve` per `functions/README.md`: 5 successful curls return audio with `X-Daily-Quota-Remaining` ticking 4 → 0; the 6th returns `429 daily_quota_exhausted`; a forced upstream 4xx rolls the slot back.
- [ ] On-device: Voice settings → Test voice past the cap → Toast reads the friendly message, device TTS fallback still plays.

There's no Jest/Vitest harness in `functions/` today; the manual emulator test plan above is the cheapest signal until one lands.

https://claude.ai/code/session_01S3sFgaMM3ofs5hb88RGhM6

---
_Generated by [Claude Code](https://claude.ai/code/session_01S3sFgaMM3ofs5hb88RGhM6)_