### PR TITLE
Confidence rating ignores a single odd hour of disagreement

### DIFF
--- a/core/data/src/main/kotlin/app/clothescast/core/data/weather/MultiModelConfidenceFetcher.kt
+++ b/core/data/src/main/kotlin/app/clothescast/core/data/weather/MultiModelConfidenceFetcher.kt
@@ -31,10 +31,12 @@ import kotlinx.serialization.json.jsonPrimitive
 import java.time.LocalDateTime
 
 /**
- * Fetches today's apparent-max temperature and peak precipitation probability from
- * several Open-Meteo models in a single request, computes the cross-model spread,
- * and maps to a [ConfidenceInfo]. When the major models agree, we surface "High
- * confidence"; when they disagree, "Low confidence — forecasts disagree".
+ * Fetches today's apparent high and low temperature and peak precipitation
+ * probability from several Open-Meteo models in a single request, computes the
+ * cross-model spread (the wider of the high- and low-temperature disagreement,
+ * plus precip), and maps to a [ConfidenceInfo]. When the major models agree, we
+ * surface "High confidence"; when they disagree, "Low confidence — forecasts
+ * disagree".
  *
  * The same call also pulls the per-model hourly apparent-temperature and
  * precipitation-probability series so the Today screen's "show model spread"
@@ -171,7 +173,7 @@ internal class MultiModelConfidenceFetcher(
                 // downstream.
                 parameter("forecast_days", 14)
                 parameter("timezone", "auto")
-                parameter("daily", "apparent_temperature_max,precipitation_probability_max")
+                parameter("daily", "apparent_temperature_max,apparent_temperature_min,precipitation_probability_max")
                 // cloud_cover_low (the deck below ~2 km) rather than total
                 // column: total picks up cirrus that looks cloudy on satellite
                 // but barely dims the sun, and the user-facing question
@@ -341,6 +343,12 @@ internal class MultiModelConfidenceFetcher(
 
     private fun readModelDaily(daily: JsonObject, model: String): ReadOutcome {
         val tempMax = numberAt(daily["apparent_temperature_max_$model"] as? JsonArray, 0)?.toDouble()
+        // Soft field: the daily low feeds the low-disagreement half of the
+        // temp spread, but a model that reports a high without a low still
+        // contributes its high. When missing it simply drops out of the
+        // low-spread calculation (see [compute]) rather than dropping the
+        // whole model.
+        val tempMin = numberAt(daily["apparent_temperature_min_$model"] as? JsonArray, 0)?.toDouble()
         val precipMax = numberAt(daily["precipitation_probability_max_$model"] as? JsonArray, 0)?.toDouble()
         return when {
             tempMax == null && precipMax == null ->
@@ -350,7 +358,7 @@ internal class MultiModelConfidenceFetcher(
             precipMax == null ->
                 ReadOutcome.Dropped("precipitation_probability_max missing or null")
             else ->
-                ReadOutcome.Usable(ModelDailyValues(tempMax, precipMax))
+                ReadOutcome.Usable(ModelDailyValues(tempMax, tempMin, precipMax))
         }
     }
 
@@ -361,9 +369,17 @@ internal class MultiModelConfidenceFetcher(
     }
 
     private fun compute(results: List<Pair<String, ModelDailyValues>>): ConfidenceInfo {
-        val temps = results.map { it.second.tempMaxC }
+        val highs = results.map { it.second.tempMaxC }
+        // Models that didn't report a daily low (older payloads, or a model
+        // that omits apparent_temperature_min) sit out the low-spread term.
+        // With fewer than two lows we can't measure low disagreement, so it
+        // contributes nothing — mirrors the precip dimension's guard.
+        val lows = results.mapNotNull { it.second.tempMinC }
         val precips = results.map { it.second.precipMaxPp }
-        val tempSpread = temps.max() - temps.min()
+        val highSpread = highs.max() - highs.min()
+        val lowSpread = if (lows.size >= 2) lows.max() - lows.min() else 0.0
+        // Disagreement on the day's high *or* its low downgrades confidence.
+        val tempSpread = maxOf(highSpread, lowSpread)
         val precipSpread = precips.max() - precips.min()
 
         val level = when {
@@ -384,7 +400,11 @@ internal class MultiModelConfidenceFetcher(
         )
     }
 
-    private data class ModelDailyValues(val tempMaxC: Double, val precipMaxPp: Double)
+    private data class ModelDailyValues(
+        val tempMaxC: Double,
+        val tempMinC: Double?,
+        val precipMaxPp: Double,
+    )
 
     private sealed class ReadOutcome {
         data class Usable(val values: ModelDailyValues) : ReadOutcome()

--- a/core/data/src/test/kotlin/app/clothescast/core/data/weather/MultiModelConfidenceFetcherTest.kt
+++ b/core/data/src/test/kotlin/app/clothescast/core/data/weather/MultiModelConfidenceFetcherTest.kt
@@ -107,7 +107,8 @@ class MultiModelConfidenceFetcherTest {
         val req = captured.single()
         req.url.encodedPath shouldBe "/v1/forecast"
         req.url.parameters["models"] shouldBe defaultModelsParam
-        req.url.parameters["daily"] shouldBe "apparent_temperature_max,precipitation_probability_max"
+        req.url.parameters["daily"] shouldBe
+            "apparent_temperature_max,apparent_temperature_min,precipitation_probability_max"
         req.url.parameters["hourly"] shouldBe
             "apparent_temperature,temperature_2m,precipitation_probability,precipitation," +
             "wind_speed_10m,relative_humidity_2m,cloud_cover_low," +
@@ -163,6 +164,18 @@ class MultiModelConfidenceFetcherTest {
 
         info.level shouldBe ForecastConfidence.LOW
         info.tempSpreadC shouldBe (5.0 plusOrMinus 0.0001)
+    }
+
+    @Test
+    fun `wide overnight-low spread drops confidence even when the highs agree`() = runTest {
+        // Highs cluster tightly (21.0 / 21.2 / 21.4 → 0.4°C) but the
+        // overnight lows split wide (8 / 11 / 14 → 6°C). The tier reads the
+        // wider of the two temp spreads, so the low disagreement drags it
+        // to LOW even though the peaks line up.
+        val info = fetcherWith(THREE_MODEL_LOW_SPLIT).fetch(london, fixtureModels)?.confidence.shouldNotBeNull()
+
+        info.level shouldBe ForecastConfidence.LOW
+        info.tempSpreadC shouldBe (6.0 plusOrMinus 0.0001)
     }
 
     @Test
@@ -461,6 +474,26 @@ class MultiModelConfidenceFetcherTest {
                 "apparent_temperature_max_ecmwf_ifs025": [18.0],
                 "apparent_temperature_max_gfs_seamless": [21.0],
                 "apparent_temperature_max_icon_seamless": [23.0],
+                "precipitation_probability_max_ecmwf_ifs025": [10],
+                "precipitation_probability_max_gfs_seamless": [15],
+                "precipitation_probability_max_icon_seamless": [20]
+              }
+            }
+        """.trimIndent()
+
+        // Highs agree (21.0 / 21.2 / 21.4) but the daily lows split wide
+        // (8.0 / 11.0 / 14.0). Exercises the low-disagreement half of the
+        // temp spread.
+        private val THREE_MODEL_LOW_SPLIT = """
+            {
+              "daily": {
+                "time": ["2026-05-12"],
+                "apparent_temperature_max_ecmwf_ifs025": [21.0],
+                "apparent_temperature_max_gfs_seamless": [21.2],
+                "apparent_temperature_max_icon_seamless": [21.4],
+                "apparent_temperature_min_ecmwf_ifs025": [8.0],
+                "apparent_temperature_min_gfs_seamless": [11.0],
+                "apparent_temperature_min_icon_seamless": [14.0],
                 "precipitation_probability_max_ecmwf_ifs025": [10],
                 "precipitation_probability_max_gfs_seamless": [15],
                 "precipitation_probability_max_icon_seamless": [20]

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/ConfidenceInfo.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/ConfidenceInfo.kt
@@ -12,11 +12,13 @@ package app.clothescast.core.domain.model
  *
  * Two construction paths exist:
  *  - [MultiModelConfidenceFetcher] in `:core:data` builds one from the daily
- *    endpoint's `apparent_temperature_max` / `precipitation_probability_max`
- *    per-model fields. Always over the full calendar day; used as a fallback
- *    on older bundles that don't carry [PerModelHourly].
+ *    endpoint's `apparent_temperature_max` / `apparent_temperature_min` /
+ *    `precipitation_probability_max` per-model fields. Always over the full
+ *    calendar day; used as a fallback on older bundles that don't carry
+ *    [PerModelHourly].
  *  - [computeFrom] (below) builds one directly from a [PerModelHourly]
- *    series, computing the spread over whatever hours that series covers.
+ *    series, comparing the models' daily high and low over whatever hours
+ *    that series covers.
  *    Used by [app.clothescast.core.domain.usecase.GenerateDailyInsight] so
  *    `Insight.confidence` describes the *same* window the Today/Tonight
  *    chip is rendering (`[morningStart, tonightStart)` for TODAY, the
@@ -27,7 +29,12 @@ package app.clothescast.core.domain.model
  */
 data class ConfidenceInfo(
     val level: ForecastConfidence,
-    /** Max - min of peak apparent ("feels-like") temperature across the consulted models, °C. */
+    /**
+     * Widest cross-model disagreement on the day's apparent ("feels-like")
+     * temperature, °C — the larger of the spread on the daily *high* and the
+     * spread on the daily *low* across the consulted models. Computed from a
+     * spike-filtered series so a single anomalous hour doesn't inflate it.
+     */
     val tempSpreadC: Double,
     /** Max - min of peak precipitation probability across the consulted models, percentage points. */
     val precipSpreadPp: Double,
@@ -67,6 +74,16 @@ data class ConfidenceInfo(
          * uses so the Today chip's tier title and the chart-side
          * divergence hint describe the same interval the user is seeing.
          *
+         * The temperature signal is the models' agreement on the day's
+         * *high* and *low*, not on every hour in between: each model's
+         * feels-like series is run through a 3-hour [medianFiltered] before
+         * its max/min is read, so one model's isolated single-hour spike
+         * can't masquerade as the day's extreme and drag the tier down. A
+         * disagreement that persists for two or more hours survives the
+         * filter and still counts. Precip stays a peak-probability spread —
+         * a single hour of likely rain is worth surfacing, so we don't
+         * smooth it.
+         *
          * `best_match` is excluded from the consulted set because it's
          * not one of the named source models — it's Open-Meteo's
          * location-tuned auto-pick that we render as an overlay rather
@@ -78,7 +95,13 @@ data class ConfidenceInfo(
                 .filterKeys { it != PerModelHourly.BEST_MATCH_MODEL_ID }
                 .filterValues { it.isNotEmpty() }
             if (consulted.size < 2) return null
-            val tempMaxes = consulted.values.map { hours -> hours.maxOf { it.apparentTemperatureC } }
+            // Read each model's daily high and low from a spike-filtered
+            // feels-like series rather than the raw hourly max/min, so a
+            // lone outlier hour (one model's 15:00 peak the others don't
+            // see) can't define the day's extreme. See [medianFiltered].
+            val smoothed = consulted.values.map { hours -> medianFiltered(hours) }
+            val tempHighs = smoothed.map { it.max() }
+            val tempLows = smoothed.map { it.min() }
             // Models whose precipitation_probability is wholesale missing (Open-Meteo
             // omits the per-model series for some models) contribute nothing to the
             // precip-spread metric — including them with a fake zero would have
@@ -89,7 +112,14 @@ data class ConfidenceInfo(
             val precipMaxes = consulted.values.mapNotNull { hours ->
                 hours.mapNotNull { it.precipitationProbabilityPct }.maxOrNull()
             }
-            val tempSpread = tempMaxes.max() - tempMaxes.min()
+            // Disagreement on *either* the day's high or its low downgrades
+            // confidence: models that line up on the afternoon peak but
+            // split on the overnight low are still telling the user
+            // different things.
+            val tempSpread = maxOf(
+                tempHighs.max() - tempHighs.min(),
+                tempLows.max() - tempLows.min(),
+            )
             val precipSpread = if (precipMaxes.size >= 2) precipMaxes.max() - precipMaxes.min() else 0.0
             val level = when {
                 tempSpread <= TEMP_HIGH_AGREEMENT_C && precipSpread <= PRECIP_HIGH_AGREEMENT_PP ->
@@ -104,6 +134,45 @@ data class ConfidenceInfo(
                 precipSpreadPp = precipSpread,
                 modelsConsulted = consulted.keys.toList(),
             )
+        }
+
+        /**
+         * Returns each hour's feels-like temperature, with an hour replaced
+         * by the median of itself and its two clock-adjacent neighbors when
+         * — and only when — both of those neighbors are present exactly one
+         * hour either side. This is a median filter: it erases an isolated
+         * single-hour spike (the lone max or min of the trio) while leaving
+         * a run of two or more consistent hours untouched, so one model's
+         * outlier hour can't define its daily high or low for the
+         * cross-model agreement check.
+         *
+         * The adjacency check is deliberately on the *timestamps*, not list
+         * position. [hours] can have gaps — the parser drops an hour whose
+         * `temperature_2m` is null, so list-adjacent entries may be several
+         * hours apart. Filtering on list position alone would let a sample
+         * across a gap vote down a genuinely-retained extreme as if it were
+         * a one-hour blip, suppressing a real high/low and leaving the tier
+         * falsely HIGH. So an hour missing a clock-adjacent neighbor on
+         * either side (a window edge, or a hour bordering a dropped-hour
+         * gap) is kept as-is: with fewer than two real neighbors we can't
+         * confirm a spike, and erring toward *keeping* an extreme keeps the
+         * rating conservative — it never hides real disagreement behind a
+         * data gap. [hours] is assumed ascending by time, as the parser and
+         * window slices produce it.
+         */
+        private fun medianFiltered(hours: List<PerModelHour>): List<Double> {
+            val temps = hours.map { it.apparentTemperatureC }
+            if (temps.size < 3) return temps
+            return temps.indices.map { i ->
+                val hasPrev = i > 0 && hours[i - 1].time.plusHours(1) == hours[i].time
+                val hasNext = i < hours.lastIndex && hours[i].time.plusHours(1) == hours[i + 1].time
+                if (hasPrev && hasNext) {
+                    // Middle of the three clock-adjacent samples.
+                    listOf(temps[i - 1], temps[i], temps[i + 1]).sorted()[1]
+                } else {
+                    temps[i]
+                }
+            }
         }
     }
 }

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/model/ConfidenceInfoTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/model/ConfidenceInfoTest.kt
@@ -91,23 +91,24 @@ class ConfidenceInfoTest {
 
     @Test
     fun `spread is computed over the hours present, so slicing changes the tier`() {
-        // Both models peak around 20°C during the day. ECMWF then sees an
-        // unusual 25°C late-evening warm front that GFS doesn't pick up
-        // (GFS cools normally to 16°C). Full-day per-model max becomes
-        // 25 / 20.5 — a 4.5°C spread, LOW tier. Daytime-only slice drops
-        // the 22:00 hour, so per-model max is 20.5 / 20.5 — HIGH tier.
-        // Validates the whole point of windowed compute: the chip's
-        // title reflects the interval the user is actually shown, not
-        // the full calendar day.
+        // Both models peak around 20°C during the day. ECMWF then sees a
+        // sustained 25°C late-evening warm front that GFS doesn't pick up
+        // (GFS cools normally to 16°C). Because the divergence lasts two
+        // hours it survives the spike filter, so the full-day high becomes
+        // 25 / 20.5 — a 4.5°C spread, LOW tier. The daytime-only slice
+        // drops the evening hours, so the high is 20.5 / 20.5 — HIGH tier.
+        // Validates the whole point of windowed compute: the chip's title
+        // reflects the interval the user is actually shown, not the full
+        // calendar day.
         val fullDay = PerModelHourly(
             byModel = mapOf(
                 "ecmwf_ifs04" to listOf(
                     hour(12, 20.0), hour(13, 20.5), hour(14, 20.0),
-                    hour(22, 25.0), // late-evening outlier
+                    hour(21, 25.0), hour(22, 25.0), // sustained late-evening warm front
                 ),
                 "gfs_seamless" to listOf(
                     hour(12, 20.5), hour(13, 20.0), hour(14, 20.5),
-                    hour(22, 16.0), // normal evening cooling
+                    hour(21, 16.0), hour(22, 16.0), // normal evening cooling
                 ),
             ),
         )
@@ -115,14 +116,109 @@ class ConfidenceInfoTest {
         fullDayInfo.level shouldBe ForecastConfidence.LOW
         fullDayInfo.tempSpreadC shouldBe (4.5 plusOrMinus 0.0001)
 
-        // Daytime-only slice — drops the 22:00 evening hours.
+        // Daytime-only slice — drops the evening hours.
         val daytime = PerModelHourly(
             byModel = fullDay.byModel.mapValues { (_, hours) ->
-                hours.filter { it.time.toLocalTime() != LocalTime.of(22, 0) }
+                hours.filter { it.time.toLocalTime() < LocalTime.of(21, 0) }
             },
         )
         val daytimeInfo = ConfidenceInfo.computeFrom(daytime).shouldNotBeNull()
         daytimeInfo.level shouldBe ForecastConfidence.HIGH
+    }
+
+    @Test
+    fun `a lone single-hour spike does not downgrade the tier`() {
+        // Both models agree the day tops out around 20°C, but GFS has an
+        // isolated 14:00 feels-like spike to 24°C that ECMWF doesn't see.
+        // The raw per-model max would read 24 / 20 — a 4°C spread, LOW
+        // tier — but a single divergent hour shouldn't define the day. The
+        // 3-hour median filter erases the lone interior spike, so the highs
+        // agree and the tier stays HIGH. This is the whole point of the
+        // change. (An hour at the very edge of the window is only damped,
+        // not erased — there's no neighbor on the far side to vote it down
+        // — so the spike sits mid-window here, where the daytime slice puts
+        // a real mid-afternoon disagreement.)
+        val data = PerModelHourly(
+            byModel = mapOf(
+                "ecmwf_ifs04" to listOf(
+                    hour(12, 20.0), hour(13, 20.0), hour(14, 20.0), hour(15, 20.0), hour(16, 20.0),
+                ),
+                "gfs_seamless" to listOf(
+                    hour(12, 20.0), hour(13, 20.0), hour(14, 24.0), hour(15, 20.0), hour(16, 20.0),
+                ),
+            ),
+        )
+        val info = ConfidenceInfo.computeFrom(data).shouldNotBeNull()
+        info.level shouldBe ForecastConfidence.HIGH
+        info.tempSpreadC shouldBe (0.0 plusOrMinus 0.0001)
+    }
+
+    @Test
+    fun `a sustained two-hour divergence still downgrades the tier`() {
+        // Same shape as the spike test, but GFS now runs 4°C hot for two
+        // consecutive hours (15:00 and 16:00). A real two-hour disagreement
+        // survives the median filter, so the high spread stays 4°C and the
+        // tier drops — the filter removes noise, not genuine divergence.
+        val data = PerModelHourly(
+            byModel = mapOf(
+                "ecmwf_ifs04" to listOf(
+                    hour(12, 20.0), hour(13, 20.0), hour(14, 20.0), hour(15, 20.0), hour(16, 20.0),
+                ),
+                "gfs_seamless" to listOf(
+                    hour(12, 20.0), hour(13, 20.0), hour(14, 20.0), hour(15, 24.0), hour(16, 24.0),
+                ),
+            ),
+        )
+        val info = ConfidenceInfo.computeFrom(data).shouldNotBeNull()
+        info.level shouldBe ForecastConfidence.LOW
+        info.tempSpreadC shouldBe (4.0 plusOrMinus 0.0001)
+    }
+
+    @Test
+    fun `a real extreme isolated by dropped-hour gaps is not filtered as a spike`() {
+        // GFS's genuine 24°C daily high sits at 14:00, but 13:00 and 15:00
+        // were dropped (null temperature_2m), so in the list it's flanked by
+        // the 12:00 and 16:00 samples — two hours away on each side. If the
+        // filter ignored timestamps it would read [20, 24, 20] as a one-hour
+        // spike, suppress the 24 down to 20, and report HIGH agreement with
+        // ECMWF — overconfident. Because the filter checks clock adjacency,
+        // the gap-isolated 24 is kept, the high spread is the real 4°C, and
+        // the tier correctly drops.
+        val data = PerModelHourly(
+            byModel = mapOf(
+                "ecmwf_ifs04" to listOf(
+                    hour(12, 20.0), hour(13, 20.0), hour(14, 20.0), hour(15, 20.0), hour(16, 20.0),
+                ),
+                "gfs_seamless" to listOf(
+                    hour(12, 20.0), hour(14, 24.0), hour(16, 20.0), // 13:00 + 15:00 dropped
+                ),
+            ),
+        )
+        val info = ConfidenceInfo.computeFrom(data).shouldNotBeNull()
+        info.level shouldBe ForecastConfidence.LOW
+        info.tempSpreadC shouldBe (4.0 plusOrMinus 0.0001)
+    }
+
+    @Test
+    fun `disagreement on the daily low alone can drive the tier down`() {
+        // Both models agree on the daytime high (20°C), but split on the
+        // overnight low: ECMWF bottoms out at 18°C, GFS at 12°C. The low
+        // disagreement is the wider of the two spreads, so it drives the
+        // tier — models that line up on the peak but not the low are still
+        // telling the user different things.
+        val data = PerModelHourly(
+            byModel = mapOf(
+                "ecmwf_ifs04" to listOf(
+                    hour(12, 20.0), hour(13, 20.0), hour(14, 18.0), hour(15, 18.0), hour(16, 18.0),
+                ),
+                "gfs_seamless" to listOf(
+                    hour(12, 20.0), hour(13, 20.0), hour(14, 12.0), hour(15, 12.0), hour(16, 12.0),
+                ),
+            ),
+        )
+        val info = ConfidenceInfo.computeFrom(data).shouldNotBeNull()
+        info.level shouldBe ForecastConfidence.LOW
+        info.tempSpreadC shouldBe (6.0 plusOrMinus 0.0001)
     }
 
     @Test


### PR DESCRIPTION
## Why

The cross-model agreement rating ("Forecasters agree / disagree a bit") keyed its temperature spread off each model's **single peak hour** (`maxOf { apparentTemperatureC }`), so one model's lone outlier hour — a brief 15:00 feels-like spike, or a late-evening warm front the others miss — could downgrade the whole day's confidence even when the daily highs, lows, and rain broadly agreed. That's exactly the case "Models disagree most at 15:00 (Δ 2.5°C feels-like)" surfaced, and it isn't interesting enough to lower confidence over.

## What changed

The temperature signal now compares the models on the day's **high *and* low**, read from a **median-filtered** feels-like series:

- The filter erases an isolated single-hour spike (a value far above/below both clock-adjacent neighbors) while leaving a disagreement that lasts two or more hours intact — genuine divergence still counts, lone blips don't.
- **Adjacency is checked on timestamps, not list position.** A model's hourly series can have gaps (the parser drops an hour with a null `temperature_2m`), so an hour missing a neighbor one hour either side — a window edge, or one bordering a dropped-hour gap — is kept as-is. With fewer than two real neighbors we can't confirm a spike, and erring toward keeping the extreme keeps the rating conservative rather than hiding real disagreement behind a data gap (the false-HIGH risk Codex flagged).
- The tier reads the **wider of** the high-spread and low-spread, so models that line up on the afternoon peak but split on the overnight low are still flagged.
- **Precip is unchanged** — a single hour of likely rain is worth surfacing, so peak precip probability is not smoothed.

Both construction paths move together to stay coherent:
- `ConfidenceInfo.computeFrom` — the hourly path the Today chip actually renders.
- `MultiModelConfidenceFetcher` — the daily-endpoint fallback now also requests `apparent_temperature_min` and takes `max(high-spread, low-spread)`. The min is a *soft* field, so a model that omits it still contributes its high.

Because the "Models disagree most at …" hint only shows when the tier isn't HIGH, a lone-hour case that now resolves to HIGH drops both the "disagree a bit" title and the hint — which is the behavior asked for.

## Device boundary

The confidence request to Open-Meteo (keyless, free) gains one daily field, `apparent_temperature_min`, for the same coordinates already sent. No new PII leaves the device.

## Test plan

`:core:domain:test`, `:core:data:test`, `:app:testDebugUnitTest` all pass locally (incl. Roborazzi snapshots — no pixel changes). New/updated coverage:
- **domain:** single-hour spike is filtered (stays HIGH); sustained two-hour divergence still downgrades (LOW); a real extreme isolated by dropped-hour gaps is *not* filtered (timestamp-aware adjacency); daily-low disagreement alone drives the tier; the slicing test reworked to use a *sustained* evening front.
- **data:** new `THREE_MODEL_LOW_SPLIT` fixture + test for the low-disagreement path; updated the `daily=` request-param assertion.

https://claude.ai/code/session_01ULTuYkUoUrT6vzsMcod8pB