### PR TITLE
internal: require a docs: prefix on docs-only commits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,9 +150,18 @@ new rule the first time something bites you, not the third.
   it skips `ci:` / `test:`. Note the path-based filter already drops
   top-level `*.md`, `docs/`, and dotfile-only commits regardless of
   prefix (PRIVACY.md is the exception — it's treated as non-docs so
-  privacy-policy updates still surface), so a pure-`AGENTS.md` change
-  doesn't strictly need the prefix; reach for `internal:` when an
-  internal-only change touches paths that *would* otherwise ship a bullet.
+  privacy-policy updates still surface), so a pure-`AGENTS.md` change is
+  dropped either way — but still prefix it so the subject's intent is
+  explicit and never reads like a shippable bullet. Reach for `internal:`
+  especially when an internal-only change touches paths that *would*
+  otherwise ship a bullet.
+- **Docs-only commits use a `docs:` subject prefix.** A commit touching
+  only `docs/`, top-level `*.md` (READMEs, setup guides), or dotfiles
+  takes `docs:` (e.g. `docs: fix stale Firebase Console nav`). Prefix it
+  even though the path filter already drops it from the changelog — the
+  prefix makes the intent explicit and keeps the subject from reading
+  like end-user copy. Exception: a PRIVACY.md-only change ships as a
+  bullet (it's treated as non-docs), so leave that one unprefixed.
 - **Play caps `whatsnew-en-US` at 500 bytes.** When the bullet list
   exceeds that, CI truncates and appends `…`. Avoid lining up a long
   stack of small commits if any one of them tells the user-facing story


### PR DESCRIPTION
#901 shipped a docs-only commit with no prefix. Turns out the existing `internal:` rule actively excused it ("a pure-`AGENTS.md` change doesn't strictly need the prefix") and there was no `docs:` rule at all — even though the repo uses `docs:` in practice.

This:
- Adds an explicit **`docs:` prefix rule** for `docs/` / top-level `*.md` / dotfile-only commits (with the PRIVACY.md exception, which ships as a bullet).
- Closes the escape hatch in the `internal:` rule — prefix even when the path filter would drop it, so the subject's intent is explicit and never reads like end-user changelog copy.

Self-applying: this commit is `internal:`-prefixed.

https://claude.ai/code/session_017udYG3q8sBRBTPLEk1duJE

---
_Generated by [Claude Code](https://claude.ai/code/session_017udYG3q8sBRBTPLEk1duJE)_