### PR TITLE
internal: clear small-tail app lint warnings

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -663,12 +663,12 @@ dependencies {
     // Production (not test-only) because the planner runs in the main coroutine flow.
     implementation(libs.kotlinx.coroutines.play.services)
 
-    testImplementation(platform("org.junit:junit-bom:6.1.0"))
+    testImplementation(platform(libs.junit.bom))
     testImplementation(libs.junit.jupiter.api)
     testRuntimeOnly(libs.junit.jupiter.engine)
     // Gradle 9 no longer injects the JUnit Platform launcher onto the test
     // runtime classpath; declare it explicitly (version from the junit-bom).
-    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    testRuntimeOnly(libs.junit.platform.launcher)
     testImplementation(libs.kotest.assertions.core)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.androidx.datastore.preferences.core)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -58,13 +58,15 @@
         android:name="android.permission.SCHEDULE_EXACT_ALARM"
         android:maxSdkVersion="32" />
 
-    <!-- TTS playback while backgrounded on Android 14+ requires a short foreground service. -->
+    <!-- TTS playback while backgrounded on Android 14+ requires a short foreground service.
+         A shortService FGS needs only FOREGROUND_SERVICE — there is no separate
+         FOREGROUND_SERVICE_SHORT_SERVICE permission. -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SHORT_SERVICE" />
 
     <application
         android:name=".ClothesCastApplication"
         android:allowBackup="false"
+        tools:ignore="UnusedAttribute"
         android:banner="@drawable/tv_banner"
         android:enableOnBackInvokedCallback="true"
         android:icon="${launcherIconRes}"

--- a/app/src/main/kotlin/app/clothescast/diag/Telemetry.kt
+++ b/app/src/main/kotlin/app/clothescast/diag/Telemetry.kt
@@ -56,6 +56,10 @@ object Telemetry {
      * unconditionally — when collection is disabled the SDK won't send
      * anything anyway, and the property store is local until an event flushes.
      */
+    // The SDK_INT < MIN_SDK_VERSION guard below looks dead to lint (install-time
+    // minSdk enforcement), but Test Lab elevated installs and some sideload
+    // paths reach it on sub-minSdk devices — see the comment there.
+    @android.annotation.SuppressLint("ObsoleteSdkInt")
     fun start(context: Context, settings: SettingsRepository, scope: CoroutineScope) {
         if (FirebaseApp.getApps(context).isEmpty()) return
         val analytics = FirebaseAnalytics.getInstance(context)

--- a/app/src/main/kotlin/app/clothescast/location/ReverseGeocoder.kt
+++ b/app/src/main/kotlin/app/clothescast/location/ReverseGeocoder.kt
@@ -146,7 +146,7 @@ class ReverseGeocoder(
             fetchSync(geocoder, lat, lon)
         }
 
-    @android.annotation.TargetApi(Build.VERSION_CODES.TIRAMISU)
+    @androidx.annotation.RequiresApi(Build.VERSION_CODES.TIRAMISU)
     private suspend fun fetchAsync(
         geocoder: Geocoder,
         lat: Double,

--- a/app/src/main/kotlin/app/clothescast/tts/HolidayGreeting.kt
+++ b/app/src/main/kotlin/app/clothescast/tts/HolidayGreeting.kt
@@ -67,6 +67,9 @@ internal fun holidayTtsGreeting(
 
 private val TERMINAL_PUNCTUATION = setOf('.', '!', '?')
 
+// getIdentifier is required: the string name is computed at runtime (holiday
+// key), so a compile-time R.string reference isn't possible.
+@android.annotation.SuppressLint("DiscouragedApi")
 private fun Context.resolveStringByName(name: String): String? {
     val resId = resources.getIdentifier(name, "string", packageName)
     return if (resId == 0) null else getString(resId)

--- a/app/src/main/kotlin/app/clothescast/ui/settings/HolidaySettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/HolidaySettings.kt
@@ -800,8 +800,10 @@ private fun OverrideDropdown(
  */
 @Composable
 // The resource id is looked up dynamically by name (getIdentifier), so
-// stringResource() can't be used here — the id isn't known at compile time.
+// stringResource() can't be used here — the id isn't known at compile time, so
+// getIdentifier is required (DiscouragedApi).
 @Suppress("LocalContextGetResourceValueCall")
+@android.annotation.SuppressLint("DiscouragedApi")
 private fun resolveHolidayString(name: String): String? {
     val context = LocalContext.current
     val resId = context.resources.getIdentifier(name, "string", context.packageName)
@@ -814,11 +816,13 @@ private fun resolveHolidayString(name: String): String? {
  * [Locale]'s display name (e.g. "United States") if the resource is
  * missing and finally to the raw code so the row is always readable.
  */
+@android.annotation.SuppressLint("DiscouragedApi")
 private fun resolveCountryDisplayName(
     context: android.content.Context,
     uiLocale: Locale,
     code: String,
 ): String {
+    // getIdentifier is required: resName is built from a runtime country code.
     val resName = "settings_holiday_country_${code.lowercase()}"
     val resId = context.resources.getIdentifier(resName, "string", context.packageName)
     if (resId != 0) return context.getString(resId)

--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
@@ -1699,12 +1699,14 @@ internal fun HolidayBanner(
  * missing translation degrades to something developer-readable rather than
  * blank.
  */
+@android.annotation.SuppressLint("DiscouragedApi")
 private fun resolveBannerString(
     context: android.content.Context,
     key: String?,
     fallback: String,
 ): String {
     if (key == null) return fallback
+    // getIdentifier is required: the string name is a runtime banner key.
     val resId = context.resources.getIdentifier(key, "string", context.packageName)
     return if (resId == 0) fallback else context.getString(resId)
 }
@@ -2262,8 +2264,9 @@ private fun formatFact(fact: Fact, unit: TemperatureUnit, liveThresholdC: Double
     val observedStr: String
     val thresholdStr: String
     if (collide) {
-        observedStr = ONE_DECIMAL_FORMAT.format(observedConverted)
-        thresholdStr = ONE_DECIMAL_FORMAT.format(thresholdConverted)
+        val format = oneDecimalFormat()
+        observedStr = format.format(observedConverted)
+        thresholdStr = format.format(thresholdConverted)
     } else {
         observedStr = observedI.toString()
         thresholdStr = thresholdI.toString()
@@ -2318,8 +2321,10 @@ private fun comparisonFor(observedC: Double, thresholdC: Double): Fact.Compariso
 // Locale-aware one-decimal formatter used as a fallback in [formatFact] when
 // integer rounding of observed and threshold values would otherwise collide
 // (e.g. "17.6" and "18.0" both rounding to "18"). Default locale picks the
-// right decimal separator (`,` in de-DE, `.` in en-US, etc.).
-private val ONE_DECIMAL_FORMAT: java.text.NumberFormat =
+// right decimal separator (`,` in de-DE, `.` in en-US, etc.). Built per call
+// rather than cached in a static field so it tracks the user's in-app locale
+// changes (NumberFormat is also not thread-safe to share).
+private fun oneDecimalFormat(): java.text.NumberFormat =
     java.text.NumberFormat.getNumberInstance(Locale.getDefault()).apply {
         minimumFractionDigits = 1
         maximumFractionDigits = 1

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -112,9 +112,12 @@ kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-cor
 kotlinx-coroutines-play-services = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-play-services", version.ref = "coroutines" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutines" }
 
+junit-bom = { group = "org.junit", name = "junit-bom", version.ref = "junit5" }
 junit-jupiter-api = { group = "org.junit.jupiter", name = "junit-jupiter-api", version.ref = "junit5" }
 junit-jupiter-engine = { group = "org.junit.jupiter", name = "junit-jupiter-engine", version.ref = "junit5" }
 junit-jupiter-params = { group = "org.junit.jupiter", name = "junit-jupiter-params", version.ref = "junit5" }
+# Version comes from the junit-bom (declared on the test classpath), so no version.ref here.
+junit-platform-launcher = { group = "org.junit.platform", name = "junit-platform-launcher" }
 mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
 kotest-assertions-core = { group = "io.kotest", name = "kotest-assertions-core", version.ref = "kotest" }
 turbine = { group = "app.cash.turbine", name = "turbine", version.ref = "turbine" }


### PR DESCRIPTION
Clears the long tail of low-volume `:app` lint warnings — real fixes where one applies, justified suppressions (with rationale at each site) where the check is a false positive or the call is required by design. Fifth in the lint-cleanup series (#987, #988, #990, #991).

**12 warnings cleared; 337 remain, still 0 errors.**

## Real fixes

| Issue | Change |
|-------|--------|
| `UseRequiresApi` | `ReverseGeocoder.fetchAsync`: `@TargetApi` → `@RequiresApi(TIRAMISU)`, so the API requirement propagates to callers. Its sole caller is already SDK-guarded, so no new `NewApi` errors. |
| `ConstantLocale` | The one-decimal fallback formatter in `TodayScreen` was a static `val` capturing `Locale.getDefault()` at class load — it kept the **old decimal separator after an in-app language change**. Now built per call (also avoids sharing a non-thread-safe `NumberFormat`). |
| `SystemPermissionTypo` | **Removed** the `FOREGROUND_SERVICE_SHORT_SERVICE` `uses-permission`. Verified against `android-36/android.jar`: no such permission constant exists, and the merged manifest has no `foregroundServiceType` — a `shortService` FGS needs only `FOREGROUND_SERVICE`, so the line was a silent no-op. (Thanks to Codex review for catching that my original "stale lint DB" suppression was wrong.) |
| `UseTomlInstead` | Moved the inline `junit-bom` and `junit-platform-launcher` test deps into the version catalog. The BOM now shares the `junit5` version ref instead of a duplicated literal. |

## Justified suppressions

Each carries a one-line rationale at the site:

- **`ObsoleteSdkInt`** (`Telemetry.start`): the sub-minSdk guard is deliberate — Test Lab elevated installs and some sideload paths reach it on sub-minSdk devices. Documented, not dead code.
- **`DiscouragedApi`** ×4 (`HolidayGreeting`, `HolidaySettings` ×2, `TodayScreen` banner lookup): `getIdentifier` is required because the resource name is computed at runtime, so a compile-time `R.string` reference isn't possible.
- **`UnusedAttribute`** (manifest `<application>`): `enableOnBackInvokedCallback` / `localeConfig` are intentional forward-compat attributes that apply on API 33+.

## Left alone on purpose

- `GradleDependency` / `OldTargetApi` — compileSdk/targetSdk bumps are real testing decisions, not a lint sweep.
- `PluralsCandidate` ×2 — touches shipped copy and all translations.
- `UnusedTranslation` ×2 — `in` (Indonesian) / `iw` (Hebrew) exist but aren't in `locales_config`; whether to expose or drop those locales is a product decision.
- The `mipmap-anydpi-v26` folder merge — touches launcher icons; riskier than this pass warrants.

## Privacy

No change to anything crossing the device boundary.

## Test plan

- `./gradlew :app:lintDebug` — 0 errors; the 12 targeted warnings cleared.
- `./gradlew :app:testDebugUnitTest` — passes, including Roborazzi snapshots.

https://claude.ai/code/session_01Ljmd6nzZ1oNSaW6rDQYFUq