### PR TITLE
Use the model consensus across the whole 7-day forecast

### DIFF
--- a/app/src/main/kotlin/app/clothescast/cast/CastTestDispatch.kt
+++ b/app/src/main/kotlin/app/clothescast/cast/CastTestDispatch.kt
@@ -92,7 +92,6 @@ internal suspend fun castCurrentInsight(
         hourly = insight.hourly,
         temperatureUnit = prefs.temperatureUnit,
         windSpeedUnit = prefs.distanceUnit.windSpeedUnit(),
-        perModelHourly = insight.perModelHourly,
     )
     val header = context.getString(
         if (insight.period == ForecastPeriod.TODAY) R.string.outfit_card_header_today

--- a/app/src/main/kotlin/app/clothescast/ui/garment/GarmentRender.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/garment/GarmentRender.kt
@@ -12,8 +12,6 @@ import androidx.core.graphics.PathParser as AndroidPathParser
 import app.clothescast.R
 import app.clothescast.core.domain.model.HourlyForecast
 import app.clothescast.core.domain.model.OutfitSuggestion
-import app.clothescast.core.domain.model.PerModelHour
-import app.clothescast.core.domain.model.PerModelHourly
 import app.clothescast.core.domain.model.TemperatureBand
 import app.clothescast.core.domain.model.TemperatureUnit
 import app.clothescast.core.domain.model.WindSpeedUnit
@@ -822,7 +820,6 @@ internal fun outfitCardInfoLines(
     hourly: List<HourlyForecast>,
     temperatureUnit: TemperatureUnit,
     windSpeedUnit: WindSpeedUnit = WindSpeedUnit.KMH,
-    perModelHourly: PerModelHourly? = null,
 ): OutfitCardInfoLines {
     val lowC = hourly.minOfOrNull { it.feelsLikeC }
     val highC = hourly.maxOfOrNull { it.feelsLikeC }
@@ -848,18 +845,12 @@ internal fun outfitCardInfoLines(
         rainLineShort = null
         rainFillFraction = null
     }
-    // Wind / UV: take the period's peak and only surface it when notable. Both
-    // prefer the cross-model consensus (per-hour mean across models) when
-    // per-model data is available — the same blend the wind / UV diagnostic
-    // charts and their "Peak N" subtitles draw, so the strip and the charts
-    // can't disagree — and fall back to the primary hourly series for callers /
-    // cached payloads that carry no per-model arrays (previews, pre-multi-model
-    // caches). The consensus is computed in km/h and gated against the km/h
-    // threshold; the km/h→unit conversion is linear, so this matches the wind
-    // chart's consensus (which converts before averaging) before the label
-    // converts for display.
-    val windMaxKmh = (perModelHourly?.let { consensusPeak(it) { h -> h.windSpeedKmh } }
-        ?: hourly.mapNotNull { it.windSpeedKmh }.maxOrNull())
+    // Wind / UV: take the period's peak and only surface it when notable. The
+    // hourly series is already the cross-model consensus blend (wind / UV folded
+    // in at fetch time — see blendConsensusHourly), so a plain max over it
+    // matches the wind / UV diagnostic charts' "Combined" line rather than a
+    // lone best_match spike.
+    val windMaxKmh = hourly.mapNotNull { it.windSpeedKmh }.maxOrNull()
         ?.takeIf { it >= WIND_NOTABLE_KMH }
     val windLabel = windMaxKmh?.let {
         context.getString(
@@ -871,9 +862,8 @@ internal fun outfitCardInfoLines(
     // UV gates on the *rounded* peak so the cell appears for exactly the values
     // the label renders: a 5.5–5.9 peak reads as "UV 6" once rounded, so testing
     // the raw value against UV_NOTABLE (6.0) would hide a UV the user is told is 6.
-    val uvPeak = perModelHourly?.let { consensusPeak(it) { h -> h.uvIndex } }
-        ?: hourly.mapNotNull { it.uvIndex }.maxOrNull()
-    val uvMax = uvPeak?.takeIf { it.roundToInt() >= UV_NOTABLE }
+    val uvMax = hourly.mapNotNull { it.uvIndex }.maxOrNull()
+        ?.takeIf { it.roundToInt() >= UV_NOTABLE }
     val uvLabel = uvMax?.let { context.getString(R.string.conditions_uv, it.roundToInt()) }
     return OutfitCardInfoLines(
         tempLine = tempLine,
@@ -1099,27 +1089,6 @@ private const val RAIN_PEAK_THRESHOLD_PCT = 30
 // the strip's principle of surfacing a metric only when it's worth acting on.
 internal const val WIND_NOTABLE_KMH = 30.0
 internal const val UV_NOTABLE = 6.0
-
-/**
- * Peak of a metric across the cross-model consensus: the per-hour mean of
- * [picker] across whichever models reported at that hour, then the maximum of
- * those means. Mirrors the main line the diagnostic charts draw (and their
- * "Peak N" subtitles), so the conditions strip surfaces the same UV / wind the
- * user sees plotted rather than a lone primary-series spike the consensus
- * smooths away. Null when no model reports the metric at any hour.
- */
-internal fun consensusPeak(
-    perModelHourly: PerModelHourly,
-    picker: (PerModelHour) -> Double?,
-): Double? {
-    val byIndex = mutableMapOf<Int, MutableList<Double>>()
-    perModelHourly.byModel.values.forEach { entries ->
-        entries.forEachIndexed { i, entry ->
-            picker(entry)?.let { byIndex.getOrPut(i) { mutableListOf() } += it }
-        }
-    }
-    return byIndex.values.maxOfOrNull { it.average() }
-}
 
 /**
  * Beaufort-flavoured colour for a wind speed in km/h: amber (fresh breeze) →

--- a/app/src/main/kotlin/app/clothescast/ui/nav/ClothesCastNavHost.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/nav/ClothesCastNavHost.kt
@@ -432,7 +432,6 @@ private fun settingsViewModelFactory(app: ClothesCastApplication, context: Conte
                         hourly = insight.hourly,
                         temperatureUnit = prefs.temperatureUnit,
                         windSpeedUnit = prefs.distanceUnit.windSpeedUnit(),
-                        perModelHourly = insight.perModelHourly,
                     )
                     val header = context.getString(
                         if (insight.period == ForecastPeriod.TODAY) R.string.outfit_card_header_today

--- a/app/src/main/kotlin/app/clothescast/ui/today/SevenDayPage.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/SevenDayPage.kt
@@ -241,14 +241,6 @@ internal fun SevenDayPage(
         // week's feels-like range and its peak rain / wind / UV rather than
         // repeating today's figures.
         conditionsHourly = flatHourly,
-        // Week-wide per-model arrays so the strip's UV reads the same consensus
-        // the UV chart on this page draws — not a lone primary-series spike on
-        // some day the consensus rates lower. Use the coverage-gated value (null
-        // on a legacy cache whose per-model series only spans the first couple
-        // of days): an ungated short series would make the strip's consensus
-        // summarize just that side-band and miss the week's real peak. Null
-        // falls back to the full-week primary [flatHourly] in outfitCardInfoLines.
-        conditionsPerModelHourly = weekPerModelDiagnostics,
         // The week-headline card is this page's "insight" section, so it
         // reorders against the outfit row exactly like the per-period insight
         // card does on pages 0 / 1 — keeping the outfit row at a consistent

--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
@@ -920,11 +920,6 @@ internal fun HomePageScaffold(
     homeSectionOrder: List<HomeSection> = HomeSection.DEFAULTS,
     insightSlot: (@Composable ColumnScope.() -> Unit)? = null,
     conditionsHourly: List<HourlyForecast>? = null,
-    // Per-model arrays matching [conditionsHourly]'s window, so the strip's UV
-    // reads the same cross-model consensus the UV chart draws (not a lone
-    // primary-series spike). Null on cached payloads without per-model data —
-    // [outfitCardInfoLines] then falls back to the primary hourly series.
-    conditionsPerModelHourly: PerModelHourly? = null,
     confidenceSlot: (@Composable ColumnScope.() -> Unit)? = null,
     chartsSlot: (@Composable ColumnScope.() -> Unit)? = null,
     content: @Composable ColumnScope.() -> Unit,
@@ -942,7 +937,6 @@ internal fun HomePageScaffold(
     val tvScrollStepPx = with(LocalDensity.current) { 240.dp.toPx() }
     val conditionsInfo: OutfitCardInfoLines? = remember(
         conditionsHourly,
-        conditionsPerModelHourly,
         state.region,
         state.temperatureUnit,
         state.distanceUnit,
@@ -956,7 +950,6 @@ internal fun HomePageScaffold(
                     hourly = hourly,
                     temperatureUnit = state.temperatureUnit,
                     windSpeedUnit = state.distanceUnit.windSpeedUnit(),
-                    perModelHourly = conditionsPerModelHourly,
                 )
             }.onFailure { t ->
                 // Explicit fallback: a formatter/resource failure hides the
@@ -1238,9 +1231,6 @@ private fun TodayPage(
         // page's insight (this period on page 0, the next period on page 1), so
         // each page's strip shows its own feels-like range / rain / wind / UV.
         conditionsHourly = insight?.hourly,
-        // Per-model arrays for this period so the strip's UV matches the chart's
-        // consensus blend rather than a primary-series spike.
-        conditionsPerModelHourly = insight?.perModelHourly,
         // The insight card — its own reorderable section. The confidence chip
         // that used to ride along with it is now [confidenceSlot]; the chart
         // deck is [chartsSlot]. Renders only when this period has an insight;

--- a/app/src/main/kotlin/app/clothescast/widget/ConditionsWidget.kt
+++ b/app/src/main/kotlin/app/clothescast/widget/ConditionsWidget.kt
@@ -85,7 +85,6 @@ class ConditionsWidget : GlanceAppWidget() {
                     hourly = insight.hourly,
                     temperatureUnit = prefs.temperatureUnit,
                     windSpeedUnit = prefs.distanceUnit.windSpeedUnit(),
-                    perModelHourly = insight.perModelHourly,
                 )
             }.getOrNull()
         } else {

--- a/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
@@ -1166,7 +1166,6 @@ class FetchAndNotifyWorker(
                 hourly = insight.hourly,
                 temperatureUnit = prefs.temperatureUnit,
                 windSpeedUnit = prefs.distanceUnit.windSpeedUnit(),
-                perModelHourly = insight.perModelHourly,
             )
             val header = applicationContext.getString(
                 if (insight.period == ForecastPeriod.TODAY) R.string.outfit_card_header_today

--- a/app/src/test/kotlin/app/clothescast/ui/garment/OutfitCardInfoLinesTest.kt
+++ b/app/src/test/kotlin/app/clothescast/ui/garment/OutfitCardInfoLinesTest.kt
@@ -4,8 +4,6 @@ import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import app.clothescast.core.domain.model.HourlyForecast
-import app.clothescast.core.domain.model.PerModelHour
-import app.clothescast.core.domain.model.PerModelHourly
 import app.clothescast.core.domain.model.TemperatureUnit
 import app.clothescast.core.domain.model.WeatherCondition
 import app.clothescast.insight.InsightFormatter
@@ -14,16 +12,14 @@ import org.junit.Assert.assertNull
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
-import java.time.LocalDate
-import java.time.LocalDateTime
 import java.time.LocalTime
 
 /**
- * Unit coverage for the UV gating in [outfitCardInfoLines] — the logic that
- * decides whether the conditions strip surfaces a UV cell. Pins two things: the
- * rounding boundary where the gate and the label have to agree, and that the
- * strip reads the cross-model consensus (matching the UV chart) rather than a
- * lone primary-series spike when per-model data is present.
+ * Unit coverage for the UV / wind gating in [outfitCardInfoLines] — the logic
+ * that decides whether the conditions strip surfaces each cell. The hourly
+ * series fed in is already the cross-model consensus blend (wind / UV folded in
+ * at fetch time — see blendConsensusHourly), so the strip just takes the peak
+ * over it; these tests pin the thresholds and the UV rounding boundary.
  */
 @RunWith(AndroidJUnit4::class)
 @Config(sdk = [33])
@@ -42,44 +38,14 @@ class OutfitCardInfoLinesTest {
         uvIndex = uv,
     )
 
-    private fun perModelHour(uv: Double? = null, wind: Double? = null) = PerModelHour(
-        time = LocalDateTime.of(LocalDate.now(), LocalTime.NOON),
-        apparentTemperatureC = 18.0,
-        temperatureC = 18.0,
-        precipitationProbabilityPct = null,
-        windSpeedKmh = wind,
-        uvIndex = uv,
-    )
+    private fun infoFor(hourly: List<HourlyForecast>) =
+        outfitCardInfoLines(ctx, formatter, hourly, TemperatureUnit.CELSIUS)
 
-    /** Per-model arrays whose per-hour mean (one hour) is [modelUvs].average(). */
-    private fun perModelUv(vararg modelUvs: Double): PerModelHourly =
-        PerModelHourly(
-            byModel = modelUvs.mapIndexed { i, uv -> "model$i" to listOf(perModelHour(uv = uv)) }.toMap(),
-        )
+    private fun uvLabelFor(peakUv: Double?): String? = infoFor(listOf(hour(uv = peakUv))).uvLabel
 
-    private fun perModelWind(vararg modelWinds: Double): PerModelHourly =
-        PerModelHourly(
-            byModel = modelWinds.mapIndexed { i, w -> "model$i" to listOf(perModelHour(wind = w)) }.toMap(),
-        )
+    private fun windLabelFor(peakWind: Double?): String? = infoFor(listOf(hour(wind = peakWind))).windLabel
 
-    private fun infoFor(
-        hourly: List<HourlyForecast>,
-        perModelHourly: PerModelHourly? = null,
-    ) = outfitCardInfoLines(
-        ctx,
-        formatter,
-        hourly,
-        TemperatureUnit.CELSIUS,
-        perModelHourly = perModelHourly,
-    )
-
-    private fun uvLabelFor(peakUv: Double?, perModelHourly: PerModelHourly? = null): String? =
-        infoFor(listOf(hour(uv = peakUv)), perModelHourly).uvLabel
-
-    private fun windLabelFor(peakWind: Double?, perModelHourly: PerModelHourly? = null): String? =
-        infoFor(listOf(hour(wind = peakWind)), perModelHourly).windLabel
-
-    // --- Primary-series fallback (no per-model data) ---
+    // --- UV (notable >= 6, gated on the rounded peak) ---
 
     @Test
     fun `uv that rounds up to the notable threshold surfaces as UV 6`() {
@@ -106,57 +72,16 @@ class OutfitCardInfoLinesTest {
         assertNull(uvLabelFor(null))
     }
 
-    // --- Consensus path (per-model data present) ---
+    // --- Wind (notable >= 30 km/h) ---
 
     @Test
-    fun `consensus peak overrides a lone primary-series spike`() {
-        // The primary series spikes to 8 (would read "UV 8"), but the cross-model
-        // consensus means out to 5 — below the notable threshold. The strip must
-        // follow the consensus (the same blend the UV chart draws) and show
-        // nothing, not the spike.
-        assertNull(uvLabelFor(8.0, perModelUv(5.0, 5.0)))
-    }
-
-    @Test
-    fun `consensus peak surfaces when it clears the threshold`() {
-        // Two models averaging 6.0 → "UV 6", even though the primary series here
-        // carries no UV at all.
-        assertEquals("UV 6", uvLabelFor(null, perModelUv(5.5, 6.5)))
-    }
-
-    @Test
-    fun `falls back to primary series when per-model carries no uv`() {
-        // Per-model arrays present but none report UV → consensus is null, so the
-        // strip falls back to the primary hourly peak.
-        assertEquals("UV 7", uvLabelFor(7.0, perModelUv()))
-        assertEquals("UV 7", uvLabelFor(7.0, PerModelHourly(byModel = mapOf("m" to listOf(perModelHour(uv = null))))))
-    }
-
-    // --- Wind: same primary-vs-consensus behavior as UV (notable >= 30 km/h) ---
-
-    @Test
-    fun `wind surfaces from the primary series above the notable threshold`() {
+    fun `wind surfaces above the notable threshold`() {
         assertEquals("35 km/h", windLabelFor(35.0))
+    }
+
+    @Test
+    fun `wind below the threshold stays hidden`() {
         assertNull(windLabelFor(29.0))
         assertNull(windLabelFor(null))
-    }
-
-    @Test
-    fun `consensus wind overrides a lone primary-series gust`() {
-        // Primary gusts to 60 km/h (would read "60 km/h"), but the consensus
-        // means out to 20 — below 30. The strip follows the consensus, like the
-        // wind chart, and shows nothing.
-        assertNull(windLabelFor(60.0, perModelWind(20.0, 20.0)))
-    }
-
-    @Test
-    fun `consensus wind surfaces when it clears the threshold`() {
-        // Models averaging 35 km/h → "35 km/h", even with no primary wind here.
-        assertEquals("35 km/h", windLabelFor(null, perModelWind(30.0, 40.0)))
-    }
-
-    @Test
-    fun `falls back to primary wind when per-model carries no wind`() {
-        assertEquals("35 km/h", windLabelFor(35.0, perModelWind()))
     }
 }

--- a/core/data/src/main/kotlin/app/clothescast/core/data/weather/OpenMeteoClient.kt
+++ b/core/data/src/main/kotlin/app/clothescast/core/data/weather/OpenMeteoClient.kt
@@ -4,6 +4,7 @@ import app.clothescast.core.data.diag.ApiCallLogger
 import app.clothescast.core.data.diag.ApiEndpoints
 import app.clothescast.core.data.diag.NoOpApiCallLogger
 import app.clothescast.core.data.diag.instrument
+import app.clothescast.core.domain.model.DailyForecast
 import app.clothescast.core.domain.model.HourlyForecast
 import app.clothescast.core.domain.model.Location
 import app.clothescast.core.domain.model.PerModelHour
@@ -112,21 +113,27 @@ class OpenMeteoClient(
         // ordering of these two blocks regressed that by passing the
         // pre-injection map (Codex caught it on PR review).
         //
-        // Include tomorrow's best_match hours too. The multi-model fetcher
-        // pulls today + tomorrow's pre-dawn (forecast_days=2) to feed the
-        // evening tie-in's wrap past midnight, so the consulted models
-        // (ECMWF / GFS / ICON) have tomorrow entries. If best_match's
-        // entries stopped at today's 23:00, [RenderInsightSummary.pickPerModelPeak]'s
-        // `majorityNeeded = models.size / 2 + 1` would compute the bar from
-        // all 4 models but only 3 readings would actually exist for any
-        // tomorrow hour, silently downgrading a clean 2-of-3-models-agree
-        // tomorrow peak to POSSIBLE (Codex caught it). Pulling
-        // [ForecastBundle.tomorrowHourly] through keeps best_match a real
-        // 4th vote on both sides of the midnight boundary.
+        // Include best_match hours for every forward day, not just today. The
+        // consulted models (ECMWF / GFS / ICON) carry the full forecast_days=7
+        // window, so best_match has to span it too or the consensus silently
+        // changes character partway through the week: with best_match present
+        // only for today + tomorrow, days 3–7 would average the consulted
+        // models *without* Open-Meteo's auto-pick, breaking the equal-weight
+        // policy [blendConsensusHourly] documents and making days 1–2 and 3–7
+        // blend differently (Codex caught it). It also keeps best_match a real
+        // vote in [RenderInsightSummary.pickPerModelPeak]'s `majorityNeeded`
+        // bar on both sides of the midnight boundary.
+        //
+        // Sources overlap — `tomorrowHourly` is tomorrow's pre-dawn slice and
+        // `upcomingDays[0]` is tomorrow's full day — so dedupe by timestamp
+        // (first wins) to avoid double-weighting best_match on the overlapping
+        // hours. Today comes only from best_match's own hourly.
         val tomorrowDate = bundle.today.date.plusDays(1)
         val bestMatchPerModel =
-            bestMatchHourly.asPerModelHours(bundle.today.date) +
-                bundle.tomorrowHourly.asPerModelHours(tomorrowDate)
+            (bestMatchHourly.asPerModelHours(bundle.today.date) +
+                bundle.tomorrowHourly.asPerModelHours(tomorrowDate) +
+                bundle.upcomingDays.flatMap { it.hourly.asPerModelHours(it.date) })
+                .distinctBy { it.time }
         val perModelWithBestMatch = multi?.hourly?.let { existing ->
             existing.copy(
                 byModel = existing.byModel +
@@ -142,12 +149,26 @@ class OpenMeteoClient(
         // steps) for a max computed from the hourly *samples*, which can
         // differ by a fraction of a degree even when the consensus didn't
         // apply anywhere.
-        val blendedToday = blendConsensusHourly(bundle.today.date, bestMatchHourly, perModelWithBestMatch)
-            ?.let { bundle.today.withAggregatesFrom(it) }
-            ?: bundle.today
+        //
+        // Blend every forward-looking series, not just today: the consulted
+        // models are fetched at forecast_days=7, so the whole week can follow
+        // the consensus. This keeps the 7-day chart's combined line, the
+        // week-ahead headline, and the conditions strip's week-wide peaks all
+        // reading the same blended numbers — and lets the strip read wind / UV
+        // straight off [HourlyForecast] (now consensus) instead of recomputing
+        // the per-model mean itself. Yesterday is historical, with no per-model
+        // coverage, so it stays best_match.
+        fun blendDay(day: DailyForecast): DailyForecast =
+            blendConsensusHourly(day.date, day.hourly, perModelWithBestMatch)
+                ?.let { day.withAggregatesFrom(it) }
+                ?: day
 
         bundle.copy(
-            today = blendedToday,
+            today = blendDay(bundle.today),
+            tomorrow = bundle.tomorrow?.let { blendDay(it) },
+            upcomingDays = bundle.upcomingDays.map { blendDay(it) },
+            tomorrowHourly = blendConsensusHourly(tomorrowDate, bundle.tomorrowHourly, perModelWithBestMatch)
+                ?: bundle.tomorrowHourly,
             confidence = multi?.confidence,
             perModelHourly = perModelWithBestMatch,
         )

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/ConsensusBlend.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/ConsensusBlend.kt
@@ -4,11 +4,13 @@ package app.clothescast.core.domain.model
  * Blends per-hour values from the consulted models — including Open-Meteo's
  * `best_match` overlay — into a single [HourlyForecast] series, replacing
  * the corresponding [bestMatch] entry with the arithmetic mean across
- * models. Used to drive the chart's "Combined" main line and — crucially —
- * the clothes-rule + insight-prose pipeline, so on days when best_match
- * diverges from the consulted ECMWF / GFS / ICON consensus (the rain case
- * the user kept catching), the recommendation follows the broader picture
- * rather than the single auto-selected line.
+ * models. Covers temperature, feels-like, precipitation probability, wind
+ * speed, UV index, and the weather condition. Used to drive the chart's
+ * "Combined" main line and — crucially — the clothes-rule + insight-prose
+ * pipeline and the conditions strip, so on days when best_match diverges
+ * from the consulted ECMWF / GFS / ICON consensus (the rain case the user
+ * kept catching), every surface follows the broader picture rather than the
+ * single auto-selected line.
  *
  * Mechanics:
  *   - At each hour t, collect values from every model in
@@ -78,10 +80,23 @@ fun blendConsensusHourly(
             } else {
                 precipCandidates.average()
             }
+            // Wind / UV: same skip-nulls-then-average treatment as precip.
+            // best_match contributes null for both (the primary forecast call
+            // doesn't carry them — see OpenMeteoClient.asPerModelHours), so the
+            // mean is over the consulted models, matching the wind / UV
+            // diagnostic charts' consensus line. Fall back to best_match's own
+            // value when no candidate reported (keeps a sane backstop rather
+            // than dropping the field to null).
+            val windCandidates = candidates.mapNotNull { it.windSpeedKmh }
+            val blendedWind = if (windCandidates.isEmpty()) hour.windSpeedKmh else windCandidates.average()
+            val uvCandidates = candidates.mapNotNull { it.uvIndex }
+            val blendedUv = if (uvCandidates.isEmpty()) hour.uvIndex else uvCandidates.average()
             hour.copy(
                 temperatureC = candidates.map { it.temperatureC }.average(),
                 feelsLikeC = candidates.map { it.apparentTemperatureC }.average(),
                 precipitationProbabilityPct = blendedPrecip,
+                windSpeedKmh = blendedWind,
+                uvIndex = blendedUv,
                 condition = consensusCondition(
                     fallback = hour.condition,
                     candidates = candidates.mapNotNull { it.condition },
@@ -133,12 +148,12 @@ private fun WeatherCondition.severityRank(): Int = when (this) {
 
 /**
  * Returns a copy of [this] daily forecast whose temperature / feels-like
- * min-max and peak precipitation probability are recomputed from
- * [blendedHourly]. Used after [blendConsensusHourly] swaps a day's
- * hourly array for the consulted-model consensus, so the daily summary
- * (which feeds clothes rules + the insight prose) stays in sync with
- * what the chart shows. When [blendedHourly] is empty, the daily fields
- * stay as best_match.
+ * min-max, peak precipitation probability, and representative condition are
+ * recomputed from [blendedHourly]. Used after [blendConsensusHourly] swaps a
+ * day's hourly array for the consulted-model consensus, so the daily summary
+ * (which feeds clothes rules, the insight prose, and the week-ahead headline)
+ * stays in sync with what the chart shows. When [blendedHourly] is empty, the
+ * daily fields stay as best_match.
  */
 fun DailyForecast.withAggregatesFrom(blendedHourly: List<HourlyForecast>): DailyForecast {
     if (blendedHourly.isEmpty()) return this
@@ -150,6 +165,18 @@ fun DailyForecast.withAggregatesFrom(blendedHourly: List<HourlyForecast>): Daily
         feelsLikeMaxC = blendedHourly.maxOf { it.feelsLikeC },
         precipitationProbabilityMaxPct = blendedHourly
             .maxOfOrNull { it.precipitationProbabilityPct } ?: precipitationProbabilityMaxPct,
+        // Take the condition from the peak-precip hour of the blended series
+        // (mirroring DailyForecast.slicedForToday), so a day the consensus
+        // turns wet carries a precipitating daily condition. Without this the
+        // daily code stays best_match's clear/cloudy while the blended precip
+        // max climbs, and DeriveWeekAheadInsight.rainHeadline — which keys its
+        // precip *type* off the daily condition — would announce a consensus
+        // snow / thunderstorm / drizzle day as plain rain. UNKNOWN doesn't
+        // override a real best_match code.
+        condition = blendedHourly.maxByOrNull { it.precipitationProbabilityPct }
+            ?.condition
+            ?.takeIf { it != WeatherCondition.UNKNOWN }
+            ?: condition,
         // precipitationMmTotal stays from best_match — the per-model fetcher
         // doesn't carry a hourly mm series, only probability percent.
     )

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/model/ConsensusBlendTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/model/ConsensusBlendTest.kt
@@ -21,12 +21,16 @@ class ConsensusBlendTest {
         temp: Double,
         feels: Double = temp - 1.0,
         precip: Double = 0.0,
+        wind: Double? = null,
+        uv: Double? = null,
         condition: WeatherCondition = WeatherCondition.CLEAR,
     ) = HourlyForecast(
         time = LocalTime.of(h, 0),
         temperatureC = temp,
         feelsLikeC = feels,
         precipitationProbabilityPct = precip,
+        windSpeedKmh = wind,
+        uvIndex = uv,
         condition = condition,
     )
 
@@ -35,6 +39,8 @@ class ConsensusBlendTest {
         apparent: Double,
         air: Double,
         precip: Double? = 0.0,
+        wind: Double? = null,
+        uv: Double? = null,
         condition: WeatherCondition? = null,
         date: LocalDate = today,
     ) = PerModelHour(
@@ -42,6 +48,8 @@ class ConsensusBlendTest {
         apparentTemperatureC = apparent,
         temperatureC = air,
         precipitationProbabilityPct = precip,
+        windSpeedKmh = wind,
+        uvIndex = uv,
         condition = condition,
     )
 
@@ -184,6 +192,47 @@ class ConsensusBlendTest {
     }
 
     @Test
+    fun `wind and uv are averaged across the candidates that reported them`() {
+        // best_match carries no wind / UV (the primary forecast call omits
+        // them — see OpenMeteoClient.asPerModelHours), so the blend averages
+        // only the consulted models. A lone best_match spike can't survive
+        // because it isn't a candidate for these fields.
+        val best = listOf(hour(12, temp = 10.0, wind = 99.0, uv = 99.0))
+        val perModel = PerModelHourly(
+            byModel = mapOf(
+                "gfs_seamless" to listOf(perModel(12, apparent = 11.0, air = 12.0, wind = 20.0, uv = 5.0)),
+                "icon_seamless" to listOf(perModel(12, apparent = 13.0, air = 14.0, wind = 30.0, uv = 7.0)),
+                PerModelHourly.BEST_MATCH_MODEL_ID to listOf(
+                    perModel(12, apparent = 9.0, air = 10.0, wind = null, uv = null),
+                ),
+            ),
+        )
+
+        val blended = blendConsensusHourly(today, best, perModel).shouldNotBeNull()
+
+        blended[0].windSpeedKmh!! shouldBe (25.0 plusOrMinus 0.0001) // (20 + 30) / 2, best_match null skipped
+        blended[0].uvIndex!! shouldBe (6.0 plusOrMinus 0.0001)       // (5 + 7) / 2
+    }
+
+    @Test
+    fun `wind and uv fall back to best-match when no candidate reported them`() {
+        // Two models report temp (so the hour blends) but neither carries
+        // wind / UV — keep best_match's own values rather than nulling them.
+        val best = listOf(hour(12, temp = 10.0, wind = 42.0, uv = 8.0))
+        val perModel = PerModelHourly(
+            byModel = mapOf(
+                "gfs_seamless" to listOf(perModel(12, apparent = 11.0, air = 12.0, wind = null, uv = null)),
+                "icon_seamless" to listOf(perModel(12, apparent = 13.0, air = 14.0, wind = null, uv = null)),
+            ),
+        )
+
+        val blended = blendConsensusHourly(today, best, perModel).shouldNotBeNull()
+
+        blended[0].windSpeedKmh!! shouldBe (42.0 plusOrMinus 0.0001)
+        blended[0].uvIndex!! shouldBe (8.0 plusOrMinus 0.0001)
+    }
+
+    @Test
     fun `per-model entries on a different calendar day do not blend with best-match`() {
         // best_match is today's hourly only (indexed by LocalTime). Per-model
         // entries carry a full LocalDateTime, so the same hour-of-day on a
@@ -323,9 +372,58 @@ class ConsensusBlendTest {
         // umbrella rule keys off this, so without recomputation the chart
         // would show "100% rain" while the umbrella stayed unrecommended.
         out.precipitationProbabilityMaxPct shouldBe (90.0 plusOrMinus 0.0001)
-        // Precip mm and condition stay from best_match (no consensus available).
+        // Precip mm stays from best_match (no consensus available). Condition is
+        // recomputed from the peak-precip hour, which is CLEAR here too.
         out.precipitationMmTotal shouldBe daily.precipitationMmTotal
-        out.condition shouldBe daily.condition
+        out.condition shouldBe WeatherCondition.CLEAR
+    }
+
+    @Test
+    fun `withAggregatesFrom takes the daily condition from the peak-precip hour`() {
+        // best_match's daily code says CLEAR, but the blended hourly turns the
+        // day snowy at its wettest hour. The recomputed daily condition must
+        // follow it so the week-ahead headline names snow, not plain rain.
+        val daily = DailyForecast(
+            date = java.time.LocalDate.of(2026, 5, 13),
+            temperatureMinC = 0.0,
+            temperatureMaxC = 4.0,
+            feelsLikeMinC = -2.0,
+            feelsLikeMaxC = 2.0,
+            precipitationProbabilityMaxPct = 20.0,
+            precipitationMmTotal = 1.0,
+            condition = WeatherCondition.CLEAR,
+        )
+        val blended = listOf(
+            hour(12, temp = 3.0, precip = 40.0, condition = WeatherCondition.CLOUDY),
+            hour(15, temp = 2.0, precip = 85.0, condition = WeatherCondition.SNOW),
+            hour(18, temp = 1.0, precip = 50.0, condition = WeatherCondition.CLOUDY),
+        )
+
+        val out = daily.withAggregatesFrom(blended)
+
+        out.precipitationProbabilityMaxPct shouldBe (85.0 plusOrMinus 0.0001)
+        out.condition shouldBe WeatherCondition.SNOW
+    }
+
+    @Test
+    fun `withAggregatesFrom keeps best-match condition when the peak hour is UNKNOWN`() {
+        val daily = DailyForecast(
+            date = java.time.LocalDate.of(2026, 5, 13),
+            temperatureMinC = 5.0,
+            temperatureMaxC = 15.0,
+            feelsLikeMinC = 3.0,
+            feelsLikeMaxC = 12.0,
+            precipitationProbabilityMaxPct = 30.0,
+            precipitationMmTotal = 2.0,
+            condition = WeatherCondition.CLOUDY,
+        )
+        val blended = listOf(
+            hour(12, temp = 12.0, precip = 70.0, condition = WeatherCondition.UNKNOWN),
+        )
+
+        val out = daily.withAggregatesFrom(blended)
+
+        out.condition shouldBe WeatherCondition.CLOUDY
     }
 
     @Test


### PR DESCRIPTION
## What

Consolidates the conditions-strip UV (#941) and wind (#944) fixes into the place the temp/precip consensus already lives, and closes two gaps that surfaced while investigating the original "missing UV 6" report.

`blendConsensusHourly` already combined temperature, feels-like, precip probability, and condition into a single blended `HourlyForecast` — but:
1. it passed **wind and UV** straight through from `best_match` (a single model), and
2. it was only applied to **today**, leaving `upcomingDays` (2–7) on best-match.

So the strip's wind/UV came from one model (a lone gust/UV spike could show a value no chart corroborated), and the 7-day view mixed a blended today with best-match days 2–7. The earlier PRs worked around (1) by computing the consensus in the strip itself.

## Change

- **`blendConsensusHourly`** now also averages `windSpeedKmh` and `uvIndex` (skip nulls, fall back to best-match when no model reports — same treatment as precip). best-match contributes null wind/UV (the primary call omits them), so the mean is over the consulted models, matching the wind/UV charts' "Combined" line.
- **`OpenMeteoClient`** applies the blend to **today, tomorrow, the tomorrow pre-dawn hours, and every upcoming day** — the consulted models are fetched at `forecast_days=7`, so the whole week can follow the consensus.
- **Conditions strip** reads wind/UV straight off the blended `hourly` series again, so the per-model parameter added to `outfitCardInfoLines` (and the threading through TodayScreen / SevenDayPage / widget / worker / cast / nav) is **removed**. One blended source now feeds the strip, the charts' combined line, the clothes rules, and the insight prose. (The diagnostic chart cards and the confidence chip keep their own `perModelHourly` for the spread overlay — untouched.)
- The rounded UV gate (`roundToInt() >= UV_NOTABLE`) is kept.

## Behavior change to flag

Beyond wind/UV: **upcoming days' temperature and precip are now consensus too**, so the 7-day temperature chart's combined line and the "week ahead" headline follow the blend rather than best-match. That's the intended direction (consensus is why the blend exists), but it's a visible shift beyond the reported bug. **No change to what leaves the device.**

## Test plan

- `ConsensusBlendTest` (+2): wind/UV averaged across reporting candidates with best-match's nulls skipped; wind/UV fall back to best-match when no model reports them. (16 tests, green.)
- `OutfitCardInfoLinesTest`: dropped the per-model cases (consensus no longer computed at the strip); kept the UV rounding boundary + threshold and the wind threshold now that the strip reads the blended series. (6 tests, green.)
- Full parity: `./gradlew :core:domain:test :core:data:test :app:testDebugUnitTest :app:assembleDebug` — BUILD SUCCESSFUL.

Supersedes the strip-level approach from #941 / #944 (both merged) with the source-level blend.

https://claude.ai/code/session_01BrCo8fAgER6KXvx3tiD9Nt

---
_Generated by [Claude Code](https://claude.ai/code/session_01BrCo8fAgER6KXvx3tiD9Nt)_