### PR TITLE
internal: share chart animation defaults, prune snapshot harness

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/today/ChartAnimations.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/ChartAnimations.kt
@@ -1,0 +1,18 @@
+package app.clothescast.ui.today
+
+import androidx.compose.animation.core.AnimationSpec
+
+// Shared `CartesianChartHost` animation defaults for every forecast chart in
+// the app. The chart appears at its final shape the moment its card composes
+// ([CHART_ANIMATE_IN] = false) and every later data change — per-model spread
+// toggle, °C/°F, feels-like, a live refresh — applies instantly
+// ([CHART_ANIMATION_SPEC] = null).
+//
+// Why: the entry grow-in ran on every page swipe for no gain on a static
+// glanceable card. The diff animation grew newly-added series up from the
+// layer baseline rather than fanning them out from the combined line, so the
+// spread reveal read as a grow-in, not an uncertainty cue — and the toggles
+// it fired on are deliberate user actions (or rare background refreshes)
+// where instant is the right feel.
+internal const val CHART_ANIMATE_IN = false
+internal val CHART_ANIMATION_SPEC: AnimationSpec<Float>? = null

--- a/app/src/main/kotlin/app/clothescast/ui/today/ForecastChart.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/ForecastChart.kt
@@ -296,18 +296,8 @@ fun ForecastChart(
             // swallow horizontal drags. The scrub gesture lives on the parent Box.
             scrollState = rememberVicoScrollState(scrollEnabled = false),
             zoomState = rememberVicoZoomState(zoomEnabled = false, initialZoom = Zoom.Content),
-            // No animations. The chart appears at its final shape the moment
-            // the card composes (animateIn = false) and every later data change
-            // — per-model spread toggle, °C/°F, feels-like, a live refresh —
-            // applies instantly (animationSpec = null). The entry grow-in ran
-            // on every page swipe for no gain on a static glanceable card. The
-            // diff animation grew newly-added series up from the layer baseline
-            // rather than fanning them out from the combined line, so the
-            // spread reveal read as a grow-in, not an uncertainty cue — and the
-            // toggles it fired on are deliberate user actions (or rare
-            // background refreshes) where instant is the right feel.
-            animateIn = false,
-            animationSpec = null,
+            animateIn = CHART_ANIMATE_IN,
+            animationSpec = CHART_ANIMATION_SPEC,
             modifier = Modifier.matchParentSize(),
         )
     }

--- a/app/src/main/kotlin/app/clothescast/ui/today/PerModelDiagnosticCard.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/PerModelDiagnosticCard.kt
@@ -314,11 +314,8 @@ private fun PerModelDiagnosticChart(
             modelProducer = producer,
             scrollState = rememberVicoScrollState(scrollEnabled = false),
             zoomState = rememberVicoZoomState(zoomEnabled = false, initialZoom = Zoom.Content),
-            // No animations — appears at final shape on compose (animateIn) and
-            // data changes apply instantly (animationSpec = null), so the spread
-            // reveal and toggles snap rather than grow in. See ForecastChart.
-            animateIn = false,
-            animationSpec = null,
+            animateIn = CHART_ANIMATE_IN,
+            animationSpec = CHART_ANIMATION_SPEC,
             modifier = Modifier.matchParentSize(),
         )
     }

--- a/app/src/main/kotlin/app/clothescast/ui/today/PrecipitationAmountChart.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/PrecipitationAmountChart.kt
@@ -163,11 +163,8 @@ fun PrecipitationAmountChart(
             modelProducer = producer,
             scrollState = rememberVicoScrollState(scrollEnabled = false),
             zoomState = rememberVicoZoomState(zoomEnabled = false, initialZoom = Zoom.Content),
-            // No animations — appears at final shape on compose (animateIn) and
-            // data changes apply instantly (animationSpec = null), snappier on
-            // page swipes and toggles. See ForecastChart for the rationale.
-            animateIn = false,
-            animationSpec = null,
+            animateIn = CHART_ANIMATE_IN,
+            animationSpec = CHART_ANIMATION_SPEC,
             modifier = Modifier.matchParentSize(),
         )
     }

--- a/app/src/main/kotlin/app/clothescast/ui/today/PrecipitationChart.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/PrecipitationChart.kt
@@ -190,11 +190,8 @@ fun PrecipitationChart(
             modelProducer = producer,
             scrollState = rememberVicoScrollState(scrollEnabled = false),
             zoomState = rememberVicoZoomState(zoomEnabled = false, initialZoom = Zoom.Content),
-            // No animations — appears at final shape on compose (animateIn) and
-            // data changes apply instantly (animationSpec = null), snappier on
-            // page swipes and toggles. See ForecastChart for the rationale.
-            animateIn = false,
-            animationSpec = null,
+            animateIn = CHART_ANIMATE_IN,
+            animationSpec = CHART_ANIMATION_SPEC,
             modifier = Modifier.matchParentSize(),
         )
     }

--- a/app/src/main/kotlin/app/clothescast/widget/FeelsLikeWidgetChart.kt
+++ b/app/src/main/kotlin/app/clothescast/widget/FeelsLikeWidgetChart.kt
@@ -35,9 +35,10 @@ import java.util.Locale
  * kept reading as "off-brand").
  *
  * Two render paths, one composable:
- *  - **Snapshot tests** drive it through `PreviewSnapshots`, whose
- *    `captureUntilStable` already pumps frames until Vico's async series has
- *    drawn — so the chart-timing problem is the harness's, not ours.
+ *  - **Snapshot tests** drive it through `PreviewSnapshots`. `WidgetFrame`
+ *    provides `LocalInspectionMode = true`, so Vico's producer runs on its
+ *    synchronous in-inspection dispatcher and the chart is fully drawn by
+ *    the time `captureUntilStable` rasterises — no extra timing dance.
  *  - **Runtime** rasterises it to a bitmap via [renderComposableToBitmap] for
  *    the Glance widget (Glance can't host Compose/Vico directly).
  *

--- a/app/src/main/kotlin/app/clothescast/widget/WidgetPreviews.kt
+++ b/app/src/main/kotlin/app/clothescast/widget/WidgetPreviews.kt
@@ -16,8 +16,10 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -62,12 +64,21 @@ private val SIDE_BY_SIDE_MIN_WIDTH = 240.dp
 
 @Composable
 private fun WidgetFrame(darkTheme: Boolean = false, content: @Composable () -> Unit) {
-    ClothesCastTheme(darkTheme = darkTheme, dynamicColor = false) {
-        // Slight surface inset so the rounded widget corners are visible against
-        // a launcher-like backdrop. The actual launcher applies its own
-        // wallpaper, so the colour here is just for visual contrast.
-        Surface(color = MaterialTheme.colorScheme.background) {
-            Box(modifier = Modifier.padding(16.dp)) { content() }
+    // Render every widget preview in inspection mode, matching `Frame` in
+    // TodayPreviews.kt. The feels-like widget previews reuse `ForecastChart`
+    // through `WidgetForecastChart`, so they need the same synchronous Vico
+    // producer dispatcher (`Dispatchers.Unconfined` under inspection mode,
+    // `Dispatchers.Default` otherwise) — without it the snapshot can race the
+    // background transaction and capture a chrome-only card with no plotted
+    // line under heavy parallel CI load.
+    CompositionLocalProvider(LocalInspectionMode provides true) {
+        ClothesCastTheme(darkTheme = darkTheme, dynamicColor = false) {
+            // Slight surface inset so the rounded widget corners are visible
+            // against a launcher-like backdrop. The actual launcher applies
+            // its own wallpaper, so the colour here is just for visual contrast.
+            Surface(color = MaterialTheme.colorScheme.background) {
+                Box(modifier = Modifier.padding(16.dp)) { content() }
+            }
         }
     }
 }

--- a/app/src/test/kotlin/app/clothescast/ui/today/PreviewSnapshots.kt
+++ b/app/src/test/kotlin/app/clothescast/ui/today/PreviewSnapshots.kt
@@ -192,23 +192,18 @@ class PreviewSnapshots {
      * Captures a snapshot to disk and re-captures until two consecutive
      * attempts produce the same bytes — i.e. the rendering has settled.
      *
-     * The test clock is pinned (see [pinClock]) because Vico 2.1+'s chart
-     * host never reports idle. So rather than leaning on auto-advance, we
-     * step the clock by hand: one generous [SETTLE_MILLIS] slice up front to
-     * drain each chart's `CartesianChartModelProducer` flow and finish its
-     * data-diff animation — the collection + recompose + paint sequence that
-     * `waitForIdle()` alone doesn't cover — then one frame per attempt so the
-     * settled state paints before we rasterize. Applied uniformly; it's cheap
-     * on chart-less previews (a single virtual-time step), so there's no need
-     * to annotate each chart-bearing preview by hand.
-     *
-     * If a chart is mid-paint we see different bytes on consecutive captures
-     * and keep looping; once the picture stops changing we accept it. Catches
-     * the "card chrome rendered but chart line missing" case the older
-     * [looksEmpty] backstop misses — a card with axis grid + text has many
-     * distinct colours and never trips [looksEmpty]'s all-pixels-equal
-     * check, but it's still the wrong answer compared to a stabilised
-     * second capture.
+     * The test clock is pinned (see [pinClock]) because Vico's chart host
+     * requests an animation frame on every frame for the life of the
+     * composition — under the default auto-advancing clock that pumps
+     * frames forever and throws AppNotIdleException. With the clock pinned,
+     * we step it by hand: one generous [SETTLE_MILLIS] slice up front so
+     * `animateFloatAsState`-driven on-load animations settle to their final
+     * values (e.g. [app.clothescast.ui.EdgeFadeOverlay]'s top/bottom fade
+     * alphas), then one frame per attempt so the settled picture paints
+     * before we rasterise. Chart producers run synchronously under inspection
+     * mode (set in [Frame]), so there's no background-dispatcher race to
+     * wait on and no data-diff animation to settle — chart animations are
+     * disabled everywhere (see [CHART_ANIMATION_SPEC]).
      *
      * After the in-session stable check passes, the result is compared
      * against the pre-capture baseline (the PNG already on disk, i.e.
@@ -222,14 +217,6 @@ class PreviewSnapshots {
      * [looksEmpty] stays as a separate guard so a *completely* blank
      * capture (every sampled pixel matching the first) never gets to
      * "stable" status just by failing the same way twice in a row.
-     *
-     * History: PR #436's CI runs flipped `precipitation_card_dry.png`
-     * between a "with chart" (29.6KB) and a "no chart" render (11.6KB)
-     * on consecutive runs of the *same* commit — the chart-missing
-     * race the stable check now closes. PR #438 cut that race to
-     * pieces but still left a 41-byte anti-aliasing wobble on
-     * `uv_index_card_with_model_spread.png` flipping each run; this
-     * helper's noise-tolerant baseline restore handles that.
      */
     private fun captureUntilStable(maxAttempts: Int = 10, snapshot: () -> Unit) {
         val outputFile = File("$outputDir/${testName.methodName}.png")
@@ -237,57 +224,28 @@ class PreviewSnapshots {
         // restore at the end. Null when this is a new preview with no
         // existing PNG; in that case any capture is the new baseline.
         val baseline = if (outputFile.exists()) outputFile.readBytes() else null
-        // The clock is pinned (see pinClock), so nothing has advanced since
-        // setContent. Step it one generous slice so that, once a chart's model
-        // has landed, Vico's data-diff animation (default tween(500ms)) runs to
-        // completion before we rasterize. SETTLE_MILLIS stays well under the
-        // 60s live-"now" minute tick so those LaunchedEffects don't re-loop
-        // mid-capture and perturb the indicator.
         composeRule.waitForIdle()
         composeRule.mainClock.advanceTimeBy(SETTLE_MILLIS)
         var prior: ByteArray? = null
-        repeat(maxAttempts) { attempt ->
+        repeat(maxAttempts) {
             composeRule.waitForIdle()
-            // One more frame so the latest collected/animated state paints
-            // before we rasterize. Vico keeps requesting frames forever, but
-            // the *pixels* are static once the data has settled, so consecutive
-            // captures match and the stability check converges.
+            // Drive one frame so the latest composition paints before we
+            // rasterise. Vico keeps requesting frames forever, but the pixels
+            // are static once composition has settled, so consecutive captures
+            // match and the stability check converges.
             composeRule.mainClock.advanceTimeByFrame()
             snapshot()
-            // looksEmpty (-> null): a *completely* blank capture must never
-            // reach "stable" by failing the same way twice. undersized: a
-            // capture far smaller than a content-bearing baseline is almost
-            // always card chrome with the Vico plot still unpainted (see the
-            // runTransaction note below) — also barred from converging until
-            // the attempt budget is spent.
             val current = if (looksEmpty(outputFile)) null else outputFile.readBytes()
-            val undersized = undersizedVsBaseline(current, baseline)
-            if (current != null && prior != null && prior.contentEquals(current) && !undersized) {
+            if (current != null && prior != null && prior.contentEquals(current)) {
                 restoreBaselineIfOnlyNoise(outputFile, current, baseline)
                 return
             }
             prior = current
-            // Vico processes the CartesianChartModelProducer transaction on a
-            // background dispatcher (Dispatchers.Default). The pinned Compose
-            // clock and waitForIdle() don't wait on it, so under parallel test
-            // load (CI runs :core:*:test alongside :app's snapshot tests) the
-            // model can land *after* we'd otherwise capture, leaving the plot
-            // blank. Yield real wall-clock time so Default drains before the
-            // next capture — but only while the picture isn't a settled,
-            // full-size render yet. A stable chart-less preview with an existing
-            // baseline returns above on its second capture without ever
-            // sleeping, so the common case stays free.
-            if (current == null || baseline == null || undersized) {
-                Thread.sleep(REAL_SETTLE_MILLIS)
-            }
         }
-        // Never converged on a settled, full-size capture within the budget.
-        // When we have a content-bearing baseline, keep it rather than commit a
-        // chart that failed to paint under load — a blank plot regressing a
-        // good snapshot is the one outcome worse than a stale one, and it would
-        // sail through CI (record-only, no diff gate). A genuine change repaints
-        // on a less-loaded run. New previews (no baseline) keep the last capture
-        // for the author to review.
+        // Never converged on a settled capture within the budget. When we have
+        // a content-bearing baseline, keep it rather than commit something
+        // unstable — a genuine change repaints on a less-loaded run. New
+        // previews (no baseline) keep the last capture for the author to review.
         if (baseline != null) {
             outputFile.writeBytes(baseline)
             System.err.println(
@@ -300,21 +258,6 @@ class PreviewSnapshots {
                     "$maxAttempts attempts",
             )
         }
-    }
-
-    /**
-     * True when [current] is far enough below a content-bearing [baseline]'s
-     * encoded size to look like a chart card whose Vico plot hasn't painted
-     * yet — the "chrome only" render comes out roughly a third the size of the
-     * full chart. Used purely as a "keep settling" hint, never a hard failure:
-     * on the final attempt the under-size capture is still accepted, so a
-     * legitimately slimmer redraw eventually commits rather than hanging.
-     * Always false when either side is null (a new preview with no baseline, or
-     * a fully blank capture already handled by [looksEmpty]).
-     */
-    private fun undersizedVsBaseline(current: ByteArray?, baseline: ByteArray?): Boolean {
-        if (current == null || baseline == null) return false
-        return current.size < baseline.size * MIN_SETTLED_SIZE_RATIO
     }
 
     /**
@@ -384,20 +327,15 @@ class PreviewSnapshots {
         return maxOf(rDiff, gDiff, bDiff)
     }
 
-    // Virtual time to advance the pinned clock once before capturing, to
-    // settle the chart deck. Two components have to finish; only one is
-    // time-gated. The producer-flow drain (LaunchedEffect → runTransaction →
-    // host collect → recompose → paint) isn't — it propagates in a frame or
-    // two, and 1s is ~62 frames. The data-diff animation is: Vico's default
-    // spec is tween(durationMillis = 500) (animateIn is off, so no entry
-    // animation on top), so 1s is a 2x margin over the only thing the clock
-    // has to outrun. It also stays far under the 60s live-"now" minute tick,
-    // so the tick's delay() never fires mid-capture. Costs ~near-zero
-    // wall-clock under Robolectric — the clock is virtual — so we spend it on
-    // every preview rather than gating it on "is this one chart-bearing?". If
-    // a future Vico raised that 500ms default past 1s, the clock stays pinned
-    // (no re-hang) and the under-settle surfaces as visible snapshot churn in
-    // review, not a silently-wrong baseline.
+    // Virtual time to advance the pinned clock once before capturing, to let
+    // any `animateFloatAsState`-driven on-load animations settle to their
+    // final values before we rasterise — e.g. EdgeFadeOverlay's top/bottom
+    // fade alphas, which spring from 0 to their target visibility. 1s sits
+    // comfortably above any tween a preview is realistically running and
+    // well under the 60s live-"now" minute tick so those LaunchedEffects
+    // don't re-loop mid-capture. Costs ~near-zero wall-clock under
+    // Robolectric — the clock is virtual — so we spend it on every preview
+    // rather than gating it case by case.
     //
     // Noise tolerances for the baseline-restore comparison.
     //
@@ -420,16 +358,6 @@ class PreviewSnapshots {
     // sub-tolerance pixels, well under the cap.
     private companion object {
         const val SETTLE_MILLIS = 1_000L
-        // Real wall-clock pause between captures while a chart is still
-        // settling, so Vico's background-dispatcher transaction can drain even
-        // under heavy parallel test load. Only spent on not-yet-settled
-        // previews (see captureUntilStable), so chart-less captures pay nothing.
-        const val REAL_SETTLE_MILLIS = 200L
-        // A capture below this fraction of a content-bearing baseline's size is
-        // treated as "chart not painted yet" and kept out of the stability
-        // check. Blank chart cards encode at ~1/3 the size of the full chart;
-        // 0.6 sits comfortably between the two.
-        const val MIN_SETTLED_SIZE_RATIO = 0.6
         const val INTENSITY_TOLERANCE = 8
         const val NOISY_PIXEL_BUDGET = 64
         const val IN_TOLERANCE_PIXEL_BUDGET = 4096


### PR DESCRIPTION
## Summary

Two follow-ups on the chart-animation removal that just landed.

**1. `internal:` share the chart-host animation defaults via a helper.** The `animateIn = false, animationSpec = null` pair was repeated at four `CartesianChartHost` call sites — `ForecastChart`, `PerModelDiagnosticCard`, `PrecipitationChart`, `PrecipitationAmountChart` — with a near-identical "see ForecastChart for the rationale" comment on each. Replaced with two constants in a new `ChartAnimations.kt` (`CHART_ANIMATE_IN`, `CHART_ANIMATION_SPEC`). The rationale lives once, on the constants.

**2. `test:` drop the chart-race guards from `PreviewSnapshots`.** With chart producers running synchronously under `LocalInspectionMode` — set in both `Frame` (today previews) and `WidgetFrame` (widget previews, hoisted here) — and `CHART_ANIMATION_SPEC = null` on every host, two guards in `captureUntilStable` had nothing left to catch:

- `undersizedVsBaseline` (+ `MIN_SETTLED_SIZE_RATIO`) — the "chrome rendered, plot missing" race the inspection-mode dispatcher now closes.
- `Thread.sleep(REAL_SETTLE_MILLIS)` between attempts — there's no background-dispatcher transaction left to wait on under parallel test load.

Removing both drops ~100 lines from the harness. The clock pin and upfront `SETTLE_MILLIS` virtual-time slice stay — Vico's host still requests frames forever, and `animateFloatAsState`-driven on-load animations (e.g. `EdgeFadeOverlay`'s top/bottom fade alphas) still need that step to settle before capture. Noise-tolerant baseline restore and the two-stable-captures check also stay; they cover anti-aliasing wobble, which is animation-independent.

`WidgetFrame` now mirrors `Frame` by providing `LocalInspectionMode = true` — the feels-like widget previews reuse `ForecastChart` through `WidgetForecastChart`, so they need the same synchronous Vico producer that the in-app chart previews rely on. Without it, the chrome-vs-plot race could still trip on widget chart snapshots under heavy parallel CI load, even though every recent local run happened to drain first. Spotted by Codex.

## Privacy

No change to what crosses the device boundary — refactor + test harness only.

## Test plan

- [x] `:app:testDebugUnitTest` (locally, sandbox SDK build) — green.
- [x] No snapshot bytes changed (verified by running the full snapshot suite after each chunk, including post-WidgetFrame fix).
- [ ] CI: JVM unit tests + Android debug build green.