### PR TITLE
Forecast confidence no longer ignores models without rain data

### DIFF
--- a/core/data/src/main/kotlin/app/clothescast/core/data/weather/MultiModelConfidenceFetcher.kt
+++ b/core/data/src/main/kotlin/app/clothescast/core/data/weather/MultiModelConfidenceFetcher.kt
@@ -48,12 +48,15 @@ import java.time.LocalDateTime
  * requested field once per model, suffixed with the model name (e.g.
  * `apparent_temperature_max_ecmwf_ifs04`, `apparent_temperature_ecmwf_ifs04`).
  *
- * Best-effort: any failure (network, parse error) falls through to null. Per-model
- * failures (server returns nulls or omits a model's fields) drop just that model;
- * we still return a [ConfidenceInfo] as long as at least two models reported
- * usable daily values, and a [PerModelHourly] when at least one model reported
- * usable hourly values. Every drop and every failure is reported through
- * [logger] so the caller can surface why the chip didn't render.
+ * Best-effort: any failure (network, parse error) falls through to null. A model
+ * is dropped only when its required daily field — `apparent_temperature_max`, the
+ * temperature vote — is missing or null; a model that omits the soft fields
+ * (`apparent_temperature_min`, `precipitation_probability_max`, which Open-Meteo
+ * leaves out for several models) still contributes, sitting out just the
+ * spread term it lacks. We still return a [ConfidenceInfo] as long as at least
+ * two models reported a usable daily high, and a [PerModelHourly] when at least
+ * one model reported usable hourly values. Every drop and every soft skip is
+ * reported through [logger] so the caller can surface why the chip didn't render.
  *
  * Invalid-model resilience: Open-Meteo rejects the *entire* batched request with
  * HTTP 400 if any one `models=` id is invalid or withdrawn (it names the bad one
@@ -357,14 +360,25 @@ internal class MultiModelConfidenceFetcher(
         // low-spread calculation (see [compute]) rather than dropping the
         // whole model.
         val tempMin = numberAt(daily["apparent_temperature_min_$model"] as? JsonArray, 0)?.toDouble()
+        // Soft field: Open-Meteo omits daily precipitation_probability_max for
+        // several models (verified 2026-06-09 against the live API — among
+        // DEFAULT_MODELS, ecmwf_aifs025_single returns null at all three of
+        // lat 51.5/lon -0.12, lat 40.7/lon -74.0, lat 35.7/lon 139.7; the
+        // ukmo_seamless / jma_seamless / meteofrance_seamless / arpege_seamless
+        // selections omit it everywhere too). A model that reports a high
+        // without a precip max still contributes its high (and low). When
+        // missing it drops out of the precip-spread calculation (see
+        // [compute]) rather than dropping the whole model — mirrors the hourly
+        // path's soft precip handling and the daily-low handling above.
+        // apparent_temperature_max stays the only hard requirement: without it
+        // the model has no temperature vote to cast.
         val precipMax = numberAt(daily["precipitation_probability_max_$model"] as? JsonArray, 0)?.toDouble()
-        return when {
-            tempMax == null && precipMax == null ->
-                ReadOutcome.Dropped("both apparent_temperature_max and precipitation_probability_max missing or null")
-            tempMax == null ->
+        if (precipMax == null) {
+            logger.log("model $model daily: precipitation_probability_max missing, precip-spread will skip this model")
+        }
+        return when (tempMax) {
+            null ->
                 ReadOutcome.Dropped("apparent_temperature_max missing or null")
-            precipMax == null ->
-                ReadOutcome.Dropped("precipitation_probability_max missing or null")
             else ->
                 ReadOutcome.Usable(ModelDailyValues(tempMax, tempMin, precipMax))
         }
@@ -383,12 +397,19 @@ internal class MultiModelConfidenceFetcher(
         // With fewer than two lows we can't measure low disagreement, so it
         // contributes nothing — mirrors the precip dimension's guard.
         val lows = results.mapNotNull { it.second.tempMinC }
-        val precips = results.map { it.second.precipMaxPp }
+        // Models that didn't report a daily precip max (Open-Meteo omits the
+        // per-model field for several models — see [readModelDaily]) sit out
+        // the precip-spread term. With fewer than two reporters we can't
+        // measure precip disagreement, so it contributes nothing — including a
+        // model with a fake zero would silently inflate divergence on a calm
+        // day and downgrade confidence. Mirrors the low-spread guard and
+        // [ConfidenceInfo.computeFrom]'s hourly precip handling.
+        val precips = results.mapNotNull { it.second.precipMaxPp }
         val highSpread = highs.max() - highs.min()
         val lowSpread = if (lows.size >= 2) lows.max() - lows.min() else 0.0
         // Disagreement on the day's high *or* its low downgrades confidence.
         val tempSpread = maxOf(highSpread, lowSpread)
-        val precipSpread = precips.max() - precips.min()
+        val precipSpread = if (precips.size >= 2) precips.max() - precips.min() else 0.0
 
         val level = when {
             tempSpread <= ConfidenceInfo.TEMP_HIGH_AGREEMENT_C &&
@@ -411,7 +432,7 @@ internal class MultiModelConfidenceFetcher(
     private data class ModelDailyValues(
         val tempMaxC: Double,
         val tempMinC: Double?,
-        val precipMaxPp: Double,
+        val precipMaxPp: Double?,
     )
 
     private sealed class ReadOutcome {

--- a/core/data/src/test/kotlin/app/clothescast/core/data/weather/MultiModelConfidenceFetcherTest.kt
+++ b/core/data/src/test/kotlin/app/clothescast/core/data/weather/MultiModelConfidenceFetcherTest.kt
@@ -330,16 +330,63 @@ class MultiModelConfidenceFetcherTest {
     }
 
     @Test
-    fun `dropping a model logs which fields were missing`() = runTest {
+    fun `dropping a model logs the missing required field`() = runTest {
+        // ecmwf has null apparent_temperature_max (the hard requirement) and
+        // null precipitation_probability_max (now soft). The drop reason names
+        // the missing required field; the absent precip max surfaces as its own
+        // soft-skip note rather than as part of the drop reason.
         val logger = CapturingLogger()
         fetcherWith(ONE_MODEL_NULL_VALUES, logger = logger).fetch(london, fixtureModels)
 
-        val message = logger.entries.singleOrNull { "ecmwf_ifs025" in it.message }
-            .shouldNotBeNull()
-            .message
-        message shouldContain "dropped"
-        message shouldContain "apparent_temperature_max"
-        message shouldContain "precipitation_probability_max"
+        val dropMessage = logger.entries.singleOrNull {
+            "ecmwf_ifs025" in it.message && "dropped" in it.message
+        }.shouldNotBeNull().message
+        dropMessage shouldContain "apparent_temperature_max"
+
+        val softMessage = logger.entries.singleOrNull {
+            "ecmwf_ifs025" in it.message && "precip-spread will skip" in it.message
+        }.shouldNotBeNull().message
+        softMessage shouldContain "precipitation_probability_max"
+    }
+
+    @Test
+    fun `model missing daily precip max still contributes its temperature`() = runTest {
+        // Open-Meteo omits precipitation_probability_max for several models
+        // (verified live: ecmwf_aifs025_single among the defaults, plus
+        // ukmo / jma / meteofrance / arpege). Such a model must still cast its
+        // temperature vote rather than being dropped from the chip entirely.
+        // icon omits precip here and also defines the day's high (23.5 vs
+        // 21.0 / 21.5), so a temp spread of 2.5 proves icon was counted —
+        // dropping it would collapse the spread to 0.5.
+        val logger = CapturingLogger()
+        val info = fetcherWith(ONE_MODEL_NO_PRECIP_MAX, logger = logger)
+            .fetch(london, fixtureModels)?.confidence.shouldNotBeNull()
+
+        info.modelsConsulted shouldContainExactlyInAnyOrder
+            listOf("ecmwf_ifs025", "gfs_seamless", "icon_seamless")
+        info.tempSpreadC shouldBe (2.5 plusOrMinus 0.0001)
+        // Precip spread is over the two reporters (ecmwf 10, gfs 15).
+        info.precipSpreadPp shouldBe (5.0 plusOrMinus 0.0001)
+        info.level shouldBe ForecastConfidence.MEDIUM
+        logger.entries.any {
+            "icon_seamless" in it.message && "precip-spread will skip" in it.message
+        } shouldBe true
+    }
+
+    @Test
+    fun `precip dimension is neutral when only one model reports precip max`() = runTest {
+        // Two models, only ecmwf reports a precip max. With fewer than two
+        // precip reporters the precip dimension contributes 0.0 spread (it
+        // can't downgrade confidence), so the tier is driven by temperature
+        // alone — here a tight 0.5 spread → HIGH.
+        val info = fetcherWith(TWO_MODELS_ONE_PRECIP_MAX)
+            .fetch(london, fixtureModels)?.confidence.shouldNotBeNull()
+
+        info.modelsConsulted shouldContainExactlyInAnyOrder
+            listOf("ecmwf_ifs025", "gfs_seamless")
+        info.tempSpreadC shouldBe (0.5 plusOrMinus 0.0001)
+        info.precipSpreadPp shouldBe (0.0 plusOrMinus 0.0001)
+        info.level shouldBe ForecastConfidence.HIGH
     }
 
     @Test
@@ -554,6 +601,38 @@ class MultiModelConfidenceFetcherTest {
               "daily": {
                 "time": ["2026-05-12"],
                 "apparent_temperature_max_ecmwf_ifs025": [21.0],
+                "precipitation_probability_max_ecmwf_ifs025": [10]
+              }
+            }
+        """.trimIndent()
+
+        // icon reports its temps but omits precipitation_probability_max
+        // entirely (the case ecmwf_aifs025_single / ukmo / jma / meteofrance /
+        // arpege hit live). icon also defines the day's high (23.5), so a
+        // 2.5°C spread confirms it still contributes a temperature vote. Only
+        // ecmwf + gfs feed the precip spread.
+        private val ONE_MODEL_NO_PRECIP_MAX = """
+            {
+              "daily": {
+                "time": ["2026-05-12"],
+                "apparent_temperature_max_ecmwf_ifs025": [21.0],
+                "apparent_temperature_max_gfs_seamless": [21.5],
+                "apparent_temperature_max_icon_seamless": [23.5],
+                "precipitation_probability_max_ecmwf_ifs025": [10],
+                "precipitation_probability_max_gfs_seamless": [15]
+              }
+            }
+        """.trimIndent()
+
+        // Two models with tight temps (0.5°C apart); only ecmwf reports a
+        // precip max, so the precip dimension goes neutral and temperature
+        // alone decides the tier.
+        private val TWO_MODELS_ONE_PRECIP_MAX = """
+            {
+              "daily": {
+                "time": ["2026-05-12"],
+                "apparent_temperature_max_ecmwf_ifs025": [21.0],
+                "apparent_temperature_max_gfs_seamless": [21.5],
                 "precipitation_probability_max_ecmwf_ifs025": [10]
               }
             }


### PR DESCRIPTION
## The bug

In `core/data/src/main/kotlin/app/clothescast/core/data/weather/MultiModelConfidenceFetcher.kt`, the daily forecast-confidence computation hard-dropped any model whose per-model `precipitation_probability_max_<model>` field was missing or null — discarding that model's *temperature* vote entirely:

```kotlin
precipMax == null ->
    ReadOutcome.Dropped("precipitation_probability_max missing or null")
```

This was asymmetric with the soft handling of `apparent_temperature_min` in the same function, with the hourly path (`parseHourly`, which keeps a model whose precip series is absent), and with `ConfidenceInfo.computeFrom` — all of which keep a model on its temperature series and let it sit out only the precip term it lacks.

## Verification against the live API

Queried `https://api.open-meteo.com/v1/forecast` on **2026-06-09** with `daily=apparent_temperature_max,apparent_temperature_min,precipitation_probability_max`, `forecast_days=1&timezone=auto`, at three locations (lat 51.5/lon -0.12, lat 40.7/lon -74.0, lat 35.7/lon 139.7).

`precipitation_probability_max_<model>` coverage:

| Model | precip max present? |
|---|---|
| `ecmwf_ifs025` | ✅ all three |
| `gfs_seamless` | ✅ all three |
| `icon_seamless` | ✅ all three |
| `gem_seamless` | ✅ all three |
| `ecmwf_aifs025_single` *(in DEFAULT_MODELS)* | ❌ **null at all three** |
| `ukmo_seamless` | ❌ null at all three |
| `jma_seamless` | ❌ null at all three |
| `meteofrance_seamless` | ❌ null at all three |
| `arpege_seamless` | ❌ null at all three |

All consulted models reported good `apparent_temperature_max` everywhere. So the premise holds: on a **default install** `ecmwf_aifs025_single` never cast a temperature vote toward the confidence chip, and a user who picks any precip-less selection (e.g. `ukmo_seamless` + `meteofrance_seamless`, a combination the test suite itself treats as valid) got a **permanently null confidence chip** with only a debug-log explanation.

## The fix

In `MultiModelConfidenceFetcher`:
- `ModelDailyValues.precipMaxPp` is now nullable. `readModelDaily` drops a model **only** when `apparent_temperature_max` is missing (the one hard requirement — the temperature vote), and logs a soft per-model note when precip max is absent, mirroring `parseHourly`'s soft-field wording.
- `compute()` derives the precip spread over the models that reported it, with the same `>= 2` guard the daily *low* already uses: fewer than two precip reporters → the precip dimension contributes `0.0` spread, so it can't downgrade confidence (exactly how low-temperature disagreement already degrades).
- `modelsConsulted` still lists every model that contributed anything.
- Class KDoc updated to describe the soft/hard field split. `ConfidenceInfo`'s KDoc only lists the fields the daily path reads (no all-fields requirement stated), so it needed no change.

## Privacy

No change to what crosses the device boundary — same request parameters, same fields; only the local parse/aggregation of the response changed.

## Test plan

`core/data/.../MultiModelConfidenceFetcherTest.kt`:
- **new:** a model missing daily precip max still contributes its temperature high — confidence non-null, model in `modelsConsulted`, and the temp spread reflects its value (the precip-less model defines the day's high, so a dropped model would visibly collapse the spread).
- **new:** two models where only one reports precip → precip dimension neutral (`0.0`), tier driven by temperature alone.
- **retained:** the missing-required-field drop coverage, updated to the new log contract (drop reason names `apparent_temperature_max`; precip absence surfaces as its own soft-skip note).

Validated locally with the full CI-equivalent:
`./gradlew :core:domain:test :core:data:test :app:testDebugUnitTest :app:assembleDebug` → **BUILD SUCCESSFUL**.

https://claude.ai/code/session_01EiEb1Z2F5JLbW4tdh2QRtq

---
_Generated by [Claude Code](https://claude.ai/code/session_01EiEb1Z2F5JLbW4tdh2QRtq)_