### PR TITLE
Mention a chance of rain whenever an umbrella is suggested

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -407,7 +407,7 @@ new rule the first time something bites you, not the third.
   enough for a jacket), the clause names the item *and* folds in the
   per-model rain when one's detected: "Tonight, rain, bring a
   jacket." If no clothes rule fires but a per-model series spots rain ≥
-  30% in the tonight window and the user has an evening event with a
+  20% in the tonight window and the user has an evening event with a
   location, the clause still emits — without recommending clothes —
   as a bare rain warning ("Tonight, rain." / the hedged
   chance-of-rain wording for the POSSIBLE tier). The prose deliberately
@@ -419,8 +419,8 @@ new rule the first time something bites you, not the third.
   surface rain when a model spots it, even when no clothes rule fires —
   e.g. the user lowered their umbrella gate, deleted the rule, or the
   probability sits below it. The umbrella itself ships as a precip-keyed
-  default (peak probability above 30% — see the comment on
-  `ClothesRule.DEFAULTS`), so on a default setup the evening clause names
+  default (peak probability above 20%, OR a drizzle weather code — see the
+  comment on `ClothesRule.DEFAULTS`), so on a default setup the evening clause names
   it; the bare-rain path is the fallback for when it doesn't. Staying
   silent on evening rain because no rule happened to trigger is exactly
   the case the per-model tier exists to catch.

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1411,7 +1411,7 @@
     <string name="insight_tie_in_at_night">Bring %1$s.</string>
     <!--
     Variant of insight_tie_in for the morning insight's evening tie-in when the
-    evening forecast also has precipitation ≥ 30%. Folds the precip mention into
+    evening forecast also has precipitation ≥ 20%. Folds the precip mention into
     the same sentence so the morning insight mentions the evening weather
     alongside the evening clothing tip, without emitting a second precip clause
     that would compete with the morning slice's own. The precip clause leads the
@@ -1431,7 +1431,7 @@
     <!--
     POSSIBLE-tier counterpart of insight_tie_in_with_rain: a clothes rule
     triggered for the evening but only one per-model series flagged the
-    precip at ≥ 30%. Hedges the wording so a single-model reading doesn't
+    precip at ≥ 20%. Hedges the wording so a single-model reading doesn't
     render with the same definite tone as a majority-of-models agreement.
     %1$s = item phrase, %2$s = timing qualifier (empty / " overnight"),
     %3$s = condition noun (lowercased), so the hedge reads "chance of snow" /
@@ -1454,7 +1454,7 @@
     <string name="insight_evening_rain">Tonight, %2$s%1$s.</string>
     <!--
     POSSIBLE-tier counterpart of insight_evening_rain: only one per-model
-    series flagged the tonight hour ≥ 30%, so we hedge the wording. Matches
+    series flagged the tonight hour ≥ 20%, so we hedge the wording. Matches
     insight_precip_chance's "Chance of rain" pattern. %1$s = timing qualifier
     (empty / " overnight"), %2$s = condition noun (lowercased).
     -->

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/ClothesRule.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/ClothesRule.kt
@@ -64,8 +64,16 @@ data class ClothesRule(
             forecast.feelsLikeMaxC > value.fromUnit(unit)
     }
 
+    /**
+     * Fires when the day's peak rain probability is at least [percent]. The
+     * comparison is inclusive (≥) so the boundary lines up exactly with the
+     * prose's chance-of-rain bar ([PrecipProbability.POSSIBLE_THRESHOLD]) and the
+     * conditions strip — a forecast sitting right on the gate (e.g. 20%) fires the
+     * umbrella the same moment the prose says "chance of rain" and the strip shows
+     * a droplet. (So a `> N` reading of "above" is really "at or above N".)
+     */
     data class PrecipitationProbabilityAbove(val percent: Double) : Condition {
-        override fun matches(forecast: DailyForecast) = forecast.precipitationProbabilityMaxPct > percent
+        override fun matches(forecast: DailyForecast) = forecast.precipitationProbabilityMaxPct >= percent
     }
 
     /**

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/InsightSummary.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/InsightSummary.kt
@@ -205,7 +205,7 @@ data class CalendarTieInClause(val item: String)
  * formatter renders "Tonight, rain at 9pm." (or "Tonight, chance of rain at
  * 9pm." when [likelihood] is POSSIBLE).
  *
- * When the evening forecast slice has rain ≥ 30%, [rainTime] carries the peak
+ * When the evening forecast slice has rain ≥ 20%, [rainTime] carries the peak
  * hour and the formatter folds it into the same sentence ("Tonight, rain at
  * 9pm, bring a jacket.") — keeps the morning insight's mention of evening rain
  * tied to the evening event, rather than emitting a second precip clause that

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Precipitation.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Precipitation.kt
@@ -185,13 +185,19 @@ internal fun PerModelHourly.peakRainCondition(): WeatherCondition =
 /**
  * Per-model agreement thresholds for surfacing rain, in precipitation-
  * probability percent. The user's mental model is "1 model says rain → hedge
- * it as a chance; majority of models say a lot of rain → just say rain". 30%
- * is the historical base-only trigger threshold; 50% is the per-model bar for
- * a *confident* announcement. Shared so the week-ahead headline only mentions
+ * it as a chance; majority of models say a lot of rain → just say rain". 20%
+ * is the chance-of-rain ("possible") bar; 50% is the per-model bar for a
+ * *confident* announcement. Shared so the week-ahead headline only mentions
  * rain the today / tonight insight would also call.
+ *
+ * [POSSIBLE_THRESHOLD] is deliberately aligned with the umbrella default's
+ * probability gate ([ClothesRule.DEFAULTS]) and the conditions strip's rain-cell
+ * gate ([app.clothescast.ui.garment] `RAIN_PEAK_THRESHOLD_PCT`), so the prose
+ * mentions rain on exactly the days the umbrella fires and the strip shows a
+ * droplet — no surface flags rain the others stay silent on.
  */
 object PrecipProbability {
-    const val POSSIBLE_THRESHOLD: Double = 30.0
+    const val POSSIBLE_THRESHOLD: Double = 20.0
     const val LIKELY_THRESHOLD: Double = 50.0
 
     /**

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/RenderInsightSummary.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/RenderInsightSummary.kt
@@ -47,7 +47,7 @@ import kotlin.math.roundToInt
  * 4. [PrecipClause] — fires in tiers driven by cross-model agreement:
  *    [PrecipLikelihood.LIKELY] when a majority of consulted models hit ≥ 50%
  *    at the same hour ("Rain at 3pm."), [PrecipLikelihood.POSSIBLE] when at
- *    least one model hits ≥ 30% but the majority bar isn't cleared ("Chance
+ *    least one model hits ≥ 20% but the majority bar isn't cleared ("Chance
  *    of rain at 3pm."). When no model clears the probability bars at all, a
  *    final POSSIBLE tier fires on a precipitating *weather code* (WMO
  *    51/53/55 drizzle, or any rain/snow/storm code) or a non-zero precip
@@ -337,9 +337,12 @@ class RenderInsightSummary {
      *    The hour carrying the single biggest per-model reading wins.
      *
      * Falls back to the base hourly series (and finally a noon synthesis from
-     * the day-level field) when per-model data isn't available. Both fallback
-     * paths emit LIKELY so legacy behaviour and cached payloads keep their
-     * original wording. The 30% bar matches the historical fallback threshold.
+     * the day-level field) when per-model data isn't available. The fallback
+     * grades by probability like the per-model tiers — LIKELY at/above
+     * [LIKELY_THRESHOLD] (≥ 50%), POSSIBLE in the [POSSIBLE_THRESHOLD]–49% chance
+     * band — so a sub-50% base-only forecast reads "Chance of rain", not a
+     * definite "Rain". The [POSSIBLE_THRESHOLD] bar is aligned with the umbrella
+     * default's gate and the conditions strip, so all three surface rain together.
      *
      * Condition resolution: prefers the base hour's weather code at the peak
      * time when it's a precipitating type; falls back to the day-level
@@ -360,22 +363,32 @@ class RenderInsightSummary {
         val peak = today.hourly.maxByOrNull { it.precipitationProbabilityPct }
         val time: LocalTime
         val condition: WeatherCondition
+        val peakProb: Double
         if (peak == null || peak.precipitationProbabilityPct < POSSIBLE_THRESHOLD) {
             if (today.precipitationProbabilityMaxPct < POSSIBLE_THRESHOLD) return null
             time = LocalTime.NOON
             condition = today.condition
+            peakProb = today.precipitationProbabilityMaxPct
         } else {
             time = peak.time
             condition = if (peak.condition == WeatherCondition.UNKNOWN) today.condition else peak.condition
+            peakProb = peak.precipitationProbabilityPct
         }
         if (!condition.isPrecipitation()) return null
-        // All-day is measured against the LIKELY bar (≥ 50%), not the 30% peak
+        // All-day is measured against the LIKELY bar (≥ 50%), not the 20% peak
         // threshold above — "rain all day" should mean confident rain, so a day
-        // that only ever nudges 30–49% still names its single peak hour. The base
+        // that only ever nudges 20–49% still names its single peak hour. The base
         // hourly list is already in window order, so adjacency in the list is
         // adjacency in time (no LocalTime midnight-wrap aliasing).
         val allDay = isAllDayRain(today.hourly.map { it.precipitationProbabilityPct >= LIKELY_THRESHOLD })
-        return PeakPrecip(time, condition, PrecipLikelihood.LIKELY, allDay)
+        // Grade the base/no-per-model fallback by probability, mirroring the
+        // per-model tiers: a confident "Rain" only at/above LIKELY (≥ 50%), a
+        // hedged "Chance of rain" in the 20–49% band. Without this the fallback
+        // would assert definite rain for a sub-50% chance — overstating exactly
+        // the low-confidence forecasts the lowered 20% bar now surfaces.
+        val likelihood =
+            if (peakProb >= LIKELY_THRESHOLD) PrecipLikelihood.LIKELY else PrecipLikelihood.POSSIBLE
+        return PeakPrecip(time, condition, likelihood, allDay)
     }
 
     private fun pickPerModelPeak(today: DailyForecast, perModelHourly: PerModelHourly): PeakPrecip? {
@@ -429,14 +442,20 @@ class RenderInsightSummary {
             return PeakPrecip(likelyHour, perModelConditionAt(likelyHour, today), PrecipLikelihood.LIKELY, allDay)
         }
 
-        val possibleHour = models.asSequence()
+        val possibleReading = models.asSequence()
             .flatten()
             .filter { (it.precipitationProbabilityPct ?: 0.0) >= POSSIBLE_THRESHOLD }
             .maxByOrNull { it.precipitationProbabilityPct ?: 0.0 }
-            ?.time
-            ?.toLocalTime()
-        if (possibleHour != null) {
-            return PeakPrecip(possibleHour, perModelConditionAt(possibleHour, today), PrecipLikelihood.POSSIBLE)
+        if (possibleReading != null) {
+            val possibleHour = possibleReading.time.toLocalTime()
+            // Keep the driving model's own precip *type*: a 20–49% drizzle / snow
+            // reading should read "chance of drizzle / snow", not default to rain.
+            // perModelConditionAt only sees the base hourly/daily code (which can
+            // be dry while a model quietly codes drizzle), so prefer the reading's
+            // effective condition and fall back to the base only when it has none.
+            val condition = possibleReading.effectivePrecipCondition()
+                ?: perModelConditionAt(possibleHour, today)
+            return PeakPrecip(possibleHour, condition, PrecipLikelihood.POSSIBLE)
         }
 
         // Drizzle / light-precip fallback, keyed off the weather code and precip
@@ -448,7 +467,7 @@ class RenderInsightSummary {
         // precipitation_probability. The two POP tiers above are blind to
         // exactly that signal: AIFS contributes a drizzle code + 0.1 mm but no
         // probability, so it never counts toward a per-hour majority and never
-        // clears the 30% possible bar. Surface it as POSSIBLE — one model's
+        // clears the 20% possible bar. Surface it as POSSIBLE — one model's
         // drizzle code is a hedged "chance of drizzle" heads-up, not a confident
         // call. We scan the whole window rather than pinning an hour: drizzle
         // timing is too fuzzy to claim precision, and a precip code anywhere in

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/model/ClothesRuleTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/model/ClothesRuleTest.kt
@@ -93,10 +93,13 @@ class ClothesRuleTest {
     }
 
     @Test
-    fun `precipitation rule uses peak probability`() {
+    fun `precipitation rule uses peak probability and is inclusive at the gate`() {
         val rule = ClothesRule(Garment.JACKET, ClothesRule.PrecipitationProbabilityAbove(50.0))
         rule.appliesTo(forecast(min = 10.0, max = 18.0, precip = 65.0)) shouldBe true
         rule.appliesTo(forecast(min = 10.0, max = 18.0, precip = 30.0)) shouldBe false
+        // Inclusive (≥) so the boundary matches the prose / strip: a forecast
+        // exactly on the gate fires.
+        rule.appliesTo(forecast(min = 10.0, max = 18.0, precip = 50.0)) shouldBe true
     }
 
     @Test

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/RenderInsightSummaryTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/RenderInsightSummaryTest.kt
@@ -679,7 +679,7 @@ class RenderInsightSummaryTest {
     }
 
     @Test
-    fun `precip clause is omitted when every model stays below 30 percent`() {
+    fun `precip clause is omitted when every model stays below 20 percent`() {
         val today = mildToday.copy(
             precipitationProbabilityMaxPct = 10.0,
             condition = WeatherCondition.PARTLY_CLOUDY,
@@ -688,11 +688,59 @@ class RenderInsightSummaryTest {
             ),
         )
         val perModel = perModelHourly(
-            "gfs_seamless" to listOf(perModelHour(LocalTime.of(10, 0), 20.0)),
-            "ecmwf_ifs04" to listOf(perModelHour(LocalTime.of(10, 0), 25.0)),
+            "gfs_seamless" to listOf(perModelHour(LocalTime.of(10, 0), 10.0)),
+            "ecmwf_ifs04" to listOf(perModelHour(LocalTime.of(10, 0), 15.0)),
             "icon_seamless" to listOf(perModelHour(LocalTime.of(10, 0), 5.0)),
         )
         subject(today, yesterday, emptyList(), perModelHourly = perModel).precip.shouldBeNull()
+    }
+
+    @Test
+    fun `base fallback hedges a sub-50 percent rain code as a chance`() {
+        // No per-model data (failed multi-model call / older cache): the base
+        // hourly carries a 25% rain code. That's the chance-of-rain band, so the
+        // clause must be POSSIBLE ("Chance of rain"), not a definite LIKELY "Rain".
+        val today = mildToday.copy(
+            precipitationProbabilityMaxPct = 25.0,
+            condition = WeatherCondition.RAIN,
+            hourly = listOf(HourlyForecast(LocalTime.of(15, 0), 18.0, 18.0, 25.0, WeatherCondition.RAIN)),
+        )
+        val out = subject(today, yesterday, emptyList()).precip
+        out.shouldNotBeNull()
+        out!!.likelihood shouldBe PrecipLikelihood.POSSIBLE
+    }
+
+    @Test
+    fun `base fallback calls a majority-probability rain code LIKELY`() {
+        val today = mildToday.copy(
+            precipitationProbabilityMaxPct = 60.0,
+            condition = WeatherCondition.RAIN,
+            hourly = listOf(HourlyForecast(LocalTime.of(15, 0), 18.0, 18.0, 60.0, WeatherCondition.RAIN)),
+        )
+        val out = subject(today, yesterday, emptyList()).precip
+        out.shouldNotBeNull()
+        out!!.likelihood shouldBe PrecipLikelihood.LIKELY
+    }
+
+    @Test
+    fun `possible tier keeps a per-model drizzle code instead of defaulting to rain`() {
+        // 25% sits in the chance band (>= 20%); the model codes drizzle while the
+        // blended/base hour is dry. The clause must say "chance of drizzle", not
+        // default to rain via the base-only perModelConditionAt.
+        val today = mildToday.copy(
+            precipitationProbabilityMaxPct = 10.0,
+            condition = WeatherCondition.CLOUDY,
+            hourly = listOf(HourlyForecast(LocalTime.of(15, 0), 18.0, 18.0, 10.0, WeatherCondition.CLOUDY)),
+        )
+        val perModel = perModelHourly(
+            "gfs_seamless" to listOf(
+                perModelHour(LocalTime.of(15, 0), precipPct = 25.0, condition = WeatherCondition.DRIZZLE),
+            ),
+        )
+        val out = subject(today, yesterday, emptyList(), perModelHourly = perModel).precip
+        out.shouldNotBeNull()
+        out!!.condition shouldBe WeatherCondition.DRIZZLE
+        out.likelihood shouldBe PrecipLikelihood.POSSIBLE
     }
 
     @Test
@@ -1057,7 +1105,7 @@ class RenderInsightSummaryTest {
         // precip code or measurable amount, not a grey sky.
         val today = mildToday.copy(precipitationProbabilityMaxPct = 10.0, condition = WeatherCondition.CLOUDY)
         val perModel = perModelHourly(
-            "gfs_seamless" to listOf(perModelHour(LocalTime.of(10, 0), precipPct = 20.0, condition = WeatherCondition.CLOUDY)),
+            "gfs_seamless" to listOf(perModelHour(LocalTime.of(10, 0), precipPct = 18.0, condition = WeatherCondition.CLOUDY)),
             "ecmwf_ifs04" to listOf(perModelHour(LocalTime.of(10, 0), precipPct = 15.0, condition = WeatherCondition.PARTLY_CLOUDY)),
         )
         subject(today, yesterday, emptyList(), perModelHourly = perModel).precip.shouldBeNull()


### PR DESCRIPTION
## What & why

Aligns the prose's "chance of rain" threshold with the umbrella and the conditions strip. `PrecipProbability.POSSIBLE_THRESHOLD` drops **30% → 20%**, so all three rain surfaces now fire on the same days:

| Surface | Rain gate |
|---|---|
| Umbrella default rule | ≥ 20% chance OR a drizzle code |
| Conditions strip droplet | ≥ 20% chance OR a rain-shaped code |
| Prose "chance of rain" (POSSIBLE) | ≥ 20% (was 30%) |

Before this, a 20–29% chance would fire the umbrella and show the strip droplet while the forecast *text* stayed silent — surfaces disagreeing on the same screen.

## Notes

- `POSSIBLE_THRESHOLD` is shared, so the **week-ahead headline** tracks the same 20% bar (it's documented as only mentioning rain the today/tonight insight would).
- The **LIKELY** tier (confident "rain", not "chance of rain") is unchanged at **50%**.
- Updated the now-stale "30%" references in the prose KDocs, the `strings.xml` translator comments, and the `AGENTS.md` domain conventions.

## Test plan

- Updated two `RenderInsightSummaryTest` boundary cases that pinned the old 30% bar (now exercise the 20% bar with sub-20% per-model values).
- `./gradlew :core:domain:test :core:data:test :app:testDebugUnitTest` green; **no snapshot changes** (no preview falls in the 20–29% range).

### Follow-up still open
This closes the *threshold* half of `TODO(rain-confidence-reconcile)`. The remaining half — the rules/strip being **binary** while the prose **grades** confidence (single-model "chance" vs majority "rain") — is still open and under discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QqmafbvGC8Ld9Yo9Sv1cuh

---
_Generated by [Claude Code](https://claude.ai/code/session_01QqmafbvGC8Ld9Yo9Sv1cuh)_