### PR TITLE
Tapping Play always speaks the forecast on your phone

### DIFF
--- a/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
@@ -1395,9 +1395,11 @@ class FetchAndNotifyWorker(
         // audio (willCast AND a synth buffer exists). An image-only
         // cast (Gemini unavailable / synth failed → silent WAV stub)
         // doesn't trigger suppression — the smart display isn't the
-        // speaker in that path.
-        val castHasAudio = gates.willCast && wav != null
-        if (castHasAudio && castDeferred != null && prefs.castSkipPhoneSpeech) {
+        // speaker in that path. gates.castSuppressesPhone folds in
+        // castSkipPhoneSpeech and the forced-Play override: a tapped
+        // Play always speaks on this phone even when a cast is playing.
+        val castHasAudio = gates.castSuppressesPhone && wav != null
+        if (castHasAudio && castDeferred != null) {
             val castOutcome = castDeferred.await()
             if (castOutcome is CastInsightController.CastWorkerOutcome.Success) {
                 DiagLog.i(TAG, "Phone speech suppressed — smart display is playing the forecast.")
@@ -1410,9 +1412,11 @@ class FetchAndNotifyWorker(
         // the user's HA-side automation to play it. Only suppresses
         // when the publish included audio (synth succeeded) — without
         // a buffer the broker has nothing to speak, so the phone needs
-        // to.
-        val mqttHasAudio = gates.mqttPublishable && wav != null
-        if (mqttHasAudio && prefs.mqttSkipPhoneSpeech) {
+        // to. gates.mqttSuppressesPhone folds in mqttSkipPhoneSpeech and
+        // the forced-Play override, so a tapped Play isn't silenced just
+        // because the bridge published the forecast.
+        val mqttHasAudio = gates.mqttSuppressesPhone && wav != null
+        if (mqttHasAudio) {
             val mqttOutcome = mqttDeferred.await()
             if (mqttOutcome is MqttPublishOutcome.Success) {
                 DiagLog.i(TAG, "Phone speech suppressed — MQTT bridge published the forecast.")

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Settings.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Settings.kt
@@ -958,7 +958,9 @@ data class UserPreferences(
      * redundant. Publishes that didn't include audio (Gemini synth failed,
      * device TTS only) don't trigger the suppression — the phone speaker
      * is what speaks in that path. The phone *notification* still posts
-     * per [deliveryMode]; only TTS playback is affected.
+     * per [deliveryMode]; only TTS playback is affected. An explicit Play
+     * tap overrides this — the user asked this phone to speak now, so it
+     * always does even when the bridge published the forecast.
      */
     val mqttSkipPhoneSpeech: Boolean = true,
     /**
@@ -1005,7 +1007,9 @@ data class UserPreferences(
      * (Gemini unavailable, smart display showing the outfit PNG silently)
      * don't trigger the suppression — the phone speaker is what speaks in
      * that path. The phone *notification* still posts per [deliveryMode];
-     * only TTS playback is affected.
+     * only TTS playback is affected. An explicit Play tap overrides this —
+     * the user asked this phone to speak now, so it always does even when
+     * the cast is playing.
      */
     val castSkipPhoneSpeech: Boolean = true,
 ) {

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/DeliveryGates.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/DeliveryGates.kt
@@ -68,6 +68,27 @@ data class DeliveryGates(
      */
     val mqttPublishable: Boolean,
     /**
+     * A successful audio-carrying cast should take over for the phone
+     * speaker on this run — `willCast` AND `castSkipPhoneSpeech`. The
+     * worker still requires a synth buffer and a *successful* cast at
+     * runtime before it actually stays quiet; this flag is just the
+     * "settings say the display is the speaker" half.
+     *
+     * Cleared by [forcePhoneSpeech]: an explicit Play tap is the user
+     * asking *this phone* to speak now, so it overrides the takeover —
+     * the phone speaks even when the cast also plays.
+     */
+    val castSuppressesPhone: Boolean,
+    /**
+     * Mirror of [castSuppressesPhone] for the MQTT bridge: a successful
+     * audio publish should take over for the phone speaker when
+     * `mqttPublishable` AND `mqttSkipPhoneSpeech`. Same runtime caveat
+     * (needs a buffer and a successful publish) and same
+     * [forcePhoneSpeech] override — a tapped Play is never silenced just
+     * because the bridge published the forecast.
+     */
+    val mqttSuppressesPhone: Boolean,
+    /**
      * True when a Gemini PCM buffer is needed by some destination:
      * MQTT audio publish, audio-carrying cast, or phone speaker on
      * the Gemini engine when the evening isn't being skipped.
@@ -101,7 +122,10 @@ data class DeliveryGates(
  *   Gemini is the only PCM producer — pulls the phone-speaker term into
  *   `needsSynth` so the buffer exists when the speaker reaches for it.
  *   Also clears `emptyEveningSkip`: an explicit "deliver now" tap is
- *   never suppressed by the tonight "only notify on events" rule.
+ *   never suppressed by the tonight "only notify on events" rule, and
+ *   clears `castSuppressesPhone` / `mqttSuppressesPhone` so a tapped
+ *   forecast is heard on the phone even when a cast or the MQTT bridge
+ *   would otherwise take over as the speaker.
  *   Defaults to false: scheduled runs and the Schedule "Play now"
  *   preview keep honouring the delivery mode exactly as before.
  */
@@ -127,6 +151,12 @@ fun computeDeliveryGates(
     }
     val willCast = prefs.castEnabled && prefs.castRouteId != null && castPeriodEnabled
     val castWillHaveAudio = willCast && geminiAvailable
+
+    // Phone-speaker takeover: a cast / MQTT publish only speaks for the
+    // phone on a scheduled run. A forced Play is the user asking this
+    // phone to speak now, so it overrides both takeovers.
+    val castSuppressesPhone = !forcePhoneSpeech && willCast && prefs.castSkipPhoneSpeech
+    val mqttSuppressesPhone = !forcePhoneSpeech && mqttPublishable && prefs.mqttSkipPhoneSpeech
 
     // Empty-evening only applies to TONIGHT. TODAY is never skipped
     // here regardless of `tonightNotifyOnlyOnEvents`. A forced Play
@@ -163,6 +193,8 @@ fun computeDeliveryGates(
         castWillHaveAudio = castWillHaveAudio,
         emptyEveningSkip = emptyEveningSkip,
         mqttPublishable = mqttPublishable,
+        castSuppressesPhone = castSuppressesPhone,
+        mqttSuppressesPhone = mqttSuppressesPhone,
         needsSynth = needsSynth,
     )
 }

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/DeliveryGatesTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/DeliveryGatesTest.kt
@@ -246,6 +246,93 @@ class DeliveryGatesTest {
     }
 
     @Test
+    fun `MQTT publishable + skip-phone-speech — bridge takes over phone speech on a scheduled run`() {
+        val gates = computeDeliveryGates(
+            prefs = basePrefs.copy(
+                ttsEngine = TtsEngine.GEMINI,
+                mqttSkipPhoneSpeech = true,
+            ),
+            period = ForecastPeriod.TODAY,
+            insightHasEvents = false,
+            geminiAvailable = true,
+            mqttPublishable = true,
+        )
+        gates.mqttSuppressesPhone shouldBe true
+    }
+
+    @Test
+    fun `force phone speech overrides MQTT takeover — tapped Play still speaks on the phone`() {
+        // Bug report 2026-06-03: MQTT bridge on with skip-phone-speech
+        // silenced a manual Play. The explicit tap must win over the
+        // bridge takeover — the phone speaks even though the bridge
+        // published the forecast.
+        val gates = computeDeliveryGates(
+            prefs = basePrefs.copy(
+                ttsEngine = TtsEngine.GEMINI,
+                mqttSkipPhoneSpeech = true,
+            ),
+            period = ForecastPeriod.TODAY,
+            insightHasEvents = false,
+            geminiAvailable = true,
+            mqttPublishable = true,
+            forcePhoneSpeech = true,
+        )
+        gates.mqttSuppressesPhone shouldBe false
+    }
+
+    @Test
+    fun `MQTT skip-phone-speech off — bridge never takes over phone speech`() {
+        val gates = computeDeliveryGates(
+            prefs = basePrefs.copy(
+                ttsEngine = TtsEngine.GEMINI,
+                mqttSkipPhoneSpeech = false,
+            ),
+            period = ForecastPeriod.TODAY,
+            insightHasEvents = false,
+            geminiAvailable = true,
+            mqttPublishable = true,
+        )
+        gates.mqttSuppressesPhone shouldBe false
+    }
+
+    @Test
+    fun `cast + skip-phone-speech — display takes over phone speech on a scheduled run`() {
+        val gates = computeDeliveryGates(
+            prefs = basePrefs.copy(
+                ttsEngine = TtsEngine.GEMINI,
+                castRouteId = "route-1",
+                castMorning = true,
+                castSkipPhoneSpeech = true,
+            ),
+            period = ForecastPeriod.TODAY,
+            insightHasEvents = false,
+            geminiAvailable = true,
+            mqttPublishable = false,
+        )
+        gates.willCast shouldBe true
+        gates.castSuppressesPhone shouldBe true
+    }
+
+    @Test
+    fun `force phone speech overrides cast takeover — tapped Play still speaks on the phone`() {
+        val gates = computeDeliveryGates(
+            prefs = basePrefs.copy(
+                ttsEngine = TtsEngine.GEMINI,
+                castRouteId = "route-1",
+                castMorning = true,
+                castSkipPhoneSpeech = true,
+            ),
+            period = ForecastPeriod.TODAY,
+            insightHasEvents = false,
+            geminiAvailable = true,
+            mqttPublishable = false,
+            forcePhoneSpeech = true,
+        )
+        gates.willCast shouldBe true
+        gates.castSuppressesPhone shouldBe false
+    }
+
+    @Test
     fun `isMqttPublishable — toggle on but blank host is not publishable`() {
         isMqttPublishable(
             basePrefs.copy(mqttBridgeEnabled = true, mqttHost = null),


### PR DESCRIPTION
## What & why

Two bug reports, one root cause:

1. **"I didn't hear the TTS this time."**
2. **"The Play/Stop button should show Stop until the TTS finishes"** (it reverted to Play almost immediately).

The Today screen's **Play** button is an explicit *"speak this now, on this phone"* request — `enqueuePlay(forceNotifyAndSpeak = true)`. That flag already overrode the scheduled delivery mode and the tonight "only notify on events" skip, **but the worker's cast / MQTT phone-speech handoff ignored it.**

With the MQTT bridge enabled and **"skip phone speech"** on (the default for both MQTT and cast), a successful publish suppressed the phone speaker — so a manual Play published the bundle to the broker and played **nothing audible** on the phone. And because `playPhoneSpeaker()` returns immediately when suppressed, the delivery worker finished in a second or two, flipping the Stop button back to Play almost instantly instead of staying Stop for the length of the spoken forecast.

The reporter's config matches exactly: `MQTT bridge enabled: true`, and the log shows `Phone speech suppressed — MQTT bridge published the forecast.`

## The fix

Fold the forced-Play override into the gate algebra (`computeDeliveryGates`), where the `phoneTtsConfigured` / `emptyEveningSkip` overrides already live:

- New gates `castSuppressesPhone` / `mqttSuppressesPhone` capture "a successful cast / publish should take over for the phone speaker" — and `forcePhoneSpeech` clears both.
- `FetchAndNotifyWorker.playPhoneSpeaker()` now reads those gates instead of `prefs.*SkipPhoneSpeech` directly.

Result: an explicit Play always speaks on the phone, even when a cast or the bridge also plays the forecast. **Scheduled runs are unchanged** — the handoff still applies there. And with the phone actually speaking, the worker stays `RUNNING` through playback, so the Stop button now correctly persists until the speech finishes (`anyWorkActive` is driven by the worker's lifecycle, and `deliver()` joins on the phone-speaker job).

## Privacy

No change to what crosses the device boundary — this only affects whether the **local** phone speaker plays. MQTT publish content is unchanged.

## Test plan

- New `DeliveryGatesTest` cases: MQTT/cast handoff fires on a scheduled run, is cleared by `forcePhoneSpeech`, and respects the skip-phone-speech prefs being off.
- `./gradlew :core:domain:test :core:data:test :app:testDebugUnitTest` — green (no snapshot diffs).
- `./gradlew :app:assembleDebug` — running locally; CI covers it.

https://claude.ai/code/session_01CpWLF9s1CfX9fRJ2rrCK57

---
_Generated by [Claude Code](https://claude.ai/code/session_01CpWLF9s1CfX9fRJ2rrCK57)_