### PR TITLE
Keep speech toggle from jumping to Voice settings when it's already set up

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/settings/ScheduleSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/ScheduleSettings.kt
@@ -79,7 +79,10 @@ internal fun ScheduleContent(
     dailyMentionEveningEvents: Boolean,
     deliveryMode: DeliveryMode,
     tonightDeliveryMode: DeliveryMode,
-    sharedTtsAvailable: Boolean,
+    // True when speech already has a working engine (device TTS, or Gemini with
+    // a BYOK key / the shared proxy). When set, turning on "Speak" skips the
+    // jump to Voice settings — there's nothing left to configure.
+    speechConfigured: Boolean,
     // Location state, so enabling a schedule can request exactly the location
     // access an unattended scheduled run needs: foreground when no location is
     // set yet, then always-on once device location is the source.
@@ -98,6 +101,7 @@ internal fun ScheduleContent(
     // Enabling the "Speak" delivery channel jumps to the full Voice settings page
     // to pick the engine and (for Gemini) drop in a key. The page shows a "Done"
     // button that returns here — see ClothesCastNavHost wiring it to VoiceDest.
+    // Only fires when speech isn't set up yet (see [speechConfigured]).
     onSetUpSpeech: () -> Unit,
     // Gates the per-section "Play now" buttons: false while any daily / tonight
     // / play worker is active, so a preview can't start a second concurrent
@@ -220,6 +224,13 @@ internal fun ScheduleContent(
         }
     }
 
+    // Turning on "Speak" jumps to Voice settings so a first-time user can pick
+    // an engine and (for Gemini) drop in a key. But if speech is already set up,
+    // there's nothing to configure — stay put rather than bouncing them away.
+    val requestSpeechSetup: () -> Unit = {
+        if (!speechConfigured) onSetUpSpeech()
+    }
+
     val scrollState = rememberScrollState()
     EdgeFadeOverlay(
         scrollState = scrollState,
@@ -255,7 +266,7 @@ internal fun ScheduleContent(
                 onSetDeliveryMode = onSetDeliveryMode,
                 onSetMentionEveningEvents = onSetDailyMentionEveningEvents,
                 onRequestNotificationPermission = requestNotificationPermission,
-                onRequestSpeechSetup = onSetUpSpeech,
+                onRequestSpeechSetup = requestSpeechSetup,
                 onPreview = { triggerPreview(context, ForecastPeriod.TODAY) },
                 previewEnabled = previewEnabled,
             )
@@ -277,7 +288,7 @@ internal fun ScheduleContent(
                 onChange = onSetTonightSchedule,
                 onSetDeliveryMode = onSetTonightDeliveryMode,
                 onRequestNotificationPermission = requestNotificationPermission,
-                onRequestSpeechSetup = onSetUpSpeech,
+                onRequestSpeechSetup = requestSpeechSetup,
                 onPreview = { triggerPreview(context, ForecastPeriod.TONIGHT) },
                 previewEnabled = previewEnabled,
             )

--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsPreviews.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsPreviews.kt
@@ -127,7 +127,7 @@ private fun ScheduleContentSample() {
         dailyMentionEveningEvents = false,
         deliveryMode = DeliveryMode.NOTIFICATION_ONLY,
         tonightDeliveryMode = DeliveryMode.NOTIFICATION_ONLY,
-        sharedTtsAvailable = false,
+        speechConfigured = false,
         useDeviceLocation = false,
         location = null,
         padding = PaddingValues(0.dp),

--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsScreen.kt
@@ -187,7 +187,7 @@ internal fun SchedulePage(
             dailyMentionEveningEvents = state.dailyMentionEveningEvents,
             deliveryMode = state.deliveryMode,
             tonightDeliveryMode = state.tonightDeliveryMode,
-            sharedTtsAvailable = state.sharedTtsAvailable,
+            speechConfigured = state.speechConfigured,
             useDeviceLocation = state.useDeviceLocation,
             location = state.location,
             padding = padding,

--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsState.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsState.kt
@@ -303,4 +303,17 @@ data class SettingsState(
     val castTonight: Boolean = true,
     /** When true, audio-carrying cast suppresses the phone speaker. */
     val castSkipPhoneSpeech: Boolean = true,
-)
+) {
+    /**
+     * True when enabling "Speak" delivery would already produce audio with
+     * nothing left to set up: device TTS is always available on the phone, and
+     * Gemini is usable once there's a BYOK key or the shared proxy. The Schedule
+     * screen reads this to avoid bouncing the user to Voice settings when speech
+     * is already configured — there'd be nothing for them to do there.
+     */
+    val speechConfigured: Boolean
+        get() = when (ttsEngine) {
+            TtsEngine.DEVICE -> true
+            TtsEngine.GEMINI -> apiKeyConfigured || sharedTtsAvailable
+        }
+}

--- a/app/src/test/kotlin/app/clothescast/ui/settings/SettingsStateTest.kt
+++ b/app/src/test/kotlin/app/clothescast/ui/settings/SettingsStateTest.kt
@@ -1,0 +1,47 @@
+package app.clothescast.ui.settings
+
+import app.clothescast.core.domain.model.TtsEngine
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+class SettingsStateTest {
+    @Test
+    fun `device engine counts as configured without any Gemini setup`() {
+        val state = SettingsState(
+            ttsEngine = TtsEngine.DEVICE,
+            apiKeyConfigured = false,
+            sharedTtsAvailable = false,
+        )
+        state.speechConfigured shouldBe true
+    }
+
+    @Test
+    fun `gemini is configured once a BYOK key is set`() {
+        val state = SettingsState(
+            ttsEngine = TtsEngine.GEMINI,
+            apiKeyConfigured = true,
+            sharedTtsAvailable = false,
+        )
+        state.speechConfigured shouldBe true
+    }
+
+    @Test
+    fun `gemini is configured when the shared proxy is available`() {
+        val state = SettingsState(
+            ttsEngine = TtsEngine.GEMINI,
+            apiKeyConfigured = false,
+            sharedTtsAvailable = true,
+        )
+        state.speechConfigured shouldBe true
+    }
+
+    @Test
+    fun `gemini without a key or proxy is not configured`() {
+        val state = SettingsState(
+            ttsEngine = TtsEngine.GEMINI,
+            apiKeyConfigured = false,
+            sharedTtsAvailable = false,
+        )
+        state.speechConfigured shouldBe false
+    }
+}


### PR DESCRIPTION
## What

On the Schedule screen, turning on the **Speak** delivery toggle always navigated the user to the full Voice settings page — even when speech was already set up. That's an annoying detour for anyone who has already chosen an engine and (for Gemini) a key. Now the jump only happens when there's actually something left to configure.

## How

- Add a computed `SettingsState.speechConfigured`:
  - `DEVICE` engine → `true` (device TTS is always available on the phone), or
  - `GEMINI` engine → `true` when a BYOK key is stored **or** the shared proxy is available.
- `ScheduleContent` now gates `onSetUpSpeech` behind this flag, so enabling **Speak** with speech already configured keeps the user on the Schedule screen instead of bouncing them to Voice settings.
- Replaces the previously-unused `sharedTtsAvailable` parameter on `ScheduleContent` with the meaningful `speechConfigured` signal.

This mirrors the existing Smart Home "nothing left to set up, skip the jump" behavior, adapted for the phone schedule (where device TTS does play, unlike Cast/MQTT).

## Privacy

No change to what crosses the device boundary — this only affects in-app navigation.

## Test plan

- New `SettingsStateTest` covers the four `speechConfigured` cases (device; Gemini with key; Gemini with shared proxy; Gemini with neither).
- `./gradlew :app:testDebugUnitTest` — BUILD SUCCESSFUL.
- `./gradlew :app:assembleDebug` — BUILD SUCCESSFUL.

https://claude.ai/code/session_01Qq2YCUw7VFFmKA3YLeG4fb

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qq2YCUw7VFFmKA3YLeG4fb)_