### PR TITLE
Set up smart devices with Home Assistant discovery

### DIFF
--- a/app/src/main/kotlin/app/clothescast/mqtt/MqttPublisher.kt
+++ b/app/src/main/kotlin/app/clothescast/mqtt/MqttPublisher.kt
@@ -17,6 +17,11 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.future.await
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 import kotlin.coroutines.cancellation.CancellationException
 import java.util.UUID
 import java.util.concurrent.TimeUnit
@@ -284,6 +289,9 @@ class MqttPublisher(
                     "($failed failed); previous retained /now bundle stays intact.",
             )
         }
+        if (proseOutcome is MqttPublishOutcome.Success) {
+            publishHomeAssistantDiscovery(prepared)
+        }
         proseOutcome
     }
 
@@ -437,6 +445,23 @@ class MqttPublisher(
         )
     }
 
+    private suspend fun publishHomeAssistantDiscovery(prepared: PreparedPublish) {
+        homeAssistantDiscoveryEntries(prepared.baseTopic).forEach { entry ->
+            val outcome = executePublish(
+                prepared = prepared,
+                topic = entry.configTopic,
+                payload = entry.payload.toByteArray(Charsets.UTF_8),
+            )
+            if (outcome !is MqttPublishOutcome.Success) {
+                DiagLog.w(
+                    TAG,
+                    "Home Assistant discovery config ${entry.configTopic} failed ($outcome); " +
+                        "forecast topics remain published but HA may not auto-create this entity.",
+                )
+            }
+        }
+    }
+
     private data class PreparedPublish(
         val config: MqttConfig,
         val baseTopic: String,
@@ -502,6 +527,71 @@ class MqttPublisher(
         // retained bundle they've already acted on.
         fun nowTimestampTopicFor(baseTopic: String): String = nowTopicForKind(baseTopic, "timestamp")
 
+        internal fun homeAssistantDiscoveryEntries(baseTopic: String): List<HomeAssistantDiscoveryEntry> {
+            val base = baseTopic.trim().trim('/').ifBlank { UserPreferences.DEFAULT_MQTT_TOPIC }
+            val suffix = discoveryIdSuffix(base)
+            val idPrefix = if (base == UserPreferences.DEFAULT_MQTT_TOPIC) {
+                "clothescast"
+            } else {
+                "clothescast_$suffix"
+            }
+            val device = JsonObject(
+                mapOf(
+                    "identifiers" to JsonArray(listOf(JsonPrimitive(idPrefix))),
+                    "name" to JsonPrimitive("ClothesCast"),
+                    "manufacturer" to JsonPrimitive("ClothesCast"),
+                    "model" to JsonPrimitive("Android app"),
+                ),
+            )
+            fun sensor(
+                id: String,
+                name: String,
+                stateTopic: String,
+                icon: String? = null,
+                deviceClass: String? = null,
+                valueTemplate: String? = null,
+            ) = HomeAssistantDiscoveryEntry(
+                configTopic = "homeassistant/sensor/${idPrefix}_$id/config",
+                payload = buildJsonObject {
+                    put("name", name)
+                    put("unique_id", "${idPrefix}_$id")
+                    put("default_entity_id", "sensor.${idPrefix}_$id")
+                    put("state_topic", stateTopic)
+                    put("device", device)
+                    if (icon != null) put("icon", icon)
+                    if (deviceClass != null) put("device_class", deviceClass)
+                    if (valueTemplate != null) put("value_template", valueTemplate)
+                }.toString(),
+            )
+            fun image(id: String, name: String, imageTopic: String) = HomeAssistantDiscoveryEntry(
+                configTopic = "homeassistant/image/${idPrefix}_$id/config",
+                payload = buildJsonObject {
+                    put("name", name)
+                    put("unique_id", "${idPrefix}_$id")
+                    put("default_entity_id", "image.${idPrefix}_$id")
+                    put("image_topic", imageTopic)
+                    put("content_type", "image/png")
+                    put("device", device)
+                }.toString(),
+            )
+            return listOf(
+                sensor("today", "Today", topicFor(base, ForecastPeriod.TODAY), icon = "mdi:tshirt-crew"),
+                sensor("tonight", "Tonight", topicFor(base, ForecastPeriod.TONIGHT), icon = "mdi:tshirt-crew"),
+                sensor("now", "Now", nowTopicFor(base), icon = "mdi:tshirt-crew"),
+                sensor(
+                    id = "now_updated",
+                    name = "Now updated",
+                    stateTopic = nowTimestampTopicFor(base),
+                    icon = "mdi:clock-outline",
+                    deviceClass = "timestamp",
+                    valueTemplate = "{{ as_datetime((value | int) / 1000) }}",
+                ),
+                image("today_image", "Today image", imageTopicFor(base, ForecastPeriod.TODAY)),
+                image("tonight_image", "Tonight image", imageTopicFor(base, ForecastPeriod.TONIGHT)),
+                image("now_image", "Now image", nowImageTopicFor(base)),
+            )
+        }
+
         private fun periodTopicFor(baseTopic: String, period: ForecastPeriod, kind: String): String {
             val trimmed = baseTopic.trim().trim('/').ifBlank { UserPreferences.DEFAULT_MQTT_TOPIC }
             return "$trimmed/${period.name.lowercase()}/$kind"
@@ -511,8 +601,23 @@ class MqttPublisher(
             val trimmed = baseTopic.trim().trim('/').ifBlank { UserPreferences.DEFAULT_MQTT_TOPIC }
             return "$trimmed/now/$kind"
         }
+
+        private fun discoveryIdSuffix(baseTopic: String): String =
+            baseTopic.trim().trim('/')
+                .ifBlank { UserPreferences.DEFAULT_MQTT_TOPIC }
+                .lowercase()
+                .map { if (it.isLetterOrDigit()) it else '_' }
+                .joinToString("")
+                .replace(Regex("_+"), "_")
+                .trim('_')
+                .ifBlank { "default" }
     }
 }
+
+internal data class HomeAssistantDiscoveryEntry(
+    val configTopic: String,
+    val payload: String,
+)
 
 /**
  * A plain-English hint for an MQTT publish that failed at the connection layer,

--- a/app/src/test/kotlin/app/clothescast/mqtt/MqttPublisherTest.kt
+++ b/app/src/test/kotlin/app/clothescast/mqtt/MqttPublisherTest.kt
@@ -25,6 +25,9 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -537,6 +540,89 @@ class MqttPublisherTest {
     }
 
     @Test
+    fun `successful publish emits Home Assistant discovery configs`() = runTest {
+        val captured = mutableListOf<PublishCall>()
+        val subject = MqttPublisher(
+            preferences = flowOf(
+                basePrefs.copy(
+                    mqttBridgeEnabled = true,
+                    mqttHost = "broker.local",
+                    mqttTopic = "home/forecast",
+                ),
+            ),
+            passwordProvider = { null },
+            publish = capturing(captured),
+        )
+
+        subject.publishIfEnabled(ForecastPeriod.TODAY, "prose")
+
+        val discovery = captured.filter { isDiscoveryTopic(it.topic) }
+        discovery.map { it.topic } shouldContainAll listOf(
+            "homeassistant/sensor/clothescast_home_forecast_today/config",
+            "homeassistant/sensor/clothescast_home_forecast_tonight/config",
+            "homeassistant/sensor/clothescast_home_forecast_now/config",
+            "homeassistant/sensor/clothescast_home_forecast_now_updated/config",
+            "homeassistant/image/clothescast_home_forecast_today_image/config",
+            "homeassistant/image/clothescast_home_forecast_tonight_image/config",
+            "homeassistant/image/clothescast_home_forecast_now_image/config",
+        )
+        val today = discoveryPayload(discovery, "homeassistant/sensor/clothescast_home_forecast_today/config")
+        today["unique_id"]!!.jsonPrimitive.content shouldBe "clothescast_home_forecast_today"
+        today["default_entity_id"]!!.jsonPrimitive.content shouldBe "sensor.clothescast_home_forecast_today"
+        today["state_topic"]!!.jsonPrimitive.content shouldBe "home/forecast/today/text"
+        today["device"]!!.jsonObject["name"]!!.jsonPrimitive.content shouldBe "ClothesCast"
+
+        val updated = discoveryPayload(discovery, "homeassistant/sensor/clothescast_home_forecast_now_updated/config")
+        updated["state_topic"]!!.jsonPrimitive.content shouldBe "home/forecast/now/timestamp"
+        updated["device_class"]!!.jsonPrimitive.content shouldBe "timestamp"
+        updated["value_template"]!!.jsonPrimitive.content shouldBe "{{ as_datetime((value | int) / 1000) }}"
+
+        val image = discoveryPayload(discovery, "homeassistant/image/clothescast_home_forecast_now_image/config")
+        image["default_entity_id"]!!.jsonPrimitive.content shouldBe "image.clothescast_home_forecast_now_image"
+        image["image_topic"]!!.jsonPrimitive.content shouldBe "home/forecast/now/image"
+        image["content_type"]!!.jsonPrimitive.content shouldBe "image/png"
+    }
+
+    @Test
+    fun `default Home Assistant discovery ids omit the default topic suffix`() {
+        val entries = MqttPublisher.homeAssistantDiscoveryEntries("clothescast/default")
+
+        entries.map { it.configTopic } shouldContainAll listOf(
+            "homeassistant/sensor/clothescast_today/config",
+            "homeassistant/sensor/clothescast_tonight/config",
+            "homeassistant/sensor/clothescast_now/config",
+            "homeassistant/sensor/clothescast_now_updated/config",
+            "homeassistant/image/clothescast_now_image/config",
+        )
+        val now = Json.parseToJsonElement(
+            entries.first { it.configTopic == "homeassistant/sensor/clothescast_now/config" }.payload,
+        ).jsonObject
+        now["default_entity_id"]!!.jsonPrimitive.content shouldBe "sensor.clothescast_now"
+    }
+
+    @Test
+    fun `Home Assistant discovery failure does not block forecast publish outcome`() = runTest {
+        val captured = mutableListOf<PublishCall>()
+        val subject = MqttPublisher(
+            preferences = flowOf(
+                basePrefs.copy(mqttBridgeEnabled = true, mqttHost = "broker.local"),
+            ),
+            passwordProvider = { null },
+            publish = { config, topic, payload ->
+                captured.add(PublishCall(config, topic, payload))
+                if (topic.startsWith("homeassistant/")) error("discovery ACL rejected")
+            },
+            retryDelayMs = 1L,
+        )
+
+        val outcome = subject.publishIfEnabled(ForecastPeriod.TODAY, "prose")
+
+        outcome shouldBe MqttPublishOutcome.Success
+        captured.any { it.topic == "clothescast/default/today/text" }.shouldBeTrue()
+        captured.any { it.topic.startsWith("homeassistant/") }.shouldBeTrue()
+    }
+
+    @Test
     fun `bundle with image publishes period prose and image, mirrors both with text last and audio cleared`() = runTest {
         val captured = mutableListOf<PublishCall>()
         val subject = MqttPublisher(
@@ -949,7 +1035,7 @@ class MqttPublisherTest {
         // clears, text, then timestamp last as the commit marker) all succeed.
         // First two attempts are the retried period publish; the rest are the
         // coordinated /now mirrors.
-        attempts.map { it.topic } shouldBe listOf(
+        nonDiscoveryTopics(attempts) shouldBe listOf(
             "clothescast/default/today/text",
             "clothescast/default/today/text",
             "clothescast/default/now/image",
@@ -998,7 +1084,7 @@ class MqttPublisherTest {
         // No retries on the period publish; the remaining attempts are the
         // coordinated /now bundle (image/audio/video clears, text, then
         // timestamp last as the commit marker).
-        attempts shouldBe listOf(
+        attempts.filterNot(::isDiscoveryTopic) shouldBe listOf(
             "clothescast/default/today/text",
             "clothescast/default/now/image",
             "clothescast/default/now/audio",
@@ -1038,6 +1124,15 @@ class MqttPublisherTest {
 
     private fun capturing(into: MutableList<PublishCall>): suspend (MqttConfig, String, ByteArray) -> Unit =
         { config, topic, payload -> into.add(PublishCall(config, topic, payload)) }
+
+    private fun nonDiscoveryTopics(calls: List<PublishCall>): List<String> =
+        calls.map { it.topic }.filterNot(::isDiscoveryTopic)
+
+    private fun isDiscoveryTopic(topic: String): Boolean =
+        topic.startsWith("homeassistant/")
+
+    private fun discoveryPayload(calls: List<PublishCall>, topic: String) =
+        Json.parseToJsonElement(calls.first { it.topic == topic }.payload.decodeToString()).jsonObject
 
     private val basePrefs = UserPreferences(
         schedule = Schedule(time = LocalTime.of(7, 0), days = Schedule.EVERY_DAY, zoneId = ZoneId.of("UTC")),

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -126,18 +126,16 @@ Done:
       removed ~70 lines of keep rules, RFC-6125 hostname verification
       enabled on the TLS socket so a CA-trusted cert for the wrong
       name fails before CONNECT is sent (PR #510).
+- [x] **HA MQTT discovery for the sensors/images.** After a successful
+      publish, ClothesCast now emits retained discovery configs under
+      `homeassistant/.../config` for today / tonight / now text sensors,
+      the `now/timestamp` timestamp sensor, and today / tonight / now
+      image entities. A fresh HA install can pick them up without YAML;
+      audio/video remain retained publish topics consumed by automations
+      or media actions rather than first-class HA MQTT entities.
+
 Open:
 
-- [ ] **HA MQTT discovery for the sensors.** Publish a discovery
-      payload on `homeassistant/sensor/clothescast_today/config` so
-      a fresh HA install picks up the `sensor.clothescast_today` and
-      `sensor.clothescast_tonight` entities without the user editing
-      `configuration.yaml` or pasting YAML into Devices & Services.
-      The discovery JSON is small (`{"name": "...", "state_topic":
-      "...", "unique_id": "..."}`). Same trick for the image, audio,
-      video, and `now/timestamp` topics. Worth it for "drop in the
-      Mosquitto add-on + flip the toggle in ClothesCast" zero-YAML
-      setup.
 - [ ] **Music Assistant `mass.announce` quick-start in the setup
       guide.** docs/smart-home.md now describes the three speaking
       options at a high level, but for users picking Option B the

--- a/docs/smart-home.md
+++ b/docs/smart-home.md
@@ -74,8 +74,13 @@ yourself; no developer-operated service ever sees the payload.
 6. Tap **Save**.
 
 The next scheduled refresh (07:00 by default for today, 19:00 for
-tonight — configurable in Settings → Schedule) will publish a retained
-MQTT message to each topic.
+tonight — configurable in Settings → Schedule) will publish retained
+MQTT messages to each topic. After a successful forecast publish,
+ClothesCast also publishes retained Home Assistant MQTT discovery
+configs under `homeassistant/.../config`, so HA can create the text,
+timestamp, and image entities automatically. The discovery configs point
+at the normal state topics above — they replace YAML setup, not the
+forecast publishes themselves.
 
 ## Broker
 
@@ -121,10 +126,12 @@ topics ClothesCast actually writes:
    ```
    user clothescast
    topic write clothescast/default/#
+   topic write homeassistant/#
    ```
-   That grants write-only access on the topic prefix and nothing else.
-   Adjust the topic if you customised the prefix in the ClothesCast
-   Smart Home settings.
+   That grants write-only access on the topic prefix plus Home
+   Assistant's MQTT discovery config topics, and nothing else. Adjust
+   `clothescast/default/#` if you customised the prefix in the
+   ClothesCast Smart Home settings.
 2. Open the Mosquitto broker add-on's **Configuration** tab and set:
    ```yaml
    customize:
@@ -147,10 +154,30 @@ forecast.
 > `mosquitto.conf` (`acl_file /etc/mosquitto/acl`). HA-side YAML for
 > reading the sensor is identical.
 
-## Home Assistant — reading the sensor
+## Home Assistant — auto-discovered entities
+
+With MQTT discovery enabled in Home Assistant (the default for the MQTT
+integration), ClothesCast creates these entities automatically after the
+next successful publish:
+
+- `sensor.clothescast_today` from `<prefix>/today/text`
+- `sensor.clothescast_tonight` from `<prefix>/tonight/text`
+- `sensor.clothescast_now` from `<prefix>/now/text`
+- `sensor.clothescast_now_updated` from `<prefix>/now/timestamp`
+- `image.clothescast_today_image` from `<prefix>/today/image`
+- `image.clothescast_tonight_image` from `<prefix>/tonight/image`
+- `image.clothescast_now_image` from `<prefix>/now/image`
+
+All entities are grouped under a single ClothesCast device in Home
+Assistant. If a broker ACL rejects `homeassistant/#`, the forecast
+topics still publish normally, but HA will not auto-create the entities;
+allow the discovery topic or use the manual YAML below.
+
+## Home Assistant — manual YAML fallback
 
 Add the following to `configuration.yaml` (or anywhere your
-`mqtt:` block lives):
+`mqtt:` block lives) only if you do not want to use MQTT discovery or
+your broker ACL blocks the discovery config topics:
 
 <!-- raw guard: the snippets below are Home Assistant Jinja templates, not
 Jekyll Liquid. Without this guard GitHub Pages runs Liquid over them first and


### PR DESCRIPTION
## What changed

- Publish retained Home Assistant MQTT discovery configs after successful ClothesCast MQTT publishes, covering forecast sensors and image entities.
- Keep MQTT forecast publishing working even if a broker rejects writes to `homeassistant/#`.
- Add a Today-screen promo card after the other setup cards that routes users to Smart Home settings.
- Persist dismissal for the smart-home promo and hide it automatically once Cast or MQTT is configured.
- Update the smart-home docs and MQTT ACL example for discovery.

## Privacy

- The new Today card does not scan the network or send data by itself; it only opens Smart Home settings.
- MQTT remains opt-in. When enabled, ClothesCast sends forecast prose and generated media only to the user-configured MQTT broker.
- Home Assistant discovery publishes retained entity metadata to `homeassistant/#`; it does not add new forecast prose/media beyond the existing MQTT forecast topics.

## Validation

- `ANDROID_HOME=/home/mikel/Android/Sdk ANDROID_SDK_ROOT=/home/mikel/Android/Sdk ./gradlew :app:testDebugUnitTest --tests app.clothescast.ui.today.PromoBannersTest`
- `ANDROID_HOME=/home/mikel/Android/Sdk ANDROID_SDK_ROOT=/home/mikel/Android/Sdk ./gradlew :core:domain:test :core:data:test :app:testDebugUnitTest`
- `ANDROID_HOME=/home/mikel/Android/Sdk ANDROID_SDK_ROOT=/home/mikel/Android/Sdk ./gradlew :app:assembleDebug`