### PR TITLE
Make umbrella a default rule at 30% rain chance

### DIFF
--- a/app/src/main/kotlin/app/clothescast/data/SettingsRepository.kt
+++ b/app/src/main/kotlin/app/clothescast/data/SettingsRepository.kt
@@ -1423,6 +1423,7 @@ private val Context.settingsDataStore: DataStore<Preferences> by preferencesData
             scheduleEnabledOptInMigration(),
             castEnabledOptInMigration(),
             glovesDefaultMigration(),
+            umbrellaDefaultMigration(),
             umbrellaRuleMigration(),
         )
     },
@@ -1566,19 +1567,57 @@ internal fun glovesDefaultMigration(): DataMigration<Preferences> {
     }
 }
 
+// One-time migration appending the umbrella rain default to installs that
+// already have an explicit clothes-rules list. Fresh and never-configured
+// installs read [ClothesRule.DEFAULTS] directly; explicit lists need this
+// materialised once so the new default remains configurable and deletable after
+// the migration sentinel is set. Mirrors [glovesDefaultMigration]: preserve
+// custom thresholds, do not duplicate an existing umbrella rule, and leave
+// corrupt / legacy-only lists untouched so the read path can still fall back to
+// DEFAULTS. Internal for unit testing.
+internal fun umbrellaDefaultMigration(): DataMigration<Preferences> {
+    val migrated = booleanPreferencesKey("umbrella_default_migrated_v1")
+    val clothesRules = stringPreferencesKey("clothes_rules_json")
+    val json = Json { ignoreUnknownKeys = true }
+    return object : DataMigration<Preferences> {
+        override suspend fun shouldMigrate(currentData: Preferences): Boolean =
+            currentData[migrated] != true
+
+        override suspend fun migrate(currentData: Preferences): Preferences {
+            val result = mutablePreferencesOf()
+            currentData.asMap().forEach { (key, value) ->
+                @Suppress("UNCHECKED_CAST")
+                result[key as Preferences.Key<Any>] = value
+            }
+            val stored = currentData[clothesRules]
+            if (!stored.isNullOrBlank()) {
+                runCatching {
+                    val dtos = json.decodeFromString<List<ClothesRuleDto>>(stored)
+                    val domainRules = dtos.mapNotNull { it.toDomain() }
+                    if (domainRules.isNotEmpty() && domainRules.none { it.item == Garment.UMBRELLA }) {
+                        val umbrellaDto = ClothesRule.DEFAULTS.first { it.item == Garment.UMBRELLA }.toDto()
+                        result[clothesRules] = json.encodeToString(dtos + umbrellaDto)
+                    }
+                }
+            }
+            result[migrated] = true
+            return result
+        }
+
+        override suspend fun cleanUp() = Unit
+    }
+}
+
 /**
  * One-time migration turning the retired `rain_accessory = UMBRELLA` toggle
  * into a configurable umbrella [ClothesRule] at the historical 30% gate, so
- * opted-in users keep their "bring an umbrella" prose now that the umbrella is
- * rule-driven rather than a global format option. `NONE` (or absent) users get
- * nothing. The old `rain_accessory` key is dropped either way.
+ * opted-in users with explicit rule lists keep their "bring an umbrella" prose
+ * now that the umbrella is rule-driven rather than a global format option.
+ * `NONE` (or absent) users get no extra materialised rule. The old
+ * `rain_accessory` key is dropped either way.
  *
- * Unlike [glovesDefaultMigration] — where gloves already ship in DEFAULTS, so a
- * fresh install needs no rule materialised — the umbrella is *not* a default,
- * so an opted-in user with no stored rule list must have one written out
- * (their existing domain rules, or DEFAULTS, plus umbrella); otherwise
- * `parseRules`' `ifEmpty { DEFAULTS }` fallback would silently drop the
- * umbrella they'd opted into.
+ * Umbrella now ships in [ClothesRule.DEFAULTS], so opted-in users without a
+ * stored rules list need no write: the read path serves the default directly.
  *
  * Gated by the `umbrella_rule_migrated_v2` sentinel. Bumped from v1 to re-run
  * once for users who migrated under v1 while the Format toggle still existed
@@ -1586,17 +1625,14 @@ internal fun glovesDefaultMigration(): DataMigration<Preferences> {
  * removing the toggle): that UI could write `rain_accessory = UMBRELLA` after
  * v1 had already fired, stranding the opt-in once the key stopped being read.
  * The re-run is idempotent for everyone else — v1 already removed the key for
- * normal opt-ins, so it finds `rain_accessory` absent and no-ops, and it never
- * resurrects an umbrella rule a user later deleted on purpose.
+ * normal opt-ins, so it finds `rain_accessory` absent and no-ops.
  */
 internal fun umbrellaRuleMigration(): DataMigration<Preferences> {
     val migrated = booleanPreferencesKey("umbrella_rule_migrated_v2")
     val rainAccessory = stringPreferencesKey("rain_accessory")
     val clothesRules = stringPreferencesKey("clothes_rules_json")
     val json = Json { ignoreUnknownKeys = true }
-    // Match the old POSSIBLE-tier gate (rain mentioned from ~30%); `> 30` is
-    // close enough to the historical `>= 30` that no real forecast differs.
-    val umbrellaRule = ClothesRule(Garment.UMBRELLA, ClothesRule.PrecipitationProbabilityAbove(30.0))
+    val umbrellaRule = ClothesRule.DEFAULTS.first { it.item == Garment.UMBRELLA }
     return object : DataMigration<Preferences> {
         override suspend fun shouldMigrate(currentData: Preferences): Boolean =
             currentData[migrated] != true
@@ -1616,11 +1652,13 @@ internal fun umbrellaRuleMigration(): DataMigration<Preferences> {
                     ?.let { runCatching { json.decodeFromString<List<ClothesRuleDto>>(it) }.getOrNull() }
                 val domainRules = existingDtos?.mapNotNull { it.toDomain() }.orEmpty()
                 if (domainRules.none { it.item == Garment.UMBRELLA }) {
-                    // Append to the user's real catalog rules, or materialise
-                    // DEFAULTS (what parseRules would otherwise have served) so
-                    // their existing recommendations survive alongside umbrella.
-                    val base = if (domainRules.isNotEmpty()) domainRules else ClothesRule.DEFAULTS
-                    result[clothesRules] = json.encodeToString((base + umbrellaRule).map { it.toDto() })
+                    // Append to the user's real catalog rules. If there are no
+                    // domain-valid stored rules, the read path now serves
+                    // DEFAULTS with umbrella directly, so no materialised list is
+                    // needed.
+                    if (domainRules.isNotEmpty()) {
+                        result[clothesRules] = json.encodeToString((domainRules + umbrellaRule).map { it.toDto() })
+                    }
                 }
             }
             result[migrated] = true

--- a/app/src/main/kotlin/app/clothescast/insight/InsightFormatter.kt
+++ b/app/src/main/kotlin/app/clothescast/insight/InsightFormatter.kt
@@ -259,14 +259,14 @@ class InsightFormatter(
                 add(formatDelta(it, leadsTemperature = rangeFormat == RangeFormat.NONE, omitLead = omitLead))
             }
             if (wearItems.isNotEmpty()) formatClothesWear(wearItems, wearMode)?.let(::add)
-            // The carried accessory (umbrella) now comes from the user's fired
+            // The carried accessory (umbrella) comes from the user's fired
             // rule — it lands in the recommended items as a Slot.CARRIED garment
-            // — via the opt-in umbrella clothes rule. It's folded into
-            // the precip clause (not the wear clause) so rain and the umbrella
-            // still travel together.
+            // via the default, configurable umbrella clothes rule. It's folded
+            // into the precip clause (not the wear clause) so rain and the
+            // umbrella still travel together.
             summary.precip?.let {
                 // Sourced from [carriedAccessories], not the (clothes-mention-
-                // gated) wear clause, so an opted-in umbrella still surfaces
+                // gated) wear clause, so a fired umbrella rule still surfaces
                 // when the wear clause is suppressed (Clothes = Never / unchanged).
                 add(formatPrecip(it, summary.carriedAccessories.firstOrNull()))
             }
@@ -441,9 +441,9 @@ class InsightFormatter(
     //  precip mention should suppress it (umbrella: yes; sunscreen: no),
     //  and pick a temporally-correct template ("Bring a hat today." vs
     //  "Tonight, bring a hat." vs no-prefix). Until then we ship
-    //  temperature-driven clothing only and accept that user-typed
-    //  umbrella rules are silent — the precip clause still warns about
-    //  rain, which is the main thing.
+    //  temperature-driven clothing only and accept that umbrella rules are
+    //  silent there — the precip clause still warns about rain, which is the
+    //  main thing.
     private fun isAccessory(item: String): Boolean = Garment.isAccessoryKey(item)
 
     private fun normalizeItemKey(item: String): String = item.trim().lowercase(Locale.ROOT)
@@ -744,8 +744,8 @@ class InsightFormatter(
         // Accessories (umbrella) are silenced from the incoming items list for
         // the same reason they're silenced in the main wear-list: until the
         // accessory catalog lands we only name temperature-driven clothing
-        // there. If the user has opted into the umbrella rule and the evening's
-        // peak condition is rain-like (RAIN / DRIZZLE), we re-inject the
+        // there. If the umbrella rule fires and the evening's peak condition
+        // is rain-like (RAIN / DRIZZLE), we re-inject the
         // chosen accessory below so the existing insight_tie_in_with_rain
         // template carries it ("…, bring a jacket and an umbrella.") and the
         // bare-rain path is promoted to the item-led template. SNOW /

--- a/app/src/test/kotlin/app/clothescast/data/SettingsRepositoryTest.kt
+++ b/app/src/test/kotlin/app/clothescast/data/SettingsRepositoryTest.kt
@@ -221,13 +221,15 @@ class SettingsRepositoryTest {
     }
 
     @Test
-    fun `umbrella migration materialises a rule for an opted-in user and drops the raw key`() = runTest {
+    fun `umbrella migration appends a rule for an opted-in user with stored rules`() = runTest {
         // A user who had opted into the retired rain_accessory = UMBRELLA toggle
-        // before it became a clothes rule. The migration materialises an umbrella
-        // ClothesRule keyed on a precipitation-probability condition (appended to
-        // the stored defaults) and drops the raw rain_accessory key.
+        // before it became a clothes rule keeps that opt-in alongside their
+        // explicitly stored rules. The raw rain_accessory key is dropped.
         val rainAccessoryKey = stringPreferencesKey("rain_accessory")
-        val before = mutablePreferencesOf(rainAccessoryKey to "UMBRELLA")
+        val before = mutablePreferencesOf(
+            rainAccessoryKey to "UMBRELLA",
+            clothesRulesKey to """[{"item":"coat","type":"temp_below","value":2.0,"unit":"CELSIUS"}]""",
+        )
 
         val result = umbrellaRuleMigration().migrate(before)
 
@@ -235,13 +237,14 @@ class SettingsRepositoryTest {
         val umbrellaRule = rules.find { it.item == Garment.UMBRELLA }
         umbrellaRule shouldNotBe null
         (umbrellaRule!!.condition is ClothesRule.PrecipitationProbabilityAbove) shouldBe true
+        rules.map { it.item.itemKey } shouldBe listOf("coat", "umbrella")
         result[rainAccessoryKey] shouldBe null
     }
 
     @Test
-    fun `umbrella migration adds no umbrella rule when rain_accessory was never set`() = runTest {
-        // A user who never opted in: no umbrella rule is materialised, and the
-        // stored clothes-rules list is left untouched (null → read DEFAULTS).
+    fun `umbrella migration leaves absent rain_accessory users on default read path`() = runTest {
+        // A user who never opted in gets no materialised rule; a null stored
+        // list reads ClothesRule.DEFAULTS, which now includes umbrella.
         val result = umbrellaRuleMigration().migrate(emptyPreferences())
 
         result[clothesRulesKey] shouldBe null
@@ -272,8 +275,8 @@ class SettingsRepositoryTest {
 
         val result = umbrellaRuleMigration().migrate(before)
 
-        val umbrellaRule = decodeStoredRules(result[clothesRulesKey]).find { it.item == Garment.UMBRELLA }
-        umbrellaRule shouldNotBe null
+        // No stored rules need to be written: DEFAULTS now includes umbrella.
+        result[clothesRulesKey] shouldBe null
         result[rainAccessoryKey] shouldBe null
     }
 
@@ -1186,6 +1189,7 @@ class SettingsRepositoryTest {
 
     private val clothesRulesKey = stringPreferencesKey("clothes_rules_json")
     private val glovesMigratedKey = booleanPreferencesKey("gloves_default_migrated_v1")
+    private val umbrellaDefaultMigratedKey = booleanPreferencesKey("umbrella_default_migrated_v1")
     private val migrationJson = Json { ignoreUnknownKeys = true }
 
     // Decode a stored clothes-rules JSON string the same way the production read
@@ -1200,6 +1204,84 @@ class SettingsRepositoryTest {
             """{"item":"jacket","type":"temp_below","value":10.0,"unit":"CELSIUS"},""" +
             """{"item":"coat","type":"temp_below","value":4.0,"unit":"CELSIUS"},""" +
             """{"item":"shorts","type":"temp_above","value":23.0,"unit":"CELSIUS"}]"""
+
+    @Test
+    fun `umbrella default migration appends the umbrella default to a stored list without it`() = runTest {
+        val before = mutablePreferencesOf(clothesRulesKey to preGlovesDefaultsJson)
+
+        val result = umbrellaDefaultMigration().migrate(before)
+
+        val rules = decodeStoredRules(result[clothesRulesKey])
+        rules.map { it.item.itemKey } shouldBe listOf("sweater", "jacket", "coat", "shorts", "umbrella")
+        rules.last() shouldBe ClothesRule.DEFAULTS.first { it.item == Garment.UMBRELLA }
+        result[umbrellaDefaultMigratedKey] shouldBe true
+    }
+
+    @Test
+    fun `umbrella default migration preserves a customised threshold and still appends umbrella`() = runTest {
+        val customised = """[{"item":"coat","type":"temp_below","value":2.0,"unit":"CELSIUS"}]"""
+        val before = mutablePreferencesOf(clothesRulesKey to customised)
+
+        val result = umbrellaDefaultMigration().migrate(before)
+
+        val rules = decodeStoredRules(result[clothesRulesKey])
+        rules.map { it.item.itemKey } shouldBe listOf("coat", "umbrella")
+        (rules.first().condition as ClothesRule.TemperatureBelow).value shouldBe 2.0
+    }
+
+    @Test
+    fun `umbrella default migration does not duplicate an existing umbrella rule`() = runTest {
+        val withUmbrella =
+            """[{"item":"coat","type":"temp_below","value":4.0,"unit":"CELSIUS"},""" +
+                """{"item":"umbrella","type":"precip_above","value":50.0}]"""
+        val before = mutablePreferencesOf(clothesRulesKey to withUmbrella)
+
+        val result = umbrellaDefaultMigration().migrate(before)
+
+        val rules = decodeStoredRules(result[clothesRulesKey])
+        rules.count { it.item == Garment.UMBRELLA } shouldBe 1
+        (rules.first { it.item == Garment.UMBRELLA }.condition as ClothesRule.PrecipitationProbabilityAbove)
+            .percent shouldBe 50.0
+    }
+
+    @Test
+    fun `umbrella default migration leaves a fresh install with no stored list untouched`() = runTest {
+        val result = umbrellaDefaultMigration().migrate(emptyPreferences())
+
+        // No stored key is written: parseRules reads DEFAULTS (now incl. umbrella)
+        // directly, so a fresh install needs nothing grandfathered.
+        result[clothesRulesKey] shouldBe null
+        result[umbrellaDefaultMigratedKey] shouldBe true
+    }
+
+    @Test
+    fun `umbrella default migration leaves corrupt JSON untouched but sets the sentinel`() = runTest {
+        val before = mutablePreferencesOf(clothesRulesKey to "{not valid json")
+
+        val result = umbrellaDefaultMigration().migrate(before)
+
+        result[clothesRulesKey] shouldBe "{not valid json"
+        result[umbrellaDefaultMigratedKey] shouldBe true
+    }
+
+    @Test
+    fun `umbrella default migration leaves a legacy-only list untouched so defaults still apply`() = runTest {
+        val legacyOnly = """[{"item":"cardigan","type":"temp_below","value":12.0,"unit":"CELSIUS"}]"""
+        val before = mutablePreferencesOf(clothesRulesKey to legacyOnly)
+
+        val result = umbrellaDefaultMigration().migrate(before)
+
+        result[clothesRulesKey] shouldBe legacyOnly
+        result[umbrellaDefaultMigratedKey] shouldBe true
+    }
+
+    @Test
+    fun `umbrella default migration runs once, gated by its sentinel`() = runTest {
+        val migration = umbrellaDefaultMigration()
+
+        migration.shouldMigrate(emptyPreferences()) shouldBe true
+        migration.shouldMigrate(mutablePreferencesOf(umbrellaDefaultMigratedKey to true)) shouldBe false
+    }
 
     @Test
     fun `gloves migration appends the gloves default to a stored list without it`() = runTest {

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/ClothesRule.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/ClothesRule.kt
@@ -73,10 +73,9 @@ data class ClothesRule(
         // align with the `today_outfit_top_*` labels in values/strings.xml.
         // Per-language phrasers translate at format time
         // (e.g. GermanClothesPhraser maps "sweater" → "Pullover").
-        // Wet-weather accessories live on an opt-in umbrella [ClothesRule]
-        // (a carried accessory) instead of [DEFAULTS]: we ship no precip-keyed
-        // default because "bring an umbrella" is the wrong answer for users
-        // who'd reach for a rain jacket or hood instead.
+        // Wet-weather accessories live as carried-accessory rules. Umbrella is
+        // now a default so rainy-day installs get a configurable / deletable
+        // "bring an umbrella" rule instead of a hidden global toggle.
         // TODO(rain-accessory-variants): broaden the carried-accessory rules
         //  beyond the umbrella (rain jacket, hood, rain boots, …) once the
         //  resource strings and per-locale phrasers cover them.
@@ -86,6 +85,7 @@ data class ClothesRule(
             ClothesRule(Garment.COAT, TemperatureBelow(4.0)),
             ClothesRule(Garment.GLOVES, TemperatureBelow(4.0)),
             ClothesRule(Garment.SHORTS, TemperatureAbove(23.0)),
+            ClothesRule(Garment.UMBRELLA, PrecipitationProbabilityAbove(30.0)),
         )
 
         /** Sanity bounds in °C for the rationale dialog's `+1°` / `−1°` taps. Wide enough

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/InsightSummary.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/InsightSummary.kt
@@ -53,7 +53,7 @@ data class InsightSummary(
      * clause ("Rain at 3pm, bring an umbrella."), so they must survive the
      * clothes-mention gating that nulls [clothes] under
      * [ClothesMentionMode.NEVER] / IF_CHANGED — a rain accessory isn't a
-     * "clothes" mention, and an opted-in umbrella should still be named on a
+     * "clothes" mention, and a fired umbrella rule should still be named on a
      * rainy day even when the wear clause is suppressed.
      */
     val carriedAccessories: List<String> = emptyList(),

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/OutfitSuggestion.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/OutfitSuggestion.kt
@@ -99,11 +99,11 @@ data class OutfitSuggestion(
 
     /**
      * Optional carried accessory shown alongside the worn outfit — today just
-     * the umbrella, the `Garment.Slot.CARRIED` member. Like [hands] it's a
-     * single opt-in tier with no fallback: present only when a carried-accessory
-     * rule fires (a rain-keyed umbrella rule), never promoted to a default. It's
-     * independent of [hands], so a cold rainy day can light both the glove icon
-     * and the umbrella.
+     * the umbrella, the `Garment.Slot.CARRIED` member. Like [hands] it has no
+     * fallback icon: present only when a carried-accessory rule fires (the
+     * default rain-keyed umbrella rule, unless the user edits or deletes it).
+     * It's independent of [hands], so a cold rainy day can light both the glove
+     * icon and the umbrella.
      */
     enum class Carried {
         UMBRELLA;

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/model/ClothesRuleTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/model/ClothesRuleTest.kt
@@ -97,11 +97,9 @@ class ClothesRuleTest {
     }
 
     @Test
-    fun `defaults cover the temperature-driven MVP cases`() {
-        // Umbrella was deliberately dropped: the precip clause already names rain,
-        // and the wet-weather accessory is going to become a personalised setting.
+    fun `defaults cover temperature and rain gear cases`() {
         val items = ClothesRule.DEFAULTS.map { it.item.itemKey }
-        items shouldBe listOf("sweater", "jacket", "coat", "gloves", "shorts")
+        items shouldBe listOf("sweater", "jacket", "coat", "gloves", "shorts", "umbrella")
     }
 
     @Test

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/model/OutfitSuggestionTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/model/OutfitSuggestionTest.kt
@@ -509,9 +509,8 @@ class OutfitSuggestionTest {
 
     @Test
     fun `carried stays null when no umbrella rule fires`() {
-        // Carried is opt-in with no fallback: a dry day (or no umbrella rule)
-        // leaves it null rather than promoting to a default, so no umbrella icon
-        // shows when the user hasn't earned one.
+        // Carried has no fallback: a dry day (or no umbrella rule) leaves it
+        // null, so no umbrella icon shows when no precipitation rule fires.
         val umbrellaRules = listOf(
             ClothesRule(Garment.UMBRELLA, ClothesRule.PrecipitationProbabilityAbove(30.0)),
         )
@@ -524,8 +523,8 @@ class OutfitSuggestionTest {
 
     @Test
     fun `gloves and umbrella light the hands and carried slots independently`() {
-        // The two opt-in tiers don't compete: a cold, rainy day with both rules
-        // firing lights gloves on the hands slot and the umbrella on carried.
+        // The two accessory tiers don't compete: a cold, rainy day with both
+        // rules firing lights gloves on the hands slot and umbrella on carried.
         val triggered = TriggeredOutfit(
             rules = listOf(
                 ClothesRule(Garment.COAT, ClothesRule.TemperatureBelow(5.0)),

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/EvaluateClothesRulesTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/EvaluateClothesRulesTest.kt
@@ -84,11 +84,9 @@ class EvaluateClothesRulesTest {
 
     @Test
     fun `wet cold day matches cold-weather rules, bottom slot resolves to the default`() {
-        // Defaults no longer include umbrella — the precip clause announces rain,
-        // and the wet-weather accessory will become a personalised setting.
         val out = subject(forecast(min = 9.0, max = 15.0, precip = 70.0), ClothesRule.DEFAULTS)
-        out.rules.map { it.item.itemKey }.shouldContainExactly("sweater", "jacket")
-        out.items.shouldContainExactly("sweater", "jacket", "pants")
+        out.rules.map { it.item.itemKey }.shouldContainExactly("sweater", "jacket", "umbrella")
+        out.items.shouldContainExactly("sweater", "jacket", "pants", "umbrella")
     }
 
 

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsightTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsightTest.kt
@@ -1930,9 +1930,9 @@ class GenerateDailyInsightTest {
     @Test
     fun `evening tie-in surfaces bare per-model rain when no clothes rule fires`() = runTest {
         // The case AGENTS.md flags under "Domain conventions": no clothes
-        // rule triggers for the tonight window (mild evening, no
-        // user-defined umbrella rule — the defaults intentionally don't
-        // ship one), but a per-model series spots rain ≥ 30%. Pre-fix the
+        // rule triggers for the tonight window (mild evening, with the
+        // default umbrella rule removed for this user's config), but a
+        // per-model series spots rain ≥ 30%. Pre-fix the
         // tie-in returned null and the morning insight stayed silent on
         // evening rain; the fix emits an item-less clause that the
         // formatter renders as a bare "Rain tonight at 9pm." (or


### PR DESCRIPTION
### Motivation
- Make the umbrella a first-class, configurable carried-accessory default so the app can recommend “bring an umbrella” on rainy days while still letting users edit or remove that rule. 
- Preserve existing user rule lists: installs that have explicit saved rules should receive the new umbrella default once (so it is editable/deletable), while fresh installs read the updated `DEFAULTS` directly. 

### Description
- Add `ClothesRule(Garment.UMBRELLA, PrecipitationProbabilityAbove(30.0))` to `ClothesRule.DEFAULTS` so the umbrella is a default rule at a 30% rain threshold. 
- Add `umbrellaDefaultMigration()` to `SettingsRepository` and wire it into the `produceMigrations` list to append the umbrella to persisted, domain-valid rule lists exactly once while avoiding duplicates and preserving custom thresholds. 
- Update `umbrellaRuleMigration()` to use the new default umbrella rule and avoid materialising a stored list when `DEFAULTS` already includes umbrella, and update related formatting/commentary and tests to reflect the umbrella default. 

### Testing
- Ran `git diff --check` which reported no whitespace/merge errors. 
- Verified repository-level changes and updated unit tests under `app/src/test` and `core/domain/src/test` (tests were modified to expect umbrella in `ClothesRule.DEFAULTS` and to exercise the new `umbrellaDefaultMigration`). 
- Attempted JVM test runs with `./gradlew :core:domain:test :core:data:test` and `./gradlew :app:testDebugUnitTest`, but execution was blocked by sandbox network/plugin resolution (Gradle plugin resolution to the Plugin Portal / Google Maven failed) and missing Android SDK in this environment, so automated tests could not complete here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ca6d04810832baa5e164d9aff993e)