### PR TITLE
Fix release build break from a newline in the TTS proxy URL secret

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -49,6 +49,22 @@ fun git(vararg args: String): String {
     return output
 }
 
+/**
+ * Escapes a string so it's safe to drop verbatim between the quotes of a
+ * `buildConfigField("String", …)` value — i.e. a Java string literal in the
+ * generated BuildConfig.java. Handles backslash (first, so the others aren't
+ * double-escaped), quote, and the control characters a value pasted with a
+ * trailing line break would otherwise inject: an unescaped newline splits the
+ * literal across two lines and the compiler reports an "unclosed string
+ * literal". Returns the escaped body only — callers add the surrounding quotes.
+ */
+fun String.asJavaStringLiteralBody(): String = this
+    .replace("\\", "\\\\")
+    .replace("\"", "\\\"")
+    .replace("\n", "\\n")
+    .replace("\r", "\\r")
+    .replace("\t", "\\t")
+
 // versionCode: total commit count on the current branch. Monotonically increases,
 // reproducible (same commit -> same number), required by Firebase App Distribution
 // and the Play Store. CI must use `actions/checkout@v4` with `fetch-depth: 0` —
@@ -132,7 +148,7 @@ android {
         // Defined for all variants so the composable compiles regardless of
         // which buildType is active.
         buildConfigField("boolean", "IS_LOCAL_BUILD", (!isCiBuild).toString())
-        buildConfigField("String", "GIT_BRANCH", "\"${gitBranch.replace("\"", "\\\"")}\"")
+        buildConfigField("String", "GIT_BRANCH", "\"${gitBranch.asJavaStringLiteralBody()}\"")
         buildConfigField("String", "GIT_SHA", "\"$gitShortSha\"")
         buildConfigField("boolean", "GIT_DIRTY", gitDirty.toString())
         buildConfigField("long", "BUILD_TIMESTAMP_MS", "${buildTimestampMs}L")
@@ -156,18 +172,18 @@ android {
         // Full setup walkthrough — Firebase project, App Check, function
         // deploy, where to get this URL — lives in docs/gemini-tts-proxy.md.
         val geminiProxyUrl: String = run {
-            val fromEnv = System.getenv("GEMINI_PROXY_URL")?.takeIf { it.isNotBlank() }
+            val fromEnv = System.getenv("GEMINI_PROXY_URL")?.trim()?.takeIf { it.isNotBlank() }
             val fromLocalProps: String? = rootProject.file("local.properties")
                 .takeIf { it.exists() }
                 ?.let { file ->
                     val props = Properties()
                     file.inputStream().use { props.load(it) }
-                    props.getProperty("geminiProxyUrl")?.takeIf { it.isNotBlank() }
+                    props.getProperty("geminiProxyUrl")?.trim()?.takeIf { it.isNotBlank() }
                 }
-            val fromGradleProps = providers.gradleProperty("geminiProxyUrl").orNull?.takeIf { it.isNotBlank() }
+            val fromGradleProps = providers.gradleProperty("geminiProxyUrl").orNull?.trim()?.takeIf { it.isNotBlank() }
             fromEnv ?: fromLocalProps ?: fromGradleProps ?: ""
         }
-        buildConfigField("String", "GEMINI_PROXY_URL", "\"${geminiProxyUrl.replace("\"", "\\\"")}\"")
+        buildConfigField("String", "GEMINI_PROXY_URL", "\"${geminiProxyUrl.asJavaStringLiteralBody()}\"")
     }
 
     signingConfigs {


### PR DESCRIPTION
## Problem

The Play release build was failing in `:app:compileReleaseJavaWithJavac`:

```
BuildConfig.java:15: error: unclosed string literal
  public static final String GEMINI_PROXY_URL = "***
BuildConfig.java:16: error: unclosed string literal
      ";
```

The `GEMINI_PROXY_URL` CI secret carried a **trailing newline** (easy to introduce when pasting a secret value). The `buildConfigField` escaping only escaped double quotes — so the newline landed inside the generated Java string literal and split it across two lines, producing an unclosed-string compile error. The `***` in the log is just GitHub masking the secret; the real culprit is the embedded newline.

## Fix

1. **Trim on read.** Each source (env var, `local.properties`, Gradle property) is now `.trim()`-ed before the blank check. A proxy URL never has meaningful leading/trailing whitespace, so this strips the stray newline at the source.
2. **Escape properly via a shared helper.** New `String.asJavaStringLiteralBody()` escapes backslash (first), quote, newline, carriage return, and tab — so no control character can break the generated `BuildConfig.java`. Both `GEMINI_PROXY_URL` and `GIT_BRANCH` now route through it.

`GIT_BRANCH` shared the old quote-only escaping. Git ref names can't carry a newline or backslash (`git check-ref-format` forbids them), so it couldn't break today — but routing both String fields through one helper keeps them consistent and defensive. `GIT_SHA` (`[0-9a-f]+`) and the numeric/boolean fields need no escaping.

## Test plan

Reproduced the failure and verified the fix by building release with a deliberately newline-terminated secret:

```
GEMINI_PROXY_URL=$'https://example.cloudfunctions.net/tts\n' \
  ./gradlew :app:compileReleaseJavaWithJavac
# BUILD SUCCESSFUL
```

Generated output is now clean for both fields:

```java
public static final String GEMINI_PROXY_URL = "https://example.cloudfunctions.net/tts";
public static final String GIT_BRANCH = "claude/buildconfig-string-literal-H8Amo";
```

## Privacy

No change to what crosses the device boundary — only how build-time values are sanitized before they're baked into `BuildConfig`.

https://claude.ai/code/session_015VJCcnD8MoRGwh3HdbduSV