### PR TITLE
internal: fix Compose UI lint errors for observable locale and resource reads

### DIFF
--- a/app/src/main/kotlin/app/clothescast/MainActivity.kt
+++ b/app/src/main/kotlin/app/clothescast/MainActivity.kt
@@ -67,13 +67,15 @@ class MainActivity : ComponentActivity() {
                 it.themeMode to it.colorPalette
             }
         }
+        // Derive the theme/palette flows outside composition — invoking flow
+        // operators (map) inside setContent recreates them on every recompose.
+        val themeModeFlow = app.settingsRepository.preferences.map { it.themeMode }
+        val colorPaletteFlow = app.settingsRepository.preferences.map { it.colorPalette }
         try {
             setContent {
-                val themeMode by app.settingsRepository.preferences
-                    .map { it.themeMode }
+                val themeMode by themeModeFlow
                     .collectAsStateWithLifecycle(initialValue = initialPrefs.first)
-                val colorPalette by app.settingsRepository.preferences
-                    .map { it.colorPalette }
+                val colorPalette by colorPaletteFlow
                     .collectAsStateWithLifecycle(initialValue = initialPrefs.second)
                 val darkTheme = when (themeMode) {
                     ThemeMode.SYSTEM -> isSystemInDarkTheme()

--- a/app/src/main/kotlin/app/clothescast/ui/settings/AboutSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/AboutSettings.kt
@@ -153,6 +153,7 @@ private fun AboutCard() {
 @Composable
 private fun DebugCard() {
     val context = LocalContext.current
+    val fireToast = stringResource(R.string.settings_debug_fire_toast)
     SectionCard(title = stringResource(R.string.settings_debug_title)) {
         Text(
             text = stringResource(R.string.settings_debug_description),
@@ -163,7 +164,7 @@ private fun DebugCard() {
                 FetchAndNotifyWorker.enqueueOneShot(context.applicationContext)
                 Toast.makeText(
                     context,
-                    context.getString(R.string.settings_debug_fire_toast),
+                    fireToast,
                     Toast.LENGTH_SHORT,
                 ).show()
             },

--- a/app/src/main/kotlin/app/clothescast/ui/settings/HolidaySettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/HolidaySettings.kt
@@ -40,6 +40,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
@@ -128,8 +129,9 @@ internal fun CalendarContent(
     val scrollState = rememberScrollState()
     val coroutineScope = rememberCoroutineScope()
     val context = LocalContext.current
-    val uiLocale = remember(context.resources.configuration) {
-        context.resources.configuration.locales.get(0) ?: Locale.getDefault()
+    val configuration = LocalConfiguration.current
+    val uiLocale = remember(configuration) {
+        configuration.locales.get(0) ?: Locale.getDefault()
     }
 
     // One source of permission truth for the whole page — the master toggle, the
@@ -797,6 +799,9 @@ private fun OverrideDropdown(
  * crashing.
  */
 @Composable
+// The resource id is looked up dynamically by name (getIdentifier), so
+// stringResource() can't be used here — the id isn't known at compile time.
+@Suppress("LocalContextGetResourceValueCall")
 private fun resolveHolidayString(name: String): String? {
     val context = LocalContext.current
     val resId = context.resources.getIdentifier(name, "string", context.packageName)

--- a/app/src/main/kotlin/app/clothescast/ui/settings/RegionSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/RegionSettings.kt
@@ -23,6 +23,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -133,10 +134,11 @@ private fun RegionLanguagePicker(
     // the app override — we use LocaleManager.getSystemLocales() there.
     // The label itself is also rendered in the device language so it reads
     // naturally regardless of which in-app region is active.
+    val configuration = LocalConfiguration.current
     val systemLocale = remember { context.deviceSystemLocale().stripExtensions() }
     val systemTag = remember(systemLocale) { systemLocale.toLanguageTag() }
-    val systemLabel = remember(systemLocale) {
-        val cfg = Configuration(context.resources.configuration)
+    val systemLabel = remember(systemLocale, configuration) {
+        val cfg = Configuration(configuration)
             .also { it.setLocale(systemLocale) }
         context.createConfigurationContext(cfg)
             .resources.getString(R.string.settings_region_language_system)

--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -349,13 +350,15 @@ internal fun CalendarPage(
     onNavigateToLocation: () -> Unit,
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
+    // Observe the device locale so the fallback country tracks a locale change.
+    val deviceLocale = LocalConfiguration.current.locales[0]
     SettingsScaffold(R.string.settings_page_calendar, onBack) { padding ->
         CalendarContent(
             holidayCountrySelection = state.holidayCountrySelection,
             holidayOverrides = state.holidayOverrides,
             effectiveEnabledHolidayCountries = state.effectiveEnabledHolidayCountries,
             localeCountry = state.region.toJavaLocale()?.country
-                ?: java.util.Locale.getDefault().country,
+                ?: deviceLocale.country,
             weatherLocationCountry = state.location?.countryCode,
             calendarEnabled = state.calendarEnabled,
             useCalendarEvents = state.useCalendarEvents,

--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
@@ -1631,13 +1631,13 @@ internal fun HolidayBanner(
     val effectiveCountry = remember(region) {
         (region.toJavaLocale() ?: Locale.getDefault()).country
     }
-    val bannerText = remember(theme, effectiveCountry) {
+    // Composed multi-celebration banner joins each piece with the localised
+    // "and" ("Happy bank holiday and don't forget your towel"). Read observably
+    // up front so it isn't queried off LocalContext inside the remember body.
+    val and = stringResource(R.string.holiday_banner_and)
+    val bannerText = remember(theme, effectiveCountry, and) {
         val segments = theme.bannerSegments
         if (!segments.isNullOrEmpty()) {
-            // Composed multi-celebration banner: join each piece with the
-            // localised "and" ("Happy bank holiday and don't forget your
-            // towel").
-            val and = context.getString(R.string.holiday_banner_and)
             segments.joinToString(separator = " $and ") { segment ->
                 segment.literalText ?: run {
                     val key = segment.textKeyByCountry[effectiveCountry.uppercase()] ?: segment.textKey


### PR DESCRIPTION
Follow-up to #987. Clears the **9 `androidx.compose.ui` lint errors** that my earlier tally had missed. **No user-visible behavior change** (`internal:`).

## Changes

**Genuine fixes (observable reads / hoisting):**
- **`MainActivity`** — hoist the theme/palette flow `.map { }` operators out of `setContent` so they aren't recreated on every recomposition (`FlowOperatorInvokedInComposition`).
- **`SettingsScreen`, `HolidaySettings`, `RegionSettings`** — read the device locale / `Configuration` via `LocalConfiguration.current` (the pattern already used in `TimeFormatLocal`/`ChartScrubber`) instead of `Locale.getDefault()` / `LocalContext.current.resources.configuration`, so the UI tracks a locale change (`NonObservableLocale`, `LocalContextConfigurationRead`). `RegionSettings` still builds a Configuration with the *system* locale for the "Follow system" label — it just bases it on the observable config now.
- **`AboutSettings`, `TodayScreen`** — hoist `getString(...)` to `stringResource(...)` at composable scope instead of querying off `LocalContext.current` (`LocalContextGetResourceValueCall`).

**Justified suppression (1):**
- **`HolidaySettings.resolveHolidayString`** — `@Suppress("LocalContextGetResourceValueCall")` with a comment: the resource id is resolved dynamically by name (`getIdentifier`), so `stringResource()` can't be used.

## Lint state
This branch (off `main`) clears all 9 Compose-UI errors; the 12 `RestrictedApi` errors that remain in its lint run are the ones **#987** fixes. The two PRs touch disjoint files, so once both merge, `:app:lintDebug` has **zero errors**.

## Test plan
- `./gradlew :app:lintDebug` → the 9 Compose-UI errors are gone (0 of each type).
- `./gradlew :app:testDebugUnitTest` → green.
- `./gradlew :app:assembleDebug` → BUILD SUCCESSFUL.

## Open PRs in this stack
- #987 — `internal:` RestrictedApi / plural / CheckResult lint fixes — https://github.com/mikelward/clothescast/pull/987
- This PR — Compose-UI lint fixes — https://github.com/mikelward/clothescast/pull/988

https://claude.ai/code/session_01Ljmd6nzZ1oNSaW6rDQYFUq

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ljmd6nzZ1oNSaW6rDQYFUq)_