### PR TITLE
Trim deep framework frames from the crash report

### DIFF
--- a/app/src/main/kotlin/app/clothescast/diag/DiagLog.kt
+++ b/app/src/main/kotlin/app/clothescast/diag/DiagLog.kt
@@ -4,8 +4,6 @@ import android.content.Context
 import android.util.Log
 import app.clothescast.BuildConfig
 import java.io.File
-import java.io.PrintWriter
-import java.io.StringWriter
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -39,14 +37,28 @@ object DiagLog {
 
     /**
      * How many `at …` frames per Throwable in the chain to keep in diag-log
-     * entries. The full trace still goes to `last-crash.txt` for uncaught
-     * exceptions, so the snapshot just needs the call site. One frame
-     * trims a typical `MqttPublisher: publish failed` block from 13 lines
-     * to 4 — the cause chain text + the top frame for each link is enough
-     * to read on its own, and the ten-deep Netty / executor noise that
-     * otherwise dominates the 300-line buffer goes away.
+     * entries. A fuller (but still capped) trace goes to `last-crash.txt` for
+     * uncaught exceptions — see [CRASH_STACK_FRAMES] — so the snapshot just
+     * needs the call site. One frame trims a typical `MqttPublisher: publish
+     * failed` block from 13 lines to 4 — the cause chain text + the top frame
+     * for each link is enough to read on its own, and the ten-deep Netty /
+     * executor noise that otherwise dominates the 300-line buffer goes away.
      */
     private const val COMPACT_STACK_FRAMES = 1
+
+    /**
+     * How many `at …` frames per Throwable to keep in `last-crash.txt`. More
+     * generous than [COMPACT_STACK_FRAMES] because the crash file is the
+     * primary post-mortem record (it's only written once, so it isn't fighting
+     * the snapshot budget) — but still capped, because the deep tail of an
+     * uncaught exception is platform plumbing (Looper / Choreographer /
+     * ActivityThread, Compose recomposition internals) that tells you nothing,
+     * and in a release build every frame is obfuscated to single letters so
+     * there's no app frame worth digging out from the bottom. Keep the throw
+     * site and its immediate callers; drop the rest with a `... N more`
+     * summary so it's clear frames were elided rather than missing.
+     */
+    private const val CRASH_STACK_FRAMES = 12
 
     /**
      * Snapshot-side defence against an individual log entry dominating the
@@ -223,7 +235,10 @@ object DiagLog {
 
     private fun writeCrashLog(thread: Thread, throwable: Throwable) {
         val file = crashFileProvider?.invoke() ?: return
-        val stack = stackTraceString(throwable)
+        // Filter the deep, useless tail (platform plumbing, obfuscated frames)
+        // out of the crash record too — keep the exception, its cause chain,
+        // and the top [CRASH_STACK_FRAMES] frames, not the full ~80-frame dump.
+        val stack = compactStackTraceString(throwable, maxFrames = CRASH_STACK_FRAMES, omittedSummary = true)
         val header = "Uncaught exception on thread \"${thread.name}\""
         // log() with a non-null throwable blocks on the executor, so by the
         // time snapshot() runs below the crash header line is on disk and
@@ -241,19 +256,18 @@ object DiagLog {
         unacknowledgedCrashState.value = true
     }
 
-    private fun stackTraceString(t: Throwable): String =
-        StringWriter().also { sw -> PrintWriter(sw).use { t.printStackTrace(it) } }
-            .toString().trimEnd()
-
     /**
      * Formats [t] like [Throwable.printStackTrace] but keeps only the top
-     * [maxFrames] frames per Throwable in the cause chain. The dropped
-     * deeper frames aren't summarised — the omitted-count line `... N more`
-     * is intentionally absent so each Throwable costs `1 + maxFrames` lines
-     * flat, maximising how much pre-failure history fits in the 300-line
-     * snapshot budget. The full trace still goes to `last-crash.txt` via
-     * [writeCrashLog] for uncaught exceptions, so post-mortem debugging
-     * loses nothing.
+     * [maxFrames] frames per Throwable in the cause chain, dropping the deep
+     * tail of platform / framework plumbing that isn't useful for triage.
+     *
+     * By default the dropped frames aren't summarised, so each Throwable costs
+     * a flat `1 + maxFrames` lines — that maximises how much pre-failure
+     * history fits in the 300-line snapshot budget, where this runs for every
+     * logged throwable. Pass [omittedSummary] `true` (as [writeCrashLog] does
+     * for `last-crash.txt`, which isn't budget-constrained) to append a
+     * `\t... N more` line per Throwable so a reader can tell frames were
+     * elided rather than absent.
      *
      * Cyclic cause chains (`a.cause = b; b.cause = a`) are guarded via an
      * identity set so a pathological Throwable can't spin the calling
@@ -263,7 +277,11 @@ object DiagLog {
      * aren't silently lost; their frames are intentionally dropped to
      * keep the budget tight. Visible for tests.
      */
-    internal fun compactStackTraceString(t: Throwable, maxFrames: Int = COMPACT_STACK_FRAMES): String {
+    internal fun compactStackTraceString(
+        t: Throwable,
+        maxFrames: Int = COMPACT_STACK_FRAMES,
+        omittedSummary: Boolean = false,
+    ): String {
         val sb = StringBuilder()
         val seen = java.util.IdentityHashMap<Throwable, Boolean>()
         var current: Throwable? = t
@@ -281,6 +299,9 @@ object DiagLog {
             val keep = minOf(maxFrames, frames.size)
             for (i in 0 until keep) {
                 sb.append('\n').append("\tat ").append(frames[i])
+            }
+            if (omittedSummary && frames.size > keep) {
+                sb.append('\n').append("\t... ").append(frames.size - keep).append(" more")
             }
             for (suppressed in current.suppressed) {
                 sb.append('\n').append("\tSuppressed: ").append(suppressed.javaClass.name)

--- a/app/src/test/kotlin/app/clothescast/diag/DiagLogTest.kt
+++ b/app/src/test/kotlin/app/clothescast/diag/DiagLogTest.kt
@@ -131,6 +131,25 @@ class DiagLogTest {
     }
 
     @Test
+    fun `compactStackTraceString summarises dropped frames when asked`() {
+        // The crash-file path (writeCrashLog) opts into the omitted-count line
+        // so a reader can tell the deep tail was elided, not absent — while the
+        // snapshot path keeps the default silent truncation above.
+        val t = makeWithStackDepth(10)
+        val s = DiagLog.compactStackTraceString(t, maxFrames = 3, omittedSummary = true)
+        s.lines().count { it.startsWith("\tat ") } shouldBe 3
+        s shouldContain "\t... 7 more"
+    }
+
+    @Test
+    fun `compactStackTraceString omits the summary when frames fit under the cap`() {
+        val t = makeWithStackDepth(2)
+        val s = DiagLog.compactStackTraceString(t, maxFrames = 5, omittedSummary = true)
+        s.lines().count { it.startsWith("\tat ") } shouldBe 2
+        s shouldNotContain "more"
+    }
+
+    @Test
     fun `compactStackTraceString preserves the cause chain with a 'Caused by' prefix`() {
         val cause = RuntimeException("inner")
         val outer = IllegalStateException("outer", cause)


### PR DESCRIPTION
## Problem

The bug report you shared is "full of shit like exception stack traces." The culprit is the **"Last crash (from previous run)"** section, which is read verbatim from `last-crash.txt`. That file was written with the full `Throwable.printStackTrace()` — for the serializer-not-found crash, that's ~80 frames of `Looper` / `Choreographer` / `ActivityThread` / Compose recomposition plumbing, every one obfuscated to single letters in the release build. None of it helps triage, and it buries the line that does (the exception + its top frames).

Per your clarification: **keep the exceptions, just filter out the deep stack stuff that isn't useful.**

## Fix

The diag-log breadcrumb path already trims stacks via `compactStackTraceString` (1 frame). The crash file simply wasn't going through it. This routes `writeCrashLog` through the same formatter with:

- a more generous **12-frame cap** (`CRASH_STACK_FRAMES`) — the crash file is written once and isn't competing for the snapshot's 300-line budget, so it can afford the throw site plus a dozen callers, but still drops the deep platform tail;
- an opt-in **`... N more`** summary per Throwable so a reader can tell frames were elided rather than missing.

The exception type, message, and full **cause chain** are all preserved. Removes the now-unused `stackTraceString` / `PrintWriter` / `StringWriter` path.

This is purely a diagnostic-output change — it doesn't touch the underlying serializer crash, and nothing new leaves the device (the crash file is on-device, surfaced only in user-initiated bug reports).

## Tests

`DiagLogTest` gains coverage for the new `omittedSummary` behavior (summary appears when frames are dropped; absent when the trace fits under the cap). Existing snapshot/compaction tests still cover the default silent-truncation path.

`./gradlew :app:testDebugUnitTest --tests "app.clothescast.diag.*"` passes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QDUyDNFpPm5cGDsJ6ihoSU)_