### PR TITLE
Log notification post, dismiss, and active-shade state

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -130,6 +130,14 @@
             </intent-filter>
         </receiver>
 
+        <!-- Internal — only the OS delivers via the notification delete
+             PendingIntent. Logs user dismissals of the insight notifications so a
+             forecast post that vanishes without a matching dismissal line points
+             at a non-user removal (e.g. foreground-service teardown). -->
+        <receiver
+            android:name=".notification.NotificationDismissReceiver"
+            android:exported="false" />
+
         <!-- System broadcasts that should re-arm the daily alarm. All four
              actions are protected system broadcasts, which the OS delivers
              to unexported receivers — exported="false" just keeps other

--- a/app/src/main/kotlin/app/clothescast/notification/InsightNotifier.kt
+++ b/app/src/main/kotlin/app/clothescast/notification/InsightNotifier.kt
@@ -10,6 +10,7 @@ import app.clothescast.MainActivity
 import app.clothescast.R
 import app.clothescast.core.domain.model.Insight
 import app.clothescast.core.domain.model.OutfitSuggestion
+import app.clothescast.diag.DiagLog
 import app.clothescast.ui.garment.renderTopWithHandsBitmap
 
 /**
@@ -69,13 +70,21 @@ class InsightNotifier(private val context: Context) {
             .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
             .setAutoCancel(true)
             .setContentIntent(pendingIntent)
+            .setDeleteIntent(
+                NotificationDismissReceiver.deleteIntent(context, NOTIFICATION_ID_DAILY_INSIGHT, "daily insight"),
+            )
             .setCategory(NotificationCompat.CATEGORY_REMINDER)
             .build()
 
         NotificationManagerCompat.from(context).notify(NOTIFICATION_ID_DAILY_INSIGHT, notification)
+        DiagLog.i(
+            TAG,
+            "Posted daily insight notification (id=$NOTIFICATION_ID_DAILY_INSIGHT, channel=$CHANNEL_DAILY_INSIGHT, importance=HIGH).",
+        )
     }
 
     companion object {
+        private const val TAG = "InsightNotifier"
         const val NOTIFICATION_ID_DAILY_INSIGHT = 1001
         private const val REQUEST_OPEN_APP = 100
 

--- a/app/src/main/kotlin/app/clothescast/notification/NotificationDismissReceiver.kt
+++ b/app/src/main/kotlin/app/clothescast/notification/NotificationDismissReceiver.kt
@@ -1,0 +1,57 @@
+package app.clothescast.notification
+
+import android.app.PendingIntent
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import app.clothescast.diag.DiagLog
+
+/**
+ * Logs when one of the app's insight notifications is cleared by the user
+ * (swipe-away or "clear all"). Wired via [androidx.core.app.NotificationCompat.Builder.setDeleteIntent]
+ * on the daily / tonight insight posts.
+ *
+ * A delete intent fires *only* on a user-initiated clear — not on a tap (that
+ * routes through the content intent + auto-cancel) and not when the app or the
+ * system cancels the notification programmatically (e.g. a foreground-service
+ * teardown removing its notification). So a forecast post that vanishes from the
+ * shade *without* a matching "dismissed" line here was removed by something other
+ * than the user. That distinction is exactly what the "notification disappears a
+ * second after posting" report needs: pair the absence of a dismissal line with
+ * the worker's active-notification snapshot to tell a user swipe from a teardown.
+ */
+class NotificationDismissReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        val id = intent.getIntExtra(EXTRA_NOTIFICATION_ID, -1)
+        val label = intent.getStringExtra(EXTRA_LABEL) ?: "insight"
+        DiagLog.i(TAG, "User dismissed the $label notification (id=$id).")
+    }
+
+    companion object {
+        private const val TAG = "NotificationDismiss"
+        private const val ACTION_DISMISSED = "app.clothescast.notification.DISMISSED"
+        private const val EXTRA_NOTIFICATION_ID = "notification_id"
+        private const val EXTRA_LABEL = "label"
+
+        /**
+         * Builds the delete-intent [PendingIntent] for a notification, carrying its
+         * id + a short [label] so the dismissal log names which post was cleared.
+         * [notificationId] doubles as the request code so daily (1001) and tonight
+         * (1003) get distinct PendingIntents rather than clobbering each other
+         * through FLAG_UPDATE_CURRENT.
+         */
+        fun deleteIntent(context: Context, notificationId: Int, label: String): PendingIntent {
+            val intent = Intent(context, NotificationDismissReceiver::class.java).apply {
+                action = ACTION_DISMISSED
+                putExtra(EXTRA_NOTIFICATION_ID, notificationId)
+                putExtra(EXTRA_LABEL, label)
+            }
+            return PendingIntent.getBroadcast(
+                context,
+                notificationId,
+                intent,
+                PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+            )
+        }
+    }
+}

--- a/app/src/main/kotlin/app/clothescast/notification/TonightInsightNotifier.kt
+++ b/app/src/main/kotlin/app/clothescast/notification/TonightInsightNotifier.kt
@@ -9,6 +9,7 @@ import app.clothescast.MainActivity
 import app.clothescast.R
 import app.clothescast.core.domain.model.Insight
 import app.clothescast.core.domain.model.OutfitSuggestion
+import app.clothescast.diag.DiagLog
 
 /**
  * Posts the tonight insight as a system notification. Picks one of two channels
@@ -73,6 +74,9 @@ class TonightInsightNotifier(private val context: Context) {
             .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
             .setAutoCancel(true)
             .setContentIntent(pendingIntent)
+            .setDeleteIntent(
+                NotificationDismissReceiver.deleteIntent(context, NOTIFICATION_ID_TONIGHT_INSIGHT, "tonight insight"),
+            )
             .setCategory(NotificationCompat.CATEGORY_REMINDER)
             .apply {
                 // Belt-and-braces: even if a downstream OEM ignores the silent
@@ -83,9 +87,14 @@ class TonightInsightNotifier(private val context: Context) {
             .build()
 
         NotificationManagerCompat.from(context).notify(NOTIFICATION_ID_TONIGHT_INSIGHT, notification)
+        DiagLog.i(
+            TAG,
+            "Posted tonight insight notification (id=$NOTIFICATION_ID_TONIGHT_INSIGHT, channel=$channel, hasEvents=${insight.hasEvents}).",
+        )
     }
 
     companion object {
+        private const val TAG = "TonightInsightNotifier"
         const val NOTIFICATION_ID_TONIGHT_INSIGHT = 1003
         private const val REQUEST_OPEN_APP = 102
     }

--- a/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
@@ -1,5 +1,6 @@
 package app.clothescast.work
 
+import android.app.NotificationManager
 import android.content.Context
 import android.content.pm.ServiceInfo
 import android.location.LocationManager
@@ -120,6 +121,11 @@ class FetchAndNotifyWorker(
         val skipTelemetry = isCacheOnly || isSilent || isPlay
         return try {
             val result = stamped(doWorkInternal())
+            // Last snapshot before this returns: WorkManager stops the playback
+            // foreground service right after doWork() completes, so anything the
+            // teardown clears is still present here. Comparing this against the
+            // "after delivery" line pins the disappearance to the teardown.
+            logActiveAppNotifications("at worker exit")
             if (!skipTelemetry) recordDailyRefreshOutcome(period, result, startMs)
             result
         } catch (ce: CancellationException) {
@@ -1356,6 +1362,8 @@ class FetchAndNotifyWorker(
                 if (t is CancellationException) throw t
                 DiagLog.w(TAG, "Failed to persist the MQTT publish status.", t)
             }
+
+            logActiveAppNotifications("after delivery")
         }
     }
 
@@ -1789,10 +1797,34 @@ class FetchAndNotifyWorker(
         }
         if (!mode.playsSpeech) return
         runCatching { setForeground(playbackForegroundInfo()) }
+            .onSuccess {
+                DiagLog.i(TAG, "Promoted to the playback foreground service (notification id=$PLAYBACK_NOTIFICATION_ID).")
+            }
             .onFailure { t ->
                 if (t is CancellationException) throw t
                 DiagLog.w(TAG, "Couldn't start the playback foreground service; speech may be inaudible from the background.", t)
             }
+    }
+
+    /**
+     * Logs the app's currently-posted notifications at [stage] so a bug report
+     * shows whether the forecast post (daily id 1001 / tonight id 1003) is still
+     * in the shade at that point or has already been cleared — and whether the
+     * playback foreground-service notification (id 1005) is still up alongside it.
+     *
+     * Pairs with the delete-intent log in [app.clothescast.notification.NotificationDismissReceiver]:
+     * a forecast id that's present at "after delivery" but gone by "at worker exit"
+     * with no dismissal line in between points at the foreground-service teardown
+     * clearing it rather than a user swipe. Only ids are logged — never the prose —
+     * so no insight content crosses into the diag file.
+     */
+    private fun logActiveAppNotifications(stage: String) {
+        val manager = applicationContext.getSystemService<NotificationManager>() ?: return
+        val active = runCatching { manager.activeNotifications }.getOrNull() ?: return
+        val ids = active.joinToString { sbn ->
+            "id=${sbn.id}" + (sbn.tag?.let { "/tag=$it" } ?: "")
+        }
+        DiagLog.i(TAG, "Active notifications $stage: [$ids] (count=${active.size}).")
     }
 
     /**


### PR DESCRIPTION
## Why

Diagnostic instrumentation for the "forecast notification disappears a second after posting" report (Pixel 10 Pro, Android 17). We confirmed the forecast post is gone from the shade entirely — not just the `IMPORTANCE_HIGH` heads-up banner retracting — so this PR adds the signals needed to pin down *what* removes it, before changing any behavior.

This is **logging only**. Notification appearance, priority, and the foreground-service / delivery flow are all unchanged.

## What it adds

Three signals, all routed through `DiagLog` so they land in the bug-report snapshot:

- **Post logs** in `InsightNotifier` / `TonightInsightNotifier` — id, channel, and importance/`hasEvents` at `notify()` time. No prose is logged, so no insight content crosses into the diag file.
- **`NotificationDismissReceiver`** wired via `setDeleteIntent` on both posts. A delete intent fires *only* on a user clear (swipe / "clear all") — not on a tap (content intent + auto-cancel) and not on a programmatic cancel. So a post that vanishes **without** a matching dismissal line was removed by something other than the user.
- **Active-notification snapshots** in `FetchAndNotifyWorker` at `"after delivery"` and `"at worker exit"`. WorkManager stops the playback foreground service right after `doWork()` returns, so a forecast id present at exit but gone afterward (with no dismissal line) points at the **foreground-service teardown** clearing it rather than a user swipe.

Also logs the foreground-service promotion *success*, not just its failure.

## How to read the next bug report

| Symptom in the log | Most likely cause |
| --- | --- |
| `User dismissed the daily insight notification` line present | User swipe / clear-all — expected |
| Forecast id in `after delivery` **and** `at worker exit`, then gone, **no** dismissal line | Foreground-service teardown removing it |
| Forecast id missing already at `at worker exit` | Something in the delivery flow cleared it |

## Privacy

No new data crosses the device boundary; only notification **ids / channel names** are logged — never the prose (which is the calendar-/TTS-bound content). Nothing here touches Firebase payloads.

## Test plan

- `./gradlew :app:testDebugUnitTest` — green
- `./gradlew :app:compileDebugKotlin` — green
- Manual confirmation deferred to a fresh bug report from the affected device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RDUSqSZCMWD8hRhmrQnCbR)_