### PR TITLE
Match the conditions strip's wind to the forecast chart

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/garment/GarmentRender.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/garment/GarmentRender.kt
@@ -12,6 +12,7 @@ import androidx.core.graphics.PathParser as AndroidPathParser
 import app.clothescast.R
 import app.clothescast.core.domain.model.HourlyForecast
 import app.clothescast.core.domain.model.OutfitSuggestion
+import app.clothescast.core.domain.model.PerModelHour
 import app.clothescast.core.domain.model.PerModelHourly
 import app.clothescast.core.domain.model.TemperatureBand
 import app.clothescast.core.domain.model.TemperatureUnit
@@ -847,8 +848,18 @@ internal fun outfitCardInfoLines(
         rainLineShort = null
         rainFillFraction = null
     }
-    // Wind / UV: take the period's peak and only surface it when notable.
-    val windMaxKmh = hourly.mapNotNull { it.windSpeedKmh }.maxOrNull()
+    // Wind / UV: take the period's peak and only surface it when notable. Both
+    // prefer the cross-model consensus (per-hour mean across models) when
+    // per-model data is available — the same blend the wind / UV diagnostic
+    // charts and their "Peak N" subtitles draw, so the strip and the charts
+    // can't disagree — and fall back to the primary hourly series for callers /
+    // cached payloads that carry no per-model arrays (previews, pre-multi-model
+    // caches). The consensus is computed in km/h and gated against the km/h
+    // threshold; the km/h→unit conversion is linear, so this matches the wind
+    // chart's consensus (which converts before averaging) before the label
+    // converts for display.
+    val windMaxKmh = (perModelHourly?.let { consensusPeak(it) { h -> h.windSpeedKmh } }
+        ?: hourly.mapNotNull { it.windSpeedKmh }.maxOrNull())
         ?.takeIf { it >= WIND_NOTABLE_KMH }
     val windLabel = windMaxKmh?.let {
         context.getString(
@@ -857,15 +868,10 @@ internal fun outfitCardInfoLines(
             windSpeedUnit.symbol(),
         )
     }
-    // Peak UV from the cross-model consensus (per-hour mean across models) when
-    // per-model data is available — the same blend the UV diagnostic chart and
-    // its "Peak N" subtitle draw, so the strip and the chart can't disagree.
-    // Falls back to the primary hourly series for callers / cached payloads that
-    // carry no per-model arrays (previews, pre-multi-model caches). Gate on the
-    // *rounded* peak so the cell appears for exactly the values the label
-    // renders: a 5.5–5.9 peak reads as "UV 6" once rounded, so testing the raw
-    // value against UV_NOTABLE (6.0) would hide a UV the user is told is 6.
-    val uvPeak = perModelHourly?.let { consensusUvPeak(it) }
+    // UV gates on the *rounded* peak so the cell appears for exactly the values
+    // the label renders: a 5.5–5.9 peak reads as "UV 6" once rounded, so testing
+    // the raw value against UV_NOTABLE (6.0) would hide a UV the user is told is 6.
+    val uvPeak = perModelHourly?.let { consensusPeak(it) { h -> h.uvIndex } }
         ?: hourly.mapNotNull { it.uvIndex }.maxOrNull()
     val uvMax = uvPeak?.takeIf { it.roundToInt() >= UV_NOTABLE }
     val uvLabel = uvMax?.let { context.getString(R.string.conditions_uv, it.roundToInt()) }
@@ -1095,18 +1101,21 @@ internal const val WIND_NOTABLE_KMH = 30.0
 internal const val UV_NOTABLE = 6.0
 
 /**
- * Peak UV across the cross-model consensus: the per-hour mean of [uvIndex]
- * across whichever models reported at that hour, then the maximum of those
- * means. Mirrors the main line the UV diagnostic chart draws (and its "Peak N"
- * subtitle), so the conditions strip surfaces the same UV the user sees plotted
- * rather than a lone primary-series spike the consensus smooths away. Null when
- * no model reports UV at any hour.
+ * Peak of a metric across the cross-model consensus: the per-hour mean of
+ * [picker] across whichever models reported at that hour, then the maximum of
+ * those means. Mirrors the main line the diagnostic charts draw (and their
+ * "Peak N" subtitles), so the conditions strip surfaces the same UV / wind the
+ * user sees plotted rather than a lone primary-series spike the consensus
+ * smooths away. Null when no model reports the metric at any hour.
  */
-internal fun consensusUvPeak(perModelHourly: PerModelHourly): Double? {
+internal fun consensusPeak(
+    perModelHourly: PerModelHourly,
+    picker: (PerModelHour) -> Double?,
+): Double? {
     val byIndex = mutableMapOf<Int, MutableList<Double>>()
     perModelHourly.byModel.values.forEach { entries ->
         entries.forEachIndexed { i, entry ->
-            entry.uvIndex?.let { byIndex.getOrPut(i) { mutableListOf() } += it }
+            picker(entry)?.let { byIndex.getOrPut(i) { mutableListOf() } += it }
         }
     }
     return byIndex.values.maxOfOrNull { it.average() }

--- a/app/src/test/kotlin/app/clothescast/ui/garment/OutfitCardInfoLinesTest.kt
+++ b/app/src/test/kotlin/app/clothescast/ui/garment/OutfitCardInfoLinesTest.kt
@@ -32,42 +32,52 @@ class OutfitCardInfoLinesTest {
     private val ctx: Context = ApplicationProvider.getApplicationContext()
     private val formatter = InsightFormatter(ctx.resources)
 
-    private fun hourWithUv(uv: Double?) = HourlyForecast(
+    private fun hour(uv: Double? = null, wind: Double? = null) = HourlyForecast(
         time = LocalTime.NOON,
         temperatureC = 18.0,
         feelsLikeC = 18.0,
         precipitationProbabilityPct = 0.0,
         condition = WeatherCondition.CLEAR,
+        windSpeedKmh = wind,
         uvIndex = uv,
     )
 
-    private fun perModelHour(uv: Double?) = PerModelHour(
+    private fun perModelHour(uv: Double? = null, wind: Double? = null) = PerModelHour(
         time = LocalDateTime.of(LocalDate.now(), LocalTime.NOON),
         apparentTemperatureC = 18.0,
         temperatureC = 18.0,
         precipitationProbabilityPct = null,
+        windSpeedKmh = wind,
         uvIndex = uv,
     )
 
     /** Per-model arrays whose per-hour mean (one hour) is [modelUvs].average(). */
-    private fun perModelHourly(vararg modelUvs: Double): PerModelHourly =
+    private fun perModelUv(vararg modelUvs: Double): PerModelHourly =
         PerModelHourly(
-            byModel = modelUvs.mapIndexed { i, uv ->
-                "model$i" to listOf(perModelHour(uv))
-            }.toMap(),
+            byModel = modelUvs.mapIndexed { i, uv -> "model$i" to listOf(perModelHour(uv = uv)) }.toMap(),
         )
 
-    private fun uvLabelFor(
-        peakUv: Double?,
+    private fun perModelWind(vararg modelWinds: Double): PerModelHourly =
+        PerModelHourly(
+            byModel = modelWinds.mapIndexed { i, w -> "model$i" to listOf(perModelHour(wind = w)) }.toMap(),
+        )
+
+    private fun infoFor(
+        hourly: List<HourlyForecast>,
         perModelHourly: PerModelHourly? = null,
-    ): String? =
-        outfitCardInfoLines(
-            ctx,
-            formatter,
-            listOf(hourWithUv(peakUv)),
-            TemperatureUnit.CELSIUS,
-            perModelHourly = perModelHourly,
-        ).uvLabel
+    ) = outfitCardInfoLines(
+        ctx,
+        formatter,
+        hourly,
+        TemperatureUnit.CELSIUS,
+        perModelHourly = perModelHourly,
+    )
+
+    private fun uvLabelFor(peakUv: Double?, perModelHourly: PerModelHourly? = null): String? =
+        infoFor(listOf(hour(uv = peakUv)), perModelHourly).uvLabel
+
+    private fun windLabelFor(peakWind: Double?, perModelHourly: PerModelHourly? = null): String? =
+        infoFor(listOf(hour(wind = peakWind)), perModelHourly).windLabel
 
     // --- Primary-series fallback (no per-model data) ---
 
@@ -104,21 +114,49 @@ class OutfitCardInfoLinesTest {
         // consensus means out to 5 — below the notable threshold. The strip must
         // follow the consensus (the same blend the UV chart draws) and show
         // nothing, not the spike.
-        assertNull(uvLabelFor(8.0, perModelHourly(5.0, 5.0)))
+        assertNull(uvLabelFor(8.0, perModelUv(5.0, 5.0)))
     }
 
     @Test
     fun `consensus peak surfaces when it clears the threshold`() {
         // Two models averaging 6.0 → "UV 6", even though the primary series here
         // carries no UV at all.
-        assertEquals("UV 6", uvLabelFor(null, perModelHourly(5.5, 6.5)))
+        assertEquals("UV 6", uvLabelFor(null, perModelUv(5.5, 6.5)))
     }
 
     @Test
     fun `falls back to primary series when per-model carries no uv`() {
         // Per-model arrays present but none report UV → consensus is null, so the
         // strip falls back to the primary hourly peak.
-        assertEquals("UV 7", uvLabelFor(7.0, perModelHourly()))
-        assertEquals("UV 7", uvLabelFor(7.0, PerModelHourly(byModel = mapOf("m" to listOf(perModelHour(null))))))
+        assertEquals("UV 7", uvLabelFor(7.0, perModelUv()))
+        assertEquals("UV 7", uvLabelFor(7.0, PerModelHourly(byModel = mapOf("m" to listOf(perModelHour(uv = null))))))
+    }
+
+    // --- Wind: same primary-vs-consensus behavior as UV (notable >= 30 km/h) ---
+
+    @Test
+    fun `wind surfaces from the primary series above the notable threshold`() {
+        assertEquals("35 km/h", windLabelFor(35.0))
+        assertNull(windLabelFor(29.0))
+        assertNull(windLabelFor(null))
+    }
+
+    @Test
+    fun `consensus wind overrides a lone primary-series gust`() {
+        // Primary gusts to 60 km/h (would read "60 km/h"), but the consensus
+        // means out to 20 — below 30. The strip follows the consensus, like the
+        // wind chart, and shows nothing.
+        assertNull(windLabelFor(60.0, perModelWind(20.0, 20.0)))
+    }
+
+    @Test
+    fun `consensus wind surfaces when it clears the threshold`() {
+        // Models averaging 35 km/h → "35 km/h", even with no primary wind here.
+        assertEquals("35 km/h", windLabelFor(null, perModelWind(30.0, 40.0)))
+    }
+
+    @Test
+    fun `falls back to primary wind when per-model carries no wind`() {
+        assertEquals("35 km/h", windLabelFor(35.0, perModelWind()))
     }
 }


### PR DESCRIPTION
## What

Follow-up to #941 (which fixed the same issue for UV). The conditions strip's **wind** cell still read the **primary** forecast series — a raw `max()` over the hourly stream — while the wind diagnostic chart (its line, scrub readout, and "Peak N" subtitle) draws the **cross-model consensus** (per-hour mean across models). So a lone primary-series gust could read e.g. "60 km/h" on the strip for a window the consensus, and the chart, never show above the notable threshold.

## Fix

- Generalize the consensus helper to take a picker: `consensusUvPeak` → `consensusPeak(perModelHourly) { picker }`.
- The wind path now prefers the consensus when per-model data is available, falling back to the primary hourly series otherwise (older caches, previews).
- The consensus is computed in km/h and gated against `WIND_NOTABLE_KMH`. The km/h→unit conversion is linear, so this matches the wind chart's consensus (which converts before averaging) before the label converts for display.

No data-source threading changes needed — the `perModelHourly` argument added in #941 already flows to every strip call site (today/tonight, 7-day with the coverage-gated week arrays, widget, notification/MQTT/cast), so wind picks it up automatically.

Display-gating only; no new data leaves the device.

## Test plan

`OutfitCardInfoLinesTest` gains wind cases mirroring the UV ones:
- Primary series above/below the 30 km/h threshold (and null) behaves as before.
- A primary gust (60 km/h) is suppressed when the consensus stays at 20.
- Consensus surfaces "35 km/h" when it clears the threshold.
- Falls back to the primary series when per-model data carries no wind.

Ran locally with full Android-SDK parity:
- `./gradlew :core:domain:test :core:data:test :app:testDebugUnitTest :app:assembleDebug` — BUILD SUCCESSFUL (11 tests in `OutfitCardInfoLinesTest`, all green).

https://claude.ai/code/session_01BrCo8fAgER6KXvx3tiD9Nt

---
_Generated by [Claude Code](https://claude.ai/code/session_01BrCo8fAgER6KXvx3tiD9Nt)_