### PR TITLE
Mention drizzle even when the chance of rain looks low

### DIFF
--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/ClothesRule.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/ClothesRule.kt
@@ -83,6 +83,19 @@ data class ClothesRule(
         // TODO(rain-accessory-variants): broaden the carried-accessory rules
         //  beyond the umbrella (rain jacket, hood, rain boots, …) once the
         //  resource strings and per-locale phrasers cover them.
+        // TODO(umbrella-on-precip-code): the umbrella gate is probability-only,
+        //  so drizzle never triggers it — probability-of-precip is the chance of
+        //  *measurable* rain (≥ ~0.1 mm) and light drizzle slips under it (one
+        //  model, ecmwf_aifs025_single, even reports a drizzle code + 0.1 mm with
+        //  no probability at all). RenderInsightSummary now *mentions* drizzle
+        //  from the weather code / precip amount, but the umbrella itself stays
+        //  silent. Consider hard-coding the umbrella whenever any model reports a
+        //  rain or drizzle weather code (independent of POP). This reverses the
+        //  "per-model rain doesn't pick clothes" convention and needs a per-model
+        //  precip signal plumbed into rule evaluation (which today only sees the
+        //  daily-aggregate DailyForecast), plus care against false umbrellas on
+        //  grey-but-dry days — so deferred. See the coded drizzle tier in
+        //  RenderInsightSummary.pickPerModelPeak.
         val DEFAULTS: List<ClothesRule> = listOf(
             ClothesRule(Garment.SWEATER, TemperatureBelow(16.0)),
             ClothesRule(Garment.JACKET, TemperatureBelow(10.0)),

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/RenderInsightSummary.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/RenderInsightSummary.kt
@@ -12,6 +12,7 @@ import app.clothescast.core.domain.model.EveningEventTieInClause
 import app.clothescast.core.domain.model.ForecastPeriod
 import app.clothescast.core.domain.model.Garment
 import app.clothescast.core.domain.model.InsightSummary
+import app.clothescast.core.domain.model.PerModelHour
 import app.clothescast.core.domain.model.PerModelHourly
 import app.clothescast.core.domain.model.PrecipClause
 import app.clothescast.core.domain.model.PrecipLikelihood
@@ -41,11 +42,17 @@ import kotlin.math.roundToInt
  *    feels-like delta is ≥ 3°C, and only for [ForecastPeriod.TODAY] (yesterday's
  *    overnight comparison isn't useful, and the morning pass already covers it).
  * 3. [ClothesClause] — items triggered by the user's rule list, in rule order.
- * 4. [PrecipClause] — fires in two tiers driven by cross-model agreement:
+ * 4. [PrecipClause] — fires in tiers driven by cross-model agreement:
  *    [PrecipLikelihood.LIKELY] when a majority of consulted models hit ≥ 50%
  *    at the same hour ("Rain at 3pm."), [PrecipLikelihood.POSSIBLE] when at
  *    least one model hits ≥ 30% but the majority bar isn't cleared ("Chance
- *    of rain at 3pm."). Falls back to the base hourly series — and ultimately
+ *    of rain at 3pm."). When no model clears the probability bars at all, a
+ *    final POSSIBLE tier fires on a precipitating *weather code* (WMO
+ *    51/53/55 drizzle, or any rain/snow/storm code) or a non-zero precip
+ *    amount from any model — this is the drizzle path: probability-of-precip
+ *    is the chance of *measurable* rain, which light drizzle slips under, and
+ *    one model (the AI model) supplies a code + trace amount but no
+ *    probability at all. Falls back to the base hourly series — and ultimately
  *    a noon synthesis from the day-level field — when per-model data isn't
  *    available; both fallbacks render as LIKELY (the existing behaviour).
  * 5. [CalendarTieInClause] — when clothes + precip both fired AND a calendar
@@ -429,7 +436,86 @@ class RenderInsightSummary {
         if (possibleHour != null) {
             return PeakPrecip(possibleHour, perModelConditionAt(possibleHour, today), PrecipLikelihood.POSSIBLE)
         }
+
+        // Drizzle / light-precip fallback, keyed off the weather code and precip
+        // amount instead of probability. Probability of precipitation is the
+        // chance of *measurable* rain (≥ ~0.1 mm); drizzle from shallow stratus
+        // routinely falls below that bar, so a model can forecast it via its WMO
+        // weather code (51/53/55) and a trace amount while reporting a low — or,
+        // for the AI model ecmwf_aifs025_single, entirely absent —
+        // precipitation_probability. The two POP tiers above are blind to
+        // exactly that signal: AIFS contributes a drizzle code + 0.1 mm but no
+        // probability, so it never counts toward a per-hour majority and never
+        // clears the 30% possible bar. Surface it as POSSIBLE — one model's
+        // drizzle code is a hedged "chance of drizzle" heads-up, not a confident
+        // call. We scan the whole window rather than pinning an hour: drizzle
+        // timing is too fuzzy to claim precision, and a precip code anywhere in
+        // the period is enough to warn the user it'll be damp (CLAUDE.md domain
+        // convention: always surface rain a model spots, even when no clothes
+        // rule fires and probability sits below every threshold).
+        val codedHit = models.asSequence()
+            .flatten()
+            .filter { effectivePrecipCondition(it) != null }
+            // Most-severe condition first (rain over drizzle, storm over rain),
+            // then the wettest hour as a stable tiebreak. Severity is taken from
+            // the *effective* condition so an amount-only heavy hour (no code)
+            // ranks as rain, not below a trivial drizzle code elsewhere.
+            .maxWithOrNull(
+                compareBy({ precipSeverity(effectivePrecipCondition(it)) }, { it.precipitationMm ?: 0.0 }),
+            )
+        if (codedHit != null) {
+            return PeakPrecip(
+                codedHit.time.toLocalTime(),
+                effectivePrecipCondition(codedHit)!!,
+                PrecipLikelihood.POSSIBLE,
+            )
+        }
         return null
+    }
+
+    /**
+     * The precipitating condition a per-model hour implies for the coded drizzle
+     * fallback, or null when the hour carries no precip signal. Prefers the
+     * model's own weather code when it's precipitating; otherwise infers from the
+     * expected amount — a trace (≤ [DRIZZLE_AMOUNT_CEILING_MM]) reads as drizzle,
+     * anything heavier as plain rain, so a coverage-less multi-millimetre hour (a
+     * model that omitted weather_code, or an older cached payload) isn't
+     * undersold as "chance of drizzle". Snow can't be told from rain by amount
+     * alone, but a genuine snow hour almost always carries its own code, so rain
+     * is the safe less-specific default for an amount-only hit.
+     */
+    private fun effectivePrecipCondition(hour: PerModelHour): WeatherCondition? {
+        hour.condition?.takeIf { it.isPrecipitation() }?.let { return it }
+        val mm = hour.precipitationMm ?: 0.0
+        return when {
+            mm <= 0.0 -> null
+            mm <= DRIZZLE_AMOUNT_CEILING_MM -> WeatherCondition.DRIZZLE
+            else -> WeatherCondition.RAIN
+        }
+    }
+
+    /**
+     * Orders precipitating conditions by severity so the coded drizzle fallback
+     * names the heaviest condition any model implied (rain over drizzle, storm
+     * over rain) rather than whichever hour happened to sort first. Non-precip
+     * conditions (and null) score 0 and never win — the caller pre-filters them
+     * out, so this only ever ranks among genuine precip hits.
+     */
+    private fun precipSeverity(condition: WeatherCondition?): Int = when (condition) {
+        WeatherCondition.THUNDERSTORM -> 4
+        WeatherCondition.SNOW -> 3
+        WeatherCondition.RAIN -> 2
+        WeatherCondition.DRIZZLE -> 1
+        else -> 0
+    }
+
+    private companion object {
+        // Hourly precip amount (mm) at/under which an amount-only signal — a
+        // positive expected amount with no precipitating weather code — is read
+        // as drizzle rather than rain. Light drizzle deposits only a few tenths
+        // of a millimetre an hour (WMO light-drizzle intensity tops out around
+        // here); above it the amount is too heavy to call "drizzle".
+        const val DRIZZLE_AMOUNT_CEILING_MM = 0.5
     }
 
     private fun perModelConditionAt(time: LocalTime, today: DailyForecast): WeatherCondition {

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/RenderInsightSummaryTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/RenderInsightSummaryTest.kt
@@ -952,6 +952,117 @@ class RenderInsightSummaryTest {
         out.allDay shouldBe false
     }
 
+    @Test
+    fun `precip clause surfaces drizzle from a weather code when the model omits probability`() {
+        // The real bug: ecmwf_aifs025_single forecasts drizzle (WMO 51) with a
+        // 0.1 mm trace but reports no precipitation_probability at all, while the
+        // other models sit well under 30%. Both POP tiers stay silent; the coded
+        // fallback must still warn so the user hears about the drizzle.
+        val today = mildToday.copy(
+            precipitationProbabilityMaxPct = 16.0,
+            condition = WeatherCondition.CLOUDY,
+            hourly = listOf(
+                HourlyForecast(LocalTime.of(7, 0), 16.0, 16.0, 16.0, WeatherCondition.CLOUDY),
+            ),
+        )
+        val perModel = perModelHourly(
+            "ecmwf_ifs04" to listOf(perModelHour(LocalTime.of(7, 0), precipPct = 8.0, condition = WeatherCondition.CLOUDY)),
+            "gfs_seamless" to listOf(perModelHour(LocalTime.of(7, 0), precipPct = 19.0, condition = WeatherCondition.CLOUDY)),
+            "ecmwf_aifs025_single" to listOf(
+                perModelHour(LocalTime.of(7, 0), precipPct = null, condition = WeatherCondition.DRIZZLE, precipMm = 0.1),
+            ),
+        )
+        val out = subject(today, yesterday, emptyList(), perModelHourly = perModel).precip
+        out.shouldNotBeNull()
+        out!!.condition shouldBe WeatherCondition.DRIZZLE
+        out.likelihood shouldBe PrecipLikelihood.POSSIBLE
+        out.time shouldBe LocalTime.of(7, 0)
+    }
+
+    @Test
+    fun `precip clause surfaces drizzle from a trace precip amount under a dry code`() {
+        // A model deposits 0.2 mm but codes the hour cloudy and reports a low
+        // probability — a few tenths of a millimetre is light drizzle, so the
+        // amount alone earns the hedged clause, defaulting the type to DRIZZLE.
+        val today = mildToday.copy(precipitationProbabilityMaxPct = 10.0, condition = WeatherCondition.CLOUDY)
+        val perModel = perModelHourly(
+            "gfs_seamless" to listOf(perModelHour(LocalTime.of(9, 0), precipPct = 10.0, condition = WeatherCondition.CLOUDY, precipMm = 0.2)),
+            "ecmwf_ifs04" to listOf(perModelHour(LocalTime.of(9, 0), precipPct = 5.0, condition = WeatherCondition.CLOUDY)),
+        )
+        val out = subject(today, yesterday, emptyList(), perModelHourly = perModel).precip
+        out.shouldNotBeNull()
+        out!!.condition shouldBe WeatherCondition.DRIZZLE
+        out.likelihood shouldBe PrecipLikelihood.POSSIBLE
+        out.time shouldBe LocalTime.of(9, 0)
+    }
+
+    @Test
+    fun `coded precip fallback names the most severe condition across models`() {
+        // One model codes drizzle in the morning, another codes rain in the
+        // afternoon — both below every probability bar. The clause should name
+        // rain (the heavier code), at rain's hour.
+        val today = mildToday.copy(precipitationProbabilityMaxPct = 12.0, condition = WeatherCondition.CLOUDY)
+        val perModel = perModelHourly(
+            "ecmwf_aifs025_single" to listOf(perModelHour(LocalTime.of(6, 0), precipPct = null, condition = WeatherCondition.DRIZZLE, precipMm = 0.1)),
+            "gfs_seamless" to listOf(perModelHour(LocalTime.of(15, 0), precipPct = 12.0, condition = WeatherCondition.RAIN, precipMm = 0.3)),
+        )
+        val out = subject(today, yesterday, emptyList(), perModelHourly = perModel).precip
+        out.shouldNotBeNull()
+        out!!.condition shouldBe WeatherCondition.RAIN
+        out.time shouldBe LocalTime.of(15, 0)
+        out.likelihood shouldBe PrecipLikelihood.POSSIBLE
+    }
+
+    @Test
+    fun `probability tier takes precedence over the coded drizzle fallback`() {
+        // A model clearing 30% drives the probability-led POSSIBLE at its own
+        // hour; a drizzle code elsewhere must not override the stronger signal.
+        val today = mildToday.copy(
+            precipitationProbabilityMaxPct = 35.0,
+            condition = WeatherCondition.RAIN,
+            hourly = listOf(HourlyForecast(LocalTime.of(15, 0), 18.0, 18.0, 35.0, WeatherCondition.RAIN)),
+        )
+        val perModel = perModelHourly(
+            "gfs_seamless" to listOf(perModelHour(LocalTime.of(15, 0), precipPct = 40.0, condition = WeatherCondition.RAIN)),
+            "ecmwf_aifs025_single" to listOf(perModelHour(LocalTime.of(6, 0), precipPct = null, condition = WeatherCondition.DRIZZLE, precipMm = 0.1)),
+            "icon_seamless" to listOf(perModelHour(LocalTime.of(15, 0), precipPct = 5.0, condition = WeatherCondition.RAIN)),
+        )
+        val out = subject(today, yesterday, emptyList(), perModelHourly = perModel).precip
+        out.shouldNotBeNull()
+        out!!.time shouldBe LocalTime.of(15, 0)
+        out.likelihood shouldBe PrecipLikelihood.POSSIBLE
+    }
+
+    @Test
+    fun `coded fallback reads a large amount-only hit as rain not drizzle`() {
+        // A model expects several mm but omits its weather code (a model without
+        // the field, or an older cached payload). Classifying by amount keeps it
+        // honest: 4 mm is rain, not "a chance of drizzle".
+        val today = mildToday.copy(precipitationProbabilityMaxPct = 10.0, condition = WeatherCondition.CLOUDY)
+        val perModel = perModelHourly(
+            "gfs_seamless" to listOf(perModelHour(LocalTime.of(14, 0), precipPct = 10.0, condition = null, precipMm = 4.0)),
+            "ecmwf_ifs04" to listOf(perModelHour(LocalTime.of(14, 0), precipPct = 5.0, condition = WeatherCondition.CLOUDY)),
+        )
+        val out = subject(today, yesterday, emptyList(), perModelHourly = perModel).precip
+        out.shouldNotBeNull()
+        out!!.condition shouldBe WeatherCondition.RAIN
+        out.time shouldBe LocalTime.of(14, 0)
+        out.likelihood shouldBe PrecipLikelihood.POSSIBLE
+    }
+
+    @Test
+    fun `coded fallback stays silent when every model reports a dry code and no precip`() {
+        // Overcast but dry: low probabilities, non-precipitating codes, no
+        // amount. Nothing should fire — the fallback only reacts to a genuine
+        // precip code or measurable amount, not a grey sky.
+        val today = mildToday.copy(precipitationProbabilityMaxPct = 10.0, condition = WeatherCondition.CLOUDY)
+        val perModel = perModelHourly(
+            "gfs_seamless" to listOf(perModelHour(LocalTime.of(10, 0), precipPct = 20.0, condition = WeatherCondition.CLOUDY)),
+            "ecmwf_ifs04" to listOf(perModelHour(LocalTime.of(10, 0), precipPct = 15.0, condition = WeatherCondition.PARTLY_CLOUDY)),
+        )
+        subject(today, yesterday, emptyList(), perModelHourly = perModel).precip.shouldBeNull()
+    }
+
     // PerModelHour now carries a LocalDateTime — paired against an arbitrary
     // anchor date so the test fixtures don't have to thread a date through
     // every call. The renderer reads `time.toLocalTime()` at output points;
@@ -959,12 +1070,19 @@ class RenderInsightSummaryTest {
     // which these tests don't exercise.
     private val perModelDate: java.time.LocalDate = java.time.LocalDate.of(2026, 5, 13)
 
-    private fun perModelHour(time: LocalTime, precipPct: Double): PerModelHour =
+    private fun perModelHour(
+        time: LocalTime,
+        precipPct: Double? = null,
+        condition: WeatherCondition? = null,
+        precipMm: Double? = null,
+    ): PerModelHour =
         PerModelHour(
             time = java.time.LocalDateTime.of(perModelDate, time),
             apparentTemperatureC = 18.0,
             temperatureC = 18.0,
             precipitationProbabilityPct = precipPct,
+            condition = condition,
+            precipitationMm = precipMm,
         )
 
     private fun perModelHourly(vararg models: Pair<String, List<PerModelHour>>): PerModelHourly =


### PR DESCRIPTION
## Why

A user reported drizzle that the app stayed silent about, while the charts showed only ~15% chance of rain. Investigating against the live Open-Meteo multi-model data for the reported location (London, this morning) showed why:

- **Probability-of-precip is the wrong instrument for drizzle.** POP is the chance of *measurable* rain (≥ ~0.1 mm); light drizzle deposits sub-threshold amounts, so a model can correctly report "low chance of measurable rain" while drizzle still falls. Max POP any model reached all day was 22% — the umbrella rule (>30%) and both prose tiers (≥30 / ≥50) were structurally guaranteed to stay silent.
- **One model actually called it — and we couldn't hear it.** `ecmwf_aifs025_single` forecast drizzle (WMO code 51) with a 0.1 mm trace at 06:00–07:00, but it reports **no `precipitation_probability` at all** (it's one of the models the logs flag as missing that field). Its drizzle signal lived only in `weather_code` and `precipitation` (mm) — both fetched and stored, neither used for rain detection.

## What

`RenderInsightSummary.pickPerModelPeak` gains a final **POSSIBLE** tier, below the two probability tiers, that fires on:

- a precipitating **weather code** from any model (WMO 51/53/55 drizzle, or any rain/snow/storm code), or
- a **non-zero precip amount** from any model,

independent of probability. It scans the whole window rather than pinning an hour (drizzle timing is too fuzzy to claim precision — consistent with the existing decision to stop naming peak hours) and picks the most severe condition across models. An **amount-only** signal (positive mm but a missing/dry weather code) is classified by magnitude via a shared `effectivePrecipCondition` helper: a trace (≤ 0.5 mm, the WMO light-drizzle ceiling) reads as drizzle, anything heavier as plain rain — so a coverage-less multi-millimetre hour isn't undersold as "chance of drizzle". The existing downstream already renders `DRIZZLE` + `POSSIBLE` as *"Chance of drizzle."*

## Outfit rules: intentionally untouched

The umbrella stays on its probability gate, matching the repo convention *"per-model rain doesn't pick clothes, but it does mention rain."* A POP gate can't express drizzle without dropping so low it false-fires on every grey-but-dry day. A `TODO(umbrella-on-precip-code)` at the umbrella default captures the option to hard-code the umbrella on a rain/drizzle code later (deferred — it reverses that convention and needs a per-model precip signal plumbed into rule evaluation).

## Privacy

Only widens generic weather prose ("Chance of drizzle.") in the spoken/notification insight. No new user data crosses the device boundary.

## Test plan

- `./gradlew :core:domain:test` — green locally.
- Six new `RenderInsightSummaryTest` cases: the AIFS no-probability drizzle code, trace-amount-only drizzle, a heavy amount-only hit reading as rain, severity ordering (rain over drizzle), probability-tier precedence, and the dry-overcast no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)