### PR TITLE
Match the conditions strip's UV to the forecast chart

### DIFF
--- a/app/src/main/kotlin/app/clothescast/cast/CastTestDispatch.kt
+++ b/app/src/main/kotlin/app/clothescast/cast/CastTestDispatch.kt
@@ -92,6 +92,7 @@ internal suspend fun castCurrentInsight(
         hourly = insight.hourly,
         temperatureUnit = prefs.temperatureUnit,
         windSpeedUnit = prefs.distanceUnit.windSpeedUnit(),
+        perModelHourly = insight.perModelHourly,
     )
     val header = context.getString(
         if (insight.period == ForecastPeriod.TODAY) R.string.outfit_card_header_today

--- a/app/src/main/kotlin/app/clothescast/ui/garment/GarmentRender.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/garment/GarmentRender.kt
@@ -12,6 +12,7 @@ import androidx.core.graphics.PathParser as AndroidPathParser
 import app.clothescast.R
 import app.clothescast.core.domain.model.HourlyForecast
 import app.clothescast.core.domain.model.OutfitSuggestion
+import app.clothescast.core.domain.model.PerModelHourly
 import app.clothescast.core.domain.model.TemperatureBand
 import app.clothescast.core.domain.model.TemperatureUnit
 import app.clothescast.core.domain.model.WindSpeedUnit
@@ -805,8 +806,9 @@ internal data class OutfitCardInfoLines(
     // below the 30 % threshold. Default null for callers that don't compute it.
     val rainLineShort: String? = null,
     // Wind / UV cells. Each label is null unless the period's peak is "notable"
-    // (>= WIND_NOTABLE_KMH / UV_NOTABLE); the raw maximum rides alongside so the
-    // renderer can pick the Beaufort / WHO scale tint.
+    // (wind >= WIND_NOTABLE_KMH; UV once it rounds to >= UV_NOTABLE, matching the
+    // integer the label shows); the raw maximum rides alongside so the renderer
+    // can pick the Beaufort / WHO scale tint.
     val windLabel: String? = null,
     val windMaxKmh: Double? = null,
     val uvLabel: String? = null,
@@ -819,6 +821,7 @@ internal fun outfitCardInfoLines(
     hourly: List<HourlyForecast>,
     temperatureUnit: TemperatureUnit,
     windSpeedUnit: WindSpeedUnit = WindSpeedUnit.KMH,
+    perModelHourly: PerModelHourly? = null,
 ): OutfitCardInfoLines {
     val lowC = hourly.minOfOrNull { it.feelsLikeC }
     val highC = hourly.maxOfOrNull { it.feelsLikeC }
@@ -854,8 +857,17 @@ internal fun outfitCardInfoLines(
             windSpeedUnit.symbol(),
         )
     }
-    val uvMax = hourly.mapNotNull { it.uvIndex }.maxOrNull()
-        ?.takeIf { it >= UV_NOTABLE }
+    // Peak UV from the cross-model consensus (per-hour mean across models) when
+    // per-model data is available — the same blend the UV diagnostic chart and
+    // its "Peak N" subtitle draw, so the strip and the chart can't disagree.
+    // Falls back to the primary hourly series for callers / cached payloads that
+    // carry no per-model arrays (previews, pre-multi-model caches). Gate on the
+    // *rounded* peak so the cell appears for exactly the values the label
+    // renders: a 5.5–5.9 peak reads as "UV 6" once rounded, so testing the raw
+    // value against UV_NOTABLE (6.0) would hide a UV the user is told is 6.
+    val uvPeak = perModelHourly?.let { consensusUvPeak(it) }
+        ?: hourly.mapNotNull { it.uvIndex }.maxOrNull()
+    val uvMax = uvPeak?.takeIf { it.roundToInt() >= UV_NOTABLE }
     val uvLabel = uvMax?.let { context.getString(R.string.conditions_uv, it.roundToInt()) }
     return OutfitCardInfoLines(
         tempLine = tempLine,
@@ -1083,6 +1095,24 @@ internal const val WIND_NOTABLE_KMH = 30.0
 internal const val UV_NOTABLE = 6.0
 
 /**
+ * Peak UV across the cross-model consensus: the per-hour mean of [uvIndex]
+ * across whichever models reported at that hour, then the maximum of those
+ * means. Mirrors the main line the UV diagnostic chart draws (and its "Peak N"
+ * subtitle), so the conditions strip surfaces the same UV the user sees plotted
+ * rather than a lone primary-series spike the consensus smooths away. Null when
+ * no model reports UV at any hour.
+ */
+internal fun consensusUvPeak(perModelHourly: PerModelHourly): Double? {
+    val byIndex = mutableMapOf<Int, MutableList<Double>>()
+    perModelHourly.byModel.values.forEach { entries ->
+        entries.forEachIndexed { i, entry ->
+            entry.uvIndex?.let { byIndex.getOrPut(i) { mutableListOf() } += it }
+        }
+    }
+    return byIndex.values.maxOfOrNull { it.average() }
+}
+
+/**
  * Beaufort-flavoured colour for a wind speed in km/h: amber (fresh breeze) →
  * orange (strong) → red (gale) → violet (storm). Since the cell only shows ≥
  * [WIND_NOTABLE_KMH] the user always sees amber-or-worse, escalating with
@@ -1097,8 +1127,9 @@ internal fun windScaleColorArgb(kmh: Double): Int = when {
 
 /**
  * WHO UV-index colour scale: green (low) → yellow → orange → red → violet
- * (extreme). The cell only shows ≥ [UV_NOTABLE], so in practice the user sees
- * orange-or-worse.
+ * (extreme). The cell only shows once the peak rounds to ≥ [UV_NOTABLE], so the
+ * user sees high-yellow-or-worse (a 5.5–5.9 peak reads "UV 6" but still tints
+ * yellow until the raw value crosses 6.0).
  */
 internal fun uvScaleColorArgb(index: Double): Int = when {
     index < 3.0 -> 0xFF558B2F.toInt() // green — low

--- a/app/src/main/kotlin/app/clothescast/ui/nav/ClothesCastNavHost.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/nav/ClothesCastNavHost.kt
@@ -432,6 +432,7 @@ private fun settingsViewModelFactory(app: ClothesCastApplication, context: Conte
                         hourly = insight.hourly,
                         temperatureUnit = prefs.temperatureUnit,
                         windSpeedUnit = prefs.distanceUnit.windSpeedUnit(),
+                        perModelHourly = insight.perModelHourly,
                     )
                     val header = context.getString(
                         if (insight.period == ForecastPeriod.TODAY) R.string.outfit_card_header_today

--- a/app/src/main/kotlin/app/clothescast/ui/today/SevenDayPage.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/SevenDayPage.kt
@@ -241,6 +241,14 @@ internal fun SevenDayPage(
         // week's feels-like range and its peak rain / wind / UV rather than
         // repeating today's figures.
         conditionsHourly = flatHourly,
+        // Week-wide per-model arrays so the strip's UV reads the same consensus
+        // the UV chart on this page draws — not a lone primary-series spike on
+        // some day the consensus rates lower. Use the coverage-gated value (null
+        // on a legacy cache whose per-model series only spans the first couple
+        // of days): an ungated short series would make the strip's consensus
+        // summarize just that side-band and miss the week's real peak. Null
+        // falls back to the full-week primary [flatHourly] in outfitCardInfoLines.
+        conditionsPerModelHourly = weekPerModelDiagnostics,
         // The week-headline card is this page's "insight" section, so it
         // reorders against the outfit row exactly like the per-period insight
         // card does on pages 0 / 1 — keeping the outfit row at a consistent

--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
@@ -912,6 +912,11 @@ internal fun HomePageScaffold(
     homeSectionOrder: List<HomeSection> = HomeSection.DEFAULTS,
     insightSlot: (@Composable ColumnScope.() -> Unit)? = null,
     conditionsHourly: List<HourlyForecast>? = null,
+    // Per-model arrays matching [conditionsHourly]'s window, so the strip's UV
+    // reads the same cross-model consensus the UV chart draws (not a lone
+    // primary-series spike). Null on cached payloads without per-model data —
+    // [outfitCardInfoLines] then falls back to the primary hourly series.
+    conditionsPerModelHourly: PerModelHourly? = null,
     confidenceSlot: (@Composable ColumnScope.() -> Unit)? = null,
     chartsSlot: (@Composable ColumnScope.() -> Unit)? = null,
     content: @Composable ColumnScope.() -> Unit,
@@ -929,6 +934,7 @@ internal fun HomePageScaffold(
     val tvScrollStepPx = with(LocalDensity.current) { 240.dp.toPx() }
     val conditionsInfo: OutfitCardInfoLines? = remember(
         conditionsHourly,
+        conditionsPerModelHourly,
         state.region,
         state.temperatureUnit,
         state.distanceUnit,
@@ -942,6 +948,7 @@ internal fun HomePageScaffold(
                     hourly = hourly,
                     temperatureUnit = state.temperatureUnit,
                     windSpeedUnit = state.distanceUnit.windSpeedUnit(),
+                    perModelHourly = conditionsPerModelHourly,
                 )
             }.onFailure { t ->
                 // Explicit fallback: a formatter/resource failure hides the
@@ -1223,6 +1230,9 @@ private fun TodayPage(
         // page's insight (this period on page 0, the next period on page 1), so
         // each page's strip shows its own feels-like range / rain / wind / UV.
         conditionsHourly = insight?.hourly,
+        // Per-model arrays for this period so the strip's UV matches the chart's
+        // consensus blend rather than a primary-series spike.
+        conditionsPerModelHourly = insight?.perModelHourly,
         // The insight card — its own reorderable section. The confidence chip
         // that used to ride along with it is now [confidenceSlot]; the chart
         // deck is [chartsSlot]. Renders only when this period has an insight;

--- a/app/src/main/kotlin/app/clothescast/widget/ConditionsWidget.kt
+++ b/app/src/main/kotlin/app/clothescast/widget/ConditionsWidget.kt
@@ -85,6 +85,7 @@ class ConditionsWidget : GlanceAppWidget() {
                     hourly = insight.hourly,
                     temperatureUnit = prefs.temperatureUnit,
                     windSpeedUnit = prefs.distanceUnit.windSpeedUnit(),
+                    perModelHourly = insight.perModelHourly,
                 )
             }.getOrNull()
         } else {

--- a/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
@@ -1166,6 +1166,7 @@ class FetchAndNotifyWorker(
                 hourly = insight.hourly,
                 temperatureUnit = prefs.temperatureUnit,
                 windSpeedUnit = prefs.distanceUnit.windSpeedUnit(),
+                perModelHourly = insight.perModelHourly,
             )
             val header = applicationContext.getString(
                 if (insight.period == ForecastPeriod.TODAY) R.string.outfit_card_header_today

--- a/app/src/test/kotlin/app/clothescast/ui/garment/OutfitCardInfoLinesTest.kt
+++ b/app/src/test/kotlin/app/clothescast/ui/garment/OutfitCardInfoLinesTest.kt
@@ -1,0 +1,124 @@
+package app.clothescast.ui.garment
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import app.clothescast.core.domain.model.HourlyForecast
+import app.clothescast.core.domain.model.PerModelHour
+import app.clothescast.core.domain.model.PerModelHourly
+import app.clothescast.core.domain.model.TemperatureUnit
+import app.clothescast.core.domain.model.WeatherCondition
+import app.clothescast.insight.InsightFormatter
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+
+/**
+ * Unit coverage for the UV gating in [outfitCardInfoLines] — the logic that
+ * decides whether the conditions strip surfaces a UV cell. Pins two things: the
+ * rounding boundary where the gate and the label have to agree, and that the
+ * strip reads the cross-model consensus (matching the UV chart) rather than a
+ * lone primary-series spike when per-model data is present.
+ */
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [33])
+class OutfitCardInfoLinesTest {
+
+    private val ctx: Context = ApplicationProvider.getApplicationContext()
+    private val formatter = InsightFormatter(ctx.resources)
+
+    private fun hourWithUv(uv: Double?) = HourlyForecast(
+        time = LocalTime.NOON,
+        temperatureC = 18.0,
+        feelsLikeC = 18.0,
+        precipitationProbabilityPct = 0.0,
+        condition = WeatherCondition.CLEAR,
+        uvIndex = uv,
+    )
+
+    private fun perModelHour(uv: Double?) = PerModelHour(
+        time = LocalDateTime.of(LocalDate.now(), LocalTime.NOON),
+        apparentTemperatureC = 18.0,
+        temperatureC = 18.0,
+        precipitationProbabilityPct = null,
+        uvIndex = uv,
+    )
+
+    /** Per-model arrays whose per-hour mean (one hour) is [modelUvs].average(). */
+    private fun perModelHourly(vararg modelUvs: Double): PerModelHourly =
+        PerModelHourly(
+            byModel = modelUvs.mapIndexed { i, uv ->
+                "model$i" to listOf(perModelHour(uv))
+            }.toMap(),
+        )
+
+    private fun uvLabelFor(
+        peakUv: Double?,
+        perModelHourly: PerModelHourly? = null,
+    ): String? =
+        outfitCardInfoLines(
+            ctx,
+            formatter,
+            listOf(hourWithUv(peakUv)),
+            TemperatureUnit.CELSIUS,
+            perModelHourly = perModelHourly,
+        ).uvLabel
+
+    // --- Primary-series fallback (no per-model data) ---
+
+    @Test
+    fun `uv that rounds up to the notable threshold surfaces as UV 6`() {
+        // Regression: a 5.5–5.9 peak rounds to "UV 6" but was hidden because the
+        // raw value sat below UV_NOTABLE (6.0). The cell must appear here.
+        assertEquals("UV 6", uvLabelFor(5.7))
+        assertEquals("UV 6", uvLabelFor(5.5))
+    }
+
+    @Test
+    fun `uv that rounds below the threshold stays hidden`() {
+        assertNull(uvLabelFor(5.49))
+        assertNull(uvLabelFor(4.0))
+    }
+
+    @Test
+    fun `uv at and above the threshold surfaces`() {
+        assertEquals("UV 6", uvLabelFor(6.0))
+        assertEquals("UV 9", uvLabelFor(9.0))
+    }
+
+    @Test
+    fun `missing uv data surfaces no cell`() {
+        assertNull(uvLabelFor(null))
+    }
+
+    // --- Consensus path (per-model data present) ---
+
+    @Test
+    fun `consensus peak overrides a lone primary-series spike`() {
+        // The primary series spikes to 8 (would read "UV 8"), but the cross-model
+        // consensus means out to 5 — below the notable threshold. The strip must
+        // follow the consensus (the same blend the UV chart draws) and show
+        // nothing, not the spike.
+        assertNull(uvLabelFor(8.0, perModelHourly(5.0, 5.0)))
+    }
+
+    @Test
+    fun `consensus peak surfaces when it clears the threshold`() {
+        // Two models averaging 6.0 → "UV 6", even though the primary series here
+        // carries no UV at all.
+        assertEquals("UV 6", uvLabelFor(null, perModelHourly(5.5, 6.5)))
+    }
+
+    @Test
+    fun `falls back to primary series when per-model carries no uv`() {
+        // Per-model arrays present but none report UV → consensus is null, so the
+        // strip falls back to the primary hourly peak.
+        assertEquals("UV 7", uvLabelFor(7.0, perModelHourly()))
+        assertEquals("UV 7", uvLabelFor(7.0, PerModelHourly(byModel = mapOf("m" to listOf(perModelHour(null))))))
+    }
+}


### PR DESCRIPTION
## What

A bug report flagged "today is missing UV 6 on the conditions strip." Tracing it down showed the strip and the UV charts read **two different UV series**:

- **Conditions strip** computed its UV peak from the **primary** forecast series — a raw `max()` over the hourly stream (`flatHourly` / `insight.hourly`).
- **Every UV chart** — its line, the scrub readout, and the "Peak N at HH:00" subtitle — draws the **cross-model consensus**: the per-hour *mean* across models (`perModelConsensusSeries` / `mainLine`).

Those disagree when the primary series has a lone one-hour spike that the consensus smooths away. In the reported case the 7-day page showed a "UV 6" strip sitting directly above a UV chart that topped out at 5 (today), 4 (tomorrow), lower after — because some non-today hour in the *primary* series hit ≥6 while the consensus rated it ≤4. The today-page strip, scoped to today only, correctly showed nothing (today's peak is ~5).

So the "6" was a primary-series artifact, not a reading any chart corroborated.

## Fix

Point the strip at the same consensus blend the charts use.

- `outfitCardInfoLines` takes an optional `perModelHourly` and derives the UV peak via a new `consensusUvPeak` (per-hour mean across models, then the max), **falling back** to the primary hourly series when no per-model arrays are present (pre-multi-model caches, previews).
- Every call site threads the matching per-model window: today/tonight strips + widget + notification/MQTT/cast card use the period arrays (`insight.perModelHourly`); the 7-day strip uses the week-wide arrays (`weekPerModelHourly`).
- Gate on the **rounded** peak (`roundToInt() >= UV_NOTABLE`) instead of the raw value, so the cell appears for exactly the integer the label renders — matching the chart's rounded "Peak N" subtitle — rather than being hidden just under 6.0.

Net effect: the strip and the UV chart can't disagree. In the reported case the week consensus peaks at 5 (< the notable 6 threshold), so no UV cell shows anywhere — consistent with the chart.

This is display-gating only; no new data leaves the device.

## Test plan

`OutfitCardInfoLinesTest` covers:
- Rounding boundary on the fallback path: 5.49 hidden; 5.5/5.7 → "UV 6"; 6.0/9.0 surface; null hidden.
- Consensus path: a primary spike (8.0) is suppressed when the consensus stays at 5; consensus surfaces "UV 6" when it averages to 6; falls back to the primary series when per-model data carries no UV.

Ran locally with full Android-SDK parity:
- `./gradlew :core:domain:test :core:data:test :app:testDebugUnitTest :app:assembleDebug` — BUILD SUCCESSFUL.

## Notes

The same primary-vs-consensus split exists for the **wind** cell (it still reads the primary series). Left out of scope here since the report is UV-specific and wind also carries a unit-conversion wrinkle — worth a follow-up if you want the strip's wind to track the consensus too.

https://claude.ai/code/session_01BrCo8fAgER6KXvx3tiD9Nt