### PR TITLE
Keep the current-time line on screen through the last hour

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/today/ChartScrubber.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/ChartScrubber.kt
@@ -460,13 +460,19 @@ private class ChartScrubIndicator(
 
             val time = controller?.activeTime ?: return
             val chartX = currentTimeChartX(hourly, startDate, time) ?: return
-            // Gate on the actual canvas pixel — chartX can fall outside
-            // the data-range bounds (`ranges.minX..maxX`) when the user
-            // scrubs into Vico's start / end padding, but it should
-            // still draw as long as the resulting line lands on the
-            // visible plot area.
-            val canvasX = chartZero + pxPerUnit * chartX.toFloat()
-            if (canvasX < layerBounds.left || canvasX > layerBounds.right) return
+            // Clamp to the plot's visible edges instead of culling. See
+            // [indicatorCanvasX] — the live "now" position can sit up to a
+            // full hour past the last data point (the 06:30–07:00 gap on a
+            // TONIGHT chart whose last point is 06:00), which lands beyond
+            // Vico's ~half-cell end padding; pinning it to the edge keeps
+            // the indicator visible through the final hour.
+            val canvasX = indicatorCanvasX(
+                chartZero = chartZero,
+                pxPerUnit = pxPerUnit,
+                chartX = chartX,
+                layerLeftPx = layerBounds.left,
+                layerRightPx = layerBounds.right,
+            )
             line.drawVertical(context, canvasX, layerBounds.top, layerBounds.bottom)
         }
     }

--- a/app/src/main/kotlin/app/clothescast/ui/today/CurrentTimeIndicator.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/CurrentTimeIndicator.kt
@@ -70,3 +70,29 @@ internal fun currentTimeChartX(
     }
     return null
 }
+
+/**
+ * Canvas-x for the live indicator line, clamped to the plot's visible
+ * edges. [currentTimeChartX] treats each hourly sample as a 1-hour bin,
+ * so a "now" inside the *last* bin can map up to a full cell past the
+ * rightmost data point — e.g. 06:48 against a TONIGHT window whose last
+ * point is 06:00 yields chartX = lastIndex + 0.8. Vico's end padding only
+ * reserves ~half a cell, so that raw canvas-x lands beyond the right edge
+ * and the previous "cull if off-plot" gate dropped the line entirely for
+ * the back half of the final hour (the 06:30–07:00 gap on a default 07:00
+ * wake time). Pinning the line to the edge keeps "now" visible through the
+ * whole last hour instead; the leading side is handled symmetrically.
+ *
+ * Scrubbed times never reach the clamp out of range — [chartXToTime] pins
+ * a scrub to ±half a cell — and these per-period charts disable
+ * scroll/zoom and fit the full window, so `scroll` is always 0 and the
+ * clamp can't surface a line for a position that's genuinely scrolled
+ * off-screen.
+ */
+internal fun indicatorCanvasX(
+    chartZero: Float,
+    pxPerUnit: Float,
+    chartX: Double,
+    layerLeftPx: Float,
+    layerRightPx: Float,
+): Float = (chartZero + pxPerUnit * chartX.toFloat()).coerceIn(layerLeftPx, layerRightPx)

--- a/app/src/test/kotlin/app/clothescast/ui/today/CurrentTimeIndicatorTest.kt
+++ b/app/src/test/kotlin/app/clothescast/ui/today/CurrentTimeIndicatorTest.kt
@@ -151,4 +151,52 @@ class CurrentTimeIndicatorTest {
         )
         x!! shouldBe (15.75 plusOrMinus 1e-6)
     }
+
+    @Test
+    fun `indicator canvas-x clamps a late last-hour now to the right edge`() {
+        // 06:48 against a TONIGHT window whose last point is 06:00 maps to
+        // chartX = lastIndex + 0.8, well past Vico's ~half-cell end padding.
+        // With a chart spanning [0, 100] px and chartZero at the +0.5-cell
+        // start padding, that raw canvas-x overshoots the right edge — the
+        // clamp pins it there so the live indicator stays visible instead of
+        // vanishing for the back half of the final hour.
+        val pxPerUnit = 8f // px per chart-x unit (hour)
+        val chartZero = 4f // chartX = 0 sits half a cell in from the left
+        val layerLeftPx = 0f
+        val layerRightPx = 100f
+        val x = indicatorCanvasX(
+            chartZero = chartZero,
+            pxPerUnit = pxPerUnit,
+            chartX = 12.8, // raw canvasX = 4 + 8*12.8 = 106.4, past the edge
+            layerLeftPx = layerLeftPx,
+            layerRightPx = layerRightPx,
+        )
+        x shouldBe layerRightPx
+    }
+
+    @Test
+    fun `indicator canvas-x leaves an in-window now untouched`() {
+        val x = indicatorCanvasX(
+            chartZero = 4f,
+            pxPerUnit = 8f,
+            chartX = 5.0, // raw canvasX = 44, comfortably inside [0, 100]
+            layerLeftPx = 0f,
+            layerRightPx = 100f,
+        )
+        x shouldBe 44f
+    }
+
+    @Test
+    fun `indicator canvas-x clamps a pre-window now to the left edge`() {
+        // RTL or a leading-padding overshoot can push canvasX below the
+        // left edge; the clamp pins it to the edge rather than off-plot.
+        val x = indicatorCanvasX(
+            chartZero = 4f,
+            pxPerUnit = 8f,
+            chartX = -1.0, // raw canvasX = -4, below the left edge
+            layerLeftPx = 0f,
+            layerRightPx = 100f,
+        )
+        x shouldBe 0f
+    }
 }


### PR DESCRIPTION
## Problem

On the **Tonight** chart at ~06:48 the live current-time marker (the vertical "now" line) vanished, and the card's now-tracking readout sat frozen on the last hour. It reappeared once the window changed.

## Cause

The overnight window's last data point is 06:00 when the morning/wake time is the default 07:00. `currentTimeChartX` correctly treats each hourly sample as a 1-hour bin, so 06:48 maps to `chartX = lastIndex + 0.8`. But Vico's end padding only reserves about half a cell, so that position lands just past the plot's right edge — and the indicator's draw code *culled* any line whose canvas-x fell outside the plot bounds. The net effect: the now-line disappeared for the back half of the final hour (roughly 06:30–07:00). The same gap exists at the trailing edge of any period (e.g. 21:45 on a window ending 21:00).

## Fix

Clamp the indicator's canvas-x to the plot's visible edges instead of dropping it, so the line pins to the edge and stays visible through the whole last hour. The leading side is handled symmetrically.

- `currentTimeChartX` is left unchanged — it still reports the true fractional position (used by the readout's bucket rounding and the inverse `chartXToTime`). Only the rendered line position is clamped, in a new pure `indicatorCanvasX` helper.
- Scrubbed taps are unaffected: `chartXToTime` already pins a scrub to ±half a cell, so scrub positions never reach the clamp out of range.
- These per-period charts disable scroll/zoom and fit the full window (`scrollEnabled = false`, `Zoom.Content`), so `scroll` is always 0 and the clamp can't surface a line for a position that's genuinely scrolled off-screen.

## Privacy

No change to anything that crosses the device boundary — UI-render math only.

## Test plan

- New JVM unit tests in `CurrentTimeIndicatorTest` cover the clamp: a late last-hour `now` pins to the right edge, an in-window `now` is untouched, and a pre-window `now` pins to the left edge.
- Full CI-equivalent build run locally and green: `:core:domain:test`, `:core:data:test`, `:app:testDebugUnitTest`, `:app:assembleDebug`.

---
_Generated by [Claude Code](https://claude.ai/code/session_014oKpgHodze9RbUcypsjYRR)_