### PR TITLE
Stop the evening rain tip repeating "bring an umbrella"

### DIFF
--- a/app/src/main/kotlin/app/clothescast/insight/InsightFormatter.kt
+++ b/app/src/main/kotlin/app/clothescast/insight/InsightFormatter.kt
@@ -269,13 +269,28 @@ class InsightFormatter(
                 add(formatPrecip(it, summary.carriedAccessories.firstOrNull()))
             }
         }
+        // The carried accessory the main precip clause already named ("Drizzle,
+        // bring an umbrella.") — gated exactly as formatPrecip gates it, so we
+        // only treat it as "mentioned" when it actually rendered. The evening
+        // tie-in re-injects the umbrella from its own fired rule; without this
+        // it double-names it ("…, bring an umbrella. Tonight, drizzle, bring an
+        // umbrella."). Suppressing the second mention drops the tie-in back to
+        // the bare-rain wording so the evening rain still surfaces.
+        val precipAccessoryKeys = buildSet {
+            summary.precip
+                ?.takeIf { it.condition.warrantsRainAccessory() }
+                ?.let { summary.carriedAccessories.firstOrNull() }
+                ?.let { add(normalizeItemKey(it)) }
+        }
         val tieInClauses = buildList {
             summary.calendarTieIn?.let { tieIn ->
                 if (isAccessory(tieIn.item)) return@let
                 if (normalizeItemKey(tieIn.item) in mentionedKeys) return@let
                 formatTieIn(summary.period, tieIn.item)?.let(::add)
             }
-            summary.eveningEventTieIn?.let(::formatEveningEventTieIn)?.let(::add)
+            summary.eveningEventTieIn
+                ?.let { formatEveningEventTieIn(it, precipAccessoryKeys) }
+                ?.let(::add)
         }
         // Whether a leading temperature sentence exists to carry the period
         // lead. The band callout is one (it renders "Today, it will be hot."),
@@ -718,7 +733,10 @@ class InsightFormatter(
         return resources.getString(template, renderedItem)
     }
 
-    private fun formatEveningEventTieIn(tieIn: EveningEventTieInClause): String? {
+    private fun formatEveningEventTieIn(
+        tieIn: EveningEventTieInClause,
+        alreadyMentionedAccessories: Set<String> = emptySet(),
+    ): String? {
         val rainTime = tieIn.rainTime
         // Accessories (umbrella) are silenced from the incoming items list for
         // the same reason they're silenced in the main wear-list: until the
@@ -734,9 +752,15 @@ class InsightFormatter(
         // doesn't slip out when the underlying peak is actually snow.
         val filteredItems = tieIn.items.filterNot(::isAccessory)
         // The carried accessory rides in on the tie-in's own items (the fired
-        // umbrella rule).
+        // umbrella rule), unless the daytime precip clause already named it —
+        // re-naming the same umbrella the morning sentence carried adds nothing
+        // ("…, bring an umbrella. Tonight, drizzle, bring an umbrella."). When
+        // it's already mentioned the injection drops and the clause falls back
+        // to the bare-rain wording ("Tonight, chance of drizzle.") so the
+        // evening rain still surfaces without the redundant carry.
         val accessoryKey = tieIn.items.firstOrNull(::isAccessory)
             ?.takeIf { rainTime != null && tieIn.precipCondition?.warrantsRainAccessory() == true }
+            ?.takeIf { normalizeItemKey(it) !in alreadyMentionedAccessories }
         val items = if (accessoryKey != null) filteredItems + accessoryKey else filteredItems
         val renderedItems = if (items.isEmpty()) "" else phraser.joinItems(items)
         // The condition noun the evening clause names — the same conditionRes()

--- a/app/src/test/kotlin/app/clothescast/insight/InsightFormatterTest.kt
+++ b/app/src/test/kotlin/app/clothescast/insight/InsightFormatterTest.kt
@@ -1467,6 +1467,78 @@ class InsightFormatterTest {
     }
 
     @Test
+    fun `evening tie-in drops the umbrella the main precip clause already named`() {
+        // Bug: the morning precip clause ("Drizzle, bring an umbrella.") and the
+        // evening tie-in both carry the same fired umbrella rule, so the prose
+        // said "bring an umbrella" twice. The tie-in now suppresses the repeat
+        // and falls back to the bare-rain wording — the evening rain still
+        // surfaces, just without re-naming the carry.
+        umbrellaSubject.format(
+            summary(
+                carriedAccessories = listOf("umbrella"),
+                precip = PrecipClause(WeatherCondition.DRIZZLE, LocalTime.of(15, 0)),
+                eveningEventTieIn = EveningEventTieInClause(
+                    items = listOf("umbrella"),
+                    rainTime = LocalTime.of(21, 0),
+                    likelihood = PrecipLikelihood.POSSIBLE,
+                    precipCondition = WeatherCondition.DRIZZLE,
+                ),
+            ),
+        ) shouldBe "Today, it will be 21°. Drizzle, bring an umbrella. Tonight, chance of drizzle."
+    }
+
+    @Test
+    fun `evening tie-in keeps a clothing item but drops the already-named umbrella`() {
+        // Only the redundant carry is suppressed — a genuine evening clothes
+        // delta (jacket) still rides the item-led template.
+        umbrellaSubject.format(
+            summary(
+                carriedAccessories = listOf("umbrella"),
+                precip = PrecipClause(WeatherCondition.RAIN, LocalTime.of(15, 0)),
+                eveningEventTieIn = EveningEventTieInClause(
+                    items = listOf("jacket", "umbrella"),
+                    rainTime = LocalTime.of(21, 0),
+                    precipCondition = WeatherCondition.RAIN,
+                ),
+            ),
+        ) shouldBe "Today, it will be 21°. Rain, bring an umbrella. Tonight, rain, bring a jacket."
+    }
+
+    @Test
+    fun `evening tie-in still names the umbrella when the main precip clause did not`() {
+        // No daytime precip clause means the umbrella was never named, so the
+        // evening tie-in keeps its carry — the per-model evening warning is the
+        // only place the umbrella surfaces.
+        umbrellaSubject.format(
+            summary(
+                eveningEventTieIn = EveningEventTieInClause(
+                    items = listOf("umbrella"),
+                    rainTime = LocalTime.of(21, 0),
+                    precipCondition = WeatherCondition.RAIN,
+                ),
+            ),
+        ) shouldBe "Today, it will be 21°. Tonight, rain, bring an umbrella."
+    }
+
+    @Test
+    fun `evening tie-in keeps the umbrella when the daytime peak was snow`() {
+        // The umbrella isn't "already mentioned" when the daytime precip is snow
+        // — formatPrecip gates the carry on warrantsRainAccessory, so a snowy
+        // day never named it. An evening rain warning re-introduces it.
+        umbrellaSubject.format(
+            summary(
+                carriedAccessories = listOf("umbrella"),
+                precip = PrecipClause(WeatherCondition.SNOW, LocalTime.of(15, 0)),
+                eveningEventTieIn = EveningEventTieInClause(
+                    items = listOf("umbrella"),
+                    rainTime = LocalTime.of(21, 0),
+                    precipCondition = WeatherCondition.RAIN,
+                ),
+            ),
+        ) shouldBe "Today, it will be 21°. Snow. Tonight, rain, bring an umbrella."
+    }
+
+    @Test
     fun `de — umbrella accessory renders Regenschirm via the German phraser`() {
         val germanUmbrellaSubject = InsightFormatter.forContext(
             context,


### PR DESCRIPTION
## Problem

From a bug report, the morning insight read:

> Wear a jumper, jacket, rain jacket, and jeans. **Drizzle, bring an umbrella.** Tonight, chance of drizzle, **bring an umbrella.**

The umbrella is named twice. The morning precip clause already folds in the fired umbrella rule (`Drizzle, bring an umbrella.`), and the evening tie-in does the same from its own copy of that rule — so the user is told to bring the umbrella they were just told to bring.

## Fix

Formatter-side. `renderInsight` now computes the carried accessory the morning precip clause actually named — gated exactly as `formatPrecip` gates it (`warrantsRainAccessory`, non-null carried accessory) — and passes it to `formatEveningEventTieIn`. When the evening umbrella is already named, the tie-in drops the re-injection and falls back to the bare-rain wording:

> Drizzle, bring an umbrella. **Tonight, chance of drizzle.**

The evening rain still surfaces — only the redundant carry is removed.

The umbrella is **kept** in the tie-in when the morning clause didn't name it:
- no daytime precip clause (per-model evening warning is the only place it appears), or
- a daytime peak that doesn't warrant an umbrella (e.g. snow) — `formatPrecip` never named it, so the evening rain re-introduces it.

A genuine evening clothes delta (e.g. an added jacket) is untouched — only the already-named accessory is suppressed: `Rain, bring an umbrella. Tonight, rain, bring a jacket.`

The domain still sources the evening umbrella directly (so it survives day-dedup); whether the morning clause rendered it is a rendering concern, which is why the dedup lives in the formatter.

## Privacy

No change to what crosses the device boundary — pure prose-composition tweak.

## Test plan

Added four `InsightFormatterTest` cases:
- evening tie-in drops the umbrella the main precip clause already named (the exact bug scenario, POSSIBLE/drizzle) → `Tonight, chance of drizzle.`
- keeps a clothing item but drops the already-named umbrella
- still names the umbrella when the main precip clause didn't
- keeps the umbrella when the daytime peak was snow (umbrella never named there)

`./gradlew :app:testDebugUnitTest --tests "app.clothescast.insight.InsightFormatterTest"` passes.

https://claude.ai/code/session_01GpXsV8DCqupn3X4oZjnU7C

---
_Generated by [Claude Code](https://claude.ai/code/session_01GpXsV8DCqupn3X4oZjnU7C)_