### PR TITLE
Bug hunt: nine fixes across consensus math, casting, settings, and charts

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ClothesCastApplication.kt
+++ b/app/src/main/kotlin/app/clothescast/ClothesCastApplication.kt
@@ -1,7 +1,9 @@
 package app.clothescast
 
+import android.app.Activity
 import android.app.Application
 import android.content.Context
+import android.os.Bundle
 import app.clothescast.alarm.DailyAlarmScheduler
 import app.clothescast.calendar.CalendarContractEventReader
 import app.clothescast.cast.CastInsightController
@@ -51,6 +53,7 @@ import io.ktor.serialization.kotlinx.json.json
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import java.lang.ref.WeakReference
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
@@ -266,6 +269,18 @@ class ClothesCastApplication : Application() {
     // Telemetry) and read by the nav layer for the onboarding-skip write.
     internal val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
+    // Weak handle on the currently-resumed Activity, maintained by the
+    // lifecycle callbacks registered in [onCreate]. Lets long-lived lambdas
+    // (e.g. ViewModel factory closures, which outlive any one Activity across
+    // config changes) act on the *live* Activity at call time — the locale
+    // switch's recreate() on API 31/32 — without retaining a destroyed
+    // instance. WeakReference so this never extends an Activity's lifetime.
+    @Volatile
+    private var resumedActivity: WeakReference<Activity>? = null
+
+    /** The Activity currently in the resumed state, or null when none is. */
+    fun currentResumedActivity(): Activity? = resumedActivity?.get()
+
     override fun attachBaseContext(base: Context) {
         // Re-apply the persisted per-app locale before the framework caches a
         // Resources reference for the Application context (used by the worker
@@ -276,6 +291,22 @@ class ClothesCastApplication : Application() {
 
     override fun onCreate() {
         super.onCreate()
+        registerActivityLifecycleCallbacks(object : ActivityLifecycleCallbacks {
+            override fun onActivityResumed(activity: Activity) {
+                resumedActivity = WeakReference(activity)
+            }
+            override fun onActivityPaused(activity: Activity) {
+                // Identity check: a *new* Activity's onResume runs before the
+                // old one's onPause during a recreate, so clearing blindly
+                // would drop the fresh reference.
+                if (resumedActivity?.get() === activity) resumedActivity = null
+            }
+            override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {}
+            override fun onActivityStarted(activity: Activity) {}
+            override fun onActivityStopped(activity: Activity) {}
+            override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {}
+            override fun onActivityDestroyed(activity: Activity) {}
+        })
         DiagLog.install(this)
         initAppCheck()
         // Bridge the user's Privacy toggle to Firebase. No-ops on builds

--- a/app/src/main/kotlin/app/clothescast/cast/CastInsightController.kt
+++ b/app/src/main/kotlin/app/clothescast/cast/CastInsightController.kt
@@ -587,7 +587,8 @@ class CastInsightController(
         if (existing != null && existing.isConnected && router.selectedRoute.id == route.id) {
             return existing
         }
-        if (router.selectedRoute.id != route.id) {
+        val routeAlreadySelected = router.selectedRoute.id == route.id
+        if (!routeAlreadySelected) {
             // selectRoute tears down any existing session on a different
             // route and starts a new one — the controller's [sessionListener]
             // catches the old session's onSessionEnded and stops the media
@@ -598,27 +599,55 @@ class CastInsightController(
         return withTimeoutOrNull(timeoutMs) {
             suspendCancellableCoroutine { cont ->
                 val listener = object : SessionManagerListener<CastSession> {
+                    // Unregister on every terminal callback, not just on
+                    // cancellation: the SessionManager lives for the process,
+                    // so a listener left behind after a *successful* start
+                    // accumulates — one per scheduled cast, each retaining its
+                    // continuation and invoked on the main thread for all
+                    // future session events.
+                    private fun complete(block: () -> Unit) {
+                        if (!cont.isActive) return
+                        sessionManager.removeSessionManagerListener(this, CastSession::class.java)
+                        block()
+                    }
                     override fun onSessionStarting(session: CastSession) {}
                     override fun onSessionStarted(session: CastSession, sessionId: String) {
-                        if (cont.isActive) cont.resume(session)
+                        complete { cont.resume(session) }
                     }
                     override fun onSessionStartFailed(session: CastSession, error: Int) {
-                        if (cont.isActive) cont.resumeWithException(CastFailure.SessionStartFailed(error))
+                        complete { cont.resumeWithException(CastFailure.SessionStartFailed(error)) }
                     }
                     override fun onSessionEnding(session: CastSession) {}
                     override fun onSessionEnded(session: CastSession, error: Int) {}
                     override fun onSessionResuming(session: CastSession, sessionId: String) {}
                     override fun onSessionResumed(session: CastSession, wasSuspended: Boolean) {
-                        if (cont.isActive) cont.resume(session)
+                        complete { cont.resume(session) }
                     }
                     override fun onSessionResumeFailed(session: CastSession, error: Int) {
-                        if (cont.isActive) cont.resumeWithException(CastFailure.SessionStartFailed(error))
+                        complete { cont.resumeWithException(CastFailure.SessionStartFailed(error)) }
                     }
                     override fun onSessionSuspended(session: CastSession, reason: Int) {}
                 }
                 sessionManager.addSessionManagerListener(listener, CastSession::class.java)
                 cont.invokeOnCancellation {
                     sessionManager.removeSessionManagerListener(listener, CastSession::class.java)
+                }
+                if (routeAlreadySelected) {
+                    // Close the registration race: a session can connect
+                    // between the [existing] snapshot above and the listener
+                    // registering, in which case no further callback fires and
+                    // the wait would time out despite a live session. Only
+                    // safe to read when no selectRoute teardown is in flight
+                    // (the route was already selected) — right after a
+                    // selectRoute the still-connected *old* session could
+                    // otherwise be returned and the insight would load on the
+                    // wrong device.
+                    sessionManager.currentCastSession?.takeIf { it.isConnected }?.let { live ->
+                        if (cont.isActive) {
+                            sessionManager.removeSessionManagerListener(listener, CastSession::class.java)
+                            cont.resume(live)
+                        }
+                    }
                 }
             }
         } ?: throw CastFailure.SessionStartTimeout

--- a/app/src/main/kotlin/app/clothescast/cast/CastMediaServer.kt
+++ b/app/src/main/kotlin/app/clothescast/cast/CastMediaServer.kt
@@ -61,9 +61,14 @@ import java.security.SecureRandom
  *   - Ktor CIO runs its accept / handler loop on its own threads. The
  *     buffer reference and the token are `@Volatile` so a handler
  *     racing a [publish] sees one set or the other, never a torn write.
- *   - [start] / [stop] / [publish] are intended to be called from a
- *     single thread (the cast session listener); concurrent calls
- *     aren't guarded.
+ *   - [stop] and [publish] are `@Synchronized`: in practice they arrive
+ *     on different threads — [publish] on the worker's dispatcher (the
+ *     controller deliberately keeps it off the main thread), [stop] on
+ *     the main thread via the session listener's onSessionEnded — and
+ *     a previous session's teardown can land mid-publish. The lock
+ *     keeps a stop from clearing the token/buffer a publish just
+ *     minted a URL for, and gives `server`/`port` (plain fields) their
+ *     memory visibility.
  */
 class CastMediaServer {
 
@@ -103,6 +108,7 @@ class CastMediaServer {
      * @param kind the media shape — sets the URL suffix and the
      *   `Content-Type` the handler serves it with.
      */
+    @Synchronized
     fun publish(host: String, media: ByteArray, kind: CastMediaKind = CastMediaKind.MP4): MediaUrl {
         this.buffer = media
         this.kind = kind
@@ -131,6 +137,7 @@ class CastMediaServer {
     }
 
     /** Stops the server, if running, and clears the buffered media + the path token. */
+    @Synchronized
     fun stop() {
         server?.stop(gracePeriodMillis = 0, timeoutMillis = 500)
         server = null
@@ -143,6 +150,7 @@ class CastMediaServer {
     }
 
     /** Currently-bound port, or 0 if the server isn't running. Test hook. */
+    @Synchronized
     internal fun port(): Int = port
 
     private fun start() {

--- a/app/src/main/kotlin/app/clothescast/cast/CastTestDispatch.kt
+++ b/app/src/main/kotlin/app/clothescast/cast/CastTestDispatch.kt
@@ -12,6 +12,7 @@ import app.clothescast.data.SettingsRepository
 import app.clothescast.insight.InsightFormatter
 import app.clothescast.ui.garment.outfitCardInfoLines
 import app.clothescast.ui.garment.renderOutfitCard
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
@@ -145,6 +146,11 @@ internal suspend fun castCurrentInsight(
         CastTestOutcome.publishedButNotFetched(reason = e.message ?: "")
     } catch (e: CastInsightController.CastFailure) {
         CastTestOutcome.failed(e.message ?: context.getString(R.string.cast_error_unknown))
+    } catch (ce: CancellationException) {
+        // The user navigating away cancels the calling scope mid-cast; that
+        // must unwind structured concurrency, not persist a bogus "cast
+        // failed" into the Settings status row for a cast they abandoned.
+        throw ce
     } catch (t: Throwable) {
         CastTestOutcome.failed(t.message ?: context.getString(R.string.cast_error_unknown))
     }

--- a/app/src/main/kotlin/app/clothescast/data/ClothesRuleDto.kt
+++ b/app/src/main/kotlin/app/clothescast/data/ClothesRuleDto.kt
@@ -29,18 +29,23 @@ internal data class ClothesRuleDto(
     val value: Double,
     val unit: String? = null,
 ) {
-    /** Returns the domain rule, or `null` if [item] isn't a catalog [Garment]. */
+    /**
+     * Returns the domain rule, or `null` if [item] isn't a catalog [Garment]
+     * or [type] isn't a known condition. Unknown types degrade per-item like
+     * unknown garments do: one forward-compat rule (written by a future build,
+     * then the app downgraded) costs only itself, not the user's entire rule
+     * list — throwing here would trip the whole-list `runCatching` in
+     * `parseRules` and silently reset every threshold to defaults.
+     */
     fun toDomain(): ClothesRule? {
         val garment = Garment.fromKey(item) ?: return null
-        return ClothesRule(
-            item = garment,
-            condition = when (type) {
-                TYPE_TEMP_BELOW -> ClothesRule.TemperatureBelow(value, parseUnit(unit))
-                TYPE_TEMP_ABOVE -> ClothesRule.TemperatureAbove(value, parseUnit(unit))
-                TYPE_PRECIP_ABOVE -> ClothesRule.PrecipitationProbabilityAbove(value)
-                else -> error("Unknown clothes rule type: $type")
-            },
-        )
+        val condition = when (type) {
+            TYPE_TEMP_BELOW -> ClothesRule.TemperatureBelow(value, parseUnit(unit))
+            TYPE_TEMP_ABOVE -> ClothesRule.TemperatureAbove(value, parseUnit(unit))
+            TYPE_PRECIP_ABOVE -> ClothesRule.PrecipitationProbabilityAbove(value)
+            else -> return null
+        }
+        return ClothesRule(item = garment, condition = condition)
     }
 
     companion object {

--- a/app/src/main/kotlin/app/clothescast/data/SettingsRepository.kt
+++ b/app/src/main/kotlin/app/clothescast/data/SettingsRepository.kt
@@ -897,7 +897,11 @@ class SettingsRepository(
     }
 
     private fun Preferences.toUserPreferences(): UserPreferences {
-        val time = this[SCHEDULE_TIME]?.let { LocalTime.parse(it, TIME_FORMAT) }
+        // Parse defensively like every other stored value: a corrupt HH:mm
+        // string would otherwise throw on every preferences emission —
+        // crashing all UI collectors and pinning the worker on retry — with
+        // no recovery short of clearing app data.
+        val time = this[SCHEDULE_TIME]?.let { runCatching { LocalTime.parse(it, TIME_FORMAT) }.getOrNull() }
             ?: DEFAULT_TIME
         val days = this[SCHEDULE_DAYS]?.mapNotNull { runCatching { DayOfWeek.valueOf(it) }.getOrNull() }
             ?.toSet()
@@ -985,7 +989,7 @@ class SettingsRepository(
         val geminiPromoCardDismissed = this[GEMINI_PROMO_CARD_DISMISSED] == true
         val onboardingSkipped = this[ONBOARDING_SKIPPED] == true
         val calendarPermissionRecheckTick = this[CALENDAR_PERMISSION_RECHECK_TICK] ?: 0L
-        val tonightTime = this[TONIGHT_TIME]?.let { LocalTime.parse(it, TIME_FORMAT) }
+        val tonightTime = this[TONIGHT_TIME]?.let { runCatching { LocalTime.parse(it, TIME_FORMAT) }.getOrNull() }
             ?: DEFAULT_TONIGHT_TIME
         val tonightDays = this[TONIGHT_DAYS]?.mapNotNull { runCatching { DayOfWeek.valueOf(it) }.getOrNull() }
             ?.toSet()

--- a/app/src/main/kotlin/app/clothescast/tts/AndroidTtsEngine.kt
+++ b/app/src/main/kotlin/app/clothescast/tts/AndroidTtsEngine.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.speech.tts.TextToSpeech
 import android.speech.tts.Voice
 import app.clothescast.diag.DiagLog
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.suspendCancellableCoroutine
 import java.util.Locale
 import kotlin.coroutines.resume
@@ -30,6 +31,9 @@ const val GOOGLE_TTS_PACKAGE = "com.google.android.tts"
 internal suspend fun initAndroidTtsEngine(context: Context): TextToSpeech =
     runCatching { initOneAttempt(context, GOOGLE_TTS_PACKAGE) }
         .getOrElse {
+            // A cancelled caller must unwind, not bind a second engine
+            // connection inside an already-cancelled coroutine.
+            if (it is CancellationException) throw it
             DiagLog.w(INIT_TAG, "Google TTS unavailable; falling back to system default.", it)
             initOneAttempt(context, null)
         }

--- a/app/src/main/kotlin/app/clothescast/ui/nav/ClothesCastNavHost.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/nav/ClothesCastNavHost.kt
@@ -1,7 +1,5 @@
 package app.clothescast.ui.nav
 
-import android.app.Activity
-import android.content.Context
 import android.content.Intent
 import androidx.compose.animation.AnimatedContentTransitionScope.SlideDirection
 import androidx.compose.animation.core.tween
@@ -9,7 +7,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
-import androidx.compose.ui.platform.LocalContext
 import androidx.core.os.LocaleListCompat
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavBackStackEntry
@@ -149,8 +146,7 @@ fun ClothesCastNavHost(
         composable<TodayRoute>(
             deepLinks = listOf(navDeepLink<TodayRoute>(basePath = MainActivity.DEEP_LINK_TODAY)),
         ) { entry ->
-            val context = LocalContext.current
-            val today: TodayViewModel = viewModel(factory = todayViewModelFactory(app, context))
+            val today: TodayViewModel = viewModel(factory = todayViewModelFactory(app))
             TodayScreen(
                 viewModel = today,
                 startPage = entry.toRoute<TodayRoute>().page,
@@ -170,14 +166,13 @@ fun ClothesCastNavHost(
         }
 
         composable<OnboardingRoute> {
-            val context = LocalContext.current
             val onboarding: OnboardingViewModel = viewModel(
                 factory = OnboardingViewModel.Factory(
                     secureKeyStore = app.secureKeyStore,
                     settingsRepository = app.settingsRepository,
                     geocodingClient = app.geocodingClient,
                     refreshLocationCache = {
-                        FetchAndNotifyWorker.enqueueLocationCacheRefresh(context)
+                        FetchAndNotifyWorker.enqueueLocationCacheRefresh(app)
                     },
                     workManager = WorkManager.getInstance(app),
                     externalScope = app.applicationScope,
@@ -369,18 +364,22 @@ private fun NavBackStackEntry.settingsViewModel(
     nav: NavController,
     app: ClothesCastApplication,
 ): SettingsViewModel {
-    val context = LocalContext.current
     val parentEntry = remember(this) { nav.getBackStackEntry<SettingsGraph>() }
-    return viewModel(viewModelStoreOwner = parentEntry, factory = settingsViewModelFactory(app, context))
+    return viewModel(viewModelStoreOwner = parentEntry, factory = settingsViewModelFactory(app))
 }
 
-private fun todayViewModelFactory(app: ClothesCastApplication, context: Context) =
+// Factory lambdas capture only [app], never an Activity context: the ViewModels
+// outlive any one Activity (they're scoped to a back-stack entry and survive
+// config changes), and `viewModel(factory = …)` consults the factory only on
+// first creation — a captured LocalContext would pin the original Activity for
+// the VM's lifetime (leak) and act on the destroyed instance after rotation.
+private fun todayViewModelFactory(app: ClothesCastApplication) =
     TodayViewModel.Factory(
         insightCache = app.insightCache,
         workManager = WorkManager.getInstance(app),
         settingsRepository = app.settingsRepository,
         refreshOutfitWidget = {
-            updateAllClothesCastWidgets(context.applicationContext)
+            updateAllClothesCastWidgets(app)
         },
         deriveInsight = app.deriveInsight,
         calendarEventReader = app.calendarEventReader,
@@ -388,7 +387,7 @@ private fun todayViewModelFactory(app: ClothesCastApplication, context: Context)
         geminiKeyNeedsReentry = app.secureKeyStore.geminiKeyNeedsReentryFlow,
     )
 
-private fun settingsViewModelFactory(app: ClothesCastApplication, context: Context) =
+private fun settingsViewModelFactory(app: ClothesCastApplication) =
     SettingsViewModel.Factory(
         settingsRepository = app.settingsRepository,
         keyStore = app.secureKeyStore,
@@ -398,10 +397,15 @@ private fun settingsViewModelFactory(app: ClothesCastApplication, context: Conte
         voiceEnumerator = app.androidTtsVoiceEnumerator,
         applyAppLocale = { region ->
             AppLocale.apply(app, region)
-            (context as? Activity)?.recreate()
+            // API 31/32 has no LocaleManager to recreate automatically, so the
+            // visible Activity is recreated by hand — resolved *at call time*
+            // (see the factory note above): the VM survives config changes, so
+            // a captured Activity would be the destroyed pre-rotation instance,
+            // whose recreate() is a no-op and the new locale wouldn't show.
+            app.currentResumedActivity()?.recreate()
         },
         refreshLocationCache = {
-            FetchAndNotifyWorker.enqueueLocationCacheRefresh(context)
+            FetchAndNotifyWorker.enqueueLocationCacheRefresh(app)
         },
         refreshOutfitWidget = {
             // No cache work needed — the cache holds the raw ForecastSnapshot,
@@ -410,7 +414,7 @@ private fun settingsViewModelFactory(app: ClothesCastApplication, context: Conte
             // don't subscribe to the prefs flow themselves, so a settings write
             // that changes what they render (outfit icon, or the chart's
             // temperature unit) needs an explicit nudge to repaint the launcher.
-            updateAllClothesCastWidgets(context.applicationContext)
+            updateAllClothesCastWidgets(app)
         },
         workManager = WorkManager.getInstance(app),
         insightCache = app.insightCache,
@@ -421,7 +425,7 @@ private fun settingsViewModelFactory(app: ClothesCastApplication, context: Conte
                 ?: return@Factory app.mqttPublisher.publishTest()
             val insight = app.deriveInsight(snapshot, prefs).insight
             val formatter = InsightFormatter.forRegion(
-                context,
+                app,
                 prefs.region,
                 prefs.temperatureUnit,
                 prefs.rangeFormat,
@@ -434,13 +438,13 @@ private fun settingsViewModelFactory(app: ClothesCastApplication, context: Conte
             val png: ByteArray? = insight.outfit?.let { outfit ->
                 runCatching {
                     val info = outfitCardInfoLines(
-                        context = context,
+                        context = app,
                         formatter = formatter,
                         hourly = insight.hourly,
                         temperatureUnit = prefs.temperatureUnit,
                         windSpeedUnit = prefs.distanceUnit.windSpeedUnit(),
                     )
-                    val header = context.getString(
+                    val header = app.getString(
                         if (insight.period == ForecastPeriod.TODAY) R.string.outfit_card_header_today
                         else R.string.outfit_card_header_tonight
                     )
@@ -457,7 +461,7 @@ private fun settingsViewModelFactory(app: ClothesCastApplication, context: Conte
                     val bottomStrokes: Map<OutfitSuggestion.Bottom, Long> =
                         theme?.bottomStrokeOverrides ?: emptyMap()
                     renderOutfitCard(
-                        context = context,
+                        context = app,
                         outfit = outfit,
                         header = header,
                         prose = prose,
@@ -482,7 +486,7 @@ private fun settingsViewModelFactory(app: ClothesCastApplication, context: Conte
         castNowAction = app.castInsightController?.let { controller ->
             {
                 castCurrentInsight(
-                    context = context,
+                    context = app,
                     settingsRepository = app.settingsRepository,
                     insightCache = app.insightCache,
                     deriveInsight = app.deriveInsight,

--- a/app/src/main/kotlin/app/clothescast/ui/today/ForecastChart.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/ForecastChart.kt
@@ -22,7 +22,6 @@ import app.clothescast.core.domain.model.TemperatureUnit
 import app.clothescast.core.domain.model.toUnit
 import app.clothescast.ui.theme.AppTheme
 import java.time.LocalDate
-import java.time.LocalDateTime
 import com.patrykandpatrick.vico.compose.cartesian.CartesianChartHost
 import com.patrykandpatrick.vico.compose.cartesian.axis.rememberAxisLabelComponent
 import com.patrykandpatrick.vico.compose.cartesian.layer.rememberLineCartesianLayer
@@ -147,6 +146,12 @@ fun ForecastChart(
 ) {
     if (hourly.isEmpty()) return
 
+    // Timestamp → list-position map for the chart's hourly window, shared by
+    // the per-model overlays and the range band so every per-model value plots
+    // at the x position the main line plots that wall-clock hour at — robust
+    // to a model dropping an hour and to DST weeks where position ≠ naive
+    // hour offset. See [hourlyTimestampIndices].
+    val indexByTime = remember(hourly, startDate) { hourlyTimestampIndices(hourly, startDate) }
     val overlays = perModelHourly?.byModel.orEmpty()
     val visibleModels = if (showModelSpread) {
         MODEL_DRAW_ORDER.filter { it in overlays }
@@ -166,7 +171,7 @@ fun ForecastChart(
     // the same model IDs still re-emits the series. [showModelSpread] is
     // included separately so flipping the toggle on/off re-fires the effect
     // even when [overlays] hasn't changed.
-    LaunchedEffect(hourly, temperatureUnit, showFeelsLike, overlays, showModelSpread) {
+    LaunchedEffect(hourly, temperatureUnit, showFeelsLike, overlays, showModelSpread, indexByTime) {
         producer.runTransaction {
             lineSeries {
                 // Main blended line first so it occupies series index 0 in
@@ -179,7 +184,25 @@ fun ForecastChart(
                 series(hourly.map { pickHourly(it).toUnit(temperatureUnit) })
                 visibleModels.forEach { modelId ->
                     overlays.getValue(modelId).let { entries ->
-                        series(entries.map { pickModel(it).toUnit(temperatureUnit) })
+                        // Plot each per-model point at the window position of
+                        // its timestamp (explicit x) rather than letting Vico
+                        // assign x by list position — a model that dropped an
+                        // hour would otherwise draw its tail an hour early,
+                        // disagreeing with the (timestamp-keyed) range band
+                        // and the bottom axis. Entries whose timestamps fall
+                        // outside the window are skipped; in the common case
+                        // every entry maps to its old position, so the
+                        // rendered line is unchanged.
+                        val points = entries.mapNotNull { e ->
+                            indexByTime[e.time]?.let { it to pickModel(e).toUnit(temperatureUnit) }
+                        }
+                        // Vico rejects an empty series; a model entirely
+                        // outside the window (shouldn't happen — per-model
+                        // data rides the same fetch as [hourly]) is skipped
+                        // rather than crashing the chart.
+                        if (points.isNotEmpty()) {
+                            series(x = points.map { it.first }, y = points.map { it.second })
+                        }
                     }
                 }
             }
@@ -255,12 +278,11 @@ fun ForecastChart(
     // Shaded min–max range band on the default view (hidden once the per-model
     // overlay is on — the individual lines convey the spread then). Built from
     // the same picker + unit as the main line so it lands on the same scale.
-    val (bandMin, bandMax) = remember(overlays, showFeelsLike, temperatureUnit, hourly, startDate) {
-        val windowStart = hourly.firstOrNull()?.let { LocalDateTime.of(startDate, it.time) }
-        if (perModelHourly == null || windowStart == null) {
+    val (bandMin, bandMax) = remember(overlays, showFeelsLike, temperatureUnit, indexByTime) {
+        if (perModelHourly == null) {
             emptyList<Pair<Int, Double>>() to emptyList()
         } else {
-            perModelEnvelope(perModelHourly, windowStart, hourly.size) {
+            perModelEnvelope(perModelHourly, indexByTime) {
                 pickModel(it).toUnit(temperatureUnit)
             }
         }

--- a/app/src/main/kotlin/app/clothescast/ui/today/PerModelDiagnosticCard.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/PerModelDiagnosticCard.kt
@@ -54,11 +54,13 @@ import kotlin.math.roundToInt
  *
  * Sparse handling: when only some of a model's hours carry the metric (the
  * upstream API can return nulls for individual hours of a model whose run
- * is still warming up), we plot the non-null hours at their original
- * indices and let Vico bridge the gap. The main consensus line is computed
- * per-index from whichever models reported at that hour, so a single
- * missing sample doesn't punch a hole in the main line either. The card
- * auto-hides when *every* consulted model is missing the metric outright.
+ * is still warming up), we plot the non-null hours at their wall-clock
+ * window positions (timestamp lookup via [hourlyTimestampIndices], robust
+ * to dropped per-model hours) and let Vico bridge the gap. The main
+ * consensus line is computed per-index from whichever models reported at
+ * that hour, so a single missing sample doesn't punch a hole in the main
+ * line either. The card auto-hides when *every* consulted model is missing
+ * the metric outright.
  *
  * Used by the [WindCard], [HumidityCard], [CloudCard], [SolarRadiationCard],
  * [UvIndexCard] and [SunshineCard] wrappers in [TodayScreen].
@@ -96,13 +98,23 @@ internal fun PerModelDiagnosticCard(
     showOverlay: Boolean = false,
 ) {
     val times = remember(hourly) { hourly.map { it.time } }
-    // Build (originalIndex, value) pairs per model so a sparse series plots at
-    // its real positions on the x-axis instead of getting compacted left and
-    // misaligned with the rest of the screen's hourly axes.
-    val seriesByModel = remember(perModelHourly, pickerKey) {
+    // Timestamp → list-position map for the card's hourly window — see
+    // [hourlyTimestampIndices]. Resolving each per-model entry by its
+    // timestamp (rather than its list position) keeps a model that dropped
+    // an hour from shifting its tail an hour early, and keeps positions
+    // honest on DST weeks where position ≠ naive hour offset.
+    val indexByTime = remember(hourly, startDate) { hourlyTimestampIndices(hourly, startDate) }
+    // Build (windowIndex, value) pairs per model so a sparse series plots at
+    // its real wall-clock positions on the x-axis instead of getting compacted
+    // left and misaligned with the rest of the screen's hourly axes. Entries
+    // whose timestamps fall outside the window are skipped.
+    val seriesByModel = remember(perModelHourly, pickerKey, indexByTime) {
         perModelHourly.byModel
             .mapValues { (_, entries) ->
-                entries.mapIndexedNotNull { i, e -> picker(e)?.let { i to it } }
+                entries.mapNotNull { e ->
+                    val idx = indexByTime[e.time] ?: return@mapNotNull null
+                    picker(e)?.let { idx to it }
+                }
             }
             .filterValues { it.isNotEmpty() }
     }
@@ -110,9 +122,10 @@ internal fun PerModelDiagnosticCard(
     if (availableModels.isEmpty() || times.isEmpty()) return
 
     // Per-hour mean of [picker] across whichever models reported at that
-    // hour. Plotted at the model's original index so the main line stays
-    // aligned with the per-model overlay underneath it (when shown) and
-    // with the rest of the screen's 0..23 axes.
+    // hour. Grouped by window index — which, thanks to the timestamp keying
+    // above, means "same wall-clock hour" — so the main line stays aligned
+    // with the per-model overlay underneath it (when shown) and with the
+    // rest of the screen's 0..23 axes.
     val mainLine = remember(seriesByModel) {
         val byIndex = mutableMapOf<Int, MutableList<Double>>()
         seriesByModel.values.forEach { entries ->

--- a/app/src/main/kotlin/app/clothescast/ui/today/PrecipitationAmountChart.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/PrecipitationAmountChart.kt
@@ -55,6 +55,11 @@ fun PrecipitationAmountChart(
 ) {
     if (hourly.isEmpty()) return
 
+    // Timestamp → list-position map for the chart's hourly window, shared by
+    // the per-model overlays, the consensus main line, and the range band —
+    // see [ForecastChart] / [hourlyTimestampIndices] for the rationale
+    // (dropped per-model hours, DST weeks where position ≠ naive hour offset).
+    val indexByTime = remember(hourly, startDate) { hourlyTimestampIndices(hourly, startDate) }
     val overlays = perModelHourly?.byModel.orEmpty()
     val visibleModels = if (showModelSpread) {
         MODEL_DRAW_ORDER.filter { modelId ->
@@ -65,19 +70,31 @@ fun PrecipitationAmountChart(
     }
     val mainLineColor = AppTheme.mainLineColor
 
-    val mainLine = remember(hourly, overlays) { consensusRainfallMainLine(hourly, perModelHourly) }
+    val mainLine = remember(hourly, overlays, indexByTime) {
+        consensusRainfallMainLine(hourly, perModelHourly, indexByTime)
+    }
 
     val producer = remember { CartesianChartModelProducer() }
-    LaunchedEffect(hourly, overlays, showModelSpread) {
+    LaunchedEffect(hourly, overlays, showModelSpread, indexByTime) {
         producer.runTransaction {
             lineSeries {
                 series(mainLine)
                 visibleModels.forEach { modelId ->
                     overlays.getValue(modelId).let { entries ->
-                        val points = entries.mapIndexedNotNull { i, e ->
-                            e.precipitationMm?.let { i to it }
+                        // Window position by timestamp lookup, not list
+                        // position — see [PrecipitationChart] for the
+                        // sparse-series x-keying rationale.
+                        val points = entries.mapNotNull { e ->
+                            val idx = indexByTime[e.time] ?: return@mapNotNull null
+                            e.precipitationMm?.let { idx to it }
                         }
-                        series(x = points.map { it.first }, y = points.map { it.second })
+                        // Vico rejects an empty series; a model entirely
+                        // outside the window (shouldn't happen — per-model
+                        // data rides the same fetch as [hourly]) is skipped
+                        // rather than crashing the chart.
+                        if (points.isNotEmpty()) {
+                            series(x = points.map { it.first }, y = points.map { it.second })
+                        }
                     }
                 }
             }
@@ -131,12 +148,11 @@ fun PrecipitationAmountChart(
     val scrubIndicator = rememberChartScrubIndicator(scrubController, scrubBounds, hourly, startDate)
     // Shaded min–max band on the default view, hidden once the per-model overlay
     // is on. Same rainfall-mm picker as the lines; shares the 0..yMax range.
-    val (bandMin, bandMax) = remember(overlays, hourly, startDate) {
-        val windowStart = hourly.firstOrNull()?.let { LocalDateTime.of(startDate, it.time) }
-        if (perModelHourly == null || windowStart == null) {
+    val (bandMin, bandMax) = remember(overlays, indexByTime) {
+        if (perModelHourly == null) {
             emptyList<Pair<Int, Double>>() to emptyList()
         } else {
-            perModelEnvelope(perModelHourly, windowStart, hourly.size) { it.precipitationMm }
+            perModelEnvelope(perModelHourly, indexByTime) { it.precipitationMm }
         }
     }
     val rangeBand = rememberRangeBandDecoration(
@@ -208,23 +224,30 @@ internal const val PRECIPITATION_AMOUNT_MIN_SPAN_MM: Double = 5.0
  * "Combined" chart line and the "X mm of rain today" figure above it
  * are always consistent — they come from the same data.
  *
- * Output length matches `hourly.size`; per-model entries are assumed to
- * align by list position (same date-sliced fetch), the convention used by
- * the existing [PerModelDiagnosticCard].
+ * Output length matches `hourly.size`; per-model entries are resolved to
+ * window positions by timestamp lookup against [indexByTime] (the map
+ * [hourlyTimestampIndices] builds from the same window), so a model that
+ * dropped an hour contributes its values to the right wall-clock hours
+ * instead of skewing every later mean — the same keying the chart's
+ * per-model lines and range band use.
  */
 internal fun consensusRainfallMainLine(
     hourly: List<HourlyForecast>,
     perModelHourly: PerModelHourly?,
+    indexByTime: Map<LocalDateTime, Int>,
 ): List<Double> {
     val overlays = perModelHourly?.byModel.orEmpty()
     val anyPerModel = overlays.values.any { entries -> entries.any { it.precipitationMm != null } }
     if (!anyPerModel) return hourly.map { it.precipitationMm }
-    return hourly.indices.map { idx ->
-        val perModelValues = overlays.values.mapNotNull { entries ->
-            entries.getOrNull(idx)?.precipitationMm
+    val byIndex = mutableMapOf<Int, MutableList<Double>>()
+    overlays.values.forEach { entries ->
+        entries.forEach { e ->
+            val idx = indexByTime[e.time] ?: return@forEach
+            e.precipitationMm?.let { byIndex.getOrPut(idx) { mutableListOf() } += it }
         }
-        if (perModelValues.isEmpty()) hourly[idx].precipitationMm
-        else perModelValues.average()
+    }
+    return hourly.indices.map { idx ->
+        byIndex[idx]?.average() ?: hourly[idx].precipitationMm
     }
 }
 

--- a/app/src/main/kotlin/app/clothescast/ui/today/PrecipitationChart.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/PrecipitationChart.kt
@@ -13,7 +13,6 @@ import app.clothescast.core.domain.model.HourlyForecast
 import app.clothescast.core.domain.model.PerModelHourly
 import app.clothescast.ui.theme.AppTheme
 import java.time.LocalDate
-import java.time.LocalDateTime
 import com.patrykandpatrick.vico.compose.cartesian.CartesianChartHost
 import com.patrykandpatrick.vico.compose.cartesian.layer.rememberLineCartesianLayer
 import com.patrykandpatrick.vico.compose.cartesian.rememberCartesianChart
@@ -56,6 +55,11 @@ fun PrecipitationChart(
 ) {
     if (hourly.isEmpty()) return
 
+    // Timestamp → list-position map for the chart's hourly window, shared by
+    // the per-model overlays and the range band — see [ForecastChart] /
+    // [hourlyTimestampIndices] for the rationale (dropped per-model hours,
+    // DST weeks where position ≠ naive hour offset).
+    val indexByTime = remember(hourly, startDate) { hourlyTimestampIndices(hourly, startDate) }
     val overlays = perModelHourly?.byModel.orEmpty()
     // A model whose precip series is all-null (Open-Meteo doesn't expose
     // `precipitation_probability_<model>` for it) has nothing to plot on
@@ -77,7 +81,7 @@ fun PrecipitationChart(
     // the same model IDs still re-emits the series. [showModelSpread] is
     // included separately so flipping the toggle on/off re-fires the effect
     // even when [overlays] hasn't changed.
-    LaunchedEffect(hourly, overlays, showModelSpread) {
+    LaunchedEffect(hourly, overlays, showModelSpread, indexByTime) {
         producer.runTransaction {
             lineSeries {
                 // Main blended line first so it stays at series index 0 in
@@ -94,19 +98,26 @@ fun PrecipitationChart(
                         // [PerModelDiagnosticCard]. A bare `series(y)` would
                         // compact surviving y values to indices 0..n which
                         // misaligns the line under the bottom axis when a
-                        // model omits its leading or trailing hours. The
-                        // x index is the entry's position in the parser's
-                        // hourly list — entries.size == hours-in-window
-                        // because the parser only drops hours when
-                        // temperature_2m itself is null, so iteration index
-                        // equals hour-since-window-start. Nulls inside the
-                        // precip series are skipped via mapIndexedNotNull;
-                        // Vico bridges the gap visually between surviving
-                        // points without drawing a fake-0 baseline.
-                        val points = entries.mapIndexedNotNull { i, e ->
-                            e.precipitationProbabilityPct?.let { i to it }
+                        // model omits its leading or trailing hours. The x
+                        // index is the window position of the entry's
+                        // timestamp ([hourlyTimestampIndices]) — not its
+                        // list position, which drifts when the parser drops
+                        // an hour whose temperature_2m is null. Entries
+                        // outside the window and nulls inside the precip
+                        // series are skipped; Vico bridges the gap visually
+                        // between surviving points without drawing a fake-0
+                        // baseline.
+                        val points = entries.mapNotNull { e ->
+                            val idx = indexByTime[e.time] ?: return@mapNotNull null
+                            e.precipitationProbabilityPct?.let { idx to it }
                         }
-                        series(x = points.map { it.first }, y = points.map { it.second })
+                        // Vico rejects an empty series; a model entirely
+                        // outside the window (shouldn't happen — per-model
+                        // data rides the same fetch as [hourly]) is skipped
+                        // rather than crashing the chart.
+                        if (points.isNotEmpty()) {
+                            series(x = points.map { it.first }, y = points.map { it.second })
+                        }
                     }
                 }
             }
@@ -156,12 +167,11 @@ fun PrecipitationChart(
     // Shaded min–max band on the default view, hidden once the per-model overlay
     // is on. Uses the same precip-probability picker as the lines; y-range is the
     // pinned 0..100.
-    val (bandMin, bandMax) = remember(overlays, hourly, startDate) {
-        val windowStart = hourly.firstOrNull()?.let { LocalDateTime.of(startDate, it.time) }
-        if (perModelHourly == null || windowStart == null) {
+    val (bandMin, bandMax) = remember(overlays, indexByTime) {
+        if (perModelHourly == null) {
             emptyList<Pair<Int, Double>>() to emptyList()
         } else {
-            perModelEnvelope(perModelHourly, windowStart, hourly.size) { it.precipitationProbabilityPct }
+            perModelEnvelope(perModelHourly, indexByTime) { it.precipitationProbabilityPct }
         }
     }
     val rangeBand = rememberRangeBandDecoration(

--- a/app/src/main/kotlin/app/clothescast/ui/today/RangeBand.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/RangeBand.kt
@@ -5,19 +5,57 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Paint
 import androidx.compose.ui.graphics.Path
+import app.clothescast.core.domain.model.HourlyForecast
 import app.clothescast.core.domain.model.PerModelHour
 import app.clothescast.core.domain.model.PerModelHourly
 import app.clothescast.core.domain.model.PerModelHourly.Companion.BEST_MATCH_MODEL_ID
 import com.patrykandpatrick.vico.compose.cartesian.CartesianDrawingContext
 import com.patrykandpatrick.vico.compose.cartesian.axis.Axis
 import com.patrykandpatrick.vico.compose.cartesian.decoration.Decoration
+import java.time.LocalDate
 import java.time.LocalDateTime
-import java.time.temporal.ChronoUnit
 
 // Opacity of the shaded min–max range band drawn beneath the consensus line on
 // the default chart view. Low enough to read as a soft "spread" shading without
 // muddying the line or the gridlines; first-pass value to eyeball on-device.
 internal const val RANGE_BAND_ALPHA = 0.12f
+
+/**
+ * Maps each entry of a chart's hourly window to its list position, keyed by
+ * the entry's full wall-clock timestamp. [HourlyForecast] carries only a
+ * `LocalTime`, so the date is reconstructed by starting at [startDate] (the
+ * date of `hourly[0]`) and advancing it whenever the hour-of-day steps
+ * backwards relative to the previous entry — the same midnight-wrap walk
+ * `chartXToTime` uses, so the tonight window's post-midnight hours land on
+ * the next date. Walking the window's actual entries (rather than adding
+ * `i` hours to the window start) keeps positions correct on DST-transition
+ * weeks, where a 23- or 25-hour day makes "hours since window start"
+ * diverge from list position. On a fall-back day whose duplicated
+ * wall-clock hour appears twice, the first occurrence wins — the same
+ * ambiguity the per-model timestamps carry, so lookups stay consistent.
+ *
+ * Per-model series ([PerModelHour.time]) are positioned on the charts by
+ * looking their timestamps up here, so every per-model value lands on the
+ * x position the consensus main line plots that wall-clock hour at. In the
+ * common case (no dropped hours, no DST) every per-model entry resolves to
+ * exactly its list position, so the rendered output is unchanged.
+ */
+internal fun hourlyTimestampIndices(
+    hourly: List<HourlyForecast>,
+    startDate: LocalDate,
+): Map<LocalDateTime, Int> {
+    val indices = LinkedHashMap<LocalDateTime, Int>(hourly.size)
+    var date = startDate
+    var prevHour: Int? = null
+    for (i in hourly.indices) {
+        val hour = hourly[i].time.hour
+        if (prevHour != null && hour < prevHour) date = date.plusDays(1)
+        prevHour = hour
+        val timestamp = LocalDateTime.of(date, hourly[i].time)
+        if (timestamp !in indices) indices[timestamp] = i
+    }
+    return indices
+}
 
 /**
  * Per-hour min and max of [picker] across the consulted models — the envelope
@@ -35,30 +73,33 @@ internal const val RANGE_BAND_ALPHA = 0.12f
  * Values are raw: the caller passes a [picker] that already applies the same unit
  * conversion it uses for the chart's series, so the band lands on the same scale.
  *
- * Indexed against the chart's own hourly window — [windowStart] is the
- * `LocalDateTime` of `hourly[0]` and [windowSize] is `hourly.size` — by each
- * entry's whole-hour offset from the window start, not its list position. A model
- * can drop an hour (the parser omits an entry when its `temperature_2m` is null),
- * which would shift its tail and make a position-keyed band merge mismatched hours
- * across models. Offsetting from the window keeps every value under the hour the
- * consensus main line plots it at, and a leading hour that *every* consulted model
- * dropped stays an empty gap rather than sliding the band left. The full
- * `LocalDateTime` (not time-of-day) is essential for the 168 h `SevenDayPage`
- * window, where a `LocalTime` would alias every day's 09:00 onto one index. An
- * entry outside `[0, windowSize)` is skipped.
+ * Indexed against the chart's own hourly window via [indexByTime] — the
+ * timestamp → list-position map [hourlyTimestampIndices] builds from the
+ * window's entries — by looking up each entry's full [PerModelHour.time], not
+ * its list position. A model can drop an hour (the parser omits an entry when
+ * its `temperature_2m` is null), which would shift its tail and make a
+ * position-keyed band merge mismatched hours across models. The timestamp
+ * lookup keeps every value under the hour the consensus main line plots it at,
+ * and a leading hour that *every* consulted model dropped stays an empty gap
+ * rather than sliding the band left. Resolving against the window's actual
+ * entries (not naive hour arithmetic from the window start) also keeps the
+ * band aligned with the position-plotted main line on DST-transition weeks,
+ * where a 23- or 25-hour day makes position ≠ hours-since-window-start. The
+ * full `LocalDateTime` (not time-of-day) is essential for the 168 h
+ * `SevenDayPage` window, where a `LocalTime` would alias every day's 09:00
+ * onto one index. An entry whose timestamp isn't in the map (outside the
+ * window) is skipped.
  */
 internal fun perModelEnvelope(
     perModelHourly: PerModelHourly,
-    windowStart: LocalDateTime,
-    windowSize: Int,
+    indexByTime: Map<LocalDateTime, Int>,
     picker: (PerModelHour) -> Double?,
 ): Pair<List<Pair<Int, Double>>, List<Pair<Int, Double>>> {
     val byIndex = mutableMapOf<Int, MutableList<Double>>()
     perModelHourly.byModel.forEach { (model, entries) ->
         if (model == BEST_MATCH_MODEL_ID) return@forEach
         entries.forEach { entry ->
-            val idx = ChronoUnit.HOURS.between(windowStart, entry.time).toInt()
-            if (idx !in 0 until windowSize) return@forEach
+            val idx = indexByTime[entry.time] ?: return@forEach
             picker(entry)?.let { byIndex.getOrPut(idx) { mutableListOf() } += it }
         }
     }

--- a/app/src/main/kotlin/app/clothescast/ui/today/SevenDayPage.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/SevenDayPage.kt
@@ -214,17 +214,15 @@ internal fun SevenDayPage(
         if (days.size < 2) null else HorizontalAxis.ItemPlacer.aligned(spacing = { 24 }, offset = { 12 })
     }
     // Restrict the per-model series to the dates this page plots before any
-    // chart sees it. The chart cards position each per-model point by its
-    // *index* in the series against the page-local [flatHourly] window (see
-    // [PerModelDiagnosticCard] / [ForecastChart]), so the series must start on
-    // the same day as [flatHourly]. The fetched series always starts at today;
-    // on the "Following 7 days" page [flatHourly] starts at day 8, so passing
-    // the unsliced series would plot days 1-7 under the day-8 axis and push the
-    // day 8-14 points off the right edge. Slicing to the window dates realigns
-    // index 0 with the first plotted hour — and on the "Next 7 days" page it
-    // also keeps the now-14-day fetch from stretching the chart's y-bounds with
-    // values the page doesn't show. Models that don't reach the window at all
-    // (ICON past day 7) drop out here.
+    // chart sees it. The chart cards position each per-model point by looking
+    // its timestamp up against the page-local [flatHourly] window (see
+    // [hourlyTimestampIndices] / [PerModelDiagnosticCard] / [ForecastChart]),
+    // so out-of-window entries would be dropped at the chart layer anyway —
+    // but slicing here still matters: it keeps the now-14-day fetch from
+    // stretching the charts' y-bounds with values the page doesn't show
+    // (y-axis sizing reads the raw per-model values, not the positioned
+    // points), and models that don't reach the window at all (ICON past
+    // day 7) drop out of the legends and coverage gate here.
     val weekPerModelInWindow: PerModelHourly? = remember(weekPerModelHourly, days) {
         val windowDates = days.map { it.date }.toSet()
         weekPerModelHourly?.let { perModel ->

--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayPreviews.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayPreviews.kt
@@ -1578,16 +1578,20 @@ internal fun PrecipitationAmountCardWithModelSpreadPreview() {
     Frame {
         PrecipitationAmountCard(
             hourly = SAMPLE_HOURLY_RAINY,
+            forDate = SAMPLE_PER_MODEL_DATE,
             perModelHourly = SAMPLE_PER_MODEL_HOURLY,
             showModelSpread = true,
         )
     }
 }
 
-// Sample anchor for per-model entries. Charts read `time.toLocalTime()` for
-// labels, so any LocalDate works — pinning today keeps preview output
-// deterministic-ish across runs (and matches SAMPLE_INSIGHT.forDate's
-// vintage).
+// Sample anchor for per-model entries. The charts resolve per-model points
+// to x positions by timestamp lookup against their hourly window (see
+// [hourlyTimestampIndices]), so every preview that pairs this fixture with a
+// chart must pass `startDate`/`forDate` = this date — a mismatched window
+// date drops the per-model series entirely. Pinned (and matching
+// SAMPLE_INSIGHT.forDate's vintage) so preview output stays deterministic
+// across runs.
 private val SAMPLE_PER_MODEL_DATE: LocalDate = LocalDate.of(2026, 4, 26)
 
 // Three model curves spread around the blended sample. Offsets are deliberate
@@ -1699,6 +1703,7 @@ internal fun WindCardConsensusPreview() {
         WindCard(
             hourly = SAMPLE_HOURLY_RAINY,
             perModelHourly = SAMPLE_PER_MODEL_HOURLY,
+            startDate = SAMPLE_PER_MODEL_DATE,
         )
     }
 }
@@ -1710,6 +1715,7 @@ internal fun WindCardWithModelSpreadPreview() {
         WindCard(
             hourly = SAMPLE_HOURLY_RAINY,
             perModelHourly = SAMPLE_PER_MODEL_HOURLY,
+            startDate = SAMPLE_PER_MODEL_DATE,
             showModelSpread = true,
         )
     }
@@ -1726,11 +1732,12 @@ internal fun WindCardWithModelSpreadPreview() {
 @Composable
 internal fun WindCardScrubbedPreview() {
     Frame {
-        // Fixed date (a Monday) so the scrub fixture is deterministic across
-        // runs — see issue #920. The hourly chart only labels times, so the
-        // date never reaches the snapshot, but pinning it keeps the fixture
-        // free of any wall-clock dependency.
-        val today = java.time.LocalDate.of(2024, 1, 1)
+        // Fixed date so the scrub fixture is deterministic across runs — see
+        // issue #920. Must match the per-model fixture's anchor date: the
+        // chart resolves per-model points by timestamp against the window
+        // keyed off [startDate], and the readout only renders hour-of-day,
+        // so the date itself never reaches the snapshot.
+        val today = SAMPLE_PER_MODEL_DATE
         val controller = androidx.compose.runtime.remember {
             ChartScrubController().apply {
                 scrubTo(java.time.LocalDateTime.of(today, java.time.LocalTime.of(14, 30)))
@@ -1759,6 +1766,7 @@ internal fun WindCardWithModelSpreadMphPreview() {
             hourly = SAMPLE_HOURLY_RAINY,
             perModelHourly = SAMPLE_PER_MODEL_HOURLY,
             windSpeedUnit = WindSpeedUnit.MPH,
+            startDate = SAMPLE_PER_MODEL_DATE,
             showModelSpread = true,
         )
     }
@@ -1771,6 +1779,7 @@ internal fun CloudCardConsensusPreview() {
         CloudCard(
             hourly = SAMPLE_HOURLY_RAINY,
             perModelHourly = SAMPLE_PER_MODEL_HOURLY,
+            startDate = SAMPLE_PER_MODEL_DATE,
         )
     }
 }
@@ -1782,6 +1791,7 @@ internal fun CloudCardWithModelSpreadPreview() {
         CloudCard(
             hourly = SAMPLE_HOURLY_RAINY,
             perModelHourly = SAMPLE_PER_MODEL_HOURLY,
+            startDate = SAMPLE_PER_MODEL_DATE,
             showModelSpread = true,
         )
     }
@@ -1794,6 +1804,7 @@ internal fun HumidityCardConsensusPreview() {
         HumidityCard(
             hourly = SAMPLE_HOURLY_RAINY,
             perModelHourly = SAMPLE_PER_MODEL_HOURLY,
+            startDate = SAMPLE_PER_MODEL_DATE,
         )
     }
 }
@@ -1805,6 +1816,7 @@ internal fun HumidityCardWithModelSpreadPreview() {
         HumidityCard(
             hourly = SAMPLE_HOURLY_RAINY,
             perModelHourly = SAMPLE_PER_MODEL_HOURLY,
+            startDate = SAMPLE_PER_MODEL_DATE,
             showModelSpread = true,
         )
     }
@@ -1817,6 +1829,7 @@ internal fun SolarRadiationCardConsensusPreview() {
         SolarRadiationCard(
             hourly = SAMPLE_HOURLY_RAINY,
             perModelHourly = SAMPLE_PER_MODEL_HOURLY,
+            startDate = SAMPLE_PER_MODEL_DATE,
         )
     }
 }
@@ -1828,6 +1841,7 @@ internal fun SolarRadiationCardWithModelSpreadPreview() {
         SolarRadiationCard(
             hourly = SAMPLE_HOURLY_RAINY,
             perModelHourly = SAMPLE_PER_MODEL_HOURLY,
+            startDate = SAMPLE_PER_MODEL_DATE,
             showModelSpread = true,
         )
     }
@@ -1878,6 +1892,7 @@ internal fun UvIndexCardConsensusPreview() {
         UvIndexCard(
             hourly = SAMPLE_HOURLY_RAINY,
             perModelHourly = SAMPLE_PER_MODEL_HOURLY,
+            startDate = SAMPLE_PER_MODEL_DATE,
         )
     }
 }
@@ -1889,6 +1904,7 @@ internal fun UvIndexCardWithModelSpreadPreview() {
         UvIndexCard(
             hourly = SAMPLE_HOURLY_RAINY,
             perModelHourly = SAMPLE_PER_MODEL_HOURLY,
+            startDate = SAMPLE_PER_MODEL_DATE,
             showModelSpread = true,
         )
     }
@@ -1915,6 +1931,7 @@ internal fun WindCardSparseTrailingPreview() {
         WindCard(
             hourly = SAMPLE_HOURLY_RAINY,
             perModelHourly = SAMPLE_PER_MODEL_HOURLY_SPARSE_WIND_TRAILING,
+            startDate = SAMPLE_PER_MODEL_DATE,
             showModelSpread = true,
         )
     }
@@ -1928,6 +1945,7 @@ internal fun ForecastChartWithModelSpreadPreview() {
             hourly = SAMPLE_HOURLY,
             temperatureUnit = TemperatureUnit.CELSIUS,
             showFeelsLike = true,
+            startDate = SAMPLE_PER_MODEL_DATE,
             perModelHourly = SAMPLE_PER_MODEL_HOURLY,
             showModelSpread = true,
         )
@@ -1945,6 +1963,7 @@ internal fun ForecastCardWithModelSpreadPreview() {
         ForecastCard(
             hourly = SAMPLE_HOURLY,
             temperatureUnit = TemperatureUnit.CELSIUS,
+            startDate = SAMPLE_PER_MODEL_DATE,
             perModelHourly = SAMPLE_PER_MODEL_HOURLY,
             showModelSpread = true,
         )
@@ -1959,11 +1978,11 @@ internal fun ForecastCardWithModelSpreadPreview() {
 @Composable
 internal fun ForecastCardScrubbedPreview() {
     Frame {
-        // Fixed date (a Monday) so the scrub fixture is deterministic across
-        // runs — see issue #920. The hourly chart only labels times, so the
-        // date never reaches the snapshot, but pinning it keeps the fixture
-        // free of any wall-clock dependency.
-        val today = java.time.LocalDate.of(2024, 1, 1)
+        // Fixed date so the scrub fixture is deterministic across runs — see
+        // issue #920. Must match the per-model fixture's anchor date (see
+        // [WindCardScrubbedPreview]); the readout only renders hour-of-day,
+        // so the date itself never reaches the snapshot.
+        val today = SAMPLE_PER_MODEL_DATE
         val controller = androidx.compose.runtime.remember {
             ChartScrubController().apply {
                 scrubTo(java.time.LocalDateTime.of(today, java.time.LocalTime.of(14, 30)))
@@ -1988,6 +2007,7 @@ internal fun AirTemperatureCardWithModelSpreadPreview() {
         AirTemperatureCard(
             hourly = SAMPLE_HOURLY,
             temperatureUnit = TemperatureUnit.CELSIUS,
+            startDate = SAMPLE_PER_MODEL_DATE,
             perModelHourly = SAMPLE_PER_MODEL_HOURLY,
             showModelSpread = true,
         )
@@ -2000,6 +2020,7 @@ internal fun PrecipitationCardWithModelSpreadPreview() {
     Frame {
         PrecipitationCard(
             hourly = SAMPLE_HOURLY_RAINY,
+            startDate = SAMPLE_PER_MODEL_DATE,
             perModelHourly = SAMPLE_PER_MODEL_HOURLY,
             showModelSpread = true,
         )
@@ -2080,6 +2101,7 @@ internal fun ForecastCardWithModelSpreadAccessiblePreview() {
         ForecastCard(
             hourly = SAMPLE_HOURLY,
             temperatureUnit = TemperatureUnit.CELSIUS,
+            startDate = SAMPLE_PER_MODEL_DATE,
             perModelHourly = SAMPLE_PER_MODEL_HOURLY,
             showModelSpread = true,
         )
@@ -2092,6 +2114,7 @@ internal fun PrecipitationCardWithModelSpreadAccessiblePreview() {
     Frame(colorPalette = ColorPalette.ACCESSIBLE) {
         PrecipitationCard(
             hourly = SAMPLE_HOURLY_RAINY,
+            startDate = SAMPLE_PER_MODEL_DATE,
             perModelHourly = SAMPLE_PER_MODEL_HOURLY,
             showModelSpread = true,
         )
@@ -2109,6 +2132,7 @@ internal fun ForecastCardWithModelSpreadHighlighterPreview() {
         ForecastCard(
             hourly = SAMPLE_HOURLY,
             temperatureUnit = TemperatureUnit.CELSIUS,
+            startDate = SAMPLE_PER_MODEL_DATE,
             perModelHourly = SAMPLE_PER_MODEL_HOURLY,
             showModelSpread = true,
         )
@@ -2121,6 +2145,7 @@ internal fun PrecipitationCardWithModelSpreadHighlighterPreview() {
     Frame(colorPalette = ColorPalette.HIGHLIGHTER) {
         PrecipitationCard(
             hourly = SAMPLE_HOURLY_RAINY,
+            startDate = SAMPLE_PER_MODEL_DATE,
             perModelHourly = SAMPLE_PER_MODEL_HOURLY,
             showModelSpread = true,
         )
@@ -2426,10 +2451,10 @@ private val SAMPLE_FOLLOWING_WEEK_PER_MODEL_HOURLY: PerModelHourly = run {
 // A full two-week per-model series (days 1-14), built by concatenating the
 // first- and second-week samples per model. Mirrors what production hands the
 // "Following 7 days" page: a series that *starts at today*, not at day 8. The
-// page must slice it to its own window before plotting (the chart positions
-// per-model points by index), so feeding this to [FollowingWeekPagePreview]
-// turns the snapshot into a regression guard for that slicing — drop the slice
-// and the overlays misalign, changing the PNG.
+// page must slice it to its own window before plotting (the slice keeps the
+// off-window days 1-7 from stretching the charts' y-bounds), so feeding this
+// to [FollowingWeekPagePreview] turns the snapshot into a regression guard
+// for that slicing — drop the slice and the y-axes rescale, changing the PNG.
 private val SAMPLE_TWO_WEEK_PER_MODEL_HOURLY: PerModelHourly = PerModelHourly(
     byModel = (SAMPLE_WEEK_PER_MODEL_HOURLY.byModel.keys + SAMPLE_FOLLOWING_WEEK_PER_MODEL_HOURLY.byModel.keys)
         .associateWith { id ->

--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
@@ -2927,13 +2927,18 @@ internal fun WindCard(
     showModelSpread: Boolean = false,
 ) {
     val times = remember(hourly) { hourly.map { it.time } }
+    // Timestamp → window-position map matching the chart's keying (see
+    // [hourlyTimestampIndices]) so the peak subtitle reads off the same
+    // consensus series the chart draws — and names the right hour even
+    // when a model dropped an hour.
+    val indexByTime = remember(hourly, startDate) { hourlyTimestampIndices(hourly, startDate) }
     // 10 km/h floor on the y-range so a near-still day doesn't get zoomed
     // into noise — same reasoning as ForecastChart.MIN_Y_SPAN. Express the
     // floor in the user's unit so the heuristic stays equivalent (10 km/h
     // ≈ 6.2 mph) instead of shrinking to a tighter span on imperial.
     val minSpan = 10.0.toWindSpeedUnit(windSpeedUnit)
-    val peak = remember(perModelHourly, windSpeedUnit, times) {
-        perModelConsensusSeries(perModelHourly) {
+    val peak = remember(perModelHourly, windSpeedUnit, times, indexByTime) {
+        perModelConsensusSeries(perModelHourly, indexByTime) {
             it.windSpeedKmh?.toWindSpeedUnit(windSpeedUnit)
         }
             .maxByOrNull { it.second }
@@ -2981,8 +2986,11 @@ internal fun CloudCard(
     startDate: java.time.LocalDate = java.time.LocalDate.now(),
     showModelSpread: Boolean = false,
 ) {
-    val range = remember(perModelHourly) {
-        perModelConsensusRange(perModelHourly) { it.cloudCoverPct }
+    // Timestamp → window-position map matching the chart's keying — see
+    // [WindCard] / [hourlyTimestampIndices].
+    val indexByTime = remember(hourly, startDate) { hourlyTimestampIndices(hourly, startDate) }
+    val range = remember(perModelHourly, indexByTime) {
+        perModelConsensusRange(perModelHourly, indexByTime) { it.cloudCoverPct }
     }
     val subtitle = range?.let {
         stringResource(R.string.today_cloud_range, it.first, it.second)
@@ -3014,8 +3022,11 @@ internal fun HumidityCard(
     startDate: java.time.LocalDate = java.time.LocalDate.now(),
     showModelSpread: Boolean = false,
 ) {
-    val range = remember(perModelHourly) {
-        perModelConsensusRange(perModelHourly) { it.relativeHumidityPct }
+    // Timestamp → window-position map matching the chart's keying — see
+    // [WindCard] / [hourlyTimestampIndices].
+    val indexByTime = remember(hourly, startDate) { hourlyTimestampIndices(hourly, startDate) }
+    val range = remember(perModelHourly, indexByTime) {
+        perModelConsensusRange(perModelHourly, indexByTime) { it.relativeHumidityPct }
     }
     val subtitle = range?.let {
         stringResource(R.string.today_humidity_range, it.first, it.second)
@@ -3048,12 +3059,15 @@ internal fun SolarRadiationCard(
     showModelSpread: Boolean = false,
 ) {
     val times = remember(hourly) { hourly.map { it.time } }
+    // Timestamp → window-position map matching the chart's keying — see
+    // [WindCard] / [hourlyTimestampIndices].
+    val indexByTime = remember(hourly, startDate) { hourlyTimestampIndices(hourly, startDate) }
     // Peak irradiance across the cross-model consensus series — same blend
     // the chart draws. Suppressed when the rounded peak is below 10 W/m²
     // (night view, deep-polar winter) so the subtitle doesn't read
     // "Peak 3 W/m² at 12:00".
-    val peak = remember(perModelHourly, times) {
-        perModelConsensusSeries(perModelHourly) { it.shortwaveRadiationWm2 }
+    val peak = remember(perModelHourly, times, indexByTime) {
+        perModelConsensusSeries(perModelHourly, indexByTime) { it.shortwaveRadiationWm2 }
             .maxByOrNull { it.second }
             ?.takeIf { it.second.roundToInt() >= 10 }
             ?.let { (idx, value) ->
@@ -3168,11 +3182,14 @@ internal fun UvIndexCard(
     showModelSpread: Boolean = false,
 ) {
     val times = remember(hourly) { hourly.map { it.time } }
+    // Timestamp → window-position map matching the chart's keying — see
+    // [WindCard] / [hourlyTimestampIndices].
+    val indexByTime = remember(hourly, startDate) { hourlyTimestampIndices(hourly, startDate) }
     // Peak UV across the cross-model consensus series — same blend the chart
     // draws. Suppressed when the rounded peak is below 1 (night view, deep
     // winter) so the subtitle doesn't read "Peak 0 at 21:00".
-    val peak = remember(perModelHourly, times) {
-        perModelConsensusSeries(perModelHourly) { it.uvIndex }
+    val peak = remember(perModelHourly, times, indexByTime) {
+        perModelConsensusSeries(perModelHourly, indexByTime) { it.uvIndex }
             .maxByOrNull { it.second }
             ?.takeIf { it.second.roundToInt() >= 1 }
             ?.let { (idx, value) ->
@@ -3317,9 +3334,12 @@ internal fun PrecipitationAmountCard(
     // best-match otherwise. Indexed by hour so the scrub readout above the
     // chart can read off the same value the line shows at that hour
     // instead of always reading best-match (which would surface a
-    // contradicting number when the consensus diverges).
-    val mainLine = remember(hourly, perModelHourly) {
-        consensusRainfallMainLine(hourly, perModelHourly)
+    // contradicting number when the consensus diverges). The timestamp →
+    // window-position map matches the one the chart builds from the same
+    // inputs, so the two series stay byte-identical.
+    val indexByTime = remember(hourly, forDate) { hourlyTimestampIndices(hourly, forDate) }
+    val mainLine = remember(hourly, perModelHourly, indexByTime) {
+        consensusRainfallMainLine(hourly, perModelHourly, indexByTime)
     }
     val totalMm = remember(mainLine) { mainLine.sum() }
     val isDry = totalMm < DRY_TOTAL_THRESHOLD_MM
@@ -3541,16 +3561,23 @@ internal fun formatMinMax(values: List<Double>, unit: TemperatureUnit): Pair<Int
 // Per-hour mean of [picker] across whichever models reported at that hour —
 // the same blend used for the diagnostic charts' main consensus line, lifted
 // out so the card subtitles can summarise the same series the chart draws.
-// Returns (originalIndex, mean) pairs sorted by index; empty when no model
-// has data for the metric.
+// Entries are resolved to window positions by timestamp lookup against
+// [indexByTime] (the [hourlyTimestampIndices] map for the card's hourly
+// window), matching [PerModelDiagnosticCard]'s keying — so a model that
+// dropped an hour doesn't merge mismatched wall-clock hours into one mean,
+// and the peak subtitles ("Peak X at H") name the right hour. Entries
+// outside the window are skipped. Returns (windowIndex, mean) pairs sorted
+// by index; empty when no model has data for the metric.
 private fun perModelConsensusSeries(
     perModelHourly: PerModelHourly,
+    indexByTime: Map<LocalDateTime, Int>,
     picker: (PerModelHour) -> Double?,
 ): List<Pair<Int, Double>> {
     val byIndex = mutableMapOf<Int, MutableList<Double>>()
     perModelHourly.byModel.values.forEach { entries ->
-        entries.forEachIndexed { i, e ->
-            picker(e)?.let { byIndex.getOrPut(i) { mutableListOf() } += it }
+        entries.forEach { e ->
+            val idx = indexByTime[e.time] ?: return@forEach
+            picker(e)?.let { byIndex.getOrPut(idx) { mutableListOf() } += it }
         }
     }
     return byIndex.entries.sortedBy { it.key }.map { (idx, vs) -> idx to vs.average() }
@@ -3558,9 +3585,10 @@ private fun perModelConsensusSeries(
 
 private fun perModelConsensusRange(
     perModelHourly: PerModelHourly,
+    indexByTime: Map<LocalDateTime, Int>,
     picker: (PerModelHour) -> Double?,
 ): Pair<Int, Int>? {
-    val values = perModelConsensusSeries(perModelHourly, picker).map { it.second }
+    val values = perModelConsensusSeries(perModelHourly, indexByTime, picker).map { it.second }
     if (values.isEmpty()) return null
     return values.min().roundToInt() to values.max().roundToInt()
 }

--- a/app/src/main/kotlin/app/clothescast/widget/FeelsLikeWidget.kt
+++ b/app/src/main/kotlin/app/clothescast/widget/FeelsLikeWidget.kt
@@ -44,6 +44,7 @@ import app.clothescast.core.domain.model.ThemeMode
 import app.clothescast.core.domain.model.UserPreferences
 import app.clothescast.diag.DiagLog
 import app.clothescast.ui.theme.ClothesCastTheme
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withTimeoutOrNull
 import java.time.LocalDate
@@ -343,17 +344,20 @@ internal fun resolveDarkTheme(context: Context, themeMode: ThemeMode): Boolean =
  * cache write (the worker) and after settings changes that affect what the
  * widgets show (temperature unit / time format / theme on the charts, outfit on
  * [OutfitWidget]). Each update is guarded independently so one widget type
- * failing to bind doesn't starve the others.
+ * failing to bind doesn't starve the others — but cancellation rethrows so a
+ * cancelled caller unwinds instead of marching through the remaining widgets.
  */
 internal suspend fun updateAllClothesCastWidgets(context: Context) {
-    runCatching { OutfitWidget().updateAll(context) }
-        .onFailure { DiagLog.w(TAG, "Outfit widget update failed.", it) }
-    runCatching { FeelsLikeWidget().updateAll(context) }
-        .onFailure { DiagLog.w(TAG, "Feels-like widget update failed.", it) }
-    runCatching { SevenDayFeelsLikeWidget().updateAll(context) }
-        .onFailure { DiagLog.w(TAG, "7-day feels-like widget update failed.", it) }
-    runCatching { ConditionsWidget().updateAll(context) }
-        .onFailure { DiagLog.w(TAG, "Conditions widget update failed.", it) }
+    suspend fun guarded(label: String, update: suspend () -> Unit) {
+        runCatching { update() }.onFailure {
+            if (it is CancellationException) throw it
+            DiagLog.w(TAG, "$label widget update failed.", it)
+        }
+    }
+    guarded("Outfit") { OutfitWidget().updateAll(context) }
+    guarded("Feels-like") { FeelsLikeWidget().updateAll(context) }
+    guarded("7-day feels-like") { SevenDayFeelsLikeWidget().updateAll(context) }
+    guarded("Conditions") { ConditionsWidget().updateAll(context) }
 }
 
 private const val TAG = "Widget"

--- a/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
@@ -1033,7 +1033,20 @@ class FetchAndNotifyWorker(
 
             awaitDeliveryAlignment()
 
-            val notifyJob = launch { postPeriodNotification(insight, prefs, prose, topColors, topStrokes, handsColors, outerColors, gates, forceNotify = forceNotifyAndSpeak) }
+            // Guard the launch body: a child `launch` failing inside a
+            // supervisorScope doesn't fail the scope — its exception goes to
+            // the (unset) CoroutineExceptionHandler and would kill the
+            // process. A notification post can throw for real (bitmap render,
+            // a SecurityException when POST_NOTIFICATIONS is revoked between
+            // the permission check and the post), and best-effort-per-
+            // destination is this scope's documented policy.
+            val notifyJob = launch {
+                runCatching { postPeriodNotification(insight, prefs, prose, topColors, topStrokes, handsColors, outerColors, gates, forceNotify = forceNotifyAndSpeak) }
+                    .onFailure { t ->
+                        if (t is CancellationException) throw t
+                        DiagLog.w(TAG, "Posting the period notification failed.", t)
+                    }
+            }
 
             // Cast load — runs in parallel with notification + MQTT.
             // The phone speaker awaits this when castWillHaveAudio so
@@ -1071,14 +1084,23 @@ class FetchAndNotifyWorker(
                     .getOrNull()
             }
 
+            // Same guard as notifyJob: parts of the speaker path (utterance
+            // build, the cast-outcome await's rethrow) run outside
+            // playPhoneSpeaker's internal guards, and an unhandled child
+            // failure here would down the process, not just this destination.
             val phoneSpeakerJob = launch {
-                playPhoneSpeaker(
-                    insight, prefs, gates, pcm,
-                    wav = wav,
-                    castDeferred = castDeferred,
-                    mqttDeferred = mqttDeferred,
-                    theme = theme,
-                )
+                runCatching {
+                    playPhoneSpeaker(
+                        insight, prefs, gates, pcm,
+                        wav = wav,
+                        castDeferred = castDeferred,
+                        mqttDeferred = mqttDeferred,
+                        theme = theme,
+                    )
+                }.onFailure { t ->
+                    if (t is CancellationException) throw t
+                    DiagLog.w(TAG, "Phone speaker playback failed.", t)
+                }
             }
 
             notifyJob.join()
@@ -1099,6 +1121,12 @@ class FetchAndNotifyWorker(
                         publishedAtMs = publishedAt,
                         fetchedAtMs = fetchedAt,
                     )
+                }.onFailure { t ->
+                    // Rethrow cancellation (mid-DataStore.edit) like
+                    // persistQuotaStatus does; log other write failures —
+                    // a stale status row isn't worth failing delivery over.
+                    if (t is CancellationException) throw t
+                    DiagLog.w(TAG, "Failed to persist the cast status.", t)
                 }
             }
 
@@ -1113,6 +1141,9 @@ class FetchAndNotifyWorker(
                     is MqttPublishOutcome.Success -> app.settingsRepository.setMqttLastError(null)
                     is MqttPublishOutcome.Failure -> app.settingsRepository.setMqttLastError(mqttOutcome.message)
                 }
+            }.onFailure { t ->
+                if (t is CancellationException) throw t
+                DiagLog.w(TAG, "Failed to persist the MQTT publish status.", t)
             }
         }
     }

--- a/app/src/test/kotlin/app/clothescast/data/SettingsRepositoryTest.kt
+++ b/app/src/test/kotlin/app/clothescast/data/SettingsRepositoryTest.kt
@@ -540,6 +540,25 @@ class SettingsRepositoryTest {
     }
 
     @Test
+    fun `rule with an unknown condition type is dropped without resetting the list`() = runTest {
+        // A future app version writes a new condition type ("wind_above"),
+        // then the user downgrades. The unrecognized rule must degrade
+        // per-item — like unknown garments do — rather than throwing and
+        // tripping the whole-list fallback that would silently reset every
+        // customized threshold to defaults.
+        dataStore.edit {
+            it[stringPreferencesKey("clothes_rules_json")] = """
+                [{"item":"jacket","type":"wind_above","value":30.0},
+                 {"item":"sweater","type":"temp_below","value":18.0}]
+            """.trimIndent()
+        }
+
+        subject.preferences.first().clothesRules shouldContainExactly listOf(
+            ClothesRule(Garment.SWEATER, ClothesRule.TemperatureBelow(18.0)),
+        )
+    }
+
+    @Test
     fun `setClothesRules round-trips a fahrenheit-typed threshold`() = runTest {
         // The rule remembers what the user typed (65°F), not a converted Celsius
         // approximation — switching unit at display time is reversible.

--- a/app/src/test/kotlin/app/clothescast/ui/today/RangeBandTest.kt
+++ b/app/src/test/kotlin/app/clothescast/ui/today/RangeBandTest.kt
@@ -1,10 +1,15 @@
 package app.clothescast.ui.today
 
+import app.clothescast.core.domain.model.HourlyForecast
 import app.clothescast.core.domain.model.PerModelHour
 import app.clothescast.core.domain.model.PerModelHourly
+import app.clothescast.core.domain.model.WeatherCondition
 import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.maps.shouldContainExactly
 import org.junit.jupiter.api.Test
+import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.LocalTime
 
 class RangeBandTest {
     private fun hour(time: LocalDateTime, value: Double) =
@@ -15,13 +20,26 @@ class RangeBandTest {
             precipitationProbabilityPct = null,
         )
 
+    private fun hourlyAt(time: LocalTime) =
+        HourlyForecast(
+            time = time,
+            temperatureC = 0.0,
+            feelsLikeC = 0.0,
+            precipitationProbabilityPct = 0.0,
+            condition = WeatherCondition.UNKNOWN,
+        )
+
+    private val startDate = LocalDate.of(2026, 6, 8)
     private val t0 = LocalDateTime.of(2026, 6, 8, 0, 0)
     private val t1 = t0.plusHours(1)
     private val t2 = t0.plusHours(2)
-    // The chart's hourly window: it starts at t0 and spans 3 hours. Entries are
-    // mapped to their whole-hour offset from t0 (the consensus main line's x grid).
-    private val windowStart = t0
-    private val windowSize = 3
+    // The chart's hourly window: t0..t2 at list positions 0..2 — the consensus
+    // main line's x grid. Per-model entries are resolved against it by
+    // timestamp lookup, exactly as the charts do via [hourlyTimestampIndices].
+    private val window = hourlyTimestampIndices(
+        hourly = (0..2).map { hourlyAt(LocalTime.of(it, 0)) },
+        startDate = startDate,
+    )
 
     @Test
     fun `envelope keys by time, so a model's dropped hour doesn't merge mismatched hours`() {
@@ -33,7 +51,7 @@ class RangeBandTest {
                 "gfs_seamless" to listOf(hour(t0, 12.0), hour(t2, 32.0)),
             ),
         )
-        val (minSeries, maxSeries) = perModelEnvelope(perModel, windowStart, windowSize) { it.apparentTemperatureC }
+        val (minSeries, maxSeries) = perModelEnvelope(perModel, window) { it.apparentTemperatureC }
 
         // t0 (index 0) has both models; t1 (index 1) has only A, so it's dropped
         // (< 2 models); t2 (index 2) pairs A's 30 with B's 32. Position-keying
@@ -54,7 +72,7 @@ class RangeBandTest {
                 "gfs_seamless" to listOf(hour(t1, 22.0), hour(t2, 32.0)),
             ),
         )
-        val (minSeries, maxSeries) = perModelEnvelope(perModel, windowStart, windowSize) { it.apparentTemperatureC }
+        val (minSeries, maxSeries) = perModelEnvelope(perModel, window) { it.apparentTemperatureC }
 
         minSeries shouldContainExactly listOf(1 to 20.0, 2 to 30.0)
         maxSeries shouldContainExactly listOf(1 to 22.0, 2 to 32.0)
@@ -77,10 +95,53 @@ class RangeBandTest {
                 PerModelHourly.BEST_MATCH_MODEL_ID to listOf(hour(t0, 99.0)),
             ),
         )
-        val (minSeries, maxSeries) = perModelEnvelope(perModel, windowStart, windowSize) { it.apparentTemperatureC }
+        val (minSeries, maxSeries) = perModelEnvelope(perModel, window) { it.apparentTemperatureC }
 
         // best_match's outlier 99 must not widen the band.
         minSeries shouldContainExactly listOf(0 to 10.0)
         maxSeries shouldContainExactly listOf(0 to 20.0)
+    }
+
+    @Test
+    fun `timestamp indices wrap midnight by advancing the date, not aliasing hours`() {
+        // A tonight window: 22:00, 23:00, then 00:00/01:00 the next day. The
+        // backwards hour-of-day step (23 -> 0) advances the date, so the
+        // post-midnight entries key under June 9 — not a second June 8 00:00.
+        val hourly = listOf(22, 23, 0, 1).map { hourlyAt(LocalTime.of(it, 0)) }
+
+        hourlyTimestampIndices(hourly, startDate) shouldContainExactly mapOf(
+            LocalDateTime.of(2026, 6, 8, 22, 0) to 0,
+            LocalDateTime.of(2026, 6, 8, 23, 0) to 1,
+            LocalDateTime.of(2026, 6, 9, 0, 0) to 2,
+            LocalDateTime.of(2026, 6, 9, 1, 0) to 3,
+        )
+    }
+
+    @Test
+    fun `a DST spring-forward day keeps band indices aligned with list positions`() {
+        // 2026-03-08 springs forward in US zones: the window's wall-clock
+        // hours skip 02:00, so the day contributes 23 entries and 03:00 sits
+        // at list position 2. Naive hours-since-window-start arithmetic would
+        // key 03:00 to index 3 — an hour right of where the position-plotted
+        // main line draws it. Walking the actual entries keeps them aligned.
+        val springForward = LocalDate.of(2026, 3, 8)
+        val hourly = listOf(0, 1, 3, 4).map { hourlyAt(LocalTime.of(it, 0)) }
+        val dstWindow = hourlyTimestampIndices(hourly, springForward)
+        fun at(h: Int) = LocalDateTime.of(springForward, LocalTime.of(h, 0))
+
+        dstWindow shouldContainExactly mapOf(at(0) to 0, at(1) to 1, at(3) to 2, at(4) to 3)
+
+        // Both models carry the same 23-hour wall-clock series the window has,
+        // so the envelope must land on list positions 0..3 — band under line.
+        val perModel = PerModelHourly(
+            byModel = mapOf(
+                "ecmwf_ifs025" to listOf(0, 1, 3, 4).map { hour(at(it), 10.0 + it) },
+                "gfs_seamless" to listOf(0, 1, 3, 4).map { hour(at(it), 20.0 + it) },
+            ),
+        )
+        val (minSeries, maxSeries) = perModelEnvelope(perModel, dstWindow) { it.apparentTemperatureC }
+
+        minSeries shouldContainExactly listOf(0 to 10.0, 1 to 11.0, 2 to 13.0, 3 to 14.0)
+        maxSeries shouldContainExactly listOf(0 to 20.0, 1 to 21.0, 2 to 23.0, 3 to 24.0)
     }
 }

--- a/core/data/src/main/kotlin/app/clothescast/core/data/tts/GeminiTtsClient.kt
+++ b/core/data/src/main/kotlin/app/clothescast/core/data/tts/GeminiTtsClient.kt
@@ -5,6 +5,8 @@ import app.clothescast.core.data.diag.ApiCallLogger
 import app.clothescast.core.data.diag.ApiEndpoints
 import app.clothescast.core.data.diag.NoOpApiCallLogger
 import app.clothescast.core.data.insight.GeminiCallPlanner
+import app.clothescast.core.data.insight.InvalidApiKeyException
+import app.clothescast.core.data.insight.MissingApiKeyException
 import app.clothescast.core.domain.model.TtsStyle
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
@@ -657,15 +659,19 @@ private fun parseDailyQuotaExhausted(body: ByteArray): GeminiTtsDailyQuotaExhaus
  * user picked Gemini, so a single blip shouldn't downgrade the whole briefing.
  *
  * Failures that won't change on a retry return false so the caller falls back
- * immediately: the spent daily free-tier quota, a blocked prompt, and a
- * non-retryable HTTP 4xx (auth / bad request). [CancellationException] is never
- * retryable — it must propagate to unwind structured concurrency rather than be
- * caught and retried.
+ * immediately: the spent daily free-tier quota, a blocked prompt, a missing or
+ * unreadable BYOK key (it won't reappear between attempts — and re-keying is
+ * the user's call, not a backoff loop's), and a non-retryable HTTP 4xx
+ * (auth / bad request). [CancellationException] is never retryable — it must
+ * propagate to unwind structured concurrency rather than be caught and
+ * retried.
  */
 fun isRetryableGeminiTtsFailure(t: Throwable): Boolean = when (t) {
     is CancellationException -> false
     is GeminiTtsDailyQuotaExhaustedException -> false
     is GeminiTtsBlockedException -> false
+    is MissingApiKeyException -> false
+    is InvalidApiKeyException -> false
     is GeminiTtsHttpException -> t.status.value == 429 || t.status.value in 500..599
     else -> true
 }

--- a/core/data/src/main/kotlin/app/clothescast/core/data/weather/MultiModelConfidenceFetcher.kt
+++ b/core/data/src/main/kotlin/app/clothescast/core/data/weather/MultiModelConfidenceFetcher.kt
@@ -109,7 +109,15 @@ internal class MultiModelConfidenceFetcher(
                     logger.log("could not read error body for status $status", readError)
                     ""
                 }
-                val rejected = remaining.filter { it.isNotBlank() && body.contains(it) }
+                // Match whole ids only: a bare substring check would also
+                // "match" a requested id that happens to be a prefix of the
+                // one the server named (Open-Meteo has such pairs, e.g.
+                // icon_d2 / icon_d2_15min) and prune a perfectly valid model
+                // alongside the bad one. Ids are word characters throughout
+                // ([a-z0-9_]), so \b anchors exactly at their edges.
+                val rejected = remaining.filter {
+                    it.isNotBlank() && Regex("""\b${Regex.escape(it)}\b""").containsMatchIn(body)
+                }
                 if (status != HTTP_BAD_REQUEST || rejected.isEmpty() || attempts > MAX_FETCH_ATTEMPTS) {
                     logger.log("confidence fetch failed (status $status)", e)
                     return null

--- a/core/data/src/main/kotlin/app/clothescast/core/data/weather/OpenMeteoClient.kt
+++ b/core/data/src/main/kotlin/app/clothescast/core/data/weather/OpenMeteoClient.kt
@@ -5,7 +5,6 @@ import app.clothescast.core.data.diag.ApiEndpoints
 import app.clothescast.core.data.diag.NoOpApiCallLogger
 import app.clothescast.core.data.diag.instrument
 import app.clothescast.core.domain.model.DailyForecast
-import app.clothescast.core.domain.model.HourlyForecast
 import app.clothescast.core.domain.model.Location
 import app.clothescast.core.domain.model.PerModelHour
 import app.clothescast.core.domain.model.PerModelHourly
@@ -92,7 +91,8 @@ class OpenMeteoClient(
         val models = confidenceModelsProvider(location)
         val multiModel = async { confidenceFetcher.fetch(location, models) }
 
-        val bundle = OpenMeteoMapper.toBundle(primary.await())
+        val response = primary.await()
+        val bundle = OpenMeteoMapper.toBundle(response)
         val multi = multiModel.await()
 
         // Replace today's hourly + the derived daily extremes with the
@@ -105,8 +105,6 @@ class OpenMeteoClient(
         // models reported keeps a sane backstop in regions where the
         // side-band fetch is sparse, and unconditionally when the
         // multi-model fetch failed entirely.
-        val bestMatchHourly = bundle.today.hourly
-
         // Stash best_match alongside the consulted models in [PerModelHourly]
         // before passing into the consensus blender so the blender sees it
         // as a regular model — equal-weight inclusion of best_match is the
@@ -114,27 +112,26 @@ class OpenMeteoClient(
         // ordering of these two blocks regressed that by passing the
         // pre-injection map (Codex caught it on PR review).
         //
-        // Include best_match hours for every forward day, not just today. The
-        // consulted models (ECMWF / GFS / ICON) carry the full forecast_days=14
-        // window, so best_match has to span it too or the consensus silently
-        // changes character partway through: with best_match present
-        // only for today + tomorrow, later days would average the consulted
-        // models *without* Open-Meteo's auto-pick, breaking the equal-weight
-        // policy [blendConsensusHourly] documents and making the near days and
-        // later days blend differently (Codex caught it). It also keeps best_match a real
-        // vote in [RenderInsightSummary.pickPerModelPeak]'s `majorityNeeded`
-        // bar on both sides of the midnight boundary.
+        // Built from the wire payload, not the mapped [HourlyForecast]s: the
+        // mapper substitutes 0.0 °C / 0 % for null hourly values (tolerable
+        // for the chart, which the blend overwrites on any consensus hour),
+        // and feeding those synthetic zeros into [blendConsensusHourly] would
+        // let a horizon-edge null cast a fake cold-and-dry vote into the
+        // consensus mean — exactly what MultiModelConfidenceFetcher.parseHourly
+        // avoids for the consulted models by dropping the hour / keeping
+        // precip null.
         //
-        // Sources overlap — `tomorrowHourly` is tomorrow's pre-dawn slice and
-        // `upcomingDays[0]` is tomorrow's full day — so dedupe by timestamp
-        // (first wins) to avoid double-weighting best_match on the overlapping
-        // hours. Today comes only from best_match's own hourly.
+        // The raw hourly stream spans yesterday through day 14, so best_match
+        // covers the same forecast_days=14 window the consulted models carry —
+        // the equal-weight policy [blendConsensusHourly] documents holds on
+        // every forward day (an earlier today-plus-tomorrow-only version made
+        // near and later days blend differently; Codex caught it), and
+        // best_match stays a real vote in
+        // [RenderInsightSummary.pickPerModelPeak]'s `majorityNeeded` bar on
+        // both sides of the midnight boundary.
         val tomorrowDate = bundle.today.date.plusDays(1)
         val bestMatchPerModel =
-            (bestMatchHourly.asPerModelHours(bundle.today.date) +
-                bundle.tomorrowHourly.asPerModelHours(tomorrowDate) +
-                bundle.upcomingDays.flatMap { it.hourly.asPerModelHours(it.date) })
-                .distinctBy { it.time }
+            response.hourly.asBestMatchPerModelHours(firstForecastDate = bundle.today.date)
         val perModelWithBestMatch = multi?.hourly?.let { existing ->
             existing.copy(
                 byModel = existing.byModel +
@@ -175,28 +172,38 @@ class OpenMeteoClient(
         )
     }
 
-    private fun List<HourlyForecast>.asPerModelHours(date: LocalDate): List<PerModelHour> = map {
-        // best_match's hourly comes from the primary `/v1/forecast` call which
-        // doesn't include the diagnostic fields (wind, humidity, cloud); those
-        // ride only the side-band multi-model call and aren't fetched per
-        // best_match. Surface as null so the diagnostic charts treat
-        // best_match as "no data for this metric" instead of dropping it.
-        // The weather code *is* available on the primary call (already
-        // mapped to a [WeatherCondition] in [OpenMeteoMapper]), so we pass
-        // it through — the consensus blend's modal aggregation gets a 4th
-        // vote from best_match this way.
-        PerModelHour(
-            time = LocalDateTime.of(date, it.time),
-            apparentTemperatureC = it.feelsLikeC,
-            temperatureC = it.temperatureC,
-            precipitationProbabilityPct = it.precipitationProbabilityPct,
-            // Both probability and amount come from the primary `/v1/forecast`
-            // call for best_match, so the amount chart's best_match overlay
-            // has real data on it — unlike the diagnostic fields above.
-            precipitationMm = it.precipitationMm,
-            condition = it.condition,
-        )
-    }
+    // Mirrors MultiModelConfidenceFetcher.parseHourly's null policy: an hour
+    // without temperature_2m is dropped (no synthetic 0 °C vote), apparent
+    // falls back to air, and the precipitation fields stay null when absent so
+    // precip-specific aggregates skip them instead of counting a fake dry hour.
+    private fun HourlyData.asBestMatchPerModelHours(firstForecastDate: LocalDate): List<PerModelHour> =
+        buildList {
+            for (i in time.indices) {
+                val ts = runCatching { LocalDateTime.parse(time[i]) }.getOrNull() ?: continue
+                // Yesterday is historical with no side-band per-model coverage;
+                // start best_match's series where the consulted models start.
+                if (ts.toLocalDate() < firstForecastDate) continue
+                val air = temperature.getOrNull(i) ?: continue
+                add(
+                    PerModelHour(
+                        time = ts,
+                        apparentTemperatureC = feelsLike.getOrNull(i) ?: air,
+                        temperatureC = air,
+                        precipitationProbabilityPct = precipitationProbability.getOrNull(i)?.toDouble(),
+                        precipitationMm = precipitation.getOrNull(i),
+                        // Wind and UV ride the primary call too, so best_match
+                        // votes in the wind / UV consensus and draws on those
+                        // diagnostic charts like any consulted model. Humidity,
+                        // cloud, solar, and sunshine ride only the side-band
+                        // multi-model call, so they stay null — "no data for
+                        // this metric" rather than a synthetic zero.
+                        windSpeedKmh = windSpeed.getOrNull(i),
+                        uvIndex = uvIndex.getOrNull(i),
+                        condition = weatherCode.getOrNull(i)?.let { WmoCodeMapper.map(it) },
+                    ),
+                )
+            }
+        }
 
     private suspend fun fetchPrimary(location: Location): OpenMeteoResponse =
         apiCallLogger.instrument(ApiEndpoints.OPEN_METEO_FORECAST) {

--- a/core/data/src/test/kotlin/app/clothescast/core/data/tts/GeminiTtsRetryClassifierTest.kt
+++ b/core/data/src/test/kotlin/app/clothescast/core/data/tts/GeminiTtsRetryClassifierTest.kt
@@ -1,5 +1,7 @@
 package app.clothescast.core.data.tts
 
+import app.clothescast.core.data.insight.InvalidApiKeyException
+import app.clothescast.core.data.insight.MissingApiKeyException
 import io.kotest.matchers.shouldBe
 import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.CancellationException
@@ -54,6 +56,19 @@ class GeminiTtsRetryClassifierTest {
     @Test
     fun `blocked prompt is not retryable`() {
         isRetryableGeminiTtsFailure(GeminiTtsBlockedException("blocked")) shouldBe false
+    }
+
+    @Test
+    fun `missing BYOK key is not retryable`() {
+        // A cleared key won't reappear between attempts — burning the retry
+        // budget with backoff just delays the device-TTS fallback.
+        isRetryableGeminiTtsFailure(MissingApiKeyException()) shouldBe false
+    }
+
+    @Test
+    fun `unreadable BYOK key is not retryable`() {
+        // Same as missing: only the user re-entering the key can fix it.
+        isRetryableGeminiTtsFailure(InvalidApiKeyException()) shouldBe false
     }
 
     @Test

--- a/core/data/src/test/kotlin/app/clothescast/core/data/weather/MultiModelConfidenceFetcherTest.kt
+++ b/core/data/src/test/kotlin/app/clothescast/core/data/weather/MultiModelConfidenceFetcherTest.kt
@@ -418,6 +418,41 @@ class MultiModelConfidenceFetcherTest {
     }
 
     @Test
+    fun `pruning matches whole model ids, not substrings`() = runTest {
+        // Open-Meteo has model ids that are prefixes of other ids (icon_d2 /
+        // icon_d2_15min). A 400 naming only the longer one must not also prune
+        // the shorter, perfectly valid model from the retry.
+        val requestedModels = mutableListOf<String?>()
+        val engine = MockEngine { request ->
+            val models = request.url.parameters["models"]
+            requestedModels += models
+            if (models != null && "icon_d2_15min" in models) {
+                respond(
+                    content = ByteReadChannel(
+                        """{"error":true,"reason":"Cannot initialize WeatherModel from String \"icon_d2_15min\""}""",
+                    ),
+                    status = HttpStatusCode.BadRequest,
+                    headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                )
+            } else {
+                respond(
+                    content = ByteReadChannel(THREE_MODEL_AGREEMENT),
+                    status = HttpStatusCode.OK,
+                    headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                )
+            }
+        }
+        fetcherWith(engine)
+            .fetch(london, listOf("icon_d2", "icon_d2_15min", "ecmwf_ifs025", "gfs_seamless"))
+            .shouldNotBeNull()
+
+        requestedModels shouldBe listOf(
+            "icon_d2,icon_d2_15min,ecmwf_ifs025,gfs_seamless",
+            "icon_d2,ecmwf_ifs025,gfs_seamless",
+        )
+    }
+
+    @Test
     fun `does not retry when the 400 names no requested model`() = runTest {
         // A 400 that isn't about a model id (bad coordinates, etc.) shouldn't
         // trigger a prune-and-retry — there's nothing to drop. Fail fast to null.

--- a/core/data/src/test/kotlin/app/clothescast/core/data/weather/OpenMeteoClientTest.kt
+++ b/core/data/src/test/kotlin/app/clothescast/core/data/weather/OpenMeteoClientTest.kt
@@ -1,9 +1,11 @@
 package app.clothescast.core.data.weather
 
 import app.clothescast.core.domain.model.Location
+import app.clothescast.core.domain.model.PerModelHourly
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldContainAll
+import io.kotest.matchers.doubles.plusOrMinus
 import io.kotest.matchers.shouldBe
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
@@ -99,6 +101,90 @@ class OpenMeteoClientTest {
         bundle.yesterday.temperatureMaxC shouldBe 18.0
         bundle.today.temperatureMaxC shouldBe 24.0
         bundle.today.hourly.size shouldBe 8
+    }
+
+    @Test
+    fun `null best_match hours do not vote synthetic zeros into the consensus blend`() = runTest {
+        // The horizon edge of the 14-day window (and a model run still warming
+        // up) returns null hourly values for best_match. The mapper turns those
+        // into 0.0 °C / 0 % for the chart; the consensus blend must not see
+        // them as real votes or a fake cold-and-dry hour drags the mean (and
+        // the recomputed daily extremes) down.
+        val primaryJson = """
+            {
+              "timezone": "Europe/London",
+              "daily": {
+                "time": ["2026-04-24", "2026-04-25"],
+                "temperature_2m_min": [12.0, 16.0],
+                "temperature_2m_max": [18.0, 24.0],
+                "apparent_temperature_min": [10.0, 15.0],
+                "apparent_temperature_max": [17.0, 23.0],
+                "precipitation_probability_max": [5, 60],
+                "precipitation_sum": [0.0, 4.5],
+                "weather_code": [2, 63]
+              },
+              "hourly": {
+                "time": ["2026-04-25T12:00", "2026-04-25T13:00"],
+                "temperature_2m": [20.0, null],
+                "apparent_temperature": [20.0, null],
+                "precipitation_probability": [40, null],
+                "weather_code": [2, null],
+                "wind_speed_10m": [10.0, null],
+                "uv_index": [4.0, null]
+              }
+            }
+        """.trimIndent()
+        val confidenceJson = """
+            {
+              "daily": {"time": ["2026-04-25"]},
+              "hourly": {
+                "time": ["2026-04-25T12:00", "2026-04-25T13:00"],
+                "temperature_2m_gfs_seamless": [21.0, 10.0],
+                "apparent_temperature_gfs_seamless": [21.0, 10.0],
+                "precipitation_probability_gfs_seamless": [50, 60],
+                "wind_speed_10m_gfs_seamless": [20.0, 20.0],
+                "temperature_2m_icon_seamless": [23.0, 20.0],
+                "apparent_temperature_icon_seamless": [23.0, 20.0],
+                "precipitation_probability_icon_seamless": [70, 80],
+                "wind_speed_10m_icon_seamless": [30.0, 30.0]
+              }
+            }
+        """.trimIndent()
+        val engine = MockEngine { request ->
+            val isPrimary = request.url.parameters["past_days"] == "1"
+            respond(
+                content = if (isPrimary) primaryJson else confidenceJson,
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+        val client = OpenMeteoClient(
+            HttpClient(engine) {
+                install(ContentNegotiation) {
+                    json(Json { ignoreUnknownKeys = true })
+                }
+            },
+        )
+
+        val bundle = client.fetchForecast(london)
+
+        // 12:00 — all three vote: best_match 20, GFS 21, ICON 23. Wind rides
+        // the primary call, so best_match votes there too: (10 + 20 + 30) / 3.
+        bundle.today.hourly[0].temperatureC shouldBe ((20.0 + 21.0 + 23.0) / 3 plusOrMinus 1e-6)
+        bundle.today.hourly[0].windSpeedKmh!! shouldBe ((10.0 + 20.0 + 30.0) / 3 plusOrMinus 1e-6)
+        // 13:00 — best_match's hour was null upstream: it must sit the hour
+        // out, not vote the mapper's synthetic 0 °C / 0 %.
+        bundle.today.hourly[1].temperatureC shouldBe ((10.0 + 20.0) / 2 plusOrMinus 1e-6)
+        bundle.today.hourly[1].precipitationProbabilityPct shouldBe ((60.0 + 80.0) / 2 plusOrMinus 1e-6)
+
+        // The exposed per-model series reflects the same policy: the null hour
+        // is absent from best_match's series rather than zero-filled, and the
+        // primary call's wind / UV ride along.
+        val bestMatch = checkNotNull(bundle.perModelHourly)
+            .byModel.getValue(PerModelHourly.BEST_MATCH_MODEL_ID)
+        bestMatch.map { it.time.hour } shouldBe listOf(12)
+        bestMatch[0].windSpeedKmh shouldBe 10.0
+        bestMatch[0].uvIndex shouldBe 4.0
     }
 
     @Test

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/CalendarEvent.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/CalendarEvent.kt
@@ -41,9 +41,9 @@ data class CalendarEvent(
     val ownerAccount: String? = null,
 ) {
     /**
-     * True when [time] falls within `[start, end)`. All-day events match every
-     * non-midnight time so the precip-peak overlap check below them never
-     * accidentally pairs an umbrella with "your all-day Public holiday".
+     * True when [time] falls within `[start, end)`. All-day events never
+     * match, so the precip-peak overlap check never accidentally pairs an
+     * umbrella with "your all-day Public holiday".
      */
     fun overlaps(time: LocalTime): Boolean {
         if (allDay) return false

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/ConsensusBlend.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/ConsensusBlend.kt
@@ -81,12 +81,11 @@ fun blendConsensusHourly(
                 precipCandidates.average()
             }
             // Wind / UV: same skip-nulls-then-average treatment as precip.
-            // best_match contributes null for both (the primary forecast call
-            // doesn't carry them — see OpenMeteoClient.asPerModelHours), so the
-            // mean is over the consulted models, matching the wind / UV
-            // diagnostic charts' consensus line. Fall back to best_match's own
-            // value when no candidate reported (keeps a sane backstop rather
-            // than dropping the field to null).
+            // best_match carries both off the primary forecast call, so it
+            // votes here like any consulted model; models whose runs omit the
+            // field sit the hour out. Fall back to best_match's own value when
+            // no candidate reported (keeps a sane backstop rather than
+            // dropping the field to null).
             val windCandidates = candidates.mapNotNull { it.windSpeedKmh }
             val blendedWind = if (windCandidates.isEmpty()) hour.windSpeedKmh else windCandidates.average()
             val uvCandidates = candidates.mapNotNull { it.uvIndex }

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Insight.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Insight.kt
@@ -82,11 +82,13 @@ data class Insight(
      */
     val period: ForecastPeriod = ForecastPeriod.TODAY,
     /**
-     * True when at least one calendar event was found in the relevant window for
-     * this insight (today's events for TODAY, tonight's events for TONIGHT). Used
-     * by the tonight notifier to decide between a silent and a default-priority
-     * notification — events present means "you might need to actually leave the
-     * house tonight," which warrants a sound and TTS read-out.
+     * True when at least one away-from-home calendar event — non-all-day, with
+     * a location — was found in the relevant window for this insight (today's
+     * events for TODAY, tonight's events for TONIGHT). Locationless and
+     * all-day events don't count: they don't imply stepping outside. Used by
+     * the tonight notifier to decide between a silent and a default-priority
+     * notification — a located event means "you might need to actually leave
+     * the house tonight," which warrants a sound and TTS read-out.
      */
     val hasEvents: Boolean = false,
     /**

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/OutfitSuggestion.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/OutfitSuggestion.kt
@@ -18,8 +18,11 @@ import java.time.LocalTime
  * icon fell through to whatever `defaultTop` the user picked (e.g. POLO).
  * Bottom tier: a firing `shorts` rule picks [Bottom.SHORTS]; `short-skirt` picks
  * [Bottom.SHORT_SKIRT]; `skirt` picks [Bottom.LONG_SKIRT]; `jeans` picks
- * [Bottom.JEANS]; otherwise the user's chosen
- * `defaultBottom` ([Bottom.LONG_PANTS] by default). The Settings "If no rules match"
+ * [Bottom.JEANS]; `pants` picks [Bottom.LONG_PANTS]; otherwise the user's chosen
+ * `defaultBottom` ([Bottom.LONG_PANTS] by default). The explicit `pants` tier
+ * mirrors the `t-shirt` one: [EvaluateClothesRules] treats a firing `pants` rule
+ * as a matched bottom, so without it the prose would name pants while the icon
+ * fell through to whatever `defaultBottom` the user picked (e.g. SHORTS). The Settings "If no rules match"
  * card lets the user point each fallback at any catalog garment so the home-screen
  * icon matches what they actually wear when no rule fires.
  *
@@ -150,10 +153,11 @@ data class OutfitSuggestion(
         // simultaneously (e.g. both coat ≤4°C and jacket ≤10°C fire at 3°C),
         // the heavier garment icon wins rather than the first match.
         // Bottom tiers: shorts → SHORTS, short-skirt → SHORT_SKIRT, skirt →
-        // LONG_SKIRT, jeans → JEANS, fallback → user's chosen defaultBottom
-        // (LONG_PANTS by default). Within the skirt family, the shorter
-        // garment is checked first so that when both a `short-skirt` and a
-        // `skirt` rule fire on the same warm day, the mini icon wins.
+        // LONG_SKIRT, jeans → JEANS, pants → LONG_PANTS, fallback → user's
+        // chosen defaultBottom (LONG_PANTS by default). Within the skirt
+        // family, the shorter garment is checked first so that when both a
+        // `short-skirt` and a `skirt` rule fire on the same warm day, the
+        // mini icon wins.
         private val THICK_JACKET_KEYS = listOf(Garment.JACKET)
         private val THICK_COAT_KEYS = listOf(Garment.COAT)
         private val PUFFER_JACKET_KEYS = listOf(Garment.PUFFER)
@@ -165,6 +169,7 @@ data class OutfitSuggestion(
         private val SHORT_SKIRT_KEYS = listOf(Garment.SHORT_SKIRT)
         private val LONG_SKIRT_KEYS = listOf(Garment.SKIRT)
         private val JEANS_KEYS = listOf(Garment.JEANS)
+        private val LONG_PANTS_KEYS = listOf(Garment.PANTS)
         // Hands tier: a firing `gloves` rule lights the optional glove icon.
         // No fallback tier — uncovered hands stay null (see the `hands` note on
         // OutfitSuggestion), so this never promotes to a default the way the top
@@ -255,6 +260,7 @@ data class OutfitSuggestion(
                 firingRules.hasKeyIn(SHORT_SKIRT_KEYS) -> Bottom.SHORT_SKIRT
                 firingRules.hasKeyIn(LONG_SKIRT_KEYS) -> Bottom.LONG_SKIRT
                 firingRules.hasKeyIn(JEANS_KEYS) -> Bottom.JEANS
+                firingRules.hasKeyIn(LONG_PANTS_KEYS) -> Bottom.LONG_PANTS
                 else -> defaultBottom
             }
             // Optional, no fallback: null unless a hands rule actually fired.
@@ -341,10 +347,12 @@ data class OutfitSuggestion(
                 ?: tempRules.firstFiring(forecast, SHORT_SKIRT_KEYS)
                 ?: tempRules.firstFiring(forecast, LONG_SKIRT_KEYS)
                 ?: tempRules.firstFiring(forecast, JEANS_KEYS)
+                ?: tempRules.firstFiring(forecast, LONG_PANTS_KEYS)
                 ?: tempRules.firstByKey(SHORTS_KEYS)
                 ?: tempRules.firstByKey(SHORT_SKIRT_KEYS)
                 ?: tempRules.firstByKey(LONG_SKIRT_KEYS)
                 ?: tempRules.firstByKey(JEANS_KEYS)
+                ?: tempRules.firstByKey(LONG_PANTS_KEYS)
                 ?: ClothesRule.DEFAULTS.first { it.item == Garment.SHORTS }
             return rule.toConditionFact(forecast, coldestHour, warmestHour)
         }

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/PerModelConsensus.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/PerModelConsensus.kt
@@ -3,21 +3,25 @@ package app.clothescast.core.domain.model
 import java.time.LocalDate
 
 /**
- * Per-model-first consensus average shared by the day-level rainfall and
- * sunshine blurbs.
+ * Hour-wise consensus average shared by the day-level rainfall and sunshine
+ * blurbs.
  *
- * Each consulted model's [select]ed hours are summed independently (optionally
- * restricted to [dateFilter]), and the arithmetic mean of those per-model
- * totals is returned. Summing per-model first — rather than averaging the
- * per-hour values across models and then summing — keeps a model with only a
- * partial hourly series from silently dragging the consensus down: its missing
- * hours don't get counted as zero.
+ * At each hour, the [select]ed values from the models that reported that hour
+ * are averaged; the per-hour means are then summed (optionally restricted to
+ * [dateFilter]). Averaging per-hour over the models that actually reported —
+ * rather than summing each model first and averaging the per-model totals —
+ * keeps a model with only a partial hourly series from silently dragging the
+ * consensus down: a per-model-totals mean treats the partial model's sum as a
+ * full-window total, which is arithmetically identical to counting its
+ * missing hours as zero. (That was this function's original implementation,
+ * while its doc already claimed the protection — the doc was the intent.)
  *
- * [select] returns null for hours a model didn't report; those are dropped
- * (not treated as zero). A model that reported nothing in range contributes no
- * total. With fewer than two models contributing a total, returns null — a
- * one-model "consensus" isn't a consensus, and callers fall back rather than
- * surfacing a misleading single-source number.
+ * [select] returns null for hours a model didn't report; those drop out of
+ * that hour's mean (not treated as zero). A model that reported nothing in
+ * range contributes nowhere. With fewer than two models contributing
+ * anywhere in the window, returns null — a one-model "consensus" isn't a
+ * consensus, and callers fall back rather than surfacing a misleading
+ * single-source number.
  *
  * Treats `best_match` like any other model, matching [blendConsensusHourly]'s
  * posture and the rest of the Today-screen consensus blends.
@@ -26,12 +30,15 @@ internal fun PerModelHourly.consensusPerModelAverage(
     dateFilter: LocalDate?,
     select: (PerModelHour) -> Double?,
 ): Double? {
-    val perModelTotals = byModel.values.mapNotNull { entries ->
-        val values = entries
+    val perModelValues = byModel.values.map { entries ->
+        entries
             .filter { dateFilter == null || it.time.toLocalDate() == dateFilter }
-            .mapNotNull(select)
-        if (values.isEmpty()) null else values.sum()
-    }
-    if (perModelTotals.size < 2) return null
-    return perModelTotals.average()
+            .mapNotNull { entry -> select(entry)?.let { entry.time to it } }
+    }.filter { it.isNotEmpty() }
+    if (perModelValues.size < 2) return null
+    return perModelValues
+        .flatten()
+        .groupBy({ it.first }, { it.second })
+        .values
+        .sumOf { it.average() }
 }

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/RainfallConsensus.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/RainfallConsensus.kt
@@ -5,16 +5,16 @@ import java.time.LocalDate
 /**
  * Day-level rainfall total averaged across the consulted models — the
  * single number behind the Today screen's "X mm of rain today" blurb.
- * Sibling of [consensusSunshineHoursFor]; same per-model-first averaging
+ * Sibling of [consensusSunshineHoursFor]; same hour-wise averaging
  * contract.
  *
- * Per-hour [PerModelHour.precipitationMm] is summed independently for each
- * model that reported precipitation on [date], and the arithmetic mean of
- * those per-model daily totals is returned in millimetres. Summing per-model
- * first (rather than averaging the per-hour values across models and then
- * summing) keeps a model with only a partial hourly series from silently
- * dragging the consensus down — its missing hours don't get counted as zero
- * rainfall.
+ * At each hour of [date], [PerModelHour.precipitationMm] is averaged over
+ * the models that reported it, and the per-hour means are summed into a
+ * daily total in millimetres. Averaging hour-wise over the reporting models
+ * (rather than summing each model first and averaging the per-model totals)
+ * keeps a model with only a partial hourly series from silently dragging
+ * the consensus down — its missing hours don't get counted as zero
+ * rainfall. See [consensusPerModelAverage].
  *
  * Treats `best_match` like any other model, matching [blendConsensusHourly]'s
  * posture and the rest of the Today-screen consensus blends. With fewer than
@@ -35,10 +35,9 @@ fun PerModelHourly.consensusRainfallMmFor(date: LocalDate): Double? =
  * (early-morning rain before the morning alarm) on the night view; this
  * variant sums the full slice instead.
  *
- * Same per-model-first averaging contract as [consensusRainfallMmFor]:
- * each consulted model's hours are summed independently, the arithmetic mean
- * of those per-model totals is returned in millimetres, and < 2 models with
- * any precipitation return null.
+ * Same hour-wise averaging contract as [consensusRainfallMmFor]: each hour's
+ * mean over the reporting models is summed into a window total in
+ * millimetres, and < 2 models with any precipitation return null.
  */
 fun PerModelHourly.consensusRainfallMm(): Double? =
     consensusPerModelAverage(dateFilter = null) { it.precipitationMm }

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/SunshineConsensus.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/SunshineConsensus.kt
@@ -6,13 +6,13 @@ import java.time.LocalDate
  * Day-level sunshine total averaged across the consulted models — the
  * single number behind the Today screen's "Xh of sun today" blurb.
  *
- * Per-hour [PerModelHour.sunshineDurationSec] is summed independently for
- * each model that reported sunshine on [date], and the arithmetic mean of
- * those per-model daily totals is returned in fractional hours. Summing
- * per-model first (rather than averaging the per-hour values across models
- * and then summing) keeps a model with only a partial hourly series from
- * silently dragging the consensus down — its missing hours don't get
- * counted as zero sunshine.
+ * At each hour of [date], [PerModelHour.sunshineDurationSec] is averaged
+ * over the models that reported it, and the per-hour means are summed into a
+ * daily total in fractional hours. Averaging hour-wise over the reporting
+ * models (rather than summing each model first and averaging the per-model
+ * totals) keeps a model with only a partial hourly series from silently
+ * dragging the consensus down — its missing hours don't get counted as zero
+ * sunshine. See [consensusPerModelAverage].
  *
  * Treats `best_match` like any other model, matching [blendConsensusHourly]'s
  * posture. With fewer than two models reporting any sunshine on [date],
@@ -34,10 +34,9 @@ fun PerModelHourly.consensusSunshineHoursFor(date: LocalDate): Double? =
  * (early-morning sun before the morning alarm) on the night view; this variant
  * sums the full slice instead.
  *
- * Same per-model-first averaging contract as [consensusSunshineHoursFor]:
- * each consulted model's hours are summed independently, the arithmetic mean
- * of those per-model totals is returned in fractional hours, and < 2 models
- * with any sunshine return null.
+ * Same hour-wise averaging contract as [consensusSunshineHoursFor]: each
+ * hour's mean over the reporting models is summed into a window total in
+ * fractional hours, and < 2 models with any sunshine return null.
  */
 fun PerModelHourly.consensusSunshineHours(): Double? =
     consensusPerModelAverage(dateFilter = null) { it.sunshineDurationSec }

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/DeliveryGates.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/DeliveryGates.kt
@@ -105,9 +105,10 @@ data class DeliveryGates(
  *
  * @param prefs preferences read once at the top of the worker run
  * @param period TODAY or TONIGHT — selects which delivery-mode applies
- * @param insightHasEvents true if the calendar has at least one event
- *   in this period's window. Only consulted on TONIGHT to evaluate
- *   `tonightNotifyOnlyOnEvents`.
+ * @param insightHasEvents true if the calendar has at least one
+ *   away-from-home event (non-all-day, with a location — see
+ *   [Insight.hasEvents]) in this period's window. Only consulted on
+ *   TONIGHT to evaluate `tonightNotifyOnlyOnEvents`.
  * @param geminiAvailable pre-computed: TTS engine = Gemini AND API
  *   key configured. The worker checks the keystore once and feeds
  *   that boolean in. A later synth failure inside the worker doesn't

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/DeriveInsight.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/DeriveInsight.kt
@@ -300,10 +300,12 @@ class DeriveInsight(
      *
      * Insulating tops are warmth-aware: an evening top is "extra" only when it's
      * warmer than the day's warmest top — wearing a jacket by day already implies
-     * the lighter layers under it, so a lighter evening top isn't worth
-     * mentioning. Warmth is [Garment.warmth], not the [Garment.Layer] band, so
-     * same-band upgrades still surface: a day `jacket` doesn't suppress a warmer
-     * evening `puffer`. The [Garment.Layer.OUTER] rain shell is the exception:
+     * the lighter layers under it, so a lighter (or equally warm) evening top
+     * isn't worth mentioning. Warmth is [Garment.warmth], which equals the
+     * garment's layer count, so the heavyweight shells (`jacket`, `coat`,
+     * `puffer` — all layer 3) tie: a day `jacket` keeps an evening `puffer`
+     * quiet, deliberately — "swap one shell for another" isn't an actionable
+     * evening tip. The [Garment.Layer.OUTER] rain shell is the exception:
      * it's keyed on rain, not warmth, so it's never gated by the warmth
      * comparison — a warm daytime top must not swallow the evening's required
      * rain jacket. It's additive instead, surfacing whenever the day's outfit

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/RenderInsightSummary.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/RenderInsightSummary.kt
@@ -48,8 +48,10 @@ import kotlin.math.roundToInt
  *    a noon synthesis from the day-level field — when per-model data isn't
  *    available; both fallbacks render as LIKELY (the existing behaviour).
  * 5. [CalendarTieInClause] — when clothes + precip both fired AND a calendar
- *    event overlaps the precip peak hour. Picks "umbrella" when on the clothes
- *    list, otherwise the first triggered item, mirroring rule 3's ordering.
+ *    event overlaps the precip peak hour. Names the first triggered item in
+ *    rule order, mirroring rule 3's ordering (no umbrella priority — the
+ *    formatter silences accessories, so see the inline comment where the
+ *    clause is built).
  *    **Only emitted on [ForecastPeriod.TONIGHT].** On TODAY the bare precip
  *    clause ("Rain at 3pm.") is enough — the listener already knows about
  *    their morning event, so chaining a tie-in just repeats what they heard.

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/model/ConsensusBlendTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/model/ConsensusBlendTest.kt
@@ -193,10 +193,11 @@ class ConsensusBlendTest {
 
     @Test
     fun `wind and uv are averaged across the candidates that reported them`() {
-        // best_match carries no wind / UV (the primary forecast call omits
-        // them — see OpenMeteoClient.asPerModelHours), so the blend averages
-        // only the consulted models. A lone best_match spike can't survive
-        // because it isn't a candidate for these fields.
+        // A model whose per-model entry carries null wind / UV (older cached
+        // payloads; model runs that omit the field) sits the hour out — here
+        // best_match's entry has neither, so the blend averages only the
+        // consulted models and a lone spike on the [HourlyForecast] side
+        // can't survive because it isn't a candidate for these fields.
         val best = listOf(hour(12, temp = 10.0, wind = 99.0, uv = 99.0))
         val perModel = PerModelHourly(
             byModel = mapOf(

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/model/OutfitSuggestionTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/model/OutfitSuggestionTest.kt
@@ -236,6 +236,33 @@ class OutfitSuggestionTest {
     }
 
     @Test
+    fun `firing pants rule picks LONG_PANTS over a SHORTS default`() {
+        // A user with a shorts default and a "pants below 15°C" rule: the prose
+        // names pants when the rule fires, so the icon must show long pants
+        // too rather than falling through to the shorts default.
+        val pantsRule = listOf(ClothesRule(Garment.PANTS, ClothesRule.TemperatureBelow(15.0)))
+        val outfit = OutfitSuggestion.fromForecast(
+            forecast(feelsLikeMin = 10.0, feelsLikeMax = 14.0),
+            pantsRule,
+            defaultBottom = OutfitSuggestion.Bottom.SHORTS,
+        )
+        outfit.bottom shouldBe OutfitSuggestion.Bottom.LONG_PANTS
+    }
+
+    @Test
+    fun `firing pants rule is cited by the bottom rationale`() {
+        // The "Why this outfit?" sheet should explain the day via the pants
+        // rule that decided it, not the un-crossed shorts threshold.
+        val pantsRule = listOf(ClothesRule(Garment.PANTS, ClothesRule.TemperatureBelow(15.0)))
+        val fact = OutfitSuggestion.explainFromForecast(
+            forecast(feelsLikeMin = 10.0, feelsLikeMax = 14.0),
+            pantsRule,
+        ).bottom.facts.single()
+        fact.ruleItem shouldBe Garment.PANTS
+        fact.thresholdC shouldBe 15.0
+    }
+
+    @Test
     fun `defaultBottom flips the fallback from LONG_PANTS to JEANS`() {
         // A denim-everyday user picks Jeans as their standard bottom. With no
         // jeans rule on file and a forecast that doesn't trigger shorts/skirt,

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/model/RainfallConsensusTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/model/RainfallConsensusTest.kt
@@ -104,10 +104,12 @@ class RainfallConsensusTest {
     }
 
     @Test
-    fun `partial null hours within a model still count toward its total`() {
-        // ecmwf has 1.0 + null = 1.0 mm total; gfs has 4.0 + 1.0 = 5.0 mm.
-        // Mean = 3.0 mm. A partial-null hour shouldn't drag the model's total
-        // to zero or disqualify it from the consensus.
+    fun `a model's missing hour drops out of that hour's mean, not counted as zero`() {
+        // Hour 10: mean(1.0, 4.0) = 2.5 mm. Hour 12: ecmwf didn't report, so
+        // gfs's 1.0 mm stands alone. Total = 3.5 mm. A per-model-totals mean
+        // would give (1.0 + 5.0) / 2 = 3.0 mm — arithmetically the same as
+        // counting ecmwf's missing hour as 0 mm, which is exactly the
+        // partial-series bias the hour-wise contract exists to avoid.
         val data = PerModelHourly(
             byModel = mapOf(
                 "ecmwf_ifs04" to listOf(
@@ -122,6 +124,6 @@ class RainfallConsensusTest {
         )
 
         val mm = data.consensusRainfallMmFor(today).shouldNotBeNull()
-        mm shouldBe (3.0 plusOrMinus 0.0001)
+        mm shouldBe (3.5 plusOrMinus 0.0001)
     }
 }

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/model/SunshineConsensusTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/model/SunshineConsensusTest.kt
@@ -104,10 +104,12 @@ class SunshineConsensusTest {
     }
 
     @Test
-    fun `partial null hours within a model still count toward its total`() {
-        // ecmwf has 1h + null = 1h total; gfs has 2h + 1h = 3h. Mean = 2h.
-        // A partial-null hour shouldn't drag the model's total to zero or
-        // disqualify it from the consensus.
+    fun `a model's missing hour drops out of that hour's mean, not counted as zero`() {
+        // Hour 10: mean(1h, 2h) = 1.5h. Hour 12: ecmwf didn't report, so
+        // gfs's 1h stands alone. Total = 2.5h. A per-model-totals mean would
+        // give (1h + 3h) / 2 = 2h — arithmetically the same as counting
+        // ecmwf's missing hour as zero sunshine, which is exactly the
+        // partial-series bias the hour-wise contract exists to avoid.
         val data = PerModelHourly(
             byModel = mapOf(
                 "ecmwf_ifs04" to listOf(
@@ -122,6 +124,6 @@ class SunshineConsensusTest {
         )
 
         val hours = data.consensusSunshineHoursFor(today).shouldNotBeNull()
-        hours shouldBe (2.0 plusOrMinus 0.0001)
+        hours shouldBe (2.5 plusOrMinus 0.0001)
     }
 }

--- a/core/parent-project/README.md
+++ b/core/parent-project/README.md
@@ -1,0 +1,13 @@
+# Why this directory exists
+
+This is the project directory for the synthetic intermediate `:core` project
+in the **inner** (sandbox-fallback) Gradle build rooted at `core/`.
+
+`core/settings.gradle.kts` includes `:core:domain` and `:core:data` so module
+paths match the outer build, which implicitly creates a parent `:core`
+project. Gradle 9 requires every project to have an existing directory and
+forbids two projects sharing one, so the parent can point neither at the
+nonexistent `core/core/` (its default) nor at `core/` itself (the inner
+build's root project). It points here instead.
+
+No build script lives here on purpose — the `:core` project carries nothing.

--- a/core/settings.gradle.kts
+++ b/core/settings.gradle.kts
@@ -42,5 +42,13 @@ rootProject.name = "core"
 
 include(":core:domain")
 include(":core:data")
+// The intermediate ":core" project exists only to give the leaf projects
+// their outer-build paths. Its default directory would be `core/` relative
+// to this settings root — i.e. the nonexistent `core/core/` — which Gradle 9
+// rejects at configuration time ("Configuring project ':core' without an
+// existing directory is not allowed"); it can't share this root directory
+// either ("Multiple projects in this build have project directory"). Park it
+// in a dedicated empty directory — it carries no build script either way.
+project(":core").projectDir = file("parent-project")
 project(":core:domain").projectDir = file("domain")
 project(":core:data").projectDir = file("data")


### PR DESCRIPTION
## Summary

A systematic bug hunt across all three modules (four parallel review passes: `:core:domain`, `:core:data`, app services, Compose UI), with the confirmed findings fixed. Nine commits, each scoped to one theme.

### Forecast correctness

- **Synthetic-zero best_match votes** (`OpenMeteoClient`): best_match's per-model series was built from the mapped `HourlyForecast` list, whose null hours the mapper zero-fills for the chart. At the 14-day horizon edge those fake 0 °C / 0 % values were averaged into the consensus blend as real votes. The series is now built from the wire payload with the same null policy as `MultiModelConfidenceFetcher.parseHourly` (drop the hour on null temp, keep precip null). Side effect: best_match now carries the primary call's wind/UV, so it votes in those consensuses and draws on the diagnostic charts (the old omission rested on a stale comment claiming the primary call doesn't fetch them — it does).
- **Rainfall/sunshine consensus undercounting** (`PerModelConsensus`): averaging per-model totals is arithmetically identical to counting a partial model's missing hours as zero — the exact bias the KDoc (in three files) claimed the design avoided. Switched to hour-wise mean over reporting models, then sum; the one test pinning the biased value was updated (3.0 mm → 3.5 mm for the partial-model scenario). **This changes the displayed "X mm of rain / Xh of sun" numbers when a model has a partial series** — flagging since it's a deliberate behavior change to match the documented intent.
- **Model-pruning substring match** (`MultiModelConfidenceFetcher`): a 400 naming `icon_d2_15min` would also prune a requested `icon_d2`. Now whole-id word-boundary matching.

### Charts

- **Per-model lines vs. range band misalignment**: commit 3816359 made the *band* hour-keyed but left every per-model *line* (and the diagnostic cards' consensus mean, the rainfall main line, and the "Peak X at H" subtitles) position-keyed — so exactly when a model drops an hour, lines drew one hour left of the band. Everything now resolves x positions by timestamp lookup against the chart's own hourly window, which also fixes the band drifting an hour off the main line on DST-transition weeks. Rendered output is unchanged in the common case; `ui.today` snapshot tests pass unmodified.

### Casting & scheduled delivery

- `ensureSession` leaked a `SessionManagerListener` on every session start (removed only on cancellation) — one per scheduled cast on the process-lifetime `SessionManager`. Now unregistered on every terminal callback, plus a re-check that closes a registration race causing spurious "did not respond in time" timeouts.
- `castCurrentInsight` converted `CancellationException` into a persisted "cast failed" Settings status when the user left mid-cast; now rethrown.
- `CastMediaServer.publish`/`stop` race (worker thread vs. main-thread `onSessionEnded`) could clear the token a fresh URL was just minted for; now synchronized.
- The notification and phone-speaker `launch`es in `deliver()`'s `supervisorScope` were unguarded — a child failure there reaches the default handler and kills the process. Both now follow the scope's documented best-effort-per-destination policy. A few `runCatching` sites that swallowed `CancellationException` now rethrow.

### Settings robustness & TTS

- One stored clothes rule with an unknown condition type (future-version write + downgrade) reset the **entire** rule list to defaults; unknown types now degrade per-item like unknown garments.
- The two schedule-time strings were the only unguarded parses in `toUserPreferences`; a corrupt value made the preferences flow throw on every emission (app-wide, unrecoverable). Now defaulted.
- `isRetryableGeminiTtsFailure` treated missing/invalid BYOK keys as transient, burning all synth retries with backoff before falling back to the device voice; both now fall back immediately.

### Smaller fixes

- **Activity leak + broken locale switch on Android 12/12L**: ViewModel factory lambdas captured the Activity; after rotation the VM held the destroyed instance and `recreate()` on it was a no-op. Factories now capture only the Application; the locale switch resolves the live Activity via a lifecycle-tracked weak reference.
- **Outfit icon ignored a firing `pants` rule** (no PANTS tier in `pickOutfit`) — prose said pants, icon showed the default bottom. Tier added, rationale cites the pants rule.
- **Inner sandbox build was broken under Gradle 9.4** (the synthetic `:core` project's directory must exist and can't be shared) — fixed with a dedicated `core/parent-project/` directory. The breakage was masked by piping gradlew output through `tail`.
- Four KDoc passages that stated the inverse of (intended, test-pinned) behavior corrected — doc-only.

## Findings reported but not fixed (judgment calls / need verification)

- `readModelDaily` hard-drops a model from the *daily confidence* when `precipitation_probability_max` is missing — asymmetric with the hourly path and possibly starving `gem_seamless` (in the default set) of a confidence vote. Needs verification against the live Open-Meteo API before softening.
- `ensureSession` stuck-route case: a MediaRouter-selected route with no connected session times out on every attempt (nothing re-initiates the session start). Needs a device to validate a fix safely.
- `CastMediaServer` port allocation is a TOCTOU (probe socket closed before Ktor binds), and the server speaks no Range/HEAD — playback works on the Default Media Receiver but seek/preflight degrade.
- 7-day diagnostic "Peak X at 2pm" subtitles don't say which day (the scrub readout does) — polish gap, matches existing "weekly subtitle is a follow-up" notes.

## Privacy

No change to what crosses the device boundary. The consensus-math changes alter locally computed numbers only; rendered insight prose composition is unchanged in structure.

## Test plan

- New regression tests: synthetic-zero blend votes + wind/UV passthrough (`OpenMeteoClientTest`), whole-id pruning (`MultiModelConfidenceFetcherTest`), non-retryable key failures (`GeminiTtsRetryClassifierTest`), hour-wise consensus (`RainfallConsensusTest`/`SunshineConsensusTest`), pants tier + rationale (`OutfitSuggestionTest`), unknown rule type (`SettingsRepositoryTest`), midnight wrap + DST window keying (`RangeBandTest`).
- `:core:domain:test` + `:core:data:test` green (outer and inner builds); `app.clothescast.ui.today.*` (333 tests incl. Roborazzi snapshots) green with snapshots unmodified. Full `:app:testDebugUnitTest` + `:app:assembleDebug` running locally; CI is the authoritative pass.

https://claude.ai/code/session_018MD6LyP3Am3FcED1NCBLw8

---
_Generated by [Claude Code](https://claude.ai/code/session_018MD6LyP3Am3FcED1NCBLw8)_