### PR TITLE
Translate the bug-report screenshot notice into all languages

### DIFF
--- a/app/src/main/res/values-am/strings.xml
+++ b/app/src/main/res/values-am/strings.xml
@@ -346,6 +346,7 @@ The rest of the UI falls through to values/strings.xml (English).
     <!-- Bug report consent -->
     <string name="bug_report_consent_title">ስህተት ሪፖርት ያጋሩ?</string>
     <string name="bug_report_consent_body">ይህ ችግሮችን ለመመርመር ይረዳል። ሪፖርቱ ቦታዎን፣ የመተግበሪያ ቅንብሮችን፣ እና የቅርብ ጊዜ እንቅስቃሴዎን ጨምሮ ስሱ ግላዊ መረጃ ይይዛል። ከመላክዎ በፊት መፈተሸና ማርትዕ ይችላሉ።</string>
+    <string name="bug_report_consent_screenshot">እንዲሁም አሁን ያሉበትን ማያ ገጽ ቅጽበታዊ ገጽ እይታ ያያይዛል፣ ስለዚህ ከመላክዎ በፊት የግል ነገር አለማሳየቱን ያረጋግጡ።</string>
     <string name="bug_report_consent_dont_show_again">ዳግም አታሳይ</string>
     <string name="bug_report_consent_continue">ቀጥል</string>
     <string name="bug_report_consent_cancel">ሰርዝ</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -442,6 +442,7 @@ they work correctly in both the single-band and range templates.
     <!-- Bug report consent dialog -->
     <string name="bug_report_consent_title">مشاركة تقرير الخطأ؟</string>
     <string name="bug_report_consent_body">يساعد ذلك في تشخيص المشكلات. يحتوي التقرير على معلومات شخصية حساسة، بما فيها موقعك وإعدادات التطبيق والنشاط الأخير. ستتمكن من مراجعته وتعديله قبل الإرسال.</string>
+    <string name="bug_report_consent_screenshot">كما يُرفِق لقطة شاشة للشاشة التي تستخدمها الآن، لذا تأكّد قبل الإرسال من أنها لا تُظهر أي معلومات خاصة.</string>
     <string name="bug_report_consent_dont_show_again">لا تُظهر هذا مجددًا</string>
     <string name="bug_report_consent_continue">متابعة</string>
     <string name="bug_report_consent_cancel">إلغاء</string>

--- a/app/src/main/res/values-b+sr+Cyrl/strings.xml
+++ b/app/src/main/res/values-b+sr+Cyrl/strings.xml
@@ -567,6 +567,7 @@ surfaces.
     <!-- Bug report consent dialog. -->
     <string name="bug_report_consent_title">Поделити извештај о грешци?</string>
     <string name="bug_report_consent_body">Ово помаже у дијагностиковању проблема. Извештај садржи осетљиве личне податке, укључујући твоју локацију, подешавања апликације и недавну активност. Моћи ћеш да га прегледаш и уредиш пре слања.</string>
+    <string name="bug_report_consent_screenshot">Такође прилаже снимак екрана на ком се тренутно налазиш, зато пре слања провери да не приказује нешто приватно.</string>
     <string name="bug_report_consent_dont_show_again">Не приказуј више</string>
     <string name="bug_report_consent_continue">Настави</string>
     <string name="bug_report_consent_cancel">Откажи</string>

--- a/app/src/main/res/values-b+sr+Latn/strings.xml
+++ b/app/src/main/res/values-b+sr+Latn/strings.xml
@@ -579,6 +579,7 @@ default English (matching values-pl / values-uk).
     <!-- Bug report consent dialog. -->
     <string name="bug_report_consent_title">Podeliti izveštaj o grešci?</string>
     <string name="bug_report_consent_body">Ovo pomaže u dijagnostikovanju problema. Izveštaj sadrži osetljive lične podatke, uključujući tvoju lokaciju, podešavanja aplikacije i nedavnu aktivnost. Moći ćeš da ga pregledaš i urediš pre slanja.</string>
+    <string name="bug_report_consent_screenshot">Takođe prilaže snimak ekrana na kom se trenutno nalaziš, zato pre slanja proveri da ne prikazuje nešto privatno.</string>
     <string name="bug_report_consent_dont_show_again">Ne prikazuj više</string>
     <string name="bug_report_consent_continue">Nastavi</string>
     <string name="bug_report_consent_cancel">Otkaži</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -577,6 +577,7 @@ What is NOT overridden, by design:
     <!-- Bug report consent dialog. -->
     <string name="bug_report_consent_title">Да се сподели ли доклад за грешка?</string>
     <string name="bug_report_consent_body">Това помага за диагностициране на проблеми. Докладът съдържа чувствителна лична информация, включително твоето местоположение, настройките на приложението и скорошната активност. Ще можеш да го прегледаш и редактираш преди изпращане.</string>
+    <string name="bug_report_consent_screenshot">Освен това прилага екранна снимка на екрана, на който си сега, затова преди да изпратиш, провери дали не показва нещо лично.</string>
     <string name="bug_report_consent_dont_show_again">Не показвай отново</string>
     <string name="bug_report_consent_continue">Продължи</string>
     <string name="bug_report_consent_cancel">Откажи</string>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -614,6 +614,7 @@ West Bengal vocabulary differences in a future PR.
 
     <string name="bug_report_consent_title">বাগ রিপোর্ট শেয়ার করবেন?</string>
     <string name="bug_report_consent_body">এটি সমস্যা নির্ণয়ে সাহায্য করে। রিপোর্টে আপনার অবস্থান, অ্যাপের সেটিংস এবং সাম্প্রতিক কার্যকলাপ সহ সংবেদনশীল ব্যক্তিগত তথ্য রয়েছে। পাঠানোর আগে আপনি এটি পর্যালোচনা ও সম্পাদনা করতে পারবেন।</string>
+    <string name="bug_report_consent_screenshot">এটি আপনি এখন যে স্ক্রিনে আছেন তার একটি স্ক্রিনশটও সংযুক্ত করে, তাই পাঠানোর আগে দেখে নিন এটি কোনো ব্যক্তিগত কিছু দেখাচ্ছে না।</string>
     <string name="bug_report_consent_dont_show_again">আর দেখাবেন না</string>
     <string name="bug_report_consent_continue">চালিয়ে যান</string>
     <string name="bug_report_consent_cancel">বাতিল করুন</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -474,6 +474,7 @@ the in-app clock is digit-driven and reads consistently across locales.
 
     <string name="bug_report_consent_title">Compartir l\'informe d\'errors?</string>
     <string name="bug_report_consent_body">Això ajuda a diagnosticar problemes. L\'informe conté informació personal sensible, com la teva ubicació, la configuració de l\'aplicació i l\'activitat recent. Podràs revisar-lo i editar-lo abans d\'enviar-lo.</string>
+    <string name="bug_report_consent_screenshot">També adjunta una captura de la pantalla on ets ara, així que abans d\'enviar-la comprova que no mostri res privat.</string>
     <string name="bug_report_consent_dont_show_again">No tornis a mostrar-ho</string>
     <string name="bug_report_consent_continue">Continua</string>
     <string name="bug_report_consent_cancel">Cancel·la</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -523,6 +523,7 @@ locale (Angličtina (USA), Francouzština (Francie), Němčina (Německo), …).
     <!-- Bug report consent dialog. -->
     <string name="bug_report_consent_title">Sdílet hlášení chyby?</string>
     <string name="bug_report_consent_body">Pomáhá to diagnostikovat problémy. Zpráva obsahuje citlivé osobní informace, včetně tvé polohy, nastavení aplikace a nedávné aktivity. Můžeš ji před odesláním zkontrolovat a upravit.</string>
+    <string name="bug_report_consent_screenshot">Přiloží také snímek obrazovky, na které se právě nacházíš, takže před odesláním zkontroluj, že neukazuje nic soukromého.</string>
     <string name="bug_report_consent_dont_show_again">Příště nezobrazovat</string>
     <string name="bug_report_consent_continue">Pokračovat</string>
     <string name="bug_report_consent_cancel">Zrušit</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -526,6 +526,7 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrig)").
     <!-- Bug report consent dialog. -->
     <string name="bug_report_consent_title">Del fejlrapport?</string>
     <string name="bug_report_consent_body">Det hjælper med at diagnosticere problemer. Rapporten indeholder følsomme personlige oplysninger, herunder din placering, app-indstillinger og seneste aktiviteter. Du kan gennemgå og redigere den, før du sender.</string>
+    <string name="bug_report_consent_screenshot">Den vedhæfter også et skærmbillede af den skærm, du er på nu, så tjek, at det ikke viser noget privat, før du sender.</string>
     <string name="bug_report_consent_dont_show_again">Vis ikke igen</string>
     <string name="bug_report_consent_continue">Fortsæt</string>
     <string name="bug_report_consent_cancel">Annuller</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -715,6 +715,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <!-- Bug report consent dialog. -->
     <string name="bug_report_consent_title">Fehlerbericht teilen?</string>
     <string name="bug_report_consent_body">Dies hilft bei der Diagnose von Problemen. Der Bericht enthält sensible persönliche Informationen, einschließlich deines Standorts, deiner App-Einstellungen und deiner letzten Aktivitäten. Du kannst ihn vor dem Senden überprüfen und bearbeiten.</string>
+    <string name="bug_report_consent_screenshot">Außerdem wird ein Screenshot des aktuellen Bildschirms angehängt. Prüfe daher vor dem Senden, dass darauf nichts Privates zu sehen ist.</string>
     <string name="bug_report_consent_dont_show_again">Nicht mehr anzeigen</string>
     <string name="bug_report_consent_continue">Weiter</string>
     <string name="bug_report_consent_cancel">Abbrechen</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -634,6 +634,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <!-- Bug-report consent dialog. -->
     <string name="bug_report_consent_title">Κοινοποίηση αναφοράς σφάλματος;</string>
     <string name="bug_report_consent_body">Βοηθά στη διάγνωση προβλημάτων. Η αναφορά περιέχει ευαίσθητες προσωπικές πληροφορίες, συμπεριλαμβανομένης της τοποθεσίας σου, των ρυθμίσεων της εφαρμογής και της πρόσφατης δραστηριότητας. Θα μπορείς να την ελέγξεις και να την επεξεργαστείς πριν την αποστολή.</string>
+    <string name="bug_report_consent_screenshot">Επισυνάπτει επίσης ένα στιγμιότυπο της οθόνης στην οποία βρίσκεσαι τώρα, γι\' αυτό πριν το στείλεις έλεγξε ότι δεν δείχνει κάτι προσωπικό.</string>
     <string name="bug_report_consent_dont_show_again">Να μην εμφανίζεται ξανά</string>
     <string name="bug_report_consent_continue">Συνέχεια</string>
     <string name="bug_report_consent_cancel">Άκυρο</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -684,6 +684,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <!-- Bug report consent dialog. -->
     <string name="bug_report_consent_title">¿Compartir informe de error?</string>
     <string name="bug_report_consent_body">Esto ayuda a diagnosticar problemas. El informe contiene información personal sensible, incluida tu ubicación, la configuración de la app y la actividad reciente. Podrás revisarlo y editarlo antes de enviarlo.</string>
+    <string name="bug_report_consent_screenshot">También adjunta una captura de la pantalla en la que estás ahora, así que antes de enviarla comprueba que no muestre nada privado.</string>
     <string name="bug_report_consent_dont_show_again">No volver a mostrar</string>
     <string name="bug_report_consent_continue">Continuar</string>
     <string name="bug_report_consent_cancel">Cancelar</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -480,6 +480,7 @@ Tone is informal "sina"-form throughout ("Pane … selga", "Võta … kaasa",
 
     <string name="bug_report_consent_title">Jaga veaaruannet?</string>
     <string name="bug_report_consent_body">See aitab probleeme diagnoosida. Aruanne sisaldab tundlikku isiklikku teavet, sh sinu asukoha, rakenduse seaded ja hiljutise tegevuse. Saad seda enne saatmist üle vaadata ja redigeerida.</string>
+    <string name="bug_report_consent_screenshot">Samuti lisatakse ekraanipilt praegusest kuvast, nii et enne saatmist kontrolli, et sellel poleks midagi privaatset.</string>
     <string name="bug_report_consent_dont_show_again">Ära näita seda enam</string>
     <string name="bug_report_consent_continue">Jätka</string>
     <string name="bug_report_consent_cancel">Tühista</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -430,6 +430,7 @@ Western Arabic numerals (0-9) are used for TTS compatibility.
     <!-- Bug report consent dialog -->
     <string name="bug_report_consent_title">گزارش خطا را به اشتراک می‌گذارید؟</string>
     <string name="bug_report_consent_body">این به تشخیص مشکلات کمک می‌کند. گزارش حاوی اطلاعات شخصی حساس است، از جمله موقعیت شما، تنظیمات برنامه و فعالیت اخیر. قبل از ارسال می‌توانید آن را بررسی و ویرایش کنید.</string>
+    <string name="bug_report_consent_screenshot">همچنین یک عکس از صفحه‌ای که اکنون در آن هستید پیوست می‌کند، پس پیش از ارسال مطمئن شوید چیز خصوصی‌ای نشان نمی‌دهد.</string>
     <string name="bug_report_consent_dont_show_again">دیگر نشان نده</string>
     <string name="bug_report_consent_continue">ادامه</string>
     <string name="bug_report_consent_cancel">لغو</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -572,6 +572,7 @@ displayed label localizes.
 
     <string name="bug_report_consent_title">Jaetaanko virheraportti?</string>
     <string name="bug_report_consent_body">Tämä auttaa ongelmien diagnosoinnissa. Raportti sisältää arkaluonteisia henkilötietoja, mukaan lukien sijaintisi, sovelluksen asetuksesi ja viimeaikaiset toimintasi. Voit tarkistaa ja muokata sitä ennen lähettämistä.</string>
+    <string name="bug_report_consent_screenshot">Se liittää mukaan myös kuvakaappauksen nykyisestä näytöstä, joten tarkista ennen lähettämistä, ettei siinä näy mitään yksityistä.</string>
     <string name="bug_report_consent_dont_show_again">Älä näytä uudelleen</string>
     <string name="bug_report_consent_continue">Jatka</string>
     <string name="bug_report_consent_cancel">Peruuta</string>

--- a/app/src/main/res/values-fil/strings.xml
+++ b/app/src/main/res/values-fil/strings.xml
@@ -604,6 +604,7 @@ The rest of the UI falls through to values/strings.xml (English).
          ============================================================ -->
     <string name="bug_report_consent_title">Ibahagi ang ulat ng bug?</string>
     <string name="bug_report_consent_body">Nakakatulong ito sa pag-diagnose ng mga isyu. Ang ulat ay naglalaman ng sensitibong personal na impormasyon, kabilang ang iyong lokasyon, mga setting ng app, at kamakailang aktibidad. Maaari mo itong suriin at i-edit bago ipadala.</string>
+    <string name="bug_report_consent_screenshot">Naglalakip din ito ng screenshot ng kasalukuyang screen mo, kaya bago ipadala, tiyaking walang pribadong ipinapakita.</string>
     <string name="bug_report_consent_dont_show_again">Huwag nang ipakita ito ulit</string>
     <string name="bug_report_consent_continue">Magpatuloy</string>
     <string name="bug_report_consent_cancel">Kanselahin</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -681,6 +681,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <!-- Bug report consent dialog. -->
     <string name="bug_report_consent_title">Partager le rapport de bug ?</string>
     <string name="bug_report_consent_body">Cela aide à diagnostiquer les problèmes. Le rapport contient des informations personnelles sensibles, notamment ta position, les paramètres de l\'app et ton activité récente. Tu pourras le vérifier et le modifier avant de l\'envoyer.</string>
+    <string name="bug_report_consent_screenshot">Il joint aussi une capture de l\'écran sur lequel tu es maintenant, alors vérifie qu\'elle ne montre rien de privé avant de l\'envoyer.</string>
     <string name="bug_report_consent_dont_show_again">Ne plus afficher</string>
     <string name="bug_report_consent_continue">Continuer</string>
     <string name="bug_report_consent_cancel">Annuler</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -583,6 +583,7 @@ Not overridden by design:
     <!-- Bug report consent dialog. -->
     <string name="bug_report_consent_title">बग रिपोर्ट साझा करें?</string>
     <string name="bug_report_consent_body">यह समस्याओं को जाँचने में मदद करता है। रिपोर्ट में आपका स्थान, ऐप सेटिंग और हालिया गतिविधि सहित संवेदनशील व्यक्तिगत जानकारी शामिल है। भेजने से पहले आप इसे देख और संपादित कर सकते हैं।</string>
+    <string name="bug_report_consent_screenshot">यह अभी आप जिस स्क्रीन पर हैं उसका स्क्रीनशॉट भी जोड़ता है, इसलिए भेजने से पहले देख लें कि उसमें कोई निजी चीज़ न दिख रही हो।</string>
     <string name="bug_report_consent_dont_show_again">यह दोबारा न दिखाएँ</string>
     <string name="bug_report_consent_continue">जारी रखें</string>
     <string name="bug_report_consent_cancel">रद्द करें</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -649,6 +649,7 @@ spousal register), matching the existing insight prose ("Ponesi …",
     <!-- Bug report consent dialog. -->
     <string name="bug_report_consent_title">Podijeliti izvješće o grešci?</string>
     <string name="bug_report_consent_body">Ovo pomaže u dijagnosticiranju problema. Izvješće sadrži osjetljive osobne podatke, uključujući tvoju lokaciju, postavke aplikacije i nedavnu aktivnost. Moći ćeš ga pregledati i urediti prije slanja.</string>
+    <string name="bug_report_consent_screenshot">Također prilaže snimku zaslona na kojem se trenutačno nalaziš, pa prije slanja provjeri da ne prikazuje ništa privatno.</string>
     <string name="bug_report_consent_dont_show_again">Ne prikazuj više</string>
     <string name="bug_report_consent_continue">Nastavi</string>
     <string name="bug_report_consent_cancel">Odustani</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -525,6 +525,7 @@ locale (Angol (Egyesült Államok), Francia (Franciaország), Német
     <!-- Bug report consent dialog. -->
     <string name="bug_report_consent_title">Hibajelentés megosztása?</string>
     <string name="bug_report_consent_body">Ez segít a problémák diagnosztizálásában. A jelentés érzékeny személyes adatokat tartalmaz, beleértve a helyszínedet, az alkalmazásbeállításaidat és a legutóbbi tevékenységeidet. Elküldés előtt megtekintheted és szerkesztheted.</string>
+    <string name="bug_report_consent_screenshot">Csatol egy képernyőképet is a jelenlegi képernyődről, ezért küldés előtt ellenőrizd, hogy nem látszik-e rajta valami magánjellegű.</string>
     <string name="bug_report_consent_dont_show_again">Ne jelenjen meg újra</string>
     <string name="bug_report_consent_continue">Folytatás</string>
     <string name="bug_report_consent_cancel">Mégse</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -563,6 +563,7 @@ to values/strings.xml (English).
     <!-- Bug report consent dialog -->
     <string name="bug_report_consent_title">Bagikan laporan bug?</string>
     <string name="bug_report_consent_body">Ini membantu mendiagnosis masalah. Laporan ini berisi informasi pribadi sensitif, termasuk lokasi, pengaturan aplikasi, dan aktivitas terkini Anda. Anda dapat meninjau dan mengeditnya sebelum dikirim.</string>
+    <string name="bug_report_consent_screenshot">Ini juga melampirkan tangkapan layar dari layar yang sedang Anda buka, jadi sebelum mengirim, periksa apakah ada hal pribadi yang terlihat.</string>
     <string name="bug_report_consent_dont_show_again">Jangan tampilkan lagi</string>
     <string name="bug_report_consent_continue">Lanjutkan</string>
     <string name="bug_report_consent_cancel">Batal</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -667,6 +667,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <!-- Bug report consent dialog. -->
     <string name="bug_report_consent_title">Condividere il report di bug?</string>
     <string name="bug_report_consent_body">Questo aiuta a diagnosticare i problemi. Il report contiene informazioni personali sensibili, tra cui la tua posizione, le impostazioni dell\'app e l\'attività recente. Potrai esaminarlo e modificarlo prima di inviarlo.</string>
+    <string name="bug_report_consent_screenshot">Allega anche uno screenshot della schermata in cui ti trovi ora, quindi prima di inviarlo controlla che non mostri nulla di privato.</string>
     <string name="bug_report_consent_dont_show_again">Non mostrare più</string>
     <string name="bug_report_consent_continue">Continua</string>
     <string name="bug_report_consent_cancel">Annulla</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -438,6 +438,7 @@ standard in Israeli digital communication.
     <!-- Bug report consent dialog -->
     <string name="bug_report_consent_title">לשתף דוח תקלה?</string>
     <string name="bug_report_consent_body">זה עוזר לאבחן בעיות. הדוח מכיל מידע אישי רגיש, כולל מיקומך, הגדרות האפליקציה ופעילות אחרונה. תוכל/י לסקור ולערוך לפני השליחה.</string>
+    <string name="bug_report_consent_screenshot">המערכת גם מצרפת צילום מסך של המסך שפתוח אצלך עכשיו, אז לפני השליחה כדאי לבדוק שלא מופיע בו מידע פרטי.</string>
     <string name="bug_report_consent_dont_show_again">אל תציג/י שוב</string>
     <string name="bug_report_consent_continue">המשך/י</string>
     <string name="bug_report_consent_cancel">ביטול</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -690,6 +690,7 @@ the displayed label localizes.
     <!-- Bug report consent dialog. -->
     <string name="bug_report_consent_title">バグレポートを共有しますか？</string>
     <string name="bug_report_consent_body">問題の診断に役立ちます。レポートには、現在地、アプリの設定、最近の操作など、機密性の高い個人情報が含まれます。送信前に内容を確認・編集できます。</string>
+    <string name="bug_report_consent_screenshot">現在開いている画面のスクリーンショットも添付されます。送信する前に、個人的な情報が写っていないか確認してください。</string>
     <string name="bug_report_consent_dont_show_again">今後表示しない</string>
     <string name="bug_report_consent_continue">続ける</string>
     <string name="bug_report_consent_cancel">キャンセル</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -693,6 +693,7 @@ displayed label localizes.
     <!-- Bug report consent dialog. -->
     <string name="bug_report_consent_title">버그 보고서를 공유할까요?</string>
     <string name="bug_report_consent_body">문제 진단에 도움이 됩니다. 보고서에는 위치, 앱 설정, 최근 활동 등 민감한 개인정보가 포함됩니다. 보내기 전에 검토하고 편집할 수 있습니다.</string>
+    <string name="bug_report_consent_screenshot">현재 보고 있는 화면의 스크린샷도 함께 첨부됩니다. 보내기 전에 비공개 정보가 없는지 확인하세요.</string>
     <string name="bug_report_consent_dont_show_again">다시 표시 안 함</string>
     <string name="bug_report_consent_continue">계속</string>
     <string name="bug_report_consent_cancel">취소</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -575,6 +575,7 @@ What is NOT overridden, by design:
     <!-- Bug report consent dialog. -->
     <string name="bug_report_consent_title">Bendrinti klaidos ataskaitą?</string>
     <string name="bug_report_consent_body">Tai padeda diagnozuoti problemas. Ataskaita apima jautrią asmeninę informaciją, įskaitant tavo vietą, programos nustatymus ir pastarąją veiklą. Prieš siunčiant galėsi peržiūrėti ir redaguoti.</string>
+    <string name="bug_report_consent_screenshot">Taip pat pridedama dabartinio ekrano ekrano kopija, todėl prieš siųsdamas patikrink, ar joje nematyti nieko asmeniško.</string>
     <string name="bug_report_consent_dont_show_again">Nerodyti dar kartą</string>
     <string name="bug_report_consent_continue">Tęsti</string>
     <string name="bug_report_consent_cancel">Atšaukti</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -535,6 +535,7 @@ informal "tu"-form throughout ("Apģērb …", "Paņem … līdzi").
     <!-- Bug report consent -->
     <string name="bug_report_consent_title">Kopīgot kļūdu ziņojumu?</string>
     <string name="bug_report_consent_body">Tas palīdz diagnosticēt problēmas. Ziņojumā ir sensitīva personiskā informācija, tostarp tava atrašanās vieta, lietotnes iestatījumi un nesenā aktivitāte. Pirms nosūtīšanas varēsi to pārskatīt un rediģēt.</string>
+    <string name="bug_report_consent_screenshot">Tāpat tiek pievienots pašreizējā ekrāna ekrānuzņēmums, tāpēc pirms nosūtīšanas pārliecinies, ka tajā nav redzams nekas privāts.</string>
     <string name="bug_report_consent_dont_show_again">Vairs nerādīt</string>
     <string name="bug_report_consent_continue">Turpināt</string>
     <string name="bug_report_consent_cancel">Atcelt</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -560,6 +560,7 @@ vs "kemungkinan", "padam" vs "hapus").
     <!-- Bug report consent dialog -->
     <string name="bug_report_consent_title">Kongsikan laporan pepijat?</string>
     <string name="bug_report_consent_body">Ini membantu mendiagnosis masalah. Laporan ini mengandungi maklumat peribadi yang sensitif, termasuk lokasi, tetapan aplikasi, dan aktiviti terkini anda. Anda akan dapat menyemak dan menyunting sebelum menghantar.</string>
+    <string name="bug_report_consent_screenshot">Ia juga melampirkan tangkapan skrin bagi skrin yang anda buka sekarang, jadi sebelum menghantar, pastikan tiada apa-apa peribadi yang dipaparkan.</string>
     <string name="bug_report_consent_dont_show_again">Jangan tunjukkan ini lagi</string>
     <string name="bug_report_consent_continue">Teruskan</string>
     <string name="bug_report_consent_cancel">Batal</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -526,6 +526,7 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrike)").
     <!-- Bug report consent dialog. -->
     <string name="bug_report_consent_title">Del feilrapport?</string>
     <string name="bug_report_consent_body">Det hjelper med å diagnostisere problemer. Rapporten inneholder sensitiv personlig informasjon, inkludert stedet ditt, appinnstillingene og nylige aktiviteter. Du kan gjennomgå og redigere den før du sender.</string>
+    <string name="bug_report_consent_screenshot">Den legger også ved et skjermbilde av skjermen du er på nå, så sjekk at det ikke viser noe privat før du sender.</string>
     <string name="bug_report_consent_dont_show_again">Ikke vis igjen</string>
     <string name="bug_report_consent_continue">Fortsett</string>
     <string name="bug_report_consent_cancel">Avbryt</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -637,6 +637,7 @@ the displayed label localizes.
     <!-- Bug report consent dialog. -->
     <string name="bug_report_consent_title">Bugrapport delen?</string>
     <string name="bug_report_consent_body">Dit helpt bij het diagnosticeren van problemen. Het rapport bevat gevoelige persoonlijke informatie, waaronder je locatie, app-instellingen en recente activiteit. Je kunt het voor verzending bekijken en bewerken.</string>
+    <string name="bug_report_consent_screenshot">Het voegt ook een schermafbeelding toe van het scherm waarop je nu bent, dus controleer voor het verzenden dat er niets privés op staat.</string>
     <string name="bug_report_consent_dont_show_again">Niet meer weergeven</string>
     <string name="bug_report_consent_continue">Doorgaan</string>
     <string name="bug_report_consent_cancel">Annuleren</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -635,6 +635,7 @@ is unchanged; only the displayed label localizes.
     <!-- Bug report consent dialog. -->
     <string name="bug_report_consent_title">Udostępnić raport o błędzie?</string>
     <string name="bug_report_consent_body">Pomoże to w diagnozowaniu problemów. Raport zawiera wrażliwe dane osobowe, w tym Twoją lokalizację, ustawienia aplikacji i ostatnią aktywność. Możesz go przejrzeć i edytować przed wysłaniem.</string>
+    <string name="bug_report_consent_screenshot">Dołącza też zrzut ekranu, na którym teraz jesteś, więc przed wysłaniem sprawdź, czy nie widać na nim niczego prywatnego.</string>
     <string name="bug_report_consent_dont_show_again">Nie pokazuj ponownie</string>
     <string name="bug_report_consent_continue">Dalej</string>
     <string name="bug_report_consent_cancel">Anuluj</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -652,6 +652,7 @@ zh-CN) is unchanged; only the displayed label localizes.
 
     <string name="bug_report_consent_title">Compartilhar relatório de bug?</string>
     <string name="bug_report_consent_body">Isso ajuda a diagnosticar problemas. O relatório contém informações pessoais sensíveis, incluindo sua localização, configurações do app e atividade recente. Você poderá revisar e editar antes de enviar.</string>
+    <string name="bug_report_consent_screenshot">Ele também anexa uma captura de tela da tela em que você está agora, então confira se não há nada privado antes de enviar.</string>
     <string name="bug_report_consent_dont_show_again">Não mostrar novamente</string>
     <string name="bug_report_consent_continue">Continuar</string>
     <string name="bug_report_consent_cancel">Cancelar</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -694,6 +694,7 @@ they diverge from BR ("Polonês" → "Polaco", "Holandês" →
 
     <string name="bug_report_consent_title">Partilhar relatório de erro?</string>
     <string name="bug_report_consent_body">Isto ajuda a diagnosticar problemas. O relatório contém informações pessoais sensíveis, incluindo a tua localização, definições da aplicação e atividade recente. Poderás rever e editar antes de enviar.</string>
+    <string name="bug_report_consent_screenshot">Também anexa uma captura de ecrã do ecrã onde estás agora, por isso, antes de enviar, verifica que não mostra nada privado.</string>
     <string name="bug_report_consent_dont_show_again">Não mostrar novamente</string>
     <string name="bug_report_consent_continue">Continuar</string>
     <string name="bug_report_consent_cancel">Cancelar</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -566,6 +566,7 @@ surfaces fall back to default English (matching values-pl / values-uk).
     <!-- Bug report consent dialog. -->
     <string name="bug_report_consent_title">Trimiți raportul de bug?</string>
     <string name="bug_report_consent_body">Aceasta ajută la diagnosticarea problemelor. Raportul conține informații personale sensibile, inclusiv locația ta, setările aplicației și activitatea recentă. Îl vei putea revizui și edita înainte de trimitere.</string>
+    <string name="bug_report_consent_screenshot">Atașează și o captură a ecranului pe care ești acum, așa că înainte de a trimite verifică să nu apară ceva privat.</string>
     <string name="bug_report_consent_dont_show_again">Nu mai arăta din nou</string>
     <string name="bug_report_consent_continue">Continuă</string>
     <string name="bug_report_consent_cancel">Anulează</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -591,6 +591,7 @@ only the displayed label localizes.
     <!-- Bug report consent dialog. -->
     <string name="bug_report_consent_title">Поделиться отчётом об ошибке?</string>
     <string name="bug_report_consent_body">Это поможет диагностировать проблемы. Отчёт содержит конфиденциальные данные, включая твоё местоположение, настройки приложения и последние действия. Перед отправкой ты сможешь просмотреть и отредактировать его.</string>
+    <string name="bug_report_consent_screenshot">Также прикрепляется снимок экрана, который у тебя сейчас открыт, поэтому перед отправкой проверь, не видно ли на нём чего-то личного.</string>
     <string name="bug_report_consent_dont_show_again">Больше не показывать</string>
     <string name="bug_report_consent_continue">Продолжить</string>
     <string name="bug_report_consent_cancel">Отмена</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -537,6 +537,7 @@ What is NOT overridden, by design:
     <!-- Bug report consent dialog. -->
     <string name="bug_report_consent_title">Zdieľať hlásenie chyby?</string>
     <string name="bug_report_consent_body">Pomáha to diagnostikovať problémy. Správa obsahuje citlivé osobné informácie vrátane tvojej polohy, nastavení aplikácie a nedávnej aktivity. Pred odoslaním si ju budeš môcť prezrieť a upraviť.</string>
+    <string name="bug_report_consent_screenshot">Priloží aj snímku obrazovky, na ktorej sa práve nachádzaš, takže pred odoslaním skontroluj, či na nej nie je niečo súkromné.</string>
     <string name="bug_report_consent_dont_show_again">Nabudúce nezobrazovať</string>
     <string name="bug_report_consent_continue">Pokračovať</string>
     <string name="bug_report_consent_cancel">Zrušiť</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -575,6 +575,7 @@ informal "ti"-form throughout, mirroring the Croatian / Serbian pass.
     <!-- Bug report consent dialog. -->
     <string name="bug_report_consent_title">Deli poročilo o napaki?</string>
     <string name="bug_report_consent_body">To pomaga pri diagnosticiranju težav. Poročilo vsebuje občutljive osebne podatke, vključno z lokacijo, nastavitvami aplikacije in nedavno dejavnostjo. Pred pošiljanjem ga boš lahko pregledal in uredil.</string>
+    <string name="bug_report_consent_screenshot">Priloži tudi posnetek zaslona, ki ga imaš trenutno odprtega, zato pred pošiljanjem preveri, da na njem ni ničesar zasebnega.</string>
     <string name="bug_report_consent_dont_show_again">Ne prikazuj več</string>
     <string name="bug_report_consent_continue">Nadaljuj</string>
     <string name="bug_report_consent_cancel">Prekliči</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -526,6 +526,7 @@ native names for all locales (e.g. "Tyska (Tyskland)", "Franska (Frankrike)").
     <!-- Bug report consent dialog. -->
     <string name="bug_report_consent_title">Dela felrapport?</string>
     <string name="bug_report_consent_body">Det här hjälper till att diagnostisera problem. Rapporten innehåller känslig personlig information, inklusive din plats, appinställningar och senaste aktiviteter. Du kan granska och redigera den innan du skickar.</string>
+    <string name="bug_report_consent_screenshot">Den bifogar även en skärmbild av skärmen du är på nu, så kontrollera att den inte visar något privat innan du skickar.</string>
     <string name="bug_report_consent_dont_show_again">Visa inte igen</string>
     <string name="bug_report_consent_continue">Fortsätt</string>
     <string name="bug_report_consent_cancel">Avbryt</string>

--- a/app/src/main/res/values-sw/strings.xml
+++ b/app/src/main/res/values-sw/strings.xml
@@ -413,6 +413,7 @@ The rest of the UI falls through to values/strings.xml (English).
     <!-- Bug report consent -->
     <string name="bug_report_consent_title">Shiriki ripoti ya hitilafu?</string>
     <string name="bug_report_consent_body">Hii husaidia kutambua matatizo. Ripoti ina taarifa za kibinafsi nyeti, ikiwa ni pamoja na mahali pako, mipangilio ya programu, na shughuli za hivi karibuni. Utaweza kukagua na kuhariri kabla ya kutuma.</string>
+    <string name="bug_report_consent_screenshot">Pia inaambatisha picha ya skrini unayoiona sasa, kwa hivyo kabla ya kutuma, hakikisha haionyeshi chochote cha faragha.</string>
     <string name="bug_report_consent_dont_show_again">Usionyeshe tena</string>
     <string name="bug_report_consent_continue">Endelea</string>
     <string name="bug_report_consent_cancel">Ghairi</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -560,6 +560,7 @@ The rest of the UI falls through to values/strings.xml (English).
     <!-- Bug report consent dialog -->
     <string name="bug_report_consent_title">แชร์รายงานข้อผิดพลาด?</string>
     <string name="bug_report_consent_body">ช่วยวินิจฉัยปัญหา รายงานมีข้อมูลส่วนตัวที่ละเอียดอ่อน รวมถึงตำแหน่ง การตั้งค่าแอป และกิจกรรมล่าสุด คุณจะสามารถตรวจสอบและแก้ไขได้ก่อนส่ง</string>
+    <string name="bug_report_consent_screenshot">ระบบจะแนบภาพหน้าจอของหน้าจอที่คุณกำลังดูอยู่ด้วย ดังนั้นก่อนส่ง โปรดตรวจสอบว่าไม่มีข้อมูลส่วนตัวปรากฏอยู่</string>
     <string name="bug_report_consent_dont_show_again">ไม่ต้องแสดงอีก</string>
     <string name="bug_report_consent_continue">ดำเนินการต่อ</string>
     <string name="bug_report_consent_cancel">ยกเลิก</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -571,6 +571,7 @@ displayed label localizes.
 
     <string name="bug_report_consent_title">Hata raporu paylaşılsın mı?</string>
     <string name="bug_report_consent_body">Bu sorunların teşhisine yardımcı olur. Rapor konumunuz, uygulama ayarlarınız ve son etkinlikleriniz dahil olmak üzere hassas kişisel bilgiler içerir. Göndermeden önce inceleyip düzenleyebilirsiniz.</string>
+    <string name="bug_report_consent_screenshot">Ayrıca şu anda açık olan ekranın bir ekran görüntüsünü de ekler; bu nedenle göndermeden önce özel bir şey göstermediğinden emin olun.</string>
     <string name="bug_report_consent_dont_show_again">Tekrar gösterme</string>
     <string name="bug_report_consent_continue">Devam et</string>
     <string name="bug_report_consent_cancel">İptal</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -529,6 +529,7 @@ only the displayed label localizes.
     <!-- Bug report consent dialog. -->
     <string name="bug_report_consent_title">Поділитися звітом про помилку?</string>
     <string name="bug_report_consent_body">Це допоможе діагностувати проблеми. Звіт містить конфіденційні особисті дані, зокрема ваше місцезнаходження, налаштування застосунку та нещодавні дії. Перед надсиланням ви зможете переглянути та відредагувати його.</string>
+    <string name="bug_report_consent_screenshot">Також додається знімок екрана, який у вас зараз відкритий, тож перед надсиланням перевірте, чи не видно на ньому чогось особистого.</string>
     <string name="bug_report_consent_dont_show_again">Більше не показувати</string>
     <string name="bug_report_consent_continue">Продовжити</string>
     <string name="bug_report_consent_cancel">Скасувати</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -615,6 +615,7 @@ Skipped intentionally: app_name (brand), insight_time_am/pm/midnight/noon
          ===================================================================== -->
     <string name="bug_report_consent_title">Chia sẻ báo cáo lỗi?</string>
     <string name="bug_report_consent_body">Điều này giúp chẩn đoán sự cố. Báo cáo chứa thông tin cá nhân nhạy cảm, bao gồm vị trí, cài đặt ứng dụng và hoạt động gần đây. Bạn sẽ có thể xem xét và chỉnh sửa trước khi gửi.</string>
+    <string name="bug_report_consent_screenshot">Báo cáo cũng đính kèm ảnh chụp màn hình bạn đang xem, vì vậy hãy kiểm tra để chắc chắn không có gì riêng tư trước khi gửi.</string>
     <string name="bug_report_consent_dont_show_again">Không hiện lại</string>
     <string name="bug_report_consent_continue">Tiếp tục</string>
     <string name="bug_report_consent_cancel">Hủy</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -682,6 +682,7 @@ label localizes.
     <!-- Bug report consent dialog. -->
     <string name="bug_report_consent_title">分享错误报告？</string>
     <string name="bug_report_consent_body">这有助于诊断问题。报告包含敏感的个人信息，包括你的位置、应用设置和近期活动。发送前你可以查看并编辑内容。</string>
+    <string name="bug_report_consent_screenshot">它还会附上你当前屏幕的截图，所以发送前请检查上面没有显示任何隐私内容。</string>
     <string name="bug_report_consent_dont_show_again">不再显示</string>
     <string name="bug_report_consent_continue">继续</string>
     <string name="bug_report_consent_cancel">取消</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -697,6 +697,7 @@ label localises.
     <!-- Bug report consent dialog. -->
     <string name="bug_report_consent_title">分享錯誤報告？</string>
     <string name="bug_report_consent_body">這有助於診斷問題。報告包含敏感的個人資訊，包括你的位置、應用程式設定和近期活動。傳送前你可以檢視和編輯內容。</string>
+    <string name="bug_report_consent_screenshot">它也會附上你目前畫面的螢幕截圖，所以傳送前請檢查上面沒有顯示任何隱私內容。</string>
     <string name="bug_report_consent_dont_show_again">不再顯示</string>
     <string name="bug_report_consent_continue">繼續</string>
     <string name="bug_report_consent_cancel">取消</string>


### PR DESCRIPTION
## What

Adds the consent dialog's screenshot disclosure string (`bug_report_consent_screenshot`) to all **45 translated locales**. It shipped en-US-only when the screenshot feature landed (#982); this fills in the rest.

## Why

The dialog now warns that the bug report attaches a screenshot of the current screen before it leaves the device. Until this PR, only English users saw that warning — everyone else got the older, text-only disclosure with no mention of the screenshot. This closes that gap so the privacy notice is consistent across languages.

## How

One `<string name="bug_report_consent_screenshot">` per locale, inserted right after each file's existing `bug_report_consent_body`. Each translation:
- matches the **formality** the locale's existing consent body already uses (informal vs. polite "you"),
- uses the locale's natural term for "screenshot",
- conveys the same meaning as en-US: *"It also attaches a screenshot of the screen you're on now, so check it doesn't show anything private before you send."*

No code or behavior change — strings only.

## Test plan

- `./gradlew :app:assembleDebug` — passes (resource compiler accepts all 45, apostrophes escaped as `\'`).
- All touched files validated as well-formed XML.
- 46 locales total now define the string (45 translated + base en-US).

---
_Generated by [Claude Code](https://claude.ai/code/session_01QxCCdvgcDCDyV4w2JoTNXA)_