### PR TITLE
Skip our location rationale dialog and go straight to the system prompt

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/settings/LocationSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/LocationSettings.kt
@@ -128,7 +128,6 @@ private fun LocationCard(
         onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
     }
 
-    var rationaleOpen by remember { mutableStateOf(false) }
     var backgroundRationaleOpen by remember { mutableStateOf(false) }
     var backgroundDeniedOpen by remember { mutableStateOf(false) }
 
@@ -178,9 +177,12 @@ private fun LocationCard(
                         return@Switch
                     }
                     when {
-                        // Show the rationale before the foreground prompt; we'll auto-
-                        // chain into the background rationale when the user grants.
-                        !coarseGranted -> rationaleOpen = true
+                        // Go straight to the system foreground prompt; we auto-chain
+                        // into the background rationale once the user grants. Showing
+                        // our own rationale first just stacks a second dialog in front
+                        // of the system one.
+                        !coarseGranted ->
+                            foregroundLauncher.launch(Manifest.permission.ACCESS_COARSE_LOCATION)
                         !backgroundGranted -> {
                             // Foreground granted previously; surface the always-on
                             // rationale before deep-linking into Settings.
@@ -313,25 +315,6 @@ private fun LocationCard(
                 dialogOpen = false
             },
             onSearch = onSearch,
-        )
-    }
-
-    if (rationaleOpen) {
-        AlertDialog(
-            onDismissRequest = { rationaleOpen = false },
-            title = { Text(stringResource(R.string.settings_location_rationale_title)) },
-            text = { Text(stringResource(R.string.settings_location_rationale_body)) },
-            confirmButton = {
-                TextButton(onClick = {
-                    rationaleOpen = false
-                    foregroundLauncher.launch(Manifest.permission.ACCESS_COARSE_LOCATION)
-                }) { Text(stringResource(R.string.settings_location_rationale_continue)) }
-            },
-            dismissButton = {
-                TextButton(onClick = { rationaleOpen = false }) {
-                    Text(stringResource(R.string.settings_location_rationale_dismiss))
-                }
-            },
         )
     }
 

--- a/app/src/main/res/values-am/strings.xml
+++ b/app/src/main/res/values-am/strings.xml
@@ -263,10 +263,6 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="settings_location_search">ፈልግ</string>
     <string name="settings_location_searching">እየፈለገ ነው…</string>
     <string name="settings_location_no_results">ምንም ውጤት የለም።</string>
-    <string name="settings_location_rationale_title">የቦታ ፍቃድ</string>
-    <string name="settings_location_rationale_body">ClothesCast ሀገርዎን ትንበያ ለማምጣት ቦታዎን ያነባል።</string>
-    <string name="settings_location_rationale_continue">ቀጥል</string>
-    <string name="settings_location_rationale_dismiss">አሁን አይሆንም</string>
     <string name="settings_location_background_rationale_title">ሁልጊዜ ፍቀድ</string>
     <string name="settings_location_background_rationale_body">ClothesCast ሲዘጋ ቦታዎን ሊያነብ \'ሁልጊዜ ፍቀድ\' ይምረጡ እናም የጠዋቱ ትንበያ ወቅቱን ጠብቆ ይዘምናል።</string>
     <string name="settings_location_background_rationale_continue">ቅንብሮችን ክፈት</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -340,10 +340,6 @@ they work correctly in both the single-band and range templates.
     <string name="settings_location_search">بحث</string>
     <string name="settings_location_searching">جارٍ البحث…</string>
     <string name="settings_location_no_results">لا توجد نتائج.</string>
-    <string name="settings_location_rationale_title">الوصول إلى الموقع</string>
-    <string name="settings_location_rationale_body">تقرأ ClothesCast موقعك لجلب توقعات الطقس المحلية.</string>
-    <string name="settings_location_rationale_continue">متابعة</string>
-    <string name="settings_location_rationale_dismiss">ليس الآن</string>
     <string name="settings_location_background_rationale_title">السماح في جميع الأوقات</string>
     <string name="settings_location_background_rationale_body">اسمح لـ ClothesCast بقراءة موقعك أثناء الإغلاق حتى تتحدث توقعات الصباح في الوقت المناسب.</string>
     <string name="settings_location_background_rationale_continue">فتح الإعدادات</string>

--- a/app/src/main/res/values-b+sr+Latn/strings.xml
+++ b/app/src/main/res/values-b+sr+Latn/strings.xml
@@ -188,10 +188,6 @@ default English (matching values-pl / values-uk).
     <string name="settings_location_search">Pretraži</string>
     <string name="settings_location_searching">Pretraga…</string>
     <string name="settings_location_no_results">Nema rezultata.</string>
-    <string name="settings_location_rationale_title">Pristup lokaciji</string>
-    <string name="settings_location_rationale_body">ClothesCast čita tvoju lokaciju radi preuzimanja lokalne prognoze.</string>
-    <string name="settings_location_rationale_continue">Nastavi</string>
-    <string name="settings_location_rationale_dismiss">Ne sada</string>
     <string name="settings_location_background_rationale_title">Dozvoli uvek</string>
     <string name="settings_location_background_rationale_body">Dozvoli ClothesCastu da čita tvoju lokaciju dok je zatvoren kako bi se jutarnja prognoza ažurirala na vreme.</string>
     <string name="settings_location_background_rationale_continue">Otvori podešavanja</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -350,10 +350,6 @@ What is NOT overridden, by design:
     <string name="settings_location_search">Търси</string>
     <string name="settings_location_searching">Търси се…</string>
     <string name="settings_location_no_results">Няма резултати.</string>
-    <string name="settings_location_rationale_title">Достъп до местоположение</string>
-    <string name="settings_location_rationale_body">ClothesCast чете местоположението ти, за да вземе местната прогноза.</string>
-    <string name="settings_location_rationale_continue">Продължи</string>
-    <string name="settings_location_rationale_dismiss">Не сега</string>
     <string name="settings_location_background_rationale_title">Разреши винаги</string>
     <string name="settings_location_background_rationale_body">Разреши на ClothesCast да чете местоположението ти, докато е затворен, за да се актуализира сутрешната прогноза навреме.</string>
     <string name="settings_location_background_rationale_continue">Отвори настройките</string>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -565,10 +565,6 @@ West Bengal vocabulary differences in a future PR.
     <string name="settings_location_search">অনুসন্ধান</string>
     <string name="settings_location_searching">অনুসন্ধান করা হচ্ছে…</string>
     <string name="settings_location_no_results">কোনো ফলাফল নেই।</string>
-    <string name="settings_location_rationale_title">অবস্থানের অ্যাক্সেস</string>
-    <string name="settings_location_rationale_body">স্থানীয় পূর্বাভাস আনতে ClothesCast আপনার অবস্থান পড়ে।</string>
-    <string name="settings_location_rationale_continue">চালিয়ে যান</string>
-    <string name="settings_location_rationale_dismiss">এখন নয়</string>
     <string name="settings_location_background_rationale_title">সব সময় অনুমতি দিন</string>
     <string name="settings_location_background_rationale_body">অ্যাপ বন্ধ থাকলেও সকালের পূর্বাভাস সময়মতো আপডেট হতে ClothesCast-কে আপনার অবস্থান পড়ার অনুমতি দিন।</string>
     <string name="settings_location_background_rationale_continue">সেটিংস খুলুন</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -224,10 +224,6 @@ the in-app clock is digit-driven and reads consistently across locales.
     <string name="settings_location_search">Cerca</string>
     <string name="settings_location_searching">Cercant…</string>
     <string name="settings_location_no_results">No hi ha coincidències.</string>
-    <string name="settings_location_rationale_title">Accés a la ubicació</string>
-    <string name="settings_location_rationale_body">ClothesCast llegeix la teva ubicació per obtenir la previsió local.</string>
-    <string name="settings_location_rationale_continue">Continua</string>
-    <string name="settings_location_rationale_dismiss">Ara no</string>
     <string name="settings_location_background_rationale_title">Permet sempre</string>
     <string name="settings_location_background_rationale_body">Permet que ClothesCast llegeixi la teva ubicació mentre és tancada perquè la previsió matinal s\'actualitzi a temps.</string>
     <string name="settings_location_background_rationale_continue">Obre Configuració</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -309,10 +309,6 @@ locale (Angličtina (USA), Francouzština (Francie), Němčina (Německo), …).
     <string name="settings_location_background_denied_open">Otevřít nastavení</string>
     <string name="settings_location_background_denied_keep">Ponechat uloženou polohu</string>
 
-    <string name="settings_location_rationale_title">Trvalá poloha</string>
-    <string name="settings_location_rationale_body">ClothesCast aktualizuje tvou předpověď na pozadí, aby ji doručil včas. K tomu potřebuje oprávnění k poloze „Vždy povolit".</string>
-    <string name="settings_location_rationale_continue">Pokračovat</string>
-    <string name="settings_location_rationale_dismiss">Teď ne</string>
 
     <!-- Notification channels. -->
     <string name="notification_channel_daily_insight_name">Denní ClothesCast</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -310,10 +310,6 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrig)").
     <string name="settings_location_background_denied_open">Åbn indstillinger</string>
     <string name="settings_location_background_denied_keep">Behold gemt placering</string>
 
-    <string name="settings_location_rationale_title">Permanent placering</string>
-    <string name="settings_location_rationale_body">ClothesCast opdaterer din prognose i baggrunden for at levere den til tiden. Det kræver placeringstilladelsen "Tillad altid".</string>
-    <string name="settings_location_rationale_continue">Fortsæt</string>
-    <string name="settings_location_rationale_dismiss">Ikke nu</string>
 
     <!-- Notification channels. -->
     <string name="notification_channel_daily_insight_name">Dagligt ClothesCast</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -540,10 +540,6 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_location_background_denied_open">Einstellungen öffnen</string>
     <string name="settings_location_background_denied_keep">Gespeicherten Standort behalten</string>
 
-    <string name="settings_location_rationale_title">Dauerhafter Standort</string>
-    <string name="settings_location_rationale_body">ClothesCast aktualisiert deine Vorhersage im Hintergrund, um sie pünktlich zu liefern. Dafür wird die Standortberechtigung \'Immer zulassen\' benötigt.</string>
-    <string name="settings_location_rationale_continue">Weiter</string>
-    <string name="settings_location_rationale_dismiss">Nicht jetzt</string>
 
 
     <string name="settings_region_language_am_et">Amharisch (Äthiopien)</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -318,10 +318,6 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_location_search">Αναζήτηση</string>
     <string name="settings_location_searching">Αναζήτηση…</string>
     <string name="settings_location_no_results">Δεν βρέθηκαν αποτελέσματα.</string>
-    <string name="settings_location_rationale_title">Τοποθεσία πάντα ενεργή</string>
-    <string name="settings_location_rationale_body">Ο ClothesCast ενημερώνει την πρόβλεψή σου στο παρασκήνιο για να την παραδώσει εγκαίρως, οπότε χρειάζεται την άδεια τοποθεσίας «Να επιτρέπεται όλη την ώρα».</string>
-    <string name="settings_location_rationale_continue">Συνέχεια</string>
-    <string name="settings_location_rationale_dismiss">Όχι τώρα</string>
     <string name="settings_location_background_denied_title">Δεν παραχωρήθηκε «πάντα ενεργή»</string>
     <string name="settings_location_background_denied_body">Χωρίς «Να επιτρέπεται όλη την ώρα», η πρωινή πρόβλεψη επιστρέφει στην αποθηκευμένη σου τοποθεσία. Άνοιγμα Ρυθμίσεων συστήματος για παραχώρηση;</string>
     <string name="settings_location_background_denied_open">Άνοιγμα Ρυθμίσεων</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -513,10 +513,6 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_location_background_denied_open">Abrir Ajustes</string>
     <string name="settings_location_background_denied_keep">Seguir usando la ubicación guardada</string>
 
-    <string name="settings_location_rationale_title">Ubicación permanente</string>
-    <string name="settings_location_rationale_body">ClothesCast actualiza tu pronóstico en segundo plano para entregarlo a tiempo, por lo que necesita el permiso de ubicación \'Permitir siempre\'.</string>
-    <string name="settings_location_rationale_continue">Continuar</string>
-    <string name="settings_location_rationale_dismiss">Ahora no</string>
 
 
     <string name="settings_region_language_am_et">Amhárico (Etiopía)</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -226,10 +226,6 @@ Tone is informal "sina"-form throughout ("Pane … selga", "Võta … kaasa",
     <string name="settings_location_search">Otsi</string>
     <string name="settings_location_searching">Otsimine…</string>
     <string name="settings_location_no_results">Tulemused puuduvad.</string>
-    <string name="settings_location_rationale_title">Asukohaluba</string>
-    <string name="settings_location_rationale_body">ClothesCast loeb su asukohta kohaliku prognoosi laadimiseks.</string>
-    <string name="settings_location_rationale_continue">Jätka</string>
-    <string name="settings_location_rationale_dismiss">Mitte praegu</string>
     <string name="settings_location_background_rationale_title">Luba alati</string>
     <string name="settings_location_background_rationale_body">Luba ClothesCast\'il lugeda su asukohta rakenduse suletuks ajal, et hommikune prognoos uueneks õigeaegselt.</string>
     <string name="settings_location_background_rationale_continue">Ava seaded</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -330,10 +330,6 @@ Western Arabic numerals (0-9) are used for TTS compatibility.
     <string name="settings_location_search">جستجو</string>
     <string name="settings_location_searching">در حال جستجو…</string>
     <string name="settings_location_no_results">نتیجه‌ای یافت نشد.</string>
-    <string name="settings_location_rationale_title">دسترسی به موقعیت</string>
-    <string name="settings_location_rationale_body">ClothesCast موقعیت شما را برای دریافت پیش‌بینی محلی می‌خواند.</string>
-    <string name="settings_location_rationale_continue">ادامه</string>
-    <string name="settings_location_rationale_dismiss">نه الان</string>
     <string name="settings_location_background_rationale_title">همیشه اجازه بده</string>
     <string name="settings_location_background_rationale_body">اجازه دهید ClothesCast موقعیت شما را در زمان بسته بودن بخواند تا پیش‌بینی صبحگاهی به موقع به‌روز شود.</string>
     <string name="settings_location_background_rationale_continue">باز کردن تنظیمات</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -440,10 +440,6 @@ displayed label localizes.
     <string name="settings_location_background_denied_open">Avaa asetukset</string>
     <string name="settings_location_background_denied_keep">Pidä tallennettu sijainti</string>
 
-    <string name="settings_location_rationale_title">Jatkuva sijainti</string>
-    <string name="settings_location_rationale_body">ClothesCast päivittää ennusteesi taustalla toimittaakseen sen ajoissa. Tähän tarvitaan "Salli aina" -sijaintilupa.</string>
-    <string name="settings_location_rationale_continue">Jatka</string>
-    <string name="settings_location_rationale_dismiss">Ei nyt</string>
 
     <string name="settings_root_schedule_subtitle">Ilmoitukset ja ajat</string>
     <string name="settings_root_format_subtitle">Sanamuoto ja yksityiskohtien taso</string>

--- a/app/src/main/res/values-fil/strings.xml
+++ b/app/src/main/res/values-fil/strings.xml
@@ -346,10 +346,6 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="settings_location_search">Maghanap</string>
     <string name="settings_location_searching">Naghahanap…</string>
     <string name="settings_location_no_results">Walang nahanap na tugma.</string>
-    <string name="settings_location_rationale_title">Access sa lokasyon</string>
-    <string name="settings_location_rationale_body">Binabasa ng ClothesCast ang iyong lokasyon para makuha ang lokal na hula.</string>
-    <string name="settings_location_rationale_continue">Magpatuloy</string>
-    <string name="settings_location_rationale_dismiss">Hindi ngayon</string>
     <string name="settings_location_background_rationale_title">Payagan sa lahat ng oras</string>
     <string name="settings_location_background_rationale_body">Payagan ang ClothesCast na basahin ang iyong lokasyon habang nakasara ito para ma-update ang umaga na hula sa oras.</string>
     <string name="settings_location_background_rationale_continue">Buksan ang Mga Setting</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -510,10 +510,6 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_location_background_denied_open">Ouvrir les paramètres</string>
     <string name="settings_location_background_denied_keep">Conserver la position enregistrée</string>
 
-    <string name="settings_location_rationale_title">Position permanente</string>
-    <string name="settings_location_rationale_body">ClothesCast met à jour tes prévisions en arrière-plan pour les livrer à temps et a besoin de l\'autorisation de position \'Autoriser en permanence\'.</string>
-    <string name="settings_location_rationale_continue">Continuer</string>
-    <string name="settings_location_rationale_dismiss">Pas maintenant</string>
 
 
     <string name="settings_region_language_am_et">Amharique (Éthiopie)</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -268,10 +268,6 @@ Not overridden by design:
     <string name="settings_location_search">खोजें</string>
     <string name="settings_location_searching">खोज रहे हैं…</string>
     <string name="settings_location_no_results">कोई मिलान नहीं।</string>
-    <string name="settings_location_rationale_title">स्थान एक्सेस</string>
-    <string name="settings_location_rationale_body">ClothesCast आपका स्थानीय पूर्वानुमान लाने के लिए आपका स्थान पढ़ता है।</string>
-    <string name="settings_location_rationale_continue">जारी रखें</string>
-    <string name="settings_location_rationale_dismiss">अभी नहीं</string>
     <string name="settings_location_background_rationale_title">हमेशा अनुमति दें</string>
     <string name="settings_location_background_rationale_body">ClothesCast बंद होने पर भी सुबह का पूर्वानुमान समय पर अपडेट हो सके, इसके लिए "हमेशा अनुमति दें" की ज़रूरत है।</string>
     <string name="settings_location_background_rationale_continue">सेटिंग खोलें</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -478,10 +478,6 @@ spousal register), matching the existing insight prose ("Ponesi …",
     <string name="settings_location_background_denied_open">Otvori Postavke</string>
     <string name="settings_location_background_denied_keep">Nastavi koristiti spremljenu lokaciju</string>
 
-    <string name="settings_location_rationale_title">Stalna lokacija</string>
-    <string name="settings_location_rationale_body">ClothesCast ažurira tvoju prognozu u pozadini kako bi je dostavio na vrijeme, pa mu je potrebno dopuštenje lokacije \'Dopusti uvijek\'.</string>
-    <string name="settings_location_rationale_continue">Nastavi</string>
-    <string name="settings_location_rationale_dismiss">Sad ne</string>
 
 
     <string name="settings_region_language_am_et">Amharski (Etiopija)</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -311,10 +311,6 @@ locale (Angol (Egyesült Államok), Francia (Franciaország), Német
     <string name="settings_location_background_denied_open">Beállítások megnyitása</string>
     <string name="settings_location_background_denied_keep">Mentett helyszín megtartása</string>
 
-    <string name="settings_location_rationale_title">Állandó helyszín</string>
-    <string name="settings_location_rationale_body">A ClothesCast a háttérben frissíti az előrejelzésedet, hogy időben kézbesítse. Ehhez „Mindig engedélyezve" helyszín-engedély szükséges.</string>
-    <string name="settings_location_rationale_continue">Folytatás</string>
-    <string name="settings_location_rationale_dismiss">Most nem</string>
 
     <!-- Notification channels. -->
     <string name="notification_channel_daily_insight_name">Napi ClothesCast</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -332,10 +332,6 @@ to values/strings.xml (English).
     <string name="settings_location_search">Cari</string>
     <string name="settings_location_searching">Mencari…</string>
     <string name="settings_location_no_results">Tidak ada hasil.</string>
-    <string name="settings_location_rationale_title">Akses lokasi</string>
-    <string name="settings_location_rationale_body">ClothesCast membaca lokasi Anda untuk mengambil prakiraan lokal.</string>
-    <string name="settings_location_rationale_continue">Lanjutkan</string>
-    <string name="settings_location_rationale_dismiss">Nanti saja</string>
     <string name="settings_location_background_rationale_title">Izinkan setiap saat</string>
     <string name="settings_location_background_rationale_body">Izinkan ClothesCast membaca lokasi Anda saat ditutup agar prakiraan pagi diperbarui tepat waktu.</string>
     <string name="settings_location_background_rationale_continue">Buka Pengaturan</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -496,10 +496,6 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_location_background_denied_open">Apri Impostazioni</string>
     <string name="settings_location_background_denied_keep">Continua a usare la posizione salvata</string>
 
-    <string name="settings_location_rationale_title">Posizione sempre attiva</string>
-    <string name="settings_location_rationale_body">ClothesCast aggiorna le previsioni in background per consegnarle puntualmente e necessita dell\'autorizzazione alla posizione \'Consenti sempre\'.</string>
-    <string name="settings_location_rationale_continue">Continua</string>
-    <string name="settings_location_rationale_dismiss">Non ora</string>
 
 
     <string name="settings_region_language_am_et">Amarico (Etiopia)</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -336,10 +336,6 @@ standard in Israeli digital communication.
     <string name="settings_location_search">חפש/י</string>
     <string name="settings_location_searching">מחפש/ת…</string>
     <string name="settings_location_no_results">אין תוצאות.</string>
-    <string name="settings_location_rationale_title">גישה למיקום</string>
-    <string name="settings_location_rationale_body">ClothesCast קורא את מיקומך כדי לאחזר את התחזית המקומית שלך.</string>
-    <string name="settings_location_rationale_continue">המשך/י</string>
-    <string name="settings_location_rationale_dismiss">לא עכשיו</string>
     <string name="settings_location_background_rationale_title">אפשר/י בכל עת</string>
     <string name="settings_location_background_rationale_body">אפשר/י ל-ClothesCast לקרוא את מיקומך כשהוא סגור כדי שתחזית הבוקר תתעדכן בזמן.</string>
     <string name="settings_location_background_rationale_continue">פתח/י הגדרות</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -512,10 +512,6 @@ the displayed label localizes.
     <string name="settings_location_background_denied_open">設定を開く</string>
     <string name="settings_location_background_denied_keep">保存済みの位置情報を使い続ける</string>
 
-    <string name="settings_location_rationale_title">常時位置情報</string>
-    <string name="settings_location_rationale_body">ClothesCastは予報を時間通りに届けるためバックグラウンドで更新します。そのため、位置情報の「常に許可」が必要です。</string>
-    <string name="settings_location_rationale_continue">続ける</string>
-    <string name="settings_location_rationale_dismiss">後で</string>
 
 
     <string name="settings_region_language_am_et">アムハラ語（エチオピア）</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -522,10 +522,6 @@ displayed label localizes.
     <string name="settings_location_background_denied_open">설정 열기</string>
     <string name="settings_location_background_denied_keep">저장된 위치 계속 사용</string>
 
-    <string name="settings_location_rationale_title">상시 위치</string>
-    <string name="settings_location_rationale_body">ClothesCast는 예보를 제때 전달하기 위해 백그라운드에서 업데이트하므로 \'항상 허용\' 위치 권한이 필요합니다.</string>
-    <string name="settings_location_rationale_continue">계속</string>
-    <string name="settings_location_rationale_dismiss">나중에</string>
 
 
     <string name="settings_region_language_am_et">암하라어 (에티오피아)</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -339,10 +339,6 @@ What is NOT overridden, by design:
     <string name="settings_location_search">Ieškoti</string>
     <string name="settings_location_searching">Ieškoma…</string>
     <string name="settings_location_no_results">Atitikmenų nerasta.</string>
-    <string name="settings_location_rationale_title">Prieiga prie vietos</string>
-    <string name="settings_location_rationale_body">ClothesCast nuskaito tavo vietą, kad gautų vietinę prognozę.</string>
-    <string name="settings_location_rationale_continue">Tęsti</string>
-    <string name="settings_location_rationale_dismiss">Ne dabar</string>
     <string name="settings_location_background_rationale_title">Leisti visada</string>
     <string name="settings_location_background_rationale_body">Leisk ClothesCast nuskaityti tavo vietą, kol programa uždaryta, kad ryto prognozė būtų atnaujinta laiku.</string>
     <string name="settings_location_background_rationale_continue">Atidaryti nustatymus</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -315,10 +315,6 @@ informal "tu"-form throughout ("Apģērb …", "Paņem … līdzi").
     <string name="settings_location_search">Meklēt</string>
     <string name="settings_location_searching">Meklē…</string>
     <string name="settings_location_no_results">Nav atbilstību.</string>
-    <string name="settings_location_rationale_title">Atrašanās vietas piekļuve</string>
-    <string name="settings_location_rationale_body">ClothesCast nolasa tavu atrašanās vietu, lai iegūtu vietējo prognozi.</string>
-    <string name="settings_location_rationale_continue">Turpināt</string>
-    <string name="settings_location_rationale_dismiss">Ne tagad</string>
     <string name="settings_location_background_rationale_title">Atļaut vienmēr</string>
     <string name="settings_location_background_rationale_body">Atļauj ClothesCast nolasīt tavu atrašanās vietu, kamēr lietotne ir aizvērta, lai rīta prognoze tiktu atjaunināta laicīgi.</string>
     <string name="settings_location_background_rationale_continue">Atvērt iestatījumus</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -333,10 +333,6 @@ vs "kemungkinan", "padam" vs "hapus").
     <string name="settings_location_search">Cari</string>
     <string name="settings_location_searching">Mencari…</string>
     <string name="settings_location_no_results">Tiada padanan.</string>
-    <string name="settings_location_rationale_title">Akses lokasi</string>
-    <string name="settings_location_rationale_body">ClothesCast membaca lokasi anda untuk mengambil ramalan tempatan anda.</string>
-    <string name="settings_location_rationale_continue">Teruskan</string>
-    <string name="settings_location_rationale_dismiss">Bukan sekarang</string>
     <string name="settings_location_background_rationale_title">Benarkan sepanjang masa</string>
     <string name="settings_location_background_rationale_body">Benarkan ClothesCast membaca lokasi anda semasa ditutup supaya ramalan pagi dikemas kini tepat pada waktunya.</string>
     <string name="settings_location_background_rationale_continue">Buka Tetapan</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -310,10 +310,6 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrike)").
     <string name="settings_location_background_denied_open">Åpne innstillinger</string>
     <string name="settings_location_background_denied_keep">Behold lagret plassering</string>
 
-    <string name="settings_location_rationale_title">Permanent plassering</string>
-    <string name="settings_location_rationale_body">ClothesCast oppdaterer prognosen din i bakgrunnen for å levere den i tide. Det krever plasseringstillatelsen "Tillat alltid".</string>
-    <string name="settings_location_rationale_continue">Fortsett</string>
-    <string name="settings_location_rationale_dismiss">Ikke nå</string>
 
     <!-- Notification channels. -->
     <string name="notification_channel_daily_insight_name">Daglig ClothesCast</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -483,10 +483,6 @@ the displayed label localizes.
     <string name="settings_location_background_denied_open">Instellingen openen</string>
     <string name="settings_location_background_denied_keep">Opgeslagen locatie behouden</string>
 
-    <string name="settings_location_rationale_title">Permanente locatie</string>
-    <string name="settings_location_rationale_body">ClothesCast vernieuwt je voorspelling op de achtergrond om hem op tijd te bezorgen. Daarvoor is de locatietoestemming \'Altijd toestaan\' nodig.</string>
-    <string name="settings_location_rationale_continue">Doorgaan</string>
-    <string name="settings_location_rationale_dismiss">Niet nu</string>
 
     <string name="settings_root_schedule_subtitle">Meldingen en tijdstippen</string>
     <string name="settings_root_format_subtitle">Formulering en uitvoerigheid</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -481,10 +481,6 @@ is unchanged; only the displayed label localizes.
     <string name="settings_location_background_denied_open">Otwórz ustawienia</string>
     <string name="settings_location_background_denied_keep">Zachowaj zapisaną lokalizację</string>
 
-    <string name="settings_location_rationale_title">Stała lokalizacja</string>
-    <string name="settings_location_rationale_body">ClothesCast aktualizuje prognozę w tle, aby dostarczyć ją na czas. Wymaga to uprawnienia lokalizacji \'Zawsze zezwalaj\'.</string>
-    <string name="settings_location_rationale_continue">Dalej</string>
-    <string name="settings_location_rationale_dismiss">Nie teraz</string>
 
     <string name="settings_root_schedule_subtitle">Powiadomienia i godziny</string>
     <string name="settings_root_format_subtitle">Sformułowanie i szczegółowość</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -514,10 +514,6 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_location_background_denied_open">Abrir Configurações</string>
     <string name="settings_location_background_denied_keep">Continuar usando a localização salva</string>
 
-    <string name="settings_location_rationale_title">Localização permanente</string>
-    <string name="settings_location_rationale_body">O ClothesCast atualiza sua previsão em segundo plano para entregá-la no horário certo e precisa da permissão de localização \'Permitir o tempo todo\'.</string>
-    <string name="settings_location_rationale_continue">Continuar</string>
-    <string name="settings_location_rationale_dismiss">Agora não</string>
 
 
     <string name="settings_region_language_am_et">Amárico (Etiópia)</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -608,10 +608,6 @@ they diverge from BR ("Polonês" → "Polaco", "Holandês" →
     <string name="settings_location_manual_override_disclosure">Se escolheres uma cidade, a deteção automática será desativada.</string>
 
     <!-- Location permission rationale dialogs. -->
-    <string name="settings_location_rationale_title">Acesso à localização</string>
-    <string name="settings_location_rationale_body">O ClothesCast lê a tua localização para ir buscar a previsão local.</string>
-    <string name="settings_location_rationale_continue">Continuar</string>
-    <string name="settings_location_rationale_dismiss">Agora não</string>
     <string name="settings_location_background_rationale_title">Permitir sempre</string>
     <string name="settings_location_background_rationale_body">O ClothesCast vai buscar a tua previsão em segundo plano todas as manhãs e precisa do acesso à localização \'Permitir sempre\'. Serás redirecionado para as Definições do sistema para o conceder.</string>
     <string name="settings_location_background_rationale_continue">Abrir Definições</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -335,10 +335,6 @@ surfaces fall back to default English (matching values-pl / values-uk).
     <string name="settings_location_search">Caută</string>
     <string name="settings_location_searching">Se caută…</string>
     <string name="settings_location_no_results">Niciun rezultat.</string>
-    <string name="settings_location_rationale_title">Acces la locație</string>
-    <string name="settings_location_rationale_body">ClothesCast citește locația ta pentru a prelua prognoza locală.</string>
-    <string name="settings_location_rationale_continue">Continuă</string>
-    <string name="settings_location_rationale_dismiss">Nu acum</string>
     <string name="settings_location_background_rationale_title">Permite mereu</string>
     <string name="settings_location_background_rationale_body">Permite ClothesCast să citească locația ta când este închis, astfel prognoza de dimineață se actualizează la timp.</string>
     <string name="settings_location_background_rationale_continue">Deschide Setările</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -353,10 +353,6 @@ only the displayed label localizes.
     <string name="settings_location_background_denied_open">Открыть настройки</string>
     <string name="settings_location_background_denied_keep">Продолжить использовать сохранённое местоположение</string>
 
-    <string name="settings_location_rationale_title">Постоянное местоположение</string>
-    <string name="settings_location_rationale_body">ClothesCast обновляет прогноз в фоновом режиме, чтобы доставить его вовремя. Для этого требуется разрешение на местоположение «Разрешить всегда».</string>
-    <string name="settings_location_rationale_continue">Продолжить</string>
-    <string name="settings_location_rationale_dismiss">Не сейчас</string>
 
     <!--
     Notification channels (system Settings → App → Notifications) and

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -316,10 +316,6 @@ What is NOT overridden, by design:
     <string name="settings_location_background_denied_open">Otvoriť nastavenia</string>
     <string name="settings_location_background_denied_keep">Ponechať uloženú polohu</string>
 
-    <string name="settings_location_rationale_title">Trvalá poloha</string>
-    <string name="settings_location_rationale_body">ClothesCast aktualizuje predpoveď na pozadí, aby ju doručil načas. Na to potrebuje oprávnenie k polohe „Vždy povoliť".</string>
-    <string name="settings_location_rationale_continue">Pokračovať</string>
-    <string name="settings_location_rationale_dismiss">Teraz nie</string>
 
     <!--
     Notification channels.

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -347,10 +347,6 @@ informal "ti"-form throughout, mirroring the Croatian / Serbian pass.
     <string name="settings_location_search">Iskanje</string>
     <string name="settings_location_searching">Iskanje…</string>
     <string name="settings_location_no_results">Ni zadetkov.</string>
-    <string name="settings_location_rationale_title">Dostop do lokacije</string>
-    <string name="settings_location_rationale_body">ClothesCast prebere tvojo lokacijo za pridobitev lokalne napovedi.</string>
-    <string name="settings_location_rationale_continue">Nadaljuj</string>
-    <string name="settings_location_rationale_dismiss">Ne zdaj</string>
     <string name="settings_location_background_rationale_title">Dovoli ves čas</string>
     <string name="settings_location_background_rationale_body">Dovoli ClothesCastu, da prebere tvojo lokacijo, ko je zaprt, da se jutranja napoved posodobi pravočasno.</string>
     <string name="settings_location_background_rationale_continue">Odpri nastavitve</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -310,10 +310,6 @@ native names for all locales (e.g. "Tyska (Tyskland)", "Franska (Frankrike)").
     <string name="settings_location_background_denied_open">Öppna inställningar</string>
     <string name="settings_location_background_denied_keep">Behåll sparad plats</string>
 
-    <string name="settings_location_rationale_title">Permanent plats</string>
-    <string name="settings_location_rationale_body">ClothesCast uppdaterar din prognos i bakgrunden för att leverera den i tid. Det kräver platsbehörigheten "Tillåt alltid".</string>
-    <string name="settings_location_rationale_continue">Fortsätt</string>
-    <string name="settings_location_rationale_dismiss">Inte nu</string>
 
     <!-- Notification channels. -->
     <string name="notification_channel_daily_insight_name">Dagligt ClothesCast</string>

--- a/app/src/main/res/values-sw/strings.xml
+++ b/app/src/main/res/values-sw/strings.xml
@@ -293,10 +293,6 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="settings_location_search">Tafuta</string>
     <string name="settings_location_searching">Inatafuta…</string>
     <string name="settings_location_no_results">Hakuna matokeo.</string>
-    <string name="settings_location_rationale_title">Upatikanaji wa mahali</string>
-    <string name="settings_location_rationale_body">ClothesCast inasoma mahali pako ili kupata utabiri wako wa karibu.</string>
-    <string name="settings_location_rationale_continue">Endelea</string>
-    <string name="settings_location_rationale_dismiss">Si sasa</string>
     <string name="settings_location_background_rationale_title">Ruhusu wakati wote</string>
     <string name="settings_location_background_rationale_body">Ruhusu ClothesCast kusoma mahali pako programu ikifungwa ili utabiri wa asubuhi usasishwe kwa wakati.</string>
     <string name="settings_location_background_rationale_continue">Fungua Mipangilio</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -335,10 +335,6 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="settings_location_search">ค้นหา</string>
     <string name="settings_location_searching">กำลังค้นหา…</string>
     <string name="settings_location_no_results">ไม่พบผลลัพธ์</string>
-    <string name="settings_location_rationale_title">การเข้าถึงตำแหน่ง</string>
-    <string name="settings_location_rationale_body">ClothesCast อ่านตำแหน่งของคุณเพื่อดึงพยากรณ์อากาศท้องถิ่น</string>
-    <string name="settings_location_rationale_continue">ดำเนินการต่อ</string>
-    <string name="settings_location_rationale_dismiss">ไม่ใช่ตอนนี้</string>
     <string name="settings_location_background_rationale_title">อนุญาตตลอดเวลา</string>
     <string name="settings_location_background_rationale_body">อนุญาตให้ ClothesCast อ่านตำแหน่งของคุณขณะแอปปิดอยู่ เพื่อให้พยากรณ์อากาศช่วงเช้าอัปเดตตรงเวลา</string>
     <string name="settings_location_background_rationale_continue">เปิดการตั้งค่า</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -439,10 +439,6 @@ displayed label localizes.
     <string name="settings_location_background_denied_open">Ayarları aç</string>
     <string name="settings_location_background_denied_keep">Kayıtlı konumu koru</string>
 
-    <string name="settings_location_rationale_title">Kalıcı konum</string>
-    <string name="settings_location_rationale_body">ClothesCast zamanında teslim etmek için tahmininizi arka planda günceller. Bunun için "Her zaman izin ver" konum iznine ihtiyaç vardır.</string>
-    <string name="settings_location_rationale_continue">Devam et</string>
-    <string name="settings_location_rationale_dismiss">Şimdi değil</string>
 
     <string name="settings_root_schedule_subtitle">Bildirimler ve saatler</string>
     <string name="settings_root_format_subtitle">İfade ve ayrıntı düzeyi</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -305,10 +305,6 @@ only the displayed label localizes.
     <string name="settings_location_search">Знайти</string>
     <string name="settings_location_searching">Пошук…</string>
     <string name="settings_location_no_results">Нічого не знайдено.</string>
-    <string name="settings_location_rationale_title">Доступ до місцезнаходження</string>
-    <string name="settings_location_rationale_body">ClothesCast зчитує ваше місцезнаходження, щоб отримати місцевий прогноз.</string>
-    <string name="settings_location_rationale_continue">Продовжити</string>
-    <string name="settings_location_rationale_dismiss">Не зараз</string>
     <string name="settings_location_background_rationale_title">Дозволити завжди</string>
     <string name="settings_location_background_rationale_body">Дозвольте ClothesCast зчитувати ваше місцезнаходження, коли застосунок закрито, щоб ранковий прогноз оновлювався вчасно.</string>
     <string name="settings_location_background_rationale_continue">Відкрити налаштування</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -352,10 +352,6 @@ Skipped intentionally: app_name (brand), insight_time_am/pm/midnight/noon
     <string name="settings_location_search">Tìm kiếm</string>
     <string name="settings_location_searching">Đang tìm kiếm…</string>
     <string name="settings_location_no_results">Không có kết quả.</string>
-    <string name="settings_location_rationale_title">Quyền truy cập vị trí</string>
-    <string name="settings_location_rationale_body">ClothesCast đọc vị trí của bạn để tải dự báo địa phương.</string>
-    <string name="settings_location_rationale_continue">Tiếp tục</string>
-    <string name="settings_location_rationale_dismiss">Để sau</string>
     <string name="settings_location_background_rationale_title">Cho phép mọi lúc</string>
     <string name="settings_location_background_rationale_body">Cho phép ClothesCast đọc vị trí khi ứng dụng đóng để dự báo buổi sáng cập nhật đúng giờ.</string>
     <string name="settings_location_background_rationale_continue">Mở Cài đặt</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -504,10 +504,6 @@ label localizes.
     <string name="settings_location_background_denied_open">打开设置</string>
     <string name="settings_location_background_denied_keep">继续使用保存的位置</string>
 
-    <string name="settings_location_rationale_title">始终开启位置</string>
-    <string name="settings_location_rationale_body">ClothesCast 在后台更新您的预报以准时送达，因此需要"始终允许"位置权限。</string>
-    <string name="settings_location_rationale_continue">继续</string>
-    <string name="settings_location_rationale_dismiss">暂不</string>
 
 
     <string name="settings_region_language_am_et">阿姆哈拉语（埃塞俄比亚）</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -574,10 +574,6 @@ label localises.
     <string name="settings_location_manual_override">位置不對？手動設定</string>
     <string name="settings_location_manual_override_disclosure">選擇城市會關閉自動偵測。</string>
 
-    <string name="settings_location_rationale_title">位置權限</string>
-    <string name="settings_location_rationale_body">ClothesCast 會讀取你的位置以取得當地天氣預報。</string>
-    <string name="settings_location_rationale_continue">繼續</string>
-    <string name="settings_location_rationale_dismiss">暫不</string>
 
     <string name="settings_location_background_rationale_title">始終允許</string>
     <string name="settings_location_background_rationale_body">允許 ClothesCast 在應用程式關閉時也讀取你的位置，讓早晨預報能準時更新。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -722,10 +722,6 @@
     <string name="settings_location_search">Search</string>
     <string name="settings_location_searching">Searching…</string>
     <string name="settings_location_no_results">No matches.</string>
-    <string name="settings_location_rationale_title">Location access</string>
-    <string name="settings_location_rationale_body">ClothesCast reads your location to fetch your local forecast.</string>
-    <string name="settings_location_rationale_continue">Continue</string>
-    <string name="settings_location_rationale_dismiss">Not now</string>
     <string name="settings_location_background_rationale_title">Allow all the time</string>
     <string name="settings_location_background_rationale_body">Allow ClothesCast to read your location while it\'s closed so the morning forecast updates on time.</string>
     <string name="settings_location_background_rationale_continue">Open Settings</string>


### PR DESCRIPTION
## What

Turning on **Use device location** in Settings previously opened our own rationale `AlertDialog` *before* the system foreground-permission prompt, so the user had to dismiss two dialogs back to back. Now the toggle launches the system `ACCESS_COARSE_LOCATION` prompt directly — just the system one.

## Why

This matches the onboarding flow, which already requests the foreground permission without a preceding rationale. Stacking our own dialog in front of the system prompt was redundant friction.

## Scope

- `LocationSettings.kt`: the `!coarseGranted` branch of the toggle now calls `foregroundLauncher.launch(...)` instead of opening `rationaleOpen`; removed the now-unused `rationaleOpen` state and its `AlertDialog`.
- Removed the now-unused `settings_location_rationale_*` strings from base `values/` and all 44 translated locales.
- **Unchanged:** the background-location rationale. Android 11+ requires `ACCESS_BACKGROUND_LOCATION` to be requested separately and deep-links into system Settings, so the explanatory dialog there still earns its place.

No change to what data leaves the device.

## Test plan

- `./gradlew :app:assembleDebug` ✅
- `./gradlew :app:testDebugUnitTest` ✅ (BUILD SUCCESSFUL)

https://claude.ai/code/session_01Bmg2erozn9B2qdJmhYLysD

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bmg2erozn9B2qdJmhYLysD)_