### PR TITLE
internal: adopt androidx KTX extensions flagged by UseKtx lint

### DIFF
--- a/app/src/debug/kotlin/app/clothescast/data/AppCheckProviderFactoryProvider.kt
+++ b/app/src/debug/kotlin/app/clothescast/data/AppCheckProviderFactoryProvider.kt
@@ -1,6 +1,7 @@
 package app.clothescast.data
 
 import android.content.Context
+import androidx.core.content.edit
 import app.clothescast.BuildConfig
 import com.google.firebase.FirebaseApp
 import com.google.firebase.appcheck.AppCheckProviderFactory
@@ -48,9 +49,9 @@ fun provideAppCheckProviderFactory(context: Context): AppCheckProviderFactory {
         val persistenceKey = FirebaseApp.getInstance().persistenceKey
         val prefName = "com.google.firebase.appcheck.debug.store.$persistenceKey"
         val prefKey = "com.google.firebase.appcheck.debug.DEBUG_SECRET"
-        context.getSharedPreferences(prefName, Context.MODE_PRIVATE).edit()
-            .putString(prefKey, token)
-            .apply()
+        context.getSharedPreferences(prefName, Context.MODE_PRIVATE).edit {
+            putString(prefKey, token)
+        }
     }
     return DebugAppCheckProviderFactory.getInstance()
 }

--- a/app/src/main/kotlin/app/clothescast/MainActivity.kt
+++ b/app/src/main/kotlin/app/clothescast/MainActivity.kt
@@ -2,7 +2,6 @@ package app.clothescast
 
 import android.content.Context
 import android.content.Intent
-import android.net.Uri
 import android.os.Bundle
 import android.view.Gravity
 import android.widget.TextView
@@ -19,6 +18,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.core.net.toUri
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import app.clothescast.core.domain.model.ThemeMode
@@ -205,7 +205,7 @@ class MainActivity : ComponentActivity() {
         /** Tap intent for notifications: opens (or brings forward) MainActivity and
          *  deep-links to Today. SINGLE_TOP/CLEAR_TOP reuses a running task. */
         fun todayTapIntent(context: Context): Intent =
-            Intent(Intent.ACTION_VIEW, Uri.parse(DEEP_LINK_TODAY), context, MainActivity::class.java).apply {
+            Intent(Intent.ACTION_VIEW, DEEP_LINK_TODAY.toUri(), context, MainActivity::class.java).apply {
                 flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
             }
     }

--- a/app/src/main/kotlin/app/clothescast/cast/Mp4Encoder.kt
+++ b/app/src/main/kotlin/app/clothescast/cast/Mp4Encoder.kt
@@ -7,6 +7,7 @@ import android.media.MediaCodec
 import android.media.MediaCodecInfo
 import android.media.MediaFormat
 import android.media.MediaMuxer
+import androidx.core.graphics.scale
 import java.io.File
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
@@ -74,7 +75,7 @@ object Mp4Encoder {
         val targetW = ((source.width * scale).toInt() / 2) * 2
         val targetH = ((source.height * scale).toInt() / 2) * 2
         if (targetW == source.width && targetH == source.height) return source
-        return Bitmap.createScaledBitmap(source, targetW, targetH, true)
+        return source.scale(targetW, targetH)
     }
 
     private fun muxToFile(frame: Bitmap, wav: WavInfo, output: File) {

--- a/app/src/main/kotlin/app/clothescast/data/AppCheckGeminiCallPlanner.kt
+++ b/app/src/main/kotlin/app/clothescast/data/AppCheckGeminiCallPlanner.kt
@@ -1,6 +1,6 @@
 package app.clothescast.data
 
-import android.net.Uri
+import androidx.core.net.toUri
 import app.clothescast.core.data.insight.GeminiCallPlan
 import app.clothescast.core.data.insight.GeminiCallPlanner
 import app.clothescast.core.data.insight.GeminiEndpoint
@@ -165,7 +165,7 @@ class AppCheckGeminiCallPlanner(
          * URL directly instead of going through `GeminiEndpoint.apiVersion`.
          */
         internal fun parseProxyEndpoint(url: String): GeminiEndpoint {
-            val parsed = Uri.parse(url)
+            val parsed = url.toUri()
             val host = parsed.host
                 ?: error("GEMINI_PROXY_URL has no host: $url")
             val pathPrefix = parsed.path.orEmpty().trim('/')

--- a/app/src/main/kotlin/app/clothescast/diag/BugReport.kt
+++ b/app/src/main/kotlin/app/clothescast/diag/BugReport.kt
@@ -16,6 +16,7 @@ import android.view.PixelCopy
 import android.view.View
 import android.view.Window
 import androidx.core.content.FileProvider
+import androidx.core.graphics.createBitmap
 import app.clothescast.BuildConfig
 import app.clothescast.ClothesCastApplication
 import app.clothescast.core.domain.model.BottomsFormat
@@ -415,7 +416,7 @@ object BugReport {
         val window = activity.window ?: return null
         val view: View = window.decorView
         if (view.width <= 0 || view.height <= 0) return null
-        val bitmap = Bitmap.createBitmap(view.width, view.height, Bitmap.Config.ARGB_8888)
+        val bitmap = createBitmap(view.width, view.height)
         return suspendCancellableCoroutine { cont ->
             val location = IntArray(2)
             view.getLocationInWindow(location)

--- a/app/src/main/kotlin/app/clothescast/locale/AppLocale.kt
+++ b/app/src/main/kotlin/app/clothescast/locale/AppLocale.kt
@@ -7,6 +7,7 @@ import android.content.res.Configuration
 import android.content.res.Resources
 import android.os.Build
 import android.os.LocaleList
+import androidx.core.content.edit
 import app.clothescast.core.domain.model.Region
 import java.util.Locale
 
@@ -52,7 +53,7 @@ object AppLocale {
             context.getSystemService(LocaleManager::class.java)
                 ?.applicationLocales = LocaleList(locale)
         } else {
-            context.prefs().edit().putString(KEY_TAG, tag).apply()
+            context.prefs().edit { putString(KEY_TAG, tag) }
         }
     }
 
@@ -68,7 +69,7 @@ object AppLocale {
             context.getSystemService(LocaleManager::class.java)
                 ?.applicationLocales = LocaleList.getEmptyLocaleList()
         } else {
-            context.prefs().edit().remove(KEY_TAG).apply()
+            context.prefs().edit { remove(KEY_TAG) }
         }
     }
 

--- a/app/src/main/kotlin/app/clothescast/ui/garment/GarmentRender.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/garment/GarmentRender.kt
@@ -9,6 +9,8 @@ import android.text.StaticLayout
 import android.text.TextPaint
 import android.text.TextUtils
 import androidx.core.graphics.PathParser as AndroidPathParser
+import androidx.core.graphics.createBitmap
+import androidx.core.graphics.withTranslation
 import app.clothescast.R
 import app.clothescast.core.domain.model.HourlyForecast
 import app.clothescast.core.domain.model.OutfitSuggestion
@@ -332,7 +334,7 @@ private fun renderRecoloredBitmap(
         customFillArgb?.let { Color(it.toInt()) },
         customStrokeArgb?.let { Color(it.toInt()) },
     )
-    val bitmap = Bitmap.createBitmap(sizePx, sizePx, Bitmap.Config.ARGB_8888)
+    val bitmap = createBitmap(sizePx, sizePx)
     val canvas = Canvas(bitmap)
     val scaleX = sizePx / vector.viewportWidth
     val scaleY = sizePx / vector.viewportHeight
@@ -425,7 +427,7 @@ internal fun renderTopWithHandsBitmap(
             customStrokeArgb = handsStrokeArgb,
         )
     }
-    val composite = Bitmap.createBitmap(sizePx, sizePx, Bitmap.Config.ARGB_8888)
+    val composite = createBitmap(sizePx, sizePx)
     Canvas(composite).apply {
         drawBitmap(topBmp, 0f, 0f, null)
         outerBmp?.let { drawBitmap(it, 0f, 0f, null) }
@@ -460,7 +462,7 @@ internal fun renderCarriedFigureBitmap(
         customFillArgb?.let { Color(it.toInt()) },
         customStrokeArgb?.let { Color(it.toInt()) },
     )
-    val bitmap = Bitmap.createBitmap(widthPx, heightPx, Bitmap.Config.ARGB_8888)
+    val bitmap = createBitmap(widthPx, heightPx)
     val canvas = Canvas(bitmap)
     canvas.scale(widthPx / vector.viewportWidth, heightPx / vector.viewportHeight)
     val paint = Paint().apply { isAntiAlias = true }
@@ -520,7 +522,7 @@ internal fun renderOutfitCard(
     outerColors: Map<OutfitSuggestion.Outer, Long> = emptyMap(),
     outerStrokes: Map<OutfitSuggestion.Outer, Long> = emptyMap(),
 ): ByteArray {
-    val bmp = Bitmap.createBitmap(CARD_W, CARD_H, Bitmap.Config.ARGB_8888)
+    val bmp = createBitmap(CARD_W, CARD_H)
     val canvas = Canvas(bmp)
     canvas.drawColor(android.graphics.Color.WHITE)
 
@@ -594,10 +596,9 @@ internal fun renderOutfitCard(
             .setEllipsize(TextUtils.TruncateAt.END)
             .setMaxLines(PROSE_MAX_LINES)
             .build()
-        canvas.save()
-        canvas.translate(proseX.toFloat(), proseTop.toFloat())
-        layout.draw(canvas)
-        canvas.restore()
+        canvas.withTranslation(proseX.toFloat(), proseTop.toFloat()) {
+            layout.draw(this)
+        }
     }
 
     // A single conditions row anchored to the bottom of the right column —
@@ -834,19 +835,18 @@ private fun drawSolidGlyph(
 ) {
     val path = AndroidPathParser.createPathFromPathData(pathData)
     val scale = size.toFloat() / 24f
-    canvas.save()
-    canvas.translate(x.toFloat(), y.toFloat())
-    canvas.scale(scale, scale)
-    canvas.drawPath(path, Paint(Paint.ANTI_ALIAS_FLAG).apply { style = Paint.Style.FILL; color = fillArgb })
-    canvas.drawPath(
-        path,
-        Paint(Paint.ANTI_ALIAS_FLAG).apply {
-            style = Paint.Style.STROKE
-            color = outlineArgb
-            strokeWidth = outlineWidth
-        },
-    )
-    canvas.restore()
+    canvas.withTranslation(x.toFloat(), y.toFloat()) {
+        scale(scale, scale)
+        drawPath(path, Paint(Paint.ANTI_ALIAS_FLAG).apply { style = Paint.Style.FILL; color = fillArgb })
+        drawPath(
+            path,
+            Paint(Paint.ANTI_ALIAS_FLAG).apply {
+                style = Paint.Style.STROKE
+                color = outlineArgb
+                strokeWidth = outlineWidth
+            },
+        )
+    }
 }
 
 /**
@@ -996,7 +996,7 @@ internal fun renderConditionsStripBitmap(
     val outlineArgb = if (darkTheme) STRIP_DARK_OUTLINE_ARGB else INFO_ICON_OUTLINE_ARGB
     val textArgb = if (darkTheme) STRIP_DARK_TEXT_ARGB else STRIP_LIGHT_TEXT_ARGB
 
-    val bitmap = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888)
+    val bitmap = createBitmap(w, h)
     val canvas = Canvas(bitmap) // transparent — the widget Box paints its own background
 
     val textPaint = TextPaint(Paint.ANTI_ALIAS_FLAG).apply {

--- a/app/src/main/kotlin/app/clothescast/ui/garment/OutfitVector.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/garment/OutfitVector.kt
@@ -8,6 +8,7 @@ import android.graphics.Path
 import android.util.Xml
 import androidx.annotation.DrawableRes
 import androidx.core.graphics.PathParser
+import androidx.core.graphics.toColorInt
 import org.xmlpull.v1.XmlPullParser
 import java.util.concurrent.ConcurrentHashMap
 
@@ -104,7 +105,7 @@ private fun floatAttr(attrs: android.util.AttributeSet, name: String): Float? =
 
 private fun colorAttr(attrs: android.util.AttributeSet, name: String): Int? {
     val raw = stringAttr(attrs, name) ?: return null
-    return runCatching { android.graphics.Color.parseColor(raw) }.getOrNull()
+    return runCatching { raw.toColorInt() }.getOrNull()
 }
 
 private fun capAttr(attrs: android.util.AttributeSet, name: String): Paint.Cap? =

--- a/app/src/main/kotlin/app/clothescast/ui/pairing/PairingViewModel.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/pairing/PairingViewModel.kt
@@ -3,6 +3,7 @@ package app.clothescast.ui.pairing
 import android.graphics.Bitmap
 import android.graphics.Color
 import android.util.Log
+import androidx.core.graphics.createBitmap
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
@@ -154,7 +155,7 @@ private fun generateQrBitmap(content: String): Bitmap {
     val pixels = IntArray(QR_SIZE_PX * QR_SIZE_PX) { i ->
         if (bits[i % QR_SIZE_PX, i / QR_SIZE_PX]) Color.BLACK else Color.WHITE
     }
-    val bmp = Bitmap.createBitmap(QR_SIZE_PX, QR_SIZE_PX, Bitmap.Config.ARGB_8888)
+    val bmp = createBitmap(QR_SIZE_PX, QR_SIZE_PX)
     bmp.setPixels(pixels, 0, QR_SIZE_PX, 0, 0, QR_SIZE_PX, QR_SIZE_PX)
     return bmp
 }

--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsCommon.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsCommon.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.withLink
 import androidx.compose.ui.unit.dp
+import androidx.core.net.toUri
 
 @Composable
 internal fun SectionCard(title: String, content: @Composable () -> Unit) {
@@ -173,7 +174,7 @@ internal const val PRIVACY_POLICY_URL =
     "https://github.com/mikelward/clothescast/blob/main/PRIVACY.md"
 
 internal fun openUrl(context: android.content.Context, url: String) {
-    val intent = android.content.Intent(android.content.Intent.ACTION_VIEW, android.net.Uri.parse(url))
+    val intent = android.content.Intent(android.content.Intent.ACTION_VIEW, url.toUri())
         .addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK)
     runCatching { context.startActivity(intent) }
 }

--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
@@ -93,6 +93,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.core.net.toUri
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -3569,7 +3570,7 @@ internal fun openInMaps(context: Context, latitude: Double, longitude: Double, l
     val labelPart = label?.takeIf { it.isNotBlank() }
         ?.let { "(${Uri.encode(it)})" }
         .orEmpty()
-    val uri = Uri.parse("geo:$latitude,$longitude?q=$latitude,$longitude$labelPart")
+    val uri = "geo:$latitude,$longitude?q=$latitude,$longitude$labelPart".toUri()
     val intent = Intent(Intent.ACTION_VIEW, uri)
     try {
         context.startActivity(intent)

--- a/app/src/main/kotlin/app/clothescast/widget/ComposeRender.kt
+++ b/app/src/main/kotlin/app/clothescast/widget/ComposeRender.kt
@@ -5,7 +5,6 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.Color
 import android.graphics.PixelFormat
-import android.graphics.drawable.ColorDrawable
 import android.hardware.display.DisplayManager
 import android.hardware.display.VirtualDisplay
 import android.media.Image
@@ -13,6 +12,9 @@ import android.media.ImageReader
 import android.view.ViewGroup
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.ComposeView
+import androidx.core.graphics.createBitmap
+import androidx.core.graphics.drawable.toDrawable
+import androidx.core.graphics.get
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleRegistry
 import androidx.lifecycle.ViewModelStore
@@ -102,7 +104,7 @@ internal suspend fun renderComposableToBitmap(
             // The RGBA_8888 ImageReader preserves the alpha channel.
             window?.apply {
                 setLayout(widthPx, heightPx)
-                setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
+                setBackgroundDrawable(Color.TRANSPARENT.toDrawable())
             }
         }
         val composeView = ComposeView(presentation.context).apply {
@@ -172,11 +174,7 @@ private fun Image.toBitmap(width: Int, height: Int): Bitmap {
     val pixelStride = plane.pixelStride
     val rowStride = plane.rowStride
     val rowPadding = rowStride - pixelStride * width
-    val padded = Bitmap.createBitmap(
-        width + rowPadding / pixelStride,
-        height,
-        Bitmap.Config.ARGB_8888,
-    )
+    val padded = createBitmap(width + rowPadding / pixelStride, height)
     padded.copyPixelsFromBuffer(plane.buffer)
     return if (rowPadding == 0) padded else Bitmap.createBitmap(padded, 0, 0, width, height)
 }
@@ -191,7 +189,7 @@ private fun Bitmap.coarseHash(): Int {
     while (y < height) {
         var x = 0
         while (x < width) {
-            hash = hash * 31 + getPixel(x, y)
+            hash = hash * 31 + this[x, y]
             x += stepX
         }
         y += stepY
@@ -202,14 +200,14 @@ private fun Bitmap.coarseHash(): Int {
 // True when every sampled pixel matches the first — a fully transparent or
 // single-colour frame, i.e. nothing meaningful drew.
 private fun Bitmap.isBlank(): Boolean {
-    val first = getPixel(0, 0)
+    val first = this[0, 0]
     val stepX = (width / 16).coerceAtLeast(1)
     val stepY = (height / 16).coerceAtLeast(1)
     var y = 0
     while (y < height) {
         var x = 0
         while (x < width) {
-            if (getPixel(x, y) != first) return false
+            if (this[x, y] != first) return false
             x += stepX
         }
         y += stepY

--- a/app/src/main/kotlin/app/clothescast/widget/FeelsLikeWidget.kt
+++ b/app/src/main/kotlin/app/clothescast/widget/FeelsLikeWidget.kt
@@ -5,9 +5,9 @@ import android.content.Context
 import android.content.Intent
 import android.content.res.Configuration
 import android.graphics.Bitmap
-import android.net.Uri
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.unit.dp
+import androidx.core.net.toUri
 import androidx.glance.GlanceId
 import androidx.glance.GlanceModifier
 import androidx.glance.GlanceTheme
@@ -185,7 +185,7 @@ private fun EmptyContent() {
 // under-specified intent hit). NEW_TASK is required because the widget launches
 // from a non-activity context.
 private fun chartTapIntent(context: Context, page: Int): Intent =
-    Intent(Intent.ACTION_VIEW, Uri.parse(MainActivity.todayPageUri(page)), context, MainActivity::class.java)
+    Intent(Intent.ACTION_VIEW, MainActivity.todayPageUri(page).toUri(), context, MainActivity::class.java)
         .apply {
             flags = Intent.FLAG_ACTIVITY_NEW_TASK or
                 Intent.FLAG_ACTIVITY_SINGLE_TOP or

--- a/app/src/main/kotlin/app/clothescast/widget/OutfitWidget.kt
+++ b/app/src/main/kotlin/app/clothescast/widget/OutfitWidget.kt
@@ -2,7 +2,6 @@ package app.clothescast.widget
 
 import android.content.Context
 import android.content.Intent
-import android.net.Uri
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
@@ -10,6 +9,7 @@ import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.core.net.toUri
 import androidx.glance.GlanceId
 import androidx.glance.GlanceModifier
 import androidx.glance.GlanceTheme
@@ -139,7 +139,7 @@ internal fun launchAppIntent(context: Context): Intent =
     Intent(Intent.ACTION_MAIN)
         .setClass(context, MainActivity::class.java)
         .addCategory(Intent.CATEGORY_LAUNCHER)
-        .setData(Uri.parse("clothescast://widget/open"))
+        .setData("clothescast://widget/open".toUri())
         .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
 
 @Composable


### PR DESCRIPTION
Clears all 25 `UseKtx` lint warnings in `:app` by swapping platform-API call sites for their `androidx.core` KTX equivalents. Pure, behavior-preserving cleanup — a follow-up to the earlier lint-error work (#987, #988).

## What changed

| Before | After |
|--------|-------|
| `Uri.parse(s)` | `s.toUri()` |
| `prefs.edit()...apply()` | `prefs.edit { ... }` |
| `Bitmap.createBitmap(w, h, ARGB_8888)` | `createBitmap(w, h)` (ARGB_8888 is the default) |
| `Bitmap.createScaledBitmap(src, w, h, true)` | `src.scale(w, h)` |
| `ColorDrawable(color)` | `color.toDrawable()` |
| `bitmap.getPixel(x, y)` | `bitmap[x, y]` |
| `Color.parseColor(s)` | `s.toColorInt()` |
| `canvas.save()` / `translate()` / `restore()` | `canvas.withTranslation { … }` |

Touched files: `MainActivity`, `AppCheckGeminiCallPlanner`, `AppCheckProviderFactoryProvider` (debug), `AppLocale`, `BugReport`, `ComposeRender`, `FeelsLikeWidget`, `GarmentRender`, `OutfitVector`, `OutfitWidget`, `PairingViewModel`, `SettingsCommon`, `TodayScreen`, `Mp4Encoder`.

## Notes

- The two `withTranslation` rewrites preserve exact `save`/`restore` scoping; the `GarmentRender` solid-glyph path keeps its `scale()` call inside the translated block, so the drawing is identical.
- `createBitmap(w, h)` uses the KTX default config `ARGB_8888` — same as every replaced call.

## Privacy

No change to anything crossing the device boundary — no weather/geocoding, insight prose, or telemetry paths touched.

## Test plan

- `./gradlew :app:lintDebug` — passes; `UseKtx` warnings 25 → 0, no new errors.
- `./gradlew :app:testDebugUnitTest` — passes, including Roborazzi snapshots (no pixel changes, as the rewrites are semantically identical).

https://claude.ai/code/session_01Ljmd6nzZ1oNSaW6rDQYFUq

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ljmd6nzZ1oNSaW6rDQYFUq)_