### PR TITLE
Keep private voice requests private after key errors

### DIFF
--- a/app/src/main/kotlin/app/clothescast/data/AppCheckGeminiCallPlanner.kt
+++ b/app/src/main/kotlin/app/clothescast/data/AppCheckGeminiCallPlanner.kt
@@ -11,6 +11,7 @@ import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.FirebaseAuthInvalidUserException
 import com.google.firebase.installations.FirebaseInstallations
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.tasks.await
 
 /**
@@ -67,21 +68,14 @@ class AppCheckGeminiCallPlanner(
         return sharedPlan()
     }
 
-    private suspend fun readOwnKey(): String? = try {
-        secureKeyStore.get().takeIf { it.isNotBlank() }
-    } catch (_: MissingApiKeyException) {
-        // TODO: SecureKeyStore.get() throws MissingApiKeyException for two
-        // distinct reasons — "user never stored a key" and "stored
-        // ciphertext failed to decrypt and was cleared" (Keystore master
-        // rotation after factory reset / cross-device transfer). The
-        // second case should keep the user on the BYOK path and prompt
-        // them to re-enter the key, not silently route the next request
-        // through the developer proxy. Distinguish by checking
-        // SecureKeyStore.geminiKeyConfiguredFlow.first() *before* calling
-        // get(): if a doc was present at decision time, treat a
-        // subsequent decrypt failure as "ask user to re-enter" rather
-        // than falling through to sharedPlan().
-        null
+    private suspend fun readOwnKey(): String? {
+        val keyWasConfigured = secureKeyStore.geminiKeyConfiguredFlow.first()
+        return try {
+            secureKeyStore.get().takeIf { it.isNotBlank() }
+        } catch (e: MissingApiKeyException) {
+            if (keyWasConfigured) throw e
+            null
+        }
     }
 
     private fun directPlan(key: String) = GeminiCallPlan(

--- a/app/src/test/kotlin/app/clothescast/data/AppCheckGeminiCallPlannerTest.kt
+++ b/app/src/test/kotlin/app/clothescast/data/AppCheckGeminiCallPlannerTest.kt
@@ -1,14 +1,63 @@
 package app.clothescast.data
 
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
 import app.clothescast.core.data.insight.GeminiEndpoint
+import app.clothescast.core.data.insight.MissingApiKeyException
+import com.google.crypto.tink.Aead
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
-import org.junit.runner.RunWith
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import java.io.File
+import java.security.GeneralSecurityException
 
+@OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(RobolectricTestRunner::class)
 class AppCheckGeminiCallPlannerTest {
+    @get:Rule val temporaryFolder = TemporaryFolder()
+
+    private lateinit var dataStore: DataStore<Preferences>
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(UnconfinedTestDispatcher(TestCoroutineScheduler()))
+        dataStore = PreferenceDataStoreFactory.create(
+            produceFile = { File(temporaryFolder.root, "secure_key.preferences_pb") },
+        )
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `plan does not fall back to shared proxy when configured key cannot decrypt`() = runTest {
+        val secureKeyStore = SecureKeyStore(aead = DecryptFailsFakeAead, dataStore = dataStore)
+        secureKeyStore.set("AIzaSyExampleKeyValue123")
+        val subject = AppCheckGeminiCallPlanner(
+            secureKeyStore = secureKeyStore,
+            proxyBaseUrl = "https://example.test/tts",
+            sharedPathEnabled = true,
+            model = "gemini-test",
+        )
+
+        shouldThrow<MissingApiKeyException> { subject.plan() }
+    }
 
     @Test
     fun `parseProxyEndpoint splits host and single path segment`() {
@@ -44,4 +93,12 @@ class AppCheckGeminiCallPlannerTest {
             AppCheckGeminiCallPlanner.parseProxyEndpoint("https://example.test/api/tts")
         }
     }
+}
+
+private object DecryptFailsFakeAead : Aead {
+    override fun encrypt(plaintext: ByteArray, associatedData: ByteArray?): ByteArray =
+        plaintext.reversedArray()
+
+    override fun decrypt(ciphertext: ByteArray, associatedData: ByteArray?): ByteArray =
+        throw GeneralSecurityException("Simulated decrypt failure")
 }


### PR DESCRIPTION
When a stored Gemini BYOK value exists but can no longer decrypt, keep the request on the missing-key path instead of falling through to the shared TTS proxy. This prevents insight prose from being sent through the developer-operated shared path after a local key-store failure.

Add a planner-level regression test with a decrypt-failing AEAD so the fallback behavior stays covered.