### PR TITLE
Late-night plans count toward tonight's forecast briefing

### DIFF
--- a/app/src/main/kotlin/app/clothescast/calendar/CalendarContractEventReader.kt
+++ b/app/src/main/kotlin/app/clothescast/calendar/CalendarContractEventReader.kt
@@ -16,7 +16,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.time.Instant
 import java.time.LocalDate
-import java.time.LocalTime
+import java.time.LocalDateTime
 import java.time.ZoneId
 import java.time.ZoneOffset
 
@@ -143,8 +143,8 @@ class CalendarContractEventReader(private val context: Context) : CalendarEventR
         data class Row(
             val date: LocalDate,
             val title: String,
-            val start: LocalTime,
-            val end: LocalTime,
+            val start: LocalDateTime,
+            val end: LocalDateTime,
             val location: String?,
             val allDay: Boolean,
             val calendarId: Long,
@@ -201,18 +201,19 @@ class CalendarContractEventReader(private val context: Context) : CalendarEventR
 
                 // CalendarContract stores all-day events in UTC midnight-to-midnight; converting
                 // those into the user's zone shifts them off the day boundary. Keep them as
-                // pure all-day markers (dated by their UTC date) and project the rest into
-                // wall-clock in the user zone (dated by the begin instant in that zone).
+                // pure all-day markers (anchored at their UTC date's midnight) and project the
+                // rest into full local date-times in the user zone (dated by the begin instant
+                // in that zone), so a midnight-crossing instance keeps its end on the next date.
                 // Callers apply their own window filter on [date]: a single-day read drops
                 // adjacent-day all-day bleed (an east-of-UTC zone overlaps the previous UTC
                 // day), a forward-window read keeps every row inside its range.
                 val (date, start, finish) = if (allDay) {
                     val eventDate = Instant.ofEpochMilli(begin).atZone(ZoneOffset.UTC).toLocalDate()
-                    Triple(eventDate, LocalTime.MIDNIGHT, LocalTime.MIDNIGHT)
+                    Triple(eventDate, eventDate.atStartOfDay(), eventDate.atStartOfDay())
                 } else {
-                    val zoned = Instant.ofEpochMilli(begin).atZone(zoneId)
-                    val e = Instant.ofEpochMilli(end).atZone(zoneId).toLocalTime()
-                    Triple(zoned.toLocalDate(), zoned.toLocalTime(), e)
+                    val zonedBegin = Instant.ofEpochMilli(begin).atZone(zoneId).toLocalDateTime()
+                    val zonedEnd = Instant.ofEpochMilli(end).atZone(zoneId).toLocalDateTime()
+                    Triple(zonedBegin.toLocalDate(), zonedBegin, zonedEnd)
                 }
 
                 rows += Row(date, title, start, finish, location, allDay, calendarId, eventType, availability)

--- a/app/src/main/kotlin/app/clothescast/data/InsightCache.kt
+++ b/app/src/main/kotlin/app/clothescast/data/InsightCache.kt
@@ -376,7 +376,10 @@ class InsightCache(
     /**
      * Minimal projection of [CalendarEvent] for on-disk persistence: only the
      * fields `RenderInsightSummary` actually consults — `start`, `end`, `allDay`,
-     * and a `hasLocation` *presence* flag — survive the round-trip.
+     * and a `hasLocation` *presence* flag — survive the round-trip. Each
+     * endpoint is stored as a date + second-of-day pair, mirroring
+     * [PerModelHourDto], so a midnight-crossing event round-trips with its end
+     * on the next date and tomorrow's pre-dawn events keep their date.
      *
      * Titles and free-form location strings are deliberately dropped, matching
      * the privacy posture of the previous derived-insight cache (which stored
@@ -388,15 +391,23 @@ class InsightCache(
      */
     @Serializable
     private data class CalendarEventDto(
+        val startDateEpochDays: Long,
         val startSecondOfDay: Int,
+        val endDateEpochDays: Long,
         val endSecondOfDay: Int,
         val allDay: Boolean = false,
         val hasLocation: Boolean = false,
     ) {
         fun toDomain(): CalendarEvent = CalendarEvent(
             title = "",
-            start = LocalTime.ofSecondOfDay(startSecondOfDay.toLong()),
-            end = LocalTime.ofSecondOfDay(endSecondOfDay.toLong()),
+            start = LocalDateTime.of(
+                LocalDate.ofEpochDay(startDateEpochDays),
+                LocalTime.ofSecondOfDay(startSecondOfDay.toLong()),
+            ),
+            end = LocalDateTime.of(
+                LocalDate.ofEpochDay(endDateEpochDays),
+                LocalTime.ofSecondOfDay(endSecondOfDay.toLong()),
+            ),
             location = if (hasLocation) PLACEHOLDER_LOCATION else null,
             allDay = allDay,
             kind = EventKind.NORMAL,
@@ -483,8 +494,10 @@ class InsightCache(
     )
 
     private fun CalendarEvent.toDto(): CalendarEventDto = CalendarEventDto(
-        startSecondOfDay = start.toSecondOfDay(),
-        endSecondOfDay = end.toSecondOfDay(),
+        startDateEpochDays = start.toLocalDate().toEpochDay(),
+        startSecondOfDay = start.toLocalTime().toSecondOfDay(),
+        endDateEpochDays = end.toLocalDate().toEpochDay(),
+        endSecondOfDay = end.toLocalTime().toSecondOfDay(),
         allDay = allDay,
         hasLocation = !location.isNullOrBlank(),
     )
@@ -494,9 +507,12 @@ class InsightCache(
         // to the raw `ForecastSnapshot` (bundle + minimal events) it's derived
         // from. The previous shape (v6) doesn't deserialise into the new DTO,
         // so the cache drops to null on first read and the next worker run
-        // populates the v7 keys.
-        private val THIS_PERIOD_KEY = stringPreferencesKey("this_period_snapshot_v7")
-        private val NEXT_PERIOD_KEY = stringPreferencesKey("next_period_snapshot_v7")
+        // populates the v7 keys. Bumped to v8 when `CalendarEventDto` gained
+        // per-endpoint dates for the LocalDateTime event model — v7 payloads
+        // don't materialise dated events, so the cache drops to null on first
+        // read and the next worker run repopulates the v8 keys.
+        private val THIS_PERIOD_KEY = stringPreferencesKey("this_period_snapshot_v8")
+        private val NEXT_PERIOD_KEY = stringPreferencesKey("next_period_snapshot_v8")
 
         // Surfaced on materialisation when the cached event had a location
         // string at fetch time. The renderer's only read of `location` is a

--- a/app/src/test/kotlin/app/clothescast/calendar/CalendarContractEventReaderTest.kt
+++ b/app/src/test/kotlin/app/clothescast/calendar/CalendarContractEventReaderTest.kt
@@ -113,6 +113,31 @@ class CalendarContractEventReaderTest {
 
         events shouldHaveSize 1
         events[0].kind shouldBe EventKind.NORMAL
+        // Timed rows project to full local date-times in the queried zone.
+        events[0].start shouldBe date.atTime(12, 0)
+        events[0].end shouldBe date.atTime(13, 0)
+    }
+
+    @Test
+    fun `timed event crossing midnight keeps its end on the next date`(): Unit = runBlocking {
+        // The projection carries dates, so a 21:00 gig ending at 00:30 the
+        // next day reads as a plain interval with end > start on the next
+        // date — not the end-before-start wall-clock wrap the old LocalTime
+        // model produced.
+        provider.calendars[31L] = "user@gmail.com"
+        provider.instances += FakeInstance(
+            calendarId = 31L,
+            title = "Late gig",
+            allDay = false,
+            beginMillis = date.atTime(21, 0).toInstant(ZoneOffset.UTC).toEpochMilli(),
+            endMillis = date.plusDays(1).atTime(0, 30).toInstant(ZoneOffset.UTC).toEpochMilli(),
+        )
+
+        val events = CalendarContractEventReader(context).eventsForDay(date, zone)
+
+        events shouldHaveSize 1
+        events[0].start shouldBe date.atTime(21, 0)
+        events[0].end shouldBe date.plusDays(1).atTime(0, 30)
     }
 
     @Test

--- a/app/src/test/kotlin/app/clothescast/calendar/HolidayThemeResolverTest.kt
+++ b/app/src/test/kotlin/app/clothescast/calendar/HolidayThemeResolverTest.kt
@@ -57,8 +57,8 @@ class HolidayThemeResolverTest {
                 listOf(
                     CalendarEvent(
                         title = "Alex's birthday",
-                        start = LocalTime.MIDNIGHT,
-                        end = LocalTime.MIDNIGHT,
+                        start = date.atStartOfDay(),
+                        end = date.atStartOfDay(),
                         allDay = true,
                         kind = EventKind.BIRTHDAY,
                     ),

--- a/app/src/test/kotlin/app/clothescast/data/InsightCacheTest.kt
+++ b/app/src/test/kotlin/app/clothescast/data/InsightCacheTest.kt
@@ -168,7 +168,7 @@ class InsightCacheTest {
     @Test
     fun `corrupt JSON drops to null rather than crashing`() = runTest {
         dataStore.edit {
-            it[stringPreferencesKey("this_period_snapshot_v7")] = "{not valid json"
+            it[stringPreferencesKey("this_period_snapshot_v8")] = "{not valid json"
         }
 
         subject.thisPeriod.first() shouldBe null
@@ -176,12 +176,27 @@ class InsightCacheTest {
 
     @Test
     fun `pre-v7 payloads (the old derived-Insight shape) are dropped on read`() = runTest {
-        // Old v6 cache key, old derived-insight JSON shape. The new v7 reader
-        // returns null and the next worker run repopulates the v7 keys.
+        // Old v6 cache key, old derived-insight JSON shape. The current reader
+        // returns null and the next worker run repopulates the live keys.
         dataStore.edit {
             it[stringPreferencesKey("this_period_insight_v6")] = """
                 {"summary":"placeholder","recommendedItems":[],"generatedAtEpochMillis":0,
                  "forDateEpochDays":0}
+            """.trimIndent()
+        }
+
+        subject.thisPeriod.first() shouldBe null
+    }
+
+    @Test
+    fun `v7 payloads (time-only events) are dropped on read`() = runTest {
+        // v7 stored CalendarEventDto with second-of-day fields only — it can't
+        // materialise dated events, so v8 reads from a fresh key, drops to
+        // null, and the next worker run repopulates.
+        dataStore.edit {
+            it[stringPreferencesKey("this_period_snapshot_v7")] = """
+                {"bundle":{},"events":[{"startSecondOfDay":0,"endSecondOfDay":0}],
+                 "generatedAtEpochMillis":0}
             """.trimIndent()
         }
 
@@ -196,8 +211,8 @@ class InsightCacheTest {
         // disk posture at parity with the previous derived-insight cache).
         val concertEvent = CalendarEvent(
             title = "Concert with band",
-            start = LocalTime.of(20, 0),
-            end = LocalTime.of(22, 0),
+            start = today.atTime(20, 0),
+            end = today.atTime(22, 0),
             location = "Royal Albert Hall",
             allDay = false,
         )
@@ -207,8 +222,8 @@ class InsightCacheTest {
 
         val read = subject.thisPeriod.first()
         val readEvent = read?.events?.singleOrNull()
-        readEvent?.start shouldBe LocalTime.of(20, 0)
-        readEvent?.end shouldBe LocalTime.of(22, 0)
+        readEvent?.start shouldBe today.atTime(20, 0)
+        readEvent?.end shouldBe today.atTime(22, 0)
         readEvent?.allDay shouldBe false
         // Title dropped, location replaced with a placeholder presence marker.
         readEvent?.title shouldBe ""
@@ -221,8 +236,8 @@ class InsightCacheTest {
         // a no-location event must come back as a no-location event.
         val noLocationEvent = CalendarEvent(
             title = "Internal sync",
-            start = LocalTime.of(10, 0),
-            end = LocalTime.of(11, 0),
+            start = today.atTime(10, 0),
+            end = today.atTime(11, 0),
             location = null,
             allDay = false,
         )
@@ -230,6 +245,27 @@ class InsightCacheTest {
 
         val read = subject.thisPeriod.first()
         read?.events?.singleOrNull()?.location shouldBe null
+    }
+
+    @Test
+    fun `midnight-crossing event keeps its dated endpoints across the round-trip`() = runTest {
+        // The DTO stores a date + second-of-day pair per endpoint (the
+        // PerModelHourDto pattern), so a 21:00 gig ending at 00:30 tomorrow
+        // must come back with its end still on tomorrow's date — collapsing
+        // both endpoints onto one date would resurrect the wrapped-interval
+        // ambiguity the LocalDateTime migration removed.
+        val gig = CalendarEvent(
+            title = "Late gig",
+            start = today.atTime(21, 0),
+            end = today.plusDays(1).atTime(0, 30),
+            location = "Venue",
+            allDay = false,
+        )
+        subject.store(InsightCache.Slot.THIS_PERIOD, sample.copy(events = listOf(gig)))
+
+        val readEvent = subject.thisPeriod.first()?.events?.singleOrNull()
+        readEvent?.start shouldBe today.atTime(21, 0)
+        readEvent?.end shouldBe today.plusDays(1).atTime(0, 30)
     }
 
     @Test

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/CalendarEvent.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/CalendarEvent.kt
@@ -1,6 +1,6 @@
 package app.clothescast.core.domain.model
 
-import java.time.LocalTime
+import java.time.LocalDateTime
 
 /**
  * Classification applied to each [CalendarEvent] by the reader, so downstream code
@@ -14,10 +14,14 @@ enum class EventKind {
 }
 
 /**
- * One scheduled event read from the user's device calendar, projected into the
- * local day the daily insight is being generated for. Times are wall-clock in the
- * user's zone — the reader is responsible for applying timezone conversion before
- * constructing the model so downstream code never has to think about Instants.
+ * One scheduled event read from the user's device calendar. [start]/[end] are
+ * full local date-times — wall-clock in the user's zone; the reader is
+ * responsible for applying timezone conversion before constructing the model
+ * so downstream code never has to think about Instants. Carrying the date
+ * means an event that crosses midnight is just an interval whose end falls on
+ * the next date, and a tomorrow-pre-dawn event inside tonight's window is
+ * distinguishable from today's — no wrapped-interval special casing anywhere
+ * downstream.
  *
  * Privacy posture: only the [title], [start]/[end], and an optional [location] line
  * are carried. Descriptions, attendees, organizers, and account info are not
@@ -33,8 +37,8 @@ enum class EventKind {
  */
 data class CalendarEvent(
     val title: String,
-    val start: LocalTime,
-    val end: LocalTime,
+    val start: LocalDateTime,
+    val end: LocalDateTime,
     val location: String? = null,
     val allDay: Boolean = false,
     val kind: EventKind = EventKind.NORMAL,
@@ -44,21 +48,11 @@ data class CalendarEvent(
      * True when [time] falls within `[start, end)`. All-day events never
      * match, so the precip-peak overlap check never accidentally pairs an
      * umbrella with "your all-day Public holiday".
-     *
-     * [start]/[end] are date-less wall-clock times, so an event that crosses
-     * midnight projects with `end < start` (a 21:00–00:30 gig reads as
-     * start 21:00, end 00:30). Treat that as a wrapped interval — inside is
-     * `time >= start || time < end` — rather than an empty one, or the
-     * late-evening events the tonight tie-in exists for would never overlap
-     * any peak hour.
      */
-    fun overlaps(time: LocalTime): Boolean {
+    fun overlaps(time: LocalDateTime): Boolean {
         if (allDay) return false
         if (start == end) return time == start
-        return if (end.isBefore(start)) {
-            !time.isBefore(start) || time.isBefore(end)
-        } else {
-            !time.isBefore(start) && time.isBefore(end)
-        }
+        // A defensive end-before-start interval (reader bug) never matches.
+        return !time.isBefore(start) && time.isBefore(end)
     }
 }

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/DeriveInsight.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/DeriveInsight.kt
@@ -126,6 +126,7 @@ class DeriveInsight(
             clothesMentionMode = prefs.clothesMentionMode,
             yesterdayTriggeredItems = periodView.yesterdayTriggeredItems,
             todayRuleItems = Garment.layerReduce(periodView.triggeredOutfit.rules).map { it.item.itemKey },
+            tonightStart = tonightStart,
             diagLog = diagLog,
         )
 
@@ -224,7 +225,7 @@ class DeriveInsight(
             forecast = periodForecast,
             nextForecast = nextForecast,
             triggeredOutfit = triggeredOutfit,
-            events = filterEventsForPeriod(events, period, tonightStart),
+            events = filterEventsForPeriod(events, period, bundle.today.date, morningStart, tonightStart),
             perModelForRender = perModelForRender,
             deltaToday = deltaToday,
             deltaYesterday = deltaYesterday,
@@ -240,7 +241,13 @@ class DeriveInsight(
         allEvents: List<CalendarEvent>,
         todayItems: List<String>,
     ): EveningEventTieInClause? {
-        val nightEvents = filterEventsForPeriod(allEvents, ForecastPeriod.TONIGHT, tonightStart)
+        val nightEvents = filterEventsForPeriod(
+            events = allEvents,
+            period = ForecastPeriod.TONIGHT,
+            todayDate = bundle.today.date,
+            morningStart = morningStart,
+            tonightStart = tonightStart,
+        )
         val awayFromHome = nightEvents.any { !it.allDay && !it.location.isNullOrBlank() }
         if (!awayFromHome) return null
 
@@ -264,6 +271,7 @@ class DeriveInsight(
             deltaThresholdC = prefs.deltaThresholdC,
             deltaFormat = prefs.deltaFormat,
             todayRuleItems = Garment.layerReduce(nightView.triggeredOutfit.rules).map { it.item.itemKey },
+            tonightStart = tonightStart,
         )
 
         // Two emission paths, either of which fires the clause: extra clothing
@@ -358,21 +366,46 @@ class DeriveInsight(
     private fun filterEventsForPeriod(
         events: List<CalendarEvent>,
         period: ForecastPeriod,
+        todayDate: LocalDate,
+        morningStart: LocalTime,
         tonightStart: LocalTime,
-    ): List<CalendarEvent> = when (period) {
-        ForecastPeriod.TODAY -> events
-        // Keep any event that overlaps the night window, not just those that
-        // *start* inside it: an 18:30–21:30 dinner straddles a 19:00 tonight
-        // start, and excluding it made the 7pm notification silent (hasEvents
-        // false) and hid the away-from-home tie-in even though the user is
-        // out for most of the evening. `end <= start` means the event crosses
-        // midnight (date-less wall-clock times), which always reaches into
-        // the night window.
-        ForecastPeriod.TONIGHT -> events.filter {
-            it.allDay ||
-                !it.start.isBefore(tonightStart) ||
-                it.end.isAfter(tonightStart) ||
-                it.end.isBefore(it.start)
+    ): List<CalendarEvent> {
+        // Real interval overlap against the period window, now that events
+        // carry dates. Keep any event that *overlaps* the window, not just
+        // those that start inside it: an 18:30–21:30 dinner straddles a 19:00
+        // tonight start, and excluding it made the 7pm notification silent
+        // (hasEvents false) and hid the away-from-home tie-in even though the
+        // user is out for most of the evening. The upper bound matters too —
+        // the two-day fetch now surfaces tomorrow's events, and a
+        // tomorrow-19:30 dinner must not count for tonight, while a
+        // tomorrow-00:30 gig must.
+        val windowStart: LocalDateTime
+        val windowEnd: LocalDateTime
+        when (period) {
+            // Whole calendar day, preserving the previous "TODAY sees every
+            // event read for the day" semantics.
+            ForecastPeriod.TODAY -> {
+                windowStart = todayDate.atStartOfDay()
+                windowEnd = todayDate.plusDays(1).atStartOfDay()
+            }
+            ForecastPeriod.TONIGHT -> {
+                windowStart = LocalDateTime.of(todayDate, tonightStart)
+                windowEnd = LocalDateTime.of(todayDate.plusDays(1), morningStart)
+            }
+        }
+        return events.filter { event ->
+            if (event.allDay) {
+                // All-day events are presence-only markers (overlaps() never
+                // matches them, and hasEvents / the away-from-home gate both
+                // exclude them): keep today's passing through both periods as
+                // before, and drop tomorrow's, which the two-day fetch now
+                // surfaces too.
+                event.start.toLocalDate() == todayDate
+            } else {
+                // Half-open interval overlap: [start, end) against
+                // [windowStart, windowEnd).
+                event.start.isBefore(windowEnd) && event.end.isAfter(windowStart)
+            }
         }
     }
 
@@ -442,10 +475,23 @@ internal fun tonightWindow(
     windowHourly: List<HourlyForecast>,
     todayDate: LocalDate,
     tonightStart: LocalTime,
-): List<LocalDateTime> = windowHourly.map { entry ->
-    val date = if (!entry.time.isBefore(tonightStart)) todayDate else todayDate.plusDays(1)
-    LocalDateTime.of(date, entry.time)
-}
+): List<LocalDateTime> = windowHourly.map { tonightDateTime(todayDate, tonightStart, it.time) }
+
+/**
+ * Dates a wall-clock [time] inside the tonight window: times at/after
+ * [tonightStart] belong to [todayDate], earlier times to the next day. The
+ * single source of truth for the tonight wrap convention — [tonightWindow]
+ * (per-model slicing) and [RenderInsightSummary] (dating the precip peak
+ * against calendar events) both go through it, so they can't drift apart.
+ */
+internal fun tonightDateTime(
+    todayDate: LocalDate,
+    tonightStart: LocalTime,
+    time: LocalTime,
+): LocalDateTime = LocalDateTime.of(
+    if (!time.isBefore(tonightStart)) todayDate else todayDate.plusDays(1),
+    time,
+)
 
 internal fun DailyForecast.slicedForToday(
     morningStart: LocalTime,

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsight.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsight.kt
@@ -12,7 +12,8 @@ import java.time.Clock
 import java.time.LocalDate
 
 /**
- * The product. Fetches the forecast + reads today's calendar events, captures
+ * The product. Fetches the forecast + reads the calendar events for today and
+ * tomorrow (the tonight window wraps past midnight), captures
  * them as a [ForecastSnapshot], and runs [DeriveInsight] against the current
  * [UserPreferences] to produce a [DailyInsightResult].
  *
@@ -72,7 +73,7 @@ class GenerateDailyInsight(
         } else {
             fetched
         }
-        val events = readEventsForDay(bundle.today.date, prefs)
+        val events = readEvents(bundle.today.date, prefs)
         return ForecastSnapshot(
             bundle = bundle,
             events = events,
@@ -82,14 +83,23 @@ class GenerateDailyInsight(
         )
     }
 
-    private suspend fun readEventsForDay(date: LocalDate, prefs: UserPreferences): List<CalendarEvent> {
+    private suspend fun readEvents(date: LocalDate, prefs: UserPreferences): List<CalendarEvent> {
         // Failures (missing permission, provider crash) degrade to no events so
         // a misbehaving reader can never fail the insight pipeline. Reader
         // implementations are expected to log their own failures before
         // throwing; we don't have a logger in pure-Kotlin :core:domain.
         val reader = calendarEventReader
         if (!prefs.calendarEventMentionsActive || reader == null) return emptyList()
-        return coRunCatching { reader.eventsForDay(date, prefs.schedule.zoneId) }
-            .getOrDefault(emptyList())
+        return coRunCatching {
+            // Fetch today AND tomorrow: the tonight window wraps past midnight
+            // to tomorrow's morning start, and the morning insight's evening
+            // tie-in reads that same window, so both periods need tomorrow's
+            // pre-dawn events — which only the tomorrow day query returns. An
+            // instance spanning midnight is materialized by both day queries
+            // with identical absolute times, so the data-class distinct()
+            // collapses the duplicate.
+            val zone = prefs.schedule.zoneId
+            (reader.eventsForDay(date, zone) + reader.eventsForDay(date.plusDays(1), zone)).distinct()
+        }.getOrDefault(emptyList())
     }
 }

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/RenderInsightSummary.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/RenderInsightSummary.kt
@@ -21,6 +21,7 @@ import app.clothescast.core.domain.model.PrecipProbability.POSSIBLE_THRESHOLD
 import app.clothescast.core.domain.model.TemperatureBand
 import app.clothescast.core.domain.model.WeatherCondition
 import app.clothescast.core.domain.model.isPrecipitation
+import java.time.LocalDate
 import java.time.LocalTime
 import java.util.Locale
 import kotlin.math.abs
@@ -116,6 +117,14 @@ class RenderInsightSummary {
         // emit "Bring a t-shirt." purely because TriggeredOutfit has
         // baseline items.
         todayRuleItems: List<String> = todayItems,
+        // Start of the tonight window, used only to date the precip peak when
+        // pairing it against the dated calendar events for the TONIGHT
+        // calendar tie-in: peak hours at/after this time fall on [today]'s
+        // date, earlier ones on the next day — the same wrap convention as
+        // [tonightWindow], via the shared [tonightDateTime] helper. Defaults
+        // to the 19:00 schedule default so existing callers/tests are
+        // unchanged; [DeriveInsight] passes the user's actual setting.
+        tonightStart: LocalTime = LocalTime.of(19, 0),
         // Diagnostic hook called once per render with a one-line summary
         // of the delta clause decision (today / yesterday inputs, picked
         // side, outcome). Pure-Kotlin module → no DiagLog dependency;
@@ -145,7 +154,11 @@ class RenderInsightSummary {
             // Threshold-rule matches only — a tier's default isn't an
             // "extra to bring," so it shouldn't be what the tie-in
             // points at.
-            calendarTieIn = if (period == ForecastPeriod.TONIGHT) calendarTieInClause(todayRuleItems, peak, events) else null,
+            calendarTieIn = if (period == ForecastPeriod.TONIGHT) {
+                calendarTieInClause(todayRuleItems, peak, events, today.date, tonightStart)
+            } else {
+                null
+            },
             eveningEventTieIn = eveningEventTieIn,
             // Carried accessories (umbrella) ride independently of the wear
             // clause: the formatter folds them into the precip clause, so they
@@ -436,13 +449,20 @@ class RenderInsightSummary {
         items: List<String>,
         peak: PeakPrecip?,
         events: List<CalendarEvent>,
+        todayDate: LocalDate,
+        tonightStart: LocalTime,
     ): CalendarTieInClause? {
         if (items.isEmpty() || peak == null || events.isEmpty()) return null
         // Need an overlapping event to motivate the clause, but we don't capture
         // the event's title or time — neither is in the rendered prose, and we
         // never want a calendar event title flowing through to off-device TTS
         // (the prose is fed to Gemini over the BYOK key).
-        events.firstOrNull { it.overlaps(peak.time) } ?: return null
+        //
+        // The peak is a wall-clock hour inside the tonight window (this clause
+        // only fires on TONIGHT); date it via the shared tonight wrap
+        // convention before pairing against the dated events.
+        val peakAt = tonightDateTime(todayDate, tonightStart, peak.time)
+        events.firstOrNull { it.overlaps(peakAt) } ?: return null
         // Pick the first triggered item, mirroring rule 3's ordering. The formatter
         // silences accessories (umbrella) before they reach the rendered prose, so
         // there's no point picking a specifically-precip-motivated item here — until

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/model/CalendarEventTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/model/CalendarEventTest.kt
@@ -2,51 +2,74 @@ package app.clothescast.core.domain.model
 
 import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
-import java.time.LocalTime
+import java.time.LocalDate
+import java.time.LocalDateTime
 
 class CalendarEventTest {
 
-    private fun event(start: LocalTime, end: LocalTime, allDay: Boolean = false) =
+    private val day: LocalDate = LocalDate.of(2026, 4, 25)
+
+    private fun event(start: LocalDateTime, end: LocalDateTime, allDay: Boolean = false) =
         CalendarEvent(title = "gig", start = start, end = end, allDay = allDay)
 
     @Test
     fun `overlaps is a half-open interval for a same-day event`() {
-        val e = event(LocalTime.of(20, 0), LocalTime.of(22, 0))
-        e.overlaps(LocalTime.of(19, 59)) shouldBe false
-        e.overlaps(LocalTime.of(20, 0)) shouldBe true
-        e.overlaps(LocalTime.of(21, 30)) shouldBe true
-        e.overlaps(LocalTime.of(22, 0)) shouldBe false
+        val e = event(day.atTime(20, 0), day.atTime(22, 0))
+        e.overlaps(day.atTime(19, 59)) shouldBe false
+        e.overlaps(day.atTime(20, 0)) shouldBe true
+        e.overlaps(day.atTime(21, 30)) shouldBe true
+        e.overlaps(day.atTime(22, 0)) shouldBe false
     }
 
     @Test
-    fun `midnight-crossing event overlaps both sides of midnight`() {
-        // start/end are date-less wall-clock times, so a 21:00-00:30 gig
-        // projects with end < start. It must read as a wrapped interval —
-        // the late-evening events the tonight tie-in exists for would
-        // otherwise never overlap any peak hour.
-        val gig = event(LocalTime.of(21, 0), LocalTime.of(0, 30))
-        gig.overlaps(LocalTime.of(20, 59)) shouldBe false
-        gig.overlaps(LocalTime.of(21, 0)) shouldBe true
-        gig.overlaps(LocalTime.of(23, 0)) shouldBe true
-        gig.overlaps(LocalTime.MIDNIGHT) shouldBe true
-        gig.overlaps(LocalTime.of(0, 29)) shouldBe true
-        gig.overlaps(LocalTime.of(0, 30)) shouldBe false
-        gig.overlaps(LocalTime.of(12, 0)) shouldBe false
+    fun `midnight-crossing event overlaps both sides of midnight with plain interval semantics`() {
+        // start/end carry dates, so a 21:00 gig ending at 00:30 the next day
+        // is just an interval whose end falls on the next date — no wrapped-
+        // interval special case needed for the overlap to hold on both sides
+        // of midnight.
+        val nextDay = day.plusDays(1)
+        val gig = event(day.atTime(21, 0), nextDay.atTime(0, 30))
+        gig.overlaps(day.atTime(20, 59)) shouldBe false
+        gig.overlaps(day.atTime(21, 0)) shouldBe true
+        gig.overlaps(day.atTime(23, 0)) shouldBe true
+        gig.overlaps(nextDay.atStartOfDay()) shouldBe true
+        gig.overlaps(nextDay.atTime(0, 29)) shouldBe true
+        gig.overlaps(nextDay.atTime(0, 30)) shouldBe false
+        // Same wall-clock hour on the wrong date never matches.
+        gig.overlaps(day.atTime(0, 15)) shouldBe false
+        gig.overlaps(day.atTime(12, 0)) shouldBe false
+        gig.overlaps(nextDay.atTime(21, 0)) shouldBe false
     }
 
     @Test
     fun `event ending exactly at midnight covers the evening only`() {
-        // end = 00:00 reads as "until midnight", not an empty interval.
-        val e = event(LocalTime.of(21, 0), LocalTime.MIDNIGHT)
-        e.overlaps(LocalTime.of(23, 0)) shouldBe true
-        e.overlaps(LocalTime.MIDNIGHT) shouldBe false
-        e.overlaps(LocalTime.of(20, 0)) shouldBe false
+        // end = next-day 00:00 reads as "until midnight", half-open.
+        val e = event(day.atTime(21, 0), day.plusDays(1).atStartOfDay())
+        e.overlaps(day.atTime(23, 0)) shouldBe true
+        e.overlaps(day.plusDays(1).atStartOfDay()) shouldBe false
+        e.overlaps(day.atTime(20, 0)) shouldBe false
+    }
+
+    @Test
+    fun `zero-length event matches only its own instant`() {
+        val e = event(day.atTime(9, 0), day.atTime(9, 0))
+        e.overlaps(day.atTime(9, 0)) shouldBe true
+        e.overlaps(day.atTime(9, 1)) shouldBe false
+    }
+
+    @Test
+    fun `end-before-start interval never matches`() {
+        // Defensive: a reader bug yielding end < start reads as empty, not wrapped.
+        val e = event(day.atTime(21, 0), day.atTime(20, 0))
+        e.overlaps(day.atTime(20, 30)) shouldBe false
+        e.overlaps(day.atTime(21, 0)) shouldBe false
+        e.overlaps(day.atTime(22, 0)) shouldBe false
     }
 
     @Test
     fun `all-day events never overlap`() {
-        val e = event(LocalTime.MIDNIGHT, LocalTime.MIDNIGHT, allDay = true)
-        e.overlaps(LocalTime.of(12, 0)) shouldBe false
-        e.overlaps(LocalTime.MIDNIGHT) shouldBe false
+        val e = event(day.atStartOfDay(), day.atStartOfDay(), allDay = true)
+        e.overlaps(day.atTime(12, 0)) shouldBe false
+        e.overlaps(day.atStartOfDay()) shouldBe false
     }
 }

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsightTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsightTest.kt
@@ -97,19 +97,23 @@ class GenerateDailyInsightTest {
     }
 
     private class FakeCalendarEventReader(
+        // Same list for any queried date — fine for fixtures dated inside the
+        // two-day fetch window, since the use case's distinct() collapses the
+        // duplicate the second day query returns. Use [eventsByDate] when a
+        // test cares which day a given event is materialized for.
         private val events: List<CalendarEvent> = emptyList(),
+        private val eventsByDate: Map<LocalDate, List<CalendarEvent>>? = null,
         private val throws: Throwable? = null,
     ) : CalendarEventReader {
-        var lastDate: LocalDate? = null
-            private set
+        val requestedDates = mutableListOf<LocalDate>()
         var lastZone: ZoneId? = null
             private set
 
         override suspend fun eventsForDay(date: LocalDate, zoneId: ZoneId): List<CalendarEvent> {
-            lastDate = date
+            requestedDates += date
             lastZone = zoneId
             throws?.let { throw it }
-            return events
+            return if (eventsByDate != null) eventsByDate[date].orEmpty() else events
         }
 
         override suspend fun upcomingCelebrations(
@@ -384,12 +388,12 @@ class GenerateDailyInsightTest {
     }
 
     @Test
-    fun `calendar reader is consulted for today's date and zone when opted in`() = runTest {
+    fun `calendar reader is consulted for today and tomorrow with the user's zone when opted in`() = runTest {
         val zone = ZoneId.of("Europe/London")
         val event = CalendarEvent(
             title = "park run",
-            start = LocalTime.of(14, 30),
-            end = LocalTime.of(16, 0),
+            start = today.date.atTime(14, 30),
+            end = today.date.atTime(16, 0),
         )
         val weather = FakeWeatherRepository(ForecastBundle(today, yesterday))
         val calendar = FakeCalendarEventReader(events = listOf(event))
@@ -403,7 +407,10 @@ class GenerateDailyInsightTest {
             ),
         )
 
-        calendar.lastDate shouldBe today.date
+        // Tomorrow rides along because the tonight window (and the morning
+        // insight's evening tie-in) wraps past midnight into tomorrow's
+        // pre-dawn hours.
+        calendar.requestedDates shouldContainExactly listOf(today.date, today.date.plusDays(1))
         calendar.lastZone shouldBe zone
         // The morning rain tie-in is suppressed on TODAY (PR #149); the tonight
         // pass still carries the existing CalendarTieInClause — see the
@@ -416,13 +423,13 @@ class GenerateDailyInsightTest {
     fun `calendar reader is not consulted when the toggle is off`() = runTest {
         val weather = FakeWeatherRepository(ForecastBundle(today, yesterday))
         val calendar = FakeCalendarEventReader(events = listOf(
-            CalendarEvent("standup", LocalTime.of(9, 0), LocalTime.of(9, 30)),
+            CalendarEvent("standup", today.date.atTime(9, 0), today.date.atTime(9, 30)),
         ))
         val subject = GenerateDailyInsight(weather, calendarEventReader = calendar, clock = clock)
 
         val result = subject(london, prefs.copy(useCalendarEvents = false))
 
-        calendar.lastDate.shouldBeNull()
+        calendar.requestedDates.shouldBeEmpty()
         result.insight.summary.calendarTieIn.shouldBeNull()
     }
 
@@ -818,8 +825,8 @@ class GenerateDailyInsightTest {
         val perModelHourly = PerModelHourly(byModel = mapOf("ecmwf_ifs04" to ecmwfFull))
         val diner = CalendarEvent(
             title = "dinner",
-            start = LocalTime.of(21, 0),
-            end = LocalTime.of(23, 0),
+            start = today.date.atTime(21, 0),
+            end = today.date.atTime(23, 0),
             location = "Restaurant",
         )
         val weather = FakeWeatherRepository(
@@ -890,8 +897,8 @@ class GenerateDailyInsightTest {
         val perModelHourly = PerModelHourly(byModel = mapOf("ecmwf_ifs04" to ecmwfFull))
         val diner = CalendarEvent(
             title = "after-hours",
-            start = LocalTime.of(22, 0),
-            end = LocalTime.of(23, 30),
+            start = today.date.atTime(22, 0),
+            end = today.date.atTime(23, 30),
             location = "Theatre",
         )
         val weather = FakeWeatherRepository(
@@ -935,8 +942,8 @@ class GenerateDailyInsightTest {
         )
         val unlocated = CalendarEvent(
             title = "call",
-            start = LocalTime.of(21, 0),
-            end = LocalTime.of(22, 0),
+            start = today.date.atTime(21, 0),
+            end = today.date.atTime(22, 0),
             location = null,
         )
         val weather = FakeWeatherRepository(ForecastBundle(baseHourly, yesterday))
@@ -979,8 +986,8 @@ class GenerateDailyInsightTest {
         )
         val diner = CalendarEvent(
             title = "dinner",
-            start = LocalTime.of(21, 0),
-            end = LocalTime.of(23, 0),
+            start = today.date.atTime(21, 0),
+            end = today.date.atTime(23, 0),
             location = "Restaurant",
         )
         val weather = FakeWeatherRepository(ForecastBundle(baseHourly, yesterday))
@@ -1027,8 +1034,8 @@ class GenerateDailyInsightTest {
         )
         val diner = CalendarEvent(
             title = "dinner",
-            start = LocalTime.of(21, 0),
-            end = LocalTime.of(23, 0),
+            start = today.date.atTime(21, 0),
+            end = today.date.atTime(23, 0),
             location = "Restaurant",
         )
         val weather = FakeWeatherRepository(ForecastBundle(baseHourly, yesterday))
@@ -1076,8 +1083,8 @@ class GenerateDailyInsightTest {
         )
         val diner = CalendarEvent(
             title = "dinner",
-            start = LocalTime.of(21, 0),
-            end = LocalTime.of(23, 0),
+            start = today.date.atTime(21, 0),
+            end = today.date.atTime(23, 0),
             location = "Restaurant",
         )
         val weather = FakeWeatherRepository(ForecastBundle(baseHourly, yesterday))
@@ -1129,8 +1136,8 @@ class GenerateDailyInsightTest {
         )
         val diner = CalendarEvent(
             title = "dinner",
-            start = LocalTime.of(21, 0),
-            end = LocalTime.of(23, 0),
+            start = today.date.atTime(21, 0),
+            end = today.date.atTime(23, 0),
             location = "Restaurant",
         )
         val weather = FakeWeatherRepository(ForecastBundle(baseHourly, yesterday))
@@ -1184,8 +1191,8 @@ class GenerateDailyInsightTest {
         )
         val diner = CalendarEvent(
             title = "dinner",
-            start = LocalTime.of(21, 0),
-            end = LocalTime.of(23, 0),
+            start = today.date.atTime(21, 0),
+            end = today.date.atTime(23, 0),
             location = "Restaurant",
         )
         val weather = FakeWeatherRepository(ForecastBundle(baseHourly, yesterday))
@@ -1235,8 +1242,8 @@ class GenerateDailyInsightTest {
         )
         val diner = CalendarEvent(
             title = "dinner",
-            start = LocalTime.of(21, 0),
-            end = LocalTime.of(23, 0),
+            start = today.date.atTime(21, 0),
+            end = today.date.atTime(23, 0),
             location = "Restaurant",
         )
         val weather = FakeWeatherRepository(ForecastBundle(baseHourly, yesterday))
@@ -1279,8 +1286,8 @@ class GenerateDailyInsightTest {
         )
         val diner = CalendarEvent(
             title = "dinner",
-            start = LocalTime.of(21, 0),
-            end = LocalTime.of(23, 0),
+            start = today.date.atTime(21, 0),
+            end = today.date.atTime(23, 0),
             location = "Restaurant",
         )
         val weather = FakeWeatherRepository(ForecastBundle(baseHourly, yesterday))
@@ -1326,8 +1333,8 @@ class GenerateDailyInsightTest {
         )
         val diner = CalendarEvent(
             title = "dinner",
-            start = LocalTime.of(21, 0),
-            end = LocalTime.of(23, 0),
+            start = today.date.atTime(21, 0),
+            end = today.date.atTime(23, 0),
             location = "Restaurant",
         )
         val weather = FakeWeatherRepository(ForecastBundle(baseHourly, yesterday))
@@ -1374,8 +1381,8 @@ class GenerateDailyInsightTest {
         )
         val diner = CalendarEvent(
             title = "dinner",
-            start = LocalTime.of(21, 0),
-            end = LocalTime.of(23, 0),
+            start = today.date.atTime(21, 0),
+            end = today.date.atTime(23, 0),
             location = "Restaurant",
         )
         val weather = FakeWeatherRepository(ForecastBundle(baseHourly, yesterday))
@@ -1424,8 +1431,8 @@ class GenerateDailyInsightTest {
         )
         val diner = CalendarEvent(
             title = "dinner",
-            start = LocalTime.of(21, 0),
-            end = LocalTime.of(23, 0),
+            start = today.date.atTime(21, 0),
+            end = today.date.atTime(23, 0),
             location = "Restaurant",
         )
         val weather = FakeWeatherRepository(ForecastBundle(baseHourly, yesterday))
@@ -1470,8 +1477,8 @@ class GenerateDailyInsightTest {
         )
         val diner = CalendarEvent(
             title = "dinner",
-            start = LocalTime.of(21, 0),
-            end = LocalTime.of(23, 0),
+            start = today.date.atTime(21, 0),
+            end = today.date.atTime(23, 0),
             location = "Restaurant",
         )
         val weather = FakeWeatherRepository(ForecastBundle(baseHourly, yesterday))
@@ -1515,8 +1522,8 @@ class GenerateDailyInsightTest {
         )
         val diner = CalendarEvent(
             title = "dinner",
-            start = LocalTime.of(21, 0),
-            end = LocalTime.of(23, 0),
+            start = today.date.atTime(21, 0),
+            end = today.date.atTime(23, 0),
             location = "Restaurant",
         )
         val weather = FakeWeatherRepository(ForecastBundle(baseHourly, yesterday))
@@ -1562,8 +1569,8 @@ class GenerateDailyInsightTest {
         )
         val diner = CalendarEvent(
             title = "dinner",
-            start = LocalTime.of(21, 0),
-            end = LocalTime.of(23, 0),
+            start = today.date.atTime(21, 0),
+            end = today.date.atTime(23, 0),
             location = "Restaurant",
         )
         val weather = FakeWeatherRepository(ForecastBundle(baseHourly, yesterday))
@@ -1612,8 +1619,8 @@ class GenerateDailyInsightTest {
         )
         val diner = CalendarEvent(
             title = "dinner",
-            start = LocalTime.of(21, 0),
-            end = LocalTime.of(23, 0),
+            start = today.date.atTime(21, 0),
+            end = today.date.atTime(23, 0),
             location = "Restaurant",
         )
         val weather = FakeWeatherRepository(ForecastBundle(baseHourly, yesterday))
@@ -1839,13 +1846,13 @@ class GenerateDailyInsightTest {
         )
         val morningStandup = CalendarEvent(
             title = "standup",
-            start = LocalTime.of(9, 0),
-            end = LocalTime.of(9, 30),
+            start = today.date.atTime(9, 0),
+            end = today.date.atTime(9, 30),
         )
         val eveningGig = CalendarEvent(
             title = "gig",
-            start = LocalTime.of(20, 0),
-            end = LocalTime.of(22, 0),
+            start = today.date.atTime(20, 0),
+            end = today.date.atTime(22, 0),
             location = "Brixton Academy",
         )
         val weather = FakeWeatherRepository(ForecastBundle(rainyEvening, yesterday))
@@ -1881,8 +1888,8 @@ class GenerateDailyInsightTest {
         val zone = ZoneId.of("Europe/London")
         val unlocatedHold = CalendarEvent(
             title = "block",
-            start = LocalTime.of(20, 0),
-            end = LocalTime.of(21, 0),
+            start = today.date.atTime(20, 0),
+            end = today.date.atTime(21, 0),
         )
         val weather = FakeWeatherRepository(ForecastBundle(today, yesterday))
         val calendar = FakeCalendarEventReader(events = listOf(unlocatedHold))
@@ -1905,15 +1912,15 @@ class GenerateDailyInsightTest {
         val zone = ZoneId.of("Europe/London")
         val christmas = CalendarEvent(
             title = "Christmas Day",
-            start = LocalTime.MIDNIGHT,
-            end = LocalTime.MIDNIGHT,
+            start = today.date.atStartOfDay(),
+            end = today.date.atStartOfDay(),
             allDay = true,
             kind = EventKind.PUBLIC_HOLIDAY,
         )
         val aliceBirthday = CalendarEvent(
             title = "Alice's birthday",
-            start = LocalTime.MIDNIGHT,
-            end = LocalTime.MIDNIGHT,
+            start = today.date.atStartOfDay(),
+            end = today.date.atStartOfDay(),
             allDay = true,
             kind = EventKind.BIRTHDAY,
         )
@@ -1935,8 +1942,8 @@ class GenerateDailyInsightTest {
         val zone = ZoneId.of("Europe/London")
         val morningOnly = CalendarEvent(
             title = "standup",
-            start = LocalTime.of(9, 0),
-            end = LocalTime.of(9, 30),
+            start = today.date.atTime(9, 0),
+            end = today.date.atTime(9, 30),
         )
         val weather = FakeWeatherRepository(ForecastBundle(today, yesterday))
         val calendar = FakeCalendarEventReader(events = listOf(morningOnly))
@@ -1960,8 +1967,8 @@ class GenerateDailyInsightTest {
         val zone = ZoneId.of("Europe/London")
         val dinner = CalendarEvent(
             title = "dinner",
-            start = LocalTime.of(18, 30),
-            end = LocalTime.of(21, 30),
+            start = today.date.atTime(18, 30),
+            end = today.date.atTime(21, 30),
             location = "City A",
         )
         val weather = FakeWeatherRepository(ForecastBundle(today, yesterday))
@@ -1979,14 +1986,14 @@ class GenerateDailyInsightTest {
 
     @Test
     fun `tonight hasEvents is true for a located event crossing midnight`() = runTest {
-        // A 21:00-00:30 gig projects with end < start (date-less wall-clock
-        // times). The crossing must read as reaching into the night window,
+        // A 21:00-00:30 gig is now a plain dated interval whose end falls on
+        // tomorrow's date. It must read as reaching into the night window,
         // not as an empty interval.
         val zone = ZoneId.of("Europe/London")
         val gig = CalendarEvent(
             title = "gig",
-            start = LocalTime.of(21, 0),
-            end = LocalTime.of(0, 30),
+            start = today.date.atTime(21, 0),
+            end = today.date.plusDays(1).atTime(0, 30),
             location = "City A",
         )
         val weather = FakeWeatherRepository(ForecastBundle(today, yesterday))
@@ -2000,6 +2007,58 @@ class GenerateDailyInsightTest {
         )
 
         result.insight.hasEvents shouldBe true
+    }
+
+    @Test
+    fun `tonight hasEvents is true for a located event in tomorrow's pre-dawn hours`() = runTest {
+        // A 00:30 event on *tomorrow's* date sits inside the tonight window
+        // [19:00 today, 07:00 tomorrow) but is only materialized by the reader
+        // for tomorrow's date — the old single-day fetch never even saw it.
+        val zone = ZoneId.of("Europe/London")
+        val tomorrow = today.date.plusDays(1)
+        val afterParty = CalendarEvent(
+            title = "after-party",
+            start = tomorrow.atTime(0, 30),
+            end = tomorrow.atTime(2, 0),
+            location = "City A",
+        )
+        val weather = FakeWeatherRepository(ForecastBundle(today, yesterday))
+        val calendar = FakeCalendarEventReader(eventsByDate = mapOf(tomorrow to listOf(afterParty)))
+        val subject = GenerateDailyInsight(weather, calendarEventReader = calendar, clock = clock)
+
+        val result = subject(
+            location = london,
+            prefs = prefs.copy(useCalendarEvents = true, schedule = Schedule.default(zone)),
+            period = ForecastPeriod.TONIGHT,
+        )
+
+        result.insight.hasEvents shouldBe true
+    }
+
+    @Test
+    fun `tonight hasEvents is false for a located event tomorrow evening`() = runTest {
+        // The two-day fetch also returns tomorrow's 19:30 dinner, but the
+        // tonight window is bounded at tomorrow's 07:00 morning start — the
+        // *next* evening's event must not light up tonight's notification.
+        val zone = ZoneId.of("Europe/London")
+        val tomorrow = today.date.plusDays(1)
+        val nextDinner = CalendarEvent(
+            title = "dinner",
+            start = tomorrow.atTime(19, 30),
+            end = tomorrow.atTime(21, 30),
+            location = "City A",
+        )
+        val weather = FakeWeatherRepository(ForecastBundle(today, yesterday))
+        val calendar = FakeCalendarEventReader(eventsByDate = mapOf(tomorrow to listOf(nextDinner)))
+        val subject = GenerateDailyInsight(weather, calendarEventReader = calendar, clock = clock)
+
+        val result = subject(
+            location = london,
+            prefs = prefs.copy(useCalendarEvents = true, schedule = Schedule.default(zone)),
+            period = ForecastPeriod.TONIGHT,
+        )
+
+        result.insight.hasEvents shouldBe false
     }
 
     @Test
@@ -2055,8 +2114,8 @@ class GenerateDailyInsightTest {
         )
         val diner = CalendarEvent(
             title = "dinner",
-            start = LocalTime.of(21, 0),
-            end = LocalTime.of(23, 0),
+            start = today.date.atTime(21, 0),
+            end = today.date.atTime(23, 0),
             location = "Restaurant",
         )
         val weather = FakeWeatherRepository(

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/RenderInsightSummaryTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/RenderInsightSummaryTest.kt
@@ -47,6 +47,13 @@ class RenderInsightSummaryTest {
         condition = WeatherCondition.PARTLY_CLOUDY,
     )
 
+    // The TONIGHT calendar tie-in dates the precip peak with the tonightWindow
+    // wrap convention: hours before the default 19:00 tonight start — like the
+    // 15:00 peak these fixtures use — fall on the day *after* mildToday.date,
+    // so events meant to overlap (or be compared against) that peak are dated
+    // tomorrow.
+    private val tonightPeakDate = mildToday.date.plusDays(1)
+
     @Test
     fun `band clause is always emitted`() {
         val out = subject(mildToday, yesterday, emptyList())
@@ -401,7 +408,7 @@ class RenderInsightSummaryTest {
             condition = WeatherCondition.RAIN,
             hourly = listOf(HourlyForecast(LocalTime.of(15, 0), 22.0, 22.0, 60.0, WeatherCondition.RAIN)),
         )
-        val event = CalendarEvent("standup", LocalTime.of(14, 30), LocalTime.of(16, 0))
+        val event = CalendarEvent("standup", mildToday.date.atTime(14, 30), mildToday.date.atTime(16, 0))
         subject(today, yesterday, listOf("umbrella"), events = listOf(event)).calendarTieIn.shouldBeNull()
     }
 
@@ -415,7 +422,7 @@ class RenderInsightSummaryTest {
             condition = WeatherCondition.CLOUDY,
             hourly = listOf(HourlyForecast(LocalTime.of(15, 0), 22.0, 22.0, 60.0, WeatherCondition.CLOUDY)),
         )
-        val event = CalendarEvent("park run", LocalTime.of(14, 30), LocalTime.of(16, 0))
+        val event = CalendarEvent("park run", tonightPeakDate.atTime(14, 30), tonightPeakDate.atTime(16, 0))
         subject(
             today, yesterday, listOf("umbrella"),
             events = listOf(event),
@@ -464,7 +471,7 @@ class RenderInsightSummaryTest {
                 HourlyForecast(LocalTime.of(15, 0), 22.0, 22.0, 60.0, WeatherCondition.RAIN),
             ),
         )
-        val event = CalendarEvent("park run", LocalTime.of(14, 30), LocalTime.of(16, 0))
+        val event = CalendarEvent("park run", tonightPeakDate.atTime(14, 30), tonightPeakDate.atTime(16, 0))
         subject(
             today, yesterday, listOf("t-shirt", "pants"),
             events = listOf(event),
@@ -484,8 +491,8 @@ class RenderInsightSummaryTest {
         )
         val event = CalendarEvent(
             title = "park run",
-            start = LocalTime.of(14, 30),
-            end = LocalTime.of(16, 0),
+            start = tonightPeakDate.atTime(14, 30),
+            end = tonightPeakDate.atTime(16, 0),
         )
         val out = subject(
             today, yesterday, listOf("umbrella"),
@@ -507,7 +514,7 @@ class RenderInsightSummaryTest {
             condition = WeatherCondition.RAIN,
             hourly = listOf(HourlyForecast(LocalTime.of(15, 0), 22.0, 22.0, 60.0, WeatherCondition.RAIN)),
         )
-        val event = CalendarEvent("park run", LocalTime.of(14, 0), LocalTime.of(16, 0))
+        val event = CalendarEvent("park run", tonightPeakDate.atTime(14, 0), tonightPeakDate.atTime(16, 0))
         val out = subject(
             today, yesterday, listOf("sweater", "jacket"),
             events = listOf(event),
@@ -524,7 +531,7 @@ class RenderInsightSummaryTest {
             condition = WeatherCondition.RAIN,
             hourly = listOf(HourlyForecast(LocalTime.of(15, 0), 22.0, 22.0, 60.0, WeatherCondition.RAIN)),
         )
-        val event = CalendarEvent("breakfast", LocalTime.of(8, 0), LocalTime.of(9, 0))
+        val event = CalendarEvent("breakfast", tonightPeakDate.atTime(8, 0), tonightPeakDate.atTime(9, 0))
         subject(
             today, yesterday, listOf("umbrella"),
             events = listOf(event),
@@ -539,7 +546,7 @@ class RenderInsightSummaryTest {
             condition = WeatherCondition.RAIN,
             hourly = listOf(HourlyForecast(LocalTime.of(15, 0), 22.0, 22.0, 60.0, WeatherCondition.RAIN)),
         )
-        val event = CalendarEvent("park run", LocalTime.of(14, 30), LocalTime.of(16, 0))
+        val event = CalendarEvent("park run", tonightPeakDate.atTime(14, 30), tonightPeakDate.atTime(16, 0))
         subject(
             today, yesterday, emptyList(),
             events = listOf(event),
@@ -549,7 +556,7 @@ class RenderInsightSummaryTest {
 
     @Test
     fun `calendar tie-in is omitted on a dry day even when an event exists`() {
-        val event = CalendarEvent("park run", LocalTime.of(11, 0), LocalTime.of(13, 0))
+        val event = CalendarEvent("park run", tonightPeakDate.atTime(11, 0), tonightPeakDate.atTime(13, 0))
         subject(
             mildToday, yesterday, listOf("umbrella"),
             events = listOf(event),
@@ -564,7 +571,12 @@ class RenderInsightSummaryTest {
             condition = WeatherCondition.RAIN,
             hourly = listOf(HourlyForecast(LocalTime.of(15, 0), 22.0, 22.0, 60.0, WeatherCondition.RAIN)),
         )
-        val holiday = CalendarEvent("public holiday", LocalTime.MIDNIGHT, LocalTime.MIDNIGHT, allDay = true)
+        val holiday = CalendarEvent(
+            "public holiday",
+            mildToday.date.atStartOfDay(),
+            mildToday.date.atStartOfDay(),
+            allDay = true,
+        )
         subject(
             today, yesterday, listOf("umbrella"),
             events = listOf(holiday),

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/ThemeForTodayTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/ThemeForTodayTest.kt
@@ -9,7 +9,6 @@ import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import java.time.LocalDate
-import java.time.LocalTime
 import java.time.Month
 import org.junit.jupiter.api.Test
 
@@ -20,10 +19,12 @@ class ThemeForTodayTest {
     private val random = LocalDate.of(2026, Month.MAY, 18)
     private val christmas = LocalDate.of(2026, Month.DECEMBER, 25)
 
+    // ThemeForToday reads only title/kind/ownerAccount, so the events'
+    // anchor date is irrelevant to these tests; [random] keeps it stable.
     private fun publicHoliday(title: String, ownerAccount: String? = null) = CalendarEvent(
         title = title,
-        start = LocalTime.MIDNIGHT,
-        end = LocalTime.MIDNIGHT,
+        start = random.atStartOfDay(),
+        end = random.atStartOfDay(),
         allDay = true,
         kind = EventKind.PUBLIC_HOLIDAY,
         ownerAccount = ownerAccount,
@@ -31,8 +32,8 @@ class ThemeForTodayTest {
 
     private fun birthday(title: String) = CalendarEvent(
         title = title,
-        start = LocalTime.MIDNIGHT,
-        end = LocalTime.MIDNIGHT,
+        start = random.atStartOfDay(),
+        end = random.atStartOfDay(),
         allDay = true,
         kind = EventKind.BIRTHDAY,
     )
@@ -416,8 +417,8 @@ class ThemeForTodayTest {
     fun `NORMAL kind events are ignored`() {
         val normalEvent = CalendarEvent(
             title = "Standup",
-            start = LocalTime.of(9, 0),
-            end = LocalTime.of(9, 30),
+            start = random.atTime(9, 0),
+            end = random.atTime(9, 30),
             kind = EventKind.NORMAL,
         )
         subject.resolve(


### PR DESCRIPTION
## Summary

The last substantial item from the bug-hunt backlog (#1008/#1009/#1010): calendar events get dated times, fixing the class of tonight-window bugs that date-less `LocalTime` start/end made unrepresentable.

**What was broken:**
1. A located event at 00:30 on tomorrow's date — squarely inside the tonight window [19:00, 07:00) — was invisible to `hasEvents`, the away-from-home gate, and both tie-ins, because events were only fetched for today's calendar date and the model couldn't carry tomorrow's date anyway. The 7pm notification posted silently even though the user had a late-night plan out of the house.
2. Midnight-crossing events (21:00–00:30) projected with `end < start` and needed a wrapped-interval special case in `overlaps()` (added in #1009 as a stopgap).
3. The tonight window had no usable morning end bound — with a two-day fetch, a tomorrow-19:30 dinner would have wrongly counted for tonight.

**The change:** `CalendarEvent.start`/`end` are now `LocalDateTime`. The reader projects instance times in full; `GenerateDailyInsight` fetches today + tomorrow (deduped — a midnight-spanning instance materializes identically from both day queries); the period filter is a true interval overlap against [today@tonightStart, tomorrow@morningStart) for TONIGHT and the whole civil day for TODAY (preserving existing semantics); all-day events stay presence-only and keep to today's date; the precip-peak-vs-event pairing dates the peak through a shared `tonightDateTime` helper using the exact wrap convention `tonightWindow` already uses; the wrapped-interval special case in `overlaps()` is deleted (a defensive `end < start` now reads as empty).

**Cache:** the snapshot schema bumps v7 → v8 (`CalendarEventDto` gains per-endpoint dates, mirroring `PerModelHourDto`). Old cached payloads drop to null on first read and the next worker run repopulates — same self-healing pattern as the v6 → v7 bump.

## Privacy

Unchanged: the cache still persists only start/end/allDay and a location-*presence* flag; titles and location strings never enter the model's persisted form, and nothing new crosses the device boundary.

## Test plan

New coverage: tomorrow-00:30 located event → tonight `hasEvents` true; tomorrow-19:30 event → tonight `hasEvents` false (the new upper bound); dated midnight-crossing overlap with no special casing; same-wall-clock-hour-wrong-date never matches; v8 DTO round-trip with a dated event. All existing straddle/crossing tests from #1009 stay green on dated fixtures. Full local run green: `:core:domain:test` + `:core:data:test` + `:app:testDebugUnitTest` + `:app:assembleDebug` (exit 0), run cleanly with no concurrent git operations.

https://claude.ai/code/session_018MD6LyP3Am3FcED1NCBLw8

---
_Generated by [Claude Code](https://claude.ai/code/session_018MD6LyP3Am3FcED1NCBLw8)_