### PR TITLE
Upgrade JUnit to 6.1.0 and Kotest to 6.1.11

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -663,7 +663,7 @@ dependencies {
     // Production (not test-only) because the planner runs in the main coroutine flow.
     implementation(libs.kotlinx.coroutines.play.services)
 
-    testImplementation(platform("org.junit:junit-bom:5.11.3"))
+    testImplementation(platform("org.junit:junit-bom:6.1.0"))
     testImplementation(libs.junit.jupiter.api)
     testRuntimeOnly(libs.junit.jupiter.engine)
     // Gradle 9 no longer injects the JUnit Platform launcher onto the test

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -15,7 +15,7 @@ dependencies {
     implementation(libs.ktor.client.content.negotiation)
     implementation(libs.ktor.serialization.kotlinx.json)
 
-    testImplementation(platform("org.junit:junit-bom:5.11.3"))
+    testImplementation(platform("org.junit:junit-bom:6.1.0"))
     testImplementation(libs.junit.jupiter.api)
     testImplementation(libs.junit.jupiter.params)
     testRuntimeOnly(libs.junit.jupiter.engine)

--- a/core/domain/build.gradle.kts
+++ b/core/domain/build.gradle.kts
@@ -9,7 +9,7 @@ kotlin {
 dependencies {
     implementation(libs.kotlinx.coroutines.core)
 
-    testImplementation(platform("org.junit:junit-bom:5.11.3"))
+    testImplementation(platform("org.junit:junit-bom:6.1.0"))
     testImplementation(libs.junit.jupiter.api)
     testImplementation(libs.junit.jupiter.params)
     testRuntimeOnly(libs.junit.jupiter.engine)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,9 +30,9 @@ navigation = "2.9.8"
 # Display "Home screen layout" reorder UI). 3.1.0 needs Compose foundation
 # 1.7.0+, well under the BoM above. Lives on Maven Central.
 reorderable = "3.1.0"
-junit5 = "5.11.3"
+junit5 = "6.1.0"
 mockk = "1.14.11"
-kotest = "5.9.1"
+kotest = "6.1.11"
 turbine = "1.2.1"
 coroutines = "1.11.0"
 ktor = "3.5.0"


### PR DESCRIPTION
Bumps the two test frameworks to their current majors. `internal:` — test-only dependencies, nothing ships in the APK.

## JUnit Jupiter 5.11.3 → 6.1.0
- **Unified version scheme:** platform, jupiter, and vintage all share `6.x` now, so the single `junit5` catalog ref drives `jupiter-api/-engine/-params` **and** `junit-vintage-engine` together, the inline `junit-bom` pins move to 6.1.0, and the `junit-platform-launcher` we declare `testRuntimeOnly` inherits 6.1.0 from the BOM.
- Java 17 / Kotlin 2.1 baselines already met (JDK 21, Kotlin 2.2.21).
- **`junit-vintage-engine` still ships in 6.x**, so the Robolectric `@RunWith(AndroidJUnit4)` snapshot tests keep running through it. It's now flagged a deprecated "temporary bridge" — functional, just a future watch-item; no action now.

## Kotest 5.9.1 → 6.1.11
- We use Kotest **only for assertions** (`kotest-assertions-core`). The matchers in use (`shouldBe`, `shouldThrow`, `plusOrMinus`, `shouldContainExactly*`) are unchanged in 6.x.
- The 6.0 breaking changes are all in spec/runner/property-testing modules we don't use; the dropped `kotest-assertions-api` artifact and the `maps.contain` rename don't apply.
- Upside: Power-Assert-style assertion failure messages (each sub-expression's value on a failed assertion).

## Verification
No source migration needed. Full suite runs and passes across both engines:
- `:core:domain` 528, `:core:data` 112, `:app` 949 = **1,589 tests, 0 failures, 0 skipped**
- `:app:assembleDebug` green, snapshots unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_011fXUoLCq41hP3BHNVzPZCT)_