### PR TITLE
Show 'Preparing your ClothesCast' when the schedule fires

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -49,6 +49,11 @@
          run is triggered by an exact alarm — an explicit FGS-start exemption). -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
+    <!-- ScheduledDeliveryService runs as a dataSync FGS during the fetch +
+         insight-generation window (and during deliver when the period doesn't
+         play speech). The mediaPlayback permission above covers the upgrade to
+         the speech window. See docs/schedule-lifecycle.md. -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
 
     <!-- Read today's calendar events to enrich the morning insight. Opt-in via the
          Settings toggle; runtime grant requested from there. We deliberately do NOT
@@ -129,6 +134,19 @@
                 <action android:name="app.clothescast.alarm.FIRE_TONIGHT" />
             </intent-filter>
         </receiver>
+
+        <!-- Owns the "Preparing your ClothesCast" / "Delivering your ClothesCast"
+             foreground-service notification across an alarm-triggered delivery.
+             Started from AlarmReceiver via startForegroundService inside the
+             exact-alarm FGS-from-background exemption window. dataSync covers
+             the fetch + insight phase (and the no-speech deliver phase);
+             mediaPlayback covers the phone-speech deliver phase so the speaker
+             can claim audio focus on Android 15+. See
+             docs/schedule-lifecycle.md. -->
+        <service
+            android:name=".alarm.ScheduledDeliveryService"
+            android:exported="false"
+            android:foregroundServiceType="dataSync|mediaPlayback" />
 
         <!-- Internal — only the OS delivers via the notification delete
              PendingIntent. Logs user dismissals of the insight notifications so a

--- a/app/src/main/kotlin/app/clothescast/ClothesCastApplication.kt
+++ b/app/src/main/kotlin/app/clothescast/ClothesCastApplication.kt
@@ -30,6 +30,7 @@ import app.clothescast.data.InsightCache
 import app.clothescast.data.SecureKeyStore
 import app.clothescast.data.SettingsRepository
 import app.clothescast.diag.DiagLog
+import app.clothescast.work.FetchAndNotifyWorker
 import app.clothescast.discovery.HomeAssistantDiscovery
 import app.clothescast.discovery.NsdHomeAssistantDiscovery
 import app.clothescast.diag.Telemetry
@@ -318,6 +319,7 @@ class ClothesCastApplication : Application() {
         // and DiagLog's wrapper above — no manual chaining needed here.
         Telemetry.start(this, settingsRepository, applicationScope)
         NotificationChannelRegistrar.register(this)
+        FetchAndNotifyWorker.cleanupLegacyQueues(this)
         // Register the Cast session-end listener so [CastMediaServer.stop]
         // fires whenever a cast session ends — user-initiated disconnect on
         // the receiver, network failure, route switch — and the LAN HTTP

--- a/app/src/main/kotlin/app/clothescast/alarm/AlarmReceiver.kt
+++ b/app/src/main/kotlin/app/clothescast/alarm/AlarmReceiver.kt
@@ -3,9 +3,14 @@ package app.clothescast.alarm
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import androidx.core.content.ContextCompat
 import app.clothescast.diag.DiagLog
 import app.clothescast.ClothesCastApplication
 import app.clothescast.core.domain.model.ForecastPeriod
+import app.clothescast.core.domain.model.UserPreferences
+import app.clothescast.core.domain.model.playsSpeech
+import app.clothescast.core.domain.model.postsNotification
+import app.clothescast.core.domain.usecase.isMqttPublishable
 import app.clothescast.work.FetchAndNotifyWorker
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -20,12 +25,20 @@ import kotlinx.coroutines.launch
  *  - [ACTION_FIRE]         — the morning ([ForecastPeriod.TODAY]) alarm
  *  - [ACTION_FIRE_TONIGHT] — the evening ([ForecastPeriod.TONIGHT]) alarm
  *
- * For each, the receiver:
- * 1. Enqueues a WorkManager OneTimeWorkRequest ([FetchAndNotifyWorker]) which actually
- *    does the fetch + insight + notification under network/retry constraints.
- * 2. Re-arms the same slot's alarm for the next day. Re-arming here (rather than only
- *    inside the Worker) keeps the alarm chain alive even if the Worker is permanently
- *    failing.
+ * The receiver reads preferences once and then routes:
+ *  1. Slot disabled → cancel the alarm, do nothing else.
+ *  2. SILENT delivery (no notification, no audio, no MQTT, no cast) →
+ *     enqueue the worker as a normal background refresh and re-arm. No
+ *     foreground service, no "Preparing" notification — the user opted out
+ *     of every visible surface and we honor that.
+ *  3. Otherwise → enqueue the worker, re-arm, and (best-effort) start
+ *     [ScheduledDeliveryService] so the user sees "Preparing your
+ *     ClothesCast" → "Delivering your ClothesCast" while the run happens.
+ *     If the Service start is refused, the worker's own
+ *     [FetchAndNotifyWorker.promoteToPlaybackServiceIfNeeded] covers the
+ *     speech window — worst case is the pre-Service behavior, never nothing.
+ *
+ * See docs/schedule-lifecycle.md for the full state machine.
  */
 class AlarmReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
@@ -72,12 +85,22 @@ class AlarmReceiver : BroadcastReceiver() {
                     scheduler.cancel(ForecastPeriod.TONIGHT)
                     return@launch
                 }
-                FetchAndNotifyWorker.enqueueOneShot(
+
+                val workId = FetchAndNotifyWorker.enqueueOneShot(
                     appCtx,
                     period = period,
                     alarmScheduledAtMs = scheduledAtMs,
                     alarmFiredAtMs = firedAtMs,
                 )
+
+                if (needsForegroundSurface(prefs, period)) {
+                    // Best-effort: if the platform refuses (background-restricted,
+                    // lapsed exemption window, OEM quirk), the worker still runs
+                    // and its own promoteToPlaybackServiceIfNeeded covers the
+                    // speech window via the static isHoldingForeground gate.
+                    tryStartService(appCtx, period, prefs, workId.toString())
+                }
+
                 val schedule = when (period) {
                     ForecastPeriod.TODAY -> prefs.schedule
                     ForecastPeriod.TONIGHT -> prefs.tonightSchedule
@@ -99,6 +122,80 @@ class AlarmReceiver : BroadcastReceiver() {
                 pending.finish()
                 scope.cancel()
             }
+        }
+    }
+
+    /**
+     * True when the period's delivery configuration calls for a visible
+     * foreground-service surface during the run. SILENT delivery with no
+     * usable smart-home destinations means the user opted out of every
+     * visible / audible affordance — posting "Preparing your ClothesCast"
+     * would regress that contract.
+     *
+     * Uses the same publishability rules the delivery pipeline does:
+     * [isMqttPublishable] requires both the toggle *and* a non-blank
+     * host, and cast requires both the toggle *and* a picked route ID
+     * (matches `DeliveryGates.willCast`). A SILENT slot with the MQTT
+     * toggle on but no host configured, or cast enabled with no route
+     * picked, falls through the same way as plain SILENT.
+     */
+    private fun needsForegroundSurface(prefs: UserPreferences, period: ForecastPeriod): Boolean {
+        val deliveryMode = when (period) {
+            ForecastPeriod.TODAY -> prefs.deliveryMode
+            ForecastPeriod.TONIGHT -> prefs.tonightDeliveryMode
+        }
+        val castThisPeriod = when (period) {
+            ForecastPeriod.TODAY -> prefs.castMorning
+            ForecastPeriod.TONIGHT -> prefs.castTonight
+        }
+        val willCast = prefs.castEnabled && prefs.castRouteId != null && castThisPeriod
+        return deliveryMode.postsNotification ||
+            deliveryMode.playsSpeech ||
+            isMqttPublishable(prefs) ||
+            willCast
+    }
+
+    /**
+     * Starts the Service with the specific [workId] to watch, and the
+     * pre-resolved mode flags. Catches both the exception path
+     * (`ForegroundServiceStartNotAllowedException` and friends) and the
+     * silent-null return — `startForegroundService` returns the
+     * `ComponentName` of the started service, or null when the system
+     * couldn't resolve it.
+     */
+    private fun tryStartService(
+        context: Context,
+        period: ForecastPeriod,
+        prefs: UserPreferences,
+        workId: String,
+    ) {
+        val deliveryMode = when (period) {
+            ForecastPeriod.TODAY -> prefs.deliveryMode
+            ForecastPeriod.TONIGHT -> prefs.tonightDeliveryMode
+        }
+        val castThisPeriod = when (period) {
+            ForecastPeriod.TODAY -> prefs.castMorning
+            ForecastPeriod.TONIGHT -> prefs.castTonight
+        }
+        val willCast = prefs.castEnabled && prefs.castRouteId != null && castThisPeriod
+        val deliveringWantsForeground =
+            deliveryMode.playsSpeech ||
+                isMqttPublishable(prefs) ||
+                willCast
+        val intent = ScheduledDeliveryService.intent(
+            context = context,
+            period = period,
+            workId = workId,
+            playsSpeech = deliveryMode.playsSpeech,
+            deliveringWantsForeground = deliveringWantsForeground,
+        )
+        val result = runCatching { ContextCompat.startForegroundService(context, intent) }
+            .onFailure { t ->
+                DiagLog.w(TAG, "startForegroundService for $period refused; falling back to worker-only path", t)
+            }
+            .getOrNull()
+        if (result == null) {
+            DiagLog.w(TAG, "startForegroundService for $period returned null (system declined); falling back to worker-only path")
         }
     }
 

--- a/app/src/main/kotlin/app/clothescast/alarm/ScheduledDeliveryService.kt
+++ b/app/src/main/kotlin/app/clothescast/alarm/ScheduledDeliveryService.kt
@@ -1,0 +1,362 @@
+package app.clothescast.alarm
+
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.os.IBinder
+import androidx.core.app.NotificationCompat
+import androidx.work.WorkInfo
+import androidx.work.WorkManager
+import app.clothescast.R
+import app.clothescast.core.domain.model.ForecastPeriod
+import app.clothescast.diag.DiagLog
+import app.clothescast.diag.Telemetry
+import app.clothescast.notification.CHANNEL_PLAYBACK
+import app.clothescast.work.FetchAndNotifyWorker
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
+import java.util.UUID
+
+/**
+ * Owns the foreground-service notification for a scheduled-delivery run, from
+ * the alarm firing through to the worker finishing its fan-out. See
+ * docs/schedule-lifecycle.md for the full state machine.
+ *
+ * Started by [AlarmReceiver] via [androidx.core.content.ContextCompat.startForegroundService]
+ * inside the exact-alarm FGS-from-background exemption window. The receiver
+ * has already read preferences, decided the run needs a foreground surface
+ * (i.e. the period isn't SILENT-with-no-MQTT-no-cast), and enqueued the
+ * worker. The Service receives the worker's UUID, the `playsSpeech` /
+ * `deliveringWantsForeground` flags, and is responsible only for:
+ *
+ *  - posting the "Preparing your ClothesCast" FGS notification immediately,
+ *  - swapping it to "Delivering your ClothesCast" when the worker stamps
+ *    [FetchAndNotifyWorker.KEY_FETCH_COMPLETE] in its progress data,
+ *  - tearing the FGS down when the worker reaches a terminal state (or the
+ *    5-minute safety timeout fires for a worker that never starts).
+ *
+ * Two foreground-service types are declared in the manifest:
+ *  - `dataSync` — used while fetching + generating, and while delivering on
+ *    paths that don't play audio (MQTT or cast without phone speech).
+ *  - `mediaPlayback` — used while speech is playing on the phone, so audio
+ *    focus can be claimed on Android 15+.
+ *
+ * The Service exposes [isHoldingForegroundFor] as a per-worker owner gate so
+ * the worker can decide whether to promote itself to its own FGS — needed
+ * for the corner cases where the Service's 5-minute safety timeout fires
+ * before the worker (deferred by [androidx.work.NetworkType.CONNECTED]) gets
+ * to run, or where a second alarm fires for a different period while we're
+ * still shepherding the first.
+ */
+class ScheduledDeliveryService : Service() {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private var watcher: Job? = null
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        val period = parsePeriod(intent)
+        val workIdString = intent?.getStringExtra(EXTRA_WORK_ID)
+        val workId = workIdString?.let { runCatching { UUID.fromString(it) }.getOrNull() }
+        val playsSpeech = intent?.getBooleanExtra(EXTRA_PLAYS_SPEECH, false) ?: false
+        val deliveringWantsForeground =
+            intent?.getBooleanExtra(EXTRA_DELIVERING_WANTS_FOREGROUND, false) ?: false
+        DiagLog.i(
+            TAG,
+            "ScheduledDeliveryService onStartCommand period=$period workId=$workIdString",
+        )
+
+        if (workId == null) {
+            DiagLog.w(TAG, "No workId on Service intent; nothing to watch — exiting")
+            stopSelfIfIdle()
+            return START_NOT_STICKY
+        }
+
+        // Same workId arriving twice (rebroadcast / restart) → idempotent.
+        if (workId == foregroundWorkId) {
+            DiagLog.i(TAG, "Already shepherding workId=$workId; no-op")
+            return START_NOT_STICKY
+        }
+
+        // A different workId arriving while we're already shepherding one
+        // means the receiver enqueued a new alarm-driven worker. Both
+        // periods share a single unique-work queue (see UNIQUE_WORK_NAME),
+        // so the REPLACE policy at the WorkManager layer cancels the
+        // previous worker — regardless of which slot it belonged to. We
+        // just need to cancel the old watcher coroutine so it doesn't run
+        // its teardown — we want to keep the Service foregrounded and swap
+        // the notification in place rather than tear down and re-create.
+        // enterForeground below updates the existing id 1005 with the new
+        // content and stamps foregroundWorkId = newId.
+        if (foregroundWorkId != null) {
+            DiagLog.i(TAG, "Replacing shepherd: oldWorkId=$foregroundWorkId → newWorkId=$workId")
+            watcher?.cancel()
+            watcher = null
+        }
+
+        if (!enterForeground(stage = Stage.PREPARING, playsSpeech = playsSpeech, workId = workId)) {
+            DiagLog.w(TAG, "Couldn't enter foreground; exiting (worker runs without Service FGS)")
+            stopSelfIfIdle()
+            return START_NOT_STICKY
+        }
+
+        watcher = scope.launch {
+            watchWorkerUntilDone(workId, period, playsSpeech, deliveringWantsForeground)
+            teardown(workId)
+        }
+        return START_NOT_STICKY
+    }
+
+    private suspend fun watchWorkerUntilDone(
+        workId: UUID,
+        period: ForecastPeriod,
+        playsSpeech: Boolean,
+        deliveringWantsForeground: Boolean,
+    ) {
+        val wm = WorkManager.getInstance(applicationContext)
+        var stage = Stage.PREPARING
+
+        // Stage upgrade is shared between both phases — encode it once so the
+        // predicates below stay focused on their own exit conditions.
+        fun maybeUpgradeStage(info: WorkInfo?) {
+            if (info == null) return
+            if (stage == Stage.PREPARING && deliveringWantsForeground &&
+                info.progress.getBoolean(FetchAndNotifyWorker.KEY_FETCH_COMPLETE, false)
+            ) {
+                stage = Stage.DELIVERING
+                enterForeground(stage = Stage.DELIVERING, playsSpeech = playsSpeech, workId = workId)
+            }
+        }
+
+        val flow = wm.getWorkInfoByIdFlow(workId)
+
+        // Phase 1 — wait for the worker to start running (or finish without
+        // running, or hit the pre-start cap). The cap protects against a
+        // worker that's deferred indefinitely by NetworkType.CONNECTED on a
+        // flaky connection: we don't want "Preparing" sitting on the user's
+        // shade for hours waiting on a network that never returns. Five
+        // minutes is generous enough for typical doze deferrals and short
+        // outages without leaving a stale notification all day.
+        val phase1Info = withTimeoutOrNull(PRE_RUNNING_TIMEOUT_MS) {
+            flow.firstOrNull { info ->
+                maybeUpgradeStage(info)
+                info != null && (info.state == WorkInfo.State.RUNNING || info.state.isFinished)
+            }
+        }
+        if (phase1Info == null) {
+            DiagLog.w(TAG, "Worker for $period didn't reach RUNNING within ${PRE_RUNNING_TIMEOUT_MS}ms; exiting service")
+            Telemetry.logScheduledDeliveryTimeout(slot = slotName(period))
+            return
+        }
+        if (phase1Info.state.isFinished) {
+            logTerminal(phase1Info, period)
+            return
+        }
+
+        // Phase 2 — worker is RUNNING. Wait for the state to leave
+        // RUNNING — either a terminal state (SUCCEEDED / FAILED /
+        // CANCELLED) or a step back to ENQUEUED / BLOCKED because the
+        // worker returned `Result.retry()` for an exponential-backoff
+        // pause (Open-Meteo 429, transient socket failure, etc.). We
+        // tear down on the retry transition too: backoff can stretch
+        // for minutes-to-hours across repeated transient failures, and
+        // leaving "Preparing" up for the whole thing is exactly the
+        // stuck-FGS case we're trying to avoid. The worker's *next*
+        // attempt will find isHoldingForegroundFor(id) false (we cleared
+        // foregroundWorkId in teardown) and promote itself for the
+        // speech window if it gets to deliver.
+        //
+        // No timeout in this phase: TTS + cast + delivery alignment can
+        // legitimately run several minutes when the worker is actually
+        // executing, and WorkManager already caps foreground workers at
+        // ~10 minutes via its own machinery. Racing that cap with our
+        // own timeout was the previous risk.
+        val finalInfo = flow.firstOrNull { info ->
+            maybeUpgradeStage(info)
+            info != null && info.state != WorkInfo.State.RUNNING
+        }
+        if (finalInfo != null) logTerminal(finalInfo, period)
+    }
+
+    /**
+     * Diagnostic log of the worker's terminal state so a missing forecast
+     * can be triaged in the field. CANCELLED is the interesting one —
+     * either a downstream REPLACE (newer alarm canceled this run) or
+     * WorkManager's own ~10-minute foreground-worker cap kicked in.
+     */
+    private fun logTerminal(info: WorkInfo, period: ForecastPeriod) {
+        when (info.state) {
+            WorkInfo.State.SUCCEEDED -> DiagLog.i(TAG, "$period worker reached SUCCEEDED")
+            WorkInfo.State.FAILED -> DiagLog.w(TAG, "$period worker reached FAILED")
+            WorkInfo.State.CANCELLED -> DiagLog.w(TAG, "$period worker reached CANCELLED (possibly REPLACE or WorkManager's ~10-min cap)")
+            WorkInfo.State.ENQUEUED, WorkInfo.State.BLOCKED ->
+                DiagLog.i(TAG, "$period worker stepped back to ${info.state} (Result.retry backoff); exiting service — next attempt will promote itself if needed")
+            else -> DiagLog.i(TAG, "$period worker phase-2 exit state=${info.state}")
+        }
+    }
+
+    /**
+     * Tears down the FGS *only* when [foregroundWorkId] still matches the
+     * workId the caller (a watcher coroutine) was responsible for. Guards
+     * the replace-in-flight race: a previous watcher can observe CANCELLED
+     * on `Dispatchers.Default` and enter teardown after [onStartCommand]
+     * has already swapped `foregroundWorkId` to a new workId. Without the
+     * guard, the stale watcher would `stopForeground(REMOVE)` on the
+     * *new* run's notification and leave its scheduled TTS without the
+     * FGS it relies on.
+     */
+    private fun teardown(workId: UUID) {
+        if (foregroundWorkId == workId) {
+            stopForeground(STOP_FOREGROUND_REMOVE)
+            foregroundWorkId = null
+            // Bare stopSelf (no startId) so any startIds the overlap-rejection
+            // branch left dangling don't keep the service alive past the
+            // shepherded run.
+            stopSelf()
+        } else {
+            DiagLog.i(TAG, "Skipping teardown for workId=$workId; current foregroundWorkId=$foregroundWorkId")
+        }
+    }
+
+    /**
+     * Used by the early-exit branches before any watcher has launched
+     * (missing workId, foreground promotion refused). Only stops the
+     * service when nothing is being shepherded — if a watcher is already
+     * running we leave the service alone and let [teardown] handle it.
+     */
+    private fun stopSelfIfIdle() {
+        if (watcher == null && foregroundWorkId == null) stopSelf()
+    }
+
+    override fun onDestroy() {
+        watcher?.cancel()
+        scope.cancel()
+        foregroundWorkId = null
+        super.onDestroy()
+    }
+
+    /**
+     * Calls [startForeground] with a notification matching [stage]. Returns
+     * false if the platform refused the start (the caller exits without
+     * holding the FGS in that case). Stamps [foregroundWorkId] on success so
+     * [isHoldingForegroundFor] reports the live owner.
+     */
+    private fun enterForeground(stage: Stage, playsSpeech: Boolean, workId: UUID): Boolean {
+        val titleRes = when (stage) {
+            Stage.PREPARING -> R.string.notification_playback_title
+            Stage.DELIVERING -> R.string.notification_delivering_title
+        }
+        val notification = NotificationCompat.Builder(this, CHANNEL_PLAYBACK)
+            .setSmallIcon(R.drawable.ic_notification_insight)
+            .setContentTitle(getString(titleRes))
+            .setOngoing(true)
+            .setSilent(true)
+            // Android 12+ defers FGS notifications by ~10 seconds by default
+            // (system optimization for short-lived FGSs). Our whole
+            // "Preparing your ClothesCast" rationale is "let the user know
+            // the schedule fired *now*" — a 10-second delay defeats that on
+            // fast runs (notification-only mode finishing before the
+            // notification even shows). FOREGROUND_SERVICE_IMMEDIATE turns
+            // that deferral off for this notification.
+            .setForegroundServiceBehavior(NotificationCompat.FOREGROUND_SERVICE_IMMEDIATE)
+            .build()
+        // When the run plays phone speech, claim mediaPlayback from the
+        // start — not just at DELIVERING. The race we're avoiding is the
+        // worker reaching TTS before the watcher's async progress observer
+        // upgrades the FGS type: a slow fetch (>60s) can swallow the
+        // alignment wait, and the cached redelivery path also goes
+        // straight from setProgress to deliver(). On Android 15+ a dataSync
+        // FGS can't grant audio focus, so the speech would be silenced.
+        // Starting mediaPlayback during PREPARING closes the window
+        // completely; the cost is a slightly broader FGS type for the few
+        // seconds before deliver() actually starts speaking — negligible.
+        val type = when {
+            playsSpeech -> ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK
+            else -> ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC
+        }
+        return runCatching { startForeground(FOREGROUND_NOTIFICATION_ID, notification, type) }
+            .onSuccess { foregroundWorkId = workId }
+            .onFailure { DiagLog.w(TAG, "startForeground($stage) failed", it) }
+            .isSuccess
+    }
+
+    private fun slotName(period: ForecastPeriod): String = when (period) {
+        ForecastPeriod.TODAY -> "today"
+        ForecastPeriod.TONIGHT -> "tonight"
+    }
+
+    private fun parsePeriod(intent: Intent?): ForecastPeriod {
+        val name = intent?.getStringExtra(EXTRA_PERIOD) ?: return ForecastPeriod.TODAY
+        return runCatching { ForecastPeriod.valueOf(name) }.getOrDefault(ForecastPeriod.TODAY)
+    }
+
+    private enum class Stage { PREPARING, DELIVERING }
+
+    companion object {
+        private const val TAG = "SchedDeliveryService"
+
+        // Same notification id as the worker's fallback playback FGS. Only
+        // one FGS can hold a given id at a time, and the worker's
+        // promoteToPlaybackServiceIfNeeded reads [isHoldingForegroundFor] to
+        // skip its own setForeground only when we own this id for the worker
+        // making the check.
+        const val FOREGROUND_NOTIFICATION_ID = 1005
+
+        /**
+         * How long the watcher will hold "Preparing" while waiting for the
+         * worker to reach RUNNING. Covers doze deferrals and short network
+         * outages without leaving the FGS notification stranded all day on
+         * a constraint that never resolves. Once the worker reaches
+         * RUNNING, the watcher drops the timeout entirely and waits for a
+         * terminal state — WorkManager's own ~10-min foreground-worker cap
+         * is the upper bound there, so we don't race it.
+         */
+        private const val PRE_RUNNING_TIMEOUT_MS = 5L * 60L * 1000L
+
+        const val EXTRA_PERIOD = "app.clothescast.alarm.PERIOD"
+        const val EXTRA_WORK_ID = "app.clothescast.alarm.WORK_ID"
+        const val EXTRA_PLAYS_SPEECH = "app.clothescast.alarm.PLAYS_SPEECH"
+        const val EXTRA_DELIVERING_WANTS_FOREGROUND = "app.clothescast.alarm.DELIVERING_WANTS_FOREGROUND"
+
+        // Per-worker owner gate. Holds the UUID of the worker whose run is
+        // currently being shepherded by the Service (FGS notification id
+        // [FOREGROUND_NOTIFICATION_ID] is up), or null when the Service is
+        // not foregrounded. Read by [FetchAndNotifyWorker.promoteToPlaybackServiceIfNeeded]
+        // via [isHoldingForegroundFor] to decide whether to promote itself.
+        //
+        // A *per-worker* gate (not a process-wide bool) is what correctly
+        // handles overlapping runs: when a second alarm fires for a different
+        // period while we're still shepherding the first, the second worker's
+        // [isHoldingForegroundFor] check returns false (different UUID) and it
+        // promotes itself. The first worker's check still returns true and it
+        // keeps relying on the Service's FGS.
+        //
+        // Resets to null on teardown / onDestroy / process restart — all
+        // cases where the next worker must take over background-audio FGS
+        // duties for Android 15+.
+        @Volatile
+        private var foregroundWorkId: UUID? = null
+
+        @JvmStatic
+        fun isHoldingForegroundFor(workId: UUID): Boolean = foregroundWorkId == workId
+
+        fun intent(
+            context: Context,
+            period: ForecastPeriod,
+            workId: String,
+            playsSpeech: Boolean,
+            deliveringWantsForeground: Boolean,
+        ): Intent = Intent(context, ScheduledDeliveryService::class.java)
+            .putExtra(EXTRA_PERIOD, period.name)
+            .putExtra(EXTRA_WORK_ID, workId)
+            .putExtra(EXTRA_PLAYS_SPEECH, playsSpeech)
+            .putExtra(EXTRA_DELIVERING_WANTS_FOREGROUND, deliveringWantsForeground)
+    }
+}

--- a/app/src/main/kotlin/app/clothescast/diag/Telemetry.kt
+++ b/app/src/main/kotlin/app/clothescast/diag/Telemetry.kt
@@ -182,6 +182,31 @@ object Telemetry {
     }
 
     /**
+     * Emits a `scheduled_delivery_timeout` event when
+     * [app.clothescast.alarm.ScheduledDeliveryService]'s pre-RUNNING safety
+     * timeout fires — the alarm fired and the Service started the foreground
+     * notification, but the worker never reached the `RUNNING` state within
+     * the cap (typically because `NetworkType.CONNECTED` deferred it on a
+     * flaky / offline device).
+     *
+     * Distinct from `daily_refresh{outcome=cancelled}` which fires when the
+     * worker itself was canceled mid-flight: this event surfaces the
+     * "worker queued but never started" case where the worker may still
+     * eventually run later (so it isn't yet canceled or failed), but the
+     * user's "Preparing your ClothesCast" notification was dismissed at the
+     * timeout.
+     *
+     *  - `slot` (string): `today` or `tonight`.
+     */
+    fun logScheduledDeliveryTimeout(slot: String) {
+        val analytics = analyticsRef ?: return
+        val params = Bundle().apply {
+            putString(PARAM_SLOT, slot)
+        }
+        analytics.logEvent(EVENT_SCHEDULED_DELIVERY_TIMEOUT, params)
+    }
+
+    /**
      * Emits the user's non-voice settings as one event per Settings page —
      * `settings_schedule`, `settings_clothes`, `settings_format`,
      * `settings_region`, `settings_display`, and `settings_calendar` — so each
@@ -282,6 +307,7 @@ object Telemetry {
     private const val EVENT_API_CALL = "api_call"
     private const val EVENT_NOTIFICATION_DELIVERY = "notification_delivery"
     private const val EVENT_DAILY_REFRESH = "daily_refresh"
+    private const val EVENT_SCHEDULED_DELIVERY_TIMEOUT = "scheduled_delivery_timeout"
     // The non-voice settings snapshot is split into one event per Settings
     // page (names mirror the screen titles) so each stays well under
     // Firebase's 25-param-per-event cap; see logSettingsSnapshot.

--- a/app/src/main/kotlin/app/clothescast/notification/InsightNotifier.kt
+++ b/app/src/main/kotlin/app/clothescast/notification/InsightNotifier.kt
@@ -49,7 +49,7 @@ class InsightNotifier(private val context: Context) {
         // Today screen's OutfitPreviewCard does — recoloured if the user has
         // customised the icon's fill.
         val top = insight.outfit?.top
-        val notification = NotificationCompat.Builder(context, CHANNEL_DAILY_INSIGHT)
+        val notification = NotificationCompat.Builder(context, CHANNEL_SCHEDULED_INSIGHT)
             .setSmallIcon(smallIconFor(top))
             .setLargeIcon(
                 largeIconForTop(
@@ -66,7 +66,11 @@ class InsightNotifier(private val context: Context) {
             .setContentTitle(context.getString(R.string.notification_daily_insight_title))
             .setContentText(prose)
             .setStyle(NotificationCompat.BigTextStyle().bigText(prose))
-            .setPriority(NotificationCompat.PRIORITY_HIGH)
+            // Channel importance is DEFAULT on API 26+; PRIORITY_DEFAULT is the
+            // pre-O equivalent for the same bucket. Was PRIORITY_HIGH (heads-up)
+            // back when the channel was IMPORTANCE_HIGH; the schedule is
+            // user-opted-in, so a sound + shade entry is enough.
+            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
             .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
             .setAutoCancel(true)
             .setContentIntent(pendingIntent)
@@ -79,7 +83,7 @@ class InsightNotifier(private val context: Context) {
         NotificationManagerCompat.from(context).notify(NOTIFICATION_ID_DAILY_INSIGHT, notification)
         DiagLog.i(
             TAG,
-            "Posted daily insight notification (id=$NOTIFICATION_ID_DAILY_INSIGHT, channel=$CHANNEL_DAILY_INSIGHT, importance=HIGH).",
+            "Posted daily insight notification (id=$NOTIFICATION_ID_DAILY_INSIGHT, channel=$CHANNEL_SCHEDULED_INSIGHT, importance=DEFAULT).",
         )
     }
 

--- a/app/src/main/kotlin/app/clothescast/notification/NotificationChannelRegistrar.kt
+++ b/app/src/main/kotlin/app/clothescast/notification/NotificationChannelRegistrar.kt
@@ -10,10 +10,14 @@ import app.clothescast.R
  * Channel IDs are stable identifiers persisted by the system; renaming or deleting one
  * is a user-visible change. Bump the suffix when channel semantics change.
  */
-internal const val CHANNEL_DAILY_INSIGHT = "daily_insight_v1"
-internal const val CHANNEL_TONIGHT_INSIGHT_DEFAULT = "tonight_insight_default_v1"
-internal const val CHANNEL_TONIGHT_INSIGHT_SILENT = "tonight_insight_silent_v1"
-internal const val CHANNEL_PLAYBACK = "playback_v1"
+internal const val CHANNEL_SCHEDULED_INSIGHT = "scheduled_insight_v1"
+// Bumped from `playback_v1` so the broader semantics (now covers Preparing
+// + Delivering across the whole scheduled run, not just speech) take a
+// fresh user importance choice. Android preserves an existing channel's
+// user-set importance forever, so a user who had muted the old "Speaking
+// the forecast" channel would otherwise also lose the new schedule-fired
+// confirmation post.
+internal const val CHANNEL_PLAYBACK = "playback_v2"
 
 // Retired channel IDs to delete on upgrade. Android persists channels by ID
 // until the app explicitly deletes them, so dropping the create call alone
@@ -21,69 +25,82 @@ internal const val CHANNEL_PLAYBACK = "playback_v1"
 // installs. deleteNotificationChannel is a no-op when the ID was never
 // registered (fresh installs), so this is safe to call unconditionally.
 private const val CHANNEL_WEATHER_ALERTS_RETIRED = "weather_alerts_v1"
+// Pre-collapse forecast channels. The three of them — morning (HIGH), evening-
+// with-events (DEFAULT), evening-empty (LOW silent) — were replaced by the
+// single DEFAULT-importance CHANNEL_SCHEDULED_INSIGHT above. The
+// notifyOnlyOnEvents preference now drives "post or don't post" at the worker
+// level, not channel routing, so the silent channel no longer makes sense:
+// the user picked "only on events", so an empty evening should produce no
+// notification, not a quiet one. And both periods at the same DEFAULT
+// importance keeps a night-worker primary tonight slot just as loud as a
+// day-worker primary morning slot.
+private const val CHANNEL_DAILY_INSIGHT_RETIRED_V1 = "daily_insight_v1"
+// Brief interim ID introduced and immediately collapsed into
+// CHANNEL_SCHEDULED_INSIGHT — retire it too in case any dev / TestFlight build
+// registered it before the collapse landed.
+private const val CHANNEL_DAILY_INSIGHT_RETIRED_V2 = "daily_insight_v2"
+private const val CHANNEL_TONIGHT_INSIGHT_DEFAULT_RETIRED = "tonight_insight_default_v1"
+private const val CHANNEL_TONIGHT_INSIGHT_SILENT_RETIRED = "tonight_insight_silent_v1"
+// Pre-v2 playback channel was scoped to "Speaking the forecast"; v2 broadens
+// to cover Preparing + Delivering across the whole scheduled run. Same
+// rationale as the forecast-channel collapse: let the user pick importance
+// again rather than silently carrying their old mute into a different
+// scope.
+private const val CHANNEL_PLAYBACK_RETIRED_V1 = "playback_v1"
 
 /**
  * Registers the notification channel(s) used by the app. Idempotent — safe to call from
  * Application.onCreate on every cold start.
  *
- * Three channels:
- * - **Daily insight** (HIGH): the morning weather summary the user opted in to.
- * - **Tonight insight (with events)** (DEFAULT): the evening summary when the user
- *   has calendar events tonight. Plays the default notification sound — the user is
- *   actually heading out and should hear the heads-up.
- * - **Tonight insight (silent)** (LOW): the evening summary when the evening is
- *   empty. Posts so the user can glance at it on the lock screen, but no sound or
- *   vibration so it doesn't interrupt the evening.
- *
- * Two tonight channels (rather than per-notification silencing) is the canonical
- * Android approach: channel importance is sticky, the user can mute / un-mute either
- * independently in system settings, and silent-vs-default behaviour is reliable
- * across OEMs.
+ * Two channels:
+ * - **Scheduled ClothesCast** (DEFAULT): the morning *and* evening forecast
+ *   summaries the user opted into. Posted at the same importance for both
+ *   periods so a night-worker primary tonight slot reads exactly as well as
+ *   a day-worker primary morning slot.
+ * - **Scheduled ClothesCast delivery** (LOW, silent): the foreground-service
+ *   notification shown while the run prepares + delivers (see
+ *   [ScheduledDeliveryService]). A policy requirement for the background
+ *   FGS, not a user-actionable post — stays silent and unobtrusive.
  */
 object NotificationChannelRegistrar {
     fun register(context: Context) {
         val manager = context.getSystemService<NotificationManager>() ?: return
 
-        // Remove the retired severe-weather-alerts channel from installs that
-        // previously registered it (the feature is gone); see the const above.
+        // Remove every retired channel ID from installs that previously
+        // registered them, so dead channels don't sit in system notification
+        // settings forever.
+        //
+        // The collapse from three forecast channels into one is a fresh
+        // start: we create the new channel at DEFAULT regardless of what
+        // the user did to the old ones. Trying to migrate the prior opt-out
+        // state has no clean answer when three channels with different
+        // user preferences fold into one — and surprise-muting a user who
+        // only silenced (say) the empty-evening silent channel would
+        // silence morning forecasts too, which they never asked for.
+        // Users who want to mute the new channel can do so in system
+        // notification settings.
         manager.deleteNotificationChannel(CHANNEL_WEATHER_ALERTS_RETIRED)
+        manager.deleteNotificationChannel(CHANNEL_DAILY_INSIGHT_RETIRED_V1)
+        manager.deleteNotificationChannel(CHANNEL_DAILY_INSIGHT_RETIRED_V2)
+        manager.deleteNotificationChannel(CHANNEL_TONIGHT_INSIGHT_DEFAULT_RETIRED)
+        manager.deleteNotificationChannel(CHANNEL_TONIGHT_INSIGHT_SILENT_RETIRED)
+        manager.deleteNotificationChannel(CHANNEL_PLAYBACK_RETIRED_V1)
 
-        val daily = NotificationChannel(
-            CHANNEL_DAILY_INSIGHT,
-            context.getString(R.string.notification_channel_daily_insight_name),
-            NotificationManager.IMPORTANCE_HIGH,
-        ).apply {
-            description = context.getString(R.string.notification_channel_daily_insight_description)
-            setShowBadge(true)
-            lockscreenVisibility = android.app.Notification.VISIBILITY_PUBLIC
-        }
-
-        val tonightWithEvents = NotificationChannel(
-            CHANNEL_TONIGHT_INSIGHT_DEFAULT,
-            context.getString(R.string.notification_channel_tonight_insight_default_name),
+        val scheduled = NotificationChannel(
+            CHANNEL_SCHEDULED_INSIGHT,
+            context.getString(R.string.notification_channel_scheduled_insight_name),
             NotificationManager.IMPORTANCE_DEFAULT,
         ).apply {
-            description = context.getString(R.string.notification_channel_tonight_insight_default_description)
+            description = context.getString(R.string.notification_channel_scheduled_insight_description)
             setShowBadge(true)
-            lockscreenVisibility = android.app.Notification.VISIBILITY_PUBLIC
-        }
-
-        val tonightSilent = NotificationChannel(
-            CHANNEL_TONIGHT_INSIGHT_SILENT,
-            context.getString(R.string.notification_channel_tonight_insight_silent_name),
-            NotificationManager.IMPORTANCE_LOW,
-        ).apply {
-            description = context.getString(R.string.notification_channel_tonight_insight_silent_description)
-            setShowBadge(false)
-            setSound(null, null)
-            enableVibration(false)
             lockscreenVisibility = android.app.Notification.VISIBILITY_PUBLIC
         }
 
         // The foreground-service notification shown while a scheduled briefing
-        // speaks (see FetchAndNotifyWorker). LOW + no sound/vibration: it's a
-        // policy requirement for background audio, not a notification the user
-        // needs to act on, so it stays quiet and unobtrusive.
+        // prepares + delivers (see ScheduledDeliveryService). LOW + no sound /
+        // vibration: it's a policy requirement for the background run, not a
+        // notification the user needs to act on, so it stays quiet and
+        // unobtrusive.
         val playback = NotificationChannel(
             CHANNEL_PLAYBACK,
             context.getString(R.string.notification_channel_playback_name),
@@ -96,9 +113,7 @@ object NotificationChannelRegistrar {
             lockscreenVisibility = android.app.Notification.VISIBILITY_PUBLIC
         }
 
-        manager.createNotificationChannel(daily)
-        manager.createNotificationChannel(tonightWithEvents)
-        manager.createNotificationChannel(tonightSilent)
+        manager.createNotificationChannel(scheduled)
         manager.createNotificationChannel(playback)
     }
 }

--- a/app/src/main/kotlin/app/clothescast/notification/TonightInsightNotifier.kt
+++ b/app/src/main/kotlin/app/clothescast/notification/TonightInsightNotifier.kt
@@ -12,14 +12,16 @@ import app.clothescast.core.domain.model.OutfitSuggestion
 import app.clothescast.diag.DiagLog
 
 /**
- * Posts the tonight insight as a system notification. Picks one of two channels
- * based on whether the insight has calendar events tonight:
- *  - [CHANNEL_TONIGHT_INSIGHT_DEFAULT] when events are present — default importance,
- *    plays the user's notification sound. The user is heading out somewhere; the
- *    summary is worth interrupting them for.
- *  - [CHANNEL_TONIGHT_INSIGHT_SILENT] when the evening is empty — low importance,
- *    silent. Still posted so the user can glance at the lock screen and see the
- *    overnight insight, but nothing audible.
+ * Posts the tonight insight as a system notification on the shared
+ * [CHANNEL_SCHEDULED_INSIGHT] — the same channel the morning insight uses, so
+ * a night-worker primary tonight slot reads exactly as well as a day-worker
+ * primary morning slot.
+ *
+ * "Only notify on events" lives at the worker / [DeliveryGates] level: when
+ * the user has it on and the evening has no events, the worker doesn't call
+ * `notify()` at all (no quiet-channel fallback). That keeps the channel
+ * design symmetric across periods and lets the user dial channel importance
+ * once in system settings.
  *
  * Tapping the notification opens MainActivity. POST_NOTIFICATIONS is checked before
  * posting; on Android 13+ a missing permission silently no-ops (the insight is
@@ -49,11 +51,8 @@ class TonightInsightNotifier(private val context: Context) {
             PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
         )
 
-        val channel = if (insight.hasEvents) CHANNEL_TONIGHT_INSIGHT_DEFAULT else CHANNEL_TONIGHT_INSIGHT_SILENT
-        val priority = if (insight.hasEvents) NotificationCompat.PRIORITY_DEFAULT else NotificationCompat.PRIORITY_LOW
-
         val top = insight.outfit?.top
-        val notification = NotificationCompat.Builder(context, channel)
+        val notification = NotificationCompat.Builder(context, CHANNEL_SCHEDULED_INSIGHT)
             .setSmallIcon(InsightNotifier.smallIconFor(top))
             .setLargeIcon(
                 InsightNotifier.largeIconForTop(
@@ -70,7 +69,7 @@ class TonightInsightNotifier(private val context: Context) {
             .setContentTitle(context.getString(R.string.notification_tonight_insight_title))
             .setContentText(prose)
             .setStyle(NotificationCompat.BigTextStyle().bigText(prose))
-            .setPriority(priority)
+            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
             .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
             .setAutoCancel(true)
             .setContentIntent(pendingIntent)
@@ -78,18 +77,12 @@ class TonightInsightNotifier(private val context: Context) {
                 NotificationDismissReceiver.deleteIntent(context, NOTIFICATION_ID_TONIGHT_INSIGHT, "tonight insight"),
             )
             .setCategory(NotificationCompat.CATEGORY_REMINDER)
-            .apply {
-                // Belt-and-braces: even if a downstream OEM ignores the silent
-                // channel's importance, the per-notification flag still suppresses
-                // sound + heads-up for the no-events case.
-                if (!insight.hasEvents) setSilent(true)
-            }
             .build()
 
         NotificationManagerCompat.from(context).notify(NOTIFICATION_ID_TONIGHT_INSIGHT, notification)
         DiagLog.i(
             TAG,
-            "Posted tonight insight notification (id=$NOTIFICATION_ID_TONIGHT_INSIGHT, channel=$channel, hasEvents=${insight.hasEvents}).",
+            "Posted tonight insight notification (id=$NOTIFICATION_ID_TONIGHT_INSIGHT, channel=$CHANNEL_SCHEDULED_INSIGHT, hasEvents=${insight.hasEvents}).",
         )
     }
 

--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsViewModel.kt
@@ -413,11 +413,12 @@ class SettingsViewModel(
             // slot's cache write.
             viewModelScope.launch {
                 combine(
+                    // Both scheduled periods now share one queue; Play stays
+                    // on its own — see FetchAndNotifyWorker.UNIQUE_WORK_NAME.
                     wm.getWorkInfosForUniqueWorkFlow(FetchAndNotifyWorker.UNIQUE_WORK_NAME),
-                    wm.getWorkInfosForUniqueWorkFlow(FetchAndNotifyWorker.UNIQUE_WORK_NAME_TONIGHT),
                     wm.getWorkInfosForUniqueWorkFlow(FetchAndNotifyWorker.UNIQUE_WORK_NAME_PLAY),
-                ) { today, tonight, play ->
-                    today.hasActiveWork() || tonight.hasActiveWork() || play.hasActiveWork()
+                ) { scheduled, play ->
+                    scheduled.hasActiveWork() || play.hasActiveWork()
                 }.collect { active ->
                     _state.update { it.copy(anyWorkActive = active) }
                 }

--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayViewModel.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayViewModel.kt
@@ -529,16 +529,18 @@ class TodayViewModel(
     // into a single flow so [state]'s `combine` stays under the 5-flow
     // overload cap now that the pager reads both period slots separately.
     private val workStatusFlow = combine(
+        // Both TODAY and TONIGHT scheduled runs share UNIQUE_WORK_NAME now
+        // (single queue, REPLACE on enqueue covers the overlap case). The
+        // Play tap stays on its own queue so an offline Play sitting there
+        // can't block an alarm.
         workManager.getWorkInfosForUniqueWorkFlow(FetchAndNotifyWorker.UNIQUE_WORK_NAME),
-        workManager.getWorkInfosForUniqueWorkFlow(FetchAndNotifyWorker.UNIQUE_WORK_NAME_TONIGHT),
         workManager.getWorkInfosForUniqueWorkFlow(FetchAndNotifyWorker.UNIQUE_WORK_NAME_PLAY),
-    ) { todayInfos, tonightInfos, replayInfos ->
-        val todayLite = todayInfos.toLite()
-        val tonightLite = tonightInfos.toLite()
+    ) { scheduledInfos, replayInfos ->
+        val scheduledLite = scheduledInfos.toLite()
         val replayLite = replayInfos.toLite()
         WorkSignals(
-            status = mergeWorkStatus(selectStatus(todayLite), selectStatus(tonightLite)),
-            anyWorkActive = anyActive(todayLite) || anyActive(tonightLite) || anyActive(replayLite),
+            status = selectStatus(scheduledLite),
+            anyWorkActive = anyActive(scheduledLite) || anyActive(replayLite),
         )
     }
 

--- a/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
@@ -20,6 +20,7 @@ import androidx.work.WorkManager
 import androidx.work.WorkerParameters
 import androidx.work.workDataOf
 import app.clothescast.ClothesCastApplication
+import app.clothescast.alarm.ScheduledDeliveryService
 import app.clothescast.core.domain.model.DailyHistoryEntry
 import app.clothescast.core.domain.model.postsNotification
 import app.clothescast.core.domain.model.ForecastPeriod
@@ -216,10 +217,10 @@ class FetchAndNotifyWorker(
         if (inputData.getBoolean(KEY_CACHE_LOCATION_ONLY, false)) {
             val resolved = resolveLocation(prefs, forceFresh = true)
             if (resolved != null && !hasCachedThisPeriodInsight()) {
-                // Route the recovery through the *observed* daily / tonight
+                // Route the recovery through the *observed* scheduled-delivery
                 // queue (silent = no notification / TTS), not the silent-refresh
                 // queue. The scheduled run that failed for lack of a location
-                // left a terminal REASON_NO_LOCATION WorkInfo on an observed
+                // left a terminal REASON_NO_LOCATION WorkInfo on the observed
                 // queue, and the Today banner only suppresses it while the
                 // location-action banner is showing — which stops the moment
                 // resolveLocation() saves a fallback here. A success on the
@@ -229,23 +230,9 @@ class FetchAndNotifyWorker(
                 // error. enqueueOneShot's REPLACE on the observed queue both
                 // clears the stale failure and shows a "Fetching" spinner while
                 // it runs.
-                //
-                // Recover the current window for the actual fetch. But the
-                // failure may sit on the *other* observed queue: if this
-                // morning's daily run failed and the user only grants location
-                // after the tonight window opens, the current period is TONIGHT
-                // while the stale REASON_NO_LOCATION lives on the daily queue.
-                // mergeWorkStatus surfaces a failure on *either* queue, so also
-                // kick a (silent) recovery on the other queue when it carries
-                // that stale failure — a no-op in the common same-window case.
                 val period = currentPeriodForSchedule(prefs)
-                val other = otherPeriod(period)
-                val periods = buildList {
-                    add(period)
-                    if (hasStaleNoLocationFailure(observedWorkName(other))) add(other)
-                }
-                DiagLog.i(TAG, "Cache-only refresh resolved a location with nothing cached; kicking $periods refresh.")
-                periods.forEach { enqueueOneShot(applicationContext, silent = true, period = it) }
+                DiagLog.i(TAG, "Cache-only refresh resolved a location with nothing cached; kicking $period refresh.")
+                enqueueOneShot(applicationContext, silent = true, period = period)
             } else {
                 DiagLog.i(TAG, "Cache-only location refresh; skipping insight pipeline.")
             }
@@ -357,6 +344,14 @@ class FetchAndNotifyWorker(
         if (cached != null) {
             val cachedInsight = cached.insight
             DiagLog.i(TAG, "Using cached $period insight for ${cachedInsight.forDate}.")
+            // Mirror the fresh-fetch path: stamp KEY_FETCH_COMPLETE so
+            // ScheduledDeliveryService swaps from PREPARING to DELIVERING
+            // (mediaPlayback FGS when speech plays). Otherwise the Service
+            // sits at "Preparing" through the whole cached delivery, and
+            // because isHoldingForegroundFor(id) is true the worker has
+            // already skipped its own promoteToPlaybackServiceIfNeeded —
+            // background TTS could be silenced on Android 15+.
+            setProgress(workDataOf(KEY_FETCH_COMPLETE to true))
             return runCatching { deliver(cachedInsight, prefs, formatProse(cachedInsight, prefs)) }
                 .map {
                     recordDailyHistory(cachedInsight)
@@ -859,32 +854,6 @@ class FetchAndNotifyWorker(
     // leaving the user on a blank Today screen.
     private suspend fun hasCachedThisPeriodInsight(): Boolean =
         runCatching { app.insightCache.thisPeriod.first() }.getOrNull() != null
-
-    // The observed unique-work queue (the ones TodayViewModel.workStatusFlow
-    // watches) that a [period]'s scheduled run lands on.
-    private fun observedWorkName(period: ForecastPeriod): String = when (period) {
-        ForecastPeriod.TODAY -> UNIQUE_WORK_NAME
-        ForecastPeriod.TONIGHT -> UNIQUE_WORK_NAME_TONIGHT
-    }
-
-    private fun otherPeriod(period: ForecastPeriod): ForecastPeriod = when (period) {
-        ForecastPeriod.TODAY -> ForecastPeriod.TONIGHT
-        ForecastPeriod.TONIGHT -> ForecastPeriod.TODAY
-    }
-
-    // True when [workName]'s most-recent terminal run failed for lack of a
-    // location and nothing's currently active on it — i.e. a stale
-    // REASON_NO_LOCATION WorkInfo the banner would surface once the saved
-    // fallback drops the location-action suppression. A query failure degrades
-    // to false — we'd rather skip the extra recovery than throw out of the
-    // cache-only path. The decision itself lives in [staleNoLocationFailure]
-    // so it can be unit-tested without WorkManager.
-    private fun hasStaleNoLocationFailure(workName: String): Boolean {
-        val infos = runCatching {
-            WorkManager.getInstance(applicationContext).getWorkInfosForUniqueWork(workName).get()
-        }.getOrElse { return false }
-        return staleNoLocationFailure(infos.toLite())
-    }
 
     private suspend fun resolveLocation(prefs: UserPreferences, forceFresh: Boolean = false): Location? {
         if (prefs.useDeviceLocation) {
@@ -1788,6 +1757,16 @@ class FetchAndNotifyWorker(
     private suspend fun promoteToPlaybackServiceIfNeeded(prefs: UserPreferences) {
         val alarmTriggered = inputData.getLong(KEY_ALARM_FIRED_AT_MS, 0L) != 0L
         if (!alarmTriggered) return
+        // ScheduledDeliveryService is the primary FGS owner for alarm-driven
+        // runs. While it's holding id 1005, we skip our own setForeground —
+        // a second call would clobber its notification and race the type
+        // transition. The static check (not a persisted input flag) is what
+        // covers the corner cases: the Service's 5-min safety timeout, a
+        // process restart, or a Service start that the receiver couldn't
+        // reach — in any of them isHoldingForeground() is false and the
+        // worker promotes itself so background TTS still has the
+        // mediaPlayback FGS Android 15+ requires.
+        if (ScheduledDeliveryService.isHoldingForegroundFor(id)) return
         val period = inputData.getString(KEY_PERIOD)
             ?.let { runCatching { ForecastPeriod.valueOf(it) }.getOrNull() }
             ?: ForecastPeriod.TODAY
@@ -1946,8 +1925,18 @@ class FetchAndNotifyWorker(
 
     companion object {
         private const val TAG = "FetchAndNotifyWorker"
+        // Single unique-work queue for both TODAY and TONIGHT scheduled runs.
+        // Sharing one queue means WorkManager's ExistingWorkPolicy.REPLACE
+        // naturally cancels any in-flight previous run when a new alarm
+        // fires — covers the "morning still mid-flight when evening alarm
+        // fires" overlap without any cross-queue dance. The period the run
+        // is for is carried on the WorkInfo's input data ([KEY_PERIOD]);
+        // observers that care about which slot is running read it there.
+        //
+        // Name preserved as "daily_insight_fetch" — WorkManager persists the
+        // queue keyed by this name and renaming would orphan any run armed
+        // before the upgrade.
         const val UNIQUE_WORK_NAME = "daily_insight_fetch"
-        const val UNIQUE_WORK_NAME_TONIGHT = "tonight_insight_fetch"
         // Distinct queue from the daily / tonight runs so a user toggling
         // device location while a forecast run is in flight doesn't cancel
         // it (and vice versa). Cache-only runs are idempotent and skip the
@@ -2154,13 +2143,20 @@ class FetchAndNotifyWorker(
          */
         internal const val KEY_PLAY_FORCE = "play_force"
 
+        /**
+         * Returns the [java.util.UUID] of the enqueued work request so callers
+         * (notably [app.clothescast.alarm.AlarmReceiver]) can hand it to
+         * [app.clothescast.alarm.ScheduledDeliveryService] to watch the
+         * specific run rather than racing whatever stale terminal WorkInfo
+         * the unique-work queue is hanging on to.
+         */
         fun enqueueOneShot(
             context: Context,
             silent: Boolean = false,
             period: ForecastPeriod = ForecastPeriod.TODAY,
             alarmScheduledAtMs: Long = 0L,
             alarmFiredAtMs: Long = 0L,
-        ) {
+        ): java.util.UUID {
             val constraints = Constraints.Builder()
                 .setRequiredNetworkType(NetworkType.CONNECTED)
                 .build()
@@ -2184,16 +2180,18 @@ class FetchAndNotifyWorker(
                 )
                 .build()
 
-            // The manual Refresh tap (the only silent caller here) uses REPLACE so
-            // it supersedes any in-flight retry and starts a fresh fetch. Alarm
-            // enqueues use KEEP so a still-retrying run isn't duplicated.
-            val policy = if (silent) ExistingWorkPolicy.REPLACE else ExistingWorkPolicy.KEEP
-            val workName = when (period) {
-                ForecastPeriod.TODAY -> UNIQUE_WORK_NAME
-                ForecastPeriod.TONIGHT -> UNIQUE_WORK_NAME_TONIGHT
-            }
+            // REPLACE across the board, and one shared queue for both
+            // periods: the alarm path uses it so a stuck retry from an
+            // earlier fire — *or* an in-flight worker for the other slot —
+            // is canceled in favor of the new alarm's fresh request. The
+            // silent refresh path already used REPLACE; the merged queue
+            // means a manual Refresh tap supersedes any in-flight scheduled
+            // run too. With REPLACE we always know `request.id` is the id
+            // WorkManager kept, so callers (notably AlarmReceiver) don't
+            // need to read it back.
             WorkManager.getInstance(context)
-                .enqueueUniqueWork(workName, policy, request)
+                .enqueueUniqueWork(UNIQUE_WORK_NAME, ExistingWorkPolicy.REPLACE, request)
+            return request.id
         }
 
         /**
@@ -2202,9 +2200,9 @@ class FetchAndNotifyWorker(
          * Replays a fresh same-day cached snapshot when one exists, else
          * fetches fresh (see [playInsight]). Runs on its own
          * [UNIQUE_WORK_NAME_PLAY] queue so an offline tap sitting here can't
-         * block a later scheduled alarm fire (which uses KEEP on
-         * [UNIQUE_WORK_NAME] / [UNIQUE_WORK_NAME_TONIGHT] and would otherwise
-         * get dropped in favour of the pending play). REPLACE because the
+         * block a later scheduled alarm fire (which uses REPLACE on
+         * [UNIQUE_WORK_NAME] — sharing the queue would let the pending
+         * play be canceled by the alarm or vice versa). REPLACE because the
          * user's most-recent tap is the one that matters; concurrent
          * Refresh+Play double-delivery is prevented by the UI gate (see
          * [TodayState.anyWorkActive]), not by sharing a queue.
@@ -2252,10 +2250,36 @@ class FetchAndNotifyWorker(
          * their `invokeOnCancellation` hooks. A future scheduled alarm is
          * unaffected — it re-enqueues on its own next fire.
          */
+        /**
+         * One-shot cleanup of unique-work queue names this class no longer
+         * uses. Idempotent — `cancelUniqueWork` is a no-op when no rows
+         * exist under the name. Called from
+         * [app.clothescast.ClothesCastApplication.onCreate] so an upgrade
+         * doesn't leave a stale TONIGHT WorkSpec lurking on the retired
+         * `tonight_insight_fetch` queue: that worker would otherwise run
+         * later with its old period input, fire a duplicate notification /
+         * TTS / MQTT / cast on top of the merged-queue run, and not be
+         * observable via the current [TodayViewModel] / [SettingsViewModel]
+         * flows (which only watch [UNIQUE_WORK_NAME] now).
+         */
+        fun cleanupLegacyQueues(context: Context) {
+            // WorkManager initializes via androidx.startup on real devices,
+            // but Robolectric doesn't fire that provider — getInstance() then
+            // throws IllegalStateException from a test that didn't explicitly
+            // initialise WorkManager. Treat that as "nothing to clean up"; on
+            // a real device the cleanup runs once per cold start.
+            runCatching {
+                WorkManager.getInstance(context).cancelUniqueWork(LEGACY_UNIQUE_WORK_NAME_TONIGHT)
+            }.onFailure { DiagLog.w(TAG, "Legacy queue cleanup skipped (WorkManager unavailable)", it) }
+        }
+
+        // Retired in the queue-merge — both periods now share UNIQUE_WORK_NAME.
+        // Kept here only so [cleanupLegacyQueues] can cancel any orphaned row.
+        private const val LEGACY_UNIQUE_WORK_NAME_TONIGHT = "tonight_insight_fetch"
+
         fun cancelDelivery(context: Context) {
             val workManager = WorkManager.getInstance(context)
             workManager.cancelUniqueWork(UNIQUE_WORK_NAME)
-            workManager.cancelUniqueWork(UNIQUE_WORK_NAME_TONIGHT)
             workManager.cancelUniqueWork(UNIQUE_WORK_NAME_PLAY)
         }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1113,19 +1113,15 @@
     <string name="settings_clothes_cond_temp_above">when temperature is above %1$s</string>
     <string name="settings_clothes_cond_precip_above">when chance of rain is above %.0f%%</string>
 
-    <string name="notification_channel_daily_insight_name">Daily ClothesCast</string>
-    <string name="notification_channel_daily_insight_description">The morning weather summary you opted in to.</string>
+    <string name="notification_channel_scheduled_insight_name">Scheduled ClothesCast</string>
+    <string name="notification_channel_scheduled_insight_description">Your scheduled weather summaries — morning and evening — when they\'re ready.</string>
     <string name="notification_daily_insight_title">Today\'s ClothesCast</string>
-
-    <string name="notification_channel_tonight_insight_default_name">Nightly ClothesCast (with events)</string>
-    <string name="notification_channel_tonight_insight_default_description">The evening weather summary when you have calendar events tonight. Plays your default notification sound.</string>
-    <string name="notification_channel_tonight_insight_silent_name">Nightly ClothesCast (silent)</string>
-    <string name="notification_channel_tonight_insight_silent_description">The evening weather summary when your evening is empty. Posted silently — you can glance at it on the lock screen, but it won\'t make a sound.</string>
     <string name="notification_tonight_insight_title">Tonight\'s ClothesCast</string>
 
-    <string name="notification_channel_playback_name">Speaking the forecast</string>
-    <string name="notification_channel_playback_description">Shown briefly while ClothesCast reads your scheduled forecast aloud. Required by Android so the audio can play from the background.</string>
+    <string name="notification_channel_playback_name">Scheduled ClothesCast delivery</string>
+    <string name="notification_channel_playback_description">Shown while ClothesCast prepares and delivers your scheduled forecast. Required by Android so the run can finish in the background.</string>
     <string name="notification_playback_title">Preparing your ClothesCast</string>
+    <string name="notification_delivering_title">Delivering your ClothesCast</string>
 
 
     <string name="settings_notification_permission_title">Notifications are blocked</string>

--- a/app/src/test/kotlin/app/clothescast/alarm/AlarmReceiverErrorHandlingTest.kt
+++ b/app/src/test/kotlin/app/clothescast/alarm/AlarmReceiverErrorHandlingTest.kt
@@ -127,7 +127,7 @@ class AlarmReceiverErrorHandlingTest {
         // The catch for TONIGHT does nothing observable, so we can't poll for a
         // positive signal — wait a beat, then assert nothing was enqueued.
         Thread.sleep(500)
-        workManager.getWorkInfosForUniqueWork(FetchAndNotifyWorker.UNIQUE_WORK_NAME_TONIGHT)
+        workManager.getWorkInfosForUniqueWork(FetchAndNotifyWorker.UNIQUE_WORK_NAME)
             .get()
             .shouldBeEmpty()
         // The alarm was also never re-armed (scheduler.schedule lives inside

--- a/app/src/test/kotlin/app/clothescast/alarm/AlarmReceiverRoutingTest.kt
+++ b/app/src/test/kotlin/app/clothescast/alarm/AlarmReceiverRoutingTest.kt
@@ -1,0 +1,211 @@
+package app.clothescast.alarm
+
+import android.app.AlarmManager
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+import androidx.core.content.getSystemService
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.work.Configuration
+import androidx.work.WorkInfo
+import androidx.work.WorkManager
+import app.clothescast.ClothesCastApplication
+import app.clothescast.core.domain.model.DeliveryMode
+import app.clothescast.core.domain.model.ForecastPeriod
+import app.clothescast.work.FetchAndNotifyWorker
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+/**
+ * Receiver routing coverage: given a slot's enabled/disabled state and the
+ * configured delivery mode (+ smart-home toggles), does the receiver
+ *  - cancel the alarm and bail (disabled slot),
+ *  - enqueue the worker AND start [ScheduledDeliveryService] (NOTIFICATION /
+ *    TTS / MQTT / cast modes),
+ *  - or enqueue the worker but *not* start the Service (SILENT with no
+ *    publishable smart-home destinations — the user opted out of every
+ *    visible affordance)?
+ *
+ * Pairs with [AlarmReceiverErrorHandlingTest] (prefs-read-failure
+ * fallback) and [ScheduledDeliveryServiceTest] (Service state machine).
+ */
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [33])
+class AlarmReceiverRoutingTest {
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val app = context.applicationContext as ClothesCastApplication
+    private val alarmManager: AlarmManager = context.getSystemService()!!
+    private val shadowApp = shadowOf(context.applicationContext as android.app.Application)
+    private val workManager: WorkManager by lazy {
+        if (!WorkManager.isInitialized()) {
+            WorkManager.initialize(
+                context,
+                Configuration.Builder()
+                    .setMinimumLoggingLevel(Log.WARN)
+                    .setExecutor(Executors.newSingleThreadExecutor())
+                    .setTaskExecutor(Executors.newSingleThreadExecutor())
+                    .build(),
+            )
+        }
+        WorkManager.getInstance(context)
+    }
+
+    @Before
+    fun resetState() {
+        // App startup arms default-prefs alarms on a background coroutine;
+        // wait for the queue to settle and then clear shadows so each test
+        // starts from a clean slate (matches AlarmReceiverErrorHandlingTest).
+        waitForAlarms(2)
+        alarmManager.cancel(DailyAlarmScheduler.pendingIntent(context, ForecastPeriod.TODAY))
+        alarmManager.cancel(DailyAlarmScheduler.pendingIntent(context, ForecastPeriod.TONIGHT))
+        drainStartedServices()
+        // Reset prefs to a known disabled state at the top of each test;
+        // individual tests opt slots in via the real SettingsRepository.
+        runBlocking {
+            app.settingsRepository.setDailyEnabled(false)
+            app.settingsRepository.setTonightEnabled(false)
+            app.settingsRepository.setDeliveryMode(DeliveryMode.NOTIFICATION_AND_TTS)
+            app.settingsRepository.setMqttBridgeEnabled(false)
+            app.settingsRepository.setMqttConfig(host = null, port = 1883, useTls = false, username = null, topic = "clothescast/default")
+            app.settingsRepository.setCastEnabled(false)
+            app.settingsRepository.setCastRoute(null, null)
+        }
+        // Make sure WorkManager is initialized before any test runs.
+        workManager
+        workManager.cancelUniqueWork(FetchAndNotifyWorker.UNIQUE_WORK_NAME)
+    }
+
+    @After
+    fun restoreDefaults() {
+        runBlocking {
+            app.settingsRepository.setDailyEnabled(false)
+            app.settingsRepository.setTonightEnabled(false)
+            app.settingsRepository.setMqttBridgeEnabled(false)
+            app.settingsRepository.setMqttConfig(host = null, port = 1883, useTls = false, username = null, topic = "clothescast/default")
+            app.settingsRepository.setCastEnabled(false)
+            app.settingsRepository.setCastRoute(null, null)
+        }
+    }
+
+    @Test
+    fun `daily disabled fire cancels the alarm without starting Service or worker`() {
+        // dailyEnabled=false is the default state we reset to in @Before.
+        fireDailyAlarm()
+
+        shadowApp.peekNextStartedService() shouldBe null
+        workManager.getWorkInfosForUniqueWork(FetchAndNotifyWorker.UNIQUE_WORK_NAME).get(5, TimeUnit.SECONDS)
+            .none { !it.state.isFinished } shouldBe true
+    }
+
+    @Test
+    fun `daily enabled with NOTIFICATION_AND_TTS starts Service and enqueues worker`() {
+        runBlocking {
+            app.settingsRepository.setDailyEnabled(true)
+            app.settingsRepository.setDeliveryMode(DeliveryMode.NOTIFICATION_AND_TTS)
+        }
+
+        fireDailyAlarm()
+
+        val started = waitForStartedService()
+        started?.component?.className shouldBe ScheduledDeliveryService::class.java.name
+        started?.getStringExtra(ScheduledDeliveryService.EXTRA_PERIOD) shouldBe ForecastPeriod.TODAY.name
+        started?.getBooleanExtra(ScheduledDeliveryService.EXTRA_PLAYS_SPEECH, false) shouldBe true
+        // EXTRA_WORK_ID is the freshly-enqueued worker — assert it's present
+        // (the receiver always passes it on the FGS path) without pinning a
+        // specific UUID.
+        (started?.getStringExtra(ScheduledDeliveryService.EXTRA_WORK_ID)?.isNotBlank() ?: false) shouldBe true
+
+        waitForEnqueuedWorker(FetchAndNotifyWorker.UNIQUE_WORK_NAME)
+    }
+
+    @Test
+    fun `daily enabled with SILENT mode and no smart-home destinations skips the Service`() {
+        runBlocking {
+            app.settingsRepository.setDailyEnabled(true)
+            app.settingsRepository.setDeliveryMode(DeliveryMode.SILENT)
+            // mqttBridgeEnabled=false, castEnabled=false from @Before.
+        }
+
+        fireDailyAlarm()
+
+        // No Service start — the user opted out of every visible affordance.
+        // But the worker still runs (cache + widget refresh contract for
+        // SILENT delivery).
+        waitForEnqueuedWorker(FetchAndNotifyWorker.UNIQUE_WORK_NAME)
+        shadowApp.peekNextStartedService() shouldBe null
+    }
+
+    @Test
+    fun `daily enabled with SILENT plus publishable MQTT starts the Service`() {
+        runBlocking {
+            app.settingsRepository.setDailyEnabled(true)
+            app.settingsRepository.setDeliveryMode(DeliveryMode.SILENT)
+            // isMqttPublishable requires both toggle on AND host non-blank.
+            app.settingsRepository.setMqttBridgeEnabled(true)
+            app.settingsRepository.setMqttConfig(host = "broker.local", port = 1883, useTls = false, username = null, topic = "clothescast/default")
+        }
+
+        fireDailyAlarm()
+
+        val started = waitForStartedService()
+        started?.component?.className shouldBe ScheduledDeliveryService::class.java.name
+        started?.getBooleanExtra(ScheduledDeliveryService.EXTRA_DELIVERING_WANTS_FOREGROUND, false) shouldBe true
+        // playsSpeech stays false — SILENT doesn't speak even when MQTT
+        // publishes; the FGS type stays dataSync.
+        started?.getBooleanExtra(ScheduledDeliveryService.EXTRA_PLAYS_SPEECH, false) shouldBe false
+        waitForEnqueuedWorker(FetchAndNotifyWorker.UNIQUE_WORK_NAME)
+    }
+
+    private fun fireDailyAlarm() {
+        AlarmReceiver().onReceive(
+            context,
+            Intent(AlarmReceiver.ACTION_FIRE).setPackage(context.packageName),
+        )
+    }
+
+    private fun waitForStartedService(): Intent? {
+        // The receiver finishes asynchronously via goAsync + Dispatchers.Default,
+        // so we poll the shadow application's started-service queue.
+        val deadline = System.currentTimeMillis() + 5_000
+        while (System.currentTimeMillis() < deadline) {
+            val intent = shadowApp.peekNextStartedService()
+            if (intent != null) return shadowApp.nextStartedService
+            Thread.sleep(25)
+        }
+        return null
+    }
+
+    private fun waitForEnqueuedWorker(workName: String): List<WorkInfo> {
+        val deadline = System.currentTimeMillis() + 5_000
+        while (System.currentTimeMillis() < deadline) {
+            val infos = workManager.getWorkInfosForUniqueWork(workName).get(2, TimeUnit.SECONDS)
+            if (infos.any { !it.state.isFinished }) return infos
+            Thread.sleep(25)
+        }
+        return workManager.getWorkInfosForUniqueWork(workName).get(2, TimeUnit.SECONDS)
+    }
+
+    private fun drainStartedServices() {
+        while (shadowApp.peekNextStartedService() != null) {
+            shadowApp.nextStartedService
+        }
+    }
+
+    private fun waitForAlarms(expected: Int) {
+        val deadline = System.currentTimeMillis() + 5_000
+        while (System.currentTimeMillis() < deadline) {
+            if (shadowOf(alarmManager).scheduledAlarms.size >= expected) return
+            Thread.sleep(25)
+        }
+    }
+}

--- a/app/src/test/kotlin/app/clothescast/alarm/ScheduledDeliveryServiceTest.kt
+++ b/app/src/test/kotlin/app/clothescast/alarm/ScheduledDeliveryServiceTest.kt
@@ -1,0 +1,152 @@
+package app.clothescast.alarm
+
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.work.Configuration
+import androidx.work.WorkManager
+import app.clothescast.core.domain.model.ForecastPeriod
+import io.kotest.matchers.shouldBe
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.android.controller.ServiceController
+import org.robolectric.annotation.Config
+import java.util.UUID
+import java.util.concurrent.Executors
+
+/**
+ * Dispatch-only coverage for [ScheduledDeliveryService]: how `onStartCommand`
+ * sets up — or refuses to set up — the per-worker owner gate
+ * ([ScheduledDeliveryService.isHoldingForegroundFor]) under different
+ * intents.
+ *
+ * WorkInfo-driven state-machine tests (PREPARING → DELIVERING on
+ * `KEY_FETCH_COMPLETE`, teardown on SUCCEEDED / FAILED / CANCELLED, phase-2
+ * exit on retry-backoff) are deferred — Robolectric's WorkManager doesn't
+ * reliably drive `getWorkInfoByIdFlow` emissions on the timing the watcher
+ * coroutine expects, so the test would either be flaky or pin the whole
+ * watcher coroutine to a synchronous dispatcher just for the test
+ * scaffolding. Worth a follow-up once the design has settled and we know
+ * which transitions are most worth pinning down.
+ */
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [33])
+class ScheduledDeliveryServiceTest {
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    @Before
+    fun installWorkManager() {
+        // Robolectric doesn't fire the androidx.startup content provider, so
+        // WorkManager has no auto-init. The Service queries WorkManager for
+        // a WorkInfo flow on the workId from its intent — without an init
+        // the very first getInstance() throws. Match the executors pattern
+        // used by the other alarm tests.
+        if (!WorkManager.isInitialized()) {
+            WorkManager.initialize(
+                context,
+                Configuration.Builder()
+                    .setMinimumLoggingLevel(Log.WARN)
+                    .setExecutor(Executors.newSingleThreadExecutor())
+                    .setTaskExecutor(Executors.newSingleThreadExecutor())
+                    .build(),
+            )
+        }
+    }
+
+    @Test
+    fun `start with no workId leaves owner unset`() {
+        val randomId = UUID.randomUUID()
+        val controller = startedServiceFor(
+            ScheduledDeliveryService.intent(
+                context = context,
+                period = ForecastPeriod.TODAY,
+                // No EXTRA_WORK_ID — strip it from the intent before start
+                // so we exercise the malformed-start branch.
+                workId = "",
+                playsSpeech = false,
+                deliveringWantsForeground = false,
+            ).apply { removeExtra(ScheduledDeliveryService.EXTRA_WORK_ID) },
+        )
+
+        ScheduledDeliveryService.isHoldingForegroundFor(randomId) shouldBe false
+        controller.destroy()
+    }
+
+    @Test
+    fun `start with valid workId stamps owner`() {
+        val workId = UUID.randomUUID()
+        val controller = startedServiceFor(
+            ScheduledDeliveryService.intent(
+                context = context,
+                period = ForecastPeriod.TODAY,
+                workId = workId.toString(),
+                playsSpeech = false,
+                deliveringWantsForeground = false,
+            ),
+        )
+
+        ScheduledDeliveryService.isHoldingForegroundFor(workId) shouldBe true
+        ScheduledDeliveryService.isHoldingForegroundFor(UUID.randomUUID()) shouldBe false
+        controller.destroy()
+    }
+
+    @Test
+    fun `same workId arriving twice is idempotent`() {
+        val workId = UUID.randomUUID()
+        val intent = ScheduledDeliveryService.intent(
+            context = context,
+            period = ForecastPeriod.TODAY,
+            workId = workId.toString(),
+            playsSpeech = false,
+            deliveringWantsForeground = false,
+        )
+        val controller = ServiceController.of(ScheduledDeliveryService(), intent)
+            .create()
+            .startCommand(0, 1)
+        ScheduledDeliveryService.isHoldingForegroundFor(workId) shouldBe true
+
+        controller.withIntent(intent).startCommand(0, 2)
+        ScheduledDeliveryService.isHoldingForegroundFor(workId) shouldBe true
+
+        controller.destroy()
+    }
+
+    @Test
+    fun `different workId replaces owner in place`() {
+        val oldId = UUID.randomUUID()
+        val newId = UUID.randomUUID()
+        val controller = ServiceController.of(
+            ScheduledDeliveryService(),
+            ScheduledDeliveryService.intent(
+                context = context,
+                period = ForecastPeriod.TODAY,
+                workId = oldId.toString(),
+                playsSpeech = false,
+                deliveringWantsForeground = false,
+            ),
+        ).create().startCommand(0, 1)
+        ScheduledDeliveryService.isHoldingForegroundFor(oldId) shouldBe true
+
+        controller.withIntent(
+            ScheduledDeliveryService.intent(
+                context = context,
+                period = ForecastPeriod.TONIGHT,
+                workId = newId.toString(),
+                playsSpeech = true,
+                deliveringWantsForeground = true,
+            ),
+        ).startCommand(0, 2)
+
+        ScheduledDeliveryService.isHoldingForegroundFor(oldId) shouldBe false
+        ScheduledDeliveryService.isHoldingForegroundFor(newId) shouldBe true
+        controller.destroy()
+    }
+
+    private fun startedServiceFor(intent: Intent): ServiceController<ScheduledDeliveryService> =
+        ServiceController.of(ScheduledDeliveryService(), intent)
+            .create()
+            .startCommand(0, 1)
+}

--- a/app/src/test/kotlin/app/clothescast/diag/TelemetryPrivacyContractTest.kt
+++ b/app/src/test/kotlin/app/clothescast/diag/TelemetryPrivacyContractTest.kt
@@ -25,6 +25,7 @@ class TelemetryPrivacyContractTest {
         "api_call",
         "notification_delivery",
         "daily_refresh",
+        "scheduled_delivery_timeout",
         // The non-voice settings snapshot fans out into one event per Settings
         // page (one combined event would exceed Firebase's 25-param cap); the
         // param-key allowlist below is unchanged — same keys, regrouped.

--- a/app/src/test/kotlin/app/clothescast/notification/InsightNotifierTest.kt
+++ b/app/src/test/kotlin/app/clothescast/notification/InsightNotifierTest.kt
@@ -57,7 +57,7 @@ class InsightNotifierTest {
         posted shouldHaveSize 1
         val n = posted.single()
 
-        n.channelId shouldBe "daily_insight_v1"
+        n.channelId shouldBe "scheduled_insight_v1"
         n.extras.getString(NotificationCompat.EXTRA_TITLE) shouldBe
             context.getString(R.string.notification_daily_insight_title)
         n.extras.getString(NotificationCompat.EXTRA_TEXT) shouldBe "Today will be mild. Wear a t-shirt."

--- a/app/src/test/kotlin/app/clothescast/notification/TonightInsightNotifierTest.kt
+++ b/app/src/test/kotlin/app/clothescast/notification/TonightInsightNotifierTest.kt
@@ -24,8 +24,12 @@ import java.time.Instant
 import java.time.LocalDate
 
 /**
- * Channel routing for the tonight notification: events present → default-importance
- * "with events" channel; empty evening → silent channel + setSilent flag.
+ * Channel routing for the tonight notification: every post lands on the shared
+ * scheduled-insight channel, regardless of whether the evening has events.
+ * Suppression of the empty-evening notification ("only notify on events") is
+ * a worker-level gate now ([DeliveryGates.emptyEveningSkip]), not channel
+ * routing — so when the notifier is called at all, it posts to the same
+ * channel the morning notifier uses.
  */
 @RunWith(AndroidJUnit4::class)
 @Config(sdk = [33])
@@ -45,22 +49,22 @@ class TonightInsightNotifierTest {
     }
 
     @Test
-    fun `tonight insight with events uses the default channel`() {
+    fun `tonight insight with events posts to the shared scheduled channel`() {
         TonightInsightNotifier(context).notify(sampleInsight(hasEvents = true), "Cool tonight. Bring a jacket.")
 
         val n = shadowOf(notificationManager).allNotifications.single()
-        n.channelId shouldBe "tonight_insight_default_v1"
+        n.channelId shouldBe "scheduled_insight_v1"
         n.extras.getString(NotificationCompat.EXTRA_TITLE) shouldBe
             context.getString(R.string.notification_tonight_insight_title)
         n.extras.getString(NotificationCompat.EXTRA_TEXT) shouldBe "Cool tonight. Bring a jacket."
     }
 
     @Test
-    fun `tonight insight without events uses the silent channel`() {
+    fun `tonight insight without events still posts to the shared scheduled channel`() {
         TonightInsightNotifier(context).notify(sampleInsight(hasEvents = false), "Cool tonight.")
 
         val n = shadowOf(notificationManager).allNotifications.single()
-        n.channelId shouldBe "tonight_insight_silent_v1"
+        n.channelId shouldBe "scheduled_insight_v1"
     }
 
     @Test

--- a/app/src/test/kotlin/app/clothescast/work/FetchAndNotifyWorkerTest.kt
+++ b/app/src/test/kotlin/app/clothescast/work/FetchAndNotifyWorkerTest.kt
@@ -325,21 +325,22 @@ class FetchAndNotifyWorkerTest {
     // --- companion enqueue routing --------------------------------------
 
     @Test
-    fun `enqueueOneShot for TODAY enqueues under the daily unique work name`() {
+    fun `enqueueOneShot for TODAY enqueues under the shared scheduled-delivery queue`() {
         FetchAndNotifyWorker.enqueueOneShot(context, period = ForecastPeriod.TODAY)
 
         workInfosFor(FetchAndNotifyWorker.UNIQUE_WORK_NAME).map { it.state } shouldContainExactlyInAnyOrder
             listOf(WorkInfo.State.ENQUEUED)
-        workInfosFor(FetchAndNotifyWorker.UNIQUE_WORK_NAME_TONIGHT) shouldHaveSize 0
     }
 
     @Test
-    fun `enqueueOneShot for TONIGHT enqueues under the tonight unique work name`() {
+    fun `enqueueOneShot for TONIGHT also enqueues under the shared scheduled-delivery queue`() {
+        // Single queue for both periods (REPLACE cancels overlapping runs).
+        // The period the worker is for is carried on the input data, not the
+        // queue name — see FetchAndNotifyWorker.UNIQUE_WORK_NAME.
         FetchAndNotifyWorker.enqueueOneShot(context, period = ForecastPeriod.TONIGHT)
 
-        workInfosFor(FetchAndNotifyWorker.UNIQUE_WORK_NAME_TONIGHT).map { it.state } shouldContainExactlyInAnyOrder
+        workInfosFor(FetchAndNotifyWorker.UNIQUE_WORK_NAME).map { it.state } shouldContainExactlyInAnyOrder
             listOf(WorkInfo.State.ENQUEUED)
-        workInfosFor(FetchAndNotifyWorker.UNIQUE_WORK_NAME) shouldHaveSize 0
     }
 
     @Test
@@ -360,28 +361,26 @@ class FetchAndNotifyWorkerTest {
 
     @Test
     fun `enqueuePlay uses its own unique work queue so it can't block scheduled refreshes`() {
-        // Play sits on UNIQUE_WORK_NAME_PLAY rather than the alarm
-        // queues; otherwise an offline Play tap parked behind the
-        // network constraint would let WorkManager's KEEP policy on
-        // the next alarm fire drop the scheduled morning refresh in
-        // favour of the pending play — the user would wake up to a
-        // stale cached announcement instead of a fresh forecast.
+        // Play sits on UNIQUE_WORK_NAME_PLAY rather than the shared
+        // scheduled-delivery queue; otherwise an offline Play tap parked
+        // behind the network constraint would let WorkManager's REPLACE
+        // policy on the next alarm fire cancel each other — the user
+        // would either lose their Play tap or wake up to a stale cached
+        // announcement.
         FetchAndNotifyWorker.enqueuePlay(context, period = ForecastPeriod.TODAY)
 
         workInfosFor(FetchAndNotifyWorker.UNIQUE_WORK_NAME_PLAY).map { it.state } shouldContainExactlyInAnyOrder
             listOf(WorkInfo.State.ENQUEUED)
         workInfosFor(FetchAndNotifyWorker.UNIQUE_WORK_NAME) shouldHaveSize 0
-        workInfosFor(FetchAndNotifyWorker.UNIQUE_WORK_NAME_TONIGHT) shouldHaveSize 0
     }
 
     @Test
-    fun `enqueuePlay for TONIGHT also lands on the play queue, not the tonight queue`() {
+    fun `enqueuePlay for TONIGHT also lands on the play queue`() {
         FetchAndNotifyWorker.enqueuePlay(context, period = ForecastPeriod.TONIGHT)
 
         workInfosFor(FetchAndNotifyWorker.UNIQUE_WORK_NAME_PLAY).map { it.state } shouldContainExactlyInAnyOrder
             listOf(WorkInfo.State.ENQUEUED)
         workInfosFor(FetchAndNotifyWorker.UNIQUE_WORK_NAME) shouldHaveSize 0
-        workInfosFor(FetchAndNotifyWorker.UNIQUE_WORK_NAME_TONIGHT) shouldHaveSize 0
     }
 
     @Test
@@ -474,11 +473,10 @@ class FetchAndNotifyWorkerTest {
     private fun workInfosFor(name: String): List<WorkInfo> =
         WorkManager.getInstance(context).getWorkInfosForUniqueWork(name).get()
 
-    // The two observed refresh queues the Today banner watches; the cache-only
-    // recovery lands on whichever matches the current schedule window.
+    // The observed refresh queue the Today banner watches; the cache-only
+    // recovery lands here regardless of which schedule window's current.
     private fun observedRefreshWorkInfos(): List<WorkInfo> =
-        workInfosFor(FetchAndNotifyWorker.UNIQUE_WORK_NAME) +
-            workInfosFor(FetchAndNotifyWorker.UNIQUE_WORK_NAME_TONIGHT)
+        workInfosFor(FetchAndNotifyWorker.UNIQUE_WORK_NAME)
 
     // Every queue a cache-only recovery could plausibly enqueue on — used to
     // assert the branch *didn't* kick one.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -136,6 +136,16 @@ Done:
 
 Open:
 
+- [ ] **Publish a calendar-events MQTT topic.** Tonight's
+      `tonightNotifyOnlyOnEvents` skips the phone-side delivery on
+      event-free evenings, but we still publish MQTT so Home Assistant
+      automations can read fresh data unconditionally. Right now HA can
+      only see the insight prose — it can't tell *why* the phone stayed
+      quiet, so the automation has to guess from prose text whether the
+      evening had events. Publish a boolean / count under e.g.
+      `clothescast/<topic>/tonight/has_events` (and possibly `event_count`)
+      so HA can decide its own trigger logic — play the cast on event
+      nights, stay quiet otherwise, etc. — without us pre-deciding for it.
 - [ ] **Music Assistant `mass.announce` quick-start in the setup
       guide.** docs/smart-home.md now describes the three speaking
       options at a high level, but for users picking Option B the
@@ -183,7 +193,9 @@ PRIVACY.md and is mirrored inline in the Settings → Privacy card.
 
 Live events: `api_call` (endpoint, outcome, status, latency;
 offline-filtered), `notification_delivery` (slot, alarm delay, total
-delay), `daily_refresh` (slot, outcome, latency), the non-voice
+delay), `daily_refresh` (slot, outcome, latency),
+`scheduled_delivery_timeout` (slot — fires when the FGS shepherd's
+pre-RUNNING 5-min cap kicks in because the worker stayed queued), the non-voice
 configuration split into one event per Settings page (`settings_schedule`
 / `settings_clothes` / `settings_format` / `settings_region` /
 `settings_display` / `settings_calendar` — one combined event would
@@ -195,6 +207,18 @@ small set since Firebase caps custom user properties at 25 per app.
 
 Open work:
 
+- [ ] **Route caught non-crash errors to Crashlytics.** Crashes already
+      flow via `FirebaseCrashlytics`, but the long tail of caught
+      exceptions logged through `DiagLog.e` / `.w` only lands in the
+      on-device diag file. Routing them through
+      `FirebaseCrashlytics.recordException` would surface real-world
+      failure modes (network outages, parsing errors, TTS synth failures)
+      without waiting for a crashing fork. The privacy work is the gating
+      cost: log strings are free-form and can contain prose / locations /
+      keys, so we'd need an audit + filtering layer (or a structured
+      replacement for the free-form messages) before piping them through.
+      PRIVACY.md → "Analytics and crash reporting" lists the hard
+      do-not-transmit set.
 - [x] **Codify the do-not-transmit list in tests.** `TelemetryPrivacyContractTest`
       structurally locks the surface: event-name / param-key / user-property
       allowlists in `Telemetry.kt`, literal-only Crashlytics custom keys, no

--- a/docs/schedule-lifecycle.md
+++ b/docs/schedule-lifecycle.md
@@ -1,0 +1,292 @@
+# Schedule lifecycle — alarm to delivery
+
+What happens between the exact alarm firing and the forecast landing in the
+user's notification shade. Read this before changing `AlarmReceiver`,
+`ScheduledDeliveryService`, or the `setForeground` / FGS handling inside
+`FetchAndNotifyWorker` — the moving parts span four classes and the
+manifest, and the failure modes are subtle.
+
+## What the user sees
+
+| Stage | User-visible notification | Notification id | Channel | FGS type |
+|---|---|---|---|---|
+| Preparing | "Preparing your ClothesCast" (silent, ongoing) | 1005 | `playback_v2` | `mediaPlayback` if speech plays, else `dataSync` |
+| Delivering — speech / MQTT / cast | "Delivering your ClothesCast" (silent, ongoing) | 1005 | `playback_v2` | `mediaPlayback` if speech plays, else `dataSync` |
+| Delivered — notification-only mode | The forecast notification | 1001 (daily) / 1003 (tonight) | `daily_insight_v1` / `tonight_insight_*_v1` | n/a |
+| Delivered — speech / MQTT / cast | "Delivering" + the forecast notification together, then "Delivering" disappears when the run completes | 1005 + 1001/1003 | both | `mediaPlayback` / `dataSync` |
+
+There is one transient overlap on the speech path: the "Delivering" service
+notification and the forecast notification sit side-by-side while the run
+completes. That's deliberate — they communicate different things ("audio is
+playing now" vs. "here is today's outfit") — and lasts at most a few seconds.
+The notification-only path has no overlap.
+
+`SILENT` delivery (no notification, no audio, no MQTT, no cast) shows *no*
+notification at all — see [SILENT skips the Service](#silent-skips-the-service)
+below.
+
+## The components
+
+```
+┌──────────────────┐  exact alarm fires
+│  AlarmManager    │ ─────────────────────────┐
+└──────────────────┘                          ▼
+                                  ┌──────────────────────┐
+                                  │   AlarmReceiver       │
+                                  │  (BroadcastReceiver)  │
+                                  └──────────┬────────────┘
+                          enqueueOneShot ┌───┴───┐ startForegroundService
+                                         │       │      (only when the
+                                         ▼       ▼       run needs an FGS
+              ┌──────────────────────────┐ ┌─────────────  surface)
+              │   FetchAndNotifyWorker   │ │ ScheduledDelivery
+              │   (WorkManager worker)   │ │  Service (FGS)
+              └──────────────────────────┘ └────────┬─────┘
+                          ▲                         │
+                          └──── watches by UUID ────┘
+```
+
+`AlarmReceiver` reads preferences once, then routes:
+
+1. **Slot disabled** → cancel the alarm, do nothing else.
+2. **`SILENT` delivery, no MQTT, no cast** → enqueue the worker, re-arm. No
+   Service, no FGS notification.
+3. **Otherwise** → enqueue the worker, re-arm, and (best-effort) start the
+   Service to watch that worker's specific UUID. The Service owns only the
+   FGS notification; it does not enqueue the worker or re-arm.
+
+`FetchAndNotifyWorker` does the fetch, insight, notification post, TTS /
+MQTT / cast fan-out. When the Service is shepherding the run, the worker's
+own `promoteToPlaybackServiceIfNeeded` skips its `setForeground` because the
+Service is already holding notification id 1005 — see
+[Owner gate](#owner-gate-foreground-id-1005) below.
+
+## States
+
+The Service is a small state machine driven by the WorkInfo flow for the
+specific worker UUID `AlarmReceiver` handed it.
+
+### `PREPARING`
+
+Entered when the Service is started by the receiver. The Service:
+
+1. Reads the worker UUID and the mode flags (`playsSpeech`,
+   `deliveringWantsForeground`) from the intent extras the receiver stamped.
+2. Calls `startForeground(1005, prepareNotification, FOREGROUND_SERVICE_TYPE_DATA_SYNC)`
+   and flips the process-local `isHoldingForeground` flag to `true`.
+3. Subscribes to `WorkManager.getWorkInfoByIdFlow(workId)` — the specific
+   request the receiver enqueued, not the unique-work-name flow (which can
+   surface stale terminal rows from yesterday's run and tear the Service
+   down immediately).
+
+`dataSync` is the right type for "the app is fetching forecast data in the
+background", and it doesn't carry the `mediaPlayback` audio-focus implications
+we don't need until speech actually starts.
+
+### `DELIVERING` (only if speech / MQTT / cast)
+
+Entered when the WorkInfo for this run reports `KEY_FETCH_COMPLETE=true` in
+its progress data — the worker has finished fetch + insight generation and
+is about to start the deliver fan-out. The Service swaps to the "Delivering"
+notification with the appropriate FGS type:
+
+- if `playsSpeech` is true, call
+  `startForeground(1005, deliverNotification, FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK)`.
+  Audio focus on Android 15+ requires the process to be hosting an FGS of
+  type `mediaPlayback` while it plays.
+- else (MQTT bridge or cast only), call
+  `startForeground(1005, deliverNotification, FOREGROUND_SERVICE_TYPE_DATA_SYNC)`.
+  No audio focus to claim, just keep the user informed that the run is still
+  publishing.
+
+Either path replaces the "Preparing" content with "Delivering" in place —
+same notification id, same channel, no transient gap.
+
+### Notification-only path — skip `DELIVERING`
+
+When the period's delivery mode is `NOTIFICATION_ONLY` *and* MQTT *and* cast
+are both off, the Service stays in `PREPARING` for the whole worker run. The
+forecast notification posts (under id 1001 / 1003 via `InsightNotifier`), the
+worker reaches terminal state, and the Service tears down.
+
+The brief "Preparing" notification is visible from alarm-fire through the
+forecast post. That's the trade discussed in the design — confirmation that
+the schedule fired vs. a flash of a placeholder when the run is fast.
+
+### `DONE`
+
+Entered when the WorkInfo reports any terminal state (`SUCCEEDED`, `FAILED`,
+`CANCELLED`) or when the Service hits its safety timeout (5 min). The Service
+calls `stopForeground(STOP_FOREGROUND_REMOVE)`, flips
+`isHoldingForeground` back to `false`, and `stopSelf()`. The forecast
+notification (id 1001 / 1003) — if posted — stays in the shade.
+
+## SILENT skips the Service
+
+`DeliveryMode.SILENT` documents the contract "the worker still runs (fetch,
+cache, insight generation, widget refresh), but nothing is surfaced to the
+user." Posting a "Preparing" foreground-service notification across the
+whole run would regress that. So `AlarmReceiver` short-circuits before the
+Service start: when the period's delivery mode is `SILENT` *and* the MQTT
+bridge is off *and* casting is off for this period, the receiver enqueues
+the worker and re-arms without ever calling `startForegroundService`. No
+FGS, no notification.
+
+The worker's `promoteToPlaybackServiceIfNeeded` is also a no-op on this
+path — the early-out reads the SILENT mode and skips before any
+`setForeground` would fire.
+
+## Owner gate: foreground id 1005
+
+`FOREGROUND_NOTIFICATION_ID = 1005` is shared between
+`ScheduledDeliveryService` (primary FGS owner for alarm-driven runs) and
+`FetchAndNotifyWorker.promoteToPlaybackServiceIfNeeded` (fallback FGS owner,
+also used by the non-alarm Play path). Only one process component can hold
+a given FGS notification id at a time, so the worker must skip its
+`setForeground` while the Service has the id.
+
+The gate is a per-worker UUID on `ScheduledDeliveryService.Companion`:
+
+- Stamped with the worker's UUID immediately after a successful
+  `startForeground` in the Service.
+- Reset to `null` in the Service's `teardown` and `onDestroy`.
+- Read by the worker's `promoteToPlaybackServiceIfNeeded` via
+  `isHoldingForegroundFor(id)` — if the gate matches the worker's own
+  UUID, skip. Otherwise promote itself.
+
+A per-worker gate (not a process-wide bool) is what correctly handles the
+corner cases:
+
+- **Service safety timeout fires before the worker gets to run.** Service
+  exits → gate clears → when the worker eventually runs (network returns),
+  `promoteToPlaybackServiceIfNeeded` sees no match and promotes itself.
+  Background TTS audio still works on Android 15+.
+- **Process restart between Service start and worker execution.** Gate is
+  per-process and resets to `null` on a fresh process. Worker promotes
+  itself. Same outcome.
+- **Receiver couldn't start the Service** (background-restricted, lapsed
+  exemption window, OEM quirk). Service never stamped the gate. Worker
+  promotes itself. The pre-Service experience.
+- **Overlapping runs** — second alarm fires (e.g. evening) while we're
+  still shepherding the first (morning TTS still mid-flight). The second
+  `onStartCommand` is rejected by the "already shepherding a different
+  workId" guard; the second worker's `isHoldingForegroundFor(id)` returns
+  false (different UUID) and it promotes itself via its own setForeground
+  path. The first worker stays correctly under the Service's wing.
+
+## One queue, `REPLACE`, cancel-on-new-alarm
+
+Both TODAY and TONIGHT scheduled runs share a single unique-work queue
+(`FetchAndNotifyWorker.UNIQUE_WORK_NAME`). Combined with
+`ExistingWorkPolicy.REPLACE`, a new alarm fire — regardless of which slot it
+fires for — cancels any in-flight previous run, including the *other*
+slot's. The semantics: only one scheduled-delivery worker is ever alive at
+a time. The period each run is for travels on the WorkInfo's input data
+(`KEY_PERIOD`), not the queue name, so observers like the Today and
+Schedule view-models read it there when they need to know which slot is
+running.
+
+Always-REPLACE also means `request.id` is always the id WorkManager kept,
+so the receiver gets the right UUID to hand to the Service without any
+read-back-after-enqueue dance.
+
+On the Service side, a new `onStartCommand` with a different `workId`
+cancels the in-flight watcher coroutine and re-enters `startForeground` in
+place (same notification id, content updates atomically) for the new
+`workId`. The old worker has already been canceled at the WorkManager
+layer by REPLACE, so it never reaches another promotion check.
+
+## Fallback
+
+`AlarmReceiver` calls `ContextCompat.startForegroundService` and treats both
+the exception path *and* a null `ComponentName` return as failure. On
+failure, it logs and continues — the worker was already enqueued and runs
+without the Service shepherding it. The worker's
+`promoteToPlaybackServiceIfNeeded` then handles the speech-window FGS via
+the owner-gate mechanism above — same as before the Service existed.
+Worst-case the user gets the pre-Service experience, never nothing.
+
+## When the Service is *not* involved
+
+- **`SILENT` delivery (no MQTT, no cast).** Receiver short-circuits as above.
+- **Manual `Play now`** (Today screen Play button, Schedule preview buttons).
+  Routes through `enqueuePlay` directly, not the alarm receiver. The user is
+  in the app — flashing "Preparing your ClothesCast" at them is redundant
+  noise. The worker's own `setForeground` continues to handle the speech
+  window on this path because the Play queue (`UNIQUE_WORK_NAME_PLAY`)
+  doesn't go through `AlarmReceiver`, and `isHoldingForeground()` is `false`
+  for the Play run.
+- **Silent refresh** (app-open opportunistic, onboarding, manual Refresh).
+  `KEY_SILENT_REFRESH=true` means no notification / TTS / MQTT / cast at all.
+  No FGS needed; the Worker runs at normal priority.
+- **Location-cache refresh** (device-location toggle on). Network-only side
+  effect, no delivery pipeline.
+
+## Manifest
+
+Three permissions are required:
+
+- `FOREGROUND_SERVICE` — base permission for any FGS (already declared).
+- `FOREGROUND_SERVICE_DATA_SYNC` — the `dataSync` type used in `PREPARING`
+  and in the no-speech `DELIVERING` path.
+- `FOREGROUND_SERVICE_MEDIA_PLAYBACK` — the `mediaPlayback` type used in the
+  speech `DELIVERING` path (already declared for the Worker's fallback FGS).
+
+All three `FOREGROUND_SERVICE*` permissions are normal-level: auto-granted at
+install, no runtime prompt.
+
+The Service declaration in `AndroidManifest.xml` carries the union of the
+two types it ever runs with:
+
+```xml
+<service
+    android:name=".alarm.ScheduledDeliveryService"
+    android:exported="false"
+    android:foregroundServiceType="dataSync|mediaPlayback" />
+```
+
+## Failure modes the design has to absorb
+
+- **Worker never starts.** `NetworkType.CONNECTED` constraint on the Worker
+  means a no-network device defers the run indefinitely. The Service's
+  **pre-RUNNING 5-minute cap** triggers and the Service exits (`isHoldingForegroundFor`
+  returns false for the workId from then on). The Worker stays queued and
+  runs when connectivity returns; the owner gate then lets it promote itself
+  for the speech window. The cap deliberately does *not* apply once the
+  worker reaches `RUNNING` — TTS + cast + delivery alignment can legitimately
+  run several minutes, and WorkManager's own ~10-minute foreground-worker
+  cap is the upper bound there. Racing those two caps was the previous
+  risk; the phase split eliminates it.
+- **Stale terminal WorkInfo for the same unique work name.** The Service
+  watches `getWorkInfoByIdFlow(workId)` — the specific UUID the receiver
+  enqueued — not the unique-work-name flow. Yesterday's `SUCCEEDED` row for
+  the same queue has a different UUID and never trips this Service.
+- **Worker is canceled mid-run.** `CANCELLED` is a terminal state, so the
+  flow collector trips the `DONE` transition and the Service tears down
+  cleanly.
+- **Worker fails / retries.** Each `setForeground` is idempotent on the same
+  id — the Service updates the notification in place across retries. The
+  Worker's WorkManager-side backoff is unchanged.
+- **Process killed mid-`DELIVERING`.** The FGS notification disappears with
+  the process; `isHoldingForeground` resets to `false` on the new process so
+  a future worker resumption can promote itself.
+- **User dismisses the "Preparing" / "Delivering" notification.** Both are
+  `ongoing` — system suppresses the swipe-to-dismiss. The user can still
+  block the channel from Settings, which would suppress the notification
+  but leave the FGS running.
+
+## Why a `Service` and not just the Worker's existing FGS
+
+The Worker's `setForeground` already covers the speech window — it's been
+shipping for months. The Service exists because the speech window is too
+late to be useful as a "the schedule fired" signal: by the time the Worker
+gets to `setForeground` it's already past fetch + insight, and on the
+notification-only path it doesn't fire at all. The Service brings the FGS
+forward to the alarm-fire instant so the user gets one consistent affordance
+("ClothesCast is working on it") for every delivery mode that opted in to a
+visible surface.
+
+It also moves the FGS owner out of WorkManager's `SystemForegroundService`
+on the primary path: WorkManager keeps its `mediaPlayback` declaration for
+the fallback (worker-self-promotion) path, and the new Service owns the
+`dataSync|mediaPlayback` declaration for the primary path.


### PR DESCRIPTION
## Summary

Surface a silent "Preparing your ClothesCast" foreground-service notification the instant an alarm fires, so the user has visible confirmation the schedule went off — even on the days Open-Meteo or Gemini take 5–15s. When the period plays speech (or publishes via MQTT / cast), it swaps in place to "Delivering your ClothesCast" while the run finishes, then disappears. Notification-only deliveries skip the Delivering swap; the Preparing notification stays up right through to the forecast post.

```
PREPARING ("Preparing your ClothesCast", dataSync FGS, id 1005)
  ↓ worker stamps KEY_FETCH_COMPLETE
DELIVERING ("Delivering your ClothesCast", mediaPlayback FGS if speech
            plays, else dataSync) — only when period speaks / casts /
            publishes via MQTT
  ↓ worker reaches terminal state
DONE — service stops, forecast notification stays in the shade
```

`SILENT` delivery with no MQTT and no cast skips the Service entirely — the user opted out of every visible surface, and the worker runs as a normal background WorkRequest with no FGS notification.

## What changed

- **New `ScheduledDeliveryService`** — owns the FGS notification end-to-end, watches the specific worker's UUID (`getWorkInfoByIdFlow`) so stale terminal rows from yesterday's run on the same unique-work queue can't tear it down prematurely. Safety timeout of 5 min caps how long Preparing can sit if the worker never starts (e.g. network constraint defers it).
- **`AlarmReceiver`** — reads preferences once and routes:
  - slot disabled → cancel the alarm, do nothing else;
  - `SILENT` + no MQTT + no cast → enqueue worker, re-arm, no Service;
  - otherwise → enqueue worker, re-arm, best-effort start the Service with the worker's UUID. Catches both the exception path *and* a null `ComponentName` return from `startForegroundService`; either way, the worker still runs (no "never nothing" regression).
- **`FetchAndNotifyWorker`** — `enqueueOneShot` now returns the request's UUID. The `KEY_SERVICE_HOLDS_FGS` persisted flag is gone; instead the worker's `promoteToPlaybackServiceIfNeeded` reads `ScheduledDeliveryService.isHoldingForeground()` — a process-local owner gate that handles the corner cases the persisted flag couldn't: Service safety-timeout while the worker is still ENQUEUED, process restart between Service start and worker execution, Service start the receiver couldn't reach. In all three the worker correctly promotes itself.
- **Manifest** — adds `FOREGROUND_SERVICE_DATA_SYNC` permission (normal-level, auto-granted) and declares the Service with `foregroundServiceType="dataSync|mediaPlayback"`.
- **`docs/schedule-lifecycle.md`** — full state machine, the SILENT short-circuit, the owner-gate mechanism, fallback rules, and failure modes the design absorbs.
- **Channel rename** — `playback_v1` is now used for the whole scheduled-delivery lifecycle, not just speech, so the user-facing channel name went from "Speaking the forecast" to "Scheduled ClothesCast delivery".

## Privacy

No change to what crosses the device boundary. Both new strings are static UI copy; no user content (location, calendar events, insight prose) appears in the FGS notification.

## Test plan

- [x] `:core:domain:test :core:data:test :app:testDebugUnitTest` green locally
- [x] `:app:assembleDebug` green locally
- [x] `AlarmReceiverErrorHandlingTest` (prefs-failure → worker fallback) still passes — the receiver's catch block still runs for TODAY when prefs read fails
- [ ] Manual: scheduled delivery in `NOTIFICATION_ONLY` mode shows only "Preparing" then the forecast (no Delivering swap)
- [ ] Manual: scheduled delivery in `NOTIFICATION_AND_TTS` mode shows Preparing → Delivering, audio plays, both clear when run completes
- [ ] Manual: scheduled delivery in `SILENT` mode + no MQTT + no cast shows *no* FGS notification at all; widget refreshes
- [ ] Manual: scheduled delivery in `SILENT` + MQTT enabled shows the FGS notification (Preparing → Delivering via dataSync, no audio focus)
- [ ] Manual: "Play now" from Today screen and Schedule settings does NOT show Preparing/Delivering (Service is bypassed for the manual path)
- [ ] Manual: airplane mode at alarm time → Preparing stays up; worker defers on `NetworkType.CONNECTED`; 5-min safety timeout removes Preparing; when connectivity returns, worker runs and `promoteToPlaybackServiceIfNeeded` correctly promotes itself for speech
- [ ] Manual: toggle a slot off after the alarm is armed → next fire cancels the alarm, no Service, no notification