### PR TITLE
Localize the chart legend's Average label

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
@@ -3433,7 +3433,7 @@ internal fun ModelSpreadLegend(
         mainLine?.let {
             LegendChip(
                 color = it.color,
-                label = it.label,
+                label = compactMainLabel(it.label),
                 style = labelStyle,
                 textColor = labelColor,
             )
@@ -3497,6 +3497,24 @@ private fun shortModelName(modelId: String): String =
         friendlyModelName(modelId)
     } else {
         friendlyModelName(modelId).take(3)
+    }
+
+/**
+ * Width budget for the blended main-line label ("Average" and its
+ * translations). Most languages have a short word for it (Media, Medel,
+ * Snitt, Mittel, Moyenne, …), but a few are long, so this is the cross-locale
+ * safety net: anything longer is truncated with an ellipsis so it can't push
+ * the one-line legend into a wrap. Translators should still aim for a short
+ * native word or abbreviation (see `today_chart_main_line_label`); this only
+ * catches overflow.
+ */
+private const val MAX_MAIN_LINE_LABEL_CHARS = 8
+
+private fun compactMainLabel(label: String): String =
+    if (label.length <= MAX_MAIN_LINE_LABEL_CHARS) {
+        label
+    } else {
+        label.take(MAX_MAIN_LINE_LABEL_CHARS - 1).trimEnd() + "…"
     }
 
 // Open-Meteo rounds probability to whole percents and returns 1–3% peaks on

--- a/app/src/main/res/values-am/strings.xml
+++ b/app/src/main/res/values-am/strings.xml
@@ -102,7 +102,7 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="today_precipitation_peak">ከፍተኛ %1$d%% በ%2$s ሰዓት</string>
     <string name="today_precipitation_dry">ዛሬ ዝናብ አይጠበቅም</string>
     <string name="today_chart_model_legend_label">ሞዴሎች:</string>
-    <string name="today_chart_main_line_label">ጠቅላላ</string>
+    <string name="today_chart_main_line_label">አማካይ</string>
     <string name="today_chart_divergence_summary">ሞዴሎቹ በ%1$s ሰዓት ይለያያሉ (Δ %2$.1f%3$s የሚሰማ) — ብዙውን ጊዜ %4$s፣ %5$s</string>
     <string name="today_factor_air_temperature">የአየር ሙቀት</string>
     <string name="today_factor_wind_speed">የንፋስ ፍጥነት</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -178,7 +178,7 @@ they work correctly in both the single-band and range templates.
 
     <!-- Today — model/chart -->
     <string name="today_chart_model_legend_label">النماذج:</string>
-    <string name="today_chart_main_line_label">المجمّع</string>
+    <string name="today_chart_main_line_label">متوسط</string>
     <string name="today_chart_divergence_summary">تتباين النماذج أكثر الساعة %1$s (Δ %2$.1f%3$s محسوس) — أساسًا %4$s، %5$s</string>
     <string name="today_factor_air_temperature">درجة حرارة الهواء</string>
     <string name="today_factor_wind_speed">سرعة الرياح</string>

--- a/app/src/main/res/values-b+sr+Cyrl/strings.xml
+++ b/app/src/main/res/values-b+sr+Cyrl/strings.xml
@@ -465,7 +465,7 @@ surfaces.
 
     <!-- Chart labels. -->
     <string name="today_chart_model_legend_label">Модели:</string>
-    <string name="today_chart_main_line_label">Комбиновано</string>
+    <string name="today_chart_main_line_label">Просек</string>
     <string name="today_chart_divergence_summary">Модели се највише разликују у %1$s (Δ %2$.1f%3$s осећајна темп.) — углавном %4$s, %5$s</string>
 
     <!-- Divergence factor names. -->

--- a/app/src/main/res/values-b+sr+Latn/strings.xml
+++ b/app/src/main/res/values-b+sr+Latn/strings.xml
@@ -477,7 +477,7 @@ default English (matching values-pl / values-uk).
 
     <!-- Chart labels. -->
     <string name="today_chart_model_legend_label">Modeli:</string>
-    <string name="today_chart_main_line_label">Kombinovano</string>
+    <string name="today_chart_main_line_label">Prosek</string>
     <string name="today_chart_divergence_summary">Modeli se najviše razlikuju u %1$s (Δ %2$.1f%3$s osećajna temp.) — uglavnom %4$s, %5$s</string>
 
     <!-- Divergence factor names. -->

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -188,7 +188,7 @@ What is NOT overridden, by design:
 
     <!-- Chart labels. -->
     <string name="today_chart_model_legend_label">Модели:</string>
-    <string name="today_chart_main_line_label">Комбиниран</string>
+    <string name="today_chart_main_line_label">Средно</string>
     <string name="today_chart_divergence_summary">Моделите се разминават най-много в %1$s (Δ %2$.1f%3$s усещана) — предимно %4$s, %5$s</string>
 
     <!-- Divergence factor names. -->

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -166,7 +166,7 @@ West Bengal vocabulary differences in a future PR.
 
     <!-- Model spread / charts -->
     <string name="today_chart_model_legend_label">মডেল:</string>
-    <string name="today_chart_main_line_label">সম্মিলিত</string>
+    <string name="today_chart_main_line_label">গড়</string>
     <string name="today_chart_divergence_summary">%1$s-এ মডেলগুলো সবচেয়ে বেশি ভিন্নমত পোষণ করে (Δ %2$.1f%3$s অনুভূত) — মূলত %4$s, %5$s</string>
 
     <!-- Factor names -->

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -77,7 +77,7 @@ the in-app clock is digit-driven and reads consistently across locales.
     <string name="today_precipitation_dry">No s\'espera pluja avui</string>
 
     <string name="today_chart_model_legend_label">Models:</string>
-    <string name="today_chart_main_line_label">Combinat</string>
+    <string name="today_chart_main_line_label">Mitjana</string>
     <string name="today_chart_divergence_summary">Els models discrepan més a les %1$s (Δ %2$.1f%3$s sensació) — principalment %4$s, %5$s</string>
 
     <string name="today_factor_air_temperature">temperatura de l\'aire</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -416,7 +416,7 @@ locale (Angličtina (USA), Francouzština (Francie), Němčina (Německo), …).
 
     <!-- Chart labels. -->
     <string name="today_chart_model_legend_label">Modely:</string>
-    <string name="today_chart_main_line_label">Kombinované</string>
+    <string name="today_chart_main_line_label">Průměr</string>
     <string name="today_chart_divergence_summary">Modely se nejvíce rozcházejí v %1$s (Δ %2$.1f%3$s pocitová teplota) — zejména %4$s, %5$s</string>
 
     <!-- Divergence factor names. -->

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -431,7 +431,7 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrig)").
 
     <!-- Chart labels. -->
     <string name="today_chart_model_legend_label">Modeller:</string>
-    <string name="today_chart_main_line_label">Kombineret</string>
+    <string name="today_chart_main_line_label">Gns.</string>
     <string name="today_chart_divergence_summary">Modellerne afviger mest kl. %1$s (Δ %2$.1f%3$s følt temp.) — primært %4$s, %5$s</string>
 
     <!-- Divergence factor names. -->

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -649,7 +649,7 @@ zh-CN) is unchanged; only the displayed label localizes.
 
     <!-- Chart labels. -->
     <string name="today_chart_model_legend_label">Modelle:</string>
-    <string name="today_chart_main_line_label">Kombiniert</string>
+    <string name="today_chart_main_line_label">Mittel</string>
     <string name="today_chart_divergence_summary">Modelle weichen am stärksten um %1$s ab (Δ %2$.1f%3$s Gefühlstemperatur) — hauptsächlich %4$s, %5$s</string>
     <string name="today_confidence_precip_spread">Modelle uneinig beim Regen (Δ %1$.0f%% über %2$d Modelle)</string>
 

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -596,7 +596,7 @@ zh-CN) is unchanged; only the displayed label localizes.
 
     <!-- Model spread / chart strings. -->
     <string name="today_chart_model_legend_label">Μοντέλα:</string>
-    <string name="today_chart_main_line_label">Συνδυασμένο</string>
+    <string name="today_chart_main_line_label">Μέσος</string>
     <string name="today_chart_divergence_summary">Τα μοντέλα διαφωνούν περισσότερο στις %1$s (Δ %2$.1f%3$s αισθητή) — κυρίως %4$s, %5$s</string>
     <string name="today_factor_air_temperature">θερμοκρασία αέρα</string>
     <string name="today_factor_wind_speed">ταχύτητα ανέμου</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -619,7 +619,7 @@ zh-CN) is unchanged; only the displayed label localizes.
 
     <!-- Chart labels. -->
     <string name="today_chart_model_legend_label">Modelos:</string>
-    <string name="today_chart_main_line_label">Combinado</string>
+    <string name="today_chart_main_line_label">Media</string>
     <string name="today_chart_divergence_summary">Los modelos discrepan más a las %1$s (Δ %2$.1f%3$s sensación) — principalmente %4$s, %5$s</string>
     <string name="today_confidence_precip_spread">Los modelos discrepan en la lluvia (Δ %1$.0f%% entre %2$d modelos)</string>
 

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -77,7 +77,7 @@ Tone is informal "sina"-form throughout ("Pane … selga", "Võta … kaasa",
     <string name="today_precipitation_dry">Täna vihma ei oodata</string>
 
     <string name="today_chart_model_legend_label">Mudelid:</string>
-    <string name="today_chart_main_line_label">Kombineeritud</string>
+    <string name="today_chart_main_line_label">Keskmine</string>
     <string name="today_chart_divergence_summary">Mudelid lahknevad kõige rohkem kell %1$s (Δ %2$.1f%3$s tunnetatav) — peamiselt %4$s, %5$s</string>
 
     <string name="today_factor_air_temperature">õhutemperatuur</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -175,7 +175,7 @@ Western Arabic numerals (0-9) are used for TTS compatibility.
     <string name="today_precipitation_peak">اوج %1$d%% در ساعت %2$s</string>
     <string name="today_precipitation_dry">امروز بارندگی انتظار نمی‌رود</string>
     <string name="today_chart_model_legend_label">مدل‌ها:</string>
-    <string name="today_chart_main_line_label">ترکیبی</string>
+    <string name="today_chart_main_line_label">میانگین</string>
     <string name="today_chart_divergence_summary">مدل‌ها بیشترین اختلاف را در ساعت %1$s دارند (Δ %2$.1f%3$s احساس‌شده) — عمدتاً %4$s، %5$s</string>
     <string name="today_factor_air_temperature">دمای هوا</string>
     <string name="today_factor_wind_speed">سرعت باد</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -516,7 +516,7 @@ displayed label localizes.
     <string name="today_precipitation_dry">Ei sadetta odotettavissa tänään</string>
 
     <string name="today_chart_model_legend_label">Mallit:</string>
-    <string name="today_chart_main_line_label">Yhdistetty</string>
+    <string name="today_chart_main_line_label">Ka.</string>
     <string name="today_chart_divergence_summary">Mallit poikkeavat eniten kello %1$s (Δ %2$.1f%3$s tuntuva lämpötila) — pääasiassa %4$s, %5$s</string>
 
     <string name="today_factor_air_temperature">Ilmalämpötila</string>

--- a/app/src/main/res/values-fil/strings.xml
+++ b/app/src/main/res/values-fil/strings.xml
@@ -172,7 +172,7 @@ The rest of the UI falls through to values/strings.xml (English).
 
     <!-- Chart labels -->
     <string name="today_chart_model_legend_label">Mga modelo:</string>
-    <string name="today_chart_main_line_label">Pinagsama</string>
+    <string name="today_chart_main_line_label">Average</string>
     <string name="today_chart_divergence_summary">Pinaka-nagkakaiba ang mga modelo ng %1$s (Δ %2$.1f%3$s nararamdamang temperatura) — kadalasang %4$s, %5$s</string>
 
     <!-- Factor names -->

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -616,7 +616,7 @@ zh-CN) is unchanged; only the displayed label localizes.
 
     <!-- Chart labels. -->
     <string name="today_chart_model_legend_label">Modèles :</string>
-    <string name="today_chart_main_line_label">Combiné</string>
+    <string name="today_chart_main_line_label">Moyenne</string>
     <string name="today_chart_divergence_summary">Les modèles divergent le plus à %1$s (Δ %2$.1f%3$s ressenti) — surtout %4$s, %5$s</string>
     <string name="today_confidence_precip_spread">Les modèles divergent sur la pluie (Δ %1$.0f%% sur %2$d modèles)</string>
 

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -518,7 +518,7 @@ Not overridden by design:
 
     <!-- Chart labels. -->
     <string name="today_chart_model_legend_label">मॉडल:</string>
-    <string name="today_chart_main_line_label">संयुक्त</string>
+    <string name="today_chart_main_line_label">औसत</string>
     <string name="today_chart_divergence_summary">मॉडलों में सबसे ज़्यादा मतभेद %1$s पर (अनुभव तापमान Δ %2$.1f%3$s) — मुख्यतः %4$s, %5$s</string>
 
     <!-- Divergence factor names (used inside today_chart_divergence_summary). -->

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -584,7 +584,7 @@ spousal register), matching the existing insight prose ("Ponesi …",
 
     <!-- Chart labels. -->
     <string name="today_chart_model_legend_label">Modeli:</string>
-    <string name="today_chart_main_line_label">Kombinirano</string>
+    <string name="today_chart_main_line_label">Prosjek</string>
     <string name="today_chart_divergence_summary">Modeli se najviše razlikuju u %1$s (Δ %2$.1f%3$s osjećajna temp.) — uglavnom %4$s, %5$s</string>
     <string name="today_confidence_precip_spread">Modeli se razlikuju oko kiše (Δ %1$.0f%% kroz %2$d modela)</string>
 

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -418,7 +418,7 @@ locale (Angol (Egyesült Államok), Francia (Franciaország), Német
 
     <!-- Chart labels. -->
     <string name="today_chart_model_legend_label">Modellek:</string>
-    <string name="today_chart_main_line_label">Kombinált</string>
+    <string name="today_chart_main_line_label">Átlag</string>
     <string name="today_chart_divergence_summary">A modellek %1$s-kor térnek el legjobban (Δ %2$.1f%3$s hőérzet) — főként %4$s, %5$s</string>
 
     <!-- Divergence factor names. -->

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -175,7 +175,7 @@ to values/strings.xml (English).
 
     <!-- Chart labels -->
     <string name="today_chart_model_legend_label">Model:</string>
-    <string name="today_chart_main_line_label">Gabungan</string>
+    <string name="today_chart_main_line_label">Rerata</string>
     <string name="today_chart_divergence_summary">Model paling tidak sepakat pukul %1$s (Δ %2$.1f%3$s terasa seperti) — terutama %4$s, %5$s</string>
     <string name="today_factor_air_temperature">suhu udara</string>
     <string name="today_factor_wind_speed">kecepatan angin</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -602,7 +602,7 @@ zh-CN) is unchanged; only the displayed label localizes.
 
     <!-- Chart labels. -->
     <string name="today_chart_model_legend_label">Modelli:</string>
-    <string name="today_chart_main_line_label">Combinato</string>
+    <string name="today_chart_main_line_label">Media</string>
     <string name="today_chart_divergence_summary">I modelli divergono maggiormente alle %1$s (Δ %2$.1f%3$s percepita) — principalmente %4$s, %5$s</string>
     <string name="today_confidence_precip_spread">I modelli divergono sulla pioggia (Δ %1$.0f%% su %2$d modelli)</string>
 

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -177,7 +177,7 @@ standard in Israeli digital communication.
 
     <!-- Today — model divergence / confidence -->
     <string name="today_chart_model_legend_label">מודלים:</string>
-    <string name="today_chart_main_line_label">משולב</string>
+    <string name="today_chart_main_line_label">ממוצע</string>
     <string name="today_chart_divergence_summary">המודלים חלוקים ביותר בשעה %1$s (Δ %2$.1f%3$s מורגש) — בעיקר %4$s, %5$s</string>
     <string name="today_factor_air_temperature">טמפרטורת אוויר</string>
     <string name="today_factor_wind_speed">מהירות רוח</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -625,7 +625,7 @@ the displayed label localizes.
 
     <!-- Chart labels. -->
     <string name="today_chart_model_legend_label">モデル:</string>
-    <string name="today_chart_main_line_label">統合</string>
+    <string name="today_chart_main_line_label">平均</string>
     <string name="today_chart_divergence_summary">モデル間の差が最も大きいのは %1$s（体感温度 Δ %2$.1f%3$s）— 主に %4$s、%5$s</string>
 
     <!-- Divergence factor names (used inside today_chart_divergence_summary). -->

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -629,7 +629,7 @@ displayed label localizes.
 
     <!-- Chart labels. -->
     <string name="today_chart_model_legend_label">모델:</string>
-    <string name="today_chart_main_line_label">통합</string>
+    <string name="today_chart_main_line_label">평균</string>
     <string name="today_chart_divergence_summary">모델 간 차이가 가장 큰 시간은 %1$s (체감 Δ %2$.1f%3$s) — 주로 %4$s, %5$s</string>
 
     <!-- Divergence factor names (used inside today_chart_divergence_summary). -->

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -175,7 +175,7 @@ What is NOT overridden, by design:
 
     <!-- Chart labels. -->
     <string name="today_chart_model_legend_label">Modeliai:</string>
-    <string name="today_chart_main_line_label">Bendras</string>
+    <string name="today_chart_main_line_label">Vidurkis</string>
     <string name="today_chart_divergence_summary">Modeliai labiausiai skiriasi %1$s (Δ %2$.1f%3$s juntama) — daugiausia %4$s, %5$s</string>
 
     <!-- Divergence factor names. -->

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -173,7 +173,7 @@ informal "tu"-form throughout ("Apģērb …", "Paņem … līdzi").
     <string name="today_precipitation_peak">Maksimums %1$d%% plkst. %2$s</string>
     <string name="today_precipitation_dry">Šodien lietus nav paredzams</string>
     <string name="today_chart_model_legend_label">Modeļi:</string>
-    <string name="today_chart_main_line_label">Apvienots</string>
+    <string name="today_chart_main_line_label">Vidējais</string>
     <string name="today_chart_divergence_summary">Modeļi visvairāk atšķiras plkst. %1$s (Δ %2$.1f%3$s sajustā) — galvenokārt %4$s, %5$s</string>
     <string name="today_factor_air_temperature">gaisa temperatūra</string>
     <string name="today_factor_wind_speed">vēja ātrums</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -173,7 +173,7 @@ vs "kemungkinan", "padam" vs "hapus").
 
     <!-- Chart labels -->
     <string name="today_chart_model_legend_label">Model:</string>
-    <string name="today_chart_main_line_label">Gabungan</string>
+    <string name="today_chart_main_line_label">Purata</string>
     <string name="today_chart_divergence_summary">Model paling berbeza pada %1$s (Δ %2$.1f%3$s terasa seperti) — kebanyakannya %4$s, %5$s</string>
 
     <!-- Factor names -->

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -431,7 +431,7 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrike)").
 
     <!-- Chart labels. -->
     <string name="today_chart_model_legend_label">Modeller:</string>
-    <string name="today_chart_main_line_label">Kombinert</string>
+    <string name="today_chart_main_line_label">Snitt</string>
     <string name="today_chart_divergence_summary">Modellene avviker mest kl. %1$s (Δ %2$.1f%3$s følt temp.) — hovedsakelig %4$s, %5$s</string>
 
     <!-- Divergence factor names. -->

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -573,7 +573,7 @@ the displayed label localizes.
 
     <!-- Chart labels. -->
     <string name="today_chart_model_legend_label">Modellen:</string>
-    <string name="today_chart_main_line_label">Gecombineerd</string>
+    <string name="today_chart_main_line_label">Gem.</string>
     <string name="today_chart_divergence_summary">Modellen wijken het meest af om %1$s (Δ %2$.1f%3$s gevoelstemperatuur) — voornamelijk %4$s, %5$s</string>
 
     <!-- Divergence factor names. -->

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -571,7 +571,7 @@ is unchanged; only the displayed label localizes.
 
     <!-- Chart labels. -->
     <string name="today_chart_model_legend_label">Modele:</string>
-    <string name="today_chart_main_line_label">Łącznie</string>
+    <string name="today_chart_main_line_label">Średnia</string>
     <string name="today_chart_divergence_summary">Modele najbardziej się różnią o %1$s (Δ %2$.1f%3$s temperatura odczuwalna) — głównie %4$s, %5$s</string>
 
     <!-- Divergence factor names. -->

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -618,7 +618,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="today_precipitation_dry">Sem chuva prevista hoje</string>
 
     <string name="today_chart_model_legend_label">Modelos:</string>
-    <string name="today_chart_main_line_label">Combinado</string>
+    <string name="today_chart_main_line_label">Média</string>
     <string name="today_chart_divergence_summary">Os modelos discordam mais às %1$s (Δ %2$.1f%3$s de sensação térmica) — principalmente %4$s, %5$s</string>
 
     <string name="today_factor_air_temperature">temperatura do ar</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -660,7 +660,7 @@ they diverge from BR ("Polonês" → "Polaco", "Holandês" →
     <string name="today_precipitation_dry">Sem chuva prevista hoje</string>
 
     <string name="today_chart_model_legend_label">Modelos:</string>
-    <string name="today_chart_main_line_label">Combinado</string>
+    <string name="today_chart_main_line_label">Média</string>
     <string name="today_chart_divergence_summary">Os modelos discordam mais às %1$s (Δ %2$.1f%3$s de sensação térmica) — principalmente %4$s, %5$s</string>
 
     <string name="today_factor_air_temperature">temperatura do ar</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -175,7 +175,7 @@ surfaces fall back to default English (matching values-pl / values-uk).
 
     <!-- Chart labels. -->
     <string name="today_chart_model_legend_label">Modele:</string>
-    <string name="today_chart_main_line_label">Combinat</string>
+    <string name="today_chart_main_line_label">Medie</string>
     <string name="today_chart_divergence_summary">Modelele diferă cel mai mult la %1$s (Δ %2$.1f%3$s resimțit) — mai ales %4$s, %5$s</string>
 
     <!-- Divergence factor names. -->

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -455,7 +455,7 @@ only the displayed label localizes.
 
     <!-- Chart labels. -->
     <string name="today_chart_model_legend_label">Модели:</string>
-    <string name="today_chart_main_line_label">Общее</string>
+    <string name="today_chart_main_line_label">Среднее</string>
     <string name="today_chart_divergence_summary">Максимальное расхождение в %1$s (Δ %2$.1f%3$s ощущений) — в основном %4$s, %5$s</string>
 
     <!-- Divergence factor names (used inside today_chart_divergence_summary). -->

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -428,7 +428,7 @@ What is NOT overridden, by design:
 
     <!-- Chart labels. -->
     <string name="today_chart_model_legend_label">Modely:</string>
-    <string name="today_chart_main_line_label">Kombinované</string>
+    <string name="today_chart_main_line_label">Priemer</string>
     <string name="today_chart_divergence_summary">Modely sa najviac rozchádzajú o %1$s (Δ %2$.1f%3$s pocitová teplota) — najmä %4$s, %5$s</string>
 
     <!-- Divergence factor names. -->

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -183,7 +183,7 @@ informal "ti"-form throughout, mirroring the Croatian / Serbian pass.
 
     <!-- Chart labels. -->
     <string name="today_chart_model_legend_label">Modeli:</string>
-    <string name="today_chart_main_line_label">Kombinirano</string>
+    <string name="today_chart_main_line_label">Povp.</string>
     <string name="today_chart_divergence_summary">Modeli se najbolj razlikujejo ob %1$s (Δ %2$.1f%3$s občutena temp.) — predvsem %4$s, %5$s</string>
 
     <!-- Divergence factor names. -->

--- a/app/src/main/res/values-sq/strings.xml
+++ b/app/src/main/res/values-sq/strings.xml
@@ -111,7 +111,7 @@
     <string name="today_confidence_tap_to_show">Prek për të parë parashikimin e çdo modeli</string>
     <string name="today_confidence_tap_to_hide">Prek për të fshehur parashikimet e modeleve</string>
     <string name="today_chart_model_legend_label">Modelet:</string>
-    <string name="today_chart_main_line_label">I kombinuar</string>
+    <string name="today_chart_main_line_label">Mesatare</string>
     <string name="today_chart_reset_to_now">Shfaq tani</string>
     <string name="today_chart_readout">%1$s në %2$s</string>
     <string name="today_working">Duke punuar — po merret ClothesCast-i yt…</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -431,7 +431,7 @@ native names for all locales (e.g. "Tyska (Tyskland)", "Franska (Frankrike)").
 
     <!-- Chart labels. -->
     <string name="today_chart_model_legend_label">Modeller:</string>
-    <string name="today_chart_main_line_label">Kombinerat</string>
+    <string name="today_chart_main_line_label">Medel</string>
     <string name="today_chart_divergence_summary">Modellerna avviker mest kl. %1$s (Δ %2$.1f%3$s upplevd temp.) — framför allt %4$s, %5$s</string>
 
     <!-- Divergence factor names. -->

--- a/app/src/main/res/values-sw/strings.xml
+++ b/app/src/main/res/values-sw/strings.xml
@@ -165,7 +165,7 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="today_precipitation_peak">Kilele %1$d%% saa %2$s</string>
     <string name="today_precipitation_dry">Hakuna mvua inayotarajiwa leo</string>
     <string name="today_chart_model_legend_label">Mifano:</string>
-    <string name="today_chart_main_line_label">Mchanganyiko</string>
+    <string name="today_chart_main_line_label">Wastani</string>
     <string name="today_chart_divergence_summary">Mifano inayotofautiana zaidi saa %1$s (Δ %2$.1f%3$s inayohisi) — hasa %4$s, %5$s</string>
     <string name="today_factor_air_temperature">joto la hewa</string>
     <string name="today_factor_wind_speed">kasi ya upepo</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -179,7 +179,7 @@ The rest of the UI falls through to values/strings.xml (English).
 
     <!-- Model spread / chart labels -->
     <string name="today_chart_model_legend_label">แบบจำลอง:</string>
-    <string name="today_chart_main_line_label">รวม</string>
+    <string name="today_chart_main_line_label">เฉลี่ย</string>
     <string name="today_chart_divergence_summary">แบบจำลองต่างกันมากที่สุดเวลา %1$s (Δ %2$.1f%3$s อุณหภูมิที่รู้สึก) — ส่วนใหญ่เป็น %4$s, %5$s</string>
     <string name="today_factor_air_temperature">อุณหภูมิอากาศ</string>
     <string name="today_factor_wind_speed">ความเร็วลม</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -515,7 +515,7 @@ displayed label localizes.
     <string name="today_precipitation_dry">Bugün yağış beklenmez</string>
 
     <string name="today_chart_model_legend_label">Modeller:</string>
-    <string name="today_chart_main_line_label">Birleşik</string>
+    <string name="today_chart_main_line_label">Ortalama</string>
     <string name="today_chart_divergence_summary">Modeller saat %1$s\'de en fazla farklılaşıyor (Δ %2$.1f%3$s hissedilen sıcaklık) — ağırlıklı olarak %4$s, %5$s</string>
 
     <string name="today_factor_air_temperature">Hava sıcaklığı</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -432,7 +432,7 @@ only the displayed label localizes.
 
     <!-- Chart labels. -->
     <string name="today_chart_model_legend_label">Моделі:</string>
-    <string name="today_chart_main_line_label">Зведене</string>
+    <string name="today_chart_main_line_label">Середнє</string>
     <string name="today_chart_divergence_summary">Найбільше розходження о %1$s (Δ %2$.1f%3$s відчуваної) — переважно %4$s, %5$s</string>
 
     <!-- Divergence factor names. -->

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -178,7 +178,7 @@ Skipped intentionally: app_name (brand), insight_time_am/pm/midnight/noon
 
     <!-- Chart labels -->
     <string name="today_chart_model_legend_label">Mô hình:</string>
-    <string name="today_chart_main_line_label">Tổng hợp</string>
+    <string name="today_chart_main_line_label">TB</string>
     <string name="today_chart_divergence_summary">Các mô hình không đồng nhất nhất lúc %1$s (Δ %2$.1f%3$s cảm giác) — chủ yếu do %4$s, %5$s</string>
 
     <!-- Factor names -->

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -618,7 +618,7 @@ label localizes.
 
     <!-- Chart labels. -->
     <string name="today_chart_model_legend_label">模型：</string>
-    <string name="today_chart_main_line_label">综合</string>
+    <string name="today_chart_main_line_label">平均</string>
     <string name="today_chart_divergence_summary">模型分歧最大的时刻是 %1$s（体感温度 Δ %2$.1f%3$s）— 主要因 %4$s、%5$s</string>
 
     <!-- Divergence factor names (used inside today_chart_divergence_summary). -->

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -633,7 +633,7 @@ label localises.
 
     <!-- Chart labels. -->
     <string name="today_chart_model_legend_label">模型：</string>
-    <string name="today_chart_main_line_label">綜合</string>
+    <string name="today_chart_main_line_label">平均</string>
     <string name="today_chart_divergence_summary">模型分歧最大的時段是 %1$s（體感溫度 Δ %2$.1f%3$s）— 主要因 %4$s、%5$s</string>
 
     <!-- Divergence factor names (used inside today_chart_divergence_summary). -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -159,7 +159,10 @@
          line is the per-hour mean across the consulted models, falling back
          to Open-Meteo's "Auto" pick when fewer than two of them reported an
          hour. This is what drives the clothes recommendation. "Average" reads
-         clearly next to the short per-model legend codes (ECM, ICO, …). -->
+         clearly next to the short per-model legend codes (ECM, ICO, …).
+         Translators: keep this short (≈8 chars max) so it stays on one line —
+         prefer a short native word or accepted abbreviation. Anything longer
+         is truncated with an ellipsis at runtime. -->
     <string name="today_chart_main_line_label">Average</string>
 
     <!-- Content description for the small restore-clock icon that appears


### PR DESCRIPTION
## Why

#998 renamed the chart's blended-line label from "Combined" to "Average" in the base `values/` strings — but all 47 localized files still translated **"Combined"**, so non-English users currently see the wrong word. This translates the label properly and keeps it within the one-line legend across languages.

## What changed

- **47 translations** updated from the stale "Combined" to a short native word for *average*. Most languages have one well under the width budget: es/it `Media`, pt `Média`, sv `Medel`, nb `Snitt`, de `Mittel`, fr `Moyenne`, ru `Среднее`, pl `Średnia`, ja/zh `平均`, ko `평균`, ar `متوسط`, hi `औसत`, th `เฉลี่ย`, …
- **Abbreviations** for the few long ones: nl `Gem.`, da `Gns.`, fi `Ka.`, sl `Povp.`, vi `TB`.
- **Runtime safety net** (the "abbreviate if too long" idea): `compactMainLabel` truncates the resolved label past ~8 chars with an ellipsis, so a long or not-yet-translated value can never push the legend into a wrap. Translators get a length note on the base string.

## Worth a sanity-check (best-effort, per our chat)

The European majors + CJK/Arabic/Hebrew/Hindi/Thai I'm confident on. These are judgment calls worth your eye:

| Locale | Value | Note |
|---|---|---|
| nl | `Gem.` | standard abbrev of *gemiddelde* |
| da | `Gns.` | standard abbrev of *gennemsnit* |
| fi | `Ka.` | standard abbrev of *keskiarvo* (terse) |
| sl | `Povp.` | abbrev of *povprečje* (per ChatGPT's suggestion) |
| vi | `TB` | abbrev of *trung bình* (terse) |
| in | `Rerata` | vs the longer *rata-rata* |
| fil | `Average` | English loanword (literal *karaniwan* = "usual", wrong sense) |
| el | `Μέσος` | mean/middle; full form *Μέσος όρος* |
| de | `Mittel` | vs *Durchschnitt* / `Ø` |
| am | `አማካይ` | lower personal confidence |

Happy to swap any of these.

## Privacy / data boundary

None — UI strings only.

## Test plan

- `:core:domain:test`, `:core:data:test`, `:app:testDebugUnitTest`, `:app:assembleDebug` — all green locally (aapt accepts all 47 resources).
- No English-rendered change → snapshots unaffected (bot confirms 251 up-to-date, no pixel changes).

https://claude.ai/code/session_01UG2U4faSW22FtM9LzUVNMA