### PR TITLE
Show wind in m/s by default in Sweden, Norway, Denmark, and Finland

### DIFF
--- a/app/src/main/kotlin/app/clothescast/data/SettingsRepository.kt
+++ b/app/src/main/kotlin/app/clothescast/data/SettingsRepository.kt
@@ -2030,12 +2030,21 @@ private const val NEW_UMBRELLA_DEFAULT_PCT = 10.0
 internal fun defaultTemperatureUnitFor(locale: Locale): TemperatureUnit =
     if (locale.country == "US") TemperatureUnit.FAHRENHEIT else TemperatureUnit.CELSIUS
 
-// US and UK public forecasts report wind in mph (Met Office included), so
-// those two locales default to MPH; everyone else defaults to km/h. Knots and
-// m/s are never an auto default — no country uses them for everyday public
-// land forecasts, so they stay opt-in via the picker.
-internal fun defaultWindSpeedUnitFor(locale: Locale): WindSpeedUnit =
-    if (locale.country in setOf("US", "GB")) WindSpeedUnit.MPH else WindSpeedUnit.KMH
+// Per-region wind-unit defaults for AUTO, by everyday public-forecast
+// convention:
+//  - US / UK report wind in mph (Met Office included) → MPH.
+//  - The Nordics report wind in m/s (SMHI, MET Norway, DMI, FMI, Veðurstofa
+//    Íslands) → MS.
+//  - Everyone else → km/h.
+// Knots is never an auto default — it's an aviation / marine unit no country
+// uses for everyday public land forecasts — so it stays opt-in via the picker.
+private val MPH_COUNTRIES = setOf("US", "GB")
+private val MS_COUNTRIES = setOf("SE", "NO", "DK", "FI", "IS")
+internal fun defaultWindSpeedUnitFor(locale: Locale): WindSpeedUnit = when (locale.country) {
+    in MPH_COUNTRIES -> WindSpeedUnit.MPH
+    in MS_COUNTRIES -> WindSpeedUnit.MS
+    else -> WindSpeedUnit.KMH
+}
 
 // Derive the locale's everyday clock convention by inspecting the SHORT
 // time-format pattern for an unquoted 12h hour field. The quote-aware

--- a/app/src/test/kotlin/app/clothescast/data/SettingsRepositoryTest.kt
+++ b/app/src/test/kotlin/app/clothescast/data/SettingsRepositoryTest.kt
@@ -667,6 +667,31 @@ class SettingsRepositoryTest {
     }
 
     @Test
+    fun `wind-speed default follows region locale - Nordic locales pick m per s`() = runTest {
+        // Sweden, Norway, Denmark, and Finland report public wind in m/s, so
+        // AUTO resolves to MS there rather than the km/h global default.
+        subject.setRegion(Region.SV_SE)
+        subject.preferences.first().windSpeedUnit shouldBe WindSpeedUnit.MS
+
+        subject.setRegion(Region.NB_NO)
+        subject.preferences.first().windSpeedUnit shouldBe WindSpeedUnit.MS
+
+        subject.setRegion(Region.DA_DK)
+        subject.preferences.first().windSpeedUnit shouldBe WindSpeedUnit.MS
+
+        subject.setRegion(Region.FI_FI)
+        subject.preferences.first().windSpeedUnit shouldBe WindSpeedUnit.MS
+    }
+
+    @Test
+    fun `wind-speed default follows region locale - de-DE keeps km per h`() = runTest {
+        // Germany is metric but reports public wind in km/h, not m/s — the
+        // m/s default is Nordic-specific, not all-metric.
+        subject.setRegion(Region.DE_DE)
+        subject.preferences.first().windSpeedUnit shouldBe WindSpeedUnit.KMH
+    }
+
+    @Test
     fun `temperature default follows region locale - en-GB picks Celsius`() = runTest {
         subject.setRegion(Region.EN_GB)
         subject.preferences.first().temperatureUnit shouldBe TemperatureUnit.CELSIUS


### PR DESCRIPTION
## What

Follow-on to the wind-speed-unit feature (#1072): under **Auto**, the wind unit now resolves to **m/s** for Nordic locales (SE / NO / DK / FI / IS) instead of the km/h global default.

## Why

Nordic national forecasters report public wind in metres per second — SMHI (Sweden), MET Norway / yr.no, DMI (Denmark), FMI (Finland), Veðurstofa Íslands. Defaulting those locales to m/s matches what users there actually see elsewhere. mph (US/UK) and km/h (everyone else) are unchanged, and knots stays opt-in only (it's an aviation/marine unit, never a public-forecast default).

The m/s default is **Nordic-specific, not all-metric**: Germany is metric but reports public wind in km/h, so it stays on km/h (covered by a guard test).

## Scope
- `defaultWindSpeedUnitFor` gains an `MS_COUNTRIES` set (SE/NO/DK/FI/IS). Only the **Auto** resolution changes — a user who explicitly picked a unit keeps it (their choice is persisted and takes precedence). No migration needed.
- The Region settings "Auto (…)" label already renders the resolved symbol, so Nordic users now see "Auto (m/s)" automatically — no UI change.

## Test plan
- `:app:testDebugUnitTest` — green. Added region-default coverage asserting SV_SE / NB_NO / DA_DK / FI_FI resolve to m/s, plus a DE_DE guard that stays km/h.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VPGYFfoGeqjGoyppxaeuWb)_