### PR TITLE
Update app libraries to current versions

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -59,11 +59,12 @@
 # R8 input. None are reachable from an MQTT publisher that just opens a TLS
 # socket and publishes a UTF-8 string — they're all alternative codec paths
 # (Brotli, Zstd, jzlib, LZ4, LZF, LZMA), protobuf serialization, JBoss
-# marshalling, GraalVM/SVM substitution annotations, and JDK-private SSL
-# self-signed cert utilities — but their references would trip R8 without
-# these warnings suppressed. List harvested from missing_rules.txt; if a
-# Netty version bump adds new optional integrations, re-run assembleDebug
-# and append any new ones here.
+# marshalling, GraalVM/SVM substitution annotations, JDK-private SSL
+# self-signed cert utilities, and OSGi bundle metadata annotations (compile-only,
+# referenced from a shaded jctools package-info) — but their references would
+# trip R8 without these warnings suppressed. List harvested from
+# missing_rules.txt; if a Netty version bump adds new optional integrations,
+# re-run assembleDebug and append any new ones here.
 -dontwarn com.aayushatharva.brotli4j.**
 -dontwarn com.github.luben.zstd.**
 -dontwarn com.google.protobuf.**
@@ -73,6 +74,7 @@
 -dontwarn lzma.sdk.**
 -dontwarn net.jpountz.**
 -dontwarn org.jboss.marshalling.**
+-dontwarn org.osgi.annotation.bundle.**
 -dontwarn sun.security.x509.**
 
 # HiveMQ MQTT Client wires its Netty pipeline through an internal Dagger 2

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,28 +15,29 @@ kotlin = "2.2.21"
 # Telemetry silences Firebase when SDK_INT < MIN_SDK_VERSION.
 minSdk = "31"
 ksp = "2.2.21-2.0.5"
-coreKtx = "1.17.0"
-lifecycle = "2.9.4"
-activityCompose = "1.11.0"
+coreKtx = "1.18.0"
+lifecycle = "2.10.0"
+activityCompose = "1.13.0"
 composeBom = "2026.05.01"
 # Navigation Compose — type-safe routes (@Serializable destinations) require
-# 2.8.0+. Aligned with the lifecycle 2.9.x cohort.
-navigation = "2.9.4"
+# 2.8.0+. 2.9.x is the current stable line (2.10.0 is still alpha); it depends
+# on lifecycle 2.9.x but composes fine against the 2.10.0 we pin above.
+navigation = "2.9.8"
 # Drag-and-drop reordering for Compose lists/columns (used by the Settings →
 # Display "Home screen layout" reorder UI). 3.1.0 needs Compose foundation
 # 1.7.0+, well under the BoM above. Lives on Maven Central.
 reorderable = "3.1.0"
 junit5 = "5.11.3"
-mockk = "1.13.13"
+mockk = "1.14.11"
 kotest = "5.9.1"
-turbine = "1.2.0"
-coroutines = "1.9.0"
-ktor = "3.0.2"
-zxing = "3.5.3"
-serialization = "1.7.3"
-tink = "1.15.0"
-datastore = "1.1.1"
-work = "2.10.0"
+turbine = "1.2.1"
+coroutines = "1.11.0"
+ktor = "3.5.0"
+zxing = "3.5.4"
+serialization = "1.11.0"
+tink = "1.21.0"
+datastore = "1.2.1"
+work = "2.11.2"
 # Glance powers the home-screen App Widget. Held at 1.1.1: 1.2.x exists only as
 # a release candidate (no stable yet) and is what the live-widget-preview API
 # needs — tracked in #914. compileSdk is no longer the blocker; the RC status is.
@@ -65,21 +66,21 @@ playAppUpdate = "2.1.0"
 # in app/build.gradle.kts based on app/google-services.json's presence so CI
 # (which doesn't carry the file) still compiles. See PRIVACY.md for the data
 # boundary contract these SDKs operate under.
-firebaseBom = "33.7.0"
-gmsGoogleServices = "4.4.2"
-firebaseCrashlyticsPlugin = "3.0.2"
+firebaseBom = "34.14.0"
+gmsGoogleServices = "4.4.4"
+firebaseCrashlyticsPlugin = "3.0.7"
 # HiveMQ MQTT Client — used by the optional Smart Home bridge to publish the
 # rendered insight prose to a user-hosted MQTT broker (Mosquitto add-on inside
 # Home Assistant, typically). Pure-Java + Netty; no JNI. The publisher uses the
 # blocking client wrapped in withContext(Dispatchers.IO), so no Reactor /
 # CompletableFuture await plumbing is needed in :app.
-hivemqMqttClient = "1.3.3"
+hivemqMqttClient = "1.3.14"
 # Google Cast — pulls in androidx.mediarouter for the route discovery /
 # session APIs and `play-services-cast` for RemoteMediaClient. Cast SDK
 # itself doesn't need google-services.json; framework init is gated at
 # runtime on Google Play services availability, so CI builds without the
 # JSON still compile and assemble.
-playServicesCast = "21.5.0"
+playServicesCast = "22.3.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }


### PR DESCRIPTION
Routine dependency refresh across `gradle/libs.versions.toml`, verified with the full CI-equivalent build (`:core:*:test`, `:app:testDebugUnitTest`, `:app:assembleDebug`) on a VM with the Android SDK + Google Maven.

## Minor / patch bumps
| Lib | From | To |
|---|---|---|
| androidx core-ktx | 1.17.0 | 1.18.0 |
| androidx lifecycle | 2.9.4 | 2.10.0 |
| androidx activity-compose | 1.11.0 | 1.13.0 |
| androidx navigation | 2.9.4 | 2.9.8 |
| androidx work | 2.10.0 | 2.11.2 |
| androidx datastore | 1.1.1 | 1.2.1 |
| mockk | 1.13.13 | 1.14.11 |
| turbine | 1.2.0 | 1.2.1 |
| zxing core | 3.5.3 | 3.5.4 |
| hivemq-mqtt-client | 1.3.3 | 1.3.14 |
| gms-google-services (plugin) | 4.4.2 | 4.4.4 |
| firebase-crashlytics (plugin) | 3.0.2 | 3.0.7 |

## Moderate bumps
| Lib | From | To |
|---|---|---|
| kotlinx-coroutines | 1.9.0 | 1.11.0 |
| ktor | 3.0.2 | 3.5.0 |
| kotlinx-serialization | 1.7.3 | 1.11.0 |
| tink-android | 1.15.0 | 1.21.0 |
| play-services-cast | 21.5.0 | 22.3.1 |
| firebase-bom | 33.7.0 | 34.14.0 |

## Held back (documented in the catalog, out of scope here)
- **AGP** — gated on bumping the Gradle wrapper off 8.11.1 first.
- **Glance** — only an RC is newer; tracked in #914.
- **Vico** — 2.1+ breaks the snapshot scrub loop; 3.x is an API rewrite.
- **Compose BoM** — already at the latest stable (2026.05.01).
- **JUnit 6 / kotest 6 / roborazzi** — platform-major jumps, deferred to their own PRs.

## R8 keep rule
The newer Netty pulled in by `hivemq-mqtt-client` 1.3.14 references the compile-only OSGi annotation `org.osgi.annotation.bundle.Export` from a shaded jctools `package-info`. Added the matching `-dontwarn` alongside the existing Netty suppression list in `app/proguard-rules.pro` so R8 keeps minifying.

## Privacy
The **Firebase BoM crosses a major version line (33 → 34)**, so the Analytics/Crashlytics SDKs update. No ClothesCast code or config changed with it: the telemetry runtime toggle still gates *whether* Firebase initializes, and the PRIVACY.md payload contract (no calendar data, location, insight prose, API keys, GPS, or ad IDs in any report) is unchanged. Flagging the SDK-line bump for review per the repo's privacy rules.

## Test plan
- [x] `./gradlew :core:domain:test :core:data:test :app:testDebugUnitTest` — green
- [x] `./gradlew :app:assembleDebug` — green (after the R8 keep rule)
- [ ] CI parity

---
_Generated by [Claude Code](https://claude.ai/code/session_011fXUoLCq41hP3BHNVzPZCT)_