### PR TITLE
Bug hunt round three: zero-fill root cause, discovery race, CI hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,12 @@ on:
 
 concurrency:
   group: ci-${{ github.ref }}
-  cancel-in-progress: true
+  # Cancel superseded runs on PR branches, but let main runs finish: a
+  # second merge landing mid-run could otherwise cancel the first between
+  # its Firebase distribution and Play upload steps, skipping a publish.
+  # (The release-notes base logic self-heals the changelog either way; the
+  # cost was the skipped publish itself.)
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   unit-tests:
@@ -272,11 +277,14 @@ jobs:
             # marks every PNG only that root's tests record as orphaned
             # and deletes it on the next CI regen — the bug behind PR
             # #905's first regen wiping
-            # `settings_voice_app_check_debug_token.png`. A glob covers
-            # any future `testRelease`, `androidTest`, etc. without
-            # another edit here.
-            expected=$(find app/src/test app/src/test[A-Z]* -name '*.kt' -print0 2>/dev/null \
-              | xargs -0 perl -0777 -ne 'while (/\@Test\b(?:\s|\@\w+(?:\([^)]*\))?)*?\bfun\s+(\w+)/g) { print "$1\n" }')
+            # `settings_voice_app_check_debug_token.png`. Roots are
+            # enumerated with find -name rather than a shell glob: an
+            # unmatched glob (`app/src/test[A-Z]*` with no variant roots
+            # present) passes through literally, find exits non-zero, and
+            # `set -euo pipefail` would kill the step.
+            expected=$(find app/src -maxdepth 1 -type d \( -name 'test' -o -name 'test[A-Z]*' \) -print0 \
+              | xargs -0 -r -I{} find {} -name '*.kt' -print0 \
+              | xargs -0 -r perl -0777 -ne 'while (/\@Test\b(?:\s|\@\w+(?:\([^)]*\))?)*?\bfun\s+(\w+)/g) { print "$1\n" }')
             for png in app/snapshots/*.png; do
               [ -f "$png" ] || continue
               name=$(basename "$png" .png)
@@ -665,7 +673,7 @@ jobs:
             local sha="$1" subject non_doc_count
             subject=$(git log -1 --pretty=%s "$sha")
             case "$subject" in
-              ci:*|test:*|internal:*) return 0 ;;
+              ci:*|test:*|internal:*|docs:*) return 0 ;;
             esac
             non_doc_count=$(git show --no-renames --name-only --pretty=format: "$sha" \
               | sed '/^$/d' \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,7 +148,7 @@ new rule the first time something bites you, not the third.
   guides, repo tooling, project meta — takes `internal:` (e.g. `internal:
   document the internal: changelog prefix`) and CI skips it the same way
   it skips `ci:` / `test:`. Note the path-based filter already drops
-  top-level `*.md`, `docs/`, and dotfile-only commits regardless of
+  `*.md` (at any depth), `docs/`, and dotfile-only commits regardless of
   prefix (PRIVACY.md is the exception — it's treated as non-docs so
   privacy-policy updates still surface), so a pure-`AGENTS.md` change is
   dropped either way — but still prefix it so the subject's intent is
@@ -156,11 +156,12 @@ new rule the first time something bites you, not the third.
   especially when an internal-only change touches paths that *would*
   otherwise ship a bullet.
 - **Docs-only commits use a `docs:` subject prefix.** A commit touching
-  only `docs/`, top-level `*.md` (READMEs, setup guides), or dotfiles
-  takes `docs:` (e.g. `docs: fix stale Firebase Console nav`). Prefix it
-  even though the path filter already drops it from the changelog — the
-  prefix makes the intent explicit and keeps the subject from reading
-  like end-user copy. Exception: a PRIVACY.md-only change ships as a
+  only `docs/`, `*.md` files (READMEs, setup guides — any depth), or
+  dotfiles takes `docs:` (e.g. `docs: fix stale Firebase Console nav`).
+  Prefix it even though the path filter already drops it from the
+  changelog — the prefix makes the intent explicit and keeps the subject
+  from reading like end-user copy (and the subject filter now skips
+  `docs:` directly, same as `ci:` / `test:` / `internal:`). Exception: a PRIVACY.md-only change ships as a
   bullet (it's treated as non-docs), so leave that one unprefixed.
 - **Play caps `whatsnew-en-US` at 500 bytes.** When the bullet list
   exceeds that, CI truncates and appends `…`. Avoid lining up a long
@@ -404,12 +405,15 @@ new rule the first time something bites you, not the third.
   morning insight's evening tie-in clause has two emission paths. If the
   user's clothes rules fire for the evening window (e.g. it'll be cold
   enough for a jacket), the clause names the item *and* folds in the
-  per-model rain time when one's detected: "Bring a jacket tonight, rain
-  at 9pm." If no clothes rule fires but a per-model series spots rain ≥
+  per-model rain when one's detected: "Tonight, rain tonight, bring a
+  jacket." If no clothes rule fires but a per-model series spots rain ≥
   30% in the tonight window and the user has an evening event with a
   location, the clause still emits — without recommending clothes —
-  as a bare rain warning ("Rain tonight at 9pm." / "Chance of rain
-  tonight at 9pm." for the POSSIBLE tier). The principle: we *always*
+  as a bare rain warning ("Tonight, rain tonight." / the hedged
+  chance-of-rain wording for the POSSIBLE tier). The prose deliberately
+  no longer pins a peak hour ("rain at 9pm") — that claimed precision
+  the hourly forecast can't back; the peak time still rides the clause
+  data for the chart and cast card. The principle: we *always*
   surface rain when a model spots it, even when no clothes rule fires —
   e.g. the user lowered their umbrella gate, deleted the rule, or the
   probability sits below it. The umbrella itself ships as a precip-keyed

--- a/app/src/main/kotlin/app/clothescast/discovery/NsdHomeAssistantDiscovery.kt
+++ b/app/src/main/kotlin/app/clothescast/discovery/NsdHomeAssistantDiscovery.kt
@@ -136,12 +136,16 @@ internal class NsdHomeAssistantDiscovery(context: Context) : HomeAssistantDiscov
                 override fun onServiceLost(serviceInfo: NsdServiceInfo) {
                     val type = serviceTypeOf(serviceInfo.serviceType) ?: return
                     val key = type to serviceInfo.serviceName
+                    // Always arm the lost-while-pending mark, not just when
+                    // the key was never resolved: a re-announce can queue a
+                    // second resolve while the entry is live, and a loss
+                    // arriving before that resolve completes must keep it
+                    // from re-inserting the dead service into the picker.
+                    // The next onServiceFound clears the mark, so a service
+                    // that genuinely comes back still inserts normally.
+                    lostWhilePending.add(key)
                     if (results.remove(key) != null) {
                         emit()
-                    } else {
-                        // Not yet resolved — flag the key so the eventual
-                        // resolve callback discards instead of inserting.
-                        lostWhilePending.add(key)
                     }
                 }
             }

--- a/core/data/src/main/kotlin/app/clothescast/core/data/weather/OpenMeteoClient.kt
+++ b/core/data/src/main/kotlin/app/clothescast/core/data/weather/OpenMeteoClient.kt
@@ -113,13 +113,12 @@ class OpenMeteoClient(
         // pre-injection map (Codex caught it on PR review).
         //
         // Built from the wire payload, not the mapped [HourlyForecast]s: the
-        // mapper substitutes 0.0 °C / 0 % for null hourly values (tolerable
-        // for the chart, which the blend overwrites on any consensus hour),
-        // and feeding those synthetic zeros into [blendConsensusHourly] would
-        // let a horizon-edge null cast a fake cold-and-dry vote into the
-        // consensus mean — exactly what MultiModelConfidenceFetcher.parseHourly
-        // avoids for the consulted models by dropping the hour / keeping
-        // precip null.
+        // mapper drops hours whose temperature_2m is null but still folds
+        // null precip to 0 % for the chart, and feeding that synthetic zero
+        // into [blendConsensusHourly] would let a horizon-edge null cast a
+        // fake dry vote into the consensus mean — exactly what
+        // MultiModelConfidenceFetcher.parseHourly avoids for the consulted
+        // models by keeping precip null.
         //
         // The raw hourly stream spans yesterday through day 14, so best_match
         // covers the same forecast_days=14 window the consulted models carry —

--- a/core/data/src/main/kotlin/app/clothescast/core/data/weather/OpenMeteoMapper.kt
+++ b/core/data/src/main/kotlin/app/clothescast/core/data/weather/OpenMeteoMapper.kt
@@ -111,7 +111,16 @@ internal object OpenMeteoMapper {
         for (i in time.indices) {
             val ts = LocalDateTime.parse(time[i])
             if (ts.toLocalDate() != date) continue
-            val raw = temperature.getOrNull(i) ?: 0.0
+            // An hour without temperature_2m (horizon edge of the 14-day
+            // window, an upstream run still warming up) is dropped, not
+            // zero-filled: a synthetic 0 °C drew a misleading dip on the
+            // chart, and [blendConsensusHourly]'s fewer-than-two-candidates
+            // fallback surfaced it verbatim — a fake 0 °C that then fed the
+            // recomputed daily extremes. Consumers handle a sparse window
+            // (timestamp-keyed charts, min/max over present hours), and the
+            // consensus blend re-covers any dropped hour that at least two
+            // consulted models still report.
+            val raw = temperature.getOrNull(i) ?: continue
             out += HourlyForecast(
                 time = LocalTime.of(ts.hour, ts.minute),
                 temperatureC = raw,

--- a/core/data/src/test/kotlin/app/clothescast/core/data/weather/OpenMeteoMapperTest.kt
+++ b/core/data/src/test/kotlin/app/clothescast/core/data/weather/OpenMeteoMapperTest.kt
@@ -163,7 +163,13 @@ class OpenMeteoMapperTest {
     }
 
     @Test
-    fun `null temperatures and probabilities are tolerated as zero`() {
+    fun `null daily values are tolerated as zero and null-temperature hours are dropped`() {
+        // Daily nulls degrade to zero (the daily aggregates must exist for
+        // the prose); an hourly entry without temperature_2m is dropped
+        // outright — a synthetic 0 °C hour drew a misleading chart dip and
+        // could feed a fake 0 °C into the consensus blend's fallback. The
+        // 15:00 hour here is null, the 16:00 hour is real: only 16:00
+        // survives.
         val sparse = OpenMeteoResponse(
             timezone = "UTC",
             daily = DailyData(
@@ -177,11 +183,11 @@ class OpenMeteoMapperTest {
                 weatherCode = listOf(null, 63),
             ),
             hourly = HourlyData(
-                time = listOf("2026-04-25T15:00"),
-                temperature = listOf(null),
-                feelsLike = listOf(null),
-                precipitationProbability = listOf(null),
-                weatherCode = listOf(null),
+                time = listOf("2026-04-25T15:00", "2026-04-25T16:00"),
+                temperature = listOf(null, 21.0),
+                feelsLike = listOf(null, null),
+                precipitationProbability = listOf(null, null),
+                weatherCode = listOf(null, null),
             ),
         )
 
@@ -194,9 +200,14 @@ class OpenMeteoMapperTest {
         bundle.yesterday.precipitationProbabilityMaxPct shouldBe 0.0
         bundle.yesterday.condition shouldBe WeatherCondition.UNKNOWN
         bundle.today.precipitationProbabilityMaxPct shouldBe 0.0
-        bundle.today.hourly.single().temperatureC shouldBe 0.0
-        bundle.today.hourly.single().feelsLikeC shouldBe 0.0
-        bundle.today.hourly.single().condition shouldBe WeatherCondition.UNKNOWN
+        val survivor = bundle.today.hourly.single()
+        survivor.time shouldBe LocalTime.of(16, 0)
+        survivor.temperatureC shouldBe 21.0
+        // Null apparent falls back to the raw temp; null precip prob stays a
+        // chart-friendly zero.
+        survivor.feelsLikeC shouldBe 21.0
+        survivor.precipitationProbabilityPct shouldBe 0.0
+        survivor.condition shouldBe WeatherCondition.UNKNOWN
     }
 
     @Test
@@ -368,8 +379,10 @@ class OpenMeteoMapperTest {
     fun `mismatched-length hourly parallel arrays are tolerated without throwing`() {
         // Open-Meteo always sends matching arrays, but a buggy proxy or a future
         // field-by-field rollout could produce shorter temperature/feelsLike/etc.
-        // arrays than `time`. The hourly mapper must degrade gracefully (using
-        // 0.0 / UNKNOWN defaults) rather than throwing IndexOutOfBoundsException.
+        // arrays than `time`. The hourly mapper must degrade gracefully rather
+        // than throwing IndexOutOfBoundsException: hours beyond the temperature
+        // array's reach are dropped (same policy as an in-range null — no
+        // synthetic 0 °C hour), and the in-range hours map normally.
         val mismatched = OpenMeteoResponse(
             timezone = "UTC",
             daily = DailyData(
@@ -394,14 +407,13 @@ class OpenMeteoMapperTest {
 
         val today = OpenMeteoMapper.toBundle(mismatched).today
 
-        // First hour is fully mapped; the other two fall back to zero / UNKNOWN.
-        today.hourly shouldHaveSize 3
-        today.hourly[0].temperatureC shouldBe 18.0
-        today.hourly[0].feelsLikeC shouldBe 17.0
-        today.hourly[1].temperatureC shouldBe 0.0
-        today.hourly[1].feelsLikeC shouldBe 0.0
-        today.hourly[1].condition shouldBe WeatherCondition.UNKNOWN
-        today.hourly[2].temperatureC shouldBe 0.0
+        // Only the hour the temperature array reaches survives; the two
+        // beyond it are dropped, not zero-filled.
+        val survivor = today.hourly.single()
+        survivor.time shouldBe LocalTime.of(9, 0)
+        survivor.temperatureC shouldBe 18.0
+        survivor.feelsLikeC shouldBe 17.0
+        survivor.condition shouldBe WeatherCondition.RAIN
     }
 
     @Test

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/ConsensusBlend.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/ConsensusBlend.kt
@@ -26,6 +26,11 @@ package app.clothescast.core.domain.model
  *   - When two or more models reported an entry at hour t, replace
  *     best_match's value with their mean. With fewer than two, keep
  *     best_match — a one-model "consensus" isn't a consensus.
+ *   - An hour at least two models cover but [bestMatch] doesn't (its
+ *     temperature came back null upstream, so the mapper dropped the hour
+ *     rather than zero-fill it) is synthesized from the consensus, keeping
+ *     the day's coverage at the forecast horizon where best_match thins
+ *     out before the consulted models do.
  *   - [HourlyForecast.condition] (CLEAR / RAIN / etc.) is aggregated
  *     modally — most-commonly-predicted bucket across the same
  *     candidate set wins, with ties broken by severity so the
@@ -61,7 +66,7 @@ fun blendConsensusHourly(
     }
 
     var anyBlended = false
-    val out = bestMatch.map { hour ->
+    val replaced = bestMatch.map { hour ->
         val candidates = byHour[java.time.LocalDateTime.of(bestMatchDate, hour.time)].orEmpty()
         if (candidates.size < 2) {
             hour
@@ -103,7 +108,43 @@ fun blendConsensusHourly(
             )
         }
     }
-    return if (anyBlended) out else null
+
+    // Hours the consulted models cover but best_match doesn't: synthesize the
+    // consensus entry. Same ≥2-candidates bar as the replacement path; the
+    // hour must land on this day's date (byHour spans the full per-model
+    // window). Precip and amount fall back to 0.0 when no candidate reported
+    // them — those fields are non-null on [HourlyForecast] and "models
+    // reported the hour but none carried precip" is the no-data case the
+    // chart already renders as zero.
+    val covered = bestMatch.mapTo(HashSet()) { java.time.LocalDateTime.of(bestMatchDate, it.time) }
+    val synthesized = byHour.entries
+        .filter { (t, candidates) ->
+            t.toLocalDate() == bestMatchDate && candidates.size >= 2 && t !in covered
+        }
+        .map { (t, candidates) ->
+            HourlyForecast(
+                time = t.toLocalTime(),
+                temperatureC = candidates.map { it.temperatureC }.average(),
+                feelsLikeC = candidates.map { it.apparentTemperatureC }.average(),
+                precipitationProbabilityPct = candidates.mapNotNull { it.precipitationProbabilityPct }
+                    .takeIf { it.isNotEmpty() }?.average() ?: 0.0,
+                condition = consensusCondition(
+                    fallback = WeatherCondition.UNKNOWN,
+                    candidates = candidates.mapNotNull { it.condition },
+                ),
+                precipitationMm = candidates.mapNotNull { it.precipitationMm }
+                    .takeIf { it.isNotEmpty() }?.average() ?: 0.0,
+                windSpeedKmh = candidates.mapNotNull { it.windSpeedKmh }
+                    .takeIf { it.isNotEmpty() }?.average(),
+                uvIndex = candidates.mapNotNull { it.uvIndex }
+                    .takeIf { it.isNotEmpty() }?.average(),
+            )
+        }
+    if (synthesized.isNotEmpty()) anyBlended = true
+    if (!anyBlended) return null
+    // Stable sort keeps a DST fall-back day's duplicated wall-clock hour as
+    // two adjacent entries in their original order.
+    return (replaced + synthesized).sortedBy { it.time }
 }
 
 /**

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/InsightSummary.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/InsightSummary.kt
@@ -146,21 +146,22 @@ data class ClothesClause(val items: List<String>) {
 
 /**
  * Peak precipitation hour: a [condition] (RAIN, SNOW, etc.) at a wall-clock [time].
- * The formatter capitalises and humanises the condition name ("Rain at 15:00.").
+ * The prose no longer speaks the hour — the formatter renders the bare
+ * condition ("Rain.") because a pinned peak hour claimed precision the
+ * hourly forecast can't back — but [time] stays on the clause for consumers
+ * that want it (the chart's scrub anchor, the Nest-Hub card).
  *
  * [likelihood] tracks how confident we are. [PrecipLikelihood.LIKELY] renders as
- * the bare condition ("Rain at 3pm."); [PrecipLikelihood.POSSIBLE] hedges
- * ("Chance of rain at 3pm.") because only a single per-model series flagged
+ * the bare condition ("Rain."); [PrecipLikelihood.POSSIBLE] hedges
+ * ("Chance of rain.") because only a single per-model series flagged
  * the hour while others stayed dry. Defaults to LIKELY so legacy cached
  * payloads — written before the field existed — keep their original wording.
  *
  * [allDay] is set when LIKELY rain runs across the whole period rather than
- * peaking at one hour — either it covers most of the window, or it falls in two
- * or more separated spells. The formatter then drops the single-hour time
- * phrase and says "Rain all day." (period-aware: "all night" on the night
- * slice) so a wet-all-day forecast doesn't get undersold as a single shower.
- * Only meaningful on the LIKELY tier; defaults to false so the POSSIBLE tier and
- * legacy cached payloads keep naming an hour.
+ * peaking at one hour — either it covers most of the window, or it falls in
+ * two or more separated spells. Carried for the same data-consumer reasons
+ * as [time]; the spoken prose reads identically either way now that the
+ * time phrase is gone.
  */
 data class PrecipClause(
     val condition: WeatherCondition,
@@ -217,11 +218,11 @@ data class CalendarTieInClause(val item: String)
  * LIKELY for back-compat with cached payloads written before the field
  * existed.
  *
- * [allDay] mirrors [PrecipClause.allDay] for the evening slice: when the night's
- * rain runs the whole window rather than peaking at one hour, the formatter
- * drops the "at 9pm" and says "all night" ("Tonight, rain all night, bring a
- * jacket."). Only meaningful when [rainTime] is set and [likelihood] is LIKELY;
- * defaults to false so the POSSIBLE tier and cached payloads keep naming an hour.
+ * [allDay] mirrors [PrecipClause.allDay] for the evening slice. Like the
+ * peak time, it's carried for data consumers rather than the prose — the
+ * formatter no longer speaks the hour or an "all night" phrase ("Tonight,
+ * rain tonight, bring a jacket." reads the same either way). Only
+ * meaningful when [rainTime] is set and [likelihood] is LIKELY.
  *
  * [precipCondition] mirrors the same per-model peak's [WeatherCondition] so
  * the formatter can decide whether a wet-weather accessory mention makes

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/model/ConsensusBlendTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/model/ConsensusBlendTest.kt
@@ -74,6 +74,62 @@ class ConsensusBlendTest {
     }
 
     @Test
+    fun `hour missing from best-match is synthesized from the consensus`() {
+        // The mapper drops a best_match hour whose temperature_2m came back
+        // null; when at least two consulted models still cover it, the blend
+        // re-adds the hour so the day keeps its coverage at the forecast
+        // horizon, where best_match thins out before the consulted models.
+        val best = listOf(hour(12, temp = 10.0, precip = 30.0))
+        val perModel = PerModelHourly(
+            byModel = mapOf(
+                "gfs_seamless" to listOf(
+                    perModel(12, apparent = 11.0, air = 12.0, precip = 40.0),
+                    perModel(13, apparent = 13.0, air = 14.0, precip = 60.0, wind = 20.0),
+                ),
+                "icon_seamless" to listOf(
+                    perModel(12, apparent = 13.0, air = 14.0, precip = 50.0),
+                    perModel(13, apparent = 15.0, air = 16.0, precip = 80.0, wind = 30.0),
+                ),
+            ),
+        )
+
+        val blended = blendConsensusHourly(today, best, perModel).shouldNotBeNull()
+
+        blended.map { it.time } shouldBe listOf(LocalTime.of(12, 0), LocalTime.of(13, 0))
+        val synthesized = blended[1]
+        synthesized.temperatureC shouldBe (15.0 plusOrMinus 0.0001)
+        synthesized.feelsLikeC shouldBe (14.0 plusOrMinus 0.0001)
+        synthesized.precipitationProbabilityPct shouldBe (70.0 plusOrMinus 0.0001)
+        synthesized.windSpeedKmh!! shouldBe (25.0 plusOrMinus 0.0001)
+    }
+
+    @Test
+    fun `synthesis skips other days' hours and single-candidate hours`() {
+        // The per-model window spans the full 14-day fetch; only this day's
+        // hours may be synthesized into this day's list, and a lone model's
+        // hour stays out — same one-model-isn't-a-consensus bar as the
+        // replacement path.
+        val best = listOf(hour(12, temp = 10.0))
+        val perModel = PerModelHourly(
+            byModel = mapOf(
+                "gfs_seamless" to listOf(
+                    perModel(12, apparent = 11.0, air = 12.0),
+                    perModel(13, apparent = 13.0, air = 14.0), // single candidate
+                    perModel(9, apparent = 9.0, air = 10.0, date = today.plusDays(1)),
+                ),
+                "icon_seamless" to listOf(
+                    perModel(12, apparent = 13.0, air = 14.0),
+                    perModel(9, apparent = 11.0, air = 12.0, date = today.plusDays(1)),
+                ),
+            ),
+        )
+
+        val blended = blendConsensusHourly(today, best, perModel).shouldNotBeNull()
+
+        blended.map { it.time } shouldBe listOf(LocalTime.of(12, 0))
+    }
+
+    @Test
     fun `includes the best-match overlay in the consensus mean`() {
         // best_match is one of the models in [byModel] and gets folded into
         // the mean alongside the consulted models. The user picked this

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsightTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsightTest.kt
@@ -1099,9 +1099,11 @@ class GenerateDailyInsightTest {
         tie.shouldNotBeNull()
         tie!!.items shouldBe listOf("jacket")
         tie.rainTime shouldBe LocalTime.of(21, 0)
-        // Both evening hours sit ≥ 50%, so the night's own notification would say
-        // "rain all night" — the tie-in mirrors that, and the morning insight
-        // renders "Tonight, rain all night, bring a jacket." rather than naming 9pm.
+        // Both evening hours sit ≥ 50%, so the whole-window flag is set. The
+        // prose no longer speaks it (the formatter dropped the hour / "all
+        // night" phrasing — "Tonight, rain tonight, bring a jacket." reads
+        // the same either way), but the flag still rides the clause for data
+        // consumers, so pin that the derivation sets it.
         tie.allDay shouldBe true
     }
 


### PR DESCRIPTION
## Summary

Third pass, working down the backlog the first two rounds (#1008, #1009) left as reports.

### The zero-fill root cause

`OpenMeteoMapper` mapped an hourly entry whose `temperature_2m` came back null (horizon edge of the 14-day window, an upstream run warming up) to a synthetic 0 °C hour. Both earlier rounds worked around downstream symptoms; this fixes the source:

- The mapper now **drops** null-temperature hours instead of zero-filling.
- `blendConsensusHourly` now **synthesizes** any hour at least two consulted models still cover but best_match doesn't — so dropping the fake hour doesn't lose real consensus coverage where best_match thins out before ECMWF/GFS/ICON do. Same ≥2-candidates bar as the replacement path; precip falls back to 0 only when no candidate reported it (the existing no-data convention for that non-null field).

Net effect: no more fake freezing dip on charts at single-candidate horizon hours (round two's F2), and no fake 0 °C ever reaching the recomputed daily extremes. Round one's blend regression test passes unchanged — the synthesized hour carries the same consensus values the old zero-filled-then-replaced hour did.

### Other fixes

- **NSD discovery race**: the lost-while-pending mark only armed for never-resolved services, so a re-announce + loss racing a queued resolve could re-insert a dead Home Assistant / MQTT device into the picker. The mark now arms on every loss (next announce clears it).
- **CI** (`ci:`): `cancel-in-progress` scoped to non-main refs (a second merge mid-run could cancel the first between Firebase distribution and Play upload, skipping a publish); the snapshot-prune source-root glob replaced with `find` enumeration (an unmatched `test[A-Z]*` glob would kill the step under `set -euo pipefail`); `docs:` subjects now skipped by the changelog filter like the other prefixes.
- **Docs drift** (`internal:`): `PrecipClause` / `EveningEventTieInClause` KDocs, a test comment, and AGENTS.md's domain-convention examples still quoted "rain at 9pm" / "rain all night" prose the formatter deliberately stopped emitting; all reworded to the current contract. AGENTS.md's description of the changelog `.md` path filter corrected (any depth, not top-level only).

## Still open (unchanged from #1009's list)

Translations dropping the rain-timing word (needs a human translation pass), tonight events unable to represent tomorrow's date (model change — happy to take this on as its own PR if wanted), the daily-confidence precip hard-drop (needs live Open-Meteo verification), the stuck-route cast timeout (needs hardware), and the two port-probe TOCTOUs.

## Privacy

No change to what leaves the device.

## Test plan

New/updated tests: mapper null-hour drop (`OpenMeteoMapperTest`), blend synthesis + skip rules (`ConsensusBlendTest`). Full local run green: `:core:domain:test` + `:core:data:test` + `:app:testDebugUnitTest` + `:app:assembleDebug` (exit 0); round one's horizon-edge regression test passes unchanged, confirming the synthesis preserves blended output.

https://claude.ai/code/session_018MD6LyP3Am3FcED1NCBLw8

---
_Generated by [Claude Code](https://claude.ai/code/session_018MD6LyP3Am3FcED1NCBLw8)_