### PR TITLE
Drop two upgrade-path migrations that have run their course

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ClothesCastApplication.kt
+++ b/app/src/main/kotlin/app/clothescast/ClothesCastApplication.kt
@@ -330,15 +330,6 @@ class ClothesCastApplication : Application() {
         // builds, see [castContext] above).
         castInsightController?.bind()
         applicationScope.launch {
-            // One-shot wipe of the home-pin coordinates that the now-removed
-            // GPS-based at-home gate used to persist. Runs every launch but
-            // is idempotent — removes by key name and no-ops when absent —
-            // so the cost on fresh installs / repeat runs is one DataStore
-            // edit's worth of disk I/O.
-            runCatching { settingsRepository.clearLegacyHomePreferences() }
-                .onFailure { DiagLog.w(TAG, "Legacy home-pref cleanup failed", it) }
-        }
-        applicationScope.launch {
             try {
                 val prefs = settingsRepository.preferences.first()
                 // Reconcile Locale.setDefault (process-scoped, lost on cold

--- a/app/src/main/kotlin/app/clothescast/data/SettingsRepository.kt
+++ b/app/src/main/kotlin/app/clothescast/data/SettingsRepository.kt
@@ -159,28 +159,6 @@ class SettingsRepository(
         dataStore.edit { it[BUG_REPORT_CONSENT_ACKED] = acked }
     }
 
-    /**
-     * One-shot cleanup of preference keys that backed the GPS-based at-home
-     * TTS gate before it was retired. The gate is gone (the MQTT- and
-     * Cast-success based "Skip phone speech…" toggles cover the same use
-     * case without a stored home pin), but a user who'd configured a home
-     * still has their coordinates sitting on disk from the previous build.
-     * Run at app start so that data is gone the first time the upgraded
-     * build reaches the launcher.
-     *
-     * Idempotent: removes by key name, no-ops when the keys are absent
-     * (fresh installs, repeat runs).
-     */
-    suspend fun clearLegacyHomePreferences() {
-        dataStore.edit { prefs ->
-            prefs.remove(doublePreferencesKey("home_latitude"))
-            prefs.remove(doublePreferencesKey("home_longitude"))
-            prefs.remove(stringPreferencesKey("home_display_name"))
-            prefs.remove(stringPreferencesKey("home_country_code"))
-            prefs.remove(booleanPreferencesKey("skip_tts_at_home"))
-        }
-    }
-
     suspend fun setSchedule(time: LocalTime, days: Set<DayOfWeek>) {
         require(days.isNotEmpty()) { "Schedule must include at least one day" }
         dataStore.edit { prefs ->

--- a/app/src/main/kotlin/app/clothescast/notification/NotificationChannelRegistrar.kt
+++ b/app/src/main/kotlin/app/clothescast/notification/NotificationChannelRegistrar.kt
@@ -24,7 +24,6 @@ internal const val CHANNEL_PLAYBACK = "playback_v2"
 // leaves the dead channel in system notification settings for existing
 // installs. deleteNotificationChannel is a no-op when the ID was never
 // registered (fresh installs), so this is safe to call unconditionally.
-private const val CHANNEL_WEATHER_ALERTS_RETIRED = "weather_alerts_v1"
 // Pre-collapse forecast channels. The three of them — morning (HIGH), evening-
 // with-events (DEFAULT), evening-empty (LOW silent) — were replaced by the
 // single DEFAULT-importance CHANNEL_SCHEDULED_INSIGHT above. The
@@ -79,7 +78,6 @@ object NotificationChannelRegistrar {
         // silence morning forecasts too, which they never asked for.
         // Users who want to mute the new channel can do so in system
         // notification settings.
-        manager.deleteNotificationChannel(CHANNEL_WEATHER_ALERTS_RETIRED)
         manager.deleteNotificationChannel(CHANNEL_DAILY_INSIGHT_RETIRED_V1)
         manager.deleteNotificationChannel(CHANNEL_DAILY_INSIGHT_RETIRED_V2)
         manager.deleteNotificationChannel(CHANNEL_TONIGHT_INSIGHT_DEFAULT_RETIRED)


### PR DESCRIPTION
## Summary

Drop two upgrade-path migrations that have been live for >2 weeks across all internal-testing builds. Every existing install has long since run them, so the keys / channel are gone from their devices and these calls are now permanent no-ops on the cold start hot path.

## What's removed

- **`weather_alerts_v1` notification channel delete** — added 2026-06-01 (`4b9f9aa8` "Remove the non-working weather alerts feature"). ~20 days live. The retired severe-weather-alerts channel has been removed from every install that ever registered it.
- **`SettingsRepository.clearLegacyHomePreferences()`** + its `Application.onCreate` caller — added 2026-05-26 (`ae26ceab` "Drop the GPS-based at-home TTS gate"). ~25 days live. Wiped the five DataStore keys (`home_latitude`/`longitude`/`display_name`/`country_code`, `skip_tts_at_home`) from upgraders. Skip-phone-speech on MQTT/cast success covers the same UX.

## What's kept

Other migrations are too recent and stay:
- `InsightCache.legacyKeyFor` — 11 days. Forecast-cache survival across the rename.
- `LEGACY_ECMWF_IFS04_NAME` in `SettingsRepository` — 13 days. Pre-0.25° ECMWF model-id forward-migration.
- All channel-ID deletes and the `tonight_insight_fetch` queue cancel from #1046 — landed today.

## Privacy

No change to what crosses the device boundary. Pure on-device cleanup removal.

## Test plan

- [x] `:core:domain:test :core:data:test :app:testDebugUnitTest` green locally
- [x] `:app:assembleDebug` green locally
- [ ] Manual: cold launch on a build that previously had the GPS at-home config — confirm no crash and that there's nothing on disk now to clean (the previous build already did it)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GDuTd2sTYEYTrntVLtBz6t)_