### PR TITLE
Set up smart devices from the Today screen

### DIFF
--- a/app/src/main/kotlin/app/clothescast/data/SettingsRepository.kt
+++ b/app/src/main/kotlin/app/clothescast/data/SettingsRepository.kt
@@ -445,6 +445,10 @@ class SettingsRepository(
         dataStore.edit { it[GEMINI_PROMO_CARD_DISMISSED] = dismissed }
     }
 
+    suspend fun setSmartHomePromoCardDismissed(dismissed: Boolean) {
+        dataStore.edit { it[SMART_HOME_PROMO_CARD_DISMISSED] = dismissed }
+    }
+
     /**
      * Records that the user tapped "Skip" on onboarding so it doesn't reappear
      * on the next cold launch even while its conditions remain unmet. See
@@ -983,6 +987,7 @@ class SettingsRepository(
         val scheduleCardDismissed = this[SCHEDULE_CARD_DISMISSED] == true
         val playCardDismissed = this[PLAY_CARD_DISMISSED] == true
         val geminiPromoCardDismissed = this[GEMINI_PROMO_CARD_DISMISSED] == true
+        val smartHomePromoCardDismissed = this[SMART_HOME_PROMO_CARD_DISMISSED] == true
         val onboardingSkipped = this[ONBOARDING_SKIPPED] == true
         val calendarPermissionRecheckTick = this[CALENDAR_PERMISSION_RECHECK_TICK] ?: 0L
         val tonightTime = this[TONIGHT_TIME]?.let { LocalTime.parse(it, TIME_FORMAT) }
@@ -1133,6 +1138,7 @@ class SettingsRepository(
             scheduleCardDismissed = scheduleCardDismissed,
             playCardDismissed = playCardDismissed,
             geminiPromoCardDismissed = geminiPromoCardDismissed,
+            smartHomePromoCardDismissed = smartHomePromoCardDismissed,
             onboardingSkipped = onboardingSkipped,
             calendarPermissionRecheckTick = calendarPermissionRecheckTick,
             dailyEnabled = dailyEnabled,
@@ -1408,6 +1414,7 @@ class SettingsRepository(
         private val SCHEDULE_CARD_DISMISSED = booleanPreferencesKey("schedule_card_dismissed")
         private val PLAY_CARD_DISMISSED = booleanPreferencesKey("play_card_dismissed")
         private val GEMINI_PROMO_CARD_DISMISSED = booleanPreferencesKey("gemini_promo_card_dismissed")
+        private val SMART_HOME_PROMO_CARD_DISMISSED = booleanPreferencesKey("smart_home_promo_card_dismissed")
         private val GEMINI_TTS_LIMIT_AT_MS = longPreferencesKey("gemini_tts_limit_at_ms")
         private val GEMINI_TTS_LIMIT_RESET_AT_MS = longPreferencesKey("gemini_tts_limit_reset_at_ms")
         private val GEMINI_TTS_LIMIT_DISMISSED_AT_MS =

--- a/app/src/main/kotlin/app/clothescast/ui/nav/ClothesCastNavHost.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/nav/ClothesCastNavHost.kt
@@ -159,6 +159,7 @@ fun ClothesCastNavHost(
                 onNavigateToDeveloper = { nav.navigate(DeveloperDest) },
                 onNavigateToFormat = { nav.navigate(FormatDest) },
                 onNavigateToVoice = { nav.navigate(VoiceDest) },
+                onNavigateToSmartHome = { nav.navigate(SmartHomeDest) },
             )
         }
 

--- a/app/src/main/kotlin/app/clothescast/ui/today/PromoBanners.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/PromoBanners.kt
@@ -6,19 +6,20 @@ package app.clothescast.ui.today
  * operational banners (update / crash / work-status / holiday), which aren't
  * capped.
  */
-internal enum class PromoBanner { LOCATION, TELEMETRY, CLOTHES, PLAY, GEMINI, SCHEDULE, CELEBRATION }
+internal enum class PromoBanner { LOCATION, TELEMETRY, CLOTHES, PLAY, GEMINI, SCHEDULE, CELEBRATION, SMART_HOME }
 
 /**
  * Decides which promo cards the Today screen shows, capping the stack so a
  * fresh user isn't buried under "set this up" noise. Eligible cards are taken
- * in priority order (location > privacy > clothes > play > gemini > schedule > celebration) up
- * to [maxVisible]; the rest wait until a higher one is resolved or dismissed.
+ * in priority order (location > privacy > clothes > play > gemini > schedule >
+ * celebration > smart home) up to [maxVisible]; the rest wait until a higher
+ * one is resolved or dismissed.
  *
- * The five customization nudges — clothes ([clothesPromoEligible]),
+ * The setup and customization nudges — clothes ([clothesPromoEligible]),
  * schedule ([schedulePromoEligible]), play ([playPromoEligible]),
- * Gemini voices ([geminiPromoEligible]), and
- * holiday/birthday theming ([celebrationEligible]) — plus the location prompt
- * ([locationActionRequired]) are held back until [hasForecast]:
+ * Gemini voices ([geminiPromoEligible]), holiday/birthday theming
+ * ([celebrationEligible]), and smart-home setup ([smartHomePromoEligible]) —
+ * plus the location prompt ([locationActionRequired]) are held back until [hasForecast]:
  * the user has received at least one forecast (foreground or background), i.e.
  * is no longer brand-new. The location banner is forecast-gated because the
  * empty-cache screen already carries its own "set up your location" placeholder
@@ -36,6 +37,7 @@ internal fun promoBannersToShow(
     playPromoEligible: Boolean,
     geminiPromoEligible: Boolean,
     celebrationEligible: Boolean,
+    smartHomePromoEligible: Boolean = false,
     hasForecast: Boolean,
     maxVisible: Int = 2,
 ): Set<PromoBanner> {
@@ -47,6 +49,7 @@ internal fun promoBannersToShow(
         if (geminiPromoEligible && hasForecast) add(PromoBanner.GEMINI)
         if (schedulePromoEligible && hasForecast) add(PromoBanner.SCHEDULE)
         if (celebrationEligible && hasForecast) add(PromoBanner.CELEBRATION)
+        if (smartHomePromoEligible && hasForecast) add(PromoBanner.SMART_HOME)
     }
     return eligible.take(maxVisible).toSet()
 }

--- a/app/src/main/kotlin/app/clothescast/ui/today/SevenDayPage.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/SevenDayPage.kt
@@ -128,6 +128,8 @@ internal fun SevenDayPage(
     onOpenVoice: () -> Unit = {},
     onDismissGeminiTtsPromoCard: () -> Unit = {},
     onDismissGeminiTtsLimitCard: () -> Unit = {},
+    onOpenSmartHome: () -> Unit = {},
+    onDismissSmartHomePromoCard: () -> Unit = {},
     onDismissMqttError: () -> Unit = {},
     onDismissCastError: () -> Unit = {},
 ) {
@@ -234,6 +236,8 @@ internal fun SevenDayPage(
         onOpenVoice = onOpenVoice,
         onDismissGeminiTtsPromoCard = onDismissGeminiTtsPromoCard,
         onDismissGeminiTtsLimitCard = onDismissGeminiTtsLimitCard,
+        onOpenSmartHome = onOpenSmartHome,
+        onDismissSmartHomePromoCard = onDismissSmartHomePromoCard,
         onNavigateToClothes = onNavigateToClothes,
         onDismissMqttError = onDismissMqttError,
         onDismissCastError = onDismissCastError,

--- a/app/src/main/kotlin/app/clothescast/ui/today/SmartHomePromoCard.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/SmartHomePromoCard.kt
@@ -1,0 +1,94 @@
+package app.clothescast.ui.today
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import app.clothescast.R
+
+/**
+ * Today-screen promo card pointing the user at Smart Home settings after the
+ * other setup prompts have had their chance. The card itself does not scan the
+ * network or publish anything; it only routes to the opt-in Cast and MQTT
+ * settings.
+ */
+@Composable
+internal fun SmartHomePromoCard(
+    visible: Boolean,
+    onOpenSmartHome: () -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    if (!visible) return
+    SmartHomePromoCardContent(
+        onOpenSettings = onOpenSmartHome,
+        onDismiss = onDismiss,
+        modifier = modifier,
+    )
+}
+
+@Composable
+internal fun SmartHomePromoCardContent(
+    onOpenSettings: () -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.secondaryContainer,
+            contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+        ),
+    ) {
+        Column(
+            modifier = Modifier.padding(start = 16.dp, top = 8.dp, end = 4.dp, bottom = 12.dp),
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = stringResource(R.string.today_smart_home_promo_title),
+                    style = MaterialTheme.typography.titleSmall,
+                    modifier = Modifier.weight(1f),
+                )
+                IconButton(onClick = onDismiss) {
+                    Icon(
+                        imageVector = Icons.Default.Close,
+                        contentDescription = stringResource(R.string.today_smart_home_promo_dismiss),
+                    )
+                }
+            }
+            Text(
+                text = stringResource(R.string.today_smart_home_promo_body),
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier.padding(end = 12.dp),
+            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End,
+            ) {
+                TextButton(onClick = onOpenSettings) {
+                    Text(stringResource(R.string.today_smart_home_promo_cta))
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
@@ -181,6 +181,7 @@ fun TodayScreen(
     onNavigateToDeveloper: () -> Unit = onNavigateToSettings,
     onNavigateToFormat: () -> Unit = onNavigateToSettings,
     onNavigateToVoice: () -> Unit = onNavigateToSettings,
+    onNavigateToSmartHome: () -> Unit = onNavigateToSettings,
     // Pager page to open on, from the Today deep link's `?page=` query. The
     // feels-like home-screen widgets deep-link to page 0 (current period) and
     // page 2 (7-day). rememberPagerState only reads this on first composition,
@@ -396,6 +397,11 @@ fun TodayScreen(
             onOpenVoice = onNavigateToVoice,
             onDismissGeminiTtsPromoCard = viewModel::dismissGeminiTtsPromoCard,
             onDismissGeminiTtsLimitCard = viewModel::dismissGeminiTtsLimitCard,
+            onOpenSmartHome = {
+                viewModel.dismissSmartHomePromoCard()
+                onNavigateToSmartHome()
+            },
+            onDismissSmartHomePromoCard = viewModel::dismissSmartHomePromoCard,
             onCalendarPermissionChanged = viewModel::notifyCalendarPermissionChanged,
             onNavigateToClothes = onNavigateToClothes,
             onNavigateToFormat = onNavigateToFormat,
@@ -442,6 +448,8 @@ private fun TodayContent(
     onOpenVoice: () -> Unit,
     onDismissGeminiTtsPromoCard: () -> Unit,
     onDismissGeminiTtsLimitCard: () -> Unit,
+    onOpenSmartHome: () -> Unit,
+    onDismissSmartHomePromoCard: () -> Unit,
     onCalendarPermissionChanged: () -> Unit,
     onNavigateToClothes: () -> Unit,
     onNavigateToFormat: () -> Unit,
@@ -527,6 +535,8 @@ private fun TodayContent(
                     onOpenVoice = onOpenVoice,
                     onDismissGeminiTtsPromoCard = onDismissGeminiTtsPromoCard,
                     onDismissGeminiTtsLimitCard = onDismissGeminiTtsLimitCard,
+                    onOpenSmartHome = onOpenSmartHome,
+                    onDismissSmartHomePromoCard = onDismissSmartHomePromoCard,
                     onDismissMqttError = onDismissMqttError,
                     onDismissCastError = onDismissCastError,
                     onOpenCalendarSettings = onOpenCalendarSettings,
@@ -625,8 +635,10 @@ private fun TodayContent(
                         onOpenVoice = onOpenVoice,
                         onDismissGeminiTtsPromoCard = onDismissGeminiTtsPromoCard,
                         onDismissGeminiTtsLimitCard = onDismissGeminiTtsLimitCard,
-                    onDismissMqttError = onDismissMqttError,
-                    onDismissCastError = onDismissCastError,
+                        onOpenSmartHome = onOpenSmartHome,
+                        onDismissSmartHomePromoCard = onDismissSmartHomePromoCard,
+                        onDismissMqttError = onDismissMqttError,
+                        onDismissCastError = onDismissCastError,
                     )
                     return@HorizontalPager
                 }
@@ -686,6 +698,8 @@ private fun TodayContent(
                     onOpenVoice = onOpenVoice,
                     onDismissGeminiTtsPromoCard = onDismissGeminiTtsPromoCard,
                     onDismissGeminiTtsLimitCard = onDismissGeminiTtsLimitCard,
+                    onOpenSmartHome = onOpenSmartHome,
+                    onDismissSmartHomePromoCard = onDismissSmartHomePromoCard,
                     onDismissMqttError = onDismissMqttError,
                     onDismissCastError = onDismissCastError,
                 )
@@ -721,6 +735,8 @@ private fun BannerStack(
     onOpenVoice: () -> Unit,
     onDismissGeminiTtsPromoCard: () -> Unit,
     onDismissGeminiTtsLimitCard: () -> Unit,
+    onOpenSmartHome: () -> Unit,
+    onDismissSmartHomePromoCard: () -> Unit,
     onOpenCalendarSettings: () -> Unit,
     onDismissCelebrationCard: () -> Unit,
     onSetUpLocation: () -> Unit,
@@ -742,6 +758,7 @@ private fun BannerStack(
         playPromoEligible = state.playPromoCardVisible,
         geminiPromoEligible = state.geminiTtsPromoCardVisible,
         celebrationEligible = state.celebrationCardVisible,
+        smartHomePromoEligible = state.smartHomePromoCardVisible,
         hasForecast = state.thisPeriodInsight != null,
     )
     // LocationActionRequiredBanner is first on purpose: without a resolvable
@@ -880,6 +897,12 @@ private fun BannerStack(
         onDismiss = onDismissCelebrationCard,
         modifier = bannerModifier,
     )
+    SmartHomePromoCard(
+        visible = PromoBanner.SMART_HOME in shownPromos,
+        onOpenSmartHome = onOpenSmartHome,
+        onDismiss = onDismissSmartHomePromoCard,
+        modifier = bannerModifier,
+    )
     WorkStatusBanner(status = workStatusToShow, modifier = bannerModifier)
     // Delivery-destination failures sit just under the fetch / work-status
     // banner: the forecast may have fetched fine, but if the cast to the
@@ -944,6 +967,8 @@ internal fun HomePageScaffold(
     onOpenVoice: () -> Unit,
     onDismissGeminiTtsPromoCard: () -> Unit,
     onDismissGeminiTtsLimitCard: () -> Unit,
+    onOpenSmartHome: () -> Unit,
+    onDismissSmartHomePromoCard: () -> Unit,
     onNavigateToClothes: () -> Unit,
     homeSectionOrder: List<HomeSection> = HomeSection.DEFAULTS,
     insightSlot: (@Composable ColumnScope.() -> Unit)? = null,
@@ -1069,6 +1094,8 @@ internal fun HomePageScaffold(
                     onOpenVoice = onOpenVoice,
                     onDismissGeminiTtsPromoCard = onDismissGeminiTtsPromoCard,
                     onDismissGeminiTtsLimitCard = onDismissGeminiTtsLimitCard,
+                    onOpenSmartHome = onOpenSmartHome,
+                    onDismissSmartHomePromoCard = onDismissSmartHomePromoCard,
                     onDismissMqttError = onDismissMqttError,
                     onDismissCastError = onDismissCastError,
                     onOpenCalendarSettings = onOpenCalendarSettings,
@@ -1227,6 +1254,8 @@ private fun TodayPage(
     onOpenVoice: () -> Unit,
     onDismissGeminiTtsPromoCard: () -> Unit,
     onDismissGeminiTtsLimitCard: () -> Unit,
+    onOpenSmartHome: () -> Unit,
+    onDismissSmartHomePromoCard: () -> Unit,
 ) {
     val scrollScope = rememberCoroutineScope()
     // Captured via onGloballyPositioned so the chip-tap handler can scroll the
@@ -1255,6 +1284,8 @@ private fun TodayPage(
         onOpenVoice = onOpenVoice,
         onDismissGeminiTtsPromoCard = onDismissGeminiTtsPromoCard,
         onDismissGeminiTtsLimitCard = onDismissGeminiTtsLimitCard,
+        onOpenSmartHome = onOpenSmartHome,
+        onDismissSmartHomePromoCard = onDismissSmartHomePromoCard,
         onNavigateToClothes = onNavigateToClothes,
         onDismissMqttError = onDismissMqttError,
         onDismissCastError = onDismissCastError,

--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayViewModel.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayViewModel.kt
@@ -27,6 +27,7 @@ import app.clothescast.core.domain.repository.CalendarEventReader
 import app.clothescast.core.domain.usecase.DeriveInsight
 import app.clothescast.core.domain.usecase.HolidayResolver
 import app.clothescast.core.domain.usecase.ThemeForToday
+import app.clothescast.core.domain.usecase.isMqttPublishable
 import app.clothescast.tts.toJavaLocale
 import java.util.Locale
 import app.clothescast.data.InsightCache
@@ -213,6 +214,13 @@ data class TodayState(
      * voices. Hides the moment a key lands, regardless of the dismissal flag.
      */
     val geminiTtsPromoCardVisible: Boolean = false,
+    /**
+     * Whether the "Set up ClothesCast on your smart devices" promo is eligible
+     * — true iff the user hasn't dismissed it AND has not configured either
+     * MQTT or Cast yet. It points at Smart Home settings for opt-in smart
+     * displays and home automation setup.
+     */
+    val smartHomePromoCardVisible: Boolean = false,
     /**
      * Whether the "free voice limit reached" card is showing — true iff a synth
      * hit the shared-key daily Gemini TTS allowance, the user hasn't dismissed
@@ -757,6 +765,9 @@ class TodayViewModel(
             // a bug. The limit card already routes to the same Speech settings.
             geminiTtsPromoCardVisible = !prefs.geminiPromoCardDismissed &&
                 !geminiKeyConfigured && !geminiKeyNeedsReentry && !misc.geminiTtsLimitExceeded,
+            smartHomePromoCardVisible = !prefs.smartHomePromoCardDismissed &&
+                !isMqttPublishable(prefs) &&
+                prefs.castRouteId.isNullOrBlank(),
             // Gate on no BYOK key: a configured key bypasses the shared free
             // proxy entirely, so the moment the user adds one (e.g. via this
             // card's CTA) the limit no longer applies and the card hides
@@ -845,6 +856,17 @@ class TodayViewModel(
     fun dismissGeminiTtsPromoCard() {
         viewModelScope.launch {
             settingsRepository.setGeminiPromoCardDismissed(true)
+        }
+    }
+
+    /**
+     * Persists the user's dismissal of the Today-screen smart-home setup promo.
+     * Called on both the X-tap and the "Smart home settings" CTA so once the
+     * user has been pointed at the page the card stays hidden.
+     */
+    fun dismissSmartHomePromoCard() {
+        viewModelScope.launch {
+            settingsRepository.setSmartHomePromoCardDismissed(true)
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -432,6 +432,15 @@
     <string name="today_celebration_card_cta">Calendar settings</string>
     <string name="today_celebration_card_dismiss">Dismiss</string>
 
+    <!-- Promo card on the Today screen routing users to opt-in Cast and
+         Home Assistant / MQTT setup. The card itself does not scan or publish;
+         it only opens Smart Home settings. Auto-hides once Cast or MQTT is
+         configured, OR after the user dismisses it / follows the CTA. -->
+    <string name="today_smart_home_promo_title">Set up ClothesCast on your smart devices</string>
+    <string name="today_smart_home_promo_body">Get ClothesCast on your smart displays and home automation.</string>
+    <string name="today_smart_home_promo_cta">Smart home settings</string>
+    <string name="today_smart_home_promo_dismiss">Dismiss</string>
+
     <string name="today_view_other_period">View other forecast</string>
     <string name="today_back_to_primary">Back</string>
     <string name="today_placeholder_today_title">Today\'s forecast</string>

--- a/app/src/test/kotlin/app/clothescast/ui/today/PromoBannersTest.kt
+++ b/app/src/test/kotlin/app/clothescast/ui/today/PromoBannersTest.kt
@@ -275,6 +275,52 @@ class PromoBannersTest {
     }
 
     @Test
+    fun `smart home promo is held back until a forecast exists`() {
+        promoBannersToShow(
+            locationActionRequired = false,
+            telemetryNoticeVisible = false,
+            clothesPromoEligible = false,
+            schedulePromoEligible = false,
+            playPromoEligible = false,
+            geminiPromoEligible = false,
+            celebrationEligible = false,
+            smartHomePromoEligible = true,
+            hasForecast = false,
+        ) shouldBe emptySet()
+    }
+
+    @Test
+    fun `smart home promo shows once a forecast exists`() {
+        promoBannersToShow(
+            locationActionRequired = false,
+            telemetryNoticeVisible = false,
+            clothesPromoEligible = false,
+            schedulePromoEligible = false,
+            playPromoEligible = false,
+            geminiPromoEligible = false,
+            celebrationEligible = false,
+            smartHomePromoEligible = true,
+            hasForecast = true,
+        ) shouldContainExactlyInAnyOrder listOf(PromoBanner.SMART_HOME)
+    }
+
+    @Test
+    fun `smart home promo waits behind celebration under the cap`() {
+        promoBannersToShow(
+            locationActionRequired = false,
+            telemetryNoticeVisible = false,
+            clothesPromoEligible = false,
+            schedulePromoEligible = false,
+            playPromoEligible = false,
+            geminiPromoEligible = false,
+            celebrationEligible = true,
+            smartHomePromoEligible = true,
+            hasForecast = true,
+            maxVisible = 1,
+        ) shouldContainExactlyInAnyOrder listOf(PromoBanner.CELEBRATION)
+    }
+
+    @Test
     fun `gemini promo outranks schedule under the cap`() {
         promoBannersToShow(
             locationActionRequired = false,

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Settings.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Settings.kt
@@ -691,6 +691,14 @@ data class UserPreferences(
      */
     val geminiPromoCardDismissed: Boolean = false,
     /**
+     * Set to true once the user acts on the Today-screen "Set up ClothesCast on
+     * your smart devices" promo card — either dismissing it via the X button or
+     * following its CTA into Smart Home settings. The card is additionally
+     * gated on no smart-home destination being configured, so it disappears as
+     * soon as the user sets up Cast or MQTT.
+     */
+    val smartHomePromoCardDismissed: Boolean = false,
+    /**
      * Set to true when the user taps "Skip" on the first-run onboarding screen.
      * Onboarding normally reappears on every cold launch while any of its
      * conditions (notification permission, location, Gemini key) are still


### PR DESCRIPTION
## What changed

- Add a Today-screen promo card after the other setup cards with:
  - `Set up ClothesCast on your smart devices`
  - `Get ClothesCast on your smart displays and home automation.`
  - `Smart home settings`
- Route the card directly to Smart Home settings.
- Persist dismissal so the card stays hidden after the user dismisses it or follows the CTA.
- Hide the card automatically once the user has configured Cast or a publishable MQTT bridge with a saved broker host.
- Cover the new promo priority behavior in `PromoBannersTest`.

## Privacy

The card does not scan the network, probe devices, publish MQTT data, or send anything off-device. It only opens Smart Home settings, where Cast and MQTT remain explicit opt-in features.

## Validation

- `ANDROID_HOME=/home/mikel/Android/Sdk ANDROID_SDK_ROOT=/home/mikel/Android/Sdk ./gradlew :app:testDebugUnitTest --tests app.clothescast.ui.today.PromoBannersTest`
- `ANDROID_HOME=/home/mikel/Android/Sdk ANDROID_SDK_ROOT=/home/mikel/Android/Sdk ./gradlew :core:domain:test :core:data:test :app:testDebugUnitTest`
- `ANDROID_HOME=/home/mikel/Android/Sdk ANDROID_SDK_ROOT=/home/mikel/Android/Sdk ./gradlew :app:assembleDebug`