### PR TITLE
Close two cross-surface rain gaps Codex flagged on the consensus change

### DIFF
--- a/app/src/main/kotlin/app/clothescast/data/SettingsRepository.kt
+++ b/app/src/main/kotlin/app/clothescast/data/SettingsRepository.kt
@@ -1545,6 +1545,7 @@ private val Context.settingsDataStore: DataStore<Preferences> by preferencesData
             umbrellaDefaultMigration(),
             rainGearDefaultsMigration(),
             rainGearProbabilityMigration(),
+            rainGearProbabilityV2Migration(),
         )
     },
 )
@@ -1901,7 +1902,71 @@ internal fun rainGearProbabilityMigration(): DataMigration<Preferences> {
     }
 }
 
-// Only the US uses Fahrenheit in everyday weather contexts. A handful of
+/**
+ * One-time follow-up to [rainGearProbabilityMigration] that bumps an untouched
+ * default umbrella from the old 20% bar down to the new 10% chance-of-rain bar.
+ *
+ * [rainGearProbabilityMigration] (the consensus build's v1) collapsed the old
+ * "≥ 20% OR drizzle-code" umbrella composite onto its 20% probability arm and set
+ * its own sentinel, so on installs that already ran it the default umbrella sits at
+ * a bare `precip_above` 20 — firing only at 20% while the prose and the conditions
+ * strip moved to 10%. A bare probability row is byte-identical through v1, so that
+ * gap can't be closed there; this v2 pass rewrites any bare 20% umbrella row to 10%.
+ *
+ * We can't tell a stale default apart from a user who deliberately set exactly 20%
+ * (the weather-code arm that once distinguished them is long gone), so both move to
+ * 10% — the same value-based upgrade the other default migrations in this file make.
+ * Because it runs once, gated by [RAIN_GEAR_PROBABILITY_V2_SENTINEL], a 20% the user
+ * sets *after* the migration has run stays 20%. Rain jacket is untouched: its old
+ * and new default are both 50%. Internal for unit testing.
+ */
+internal fun rainGearProbabilityV2Migration(): DataMigration<Preferences> {
+    val migrated = booleanPreferencesKey(RAIN_GEAR_PROBABILITY_V2_SENTINEL)
+    val clothesRules = stringPreferencesKey("clothes_rules_json")
+    val json = Json { ignoreUnknownKeys = true }
+
+    fun ClothesRuleDto.isOldDefaultUmbrella(): Boolean =
+        Garment.fromKey(item) == Garment.UMBRELLA &&
+            type == ClothesRuleDto.TYPE_PRECIP_ABOVE &&
+            value == OLD_UMBRELLA_DEFAULT_PCT
+
+    return object : DataMigration<Preferences> {
+        override suspend fun shouldMigrate(currentData: Preferences): Boolean =
+            currentData[migrated] != true
+
+        override suspend fun migrate(currentData: Preferences): Preferences {
+            val result = mutablePreferencesOf()
+            currentData.asMap().forEach { (key, value) ->
+                @Suppress("UNCHECKED_CAST")
+                result[key as Preferences.Key<Any>] = value
+            }
+            val stored = currentData[clothesRules]
+            if (!stored.isNullOrBlank()) {
+                runCatching {
+                    val dtos = json.decodeFromString<List<ClothesRuleDto>>(stored)
+                    // Only rewrite when a bare 20% umbrella is present; any other list
+                    // (already 10%, customized, no umbrella rule) re-encodes unchanged.
+                    if (dtos.any { it.isOldDefaultUmbrella() }) {
+                        val rebuilt = dtos.map { dto ->
+                            if (dto.isOldDefaultUmbrella()) dto.copy(value = NEW_UMBRELLA_DEFAULT_PCT) else dto
+                        }
+                        result[clothesRules] = json.encodeToString(rebuilt)
+                    }
+                }
+                // Corrupt JSON: leave it untouched and still set the sentinel —
+                // parseRules falls back to the new DEFAULTS when it can't decode.
+            }
+            result[migrated] = true
+            return result
+        }
+
+        override suspend fun cleanUp() = Unit
+    }
+}
+
+private const val RAIN_GEAR_PROBABILITY_V2_SENTINEL = "rain_gear_probability_migrated_v2"
+private const val OLD_UMBRELLA_DEFAULT_PCT = 20.0
+private const val NEW_UMBRELLA_DEFAULT_PCT = 10.0
 // dependencies (BS, BZ, KY, PW) also do, but they're rounding error and the
 // user can override via the unit picker if needed — not worth the extra surface.
 // Internal so SettingsState can mirror the repository's defaults at construction

--- a/app/src/test/kotlin/app/clothescast/data/SettingsRepositoryTest.kt
+++ b/app/src/test/kotlin/app/clothescast/data/SettingsRepositoryTest.kt
@@ -419,6 +419,72 @@ class SettingsRepositoryTest {
     }
 
     @Test
+    fun `rain-gear v2 migration bumps an untouched 20 percent umbrella to 10 percent`() = runTest {
+        // Installs that already ran v1 have the umbrella default collapsed to a bare
+        // 20% row (v1 sentinel set, so v1 won't run again). This v2 pass drops that
+        // untouched default to the new 10% bar so it fires on the same chance as the
+        // prose and the conditions strip.
+        val storedJson = """[
+            {"item":"sweater","type":"temp_below","value":16.0,"unit":"CELSIUS"},
+            {"item":"umbrella","type":"precip_above","value":20.0},
+            {"item":"rain-jacket","type":"precip_above","value":50.0}
+        ]""".trimIndent()
+        val before = mutablePreferencesOf(clothesRulesKey to storedJson)
+
+        val result = rainGearProbabilityV2Migration().migrate(before)
+
+        val rules = decodeStoredRules(result[clothesRulesKey])
+        (rules.first { it.item == Garment.UMBRELLA }.condition as ClothesRule.PrecipitationProbabilityAbove)
+            .percent shouldBe 10.0
+        // Rain jacket (50% old = new) and the temperature rule are left as-is.
+        (rules.first { it.item == Garment.RAIN_JACKET }.condition as ClothesRule.PrecipitationProbabilityAbove)
+            .percent shouldBe 50.0
+        result[clothesRulesKey]!! shouldContain
+            """{"item":"sweater","type":"temp_below","value":16.0,"unit":"CELSIUS"}"""
+    }
+
+    @Test
+    fun `rain-gear v2 migration leaves a customized umbrella percentage byte-identical`() = runTest {
+        // 25% is not the old 20% default, so it's a deliberate setting — v2 leaves the
+        // stored JSON untouched.
+        val storedJson = """[{"item":"umbrella","type":"precip_above","value":25.0}]""".trimIndent()
+        val before = mutablePreferencesOf(clothesRulesKey to storedJson)
+
+        val result = rainGearProbabilityV2Migration().migrate(before)
+
+        result[clothesRulesKey] shouldBe storedJson
+    }
+
+    @Test
+    fun `rain-gear v2 migration runs once, gated by its sentinel`() = runTest {
+        val migration = rainGearProbabilityV2Migration()
+        migration.shouldMigrate(emptyPreferences()) shouldBe true
+        migration.shouldMigrate(
+            mutablePreferencesOf(booleanPreferencesKey("rain_gear_probability_migrated_v2") to true),
+        ) shouldBe false
+    }
+
+    @Test
+    fun `rain-gear v1 then v2 upgrades a legacy composite umbrella to 10 percent`() = runTest {
+        // End to end across the chain: the pre-consensus composite umbrella collapses
+        // to a bare 20% via v1, then v2 drops it to the new 10% default.
+        val storedJson = """[
+            {"item":"umbrella","type":"any_of","value":0.0,"any":[
+                {"type":"precip_above","value":20.0},
+                {"type":"rain_code","value":0.0,"codeFloor":"DRIZZLE"}
+            ]}
+        ]""".trimIndent()
+        val afterV1 = rainGearProbabilityMigration().migrate(
+            mutablePreferencesOf(clothesRulesKey to storedJson),
+        )
+        val afterV2 = rainGearProbabilityV2Migration().migrate(afterV1)
+
+        val rules = decodeStoredRules(afterV2[clothesRulesKey])
+        (rules.first { it.item == Garment.UMBRELLA }.condition as ClothesRule.PrecipitationProbabilityAbove)
+            .percent shouldBe 10.0
+    }
+
+    @Test
     fun `periodPreamble defaults to ALWAYS and round-trips all values`() = runTest {
         subject.preferences.first().periodPreamble shouldBe PreambleVisibility.ALWAYS
 

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/RenderInsightSummary.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/RenderInsightSummary.kt
@@ -327,30 +327,44 @@ class RenderInsightSummary {
      *  - [PrecipLikelihood.LIKELY] ("Rain.") at/above [LIKELY_THRESHOLD] (50%).
      *  - [PrecipLikelihood.POSSIBLE] ("Chance of rain.") in the
      *    [POSSIBLE_THRESHOLD]–49% band (10–49%).
-     * Below [POSSIBLE_THRESHOLD] (10%), or when the resolved condition isn't a
-     * precipitating type, nothing fires.
+     * Below [POSSIBLE_THRESHOLD] (10%) nothing fires; at or above it the clause
+     * always fires, because the blended chance is the single signal — a dry
+     * weather *code* (a high-POP overcast hour) no longer cancels it.
      *
      * Condition resolution: prefers the peak hour's weather code when it's a
      * precipitating type, falling back to the day-level condition (after
      * `slicedFor…` this is already the wettest in-window hour's code) when the
      * hour is UNKNOWN; the noon fallback uses the day-level condition directly.
+     * A non-precipitating resolved code is coerced to [WeatherCondition.RAIN]
+     * (snow and the other precipitating codes keep their own type), so the prose
+     * agrees with the umbrella rule and the conditions strip instead of going
+     * silent on the code.
      */
     private fun peakPrecip(today: DailyForecast): PeakPrecip? {
         val peak = today.hourly.maxByOrNull { it.precipitationProbabilityPct }
         val time: LocalTime
-        val condition: WeatherCondition
+        val baseCondition: WeatherCondition
         val peakProb: Double
         if (peak == null || peak.precipitationProbabilityPct < POSSIBLE_THRESHOLD) {
             if (today.precipitationProbabilityMaxPct < POSSIBLE_THRESHOLD) return null
             time = LocalTime.NOON
-            condition = today.condition
+            baseCondition = today.condition
             peakProb = today.precipitationProbabilityMaxPct
         } else {
             time = peak.time
-            condition = if (peak.condition == WeatherCondition.UNKNOWN) today.condition else peak.condition
+            baseCondition = if (peak.condition == WeatherCondition.UNKNOWN) today.condition else peak.condition
             peakProb = peak.precipitationProbabilityPct
         }
-        if (!condition.isPrecipitation()) return null
+        // Honor the single number: once the blended-consensus chance clears the
+        // chance-of-rain bar, a dry weather *code* doesn't cancel the rain. A
+        // high-POP overcast hour (high probability, ~0 modeled accumulation) is
+        // rain by the numbers — the umbrella rule and the conditions strip already
+        // fire from the probability alone, so the prose and evening tie-in must
+        // agree rather than going silent on the code. Coerce a non-precipitating
+        // code to RAIN; snow (and drizzle / rain / thunderstorm) keep their own
+        // condition, so snow still reads as snow.
+        val condition =
+            if (baseCondition.isPrecipitation()) baseCondition else WeatherCondition.RAIN
         // All-day is measured against the LIKELY bar (≥ 50%), not the 10% peak
         // threshold above — "rain all day" should mean confident rain, so a day
         // that only ever nudges 10–49% still names its single peak hour. The base

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/RenderInsightSummaryTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/RenderInsightSummaryTest.kt
@@ -341,10 +341,11 @@ class RenderInsightSummaryTest {
     }
 
     @Test
-    fun `precip clause is omitted when the peak hour's condition is cloudy`() {
-        // "Cloudy at 15:00" doesn't earn a clause: precipitation info is what the
-        // user wants to hear, not haziness. A 30%+ probability with a non-precip
-        // dominant condition gets dropped entirely.
+    fun `precip clause coerces a high-POP cloudy peak hour to rain`() {
+        // A 60% chance with an overcast code is rain by the numbers (high
+        // probability, ~0 modeled accumulation). The umbrella rule and the
+        // conditions strip already fire from the probability, so the prose agrees
+        // instead of going silent on the dry code: the clause emits as RAIN.
         val today = mildToday.copy(
             precipitationProbabilityMaxPct = 60.0,
             condition = WeatherCondition.CLOUDY,
@@ -352,20 +353,28 @@ class RenderInsightSummaryTest {
                 HourlyForecast(LocalTime.of(15, 0), 22.0, 22.0, 60.0, WeatherCondition.CLOUDY),
             ),
         )
-        subject(today, yesterday, emptyList()).precip.shouldBeNull()
+        val out = subject(today, yesterday, emptyList()).precip
+        out.shouldNotBeNull()
+        out!!.condition shouldBe WeatherCondition.RAIN
+        out.time shouldBe LocalTime.of(15, 0)
+        out.likelihood shouldBe PrecipLikelihood.LIKELY
     }
 
     @Test
-    fun `precip clause is omitted when the noon fallback condition is partly cloudy`() {
-        // Day-level chance 40% but no hourly entry crosses 30%, so we'd normally fall
-        // back to noon with today.condition. If today.condition is non-precip we still
-        // drop the clause.
+    fun `noon fallback coerces a dry day-level chance to rain`() {
+        // Day-level chance 40% with no hourly entries: the noon fallback fires, and
+        // a non-precip day condition no longer drops the clause — 40% is a
+        // chance-of-rain by the numbers, so it emits as RAIN at noon (POSSIBLE).
         val today = mildToday.copy(
             precipitationProbabilityMaxPct = 40.0,
             condition = WeatherCondition.PARTLY_CLOUDY,
             hourly = emptyList(),
         )
-        subject(today, yesterday, emptyList()).precip.shouldBeNull()
+        val out = subject(today, yesterday, emptyList()).precip
+        out.shouldNotBeNull()
+        out!!.condition shouldBe WeatherCondition.RAIN
+        out.time shouldBe LocalTime.NOON
+        out.likelihood shouldBe PrecipLikelihood.POSSIBLE
     }
 
     @Test
@@ -462,21 +471,24 @@ class RenderInsightSummaryTest {
     }
 
     @Test
-    fun `calendar tie-in is omitted when the peak condition is non-precipitation`() {
-        // Even with the umbrella rule firing on day-level probability and an event
-        // overlapping the peak hour, a cloudy peak shouldn't motivate a tie-in —
-        // there's no precipitation clause to anchor it to.
+    fun `calendar tie-in fires on a high-POP cloudy peak once it coerces to rain`() {
+        // A cloudy peak at 60% now coerces to a RAIN precip clause (the single
+        // number drives the prose), so an overlapping event plus the umbrella rule
+        // motivate the tie-in — agreeing with the umbrella the rule already
+        // suggests, rather than leaving it unanchored.
         val today = mildToday.copy(
             precipitationProbabilityMaxPct = 60.0,
             condition = WeatherCondition.CLOUDY,
             hourly = listOf(HourlyForecast(LocalTime.of(15, 0), 22.0, 22.0, 60.0, WeatherCondition.CLOUDY)),
         )
         val event = CalendarEvent("park run", tonightPeakDate.atTime(14, 30), tonightPeakDate.atTime(16, 0))
-        subject(
+        val out = subject(
             today, yesterday, listOf("umbrella"),
             events = listOf(event),
             period = ForecastPeriod.TONIGHT,
-        ).calendarTieIn.shouldBeNull()
+        ).calendarTieIn
+        out.shouldNotBeNull()
+        out!!.item shouldBe "umbrella"
     }
 
     @Test


### PR DESCRIPTION
Follow-up to #1041 (merged), closing the two cross-surface rain mismatches it left behind — exactly what the consensus change set out to remove. Two commits, one per fix.

## 1. Default umbrella stranded at 20% (migration commit)
The consensus change moved the prose "chance of rain" and the conditions strip to a **10%** bar but left the default umbrella rule firing at **20%**, so on a 10–19% forecast the app showed rain everywhere except the umbrella suggestion. #1041's own migration collapsed the old `≥20% OR drizzle-code` composite to its 20% arm and set a sentinel, so it can't re-run to fix this.

**Fix:** a one-time `rainGearProbabilityV2Migration` (new `rain_gear_probability_migrated_v2` sentinel) that bumps a bare 20% umbrella row to 10%. It runs *after* v1, so it catches both installs still carrying the old composite (v1 collapses `any_of`→20, then v2 → 10) and installs that already updated to a bare 20%. Post-collapse we can't distinguish a stale default from a deliberately-set 20% — so, matching the repo's other default-upgrade migrations, both move to 10%; a 20% set *after* the migration runs stays put. Rain jacket is untouched (old default 50% = new 50%).

## 2. High-chance overcast days went silent in the prose (prose commit)
With the per-model path removed, `peakPrecip` still bailed whenever the peak hour's blended code wasn't a precipitating type. In the high-POP-overcast case (e.g. 88% chance, overcast code, ~0 modeled accumulation) the umbrella rule and the strip fired from the probability, but the prose and evening tie-in disappeared — the single-number promise half-kept.

**Fix:** once the blended chance clears 10%, coerce a non-precip code to `RAIN` so the prose and evening tie-in agree with the umbrella and strip. Snow (and drizzle/rain/thunderstorm) keep their own condition, so snow still reads as snow and never triggers rain gear.

## Review notes
Codex and Copilot both flagged the migration on the first push. The original approach (detect the exact old-default `any_of` composite during DTO decode) only reached not-yet-migrated installs and drew a complexity flag; the v2 migration above subsumes it, so that detection (and the `isOldRainGearDefault` helper) was dropped entirely. Both review threads resolved.

## Privacy
No change to what crosses the device boundary. Fix 2 only ever synthesizes generic "chance of rain" / "rain" wording from a probability number; no new data leaves the device.

## Test plan
- `:core:domain:test` + `:core:data:test` — green. Updated the three `RenderInsightSummaryTest` cases that encoded the old "suppress on dry code" behavior to expect the coerced rain clause (peak hour, noon fallback, calendar tie-in).
- `:app:testDebugUnitTest` — green, **no snapshot changes**. Added v2-migration tests: bumps a bare 20% umbrella to 10%, leaves a customized 25% byte-identical, runs once via its sentinel, and an end-to-end v1→v2 check on a legacy composite.
- `:app:assembleDebug` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)