### PR TITLE
Change forecast playback notification to Preparing your ClothesCast

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1125,7 +1125,7 @@
 
     <string name="notification_channel_playback_name">Speaking the forecast</string>
     <string name="notification_channel_playback_description">Shown briefly while ClothesCast reads your scheduled forecast aloud. Required by Android so the audio can play from the background.</string>
-    <string name="notification_playback_title">Reading your forecast aloud…</string>
+    <string name="notification_playback_title">Preparing your ClothesCast</string>
 
 
     <string name="settings_notification_permission_title">Notifications are blocked</string>


### PR DESCRIPTION
## What

Changes the ongoing playback foreground-service notification title from "Reading your forecast aloud…" to "Preparing your ClothesCast" (no trailing ellipsis, so it fits on one line).

## Why

The notification shows while the scheduled briefing is being prepared/spoken; "Preparing your ClothesCast" reads more naturally and uses the app's name.

## Scope

- `app/src/main/res/values/strings.xml` — `notification_playback_title` only. No localized `values-*` override exists for this string, so the base copy is the only one to change.

## Privacy

No change to anything that crosses the device boundary.

## Test plan

String-only change; covered by the existing `:app` build/tests in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)