### PR TITLE
Ask one question at a time and keep replies brief

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,20 @@ Rules and gotchas for AI coding agents (Claude Code, Codex, etc.) working in
 this repo. Keep this file short and concrete — one-liners over essays. Add a
 new rule the first time something bites you, not the third.
 
+## Talking to the user
+
+- **One question at a time.** Never stack multiple questions in a single
+  turn — ask the most important one, wait for the answer, then ask the
+  next if you still need it. A wall of bundled questions is harder to
+  answer than a short back-and-forth.
+- **Don't interrupt.** Never fire off a question while the user is still
+  typing. Let them finish; a half-typed message isn't an invitation to
+  jump in.
+- **Keep replies short — don't dump a full page.** Lead with the single
+  most important point and stop. If there's more, say the first point and
+  ask whether they're ready for the next one rather than emptying
+  everything at once.
+
 ## Working in this repo
 
 - This repo is an Android app (Kotlin + Compose) with two pure-Kotlin


### PR DESCRIPTION
Adds a "Talking to the user" section to the agent guide (`AGENTS.md`, symlinked as `CLAUDE.md`) capturing three interaction rules:

- **One question at a time** — never stack multiple questions; ask the most important, wait, then ask the next.
- **Don't interrupt** — never ask a question while the user is still typing.
- **Keep replies short** — lead with the single most important point; if there's more, ask whether they're ready for the next point rather than dumping a full page.

Docs-only change to the agent guide; no code or shipped strings touched.

https://claude.ai/code/session_01HTpk1gycPZmsC7wih3ZBbc

---
_Generated by [Claude Code](https://claude.ai/code/session_01HTpk1gycPZmsC7wih3ZBbc)_