### PR TITLE
Cast to Google speaker groups, not just single speakers

### DIFF
--- a/app/src/main/kotlin/app/clothescast/cast/CastDeviceClass.kt
+++ b/app/src/main/kotlin/app/clothescast/cast/CastDeviceClass.kt
@@ -19,10 +19,14 @@ enum class CastDeviceClass { DISPLAY, AUDIO_ONLY, UNKNOWN }
  *
  * [CastDevice.CAPABILITY_VIDEO_OUT] is the authoritative signal — it's
  * the receiver-reported capability Google's own Cast dialog uses to
- * route audio vs. video. The MediaRouter speaker device-type is a
- * fallback for when the [CastDevice] bundle isn't populated yet.
+ * route audio vs. video. When the [CastDevice] bundle isn't populated
+ * yet (the AndroidX route API allows `extras` to be null, common for
+ * speaker groups), MediaRouter's own metadata is the fallback: a route
+ * that is a group, or whose device type is a speaker, has no screen.
+ * Google Cast groups are audio-only by design — there are no video
+ * groups — so a group route never wants the image+audio MP4.
  *
- * Returns [CastDeviceClass.UNKNOWN] when neither signal is conclusive;
+ * Returns [CastDeviceClass.UNKNOWN] when no signal is conclusive;
  * callers treat UNKNOWN as a display ([mediaPlanFor]) so an
  * unidentified route keeps the proven image+audio path rather than
  * being silently downgraded to audio-only. Worst case an MP4 lands on a
@@ -31,14 +35,41 @@ enum class CastDeviceClass { DISPLAY, AUDIO_ONLY, UNKNOWN }
  */
 internal fun classifyRoute(route: MediaRouter.RouteInfo): CastDeviceClass {
     val device = route.extras?.let { CastDevice.getFromBundle(it) }
-    return when {
-        device != null && device.hasCapability(CastDevice.CAPABILITY_VIDEO_OUT) ->
-            CastDeviceClass.DISPLAY
-        device != null -> CastDeviceClass.AUDIO_ONLY
-        route.deviceType == MediaRouter.RouteInfo.DEVICE_TYPE_SPEAKER ->
-            CastDeviceClass.AUDIO_ONLY
-        else -> CastDeviceClass.UNKNOWN
-    }
+    return classifyDevice(
+        hasCastDevice = device != null,
+        hasVideoOut = device?.hasCapability(CastDevice.CAPABILITY_VIDEO_OUT) == true,
+        isGroup = route.isGroup,
+        deviceType = route.deviceType,
+    )
+}
+
+/**
+ * MediaRouter device types with no screen. The fallback when no
+ * [CastDevice] is attached — covers Cast speaker groups
+ * ([MediaRouter.RouteInfo.DEVICE_TYPE_GROUP]) and bare speakers.
+ */
+private val AUDIO_ONLY_DEVICE_TYPES = setOf(
+    MediaRouter.RouteInfo.DEVICE_TYPE_SPEAKER,
+    MediaRouter.RouteInfo.DEVICE_TYPE_REMOTE_SPEAKER,
+    MediaRouter.RouteInfo.DEVICE_TYPE_GROUP,
+)
+
+/**
+ * Pure decision behind [classifyRoute], split out so the
+ * group / speaker / video-out matrix is unit-testable without a real
+ * [MediaRouter.RouteInfo].
+ */
+internal fun classifyDevice(
+    hasCastDevice: Boolean,
+    hasVideoOut: Boolean,
+    isGroup: Boolean,
+    deviceType: Int,
+): CastDeviceClass = when {
+    hasCastDevice && hasVideoOut -> CastDeviceClass.DISPLAY
+    hasCastDevice -> CastDeviceClass.AUDIO_ONLY
+    isGroup -> CastDeviceClass.AUDIO_ONLY
+    deviceType in AUDIO_ONLY_DEVICE_TYPES -> CastDeviceClass.AUDIO_ONLY
+    else -> CastDeviceClass.UNKNOWN
 }
 
 /**

--- a/app/src/test/kotlin/app/clothescast/cast/CastDeviceClassTest.kt
+++ b/app/src/test/kotlin/app/clothescast/cast/CastDeviceClassTest.kt
@@ -1,9 +1,63 @@
 package app.clothescast.cast
 
+import androidx.mediarouter.media.MediaRouter.RouteInfo
 import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
 
 class CastDeviceClassTest {
+
+    @Test
+    fun `a cast device reporting video-out is a display`() {
+        classifyDevice(
+            hasCastDevice = true,
+            hasVideoOut = true,
+            isGroup = false,
+            deviceType = RouteInfo.DEVICE_TYPE_TV,
+        ) shouldBe CastDeviceClass.DISPLAY
+    }
+
+    @Test
+    fun `a cast device with no video-out is audio-only`() {
+        classifyDevice(
+            hasCastDevice = true,
+            hasVideoOut = false,
+            isGroup = false,
+            deviceType = RouteInfo.DEVICE_TYPE_SPEAKER,
+        ) shouldBe CastDeviceClass.AUDIO_ONLY
+    }
+
+    @Test
+    fun `a group route with no cast device extras is audio-only, not unknown`() {
+        // Speaker groups often expose null extras, so the video-out check is
+        // skipped — the group signal must still route them to the WAV path
+        // rather than the padded image+audio MP4.
+        classifyDevice(
+            hasCastDevice = false,
+            hasVideoOut = false,
+            isGroup = true,
+            deviceType = RouteInfo.DEVICE_TYPE_GROUP,
+        ) shouldBe CastDeviceClass.AUDIO_ONLY
+    }
+
+    @Test
+    fun `a speaker device type with no cast device is audio-only`() {
+        classifyDevice(
+            hasCastDevice = false,
+            hasVideoOut = false,
+            isGroup = false,
+            deviceType = RouteInfo.DEVICE_TYPE_REMOTE_SPEAKER,
+        ) shouldBe CastDeviceClass.AUDIO_ONLY
+    }
+
+    @Test
+    fun `an unidentifiable route falls back to unknown`() {
+        classifyDevice(
+            hasCastDevice = false,
+            hasVideoOut = false,
+            isGroup = false,
+            deviceType = RouteInfo.DEVICE_TYPE_UNKNOWN,
+        ) shouldBe CastDeviceClass.UNKNOWN
+    }
 
     @Test
     fun `display gets the muxed MP4 regardless of audio`() {


### PR DESCRIPTION
Follow-up to #1006 (audio-only Cast support), addressing a post-merge review comment.

## Problem

`classifyRoute` keyed on the receiver-reported `CastDevice.CAPABILITY_VIDEO_OUT`, with the MediaRouter speaker device-type as a fallback. But a Cast **speaker group** often exposes **null route extras** (no `CastDevice` attached) and a `DEVICE_TYPE_GROUP` device type — so it fell through to `UNKNOWN`, and `UNKNOWN` takes the display path. Result: speaker groups still got the padded image+audio **MP4** instead of the bare spoken-forecast **WAV** the audio-only path exists to give them.

This was the speaker-group risk called out in the original PR's "needs hardware verification" notes — now fixed in code rather than left to chance.

## Fix

`classifyRoute` now treats a **group route** (`RouteInfo.isGroup`) and the **remote-speaker** device type as audio-only when no `CastDevice` is attached. Google Cast groups are audio-only by design — there are no video groups — so a group never wants the MP4.

- The decision is split into a pure `classifyDevice(hasCastDevice, hasVideoOut, isGroup, deviceType)` seam so the group / speaker / video-out matrix is **unit-testable** without a real `MediaRouter.RouteInfo`.
- `UNKNOWN` → display fallback is unchanged for genuinely unidentifiable routes.

## Test plan

- ✅ `:app:testDebugUnitTest` cast suite green. New `classifyDevice` tests cover: video-out → display, cast-device-no-video → audio, **group with null extras → audio (not unknown)**, speaker device-type → audio, and unidentifiable → unknown.
- ⚠️ Still wants real-hardware confirmation that a Google Home speaker group actually plays the WAV — but the classification gap that sent it down the MP4 path is closed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RvYhadrc9ttWrqkYhYPTvf)_