### PR TITLE
Keep the widget showing the ongoing overnight after midnight

### DIFF
--- a/app/src/main/kotlin/app/clothescast/widget/WidgetInsightLoader.kt
+++ b/app/src/main/kotlin/app/clothescast/widget/WidgetInsightLoader.kt
@@ -2,6 +2,7 @@ package app.clothescast.widget
 
 import android.content.Context
 import app.clothescast.ClothesCastApplication
+import app.clothescast.core.domain.model.ForecastPeriod
 import app.clothescast.core.domain.model.Insight
 import app.clothescast.core.domain.model.UserPreferences
 import app.clothescast.diag.DiagLog
@@ -137,12 +138,30 @@ internal fun widgetCacheAction(
     val localNow = LocalDateTime.ofInstant(now, zone)
     val currentPeriod = FetchAndNotifyWorker.currentPeriodForSchedule(morningTime, tonightTime, localNow.toLocalTime())
     val currentDate = FetchAndNotifyWorker.playTargetDate(currentPeriod, localNow, morningTime, tonightTime)
-    if (insight.period == currentPeriod && insight.forDate == currentDate) return WidgetCacheAction.RENDER
+    // The ongoing overnight (the post-midnight tail of the TONIGHT window) dates
+    // its *derived* insight to yesterday — the night began yesterday evening —
+    // even though its snapshot bundle, and so [currentDate], stays anchored on
+    // today (see FetchAndNotifyWorker.playTargetDate / InsightSummary.overnight).
+    // So in that tail match the current window on the overnight flag plus the
+    // expected night's date (yesterday), not on [currentDate]: the flag alone
+    // would also accept a day-old overnight, and [currentDate] (today) would
+    // accept the *coming* night. Outside the tail, the usual period+date match.
+    val currentlyOvernight = currentPeriod == ForecastPeriod.TONIGHT &&
+        tonightTime > morningTime && localNow.toLocalTime() < morningTime
+    val matchesCurrentWindow = if (currentlyOvernight) {
+        insight.period == ForecastPeriod.TONIGHT &&
+            insight.summary.overnight &&
+            insight.forDate == localNow.toLocalDate().minusDays(1)
+    } else {
+        insight.period == currentPeriod && insight.forDate == currentDate
+    }
+    if (matchesCurrentWindow) return WidgetCacheAction.RENDER
     if (Duration.between(insight.generatedAt, now) < FetchAndNotifyWorker.SILENT_REFRESH_MIN_AGE) {
         return WidgetCacheAction.RENDER
     }
-    // currentDate trails the device date only in the post-midnight tail of the
-    // tonight window, where a dayOffset-0 refresh can't reach the ongoing night.
+    // Defensive: [currentDate] no longer trails the device date (the overnight is
+    // today-anchored since "Show Overnight and Today before dawn"), so a refresh
+    // can always reach the current window and this branch is normally not taken.
     if (currentDate != localNow.toLocalDate()) return WidgetCacheAction.KEEP
     return WidgetCacheAction.REFRESH
 }

--- a/app/src/test/kotlin/app/clothescast/widget/WidgetInsightFreshnessTest.kt
+++ b/app/src/test/kotlin/app/clothescast/widget/WidgetInsightFreshnessTest.kt
@@ -5,7 +5,6 @@ import app.clothescast.core.domain.model.ForecastPeriod
 import app.clothescast.core.domain.model.Insight
 import app.clothescast.core.domain.model.InsightSummary
 import app.clothescast.core.domain.model.TemperatureBand
-import app.clothescast.widget.WidgetCacheAction.KEEP
 import app.clothescast.widget.WidgetCacheAction.REFRESH
 import app.clothescast.widget.WidgetCacheAction.RENDER
 import org.junit.Assert.assertEquals
@@ -20,14 +19,14 @@ import java.time.ZoneId
  * Unit coverage for [widgetCacheAction] — the gate that stops the home-screen
  * widgets plotting a previous window as the current one (the "Feels like
  * 17 – 22°C" bug, where a day-stale daytime snapshot drew yesterday's curve
- * under today's axis). It renders the cache when it's the current window,
- * [REFRESH]es (empty + kick) when a refresh can replace it, and [KEEP]s the
- * last-known render when a refresh can't reach the current window (the
- * post-midnight overnight window) — never churning. A snapshot younger than the
- * silent-refresh threshold is always rendered, so it can't settle into a loop.
- * The render path itself needs a real display and is verified on-device; this
- * locks the pure period/date logic. The default 07:00 / 19:00 cutoffs match the
- * app's default morning / tonight schedule.
+ * under today's axis). It renders the cache when it's the current window —
+ * including the ongoing post-midnight overnight, matched on its overnight flag
+ * since that window's insight dates to yesterday while its bundle stays
+ * today-anchored — and [REFRESH]es (empty + kick) otherwise. A snapshot younger
+ * than the silent-refresh threshold is always rendered, so it can't settle into
+ * a loop. The render path itself needs a real display and is verified on-device;
+ * this locks the pure period/date logic. The default 07:00 / 19:00 cutoffs match
+ * the app's default morning / tonight schedule.
  */
 class WidgetInsightFreshnessTest {
 
@@ -54,9 +53,29 @@ class WidgetInsightFreshnessTest {
 
     @Test
     fun `ongoing tonight snapshot renders in the small hours after midnight`() {
-        // Generated the evening of the 18th; at 01:00 on the 19th the current
-        // tonight window is still dated the 18th, so it matches.
-        assertEquals(RENDER, action(nightInsight(LocalDate.of(2026, 6, 18)), at(2026, 6, 19, 1, 0)))
+        // Captured post-midnight (00:30, how an overnight snapshot really arises)
+        // and dated the 18th; at 02:00 on the 19th the current window is still
+        // that ongoing overnight, recognised by its overnight flag + the 18th
+        // date. generatedAt is >1h old so the age gate doesn't mask the match.
+        val overnight = nightInsight(
+            LocalDate.of(2026, 6, 18),
+            generatedAt = at(2026, 6, 19, 0, 30),
+            overnight = true,
+        )
+        assertEquals(RENDER, action(overnight, at(2026, 6, 19, 2, 0)))
+    }
+
+    @Test
+    fun `a day-old overnight snapshot refreshes instead of rendering stale`() {
+        // An overnight from the night of the 17th, still cached at 02:00 on the
+        // 19th: its flag is set but its date (the 17th) isn't the night now in
+        // progress (the 18th), so it must refresh, not render two-day-old data.
+        val staleOvernight = nightInsight(
+            LocalDate.of(2026, 6, 17),
+            generatedAt = at(2026, 6, 18, 0, 30),
+            overnight = true,
+        )
+        assertEquals(REFRESH, action(staleOvernight, at(2026, 6, 19, 2, 0)))
     }
 
     @Test
@@ -65,25 +84,31 @@ class WidgetInsightFreshnessTest {
     }
 
     @Test
-    fun `post-midnight, a stale daytime snapshot is kept without refreshing`() {
-        // Codex P2: between midnight and the wake cutoff the ongoing night is
-        // dated yesterday, which a dayOffset-0 refresh can't fetch — it would
-        // write the upcoming night instead. Keep the last-known daytime render
-        // rather than churn toward a future-night snapshot.
-        assertEquals(KEEP, action(dayInsight(LocalDate.of(2026, 6, 18)), at(2026, 6, 19, 2, 0)))
+    fun `post-midnight, a stale daytime snapshot refreshes toward the ongoing overnight`() {
+        // Between midnight and the wake cutoff the current window is the ongoing
+        // overnight, which is today-anchored (since "Show Overnight and Today
+        // before dawn") and so reachable by a dayOffset-0 refresh. A stale
+        // daytime snapshot therefore refreshes toward it rather than being kept.
+        assertEquals(REFRESH, action(dayInsight(LocalDate.of(2026, 6, 18)), at(2026, 6, 19, 2, 0)))
     }
 
     @Test
     fun `tonight snapshot honors a later-than-default wake time`() {
-        // Wake set to 09:00: the overnight widget stays current until then.
+        // Wake set to 09:00: the ongoing overnight stays current until then.
+        // Captured post-midnight (01:00) and >1h old at both clocks below.
         val lateMorning = LocalTime.of(9, 0)
+        val overnight = nightInsight(
+            LocalDate.of(2026, 6, 18),
+            generatedAt = at(2026, 6, 19, 1, 0),
+            overnight = true,
+        )
         assertEquals(
             RENDER,
-            widgetCacheAction(nightInsight(LocalDate.of(2026, 6, 18)), at(2026, 6, 19, 8, 0), lateMorning, tonight, zone),
+            widgetCacheAction(overnight, at(2026, 6, 19, 8, 0), lateMorning, tonight, zone),
         )
         assertEquals(
             REFRESH,
-            widgetCacheAction(nightInsight(LocalDate.of(2026, 6, 18)), at(2026, 6, 19, 9, 30), lateMorning, tonight, zone),
+            widgetCacheAction(overnight, at(2026, 6, 19, 9, 30), lateMorning, tonight, zone),
         )
     }
 
@@ -124,14 +149,28 @@ class WidgetInsightFreshnessTest {
     private fun dayInsight(forDate: LocalDate, generatedAt: Instant = forDate.atTime(7, 0).atZone(zone).toInstant()): Insight =
         insight(ForecastPeriod.TODAY, forDate, generatedAt)
 
-    private fun nightInsight(forDate: LocalDate, generatedAt: Instant = forDate.atTime(19, 0).atZone(zone).toInstant()): Insight =
-        insight(ForecastPeriod.TONIGHT, forDate, generatedAt)
+    // overnight = true models the ongoing post-midnight night: its bundle is
+    // anchored on today but its derived insight dates to yesterday (see
+    // InsightSummary.overnight). The widget recognises that window by the flag,
+    // not the date.
+    private fun nightInsight(
+        forDate: LocalDate,
+        generatedAt: Instant = forDate.atTime(19, 0).atZone(zone).toInstant(),
+        overnight: Boolean = false,
+    ): Insight =
+        insight(ForecastPeriod.TONIGHT, forDate, generatedAt, overnight)
 
-    private fun insight(period: ForecastPeriod, forDate: LocalDate, generatedAt: Instant): Insight =
+    private fun insight(
+        period: ForecastPeriod,
+        forDate: LocalDate,
+        generatedAt: Instant,
+        overnight: Boolean = false,
+    ): Insight =
         Insight(
             summary = InsightSummary(
                 period = period,
                 band = BandClause(TemperatureBand.MILD, TemperatureBand.MILD),
+                overnight = overnight,
             ),
             recommendedItems = emptyList(),
             generatedAt = generatedAt,


### PR DESCRIPTION
## What & why

Fixes 3 `WidgetInsightFreshnessTest` failures currently red on `main` — and the real regression behind them.

`10e3001` ("Show Overnight and Today before dawn") made the ongoing post-midnight overnight **today-anchored** in its snapshot bundle, while its *derived* insight is dated to **yesterday** (so it can label "Overnight"). But `widgetCacheAction` still matched the current window on `insight.forDate`, so after midnight it never recognized the night in progress — it treated the perfectly current overnight snapshot as stale and **churned a refresh against it every hour** through the small hours.

## Fix

- `widgetCacheAction` now matches the ongoing overnight on `InsightSummary.overnight` (in the post-midnight tail) rather than on the date.
- A stale *daytime* snapshot sitting in that window now `REFRESH`es toward the overnight — which is reachable, being today-anchored — instead of being `KEEP`t. The `KEEP` branch is now a defensive fallback (the overnight is always reachable post-`10e3001`), noted in a comment.
- `WidgetInsightFreshnessTest` updated to the new model: overnight-flagged fixtures render; the stale-daytime case refreshes.

## Test plan

- ✅ `:app:testDebugUnitTest --tests WidgetInsightFreshnessTest` passes (was 3 failing on `main`).
- The widget render path itself needs a real display and isn't unit-tested here (unchanged); this locks the pure period/date/overnight gate logic.

This is independent of #1039 (the notification merge) — it targets `main` directly so `main`'s CI goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019dW5rSjHB1X2cvyPyqeudb

---
_Generated by [Claude Code](https://claude.ai/code/session_019dW5rSjHB1X2cvyPyqeudb)_