### PR TITLE
Speak scheduled forecasts again on Android 15 and newer

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -41,6 +41,15 @@
     <!-- Daily notification. POST_NOTIFICATIONS is runtime on Android 13+. -->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
+    <!-- The scheduled briefing speaks from a WorkManager worker, i.e. the
+         background. Android 15+ refuses audio focus to background apps and
+         Android 17+ silences background AudioTrack writes outright, so the
+         worker promotes itself to a media-playback foreground service for the
+         brief delivery window (it can start one from the background because the
+         run is triggered by an exact alarm — an explicit FGS-start exemption). -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
+
     <!-- Read today's calendar events to enrich the morning insight. Opt-in via the
          Settings toggle; runtime grant requested from there. We deliberately do NOT
          declare WRITE_CALENDAR — ClothesCast only reads. -->
@@ -207,6 +216,15 @@
                 android:name="android.appwidget.provider"
                 android:resource="@xml/conditions_widget_info" />
         </receiver>
+
+        <!-- WorkManager hosts foreground workers in its own SystemForegroundService.
+             API 34+ requires the service to declare every foregroundServiceType it
+             runs with; merge the media-playback type onto WorkManager's declaration
+             so FetchAndNotifyWorker.setForeground(...) can use it for spoken delivery. -->
+        <service
+            android:name="androidx.work.impl.foreground.SystemForegroundService"
+            android:foregroundServiceType="mediaPlayback"
+            tools:node="merge" />
 
     </application>
 

--- a/app/src/main/kotlin/app/clothescast/diag/BugReport.kt
+++ b/app/src/main/kotlin/app/clothescast/diag/BugReport.kt
@@ -208,6 +208,7 @@ object BugReport {
         mqttPublishStatus: SettingsRepository.MqttPublishStatus?,
     ) {
         appendLine("MQTT bridge enabled: ${prefs.mqttBridgeEnabled}")
+        appendLine("MQTT skip phone speech: ${prefs.mqttSkipPhoneSpeech}")
         val hostLine = prefs.mqttHost?.takeIf { it.isNotBlank() }?.let { "$it:${prefs.mqttPort}" }
             ?: "(unset)"
         appendLine("MQTT broker: $hostLine")

--- a/app/src/main/kotlin/app/clothescast/notification/NotificationChannelRegistrar.kt
+++ b/app/src/main/kotlin/app/clothescast/notification/NotificationChannelRegistrar.kt
@@ -13,6 +13,7 @@ import app.clothescast.R
 internal const val CHANNEL_DAILY_INSIGHT = "daily_insight_v1"
 internal const val CHANNEL_TONIGHT_INSIGHT_DEFAULT = "tonight_insight_default_v1"
 internal const val CHANNEL_TONIGHT_INSIGHT_SILENT = "tonight_insight_silent_v1"
+internal const val CHANNEL_PLAYBACK = "playback_v1"
 
 // Retired channel IDs to delete on upgrade. Android persists channels by ID
 // until the app explicitly deletes them, so dropping the create call alone
@@ -79,8 +80,25 @@ object NotificationChannelRegistrar {
             lockscreenVisibility = android.app.Notification.VISIBILITY_PUBLIC
         }
 
+        // The foreground-service notification shown while a scheduled briefing
+        // speaks (see FetchAndNotifyWorker). LOW + no sound/vibration: it's a
+        // policy requirement for background audio, not a notification the user
+        // needs to act on, so it stays quiet and unobtrusive.
+        val playback = NotificationChannel(
+            CHANNEL_PLAYBACK,
+            context.getString(R.string.notification_channel_playback_name),
+            NotificationManager.IMPORTANCE_LOW,
+        ).apply {
+            description = context.getString(R.string.notification_channel_playback_description)
+            setShowBadge(false)
+            setSound(null, null)
+            enableVibration(false)
+            lockscreenVisibility = android.app.Notification.VISIBILITY_PUBLIC
+        }
+
         manager.createNotificationChannel(daily)
         manager.createNotificationChannel(tonightWithEvents)
         manager.createNotificationChannel(tonightSilent)
+        manager.createNotificationChannel(playback)
     }
 }

--- a/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
@@ -1,14 +1,17 @@
 package app.clothescast.work
 
 import android.content.Context
+import android.content.pm.ServiceInfo
 import android.location.LocationManager
 import app.clothescast.diag.DiagLog
+import androidx.core.app.NotificationCompat
 import androidx.core.content.getSystemService
 import androidx.work.BackoffPolicy
 import androidx.work.Constraints
 import androidx.work.CoroutineWorker
 import androidx.work.Data
 import androidx.work.ExistingWorkPolicy
+import androidx.work.ForegroundInfo
 import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkInfo
@@ -24,6 +27,7 @@ import app.clothescast.core.domain.model.HolidayTheme
 import app.clothescast.core.domain.model.Insight
 import app.clothescast.core.domain.model.Location
 import app.clothescast.core.domain.model.OutfitSuggestion
+import app.clothescast.core.domain.model.playsSpeech
 import app.clothescast.core.domain.model.TtsEngine
 import app.clothescast.core.domain.model.UserPreferences
 import app.clothescast.core.domain.model.windSpeedUnit
@@ -40,6 +44,7 @@ import app.clothescast.core.data.tts.WavEncoder
 import app.clothescast.core.data.tts.isRetryableGeminiTtsFailure
 import app.clothescast.data.InsightCache
 import app.clothescast.mqtt.MqttPublishOutcome
+import app.clothescast.notification.CHANNEL_PLAYBACK
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -166,6 +171,15 @@ class FetchAndNotifyWorker(
             DiagLog.e(TAG, "Failed to read user preferences; retrying", t)
             return Result.retry()
         }
+
+        // Promote to a media-playback foreground service as early as possible
+        // (before the jitter/alignment waits, so it lands inside the
+        // exact-alarm FGS-start exemption window) when this scheduled run will
+        // speak. Without it, the TTS later can't get audio focus on Android
+        // 15+ and is silenced outright on Android 17+ — both because the
+        // worker runs in the background. No-op for the play / cache-only /
+        // silent paths, which aren't alarm-driven.
+        promoteToPlaybackServiceIfNeeded(prefs)
 
         // On-demand play path: the Today screen's Play button and the
         // Schedule settings "Play now" buttons. Runs the full deliver()
@@ -1718,6 +1732,66 @@ class FetchAndNotifyWorker(
      * already passed (slow fetch, retry backoff), the wait is skipped and delivery
      * starts immediately.
      */
+    /**
+     * Promote a scheduled, speaking run to a media-playback foreground service
+     * so its TTS can actually be heard. Two background-audio restrictions make
+     * this necessary on modern Android, both because [FetchAndNotifyWorker]
+     * runs in the background:
+     *  - Android 15+ (API 35) refuses audio focus to apps that aren't the top
+     *    app or running a foreground service (`AUDIOFOCUS_REQUEST_FAILED`).
+     *  - Android 17+ goes further and silences background `AudioTrack` writes
+     *    entirely — so even "speak without focus" produces nothing.
+     *
+     * Only the alarm-driven path qualifies: a foreground "Play" tap already
+     * runs while the app is the top app (focus works without a service), and
+     * the exact-alarm exemption that lets us *start* a foreground service from
+     * the background only covers the alarm fire. We also skip it when the
+     * period's delivery mode won't speak, so notification-only users don't see
+     * a service notification for nothing. Best-effort: if the system refuses
+     * the start (e.g. the exemption window lapsed), log and continue in the
+     * background rather than failing the whole run.
+     */
+    private suspend fun promoteToPlaybackServiceIfNeeded(prefs: UserPreferences) {
+        val alarmTriggered = inputData.getLong(KEY_ALARM_FIRED_AT_MS, 0L) != 0L
+        if (!alarmTriggered) return
+        val period = inputData.getString(KEY_PERIOD)
+            ?.let { runCatching { ForecastPeriod.valueOf(it) }.getOrNull() }
+            ?: ForecastPeriod.TODAY
+        val mode = when (period) {
+            ForecastPeriod.TODAY -> prefs.deliveryMode
+            ForecastPeriod.TONIGHT -> prefs.tonightDeliveryMode
+        }
+        if (!mode.playsSpeech) return
+        runCatching { setForeground(playbackForegroundInfo()) }
+            .onFailure { t ->
+                if (t is CancellationException) throw t
+                DiagLog.w(TAG, "Couldn't start the playback foreground service; speech may be inaudible from the background.", t)
+            }
+    }
+
+    /**
+     * The notification carried by the playback foreground service (see
+     * [promoteToPlaybackServiceIfNeeded]). Silent and LOW-importance — it's a
+     * platform requirement for background audio, not a user-actionable post —
+     * and tagged `mediaPlayback` so the foreground-service type matches the
+     * permission and manifest declaration.
+     */
+    private fun playbackForegroundInfo(): ForegroundInfo {
+        val notification = NotificationCompat.Builder(applicationContext, CHANNEL_PLAYBACK)
+            .setSmallIcon(R.drawable.ic_notification_insight)
+            .setContentTitle(applicationContext.getString(R.string.notification_playback_title))
+            .setOngoing(true)
+            .setSilent(true)
+            .build()
+        // minSdk is 31, so the typed ForegroundInfo constructor (foreground
+        // service type, applied on API 29+) is always available here.
+        return ForegroundInfo(
+            PLAYBACK_NOTIFICATION_ID,
+            notification,
+            ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK,
+        )
+    }
+
     private suspend fun awaitDeliveryAlignment() {
         val alarmFiredAtMs = inputData.getLong(KEY_ALARM_FIRED_AT_MS, 0L)
         if (alarmFiredAtMs == 0L) return
@@ -1834,6 +1908,11 @@ class FetchAndNotifyWorker(
         // fresh forecast. Race vs. concurrent plays is handled in the
         // UI gate — see TodayState.anyWorkActive.
         const val UNIQUE_WORK_NAME_PLAY = "insight_play"
+
+        // Foreground-service notification ID for the playback service. Distinct
+        // from the insight notification IDs (1001 daily, 1003 tonight) so the
+        // service notification and the delivered insight don't clobber each other.
+        private const val PLAYBACK_NOTIFICATION_ID = 1005
 
         // Output Data keys for surfacing failure reasons in the UI.
         const val KEY_REASON = "reason"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1136,6 +1136,10 @@
     <string name="notification_channel_tonight_insight_silent_description">The evening weather summary when your evening is empty. Posted silently — you can glance at it on the lock screen, but it won\'t make a sound.</string>
     <string name="notification_tonight_insight_title">Tonight\'s ClothesCast</string>
 
+    <string name="notification_channel_playback_name">Speaking the forecast</string>
+    <string name="notification_channel_playback_description">Shown briefly while ClothesCast reads your scheduled forecast aloud. Required by Android so the audio can play from the background.</string>
+    <string name="notification_playback_title">Reading your forecast aloud…</string>
+
 
     <string name="settings_notification_permission_title">Notifications are blocked</string>
     <string name="settings_notification_permission_description">Without notification permission, your daily ClothesCast has nowhere to go. Grant it so ClothesCast can post tomorrow morning.</string>

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Settings.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Settings.kt
@@ -46,6 +46,10 @@ enum class DeliveryMode { NOTIFICATION_ONLY, TTS_ONLY, NOTIFICATION_AND_TTS, SIL
 val DeliveryMode.postsNotification: Boolean
     get() = this == DeliveryMode.NOTIFICATION_ONLY || this == DeliveryMode.NOTIFICATION_AND_TTS
 
+/** True for the two modes that speak the briefing aloud on the phone. */
+val DeliveryMode.playsSpeech: Boolean
+    get() = this == DeliveryMode.TTS_ONLY || this == DeliveryMode.NOTIFICATION_AND_TTS
+
 /**
  * Per-holiday firing state, with [AUTO] the default and [ON] / [OFF] as
  * explicit overrides:

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/model/DeliveryModeTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/model/DeliveryModeTest.kt
@@ -1,0 +1,29 @@
+package app.clothescast.core.domain.model
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+/**
+ * Locks the two derived predicates on [DeliveryMode] that gate delivery
+ * fan-out: [postsNotification] (which modes post a phone notification) and
+ * [playsSpeech] (which modes speak aloud, gating the playback foreground
+ * service in FetchAndNotifyWorker).
+ */
+class DeliveryModeTest {
+
+    @Test
+    fun `postsNotification covers the two notification-posting modes`() {
+        assertEquals(
+            setOf(DeliveryMode.NOTIFICATION_ONLY, DeliveryMode.NOTIFICATION_AND_TTS),
+            DeliveryMode.entries.filter { it.postsNotification }.toSet(),
+        )
+    }
+
+    @Test
+    fun `playsSpeech covers the two speaking modes`() {
+        assertEquals(
+            setOf(DeliveryMode.TTS_ONLY, DeliveryMode.NOTIFICATION_AND_TTS),
+            DeliveryMode.entries.filter { it.playsSpeech }.toSet(),
+        )
+    }
+}


### PR DESCRIPTION
From a "didn't speak the forecast" bug report (device on Android 17). Two commits.

## 1. Speak scheduled forecasts again on Android 15+ (the fix)

The briefing is spoken from `FetchAndNotifyWorker` — a background WorkManager worker — and modern Android forbids background audio:

- **Android 15 (API 35):** apps that aren't the top app or running a foreground service get `AUDIOFOCUS_REQUEST_FAILED` ([behavior change](https://developer.android.com/about/versions/15/behavior-changes-15)).
- **Android 17:** background `AudioTrack` writes are **silenced outright** ([background audio hardening](https://developer.android.com/about/versions/17/changes/bg-audio)) — so even "speak without focus" produces nothing. This is why the reporter (Pixel 10 Pro, Android 17) saw `Played 127943 PCM frames` in the log but heard nothing.

**Fix:** the worker promotes itself to a short-lived **`mediaPlayback` foreground service** for the delivery window, satisfying both restrictions. Details:

- Started as early in the run as possible so it lands inside the **exact-alarm FGS-start exemption** (scheduled runs fire from `setExactAndAllowWhileIdle`), then carries through the jitter/alignment waits and playback.
- Only **alarm-driven runs whose delivery mode actually speaks** are promoted — a foreground "Play" tap is already the top app (focus works), and notification-only/silent runs need no audio. New domain helper `DeliveryMode.playsSpeech` gates this (mirrors `postsNotification`).
- Best-effort: if the system refuses the start, it logs and continues in the background rather than failing the run.
- A low-importance, silent FGS notification ("Reading your forecast aloud…") shows briefly — a platform requirement for background audio, not a user-actionable post.

Adds `FOREGROUND_SERVICE` + `FOREGROUND_SERVICE_MEDIA_PLAYBACK` permissions and declares the `mediaPlayback` type on WorkManager's foreground service.

## 2. Show the MQTT skip-phone-speech setting in bug reports

The dump listed `Cast skip phone speech` but omitted the separate `mqttSkipPhoneSpeech` toggle, leaving a triage gap when MQTT is on and the phone is silent. Added next to `MQTT bridge enabled`.

## Background

An earlier attempt to fix this by poll-retrying `requestAudioFocus` was **correctly flagged P1 by Codex** and dropped — focus is denied structurally in the background, so retrying just stalls every run. See the [resolved thread](https://github.com/mikelward/clothescast/pull/1037#discussion_r3441260703). The foreground service is the actual remedy.

## Privacy

No change to what crosses the device boundary. Adds two normal-level FGS permissions and a brief local notification.

## Test plan

- `./gradlew :core:domain:test :core:data:test :app:testDebugUnitTest` and `:app:assembleDebug` pass locally; new `DeliveryModeTest` covers the gating helper.
- **Needs on-device verification** (audio-focus/FGS eligibility can't be exercised in JVM/Robolectric): on an Android 15+/17 device, confirm a scheduled briefing speaks, and that it speaks over/after other audio. One residual risk to watch: the exact-alarm FGS-start exemption must still be active when the worker calls `setForeground` shortly after the alarm — if a `ForegroundServiceStartNotAllowedException` shows in the log, we'd move the service start into `AlarmReceiver` instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)