### PR TITLE
Forecast charts update instantly instead of animating

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/today/ForecastChart.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/ForecastChart.kt
@@ -296,14 +296,18 @@ fun ForecastChart(
             // swallow horizontal drags. The scrub gesture lives on the parent Box.
             scrollState = rememberVicoScrollState(scrollEnabled = false),
             zoomState = rememberVicoZoomState(zoomEnabled = false, initialZoom = Zoom.Content),
-            // No entry animation: the chart appears at its final shape the
-            // moment the card composes. The grow-in added nothing for a static
-            // glanceable card and ran on every page swipe, so dropping it makes
-            // swiping between the per-period / 7-day pages snappier. The
-            // data-diff animation (animationSpec, left at its default) is
-            // untouched, so toggling the per-model spread still animates the
-            // lines in and out — the one chart animation worth keeping.
+            // No animations. The chart appears at its final shape the moment
+            // the card composes (animateIn = false) and every later data change
+            // — per-model spread toggle, °C/°F, feels-like, a live refresh —
+            // applies instantly (animationSpec = null). The entry grow-in ran
+            // on every page swipe for no gain on a static glanceable card. The
+            // diff animation grew newly-added series up from the layer baseline
+            // rather than fanning them out from the combined line, so the
+            // spread reveal read as a grow-in, not an uncertainty cue — and the
+            // toggles it fired on are deliberate user actions (or rare
+            // background refreshes) where instant is the right feel.
             animateIn = false,
+            animationSpec = null,
             modifier = Modifier.matchParentSize(),
         )
     }

--- a/app/src/main/kotlin/app/clothescast/ui/today/PerModelDiagnosticCard.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/PerModelDiagnosticCard.kt
@@ -314,10 +314,11 @@ private fun PerModelDiagnosticChart(
             modelProducer = producer,
             scrollState = rememberVicoScrollState(scrollEnabled = false),
             zoomState = rememberVicoZoomState(zoomEnabled = false, initialZoom = Zoom.Content),
-            // No entry animation — appears at final shape on compose, snappier
-            // on page swipes. Diff animation (animationSpec) kept, so the
-            // per-model spread reveal still animates. See ForecastChart.
+            // No animations — appears at final shape on compose (animateIn) and
+            // data changes apply instantly (animationSpec = null), so the spread
+            // reveal and toggles snap rather than grow in. See ForecastChart.
             animateIn = false,
+            animationSpec = null,
             modifier = Modifier.matchParentSize(),
         )
     }

--- a/app/src/main/kotlin/app/clothescast/ui/today/PrecipitationAmountChart.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/PrecipitationAmountChart.kt
@@ -163,10 +163,11 @@ fun PrecipitationAmountChart(
             modelProducer = producer,
             scrollState = rememberVicoScrollState(scrollEnabled = false),
             zoomState = rememberVicoZoomState(zoomEnabled = false, initialZoom = Zoom.Content),
-            // No entry animation — appears at final shape on compose, snappier
-            // on page swipes. Diff animation (animationSpec) kept. See
-            // ForecastChart for the rationale.
+            // No animations — appears at final shape on compose (animateIn) and
+            // data changes apply instantly (animationSpec = null), snappier on
+            // page swipes and toggles. See ForecastChart for the rationale.
             animateIn = false,
+            animationSpec = null,
             modifier = Modifier.matchParentSize(),
         )
     }

--- a/app/src/main/kotlin/app/clothescast/ui/today/PrecipitationChart.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/PrecipitationChart.kt
@@ -190,10 +190,11 @@ fun PrecipitationChart(
             modelProducer = producer,
             scrollState = rememberVicoScrollState(scrollEnabled = false),
             zoomState = rememberVicoZoomState(zoomEnabled = false, initialZoom = Zoom.Content),
-            // No entry animation — appears at final shape on compose, snappier
-            // on page swipes. Diff animation (animationSpec) kept. See
-            // ForecastChart for the rationale.
+            // No animations — appears at final shape on compose (animateIn) and
+            // data changes apply instantly (animationSpec = null), snappier on
+            // page swipes and toggles. See ForecastChart for the rationale.
             animateIn = false,
+            animationSpec = null,
             modifier = Modifier.matchParentSize(),
         )
     }

--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayPreviews.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayPreviews.kt
@@ -84,8 +84,20 @@ internal fun Frame(
     colorPalette: ColorPalette = ColorPalette.RAINBOW,
     content: @Composable () -> Unit,
 ) {
-    ClothesCastTheme(darkTheme = darkTheme, dynamicColor = false, colorPalette = colorPalette) {
-        Surface { Column(modifier = Modifier.padding(16.dp)) { content() } }
+    // Render every preview in inspection mode, exactly as Android Studio's
+    // @Preview pane does. Beyond matching Studio, this is what lets the Vico
+    // charts snapshot deterministically: Vico's CartesianChartModelProducer
+    // runs its model transform on Dispatchers.Default (a real background
+    // thread) in normal composition, but switches to Dispatchers.Unconfined
+    // — synchronous, on the calling thread — when LocalInspectionMode is set.
+    // Without this, a chart-bearing preview races the background transform and
+    // can capture a chrome-only card with no plotted line. The inspection-mode
+    // guards in the *Banner wrappers don't bite here: the banner previews
+    // render the stateless *Card variants directly, which carry no guard.
+    CompositionLocalProvider(LocalInspectionMode provides true) {
+        ClothesCastTheme(darkTheme = darkTheme, dynamicColor = false, colorPalette = colorPalette) {
+            Surface { Column(modifier = Modifier.padding(16.dp)) { content() } }
+        }
     }
 }
 
@@ -2100,14 +2112,13 @@ private val SAMPLE_WEEK_OUTFIT_INSIGHT = SAMPLE_INSIGHT.copy(
 
 // The 7-day previews render the full [HomePageScaffold], whose banner stack
 // reads runtime-only app state (update checker, crash log, telemetry pref).
-// Flag inspection mode so those banners no-op (see the LocalInspectionMode
-// guards in the *Banner wrappers) and the chart deck snapshots cleanly without
-// a live Application — matching how Android Studio renders the same screen.
+// [Frame] already provides LocalInspectionMode = true, so those banners no-op
+// (see the LocalInspectionMode guards in the *Banner wrappers) and the chart
+// deck snapshots cleanly without a live Application — matching how Android
+// Studio renders the same screen.
 @Composable
 private fun SevenDayFrame(content: @Composable () -> Unit) {
-    Frame {
-        CompositionLocalProvider(LocalInspectionMode provides true) { content() }
-    }
+    Frame { content() }
 }
 
 // [SAMPLE_WEEK]'s feels-like highs swing from 18° today up to 22° Wednesday


### PR DESCRIPTION
## What

Disables the Vico chart **data-diff animation** (`animationSpec = null` on all four `CartesianChartHost` call sites: `ForecastChart`, `PrecipitationChart`, `PrecipitationAmountChart`, `PerModelDiagnosticCard`). Every data change now applies instantly instead of a 500ms tween:

- tapping to reveal/hide the per-model spread
- switching °C/°F or feels-like
- a background forecast refresh

The chart *entry* animation was already off (#931); this removes the remaining one.

## Why

The diff animation grew newly-added series **up from the layer baseline**, not fanning them out from the combined line — so the spread reveal read as a generic grow-in, not an uncertainty cue. The transitions it covered are deliberate user toggles (or rare background refreshes) where instant feedback is the right feel, consistent with the earlier entry-animation removal.

## Snapshot harness (the interesting part)

Removing the animation surfaced that it had been **masking a producer-drain race**. Vico's `CartesianChartModelProducer` runs its model transform on `Dispatchers.Default` (a real background thread) in normal composition, switching to `Dispatchers.Unconfined` — synchronous — only when `LocalInspectionMode` is set (its `getDispatcher` checks for `PreviewContextKey`). The preview snapshots ran with inspection mode **unset**, so with the 500ms animation gone a chart-bearing preview could capture a chrome-only card before the background transform delivered its line (reproduced: `humidity_card_with_model_spread` drew on only ~1–3 of 5 isolated runs).

**Fix:** the shared preview `Frame` now provides `LocalInspectionMode = true`, exactly as Android Studio's `@Preview` pane does. The transform then runs synchronously and the chart paints deterministically (5/5 isolated runs, byte-identical). The 7-day previews already did this locally; this hoists it to `Frame` so *every* chart preview is covered, including future ones. The banner previews are unaffected — they render the stateless `*Card` variants, which carry no inspection-mode guard.

Notably this needs **no change to the snapshot test harness** (`PreviewSnapshots.kt` is untouched from `main`) — the pinned-clock work from #934 still does its job.

## Test plan

- `./gradlew :core:domain:test :core:data:test :app:testDebugUnitTest` — **1589 tests, 0 failures**, run twice for reliability.
- `./gradlew :app:assembleDebug` — green.
- **Zero snapshot churn** — every snapshot byte-identical to the `main` baseline (the settled chart is the same with or without the animation; the noise-tolerant baseline restore keeps the bytes stable).

## Privacy

No change to what crosses the device boundary — rendering only.

https://claude.ai/code/session_013A7TDsJuwdWCqUT3TUYBnU

---
_Generated by [Claude Code](https://claude.ai/code/session_013A7TDsJuwdWCqUT3TUYBnU)_