### PR TITLE
Pin Guava to a patched version to clear a security advisory

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -553,6 +553,15 @@ androidComponents {
 }
 
 dependencies {
+    // Force Guava off the vulnerable 31.1-android that firebase-analytics pulls
+    // transitively (via play-services-measurement, which still pins it even in
+    // its latest release). Clears CVE-2023-2976 / GHSA-7g45-4rm6-3mm3 (moderate:
+    // FileBackedOutputStream temp-dir disclosure, fixed in 32.0.0). The app
+    // doesn't use that API, so this is alert hygiene, not a behavior change.
+    constraints {
+        implementation(libs.guava)
+    }
+
     implementation(project(":core:domain"))
     implementation(project(":core:data"))
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -82,6 +82,12 @@ hivemqMqttClient = "1.3.14"
 # runtime on Google Play services availability, so CI builds without the
 # JSON still compile and assemble.
 playServicesCast = "22.3.1"
+# Guava is not used directly — it arrives transitively via firebase-analytics
+# (-> play-services-measurement, which still pins 31.1-android even in its
+# latest release). We force it up to clear CVE-2023-2976 / GHSA-7g45-4rm6-3mm3
+# (moderate: FileBackedOutputStream temp-dir disclosure, fixed in 32.0.0). See
+# the dependency constraint in app/build.gradle.kts.
+guava = "33.6.0-android"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -159,6 +165,7 @@ firebase-installations = { group = "com.google.firebase", name = "firebase-insta
 hivemq-mqtt-client = { group = "com.hivemq", name = "hivemq-mqtt-client", version.ref = "hivemqMqttClient" }
 
 play-services-cast-framework = { group = "com.google.android.gms", name = "play-services-cast-framework", version.ref = "playServicesCast" }
+guava = { group = "com.google.guava", name = "guava", version.ref = "guava" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
Clears the moderate Dependabot advisory on the default branch.

## What
`firebase-analytics` pulls `com.google.guava:guava:31.1-android` transitively (via `play-services-measurement`), which is flagged by **CVE-2023-2976 / GHSA-7g45-4rm6-3mm3** — a moderate `FileBackedOutputStream` temp-directory information-disclosure issue fixed in Guava 32.0.0.

## Why a constraint (not a Firebase/Play-services bump)
We're already on the latest `firebase-bom` (34.14.0) and `play-services-measurement` (23.2.0), and **even that latest release still declares `guava:31.1-android`** — there's no upstream version that clears it. So we force it ourselves with a dependency constraint to `33.6.0-android`.

## Impact
The app never touches `FileBackedOutputStream`, so this is **Dependabot-alert hygiene, not a behavior change** — hence the `internal:` prefix and no Play "What's new" entry. No functional or user-visible difference; snapshots unchanged.

## Verification
- `:app:dependencyInsight` confirms guava resolves `31.1-android -> 33.6.0-android` on the release runtime classpath.
- Full build green: `:app:testDebugUnitTest`, `:app:assembleDebug`.

Other advisory-prone transitives were checked and are current (netty 4.1.133, okhttp 5.3.2, okio 3.9+, gson 2.13.2, tink 1.21) — guava was the lone stale one.

---
_Generated by [Claude Code](https://claude.ai/code/session_011fXUoLCq41hP3BHNVzPZCT)_