### PR TITLE
Drop stale notification channel translations

### DIFF
--- a/app/src/main/res/values-am/strings.xml
+++ b/app/src/main/res/values-am/strings.xml
@@ -354,13 +354,7 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="bug_report_consent_cancel">ሰርዝ</string>
 
     <!-- Notifications -->
-    <string name="notification_channel_daily_insight_name">ዕለታዊ ClothesCast</string>
-    <string name="notification_channel_daily_insight_description">የጠዋቱ የአየር ሁኔታ ማጠቃለያ ለምን ተመዘገቡ።</string>
     <string name="notification_daily_insight_title">የዛሬ ClothesCast</string>
-    <string name="notification_channel_tonight_insight_default_name">ምሽታዊ ClothesCast (ዝግጅቶች ሲኖሩ)</string>
-    <string name="notification_channel_tonight_insight_default_description">ዛሬ ምሽት የቀን መቁጠሪያ ዝግጅቶቻቸው ሲኖሩ የምሽቱ የአየር ሁኔታ ማጠቃለያ።</string>
-    <string name="notification_channel_tonight_insight_silent_name">ምሽታዊ ClothesCast (ዝምታ)</string>
-    <string name="notification_channel_tonight_insight_silent_description">ምሽቱ ጸጥ ሲሆን የምሽቱ የአየር ሁኔታ ማጠቃለያ። ዝምታ ሆኖ ይለጠፋል።</string>
     <string name="notification_tonight_insight_title">የዛሬ ምሽት ClothesCast</string>
 
     <!-- Insight prose -->

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -413,13 +413,7 @@ they work correctly in both the single-band and range templates.
     <string name="garment_polo">بولو</string>
 
     <!-- Notification channels and content -->
-    <string name="notification_channel_daily_insight_name">ClothesCast اليومي</string>
-    <string name="notification_channel_daily_insight_description">ملخص الطقس الصباحي الذي اشتركت فيه.</string>
     <string name="notification_daily_insight_title">ClothesCast اليوم</string>
-    <string name="notification_channel_tonight_insight_default_name">ClothesCast الليلي (مع الأحداث)</string>
-    <string name="notification_channel_tonight_insight_default_description">ملخص الطقس المسائي عند وجود أحداث تقويم الليلة.</string>
-    <string name="notification_channel_tonight_insight_silent_name">ClothesCast الليلي (صامت)</string>
-    <string name="notification_channel_tonight_insight_silent_description">ملخص الطقس المسائي في المساء الهادئ. يُرسَل صامتًا.</string>
     <string name="notification_tonight_insight_title">ClothesCast الليلة</string>
 
     <!-- Settings — notification permission -->

--- a/app/src/main/res/values-b+sr+Cyrl/strings.xml
+++ b/app/src/main/res/values-b+sr+Cyrl/strings.xml
@@ -362,14 +362,8 @@ surfaces.
     <string name="settings_tts_voice_locale_am_et">Амхарски (Етиопија)</string>
 
     <!-- Notification channels. -->
-    <string name="notification_channel_daily_insight_name">Дневни ClothesCast</string>
-    <string name="notification_channel_daily_insight_description">Јутарњи временски резиме који си укључио.</string>
     <string name="notification_daily_insight_title">Данашњи ClothesCast</string>
 
-    <string name="notification_channel_tonight_insight_default_name">Ноћни ClothesCast (са догађајима)</string>
-    <string name="notification_channel_tonight_insight_default_description">Вечерњи временски резиме када вечерас имаш догађаје у календару. Репродукује твој подразумевани звук обавештења.</string>
-    <string name="notification_channel_tonight_insight_silent_name">Ноћни ClothesCast (тихи)</string>
-    <string name="notification_channel_tonight_insight_silent_description">Вечерњи временски резиме када ти је вечер слободна. Шаље се тихо — можеш да га погледаш на закључаном екрану, али неће репродуковати звук.</string>
     <string name="notification_tonight_insight_title">Вечерашњи ClothesCast</string>
 
 

--- a/app/src/main/res/values-b+sr+Latn/strings.xml
+++ b/app/src/main/res/values-b+sr+Latn/strings.xml
@@ -374,14 +374,8 @@ default English (matching values-pl / values-uk).
     <string name="settings_tts_voice_locale_am_et">Amharski (Etiopija)</string>
 
     <!-- Notification channels. -->
-    <string name="notification_channel_daily_insight_name">Dnevni ClothesCast</string>
-    <string name="notification_channel_daily_insight_description">Jutarnji vremenski rezime koji si uključio.</string>
     <string name="notification_daily_insight_title">Današnji ClothesCast</string>
 
-    <string name="notification_channel_tonight_insight_default_name">Noćni ClothesCast (sa događajima)</string>
-    <string name="notification_channel_tonight_insight_default_description">Večernji vremenski rezime kada večeras imaš događaje u kalendaru. Reprodukuje tvoj podrazumevani zvuk obaveštenja.</string>
-    <string name="notification_channel_tonight_insight_silent_name">Noćni ClothesCast (tihi)</string>
-    <string name="notification_channel_tonight_insight_silent_description">Večernji vremenski rezime kada ti je večer slobodna. Šalje se tiho — možeš da ga pogledaš na zaključanom ekranu, ali neće reprodukovati zvuk.</string>
     <string name="notification_tonight_insight_title">Večerašnji ClothesCast</string>
 
 

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -544,13 +544,7 @@ What is NOT overridden, by design:
     <string name="settings_tts_voice_locale_am_et">Амхарски (Етиопия)</string>
 
     <!-- Notification channels. -->
-    <string name="notification_channel_daily_insight_name">Дневен ClothesCast</string>
-    <string name="notification_channel_daily_insight_description">Сутрешното резюме на времето, което си активирал.</string>
     <string name="notification_daily_insight_title">Днешният ClothesCast</string>
-    <string name="notification_channel_tonight_insight_default_name">Нощен ClothesCast (със събития)</string>
-    <string name="notification_channel_tonight_insight_default_description">Вечерното резюме на времето, когато имаш събития в календара тази вечер. Пуска стандартния звук за известие.</string>
-    <string name="notification_channel_tonight_insight_silent_name">Нощен ClothesCast (тих)</string>
-    <string name="notification_channel_tonight_insight_silent_description">Вечерното резюме на времето, когато вечерта е спокойна. Публикува се тихо — можеш да го видиш на заключения екран, но няма да издаде звук.</string>
     <string name="notification_tonight_insight_title">Нощният ClothesCast</string>
 
     <!-- Notification permission card. -->

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -625,13 +625,7 @@ West Bengal vocabulary differences in a future PR.
          Notification channels
          ============================================================ -->
 
-    <string name="notification_channel_daily_insight_name">দৈনিক ClothesCast</string>
-    <string name="notification_channel_daily_insight_description">আপনার অপ্ট-ইন করা সকালের আবহাওয়ার সারসংক্ষেপ।</string>
     <string name="notification_daily_insight_title">আজকের ClothesCast</string>
-    <string name="notification_channel_tonight_insight_default_name">রাতের ClothesCast (ইভেন্টসহ)</string>
-    <string name="notification_channel_tonight_insight_default_description">আজ রাতে ক্যালেন্ডার ইভেন্ট থাকলে সন্ধ্যার আবহাওয়ার সারসংক্ষেপ। আপনার ডিফল্ট বিজ্ঞপ্তির শব্দ বাজায়।</string>
-    <string name="notification_channel_tonight_insight_silent_name">রাতের ClothesCast (নীরব)</string>
-    <string name="notification_channel_tonight_insight_silent_description">সন্ধ্যা ফাঁকা থাকলে সন্ধ্যার আবহাওয়ার সারসংক্ষেপ। নীরবে পোস্ট হয় — লক স্ক্রিনে দেখতে পাবেন, কিন্তু কোনো শব্দ করবে না।</string>
     <string name="notification_tonight_insight_title">আজ রাতের ClothesCast</string>
 
     <!-- ============================================================

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -444,14 +444,8 @@ the in-app clock is digit-driven and reads consistently across locales.
     <string name="settings_clothes_cond_temp_above">quan la temperatura percebuda és superior a %1$s</string>
     <string name="settings_clothes_cond_precip_above">quan la probabilitat de pluja supera el %.0f%%</string>
 
-    <string name="notification_channel_daily_insight_name">ClothesCast diari</string>
-    <string name="notification_channel_daily_insight_description">El resum meteorològic matinal al qual t\'has subscrit.</string>
     <string name="notification_daily_insight_title">El temps d\'avui</string>
 
-    <string name="notification_channel_tonight_insight_default_name">ClothesCast nocturn (amb esdeveniments)</string>
-    <string name="notification_channel_tonight_insight_default_description">El resum meteorològic del vespre quan tens esdeveniments al calendari aquesta nit. Reprodueix el so de notificació predeterminat.</string>
-    <string name="notification_channel_tonight_insight_silent_name">ClothesCast nocturn (silenciós)</string>
-    <string name="notification_channel_tonight_insight_silent_description">El resum meteorològic del vespre quan el teu vespre és lliure. S\'envia silenciosament — pots veure\'l a la pantalla de bloqueig, però no fa cap so.</string>
     <string name="notification_tonight_insight_title">El temps d\'aquesta nit</string>
 
 

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -301,14 +301,8 @@ locale (Angličtina (USA), Francouzština (Francie), Němčina (Německo), …).
 
 
     <!-- Notification channels. -->
-    <string name="notification_channel_daily_insight_name">Denní ClothesCast</string>
-    <string name="notification_channel_daily_insight_description">Ranní shrnutí počasí, které jsi aktivoval/a.</string>
     <string name="notification_daily_insight_title">Dnešní počasí</string>
 
-    <string name="notification_channel_tonight_insight_default_name">Noční ClothesCast (s událostmi)</string>
-    <string name="notification_channel_tonight_insight_default_description">Večerní shrnutí počasí, pokud máš dnes večer události. Přehraje tvůj výchozí tón oznámení.</string>
-    <string name="notification_channel_tonight_insight_silent_name">Noční ClothesCast (tichý)</string>
-    <string name="notification_channel_tonight_insight_silent_description">Večerní shrnutí počasí v klidné večery. Doručí se tiše — uvidíš ho na zamykací obrazovce, ale nevydá žádný zvuk.</string>
     <string name="notification_tonight_insight_title">Dnešní večerní počasí</string>
 
 

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -302,14 +302,8 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrig)").
 
 
     <!-- Notification channels. -->
-    <string name="notification_channel_daily_insight_name">Dagligt ClothesCast</string>
-    <string name="notification_channel_daily_insight_description">Den daglige vejropsummering, du har aktiveret.</string>
     <string name="notification_daily_insight_title">Dagens vejr</string>
 
-    <string name="notification_channel_tonight_insight_default_name">Aftenens ClothesCast (med begivenheder)</string>
-    <string name="notification_channel_tonight_insight_default_description">Den aftenvise vejropsummering, når du har begivenheder i aften. Afspiller din standardnotifikationslyd.</string>
-    <string name="notification_channel_tonight_insight_silent_name">Aftenens ClothesCast (stille)</string>
-    <string name="notification_channel_tonight_insight_silent_description">Den aftenvise vejropsummering på rolige aftener. Leveres lydløst — du kan se den på låseskærmen, men den laver ingen lyd.</string>
     <string name="notification_tonight_insight_title">Vejret i aften</string>
 
 

--- a/app/src/main/res/values-de-rAT/strings.xml
+++ b/app/src/main/res/values-de-rAT/strings.xml
@@ -281,14 +281,8 @@ zh-CN) is unchanged; only the displayed label localizes.
     the per-channel notification titles. Three channels: daily, nightly
     (default + silent variants), and weather alerts.
     -->
-    <string name="notification_channel_daily_insight_name">Täglicher ClothesCast</string>
-    <string name="notification_channel_daily_insight_description">Die morgendliche Wetterzusammenfassung, die du aktiviert hast.</string>
     <string name="notification_daily_insight_title">Heutiges Wetter</string>
 
-    <string name="notification_channel_tonight_insight_default_name">Nächtlicher ClothesCast (mit Terminen)</string>
-    <string name="notification_channel_tonight_insight_default_description">Die abendliche Wetterzusammenfassung, wenn du heute Abend Termine hast. Spielt deinen Standard-Benachrichtigungston ab.</string>
-    <string name="notification_channel_tonight_insight_silent_name">Nächtlicher ClothesCast (lautlos)</string>
-    <string name="notification_channel_tonight_insight_silent_description">Die abendliche Wetterzusammenfassung an freien Abenden. Wird lautlos zugestellt — du kannst sie auf dem Sperrbildschirm sehen, sie macht aber keinen Ton.</string>
     <string name="notification_tonight_insight_title">Wetter heute Abend</string>
 
 

--- a/app/src/main/res/values-de-rCH/strings.xml
+++ b/app/src/main/res/values-de-rCH/strings.xml
@@ -286,14 +286,8 @@ zh-CN) is unchanged; only the displayed label localizes.
     the per-channel notification titles. Three channels: daily, nightly
     (default + silent variants), and weather alerts.
     -->
-    <string name="notification_channel_daily_insight_name">Täglicher ClothesCast</string>
-    <string name="notification_channel_daily_insight_description">Die morgendliche Wetterzusammenfassung, die du aktiviert hast.</string>
     <string name="notification_daily_insight_title">Heutiges Wetter</string>
 
-    <string name="notification_channel_tonight_insight_default_name">Nächtlicher ClothesCast (mit Terminen)</string>
-    <string name="notification_channel_tonight_insight_default_description">Die abendliche Wetterzusammenfassung, wenn du heute Abend Termine hast. Spielt deinen Standard-Benachrichtigungston ab.</string>
-    <string name="notification_channel_tonight_insight_silent_name">Nächtlicher ClothesCast (lautlos)</string>
-    <string name="notification_channel_tonight_insight_silent_description">Die abendliche Wetterzusammenfassung an freien Abenden. Wird lautlos zugestellt — du kannst sie auf dem Sperrbildschirm sehen, sie macht aber keinen Ton.</string>
     <string name="notification_tonight_insight_title">Wetter heute Abend</string>
 
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -283,14 +283,8 @@ zh-CN) is unchanged; only the displayed label localizes.
     the per-channel notification titles. Three channels: daily, nightly
     (default + silent variants), and weather alerts.
     -->
-    <string name="notification_channel_daily_insight_name">Täglicher ClothesCast</string>
-    <string name="notification_channel_daily_insight_description">Die morgendliche Wetterzusammenfassung, die du aktiviert hast.</string>
     <string name="notification_daily_insight_title">Heutiges Wetter</string>
 
-    <string name="notification_channel_tonight_insight_default_name">Nächtlicher ClothesCast (mit Terminen)</string>
-    <string name="notification_channel_tonight_insight_default_description">Die abendliche Wetterzusammenfassung, wenn du heute Abend Termine hast. Spielt deinen Standard-Benachrichtigungston ab.</string>
-    <string name="notification_channel_tonight_insight_silent_name">Nächtlicher ClothesCast (lautlos)</string>
-    <string name="notification_channel_tonight_insight_silent_description">Die abendliche Wetterzusammenfassung an freien Abenden. Wird lautlos zugestellt — du kannst sie auf dem Sperrbildschirm sehen, sie macht aber keinen Ton.</string>
     <string name="notification_tonight_insight_title">Wetter heute Abend</string>
 
 

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -321,14 +321,8 @@ zh-CN) is unchanged; only the displayed label localizes.
     and the per-channel notification titles. Three channels: daily,
     nightly (default + silent variants), severe-weather alerts.
     -->
-    <string name="notification_channel_daily_insight_name">Καθημερινός ClothesCast</string>
-    <string name="notification_channel_daily_insight_description">Η πρωινή σύνοψη καιρού στην οποία επέλεξες να συμμετέχεις.</string>
     <string name="notification_daily_insight_title">Καιρός σήμερα</string>
 
-    <string name="notification_channel_tonight_insight_default_name">Νυχτερινός ClothesCast (με συμβάντα)</string>
-    <string name="notification_channel_tonight_insight_default_description">Η βραδινή σύνοψη καιρού όταν έχεις συμβάντα ημερολογίου απόψε. Παίζει τον προεπιλεγμένο ήχο ειδοποιήσεών σου.</string>
-    <string name="notification_channel_tonight_insight_silent_name">Νυχτερινός ClothesCast (σιωπηλός)</string>
-    <string name="notification_channel_tonight_insight_silent_description">Η βραδινή σύνοψη καιρού όταν το βράδυ σου είναι ελεύθερο. Παραδίδεται σιωπηλά — μπορείς να τη δεις στην οθόνη κλειδώματος, αλλά δεν παράγει ήχο.</string>
     <string name="notification_tonight_insight_title">Καιρός απόψε</string>
 
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -284,14 +284,8 @@ zh-CN) is unchanged; only the displayed label localizes.
     the per-channel notification titles. Three channels: daily, nightly
     (default + silent variants), weather alerts.
     -->
-    <string name="notification_channel_daily_insight_name">ClothesCast diario</string>
-    <string name="notification_channel_daily_insight_description">El resumen del tiempo matutino que has activado.</string>
     <string name="notification_daily_insight_title">El tiempo de hoy</string>
 
-    <string name="notification_channel_tonight_insight_default_name">ClothesCast nocturno (con eventos)</string>
-    <string name="notification_channel_tonight_insight_default_description">El resumen del tiempo de la tarde cuando esta noche tienes eventos en el calendario. Reproduce tu sonido de notificación predeterminado.</string>
-    <string name="notification_channel_tonight_insight_silent_name">ClothesCast nocturno (silencioso)</string>
-    <string name="notification_channel_tonight_insight_silent_description">El resumen del tiempo de la tarde cuando tu noche está libre. Se entrega en silencio — puedes echarle un vistazo en la pantalla de bloqueo, pero no emite ningún sonido.</string>
     <string name="notification_tonight_insight_title">El tiempo de esta noche</string>
 
 

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -450,14 +450,8 @@ Tone is informal "sina"-form throughout ("Pane … selga", "Võta … kaasa",
     <string name="settings_clothes_cond_temp_above">kui tunnetatav temperatuur on üle %1$s</string>
     <string name="settings_clothes_cond_precip_above">kui vihma tõenäosus on üle %.0f%%</string>
 
-    <string name="notification_channel_daily_insight_name">Igapäevane ClothesCast</string>
-    <string name="notification_channel_daily_insight_description">Hommikune ilmakokkuvõte, millele oled tellinud.</string>
     <string name="notification_daily_insight_title">Tänane ClothesCast</string>
 
-    <string name="notification_channel_tonight_insight_default_name">Õhtune ClothesCast (sündmustega)</string>
-    <string name="notification_channel_tonight_insight_default_description">Õhtune ilmakokkuvõte, kui täna õhtul on kalendrisündmusi. Esitab vaikimisi teavitusheli.</string>
-    <string name="notification_channel_tonight_insight_silent_name">Õhtune ClothesCast (vaikne)</string>
-    <string name="notification_channel_tonight_insight_silent_description">Õhtune ilmakokkuvõte, kui õhtu on vaba. Postitatakse vaikselt — saad sellele lukustusekraanilt pilgu heita, kuid heli ei esita.</string>
     <string name="notification_tonight_insight_title">Tänase õhtu ClothesCast</string>
 
 

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -402,13 +402,7 @@ Western Arabic numerals (0-9) are used for TTS compatibility.
     <string name="garment_polo">پولو</string>
 
     <!-- Notifications -->
-    <string name="notification_channel_daily_insight_name">ClothesCast روزانه</string>
-    <string name="notification_channel_daily_insight_description">خلاصه آب‌وهوای صبحگاهی که ثبت‌نام کرده‌اید.</string>
     <string name="notification_daily_insight_title">ClothesCast امروز</string>
-    <string name="notification_channel_tonight_insight_default_name">ClothesCast شبانه (با رویدادها)</string>
-    <string name="notification_channel_tonight_insight_default_description">خلاصه آب‌وهوای عصرگاهی هنگامی که امشب رویدادهای تقویم دارید.</string>
-    <string name="notification_channel_tonight_insight_silent_name">ClothesCast شبانه (ساکت)</string>
-    <string name="notification_channel_tonight_insight_silent_description">خلاصه آب‌وهوای عصرگاهی وقتی عصر شما خالی است. ساکت ارسال می‌شود.</string>
     <string name="notification_tonight_insight_title">ClothesCast امشب</string>
 
     <!-- Settings — notification permission -->

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -228,14 +228,8 @@ displayed label localizes.
     <string name="settings_location_searching">Haetaan…</string>
     <string name="settings_location_no_results">Ei tuloksia.</string>
 
-    <string name="notification_channel_daily_insight_name">Päivittäinen ClothesCast</string>
-    <string name="notification_channel_daily_insight_description">Aktivoimasi aamuinen säätiivis.</string>
     <string name="notification_daily_insight_title">Tämän päivän sää</string>
 
-    <string name="notification_channel_tonight_insight_default_name">Iltainen ClothesCast (tapahtumien kanssa)</string>
-    <string name="notification_channel_tonight_insight_default_description">Iltainen säätiivis, kun sinulla on tapahtumia tänä iltana. Soittaa oletusäänimerkityksesi.</string>
-    <string name="notification_channel_tonight_insight_silent_name">Iltainen ClothesCast (hiljainen)</string>
-    <string name="notification_channel_tonight_insight_silent_description">Iltainen säätiivis hiljaisina iltoina. Toimitetaan äänettömästi — näet sen lukitusnäytöllä, mutta se ei soi.</string>
     <string name="notification_tonight_insight_title">Tämän illan sää</string>
 
 

--- a/app/src/main/res/values-fil/strings.xml
+++ b/app/src/main/res/values-fil/strings.xml
@@ -562,14 +562,8 @@ The rest of the UI falls through to values/strings.xml (English).
     <!-- ============================================================
          Notifications
          ============================================================ -->
-    <string name="notification_channel_daily_insight_name">Pang-araw na ClothesCast</string>
-    <string name="notification_channel_daily_insight_description">Ang umaga na buod ng panahon na pinili mo.</string>
     <string name="notification_daily_insight_title">ClothesCast ngayon</string>
 
-    <string name="notification_channel_tonight_insight_default_name">Pang-gabing ClothesCast (may mga evento)</string>
-    <string name="notification_channel_tonight_insight_default_description">Ang gabi na buod ng panahon kapag mayroon kang mga evento ng kalendaryo ngayong gabi. Nagpapatugtog ng iyong default na tunog ng notipikasyon.</string>
-    <string name="notification_channel_tonight_insight_silent_name">Pang-gabing ClothesCast (tahimik)</string>
-    <string name="notification_channel_tonight_insight_silent_description">Ang gabi na buod ng panahon kapag walang laman ang iyong gabi. Nipo-post nang tahimik — maaari mo itong tingnan sa lock screen, ngunit hindi ito magpapatugtog ng tunog.</string>
     <string name="notification_tonight_insight_title">ClothesCast ngayong gabi</string>
 
 

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -286,14 +286,8 @@ zh-CN) is unchanged; only the displayed label localizes.
     the per-channel notification titles. Three channels: daily, nightly
     (default + silent variants), weather alerts.
     -->
-    <string name="notification_channel_daily_insight_name">ClothesCast quotidien</string>
-    <string name="notification_channel_daily_insight_description">Le résumé météo matinal que tu as activé.</string>
     <string name="notification_daily_insight_title">Météo d\'aujourd\'hui</string>
 
-    <string name="notification_channel_tonight_insight_default_name">ClothesCast nocturne (avec événements)</string>
-    <string name="notification_channel_tonight_insight_default_description">Le résumé météo du soir quand tu as des événements ce soir dans ton calendrier. Joue ton son de notification par défaut.</string>
-    <string name="notification_channel_tonight_insight_silent_name">ClothesCast nocturne (silencieux)</string>
-    <string name="notification_channel_tonight_insight_silent_description">Le résumé météo du soir quand ta soirée est libre. Envoyé en silence — tu peux y jeter un œil sur l\'écran de verrouillage, mais aucun son ne sera émis.</string>
     <string name="notification_tonight_insight_title">Météo de ce soir</string>
 
 

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -271,14 +271,8 @@ Not overridden by design:
     <string name="settings_location_background_denied_keep">अभी नहीं</string>
 
     <!-- Notification channels. -->
-    <string name="notification_channel_daily_insight_name">दैनिक ClothesCast</string>
-    <string name="notification_channel_daily_insight_description">वह सुबह की मौसम सारांश जिसे आपने चालू किया।</string>
     <string name="notification_daily_insight_title">आज का ClothesCast</string>
 
-    <string name="notification_channel_tonight_insight_default_name">रात्रि ClothesCast (घटनाओं के साथ)</string>
-    <string name="notification_channel_tonight_insight_default_description">जब आज रात कैलेंडर में घटनाएँ हों तो शाम की मौसम सारांश। डिफ़ॉल्ट सूचना ध्वनि बजाता है।</string>
-    <string name="notification_channel_tonight_insight_silent_name">रात्रि ClothesCast (मौन)</string>
-    <string name="notification_channel_tonight_insight_silent_description">जब आपकी शाम खाली हो तब की मौसम सारांश। चुपचाप भेजी जाती है — लॉक स्क्रीन पर देख सकते हैं, लेकिन आवाज़ नहीं होगी।</string>
     <string name="notification_tonight_insight_title">आज रात का ClothesCast</string>
 
 

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -257,14 +257,8 @@ spousal register), matching the existing insight prose ("Ponesi …",
     the per-channel notification titles. Three channels: daily, nightly
     (default + silent variants), weather alerts.
     -->
-    <string name="notification_channel_daily_insight_name">Dnevni ClothesCast</string>
-    <string name="notification_channel_daily_insight_description">Jutarnji vremenski sažetak koji je uključen.</string>
     <string name="notification_daily_insight_title">Današnje vrijeme</string>
 
-    <string name="notification_channel_tonight_insight_default_name">Noćni ClothesCast (s događajima)</string>
-    <string name="notification_channel_tonight_insight_default_description">Večernji vremenski sažetak kada večeras imaš događaje u kalendaru. Reproducira tvoj zadani zvuk obavijesti.</string>
-    <string name="notification_channel_tonight_insight_silent_name">Noćni ClothesCast (tihi)</string>
-    <string name="notification_channel_tonight_insight_silent_description">Večernji vremenski sažetak kad ti je večer slobodna. Šalje se tiho — možeš ga pogledati na zaključanom zaslonu, ali neće proizvesti zvuk.</string>
     <string name="notification_tonight_insight_title">Vrijeme večeras</string>
 
 

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -303,14 +303,8 @@ locale (Angol (Egyesült Államok), Francia (Franciaország), Német
 
 
     <!-- Notification channels. -->
-    <string name="notification_channel_daily_insight_name">Napi ClothesCast</string>
-    <string name="notification_channel_daily_insight_description">Az általad aktivált reggeli időjárás-összefoglaló.</string>
     <string name="notification_daily_insight_title">Mai időjárás</string>
 
-    <string name="notification_channel_tonight_insight_default_name">Esti ClothesCast (eseményekkel)</string>
-    <string name="notification_channel_tonight_insight_default_description">Az esti időjárás-összefoglaló, ha ma este eseményeid vannak. Lejátssza az alapértelmezett értesítési hangot.</string>
-    <string name="notification_channel_tonight_insight_silent_name">Esti ClothesCast (néma)</string>
-    <string name="notification_channel_tonight_insight_silent_description">Az esti időjárás-összefoglaló csendes estéken. Némán érkezik — láthatod a zárolási képernyőn, de nem ad hangot.</string>
     <string name="notification_tonight_insight_title">Mai esti időjárás</string>
 
 

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -529,13 +529,7 @@ to values/strings.xml (English).
     <string name="garment_polo">Polo</string>
 
     <!-- Notification channels -->
-    <string name="notification_channel_daily_insight_name">ClothesCast Harian</string>
-    <string name="notification_channel_daily_insight_description">Ringkasan cuaca pagi yang Anda pilih.</string>
     <string name="notification_daily_insight_title">ClothesCast hari ini</string>
-    <string name="notification_channel_tonight_insight_default_name">ClothesCast Malam (dengan acara)</string>
-    <string name="notification_channel_tonight_insight_default_description">Ringkasan cuaca malam saat Anda memiliki acara kalender malam ini. Memainkan suara notifikasi default Anda.</string>
-    <string name="notification_channel_tonight_insight_silent_name">ClothesCast Malam (senyap)</string>
-    <string name="notification_channel_tonight_insight_silent_description">Ringkasan cuaca malam saat malam Anda kosong. Diposting secara senyap — Anda dapat melihatnya di layar kunci, tetapi tidak akan mengeluarkan suara.</string>
     <string name="notification_tonight_insight_title">ClothesCast malam ini</string>
 
     <!-- Notification permission settings -->

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -276,14 +276,8 @@ zh-CN) is unchanged; only the displayed label localizes.
     the per-channel notification titles. Three channels: daily, nightly
     (default + silent variants), weather alerts.
     -->
-    <string name="notification_channel_daily_insight_name">ClothesCast quotidiano</string>
-    <string name="notification_channel_daily_insight_description">Il riepilogo meteo mattutino che hai attivato.</string>
     <string name="notification_daily_insight_title">Meteo di oggi</string>
 
-    <string name="notification_channel_tonight_insight_default_name">ClothesCast serale (con eventi)</string>
-    <string name="notification_channel_tonight_insight_default_description">Il riepilogo meteo serale quando stasera hai eventi in calendario. Riproduce il tuo suono di notifica predefinito.</string>
-    <string name="notification_channel_tonight_insight_silent_name">ClothesCast serale (silenzioso)</string>
-    <string name="notification_channel_tonight_insight_silent_description">Il riepilogo meteo serale quando la serata è libera. Inviato in silenzio — puoi dargli un\'occhiata sulla schermata di blocco, ma non emette suoni.</string>
     <string name="notification_tonight_insight_title">Meteo di stasera</string>
 
 

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -408,13 +408,7 @@ standard in Israeli digital communication.
     <string name="garment_polo">פולו</string>
 
     <!-- Notification channels -->
-    <string name="notification_channel_daily_insight_name">ClothesCast יומי</string>
-    <string name="notification_channel_daily_insight_description">סיכום מזג האוויר הבוקר שנרשמת אליו.</string>
     <string name="notification_daily_insight_title">ClothesCast להיום</string>
-    <string name="notification_channel_tonight_insight_default_name">ClothesCast לילי (עם אירועים)</string>
-    <string name="notification_channel_tonight_insight_default_description">סיכום מזג האוויר הערבי כשיש לך אירועי לוח שנה הלילה.</string>
-    <string name="notification_channel_tonight_insight_silent_name">ClothesCast לילי (שקט)</string>
-    <string name="notification_channel_tonight_insight_silent_description">סיכום מזג האוויר הערבי כשהערב שלך ריק. נשלח בשקט.</string>
     <string name="notification_tonight_insight_title">ClothesCast ללילה</string>
 
     <!-- Settings — notification permission -->

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -283,14 +283,8 @@ the displayed label localizes.
     the per-channel notification titles. Three channels: daily, nightly
     (default + silent variants), weather alerts.
     -->
-    <string name="notification_channel_daily_insight_name">毎日の ClothesCast</string>
-    <string name="notification_channel_daily_insight_description">あなたが有効にした朝の天気要約です。</string>
     <string name="notification_daily_insight_title">今日の天気</string>
 
-    <string name="notification_channel_tonight_insight_default_name">夜間の ClothesCast（予定あり）</string>
-    <string name="notification_channel_tonight_insight_default_description">今夜カレンダーに予定があるときの夜の天気要約です。既定の通知音を鳴らします。</string>
-    <string name="notification_channel_tonight_insight_silent_name">夜間の ClothesCast（無音）</string>
-    <string name="notification_channel_tonight_insight_silent_description">予定のない夜の天気要約です。無音で配信され、ロック画面で確認できますが、音は鳴りません。</string>
     <string name="notification_tonight_insight_title">今夜の天気</string>
 
 

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -296,14 +296,8 @@ displayed label localizes.
     the per-channel notification titles. Three channels: daily, nightly
     (default + silent variants), weather alerts.
     -->
-    <string name="notification_channel_daily_insight_name">매일 ClothesCast</string>
-    <string name="notification_channel_daily_insight_description">활성화한 아침 날씨 요약입니다.</string>
     <string name="notification_daily_insight_title">오늘 날씨</string>
 
-    <string name="notification_channel_tonight_insight_default_name">야간 ClothesCast (일정 있음)</string>
-    <string name="notification_channel_tonight_insight_default_description">오늘 밤 캘린더에 일정이 있을 때의 저녁 날씨 요약입니다. 기본 알림음을 재생합니다.</string>
-    <string name="notification_channel_tonight_insight_silent_name">야간 ClothesCast (무음)</string>
-    <string name="notification_channel_tonight_insight_silent_description">일정이 없는 저녁의 날씨 요약입니다. 무음으로 전송되며 잠금 화면에서 확인할 수 있지만 소리는 나지 않아요.</string>
     <string name="notification_tonight_insight_title">오늘 밤 날씨</string>
 
 

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -542,13 +542,7 @@ What is NOT overridden, by design:
     <string name="garment_polo">Polo</string>
 
     <!-- Notification channels. -->
-    <string name="notification_channel_daily_insight_name">Dienos ClothesCast</string>
-    <string name="notification_channel_daily_insight_description">Ryto orų santrauka, kurią užsisakei.</string>
     <string name="notification_daily_insight_title">Šiandienos ClothesCast</string>
-    <string name="notification_channel_tonight_insight_default_name">Nakties ClothesCast (su renginiais)</string>
-    <string name="notification_channel_tonight_insight_default_description">Vakaro orų santrauka, kai šiandien vakare turi kalendoriaus renginių. Skleidžia numatytąjį pranešimo garsą.</string>
-    <string name="notification_channel_tonight_insight_silent_name">Nakties ClothesCast (tylus)</string>
-    <string name="notification_channel_tonight_insight_silent_description">Vakaro orų santrauka ramiais vakarais. Pateikiama tyliai — gali matyti užrakto ekrane, bet nekeliks garso.</string>
     <string name="notification_tonight_insight_title">Šiandien vakaro ClothesCast</string>
 
     <!-- Notification permission card. -->

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -502,13 +502,7 @@ informal "tu"-form throughout ("Apģērb …", "Paņem … līdzi").
     <string name="settings_distance_unit_miles">Jūdzes</string>
 
     <!-- Notifications -->
-    <string name="notification_channel_daily_insight_name">Ikdienas ClothesCast</string>
-    <string name="notification_channel_daily_insight_description">Rīta laika apkopojums, kuram tu pierakstījies.</string>
     <string name="notification_daily_insight_title">Šodienas ClothesCast</string>
-    <string name="notification_channel_tonight_insight_default_name">Nakts ClothesCast (ar notikumiem)</string>
-    <string name="notification_channel_tonight_insight_default_description">Vakara laika apkopojums, ja šovakar ir kalendāra notikumi. Atskaņo noklusējuma paziņojuma skaņu.</string>
-    <string name="notification_channel_tonight_insight_silent_name">Nakts ClothesCast (klusais)</string>
-    <string name="notification_channel_tonight_insight_silent_description">Vakara laika apkopojums, ja vakars ir brīvs. Publicēts klusumā — vari to apskatīt bloķēšanas ekrānā, taču tas neskanēs.</string>
     <string name="notification_tonight_insight_title">Šovakarējais ClothesCast</string>
 
     <!-- Notification permission settings -->

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -527,13 +527,7 @@ vs "kemungkinan", "padam" vs "hapus").
     <string name="garment_polo">Polo</string>
 
     <!-- Notification channels -->
-    <string name="notification_channel_daily_insight_name">ClothesCast Harian</string>
-    <string name="notification_channel_daily_insight_description">Ringkasan cuaca pagi yang anda pilih untuk terima.</string>
     <string name="notification_daily_insight_title">ClothesCast Hari Ini</string>
-    <string name="notification_channel_tonight_insight_default_name">ClothesCast Malam (dengan acara)</string>
-    <string name="notification_channel_tonight_insight_default_description">Ringkasan cuaca petang apabila anda mempunyai acara kalendar malam ini. Memainkan bunyi pemberitahuan lalai anda.</string>
-    <string name="notification_channel_tonight_insight_silent_name">ClothesCast Malam (senyap)</string>
-    <string name="notification_channel_tonight_insight_silent_description">Ringkasan cuaca petang apabila petang anda kosong. Dihantar secara senyap — anda boleh melihatnya pada skrin kunci, tetapi tidak akan berbunyi.</string>
     <string name="notification_tonight_insight_title">ClothesCast Malam Ini</string>
 
     <!-- Notification permission prompt in settings -->

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -302,14 +302,8 @@ native names for all locales (e.g. "Tysk (Tyskland)", "Fransk (Frankrike)").
 
 
     <!-- Notification channels. -->
-    <string name="notification_channel_daily_insight_name">Daglig ClothesCast</string>
-    <string name="notification_channel_daily_insight_description">Det daglige væroppsummeringen du har aktivert.</string>
     <string name="notification_daily_insight_title">Dagens vær</string>
 
-    <string name="notification_channel_tonight_insight_default_name">Kveldens ClothesCast (med hendelser)</string>
-    <string name="notification_channel_tonight_insight_default_description">Den kveldslige væroppsummeringen når du har hendelser i kveld. Spiller av standard varsellyden din.</string>
-    <string name="notification_channel_tonight_insight_silent_name">Kveldens ClothesCast (stille)</string>
-    <string name="notification_channel_tonight_insight_silent_description">Den kveldslige væroppsummeringen på rolige kvelder. Leveres lydløst — du kan se den på låseskjermen, men den lager ingen lyd.</string>
     <string name="notification_tonight_insight_title">Været i kveld</string>
 
 

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -257,14 +257,8 @@ the displayed label localizes.
     <!--
     Notification channels.
     -->
-    <string name="notification_channel_daily_insight_name">Dagelijkse ClothesCast</string>
-    <string name="notification_channel_daily_insight_description">De ochtendelijke weersamenvatting die je hebt ingesteld.</string>
     <string name="notification_daily_insight_title">Weer vandaag</string>
 
-    <string name="notification_channel_tonight_insight_default_name">Avondlijkse ClothesCast (met afspraken)</string>
-    <string name="notification_channel_tonight_insight_default_description">De avondlijkse weersamenvatting als je vanavond afspraken hebt. Speelt je standaard meldingsgeluid af.</string>
-    <string name="notification_channel_tonight_insight_silent_name">Avondlijkse ClothesCast (stil)</string>
-    <string name="notification_channel_tonight_insight_silent_description">De avondlijkse weersamenvatting op vrije avonden. Stil bezorgd — je kunt hem op het vergrendelscherm zien, maar hij maakt geen geluid.</string>
     <string name="notification_tonight_insight_title">Weer vanavond</string>
 
 

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -257,14 +257,8 @@ is unchanged; only the displayed label localizes.
     <!--
     Notification channels.
     -->
-    <string name="notification_channel_daily_insight_name">Codzienny ClothesCast</string>
-    <string name="notification_channel_daily_insight_description">Poranne podsumowanie pogody, które włączyłeś.</string>
     <string name="notification_daily_insight_title">Pogoda dzisiaj</string>
 
-    <string name="notification_channel_tonight_insight_default_name">Wieczorny ClothesCast (z wydarzeniami)</string>
-    <string name="notification_channel_tonight_insight_default_description">Wieczorne podsumowanie pogody, gdy masz dzisiaj wieczorem wydarzenia. Odtwarza domyślny dźwięk powiadomienia.</string>
-    <string name="notification_channel_tonight_insight_silent_name">Wieczorny ClothesCast (cichy)</string>
-    <string name="notification_channel_tonight_insight_silent_description">Wieczorne podsumowanie pogody w spokojne wieczory. Dostarczane bezgłośnie — możesz je zobaczyć na ekranie blokady, ale nie wydaje dźwięku.</string>
     <string name="notification_tonight_insight_title">Pogoda wieczorem</string>
 
 

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -287,14 +287,8 @@ zh-CN) is unchanged; only the displayed label localizes.
     the per-channel notification titles. Three channels: daily, nightly
     (default + silent variants), weather alerts.
     -->
-    <string name="notification_channel_daily_insight_name">ClothesCast diário</string>
-    <string name="notification_channel_daily_insight_description">O resumo do tempo matinal que você ativou.</string>
     <string name="notification_daily_insight_title">Tempo de hoje</string>
 
-    <string name="notification_channel_tonight_insight_default_name">ClothesCast noturno (com eventos)</string>
-    <string name="notification_channel_tonight_insight_default_description">O resumo do tempo da noite quando você tem eventos no calendário esta noite. Toca seu som de notificação padrão.</string>
-    <string name="notification_channel_tonight_insight_silent_name">ClothesCast noturno (silencioso)</string>
-    <string name="notification_channel_tonight_insight_silent_description">O resumo do tempo da noite quando sua noite está livre. Enviado em silêncio — você pode dar uma olhada na tela de bloqueio, mas ele não emite som.</string>
     <string name="notification_tonight_insight_title">Tempo desta noite</string>
 
 

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -301,14 +301,8 @@ they diverge from BR ("Polonês" → "Polaco", "Holandês" →
     (PT) for BR "padrão" in the default-sound copy; "ecrã de bloqueio"
     (PT) for BR "tela de bloqueio".
     -->
-    <string name="notification_channel_daily_insight_name">ClothesCast diário</string>
-    <string name="notification_channel_daily_insight_description">O resumo matinal do tempo que ativaste.</string>
     <string name="notification_daily_insight_title">Tempo de hoje</string>
 
-    <string name="notification_channel_tonight_insight_default_name">ClothesCast noturno (com eventos)</string>
-    <string name="notification_channel_tonight_insight_default_description">O resumo do tempo da noite quando tens eventos no calendário para esta noite. Toca o teu som de notificação predefinido.</string>
-    <string name="notification_channel_tonight_insight_silent_name">ClothesCast noturno (silencioso)</string>
-    <string name="notification_channel_tonight_insight_silent_description">O resumo do tempo da noite quando a tua noite está livre. Entregue em silêncio — podes vê-lo no ecrã de bloqueio, mas não emite som.</string>
     <string name="notification_tonight_insight_title">Tempo desta noite</string>
 
 

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -533,13 +533,7 @@ surfaces fall back to default English (matching values-pl / values-uk).
     <string name="garment_polo">Polo</string>
 
     <!-- Notification channels. -->
-    <string name="notification_channel_daily_insight_name">ClothesCast zilnic</string>
-    <string name="notification_channel_daily_insight_description">Rezumatul meteo de dimineață la care ai optat.</string>
     <string name="notification_daily_insight_title">ClothesCast-ul de astăzi</string>
-    <string name="notification_channel_tonight_insight_default_name">ClothesCast nocturn (cu evenimente)</string>
-    <string name="notification_channel_tonight_insight_default_description">Rezumatul meteo de seară când ai evenimente în calendar diseară. Redă sunetul de notificare implicit.</string>
-    <string name="notification_channel_tonight_insight_silent_name">ClothesCast nocturn (silențios)</string>
-    <string name="notification_channel_tonight_insight_silent_description">Rezumatul meteo de seară când seara este liberă. Postat silențios — îl poți vedea pe ecranul de blocare, dar nu va emite niciun sunet.</string>
     <string name="notification_tonight_insight_title">ClothesCast-ul de diseară</string>
 
     <!-- Notification permission card. -->

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -349,14 +349,8 @@ only the displayed label localizes.
     the per-channel notification titles. Three channels: daily, nightly
     (default + silent variants), weather alerts.
     -->
-    <string name="notification_channel_daily_insight_name">Ежедневный ClothesCast</string>
-    <string name="notification_channel_daily_insight_description">Утренняя сводка погоды, которая включена.</string>
     <string name="notification_daily_insight_title">Погода сегодня</string>
 
-    <string name="notification_channel_tonight_insight_default_name">Вечерний ClothesCast (с событиями)</string>
-    <string name="notification_channel_tonight_insight_default_description">Вечерняя сводка погоды, когда у тебя сегодня есть события в календаре. Воспроизводит звук уведомления по умолчанию.</string>
-    <string name="notification_channel_tonight_insight_silent_name">Вечерний ClothesCast (тихий)</string>
-    <string name="notification_channel_tonight_insight_silent_description">Вечерняя сводка погоды, когда у тебя свободный вечер. Доставляется бесшумно — можешь увидеть на экране блокировки, но звук не издаётся.</string>
     <string name="notification_tonight_insight_title">Погода сегодня вечером</string>
 
 

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -310,14 +310,8 @@ What is NOT overridden, by design:
     <!--
     Notification channels.
     -->
-    <string name="notification_channel_daily_insight_name">Denný ClothesCast</string>
-    <string name="notification_channel_daily_insight_description">Ranné zhrnutie počasia, ktoré si aktivoval.</string>
     <string name="notification_daily_insight_title">Dnešné počasie</string>
 
-    <string name="notification_channel_tonight_insight_default_name">Nočný ClothesCast (s udalosťami)</string>
-    <string name="notification_channel_tonight_insight_default_description">Večerné zhrnutie počasia, keď máš dnes večer udalosti. Prehrá tvoj predvolený tón upozornenia.</string>
-    <string name="notification_channel_tonight_insight_silent_name">Nočný ClothesCast (tichý)</string>
-    <string name="notification_channel_tonight_insight_silent_description">Večerné zhrnutie počasia v pokojné večery. Doručí sa ticho — uvidíš ho na zamykacej obrazovke, ale nevydá žiadny zvuk.</string>
     <string name="notification_tonight_insight_title">Dnešné večerné počasie</string>
 
 

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -542,13 +542,7 @@ informal "ti"-form throughout, mirroring the Croatian / Serbian pass.
     <string name="settings_clothes_description">Če napoved preseže enega od teh pragov, se predmet prikaže v tvojem dnevnem ClothesCastu.</string>
 
     <!-- Notification channels and titles. -->
-    <string name="notification_channel_daily_insight_name">Dnevni ClothesCast</string>
-    <string name="notification_channel_daily_insight_description">Jutranji vremenski povzetek, ki si ga vklopil.</string>
     <string name="notification_daily_insight_title">Današnji ClothesCast</string>
-    <string name="notification_channel_tonight_insight_default_name">Nočni ClothesCast (z dogodki)</string>
-    <string name="notification_channel_tonight_insight_default_description">Večerni vremenski povzetek, ko imaš nocoj dogodke v koledarju. Predvaja tvoj privzeti zvok obvestila.</string>
-    <string name="notification_channel_tonight_insight_silent_name">Nočni ClothesCast (tiho)</string>
-    <string name="notification_channel_tonight_insight_silent_description">Večerni vremenski povzetek, ko je tvoj večer prost. Objavljeno tiho — na zaklenjenem zaslonu si ga lahko ogledaš, a ne bo proizvajal zvoka.</string>
     <string name="notification_tonight_insight_title">Nocojšnji ClothesCast</string>
 
     <!-- Notification permission card. -->

--- a/app/src/main/res/values-sq/strings.xml
+++ b/app/src/main/res/values-sq/strings.xml
@@ -747,13 +747,7 @@
     <string name="settings_default_outfit_range_never">asnjëherë</string>
     <string name="garment_short_skirt">Fund i shkurtër</string>
     <string name="garment_rain_jacket">Xhaketë kundër shiut</string>
-    <string name="notification_channel_daily_insight_name">ClothesCast-i ditor</string>
-    <string name="notification_channel_daily_insight_description">Përmbledhja e motit në mëngjes që zgjodhe ta marrësh.</string>
     <string name="notification_daily_insight_title">ClothesCast-i i sotëm</string>
-    <string name="notification_channel_tonight_insight_default_name">ClothesCast-i i mbrëmjes (me ngjarje)</string>
-    <string name="notification_channel_tonight_insight_default_description">Përmbledhja e motit në mbrëmje kur ke ngjarje në kalendar sonte. Luan tingullin tënd të parazgjedhur të njoftimeve.</string>
-    <string name="notification_channel_tonight_insight_silent_name">ClothesCast-i i mbrëmjes (në heshtje)</string>
-    <string name="notification_channel_tonight_insight_silent_description">Përmbledhja e motit në mbrëmje kur mbrëmja jote është bosh. Postohet në heshtje — mund ta shohësh në ekranin e kyçur, por nuk do të bëjë zhurmë.</string>
     <string name="notification_tonight_insight_title">ClothesCast-i i sontëm</string>
     <string name="settings_notification_permission_title">Njoftimet janë të bllokuara</string>
     <string name="settings_notification_permission_description">Pa lejen e njoftimeve, ClothesCast-i yt ditor s\'ka ku të shkojë. Jepe që ClothesCast të mund ta dërgojë nesër në mëngjes.</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -302,14 +302,8 @@ native names for all locales (e.g. "Tyska (Tyskland)", "Franska (Frankrike)").
 
 
     <!-- Notification channels. -->
-    <string name="notification_channel_daily_insight_name">Dagligt ClothesCast</string>
-    <string name="notification_channel_daily_insight_description">Den morgonliga vädersammanfattning du har aktiverat.</string>
     <string name="notification_daily_insight_title">Dagens väder</string>
 
-    <string name="notification_channel_tonight_insight_default_name">Kvällens ClothesCast (med händelser)</string>
-    <string name="notification_channel_tonight_insight_default_description">Den kvällsvisa vädersammanfattningen när du har händelser ikväll. Spelar upp din standardaviseringston.</string>
-    <string name="notification_channel_tonight_insight_silent_name">Kvällens ClothesCast (tyst)</string>
-    <string name="notification_channel_tonight_insight_silent_description">Den kvällsvisa vädersammanfattningen på lediga kvällar. Levereras tyst — du kan se den på låsskärmen men den gör inget ljud.</string>
     <string name="notification_tonight_insight_title">Vädret ikväll</string>
 
 

--- a/app/src/main/res/values-sw/strings.xml
+++ b/app/src/main/res/values-sw/strings.xml
@@ -368,13 +368,7 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="garment_polo">Polo</string>
 
     <!-- Notification channels -->
-    <string name="notification_channel_daily_insight_name">ClothesCast ya kila siku</string>
-    <string name="notification_channel_daily_insight_description">Muhtasari wa hali ya hewa ya asubuhi uliojiunga.</string>
     <string name="notification_daily_insight_title">ClothesCast ya Leo</string>
-    <string name="notification_channel_tonight_insight_default_name">ClothesCast ya usiku (na matukio)</string>
-    <string name="notification_channel_tonight_insight_default_description">Muhtasari wa hali ya hewa ya jioni unapokuwa na matukio ya kalenda usiku huu.</string>
-    <string name="notification_channel_tonight_insight_silent_name">ClothesCast ya usiku (kimya)</string>
-    <string name="notification_channel_tonight_insight_silent_description">Muhtasari wa hali ya hewa ya jioni jioni yako ikiwa tulivu. Imetumwa kimya.</string>
     <string name="notification_tonight_insight_title">ClothesCast ya Usiku Huu</string>
 
     <!-- Settings: notifications permission -->

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -527,13 +527,7 @@ The rest of the UI falls through to values/strings.xml (English).
     <string name="settings_clothes_description">หากพยากรณ์อากาศเกินค่าเกณฑ์ใดค่าหนึ่ง รายการนั้นจะปรากฏใน ClothesCast รายวันของคุณ</string>
 
     <!-- Notification channels -->
-    <string name="notification_channel_daily_insight_name">ClothesCast รายวัน</string>
-    <string name="notification_channel_daily_insight_description">สรุปสภาพอากาศช่วงเช้าที่คุณสมัครรับ</string>
     <string name="notification_daily_insight_title">ClothesCast วันนี้</string>
-    <string name="notification_channel_tonight_insight_default_name">ClothesCast รายคืน (มีกิจกรรม)</string>
-    <string name="notification_channel_tonight_insight_default_description">สรุปสภาพอากาศตอนเย็นเมื่อมีกิจกรรมปฏิทินคืนนี้ ส่งเสียงการแจ้งเตือนเริ่มต้น</string>
-    <string name="notification_channel_tonight_insight_silent_name">ClothesCast รายคืน (เงียบ)</string>
-    <string name="notification_channel_tonight_insight_silent_description">สรุปสภาพอากาศตอนเย็นเมื่อตอนเย็นว่าง โพสต์แบบเงียบ — สามารถดูบนหน้าจอล็อก แต่จะไม่ส่งเสียง</string>
     <string name="notification_tonight_insight_title">ClothesCast คืนนี้</string>
 
     <!-- Notification permission settings -->

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -228,14 +228,8 @@ displayed label localizes.
     <string name="settings_location_searching">Aranıyor…</string>
     <string name="settings_location_no_results">Sonuç bulunamadı.</string>
 
-    <string name="notification_channel_daily_insight_name">Günlük ClothesCast</string>
-    <string name="notification_channel_daily_insight_description">Etkinleştirdiğiniz sabah hava durumu özeti.</string>
     <string name="notification_daily_insight_title">Bugünün hava durumu</string>
 
-    <string name="notification_channel_tonight_insight_default_name">Gecelik ClothesCast (etkinliklerle)</string>
-    <string name="notification_channel_tonight_insight_default_description">Bu akşam etkinlikleriniz olduğunda gelen akşam hava durumu özeti. Varsayılan bildirim sesini çalar.</string>
-    <string name="notification_channel_tonight_insight_silent_name">Gecelik ClothesCast (sessiz)</string>
-    <string name="notification_channel_tonight_insight_silent_description">Sakin akşamlarda gelen akşam hava durumu özeti. Sessiz teslim edilir — kilit ekranında görebilirsiniz ama ses çıkarmaz.</string>
     <string name="notification_tonight_insight_title">Bu akşamın hava durumu</string>
 
 

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -305,14 +305,8 @@ only the displayed label localizes.
     <string name="settings_location_background_denied_keep">Не зараз</string>
 
     <!-- Notification channels and titles. -->
-    <string name="notification_channel_daily_insight_name">Щоденний ClothesCast</string>
-    <string name="notification_channel_daily_insight_description">Ранкова зведення погоди, яку ви підключили.</string>
     <string name="notification_daily_insight_title">Погода на сьогодні</string>
 
-    <string name="notification_channel_tonight_insight_default_name">Вечірній ClothesCast (з подіями)</string>
-    <string name="notification_channel_tonight_insight_default_description">Вечірнє зведення погоди, коли у вас є події у календарі сьогодні ввечері. Відтворює стандартний звук сповіщення.</string>
-    <string name="notification_channel_tonight_insight_silent_name">Вечірній ClothesCast (беззвучний)</string>
-    <string name="notification_channel_tonight_insight_silent_description">Вечірнє зведення погоди, коли у вас вільний вечір. Доставляється беззвучно — можна побачити на екрані блокування, але звук не лунає.</string>
     <string name="notification_tonight_insight_title">Погода сьогодні ввечері</string>
 
 

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -572,14 +572,8 @@ Skipped intentionally: app_name (brand), insight_time_am/pm/midnight/noon
     <!-- =====================================================================
          Notifications
          ===================================================================== -->
-    <string name="notification_channel_daily_insight_name">ClothesCast hàng ngày</string>
-    <string name="notification_channel_daily_insight_description">Tóm tắt thời tiết buổi sáng bạn đã đăng ký.</string>
     <string name="notification_daily_insight_title">ClothesCast hôm nay</string>
 
-    <string name="notification_channel_tonight_insight_default_name">ClothesCast buổi tối (có sự kiện)</string>
-    <string name="notification_channel_tonight_insight_default_description">Tóm tắt thời tiết buổi tối khi bạn có sự kiện lịch tối nay. Phát âm thanh thông báo mặc định.</string>
-    <string name="notification_channel_tonight_insight_silent_name">ClothesCast buổi tối (im lặng)</string>
-    <string name="notification_channel_tonight_insight_silent_description">Tóm tắt thời tiết buổi tối khi buổi tối của bạn trống. Đăng im lặng — bạn có thể xem trên màn hình khóa nhưng sẽ không phát âm thanh.</string>
     <string name="notification_tonight_insight_title">ClothesCast tối nay</string>
 
 

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -278,14 +278,8 @@ label localizes.
     the per-channel notification titles. Three channels: daily, nightly
     (default + silent variants), weather alerts.
     -->
-    <string name="notification_channel_daily_insight_name">每日 ClothesCast</string>
-    <string name="notification_channel_daily_insight_description">你启用的早晨天气摘要。</string>
     <string name="notification_daily_insight_title">今天的天气</string>
 
-    <string name="notification_channel_tonight_insight_default_name">夜间 ClothesCast（有日程）</string>
-    <string name="notification_channel_tonight_insight_default_description">你今晚有日历日程时的晚间天气摘要。播放你的默认通知声音。</string>
-    <string name="notification_channel_tonight_insight_silent_name">夜间 ClothesCast（静音）</string>
-    <string name="notification_channel_tonight_insight_silent_description">晚上没有日程时的晚间天气摘要。静默发送 — 你可以在锁屏上看到，但不会发出声音。</string>
     <string name="notification_tonight_insight_title">今晚的天气</string>
 
 

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -268,14 +268,8 @@ label localises.
     the per-channel notification titles. Three channels: daily, nightly
     (default + silent variants), weather alerts.
     -->
-    <string name="notification_channel_daily_insight_name">每日 ClothesCast</string>
-    <string name="notification_channel_daily_insight_description">你啟用的早晨天氣摘要。</string>
     <string name="notification_daily_insight_title">今天的天氣</string>
 
-    <string name="notification_channel_tonight_insight_default_name">夜間 ClothesCast（有行程）</string>
-    <string name="notification_channel_tonight_insight_default_description">你今晚有行事曆行程時的晚間天氣摘要。會播放你的預設通知聲音。</string>
-    <string name="notification_channel_tonight_insight_silent_name">夜間 ClothesCast（靜音）</string>
-    <string name="notification_channel_tonight_insight_silent_description">晚上沒有行程時的晚間天氣摘要。靜音傳送 — 你可以在鎖定畫面上看到，但不會發出聲音。</string>
     <string name="notification_tonight_insight_title">今晚的天氣</string>
 
 


### PR DESCRIPTION
## What

Removes six orphaned notification-channel string keys from all 48 `values-*/strings.xml` translation files. They no longer exist in the default locale, so Lint flagged them as `ExtraTranslation`:

```
values-fi/strings.xml:231: Error: "notification_channel_daily_insight_name"
is translated here but not found in default locale [ExtraTranslation]
```

## Why

Commit `c88ecf6` ("Show 'Preparing your ClothesCast' when the schedule fires") renamed the notification channels in the **default** locale — `notification_channel_daily_insight_*` → `notification_channel_scheduled_insight_*`, and dropped the `tonight_insight_default` / `tonight_insight_silent` channels — but never updated the translation files. The old keys lingered in every locale as orphans.

Keys removed (name + description for each):
- `notification_channel_daily_insight_name` / `_description`
- `notification_channel_tonight_insight_default_name` / `_description`
- `notification_channel_tonight_insight_silent_name` / `_description`

None are referenced in code or present in the default locale, so this is a pure cleanup with **no user-visible effect** (288 deletions across 48 files).

## Testing

- `./gradlew :app:lintDebug` — `ExtraTranslation` now reports **0** (was failing on the daily-insight orphan). All 48 files validate as well-formed XML.
- Remaining Lint failures (`MissingTranslation` for the live `scheduled_insight` / `playback` keys, plus `NonObservableLocale` / `RestrictedApi`) are pre-existing and unrelated — those keys were already untranslated at HEAD before this change. The repo's CI runs `:app:testDebugUnitTest` + `:app:assembleDebug`, not `lintDebug`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QJ3j7sKs6diKykA6We88kA)_