### PR TITLE
Evening rain heads-up no longer says "tonight" twice

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -405,15 +405,17 @@ new rule the first time something bites you, not the third.
   morning insight's evening tie-in clause has two emission paths. If the
   user's clothes rules fire for the evening window (e.g. it'll be cold
   enough for a jacket), the clause names the item *and* folds in the
-  per-model rain when one's detected: "Tonight, rain tonight, bring a
+  per-model rain when one's detected: "Tonight, rain, bring a
   jacket." If no clothes rule fires but a per-model series spots rain ≥
   30% in the tonight window and the user has an evening event with a
   location, the clause still emits — without recommending clothes —
-  as a bare rain warning ("Tonight, rain tonight." / the hedged
+  as a bare rain warning ("Tonight, rain." / the hedged
   chance-of-rain wording for the POSSIBLE tier). The prose deliberately
   no longer pins a peak hour ("rain at 9pm") — that claimed precision
   the hourly forecast can't back; the peak time still rides the clause
-  data for the chart and cast card. The principle: we *always*
+  data for the chart and cast card. A post-midnight peak appends
+  "overnight" ("Tonight, rain overnight."); an evening peak adds no
+  timing word — the "Tonight," lead already carries it. The principle: we *always*
   surface rain when a model spots it, even when no clothes rule fires —
   e.g. the user lowered their umbrella gate, deleted the rule, or the
   probability sits below it. The umbrella itself ships as a precip-keyed

--- a/app/src/main/kotlin/app/clothescast/insight/InsightFormatter.kt
+++ b/app/src/main/kotlin/app/clothescast/insight/InsightFormatter.kt
@@ -730,7 +730,7 @@ class InsightFormatter(
         // a jacket and an umbrella.") and the bare-rain path is promoted to
         // the item-led template. SNOW peaks (or a null condition on a
         // pre-field cached payload) skip the injection — same gating as
-        // formatPrecip — so "Tonight, rain at 9pm, bring an umbrella."
+        // formatPrecip — so "Tonight, rain, bring an umbrella."
         // doesn't slip out when the underlying peak is actually snow.
         val filteredItems = tieIn.items.filterNot(::isAccessory)
         // The carried accessory rides in on the tie-in's own items (the fired
@@ -760,7 +760,7 @@ class InsightFormatter(
                 PrecipLikelihood.LIKELY -> R.string.insight_evening_rain
                 PrecipLikelihood.POSSIBLE -> R.string.insight_evening_rain_chance
             }
-            return resources.getString(template, coarseRainWhen(rainTime), conditionNoun)
+            return resources.getString(template, overnightQualifier(rainTime), conditionNoun)
         }
         // No rain — bare item-led sentence. Always uses the TODAY-context
         // "Tonight, bring …" template because the evening tie-in only fires
@@ -773,22 +773,24 @@ class InsightFormatter(
             PrecipLikelihood.LIKELY -> R.string.insight_tie_in_with_rain
             PrecipLikelihood.POSSIBLE -> R.string.insight_tie_in_with_rain_chance
         }
-        return resources.getString(template, renderedItems, coarseRainWhen(rainTime), conditionNoun)
+        return resources.getString(template, renderedItems, overnightQualifier(rainTime), conditionNoun)
     }
 
-    // Coarse timing word for the evening tie-in's rain mention: post-midnight
-    // peaks (00:00–04:59) read "overnight", everything else "tonight". The
-    // clause already leads with "Tonight," so this reinforces the window
-    // without pinning a robotic hour the user can't act on precisely — and
-    // "overnight" still flags the post-midnight case the lead doesn't cover.
-    private fun coarseRainWhen(time: LocalTime): String =
-        resources.getString(
-            if (time.hour in OVERNIGHT_HOURS) {
-                R.string.insight_precip_overnight
-            } else {
-                R.string.insight_precip_tonight
-            },
-        )
+    // Timing qualifier for the evening tie-in's rain mention: post-midnight
+    // peaks (00:00–04:59) read " overnight" — the one case the clause's
+    // "Tonight," lead doesn't cover — and everything else gets no qualifier
+    // at all, because repeating "tonight" mid-sentence stuttered ("Tonight,
+    // drizzle tonight, bring an umbrella."). The leading space is joined here
+    // rather than in the template (the templates butt the qualifier slot up
+    // against the condition noun so the empty case leaves no stray gap);
+    // base English is the only locale that renders the slot — every
+    // translation dropped it — so the join needs no locale template.
+    private fun overnightQualifier(time: LocalTime): String =
+        if (time.hour in OVERNIGHT_HOURS) {
+            " " + resources.getString(R.string.insight_precip_overnight)
+        } else {
+            ""
+        }
 
     private fun leadRes(period: ForecastPeriod, isFutureDay: Boolean): Int = when (period) {
         ForecastPeriod.TODAY -> if (isFutureDay) R.string.insight_lead_tomorrow else R.string.insight_lead_today

--- a/app/src/main/res/values-am/strings.xml
+++ b/app/src/main/res/values-am/strings.xml
@@ -398,7 +398,6 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="insight_precip">%1$s።</string>
     <string name="insight_precip_overnight">ሌሊት</string>
 
-    <string name="insight_precip_tonight">ዛሬ ምሽት</string>
     <string name="insight_condition_clear">ፀሃያማ</string>
     <string name="insight_condition_partly_cloudy">ትንሽ ደመናማ</string>
     <string name="insight_condition_cloudy">ደመናማ</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -89,7 +89,6 @@ they work correctly in both the single-band and range templates.
     <string name="insight_precip">%1$s.</string>
     <string name="insight_precip_overnight">طوال الليل</string>
 
-    <string name="insight_precip_tonight">الليلة</string>
     <string name="insight_condition_clear">صافٍ</string>
     <string name="insight_condition_partly_cloudy">غائم جزئياً</string>
     <string name="insight_condition_cloudy">غائم</string>

--- a/app/src/main/res/values-b+sr+Cyrl/strings.xml
+++ b/app/src/main/res/values-b+sr+Cyrl/strings.xml
@@ -97,7 +97,6 @@ surfaces.
     <string name="insight_precip_chance">Могућа %1$s.</string>
     <string name="insight_precip_overnight">током ноћи</string>
 
-    <string name="insight_precip_tonight">вечерас</string>
     <string name="insight_condition_clear">Ведро</string>
     <string name="insight_condition_partly_cloudy">Делимично облачно</string>
     <string name="insight_condition_cloudy">Облачно</string>

--- a/app/src/main/res/values-b+sr+Latn/strings.xml
+++ b/app/src/main/res/values-b+sr+Latn/strings.xml
@@ -109,7 +109,6 @@ default English (matching values-pl / values-uk).
     <string name="insight_precip_chance">Moguća %1$s.</string>
     <string name="insight_precip_overnight">tokom noći</string>
 
-    <string name="insight_precip_tonight">večeras</string>
     <string name="insight_condition_clear">Vedro</string>
     <string name="insight_condition_partly_cloudy">Delimično oblačno</string>
     <string name="insight_condition_cloudy">Oblačno</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -94,7 +94,6 @@ What is NOT overridden, by design:
     <string name="insight_precip">%1$s.</string>
     <string name="insight_precip_overnight">през нощта</string>
 
-    <string name="insight_precip_tonight">тази вечер</string>
     <string name="insight_condition_clear">Ясно</string>
     <string name="insight_condition_partly_cloudy">Частично облачно</string>
     <string name="insight_condition_cloudy">Облачно</string>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -84,7 +84,6 @@ West Bengal vocabulary differences in a future PR.
     <string name="insight_precip">%1$s।</string>
     <string name="insight_precip_overnight">সারারাত</string>
 
-    <string name="insight_precip_tonight">আজ রাতে</string>
     <string name="insight_condition_clear">পরিষ্কার</string>
     <string name="insight_condition_partly_cloudy">আংশিক মেঘলা</string>
     <string name="insight_condition_cloudy">মেঘলা</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -516,7 +516,6 @@ the in-app clock is digit-driven and reads consistently across locales.
     <string name="insight_precip_chance">Possibilitat de %1$s.</string>
     <string name="insight_precip_overnight">durant la nit</string>
 
-    <string name="insight_precip_tonight">aquesta nit</string>
     <string name="insight_condition_clear">Cel serè</string>
     <string name="insight_condition_partly_cloudy">Parcialment ennuvolat</string>
     <string name="insight_condition_cloudy">Ennuvolat</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -563,7 +563,6 @@ locale (Angličtina (USA), Francouzština (Francie), Němčina (Německo), …).
     <string name="insight_precip">%1$s.</string>
     <string name="insight_precip_overnight">v noci</string>
 
-    <string name="insight_precip_tonight">dnes večer</string>
     <string name="insight_precip_chance">Možná %1$s.</string>
     <string name="insight_condition_clear">Jasno</string>
     <string name="insight_condition_partly_cloudy">Polojasno</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -573,7 +573,6 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrig)").
     <string name="insight_precip">%1$s.</string>
     <string name="insight_precip_overnight">i nat</string>
 
-    <string name="insight_precip_tonight">i aften</string>
     <string name="insight_precip_chance">Risiko for %1$s.</string>
 
     <string name="insight_condition_clear">Klart</string>

--- a/app/src/main/res/values-de-rAT/strings.xml
+++ b/app/src/main/res/values-de-rAT/strings.xml
@@ -451,8 +451,6 @@ zh-CN) is unchanged; only the displayed label localizes.
     <!-- "Regen über Nacht." for the early-morning collapse. -->
     <string name="insight_precip_overnight">über Nacht</string>
 
-    <string name="insight_precip_tonight">heute Abend</string>
-
     <string name="insight_condition_clear">Klar</string>
     <string name="insight_condition_partly_cloudy">Teilweise bewölkt</string>
     <string name="insight_condition_cloudy">Bewölkt</string>

--- a/app/src/main/res/values-de-rCH/strings.xml
+++ b/app/src/main/res/values-de-rCH/strings.xml
@@ -456,8 +456,6 @@ zh-CN) is unchanged; only the displayed label localizes.
     <!-- "Regen über Nacht." for the early-morning collapse. -->
     <string name="insight_precip_overnight">über Nacht</string>
 
-    <string name="insight_precip_tonight">heute Abend</string>
-
     <string name="insight_condition_clear">Klar</string>
     <string name="insight_condition_partly_cloudy">Teilweise bewölkt</string>
     <string name="insight_condition_cloudy">Bewölkt</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -479,8 +479,6 @@ zh-CN) is unchanged; only the displayed label localizes.
     <!-- "Regen über Nacht." for the early-morning collapse. -->
     <string name="insight_precip_overnight">über Nacht</string>
 
-    <string name="insight_precip_tonight">heute Abend</string>
-
     <string name="insight_condition_clear">Klar</string>
     <string name="insight_condition_partly_cloudy">Teilweise bewölkt</string>
     <string name="insight_condition_cloudy">Bewölkt</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -507,7 +507,6 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="insight_precip">%1$s.</string>
     <string name="insight_precip_overnight">τη νύχτα</string>
 
-    <string name="insight_precip_tonight">απόψε</string>
     <string name="insight_condition_clear">Αίθριος</string>
     <string name="insight_condition_partly_cloudy">Μερική συννεφιά</string>
     <string name="insight_condition_cloudy">Συννεφιά</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -451,7 +451,6 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="insight_precip">%1$s.</string>
     <string name="insight_precip_overnight">durante la noche</string>
 
-    <string name="insight_precip_tonight">esta noche</string>
     <string name="insight_condition_clear">Despejado</string>
     <string name="insight_condition_partly_cloudy">Parcialmente nublado</string>
     <string name="insight_condition_cloudy">Nublado</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -522,7 +522,6 @@ Tone is informal "sina"-form throughout ("Pane … selga", "Võta … kaasa",
     <string name="insight_precip_chance">Vihma võimalus: %1$s.</string>
     <string name="insight_precip_overnight">öö jooksul</string>
 
-    <string name="insight_precip_tonight">täna õhtul</string>
     <string name="insight_condition_clear">Selge</string>
     <string name="insight_condition_partly_cloudy">Vahelduv pilvisus</string>
     <string name="insight_condition_cloudy">Pilves</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -88,7 +88,6 @@ Western Arabic numerals (0-9) are used for TTS compatibility.
     <string name="insight_precip">%1$s.</string>
     <string name="insight_precip_overnight">در طول شب</string>
 
-    <string name="insight_precip_tonight">امشب</string>
     <string name="insight_condition_clear">آفتابی</string>
     <string name="insight_condition_partly_cloudy">نیمه ابری</string>
     <string name="insight_condition_cloudy">ابری</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -377,8 +377,6 @@ displayed label localizes.
     <string name="insight_precip">%1$s.</string>
     <string name="insight_precip_overnight">yön aikana</string>
 
-    <string name="insight_precip_tonight">tänä iltana</string>
-
     <string name="insight_condition_clear">Selkeää</string>
     <string name="insight_condition_partly_cloudy">Puolipilvistä</string>
     <string name="insight_condition_cloudy">Pilvistä</string>

--- a/app/src/main/res/values-fil/strings.xml
+++ b/app/src/main/res/values-fil/strings.xml
@@ -82,7 +82,6 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="insight_precip">%1$s.</string>
     <string name="insight_precip_overnight">buong gabi</string>
 
-    <string name="insight_precip_tonight">ngayong gabi</string>
     <string name="insight_condition_clear">Maliwanag</string>
     <string name="insight_condition_partly_cloudy">Bahagyang maulap</string>
     <string name="insight_condition_cloudy">Maulap</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -454,7 +454,6 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="insight_precip">%1$s.</string>
     <string name="insight_precip_overnight">pendant la nuit</string>
 
-    <string name="insight_precip_tonight">ce soir</string>
     <string name="insight_condition_clear">Clair</string>
     <string name="insight_condition_partly_cloudy">Partiellement nuageux</string>
     <string name="insight_condition_cloudy">Nuageux</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -483,7 +483,6 @@ Not overridden by design:
     <string name="insight_precip">%1$s।</string>
     <string name="insight_precip_overnight">रात भर</string>
 
-    <string name="insight_precip_tonight">आज रात</string>
     <string name="insight_condition_clear">साफ़</string>
     <string name="insight_condition_partly_cloudy">आंशिक बादल</string>
     <string name="insight_condition_cloudy">बादल</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -422,7 +422,6 @@ spousal register), matching the existing insight prose ("Ponesi …",
     <string name="insight_precip">%1$s.</string>
     <string name="insight_precip_overnight">noću</string>
 
-    <string name="insight_precip_tonight">večeras</string>
     <string name="insight_condition_clear">Vedro</string>
     <string name="insight_condition_partly_cloudy">Djelomično oblačno</string>
     <string name="insight_condition_cloudy">Oblačno</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -566,7 +566,6 @@ locale (Angol (Egyesült Államok), Francia (Franciaország), Német
     <string name="insight_precip">%1$s.</string>
     <string name="insight_precip_overnight">éjszaka</string>
 
-    <string name="insight_precip_tonight">ma este</string>
     <string name="insight_precip_chance">Esetleg %1$s.</string>
     <string name="insight_condition_clear">Tiszta</string>
     <string name="insight_condition_partly_cloudy">Részben felhős</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -84,7 +84,6 @@ to values/strings.xml (English).
     <string name="insight_precip">%1$s.</string>
     <string name="insight_precip_overnight">semalam</string>
 
-    <string name="insight_precip_tonight">malam ini</string>
     <string name="insight_condition_clear">Cerah</string>
     <string name="insight_condition_partly_cloudy">Sebagian berawan</string>
     <string name="insight_condition_cloudy">Berawan</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -440,7 +440,6 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="insight_precip">%1$s.</string>
     <string name="insight_precip_overnight">durante la notte</string>
 
-    <string name="insight_precip_tonight">stasera</string>
     <string name="insight_condition_clear">Sereno</string>
     <string name="insight_condition_partly_cloudy">Parzialmente nuvoloso</string>
     <string name="insight_condition_cloudy">Nuvoloso</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -89,7 +89,6 @@ standard in Israeli digital communication.
     <string name="insight_precip">%1$s.</string>
     <string name="insight_precip_overnight">בלילה</string>
 
-    <string name="insight_precip_tonight">הלילה</string>
     <string name="insight_condition_clear">בהיר</string>
     <string name="insight_condition_partly_cloudy">מעונן חלקית</string>
     <string name="insight_condition_cloudy">מעונן</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -454,7 +454,6 @@ the displayed label localizes.
     <string name="insight_precip">%1$s。</string>
     <string name="insight_precip_overnight">夜通し</string>
 
-    <string name="insight_precip_tonight">今夜</string>
     <string name="insight_condition_clear">晴れ</string>
     <string name="insight_condition_partly_cloudy">晴れのち曇り</string>
     <string name="insight_condition_cloudy">曇り</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -465,7 +465,6 @@ displayed label localizes.
     <string name="insight_precip">%1$s.</string>
     <string name="insight_precip_overnight">밤새</string>
 
-    <string name="insight_precip_tonight">오늘 밤</string>
     <string name="insight_condition_clear">맑음</string>
     <string name="insight_condition_partly_cloudy">구름 조금</string>
     <string name="insight_condition_cloudy">흐림</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -88,7 +88,6 @@ What is NOT overridden, by design:
     <string name="insight_precip">%1$s.</string>
     <string name="insight_precip_overnight">naktį</string>
 
-    <string name="insight_precip_tonight">šįvakar</string>
     <string name="insight_condition_clear">Giedra</string>
     <string name="insight_condition_partly_cloudy">Mažai debesuota</string>
     <string name="insight_condition_cloudy">Debesuota</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -94,7 +94,6 @@ informal "tu"-form throughout ("Apģērb …", "Paņem … līdzi").
     <string name="insight_precip">%1$s.</string>
     <string name="insight_precip_overnight">naktī</string>
 
-    <string name="insight_precip_tonight">šovakar</string>
     <string name="insight_precip_chance">Iespējams %1$s.</string>
     <string name="insight_condition_clear">Skaidrs</string>
     <string name="insight_condition_partly_cloudy">Daļēji mākoņains</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -84,7 +84,6 @@ vs "kemungkinan", "padam" vs "hapus").
     <string name="insight_precip">%1$s.</string>
     <string name="insight_precip_overnight">semalaman</string>
 
-    <string name="insight_precip_tonight">malam ini</string>
     <string name="insight_condition_clear">Cerah</string>
     <string name="insight_condition_partly_cloudy">Sebahagian berawan</string>
     <string name="insight_condition_cloudy">Berawan</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -572,7 +572,6 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrike)").
     <string name="insight_precip">%1$s.</string>
     <string name="insight_precip_overnight">i natt</string>
 
-    <string name="insight_precip_tonight">i kveld</string>
     <string name="insight_precip_chance">Sjanse for %1$s.</string>
 
     <string name="insight_condition_clear">Klart</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -421,8 +421,6 @@ the displayed label localizes.
     <!-- Apostrophe before s-genitive in Dutch: "'s nachts" = at night. -->
     <string name="insight_precip_overnight">\'s nachts</string>
 
-    <string name="insight_precip_tonight">vanavond</string>
-
     <string name="insight_condition_clear">Helder</string>
     <string name="insight_condition_partly_cloudy">Gedeeltelijk bewolkt</string>
     <string name="insight_condition_cloudy">Bewolkt</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -419,8 +419,6 @@ is unchanged; only the displayed label localizes.
     <string name="insight_precip">%1$s.</string>
     <string name="insight_precip_overnight">w nocy</string>
 
-    <string name="insight_precip_tonight">wieczorem</string>
-
     <string name="insight_condition_clear">Słonecznie</string>
     <string name="insight_condition_partly_cloudy">Częściowe zachmurzenie</string>
     <string name="insight_condition_cloudy">Pochmurno</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -458,7 +458,6 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="insight_precip">%1$s.</string>
     <string name="insight_precip_overnight">de madrugada</string>
 
-    <string name="insight_precip_tonight">esta noite</string>
     <string name="insight_condition_clear">Céu limpo</string>
     <string name="insight_condition_partly_cloudy">Parcialmente nublado</string>
     <string name="insight_condition_cloudy">Nublado</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -482,7 +482,6 @@ they diverge from BR ("Polonês" → "Polaco", "Holandês" →
     <string name="insight_precip">%1$s.</string>
     <string name="insight_precip_overnight">de madrugada</string>
 
-    <string name="insight_precip_tonight">esta noite</string>
     <string name="insight_condition_clear">Céu limpo</string>
     <string name="insight_condition_partly_cloudy">Parcialmente nublado</string>
     <string name="insight_condition_cloudy">Nublado</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -81,7 +81,6 @@ surfaces fall back to default English (matching values-pl / values-uk).
     <string name="insight_precip">%1$s.</string>
     <string name="insight_precip_overnight">peste noapte</string>
 
-    <string name="insight_precip_tonight">diseară</string>
     <string name="insight_condition_clear">Senin</string>
     <string name="insight_condition_partly_cloudy">Parțial înnorat</string>
     <string name="insight_condition_cloudy">Înnorat</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -634,7 +634,6 @@ only the displayed label localizes.
     <string name="insight_precip">%1$s.</string>
     <string name="insight_precip_overnight">ночью</string>
 
-    <string name="insight_precip_tonight">сегодня вечером</string>
     <string name="insight_precip_chance">Возможен %1$s.</string>
     <string name="insight_condition_clear">Ясно</string>
     <string name="insight_condition_partly_cloudy">Переменная облачность</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -577,7 +577,6 @@ What is NOT overridden, by design:
     <string name="insight_precip">%1$s.</string>
     <string name="insight_precip_overnight">v noci</string>
 
-    <string name="insight_precip_tonight">dnes večer</string>
     <string name="insight_precip_chance">Možnosť %1$s.</string>
     <string name="insight_condition_clear">Jasno</string>
     <string name="insight_condition_partly_cloudy">Polooblačno</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -82,7 +82,6 @@ informal "ti"-form throughout, mirroring the Croatian / Serbian pass.
     <string name="insight_precip">%1$s.</string>
     <string name="insight_precip_overnight">čez noč</string>
 
-    <string name="insight_precip_tonight">nocoj</string>
     <string name="insight_condition_clear">Jasno</string>
     <string name="insight_condition_partly_cloudy">Delno oblačno</string>
     <string name="insight_condition_cloudy">Oblačno</string>

--- a/app/src/main/res/values-sq/strings.xml
+++ b/app/src/main/res/values-sq/strings.xml
@@ -158,7 +158,6 @@
     <string name="insight_precip_chance">Mundësi për %1$s.</string>
     <string name="insight_precip_overnight">gjatë natës</string>
 
-    <string name="insight_precip_tonight">sonte</string>
     <string name="insight_condition_clear">Qartë</string>
     <string name="insight_condition_partly_cloudy">Pjesërisht me re</string>
     <string name="insight_condition_cloudy">Me re</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -572,7 +572,6 @@ native names for all locales (e.g. "Tyska (Tyskland)", "Franska (Frankrike)").
     <string name="insight_precip">%1$s.</string>
     <string name="insight_precip_overnight">under natten</string>
 
-    <string name="insight_precip_tonight">i kväll</string>
     <string name="insight_precip_chance">Risk för %1$s.</string>
 
     <string name="insight_condition_clear">Klart</string>

--- a/app/src/main/res/values-sw/strings.xml
+++ b/app/src/main/res/values-sw/strings.xml
@@ -82,7 +82,6 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="insight_precip">%1$s.</string>
     <string name="insight_precip_overnight">usiku</string>
 
-    <string name="insight_precip_tonight">usiku huu</string>
     <string name="insight_condition_clear">Angavu</string>
     <string name="insight_condition_partly_cloudy">Na mawingu kidogo</string>
     <string name="insight_condition_cloudy">Mawingu</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -82,7 +82,6 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="insight_precip">%1$s</string>
     <string name="insight_precip_overnight">ตลอดทั้งคืน</string>
 
-    <string name="insight_precip_tonight">คืนนี้</string>
     <string name="insight_condition_clear">ท้องฟ้าแจ่มใส</string>
     <string name="insight_condition_partly_cloudy">มีเมฆบางส่วน</string>
     <string name="insight_condition_cloudy">มีเมฆมาก</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -376,8 +376,6 @@ displayed label localizes.
     <string name="insight_precip">%1$s.</string>
     <string name="insight_precip_overnight">gece boyunca</string>
 
-    <string name="insight_precip_tonight">bu gece</string>
-
     <string name="insight_condition_clear">Açık</string>
     <string name="insight_condition_partly_cloudy">Parçalı bulutlu</string>
     <string name="insight_condition_cloudy">Bulutlu</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -576,7 +576,6 @@ only the displayed label localizes.
     <string name="insight_precip_chance">Можливий %1$s.</string>
     <string name="insight_precip_overnight">вночі</string>
 
-    <string name="insight_precip_tonight">сьогодні ввечері</string>
     <string name="insight_condition_clear">Ясно</string>
     <string name="insight_condition_partly_cloudy">Мінлива хмарність</string>
     <string name="insight_condition_cloudy">Хмарно</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -87,7 +87,6 @@ Skipped intentionally: app_name (brand), insight_time_am/pm/midnight/noon
     <string name="insight_precip">%1$s.</string>
     <string name="insight_precip_overnight">suốt đêm</string>
 
-    <string name="insight_precip_tonight">tối nay</string>
     <string name="insight_condition_clear">Trời quang</string>
     <string name="insight_condition_partly_cloudy">Có mây</string>
     <string name="insight_condition_cloudy">Nhiều mây</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -447,7 +447,6 @@ label localizes.
     <string name="insight_precip">%1$s。</string>
     <string name="insight_precip_overnight">整夜</string>
 
-    <string name="insight_precip_tonight">今晚</string>
     <string name="insight_condition_clear">晴</string>
     <string name="insight_condition_partly_cloudy">多云</string>
     <string name="insight_condition_cloudy">阴</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -438,7 +438,6 @@ label localises.
     <string name="insight_precip">%1$s。</string>
     <string name="insight_precip_overnight">整夜</string>
 
-    <string name="insight_precip_tonight">今晚</string>
     <string name="insight_condition_clear">晴</string>
     <string name="insight_condition_partly_cloudy">多雲</string>
     <string name="insight_condition_cloudy">陰</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1302,14 +1302,16 @@
     %1$s = condition (downcased), %2$s = accessory phrase.
     -->
     <string name="insight_precip_chance_with_accessory">Chance of %1$s, bring %2$s.</string>
-    <!-- Coarse timing word for the morning insight's evening rain tie-in:
-         post-midnight peaks (00:00–04:59) read "overnight". The tie-in already
-         leads with "Tonight," so this only has to flag the post-midnight case
-         the lead doesn't cover. -->
+    <!-- Timing qualifier for the morning insight's evening rain tie-in,
+         appended after the condition noun ("Tonight, rain overnight, …") only
+         when the precip peak falls post-midnight (00:00–04:59). Evening peaks
+         get no qualifier at all: the clause already leads with "Tonight," so
+         repeating "tonight" mid-sentence stuttered ("Tonight, rain tonight").
+         The formatter joins this word onto the qualifier slot with a leading
+         space (the templates butt the slot up against the condition so an
+         empty qualifier leaves no stray gap). Base English is the only locale
+         that renders the qualifier slot — translations dropped it. -->
     <string name="insight_precip_overnight">overnight</string>
-    <!-- Coarse timing word for the evening rain tie-in when the peak is this
-         evening rather than post-midnight — "Tonight, rain tonight." -->
-    <string name="insight_precip_tonight">tonight</string>
 
     <!--
     Spoken-time vocabulary used by InsightFormatter.spokenTime to emit forms
@@ -1371,49 +1373,50 @@
     the same sentence so the morning insight mentions the evening weather
     alongside the evening clothing tip, without emitting a second precip clause
     that would compete with the morning slice's own. The precip clause leads the
-    item ("Tonight, rain tonight, bring a jacket.") so the sentence reads
+    item ("Tonight, rain, bring a jacket.") so the sentence reads
     weather-then-action, mirroring how the day insight orders precip before the
     carry. "umbrella" is stripped from the items by the formatter when this
     template is used — the precip mention already covers what an umbrella's for
-    — so the template never has to apologise for "bring an umbrella, rain
-    tonight." %1$s = item phrase, %2$s = coarse timing word ("tonight" /
-    "overnight"), %3$s = condition noun (the same insight_condition_* label the
-    main clause uses, lowercased mid-sentence) so a stormy / snowy evening names
-    the real condition ("Tonight, snow overnight, …") instead of always saying
-    "rain".
+    — so the template never has to apologise for "bring an umbrella, rain."
+    %1$s = item phrase, %2$s = timing qualifier (empty for evening
+    peaks; " overnight" with its leading space for post-midnight ones — see
+    insight_precip_overnight), %3$s = condition noun (the same
+    insight_condition_* label the main clause uses, lowercased mid-sentence) so
+    a stormy / snowy evening names the real condition ("Tonight, snow
+    overnight, …") instead of always saying "rain".
     -->
-    <string name="insight_tie_in_with_rain">Tonight, %3$s %2$s, bring %1$s.</string>
+    <string name="insight_tie_in_with_rain">Tonight, %3$s%2$s, bring %1$s.</string>
     <!--
     POSSIBLE-tier counterpart of insight_tie_in_with_rain: a clothes rule
     triggered for the evening but only one per-model series flagged the
     precip at ≥ 30%. Hedges the wording so a single-model reading doesn't
     render with the same definite tone as a majority-of-models agreement.
-    %1$s = item phrase, %2$s = coarse timing word ("tonight" / "overnight"),
+    %1$s = item phrase, %2$s = timing qualifier (empty / " overnight"),
     %3$s = condition noun (lowercased), so the hedge reads "chance of snow" /
     "chance of thunderstorm" when the peak isn't plain rain.
     -->
-    <string name="insight_tie_in_with_rain_chance">Tonight, chance of %3$s %2$s, bring %1$s.</string>
+    <string name="insight_tie_in_with_rain_chance">Tonight, chance of %3$s%2$s, bring %1$s.</string>
     <!--
     Bare-precip variant of the evening tie-in for the morning insight: emitted
     when the user has an evening event with a location and the per-model
     forecast tier spots precip ≥ 50% (majority of models agree) at some hour in
     the tonight window, but no clothes rule fired for that period. The
     morning insight stays silent on clothing because nothing's been picked
-    yet — the precip mention itself is the point. %1$s = coarse timing word
-    ("tonight" / "overnight"), %2$s = condition noun (lowercased) so a snowy /
+    yet — the precip mention itself is the point. %1$s = timing qualifier
+    (empty / " overnight"), %2$s = condition noun (lowercased) so a snowy /
     stormy evening names the real condition ("Tonight, snow overnight.")
     instead of always saying "rain". Fronts the "Tonight," time marker so the
     sentence reads in the same "<time>, <content>." shape as the band lead and
     the item-led tie-in templates.
     -->
-    <string name="insight_evening_rain">Tonight, %2$s %1$s.</string>
+    <string name="insight_evening_rain">Tonight, %2$s%1$s.</string>
     <!--
     POSSIBLE-tier counterpart of insight_evening_rain: only one per-model
     series flagged the tonight hour ≥ 30%, so we hedge the wording. Matches
-    insight_precip_chance's "Chance of rain" pattern. %1$s = coarse timing word
-    ("tonight" / "overnight"), %2$s = condition noun (lowercased).
+    insight_precip_chance's "Chance of rain" pattern. %1$s = timing qualifier
+    (empty / " overnight"), %2$s = condition noun (lowercased).
     -->
-    <string name="insight_evening_rain_chance">Tonight, chance of %2$s %1$s.</string>
+    <string name="insight_evening_rain_chance">Tonight, chance of %2$s%1$s.</string>
 
     <!--
     Holidays sub-page: per-holiday opt-in toggles. On the matching calendar

--- a/app/src/test/kotlin/app/clothescast/insight/InsightFormatterTest.kt
+++ b/app/src/test/kotlin/app/clothescast/insight/InsightFormatterTest.kt
@@ -983,14 +983,15 @@ class InsightFormatterTest {
                 ),
             ),
         )
-        out shouldBe "Today, it will be 21°. Tonight, rain tonight."
+        out shouldBe "Today, it will be 21°. Tonight, rain."
     }
 
     @Test
     fun `evening event tie-in says 'overnight' for a post-midnight rain peak`() {
-        // A peak in the early hours (00:00–04:59) reads "overnight" instead of
-        // "tonight", flagging the post-midnight window the "Tonight," lead
-        // doesn't already cover.
+        // A peak in the early hours (00:00–04:59) appends "overnight",
+        // flagging the post-midnight window the "Tonight," lead doesn't
+        // already cover. Evening peaks get no qualifier — the lead alone
+        // carries the timing ("Tonight, rain, …").
         val out = subject.format(
             summary(
                 eveningEventTieIn = EveningEventTieInClause(
@@ -1017,8 +1018,8 @@ class InsightFormatterTest {
 
     @Test
     fun `evening event tie-in ignores the all-day flag on bare evening rain`() {
-        // The coarse "tonight" / "overnight" word is keyed off the peak hour,
-        // not coverage, so an all-day evening reads the same "tonight" as a
+        // The "overnight" qualifier is keyed off the peak hour, not coverage,
+        // so an all-day evening reads the same bare "Tonight, rain." as a
         // single-hour evening peak — the all-day distinction is gone.
         val out = subject.format(
             summary(
@@ -1029,7 +1030,7 @@ class InsightFormatterTest {
                 ),
             ),
         )
-        out shouldBe "Today, it will be 21°. Tonight, rain tonight."
+        out shouldBe "Today, it will be 21°. Tonight, rain."
     }
 
     @Test
@@ -1044,7 +1045,7 @@ class InsightFormatterTest {
                 ),
             ),
         )
-        out shouldBe "Today, it will be 21°. Tonight, chance of rain tonight."
+        out shouldBe "Today, it will be 21°. Tonight, chance of rain."
     }
 
     @Test
@@ -1058,7 +1059,7 @@ class InsightFormatterTest {
                 ),
             ),
         )
-        out shouldBe "Today, it will be 21°. Tonight, rain tonight, bring a jacket."
+        out shouldBe "Today, it will be 21°. Tonight, rain, bring a jacket."
     }
 
     @Test
@@ -1072,7 +1073,7 @@ class InsightFormatterTest {
                 ),
             ),
         )
-        out shouldBe "Today, it will be 21°. Tonight, chance of rain tonight."
+        out shouldBe "Today, it will be 21°. Tonight, chance of rain."
     }
 
     @Test
@@ -1120,7 +1121,7 @@ class InsightFormatterTest {
 
     @Test
     fun `evening event tie-in folds rain time leading the items when present`() {
-        // Rain leads the item ("Tonight, rain tonight, bring a jacket.") so
+        // Rain leads the item ("Tonight, rain, bring a jacket.") so
         // the tie-in reads weather-then-action, same shape as the day insight
         // (precip clause precedes the carry).
         val out = subject.format(
@@ -1128,7 +1129,7 @@ class InsightFormatterTest {
                 eveningEventTieIn = EveningEventTieInClause(items = listOf("jacket"), rainTime = LocalTime.of(21, 0)),
             ),
         )
-        out shouldBe "Today, it will be 21°. Tonight, rain tonight, bring a jacket."
+        out shouldBe "Today, it will be 21°. Tonight, rain, bring a jacket."
     }
 
     @Test
@@ -1144,7 +1145,7 @@ class InsightFormatterTest {
                     precipCondition = WeatherCondition.SNOW,
                 ),
             ),
-        ) shouldBe "Today, it will be 21°. Tonight, snow tonight, bring a jacket."
+        ) shouldBe "Today, it will be 21°. Tonight, snow, bring a jacket."
 
         subject.format(
             summary(
@@ -1154,7 +1155,7 @@ class InsightFormatterTest {
                     precipCondition = WeatherCondition.THUNDERSTORM,
                 ),
             ),
-        ) shouldBe "Today, it will be 21°. Tonight, thunderstorm tonight."
+        ) shouldBe "Today, it will be 21°. Tonight, thunderstorm."
     }
 
     @Test
@@ -1170,7 +1171,7 @@ class InsightFormatterTest {
                     precipCondition = WeatherCondition.SNOW,
                 ),
             ),
-        ) shouldBe "Today, it will be 21°. Tonight, chance of snow tonight."
+        ) shouldBe "Today, it will be 21°. Tonight, chance of snow."
     }
 
     @Test
@@ -1186,7 +1187,7 @@ class InsightFormatterTest {
                 ),
             ),
         )
-        out shouldBe "Today, it will be 21°. Tonight, rain tonight."
+        out shouldBe "Today, it will be 21°. Tonight, rain."
     }
 
     @Test
@@ -1199,7 +1200,7 @@ class InsightFormatterTest {
                 ),
             ),
         )
-        out shouldBe "Today, it will be 21°. Tonight, rain tonight, bring a jacket."
+        out shouldBe "Today, it will be 21°. Tonight, rain, bring a jacket."
     }
 
     @Test
@@ -1229,7 +1230,7 @@ class InsightFormatterTest {
                 ),
             ),
         )
-        out shouldBe "Today, it will be 21°. Tonight, chance of rain tonight, bring a jacket."
+        out shouldBe "Today, it will be 21°. Tonight, chance of rain, bring a jacket."
     }
 
     @Test
@@ -1353,12 +1354,12 @@ class InsightFormatterTest {
                     precipCondition = WeatherCondition.RAIN,
                 ),
             ),
-        ) shouldBe "Today, it will be 21°. Tonight, rain tonight, bring a jacket and umbrella."
+        ) shouldBe "Today, it will be 21°. Tonight, rain, bring a jacket and umbrella."
     }
 
     @Test
     fun `umbrella accessory promotes the bare-rain evening tie-in to the item-led template`() {
-        // Without an opted-in umbrella rule this path renders "Tonight, rain tonight.".
+        // Without an opted-in umbrella rule this path renders "Tonight, rain.".
         // The umbrella choice promotes it to the item-led template with the
         // accessory as the lone item.
         umbrellaSubject.format(
@@ -1369,7 +1370,7 @@ class InsightFormatterTest {
                     precipCondition = WeatherCondition.RAIN,
                 ),
             ),
-        ) shouldBe "Today, it will be 21°. Tonight, rain tonight, bring an umbrella."
+        ) shouldBe "Today, it will be 21°. Tonight, rain, bring an umbrella."
     }
 
     @Test
@@ -1383,7 +1384,7 @@ class InsightFormatterTest {
                     precipCondition = WeatherCondition.RAIN,
                 ),
             ),
-        ) shouldBe "Today, it will be 21°. Tonight, chance of rain tonight, bring an umbrella."
+        ) shouldBe "Today, it will be 21°. Tonight, chance of rain, bring an umbrella."
     }
 
     @Test
@@ -1409,7 +1410,7 @@ class InsightFormatterTest {
                     precipCondition = WeatherCondition.RAIN,
                 ),
             ),
-        ) shouldBe "Today, it will be 21°. Tonight, rain tonight, bring a jacket and umbrella."
+        ) shouldBe "Today, it will be 21°. Tonight, rain, bring a jacket and umbrella."
     }
 
     @Test
@@ -1427,7 +1428,7 @@ class InsightFormatterTest {
                     precipCondition = WeatherCondition.SNOW,
                 ),
             ),
-        ) shouldBe "Today, it will be 21°. Tonight, snow tonight."
+        ) shouldBe "Today, it will be 21°. Tonight, snow."
     }
 
     @Test
@@ -1446,7 +1447,7 @@ class InsightFormatterTest {
                     precipCondition = WeatherCondition.THUNDERSTORM,
                 ),
             ),
-        ) shouldBe "Today, it will be 21°. Tonight, thunderstorm tonight, bring a jacket and umbrella."
+        ) shouldBe "Today, it will be 21°. Tonight, thunderstorm, bring a jacket and umbrella."
     }
 
     @Test
@@ -1462,7 +1463,7 @@ class InsightFormatterTest {
                     precipCondition = null,
                 ),
             ),
-        ) shouldBe "Today, it will be 21°. Tonight, rain tonight, bring a jacket."
+        ) shouldBe "Today, it will be 21°. Tonight, rain, bring a jacket."
     }
 
     @Test
@@ -2015,7 +2016,7 @@ class InsightFormatterTest {
                 ),
             ),
         )
-        out shouldBe "Today, it will be 21°. Tonight, rain tonight."
+        out shouldBe "Today, it will be 21°. Tonight, rain."
     }
 
     @Test

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/InsightSummary.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/InsightSummary.kt
@@ -221,7 +221,7 @@ data class CalendarTieInClause(val item: String)
  * [allDay] mirrors [PrecipClause.allDay] for the evening slice. Like the
  * peak time, it's carried for data consumers rather than the prose — the
  * formatter no longer speaks the hour or an "all night" phrase ("Tonight,
- * rain tonight, bring a jacket." reads the same either way). Only
+ * rain, bring a jacket." reads the same either way). Only
  * meaningful when [rainTime] is set and [likelihood] is LIKELY.
  *
  * [precipCondition] mirrors the same per-model peak's [WeatherCondition] so

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsightTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsightTest.kt
@@ -1108,7 +1108,7 @@ class GenerateDailyInsightTest {
         tie.rainTime shouldBe LocalTime.of(21, 0)
         // Both evening hours sit ≥ 50%, so the whole-window flag is set. The
         // prose no longer speaks it (the formatter dropped the hour / "all
-        // night" phrasing — "Tonight, rain tonight, bring a jacket." reads
+        // night" phrasing — "Tonight, rain, bring a jacket." reads
         // the same either way), but the flag still rides the clause for data
         // consumers, so pin that the derivation sets it.
         tie.allDay shouldBe true


### PR DESCRIPTION
## What

Fixes the stutter from the bug report: the morning insight's evening tie-in read **"Tonight, drizzle tonight, bring an umbrella."** The clause's "Tonight," lead and the coarse timing word were both emitted for evening peaks.

Now:
- Evening peaks (the common case) drop the timing word: **"Tonight, drizzle, bring an umbrella."**
- Post-midnight peaks (00:00–04:59) still append **"overnight"** — the one case the lead doesn't cover: "Tonight, rain overnight, bring a jacket."

## Why this shape

This was a base-English-only stutter: all 48 translations had already dropped the `%2$s` timing slot from `insight_tie_in_with_rain` / `insight_evening_rain` (and their `_chance` variants), so only `values/strings.xml` changes wording — translations are untouched and behave exactly as before.

- The four base templates now butt the qualifier slot against the condition noun (`%3$s%2$s`); `InsightFormatter.overnightQualifier` passes `""` for evening peaks or `" overnight"` (leading space joined in code) for post-midnight ones. Argument positions are unchanged, so every translation's placeholder references stay valid.
- `insight_precip_tonight` is now unused and removed from base and all locale files (avoids dead resources / ExtraTranslation lint).
- Updated stale prose examples in comments (`InsightSummary`, `AGENTS.md`, string comments) and the `InsightFormatterTest` expectations.

## Privacy

The rendered prose (which is fed to Gemini TTS on BYOK setups) shrinks by one word; nothing new crosses the device boundary.

## Test plan

Ran the full CI-equivalent locally in the sandbox (Google Maven + SDK available):
- `./gradlew :core:domain:test :core:data:test :app:testDebugUnitTest` — green (1021 tests)
- `./gradlew :app:assembleDebug` — green (validates resource linking across the 50 edited locale files)

https://claude.ai/code/session_017uV9oMx3cUDq2PdMGwhaq6

---
_Generated by [Claude Code](https://claude.ai/code/session_017uV9oMx3cUDq2PdMGwhaq6)_