### PR TITLE
Add missing tonight translations across all locales

### DIFF
--- a/app/src/main/res/values-am/strings.xml
+++ b/app/src/main/res/values-am/strings.xml
@@ -397,6 +397,8 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="insight_clothes_join_many">%1$s፣ %2$s፣ እና %3$s</string>
     <string name="insight_precip">%1$s።</string>
     <string name="insight_precip_overnight">ሌሊት</string>
+
+    <string name="insight_precip_tonight">ዛሬ ምሽት</string>
     <string name="insight_condition_clear">ፀሃያማ</string>
     <string name="insight_condition_partly_cloudy">ትንሽ ደመናማ</string>
     <string name="insight_condition_cloudy">ደመናማ</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -88,6 +88,8 @@ they work correctly in both the single-band and range templates.
     <string name="insight_clothes_join_many">%1$s و%2$s و%3$s</string>
     <string name="insight_precip">%1$s.</string>
     <string name="insight_precip_overnight">طوال الليل</string>
+
+    <string name="insight_precip_tonight">الليلة</string>
     <string name="insight_condition_clear">صافٍ</string>
     <string name="insight_condition_partly_cloudy">غائم جزئياً</string>
     <string name="insight_condition_cloudy">غائم</string>

--- a/app/src/main/res/values-b+sr+Cyrl/strings.xml
+++ b/app/src/main/res/values-b+sr+Cyrl/strings.xml
@@ -96,6 +96,8 @@ surfaces.
     <string name="insight_precip">%1$s.</string>
     <string name="insight_precip_chance">Могућа %1$s.</string>
     <string name="insight_precip_overnight">током ноћи</string>
+
+    <string name="insight_precip_tonight">вечерас</string>
     <string name="insight_condition_clear">Ведро</string>
     <string name="insight_condition_partly_cloudy">Делимично облачно</string>
     <string name="insight_condition_cloudy">Облачно</string>

--- a/app/src/main/res/values-b+sr+Latn/strings.xml
+++ b/app/src/main/res/values-b+sr+Latn/strings.xml
@@ -108,6 +108,8 @@ default English (matching values-pl / values-uk).
     <string name="insight_precip">%1$s.</string>
     <string name="insight_precip_chance">Moguća %1$s.</string>
     <string name="insight_precip_overnight">tokom noći</string>
+
+    <string name="insight_precip_tonight">večeras</string>
     <string name="insight_condition_clear">Vedro</string>
     <string name="insight_condition_partly_cloudy">Delimično oblačno</string>
     <string name="insight_condition_cloudy">Oblačno</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -93,6 +93,8 @@ What is NOT overridden, by design:
     <string name="insight_clothes_join_many">%1$s, %2$s и %3$s</string>
     <string name="insight_precip">%1$s.</string>
     <string name="insight_precip_overnight">през нощта</string>
+
+    <string name="insight_precip_tonight">тази вечер</string>
     <string name="insight_condition_clear">Ясно</string>
     <string name="insight_condition_partly_cloudy">Частично облачно</string>
     <string name="insight_condition_cloudy">Облачно</string>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -83,6 +83,8 @@ West Bengal vocabulary differences in a future PR.
     <string name="insight_clothes_join_many">%1$s, %2$s এবং %3$s</string>
     <string name="insight_precip">%1$s।</string>
     <string name="insight_precip_overnight">সারারাত</string>
+
+    <string name="insight_precip_tonight">আজ রাতে</string>
     <string name="insight_condition_clear">পরিষ্কার</string>
     <string name="insight_condition_partly_cloudy">আংশিক মেঘলা</string>
     <string name="insight_condition_cloudy">মেঘলা</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -515,6 +515,8 @@ the in-app clock is digit-driven and reads consistently across locales.
     <string name="insight_precip">%1$s.</string>
     <string name="insight_precip_chance">Possibilitat de %1$s.</string>
     <string name="insight_precip_overnight">durant la nit</string>
+
+    <string name="insight_precip_tonight">aquesta nit</string>
     <string name="insight_condition_clear">Cel serè</string>
     <string name="insight_condition_partly_cloudy">Parcialment ennuvolat</string>
     <string name="insight_condition_cloudy">Ennuvolat</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -562,6 +562,8 @@ locale (Angličtina (USA), Francouzština (Francie), Němčina (Německo), …).
     <string name="insight_clothes_join_many">%1$s, %2$s a %3$s</string>
     <string name="insight_precip">%1$s.</string>
     <string name="insight_precip_overnight">v noci</string>
+
+    <string name="insight_precip_tonight">dnes večer</string>
     <string name="insight_precip_chance">Možná %1$s.</string>
     <string name="insight_condition_clear">Jasno</string>
     <string name="insight_condition_partly_cloudy">Polojasno</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -572,6 +572,8 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrig)").
 
     <string name="insight_precip">%1$s.</string>
     <string name="insight_precip_overnight">i nat</string>
+
+    <string name="insight_precip_tonight">i aften</string>
     <string name="insight_precip_chance">Risiko for %1$s.</string>
 
     <string name="insight_condition_clear">Klart</string>

--- a/app/src/main/res/values-de-rAT/strings.xml
+++ b/app/src/main/res/values-de-rAT/strings.xml
@@ -404,6 +404,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="insight_lead_tomorrow">Morgen</string>
     <string name="insight_unchanged_today">Heute wird es genauso wie gestern.</string>
     <string name="insight_unchanged_tonight">Heute Abend wird es genauso wie gestern Abend.</string>
+    <string name="insight_unchanged_tonight_no_lead">Wie gestern Abend.</string>
     <string name="insight_unchanged_tomorrow">Morgen wird es genauso wie heute.</string>
     <string name="insight_lead_tonight">Heute Abend</string>
 
@@ -449,6 +450,8 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="insight_precip">%1$s.</string>
     <!-- "Regen über Nacht." for the early-morning collapse. -->
     <string name="insight_precip_overnight">über Nacht</string>
+
+    <string name="insight_precip_tonight">heute Abend</string>
 
     <string name="insight_condition_clear">Klar</string>
     <string name="insight_condition_partly_cloudy">Teilweise bewölkt</string>
@@ -697,4 +700,12 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_page_clothes">Kleidungseinstellungen</string>
     <string name="settings_page_smart_home">Smart-Home-Einstellungen</string>
     <string name="settings_page_developer">Entwicklereinstellungen</string>
+
+    <!-- Tonight variants for precipitation, sunshine, and placeholder strings. -->
+    <string name="today_precipitation_amount_total_tonight">%1$s Regen heute Abend</string>
+    <string name="today_precipitation_amount_dry_tonight">Heute Abend wird kein Regen erwartet</string>
+    <string name="today_sunshine_total_hours_minutes_tonight">%1$d Std. %2$d Min. Sonne heute Abend</string>
+    <string name="today_sunshine_total_hours_only_tonight">%1$d Std. Sonne heute Abend</string>
+    <string name="today_sunshine_total_minutes_only_tonight">%1$d Min. Sonne heute Abend</string>
+    <string name="today_placeholder_tonight_title">Vorhersage für heute Abend</string>
 </resources>

--- a/app/src/main/res/values-de-rCH/strings.xml
+++ b/app/src/main/res/values-de-rCH/strings.xml
@@ -409,6 +409,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="insight_lead_tomorrow">Morgen</string>
     <string name="insight_unchanged_today">Heute wird es genauso wie gestern.</string>
     <string name="insight_unchanged_tonight">Heute Abend wird es genauso wie gestern Abend.</string>
+    <string name="insight_unchanged_tonight_no_lead">Wie gestern Abend.</string>
     <string name="insight_unchanged_tomorrow">Morgen wird es genauso wie heute.</string>
     <string name="insight_lead_tonight">Heute Abend</string>
 
@@ -454,6 +455,8 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="insight_precip">%1$s.</string>
     <!-- "Regen über Nacht." for the early-morning collapse. -->
     <string name="insight_precip_overnight">über Nacht</string>
+
+    <string name="insight_precip_tonight">heute Abend</string>
 
     <string name="insight_condition_clear">Klar</string>
     <string name="insight_condition_partly_cloudy">Teilweise bewölkt</string>
@@ -702,4 +705,12 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="settings_page_clothes">Kleidungseinstellungen</string>
     <string name="settings_page_smart_home">Smart-Home-Einstellungen</string>
     <string name="settings_page_developer">Entwicklereinstellungen</string>
+
+    <!-- Tonight variants for precipitation, sunshine, and placeholder strings. -->
+    <string name="today_precipitation_amount_total_tonight">%1$s Regen heute Abend</string>
+    <string name="today_precipitation_amount_dry_tonight">Heute Abend wird kein Regen erwartet</string>
+    <string name="today_sunshine_total_hours_minutes_tonight">%1$d Std. %2$d Min. Sonne heute Abend</string>
+    <string name="today_sunshine_total_hours_only_tonight">%1$d Std. Sonne heute Abend</string>
+    <string name="today_sunshine_total_minutes_only_tonight">%1$d Min. Sonne heute Abend</string>
+    <string name="today_placeholder_tonight_title">Vorhersage für heute Abend</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -479,6 +479,8 @@ zh-CN) is unchanged; only the displayed label localizes.
     <!-- "Regen über Nacht." for the early-morning collapse. -->
     <string name="insight_precip_overnight">über Nacht</string>
 
+    <string name="insight_precip_tonight">heute Abend</string>
+
     <string name="insight_condition_clear">Klar</string>
     <string name="insight_condition_partly_cloudy">Teilweise bewölkt</string>
     <string name="insight_condition_cloudy">Bewölkt</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -506,6 +506,8 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="insight_clothes_join_many">%1$s, %2$s και %3$s</string>
     <string name="insight_precip">%1$s.</string>
     <string name="insight_precip_overnight">τη νύχτα</string>
+
+    <string name="insight_precip_tonight">απόψε</string>
     <string name="insight_condition_clear">Αίθριος</string>
     <string name="insight_condition_partly_cloudy">Μερική συννεφιά</string>
     <string name="insight_condition_cloudy">Συννεφιά</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -450,6 +450,8 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="insight_clothes_join_many">%1$s, %2$s y %3$s</string>
     <string name="insight_precip">%1$s.</string>
     <string name="insight_precip_overnight">durante la noche</string>
+
+    <string name="insight_precip_tonight">esta noche</string>
     <string name="insight_condition_clear">Despejado</string>
     <string name="insight_condition_partly_cloudy">Parcialmente nublado</string>
     <string name="insight_condition_cloudy">Nublado</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -521,6 +521,8 @@ Tone is informal "sina"-form throughout ("Pane … selga", "Võta … kaasa",
     <string name="insight_precip">%1$s.</string>
     <string name="insight_precip_chance">Vihma võimalus: %1$s.</string>
     <string name="insight_precip_overnight">öö jooksul</string>
+
+    <string name="insight_precip_tonight">täna õhtul</string>
     <string name="insight_condition_clear">Selge</string>
     <string name="insight_condition_partly_cloudy">Vahelduv pilvisus</string>
     <string name="insight_condition_cloudy">Pilves</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -87,6 +87,8 @@ Western Arabic numerals (0-9) are used for TTS compatibility.
     <string name="insight_clothes_join_many">%1$s، %2$s و %3$s</string>
     <string name="insight_precip">%1$s.</string>
     <string name="insight_precip_overnight">در طول شب</string>
+
+    <string name="insight_precip_tonight">امشب</string>
     <string name="insight_condition_clear">آفتابی</string>
     <string name="insight_condition_partly_cloudy">نیمه ابری</string>
     <string name="insight_condition_cloudy">ابری</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -377,6 +377,8 @@ displayed label localizes.
     <string name="insight_precip">%1$s.</string>
     <string name="insight_precip_overnight">yön aikana</string>
 
+    <string name="insight_precip_tonight">tänä iltana</string>
+
     <string name="insight_condition_clear">Selkeää</string>
     <string name="insight_condition_partly_cloudy">Puolipilvistä</string>
     <string name="insight_condition_cloudy">Pilvistä</string>

--- a/app/src/main/res/values-fil/strings.xml
+++ b/app/src/main/res/values-fil/strings.xml
@@ -81,6 +81,8 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="insight_clothes_join_many">%1$s, %2$s, at %3$s</string>
     <string name="insight_precip">%1$s.</string>
     <string name="insight_precip_overnight">buong gabi</string>
+
+    <string name="insight_precip_tonight">ngayong gabi</string>
     <string name="insight_condition_clear">Maliwanag</string>
     <string name="insight_condition_partly_cloudy">Bahagyang maulap</string>
     <string name="insight_condition_cloudy">Maulap</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -453,6 +453,8 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="insight_clothes_join_many">%1$s, %2$s et %3$s</string>
     <string name="insight_precip">%1$s.</string>
     <string name="insight_precip_overnight">pendant la nuit</string>
+
+    <string name="insight_precip_tonight">ce soir</string>
     <string name="insight_condition_clear">Clair</string>
     <string name="insight_condition_partly_cloudy">Partiellement nuageux</string>
     <string name="insight_condition_cloudy">Nuageux</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -482,6 +482,8 @@ Not overridden by design:
     <string name="insight_clothes_join_many">%1$s, %2$s और %3$s</string>
     <string name="insight_precip">%1$s।</string>
     <string name="insight_precip_overnight">रात भर</string>
+
+    <string name="insight_precip_tonight">आज रात</string>
     <string name="insight_condition_clear">साफ़</string>
     <string name="insight_condition_partly_cloudy">आंशिक बादल</string>
     <string name="insight_condition_cloudy">बादल</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -421,6 +421,8 @@ spousal register), matching the existing insight prose ("Ponesi …",
     <string name="insight_clothes_join_many">%1$s, %2$s i %3$s</string>
     <string name="insight_precip">%1$s.</string>
     <string name="insight_precip_overnight">noću</string>
+
+    <string name="insight_precip_tonight">večeras</string>
     <string name="insight_condition_clear">Vedro</string>
     <string name="insight_condition_partly_cloudy">Djelomično oblačno</string>
     <string name="insight_condition_cloudy">Oblačno</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -565,6 +565,8 @@ locale (Angol (Egyesült Államok), Francia (Franciaország), Német
     <string name="insight_clothes_join_many">%1$s, %2$s és %3$s</string>
     <string name="insight_precip">%1$s.</string>
     <string name="insight_precip_overnight">éjszaka</string>
+
+    <string name="insight_precip_tonight">ma este</string>
     <string name="insight_precip_chance">Esetleg %1$s.</string>
     <string name="insight_condition_clear">Tiszta</string>
     <string name="insight_condition_partly_cloudy">Részben felhős</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -83,6 +83,8 @@ to values/strings.xml (English).
     <string name="insight_clothes_join_many">%1$s, %2$s, dan %3$s</string>
     <string name="insight_precip">%1$s.</string>
     <string name="insight_precip_overnight">semalam</string>
+
+    <string name="insight_precip_tonight">malam ini</string>
     <string name="insight_condition_clear">Cerah</string>
     <string name="insight_condition_partly_cloudy">Sebagian berawan</string>
     <string name="insight_condition_cloudy">Berawan</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -439,6 +439,8 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="insight_clothes_join_many">%1$s, %2$s e %3$s</string>
     <string name="insight_precip">%1$s.</string>
     <string name="insight_precip_overnight">durante la notte</string>
+
+    <string name="insight_precip_tonight">stasera</string>
     <string name="insight_condition_clear">Sereno</string>
     <string name="insight_condition_partly_cloudy">Parzialmente nuvoloso</string>
     <string name="insight_condition_cloudy">Nuvoloso</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -88,6 +88,8 @@ standard in Israeli digital communication.
     <string name="insight_clothes_join_many">%1$s, %2$s ו%3$s</string>
     <string name="insight_precip">%1$s.</string>
     <string name="insight_precip_overnight">בלילה</string>
+
+    <string name="insight_precip_tonight">הלילה</string>
     <string name="insight_condition_clear">בהיר</string>
     <string name="insight_condition_partly_cloudy">מעונן חלקית</string>
     <string name="insight_condition_cloudy">מעונן</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -453,6 +453,8 @@ the displayed label localizes.
     <string name="insight_clothes_join_many">%1$s、%2$s、%3$s</string>
     <string name="insight_precip">%1$s。</string>
     <string name="insight_precip_overnight">夜通し</string>
+
+    <string name="insight_precip_tonight">今夜</string>
     <string name="insight_condition_clear">晴れ</string>
     <string name="insight_condition_partly_cloudy">晴れのち曇り</string>
     <string name="insight_condition_cloudy">曇り</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -464,6 +464,8 @@ displayed label localizes.
     <string name="insight_clothes_join_many">%1$s, %2$s 그리고 %3$s</string>
     <string name="insight_precip">%1$s.</string>
     <string name="insight_precip_overnight">밤새</string>
+
+    <string name="insight_precip_tonight">오늘 밤</string>
     <string name="insight_condition_clear">맑음</string>
     <string name="insight_condition_partly_cloudy">구름 조금</string>
     <string name="insight_condition_cloudy">흐림</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -87,6 +87,8 @@ What is NOT overridden, by design:
     <string name="insight_clothes_join_many">%1$s, %2$s ir %3$s</string>
     <string name="insight_precip">%1$s.</string>
     <string name="insight_precip_overnight">naktį</string>
+
+    <string name="insight_precip_tonight">šįvakar</string>
     <string name="insight_condition_clear">Giedra</string>
     <string name="insight_condition_partly_cloudy">Mažai debesuota</string>
     <string name="insight_condition_cloudy">Debesuota</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -93,6 +93,8 @@ informal "tu"-form throughout ("Apģērb …", "Paņem … līdzi").
     <string name="insight_clothes_join_many">%1$s, %2$s un %3$s</string>
     <string name="insight_precip">%1$s.</string>
     <string name="insight_precip_overnight">naktī</string>
+
+    <string name="insight_precip_tonight">šovakar</string>
     <string name="insight_precip_chance">Iespējams %1$s.</string>
     <string name="insight_condition_clear">Skaidrs</string>
     <string name="insight_condition_partly_cloudy">Daļēji mākoņains</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -83,6 +83,8 @@ vs "kemungkinan", "padam" vs "hapus").
     <string name="insight_clothes_join_many">%1$s, %2$s, dan %3$s</string>
     <string name="insight_precip">%1$s.</string>
     <string name="insight_precip_overnight">semalaman</string>
+
+    <string name="insight_precip_tonight">malam ini</string>
     <string name="insight_condition_clear">Cerah</string>
     <string name="insight_condition_partly_cloudy">Sebahagian berawan</string>
     <string name="insight_condition_cloudy">Berawan</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -571,6 +571,8 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrike)").
 
     <string name="insight_precip">%1$s.</string>
     <string name="insight_precip_overnight">i natt</string>
+
+    <string name="insight_precip_tonight">i kveld</string>
     <string name="insight_precip_chance">Sjanse for %1$s.</string>
 
     <string name="insight_condition_clear">Klart</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -421,6 +421,8 @@ the displayed label localizes.
     <!-- Apostrophe before s-genitive in Dutch: "'s nachts" = at night. -->
     <string name="insight_precip_overnight">\'s nachts</string>
 
+    <string name="insight_precip_tonight">vanavond</string>
+
     <string name="insight_condition_clear">Helder</string>
     <string name="insight_condition_partly_cloudy">Gedeeltelijk bewolkt</string>
     <string name="insight_condition_cloudy">Bewolkt</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -419,6 +419,8 @@ is unchanged; only the displayed label localizes.
     <string name="insight_precip">%1$s.</string>
     <string name="insight_precip_overnight">w nocy</string>
 
+    <string name="insight_precip_tonight">wieczorem</string>
+
     <string name="insight_condition_clear">Słonecznie</string>
     <string name="insight_condition_partly_cloudy">Częściowe zachmurzenie</string>
     <string name="insight_condition_cloudy">Pochmurno</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -457,6 +457,8 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="insight_clothes_join_many">%1$s, %2$s e %3$s</string>
     <string name="insight_precip">%1$s.</string>
     <string name="insight_precip_overnight">de madrugada</string>
+
+    <string name="insight_precip_tonight">esta noite</string>
     <string name="insight_condition_clear">Céu limpo</string>
     <string name="insight_condition_partly_cloudy">Parcialmente nublado</string>
     <string name="insight_condition_cloudy">Nublado</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -481,6 +481,8 @@ they diverge from BR ("Polonês" → "Polaco", "Holandês" →
     <string name="insight_clothes_join_many">%1$s, %2$s e %3$s</string>
     <string name="insight_precip">%1$s.</string>
     <string name="insight_precip_overnight">de madrugada</string>
+
+    <string name="insight_precip_tonight">esta noite</string>
     <string name="insight_condition_clear">Céu limpo</string>
     <string name="insight_condition_partly_cloudy">Parcialmente nublado</string>
     <string name="insight_condition_cloudy">Nublado</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -80,6 +80,8 @@ surfaces fall back to default English (matching values-pl / values-uk).
     <string name="insight_clothes_join_many">%1$s, %2$s și %3$s</string>
     <string name="insight_precip">%1$s.</string>
     <string name="insight_precip_overnight">peste noapte</string>
+
+    <string name="insight_precip_tonight">diseară</string>
     <string name="insight_condition_clear">Senin</string>
     <string name="insight_condition_partly_cloudy">Parțial înnorat</string>
     <string name="insight_condition_cloudy">Înnorat</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -633,6 +633,8 @@ only the displayed label localizes.
     <string name="insight_clothes_join_many">%1$s, %2$s и %3$s</string>
     <string name="insight_precip">%1$s.</string>
     <string name="insight_precip_overnight">ночью</string>
+
+    <string name="insight_precip_tonight">сегодня вечером</string>
     <string name="insight_precip_chance">Возможен %1$s.</string>
     <string name="insight_condition_clear">Ясно</string>
     <string name="insight_condition_partly_cloudy">Переменная облачность</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -576,6 +576,8 @@ What is NOT overridden, by design:
     <string name="insight_clothes_join_many">%1$s, %2$s a %3$s</string>
     <string name="insight_precip">%1$s.</string>
     <string name="insight_precip_overnight">v noci</string>
+
+    <string name="insight_precip_tonight">dnes večer</string>
     <string name="insight_precip_chance">Možnosť %1$s.</string>
     <string name="insight_condition_clear">Jasno</string>
     <string name="insight_condition_partly_cloudy">Polooblačno</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -81,6 +81,8 @@ informal "ti"-form throughout, mirroring the Croatian / Serbian pass.
     <string name="insight_clothes_join_many">%1$s, %2$s in %3$s</string>
     <string name="insight_precip">%1$s.</string>
     <string name="insight_precip_overnight">čez noč</string>
+
+    <string name="insight_precip_tonight">nocoj</string>
     <string name="insight_condition_clear">Jasno</string>
     <string name="insight_condition_partly_cloudy">Delno oblačno</string>
     <string name="insight_condition_cloudy">Oblačno</string>

--- a/app/src/main/res/values-sq/strings.xml
+++ b/app/src/main/res/values-sq/strings.xml
@@ -157,6 +157,8 @@
     <string name="insight_precip">%1$s.</string>
     <string name="insight_precip_chance">Mundësi për %1$s.</string>
     <string name="insight_precip_overnight">gjatë natës</string>
+
+    <string name="insight_precip_tonight">sonte</string>
     <string name="insight_condition_clear">Qartë</string>
     <string name="insight_condition_partly_cloudy">Pjesërisht me re</string>
     <string name="insight_condition_cloudy">Me re</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -571,6 +571,8 @@ native names for all locales (e.g. "Tyska (Tyskland)", "Franska (Frankrike)").
 
     <string name="insight_precip">%1$s.</string>
     <string name="insight_precip_overnight">under natten</string>
+
+    <string name="insight_precip_tonight">i kväll</string>
     <string name="insight_precip_chance">Risk för %1$s.</string>
 
     <string name="insight_condition_clear">Klart</string>

--- a/app/src/main/res/values-sw/strings.xml
+++ b/app/src/main/res/values-sw/strings.xml
@@ -81,6 +81,8 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="insight_clothes_join_many">%1$s, %2$s, na %3$s</string>
     <string name="insight_precip">%1$s.</string>
     <string name="insight_precip_overnight">usiku</string>
+
+    <string name="insight_precip_tonight">usiku huu</string>
     <string name="insight_condition_clear">Angavu</string>
     <string name="insight_condition_partly_cloudy">Na mawingu kidogo</string>
     <string name="insight_condition_cloudy">Mawingu</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -81,6 +81,8 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="insight_clothes_join_many">%1$s, %2$s และ%3$s</string>
     <string name="insight_precip">%1$s</string>
     <string name="insight_precip_overnight">ตลอดทั้งคืน</string>
+
+    <string name="insight_precip_tonight">คืนนี้</string>
     <string name="insight_condition_clear">ท้องฟ้าแจ่มใส</string>
     <string name="insight_condition_partly_cloudy">มีเมฆบางส่วน</string>
     <string name="insight_condition_cloudy">มีเมฆมาก</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -376,6 +376,8 @@ displayed label localizes.
     <string name="insight_precip">%1$s.</string>
     <string name="insight_precip_overnight">gece boyunca</string>
 
+    <string name="insight_precip_tonight">bu gece</string>
+
     <string name="insight_condition_clear">Açık</string>
     <string name="insight_condition_partly_cloudy">Parçalı bulutlu</string>
     <string name="insight_condition_cloudy">Bulutlu</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -575,6 +575,8 @@ only the displayed label localizes.
     <string name="insight_precip">%1$s.</string>
     <string name="insight_precip_chance">Можливий %1$s.</string>
     <string name="insight_precip_overnight">вночі</string>
+
+    <string name="insight_precip_tonight">сьогодні ввечері</string>
     <string name="insight_condition_clear">Ясно</string>
     <string name="insight_condition_partly_cloudy">Мінлива хмарність</string>
     <string name="insight_condition_cloudy">Хмарно</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -86,6 +86,8 @@ Skipped intentionally: app_name (brand), insight_time_am/pm/midnight/noon
     <string name="insight_clothes_join_many">%1$s, %2$s và %3$s</string>
     <string name="insight_precip">%1$s.</string>
     <string name="insight_precip_overnight">suốt đêm</string>
+
+    <string name="insight_precip_tonight">tối nay</string>
     <string name="insight_condition_clear">Trời quang</string>
     <string name="insight_condition_partly_cloudy">Có mây</string>
     <string name="insight_condition_cloudy">Nhiều mây</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -446,6 +446,8 @@ label localizes.
     <!-- "雨（15:00）。" / "雨（整夜）。" — parenthetical time fits Chinese style. -->
     <string name="insight_precip">%1$s。</string>
     <string name="insight_precip_overnight">整夜</string>
+
+    <string name="insight_precip_tonight">今晚</string>
     <string name="insight_condition_clear">晴</string>
     <string name="insight_condition_partly_cloudy">多云</string>
     <string name="insight_condition_cloudy">阴</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -437,6 +437,8 @@ label localises.
     <!-- "雨（15:00）。" / "雨（整夜）。" — parenthetical time fits Chinese style. -->
     <string name="insight_precip">%1$s。</string>
     <string name="insight_precip_overnight">整夜</string>
+
+    <string name="insight_precip_tonight">今晚</string>
     <string name="insight_condition_clear">晴</string>
     <string name="insight_condition_partly_cloudy">多雲</string>
     <string name="insight_condition_cloudy">陰</string>


### PR DESCRIPTION
## Summary

- `insight_precip_tonight` was missing from all 46 non-English locale files. It's used mid-sentence in the evening rain clause (e.g. "Tonight, rain tonight, bring a jacket." / "Tonight, rain overnight.") via `coarseRainWhen()` in `InsightFormatter`. Added with the natural lowercase mid-sentence form derived from each locale's existing `insight_lead_tonight` value.
- `de-rAT` and `de-rCH` were each missing 7 further tonight strings present in `values-de` but never synced to the regional variants: `insight_unchanged_tonight_no_lead`, `today_precipitation_amount_{total,dry}_tonight`, `today_sunshine_total_{hours_minutes,hours_only,minutes_only}_tonight`, and `today_placeholder_tonight_title`.

## Test plan

- [ ] Core unit tests pass (`./gradlew :core:domain:test :core:data:test`) ✅
- [ ] Verify "Tonight, rain tonight" prose renders correctly in a German (Austria/Switzerland) locale
- [ ] Verify the same for a few representative non-German locales (French, Japanese, Spanish)

https://claude.ai/code/session_01VTN49zyc6yk6xt9jxuu1nv

---
_Generated by [Claude Code](https://claude.ai/code/session_01VTN49zyc6yk6xt9jxuu1nv)_