### PR TITLE
Stop repeating rain in the evening when the day already mentioned it

### DIFF
--- a/app/src/main/kotlin/app/clothescast/insight/InsightFormatter.kt
+++ b/app/src/main/kotlin/app/clothescast/insight/InsightFormatter.kt
@@ -301,7 +301,7 @@ class InsightFormatter(
                 formatExtras(summary.period, extras.item)?.let(::add)
             }
             summary.eveningEventExtras
-                ?.let { formatEveningEventExtras(it, precipAccessoryKeys) }
+                ?.let { formatEveningEventExtras(it, precipAccessoryKeys, summary.precip) }
                 ?.let(::add)
         }
         // Whether a leading temperature sentence exists to carry the period
@@ -453,13 +453,6 @@ class InsightFormatter(
         return "($preamble) $tail"
     }
 
-    // TODO(insight-tweak): when the morning precip clause already names a
-    //  daytime peak ("Rain at 3pm.") and the evening extras also names an
-    //  evening rain ("…, rain at 9pm, bring a jacket."), the listener hears
-    //  two distinct rain times back-to-back. Consider folding both peaks into
-    //  one mention ("Rain at 3pm and 9pm.") or suppressing the second when
-    //  the extras adds no new clothes vocabulary beyond rain.
-    //
     // TODO(accessories-catalog): accessories are silenced rather than
     //  rendered. To bring them back, build a domain-side ClothesRule
     //  item-kind classification (garment / accessory) so each item knows
@@ -751,6 +744,7 @@ class InsightFormatter(
     private fun formatEveningEventExtras(
         extras: EveningEventExtrasClause,
         alreadyMentionedAccessories: Set<String> = emptySet(),
+        daytimePrecip: PrecipClause? = null,
     ): String? {
         val rainTime = extras.rainTime
         // Accessories (umbrella) are silenced from the incoming items list for
@@ -796,6 +790,22 @@ class InsightFormatter(
             // collapses to the bare-rain prose (the only signal left);
             // otherwise the whole extras is empty and we drop it.
             if (rainTime == null) return null
+            // Drop the bare evening rain echo when the daytime precip clause
+            // already named the same condition at least as confidently — the
+            // listener would otherwise hear "rain" twice with no new clothes
+            // vocabulary between them ("Rain. Tonight, rain."). A different
+            // evening condition (snow day + evening rain) or an escalation from
+            // a hedged daytime "chance of rain" to a confident evening "rain"
+            // still surfaces, and an item-led evening clause adds vocabulary so
+            // it never reaches this branch. A post-midnight peak is deduped the
+            // same as any other — the bare "overnight" qualifier isn't worth
+            // repeating a rain the daytime clause already named.
+            if (daytimePrecip != null &&
+                daytimePrecip.condition == (extras.precipCondition ?: WeatherCondition.RAIN) &&
+                daytimePrecip.likelihood <= extras.likelihood
+            ) {
+                return null
+            }
             val template = when (extras.likelihood) {
                 PrecipLikelihood.LIKELY -> R.string.insight_evening_rain
                 PrecipLikelihood.POSSIBLE -> R.string.insight_evening_rain_chance

--- a/app/src/test/kotlin/app/clothescast/insight/InsightFormatterTest.kt
+++ b/app/src/test/kotlin/app/clothescast/insight/InsightFormatterTest.kt
@@ -999,6 +999,89 @@ class InsightFormatterTest {
     }
 
     @Test
+    fun `bare evening rain is suppressed when the daytime precip already named rain`() {
+        // The daytime clause already says "Rain."; a bare evening rain echo with
+        // no new clothes vocabulary would just repeat the word, so we drop it.
+        val out = subject.format(
+            summary(
+                precip = PrecipClause(WeatherCondition.RAIN, LocalTime.of(15, 0)),
+                eveningEventExtras = EveningEventExtrasClause(
+                    items = emptyList(),
+                    rainTime = LocalTime.of(21, 0),
+                ),
+            ),
+        )
+        out shouldBe "Today, it will be 21°. Rain."
+    }
+
+    @Test
+    fun `bare overnight rain is suppressed too when the day already named rain`() {
+        // A post-midnight peak would add "overnight", but that bare qualifier
+        // isn't interesting enough to repeat a rain the daytime clause already
+        // named — so it's deduped the same as any other evening peak.
+        val out = subject.format(
+            summary(
+                precip = PrecipClause(WeatherCondition.RAIN, LocalTime.of(15, 0)),
+                eveningEventExtras = EveningEventExtrasClause(
+                    items = emptyList(),
+                    rainTime = LocalTime.of(2, 0),
+                ),
+            ),
+        )
+        out shouldBe "Today, it will be 21°. Rain."
+    }
+
+    @Test
+    fun `bare evening rain still surfaces when the daytime condition differs`() {
+        // A snow day plus a separate evening rain are two distinct messages, not
+        // a repeat — keep both.
+        val out = subject.format(
+            summary(
+                precip = PrecipClause(WeatherCondition.SNOW, LocalTime.of(15, 0)),
+                eveningEventExtras = EveningEventExtrasClause(
+                    items = emptyList(),
+                    rainTime = LocalTime.of(21, 0),
+                    precipCondition = WeatherCondition.RAIN,
+                ),
+            ),
+        )
+        out shouldBe "Today, it will be 21°. Snow. Tonight, rain."
+    }
+
+    @Test
+    fun `bare evening rain still surfaces when it escalates a hedged daytime chance`() {
+        // Daytime only hedged ("Chance of rain."); a confident evening "rain" is
+        // an escalation, not a repeat, so it stays.
+        val out = subject.format(
+            summary(
+                precip = PrecipClause(WeatherCondition.RAIN, LocalTime.of(15, 0), PrecipLikelihood.POSSIBLE),
+                eveningEventExtras = EveningEventExtrasClause(
+                    items = emptyList(),
+                    rainTime = LocalTime.of(21, 0),
+                    likelihood = PrecipLikelihood.LIKELY,
+                ),
+            ),
+        )
+        out shouldBe "Today, it will be 21°. Chance of rain. Tonight, rain."
+    }
+
+    @Test
+    fun `evening rain with clothes items survives the daytime precip dedup`() {
+        // The evening clause adds new clothes vocabulary ("bring a jacket"), so
+        // it's kept even though the daytime clause already named rain.
+        val out = subject.format(
+            summary(
+                precip = PrecipClause(WeatherCondition.RAIN, LocalTime.of(15, 0)),
+                eveningEventExtras = EveningEventExtrasClause(
+                    items = listOf("jacket"),
+                    rainTime = LocalTime.of(21, 0),
+                ),
+            ),
+        )
+        out shouldBe "Today, it will be 21°. Rain. Tonight, rain, bring a jacket."
+    }
+
+    @Test
     fun `evening event extras says 'overnight' for a post-midnight rain peak`() {
         // A peak in the early hours (00:00–04:59) appends "overnight",
         // flagging the post-midnight window the "Tonight," lead doesn't
@@ -1480,11 +1563,12 @@ class InsightFormatterTest {
 
     @Test
     fun `evening extras drops the umbrella the main precip clause already named`() {
-        // Bug: the morning precip clause ("Drizzle, bring an umbrella.") and the
-        // evening extras both carry the same fired umbrella rule, so the prose
-        // said "bring an umbrella" twice. The extras now suppresses the repeat
-        // and falls back to the bare-rain wording — the evening rain still
-        // surfaces, just without re-naming the carry.
+        // The morning precip clause ("Drizzle, bring an umbrella.") and the
+        // evening extras both carry the same fired umbrella rule. After the
+        // umbrella repeat is suppressed the evening clause has no new vocabulary
+        // left — just the same DRIZZLE condition the daytime clause already named
+        // at least as confidently — so the bare condition-echo is dropped too,
+        // rather than tacking on a redundant "Tonight, chance of drizzle."
         umbrellaSubject.format(
             summary(
                 carriedAccessories = listOf("umbrella"),
@@ -1496,7 +1580,7 @@ class InsightFormatterTest {
                     precipCondition = WeatherCondition.DRIZZLE,
                 ),
             ),
-        ) shouldBe "Today, it will be 21°. Drizzle, bring an umbrella. Tonight, chance of drizzle."
+        ) shouldBe "Today, it will be 21°. Drizzle, bring an umbrella."
     }
 
     @Test


### PR DESCRIPTION
## What

The morning briefing's evening add-on no longer echoes a bare rain warning when the daytime forecast already named the **same condition at equal-or-higher confidence**. Today the listener can hear "rain" twice back-to-back with nothing new between the two clauses — e.g. `… Rain. Tonight, rain.` This drops the redundant second mention.

## Scope of the dedup

In `InsightFormatter.formatEveningEventExtras`, the bare evening-rain clause is suppressed only when the daytime precip clause already covered it:

- **Bare-rain only.** An evening clause that adds clothes vocabulary still fires — `Tonight, rain, bring a jacket.` is untouched.
- **Same condition only.** A snow day plus a separate evening rain keeps both: `Snow. Tonight, rain.`
- **Confidence-gated.** A hedged daytime `Chance of rain.` escalating to a confident evening `rain` still surfaces; only an equal-or-weaker echo is dropped.

This also tightens the existing umbrella-dedup path: once the repeated umbrella is suppressed, the leftover bare condition-echo (`Tonight, chance of drizzle.`) is now dropped too, instead of trailing the daytime `Drizzle, bring an umbrella.`

Addresses the `TODO(insight-tweak)` note (removed). The peak-*time* wording that TODO referenced was already gone; the remaining redundancy was the repeated condition word.

## Privacy

Prose-only change that **reduces** what's spoken / sent to the (BYOK) TTS endpoint; it never broadens the insight text that crosses the device boundary.

## Test plan

- Added `InsightFormatterTest` cases: suppression when daytime already named rain; still-surfaces for a differing condition (snow + rain); still-surfaces on hedged→confident escalation; survives when the evening clause carries clothes items.
- Updated the umbrella-dedup test to the tighter expected output.
- `./gradlew :core:domain:test :core:data:test :app:testDebugUnitTest` green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HvXeNpUi6S5ibXkdEaeG8g)_