### PR TITLE
Keep Gemini private after saved key failures

### DIFF
--- a/app/src/main/kotlin/app/clothescast/data/AppCheckGeminiCallPlanner.kt
+++ b/app/src/main/kotlin/app/clothescast/data/AppCheckGeminiCallPlanner.kt
@@ -11,7 +11,6 @@ import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.FirebaseAuthInvalidUserException
 import com.google.firebase.installations.FirebaseInstallations
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.tasks.await
 
 /**
@@ -68,14 +67,10 @@ class AppCheckGeminiCallPlanner(
         return sharedPlan()
     }
 
-    private suspend fun readOwnKey(): String? {
-        val keyWasConfigured = secureKeyStore.geminiKeyConfiguredFlow.first()
-        return try {
-            secureKeyStore.get().takeIf { it.isNotBlank() }
-        } catch (e: MissingApiKeyException) {
-            if (keyWasConfigured) throw e
-            null
-        }
+    private suspend fun readOwnKey(): String? = try {
+        secureKeyStore.get().takeIf { it.isNotBlank() }
+    } catch (_: MissingApiKeyException) {
+        null
     }
 
     private fun directPlan(key: String) = GeminiCallPlan(

--- a/app/src/main/kotlin/app/clothescast/data/SecureKeyStore.kt
+++ b/app/src/main/kotlin/app/clothescast/data/SecureKeyStore.kt
@@ -3,9 +3,11 @@ package app.clothescast.data
 import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
+import app.clothescast.core.data.insight.InvalidApiKeyException
 import app.clothescast.core.data.insight.MissingApiKeyException
 import com.google.crypto.tink.Aead
 import com.google.crypto.tink.KeyTemplates
@@ -32,10 +34,11 @@ import java.util.Base64
  * a fake AEAD and a test DataStore (e.g. temp-file-backed via PreferenceDataStoreFactory).
  * Production callers use [SecureKeyStore.create].
  *
- * `get()` reports any decode or decrypt failure as [MissingApiKeyException] and clears
- * the stored value. This handles the Keystore master key rotating (factory reset,
- * device-to-device transfer that doesn't preserve hardware-backed keys, etc.) by asking
- * the user to re-enter their key, rather than looping on a corrupt ciphertext.
+ * `get()` reports any decode or decrypt failure as [InvalidApiKeyException],
+ * clears the stored value, and records that the key needs re-entry. This
+ * handles the Keystore master key rotating (factory reset, device-to-device
+ * transfer that doesn't preserve hardware-backed keys, etc.) without silently
+ * falling back to a shared-key network path.
  *
  * Read by the Gemini call planner on the BYOK branch: when the user has stored
  * their own Gemini key, the planner pulls it via [get] and routes the request
@@ -46,11 +49,16 @@ class SecureKeyStore(
     private val dataStore: DataStore<Preferences>,
 ) {
 
-    suspend fun get(): String = read(GEMINI_PREF_KEY, GEMINI_AAD, "Gemini")
+    suspend fun get(): String = read(
+        prefKey = GEMINI_PREF_KEY,
+        invalidPrefKey = GEMINI_NEEDS_REENTRY_KEY,
+        aad = GEMINI_AAD,
+        provider = "Gemini",
+    )
 
     suspend fun set(key: String) = write(GEMINI_PREF_KEY, GEMINI_AAD, key)
 
-    suspend fun clear() = remove(GEMINI_PREF_KEY)
+    suspend fun clear() = remove(GEMINI_PREF_KEY, GEMINI_NEEDS_REENTRY_KEY)
 
     /**
      * MQTT broker password for the optional Smart Home bridge. Returns `null`
@@ -58,7 +66,12 @@ class SecureKeyStore(
      * state are both indistinguishable from "unset" by design.
      */
     suspend fun getMqttPassword(): String? = try {
-        read(MQTT_PASS_PREF_KEY, MQTT_PASS_AAD, "MQTT")
+        read(
+            prefKey = MQTT_PASS_PREF_KEY,
+            invalidPrefKey = null,
+            aad = MQTT_PASS_AAD,
+            provider = "MQTT",
+        )
     } catch (_: MissingApiKeyException) {
         null
     }
@@ -77,6 +90,16 @@ class SecureKeyStore(
         .distinctUntilChanged()
 
     /**
+     * True after a stored Gemini key failed to decrypt and was cleared. Stays
+     * true until the user re-enters or explicitly clears the key so retries
+     * keep the BYOK privacy boundary instead of falling through to the shared
+     * TTS proxy.
+     */
+    val geminiKeyNeedsReentryFlow: Flow<Boolean> = dataStore.data
+        .map { it[GEMINI_NEEDS_REENTRY_KEY] == true }
+        .distinctUntilChanged()
+
+    /**
      * Sibling of [geminiKeyConfiguredFlow] for the MQTT broker password. The
      * Smart Home settings card uses it to render the "Password set" indicator
      * without ever decrypting the stored value.
@@ -85,32 +108,58 @@ class SecureKeyStore(
         .map { it[MQTT_PASS_PREF_KEY] != null }
         .distinctUntilChanged()
 
-    private suspend fun read(prefKey: Preferences.Key<String>, aad: ByteArray, provider: String): String {
+    private suspend fun read(
+        prefKey: Preferences.Key<String>,
+        invalidPrefKey: Preferences.Key<Boolean>?,
+        aad: ByteArray,
+        provider: String,
+    ): String {
         val ciphertextB64 = dataStore.data.map { it[prefKey] }.first()
-            ?: throw MissingApiKeyException(provider)
+            ?: if (invalidPrefKey != null && dataStore.data.map { it[invalidPrefKey] == true }.first()) {
+                throw InvalidApiKeyException(provider)
+            } else {
+                throw MissingApiKeyException(provider)
+            }
         return try {
             val ciphertext = Base64.getDecoder().decode(ciphertextB64)
             aead.decrypt(ciphertext, aad).toString(Charsets.UTF_8)
         } catch (_: Exception) {
             // Corrupt ciphertext or unrecoverable Keystore state — drop the bad value so
             // the next attempt prompts the user to re-enter their key cleanly.
-            remove(prefKey)
-            throw MissingApiKeyException(provider)
+            dataStore.edit {
+                it.remove(prefKey)
+                if (invalidPrefKey != null) it[invalidPrefKey] = true
+            }
+            if (invalidPrefKey != null) {
+                throw InvalidApiKeyException(provider)
+            } else {
+                throw MissingApiKeyException(provider)
+            }
         }
     }
 
     private suspend fun write(prefKey: Preferences.Key<String>, aad: ByteArray, key: String) {
         val ciphertext = aead.encrypt(key.toByteArray(Charsets.UTF_8), aad)
         val ciphertextB64 = Base64.getEncoder().encodeToString(ciphertext)
-        dataStore.edit { it[prefKey] = ciphertextB64 }
+        dataStore.edit {
+            it[prefKey] = ciphertextB64
+            if (prefKey == GEMINI_PREF_KEY) it.remove(GEMINI_NEEDS_REENTRY_KEY)
+        }
     }
 
-    private suspend fun remove(prefKey: Preferences.Key<String>) {
-        dataStore.edit { it.remove(prefKey) }
+    private suspend fun remove(
+        prefKey: Preferences.Key<String>,
+        invalidPrefKey: Preferences.Key<Boolean>? = null,
+    ) {
+        dataStore.edit {
+            it.remove(prefKey)
+            if (invalidPrefKey != null) it.remove(invalidPrefKey)
+        }
     }
 
     companion object {
         private val GEMINI_PREF_KEY = stringPreferencesKey("gemini_api_key_v1")
+        private val GEMINI_NEEDS_REENTRY_KEY = booleanPreferencesKey("gemini_api_key_needs_reentry_v1")
         private val GEMINI_AAD = "clothescast:gemini_api_key:v1".toByteArray(Charsets.UTF_8)
         private val MQTT_PASS_PREF_KEY = stringPreferencesKey("mqtt_password_v1")
         private val MQTT_PASS_AAD = "clothescast:mqtt_password:v1".toByteArray(Charsets.UTF_8)

--- a/app/src/main/kotlin/app/clothescast/ui/nav/ClothesCastNavHost.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/nav/ClothesCastNavHost.kt
@@ -377,6 +377,7 @@ private fun todayViewModelFactory(app: ClothesCastApplication, context: Context)
         deriveInsight = app.deriveInsight,
         calendarEventReader = app.calendarEventReader,
         geminiKeyConfigured = app.secureKeyStore.geminiKeyConfiguredFlow,
+        geminiKeyNeedsReentry = app.secureKeyStore.geminiKeyNeedsReentryFlow,
     )
 
 private fun settingsViewModelFactory(app: ClothesCastApplication, context: Context) =

--- a/app/src/main/kotlin/app/clothescast/ui/today/GeminiTtsLimitCard.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/GeminiTtsLimitCard.kt
@@ -101,3 +101,47 @@ internal fun GeminiTtsLimitCardContent(
         }
     }
 }
+
+/**
+ * Persistent Today-screen card shown when the stored BYOK Gemini key could not
+ * be decrypted locally. It intentionally has no dismiss action: the card
+ * clears only when the user re-enters or explicitly clears the key, matching
+ * the planner's privacy boundary.
+ */
+@Composable
+internal fun GeminiKeyNeedsReentryCard(
+    visible: Boolean,
+    onOpenVoice: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    if (!visible) return
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.errorContainer,
+            contentColor = MaterialTheme.colorScheme.onErrorContainer,
+        ),
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.today_gemini_key_invalid_title),
+                style = MaterialTheme.typography.titleSmall,
+            )
+            Text(
+                text = stringResource(R.string.today_gemini_key_invalid_body),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End,
+            ) {
+                TextButton(onClick = onOpenVoice) {
+                    Text(stringResource(R.string.today_gemini_key_invalid_cta))
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
@@ -846,6 +846,11 @@ private fun BannerStack(
         onDismiss = onDismissGeminiTtsLimitCard,
         modifier = bannerModifier,
     )
+    GeminiKeyNeedsReentryCard(
+        visible = state.geminiKeyNeedsReentry,
+        onOpenVoice = onOpenVoice,
+        modifier = bannerModifier,
+    )
     // "Set up a schedule" nudge — scheduled casts don't fire until the user
     // enables a slot, so a fresh install gets nothing on a timer. Gated
     // upstream on neither master switch being on (plus the user not having
@@ -3614,4 +3619,3 @@ internal fun openInMaps(context: Context, latitude: Double, longitude: Double, l
         // No maps app installed; nothing useful to do.
     }
 }
-

--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayViewModel.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayViewModel.kt
@@ -231,6 +231,12 @@ data class TodayState(
      */
     val geminiTtsLimitExceededAt: Long = 0L,
     /**
+     * True after a configured Gemini BYOK value failed local decrypt. It stays
+     * true until the user re-enters or clears the key, preserving the user's
+     * private BYOK choice across retries.
+     */
+    val geminiKeyNeedsReentry: Boolean = false,
+    /**
      * Whether the one-time telemetry/privacy disclosure is still pending
      * (the user hasn't acked it). Lifted out of the banner so [BannerStack]
      * can fold it into the capped promo pool alongside the location, clothes,
@@ -403,6 +409,12 @@ internal data class WorkSignals(
     val anyWorkActive: Boolean,
 )
 
+/** Presence + invalid-state mirror of the Gemini BYOK secret. */
+internal data class GeminiKeySignals(
+    val configured: Boolean,
+    val needsReentry: Boolean,
+)
+
 /**
  * Per-tick bundle of the odds-and-ends signals folded into
  * [TodayViewModel.state] so the outer combine stays at its five-flow
@@ -412,7 +424,7 @@ internal data class WorkSignals(
  */
 internal data class MiscSignals(
     val showModelSpread: Boolean,
-    val geminiKeyConfigured: Boolean,
+    val geminiKey: GeminiKeySignals,
     /** Latest MQTT publish failure to show (null when none / dismissed). */
     val mqttError: String?,
     /** [recordedAtMs] of the latest MQTT failure, so dismiss can mark it seen. */
@@ -496,6 +508,7 @@ class TodayViewModel(
      * it (no key ⇒ the promo is eligible, matching a fresh install).
      */
     private val geminiKeyConfigured: Flow<Boolean> = flowOf(false),
+    private val geminiKeyNeedsReentry: Flow<Boolean> = flowOf(false),
 ) : ViewModel() {
     /**
      * Session-scoped "show model spread" flag. Held in the ViewModel rather
@@ -594,6 +607,9 @@ class TodayViewModel(
             }
         }
 
+    private val geminiKeySignals: Flow<GeminiKeySignals> =
+        combine(geminiKeyConfigured, geminiKeyNeedsReentry, ::GeminiKeySignals)
+
     // Fuse the session-scoped spread toggle, the external "Gemini key
     // configured" signal, and the latest MQTT / Cast publish-error messages
     // into one input so the outer [state] combine stays at five flows (the
@@ -603,7 +619,7 @@ class TodayViewModel(
     private val miscSignals: Flow<MiscSignals> =
         combine(
             showModelSpread,
-            geminiKeyConfigured,
+            geminiKeySignals,
             settingsRepository.mqttPublishStatus,
             settingsRepository.castStatus,
             geminiTtsLimitStatusTicking,
@@ -632,7 +648,7 @@ class TodayViewModel(
             } ?: false
             MiscSignals(
                 showModelSpread = spread,
-                geminiKeyConfigured = geminiKey,
+                geminiKey = geminiKey,
                 mqttError = mqttError,
                 mqttErrorAt = mqtt?.recordedAtMs ?: 0L,
                 castError = castError,
@@ -650,7 +666,8 @@ class TodayViewModel(
         miscSignals,
     ) { thisPeriodSnapshot, nextPeriodSnapshot, workSignals, prefsDateEvents, misc ->
         val spread = misc.showModelSpread
-        val geminiKeyConfigured = misc.geminiKeyConfigured
+        val geminiKeyConfigured = misc.geminiKey.configured
+        val geminiKeyNeedsReentry = misc.geminiKey.needsReentry
         val (prefs, today, events) = prefsDateEvents
         // Derive each cached snapshot against the *current* prefs so a settings
         // change re-renders the prose / outfit / bullets in the same frame as
@@ -739,14 +756,17 @@ class TodayViewModel(
             // card is up — pitching voices the user just hit a cap on reads as
             // a bug. The limit card already routes to the same Speech settings.
             geminiTtsPromoCardVisible = !prefs.geminiPromoCardDismissed &&
-                !geminiKeyConfigured && !misc.geminiTtsLimitExceeded,
+                !geminiKeyConfigured && !geminiKeyNeedsReentry && !misc.geminiTtsLimitExceeded,
             // Gate on no BYOK key: a configured key bypasses the shared free
             // proxy entirely, so the moment the user adds one (e.g. via this
             // card's CTA) the limit no longer applies and the card hides
             // immediately — without waiting for the next synth to clear the
             // persisted quota status.
-            geminiTtsLimitCardVisible = misc.geminiTtsLimitExceeded && !geminiKeyConfigured,
+            geminiTtsLimitCardVisible = misc.geminiTtsLimitExceeded &&
+                !geminiKeyConfigured &&
+                !geminiKeyNeedsReentry,
             geminiTtsLimitExceededAt = misc.geminiTtsLimitExceededAt,
+            geminiKeyNeedsReentry = geminiKeyNeedsReentry,
             telemetryNoticeVisible = !prefs.telemetryNoticeAcked,
             usesCalendarThemes = prefs.calendarHolidayThemingActive || prefs.calendarBirthdayThemingActive,
             // Surface a publish error for any failed delivery attempt — a
@@ -923,6 +943,7 @@ class TodayViewModel(
         private val deriveInsight: DeriveInsight = DeriveInsight(),
         private val calendarEventReader: CalendarEventReader? = null,
         private val geminiKeyConfigured: Flow<Boolean> = flowOf(false),
+        private val geminiKeyNeedsReentry: Flow<Boolean> = flowOf(false),
     ) : ViewModelProvider.Factory {
         @Suppress("UNCHECKED_CAST")
         override fun <T : ViewModel> create(modelClass: Class<T>): T {
@@ -937,6 +958,7 @@ class TodayViewModel(
                 deriveInsight = deriveInsight,
                 calendarEventReader = calendarEventReader,
                 geminiKeyConfigured = geminiKeyConfigured,
+                geminiKeyNeedsReentry = geminiKeyNeedsReentry,
             ) as T
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -420,6 +420,9 @@
     <string name="today_gemini_limit_body">You\'ve used today\'s free Gemini voices. Add your own Gemini key for more.</string>
     <string name="today_gemini_limit_cta">Speech settings</string>
     <string name="today_gemini_limit_dismiss">Dismiss</string>
+    <string name="today_gemini_key_invalid_title">Gemini key needs re-entry</string>
+    <string name="today_gemini_key_invalid_body">Your saved Gemini key could not be read on this device, so ClothesCast will not use shared Gemini voices until you re-enter or clear it.</string>
+    <string name="today_gemini_key_invalid_cta">Speech settings</string>
 
     <!-- Promo card on the Today screen nudging users toward the new
          calendar-sourced holiday + birthday theming. Auto-hides once

--- a/app/src/test/kotlin/app/clothescast/data/AppCheckGeminiCallPlannerTest.kt
+++ b/app/src/test/kotlin/app/clothescast/data/AppCheckGeminiCallPlannerTest.kt
@@ -4,7 +4,7 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences
 import app.clothescast.core.data.insight.GeminiEndpoint
-import app.clothescast.core.data.insight.MissingApiKeyException
+import app.clothescast.core.data.insight.InvalidApiKeyException
 import com.google.crypto.tink.Aead
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
@@ -46,8 +46,8 @@ class AppCheckGeminiCallPlannerTest {
     }
 
     @Test
-    fun `plan does not fall back to shared proxy when configured key cannot decrypt`() = runTest {
-        val secureKeyStore = SecureKeyStore(aead = DecryptFailsFakeAead, dataStore = dataStore)
+    fun `plan does not fall back to shared proxy after configured key cannot decrypt`() = runTest {
+        val secureKeyStore = SecureKeyStore(aead = PlannerDecryptFailsFakeAead, dataStore = dataStore)
         secureKeyStore.set("AIzaSyExampleKeyValue123")
         val subject = AppCheckGeminiCallPlanner(
             secureKeyStore = secureKeyStore,
@@ -56,7 +56,8 @@ class AppCheckGeminiCallPlannerTest {
             model = "gemini-test",
         )
 
-        shouldThrow<MissingApiKeyException> { subject.plan() }
+        shouldThrow<InvalidApiKeyException> { subject.plan() }
+        shouldThrow<InvalidApiKeyException> { subject.plan() }
     }
 
     @Test
@@ -95,7 +96,7 @@ class AppCheckGeminiCallPlannerTest {
     }
 }
 
-private object DecryptFailsFakeAead : Aead {
+private object PlannerDecryptFailsFakeAead : Aead {
     override fun encrypt(plaintext: ByteArray, associatedData: ByteArray?): ByteArray =
         plaintext.reversedArray()
 

--- a/app/src/test/kotlin/app/clothescast/data/SecureKeyStoreTest.kt
+++ b/app/src/test/kotlin/app/clothescast/data/SecureKeyStoreTest.kt
@@ -5,6 +5,7 @@ import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
+import app.clothescast.core.data.insight.InvalidApiKeyException
 import app.clothescast.core.data.insight.MissingApiKeyException
 import com.google.crypto.tink.Aead
 import io.kotest.assertions.throwables.shouldThrow
@@ -93,15 +94,33 @@ class SecureKeyStoreTest {
     }
 
     @Test
-    fun `corrupt ciphertext is cleared and reported as MissingApiKeyException`() = runTest {
+    fun `corrupt ciphertext is cleared and reported as InvalidApiKeyException`() = runTest {
         // Simulate a Keystore master-key rotation: the stored ciphertext is no longer
-        // decodeable. The store should drop the bad value and tell callers there's no key.
+        // decodeable. The store should drop the bad value and keep asking for re-entry.
         dataStore.edit { it[GEMINI_KEY_PREFERENCE] = "@@@not-valid-base64@@@" }
 
-        shouldThrow<MissingApiKeyException> { subject.get() }
+        shouldThrow<InvalidApiKeyException> { subject.get() }
 
         // And subsequent reads no longer see the corrupt value.
         dataStore.data.first()[GEMINI_KEY_PREFERENCE] shouldBe null
+    }
+
+    @Test
+    fun `decrypt failure keeps reporting invalid key until re-entered`() = runTest {
+        subject = SecureKeyStore(aead = DecryptFailsFakeAead, dataStore = dataStore)
+        subject.set("AIzaSyExampleKeyValue123")
+
+        shouldThrow<InvalidApiKeyException> { subject.get() }
+        dataStore.data.first()[GEMINI_KEY_PREFERENCE] shouldBe null
+        subject.geminiKeyNeedsReentryFlow.first() shouldBe true
+
+        shouldThrow<InvalidApiKeyException> { subject.get() }
+
+        subject = SecureKeyStore(aead = ReversibleFakeAead, dataStore = dataStore)
+        subject.set("AIzaSyNewExampleKeyValue123")
+
+        subject.geminiKeyNeedsReentryFlow.first() shouldBe false
+        subject.get() shouldBe "AIzaSyNewExampleKeyValue123"
     }
 
     private companion object {
@@ -122,4 +141,12 @@ private object ReversibleFakeAead : Aead {
 
     override fun decrypt(ciphertext: ByteArray, associatedData: ByteArray?): ByteArray =
         ciphertext.reversedArray()
+}
+
+private object DecryptFailsFakeAead : Aead {
+    override fun encrypt(plaintext: ByteArray, associatedData: ByteArray?): ByteArray =
+        plaintext.reversedArray()
+
+    override fun decrypt(ciphertext: ByteArray, associatedData: ByteArray?): ByteArray =
+        throw java.security.GeneralSecurityException("Simulated decrypt failure")
 }

--- a/core/data/src/main/kotlin/app/clothescast/core/data/insight/InvalidApiKeyException.kt
+++ b/core/data/src/main/kotlin/app/clothescast/core/data/insight/InvalidApiKeyException.kt
@@ -1,0 +1,10 @@
+package app.clothescast.core.data.insight
+
+/**
+ * Thrown when a previously stored API key can no longer be read. This is
+ * distinct from [MissingApiKeyException]: the user had opted into the BYOK
+ * path, so callers must not silently fall back to a shared proxy until the user
+ * re-enters or clears that key.
+ */
+class InvalidApiKeyException(provider: String = "Gemini") :
+    IllegalStateException("$provider API key could not be read; re-enter it")


### PR DESCRIPTION
Remember when a stored BYOK Gemini key can no longer decrypt, report it as an invalid saved key, and keep retries on the missing-key path until the user re-enters or clears the key.

Surface the re-entry state as a persistent Today card linking to Speech settings, and cover the planner/keystore behavior with regression tests.