### PR TITLE
Fix holiday banner showing a code, and make banner wording more inclusive

### DIFF
--- a/app/src/main/res/raw/keep.xml
+++ b/app/src/main/res/raw/keep.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Holiday banner / display-name strings and per-country labels are resolved
+  at runtime by name via Resources.getIdentifier — the theme catalogue lives
+  in :core:domain (pure Kotlin) and can't hold compile-time R ids, so the
+  string keys ("holiday_banner_uk_kings_birthday", "holiday_name_…",
+  "settings_holiday_country_gb") are data, never @string/… references the
+  resource shrinker can see. In minified builds (isShrinkResources = true on
+  both debug and release) the shrinker therefore counts them as unused and
+  strips them; getIdentifier then returns 0 and the banner falls back to the
+  raw HolidayId enum name (e.g. "UK_KINGS_BIRTHDAY" instead of "God save the
+  King"). Keep the three dynamically-referenced families so the lookup
+  resolves. See TodayScreen.resolveBannerString, HolidayGreeting, and
+  HolidaySettings.resolveHolidayString.
+-->
+<resources xmlns:tools="http://schemas.android.com/tools"
+    tools:keep="@string/holiday_name_*,@string/holiday_banner_*,@string/settings_holiday_country_*" />

--- a/app/src/main/res/values-am/strings.xml
+++ b/app/src/main/res/values-am/strings.xml
@@ -680,7 +680,7 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="holiday_banner_st_georges_day">የቅዱስ ጊዮርጊስ ቀን</string>
     <string name="holiday_banner_st_patricks_day">የቅዱስ ፓትሪክ ቀን</string>
     <string name="holiday_banner_uk_bank_holiday">ብሔራዊ ዕረፍት</string>
-    <string name="holiday_banner_uk_kings_birthday">ሞናርኩ ይጠብቅ</string>
+    <string name="holiday_banner_uk_kings_birthday">የንጉሡ ልደት መልካም ይሁን</string>
     <string name="holiday_banner_uk_mothering_sunday">የእናቶች እሁድ</string>
     <string name="holiday_banner_us_independence_day">ሐምሌ 4 ደስ ይሁንዎ</string>
     <string name="holiday_banner_us_memorial_day">ለወደቁ ወታደሮቻችን</string>
@@ -959,7 +959,7 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="holiday_banner_argentina_independence_day">የአርጀንቲና የነፃነት ቀን መልካም ይሁን</string>
     <string name="holiday_banner_argentina_may_revolution">የግንቦት አብዮት ቀን መልካም ይሁን</string>
     <string name="holiday_banner_ascension_day">የእርገት በዓል መልካም ይሁን</string>
-    <string name="holiday_banner_ash_wednesday">አፈር መሆንህን አስታውስ</string>
+    <string name="holiday_banner_ash_wednesday">የአመድ ረቡዕ</string>
     <string name="holiday_banner_bangladesh_independence_day">የነፃነት ቀን መልካም ይሁን</string>
     <string name="holiday_banner_bangladesh_victory_day">የድል ቀን መልካም ይሁን</string>
     <string name="holiday_banner_brazil_black_awareness">የጥቁር ግንዛቤ ቀን</string>
@@ -982,7 +982,7 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="holiday_banner_malaysia_day">የማሌዢያ ቀን መልካም ይሁን</string>
     <string name="holiday_banner_malaysia_independence_day">የመርዴካ ቀን መልካም ይሁን</string>
     <string name="holiday_banner_mardi_gras">ማርዲ ግራ መልካም ይሁን</string>
-    <string name="holiday_banner_maundy_thursday">አዲስ ትዕዛዝ</string>
+    <string name="holiday_banner_maundy_thursday">ጸሎተ ሐሙስ</string>
     <string name="holiday_banner_melbourne_cup_day">ሀገርን የሚያቆም ውድድር</string>
     <string name="holiday_banner_mexico_benito_juarez_birthday">ቤኒቶ ሁዋሬዝን በማስታወስ</string>
     <string name="holiday_banner_mexico_constitution_day">የሕገ መንግሥት ቀን መልካም ይሁን</string>
@@ -994,7 +994,7 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="holiday_banner_orthodox_christmas">የኦርቶዶክስ ገና መልካም ይሁን</string>
     <string name="holiday_banner_pakistan_day">የፓኪስታን ቀን መልካም ይሁን</string>
     <string name="holiday_banner_pakistan_independence_day">የነፃነት ቀን መልካም ይሁን</string>
-    <string name="holiday_banner_palm_sunday">ሆሳዕና በላይኛው</string>
+    <string name="holiday_banner_palm_sunday">የቅርንጫፍ እሁድ</string>
     <string name="holiday_banner_pentecost">የጴንጤቆስጤ መልካም ይሁን</string>
     <string name="holiday_banner_philippines_bonifacio_day">የቦኒፋሲዮ ቀን መልካም ይሁን</string>
     <string name="holiday_banner_philippines_independence_day">የፊሊፒንስ የነፃነት ቀን መልካም ይሁን</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -705,7 +705,7 @@ they work correctly in both the single-band and range templates.
     <string name="holiday_banner_st_georges_day">يوم القديس جورج المبارك</string>
     <string name="holiday_banner_st_patricks_day">يوم القديس باتريك المبارك</string>
     <string name="holiday_banner_uk_bank_holiday">إجازة بنكية مباركة</string>
-    <string name="holiday_banner_uk_kings_birthday">الله يحفظ الملك</string>
+    <string name="holiday_banner_uk_kings_birthday">عيد ميلاد سعيد للملك</string>
     <string name="holiday_banner_uk_mothering_sunday">يوم الأمومة المبارك</string>
     <string name="holiday_banner_us_independence_day">عيد الرابع من يوليو المبارك</string>
     <string name="holiday_banner_us_memorial_day">تكريماً لشهدائنا</string>
@@ -987,7 +987,7 @@ they work correctly in both the single-band and range templates.
     <string name="holiday_banner_argentina_independence_day">عيد استقلال الأرجنتين سعيد</string>
     <string name="holiday_banner_argentina_may_revolution">ذكرى ثورة مايو سعيدة</string>
     <string name="holiday_banner_ascension_day">عيد الصعود سعيد</string>
-    <string name="holiday_banner_ash_wednesday">تذكر أنك تراب</string>
+    <string name="holiday_banner_ash_wednesday">أربعاء الرماد</string>
     <string name="holiday_banner_bangladesh_independence_day">عيد استقلال سعيد</string>
     <string name="holiday_banner_bangladesh_victory_day">عيد النصر سعيد</string>
     <string name="holiday_banner_brazil_black_awareness">يوم الوعي الأسود</string>
@@ -1010,7 +1010,7 @@ they work correctly in both the single-band and range templates.
     <string name="holiday_banner_malaysia_day">عيد ماليزيا سعيد</string>
     <string name="holiday_banner_malaysia_independence_day">عيد مرديكا سعيد</string>
     <string name="holiday_banner_mardi_gras">ثلاثاء المرفع سعيد</string>
-    <string name="holiday_banner_maundy_thursday">وصية جديدة</string>
+    <string name="holiday_banner_maundy_thursday">خميس العهد</string>
     <string name="holiday_banner_melbourne_cup_day">السباق الذي يوقف الأمة</string>
     <string name="holiday_banner_mexico_benito_juarez_birthday">تكريمًا لبينيتو خواريز</string>
     <string name="holiday_banner_mexico_constitution_day">عيد الدستور سعيد</string>
@@ -1022,7 +1022,7 @@ they work correctly in both the single-band and range templates.
     <string name="holiday_banner_orthodox_christmas">ميلاد مجيد للأرثوذكس</string>
     <string name="holiday_banner_pakistan_day">عيد باكستان سعيد</string>
     <string name="holiday_banner_pakistan_independence_day">عيد استقلال سعيد</string>
-    <string name="holiday_banner_palm_sunday">هوشعنا في الأعالي</string>
+    <string name="holiday_banner_palm_sunday">أحد الشعانين</string>
     <string name="holiday_banner_pentecost">عيد العنصرة سعيد</string>
     <string name="holiday_banner_philippines_bonifacio_day">عيد بونيفاسيو سعيد</string>
     <string name="holiday_banner_philippines_independence_day">عيد استقلال الفلبين سعيد</string>

--- a/app/src/main/res/values-b+sr+Cyrl/strings.xml
+++ b/app/src/main/res/values-b+sr+Cyrl/strings.xml
@@ -968,7 +968,7 @@ surfaces.
     <string name="holiday_banner_argentina_independence_day">Срећан Дан независности Аргентине</string>
     <string name="holiday_banner_argentina_may_revolution">Срећан Дан Мајске револуције</string>
     <string name="holiday_banner_ascension_day">Срећно Вазнесење</string>
-    <string name="holiday_banner_ash_wednesday">Сети се да си прах</string>
+    <string name="holiday_banner_ash_wednesday">Чиста среда</string>
     <string name="holiday_banner_bangladesh_independence_day">Срећан Дан независности</string>
     <string name="holiday_banner_bangladesh_victory_day">Срећан Дан победе</string>
     <string name="holiday_banner_brazil_black_awareness">Дан црне свести</string>
@@ -991,7 +991,7 @@ surfaces.
     <string name="holiday_banner_malaysia_day">Срећан Дан Малезије</string>
     <string name="holiday_banner_malaysia_independence_day">Срећан Дан Мердеке</string>
     <string name="holiday_banner_mardi_gras">Срећне Покладе</string>
-    <string name="holiday_banner_maundy_thursday">Нова заповест</string>
+    <string name="holiday_banner_maundy_thursday">Велики четвртак</string>
     <string name="holiday_banner_melbourne_cup_day">Трка која зауставља нацију</string>
     <string name="holiday_banner_mexico_benito_juarez_birthday">У част Бенита Хуареса</string>
     <string name="holiday_banner_mexico_constitution_day">Срећан Дан Устава</string>
@@ -1003,7 +1003,7 @@ surfaces.
     <string name="holiday_banner_orthodox_christmas">Срећан православни Божић</string>
     <string name="holiday_banner_pakistan_day">Срећан Дан Пакистана</string>
     <string name="holiday_banner_pakistan_independence_day">Срећан Дан независности</string>
-    <string name="holiday_banner_palm_sunday">Осана на висини</string>
+    <string name="holiday_banner_palm_sunday">Цвети</string>
     <string name="holiday_banner_pentecost">Срећна Педесетница</string>
     <string name="holiday_banner_philippines_bonifacio_day">Срећан Дан Бонифасија</string>
     <string name="holiday_banner_philippines_independence_day">Срећан Дан независности Филипина</string>

--- a/app/src/main/res/values-b+sr+Latn/strings.xml
+++ b/app/src/main/res/values-b+sr+Latn/strings.xml
@@ -980,7 +980,7 @@ default English (matching values-pl / values-uk).
     <string name="holiday_banner_argentina_independence_day">Srećan Dan nezavisnosti Argentine</string>
     <string name="holiday_banner_argentina_may_revolution">Srećan Dan Majske revolucije</string>
     <string name="holiday_banner_ascension_day">Srećno Vaznesenje</string>
-    <string name="holiday_banner_ash_wednesday">Seti se da si prah</string>
+    <string name="holiday_banner_ash_wednesday">Čista sreda</string>
     <string name="holiday_banner_bangladesh_independence_day">Srećan Dan nezavisnosti</string>
     <string name="holiday_banner_bangladesh_victory_day">Srećan Dan pobede</string>
     <string name="holiday_banner_brazil_black_awareness">Dan crne svesti</string>
@@ -1003,7 +1003,7 @@ default English (matching values-pl / values-uk).
     <string name="holiday_banner_malaysia_day">Srećan Dan Malezije</string>
     <string name="holiday_banner_malaysia_independence_day">Srećan Dan Merdeke</string>
     <string name="holiday_banner_mardi_gras">Srećne Poklade</string>
-    <string name="holiday_banner_maundy_thursday">Nova zapovest</string>
+    <string name="holiday_banner_maundy_thursday">Veliki četvrtak</string>
     <string name="holiday_banner_melbourne_cup_day">Trka koja zaustavlja naciju</string>
     <string name="holiday_banner_mexico_benito_juarez_birthday">U čast Benita Huaresa</string>
     <string name="holiday_banner_mexico_constitution_day">Srećan Dan Ustava</string>
@@ -1015,7 +1015,7 @@ default English (matching values-pl / values-uk).
     <string name="holiday_banner_orthodox_christmas">Srećan pravoslavni Božić</string>
     <string name="holiday_banner_pakistan_day">Srećan Dan Pakistana</string>
     <string name="holiday_banner_pakistan_independence_day">Srećan Dan nezavisnosti</string>
-    <string name="holiday_banner_palm_sunday">Osana na visini</string>
+    <string name="holiday_banner_palm_sunday">Cveti</string>
     <string name="holiday_banner_pentecost">Srećna Pedesetnica</string>
     <string name="holiday_banner_philippines_bonifacio_day">Srećan Dan Bonifasija</string>
     <string name="holiday_banner_philippines_independence_day">Srećan Dan nezavisnosti Filipina</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -978,7 +978,7 @@ What is NOT overridden, by design:
     <string name="holiday_banner_argentina_independence_day">Честит Ден на независимостта на Аржентина</string>
     <string name="holiday_banner_argentina_may_revolution">Честит Ден на Майската революция</string>
     <string name="holiday_banner_ascension_day">Честито Възнесение</string>
-    <string name="holiday_banner_ash_wednesday">Помни, че си прах</string>
+    <string name="holiday_banner_ash_wednesday">Пепелна сряда</string>
     <string name="holiday_banner_bangladesh_independence_day">Честит Ден на независимостта</string>
     <string name="holiday_banner_bangladesh_victory_day">Честит Ден на победата</string>
     <string name="holiday_banner_brazil_black_awareness">Ден на черното самосъзнание</string>
@@ -1001,7 +1001,7 @@ What is NOT overridden, by design:
     <string name="holiday_banner_malaysia_day">Честит Ден на Малайзия</string>
     <string name="holiday_banner_malaysia_independence_day">Честит Ден на Мердека</string>
     <string name="holiday_banner_mardi_gras">Весели Заговезни</string>
-    <string name="holiday_banner_maundy_thursday">Нова заповед</string>
+    <string name="holiday_banner_maundy_thursday">Велики четвъртък</string>
     <string name="holiday_banner_melbourne_cup_day">Състезанието, което спира нацията</string>
     <string name="holiday_banner_mexico_benito_juarez_birthday">В чест на Бенито Хуарес</string>
     <string name="holiday_banner_mexico_constitution_day">Честит Ден на Конституцията</string>
@@ -1013,7 +1013,7 @@ What is NOT overridden, by design:
     <string name="holiday_banner_orthodox_christmas">Весели православни Коледни празници</string>
     <string name="holiday_banner_pakistan_day">Честит Ден на Пакистан</string>
     <string name="holiday_banner_pakistan_independence_day">Честит Ден на независимостта</string>
-    <string name="holiday_banner_palm_sunday">Осанна във висините</string>
+    <string name="holiday_banner_palm_sunday">Цветница</string>
     <string name="holiday_banner_pentecost">Весела Петдесетница</string>
     <string name="holiday_banner_philippines_bonifacio_day">Честит Ден на Бонифасио</string>
     <string name="holiday_banner_philippines_independence_day">Честит Ден на независимостта на Филипините</string>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -865,7 +865,7 @@ West Bengal vocabulary differences in a future PR.
     <string name="holiday_banner_st_georges_day">সেন্ট জর্জ দিবসের শুভেচ্ছা</string>
     <string name="holiday_banner_st_patricks_day">সেন্ট প্যাট্রিক দিবসের শুভেচ্ছা</string>
     <string name="holiday_banner_uk_bank_holiday">শুভ ব্যাংক হলিডে</string>
-    <string name="holiday_banner_uk_kings_birthday">ঈশ্বর রাজাকে রক্ষা করুন</string>
+    <string name="holiday_banner_uk_kings_birthday">রাজার জন্মদিন শুভ হোক</string>
     <string name="holiday_banner_uk_mothering_sunday">শুভ মাদারিং সানডে</string>
     <string name="holiday_banner_us_independence_day">শুভ ৪ জুলাই</string>
     <string name="holiday_banner_us_memorial_day">আমাদের শহীদদের প্রতি শ্রদ্ধা</string>
@@ -1063,7 +1063,7 @@ West Bengal vocabulary differences in a future PR.
     <string name="holiday_banner_argentina_independence_day">আর্জেন্টিনার স্বাধীনতা দিবসের শুভেচ্ছা</string>
     <string name="holiday_banner_argentina_may_revolution">মে বিপ্লব দিবসের শুভেচ্ছা</string>
     <string name="holiday_banner_ascension_day">যিশুর স্বর্গারোহণ দিবসের শুভেচ্ছা</string>
-    <string name="holiday_banner_ash_wednesday">মনে রেখো তুমি ধূলিকণা</string>
+    <string name="holiday_banner_ash_wednesday">অ্যাশ বুধবার</string>
     <string name="holiday_banner_bangladesh_independence_day">স্বাধীনতা দিবসের শুভেচ্ছা</string>
     <string name="holiday_banner_bangladesh_victory_day">বিজয় দিবসের শুভেচ্ছা</string>
     <string name="holiday_banner_brazil_black_awareness">কৃষ্ণাঙ্গ সচেতনতা দিবস</string>
@@ -1086,7 +1086,7 @@ West Bengal vocabulary differences in a future PR.
     <string name="holiday_banner_malaysia_day">মালয়েশিয়া দিবসের শুভেচ্ছা</string>
     <string name="holiday_banner_malaysia_independence_day">মারডেকা দিবসের শুভেচ্ছা</string>
     <string name="holiday_banner_mardi_gras">শুভ মার্ডি গ্রা</string>
-    <string name="holiday_banner_maundy_thursday">একটি নতুন আদেশ</string>
+    <string name="holiday_banner_maundy_thursday">মন্দি বৃহস্পতিবার</string>
     <string name="holiday_banner_melbourne_cup_day">যে দৌড় একটি জাতিকে থামিয়ে দেয়</string>
     <string name="holiday_banner_mexico_benito_juarez_birthday">বেনিতো হুয়ারেজের সম্মানে</string>
     <string name="holiday_banner_mexico_constitution_day">সংবিধান দিবসের শুভেচ্ছা</string>
@@ -1098,7 +1098,7 @@ West Bengal vocabulary differences in a future PR.
     <string name="holiday_banner_orthodox_christmas">অর্থোডক্স বড়দিনের শুভেচ্ছা</string>
     <string name="holiday_banner_pakistan_day">পাকিস্তান দিবসের শুভেচ্ছা</string>
     <string name="holiday_banner_pakistan_independence_day">স্বাধীনতা দিবসের শুভেচ্ছা</string>
-    <string name="holiday_banner_palm_sunday">ঊর্ধ্বে হোসান্না</string>
+    <string name="holiday_banner_palm_sunday">পাম রবিবার</string>
     <string name="holiday_banner_pentecost">পঞ্চাশত্তমীর শুভেচ্ছা</string>
     <string name="holiday_banner_philippines_bonifacio_day">বনিফাসিও দিবসের শুভেচ্ছা</string>
     <string name="holiday_banner_philippines_independence_day">ফিলিপাইন স্বাধীনতা দিবসের শুভেচ্ছা</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -806,7 +806,7 @@ the in-app clock is digit-driven and reads consistently across locales.
     <string name="holiday_banner_st_georges_day">Feliç Dia de Sant Jordi</string>
     <string name="holiday_banner_anzac_day">Per no oblidar</string>
     <string name="holiday_banner_uk_bank_holiday">Feliç festiu bancari</string>
-    <string name="holiday_banner_uk_kings_birthday">Déu salvi el Rei</string>
+    <string name="holiday_banner_uk_kings_birthday">Bon aniversari del Rei</string>
     <string name="holiday_banner_japan_greenery_day">Feliç Dia japonès de la Verdor</string>
     <string name="holiday_banner_croatia_statehood_day">Feliç Dia de l\'Estat Croat</string>
     <string name="holiday_banner_us_memorial_day">Honorant els caiguts</string>
@@ -931,7 +931,7 @@ the in-app clock is digit-driven and reads consistently across locales.
     <string name="holiday_banner_argentina_independence_day">Bon Dia de la Independència d\'Argentina</string>
     <string name="holiday_banner_argentina_may_revolution">Bona Revolució de Maig</string>
     <string name="holiday_banner_ascension_day">Bona Ascensió</string>
-    <string name="holiday_banner_ash_wednesday">Recorda que ets pols</string>
+    <string name="holiday_banner_ash_wednesday">Dimecres de Cendra</string>
     <string name="holiday_banner_bangladesh_independence_day">Bon Dia de la Independència</string>
     <string name="holiday_banner_bangladesh_victory_day">Bon Dia de la Victòria</string>
     <string name="holiday_banner_brazil_black_awareness">Dia de la Consciència Negra</string>
@@ -954,7 +954,7 @@ the in-app clock is digit-driven and reads consistently across locales.
     <string name="holiday_banner_malaysia_day">Bon Dia de Malàisia</string>
     <string name="holiday_banner_malaysia_independence_day">Bon Dia de la Merdeka</string>
     <string name="holiday_banner_mardi_gras">Bon Carnestoltes</string>
-    <string name="holiday_banner_maundy_thursday">Un manament nou</string>
+    <string name="holiday_banner_maundy_thursday">Dijous Sant</string>
     <string name="holiday_banner_melbourne_cup_day">La cursa que atura una nació</string>
     <string name="holiday_banner_mexico_benito_juarez_birthday">Honorant Benito Juárez</string>
     <string name="holiday_banner_mexico_constitution_day">Bon Dia de la Constitució</string>
@@ -966,7 +966,7 @@ the in-app clock is digit-driven and reads consistently across locales.
     <string name="holiday_banner_orthodox_christmas">Bon Nadal ortodox</string>
     <string name="holiday_banner_pakistan_day">Bon Dia del Pakistan</string>
     <string name="holiday_banner_pakistan_independence_day">Bon Dia de la Independència</string>
-    <string name="holiday_banner_palm_sunday">Hosanna a les altures</string>
+    <string name="holiday_banner_palm_sunday">Diumenge de Rams</string>
     <string name="holiday_banner_pentecost">Bona Pentecosta</string>
     <string name="holiday_banner_philippines_bonifacio_day">Bon Dia de Bonifacio</string>
     <string name="holiday_banner_philippines_independence_day">Bon Dia de la Independència de les Filipines</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -875,7 +875,7 @@ locale (Angličtina (USA), Francouzština (Francie), Němčina (Německo), …).
     <string name="holiday_banner_st_georges_day">Šťastný Den svatého Jiří</string>
     <string name="holiday_banner_anzac_day">Uctíváme padlé</string>
     <string name="holiday_banner_uk_bank_holiday">Šťastný státní svátek</string>
-    <string name="holiday_banner_uk_kings_birthday">Bůh ochraňuj krále</string>
+    <string name="holiday_banner_uk_kings_birthday">Vše nejlepší k narozeninám krále</string>
     <string name="holiday_banner_japan_greenery_day">Šťastný japonský Den zeleně</string>
     <string name="holiday_banner_croatia_statehood_day">Šťastný Den chorvatské státnosti</string>
     <string name="holiday_banner_us_memorial_day">Uctíváme padlé</string>
@@ -999,7 +999,7 @@ locale (Angličtina (USA), Francouzština (Francie), Němčina (Německo), …).
     <string name="holiday_banner_argentina_independence_day">Šťastný den nezávislosti Argentiny</string>
     <string name="holiday_banner_argentina_may_revolution">Šťastné výročí Květnové revoluce</string>
     <string name="holiday_banner_ascension_day">Šťastné Nanebevstoupení</string>
-    <string name="holiday_banner_ash_wednesday">Pamatuj, že jsi prach</string>
+    <string name="holiday_banner_ash_wednesday">Popeleční středa</string>
     <string name="holiday_banner_bangladesh_independence_day">Šťastný den nezávislosti</string>
     <string name="holiday_banner_bangladesh_victory_day">Šťastný Den vítězství</string>
     <string name="holiday_banner_brazil_black_awareness">Den černého povědomí</string>
@@ -1022,7 +1022,7 @@ locale (Angličtina (USA), Francouzština (Francie), Němčina (Německo), …).
     <string name="holiday_banner_malaysia_day">Šťastný den Malajsie</string>
     <string name="holiday_banner_malaysia_independence_day">Šťastný den Merdeka</string>
     <string name="holiday_banner_mardi_gras">Veselé Masopustní úterý</string>
-    <string name="holiday_banner_maundy_thursday">Nové přikázání</string>
+    <string name="holiday_banner_maundy_thursday">Zelený čtvrtek</string>
     <string name="holiday_banner_melbourne_cup_day">Závod, který zastaví národ</string>
     <string name="holiday_banner_mexico_benito_juarez_birthday">Na počest Benita Juáreze</string>
     <string name="holiday_banner_mexico_constitution_day">Šťastný Den ústavy</string>
@@ -1034,7 +1034,7 @@ locale (Angličtina (USA), Francouzština (Francie), Němčina (Německo), …).
     <string name="holiday_banner_orthodox_christmas">Veselé pravoslavné Vánoce</string>
     <string name="holiday_banner_pakistan_day">Šťastný den Pákistánu</string>
     <string name="holiday_banner_pakistan_independence_day">Šťastný den nezávislosti</string>
-    <string name="holiday_banner_palm_sunday">Hosana na výsostech</string>
+    <string name="holiday_banner_palm_sunday">Květná neděle</string>
     <string name="holiday_banner_pentecost">Veselé Letnice</string>
     <string name="holiday_banner_philippines_bonifacio_day">Šťastný Bonifaciův den</string>
     <string name="holiday_banner_philippines_independence_day">Šťastný den nezávislosti Filipín</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -917,7 +917,7 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrig)").
     <string name="holiday_banner_st_davids_day">Glædelig Sankt Davids dag</string>
     <string name="holiday_banner_st_georges_day">Glædelig Sankt Georgs dag</string>
     <string name="holiday_banner_uk_bank_holiday">Glædelig helligdag</string>
-    <string name="holiday_banner_uk_kings_birthday">God save the King</string>
+    <string name="holiday_banner_uk_kings_birthday">Tillykke med kongens fødselsdag</string>
     <string name="holiday_banner_uk_mothering_sunday">Glædelig Moders Søndag</string>
     <string name="holiday_banner_us_independence_day">Glædelig 4. juli</string>
     <string name="holiday_banner_us_memorial_day">Vi ærer vores faldne</string>
@@ -1021,7 +1021,7 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrig)").
     <string name="holiday_banner_argentina_independence_day">Glædelig argentinsk uafhængighedsdag</string>
     <string name="holiday_banner_argentina_may_revolution">Glædelig majrevolution</string>
     <string name="holiday_banner_ascension_day">Glædelig Kristi himmelfartsdag</string>
-    <string name="holiday_banner_ash_wednesday">Husk, at du er støv</string>
+    <string name="holiday_banner_ash_wednesday">Askeonsdag</string>
     <string name="holiday_banner_bangladesh_independence_day">Glædelig uafhængighedsdag</string>
     <string name="holiday_banner_bangladesh_victory_day">Glædelig sejrsdag</string>
     <string name="holiday_banner_brazil_black_awareness">Dag for sort bevidsthed</string>
@@ -1044,7 +1044,7 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrig)").
     <string name="holiday_banner_malaysia_day">Glædelig Malaysia-dag</string>
     <string name="holiday_banner_malaysia_independence_day">Glædelig Merdeka-dag</string>
     <string name="holiday_banner_mardi_gras">Glædelig fastelavn</string>
-    <string name="holiday_banner_maundy_thursday">Et nyt bud</string>
+    <string name="holiday_banner_maundy_thursday">Skærtorsdag</string>
     <string name="holiday_banner_melbourne_cup_day">Løbet der stopper en nation</string>
     <string name="holiday_banner_mexico_benito_juarez_birthday">Til ære for Benito Juárez</string>
     <string name="holiday_banner_mexico_constitution_day">Glædelig forfatningsdag</string>
@@ -1056,7 +1056,7 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrig)").
     <string name="holiday_banner_orthodox_christmas">Glædelig ortodoks jul</string>
     <string name="holiday_banner_pakistan_day">Glædelig Pakistan-dag</string>
     <string name="holiday_banner_pakistan_independence_day">Glædelig uafhængighedsdag</string>
-    <string name="holiday_banner_palm_sunday">Hosianna i det højeste</string>
+    <string name="holiday_banner_palm_sunday">Palmesøndag</string>
     <string name="holiday_banner_pentecost">Glædelig pinse</string>
     <string name="holiday_banner_philippines_bonifacio_day">Glædelig Bonifacio-dag</string>
     <string name="holiday_banner_philippines_independence_day">Glædelig filippinsk uafhængighedsdag</string>

--- a/app/src/main/res/values-de-rAT/strings.xml
+++ b/app/src/main/res/values-de-rAT/strings.xml
@@ -526,7 +526,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="holiday_banner_st_georges_day">Frohen St.-Georgs-Tag</string>
     <string name="holiday_banner_st_andrews_day">Frohen St.-Andreas-Tag</string>
     <string name="holiday_banner_uk_bank_holiday">Frohen Bankfeiertag</string>
-    <string name="holiday_banner_uk_kings_birthday">Gott schütze den König</string>
+    <string name="holiday_banner_uk_kings_birthday">Alles Gute zum Geburtstag des Königs</string>
     <string name="holiday_banner_uk_mothering_sunday">Frohen Muttersonntag</string>
     <string name="holiday_banner_bastille_day">Frohen Bastille-Tag</string>
     <string name="holiday_banner_fr_armistice_day">Wir gedenken der Gefallenen</string>

--- a/app/src/main/res/values-de-rCH/strings.xml
+++ b/app/src/main/res/values-de-rCH/strings.xml
@@ -531,7 +531,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="holiday_banner_st_georges_day">Frohen St.-Georgs-Tag</string>
     <string name="holiday_banner_st_andrews_day">Frohen St.-Andreas-Tag</string>
     <string name="holiday_banner_uk_bank_holiday">Frohen Bankfeiertag</string>
-    <string name="holiday_banner_uk_kings_birthday">Gott schütze den König</string>
+    <string name="holiday_banner_uk_kings_birthday">Alles Gute zum Geburtstag des Königs</string>
     <string name="holiday_banner_uk_mothering_sunday">Frohen Muttersonntag</string>
     <string name="holiday_banner_bastille_day">Frohen Bastille-Tag</string>
     <string name="holiday_banner_fr_armistice_day">Wir gedenken der Gefallenen</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -975,7 +975,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="holiday_banner_st_georges_day">Frohen St.-Georgs-Tag</string>
     <string name="holiday_banner_st_andrews_day">Frohen St.-Andreas-Tag</string>
     <string name="holiday_banner_uk_bank_holiday">Frohen Bankfeiertag</string>
-    <string name="holiday_banner_uk_kings_birthday">Gott schütze den König</string>
+    <string name="holiday_banner_uk_kings_birthday">Alles Gute zum Geburtstag des Königs</string>
     <string name="holiday_banner_uk_mothering_sunday">Frohen Muttersonntag</string>
     <string name="holiday_banner_bastille_day">Frohen Bastille-Tag</string>
     <string name="holiday_banner_fr_armistice_day">Wir gedenken der Gefallenen</string>
@@ -1150,7 +1150,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="holiday_banner_argentina_independence_day">Frohen argentinischen Unabhängigkeitstag</string>
     <string name="holiday_banner_argentina_may_revolution">Frohe Mairevolution</string>
     <string name="holiday_banner_ascension_day">Frohe Christi Himmelfahrt</string>
-    <string name="holiday_banner_ash_wednesday">Bedenke, dass du Staub bist</string>
+    <string name="holiday_banner_ash_wednesday">Aschermittwoch</string>
     <string name="holiday_banner_bangladesh_independence_day">Frohen Unabhängigkeitstag</string>
     <string name="holiday_banner_bangladesh_victory_day">Frohen Tag des Sieges</string>
     <string name="holiday_banner_brazil_black_awareness">Tag des schwarzen Bewusstseins</string>
@@ -1173,7 +1173,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="holiday_banner_malaysia_day">Frohen Tag Malaysias</string>
     <string name="holiday_banner_malaysia_independence_day">Frohen Merdeka-Tag</string>
     <string name="holiday_banner_mardi_gras">Lasst die guten Zeiten rollen</string>
-    <string name="holiday_banner_maundy_thursday">Ein neues Gebot</string>
+    <string name="holiday_banner_maundy_thursday">Gründonnerstag</string>
     <string name="holiday_banner_melbourne_cup_day">Das Rennen, das eine Nation stoppt</string>
     <string name="holiday_banner_mexico_benito_juarez_birthday">Zu Ehren von Benito Juárez</string>
     <string name="holiday_banner_mexico_constitution_day">Frohen Tag der Verfassung</string>
@@ -1185,7 +1185,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="holiday_banner_orthodox_christmas">Frohe orthodoxe Weihnachten</string>
     <string name="holiday_banner_pakistan_day">Frohen Tag Pakistans</string>
     <string name="holiday_banner_pakistan_independence_day">Frohen Unabhängigkeitstag</string>
-    <string name="holiday_banner_palm_sunday">Hosianna in der Höhe</string>
+    <string name="holiday_banner_palm_sunday">Palmsonntag</string>
     <string name="holiday_banner_pentecost">Frohe Pfingsten</string>
     <string name="holiday_banner_philippines_bonifacio_day">Frohen Bonifacio-Tag</string>
     <string name="holiday_banner_philippines_independence_day">Frohen Unabhängigkeitstag der Philippinen</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -1111,7 +1111,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="holiday_banner_argentina_independence_day">Καλή Ημέρα Ανεξαρτησίας Αργεντινής</string>
     <string name="holiday_banner_argentina_may_revolution">Καλή Ημέρα Επανάστασης του Μαΐου</string>
     <string name="holiday_banner_ascension_day">Καλή Ανάληψη</string>
-    <string name="holiday_banner_ash_wednesday">Θυμήσου ότι είσαι χώμα</string>
+    <string name="holiday_banner_ash_wednesday">Τετάρτη της Σποδού</string>
     <string name="holiday_banner_bangladesh_independence_day">Καλή Ημέρα Ανεξαρτησίας</string>
     <string name="holiday_banner_bangladesh_victory_day">Καλή Ημέρα Νίκης</string>
     <string name="holiday_banner_brazil_black_awareness">Ημέρα Μαύρης Συνείδησης</string>
@@ -1134,7 +1134,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="holiday_banner_malaysia_day">Καλή Ημέρα Μαλαισίας</string>
     <string name="holiday_banner_malaysia_independence_day">Καλή Ημέρα Μερντέκα</string>
     <string name="holiday_banner_mardi_gras">Καλή Αποκριά</string>
-    <string name="holiday_banner_maundy_thursday">Μία καινούργια εντολή</string>
+    <string name="holiday_banner_maundy_thursday">Μεγάλη Πέμπτη</string>
     <string name="holiday_banner_melbourne_cup_day">Ο αγώνας που σταματά ένα έθνος</string>
     <string name="holiday_banner_mexico_benito_juarez_birthday">Τιμώντας τον Μπενίτο Χουάρες</string>
     <string name="holiday_banner_mexico_constitution_day">Καλή Ημέρα Συντάγματος</string>
@@ -1146,7 +1146,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="holiday_banner_orthodox_christmas">Καλά Ορθόδοξα Χριστούγεννα</string>
     <string name="holiday_banner_pakistan_day">Καλή Ημέρα Πακιστάν</string>
     <string name="holiday_banner_pakistan_independence_day">Καλή Ημέρα Ανεξαρτησίας</string>
-    <string name="holiday_banner_palm_sunday">Ωσαννά εν τοις υψίστοις</string>
+    <string name="holiday_banner_palm_sunday">Κυριακή των Βαΐων</string>
     <string name="holiday_banner_pentecost">Καλή Πεντηκοστή</string>
     <string name="holiday_banner_philippines_bonifacio_day">Καλή Ημέρα Μπονιφάσιο</string>
     <string name="holiday_banner_philippines_independence_day">Καλή Ημέρα Ανεξαρτησίας Φιλιππίνων</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -940,7 +940,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="holiday_banner_st_georges_day">Feliz Día de San Jorge</string>
     <string name="holiday_banner_st_andrews_day">Feliz Día de San Andrés</string>
     <string name="holiday_banner_uk_bank_holiday">Feliz día festivo</string>
-    <string name="holiday_banner_uk_kings_birthday">Dios salve al rey</string>
+    <string name="holiday_banner_uk_kings_birthday">Feliz cumpleaños del Rey</string>
     <string name="holiday_banner_uk_mothering_sunday">Feliz Día de la Madre</string>
     <string name="holiday_banner_austria_national_day">Feliz Día Nacional de Austria</string>
     <string name="holiday_banner_german_unity_day">Feliz Día de la Unidad Alemana</string>
@@ -1119,7 +1119,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="holiday_banner_argentina_independence_day">¡Feliz Día de la Independencia!</string>
     <string name="holiday_banner_argentina_may_revolution">¡Feliz Día de la Revolución de Mayo!</string>
     <string name="holiday_banner_ascension_day">Feliz Ascensión</string>
-    <string name="holiday_banner_ash_wednesday">Recuerda que eres polvo</string>
+    <string name="holiday_banner_ash_wednesday">Miércoles de Ceniza</string>
     <string name="holiday_banner_bangladesh_independence_day">Feliz Día de la Independencia</string>
     <string name="holiday_banner_bangladesh_victory_day">Feliz Día de la Victoria</string>
     <string name="holiday_banner_brazil_black_awareness">Día de la Conciencia Negra</string>
@@ -1142,7 +1142,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="holiday_banner_malaysia_day">Feliz Día de Malasia</string>
     <string name="holiday_banner_malaysia_independence_day">Feliz Día de la Independencia (Merdeka)</string>
     <string name="holiday_banner_mardi_gras">Feliz Martes de Carnaval</string>
-    <string name="holiday_banner_maundy_thursday">Un mandamiento nuevo</string>
+    <string name="holiday_banner_maundy_thursday">Jueves Santo</string>
     <string name="holiday_banner_melbourne_cup_day">La carrera que detiene a una nación</string>
     <string name="holiday_banner_mexico_benito_juarez_birthday">Honrando a Benito Juárez</string>
     <string name="holiday_banner_mexico_constitution_day">Feliz Día de la Constitución</string>
@@ -1154,7 +1154,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="holiday_banner_orthodox_christmas">Feliz Navidad ortodoxa</string>
     <string name="holiday_banner_pakistan_day">Feliz Día de Pakistán</string>
     <string name="holiday_banner_pakistan_independence_day">Feliz Día de la Independencia</string>
-    <string name="holiday_banner_palm_sunday">Hosanna en el cielo</string>
+    <string name="holiday_banner_palm_sunday">Domingo de Ramos</string>
     <string name="holiday_banner_pentecost">Feliz Pentecostés</string>
     <string name="holiday_banner_philippines_bonifacio_day">Feliz Día de Bonifacio</string>
     <string name="holiday_banner_philippines_independence_day">Feliz Día de la Independencia de Filipinas</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -811,7 +811,7 @@ Tone is informal "sina"-form throughout ("Pane … selga", "Võta … kaasa",
     <string name="holiday_banner_st_georges_day">Head Püha Georgi päeva</string>
     <string name="holiday_banner_anzac_day">Mäletame</string>
     <string name="holiday_banner_uk_bank_holiday">Head pangapüha</string>
-    <string name="holiday_banner_uk_kings_birthday">Jumal hoidku Kuningat</string>
+    <string name="holiday_banner_uk_kings_birthday">Head kuninga sünnipäeva</string>
     <string name="holiday_banner_japan_greenery_day">Head Jaapani roheluse päeva</string>
     <string name="holiday_banner_croatia_statehood_day">Head Horvaatia riikluspäeva</string>
     <string name="holiday_banner_us_memorial_day">Austame langenuid</string>
@@ -935,7 +935,7 @@ Tone is informal "sina"-form throughout ("Pane … selga", "Võta … kaasa",
     <string name="holiday_banner_argentina_independence_day">Häid Argentina iseseisvuspäeva</string>
     <string name="holiday_banner_argentina_may_revolution">Häid mairevolutsiooni päeva</string>
     <string name="holiday_banner_ascension_day">Häid taevaminemise püha</string>
-    <string name="holiday_banner_ash_wednesday">Mäleta, et oled põrm</string>
+    <string name="holiday_banner_ash_wednesday">Tuhkapäev</string>
     <string name="holiday_banner_bangladesh_independence_day">Häid iseseisvuspäeva</string>
     <string name="holiday_banner_bangladesh_victory_day">Häid võidupüha</string>
     <string name="holiday_banner_brazil_black_awareness">Musta teadlikkuse päev</string>
@@ -958,7 +958,7 @@ Tone is informal "sina"-form throughout ("Pane … selga", "Võta … kaasa",
     <string name="holiday_banner_malaysia_day">Häid Malaisia päeva</string>
     <string name="holiday_banner_malaysia_independence_day">Häid Merdeka päeva</string>
     <string name="holiday_banner_mardi_gras">Häid vastlapäeva</string>
-    <string name="holiday_banner_maundy_thursday">Uus käsk</string>
+    <string name="holiday_banner_maundy_thursday">Suur neljapäev</string>
     <string name="holiday_banner_melbourne_cup_day">Võistlus, mis peatab rahva</string>
     <string name="holiday_banner_mexico_benito_juarez_birthday">Benito Juárezi auks</string>
     <string name="holiday_banner_mexico_constitution_day">Häid põhiseaduse päeva</string>
@@ -970,7 +970,7 @@ Tone is informal "sina"-form throughout ("Pane … selga", "Võta … kaasa",
     <string name="holiday_banner_orthodox_christmas">Häid õigeusu jõule</string>
     <string name="holiday_banner_pakistan_day">Häid Pakistani päeva</string>
     <string name="holiday_banner_pakistan_independence_day">Häid iseseisvuspäeva</string>
-    <string name="holiday_banner_palm_sunday">Hoosianna kõrgustes</string>
+    <string name="holiday_banner_palm_sunday">Palmipuudepüha</string>
     <string name="holiday_banner_pentecost">Häid nelipühi</string>
     <string name="holiday_banner_philippines_bonifacio_day">Häid Bonifacio päeva</string>
     <string name="holiday_banner_philippines_independence_day">Häid Filipiinide iseseisvuspäeva</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -697,7 +697,7 @@ Western Arabic numerals (0-9) are used for TTS compatibility.
     <string name="holiday_banner_st_georges_day">روز سنت جورج مبارک</string>
     <string name="holiday_banner_st_patricks_day">روز سنت پاتریک مبارک</string>
     <string name="holiday_banner_uk_bank_holiday">تعطیلات عمومی مبارک</string>
-    <string name="holiday_banner_uk_kings_birthday">خدا نگهدار پادشاه</string>
+    <string name="holiday_banner_uk_kings_birthday">تولد پادشاه مبارک</string>
     <string name="holiday_banner_uk_mothering_sunday">یکشنبه مادران مبارک</string>
     <string name="holiday_banner_us_independence_day">چهارم ژوئیه مبارک</string>
     <string name="holiday_banner_us_memorial_day">گرامی‌داشت شهدای ما</string>
@@ -979,7 +979,7 @@ Western Arabic numerals (0-9) are used for TTS compatibility.
     <string name="holiday_banner_argentina_independence_day">روز استقلال آرژانتین مبارک</string>
     <string name="holiday_banner_argentina_may_revolution">سالگرد انقلاب مه مبارک</string>
     <string name="holiday_banner_ascension_day">عید عروج مبارک</string>
-    <string name="holiday_banner_ash_wednesday">به یاد آور که خاک هستی</string>
+    <string name="holiday_banner_ash_wednesday">چهارشنبه خاکستر</string>
     <string name="holiday_banner_bangladesh_independence_day">روز استقلال مبارک</string>
     <string name="holiday_banner_bangladesh_victory_day">روز پیروزی مبارک</string>
     <string name="holiday_banner_brazil_black_awareness">روز آگاهی سیاه‌پوستان</string>
@@ -1002,7 +1002,7 @@ Western Arabic numerals (0-9) are used for TTS compatibility.
     <string name="holiday_banner_malaysia_day">روز مالزی مبارک</string>
     <string name="holiday_banner_malaysia_independence_day">روز مرکا مبارک</string>
     <string name="holiday_banner_mardi_gras">ماردی گرا مبارک</string>
-    <string name="holiday_banner_maundy_thursday">فرمانی نو</string>
+    <string name="holiday_banner_maundy_thursday">پنج‌شنبه مقدس</string>
     <string name="holiday_banner_melbourne_cup_day">مسابقه‌ای که ملتی را متوقف می‌کند</string>
     <string name="holiday_banner_mexico_benito_juarez_birthday">به یاد بنیتو خوارز</string>
     <string name="holiday_banner_mexico_constitution_day">روز قانون اساسی مبارک</string>
@@ -1014,7 +1014,7 @@ Western Arabic numerals (0-9) are used for TTS compatibility.
     <string name="holiday_banner_orthodox_christmas">کریسمس ارتدوکس مبارک</string>
     <string name="holiday_banner_pakistan_day">روز پاکستان مبارک</string>
     <string name="holiday_banner_pakistan_independence_day">روز استقلال مبارک</string>
-    <string name="holiday_banner_palm_sunday">هوسانا در اعالی</string>
+    <string name="holiday_banner_palm_sunday">یکشنبه نخل</string>
     <string name="holiday_banner_pentecost">عید پنطیکاست مبارک</string>
     <string name="holiday_banner_philippines_bonifacio_day">روز بونیفاسیو مبارک</string>
     <string name="holiday_banner_philippines_independence_day">روز استقلال فیلیپین مبارک</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -895,7 +895,7 @@ displayed label localizes.
     <string name="holiday_banner_st_davids_day">Hyvää Pyhän Daavidin päivää</string>
     <string name="holiday_banner_st_georges_day">Hyvää Pyhän Yrjön päivää</string>
     <string name="holiday_banner_uk_bank_holiday">Hyvää vapaapäivää</string>
-    <string name="holiday_banner_uk_kings_birthday">God save the King</string>
+    <string name="holiday_banner_uk_kings_birthday">Hyvää kuninkaan syntymäpäivää</string>
     <string name="holiday_banner_uk_mothering_sunday">Hyvää äitienpäivää (UK)</string>
     <string name="holiday_banner_us_independence_day">Hyvää 4. heinäkuuta</string>
     <string name="holiday_banner_us_memorial_day">Kunnioitamme kaatuneita</string>
@@ -998,7 +998,7 @@ displayed label localizes.
     <string name="holiday_banner_argentina_independence_day">Hyvää Argentiinan itsenäisyyspäivää</string>
     <string name="holiday_banner_argentina_may_revolution">Hyvää toukokuun vallankumouksen päivää</string>
     <string name="holiday_banner_ascension_day">Hyvää helatorstaita</string>
-    <string name="holiday_banner_ash_wednesday">Muista, että olet tomua</string>
+    <string name="holiday_banner_ash_wednesday">Tuhkakeskiviikko</string>
     <string name="holiday_banner_bangladesh_independence_day">Hyvää itsenäisyyspäivää</string>
     <string name="holiday_banner_bangladesh_victory_day">Hyvää voitonpäivää</string>
     <string name="holiday_banner_brazil_black_awareness">Mustien tietoisuuden päivä</string>
@@ -1021,7 +1021,7 @@ displayed label localizes.
     <string name="holiday_banner_malaysia_day">Hyvää Malesian päivää</string>
     <string name="holiday_banner_malaysia_independence_day">Hyvää Merdeka-päivää</string>
     <string name="holiday_banner_mardi_gras">Hyvää laskiaista</string>
-    <string name="holiday_banner_maundy_thursday">Uusi käsky</string>
+    <string name="holiday_banner_maundy_thursday">Kiirastorstai</string>
     <string name="holiday_banner_melbourne_cup_day">Kilpailu, joka pysäyttää kansakunnan</string>
     <string name="holiday_banner_mexico_benito_juarez_birthday">Benito Juárezin kunniaksi</string>
     <string name="holiday_banner_mexico_constitution_day">Hyvää perustuslain päivää</string>
@@ -1033,7 +1033,7 @@ displayed label localizes.
     <string name="holiday_banner_orthodox_christmas">Hyvää ortodoksista joulua</string>
     <string name="holiday_banner_pakistan_day">Hyvää Pakistanin päivää</string>
     <string name="holiday_banner_pakistan_independence_day">Hyvää itsenäisyyspäivää</string>
-    <string name="holiday_banner_palm_sunday">Hoosianna korkeuksissa</string>
+    <string name="holiday_banner_palm_sunday">Palmusunnuntai</string>
     <string name="holiday_banner_pentecost">Hyvää helluntaita</string>
     <string name="holiday_banner_philippines_bonifacio_day">Hyvää Bonifacion päivää</string>
     <string name="holiday_banner_philippines_independence_day">Hyvää Filippiinien itsenäisyyspäivää</string>

--- a/app/src/main/res/values-fil/strings.xml
+++ b/app/src/main/res/values-fil/strings.xml
@@ -845,7 +845,7 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="holiday_banner_st_georges_day">Maligayang Araw ni San George</string>
     <string name="holiday_banner_st_patricks_day">Maligayang Araw ni San Patrick</string>
     <string name="holiday_banner_uk_bank_holiday">Maligayang bank holiday</string>
-    <string name="holiday_banner_uk_kings_birthday">God save the King</string>
+    <string name="holiday_banner_uk_kings_birthday">Maligayang Kaarawan ng Hari</string>
     <string name="holiday_banner_uk_mothering_sunday">Maligayang Linggo ng Ina</string>
     <string name="holiday_banner_us_independence_day">Maligayang Ika-4 ng Hulyo</string>
     <string name="holiday_banner_us_memorial_day">Nagbibigay-pugay sa ating mga bayani</string>
@@ -1042,7 +1042,7 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="holiday_banner_argentina_independence_day">Maligayang Araw ng Kalayaan ng Argentina</string>
     <string name="holiday_banner_argentina_may_revolution">Maligayang Rebolusyon ng Mayo</string>
     <string name="holiday_banner_ascension_day">Maligayang Pag-akyat sa Langit</string>
-    <string name="holiday_banner_ash_wednesday">Tandaan na ikaw ay alikabok</string>
+    <string name="holiday_banner_ash_wednesday">Miyerkules ng Abo</string>
     <string name="holiday_banner_bangladesh_independence_day">Maligayang Araw ng Kalayaan</string>
     <string name="holiday_banner_bangladesh_victory_day">Maligayang Araw ng Tagumpay</string>
     <string name="holiday_banner_brazil_black_awareness">Araw ng Kamalayan ng Itim</string>
@@ -1065,7 +1065,7 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="holiday_banner_malaysia_day">Maligayang Araw ng Malaysia</string>
     <string name="holiday_banner_malaysia_independence_day">Maligayang Araw ng Merdeka</string>
     <string name="holiday_banner_mardi_gras">Maligayang Mardi Gras</string>
-    <string name="holiday_banner_maundy_thursday">Isang bagong utos</string>
+    <string name="holiday_banner_maundy_thursday">Huwebes Santo</string>
     <string name="holiday_banner_melbourne_cup_day">Ang karera na pumipigil sa isang bansa</string>
     <string name="holiday_banner_mexico_benito_juarez_birthday">Pagpaparangal kay Benito Juárez</string>
     <string name="holiday_banner_mexico_constitution_day">Maligayang Araw ng Konstitusyon</string>
@@ -1077,7 +1077,7 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="holiday_banner_orthodox_christmas">Maligayang Pasko ng Ortodokso</string>
     <string name="holiday_banner_pakistan_day">Maligayang Araw ng Pakistan</string>
     <string name="holiday_banner_pakistan_independence_day">Maligayang Araw ng Kalayaan</string>
-    <string name="holiday_banner_palm_sunday">Hosanna sa kaitaasan</string>
+    <string name="holiday_banner_palm_sunday">Linggo ng Palaspas</string>
     <string name="holiday_banner_pentecost">Maligayang Pentecost</string>
     <string name="holiday_banner_philippines_bonifacio_day">Maligayang Araw ni Bonifacio</string>
     <string name="holiday_banner_philippines_independence_day">Maligayang Araw ng Kalayaan</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -940,7 +940,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="holiday_banner_st_georges_day">Bonne Saint-Georges</string>
     <string name="holiday_banner_st_andrews_day">Bonne Saint-André</string>
     <string name="holiday_banner_uk_bank_holiday">Bon jour férié</string>
-    <string name="holiday_banner_uk_kings_birthday">Vive le roi</string>
+    <string name="holiday_banner_uk_kings_birthday">Joyeux anniversaire au roi</string>
     <string name="holiday_banner_uk_mothering_sunday">Bonne fête des Mères</string>
     <string name="holiday_banner_austria_national_day">Bonne fête nationale autrichienne</string>
     <string name="holiday_banner_german_unity_day">Bonne Journée de l\'Unité allemande</string>
@@ -1118,7 +1118,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="holiday_banner_argentina_independence_day">Bonne fête de l\'Indépendance de l\'Argentine</string>
     <string name="holiday_banner_argentina_may_revolution">Bonne fête de la Révolution de Mai</string>
     <string name="holiday_banner_ascension_day">Bonne Ascension</string>
-    <string name="holiday_banner_ash_wednesday">Souviens-toi que tu es poussière</string>
+    <string name="holiday_banner_ash_wednesday">Mercredi des Cendres</string>
     <string name="holiday_banner_bangladesh_independence_day">Bonne fête de l\'Indépendance</string>
     <string name="holiday_banner_bangladesh_victory_day">Bonne fête de la Victoire</string>
     <string name="holiday_banner_brazil_black_awareness">Journée de la conscience noire</string>
@@ -1141,7 +1141,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="holiday_banner_malaysia_day">Bonne fête de la Malaisie</string>
     <string name="holiday_banner_malaysia_independence_day">Bonne fête de la Merdeka</string>
     <string name="holiday_banner_mardi_gras">Laissez les bons temps rouler</string>
-    <string name="holiday_banner_maundy_thursday">Un commandement nouveau</string>
+    <string name="holiday_banner_maundy_thursday">Jeudi saint</string>
     <string name="holiday_banner_melbourne_cup_day">La course qui arrête une nation</string>
     <string name="holiday_banner_mexico_benito_juarez_birthday">En l\'honneur de Benito Juárez</string>
     <string name="holiday_banner_mexico_constitution_day">Bonne fête de la Constitution</string>
@@ -1153,7 +1153,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="holiday_banner_orthodox_christmas">Joyeux Noël orthodoxe</string>
     <string name="holiday_banner_pakistan_day">Bonne fête du Pakistan</string>
     <string name="holiday_banner_pakistan_independence_day">Bonne fête de l\'Indépendance</string>
-    <string name="holiday_banner_palm_sunday">Hosanna au plus haut des cieux</string>
+    <string name="holiday_banner_palm_sunday">Dimanche des Rameaux</string>
     <string name="holiday_banner_pentecost">Bonne Pentecôte</string>
     <string name="holiday_banner_philippines_bonifacio_day">Bonne fête de Bonifacio</string>
     <string name="holiday_banner_philippines_independence_day">Bonne fête de l\'Indépendance des Philippines</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -824,7 +824,7 @@ Not overridden by design:
     <string name="holiday_banner_st_georges_day">सेंट जॉर्ज दिवस की शुभकामनाएँ</string>
     <string name="holiday_banner_st_patricks_day">सेंट पैट्रिक दिवस की शुभकामनाएँ</string>
     <string name="holiday_banner_uk_bank_holiday">बैंक हॉलिडे की शुभकामनाएँ</string>
-    <string name="holiday_banner_uk_kings_birthday">ईश्वर राजा की रक्षा करे</string>
+    <string name="holiday_banner_uk_kings_birthday">राजा को जन्मदिन की शुभकामनाएं</string>
     <string name="holiday_banner_uk_mothering_sunday">मदरिंग संडे की शुभकामनाएँ</string>
     <string name="holiday_banner_us_independence_day">4 जुलाई की शुभकामनाएँ</string>
     <string name="holiday_banner_us_memorial_day">हमारे शहीदों को नमन</string>
@@ -1022,7 +1022,7 @@ Not overridden by design:
     <string name="holiday_banner_argentina_independence_day">अर्जेंटीना स्वतंत्रता दिवस की शुभकामनाएं</string>
     <string name="holiday_banner_argentina_may_revolution">मई क्रांति दिवस की शुभकामनाएं</string>
     <string name="holiday_banner_ascension_day">स्वर्गारोहण दिवस की शुभकामनाएं</string>
-    <string name="holiday_banner_ash_wednesday">याद रखो कि तुम धूल हो</string>
+    <string name="holiday_banner_ash_wednesday">ऐश बुधवार</string>
     <string name="holiday_banner_bangladesh_independence_day">स्वतंत्रता दिवस की शुभकामनाएं</string>
     <string name="holiday_banner_bangladesh_victory_day">विजय दिवस की शुभकामनाएं</string>
     <string name="holiday_banner_brazil_black_awareness">अश्वेत जागरूकता दिवस</string>
@@ -1045,7 +1045,7 @@ Not overridden by design:
     <string name="holiday_banner_malaysia_day">मलेशिया दिवस की शुभकामनाएं</string>
     <string name="holiday_banner_malaysia_independence_day">मरडेका दिवस की शुभकामनाएं</string>
     <string name="holiday_banner_mardi_gras">मार्डी ग्रास की शुभकामनाएं</string>
-    <string name="holiday_banner_maundy_thursday">एक नई आज्ञा</string>
+    <string name="holiday_banner_maundy_thursday">पवित्र गुरुवार</string>
     <string name="holiday_banner_melbourne_cup_day">वह दौड़ जो एक राष्ट्र को रोक देती है</string>
     <string name="holiday_banner_mexico_benito_juarez_birthday">बेनिटो जुआरेज़ के सम्मान में</string>
     <string name="holiday_banner_mexico_constitution_day">संविधान दिवस की शुभकामनाएं</string>
@@ -1057,7 +1057,7 @@ Not overridden by design:
     <string name="holiday_banner_orthodox_christmas">ऑर्थोडॉक्स क्रिसमस की शुभकामनाएं</string>
     <string name="holiday_banner_pakistan_day">पाकिस्तान दिवस की शुभकामनाएं</string>
     <string name="holiday_banner_pakistan_independence_day">स्वतंत्रता दिवस की शुभकामनाएं</string>
-    <string name="holiday_banner_palm_sunday">उच्चतम में होशन्ना</string>
+    <string name="holiday_banner_palm_sunday">पाम संडे</string>
     <string name="holiday_banner_pentecost">पेंटेकोस्ट की शुभकामनाएं</string>
     <string name="holiday_banner_philippines_bonifacio_day">बोनिफासियो दिवस की शुभकामनाएं</string>
     <string name="holiday_banner_philippines_independence_day">फिलीपींस स्वतंत्रता दिवस की शुभकामनाएं</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -1060,7 +1060,7 @@ spousal register), matching the existing insight prose ("Ponesi …",
     <string name="holiday_banner_argentina_independence_day">Sretan Dan neovisnosti Argentine</string>
     <string name="holiday_banner_argentina_may_revolution">Sretna Svibanjska revolucija</string>
     <string name="holiday_banner_ascension_day">Sretan Spasovdan</string>
-    <string name="holiday_banner_ash_wednesday">Sjeti se da si prah</string>
+    <string name="holiday_banner_ash_wednesday">Pepelnica</string>
     <string name="holiday_banner_bangladesh_independence_day">Sretan Dan neovisnosti</string>
     <string name="holiday_banner_bangladesh_victory_day">Sretan Dan pobjede</string>
     <string name="holiday_banner_brazil_black_awareness">Dan crne svijesti</string>
@@ -1083,7 +1083,7 @@ spousal register), matching the existing insight prose ("Ponesi …",
     <string name="holiday_banner_malaysia_day">Selamat Hari Malaysia</string>
     <string name="holiday_banner_malaysia_independence_day">Selamat Hari Merdeka</string>
     <string name="holiday_banner_mardi_gras">Sretne Pokladne</string>
-    <string name="holiday_banner_maundy_thursday">Nova zapovijed</string>
+    <string name="holiday_banner_maundy_thursday">Veliki četvrtak</string>
     <string name="holiday_banner_melbourne_cup_day">Utrka koja zaustavlja naciju</string>
     <string name="holiday_banner_mexico_benito_juarez_birthday">U čast Benita Juáreza</string>
     <string name="holiday_banner_mexico_constitution_day">Sretan Dan Ustava</string>
@@ -1095,7 +1095,7 @@ spousal register), matching the existing insight prose ("Ponesi …",
     <string name="holiday_banner_orthodox_christmas">Sretan pravoslavni Božić</string>
     <string name="holiday_banner_pakistan_day">Sretan Dan Pakistana</string>
     <string name="holiday_banner_pakistan_independence_day">Sretan Dan neovisnosti</string>
-    <string name="holiday_banner_palm_sunday">Hosana u visini</string>
+    <string name="holiday_banner_palm_sunday">Cvjetnica</string>
     <string name="holiday_banner_pentecost">Sretne Duhove</string>
     <string name="holiday_banner_philippines_bonifacio_day">Sretan Dan Bonifacija</string>
     <string name="holiday_banner_philippines_independence_day">Maligayang Araw ng Kalayaan</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -804,7 +804,7 @@ locale (Angol (Egyesült Államok), Francia (Franciaország), Német
     <string name="holiday_banner_st_davids_day">Boldog Szent Dávid napját</string>
     <string name="holiday_banner_st_georges_day">Boldog Szent György napját</string>
     <string name="holiday_banner_uk_bank_holiday">Boldog banki ünnepet</string>
-    <string name="holiday_banner_uk_kings_birthday">Boldog A király születésnapját</string>
+    <string name="holiday_banner_uk_kings_birthday">Boldog születésnapot, Király!</string>
     <string name="holiday_banner_uk_mothering_sunday">Boldog Anyák vasárnapját</string>
     <string name="holiday_banner_us_independence_day">Boldog Függetlenség napját</string>
     <string name="holiday_banner_us_memorial_day">Emlékezünk az elesettekre</string>
@@ -984,7 +984,7 @@ locale (Angol (Egyesült Államok), Francia (Franciaország), Német
     <string name="holiday_banner_argentina_independence_day">Boldog argentin függetlenség napját</string>
     <string name="holiday_banner_argentina_may_revolution">Boldog Májusi forradalom napját</string>
     <string name="holiday_banner_ascension_day">Boldog Áldozócsütörtököt</string>
-    <string name="holiday_banner_ash_wednesday">Emlékezz, hogy por vagy</string>
+    <string name="holiday_banner_ash_wednesday">Hamvazószerda</string>
     <string name="holiday_banner_bangladesh_independence_day">Boldog függetlenség napját</string>
     <string name="holiday_banner_bangladesh_victory_day">Boldog győzelem napját</string>
     <string name="holiday_banner_brazil_black_awareness">A fekete tudatosság napja</string>
@@ -1007,7 +1007,7 @@ locale (Angol (Egyesült Államok), Francia (Franciaország), Német
     <string name="holiday_banner_malaysia_day">Boldog Malajzia napját</string>
     <string name="holiday_banner_malaysia_independence_day">Boldog Merdeka napját</string>
     <string name="holiday_banner_mardi_gras">Boldog farsang utolját</string>
-    <string name="holiday_banner_maundy_thursday">Új parancsolat</string>
+    <string name="holiday_banner_maundy_thursday">Nagycsütörtök</string>
     <string name="holiday_banner_melbourne_cup_day">A nemzetet megállító verseny</string>
     <string name="holiday_banner_mexico_benito_juarez_birthday">Benito Juárez tiszteletére</string>
     <string name="holiday_banner_mexico_constitution_day">Boldog alkotmány napját</string>
@@ -1019,7 +1019,7 @@ locale (Angol (Egyesült Államok), Francia (Franciaország), Német
     <string name="holiday_banner_orthodox_christmas">Boldog ortodox karácsonyt</string>
     <string name="holiday_banner_pakistan_day">Boldog Pakisztán napját</string>
     <string name="holiday_banner_pakistan_independence_day">Boldog függetlenség napját</string>
-    <string name="holiday_banner_palm_sunday">Hozsanna a magasságban</string>
+    <string name="holiday_banner_palm_sunday">Virágvasárnap</string>
     <string name="holiday_banner_pentecost">Boldog Pünkösdöt</string>
     <string name="holiday_banner_philippines_bonifacio_day">Boldog Bonifacio napját</string>
     <string name="holiday_banner_philippines_independence_day">Boldog Fülöp-szigeteki függetlenség napját</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -794,7 +794,7 @@ to values/strings.xml (English).
     <string name="holiday_banner_st_georges_day">Selamat Hari Santo George</string>
     <string name="holiday_banner_st_patricks_day">Selamat Hari Santo Patrick</string>
     <string name="holiday_banner_uk_bank_holiday">Selamat hari libur bank</string>
-    <string name="holiday_banner_uk_kings_birthday">God save the King</string>
+    <string name="holiday_banner_uk_kings_birthday">Selamat Ulang Tahun Raja</string>
     <string name="holiday_banner_uk_mothering_sunday">Selamat Hari Ibu</string>
     <string name="holiday_banner_us_independence_day">Selamat 4 Juli</string>
     <string name="holiday_banner_us_memorial_day">Menghormati pahlawan kita</string>
@@ -991,7 +991,7 @@ to values/strings.xml (English).
     <string name="holiday_banner_argentina_independence_day">Selamat Hari Kemerdekaan Argentina</string>
     <string name="holiday_banner_argentina_may_revolution">Selamat Hari Revolusi Mei</string>
     <string name="holiday_banner_ascension_day">Selamat Hari Kenaikan</string>
-    <string name="holiday_banner_ash_wednesday">Ingatlah bahwa kau adalah debu</string>
+    <string name="holiday_banner_ash_wednesday">Rabu Abu</string>
     <string name="holiday_banner_bangladesh_independence_day">Selamat Hari Kemerdekaan</string>
     <string name="holiday_banner_bangladesh_victory_day">Selamat Hari Kemenangan</string>
     <string name="holiday_banner_brazil_black_awareness">Hari Kesadaran Kulit Hitam</string>
@@ -1014,7 +1014,7 @@ to values/strings.xml (English).
     <string name="holiday_banner_malaysia_day">Selamat Hari Malaysia</string>
     <string name="holiday_banner_malaysia_independence_day">Selamat Hari Merdeka</string>
     <string name="holiday_banner_mardi_gras">Selamat Mardi Gras</string>
-    <string name="holiday_banner_maundy_thursday">Perintah baru</string>
+    <string name="holiday_banner_maundy_thursday">Kamis Putih</string>
     <string name="holiday_banner_melbourne_cup_day">Lomba yang menghentikan bangsa</string>
     <string name="holiday_banner_mexico_benito_juarez_birthday">Mengenang Benito Juárez</string>
     <string name="holiday_banner_mexico_constitution_day">Selamat Hari Konstitusi</string>
@@ -1026,7 +1026,7 @@ to values/strings.xml (English).
     <string name="holiday_banner_orthodox_christmas">Selamat Natal Ortodoks</string>
     <string name="holiday_banner_pakistan_day">Selamat Hari Pakistan</string>
     <string name="holiday_banner_pakistan_independence_day">Selamat Hari Kemerdekaan</string>
-    <string name="holiday_banner_palm_sunday">Hosana di tempat yang tertinggi</string>
+    <string name="holiday_banner_palm_sunday">Minggu Palma</string>
     <string name="holiday_banner_pentecost">Selamat Pentakosta</string>
     <string name="holiday_banner_philippines_bonifacio_day">Selamat Hari Bonifacio</string>
     <string name="holiday_banner_philippines_independence_day">Selamat Hari Kemerdekaan Filipina</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -925,7 +925,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="holiday_banner_st_georges_day">Buona Festa di San Giorgio</string>
     <string name="holiday_banner_st_andrews_day">Buona Festa di Sant\'Andrea</string>
     <string name="holiday_banner_uk_bank_holiday">Buona festa nazionale</string>
-    <string name="holiday_banner_uk_kings_birthday">Dio salvi il Re</string>
+    <string name="holiday_banner_uk_kings_birthday">Buon compleanno al Re</string>
     <string name="holiday_banner_uk_mothering_sunday">Buona Festa della Mamma</string>
     <string name="holiday_banner_austria_national_day">Buona Festa Nazionale dell\'Austria</string>
     <string name="holiday_banner_german_unity_day">Buona Giornata dell\'Unità Tedesca</string>
@@ -1104,7 +1104,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="holiday_banner_argentina_independence_day">Buona festa dell\'Indipendenza argentina</string>
     <string name="holiday_banner_argentina_may_revolution">Buona Rivoluzione di Maggio</string>
     <string name="holiday_banner_ascension_day">Buona Ascensione</string>
-    <string name="holiday_banner_ash_wednesday">Ricordati che sei polvere</string>
+    <string name="holiday_banner_ash_wednesday">Mercoledì delle Ceneri</string>
     <string name="holiday_banner_bangladesh_independence_day">Buona festa dell\'Indipendenza</string>
     <string name="holiday_banner_bangladesh_victory_day">Buona festa della Vittoria</string>
     <string name="holiday_banner_brazil_black_awareness">Giornata della consapevolezza nera</string>
@@ -1127,7 +1127,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="holiday_banner_malaysia_day">Buona festa della Malesia</string>
     <string name="holiday_banner_malaysia_independence_day">Buona festa della Merdeka</string>
     <string name="holiday_banner_mardi_gras">Buon Martedì Grasso</string>
-    <string name="holiday_banner_maundy_thursday">Un comandamento nuovo</string>
+    <string name="holiday_banner_maundy_thursday">Giovedì santo</string>
     <string name="holiday_banner_melbourne_cup_day">La corsa che ferma una nazione</string>
     <string name="holiday_banner_mexico_benito_juarez_birthday">In onore di Benito Juárez</string>
     <string name="holiday_banner_mexico_constitution_day">Buona festa della Costituzione</string>
@@ -1139,7 +1139,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="holiday_banner_orthodox_christmas">Buon Natale ortodosso</string>
     <string name="holiday_banner_pakistan_day">Buona Giornata del Pakistan</string>
     <string name="holiday_banner_pakistan_independence_day">Buona festa dell\'Indipendenza</string>
-    <string name="holiday_banner_palm_sunday">Osanna nell\'alto dei cieli</string>
+    <string name="holiday_banner_palm_sunday">Domenica delle Palme</string>
     <string name="holiday_banner_pentecost">Buona Pentecoste</string>
     <string name="holiday_banner_philippines_bonifacio_day">Buona festa di Bonifacio</string>
     <string name="holiday_banner_philippines_independence_day">Buona festa dell\'Indipendenza delle Filippine</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -703,7 +703,7 @@ standard in Israeli digital communication.
     <string name="holiday_banner_st_georges_day">יום סנט ג׳ורג׳ שמח</string>
     <string name="holiday_banner_st_patricks_day">יום סנט פטריק שמח</string>
     <string name="holiday_banner_uk_bank_holiday">חג בנקאי שמח</string>
-    <string name="holiday_banner_uk_kings_birthday">יחי המלך</string>
+    <string name="holiday_banner_uk_kings_birthday">יום הולדת שמח למלך</string>
     <string name="holiday_banner_uk_mothering_sunday">יום האמהות שמח</string>
     <string name="holiday_banner_us_independence_day">חג הרביעי ביולי שמח</string>
     <string name="holiday_banner_us_memorial_day">מכבדים את נופלינו</string>
@@ -985,7 +985,7 @@ standard in Israeli digital communication.
     <string name="holiday_banner_argentina_independence_day">יום עצמאות שמח לארגנטינה</string>
     <string name="holiday_banner_argentina_may_revolution">יום שמח למהפכת מאי</string>
     <string name="holiday_banner_ascension_day">חג עלייה שמח</string>
-    <string name="holiday_banner_ash_wednesday">זכור שאתה עפר</string>
+    <string name="holiday_banner_ash_wednesday">יום רביעי של אפר</string>
     <string name="holiday_banner_bangladesh_independence_day">יום עצמאות שמח</string>
     <string name="holiday_banner_bangladesh_victory_day">יום ניצחון שמח</string>
     <string name="holiday_banner_brazil_black_awareness">יום המודעות השחורה</string>
@@ -1008,7 +1008,7 @@ standard in Israeli digital communication.
     <string name="holiday_banner_malaysia_day">יום שמח למלזיה</string>
     <string name="holiday_banner_malaysia_independence_day">יום מרדקה שמח</string>
     <string name="holiday_banner_mardi_gras">יום הקרנבל שמח</string>
-    <string name="holiday_banner_maundy_thursday">מצווה חדשה</string>
+    <string name="holiday_banner_maundy_thursday">יום חמישי הקדוש</string>
     <string name="holiday_banner_melbourne_cup_day">המרוץ שעוצר אומה</string>
     <string name="holiday_banner_mexico_benito_juarez_birthday">לזכר בניטו חוארס</string>
     <string name="holiday_banner_mexico_constitution_day">יום החוקה שמח</string>
@@ -1020,7 +1020,7 @@ standard in Israeli digital communication.
     <string name="holiday_banner_orthodox_christmas">חג מולד אורתודוקסי שמח</string>
     <string name="holiday_banner_pakistan_day">יום פקיסטן שמח</string>
     <string name="holiday_banner_pakistan_independence_day">יום עצמאות שמח</string>
-    <string name="holiday_banner_palm_sunday">הושענא במרומים</string>
+    <string name="holiday_banner_palm_sunday">יום ראשון של ההושענות</string>
     <string name="holiday_banner_pentecost">חג שבועות שמח</string>
     <string name="holiday_banner_philippines_bonifacio_day">יום בוניפסיו שמח</string>
     <string name="holiday_banner_philippines_independence_day">יום עצמאות שמח לפיליפינים</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -936,7 +936,7 @@ the displayed label localizes.
     <string name="holiday_banner_st_georges_day">聖ジョージの日おめでとうございます</string>
     <string name="holiday_banner_st_patricks_day">聖パトリックの日おめでとうございます</string>
     <string name="holiday_banner_uk_bank_holiday">祝日おめでとうございます</string>
-    <string name="holiday_banner_uk_kings_birthday">国王陛下万歳</string>
+    <string name="holiday_banner_uk_kings_birthday">国王誕生日おめでとう</string>
     <string name="holiday_banner_uk_mothering_sunday">母の日おめでとうございます</string>
     <string name="holiday_banner_us_independence_day">独立記念日おめでとうございます</string>
     <string name="holiday_banner_us_memorial_day">先人の勇気を称えます</string>
@@ -1141,7 +1141,7 @@ the displayed label localizes.
     <string name="holiday_banner_argentina_independence_day">アルゼンチン独立記念日おめでとう</string>
     <string name="holiday_banner_argentina_may_revolution">五月革命の日おめでとう</string>
     <string name="holiday_banner_ascension_day">昇天祭おめでとう</string>
-    <string name="holiday_banner_ash_wednesday">あなたが塵であることを思い起こせ</string>
+    <string name="holiday_banner_ash_wednesday">灰の水曜日</string>
     <string name="holiday_banner_bangladesh_independence_day">独立記念日おめでとう</string>
     <string name="holiday_banner_bangladesh_victory_day">戦勝記念日おめでとう</string>
     <string name="holiday_banner_brazil_black_awareness">黒人意識の日</string>
@@ -1164,7 +1164,7 @@ the displayed label localizes.
     <string name="holiday_banner_malaysia_day">マレーシアの日おめでとう</string>
     <string name="holiday_banner_malaysia_independence_day">ムルデカおめでとう</string>
     <string name="holiday_banner_mardi_gras">マルディグラおめでとう</string>
-    <string name="holiday_banner_maundy_thursday">新しい戒め</string>
+    <string name="holiday_banner_maundy_thursday">聖木曜日</string>
     <string name="holiday_banner_melbourne_cup_day">国を止めるレース</string>
     <string name="holiday_banner_mexico_benito_juarez_birthday">ベニート・フアレスを称えて</string>
     <string name="holiday_banner_mexico_constitution_day">憲法記念日おめでとう</string>
@@ -1176,7 +1176,7 @@ the displayed label localizes.
     <string name="holiday_banner_orthodox_christmas">東方正教会のクリスマスおめでとう</string>
     <string name="holiday_banner_pakistan_day">パキスタンの日おめでとう</string>
     <string name="holiday_banner_pakistan_independence_day">独立記念日おめでとう</string>
-    <string name="holiday_banner_palm_sunday">天のいと高きところにホサナ</string>
+    <string name="holiday_banner_palm_sunday">枝の主日</string>
     <string name="holiday_banner_pentecost">聖霊降臨祭おめでとう</string>
     <string name="holiday_banner_philippines_bonifacio_day">ボニファシオの日おめでとう</string>
     <string name="holiday_banner_philippines_independence_day">フィリピン独立記念日おめでとう</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -940,7 +940,7 @@ displayed label localizes.
     <string name="holiday_banner_st_georges_day">성 조지의 날을 기념합니다</string>
     <string name="holiday_banner_st_patricks_day">성 패트릭의 날을 기념합니다</string>
     <string name="holiday_banner_uk_bank_holiday">공휴일을 기념합니다</string>
-    <string name="holiday_banner_uk_kings_birthday">국왕 폐하 만세</string>
+    <string name="holiday_banner_uk_kings_birthday">국왕 생신을 축하합니다</string>
     <string name="holiday_banner_uk_mothering_sunday">어머니 주일을 기념합니다</string>
     <string name="holiday_banner_us_independence_day">미국 독립기념일을 기념합니다</string>
     <string name="holiday_banner_us_memorial_day">전몰용사를 기립니다</string>
@@ -1145,7 +1145,7 @@ displayed label localizes.
     <string name="holiday_banner_argentina_independence_day">아르헨티나 독립기념일을 축하합니다</string>
     <string name="holiday_banner_argentina_may_revolution">5월 혁명 기념일을 축하합니다</string>
     <string name="holiday_banner_ascension_day">예수 승천 대축일을 축하합니다</string>
-    <string name="holiday_banner_ash_wednesday">그대가 흙임을 기억하라</string>
+    <string name="holiday_banner_ash_wednesday">재의 수요일</string>
     <string name="holiday_banner_bangladesh_independence_day">독립기념일을 축하합니다</string>
     <string name="holiday_banner_bangladesh_victory_day">승전기념일을 축하합니다</string>
     <string name="holiday_banner_brazil_black_awareness">흑인 의식의 날</string>
@@ -1168,7 +1168,7 @@ displayed label localizes.
     <string name="holiday_banner_malaysia_day">말레이시아의 날을 축하합니다</string>
     <string name="holiday_banner_malaysia_independence_day">므르데카의 날을 축하합니다</string>
     <string name="holiday_banner_mardi_gras">마르디 그라를 즐기세요</string>
-    <string name="holiday_banner_maundy_thursday">새로운 계명</string>
+    <string name="holiday_banner_maundy_thursday">성목요일</string>
     <string name="holiday_banner_melbourne_cup_day">온 나라를 멈추는 경마</string>
     <string name="holiday_banner_mexico_benito_juarez_birthday">베니토 후아레스를 기리며</string>
     <string name="holiday_banner_mexico_constitution_day">헌법의 날을 축하합니다</string>
@@ -1180,7 +1180,7 @@ displayed label localizes.
     <string name="holiday_banner_orthodox_christmas">정교회 성탄절을 축하합니다</string>
     <string name="holiday_banner_pakistan_day">파키스탄의 날을 축하합니다</string>
     <string name="holiday_banner_pakistan_independence_day">독립기념일을 축하합니다</string>
-    <string name="holiday_banner_palm_sunday">지극히 높은 곳에 호산나</string>
+    <string name="holiday_banner_palm_sunday">성지주일</string>
     <string name="holiday_banner_pentecost">성령강림 대축일을 축하합니다</string>
     <string name="holiday_banner_philippines_bonifacio_day">보니파시오의 날을 축하합니다</string>
     <string name="holiday_banner_philippines_independence_day">필리핀 독립기념일을 축하합니다</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -855,7 +855,7 @@ What is NOT overridden, by design:
     <string name="holiday_banner_st_georges_day">Su šv. Jurgio diena</string>
     <string name="holiday_banner_anzac_day">Tegul neužmirštama</string>
     <string name="holiday_banner_uk_bank_holiday">Su banko švente</string>
-    <string name="holiday_banner_uk_kings_birthday">Dieve, saugok Karalių</string>
+    <string name="holiday_banner_uk_kings_birthday">Sveikiname Karalių su gimtadieniu</string>
     <string name="holiday_banner_japan_greenery_day">Su japonų žalumos diena</string>
     <string name="holiday_banner_croatia_statehood_day">Su Kroatijos valstybingumo diena</string>
     <string name="holiday_banner_us_memorial_day">Gerbiame žuvusius</string>
@@ -979,7 +979,7 @@ What is NOT overridden, by design:
     <string name="holiday_banner_argentina_independence_day">Su Argentinos Nepriklausomybės diena</string>
     <string name="holiday_banner_argentina_may_revolution">Su Gegužės revoliucijos diena</string>
     <string name="holiday_banner_ascension_day">Su Šeštinėmis</string>
-    <string name="holiday_banner_ash_wednesday">Atmink, kad esi dulkė</string>
+    <string name="holiday_banner_ash_wednesday">Pelenų trečiadienis</string>
     <string name="holiday_banner_bangladesh_independence_day">Su Nepriklausomybės diena</string>
     <string name="holiday_banner_bangladesh_victory_day">Su Pergalės diena</string>
     <string name="holiday_banner_brazil_black_awareness">Juodosios sąmonės diena</string>
@@ -1002,7 +1002,7 @@ What is NOT overridden, by design:
     <string name="holiday_banner_malaysia_day">Su Malaizijos diena</string>
     <string name="holiday_banner_malaysia_independence_day">Su Merdeka diena</string>
     <string name="holiday_banner_mardi_gras">Linksmos Užgavėnės</string>
-    <string name="holiday_banner_maundy_thursday">Naujas įsakymas</string>
+    <string name="holiday_banner_maundy_thursday">Didysis ketvirtadienis</string>
     <string name="holiday_banner_melbourne_cup_day">Lenktynės, sustabdančios tautą</string>
     <string name="holiday_banner_mexico_benito_juarez_birthday">Pagerbiant Benito Juárezą</string>
     <string name="holiday_banner_mexico_constitution_day">Su Konstitucijos diena</string>
@@ -1014,7 +1014,7 @@ What is NOT overridden, by design:
     <string name="holiday_banner_orthodox_christmas">Su Stačiatikių Kalėdomis</string>
     <string name="holiday_banner_pakistan_day">Su Pakistano diena</string>
     <string name="holiday_banner_pakistan_independence_day">Su Nepriklausomybės diena</string>
-    <string name="holiday_banner_palm_sunday">Osana aukštybėse</string>
+    <string name="holiday_banner_palm_sunday">Verbų sekmadienis</string>
     <string name="holiday_banner_pentecost">Su Sekminėmis</string>
     <string name="holiday_banner_philippines_bonifacio_day">Su Bonifacio diena</string>
     <string name="holiday_banner_philippines_independence_day">Su Filipinų Nepriklausomybės diena</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -808,7 +808,7 @@ informal "tu"-form throughout ("Apģērb …", "Paņem … līdzi").
     <string name="holiday_banner_st_georges_day">Priecīgu Svētā Georga dienu</string>
     <string name="holiday_banner_anzac_day">Lai neaizmirstu</string>
     <string name="holiday_banner_uk_bank_holiday">Priecīgu bankas brīvdienu</string>
-    <string name="holiday_banner_uk_kings_birthday">Dievs, glāb Karali</string>
+    <string name="holiday_banner_uk_kings_birthday">Daudz laimes Karaļa dzimšanas dienā</string>
     <string name="holiday_banner_japan_greenery_day">Priecīgu Japānas zaļumu dienu</string>
     <string name="holiday_banner_croatia_statehood_day">Priecīgu Horvātijas valstiskuma dienu</string>
     <string name="holiday_banner_us_memorial_day">Godinām kritušos</string>
@@ -932,7 +932,7 @@ informal "tu"-form throughout ("Apģērb …", "Paņem … līdzi").
     <string name="holiday_banner_argentina_independence_day">Priecīgu Argentīnas Neatkarības dienu</string>
     <string name="holiday_banner_argentina_may_revolution">Priecīgu Maija revolūcijas dienu</string>
     <string name="holiday_banner_ascension_day">Priecīgu Debesbraukšanas dienu</string>
-    <string name="holiday_banner_ash_wednesday">Atceries, ka esi pīšļi</string>
+    <string name="holiday_banner_ash_wednesday">Pelnu trešdiena</string>
     <string name="holiday_banner_bangladesh_independence_day">Priecīgu Neatkarības dienu</string>
     <string name="holiday_banner_bangladesh_victory_day">Priecīgu Uzvaras dienu</string>
     <string name="holiday_banner_brazil_black_awareness">Melnās apziņas diena</string>
@@ -955,7 +955,7 @@ informal "tu"-form throughout ("Apģērb …", "Paņem … līdzi").
     <string name="holiday_banner_malaysia_day">Priecīgu Malaizijas dienu</string>
     <string name="holiday_banner_malaysia_independence_day">Priecīgu Merdeka dienu</string>
     <string name="holiday_banner_mardi_gras">Priecīgu Vastlavju</string>
-    <string name="holiday_banner_maundy_thursday">Jauns bauslis</string>
+    <string name="holiday_banner_maundy_thursday">Zaļā ceturtdiena</string>
     <string name="holiday_banner_melbourne_cup_day">Skrējiens, kas aptur nāciju</string>
     <string name="holiday_banner_mexico_benito_juarez_birthday">Godinot Benito Huaresu</string>
     <string name="holiday_banner_mexico_constitution_day">Priecīgu Konstitūcijas dienu</string>
@@ -967,7 +967,7 @@ informal "tu"-form throughout ("Apģērb …", "Paņem … līdzi").
     <string name="holiday_banner_orthodox_christmas">Priecīgus Pareizticīgo Ziemassvētkus</string>
     <string name="holiday_banner_pakistan_day">Priecīgu Pakistānas dienu</string>
     <string name="holiday_banner_pakistan_independence_day">Priecīgu Neatkarības dienu</string>
-    <string name="holiday_banner_palm_sunday">Hosanna augstībā</string>
+    <string name="holiday_banner_palm_sunday">Pūpolsvētdiena</string>
     <string name="holiday_banner_pentecost">Priecīgus Vasarsvētkus</string>
     <string name="holiday_banner_philippines_bonifacio_day">Priecīgu Bonifācio dienu</string>
     <string name="holiday_banner_philippines_independence_day">Priecīgu Filipīnu Neatkarības dienu</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -801,7 +801,7 @@ vs "kemungkinan", "padam" vs "hapus").
     <string name="holiday_banner_st_georges_day">Selamat Hari Saint George</string>
     <string name="holiday_banner_st_patricks_day">Selamat Hari Saint Patrick</string>
     <string name="holiday_banner_uk_bank_holiday">Selamat cuti bank</string>
-    <string name="holiday_banner_uk_kings_birthday">God save the King</string>
+    <string name="holiday_banner_uk_kings_birthday">Selamat Hari Lahir Raja</string>
     <string name="holiday_banner_uk_mothering_sunday">Selamat Hari Ibu</string>
     <string name="holiday_banner_us_independence_day">Selamat 4 Julai</string>
     <string name="holiday_banner_us_memorial_day">Menghormati mereka yang gugur</string>
@@ -998,7 +998,7 @@ vs "kemungkinan", "padam" vs "hapus").
     <string name="holiday_banner_argentina_independence_day">Selamat Hari Kemerdekaan Argentina</string>
     <string name="holiday_banner_argentina_may_revolution">Selamat Hari Revolusi Mei</string>
     <string name="holiday_banner_ascension_day">Selamat Hari Kenaikan</string>
-    <string name="holiday_banner_ash_wednesday">Ingatlah bahawa kamu debu</string>
+    <string name="holiday_banner_ash_wednesday">Rabu Abu</string>
     <string name="holiday_banner_bangladesh_independence_day">Selamat Hari Kemerdekaan</string>
     <string name="holiday_banner_bangladesh_victory_day">Selamat Hari Kemenangan</string>
     <string name="holiday_banner_brazil_black_awareness">Hari Kesadaran Kulit Hitam</string>
@@ -1021,7 +1021,7 @@ vs "kemungkinan", "padam" vs "hapus").
     <string name="holiday_banner_malaysia_day">Selamat Hari Malaysia</string>
     <string name="holiday_banner_malaysia_independence_day">Selamat Hari Merdeka</string>
     <string name="holiday_banner_mardi_gras">Selamat Mardi Gras</string>
-    <string name="holiday_banner_maundy_thursday">Perintah baharu</string>
+    <string name="holiday_banner_maundy_thursday">Kamis Putih</string>
     <string name="holiday_banner_melbourne_cup_day">Perlumbaan yang menghentikan negara</string>
     <string name="holiday_banner_mexico_benito_juarez_birthday">Mengenang Benito Juárez</string>
     <string name="holiday_banner_mexico_constitution_day">Selamat Hari Konstitusi</string>
@@ -1033,7 +1033,7 @@ vs "kemungkinan", "padam" vs "hapus").
     <string name="holiday_banner_orthodox_christmas">Selamat Krismas Ortodoks</string>
     <string name="holiday_banner_pakistan_day">Selamat Hari Pakistan</string>
     <string name="holiday_banner_pakistan_independence_day">Selamat Hari Kemerdekaan</string>
-    <string name="holiday_banner_palm_sunday">Hosana di tempat tertinggi</string>
+    <string name="holiday_banner_palm_sunday">Ahad Palma</string>
     <string name="holiday_banner_pentecost">Selamat Pentakosta</string>
     <string name="holiday_banner_philippines_bonifacio_day">Selamat Hari Bonifacio</string>
     <string name="holiday_banner_philippines_independence_day">Selamat Hari Kemerdekaan Filipina</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -916,7 +916,7 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrike)").
     <string name="holiday_banner_st_davids_day">God Sankta Davids dag</string>
     <string name="holiday_banner_st_georges_day">God Sankta Georgs dag</string>
     <string name="holiday_banner_uk_bank_holiday">God helligdag</string>
-    <string name="holiday_banner_uk_kings_birthday">God save the King</string>
+    <string name="holiday_banner_uk_kings_birthday">Gratulerer med kongens fødselsdag</string>
     <string name="holiday_banner_uk_mothering_sunday">God Morsdag (UK)</string>
     <string name="holiday_banner_us_independence_day">God 4. juli</string>
     <string name="holiday_banner_us_memorial_day">Vi hedrer våre falne</string>
@@ -1020,7 +1020,7 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrike)").
     <string name="holiday_banner_argentina_independence_day">Gratulerer med Argentinas uavhengighetsdag</string>
     <string name="holiday_banner_argentina_may_revolution">Gratulerer med mairevolusjonen</string>
     <string name="holiday_banner_ascension_day">Gratulerer med Kristi himmelfartsdag</string>
-    <string name="holiday_banner_ash_wednesday">Husk at du er støv</string>
+    <string name="holiday_banner_ash_wednesday">Askeonsdag</string>
     <string name="holiday_banner_bangladesh_independence_day">Gratulerer med uavhengighetsdagen</string>
     <string name="holiday_banner_bangladesh_victory_day">Gratulerer med seiersdagen</string>
     <string name="holiday_banner_brazil_black_awareness">Dagen for svart bevissthet</string>
@@ -1043,7 +1043,7 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrike)").
     <string name="holiday_banner_malaysia_day">Gratulerer med Malaysia-dagen</string>
     <string name="holiday_banner_malaysia_independence_day">Gratulerer med Merdeka-dagen</string>
     <string name="holiday_banner_mardi_gras">God fetetirsdag</string>
-    <string name="holiday_banner_maundy_thursday">Et nytt bud</string>
+    <string name="holiday_banner_maundy_thursday">Skjærtorsdag</string>
     <string name="holiday_banner_melbourne_cup_day">Løpet som stopper en nasjon</string>
     <string name="holiday_banner_mexico_benito_juarez_birthday">Til ære for Benito Juárez</string>
     <string name="holiday_banner_mexico_constitution_day">Gratulerer med grunnlovsdagen</string>
@@ -1055,7 +1055,7 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrike)").
     <string name="holiday_banner_orthodox_christmas">God ortodoks jul</string>
     <string name="holiday_banner_pakistan_day">Gratulerer med Pakistan-dagen</string>
     <string name="holiday_banner_pakistan_independence_day">Gratulerer med uavhengighetsdagen</string>
-    <string name="holiday_banner_palm_sunday">Hosianna i det høyeste</string>
+    <string name="holiday_banner_palm_sunday">Palmesøndag</string>
     <string name="holiday_banner_pentecost">God pinse</string>
     <string name="holiday_banner_philippines_bonifacio_day">Gratulerer med Bonifacio-dagen</string>
     <string name="holiday_banner_philippines_independence_day">Gratulerer med Filippinenes uavhengighetsdag</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -935,7 +935,7 @@ the displayed label localizes.
     <string name="holiday_banner_st_davids_day">Fijne Sint-Daviddag</string>
     <string name="holiday_banner_st_georges_day">Fijne Sint-Jorisddag</string>
     <string name="holiday_banner_uk_bank_holiday">Fijne bankfeestdag</string>
-    <string name="holiday_banner_uk_kings_birthday">God save the King</string>
+    <string name="holiday_banner_uk_kings_birthday">Fijne verjaardag van de Koning</string>
     <string name="holiday_banner_uk_mothering_sunday">Fijne Moederzondag</string>
     <string name="holiday_banner_us_independence_day">Fijne Vierde Juli</string>
     <string name="holiday_banner_us_memorial_day">Wij herdenken onze gevallenen</string>
@@ -1039,7 +1039,7 @@ the displayed label localizes.
     <string name="holiday_banner_argentina_independence_day">Fijne Onafhankelijkheidsdag van Argentinië</string>
     <string name="holiday_banner_argentina_may_revolution">Fijne Meirevolutie</string>
     <string name="holiday_banner_ascension_day">Fijne Hemelvaartsdag</string>
-    <string name="holiday_banner_ash_wednesday">Gedenk dat je stof bent</string>
+    <string name="holiday_banner_ash_wednesday">Aswoensdag</string>
     <string name="holiday_banner_bangladesh_independence_day">Fijne Onafhankelijkheidsdag</string>
     <string name="holiday_banner_bangladesh_victory_day">Fijne Overwinningsdag</string>
     <string name="holiday_banner_brazil_black_awareness">Dag van het Zwarte Bewustzijn</string>
@@ -1062,7 +1062,7 @@ the displayed label localizes.
     <string name="holiday_banner_malaysia_day">Fijne Dag van Maleisië</string>
     <string name="holiday_banner_malaysia_independence_day">Fijne Merdeka-dag</string>
     <string name="holiday_banner_mardi_gras">Fijne Vastenavond</string>
-    <string name="holiday_banner_maundy_thursday">Een nieuw gebod</string>
+    <string name="holiday_banner_maundy_thursday">Witte Donderdag</string>
     <string name="holiday_banner_melbourne_cup_day">De race die een natie stilzet</string>
     <string name="holiday_banner_mexico_benito_juarez_birthday">Ter ere van Benito Juárez</string>
     <string name="holiday_banner_mexico_constitution_day">Fijne Dag van de Grondwet</string>
@@ -1074,7 +1074,7 @@ the displayed label localizes.
     <string name="holiday_banner_orthodox_christmas">Vrolijk Orthodox Kerstfeest</string>
     <string name="holiday_banner_pakistan_day">Fijne Pakistandag</string>
     <string name="holiday_banner_pakistan_independence_day">Fijne Onafhankelijkheidsdag</string>
-    <string name="holiday_banner_palm_sunday">Hosanna in den hoge</string>
+    <string name="holiday_banner_palm_sunday">Palmzondag</string>
     <string name="holiday_banner_pentecost">Fijne Pinksteren</string>
     <string name="holiday_banner_philippines_bonifacio_day">Fijne Bonifacio-dag</string>
     <string name="holiday_banner_philippines_independence_day">Fijne Filipijnse Onafhankelijkheidsdag</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -913,7 +913,7 @@ is unchanged; only the displayed label localizes.
     <string name="holiday_banner_st_georges_day">Wesołego Dnia Świętego Jerzego</string>
     <string name="holiday_banner_anzac_day">Wspominamy poległych</string>
     <string name="holiday_banner_uk_bank_holiday">Wesołego dnia wolnego</string>
-    <string name="holiday_banner_uk_kings_birthday">Niech żyje Król</string>
+    <string name="holiday_banner_uk_kings_birthday">Wszystkiego najlepszego dla Króla</string>
     <string name="holiday_banner_japan_greenery_day">Wesołego Dnia Zieleni</string>
     <string name="holiday_banner_croatia_statehood_day">Wesołego Dnia Państwowości Chorwacji</string>
     <string name="holiday_banner_us_memorial_day">Wspominamy poległych</string>
@@ -1037,7 +1037,7 @@ is unchanged; only the displayed label localizes.
     <string name="holiday_banner_argentina_independence_day">Wesołego Dnia Niepodległości Argentyny</string>
     <string name="holiday_banner_argentina_may_revolution">Wesołej Rewolucji Majowej</string>
     <string name="holiday_banner_ascension_day">Wesołego Wniebowstąpienia</string>
-    <string name="holiday_banner_ash_wednesday">Pamiętaj, że prochem jesteś</string>
+    <string name="holiday_banner_ash_wednesday">Środa Popielcowa</string>
     <string name="holiday_banner_bangladesh_independence_day">Wesołego Dnia Niepodległości</string>
     <string name="holiday_banner_bangladesh_victory_day">Wesołego Dnia Zwycięstwa</string>
     <string name="holiday_banner_brazil_black_awareness">Dzień Świadomości Czarnych</string>
@@ -1060,7 +1060,7 @@ is unchanged; only the displayed label localizes.
     <string name="holiday_banner_malaysia_day">Wesołego Dnia Malezji</string>
     <string name="holiday_banner_malaysia_independence_day">Wesołego Dnia Merdeka</string>
     <string name="holiday_banner_mardi_gras">Wesołego Ostatków</string>
-    <string name="holiday_banner_maundy_thursday">Nowe przykazanie</string>
+    <string name="holiday_banner_maundy_thursday">Wielki Czwartek</string>
     <string name="holiday_banner_melbourne_cup_day">Wyścig, który zatrzymuje naród</string>
     <string name="holiday_banner_mexico_benito_juarez_birthday">Ku czci Benita Juáreza</string>
     <string name="holiday_banner_mexico_constitution_day">Wesołego Dnia Konstytucji</string>
@@ -1072,7 +1072,7 @@ is unchanged; only the displayed label localizes.
     <string name="holiday_banner_orthodox_christmas">Wesołych Świąt Prawosławnego Bożego Narodzenia</string>
     <string name="holiday_banner_pakistan_day">Wesołego Dnia Pakistanu</string>
     <string name="holiday_banner_pakistan_independence_day">Wesołego Dnia Niepodległości</string>
-    <string name="holiday_banner_palm_sunday">Hosanna na wysokościach</string>
+    <string name="holiday_banner_palm_sunday">Niedziela Palmowa</string>
     <string name="holiday_banner_pentecost">Wesołej Zesłania Ducha Świętego</string>
     <string name="holiday_banner_philippines_bonifacio_day">Wesołego Dnia Bonifacio</string>
     <string name="holiday_banner_philippines_independence_day">Wesołego Dnia Niepodległości Filipin</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -952,7 +952,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="holiday_banner_st_georges_day">Feliz Dia de São Jorge</string>
     <string name="holiday_banner_anzac_day">Que nunca esqueçamos</string>
     <string name="holiday_banner_uk_bank_holiday">Feliz feriado bancário</string>
-    <string name="holiday_banner_uk_kings_birthday">Deus salve o Rei</string>
+    <string name="holiday_banner_uk_kings_birthday">Feliz Aniversário do Rei</string>
     <string name="holiday_banner_japan_greenery_day">Feliz Dia da Natureza Japonesa</string>
     <string name="holiday_banner_croatia_statehood_day">Feliz Dia da Estadualidade Croata</string>
     <string name="holiday_banner_us_memorial_day">Em honra dos nossos heróis caídos</string>
@@ -1076,7 +1076,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="holiday_banner_argentina_independence_day">Feliz Dia da Independência da Argentina</string>
     <string name="holiday_banner_argentina_may_revolution">Feliz Revolução de Maio</string>
     <string name="holiday_banner_ascension_day">Feliz Ascensão</string>
-    <string name="holiday_banner_ash_wednesday">Lembra-te de que és pó</string>
+    <string name="holiday_banner_ash_wednesday">Quarta-feira de Cinzas</string>
     <string name="holiday_banner_bangladesh_independence_day">Feliz Dia da Independência</string>
     <string name="holiday_banner_bangladesh_victory_day">Feliz Dia da Vitória</string>
     <string name="holiday_banner_brazil_black_awareness">Dia da Consciência Negra</string>
@@ -1099,7 +1099,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="holiday_banner_malaysia_day">Feliz Dia da Malásia</string>
     <string name="holiday_banner_malaysia_independence_day">Feliz Dia da Merdeka</string>
     <string name="holiday_banner_mardi_gras">Feliz Terça-feira Gorda</string>
-    <string name="holiday_banner_maundy_thursday">Um novo mandamento</string>
+    <string name="holiday_banner_maundy_thursday">Quinta-feira Santa</string>
     <string name="holiday_banner_melbourne_cup_day">A corrida que para a nação</string>
     <string name="holiday_banner_mexico_benito_juarez_birthday">Em homenagem a Benito Juárez</string>
     <string name="holiday_banner_mexico_constitution_day">Feliz Dia da Constituição</string>
@@ -1111,7 +1111,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="holiday_banner_orthodox_christmas">Feliz Natal Ortodoxo</string>
     <string name="holiday_banner_pakistan_day">Feliz Dia do Paquistão</string>
     <string name="holiday_banner_pakistan_independence_day">Feliz Dia da Independência</string>
-    <string name="holiday_banner_palm_sunday">Hosana nas alturas</string>
+    <string name="holiday_banner_palm_sunday">Domingo de Ramos</string>
     <string name="holiday_banner_pentecost">Feliz Pentecostes</string>
     <string name="holiday_banner_philippines_bonifacio_day">Feliz Dia de Bonifacio</string>
     <string name="holiday_banner_philippines_independence_day">Feliz Dia da Independência das Filipinas</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -994,7 +994,7 @@ they diverge from BR ("Polonês" → "Polaco", "Holandês" →
     <string name="holiday_banner_st_georges_day">Feliz Dia de São Jorge</string>
     <string name="holiday_banner_anzac_day">Que nunca esqueçamos</string>
     <string name="holiday_banner_uk_bank_holiday">Feliz feriado bancário</string>
-    <string name="holiday_banner_uk_kings_birthday">Deus salve o Rei</string>
+    <string name="holiday_banner_uk_kings_birthday">Feliz Aniversário do Rei</string>
     <string name="holiday_banner_japan_greenery_day">Feliz Dia da Natureza Japonesa</string>
     <string name="holiday_banner_croatia_statehood_day">Feliz Dia da Estadualidade Croata</string>
     <string name="holiday_banner_us_memorial_day">Em honra dos nossos heróis caídos</string>
@@ -1119,7 +1119,7 @@ they diverge from BR ("Polonês" → "Polaco", "Holandês" →
     <string name="holiday_banner_argentina_independence_day">Feliz Dia da Independência da Argentina</string>
     <string name="holiday_banner_argentina_may_revolution">Feliz Revolução de Maio</string>
     <string name="holiday_banner_ascension_day">Feliz Ascensão</string>
-    <string name="holiday_banner_ash_wednesday">Lembra-te de que és pó</string>
+    <string name="holiday_banner_ash_wednesday">Quarta-feira de Cinzas</string>
     <string name="holiday_banner_bangladesh_independence_day">Feliz Dia da Independência</string>
     <string name="holiday_banner_bangladesh_victory_day">Feliz Dia da Vitória</string>
     <string name="holiday_banner_brazil_black_awareness">Dia da Consciência Negra</string>
@@ -1142,7 +1142,7 @@ they diverge from BR ("Polonês" → "Polaco", "Holandês" →
     <string name="holiday_banner_malaysia_day">Feliz Dia da Malásia</string>
     <string name="holiday_banner_malaysia_independence_day">Feliz Dia da Merdeka</string>
     <string name="holiday_banner_mardi_gras">Feliz Terça-feira Gorda</string>
-    <string name="holiday_banner_maundy_thursday">Um novo mandamento</string>
+    <string name="holiday_banner_maundy_thursday">Quinta-feira Santa</string>
     <string name="holiday_banner_melbourne_cup_day">A corrida que pára a nação</string>
     <string name="holiday_banner_mexico_benito_juarez_birthday">Em homenagem a Benito Juárez</string>
     <string name="holiday_banner_mexico_constitution_day">Feliz Dia da Constituição</string>
@@ -1154,7 +1154,7 @@ they diverge from BR ("Polonês" → "Polaco", "Holandês" →
     <string name="holiday_banner_orthodox_christmas">Feliz Natal Ortodoxo</string>
     <string name="holiday_banner_pakistan_day">Feliz Dia do Paquistão</string>
     <string name="holiday_banner_pakistan_independence_day">Feliz Dia da Independência</string>
-    <string name="holiday_banner_palm_sunday">Hossana nas alturas</string>
+    <string name="holiday_banner_palm_sunday">Domingo de Ramos</string>
     <string name="holiday_banner_pentecost">Feliz Pentecostes</string>
     <string name="holiday_banner_philippines_bonifacio_day">Feliz Dia de Bonifacio</string>
     <string name="holiday_banner_philippines_independence_day">Feliz Dia da Independência das Filipinas</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -968,7 +968,7 @@ surfaces fall back to default English (matching values-pl / values-uk).
     <string name="holiday_banner_argentina_independence_day">La mulți ani de Ziua Independenței Argentinei</string>
     <string name="holiday_banner_argentina_may_revolution">La mulți ani de Revoluția din Mai</string>
     <string name="holiday_banner_ascension_day">La mulți ani de Înălțare</string>
-    <string name="holiday_banner_ash_wednesday">Adu-ți aminte că ești țărână</string>
+    <string name="holiday_banner_ash_wednesday">Miercurea Cenușii</string>
     <string name="holiday_banner_bangladesh_independence_day">La mulți ani de Ziua Independenței</string>
     <string name="holiday_banner_bangladesh_victory_day">La mulți ani de Ziua Victoriei</string>
     <string name="holiday_banner_brazil_black_awareness">Ziua Conștiinței Negre</string>
@@ -991,7 +991,7 @@ surfaces fall back to default English (matching values-pl / values-uk).
     <string name="holiday_banner_malaysia_day">La mulți ani de Ziua Malaeziei</string>
     <string name="holiday_banner_malaysia_independence_day">La mulți ani de Ziua Merdeka</string>
     <string name="holiday_banner_mardi_gras">Lăsata Secului veselă</string>
-    <string name="holiday_banner_maundy_thursday">O poruncă nouă</string>
+    <string name="holiday_banner_maundy_thursday">Joia Mare</string>
     <string name="holiday_banner_melbourne_cup_day">Cursa care oprește o națiune</string>
     <string name="holiday_banner_mexico_benito_juarez_birthday">În cinstea lui Benito Juárez</string>
     <string name="holiday_banner_mexico_constitution_day">La mulți ani de Ziua Constituției</string>
@@ -1003,7 +1003,7 @@ surfaces fall back to default English (matching values-pl / values-uk).
     <string name="holiday_banner_orthodox_christmas">Sărbători Fericite de Crăciunul Ortodox</string>
     <string name="holiday_banner_pakistan_day">La mulți ani de Ziua Pakistanului</string>
     <string name="holiday_banner_pakistan_independence_day">La mulți ani de Ziua Independenței</string>
-    <string name="holiday_banner_palm_sunday">Osana întru cei de sus</string>
+    <string name="holiday_banner_palm_sunday">Floriile</string>
     <string name="holiday_banner_pentecost">La mulți ani de Rusalii</string>
     <string name="holiday_banner_philippines_bonifacio_day">La mulți ani de Ziua lui Bonifacio</string>
     <string name="holiday_banner_philippines_independence_day">La mulți ani de Ziua Independenței Filipinelor</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -921,7 +921,7 @@ only the displayed label localizes.
     <string name="holiday_banner_st_georges_day">С Днём святого Георгия</string>
     <string name="holiday_banner_anzac_day">Помним</string>
     <string name="holiday_banner_uk_bank_holiday">С банковским праздником</string>
-    <string name="holiday_banner_uk_kings_birthday">Боже, храни Короля</string>
+    <string name="holiday_banner_uk_kings_birthday">С Днём рождения Короля</string>
     <string name="holiday_banner_japan_greenery_day">С японским Днём зелени</string>
     <string name="holiday_banner_croatia_statehood_day">С Днём государственности Хорватии</string>
     <string name="holiday_banner_us_memorial_day">Чтим память павших</string>
@@ -1045,7 +1045,7 @@ only the displayed label localizes.
     <string name="holiday_banner_argentina_independence_day">С Днём независимости Аргентины</string>
     <string name="holiday_banner_argentina_may_revolution">С Майской революцией</string>
     <string name="holiday_banner_ascension_day">С Вознесением Господним</string>
-    <string name="holiday_banner_ash_wednesday">Помни, что ты — прах</string>
+    <string name="holiday_banner_ash_wednesday">Пепельная среда</string>
     <string name="holiday_banner_bangladesh_independence_day">С Днём независимости</string>
     <string name="holiday_banner_bangladesh_victory_day">С Днём Победы</string>
     <string name="holiday_banner_brazil_black_awareness">День чёрного самосознания</string>
@@ -1068,7 +1068,7 @@ only the displayed label localizes.
     <string name="holiday_banner_malaysia_day">С Днём Малайзии</string>
     <string name="holiday_banner_malaysia_independence_day">С Днём Мердека</string>
     <string name="holiday_banner_mardi_gras">С Жирным вторником</string>
-    <string name="holiday_banner_maundy_thursday">Заповедь новую даю вам</string>
+    <string name="holiday_banner_maundy_thursday">Великий четверг</string>
     <string name="holiday_banner_melbourne_cup_day">Гонка, останавливающая нацию</string>
     <string name="holiday_banner_mexico_benito_juarez_birthday">В честь Бенито Хуареса</string>
     <string name="holiday_banner_mexico_constitution_day">С Днём Конституции</string>
@@ -1080,7 +1080,7 @@ only the displayed label localizes.
     <string name="holiday_banner_orthodox_christmas">С Рождеством Христовым</string>
     <string name="holiday_banner_pakistan_day">С Днём Пакистана</string>
     <string name="holiday_banner_pakistan_independence_day">С Днём независимости</string>
-    <string name="holiday_banner_palm_sunday">Осанна в вышних</string>
+    <string name="holiday_banner_palm_sunday">Вербное воскресенье</string>
     <string name="holiday_banner_pentecost">С Днём Святой Троицы</string>
     <string name="holiday_banner_philippines_bonifacio_day">С Днём Бонифасио</string>
     <string name="holiday_banner_philippines_independence_day">С Днём независимости Филиппин</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -889,7 +889,7 @@ What is NOT overridden, by design:
     <string name="holiday_banner_st_georges_day">Šťastný Deň svätého Juraja</string>
     <string name="holiday_banner_anzac_day">Uctievame padlých</string>
     <string name="holiday_banner_uk_bank_holiday">Šťastný štátny sviatok</string>
-    <string name="holiday_banner_uk_kings_birthday">Boh ochraňuj kráľa</string>
+    <string name="holiday_banner_uk_kings_birthday">Všetko najlepšie k narodeninám kráľa</string>
     <string name="holiday_banner_japan_greenery_day">Šťastný japonský Deň zelene</string>
     <string name="holiday_banner_croatia_statehood_day">Šťastný Deň chorvátskej štátnosti</string>
     <string name="holiday_banner_us_memorial_day">Uctievame padlých</string>
@@ -1013,7 +1013,7 @@ What is NOT overridden, by design:
     <string name="holiday_banner_argentina_independence_day">Šťastný Deň nezávislosti Argentíny</string>
     <string name="holiday_banner_argentina_may_revolution">Šťastná Májová revolúcia</string>
     <string name="holiday_banner_ascension_day">Šťastné Nanebovstúpenie</string>
-    <string name="holiday_banner_ash_wednesday">Pamätaj, že si prach</string>
+    <string name="holiday_banner_ash_wednesday">Popolcová streda</string>
     <string name="holiday_banner_bangladesh_independence_day">Šťastný Deň nezávislosti</string>
     <string name="holiday_banner_bangladesh_victory_day">Šťastný Deň víťazstva</string>
     <string name="holiday_banner_brazil_black_awareness">Deň čierneho povedomia</string>
@@ -1036,7 +1036,7 @@ What is NOT overridden, by design:
     <string name="holiday_banner_malaysia_day">Šťastný Deň Malajzie</string>
     <string name="holiday_banner_malaysia_independence_day">Šťastný Deň Merdeka</string>
     <string name="holiday_banner_mardi_gras">Veselé Fašiangy</string>
-    <string name="holiday_banner_maundy_thursday">Nové prikázanie</string>
+    <string name="holiday_banner_maundy_thursday">Zelený štvrtok</string>
     <string name="holiday_banner_melbourne_cup_day">Preteky, ktoré zastavujú národ</string>
     <string name="holiday_banner_mexico_benito_juarez_birthday">Na počesť Benita Juáreza</string>
     <string name="holiday_banner_mexico_constitution_day">Šťastný Deň ústavy</string>
@@ -1048,7 +1048,7 @@ What is NOT overridden, by design:
     <string name="holiday_banner_orthodox_christmas">Veselé pravoslávne Vianoce</string>
     <string name="holiday_banner_pakistan_day">Šťastný Deň Pakistanu</string>
     <string name="holiday_banner_pakistan_independence_day">Šťastný Deň nezávislosti</string>
-    <string name="holiday_banner_palm_sunday">Hosanna na výsostiach</string>
+    <string name="holiday_banner_palm_sunday">Kvetná nedeľa</string>
     <string name="holiday_banner_pentecost">Veselé Turíce</string>
     <string name="holiday_banner_philippines_bonifacio_day">Šťastný Deň Bonifacia</string>
     <string name="holiday_banner_philippines_independence_day">Šťastný Deň nezávislosti Filipín</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -976,7 +976,7 @@ informal "ti"-form throughout, mirroring the Croatian / Serbian pass.
     <string name="holiday_banner_argentina_independence_day">Vesel dan neodvisnosti Argentine</string>
     <string name="holiday_banner_argentina_may_revolution">Vesel dan majniške revolucije</string>
     <string name="holiday_banner_ascension_day">Vesel praznik Gospodovega vnebohoda</string>
-    <string name="holiday_banner_ash_wednesday">Spomni se, da si prah</string>
+    <string name="holiday_banner_ash_wednesday">Pepelnična sreda</string>
     <string name="holiday_banner_bangladesh_independence_day">Vesel dan neodvisnosti</string>
     <string name="holiday_banner_bangladesh_victory_day">Vesel dan zmage</string>
     <string name="holiday_banner_brazil_black_awareness">Dan črne zavesti</string>
@@ -999,7 +999,7 @@ informal "ti"-form throughout, mirroring the Croatian / Serbian pass.
     <string name="holiday_banner_malaysia_day">Vesel dan Malezije</string>
     <string name="holiday_banner_malaysia_independence_day">Vesel dan Merdeka</string>
     <string name="holiday_banner_mardi_gras">Vesele pustne dni</string>
-    <string name="holiday_banner_maundy_thursday">Nova zapoved</string>
+    <string name="holiday_banner_maundy_thursday">Veliki četrtek</string>
     <string name="holiday_banner_melbourne_cup_day">Dirka, ki ustavi narod</string>
     <string name="holiday_banner_mexico_benito_juarez_birthday">V čast Benitu Juárezu</string>
     <string name="holiday_banner_mexico_constitution_day">Vesel dan ustave</string>
@@ -1011,7 +1011,7 @@ informal "ti"-form throughout, mirroring the Croatian / Serbian pass.
     <string name="holiday_banner_orthodox_christmas">Vesel pravoslavni božič</string>
     <string name="holiday_banner_pakistan_day">Vesel dan Pakistana</string>
     <string name="holiday_banner_pakistan_independence_day">Vesel dan neodvisnosti</string>
-    <string name="holiday_banner_palm_sunday">Hozana v višavah</string>
+    <string name="holiday_banner_palm_sunday">Cvetna nedelja</string>
     <string name="holiday_banner_pentecost">Vesele binkošti</string>
     <string name="holiday_banner_philippines_bonifacio_day">Vesel Bonifaciov dan</string>
     <string name="holiday_banner_philippines_independence_day">Vesel dan neodvisnosti Filipinov</string>

--- a/app/src/main/res/values-sq/strings.xml
+++ b/app/src/main/res/values-sq/strings.xml
@@ -945,7 +945,7 @@
     <string name="holiday_banner_anzac_day">Që të mos harrojmë</string>
     <string name="holiday_banner_labour_day">Gëzuar Ditën e Punës</string>
     <string name="holiday_banner_uk_bank_holiday">Gëzuar ditën e pushimit</string>
-    <string name="holiday_banner_uk_kings_birthday">Zoti e ruajtë Mbretin</string>
+    <string name="holiday_banner_uk_kings_birthday">Gëzuar ditëlindjen e Mbretit</string>
     <string name="holiday_banner_mothers_day">Gëzuar Ditën e Nënës</string>
     <string name="holiday_banner_japan_greenery_day">Gëzuar Ditën Japoneze të Gjelbërimit</string>
     <string name="holiday_banner_cinco_de_mayo">¡Feliz Cinco de Mayo!</string>
@@ -1102,11 +1102,11 @@
     <string name="holiday_name_mardi_gras">Mardi Gras / E marta e Karnavaleve</string>
     <string name="holiday_banner_mardi_gras">Laissez les bons temps rouler</string>
     <string name="holiday_name_ash_wednesday">E Mërkura e Përhirit</string>
-    <string name="holiday_banner_ash_wednesday">Kujto se je pluhur</string>
+    <string name="holiday_banner_ash_wednesday">E Mërkura e Përhirit</string>
     <string name="holiday_name_palm_sunday">E diela e Palmave</string>
-    <string name="holiday_banner_palm_sunday">Hosana në lartësitë</string>
+    <string name="holiday_banner_palm_sunday">E diela e Palmave</string>
     <string name="holiday_name_maundy_thursday">E enjtja e Madhe</string>
-    <string name="holiday_banner_maundy_thursday">Një urdhërim i ri</string>
+    <string name="holiday_banner_maundy_thursday">E enjtja e Madhe</string>
     <string name="holiday_name_ascension_day">Dita e Të Ngjiturit</string>
     <string name="holiday_banner_ascension_day">Gëzuar Ditën e Ngjitjes</string>
     <string name="holiday_name_pentecost">Rrëshajët</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -916,7 +916,7 @@ native names for all locales (e.g. "Tyska (Tyskland)", "Franska (Frankrike)").
     <string name="holiday_banner_st_davids_day">Glad Sankt Davids dag</string>
     <string name="holiday_banner_st_georges_day">Glad Sankt Georgs dag</string>
     <string name="holiday_banner_uk_bank_holiday">Glad helgdag</string>
-    <string name="holiday_banner_uk_kings_birthday">God save the King</string>
+    <string name="holiday_banner_uk_kings_birthday">Grattis på kungens födelsedag</string>
     <string name="holiday_banner_uk_mothering_sunday">Glad Mors dag (UK)</string>
     <string name="holiday_banner_us_independence_day">Glad 4 juli</string>
     <string name="holiday_banner_us_memorial_day">Hedrar våra fallna</string>
@@ -1020,7 +1020,7 @@ native names for all locales (e.g. "Tyska (Tyskland)", "Franska (Frankrike)").
     <string name="holiday_banner_argentina_independence_day">Grattis på Argentinas självständighetsdag</string>
     <string name="holiday_banner_argentina_may_revolution">Glad majrevolution</string>
     <string name="holiday_banner_ascension_day">Glad Kristi himmelsfärdsdag</string>
-    <string name="holiday_banner_ash_wednesday">Kom ihåg att du är stoft</string>
+    <string name="holiday_banner_ash_wednesday">Askonsdagen</string>
     <string name="holiday_banner_bangladesh_independence_day">Grattis på självständighetsdagen</string>
     <string name="holiday_banner_bangladesh_victory_day">Grattis på segerdagen</string>
     <string name="holiday_banner_brazil_black_awareness">Dagen för svart medvetenhet</string>
@@ -1043,7 +1043,7 @@ native names for all locales (e.g. "Tyska (Tyskland)", "Franska (Frankrike)").
     <string name="holiday_banner_malaysia_day">Glad Malaysia-dag</string>
     <string name="holiday_banner_malaysia_independence_day">Glad Merdeka-dag</string>
     <string name="holiday_banner_mardi_gras">Glad fettisdag</string>
-    <string name="holiday_banner_maundy_thursday">Ett nytt bud</string>
+    <string name="holiday_banner_maundy_thursday">Skärtorsdag</string>
     <string name="holiday_banner_melbourne_cup_day">Loppet som stoppar en nation</string>
     <string name="holiday_banner_mexico_benito_juarez_birthday">Till minne av Benito Juárez</string>
     <string name="holiday_banner_mexico_constitution_day">Glad grundlagsdag</string>
@@ -1055,7 +1055,7 @@ native names for all locales (e.g. "Tyska (Tyskland)", "Franska (Frankrike)").
     <string name="holiday_banner_orthodox_christmas">God ortodox jul</string>
     <string name="holiday_banner_pakistan_day">Glad Pakistan-dag</string>
     <string name="holiday_banner_pakistan_independence_day">Grattis på självständighetsdagen</string>
-    <string name="holiday_banner_palm_sunday">Hosianna i höjden</string>
+    <string name="holiday_banner_palm_sunday">Palmsöndagen</string>
     <string name="holiday_banner_pentecost">Glad pingst</string>
     <string name="holiday_banner_philippines_bonifacio_day">Glad Bonifacio-dag</string>
     <string name="holiday_banner_philippines_independence_day">Grattis på Filippinernas självständighetsdag</string>

--- a/app/src/main/res/values-sw/strings.xml
+++ b/app/src/main/res/values-sw/strings.xml
@@ -681,7 +681,7 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="holiday_banner_st_georges_day">Siku ya Mtakatifu George</string>
     <string name="holiday_banner_st_patricks_day">Siku ya Mtakatifu Patrick</string>
     <string name="holiday_banner_uk_bank_holiday">Heri ya likizo ya benki</string>
-    <string name="holiday_banner_uk_kings_birthday">Mungu Amlinde Mfalme</string>
+    <string name="holiday_banner_uk_kings_birthday">Heri ya Kuzaliwa kwa Mfalme</string>
     <string name="holiday_banner_uk_mothering_sunday">Heri ya Jumapili ya Mama</string>
     <string name="holiday_banner_us_independence_day">Heri ya Julai 4</string>
     <string name="holiday_banner_us_memorial_day">Heshima kwa walioanguka wetu</string>
@@ -960,7 +960,7 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="holiday_banner_argentina_independence_day">Heri ya Siku ya Uhuru wa Argentina</string>
     <string name="holiday_banner_argentina_may_revolution">Heri ya Mapinduzi ya Mei</string>
     <string name="holiday_banner_ascension_day">Heri ya Siku ya Kupaa</string>
-    <string name="holiday_banner_ash_wednesday">Kumbuka kuwa wewe ni mavumbi</string>
+    <string name="holiday_banner_ash_wednesday">Jumatano ya Majivu</string>
     <string name="holiday_banner_bangladesh_independence_day">Heri ya Siku ya Uhuru</string>
     <string name="holiday_banner_bangladesh_victory_day">Heri ya Siku ya Ushindi</string>
     <string name="holiday_banner_brazil_black_awareness">Siku ya Uelewa wa Watu Weusi</string>
@@ -983,7 +983,7 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="holiday_banner_malaysia_day">Heri ya Siku ya Malaysia</string>
     <string name="holiday_banner_malaysia_independence_day">Heri ya Siku ya Merdeka</string>
     <string name="holiday_banner_mardi_gras">Heri ya Mardi Gras</string>
-    <string name="holiday_banner_maundy_thursday">Amri mpya</string>
+    <string name="holiday_banner_maundy_thursday">Alhamisi Kuu</string>
     <string name="holiday_banner_melbourne_cup_day">Mbio zinazosimamisha taifa</string>
     <string name="holiday_banner_mexico_benito_juarez_birthday">Kumheshimu Benito Juárez</string>
     <string name="holiday_banner_mexico_constitution_day">Heri ya Siku ya Katiba</string>
@@ -995,7 +995,7 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="holiday_banner_orthodox_christmas">Heri ya Krismasi ya Othodoksi</string>
     <string name="holiday_banner_pakistan_day">Heri ya Siku ya Pakistan</string>
     <string name="holiday_banner_pakistan_independence_day">Heri ya Siku ya Uhuru</string>
-    <string name="holiday_banner_palm_sunday">Hosana juu mbinguni</string>
+    <string name="holiday_banner_palm_sunday">Jumapili ya Matawi</string>
     <string name="holiday_banner_pentecost">Heri ya Pentekoste</string>
     <string name="holiday_banner_philippines_bonifacio_day">Heri ya Siku ya Bonifacio</string>
     <string name="holiday_banner_philippines_independence_day">Heri ya Siku ya Uhuru wa Ufilipino</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -795,7 +795,7 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="holiday_banner_st_georges_day">สุขสันต์วันนักบุญจอร์จ</string>
     <string name="holiday_banner_st_patricks_day">สุขสันต์วันนักบุญแพทริก</string>
     <string name="holiday_banner_uk_bank_holiday">สุขสันต์วันหยุดธนาคาร</string>
-    <string name="holiday_banner_uk_kings_birthday">ทรงพระเจริญ</string>
+    <string name="holiday_banner_uk_kings_birthday">สุขสันต์วันคล้ายวันพระราชสมภพ</string>
     <string name="holiday_banner_uk_mothering_sunday">สุขสันต์วันแม่</string>
     <string name="holiday_banner_us_independence_day">สุขสันต์วันที่ 4 กรกฎาคม</string>
     <string name="holiday_banner_us_memorial_day">รำลึกถึงวีรชน</string>
@@ -992,7 +992,7 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="holiday_banner_argentina_independence_day">สุขสันต์วันประกาศอิสรภาพอาร์เจนตินา</string>
     <string name="holiday_banner_argentina_may_revolution">สุขสันต์วันปฏิวัติเดือนพฤษภาคม</string>
     <string name="holiday_banner_ascension_day">สุขสันต์วันเสด็จขึ้นสวรรค์</string>
-    <string name="holiday_banner_ash_wednesday">จงระลึกว่าเจ้าเป็นผงคลีดิน</string>
+    <string name="holiday_banner_ash_wednesday">วันพุธรับเถ้า</string>
     <string name="holiday_banner_bangladesh_independence_day">สุขสันต์วันประกาศอิสรภาพ</string>
     <string name="holiday_banner_bangladesh_victory_day">สุขสันต์วันแห่งชัยชนะ</string>
     <string name="holiday_banner_brazil_black_awareness">วันแห่งการตระหนักรู้ของคนผิวดำ</string>
@@ -1015,7 +1015,7 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="holiday_banner_malaysia_day">สุขสันต์วันมาเลเซีย</string>
     <string name="holiday_banner_malaysia_independence_day">สุขสันต์วันแมร์เดก้า</string>
     <string name="holiday_banner_mardi_gras">สุขสันต์วันมาร์ดิกรา</string>
-    <string name="holiday_banner_maundy_thursday">บัญญัติใหม่</string>
+    <string name="holiday_banner_maundy_thursday">วันพฤหัสบดีศักดิ์สิทธิ์</string>
     <string name="holiday_banner_melbourne_cup_day">การแข่งขันที่หยุดทั้งชาติ</string>
     <string name="holiday_banner_mexico_benito_juarez_birthday">ระลึกถึงเบนิโต ฮัวเรซ</string>
     <string name="holiday_banner_mexico_constitution_day">สุขสันต์วันรัฐธรรมนูญ</string>
@@ -1027,7 +1027,7 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="holiday_banner_orthodox_christmas">สุขสันต์วันคริสต์มาสออร์โธดอกซ์</string>
     <string name="holiday_banner_pakistan_day">สุขสันต์วันปากีสถาน</string>
     <string name="holiday_banner_pakistan_independence_day">สุขสันต์วันประกาศอิสรภาพ</string>
-    <string name="holiday_banner_palm_sunday">โฮซันนาในสวรรค์</string>
+    <string name="holiday_banner_palm_sunday">วันอาทิตย์ใบลาน</string>
     <string name="holiday_banner_pentecost">สุขสันต์วันเพ็นเทคอสต์</string>
     <string name="holiday_banner_philippines_bonifacio_day">สุขสันต์วันโบนิฟาซิโอ</string>
     <string name="holiday_banner_philippines_independence_day">สุขสันต์วันประกาศอิสรภาพฟิลิปปินส์</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -713,7 +713,7 @@ displayed label localizes.
     <string name="holiday_banner_st_georges_day">Aziz Georgios Günün kutlu olsun</string>
     <string name="holiday_banner_st_patricks_day">Aziz Patrick Günün kutlu olsun</string>
     <string name="holiday_banner_uk_bank_holiday">Resmî tatil kutlu olsun</string>
-    <string name="holiday_banner_uk_kings_birthday">Tanrı Kral\'ı korusun</string>
+    <string name="holiday_banner_uk_kings_birthday">Kral\'ın Doğum Günü kutlu olsun</string>
     <string name="holiday_banner_uk_mothering_sunday">Anneler Pazar Günün kutlu olsun</string>
     <string name="holiday_banner_us_independence_day">4 Temmuz\'unuz kutlu olsun</string>
     <string name="holiday_banner_us_memorial_day">Şehitlerimizi anıyoruz</string>
@@ -991,7 +991,7 @@ displayed label localizes.
     <string name="holiday_banner_argentina_independence_day">Arjantin Bağımsızlık Günü kutlu olsun</string>
     <string name="holiday_banner_argentina_may_revolution">Mayıs Devrimi kutlu olsun</string>
     <string name="holiday_banner_ascension_day">İyi Bayramlar</string>
-    <string name="holiday_banner_ash_wednesday">Topraktan geldiğini unutma</string>
+    <string name="holiday_banner_ash_wednesday">Kül Çarşambası</string>
     <string name="holiday_banner_bangladesh_independence_day">Bağımsızlık Günü kutlu olsun</string>
     <string name="holiday_banner_bangladesh_victory_day">Zafer Günü kutlu olsun</string>
     <string name="holiday_banner_brazil_black_awareness">Siyahların Bilinçlenme Günü</string>
@@ -1014,7 +1014,7 @@ displayed label localizes.
     <string name="holiday_banner_malaysia_day">Malezya Günü kutlu olsun</string>
     <string name="holiday_banner_malaysia_independence_day">Merdeka Günü kutlu olsun</string>
     <string name="holiday_banner_mardi_gras">İyi Mardi Gras</string>
-    <string name="holiday_banner_maundy_thursday">Yeni bir buyruk</string>
+    <string name="holiday_banner_maundy_thursday">Kutsal Perşembe</string>
     <string name="holiday_banner_melbourne_cup_day">Ulusu durduran yarış</string>
     <string name="holiday_banner_mexico_benito_juarez_birthday">Benito Juárez anısına</string>
     <string name="holiday_banner_mexico_constitution_day">Anayasa Günü kutlu olsun</string>
@@ -1026,7 +1026,7 @@ displayed label localizes.
     <string name="holiday_banner_orthodox_christmas">Mutlu Ortodoks Noeli</string>
     <string name="holiday_banner_pakistan_day">Pakistan Günü kutlu olsun</string>
     <string name="holiday_banner_pakistan_independence_day">Bağımsızlık Günü kutlu olsun</string>
-    <string name="holiday_banner_palm_sunday">Göklerin yücesinde hozana</string>
+    <string name="holiday_banner_palm_sunday">Hurma Pazarı</string>
     <string name="holiday_banner_pentecost">Mutlu Pentekost</string>
     <string name="holiday_banner_philippines_bonifacio_day">Bonifacio Günü kutlu olsun</string>
     <string name="holiday_banner_philippines_independence_day">Filipinler Bağımsızlık Günü kutlu olsun</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -864,7 +864,7 @@ only the displayed label localizes.
     <string name="holiday_banner_st_georges_day">З Днем святого Георгія</string>
     <string name="holiday_banner_anzac_day">Пам\'ятаємо</string>
     <string name="holiday_banner_uk_bank_holiday">З банківським святом</string>
-    <string name="holiday_banner_uk_kings_birthday">Боже, бережи Короля</string>
+    <string name="holiday_banner_uk_kings_birthday">З Днем народження Короля</string>
     <string name="holiday_banner_japan_greenery_day">З японським Днем зелені</string>
     <string name="holiday_banner_croatia_statehood_day">З Днем державності Хорватії</string>
     <string name="holiday_banner_us_memorial_day">Вшановуємо полеглих</string>
@@ -988,7 +988,7 @@ only the displayed label localizes.
     <string name="holiday_banner_argentina_independence_day">Зі святом Дня незалежності Аргентини</string>
     <string name="holiday_banner_argentina_may_revolution">Зі святом Травневої революції</string>
     <string name="holiday_banner_ascension_day">Зі святом Вознесіння</string>
-    <string name="holiday_banner_ash_wednesday">Памʼятай, що ти прах</string>
+    <string name="holiday_banner_ash_wednesday">Попільна середа</string>
     <string name="holiday_banner_bangladesh_independence_day">Зі святом Дня незалежності</string>
     <string name="holiday_banner_bangladesh_victory_day">Зі святом Дня перемоги</string>
     <string name="holiday_banner_brazil_black_awareness">День чорної свідомості</string>
@@ -1011,7 +1011,7 @@ only the displayed label localizes.
     <string name="holiday_banner_malaysia_day">Зі святом Дня Малайзії</string>
     <string name="holiday_banner_malaysia_independence_day">Зі святом Дня Мердека</string>
     <string name="holiday_banner_mardi_gras">Веселого Жирного вівторка</string>
-    <string name="holiday_banner_maundy_thursday">Нова заповідь</string>
+    <string name="holiday_banner_maundy_thursday">Великий четвер</string>
     <string name="holiday_banner_melbourne_cup_day">Перегони, що зупиняють націю</string>
     <string name="holiday_banner_mexico_benito_juarez_birthday">На честь Беніто Хуареса</string>
     <string name="holiday_banner_mexico_constitution_day">Зі святом Дня Конституції</string>
@@ -1023,7 +1023,7 @@ only the displayed label localizes.
     <string name="holiday_banner_orthodox_christmas">З Різдвом Христовим</string>
     <string name="holiday_banner_pakistan_day">Зі святом Дня Пакистану</string>
     <string name="holiday_banner_pakistan_independence_day">Зі святом Дня незалежності</string>
-    <string name="holiday_banner_palm_sunday">Осанна у вишніх</string>
+    <string name="holiday_banner_palm_sunday">Вербна неділя</string>
     <string name="holiday_banner_pentecost">Зі святом Трійці</string>
     <string name="holiday_banner_philippines_bonifacio_day">Зі святом Дня Боніфасіо</string>
     <string name="holiday_banner_philippines_independence_day">Зі святом Дня незалежності Філіппін</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -856,7 +856,7 @@ Skipped intentionally: app_name (brand), insight_time_am/pm/midnight/noon
     <string name="holiday_banner_st_georges_day">Chúc mừng Ngày Thánh George</string>
     <string name="holiday_banner_st_patricks_day">Chúc mừng Ngày Thánh Patrick</string>
     <string name="holiday_banner_uk_bank_holiday">Chúc mừng ngày nghỉ lễ</string>
-    <string name="holiday_banner_uk_kings_birthday">God save the King</string>
+    <string name="holiday_banner_uk_kings_birthday">Chúc mừng Sinh nhật Nhà vua</string>
     <string name="holiday_banner_uk_mothering_sunday">Chúc mừng Chủ nhật Tôn vinh Mẹ</string>
     <string name="holiday_banner_us_independence_day">Chúc mừng Ngày 4 tháng 7</string>
     <string name="holiday_banner_us_memorial_day">Tưởng niệm những người đã ngã xuống</string>
@@ -1053,7 +1053,7 @@ Skipped intentionally: app_name (brand), insight_time_am/pm/midnight/noon
     <string name="holiday_banner_argentina_independence_day">Chúc mừng Quốc khánh Argentina</string>
     <string name="holiday_banner_argentina_may_revolution">Chúc mừng Cách mạng tháng Năm</string>
     <string name="holiday_banner_ascension_day">Chúc mừng Lễ Thăng Thiên</string>
-    <string name="holiday_banner_ash_wednesday">Hãy nhớ rằng bạn là cát bụi</string>
+    <string name="holiday_banner_ash_wednesday">Thứ Tư Lễ Tro</string>
     <string name="holiday_banner_bangladesh_independence_day">Chúc mừng Ngày Độc lập</string>
     <string name="holiday_banner_bangladesh_victory_day">Chúc mừng Ngày Chiến thắng</string>
     <string name="holiday_banner_brazil_black_awareness">Ngày Nhận thức Người Da đen</string>
@@ -1076,7 +1076,7 @@ Skipped intentionally: app_name (brand), insight_time_am/pm/midnight/noon
     <string name="holiday_banner_malaysia_day">Chúc mừng Ngày Malaysia</string>
     <string name="holiday_banner_malaysia_independence_day">Chúc mừng Ngày Merdeka</string>
     <string name="holiday_banner_mardi_gras">Chúc mừng Mardi Gras</string>
-    <string name="holiday_banner_maundy_thursday">Một điều răn mới</string>
+    <string name="holiday_banner_maundy_thursday">Thứ Năm Tuần Thánh</string>
     <string name="holiday_banner_melbourne_cup_day">Cuộc đua làm cả quốc gia dừng lại</string>
     <string name="holiday_banner_mexico_benito_juarez_birthday">Tưởng nhớ Benito Juárez</string>
     <string name="holiday_banner_mexico_constitution_day">Chúc mừng Ngày Hiến pháp</string>
@@ -1088,7 +1088,7 @@ Skipped intentionally: app_name (brand), insight_time_am/pm/midnight/noon
     <string name="holiday_banner_orthodox_christmas">Chúc mừng Giáng sinh Chính thống</string>
     <string name="holiday_banner_pakistan_day">Chúc mừng Ngày Pakistan</string>
     <string name="holiday_banner_pakistan_independence_day">Chúc mừng Ngày Độc lập</string>
-    <string name="holiday_banner_palm_sunday">Hosanna trên trời cao</string>
+    <string name="holiday_banner_palm_sunday">Chúa Nhật Lễ Lá</string>
     <string name="holiday_banner_pentecost">Chúc mừng Lễ Hiện Xuống</string>
     <string name="holiday_banner_philippines_bonifacio_day">Chúc mừng Ngày Bonifacio</string>
     <string name="holiday_banner_philippines_independence_day">Chúc mừng Quốc khánh Philippines</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -934,7 +934,7 @@ label localizes.
     <string name="holiday_banner_st_georges_day">圣乔治节快乐</string>
     <string name="holiday_banner_st_patricks_day">圣帕特里克节快乐</string>
     <string name="holiday_banner_uk_bank_holiday">公假日快乐</string>
-    <string name="holiday_banner_uk_kings_birthday">天佑国王</string>
+    <string name="holiday_banner_uk_kings_birthday">国王生日快乐</string>
     <string name="holiday_banner_uk_mothering_sunday">母亲节快乐</string>
     <string name="holiday_banner_us_independence_day">7月4日快乐</string>
     <string name="holiday_banner_us_memorial_day">铭记英烈</string>
@@ -1140,7 +1140,7 @@ label localizes.
     <string name="holiday_banner_argentina_independence_day">阿根廷独立日快乐</string>
     <string name="holiday_banner_argentina_may_revolution">五月革命纪念日快乐</string>
     <string name="holiday_banner_ascension_day">耶稣升天节快乐</string>
-    <string name="holiday_banner_ash_wednesday">记住你本是尘土</string>
+    <string name="holiday_banner_ash_wednesday">圣灰星期三</string>
     <string name="holiday_banner_bangladesh_independence_day">独立日快乐</string>
     <string name="holiday_banner_bangladesh_victory_day">胜利日快乐</string>
     <string name="holiday_banner_brazil_black_awareness">黑人意识日</string>
@@ -1163,7 +1163,7 @@ label localizes.
     <string name="holiday_banner_malaysia_day">马来西亚日快乐</string>
     <string name="holiday_banner_malaysia_independence_day">默迪卡日快乐</string>
     <string name="holiday_banner_mardi_gras">肥美星期二快乐</string>
-    <string name="holiday_banner_maundy_thursday">一条新的命令</string>
+    <string name="holiday_banner_maundy_thursday">圣星期四</string>
     <string name="holiday_banner_melbourne_cup_day">让全国停摆的赛马</string>
     <string name="holiday_banner_mexico_benito_juarez_birthday">纪念贝尼托·华雷斯</string>
     <string name="holiday_banner_mexico_constitution_day">宪法日快乐</string>
@@ -1175,7 +1175,7 @@ label localizes.
     <string name="holiday_banner_orthodox_christmas">东正教圣诞节快乐</string>
     <string name="holiday_banner_pakistan_day">巴基斯坦日快乐</string>
     <string name="holiday_banner_pakistan_independence_day">独立日快乐</string>
-    <string name="holiday_banner_palm_sunday">和散那归于至高之处</string>
+    <string name="holiday_banner_palm_sunday">棕枝主日</string>
     <string name="holiday_banner_pentecost">圣灵降临节快乐</string>
     <string name="holiday_banner_philippines_bonifacio_day">博尼法西奥日快乐</string>
     <string name="holiday_banner_philippines_independence_day">菲律宾独立日快乐</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -949,7 +949,7 @@ label localises.
     <string name="holiday_banner_st_georges_day">聖喬治節快樂</string>
     <string name="holiday_banner_st_patricks_day">聖派翠克節快樂</string>
     <string name="holiday_banner_uk_bank_holiday">公假日快樂</string>
-    <string name="holiday_banner_uk_kings_birthday">天佑吾王</string>
+    <string name="holiday_banner_uk_kings_birthday">國王生日快樂</string>
     <string name="holiday_banner_uk_mothering_sunday">母親節快樂</string>
     <string name="holiday_banner_us_independence_day">7月4日快樂</string>
     <string name="holiday_banner_us_memorial_day">銘記英烈</string>
@@ -1155,7 +1155,7 @@ label localises.
     <string name="holiday_banner_argentina_independence_day">阿根廷獨立日快樂</string>
     <string name="holiday_banner_argentina_may_revolution">五月革命紀念日快樂</string>
     <string name="holiday_banner_ascension_day">耶穌升天節快樂</string>
-    <string name="holiday_banner_ash_wednesday">記住你本是塵土</string>
+    <string name="holiday_banner_ash_wednesday">聖灰星期三</string>
     <string name="holiday_banner_bangladesh_independence_day">獨立日快樂</string>
     <string name="holiday_banner_bangladesh_victory_day">勝利日快樂</string>
     <string name="holiday_banner_brazil_black_awareness">黑人意識日</string>
@@ -1178,7 +1178,7 @@ label localises.
     <string name="holiday_banner_malaysia_day">馬來西亞日快樂</string>
     <string name="holiday_banner_malaysia_independence_day">默迪卡日快樂</string>
     <string name="holiday_banner_mardi_gras">肥美星期二快樂</string>
-    <string name="holiday_banner_maundy_thursday">一條新的命令</string>
+    <string name="holiday_banner_maundy_thursday">聖星期四</string>
     <string name="holiday_banner_melbourne_cup_day">讓全國停擺的賽馬</string>
     <string name="holiday_banner_mexico_benito_juarez_birthday">紀念貝尼托·華雷斯</string>
     <string name="holiday_banner_mexico_constitution_day">憲法日快樂</string>
@@ -1190,7 +1190,7 @@ label localises.
     <string name="holiday_banner_orthodox_christmas">東正教聖誕節快樂</string>
     <string name="holiday_banner_pakistan_day">巴基斯坦日快樂</string>
     <string name="holiday_banner_pakistan_independence_day">獨立日快樂</string>
-    <string name="holiday_banner_palm_sunday">和散那歸於至高之處</string>
+    <string name="holiday_banner_palm_sunday">棕枝主日</string>
     <string name="holiday_banner_pentecost">聖靈降臨節快樂</string>
     <string name="holiday_banner_philippines_bonifacio_day">博尼法西奧日快樂</string>
     <string name="holiday_banner_philippines_independence_day">菲律賓獨立日快樂</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1683,7 +1683,7 @@
          Summer). Each entry's HolidayTheme references this same key
          rather than a per-bank-holiday string. -->
     <string name="holiday_banner_uk_bank_holiday">Happy bank holiday</string>
-    <string name="holiday_banner_uk_kings_birthday">God save the King</string>
+    <string name="holiday_banner_uk_kings_birthday">Happy King\'s Birthday</string>
     <string name="holiday_banner_mothers_day">Happy Mother\'s Day</string>
     <string name="holiday_banner_japan_greenery_day">Happy Japanese Greenery Day</string>
     <string name="holiday_banner_cinco_de_mayo">¡Feliz Cinco de Mayo!</string>
@@ -1905,11 +1905,11 @@
     <string name="holiday_name_mardi_gras">Mardi Gras / Shrove Tuesday</string>
     <string name="holiday_banner_mardi_gras">Laissez les bons temps rouler</string>
     <string name="holiday_name_ash_wednesday">Ash Wednesday</string>
-    <string name="holiday_banner_ash_wednesday">Remember that you are dust</string>
+    <string name="holiday_banner_ash_wednesday">Ash Wednesday</string>
     <string name="holiday_name_palm_sunday">Palm Sunday</string>
-    <string name="holiday_banner_palm_sunday">Hosanna in the highest</string>
+    <string name="holiday_banner_palm_sunday">Palm Sunday</string>
     <string name="holiday_name_maundy_thursday">Maundy Thursday</string>
-    <string name="holiday_banner_maundy_thursday">A new commandment</string>
+    <string name="holiday_banner_maundy_thursday">Maundy Thursday</string>
     <string name="holiday_name_ascension_day">Ascension Day</string>
     <string name="holiday_banner_ascension_day">Happy Ascension Day</string>
     <string name="holiday_name_pentecost">Pentecost</string>


### PR DESCRIPTION
Two related changes to the holiday banner, both prompted by a King's Birthday bug report.

## 1. Fix banner showing the raw enum name (`UK_KINGS_BIRTHDAY`)

In the reporter's **release** build the banner rendered `UK_KINGS_BIRTHDAY` instead of the localized title.

**Root cause:** holiday banners (plus the Settings holiday list and TTS greetings) resolve their text *by name* via `Resources.getIdentifier`, because the theme catalogue lives in `:core:domain` (pure Kotlin) and stores string keys as *data*, not compile-time `R.string.…` references. Both build types run `isShrinkResources = true`, and the shrinker can't see those dynamic lookups, so it stripped the `holiday_name_*` / `holiday_banner_*` / `settings_holiday_country_*` families as unused. `getIdentifier` then returned `0` and `resolveBannerString` fell back to `theme.id.name`.

**Fix:** add `app/src/main/res/raw/keep.xml` with a `tools:keep` rule for the three dynamically-referenced string families. Verified against the resource shrinker report (`app/build/outputs/mapping/debug/resources.txt`): the holiday strings now list `reachable from keep xml file` where before they had no retention reason.

(The reported date was correct — the King's Official Birthday is the 2nd Saturday of June = June 13 in 2026.)

## 2. Friendlier, more inclusive banner wording

Four banners spoke in the voice of a faith or the crown rather than greeting the user:

| Banner | Was | Now |
|---|---|---|
| King's Birthday | "God save the King" | "Happy King's Birthday" (festive birthday greeting) |
| Ash Wednesday | "Remember that you are dust" | "Ash Wednesday" (names the day) |
| Palm Sunday | "Hosanna in the highest" | "Palm Sunday" |
| Maundy Thursday | "A new commandment" | "Maundy Thursday" |

Reworded across the base locale **and all ~49 translations**. The three Christian observances now simply name the day (matching the existing Good Friday / Corpus Christi banners), reusing each locale's already-translated holiday display name so wording stays correct per language. King's Birthday becomes a plain festive greeting, with the natural equivalent in each language (keeping the ones that were already festive, e.g. Greek/Bulgarian/Serbian/Romanian).

Banners that merely *name* a holiday ("Happy Easter", "Merry Christmas") are left alone — naming a day people observe is inclusive; only the four that professed faith or fealty were the issue.

## Privacy

Banner text is also spoken via TTS (Gemini, BYOK), so this changes what leaves the device on those days. The new copy is **less** sensitive (a plain greeting / day name rather than a prayer or anthem), not more.

## Test plan

- `./gradlew :app:processDebugResources` — all 49 locale XML files compile.
- `./gradlew :app:assembleDebug` — succeeds (debug also shrinks, exercising the keep rule).
- Shrinker report confirms the holiday strings are retained.

https://claude.ai/code/session_01U1TE5FCDyaU86ro2Z1zWFM