### PR TITLE
Retry the Gemini voice before falling back to the device voice

### DIFF
--- a/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
@@ -37,6 +37,7 @@ import app.clothescast.core.domain.util.isWithin
 import app.clothescast.core.data.tts.GeminiTtsDailyQuotaExhaustedException
 import app.clothescast.core.data.tts.PcmAudio
 import app.clothescast.core.data.tts.WavEncoder
+import app.clothescast.core.data.tts.isRetryableGeminiTtsFailure
 import app.clothescast.data.InsightCache
 import app.clothescast.mqtt.MqttPublishOutcome
 import kotlinx.coroutines.Deferred
@@ -1118,11 +1119,23 @@ class FetchAndNotifyWorker(
 
     /**
      * Synthesises insight prose via Gemini TTS for the pre-alignment
-     * synth track. Returns null on any failure so downstream
-     * consumers (MQTT audio, phone speaker) can degrade gracefully:
-     * the bridge skips its audio publish, the phone speaker falls back
-     * to the device engine. Logs the failure with enough context to
-     * diagnose without spamming successes.
+     * synth track. Returns null on failure so downstream consumers
+     * (MQTT audio, phone speaker) can degrade gracefully: the bridge
+     * skips its audio publish, the phone speaker falls back to the
+     * device engine.
+     *
+     * A single transient network blip — socket timeout, dropped
+     * connection, a 429 / 5xx from the shared-key proxy — shouldn't
+     * downgrade the whole briefing to the device engine; the user
+     * picked Gemini. Retry [GEMINI_TTS_SYNTH_ATTEMPTS] times with a
+     * short exponential backoff before giving up. The synth runs
+     * pre-alignment, concurrently with the outfit render and ahead of
+     * [awaitDeliveryAlignment], so these waits are usually absorbed by
+     * the alignment barrier rather than delaying delivery. Permanent
+     * failures for this run (spent daily quota, blocked prompt, a
+     * non-retryable HTTP 4xx) skip the retries via
+     * [isRetryableGeminiTtsFailure] and fall back immediately. Logs each
+     * failure with enough context to diagnose without spamming successes.
      */
     private suspend fun synthesizeForDelivery(
         insight: Insight,
@@ -1134,38 +1147,57 @@ class FetchAndNotifyWorker(
         // holiday's voice (Father Christmas on Dec 25, a president on
         // Presidents' Day, …) and switch to a matching-gender voice.
         val selection = resolveHolidayVoice(theme?.id, prefs.geminiVoice, prefs.ttsStyle)
-        return runCatching {
-            GeminiTtsSpeaker(
-                app.geminiTtsClient,
-                voiceName = selection.voiceName,
-                style = selection.style,
-            ).synthesize(utterance.text, utterance.locale)
-        }
-            .onSuccess {
+        val speaker = GeminiTtsSpeaker(
+            app.geminiTtsClient,
+            voiceName = selection.voiceName,
+            style = selection.style,
+        )
+
+        var lastFailure: Throwable? = null
+        for (attempt in 0 until GEMINI_TTS_SYNTH_ATTEMPTS) {
+            try {
+                val pcm = speaker.synthesize(utterance.text, utterance.locale)
                 // A successful synth means the shared-key daily allowance isn't
                 // exhausted (or the user added their own key), so retire any
                 // Today limit card. Best-effort: a failed write just leaves the
                 // card up until the next success.
                 persistQuotaStatus { app.settingsRepository.clearGeminiTtsLimitExceeded() }
-            }
-            .onFailure { t ->
-                if (t is CancellationException) throw t
-                if (t is GeminiTtsDailyQuotaExhaustedException) {
-                    // The free shared-key allowance is spent for today. The cast
-                    // still plays via the device engine below; record the limit so
-                    // the Today screen can nudge the user toward Speech settings to
-                    // add their own Gemini key for unlimited casts. Persist the
-                    // reset time so the card auto-expires at the daily boundary
-                    // even before a later synth clears it.
-                    persistQuotaStatus {
-                        app.settingsRepository.setGeminiTtsLimitExceeded(
-                            resetAtMs = quotaResetAtMs(t.resetAtUtc),
-                        )
-                    }
+                return pcm
+            } catch (ce: CancellationException) {
+                throw ce
+            } catch (t: Throwable) {
+                lastFailure = t
+                if (!isRetryableGeminiTtsFailure(t)) break
+                if (attempt < GEMINI_TTS_SYNTH_ATTEMPTS - 1) {
+                    val backoffMs = GEMINI_TTS_SYNTH_BACKOFF_MS shl attempt
+                    DiagLog.w(
+                        TAG,
+                        "Gemini TTS synth attempt ${attempt + 1}/$GEMINI_TTS_SYNTH_ATTEMPTS " +
+                            "failed; retrying in ${backoffMs}ms.",
+                        t,
+                    )
+                    delay(backoffMs)
                 }
-                DiagLog.w(TAG, "Gemini TTS synth failed; downstream audio destinations degrade.", t)
             }
-            .getOrNull()
+        }
+
+        // Every attempt failed, or a permanent failure broke the loop early.
+        val failure = lastFailure
+        if (failure is GeminiTtsDailyQuotaExhaustedException) {
+            // The free shared-key allowance is spent for today. The cast
+            // still plays via the device engine below; record the limit so
+            // the Today screen can nudge the user toward Speech settings to
+            // add their own Gemini key for unlimited casts. Persist the
+            // reset time so the card auto-expires at the daily boundary
+            // even before a later synth clears it.
+            persistQuotaStatus {
+                app.settingsRepository.setGeminiTtsLimitExceeded(
+                    resetAtMs = quotaResetAtMs(failure.resetAtUtc),
+                )
+            }
+        }
+        DiagLog.w(TAG, "Gemini TTS synth failed; downstream audio destinations degrade.", failure)
+        return null
     }
 
     /**
@@ -1698,6 +1730,24 @@ class FetchAndNotifyWorker(
          * the unlucky tail where rolls bunch up.
          */
         private const val ALARM_FETCH_JITTER_MS = 30_000L
+
+        /**
+         * Total Gemini TTS synth attempts (initial try + retries) before the
+         * delivery falls back to the device engine. A single transient blip —
+         * the socket timeout in the field report that triggered this — shouldn't
+         * downgrade the briefing to the device voice the user didn't pick. Three
+         * attempts clears the common one-off timeout while staying bounded; the
+         * retries run pre-alignment, usually absorbed by the alignment barrier.
+         */
+        private const val GEMINI_TTS_SYNTH_ATTEMPTS = 3
+
+        /**
+         * Base backoff between Gemini TTS synth retries, doubled each attempt
+         * (1 s, then 2 s). Short on purpose: the synth track runs ahead of
+         * [awaitDeliveryAlignment], so a couple of seconds of retry is normally
+         * swallowed by the ~60 s alignment wait without pushing delivery later.
+         */
+        private const val GEMINI_TTS_SYNTH_BACKOFF_MS = 1_000L
 
         /** Which slice of the day this run is for; defaults to TODAY when absent. */
         internal const val KEY_PERIOD = "period"

--- a/core/data/src/main/kotlin/app/clothescast/core/data/tts/GeminiTtsClient.kt
+++ b/core/data/src/main/kotlin/app/clothescast/core/data/tts/GeminiTtsClient.kt
@@ -648,6 +648,28 @@ private fun parseDailyQuotaExhausted(body: ByteArray): GeminiTtsDailyQuotaExhaus
     return GeminiTtsDailyQuotaExhaustedException(limit = limit, resetAtUtc = resetAtUtc)
 }
 
+/**
+ * Classifies a Gemini TTS synthesis failure for the caller's retry decision.
+ *
+ * Transient failures — network timeouts, dropped connections, a 429 rate-limit
+ * or a 5xx from the shared-key proxy, and the occasional empty-candidate model
+ * hiccup — are worth another attempt before degrading to the device engine; the
+ * user picked Gemini, so a single blip shouldn't downgrade the whole briefing.
+ *
+ * Failures that won't change on a retry return false so the caller falls back
+ * immediately: the spent daily free-tier quota, a blocked prompt, and a
+ * non-retryable HTTP 4xx (auth / bad request). [CancellationException] is never
+ * retryable — it must propagate to unwind structured concurrency rather than be
+ * caught and retried.
+ */
+fun isRetryableGeminiTtsFailure(t: Throwable): Boolean = when (t) {
+    is CancellationException -> false
+    is GeminiTtsDailyQuotaExhaustedException -> false
+    is GeminiTtsBlockedException -> false
+    is GeminiTtsHttpException -> t.status.value == 429 || t.status.value in 500..599
+    else -> true
+}
+
 class GeminiTtsHttpException(val status: HttpStatusCode, body: ByteArray) :
     IllegalStateException(buildMessage(status, body)) {
 

--- a/core/data/src/test/kotlin/app/clothescast/core/data/tts/GeminiTtsRetryClassifierTest.kt
+++ b/core/data/src/test/kotlin/app/clothescast/core/data/tts/GeminiTtsRetryClassifierTest.kt
@@ -1,0 +1,64 @@
+package app.clothescast.core.data.tts
+
+import io.kotest.matchers.shouldBe
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.CancellationException
+import org.junit.jupiter.api.Test
+import java.io.IOException
+import java.net.SocketTimeoutException
+
+class GeminiTtsRetryClassifierTest {
+
+    @Test
+    fun `socket timeout is retryable`() {
+        // The field report that motivated the retry: a transient
+        // SocketTimeoutException downgraded the whole briefing to device TTS.
+        isRetryableGeminiTtsFailure(SocketTimeoutException("timeout")) shouldBe true
+    }
+
+    @Test
+    fun `generic network IO failure is retryable`() {
+        isRetryableGeminiTtsFailure(IOException("connection reset")) shouldBe true
+    }
+
+    @Test
+    fun `empty-candidate model hiccup is retryable`() {
+        isRetryableGeminiTtsFailure(GeminiTtsEmptyResponseException(finishReason = null)) shouldBe true
+    }
+
+    @Test
+    fun `5xx server error is retryable`() {
+        val failure = GeminiTtsHttpException(HttpStatusCode.BadGateway, ByteArray(0))
+        isRetryableGeminiTtsFailure(failure) shouldBe true
+    }
+
+    @Test
+    fun `429 rate-limit is retryable`() {
+        val failure = GeminiTtsHttpException(HttpStatusCode.TooManyRequests, ByteArray(0))
+        isRetryableGeminiTtsFailure(failure) shouldBe true
+    }
+
+    @Test
+    fun `4xx auth failure is not retryable`() {
+        // Auth / bad-request won't change on a retry — fall back immediately.
+        val failure = GeminiTtsHttpException(HttpStatusCode.Forbidden, ByteArray(0))
+        isRetryableGeminiTtsFailure(failure) shouldBe false
+    }
+
+    @Test
+    fun `spent daily quota is not retryable`() {
+        val failure = GeminiTtsDailyQuotaExhaustedException(limit = 50, resetAtUtc = null)
+        isRetryableGeminiTtsFailure(failure) shouldBe false
+    }
+
+    @Test
+    fun `blocked prompt is not retryable`() {
+        isRetryableGeminiTtsFailure(GeminiTtsBlockedException("blocked")) shouldBe false
+    }
+
+    @Test
+    fun `cancellation is never retryable`() {
+        // Must propagate to unwind structured concurrency, not be retried.
+        isRetryableGeminiTtsFailure(CancellationException("cancelled")) shouldBe false
+    }
+}


### PR DESCRIPTION
## What

A single transient network blip during Gemini TTS synthesis used to drop the whole spoken briefing to the on-device voice the user didn't pick. A field bug report showed exactly this:

```
W FetchAndNotifyWorker: Gemini TTS synth failed; downstream audio destinations degrade.
java.net.SocketTimeoutException: Socket timeout has expired [url=…/gemini-2.5-flash-preview-tts:generateContent]
…
I AndroidTtsSpeaker: TTS voice (auto): en-gb-x-gba-local
```

One `SocketTimeoutException` and the morning forecast spoke in the device engine despite `TTS engine: GEMINI` being set.

## Change

`synthesizeForDelivery` now retries the Gemini synth up to **3 attempts** with a short exponential backoff (1 s, then 2 s) before degrading to the device engine. The synth track runs pre-alignment — concurrently with the outfit render and ahead of the ~60 s delivery-alignment barrier — so the retries are normally absorbed by the alignment wait rather than pushing delivery later.

Failures that won't change on a retry skip the retries and fall back immediately:
- spent daily free-tier quota (`GeminiTtsDailyQuotaExhaustedException`)
- blocked prompt (`GeminiTtsBlockedException`)
- non-retryable HTTP 4xx (auth / bad request)

`CancellationException` always propagates so a worker cancellation still unwinds structured concurrency.

The retry classification lives in `:core:data` as `isRetryableGeminiTtsFailure` so it's unit-testable on a JVM.

## Privacy

No change to what crosses the device boundary — the same insight prose is sent to the same TTS endpoint, just retried (up to 3×) on a transient failure. Nothing new leaves the device.

## Test plan

- `GeminiTtsRetryClassifierTest` (new, `:core:data`) covers the classifier: socket timeout / generic IO / empty-candidate / 5xx / 429 retryable; 4xx / quota / blocked / cancellation not retryable. ✅ passing
- `:app:compileDebugKotlin` ✅
- Relying on CI for the full `:app` test + Android build.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KJg6cSpUAHVnw43U9EUpii)_

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/2518d586-986c-4e1f-92d0-1a5c88b8c693/pull/1004"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a>
<!-- capy-pr-badge:end -->