### PR TITLE
Drop the weak GEM model from European forecast defaults

### DIFF
--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/ForecastModelDefaults.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/ForecastModelDefaults.kt
@@ -18,12 +18,19 @@ package app.clothescast.core.domain.model
  * ECMWF happen to share a synoptic interpretation.
  *
  * Tail reinforcement: the regional locals (UKMO, ARPEGE, JMA) and ICON are
- * short-range — they fall silent after ~day 7, which would leave only ECMWF
- * painting the second-week ("Following 7 days") charts in most regions. So
- * every set also carries GEM (reaches ~day 10) and AIFS — ECMWF's AI model,
- * skillful to ~day 15 — so at least two models keep reporting through days
- * 8-14. They append last because they're the lowest-priority members to
- * trim, and they push each set to the picker's MAX_MODELS = 5 ceiling.
+ * short-range — they fall silent after ~day 7, which would leave the
+ * second-week ("Following 7 days") charts thin. So every set carries AIFS —
+ * ECMWF's AI model, skillful to ~day 15 — paired with ECMWF IFS 0.25° (also
+ * ~day 15), so at least two models keep reporting through days 8-14. AIFS
+ * appends last because it's the lowest-priority member to trim.
+ *
+ * GEM (ECCC, reaches ~day 10) adds a third long-range voice, but only where
+ * it's actually skillful: it's the local official over North America and a
+ * reasonable cross-check over East Asia, so those sets carry it. It's a poor
+ * performer over Europe — the same reason GFS (NOAA) is kept out of every
+ * European set — so the British Isles, Iceland, Nordics, and Western/Central
+ * Europe branches leave it out and lean on ECMWF IFS + AIFS for the second
+ * week.
  *
  * The mapping is intentionally coarse — bounding boxes, not country
  * polygons — because the goal is "good defaults", not "perfect mapping".
@@ -58,7 +65,6 @@ fun ForecastModel.Companion.defaultsFor(location: Location?): Set<ForecastModel>
                 ForecastModel.UKMO_SEAMLESS,
                 ForecastModel.ECMWF_IFS025,
                 ForecastModel.ICON_SEAMLESS,
-                ForecastModel.GEM_SEAMLESS,
                 ForecastModel.ECMWF_AIFS025_SINGLE,
             )
 
@@ -71,7 +77,6 @@ fun ForecastModel.Companion.defaultsFor(location: Location?): Set<ForecastModel>
                 ForecastModel.ECMWF_IFS025,
                 ForecastModel.ICON_SEAMLESS,
                 ForecastModel.UKMO_SEAMLESS,
-                ForecastModel.GEM_SEAMLESS,
                 ForecastModel.ECMWF_AIFS025_SINGLE,
             )
 
@@ -84,7 +89,6 @@ fun ForecastModel.Companion.defaultsFor(location: Location?): Set<ForecastModel>
                 ForecastModel.ECMWF_IFS025,
                 ForecastModel.ICON_SEAMLESS,
                 ForecastModel.UKMO_SEAMLESS,
-                ForecastModel.GEM_SEAMLESS,
                 ForecastModel.ECMWF_AIFS025_SINGLE,
             )
 
@@ -98,7 +102,6 @@ fun ForecastModel.Companion.defaultsFor(location: Location?): Set<ForecastModel>
                 ForecastModel.ECMWF_IFS025,
                 ForecastModel.ICON_SEAMLESS,
                 ForecastModel.METEOFRANCE_SEAMLESS,
-                ForecastModel.GEM_SEAMLESS,
                 ForecastModel.ECMWF_AIFS025_SINGLE,
             )
 

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/model/ForecastModelDefaultsTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/model/ForecastModelDefaultsTest.kt
@@ -2,6 +2,7 @@ package app.clothescast.core.domain.model
 
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
 
@@ -11,28 +12,27 @@ class ForecastModelDefaultsTest {
         Location(latitude = lat, longitude = lon, displayName = null)
 
     // The regional locals (UKMO / ARPEGE / JMA) and ICON are short-range, so
-    // every default set carries GEM (~day 10) and AIFS (~day 15) to keep the
-    // second-week charts populated. Shared here so the per-city expectations
-    // stay readable.
+    // every default set keeps a long-range model painting the second-week
+    // charts: AIFS (~day 15) everywhere, paired with ECMWF IFS 0.25° (~day
+    // 15). GEM (~day 10) reinforces only where it's skillful — North America
+    // and East Asia — and is left out of the European sets the same way GFS
+    // is. Shared here so the per-city expectations stay readable.
     private val britishIsles = listOf(
         ForecastModel.UKMO_SEAMLESS,
         ForecastModel.ECMWF_IFS025,
         ForecastModel.ICON_SEAMLESS,
-        ForecastModel.GEM_SEAMLESS,
         ForecastModel.ECMWF_AIFS025_SINGLE,
     )
     private val westernEurope = listOf(
         ForecastModel.ECMWF_IFS025,
         ForecastModel.ICON_SEAMLESS,
         ForecastModel.METEOFRANCE_SEAMLESS,
-        ForecastModel.GEM_SEAMLESS,
         ForecastModel.ECMWF_AIFS025_SINGLE,
     )
     private val nordics = listOf(
         ForecastModel.ECMWF_IFS025,
         ForecastModel.ICON_SEAMLESS,
         ForecastModel.UKMO_SEAMLESS,
-        ForecastModel.GEM_SEAMLESS,
         ForecastModel.ECMWF_AIFS025_SINGLE,
     )
     private val northAmerica = listOf(
@@ -170,6 +170,25 @@ class ForecastModelDefaultsTest {
         )
         for (city in cities) {
             ForecastModel.defaultsFor(city) shouldContain ForecastModel.ECMWF_AIFS025_SINGLE
+        }
+    }
+
+    @Test
+    fun `European defaults exclude both GFS and GEM`() {
+        // GFS and GEM are both weak over Europe, so neither belongs in a
+        // European default set — Europe leans on ECMWF IFS + AIFS for the
+        // second week instead of GEM's tail reinforcement.
+        val europeanCities = listOf(
+            at(51.51, -0.13), // London (British Isles)
+            at(48.86, 2.35), // Paris (Western Europe)
+            at(40.42, -3.70), // Madrid (Western Europe)
+            at(59.33, 18.07), // Stockholm (Nordics)
+            at(64.13, -21.94), // Reykjavik (Iceland)
+        )
+        for (city in europeanCities) {
+            val models = ForecastModel.defaultsFor(city)
+            models shouldNotContain ForecastModel.GFS_SEAMLESS
+            models shouldNotContain ForecastModel.GEM_SEAMLESS
         }
     }
 }


### PR DESCRIPTION
## What

Removes `GEM_SEAMLESS` from the four European branches in `ForecastModelDefaults` — British Isles, Iceland, Nordics, and Western/Central Europe.

## Why

GEM (Environment Canada) only appeared in the European default sets as second-week **tail reinforcement**, not for regional accuracy — it forecasts poorly over Europe. That's exactly the reason GFS (NOAA) is already kept out of every European set, so GEM now gets the same treatment.

The "Following 7 days" coverage invariant still holds: those regions keep **ECMWF IFS 0.25°** and **AIFS** (both skillful to ~day 15), so at least two models keep painting the second-week charts without GEM.

GEM stays where it's actually skillful:
- **North America** — it's the local official (Environment Canada)
- **East Asia** — a reasonable long-range cross-check
- **Global `DEFAULTS`** fallback — unchanged

It remains user-selectable everywhere via the Forecasters picker; this only changes the auto-defaults for European coordinates.

## Scope

European default sets drop from 5 → 4 models (North America was already 4). No domain logic depends on the count.

## Privacy

No change to what leaves the device — same Open-Meteo request shape, just a different default `models=` list for European coordinates.

## Test plan

- Updated the British Isles / Western Europe / Nordics expected sets in `ForecastModelDefaultsTest` (East Asia + North America keep GEM).
- Added a regression test asserting European defaults exclude **both** GFS and GEM.
- `./gradlew :core:domain:test --tests "*ForecastModelDefaultsTest*"` — green.

https://claude.ai/code/session_013gVUGwXkJe6zY8waEaovn2

---
_Generated by [Claude Code](https://claude.ai/code/session_013gVUGwXkJe6zY8waEaovn2)_

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/2518d586-986c-4e1f-92d0-1a5c88b8c693/pull/1000"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a>
<!-- capy-pr-badge:end -->