### PR TITLE
Ask for always-on location when you enable a schedule, not before

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/settings/LocationSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/LocationSettings.kt
@@ -54,6 +54,11 @@ internal fun LocationContent(
     location: Location?,
     useDeviceLocation: Boolean,
     locationDetecting: Boolean = false,
+    // Whether a morning or evening schedule is enabled. Background ("Allow all
+    // the time") location is only needed when the worker runs unattended, so
+    // the always-on warning banner only nags when a schedule is on — granting
+    // it now lives on the Schedule page's enable flow.
+    scheduleEnabled: Boolean = false,
     padding: PaddingValues,
     onSetUseDeviceLocation: (Boolean) -> Unit,
     onSelectLocation: (Location) -> Unit,
@@ -79,6 +84,7 @@ internal fun LocationContent(
                 current = location,
                 useDeviceLocation = useDeviceLocation,
                 locationDetecting = locationDetecting,
+                scheduleEnabled = scheduleEnabled,
                 onSetUseDeviceLocation = onSetUseDeviceLocation,
                 onSelect = onSelectLocation,
                 onClear = onClearLocation,
@@ -103,6 +109,7 @@ private fun LocationCard(
     current: Location?,
     useDeviceLocation: Boolean,
     locationDetecting: Boolean,
+    scheduleEnabled: Boolean,
     onSetUseDeviceLocation: (Boolean) -> Unit,
     onSelect: (Location) -> Unit,
     onClear: () -> Unit,
@@ -144,16 +151,17 @@ private fun LocationCard(
         coarseGranted = granted
         // Only flip the toggle on if foreground was granted; otherwise the worker
         // would hit our isPermissionGranted check, return null, and quietly fall
-        // through to the settings location every day.
+        // through to the settings location every day. We no longer auto-chain into
+        // the always-on prompt here — background location is only needed once a
+        // schedule runs the worker unattended, so that grant moved to the Schedule
+        // page's enable flow.
         onSetUseDeviceLocation(granted)
-        if (granted && !hasBackgroundLocationPermission(context)) {
-            // Auto-chain into the always-on rationale; the worker can't read the
-            // device fix without ACCESS_BACKGROUND_LOCATION.
-            backgroundRationaleOpen = true
-        }
     }
 
-    if (useDeviceLocation && !backgroundGranted) {
+    // Only nag for always-on once a schedule actually needs it: device location +
+    // a foreground refresh works fine without ACCESS_BACKGROUND_LOCATION; it's the
+    // unattended scheduled run that can't read the fix without it.
+    if (useDeviceLocation && scheduleEnabled && !backgroundGranted) {
         BackgroundLocationWarningBanner(
             onGrant = { backgroundRationaleOpen = true },
         )
@@ -176,20 +184,15 @@ private fun LocationCard(
                         onSetUseDeviceLocation(false)
                         return@Switch
                     }
-                    when {
-                        // Go straight to the system foreground prompt; we auto-chain
-                        // into the background rationale once the user grants. Showing
-                        // our own rationale first just stacks a second dialog in front
-                        // of the system one.
-                        !coarseGranted ->
-                            foregroundLauncher.launch(Manifest.permission.ACCESS_COARSE_LOCATION)
-                        !backgroundGranted -> {
-                            // Foreground granted previously; surface the always-on
-                            // rationale before deep-linking into Settings.
-                            onSetUseDeviceLocation(true)
-                            backgroundRationaleOpen = true
-                        }
-                        else -> onSetUseDeviceLocation(true)
+                    // Just get foreground location here — that's all turning on
+                    // device location needs to resolve a fix on a foreground
+                    // refresh. The always-on ("Allow all the time") grant is
+                    // requested later, when the user enables a schedule and the
+                    // worker actually needs to read the fix unattended.
+                    if (!coarseGranted) {
+                        foregroundLauncher.launch(Manifest.permission.ACCESS_COARSE_LOCATION)
+                    } else {
+                        onSetUseDeviceLocation(true)
                     }
                 },
             )
@@ -414,15 +417,17 @@ private fun BackgroundLocationWarningBanner(onGrant: () -> Unit) {
 /**
  * Settings root warning card — a compact deep-link variant of
  * [BackgroundLocationWarningBanner]. Shown on the Settings root when device
- * location is on but background access is missing; tapping the card navigates
- * into the Location sub-page where the full launcher and rationale dialogs
- * live. Renders nothing while permission is granted or device location is off,
- * and re-checks on resume so granting from system Settings clears the card
- * without an in-app action.
+ * location is on, a schedule is enabled, but background access is missing;
+ * tapping the card navigates into the Location sub-page where the full launcher
+ * and rationale dialogs live. Renders nothing while permission is granted,
+ * device location is off, or no schedule needs an unattended fix, and re-checks
+ * on resume so granting from system Settings clears the card without an in-app
+ * action.
  */
 @Composable
 internal fun BackgroundLocationWarningCard(
     useDeviceLocation: Boolean,
+    scheduleEnabled: Boolean,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -440,7 +445,7 @@ internal fun BackgroundLocationWarningCard(
         onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
     }
 
-    if (!useDeviceLocation || backgroundGranted) return
+    if (!useDeviceLocation || !scheduleEnabled || backgroundGranted) return
 
     Card(
         onClick = onClick,

--- a/app/src/main/kotlin/app/clothescast/ui/settings/ScheduleSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/ScheduleSettings.kt
@@ -1,5 +1,6 @@
 package app.clothescast.ui.settings
 
+import android.Manifest
 import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -53,7 +54,10 @@ import androidx.lifecycle.LifecycleEventObserver
 import app.clothescast.R
 import app.clothescast.core.domain.model.DeliveryMode
 import app.clothescast.core.domain.model.ForecastPeriod
+import app.clothescast.core.domain.model.Location
 import app.clothescast.core.domain.model.TimeFormat
+import app.clothescast.location.hasBackgroundLocationPermission
+import app.clothescast.location.hasCoarseLocationPermission
 import app.clothescast.notification.NotificationPermission
 import app.clothescast.work.FetchAndNotifyWorker
 import app.clothescast.ui.EdgeFadeOverlay
@@ -76,11 +80,17 @@ internal fun ScheduleContent(
     deliveryMode: DeliveryMode,
     tonightDeliveryMode: DeliveryMode,
     sharedTtsAvailable: Boolean,
+    // Location state, so enabling a schedule can request exactly the location
+    // access an unattended scheduled run needs: foreground when no location is
+    // set yet, then always-on once device location is the source.
+    useDeviceLocation: Boolean,
+    location: Location?,
     padding: PaddingValues,
     onSetSchedule: (LocalTime, Set<DayOfWeek>) -> Unit,
     onSetDailyEnabled: (Boolean) -> Unit,
     onSetTonightSchedule: (LocalTime, Set<DayOfWeek>) -> Unit,
     onSetTonightEnabled: (Boolean) -> Unit,
+    onSetUseDeviceLocation: (Boolean) -> Unit,
     onSetTonightNotifyOnlyOnEvents: (Boolean) -> Unit,
     onSetDailyMentionEveningEvents: (Boolean) -> Unit,
     onSetDeliveryMode: (DeliveryMode) -> Unit,
@@ -106,16 +116,32 @@ internal fun ScheduleContent(
     var notificationGranted by remember {
         mutableStateOf(NotificationPermission.isGranted(context))
     }
+    // Location grants gate the just-in-time prompts on the schedule-enable path.
+    // Re-checked on resume alongside notifications so a grant/revoke made in
+    // system Settings (the always-on picker deep-links there) is reflected
+    // without an in-app action.
+    var coarseGranted by remember { mutableStateOf(hasCoarseLocationPermission(context)) }
+    var backgroundGranted by remember { mutableStateOf(hasBackgroundLocationPermission(context)) }
     val lifecycleOwner = LocalLifecycleOwner.current
     DisposableEffect(lifecycleOwner) {
         val observer = LifecycleEventObserver { _, event ->
             if (event == Lifecycle.Event.ON_RESUME) {
                 notificationGranted = NotificationPermission.isGranted(context)
+                coarseGranted = hasCoarseLocationPermission(context)
+                backgroundGranted = hasBackgroundLocationPermission(context)
             }
         }
         lifecycleOwner.lifecycle.addObserver(observer)
         onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
     }
+
+    var backgroundRationaleOpen by remember { mutableStateOf(false) }
+    var backgroundDeniedOpen by remember { mutableStateOf(false) }
+    // Set while a notification prompt fired from the enable path is in flight, so
+    // its result callback knows to continue into the location chain rather than
+    // showing two system dialogs at once. Delivery-channel toggles reuse the same
+    // launcher but leave this false, so they don't trigger the location chain.
+    var pendingScheduleLocationCheck by remember { mutableStateOf(false) }
 
     // Turning a delivery channel on requests exactly what that channel needs,
     // just-in-time. Notify → the system POST_NOTIFICATIONS prompt (no-op on
@@ -123,12 +149,74 @@ internal fun ScheduleContent(
     // NotificationPermissionBanner shown beside the toggle). Speak → the full
     // Voice settings page (via onSetUpSpeech) to pick Gemini-with-key or device
     // TTS, which returns here via its "Done" button.
+    val backgroundLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestPermission(),
+    ) { granted ->
+        backgroundGranted = granted
+        if (!granted) backgroundDeniedOpen = true
+    }
+
+    // Launching ACCESS_BACKGROUND_LOCATION on Android 11+ deep-links to the
+    // system Location-permission picker (the "Allow all the time" page). We
+    // front it with our own rationale so the deep-link isn't a surprise.
+    val ensureBackgroundLocation: () -> Unit = {
+        if (!backgroundGranted) backgroundRationaleOpen = true
+    }
+
+    val foregroundLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestPermission(),
+    ) { granted ->
+        coarseGranted = granted
+        if (granted) {
+            // Granting foreground from the schedule path means the user wants the
+            // scheduled cast to follow the device, so switch the source on — then
+            // chain into always-on, which the unattended run actually needs.
+            onSetUseDeviceLocation(true)
+            ensureBackgroundLocation()
+        }
+    }
+
+    // The location access a scheduled run needs, requested just-in-time when a
+    // schedule is enabled. No location set yet → ask for foreground (which turns
+    // device location on); already on device location → make sure always-on is
+    // granted. A manual city needs no location permission, so nothing fires.
+    val ensureLocationForSchedule: () -> Unit = {
+        when {
+            useDeviceLocation && !coarseGranted ->
+                foregroundLauncher.launch(Manifest.permission.ACCESS_COARSE_LOCATION)
+            useDeviceLocation -> ensureBackgroundLocation()
+            location == null ->
+                foregroundLauncher.launch(Manifest.permission.ACCESS_COARSE_LOCATION)
+        }
+    }
+
     val notificationLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.RequestPermission(),
-    ) { granted -> notificationGranted = granted }
+    ) { granted ->
+        notificationGranted = granted
+        // Continue the enable chain only if this prompt came from enabling a
+        // schedule; sequencing after the notification result avoids stacking two
+        // system permission dialogs.
+        if (pendingScheduleLocationCheck) {
+            pendingScheduleLocationCheck = false
+            ensureLocationForSchedule()
+        }
+    }
     val requestNotificationPermission: () -> Unit = {
         if (NotificationPermission.isRequired() && !notificationGranted) {
             notificationLauncher.launch(NotificationPermission.MANIFEST_PERMISSION)
+        }
+    }
+
+    // Enabling a schedule opts the user into unattended delivery, so request
+    // everything that run needs: notifications first, then — sequenced after its
+    // result — the location access the worker needs to resolve a fix on its own.
+    val onScheduleEnabled: () -> Unit = {
+        if (NotificationPermission.isRequired() && !notificationGranted) {
+            pendingScheduleLocationCheck = true
+            notificationLauncher.launch(NotificationPermission.MANIFEST_PERMISSION)
+        } else {
+            ensureLocationForSchedule()
         }
     }
 
@@ -153,13 +241,15 @@ internal fun ScheduleContent(
                 notificationGranted = notificationGranted,
                 mentionEveningEvents = dailyMentionEveningEvents,
                 // Enabling a master switch is the user opting into scheduled
-                // delivery, so prompt for notification permission right then —
-                // not only when the notification channel is toggled. The channel
-                // is on by default, so without this the prompt would never fire
-                // on the enable path and the worker would later no-op silently.
+                // delivery, so prompt for everything that unattended run needs —
+                // notifications and, when device location is the source, the
+                // always-on location grant — right then, not only when a channel
+                // is toggled. The notification channel is on by default, so
+                // without this the prompts would never fire on the enable path
+                // and the worker would later no-op silently.
                 onSetEnabled = { enabled ->
                     onSetDailyEnabled(enabled)
-                    if (enabled) requestNotificationPermission()
+                    if (enabled) onScheduleEnabled()
                 },
                 onChange = onSetSchedule,
                 onSetDeliveryMode = onSetDeliveryMode,
@@ -176,11 +266,12 @@ internal fun ScheduleContent(
                 notifyOnlyOnEvents = tonightNotifyOnlyOnEvents,
                 deliveryMode = tonightDeliveryMode,
                 notificationGranted = notificationGranted,
-                // Same as the morning card: prompt for notification permission
-                // the moment the user enables the evening schedule.
+                // Same as the morning card: prompt for notification and (when
+                // device location is the source) always-on location the moment
+                // the user enables the evening schedule.
                 onSetEnabled = { enabled ->
                     onSetTonightEnabled(enabled)
-                    if (enabled) requestNotificationPermission()
+                    if (enabled) onScheduleEnabled()
                 },
                 onSetNotifyOnlyOnEvents = onSetTonightNotifyOnlyOnEvents,
                 onChange = onSetTonightSchedule,
@@ -191,6 +282,44 @@ internal fun ScheduleContent(
                 previewEnabled = previewEnabled,
             )
         }
+    }
+
+    if (backgroundRationaleOpen) {
+        AlertDialog(
+            onDismissRequest = { backgroundRationaleOpen = false },
+            title = { Text(stringResource(R.string.settings_location_background_rationale_title)) },
+            text = { Text(stringResource(R.string.settings_location_background_rationale_body)) },
+            confirmButton = {
+                TextButton(onClick = {
+                    backgroundRationaleOpen = false
+                    backgroundLauncher.launch(Manifest.permission.ACCESS_BACKGROUND_LOCATION)
+                }) { Text(stringResource(R.string.settings_location_background_rationale_continue)) }
+            },
+            dismissButton = {
+                TextButton(onClick = { backgroundRationaleOpen = false }) {
+                    Text(stringResource(R.string.settings_location_background_rationale_dismiss))
+                }
+            },
+        )
+    }
+
+    if (backgroundDeniedOpen) {
+        AlertDialog(
+            onDismissRequest = { backgroundDeniedOpen = false },
+            title = { Text(stringResource(R.string.settings_location_background_denied_title)) },
+            text = { Text(stringResource(R.string.settings_location_background_denied_body)) },
+            confirmButton = {
+                TextButton(onClick = {
+                    backgroundDeniedOpen = false
+                    openAppDetails(context)
+                }) { Text(stringResource(R.string.settings_location_background_denied_open)) }
+            },
+            dismissButton = {
+                TextButton(onClick = { backgroundDeniedOpen = false }) {
+                    Text(stringResource(R.string.settings_location_background_denied_keep))
+                }
+            },
+        )
     }
 }
 

--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsPreviews.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsPreviews.kt
@@ -87,6 +87,7 @@ internal fun SettingsRootPreview() {
     SettingsFrame {
         SettingsRoot(
             useDeviceLocation = false,
+            scheduleEnabled = true,
             items = SettingsDest.entries.map { dest ->
                 SettingsMenuItem(dest.titleRes, dest.subtitleRes) {}
             },
@@ -127,11 +128,14 @@ private fun ScheduleContentSample() {
         deliveryMode = DeliveryMode.NOTIFICATION_ONLY,
         tonightDeliveryMode = DeliveryMode.NOTIFICATION_ONLY,
         sharedTtsAvailable = false,
+        useDeviceLocation = false,
+        location = null,
         padding = PaddingValues(0.dp),
         onSetSchedule = { _, _ -> },
         onSetDailyEnabled = {},
         onSetTonightSchedule = { _, _ -> },
         onSetTonightEnabled = {},
+        onSetUseDeviceLocation = {},
         onSetTonightNotifyOnlyOnEvents = {},
         onSetDailyMentionEveningEvents = {},
         onSetDeliveryMode = {},
@@ -539,6 +543,9 @@ internal fun SettingsLocationPreview() {
                 addressDetail = "Westminster, London SW1A 2AA, UK",
             ),
             useDeviceLocation = true,
+            // A schedule is on, so the always-on warning banner shows — that's
+            // the state this snapshot is meant to cover.
+            scheduleEnabled = true,
             padding = PaddingValues(0.dp),
             onSetUseDeviceLocation = {},
             onSelectLocation = {},
@@ -567,6 +574,7 @@ internal fun SettingsDoneBarPreview() {
                         addressDetail = "Westminster, London SW1A 2AA, UK",
                     ),
                     useDeviceLocation = true,
+                    scheduleEnabled = true,
                     padding = padding,
                     onSetUseDeviceLocation = {},
                     onSelectLocation = {},

--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsScreen.kt
@@ -159,6 +159,7 @@ internal fun SettingsRootPage(
     SettingsScaffold(R.string.settings_title, onBack) { padding ->
         SettingsRoot(
             useDeviceLocation = state.useDeviceLocation,
+            scheduleEnabled = state.dailyEnabled || state.tonightEnabled,
             items = items,
             padding = padding,
             onOpenLocation = onOpenLocation,
@@ -187,9 +188,12 @@ internal fun SchedulePage(
             deliveryMode = state.deliveryMode,
             tonightDeliveryMode = state.tonightDeliveryMode,
             sharedTtsAvailable = state.sharedTtsAvailable,
+            useDeviceLocation = state.useDeviceLocation,
+            location = state.location,
             padding = padding,
             onSetSchedule = viewModel::setSchedule,
             onSetDailyEnabled = viewModel::setDailyEnabled,
+            onSetUseDeviceLocation = viewModel::setUseDeviceLocation,
             onSetTonightSchedule = viewModel::setTonightSchedule,
             onSetTonightEnabled = viewModel::setTonightEnabled,
             onSetTonightNotifyOnlyOnEvents = viewModel::setTonightNotifyOnlyOnEvents,
@@ -314,6 +318,7 @@ internal fun LocationPage(viewModel: SettingsViewModel, onBack: () -> Unit) {
             location = state.location,
             useDeviceLocation = state.useDeviceLocation,
             locationDetecting = state.locationDetecting,
+            scheduleEnabled = state.dailyEnabled || state.tonightEnabled,
             padding = padding,
             onSetUseDeviceLocation = viewModel::setUseDeviceLocation,
             onSelectLocation = viewModel::selectLocation,
@@ -466,6 +471,7 @@ internal fun AboutPage(onBack: () -> Unit) {
 @Composable
 internal fun SettingsRoot(
     useDeviceLocation: Boolean,
+    scheduleEnabled: Boolean,
     items: List<SettingsMenuItem>,
     padding: PaddingValues,
     onOpenLocation: () -> Unit,
@@ -489,6 +495,7 @@ internal fun SettingsRoot(
             // rationale dialogs live.
             BackgroundLocationWarningCard(
                 useDeviceLocation = useDeviceLocation,
+                scheduleEnabled = scheduleEnabled,
                 onClick = onOpenLocation,
             )
             items.forEach { item ->


### PR DESCRIPTION
## What

Background (**Allow all the time**) location is only genuinely needed when the worker runs **unattended** for a scheduled cast — a foreground refresh resolves a fix with coarse location alone. Requesting it the moment device location is turned on was premature. This moves the always-on prompt to where it's actually justified: enabling a schedule.

## Behavior

When the user enables the **morning or evening schedule**, we now request, in sequence:
1. Notification permission (unchanged).
2. The location access the unattended run needs:
   - **No location set yet** → prompt for foreground (coarse) location, which turns device location on, then chain into always-on.
   - **Already on device location** → prompt for always-on.
   - **Manual city picked** → nothing (no location permission needed).

The two system prompts are sequenced via the notification result so they never stack on screen.

Other changes:
- The **device-location toggle** on the Location page no longer chains into the always-on prompt — it just secures foreground access.
- The always-on **warning banner** (Location page) and **card** (Settings root) now show only when a schedule is enabled + device location on + always-on missing.

Onboarding is intentionally unchanged for now.

## Privacy

No change to what data leaves the device. This only changes **when** we request `ACCESS_BACKGROUND_LOCATION` — strictly less eagerly, and only when an unattended scheduled run will actually read the fix.

## Test plan

- `./gradlew :app:assembleDebug` ✅
- `./gradlew :app:testDebugUnitTest` ✅ (Roborazzi snapshots unchanged — the Location preview keeps `scheduleEnabled = true` so it still covers the banner)

https://claude.ai/code/session_01Bmg2erozn9B2qdJmhYLysD

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bmg2erozn9B2qdJmhYLysD)_