### PR TITLE
Pin chart preview fixtures to a fixed date for stable snapshots

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayPreviews.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayPreviews.kt
@@ -1426,7 +1426,9 @@ internal fun ForecastChartWithCurrentTimePreview() {
             ChartScrubController().apply {
                 setNow(
                     java.time.LocalDateTime.of(
-                        java.time.LocalDate.now(),
+                        // Fixed date (a Monday) so the fixture is deterministic
+                        // across runs — see issue #920.
+                        java.time.LocalDate.of(2024, 1, 1),
                         java.time.LocalTime.of(14, 30),
                     ),
                 )
@@ -1436,6 +1438,10 @@ internal fun ForecastChartWithCurrentTimePreview() {
             ForecastChart(
                 hourly = SAMPLE_HOURLY,
                 temperatureUnit = TemperatureUnit.CELSIUS,
+                // Match the pinned setNow date above so the now-indicator lands
+                // mid-chart; ForecastChart's startDate otherwise defaults to
+                // LocalDate.now() and the two-year gap would push it off-axis.
+                startDate = java.time.LocalDate.of(2024, 1, 1),
                 showFeelsLike = true,
             )
         }
@@ -1641,7 +1647,11 @@ internal fun WindCardWithModelSpreadPreview() {
 @Composable
 internal fun WindCardScrubbedPreview() {
     Frame {
-        val today = java.time.LocalDate.now()
+        // Fixed date (a Monday) so the scrub fixture is deterministic across
+        // runs — see issue #920. The hourly chart only labels times, so the
+        // date never reaches the snapshot, but pinning it keeps the fixture
+        // free of any wall-clock dependency.
+        val today = java.time.LocalDate.of(2024, 1, 1)
         val controller = androidx.compose.runtime.remember {
             ChartScrubController().apply {
                 scrubTo(java.time.LocalDateTime.of(today, java.time.LocalTime.of(14, 30)))
@@ -1870,7 +1880,11 @@ internal fun ForecastCardWithModelSpreadPreview() {
 @Composable
 internal fun ForecastCardScrubbedPreview() {
     Frame {
-        val today = java.time.LocalDate.now()
+        // Fixed date (a Monday) so the scrub fixture is deterministic across
+        // runs — see issue #920. The hourly chart only labels times, so the
+        // date never reaches the snapshot, but pinning it keeps the fixture
+        // free of any wall-clock dependency.
+        val today = java.time.LocalDate.of(2024, 1, 1)
         val controller = androidx.compose.runtime.remember {
             ChartScrubController().apply {
                 scrubTo(java.time.LocalDateTime.of(today, java.time.LocalTime.of(14, 30)))

--- a/app/src/main/kotlin/app/clothescast/widget/WidgetPreviews.kt
+++ b/app/src/main/kotlin/app/clothescast/widget/WidgetPreviews.kt
@@ -482,6 +482,13 @@ private fun bottomLabelResMock(bottom: OutfitSuggestion.Bottom): Int = when (bot
 // composes with data under the PreviewSnapshots harness.
 //
 
+// Pinned reference date so the day/week axis labels stay deterministic across
+// runs (issue #920). The week chart labels each point by its real weekday, so a
+// LocalDate.now()-based fixture churned the committed PNG ~6 days out of 7.
+// 2024-01-01 is a Monday, so the week axis reads Mon→Sun no matter when the
+// snapshot test runs.
+private val SAMPLE_START_DATE: LocalDate = LocalDate.of(2024, 1, 1)
+
 // One synthetic day of hourly feels-like (°C): cool overnight, warm mid-afternoon.
 private val SAMPLE_FEELS_DAY: List<HourlyForecast> = run {
     val feels = listOf(
@@ -511,7 +518,7 @@ private val SAMPLE_FEELS_WEEK: List<DailyForecast> = (0..6).map { d ->
     val feels = hourly.map { it.feelsLikeC }
     val air = hourly.map { it.temperatureC }
     DailyForecast(
-        date = LocalDate.now().plusDays(d.toLong()),
+        date = SAMPLE_START_DATE.plusDays(d.toLong()),
         temperatureMinC = air.min(),
         temperatureMaxC = air.max(),
         feelsLikeMinC = feels.min(),
@@ -523,7 +530,7 @@ private val SAMPLE_FEELS_WEEK: List<DailyForecast> = (0..6).map { d ->
     )
 }
 
-private val SAMPLE_NOW: LocalDateTime = LocalDateTime.of(LocalDate.now(), LocalTime.of(10, 30))
+private val SAMPLE_NOW: LocalDateTime = LocalDateTime.of(SAMPLE_START_DATE, LocalTime.of(10, 30))
 
 @Preview(name = "Feels-like widget · today", widthDp = 360)
 @Composable
@@ -534,7 +541,7 @@ internal fun FeelsLikeWidgetTodayPreview() {
             days = null,
             temperatureUnit = TemperatureUnit.CELSIUS,
             timeFormat = TimeFormat.TWELVE_HOUR,
-            startDate = LocalDate.now(),
+            startDate = SAMPLE_START_DATE,
             now = SAMPLE_NOW,
         )
     }
@@ -549,7 +556,7 @@ internal fun FeelsLikeWidgetTodayDarkPreview() {
             days = null,
             temperatureUnit = TemperatureUnit.CELSIUS,
             timeFormat = TimeFormat.TWELVE_HOUR,
-            startDate = LocalDate.now(),
+            startDate = SAMPLE_START_DATE,
             now = SAMPLE_NOW,
         )
     }
@@ -589,7 +596,7 @@ internal fun FeelsLikeWidgetWidePreview() {
                 days = null,
                 temperatureUnit = TemperatureUnit.CELSIUS,
                 timeFormat = TimeFormat.TWELVE_HOUR,
-                startDate = LocalDate.now(),
+                startDate = SAMPLE_START_DATE,
                 now = SAMPLE_NOW,
                 fillHeight = true,
             )
@@ -606,7 +613,7 @@ internal fun FeelsLikeWidgetNoCurrentTimePreview() {
             days = null,
             temperatureUnit = TemperatureUnit.CELSIUS,
             timeFormat = TimeFormat.TWELVE_HOUR,
-            startDate = LocalDate.now(),
+            startDate = SAMPLE_START_DATE,
             now = null,
         )
     }


### PR DESCRIPTION
Fixes #920.

## Problem

The `feels_like_widget_week` snapshot rendered **different weekday labels depending on the day the test ran**. The preview fixture built its sample data from `LocalDate.now()` (`WidgetPreviews.kt` — `SAMPLE_FEELS_WEEK` / `SAMPLE_NOW`), and the week chart labels each point by its real weekday. So the committed PNG drifted on any run whose weekday differed from when the baseline was last recorded — the regen bot would flip the x-axis labels (and the "… at Mon 11am" title) back and forth ~6 days out of 7, independent of any code change. (This is exactly the drift seen on PR #921.)

## Fix

Pin all preview-fixture dates to **2024-01-01 (a Monday)** so the weekday labels read Mon→Sun on every run:

- **`WidgetPreviews.kt`**: add `SAMPLE_START_DATE` and use it for `SAMPLE_FEELS_WEEK`, `SAMPLE_NOW`, and every feels-like widget preview's `startDate` (today / today-dark / wide / no-current-time).
- **`TodayPreviews.kt`**: pin the three scrub / now-indicator fixtures that still used `LocalDate.now()` — `ForecastChartWithCurrentTime`, `WindCardScrubbed`, `ForecastCardScrubbed`. For the now-indicator preview, also pass an explicit `startDate` matching the pinned `now`: `ForecastChart`'s `startDate` defaults to `LocalDate.now()`, and a two-year gap would otherwise push the indicator off-axis.

## No rendered-output change

Regenerating the snapshots after this change produces **zero PNG diffs**. The in-app 7-day card already pinned a fixed Monday (`SAMPLE_WEEK`, `LocalDate.of(2026, 4, 27)`), so the established baseline was already Monday-start. This PR only removes the wall-clock dependency so the baseline stops churning — it brings the widget/scrub fixtures in line with the existing pattern.

## Test plan

- [x] Audited every `*Previews.kt` / `PreviewSnapshots.kt` for `now()`-style date calls — none remain.
- [x] `./gradlew :app:testDebugUnitTest --tests "*.PreviewSnapshots"` (record mode) → `git status app/snapshots/` clean, no PNG changes.
- [x] `ChartScrubberTest` / `ChartAxisTest` still pass.

https://claude.ai/code/session_019C8CGsqTb3hR21kV4vAx5W

---
_Generated by [Claude Code](https://claude.ai/code/session_019C8CGsqTb3hR21kV4vAx5W)_