### PR TITLE
internal: mark locale-correct strings as intentional, not typos

### DIFF
--- a/app/src/main/res/values-de-rCH/strings.xml
+++ b/app/src/main/res/values-de-rCH/strings.xml
@@ -43,7 +43,7 @@ locale (Englisch (Vereinigte Staaten), Französisch (Kanada), Chinesisch
 (vereinfacht), …). The locale tag stored on disk (en-US / fr-CA /
 zh-CN) is unchanged; only the displayed label localizes.
 -->
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <string name="settings_region_language_de_de">Deutsch (Deutschland)</string>
     <string name="settings_region_language_de_at">Deutsch (Österreich)</string>
     <string name="settings_region_language_de_ch">Deutsch (Schweiz)</string>
@@ -424,7 +424,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="insight_band_cool">kühl</string>
     <string name="insight_band_mild">mild</string>
     <string name="insight_band_warm">warm</string>
-    <string name="insight_band_hot">heiss</string>
+    <string name="insight_band_hot" tools:ignore="Typos">heiss</string>
 
     <!-- Subject-less comparison fragment (see values-de): keep it equal to
          insight_delta_*_lead minus the leading "es wird " so the no-lead
@@ -495,7 +495,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="today_celebration_card_title">Festtagsthemen</string>
     <string name="today_celebration_card_body">Aktiviere besondere Farben und Nachrichten für Feiertage und Geburtstage.</string>
     <string name="today_celebration_card_cta">Kalendereinstellungen</string>
-    <string name="today_celebration_card_dismiss">Schliessen</string>
+    <string name="today_celebration_card_dismiss" tools:ignore="Typos">Schliessen</string>
 
     <!-- Holidays settings — source filter chips. -->
     <string name="settings_holidays_source_global">Global</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -17,7 +17,7 @@ Picker labels under `settings_region_language_*` and
 locale (Angol (Egyesült Államok), Francia (Franciaország), Német
 (Németország), …).
 -->
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <string name="settings_region_language_hu_hu">Magyar (Magyarország)</string>
     <string name="settings_tts_voice_locale_hu_hu">Magyar (Magyarország)</string>
     <string name="settings_tts_voice_locale_label">Akcentus</string>
@@ -62,7 +62,7 @@ locale (Angol (Egyesült Államok), Francia (Franciaország), Német
     <string name="settings_region_language_id_id">Indonéz (Indonézia)</string>
     <string name="settings_region_language_ms_my">Maláj (Malajzia)</string>
     <string name="settings_region_language_fil_ph">Filippínó (Fülöp-szigetek)</string>
-    <string name="settings_region_language_vi_vn">Vietnami (Vietnám)</string>
+    <string name="settings_region_language_vi_vn" tools:ignore="Typos">Vietnami (Vietnám)</string>
     <string name="settings_region_language_th_th">Thai (Thaiföld)</string>
     <string name="settings_region_language_zh_cn">Kínai (egyszerűsített)</string>
     <string name="settings_region_language_zh_tw">Kínai (hagyományos)</string>
@@ -118,7 +118,7 @@ locale (Angol (Egyesült Államok), Francia (Franciaország), Német
     <string name="settings_tts_voice_locale_id_id">Indonéz (Indonézia)</string>
     <string name="settings_tts_voice_locale_ms_my">Maláj (Malajzia)</string>
     <string name="settings_tts_voice_locale_fil_ph">Filippínó (Fülöp-szigetek)</string>
-    <string name="settings_tts_voice_locale_vi_vn">Vietnami (Vietnám)</string>
+    <string name="settings_tts_voice_locale_vi_vn" tools:ignore="Typos">Vietnami (Vietnám)</string>
     <string name="settings_tts_voice_locale_th_th">Thai (Thaiföld)</string>
     <string name="settings_tts_voice_locale_zh_cn">Kínai (egyszerűsített)</string>
     <string name="settings_tts_voice_locale_zh_tw">Kínai (hagyományos)</string>
@@ -1120,8 +1120,8 @@ locale (Angol (Egyesült Államok), Francia (Franciaország), Német
     <string name="holiday_name_ukraine_victory_day">Győzelem a nácizmus felett a II. világháborúban (Ukrajna)</string>
     <string name="holiday_name_us_election_day">Választás napja</string>
     <string name="holiday_name_us_labor_day">Munka ünnepe</string>
-    <string name="holiday_name_vietnam_national_day">Nemzeti ünnep (Vietnám)</string>
-    <string name="holiday_name_vietnam_reunification_day">Újraegyesítés napja (Vietnám)</string>
+    <string name="holiday_name_vietnam_national_day" tools:ignore="Typos">Nemzeti ünnep (Vietnám)</string>
+    <string name="holiday_name_vietnam_reunification_day" tools:ignore="Typos">Újraegyesítés napja (Vietnám)</string>
     <string name="holiday_name_whit_monday">Pünkösdhétfő</string>
     <plurals name="insight_clothes_layer_count">
         <item quantity="one">%1$d réteg</item>
@@ -1161,7 +1161,7 @@ locale (Angol (Egyesült Államok), Francia (Franciaország), Német
     <string name="settings_holiday_country_th">Thaiföld</string>
     <string name="settings_holiday_country_tr">Törökország</string>
     <string name="settings_holiday_country_ua">Ukrajna</string>
-    <string name="settings_holiday_country_vn">Vietnám</string>
+    <string name="settings_holiday_country_vn" tools:ignore="Typos">Vietnám</string>
     <string name="settings_holiday_country_za">Dél-Afrika</string>
     <string name="settings_holidays_calendar_enable_master">Kapcsold be fent a \"Naptáram használata\" opciót a közelgő ünnepek megjelenítéséhez.</string>
     <string name="settings_holidays_calendar_grant_permission">Adj naptárhozzáférést, hogy lásd a szinkronizált naptáraidból a közelgő ünnepeket.</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -13,7 +13,7 @@ What is NOT overridden, by design:
 `settings_region_language_*` and `settings_tts_voice_locale_*` use Norwegian
 native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrike)").
 -->
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Own-locale entries (used by both Region and Voice pickers). -->
     <string name="settings_region_language_nb_no">Norsk bokmål (Norge)</string>
     <string name="settings_tts_voice_locale_nb_no">Norsk bokmål (Norge)</string>
@@ -534,11 +534,11 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrike)").
     <!-- Insight prose templates. -->
     <string name="insight_lead_today">I dag</string>
     <string name="insight_lead_tomorrow">I morgen</string>
-    <string name="insight_unchanged_today">I dag blir det det samme som i går.</string>
+    <string name="insight_unchanged_today" tools:ignore="Typos">I dag blir det det samme som i går.</string>
     <string name="insight_unchanged_today_no_lead">Som i går.</string>
-    <string name="insight_unchanged_tonight">I kveld blir det det samme som i går kveld.</string>
+    <string name="insight_unchanged_tonight" tools:ignore="Typos">I kveld blir det det samme som i går kveld.</string>
     <string name="insight_unchanged_tonight_no_lead">Som i går kveld.</string>
-    <string name="insight_unchanged_tomorrow">I morgen blir det det samme som i dag.</string>
+    <string name="insight_unchanged_tomorrow" tools:ignore="Typos">I morgen blir det det samme som i dag.</string>
     <string name="insight_unchanged_tomorrow_no_lead">Som i dag.</string>
     <string name="insight_lead_tonight">I kveld</string>
     <!-- Norwegian V2 word order: "I dag blir det mildt." -->

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -42,7 +42,7 @@ Polaco / Neerlandês / Japonês / etc. follow PT-PT conventions where
 they diverge from BR ("Polonês" → "Polaco", "Holandês" →
 "Neerlandês").
 -->
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <string name="settings_region_language_pt_pt">Português (Portugal)</string>
     <string name="settings_region_language_pt_br">Português (Brasil)</string>
     <string name="settings_tts_voice_locale_pt_pt">Português (Portugal)</string>
@@ -1309,7 +1309,7 @@ they diverge from BR ("Polonês" → "Polaco", "Holandês" →
     <string name="settings_holidays_source_funny">Engraçados</string>
     <string name="settings_holidays_source_orthodox">Ortodoxo</string>
     <string name="settings_holidays_sources_title">Calendários integrados</string>
-    <string name="settings_location_privacy_note">As localizações são arredondadas ao quilómetro mais próximo para a tua privacidade.</string>
+    <string name="settings_location_privacy_note" tools:ignore="Typos">As localizações são arredondadas ao quilómetro mais próximo para a tua privacidade.</string>
     <string name="settings_location_refresh">Atualizar</string>
     <string name="settings_time_format_12h">12 horas</string>
     <string name="settings_time_format_24h">24 horas</string>


### PR DESCRIPTION
Clears the 11 `Typos` lint warnings by marking spellings that are **correct in their own locale** as intentional with `tools:ignore="Typos"`, rather than "correcting" them — which would introduce real translation errors. Follow-up to the lint-cleanup series (#987, #988, #990).

## Why suppress, not fix

Android Lint's `Typos` check applies an English-leaning dictionary to every locale's strings, so it flags valid foreign spellings. Each flagged string here is correct:

| Locale | String(s) | Why it's correct |
|--------|-----------|------------------|
| `values-hu` | `Vietnám` (×5) | The Hungarian name for Vietnam. |
| `values-de-rCH` | `heiss`, `Schliessen` | Swiss German writes `ss`, never `ß` — the whole point of the de-CH locale. |
| `values-nb` | `blir det det samme` (×3) | The repeated `det` is correct Norwegian ("it'll be the same"), not a doubled-word typo. |
| `values-pt-rPT` | `quilómetro` | European Portuguese spelling (Brazilian is `quilômetro`). |

## What changed

- Added `tools:ignore="Typos"` to the 11 flagged `<string>` elements across four locale files.
- Added the `xmlns:tools` namespace to those four `<resources>` roots (none had it).

Per-string suppression (rather than disabling `Typos` globally or per-file) keeps the check live for any genuine future typo in these same files, and documents the intent at the string itself.

## Notes

- **No displayed text changes.** `tools:*` attributes are build-time only and are stripped from the APK — nothing user-visible ships, hence the `internal:` prefix.
- No change to anything crossing the device boundary.

## Test plan

- `./gradlew :app:lintDebug` — passes; `Typos` warnings 11 → 0, no new errors, still 0 lint errors overall.

https://claude.ai/code/session_01Ljmd6nzZ1oNSaW6rDQYFUq

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ljmd6nzZ1oNSaW6rDQYFUq)_