### PR TITLE
Show the umbrella on cloudy days when rain is likely

### DIFF
--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/OutfitSuggestion.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/OutfitSuggestion.kt
@@ -168,11 +168,13 @@ data class OutfitSuggestion(
         ): OutfitSuggestion =
             pickOutfit(
                 // Mirror EvaluateClothesRules' carried-accessory gate: the
-                // umbrella surfaces only when the day's condition warrants rain
-                // gear, so the next-period icon agrees with the primary path.
+                // umbrella surfaces once its probability gate clears unless the
+                // precipitation is frozen (snow), so the next-period icon agrees
+                // with the primary path. See [isFrozenPrecipitation] for why this
+                // excludes only snow rather than requiring a wet weather code.
                 clothesRules.filter {
                     it.appliesTo(forecast) &&
-                        !(it.item.slot == Garment.Slot.CARRIED && !forecast.condition.warrantsRainAccessory())
+                        !(it.item.slot == Garment.Slot.CARRIED && forecast.condition.isFrozenPrecipitation())
                 },
                 defaultTop,
                 defaultBottom,

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Precipitation.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Precipitation.kt
@@ -45,6 +45,29 @@ fun WeatherCondition.warrantsRainAccessory(): Boolean = when (this) {
 }
 
 /**
+ * True when this condition is frozen precipitation — snow — which an umbrella
+ * doesn't shelter against.
+ *
+ * This is the carried-accessory gate the *rule engine* uses
+ * ([EvaluateClothesRules], mirrored in [OutfitSuggestion.fromForecast]), and
+ * it's deliberately the inverse-minus-snow of [warrantsRainAccessory] rather
+ * than `!warrantsRainAccessory()`. The rule engine reads the raw daily
+ * `condition` — the weather code of the day's peak-*probability* hour — which
+ * routinely under-calls the precipitation *type*: an hour can sit at 88% chance
+ * of rain yet carry an "overcast" code because its modeled accumulation is ~0
+ * (high probability, little rain). Gating the umbrella on "is the code wet"
+ * there drops it on exactly those days, even though the insight prose still
+ * announces the rain (the prose coerces a high-probability hour to RAIN via
+ * `perModelConditionAt`, then gates its "bring an umbrella" clause on
+ * [warrantsRainAccessory] against that coerced condition). The rule engine
+ * can't coerce, so it gates on "not snow" instead — the umbrella's purpose is
+ * solely to keep it off a *snowy* day (snow can clear the probability gate too,
+ * and you don't umbrella snow). Any rain-shaped or dry-coded-but-likely day
+ * keeps the umbrella, so the card and the prose agree.
+ */
+internal fun WeatherCondition.isFrozenPrecipitation(): Boolean = this == WeatherCondition.SNOW
+
+/**
  * Per-model agreement thresholds for surfacing rain, in precipitation-
  * probability percent. The user's mental model is "1 model says rain → hedge
  * it as a chance; majority of models say a lot of rain → just say rain". 30%

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/EvaluateClothesRules.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/EvaluateClothesRules.kt
@@ -5,7 +5,7 @@ import app.clothescast.core.domain.model.DailyForecast
 import app.clothescast.core.domain.model.Garment
 import app.clothescast.core.domain.model.OutfitSuggestion
 import app.clothescast.core.domain.model.TriggeredOutfit
-import app.clothescast.core.domain.model.warrantsRainAccessory
+import app.clothescast.core.domain.model.isFrozenPrecipitation
 
 /**
  * Resolves the day's outfit from the forecast: the user's threshold
@@ -35,16 +35,21 @@ class EvaluateClothesRules {
         defaultBottom: OutfitSuggestion.Bottom = OutfitSuggestion.Bottom.LONG_PANTS,
     ): TriggeredOutfit {
         val matched = rules.filter { it.appliesTo(forecast) }
-            // A carried accessory (the umbrella) is rain gear: it surfaces only
-            // when the day's condition warrants one. The umbrella default keys
-            // off aggregate precipitation *probability*, which can clear its
-            // gate on a snowy day, so gate the carried slot on the precipitation
-            // *type* here — at the single rule-evaluation chokepoint the icon,
-            // the recommendations, and the prose all read from — rather than
-            // letting "bring an umbrella" reach the snow-day outfit surfaces.
+            // A carried accessory (the umbrella) is rain gear: it surfaces once
+            // its probability gate clears, *unless* the precipitation is frozen.
+            // The umbrella default keys off aggregate precipitation *probability*,
+            // which can clear its gate on a snowy day — and you don't umbrella
+            // snow — so gate the carried slot on snow here, at the single
+            // rule-evaluation chokepoint the icon, the recommendations, and the
+            // prose all read from. We deliberately exclude *only* snow rather
+            // than requiring a wet code ([warrantsRainAccessory]): the raw daily
+            // condition is the peak-*probability* hour's weather code, which can
+            // read "overcast" at 88% chance of rain when accumulation is ~0, and
+            // requiring a wet code there would drop the umbrella on exactly the
+            // day the prose still announces rain. See [isFrozenPrecipitation].
             // Worn garments (tops/bottoms/gloves) are unaffected.
             .filterNot {
-                it.item.slot == Garment.Slot.CARRIED && !forecast.condition.warrantsRainAccessory()
+                it.item.slot == Garment.Slot.CARRIED && forecast.condition.isFrozenPrecipitation()
             }
         // Every [ClothesRule.item] is a catalog [Garment], so each matched rule
         // claims a known slot. A slot covered by a matched rule (whether keyed

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/model/OutfitSuggestionTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/model/OutfitSuggestionTest.kt
@@ -534,6 +534,27 @@ class OutfitSuggestionTest {
     }
 
     @Test
+    fun `a high rain chance coded overcast still lights the carried umbrella`() {
+        // The bug case: 88% chance of rain, but the peak-probability hour's
+        // weather code is overcast (high probability, ~0mm accumulation), so the
+        // raw daily condition is CLOUDY rather than a wet code. The umbrella must
+        // still light, matching the prose, since only snow suppresses it.
+        val umbrellaRules = listOf(
+            ClothesRule(Garment.UMBRELLA, ClothesRule.PrecipitationProbabilityAbove(30.0)),
+        )
+        val outfit = OutfitSuggestion.fromForecast(
+            forecast(
+                feelsLikeMin = 9.0,
+                feelsLikeMax = 15.0,
+                precipMaxPct = 88.0,
+                condition = WeatherCondition.CLOUDY,
+            ),
+            umbrellaRules,
+        )
+        outfit.carried shouldBe OutfitSuggestion.Carried.UMBRELLA
+    }
+
+    @Test
     fun `a snowy day suppresses the carried umbrella even above the gate`() {
         // The umbrella default keys off aggregate precip probability, which can
         // clear its gate on a snowy day — but snow isn't wet-in-the-umbrella

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/EvaluateClothesRulesTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/EvaluateClothesRulesTest.kt
@@ -129,6 +129,21 @@ class EvaluateClothesRulesTest {
         out.rules.map { it.item.itemKey }.shouldContain("umbrella")
     }
 
+    @Test
+    fun `high rain chance coded overcast still keeps the carried umbrella`() {
+        // The bug case: 88% chance of rain but the peak-probability hour carries
+        // an "overcast" code (high probability, ~0mm accumulation), so the raw
+        // daily condition is CLOUDY, not a wet code. The prose still announces
+        // the rain, so the umbrella must surface too — only frozen precip (snow)
+        // suppresses the carried slot.
+        val out = subject(
+            forecast(min = 9.0, max = 15.0, precip = 88.0, condition = WeatherCondition.CLOUDY),
+            ClothesRule.DEFAULTS,
+        )
+        out.rules.map { it.item.itemKey }.shouldContain("umbrella")
+        out.items.shouldContain("umbrella")
+    }
+
 
     @Test
     fun `user-selected default rules flow through to the resolved items`() {


### PR DESCRIPTION
## The bug

The umbrella went missing from the outfit card and the bulleted recommendations even on a high-chance-of-rain day, while the insight prose *did* announce the rain. From the report: prose `Cool. Wear a jumper and jeans. Rain at 4pm.`, outfit `SWEATER + JEANS`, recommended items `sweater, jeans` — no umbrella, despite the default `umbrella when precipMaxPct > 30` rule and a chart showing **88% chance of rain at 17:00** with **7mm of rain that day**. The two surfaces disagreed.

## Root cause

Carried accessories (the umbrella) pass a *second* gate beyond their probability rule. In `EvaluateClothesRules` (and the mirror in `OutfitSuggestion.fromForecast`) the carried slot required the day's `condition` to be a wet weather code via `warrantsRainAccessory()` (RAIN / DRIZZLE / THUNDERSTORM).

But that `condition` is the weather code of the day's **peak-*probability*** hour (`DailyForecast.slicedForToday` → `maxByOrNull { precipitationProbabilityPct }`). When the chance of rain is high (88%) but the modeled *accumulation* at that hour is ~0, Open-Meteo codes the hour **overcast**, not rain. So the wet-code gate dropped the umbrella on exactly the days the prose still announced rain — the prose coerces a high-probability hour to RAIN (`perModelConditionAt`) and surfaces it, but the rule engine read the raw, under-called code.

## Fix

Gate the carried slot on **frozen precipitation (snow)** instead of requiring a wet code, via a new `internal` `WeatherCondition.isFrozenPrecipitation()` predicate. The carried gate's only real job is to keep the umbrella off a *snowy* day (snow can clear the probability gate too, and you don't umbrella snow). Any rain-shaped — or dry-coded-but-likely — day now keeps the umbrella, so the card, the icon, the recommendations, and the prose agree.

`warrantsRainAccessory()` is unchanged: it still gates the **prose's** "bring an umbrella" clause (`InsightFormatter`) against its per-model-coerced precip condition, which is the right input there.

## Scope
- `Precipitation.kt` — new `isFrozenPrecipitation()` predicate + rationale.
- `EvaluateClothesRules.kt` — carried-slot gate now excludes only snow.
- `OutfitSuggestion.kt` — mirrored gate in `fromForecast` (next-period icon / forecast-only callers).

## Privacy
No change to what crosses the device boundary — purely an outfit-selection gate.

## Test plan
- New `EvaluateClothesRulesTest` and `OutfitSuggestionTest` cases for "88% chance, overcast code → umbrella keeps firing".
- Existing snow-suppression and thunderstorm-keeps-umbrella tests still pass.
- `./gradlew :core:domain:test` green.

https://claude.ai/code/session_018KaxweuRr6DzHyVdxrt6dJ

---
_Generated by [Claude Code](https://claude.ai/code/session_018KaxweuRr6DzHyVdxrt6dJ)_