### PR TITLE
Bug hunt round two: seven fixes in pairing, manifest, tonight window, and charts

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -58,10 +58,16 @@
         android:name="android.permission.SCHEDULE_EXACT_ALARM"
         android:maxSdkVersion="32" />
 
-    <!-- TTS playback while backgrounded on Android 14+ requires a short foreground service.
-         A shortService FGS needs only FOREGROUND_SERVICE — there is no separate
-         FOREGROUND_SERVICE_SHORT_SERVICE permission. -->
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <!-- Package visibility (API 30+ filtering applies on every supported
+         device): the device-voice path constructs TextToSpeech engines and
+         enumerates voices (AndroidTtsEngine / AndroidTtsVoiceEnumerator),
+         which requires declaring the TTS_SERVICE intent or engine resolution
+         and getEngines()/voice listing silently come up empty. -->
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.TTS_SERVICE" />
+        </intent>
+    </queries>
 
     <application
         android:name=".ClothesCastApplication"
@@ -115,10 +121,13 @@
             </intent-filter>
         </receiver>
 
-        <!-- System broadcasts that should re-arm the daily alarm. -->
+        <!-- System broadcasts that should re-arm the daily alarm. All four
+             actions are protected system broadcasts, which the OS delivers
+             to unexported receivers — exported="false" just keeps other
+             apps from poking the receiver directly. -->
         <receiver
             android:name=".alarm.ScheduleRefreshReceiver"
-            android:exported="true">
+            android:exported="false">
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
                 <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />

--- a/app/src/main/kotlin/app/clothescast/ClothesCastApplication.kt
+++ b/app/src/main/kotlin/app/clothescast/ClothesCastApplication.kt
@@ -296,9 +296,11 @@ class ClothesCastApplication : Application() {
                 resumedActivity = WeakReference(activity)
             }
             override fun onActivityPaused(activity: Activity) {
-                // Identity check: a *new* Activity's onResume runs before the
-                // old one's onPause during a recreate, so clearing blindly
-                // would drop the fresh reference.
+                // Identity check rather than a blind clear: the standard
+                // ordering pauses the old Activity before resuming the new
+                // one, so a blind clear also works today — but the check
+                // costs nothing and stays correct if a future flow ever
+                // pauses an already-superseded instance late.
                 if (resumedActivity?.get() === activity) resumedActivity = null
             }
             override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {}

--- a/app/src/main/kotlin/app/clothescast/insight/InsightFormatter.kt
+++ b/app/src/main/kotlin/app/clothescast/insight/InsightFormatter.kt
@@ -665,9 +665,11 @@ class InsightFormatter(
     private fun formatPrecip(precip: PrecipClause, accessoryKey: String?): String {
         val rawType = resources.getString(conditionRes(precip.condition))
         // The accessory is rain-keyed by name ("Rain accessory: Umbrella");
-        // gate it to RAIN / DRIZZLE so "Snow, bring an umbrella." doesn't slip
-        // through. THUNDERSTORM is intentionally excluded too — an umbrella
-        // under lightning is bad practice.
+        // gate it on [warrantsRainAccessory] — RAIN / DRIZZLE / THUNDERSTORM —
+        // so "Snow, bring an umbrella." doesn't slip through. Thunderstorm
+        // deliberately keeps the umbrella (see warrantsRainAccessory's KDoc:
+        // a thunderstorm forecast is still a wet one), matching the rule
+        // engine so the prose and the outfit icon can't drift.
         val accessoryPhrase = accessoryKey
             ?.takeIf { precip.condition.warrantsRainAccessory() }
             ?.let(phraser::withArticle)
@@ -722,14 +724,14 @@ class InsightFormatter(
         // the same reason they're silenced in the main wear-list: until the
         // accessory catalog lands we only name temperature-driven clothing
         // there. If the user has opted into the umbrella rule and the evening's
-        // peak condition is rain-like (RAIN / DRIZZLE), we re-inject the
-        // chosen accessory below so the existing insight_tie_in_with_rain
-        // template carries it ("…, bring a jacket and an umbrella.") and the
-        // bare-rain path is promoted to the item-led template. SNOW /
-        // THUNDERSTORM peaks (or a null condition on a pre-field cached
-        // payload) skip the injection — same gating as formatPrecip — so
-        // "Tonight, rain at 9pm, bring an umbrella." doesn't slip out when
-        // the underlying peak is actually snow.
+        // peak condition warrants one (RAIN / DRIZZLE / THUNDERSTORM — see
+        // [warrantsRainAccessory]), we re-inject the chosen accessory below so
+        // the existing insight_tie_in_with_rain template carries it ("…, bring
+        // a jacket and an umbrella.") and the bare-rain path is promoted to
+        // the item-led template. SNOW peaks (or a null condition on a
+        // pre-field cached payload) skip the injection — same gating as
+        // formatPrecip — so "Tonight, rain at 9pm, bring an umbrella."
+        // doesn't slip out when the underlying peak is actually snow.
         val filteredItems = tieIn.items.filterNot(::isAccessory)
         // The carried accessory rides in on the tie-in's own items (the fired
         // umbrella rule).
@@ -823,18 +825,22 @@ class InsightFormatter(
     fun formatWeekAhead(insight: WeekAheadInsight): String {
         // (sortKey, phrase). Persistence has no date and sorts first; the
         // remaining clauses sort by date. Phrases are stripped of their
-        // trailing "." so we can join with the locale separator and append a
-        // single final period — this relies on every today_week_ahead_*
-        // template ending in a literal ".". If a locale needs different
-        // terminal punctuation, split into terminal / non-terminal templates.
+        // trailing full stop so we can join with the locale separator and
+        // append a single final one — every today_week_ahead_* template ends
+        // in a literal "." or, in CJK locales, the ideographic "。"; the
+        // final terminator re-applies whichever the templates used, so a
+        // Japanese headline doesn't end in a stray ASCII period (or keep
+        // mid-sentence 。 the join was supposed to strip).
         val clauses = mutableListOf<Pair<LocalDate?, String>>()
         insight.persistence?.let { clauses += null to renderClause(it) }
         insight.firstWarmer?.let { clauses += clauseDate(it) to renderClause(it) }
         insight.firstCooler?.let { clauses += clauseDate(it) to renderClause(it) }
         insight.rain?.let { clauses += clauseDate(it) to renderClause(it) }
-        val sorted = clauses
+        val rawPhrases = clauses
             .sortedWith(compareBy(nullsFirst()) { it.first })
-            .map { it.second.trimEnd('.') }
+            .map { it.second }
+        val terminator = if (rawPhrases.any { it.endsWith("。") }) "。" else "."
+        val sorted = rawPhrases.map { it.trimEnd('.', '。') }
         // Lowercase the first letter of each non-leading clause so the joined
         // sentence reads naturally ("…, cooler Sunday." rather than "…,
         // Cooler Sunday."). Templates are authored with a sentence-leading
@@ -846,7 +852,7 @@ class InsightFormatter(
             if (index == 0) phrase else phrase.replaceFirstChar { it.lowercase(locale) }
         }
         val separator = resources.getString(R.string.today_week_ahead_separator)
-        return joined.joinToString(separator = separator, postfix = ".")
+        return joined.joinToString(separator = separator, postfix = terminator)
     }
 
     private fun renderClause(clause: WeekAheadClause): String = when (clause) {

--- a/app/src/main/kotlin/app/clothescast/pairing/PairingServer.kt
+++ b/app/src/main/kotlin/app/clothescast/pairing/PairingServer.kt
@@ -26,8 +26,12 @@ import java.security.SecureRandom
  *
  * Security:
  *   - The random hex [token] in the URL path is the only shared secret; it's never logged.
- *   - The server only processes the first valid POST — subsequent POSTs with the same token
- *     return an "already used" page and do not call [onKeyReceived] again.
+ *   - Every valid POST with the token calls [onKeyReceived]; the last submission wins.
+ *     Deliberate: a user who pastes a truncated key and notices the TV's voice failing
+ *     can go back and resubmit the corrected key in the same session — the previous
+ *     single-shot behavior answered "Done!" while silently keeping the wrong key. The
+ *     token gates who can submit at all, and the callback's persist is idempotent, so
+ *     accepting overwrites within the session costs nothing.
  *   - The server is only reachable from the local network (LAN). It is the caller's
  *     responsibility to call [stop] promptly after success or timeout.
  */
@@ -37,7 +41,6 @@ class PairingServer(
     val token: String = generateToken()
 
     private var server: EmbeddedServer<*, *>? = null
-    private var claimed = false
 
     /**
      * Starts the HTTP server on an available local port and returns that port.
@@ -57,11 +60,10 @@ class PairingServer(
                         call.respondText(htmlForm(error = true), ContentType.Text.Html)
                         return@post
                     }
+                    // Serialize concurrent POSTs so callback invocations don't
+                    // interleave; last submission wins (see the class doc).
                     synchronized(this@PairingServer) {
-                        if (!claimed) {
-                            claimed = true
-                            onKeyReceived(key)
-                        }
+                        onKeyReceived(key)
                     }
                     call.respondText(htmlSuccess(), ContentType.Text.Html)
                 }

--- a/app/src/main/kotlin/app/clothescast/ui/today/ForecastChart.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/ForecastChart.kt
@@ -154,7 +154,14 @@ fun ForecastChart(
     val indexByTime = remember(hourly, startDate) { hourlyTimestampIndices(hourly, startDate) }
     val overlays = perModelHourly?.byModel.orEmpty()
     val visibleModels = if (showModelSpread) {
-        MODEL_DRAW_ORDER.filter { it in overlays }
+        // Only models with at least one point inside this chart's window.
+        // [rememberPinnedLineProvider] assigns line colors by position in
+        // this list against the series emitted below, so the two must stay
+        // in lockstep — emitting fewer series than entries here would shift
+        // every later model onto the wrong color.
+        MODEL_DRAW_ORDER.filter { modelId ->
+            overlays[modelId].orEmpty().any { it.time in indexByTime }
+        }
     } else {
         emptyList()
     }
@@ -196,13 +203,11 @@ fun ForecastChart(
                         val points = entries.mapNotNull { e ->
                             indexByTime[e.time]?.let { it to pickModel(e).toUnit(temperatureUnit) }
                         }
-                        // Vico rejects an empty series; a model entirely
-                        // outside the window (shouldn't happen — per-model
-                        // data rides the same fetch as [hourly]) is skipped
-                        // rather than crashing the chart.
-                        if (points.isNotEmpty()) {
-                            series(x = points.map { it.first }, y = points.map { it.second })
-                        }
+                        // Never empty: [visibleModels] is pre-filtered to
+                        // models with ≥1 in-window point, which keeps the
+                        // emitted series count equal to the line provider's
+                        // color list (and Vico rejects an empty series).
+                        series(x = points.map { it.first }, y = points.map { it.second })
                     }
                 }
             }

--- a/app/src/main/kotlin/app/clothescast/ui/today/PrecipitationAmountChart.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/PrecipitationAmountChart.kt
@@ -61,9 +61,14 @@ fun PrecipitationAmountChart(
     // (dropped per-model hours, DST weeks where position ≠ naive hour offset).
     val indexByTime = remember(hourly, startDate) { hourlyTimestampIndices(hourly, startDate) }
     val overlays = perModelHourly?.byModel.orEmpty()
+    // Only models with ≥1 plottable point (non-null mm, inside this chart's
+    // window): the pinned line provider assigns colors by position in this
+    // list against the series emitted below, so the two must stay in lockstep.
     val visibleModels = if (showModelSpread) {
         MODEL_DRAW_ORDER.filter { modelId ->
-            overlays[modelId]?.any { it.precipitationMm != null } == true
+            overlays[modelId].orEmpty().any {
+                it.precipitationMm != null && it.time in indexByTime
+            }
         }
     } else {
         emptyList()
@@ -88,13 +93,11 @@ fun PrecipitationAmountChart(
                             val idx = indexByTime[e.time] ?: return@mapNotNull null
                             e.precipitationMm?.let { idx to it }
                         }
-                        // Vico rejects an empty series; a model entirely
-                        // outside the window (shouldn't happen — per-model
-                        // data rides the same fetch as [hourly]) is skipped
-                        // rather than crashing the chart.
-                        if (points.isNotEmpty()) {
-                            series(x = points.map { it.first }, y = points.map { it.second })
-                        }
+                        // Never empty: [visibleModels] is pre-filtered to
+                        // models with ≥1 plottable in-window point, keeping
+                        // the emitted series count equal to the line
+                        // provider's color list (Vico rejects empty series).
+                        series(x = points.map { it.first }, y = points.map { it.second })
                     }
                 }
             }

--- a/app/src/main/kotlin/app/clothescast/ui/today/PrecipitationChart.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/PrecipitationChart.kt
@@ -61,14 +61,20 @@ fun PrecipitationChart(
     // DST weeks where position ≠ naive hour offset).
     val indexByTime = remember(hourly, startDate) { hourlyTimestampIndices(hourly, startDate) }
     val overlays = perModelHourly?.byModel.orEmpty()
-    // A model whose precip series is all-null (Open-Meteo doesn't expose
-    // `precipitation_probability_<model>` for it) has nothing to plot on
-    // this chart — skip it so we don't draw an empty Vico series and the
-    // legend doesn't list a phantom line. The model still appears on the
-    // temperature chart via [ForecastChart], which only needs air-temp.
+    // A model with no plottable point on this chart — precip series all-null
+    // (Open-Meteo doesn't expose `precipitation_probability_<model>` for it)
+    // or no entry inside this chart's window — is skipped so we don't draw an
+    // empty Vico series and the legend doesn't list a phantom line. The
+    // window check keeps this list in lockstep with the series emitted below:
+    // the pinned line provider assigns colors by position, so emitting fewer
+    // series than entries here would shift later models onto the wrong
+    // color. The model still appears on the temperature chart via
+    // [ForecastChart], which only needs air-temp.
     val visibleModels = if (showModelSpread) {
         MODEL_DRAW_ORDER.filter { modelId ->
-            overlays[modelId]?.any { it.precipitationProbabilityPct != null } == true
+            overlays[modelId].orEmpty().any {
+                it.precipitationProbabilityPct != null && it.time in indexByTime
+            }
         }
     } else {
         emptyList()
@@ -111,13 +117,11 @@ fun PrecipitationChart(
                             val idx = indexByTime[e.time] ?: return@mapNotNull null
                             e.precipitationProbabilityPct?.let { idx to it }
                         }
-                        // Vico rejects an empty series; a model entirely
-                        // outside the window (shouldn't happen — per-model
-                        // data rides the same fetch as [hourly]) is skipped
-                        // rather than crashing the chart.
-                        if (points.isNotEmpty()) {
-                            series(x = points.map { it.first }, y = points.map { it.second })
-                        }
+                        // Never empty: [visibleModels] is pre-filtered to
+                        // models with ≥1 plottable in-window point, keeping
+                        // the emitted series count equal to the line
+                        // provider's color list (Vico rejects empty series).
+                        series(x = points.map { it.first }, y = points.map { it.second })
                     }
                 }
             }

--- a/app/src/test/kotlin/app/clothescast/insight/InsightFormatterTest.kt
+++ b/app/src/test/kotlin/app/clothescast/insight/InsightFormatterTest.kt
@@ -1431,18 +1431,22 @@ class InsightFormatterTest {
     }
 
     @Test
-    fun `umbrella accessory is suppressed in the evening tie-in when the peak is thunderstorm`() {
-        // No umbrella under lightning, but the clause still names the real
-        // condition ("thunderstorm") rather than mislabelling it "rain".
+    fun `umbrella accessory rides the evening tie-in when the peak is thunderstorm`() {
+        // warrantsRainAccessory deliberately includes THUNDERSTORM — a
+        // thunderstorm forecast is still a wet one — so the tie-in carries
+        // the umbrella the same way the main precip clause does, and the
+        // clause names the real condition rather than mislabelling it
+        // "rain". (An earlier version of this test asserted suppression but
+        // passed vacuously: its items list carried no umbrella to suppress.)
         umbrellaSubject.format(
             summary(
                 eveningEventTieIn = EveningEventTieInClause(
-                    items = listOf("jacket"),
+                    items = listOf("jacket", "umbrella"),
                     rainTime = LocalTime.of(21, 0),
                     precipCondition = WeatherCondition.THUNDERSTORM,
                 ),
             ),
-        ) shouldBe "Today, it will be 21°. Tonight, thunderstorm tonight, bring a jacket."
+        ) shouldBe "Today, it will be 21°. Tonight, thunderstorm tonight, bring a jacket and umbrella."
     }
 
     @Test
@@ -2012,6 +2016,42 @@ class InsightFormatterTest {
             ),
         )
         out shouldBe "Today, it will be 21°. Tonight, rain tonight."
+    }
+
+    @Test
+    fun `ja — week-ahead headline keeps the ideographic full stop, no stray ASCII period`() {
+        // values-ja templates end in "。"; the join must strip those and
+        // re-terminate with "。" — not render "明日は雨。." (solo) or keep a
+        // mid-sentence 。 ahead of the separator (multi-clause).
+        val jaConfig = Configuration(context.resources.configuration).apply {
+            setLocale(Locale.JAPAN)
+        }
+        val jaContext = context.createConfigurationContext(jaConfig)
+        val ja = InsightFormatter.forRegion(jaContext, Region.SYSTEM)
+
+        ja.formatWeekAhead(
+            WeekAheadInsight(
+                rain = WeekAheadClause.Rain(
+                    date = LocalDate.of(2026, 5, 27),
+                    isTomorrow = true,
+                    condition = WeatherCondition.RAIN,
+                ),
+            ),
+        ) shouldBe "明日は雨。"
+
+        ja.formatWeekAhead(
+            WeekAheadInsight(
+                firstCooler = WeekAheadClause.Cooler(
+                    date = LocalDate.of(2026, 5, 27),
+                    isTomorrow = true,
+                ),
+                rain = WeekAheadClause.Rain(
+                    date = LocalDate.of(2026, 6, 1), // Monday
+                    isTomorrow = false,
+                    condition = WeatherCondition.RAIN,
+                ),
+            ),
+        ) shouldBe "明日は涼しめ, 月曜日は雨。"
     }
 
     @Test

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/CalendarEvent.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/CalendarEvent.kt
@@ -44,10 +44,21 @@ data class CalendarEvent(
      * True when [time] falls within `[start, end)`. All-day events never
      * match, so the precip-peak overlap check never accidentally pairs an
      * umbrella with "your all-day Public holiday".
+     *
+     * [start]/[end] are date-less wall-clock times, so an event that crosses
+     * midnight projects with `end < start` (a 21:00–00:30 gig reads as
+     * start 21:00, end 00:30). Treat that as a wrapped interval — inside is
+     * `time >= start || time < end` — rather than an empty one, or the
+     * late-evening events the tonight tie-in exists for would never overlap
+     * any peak hour.
      */
     fun overlaps(time: LocalTime): Boolean {
         if (allDay) return false
         if (start == end) return time == start
-        return !time.isBefore(start) && time.isBefore(end)
+        return if (end.isBefore(start)) {
+            !time.isBefore(start) || time.isBefore(end)
+        } else {
+            !time.isBefore(start) && time.isBefore(end)
+        }
     }
 }

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/PerModelConsensus.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/PerModelConsensus.kt
@@ -30,15 +30,23 @@ internal fun PerModelHourly.consensusPerModelAverage(
     dateFilter: LocalDate?,
     select: (PerModelHour) -> Double?,
 ): Double? {
-    val perModelValues = byModel.values.map { entries ->
+    // Per model: sum values per wall-clock timestamp first. Normally that's
+    // a no-op (one entry per hour), but on the DST fall-back day Open-Meteo's
+    // local-time array repeats an hour and both physical hours land on the
+    // same LocalDateTime — summing them keeps the model's 25-hour physical
+    // total intact and stops a model with two entries from double-voting
+    // that hour's cross-model mean against models with one.
+    val perModelByHour = byModel.values.map { entries ->
         entries
             .filter { dateFilter == null || it.time.toLocalDate() == dateFilter }
             .mapNotNull { entry -> select(entry)?.let { entry.time to it } }
+            .groupBy({ it.first }, { it.second })
+            .mapValues { (_, values) -> values.sum() }
     }.filter { it.isNotEmpty() }
-    if (perModelValues.size < 2) return null
-    return perModelValues
-        .flatten()
-        .groupBy({ it.first }, { it.second })
+    if (perModelByHour.size < 2) return null
+    return perModelByHour
+        .flatMap { it.entries }
+        .groupBy({ it.key }, { it.value })
         .values
         .sumOf { it.average() }
 }

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/DeriveInsight.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/DeriveInsight.kt
@@ -361,7 +361,19 @@ class DeriveInsight(
         tonightStart: LocalTime,
     ): List<CalendarEvent> = when (period) {
         ForecastPeriod.TODAY -> events
-        ForecastPeriod.TONIGHT -> events.filter { it.allDay || !it.start.isBefore(tonightStart) }
+        // Keep any event that overlaps the night window, not just those that
+        // *start* inside it: an 18:30–21:30 dinner straddles a 19:00 tonight
+        // start, and excluding it made the 7pm notification silent (hasEvents
+        // false) and hid the away-from-home tie-in even though the user is
+        // out for most of the evening. `end <= start` means the event crosses
+        // midnight (date-less wall-clock times), which always reaches into
+        // the night window.
+        ForecastPeriod.TONIGHT -> events.filter {
+            it.allDay ||
+                !it.start.isBefore(tonightStart) ||
+                it.end.isAfter(tonightStart) ||
+                it.end.isBefore(it.start)
+        }
     }
 
     private data class PeriodView(
@@ -401,13 +413,25 @@ internal fun ForecastBundle.shiftedToTomorrow(): ForecastBundle? {
     )
 }
 
+/**
+ * Restricts each model's series to the hours in [window], keeping whatever
+ * subset of the window a model reported. A model with gaps stays in — every
+ * consumer is sparse-safe: the charts position points by timestamp lookup
+ * (not list position), and [RenderInsightSummary.pickPerModelPeak] counts
+ * per-hour reporters by design. The previous behavior evicted a model
+ * missing even one window hour, which starved the rain-tier majority logic
+ * of exactly the warming-up models its sparse handling exists for — and
+ * when *every* model had a gap, collapsed the overlay to null, dropping the
+ * confidence chip and downgrading the precip clause to the base-hourly
+ * fallback. Models with nothing in the window drop out entirely (ICON past
+ * day 7); null when none remain.
+ */
 internal fun PerModelHourly.slicedTo(window: List<LocalDateTime>): PerModelHourly? {
     if (window.isEmpty()) return null
-    val filtered = byModel.mapNotNull { (model, entries) ->
-        val byTime = entries.associateBy { it.time }
-        val sliced = window.map { byTime[it] ?: return@mapNotNull null }
-        model to sliced
-    }.toMap()
+    val windowSet = window.toSet()
+    val filtered = byModel
+        .mapValues { (_, entries) -> entries.filter { it.time in windowSet } }
+        .filterValues { it.isNotEmpty() }
     return if (filtered.isEmpty()) null else PerModelHourly(filtered)
 }
 

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/model/CalendarEventTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/model/CalendarEventTest.kt
@@ -1,0 +1,52 @@
+package app.clothescast.core.domain.model
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import java.time.LocalTime
+
+class CalendarEventTest {
+
+    private fun event(start: LocalTime, end: LocalTime, allDay: Boolean = false) =
+        CalendarEvent(title = "gig", start = start, end = end, allDay = allDay)
+
+    @Test
+    fun `overlaps is a half-open interval for a same-day event`() {
+        val e = event(LocalTime.of(20, 0), LocalTime.of(22, 0))
+        e.overlaps(LocalTime.of(19, 59)) shouldBe false
+        e.overlaps(LocalTime.of(20, 0)) shouldBe true
+        e.overlaps(LocalTime.of(21, 30)) shouldBe true
+        e.overlaps(LocalTime.of(22, 0)) shouldBe false
+    }
+
+    @Test
+    fun `midnight-crossing event overlaps both sides of midnight`() {
+        // start/end are date-less wall-clock times, so a 21:00-00:30 gig
+        // projects with end < start. It must read as a wrapped interval —
+        // the late-evening events the tonight tie-in exists for would
+        // otherwise never overlap any peak hour.
+        val gig = event(LocalTime.of(21, 0), LocalTime.of(0, 30))
+        gig.overlaps(LocalTime.of(20, 59)) shouldBe false
+        gig.overlaps(LocalTime.of(21, 0)) shouldBe true
+        gig.overlaps(LocalTime.of(23, 0)) shouldBe true
+        gig.overlaps(LocalTime.MIDNIGHT) shouldBe true
+        gig.overlaps(LocalTime.of(0, 29)) shouldBe true
+        gig.overlaps(LocalTime.of(0, 30)) shouldBe false
+        gig.overlaps(LocalTime.of(12, 0)) shouldBe false
+    }
+
+    @Test
+    fun `event ending exactly at midnight covers the evening only`() {
+        // end = 00:00 reads as "until midnight", not an empty interval.
+        val e = event(LocalTime.of(21, 0), LocalTime.MIDNIGHT)
+        e.overlaps(LocalTime.of(23, 0)) shouldBe true
+        e.overlaps(LocalTime.MIDNIGHT) shouldBe false
+        e.overlaps(LocalTime.of(20, 0)) shouldBe false
+    }
+
+    @Test
+    fun `all-day events never overlap`() {
+        val e = event(LocalTime.MIDNIGHT, LocalTime.MIDNIGHT, allDay = true)
+        e.overlaps(LocalTime.of(12, 0)) shouldBe false
+        e.overlaps(LocalTime.MIDNIGHT) shouldBe false
+    }
+}

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/model/RainfallConsensusTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/model/RainfallConsensusTest.kt
@@ -104,6 +104,30 @@ class RainfallConsensusTest {
     }
 
     @Test
+    fun `DST fall-back duplicate timestamps sum within a model, not double-vote the mean`() {
+        // On the 25-hour fall-back day Open-Meteo's local-time array repeats
+        // a wall-clock hour; both physical hours carry the same LocalDateTime.
+        // Each model's duplicates sum into that hour's value (1.0 + 2.0 = 3.0
+        // for ecmwf), keeping the physical total, and then the hour's mean is
+        // one vote per model: mean(3.0, 1.0) = 2.0 — not a 3-way mean where
+        // ecmwf votes twice.
+        val data = PerModelHourly(
+            byModel = mapOf(
+                "ecmwf_ifs04" to listOf(
+                    entry(today, 2, 1.0),
+                    entry(today, 2, 2.0),
+                ),
+                "gfs_seamless" to listOf(
+                    entry(today, 2, 1.0),
+                ),
+            ),
+        )
+
+        val mm = data.consensusRainfallMmFor(today).shouldNotBeNull()
+        mm shouldBe (2.0 plusOrMinus 0.0001)
+    }
+
+    @Test
     fun `a model's missing hour drops out of that hour's mean, not counted as zero`() {
         // Hour 10: mean(1.0, 4.0) = 2.5 mm. Hour 12: ecmwf didn't report, so
         // gfs's 1.0 mm stands alone. Total = 3.5 mm. A per-model-totals mean

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsightTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsightTest.kt
@@ -735,19 +735,21 @@ class GenerateDailyInsightTest {
     }
 
     @Test
-    fun `model with a missing in-window hour is dropped from the overlay`() = runTest {
+    fun `model with a missing in-window hour keeps its surviving hours in the overlay`() = runTest {
         // parseHourly drops the per-hour entry for a model whose run hasn't
-        // landed that hour (temp or precip null); the resulting series has a
-        // gap that, if surfaced, would compact the surviving points left and
-        // misalign the line with the blended hourly. Keep the model out of
-        // the overlay entirely rather than draw a silently-shifted curve.
+        // landed that hour (temp or precip null). The sparse model stays in
+        // the overlay with the hours it did report: the charts position
+        // points by timestamp lookup (a gap renders as a gap, not a shifted
+        // curve) and pickPerModelPeak counts per-hour reporters by design —
+        // evicting the whole model starved the rain-tier majority of exactly
+        // the warming-up models the sparse handling exists for.
         val daytime = listOf(
             HourlyForecast(LocalTime.of(8, 0), 12.0, 11.0, 10.0, WeatherCondition.CLEAR),
             HourlyForecast(LocalTime.of(12, 0), 18.0, 17.0, 30.0, WeatherCondition.CLEAR),
             HourlyForecast(LocalTime.of(15, 0), 22.0, 21.0, 40.0, WeatherCondition.CLEAR),
         )
         val incompleteEcmwf = listOf(
-            // 12:00 hour missing — the model is dropped from the overlay.
+            // 12:00 hour missing — the model keeps its 8:00 and 15:00 entries.
             PerModelHour(LocalDateTime.of(today.date, LocalTime.of(8, 0)), 11.5, 12.5, 9.0),
             PerModelHour(LocalDateTime.of(today.date, LocalTime.of(15, 0)), 21.5, 22.5, 38.0),
         )
@@ -770,7 +772,9 @@ class GenerateDailyInsightTest {
 
         val overlay = subject(london, prefs, ForecastPeriod.TODAY).insight.perModelHourly
             .shouldNotBeNull()
-        overlay.byModel.keys shouldContainExactlyInAnyOrder listOf("gfs_seamless")
+        overlay.byModel.keys shouldContainExactlyInAnyOrder listOf("ecmwf_ifs04", "gfs_seamless")
+        overlay.byModel.getValue("ecmwf_ifs04").map { it.time.toLocalTime() } shouldBe
+            listOf(LocalTime.of(8, 0), LocalTime.of(15, 0))
         overlay.byModel.getValue("gfs_seamless").map { it.time.toLocalTime() } shouldBe daytime.map { it.time }
     }
 
@@ -1943,6 +1947,57 @@ class GenerateDailyInsightTest {
         )
 
         result.insight.hasEvents shouldBe false
+    }
+
+    @Test
+    fun `tonight hasEvents is true for a located event straddling the tonight start`() = runTest {
+        // An 18:30-21:30 dinner overlaps most of the night window even
+        // though it *starts* before the 19:00 tonight boundary. The old
+        // start-keyed filter dropped it, posting the 7pm notification
+        // silently while the user was out.
+        val zone = ZoneId.of("Europe/London")
+        val dinner = CalendarEvent(
+            title = "dinner",
+            start = LocalTime.of(18, 30),
+            end = LocalTime.of(21, 30),
+            location = "City A",
+        )
+        val weather = FakeWeatherRepository(ForecastBundle(today, yesterday))
+        val calendar = FakeCalendarEventReader(events = listOf(dinner))
+        val subject = GenerateDailyInsight(weather, calendarEventReader = calendar, clock = clock)
+
+        val result = subject(
+            location = london,
+            prefs = prefs.copy(useCalendarEvents = true, schedule = Schedule.default(zone)),
+            period = ForecastPeriod.TONIGHT,
+        )
+
+        result.insight.hasEvents shouldBe true
+    }
+
+    @Test
+    fun `tonight hasEvents is true for a located event crossing midnight`() = runTest {
+        // A 21:00-00:30 gig projects with end < start (date-less wall-clock
+        // times). The crossing must read as reaching into the night window,
+        // not as an empty interval.
+        val zone = ZoneId.of("Europe/London")
+        val gig = CalendarEvent(
+            title = "gig",
+            start = LocalTime.of(21, 0),
+            end = LocalTime.of(0, 30),
+            location = "City A",
+        )
+        val weather = FakeWeatherRepository(ForecastBundle(today, yesterday))
+        val calendar = FakeCalendarEventReader(events = listOf(gig))
+        val subject = GenerateDailyInsight(weather, calendarEventReader = calendar, clock = clock)
+
+        val result = subject(
+            location = london,
+            prefs = prefs.copy(useCalendarEvents = true, schedule = Schedule.default(zone)),
+            period = ForecastPeriod.TONIGHT,
+        )
+
+        result.insight.hasEvents shouldBe true
     }
 
     @Test


### PR DESCRIPTION
## Summary

Second bug-hunt pass, targeting what round one (#1008) didn't cover: the packages the first sweep skipped (pairing, manifest, variant source sets, resources, CI), an end-to-end trace of the insight pipeline for cross-component contract mismatches, and an adversarial review of round one's own merged fixes.

### Field-visible fixes

- **Device-voice picker could come up empty** (`AndroidManifest.xml`): no `<queries>` declaration for `TTS_SERVICE` — package-visibility filtering applies on every supported API level (minSdk 31), so `TextToSpeech` engine resolution and voice enumeration could silently fail. Also dropped the `FOREGROUND_SERVICE` permission (no Service exists anywhere in the app — the comment described a mechanism never implemented) and unexported `ScheduleRefreshReceiver` (its actions are protected system broadcasts; exported only let other apps poke it).
- **TV pairing discarded a corrected API key**: the pairing page accepted only the first POST and answered "Done!" to every later one while silently keeping the wrong key. Resubmission within the session now overwrites (token still gates access; the persist callback is idempotent).
- **Tonight window missed straddling and midnight-crossing events**: the event filter was start-keyed (an 18:30–21:30 dinner overlapping the 19:00–07:00 window was dropped → silent 7pm notification, no away-from-home tie-in), and `CalendarEvent.overlaps` treated a midnight-crossing event (`end < start`, date-less wall-clock times) as an empty interval — the late-evening gigs the tonight tie-in exists for could never match a rain peak.
- **`slicedTo` evicted a model from the rendered per-model view on one missing window hour** — starving `pickPerModelPeak`'s sparse-by-design majority logic, and (after round one made best_match no longer zero-filled) able to drop best_match's vote or collapse the whole overlay to null, losing the confidence chip. Models now keep whatever subset of the window they reported; all consumers are sparse-safe.
- **Japanese/Chinese weekly headlines rendered stray periods**: `trimEnd('.')` didn't strip the ideographic `。` the ja/zh templates end with, producing `明日は雨。.` — the join now re-terminates with whichever form the templates used.
- **DST fall-back day undercounted rain/sunshine totals**: the duplicated wall-clock hour collapsed into one consensus bucket (losing a physical hour) and let a model double-vote that hour's mean. Duplicates now sum per model first.
- **Chart line colors could shift onto the wrong model**: charts skip empty Vico series but the pinned line provider assigns colors by position against the unfiltered model list. Latent (production slices to the window first), now structurally fixed by pre-filtering the visible-model list.

### Comment/test-integrity fixes

- Two formatter comments claimed the umbrella is suppressed under thunderstorm; `warrantsRainAccessory` deliberately includes THUNDERSTORM and the main-clause test pins it. The tie-in test that "pinned" suppression passed vacuously (no umbrella in its items list) — rewritten to pin the real policy.
- A backwards Activity-lifecycle-ordering claim in `ClothesCastApplication` corrected (behavior was fine).

## Reported, not fixed

- **~46 translations drop the "tonight vs. overnight" rain-timing word**: four `insight_*rain*` strings omit the `coarseRainWhen()` argument in most locales (authored against an older 2-arg template?), so a 2am peak reads "Ce soir, pluie." instead of distinguishing overnight. No crash risk (unused args are tolerated; all locales machine-checked for index/type mismatches — zero found). Needs a proper translation pass, not mechanical editing in 46 languages.
- **Tonight calendar events are only fetched for today's date** and `CalendarEvent` carries date-less times, so a located 00:30 event entered on tomorrow's date is invisible to tonight's gates. Needs a model change (dated event times).
- `blendConsensusHourly` falls back to the mapper's zero-filled best_match entry at hours with exactly one consulted reporter (horizon-edge, days 8–14) — the root cause is the mapper's null→0.0 fill, which deserves its own change (it's chart-load-bearing).
- Manual remote locations mix the device zone (events) with the forecast zone (precip peaks) in `overlaps()` comparisons; pre-existing, acknowledged in `Insight.forecastZone`'s KDoc.
- Stale prose docs: `PrecipClause`/CLAUDE.md examples still show "rain at 9pm" wording the formatter deliberately no longer emits.
- `NsdHomeAssistantDiscovery` can re-insert a lost service via a pending resolve (narrow window); `PairingServer`/`CastMediaServer` port probes are TOCTOU; two `ci.yml` nits (snapshot-prune glob fragility, `.md` path filter broader than documented, `cancel-in-progress` can skip a main publish between FAD and Play upload).

## Privacy

No change to what crosses the device boundary. The pairing change accepts repeated submissions of the user's own key on the same LAN session; the token gate is unchanged.

## Test plan

New tests: `CalendarEventTest` (wrap/half-open/midnight-end), straddling + midnight-crossing `hasEvents` cases in `GenerateDailyInsightTest`, the `slicedTo` sparse-keep expectation, DST duplicate-timestamp consensus in `RainfallConsensusTest`, the ja week-ahead headline, and the de-vacuoused thunderstorm tie-in test. Full local run of `:core:domain:test` + `:core:data:test` + `:app:testDebugUnitTest` + `:app:assembleDebug` in flight; CI is the authoritative pass.

https://claude.ai/code/session_018MD6LyP3Am3FcED1NCBLw8

---
_Generated by [Claude Code](https://claude.ai/code/session_018MD6LyP3Am3FcED1NCBLw8)_