### PR TITLE
Extract shared JSON DataStore plumbing into JsonPreferenceStore

### DIFF
--- a/app/src/main/kotlin/app/clothescast/data/DailyHistoryStore.kt
+++ b/app/src/main/kotlin/app/clothescast/data/DailyHistoryStore.kt
@@ -7,10 +7,8 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import app.clothescast.core.domain.model.DailyHistoryEntry
-import kotlinx.coroutines.flow.first
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.decodeFromString
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import java.time.LocalDate
 
@@ -36,18 +34,9 @@ import java.time.LocalDate
  * duplicate-day write into the list.
  */
 class DailyHistoryStore(
-    private val dataStore: DataStore<Preferences>,
-    private val json: Json = Json { ignoreUnknownKeys = true },
-) {
-    // TODO(datastore-json-plumbing): this read-flow / edit / runCatching-decode
-    //   / Dto<->domain pattern is duplicated across DailyHistoryStore,
-    //   InsightCache, and SettingsRepository. Extract a JsonPreferenceStore base
-    //   for the I/O plumbing (readJson/writeJson) — but KEEP the per-store DTOs:
-    //   they're a deliberate schema boundary (versioned `_v1` keys,
-    //   ignoreUnknownKeys) decoupling on-disk format from the domain model, so
-    //   collapsing them into @Serializable domain types would couple wire format
-    //   to domain shape. This is the cleanest store to migrate first as the
-    //   proof; then InsightCache, then SettingsRepository — one per PR.
+    dataStore: DataStore<Preferences>,
+    json: Json = Json { ignoreUnknownKeys = true },
+) : JsonPreferenceStore(dataStore, json) {
 
     /**
      * Returns the entry recorded for [date], or null when nothing was stored
@@ -69,22 +58,18 @@ class DailyHistoryStore(
     suspend fun put(entry: DailyHistoryEntry) {
         dataStore.edit { prefs ->
             val cutoff = entry.date.minusDays(1)
-            val existing = decode(prefs[HISTORY_KEY])
+            val existing = decodeJson(prefs[HISTORY_KEY], emptyList(), ::decodeEntries)
             val merged = (existing.filter { it.date != entry.date && !it.date.isBefore(cutoff) } + entry)
                 .sortedBy { it.date }
-            prefs[HISTORY_KEY] = json.encodeToString(merged.map { it.toDto() })
+            prefs.writeJson(HISTORY_KEY, merged.map { it.toDto() })
         }
     }
 
     private suspend fun read(): List<DailyHistoryEntry> =
-        decode(dataStore.data.first()[HISTORY_KEY])
+        readJson(HISTORY_KEY, emptyList(), ::decodeEntries)
 
-    private fun decode(raw: String?): List<DailyHistoryEntry> {
-        if (raw.isNullOrEmpty()) return emptyList()
-        return runCatching {
-            json.decodeFromString<List<EntryDto>>(raw).map { it.toDomain() }
-        }.getOrDefault(emptyList())
-    }
+    private fun decodeEntries(raw: String): List<DailyHistoryEntry> =
+        json.decodeFromString<List<EntryDto>>(raw).map { it.toDomain() }
 
     @Serializable
     private data class EntryDto(

--- a/app/src/main/kotlin/app/clothescast/data/InsightCache.kt
+++ b/app/src/main/kotlin/app/clothescast/data/InsightCache.kt
@@ -30,7 +30,6 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.decodeFromString
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import java.time.Instant
 import java.time.LocalDate
@@ -81,9 +80,9 @@ import java.time.ZoneId
  * corruption (deserialization failure → drop and regenerate) trivial.
  */
 class InsightCache(
-    private val dataStore: DataStore<Preferences>,
+    dataStore: DataStore<Preferences>,
     private val deriveInsight: DeriveInsight = DeriveInsight(),
-    private val json: Json = Json { ignoreUnknownKeys = true },
+    json: Json = Json { ignoreUnknownKeys = true },
     // Whether cached calendar events may still be used. Snapshots persist the
     // events captured while permission was granted; revoking READ_CALENDAR in
     // system settings isn't reflected in prefs, so DeriveInsight's
@@ -94,10 +93,7 @@ class InsightCache(
     // Non-destructive: the stored bytes keep their events, so re-granting
     // permission restores them on the next read.
     private val calendarEventsReadable: () -> Boolean = { true },
-) {
-    // TODO(datastore-json-plumbing): see DailyHistoryStore — shared
-    //   JSON-preference I/O plumbing opportunity across this, SettingsRepository,
-    //   and DailyHistoryStore (extract readJson/writeJson; keep the DTOs).
+) : JsonPreferenceStore(dataStore, json) {
 
     /**
      * Which 12-hour window a snapshot occupies relative to the rendering
@@ -154,7 +150,7 @@ class InsightCache(
 
     suspend fun store(slot: Slot, snapshot: ForecastSnapshot) {
         dataStore.edit {
-            it[keyFor(slot)] = json.encodeToString(snapshot.toDto())
+            it.writeJson(keyFor(slot), snapshot.toDto())
             // A fresh capture supersedes whatever the pre-update build left
             // under the old key names; drop them so the read fallback can't
             // resurrect a stale snapshot and the orphaned bytes don't linger.
@@ -212,8 +208,9 @@ class InsightCache(
         // fetch lands. The v7 shape decodes into the current DTO (the event
         // date fields default to null and materialise against the snapshot's
         // own date), so only the key name needs bridging.
-        val raw = this[key] ?: this[legacyKey] ?: return null
-        return runCatching { json.decodeFromString<ForecastSnapshotDto>(raw).toDomain() }.getOrNull()
+        return decodeJson<ForecastSnapshot?>(this[key] ?: this[legacyKey], null) {
+            json.decodeFromString<ForecastSnapshotDto>(it).toDomain()
+        }
     }
 
     private fun keyFor(slot: Slot): Preferences.Key<String> =

--- a/app/src/main/kotlin/app/clothescast/data/JsonPreferenceStore.kt
+++ b/app/src/main/kotlin/app/clothescast/data/JsonPreferenceStore.kt
@@ -1,0 +1,69 @@
+package app.clothescast.data
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.MutablePreferences
+import androidx.datastore.preferences.core.Preferences
+import kotlinx.coroutines.flow.first
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+/**
+ * Shared JSON-in-Preferences I/O plumbing for the DataStore-backed stores in
+ * this package ([DailyHistoryStore], [InsightCache], [SettingsRepository]).
+ *
+ * Each persists one or more values as JSON strings under a
+ * `stringPreferencesKey`, and every read does the same three things: skip an
+ * absent / blank key, decode defensively (a corrupt or forward-incompatible
+ * payload must fall back to a default rather than throw on every flow
+ * emission — a thrown exception in a DataStore `map` crashes all collectors
+ * and pins the worker on retry), and map the on-disk DTO to the domain type.
+ * This base owns that guard-and-decode dance — the `isNullOrBlank` +
+ * `runCatching { … }.getOrDefault(default)` boilerplate — so the stores don't
+ * each re-implement it.
+ *
+ * It deliberately does NOT own the DTOs. Each store keeps its own private
+ * `@Serializable` DTOs as a versioned schema boundary (`_v1` / `_v8` keys,
+ * `ignoreUnknownKeys`) decoupling the on-disk format from the domain model;
+ * collapsing them into `@Serializable` domain types would couple the wire
+ * format to the domain shape. The decode / encode lambdas carry the reified
+ * DTO type, so they run in the subclass where those private DTOs are visible.
+ */
+abstract class JsonPreferenceStore(
+    protected val dataStore: DataStore<Preferences>,
+    protected val json: Json = Json { ignoreUnknownKeys = true },
+) {
+    /**
+     * Decodes [raw] via [decode], returning [default] when the value is absent
+     * or blank, or when decoding throws (corrupt payload, schema drift). The
+     * [decode] lambda owns the reified DTO type and the DTO → domain mapping.
+     */
+    protected fun <T> decodeJson(raw: String?, default: T, decode: (String) -> T): T {
+        if (raw.isNullOrBlank()) return default
+        return runCatching { decode(raw) }.getOrDefault(default)
+    }
+
+    /**
+     * Reads the JSON string under [key] from the latest DataStore snapshot and
+     * decodes it via [decodeJson]. A one-shot read (`data.first()`); a store
+     * wanting a reactive view maps over [dataStore]`.data` and calls
+     * [decodeJson] per emission instead.
+     */
+    protected suspend fun <T> readJson(
+        key: Preferences.Key<String>,
+        default: T,
+        decode: (String) -> T,
+    ): T = decodeJson(dataStore.data.first()[key], default, decode)
+
+    /**
+     * Encodes [value] to JSON and stores it under [key] within the current
+     * [androidx.datastore.preferences.core.edit] transaction. The reified type
+     * resolves against the DTO the caller passes, keeping the wire shape the
+     * store's concern while the `encodeToString`-into-key step stays here.
+     */
+    protected inline fun <reified T> MutablePreferences.writeJson(
+        key: Preferences.Key<String>,
+        value: T,
+    ) {
+        this[key] = json.encodeToString(value)
+    }
+}

--- a/app/src/main/kotlin/app/clothescast/data/SettingsRepository.kt
+++ b/app/src/main/kotlin/app/clothescast/data/SettingsRepository.kt
@@ -75,14 +75,11 @@ import java.util.Locale
  * [SettingsRepository.create] is the production factory.
  */
 class SettingsRepository(
-    private val dataStore: DataStore<Preferences>,
+    dataStore: DataStore<Preferences>,
     private val zoneIdProvider: () -> ZoneId = { ZoneId.systemDefault() },
     private val systemLocaleProvider: () -> Locale = { Locale.getDefault() },
-    private val json: Json = Json { ignoreUnknownKeys = true },
-) {
-    // TODO(datastore-json-plumbing): see DailyHistoryStore — shared
-    //   JSON-preference I/O plumbing opportunity across this, InsightCache, and
-    //   DailyHistoryStore (extract readJson/writeJson; keep the DTOs).
+    json: Json = Json { ignoreUnknownKeys = true },
+) : JsonPreferenceStore(dataStore, json) {
 
     val preferences: Flow<UserPreferences> = dataStore.data.map { prefs -> prefs.toUserPreferences() }
 
@@ -298,7 +295,7 @@ class SettingsRepository(
     }
 
     suspend fun setClothesRules(rules: List<ClothesRule>) {
-        dataStore.edit { it[CLOTHES_RULES] = json.encodeToString(rules.map { rule -> rule.toDto() }) }
+        dataStore.edit { it.writeJson(CLOTHES_RULES, rules.map { rule -> rule.toDto() }) }
     }
 
     /**
@@ -309,7 +306,7 @@ class SettingsRepository(
      */
     suspend fun setHomeSectionOrder(order: List<HomeSection>) {
         dataStore.edit {
-            it[HOME_SECTION_ORDER] = json.encodeToString(HomeSection.normalize(order).map { s -> s.name })
+            it.writeJson(HOME_SECTION_ORDER, HomeSection.normalize(order).map { s -> s.name })
         }
     }
 
@@ -804,7 +801,7 @@ class SettingsRepository(
         dataStore.edit { prefs ->
             val current = parseOutfitTopColors(prefs[OUTFIT_TOP_COLORS])
             val updated = if (argb == null) current - top else current + (top to argb)
-            prefs[OUTFIT_TOP_COLORS] = json.encodeToString(updated.mapKeys { it.key.name })
+            prefs.writeJson(OUTFIT_TOP_COLORS, updated.mapKeys { it.key.name })
         }
     }
 
@@ -813,7 +810,7 @@ class SettingsRepository(
         dataStore.edit { prefs ->
             val current = parseOutfitBottomColors(prefs[OUTFIT_BOTTOM_COLORS])
             val updated = if (argb == null) current - bottom else current + (bottom to argb)
-            prefs[OUTFIT_BOTTOM_COLORS] = json.encodeToString(updated.mapKeys { it.key.name })
+            prefs.writeJson(OUTFIT_BOTTOM_COLORS, updated.mapKeys { it.key.name })
         }
     }
 
@@ -822,7 +819,7 @@ class SettingsRepository(
         dataStore.edit { prefs ->
             val current = parseOutfitHandsColors(prefs[OUTFIT_HANDS_COLORS])
             val updated = if (argb == null) current - hands else current + (hands to argb)
-            prefs[OUTFIT_HANDS_COLORS] = json.encodeToString(updated.mapKeys { it.key.name })
+            prefs.writeJson(OUTFIT_HANDS_COLORS, updated.mapKeys { it.key.name })
         }
     }
 
@@ -831,7 +828,7 @@ class SettingsRepository(
         dataStore.edit { prefs ->
             val current = parseOutfitCarriedColors(prefs[OUTFIT_CARRIED_COLORS])
             val updated = if (argb == null) current - carried else current + (carried to argb)
-            prefs[OUTFIT_CARRIED_COLORS] = json.encodeToString(updated.mapKeys { it.key.name })
+            prefs.writeJson(OUTFIT_CARRIED_COLORS, updated.mapKeys { it.key.name })
         }
     }
 
@@ -840,7 +837,7 @@ class SettingsRepository(
         dataStore.edit { prefs ->
             val current = parseOutfitOuterColors(prefs[OUTFIT_OUTER_COLORS])
             val updated = if (argb == null) current - outer else current + (outer to argb)
-            prefs[OUTFIT_OUTER_COLORS] = json.encodeToString(updated.mapKeys { it.key.name })
+            prefs.writeJson(OUTFIT_OUTER_COLORS, updated.mapKeys { it.key.name })
         }
     }
 
@@ -1404,29 +1401,25 @@ class SettingsRepository(
      * forward-compat values (a future-added `Top` variant in stored JSON
      * silently disappears on read rather than crashing the whole flow).
      */
-    private fun <K : Any> parseOutfitColors(raw: String?, resolveKey: (String) -> K?): Map<K, Long> {
-        if (raw.isNullOrBlank()) return emptyMap()
-        return runCatching {
-            json.decodeFromString<Map<String, Long>>(raw)
-                .mapNotNull { (key, value) -> resolveKey(key)?.let { it to value } }
+    private fun <K : Any> parseOutfitColors(raw: String?, resolveKey: (String) -> K?): Map<K, Long> =
+        decodeJson(raw, emptyMap()) {
+            json.decodeFromString<Map<String, Long>>(it)
+                .mapNotNull { (key, value) -> resolveKey(key)?.let { k -> k to value } }
                 .toMap()
-        }.getOrDefault(emptyMap())
-    }
+        }
 
-    private fun parseRules(raw: String?): List<ClothesRule> {
-        if (raw.isNullOrBlank()) return ClothesRule.DEFAULTS
-        return runCatching {
+    private fun parseRules(raw: String?): List<ClothesRule> =
+        decodeJson(raw, ClothesRule.DEFAULTS) {
             // Drop any stored rule whose item isn't a catalog garment (legacy
             // free-form items from before the catalog) — see [ClothesRuleDto.toDomain].
-            json.decodeFromString<List<ClothesRuleDto>>(raw).mapNotNull { it.toDomain() }
-        }.getOrDefault(ClothesRule.DEFAULTS)
+            json.decodeFromString<List<ClothesRuleDto>>(it).mapNotNull { dto -> dto.toDomain() }
+        }
             // An empty stored list is also treated as "no rules configured" rather
             // than honoured as an intentional zero — with editing locked
             // (ClothesSettings is read-only), a user who deleted all their rules
             // in a previous editable-UI version would otherwise have no way to
             // recover the defaults.
             .ifEmpty { ClothesRule.DEFAULTS }
-    }
 
     /**
      * Decodes the stored home-section order (a JSON list of [HomeSection] enum
@@ -1435,11 +1428,12 @@ class SettingsRepository(
      * all-unknown list all fall back to [HomeSection.DEFAULTS].
      */
     private fun parseHomeSectionOrder(raw: String?): List<HomeSection> {
-        if (raw.isNullOrBlank()) return HomeSection.DEFAULTS
-        val stored = runCatching {
-            json.decodeFromString<List<String>>(raw)
+        // normalize(emptyList) == HomeSection.DEFAULTS, so an absent / blank /
+        // malformed key falls back to the defaults the same as before.
+        val stored = decodeJson(raw, emptyList()) {
+            json.decodeFromString<List<String>>(it)
                 .mapNotNull { name -> runCatching { HomeSection.valueOf(name) }.getOrNull() }
-        }.getOrDefault(emptyList())
+        }
         return HomeSection.normalize(stored)
     }
 


### PR DESCRIPTION
## What

Extracts the duplicated read/edit/decode/DTO plumbing shared by `DailyHistoryStore`, `InsightCache`, and `SettingsRepository` into a new `JsonPreferenceStore` base class — resolving the `TODO(datastore-json-plumbing)` that lived in all three files.

All three persisted values as JSON strings under a `stringPreferencesKey` and re-implemented the same defensive guard-and-decode dance:
- skip an absent / blank key,
- decode inside `runCatching` so a corrupt or forward-incompatible payload falls back to a default rather than throwing on every flow emission (a thrown exception in a DataStore `map` crashes all collectors and pins the worker on retry),
- map the on-disk DTO to the domain type.

## The base

`JsonPreferenceStore` (new) owns the plumbing the three stores now extend:

- `decodeJson(raw, default, decode)` — the `isNullOrBlank` + `runCatching { … }.getOrDefault(default)` boilerplate; the `decode` lambda carries the reified DTO type.
- `readJson(key, default, decode)` — one-shot snapshot read (`data.first()`) + `decodeJson`.
- `MutablePreferences.writeJson(key, value)` — `encodeToString` into the key inside an `edit` transaction.

`dataStore` and `json` move to the base constructor (kept as the test-injection seam); each store passes them up and keeps its other params (`deriveInsight` / `calendarEventsReadable` on `InsightCache`, the zone/locale providers on `SettingsRepository`).

## What's deliberately NOT changed

The per-store `@Serializable` DTOs stay private to each store. They're a versioned schema boundary (`_v1` / `_v8` keys, `ignoreUnknownKeys`) decoupling the on-disk format from the domain model — collapsing them into `@Serializable` domain types would couple the wire format to the domain shape. The `decode` / `encode` lambdas run in each subclass where its private DTOs are visible.

The top-level one-shot `DataMigration` helpers in `SettingsRepository` (each with its own local `json`) are out of scope and untouched.

## Privacy

No behavior change and nothing crosses the device boundary differently — this is a pure internal refactor of how the same bytes are read from / written to the local DataStore.

## Test plan

- `:core:domain:test` · `:core:data:test` · `:app:testDebugUnitTest` — green
- `:app:assembleDebug` — green

One behavioral detail confirmed safe: `DailyHistoryStore`'s old `isNullOrEmpty` guard becomes `isNullOrBlank` via the shared `decodeJson`. That only routes whitespace-only payloads to the same empty-list fallback they already reached via the failed decode, so the outcome is identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ha8deeHzAxJsUmx8mkAM6f

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ha8deeHzAxJsUmx8mkAM6f)_