### PR TITLE
Explain stale calendar holiday dates and how to fix them

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ Three options, in roughly increasing order of friction:
 6. **Calendar tie-in** (optional): toggle _Use calendar events_ in
    Settings → Data Sources and grant `READ_CALENDAR` to let calendar presence
    gate event-relevant advice without putting event titles in rendered output.
+   See [docs/calendar-holidays.md](docs/calendar-holidays.md) for how holidays
+   are used and what to do if one shows on the wrong date.
 7. **Verify**: tap the **Fire insight now** button (About → Debug card,
    only in debug builds) to exercise the full pipeline without waiting
    until the scheduled time.

--- a/docs/calendar-holidays.md
+++ b/docs/calendar-holidays.md
@@ -1,0 +1,86 @@
+# Calendars and holidays
+
+With your permission (`READ_CALENDAR`), ClothesCast can read the calendars
+already synced to your phone to make the daily forecast more useful:
+
+- **Evening tie-ins** — if you have an evening event somewhere, the forecast
+  can fold in the weather for *that* part of the day (e.g. "Tonight, rain,
+  bring a jacket").
+- **Birthdays and public holidays** — these can theme the outfit card with
+  special colors and messages.
+
+The **Calendar settings** screen has two listings — **Birthdays** and
+**Public holidays** — that show the upcoming celebrations ClothesCast found in
+your synced calendars for the year ahead. Event titles stay on your device:
+they never appear in notifications, the spoken forecast, Cast, MQTT, or any
+analytics. See [PRIVACY.md](../PRIVACY.md) for the full boundary.
+
+## Why a holiday sometimes shows on the wrong date
+
+You may notice a public holiday listed on a date that your Google Calendar app
+no longer shows — for example, a "King's Birthday" appearing a week after the
+real one.
+
+This isn't ClothesCast inventing a date. ClothesCast reads holidays straight
+from your phone's shared calendar storage — the same place your calendar app
+syncs Google's "Holidays in <country>" calendars into.
+
+The catch: **Google revises those holiday calendars, sometimes only days
+before the date, and the change isn't always clean.** A real example — the UK
+"King's Birthday" for 2026 was moved from 20 June to 13 June on 16 June, four
+days beforehand. When Google moves a holiday like this, your phone usually
+picks up the new date, but the *old* copy can be left behind in your phone's
+calendar storage as a leftover ("ghost") entry. Google's own Calendar app
+tidies that away in its display, but other apps that read your calendar —
+ClothesCast included — still see it until the storage is cleaned up.
+
+So the wrong date you're seeing is a stale entry sitting on your device, not a
+date ClothesCast made up.
+
+## How to fix it
+
+A normal "sync now" or toggling account sync off and on usually **won't**
+remove a ghost entry — your phone only deletes an event when the server
+explicitly tells it to, and a quietly-revised holiday sometimes never sends
+that signal. You have two reliable options, mild to thorough:
+
+1. **Re-subscribe to the holiday calendar.** In the Google Calendar app:
+   Menu (☰) → **Settings** → the affected **Holidays in <country>** calendar →
+   turn it **off**, then **on** again. This re-fetches that calendar.
+2. **Clear the calendar cache** (thorough). This rebuilds the shared calendar
+   database from scratch and drops leftover entries. Clearing it while a sync
+   is mid-flight tends to leave the calendar half-populated, so do it in this
+   order:
+   1. **Settings → Passwords & accounts** (or **Accounts**) → your Google
+      account → **Account sync** → turn **Calendar** sync **off**.
+   2. **Settings → Apps**, turn on **Show system apps**, open **Calendar
+      Storage** → **Storage & cache** → **Clear storage**.
+   3. **Restart the phone.**
+   4. Turn **Calendar** sync back **on**, then open Google Calendar. The first
+      full re-sync can take a few minutes — and sometimes a couple of attempts.
+      If the calendar looks incomplete at first, give it time or pull down to
+      refresh.
+
+   > **Caution:** this clears the calendar database for *every* account on the
+   > phone, not just a throwaway cache. Anything backed by a sync account
+   > (Google, Exchange, and the like) comes back on the next sync — but events
+   > in **local, on-device-only calendars**, or events you created that never
+   > synced anywhere, are **not** recoverable. If you have any local calendars,
+   > use option 1 instead, or back them up first (for example, export to iCal).
+
+After either step, reopen ClothesCast's Calendar settings and the stale entry
+should be gone.
+
+## Or just turn the calendar off in ClothesCast
+
+If you'd rather ClothesCast ignore a particular holiday calendar entirely —
+ghost entries and all — open **Calendar settings → Calendars** and switch it
+off. That stops it theming outfits and appearing in the listings, and it
+doesn't touch your Google Calendar in any way.
+
+## Reporting a wrong holiday to Google
+
+Because the date originates in Google's holiday calendar, the source fix is on
+Google's side. You can report it from the Google Calendar app:
+Menu (☰) → **Help & feedback → Send feedback**, with a screenshot of the wrong
+date attached.


### PR DESCRIPTION
## What

Adds a user-facing help page, **`docs/calendar-holidays.md`**, and links it from the README's calendar setup step.

It covers:
- How ClothesCast uses synced calendars (evening tie-ins; birthday / public-holiday theming) and the on-device privacy boundary for event titles.
- **Why a public holiday can show on a date the user's Google Calendar no longer shows** — the motivating bug report — in plain terms: Google revises its "Holidays in <country>" calendars late (real case: UK King's Birthday 2026 moved 20 Jun → 13 Jun on 16 Jun), and when an event moves, the old copy can be left behind in the device's shared calendar storage as a leftover ("ghost") entry that any calendar-reading app still sees. ClothesCast reads that storage faithfully, so the stale date surfaces in the Calendar settings listings.
- **Recovery steps**: re-subscribe the holiday calendar, or clear Calendar Storage to force a full rebuild (a plain "sync now" / account-sync toggle won't drop a leftover entry, because the device only deletes events when the server sends an explicit tombstone). Plus the per-calendar toggle as an alternative, and how to report the source issue to Google.

## Why

A user saw "King's Birthday" listed on 20 Jun when their calendar had it on 13 Jun. Investigation (cross-checked against the live Google Calendar API) confirmed the date comes straight from the device's `CalendarContract` store and that the app renders it verbatim — the wrong date is a stale on-device entry, not an app date bug. This page captures that explanation so users (and we) don't have to re-derive it.

## Notes

- Docs-only change (`docs/calendar-holidays.md` + README link). No code, no behavior change.
- Branch rebased onto `main` after PR #1052 (developer-screen classifications) merged, so this PR's diff is just the docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HvXeNpUi6S5ibXkdEaeG8g)_