### PR TITLE
internal: extract shared InsightCardShell for the Today insight cards

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/today/InsightCardShell.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/InsightCardShell.kt
@@ -1,0 +1,124 @@
+package app.clothescast.ui.today
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Card
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.dp
+
+/**
+ * Shared scaffolding for the insight header cards on the Today pager — the
+ * per-period [InsightCard] (pages 0 / 1) and the week-ahead headline card on
+ * [SevenDayPage] (page 2). Owns the card geometry both shapes must keep in
+ * lockstep so swiping between pages doesn't jitter: a 20.dp-padded [Card], a
+ * 12.dp inter-row gap, and a three-zone header row with a fixed 28.dp slot on
+ * each edge — so the centered label holds its horizontal position whether or
+ * not a chevron is currently shown — framing a `weight(1f)` centered region.
+ *
+ * The edge slots and the centered region are caller-supplied so each card fills
+ * in its own chevrons ([leftSlot] / [rightSlot], typically an
+ * [InsightCardChevron] or nothing) and label ([centerContent], typically an
+ * [InsightCardCenterLabel]); [body] is the content below the header — the prose
+ * headline. Keeping the scaffolding here means a retune of the chevron slot
+ * size, the inter-row spacing, or the header layout lands on both cards at once
+ * instead of silently drifting between two hand-rolled copies.
+ */
+@Composable
+internal fun InsightCardShell(
+    modifier: Modifier = Modifier,
+    leftSlot: @Composable () -> Unit = {},
+    rightSlot: @Composable () -> Unit = {},
+    centerContent: @Composable RowScope.() -> Unit,
+    body: @Composable ColumnScope.() -> Unit,
+) {
+    Card(modifier = modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier.padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Box(modifier = Modifier.size(28.dp)) { leftSlot() }
+                Row(
+                    modifier = Modifier.weight(1f),
+                    horizontalArrangement = Arrangement.Center,
+                    verticalAlignment = Alignment.CenterVertically,
+                    content = centerContent,
+                )
+                Box(modifier = Modifier.size(28.dp)) { rightSlot() }
+            }
+            body()
+        }
+    }
+}
+
+/**
+ * A header chevron sized to the shell's 28.dp edge slot — the back / forward
+ * affordances on both insight cards. [imageVector] is expected to be an
+ * `Icons.AutoMirrored` arrow so it flips in RTL automatically.
+ */
+@Composable
+internal fun InsightCardChevron(
+    imageVector: ImageVector,
+    contentDescription: String,
+    onClick: () -> Unit,
+) {
+    IconButton(onClick = onClick, modifier = Modifier.size(28.dp)) {
+        Icon(imageVector = imageVector, contentDescription = contentDescription)
+    }
+}
+
+/**
+ * The centered header label both cards share: [label] in `labelLarge`, plus an
+ * optional " · <city>" suffix that navigates to Location settings when
+ * [onNavigateToLocation] is wired (inert in previews / tests). [locationLabel]
+ * is the resolved city name, or null to omit the suffix entirely.
+ * [labelModifier] lets the per-period card attach its hidden
+ * long-press-to-Developer-settings gesture to the label without the week-ahead
+ * card inheriting it.
+ */
+@Composable
+internal fun InsightCardCenterLabel(
+    label: String,
+    locationLabel: String?,
+    onNavigateToLocation: (() -> Unit)?,
+    labelModifier: Modifier = Modifier,
+) {
+    Text(
+        text = label,
+        style = MaterialTheme.typography.labelLarge,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = labelModifier,
+    )
+    if (locationLabel != null) {
+        Text(
+            text = " · ",
+            style = MaterialTheme.typography.labelLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Text(
+            text = locationLabel,
+            style = MaterialTheme.typography.labelLarge,
+            color = MaterialTheme.colorScheme.primary,
+            modifier = if (onNavigateToLocation != null) {
+                Modifier.clickable { onNavigateToLocation() }
+            } else {
+                Modifier
+            },
+        )
+    }
+}

--- a/app/src/main/kotlin/app/clothescast/ui/today/SevenDayPage.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/SevenDayPage.kt
@@ -2,19 +2,12 @@ package app.clothescast.ui.today
 
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material3.Card
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -22,7 +15,6 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.remember
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -322,14 +314,11 @@ internal fun SevenDayPage(
         // card does on pages 0 / 1 — keeping the outfit row at a consistent
         // vertical offset across a swipe whichever order the user picked.
         insightSlot = {
-        // Page header — same visual treatment as [InsightCard] on pages 0 / 1:
-        // a 20.dp-padded Card with the chevron in a 28.dp slot on the left,
-        // a "Next 7 days" label in the centered position the per-period
-        // label occupies on those pages, and the prose headline below in
-        // headlineSmall (matching the per-period insight prose typography).
-        // Reserving 28.dp on the right keeps the label in the same horizontal
-        // position as the per-period label on pages 0 / 1, so swiping between
-        // pages doesn't jitter the centered label sideways.
+        // Page header — same shell as [InsightCard] on pages 0 / 1 (see
+        // [InsightCardShell]): a 20.dp-padded Card, a back chevron in the left
+        // 28.dp slot, the title in the centered label position, a 28.dp slot
+        // reserved on the right for an optional forward chevron to the
+        // following week, and the prose headline below in headlineSmall.
         //
         // The prose slot shows the week-ahead headline when one fires (rain,
         // a notable temperature shift, or a persistent hot / cold run); a
@@ -337,95 +326,44 @@ internal fun SevenDayPage(
         // always carries content; and the legacy "Will be ready after the
         // next forecast." line on pre-7-day-fetch cached payloads where
         // [days] is empty or has fewer than 2 entries.
-        //
-        // TODO: extract an `InsightCardShell` composable shared with
-        // [InsightCard] so the chevron-row geometry / padding / spacing live
-        // in one place. Today this block is a hand-rolled copy of
-        // InsightCard's Card+Row+Column scaffolding (TodayScreen.kt:1784–1859);
-        // if someone retunes the chevron slot size, the inter-row spacing, or
-        // the centered-label typography there, this card silently drifts.
-        // The refactor needs the shell flexible enough for both shapes
-        // (optional center content: date+location chip vs. plain label;
-        // optional right chevron) and touches
-        // the today/tonight code path + every snapshot through `InsightCard`,
-        // which is why it's deferred to a follow-up rather than landed here.
-        Card(modifier = Modifier.fillMaxWidth()) {
-            Column(
-                modifier = Modifier.padding(20.dp),
-                verticalArrangement = Arrangement.spacedBy(12.dp),
-            ) {
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    Box(modifier = Modifier.size(28.dp)) {
-                        IconButton(
-                            onClick = onChevronTap,
-                            modifier = Modifier.size(28.dp),
-                        ) {
-                            Icon(
-                                imageVector = Icons.AutoMirrored.Filled.KeyboardArrowLeft,
-                                contentDescription = stringResource(R.string.today_back_to_primary),
-                            )
-                        }
-                    }
-                    val locationLabel = shortLocationLabel(location?.displayName)
-                        ?: location?.let { stringResource(R.string.today_location_unknown) }
-                    Row(
-                        modifier = Modifier.weight(1f),
-                        horizontalArrangement = Arrangement.Center,
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Text(
-                            text = stringResource(titleRes),
-                            style = MaterialTheme.typography.labelLarge,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-                        if (location != null && locationLabel != null) {
-                            Text(
-                                text = " · ",
-                                style = MaterialTheme.typography.labelLarge,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            )
-                            Text(
-                                text = locationLabel,
-                                style = MaterialTheme.typography.labelLarge,
-                                color = MaterialTheme.colorScheme.primary,
-                                // Tapping the city name opens the Location
-                                // settings page — same affordance as the
-                                // per-period [InsightCard] header. Falls back
-                                // to inert text when no nav callback is wired
-                                // (previews / tests).
-                                modifier = if (onNavigateToLocation != null) {
-                                    Modifier.clickable { onNavigateToLocation() }
-                                } else {
-                                    Modifier
-                                },
-                            )
-                        }
-                    }
-                    Box(modifier = Modifier.size(28.dp)) {
-                        if (onForwardChevronTap != null) {
-                            IconButton(
-                                onClick = onForwardChevronTap,
-                                modifier = Modifier.size(28.dp),
-                            ) {
-                                Icon(
-                                    imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
-                                    contentDescription =
-                                        stringResource(R.string.today_forward_to_following_week),
-                                )
-                            }
-                        }
-                    }
-                }
-                val proseText = when {
-                    days.size < 2 -> stringResource(R.string.today_week_empty)
-                    weekAheadText != null -> weekAheadText
-                    else -> stringResource(R.string.today_week_ahead_steady)
-                }
-                Text(
-                    text = proseText,
-                    style = MaterialTheme.typography.headlineSmall,
+        val locationLabel = shortLocationLabel(location?.displayName)
+            ?: location?.let { stringResource(R.string.today_location_unknown) }
+        val proseText = when {
+            days.size < 2 -> stringResource(R.string.today_week_empty)
+            weekAheadText != null -> weekAheadText
+            else -> stringResource(R.string.today_week_ahead_steady)
+        }
+        InsightCardShell(
+            leftSlot = {
+                InsightCardChevron(
+                    imageVector = Icons.AutoMirrored.Filled.KeyboardArrowLeft,
+                    contentDescription = stringResource(R.string.today_back_to_primary),
+                    onClick = onChevronTap,
                 )
-            }
+            },
+            rightSlot = {
+                if (onForwardChevronTap != null) {
+                    InsightCardChevron(
+                        imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                        contentDescription = stringResource(R.string.today_forward_to_following_week),
+                        onClick = onForwardChevronTap,
+                    )
+                }
+            },
+            centerContent = {
+                // Same affordance as the per-period card's header: the city
+                // suffix opens Location settings (inert in previews / tests).
+                InsightCardCenterLabel(
+                    label = stringResource(titleRes),
+                    locationLabel = locationLabel,
+                    onNavigateToLocation = onNavigateToLocation,
+                )
+            },
+        ) {
+            Text(
+                text = proseText,
+                style = MaterialTheme.typography.headlineSmall,
+            )
         }
         },
         // The chart deck — its own reorderable section, same as on the

--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
@@ -2522,99 +2522,62 @@ internal fun InsightCard(
     val renderLeftChevron = showChevronLeft && onChevronTap != null
     val rightChevronAction = onChevronRightTap ?: onChevronTap
     val renderRightChevron = showChevronRight && rightChevronAction != null
-    Card(modifier = Modifier.fillMaxWidth()) {
-        Column(
-            modifier = Modifier.padding(20.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp),
-        ) {
-            // Three-zone header: 28.dp slots are reserved on both edges so
-            // the period label sits in the same horizontal position whether
-            // or not a chevron is currently rendered, and so the back/forward
-            // affordances land on opposite edges as the user swipes between
-            // pages. AutoMirrored chevron variants flip in RTL automatically.
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Box(modifier = Modifier.size(28.dp)) {
-                    if (renderLeftChevron) {
-                        IconButton(
-                            onClick = { onChevronTap?.invoke() },
-                            modifier = Modifier.size(28.dp),
-                        ) {
-                            Icon(
-                                imageVector = Icons.AutoMirrored.Filled.KeyboardArrowLeft,
-                                contentDescription = stringResource(R.string.today_back_to_primary),
-                            )
-                        }
-                    }
-                }
-                Row(
-                    modifier = Modifier.weight(1f),
-                    horizontalArrangement = Arrangement.Center,
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Text(
-                        text = periodLabel,
-                        style = MaterialTheme.typography.labelLarge,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = if (onLongPressDate != null) {
-                            Modifier.pointerInput(onLongPressDate) {
-                                detectTapGestures(onLongPress = { onLongPressDate() })
-                            }
-                        } else {
-                            Modifier
-                        },
-                    )
-                    if (location != null && locationLabel != null) {
-                        Text(
-                            text = " · ",
-                            style = MaterialTheme.typography.labelLarge,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-                        Text(
-                            text = locationLabel,
-                            style = MaterialTheme.typography.labelLarge,
-                            color = MaterialTheme.colorScheme.primary,
-                            // Tapping the city name opens the Location settings
-                            // page — the address detail + Map button live there.
-                            // Falls back to inert text when no nav callback is
-                            // wired (previews / tests).
-                            modifier = if (onNavigateToLocation != null) {
-                                Modifier.clickable { onNavigateToLocation() }
-                            } else {
-                                Modifier
-                            },
-                        )
-                    }
-                }
-                Box(modifier = Modifier.size(28.dp)) {
-                    if (renderRightChevron) {
-                        IconButton(
-                            onClick = { rightChevronAction?.invoke() },
-                            modifier = Modifier.size(28.dp),
-                        ) {
-                            Icon(
-                                imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
-                                contentDescription = stringResource(R.string.today_view_other_period),
-                            )
-                        }
-                    }
-                }
+    InsightCardShell(
+        // 28.dp edge slots reserved on both sides so the centered label holds
+        // its position whether or not a chevron renders, and the back / forward
+        // affordances land on opposite edges as the user swipes between pages.
+        leftSlot = {
+            if (renderLeftChevron) {
+                InsightCardChevron(
+                    imageVector = Icons.AutoMirrored.Filled.KeyboardArrowLeft,
+                    contentDescription = stringResource(R.string.today_back_to_primary),
+                    onClick = { onChevronTap?.invoke() },
+                )
             }
-            Text(
-                // VISUAL surface: under the default Speech-only period preamble
-                // the card opens straight on the measurement ("14° to 20°. …"),
-                // dropping the redundant "Today, it will be …" lead the card's
-                // own period header already supplies. The user's Lead-in setting
-                // can override (Always shows the lead here too; Never drops it
-                // from the spoken briefing as well).
-                text = formatter.format(insight.summary, isFutureDay = isFutureDay),
-                style = MaterialTheme.typography.headlineSmall,
-                modifier = if (onNavigateToFormat != null) {
-                    Modifier.clickable { onNavigateToFormat() }
+        },
+        rightSlot = {
+            if (renderRightChevron) {
+                InsightCardChevron(
+                    imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                    contentDescription = stringResource(R.string.today_view_other_period),
+                    onClick = { rightChevronAction?.invoke() },
+                )
+            }
+        },
+        centerContent = {
+            // The period label carries the hidden long-press-to-Developer-
+            // settings gesture when wired; the city suffix opens Location
+            // settings (the address detail + Map button live there) and falls
+            // back to inert text when no nav callback is wired (previews / tests).
+            InsightCardCenterLabel(
+                label = periodLabel,
+                locationLabel = locationLabel,
+                onNavigateToLocation = onNavigateToLocation,
+                labelModifier = if (onLongPressDate != null) {
+                    Modifier.pointerInput(onLongPressDate) {
+                        detectTapGestures(onLongPress = { onLongPressDate() })
+                    }
                 } else {
                     Modifier
                 },
             )
-        }
+        },
+    ) {
+        Text(
+            // VISUAL surface: under the default Speech-only period preamble
+            // the card opens straight on the measurement ("14° to 20°. …"),
+            // dropping the redundant "Today, it will be …" lead the card's
+            // own period header already supplies. The user's Lead-in setting
+            // can override (Always shows the lead here too; Never drops it
+            // from the spoken briefing as well).
+            text = formatter.format(insight.summary, isFutureDay = isFutureDay),
+            style = MaterialTheme.typography.headlineSmall,
+            modifier = if (onNavigateToFormat != null) {
+                Modifier.clickable { onNavigateToFormat() }
+            } else {
+                Modifier
+            },
+        )
     }
 }
 


### PR DESCRIPTION
## What

The per-period `InsightCard` (Today pager pages 0/1) and the week-ahead headline card on `SevenDayPage` (page 2) each hand-rolled the same `Card` + header-row + prose scaffolding. A retune of the chevron slot size, inter-row spacing, or header typography in one would silently drift from the other — the exact risk the `TODO(InsightCardShell)` on `SevenDayPage` called out.

## Change

New `InsightCardShell.kt` (package-internal) holds the shared geometry plus two small helpers:

- **`InsightCardShell`** — a 20.dp-padded `Card`, a 12.dp inter-row gap, and a three-zone header row with fixed **28.dp edge slots** framing a `weight(1f)` centered region. Edge slots (`leftSlot`/`rightSlot`), the centered region (`centerContent`), and the `body` are caller-supplied composable slots.
- **`InsightCardChevron`** — the 28.dp edge affordance (AutoMirrored arrow, RTL-aware).
- **`InsightCardCenterLabel`** — the `labelLarge` title + optional `" · <city>"` suffix that links to Location settings.

Both cards now compose against the shell. Each keeps its own specifics via the slots: the per-period card keeps its hidden long-press-to-Developer-settings gesture on the label and its prose→Format-settings tap target; the week-ahead card keeps its plain title and optional forward chevron.

Also pruned 8 now-unused imports from `SevenDayPage`.

## No behavior change

Rendered output is **byte-identical** — the 262 Roborazzi snapshots are unchanged (no regen needed). Removes the `TODO(InsightCardShell)` note.

## Test plan

- `./gradlew :app:testDebugUnitTest` (incl. Roborazzi snapshot verification) — green, no diffs.
- `./gradlew :app:assembleDebug` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HvXeNpUi6S5ibXkdEaeG8g)_