### PR TITLE
Use an anonymous ID for the free voice's daily limit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -358,6 +358,19 @@ new rule the first time something bites you, not the third.
   rule is about the default English we author in base `values/` and in
   our commits, PRs, comments, and docs.
 
+- **Plain, honest voice in user-facing copy.** Write privacy
+  disclosures (`PRIVACY.md`), changelog / "What's new" bullets, settings
+  and UI strings, and docs the way you'd say them out loud — direct and
+  specific, no weasel words. If the app does something, name it plainly:
+  the free voice "signs in anonymously," not "has no accounts you sign
+  in to." Never hedge a true-but-narrow claim to imply something broader;
+  if a caveat matters, state it outright. Prefer the concrete term ("an
+  anonymous, random ID — no name, email, or password") over the vague
+  reassurance ("no data held about you"). Applies doubly to anything
+  describing what crosses the device boundary — see the Privacy section:
+  the reader should come away knowing exactly what happens, not
+  comfortably misled.
+
 ## Domain conventions
 
 - Clothes rules and outfit suggestions both look at *feels-like*

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -8,7 +8,10 @@ have over it.
 
 ## TL;DR
 
-- ClothesCast has no user accounts and no backend that holds your data.
+- ClothesCast has no login and no personal account. The free online
+  voice signs in **anonymously** — a random ID with no name, email, or
+  password — purely to count your daily usage; no backend holds personal
+  data about you.
   The app may send anonymous crash reports and aggregate usage analytics
   to a third-party reporting service so the developer can fix bugs and
   decide which features to keep — see "Analytics and crash reporting"
@@ -240,29 +243,43 @@ Online TTS (the Gemini voice) has two paths.
   The function holds a Google Gemini API key paid for by the developer,
   forwards your request to Google, and returns the audio. It does not
   log the spoken prose or the audio response.
+  - **First use — an anonymous identifier from Google.** Before the
+    first shared-key request, the app signs in anonymously to Firebase
+    Authentication (a Google service). This is **not** a user account:
+    there is no name, email, password, or sign-in screen. It returns a
+    random, app-generated identifier — just a string of letters and
+    digits, e.g. `a1B2c3…` — that is **not** linked to your name,
+    email, phone number, device, or location, and is never used for
+    advertising or tracking across apps. It exists only so the proxy
+    can count how many free clips this app install has used today. On
+    the shared path your data is handled by ClothesCast and Google
+    servers.
   - **Sent on each request:** the rendered insight sentence (the same
-    text the phone speaks), a per-install pseudonymous identifier
-    (your Firebase Installation ID), a Firebase App Check attestation
-    token (proves the request came from a genuine install — verified
-    in-memory and discarded), and the model name. No coordinates,
-    calendar metadata as fields, account, advertising ID, or device
-    identifiers are added.
-  - **Stored:** a Firestore document at `installs/<your install ID>`
+    text the phone speaks), the anonymous identifier above (carried as
+    a signed Firebase ID token in the `Authorization` header, which the
+    proxy verifies to read the identifier — the client cannot forge or
+    swap it), a Firebase App Check attestation token (proves the request
+    came from a genuine install — verified in-memory and discarded), and
+    the model name. No coordinates, calendar metadata as fields, user
+    account, advertising ID, or hardware / device identifiers are added.
+  - **Stored:** a Firestore document at `quota/<your anonymous ID>`
     with a first-use timestamp, a successful-call counter, and a
-    most-recent-use timestamp. Used now for capacity planning and
-    later to enforce a free-trial limit (planned: 30 calls or 30 days
-    from first use). Not used for advertising or cross-app tracking.
-    Your install ID changes if you reinstall the app or use "Clear
-    data" in Android Settings.
+    most-recent-use timestamp, capped at 5 successful clips per UTC day.
+    Used to enforce the free daily limit and for capacity planning. Not
+    used for advertising or cross-app tracking. Your anonymous
+    identifier resets if you reinstall the app or use "Clear data" in
+    Android Settings.
   - **Cloud Functions infrastructure logs** (operated by Google Cloud,
     not configured by us) record the client IP and HTTP status of
-    each call. We do not associate the IP with your install ID.
+    each call. We do not associate the IP with your anonymous
+    identifier.
 - **Your own key (BYOK).** Open Settings → Voice → Gemini API key and
   paste your own key. Keys are stored on your device, encrypted at
   rest using a key sealed by the Android Keystore. With your own key
   set, online TTS requests skip the ClothesCast proxy entirely and
-  go straight to Google — no install ID, no App Check token, no proxy
-  involvement. Your key is never shared with us or any third party.
+  go straight to Google — no anonymous identifier, no App Check token,
+  no anonymous sign-in, no proxy involvement. Your key is never shared
+  with us or any third party.
 
 ## Third-party services
 
@@ -273,16 +290,17 @@ policies apply to anything they receive:
 |---|---|---|
 | [Open-Meteo](https://open-meteo.com/en/terms) | Coarse coordinate (forecast); your typed search text when you use a location picker (first-run onboarding and Settings) | Always for forecast; only when you search for a place name |
 | Google's geocoding service (via Android's [`Geocoder`](https://developer.android.com/reference/android/location/Geocoder) on Play Services devices), governed by [Google's Privacy Policy](https://policies.google.com/privacy) | Coarse coordinate | Always on Play Services devices (city / country lookup for the Today header); skipped on AOSP devices |
-| ClothesCast TTS proxy (Cloud Function, ClothesCast-operated) | The short rendered insight sentence, your Firebase Installation ID, a Firebase App Check token, and the Gemini model name | Online TTS with the shared key (default) |
+| Google Firebase Authentication | An App Check attestation, to mint and refresh an anonymous identifier (no name, email, or password) | First use of the shared-key path, then periodic token refreshes |
+| ClothesCast TTS proxy (Cloud Function, ClothesCast-operated) | The short rendered insight sentence, an anonymous app identifier (as a signed Firebase ID token), a Firebase App Check token, and the Gemini model name | Online TTS with the shared key (default) |
 | [Google Gemini API](https://ai.google.dev/gemini-api/terms) | The short rendered insight sentence (forwarded by the proxy, or sent directly when you use your own key) | Online TTS, either path |
 | Your self-hosted MQTT broker (e.g. Mosquitto inside Home Assistant) | The short rendered insight sentence, as a retained MQTT message | Only if you opt in to the Smart Home bridge and configure a broker |
 | Analytics / crash-reporting service (e.g. Firebase Crashlytics + Google Analytics for Firebase) | Aggregate usage events and crash diagnostics — see "Analytics and crash reporting" below for what's in and out | Possibly always, in all builds |
 
 These providers act as service providers fulfilling a single request and
 returning the result. When the ClothesCast TTS proxy is in the path, it
-adds the install ID and App Check token described above; when you use
-your own Gemini key, the request goes straight to Google and no install
-identifier is attached.
+adds the anonymous identifier and App Check token described above; when
+you use your own Gemini key, the request goes straight to Google and no
+anonymous identifier is attached.
 
 Note on Gemini API: request inputs are not retained for training by
 default. See the provider's policy linked above for the authoritative
@@ -290,7 +308,11 @@ terms.
 
 ## What we do _not_ collect
 
-- No accounts, no sign-in.
+- No user accounts and no personal sign-in — no name, email, password,
+  or login screen. (The free online-TTS path uses an anonymous,
+  randomly-generated identifier to count daily usage, described under
+  "Online TTS" above; it identifies an app install, not you, and carries
+  no personal information.)
 - No advertising identifiers, no ad networks, no ad targeting.
 - No precise GPS location.
 - No contacts, photos, microphone, or files.
@@ -436,6 +458,18 @@ email the address listed on the Play Store listing.
 
 ## Changelog
 
+- **2026-05-31** — Hardened the shared-key TTS identifier. The free
+  online-TTS path now identifies each install by an anonymous Firebase
+  Authentication identifier, verified on the server, instead of the
+  Firebase Installation ID the app previously sent in a header. This
+  stops a modified client from rotating the identifier to bypass the
+  daily free-clip limit. The identifier is still random and carries no
+  personal information; the daily counter moved from
+  `installs/<install ID>` to `quota/<anonymous ID>`. To obtain the
+  identifier the app now signs in anonymously to Firebase Authentication
+  (a Google service) — no name, email, or password, and no user-facing
+  account. See "Online TTS: shared key by default, your own key on
+  request" and the third-party services table above.
 - **2026-05-31** — Online TTS now has a shared-key default: when you
   haven't supplied your own Gemini API key, the spoken sentence is sent
   to a small Cloud Function operated by the developer, which forwards

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -432,16 +432,17 @@ dependencies {
     implementation(libs.firebase.analytics)
     implementation(libs.firebase.crashlytics)
     // App Check (Play Integrity in release, Debug provider in debug) +
-    // Installations: the TTS proxy gates on a valid App Check token and
-    // counts usage per Firebase Installation ID. Both no-op on builds
-    // assembled without google-services.json — FirebaseApp doesn't init,
-    // the planner falls back to BYOK semantics, and the rest of the app
-    // continues to assemble and run.
+    // anonymous Auth: the TTS proxy gates on a valid App Check token and
+    // counts usage per anonymous Firebase Authentication uid (verified
+    // server-side, so the client can't spoof its quota bucket). Both
+    // no-op on builds assembled without google-services.json — FirebaseApp
+    // doesn't init, the planner falls back to BYOK semantics, and the rest
+    // of the app continues to assemble and run.
     implementation(libs.firebase.appcheck.playintegrity)
     debugImplementation(libs.firebase.appcheck.debug)
-    implementation(libs.firebase.installations)
-    // `.await()` on the App Check token / Installations ID Tasks. Production
-    // (not test-only) because the planner runs in the main coroutine flow.
+    implementation(libs.firebase.auth)
+    // `.await()` on the App Check token / anonymous sign-in / ID token Tasks.
+    // Production (not test-only) because the planner runs in the main coroutine flow.
     implementation(libs.kotlinx.coroutines.play.services)
 
     testImplementation(platform("org.junit:junit-bom:5.11.3"))

--- a/app/src/main/kotlin/app/clothescast/data/AppCheckGeminiCallPlanner.kt
+++ b/app/src/main/kotlin/app/clothescast/data/AppCheckGeminiCallPlanner.kt
@@ -5,8 +5,10 @@ import app.clothescast.core.data.insight.GeminiCallPlan
 import app.clothescast.core.data.insight.GeminiCallPlanner
 import app.clothescast.core.data.insight.GeminiEndpoint
 import app.clothescast.core.data.insight.MissingApiKeyException
+import app.clothescast.diag.DiagLog
 import com.google.firebase.appcheck.FirebaseAppCheck
-import com.google.firebase.installations.FirebaseInstallations
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.FirebaseAuthInvalidUserException
 import kotlinx.coroutines.tasks.await
 
 /**
@@ -17,21 +19,26 @@ import kotlinx.coroutines.tasks.await
  *   The developer's proxy never sees the request.
  * - **No key set, proxy configured:** plan a SHARED call — to the
  *   developer-operated Cloud Function at [proxyBaseUrl], carrying a
- *   Firebase App Check attestation token (`X-Firebase-AppCheck`),
- *   the user's Firebase Installation ID (`X-Install-Id`), and the model
- *   name (`X-Gemini-Model`). The function holds the developer's Gemini
- *   key and forwards the call.
+ *   Firebase App Check attestation token (`X-Firebase-AppCheck`), an
+ *   anonymous Firebase Authentication ID token (`Authorization: Bearer
+ *   <idToken>`), and the model name (`X-Gemini-Model`). The function
+ *   holds the developer's Gemini key and forwards the call. Quota is
+ *   keyed server-side on the verified `uid` from the ID token rather
+ *   than a client-supplied header, so a modded client can't rotate an
+ *   identifier to evade the daily cap.
  * - **No key set and shared path disabled** ([sharedPathEnabled] is
  *   false — CI builds without `google-services.json`, or forks that
  *   haven't configured `GEMINI_PROXY_URL`): throw
  *   [MissingApiKeyException], same surface as before.
  *
- * On the SHARED path, App Check token and FID fetches can fail
- * legitimately (offline, Play Integrity unavailable). Those propagate as
- * the SDK's own exceptions — surfaced as the existing diagnostic Toast
- * via [app.clothescast.ui.settings.VoiceSettings]'s catch-all. We don't
- * map them to a dedicated app-side type until the trial-exhausted (429)
- * mapping lands; see `docs/TODO.md` "Enforce shared-key TTS trial limit".
+ * On the SHARED path, App Check token, anonymous sign-in, and ID token
+ * fetches can fail legitimately (offline, Play Integrity unavailable,
+ * Anonymous Auth provider not enabled in the Firebase project). Those
+ * propagate as the SDK's own exceptions — surfaced as the existing
+ * diagnostic Toast via [app.clothescast.ui.settings.VoiceSettings]'s
+ * catch-all. We don't map them to a dedicated app-side type until the
+ * trial-exhausted (429) mapping lands; see `docs/TODO.md` "Enforce
+ * shared-key TTS trial limit".
  */
 class AppCheckGeminiCallPlanner(
     private val secureKeyStore: SecureKeyStore,
@@ -39,7 +46,7 @@ class AppCheckGeminiCallPlanner(
     private val sharedPathEnabled: Boolean,
     private val model: String,
     private val appCheck: () -> FirebaseAppCheck = { FirebaseAppCheck.getInstance() },
-    private val installations: () -> FirebaseInstallations = { FirebaseInstallations.getInstance() },
+    private val auth: () -> FirebaseAuth = { FirebaseAuth.getInstance() },
 ) : GeminiCallPlanner {
 
     override suspend fun plan(): GeminiCallPlan {
@@ -81,15 +88,52 @@ class AppCheckGeminiCallPlanner(
             endpoint = endpoint,
             applyAuth = {
                 val appCheckToken = appCheck().getAppCheckToken(false).await().token
-                val installId = installations().id.await()
+                val idToken = anonymousIdToken()
                 it.headers.append("X-Firebase-AppCheck", appCheckToken)
-                it.headers.append("X-Install-Id", installId)
+                it.headers.append("Authorization", "Bearer $idToken")
                 it.headers.append("X-Gemini-Model", model)
             },
         )
     }
 
+    /**
+     * Fetches an ID token for the anonymous Firebase user, creating that
+     * user on first use. The `uid` inside the token is what the proxy keys
+     * its per-install daily quota on — minted and signed by Firebase Auth,
+     * so the client can't choose it. [com.google.firebase.auth.FirebaseUser.getIdToken]
+     * returns a cached token until it expires (~1 h) and refreshes
+     * transparently after that, so steady-state calls don't hit the network
+     * for a new token.
+     *
+     * If the cached anonymous account was deleted or disabled server-side
+     * — e.g. Firebase's optional inactive-anonymous-account cleanup ran
+     * while this install kept the user cached — the token refresh throws
+     * [FirebaseAuthInvalidUserException]. We recover by signing the stale
+     * user out and minting a fresh anonymous identity, rather than letting
+     * the install's free-voice path break permanently until app-data-clear.
+     * A fresh identity just means a fresh daily quota, which is the correct
+     * outcome for what is effectively a new install record.
+     */
+    private suspend fun anonymousIdToken(): String {
+        val firebaseAuth = auth()
+        firebaseAuth.currentUser?.let { existing ->
+            try {
+                return existing.getIdToken(false).await().token
+                    ?: error("Anonymous user returned no ID token")
+            } catch (e: FirebaseAuthInvalidUserException) {
+                DiagLog.w(TAG, "Cached anonymous user invalid; re-signing in", e)
+                firebaseAuth.signOut()
+            }
+        }
+        val user = firebaseAuth.signInAnonymously().await().user
+            ?: error("Anonymous sign-in returned no user")
+        return user.getIdToken(false).await().token
+            ?: error("Anonymous user returned no ID token")
+    }
+
     companion object {
+        private const val TAG = "GeminiCallPlanner"
+
         /**
          * Splits the configured proxy base URL into the host + single-segment
          * path prefix that `GeminiTtsClient` expects. The client builds the

--- a/core/data/src/main/kotlin/app/clothescast/core/data/insight/GeminiCallPlanner.kt
+++ b/core/data/src/main/kotlin/app/clothescast/core/data/insight/GeminiCallPlanner.kt
@@ -13,7 +13,7 @@ import io.ktor.client.request.HttpRequestBuilder
  *    `x-goog-api-key` via the plan's `applyAuth` callback.
  *  - the developer's Cloud Function proxy, constructed at the call site
  *    from `BuildConfig.GEMINI_PROXY_URL` in `:app`. App Check token +
- *    Firebase Installation ID travel in headers via `applyAuth`.
+ *    anonymous Firebase Auth ID token travel in headers via `applyAuth`.
  */
 data class GeminiEndpoint(
     val host: String,

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -269,14 +269,18 @@ Open work:
   TTS — a Today / Settings banner pointing at the BYOK flow would
   let users notice and resolve the cap without going hunting in the
   logs.
-- Bind the TTS proxy quota to a server-verified install identity
-  rather than the client-chosen `X-Install-Id` header. Today a
-  caller with a valid App Check token can rotate the header per
-  request and get a fresh `installs/<id>` doc each time, bypassing
-  the daily cap. The standard fix is to have the Android client send
-  the Firebase Installations *auth token* (a JWT issued for the FID)
-  and have the function call the Installations REST API to verify
-  and extract the FID before reserving a slot. Surfaced by Codex
-  review on #893.
+- [x] **Bind the TTS proxy quota to a server-verified identity**
+  rather than the client-chosen `X-Install-Id` header. Done: the
+  client now sends an anonymous Firebase Authentication ID token
+  (`Authorization: Bearer …`) and the function verifies it
+  (`getAuth().verifyIdToken`) and keys the daily quota on the
+  resulting `uid` (`quota/<uid>`). The earlier idea of verifying a
+  Firebase Installations *auth token* was dropped — there's no
+  documented way for a custom backend to verify one (the Installations
+  REST API only creates/deletes installations and generates tokens; no
+  verify/introspect method, and the Admin SDK has no installations-token
+  verifier). Requires Anonymous sign-in enabled and App Check enforced
+  on Authentication in the Firebase project. Surfaced by Codex review
+  on #893.
 - Google Home / alarm-clock-app integration.
 - Play Store submission. Sideload + FAD only for v1.

--- a/docs/gemini-tts-proxy.md
+++ b/docs/gemini-tts-proxy.md
@@ -12,7 +12,8 @@ Check verifies the request came from a genuine install of the app.
   key and forwards each TTS request to Google.
 - Users who paste their own key in Settings continue to bypass the
   function entirely and pay their own Gemini bill.
-- Per-install usage is counted in Firestore (`installs/<fid>`) and
+- Per-install usage is counted in Firestore (`quota/<uid>`, keyed on
+  the verified anonymous Firebase Auth uid) and
   capped at 5 successful syntheses per UTC day. Above the cap the
   function returns `429 daily_quota_exhausted`; the Android client
   surfaces a friendly "free TTS limit reached" message and the user
@@ -89,6 +90,22 @@ to your function region (step 5).
 - Once both are registered, click **Cloud Functions → Enforce**.
   Until you do this, the function still works but doesn't actually
   reject unsigned requests.
+
+Also enable anonymous sign-in and protect it with App Check — the
+function keys its per-install daily quota on the anonymous Firebase
+Auth `uid`, so the client can't spoof the quota bucket the way it
+could when the proxy trusted a header:
+
+- **Build → Authentication → Get started → Sign-in method →
+  Anonymous → Enable.** The app signs in anonymously to obtain the
+  ID token it sends to the proxy; no other provider is needed.
+- Back in **Build → App Check**, also click **Authentication →
+  Enforce**. This is what stops scripted anonymous-account farming
+  to mint fresh `uid`s and reset the daily cap. Without it, App Check
+  still gates the function but not account creation.
+- Optionally, under **Authentication → Settings → User account
+  management**, enable auto-deletion of anonymous accounts that have
+  been inactive for 30+ days so stale quota identities don't pile up.
 
 ### 5. Set up the function locally
 
@@ -184,8 +201,8 @@ End-to-end check after all the above:
 4. Filter Logcat for `GeminiTtsClient` (or the proxy hostname) and
    confirm the request hit your function URL, **not**
    `generativelanguage.googleapis.com`.
-5. In the Firebase console → Firestore → `installs` collection, you
-   should see a doc keyed by your Firebase Installation ID with
+5. In the Firebase console → Firestore → `quota` collection, you
+   should see a doc keyed by your anonymous Firebase Auth uid with
    `firstUseAt`, `count: 1`, `lastUseAt`, `dayKey: "YYYY-MM-DD"`,
    `dayCount: 1`.
 
@@ -193,7 +210,7 @@ Then paste a real Gemini key into Settings and Test Voice again:
 
 6. Same Logcat filter — this time the request should go straight to
    `generativelanguage.googleapis.com` with `x-goog-api-key` set, and
-   the Firestore `installs/<fid>` doc should **not** get a new
+   the Firestore `quota/<uid>` doc should **not** get a new
    increment (BYOK never touches the proxy).
 
 ## Running the function locally (emulator)
@@ -211,7 +228,7 @@ It prints local URLs like
 ```sh
 curl -i -X POST "http://127.0.0.1:5001/<projectId>/us-central1/tts" \
   -H "X-Firebase-AppCheck: <debug token>" \
-  -H "X-Install-Id: dev-test-install-001" \
+  -H "Authorization: Bearer <anonymous ID token>" \
   -H "X-Gemini-Model: gemini-2.5-flash-preview-tts" \
   -H "Content-Type: application/json" \
   -d '{ "contents":[{"parts":[{"text":"Hello"}]}],
@@ -232,13 +249,16 @@ but using one is closer to production behaviour.
   tier covers 50K reads + 20K writes/day. At 1000 users × 2 daily
   insights = ~60K invocations/month — well within free tier on the
   infrastructure side; the Gemini bill is the only one that scales.
-- **Limiting abuse**: App Check stops scrapers; a transactional
-  per-install cap of 5 successful syntheses per UTC day stops a
-  single legitimate install from melting the budget. Above the cap
-  the function returns `429 daily_quota_exhausted` with a
-  `resetAtUtc` timestamp; see `functions/README.md` → "Quota
-  enforcement" for the doc shape and the rollback-on-failure
-  semantics.
+- **Limiting abuse**: App Check stops scrapers and modded clients; a
+  transactional cap of 5 successful syntheses per UTC day, keyed on the
+  verified anonymous Auth `uid`, stops a single install from melting the
+  budget. Because the `uid` is minted and signed by Firebase Auth (not a
+  client-supplied header), a modified client can't rotate it to reset the
+  cap — provided App Check is enforced on Authentication (step 4) so it
+  can't farm fresh anonymous accounts either. Above the cap the function
+  returns `429 daily_quota_exhausted` with a `resetAtUtc` timestamp; see
+  `functions/README.md` → "Quota enforcement" for the doc shape and the
+  rollback-on-failure semantics.
 - **Rotating the Gemini key**: `firebase functions:secrets:set
   GEMINI_API_KEY` again, then redeploy. The function picks up the
   new value on cold start.

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,7 +1,7 @@
 rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
-    // The `installs/{fid}` collection is written exclusively by the `tts`
+    // The `quota/{uid}` collection is written exclusively by the `tts`
     // Cloud Function (via the Admin SDK, which bypasses rules). No client
     // — Android app, web, otherwise — has any read or write access.
     match /{document=**} {

--- a/functions/README.md
+++ b/functions/README.md
@@ -2,8 +2,9 @@
 
 Single function today: `tts` — the Gemini TTS proxy backing the Android
 app's shared-key path. Holds the developer's Gemini API key, verifies
-Firebase App Check on each request, counts usage per Firebase
-Installation ID in Firestore, and forwards to Gemini.
+Firebase App Check and an anonymous Firebase Authentication ID token on
+each request, counts usage per verified `uid` in Firestore, and forwards
+to Gemini.
 
 **Setup guide for the whole proxy (Firebase project, App Check,
 function deploy, Android wiring):**
@@ -26,12 +27,13 @@ npm run serve     # starts functions + firestore emulators, prints local URL
 ```
 
 Exercise the local endpoint with a debug App Check token (register it
-in the Firebase Console first):
+in the Firebase Console first) and an anonymous ID token (mint one from
+the Auth emulator, or sign in anonymously against the real project):
 
 ```sh
 curl -i -X POST "http://127.0.0.1:5001/<project-id>/us-central1/tts" \
   -H "X-Firebase-AppCheck: <debug token>" \
-  -H "X-Install-Id: dev-test-install-001" \
+  -H "Authorization: Bearer <anonymous ID token>" \
   -H "X-Gemini-Model: gemini-2.5-flash-preview-tts" \
   -H "Content-Type: application/json" \
   -d '{ "contents":[{"parts":[{"text":"Read the following: hello"}]}],
@@ -47,10 +49,12 @@ npm run deploy
 
 ## Quota enforcement
 
-Each install gets 5 successful syntheses per UTC calendar day. The
-reservation is transactional:
+Each install gets 5 successful syntheses per UTC calendar day, keyed on
+the anonymous Firebase Auth `uid` from the verified ID token (not a
+client-supplied header — a modded client can't pick its own bucket).
+The reservation is transactional:
 
-1. Pre-flight transaction reads `installs/<fid>`; if today's
+1. Pre-flight transaction reads `quota/<uid>`; if today's
    `dayCount` is already at 5, the request returns
    `429 { "error": "daily_quota_exhausted", "limit": 5,
    "resetAtUtc": "<next-UTC-midnight>" }` without calling Gemini.
@@ -70,7 +74,7 @@ today. Add your own Gemini key in Settings for unlimited use."
 Firestore document shape:
 
 ```
-installs/<fid> {
+quota/<uid> {
   firstUseAt: Timestamp,
   lastUseAt:  Timestamp,
   count:      number,   // lifetime
@@ -82,5 +86,5 @@ installs/<fid> {
 If Firestore is unreachable, the function **fails open** (forwards
 the call without recording it) so a backend hiccup doesn't deny
 service. The trade-off is that a sustained outage lets a single
-install exceed the daily cap — acceptable given how expensive
+uid exceed the daily cap — acceptable given how expensive
 Gemini TTS is relative to a Firestore read.

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -4,6 +4,7 @@ import { defineSecret } from "firebase-functions/params";
 import { logger } from "firebase-functions";
 import { initializeApp } from "firebase-admin/app";
 import { getAppCheck } from "firebase-admin/app-check";
+import { getAuth } from "firebase-admin/auth";
 import {
   FieldValue,
   getFirestore,
@@ -23,7 +24,7 @@ const ALLOWED_MODELS = new Set<string>(["gemini-2.5-flash-preview-tts"]);
 const GEMINI_HOST = "generativelanguage.googleapis.com";
 const GEMINI_API_VERSION = "v1beta";
 
-const INSTALLS_COLLECTION = "installs";
+const QUOTA_COLLECTION = "quota";
 
 // Per-install daily quota for the shared-key path. Counted by UTC calendar
 // day so the reset moment is global and unambiguous; the Android client's
@@ -57,9 +58,29 @@ export const tts = onRequest(
       return;
     }
 
-    const installId = headerValue(req.header("X-Install-Id"));
-    if (!installId || !/^[A-Za-z0-9_-]{1,128}$/.test(installId)) {
-      res.status(400).json({ error: "missing_or_invalid_install_id" });
+    // Quota is keyed on the Firebase Authentication uid pulled from a
+    // verified anonymous ID token — never a client-supplied header. The
+    // uid is minted and signed by Firebase Auth, so a modded client can't
+    // choose its own quota bucket the way it could when we trusted an
+    // `X-Install-Id` header: verifyIdToken rejects anything we didn't
+    // issue. App Check above already proves the caller is a genuine app
+    // build; enforcing App Check on Authentication in the console
+    // (Build → App Check → Authentication → Enforce) closes the last gap
+    // by stopping scripted anonymous-account farming to rotate the uid.
+    const authHeader = headerValue(req.header("Authorization"));
+    const idToken = authHeader?.startsWith("Bearer ")
+      ? authHeader.slice("Bearer ".length).trim()
+      : null;
+    if (!idToken) {
+      res.status(401).json({ error: "missing_auth_token" });
+      return;
+    }
+    let uid: string;
+    try {
+      uid = (await getAuth().verifyIdToken(idToken)).uid;
+    } catch (err) {
+      logger.warn("ID token verification failed", { code: errorCode(err) });
+      res.status(401).json({ error: "invalid_auth_token" });
       return;
     }
 
@@ -85,7 +106,7 @@ export const tts = onRequest(
     const today = utcDayKey(now);
     let reservation: Reservation;
     try {
-      reservation = await reserveDailySlot(installId, today);
+      reservation = await reserveDailySlot(uid, today);
     } catch (err) {
       logger.warn("Quota reservation failed; failing open", {
         code: errorCode(err),
@@ -129,7 +150,7 @@ export const tts = onRequest(
       // Firestore recovers.
       if (reservation.reserved) {
         try {
-          await releaseDailySlot(installId, today);
+          await releaseDailySlot(uid, today);
         } catch (rbErr) {
           logger.warn("Quota rollback after fetch failure failed", {
             code: errorCode(rbErr),
@@ -152,7 +173,7 @@ export const tts = onRequest(
       logger.error("Upstream Gemini body read failed", { code: errorCode(err) });
       if (reservation.reserved) {
         try {
-          await releaseDailySlot(installId, today);
+          await releaseDailySlot(uid, today);
         } catch (rbErr) {
           logger.warn("Quota rollback after body read failure failed", {
             code: errorCode(rbErr),
@@ -189,7 +210,7 @@ export const tts = onRequest(
       logger.warn("Gemini returned 200 but no inline audio", structuralEnvelope(upstreamBody));
       if (reservation.reserved) {
         try {
-          await releaseDailySlot(installId, today);
+          await releaseDailySlot(uid, today);
         } catch (err) {
           logger.warn("Quota rollback after no-audio 200 failed", {
             code: errorCode(err),
@@ -210,7 +231,7 @@ export const tts = onRequest(
       // to undo.
       if (reservation.reserved) {
         try {
-          await releaseDailySlot(installId, today);
+          await releaseDailySlot(uid, today);
         } catch (err) {
           logger.warn("Quota rollback after upstream non-success failed", {
             code: errorCode(err),
@@ -238,10 +259,10 @@ interface Reservation {
 }
 
 async function reserveDailySlot(
-  installId: string,
+  uid: string,
   today: string,
 ): Promise<Reservation> {
-  const docRef = getFirestore().collection(INSTALLS_COLLECTION).doc(installId);
+  const docRef = getFirestore().collection(QUOTA_COLLECTION).doc(uid);
   return await getFirestore().runTransaction(async (tx) => {
     const snap = await tx.get(docRef);
     const now = Timestamp.now();
@@ -281,10 +302,10 @@ async function reserveDailySlot(
 }
 
 async function releaseDailySlot(
-  installId: string,
+  uid: string,
   today: string,
 ): Promise<void> {
-  const docRef = getFirestore().collection(INSTALLS_COLLECTION).doc(installId);
+  const docRef = getFirestore().collection(QUOTA_COLLECTION).doc(uid);
   await getFirestore().runTransaction(async (tx) => {
     const snap = await tx.get(docRef);
     if (!snap.exists) return;

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -144,7 +144,7 @@ firebase-analytics = { group = "com.google.firebase", name = "firebase-analytics
 firebase-crashlytics = { group = "com.google.firebase", name = "firebase-crashlytics" }
 firebase-appcheck-playintegrity = { group = "com.google.firebase", name = "firebase-appcheck-playintegrity" }
 firebase-appcheck-debug = { group = "com.google.firebase", name = "firebase-appcheck-debug" }
-firebase-installations = { group = "com.google.firebase", name = "firebase-installations" }
+firebase-auth = { group = "com.google.firebase", name = "firebase-auth" }
 
 hivemq-mqtt-client = { group = "com.hivemq", name = "hivemq-mqtt-client", version.ref = "hivemqMqttClient" }
 


### PR DESCRIPTION
## Why

The shared-key TTS proxy caps free Gemini-voice usage at 5 clips/day per install, but keyed that quota on a **client-supplied** `X-Install-Id` header (the Firebase Installation ID). A valid App Check token only proves the caller is a genuine build of the app — it carries no per-install identity — so a modded client could rotate the header per request and mint a fresh quota doc each time, bypassing the cap. (Surfaced by Codex review on #893; was tracked in `docs/TODO.md`.)

## What

- **Client** signs in anonymously to Firebase Authentication and sends the resulting ID token as `Authorization: Bearer <token>` instead of `X-Install-Id`.
- **Function** verifies it with `getAuth().verifyIdToken()` and keys the daily quota on the verified `uid` (`quota/<uid>`), which is minted and signed by Firebase Auth — the client can't choose or rotate it. App Check verification is unchanged.
- Swaps `firebase-installations` → `firebase-auth` in `:app`.
- Firestore collection renamed `installs/<fid>` → `quota/<uid>` in rules and docs.

### Why not the Installations auth token (the original TODO plan)
There's no documented way for a custom backend to verify a Firebase Installations *auth token*: the Installations REST API only creates/deletes installations and generates tokens (no verify/introspect), and the Admin SDK has no installations-token verifier. Anonymous Auth is the supported path to a server-verified per-install identity.

## Setup (Firebase Console)
Requires **Anonymous sign-in enabled** and **App Check enforced on Authentication** (so anonymous accounts can't be farmed to rotate the `uid`). Documented in `docs/gemini-tts-proxy.md`, with an optional 30-day inactive-account cleanup note.

## Privacy (device-boundary change)
The app now contacts **Firebase Authentication (a Google service)** to obtain an anonymous identifier, and **stops sending the Firebase Installation ID** to the proxy. The new identifier is an anonymous, randomly-generated `uid` carrying no personal information (no name, email, device, or location) — net neutral-to-less data leaving the device. `PRIVACY.md` (shared-key TTS section, third-party services table, the "no accounts/no sign-in" line, and a changelog entry) is updated to describe it clearly.

## Test plan
- `functions/` type-checks clean with the pinned tsc (`npm run build`).
- `:app:compileDebugKotlin` ✅ and existing `AppCheckGeminiCallPlannerTest` passes ✅ (outer build, SDK present).
- ⚠️ No new unit test covers the Firebase-dependent `sharedPlan()` header path — the planner has no Firebase mocking harness today (`firebase-auth`/`FirebaseUser`/`Task` mocking, mockk not yet wired into `:app`). Happy to add one if you'd like; flag it.

https://claude.ai/code/session_017udYG3q8sBRBTPLEk1duJE

---
_Generated by [Claude Code](https://claude.ai/code/session_017udYG3q8sBRBTPLEk1duJE)_