### PR TITLE
Update home-screen widgets when you change display settings

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsViewModel.kt
@@ -511,41 +511,61 @@ class SettingsViewModel(
         viewModelScope.launch { settingsRepository.setTonightDeliveryMode(mode) }
     }
 
+    // Display settings below all poke refreshOutfitWidget() after the write.
+    // The home-screen widgets render from a one-shot prefs snapshot and don't
+    // subscribe to the prefs flow (unlike the Today screen), so they only
+    // repaint when updateAllClothesCastWidgets() is called or at the next
+    // scheduled refresh. The ConditionsWidget reads temperatureUnit /
+    // windSpeedUnit; the FeelsLikeWidget reads temperatureUnit / timeFormat /
+    // colorPalette / themeMode; region changes the AUTO-resolved units. Without
+    // the nudge the launcher shows the old value until the next worker run.
+    // (Same contract the outfit-color setters below follow; see the
+    // refreshOutfitWidget note in ClothesCastNavHost.)
     fun setRegion(region: Region) {
         // Apply the locale up front so the UI recreates immediately; the
         // DataStore write happens in the background. The Application's
         // onCreate reconciler re-applies on next cold start, so the order
         // here can't drift out of sync.
         applyAppLocale(region)
-        viewModelScope.launch { settingsRepository.setRegion(region) }
+        viewModelScope.launch {
+            settingsRepository.setRegion(region)
+            refreshOutfitWidget()
+        }
     }
 
     fun setTemperatureUnitSetting(setting: TemperatureUnitSetting) {
-        viewModelScope.launch { settingsRepository.setTemperatureUnitSetting(setting) }
+        viewModelScope.launch {
+            settingsRepository.setTemperatureUnitSetting(setting)
+            refreshOutfitWidget()
+        }
     }
 
     fun setWindSpeedUnitSetting(setting: WindSpeedUnitSetting) {
         viewModelScope.launch {
             settingsRepository.setWindSpeedUnitSetting(setting)
-            // The Conditions widget renders the wind label off prefs.windSpeedUnit
-            // but doesn't subscribe to the prefs flow, so nudge it to repaint —
-            // otherwise the launcher keeps the old unit until the next scheduled
-            // cache/widget refresh. (Same reason the outfit-color setters below
-            // refresh; see the refreshOutfitWidget note in ClothesCastNavHost.)
             refreshOutfitWidget()
         }
     }
 
     fun setTimeFormatSetting(setting: TimeFormatSetting) {
-        viewModelScope.launch { settingsRepository.setTimeFormatSetting(setting) }
+        viewModelScope.launch {
+            settingsRepository.setTimeFormatSetting(setting)
+            refreshOutfitWidget()
+        }
     }
 
     fun setThemeMode(mode: ThemeMode) {
-        viewModelScope.launch { settingsRepository.setThemeMode(mode) }
+        viewModelScope.launch {
+            settingsRepository.setThemeMode(mode)
+            refreshOutfitWidget()
+        }
     }
 
     fun setColorPalette(palette: ColorPalette) {
-        viewModelScope.launch { settingsRepository.setColorPalette(palette) }
+        viewModelScope.launch {
+            settingsRepository.setColorPalette(palette)
+            refreshOutfitWidget()
+        }
     }
 
     /**

--- a/app/src/test/kotlin/app/clothescast/ui/settings/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/app/clothescast/ui/settings/SettingsViewModelTest.kt
@@ -11,6 +11,7 @@ import app.clothescast.core.domain.model.CalendarEvent
 import app.clothescast.core.domain.model.ClothesMentionMode
 import app.clothescast.core.domain.model.PreambleVisibility
 import app.clothescast.core.domain.model.ClothesRule
+import app.clothescast.core.domain.model.ColorPalette
 import app.clothescast.core.domain.model.DeliveryMode
 import app.clothescast.core.domain.model.WindSpeedUnit
 import app.clothescast.core.domain.model.WindSpeedUnitSetting
@@ -19,6 +20,8 @@ import app.clothescast.core.domain.model.OutfitSuggestion
 import app.clothescast.core.domain.model.Region
 import app.clothescast.core.domain.model.TemperatureUnit
 import app.clothescast.core.domain.model.TemperatureUnitSetting
+import app.clothescast.core.domain.model.ThemeMode
+import app.clothescast.core.domain.model.TimeFormatSetting
 import app.clothescast.core.domain.model.UpcomingCalendarEvent
 import app.clothescast.core.domain.repository.CalendarEventReader
 import app.clothescast.data.SecureKeyStore
@@ -465,12 +468,34 @@ class SettingsViewModelTest {
         refreshSubject.state.first { it.deltaThresholdC == 8.0 }
         refreshCount shouldBe 4
 
-        // The wind-speed unit changes the Conditions widget's wind label, which
-        // doesn't subscribe to the prefs flow — so the setter must poke the
-        // widget (Codex flag on PR #1072).
+        // Display settings that change what a home-screen widget renders must
+        // poke it too — the widgets don't subscribe to the prefs flow.
+        // ConditionsWidget reads temperatureUnit / windSpeedUnit; FeelsLikeWidget
+        // reads temperatureUnit / timeFormat / colorPalette / themeMode; region
+        // changes the AUTO-resolved units. (Codex flag on PR #1072.)
         refreshSubject.setWindSpeedUnitSetting(WindSpeedUnitSetting.KNOTS)
         refreshSubject.state.first { it.windSpeedUnitSetting == WindSpeedUnitSetting.KNOTS }
         refreshCount shouldBe 5
+
+        refreshSubject.setTemperatureUnitSetting(TemperatureUnitSetting.FAHRENHEIT)
+        refreshSubject.state.first { it.temperatureUnitSetting == TemperatureUnitSetting.FAHRENHEIT }
+        refreshCount shouldBe 6
+
+        refreshSubject.setTimeFormatSetting(TimeFormatSetting.TWELVE_HOUR)
+        refreshSubject.state.first { it.timeFormatSetting == TimeFormatSetting.TWELVE_HOUR }
+        refreshCount shouldBe 7
+
+        refreshSubject.setColorPalette(ColorPalette.ACCESSIBLE)
+        refreshSubject.state.first { it.colorPalette == ColorPalette.ACCESSIBLE }
+        refreshCount shouldBe 8
+
+        refreshSubject.setThemeMode(ThemeMode.DARK)
+        refreshSubject.state.first { it.themeMode == ThemeMode.DARK }
+        refreshCount shouldBe 9
+
+        refreshSubject.setRegion(Region.EN_US)
+        refreshSubject.state.first { it.region == Region.EN_US }
+        refreshCount shouldBe 10
     }
 
     @Test


### PR DESCRIPTION
## What

Changing **temperature unit, time format, color palette, theme, or region** now repaints any placed home-screen widget immediately, instead of leaving the stale value until the next scheduled refresh / reboot.

## Why

Glance widgets render from a one-shot preferences snapshot and **don't subscribe to the prefs DataStore flow** (the Today screen does, which is why it updates live). A widget only repaints when `updateAllClothesCastWidgets()` is called (the `refreshOutfitWidget` hook) or on its periodic schedule. So a settings change that affects what a widget draws was invisible on the launcher until the next worker run.

The outfit-color and clothes-rule setters already poked the widget, and `setWindSpeedUnitSetting` did as of #1072 (Codex flag). This closes the same gap for the remaining display settings the widgets actually read:

| Widget | Prefs it renders |
|---|---|
| `ConditionsWidget` | `temperatureUnit`, `windSpeedUnit` |
| `FeelsLikeWidget` | `temperatureUnit`, `timeFormat`, `colorPalette`, `themeMode` |

…plus `setRegion`, which changes the AUTO-resolved units.

## Scope
- `SettingsViewModel`: `setRegion`, `setTemperatureUnitSetting`, `setTimeFormatSetting`, `setColorPalette`, `setThemeMode` now call `refreshOutfitWidget()` after the write (matching `setWindSpeedUnitSetting`). A shared comment documents the contract.
- No behavior change beyond the immediate repaint — these are pure display settings; nothing in the data pipeline changes.

## Test plan
- `:core:*:test`, `:app:testDebugUnitTest`, `:app:assembleDebug` — green.
- Extended the existing refresh-contract test (`SettingsViewModelTest`) to assert each of the five display setters pokes the widget exactly once (refreshCount 5→10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VPGYFfoGeqjGoyppxaeuWb)_