### PR TITLE
internal: dual-path the TTS quota identity during the ID migration

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -260,8 +260,13 @@ Online TTS (the Gemini voice) has two paths.
     proxy verifies to read the identifier — the client cannot forge or
     swap it), a Firebase App Check attestation token (proves the request
     came from a genuine install — verified in-memory and discarded), and
-    the model name. No coordinates, calendar metadata as fields, user
-    account, advertising ID, or hardware / device identifiers are added.
+    the model name. During the current rollout the app *also* sends a
+    Firebase Installation ID for backward compatibility (so older proxy
+    versions still recognize the install); it is likewise an anonymous,
+    random identifier with no personal information, and is dropped once
+    the rollout completes. No coordinates, calendar metadata as fields,
+    user account, advertising ID, or hardware / device identifiers are
+    added.
   - **Stored:** a Firestore document at `quota/<your anonymous ID>`
     with a first-use timestamp, a successful-call counter, and a
     most-recent-use timestamp, capped at 5 successful clips per UTC day.
@@ -291,7 +296,7 @@ policies apply to anything they receive:
 | [Open-Meteo](https://open-meteo.com/en/terms) | Coarse coordinate (forecast); your typed search text when you use a location picker (first-run onboarding and Settings) | Always for forecast; only when you search for a place name |
 | Google's geocoding service (via Android's [`Geocoder`](https://developer.android.com/reference/android/location/Geocoder) on Play Services devices), governed by [Google's Privacy Policy](https://policies.google.com/privacy) | Coarse coordinate | Always on Play Services devices (city / country lookup for the Today header); skipped on AOSP devices |
 | Google Firebase Authentication | An App Check attestation, to mint and refresh an anonymous identifier (no name, email, or password) | First use of the shared-key path, then periodic token refreshes |
-| ClothesCast TTS proxy (Cloud Function, ClothesCast-operated) | The short rendered insight sentence, an anonymous app identifier (as a signed Firebase ID token), a Firebase App Check token, and the Gemini model name | Online TTS with the shared key (default) |
+| ClothesCast TTS proxy (Cloud Function, ClothesCast-operated) | The short rendered insight sentence, an anonymous app identifier (as a signed Firebase ID token; plus a Firebase Installation ID during the current rollout), a Firebase App Check token, and the Gemini model name | Online TTS with the shared key (default) |
 | [Google Gemini API](https://ai.google.dev/gemini-api/terms) | The short rendered insight sentence (forwarded by the proxy, or sent directly when you use your own key) | Online TTS, either path |
 | Your self-hosted MQTT broker (e.g. Mosquitto inside Home Assistant) | The short rendered insight sentence, as a retained MQTT message | Only if you opt in to the Smart Home bridge and configure a broker |
 | Analytics / crash-reporting service (e.g. Firebase Crashlytics + Google Analytics for Firebase) | Aggregate usage events and crash diagnostics — see "Analytics and crash reporting" below for what's in and out | Possibly always, in all builds |
@@ -458,6 +463,12 @@ email the address listed on the Play Store listing.
 
 ## Changelog
 
+- **2026-05-31** — Transitional note for the identifier change below:
+  during the staged rollout the app sends *both* the new anonymous
+  Firebase Authentication identifier and the older Firebase Installation
+  ID, so older versions of the proxy keep working while clients update.
+  Both are anonymous, random identifiers with no personal information.
+  The Installation ID is dropped once the rollout completes.
 - **2026-05-31** — Hardened the shared-key TTS identifier. The free
   online-TTS path now identifies each install by an anonymous Firebase
   Authentication identifier, verified on the server, instead of the

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -513,13 +513,17 @@ dependencies {
     // App Check (Play Integrity in release, Debug provider in debug) +
     // anonymous Auth: the TTS proxy gates on a valid App Check token and
     // counts usage per anonymous Firebase Authentication uid (verified
-    // server-side, so the client can't spoof its quota bucket). Both
-    // no-op on builds assembled without google-services.json — FirebaseApp
-    // doesn't init, the planner falls back to BYOK semantics, and the rest
-    // of the app continues to assemble and run.
+    // server-side, so the client can't spoof its quota bucket). Installations
+    // stays for the migration window — the client sends the legacy FID
+    // alongside the ID token so a not-yet-redeployed function keeps working;
+    // it's dropped once old app versions age out. All no-op on builds
+    // assembled without google-services.json — FirebaseApp doesn't init, the
+    // planner falls back to BYOK semantics, and the rest of the app
+    // continues to assemble and run.
     implementation(libs.firebase.appcheck.playintegrity)
     debugImplementation(libs.firebase.appcheck.debug)
     implementation(libs.firebase.auth)
+    implementation(libs.firebase.installations)
     // `.await()` on the App Check token / anonymous sign-in / ID token Tasks.
     // Production (not test-only) because the planner runs in the main coroutine flow.
     implementation(libs.kotlinx.coroutines.play.services)

--- a/app/src/main/kotlin/app/clothescast/data/AppCheckGeminiCallPlanner.kt
+++ b/app/src/main/kotlin/app/clothescast/data/AppCheckGeminiCallPlanner.kt
@@ -9,6 +9,8 @@ import app.clothescast.diag.DiagLog
 import com.google.firebase.appcheck.FirebaseAppCheck
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.FirebaseAuthInvalidUserException
+import com.google.firebase.installations.FirebaseInstallations
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.tasks.await
 
 /**
@@ -21,11 +23,15 @@ import kotlinx.coroutines.tasks.await
  *   developer-operated Cloud Function at [proxyBaseUrl], carrying a
  *   Firebase App Check attestation token (`X-Firebase-AppCheck`), an
  *   anonymous Firebase Authentication ID token (`Authorization: Bearer
- *   <idToken>`), and the model name (`X-Gemini-Model`). The function
- *   holds the developer's Gemini key and forwards the call. Quota is
- *   keyed server-side on the verified `uid` from the ID token rather
- *   than a client-supplied header, so a modded client can't rotate an
- *   identifier to evade the daily cap.
+ *   <idToken>`), the model name (`X-Gemini-Model`), and — during the
+ *   rollout migration — the legacy Firebase Installation ID
+ *   (`X-Install-Id`). The function holds the developer's Gemini key and
+ *   forwards the call. It prefers the verified `uid` from the ID token
+ *   (which a modded client can't rotate to evade the daily cap) and
+ *   falls back to the FID only for app versions built before the switch.
+ *   Sending both keeps a pre-switch *and* a post-switch function happy,
+ *   so the app, function, and Firebase config can roll out in any order;
+ *   the FID send is removed once old app versions age out.
  * - **No key set and shared path disabled** ([sharedPathEnabled] is
  *   false — CI builds without `google-services.json`, or forks that
  *   haven't configured `GEMINI_PROXY_URL`): throw
@@ -47,6 +53,7 @@ class AppCheckGeminiCallPlanner(
     private val model: String,
     private val appCheck: () -> FirebaseAppCheck = { FirebaseAppCheck.getInstance() },
     private val auth: () -> FirebaseAuth = { FirebaseAuth.getInstance() },
+    private val installations: () -> FirebaseInstallations = { FirebaseInstallations.getInstance() },
 ) : GeminiCallPlanner {
 
     override suspend fun plan(): GeminiCallPlan {
@@ -88,9 +95,27 @@ class AppCheckGeminiCallPlanner(
             endpoint = endpoint,
             applyAuth = {
                 val appCheckToken = appCheck().getAppCheckToken(false).await().token
-                val idToken = anonymousIdToken()
                 it.headers.append("X-Firebase-AppCheck", appCheckToken)
-                it.headers.append("Authorization", "Bearer $idToken")
+                // Backward-compat during the rollout: always send the FID so
+                // a not-yet-redeployed function (which keys quota on
+                // X-Install-Id) keeps working, and so a token fetch failure
+                // still leaves a usable identity. The new function prefers
+                // the verified uid below and ignores this when present.
+                it.headers.append("X-Install-Id", installations().id.await())
+                // Anonymous ID token: the new function verifies it and keys
+                // quota on the unspoofable uid. If sign-in is unavailable
+                // (Anonymous provider disabled, offline), fall back to the
+                // FID-only request above rather than failing the call —
+                // worst case the user is on the old, spoofable identity, not
+                // dropped to device TTS.
+                try {
+                    val idToken = anonymousIdToken()
+                    it.headers.append("Authorization", "Bearer $idToken")
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    DiagLog.w(TAG, "Anonymous ID token unavailable; sending FID only", e)
+                }
                 it.headers.append("X-Gemini-Model", model)
             },
         )

--- a/docs/gemini-tts-proxy.md
+++ b/docs/gemini-tts-proxy.md
@@ -255,6 +255,36 @@ verification by default (since the SDK can't reach the real Firebase
 backend), so a debug token isn't strictly required while emulating —
 but using one is closer to production behaviour.
 
+## Rolling out the anonymous-ID migration
+
+The quota identity changed from a client-chosen `X-Install-Id` header to
+a server-verified anonymous Firebase Auth `uid`. To avoid breaking the
+free voice for anyone mid-rollout, both client and function speak both
+dialects during the transition, so **the function deploy, the app
+release, and the Firebase config can happen in any order**:
+
+- **Client** sends *both* the legacy `X-Install-Id` and an
+  `Authorization: Bearer <idToken>` on every shared-key request. If
+  anonymous sign-in is unavailable it sends the FID alone.
+- **Function** prefers the verified `uid` and falls back to
+  `X-Install-Id` only when there's no Bearer token.
+
+So an old app hits the new function (FID fallback) and a new app hits an
+old function (still reads the FID) without anyone dropping to device TTS.
+
+One step is *not* order-independent: **enable Anonymous sign-in (step 4)
+before the new app ships**, or the client can't get an ID token (it
+degrades to the spoofable FID path, which still works but doesn't gain
+the protection).
+
+⚠️ **The fallback keeps the spoofing hole open.** A client can omit the
+Bearer token and rotate `X-Install-Id` to evade the cap for as long as
+the fallback exists. Close it in a **cleanup phase** once old app
+versions have aged out: drop the `X-Install-Id` send from the client and
+delete the fallback branch in `functions/src/index.ts` (then the
+`missing_identity` path becomes `missing_auth_token` again). Only then is
+the cap actually tamper-resistant.
+
 ## Operational notes
 
 - **Cost**: Gemini Flash TTS is ~$0.003 per ~5 s clip. Cloud

--- a/functions/README.md
+++ b/functions/README.md
@@ -52,6 +52,10 @@ npm run deploy
 Each install gets 5 successful syntheses per UTC calendar day, keyed on
 the anonymous Firebase Auth `uid` from the verified ID token (not a
 client-supplied header — a modded client can't pick its own bucket).
+During the client rollout, requests without a Bearer token fall back to
+the legacy client-chosen `X-Install-Id` header so pre-switch app
+versions keep working; that fallback is spoofable and is removed once
+old app versions age out (see `docs/gemini-tts-proxy.md` → rollout).
 The reservation is transactional:
 
 1. Pre-flight transaction reads `quota/<uid>`; if today's

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -58,30 +58,37 @@ export const tts = onRequest(
       return;
     }
 
-    // Quota is keyed on the Firebase Authentication uid pulled from a
-    // verified anonymous ID token — never a client-supplied header. The
-    // uid is minted and signed by Firebase Auth, so a modded client can't
-    // choose its own quota bucket the way it could when we trusted an
-    // `X-Install-Id` header: verifyIdToken rejects anything we didn't
-    // issue. App Check above already proves the caller is a genuine app
-    // build; enforcing App Check on Authentication in the console
-    // (Build → App Check → Authentication → Enforce) closes the last gap
-    // by stopping scripted anonymous-account farming to rotate the uid.
+    // Identity for the per-install daily quota. Prefer the Firebase
+    // Authentication uid from a verified anonymous ID token — it's minted
+    // and signed by Firebase Auth, so a modded client can't choose its own
+    // quota bucket. During the client rollout we still accept the legacy
+    // client-chosen `X-Install-Id` header so app versions built before the
+    // switch keep working; that header is spoofable, so it's a transitional
+    // fallback only — remove it (and stop the client sending it) once old
+    // app versions have aged out. App Check above already proves the caller
+    // is a genuine app build; enforcing App Check on Authentication
+    // (Security → App Check → Authentication → Enforce) stops scripted
+    // anonymous-account farming to rotate the uid.
+    let quotaKey: string;
     const authHeader = headerValue(req.header("Authorization"));
     const idToken = authHeader?.startsWith("Bearer ")
       ? authHeader.slice("Bearer ".length).trim()
       : null;
-    if (!idToken) {
-      res.status(401).json({ error: "missing_auth_token" });
-      return;
-    }
-    let uid: string;
-    try {
-      uid = (await getAuth().verifyIdToken(idToken)).uid;
-    } catch (err) {
-      logger.warn("ID token verification failed", { code: errorCode(err) });
-      res.status(401).json({ error: "invalid_auth_token" });
-      return;
+    if (idToken) {
+      try {
+        quotaKey = (await getAuth().verifyIdToken(idToken)).uid;
+      } catch (err) {
+        logger.warn("ID token verification failed", { code: errorCode(err) });
+        res.status(401).json({ error: "invalid_auth_token" });
+        return;
+      }
+    } else {
+      const installId = headerValue(req.header("X-Install-Id"));
+      if (!installId || !/^[A-Za-z0-9_-]{1,128}$/.test(installId)) {
+        res.status(401).json({ error: "missing_identity" });
+        return;
+      }
+      quotaKey = installId;
     }
 
     const body = req.body;
@@ -106,7 +113,7 @@ export const tts = onRequest(
     const today = utcDayKey(now);
     let reservation: Reservation;
     try {
-      reservation = await reserveDailySlot(uid, today);
+      reservation = await reserveDailySlot(quotaKey, today);
     } catch (err) {
       logger.warn("Quota reservation failed; failing open", {
         code: errorCode(err),
@@ -150,7 +157,7 @@ export const tts = onRequest(
       // Firestore recovers.
       if (reservation.reserved) {
         try {
-          await releaseDailySlot(uid, today);
+          await releaseDailySlot(quotaKey, today);
         } catch (rbErr) {
           logger.warn("Quota rollback after fetch failure failed", {
             code: errorCode(rbErr),
@@ -173,7 +180,7 @@ export const tts = onRequest(
       logger.error("Upstream Gemini body read failed", { code: errorCode(err) });
       if (reservation.reserved) {
         try {
-          await releaseDailySlot(uid, today);
+          await releaseDailySlot(quotaKey, today);
         } catch (rbErr) {
           logger.warn("Quota rollback after body read failure failed", {
             code: errorCode(rbErr),
@@ -210,7 +217,7 @@ export const tts = onRequest(
       logger.warn("Gemini returned 200 but no inline audio", structuralEnvelope(upstreamBody));
       if (reservation.reserved) {
         try {
-          await releaseDailySlot(uid, today);
+          await releaseDailySlot(quotaKey, today);
         } catch (err) {
           logger.warn("Quota rollback after no-audio 200 failed", {
             code: errorCode(err),
@@ -231,7 +238,7 @@ export const tts = onRequest(
       // to undo.
       if (reservation.reserved) {
         try {
-          await releaseDailySlot(uid, today);
+          await releaseDailySlot(quotaKey, today);
         } catch (err) {
           logger.warn("Quota rollback after upstream non-success failed", {
             code: errorCode(err),
@@ -259,10 +266,10 @@ interface Reservation {
 }
 
 async function reserveDailySlot(
-  uid: string,
+  quotaKey: string,
   today: string,
 ): Promise<Reservation> {
-  const docRef = getFirestore().collection(QUOTA_COLLECTION).doc(uid);
+  const docRef = getFirestore().collection(QUOTA_COLLECTION).doc(quotaKey);
   return await getFirestore().runTransaction(async (tx) => {
     const snap = await tx.get(docRef);
     const now = Timestamp.now();
@@ -302,10 +309,10 @@ async function reserveDailySlot(
 }
 
 async function releaseDailySlot(
-  uid: string,
+  quotaKey: string,
   today: string,
 ): Promise<void> {
-  const docRef = getFirestore().collection(QUOTA_COLLECTION).doc(uid);
+  const docRef = getFirestore().collection(QUOTA_COLLECTION).doc(quotaKey);
   await getFirestore().runTransaction(async (tx) => {
     const snap = await tx.get(docRef);
     if (!snap.exists) return;

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -145,6 +145,7 @@ firebase-crashlytics = { group = "com.google.firebase", name = "firebase-crashly
 firebase-appcheck-playintegrity = { group = "com.google.firebase", name = "firebase-appcheck-playintegrity" }
 firebase-appcheck-debug = { group = "com.google.firebase", name = "firebase-appcheck-debug" }
 firebase-auth = { group = "com.google.firebase", name = "firebase-auth" }
+firebase-installations = { group = "com.google.firebase", name = "firebase-installations" }
 
 hivemq-mqtt-client = { group = "com.hivemq", name = "hivemq-mqtt-client", version.ref = "hivemqMqttClient" }
 


### PR DESCRIPTION
Phase-1 of the `X-Install-Id` → anonymous-`uid` migration (#899), making the rollout **order-independent** so no existing user drops to device TTS while the function, app, and Firebase config land at different times.

**Client** (`AppCheckGeminiCallPlanner`): sends *both* the legacy `X-Install-Id` and `Authorization: Bearer <idToken>`. If anonymous sign-in/token fetch fails, sends the FID alone rather than failing the call.

**Function**: prefers the verified `uid`; falls back to `X-Install-Id` only when there's no Bearer token. Single `quota/<key>` collection.

So old-app→new-function (FID fallback) and new-app→old-function (still reads FID) both keep working.

### Caveat — this does not yet close the hole
The FID fallback is spoofable (omit the Bearer, rotate the FID). The cap is only tamper-resistant after a **cleanup phase** drops the FID send + the fallback once old app versions age out. Documented in `docs/gemini-tts-proxy.md` → "Rolling out the anonymous-ID migration", including the one ordering constraint (enable Anonymous sign-in before the new app ships).

### Privacy / device boundary
During the rollout the app sends the Firebase Installation ID again alongside the anonymous Auth identifier — both anonymous, random, no PII; FID dropped at cleanup. `PRIVACY.md` updated (shared-key "Sent on each request" bullet, third-party table, changelog note).

### Test plan
- `functions/` type-checks clean (`npm run build`).
- `:app:compileDebugKotlin` ✅.
- ⚠️ Still no unit test on the Firebase-dependent `sharedPlan()` header path (no Firebase mocking harness in `:app`).

https://claude.ai/code/session_017udYG3q8sBRBTPLEk1duJE

---
_Generated by [Claude Code](https://claude.ai/code/session_017udYG3q8sBRBTPLEk1duJE)_