### PR TITLE
Match the Speech setup sheet description to the Voice engine row

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -119,16 +119,49 @@ export const tts = onRequest(
       });
     } catch (err) {
       logger.error("Upstream Gemini fetch failed", { code: errorCode(err) });
-      releaseDailySlot(installId, today).catch((rbErr) => {
-        logger.warn("Quota rollback after fetch failure failed", {
-          code: errorCode(rbErr),
-        });
-      });
+      // Await the rollback before responding: Cloud Functions for
+      // Firebase v2 doesn't guarantee work continues after res.send(),
+      // and a missed rollback here burns one of the user's daily
+      // slots on a network blip. Only roll back when we actually
+      // reserved a slot — when reserveDailySlot failed open
+      // (reservation.reserved === false), no counter was incremented
+      // and a decrement would silently steal from a future slot once
+      // Firestore recovers.
+      if (reservation.reserved) {
+        try {
+          await releaseDailySlot(installId, today);
+        } catch (rbErr) {
+          logger.warn("Quota rollback after fetch failure failed", {
+            code: errorCode(rbErr),
+          });
+        }
+      }
       res.status(502).json({ error: "upstream_unreachable" });
       return;
     }
 
-    const upstreamBody = await upstream.arrayBuffer();
+    // The fetch() resolves once headers are in; the body read can
+    // still throw if the upstream connection drops between header and
+    // body. Treat that like a fetch-throw — release the slot before
+    // responding so a transient network blip doesn't burn one of the
+    // user's daily slots.
+    let upstreamBody: ArrayBuffer;
+    try {
+      upstreamBody = await upstream.arrayBuffer();
+    } catch (err) {
+      logger.error("Upstream Gemini body read failed", { code: errorCode(err) });
+      if (reservation.reserved) {
+        try {
+          await releaseDailySlot(installId, today);
+        } catch (rbErr) {
+          logger.warn("Quota rollback after body read failure failed", {
+            code: errorCode(rbErr),
+          });
+        }
+      }
+      res.status(502).json({ error: "upstream_unreachable" });
+      return;
+    }
 
     if (upstream.ok) {
       if (reservation.reserved) {
@@ -142,12 +175,20 @@ export const tts = onRequest(
       });
       // Only successful syntheses should burn quota. Roll back the
       // reservation; clients can retry within the same day without
-      // penalty.
-      releaseDailySlot(installId, today).catch((err) => {
-        logger.warn("Quota rollback after upstream non-success failed", {
-          code: errorCode(err),
-        });
-      });
+      // penalty. Awaited (not fire-and-forget) so the work doesn't
+      // get cut off by the response below — see the fetch-throw
+      // path above for the rationale. Gated on `reservation.reserved`
+      // for the same reason: a failed-open reservation has nothing
+      // to undo.
+      if (reservation.reserved) {
+        try {
+          await releaseDailySlot(installId, today);
+        } catch (err) {
+          logger.warn("Quota rollback after upstream non-success failed", {
+            code: errorCode(err),
+          });
+        }
+      }
     }
 
     res.status(upstream.status);


### PR DESCRIPTION
## Summary

Two changes shipping together on the same branch — the speech-setup sheet text alignment plus three robustness fixes in the rate-limit proxy that landed via #884 (all surfaced by Codex review on this PR).

### 1. Match the Speech setup sheet description to the Voice engine row

The first-run **Set up spoken ClothesCasts** bottom sheet had its own top-level description, distinct from the matching paragraph on the Voice settings page:

| Surface | Before |
| --- | --- |
| Bottom sheet | "Choose how your ClothesCast is spoken aloud. Use the free device voice, or add a Gemini API key for high-quality voices." |
| Voice settings | "Choose between low-quality on-device speech and high-quality online speech." |

Two paragraphs saying close-but-not-identical things at two entry points to the same setting reads as inconsistency. The Voice settings copy is cleaner — it names the actual trade-off (quality vs. on-device) without foreshadowing the API-key step the per-engine block below already covers — so the sheet reuses it and `speech_setup_description` is dropped from base `values/` and every translated `values-*/strings.xml`.

The per-engine description blocks already shared `settings_api_key_gemini_header` / `settings_tts_device_header` between the two surfaces; this aligns the top-level paragraph the same way.

Three Roborazzi snapshots (`settings_speech_setup_{device,gemini,smart_home}.png`) regenerate. Embedded as before/after in a follow-up comment per the snapshots-in-mobile rule.

### 2. Tighten the TTS quota rollback path (follow-up to #884)

Three Codex findings on the rate-limit code shipped in #884:

- **Cloud Functions v2 doesn't guarantee fire-and-forget work runs after `res.send()`** — the `.catch()`-style rollback could silently fail, burning a daily slot on a Gemini hiccup. Switched to `await releaseDailySlot(...)` inside a try/catch on every failure path.
- **`releaseDailySlot` was called even when `reserveDailySlot` had failed open** — if Firestore recovered between the failed reservation and the rollback, the decrement would steal from an unrelated successful slot for the same install/day. Every rollback is now gated on `reservation.reserved`.
- **`await upstream.arrayBuffer()` was unguarded** — `fetch()` resolves on headers, so a Gemini connection that drops mid-body would skip both rollback branches and pin `dayCount` even though the client got nothing. Body read is now wrapped in its own try/catch with the same `reservation.reserved`-gated awaited rollback, returning 502 like the fetch-throw path.

Adds at most one Firestore RTT to the error-response latency — same one we already pay on the success path for the reservation read. No behavior change on the happy path or when Firestore + the upstream are healthy.

## Test plan

- [x] `./gradlew :app:testDebugUnitTest` — green, three speech-setup snapshots regenerated.
- [x] `npx tsc --noEmit` in `functions/` — clean.
- [ ] Visual check of the sheet at first-launch (Schedule → Speak channel toggle) shows the new description.
- [ ] Manual emulator round-trip per `functions/README.md`:
  - 5 successful curls return audio.
  - Force a Gemini 500 to verify the rollback completes before the response.
  - Pause the Firestore emulator mid-reservation to verify the fail-open path leaves `dayCount` untouched on rollback.
  - Truncate the upstream body mid-stream to verify the body-read rollback path.

https://claude.ai/code/session_01S3sFgaMM3ofs5hb88RGhM6