### PR TITLE
Scheduled forecast notifications no longer make a sound

### DIFF
--- a/app/src/main/kotlin/app/clothescast/notification/InsightNotifier.kt
+++ b/app/src/main/kotlin/app/clothescast/notification/InsightNotifier.kt
@@ -66,11 +66,11 @@ class InsightNotifier(private val context: Context) {
             .setContentTitle(context.getString(R.string.notification_daily_insight_title))
             .setContentText(prose)
             .setStyle(NotificationCompat.BigTextStyle().bigText(prose))
-            // Channel importance is DEFAULT on API 26+; PRIORITY_DEFAULT is the
-            // pre-O equivalent for the same bucket. Was PRIORITY_HIGH (heads-up)
-            // back when the channel was IMPORTANCE_HIGH; the schedule is
-            // user-opted-in, so a sound + shade entry is enough.
-            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+            // Channel importance is LOW (silent) on API 26+; PRIORITY_LOW is the
+            // pre-O equivalent for the same bucket. The schedule is user-opted-in
+            // and read at a glance, so a quiet shade entry — no ding, no heads-up —
+            // is enough.
+            .setPriority(NotificationCompat.PRIORITY_LOW)
             .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
             .setAutoCancel(true)
             .setContentIntent(pendingIntent)
@@ -83,7 +83,7 @@ class InsightNotifier(private val context: Context) {
         NotificationManagerCompat.from(context).notify(NOTIFICATION_ID_DAILY_INSIGHT, notification)
         DiagLog.i(
             TAG,
-            "Posted daily insight notification (id=$NOTIFICATION_ID_DAILY_INSIGHT, channel=$CHANNEL_SCHEDULED_INSIGHT, importance=DEFAULT).",
+            "Posted daily insight notification (id=$NOTIFICATION_ID_DAILY_INSIGHT, channel=$CHANNEL_SCHEDULED_INSIGHT, importance=LOW).",
         )
     }
 

--- a/app/src/main/kotlin/app/clothescast/notification/NotificationChannelRegistrar.kt
+++ b/app/src/main/kotlin/app/clothescast/notification/NotificationChannelRegistrar.kt
@@ -10,7 +10,11 @@ import app.clothescast.R
  * Channel IDs are stable identifiers persisted by the system; renaming or deleting one
  * is a user-visible change. Bump the suffix when channel semantics change.
  */
-internal const val CHANNEL_SCHEDULED_INSIGHT = "scheduled_insight_v1"
+// Bumped from `scheduled_insight_v1` so the drop from DEFAULT to LOW (silent —
+// no sound or heads-up) actually reaches existing installs. Android preserves an
+// existing channel's user-set importance forever, so editing the constant alone
+// would leave anyone who already had v1 still hearing the old ding.
+internal const val CHANNEL_SCHEDULED_INSIGHT = "scheduled_insight_v2"
 // Bumped from `playback_v1` so the broader semantics (now covers Preparing
 // + Delivering across the whole scheduled run, not just speech) take a
 // fresh user importance choice. Android preserves an existing channel's
@@ -41,6 +45,10 @@ private const val CHANNEL_DAILY_INSIGHT_RETIRED_V1 = "daily_insight_v1"
 private const val CHANNEL_DAILY_INSIGHT_RETIRED_V2 = "daily_insight_v2"
 private const val CHANNEL_TONIGHT_INSIGHT_DEFAULT_RETIRED = "tonight_insight_default_v1"
 private const val CHANNEL_TONIGHT_INSIGHT_SILENT_RETIRED = "tonight_insight_silent_v1"
+// Pre-silent forecast channel, IMPORTANCE_DEFAULT (made a sound). Replaced by the
+// LOW (silent) CHANNEL_SCHEDULED_INSIGHT above — a fresh ID so the new silence
+// reaches installs that already created the DEFAULT channel.
+private const val CHANNEL_SCHEDULED_INSIGHT_RETIRED_V1 = "scheduled_insight_v1"
 // Pre-v2 playback channel was scoped to "Speaking the forecast"; v2 broadens
 // to cover Preparing + Delivering across the whole scheduled run. Same
 // rationale as the forecast-channel collapse: let the user pick importance
@@ -53,10 +61,11 @@ private const val CHANNEL_PLAYBACK_RETIRED_V1 = "playback_v1"
  * Application.onCreate on every cold start.
  *
  * Two channels:
- * - **Scheduled ClothesCast** (DEFAULT): the morning *and* evening forecast
+ * - **Scheduled ClothesCast** (LOW, silent): the morning *and* evening forecast
  *   summaries the user opted into. Posted at the same importance for both
  *   periods so a night-worker primary tonight slot reads exactly as well as
- *   a day-worker primary morning slot.
+ *   a day-worker primary morning slot. Silent by design — these are a calm
+ *   reminder, not an alert, so they land in the shade without a sound.
  * - **Scheduled ClothesCast delivery** (LOW, silent): the foreground-service
  *   notification shown while the run prepares + delivers (see
  *   [ScheduledDeliveryService]). A policy requirement for the background
@@ -85,14 +94,21 @@ object NotificationChannelRegistrar {
         manager.deleteNotificationChannel(CHANNEL_TONIGHT_INSIGHT_DEFAULT_RETIRED)
         manager.deleteNotificationChannel(CHANNEL_TONIGHT_INSIGHT_SILENT_RETIRED)
         manager.deleteNotificationChannel(CHANNEL_PLAYBACK_RETIRED_V1)
+        manager.deleteNotificationChannel(CHANNEL_SCHEDULED_INSIGHT_RETIRED_V1)
 
+        // LOW + no sound / vibration: the morning and evening summaries are a
+        // calm, opted-in reminder, not an alert — they post silently to the shade
+        // and status bar without a ding or heads-up. setShowBadge stays on so the
+        // launcher dot still flags an unread summary.
         val scheduled = NotificationChannel(
             CHANNEL_SCHEDULED_INSIGHT,
             context.getString(R.string.notification_channel_scheduled_insight_name),
-            NotificationManager.IMPORTANCE_DEFAULT,
+            NotificationManager.IMPORTANCE_LOW,
         ).apply {
             description = context.getString(R.string.notification_channel_scheduled_insight_description)
             setShowBadge(true)
+            setSound(null, null)
+            enableVibration(false)
             lockscreenVisibility = android.app.Notification.VISIBILITY_PUBLIC
         }
 

--- a/app/src/main/kotlin/app/clothescast/notification/TonightInsightNotifier.kt
+++ b/app/src/main/kotlin/app/clothescast/notification/TonightInsightNotifier.kt
@@ -69,7 +69,9 @@ class TonightInsightNotifier(private val context: Context) {
             .setContentTitle(context.getString(R.string.notification_tonight_insight_title))
             .setContentText(prose)
             .setStyle(NotificationCompat.BigTextStyle().bigText(prose))
-            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+            // PRIORITY_LOW mirrors the LOW (silent) channel importance on pre-O —
+            // posts quietly to the shade, no ding or heads-up. See InsightNotifier.
+            .setPriority(NotificationCompat.PRIORITY_LOW)
             .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
             .setAutoCancel(true)
             .setContentIntent(pendingIntent)

--- a/app/src/test/kotlin/app/clothescast/notification/InsightNotifierTest.kt
+++ b/app/src/test/kotlin/app/clothescast/notification/InsightNotifierTest.kt
@@ -57,7 +57,7 @@ class InsightNotifierTest {
         posted shouldHaveSize 1
         val n = posted.single()
 
-        n.channelId shouldBe "scheduled_insight_v1"
+        n.channelId shouldBe "scheduled_insight_v2"
         n.extras.getString(NotificationCompat.EXTRA_TITLE) shouldBe
             context.getString(R.string.notification_daily_insight_title)
         n.extras.getString(NotificationCompat.EXTRA_TEXT) shouldBe "Today will be mild. Wear a t-shirt."

--- a/app/src/test/kotlin/app/clothescast/notification/TonightInsightNotifierTest.kt
+++ b/app/src/test/kotlin/app/clothescast/notification/TonightInsightNotifierTest.kt
@@ -53,7 +53,7 @@ class TonightInsightNotifierTest {
         TonightInsightNotifier(context).notify(sampleInsight(hasEvents = true), "Cool tonight. Bring a jacket.")
 
         val n = shadowOf(notificationManager).allNotifications.single()
-        n.channelId shouldBe "scheduled_insight_v1"
+        n.channelId shouldBe "scheduled_insight_v2"
         n.extras.getString(NotificationCompat.EXTRA_TITLE) shouldBe
             context.getString(R.string.notification_tonight_insight_title)
         n.extras.getString(NotificationCompat.EXTRA_TEXT) shouldBe "Cool tonight. Bring a jacket."
@@ -64,7 +64,7 @@ class TonightInsightNotifierTest {
         TonightInsightNotifier(context).notify(sampleInsight(hasEvents = false), "Cool tonight.")
 
         val n = shadowOf(notificationManager).allNotifications.single()
-        n.channelId shouldBe "scheduled_insight_v1"
+        n.channelId shouldBe "scheduled_insight_v2"
     }
 
     @Test


### PR DESCRIPTION
## What

Make the scheduled morning/evening forecast summary notifications **silent** — no ding, no vibration, no heads-up. They still post to the notification shade and status bar and still show a launcher badge.

## Why

A sound on every scheduled summary isn't useful — these are a calm, opted-in glance-at-it reminder, not an alert. Silencing them keeps them unobtrusive while still surfacing them where the user expects.

## How

- `CHANNEL_SCHEDULED_INSIGHT` drops from `IMPORTANCE_DEFAULT` to `IMPORTANCE_LOW`, plus explicit `setSound(null, null)` / `enableVibration(false)`.
- Android persists a channel's user-set importance forever, so editing the importance alone wouldn't reach installs that already created the channel. Per the repo's channel-versioning convention, the channel ID is bumped `scheduled_insight_v1` → `scheduled_insight_v2`, and `v1` is added to the retired-channel cleanup list (deleted on next launch).
- Both `InsightNotifier` and `TonightInsightNotifier` drop their pre-O `setPriority` to `PRIORITY_LOW` to match.
- Diagnostic log line now reads `importance=LOW`.

The foreground-service delivery channel (`CHANNEL_PLAYBACK`) was already LOW/silent — untouched.

## Privacy

No change to what crosses the device boundary.

## Test plan

- `./gradlew :app:testDebugUnitTest --tests "app.clothescast.notification.*"` — green. Channel-ID assertions in `InsightNotifierTest` / `TonightInsightNotifierTest` updated to `scheduled_insight_v2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K9oykqVWafWyNb2EzeGZNM

---
_Generated by [Claude Code](https://claude.ai/code/session_01K9oykqVWafWyNb2EzeGZNM)_