### PR TITLE
Refresh home-screen widgets instead of showing a stale forecast

### DIFF
--- a/app/src/main/kotlin/app/clothescast/widget/ConditionsWidget.kt
+++ b/app/src/main/kotlin/app/clothescast/widget/ConditionsWidget.kt
@@ -28,7 +28,6 @@ import androidx.glance.text.FontWeight
 import androidx.glance.text.Text
 import androidx.glance.text.TextStyle
 import androidx.glance.unit.ColorProvider
-import app.clothescast.ClothesCastApplication
 import app.clothescast.R
 import app.clothescast.core.domain.model.windSpeedUnit
 import app.clothescast.insight.InsightFormatter
@@ -38,7 +37,6 @@ import app.clothescast.ui.garment.STRIP_SURFACE_LIGHT_ARGB
 import app.clothescast.ui.garment.conditionsCells
 import app.clothescast.ui.garment.outfitCardInfoLines
 import app.clothescast.ui.garment.renderConditionsStripBitmap
-import kotlinx.coroutines.flow.first
 
 /**
  * A glanceable home-screen widget showing the day's conditions as a horizontal
@@ -61,18 +59,15 @@ class ConditionsWidget : GlanceAppWidget() {
     override val sizeMode: SizeMode = SizeMode.Exact
 
     override suspend fun provideGlance(context: Context, id: GlanceId) {
-        val app = context.applicationContext as ClothesCastApplication
-        // Mirror OutfitWidget: read snapshot + prefs once, derive against the
-        // current prefs so a unit / theme change reflects without the cache
-        // moving. THIS_PERIOD specifically — NEXT_PERIOD is a pre-render of the
-        // upcoming window and would surface tomorrow's range mid-afternoon.
-        val prefs = runCatching { app.settingsRepository.preferences.first() }.getOrNull()
-        val snapshot = runCatching { app.insightCache.thisPeriod.first() }.getOrNull()
-        val insight = if (snapshot != null && prefs != null) {
-            runCatching { app.deriveInsight(snapshot, prefs).insight }.getOrNull()
-        } else {
-            null
-        }
+        // Shared loader: reads the THIS_PERIOD snapshot + prefs and derives
+        // against the current prefs (so a unit / theme change reflects without
+        // the cache moving), and returns null when the cached window has wholly
+        // elapsed — so a day-stale snapshot shows the empty state and self-heals
+        // rather than surfacing yesterday's range. NEXT_PERIOD is deliberately
+        // not consulted: it's a pre-render of the upcoming window.
+        val loaded = loadCurrentInsight(context)
+        val insight = loaded?.first
+        val prefs = loaded?.second
         // Compute the strip's labels / fill fractions here (off the composition)
         // so the temperature + peak-rain math runs on this dispatcher, reusing
         // the exact helper the outfit card uses.

--- a/app/src/main/kotlin/app/clothescast/widget/FeelsLikeWidget.kt
+++ b/app/src/main/kotlin/app/clothescast/widget/FeelsLikeWidget.kt
@@ -34,18 +34,14 @@ import androidx.glance.layout.padding
 import androidx.glance.text.FontWeight
 import androidx.glance.text.Text
 import androidx.glance.text.TextStyle
-import app.clothescast.ClothesCastApplication
 import app.clothescast.MainActivity
 import app.clothescast.R
 import app.clothescast.core.domain.model.DailyForecast
 import app.clothescast.core.domain.model.HourlyForecast
-import app.clothescast.core.domain.model.Insight
 import app.clothescast.core.domain.model.ThemeMode
-import app.clothescast.core.domain.model.UserPreferences
 import app.clothescast.diag.DiagLog
 import app.clothescast.ui.theme.ClothesCastTheme
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withTimeoutOrNull
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -198,7 +194,7 @@ private fun chartTapIntent(context: Context, page: Int): Intent =
 // cached forecast yet or the render fails / times out, so a flaky render
 // degrades to "tap to open" rather than crashing the launcher.
 private suspend fun buildChartBitmap(context: Context, id: GlanceId, weekly: Boolean): Bitmap? {
-    val (insight, prefs) = loadInsight(context) ?: return null
+    val (insight, prefs) = loadCurrentInsight(context) ?: return null
 
     val hourly: List<HourlyForecast>
     val days: List<DailyForecast>?
@@ -310,24 +306,6 @@ private fun chartRenderSizePx(context: Context, id: GlanceId): Pair<Int, Int> {
     widthPx = (widthPx * scale).roundToInt()
     heightPx = (heightPx * scale).roundToInt()
     return widthPx to heightPx
-}
-
-private suspend fun loadInsight(context: Context): Pair<Insight, UserPreferences>? {
-    val app = context.applicationContext as ClothesCastApplication
-    val prefs = runCatching { app.settingsRepository.preferences.first() }
-        .onFailure { DiagLog.w(TAG, "Widget: reading preferences failed", it) }
-        .getOrNull() ?: return null
-    val snapshot = runCatching { app.insightCache.thisPeriod.first() }
-        .onFailure { DiagLog.w(TAG, "Widget: reading cached snapshot failed", it) }
-        .getOrNull()
-    if (snapshot == null) {
-        DiagLog.i(TAG, "Widget: no cached forecast yet — showing empty state")
-        return null
-    }
-    val insight = runCatching { app.deriveInsight(snapshot, prefs).insight }
-        .onFailure { DiagLog.w(TAG, "Widget: deriveInsight failed", it) }
-        .getOrNull() ?: return null
-    return insight to prefs
 }
 
 // Mirrors MainActivity's theme resolution so the widget's dark mode tracks the

--- a/app/src/main/kotlin/app/clothescast/widget/OutfitWidget.kt
+++ b/app/src/main/kotlin/app/clothescast/widget/OutfitWidget.kt
@@ -40,7 +40,6 @@ import androidx.glance.text.FontWeight
 import androidx.glance.text.Text
 import androidx.glance.text.TextAlign
 import androidx.glance.text.TextStyle
-import app.clothescast.ClothesCastApplication
 import app.clothescast.MainActivity
 import app.clothescast.R
 import app.clothescast.core.domain.model.ForecastPeriod
@@ -53,7 +52,6 @@ import app.clothescast.ui.garment.outfitGarmentCaptionLineCount
 import app.clothescast.ui.garment.renderOutfitBitmap
 import app.clothescast.ui.garment.renderCarriedFigureBitmap
 import app.clothescast.ui.garment.renderTopWithHandsBitmap
-import kotlinx.coroutines.flow.first
 
 /**
  * A glanceable home-screen widget showing the current period's outfit — top icon,
@@ -77,22 +75,18 @@ class OutfitWidget : GlanceAppWidget() {
     override val sizeMode: SizeMode = SizeMode.Exact
 
     override suspend fun provideGlance(context: Context, id: GlanceId) {
-        val app = context.applicationContext as ClothesCastApplication
-        // Read snapshot + prefs once per provideGlance() pass and derive the
-        // insight against the current prefs — so a settings change picked up
-        // by an updateAll() reflects the new outfit / mention mode without
-        // the cache itself having moved. We read THIS_PERIOD specifically
-        // (not "freshest of either slot") because NEXT_PERIOD is a pre-
-        // render of the upcoming window — taking the newer-generated-at
-        // would surface "Tonight" while the user is still in the daytime
-        // window the morning worker just delivered.
-        val prefs = runCatching { app.settingsRepository.preferences.first() }.getOrNull()
-        val snapshot = runCatching { app.insightCache.thisPeriod.first() }.getOrNull()
-        val insight = if (snapshot != null && prefs != null) {
-            runCatching { app.deriveInsight(snapshot, prefs).insight }.getOrNull()
-        } else {
-            null
-        }
+        // Shared loader: reads the THIS_PERIOD snapshot + prefs and derives the
+        // insight against the current prefs — so a settings change picked up by
+        // an updateAll() reflects the new outfit / mention mode without the cache
+        // itself having moved — and returns null when the cached window has
+        // wholly elapsed, so a day-stale snapshot shows the empty state and
+        // self-heals rather than surfacing the wrong outfit. THIS_PERIOD
+        // specifically (not "freshest of either slot"): NEXT_PERIOD is a
+        // pre-render of the upcoming window and would surface "Tonight" while
+        // the user is still in the daytime window the morning worker delivered.
+        val loaded = loadCurrentInsight(context)
+        val insight = loaded?.first
+        val prefs = loaded?.second
         // Per-garment colour overrides — empty when the user hasn't customised.
         // Pulled here (not inside the Composable) so the bitmap rasterizer can
         // run on this dispatcher rather than during composition.

--- a/app/src/main/kotlin/app/clothescast/widget/WidgetInsightLoader.kt
+++ b/app/src/main/kotlin/app/clothescast/widget/WidgetInsightLoader.kt
@@ -1,0 +1,150 @@
+package app.clothescast.widget
+
+import android.content.Context
+import app.clothescast.ClothesCastApplication
+import app.clothescast.core.domain.model.Insight
+import app.clothescast.core.domain.model.UserPreferences
+import app.clothescast.diag.DiagLog
+import app.clothescast.work.FetchAndNotifyWorker
+import kotlinx.coroutines.flow.first
+import java.time.Duration
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.ZoneId
+
+/**
+ * Loads the current-period insight every home-screen widget renders from: reads
+ * the [app.clothescast.data.InsightCache.Slot.THIS_PERIOD] snapshot plus the
+ * live [UserPreferences], derives the insight against those prefs, and — the
+ * point of routing every widget through one loader — returns null when the
+ * cached snapshot's rendered window has wholly elapsed.
+ *
+ * Why the freshness gate exists: the widgets have no polling of their own
+ * (`updatePeriodMillis=0`; refreshes are pushed by the fetch worker via
+ * `updateAll()`). When scheduled delivery is off, the cache only moves on
+ * app-open — so a user who hasn't opened the app since yesterday was shown
+ * *yesterday's* forecast plotted as today's. The per-period feels-like chart is
+ * the clearest victim: it plots hour-of-day points for the snapshot's own date,
+ * so a day-old snapshot draws a previous day's curve under today's axis (the
+ * bug report's "Feels like 17 – 22°C" was yesterday's range, not today's).
+ *
+ * Rather than confidently render stale data, a widget whose snapshot has elapsed
+ * shows its empty state, and we kick a silent refresh on the way out so it
+ * self-heals: the worker's cache write fires `updateAll()`, which re-renders the
+ * widget off the fresh snapshot. The refresh is enqueued unique+KEEP, so the
+ * widgets sharing this loader coalesce onto one in-flight run.
+ */
+internal suspend fun loadCurrentInsight(context: Context): Pair<Insight, UserPreferences>? {
+    val app = context.applicationContext as ClothesCastApplication
+    val prefs = runCatching { app.settingsRepository.preferences.first() }
+        .onFailure { DiagLog.w(TAG, "Widget: reading preferences failed", it) }
+        .getOrNull() ?: return null
+    val snapshot = runCatching { app.insightCache.thisPeriod.first() }
+        .onFailure { DiagLog.w(TAG, "Widget: reading cached snapshot failed", it) }
+        .getOrNull()
+    if (snapshot == null) {
+        DiagLog.i(TAG, "Widget: no cached forecast yet — showing empty state")
+        return null
+    }
+    val insight = runCatching { app.deriveInsight(snapshot, prefs).insight }
+        .onFailure { DiagLog.w(TAG, "Widget: deriveInsight failed", it) }
+        .getOrNull() ?: return null
+    when (widgetCacheAction(insight, Instant.now(), prefs.schedule.time, prefs.tonightSchedule.time)) {
+        WidgetCacheAction.RENDER -> Unit
+        WidgetCacheAction.KEEP ->
+            DiagLog.i(
+                TAG,
+                "Widget: cached ${insight.period} insight for ${insight.forDate} isn't the current " +
+                    "window, but a silent refresh can't reach it (post-midnight overnight window) — " +
+                    "keeping the last-known render rather than churning",
+            )
+        WidgetCacheAction.REFRESH -> {
+            DiagLog.i(
+                TAG,
+                "Widget: cached ${insight.period} insight for ${insight.forDate} is no longer the " +
+                    "current window — showing empty state and kicking a silent refresh",
+            )
+            FetchAndNotifyWorker.enqueueSilentRefresh(context)
+            return null
+        }
+    }
+    return insight to prefs
+}
+
+/** What a widget should do with the cached snapshot — see [widgetCacheAction]. */
+internal enum class WidgetCacheAction {
+    /** The snapshot is the current window (or freshly written) — render it as-is. */
+    RENDER,
+
+    /**
+     * Stale, *and* a silent refresh could replace it with the current window —
+     * render the empty state and kick one. The worker's cache write then
+     * re-renders the widget off the fresh snapshot.
+     */
+    REFRESH,
+
+    /**
+     * Stale, but a `dayOffset = 0` silent refresh can't reach the current window
+     * — render the last-known snapshot and *don't* kick one. The only such case
+     * is the ongoing overnight window in the post-midnight tail: it's dated
+     * yesterday and would need a `dayOffset = -1` the worker doesn't support, so
+     * a refresh would write the *upcoming* night instead. Keeping the last-known
+     * render until the morning cutoff makes the daytime window reachable again
+     * beats both blanking and churning toward a future-night snapshot.
+     */
+    KEEP,
+}
+
+/**
+ * Decides what a widget does with the cached [insight]: render it, render-and-
+ * refresh, or keep it without refreshing. The cached snapshot is the current
+ * window when its period+date is what a refresh kicked right now would target —
+ * the current period via [FetchAndNotifyWorker.currentPeriodForSchedule] and its
+ * dated day via [FetchAndNotifyWorker.playTargetDate], the same wrap-past-
+ * midnight logic (and the same `bundle.today.date == playTargetDate(...)` test)
+ * the worker's own cache match runs, in the device's wall clock [zone]. When it
+ * isn't — a day-old snapshot, or one left over from a crossed schedule boundary
+ * — plotting it would mislabel a previous window as the current one (the day-old
+ * "Feels like 17 – 22°C" case), so we [REFRESH].
+ *
+ * Two carve-outs keep that from churning:
+ *
+ *  - **Loop-breaker (age).** The worker stamps [Insight.forDate] from the
+ *    *forecast location's* zone but picks the period from the *device* clock, so
+ *    for a manual location a calendar day off the device the period/date match
+ *    can disagree with what a refresh just wrote. Accepting any snapshot younger
+ *    than [FetchAndNotifyWorker.SILENT_REFRESH_MIN_AGE] ([RENDER]) guarantees a
+ *    freshly written one ends the staleness instead of feeding refresh→reject→…
+ *  - **Unreachable window ([KEEP]).** A `dayOffset = 0` refresh can only produce
+ *    the window dated *today*; the ongoing overnight window post-midnight is
+ *    dated yesterday, so a refresh can't reach it and would write the upcoming
+ *    night. We render the last-known snapshot without refreshing until the
+ *    morning cutoff.
+ *
+ * In the common case — device location, so forecast zone == device zone — forDate
+ * and the device date never diverge, the age gate is moot, and the only [KEEP]
+ * is the genuine post-midnight overnight window. The forecast zone still governs
+ * only where the chart's "now" line falls, not which cast is current.
+ */
+internal fun widgetCacheAction(
+    insight: Insight,
+    now: Instant,
+    morningTime: LocalTime,
+    tonightTime: LocalTime,
+    zone: ZoneId = ZoneId.systemDefault(),
+): WidgetCacheAction {
+    val localNow = LocalDateTime.ofInstant(now, zone)
+    val currentPeriod = FetchAndNotifyWorker.currentPeriodForSchedule(morningTime, tonightTime, localNow.toLocalTime())
+    val currentDate = FetchAndNotifyWorker.playTargetDate(currentPeriod, localNow, morningTime, tonightTime)
+    if (insight.period == currentPeriod && insight.forDate == currentDate) return WidgetCacheAction.RENDER
+    if (Duration.between(insight.generatedAt, now) < FetchAndNotifyWorker.SILENT_REFRESH_MIN_AGE) {
+        return WidgetCacheAction.RENDER
+    }
+    // currentDate trails the device date only in the post-midnight tail of the
+    // tonight window, where a dayOffset-0 refresh can't reach the ongoing night.
+    if (currentDate != localNow.toLocalDate()) return WidgetCacheAction.KEEP
+    return WidgetCacheAction.REFRESH
+}
+
+private const val TAG = "Widget"

--- a/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
@@ -2251,13 +2251,24 @@ class FetchAndNotifyWorker(
         fun currentPeriodForSchedule(
             prefs: UserPreferences,
             now: LocalTime = LocalTime.now(),
+        ): ForecastPeriod = currentPeriodForSchedule(prefs.schedule.time, prefs.tonightSchedule.time, now)
+
+        /**
+         * [currentPeriodForSchedule] over raw cutoff times rather than the whole
+         * [UserPreferences] — so callers that already hold the schedule times
+         * (e.g. the widget freshness gate) can share the exact tonight-window
+         * test without threading prefs through, and without re-deriving the
+         * wrap-past-midnight logic by hand.
+         */
+        fun currentPeriodForSchedule(
+            morningTime: LocalTime,
+            tonightTime: LocalTime,
+            now: LocalTime,
         ): ForecastPeriod {
-            val morning = prefs.schedule.time
-            val tonight = prefs.tonightSchedule.time
-            val inTonightWindow = if (tonight > morning) {
-                now >= tonight || now < morning
+            val inTonightWindow = if (tonightTime > morningTime) {
+                now >= tonightTime || now < morningTime
             } else {
-                now >= tonight && now < morning
+                now >= tonightTime && now < morningTime
             }
             return if (inTonightWindow) ForecastPeriod.TONIGHT else ForecastPeriod.TODAY
         }

--- a/app/src/test/kotlin/app/clothescast/widget/WidgetInsightFreshnessTest.kt
+++ b/app/src/test/kotlin/app/clothescast/widget/WidgetInsightFreshnessTest.kt
@@ -1,0 +1,141 @@
+package app.clothescast.widget
+
+import app.clothescast.core.domain.model.BandClause
+import app.clothescast.core.domain.model.ForecastPeriod
+import app.clothescast.core.domain.model.Insight
+import app.clothescast.core.domain.model.InsightSummary
+import app.clothescast.core.domain.model.TemperatureBand
+import app.clothescast.widget.WidgetCacheAction.KEEP
+import app.clothescast.widget.WidgetCacheAction.REFRESH
+import app.clothescast.widget.WidgetCacheAction.RENDER
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.ZoneId
+
+/**
+ * Unit coverage for [widgetCacheAction] — the gate that stops the home-screen
+ * widgets plotting a previous window as the current one (the "Feels like
+ * 17 – 22°C" bug, where a day-stale daytime snapshot drew yesterday's curve
+ * under today's axis). It renders the cache when it's the current window,
+ * [REFRESH]es (empty + kick) when a refresh can replace it, and [KEEP]s the
+ * last-known render when a refresh can't reach the current window (the
+ * post-midnight overnight window) — never churning. A snapshot younger than the
+ * silent-refresh threshold is always rendered, so it can't settle into a loop.
+ * The render path itself needs a real display and is verified on-device; this
+ * locks the pure period/date logic. The default 07:00 / 19:00 cutoffs match the
+ * app's default morning / tonight schedule.
+ */
+class WidgetInsightFreshnessTest {
+
+    private val zone: ZoneId = ZoneId.of("Europe/London")
+    private val morning: LocalTime = LocalTime.of(7, 0)
+    private val tonight: LocalTime = LocalTime.of(19, 0)
+
+    @Test
+    fun `daytime snapshot renders during its own daytime`() {
+        assertEquals(RENDER, action(dayInsight(LocalDate.of(2026, 6, 18)), at(2026, 6, 18, 17, 3)))
+    }
+
+    @Test
+    fun `daytime snapshot refreshes once the user crosses into the tonight window`() {
+        // Past 19:00 a refresh would target tonight (reachable, dated today).
+        assertEquals(REFRESH, action(dayInsight(LocalDate.of(2026, 6, 18)), at(2026, 6, 18, 19, 30)))
+    }
+
+    @Test
+    fun `day-old daytime snapshot refreshes - the reported case`() {
+        // Bug report: snapshot for 2026-06-17 still on screen at 2026-06-18 17:03.
+        assertEquals(REFRESH, action(dayInsight(LocalDate.of(2026, 6, 17)), at(2026, 6, 18, 17, 3)))
+    }
+
+    @Test
+    fun `ongoing tonight snapshot renders in the small hours after midnight`() {
+        // Generated the evening of the 18th; at 01:00 on the 19th the current
+        // tonight window is still dated the 18th, so it matches.
+        assertEquals(RENDER, action(nightInsight(LocalDate.of(2026, 6, 18)), at(2026, 6, 19, 1, 0)))
+    }
+
+    @Test
+    fun `tonight snapshot refreshes once the next morning's cutoff passes`() {
+        assertEquals(REFRESH, action(nightInsight(LocalDate.of(2026, 6, 18)), at(2026, 6, 19, 7, 30)))
+    }
+
+    @Test
+    fun `post-midnight, a stale daytime snapshot is kept without refreshing`() {
+        // Codex P2: between midnight and the wake cutoff the ongoing night is
+        // dated yesterday, which a dayOffset-0 refresh can't fetch — it would
+        // write the upcoming night instead. Keep the last-known daytime render
+        // rather than churn toward a future-night snapshot.
+        assertEquals(KEEP, action(dayInsight(LocalDate.of(2026, 6, 18)), at(2026, 6, 19, 2, 0)))
+    }
+
+    @Test
+    fun `tonight snapshot honors a later-than-default wake time`() {
+        // Wake set to 09:00: the overnight widget stays current until then.
+        val lateMorning = LocalTime.of(9, 0)
+        assertEquals(
+            RENDER,
+            widgetCacheAction(nightInsight(LocalDate.of(2026, 6, 18)), at(2026, 6, 19, 8, 0), lateMorning, tonight, zone),
+        )
+        assertEquals(
+            REFRESH,
+            widgetCacheAction(nightInsight(LocalDate.of(2026, 6, 18)), at(2026, 6, 19, 9, 30), lateMorning, tonight, zone),
+        )
+    }
+
+    @Test
+    fun `daytime snapshot honors a later-than-default evening cutoff`() {
+        // Evening cutoff set to 21:00: the daytime widget stays current until then.
+        val lateEvening = LocalTime.of(21, 0)
+        assertEquals(
+            RENDER,
+            widgetCacheAction(dayInsight(LocalDate.of(2026, 6, 18)), at(2026, 6, 18, 20, 0), morning, lateEvening, zone),
+        )
+    }
+
+    @Test
+    fun `a just-written snapshot renders even when its date does not match`() {
+        // Loop-breaker: a cross-zone refresh can land a snapshot whose
+        // forecast-zone forDate (the 19th) differs from the device-clock target
+        // date (the 18th). Generated seconds ago, it's rendered so the kicked
+        // refresh ends the staleness instead of churning.
+        val justNow = at(2026, 6, 18, 20, 30)
+        val fresh = nightInsight(forDate = LocalDate.of(2026, 6, 19), generatedAt = justNow.minusSeconds(30))
+        assertEquals(RENDER, action(fresh, justNow))
+        // Same period/date mismatch, but hours old and in a reachable window →
+        // the age gate no longer protects it and a refresh is due.
+        val old = nightInsight(forDate = LocalDate.of(2026, 6, 19), generatedAt = justNow.minusSeconds(7200))
+        assertEquals(REFRESH, action(old, justNow))
+    }
+
+    private fun action(insight: Insight, now: Instant): WidgetCacheAction =
+        widgetCacheAction(insight, now, morning, tonight, zone)
+
+    private fun at(year: Int, month: Int, day: Int, hour: Int, minute: Int): Instant =
+        LocalDateTime.of(year, month, day, hour, minute).atZone(zone).toInstant()
+
+    // generatedAt defaults to the snapshot date's 07:00 — comfortably older than
+    // the silent-refresh threshold for any same-or-later test clock, so the age
+    // gate doesn't mask the period/date logic under test.
+    private fun dayInsight(forDate: LocalDate, generatedAt: Instant = forDate.atTime(7, 0).atZone(zone).toInstant()): Insight =
+        insight(ForecastPeriod.TODAY, forDate, generatedAt)
+
+    private fun nightInsight(forDate: LocalDate, generatedAt: Instant = forDate.atTime(19, 0).atZone(zone).toInstant()): Insight =
+        insight(ForecastPeriod.TONIGHT, forDate, generatedAt)
+
+    private fun insight(period: ForecastPeriod, forDate: LocalDate, generatedAt: Instant): Insight =
+        Insight(
+            summary = InsightSummary(
+                period = period,
+                band = BandClause(TemperatureBand.MILD, TemperatureBand.MILD),
+            ),
+            recommendedItems = emptyList(),
+            generatedAt = generatedAt,
+            forDate = forDate,
+            period = period,
+        )
+}

--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -17,6 +17,51 @@ after each cache write / relevant settings change (no per-widget polling):
 | `FeelsLikeWidget` | Current 12-hour feels-like line (pager page 0) | Off-screen Compose render of the real chart |
 | `SevenDayFeelsLikeWidget` | Next-7-days feels-like line (pager page 2) | Off-screen Compose render of the real chart |
 
+### Freshness gate
+
+There's no per-widget polling (`updatePeriodMillis=0`), so the cache only moves
+when the fetch worker writes it: on a scheduled morning/tonight alarm, on
+app-open, or on a manual refresh. With scheduled delivery off, a user who hasn't
+opened the app since yesterday would otherwise see *yesterday's* forecast
+plotted as today's — the per-period feels-like chart plots hour-of-day points
+for the snapshot's own date, so a day-old snapshot draws a previous day's curve
+under today's axis.
+
+So every widget loads through `loadCurrentInsight` (`WidgetInsightLoader.kt`),
+which calls `widgetCacheAction` to pick one of three actions. The cached
+snapshot is the *current window* when its `(period, date)` is what a silent
+refresh kicked right now would target — computed with the same
+`currentPeriodForSchedule` / `playTargetDate` the worker uses (the same
+`bundle.today.date == playTargetDate(...)` test the worker's own cache match
+runs), in the device's wall clock:
+
+- **`RENDER`** — it's the current window (or freshly written, see below); draw it.
+- **`REFRESH`** — stale and a refresh can replace it: draw the empty state and
+  kick a silent refresh. A day-old snapshot fails the date match; an evening
+  glance at a still-cached daytime snapshot fails the period match and self-heals
+  to tonight; the wrapping tonight window and customized wake / evening cutoffs
+  all fall out of the shared schedule logic. The worker's cache write then fires
+  `updateAllClothesCastWidgets`, re-rendering off the fresh snapshot — so it
+  self-heals on the next glance without the user opening the app.
+- **`KEEP`** — stale, but a `dayOffset = 0` refresh can't reach the current
+  window, so draw the last-known snapshot *without* refreshing. The only such
+  case is the ongoing overnight window in the post-midnight tail: it's dated
+  yesterday and would need a `dayOffset = -1` the worker doesn't support, so a
+  refresh would write the *upcoming* night instead. Keeping the last render until
+  the morning cutoff makes the daytime window reachable beats both blanking and
+  churning toward a future-night snapshot.
+
+A leading age check is the loop-breaker: the worker stamps `forDate` from the
+*forecast location's* zone but picks the period from the *device* clock, so for
+a manual location whose calendar date differs from the device's the period/date
+match can disagree with what a refresh just wrote — and re-kicking on that would
+churn. Rendering any snapshot younger than `SILENT_REFRESH_MIN_AGE` guarantees a
+freshly written one ends the staleness instead of feeding a loop. (In the common
+case — device location, so forecast zone == device zone — `forDate` and the
+device date never diverge, the age gate is moot, and the only `KEEP` is the
+genuine post-midnight overnight window.) The pure period/date logic is
+unit-tested (`WidgetInsightFreshnessTest`); the render plumbing stays on-device.
+
 Glance emits `RemoteViews`, so it **cannot host Compose or Vico directly**.
 Anything richer than Glance's own `Text`/`Image`/layout primitives has to be
 rasterized to a `Bitmap` first and shown via `ImageProvider`. The two charts


### PR DESCRIPTION
## What

The home-screen widgets render whatever the `THIS_PERIOD` insight cache holds, with **no polling of their own** (`updatePeriodMillis=0`; refreshes are pushed by the fetch worker via `updateAll()`). When scheduled morning/tonight delivery is **off**, the cache only moves on app-open — so a user who hasn't opened the app since the previous day is shown **yesterday's forecast plotted as today's**.

The per-period feels-like chart is the clearest victim: it plots hour-of-day points for the snapshot's own date, so a day-old snapshot draws yesterday's curve under today's axis.

### The reported case
- Today's cast (just fetched): feels-like min/max **17.5 / 25.5 °C** → should read ~"18 – 26°C"
- The widget chart showed **"Feels like 17 – 22°C"**
- Yesterday's (2026-06-17) historic feels-like min/max: **16.6 / 22.4 °C** → rounds to exactly **"17 – 22"**

The widget was rendering yesterday's snapshot. With both daily and tonight notifications disabled, nothing had refreshed the cache since the previous app-open.

## Fix

Route all four widgets through a shared `loadCurrentInsight()` (`WidgetInsightLoader.kt`) that picks one of three actions via `widgetCacheAction()`. The cached snapshot is the *current window* when its `(period, date)` is what a silent refresh kicked right now would target — computed with the same `currentPeriodForSchedule` / `playTargetDate` the worker uses (the same `bundle.today.date == playTargetDate(...)` test the worker's own cache match runs), in the device's wall clock:

- **`RENDER`** — it's the current window (or freshly written); draw it.
- **`REFRESH`** — stale and a refresh can replace it: draw the empty state and kick a silent refresh. A day-old snapshot fails the date match; an evening glance at a still-cached daytime snapshot fails the period match and self-heals to tonight. The worker's cache write then fires `updateAllClothesCastWidgets`, re-rendering off the fresh snapshot — so the widget **self-heals on the next glance** without the user opening the app.
- **`KEEP`** — stale, but a `dayOffset = 0` refresh can't reach the current window, so draw the last-known snapshot *without* refreshing. The only such case is the ongoing overnight window post-midnight: it's dated yesterday and would need a `dayOffset = -1` the worker doesn't support, so a refresh would write the *upcoming* night. Keeping the last render until the morning cutoff (when the daytime window becomes reachable) beats both blanking and churning toward a future-night snapshot.

**Loop-breaker:** the worker stamps `forDate` from the *forecast-location* zone but picks the period from the *device* clock, so for a manual location a calendar day off the device the period/date match can disagree with what a refresh just wrote. Rendering any snapshot younger than `SILENT_REFRESH_MIN_AGE` guarantees a freshly written one ends the staleness instead of feeding a "reject → refresh → reject" loop. In the common case (device location → forecast zone == device zone) `forDate` and the device date never diverge, the age gate is moot, and the only `KEEP` is the genuine post-midnight overnight window.

Adds a raw-cutoff-times overload of `currentPeriodForSchedule` so the gate can share the wrap-past-midnight period test without threading `UserPreferences` through. Also de-duplicates the near-identical snapshot+prefs+derive load the four widgets each had inline.

## Scope / privacy

No change to what crosses the device boundary — this only gates *display* of an already-cached snapshot and enqueues the existing silent-refresh worker. No new network, weather, or LLM/TTS payloads.

## Test plan

- `WidgetInsightFreshnessTest` asserts the three actions across: same-day `RENDER`, the day-old reported case (`REFRESH`), the daytime→tonight and post-midnight→daytime boundaries, the post-midnight overnight `KEEP`, custom wake / evening cutoffs, and the loop-breaker (a just-written cross-zone-dated snapshot renders; the same mismatch hours-old refreshes).
- Reused worker helpers stay covered by `SilentRefreshFreshnessTest` / `FetchAndNotifyWorkerTest`.
- `./gradlew :app:testDebugUnitTest` and `:app:assembleDebug` both green locally.
- The on-device `Presentation`/`VirtualDisplay` render plumbing is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K7vS2yVXomVfGpSGLoY8ez