### PR TITLE
Stop a "backed-off" auto title from disabling session naming

### DIFF
--- a/.claude/hooks/session-title.sh
+++ b/.claude/hooks/session-title.sh
@@ -38,17 +38,22 @@ cur_title="$(printf '%s' "$input" | jq -r '.session_title // ""')"
 [ -n "$prompt" ] || exit 0
 
 marker="${TMPDIR:-/tmp}/cc-autotitle-${session_id//[^A-Za-z0-9_-]/_}"
+backoff="$marker.off"
 last_set=""
 [ -f "$marker" ] && last_set="$(cat "$marker" 2>/dev/null)"
+
+# Once we've backed off (manual rename seen), stay silent for the session.
+[ -f "$backoff" ] && exit 0
 
 # Respect a human-set name (only observable when the build supplies
 # session_title): if a title exists and it isn't the one we last wrote,
 # someone renamed it deliberately. Back off for the rest of the session.
+# The flag lives in a separate file (not a sentinel string in $marker) so a
+# legitimately generated title like "backed-off" can't be mistaken for it.
 if [ -n "$cur_title" ] && [ "$cur_title" != "$last_set" ]; then
-  printf 'backed-off' >"$marker" 2>/dev/null || true
+  : >"$backoff" 2>/dev/null || true
   exit 0
 fi
-[ "$last_set" = "backed-off" ] && exit 0
 
 # Ask a fast model for a label. Run from a fresh, private temp dir (layer 1 of
 # the recursion guard) so the inner call discovers no .claude/settings.json or


### PR DESCRIPTION
## What

Follow-up to #883 (merged). Fixes a marker-file collision in the session-title hook that Codex flagged on the final commit, just as #883 was merging — so the fix didn't make it in.

## The bug

`.claude/hooks/session-title.sh` overloaded one marker file with two meanings: it held either **the last title we set**, or the literal sentinel string **`backed-off`** meaning "user renamed the session manually, stay quiet for the rest of the session."

Because `backed-off` is itself a valid sanitized title (kebab-case, ≤16 chars), a prompt about *reverting or backing off work* could legitimately make the model emit it. The hook would write `backed-off` to the marker as a normal title, and the **next** prompt would read it back, mistake it for the sentinel, and silently disable auto-naming for the rest of the session — even though no manual rename ever happened.

## The fix

Move the backed-off state into its own flag file (`"$marker.off"`). The title marker now only ever holds titles, so a generated title can never collide with the sentinel. Six-line change.

## Test plan

Verified with a deterministic mock `claude`:

- **Collision case:** model emits `backed-off` as the title → next prompt still evolves the name (`add-tests`) instead of going silent. ✅ (this was the bug)
- **Genuine manual rename** (current title ≠ last-set) → backs off, writes the `.off` flag, and stays silent on subsequent prompts. ✅
- `bash -n` syntax check. ✅

---
_Generated by [Claude Code](https://claude.ai/code/session_01BfYZ2uHbrGitBkgMD4Nh9R)_