### PR TITLE
Stop using cached calendar events after you revoke calendar access

### DIFF
--- a/app/src/main/kotlin/app/clothescast/data/InsightCache.kt
+++ b/app/src/main/kotlin/app/clothescast/data/InsightCache.kt
@@ -6,6 +6,7 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
+import app.clothescast.calendar.CalendarPermission
 import app.clothescast.core.domain.model.CalendarEvent
 import app.clothescast.core.domain.model.ConfidenceInfo
 import app.clothescast.core.domain.model.DailyForecast
@@ -83,6 +84,16 @@ class InsightCache(
     private val dataStore: DataStore<Preferences>,
     private val deriveInsight: DeriveInsight = DeriveInsight(),
     private val json: Json = Json { ignoreUnknownKeys = true },
+    // Whether cached calendar events may still be used. Snapshots persist the
+    // events captured while permission was granted; revoking READ_CALENDAR in
+    // system settings isn't reflected in prefs, so DeriveInsight's
+    // calendarEventMentionsActive gate can't catch it. When this returns false
+    // every read drops the stale events, so a since-revoked event can't
+    // resurface in re-derived prose, the Today screen, or the MQTT has_events
+    // flag on a cache hit / replay before the next fetch clears the cache.
+    // Non-destructive: the stored bytes keep their events, so re-granting
+    // permission restores them on the next read.
+    private val calendarEventsReadable: () -> Boolean = { true },
 ) {
     // TODO(datastore-json-plumbing): see DailyHistoryStore — shared
     //   JSON-preference I/O plumbing opportunity across this, SettingsRepository,
@@ -99,11 +110,24 @@ class InsightCache(
 
     /** Raw snapshot stored for page 1 — the 12-hour window the user is currently in. */
     val thisPeriod: Flow<ForecastSnapshot?> =
-        dataStore.data.map { it.readSlot(THIS_PERIOD_KEY, LEGACY_THIS_PERIOD_V7_KEY) }
+        dataStore.data.map { it.readSlot(THIS_PERIOD_KEY, LEGACY_THIS_PERIOD_V7_KEY)?.gateCalendarEvents() }
 
     /** Raw snapshot stored for page 2 — the pre-captured next 12-hour window. */
     val nextPeriod: Flow<ForecastSnapshot?> =
-        dataStore.data.map { it.readSlot(NEXT_PERIOD_KEY, LEGACY_NEXT_PERIOD_V7_KEY) }
+        dataStore.data.map { it.readSlot(NEXT_PERIOD_KEY, LEGACY_NEXT_PERIOD_V7_KEY)?.gateCalendarEvents() }
+
+    // Drops cached calendar events when calendar access is no longer readable
+    // (see [calendarEventsReadable]); a no-op when there are none or access is
+    // intact. Applied on the raw [thisPeriod] / [nextPeriod] reads (so .first()
+    // consumers — the worker, the Smart Home replay / has_events flag — re-check
+    // per read) AND re-applied inside [deriveFlow]'s combine, so a long-lived
+    // Today collector re-evaluates the gate when permission changes: the cache
+    // DataStore doesn't re-emit on a permission change, but the resume path
+    // ticks prefs (calendar_permission_recheck_tick), which recombines. Without
+    // the combine-side re-check the collector would keep the snapshot it cached
+    // while access was still granted, events and all.
+    private fun ForecastSnapshot.gateCalendarEvents(): ForecastSnapshot =
+        if (events.isEmpty() || calendarEventsReadable()) this else copy(events = emptyList())
 
     /**
      * Derives the [DailyInsightResult] for [slot] against [prefs] using the
@@ -121,7 +145,10 @@ class InsightCache(
             Slot.NEXT_PERIOD -> nextPeriod
         }
         return combine(snapshotFlow, prefsFlow) { snapshot, prefs ->
-            snapshot?.let { deriveInsight(it, prefs) }
+            // Re-check the calendar gate on every recombine, not just when the
+            // cache DataStore emits — a permission revoke surfaces here as a
+            // prefs (recheck-tick) emission against an unchanged snapshot.
+            snapshot?.gateCalendarEvents()?.let { deriveInsight(it, prefs) }
         }
     }
 
@@ -581,7 +608,11 @@ class InsightCache(
         fun create(
             context: Context,
             deriveInsight: DeriveInsight = DeriveInsight(),
-        ): InsightCache = InsightCache(context.insightDataStore, deriveInsight)
+        ): InsightCache = InsightCache(
+            context.insightDataStore,
+            deriveInsight,
+            calendarEventsReadable = { CalendarPermission.isGranted(context) },
+        )
     }
 }
 

--- a/app/src/test/kotlin/app/clothescast/data/InsightCacheTest.kt
+++ b/app/src/test/kotlin/app/clothescast/data/InsightCacheTest.kt
@@ -13,6 +13,7 @@ import app.clothescast.core.domain.model.ConfidenceInfo
 import app.clothescast.core.domain.model.DailyForecast
 import app.clothescast.core.domain.model.DeliveryMode
 import app.clothescast.core.domain.model.DistanceUnit
+import app.clothescast.core.domain.model.EventKind
 import app.clothescast.core.domain.model.ForecastConfidence
 import app.clothescast.core.domain.model.ForecastPeriod
 import app.clothescast.core.domain.model.ForecastSnapshot
@@ -28,10 +29,14 @@ import app.clothescast.core.domain.model.UserPreferences
 import app.clothescast.core.domain.model.WeatherCondition
 import app.clothescast.core.domain.repository.ForecastBundle
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
@@ -103,6 +108,19 @@ class InsightCacheTest {
         generatedAt = now,
     )
 
+    private val sampleWithEvent = sample.copy(
+        events = listOf(
+            CalendarEvent(
+                title = "Concert",
+                start = LocalDateTime.of(2026, 4, 25, 14, 0),
+                end = LocalDateTime.of(2026, 4, 25, 15, 0),
+                location = "Arena",
+                allDay = false,
+                kind = EventKind.NORMAL,
+            ),
+        ),
+    )
+
     private val basePrefs = UserPreferences(
         schedule = Schedule(time = LocalTime.of(7, 0), days = Schedule.EVERY_DAY, zoneId = ZoneId.of("UTC")),
         deliveryMode = DeliveryMode.NOTIFICATION_ONLY,
@@ -142,6 +160,68 @@ class InsightCacheTest {
 
         val read = subject.thisPeriod.first()
         read shouldBe sample
+    }
+
+    // The cache scrubs event content to placeholders on disk (privacy — see
+    // PLACEHOLDER_LOCATION), so events don't round-trip by value; these assert
+    // on event *presence*, which is what the permission gate switches.
+    @Test
+    fun `cached events are kept on read when calendar access is intact`() = runTest {
+        val cache = InsightCache(dataStore, calendarEventsReadable = { true })
+        cache.store(InsightCache.Slot.THIS_PERIOD, sampleWithEvent)
+
+        cache.thisPeriod.first()?.events?.size shouldBe 1
+    }
+
+    @Test
+    fun `cached events are dropped on read when calendar permission is revoked`() = runTest {
+        // Stored while permission was granted; access revoked in system settings
+        // since. A read must not surface the event — otherwise a cache hit /
+        // replay would re-derive stale prose and publish has_events=true after
+        // calendar access is gone.
+        val revoked = InsightCache(dataStore, calendarEventsReadable = { false })
+        revoked.store(InsightCache.Slot.THIS_PERIOD, sampleWithEvent)
+
+        revoked.thisPeriod.first()?.events shouldBe emptyList()
+
+        // Non-destructive: the stored bytes keep the event, so a reader with
+        // access restored still sees it (re-granting permission heals the read).
+        InsightCache(dataStore, calendarEventsReadable = { true })
+            .thisPeriod.first()?.events?.size shouldBe 1
+    }
+
+    @Test
+    fun `deriveFlow re-drops events when permission is revoked mid-collection`() = runTest {
+        // A DataStore on the test scheduler so the long-lived collector below is
+        // deterministic (the shared one in setUp runs on Dispatchers.IO).
+        val ds = PreferenceDataStoreFactory.create(
+            scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler) + Job()),
+            produceFile = { File(tempDir.toFile(), "recheck.preferences_pb") },
+        )
+        var readable = true
+        val cache = InsightCache(ds, calendarEventsReadable = { readable })
+        cache.store(InsightCache.Slot.THIS_PERIOD, sampleWithEvent)
+
+        val prefs = MutableStateFlow(
+            basePrefs.copy(calendarEnabled = true, useCalendarEvents = true),
+        )
+        val hasEvents = mutableListOf<Boolean?>()
+        val job = launch(UnconfinedTestDispatcher(testScheduler)) {
+            cache.deriveFlow(InsightCache.Slot.THIS_PERIOD, prefs)
+                .collect { hasEvents += it?.insight?.hasEvents }
+        }
+
+        hasEvents.last() shouldBe true
+
+        // READ_CALENDAR revoked in system settings; the Today resume path ticks
+        // prefs (calendar_permission_recheck_tick) against the unchanged cached
+        // snapshot. The live collector must re-evaluate the gate, not keep
+        // deriving the cached event.
+        readable = false
+        prefs.value = prefs.value.copy(deltaThresholdC = 4.0)
+
+        hasEvents.last() shouldBe false
+        job.cancel()
     }
 
     @Test


### PR DESCRIPTION
## What

Follow-up to the `has_events` MQTT flag (#1063). Closes the remaining gap Codex flagged: revoking `READ_CALENDAR` in **Android system settings** isn't reflected in prefs, so a cache hit / replay before the next fetch could re-derive since-revoked calendar events and publish `has_events=true` (and name the event in replayed prose) to the user's own broker.

## Why the previous gate didn't catch it

`DeriveInsight` already drops cached events when the **in-app** calendar tie-in is toggled off (`calendarEventMentionsActive`). But:
- System-settings permission revocation isn't in `prefs`, so that gate is blind to it.
- `DeriveInsight` lives in `:core:domain` (pure Kotlin) and can't check an Android permission.

## Fix

Gate one level up, at the **`InsightCache` read boundary**:
- `thisPeriod` / `nextPeriod` now drop `snapshot.events` when calendar access isn't readable, via an injected `calendarEventsReadable: () -> Boolean` (defaults to `{ true }` for tests; `create()` wires `{ CalendarPermission.isGranted(context) }`).
- Both raw-snapshot consumers (replay / "Publish now", worker) **and** the derive helpers (`deriveFlow`, `deliveredForToday`) funnel through these flows, so one chokepoint keeps the Today screen, the worker, and the Smart Home replay / `has_events` flag in agreement.
- **Non-destructive**: the stored bytes keep their events, so re-granting permission restores them on the next read.

The scheduled worker was already safe (it fresh-fetches through the permission-gated calendar reader); this closes the cache-replay path.

## Privacy

Narrows what a cache replay can send to the user's own MQTT broker — and what the replayed prose (fed to BYOK TTS) can name — once calendar access is withdrawn. No new data leaves the device; this only *removes* a stale path.

## Test plan

- `:app:testDebugUnitTest` passes. Added two `InsightCacheTest` cases: access intact → cached event survives the read; access revoked → event dropped on read, and (non-destructive) a reader with access restored sees it again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HvXeNpUi6S5ibXkdEaeG8g)_