### PR TITLE
internal: clear RestrictedApi lint errors, plural gaps, and an MQTT CheckResult warning

### DIFF
--- a/app/src/main/kotlin/app/clothescast/mqtt/MqttPublisher.kt
+++ b/app/src/main/kotlin/app/clothescast/mqtt/MqttPublisher.kt
@@ -660,6 +660,10 @@ data class MqttConfig(
     val password: String?,
 )
 
+// HiveMQ's builders are fluent and mutate in place, returning the receiver;
+// sslWithDefaultConfig() / password() inside the apply{} blocks below take
+// effect even though their return value is discarded.
+@Suppress("CheckResult")
 private suspend fun publishWithHiveMq(
     config: MqttConfig,
     topic: String,

--- a/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
@@ -127,6 +127,10 @@ class FetchAndNotifyWorker(
         }
     }
 
+    // WorkManager marks Result.Success/Failure and getOutputData @RestrictTo its
+    // own library group; reading the terminal Result's output data here is
+    // intentional and has no public equivalent.
+    @Suppress("RestrictedApi")
     private fun recordDailyRefreshOutcome(period: ForecastPeriod, result: Result, startMs: Long) {
         val outcome = when (result) {
             is Result.Success -> {
@@ -724,6 +728,7 @@ class FetchAndNotifyWorker(
      * Result.retry() leaves the WorkInfo non-terminal, so it doesn't need stamping;
      * we only annotate success / failure outputs.
      */
+    @Suppress("RestrictedApi") // see recordDailyRefreshOutcome: reading restricted Result output is intentional
     private fun stamped(result: Result): Result {
         val now = System.currentTimeMillis()
         return when (result) {

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -1072,6 +1072,7 @@ the in-app clock is digit-driven and reads consistently across locales.
     <string name="holiday_name_whit_monday">Dilluns de Pentecosta</string>
     <plurals name="insight_clothes_layer_count">
         <item quantity="one">%1$d capa</item>
+        <item quantity="many">%1$d capes</item>
         <item quantity="other">%1$d capes</item>
     </plurals>
     <string name="insight_delta_cooler_lead">farà %1$d° menys que ahir.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1260,6 +1260,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="holiday_name_whit_monday">Lunes de Pentecostés</string>
     <plurals name="insight_clothes_layer_count">
         <item quantity="one">%1$d capa</item>
+        <item quantity="many">%1$d capas</item>
         <item quantity="other">%1$d capas</item>
     </plurals>
     <string name="insight_delta_cooler_lead">hará %1$d° menos que ayer.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1259,6 +1259,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="holiday_name_whit_monday">Lundi de Pentecôte</string>
     <plurals name="insight_clothes_layer_count">
         <item quantity="one">%1$d couche</item>
+        <item quantity="many">%1$d couches</item>
         <item quantity="other">%1$d couches</item>
     </plurals>
     <string name="insight_delta_cooler_lead">il fera %1$d° de moins qu\'hier.</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1245,6 +1245,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="holiday_name_whit_monday">Lunedì di Pentecoste</string>
     <plurals name="insight_clothes_layer_count">
         <item quantity="one">%1$d strato</item>
+        <item quantity="many">%1$d strati</item>
         <item quantity="other">%1$d strati</item>
     </plurals>
     <string name="insight_delta_cooler_lead">farà %1$d° in meno rispetto a ieri.</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -1130,7 +1130,6 @@ standard in Israeli digital communication.
     <plurals name="insight_clothes_layer_count">
         <item quantity="one">שכבה אחת</item>
         <item quantity="two">שתי שכבות</item>
-        <item quantity="many">%1$d שכבות</item>
         <item quantity="other">%1$d שכבות</item>
     </plurals>
     <string name="insight_delta_cooler_lead">יהיה קריר ב-%1$d° מאשר אתמול.</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1217,6 +1217,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="holiday_name_whit_monday">Segunda-feira de Pentecostes</string>
     <plurals name="insight_clothes_layer_count">
         <item quantity="one">%1$d camada</item>
+        <item quantity="many">%1$d camadas</item>
         <item quantity="other">%1$d camadas</item>
     </plurals>
     <string name="insight_delta_cooler_lead">ficará %1$d° mais frio que ontem.</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -1260,6 +1260,7 @@ they diverge from BR ("Polonês" → "Polaco", "Holandês" →
     <string name="holiday_name_whit_monday">Segunda-feira de Pentecostes</string>
     <plurals name="insight_clothes_layer_count">
         <item quantity="one">%1$d camada</item>
+        <item quantity="many">%1$d camadas</item>
         <item quantity="other">%1$d camadas</item>
     </plurals>
     <string name="insight_delta_cooler_lead">estará %1$d° mais frio do que ontem.</string>


### PR DESCRIPTION
Lint hygiene on `:app`. **No user-visible behavior change** (suppressions are no-ops; the plural changes only matter at magnitudes that never occur for clothing-layer counts), so this is `internal:`.

## Changes

1. **`RestrictedApi` (12 errors → 0).** `@Suppress("RestrictedApi")` on `FetchAndNotifyWorker.recordDailyRefreshOutcome` and `stamped()`. Both read a terminal WorkManager `Result`'s `outputData` on the `Success`/`Failure` subtypes — intentional, with no public-API equivalent. Commented inline.

2. **Plural quantities (`MissingQuantity` ×6 + `UnusedQuantity` ×1 → 0).** Added the `many` quantity to `insight_clothes_layer_count` for `ca`, `es`, `fr`, `it`, `pt-BR`, `pt-PT` (these CLDR languages require it; content mirrors `other`), and removed the irrelevant `many` item from Hebrew (`iw`). No runtime change — layer counts never reach the magnitudes `many` selects.

3. **`CheckResult` ×2 → 0.** `@Suppress("CheckResult")` on `MqttPublisher.publishWithHiveMq()`. Confirmed benign: HiveMQ's builders are fluent and mutate in place, so `sslWithDefaultConfig()` / `password()` take effect even though their return value is discarded inside `apply { }` (TLS and auth are correctly applied).

## Test plan

- `./gradlew :app:lintDebug` → these specific findings are all 0.
- `./gradlew :core:domain:test :app:testDebugUnitTest` → green.
- `./gradlew :app:assembleDebug` → BUILD SUCCESSFUL.

## Note / not in this PR

While doing this I found my earlier "21 errors = all RestrictedApi" tally was wrong — a grep bug skipped tags containing spaces. It's actually 12 `RestrictedApi` + **9 `androidx.compose.ui` lint errors** (`NonObservableLocale`, `FlowOperatorInvokedInComposition`, `LocalContextConfigurationRead`, `LocalContextGetResourceValueCall`). This PR clears the 12; the 9 are pre-existing and need case-by-case handling (some are genuine fixes, a couple are intentional patterns needing justified suppression), so they're deliberately left for a follow-up.

https://claude.ai/code/session_01Ljmd6nzZ1oNSaW6rDQYFUq

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ljmd6nzZ1oNSaW6rDQYFUq)_