### PR TITLE
Translate the forecast playback notification into all languages

### DIFF
--- a/app/src/main/res/values-am/strings.xml
+++ b/app/src/main/res/values-am/strings.xml
@@ -362,6 +362,7 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="notification_channel_tonight_insight_silent_name">ምሽታዊ ClothesCast (ዝምታ)</string>
     <string name="notification_channel_tonight_insight_silent_description">ምሽቱ ጸጥ ሲሆን የምሽቱ የአየር ሁኔታ ማጠቃለያ። ዝምታ ሆኖ ይለጠፋል።</string>
     <string name="notification_tonight_insight_title">የዛሬ ምሽት ClothesCast</string>
+    <string name="notification_playback_title">ClothesCastዎን በማዘጋጀት ላይ</string>
 
     <!-- Insight prose -->
     <string name="insight_lead_today">ዛሬ</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -421,6 +421,7 @@ they work correctly in both the single-band and range templates.
     <string name="notification_channel_tonight_insight_silent_name">ClothesCast الليلي (صامت)</string>
     <string name="notification_channel_tonight_insight_silent_description">ملخص الطقس المسائي في المساء الهادئ. يُرسَل صامتًا.</string>
     <string name="notification_tonight_insight_title">ClothesCast الليلة</string>
+    <string name="notification_playback_title">جارٍ تحضير ClothesCast</string>
 
     <!-- Settings — notification permission -->
     <string name="settings_notification_permission_title">الإشعارات محظورة</string>

--- a/app/src/main/res/values-b+sr+Cyrl/strings.xml
+++ b/app/src/main/res/values-b+sr+Cyrl/strings.xml
@@ -371,6 +371,7 @@ surfaces.
     <string name="notification_channel_tonight_insight_silent_name">Ноћни ClothesCast (тихи)</string>
     <string name="notification_channel_tonight_insight_silent_description">Вечерњи временски резиме када ти је вечер слободна. Шаље се тихо — можеш да га погледаш на закључаном екрану, али неће репродуковати звук.</string>
     <string name="notification_tonight_insight_title">Вечерашњи ClothesCast</string>
+    <string name="notification_playback_title">Припрема твог ClothesCastа</string>
 
 
     <!-- Notification-permission card. -->

--- a/app/src/main/res/values-b+sr+Latn/strings.xml
+++ b/app/src/main/res/values-b+sr+Latn/strings.xml
@@ -383,6 +383,7 @@ default English (matching values-pl / values-uk).
     <string name="notification_channel_tonight_insight_silent_name">Noćni ClothesCast (tihi)</string>
     <string name="notification_channel_tonight_insight_silent_description">Večernji vremenski rezime kada ti je večer slobodna. Šalje se tiho — možeš da ga pogledaš na zaključanom ekranu, ali neće reprodukovati zvuk.</string>
     <string name="notification_tonight_insight_title">Večerašnji ClothesCast</string>
+    <string name="notification_playback_title">Priprema tvog ClothesCasta</string>
 
 
     <!-- Notification-permission card. -->

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -552,6 +552,7 @@ What is NOT overridden, by design:
     <string name="notification_channel_tonight_insight_silent_name">Нощен ClothesCast (тих)</string>
     <string name="notification_channel_tonight_insight_silent_description">Вечерното резюме на времето, когато вечерта е спокойна. Публикува се тихо — можеш да го видиш на заключения екран, но няма да издаде звук.</string>
     <string name="notification_tonight_insight_title">Нощният ClothesCast</string>
+    <string name="notification_playback_title">Подготвя твоя ClothesCast</string>
 
     <!-- Notification permission card. -->
     <string name="settings_notification_permission_title">Известията са блокирани</string>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -633,6 +633,7 @@ West Bengal vocabulary differences in a future PR.
     <string name="notification_channel_tonight_insight_silent_name">রাতের ClothesCast (নীরব)</string>
     <string name="notification_channel_tonight_insight_silent_description">সন্ধ্যা ফাঁকা থাকলে সন্ধ্যার আবহাওয়ার সারসংক্ষেপ। নীরবে পোস্ট হয় — লক স্ক্রিনে দেখতে পাবেন, কিন্তু কোনো শব্দ করবে না।</string>
     <string name="notification_tonight_insight_title">আজ রাতের ClothesCast</string>
+    <string name="notification_playback_title">আপনার ClothesCast প্রস্তুত করা হচ্ছে</string>
 
     <!-- ============================================================
          Error / incompatible device

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -453,6 +453,7 @@ the in-app clock is digit-driven and reads consistently across locales.
     <string name="notification_channel_tonight_insight_silent_name">ClothesCast nocturn (silenciós)</string>
     <string name="notification_channel_tonight_insight_silent_description">El resum meteorològic del vespre quan el teu vespre és lliure. S\'envia silenciosament — pots veure\'l a la pantalla de bloqueig, però no fa cap so.</string>
     <string name="notification_tonight_insight_title">El temps d\'aquesta nit</string>
+    <string name="notification_playback_title">Preparant el teu ClothesCast</string>
 
 
     <string name="settings_notification_permission_title">Les notificacions estan bloquejades</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -310,6 +310,7 @@ locale (Angličtina (USA), Francouzština (Francie), Němčina (Německo), …).
     <string name="notification_channel_tonight_insight_silent_name">Noční ClothesCast (tichý)</string>
     <string name="notification_channel_tonight_insight_silent_description">Večerní shrnutí počasí v klidné večery. Doručí se tiše — uvidíš ho na zamykací obrazovce, ale nevydá žádný zvuk.</string>
     <string name="notification_tonight_insight_title">Dnešní večerní počasí</string>
+    <string name="notification_playback_title">Připravuji tvůj ClothesCast</string>
 
 
     <!-- Notification permission card. -->

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -311,6 +311,7 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrig)").
     <string name="notification_channel_tonight_insight_silent_name">Aftenens ClothesCast (stille)</string>
     <string name="notification_channel_tonight_insight_silent_description">Den aftenvise vejropsummering på rolige aftener. Leveres lydløst — du kan se den på låseskærmen, men den laver ingen lyd.</string>
     <string name="notification_tonight_insight_title">Vejret i aften</string>
+    <string name="notification_playback_title">Forbereder dit ClothesCast</string>
 
 
     <!-- Notification permission card. -->

--- a/app/src/main/res/values-de-rAT/strings.xml
+++ b/app/src/main/res/values-de-rAT/strings.xml
@@ -290,6 +290,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="notification_channel_tonight_insight_silent_name">Nächtlicher ClothesCast (lautlos)</string>
     <string name="notification_channel_tonight_insight_silent_description">Die abendliche Wetterzusammenfassung an freien Abenden. Wird lautlos zugestellt — du kannst sie auf dem Sperrbildschirm sehen, sie macht aber keinen Ton.</string>
     <string name="notification_tonight_insight_title">Wetter heute Abend</string>
+    <string name="notification_playback_title">Bereite deinen ClothesCast vor</string>
 
 
     <!-- Notification-permission card (Settings → top of any screen if

--- a/app/src/main/res/values-de-rCH/strings.xml
+++ b/app/src/main/res/values-de-rCH/strings.xml
@@ -295,6 +295,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="notification_channel_tonight_insight_silent_name">Nächtlicher ClothesCast (lautlos)</string>
     <string name="notification_channel_tonight_insight_silent_description">Die abendliche Wetterzusammenfassung an freien Abenden. Wird lautlos zugestellt — du kannst sie auf dem Sperrbildschirm sehen, sie macht aber keinen Ton.</string>
     <string name="notification_tonight_insight_title">Wetter heute Abend</string>
+    <string name="notification_playback_title">Bereite deinen ClothesCast vor</string>
 
 
     <!-- Notification-permission card (Settings → top of any screen if

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -292,6 +292,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="notification_channel_tonight_insight_silent_name">Nächtlicher ClothesCast (lautlos)</string>
     <string name="notification_channel_tonight_insight_silent_description">Die abendliche Wetterzusammenfassung an freien Abenden. Wird lautlos zugestellt — du kannst sie auf dem Sperrbildschirm sehen, sie macht aber keinen Ton.</string>
     <string name="notification_tonight_insight_title">Wetter heute Abend</string>
+    <string name="notification_playback_title">Bereite deinen ClothesCast vor</string>
 
 
     <!-- Notification-permission card (Settings → top of any screen if

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -330,6 +330,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="notification_channel_tonight_insight_silent_name">Νυχτερινός ClothesCast (σιωπηλός)</string>
     <string name="notification_channel_tonight_insight_silent_description">Η βραδινή σύνοψη καιρού όταν το βράδυ σου είναι ελεύθερο. Παραδίδεται σιωπηλά — μπορείς να τη δεις στην οθόνη κλειδώματος, αλλά δεν παράγει ήχο.</string>
     <string name="notification_tonight_insight_title">Καιρός απόψε</string>
+    <string name="notification_playback_title">Ετοιμάζεται ο ClothesCast σου</string>
 
 
     <!-- Notification-permission card. -->

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -293,6 +293,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="notification_channel_tonight_insight_silent_name">ClothesCast nocturno (silencioso)</string>
     <string name="notification_channel_tonight_insight_silent_description">El resumen del tiempo de la tarde cuando tu noche está libre. Se entrega en silencio — puedes echarle un vistazo en la pantalla de bloqueo, pero no emite ningún sonido.</string>
     <string name="notification_tonight_insight_title">El tiempo de esta noche</string>
+    <string name="notification_playback_title">Preparando tu ClothesCast</string>
 
 
     <!-- Notification-permission card. -->

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -459,6 +459,7 @@ Tone is informal "sina"-form throughout ("Pane … selga", "Võta … kaasa",
     <string name="notification_channel_tonight_insight_silent_name">Õhtune ClothesCast (vaikne)</string>
     <string name="notification_channel_tonight_insight_silent_description">Õhtune ilmakokkuvõte, kui õhtu on vaba. Postitatakse vaikselt — saad sellele lukustusekraanilt pilgu heita, kuid heli ei esita.</string>
     <string name="notification_tonight_insight_title">Tänase õhtu ClothesCast</string>
+    <string name="notification_playback_title">Valmistab sinu ClothesCast\'i ette</string>
 
 
     <string name="settings_notification_permission_title">Teavitused on blokeeritud</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -410,6 +410,7 @@ Western Arabic numerals (0-9) are used for TTS compatibility.
     <string name="notification_channel_tonight_insight_silent_name">ClothesCast شبانه (ساکت)</string>
     <string name="notification_channel_tonight_insight_silent_description">خلاصه آب‌وهوای عصرگاهی وقتی عصر شما خالی است. ساکت ارسال می‌شود.</string>
     <string name="notification_tonight_insight_title">ClothesCast امشب</string>
+    <string name="notification_playback_title">در حال آماده‌سازی ClothesCast شما</string>
 
     <!-- Settings — notification permission -->
     <string name="settings_notification_permission_title">اعلان‌ها مسدود شده‌اند</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -237,6 +237,7 @@ displayed label localizes.
     <string name="notification_channel_tonight_insight_silent_name">Iltainen ClothesCast (hiljainen)</string>
     <string name="notification_channel_tonight_insight_silent_description">Iltainen säätiivis hiljaisina iltoina. Toimitetaan äänettömästi — näet sen lukitusnäytöllä, mutta se ei soi.</string>
     <string name="notification_tonight_insight_title">Tämän illan sää</string>
+    <string name="notification_playback_title">Valmistellaan ClothesCastiasi</string>
 
 
     <string name="settings_notification_permission_title">Ilmoitukset on estetty</string>

--- a/app/src/main/res/values-fil/strings.xml
+++ b/app/src/main/res/values-fil/strings.xml
@@ -571,6 +571,7 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="notification_channel_tonight_insight_silent_name">Pang-gabing ClothesCast (tahimik)</string>
     <string name="notification_channel_tonight_insight_silent_description">Ang gabi na buod ng panahon kapag walang laman ang iyong gabi. Nipo-post nang tahimik — maaari mo itong tingnan sa lock screen, ngunit hindi ito magpapatugtog ng tunog.</string>
     <string name="notification_tonight_insight_title">ClothesCast ngayong gabi</string>
+    <string name="notification_playback_title">Inihahanda ang iyong ClothesCast</string>
 
 
     <string name="settings_notification_permission_title">Naka-block ang mga notipikasyon</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -295,6 +295,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="notification_channel_tonight_insight_silent_name">ClothesCast nocturne (silencieux)</string>
     <string name="notification_channel_tonight_insight_silent_description">Le résumé météo du soir quand ta soirée est libre. Envoyé en silence — tu peux y jeter un œil sur l\'écran de verrouillage, mais aucun son ne sera émis.</string>
     <string name="notification_tonight_insight_title">Météo de ce soir</string>
+    <string name="notification_playback_title">Préparation de ton ClothesCast</string>
 
 
     <!-- Notification-permission card. -->

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -280,6 +280,7 @@ Not overridden by design:
     <string name="notification_channel_tonight_insight_silent_name">रात्रि ClothesCast (मौन)</string>
     <string name="notification_channel_tonight_insight_silent_description">जब आपकी शाम खाली हो तब की मौसम सारांश। चुपचाप भेजी जाती है — लॉक स्क्रीन पर देख सकते हैं, लेकिन आवाज़ नहीं होगी।</string>
     <string name="notification_tonight_insight_title">आज रात का ClothesCast</string>
+    <string name="notification_playback_title">आपका ClothesCast तैयार हो रहा है</string>
 
 
     <!-- Notification permission card. -->

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -266,6 +266,7 @@ spousal register), matching the existing insight prose ("Ponesi …",
     <string name="notification_channel_tonight_insight_silent_name">Noćni ClothesCast (tihi)</string>
     <string name="notification_channel_tonight_insight_silent_description">Večernji vremenski sažetak kad ti je večer slobodna. Šalje se tiho — možeš ga pogledati na zaključanom zaslonu, ali neće proizvesti zvuk.</string>
     <string name="notification_tonight_insight_title">Vrijeme večeras</string>
+    <string name="notification_playback_title">Pripremam tvoj ClothesCast</string>
 
 
     <!-- Notification-permission card. -->

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -312,6 +312,7 @@ locale (Angol (Egyesült Államok), Francia (Franciaország), Német
     <string name="notification_channel_tonight_insight_silent_name">Esti ClothesCast (néma)</string>
     <string name="notification_channel_tonight_insight_silent_description">Az esti időjárás-összefoglaló csendes estéken. Némán érkezik — láthatod a zárolási képernyőn, de nem ad hangot.</string>
     <string name="notification_tonight_insight_title">Mai esti időjárás</string>
+    <string name="notification_playback_title">A ClothesCastod készül</string>
 
 
     <!-- Notification permission card. -->

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -537,6 +537,7 @@ to values/strings.xml (English).
     <string name="notification_channel_tonight_insight_silent_name">ClothesCast Malam (senyap)</string>
     <string name="notification_channel_tonight_insight_silent_description">Ringkasan cuaca malam saat malam Anda kosong. Diposting secara senyap — Anda dapat melihatnya di layar kunci, tetapi tidak akan mengeluarkan suara.</string>
     <string name="notification_tonight_insight_title">ClothesCast malam ini</string>
+    <string name="notification_playback_title">Menyiapkan ClothesCast Anda</string>
 
     <!-- Notification permission settings -->
     <string name="settings_notification_permission_title">Notifikasi diblokir</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -285,6 +285,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="notification_channel_tonight_insight_silent_name">ClothesCast serale (silenzioso)</string>
     <string name="notification_channel_tonight_insight_silent_description">Il riepilogo meteo serale quando la serata è libera. Inviato in silenzio — puoi dargli un\'occhiata sulla schermata di blocco, ma non emette suoni.</string>
     <string name="notification_tonight_insight_title">Meteo di stasera</string>
+    <string name="notification_playback_title">Preparazione del tuo ClothesCast</string>
 
 
     <!-- Notification-permission card. -->

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -416,6 +416,7 @@ standard in Israeli digital communication.
     <string name="notification_channel_tonight_insight_silent_name">ClothesCast לילי (שקט)</string>
     <string name="notification_channel_tonight_insight_silent_description">סיכום מזג האוויר הערבי כשהערב שלך ריק. נשלח בשקט.</string>
     <string name="notification_tonight_insight_title">ClothesCast ללילה</string>
+    <string name="notification_playback_title">מכין/ה את ClothesCast שלך</string>
 
     <!-- Settings — notification permission -->
     <string name="settings_notification_permission_title">התראות חסומות</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -292,6 +292,7 @@ the displayed label localizes.
     <string name="notification_channel_tonight_insight_silent_name">夜間の ClothesCast（無音）</string>
     <string name="notification_channel_tonight_insight_silent_description">予定のない夜の天気要約です。無音で配信され、ロック画面で確認できますが、音は鳴りません。</string>
     <string name="notification_tonight_insight_title">今夜の天気</string>
+    <string name="notification_playback_title">ClothesCast を準備中…</string>
 
 
     <!-- Notification-permission card. -->

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -305,6 +305,7 @@ displayed label localizes.
     <string name="notification_channel_tonight_insight_silent_name">야간 ClothesCast (무음)</string>
     <string name="notification_channel_tonight_insight_silent_description">일정이 없는 저녁의 날씨 요약입니다. 무음으로 전송되며 잠금 화면에서 확인할 수 있지만 소리는 나지 않아요.</string>
     <string name="notification_tonight_insight_title">오늘 밤 날씨</string>
+    <string name="notification_playback_title">ClothesCast 준비 중…</string>
 
 
     <!-- Notification-permission card. -->

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -550,6 +550,7 @@ What is NOT overridden, by design:
     <string name="notification_channel_tonight_insight_silent_name">Nakties ClothesCast (tylus)</string>
     <string name="notification_channel_tonight_insight_silent_description">Vakaro orų santrauka ramiais vakarais. Pateikiama tyliai — gali matyti užrakto ekrane, bet nekeliks garso.</string>
     <string name="notification_tonight_insight_title">Šiandien vakaro ClothesCast</string>
+    <string name="notification_playback_title">Ruošiamas tavo ClothesCast</string>
 
     <!-- Notification permission card. -->
     <string name="settings_notification_permission_title">Pranešimai užblokuoti</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -510,6 +510,7 @@ informal "tu"-form throughout ("Apģērb …", "Paņem … līdzi").
     <string name="notification_channel_tonight_insight_silent_name">Nakts ClothesCast (klusais)</string>
     <string name="notification_channel_tonight_insight_silent_description">Vakara laika apkopojums, ja vakars ir brīvs. Publicēts klusumā — vari to apskatīt bloķēšanas ekrānā, taču tas neskanēs.</string>
     <string name="notification_tonight_insight_title">Šovakarējais ClothesCast</string>
+    <string name="notification_playback_title">Sagatavo tavu ClothesCast</string>
 
     <!-- Notification permission settings -->
     <string name="settings_notification_permission_title">Paziņojumi ir bloķēti</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -535,6 +535,7 @@ vs "kemungkinan", "padam" vs "hapus").
     <string name="notification_channel_tonight_insight_silent_name">ClothesCast Malam (senyap)</string>
     <string name="notification_channel_tonight_insight_silent_description">Ringkasan cuaca petang apabila petang anda kosong. Dihantar secara senyap — anda boleh melihatnya pada skrin kunci, tetapi tidak akan berbunyi.</string>
     <string name="notification_tonight_insight_title">ClothesCast Malam Ini</string>
+    <string name="notification_playback_title">Menyediakan ClothesCast anda</string>
 
     <!-- Notification permission prompt in settings -->
     <string name="settings_notification_permission_title">Pemberitahuan disekat</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -311,6 +311,7 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrike)").
     <string name="notification_channel_tonight_insight_silent_name">Kveldens ClothesCast (stille)</string>
     <string name="notification_channel_tonight_insight_silent_description">Den kveldslige væroppsummeringen på rolige kvelder. Leveres lydløst — du kan se den på låseskjermen, men den lager ingen lyd.</string>
     <string name="notification_tonight_insight_title">Været i kveld</string>
+    <string name="notification_playback_title">Gjør klar ClothesCast-en din</string>
 
 
     <!-- Notification permission card. -->

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -266,6 +266,7 @@ the displayed label localizes.
     <string name="notification_channel_tonight_insight_silent_name">Avondlijkse ClothesCast (stil)</string>
     <string name="notification_channel_tonight_insight_silent_description">De avondlijkse weersamenvatting op vrije avonden. Stil bezorgd — je kunt hem op het vergrendelscherm zien, maar hij maakt geen geluid.</string>
     <string name="notification_tonight_insight_title">Weer vanavond</string>
+    <string name="notification_playback_title">Je ClothesCast wordt voorbereid</string>
 
 
     <!-- Notification-permission card. -->

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -266,6 +266,7 @@ is unchanged; only the displayed label localizes.
     <string name="notification_channel_tonight_insight_silent_name">Wieczorny ClothesCast (cichy)</string>
     <string name="notification_channel_tonight_insight_silent_description">Wieczorne podsumowanie pogody w spokojne wieczory. Dostarczane bezgłośnie — możesz je zobaczyć na ekranie blokady, ale nie wydaje dźwięku.</string>
     <string name="notification_tonight_insight_title">Pogoda wieczorem</string>
+    <string name="notification_playback_title">Przygotowuję Twój ClothesCast</string>
 
 
     <!-- Notification-permission card. -->

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -296,6 +296,7 @@ zh-CN) is unchanged; only the displayed label localizes.
     <string name="notification_channel_tonight_insight_silent_name">ClothesCast noturno (silencioso)</string>
     <string name="notification_channel_tonight_insight_silent_description">O resumo do tempo da noite quando sua noite está livre. Enviado em silêncio — você pode dar uma olhada na tela de bloqueio, mas ele não emite som.</string>
     <string name="notification_tonight_insight_title">Tempo desta noite</string>
+    <string name="notification_playback_title">Preparando seu ClothesCast</string>
 
 
     <!-- Notification-permission card. -->

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -310,6 +310,7 @@ they diverge from BR ("Polonês" → "Polaco", "Holandês" →
     <string name="notification_channel_tonight_insight_silent_name">ClothesCast noturno (silencioso)</string>
     <string name="notification_channel_tonight_insight_silent_description">O resumo do tempo da noite quando a tua noite está livre. Entregue em silêncio — podes vê-lo no ecrã de bloqueio, mas não emite som.</string>
     <string name="notification_tonight_insight_title">Tempo desta noite</string>
+    <string name="notification_playback_title">A preparar o teu ClothesCast</string>
 
 
     <!-- Notification-permission card. -->

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -541,6 +541,7 @@ surfaces fall back to default English (matching values-pl / values-uk).
     <string name="notification_channel_tonight_insight_silent_name">ClothesCast nocturn (silențios)</string>
     <string name="notification_channel_tonight_insight_silent_description">Rezumatul meteo de seară când seara este liberă. Postat silențios — îl poți vedea pe ecranul de blocare, dar nu va emite niciun sunet.</string>
     <string name="notification_tonight_insight_title">ClothesCast-ul de diseară</string>
+    <string name="notification_playback_title">Se pregătește ClothesCast-ul tău</string>
 
     <!-- Notification permission card. -->
     <string name="settings_notification_permission_title">Notificările sunt blocate</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -358,6 +358,7 @@ only the displayed label localizes.
     <string name="notification_channel_tonight_insight_silent_name">Вечерний ClothesCast (тихий)</string>
     <string name="notification_channel_tonight_insight_silent_description">Вечерняя сводка погоды, когда у тебя свободный вечер. Доставляется бесшумно — можешь увидеть на экране блокировки, но звук не издаётся.</string>
     <string name="notification_tonight_insight_title">Погода сегодня вечером</string>
+    <string name="notification_playback_title">Готовлю твой ClothesCast</string>
 
 
     <!-- Notification-permission card. -->

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -319,6 +319,7 @@ What is NOT overridden, by design:
     <string name="notification_channel_tonight_insight_silent_name">Nočný ClothesCast (tichý)</string>
     <string name="notification_channel_tonight_insight_silent_description">Večerné zhrnutie počasia v pokojné večery. Doručí sa ticho — uvidíš ho na zamykacej obrazovke, ale nevydá žiadny zvuk.</string>
     <string name="notification_tonight_insight_title">Dnešné večerné počasie</string>
+    <string name="notification_playback_title">Pripravujem tvoj ClothesCast</string>
 
 
     <!-- Notification-permission card. -->

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -550,6 +550,7 @@ informal "ti"-form throughout, mirroring the Croatian / Serbian pass.
     <string name="notification_channel_tonight_insight_silent_name">Nočni ClothesCast (tiho)</string>
     <string name="notification_channel_tonight_insight_silent_description">Večerni vremenski povzetek, ko je tvoj večer prost. Objavljeno tiho — na zaklenjenem zaslonu si ga lahko ogledaš, a ne bo proizvajal zvoka.</string>
     <string name="notification_tonight_insight_title">Nocojšnji ClothesCast</string>
+    <string name="notification_playback_title">Pripravljam tvoj ClothesCast</string>
 
     <!-- Notification permission card. -->
     <string name="settings_notification_permission_title">Obvestila so blokirana</string>

--- a/app/src/main/res/values-sq/strings.xml
+++ b/app/src/main/res/values-sq/strings.xml
@@ -755,6 +755,7 @@
     <string name="notification_channel_tonight_insight_silent_name">ClothesCast-i i mbrëmjes (në heshtje)</string>
     <string name="notification_channel_tonight_insight_silent_description">Përmbledhja e motit në mbrëmje kur mbrëmja jote është bosh. Postohet në heshtje — mund ta shohësh në ekranin e kyçur, por nuk do të bëjë zhurmë.</string>
     <string name="notification_tonight_insight_title">ClothesCast-i i sontëm</string>
+    <string name="notification_playback_title">Po përgatitet ClothesCast-i yt</string>
     <string name="settings_notification_permission_title">Njoftimet janë të bllokuara</string>
     <string name="settings_notification_permission_description">Pa lejen e njoftimeve, ClothesCast-i yt ditor s\'ka ku të shkojë. Jepe që ClothesCast të mund ta dërgojë nesër në mëngjes.</string>
     <string name="settings_notification_permission_grant">Jep lejen e njoftimeve</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -311,6 +311,7 @@ native names for all locales (e.g. "Tyska (Tyskland)", "Franska (Frankrike)").
     <string name="notification_channel_tonight_insight_silent_name">Kvällens ClothesCast (tyst)</string>
     <string name="notification_channel_tonight_insight_silent_description">Den kvällsvisa vädersammanfattningen på lediga kvällar. Levereras tyst — du kan se den på låsskärmen men den gör inget ljud.</string>
     <string name="notification_tonight_insight_title">Vädret ikväll</string>
+    <string name="notification_playback_title">Förbereder ditt ClothesCast</string>
 
 
     <!-- Notification permission card. -->

--- a/app/src/main/res/values-sw/strings.xml
+++ b/app/src/main/res/values-sw/strings.xml
@@ -376,6 +376,7 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="notification_channel_tonight_insight_silent_name">ClothesCast ya usiku (kimya)</string>
     <string name="notification_channel_tonight_insight_silent_description">Muhtasari wa hali ya hewa ya jioni jioni yako ikiwa tulivu. Imetumwa kimya.</string>
     <string name="notification_tonight_insight_title">ClothesCast ya Usiku Huu</string>
+    <string name="notification_playback_title">Inaandaa ClothesCast yako</string>
 
     <!-- Settings: notifications permission -->
     <string name="settings_notification_permission_title">Arifa zimezuiwa</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -535,6 +535,7 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="notification_channel_tonight_insight_silent_name">ClothesCast รายคืน (เงียบ)</string>
     <string name="notification_channel_tonight_insight_silent_description">สรุปสภาพอากาศตอนเย็นเมื่อตอนเย็นว่าง โพสต์แบบเงียบ — สามารถดูบนหน้าจอล็อก แต่จะไม่ส่งเสียง</string>
     <string name="notification_tonight_insight_title">ClothesCast คืนนี้</string>
+    <string name="notification_playback_title">กำลังเตรียม ClothesCast ของคุณ</string>
 
     <!-- Notification permission settings -->
     <string name="settings_notification_permission_title">การแจ้งเตือนถูกบล็อก</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -237,6 +237,7 @@ displayed label localizes.
     <string name="notification_channel_tonight_insight_silent_name">Gecelik ClothesCast (sessiz)</string>
     <string name="notification_channel_tonight_insight_silent_description">Sakin akşamlarda gelen akşam hava durumu özeti. Sessiz teslim edilir — kilit ekranında görebilirsiniz ama ses çıkarmaz.</string>
     <string name="notification_tonight_insight_title">Bu akşamın hava durumu</string>
+    <string name="notification_playback_title">ClothesCast\'ın hazırlanıyor</string>
 
 
     <string name="settings_notification_permission_title">Bildirimler engellendi</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -314,6 +314,7 @@ only the displayed label localizes.
     <string name="notification_channel_tonight_insight_silent_name">Вечірній ClothesCast (беззвучний)</string>
     <string name="notification_channel_tonight_insight_silent_description">Вечірнє зведення погоди, коли у вас вільний вечір. Доставляється беззвучно — можна побачити на екрані блокування, але звук не лунає.</string>
     <string name="notification_tonight_insight_title">Погода сьогодні ввечері</string>
+    <string name="notification_playback_title">Готуємо ваш ClothesCast</string>
 
 
     <!-- Notification-permission card. -->

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -581,6 +581,7 @@ Skipped intentionally: app_name (brand), insight_time_am/pm/midnight/noon
     <string name="notification_channel_tonight_insight_silent_name">ClothesCast buổi tối (im lặng)</string>
     <string name="notification_channel_tonight_insight_silent_description">Tóm tắt thời tiết buổi tối khi buổi tối của bạn trống. Đăng im lặng — bạn có thể xem trên màn hình khóa nhưng sẽ không phát âm thanh.</string>
     <string name="notification_tonight_insight_title">ClothesCast tối nay</string>
+    <string name="notification_playback_title">Đang chuẩn bị ClothesCast của bạn</string>
 
 
     <!-- Notification permission -->

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -287,6 +287,7 @@ label localizes.
     <string name="notification_channel_tonight_insight_silent_name">夜间 ClothesCast（静音）</string>
     <string name="notification_channel_tonight_insight_silent_description">晚上没有日程时的晚间天气摘要。静默发送 — 你可以在锁屏上看到，但不会发出声音。</string>
     <string name="notification_tonight_insight_title">今晚的天气</string>
+    <string name="notification_playback_title">正在准备你的 ClothesCast</string>
 
 
     <!-- Notification-permission card. -->

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -277,6 +277,7 @@ label localises.
     <string name="notification_channel_tonight_insight_silent_name">夜間 ClothesCast（靜音）</string>
     <string name="notification_channel_tonight_insight_silent_description">晚上沒有行程時的晚間天氣摘要。靜音傳送 — 你可以在鎖定畫面上看到，但不會發出聲音。</string>
     <string name="notification_tonight_insight_title">今晚的天氣</string>
+    <string name="notification_playback_title">正在準備你的 ClothesCast</string>
 
 
     <!-- Notification-permission card. -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1123,6 +1123,10 @@
     <string name="notification_channel_tonight_insight_silent_description">The evening weather summary when your evening is empty. Posted silently — you can glance at it on the lock screen, but it won\'t make a sound.</string>
     <string name="notification_tonight_insight_title">Tonight\'s ClothesCast</string>
 
+    <!-- TODO(i18n): translate notification_channel_playback_name and
+         notification_channel_playback_description once the channel's exact
+         semantics are settled. Only notification_playback_title (the
+         user-visible foreground-service title) is localized for now. -->
     <string name="notification_channel_playback_name">Speaking the forecast</string>
     <string name="notification_channel_playback_description">Shown briefly while ClothesCast reads your scheduled forecast aloud. Required by Android so the audio can play from the background.</string>
     <string name="notification_playback_title">Preparing your ClothesCast</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1125,7 +1125,7 @@
 
     <string name="notification_channel_playback_name">Speaking the forecast</string>
     <string name="notification_channel_playback_description">Shown briefly while ClothesCast reads your scheduled forecast aloud. Required by Android so the audio can play from the background.</string>
-    <string name="notification_playback_title">Reading your forecast aloud…</string>
+    <string name="notification_playback_title">Preparing your ClothesCast</string>
 
 
     <string name="settings_notification_permission_title">Notifications are blocked</string>


### PR DESCRIPTION
## What

Adds the `notification_playback_title` string ("Preparing your ClothesCast") — the ongoing foreground-service notification shown while a scheduled briefing is prepared/spoken — to the **48 locales** that already carry the other notification strings. Inserted immediately after `notification_tonight_insight_title` in each file.

## Scope / decisions

- **Title only for now.** The playback channel name (`notification_channel_playback_name`) and description (`notification_channel_playback_description`) are deliberately left in English, with a `TODO(i18n)` in base `values/strings.xml`, until the channel's exact semantics are settled. Only the user-visible title is localized in this PR.
- **Brand stays verbatim.** "ClothesCast" is never translated or transliterated; each translation matches its own file's documented formality / possessive conventions (informal `du`/`tu`/`ty` where the file uses it, formal `Anda`/`आपका` where it doesn't), mirroring how that file already renders "your ClothesCast" in `today_working` and the notification block.
- **6 regional-override locales need no entry.** `en-rAU/rCA/rGB/rZA`, `es-rMX`, and `fr-rCA` only carry region-specific overrides and inherit their parent language, matching the existing coverage of the other 8 notification strings.

## Validation

- All 55 `strings.xml` files parse as well-formed XML; each target locale has exactly one new entry, no duplicates, no unescaped apostrophes/ampersands.
- `./gradlew :app:processDebugResources` passes (AAPT accepts the merged resources).

## Privacy

No change to anything that crosses the device boundary — these are static UI strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MwH23R9kKPCzDS1GshX9Uj)_