### PR TITLE
Correct rebase-merge wording and stale SDK note in agent guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -182,7 +182,7 @@ new rule the first time something bites you, not the third.
   update the title and body via `mcp__github__update_pull_request` so
   they describe the *current* state — not the state at PR creation.
   Subject line stays Play-Store-ready (sentence case, end-user copy, ≤
-  ~80 chars, matches the squash-merge subject); body covers scope,
+  ~80 chars, matches the rebase-merge subject); body covers scope,
   rationale, privacy-relevant changes, and test plan for everything now
   in the diff. If nothing material changed, no update is needed — but
   check, don't assume.
@@ -443,9 +443,8 @@ new rule the first time something bites you, not the third.
   + build-tools;35.0.0). `ANDROID_HOME` / `ANDROID_SDK_ROOT` are exported via
   `~/.bashrc`; source it or `export ANDROID_HOME=/opt/android-sdk` before
   running Gradle if your shell hasn't picked it up.
-- **All three modules build and test on this VM.** Unlike the AGENTS.md note
-  about agent sandboxes lacking the SDK, the Cursor Cloud VM has it. You can
-  run the full CI-equivalent locally:
+- **All three modules build and test on this VM.** The Cursor Cloud VM has
+  the Android SDK installed, so you can run the full CI-equivalent locally:
   ```
   export ANDROID_HOME=/opt/android-sdk
   ./gradlew :core:domain:test :core:data:test :app:testDebugUnitTest


### PR DESCRIPTION
Two factual errors in `AGENTS.md` (and its `CLAUDE.md` symlink), found while reviewing the guide against the repo and the live sandbox.

## Fixes

1. **"squash-merge subject" → "rebase-merge subject"** (GitHub / PR-sync rule).
   The repo lands PRs via rebase merge — history is linear, there are no merge
   commits, and `ci.yml` itself describes the head commit ending up as "a
   rebase-merge to `main`". The changelog step also reads *every* commit
   subject since the last main CI run, which only makes sense under rebase
   merge (a squash merge would collapse the PR to one subject). The old
   wording contradicted all of that.

2. **Dropped a dangling reference to a note that no longer exists.** The Cursor
   Cloud section said "Unlike the AGENTS.md note about agent sandboxes lacking
   the SDK…", but the guide now expects the SDK present (the "Sandbox testing"
   section treats `/opt/android-sdk` + Google Maven as the intended state, and
   the SessionStart hook installs the SDK). Reworded to state plainly that the
   VM has the SDK.

Verified in-session that the build toolchain is reachable here: `maven.google.com`
and `dl.google.com` respond, `sdkmanager` is on PATH, and `ANDROID_HOME=/opt/android-sdk`
with platforms + build-tools installed.

## Test plan

Docs-only change (no code, no shipped strings). No build impact.

https://claude.ai/code/session_011jjrayrYF66vb5igqdPPdh

---
_Generated by [Claude Code](https://claude.ai/code/session_011jjrayrYF66vb5igqdPPdh)_