### PR TITLE
Forecast confidence survives a one-off network timeout

### DIFF
--- a/core/data/src/main/kotlin/app/clothescast/core/data/weather/MultiModelConfidenceFetcher.kt
+++ b/core/data/src/main/kotlin/app/clothescast/core/data/weather/MultiModelConfidenceFetcher.kt
@@ -19,6 +19,7 @@ import io.ktor.client.statement.bodyAsText
 import io.ktor.http.URLProtocol
 import io.ktor.http.path
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.delay
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
@@ -28,6 +29,7 @@ import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.doubleOrNull
 import kotlinx.serialization.json.intOrNull
 import kotlinx.serialization.json.jsonPrimitive
+import java.io.IOException
 import java.time.LocalDateTime
 
 /**
@@ -79,6 +81,7 @@ internal class MultiModelConfidenceFetcher(
         // a hand-edited-DataStore safety net more than a user-reachable path.
         var remaining = models.takeIf { it.isNotEmpty() } ?: DEFAULT_MODELS
         var attempts = 0
+        var transientAttempts = 0
         while (true) {
             attempts++
             val response = try {
@@ -134,6 +137,28 @@ internal class MultiModelConfidenceFetcher(
                 remaining = pruned
                 continue
             } catch (t: Throwable) {
+                // A transient network failure — a socket / connect / request
+                // timeout or a mid-flight IO drop — shouldn't cost the whole
+                // per-model feature for the period. The primary forecast
+                // retries these via WorkManager, but this side-band fetch is
+                // deliberately best-effort: its failure is swallowed (returns
+                // null) so it never reaches the worker's retry path. A single
+                // timeout on the 7am round-trip would otherwise drop the
+                // confidence card *and* every per-model chart until the next
+                // scheduled run. Retry a couple of times with a short backoff
+                // here instead. Parse errors and the like aren't IOExceptions,
+                // so they fall straight through to null — a malformed body
+                // won't fix itself on a retry.
+                if (transientAttempts < MAX_TRANSIENT_RETRIES && t.isTransientNetworkFailure()) {
+                    transientAttempts++
+                    logger.log(
+                        "confidence fetch transient failure " +
+                            "(retry $transientAttempts/$MAX_TRANSIENT_RETRIES)",
+                        t,
+                    )
+                    delay(TRANSIENT_RETRY_BACKOFF_MS * transientAttempts)
+                    continue
+                }
                 logger.log("confidence fetch failed", t)
                 return null
             }
@@ -458,8 +483,26 @@ internal class MultiModelConfidenceFetcher(
         // belt-and-suspenders bound against a pathological model list (and
         // keeps a worst case of a handful of requests, not an unbounded storm).
         private const val MAX_FETCH_ATTEMPTS = 6
+
+        // Transient-network retry budget. A socket timeout on this best-effort
+        // side-band fetch is swallowed before it can reach the worker's
+        // WorkManager retry, so without an internal retry one 7am timeout drops
+        // the confidence card and every per-model chart for the whole period.
+        // Two extra attempts with a short linear backoff clear the common
+        // one-off timeout without stalling the round-trip for long when the
+        // network is genuinely down.
+        private const val MAX_TRANSIENT_RETRIES = 2
+        private const val TRANSIENT_RETRY_BACKOFF_MS = 500L
     }
 }
+
+// True when [this] (or any cause in its chain) is an IOException — the socket /
+// connect / request timeouts and generic network drops a retry might clear.
+// java.net.SocketTimeoutException, Ktor's socket/connect timeout types, and
+// HttpRequestTimeoutException all extend IOException; a SerializationException
+// or other parse failure does not, so it isn't retried.
+private fun Throwable.isTransientNetworkFailure(): Boolean =
+    generateSequence(this) { it.cause }.any { it is IOException }
 
 internal data class MultiModelData(
     val confidence: ConfidenceInfo?,

--- a/core/data/src/test/kotlin/app/clothescast/core/data/weather/MultiModelConfidenceFetcherTest.kt
+++ b/core/data/src/test/kotlin/app/clothescast/core/data/weather/MultiModelConfidenceFetcherTest.kt
@@ -414,6 +414,49 @@ class MultiModelConfidenceFetcherTest {
     }
 
     @Test
+    fun `retries a transient network timeout and then succeeds`() = runTest {
+        // A socket timeout on this best-effort side-band fetch is swallowed
+        // before it can reach the worker's WorkManager retry, so one 7am
+        // timeout would otherwise drop the confidence card and every per-model
+        // chart for the whole period. Verify the internal retry clears a
+        // one-off timeout: first request times out, the retry succeeds.
+        var calls = 0
+        val engine = MockEngine {
+            calls++
+            if (calls == 1) throw java.net.SocketTimeoutException("timeout")
+            respond(
+                content = ByteReadChannel(THREE_MODEL_AGREEMENT),
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+        val logger = CapturingLogger()
+        fetcherWith(engine, logger = logger).fetch(london, fixtureModels).shouldNotBeNull()
+
+        calls shouldBe 2
+        logger.entries.any { "transient" in it.message } shouldBe true
+        // No terminal give-up once the retry succeeds.
+        logger.entries.none { it.message == "confidence fetch failed" } shouldBe true
+    }
+
+    @Test
+    fun `gives up and returns null after exhausting the transient retry budget`() = runTest {
+        // A persistent timeout (network genuinely down) must terminate rather
+        // than loop forever, and still log the final give-up.
+        var calls = 0
+        val engine = MockEngine {
+            calls++
+            throw java.net.SocketTimeoutException("timeout")
+        }
+        val logger = CapturingLogger()
+        fetcherWith(engine, logger = logger).fetch(london, fixtureModels).shouldBeNull()
+
+        // Initial attempt + 2 transient retries = 3 requests, then give up.
+        calls shouldBe 3
+        logger.entries.last().message shouldBe "confidence fetch failed"
+    }
+
+    @Test
     fun `successful fetch logs nothing`() = runTest {
         val logger = CapturingLogger()
         fetcherWith(THREE_MODEL_AGREEMENT, logger = logger).fetch(london, fixtureModels).shouldNotBeNull()


### PR DESCRIPTION
## What the user saw

Tapping the forecast chart did nothing — no per-model lines — and the **confidence card was gone entirely**.

## Root cause

The bug report's log has the smoking gun:

```
2026-06-10 19:00:41.468 W ConfidenceFetcher: confidence fetch failed
java.net.SocketTimeoutException: Socket timeout has expired [url=.../forecast?...&models=ukmo_seamless,ecmwf_ifs025,icon_seamless,ecmwf_aifs025_single]
```

The multi-model confidence / per-model fetch is a **best-effort side-band**: its failure is deliberately swallowed (`MultiModelConfidenceFetcher.fetch` returns `null`) inside `OpenMeteoClient`, so `bundle.confidence` and `bundle.perModelHourly` both go null. That's by design — a missing confidence chip shouldn't fail the whole forecast.

But because the failure is swallowed *before* it can reach the worker, it never triggers the worker's WorkManager retry path the way a primary-fetch socket timeout does (`Socket timeout; retrying.` → `Result.retry()`). So a single transient timeout dropped:

- the confidence card (gated on `insight.confidence != null`), and
- every per-model chart overlay + the tap-to-reveal affordance (gated on `insight.perModelHourly != null`)

…for the entire period, with no retry, until the next scheduled run.

## Fix

Retry transient network failures inside `MultiModelConfidenceFetcher.fetch` — anything with an `IOException` in its cause chain (socket / connect / request timeouts, mid-flight IO drops) — up to twice with a short linear backoff (500ms, 1000ms) before giving up. Parse errors and other non-IO throwables still fall straight through to `null`, since a malformed body won't fix itself on a retry. This mirrors the worker's transient-retry posture, but lives where the failure is otherwise swallowed.

The existing 5xx path (HTTP 500 → `ResponseException` → return null after one request) and the invalid-model prune-and-retry path are unchanged.

## Privacy

No change to what crosses the device boundary — same request, same parameters, just retried on a transient timeout.

## Test plan

- `:core:data:test` — two new cases in `MultiModelConfidenceFetcherTest`:
  - `retries a transient network timeout and then succeeds` — first request throws `SocketTimeoutException`, the retry succeeds, result is non-null and no terminal "confidence fetch failed" is logged.
  - `gives up and returns null after exhausting the transient retry budget` — a persistent timeout terminates after the initial attempt + 2 retries (3 requests) and logs the give-up, proving it doesn't loop forever.
- Full `:core:data:test` + `:core:domain:test` green.

https://claude.ai/code/session_013qTkcvN2Cg5aWYQ6MhL9Es

---
_Generated by [Claude Code](https://claude.ai/code/session_013qTkcvN2Cg5aWYQ6MhL9Es)_