### PR TITLE
Snappier swiping between forecast pages

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/today/ForecastChart.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/ForecastChart.kt
@@ -288,6 +288,14 @@ fun ForecastChart(
             // swallow horizontal drags. The scrub gesture lives on the parent Box.
             scrollState = rememberVicoScrollState(scrollEnabled = false),
             zoomState = rememberVicoZoomState(zoomEnabled = false, initialZoom = Zoom.Content),
+            // No entry animation: the chart appears at its final shape the
+            // moment the card composes. The grow-in added nothing for a static
+            // glanceable card and ran on every page swipe, so dropping it makes
+            // swiping between the per-period / 7-day pages snappier. The
+            // data-diff animation (animationSpec, left at its default) is
+            // untouched, so toggling the per-model spread still animates the
+            // lines in and out — the one chart animation worth keeping.
+            animateIn = false,
             modifier = Modifier.matchParentSize(),
         )
     }

--- a/app/src/main/kotlin/app/clothescast/ui/today/PerModelDiagnosticCard.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/PerModelDiagnosticCard.kt
@@ -308,6 +308,10 @@ private fun PerModelDiagnosticChart(
             modelProducer = producer,
             scrollState = rememberVicoScrollState(scrollEnabled = false),
             zoomState = rememberVicoZoomState(zoomEnabled = false, initialZoom = Zoom.Content),
+            // No entry animation — appears at final shape on compose, snappier
+            // on page swipes. Diff animation (animationSpec) kept, so the
+            // per-model spread reveal still animates. See ForecastChart.
+            animateIn = false,
             modifier = Modifier.matchParentSize(),
         )
     }

--- a/app/src/main/kotlin/app/clothescast/ui/today/PrecipitationAmountChart.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/PrecipitationAmountChart.kt
@@ -158,6 +158,10 @@ fun PrecipitationAmountChart(
             modelProducer = producer,
             scrollState = rememberVicoScrollState(scrollEnabled = false),
             zoomState = rememberVicoZoomState(zoomEnabled = false, initialZoom = Zoom.Content),
+            // No entry animation — appears at final shape on compose, snappier
+            // on page swipes. Diff animation (animationSpec) kept. See
+            // ForecastChart for the rationale.
+            animateIn = false,
             modifier = Modifier.matchParentSize(),
         )
     }

--- a/app/src/main/kotlin/app/clothescast/ui/today/PrecipitationChart.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/PrecipitationChart.kt
@@ -185,6 +185,10 @@ fun PrecipitationChart(
             modelProducer = producer,
             scrollState = rememberVicoScrollState(scrollEnabled = false),
             zoomState = rememberVicoZoomState(zoomEnabled = false, initialZoom = Zoom.Content),
+            // No entry animation — appears at final shape on compose, snappier
+            // on page swipes. Diff animation (animationSpec) kept. See
+            // ForecastChart for the rationale.
+            animateIn = false,
             modifier = Modifier.matchParentSize(),
         )
     }


### PR DESCRIPTION
## What

The Today/7-day forecast charts no longer play an **entry animation**. Each chart now appears at its final shape the instant its card composes, instead of growing in. That grow-in ran on every page swipe and added nothing for a static, glanceable, scroll/zoom-disabled summary card — so dropping it makes swiping between the per-period and 7-day pages feel snappier.

## What's kept

The **data-diff animation** (`animationSpec`, left at its default) is untouched, so tapping to toggle the per-model spread still animates the lines in and out — the one chart animation worth keeping.

## Implementation

`animateIn = false` on all four `CartesianChartHost` call sites: `ForecastChart`, `PrecipitationChart`, `PrecipitationAmountChart`, `PerModelDiagnosticCard`. +20 lines, no other changes.

## Scope note

This PR started as the Vico 2.0.3 → 2.5.1 bump. We investigated and found:
- The thing actually wanted (snappier swipes, drop the boring entry animation, keep the tap reveal) is delivered entirely by `animateIn = false` — and it works on the **current Vico 2.0.3**, so the version bump isn't needed for it.
- The Vico 2.5.1 bump separately introduced a snapshot-test hang on the live 7-day page that is **not** animation-related (it hung with all chart animations off too). Not worth chasing for no user-facing gain, so the version bump is dropped.

Stays on Vico 2.0.3.

## Test plan

- `./gradlew :app:testDebugUnitTest` — green
- `./gradlew :app:assembleDebug` — green
- **Zero snapshot churn**: snapshots capture the settled frame either way, so this is a pure runtime/feel change with no pixel diff.

## Privacy

No change to what crosses the device boundary — rendering only.

https://claude.ai/code/session_013A7TDsJuwdWCqUT3TUYBnU