### PR TITLE
Translate the home screen layout settings into every language

### DIFF
--- a/app/src/main/res/values-am/strings.xml
+++ b/app/src/main/res/values-am/strings.xml
@@ -244,6 +244,7 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="settings_tts_device_header">በስልክህ ውስጥ የተገነቡ ዝቅተኛ ጥራት ድምፆች።</string>
     <string name="settings_api_key_status_set">Gemini ቁልፍ ተዋቅሯል።</string>
     <string name="settings_api_key_status_unset">ነፃ API key ያግኙ aistudio.google.com ላይ</string>
+    <string name="settings_api_key_status_unset_shared">አማራጭ — የራስዎን ቁልፍ ይለጥፉ። ነፃ ቁልፍ በ aistudio.google.com ያግኙ</string>
     <string name="settings_api_key_placeholder">Gemini API key ይለጥፉ</string>
     <string name="settings_api_key_save">Gemini ቁልፍ አስቀምጥ</string>
     <string name="settings_api_key_clear">የተቀመጠ Gemini ቁልፍ ሰርዝ</string>
@@ -458,6 +459,14 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="settings_display_palette_rainbow_description">ሮዝ፣ ብርቱካናማ እና አረንጓዴ ሰንጠረዥ መስመሮች የ Material ቲያ/ቀይ የአስተማማኝነት ካርዶች ጋር። ነባሪ።</string>
     <string name="settings_display_palette_highlighter">ማድመቂያ</string>
     <string name="settings_display_palette_highlighter_description">ማጄንታ፣ ቢጫ እና ሳያን የግራፍ መስመሮች — በወረቀት ላይ እንዳለ የማስታወቂያ ብዕር ሁሉ። ከ\"ቀስተ ደመና\" በቅጽበት ይለያያሉ፤ የብርሃን ጭብጥ ለንባብ ምቾት ጥልቅ ቅርጾች ይጠቀማል። ለቀይ-አረንጓዴ የቀለም ዕውር ሁኔታ ደህንነቱ የተጠበቀ።</string>
+    <string name="settings_display_home_layout_title">የመነሻ ማያ ገጽ አቀማመጥ</string>
+    <string name="settings_display_home_layout_description">እነዚህ ክፍሎች በመነሻ ማያ ገጹ ላይ የሚታዩበትን ቅደም ተከተል ለመቀየር መያዣዎቹን ይጎትቱ።</string>
+    <string name="settings_display_home_layout_drag">%1$s ለመቀየር ይጎትቱ</string>
+    <string name="settings_display_home_section_outfit">ልብስ</string>
+    <string name="settings_display_home_section_conditions">ሁኔታዎች</string>
+    <string name="settings_display_home_section_confidence">መተማመኛ</string>
+    <string name="settings_display_home_section_insight">ትንበያ</string>
+    <string name="settings_display_home_section_charts">ቻርቶች</string>
     <string name="settings_display_palette_accessible">ተደራሽ</string>
     <string name="settings_display_palette_accessible_description">ዲዩተራኖፒያ፣ ፕሮቶናኖፒያ እና ትሪታኖፒያ ሲኖር ሊለዩ የሚችሉ Okabe-Ito ፓሌት። ካርዶቹ ቲያ፣ ገለልተኛ እና ቀይ ፋንታ ሰማያዊ፣ ገለልተኛ እና ሀምበር ይጠቀማሉ።</string>
     <string name="today_cloud_range">ደመና %1$d–%2$d%%</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -321,6 +321,7 @@ they work correctly in both the single-band and range templates.
     <string name="settings_tts_device_header">أصوات منخفضة الجودة مدمجة في هاتفك.</string>
     <string name="settings_api_key_status_set">تم تكوين مفتاح Gemini.</string>
     <string name="settings_api_key_status_unset">احصل على مفتاح API مجاني من aistudio.google.com</string>
+    <string name="settings_api_key_status_unset_shared">اختياري — الصق مفتاحك الخاص. احصل على واحد مجانًا من aistudio.google.com</string>
     <string name="settings_api_key_placeholder">الصق مفتاح Gemini API</string>
     <string name="settings_api_key_save">حفظ مفتاح Gemini</string>
     <string name="settings_api_key_clear">مسح مفتاح Gemini المخزّن</string>
@@ -488,6 +489,14 @@ they work correctly in both the single-band and range templates.
     <string name="settings_display_palette_rainbow_description">خطوط مخطط وردي وبرتقالي وأخضر مع بطاقات ثقة Material باللون الفيروزي/الأحمر. الافتراضي.</string>
     <string name="settings_display_palette_highlighter">قلم تظليل</string>
     <string name="settings_display_palette_highlighter_description">خطوط رسم بياني بألوان أرجواني وأصفر وسماوي — كأثر قلم تظليل على الورق. تختلف عن \"قوس قزح\" بوضوح من النظرة الأولى؛ يستخدم الوضع الفاتح إصدارات أعمق لزيادة الوضوح. آمنة لعمى الألوان الأحمر-الأخضر.</string>
+    <string name="settings_display_home_layout_title">تخطيط الشاشة الرئيسية</string>
+    <string name="settings_display_home_layout_description">اسحب المقابض لإعادة ترتيب طريقة ظهور هذه الأقسام على الشاشة الرئيسية.</string>
+    <string name="settings_display_home_layout_drag">اسحب لإعادة ترتيب %1$s</string>
+    <string name="settings_display_home_section_outfit">الزي</string>
+    <string name="settings_display_home_section_conditions">الأحوال الجوية</string>
+    <string name="settings_display_home_section_confidence">الثقة</string>
+    <string name="settings_display_home_section_insight">التوقعات</string>
+    <string name="settings_display_home_section_charts">المخططات</string>
     <string name="settings_display_palette_accessible">إمكانية الوصول</string>
     <string name="settings_display_palette_accessible_description">لوحة ألوان مشتقة من Okabe-Ito مصممة للتمييز في حالات عمى الألوان. تستخدم بطاقات الثقة الأزرق السماوي والمحايد والكهرماني بدلاً من الفيروزي والمحايد والأحمر.</string>
     <string name="today_cloud_range">السحب %1$d–%2$d%%</string>

--- a/app/src/main/res/values-b+sr+Latn/strings.xml
+++ b/app/src/main/res/values-b+sr+Latn/strings.xml
@@ -169,6 +169,7 @@ default English (matching values-pl / values-uk).
     <string name="settings_tts_device_header">Glasovi niskog kvaliteta ugrađeni u tvoj telefon.</string>
     <string name="settings_api_key_status_set">Gemini ključ je podešen.</string>
     <string name="settings_api_key_status_unset">Nema Gemini ključa. Nabavi ga besplatno na aistudio.google.com za korišćenje Gemini glasova.</string>
+    <string name="settings_api_key_status_unset_shared">Opciono — nalepi sopstveni ključ. Nabavi ga besplatno na aistudio.google.com</string>
     <string name="settings_api_key_placeholder">Nalepi svoj Gemini API ključ</string>
     <string name="settings_api_key_save">Sačuvaj Gemini ključ</string>
     <string name="settings_api_key_clear">Obriši sačuvani Gemini ključ</string>
@@ -617,6 +618,14 @@ default English (matching values-pl / values-uk).
     <string name="settings_display_palette_rainbow_description">Roze, narandžaste i zelene linije grafikona sa tirkiznim/crvenim karticama pouzdanosti Material. Podrazumevano.</string>
     <string name="settings_display_palette_highlighter">Marker</string>
     <string name="settings_display_palette_highlighter_description">Magenta, žute i cijan linije grafikona — kao trag markera na stranici. Na prvi pogled vidno drugačije od \"Duge\"; svetla tema koristi dublje varijante za čitljivost. Bezbedno za crveno-zeleno slepilo za boje.</string>
+    <string name="settings_display_home_layout_title">Raspored početnog ekrana</string>
+    <string name="settings_display_home_layout_description">Prevuci ručice da promeniš redosled kojim se ovi odeljci prikazuju na početnom ekranu.</string>
+    <string name="settings_display_home_layout_drag">Prevuci da promeniš redosled: %1$s</string>
+    <string name="settings_display_home_section_outfit">Kombinacija</string>
+    <string name="settings_display_home_section_conditions">Uslovi</string>
+    <string name="settings_display_home_section_confidence">Pouzdanost</string>
+    <string name="settings_display_home_section_insight">Prognoza</string>
+    <string name="settings_display_home_section_charts">Grafikoni</string>
     <string name="settings_unit_auto">Auto</string>
     <string name="today_cloud_range">Oblačnost %1$d–%2$d%%</string>
     <string name="today_confidence_precip_spread">Modeli se ne slažu oko kiše (Δ %1$.0f%% kod %2$d modela)</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -331,6 +331,7 @@ What is NOT overridden, by design:
     <string name="settings_tts_device_header">Гласове с ниско качество, вградени в телефона ти.</string>
     <string name="settings_api_key_status_set">Конфигуриран е ключ за Gemini.</string>
     <string name="settings_api_key_status_unset">Вземи безплатен API ключ от aistudio.google.com</string>
+    <string name="settings_api_key_status_unset_shared">По избор — постави свой ключ. Вземи безплатен от aistudio.google.com</string>
     <string name="settings_api_key_placeholder">Постави своя API ключ за Gemini</string>
     <string name="settings_api_key_save">Запази ключа за Gemini</string>
     <string name="settings_api_key_clear">Изтрий запазения ключ за Gemini</string>
@@ -615,6 +616,14 @@ What is NOT overridden, by design:
     <string name="settings_display_palette_rainbow_description">Розови, оранжеви и зелени линии на графиките с карти за достоверност Material синьо-зелено/червено. По подразбиране.</string>
     <string name="settings_display_palette_highlighter">Маркер</string>
     <string name="settings_display_palette_highlighter_description">Линии на графиката в магента, жълто и циан — като следа от маркер върху страницата. Видимо различни от \"Дъга\" от пръв поглед; светлата тема използва по-наситени варианти за четливост. Безопасни при червено-зелена цветна слепота.</string>
+    <string name="settings_display_home_layout_title">Оформление на началния екран</string>
+    <string name="settings_display_home_layout_description">Плъзни манипулаторите, за да пренаредиш как тези секции се показват на началния екран.</string>
+    <string name="settings_display_home_layout_drag">Плъзни, за да пренаредиш %1$s</string>
+    <string name="settings_display_home_section_outfit">Тоалет</string>
+    <string name="settings_display_home_section_conditions">Условия</string>
+    <string name="settings_display_home_section_confidence">Увереност</string>
+    <string name="settings_display_home_section_insight">Прогноза</string>
+    <string name="settings_display_home_section_charts">Графики</string>
     <string name="settings_unit_auto">Авто</string>
     <string name="today_cloud_range">Облачност %1$d–%2$d%%</string>
     <string name="today_confidence_precip_spread">Моделите не са съгласни за дъжда (Δ %1$.0f%% при %2$d модела)</string>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -543,6 +543,7 @@ West Bengal vocabulary differences in a future PR.
     <string name="settings_tts_device_header">আপনার ফোনে অন্তর্নির্মিত নিম্ন-মানের ভয়েস।</string>
     <string name="settings_api_key_status_set">একটি Gemini কী কনফিগার করা আছে।</string>
     <string name="settings_api_key_status_unset">aistudio.google.com-এ বিনামূল্যে API কী নিন</string>
+    <string name="settings_api_key_status_unset_shared">ঐচ্ছিক — নিজের কী পেস্ট করুন। aistudio.google.com থেকে বিনামূল্যে একটি নিন</string>
     <string name="settings_api_key_placeholder">আপনার Gemini API কী পেস্ট করুন</string>
     <string name="settings_api_key_save">Gemini কী সংরক্ষণ করুন</string>
     <string name="settings_api_key_clear">সংরক্ষিত Gemini কী মুছুন</string>
@@ -671,6 +672,14 @@ West Bengal vocabulary differences in a future PR.
     <string name="settings_display_palette_rainbow_description">গোলাপি, কমলা এবং সবুজ চার্ট লাইন সহ Material টিল/লাল আস্থা কার্ড। ডিফল্ট।</string>
     <string name="settings_display_palette_highlighter">হাইলাইটার</string>
     <string name="settings_display_palette_highlighter_description">ম্যাজেন্টা, হলুদ এবং সায়ান চার্ট লাইন — যেন পাতার উপর হাইলাইটার কলমের ছোঁয়া। এক নজরেই \"রংধনু\" থেকে দৃশ্যমানভাবে আলাদা; লাইট থিমে পঠনযোগ্যতার জন্য গভীরতর সংস্করণ ব্যবহার করা হয়। লাল-সবুজ বর্ণান্ধতার জন্য নিরাপদ।</string>
+    <string name="settings_display_home_layout_title">হোম স্ক্রিনের লেআউট</string>
+    <string name="settings_display_home_layout_description">এই বিভাগগুলো হোম স্ক্রিনে কীভাবে দেখাবে তা পুনর্বিন্যাস করতে হ্যান্ডেলগুলো টেনে নিন।</string>
+    <string name="settings_display_home_layout_drag">%1$s পুনর্বিন্যাস করতে টেনে নিন</string>
+    <string name="settings_display_home_section_outfit">পোশাক</string>
+    <string name="settings_display_home_section_conditions">অবস্থা</string>
+    <string name="settings_display_home_section_confidence">আস্থা</string>
+    <string name="settings_display_home_section_insight">পূর্বাভাস</string>
+    <string name="settings_display_home_section_charts">চার্ট</string>
     <string name="settings_unit_auto">স্বয়ংক্রিয়</string>
     <string name="today_cloud_range">মেঘ %1$d–%2$d%%</string>
     <string name="today_confidence_precip_spread">মডেলগুলো বৃষ্টি নিয়ে একমত নয় (Δ %1$.0f%%, %2$dটি মডেল)</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -206,6 +206,7 @@ the in-app clock is digit-driven and reads consistently across locales.
     <string name="settings_tts_device_header">Veus de baixa qualitat integrades al teu telèfon.</string>
     <string name="settings_api_key_status_set">Hi ha una clau de Gemini configurada.</string>
     <string name="settings_api_key_status_unset">Obtén una clau gratuïta a aistudio.google.com</string>
+    <string name="settings_api_key_status_unset_shared">Opcional — enganxa la teva clau. Aconsegueix-ne una gratis a aistudio.google.com</string>
     <string name="settings_api_key_placeholder">Enganxa la teva clau API de Gemini</string>
     <string name="settings_api_key_save">Guarda la clau de Gemini</string>
     <string name="settings_api_key_clear">Esborra la clau de Gemini guardada</string>
@@ -568,6 +569,14 @@ the in-app clock is digit-driven and reads consistently across locales.
     <string name="settings_display_palette_rainbow_description">Línies de gràfic rosa, taronja i verd amb targetes de confiança Material blau verdós/vermell. Per defecte.</string>
     <string name="settings_display_palette_highlighter">Marcador</string>
     <string name="settings_display_palette_highlighter_description">Línies de gràfic en magenta, groc i cian — com una pinzellada de marcador a la pàgina. Es distingeixen clarament de l\'\"Arc de Sant Martí\" d\'un cop d\'ull; el tema clar utilitza variants més profundes per a la llegibilitat. Segures per al daltonisme vermell-verd.</string>
+    <string name="settings_display_home_layout_title">Disseny de la pantalla d\'inici</string>
+    <string name="settings_display_home_layout_description">Arrossega les nanses per reordenar com apareixen aquestes seccions a la pantalla d\'inici.</string>
+    <string name="settings_display_home_layout_drag">Arrossega per reordenar %1$s</string>
+    <string name="settings_display_home_section_outfit">Conjunt</string>
+    <string name="settings_display_home_section_conditions">Condicions</string>
+    <string name="settings_display_home_section_confidence">Confiança</string>
+    <string name="settings_display_home_section_insight">Previsió</string>
+    <string name="settings_display_home_section_charts">Gràfics</string>
     <string name="settings_unit_auto">Auto</string>
     <string name="today_cloud_range">Nuvolositat %1$d–%2$d%%</string>
     <string name="today_confidence_precip_spread">Els models no es posen d\'acord sobre la pluja (Δ %1$.0f%% entre %2$d models)</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -279,6 +279,7 @@ locale (Angličtina (USA), Francouzština (Francie), Němčina (Německo), …).
     <string name="settings_tts_device_header">Hlasy v nízké kvalitě zabudované do tvého telefonu.</string>
     <string name="settings_api_key_status_set">Gemini klíč je nastaven.</string>
     <string name="settings_api_key_status_unset">Žádný Gemini klíč není nastaven. Získej ho na aistudio.google.com pro použití hlasů Gemini.</string>
+    <string name="settings_api_key_status_unset_shared">Volitelné — vlož vlastní klíč. Získej ho zdarma na aistudio.google.com</string>
     <string name="settings_api_key_placeholder">Vlož sem Gemini API klíč</string>
     <string name="settings_api_key_save">Uložit Gemini klíč</string>
     <string name="settings_api_key_clear">Smazat uložený Gemini klíč</string>
@@ -618,6 +619,14 @@ locale (Angličtina (USA), Francouzština (Francie), Němčina (Německo), …).
     <string name="settings_display_palette_rainbow_description">Růžové, oranžové a zelené linky grafů s tyrkysovými/červenými kartami spolehlivosti Material. Výchozí.</string>
     <string name="settings_display_palette_highlighter">Zvýrazňovač</string>
     <string name="settings_display_palette_highlighter_description">Purpurové, žluté a azurové čáry grafu — jako stopa zvýrazňovače na stránce. Na první pohled viditelně odlišné od \"Duhy\"; světlý motiv používá hlubší varianty pro čitelnost. Bezpečné při červeno-zelené barvosleposti.</string>
+    <string name="settings_display_home_layout_title">Rozvržení domovské obrazovky</string>
+    <string name="settings_display_home_layout_description">Přetažením úchytů změň pořadí, v jakém se tyto sekce zobrazují na domovské obrazovce.</string>
+    <string name="settings_display_home_layout_drag">Přetažením změň pořadí: %1$s</string>
+    <string name="settings_display_home_section_outfit">Outfit</string>
+    <string name="settings_display_home_section_conditions">Podmínky</string>
+    <string name="settings_display_home_section_confidence">Spolehlivost</string>
+    <string name="settings_display_home_section_insight">Předpověď</string>
+    <string name="settings_display_home_section_charts">Grafy</string>
     <string name="settings_unit_auto">Auto</string>
     <string name="today_cloud_range">Oblačnost %1$d\u2013%2$d%%</string>
     <string name="today_confidence_precip_spread">Modely se neshodují na srážkách (Δ %1$.0f%% pro %2$d modely)</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -279,6 +279,7 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrig)").
     <string name="settings_tts_device_header">Stemmer i lav kvalitet indbygget i din telefon.</string>
     <string name="settings_api_key_status_set">En Gemini-nøgle er oprettet.</string>
     <string name="settings_api_key_status_unset">Ingen Gemini-nøgle oprettet. Hent en på aistudio.google.com for at bruge Gemini-stemmer.</string>
+    <string name="settings_api_key_status_unset_shared">Valgfrit — indsæt din egen nøgle. Hent en gratis på aistudio.google.com</string>
     <string name="settings_api_key_placeholder">Indsæt Gemini API-nøgle her</string>
     <string name="settings_api_key_save">Gem Gemini-nøgle</string>
     <string name="settings_api_key_clear">Slet gemt Gemini-nøgle</string>
@@ -631,6 +632,14 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrig)").
     <string name="settings_display_palette_rainbow_description">Lyserøde, orange og grønne diagramlinjer med Material teal/røde tillidskort. Standard.</string>
     <string name="settings_display_palette_highlighter">Markeringspen</string>
     <string name="settings_display_palette_highlighter_description">Magenta, gule og cyan grafiklinjer — som markeringspenne på siden. Ved første øjekast synligt anderledes end \"Regnbue\"; det lyse tema bruger dybere varianter for læsbarhed. Sikker ved rød-grøn farveblindhed.</string>
+    <string name="settings_display_home_layout_title">Layout for startskærm</string>
+    <string name="settings_display_home_layout_description">Træk i håndtagene for at ændre rækkefølgen, som disse sektioner vises i på startskærmen.</string>
+    <string name="settings_display_home_layout_drag">Træk for at ændre rækkefølgen af %1$s</string>
+    <string name="settings_display_home_section_outfit">Outfit</string>
+    <string name="settings_display_home_section_conditions">Forhold</string>
+    <string name="settings_display_home_section_confidence">Sikkerhed</string>
+    <string name="settings_display_home_section_insight">Prognose</string>
+    <string name="settings_display_home_section_charts">Diagrammer</string>
     <string name="settings_unit_auto">Auto</string>
     <string name="today_cloud_range">Skydække %1$d\u2013%2$d%%</string>
     <string name="today_confidence_precip_spread">Modellerne er uenige om regn (Δ %1$.0f%% på tværs af %2$d modeller)</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -264,6 +264,7 @@ zh-CN) is unchanged; only the displayed label localizes.
 
     <string name="settings_api_key_status_set">Ein Gemini-Schlüssel ist eingerichtet.</string>
     <string name="settings_api_key_status_unset">Kein Gemini-Schlüssel eingerichtet. Hol dir einen unter aistudio.google.com, um Gemini-Stimmen zu nutzen.</string>
+    <string name="settings_api_key_status_unset_shared">Optional — füge deinen eigenen Schlüssel ein. Kostenlos erhältlich unter aistudio.google.com</string>
     <string name="settings_api_key_placeholder">Gemini-API-Schlüssel hier einfügen</string>
     <string name="settings_api_key_save">Gemini-Schlüssel speichern</string>
     <string name="settings_api_key_clear">Gespeicherten Gemini-Schlüssel löschen</string>
@@ -764,6 +765,14 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_display_palette_rainbow_description">Pinke, orange und grüne Diagrammlinien sowie türkis/rote Konfidenz-Karten. Standard.</string>
     <string name="settings_display_palette_highlighter">Textmarker</string>
     <string name="settings_display_palette_highlighter_description">Magenta, gelbe und cyanfarbene Diagrammlinien — wie Textmarker auf dem Papier. Auf einen Blick sichtbar anders als \"Regenbogen\"; das helle Design verwendet tiefere Varianten für bessere Lesbarkeit. Sicher bei Rot-Grün-Sehschwäche.</string>
+    <string name="settings_display_home_layout_title">Layout des Startbildschirms</string>
+    <string name="settings_display_home_layout_description">Zieh an den Griffen, um die Reihenfolge dieser Bereiche auf dem Startbildschirm zu ändern.</string>
+    <string name="settings_display_home_layout_drag">Ziehen, um %1$s neu anzuordnen</string>
+    <string name="settings_display_home_section_outfit">Outfit</string>
+    <string name="settings_display_home_section_conditions">Bedingungen</string>
+    <string name="settings_display_home_section_confidence">Zuverlässigkeit</string>
+    <string name="settings_display_home_section_insight">Vorhersage</string>
+    <string name="settings_display_home_section_charts">Diagramme</string>
     <string name="settings_unit_auto">Auto</string>
     <string name="today_cloud_range">Bewölkung %1$d\u2013%2$d%%</string>
     <string name="today_confidence_tap_to_hide">Tippen zum Ausblenden der Modellvorhersagen</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -296,6 +296,7 @@ zh-CN) is unchanged; only the displayed label localizes.
 
     <string name="settings_api_key_status_set">Έχει ρυθμιστεί ένα Gemini key.</string>
     <string name="settings_api_key_status_unset">Δεν έχει ρυθμιστεί Gemini key. Πάρε ένα από το aistudio.google.com για να χρησιμοποιήσεις τις φωνές Gemini.</string>
+    <string name="settings_api_key_status_unset_shared">Προαιρετικό — επικόλλησε το δικό σου key. Πάρε ένα δωρεάν από το aistudio.google.com</string>
     <string name="settings_api_key_placeholder">Επικόλλησε το Gemini API key σου</string>
     <string name="settings_api_key_save">Αποθήκευση Gemini key</string>
     <string name="settings_api_key_clear">Διαγραφή αποθηκευμένου Gemini key</string>
@@ -748,6 +749,14 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_display_palette_rainbow_description">Ροζ, πορτοκαλί και πράσινες γραμμές γραφημάτων με κάρτες αξιοπιστίας Material πετρόλ/κόκκινο. Προεπιλογή.</string>
     <string name="settings_display_palette_highlighter">Μαρκαδόρος</string>
     <string name="settings_display_palette_highlighter_description">Γραμμές γραφήματος σε ματζέντα, κίτρινο και κυανό — σαν ίχνος μαρκαδόρου στη σελίδα. Με μια ματιά διακρίνονται από το \"Ουράνιο τόξο\"· το ανοιχτό θέμα χρησιμοποιεί πιο σκούρες εκδοχές για αναγνωσιμότητα. Ασφαλές για κόκκινη-πράσινη αχρωματοψία.</string>
+    <string name="settings_display_home_layout_title">Διάταξη αρχικής οθόνης</string>
+    <string name="settings_display_home_layout_description">Σύρε τις λαβές για να αλλάξεις τη σειρά με την οποία εμφανίζονται αυτές οι ενότητες στην αρχική οθόνη.</string>
+    <string name="settings_display_home_layout_drag">Σύρε για αναδιάταξη: %1$s</string>
+    <string name="settings_display_home_section_outfit">Σύνολο</string>
+    <string name="settings_display_home_section_conditions">Συνθήκες</string>
+    <string name="settings_display_home_section_confidence">Αξιοπιστία</string>
+    <string name="settings_display_home_section_insight">Πρόβλεψη</string>
+    <string name="settings_display_home_section_charts">Γραφήματα</string>
     <string name="settings_unit_auto">Αυτόματο</string>
     <string name="today_cloud_range">Νέφωση %1$d–%2$d%%</string>
     <string name="today_confidence_precip_spread">Τα μοντέλα διαφωνούν για τη βροχή (Δ %1$.0f%% σε %2$d μοντέλα)</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -266,6 +266,7 @@ zh-CN) is unchanged; only the displayed label localizes.
 
     <string name="settings_api_key_status_set">Hay una clave de Gemini configurada.</string>
     <string name="settings_api_key_status_unset">No hay clave de Gemini configurada. Consigue una en aistudio.google.com para usar las voces de Gemini.</string>
+    <string name="settings_api_key_status_unset_shared">Opcional — pega tu propia clave. Consigue una gratis en aistudio.google.com</string>
     <string name="settings_api_key_placeholder">Pega tu clave API de Gemini</string>
     <string name="settings_api_key_save">Guardar clave de Gemini</string>
     <string name="settings_api_key_clear">Borrar clave de Gemini guardada</string>
@@ -730,6 +731,14 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_display_palette_rainbow_description">Líneas de gráfico rosa, naranja y verde con tarjetas de confianza Material en verde azulado/rojo. La predeterminada.</string>
     <string name="settings_display_palette_highlighter">Marcador</string>
     <string name="settings_display_palette_highlighter_description">Líneas de gráfico en magenta, amarillo y cian — como marcadores fluorescentes sobre el papel. Visiblemente diferentes de \"Arcoíris\" a primera vista; el tema claro usa variantes más oscuras para mayor legibilidad. Seguro con daltonismo rojo-verde.</string>
+    <string name="settings_display_home_layout_title">Diseño de la pantalla de inicio</string>
+    <string name="settings_display_home_layout_description">Arrastra los controladores para reordenar cómo aparecen estas secciones en la pantalla de inicio.</string>
+    <string name="settings_display_home_layout_drag">Arrastra para reordenar %1$s</string>
+    <string name="settings_display_home_section_outfit">Outfit</string>
+    <string name="settings_display_home_section_conditions">Condiciones</string>
+    <string name="settings_display_home_section_confidence">Confianza</string>
+    <string name="settings_display_home_section_insight">Pronóstico</string>
+    <string name="settings_display_home_section_charts">Gráficos</string>
     <string name="settings_unit_auto">Auto</string>
     <string name="today_cloud_range">Nubosidad %1$d\u2013%2$d%%</string>
     <string name="today_confidence_tap_to_hide">Toca para ocultar las previsiones por modelo</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -208,6 +208,7 @@ Tone is informal "sina"-form throughout ("Pane … selga", "Võta … kaasa",
     <string name="settings_tts_device_header">Madala kvaliteediga hääled, mis on telefoni sisse ehitatud.</string>
     <string name="settings_api_key_status_set">Gemini võti on seadistatud.</string>
     <string name="settings_api_key_status_unset">Hangi tasuta API-võti aadressilt aistudio.google.com</string>
+    <string name="settings_api_key_status_unset_shared">Valikuline — kleebi oma võti. Hangi tasuta aadressilt aistudio.google.com</string>
     <string name="settings_api_key_placeholder">Kleebi oma Gemini API-võti</string>
     <string name="settings_api_key_save">Salvesta Gemini võti</string>
     <string name="settings_api_key_clear">Kustuta salvestatud Gemini võti</string>
@@ -576,6 +577,14 @@ Tone is informal "sina"-form throughout ("Pane … selga", "Võta … kaasa",
     <string name="settings_display_palette_rainbow_description">Roosa, oranž ja roheline diagrammijoon koos Material teal/punaste usaldusväärsuskaartidega. Vaikimisi.</string>
     <string name="settings_display_palette_highlighter">Esiletõstja</string>
     <string name="settings_display_palette_highlighter_description">Magenta, kollased ja tsüaani värvi graafiku jooned — nagu esiletõstja jälg lehel. Ühe pilguga selgelt erinevad \"Vikerkaarest\"; hele teema kasutab loetavuse jaoks tumedamaid variante. Ohutu punase-rohelise värvipimeduse korral.</string>
+    <string name="settings_display_home_layout_title">Avakuva paigutus</string>
+    <string name="settings_display_home_layout_description">Lohista pidemeid, et muuta nende jaotiste järjestust avakuval.</string>
+    <string name="settings_display_home_layout_drag">Lohista, et muuta jaotise %1$s järjestust</string>
+    <string name="settings_display_home_section_outfit">Riietus</string>
+    <string name="settings_display_home_section_conditions">Tingimused</string>
+    <string name="settings_display_home_section_confidence">Usaldusväärsus</string>
+    <string name="settings_display_home_section_insight">Prognoos</string>
+    <string name="settings_display_home_section_charts">Graafikud</string>
     <string name="settings_unit_auto">Automaatne</string>
     <string name="today_cloud_range">Pilvisus %1$d–%2$d%%</string>
     <string name="today_confidence_precip_spread">Mudelid ei nõustu vihma osas (Δ %1$.0f%% %2$d mudeli vahel)</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -311,6 +311,7 @@ Western Arabic numerals (0-9) are used for TTS compatibility.
     <string name="settings_tts_device_header">صداهای کم‌کیفیت تعبیه‌شده در گوشی شما.</string>
     <string name="settings_api_key_status_set">یک کلید Gemini پیکربندی شده.</string>
     <string name="settings_api_key_status_unset">یک کلید API رایگان از aistudio.google.com دریافت کنید</string>
+    <string name="settings_api_key_status_unset_shared">اختیاری — کلید خودتان را بچسبانید. یکی رایگان از aistudio.google.com بگیرید</string>
     <string name="settings_api_key_placeholder">کلید Gemini API خود را جای‌گذاری کنید</string>
     <string name="settings_api_key_save">ذخیره کلید Gemini</string>
     <string name="settings_api_key_clear">پاک کردن کلید ذخیره‌شده Gemini</string>
@@ -476,6 +477,14 @@ Western Arabic numerals (0-9) are used for TTS compatibility.
     <string name="settings_display_palette_rainbow_description">خطوط نمودار صورتی، نارنجی و سبز با کارت‌های اطمینان Material فیروزه‌ای/قرمز. پیش‌فرض.</string>
     <string name="settings_display_palette_highlighter">ماژیک هایلایت</string>
     <string name="settings_display_palette_highlighter_description">خطوط نمودار به رنگ‌های ارغوانی، زرد و فیروزه‌ای — مانند ردّ ماژیک هایلایت روی کاغذ. در نگاه اول به‌وضوح از \"رنگین‌کمان\" متمایزند؛ تم روشن از تنالیته‌های عمیق‌تر برای خوانایی استفاده می‌کند. برای کوررنگی قرمز-سبز ایمن است.</string>
+    <string name="settings_display_home_layout_title">چیدمان صفحه اصلی</string>
+    <string name="settings_display_home_layout_description">برای تغییر ترتیب نمایش این بخش‌ها در صفحه اصلی، دستگیره‌ها را بکشید.</string>
+    <string name="settings_display_home_layout_drag">برای تغییر ترتیب %1$s بکشید</string>
+    <string name="settings_display_home_section_outfit">لباس</string>
+    <string name="settings_display_home_section_conditions">شرایط</string>
+    <string name="settings_display_home_section_confidence">اطمینان</string>
+    <string name="settings_display_home_section_insight">پیش‌بینی</string>
+    <string name="settings_display_home_section_charts">نمودارها</string>
     <string name="settings_display_palette_accessible">در دسترس</string>
     <string name="settings_display_palette_accessible_description">پالتی برگرفته از Okabe-Ito که برای تمایز در انواع کوررنگی طراحی شده. کارت‌های اطمینان از آبی آسمانی، خنثی و کهربایی به‌جای فیروزه‌ای، خنثی و قرمز استفاده می‌کنند.</string>
     <string name="today_cloud_range">ابر %1$d–%2$d%%</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -221,6 +221,7 @@ displayed label localizes.
 
     <string name="settings_api_key_status_set">Gemini-avain on asetettu.</string>
     <string name="settings_api_key_status_unset">Gemini-avainta ei ole asetettu. Hanki avain osoitteesta aistudio.google.com käyttääksesi Gemini-ääniä.</string>
+    <string name="settings_api_key_status_unset_shared">Valinnainen — liitä oma avaimesi. Hanki ilmainen osoitteesta aistudio.google.com</string>
     <string name="settings_api_key_placeholder">Liitä Gemini-API-avain tähän</string>
     <string name="settings_api_key_save">Tallenna Gemini-avain</string>
     <string name="settings_api_key_clear">Poista tallennettu Gemini-avain</string>
@@ -611,6 +612,14 @@ displayed label localizes.
     <string name="settings_display_palette_rainbow_description">Vaaleanpunaiset, oranssit ja vihreät kaavioviivat sekä Material teal/punaiset luotettavuuskortit. Oletus.</string>
     <string name="settings_display_palette_highlighter">Korostuskynä</string>
     <string name="settings_display_palette_highlighter_description">Magenta, keltaiset ja syaaninväriset kaaviolinjat — kuin korostuskynänjälki sivulla. Erottuu ensisilmäyksellä \"Sateenkaaresta\"; vaalea teema käyttää syvempiä variantteja luettavuuden vuoksi. Turvallinen puna-vihersokeudelle.</string>
+    <string name="settings_display_home_layout_title">Aloitusnäytön asettelu</string>
+    <string name="settings_display_home_layout_description">Vedä kahvoista järjestääksesi uudelleen, miten nämä osiot näkyvät aloitusnäytöllä.</string>
+    <string name="settings_display_home_layout_drag">Vedä järjestääksesi uudelleen: %1$s</string>
+    <string name="settings_display_home_section_outfit">Asu</string>
+    <string name="settings_display_home_section_conditions">Olosuhteet</string>
+    <string name="settings_display_home_section_confidence">Luotettavuus</string>
+    <string name="settings_display_home_section_insight">Ennuste</string>
+    <string name="settings_display_home_section_charts">Kaaviot</string>
     <string name="settings_unit_auto">Auto</string>
     <string name="today_cloud_range">Pilvisyys %1$d\u2013%2$d%%</string>
     <string name="today_confidence_precip_spread">Mallit ovat eri mieltä sateesta (Δ %1$.0f%% %2$d mallin kesken)</string>

--- a/app/src/main/res/values-fil/strings.xml
+++ b/app/src/main/res/values-fil/strings.xml
@@ -325,6 +325,7 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="settings_tts_device_header">Mga boses na may mababang kalidad na nakapaloob sa iyong telepono.</string>
     <string name="settings_api_key_status_set">May naka-configure na Gemini key.</string>
     <string name="settings_api_key_status_unset">Kumuha ng libreng API key sa aistudio.google.com</string>
+    <string name="settings_api_key_status_unset_shared">Opsyonal — i-paste ang sarili mong key. Kumuha ng libre sa aistudio.google.com</string>
     <string name="settings_api_key_placeholder">I-paste ang iyong Gemini API key</string>
     <string name="settings_api_key_save">I-save ang Gemini key</string>
     <string name="settings_api_key_clear">I-clear ang nakaimbak na Gemini key</string>
@@ -651,6 +652,14 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="settings_display_palette_rainbow_description">Pink, orange, at berdeng linya ng tsart na may teal/pulang confidence card na Material. Default.</string>
     <string name="settings_display_palette_highlighter">Highlighter</string>
     <string name="settings_display_palette_highlighter_description">Mga linya ng tsart sa magenta, dilaw, at cyan — parang gurit ng highlighter sa pahina. Madaling makita ang pagkaiba sa \"Bahaghari\"; gumagamit ang light theme ng mas matingkad na bersyon para sa kabasahan. Ligtas para sa pagkabulag sa pula-berde.</string>
+    <string name="settings_display_home_layout_title">Layout ng home screen</string>
+    <string name="settings_display_home_layout_description">I-drag ang mga hawakan para baguhin ang pagkakasunod-sunod ng mga seksyong ito sa home screen.</string>
+    <string name="settings_display_home_layout_drag">I-drag para baguhin ang pagkakasunod-sunod ng %1$s</string>
+    <string name="settings_display_home_section_outfit">Outfit</string>
+    <string name="settings_display_home_section_conditions">Mga kondisyon</string>
+    <string name="settings_display_home_section_confidence">Kumpiyansa</string>
+    <string name="settings_display_home_section_insight">Hula</string>
+    <string name="settings_display_home_section_charts">Mga tsart</string>
     <string name="settings_unit_auto">Auto</string>
     <string name="today_cloud_range">Ulap %1$d–%2$d%%</string>
     <string name="today_confidence_precip_spread">Hindi nagkakasundo ang mga modelo sa ulan (Δ %1$.0f%% sa %2$d modelo)</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -268,6 +268,7 @@ zh-CN) is unchanged; only the displayed label localizes.
 
     <string name="settings_api_key_status_set">Une clé Gemini est configurée.</string>
     <string name="settings_api_key_status_unset">Aucune clé Gemini configurée. Obtiens-en une sur aistudio.google.com pour utiliser les voix Gemini.</string>
+    <string name="settings_api_key_status_unset_shared">Facultatif — colle ta propre clé. Obtiens-en une gratuitement sur aistudio.google.com</string>
     <string name="settings_api_key_placeholder">Colle ta clé API Gemini</string>
     <string name="settings_api_key_save">Enregistrer la clé Gemini</string>
     <string name="settings_api_key_clear">Effacer la clé Gemini enregistrée</string>
@@ -729,6 +730,14 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_display_palette_rainbow_description">Lignes de graphique roses, oranges et vertes avec des cartes de confiance sarcelle/rouge Material. Par défaut.</string>
     <string name="settings_display_palette_highlighter">Surligneur</string>
     <string name="settings_display_palette_highlighter_description">Lignes de graphique magenta, jaune et cyan — comme un coup de surligneur sur la page. Visiblement différentes d\'\"Arc-en-ciel\" d\'un coup d\'œil ; le thème clair utilise des variantes plus profondes pour la lisibilité. Adapté au daltonisme rouge-vert.</string>
+    <string name="settings_display_home_layout_title">Disposition de l\'écran d\'accueil</string>
+    <string name="settings_display_home_layout_description">Fais glisser les poignées pour réorganiser l\'ordre d\'affichage de ces sections sur l\'écran d\'accueil.</string>
+    <string name="settings_display_home_layout_drag">Faire glisser pour réorganiser %1$s</string>
+    <string name="settings_display_home_section_outfit">Tenue</string>
+    <string name="settings_display_home_section_conditions">Conditions</string>
+    <string name="settings_display_home_section_confidence">Fiabilité</string>
+    <string name="settings_display_home_section_insight">Prévisions</string>
+    <string name="settings_display_home_section_charts">Graphiques</string>
     <string name="settings_unit_auto">Auto</string>
     <string name="today_cloud_range">Nuages %1$d\u2013%2$d%%</string>
     <string name="today_confidence_tap_to_hide">Appuyer pour masquer les prévisions par modèle</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -249,6 +249,7 @@ Not overridden by design:
     <string name="settings_tts_device_header">आपके फ़ोन में निर्मित निम्न-गुणवत्ता वाली आवाज़ें।</string>
     <string name="settings_api_key_status_set">Gemini कुंजी सेट है।</string>
     <string name="settings_api_key_status_unset">aistudio.google.com पर मुफ़्त API कुंजी पाएँ</string>
+    <string name="settings_api_key_status_unset_shared">वैकल्पिक — अपनी कुंजी पेस्ट करें। aistudio.google.com पर मुफ़्त में पाएँ</string>
     <string name="settings_api_key_placeholder">अपनी Gemini API कुंजी चिपकाएँ</string>
     <string name="settings_api_key_save">Gemini कुंजी सेव करें</string>
     <string name="settings_api_key_clear">सेव की गई Gemini कुंजी हटाएँ</string>
@@ -631,6 +632,14 @@ Not overridden by design:
     <string name="settings_display_palette_rainbow_description">गुलाबी, नारंगी और हरी चार्ट लाइनें Material टील/लाल विश्वास कार्ड के साथ। डिफ़ॉल्ट।</string>
     <string name="settings_display_palette_highlighter">हाइलाइटर</string>
     <string name="settings_display_palette_highlighter_description">मैजेंटा, पीली और सायन रंग की चार्ट लाइनें — पन्ने पर हाइलाइटर पेन की तरह। \"इंद्रधनुष\" से एक नज़र में स्पष्ट रूप से अलग; लाइट थीम पठनीयता के लिए गहरे संस्करण उपयोग करती है। लाल-हरे रंग अंधता में सुरक्षित।</string>
+    <string name="settings_display_home_layout_title">होम स्क्रीन लेआउट</string>
+    <string name="settings_display_home_layout_description">ये सेक्शन होम स्क्रीन पर किस क्रम में दिखें, यह बदलने के लिए हैंडल खींचें।</string>
+    <string name="settings_display_home_layout_drag">%1$s को पुनः क्रमित करने के लिए खींचें</string>
+    <string name="settings_display_home_section_outfit">पोशाक</string>
+    <string name="settings_display_home_section_conditions">स्थितियाँ</string>
+    <string name="settings_display_home_section_confidence">विश्वास</string>
+    <string name="settings_display_home_section_insight">पूर्वानुमान</string>
+    <string name="settings_display_home_section_charts">चार्ट</string>
     <string name="settings_unit_auto">स्वचालित</string>
     <string name="today_cloud_range">बादल %1$d–%2$d%%</string>
     <string name="today_confidence_precip_spread">मॉडल बारिश पर सहमत नहीं (Δ %1$.0f%%, %2$d मॉडल में)</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -239,6 +239,7 @@ spousal register), matching the existing insight prose ("Ponesi …",
 
     <string name="settings_api_key_status_set">Gemini ključ je postavljen.</string>
     <string name="settings_api_key_status_unset">Gemini ključ nije postavljen. Nabavi ga na aistudio.google.com za korištenje Gemini glasova.</string>
+    <string name="settings_api_key_status_unset_shared">Neobavezno — zalijepi vlastiti ključ. Nabavi ga besplatno na aistudio.google.com</string>
     <string name="settings_api_key_placeholder">Zalijepi svoj Gemini API ključ</string>
     <string name="settings_api_key_save">Spremi Gemini ključ</string>
     <string name="settings_api_key_clear">Izbriši spremljeni Gemini ključ</string>
@@ -698,6 +699,14 @@ spousal register), matching the existing insight prose ("Ponesi …",
     <string name="settings_display_palette_rainbow_description">Ružičaste, narančaste i zelene linije grafikona s tirkiznim/crvenim karticama pouzdanosti Material. Zadano.</string>
     <string name="settings_display_palette_highlighter">Marker</string>
     <string name="settings_display_palette_highlighter_description">Magenta, žute i cijan linije grafikona — kao trag markera na stranici. Na prvi pogled vidno različite od \"Duge\"; svijetla tema koristi dublje varijante za čitljivost. Sigurne za crveno-zelenu sljepoću za boje.</string>
+    <string name="settings_display_home_layout_title">Raspored početnog zaslona</string>
+    <string name="settings_display_home_layout_description">Povuci ručke da promijeniš redoslijed prikaza ovih odjeljaka na početnom zaslonu.</string>
+    <string name="settings_display_home_layout_drag">Povuci za promjenu redoslijeda: %1$s</string>
+    <string name="settings_display_home_section_outfit">Outfit</string>
+    <string name="settings_display_home_section_conditions">Uvjeti</string>
+    <string name="settings_display_home_section_confidence">Pouzdanost</string>
+    <string name="settings_display_home_section_insight">Prognoza</string>
+    <string name="settings_display_home_section_charts">Grafikoni</string>
     <string name="settings_unit_auto">Auto</string>
     <string name="today_cloud_range">Oblačnost %1$d\u2013%2$d%%</string>
     <string name="today_confidence_tap_to_hide">Dodirnite za skrivanje prognoza po modelu</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -281,6 +281,7 @@ locale (Angol (Egyesült Államok), Francia (Franciaország), Német
     <string name="settings_tts_device_header">A telefonodba beépített, gyenge minőségű hangok.</string>
     <string name="settings_api_key_status_set">Gemini-kulcs be van állítva.</string>
     <string name="settings_api_key_status_unset">Nincs Gemini-kulcs beállítva. Szerezz egyet az aistudio.google.com oldalon a Gemini-hangok használatához.</string>
+    <string name="settings_api_key_status_unset_shared">Választható — illeszd be a saját kulcsod. Szerezz egyet ingyen az aistudio.google.com oldalon</string>
     <string name="settings_api_key_placeholder">Gemini API-kulcs beillesztése ide</string>
     <string name="settings_api_key_save">Gemini-kulcs mentése</string>
     <string name="settings_api_key_clear">Mentett Gemini-kulcs törlése</string>
@@ -621,6 +622,14 @@ locale (Angol (Egyesült Államok), Francia (Franciaország), Német
     <string name="settings_display_palette_rainbow_description">Rózsaszín, narancssárga és zöld diagramvonalak Material kékeszöld/piros megbízhatósági kártyákkal. Az alapértelmezett.</string>
     <string name="settings_display_palette_highlighter">Szövegkiemelő</string>
     <string name="settings_display_palette_highlighter_description">Magenta, sárga és ciánkék diagramvonalak — mint a szövegkiemelő nyoma a lapon. Első pillantásra láthatóan más, mint a \"Szivárvány\"; a világos téma mélyebb változatokat használ az olvashatóság érdekében. Biztonságos vörös-zöld színtévesztéshez.</string>
+    <string name="settings_display_home_layout_title">Kezdőképernyő elrendezése</string>
+    <string name="settings_display_home_layout_description">Húzd a fogantyúkat, hogy átrendezd, milyen sorrendben jelennek meg ezek a szakaszok a kezdőképernyőn.</string>
+    <string name="settings_display_home_layout_drag">Húzd a(z) %1$s átrendezéséhez</string>
+    <string name="settings_display_home_section_outfit">Outfit</string>
+    <string name="settings_display_home_section_conditions">Körülmények</string>
+    <string name="settings_display_home_section_confidence">Megbízhatóság</string>
+    <string name="settings_display_home_section_insight">Előrejelzés</string>
+    <string name="settings_display_home_section_charts">Diagramok</string>
     <string name="settings_unit_auto">Auto</string>
     <string name="today_cloud_range">Felhőzet %1$d\u2013%2$d%%</string>
     <string name="today_confidence_precip_spread">A modellek nem értenek egyet a csapadékban (Δ %1$.0f%% %2$d modell között)</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -313,6 +313,7 @@ to values/strings.xml (English).
     <string name="settings_tts_device_header">Suara berkualitas rendah bawaan di ponselmu.</string>
     <string name="settings_api_key_status_set">Kunci Gemini telah dikonfigurasi.</string>
     <string name="settings_api_key_status_unset">Dapatkan kunci API gratis di aistudio.google.com</string>
+    <string name="settings_api_key_status_unset_shared">Opsional — tempel kuncimu sendiri. Dapatkan gratis di aistudio.google.com</string>
     <string name="settings_api_key_placeholder">Tempelkan kunci API Gemini Anda</string>
     <string name="settings_api_key_save">Simpan kunci Gemini</string>
     <string name="settings_api_key_clear">Hapus kunci Gemini tersimpan</string>
@@ -601,6 +602,14 @@ to values/strings.xml (English).
     <string name="settings_display_palette_rainbow_description">Garis grafik merah muda, oranye, dan hijau dengan kartu keyakinan Material teal/merah. Bawaan.</string>
     <string name="settings_display_palette_highlighter">Stabilo</string>
     <string name="settings_display_palette_highlighter_description">Garis grafik magenta, kuning, dan cyan — seperti goresan stabilo di halaman. Sekilas tampak jelas berbeda dari \"Pelangi\"; tema terang memakai varian yang lebih gelap agar lebih mudah dibaca. Aman untuk buta warna merah-hijau.</string>
+    <string name="settings_display_home_layout_title">Tata letak layar utama</string>
+    <string name="settings_display_home_layout_description">Seret pegangan untuk mengatur ulang urutan tampilan bagian-bagian ini di layar utama.</string>
+    <string name="settings_display_home_layout_drag">Seret untuk mengatur ulang %1$s</string>
+    <string name="settings_display_home_section_outfit">Pakaian</string>
+    <string name="settings_display_home_section_conditions">Kondisi</string>
+    <string name="settings_display_home_section_confidence">Keyakinan</string>
+    <string name="settings_display_home_section_insight">Prakiraan</string>
+    <string name="settings_display_home_section_charts">Grafik</string>
     <string name="settings_unit_auto">Otomatis</string>
     <string name="today_cloud_range">Awan %1$d–%2$d%%</string>
     <string name="today_confidence_precip_spread">Model tidak sepakat soal hujan (Δ %1$.0f%% dari %2$d model)</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -258,6 +258,7 @@ zh-CN) is unchanged; only the displayed label localizes.
 
     <string name="settings_api_key_status_set">È configurata una chiave Gemini.</string>
     <string name="settings_api_key_status_unset">Nessuna chiave Gemini configurata. Ottienine una su aistudio.google.com per usare le voci Gemini.</string>
+    <string name="settings_api_key_status_unset_shared">Facoltativo — incolla la tua chiave. Ottienine una gratis su aistudio.google.com</string>
     <string name="settings_api_key_placeholder">Incolla la tua chiave API Gemini</string>
     <string name="settings_api_key_save">Salva chiave Gemini</string>
     <string name="settings_api_key_clear">Cancella chiave Gemini salvata</string>
@@ -715,6 +716,14 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_display_palette_rainbow_description">Linee del grafico rosa, arancione e verde con schede di affidabilità Material verde acqua/rosso. Il valore predefinito.</string>
     <string name="settings_display_palette_highlighter">Evidenziatore</string>
     <string name="settings_display_palette_highlighter_description">Linee del grafico magenta, gialle e ciano — come tratti di evidenziatore sulla pagina. Visivamente diverse da \"Arcobaleno\" al primo sguardo; il tema chiaro usa varianti più scure per la leggibilità. Sicuro per il daltonismo rosso-verde.</string>
+    <string name="settings_display_home_layout_title">Layout della schermata Home</string>
+    <string name="settings_display_home_layout_description">Trascina le maniglie per riordinare come queste sezioni appaiono nella schermata Home.</string>
+    <string name="settings_display_home_layout_drag">Trascina per riordinare %1$s</string>
+    <string name="settings_display_home_section_outfit">Outfit</string>
+    <string name="settings_display_home_section_conditions">Condizioni</string>
+    <string name="settings_display_home_section_confidence">Affidabilità</string>
+    <string name="settings_display_home_section_insight">Previsioni</string>
+    <string name="settings_display_home_section_charts">Grafici</string>
     <string name="settings_unit_auto">Auto</string>
     <string name="today_cloud_range">Nuvolosità %1$d\u2013%2$d%%</string>
     <string name="today_confidence_tap_to_hide">Tocca per nascondere le previsioni per modello</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -317,6 +317,7 @@ standard in Israeli digital communication.
     <string name="settings_tts_device_header">קולות באיכות נמוכה שמובנים בטלפון שלך.</string>
     <string name="settings_api_key_status_set">מפתח Gemini מוגדר.</string>
     <string name="settings_api_key_status_unset">קבל/י מפתח API חינמי ב-aistudio.google.com</string>
+    <string name="settings_api_key_status_unset_shared">אופציונלי — הדבק/י מפתח משלך. קבל/י אחד בחינם ב-aistudio.google.com</string>
     <string name="settings_api_key_placeholder">הדבק/י את מפתח Gemini API שלך</string>
     <string name="settings_api_key_save">שמור/י מפתח Gemini</string>
     <string name="settings_api_key_clear">מחק/י מפתח Gemini שמור</string>
@@ -484,6 +485,14 @@ standard in Israeli digital communication.
     <string name="settings_display_palette_rainbow_description">קווי גרף ורוד, כתום וירוק עם כרטיסי אמון Material בירקרק/אדום. ברירת המחדל.</string>
     <string name="settings_display_palette_highlighter">טוש זוהר</string>
     <string name="settings_display_palette_highlighter_description">קווי גרף בצבעי מגנטה, צהוב ותכלת — כמו טוש זוהר על הדף. נבדלים מ\"קשת בענן\" במבט ראשון; הערכת הבהיר משתמשת בגוונים עמוקים יותר לקריאות. בטוחים לעיוורי צבעים אדום-ירוק.</string>
+    <string name="settings_display_home_layout_title">פריסת מסך הבית</string>
+    <string name="settings_display_home_layout_description">גרור את הידיות כדי לסדר מחדש את האופן שבו הקטעים האלה מופיעים במסך הבית.</string>
+    <string name="settings_display_home_layout_drag">גרור כדי לסדר מחדש את %1$s</string>
+    <string name="settings_display_home_section_outfit">לבוש</string>
+    <string name="settings_display_home_section_conditions">תנאים</string>
+    <string name="settings_display_home_section_confidence">ודאות</string>
+    <string name="settings_display_home_section_insight">תחזית</string>
+    <string name="settings_display_home_section_charts">תרשימים</string>
     <string name="settings_display_palette_accessible">נגיש</string>
     <string name="settings_display_palette_accessible_description">פלטה המבוססת על Okabe-Ito, מעוצבת להישאר מבחינה בעיוורון צבעים. כרטיסי האמון משתמשים בכחול שמים, ניטרלי וענבר במקום ירקרק, ניטרלי ואדום.</string>
     <string name="today_cloud_range">ענן %1$d–%2$d%%</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -265,6 +265,7 @@ the displayed label localizes.
 
     <string name="settings_api_key_status_set">Gemini キーが設定されています。</string>
     <string name="settings_api_key_status_unset">Gemini キーが未設定です。aistudio.google.com で取得すると Gemini 音声を使用できます。</string>
+    <string name="settings_api_key_status_unset_shared">任意 — 自分のキーを貼り付けます。aistudio.google.com で無料で取得できます</string>
     <string name="settings_api_key_placeholder">Gemini API キーを貼り付け</string>
     <string name="settings_api_key_save">Gemini キーを保存</string>
     <string name="settings_api_key_clear">保存された Gemini キーを削除</string>
@@ -738,6 +739,14 @@ the displayed label localizes.
     <string name="settings_display_palette_rainbow_description">ピンク・オレンジ・グリーンのグラフ線とMaterialのティール/レッドの信頼度カード。デフォルト設定。</string>
     <string name="settings_display_palette_highlighter">ハイライト</string>
     <string name="settings_display_palette_highlighter_description">マゼンタ・イエロー・シアンのグラフ線。ページの上の蛍光ペンのよう。「レインボー」とひと目で見分けがつき、ライトテーマでは読みやすさのため少し濃いバージョンを使います。赤緑の色覚特性でも安全です。</string>
+    <string name="settings_display_home_layout_title">ホーム画面のレイアウト</string>
+    <string name="settings_display_home_layout_description">ハンドルをドラッグして、これらのセクションがホーム画面に表示される順序を変更します。</string>
+    <string name="settings_display_home_layout_drag">ドラッグして%1$sを並べ替え</string>
+    <string name="settings_display_home_section_outfit">コーデ</string>
+    <string name="settings_display_home_section_conditions">コンディション</string>
+    <string name="settings_display_home_section_confidence">信頼度</string>
+    <string name="settings_display_home_section_insight">予報</string>
+    <string name="settings_display_home_section_charts">グラフ</string>
     <string name="settings_unit_auto">自動</string>
     <string name="today_cloud_range">雲量 %1$d〜%2$d%%</string>
     <string name="today_confidence_precip_spread">降水確率でモデル間に差あり（Δ %1$.0f%%、%2$dモデル間）</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -278,6 +278,7 @@ displayed label localizes.
 
     <string name="settings_api_key_status_set">Gemini 키가 설정되어 있어요.</string>
     <string name="settings_api_key_status_unset">Gemini 키가 설정되지 않았어요. Gemini 음성을 사용하려면 aistudio.google.com에서 받으세요.</string>
+    <string name="settings_api_key_status_unset_shared">선택 사항 — 직접 키를 붙여넣으세요. aistudio.google.com에서 무료로 받을 수 있어요</string>
     <string name="settings_api_key_placeholder">Gemini API 키 붙여넣기</string>
     <string name="settings_api_key_save">Gemini 키 저장</string>
     <string name="settings_api_key_clear">저장된 Gemini 키 삭제</string>
@@ -741,6 +742,14 @@ displayed label localizes.
     <string name="settings_display_palette_rainbow_description">핑크, 주황, 초록 차트 선과 Material 청록/빨강 신뢰도 카드. 기본값.</string>
     <string name="settings_display_palette_highlighter">형광펜</string>
     <string name="settings_display_palette_highlighter_description">마젠타·노랑·시안 차트 선 — 종이 위에 형광펜으로 그은 듯한 느낌입니다. 한눈에 \"무지개\"와 분명히 구분되며, 라이트 테마는 가독성을 위해 더 짙은 색을 사용합니다. 적-녹 색각 이상에서도 안전합니다.</string>
+    <string name="settings_display_home_layout_title">홈 화면 레이아웃</string>
+    <string name="settings_display_home_layout_description">핸들을 드래그하여 이 섹션들이 홈 화면에 표시되는 순서를 바꾸세요.</string>
+    <string name="settings_display_home_layout_drag">드래그하여 %1$s 순서 변경</string>
+    <string name="settings_display_home_section_outfit">코디</string>
+    <string name="settings_display_home_section_conditions">날씨 상태</string>
+    <string name="settings_display_home_section_confidence">신뢰도</string>
+    <string name="settings_display_home_section_insight">예보</string>
+    <string name="settings_display_home_section_charts">차트</string>
     <string name="settings_unit_auto">자동</string>
     <string name="today_cloud_range">구름량 %1$d〜%2$d%%</string>
     <string name="today_confidence_precip_spread">강수 확률에서 모델 간 의견 불일치 (Δ %1$.0f%%, %2$d개 모델)</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -320,6 +320,7 @@ What is NOT overridden, by design:
     <string name="settings_tts_device_header">Žemos kokybės balsai, įdiegti tavo telefone.</string>
     <string name="settings_api_key_status_set">Gemini raktas sukonfigūruotas.</string>
     <string name="settings_api_key_status_unset">Gauk nemokamą API raktą adresu aistudio.google.com</string>
+    <string name="settings_api_key_status_unset_shared">Pasirinktinai — įklijuok savo raktą. Gauk nemokamą adresu aistudio.google.com</string>
     <string name="settings_api_key_placeholder">Įklijuok Gemini API raktą</string>
     <string name="settings_api_key_save">Išsaugoti Gemini raktą</string>
     <string name="settings_api_key_clear">Ištrinti išsaugotą Gemini raktą</string>
@@ -620,6 +621,14 @@ What is NOT overridden, by design:
     <string name="settings_display_palette_rainbow_description">Rožinės, oranžinės ir žalios diagramų linijos su Material žalsvomis/raudonomis patikimumo kortelėmis. Numatytoji.</string>
     <string name="settings_display_palette_highlighter">Žymeklis</string>
     <string name="settings_display_palette_highlighter_description">Purpurinės, geltonos ir žydros diagramos linijos — tarsi žymeklio brūkšnis ant puslapio. Iš pirmo žvilgsnio aiškiai skiriasi nuo \"Vaivorykštės\"; šviesi tema naudoja tamsesnius variantus, kad būtų geriau įskaitoma. Saugu esant raudonai-žaliai spalvinei aklumai.</string>
+    <string name="settings_display_home_layout_title">Pradžios ekrano išdėstymas</string>
+    <string name="settings_display_home_layout_description">Vilkdami rankenėles pakeiskite, kokia tvarka šie skyriai rodomi pradžios ekrane.</string>
+    <string name="settings_display_home_layout_drag">Vilkite, kad pertvarkytumėte %1$s</string>
+    <string name="settings_display_home_section_outfit">Apranga</string>
+    <string name="settings_display_home_section_conditions">Sąlygos</string>
+    <string name="settings_display_home_section_confidence">Patikimumas</string>
+    <string name="settings_display_home_section_insight">Prognozė</string>
+    <string name="settings_display_home_section_charts">Grafikai</string>
     <string name="settings_unit_auto">Automatiškai</string>
     <string name="today_cloud_range">Debesuotumas %1$d–%2$d%%</string>
     <string name="today_confidence_precip_spread">Modeliai nesutaria dėl lietaus (Δ %1$.0f%% iš %2$d modelių)</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -296,6 +296,7 @@ informal "tu"-form throughout ("Apģērb …", "Paņem … līdzi").
     <string name="settings_tts_device_header">Zemas kvalitātes balsis, kas iebūvētas jūsu tālrunī.</string>
     <string name="settings_api_key_status_set">Gemini atslēga ir konfigurēta.</string>
     <string name="settings_api_key_status_unset">Iegūsti bezmaksas API atslēgu vietnē aistudio.google.com</string>
+    <string name="settings_api_key_status_unset_shared">Neobligāti — ielīmē savu atslēgu. Iegūsti bezmaksas vietnē aistudio.google.com</string>
     <string name="settings_api_key_placeholder">Ielīmē savu Gemini API atslēgu</string>
     <string name="settings_api_key_save">Saglabāt Gemini atslēgu</string>
     <string name="settings_api_key_clear">Dzēst saglabāto Gemini atslēgu</string>
@@ -573,6 +574,14 @@ informal "tu"-form throughout ("Apģērb …", "Paņem … līdzi").
     <string name="settings_display_palette_rainbow_description">Rozā, oranžas un zaļas diagrammas līnijas ar Material tirkīza/sarkanām ticamības kartēm. Noklusējums.</string>
     <string name="settings_display_palette_highlighter">Marķieris</string>
     <string name="settings_display_palette_highlighter_description">Fuksiju, dzeltenas un ciāna grafika līnijas — kā marķiera pēdas uz lapas. No pirmā skatiena nepārprotami atšķiras no \"Varavīksnes\"; gaišā tēma izmanto tumšākus variantus labākai lasāmībai. Droši sarkanas-zaļas krāsu akluma gadījumā.</string>
+    <string name="settings_display_home_layout_title">Sākuma ekrāna izkārtojums</string>
+    <string name="settings_display_home_layout_description">Velc rokturus, lai mainītu secību, kādā šīs sadaļas tiek rādītas sākuma ekrānā.</string>
+    <string name="settings_display_home_layout_drag">Velc, lai mainītu %1$s secību</string>
+    <string name="settings_display_home_section_outfit">Apģērbs</string>
+    <string name="settings_display_home_section_conditions">Apstākļi</string>
+    <string name="settings_display_home_section_confidence">Ticamība</string>
+    <string name="settings_display_home_section_insight">Prognoze</string>
+    <string name="settings_display_home_section_charts">Grafiki</string>
     <string name="settings_unit_auto">Automātiski</string>
     <string name="today_cloud_range">Mākoņainums %1$d–%2$d%%</string>
     <string name="today_confidence_precip_spread">Modeļi nepiekrīt lietus jautājumā (Δ %1$.0f%% starp %2$d modeļiem)</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -314,6 +314,7 @@ vs "kemungkinan", "padam" vs "hapus").
     <string name="settings_tts_device_header">Suara berkualiti rendah yang terbina dalam telefon anda.</string>
     <string name="settings_api_key_status_set">Kunci Gemini telah dikonfigurasi.</string>
     <string name="settings_api_key_status_unset">Dapatkan kunci API percuma di aistudio.google.com</string>
+    <string name="settings_api_key_status_unset_shared">Pilihan — tampal kunci anda sendiri. Dapatkan percuma di aistudio.google.com</string>
     <string name="settings_api_key_placeholder">Tampal kunci API Gemini anda</string>
     <string name="settings_api_key_save">Simpan kunci Gemini</string>
     <string name="settings_api_key_clear">Kosongkan kunci Gemini yang tersimpan</string>
@@ -607,6 +608,14 @@ vs "kemungkinan", "padam" vs "hapus").
     <string name="settings_display_palette_rainbow_description">Garis carta merah jambu, oren, dan hijau dengan kad keyakinan Material teal/merah. Lalai.</string>
     <string name="settings_display_palette_highlighter">Stabilo</string>
     <string name="settings_display_palette_highlighter_description">Garis carta magenta, kuning, dan biru kehijauan — seperti coretan stabilo di muka surat. Sekilas pandang ternyata berbeza daripada \"Pelangi\"; tema cerah menggunakan varian yang lebih gelap untuk kebolehbacaan. Selamat untuk buta warna merah-hijau.</string>
+    <string name="settings_display_home_layout_title">Susun atur skrin utama</string>
+    <string name="settings_display_home_layout_description">Seret pemegang untuk menyusun semula cara bahagian ini muncul pada skrin utama.</string>
+    <string name="settings_display_home_layout_drag">Seret untuk menyusun semula %1$s</string>
+    <string name="settings_display_home_section_outfit">Pakaian</string>
+    <string name="settings_display_home_section_conditions">Keadaan</string>
+    <string name="settings_display_home_section_confidence">Keyakinan</string>
+    <string name="settings_display_home_section_insight">Ramalan</string>
+    <string name="settings_display_home_section_charts">Carta</string>
     <string name="settings_unit_auto">Auto</string>
     <string name="today_cloud_range">Awan %1$d–%2$d%%</string>
     <string name="today_confidence_precip_spread">Model tidak bersetuju tentang hujan (Δ %1$.0f%% merentasi %2$d model)</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -279,6 +279,7 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrike)").
     <string name="settings_tts_device_header">Stemmer i lav kvalitet, innebygd i telefonen din.</string>
     <string name="settings_api_key_status_set">En Gemini-nøkkel er satt opp.</string>
     <string name="settings_api_key_status_unset">Ingen Gemini-nøkkel satt opp. Hent en på aistudio.google.com for å bruke Gemini-stemmer.</string>
+    <string name="settings_api_key_status_unset_shared">Valgfritt — lim inn din egen nøkkel. Hent en gratis på aistudio.google.com</string>
     <string name="settings_api_key_placeholder">Lim inn Gemini API-nøkkel her</string>
     <string name="settings_api_key_save">Lagre Gemini-nøkkel</string>
     <string name="settings_api_key_clear">Slett lagret Gemini-nøkkel</string>
@@ -630,6 +631,14 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrike)").
     <string name="settings_display_palette_rainbow_description">Rosa, oransje og grønne diagramlinjer med Material teal/røde tillitskort. Standard.</string>
     <string name="settings_display_palette_highlighter">Markeringspenn</string>
     <string name="settings_display_palette_highlighter_description">Magenta, gule og cyan grafikklinjer — som markeringspenner på siden. Ved første øyekast synlig forskjellig fra \"Regnbue\"; det lyse temaet bruker dypere varianter for lesbarhet. Trygg ved rød-grønn fargeblindhet.</string>
+    <string name="settings_display_home_layout_title">Oppsett for startskjerm</string>
+    <string name="settings_display_home_layout_description">Dra i håndtakene for å endre rekkefølgen disse seksjonene vises i på startskjermen.</string>
+    <string name="settings_display_home_layout_drag">Dra for å endre rekkefølgen på %1$s</string>
+    <string name="settings_display_home_section_outfit">Antrekk</string>
+    <string name="settings_display_home_section_conditions">Forhold</string>
+    <string name="settings_display_home_section_confidence">Pålitelighet</string>
+    <string name="settings_display_home_section_insight">Værmelding</string>
+    <string name="settings_display_home_section_charts">Diagrammer</string>
     <string name="settings_unit_auto">Auto</string>
     <string name="today_cloud_range">Skydekke %1$d\u2013%2$d%%</string>
     <string name="today_confidence_precip_spread">Modellene er uenige om nedbør (Δ %1$.0f%% på tvers av %2$d modeller)</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -244,6 +244,7 @@ the displayed label localizes.
     <string name="settings_api_key_gemini_label">Gemini</string>
     <string name="settings_api_key_status_set">Er is een Gemini-sleutel ingesteld.</string>
     <string name="settings_api_key_status_unset">Geen Gemini-sleutel ingesteld. Haal er een op via aistudio.google.com om Gemini-stemmen te gebruiken.</string>
+    <string name="settings_api_key_status_unset_shared">Optioneel — plak je eigen sleutel. Haal er gratis een op via aistudio.google.com</string>
     <string name="settings_api_key_placeholder">Plak hier je Gemini-API-sleutel</string>
     <string name="settings_api_key_save">Gemini-sleutel opslaan</string>
     <string name="settings_api_key_clear">Opgeslagen Gemini-sleutel wissen</string>
@@ -677,6 +678,14 @@ the displayed label localizes.
     <string name="settings_display_palette_rainbow_description">Roze, oranje en groene grafieklijnen met Material teal/rode betrouwbaarheidskaarten. De standaard.</string>
     <string name="settings_display_palette_highlighter">Markeerstift</string>
     <string name="settings_display_palette_highlighter_description">Magenta, gele en cyaan grafieklijnen — als markeerstift op de pagina. Op het eerste gezicht zichtbaar anders dan \"Regenboog\"; het lichte thema gebruikt diepere varianten voor leesbaarheid. Veilig bij rood-groen kleurenblindheid.</string>
+    <string name="settings_display_home_layout_title">Indeling van startscherm</string>
+    <string name="settings_display_home_layout_description">Sleep aan de handgrepen om de volgorde van deze secties op het startscherm te wijzigen.</string>
+    <string name="settings_display_home_layout_drag">Sleep om %1$s opnieuw te ordenen</string>
+    <string name="settings_display_home_section_outfit">Outfit</string>
+    <string name="settings_display_home_section_conditions">Omstandigheden</string>
+    <string name="settings_display_home_section_confidence">Betrouwbaarheid</string>
+    <string name="settings_display_home_section_insight">Voorspelling</string>
+    <string name="settings_display_home_section_charts">Grafieken</string>
     <string name="settings_unit_auto">Auto</string>
     <string name="today_cloud_range">Bewolking %1$d\u2013%2$d%%</string>
     <string name="today_confidence_precip_spread">Modellen het niet eens over neerslag (Δ %1$.0f%% over %2$d modellen)</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -244,6 +244,7 @@ is unchanged; only the displayed label localizes.
     <string name="settings_api_key_gemini_label">Gemini</string>
     <string name="settings_api_key_status_set">Klucz Gemini jest skonfigurowany.</string>
     <string name="settings_api_key_status_unset">Brak klucza Gemini. Pobierz go na stronie aistudio.google.com, aby korzystać z głosów Gemini.</string>
+    <string name="settings_api_key_status_unset_shared">Opcjonalnie — wklej własny klucz. Zdobądź go za darmo na aistudio.google.com</string>
     <string name="settings_api_key_placeholder">Wklej tutaj klucz API Gemini</string>
     <string name="settings_api_key_save">Zapisz klucz Gemini</string>
     <string name="settings_api_key_clear">Usuń zapisany klucz Gemini</string>
@@ -675,6 +676,14 @@ is unchanged; only the displayed label localizes.
     <string name="settings_display_palette_rainbow_description">Różowe, pomarańczowe i zielone linie wykresów z turkusowo/czerwonymi kartami pewności Material. Domyślna.</string>
     <string name="settings_display_palette_highlighter">Zakreślacz</string>
     <string name="settings_display_palette_highlighter_description">Magentowe, żółte i cyjanowe linie wykresu — jak ślad zakreślacza na stronie. Na pierwszy rzut oka widocznie inne niż \"Tęcza\"; jasny motyw używa głębszych wariantów dla czytelności. Bezpieczne przy daltonizmie czerwono-zielonym.</string>
+    <string name="settings_display_home_layout_title">Układ ekranu głównego</string>
+    <string name="settings_display_home_layout_description">Przeciągaj uchwyty, aby zmienić kolejność wyświetlania tych sekcji na ekranie głównym.</string>
+    <string name="settings_display_home_layout_drag">Przeciągnij, aby zmienić kolejność: %1$s</string>
+    <string name="settings_display_home_section_outfit">Outfit</string>
+    <string name="settings_display_home_section_conditions">Warunki</string>
+    <string name="settings_display_home_section_confidence">Pewność</string>
+    <string name="settings_display_home_section_insight">Prognoza</string>
+    <string name="settings_display_home_section_charts">Wykresy</string>
     <string name="settings_unit_auto">Auto</string>
     <string name="today_cloud_range">Zachmurzenie %1$d\u2013%2$d%%</string>
     <string name="today_confidence_precip_spread">Modele nie zgadzają się co do opadów (Δ %1$.0f%% dla %2$d modeli)</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -269,6 +269,7 @@ zh-CN) is unchanged; only the displayed label localizes.
 
     <string name="settings_api_key_status_set">Uma chave Gemini está configurada.</string>
     <string name="settings_api_key_status_unset">Nenhuma chave Gemini configurada. Obtenha uma em aistudio.google.com para usar vozes Gemini.</string>
+    <string name="settings_api_key_status_unset_shared">Opcional — cole sua própria chave. Obtenha uma grátis em aistudio.google.com</string>
     <string name="settings_api_key_placeholder">Cole sua chave API Gemini</string>
     <string name="settings_api_key_save">Salvar chave Gemini</string>
     <string name="settings_api_key_clear">Apagar chave Gemini salva</string>
@@ -716,6 +717,14 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_display_palette_rainbow_description">Linhas de gráfico rosa, laranja e verde com cartões de confiança Material verde-azulado/vermelho. O padrão.</string>
     <string name="settings_display_palette_highlighter">Marca-texto</string>
     <string name="settings_display_palette_highlighter_description">Linhas de gráfico magenta, amarelas e ciano — como marcadores fluorescentes na página. Visivelmente diferentes de \"Arco-íris\" à primeira vista; o tema claro usa variantes mais escuras para legibilidade. Seguro para daltonismo vermelho-verde.</string>
+    <string name="settings_display_home_layout_title">Layout da tela inicial</string>
+    <string name="settings_display_home_layout_description">Arraste as alças para reordenar como essas seções aparecem na tela inicial.</string>
+    <string name="settings_display_home_layout_drag">Arraste para reordenar %1$s</string>
+    <string name="settings_display_home_section_outfit">Look</string>
+    <string name="settings_display_home_section_conditions">Condições</string>
+    <string name="settings_display_home_section_confidence">Confiança</string>
+    <string name="settings_display_home_section_insight">Previsão</string>
+    <string name="settings_display_home_section_charts">Gráficos</string>
     <string name="settings_unit_auto">Auto</string>
     <string name="today_cloud_range">Nuvens %1$d\u2013%2$d%%</string>
     <string name="today_confidence_precip_spread">Os modelos discordam sobre chuva (Δ %1$.0f%% em %2$d modelos)</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -278,6 +278,7 @@ they diverge from BR ("Polonês" → "Polaco", "Holandês" →
 
     <string name="settings_api_key_status_set">Está configurada uma chave Gemini.</string>
     <string name="settings_api_key_status_unset">Nenhuma chave Gemini configurada. Obtém uma em aistudio.google.com para utilizar vozes Gemini.</string>
+    <string name="settings_api_key_status_unset_shared">Opcional — cola a tua própria chave. Obtém uma grátis em aistudio.google.com</string>
     <string name="settings_api_key_placeholder">Cola a tua chave API Gemini</string>
     <string name="settings_api_key_save">Guardar chave Gemini</string>
     <string name="settings_api_key_clear">Apagar chave Gemini guardada</string>
@@ -758,6 +759,14 @@ they diverge from BR ("Polonês" → "Polaco", "Holandês" →
     <string name="settings_display_palette_rainbow_description">Linhas de gráfico rosa, cor-de-laranja e verde com cartões de confiança Material verde-azulado/vermelho. A predefinição.</string>
     <string name="settings_display_palette_highlighter">Marcador</string>
     <string name="settings_display_palette_highlighter_description">Linhas de gráfico magenta, amarelas e ciano — como marcadores fluorescentes na página. Visivelmente diferentes do \"Arco-íris\" à primeira vista; o tema claro usa variantes mais escuras para legibilidade. Seguro para daltonismo vermelho-verde.</string>
+    <string name="settings_display_home_layout_title">Esquema do ecrã inicial</string>
+    <string name="settings_display_home_layout_description">Arrasta as pegas para reordenar como estas secções aparecem no ecrã inicial.</string>
+    <string name="settings_display_home_layout_drag">Arrasta para reordenar %1$s</string>
+    <string name="settings_display_home_section_outfit">Visual</string>
+    <string name="settings_display_home_section_conditions">Condições</string>
+    <string name="settings_display_home_section_confidence">Confiança</string>
+    <string name="settings_display_home_section_insight">Previsão</string>
+    <string name="settings_display_home_section_charts">Gráficos</string>
     <string name="settings_unit_auto">Auto</string>
     <string name="today_cloud_range">Nuvens %1$d\u2013%2$d%%</string>
     <string name="today_confidence_precip_spread">Os modelos discordam sobre chuva (Δ %1$.0f%% em %2$d modelos)</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -316,6 +316,7 @@ surfaces fall back to default English (matching values-pl / values-uk).
     <string name="settings_tts_device_header">Voci de calitate scăzută integrate în telefonul tău.</string>
     <string name="settings_api_key_status_set">O cheie Gemini este configurată.</string>
     <string name="settings_api_key_status_unset">Obține o cheie API gratuită la aistudio.google.com</string>
+    <string name="settings_api_key_status_unset_shared">Opțional — lipește-ți propria cheie. Obține una gratuit la aistudio.google.com</string>
     <string name="settings_api_key_placeholder">Lipește cheia ta API Gemini</string>
     <string name="settings_api_key_save">Salvează cheia Gemini</string>
     <string name="settings_api_key_clear">Șterge cheia Gemini salvată</string>
@@ -604,6 +605,14 @@ surfaces fall back to default English (matching values-pl / values-uk).
     <string name="settings_display_palette_rainbow_description">Linii de grafic roz, portocaliu și verde cu carduri de încredere Material teal/roșu. Implicit.</string>
     <string name="settings_display_palette_highlighter">Marker</string>
     <string name="settings_display_palette_highlighter_description">Linii de grafic magenta, galben și cyan — ca urma unui marker pe pagină. Vizibil diferite față de \"Curcubeu\" de la prima privire; tema deschisă folosește variante mai închise pentru lizibilitate. Sigure în cazul daltonismului roșu-verde.</string>
+    <string name="settings_display_home_layout_title">Aspectul ecranului principal</string>
+    <string name="settings_display_home_layout_description">Trage de mânere pentru a reordona modul în care apar aceste secțiuni pe ecranul principal.</string>
+    <string name="settings_display_home_layout_drag">Trage pentru a reordona %1$s</string>
+    <string name="settings_display_home_section_outfit">Ținută</string>
+    <string name="settings_display_home_section_conditions">Condiții</string>
+    <string name="settings_display_home_section_confidence">Încredere</string>
+    <string name="settings_display_home_section_insight">Prognoză</string>
+    <string name="settings_display_home_section_charts">Grafice</string>
     <string name="settings_unit_auto">Auto</string>
     <string name="today_cloud_range">Nori %1$d–%2$d%%</string>
     <string name="today_confidence_precip_spread">Modelele nu sunt de acord cu privire la ploaie (Δ %1$.0f%% pe %2$d modele)</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -320,6 +320,7 @@ only the displayed label localizes.
 
     <string name="settings_api_key_status_set">Ключ Gemini настроен.</string>
     <string name="settings_api_key_status_unset">Ключ Gemini не настроен. Получи на aistudio.google.com, чтобы использовать голоса Gemini.</string>
+    <string name="settings_api_key_status_unset_shared">Необязательно — вставь свой ключ. Получи бесплатно на aistudio.google.com</string>
     <string name="settings_api_key_placeholder">Вставь свой ключ API Gemini</string>
     <string name="settings_api_key_save">Сохранить ключ Gemini</string>
     <string name="settings_api_key_clear">Удалить сохранённый ключ Gemini</string>
@@ -686,6 +687,14 @@ only the displayed label localizes.
     <string name="settings_display_palette_rainbow_description">Розовые, оранжевые и зелёные линии графиков с карточками достоверности Material бирюзово/красного цвета. По умолчанию.</string>
     <string name="settings_display_palette_highlighter">Маркер</string>
     <string name="settings_display_palette_highlighter_description">Линии графика пурпурного, жёлтого и голубого цвета — как след маркера на странице. Заметно отличаются от \"Радуги\" с первого взгляда; светлая тема использует более глубокие оттенки для читаемости. Безопасно при красно-зелёной цветовой слепоте.</string>
+    <string name="settings_display_home_layout_title">Макет главного экрана</string>
+    <string name="settings_display_home_layout_description">Перетаскивай маркеры, чтобы изменить порядок отображения этих разделов на главном экране.</string>
+    <string name="settings_display_home_layout_drag">Перетащите, чтобы изменить порядок: %1$s</string>
+    <string name="settings_display_home_section_outfit">Образ</string>
+    <string name="settings_display_home_section_conditions">Условия</string>
+    <string name="settings_display_home_section_confidence">Достоверность</string>
+    <string name="settings_display_home_section_insight">Прогноз</string>
+    <string name="settings_display_home_section_charts">Графики</string>
     <string name="settings_unit_auto">Авто</string>
     <string name="today_cloud_range">Облачность %1$d\u2013%2$d%%</string>
     <string name="today_confidence_precip_spread">Модели расходятся во мнении о дожде (Δ %1$.0f%% по %2$d моделям)</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -284,6 +284,7 @@ What is NOT overridden, by design:
     <string name="settings_tts_device_header">Hlasy v nízkej kvalite zabudované v tvojom telefóne.</string>
     <string name="settings_api_key_status_set">Gemini kľúč je nastavený.</string>
     <string name="settings_api_key_status_unset">Žiadny Gemini kľúč nie je nastavený. Získaj ho na aistudio.google.com pre používanie hlasov Gemini.</string>
+    <string name="settings_api_key_status_unset_shared">Voliteľné — vlož vlastný kľúč. Získaj ho zdarma na aistudio.google.com</string>
     <string name="settings_api_key_placeholder">Vlož sem Gemini API kľúč</string>
     <string name="settings_api_key_save">Uložiť Gemini kľúč</string>
     <string name="settings_api_key_clear">Vymazať uložený Gemini kľúč</string>
@@ -632,6 +633,14 @@ What is NOT overridden, by design:
     <string name="settings_display_palette_rainbow_description">Ružové, oranžové a zelené čiary grafov s tyrkysovými/červenými kartami istoty Material. Predvolené.</string>
     <string name="settings_display_palette_highlighter">Zvýrazňovač</string>
     <string name="settings_display_palette_highlighter_description">Purpurové, žlté a azúrové čiary grafu — ako stopa zvýrazňovača na stránke. Na prvý pohľad viditeľne odlišné od \"Dúhy\"; svetlá téma používa hlbšie varianty pre čitateľnosť. Bezpečné pri červeno-zelenej farboslepote.</string>
+    <string name="settings_display_home_layout_title">Rozloženie domovskej obrazovky</string>
+    <string name="settings_display_home_layout_description">Potiahnutím úchytiek zmeň poradie, v ktorom sa tieto sekcie zobrazujú na domovskej obrazovke.</string>
+    <string name="settings_display_home_layout_drag">Potiahnutím zmeň poradie: %1$s</string>
+    <string name="settings_display_home_section_outfit">Outfit</string>
+    <string name="settings_display_home_section_conditions">Podmienky</string>
+    <string name="settings_display_home_section_confidence">Spoľahlivosť</string>
+    <string name="settings_display_home_section_insight">Predpoveď</string>
+    <string name="settings_display_home_section_charts">Grafy</string>
     <string name="settings_unit_auto">Auto</string>
     <string name="today_cloud_range">Oblačnosť %1$d–%2$d%%</string>
     <string name="today_confidence_precip_spread">Modely sa nezhodujú na zrážkach (Δ %1$.0f%% pre %2$d modely)</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -328,6 +328,7 @@ informal "ti"-form throughout, mirroring the Croatian / Serbian pass.
     <string name="settings_tts_device_header">Glasovi v nizki kakovosti, vgrajeni v tvoj telefon.</string>
     <string name="settings_api_key_status_set">Gemini-ključ je nastavljen.</string>
     <string name="settings_api_key_status_unset">Pridobi brezplačen API-ključ na aistudio.google.com</string>
+    <string name="settings_api_key_status_unset_shared">Izbirno — prilepi svoj ključ. Pridobi brezplačnega na aistudio.google.com</string>
     <string name="settings_api_key_placeholder">Prilepi svoj Gemini API-ključ</string>
     <string name="settings_api_key_save">Shrani Gemini-ključ</string>
     <string name="settings_api_key_clear">Izbriši shranjeni Gemini-ključ</string>
@@ -613,6 +614,14 @@ informal "ti"-form throughout, mirroring the Croatian / Serbian pass.
     <string name="settings_display_palette_rainbow_description">Rožnate, oranžne in zelene linije grafikonov z modrozeleno/rdečimi karticami zanesljivosti Material. Privzeto.</string>
     <string name="settings_display_palette_highlighter">Označevalec</string>
     <string name="settings_display_palette_highlighter_description">Magenta, rumene in cijan črte grafa — kot sled označevalca na strani. Na prvi pogled vidno drugačne od \"Mavrice\"; svetla tema uporablja temnejše različice za boljšo berljivost. Varno za rdeče-zeleno barvno slepoto.</string>
+    <string name="settings_display_home_layout_title">Postavitev začetnega zaslona</string>
+    <string name="settings_display_home_layout_description">Povleci ročice, da spremeniš vrstni red prikaza teh razdelkov na začetnem zaslonu.</string>
+    <string name="settings_display_home_layout_drag">Povleci za spremembo vrstnega reda: %1$s</string>
+    <string name="settings_display_home_section_outfit">Obleka</string>
+    <string name="settings_display_home_section_conditions">Pogoji</string>
+    <string name="settings_display_home_section_confidence">Zanesljivost</string>
+    <string name="settings_display_home_section_insight">Napoved</string>
+    <string name="settings_display_home_section_charts">Grafi</string>
     <string name="settings_unit_auto">Samodejno</string>
     <string name="today_cloud_range">Oblačnost %1$d–%2$d%%</string>
     <string name="today_confidence_precip_spread">Modeli se ne strinjajo glede dežja (Δ %1$.0f%% za %2$d modele)</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -279,6 +279,7 @@ native names for all locales (e.g. "Tyska (Tyskland)", "Franska (Frankrike)").
     <string name="settings_tts_device_header">Röster i låg kvalitet inbyggda i din telefon.</string>
     <string name="settings_api_key_status_set">En Gemini-nyckel är inställd.</string>
     <string name="settings_api_key_status_unset">Ingen Gemini-nyckel inställd. Hämta en på aistudio.google.com för att använda Gemini-röster.</string>
+    <string name="settings_api_key_status_unset_shared">Valfritt — klistra in din egen nyckel. Hämta en gratis på aistudio.google.com</string>
     <string name="settings_api_key_placeholder">Klistra in Gemini API-nyckel här</string>
     <string name="settings_api_key_save">Spara Gemini-nyckel</string>
     <string name="settings_api_key_clear">Ta bort sparad Gemini-nyckel</string>
@@ -630,6 +631,14 @@ native names for all locales (e.g. "Tyska (Tyskland)", "Franska (Frankrike)").
     <string name="settings_display_palette_rainbow_description">Rosa, orange och gröna diagramlinjer med Material teal/röda konfidenskort. Standardalternativet.</string>
     <string name="settings_display_palette_highlighter">Överstrykningspenna</string>
     <string name="settings_display_palette_highlighter_description">Magenta, gula och cyanfärgade diagramlinjer — som en överstrykningspenna på sidan. Vid en första anblick synligt annorlunda än \"Regnbåge\"; det ljusa temat använder djupare varianter för läsbarhet. Säker vid röd-grön färgblindhet.</string>
+    <string name="settings_display_home_layout_title">Layout för startskärm</string>
+    <string name="settings_display_home_layout_description">Dra i handtagen för att ändra ordningen som de här avsnitten visas i på startskärmen.</string>
+    <string name="settings_display_home_layout_drag">Dra för att ändra ordning på %1$s</string>
+    <string name="settings_display_home_section_outfit">Outfit</string>
+    <string name="settings_display_home_section_conditions">Förhållanden</string>
+    <string name="settings_display_home_section_confidence">Tillförlitlighet</string>
+    <string name="settings_display_home_section_insight">Prognos</string>
+    <string name="settings_display_home_section_charts">Diagram</string>
     <string name="settings_unit_auto">Auto</string>
     <string name="today_cloud_range">Molnighet %1$d\u2013%2$d%%</string>
     <string name="today_confidence_precip_spread">Modellerna är oeniga om regn (Δ %1$.0f%% för %2$d modeller)</string>

--- a/app/src/main/res/values-sw/strings.xml
+++ b/app/src/main/res/values-sw/strings.xml
@@ -421,6 +421,7 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="settings_tts_device_header">Sauti za ubora wa chini zilizojengwa kwenye simu yako.</string>
     <string name="settings_api_key_status_set">Ufunguo wa Gemini umewekwa.</string>
     <string name="settings_api_key_status_unset">Pata ufunguo wa API bure kwenye aistudio.google.com</string>
+    <string name="settings_api_key_status_unset_shared">Si lazima — bandika ufunguo wako mwenyewe. Pata bure kwenye aistudio.google.com</string>
     <string name="settings_api_key_placeholder">Bandika ufunguo wako wa Gemini API</string>
     <string name="settings_api_key_save">Hifadhi ufunguo wa Gemini</string>
     <string name="settings_api_key_clear">Futa ufunguo uliohifadhiwa wa Gemini</string>
@@ -459,6 +460,14 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="settings_display_palette_rainbow_description">Mistari ya chati ya rangi waridi, machungwa na kijani na kadi za imani za Material bluu-kijani/nyekundu. Chaguo-msingi.</string>
     <string name="settings_display_palette_highlighter">Highlighter</string>
     <string name="settings_display_palette_highlighter_description">Mistari ya chati ya magenta, manjano, na cyan — kama alama ya kalamu ya kuangaza kwenye karatasi. Inatofautiana wazi na \"Upinde wa Mvua\" kwa mtazamo wa kwanza; mandhari nyepesi hutumia rangi za kina zaidi kwa kusomeka kwa urahisi. Salama kwa upofu wa rangi nyekundu-kijani.</string>
+    <string name="settings_display_home_layout_title">Mpangilio wa skrini ya mwanzo</string>
+    <string name="settings_display_home_layout_description">Buruta vishikizo ili kupanga upya jinsi sehemu hizi zinavyoonekana kwenye skrini ya mwanzo.</string>
+    <string name="settings_display_home_layout_drag">Buruta ili kupanga upya %1$s</string>
+    <string name="settings_display_home_section_outfit">Mavazi</string>
+    <string name="settings_display_home_section_conditions">Hali</string>
+    <string name="settings_display_home_section_confidence">Uhakika</string>
+    <string name="settings_display_home_section_insight">Utabiri</string>
+    <string name="settings_display_home_section_charts">Chati</string>
     <string name="settings_display_palette_accessible">Inayopatikana</string>
     <string name="settings_display_palette_accessible_description">Paleti inayotokana na Okabe-Ito, iliyoundwa kubaki inayoweza kutofautishwa katika hali za upofu wa rangi. Kadi za imani hutumia bluu ya anga, ya wastani na ya amber badala ya bluu-kijani, ya wastani na nyekundu.</string>
     <string name="today_cloud_range">Mawingu %1$d–%2$d%%</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -316,6 +316,7 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="settings_tts_device_header">เสียงคุณภาพต่ำที่มีมาในเครื่องของคุณ</string>
     <string name="settings_api_key_status_set">กำหนดค่า Gemini key แล้ว</string>
     <string name="settings_api_key_status_unset">รับ API key ฟรีที่ aistudio.google.com</string>
+    <string name="settings_api_key_status_unset_shared">ไม่บังคับ — วางคีย์ของคุณเอง รับฟรีที่ aistudio.google.com</string>
     <string name="settings_api_key_placeholder">วาง Gemini API key ของคุณ</string>
     <string name="settings_api_key_save">บันทึก Gemini key</string>
     <string name="settings_api_key_clear">ล้าง Gemini key ที่บันทึกไว้</string>
@@ -601,6 +602,14 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="settings_display_palette_rainbow_description">เส้นกราฟสีชมพู ส้ม และเขียว พร้อมการ์ดความเชื่อมั่น Material สีเขียวน้ำทะเล/แดง ค่าเริ่มต้น</string>
     <string name="settings_display_palette_highlighter">ปากกาเน้น</string>
     <string name="settings_display_palette_highlighter_description">เส้นกราฟสีบานเย็น เหลือง และฟ้าคราม — เหมือนรอยปากกาเน้นข้อความบนหน้ากระดาษ มองปุ๊บก็เห็นต่างจาก \"สีรุ้ง\" ทันที ธีมสว่างใช้โทนเข้มขึ้นเพื่อให้อ่านง่าย ปลอดภัยกับตาบอดสีแดง-เขียว</string>
+    <string name="settings_display_home_layout_title">เลย์เอาต์หน้าหลัก</string>
+    <string name="settings_display_home_layout_description">ลากที่จับเพื่อจัดลำดับการแสดงส่วนเหล่านี้บนหน้าหลักใหม่</string>
+    <string name="settings_display_home_layout_drag">ลากเพื่อจัดลำดับ %1$s ใหม่</string>
+    <string name="settings_display_home_section_outfit">ชุดแต่งกาย</string>
+    <string name="settings_display_home_section_conditions">สภาพอากาศ</string>
+    <string name="settings_display_home_section_confidence">ความเชื่อมั่น</string>
+    <string name="settings_display_home_section_insight">พยากรณ์</string>
+    <string name="settings_display_home_section_charts">กราฟ</string>
     <string name="settings_unit_auto">อัตโนมัติ</string>
     <string name="today_cloud_range">เมฆ %1$d–%2$d%%</string>
     <string name="today_confidence_precip_spread">แบบจำลองไม่ตรงกันเรื่องฝน (Δ %1$.0f%% ใน %2$d แบบจำลอง)</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -221,6 +221,7 @@ displayed label localizes.
 
     <string name="settings_api_key_status_set">Bir Gemini anahtarı ayarlandı.</string>
     <string name="settings_api_key_status_unset">Gemini anahtarı ayarlanmadı. Gemini seslerini kullanmak için aistudio.google.com adresinden bir anahtar alın.</string>
+    <string name="settings_api_key_status_unset_shared">İsteğe bağlı — kendi anahtarını yapıştır. aistudio.google.com adresinden ücretsiz al</string>
     <string name="settings_api_key_placeholder">Gemini API anahtarını buraya yapıştırın</string>
     <string name="settings_api_key_save">Gemini anahtarını kaydet</string>
     <string name="settings_api_key_clear">Kayıtlı Gemini anahtarını sil</string>
@@ -610,6 +611,14 @@ displayed label localizes.
     <string name="settings_display_palette_rainbow_description">Pembe, turuncu ve yeşil grafik çizgileri ile Material teal/kırmızı güven kartları. Varsayılan.</string>
     <string name="settings_display_palette_highlighter">Fosforlu kalem</string>
     <string name="settings_display_palette_highlighter_description">Macenta, sarı ve camgöbeği renkli grafik çizgileri — sayfa üzerindeki fosforlu kalem izi gibi. \"Gökkuşağı\"ndan ilk bakışta belirgin biçimde farklı; açık tema okunabilirlik için daha koyu varyantlar kullanır. Kırmızı-yeşil renk körlüğünde güvenli.</string>
+    <string name="settings_display_home_layout_title">Ana ekran düzeni</string>
+    <string name="settings_display_home_layout_description">Bu bölümlerin ana ekranda görünme sırasını değiştirmek için tutamaçları sürükleyin.</string>
+    <string name="settings_display_home_layout_drag">%1$s sırasını değiştirmek için sürükleyin</string>
+    <string name="settings_display_home_section_outfit">Kıyafet</string>
+    <string name="settings_display_home_section_conditions">Koşullar</string>
+    <string name="settings_display_home_section_confidence">Güvenilirlik</string>
+    <string name="settings_display_home_section_insight">Tahmin</string>
+    <string name="settings_display_home_section_charts">Grafikler</string>
     <string name="settings_unit_auto">Otomatik</string>
     <string name="today_cloud_range">Bulutluluk %1$d\u2013%2$d%%</string>
     <string name="today_confidence_precip_spread">Modeller yağmur konusunda hemfikir değil (Δ %1$.0f%%, %2$d model arasında)</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -286,6 +286,7 @@ only the displayed label localizes.
     <string name="settings_tts_device_header">Голоси низької якості, вбудовані у твій телефон.</string>
     <string name="settings_api_key_status_set">Ключ Gemini налаштовано.</string>
     <string name="settings_api_key_status_unset">Отримайте безкоштовний ключ API на aistudio.google.com</string>
+    <string name="settings_api_key_status_unset_shared">Необов\'язково — встав свій ключ. Отримай безкоштовно на aistudio.google.com</string>
     <string name="settings_api_key_placeholder">Вставте ваш ключ API Gemini</string>
     <string name="settings_api_key_save">Зберегти ключ Gemini</string>
     <string name="settings_api_key_clear">Видалити збережений ключ Gemini</string>
@@ -629,6 +630,14 @@ only the displayed label localizes.
     <string name="settings_display_palette_rainbow_description">Рожеві, помаранчеві та зелені лінії графіків з картками достовірності Material бірюзово/червоного. За замовчуванням.</string>
     <string name="settings_display_palette_highlighter">Маркер</string>
     <string name="settings_display_palette_highlighter_description">Лінії графіка пурпурового, жовтого та блакитного кольорів — наче слід маркера на сторінці. Помітно відрізняються від \"Райдуги\" з першого погляду; світла тема використовує глибші варіанти для читабельності. Безпечно для червоно-зеленої цветової сліпоти.</string>
+    <string name="settings_display_home_layout_title">Макет головного екрана</string>
+    <string name="settings_display_home_layout_description">Перетягуй маркери, щоб змінити порядок відображення цих розділів на головному екрані.</string>
+    <string name="settings_display_home_layout_drag">Перетягни, щоб змінити порядок: %1$s</string>
+    <string name="settings_display_home_section_outfit">Вбрання</string>
+    <string name="settings_display_home_section_conditions">Умови</string>
+    <string name="settings_display_home_section_confidence">Достовірність</string>
+    <string name="settings_display_home_section_insight">Прогноз</string>
+    <string name="settings_display_home_section_charts">Графіки</string>
     <string name="settings_unit_auto">Авто</string>
     <string name="today_cloud_range">Хмарність %1$d–%2$d%%</string>
     <string name="today_confidence_precip_spread">Моделі розходяться щодо дощу (Δ %1$.0f%% по %2$d моделях)</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -331,6 +331,7 @@ Skipped intentionally: app_name (brand), insight_time_am/pm/midnight/noon
     <string name="settings_tts_device_header">Giọng nói chất lượng thấp tích hợp sẵn trong điện thoại của bạn.</string>
     <string name="settings_api_key_status_set">Đã cài đặt khóa Gemini.</string>
     <string name="settings_api_key_status_unset">Lấy khóa API miễn phí tại aistudio.google.com</string>
+    <string name="settings_api_key_status_unset_shared">Tùy chọn — dán khóa của riêng bạn. Lấy miễn phí tại aistudio.google.com</string>
     <string name="settings_api_key_placeholder">Dán khóa API Gemini của bạn</string>
     <string name="settings_api_key_save">Lưu khóa Gemini</string>
     <string name="settings_api_key_clear">Xóa khóa Gemini đã lưu</string>
@@ -662,6 +663,14 @@ Skipped intentionally: app_name (brand), insight_time_am/pm/midnight/noon
     <string name="settings_display_palette_rainbow_description">Đường biểu đồ màu hồng, cam và xanh lá với thẻ độ tin cậy Material xanh mòng két/đỏ. Mặc định.</string>
     <string name="settings_display_palette_highlighter">Bút dạ quang</string>
     <string name="settings_display_palette_highlighter_description">Các đường biểu đồ màu hồng cánh sen, vàng và xanh lơ — như nét bút dạ quang trên trang giấy. Khác biệt rõ rệt so với \"Cầu vồng\" ngay từ cái nhìn đầu tiên; chủ đề sáng dùng các biến thể đậm hơn để dễ đọc. An toàn cho người mù màu đỏ-xanh lục.</string>
+    <string name="settings_display_home_layout_title">Bố cục màn hình chính</string>
+    <string name="settings_display_home_layout_description">Kéo các tay cầm để sắp xếp lại thứ tự hiển thị của các phần này trên màn hình chính.</string>
+    <string name="settings_display_home_layout_drag">Kéo để sắp xếp lại %1$s</string>
+    <string name="settings_display_home_section_outfit">Trang phục</string>
+    <string name="settings_display_home_section_conditions">Điều kiện</string>
+    <string name="settings_display_home_section_confidence">Độ tin cậy</string>
+    <string name="settings_display_home_section_insight">Dự báo</string>
+    <string name="settings_display_home_section_charts">Biểu đồ</string>
     <string name="settings_unit_auto">Tự động</string>
     <string name="today_cloud_range">Mây %1$d–%2$d%%</string>
     <string name="today_confidence_precip_spread">Các mô hình không đồng thuận về mưa (Δ %1$.0f%% trên %2$d mô hình)</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -260,6 +260,7 @@ label localizes.
 
     <string name="settings_api_key_status_set">已配置 Gemini 密钥。</string>
     <string name="settings_api_key_status_unset">未配置 Gemini 密钥。可在 aistudio.google.com 获取一个，以使用 Gemini 语音。</string>
+    <string name="settings_api_key_status_unset_shared">可选 — 粘贴你自己的密钥。可在 aistudio.google.com 免费获取</string>
     <string name="settings_api_key_placeholder">粘贴你的 Gemini API 密钥</string>
     <string name="settings_api_key_save">保存 Gemini 密钥</string>
     <string name="settings_api_key_clear">清除已保存的 Gemini 密钥</string>
@@ -730,6 +731,14 @@ label localizes.
     <string name="settings_display_palette_rainbow_description">粉红、橙色和绿色图表线条，以及 Material 青色/红色置信度卡片。默认设置。</string>
     <string name="settings_display_palette_highlighter">荧光笔</string>
     <string name="settings_display_palette_highlighter_description">洋红、黄色和青色的图表线条——像是用荧光笔在纸上画过。一眼就能与\"彩虹\"区分；浅色主题使用更深的变体以提高可读性。对红绿色盲安全。</string>
+    <string name="settings_display_home_layout_title">主屏幕布局</string>
+    <string name="settings_display_home_layout_description">拖动手柄可重新排列这些版块在主屏幕上的显示顺序。</string>
+    <string name="settings_display_home_layout_drag">拖动以重新排列%1$s</string>
+    <string name="settings_display_home_section_outfit">穿搭</string>
+    <string name="settings_display_home_section_conditions">天气状况</string>
+    <string name="settings_display_home_section_confidence">可信度</string>
+    <string name="settings_display_home_section_insight">预报</string>
+    <string name="settings_display_home_section_charts">图表</string>
     <string name="settings_unit_auto">自动</string>
     <string name="today_cloud_range">云量 %1$d〜%2$d%%</string>
     <string name="today_confidence_precip_spread">各模型对降水意见不一（Δ %1$.0f%%，共 %2$d 个模型）</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -250,6 +250,7 @@ label localises.
 
     <string name="settings_api_key_status_set">已設定 Gemini 金鑰。</string>
     <string name="settings_api_key_status_unset">尚未設定 Gemini 金鑰。可在 aistudio.google.com 取得一組，以使用 Gemini 語音。</string>
+    <string name="settings_api_key_status_unset_shared">選用 — 貼上你自己的金鑰。可在 aistudio.google.com 免費取得</string>
     <string name="settings_api_key_placeholder">貼上你的 Gemini API 金鑰</string>
     <string name="settings_api_key_save">儲存 Gemini 金鑰</string>
     <string name="settings_api_key_clear">清除已儲存的 Gemini 金鑰</string>
@@ -745,6 +746,14 @@ label localises.
     <string name="settings_display_palette_rainbow_description">粉紅、橙色和綠色圖表線條，以及 Material 青色/紅色信心卡片。預設值。</string>
     <string name="settings_display_palette_highlighter">螢光筆</string>
     <string name="settings_display_palette_highlighter_description">洋紅、黃色和青色的圖表線條——彷彿用螢光筆在紙上劃過。一眼即可與「彩虹」區分；淺色佈景使用更深的變體以提升可讀性。對紅綠色盲安全。</string>
+    <string name="settings_display_home_layout_title">主畫面版面配置</string>
+    <string name="settings_display_home_layout_description">拖曳控點即可重新排列這些區塊在主畫面上的顯示順序。</string>
+    <string name="settings_display_home_layout_drag">拖曳以重新排列%1$s</string>
+    <string name="settings_display_home_section_outfit">穿搭</string>
+    <string name="settings_display_home_section_conditions">天氣狀況</string>
+    <string name="settings_display_home_section_confidence">可信度</string>
+    <string name="settings_display_home_section_insight">預報</string>
+    <string name="settings_display_home_section_charts">圖表</string>
     <string name="settings_unit_auto">自動</string>
     <string name="today_cloud_range">雲量 %1$d〜%2$d%%</string>
     <string name="today_confidence_precip_spread">各模型對降水意見不一（Δ %1$.0f%%，共 %2$d 個模型）</string>


### PR DESCRIPTION
## What

Translates the nine strings that were added with the home-screen layout reordering feature (and the shared-key hint) but until now existed only in the base `en-US` locale. They're now filled in across all **44 full-translation locales**:

- `settings_api_key_status_unset_shared` — *"Optional — paste your own key. Get one free at aistudio.google.com"*
- `settings_display_home_layout_title` / `_description` / `_drag`
- `settings_display_home_section_outfit` / `_conditions` / `_confidence` / `_insight` / `_charts`

## Notes

- **Terminology consistency:** section names reuse each locale's existing app vocabulary — the Outfit (`widget_label`) and Conditions (`conditions_widget_label`) labels, and the feels-like chart label — so the layout list matches the rest of the UI.
- **Region overrides untouched:** the partial override locales (`de-rAT`, `de-rCH`, `en-rAU`, `en-rCA`, `en-rGB`, `en-rZA`, `es-rMX`, `fr-rCA`) are intentionally left alone — they inherit these strings from their parent locale via Android's API 24+ locale fallback.
- **Placeholders & escaping:** the `%1$s` placeholder in `_drag` is preserved in all 44 files, and apostrophes are escaped (`\'`) per Android resource rules.

## Privacy

UI strings only — no change to what leaves the device.

## Test plan

- `./gradlew :app:assembleDebug` — passes (resources compile across all locales).
- Verified every full-translation locale now contains all base string keys, all files are well-formed XML, and the `%1$s` placeholder survives in every `_drag` string.

---
_Generated by [Claude Code](https://claude.ai/code/session_019hSawWyLVXVNCf7RE5TTJj)_