### PR TITLE
Silence two false-positive lint errors on guarded calls

### DIFF
--- a/app/src/main/kotlin/app/clothescast/notification/InsightNotifier.kt
+++ b/app/src/main/kotlin/app/clothescast/notification/InsightNotifier.kt
@@ -1,5 +1,6 @@
 package app.clothescast.notification
 
+import android.annotation.SuppressLint
 import android.app.PendingIntent
 import android.content.Context
 import android.graphics.Bitmap
@@ -19,6 +20,11 @@ import app.clothescast.ui.garment.renderTopWithHandsBitmap
  */
 class InsightNotifier(private val context: Context) {
 
+    // POST_NOTIFICATIONS is checked via NotificationPermission.isGranted() at the
+    // top of this method (an early return), but lint can't trace the permission
+    // check through that helper to the notify() call below — so it flags a false
+    // positive. The guard makes the post safe on Android 13+.
+    @SuppressLint("MissingPermission")
     fun notify(
         insight: Insight,
         prose: String,

--- a/app/src/main/kotlin/app/clothescast/notification/TonightInsightNotifier.kt
+++ b/app/src/main/kotlin/app/clothescast/notification/TonightInsightNotifier.kt
@@ -1,5 +1,6 @@
 package app.clothescast.notification
 
+import android.annotation.SuppressLint
 import android.app.PendingIntent
 import android.content.Context
 import androidx.core.app.NotificationCompat
@@ -25,6 +26,11 @@ import app.clothescast.core.domain.model.OutfitSuggestion
  */
 class TonightInsightNotifier(private val context: Context) {
 
+    // POST_NOTIFICATIONS is checked via NotificationPermission.isGranted() at the
+    // top of this method (an early return), but lint can't trace the permission
+    // check through that helper to the notify() call below — so it flags a false
+    // positive. The guard makes the post safe on Android 13+.
+    @SuppressLint("MissingPermission")
     fun notify(
         insight: Insight,
         prose: String,

--- a/app/src/main/kotlin/app/clothescast/ui/garment/OutfitVector.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/garment/OutfitVector.kt
@@ -1,5 +1,6 @@
 package app.clothescast.ui.garment
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.content.res.Resources
 import android.graphics.Paint
@@ -48,6 +49,11 @@ private val cache = ConcurrentHashMap<Int, OutfitVector>()
 internal fun loadOutfitVector(context: Context, @DrawableRes resId: Int): OutfitVector =
     cache.getOrPut(resId) { parseOutfitVector(context.resources, resId) }
 
+// resId is a vector drawable (@DrawableRes), and we deliberately read its raw
+// XML with getXml() to parse the <path> elements ourselves. Lint wants an
+// @XmlRes for getXml() and so flags a false positive — vector drawables are
+// XML resources, and parsing one this way is intentional.
+@SuppressLint("ResourceType")
 private fun parseOutfitVector(res: Resources, @DrawableRes resId: Int): OutfitVector {
     val parser = res.getXml(resId)
     val attrs = Xml.asAttributeSet(parser)


### PR DESCRIPTION
Clears two false-positive Android Lint **errors** — code that's already correct but that lint can't see through. Found during the lint audit; these were masking the signal in the `lintDebug` report.

## What

- **`MissingPermission`** on `InsightNotifier.notify()` and `TonightInsightNotifier.notify()`. Both early-return via `NotificationPermission.isGranted()` — a real `ContextCompat.checkSelfPermission(POST_NOTIFICATIONS)` check — before calling `NotificationManagerCompat.notify()`. Lint can't trace the permission check through that helper indirection, so it reports a false positive. The runtime is safe on Android 13+.
- **`ResourceType`** on `OutfitVector.parseOutfitVector()`, which deliberately reads a vector drawable's raw XML via `Resources.getXml(@DrawableRes)` to parse its `<path>` elements. Lint wants an `@XmlRes`; vector drawables *are* XML resources and parsing one this way is intentional.

Each call site gets a `@SuppressLint` with a comment naming the guarantee that makes it safe.

## Verification

`./gradlew :app:lintDebug` — `MissingPermission` and `ResourceType` counts drop to **0** (from 3 + 1). No behavior change; nothing shipped in the APK changes.

## Out of scope

The 12 `RestrictedApi` findings on WorkManager's `Result.outputData` are intentionally left alone — that's a separate suppress-vs-refactor decision, and these aren't bugs or CI gates either. The `MissingTranslation` / `UnusedResources` noise is likewise untouched (expected/risky-to-bulk-edit).

https://claude.ai/code/session_019C8CGsqTb3hR21kV4vAx5W

---
_Generated by [Claude Code](https://claude.ai/code/session_019C8CGsqTb3hR21kV4vAx5W)_