### PR TITLE
Your saved forecast now survives app updates

### DIFF
--- a/app/src/main/kotlin/app/clothescast/data/InsightCache.kt
+++ b/app/src/main/kotlin/app/clothescast/data/InsightCache.kt
@@ -98,10 +98,12 @@ class InsightCache(
     enum class Slot { THIS_PERIOD, NEXT_PERIOD }
 
     /** Raw snapshot stored for page 1 — the 12-hour window the user is currently in. */
-    val thisPeriod: Flow<ForecastSnapshot?> = dataStore.data.map { it.readSlot(THIS_PERIOD_KEY) }
+    val thisPeriod: Flow<ForecastSnapshot?> =
+        dataStore.data.map { it.readSlot(THIS_PERIOD_KEY, LEGACY_THIS_PERIOD_V7_KEY) }
 
     /** Raw snapshot stored for page 2 — the pre-captured next 12-hour window. */
-    val nextPeriod: Flow<ForecastSnapshot?> = dataStore.data.map { it.readSlot(NEXT_PERIOD_KEY) }
+    val nextPeriod: Flow<ForecastSnapshot?> =
+        dataStore.data.map { it.readSlot(NEXT_PERIOD_KEY, LEGACY_NEXT_PERIOD_V7_KEY) }
 
     /**
      * Derives the [DailyInsightResult] for [slot] against [prefs] using the
@@ -124,7 +126,14 @@ class InsightCache(
     }
 
     suspend fun store(slot: Slot, snapshot: ForecastSnapshot) {
-        dataStore.edit { it[keyFor(slot)] = json.encodeToString(snapshot.toDto()) }
+        dataStore.edit {
+            it[keyFor(slot)] = json.encodeToString(snapshot.toDto())
+            // A fresh capture supersedes whatever the pre-update build left
+            // under the old key names; drop them so the read fallback can't
+            // resurrect a stale snapshot and the orphaned bytes don't linger.
+            it.remove(legacyKeyFor(slot))
+            it.remove(LEGACY_V6_KEYS.getValue(slot))
+        }
     }
 
     /**
@@ -161,18 +170,35 @@ class InsightCache(
         dataStore.edit {
             it.remove(THIS_PERIOD_KEY)
             it.remove(NEXT_PERIOD_KEY)
+            it.remove(LEGACY_THIS_PERIOD_V7_KEY)
+            it.remove(LEGACY_NEXT_PERIOD_V7_KEY)
+            LEGACY_V6_KEYS.values.forEach { key -> it.remove(key) }
         }
     }
 
-    private fun Preferences.readSlot(key: androidx.datastore.preferences.core.Preferences.Key<String>): ForecastSnapshot? {
-        val raw = this[key] ?: return null
+    private fun Preferences.readSlot(
+        key: Preferences.Key<String>,
+        legacyKey: Preferences.Key<String>,
+    ): ForecastSnapshot? {
+        // Fall back to the pre-update v7 payload when the live key is empty so
+        // an app update doesn't blank the Today screen / widget until the next
+        // fetch lands. The v7 shape decodes into the current DTO (the event
+        // date fields default to null and materialise against the snapshot's
+        // own date), so only the key name needs bridging.
+        val raw = this[key] ?: this[legacyKey] ?: return null
         return runCatching { json.decodeFromString<ForecastSnapshotDto>(raw).toDomain() }.getOrNull()
     }
 
-    private fun keyFor(slot: Slot): androidx.datastore.preferences.core.Preferences.Key<String> =
+    private fun keyFor(slot: Slot): Preferences.Key<String> =
         when (slot) {
             Slot.THIS_PERIOD -> THIS_PERIOD_KEY
             Slot.NEXT_PERIOD -> NEXT_PERIOD_KEY
+        }
+
+    private fun legacyKeyFor(slot: Slot): Preferences.Key<String> =
+        when (slot) {
+            Slot.THIS_PERIOD -> LEGACY_THIS_PERIOD_V7_KEY
+            Slot.NEXT_PERIOD -> LEGACY_NEXT_PERIOD_V7_KEY
         }
 
     @Serializable
@@ -184,14 +210,17 @@ class InsightCache(
         val generatedAtEpochMillis: Long,
         val historicYesterday: DailyHistoryDto? = null,
     ) {
-        fun toDomain(): ForecastSnapshot = ForecastSnapshot(
-            bundle = bundle.toDomain(),
-            events = events.map { it.toDomain() },
-            location = location?.toDomain(),
-            period = runCatching { ForecastPeriod.valueOf(period) }.getOrDefault(ForecastPeriod.TODAY),
-            generatedAt = Instant.ofEpochMilli(generatedAtEpochMillis),
-            historicYesterday = historicYesterday?.toDomain(),
-        )
+        fun toDomain(): ForecastSnapshot {
+            val domainBundle = bundle.toDomain()
+            return ForecastSnapshot(
+                bundle = domainBundle,
+                events = events.map { it.toDomain(fallbackDate = domainBundle.today.date) },
+                location = location?.toDomain(),
+                period = runCatching { ForecastPeriod.valueOf(period) }.getOrDefault(ForecastPeriod.TODAY),
+                generatedAt = Instant.ofEpochMilli(generatedAtEpochMillis),
+                historicYesterday = historicYesterday?.toDomain(),
+            )
+        }
     }
 
     @Serializable
@@ -381,6 +410,11 @@ class InsightCache(
      * [PerModelHourDto], so a midnight-crossing event round-trips with its end
      * on the next date and tomorrow's pre-dawn events keep their date.
      *
+     * The date fields default to null so the time-only v7 payload (written by
+     * pre-update builds) still decodes; materialisation then infers the dates
+     * from the snapshot's own day — see [toDomain]. v8 writers always populate
+     * them.
+     *
      * Titles and free-form location strings are deliberately dropped, matching
      * the privacy posture of the previous derived-insight cache (which stored
      * `CalendarTieInClause(item: String)` — a garment name, never the event
@@ -391,28 +425,34 @@ class InsightCache(
      */
     @Serializable
     private data class CalendarEventDto(
-        val startDateEpochDays: Long,
+        val startDateEpochDays: Long? = null,
         val startSecondOfDay: Int,
-        val endDateEpochDays: Long,
+        val endDateEpochDays: Long? = null,
         val endSecondOfDay: Int,
         val allDay: Boolean = false,
         val hasLocation: Boolean = false,
     ) {
-        fun toDomain(): CalendarEvent = CalendarEvent(
-            title = "",
-            start = LocalDateTime.of(
-                LocalDate.ofEpochDay(startDateEpochDays),
-                LocalTime.ofSecondOfDay(startSecondOfDay.toLong()),
-            ),
-            end = LocalDateTime.of(
-                LocalDate.ofEpochDay(endDateEpochDays),
-                LocalTime.ofSecondOfDay(endSecondOfDay.toLong()),
-            ),
-            location = if (hasLocation) PLACEHOLDER_LOCATION else null,
-            allDay = allDay,
-            kind = EventKind.NORMAL,
-            ownerAccount = null,
-        )
+        /**
+         * [fallbackDate] stands in for the date fields a v7 payload lacks: the
+         * start lands on the snapshot's own day, and the end rolls to the next
+         * day when its time-of-day precedes the start's (a 21:00–00:30 gig).
+         * Best effort — v7 never recorded the real dates — and only consulted
+         * until the first post-update fetch rewrites the slot in v8 form.
+         */
+        fun toDomain(fallbackDate: LocalDate): CalendarEvent {
+            val startDate = startDateEpochDays?.let(LocalDate::ofEpochDay) ?: fallbackDate
+            val endDate = endDateEpochDays?.let(LocalDate::ofEpochDay)
+                ?: if (endSecondOfDay < startSecondOfDay) startDate.plusDays(1) else startDate
+            return CalendarEvent(
+                title = "",
+                start = LocalDateTime.of(startDate, LocalTime.ofSecondOfDay(startSecondOfDay.toLong())),
+                end = LocalDateTime.of(endDate, LocalTime.ofSecondOfDay(endSecondOfDay.toLong())),
+                location = if (hasLocation) PLACEHOLDER_LOCATION else null,
+                allDay = allDay,
+                kind = EventKind.NORMAL,
+                ownerAccount = null,
+            )
+        }
     }
 
     private fun ForecastSnapshot.toDto(): ForecastSnapshotDto = ForecastSnapshotDto(
@@ -505,14 +545,26 @@ class InsightCache(
     companion object {
         // Bumped to v7 with the schema switch from a derived `Insight` payload
         // to the raw `ForecastSnapshot` (bundle + minimal events) it's derived
-        // from. The previous shape (v6) doesn't deserialise into the new DTO,
-        // so the cache drops to null on first read and the next worker run
-        // populates the v7 keys. Bumped to v8 when `CalendarEventDto` gained
-        // per-endpoint dates for the LocalDateTime event model — v7 payloads
-        // don't materialise dated events, so the cache drops to null on first
-        // read and the next worker run repopulates the v8 keys.
+        // from. Bumped to v8 when `CalendarEventDto` gained per-endpoint dates
+        // for the LocalDateTime event model. The v7→v8 bump originally dropped
+        // the cache to null on first read after an update, blanking the Today
+        // screen and widget until the next fetch — slow or offline networks
+        // made that gap user-visible — so reads now fall back to the v7 keys
+        // (see `readSlot`) and stores/clears retire them. Future schema changes
+        // should prefer defaulted fields over a key bump where possible; if a
+        // bump is unavoidable, bridge the old key the same way.
         private val THIS_PERIOD_KEY = stringPreferencesKey("this_period_snapshot_v8")
         private val NEXT_PERIOD_KEY = stringPreferencesKey("next_period_snapshot_v8")
+        private val LEGACY_THIS_PERIOD_V7_KEY = stringPreferencesKey("this_period_snapshot_v7")
+        private val LEGACY_NEXT_PERIOD_V7_KEY = stringPreferencesKey("next_period_snapshot_v7")
+
+        // v6 held the old derived-`Insight` shape — not decodable into the
+        // snapshot DTO, so never read; removed on store/clear purely so the
+        // orphaned bytes don't sit in the DataStore file forever.
+        private val LEGACY_V6_KEYS = mapOf(
+            Slot.THIS_PERIOD to stringPreferencesKey("this_period_insight_v6"),
+            Slot.NEXT_PERIOD to stringPreferencesKey("next_period_insight_v6"),
+        )
 
         // Surfaced on materialisation when the cached event had a location
         // string at fetch time. The renderer's only read of `location` is a

--- a/app/src/test/kotlin/app/clothescast/data/InsightCacheTest.kt
+++ b/app/src/test/kotlin/app/clothescast/data/InsightCacheTest.kt
@@ -188,19 +188,100 @@ class InsightCacheTest {
         subject.thisPeriod.first() shouldBe null
     }
 
+    /**
+     * The exact JSON shape the v7 (pre-update) build wrote: same snapshot DTO
+     * as v8 except `CalendarEventDto` carried second-of-day fields only — no
+     * dates — and it lived under the `_v7` key.
+     */
+    private fun v7SnapshotJson(eventsJson: String = "[]"): String {
+        fun day(date: LocalDate, minC: Double, maxC: Double) = """
+            {"dateEpochDays":${date.toEpochDay()},"temperatureMinC":${minC + 1},
+             "temperatureMaxC":${maxC + 1},"feelsLikeMinC":$minC,"feelsLikeMaxC":$maxC,
+             "precipitationProbabilityMaxPct":5.0,"precipitationMmTotal":0.0,"condition":"CLEAR"}
+        """.trimIndent()
+        return """
+            {"bundle":{"today":${day(today, 13.0, 18.0)},"yesterday":${day(yesterday, 12.0, 17.0)}},
+             "events":$eventsJson,
+             "period":"TODAY",
+             "generatedAtEpochMillis":${now.toEpochMilli()}}
+        """.trimIndent()
+    }
+
     @Test
-    fun `v7 payloads (time-only events) are dropped on read`() = runTest {
-        // v7 stored CalendarEventDto with second-of-day fields only — it can't
-        // materialise dated events, so v8 reads from a fresh key, drops to
-        // null, and the next worker run repopulates.
+    fun `v7 payloads survive the update via the legacy-key fallback`() = runTest {
+        // The v7→v8 key bump used to drop the cache on first read after an
+        // app update, blanking the Today screen and widget until the next
+        // fetch (painfully visible when the network is slow). Reads now fall
+        // back to the v7 key, inferring the event dates v7 never stored from
+        // the snapshot's own day.
         dataStore.edit {
-            it[stringPreferencesKey("this_period_snapshot_v7")] = """
-                {"bundle":{},"events":[{"startSecondOfDay":0,"endSecondOfDay":0}],
-                 "generatedAtEpochMillis":0}
-            """.trimIndent()
+            it[stringPreferencesKey("this_period_snapshot_v7")] = v7SnapshotJson(
+                """[{"startSecondOfDay":72000,"endSecondOfDay":79200,"hasLocation":true}]""",
+            )
         }
 
-        subject.thisPeriod.first() shouldBe null
+        val read = subject.thisPeriod.first()
+        read?.bundle?.today?.date shouldBe today
+        val readEvent = read?.events?.singleOrNull()
+        readEvent?.start shouldBe today.atTime(20, 0)
+        readEvent?.end shouldBe today.atTime(22, 0)
+        (readEvent?.location.isNullOrBlank()) shouldBe false
+    }
+
+    @Test
+    fun `v7 event ending before it starts rolls its end past midnight`() = runTest {
+        // v7 stored times only, so a 21:00–00:30 gig serialised as end < start.
+        // The fallback decode keeps it a forward interval by rolling the end
+        // to the next day instead of materialising a negative-length event.
+        dataStore.edit {
+            it[stringPreferencesKey("this_period_snapshot_v7")] = v7SnapshotJson(
+                """[{"startSecondOfDay":75600,"endSecondOfDay":1800}]""",
+            )
+        }
+
+        val readEvent = subject.thisPeriod.first()?.events?.singleOrNull()
+        readEvent?.start shouldBe today.atTime(21, 0)
+        readEvent?.end shouldBe today.plusDays(1).atTime(0, 30)
+    }
+
+    @Test
+    fun `v8 payload wins over a leftover v7 payload`() = runTest {
+        subject.store(InsightCache.Slot.THIS_PERIOD, sample)
+        dataStore.edit {
+            it[stringPreferencesKey("this_period_snapshot_v7")] =
+                v7SnapshotJson("""[{"startSecondOfDay":0,"endSecondOfDay":3600}]""")
+        }
+
+        subject.thisPeriod.first() shouldBe sample
+    }
+
+    @Test
+    fun `store retires the legacy v7 and v6 keys for its slot`() = runTest {
+        // Once a fresh v8 capture lands, the pre-update payloads are stale —
+        // remove them so the fallback can't resurrect them after a clear()
+        // of the live keys and the orphaned bytes don't linger on disk.
+        dataStore.edit {
+            it[stringPreferencesKey("this_period_snapshot_v7")] = v7SnapshotJson()
+            it[stringPreferencesKey("this_period_insight_v6")] = """{"summary":"old"}"""
+        }
+
+        subject.store(InsightCache.Slot.THIS_PERIOD, sample)
+
+        val prefs = dataStore.data.first()
+        prefs[stringPreferencesKey("this_period_snapshot_v7")] shouldBe null
+        prefs[stringPreferencesKey("this_period_insight_v6")] shouldBe null
+        subject.thisPeriod.first() shouldBe sample
+    }
+
+    @Test
+    fun `clear removes legacy payloads too`() = runTest {
+        dataStore.edit {
+            it[stringPreferencesKey("next_period_snapshot_v7")] = v7SnapshotJson()
+        }
+
+        subject.clear()
+
+        subject.nextPeriod.first() shouldBe null
     }
 
     @Test


### PR DESCRIPTION
## Problem

Updating from build 1451 to 1454 blanked the app: the Today screen and widget showed "no ClothesCast yet" even though a forecast had been cached a minute earlier, and the refill fetch hit Open-Meteo socket timeouts, stretching the gap to minutes (per the bug report log).

Root cause: the v7→v8 `InsightCache` schema bump in `10f5092` (calendar events gained per-endpoint dates) deliberately switched DataStore keys and dropped the old payload on first read after the update, leaving the cache empty until the next successful fetch.

## Fix

- Reads fall back to the legacy `*_snapshot_v7` key when the v8 key is empty, so a pre-update forecast keeps rendering across the update.
- The v7 payload decodes into the current DTO: `CalendarEventDto`'s date fields are now nullable with null defaults, and materialization infers the dates v7 never stored from the snapshot's own day (an end whose time-of-day precedes the start's rolls to the next day, e.g. a 21:00–00:30 event).
- `store()` and `clear()` retire the orphaned v7 and v6 keys, so the fallback can't resurrect stale data after a fresh capture and the dead bytes don't linger on disk.
- Companion comment now steers future schema changes toward defaulted fields (or a bridged key) instead of a drop-on-bump.

The slow refresh itself was network weather — two 10s socket timeouts against api.open-meteo.com with a retry — but with the cache surviving the update it's no longer user-visible.

## Privacy

No change to what leaves the device or what's stored: the migrated payload is the same on-disk snapshot the previous build wrote (event timing + location-presence flag only; no titles or location strings).

## Test plan

- New `InsightCacheTest` cases: v7 payload materializes via the fallback with inferred event dates, midnight rollover for end-before-start v7 events, v8 winning over a leftover v7 payload, store/clear retiring legacy keys.
- Full suite green locally: `./gradlew :core:domain:test :core:data:test :app:testDebugUnitTest`.

https://claude.ai/code/session_01NcvoVaEeMPHATJzzCY9Ha9

---
_Generated by [Claude Code](https://claude.ai/code/session_01NcvoVaEeMPHATJzzCY9Ha9)_