### PR TITLE
Show the rain icon when the forecast mentions rain

### DIFF
--- a/app/src/main/kotlin/app/clothescast/cast/CastTestDispatch.kt
+++ b/app/src/main/kotlin/app/clothescast/cast/CastTestDispatch.kt
@@ -93,6 +93,7 @@ internal suspend fun castCurrentInsight(
         hourly = insight.hourly,
         temperatureUnit = prefs.temperatureUnit,
         windSpeedUnit = prefs.distanceUnit.windSpeedUnit(),
+        precipCondition = insight.summary.precip?.condition,
     )
     val header = context.getString(
         if (insight.period == ForecastPeriod.TODAY) R.string.outfit_card_header_today

--- a/app/src/main/kotlin/app/clothescast/ui/garment/GarmentRender.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/garment/GarmentRender.kt
@@ -891,6 +891,15 @@ internal fun outfitCardInfoLines(
     hourly: List<HourlyForecast>,
     temperatureUnit: TemperatureUnit,
     windSpeedUnit: WindSpeedUnit = WindSpeedUnit.KMH,
+    // The insight's rain-clause condition ([InsightSummary.precip]) when the prose
+    // detected rain — the *same* per-model signal the clothes rules and prose use.
+    // The blended [hourly] codes are a per-hour consensus (modal vote, severity
+    // tiebreak only among the tied winners), so a minority of models coding rain
+    // loses to a unified dry plurality and the blend reads clear — yet the rules
+    // still fire the umbrella and the prose still says "chance of drizzle". Passing
+    // this in keeps the strip in lockstep with the prose: if the insight surfaces
+    // rain, the droplet shows. Null when the prose found no rain.
+    precipCondition: WeatherCondition? = null,
 ): OutfitCardInfoLines {
     val lowC = hourly.minOfOrNull { it.feelsLikeC }
     val highC = hourly.maxOfOrNull { it.feelsLikeC }
@@ -916,12 +925,14 @@ internal fun outfitCardInfoLines(
         .maxByOrNull { it.precipitationProbabilityPct }
     val peakPct = rainPeak?.precipitationProbabilityPct?.roundToInt()
     // Show the rain cell on the same composite-OR the clothes rules use: a peak
-    // chance at/above the probability gate, *or* any hour coded as rain-shaped
-    // (drizzle / rain / thunderstorm — [warrantsRainAccessory], which excludes
-    // snow). The code arm catches drizzle that sits below the probability gate;
-    // the label still shows the honest peak chance, so a drizzle-coded hour reads
-    // as the low percentage it is rather than overstating it.
-    val rainCoded = hourly.any { it.condition.warrantsRainAccessory() }
+    // chance at/above the probability gate, *or* a rain-shaped code (drizzle /
+    // rain / thunderstorm — [warrantsRainAccessory], which excludes snow) from
+    // either the insight's own rain clause ([precipCondition], the per-model
+    // signal the consensus blend can hide) or any blended [hourly] code. The label
+    // still shows the honest peak chance, so a drizzle hour reads as the low
+    // percentage it is rather than overstating it.
+    val rainCoded = precipCondition?.warrantsRainAccessory() == true ||
+        hourly.any { it.condition.warrantsRainAccessory() }
     val rainLineShort: String?
     val rainFillFraction: Float?
     // A rain-shaped code shows the droplet regardless of probability — even at a

--- a/app/src/main/kotlin/app/clothescast/ui/nav/ClothesCastNavHost.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/nav/ClothesCastNavHost.kt
@@ -443,6 +443,7 @@ private fun settingsViewModelFactory(app: ClothesCastApplication) =
                         hourly = insight.hourly,
                         temperatureUnit = prefs.temperatureUnit,
                         windSpeedUnit = prefs.distanceUnit.windSpeedUnit(),
+                        precipCondition = insight.summary.precip?.condition,
                     )
                     val header = app.getString(
                         if (insight.period == ForecastPeriod.TODAY) R.string.outfit_card_header_today

--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
@@ -115,6 +115,7 @@ import app.clothescast.core.domain.model.OutfitSuggestion
 import app.clothescast.core.domain.model.ModelDivergenceSummary
 import app.clothescast.core.domain.model.PerModelHour
 import app.clothescast.core.domain.model.PerModelHourly
+import app.clothescast.core.domain.model.WeatherCondition
 import app.clothescast.core.domain.model.consensusSunshineHours
 import app.clothescast.core.domain.model.consensusSunshineHoursFor
 import app.clothescast.core.domain.model.BottomsFormat
@@ -921,6 +922,10 @@ internal fun HomePageScaffold(
     homeSectionOrder: List<HomeSection> = HomeSection.DEFAULTS,
     insightSlot: (@Composable ColumnScope.() -> Unit)? = null,
     conditionsHourly: List<HourlyForecast>? = null,
+    // This page's rain-clause condition (insight.summary.precip), so the strip's
+    // droplet matches the prose even when a minority of models codes the rain and
+    // the blended [conditionsHourly] consensus reads dry. Null when no rain clause.
+    conditionsPrecipCondition: WeatherCondition? = null,
     confidenceSlot: (@Composable ColumnScope.() -> Unit)? = null,
     chartsSlot: (@Composable ColumnScope.() -> Unit)? = null,
     content: @Composable ColumnScope.() -> Unit,
@@ -938,6 +943,7 @@ internal fun HomePageScaffold(
     val tvScrollStepPx = with(LocalDensity.current) { 240.dp.toPx() }
     val conditionsInfo: OutfitCardInfoLines? = remember(
         conditionsHourly,
+        conditionsPrecipCondition,
         state.region,
         state.temperatureUnit,
         state.distanceUnit,
@@ -951,6 +957,7 @@ internal fun HomePageScaffold(
                     hourly = hourly,
                     temperatureUnit = state.temperatureUnit,
                     windSpeedUnit = state.distanceUnit.windSpeedUnit(),
+                    precipCondition = conditionsPrecipCondition,
                 )
             }.onFailure { t ->
                 // Explicit fallback: a formatter/resource failure hides the
@@ -1236,6 +1243,9 @@ private fun TodayPage(
         // page's insight (this period on page 0, the next period on page 1), so
         // each page's strip shows its own feels-like range / rain / wind / UV.
         conditionsHourly = insight?.hourly,
+        // Pair the strip's hourly with this page's rain-clause condition so the
+        // droplet matches the prose on a minority-model drizzle the blend hides.
+        conditionsPrecipCondition = insight?.summary?.precip?.condition,
         // The insight card — its own reorderable section. The confidence chip
         // that used to ride along with it is now [confidenceSlot]; the chart
         // deck is [chartsSlot]. Renders only when this period has an insight;

--- a/app/src/main/kotlin/app/clothescast/widget/ConditionsWidget.kt
+++ b/app/src/main/kotlin/app/clothescast/widget/ConditionsWidget.kt
@@ -85,6 +85,7 @@ class ConditionsWidget : GlanceAppWidget() {
                     hourly = insight.hourly,
                     temperatureUnit = prefs.temperatureUnit,
                     windSpeedUnit = prefs.distanceUnit.windSpeedUnit(),
+                    precipCondition = insight.summary.precip?.condition,
                 )
             }.getOrNull()
         } else {

--- a/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
@@ -1468,6 +1468,7 @@ class FetchAndNotifyWorker(
                 hourly = insight.hourly,
                 temperatureUnit = prefs.temperatureUnit,
                 windSpeedUnit = prefs.distanceUnit.windSpeedUnit(),
+                precipCondition = insight.summary.precip?.condition,
             )
             val header = applicationContext.getString(
                 if (insight.period == ForecastPeriod.TODAY) R.string.outfit_card_header_today

--- a/app/src/test/kotlin/app/clothescast/ui/garment/OutfitCardInfoLinesTest.kt
+++ b/app/src/test/kotlin/app/clothescast/ui/garment/OutfitCardInfoLinesTest.kt
@@ -53,6 +53,17 @@ class OutfitCardInfoLinesTest {
     private fun rainLineFor(pct: Double, condition: WeatherCondition = WeatherCondition.CLEAR): String? =
         infoFor(listOf(rainHour(pct, condition))).rainLineShort
 
+    // The strip cell when the blended hourly is dry but the insight's prose rain
+    // clause carries [precipCondition] (the per-model signal the consensus hides).
+    private fun rainLineForPrecip(precipCondition: WeatherCondition?): String? =
+        outfitCardInfoLines(
+            ctx,
+            formatter,
+            listOf(rainHour(5.0, WeatherCondition.CLOUDY)),
+            TemperatureUnit.CELSIUS,
+            precipCondition = precipCondition,
+        ).rainLineShort
+
     // --- Rain (shown at >= 20% peak chance OR a rain-shaped weather code) ---
 
     @Test
@@ -93,6 +104,24 @@ class OutfitCardInfoLinesTest {
         assertNull(rainLineFor(10.0, WeatherCondition.SNOW))
         assertNull(rainLineFor(25.0, WeatherCondition.SNOW))
         assertNull(rainLineFor(80.0, WeatherCondition.SNOW))
+    }
+
+    @Test
+    fun `rain cell shows when the prose rain clause is rain-shaped though the blend is dry`() {
+        // The minority-model case: blended hourly is cloudy at 5% (consensus hid
+        // the rain), but the insight's prose clause carries drizzle/rain — the
+        // same per-model signal the rules use. The strip must match the prose.
+        assertNotNull(rainLineForPrecip(WeatherCondition.DRIZZLE))
+        assertNotNull(rainLineForPrecip(WeatherCondition.RAIN))
+        assertNotNull(rainLineForPrecip(WeatherCondition.THUNDERSTORM))
+    }
+
+    @Test
+    fun `prose rain clause of snow or none leaves the dry cell hidden`() {
+        // Snow isn't a rain droplet, and a null clause adds nothing — the dry,
+        // sub-gate blend keeps the cell hidden.
+        assertNull(rainLineForPrecip(WeatherCondition.SNOW))
+        assertNull(rainLineForPrecip(null))
     }
 
     // --- UV (notable >= 6, gated on the rounded peak) ---


### PR DESCRIPTION
## What & why

Bug: with the prose saying **"Chance of drizzle, bring an umbrella"** and the umbrella in the recommended items, the conditions-strip rain droplet stayed **empty** — the indicator contradicted the text right next to it.

Root cause: the strip read the **blended hourly** condition, which is a per-hour consensus (`consensusCondition`: modal vote, severity tiebreak only among the tied winners). When a *minority* of models codes the rain, it loses to a unified dry plurality and the blend reads clear/cloudy — even though the clothes rules and prose fire off the *any-model* per-model signal (`peakRainCondition`). So the rules/prose surfaced the drizzle while the strip didn't.

Fix: the strip now also fires its rain droplet off the insight's own rain clause (`insight.summary.precip`) — the same per-model signal the rules/prose use. If the insight surfaces rain, the droplet shows.

## Behavior

- **Consensus-rainy days:** unchanged (already showed).
- **Minority-model drizzle/rain** (blend reads dry, prose says rain): **now shows** the droplet, matching the prose.
- **Snow:** still excluded — `warrantsRainAccessory()` is false for snow, so a snow clause/blend never lights the rain droplet.
- **Label:** still the honest peak chance over non-snow hours (may be low / a rounded 0% for a code-only drizzle — shown by design, per the earlier decision).

## Plumbing

Threads the rain-clause condition into `outfitCardInfoLines` across all five render sites: Today screen, conditions widget, notification outfit card, cast card, and the format-settings preview.

## Test plan

- Added `OutfitCardInfoLinesTest` cases: the cell shows when the prose clause is drizzle/rain/thunderstorm though the blend is dry; stays hidden for a snow clause or none.
- Existing rain/snow/probability/0%-code cases still pass.
- `./gradlew :app:testDebugUnitTest` green; **no snapshot changes** (the fix only adds the minority-model case, which no preview fixture exercises).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QqmafbvGC8Ld9Yo9Sv1cuh

---
_Generated by [Claude Code](https://claude.ai/code/session_01QqmafbvGC8Ld9Yo9Sv1cuh)_