### PR TITLE
Fix the forecast range band on the 7-day charts

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/today/ForecastChart.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/ForecastChart.kt
@@ -22,6 +22,7 @@ import app.clothescast.core.domain.model.TemperatureUnit
 import app.clothescast.core.domain.model.toUnit
 import app.clothescast.ui.theme.AppTheme
 import java.time.LocalDate
+import java.time.LocalDateTime
 import com.patrykandpatrick.vico.compose.cartesian.CartesianChartHost
 import com.patrykandpatrick.vico.compose.cartesian.axis.rememberAxisLabelComponent
 import com.patrykandpatrick.vico.compose.cartesian.layer.rememberLineCartesianLayer
@@ -254,11 +255,12 @@ fun ForecastChart(
     // Shaded min–max range band on the default view (hidden once the per-model
     // overlay is on — the individual lines convey the spread then). Built from
     // the same picker + unit as the main line so it lands on the same scale.
-    val (bandMin, bandMax) = remember(overlays, showFeelsLike, temperatureUnit, hourly) {
-        if (perModelHourly == null) {
+    val (bandMin, bandMax) = remember(overlays, showFeelsLike, temperatureUnit, hourly, startDate) {
+        val windowStart = hourly.firstOrNull()?.let { LocalDateTime.of(startDate, it.time) }
+        if (perModelHourly == null || windowStart == null) {
             emptyList<Pair<Int, Double>>() to emptyList()
         } else {
-            perModelEnvelope(perModelHourly, hourly.map { it.time }) {
+            perModelEnvelope(perModelHourly, windowStart, hourly.size) {
                 pickModel(it).toUnit(temperatureUnit)
             }
         }

--- a/app/src/main/kotlin/app/clothescast/ui/today/PrecipitationAmountChart.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/PrecipitationAmountChart.kt
@@ -13,6 +13,7 @@ import app.clothescast.core.domain.model.HourlyForecast
 import app.clothescast.core.domain.model.PerModelHourly
 import app.clothescast.ui.theme.AppTheme
 import java.time.LocalDate
+import java.time.LocalDateTime
 import com.patrykandpatrick.vico.compose.cartesian.CartesianChartHost
 import com.patrykandpatrick.vico.compose.cartesian.layer.rememberLineCartesianLayer
 import com.patrykandpatrick.vico.compose.cartesian.rememberCartesianChart
@@ -130,11 +131,12 @@ fun PrecipitationAmountChart(
     val scrubIndicator = rememberChartScrubIndicator(scrubController, scrubBounds, hourly, startDate)
     // Shaded min–max band on the default view, hidden once the per-model overlay
     // is on. Same rainfall-mm picker as the lines; shares the 0..yMax range.
-    val (bandMin, bandMax) = remember(overlays, hourly) {
-        if (perModelHourly == null) {
+    val (bandMin, bandMax) = remember(overlays, hourly, startDate) {
+        val windowStart = hourly.firstOrNull()?.let { LocalDateTime.of(startDate, it.time) }
+        if (perModelHourly == null || windowStart == null) {
             emptyList<Pair<Int, Double>>() to emptyList()
         } else {
-            perModelEnvelope(perModelHourly, hourly.map { it.time }) { it.precipitationMm }
+            perModelEnvelope(perModelHourly, windowStart, hourly.size) { it.precipitationMm }
         }
     }
     val rangeBand = rememberRangeBandDecoration(

--- a/app/src/main/kotlin/app/clothescast/ui/today/PrecipitationChart.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/PrecipitationChart.kt
@@ -13,6 +13,7 @@ import app.clothescast.core.domain.model.HourlyForecast
 import app.clothescast.core.domain.model.PerModelHourly
 import app.clothescast.ui.theme.AppTheme
 import java.time.LocalDate
+import java.time.LocalDateTime
 import com.patrykandpatrick.vico.compose.cartesian.CartesianChartHost
 import com.patrykandpatrick.vico.compose.cartesian.layer.rememberLineCartesianLayer
 import com.patrykandpatrick.vico.compose.cartesian.rememberCartesianChart
@@ -155,11 +156,12 @@ fun PrecipitationChart(
     // Shaded min–max band on the default view, hidden once the per-model overlay
     // is on. Uses the same precip-probability picker as the lines; y-range is the
     // pinned 0..100.
-    val (bandMin, bandMax) = remember(overlays, hourly) {
-        if (perModelHourly == null) {
+    val (bandMin, bandMax) = remember(overlays, hourly, startDate) {
+        val windowStart = hourly.firstOrNull()?.let { LocalDateTime.of(startDate, it.time) }
+        if (perModelHourly == null || windowStart == null) {
             emptyList<Pair<Int, Double>>() to emptyList()
         } else {
-            perModelEnvelope(perModelHourly, hourly.map { it.time }) { it.precipitationProbabilityPct }
+            perModelEnvelope(perModelHourly, windowStart, hourly.size) { it.precipitationProbabilityPct }
         }
     }
     val rangeBand = rememberRangeBandDecoration(

--- a/app/src/main/kotlin/app/clothescast/ui/today/RangeBand.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/RangeBand.kt
@@ -11,7 +11,8 @@ import app.clothescast.core.domain.model.PerModelHourly.Companion.BEST_MATCH_MOD
 import com.patrykandpatrick.vico.compose.cartesian.CartesianDrawingContext
 import com.patrykandpatrick.vico.compose.cartesian.axis.Axis
 import com.patrykandpatrick.vico.compose.cartesian.decoration.Decoration
-import java.time.LocalTime
+import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
 
 // Opacity of the shaded min–max range band drawn beneath the consensus line on
 // the default chart view. Low enough to read as a soft "spread" shading without
@@ -34,30 +35,30 @@ internal const val RANGE_BAND_ALPHA = 0.12f
  * Values are raw: the caller passes a [picker] that already applies the same unit
  * conversion it uses for the chart's series, so the band lands on the same scale.
  *
- * Indexed against the chart's own hourly window ([windowHourTimes], the
- * `hourly` series' times) by wall-clock time rather than each model's list
- * position. A model can drop an hour (the parser omits an entry when its
- * `temperature_2m` is null), which would shift its tail and make a position-keyed
- * band merge mismatched hours across models. Anchoring to the window keeps every
- * value under the hour the consensus main line plots it at — and a leading hour
- * that *every* consulted model dropped stays an empty gap rather than sliding the
- * whole band left. Matching is by `LocalTime`: each chart window is ≤ 24 h so its
- * times are unique, and using the time-of-day (not the full `LocalDateTime`) keeps
- * it date-agnostic, which the previews rely on. An entry whose time isn't in the
- * window is skipped.
+ * Indexed against the chart's own hourly window — [windowStart] is the
+ * `LocalDateTime` of `hourly[0]` and [windowSize] is `hourly.size` — by each
+ * entry's whole-hour offset from the window start, not its list position. A model
+ * can drop an hour (the parser omits an entry when its `temperature_2m` is null),
+ * which would shift its tail and make a position-keyed band merge mismatched hours
+ * across models. Offsetting from the window keeps every value under the hour the
+ * consensus main line plots it at, and a leading hour that *every* consulted model
+ * dropped stays an empty gap rather than sliding the band left. The full
+ * `LocalDateTime` (not time-of-day) is essential for the 168 h `SevenDayPage`
+ * window, where a `LocalTime` would alias every day's 09:00 onto one index. An
+ * entry outside `[0, windowSize)` is skipped.
  */
 internal fun perModelEnvelope(
     perModelHourly: PerModelHourly,
-    windowHourTimes: List<LocalTime>,
+    windowStart: LocalDateTime,
+    windowSize: Int,
     picker: (PerModelHour) -> Double?,
 ): Pair<List<Pair<Int, Double>>, List<Pair<Int, Double>>> {
-    val indexByTime = HashMap<LocalTime, Int>(windowHourTimes.size)
-    windowHourTimes.forEachIndexed { i, t -> indexByTime.putIfAbsent(t, i) }
     val byIndex = mutableMapOf<Int, MutableList<Double>>()
     perModelHourly.byModel.forEach { (model, entries) ->
         if (model == BEST_MATCH_MODEL_ID) return@forEach
         entries.forEach { entry ->
-            val idx = indexByTime[entry.time.toLocalTime()] ?: return@forEach
+            val idx = ChronoUnit.HOURS.between(windowStart, entry.time).toInt()
+            if (idx !in 0 until windowSize) return@forEach
             picker(entry)?.let { byIndex.getOrPut(idx) { mutableListOf() } += it }
         }
     }

--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayPreviews.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayPreviews.kt
@@ -2017,6 +2017,9 @@ internal fun ForecastCardConsensusPreview() {
         ForecastCard(
             hourly = SAMPLE_HOURLY,
             temperatureUnit = TemperatureUnit.CELSIUS,
+            // Match the per-model fixture's date so the band's window-start
+            // anchor lines up with the sample entries' timestamps.
+            startDate = SAMPLE_PER_MODEL_DATE,
             perModelHourly = SAMPLE_PER_MODEL_HOURLY,
             showModelSpread = false,
         )
@@ -2030,6 +2033,7 @@ internal fun AirTemperatureCardConsensusPreview() {
         AirTemperatureCard(
             hourly = SAMPLE_HOURLY,
             temperatureUnit = TemperatureUnit.CELSIUS,
+            startDate = SAMPLE_PER_MODEL_DATE,
             perModelHourly = SAMPLE_PER_MODEL_HOURLY,
             showModelSpread = false,
         )
@@ -2042,6 +2046,7 @@ internal fun PrecipitationCardConsensusPreview() {
     Frame {
         PrecipitationCard(
             hourly = SAMPLE_HOURLY_RAINY,
+            startDate = SAMPLE_PER_MODEL_DATE,
             perModelHourly = SAMPLE_PER_MODEL_HOURLY,
             showModelSpread = false,
         )
@@ -2054,6 +2059,7 @@ internal fun PrecipitationAmountCardConsensusPreview() {
     Frame {
         PrecipitationAmountCard(
             hourly = SAMPLE_HOURLY_RAINY,
+            forDate = SAMPLE_PER_MODEL_DATE,
             perModelHourly = SAMPLE_PER_MODEL_HOURLY,
             showModelSpread = false,
         )

--- a/app/src/test/kotlin/app/clothescast/ui/today/RangeBandTest.kt
+++ b/app/src/test/kotlin/app/clothescast/ui/today/RangeBandTest.kt
@@ -18,9 +18,10 @@ class RangeBandTest {
     private val t0 = LocalDateTime.of(2026, 6, 8, 0, 0)
     private val t1 = t0.plusHours(1)
     private val t2 = t0.plusHours(2)
-    // The chart's hourly window — the canonical x grid the consensus main line
-    // is plotted against. Matched by time-of-day (date-agnostic).
-    private val window = listOf(t0, t1, t2).map { it.toLocalTime() }
+    // The chart's hourly window: it starts at t0 and spans 3 hours. Entries are
+    // mapped to their whole-hour offset from t0 (the consensus main line's x grid).
+    private val windowStart = t0
+    private val windowSize = 3
 
     @Test
     fun `envelope keys by time, so a model's dropped hour doesn't merge mismatched hours`() {
@@ -32,7 +33,7 @@ class RangeBandTest {
                 "gfs_seamless" to listOf(hour(t0, 12.0), hour(t2, 32.0)),
             ),
         )
-        val (minSeries, maxSeries) = perModelEnvelope(perModel, window) { it.apparentTemperatureC }
+        val (minSeries, maxSeries) = perModelEnvelope(perModel, windowStart, windowSize) { it.apparentTemperatureC }
 
         // t0 (index 0) has both models; t1 (index 1) has only A, so it's dropped
         // (< 2 models); t2 (index 2) pairs A's 30 with B's 32. Position-keying
@@ -53,7 +54,7 @@ class RangeBandTest {
                 "gfs_seamless" to listOf(hour(t1, 22.0), hour(t2, 32.0)),
             ),
         )
-        val (minSeries, maxSeries) = perModelEnvelope(perModel, window) { it.apparentTemperatureC }
+        val (minSeries, maxSeries) = perModelEnvelope(perModel, windowStart, windowSize) { it.apparentTemperatureC }
 
         minSeries shouldContainExactly listOf(1 to 20.0, 2 to 30.0)
         maxSeries shouldContainExactly listOf(1 to 22.0, 2 to 32.0)
@@ -76,7 +77,7 @@ class RangeBandTest {
                 PerModelHourly.BEST_MATCH_MODEL_ID to listOf(hour(t0, 99.0)),
             ),
         )
-        val (minSeries, maxSeries) = perModelEnvelope(perModel, window) { it.apparentTemperatureC }
+        val (minSeries, maxSeries) = perModelEnvelope(perModel, windowStart, windowSize) { it.apparentTemperatureC }
 
         // best_match's outlier 99 must not widen the band.
         minSeries shouldContainExactly listOf(0 to 10.0)


### PR DESCRIPTION
Follow-up to the range-band feature (#1001), fixing the last edge Codex flagged after merge.

## The bug
The temp/rain charts (`ForecastChart`, `PrecipitationChart`, `PrecipitationAmountChart`) are reused by `SevenDayPage` with a **168-hour** `flatHourly` window. The band keyed each model value by **time-of-day** (`LocalTime`), which across a multi-day window aliases every day's 09:00/10:00/… onto the first matching hour — so the weekly band collapsed onto day 1 and left the rest of the week unshaded.

## The fix
`perModelEnvelope` now takes `windowStart: LocalDateTime` (= `hourly[0]`'s datetime) and `windowSize: Int` (= `hourly.size`), and keys each entry by its whole-hour offset `ChronoUnit.HOURS.between(windowStart, entry.time)`, bounded to `[0, windowSize)`. The full `LocalDateTime` disambiguates days, so it handles:
- the 168 h weekly window (no day aliasing),
- the ≤24 h day/tonight windows,
- a leading hour every model dropped (stays an empty gap, not a left-shift),
- interior gaps (already split into contiguous runs at draw time).

The offset equals the index the consensus main line plots at, so the band stays under it. The diagnostic cards (`envelopeFromSeries`) already key by list index and are unaffected.

The three charts pass `LocalDateTime.of(startDate, hourly.first().time)`; the four default-view previews now pass `startDate = SAMPLE_PER_MODEL_DATE` so the window-start anchor lines up with the fixed-date per-model fixture.

## Tests
- `RangeBandTest` (4 cases) updated to the new signature; covers dropped-interior-hour, leading-gap, interior-gap run-splitting, and best_match exclusion.
- `./gradlew :app:testDebugUnitTest` green. The ≤24 h preview renders are byte-identical (no snapshot churn from the keying change).

## Privacy / data boundary
None — presentation only.

https://claude.ai/code/session_01UG2U4faSW22FtM9LzUVNMA

---
_Generated by [Claude Code](https://claude.ai/code/session_01UG2U4faSW22FtM9LzUVNMA)_

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/2518d586-986c-4e1f-92d0-1a5c88b8c693/pull/1002"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a>
<!-- capy-pr-badge:end -->