### PR TITLE
Show your forecast in one notification while it's read aloud

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -217,14 +217,22 @@
                 android:resource="@xml/conditions_widget_info" />
         </receiver>
 
-        <!-- WorkManager hosts foreground workers in its own SystemForegroundService.
-             API 34+ requires the service to declare every foregroundServiceType it
-             runs with; merge the media-playback type onto WorkManager's declaration
-             so FetchAndNotifyWorker.setForeground(...) can use it for spoken delivery. -->
+        <!-- Owns the single notification for a scheduled spoken briefing and holds
+             the process foreground (type mediaPlayback) so the worker's TTS is
+             audible on Android 15+. We run our own service rather than
+             WorkManager's setForeground so we can stopForeground(DETACH) when
+             speech ends, leaving the forecast notification in the shade instead
+             of having WorkManager remove it. See PlaybackForegroundService. -->
         <service
-            android:name="androidx.work.impl.foreground.SystemForegroundService"
-            android:foregroundServiceType="mediaPlayback"
-            tools:node="merge" />
+            android:name=".work.PlaybackForegroundService"
+            android:exported="false"
+            android:foregroundServiceType="mediaPlayback" />
+
+        <!-- Delete-intent target: swiping the spoken-briefing notification away
+             cancels on-device speech (without aborting MQTT / cast delivery). -->
+        <receiver
+            android:name=".notification.SpeechDismissReceiver"
+            android:exported="false" />
 
     </application>
 

--- a/app/src/main/kotlin/app/clothescast/notification/InsightNotifier.kt
+++ b/app/src/main/kotlin/app/clothescast/notification/InsightNotifier.kt
@@ -32,8 +32,17 @@ class InsightNotifier(private val context: Context) {
         topStrokes: Map<OutfitSuggestion.Top, Long> = emptyMap(),
         handsColors: Map<OutfitSuggestion.Hands, Long> = emptyMap(),
         outerColors: Map<OutfitSuggestion.Outer, Long> = emptyMap(),
-    ) {
-        if (!NotificationPermission.isGranted(context)) return
+        // Set on a scheduled spoken run: this notification doubles as the
+        // playback foreground service's notification, and swiping it away
+        // cancels the on-device speech (see SpeechDismissReceiver). Null for
+        // notification-only / non-spoken posts — there's nothing to cancel.
+        deleteIntent: PendingIntent? = null,
+        // True for a TTS-only run, where this is only the forced foreground-service
+        // notification shown during speech (removed afterward): suppress
+        // sound/heads-up so it doesn't chime on top of the spoken briefing.
+        silent: Boolean = false,
+    ): Boolean {
+        if (!NotificationPermission.isGranted(context)) return false
 
         val pendingIntent = PendingIntent.getActivity(
             context,
@@ -67,12 +76,19 @@ class InsightNotifier(private val context: Context) {
             .setStyle(NotificationCompat.BigTextStyle().bigText(prose))
             .setPriority(NotificationCompat.PRIORITY_HIGH)
             .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
-            .setAutoCancel(true)
+            // On a spoken run (deleteIntent set) don't auto-cancel: the delete
+            // intent stops speech, and auto-cancelling on tap could remove the
+            // notification mid-briefing (and risk firing that intent), so tapping
+            // just opens the app. Only a swipe stops speech.
+            .setAutoCancel(deleteIntent == null)
             .setContentIntent(pendingIntent)
+            .setDeleteIntent(deleteIntent)
             .setCategory(NotificationCompat.CATEGORY_REMINDER)
+            .setSilent(silent)
             .build()
 
         NotificationManagerCompat.from(context).notify(NOTIFICATION_ID_DAILY_INSIGHT, notification)
+        return true
     }
 
     companion object {

--- a/app/src/main/kotlin/app/clothescast/notification/NotificationChannelRegistrar.kt
+++ b/app/src/main/kotlin/app/clothescast/notification/NotificationChannelRegistrar.kt
@@ -13,7 +13,6 @@ import app.clothescast.R
 internal const val CHANNEL_DAILY_INSIGHT = "daily_insight_v1"
 internal const val CHANNEL_TONIGHT_INSIGHT_DEFAULT = "tonight_insight_default_v1"
 internal const val CHANNEL_TONIGHT_INSIGHT_SILENT = "tonight_insight_silent_v1"
-internal const val CHANNEL_PLAYBACK = "playback_v1"
 
 // Retired channel IDs to delete on upgrade. Android persists channels by ID
 // until the app explicitly deletes them, so dropping the create call alone
@@ -21,6 +20,12 @@ internal const val CHANNEL_PLAYBACK = "playback_v1"
 // installs. deleteNotificationChannel is a no-op when the ID was never
 // registered (fresh installs), so this is safe to call unconditionally.
 private const val CHANNEL_WEATHER_ALERTS_RETIRED = "weather_alerts_v1"
+
+// Retired: the spoken briefing's playback foreground service used to show its
+// own "Speaking the forecast" notification on this channel. It now reuses the
+// forecast's own daily/tonight channel (the foreground-service notification *is*
+// the forecast), so this dedicated channel is gone.
+private const val CHANNEL_PLAYBACK_RETIRED = "playback_v1"
 
 /**
  * Registers the notification channel(s) used by the app. Idempotent — safe to call from
@@ -44,9 +49,12 @@ object NotificationChannelRegistrar {
     fun register(context: Context) {
         val manager = context.getSystemService<NotificationManager>() ?: return
 
-        // Remove the retired severe-weather-alerts channel from installs that
-        // previously registered it (the feature is gone); see the const above.
+        // Remove retired channels from installs that previously registered them
+        // (the severe-weather-alerts feature is gone; the spoken-briefing
+        // playback notification now lives on the forecast's own channel); see
+        // the consts above.
         manager.deleteNotificationChannel(CHANNEL_WEATHER_ALERTS_RETIRED)
+        manager.deleteNotificationChannel(CHANNEL_PLAYBACK_RETIRED)
 
         val daily = NotificationChannel(
             CHANNEL_DAILY_INSIGHT,
@@ -80,25 +88,8 @@ object NotificationChannelRegistrar {
             lockscreenVisibility = android.app.Notification.VISIBILITY_PUBLIC
         }
 
-        // The foreground-service notification shown while a scheduled briefing
-        // speaks (see FetchAndNotifyWorker). LOW + no sound/vibration: it's a
-        // policy requirement for background audio, not a notification the user
-        // needs to act on, so it stays quiet and unobtrusive.
-        val playback = NotificationChannel(
-            CHANNEL_PLAYBACK,
-            context.getString(R.string.notification_channel_playback_name),
-            NotificationManager.IMPORTANCE_LOW,
-        ).apply {
-            description = context.getString(R.string.notification_channel_playback_description)
-            setShowBadge(false)
-            setSound(null, null)
-            enableVibration(false)
-            lockscreenVisibility = android.app.Notification.VISIBILITY_PUBLIC
-        }
-
         manager.createNotificationChannel(daily)
         manager.createNotificationChannel(tonightWithEvents)
         manager.createNotificationChannel(tonightSilent)
-        manager.createNotificationChannel(playback)
     }
 }

--- a/app/src/main/kotlin/app/clothescast/notification/SpeechDismissReceiver.kt
+++ b/app/src/main/kotlin/app/clothescast/notification/SpeechDismissReceiver.kt
@@ -1,0 +1,34 @@
+package app.clothescast.notification
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import app.clothescast.diag.DiagLog
+import app.clothescast.tts.ActiveSpeechSession
+
+/**
+ * Delete-intent target for the spoken-forecast notification. When the user
+ * swipes the briefing notification away (Android 14+ lets a foreground-service
+ * notification be dismissed), this cancels the on-device speech so the phone
+ * stops talking — without aborting the rest of the delivery. The MQTT and cast
+ * publishes run as independent jobs, so they keep going; see [ActiveSpeechSession].
+ *
+ * The intent carries the run's [EXTRA_TOKEN] so dismissing a *stale* notification
+ * (one left in the shade after its own briefing finished) only stops speech when
+ * its token is the one currently playing — swiping yesterday's notification can't
+ * cut off tonight's briefing.
+ */
+class SpeechDismissReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action != ACTION_DISMISS) return
+        val token = intent.getLongExtra(EXTRA_TOKEN, 0L)
+        DiagLog.i(TAG, "Spoken-forecast notification dismissed (token=$token); stopping its speech if still playing.")
+        ActiveSpeechSession.stop(token)
+    }
+
+    companion object {
+        const val ACTION_DISMISS = "app.clothescast.notification.DISMISS_SPEECH"
+        const val EXTRA_TOKEN = "token"
+        private const val TAG = "SpeechDismissReceiver"
+    }
+}

--- a/app/src/main/kotlin/app/clothescast/notification/TonightInsightNotifier.kt
+++ b/app/src/main/kotlin/app/clothescast/notification/TonightInsightNotifier.kt
@@ -38,8 +38,17 @@ class TonightInsightNotifier(private val context: Context) {
         topStrokes: Map<OutfitSuggestion.Top, Long> = emptyMap(),
         handsColors: Map<OutfitSuggestion.Hands, Long> = emptyMap(),
         outerColors: Map<OutfitSuggestion.Outer, Long> = emptyMap(),
-    ) {
-        if (!NotificationPermission.isGranted(context)) return
+        // Set on a scheduled spoken run: this notification doubles as the
+        // playback foreground service's notification, and swiping it away
+        // cancels the on-device speech (see SpeechDismissReceiver). Null for
+        // notification-only / non-spoken posts — there's nothing to cancel.
+        deleteIntent: PendingIntent? = null,
+        // True for a TTS-only run, where this is only the forced foreground-service
+        // notification shown during speech (removed afterward): suppress
+        // sound/heads-up so it doesn't chime on top of the spoken briefing.
+        silent: Boolean = false,
+    ): Boolean {
+        if (!NotificationPermission.isGranted(context)) return false
 
         val pendingIntent = PendingIntent.getActivity(
             context,
@@ -48,8 +57,17 @@ class TonightInsightNotifier(private val context: Context) {
             PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
         )
 
-        val channel = if (insight.hasEvents) CHANNEL_TONIGHT_INSIGHT_DEFAULT else CHANNEL_TONIGHT_INSIGHT_SILENT
-        val priority = if (insight.hasEvents) NotificationCompat.PRIORITY_DEFAULT else NotificationCompat.PRIORITY_LOW
+        // A spoken run (deleteIntent != null) always uses the DEFAULT channel.
+        // Two reasons: the briefing is read aloud, so an alerting notification is
+        // consistent with "alert when speech starts"; and the playback foreground
+        // service posts its placeholder on the DEFAULT channel — Android won't
+        // move an already-posted notification to a different channel, so a
+        // no-events spoken run must not try to land the forecast on the SILENT
+        // channel or it would be stuck on DEFAULT with a mismatched silent flag.
+        val spokenRun = deleteIntent != null
+        val alerting = insight.hasEvents || spokenRun
+        val channel = if (alerting) CHANNEL_TONIGHT_INSIGHT_DEFAULT else CHANNEL_TONIGHT_INSIGHT_SILENT
+        val priority = if (alerting) NotificationCompat.PRIORITY_DEFAULT else NotificationCompat.PRIORITY_LOW
 
         val top = insight.outfit?.top
         val notification = NotificationCompat.Builder(context, channel)
@@ -71,18 +89,27 @@ class TonightInsightNotifier(private val context: Context) {
             .setStyle(NotificationCompat.BigTextStyle().bigText(prose))
             .setPriority(priority)
             .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
-            .setAutoCancel(true)
+            // On a spoken run (deleteIntent set) don't auto-cancel: the delete
+            // intent stops speech, and auto-cancelling on tap could remove the
+            // notification mid-briefing (and risk firing that intent), so tapping
+            // just opens the app. Only a swipe stops speech.
+            .setAutoCancel(deleteIntent == null)
             .setContentIntent(pendingIntent)
+            .setDeleteIntent(deleteIntent)
             .setCategory(NotificationCompat.CATEGORY_REMINDER)
             .apply {
                 // Belt-and-braces: even if a downstream OEM ignores the silent
                 // channel's importance, the per-notification flag still suppresses
-                // sound + heads-up for the no-events case.
-                if (!insight.hasEvents) setSilent(true)
+                // sound + heads-up. Silence the no-events case, and a TTS-only run
+                // (silent = true) even though it's on the DEFAULT channel — its
+                // forecast is the forced FGS notification, not an alert the user
+                // asked for.
+                if (!alerting || silent) setSilent(true)
             }
             .build()
 
         NotificationManagerCompat.from(context).notify(NOTIFICATION_ID_TONIGHT_INSIGHT, notification)
+        return true
     }
 
     companion object {

--- a/app/src/main/kotlin/app/clothescast/tts/ActiveSpeechSession.kt
+++ b/app/src/main/kotlin/app/clothescast/tts/ActiveSpeechSession.kt
@@ -1,0 +1,102 @@
+package app.clothescast.tts
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
+
+/**
+ * Process-wide handle to the coroutine currently playing a scheduled briefing on
+ * the phone speaker, so the spoken-forecast notification's dismiss action can stop
+ * *just the speech* without touching the rest of the delivery.
+ *
+ * The phone-speaker coroutine [register]s its own [Job] (keyed by a per-run
+ * [token]) for the duration of playback and [clear]s it when done.
+ * [SpeechDismissReceiver] (wired to the notification's delete intent) calls
+ * [stop] with the *dismissed notification's* token, which cancels the job only
+ * when that token is the one currently playing. That scoping matters because a
+ * spoken notification can persist in the shade after its own briefing ends: a
+ * later briefing then registers a different token, so swiping the old
+ * notification is a no-op rather than cancelling the new briefing's speech.
+ *
+ * A dismissal can also arrive *before* playback starts — the "Preparing…"
+ * placeholder is swipeable on Android 14+ during the fetch/alignment wait. Such a
+ * [stop] is remembered (per token) so the matching [register] returns false and
+ * the briefing skips speech rather than talking over a dismissal. The remembered
+ * set is bounded so a stream of stale-notification swipes can't grow it without
+ * limit, and keyed by token so an unrelated stale swipe can't clobber the live
+ * run's pending dismissal.
+ *
+ * Cancelling the matched job propagates into the suspending `speak()` / `play()`
+ * call and tears down the AudioTrack / TextToSpeech engine via their
+ * `invokeOnCancellation` hooks, exactly like the Today screen's Stop button does.
+ * Because the MQTT and cast publishes run as sibling jobs in the delivery
+ * `supervisorScope`, they are unaffected: dismissing the phone notification means
+ * "stop talking on *this* phone," not "abort delivery."
+ */
+object ActiveSpeechSession {
+    private data class Session(val token: Long, val job: Job)
+
+    private val lock = Any()
+    private var current: Session? = null
+
+    // Tokens dismissed before their speech registered (placeholder swiped during
+    // the fetch/alignment wait), newest last. A bounded LRU: a dismissal for a
+    // run that never registers (e.g. a persisted older notification swiped) would
+    // otherwise linger forever. A live run registers far inside this cap.
+    private val dismissedBeforeStart = LinkedHashSet<Long>()
+
+    /**
+     * Record [job] (identified by [token]) as the speech about to play. Returns
+     * false — and does *not* register — when this run was already dismissed
+     * before playback started, signalling the caller to skip speech.
+     */
+    fun register(token: Long, job: Job): Boolean = synchronized(lock) {
+        if (dismissedBeforeStart.remove(token)) return false
+        current = Session(token, job)
+        true
+    }
+
+    /**
+     * Cancel the playing speech *only if* it's the run identified by [token] —
+     * i.e. the notification the user just dismissed is the one currently
+     * speaking. If that run hasn't started speaking yet (placeholder dismissal),
+     * remember the token so its upcoming [register] skips playback. A stale token
+     * or no active speech is a safe no-op.
+     */
+    fun stop(token: Long) {
+        val toCancel: Job? = synchronized(lock) {
+            val session = current
+            if (session != null && session.token == token) {
+                current = null
+                session.job
+            } else {
+                rememberDismissal(token)
+                null
+            }
+        }
+        // Cancel outside the lock so a cancellation callback can't reenter under it.
+        toCancel?.cancel(CancellationException("Spoken forecast notification dismissed"))
+    }
+
+    /** Clear this run's registration once its playback finishes, if still current. */
+    fun clear(token: Long, job: Job) = synchronized(lock) {
+        val session = current
+        if (session != null && session.token == token && session.job === job) {
+            current = null
+        }
+    }
+
+    private fun rememberDismissal(token: Long) {
+        // Re-insert at the tail (LRU) and evict the eldest past the cap.
+        dismissedBeforeStart.remove(token)
+        dismissedBeforeStart.add(token)
+        while (dismissedBeforeStart.size > MAX_REMEMBERED_DISMISSALS) {
+            val eldest = dismissedBeforeStart.iterator()
+            eldest.next()
+            eldest.remove()
+        }
+    }
+
+    // Generous headroom — only one briefing's placeholder is "live" at a time,
+    // and reaching the cap needs that many stale swipes inside one fetch window.
+    private const val MAX_REMEMBERED_DISMISSALS = 16
+}

--- a/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
@@ -1,17 +1,16 @@
 package app.clothescast.work
 
+import android.app.PendingIntent
 import android.content.Context
-import android.content.pm.ServiceInfo
+import android.content.Intent
 import android.location.LocationManager
 import app.clothescast.diag.DiagLog
-import androidx.core.app.NotificationCompat
 import androidx.core.content.getSystemService
 import androidx.work.BackoffPolicy
 import androidx.work.Constraints
 import androidx.work.CoroutineWorker
 import androidx.work.Data
 import androidx.work.ExistingWorkPolicy
-import androidx.work.ForegroundInfo
 import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkInfo
@@ -44,7 +43,11 @@ import app.clothescast.core.data.tts.WavEncoder
 import app.clothescast.core.data.tts.isRetryableGeminiTtsFailure
 import app.clothescast.data.InsightCache
 import app.clothescast.mqtt.MqttPublishOutcome
-import app.clothescast.notification.CHANNEL_PLAYBACK
+import androidx.core.app.NotificationManagerCompat
+import app.clothescast.notification.InsightNotifier
+import app.clothescast.notification.SpeechDismissReceiver
+import app.clothescast.notification.TonightInsightNotifier
+import app.clothescast.tts.ActiveSpeechSession
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -74,6 +77,8 @@ import io.ktor.client.network.sockets.SocketTimeoutException
 import io.ktor.client.plugins.HttpRequestTimeoutException
 import io.ktor.client.plugins.ResponseException
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import java.io.IOException
@@ -104,6 +109,16 @@ class FetchAndNotifyWorker(
     private val app: ClothesCastApplication
         get() = applicationContext as ClothesCastApplication
 
+    // True once this run promoted itself to the playback foreground service
+    // ([promoteToPlaybackServiceIfNeeded]); gates tearing it down at the end.
+    private var startedPlaybackService = false
+
+    // True once a forecast notification the user's mode actually wants has been
+    // posted on this run. Tells the playback service whether to *detach* its
+    // notification (keep the forecast in the shade) or *remove* it (TTS-only
+    // transient post, or nothing delivered — drop it) when we finish it.
+    private var persistNotificationAfterRun = false
+
     override suspend fun doWork(): Result {
         val isCacheOnly = inputData.getBoolean(KEY_CACHE_LOCATION_ONLY, false)
         val isSilent = inputData.getBoolean(KEY_SILENT_REFRESH, false)
@@ -131,6 +146,29 @@ class FetchAndNotifyWorker(
                 )
             }
             throw ce
+        } finally {
+            // Always tear down the playback foreground service we started, on
+            // success, failure, or cancellation — leaving one foreground would
+            // strand a "Preparing…"/forecast notification and hold the process
+            // foreground. Detach (keep the forecast in the shade) only when the
+            // mode wanted a persistent notification; otherwise remove it (the
+            // placeholder, or a TTS-only run's transient forecast).
+            if (startedPlaybackService) {
+                PlaybackForegroundService.finish(applicationContext, detach = persistNotificationAfterRun)
+                // Backstop: the start request was accepted, but if the service
+                // then couldn't actually go foreground its finish() can't remove
+                // a transient TTS-only forecast we already posted. Cancel it here
+                // so a run the user opted out of a notification for never leaves
+                // one behind. A no-op when the service did run (it removed the
+                // notification on finish) or nothing was posted.
+                if (!persistNotificationAfterRun) {
+                    val id = when (period) {
+                        ForecastPeriod.TODAY -> InsightNotifier.NOTIFICATION_ID_DAILY_INSIGHT
+                        ForecastPeriod.TONIGHT -> TonightInsightNotifier.NOTIFICATION_ID_TONIGHT_INSIGHT
+                    }
+                    NotificationManagerCompat.from(applicationContext).cancel(id)
+                }
+            }
         }
     }
 
@@ -1633,15 +1671,77 @@ class FetchAndNotifyWorker(
         // forceNotify: the Today screen's Play button posts the notification
         // even on SILENT / TTS-only — an explicit tap means "show it now."
         val canNotify = forceNotify || mode.postsNotification
-        if (!canNotify) return
-        when (insight.period) {
+        // A spoken foreground-service run must keep a visible notification while
+        // it speaks (Android requires one for background audio), so replace the
+        // service's "Preparing…" placeholder with the forecast even on TTS-only —
+        // otherwise the user hears speech under a stuck placeholder with no
+        // swipe-to-stop. It just won't *persist* afterward unless the mode
+        // actually posts a notification (see persistNotificationAfterRun / the
+        // detach gate in doWork). When neither applies, there's nothing to post.
+        val showForecast = canNotify || startedPlaybackService
+        if (!showForecast) return
+        // On a spoken run this notification *is* the playback foreground service's
+        // notification, so swiping it away should stop the speech (see
+        // SpeechDismissReceiver). Notification-only / non-spoken posts have no
+        // speech to cancel, so no delete intent.
+        val deleteIntent = if (startedPlaybackService) stopSpeechDeleteIntent() else null
+        // A TTS-only run posts no notification of its own — the one we show is
+        // the forced FGS notification — so keep it silent, matching the old
+        // silent playback notification. Modes that do post a notification alert
+        // normally (the "alert when speech starts" behavior).
+        val silent = !canNotify
+        val posted = when (insight.period) {
             ForecastPeriod.TODAY ->
-                app.insightNotifier.notify(insight, prose, topColors, topStrokes, handsColors, outerColors)
+                app.insightNotifier.notify(insight, prose, topColors, topStrokes, handsColors, outerColors, deleteIntent, silent)
             ForecastPeriod.TONIGHT ->
-                app.tonightInsightNotifier.notify(insight, prose, topColors, topStrokes, handsColors, outerColors)
+                app.tonightInsightNotifier.notify(insight, prose, topColors, topStrokes, handsColors, outerColors, deleteIntent, silent)
         }
-        recordDeliveryDelay(insight.period)
+        // Keep the notification in the shade after the run only when the mode
+        // wants one *and* the forecast actually posted. If POST_NOTIFICATIONS is
+        // denied the notifier no-ops, so detaching would strand the placeholder —
+        // leave persistNotificationAfterRun false there so finish() removes it.
+        // A TTS-only run shows the forecast transiently during speech and clears
+        // it when the service stops — honoring "speak, don't leave a notification."
+        persistNotificationAfterRun = canNotify && posted
+        // The delivery-delay metric measures an *intended* notification post;
+        // skip it for a TTS-only run or a denied-permission no-op.
+        if (canNotify && posted) recordDeliveryDelay(insight.period)
     }
+
+    /**
+     * Broadcast PendingIntent fired when the user swipes the spoken-briefing
+     * notification away — [SpeechDismissReceiver] cancels the on-device speech
+     * (but not the MQTT / cast publishes). Carries the run's [speechToken] so the
+     * receiver only stops speech that's still this briefing's; a distinct
+     * per-run request code keeps each run's (immutable) PendingIntent its own, so
+     * a persisted older notification keeps firing its *own* token rather than a
+     * later run's.
+     */
+    private fun stopSpeechDeleteIntent(): PendingIntent {
+        val token = speechToken
+        val intent = Intent(applicationContext, SpeechDismissReceiver::class.java)
+            .setAction(SpeechDismissReceiver.ACTION_DISMISS)
+            .putExtra(SpeechDismissReceiver.EXTRA_TOKEN, token)
+        // Request code is the token's Int hash (Long.hashCode folds the high and
+        // low 32-bit halves of the millisecond timestamp): well-distributed and
+        // stable past 2038, unlike a raw .toInt() (low 32 bits truncate/wrap) or
+        // seconds-since-epoch (which overflows Int.MAX in 2038). Distinct per run,
+        // so each run's immutable PendingIntent — and its baked-in token extra —
+        // stays its own; the same formula in PlaybackForegroundService keeps
+        // placeholder + forecast sharing one.
+        return PendingIntent.getBroadcast(
+            applicationContext,
+            token.hashCode(),
+            intent,
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+        )
+    }
+
+    // Per-run identifier for the spoken-briefing notification's dismiss path: the
+    // alarm-fire timestamp, which is unique per scheduled run and is always
+    // non-zero whenever a delete intent is built (the playback service only
+    // starts on alarm-driven runs — see promoteToPlaybackServiceIfNeeded).
+    private val speechToken: Long get() = inputData.getLong(KEY_ALARM_FIRED_AT_MS, 0L)
 
     /**
      * Plays the spoken briefing on the phone speaker (or skips it).
@@ -1678,64 +1778,88 @@ class FetchAndNotifyWorker(
         }
         if (!gates.phoneTtsConfigured) return
 
-        // Cast suppression: only when this cast is genuinely playing
-        // audio (willCast AND a synth buffer exists). An image-only
-        // cast (Gemini unavailable / synth failed → silent WAV stub)
-        // doesn't trigger suppression — the smart display isn't the
-        // speaker in that path. gates.castSuppressesPhone folds in
-        // castSkipPhoneSpeech and the forced-Play override: a tapped
-        // Play always speaks on this phone even when a cast is playing.
-        val castHasAudio = gates.castSuppressesPhone && wav != null
-        if (castHasAudio && castDeferred != null) {
-            val castOutcome = castDeferred.await()
-            if (castOutcome is CastInsightController.CastWorkerOutcome.Success) {
-                DiagLog.i(TAG, "Phone speech suppressed — smart display is playing the forecast.")
-                return
-            }
+        // Register this playback coroutine *before* the cast/MQTT suppression
+        // awaits, not just before the audio. A dismissal during those waits must
+        // cancel pending speech too: otherwise a publish that later fails would
+        // fall through the suppression checks and start speaking after the user
+        // already swiped the notification away (see ActiveSpeechSession /
+        // SpeechDismissReceiver). Cancellation propagates into the suspending
+        // awaits and the play/speak below, stopping the AudioTrack / TextToSpeech
+        // via their invokeOnCancellation hooks; the sibling MQTT / cast jobs in
+        // deliver()'s supervisorScope are untouched, so the smart-home publish
+        // still happens.
+        // Only the spoken FGS path has a dismissible notification, so only it
+        // registers for cancellation (keyed by the run's token so a stale
+        // notification's swipe can't stop a later briefing).
+        val speechJob = if (startedPlaybackService) currentCoroutineContext()[Job] else null
+        if (speechJob != null && !ActiveSpeechSession.register(speechToken, speechJob)) {
+            // The user swiped the notification (its "Preparing…" placeholder)
+            // before playback started — honour the dismissal and don't speak.
+            DiagLog.i(TAG, "Spoken forecast dismissed before playback started; skipping speech.")
+            return
         }
-
-        // MQTT suppression: mirror of the cast block above. The MQTT
-        // bridge publishes the rendered audio to the broker; we trust
-        // the user's HA-side automation to play it. Only suppresses
-        // when the publish included audio (synth succeeded) — without
-        // a buffer the broker has nothing to speak, so the phone needs
-        // to. gates.mqttSuppressesPhone folds in mqttSkipPhoneSpeech and
-        // the forced-Play override, so a tapped Play isn't silenced just
-        // because the bridge published the forecast.
-        val mqttHasAudio = gates.mqttSuppressesPhone && wav != null
-        if (mqttHasAudio) {
-            val mqttOutcome = mqttDeferred.await()
-            if (mqttOutcome is MqttPublishOutcome.Success) {
-                DiagLog.i(TAG, "Phone speech suppressed — MQTT bridge published the forecast.")
-                return
+        try {
+            // Cast suppression: only when this cast is genuinely playing
+            // audio (willCast AND a synth buffer exists). An image-only
+            // cast (Gemini unavailable / synth failed → silent WAV stub)
+            // doesn't trigger suppression — the smart display isn't the
+            // speaker in that path. gates.castSuppressesPhone folds in
+            // castSkipPhoneSpeech and the forced-Play override: a tapped
+            // Play always speaks on this phone even when a cast is playing.
+            val castHasAudio = gates.castSuppressesPhone && wav != null
+            if (castHasAudio && castDeferred != null) {
+                val castOutcome = castDeferred.await()
+                if (castOutcome is CastInsightController.CastWorkerOutcome.Success) {
+                    DiagLog.i(TAG, "Phone speech suppressed — smart display is playing the forecast.")
+                    return
+                }
             }
-        }
 
-        val utterance = ttsUtterance(insight, prefs, theme)
-        withSpeechAudioFocus(applicationContext) {
-            if (prefs.ttsEngine == TtsEngine.GEMINI && pcm != null) {
+            // MQTT suppression: mirror of the cast block above. The MQTT
+            // bridge publishes the rendered audio to the broker; we trust
+            // the user's HA-side automation to play it. Only suppresses
+            // when the publish included audio (synth succeeded) — without
+            // a buffer the broker has nothing to speak, so the phone needs
+            // to. gates.mqttSuppressesPhone folds in mqttSkipPhoneSpeech and
+            // the forced-Play override, so a tapped Play isn't silenced just
+            // because the bridge published the forecast.
+            val mqttHasAudio = gates.mqttSuppressesPhone && wav != null
+            if (mqttHasAudio) {
+                val mqttOutcome = mqttDeferred.await()
+                if (mqttOutcome is MqttPublishOutcome.Success) {
+                    DiagLog.i(TAG, "Phone speech suppressed — MQTT bridge published the forecast.")
+                    return
+                }
+            }
+
+            val utterance = ttsUtterance(insight, prefs, theme)
+            withSpeechAudioFocus(applicationContext) {
+                if (prefs.ttsEngine == TtsEngine.GEMINI && pcm != null) {
+                    runCatching {
+                        GeminiTtsSpeaker(
+                            app.geminiTtsClient,
+                            voiceName = prefs.geminiVoice,
+                            style = prefs.ttsStyle,
+                        ).play(pcm)
+                    }.onFailure { t ->
+                        if (t is CancellationException) throw t
+                        DiagLog.w(TAG, "Gemini playback failed; insight is still posted as notification.", t)
+                    }
+                    return@withSpeechAudioFocus
+                }
+                // Device engine, or Gemini synth failed pre-alignment.
+                // Either way, on-device TTS synthesises at playback time
+                // and gets the user audio without burning another Gemini
+                // call.
                 runCatching {
-                    GeminiTtsSpeaker(
-                        app.geminiTtsClient,
-                        voiceName = prefs.geminiVoice,
-                        style = prefs.ttsStyle,
-                    ).play(pcm)
+                    app.deviceTtsSpeaker(prefs.deviceVoice).speak(utterance.text, utterance.locale)
                 }.onFailure { t ->
                     if (t is CancellationException) throw t
-                    DiagLog.w(TAG, "Gemini playback failed; insight is still posted as notification.", t)
+                    DiagLog.w(TAG, "Device TTS failed; insight is still posted as notification.", t)
                 }
-                return@withSpeechAudioFocus
             }
-            // Device engine, or Gemini synth failed pre-alignment.
-            // Either way, on-device TTS synthesises at playback time
-            // and gets the user audio without burning another Gemini
-            // call.
-            runCatching {
-                app.deviceTtsSpeaker(prefs.deviceVoice).speak(utterance.text, utterance.locale)
-            }.onFailure { t ->
-                if (t is CancellationException) throw t
-                DiagLog.w(TAG, "Device TTS failed; insight is still posted as notification.", t)
-            }
+        } finally {
+            speechJob?.let { ActiveSpeechSession.clear(speechToken, it) }
         }
     }
 
@@ -1772,12 +1896,16 @@ class FetchAndNotifyWorker(
      * runs while the app is the top app (focus works without a service), and
      * the exact-alarm exemption that lets us *start* a foreground service from
      * the background only covers the alarm fire. We also skip it when the
-     * period's delivery mode won't speak, so notification-only users don't see
-     * a service notification for nothing. Best-effort: if the system refuses
-     * the start (e.g. the exemption window lapsed), log and continue in the
-     * background rather than failing the whole run.
+     * period's delivery mode won't speak, so notification-only users don't get
+     * a foreground service for nothing.
+     *
+     * The service ([PlaybackForegroundService]) owns the run's single
+     * notification: it posts a silent "Preparing…" placeholder now, the worker
+     * replaces it with the forecast at delivery, and the service detaches it on
+     * finish so it persists after speech. Best-effort: a refused start is logged
+     * inside the service and the run continues in the background.
      */
-    private suspend fun promoteToPlaybackServiceIfNeeded(prefs: UserPreferences) {
+    private fun promoteToPlaybackServiceIfNeeded(prefs: UserPreferences) {
         val alarmTriggered = inputData.getLong(KEY_ALARM_FIRED_AT_MS, 0L) != 0L
         if (!alarmTriggered) return
         val period = inputData.getString(KEY_PERIOD)
@@ -1788,34 +1916,12 @@ class FetchAndNotifyWorker(
             ForecastPeriod.TONIGHT -> prefs.tonightDeliveryMode
         }
         if (!mode.playsSpeech) return
-        runCatching { setForeground(playbackForegroundInfo()) }
-            .onFailure { t ->
-                if (t is CancellationException) throw t
-                DiagLog.w(TAG, "Couldn't start the playback foreground service; speech may be inaudible from the background.", t)
-            }
-    }
-
-    /**
-     * The notification carried by the playback foreground service (see
-     * [promoteToPlaybackServiceIfNeeded]). Silent and LOW-importance — it's a
-     * platform requirement for background audio, not a user-actionable post —
-     * and tagged `mediaPlayback` so the foreground-service type matches the
-     * permission and manifest declaration.
-     */
-    private fun playbackForegroundInfo(): ForegroundInfo {
-        val notification = NotificationCompat.Builder(applicationContext, CHANNEL_PLAYBACK)
-            .setSmallIcon(R.drawable.ic_notification_insight)
-            .setContentTitle(applicationContext.getString(R.string.notification_playback_title))
-            .setOngoing(true)
-            .setSilent(true)
-            .build()
-        // minSdk is 31, so the typed ForegroundInfo constructor (foreground
-        // service type, applied on API 29+) is always available here.
-        return ForegroundInfo(
-            PLAYBACK_NOTIFICATION_ID,
-            notification,
-            ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK,
-        )
+        // Only enable the transient-notification path if the start request was
+        // actually accepted: a background startForegroundService is rejected
+        // synchronously once the exact-alarm exemption lapses, and we mustn't
+        // then post (and rely on the service to remove) a TTS-only notification
+        // with no service behind it.
+        startedPlaybackService = PlaybackForegroundService.start(applicationContext, period, speechToken)
     }
 
     private suspend fun awaitDeliveryAlignment() {
@@ -1934,11 +2040,6 @@ class FetchAndNotifyWorker(
         // fresh forecast. Race vs. concurrent plays is handled in the
         // UI gate — see TodayState.anyWorkActive.
         const val UNIQUE_WORK_NAME_PLAY = "insight_play"
-
-        // Foreground-service notification ID for the playback service. Distinct
-        // from the insight notification IDs (1001 daily, 1003 tonight) so the
-        // service notification and the delivered insight don't clobber each other.
-        private const val PLAYBACK_NOTIFICATION_ID = 1005
 
         // Output Data keys for surfacing failure reasons in the UI.
         const val KEY_REASON = "reason"

--- a/app/src/main/kotlin/app/clothescast/work/PlaybackForegroundService.kt
+++ b/app/src/main/kotlin/app/clothescast/work/PlaybackForegroundService.kt
@@ -1,0 +1,230 @@
+package app.clothescast.work
+
+import android.app.Notification
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.os.Handler
+import android.os.IBinder
+import android.os.Looper
+import androidx.core.app.NotificationCompat
+import androidx.core.app.ServiceCompat
+import androidx.core.content.ContextCompat
+import app.clothescast.MainActivity
+import app.clothescast.R
+import app.clothescast.core.domain.model.ForecastPeriod
+import app.clothescast.diag.DiagLog
+import app.clothescast.notification.CHANNEL_DAILY_INSIGHT
+import app.clothescast.notification.CHANNEL_TONIGHT_INSIGHT_DEFAULT
+import app.clothescast.notification.InsightNotifier
+import app.clothescast.notification.SpeechDismissReceiver
+import app.clothescast.notification.TonightInsightNotifier
+
+/**
+ * Short-lived media-playback foreground service that owns the single notification
+ * for a *scheduled, spoken* briefing.
+ *
+ * Why a service we control rather than WorkManager's `setForeground`: a spoken
+ * briefing runs from a background WorkManager worker, and modern Android only
+ * lets background audio play while a `mediaPlayback` foreground service is up
+ * (15+ denies audio focus, 17+ silences `AudioTrack` outright otherwise). The
+ * worker could get that via `setForeground`, but WorkManager *removes* its
+ * foreground notification the moment the worker finishes — so the forecast would
+ * vanish from the shade the instant speech ends. By owning the service we can
+ * call `stopForeground(STOP_FOREGROUND_DETACH)` instead, which leaves the very
+ * same notification behind as an ordinary one the user can read and clear on
+ * their own time. One notification, full lifecycle, no duplicate.
+ *
+ * Lifecycle, driven by the worker ([FetchAndNotifyWorker]):
+ *  1. [start] (early in the run, inside the exact-alarm FGS-start exemption):
+ *     `startForeground` with a silent "Preparing your forecast…" placeholder on
+ *     the period's own notification id + channel. Silent so it doesn't alert a
+ *     minute before there's anything to say — the alert lands when the worker
+ *     replaces this with the real forecast at the aligned briefing moment.
+ *  2. The worker posts the forecast under the *same notification id* (via
+ *     [InsightNotifier] / [TonightInsightNotifier]), which updates this very
+ *     notification in place — now showing the outfit + prose, and alerting.
+ *  3. [finish] once delivery is done: `STOP_FOREGROUND_DETACH` when the forecast
+ *     was posted (leave it in the shade until the user clears it), or
+ *     `STOP_FOREGROUND_REMOVE` when nothing was delivered (drop the bare
+ *     placeholder), then `stopSelf`.
+ *
+ * A safety timeout removes the notification and stops the service if [finish]
+ * never arrives (worker killed mid-run), so a crash can't strand a foreground
+ * service with a "Preparing…" notification forever.
+ */
+class PlaybackForegroundService : Service() {
+
+    private val handler = Handler(Looper.getMainLooper())
+    private val timeout = Runnable {
+        DiagLog.w(TAG, "Playback service timed out without a finish signal; stopping and clearing.")
+        stopAndClear(detach = false)
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        when (intent?.action) {
+            ACTION_START -> {
+                val period = intent.getStringExtra(EXTRA_PERIOD)
+                    ?.let { runCatching { ForecastPeriod.valueOf(it) }.getOrNull() }
+                    ?: ForecastPeriod.TODAY
+                promote(period, intent.getLongExtra(EXTRA_TOKEN, 0L))
+            }
+            ACTION_FINISH -> stopAndClear(detach = intent.getBooleanExtra(EXTRA_DETACH, false))
+            else -> {
+                // An unrecognized (or null, e.g. process-restart) start: we have
+                // nothing to play and no notification to keep alive, so stop
+                // rather than sit foreground with a placeholder we never finish.
+                DiagLog.w(TAG, "Playback service started without a recognized action; stopping.")
+                stopAndClear(detach = false)
+            }
+        }
+        // Don't recreate with a null intent if the system kills us — there's
+        // nothing to resume, and a sticky restart would re-post the placeholder.
+        return START_NOT_STICKY
+    }
+
+    private fun promote(period: ForecastPeriod, token: Long) {
+        val (channel, id) = when (period) {
+            ForecastPeriod.TODAY ->
+                CHANNEL_DAILY_INSIGHT to InsightNotifier.NOTIFICATION_ID_DAILY_INSIGHT
+            ForecastPeriod.TONIGHT ->
+                CHANNEL_TONIGHT_INSIGHT_DEFAULT to TonightInsightNotifier.NOTIFICATION_ID_TONIGHT_INSIGHT
+        }
+        try {
+            ServiceCompat.startForeground(
+                this,
+                id,
+                placeholderNotification(channel, token),
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK,
+            )
+            handler.removeCallbacks(timeout)
+            handler.postDelayed(timeout, MAX_PLAYBACK_MS)
+            DiagLog.i(TAG, "Playback foreground service started for $period (notification $id).")
+        } catch (t: Throwable) {
+            // Most likely a ForegroundServiceStartNotAllowedException if the
+            // exact-alarm exemption window had lapsed by the time we started, or
+            // a missing-type error. The worker continues in the background
+            // (speech may be inaudible on 15+, the documented degradation); don't
+            // leave a half-started service behind.
+            DiagLog.w(TAG, "Couldn't start the playback foreground service; stopping it.", t)
+            stopSelf()
+        }
+    }
+
+    private fun placeholderNotification(channel: String, token: Long): Notification =
+        NotificationCompat.Builder(this, channel)
+            .setSmallIcon(R.drawable.ic_notification_insight)
+            .setContentTitle(getString(R.string.notification_preparing_title))
+            .setContentIntent(
+                PendingIntent.getActivity(
+                    this,
+                    REQUEST_OPEN_APP,
+                    MainActivity.todayTapIntent(this),
+                    PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+                ),
+            )
+            // Carry the run token so swiping the placeholder during the
+            // fetch/alignment wait (Android 14+ lets an FGS notification be
+            // dismissed) is remembered and the briefing skips speech rather than
+            // talking over the dismissal. Same request code + token as the
+            // forecast that replaces it (FetchAndNotifyWorker.stopSpeechDeleteIntent),
+            // so they share one PendingIntent.
+            .setDeleteIntent(stopSpeechDeleteIntent(token))
+            .setOngoing(true)
+            // Silent: the real forecast (which replaces this) carries the alert
+            // when speech starts; a placeholder shown during the fetch/alignment
+            // wait shouldn't chime on its own.
+            .setSilent(true)
+            .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
+            .build()
+
+    // Must match FetchAndNotifyWorker.stopSpeechDeleteIntent's request-code
+    // formula (token.hashCode()) so the placeholder and the forecast that
+    // replaces it share one PendingIntent.
+    private fun stopSpeechDeleteIntent(token: Long): PendingIntent =
+        PendingIntent.getBroadcast(
+            this,
+            token.hashCode(),
+            Intent(this, SpeechDismissReceiver::class.java)
+                .setAction(SpeechDismissReceiver.ACTION_DISMISS)
+                .putExtra(SpeechDismissReceiver.EXTRA_TOKEN, token),
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+        )
+
+    private fun stopAndClear(detach: Boolean) {
+        handler.removeCallbacks(timeout)
+        val flags = if (detach) ServiceCompat.STOP_FOREGROUND_DETACH else ServiceCompat.STOP_FOREGROUND_REMOVE
+        ServiceCompat.stopForeground(this, flags)
+        stopSelf()
+    }
+
+    override fun onDestroy() {
+        handler.removeCallbacks(timeout)
+        super.onDestroy()
+    }
+
+    companion object {
+        private const val TAG = "PlaybackFgsService"
+        private const val ACTION_START = "app.clothescast.work.PLAYBACK_START"
+        private const val ACTION_FINISH = "app.clothescast.work.PLAYBACK_FINISH"
+        private const val EXTRA_PERIOD = "period"
+        private const val EXTRA_DETACH = "detach"
+        private const val EXTRA_TOKEN = "token"
+        private const val REQUEST_OPEN_APP = 105
+
+        // Hard ceiling on how long the service may sit foreground without a
+        // finish signal. A normal run is well under two minutes (up to 30s
+        // fetch jitter + 60s delivery alignment + synth + speech); five minutes
+        // leaves generous headroom for a slow network while still bounding a
+        // stranded service if the worker is killed mid-delivery.
+        private const val MAX_PLAYBACK_MS = 5 * 60 * 1000L
+
+        /**
+         * Promote the process to a media-playback foreground service for a
+         * spoken [period] briefing. Call as early in the alarm-driven run as
+         * possible so the start lands inside the exact-alarm FGS-start
+         * exemption. Best-effort: a refused start is logged and the run
+         * continues in the background.
+         *
+         * Returns true if the start request was accepted. A background
+         * `startForegroundService` is rejected *synchronously* with
+         * `ForegroundServiceStartNotAllowedException` once the exemption window
+         * has lapsed, so a false return is the caller's signal not to enable the
+         * transient-notification path that assumes a running service.
+         *
+         * [token] is the run's per-run identifier (the alarm-fire time): it's
+         * baked into the placeholder's dismiss intent so a swipe before speech
+         * starts is remembered (see ActiveSpeechSession).
+         */
+        fun start(context: Context, period: ForecastPeriod, token: Long): Boolean {
+            val intent = Intent(context, PlaybackForegroundService::class.java)
+                .setAction(ACTION_START)
+                .putExtra(EXTRA_PERIOD, period.name)
+                .putExtra(EXTRA_TOKEN, token)
+            return runCatching { ContextCompat.startForegroundService(context, intent) }
+                .onFailure { DiagLog.w(TAG, "Failed to request playback foreground service start.", it) }
+                .isSuccess
+        }
+
+        /**
+         * Tear the service down once delivery is done. [detach] true leaves the
+         * forecast notification in the shade (the forecast was posted); false
+         * removes it (nothing was delivered — drop the bare placeholder).
+         */
+        fun finish(context: Context, detach: Boolean) {
+            val intent = Intent(context, PlaybackForegroundService::class.java)
+                .setAction(ACTION_FINISH)
+                .putExtra(EXTRA_DETACH, detach)
+            // The service is already running and foreground, so a plain
+            // startService to deliver the finish command is allowed even from
+            // the background. Guard anyway: if the original start was refused
+            // there's no service to signal.
+            runCatching { context.startService(intent) }
+                .onFailure { DiagLog.w(TAG, "Failed to signal playback foreground service finish.", it) }
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1123,9 +1123,10 @@
     <string name="notification_channel_tonight_insight_silent_description">The evening weather summary when your evening is empty. Posted silently — you can glance at it on the lock screen, but it won\'t make a sound.</string>
     <string name="notification_tonight_insight_title">Tonight\'s ClothesCast</string>
 
-    <string name="notification_channel_playback_name">Speaking the forecast</string>
-    <string name="notification_channel_playback_description">Shown briefly while ClothesCast reads your scheduled forecast aloud. Required by Android so the audio can play from the background.</string>
-    <string name="notification_playback_title">Reading your forecast aloud…</string>
+    <!-- Brief placeholder shown on the spoken-briefing notification while the
+         forecast is still being fetched, before it's replaced in place by the
+         forecast itself. -->
+    <string name="notification_preparing_title">Preparing your forecast…</string>
 
 
     <string name="settings_notification_permission_title">Notifications are blocked</string>

--- a/app/src/test/kotlin/app/clothescast/tts/ActiveSpeechSessionTest.kt
+++ b/app/src/test/kotlin/app/clothescast/tts/ActiveSpeechSessionTest.kt
@@ -1,0 +1,101 @@
+package app.clothescast.tts
+
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.Job
+import org.junit.Test
+
+/**
+ * Covers the token-scoped cancel contract that lets the spoken briefing
+ * notification's dismiss action stop *its own* phone speaker — including a
+ * dismissal that lands before playback starts — without touching a later
+ * briefing's speech or the rest of delivery. Each test uses distinct tokens so
+ * the process-wide singleton's state can't bleed between cases.
+ */
+class ActiveSpeechSessionTest {
+
+    @Test
+    fun `register without a prior dismissal returns true`() {
+        ActiveSpeechSession.register(token = 1L, job = Job()) shouldBe true
+    }
+
+    @Test
+    fun `stop cancels the speech registered under the same token`() {
+        val job = Job()
+        ActiveSpeechSession.register(token = 2L, job = job)
+
+        ActiveSpeechSession.stop(token = 2L)
+
+        job.isCancelled shouldBe true
+    }
+
+    @Test
+    fun `stop with a stale token leaves the current speech playing`() {
+        // A persisted older notification (token 3) is swiped while a newer
+        // briefing (token 4) is speaking: the new briefing must keep playing.
+        val current = Job()
+        ActiveSpeechSession.register(token = 4L, job = current)
+
+        ActiveSpeechSession.stop(token = 3L)
+
+        current.isCancelled shouldBe false
+        ActiveSpeechSession.stop(token = 4L) // cleanup
+    }
+
+    @Test
+    fun `a dismissal before playback makes the matching register skip speech`() {
+        // Real tokens are epoch-millis (well outside the JVM's cached-Long range),
+        // so this also guards the remembered-dismissal lookup against comparing by
+        // boxed identity instead of value.
+        val token = 1_700_000_000_000L
+        // The placeholder is swiped during the fetch/alignment wait, before
+        // playPhoneSpeaker registers — the matching register then declines.
+        ActiveSpeechSession.stop(token)
+
+        ActiveSpeechSession.register(token, job = Job()) shouldBe false
+    }
+
+    @Test
+    fun `a pre-playback dismissal of one run does not block a different run`() {
+        ActiveSpeechSession.stop(token = 1_700_000_001_000L)
+
+        ActiveSpeechSession.register(token = 1_700_000_002_000L, job = Job()) shouldBe true
+    }
+
+    @Test
+    fun `a stale dismissal does not overwrite a pending one for a different run`() {
+        // Epoch-millis tokens (non-cached Longs). The live run's placeholder is
+        // swiped pre-register, then an unrelated older notification is swiped; the
+        // live run must still see its own dismissal and skip speech — the stale
+        // token must not clobber the remembered one.
+        val live = 1_700_000_003_000L
+        val stale = 1_700_000_004_000L
+        ActiveSpeechSession.stop(live)
+        ActiveSpeechSession.stop(stale)
+
+        ActiveSpeechSession.register(live, job = Job()) shouldBe false
+    }
+
+    @Test
+    fun `a late clear from an older run does not unregister a newer job`() {
+        val old = Job()
+        ActiveSpeechSession.register(token = 8L, job = old)
+        val current = Job()
+        ActiveSpeechSession.register(token = 9L, job = current)
+
+        ActiveSpeechSession.clear(token = 8L, job = old)
+        ActiveSpeechSession.stop(token = 9L)
+
+        current.isCancelled shouldBe true
+    }
+
+    @Test
+    fun `clearing the current run stops a later dismiss from cancelling it`() {
+        val job = Job()
+        ActiveSpeechSession.register(token = 10L, job = job)
+
+        ActiveSpeechSession.clear(token = 10L, job = job)
+        ActiveSpeechSession.stop(token = 10L)
+
+        job.isCancelled shouldBe false
+    }
+}


### PR DESCRIPTION
## What & why

A scheduled **spoken** briefing used to post **two** notifications: the forecast itself, plus a separate bare **"Reading your forecast aloud…"** notification for the media-playback foreground service that lets the worker speak from the background. This merges them into **one**.

## How

- **The playback foreground service now owns the run's single notification.** It posts a brief silent **"Preparing your forecast…"** placeholder while fetching, then the worker replaces it *in place* with the real forecast (outfit icon + prose) at the aligned briefing moment.
- **We run our own service** (`PlaybackForegroundService`) instead of WorkManager's `setForeground`, specifically so we can `stopForeground(STOP_FOREGROUND_DETACH)` when speech ends — leaving the *same* notification in the shade until the user clears it (WorkManager always *removes* its foreground notification on completion). A safety timeout stops a stranded service if the worker dies; `start()` reports whether the FGS actually started so a refused start can't leave a stray notification.
- **Swiping the notification stops on-device speech** (delete-intent → `SpeechDismissReceiver` → `ActiveSpeechSession`), scoped by a **per-run token** so swiping a *persisted older* notification can't cancel a *later* briefing's speech. MQTT and cast are sibling jobs and keep going: dismiss = "stop talking on *this* phone," not "abort delivery."
- **`setAutoCancel(false)` on spoken runs** so tapping opens the app without dismissing/canceling speech — only a swipe stops it.
- **TTS-only runs** still show the forecast (with swipe-to-stop) during speech but remove it afterward (silent, not persisted) — honoring "speak, don't leave a notification."
- **Spoken tonight runs use the default channel** consistently, avoiding a stuck-channel mismatch with the placeholder.
- **Retires the `playback_v1` ("Speaking the forecast") channel** and its strings; the merged notification lives on the forecast's own daily/tonight channel and is deleted from existing installs on upgrade.

## Privacy

No change to what crosses the device boundary — same prose, same MQTT / cast / TTS paths.

## Test plan

- ✅ `:app:testDebugUnitTest` + `:app:assembleDebug` pass (rebased on `main`). New `ActiveSpeechSessionTest` covers the token-scoped cancel (incl. the stale-token no-op).
- ⚠️ **Needs a real Android 15+ device check**: the foreground-service start/detach + audio-focus path can't be exercised in Robolectric/CI. Verify a scheduled spoken briefing shows one notification, alerts when speech starts, persists after speech, and that swiping it stops *that* briefing's speech while smart-home delivery continues.

Rebased onto `main` after #1040 (the widget overnight-freshness fix) merged, so this PR's diff is just the notification work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019dW5rSjHB1X2cvyPyqeudb