### PR TITLE
Rain clothing rules no longer trigger on snowy days

### DIFF
--- a/app/src/main/kotlin/app/clothescast/data/ClothesRuleDto.kt
+++ b/app/src/main/kotlin/app/clothescast/data/ClothesRuleDto.kt
@@ -18,9 +18,12 @@ import kotlinx.serialization.Serializable
  * silently discarded rather than kept as untyped strings.
  *
  * `type` strings are intentionally non-camelCase so they're stable identifiers in JSON
- * even if class names are renamed. [unit] is nullable so JSON written by app versions
- * before unit-aware thresholds existed still deserialises (legacy = always Celsius);
- * unit is meaningless for precipitation rules and stays null there.
+ * even if class names are renamed. Rain rules write `"rain_above"`; the older
+ * `"precip_above"` token (written before the precipitation→rain rename) is still read
+ * via [TYPE_RAIN_ABOVE_LEGACY] so rules saved by earlier builds keep loading. [unit] is
+ * nullable so JSON written by app versions before unit-aware thresholds existed still
+ * deserialises (legacy = always Celsius); unit is meaningless for rain rules and stays
+ * null there.
  */
 @Serializable
 internal data class ClothesRuleDto(
@@ -37,7 +40,7 @@ internal data class ClothesRuleDto(
             condition = when (type) {
                 TYPE_TEMP_BELOW -> ClothesRule.TemperatureBelow(value, parseUnit(unit))
                 TYPE_TEMP_ABOVE -> ClothesRule.TemperatureAbove(value, parseUnit(unit))
-                TYPE_PRECIP_ABOVE -> ClothesRule.PrecipitationProbabilityAbove(value)
+                TYPE_RAIN_ABOVE, TYPE_RAIN_ABOVE_LEGACY -> ClothesRule.RainProbabilityAbove(value)
                 else -> error("Unknown clothes rule type: $type")
             },
         )
@@ -46,7 +49,14 @@ internal data class ClothesRuleDto(
     companion object {
         const val TYPE_TEMP_BELOW = "temp_below"
         const val TYPE_TEMP_ABOVE = "temp_above"
-        const val TYPE_PRECIP_ABOVE = "precip_above"
+        const val TYPE_RAIN_ABOVE = "rain_above"
+
+        /**
+         * Legacy wire token for rain rules, written before the precipitation→rain
+         * rename. Read-only: [toDomain] still accepts it so saved rules keep
+         * loading, but [toDto] always writes the current [TYPE_RAIN_ABOVE].
+         */
+        const val TYPE_RAIN_ABOVE_LEGACY = "precip_above"
 
         /** Falls back to Celsius for legacy data (`null`) or unrecognised tokens. */
         private fun parseUnit(raw: String?): TemperatureUnit =
@@ -60,6 +70,6 @@ internal fun ClothesRule.toDto(): ClothesRuleDto = when (val c = condition) {
         ClothesRuleDto(item.itemKey, ClothesRuleDto.TYPE_TEMP_BELOW, c.value, c.unit.name)
     is ClothesRule.TemperatureAbove ->
         ClothesRuleDto(item.itemKey, ClothesRuleDto.TYPE_TEMP_ABOVE, c.value, c.unit.name)
-    is ClothesRule.PrecipitationProbabilityAbove ->
-        ClothesRuleDto(item.itemKey, ClothesRuleDto.TYPE_PRECIP_ABOVE, c.percent)
+    is ClothesRule.RainProbabilityAbove ->
+        ClothesRuleDto(item.itemKey, ClothesRuleDto.TYPE_RAIN_ABOVE, c.percent)
 }

--- a/app/src/main/kotlin/app/clothescast/diag/BugReport.kt
+++ b/app/src/main/kotlin/app/clothescast/diag/BugReport.kt
@@ -284,7 +284,7 @@ object BugReport {
         val cond = when (val c = rule.condition) {
             is ClothesRule.TemperatureBelow -> "feelsLikeMin < ${c.value}${c.unit.symbol()}"
             is ClothesRule.TemperatureAbove -> "feelsLikeMax > ${c.value}${c.unit.symbol()}"
-            is ClothesRule.PrecipitationProbabilityAbove -> "precipMaxPct > ${c.percent}"
+            is ClothesRule.RainProbabilityAbove -> "rainChance > ${c.percent}%"
         }
         return "${rule.item.itemKey} when $cond"
     }

--- a/app/src/main/kotlin/app/clothescast/diag/ClothesRulesSnapshot.kt
+++ b/app/src/main/kotlin/app/clothescast/diag/ClothesRulesSnapshot.kt
@@ -37,7 +37,7 @@ data class ClothesRulesSnapshot(
         const val DELTA_CLAMP_C: Int = 5
 
         /**
-         * Largest absolute percentage-point delta reported for the precip-keyed
+         * Largest absolute percentage-point delta reported for the rain-keyed
          * umbrella default; beyond this saturates. Wider than [DELTA_CLAMP_C]
          * because a probability gate spans 0–100%, but still bucketed (rounded to
          * the nearest [PCT_BUCKET]) so the aggregate stays coarse.
@@ -63,12 +63,12 @@ data class ClothesRulesSnapshot(
                 val userRule = byItem[item]
                 when {
                     userRule == null -> MISSING
-                    // The umbrella default is precip-keyed (no Celsius threshold),
+                    // The umbrella default is rain-keyed (no Celsius threshold),
                     // so bucket its probability-gate delta separately — routing it
                     // through deltaBucket would always report "0" and hide every
-                    // gate customisation. See precipDeltaBucket.
-                    defaultRule.condition is ClothesRule.PrecipitationProbabilityAbove ->
-                        precipDeltaBucket(userRule, defaultRule)
+                    // gate customisation. See rainGateDeltaBucket.
+                    defaultRule.condition is ClothesRule.RainProbabilityAbove ->
+                        rainGateDeltaBucket(userRule, defaultRule)
                     else -> deltaBucket(userRule, defaultRule)
                 }
             }
@@ -93,7 +93,7 @@ data class ClothesRulesSnapshot(
 
         /**
          * Integer °C delta of [userRule] from [defaultRule], formatted as a signed
-         * bucket. Non-temperature rules (precipitation) and type-mismatch cases
+         * bucket. Non-temperature rules (rain) and type-mismatch cases
          * report `"0"` only when both thresholds are absent — otherwise the bucket
          * reflects whichever side has a temperature. Default rules in the current
          * catalog are all temperature, so the type-mismatch arm is defensive.
@@ -113,17 +113,17 @@ data class ClothesRulesSnapshot(
         }
 
         /**
-         * Signed percentage-point delta of a precip-keyed [userRule] from its
-         * precip-keyed [defaultRule] (the umbrella's rain-probability gate),
+         * Signed percentage-point delta of a rain-keyed [userRule] from its
+         * rain-keyed [defaultRule] (the umbrella's rain-probability gate),
          * rounded to the nearest [PCT_BUCKET] and clamped to ±[DELTA_CLAMP_PCT] —
          * `"0"`, `"+10"`, `"-20"`, `"+50+"` (saturated above), `"-50-"` (below).
-         * A user rule that isn't precip-keyed (shouldn't happen — the umbrella
-         * editor only writes precip conditions) reports [MISSING].
+         * A user rule that isn't rain-keyed (shouldn't happen — the umbrella
+         * editor only writes rain conditions) reports [MISSING].
          */
-        private fun precipDeltaBucket(userRule: ClothesRule, defaultRule: ClothesRule): String {
-            val defaultPct = (defaultRule.condition as? ClothesRule.PrecipitationProbabilityAbove)?.percent
+        private fun rainGateDeltaBucket(userRule: ClothesRule, defaultRule: ClothesRule): String {
+            val defaultPct = (defaultRule.condition as? ClothesRule.RainProbabilityAbove)?.percent
                 ?: return MISSING
-            val userPct = (userRule.condition as? ClothesRule.PrecipitationProbabilityAbove)?.percent
+            val userPct = (userRule.condition as? ClothesRule.RainProbabilityAbove)?.percent
                 ?: return MISSING
             val bucketed = ((userPct - defaultPct) / PCT_BUCKET).roundToInt() * PCT_BUCKET
             return when {

--- a/app/src/main/kotlin/app/clothescast/ui/settings/ClothesSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/ClothesSettings.kt
@@ -893,8 +893,8 @@ private fun describeCondition(
             R.string.settings_clothes_cond_temp_above,
             formatThreshold(condition.value, condition.unit, temperatureUnit),
         )
-    is ClothesRule.PrecipitationProbabilityAbove ->
-        stringResource(R.string.settings_clothes_cond_precip_above, condition.percent)
+    is ClothesRule.RainProbabilityAbove ->
+        stringResource(R.string.settings_clothes_cond_rain_above, condition.percent)
 }
 
 /**
@@ -919,7 +919,7 @@ private fun formatThreshold(
 private enum class ConditionType(@StringRes val labelRes: Int) {
     TEMP_BELOW(R.string.settings_clothes_cond_type_temp_below),
     TEMP_ABOVE(R.string.settings_clothes_cond_type_temp_above),
-    PRECIP_ABOVE(R.string.settings_clothes_cond_type_precip_above),
+    RAIN_ABOVE(R.string.settings_clothes_cond_type_rain_above),
 }
 
 /** Maps a [Garment] enum entry to its localised display label resource. */
@@ -979,18 +979,18 @@ internal fun ClothesRuleDialog(
     val initialType = when (initial?.condition) {
         is ClothesRule.TemperatureBelow -> ConditionType.TEMP_BELOW
         is ClothesRule.TemperatureAbove -> ConditionType.TEMP_ABOVE
-        is ClothesRule.PrecipitationProbabilityAbove -> ConditionType.PRECIP_ABOVE
+        is ClothesRule.RainProbabilityAbove -> ConditionType.RAIN_ABOVE
         null -> ConditionType.TEMP_BELOW
     }
     var type by remember { mutableStateOf(initialType) }
     // A carried accessory (umbrella) is only ever named off a rain/drizzle
-    // precip clause, so a temperature-keyed umbrella rule would fire but render
-    // nothing. Restrict carried gear to the precipitation condition and force
-    // the selection there if the user picks it while a temp type was active.
+    // clause, so a temperature-keyed umbrella rule would fire but render
+    // nothing. Restrict carried gear to the rain condition and force the
+    // selection there if the user picks it while a temp type was active.
     val carried = garment.slot == Garment.Slot.CARRIED
-    val allowedTypes = if (carried) listOf(ConditionType.PRECIP_ABOVE) else ConditionType.entries.toList()
+    val allowedTypes = if (carried) listOf(ConditionType.RAIN_ABOVE) else ConditionType.entries.toList()
     LaunchedEffect(carried) {
-        if (carried && type != ConditionType.PRECIP_ABOVE) type = ConditionType.PRECIP_ABOVE
+        if (carried && type != ConditionType.RAIN_ABOVE) type = ConditionType.RAIN_ABOVE
     }
     // Pre-fill in the user's *current* display unit. A 65°F rule opened by a °C
     // user pre-fills as "18" (the saved value converted via Celsius); when the
@@ -1000,7 +1000,7 @@ internal fun ClothesRuleDialog(
     val initialValue = when (val c = initial?.condition) {
         is ClothesRule.TemperatureBelow -> c.value.fromUnit(c.unit).toUnit(temperatureUnit)
         is ClothesRule.TemperatureAbove -> c.value.fromUnit(c.unit).toUnit(temperatureUnit)
-        is ClothesRule.PrecipitationProbabilityAbove -> c.percent
+        is ClothesRule.RainProbabilityAbove -> c.percent
         null -> 18.0.toUnit(temperatureUnit)
     }
     val initialInt = initialValue.roundToInt()
@@ -1017,7 +1017,7 @@ internal fun ClothesRuleDialog(
     // rules can be any int. Disable confirm when out of range so the rule can't
     // be saved with a nonsense threshold.
     val valueValid = parsedValue != null &&
-        (type != ConditionType.PRECIP_ABOVE || parsedValue in 0..100)
+        (type != ConditionType.RAIN_ABOVE || parsedValue in 0..100)
 
     AlertDialog(
         onDismissRequest = onDismiss,
@@ -1041,9 +1041,9 @@ internal fun ClothesRuleDialog(
                         ConditionType.TEMP_ABOVE ->
                             if (unchanged && initialCond is ClothesRule.TemperatureAbove) initialCond
                             else ClothesRule.TemperatureAbove(v, temperatureUnit)
-                        ConditionType.PRECIP_ABOVE ->
-                            if (unchanged && initialCond is ClothesRule.PrecipitationProbabilityAbove) initialCond
-                            else ClothesRule.PrecipitationProbabilityAbove(v)
+                        ConditionType.RAIN_ABOVE ->
+                            if (unchanged && initialCond is ClothesRule.RainProbabilityAbove) initialCond
+                            else ClothesRule.RainProbabilityAbove(v)
                     }
                     onConfirm(ClothesRule(garment, condition))
                 },
@@ -1092,8 +1092,8 @@ internal fun ClothesRuleDialog(
                 valueText = valueText,
                 onValueChange = { valueText = it },
                 valueValid = valueValid,
-                valueLabel = if (type == ConditionType.PRECIP_ABOVE) {
-                    stringResource(R.string.settings_clothes_value_label_precip)
+                valueLabel = if (type == ConditionType.RAIN_ABOVE) {
+                    stringResource(R.string.settings_clothes_value_label_rain)
                 } else {
                     stringResource(R.string.settings_clothes_value_label_temp, temperatureUnit.symbol())
                 },
@@ -1203,7 +1203,7 @@ internal fun ClothesRuleEditPreviewCard(
     // by a Boolean the preview wrappers in SettingsPreviews can pass.
     precip: Boolean = false,
 ) {
-    val type = if (precip) ConditionType.PRECIP_ABOVE else ConditionType.TEMP_BELOW
+    val type = if (precip) ConditionType.RAIN_ABOVE else ConditionType.TEMP_BELOW
     Surface(
         shape = MaterialTheme.shapes.extraLarge,
         tonalElevation = 6.dp,
@@ -1242,7 +1242,7 @@ internal fun ClothesRuleEditPreviewCard(
                 // Mirror [ClothesRuleDialog]'s label selection so the preview
                 // exercises the same precip-vs-temp branch the real dialog does.
                 valueLabel = if (precip) {
-                    stringResource(R.string.settings_clothes_value_label_precip)
+                    stringResource(R.string.settings_clothes_value_label_rain)
                 } else {
                     stringResource(
                         R.string.settings_clothes_value_label_temp,

--- a/app/src/main/res/values-am/strings.xml
+++ b/app/src/main/res/values-am/strings.xml
@@ -38,13 +38,13 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="settings_clothes_color_label">ቀለም</string>
     <string name="settings_clothes_condition_label">ሁኔታ</string>
     <string name="settings_clothes_value_label_temp">ደረጃ (%1$s)</string>
-    <string name="settings_clothes_value_label_precip">ደረጃ (%)</string>
+    <string name="settings_clothes_value_label_rain">ደረጃ (%)</string>
     <string name="settings_clothes_cond_type_temp_below">ከሚሰማ ቀዝቃዛ ሲሆን</string>
     <string name="settings_clothes_cond_type_temp_above">ከሚሰማ ሞቃት ሲሆን</string>
-    <string name="settings_clothes_cond_type_precip_above">የዝናብ ዕድል ሲጨምር</string>
+    <string name="settings_clothes_cond_type_rain_above">የዝናብ ዕድል ሲጨምር</string>
     <string name="settings_clothes_cond_temp_below">ዝቅተኛ ሙቀት %1$s ሲቀንስ</string>
     <string name="settings_clothes_cond_temp_above">ከፍተኛ ሙቀት %1$s ሲጨምር</string>
-    <string name="settings_clothes_cond_precip_above">የዝናብ ዕድል %.0f%% ሲጨምር</string>
+    <string name="settings_clothes_cond_rain_above">የዝናብ ዕድል %.0f%% ሲጨምር</string>
     <string name="settings_clothes_title">የልብስ ህጎች</string>
     <string name="settings_clothes_description">አንድ ትንበያ ከእነዚህ ደረጃዎች ካለፈ፣ ልብሱ ወደ ዕለታዊ ClothesCast ይታከላል።</string>
 

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -38,13 +38,13 @@ they work correctly in both the single-band and range templates.
     <string name="settings_clothes_color_label">اللون</string>
     <string name="settings_clothes_condition_label">الشرط</string>
     <string name="settings_clothes_value_label_temp">العتبة (%1$s)</string>
-    <string name="settings_clothes_value_label_precip">العتبة (%)</string>
+    <string name="settings_clothes_value_label_rain">العتبة (%)</string>
     <string name="settings_clothes_cond_type_temp_below">عندما تكون درجة الحرارة المحسوسة أقل من</string>
     <string name="settings_clothes_cond_type_temp_above">عندما تكون درجة الحرارة المحسوسة أعلى من</string>
-    <string name="settings_clothes_cond_type_precip_above">عندما تكون احتمالية الأمطار أعلى من</string>
+    <string name="settings_clothes_cond_type_rain_above">عندما تكون احتمالية الأمطار أعلى من</string>
     <string name="settings_clothes_cond_temp_below">عندما تكون درجة الحرارة المحسوسة الدنيا أقل من %1$s</string>
     <string name="settings_clothes_cond_temp_above">عندما تكون درجة الحرارة المحسوسة القصوى أعلى من %1$s</string>
-    <string name="settings_clothes_cond_precip_above">عندما تكون احتمالية الأمطار أعلى من %.0f%%</string>
+    <string name="settings_clothes_cond_rain_above">عندما تكون احتمالية الأمطار أعلى من %.0f%%</string>
 
     <string name="today_outfit_top_tshirt">تي شيرت</string>
     <string name="today_outfit_top_sweater">سترة صوفية</string>

--- a/app/src/main/res/values-b+sr+Cyrl/strings.xml
+++ b/app/src/main/res/values-b+sr+Cyrl/strings.xml
@@ -38,13 +38,13 @@ surfaces.
     <string name="settings_clothes_color_label">Боја</string>
     <string name="settings_clothes_condition_label">Услов</string>
     <string name="settings_clothes_value_label_temp">Праг (%1$s)</string>
-    <string name="settings_clothes_value_label_precip">Праг (%)</string>
+    <string name="settings_clothes_value_label_rain">Праг (%)</string>
     <string name="settings_clothes_cond_type_temp_below">Када се осећа хладније од</string>
     <string name="settings_clothes_cond_type_temp_above">Када се осећа топлије од</string>
-    <string name="settings_clothes_cond_type_precip_above">Када је вероватноћа кише већа од</string>
+    <string name="settings_clothes_cond_type_rain_above">Када је вероватноћа кише већа од</string>
     <string name="settings_clothes_cond_temp_below">када је осећајна температура испод %1$s</string>
     <string name="settings_clothes_cond_temp_above">када је осећајна температура изнад %1$s</string>
-    <string name="settings_clothes_cond_precip_above">када је вероватноћа кише већа од %.0f%%</string>
+    <string name="settings_clothes_cond_rain_above">када је вероватноћа кише већа од %.0f%%</string>
 
     <!-- Clothes settings — title + description. -->
     <string name="settings_clothes_title">Правила одевања</string>

--- a/app/src/main/res/values-b+sr+Latn/strings.xml
+++ b/app/src/main/res/values-b+sr+Latn/strings.xml
@@ -50,13 +50,13 @@ default English (matching values-pl / values-uk).
     <string name="settings_clothes_color_label">Boja</string>
     <string name="settings_clothes_condition_label">Uslov</string>
     <string name="settings_clothes_value_label_temp">Prag (%1$s)</string>
-    <string name="settings_clothes_value_label_precip">Prag (%)</string>
+    <string name="settings_clothes_value_label_rain">Prag (%)</string>
     <string name="settings_clothes_cond_type_temp_below">Kada se oseća hladnije od</string>
     <string name="settings_clothes_cond_type_temp_above">Kada se oseća toplije od</string>
-    <string name="settings_clothes_cond_type_precip_above">Kada je verovatnoća kiše veća od</string>
+    <string name="settings_clothes_cond_type_rain_above">Kada je verovatnoća kiše veća od</string>
     <string name="settings_clothes_cond_temp_below">kada je osećajna temperatura ispod %1$s</string>
     <string name="settings_clothes_cond_temp_above">kada je osećajna temperatura iznad %1$s</string>
-    <string name="settings_clothes_cond_precip_above">kada je verovatnoća kiše veća od %.0f%%</string>
+    <string name="settings_clothes_cond_rain_above">kada je verovatnoća kiše veća od %.0f%%</string>
 
     <!-- Clothes settings — title + description. -->
     <string name="settings_clothes_title">Pravila odevanja</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -46,13 +46,13 @@ What is NOT overridden, by design:
     <string name="settings_clothes_color_label">Цвят</string>
     <string name="settings_clothes_condition_label">Условие</string>
     <string name="settings_clothes_value_label_temp">Праг (%1$s)</string>
-    <string name="settings_clothes_value_label_precip">Праг (%)</string>
+    <string name="settings_clothes_value_label_rain">Праг (%)</string>
     <string name="settings_clothes_cond_type_temp_below">Когато усещаната е под</string>
     <string name="settings_clothes_cond_type_temp_above">Когато усещаната е над</string>
-    <string name="settings_clothes_cond_type_precip_above">Когато вероятността за дъжд е над</string>
+    <string name="settings_clothes_cond_type_rain_above">Когато вероятността за дъжд е над</string>
     <string name="settings_clothes_cond_temp_below">когато усещаната температура е под %1$s</string>
     <string name="settings_clothes_cond_temp_above">когато усещаната температура е над %1$s</string>
-    <string name="settings_clothes_cond_precip_above">когато вероятността за дъжд е над %.0f%%</string>
+    <string name="settings_clothes_cond_rain_above">когато вероятността за дъжд е над %.0f%%</string>
 
     <string name="today_outfit_top_tshirt">Тениска</string>
     <string name="today_outfit_top_sweater">Пуловер</string>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -34,13 +34,13 @@ West Bengal vocabulary differences in a future PR.
     <string name="settings_clothes_color_label">রং</string>
     <string name="settings_clothes_condition_label">শর্ত</string>
     <string name="settings_clothes_value_label_temp">সীমা (%1$s)</string>
-    <string name="settings_clothes_value_label_precip">সীমা (%)</string>
+    <string name="settings_clothes_value_label_rain">সীমা (%)</string>
     <string name="settings_clothes_cond_type_temp_below">যখন অনুভব হয় তার চেয়ে ঠান্ডা</string>
     <string name="settings_clothes_cond_type_temp_above">যখন অনুভব হয় তার চেয়ে গরম</string>
-    <string name="settings_clothes_cond_type_precip_above">যখন বৃষ্টির সম্ভাবনা বেশি</string>
+    <string name="settings_clothes_cond_type_rain_above">যখন বৃষ্টির সম্ভাবনা বেশি</string>
     <string name="settings_clothes_cond_temp_below">যখন সর্বনিম্ন অনুভূত তাপমাত্রা %1$s-এর নিচে</string>
     <string name="settings_clothes_cond_temp_above">যখন সর্বোচ্চ অনুভূত তাপমাত্রা %1$s-এর বেশি</string>
-    <string name="settings_clothes_cond_precip_above">যখন বৃষ্টির সম্ভাবনা %.0f%%-এর বেশি</string>
+    <string name="settings_clothes_cond_rain_above">যখন বৃষ্টির সম্ভাবনা %.0f%%-এর বেশি</string>
 
     <string name="today_outfit_top_tshirt">টি-শার্ট</string>
     <string name="today_outfit_top_sweater">সোয়েটার</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -434,13 +434,13 @@ the in-app clock is digit-driven and reads consistently across locales.
     <string name="settings_clothes_color_label">Color</string>
     <string name="settings_clothes_condition_label">Condició</string>
     <string name="settings_clothes_value_label_temp">Llindar (%1$s)</string>
-    <string name="settings_clothes_value_label_precip">Llindar (%)</string>
+    <string name="settings_clothes_value_label_rain">Llindar (%)</string>
     <string name="settings_clothes_cond_type_temp_below">Quan se sent més fred que</string>
     <string name="settings_clothes_cond_type_temp_above">Quan se sent més càlid que</string>
-    <string name="settings_clothes_cond_type_precip_above">Quan la probabilitat de pluja supera</string>
+    <string name="settings_clothes_cond_type_rain_above">Quan la probabilitat de pluja supera</string>
     <string name="settings_clothes_cond_temp_below">quan la temperatura percebuda és inferior a %1$s</string>
     <string name="settings_clothes_cond_temp_above">quan la temperatura percebuda és superior a %1$s</string>
-    <string name="settings_clothes_cond_precip_above">quan la probabilitat de pluja supera el %.0f%%</string>
+    <string name="settings_clothes_cond_rain_above">quan la probabilitat de pluja supera el %.0f%%</string>
 
     <string name="notification_channel_daily_insight_name">ClothesCast diari</string>
     <string name="notification_channel_daily_insight_description">El resum meteorològic matinal al qual t\'has subscrit.</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -189,13 +189,13 @@ locale (Angličtina (USA), Francouzština (Francie), Němčina (Německo), …).
     <string name="settings_clothes_color_label">Barva</string>
     <string name="settings_clothes_condition_label">Podmínka</string>
     <string name="settings_clothes_value_label_temp">Práh (%1$s)</string>
-    <string name="settings_clothes_value_label_precip">Práh (%)</string>
+    <string name="settings_clothes_value_label_rain">Práh (%)</string>
     <string name="settings_clothes_cond_type_temp_below">Když je pocitová pod</string>
     <string name="settings_clothes_cond_type_temp_above">Když je pocitová nad</string>
-    <string name="settings_clothes_cond_type_precip_above">Když je pravděpodobnost deště nad</string>
+    <string name="settings_clothes_cond_type_rain_above">Když je pravděpodobnost deště nad</string>
     <string name="settings_clothes_cond_temp_below">když je pocitová teplota pod %1$s</string>
     <string name="settings_clothes_cond_temp_above">když je pocitová teplota nad %1$s</string>
-    <string name="settings_clothes_cond_precip_above">když je pravděpodobnost deště nad %.0f%%</string>
+    <string name="settings_clothes_cond_rain_above">když je pravděpodobnost deště nad %.0f%%</string>
 
     <!-- Schedule screen. -->
     <string name="settings_schedule_title">Denní ClothesCast</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -74,13 +74,13 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrig)").
     <string name="settings_clothes_color_label">Farve</string>
     <string name="settings_clothes_condition_label">Betingelse</string>
     <string name="settings_clothes_value_label_temp">Tærskel (%1$s)</string>
-    <string name="settings_clothes_value_label_precip">Tærskel (%)</string>
+    <string name="settings_clothes_value_label_rain">Tærskel (%)</string>
     <string name="settings_clothes_cond_type_temp_below">Når det føles koldere end</string>
     <string name="settings_clothes_cond_type_temp_above">Når det føles varmere end</string>
-    <string name="settings_clothes_cond_type_precip_above">Når regnsandsynligheden er over</string>
+    <string name="settings_clothes_cond_type_rain_above">Når regnsandsynligheden er over</string>
     <string name="settings_clothes_cond_temp_below">når den følte temperatur er under %1$s</string>
     <string name="settings_clothes_cond_temp_above">når den følte temperatur er over %1$s</string>
-    <string name="settings_clothes_cond_precip_above">når regnsandsynligheden er over %.0f%%</string>
+    <string name="settings_clothes_cond_rain_above">når regnsandsynligheden er over %.0f%%</string>
 
     <!-- Schedule screen. -->
     <string name="settings_schedule_title">Dagligt ClothesCast</string>

--- a/app/src/main/res/values-de-rAT/strings.xml
+++ b/app/src/main/res/values-de-rAT/strings.xml
@@ -91,16 +91,16 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_clothes_item_label">Kleidungsstück</string>
     <string name="settings_clothes_condition_label">Auslöser</string>
     <string name="settings_clothes_value_label_temp">Schwelle (%1$s)</string>
-    <string name="settings_clothes_value_label_precip">Schwelle (%)</string>
+    <string name="settings_clothes_value_label_rain">Schwelle (%)</string>
     <string name="settings_clothes_cond_type_temp_below">Wenn es sich kälter anfühlt als</string>
     <string name="settings_clothes_cond_type_temp_above">Wenn es sich wärmer anfühlt als</string>
-    <string name="settings_clothes_cond_type_precip_above">Wenn die Regenwahrscheinlichkeit über</string>
+    <string name="settings_clothes_cond_type_rain_above">Wenn die Regenwahrscheinlichkeit über</string>
 
     <!-- Row description for an existing rule. Mirrors the English templates
          in values/strings.xml. -->
     <string name="settings_clothes_cond_temp_below">wenn die gefühlte Mindesttemperatur unter %1$s liegt</string>
     <string name="settings_clothes_cond_temp_above">wenn die gefühlte Höchsttemperatur über %1$s liegt</string>
-    <string name="settings_clothes_cond_precip_above">wenn die Regenwahrscheinlichkeit über %.0f%% liegt</string>
+    <string name="settings_clothes_cond_rain_above">wenn die Regenwahrscheinlichkeit über %.0f%% liegt</string>
 
     <!--
     Schedule screen — daily and nightly ClothesCast cards, delivery picker,

--- a/app/src/main/res/values-de-rCH/strings.xml
+++ b/app/src/main/res/values-de-rCH/strings.xml
@@ -96,16 +96,16 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_clothes_item_label">Kleidungsstück</string>
     <string name="settings_clothes_condition_label">Auslöser</string>
     <string name="settings_clothes_value_label_temp">Schwelle (%1$s)</string>
-    <string name="settings_clothes_value_label_precip">Schwelle (%)</string>
+    <string name="settings_clothes_value_label_rain">Schwelle (%)</string>
     <string name="settings_clothes_cond_type_temp_below">Wenn es sich kälter anfühlt als</string>
     <string name="settings_clothes_cond_type_temp_above">Wenn es sich wärmer anfühlt als</string>
-    <string name="settings_clothes_cond_type_precip_above">Wenn die Regenwahrscheinlichkeit über</string>
+    <string name="settings_clothes_cond_type_rain_above">Wenn die Regenwahrscheinlichkeit über</string>
 
     <!-- Row description for an existing rule. Mirrors the English templates
          in values/strings.xml. -->
     <string name="settings_clothes_cond_temp_below">wenn die gefühlte Mindesttemperatur unter %1$s liegt</string>
     <string name="settings_clothes_cond_temp_above">wenn die gefühlte Höchsttemperatur über %1$s liegt</string>
-    <string name="settings_clothes_cond_precip_above">wenn die Regenwahrscheinlichkeit über %.0f%% liegt</string>
+    <string name="settings_clothes_cond_rain_above">wenn die Regenwahrscheinlichkeit über %.0f%% liegt</string>
 
     <!--
     Schedule screen — daily and nightly ClothesCast cards, delivery picker,

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -76,16 +76,16 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_clothes_color_label">Farbe</string>
     <string name="settings_clothes_condition_label">Auslöser</string>
     <string name="settings_clothes_value_label_temp">Schwelle (%1$s)</string>
-    <string name="settings_clothes_value_label_precip">Schwelle (%)</string>
+    <string name="settings_clothes_value_label_rain">Schwelle (%)</string>
     <string name="settings_clothes_cond_type_temp_below">Wenn es sich kälter anfühlt als</string>
     <string name="settings_clothes_cond_type_temp_above">Wenn es sich wärmer anfühlt als</string>
-    <string name="settings_clothes_cond_type_precip_above">Wenn die Regenwahrscheinlichkeit über</string>
+    <string name="settings_clothes_cond_type_rain_above">Wenn die Regenwahrscheinlichkeit über</string>
 
     <!-- Row description for an existing rule. Mirrors the English templates
          in values/strings.xml. -->
     <string name="settings_clothes_cond_temp_below">wenn die gefühlte Mindesttemperatur unter %1$s liegt</string>
     <string name="settings_clothes_cond_temp_above">wenn die gefühlte Höchsttemperatur über %1$s liegt</string>
-    <string name="settings_clothes_cond_precip_above">wenn die Regenwahrscheinlichkeit über %.0f%% liegt</string>
+    <string name="settings_clothes_cond_rain_above">wenn die Regenwahrscheinlichkeit über %.0f%% liegt</string>
 
     <!--
     Schedule screen — daily and nightly ClothesCast cards, delivery picker,

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -91,13 +91,13 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_clothes_color_label">Χρώμα</string>
     <string name="settings_clothes_condition_label">Συνθήκη</string>
     <string name="settings_clothes_value_label_temp">Όριο (%1$s)</string>
-    <string name="settings_clothes_value_label_precip">Όριο (%)</string>
+    <string name="settings_clothes_value_label_rain">Όριο (%)</string>
     <string name="settings_clothes_cond_type_temp_below">Όταν η αισθητή θερμοκρασία είναι κάτω από</string>
     <string name="settings_clothes_cond_type_temp_above">Όταν η αισθητή θερμοκρασία είναι πάνω από</string>
-    <string name="settings_clothes_cond_type_precip_above">Όταν η πιθανότητα βροχής ξεπερνά</string>
+    <string name="settings_clothes_cond_type_rain_above">Όταν η πιθανότητα βροχής ξεπερνά</string>
     <string name="settings_clothes_cond_temp_below">όταν η ελάχιστη αισθητή θερμοκρασία είναι κάτω από %1$s</string>
     <string name="settings_clothes_cond_temp_above">όταν η μέγιστη αισθητή θερμοκρασία είναι πάνω από %1$s</string>
-    <string name="settings_clothes_cond_precip_above">όταν η πιθανότητα βροχής ξεπερνά %.0f%%</string>
+    <string name="settings_clothes_cond_rain_above">όταν η πιθανότητα βροχής ξεπερνά %.0f%%</string>
 
     <!--
     Schedule screen — daily and nightly ClothesCast cards, delivery

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -78,13 +78,13 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_clothes_color_label">Color</string>
     <string name="settings_clothes_condition_label">Condición</string>
     <string name="settings_clothes_value_label_temp">Umbral (%1$s)</string>
-    <string name="settings_clothes_value_label_precip">Umbral (%)</string>
+    <string name="settings_clothes_value_label_rain">Umbral (%)</string>
     <string name="settings_clothes_cond_type_temp_below">Cuando se siente menos de</string>
     <string name="settings_clothes_cond_type_temp_above">Cuando se siente más de</string>
-    <string name="settings_clothes_cond_type_precip_above">Cuando la probabilidad de lluvia supera</string>
+    <string name="settings_clothes_cond_type_rain_above">Cuando la probabilidad de lluvia supera</string>
     <string name="settings_clothes_cond_temp_below">cuando la temperatura percibida es inferior a %1$s</string>
     <string name="settings_clothes_cond_temp_above">cuando la temperatura percibida es superior a %1$s</string>
-    <string name="settings_clothes_cond_precip_above">cuando la probabilidad de lluvia supera %.0f%%</string>
+    <string name="settings_clothes_cond_rain_above">cuando la probabilidad de lluvia supera %.0f%%</string>
 
     <!--
     Schedule screen — daily and nightly ClothesCast cards, delivery

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -440,13 +440,13 @@ Tone is informal "sina"-form throughout ("Pane … selga", "Võta … kaasa",
     <string name="settings_clothes_color_label">Värv</string>
     <string name="settings_clothes_condition_label">Tingimus</string>
     <string name="settings_clothes_value_label_temp">Lävi (%1$s)</string>
-    <string name="settings_clothes_value_label_precip">Lävi (%)</string>
+    <string name="settings_clothes_value_label_rain">Lävi (%)</string>
     <string name="settings_clothes_cond_type_temp_below">Kui tundub külmem kui</string>
     <string name="settings_clothes_cond_type_temp_above">Kui tundub soojem kui</string>
-    <string name="settings_clothes_cond_type_precip_above">Kui vihma tõenäosus on üle</string>
+    <string name="settings_clothes_cond_type_rain_above">Kui vihma tõenäosus on üle</string>
     <string name="settings_clothes_cond_temp_below">kui tunnetatav temperatuur on alla %1$s</string>
     <string name="settings_clothes_cond_temp_above">kui tunnetatav temperatuur on üle %1$s</string>
-    <string name="settings_clothes_cond_precip_above">kui vihma tõenäosus on üle %.0f%%</string>
+    <string name="settings_clothes_cond_rain_above">kui vihma tõenäosus on üle %.0f%%</string>
 
     <string name="notification_channel_daily_insight_name">Igapäevane ClothesCast</string>
     <string name="notification_channel_daily_insight_description">Hommikune ilmakokkuvõte, millele oled tellinud.</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -36,13 +36,13 @@ Western Arabic numerals (0-9) are used for TTS compatibility.
     <string name="settings_clothes_color_label">رنگ</string>
     <string name="settings_clothes_condition_label">شرط</string>
     <string name="settings_clothes_value_label_temp">آستانه (%1$s)</string>
-    <string name="settings_clothes_value_label_precip">آستانه (%)</string>
+    <string name="settings_clothes_value_label_rain">آستانه (%)</string>
     <string name="settings_clothes_cond_type_temp_below">وقتی دمای احساس‌شده کمتر از</string>
     <string name="settings_clothes_cond_type_temp_above">وقتی دمای احساس‌شده بیشتر از</string>
-    <string name="settings_clothes_cond_type_precip_above">وقتی احتمال بارندگی بیشتر از</string>
+    <string name="settings_clothes_cond_type_rain_above">وقتی احتمال بارندگی بیشتر از</string>
     <string name="settings_clothes_cond_temp_below">وقتی حداقل دمای احساس‌شده کمتر از %1$s است</string>
     <string name="settings_clothes_cond_temp_above">وقتی حداکثر دمای احساس‌شده بیشتر از %1$s است</string>
-    <string name="settings_clothes_cond_precip_above">وقتی احتمال بارندگی بیشتر از %.0f%% است</string>
+    <string name="settings_clothes_cond_rain_above">وقتی احتمال بارندگی بیشتر از %.0f%% است</string>
 
     <string name="today_outfit_top_tshirt">تی‌شرت</string>
     <string name="today_outfit_top_sweater">پلیور</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -59,14 +59,14 @@ displayed label localizes.
     <string name="settings_clothes_color_label">Väri</string>
     <string name="settings_clothes_condition_label">Ehto</string>
     <string name="settings_clothes_value_label_temp">Raja-arvo (%1$s)</string>
-    <string name="settings_clothes_value_label_precip">Raja-arvo (%)</string>
+    <string name="settings_clothes_value_label_rain">Raja-arvo (%)</string>
     <string name="settings_clothes_cond_type_temp_below">Kun tuntuu kylmemmältä kuin</string>
     <string name="settings_clothes_cond_type_temp_above">Kun tuntuu lämpimämmältä kuin</string>
-    <string name="settings_clothes_cond_type_precip_above">Kun sateen todennäköisyys on yli</string>
+    <string name="settings_clothes_cond_type_rain_above">Kun sateen todennäköisyys on yli</string>
 
     <string name="settings_clothes_cond_temp_below">kun tuntuva lämpötila on alle %1$s</string>
     <string name="settings_clothes_cond_temp_above">kun tuntuva lämpötila on yli %1$s</string>
-    <string name="settings_clothes_cond_precip_above">kun sateen todennäköisyys on yli %.0f%%</string>
+    <string name="settings_clothes_cond_rain_above">kun sateen todennäköisyys on yli %.0f%%</string>
 
     <string name="settings_schedule_title">Päivittäinen ClothesCast</string>
     <string name="settings_schedule_time_label">Aika</string>

--- a/app/src/main/res/values-fil/strings.xml
+++ b/app/src/main/res/values-fil/strings.xml
@@ -32,13 +32,13 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="settings_clothes_color_label">Kulay</string>
     <string name="settings_clothes_condition_label">Kondisyon</string>
     <string name="settings_clothes_value_label_temp">Limitasyon (%1$s)</string>
-    <string name="settings_clothes_value_label_precip">Limitasyon (%)</string>
+    <string name="settings_clothes_value_label_rain">Limitasyon (%)</string>
     <string name="settings_clothes_cond_type_temp_below">Kapag malamig nang mas mababa sa</string>
     <string name="settings_clothes_cond_type_temp_above">Kapag mainit nang higit sa</string>
-    <string name="settings_clothes_cond_type_precip_above">Kapag ang tsansa ng ulan ay higit sa</string>
+    <string name="settings_clothes_cond_type_rain_above">Kapag ang tsansa ng ulan ay higit sa</string>
     <string name="settings_clothes_cond_temp_below">kapag ang nararamdamang pinakamababang temperatura ay mas mababa sa %1$s</string>
     <string name="settings_clothes_cond_temp_above">kapag ang nararamdamang pinakamataas na temperatura ay higit sa %1$s</string>
-    <string name="settings_clothes_cond_precip_above">kapag ang tsansa ng ulan ay higit sa %.0f%%</string>
+    <string name="settings_clothes_cond_rain_above">kapag ang tsansa ng ulan ay higit sa %.0f%%</string>
 
     <string name="today_outfit_top_tshirt">T-shirt</string>
     <string name="today_outfit_top_sweater">Sweater</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -78,13 +78,13 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_clothes_color_label">Couleur</string>
     <string name="settings_clothes_condition_label">Déclencheur</string>
     <string name="settings_clothes_value_label_temp">Seuil (%1$s)</string>
-    <string name="settings_clothes_value_label_precip">Seuil (%)</string>
+    <string name="settings_clothes_value_label_rain">Seuil (%)</string>
     <string name="settings_clothes_cond_type_temp_below">Quand il fait moins de</string>
     <string name="settings_clothes_cond_type_temp_above">Quand il fait plus de</string>
-    <string name="settings_clothes_cond_type_precip_above">Quand le risque de pluie dépasse</string>
+    <string name="settings_clothes_cond_type_rain_above">Quand le risque de pluie dépasse</string>
     <string name="settings_clothes_cond_temp_below">quand la température ressentie est en dessous de %1$s</string>
     <string name="settings_clothes_cond_temp_above">quand la température ressentie est au-dessus de %1$s</string>
-    <string name="settings_clothes_cond_precip_above">quand le risque de pluie dépasse %.0f%%</string>
+    <string name="settings_clothes_cond_rain_above">quand le risque de pluie dépasse %.0f%%</string>
 
     <!--
     Schedule screen — daily and nightly ClothesCast cards, delivery

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -68,13 +68,13 @@ Not overridden by design:
     <string name="settings_clothes_color_label">रंग</string>
     <string name="settings_clothes_condition_label">शर्त</string>
     <string name="settings_clothes_value_label_temp">सीमा (%1$s)</string>
-    <string name="settings_clothes_value_label_precip">सीमा (%)</string>
+    <string name="settings_clothes_value_label_rain">सीमा (%)</string>
     <string name="settings_clothes_cond_type_temp_below">जब महसूस हो उससे ठंडा</string>
     <string name="settings_clothes_cond_type_temp_above">जब महसूस हो उससे गर्म</string>
-    <string name="settings_clothes_cond_type_precip_above">जब बारिश की संभावना से अधिक</string>
+    <string name="settings_clothes_cond_type_rain_above">जब बारिश की संभावना से अधिक</string>
     <string name="settings_clothes_cond_temp_below">जब न्यूनतम महसूस तापमान %1$s से कम हो</string>
     <string name="settings_clothes_cond_temp_above">जब अधिकतम महसूस तापमान %1$s से अधिक हो</string>
-    <string name="settings_clothes_cond_precip_above">जब बारिश की संभावना %.0f%% से अधिक हो</string>
+    <string name="settings_clothes_cond_rain_above">जब बारिश की संभावना %.0f%% से अधिक हो</string>
 
     <!-- Schedule screen. -->
     <string name="settings_schedule_title">दैनिक ClothesCast</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -48,13 +48,13 @@ spousal register), matching the existing insight prose ("Ponesi …",
     <string name="settings_clothes_color_label">Boja</string>
     <string name="settings_clothes_condition_label">Uvjet</string>
     <string name="settings_clothes_value_label_temp">Prag (%1$s)</string>
-    <string name="settings_clothes_value_label_precip">Prag (%)</string>
+    <string name="settings_clothes_value_label_rain">Prag (%)</string>
     <string name="settings_clothes_cond_type_temp_below">Kada se osjeća hladnije od</string>
     <string name="settings_clothes_cond_type_temp_above">Kada se osjeća toplije od</string>
-    <string name="settings_clothes_cond_type_precip_above">Kada je vjerojatnost kiše veća od</string>
+    <string name="settings_clothes_cond_type_rain_above">Kada je vjerojatnost kiše veća od</string>
     <string name="settings_clothes_cond_temp_below">kada je osjećajna temperatura ispod %1$s</string>
     <string name="settings_clothes_cond_temp_above">kada je osjećajna temperatura iznad %1$s</string>
-    <string name="settings_clothes_cond_precip_above">kada je vjerojatnost kiše veća od %.0f%%</string>
+    <string name="settings_clothes_cond_rain_above">kada je vjerojatnost kiše veća od %.0f%%</string>
 
     <!--
     Schedule screen — daily and nightly ClothesCast cards, delivery

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -191,13 +191,13 @@ locale (Angol (Egyesült Államok), Francia (Franciaország), Német
     <string name="settings_clothes_color_label">Szín</string>
     <string name="settings_clothes_condition_label">Feltétel</string>
     <string name="settings_clothes_value_label_temp">Küszöb (%1$s)</string>
-    <string name="settings_clothes_value_label_precip">Küszöb (%)</string>
+    <string name="settings_clothes_value_label_rain">Küszöb (%)</string>
     <string name="settings_clothes_cond_type_temp_below">Ha hidegebbnek érződik mint</string>
     <string name="settings_clothes_cond_type_temp_above">Ha melegebbnek érződik mint</string>
-    <string name="settings_clothes_cond_type_precip_above">Ha az eső valószínűsége nagyobb mint</string>
+    <string name="settings_clothes_cond_type_rain_above">Ha az eső valószínűsége nagyobb mint</string>
     <string name="settings_clothes_cond_temp_below">ha a hőérzet %1$s alatt van</string>
     <string name="settings_clothes_cond_temp_above">ha a hőérzet %1$s felett van</string>
-    <string name="settings_clothes_cond_precip_above">ha az eső valószínűsége meghaladja a %.0f%%-ot</string>
+    <string name="settings_clothes_cond_rain_above">ha az eső valószínűsége meghaladja a %.0f%%-ot</string>
 
     <!-- Schedule screen. -->
     <string name="settings_schedule_title">Napi ClothesCast</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -34,13 +34,13 @@ to values/strings.xml (English).
     <string name="settings_clothes_color_label">Warna</string>
     <string name="settings_clothes_condition_label">Pemicu</string>
     <string name="settings_clothes_value_label_temp">Ambang batas (%1$s)</string>
-    <string name="settings_clothes_value_label_precip">Ambang batas (%)</string>
+    <string name="settings_clothes_value_label_rain">Ambang batas (%)</string>
     <string name="settings_clothes_cond_type_temp_below">Ketika terasa lebih dingin dari</string>
     <string name="settings_clothes_cond_type_temp_above">Ketika terasa lebih panas dari</string>
-    <string name="settings_clothes_cond_type_precip_above">Ketika kemungkinan hujan di atas</string>
+    <string name="settings_clothes_cond_type_rain_above">Ketika kemungkinan hujan di atas</string>
     <string name="settings_clothes_cond_temp_below">ketika suhu terasa di bawah %1$s</string>
     <string name="settings_clothes_cond_temp_above">ketika suhu terasa di atas %1$s</string>
-    <string name="settings_clothes_cond_precip_above">ketika kemungkinan hujan di atas %.0f%%</string>
+    <string name="settings_clothes_cond_rain_above">ketika kemungkinan hujan di atas %.0f%%</string>
 
     <string name="today_outfit_top_tshirt">Kaos</string>
     <string name="today_outfit_top_sweater">Sweater</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -66,13 +66,13 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_clothes_color_label">Colore</string>
     <string name="settings_clothes_condition_label">Condizione</string>
     <string name="settings_clothes_value_label_temp">Soglia (%1$s)</string>
-    <string name="settings_clothes_value_label_precip">Soglia (%)</string>
+    <string name="settings_clothes_value_label_rain">Soglia (%)</string>
     <string name="settings_clothes_cond_type_temp_below">Quando si percepisce meno di</string>
     <string name="settings_clothes_cond_type_temp_above">Quando si percepisce più di</string>
-    <string name="settings_clothes_cond_type_precip_above">Quando la probabilità di pioggia supera</string>
+    <string name="settings_clothes_cond_type_rain_above">Quando la probabilità di pioggia supera</string>
     <string name="settings_clothes_cond_temp_below">quando la temperatura percepita è sotto %1$s</string>
     <string name="settings_clothes_cond_temp_above">quando la temperatura percepita è sopra %1$s</string>
-    <string name="settings_clothes_cond_precip_above">quando la probabilità di pioggia supera %.0f%%</string>
+    <string name="settings_clothes_cond_rain_above">quando la probabilità di pioggia supera %.0f%%</string>
 
     <!--
     Schedule screen — daily and nightly ClothesCast cards, delivery

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -37,13 +37,13 @@ standard in Israeli digital communication.
     <string name="settings_clothes_color_label">צבע</string>
     <string name="settings_clothes_condition_label">תנאי</string>
     <string name="settings_clothes_value_label_temp">סף (%1$s)</string>
-    <string name="settings_clothes_value_label_precip">סף (%)</string>
+    <string name="settings_clothes_value_label_rain">סף (%)</string>
     <string name="settings_clothes_cond_type_temp_below">כאשר הטמפרטורה המורגשת נמוכה מ</string>
     <string name="settings_clothes_cond_type_temp_above">כאשר הטמפרטורה המורגשת גבוהה מ</string>
-    <string name="settings_clothes_cond_type_precip_above">כאשר הסיכוי לגשם גבוה מ</string>
+    <string name="settings_clothes_cond_type_rain_above">כאשר הסיכוי לגשם גבוה מ</string>
     <string name="settings_clothes_cond_temp_below">כשהטמפ׳ המורגשת המינימלית מתחת ל-%1$s</string>
     <string name="settings_clothes_cond_temp_above">כשהטמפ׳ המורגשת המקסימלית מעל %1$s</string>
-    <string name="settings_clothes_cond_precip_above">כשסיכוי הגשם מעל %.0f%%</string>
+    <string name="settings_clothes_cond_rain_above">כשסיכוי הגשם מעל %.0f%%</string>
 
     <string name="today_outfit_top_tshirt">חולצת טי</string>
     <string name="today_outfit_top_sweater">סוודר</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -76,13 +76,13 @@ the displayed label localizes.
     <string name="settings_clothes_color_label">色</string>
     <string name="settings_clothes_condition_label">条件</string>
     <string name="settings_clothes_value_label_temp">しきい値 (%1$s)</string>
-    <string name="settings_clothes_value_label_precip">しきい値 (%)</string>
+    <string name="settings_clothes_value_label_rain">しきい値 (%)</string>
     <string name="settings_clothes_cond_type_temp_below">体感温度が以下のとき</string>
     <string name="settings_clothes_cond_type_temp_above">体感温度が以上のとき</string>
-    <string name="settings_clothes_cond_type_precip_above">降水確率が以上のとき</string>
+    <string name="settings_clothes_cond_type_rain_above">降水確率が以上のとき</string>
     <string name="settings_clothes_cond_temp_below">最低体感温度が %1$s 未満のとき</string>
     <string name="settings_clothes_cond_temp_above">最高体感温度が %1$s を超えるとき</string>
-    <string name="settings_clothes_cond_precip_above">降水確率が %.0f%% を超えるとき</string>
+    <string name="settings_clothes_cond_rain_above">降水確率が %.0f%% を超えるとき</string>
 
     <!--
     Schedule screen — daily and nightly ClothesCast cards, delivery

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -80,13 +80,13 @@ displayed label localizes.
     <string name="settings_clothes_color_label">색상</string>
     <string name="settings_clothes_condition_label">조건</string>
     <string name="settings_clothes_value_label_temp">기준값 (%1$s)</string>
-    <string name="settings_clothes_value_label_precip">기준값 (%)</string>
+    <string name="settings_clothes_value_label_rain">기준값 (%)</string>
     <string name="settings_clothes_cond_type_temp_below">체감 온도가 다음보다 낮을 때</string>
     <string name="settings_clothes_cond_type_temp_above">체감 온도가 다음보다 높을 때</string>
-    <string name="settings_clothes_cond_type_precip_above">강수 확률이 다음보다 높을 때</string>
+    <string name="settings_clothes_cond_type_rain_above">강수 확률이 다음보다 높을 때</string>
     <string name="settings_clothes_cond_temp_below">최저 체감 온도가 %1$s 미만일 때</string>
     <string name="settings_clothes_cond_temp_above">최고 체감 온도가 %1$s 초과일 때</string>
-    <string name="settings_clothes_cond_precip_above">강수 확률이 %.0f%% 초과일 때</string>
+    <string name="settings_clothes_cond_rain_above">강수 확률이 %.0f%% 초과일 때</string>
 
     <!--
     Schedule screen — daily and nightly ClothesCast cards, delivery

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -39,13 +39,13 @@ What is NOT overridden, by design:
     <string name="settings_clothes_color_label">Spalva</string>
     <string name="settings_clothes_condition_label">Sąlyga</string>
     <string name="settings_clothes_value_label_temp">Riba (%1$s)</string>
-    <string name="settings_clothes_value_label_precip">Riba (%)</string>
+    <string name="settings_clothes_value_label_rain">Riba (%)</string>
     <string name="settings_clothes_cond_type_temp_below">Kai juntama šalčiau nei</string>
     <string name="settings_clothes_cond_type_temp_above">Kai juntama šilčiau nei</string>
-    <string name="settings_clothes_cond_type_precip_above">Kai lietaus tikimybė viršija</string>
+    <string name="settings_clothes_cond_type_rain_above">Kai lietaus tikimybė viršija</string>
     <string name="settings_clothes_cond_temp_below">kai pojūčio temperatūra žemiau %1$s</string>
     <string name="settings_clothes_cond_temp_above">kai pojūčio temperatūra aukščiau %1$s</string>
-    <string name="settings_clothes_cond_precip_above">kai lietaus tikimybė viršija %.0f%%</string>
+    <string name="settings_clothes_cond_rain_above">kai lietaus tikimybė viršija %.0f%%</string>
 
     <string name="today_outfit_top_tshirt">Marškinėliai</string>
     <string name="today_outfit_top_sweater">Megztinis</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -36,13 +36,13 @@ informal "tu"-form throughout ("Apģērb …", "Paņem … līdzi").
     <string name="settings_clothes_color_label">Krāsa</string>
     <string name="settings_clothes_condition_label">Nosacījums</string>
     <string name="settings_clothes_value_label_temp">Slieksnis (%1$s)</string>
-    <string name="settings_clothes_value_label_precip">Slieksnis (%)</string>
+    <string name="settings_clothes_value_label_rain">Slieksnis (%)</string>
     <string name="settings_clothes_cond_type_temp_below">Kad sajūtas vēsāks nekā</string>
     <string name="settings_clothes_cond_type_temp_above">Kad sajūtas siltāks nekā</string>
-    <string name="settings_clothes_cond_type_precip_above">Kad lietus iespējamība pārsniedz</string>
+    <string name="settings_clothes_cond_type_rain_above">Kad lietus iespējamība pārsniedz</string>
     <string name="settings_clothes_cond_temp_below">kad sajustā temperatūra ir zem %1$s</string>
     <string name="settings_clothes_cond_temp_above">kad sajustā temperatūra ir virs %1$s</string>
-    <string name="settings_clothes_cond_precip_above">kad lietus iespējamība pārsniedz %.0f%%</string>
+    <string name="settings_clothes_cond_rain_above">kad lietus iespējamība pārsniedz %.0f%%</string>
     <string name="settings_clothes_title">Apģērba noteikumi</string>
     <string name="settings_clothes_description">Ja prognoze pārsniedz kādu no šiem sliekšņiem, apģērbs parādās tavā ikdienas ClothesCast.</string>
 

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -34,13 +34,13 @@ vs "kemungkinan", "padam" vs "hapus").
     <string name="settings_clothes_color_label">Warna</string>
     <string name="settings_clothes_condition_label">Pencetus</string>
     <string name="settings_clothes_value_label_temp">Ambang (%1$s)</string>
-    <string name="settings_clothes_value_label_precip">Ambang (%)</string>
+    <string name="settings_clothes_value_label_rain">Ambang (%)</string>
     <string name="settings_clothes_cond_type_temp_below">Apabila terasa lebih sejuk daripada</string>
     <string name="settings_clothes_cond_type_temp_above">Apabila terasa lebih panas daripada</string>
-    <string name="settings_clothes_cond_type_precip_above">Apabila kebarangkalian hujan melebihi</string>
+    <string name="settings_clothes_cond_type_rain_above">Apabila kebarangkalian hujan melebihi</string>
     <string name="settings_clothes_cond_temp_below">apabila suhu terasa di bawah %1$s</string>
     <string name="settings_clothes_cond_temp_above">apabila suhu terasa di atas %1$s</string>
-    <string name="settings_clothes_cond_precip_above">apabila kebarangkalian hujan melebihi %.0f%%</string>
+    <string name="settings_clothes_cond_rain_above">apabila kebarangkalian hujan melebihi %.0f%%</string>
 
     <string name="today_outfit_top_tshirt">Kemeja-T</string>
     <string name="today_outfit_top_sweater">Baju panas</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -74,13 +74,13 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrike)").
     <string name="settings_clothes_color_label">Farge</string>
     <string name="settings_clothes_condition_label">Vilkår</string>
     <string name="settings_clothes_value_label_temp">Terskel (%1$s)</string>
-    <string name="settings_clothes_value_label_precip">Terskel (%)</string>
+    <string name="settings_clothes_value_label_rain">Terskel (%)</string>
     <string name="settings_clothes_cond_type_temp_below">Når det føles kaldere enn</string>
     <string name="settings_clothes_cond_type_temp_above">Når det føles varmere enn</string>
-    <string name="settings_clothes_cond_type_precip_above">Når regnsannsynligheten er over</string>
+    <string name="settings_clothes_cond_type_rain_above">Når regnsannsynligheten er over</string>
     <string name="settings_clothes_cond_temp_below">når følt temperatur er under %1$s</string>
     <string name="settings_clothes_cond_temp_above">når følt temperatur er over %1$s</string>
-    <string name="settings_clothes_cond_precip_above">når regnsannsynligheten er over %.0f%%</string>
+    <string name="settings_clothes_cond_rain_above">når regnsannsynligheten er over %.0f%%</string>
 
     <!-- Schedule screen. -->
     <string name="settings_schedule_title">Daglig ClothesCast</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -64,13 +64,13 @@ the displayed label localizes.
     <string name="settings_clothes_color_label">Kleur</string>
     <string name="settings_clothes_condition_label">Voorwaarde</string>
     <string name="settings_clothes_value_label_temp">Drempel (%1$s)</string>
-    <string name="settings_clothes_value_label_precip">Drempel (%)</string>
+    <string name="settings_clothes_value_label_rain">Drempel (%)</string>
     <string name="settings_clothes_cond_type_temp_below">Wanneer het kouder voelt dan</string>
     <string name="settings_clothes_cond_type_temp_above">Wanneer het warmer voelt dan</string>
-    <string name="settings_clothes_cond_type_precip_above">Wanneer de kans op regen groter is dan</string>
+    <string name="settings_clothes_cond_type_rain_above">Wanneer de kans op regen groter is dan</string>
     <string name="settings_clothes_cond_temp_below">wanneer de gevoelstemperatuur onder %1$s ligt</string>
     <string name="settings_clothes_cond_temp_above">wanneer de gevoelstemperatuur boven %1$s ligt</string>
-    <string name="settings_clothes_cond_precip_above">wanneer de kans op regen groter is dan %.0f%%</string>
+    <string name="settings_clothes_cond_rain_above">wanneer de kans op regen groter is dan %.0f%%</string>
 
     <!--
     Schedule screen.

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -64,13 +64,13 @@ is unchanged; only the displayed label localizes.
     <string name="settings_clothes_color_label">Kolor</string>
     <string name="settings_clothes_condition_label">Warunek</string>
     <string name="settings_clothes_value_label_temp">Próg (%1$s)</string>
-    <string name="settings_clothes_value_label_precip">Próg (%)</string>
+    <string name="settings_clothes_value_label_rain">Próg (%)</string>
     <string name="settings_clothes_cond_type_temp_below">Gdy odczuwalna temperatura spada poniżej</string>
     <string name="settings_clothes_cond_type_temp_above">Gdy odczuwalna temperatura przekracza</string>
-    <string name="settings_clothes_cond_type_precip_above">Gdy prawdopodobieństwo deszczu przekracza</string>
+    <string name="settings_clothes_cond_type_rain_above">Gdy prawdopodobieństwo deszczu przekracza</string>
     <string name="settings_clothes_cond_temp_below">gdy odczuwalna temperatura spada poniżej %1$s</string>
     <string name="settings_clothes_cond_temp_above">gdy odczuwalna temperatura przekracza %1$s</string>
-    <string name="settings_clothes_cond_precip_above">gdy prawdopodobieństwo deszczu przekracza %.0f%%</string>
+    <string name="settings_clothes_cond_rain_above">gdy prawdopodobieństwo deszczu przekracza %.0f%%</string>
 
     <!--
     Schedule screen.

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -83,13 +83,13 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_clothes_color_label">Cor</string>
     <string name="settings_clothes_condition_label">Condição</string>
     <string name="settings_clothes_value_label_temp">Limite (%1$s)</string>
-    <string name="settings_clothes_value_label_precip">Limite (%)</string>
+    <string name="settings_clothes_value_label_rain">Limite (%)</string>
     <string name="settings_clothes_cond_type_temp_below">Quando a sensação for menor que</string>
     <string name="settings_clothes_cond_type_temp_above">Quando a sensação for maior que</string>
-    <string name="settings_clothes_cond_type_precip_above">Quando a chance de chuva superar</string>
+    <string name="settings_clothes_cond_type_rain_above">Quando a chance de chuva superar</string>
     <string name="settings_clothes_cond_temp_below">quando a temperatura sentida for abaixo de %1$s</string>
     <string name="settings_clothes_cond_temp_above">quando a temperatura sentida for acima de %1$s</string>
-    <string name="settings_clothes_cond_precip_above">quando a chance de chuva superar %.0f%%</string>
+    <string name="settings_clothes_cond_rain_above">quando a chance de chuva superar %.0f%%</string>
 
     <!--
     Schedule screen — daily and nightly ClothesCast cards, delivery

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -99,13 +99,13 @@ they diverge from BR ("Polonês" → "Polaco", "Holandês" →
     <string name="settings_clothes_color_label">Cor</string>
     <string name="settings_clothes_condition_label">Condição</string>
     <string name="settings_clothes_value_label_temp">Limite (%1$s)</string>
-    <string name="settings_clothes_value_label_precip">Limite (%)</string>
+    <string name="settings_clothes_value_label_rain">Limite (%)</string>
     <string name="settings_clothes_cond_type_temp_below">Quando a sensação térmica for inferior a</string>
     <string name="settings_clothes_cond_type_temp_above">Quando a sensação térmica for superior a</string>
-    <string name="settings_clothes_cond_type_precip_above">Quando a probabilidade de chuva ultrapassar</string>
+    <string name="settings_clothes_cond_type_rain_above">Quando a probabilidade de chuva ultrapassar</string>
     <string name="settings_clothes_cond_temp_below">quando a temperatura sentida for inferior a %1$s</string>
     <string name="settings_clothes_cond_temp_above">quando a temperatura sentida for superior a %1$s</string>
-    <string name="settings_clothes_cond_precip_above">quando a probabilidade de chuva ultrapassar %.0f%%</string>
+    <string name="settings_clothes_cond_rain_above">quando a probabilidade de chuva ultrapassar %.0f%%</string>
 
     <!--
     Schedule screen — daily and nightly ClothesCast cards, delivery

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -33,13 +33,13 @@ surfaces fall back to default English (matching values-pl / values-uk).
     <string name="settings_clothes_color_label">Culoare</string>
     <string name="settings_clothes_condition_label">Condiție</string>
     <string name="settings_clothes_value_label_temp">Prag (%1$s)</string>
-    <string name="settings_clothes_value_label_precip">Prag (%)</string>
+    <string name="settings_clothes_value_label_rain">Prag (%)</string>
     <string name="settings_clothes_cond_type_temp_below">Când se simte mai rece de</string>
     <string name="settings_clothes_cond_type_temp_above">Când se simte mai cald de</string>
-    <string name="settings_clothes_cond_type_precip_above">Când probabilitatea de ploaie depășește</string>
+    <string name="settings_clothes_cond_type_rain_above">Când probabilitatea de ploaie depășește</string>
     <string name="settings_clothes_cond_temp_below">când temperatura resimțită este sub %1$s</string>
     <string name="settings_clothes_cond_temp_above">când temperatura resimțită este peste %1$s</string>
-    <string name="settings_clothes_cond_precip_above">când probabilitatea de ploaie depășește %.0f%%</string>
+    <string name="settings_clothes_cond_rain_above">când probabilitatea de ploaie depășește %.0f%%</string>
 
     <string name="today_outfit_top_tshirt">Tricou</string>
     <string name="today_outfit_top_sweater">Pulover</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -89,13 +89,13 @@ only the displayed label localizes.
     <string name="settings_clothes_color_label">Цвет</string>
     <string name="settings_clothes_condition_label">Условие</string>
     <string name="settings_clothes_value_label_temp">Порог (%1$s)</string>
-    <string name="settings_clothes_value_label_precip">Порог (%)</string>
+    <string name="settings_clothes_value_label_rain">Порог (%)</string>
     <string name="settings_clothes_cond_type_temp_below">Когда ощущается холоднее</string>
     <string name="settings_clothes_cond_type_temp_above">Когда ощущается теплее</string>
-    <string name="settings_clothes_cond_type_precip_above">Когда вероятность дождя превышает</string>
+    <string name="settings_clothes_cond_type_rain_above">Когда вероятность дождя превышает</string>
     <string name="settings_clothes_cond_temp_below">когда ощущаемая температура ниже %1$s</string>
     <string name="settings_clothes_cond_temp_above">когда ощущаемая температура выше %1$s</string>
-    <string name="settings_clothes_cond_precip_above">когда вероятность дождя превышает %.0f%%</string>
+    <string name="settings_clothes_cond_rain_above">когда вероятность дождя превышает %.0f%%</string>
 
     <!--
     Schedule screen — daily and nightly ClothesCast cards, delivery

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -192,13 +192,13 @@ What is NOT overridden, by design:
     <string name="settings_clothes_color_label">Farba</string>
     <string name="settings_clothes_condition_label">Podmienka</string>
     <string name="settings_clothes_value_label_temp">Prah (%1$s)</string>
-    <string name="settings_clothes_value_label_precip">Prah (%)</string>
+    <string name="settings_clothes_value_label_rain">Prah (%)</string>
     <string name="settings_clothes_cond_type_temp_below">Keď je pocitová pod</string>
     <string name="settings_clothes_cond_type_temp_above">Keď je pocitová nad</string>
-    <string name="settings_clothes_cond_type_precip_above">Keď je pravdepodobnosť dažďa nad</string>
+    <string name="settings_clothes_cond_type_rain_above">Keď je pravdepodobnosť dažďa nad</string>
     <string name="settings_clothes_cond_temp_below">keď je pocitová teplota pod %1$s</string>
     <string name="settings_clothes_cond_temp_above">keď je pocitová teplota nad %1$s</string>
-    <string name="settings_clothes_cond_precip_above">keď je pravdepodobnosť dažďa nad %.0f%%</string>
+    <string name="settings_clothes_cond_rain_above">keď je pravdepodobnosť dažďa nad %.0f%%</string>
 
     <!--
     Schedule screen.

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -32,13 +32,13 @@ informal "ti"-form throughout, mirroring the Croatian / Serbian pass.
     <string name="settings_clothes_color_label">Barva</string>
     <string name="settings_clothes_condition_label">Pogoj</string>
     <string name="settings_clothes_value_label_temp">Prag (%1$s)</string>
-    <string name="settings_clothes_value_label_precip">Prag (%)</string>
+    <string name="settings_clothes_value_label_rain">Prag (%)</string>
     <string name="settings_clothes_cond_type_temp_below">Ko se občuti hladneje kot</string>
     <string name="settings_clothes_cond_type_temp_above">Ko se občuti topleje kot</string>
-    <string name="settings_clothes_cond_type_precip_above">Ko je verjetnost dežja nad</string>
+    <string name="settings_clothes_cond_type_rain_above">Ko je verjetnost dežja nad</string>
     <string name="settings_clothes_cond_temp_below">ko je občutena temperatura pod %1$s</string>
     <string name="settings_clothes_cond_temp_above">ko je občutena temperatura nad %1$s</string>
-    <string name="settings_clothes_cond_precip_above">ko je verjetnost dežja nad %.0f%%</string>
+    <string name="settings_clothes_cond_rain_above">ko je verjetnost dežja nad %.0f%%</string>
 
     <string name="today_outfit_top_tshirt">Majica</string>
     <string name="today_outfit_top_sweater">Pulover</string>

--- a/app/src/main/res/values-sq/strings.xml
+++ b/app/src/main/res/values-sq/strings.xml
@@ -301,11 +301,11 @@
     <string name="settings_clothes_color_label">Ngjyra</string>
     <string name="settings_clothes_condition_label">Kushti</string>
     <string name="settings_clothes_value_label_temp">Pragu (%1$s)</string>
-    <string name="settings_clothes_value_label_precip">Pragu (%)</string>
+    <string name="settings_clothes_value_label_rain">Pragu (%)</string>
     <string name="settings_clothes_cond_type_temp_below">Kur ndihet më ftohtë se</string>
     <string name="settings_clothes_cond_type_temp_above">Kur ndihet më ngrohtë se</string>
-    <string name="settings_clothes_cond_type_precip_above">Kur mundësia e shiut është mbi</string>
+    <string name="settings_clothes_cond_type_rain_above">Kur mundësia e shiut është mbi</string>
     <string name="settings_clothes_cond_temp_below">kur temperatura e ndjeshme është nën %1$s</string>
     <string name="settings_clothes_cond_temp_above">kur temperatura e ndjeshme është mbi %1$s</string>
-    <string name="settings_clothes_cond_precip_above">kur mundësia e shiut është mbi %.0f%%</string>
+    <string name="settings_clothes_cond_rain_above">kur mundësia e shiut është mbi %.0f%%</string>
 </resources>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -74,13 +74,13 @@ native names for all locales (e.g. "Tyska (Tyskland)", "Franska (Frankrike)").
     <string name="settings_clothes_color_label">Färg</string>
     <string name="settings_clothes_condition_label">Villkor</string>
     <string name="settings_clothes_value_label_temp">Tröskel (%1$s)</string>
-    <string name="settings_clothes_value_label_precip">Tröskel (%)</string>
+    <string name="settings_clothes_value_label_rain">Tröskel (%)</string>
     <string name="settings_clothes_cond_type_temp_below">När det känns kallare än</string>
     <string name="settings_clothes_cond_type_temp_above">När det känns varmare än</string>
-    <string name="settings_clothes_cond_type_precip_above">När risken för regn överstiger</string>
+    <string name="settings_clothes_cond_type_rain_above">När risken för regn överstiger</string>
     <string name="settings_clothes_cond_temp_below">när upplevd temperatur är under %1$s</string>
     <string name="settings_clothes_cond_temp_above">när upplevd temperatur är över %1$s</string>
-    <string name="settings_clothes_cond_precip_above">när risken för regn överstiger %.0f%%</string>
+    <string name="settings_clothes_cond_rain_above">när risken för regn överstiger %.0f%%</string>
 
     <!-- Schedule screen. -->
     <string name="settings_schedule_title">Dagligt ClothesCast</string>

--- a/app/src/main/res/values-sw/strings.xml
+++ b/app/src/main/res/values-sw/strings.xml
@@ -32,13 +32,13 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="settings_clothes_color_label">Rangi</string>
     <string name="settings_clothes_condition_label">Hali</string>
     <string name="settings_clothes_value_label_temp">Kiwango (%1$s)</string>
-    <string name="settings_clothes_value_label_precip">Kiwango (%)</string>
+    <string name="settings_clothes_value_label_rain">Kiwango (%)</string>
     <string name="settings_clothes_cond_type_temp_below">Inapohisi baridi zaidi ya</string>
     <string name="settings_clothes_cond_type_temp_above">Inapohisi joto zaidi ya</string>
-    <string name="settings_clothes_cond_type_precip_above">Uwezekano wa mvua ni zaidi ya</string>
+    <string name="settings_clothes_cond_type_rain_above">Uwezekano wa mvua ni zaidi ya</string>
     <string name="settings_clothes_cond_temp_below">wakati joto la chini ni chini ya %1$s</string>
     <string name="settings_clothes_cond_temp_above">wakati joto la juu ni zaidi ya %1$s</string>
-    <string name="settings_clothes_cond_precip_above">wakati uwezekano wa mvua ni zaidi ya %.0f%%</string>
+    <string name="settings_clothes_cond_rain_above">wakati uwezekano wa mvua ni zaidi ya %.0f%%</string>
 
     <string name="today_outfit_top_tshirt">T-shati</string>
     <string name="today_outfit_top_sweater">Sweta</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -32,13 +32,13 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="settings_clothes_color_label">สี</string>
     <string name="settings_clothes_condition_label">เงื่อนไข</string>
     <string name="settings_clothes_value_label_temp">ค่าเกณฑ์ (%1$s)</string>
-    <string name="settings_clothes_value_label_precip">ค่าเกณฑ์ (%)</string>
+    <string name="settings_clothes_value_label_rain">ค่าเกณฑ์ (%)</string>
     <string name="settings_clothes_cond_type_temp_below">เมื่ออากาศรู้สึกหนาวกว่า</string>
     <string name="settings_clothes_cond_type_temp_above">เมื่ออากาศรู้สึกร้อนกว่า</string>
-    <string name="settings_clothes_cond_type_precip_above">เมื่อโอกาสฝนตกเกิน</string>
+    <string name="settings_clothes_cond_type_rain_above">เมื่อโอกาสฝนตกเกิน</string>
     <string name="settings_clothes_cond_temp_below">เมื่ออุณหภูมิที่รู้สึกต่ำกว่า %1$s</string>
     <string name="settings_clothes_cond_temp_above">เมื่ออุณหภูมิที่รู้สึกสูงกว่า %1$s</string>
-    <string name="settings_clothes_cond_precip_above">เมื่อโอกาสฝนตกเกิน %.0f%%</string>
+    <string name="settings_clothes_cond_rain_above">เมื่อโอกาสฝนตกเกิน %.0f%%</string>
 
     <string name="today_outfit_top_tshirt">เสื้อยืด</string>
     <string name="today_outfit_top_sweater">เสื้อกันหนาว</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -59,14 +59,14 @@ displayed label localizes.
     <string name="settings_clothes_color_label">Renk</string>
     <string name="settings_clothes_condition_label">Koşul</string>
     <string name="settings_clothes_value_label_temp">Eşik (%1$s)</string>
-    <string name="settings_clothes_value_label_precip">Eşik (%)</string>
+    <string name="settings_clothes_value_label_rain">Eşik (%)</string>
     <string name="settings_clothes_cond_type_temp_below">Hissedilen sıcaklık şundan düşükse</string>
     <string name="settings_clothes_cond_type_temp_above">Hissedilen sıcaklık şundan yüksekse</string>
-    <string name="settings_clothes_cond_type_precip_above">Yağmur ihtimali şunu aşarsa</string>
+    <string name="settings_clothes_cond_type_rain_above">Yağmur ihtimali şunu aşarsa</string>
 
     <string name="settings_clothes_cond_temp_below">hissedilen sıcaklık %1$s\'nin altındaysa</string>
     <string name="settings_clothes_cond_temp_above">hissedilen sıcaklık %1$s\'nin üstündeyse</string>
-    <string name="settings_clothes_cond_precip_above">yağmur ihtimali %.0f%% üzerindeyse</string>
+    <string name="settings_clothes_cond_rain_above">yağmur ihtimali %.0f%% üzerindeyse</string>
 
     <string name="settings_schedule_title">Günlük ClothesCast</string>
     <string name="settings_schedule_time_label">Saat</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -82,13 +82,13 @@ only the displayed label localizes.
     <string name="settings_clothes_color_label">Колір</string>
     <string name="settings_clothes_condition_label">Умова</string>
     <string name="settings_clothes_value_label_temp">Поріг (%1$s)</string>
-    <string name="settings_clothes_value_label_precip">Поріг (%)</string>
+    <string name="settings_clothes_value_label_rain">Поріг (%)</string>
     <string name="settings_clothes_cond_type_temp_below">Коли відчувається холодніше</string>
     <string name="settings_clothes_cond_type_temp_above">Коли відчувається тепліше</string>
-    <string name="settings_clothes_cond_type_precip_above">Коли ймовірність дощу перевищує</string>
+    <string name="settings_clothes_cond_type_rain_above">Коли ймовірність дощу перевищує</string>
     <string name="settings_clothes_cond_temp_below">коли відчувана температура нижче %1$s</string>
     <string name="settings_clothes_cond_temp_above">коли відчувана температура вище %1$s</string>
-    <string name="settings_clothes_cond_precip_above">коли ймовірність дощу перевищує %.0f%%</string>
+    <string name="settings_clothes_cond_rain_above">коли ймовірність дощу перевищує %.0f%%</string>
 
     <!-- Schedule screen. -->
     <string name="settings_schedule_title">Щоденний ClothesCast</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -37,13 +37,13 @@ Skipped intentionally: app_name (brand), insight_time_am/pm/midnight/noon
     <string name="settings_clothes_color_label">Màu</string>
     <string name="settings_clothes_condition_label">Điều kiện</string>
     <string name="settings_clothes_value_label_temp">Ngưỡng (%1$s)</string>
-    <string name="settings_clothes_value_label_precip">Ngưỡng (%)</string>
+    <string name="settings_clothes_value_label_rain">Ngưỡng (%)</string>
     <string name="settings_clothes_cond_type_temp_below">Khi cảm giác lạnh hơn</string>
     <string name="settings_clothes_cond_type_temp_above">Khi cảm giác nóng hơn</string>
-    <string name="settings_clothes_cond_type_precip_above">Khi khả năng mưa vượt</string>
+    <string name="settings_clothes_cond_type_rain_above">Khi khả năng mưa vượt</string>
     <string name="settings_clothes_cond_temp_below">khi nhiệt độ cảm nhận thấp nhất dưới %1$s</string>
     <string name="settings_clothes_cond_temp_above">khi nhiệt độ cảm nhận cao nhất trên %1$s</string>
-    <string name="settings_clothes_cond_precip_above">khi khả năng mưa vượt %.0f%%</string>
+    <string name="settings_clothes_cond_rain_above">khi khả năng mưa vượt %.0f%%</string>
 
     <string name="today_outfit_top_tshirt">Áo phông</string>
     <string name="today_outfit_top_sweater">Áo len</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -74,13 +74,13 @@ label localizes.
     <string name="settings_clothes_color_label">颜色</string>
     <string name="settings_clothes_condition_label">触发条件</string>
     <string name="settings_clothes_value_label_temp">阈值 (%1$s)</string>
-    <string name="settings_clothes_value_label_precip">阈值 (%)</string>
+    <string name="settings_clothes_value_label_rain">阈值 (%)</string>
     <string name="settings_clothes_cond_type_temp_below">当体感温度低于</string>
     <string name="settings_clothes_cond_type_temp_above">当体感温度高于</string>
-    <string name="settings_clothes_cond_type_precip_above">当降水概率超过</string>
+    <string name="settings_clothes_cond_type_rain_above">当降水概率超过</string>
     <string name="settings_clothes_cond_temp_below">当最低体感温度低于 %1$s 时</string>
     <string name="settings_clothes_cond_temp_above">当最高体感温度高于 %1$s 时</string>
-    <string name="settings_clothes_cond_precip_above">当降水概率超过 %.0f%% 时</string>
+    <string name="settings_clothes_cond_rain_above">当降水概率超过 %.0f%% 时</string>
 
     <!--
     Schedule screen — daily and nightly ClothesCast cards, delivery

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -83,13 +83,13 @@ label localises.
     <string name="settings_clothes_color_label">顏色</string>
     <string name="settings_clothes_condition_label">觸發條件</string>
     <string name="settings_clothes_value_label_temp">閾值 (%1$s)</string>
-    <string name="settings_clothes_value_label_precip">閾值 (%)</string>
+    <string name="settings_clothes_value_label_rain">閾值 (%)</string>
     <string name="settings_clothes_cond_type_temp_below">當體感溫度低於</string>
     <string name="settings_clothes_cond_type_temp_above">當體感溫度高於</string>
-    <string name="settings_clothes_cond_type_precip_above">當降水機率超過</string>
+    <string name="settings_clothes_cond_type_rain_above">當降水機率超過</string>
     <string name="settings_clothes_cond_temp_below">當最低體感溫度低於 %1$s 時</string>
     <string name="settings_clothes_cond_temp_above">當最高體感溫度高於 %1$s 時</string>
-    <string name="settings_clothes_cond_precip_above">當降水機率超過 %.0f%% 時</string>
+    <string name="settings_clothes_cond_rain_above">當降水機率超過 %.0f%% 時</string>
 
     <!--
     Schedule screen — daily and nightly ClothesCast cards, delivery

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1063,14 +1063,14 @@
     <string name="settings_clothes_color_label">Color</string>
     <string name="settings_clothes_condition_label">Trigger</string>
     <string name="settings_clothes_value_label_temp">Threshold (%1$s)</string>
-    <string name="settings_clothes_value_label_precip">Threshold (%)</string>
+    <string name="settings_clothes_value_label_rain">Threshold (%)</string>
     <string name="settings_clothes_cond_type_temp_below">When it feels colder than</string>
     <string name="settings_clothes_cond_type_temp_above">When it feels warmer than</string>
-    <string name="settings_clothes_cond_type_precip_above">When chance of rain is above</string>
+    <string name="settings_clothes_cond_type_rain_above">When chance of rain is above</string>
 
     <string name="settings_clothes_cond_temp_below">when temperature is below %1$s</string>
     <string name="settings_clothes_cond_temp_above">when temperature is above %1$s</string>
-    <string name="settings_clothes_cond_precip_above">when chance of rain is above %.0f%%</string>
+    <string name="settings_clothes_cond_rain_above">when chance of rain is above %.0f%%</string>
 
     <string name="notification_channel_daily_insight_name">Daily ClothesCast</string>
     <string name="notification_channel_daily_insight_description">The morning weather summary you opted in to.</string>

--- a/app/src/test/kotlin/app/clothescast/data/SettingsRepositoryTest.kt
+++ b/app/src/test/kotlin/app/clothescast/data/SettingsRepositoryTest.kt
@@ -39,6 +39,8 @@ import app.clothescast.diag.SettingsAnalyticsSnapshot
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
 import io.kotest.matchers.doubles.plusOrMinus
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
@@ -224,7 +226,7 @@ class SettingsRepositoryTest {
     @Test
     fun `umbrella migration appends the umbrella default to a stored list without it`() = runTest {
         // A user with a persisted rule list that predates the umbrella default
-        // gets it appended, keyed on a precipitation-probability condition.
+        // gets it appended, keyed on a rain-probability condition.
         val legacyJson = encodeRules(
             ClothesRule(Garment.SWEATER, ClothesRule.TemperatureBelow(16.0)),
         )
@@ -235,14 +237,39 @@ class SettingsRepositoryTest {
         val rules = decodeStoredRules(result[clothesRulesKey])
         rules.map { it.item } shouldBe listOf(Garment.SWEATER, Garment.UMBRELLA)
         val umbrellaRule = rules.first { it.item == Garment.UMBRELLA }
-        (umbrellaRule.condition is ClothesRule.PrecipitationProbabilityAbove) shouldBe true
+        (umbrellaRule.condition is ClothesRule.RainProbabilityAbove) shouldBe true
+    }
+
+    @Test
+    fun `legacy precip_above wire token still decodes to a rain rule`() {
+        // The precipitation→rain rename moved the canonical on-disk token to
+        // "rain_above", but the older "precip_above" token (written by earlier
+        // builds) is still read so rules saved before the rename keep loading.
+        // Decode a hand-written legacy blob.
+        val legacy = """[{"item":"umbrella","type":"precip_above","value":30.0}]"""
+
+        val rules = decodeStoredRules(legacy)
+
+        rules.map { it.item } shouldBe listOf(Garment.UMBRELLA)
+        (rules.single().condition as ClothesRule.RainProbabilityAbove).percent shouldBe 30.0
+    }
+
+    @Test
+    fun `rain rules now write the rain_above wire token`() {
+        // New writes use the renamed token; round-trips through the read path
+        // too. Guards against accidentally reintroducing "precip_above" on write.
+        val json = encodeRules(ClothesRule(Garment.UMBRELLA, ClothesRule.RainProbabilityAbove(30.0)))
+
+        json shouldContain "\"type\":\"rain_above\""
+        json shouldNotContain "precip_above"
+        (decodeStoredRules(json).single().condition as ClothesRule.RainProbabilityAbove).percent shouldBe 30.0
     }
 
     @Test
     fun `umbrella migration does not duplicate an existing umbrella rule`() = runTest {
         val withUmbrella = encodeRules(
             ClothesRule(Garment.SWEATER, ClothesRule.TemperatureBelow(16.0)),
-            ClothesRule(Garment.UMBRELLA, ClothesRule.PrecipitationProbabilityAbove(50.0)),
+            ClothesRule(Garment.UMBRELLA, ClothesRule.RainProbabilityAbove(50.0)),
         )
         val before = mutablePreferencesOf(clothesRulesKey to withUmbrella)
 
@@ -251,7 +278,7 @@ class SettingsRepositoryTest {
         val rules = decodeStoredRules(result[clothesRulesKey])
         rules.count { it.item == Garment.UMBRELLA } shouldBe 1
         // The user's customised gate survives — we don't reset it to the default.
-        (rules.first { it.item == Garment.UMBRELLA }.condition as ClothesRule.PrecipitationProbabilityAbove)
+        (rules.first { it.item == Garment.UMBRELLA }.condition as ClothesRule.RainProbabilityAbove)
             .percent shouldBe 50.0
     }
 
@@ -514,7 +541,7 @@ class SettingsRepositoryTest {
         val rules = listOf(
             ClothesRule(Garment.SWEATER, ClothesRule.TemperatureBelow(5.0)),
             ClothesRule(Garment.SHORTS, ClothesRule.TemperatureAbove(28.5)),
-            ClothesRule(Garment.JACKET, ClothesRule.PrecipitationProbabilityAbove(40.0)),
+            ClothesRule(Garment.JACKET, ClothesRule.RainProbabilityAbove(40.0)),
         )
 
         subject.setClothesRules(rules)

--- a/app/src/test/kotlin/app/clothescast/diag/ClothesRulesSnapshotTest.kt
+++ b/app/src/test/kotlin/app/clothescast/diag/ClothesRulesSnapshotTest.kt
@@ -31,7 +31,7 @@ class ClothesRulesSnapshotTest {
         // silently report "0" the way routing it through the °C bucket would.
         val rules = ClothesRule.DEFAULTS.map { rule ->
             if (rule.item == Garment.UMBRELLA) {
-                rule.copy(condition = ClothesRule.PrecipitationProbabilityAbove(60.0))
+                rule.copy(condition = ClothesRule.RainProbabilityAbove(60.0))
             } else {
                 rule
             }
@@ -50,7 +50,7 @@ class ClothesRulesSnapshotTest {
         // Default 30% → 10% is a -20pp change.
         val rules = ClothesRule.DEFAULTS.map { rule ->
             if (rule.item == Garment.UMBRELLA) {
-                rule.copy(condition = ClothesRule.PrecipitationProbabilityAbove(10.0))
+                rule.copy(condition = ClothesRule.RainProbabilityAbove(10.0))
             } else {
                 rule
             }

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/ClothesRule.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/ClothesRule.kt
@@ -6,8 +6,8 @@ package app.clothescast.core.domain.model
  *
  * Temperature thresholds are checked against "feels like" (apparent) values rather
  * than raw 2 m air temperature — what the user actually experiences when stepping
- * outside, factoring in wind chill and humidity. Precipitation rules check the day's
- * peak probability.
+ * outside, factoring in wind chill and humidity. Rain rules check the day's peak
+ * chance of rain — rain specifically, not snow (see [RainProbabilityAbove]).
  *
  * [item] is a typed [Garment]; the on-disk DTO stores its key as a string and
  * drops any stored rule whose key isn't in the catalog (legacy free-form items
@@ -64,8 +64,22 @@ data class ClothesRule(
             forecast.feelsLikeMaxC > value.fromUnit(unit)
     }
 
-    data class PrecipitationProbabilityAbove(val percent: Double) : Condition {
-        override fun matches(forecast: DailyForecast) = forecast.precipitationProbabilityMaxPct > percent
+    /**
+     * Rain-chance threshold: matches when the day's peak chance of rain clears
+     * [percent]. "Rain" specifically — not snow. The forecast carries a single
+     * precipitation-probability series (Open-Meteo doesn't split rain vs. snow
+     * probability), so "is it rain" is decided from the day's [condition]: the
+     * rule clears when the probability is above [percent] **and** the day isn't
+     * snowing ([isFrozenPrecipitation]). A high-probability hour the weather
+     * code happens to label overcast (88% chance, ~0 mm accumulation) still
+     * counts as rain — only frozen precipitation is excluded — so a rain rule
+     * fires on exactly the days the insight prose announces rain, and stays off
+     * a snowy day (where the snow probability would otherwise clear the gate).
+     */
+    data class RainProbabilityAbove(val percent: Double) : Condition {
+        override fun matches(forecast: DailyForecast) =
+            forecast.precipitationProbabilityMaxPct > percent &&
+                !forecast.condition.isFrozenPrecipitation()
     }
 
     companion object {
@@ -73,13 +87,15 @@ data class ClothesRule(
         // align with the `today_outfit_top_*` labels in values/strings.xml.
         // Per-language phrasers translate at format time
         // (e.g. GermanClothesPhraser maps "sweater" → "Pullover").
-        // The umbrella ships as a precip-keyed default (carried accessory):
-        // when the day's peak rain probability clears 30% we suggest bringing
+        // The umbrella ships as a rain-keyed default (carried accessory):
+        // when the day's peak chance of rain clears 30% we suggest bringing
         // one, folded into the insight's rain clause ("Rain at 3pm, bring an
-        // umbrella."). Like every default it's editable — the user can lower /
-        // raise the gate or delete the rule entirely from the clothes-rule
-        // editor. The 30% gate mirrors the POSSIBLE rain tier the morning
-        // insight already uses to mention rain at all.
+        // umbrella."). [RainProbabilityAbove] excludes snow, so the umbrella
+        // stays off a snowy day even though snow would clear the probability.
+        // Like every default it's editable — the user can lower / raise the
+        // gate or delete the rule entirely from the clothes-rule editor. The
+        // 30% gate mirrors the POSSIBLE rain tier the morning insight already
+        // uses to mention rain at all.
         // TODO(rain-accessory-variants): broaden the carried-accessory rules
         //  beyond the umbrella (rain jacket, hood, rain boots, …) once the
         //  resource strings and per-locale phrasers cover them.
@@ -89,7 +105,7 @@ data class ClothesRule(
             ClothesRule(Garment.COAT, TemperatureBelow(4.0)),
             ClothesRule(Garment.GLOVES, TemperatureBelow(4.0)),
             ClothesRule(Garment.SHORTS, TemperatureAbove(23.0)),
-            ClothesRule(Garment.UMBRELLA, PrecipitationProbabilityAbove(30.0)),
+            ClothesRule(Garment.UMBRELLA, RainProbabilityAbove(30.0)),
         )
 
         /** Sanity bounds in °C for the rationale dialog's `+1°` / `−1°` taps. Wide enough
@@ -104,11 +120,11 @@ data class ClothesRule(
 
 /**
  * The Celsius-equivalent threshold of a temperature-keyed rule, regardless of
- * which unit the user typed it in. Returns `null` for [ClothesRule.PrecipitationProbabilityAbove].
+ * which unit the user typed it in. Returns `null` for [ClothesRule.RainProbabilityAbove].
  */
 fun ClothesRule.thresholdC(): Double? = when (val c = condition) {
     is ClothesRule.TemperatureBelow -> c.value.fromUnit(c.unit)
     is ClothesRule.TemperatureAbove -> c.value.fromUnit(c.unit)
-    is ClothesRule.PrecipitationProbabilityAbove -> null
+    is ClothesRule.RainProbabilityAbove -> null
 }
 

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/FallbackRange.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/FallbackRange.kt
@@ -64,7 +64,7 @@ fun fallbackRange(rules: List<ClothesRule>, tier: FallbackTier): FallbackRange {
             is ClothesRule.TemperatureAbove -> {
                 if (upper == null || threshold < upper) upper = threshold
             }
-            is ClothesRule.PrecipitationProbabilityAbove -> Unit
+            is ClothesRule.RainProbabilityAbove -> Unit
         }
     }
     return FallbackRange(lowerC = lower, upperC = upper)

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/OutfitSuggestion.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/OutfitSuggestion.kt
@@ -197,15 +197,11 @@ data class OutfitSuggestion(
             defaultTop: Top = Top.TSHIRT,
         ): OutfitSuggestion =
             pickOutfit(
-                // Mirror EvaluateClothesRules' carried-accessory gate: the
-                // umbrella surfaces once its probability gate clears unless the
-                // precipitation is frozen (snow), so the next-period icon agrees
-                // with the primary path. See [isFrozenPrecipitation] for why this
-                // excludes only snow rather than requiring a wet weather code.
-                clothesRules.filter {
-                    it.appliesTo(forecast) &&
-                        !(it.item.slot == Garment.Slot.CARRIED && forecast.condition.isFrozenPrecipitation())
-                },
+                // A rain rule ([ClothesRule.RainProbabilityAbove]) excludes snow
+                // itself, so the umbrella simply doesn't match on a snowy day —
+                // no separate carried-slot gate needed for the next-period icon
+                // to agree with the primary [EvaluateClothesRules] path.
+                clothesRules.filter { it.appliesTo(forecast) },
                 defaultTop,
                 defaultBottom,
             )

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Precipitation.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Precipitation.kt
@@ -48,22 +48,18 @@ fun WeatherCondition.warrantsRainAccessory(): Boolean = when (this) {
  * True when this condition is frozen precipitation — snow — which an umbrella
  * doesn't shelter against.
  *
- * This is the carried-accessory gate the *rule engine* uses
- * ([EvaluateClothesRules], mirrored in [OutfitSuggestion.fromForecast]), and
- * it's deliberately the inverse-minus-snow of [warrantsRainAccessory] rather
- * than `!warrantsRainAccessory()`. The rule engine reads the raw daily
- * `condition` — the weather code of the day's peak-*probability* hour — which
- * routinely under-calls the precipitation *type*: an hour can sit at 88% chance
- * of rain yet carry an "overcast" code because its modeled accumulation is ~0
- * (high probability, little rain). Gating the umbrella on "is the code wet"
- * there drops it on exactly those days, even though the insight prose still
- * announces the rain (the prose coerces a high-probability hour to RAIN via
- * `perModelConditionAt`, then gates its "bring an umbrella" clause on
- * [warrantsRainAccessory] against that coerced condition). The rule engine
- * can't coerce, so it gates on "not snow" instead — the umbrella's purpose is
- * solely to keep it off a *snowy* day (snow can clear the probability gate too,
- * and you don't umbrella snow). Any rain-shaped or dry-coded-but-likely day
- * keeps the umbrella, so the card and the prose agree.
+ * This is how a rain rule ([ClothesRule.RainProbabilityAbove]) tells rain from
+ * snow. It's deliberately "is it snow" rather than `!warrantsRainAccessory()`:
+ * the rule reads the raw daily `condition` — the weather code of the day's
+ * peak-*probability* hour — which routinely under-calls the precipitation
+ * *type*. An hour can sit at 88% chance of rain yet carry an "overcast" code
+ * because its modeled accumulation is ~0 (high probability, little rain).
+ * Requiring a *wet* code would drop the umbrella on exactly those days, even
+ * though the insight prose still announces the rain (the prose coerces a
+ * high-probability hour to RAIN via `perModelConditionAt`). Excluding only
+ * snow keeps any rain-shaped — or dry-coded-but-likely — day as rain, while a
+ * genuinely snowy day (whose peak-probability hour is coded snow) doesn't
+ * count as rain, so its snow probability can't clear a rain rule's gate.
  */
 internal fun WeatherCondition.isFrozenPrecipitation(): Boolean = this == WeatherCondition.SNOW
 

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/EvaluateClothesRules.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/EvaluateClothesRules.kt
@@ -5,7 +5,6 @@ import app.clothescast.core.domain.model.DailyForecast
 import app.clothescast.core.domain.model.Garment
 import app.clothescast.core.domain.model.OutfitSuggestion
 import app.clothescast.core.domain.model.TriggeredOutfit
-import app.clothescast.core.domain.model.isFrozenPrecipitation
 
 /**
  * Resolves the day's outfit from the forecast: the user's threshold
@@ -34,26 +33,15 @@ class EvaluateClothesRules {
         defaultTop: OutfitSuggestion.Top = OutfitSuggestion.Top.TSHIRT,
         defaultBottom: OutfitSuggestion.Bottom = OutfitSuggestion.Bottom.LONG_PANTS,
     ): TriggeredOutfit {
+        // Snow no longer needs a special carried-slot gate here: a rain rule
+        // ([ClothesRule.RainProbabilityAbove]) excludes snow itself, so the
+        // umbrella default — and any user rain rule — simply doesn't match on a
+        // snowy day. That keeps the single rule-evaluation chokepoint (icon,
+        // recommendations, prose) reading from one place.
         val matched = rules.filter { it.appliesTo(forecast) }
-            // A carried accessory (the umbrella) is rain gear: it surfaces once
-            // its probability gate clears, *unless* the precipitation is frozen.
-            // The umbrella default keys off aggregate precipitation *probability*,
-            // which can clear its gate on a snowy day — and you don't umbrella
-            // snow — so gate the carried slot on snow here, at the single
-            // rule-evaluation chokepoint the icon, the recommendations, and the
-            // prose all read from. We deliberately exclude *only* snow rather
-            // than requiring a wet code ([warrantsRainAccessory]): the raw daily
-            // condition is the peak-*probability* hour's weather code, which can
-            // read "overcast" at 88% chance of rain when accumulation is ~0, and
-            // requiring a wet code there would drop the umbrella on exactly the
-            // day the prose still announces rain. See [isFrozenPrecipitation].
-            // Worn garments (tops/bottoms/gloves) are unaffected.
-            .filterNot {
-                it.item.slot == Garment.Slot.CARRIED && forecast.condition.isFrozenPrecipitation()
-            }
         // Every [ClothesRule.item] is a catalog [Garment], so each matched rule
         // claims a known slot. A slot covered by a matched rule (whether keyed
-        // on temperature or precipitation) doesn't also get its per-tier default.
+        // on temperature or rain) doesn't also get its per-tier default.
         //
         // The base top is the exception: a [Garment.Layer.OUTER] shell (the rain
         // jacket) is worn *over* a base top, not in place of one, so it doesn't

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/model/ClothesRuleTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/model/ClothesRuleTest.kt
@@ -90,15 +90,25 @@ class ClothesRuleTest {
     }
 
     @Test
-    fun `precipitation rule uses peak probability`() {
-        val rule = ClothesRule(Garment.JACKET, ClothesRule.PrecipitationProbabilityAbove(50.0))
+    fun `rain rule uses peak chance of rain`() {
+        val rule = ClothesRule(Garment.JACKET, ClothesRule.RainProbabilityAbove(50.0))
         rule.appliesTo(forecast(min = 10.0, max = 18.0, precip = 65.0)) shouldBe true
         rule.appliesTo(forecast(min = 10.0, max = 18.0, precip = 30.0)) shouldBe false
     }
 
     @Test
-    fun `defaults cover the temperature cases plus the precip-keyed umbrella`() {
-        // The umbrella ships as a precip-keyed default (peak rain probability
+    fun `rain rule excludes snow even above the gate`() {
+        // "Rain" means rain, not snow: an 80% snowy day clears the numeric gate
+        // but isn't rain, so the rule doesn't apply. A high-chance overcast day
+        // (no wet code, but not snow) still counts as rain.
+        val rule = ClothesRule(Garment.UMBRELLA, ClothesRule.RainProbabilityAbove(30.0))
+        rule.appliesTo(forecast(min = -2.0, max = 2.0, precip = 80.0).copy(condition = WeatherCondition.SNOW)) shouldBe false
+        rule.appliesTo(forecast(min = 9.0, max = 15.0, precip = 80.0).copy(condition = WeatherCondition.CLOUDY)) shouldBe true
+    }
+
+    @Test
+    fun `defaults cover the temperature cases plus the rain-keyed umbrella`() {
+        // The umbrella ships as a rain-keyed default (peak chance of rain
         // above 30%); the temperature rules cover the cold / warm cases.
         val items = ClothesRule.DEFAULTS.map { it.item.itemKey }
         items shouldBe listOf("sweater", "jacket", "coat", "gloves", "shorts", "umbrella")

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/model/FallbackRangeTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/model/FallbackRangeTest.kt
@@ -44,7 +44,7 @@ class FallbackRangeTest {
     @Test
     fun `precipitation rules are ignored`() {
         fallbackRange(
-            listOf(ClothesRule(Garment.SWEATER, ClothesRule.PrecipitationProbabilityAbove(30.0))),
+            listOf(ClothesRule(Garment.SWEATER, ClothesRule.RainProbabilityAbove(30.0))),
             FallbackTier.TOP,
         ) shouldBe FallbackRange(null, null)
     }

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/model/GarmentTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/model/GarmentTest.kt
@@ -84,7 +84,7 @@ class GarmentTest {
         // umbrella) and never displaces a top or bottom.
         val rules = listOf(
             ClothesRule(Garment.SWEATER, ClothesRule.TemperatureBelow(16.0)),
-            ClothesRule(Garment.UMBRELLA, ClothesRule.PrecipitationProbabilityAbove(50.0)),
+            ClothesRule(Garment.UMBRELLA, ClothesRule.RainProbabilityAbove(50.0)),
         )
         Garment.layerReduce(rules) shouldBe rules
     }
@@ -102,7 +102,7 @@ class GarmentTest {
         Garment.isAccessoryKey("rain-jacket") shouldBe false
         val rules = listOf(
             ClothesRule(Garment.SWEATER, ClothesRule.TemperatureBelow(16.0)),
-            ClothesRule(Garment.RAIN_JACKET, ClothesRule.PrecipitationProbabilityAbove(30.0)),
+            ClothesRule(Garment.RAIN_JACKET, ClothesRule.RainProbabilityAbove(30.0)),
         )
         Garment.layerReduce(rules) shouldBe rules
     }
@@ -115,7 +115,7 @@ class GarmentTest {
         // prose then matches the icon, which shows the shell over the base top.
         val baseAndShell = listOf(
             ClothesRule(Garment.TSHIRT, ClothesRule.TemperatureAbove(20.0)),
-            ClothesRule(Garment.RAIN_JACKET, ClothesRule.PrecipitationProbabilityAbove(30.0)),
+            ClothesRule(Garment.RAIN_JACKET, ClothesRule.RainProbabilityAbove(30.0)),
         )
         Garment.layerReduce(baseAndShell) shouldBe baseAndShell
 
@@ -124,7 +124,7 @@ class GarmentTest {
         val baseMidShell = listOf(
             ClothesRule(Garment.TSHIRT, ClothesRule.TemperatureAbove(20.0)),
             ClothesRule(Garment.SWEATER, ClothesRule.TemperatureBelow(16.0)),
-            ClothesRule(Garment.RAIN_JACKET, ClothesRule.PrecipitationProbabilityAbove(30.0)),
+            ClothesRule(Garment.RAIN_JACKET, ClothesRule.RainProbabilityAbove(30.0)),
         )
         Garment.layerReduce(baseMidShell) shouldBe listOf(baseMidShell[1], baseMidShell[2])
     }

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/model/OutfitSuggestionTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/model/OutfitSuggestionTest.kt
@@ -408,13 +408,13 @@ class OutfitSuggestionTest {
     }
 
     @Test
-    fun `precipitation-keyed t-shirt rule drives the icon without crashing the rationale`() {
-        // Settings lets a user key any garment — a top included — off
-        // precipitation. On a rainy day such a rule fires and drives the icon
+    fun `rain-keyed t-shirt rule drives the icon without crashing the rationale`() {
+        // Settings lets a user key any garment — a top included — off the
+        // chance of rain. On a rainy day such a rule fires and drives the icon
         // (TSHIRT here, beating the POLO default), but it carries no temperature
         // threshold: the rationale must skip it and fall back to a temperature
         // rule rather than throw in toFact.
-        val rules = listOf(ClothesRule(Garment.TSHIRT, ClothesRule.PrecipitationProbabilityAbove(50.0)))
+        val rules = listOf(ClothesRule(Garment.TSHIRT, ClothesRule.RainProbabilityAbove(50.0)))
         val rainy = forecast(feelsLikeMin = 12.0, feelsLikeMax = 20.0, precipMaxPct = 60.0)
 
         OutfitSuggestion.fromForecast(
@@ -500,7 +500,7 @@ class OutfitSuggestionTest {
         // when the day's precip probability crosses its threshold and the
         // condition is wet (rain).
         val umbrellaRules = listOf(
-            ClothesRule(Garment.UMBRELLA, ClothesRule.PrecipitationProbabilityAbove(30.0)),
+            ClothesRule(Garment.UMBRELLA, ClothesRule.RainProbabilityAbove(30.0)),
         )
         val outfit = OutfitSuggestion.fromForecast(
             forecast(
@@ -519,7 +519,7 @@ class OutfitSuggestionTest {
         // Thunderstorm is treated as rain: it's a wet forecast the user wants an
         // umbrella for, so the carried slot fires (consistent with the prose).
         val umbrellaRules = listOf(
-            ClothesRule(Garment.UMBRELLA, ClothesRule.PrecipitationProbabilityAbove(30.0)),
+            ClothesRule(Garment.UMBRELLA, ClothesRule.RainProbabilityAbove(30.0)),
         )
         val outfit = OutfitSuggestion.fromForecast(
             forecast(
@@ -538,9 +538,9 @@ class OutfitSuggestionTest {
         // The bug case: 88% chance of rain, but the peak-probability hour's
         // weather code is overcast (high probability, ~0mm accumulation), so the
         // raw daily condition is CLOUDY rather than a wet code. The umbrella must
-        // still light, matching the prose, since only snow suppresses it.
+        // still light, matching the prose, since a rain rule excludes only snow.
         val umbrellaRules = listOf(
-            ClothesRule(Garment.UMBRELLA, ClothesRule.PrecipitationProbabilityAbove(30.0)),
+            ClothesRule(Garment.UMBRELLA, ClothesRule.RainProbabilityAbove(30.0)),
         )
         val outfit = OutfitSuggestion.fromForecast(
             forecast(
@@ -555,12 +555,12 @@ class OutfitSuggestionTest {
     }
 
     @Test
-    fun `a snowy day suppresses the carried umbrella even above the gate`() {
-        // The umbrella default keys off aggregate precip probability, which can
-        // clear its gate on a snowy day — but snow isn't wet-in-the-umbrella
-        // sense, so the carried slot stays null and no umbrella icon shows.
+    fun `a snowy day does not light the carried umbrella even above the gate`() {
+        // A rain rule excludes snow, so an 80% snowy day — whose probability
+        // would otherwise clear the umbrella's gate — doesn't match it, and the
+        // carried slot stays null with no umbrella icon.
         val umbrellaRules = listOf(
-            ClothesRule(Garment.UMBRELLA, ClothesRule.PrecipitationProbabilityAbove(30.0)),
+            ClothesRule(Garment.UMBRELLA, ClothesRule.RainProbabilityAbove(30.0)),
         )
         val outfit = OutfitSuggestion.fromForecast(
             forecast(
@@ -580,7 +580,7 @@ class OutfitSuggestionTest {
         // leaves it null rather than promoting to a default, so no umbrella icon
         // shows when the user hasn't earned one.
         val umbrellaRules = listOf(
-            ClothesRule(Garment.UMBRELLA, ClothesRule.PrecipitationProbabilityAbove(30.0)),
+            ClothesRule(Garment.UMBRELLA, ClothesRule.RainProbabilityAbove(30.0)),
         )
         val outfit = OutfitSuggestion.fromForecast(
             forecast(feelsLikeMin = 12.0, feelsLikeMax = 18.0, precipMaxPct = 10.0),
@@ -597,7 +597,7 @@ class OutfitSuggestionTest {
             rules = listOf(
                 ClothesRule(Garment.COAT, ClothesRule.TemperatureBelow(5.0)),
                 ClothesRule(Garment.GLOVES, ClothesRule.TemperatureBelow(4.0)),
-                ClothesRule(Garment.UMBRELLA, ClothesRule.PrecipitationProbabilityAbove(30.0)),
+                ClothesRule(Garment.UMBRELLA, ClothesRule.RainProbabilityAbove(30.0)),
             ),
             fallbacks = emptyList(),
         )
@@ -625,7 +625,7 @@ class OutfitSuggestionTest {
         // rules picked (here the sweater) intact underneath.
         val rules = listOf(
             ClothesRule(Garment.SWEATER, ClothesRule.TemperatureBelow(16.0)),
-            ClothesRule(Garment.RAIN_JACKET, ClothesRule.PrecipitationProbabilityAbove(30.0)),
+            ClothesRule(Garment.RAIN_JACKET, ClothesRule.RainProbabilityAbove(30.0)),
         )
         val outfit = OutfitSuggestion.fromForecast(
             forecast(feelsLikeMin = 12.0, feelsLikeMax = 15.0, precipMaxPct = 60.0),
@@ -652,7 +652,7 @@ class OutfitSuggestionTest {
         // user's default and the rain jacket paints over it — the shell adds to
         // the outfit rather than standing in for a missing top.
         val rules = listOf(
-            ClothesRule(Garment.RAIN_JACKET, ClothesRule.PrecipitationProbabilityAbove(30.0)),
+            ClothesRule(Garment.RAIN_JACKET, ClothesRule.RainProbabilityAbove(30.0)),
         )
         val outfit = OutfitSuggestion.fromForecast(
             forecast(feelsLikeMin = 18.0, feelsLikeMax = 24.0, precipMaxPct = 70.0),

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/EvaluateClothesRulesTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/EvaluateClothesRulesTest.kt
@@ -113,7 +113,7 @@ class EvaluateClothesRulesTest {
         // bare "rain jacket", matching the icon (which paints the shell over the
         // default top). The bottom slot still falls back to its default too.
         val rules = listOf(
-            ClothesRule(Garment.RAIN_JACKET, ClothesRule.PrecipitationProbabilityAbove(30.0)),
+            ClothesRule(Garment.RAIN_JACKET, ClothesRule.RainProbabilityAbove(30.0)),
         )
         val out = subject(
             forecast(min = 18.0, max = 24.0, precip = 70.0, condition = WeatherCondition.RAIN),
@@ -130,7 +130,7 @@ class EvaluateClothesRulesTest {
 
     @Test
     fun `explicit base-top rule survives under a rain jacket`() {
-        // A user's own base-top rule (t-shirt > 20°C) plus a rain-jacket precip
+        // A user's own base-top rule (t-shirt > 20°C) plus a rain-jacket rain
         // rule, both firing on a warm wet day. The rain jacket is a thin OUTER
         // shell that doesn't subsume the base top, so layerReduce keeps the
         // t-shirt — the prose reads "Wear a t-shirt and a rain jacket", matching
@@ -138,7 +138,7 @@ class EvaluateClothesRulesTest {
         // added since an explicit base top already covers the slot.
         val rules = listOf(
             ClothesRule(Garment.TSHIRT, ClothesRule.TemperatureAbove(20.0)),
-            ClothesRule(Garment.RAIN_JACKET, ClothesRule.PrecipitationProbabilityAbove(30.0)),
+            ClothesRule(Garment.RAIN_JACKET, ClothesRule.RainProbabilityAbove(30.0)),
         )
         val out = subject(
             forecast(min = 19.0, max = 24.0, precip = 70.0, condition = WeatherCondition.RAIN),
@@ -156,7 +156,7 @@ class EvaluateClothesRulesTest {
         // prose reads "Wear a sweater and a rain jacket".
         val rules = listOf(
             ClothesRule(Garment.SWEATER, ClothesRule.TemperatureBelow(16.0)),
-            ClothesRule(Garment.RAIN_JACKET, ClothesRule.PrecipitationProbabilityAbove(30.0)),
+            ClothesRule(Garment.RAIN_JACKET, ClothesRule.RainProbabilityAbove(30.0)),
         )
         val out = subject(
             forecast(min = 11.0, max = 15.0, precip = 70.0, condition = WeatherCondition.RAIN),
@@ -168,11 +168,11 @@ class EvaluateClothesRulesTest {
     }
 
     @Test
-    fun `snowy day above the umbrella gate suppresses the carried umbrella`() {
-        // The umbrella default keys off aggregate precip probability, so an 80%
-        // snowy day clears its gate — but snow doesn't warrant an umbrella, so
-        // the carried rule is filtered out while the worn cold-weather rules
-        // still fire. Keeps the icon, recommendations, and prose consistent.
+    fun `snowy day does not match the rain-keyed umbrella`() {
+        // A rain rule excludes snow, so an 80% snowy day — whose probability
+        // would otherwise clear the umbrella's gate — doesn't match it, while
+        // the worn cold-weather rules still fire. Keeps the icon,
+        // recommendations, and prose consistent.
         val out = subject(
             forecast(min = -2.0, max = 2.0, precip = 80.0, condition = WeatherCondition.SNOW),
             ClothesRule.DEFAULTS,
@@ -182,9 +182,25 @@ class EvaluateClothesRulesTest {
     }
 
     @Test
-    fun `thunderstorm day above the umbrella gate keeps the carried umbrella`() {
-        // Thunderstorm is treated as rain — a wet forecast the user wants an
-        // umbrella for — so the carried rule survives the condition gate.
+    fun `snowy day does not match a worn rain rule either`() {
+        // Snow excludes *every* rain rule, not just the carried umbrella: a
+        // user's worn rain rule (here a rain-keyed jacket) also stays off a
+        // snowy day, because snow isn't rain. (A separate cold-weather sweater
+        // rule still fires on the temperature.)
+        val rainJacket = ClothesRule(Garment.JACKET, ClothesRule.RainProbabilityAbove(50.0))
+        val sweater = ClothesRule(Garment.SWEATER, ClothesRule.TemperatureBelow(16.0))
+        val out = subject(
+            forecast(min = -2.0, max = 2.0, precip = 80.0, condition = WeatherCondition.SNOW),
+            listOf(rainJacket, sweater),
+        )
+        out.rules.map { it.item.itemKey }.shouldContainExactly("sweater")
+        out.items.shouldNotContain("jacket")
+    }
+
+    @Test
+    fun `thunderstorm day matches the rain-keyed umbrella`() {
+        // Thunderstorm is rain (not frozen), so the rain rule matches and the
+        // umbrella fires.
         val out = subject(
             forecast(min = 12.0, max = 18.0, precip = 70.0, condition = WeatherCondition.THUNDERSTORM),
             ClothesRule.DEFAULTS,
@@ -193,12 +209,12 @@ class EvaluateClothesRulesTest {
     }
 
     @Test
-    fun `high rain chance coded overcast still keeps the carried umbrella`() {
+    fun `high rain chance coded overcast still matches the rain-keyed umbrella`() {
         // The bug case: 88% chance of rain but the peak-probability hour carries
         // an "overcast" code (high probability, ~0mm accumulation), so the raw
         // daily condition is CLOUDY, not a wet code. The prose still announces
-        // the rain, so the umbrella must surface too — only frozen precip (snow)
-        // suppresses the carried slot.
+        // the rain, so the umbrella must surface too — a rain rule excludes only
+        // frozen precip (snow), not dry-coded-but-likely days.
         val out = subject(
             forecast(min = 9.0, max = 15.0, precip = 88.0, condition = WeatherCondition.CLOUDY),
             ClothesRule.DEFAULTS,

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsightTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsightTest.kt
@@ -983,7 +983,7 @@ class GenerateDailyInsightTest {
         val calendar = FakeCalendarEventReader(events = listOf(diner))
         val subject = GenerateDailyInsight(weather, calendarEventReader = calendar, clock = clock)
 
-        val umbrellaOnly = listOf(ClothesRule(Garment.UMBRELLA, ClothesRule.PrecipitationProbabilityAbove(30.0)))
+        val umbrellaOnly = listOf(ClothesRule(Garment.UMBRELLA, ClothesRule.RainProbabilityAbove(30.0)))
         val result = subject(
             location = london,
             prefs = prefs.copy(
@@ -1033,7 +1033,7 @@ class GenerateDailyInsightTest {
 
         val sweaterAndRainJacket = listOf(
             ClothesRule(Garment.SWEATER, ClothesRule.TemperatureBelow(16.0)),
-            ClothesRule(Garment.RAIN_JACKET, ClothesRule.PrecipitationProbabilityAbove(30.0)),
+            ClothesRule(Garment.RAIN_JACKET, ClothesRule.RainProbabilityAbove(30.0)),
         )
         val result = subject(
             location = london,


### PR DESCRIPTION
## What & why

Clothes rules that key off the chance of rain are conceptually about **rain** — that was always the intention, and the rule editor already reads *"When chance of rain is above"*. This makes the model, the on-disk format, and the diagnostics all say "rain" too, and fixes a real behavior bug: a snowy day could wrongly fire rain gear.

## Changes

- **Rename** the domain condition `PrecipitationProbabilityAbove` → `RainProbabilityAbove` throughout — model, persistence DTO, settings-UI enum, and diagnostics.
- **Fold snow-exclusion into the rain condition.** A rain rule now matches only when the day's chance of rain is above the threshold **and** the day isn't snowing. Open-Meteo carries one combined rain/snow probability, so without this a snowy day clears the gate and fires rain gear. The carried-slot snow gates in `EvaluateClothesRules` and `OutfitSuggestion.fromForecast` are **removed** — the condition handles it at one chokepoint, and the exclusion now applies uniformly (a user's worn rain rule, e.g. a rain-keyed jacket, also stays off snow, not just the umbrella).
- A high-chance day the weather code labels **overcast** (88% chance, ~0 mm accumulation) still counts as rain, so the umbrella keeps surfacing there — the fix from #958 is preserved.
- **Say "rain", not "precipitation", on disk and in identifiers.** The wire token is now `"rain_above"`; the older `"precip_above"` token written by earlier builds is still **read** so saved rules keep loading. The settings string-resource keys were renamed `*_precip_*` → `*_rain_*`. The translated string *values* already said "rain" in every locale, so **no copy changes** — only key identifiers moved.

## Persistence / migration

Backward compatible: existing users' saved rules (including a customized umbrella gate) load unchanged via the legacy-token read path; new writes use `rain_above`.

## Privacy

No change to what crosses the device boundary — purely rule-evaluation and naming.

## Test plan

- Rain-rule snow exclusion at the condition, use-case, and outfit-icon levels.
- A worn (non-umbrella) rain rule suppressed on snow.
- The overcast-high-chance umbrella case still fires.
- Legacy `"precip_above"` wire token still decodes to a rain rule; new writes emit `"rain_above"`.
- Full JVM suite (`:core:domain`, `:core:data`, `:app:testDebugUnitTest`) green locally.

https://claude.ai/code/session_018KaxweuRr6DzHyVdxrt6dJ