### PR TITLE
Smoother swiping between forecast pages

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
@@ -563,6 +563,14 @@ private fun TodayContent(
             val nextPeriodFallback = state.thisPeriodInsight.period.opposite()
             HorizontalPager(
                 state = pagerState,
+                // Pre-compose the neighbouring pages so the swipe is pure
+                // translation of already-laid-out content. The 7-day page
+                // (page 2) carries six Vico chart cards plus the per-model
+                // diagnostic deck; composing all that on the frame the user's
+                // finger starts moving is the bulk of the perceived jank.
+                // 1 covers 0↔1 and 1↔2 — the common swipe paths — without
+                // paying for page 2's composition on a cold open to page 0.
+                beyondViewportPageCount = 1,
                 modifier = Modifier
                     .weight(1f)
                     .fillMaxWidth(),


### PR DESCRIPTION
## Summary

Step (1) of two changes to make the Today pager feel less heavy and janky.

The `HorizontalPager` left `beyondViewportPageCount` at the default 0, so the destination page only started composing the moment the user's finger started moving. Page 2 (the 7-day page) carries six Vico chart cards plus the per-model diagnostic deck, so composing all that on the first frame of the gesture is the bulk of the weight on the 1↔2 swipe.

Setting `beyondViewportPageCount = 1` pre-composes the immediate neighbours so swipes become pure translation of already-laid-out content. 1 covers the common 0↔1 and 1↔2 paths without paying page 2's composition cost on a cold open straight to page 0.

The second tuning lever — `flingBehavior` (snap threshold + spring stiffness, the "heavy" feel as opposed to the "janky" feel) — is deliberately not in this PR; landing it separately so each can be felt and reverted independently.

## Privacy

No change to what crosses the device boundary.

## Test plan

- [x] `:app:testDebugUnitTest` + `:app:assembleDebug` (locally, sandbox SDK build) — green.
- [x] No snapshot bytes changed.
- [ ] On-device feel check of the 1↔2 swipe.
- [ ] CI: JVM unit tests + Android debug build green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DdCG9JNg4phAPZxshMCNKL)_