### PR TITLE
Say "rain all day" when rain lasts the whole day

### DIFF
--- a/app/src/main/kotlin/app/clothescast/insight/InsightFormatter.kt
+++ b/app/src/main/kotlin/app/clothescast/insight/InsightFormatter.kt
@@ -266,7 +266,7 @@ class InsightFormatter(
                 // Sourced from [carriedAccessories], not the (clothes-mention-
                 // gated) wear clause, so an opted-in umbrella still surfaces
                 // when the wear clause is suppressed (Clothes = Never / unchanged).
-                add(formatPrecip(it, summary.carriedAccessories.firstOrNull()))
+                add(formatPrecip(it, summary.carriedAccessories.firstOrNull(), summary.period))
             }
         }
         val tieInClauses = buildList {
@@ -651,14 +651,23 @@ class InsightFormatter(
         return resources.getString(R.string.insight_clothes_join_two, countPhrase, tailPhrase)
     }
 
-    private fun formatPrecip(precip: PrecipClause, accessoryKey: String?): String {
+    private fun formatPrecip(precip: PrecipClause, accessoryKey: String?, period: ForecastPeriod): String {
         val rawType = resources.getString(conditionRes(precip.condition))
         // "Rain at 02:00" sounds robotic and a precise hour adds little value
         // when the user is asleep — collapse early-morning peaks to "overnight".
-        val timePhrase = if (precip.time.hour in OVERNIGHT_HOURS) {
-            resources.getString(R.string.insight_precip_overnight)
-        } else {
-            resources.getString(R.string.insight_precip_at_time, spokenTime(precip.time))
+        // When rain runs the whole period, drop the hour entirely and say "all
+        // day" / "all night" — a single time undersells a wet-all-day forecast
+        // (period-keyed so the night slice doesn't say "all day").
+        val timePhrase = when {
+            precip.allDay -> resources.getString(
+                if (period == ForecastPeriod.TONIGHT) {
+                    R.string.insight_precip_all_night
+                } else {
+                    R.string.insight_precip_all_day
+                },
+            )
+            precip.time.hour in OVERNIGHT_HOURS -> resources.getString(R.string.insight_precip_overnight)
+            else -> resources.getString(R.string.insight_precip_at_time, spokenTime(precip.time))
         }
         // The accessory is rain-keyed by name ("Rain accessory: Umbrella");
         // gate it to RAIN / DRIZZLE so "Snow overnight, bring an umbrella."
@@ -747,11 +756,18 @@ class InsightFormatter(
         val conditionNoun =
             resources.getString(conditionRes(tieIn.precipCondition ?: WeatherCondition.RAIN))
                 .lowercase(locale)
+        // All-night mirrors the main precip clause: when the evening's rain runs
+        // the whole window the "at 9pm" undersells it, so we drop the hour and
+        // say "all night". Only meaningful on the LIKELY tier (POSSIBLE keeps
+        // hedging an hour), and the all-night templates take the condition noun
+        // without a time arg.
+        val allNight = tieIn.allDay && rainTime != null && tieIn.likelihood == PrecipLikelihood.LIKELY
         if (renderedItems.isBlank()) {
             // No items left to name. If there's a rain time, the clause
             // collapses to the bare-rain prose (the only signal left);
             // otherwise the whole tie-in is empty and we drop it.
             if (rainTime == null) return null
+            if (allNight) return resources.getString(R.string.insight_evening_rain_all_night, conditionNoun)
             val template = when (tieIn.likelihood) {
                 PrecipLikelihood.LIKELY -> R.string.insight_evening_rain
                 PrecipLikelihood.POSSIBLE -> R.string.insight_evening_rain_chance
@@ -763,6 +779,9 @@ class InsightFormatter(
         // on TODAY (the TONIGHT pass uses calendarTieIn for event-anchored
         // tie-ins).
         rainTime ?: return resources.getString(R.string.insight_tie_in, renderedItems)
+        if (allNight) {
+            return resources.getString(R.string.insight_tie_in_with_rain_all_night, renderedItems, conditionNoun)
+        }
         // Hedge the item-led wording when only one model spotted the rain,
         // matching the bare-rain path's chance-of-rain template.
         val template = when (tieIn.likelihood) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1299,6 +1299,13 @@
          (00:00–04:59) — "Rain at 2am" sounds robotic and the user is asleep
          anyway. -->
     <string name="insight_precip_overnight">overnight</string>
+    <!-- Replaces the time phrase entirely when rain runs the whole daytime
+         period rather than peaking at one hour — "Rain all day." Used as %2$s in
+         insight_precip / insight_precip_with_accessory and as the time phrase in
+         the "Chance of" variants. -->
+    <string name="insight_precip_all_day">all day</string>
+    <!-- Night-slice counterpart of insight_precip_all_day — "Rain all night." -->
+    <string name="insight_precip_all_night">all night</string>
 
     <!--
     Spoken-time vocabulary used by InsightFormatter.spokenTime to emit forms
@@ -1372,6 +1379,14 @@
     -->
     <string name="insight_tie_in_with_rain">Tonight, %3$s at %2$s, bring %1$s.</string>
     <!--
+    All-night variant of insight_tie_in_with_rain: the evening's rain runs the
+    whole window rather than peaking at one hour, so we drop the time and say
+    "all night" ("Tonight, rain all night, bring a jacket."). No time arg.
+    %1$s = item phrase, %2$s = condition noun (lowercased). LIKELY tier only —
+    the POSSIBLE hedge keeps naming an hour.
+    -->
+    <string name="insight_tie_in_with_rain_all_night">Tonight, %2$s all night, bring %1$s.</string>
+    <!--
     POSSIBLE-tier counterpart of insight_tie_in_with_rain: a clothes rule
     triggered for the evening but only one per-model series flagged the
     precip at ≥ 30%. Hedges the wording so a single-model reading doesn't
@@ -1395,6 +1410,13 @@
     templates.
     -->
     <string name="insight_evening_rain">Tonight, %2$s at %1$s.</string>
+    <!--
+    All-night variant of insight_evening_rain: bare-precip evening tie-in whose
+    rain runs the whole window, so it drops the hour and says "all night"
+    ("Tonight, rain all night."). No time arg. %1$s = condition noun
+    (lowercased). LIKELY tier only.
+    -->
+    <string name="insight_evening_rain_all_night">Tonight, %1$s all night.</string>
     <!--
     POSSIBLE-tier counterpart of insight_evening_rain: only one per-model
     series flagged the tonight hour ≥ 30%, so we hedge the wording. Matches

--- a/app/src/test/kotlin/app/clothescast/insight/InsightFormatterTest.kt
+++ b/app/src/test/kotlin/app/clothescast/insight/InsightFormatterTest.kt
@@ -647,6 +647,33 @@ class InsightFormatterTest {
     }
 
     @Test
+    fun `precip clause says 'all day' when rain runs the whole period`() {
+        subject.format(
+            summary(precip = PrecipClause(WeatherCondition.RAIN, LocalTime.of(15, 0), allDay = true)),
+        ) shouldBe "Today, it will be 21°. Rain all day."
+    }
+
+    @Test
+    fun `precip clause says 'all night' for an all-day night slice`() {
+        subject.format(
+            summary(
+                period = ForecastPeriod.TONIGHT,
+                precip = PrecipClause(WeatherCondition.RAIN, LocalTime.of(21, 0), allDay = true),
+            ),
+        ) shouldBe "Tonight, it will be 21°. Rain all night."
+    }
+
+    @Test
+    fun `all-day precip still appends a carried umbrella`() {
+        subject.format(
+            summary(
+                precip = PrecipClause(WeatherCondition.RAIN, LocalTime.of(15, 0), allDay = true),
+                carriedAccessories = listOf("umbrella"),
+            ),
+        ) shouldBe "Today, it will be 21°. Rain all day, bring an umbrella."
+    }
+
+    @Test
     fun `precip clause hedges with 'Chance of rain' when likelihood is POSSIBLE`() {
         subject.format(
             summary(
@@ -935,6 +962,50 @@ class InsightFormatterTest {
             ),
         )
         out shouldBe "Today, it will be 21°. Tonight, rain at 9pm."
+    }
+
+    @Test
+    fun `evening event tie-in says 'all night' for bare all-day rain`() {
+        val out = subject.format(
+            summary(
+                eveningEventTieIn = EveningEventTieInClause(
+                    items = emptyList(),
+                    rainTime = LocalTime.of(21, 0),
+                    allDay = true,
+                ),
+            ),
+        )
+        out shouldBe "Today, it will be 21°. Tonight, rain all night."
+    }
+
+    @Test
+    fun `evening event tie-in keeps the hour for all-day rain on the POSSIBLE tier`() {
+        // all-night is LIKELY-only — a single-model chance still names its hour.
+        val out = subject.format(
+            summary(
+                eveningEventTieIn = EveningEventTieInClause(
+                    items = emptyList(),
+                    rainTime = LocalTime.of(21, 0),
+                    likelihood = PrecipLikelihood.POSSIBLE,
+                    allDay = true,
+                ),
+            ),
+        )
+        out shouldBe "Today, it will be 21°. Tonight, chance of rain at 9pm."
+    }
+
+    @Test
+    fun `evening event tie-in folds all-night rain ahead of the items`() {
+        val out = subject.format(
+            summary(
+                eveningEventTieIn = EveningEventTieInClause(
+                    items = listOf("jacket"),
+                    rainTime = LocalTime.of(21, 0),
+                    allDay = true,
+                ),
+            ),
+        )
+        out shouldBe "Today, it will be 21°. Tonight, rain all night, bring a jacket."
     }
 
     @Test

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/InsightSummary.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/InsightSummary.kt
@@ -153,11 +153,20 @@ data class ClothesClause(val items: List<String>) {
  * ("Chance of rain at 3pm.") because only a single per-model series flagged
  * the hour while others stayed dry. Defaults to LIKELY so legacy cached
  * payloads — written before the field existed — keep their original wording.
+ *
+ * [allDay] is set when LIKELY rain runs across the whole period rather than
+ * peaking at one hour — either it covers most of the window, or it falls in two
+ * or more separated spells. The formatter then drops the single-hour time
+ * phrase and says "Rain all day." (period-aware: "all night" on the night
+ * slice) so a wet-all-day forecast doesn't get undersold as a single shower.
+ * Only meaningful on the LIKELY tier; defaults to false so the POSSIBLE tier and
+ * legacy cached payloads keep naming an hour.
  */
 data class PrecipClause(
     val condition: WeatherCondition,
     val time: LocalTime,
     val likelihood: PrecipLikelihood = PrecipLikelihood.LIKELY,
+    val allDay: Boolean = false,
 )
 
 /**
@@ -208,6 +217,12 @@ data class CalendarTieInClause(val item: String)
  * LIKELY for back-compat with cached payloads written before the field
  * existed.
  *
+ * [allDay] mirrors [PrecipClause.allDay] for the evening slice: when the night's
+ * rain runs the whole window rather than peaking at one hour, the formatter
+ * drops the "at 9pm" and says "all night" ("Tonight, rain all night, bring a
+ * jacket."). Only meaningful when [rainTime] is set and [likelihood] is LIKELY;
+ * defaults to false so the POSSIBLE tier and cached payloads keep naming an hour.
+ *
  * [precipCondition] mirrors the same per-model peak's [WeatherCondition] so
  * the formatter can decide whether a wet-weather accessory mention makes
  * sense — see [warrantsRainAccessory] (umbrella for RAIN / DRIZZLE /
@@ -220,6 +235,7 @@ data class EveningEventTieInClause(
     val rainTime: LocalTime? = null,
     val likelihood: PrecipLikelihood = PrecipLikelihood.LIKELY,
     val precipCondition: WeatherCondition? = null,
+    val allDay: Boolean = false,
 )
 
 /**

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Precipitation.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Precipitation.kt
@@ -55,4 +55,15 @@ fun WeatherCondition.warrantsRainAccessory(): Boolean = when (this) {
 object PrecipProbability {
     const val POSSIBLE_THRESHOLD: Double = 30.0
     const val LIKELY_THRESHOLD: Double = 50.0
+
+    /**
+     * Fraction of a period's reported hours that must clear [LIKELY_THRESHOLD]
+     * before the insight stops naming a single peak hour ("Rain at 4pm.") and
+     * says the rain runs the whole window ("Rain all day."). 0.6 = a clear
+     * majority of the hours are wet, so a single time would undersell it — the
+     * exact case where the chart shows rain ≥ 50% across nearly every hour.
+     * Pairs with a separate "two or more separated rainy spells also count as
+     * all-day" rule in the renderer; either condition trips the all-day wording.
+     */
+    const val ALL_DAY_COVERAGE_FRACTION: Double = 0.6
 }

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/DeriveInsight.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/DeriveInsight.kt
@@ -287,6 +287,7 @@ class DeriveInsight(
             rainTime = precip?.time,
             likelihood = precip?.likelihood ?: PrecipLikelihood.LIKELY,
             precipCondition = precip?.condition,
+            allDay = precip?.allDay ?: false,
         )
     }
 

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/RenderInsightSummary.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/RenderInsightSummary.kt
@@ -15,6 +15,7 @@ import app.clothescast.core.domain.model.InsightSummary
 import app.clothescast.core.domain.model.PerModelHourly
 import app.clothescast.core.domain.model.PrecipClause
 import app.clothescast.core.domain.model.PrecipLikelihood
+import app.clothescast.core.domain.model.PrecipProbability.ALL_DAY_COVERAGE_FRACTION
 import app.clothescast.core.domain.model.PrecipProbability.LIKELY_THRESHOLD
 import app.clothescast.core.domain.model.PrecipProbability.POSSIBLE_THRESHOLD
 import app.clothescast.core.domain.model.TemperatureBand
@@ -128,7 +129,7 @@ class RenderInsightSummary {
             band = bandClause(today),
             delta = if (period == ForecastPeriod.TODAY) deltaClause(todayForDelta, yesterday, deltaThresholdC, deltaFormat, diagLog) else null,
             clothes = clothesClause(todayItems, period, clothesMentionMode, yesterdayTriggeredItems),
-            precip = peak?.let { PrecipClause(it.condition, it.time, it.likelihood) },
+            precip = peak?.let { PrecipClause(it.condition, it.time, it.likelihood, it.allDay) },
             // Calendar tie-in only fires on TONIGHT — pairing the precip peak
             // with an event the listener hasn't yet attended ("Bring an
             // umbrella.") is the case where it adds value. Event titles and
@@ -344,7 +345,13 @@ class RenderInsightSummary {
             condition = if (peak.condition == WeatherCondition.UNKNOWN) today.condition else peak.condition
         }
         if (!condition.isPrecipitation()) return null
-        return PeakPrecip(time, condition, PrecipLikelihood.LIKELY)
+        // All-day is measured against the LIKELY bar (≥ 50%), not the 30% peak
+        // threshold above — "rain all day" should mean confident rain, so a day
+        // that only ever nudges 30–49% still names its single peak hour. The base
+        // hourly list is already in window order, so adjacency in the list is
+        // adjacency in time (no LocalTime midnight-wrap aliasing).
+        val allDay = isAllDayRain(today.hourly.map { it.precipitationProbabilityPct >= LIKELY_THRESHOLD })
+        return PeakPrecip(time, condition, PrecipLikelihood.LIKELY, allDay)
     }
 
     private fun pickPerModelPeak(today: DailyForecast, perModelHourly: PerModelHourly): PeakPrecip? {
@@ -363,8 +370,8 @@ class RenderInsightSummary {
         // POSSIBLE rather than promoting it to LIKELY: "one model says rain"
         // is the textbook chance-of-rain case the per-model tier exists to
         // express.
-        val hours = models.flatMap { entries -> entries.map { it.time } }.toSortedSet()
-        val likelyHour = hours
+        val hours = models.flatMap { entries -> entries.map { it.time } }.toSortedSet().toList()
+        val likelyHours = hours
             .mapNotNull { hour ->
                 // Readings with usable precip only: a model that reported
                 // temperature for this hour but no precipitation_probability
@@ -383,11 +390,19 @@ class RenderInsightSummary {
                 val likelyCount = readings.count { (it.precipitationProbabilityPct ?: 0.0) >= LIKELY_THRESHOLD }
                 if (likelyCount >= majorityOfReporters) hour to readings else null
             }
+        val likelyHour = likelyHours
             .maxByOrNull { (_, readings) -> readings.maxOf { it.precipitationProbabilityPct ?: 0.0 } }
             ?.first
             ?.toLocalTime()
         if (likelyHour != null) {
-            return PeakPrecip(likelyHour, perModelConditionAt(likelyHour, today), PrecipLikelihood.LIKELY)
+            // [hours] is sorted, so mapping each reported hour to "did it clear
+            // the per-hour majority" yields a window-ordered flag list — dry
+            // gaps split runs, missing hours simply don't appear (so they don't
+            // count as a dry break). LocalDateTime hours sort across the tonight
+            // midnight wrap correctly, unlike a bare LocalTime.
+            val likelySet = likelyHours.mapTo(HashSet()) { it.first }
+            val allDay = isAllDayRain(hours.map { it in likelySet })
+            return PeakPrecip(likelyHour, perModelConditionAt(likelyHour, today), PrecipLikelihood.LIKELY, allDay)
         }
 
         val possibleHour = models.asSequence()
@@ -433,9 +448,37 @@ class RenderInsightSummary {
         return CalendarTieInClause(item = items.first())
     }
 
+    /**
+     * Decides whether LIKELY rain runs the whole period rather than peaking at a
+     * single hour. [likelyByHour] is the period's reported hours in chronological
+     * order, each flagged true when it cleared the LIKELY rain bar. Two ways to
+     * trip (matching the user's two mental models):
+     *  - **Coverage** — a clear majority of the hours are wet
+     *    (≥ [ALL_DAY_COVERAGE_FRACTION]); a single time would undersell a chart
+     *    that's ≥ 50% across nearly every hour.
+     *  - **Multiple spells** — rain falls in two or more separated runs (a dry
+     *    gap between them), so no one hour represents the day.
+     * Needs at least two wet hours either way — one isolated hour is just a peak,
+     * not an all-day pattern.
+     */
+    private fun isAllDayRain(likelyByHour: List<Boolean>): Boolean {
+        val total = likelyByHour.size
+        val wet = likelyByHour.count { it }
+        if (wet < 2) return false
+        val coverage = wet.toDouble() / total >= ALL_DAY_COVERAGE_FRACTION
+        var runs = 0
+        var inRun = false
+        for (likely in likelyByHour) {
+            if (likely && !inRun) runs++
+            inRun = likely
+        }
+        return coverage || runs >= 2
+    }
+
     private data class PeakPrecip(
         val time: LocalTime,
         val condition: WeatherCondition,
         val likelihood: PrecipLikelihood,
+        val allDay: Boolean = false,
     )
 }

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsightTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsightTest.kt
@@ -1044,6 +1044,10 @@ class GenerateDailyInsightTest {
         tie.shouldNotBeNull()
         tie!!.items shouldBe listOf("jacket")
         tie.rainTime shouldBe LocalTime.of(21, 0)
+        // Both evening hours sit ≥ 50%, so the night's own notification would say
+        // "rain all night" — the tie-in mirrors that, and the morning insight
+        // renders "Tonight, rain all night, bring a jacket." rather than naming 9pm.
+        tie.allDay shouldBe true
     }
 
     @Test

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/RenderInsightSummaryTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/RenderInsightSummaryTest.kt
@@ -836,6 +836,110 @@ class RenderInsightSummaryTest {
         out.likelihood shouldBe PrecipLikelihood.LIKELY
     }
 
+    @Test
+    fun `precip clause is all-day when likely rain covers most of the daytime hours`() {
+        // The screenshot scenario: a single combined series sits ≥ 50% every
+        // hour from 07:00–18:00. No one hour represents the day, so the clause
+        // should drop the single peak and flag all-day. (One series → the
+        // per-model majority path can't fire; this exercises the base fallback.)
+        val today = mildToday.copy(
+            precipitationProbabilityMaxPct = 88.0,
+            condition = WeatherCondition.RAIN,
+            hourly = (7..18).map { hour ->
+                HourlyForecast(LocalTime.of(hour, 0), 14.0, 14.0, 70.0, WeatherCondition.RAIN)
+            },
+        )
+        val out = subject(today, yesterday, emptyList()).precip
+        out.shouldNotBeNull()
+        out!!.likelihood shouldBe PrecipLikelihood.LIKELY
+        out.allDay shouldBe true
+    }
+
+    @Test
+    fun `precip clause is all-day when likely rain falls in two separated spells`() {
+        // Two distinct rainy runs with a dry gap between them — neither covers a
+        // majority of the window (4 of 7 hours = 57%, under the coverage bar),
+        // but two separated spells alone trip all-day per the "either" rule.
+        val today = mildToday.copy(
+            precipitationProbabilityMaxPct = 80.0,
+            condition = WeatherCondition.RAIN,
+            hourly = listOf(
+                HourlyForecast(LocalTime.of(8, 0), 14.0, 14.0, 70.0, WeatherCondition.RAIN),
+                HourlyForecast(LocalTime.of(9, 0), 14.0, 14.0, 65.0, WeatherCondition.RAIN),
+                HourlyForecast(LocalTime.of(10, 0), 14.0, 14.0, 10.0, WeatherCondition.RAIN),
+                HourlyForecast(LocalTime.of(11, 0), 14.0, 14.0, 10.0, WeatherCondition.RAIN),
+                HourlyForecast(LocalTime.of(12, 0), 14.0, 14.0, 10.0, WeatherCondition.RAIN),
+                HourlyForecast(LocalTime.of(16, 0), 14.0, 14.0, 80.0, WeatherCondition.RAIN),
+                HourlyForecast(LocalTime.of(17, 0), 14.0, 14.0, 75.0, WeatherCondition.RAIN),
+            ),
+        )
+        val out = subject(today, yesterday, emptyList()).precip
+        out.shouldNotBeNull()
+        out!!.allDay shouldBe true
+    }
+
+    @Test
+    fun `precip clause names a single hour for one short rain spell`() {
+        // One brief shower in an otherwise dry day — a single peak, not all-day.
+        val today = mildToday.copy(
+            precipitationProbabilityMaxPct = 70.0,
+            condition = WeatherCondition.RAIN,
+            hourly = (10..18).map { hour ->
+                val pct = if (hour == 14 || hour == 15) 65.0 else 10.0
+                HourlyForecast(LocalTime.of(hour, 0), 14.0, 14.0, pct, WeatherCondition.RAIN)
+            },
+        )
+        val out = subject(today, yesterday, emptyList()).precip
+        out.shouldNotBeNull()
+        out!!.allDay shouldBe false
+        out.time shouldBe LocalTime.of(14, 0)
+    }
+
+    @Test
+    fun `precip clause is all-day when the model majority is wet across most hours`() {
+        // Per-model path: two of three models clear 50% at nearly every hour
+        // 09:00–17:00, so the majority-agreement hours blanket the window.
+        val today = mildToday.copy(
+            precipitationProbabilityMaxPct = 80.0,
+            condition = WeatherCondition.RAIN,
+            hourly = (9..17).map { hour ->
+                HourlyForecast(LocalTime.of(hour, 0), 14.0, 14.0, 70.0, WeatherCondition.RAIN)
+            },
+        )
+        val perModel = perModelHourly(
+            "gfs_seamless" to (9..17).map { perModelHour(LocalTime.of(it, 0), 75.0) },
+            "ecmwf_ifs04" to (9..17).map { perModelHour(LocalTime.of(it, 0), 65.0) },
+            "icon_seamless" to (9..17).map { perModelHour(LocalTime.of(it, 0), 10.0) },
+        )
+        val out = subject(today, yesterday, emptyList(), perModelHourly = perModel).precip
+        out.shouldNotBeNull()
+        out!!.likelihood shouldBe PrecipLikelihood.LIKELY
+        out.allDay shouldBe true
+    }
+
+    @Test
+    fun `precip clause is not all-day for the POSSIBLE tier`() {
+        // A single model hits 80% across every hour while the others stay dry —
+        // never a majority, so it stays POSSIBLE and keeps naming one hour even
+        // though that lone model is wet all day.
+        val today = mildToday.copy(
+            precipitationProbabilityMaxPct = 30.0,
+            condition = WeatherCondition.RAIN,
+            hourly = (9..17).map { hour ->
+                HourlyForecast(LocalTime.of(hour, 0), 14.0, 14.0, 30.0, WeatherCondition.RAIN)
+            },
+        )
+        val perModel = perModelHourly(
+            "gfs_seamless" to (9..17).map { perModelHour(LocalTime.of(it, 0), 80.0) },
+            "ecmwf_ifs04" to (9..17).map { perModelHour(LocalTime.of(it, 0), 5.0) },
+            "icon_seamless" to (9..17).map { perModelHour(LocalTime.of(it, 0), 5.0) },
+        )
+        val out = subject(today, yesterday, emptyList(), perModelHourly = perModel).precip
+        out.shouldNotBeNull()
+        out!!.likelihood shouldBe PrecipLikelihood.POSSIBLE
+        out.allDay shouldBe false
+    }
+
     // PerModelHour now carries a LocalDateTime — paired against an arbitrary
     // anchor date so the test fixtures don't have to thread a date through
     // every call. The renderer reads `time.toLocalTime()` at output points;


### PR DESCRIPTION
## Problem

On the Today screen the rain insight collapsed rain to a single peak hour ("Rain at 4pm.") even on days where the *Chance of rain* chart sits above 50% nearly every hour. A screenshot from the user showed exactly this — rain ≥ 50% from 07:00–18:00, but the prose still named one afternoon hour, underselling a wet-all-day forecast.

## Change

`RenderInsightSummary` now flags a `PrecipClause` as **all-day** when *confident* (LIKELY, ≥ 50%) rain either:
- **covers most of the period's hours** (≥ 60%, `PrecipProbability.ALL_DAY_COVERAGE_FRACTION`), or
- **falls in two or more separated spells** (a dry gap between rainy runs).

Either condition trips it (per the agreed design). The formatter then drops the single-hour time phrase and renders **"Rain all day."** — or **"Rain all night."** on the night slice (period-aware).

The morning insight's **evening-event tie-in** carries the same wording: when tonight's slice is rainy all evening, it reads **"Tonight, rain all night, bring a jacket."** instead of naming a single hour — matching what the night's own notification would say. (Addresses Codex's P2 review note.)

What stays the same:
- The POSSIBLE ("Chance of rain") tier still names an hour — "all day" implies confidence.
- A single short shower still names its peak hour.
- A carried umbrella still folds in: "Rain all day, bring an umbrella."

## Implementation notes

- Detection reuses the existing per-model agreement path and base-hourly fallback the peak-hour logic already uses. Wet-hour runs are counted over the **chronologically-ordered** window, so the tonight midnight-wrap doesn't split one contiguous block into two false "spells".
- New `PrecipClause.allDay` / `EveningEventTieInClause.allDay` default to `false`, so every existing call site, preview, and cached payload is unchanged. The insight cache stores forecast *inputs* (re-derived each render), so all-day is recomputed from cached per-model/base-hourly data — no cache DTO change needed.
- New base strings: `insight_precip_all_day`, `insight_precip_all_night`, `insight_evening_rain_all_night`, `insight_tie_in_with_rain_all_night` (en-US base only; other locales fall back until translated).

## Privacy

No change to what crosses the device boundary — the all-day phrasing is derived from the same forecast data already in use; no new fields are sent to TTS or anywhere off-device.

## Test plan

- New `RenderInsightSummaryTest` cases: all-day via coverage (the screenshot scenario, single combined series → base fallback), all-day via two separated spells, single short spell stays single-hour, per-model majority all-day, and POSSIBLE tier stays single-hour.
- New `InsightFormatterTest` cases: "Rain all day.", "Rain all night." on TONIGHT, "Rain all day, bring an umbrella.", plus the evening tie-in all-night forms (bare + item-led) and POSSIBLE-keeps-the-hour.
- `GenerateDailyInsightTest`: the "mirrors the night notification" case now asserts `allDay` propagates end-to-end into the evening tie-in.
- Full JVM suite (`:core:domain:test :core:data:test :app:testDebugUnitTest`) and `:app:assembleDebug` both green locally.

https://claude.ai/code/session_0181Z5WH37nvEdy15xHQYmTT