### PR TITLE
Stop repeating "tonight" in the evening forecast

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -405,15 +405,19 @@ new rule the first time something bites you, not the third.
   morning insight's evening tie-in clause has two emission paths. If the
   user's clothes rules fire for the evening window (e.g. it'll be cold
   enough for a jacket), the clause names the item *and* folds in the
-  per-model rain when one's detected: "Tonight, rain tonight, bring a
+  per-model rain when one's detected: "Tonight, rain, bring a
   jacket." If no clothes rule fires but a per-model series spots rain ≥
   30% in the tonight window and the user has an evening event with a
   location, the clause still emits — without recommending clothes —
-  as a bare rain warning ("Tonight, rain tonight." / the hedged
+  as a bare rain warning ("Tonight, rain." / the hedged
   chance-of-rain wording for the POSSIBLE tier). The prose deliberately
   no longer pins a peak hour ("rain at 9pm") — that claimed precision
   the hourly forecast can't back; the peak time still rides the clause
-  data for the chart and cast card. The principle: we *always*
+  data for the chart and cast card. It also no longer repeats the
+  evening timing word — the "Tonight," lead already conveys it, so an
+  evening peak emits no second "tonight"; only a post-midnight peak adds
+  "overnight" ("Tonight, rain overnight, …"), the one case the lead
+  doesn't cover. The principle: we *always*
   surface rain when a model spots it, even when no clothes rule fires —
   e.g. the user lowered their umbrella gate, deleted the rule, or the
   probability sits below it. The umbrella itself ships as a precip-keyed

--- a/app/src/main/kotlin/app/clothescast/insight/InsightFormatter.kt
+++ b/app/src/main/kotlin/app/clothescast/insight/InsightFormatter.kt
@@ -776,19 +776,26 @@ class InsightFormatter(
         return resources.getString(template, renderedItems, coarseRainWhen(rainTime), conditionNoun)
     }
 
-    // Coarse timing word for the evening tie-in's rain mention: post-midnight
-    // peaks (00:00–04:59) read "overnight", everything else "tonight". The
-    // clause already leads with "Tonight," so this reinforces the window
-    // without pinning a robotic hour the user can't act on precisely — and
-    // "overnight" still flags the post-midnight case the lead doesn't cover.
-    private fun coarseRainWhen(time: LocalTime): String =
-        resources.getString(
+    // Coarse timing fragment for the evening tie-in's rain mention. The clause
+    // already leads with "Tonight,", so an evening peak adds nothing — the
+    // English insight_precip_tonight is empty and this contributes no second
+    // "tonight" (the redundant "Tonight, rain tonight." users flagged). Only a
+    // post-midnight peak (00:00–04:59) carries information the lead doesn't
+    // cover, so "overnight" still surfaces. The separating space is supplied
+    // here rather than baked into the resource word, so the empty evening case
+    // leaves no orphan space in the template's adjacent slot. Non-English
+    // locales bake the evening reference into their own templates and ignore
+    // this slot entirely.
+    private fun coarseRainWhen(time: LocalTime): String {
+        val word = resources.getString(
             if (time.hour in OVERNIGHT_HOURS) {
                 R.string.insight_precip_overnight
             } else {
                 R.string.insight_precip_tonight
             },
         )
+        return if (word.isEmpty()) "" else " $word"
+    }
 
     private fun leadRes(period: ForecastPeriod, isFutureDay: Boolean): Int = when (period) {
         ForecastPeriod.TODAY -> if (isFutureDay) R.string.insight_lead_tomorrow else R.string.insight_lead_today

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1305,11 +1305,17 @@
     <!-- Coarse timing word for the morning insight's evening rain tie-in:
          post-midnight peaks (00:00–04:59) read "overnight". The tie-in already
          leads with "Tonight," so this only has to flag the post-midnight case
-         the lead doesn't cover. -->
+         the lead doesn't cover. The formatter supplies the separating space, so
+         the word itself carries none. -->
     <string name="insight_precip_overnight">overnight</string>
     <!-- Coarse timing word for the evening rain tie-in when the peak is this
-         evening rather than post-midnight — "Tonight, rain tonight." -->
-    <string name="insight_precip_tonight">tonight</string>
+         evening rather than post-midnight. Deliberately empty in English: the
+         tie-in already leads with "Tonight,", so repeating "tonight" here read
+         as a redundant "Tonight, rain tonight." Only the post-midnight
+         "overnight" case adds anything the lead doesn't already say. (Other
+         locales bake the evening reference into their tie-in templates and
+         ignore this slot entirely.) -->
+    <string name="insight_precip_tonight"></string>
 
     <!--
     Spoken-time vocabulary used by InsightFormatter.spokenTime to emit forms
@@ -1371,49 +1377,53 @@
     the same sentence so the morning insight mentions the evening weather
     alongside the evening clothing tip, without emitting a second precip clause
     that would compete with the morning slice's own. The precip clause leads the
-    item ("Tonight, rain tonight, bring a jacket.") so the sentence reads
+    item ("Tonight, rain, bring a jacket.") so the sentence reads
     weather-then-action, mirroring how the day insight orders precip before the
     carry. "umbrella" is stripped from the items by the formatter when this
     template is used — the precip mention already covers what an umbrella's for
-    — so the template never has to apologise for "bring an umbrella, rain
-    tonight." %1$s = item phrase, %2$s = coarse timing word ("tonight" /
-    "overnight"), %3$s = condition noun (the same insight_condition_* label the
-    main clause uses, lowercased mid-sentence) so a stormy / snowy evening names
-    the real condition ("Tonight, snow overnight, …") instead of always saying
-    "rain".
+    — so the template never has to apologise for "bring an umbrella, rain." %1$s
+    = item phrase, %2$s = coarse timing fragment (empty for an evening peak — the
+    "Tonight," lead already says it — or " overnight" with a leading space for a
+    post-midnight peak), %3$s = condition noun (the same insight_condition_*
+    label the main clause uses, lowercased mid-sentence) so a stormy / snowy
+    evening names the real condition ("Tonight, snow overnight, …") instead of
+    always saying "rain".
     -->
-    <string name="insight_tie_in_with_rain">Tonight, %3$s %2$s, bring %1$s.</string>
+    <string name="insight_tie_in_with_rain">Tonight, %3$s%2$s, bring %1$s.</string>
     <!--
     POSSIBLE-tier counterpart of insight_tie_in_with_rain: a clothes rule
     triggered for the evening but only one per-model series flagged the
     precip at ≥ 30%. Hedges the wording so a single-model reading doesn't
     render with the same definite tone as a majority-of-models agreement.
-    %1$s = item phrase, %2$s = coarse timing word ("tonight" / "overnight"),
+    %1$s = item phrase, %2$s = coarse timing fragment (empty for an evening peak,
+    " overnight" with a leading space for a post-midnight one),
     %3$s = condition noun (lowercased), so the hedge reads "chance of snow" /
     "chance of thunderstorm" when the peak isn't plain rain.
     -->
-    <string name="insight_tie_in_with_rain_chance">Tonight, chance of %3$s %2$s, bring %1$s.</string>
+    <string name="insight_tie_in_with_rain_chance">Tonight, chance of %3$s%2$s, bring %1$s.</string>
     <!--
     Bare-precip variant of the evening tie-in for the morning insight: emitted
     when the user has an evening event with a location and the per-model
     forecast tier spots precip ≥ 50% (majority of models agree) at some hour in
     the tonight window, but no clothes rule fired for that period. The
     morning insight stays silent on clothing because nothing's been picked
-    yet — the precip mention itself is the point. %1$s = coarse timing word
-    ("tonight" / "overnight"), %2$s = condition noun (lowercased) so a snowy /
-    stormy evening names the real condition ("Tonight, snow overnight.")
-    instead of always saying "rain". Fronts the "Tonight," time marker so the
-    sentence reads in the same "<time>, <content>." shape as the band lead and
-    the item-led tie-in templates.
+    yet — the precip mention itself is the point. %1$s = coarse timing fragment
+    (empty for an evening peak — the "Tonight," lead already says it — or
+    " overnight" with a leading space for a post-midnight peak), %2$s = condition
+    noun (lowercased) so a snowy / stormy evening names the real condition
+    ("Tonight, snow overnight.") instead of always saying "rain". Fronts the
+    "Tonight," time marker so the sentence reads in the same "<time>, <content>."
+    shape as the band lead and the item-led tie-in templates.
     -->
-    <string name="insight_evening_rain">Tonight, %2$s %1$s.</string>
+    <string name="insight_evening_rain">Tonight, %2$s%1$s.</string>
     <!--
     POSSIBLE-tier counterpart of insight_evening_rain: only one per-model
     series flagged the tonight hour ≥ 30%, so we hedge the wording. Matches
-    insight_precip_chance's "Chance of rain" pattern. %1$s = coarse timing word
-    ("tonight" / "overnight"), %2$s = condition noun (lowercased).
+    insight_precip_chance's "Chance of rain" pattern. %1$s = coarse timing
+    fragment (empty for an evening peak, " overnight" with a leading space for a
+    post-midnight one), %2$s = condition noun (lowercased).
     -->
-    <string name="insight_evening_rain_chance">Tonight, chance of %2$s %1$s.</string>
+    <string name="insight_evening_rain_chance">Tonight, chance of %2$s%1$s.</string>
 
     <!--
     Holidays sub-page: per-holiday opt-in toggles. On the matching calendar

--- a/app/src/test/kotlin/app/clothescast/insight/InsightFormatterTest.kt
+++ b/app/src/test/kotlin/app/clothescast/insight/InsightFormatterTest.kt
@@ -983,14 +983,14 @@ class InsightFormatterTest {
                 ),
             ),
         )
-        out shouldBe "Today, it will be 21°. Tonight, rain tonight."
+        out shouldBe "Today, it will be 21°. Tonight, rain."
     }
 
     @Test
     fun `evening event tie-in says 'overnight' for a post-midnight rain peak`() {
-        // A peak in the early hours (00:00–04:59) reads "overnight" instead of
-        // "tonight", flagging the post-midnight window the "Tonight," lead
-        // doesn't already cover.
+        // A peak in the early hours (00:00–04:59) adds "overnight", flagging
+        // the post-midnight window the "Tonight," lead doesn't already cover.
+        // (An evening peak emits no timing word at all — the lead says it.)
         val out = subject.format(
             summary(
                 eveningEventTieIn = EveningEventTieInClause(
@@ -1017,9 +1017,10 @@ class InsightFormatterTest {
 
     @Test
     fun `evening event tie-in ignores the all-day flag on bare evening rain`() {
-        // The coarse "tonight" / "overnight" word is keyed off the peak hour,
-        // not coverage, so an all-day evening reads the same "tonight" as a
-        // single-hour evening peak — the all-day distinction is gone.
+        // The coarse timing word is keyed off the peak hour, not coverage, so
+        // an all-day evening reads the same (no timing word — the "Tonight,"
+        // lead covers it) as a single-hour evening peak — the all-day
+        // distinction is gone.
         val out = subject.format(
             summary(
                 eveningEventTieIn = EveningEventTieInClause(
@@ -1029,7 +1030,7 @@ class InsightFormatterTest {
                 ),
             ),
         )
-        out shouldBe "Today, it will be 21°. Tonight, rain tonight."
+        out shouldBe "Today, it will be 21°. Tonight, rain."
     }
 
     @Test
@@ -1044,7 +1045,7 @@ class InsightFormatterTest {
                 ),
             ),
         )
-        out shouldBe "Today, it will be 21°. Tonight, chance of rain tonight."
+        out shouldBe "Today, it will be 21°. Tonight, chance of rain."
     }
 
     @Test
@@ -1058,7 +1059,7 @@ class InsightFormatterTest {
                 ),
             ),
         )
-        out shouldBe "Today, it will be 21°. Tonight, rain tonight, bring a jacket."
+        out shouldBe "Today, it will be 21°. Tonight, rain, bring a jacket."
     }
 
     @Test
@@ -1072,7 +1073,7 @@ class InsightFormatterTest {
                 ),
             ),
         )
-        out shouldBe "Today, it will be 21°. Tonight, chance of rain tonight."
+        out shouldBe "Today, it will be 21°. Tonight, chance of rain."
     }
 
     @Test
@@ -1120,7 +1121,7 @@ class InsightFormatterTest {
 
     @Test
     fun `evening event tie-in folds rain time leading the items when present`() {
-        // Rain leads the item ("Tonight, rain tonight, bring a jacket.") so
+        // Rain leads the item ("Tonight, rain, bring a jacket.") so
         // the tie-in reads weather-then-action, same shape as the day insight
         // (precip clause precedes the carry).
         val out = subject.format(
@@ -1128,7 +1129,7 @@ class InsightFormatterTest {
                 eveningEventTieIn = EveningEventTieInClause(items = listOf("jacket"), rainTime = LocalTime.of(21, 0)),
             ),
         )
-        out shouldBe "Today, it will be 21°. Tonight, rain tonight, bring a jacket."
+        out shouldBe "Today, it will be 21°. Tonight, rain, bring a jacket."
     }
 
     @Test
@@ -1144,7 +1145,7 @@ class InsightFormatterTest {
                     precipCondition = WeatherCondition.SNOW,
                 ),
             ),
-        ) shouldBe "Today, it will be 21°. Tonight, snow tonight, bring a jacket."
+        ) shouldBe "Today, it will be 21°. Tonight, snow, bring a jacket."
 
         subject.format(
             summary(
@@ -1154,7 +1155,7 @@ class InsightFormatterTest {
                     precipCondition = WeatherCondition.THUNDERSTORM,
                 ),
             ),
-        ) shouldBe "Today, it will be 21°. Tonight, thunderstorm tonight."
+        ) shouldBe "Today, it will be 21°. Tonight, thunderstorm."
     }
 
     @Test
@@ -1170,7 +1171,7 @@ class InsightFormatterTest {
                     precipCondition = WeatherCondition.SNOW,
                 ),
             ),
-        ) shouldBe "Today, it will be 21°. Tonight, chance of snow tonight."
+        ) shouldBe "Today, it will be 21°. Tonight, chance of snow."
     }
 
     @Test
@@ -1186,7 +1187,7 @@ class InsightFormatterTest {
                 ),
             ),
         )
-        out shouldBe "Today, it will be 21°. Tonight, rain tonight."
+        out shouldBe "Today, it will be 21°. Tonight, rain."
     }
 
     @Test
@@ -1199,7 +1200,7 @@ class InsightFormatterTest {
                 ),
             ),
         )
-        out shouldBe "Today, it will be 21°. Tonight, rain tonight, bring a jacket."
+        out shouldBe "Today, it will be 21°. Tonight, rain, bring a jacket."
     }
 
     @Test
@@ -1229,7 +1230,7 @@ class InsightFormatterTest {
                 ),
             ),
         )
-        out shouldBe "Today, it will be 21°. Tonight, chance of rain tonight, bring a jacket."
+        out shouldBe "Today, it will be 21°. Tonight, chance of rain, bring a jacket."
     }
 
     @Test
@@ -1353,12 +1354,12 @@ class InsightFormatterTest {
                     precipCondition = WeatherCondition.RAIN,
                 ),
             ),
-        ) shouldBe "Today, it will be 21°. Tonight, rain tonight, bring a jacket and umbrella."
+        ) shouldBe "Today, it will be 21°. Tonight, rain, bring a jacket and umbrella."
     }
 
     @Test
     fun `umbrella accessory promotes the bare-rain evening tie-in to the item-led template`() {
-        // Without an opted-in umbrella rule this path renders "Tonight, rain tonight.".
+        // Without an opted-in umbrella rule this path renders "Tonight, rain.".
         // The umbrella choice promotes it to the item-led template with the
         // accessory as the lone item.
         umbrellaSubject.format(
@@ -1369,7 +1370,7 @@ class InsightFormatterTest {
                     precipCondition = WeatherCondition.RAIN,
                 ),
             ),
-        ) shouldBe "Today, it will be 21°. Tonight, rain tonight, bring an umbrella."
+        ) shouldBe "Today, it will be 21°. Tonight, rain, bring an umbrella."
     }
 
     @Test
@@ -1383,7 +1384,7 @@ class InsightFormatterTest {
                     precipCondition = WeatherCondition.RAIN,
                 ),
             ),
-        ) shouldBe "Today, it will be 21°. Tonight, chance of rain tonight, bring an umbrella."
+        ) shouldBe "Today, it will be 21°. Tonight, chance of rain, bring an umbrella."
     }
 
     @Test
@@ -1409,7 +1410,7 @@ class InsightFormatterTest {
                     precipCondition = WeatherCondition.RAIN,
                 ),
             ),
-        ) shouldBe "Today, it will be 21°. Tonight, rain tonight, bring a jacket and umbrella."
+        ) shouldBe "Today, it will be 21°. Tonight, rain, bring a jacket and umbrella."
     }
 
     @Test
@@ -1427,7 +1428,7 @@ class InsightFormatterTest {
                     precipCondition = WeatherCondition.SNOW,
                 ),
             ),
-        ) shouldBe "Today, it will be 21°. Tonight, snow tonight."
+        ) shouldBe "Today, it will be 21°. Tonight, snow."
     }
 
     @Test
@@ -1446,7 +1447,7 @@ class InsightFormatterTest {
                     precipCondition = WeatherCondition.THUNDERSTORM,
                 ),
             ),
-        ) shouldBe "Today, it will be 21°. Tonight, thunderstorm tonight, bring a jacket and umbrella."
+        ) shouldBe "Today, it will be 21°. Tonight, thunderstorm, bring a jacket and umbrella."
     }
 
     @Test
@@ -1462,7 +1463,7 @@ class InsightFormatterTest {
                     precipCondition = null,
                 ),
             ),
-        ) shouldBe "Today, it will be 21°. Tonight, rain tonight, bring a jacket."
+        ) shouldBe "Today, it will be 21°. Tonight, rain, bring a jacket."
     }
 
     @Test
@@ -2015,7 +2016,7 @@ class InsightFormatterTest {
                 ),
             ),
         )
-        out shouldBe "Today, it will be 21°. Tonight, rain tonight."
+        out shouldBe "Today, it will be 21°. Tonight, rain."
     }
 
     @Test

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsightTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsightTest.kt
@@ -1108,7 +1108,7 @@ class GenerateDailyInsightTest {
         tie.rainTime shouldBe LocalTime.of(21, 0)
         // Both evening hours sit ≥ 50%, so the whole-window flag is set. The
         // prose no longer speaks it (the formatter dropped the hour / "all
-        // night" phrasing — "Tonight, rain tonight, bring a jacket." reads
+        // night" phrasing — "Tonight, rain, bring a jacket." reads
         // the same either way), but the flag still rides the clause for data
         // consumers, so pin that the derivation sets it.
         tie.allDay shouldBe true


### PR DESCRIPTION
## What

A bug report flagged the doubled word in the morning insight's evening tie-in:

> "Tonight, drizzle tonight, bring an umbrella." — double tonight

The tie-in clause leads with **"Tonight,"** and then folded the per-model rain mention's own coarse timing word into the same sentence. For an evening rain peak that timing word is also **"tonight"**, so the lead and the mention duplicated each other.

## Fix

The `"Tonight,"` lead already conveys the evening, so the evening timing word adds nothing. Only a **post-midnight** peak does — there `"overnight"` flags the window the lead doesn't cover. So:

- `insight_precip_tonight` (English base) is now **empty** — an evening peak emits no second "tonight".
- `insight_precip_overnight` is unchanged; the post-midnight path still reads **"Tonight, rain overnight, …"**.
- `InsightFormatter.coarseRainWhen` supplies the separating space only when a word is present, so the empty evening case leaves no orphan space.
- The four affected templates (`insight_tie_in_with_rain`, `_chance`, `insight_evening_rain`, `_chance`) drop the now-redundant literal space adjacent to that slot.

### Before → After (English)

| | Before | After |
|---|---|---|
| Evening, items | `Tonight, rain tonight, bring a jacket.` | `Tonight, rain, bring a jacket.` |
| Evening, bare | `Tonight, rain tonight.` | `Tonight, rain.` |
| Post-midnight | `Tonight, rain overnight, bring a jacket.` | _(unchanged)_ |

## Scope / i18n

Contained to English base strings plus a one-line formatter tweak. **Every other locale already bakes the evening reference into its own template and ignores this timing slot** (e.g. German `Denk an %1$s für heute Abend, %3$s.`), so no re-translation is needed and no other-locale output changes.

## Privacy

No change to what crosses the device boundary.

## Test plan

- Updated `InsightFormatterTest` expectations for the evening cases (dropped the redundant "tonight"); the two `overnight` assertions are unchanged.
- `./gradlew :app:testDebugUnitTest --tests "app.clothescast.insight.InsightFormatterTest"` → **BUILD SUCCESSFUL**.

https://claude.ai/code/session_01GXJcittcGwEruXT5ARuNDx

---
_Generated by [Claude Code](https://claude.ai/code/session_01GXJcittcGwEruXT5ARuNDx)_