### PR TITLE
Show per-model lines across the whole Overnight chart

### DIFF
--- a/core/data/src/main/kotlin/app/clothescast/core/data/weather/MultiModelConfidenceFetcher.kt
+++ b/core/data/src/main/kotlin/app/clothescast/core/data/weather/MultiModelConfidenceFetcher.kt
@@ -204,10 +204,19 @@ internal class MultiModelConfidenceFetcher(
                 // coverage gate auto-hides diagnostics for any day a model
                 // doesn't reach. The tonight insight's evening tie-in still
                 // reads tomorrow's pre-dawn hours out of the same series.
-                // Confidence aggregates read `daily[0]` (today's value), so
-                // widening the window doesn't disturb the tier calculation
-                // downstream.
+                // With past_days=1 below the daily arrays lead with yesterday,
+                // so the confidence aggregate reads today at index 1 (see
+                // todayDailyIndex / readModelDaily) — not index 0, which is now
+                // yesterday.
                 parameter("forecast_days", 14)
+                // past_days=1 mirrors the primary OpenMeteoClient call so the
+                // per-model hourly series reaches back into yesterday evening.
+                // The Overnight view's window starts at ~19:00 the previous
+                // day; without yesterday's hours the per-model lines only have
+                // data from today 00:00 onward, so the chart shows just the
+                // blended line before midnight and the per-model lines only
+                // diverge after it.
+                parameter("past_days", 1)
                 parameter("timezone", "auto")
                 parameter("daily", "apparent_temperature_max,apparent_temperature_min,precipitation_probability_max")
                 // cloud_cover_low (the deck below ~2 km) rather than total
@@ -228,9 +237,10 @@ internal class MultiModelConfidenceFetcher(
         }
 
     private fun computeConfidence(daily: JsonObject, models: List<String>): ConfidenceInfo? {
+        val todayIndex = todayDailyIndex(daily)
         val results = buildList {
             for (model in models) {
-                when (val outcome = readModelDaily(daily, model)) {
+                when (val outcome = readModelDaily(daily, model, todayIndex)) {
                     is ReadOutcome.Usable -> add(model to outcome.values)
                     is ReadOutcome.Dropped ->
                         logger.log("model $model dropped: ${outcome.reason}")
@@ -377,14 +387,27 @@ internal class MultiModelConfidenceFetcher(
         return runCatching { LocalDateTime.parse(text) }.getOrNull()
     }
 
-    private fun readModelDaily(daily: JsonObject, model: String): ReadOutcome {
-        val tempMax = numberAt(daily["apparent_temperature_max_$model"] as? JsonArray, 0)?.toDouble()
+    /**
+     * Index of today's entry within the daily arrays. The confidence call uses
+     * `past_days=1`, so Open-Meteo leads the daily arrays with yesterday (index
+     * 0) and today sits at index 1 — mirror [OpenMeteoMapper], which reads today
+     * the same way. A degenerate response with a single daily entry (no past
+     * day) falls back to index 0 so the aggregate still describes the only day
+     * present rather than dropping every model on an out-of-bounds read.
+     */
+    private fun todayDailyIndex(daily: JsonObject): Int {
+        val times = daily["time"] as? JsonArray ?: return 0
+        return if (times.size >= 2) 1 else 0
+    }
+
+    private fun readModelDaily(daily: JsonObject, model: String, todayIndex: Int): ReadOutcome {
+        val tempMax = numberAt(daily["apparent_temperature_max_$model"] as? JsonArray, todayIndex)?.toDouble()
         // Soft field: the daily low feeds the low-disagreement half of the
         // temp spread, but a model that reports a high without a low still
         // contributes its high. When missing it simply drops out of the
         // low-spread calculation (see [compute]) rather than dropping the
         // whole model.
-        val tempMin = numberAt(daily["apparent_temperature_min_$model"] as? JsonArray, 0)?.toDouble()
+        val tempMin = numberAt(daily["apparent_temperature_min_$model"] as? JsonArray, todayIndex)?.toDouble()
         // Soft field: Open-Meteo omits daily precipitation_probability_max for
         // several models (verified 2026-06-09 against the live API — among
         // DEFAULT_MODELS, ecmwf_aifs025_single returns null at all three of
@@ -397,7 +420,7 @@ internal class MultiModelConfidenceFetcher(
         // path's soft precip handling and the daily-low handling above.
         // apparent_temperature_max stays the only hard requirement: without it
         // the model has no temperature vote to cast.
-        val precipMax = numberAt(daily["precipitation_probability_max_$model"] as? JsonArray, 0)?.toDouble()
+        val precipMax = numberAt(daily["precipitation_probability_max_$model"] as? JsonArray, todayIndex)?.toDouble()
         if (precipMax == null) {
             logger.log("model $model daily: precipitation_probability_max missing, precip-spread will skip this model")
         }

--- a/core/data/src/test/kotlin/app/clothescast/core/data/weather/MultiModelConfidenceFetcherTest.kt
+++ b/core/data/src/test/kotlin/app/clothescast/core/data/weather/MultiModelConfidenceFetcherTest.kt
@@ -120,7 +120,10 @@ class MultiModelConfidenceFetcherTest {
         // evening tie-in able to see tomorrow's pre-dawn rain that one model
         // spots but the base forecast under-calls.
         req.url.parameters["forecast_days"] shouldBe "14"
-        req.url.parameters["past_days"].shouldBeNull()
+        // past_days=1 reaches back into yesterday evening so the Overnight
+        // view's per-model lines have data before midnight, matching the
+        // blended line's window (which the primary call already covers).
+        req.url.parameters["past_days"] shouldBe "1"
     }
 
     @Test
@@ -156,6 +159,18 @@ class MultiModelConfidenceFetcherTest {
         info.precipSpreadPp shouldBe (10.0 plusOrMinus 0.0001)
         info.modelsConsulted shouldContainExactlyInAnyOrder
             listOf("ecmwf_ifs025", "gfs_seamless", "icon_seamless")
+    }
+
+    @Test
+    fun `confidence reads today not yesterday when past_days prepends a day`() = runTest {
+        // With past_days=1 the daily arrays lead with yesterday; the aggregate
+        // must read today (index 1). Yesterday disagrees wildly here, so a
+        // regression to index 0 would report LOW instead of today's HIGH.
+        val info = fetcherWith(PAST_DAY_THEN_TODAY).fetch(london, fixtureModels)?.confidence.shouldNotBeNull()
+
+        info.level shouldBe ForecastConfidence.HIGH
+        info.tempSpreadC shouldBe (1.0 plusOrMinus 0.0001)
+        info.precipSpreadPp shouldBe (10.0 plusOrMinus 0.0001)
     }
 
     @Test
@@ -587,6 +602,26 @@ class MultiModelConfidenceFetcherTest {
                 "precipitation_probability_max_ecmwf_ifs025": [10],
                 "precipitation_probability_max_gfs_seamless": [15],
                 "precipitation_probability_max_icon_seamless": [20]
+              }
+            }
+        """.trimIndent()
+
+        // The real past_days=1 shape: yesterday at index 0, today at index 1.
+        // Yesterday's highs split wide (10 / 15 / 20 → spread 10 → LOW) while
+        // today's cluster tight (21.0 / 21.5 / 22.0 → spread 1.0 → HIGH, the
+        // same values as THREE_MODEL_AGREEMENT). The confidence aggregate must
+        // describe today, so reading index 0 by mistake flips the tier and is
+        // caught here.
+        private val PAST_DAY_THEN_TODAY = """
+            {
+              "daily": {
+                "time": ["2026-05-11", "2026-05-12"],
+                "apparent_temperature_max_ecmwf_ifs025": [10.0, 21.0],
+                "apparent_temperature_max_gfs_seamless": [15.0, 21.5],
+                "apparent_temperature_max_icon_seamless": [20.0, 22.0],
+                "precipitation_probability_max_ecmwf_ifs025": [80, 10],
+                "precipitation_probability_max_gfs_seamless": [50, 15],
+                "precipitation_probability_max_icon_seamless": [20, 20]
               }
             }
         """.trimIndent()

--- a/core/data/src/test/kotlin/app/clothescast/core/data/weather/OpenMeteoClientTest.kt
+++ b/core/data/src/test/kotlin/app/clothescast/core/data/weather/OpenMeteoClientTest.kt
@@ -60,11 +60,11 @@ class OpenMeteoClientTest {
         client.fetchForecast(london)
 
         // The confidence fetcher also hits /v1/forecast (one batched call across
-        // all configured models) with a different param shape (no past_days).
-        // Pick out the primary call by looking for past_days=1 so this test isn't
-        // sensitive to async ordering.
+        // all configured models). Both calls now carry past_days=1, so pick out
+        // the primary call by the absence of `models` (only the confidence call
+        // lists them) so this test isn't sensitive to async ordering.
         val forecastReq = captured.first {
-            it.url.encodedPath == "/v1/forecast" && it.url.parameters["past_days"] == "1"
+            it.url.encodedPath == "/v1/forecast" && it.url.parameters["models"] == null
         }
         forecastReq.url.host shouldBe OPEN_METEO_HOST
 
@@ -151,7 +151,11 @@ class OpenMeteoClientTest {
             }
         """.trimIndent()
         val engine = MockEngine { request ->
-            val isPrimary = request.url.parameters["past_days"] == "1"
+            // Both calls now carry past_days=1 (the per-model confidence call
+            // reaches back into yesterday so the Overnight chart's per-model
+            // lines have pre-midnight data). The confidence call is the one
+            // that lists `models`; the primary forecast doesn't.
+            val isPrimary = request.url.parameters["models"] == null
             respond(
                 content = if (isPrimary) primaryJson else confidenceJson,
                 status = HttpStatusCode.OK,


### PR DESCRIPTION
## Problem

In the Overnight view, the "Feels like temperature" chart showed only the blended **Average** (white) line before midnight, with the individual model lines (ECM, ICO, UKM, AIF) appearing only *after* 00:00. The per-model spread should be visible across the whole window.

## Root cause

`OpenMeteoClient` makes two calls into `/v1/forecast`:

- the **primary forecast** (drives the blended line) — already requests `past_days=1`, so it covers the previous evening;
- the **per-model confidence** call in `MultiModelConfidenceFetcher` — omitted `past_days`, so its hourly series started at today `00:00`.

The Overnight window starts around `19:00` the previous day. With no pre-midnight per-model data, `PerModelHourly.slicedTo(window)` only matched today's post-midnight hours, so the per-model lines began at `00:00` while the blended line spanned the full window.

## Fix

Request `past_days=1` on the confidence call too, mirroring the primary forecast. The per-model series now reaches back into yesterday evening and the lines render across the full Overnight window.

### Daily-index follow-up (from Codex review)

`past_days=1` also prepends yesterday to the **daily** arrays, so the confidence aggregate's `readModelDaily` could no longer read index 0 as "today". It now reads today's entry via a `todayDailyIndex` helper (index 1 when a past day is present, falling back to 0 for a degenerate single-entry response), mirroring `OpenMeteoMapper`'s index-1-is-today convention. This keeps the "forecasters disagree" chip describing today's spread when the app falls back to `ForecastBundle.confidence`.

## Tests

- `MultiModelConfidenceFetcherTest`: now expects `past_days=1` on the batched request; added `confidence reads today not yesterday when past_days prepends a day` (two-day fixture — yesterday disagrees wildly, today agrees tightly — fails if the aggregate reads index 0).
- `OpenMeteoClientTest`: both `/v1/forecast` calls now carry `past_days=1`, so the test's primary-vs-confidence discriminator switched from `past_days` to the `models` param (only the confidence call lists models). Two spots updated.
- `:core:domain:test`, `:core:data:test`, and `:app:testDebugUnitTest` all pass locally.

## Privacy / data boundary

No change to what crosses the device boundary — same Open-Meteo endpoint and parameters, only `past_days=1` added (Open-Meteo is keyless; the request already carried coordinates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)