### PR TITLE
Show Overnight and Today before dawn instead of Tonight and Tomorrow

### DIFF
--- a/app/src/main/kotlin/app/clothescast/data/InsightCache.kt
+++ b/app/src/main/kotlin/app/clothescast/data/InsightCache.kt
@@ -209,6 +209,8 @@ class InsightCache(
         val period: String = ForecastPeriod.TODAY.name,
         val generatedAtEpochMillis: Long,
         val historicYesterday: DailyHistoryDto? = null,
+        // Defaults false for payloads cached before the overnight feature.
+        val overnight: Boolean = false,
     ) {
         fun toDomain(): ForecastSnapshot {
             val domainBundle = bundle.toDomain()
@@ -219,6 +221,7 @@ class InsightCache(
                 period = runCatching { ForecastPeriod.valueOf(period) }.getOrDefault(ForecastPeriod.TODAY),
                 generatedAt = Instant.ofEpochMilli(generatedAtEpochMillis),
                 historicYesterday = historicYesterday?.toDomain(),
+                overnight = overnight,
             )
         }
     }
@@ -470,6 +473,7 @@ class InsightCache(
                 feelsLikeMaxC = it.feelsLikeMaxC,
             )
         },
+        overnight = overnight,
     )
 
     private fun ForecastBundle.toDto(): ForecastBundleDto = ForecastBundleDto(

--- a/app/src/main/kotlin/app/clothescast/insight/InsightFormatter.kt
+++ b/app/src/main/kotlin/app/clothescast/insight/InsightFormatter.kt
@@ -240,11 +240,11 @@ class InsightFormatter(
         val primaryClauses = buildList {
             when {
                 bandCallout != null ->
-                    add(formatBandAbsolute(summary.period, bandCallout, isFutureDay, omitLead))
+                    add(formatBandAbsolute(summary.period, bandCallout, isFutureDay, omitLead, summary.overnight))
                 else -> when (rangeFormat) {
                     RangeFormat.NONE -> Unit
-                    RangeFormat.DEGREES -> add(formatBand(summary.period, summary.band, isFutureDay, omitLead))
-                    RangeFormat.BANDS -> add(formatBandWords(summary.period, summary.band, isFutureDay, omitLead))
+                    RangeFormat.DEGREES -> add(formatBand(summary.period, summary.band, isFutureDay, omitLead, summary.overnight))
+                    RangeFormat.BANDS -> add(formatBandWords(summary.period, summary.band, isFutureDay, omitLead, summary.overnight))
                 }
             }
             // When the range is omitted there's no band sentence ahead of the
@@ -303,7 +303,7 @@ class InsightFormatter(
             // present it's the first primary clause. It renders as the
             // self-introducing "it will be …" fragment (insight_delta_*_lead)
             // that the period lead folds into ("Today, it will be 5° warmer …").
-            renderLeadOnly(summary.period, isFutureDay, primaryClauses, tieInClauses, omitLead)
+            renderLeadOnly(summary.period, isFutureDay, primaryClauses, tieInClauses, omitLead, summary.overnight)
         } else {
             (primaryClauses + tieInClauses).joinToString(" ")
         }
@@ -345,6 +345,7 @@ class InsightFormatter(
         primaryClauses: List<String>,
         tieInClauses: List<String>,
         omitLead: Boolean,
+        overnight: Boolean,
     ): String {
         if (primaryClauses.isEmpty()) {
             return tieInClauses.joinToString(" ")
@@ -358,7 +359,7 @@ class InsightFormatter(
             val first = capitalize(primaryClauses.first())
             return (listOf(first) + primaryClauses.drop(1) + tieInClauses).joinToString(" ")
         }
-        val lead = resources.getString(leadRes(period, isFutureDay))
+        val lead = resources.getString(leadRes(period, isFutureDay, overnight))
         val first = resources.getString(
             R.string.insight_lead_continues,
             lead,
@@ -461,7 +462,7 @@ class InsightFormatter(
 
     private fun normalizeItemKey(item: String): String = item.trim().lowercase(Locale.ROOT)
 
-    private fun formatBand(period: ForecastPeriod, band: BandClause, isFutureDay: Boolean, omitLead: Boolean): String {
+    private fun formatBand(period: ForecastPeriod, band: BandClause, isFutureDay: Boolean, omitLead: Boolean, overnight: Boolean): String {
         val low = band.feelsLikeMinC.toUnit(temperatureUnit).roundToInt()
         val high = band.feelsLikeMaxC.toUnit(temperatureUnit).roundToInt()
         if (omitLead) {
@@ -471,7 +472,7 @@ class InsightFormatter(
                 resources.getString(R.string.insight_band_range_no_lead, low, high)
             }
         }
-        val lead = resources.getString(leadRes(period, isFutureDay))
+        val lead = resources.getString(leadRes(period, isFutureDay, overnight))
         return if (low == high) {
             resources.getString(R.string.insight_band_single, lead, low)
         } else {
@@ -479,7 +480,7 @@ class InsightFormatter(
         }
     }
 
-    private fun formatBandWords(period: ForecastPeriod, band: BandClause, isFutureDay: Boolean, omitLead: Boolean): String {
+    private fun formatBandWords(period: ForecastPeriod, band: BandClause, isFutureDay: Boolean, omitLead: Boolean, overnight: Boolean): String {
         val low = resources.getString(bandRes(band.low))
         val high = resources.getString(bandRes(band.high))
         if (omitLead) {
@@ -491,7 +492,7 @@ class InsightFormatter(
                 resources.getString(R.string.insight_band_words_range_no_lead, capitalize(low), high)
             }
         }
-        val lead = resources.getString(leadRes(period, isFutureDay))
+        val lead = resources.getString(leadRes(period, isFutureDay, overnight))
         return if (band.low == band.high) {
             resources.getString(R.string.insight_band_words_single, lead, low)
         } else {
@@ -574,6 +575,7 @@ class InsightFormatter(
         band: TemperatureBand,
         isFutureDay: Boolean,
         omitLead: Boolean,
+        overnight: Boolean,
     ): String {
         val word = resources.getString(bandRes(band))
         if (omitLead) {
@@ -581,7 +583,7 @@ class InsightFormatter(
             // sentence opens like a sentence ("Hot.").
             return resources.getString(R.string.insight_band_words_single_no_lead, capitalize(word))
         }
-        val lead = resources.getString(leadRes(period, isFutureDay))
+        val lead = resources.getString(leadRes(period, isFutureDay, overnight))
         return resources.getString(R.string.insight_band_words_single, lead, word)
     }
 
@@ -816,9 +818,12 @@ class InsightFormatter(
             ""
         }
 
-    private fun leadRes(period: ForecastPeriod, isFutureDay: Boolean): Int = when (period) {
+    private fun leadRes(period: ForecastPeriod, isFutureDay: Boolean, overnight: Boolean): Int = when (period) {
         ForecastPeriod.TODAY -> if (isFutureDay) R.string.insight_lead_tomorrow else R.string.insight_lead_today
-        ForecastPeriod.TONIGHT -> R.string.insight_lead_tonight
+        // The ongoing overnight leads with "Overnight", not "Tonight", so the
+        // spoken / written prose matches the "Overnight" page + outfit labels.
+        ForecastPeriod.TONIGHT ->
+            if (overnight) R.string.insight_lead_overnight else R.string.insight_lead_tonight
     }
 
     private fun conditionRes(condition: WeatherCondition): Int = when (condition) {

--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
@@ -203,6 +203,7 @@ fun TodayScreen(
     val titleRes = topBarTitleRes(
         period = state.thisPeriodInsight?.period,
         page = pagerState.currentPage,
+        overnight = state.thisPeriodInsight?.summary?.overnight == true,
     )
     // System back on page 1 or 2 steps back one page instead of exiting the
     // app — matches the on-screen left chevron. Page 0 falls through to the
@@ -1968,7 +1969,7 @@ internal fun OutfitPreviewRow(
     onNavigateToClothes: () -> Unit = {},
 ) {
     val primary = insight.outfit ?: return
-    val (primaryLabel, nextLabel) = outfitLabels(insight.period)
+    val (primaryLabel, nextLabel) = outfitLabels(insight)
     // IntrinsicSize.Max + fillMaxHeight stretches both cards to the taller one's
     // height. The garment caption grows to as many lines as its content needs
     // (a long worn line wrapping on a narrow card, plus an accessory line) — so
@@ -2015,10 +2016,19 @@ internal fun OutfitPreviewRow(
     }
 }
 
-private fun outfitLabels(period: ForecastPeriod): Pair<Int, Int> = when (period) {
-    ForecastPeriod.TODAY -> R.string.today_outfit_label_today to R.string.today_outfit_label_tonight
-    ForecastPeriod.TONIGHT -> R.string.today_outfit_label_tonight to R.string.today_outfit_label_tomorrow
-}
+private fun outfitLabels(insight: Insight): Pair<Int, Int> =
+    when (insight.period) {
+        ForecastPeriod.TODAY ->
+            R.string.today_outfit_label_today to R.string.today_outfit_label_tonight
+        ForecastPeriod.TONIGHT ->
+            // Ongoing overnight → "Overnight" + "Today"; the coming night →
+            // "Tonight" + "Tomorrow".
+            if (insight.summary.overnight) {
+                R.string.today_outfit_label_overnight to R.string.today_outfit_label_today
+            } else {
+                R.string.today_outfit_label_tonight to R.string.today_outfit_label_tomorrow
+            }
+    }
 
 // Title shown in the TopAppBar — tracks the visible pager page so swiping
 // right from a morning view flips "Today" to "Tonight" (and the evening
@@ -2026,13 +2036,24 @@ private fun outfitLabels(period: ForecastPeriod): Pair<Int, Int> = when (period)
 // page 3 the following week (days 8-14); their titles are the same regardless
 // of which period the user opened from. Falls back to "Today" when no insight
 // is cached yet (pager isn't rendered in that state).
-internal fun topBarTitleRes(period: ForecastPeriod?, page: Int): Int {
+internal fun topBarTitleRes(
+    period: ForecastPeriod?,
+    page: Int,
+    overnight: Boolean = false,
+): Int {
     if (page == 2) return R.string.today_title_week
     if (page == 3) return R.string.today_title_following_week
+    // The ongoing overnight (post-midnight tail): page 0 is "Overnight", page 1
+    // the daytime it leads into ("Today").
     return when (period) {
         null -> R.string.today_title
         ForecastPeriod.TODAY -> if (page == 0) R.string.today_title else R.string.today_outfit_label_tonight
-        ForecastPeriod.TONIGHT -> if (page == 0) R.string.today_outfit_label_tonight else R.string.today_outfit_label_tomorrow
+        ForecastPeriod.TONIGHT ->
+            if (overnight) {
+                if (page == 0) R.string.today_outfit_label_overnight else R.string.today_outfit_label_today
+            } else {
+                if (page == 0) R.string.today_outfit_label_tonight else R.string.today_outfit_label_tomorrow
+            }
     }
 }
 
@@ -2482,14 +2503,17 @@ internal fun InsightCard(
     }
     // Page 2 caches tomorrow's daytime insight after the evening worker run;
     // surface it as "Tomorrow" rather than "Today" so the heading matches the
-    // prose lead-in below.
+    // prose lead-in below. The ongoing overnight (post-midnight tail) is flagged
+    // on the insight itself — "Overnight", not "Tonight".
     val isFutureDay = insight.forDate.isAfter(LocalDate.now())
     val periodLabel = stringResource(
         when (insight.period) {
             ForecastPeriod.TODAY ->
                 if (isFutureDay) R.string.today_outfit_label_tomorrow
                 else R.string.today_outfit_label_today
-            ForecastPeriod.TONIGHT -> R.string.today_outfit_label_tonight
+            ForecastPeriod.TONIGHT ->
+                if (insight.summary.overnight) R.string.today_outfit_label_overnight
+                else R.string.today_outfit_label_tonight
         },
     )
     val location = insight.location

--- a/app/src/main/kotlin/app/clothescast/widget/OutfitWidget.kt
+++ b/app/src/main/kotlin/app/clothescast/widget/OutfitWidget.kt
@@ -173,7 +173,7 @@ private fun OutfitWidgetContent(
             SideBySideContent(insight, size, topColors, bottomColors, handsColors, carriedColors, outerColors)
         } else {
             SingleColumnContent(
-                label = context.getString(periodLabelRes(insight.period)),
+                label = context.getString(periodLabelRes(insight)),
                 outfit = outfit,
                 size = size,
                 topColors = topColors,
@@ -325,7 +325,7 @@ private fun SideBySideContent(
     val context = LocalContext.current
     val primaryOutfit = insight.outfit ?: return
     val nextOutfit = insight.nextOutfit ?: return
-    val (primaryLabelRes, nextLabelRes) = sideBySideLabelRes(insight.period)
+    val (primaryLabelRes, nextLabelRes) = sideBySideLabelRes(insight)
     // Each column gets roughly half the available width; drive the per-column
     // scale off that half-width so icons / text don't try to grow into space
     // they don't actually have.
@@ -456,19 +456,28 @@ private fun scaledSubtitleSp(size: DpSize): TextUnit {
     return (short * 0.0688f).coerceAtLeast(10f).sp
 }
 
-private fun periodLabelRes(period: ForecastPeriod): Int = when (period) {
-    ForecastPeriod.TODAY -> R.string.today_outfit_label_today
-    ForecastPeriod.TONIGHT -> R.string.today_outfit_label_tonight
-}
+private fun periodLabelRes(insight: Insight): Int =
+    when (insight.period) {
+        ForecastPeriod.TODAY -> R.string.today_outfit_label_today
+        ForecastPeriod.TONIGHT ->
+            if (insight.summary.overnight) R.string.today_outfit_label_overnight
+            else R.string.today_outfit_label_tonight
+    }
 
 // Mirrors `outfitLabels` in TodayScreen.OutfitPreviewRow: the "next" period
-// after TODAY is TONIGHT, after TONIGHT it's TOMORROW.
-private fun sideBySideLabelRes(period: ForecastPeriod): Pair<Int, Int> = when (period) {
-    ForecastPeriod.TODAY ->
-        R.string.today_outfit_label_today to R.string.today_outfit_label_tonight
-    ForecastPeriod.TONIGHT ->
-        R.string.today_outfit_label_tonight to R.string.today_outfit_label_tomorrow
-}
+// after TODAY is TONIGHT, after TONIGHT it's TOMORROW — except the ongoing
+// overnight, which leads into TODAY.
+private fun sideBySideLabelRes(insight: Insight): Pair<Int, Int> =
+    when (insight.period) {
+        ForecastPeriod.TODAY ->
+            R.string.today_outfit_label_today to R.string.today_outfit_label_tonight
+        ForecastPeriod.TONIGHT ->
+            if (insight.summary.overnight) {
+                R.string.today_outfit_label_overnight to R.string.today_outfit_label_today
+            } else {
+                R.string.today_outfit_label_tonight to R.string.today_outfit_label_tomorrow
+            }
+    }
 
 // Top-icon accessible label, appending the carried / extremity gear the
 // composited overlay shows so a screen reader names the whole glance ("Coat,

--- a/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
@@ -233,7 +233,13 @@ class FetchAndNotifyWorker(
         }
 
         val isSilentRefresh = inputData.getBoolean(KEY_SILENT_REFRESH, false)
-        val today = LocalDate.now()
+        // Read wall-clock time once and derive both the date and every
+        // schedule-relative decision (period selection + day-offset) from the
+        // same instant. Two separate now() reads can straddle the morning cutoff
+        // mid-run (e.g. 06:59 → 07:00), which would pick the period for one side
+        // of the boundary and the day-offset for the other.
+        val now = LocalDateTime.now()
+        val today = now.toLocalDate()
         // Silent refreshes — app-open, onboarding, and the manual Refresh tap —
         // derive the window from the user's schedule against wall-clock time at
         // *run* time, so they refresh whichever 12-hour window the user is
@@ -243,12 +249,17 @@ class FetchAndNotifyWorker(
         // window choice ignores them — the Today screen shows both windows from
         // the cache regardless.
         val period = if (isSilentRefresh) {
-            currentPeriodForSchedule(prefs)
+            currentPeriodForSchedule(prefs, now.toLocalTime())
         } else {
             inputData.getString(KEY_PERIOD)
                 ?.let { runCatching { ForecastPeriod.valueOf(it) }.getOrNull() }
                 ?: ForecastPeriod.TODAY
         }
+
+        // True when the current TONIGHT window is the ongoing overnight (the
+        // post-midnight tail). Same [now] as the period selection so the two
+        // can't disagree across the morning cutoff. See [currentWindowIsOvernight].
+        val overnight = currentWindowIsOvernight(prefs, period, now.toLocalTime())
 
         // The enable toggles gate *scheduled* delivery only: the tonight alarm
         // rearms blindly via AlarmReceiver, so the toggle is honoured here to stop
@@ -377,11 +388,11 @@ class FetchAndNotifyWorker(
                 .getOrElse {
                     if (it is CancellationException) throw it
                     DiagLog.e(TAG, "Cached delivery failed; falling through to fresh generate.", it)
-                    fresh(location, prefs, period)
+                    fresh(location, prefs, period, overnight)
                 }
         }
 
-        return fresh(location, prefs, period)
+        return fresh(location, prefs, period, overnight)
     }
 
     /**
@@ -404,9 +415,9 @@ class FetchAndNotifyWorker(
         val currentPeriod = currentPeriodForSchedule(prefs, now.toLocalTime())
         // The calendar date the [requestedPeriod] cast the user wants is dated
         // for. Accounts for the nightly window wrapping past midnight (see
-        // [playTargetDate]): in the post-midnight tail of the night the current
-        // nightly snapshot is still dated *yesterday*, and the next daytime cast
-        // is *this* morning (today), not tomorrow.
+        // [playTargetDate]): in the post-midnight tail the next daytime cast is
+        // *this* morning (today), not tomorrow. The nightly cast is always
+        // today's — the ongoing overnight snapshot stays anchored on today.
         val targetDate = playTargetDate(
             requestedPeriod,
             now,
@@ -450,23 +461,29 @@ class FetchAndNotifyWorker(
         // When the requested period IS the current window, route through the
         // full fresh() path so the fetched snapshot lands in the cache (+
         // next-window pre-capture, + history): an empty-cache Play populates
-        // the Today screen as a side effect. (Current-window play always has
-        // dayOffset 0, which fresh() uses internally.) When it's the *other*
+        // the Today screen as a side effect. Current-window play carries the same
+        // overnight flag the silent refresh would ([currentWindowIsOvernight]) so
+        // a post-midnight Play of the ongoing overnight casts the night "now"
+        // sits in, matching what the Today screen shows. When it's the *other*
         // window (e.g. "Play now" on Nightly tapped in the morning, or on Daily
         // tapped at night), fetch ephemerally for the right day and DON'T
         // store — fresh() always writes THIS_PERIOD, which would clobber the
         // current window's snapshot the Today screen is showing.
         if (requestedPeriod == currentPeriod) {
             DiagLog.i(TAG, "Play cache miss for current window $requestedPeriod; fetching fresh.")
-            return fresh(location, prefs, requestedPeriod)
+            return fresh(
+                location,
+                prefs,
+                requestedPeriod,
+                currentWindowIsOvernight(prefs, requestedPeriod, now.toLocalTime()),
+            )
         }
-        // capturedSnapshot only supports dayOffset 0 (either period) or 1
-        // (TODAY = tomorrow's daytime). The non-current ephemeral path only ever
-        // needs tomorrow's daytime (+1, when Daily is tapped in the evening);
-        // every other non-current case is today (0). The overnight "current
-        // night dated yesterday" can't be fetched — Open-Meteo anchors to the
-        // real calendar day — but that case is the *current* window, so it goes
-        // through the cache hit or the fresh() branch above, never here.
+        // capturedSnapshot supports dayOffset 0 (either period) and 1 (TODAY =
+        // tomorrow's daytime). The non-current ephemeral path only ever needs
+        // tomorrow's daytime (+1, when Daily is tapped in the evening); every
+        // other non-current case is today (0). The overnight is always the
+        // *current* window, so it goes through the cache hit or the fresh()
+        // branch above, never here (and isn't an ephemeral fetch).
         val fetchDayOffset =
             if (requestedPeriod == ForecastPeriod.TODAY && targetDate.isAfter(now.toLocalDate())) 1 else 0
         DiagLog.i(TAG, "Play cache miss for non-current window $requestedPeriod (+${fetchDayOffset}d); ephemeral fetch.")
@@ -515,6 +532,7 @@ class FetchAndNotifyWorker(
         location: Location,
         prefs: UserPreferences,
         period: ForecastPeriod,
+        overnight: Boolean = false,
     ): Result {
         // Spread alarm-triggered fetches across a small window so multiple
         // devices on the same home IP (alarms armed for the same wall-clock
@@ -545,7 +563,7 @@ class FetchAndNotifyWorker(
             // lands in the cache so any later settings change re-renders
             // off the same upstream data for free; the derive call here is the
             // one we deliver on this run.
-            val snapshot = capturedSnapshot(location, prefs, period, dayOffset = 0)
+            val snapshot = capturedSnapshot(location, prefs, period, dayOffset = 0, overnight = overnight)
             val insight = app.deriveInsight(snapshot, prefs, diagLog = { DiagLog.i(TAG, it) }).insight
             val isSilentRun = inputData.getBoolean(KEY_SILENT_REFRESH, false)
             runCatching { app.insightCache.store(InsightCache.Slot.THIS_PERIOD, snapshot) }
@@ -579,7 +597,7 @@ class FetchAndNotifyWorker(
             // consults Slot.THIS_PERIOD so the next morning's fresh fetch
             // isn't suppressed by yesterday-evening's tomorrow-daytime
             // pre-render.
-            val pairedSnapshot = generatePairedInsight(location, prefs, period)
+            val pairedSnapshot = generatePairedInsight(location, prefs, period, overnight)
             // Render once per delivery so notification, TTS, and the audit log
             // all share the same string and we don't reconfigure the
             // Configuration-overridden Resources three times per fire.
@@ -681,6 +699,10 @@ class FetchAndNotifyWorker(
      *    daytime — generated with `dayOffset = 1`, `period = TODAY`. The
      *    bundle's `forecast_days=2` response carries tomorrow's full daily
      *    aggregates + hourly, so no extra fetch is needed.
+     *  - Post-midnight overnight (`primaryPeriod = TONIGHT`, [primaryOvernight]
+     *    = true): the primary is the ongoing night, so the next window is
+     *    *today's* daytime — `period = TODAY` at `dayOffset = 0`. This is what
+     *    makes the 6am pager read "Overnight" + "Today".
      *
      * Silent — no notification, no TTS, no widget update. Failures are
      * logged and swallowed; the Today screen's pager falls back to its
@@ -690,12 +712,16 @@ class FetchAndNotifyWorker(
         location: Location,
         prefs: UserPreferences,
         primaryPeriod: ForecastPeriod,
+        primaryOvernight: Boolean,
     ): ForecastSnapshot? {
-        val nextWindowPeriod = when (primaryPeriod) {
-            ForecastPeriod.TODAY -> ForecastPeriod.TONIGHT
-            ForecastPeriod.TONIGHT -> ForecastPeriod.TODAY
+        // The overnight pairs with today's daytime (dayOffset 0); the coming
+        // night with tomorrow's (dayOffset 1); the morning with that evening's
+        // night (dayOffset 0). The paired window is never itself an overnight.
+        val (nextWindowPeriod, dayOffset) = when {
+            primaryOvernight -> ForecastPeriod.TODAY to 0
+            primaryPeriod == ForecastPeriod.TODAY -> ForecastPeriod.TONIGHT to 0
+            else -> ForecastPeriod.TODAY to 1
         }
-        val dayOffset = if (primaryPeriod == ForecastPeriod.TONIGHT) 1 else 0
         return runCatching {
             val snapshot = capturedSnapshot(location, prefs, nextWindowPeriod, dayOffset)
             app.insightCache.store(InsightCache.Slot.NEXT_PERIOD, snapshot)
@@ -723,8 +749,9 @@ class FetchAndNotifyWorker(
         prefs: UserPreferences,
         period: ForecastPeriod,
         dayOffset: Int,
+        overnight: Boolean = false,
     ): ForecastSnapshot {
-        val raw = app.generateDailyInsight.snapshot(location, prefs, period, dayOffset)
+        val raw = app.generateDailyInsight.snapshot(location, prefs, period, dayOffset, overnight)
         val historic = runCatching {
             app.dailyHistoryStore.entryFor(raw.bundle.today.date.minusDays(1))
         }.getOrElse {
@@ -2263,6 +2290,37 @@ class FetchAndNotifyWorker(
         }
 
         /**
+         * Whether the *current* TONIGHT window is the **ongoing overnight** — the
+         * night that began yesterday evening and ends this morning — rather than
+         * the coming night. True only in the post-midnight tail: before the
+         * morning run, with the usual schedule shape (evening time later than
+         * morning time). The overnight slices its night off yesterday → today
+         * pre-dawn, dates itself to yesterday, and pairs with *today's* daytime,
+         * so the 6am pager reads "Overnight" + "Today" instead of "Tonight" +
+         * "Tomorrow" (which skipped today's daytime entirely). The calendar
+         * anchor stays on the real today regardless — see [ForecastSnapshot.overnight].
+         *
+         * Purely time-based, not trigger-based: scheduled alarms fire at the
+         * morning / evening times and never land in the tail, and a TONIGHT alarm
+         * *delayed* past midnight genuinely IS the ongoing overnight. TODAY is
+         * never overnight; the degenerate crossed schedule (tonight not after
+         * morning) falls back to false.
+         *
+         * TODO(overnight): revisit leading with "Overnight" late in the window —
+         * by ~6am the ongoing night is nearly spent (an hour to the morning run),
+         * so past some cutoff we may prefer to lead with "Today". A deliberate
+         * follow-up; "overnight leads" is the agreed behaviour for now.
+         */
+        fun currentWindowIsOvernight(
+            prefs: UserPreferences,
+            period: ForecastPeriod,
+            now: LocalTime = LocalTime.now(),
+        ): Boolean =
+            period == ForecastPeriod.TONIGHT &&
+                prefs.tonightSchedule.time > prefs.schedule.time &&
+                now < prefs.schedule.time
+
+        /**
          * The calendar date the [requestedPeriod] cast that on-demand play
          * should target is dated for, given wall-clock [now] and the schedule
          * [morningTime] / [tonightTime]. This is the date the desired snapshot's
@@ -2277,9 +2335,12 @@ class FetchAndNotifyWorker(
          *    one is tomorrow's. Crucially, in the post-midnight tail of the night
          *    (before the morning cutoff) the next daytime cast is *this* morning,
          *    i.e. today — not tomorrow.
-         *  - **Nightly cast (TONIGHT):** today's, except in that same
-         *    post-midnight tail, where the *current* (ongoing) night began the
-         *    previous evening and so is dated *yesterday*.
+         *  - **Nightly cast (TONIGHT):** always today's. The snapshot's
+         *    `bundle.today` is the real current day in every case — the coming
+         *    night and the post-midnight ongoing overnight are both anchored on
+         *    today (the overnight only dates its *derived* insight to yesterday
+         *    via [ForecastSnapshot.overnight]; its bundle stays today-anchored),
+         *    so the cache always matches on today's date.
          *
          * Assumes the usual schedule shape (tonightTime later than morningTime);
          * the degenerate crossed config falls back to "today", same window the
@@ -2296,8 +2357,7 @@ class FetchAndNotifyWorker(
             return when (requestedPeriod) {
                 ForecastPeriod.TODAY ->
                     if (tonightTime > morningTime && time >= tonightTime) date.plusDays(1) else date
-                ForecastPeriod.TONIGHT ->
-                    if (tonightTime > morningTime && time < morningTime) date.minusDays(1) else date
+                ForecastPeriod.TONIGHT -> date
             }
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -46,6 +46,7 @@
     <string name="today_outfit_title">What to wear</string>
     <string name="today_outfit_label_today">Today</string>
     <string name="today_outfit_label_tonight">Tonight</string>
+    <string name="today_outfit_label_overnight">Overnight</string>
     <string name="today_outfit_label_tomorrow">Tomorrow</string>
     <string name="today_outfit_top_tshirt">T-shirt</string>
     <string name="today_outfit_top_polo">Polo</string>
@@ -1215,6 +1216,7 @@
          shows "Today". -->
     <string name="insight_lead_today">Today</string>
     <string name="insight_lead_tonight">Tonight</string>
+    <string name="insight_lead_overnight">Overnight</string>
     <string name="insight_lead_tomorrow">Tomorrow</string>
 
     <!-- Single-band sentence: %1$s = lead-in ("Today"), %2$d = feels-like

--- a/app/src/test/kotlin/app/clothescast/data/InsightCacheTest.kt
+++ b/app/src/test/kotlin/app/clothescast/data/InsightCacheTest.kt
@@ -145,6 +145,16 @@ class InsightCacheTest {
     }
 
     @Test
+    fun `overnight flag survives the cache round-trip`() = runTest {
+        // The "Overnight" label is baked into the snapshot so it stays stable
+        // across re-renders / process death; the cache must persist it.
+        val overnight = sample.copy(period = ForecastPeriod.TONIGHT, overnight = true)
+        subject.store(InsightCache.Slot.THIS_PERIOD, overnight)
+
+        subject.thisPeriod.first()?.overnight shouldBe true
+    }
+
+    @Test
     fun `store NEXT_PERIOD round-trips independently of THIS_PERIOD`() = runTest {
         val other = sample.copy(period = ForecastPeriod.TONIGHT)
         subject.store(InsightCache.Slot.THIS_PERIOD, sample)

--- a/app/src/test/kotlin/app/clothescast/insight/InsightFormatterTest.kt
+++ b/app/src/test/kotlin/app/clothescast/insight/InsightFormatterTest.kt
@@ -60,8 +60,9 @@ class InsightFormatterTest {
         // umbrella-in-clothes cases work; override to exercise the gating-
         // independent path (clothes == null but the umbrella still surfaces).
         carriedAccessories: List<String> = clothes?.items.orEmpty().filter { Garment.isAccessoryKey(it) },
+        overnight: Boolean = false,
     ) = InsightSummary(
-        period, band, delta, clothes, precip, calendarTieIn, eveningEventTieIn, carriedAccessories,
+        period, band, delta, clothes, precip, calendarTieIn, eveningEventTieIn, carriedAccessories, overnight,
     )
 
     @Test
@@ -90,6 +91,16 @@ class InsightFormatterTest {
     @Test
     fun `tonight period switches the lead-in`() {
         subject.format(summary(period = ForecastPeriod.TONIGHT)) shouldBe "Tonight, it will be 21°."
+    }
+
+    @Test
+    fun `ongoing overnight leads with Overnight, not Tonight`() {
+        // The post-midnight ongoing overnight is a TONIGHT summary flagged
+        // overnight; the prose must lead with "Overnight" so it matches the
+        // "Overnight" page / outfit labels (and the spoken cast).
+        subject.format(
+            summary(period = ForecastPeriod.TONIGHT, overnight = true),
+        ) shouldBe "Overnight, it will be 21°."
     }
 
     @Test

--- a/app/src/test/kotlin/app/clothescast/work/FetchAndNotifyWorkerTest.kt
+++ b/app/src/test/kotlin/app/clothescast/work/FetchAndNotifyWorkerTest.kt
@@ -449,12 +449,13 @@ class FetchAndNotifyWorkerTest {
         target(ForecastPeriod.TODAY, LocalTime.of(20, 0)) shouldBe date.plusDays(1)
         target(ForecastPeriod.TONIGHT, LocalTime.of(20, 0)) shouldBe date
 
-        // Overnight (02:00, past midnight, before the morning cutoff) — the
-        // current ongoing night began the previous evening, so it's dated
-        // yesterday; the next daytime cast is *this* morning, i.e. today (not
-        // tomorrow). This is the midnight-crossing case the offset must handle.
+        // Overnight (02:00, past midnight, before the morning cutoff) — the next
+        // daytime cast is *this* morning, i.e. today (not tomorrow). The nightly
+        // cast stays today's: the ongoing overnight snapshot is anchored on the
+        // real today (it only dates its derived insight to yesterday via the
+        // overnight flag), so the cache matches on today's date.
         target(ForecastPeriod.TODAY, LocalTime.of(2, 0)) shouldBe date
-        target(ForecastPeriod.TONIGHT, LocalTime.of(2, 0)) shouldBe date.minusDays(1)
+        target(ForecastPeriod.TONIGHT, LocalTime.of(2, 0)) shouldBe date
     }
 
     // Minimal WorkInfoLite for the staleNoLocationFailure pure-function tests.

--- a/app/src/test/kotlin/app/clothescast/work/SilentRefreshFreshnessTest.kt
+++ b/app/src/test/kotlin/app/clothescast/work/SilentRefreshFreshnessTest.kt
@@ -133,4 +133,25 @@ class SilentRefreshFreshnessTest {
         FetchAndNotifyWorker.currentPeriodForSchedule(prefs, LocalTime.of(2, 0)) shouldBe ForecastPeriod.TONIGHT
         FetchAndNotifyWorker.currentPeriodForSchedule(prefs, LocalTime.of(9, 0)) shouldBe ForecastPeriod.TODAY
     }
+
+    @Test
+    fun `post-midnight TONIGHT is the ongoing overnight`() {
+        // Before the morning run, the TONIGHT window "now" is in began yesterday
+        // evening — flag it as overnight so the pager leads with "Overnight" +
+        // "Today" rather than "Tonight" + "Tomorrow".
+        val prefs = basePrefs
+        FetchAndNotifyWorker.currentWindowIsOvernight(prefs, ForecastPeriod.TONIGHT, LocalTime.of(2, 0)) shouldBe true
+        FetchAndNotifyWorker.currentWindowIsOvernight(prefs, ForecastPeriod.TONIGHT, LocalTime.of(6, 59)) shouldBe true
+    }
+
+    @Test
+    fun `evening TONIGHT and daytime TODAY are not overnight`() {
+        val prefs = basePrefs
+        // Evening tonight is the coming night, not overnight.
+        FetchAndNotifyWorker.currentWindowIsOvernight(prefs, ForecastPeriod.TONIGHT, LocalTime.of(21, 0)) shouldBe false
+        // At the morning cutoff TONIGHT no longer applies; TODAY is never overnight.
+        FetchAndNotifyWorker.currentWindowIsOvernight(prefs, ForecastPeriod.TONIGHT, LocalTime.of(7, 0)) shouldBe false
+        FetchAndNotifyWorker.currentWindowIsOvernight(prefs, ForecastPeriod.TODAY, LocalTime.of(2, 0)) shouldBe false
+        FetchAndNotifyWorker.currentWindowIsOvernight(prefs, ForecastPeriod.TODAY, LocalTime.of(9, 0)) shouldBe false
+    }
 }

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/ForecastSnapshot.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/ForecastSnapshot.kt
@@ -47,4 +47,17 @@ data class ForecastSnapshot(
      * a path that doesn't have a store wired (tests, previews).
      */
     val historicYesterday: DailyHistoryEntry? = null,
+    /**
+     * Marks the *ongoing overnight* window — the night that began yesterday
+     * evening and ends this morning, captured in the post-midnight tail. Unlike
+     * the coming night (the evening's TONIGHT), the calendar anchor stays on
+     * today: `bundle.today` is still the real current day (so the week pages /
+     * `currentDay` / `upcomingDays` stay correct), but the renderer slices the
+     * night off `bundle.yesterday` → `bundle.today` pre-dawn, dates the insight
+     * to yesterday, and pairs it with *today's* daytime. Baked in (not derived
+     * from render-time `now()`) so the "Overnight" label is stable across
+     * re-renders and doesn't depend on when a surface happens to repaint. Only
+     * ever set with [period] == TONIGHT.
+     */
+    val overnight: Boolean = false,
 )

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Insight.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Insight.kt
@@ -20,6 +20,16 @@ data class Insight(
     val summary: InsightSummary,
     val recommendedItems: List<String>,
     val generatedAt: Instant,
+    /**
+     * The calendar date this insight's period is *about*. Normally
+     * `currentDay.date`. The exception is the ongoing overnight
+     * ([InsightSummary.overnight]): its night began yesterday evening, so
+     * `forDate` is **yesterday** even though [currentDay] / [upcomingDays] stay
+     * anchored to the real today (the night-in-progress shifts the period's
+     * date, not the calendar anchor). Don't assume [upcomingDays] is "after
+     * `forDate`" — for an overnight it starts the day after [currentDay], which
+     * is `forDate.plusDays(2)`.
+     */
     val forDate: LocalDate,
     /**
      * The location the forecast was generated for. UI-only — the home screen

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/InsightSummary.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/InsightSummary.kt
@@ -56,6 +56,17 @@ data class InsightSummary(
      * rainy day even when the wear clause is suppressed.
      */
     val carriedAccessories: List<String> = emptyList(),
+    /**
+     * Marks the *ongoing overnight* window — the night that began yesterday
+     * evening and ends this morning (post-midnight tail), as opposed to the
+     * coming night ("tonight"). Always with [period] == TONIGHT. Carried on the
+     * summary (not just the [Insight]) so the formatter — which receives the
+     * summary, not the full insight — leads the prose with "Overnight" instead
+     * of "Tonight" on every surface (card, notification, TTS, cast) without each
+     * call site having to thread a separate flag. Drives the "Overnight" page /
+     * outfit labels too, so the visible/spoken wording can't contradict them.
+     */
+    val overnight: Boolean = false,
 )
 
 /**

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/DeriveInsight.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/DeriveInsight.kt
@@ -64,6 +64,11 @@ class DeriveInsight(
         val morningStart = prefs.schedule.time
         val tonightStart = prefs.tonightSchedule.time
         val period = snapshot.period
+        // The ongoing overnight slices its night off *yesterday* (yesterday
+        // 19:00 → today 07:00) and dates itself to yesterday, while the calendar
+        // anchor (currentDay / upcomingDays / week pages) stays on the real
+        // today. Only ever set with TONIGHT.
+        val overnight = snapshot.overnight
 
         val periodView = buildPeriodView(
             bundle = bundle,
@@ -72,6 +77,7 @@ class DeriveInsight(
             morningStart = morningStart,
             tonightStart = tonightStart,
             events = snapshot.events,
+            overnight = overnight,
         )
 
         val eveningEventTieIn = if (period == ForecastPeriod.TODAY && prefs.dailyMentionEveningEvents) {
@@ -129,13 +135,16 @@ class DeriveInsight(
             todayRuleItems = Garment.layerReduce(periodView.triggeredOutfit.rules).map { it.item.itemKey },
             tonightStart = tonightStart,
             diagLog = diagLog,
+            overnight = overnight,
         )
 
         val insight = Insight(
             summary = summary,
             recommendedItems = periodView.triggeredOutfit.items,
             generatedAt = snapshot.generatedAt,
-            forDate = bundle.today.date,
+            // The overnight is the night that began yesterday evening, so it
+            // dates to yesterday even though the calendar anchor stays today.
+            forDate = if (overnight) bundle.yesterday.date else bundle.today.date,
             location = snapshot.location,
             hourly = periodView.forecast.hourly,
             confidence = if (bundle.perModelHourly == null) {
@@ -173,15 +182,23 @@ class DeriveInsight(
         morningStart: LocalTime,
         tonightStart: LocalTime,
         events: List<CalendarEvent>,
+        overnight: Boolean,
     ): PeriodView {
         val todayForecast = bundle.today.slicedForToday(
             morningStart = morningStart,
             eveningEnd = tonightStart,
         )
-        val tonightForecast = bundle.today.slicedForTonight(
+        // The night base: the ongoing overnight began *yesterday* evening
+        // (yesterday 19:00 → today 07:00), so it slices off yesterday with
+        // today's hourly as the pre-dawn wrap. The coming night slices off today
+        // with tomorrow's hourly. The calendar anchor (currentDay / week) is
+        // unaffected either way — it always stays on `bundle.today`.
+        val nightBase = if (overnight) bundle.yesterday else bundle.today
+        val nightWrapHourly = if (overnight) bundle.today.hourly else bundle.tomorrowHourly
+        val tonightForecast = nightBase.slicedForTonight(
             tonightStart = tonightStart,
             morningEnd = morningStart,
-            tomorrowHourly = bundle.tomorrowHourly,
+            tomorrowHourly = nightWrapHourly,
         )
         val periodForecast = when (period) {
             ForecastPeriod.TODAY -> todayForecast
@@ -199,10 +216,18 @@ class DeriveInsight(
             }
         val rawNextForecast = when (period) {
             ForecastPeriod.TODAY -> tonightForecast.takeIf { it.hourly.isNotEmpty() }
-            ForecastPeriod.TONIGHT -> bundle.tomorrow?.slicedForToday(
-                morningStart = morningStart,
-                eveningEnd = tonightStart,
-            )
+            // The coming night leads into tomorrow's daytime; the ongoing
+            // overnight leads into *today's* daytime (the day you're walking
+            // into), so its "next" card is today, not tomorrow.
+            ForecastPeriod.TONIGHT ->
+                if (overnight) {
+                    todayForecast.takeIf { it.hourly.isNotEmpty() }
+                } else {
+                    bundle.tomorrow?.slicedForToday(
+                        morningStart = morningStart,
+                        eveningEnd = tonightStart,
+                    )
+                }
         }
         // Carry the same per-model rain-code enrichment onto the *next* period's
         // forecast, sliced to that period's own window. Without it the Today card
@@ -223,7 +248,9 @@ class DeriveInsight(
         val perModelForRender = bundle.perModelHourly?.slicedTo(
             when (period) {
                 ForecastPeriod.TODAY -> todayWindow(periodForecast.hourly, bundle.today.date)
-                ForecastPeriod.TONIGHT -> tonightWindow(periodForecast.hourly, bundle.today.date, tonightStart)
+                // The night window is dated off its base day (yesterday for the
+                // ongoing overnight, today for the coming night).
+                ForecastPeriod.TONIGHT -> tonightWindow(periodForecast.hourly, nightBase.date, tonightStart)
             },
         )
         // Enrich the forecast the rule engine sees with the per-model rain-code
@@ -253,7 +280,7 @@ class DeriveInsight(
             forecast = periodForecast,
             nextForecast = nextForecast,
             triggeredOutfit = triggeredOutfit,
-            events = filterEventsForPeriod(events, period, bundle.today.date, morningStart, tonightStart),
+            events = filterEventsForPeriod(events, period, nightBase.date, morningStart, tonightStart),
             perModelForRender = perModelForRender,
             deltaToday = deltaToday,
             deltaYesterday = deltaYesterday,
@@ -286,6 +313,9 @@ class DeriveInsight(
             morningStart = morningStart,
             tonightStart = tonightStart,
             events = allEvents,
+            // The morning insight's evening tie-in is about *tonight* (the coming
+            // night of today), never the ongoing overnight.
+            overnight = false,
         )
         val nightSummary: InsightSummary = renderInsightSummary(
             today = nightView.forecast,

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsight.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsight.kt
@@ -44,8 +44,13 @@ class GenerateDailyInsight(
         // `(TODAY, 1)` is supported — there's no day-after-tomorrow data in
         // the bundle to wrap a tomorrow-tonight window around.
         dayOffset: Int = 0,
+        // Marks the ongoing overnight (post-midnight tail): the night in
+        // progress is sliced off yesterday → today pre-dawn and dated yesterday,
+        // while the calendar anchor stays on today. Only valid with TONIGHT and
+        // dayOffset = 0. See [ForecastSnapshot.overnight].
+        overnight: Boolean = false,
     ): DailyInsightResult {
-        val snapshot = snapshot(location, prefs, period, dayOffset)
+        val snapshot = snapshot(location, prefs, period, dayOffset, overnight)
         return deriveInsight(snapshot, prefs)
     }
 
@@ -61,9 +66,13 @@ class GenerateDailyInsight(
         prefs: UserPreferences,
         period: ForecastPeriod = ForecastPeriod.TODAY,
         dayOffset: Int = 0,
+        overnight: Boolean = false,
     ): ForecastSnapshot {
         require(dayOffset == 0 || (dayOffset == 1 && period == ForecastPeriod.TODAY)) {
             "Only same-day (dayOffset=0) and tomorrow-daytime (dayOffset=1, period=TODAY) generation are supported."
+        }
+        require(!overnight || (period == ForecastPeriod.TONIGHT && dayOffset == 0)) {
+            "The overnight window only applies to the same-day TONIGHT period (period=TONIGHT, dayOffset=0)."
         }
         val fetched = weatherRepository.fetchForecast(location)
         val bundle = if (dayOffset == 1) {
@@ -80,6 +89,7 @@ class GenerateDailyInsight(
             location = location,
             period = period,
             generatedAt = clock.instant(),
+            overnight = overnight,
         )
     }
 

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/RenderInsightSummary.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/RenderInsightSummary.kt
@@ -142,10 +142,15 @@ class RenderInsightSummary {
         // than yesterday" surprise, while tests / previews / cache
         // re-derives keep the no-op default and pay nothing.
         diagLog: (String) -> Unit = {},
+        // Marks the ongoing overnight (post-midnight tail). Carried onto the
+        // returned summary so the formatter leads with "Overnight" instead of
+        // "Tonight". Only meaningful with [period] == TONIGHT; defaults false.
+        overnight: Boolean = false,
     ): InsightSummary {
         val peak = peakPrecip(today, perModelHourly)
         return InsightSummary(
             period = period,
+            overnight = overnight,
             band = bandClause(today),
             delta = if (period == ForecastPeriod.TODAY) deltaClause(todayForDelta, yesterday, deltaThresholdC, deltaFormat, diagLog) else null,
             clothes = clothesClause(todayItems, period, clothesMentionMode, yesterdayTriggeredItems),

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsightTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsightTest.kt
@@ -27,6 +27,7 @@ import app.clothescast.core.domain.model.WeatherCondition
 import app.clothescast.core.domain.repository.CalendarEventReader
 import app.clothescast.core.domain.repository.ForecastBundle
 import app.clothescast.core.domain.repository.WeatherRepository
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
@@ -405,6 +406,111 @@ class GenerateDailyInsightTest {
         val result = subject(london, prefs)
 
         result.insight.hourly.shouldContainExactly(hourly)
+    }
+
+    @Test
+    fun `overnight (TONIGHT) renders the ongoing night dated yesterday, anchored on today`() = runTest {
+        // The post-midnight tail: the night "now" sits in began yesterday evening
+        // and ends this morning. overnight = true slices the night off yesterday
+        // (>=19:00) -> today-pre-dawn (<07:00) and dates the insight to yesterday,
+        // while the calendar anchor (currentDay / upcomingDays) stays on today.
+        val yesterdayEvening = HourlyForecast(
+            time = LocalTime.of(20, 0),
+            temperatureC = 11.0,
+            feelsLikeC = 9.0,
+            precipitationProbabilityPct = 5.0,
+            condition = WeatherCondition.CLEAR,
+        )
+        val preDawn3 = HourlyForecast(
+            time = LocalTime.of(3, 0),
+            temperatureC = 6.0,
+            feelsLikeC = 3.0,
+            precipitationProbabilityPct = 5.0,
+            condition = WeatherCondition.CLEAR,
+        )
+        val preDawn6 = HourlyForecast(
+            time = LocalTime.of(6, 0),
+            temperatureC = 7.0,
+            feelsLikeC = 4.0,
+            precipitationProbabilityPct = 5.0,
+            condition = WeatherCondition.CLEAR,
+        )
+        val daytimeNoon = HourlyForecast(
+            time = LocalTime.of(12, 0),
+            temperatureC = 20.0,
+            feelsLikeC = 20.0,
+            precipitationProbabilityPct = 5.0,
+            condition = WeatherCondition.CLEAR,
+        )
+        val tomorrowDay = today.copy(date = today.date.plusDays(1))
+        val dayAfter = today.copy(date = today.date.plusDays(2))
+        val weather = FakeWeatherRepository(
+            ForecastBundle(
+                today = today.copy(hourly = listOf(preDawn3, preDawn6, daytimeNoon)),
+                yesterday = yesterday.copy(hourly = listOf(yesterdayEvening)),
+                tomorrow = tomorrowDay,
+                // upcomingDays starts at the original tomorrow, per the bundle's
+                // duplication convention.
+                upcomingDays = listOf(tomorrowDay, dayAfter),
+            ),
+        )
+        val subject = GenerateDailyInsight(weather, clock = clock)
+
+        val result = subject(london, prefs, ForecastPeriod.TONIGHT, overnight = true).insight
+
+        result.period shouldBe ForecastPeriod.TONIGHT
+        result.summary.overnight shouldBe true
+        // Dated yesterday — that's what the "Overnight" wording and the morning
+        // delta keys off — even though the calendar anchor stays on today.
+        result.forDate shouldBe yesterday.date
+        // The slice is yesterday-evening + today-pre-dawn; today's daytime noon
+        // hour is excluded.
+        result.hourly.map { it.time } shouldContainExactly listOf(
+            LocalTime.of(20, 0),
+            LocalTime.of(3, 0),
+            LocalTime.of(6, 0),
+        )
+        // The calendar anchor stays on the real today: currentDay is today and
+        // upcomingDays is the unshifted forward week, so the 7/14-day pages stay
+        // correct (no empty week, no off-by-one).
+        result.currentDay?.date shouldBe today.date
+        result.upcomingDays.map { it.date } shouldContainExactly listOf(
+            tomorrowDay.date,
+            dayAfter.date,
+        )
+        // The overnight leads into *today's* daytime, so the in-card "next"
+        // outfit comes from today's noon hour, not tomorrow.
+        result.nextOutfit.shouldNotBeNull()
+    }
+
+    @Test
+    fun `the coming night (TONIGHT, not overnight) is dated today`() = runTest {
+        val weather = FakeWeatherRepository(
+            ForecastBundle(
+                today = today.copy(
+                    hourly = listOf(
+                        HourlyForecast(LocalTime.of(20, 0), 11.0, 9.0, 5.0, WeatherCondition.CLEAR),
+                    ),
+                ),
+                yesterday = yesterday,
+            ),
+        )
+        val subject = GenerateDailyInsight(weather, clock = clock)
+
+        val result = subject(london, prefs, ForecastPeriod.TONIGHT).insight
+
+        result.forDate shouldBe today.date
+        result.summary.overnight shouldBe false
+    }
+
+    @Test
+    fun `overnight is rejected for the TODAY period`() = runTest {
+        val weather = FakeWeatherRepository(ForecastBundle(today, yesterday))
+        val subject = GenerateDailyInsight(weather, clock = clock)
+
+        shouldThrow<IllegalArgumentException> {
+            subject.snapshot(london, prefs, ForecastPeriod.TODAY, overnight = true)
+        }
     }
 
     @Test


### PR DESCRIPTION
## What & why

In the hours after midnight (before the morning run), the Today screen jumped a full day ahead: it led with the **coming** night ("Tonight") and **tomorrow's** daytime ("Tomorrow"), skipping both the night actually in progress and today's own daytime. So a 6am glance showed "Tonight" + "Tomorrow" and never surfaced the day you were about to walk into.

Now the post-midnight tail leads with the ongoing overnight and today:

| time of day | front card | second card |
|---|---|---|
| 00:00–07:00 (tail) — **changed** | **Overnight** (night in progress) | **Today** |
| 07:00–19:00 (day) — unchanged | Today | Tonight |
| 19:00–24:00 (evening) — unchanged | Tonight | Tomorrow |

## How

- **`currentWindowIsOvernight()`** flags the current TONIGHT window as the ongoing overnight in the post-midnight tail. Evaluated against the same wall-clock instant as the period selection, so the two can't disagree across the morning cutoff. Purely time-based — scheduled alarms never land in the tail, and a TONIGHT alarm *delayed* past midnight genuinely is the ongoing overnight.
- **The overnight keeps the bundle anchored on the real today.** `currentDay`, `upcomingDays` and the 7/14-day week pages stay correct (no shift, no placeholder day). Only three things differ for the overnight: the night slice (yesterday-evening → today-pre-dawn, off the same Open-Meteo bundle — no extra fetch), the insight's date (yesterday), and the paired "next" window (today's daytime, not tomorrow's).
- **Baked flag, on the summary, not a render-time date compare.** `ForecastSnapshot.overnight` (persisted through `InsightCache`) → `InsightSummary.overnight` (derived). Carrying it on the summary means **one flag drives everything**: the Today card heading, top-bar title, outfit-preview row and the widget labels *and* the formatted prose lead. So a post-midnight insight reads "Overnight" consistently across the card, notification, TTS and cast — the spoken/written forecast can't contradict the "Overnight" label (a new `insight_lead_overnight` string + a `leadRes` branch). Because the formatter already receives the summary, no `format(...)` call site changed. Being baked (not `now()`-derived) also keeps the label stable across re-renders / process death and keeps fixed-date previews deterministic.
- **`playTargetDate` simplifies:** the overnight snapshot is today-anchored, so the nightly cast always matches the cache on today's date (the post-midnight "dated yesterday" special-case is gone).

## Privacy

No change to what leaves the device — pure window-selection and labeling logic. No weather/geocoding/TTS payload change (the overnight prose says "Overnight" instead of "Tonight"; same data).

## Follow-up (deferred, in-code TODO)

- **Lead with "Today" late in the overnight window** — by ~6am the ongoing night is nearly spent (an hour to the morning run), so we may later prefer to lead with "Today" past some cutoff. "Overnight leads" is the agreed behaviour for now.

## Review notes

Resolved across review rounds (Codex + Copilot): the week-view regressions (empty week / following-week off-by-one), the widget label staleness, the `now()` boundary race, and the prose lead saying "Tonight" while the label said "Overnight". The week / widget / prose issues all traced back to an earlier bundle-shift approach; the final decouple (keep the calendar on the real today + a baked overnight flag on the summary) fixes them structurally rather than patching.

## Test plan

- `./gradlew :core:domain:test` — overnight slices the night off yesterday→today pre-dawn, dates the insight to yesterday, **keeps `currentDay` = today and the unshifted `upcomingDays`**, pairs with today's daytime, and sets `summary.overnight`; the coming night is dated today and not overnight; `overnight` is rejected for TODAY.
- `./gradlew :app:testDebugUnitTest :app:assembleDebug` — green; UI snapshots unchanged. Formatter test asserts `"Overnight, it will be 21°."`; `currentWindowIsOvernight` cases; `playTargetDate` updated; `InsightCache` round-trip for the `overnight` flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015zo9zjqdJMv4CGL8kpqGB5