### PR TITLE
Target Android 16 (API 36)

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -30,8 +30,8 @@ ANDROID_SDK_ROOT="$ANDROID_HOME"
 CMDLINE_TOOLS_DIR="$ANDROID_HOME/cmdline-tools/latest"
 # Pinned to the version CI installs via android-actions/setup-android@v3.
 # Bump in lockstep with `app/build.gradle.kts` (compileSdk) and ci.yml.
-PLATFORM="platforms;android-35"
-BUILD_TOOLS="build-tools;35.0.0"
+PLATFORM="platforms;android-36"
+BUILD_TOOLS="build-tools;36.0.0"
 PLATFORM_TOOLS="platform-tools"
 # Released August 2024; the last build before Google started shipping JDK 21
 # checks. Any newer cmdline-tools would also be fine — pinning makes the
@@ -51,8 +51,8 @@ persist_env() {
 
 # Fast path: SDK already installed (warm sandbox or re-run). Just re-export.
 if [ -x "$CMDLINE_TOOLS_DIR/bin/sdkmanager" ] \
-  && [ -d "$ANDROID_HOME/platforms/android-35" ] \
-  && [ -d "$ANDROID_HOME/build-tools/35.0.0" ]; then
+  && [ -d "$ANDROID_HOME/platforms/android-36" ] \
+  && [ -d "$ANDROID_HOME/build-tools/36.0.0" ]; then
   echo "Android SDK already installed at $ANDROID_HOME — skipping install."
   persist_env
   exit 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Set up Android SDK
         # AGP must be loadable for Gradle to configure :app, even when only
-        # running :core:* tasks. Pre-installing platform 35 + build-tools 35.0.0
+        # running :core:* tasks. Pre-installing platform 36 + build-tools 36.0.0
         # avoids on-demand downloads at configure time.
         # Pinned to a specific commit SHA (rather than the floating @v3 tag)
         # so a compromised upstream release can't silently swap in malicious
@@ -84,7 +84,7 @@ jobs:
         # actions below. SHA is android-actions/setup-android v3.2.2.
         uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3.2.2
         with:
-          packages: 'platforms;android-35 build-tools;35.0.0 platform-tools'
+          packages: 'platforms;android-36 build-tools;36.0.0 platform-tools'
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
@@ -402,7 +402,7 @@ jobs:
         # SHA-pinned — see rationale on the unit-tests job's copy of this step.
         uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3.2.2
         with:
-          packages: 'platforms;android-35 build-tools;35.0.0 platform-tools'
+          packages: 'platforms;android-36 build-tools;36.0.0 platform-tools'
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -190,7 +190,13 @@ android {
     // app — the applicationId is the install identity; do not change it again
     // without a planned migration story.
     namespace = "app.clothescast"
-    compileSdk = 35
+    compileSdk = 36
+    // Pin to the build-tools the CI / sandbox setup installs. AGP 8.10's default
+    // is 35.0.0, so without this AGP would fetch 35.0.0 on demand even though
+    // we pre-install 36.0.0 — defeating the point of pinning the SDK packages in
+    // ci.yml / session-start.sh (and failing when on-demand downloads are
+    // blocked). Keep this in lockstep with the build-tools version installed there.
+    buildToolsVersion = "36.0.0"
 
     defaultConfig {
         applicationId = "app.clothescast"
@@ -198,7 +204,7 @@ android {
         // install-time gate (this line) and BuildConfig.MIN_SDK_VERSION below
         // — see the catalog entry for why the runtime guard exists.
         minSdk = libs.versions.minSdk.get().toInt()
-        targetSdk = 35
+        targetSdk = 36
         versionCode = gitCommitCount
         // semver build metadata: <base>+<commitCount>.<shortSha>. Some downstream
         // tools (Crashlytics, Bugsnag, screenshots in bug reports) carry only

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,7 @@
-org.gradle.jvmargs=-Xmx2g -Dfile.encoding=UTF-8 -XX:+UseParallelGC
+# 4g (was 2g): AGP 8.10's R8 needs more heap to shrink the app — at 2g the
+# minifyDebugWithR8 task died with "OutOfMemoryError: GC overhead limit
+# exceeded" after the compileSdk 36 / AGP 8.10 bump.
+org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8 -XX:+UseParallelGC
 org.gradle.parallel=true
 org.gradle.caching=true
 # Configuration cache disabled until :app module is stable in CI.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,9 @@
 [versions]
-agp = "8.7.3"
+# AGP 8.10.x is the newest line that still runs on the repo's current Gradle
+# 8.11.1 wrapper (AGP 8.11+ requires Gradle 8.13+); it supports compileSdk 36,
+# which targetSdk 36 needs (AGP 8.7.x capped at compileSdk 35). Bump the Gradle
+# wrapper in lockstep before moving to AGP 8.11+.
+agp = "8.10.1"
 kotlin = "2.0.21"
 # Android API floor. Single source of truth: `app/build.gradle.kts` reads this
 # for `minSdk` and re-emits it as `BuildConfig.MIN_SDK_VERSION` so the runtime
@@ -47,7 +51,7 @@ vico = "2.0.3"
 # needed, runs in :app's JVM unit tests job. The CI step uploads the PNGs as a
 # workflow artifact for human review on every PR (no diff gate, by intent).
 roborazzi = "1.32.0"
-robolectric = "4.14.1"
+robolectric = "4.16.1"
 junit4 = "4.13.2"
 # Play in-app updates: AppUpdateManager + the FLEXIBLE flow (background download
 # + "Restart to install" prompt). Used to surface the update-available banner on


### PR DESCRIPTION
## What

Raises `compileSdk` and `targetSdk` from **35 → 36**, so the app targets the current Android release (Android 16) — picking up its behavior changes and staying inside Play's target-API window.

## Dependencies dragged in lockstep

`targetSdk 36` is the trigger; everything else here is forced by it:

- **AGP `8.7.3 → 8.10.1`** — AGP 8.7.x caps at compileSdk 35. 8.10.1 is deliberately the newest line that still runs on the repo's **Gradle 8.11.1** wrapper (AGP 8.11+ needs Gradle 8.13+), so **no Gradle wrapper change** here. A catalog comment records this for the next bump.
- **Robolectric `4.14.1 → 4.16.1`** — Robolectric rejects a package whose `targetSdkVersion` exceeds the max API it ships a runtime for (`Package targetSdkVersion=36 > maxSdkVersion=35`). 4.16.x is the first line with an API-36 (Android 16) runtime.
- **Gradle heap `-Xmx2g → -Xmx4g`** — AGP 8.10's R8 OOM'd (`GC overhead limit exceeded`) shrinking the app at 2g.

Kotlin stays at 2.0.21 (already current).

## Scope

- `app/build.gradle.kts`: `compileSdk` / `targetSdk` → 36
- `gradle/libs.versions.toml`: `agp` → 8.10.1, `robolectric` → 4.16.1 (+ rationale comments)
- `gradle.properties`: JVM heap → 4g (+ rationale)
- `.github/workflows/ci.yml`: both SDK-setup steps install `platforms;android-36 build-tools;36.0.0`
- `.claude/hooks/session-start.sh`: Claude-on-web sandbox installs SDK 36 to match CI

Does **not** include the Glance/Vico bumps or live widget previews from #914 — those need a release-candidate Glance and are a separate, larger change.

## Test plan

Verified locally on the new toolchain (CI-equivalent), after the first CI run surfaced the Robolectric + R8-heap failures that are now fixed:

- `./gradlew :app:testDebugUnitTest :app:assembleDebug` → **BUILD SUCCESSFUL**, 0 test failures, no R8 OOM
- Built APK reports `targetSdkVersion:'36'` (via `aapt2 dump badging`)

No app behavior change beyond the platform target.