### PR TITLE
Repaint home-screen widgets from one settings observer

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ClothesCastApplication.kt
+++ b/app/src/main/kotlin/app/clothescast/ClothesCastApplication.kt
@@ -35,6 +35,8 @@ import app.clothescast.discovery.HomeAssistantDiscovery
 import app.clothescast.discovery.NsdHomeAssistantDiscovery
 import app.clothescast.diag.Telemetry
 import app.clothescast.diag.TelemetryApiCallLogger
+import app.clothescast.widget.toWidgetInputs
+import app.clothescast.widget.updateAllClothesCastWidgets
 import app.clothescast.locale.AppLocale
 import app.clothescast.location.LocationResolver
 import app.clothescast.location.ReverseGeocoder
@@ -51,11 +53,15 @@ import io.ktor.client.HttpClient
 import io.ktor.client.engine.okhttp.OkHttp
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import java.lang.ref.WeakReference
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
 
@@ -339,6 +345,33 @@ class ClothesCastApplication : Application() {
             // edit's worth of disk I/O.
             runCatching { settingsRepository.clearLegacyHomePreferences() }
                 .onFailure { DiagLog.w(TAG, "Legacy home-pref cleanup failed", it) }
+        }
+        applicationScope.launch {
+            // Repaint placed home-screen widgets whenever a setting they render
+            // changes. Glance widgets don't observe the preferences flow (they
+            // render from a one-shot snapshot), so a single observer here is the
+            // one place that pokes the launcher — the settings setters just
+            // write. distinctUntilChanged on the widget-relevant slice (see
+            // WidgetInputs) avoids needless repaints on unrelated edits; drop(1)
+            // skips the value present at process start (the widgets already show
+            // it). Settings only change while the app is foregrounded, so this
+            // process-scoped collector reliably catches every edit.
+            settingsRepository.preferences
+                .map { it.toWidgetInputs() }
+                .distinctUntilChanged()
+                .drop(1)
+                .collect {
+                    try {
+                        updateAllClothesCastWidgets(this@ClothesCastApplication)
+                    } catch (c: CancellationException) {
+                        throw c
+                    } catch (t: Throwable) {
+                        // A repaint failure (e.g. Glance host transiently
+                        // unavailable) shouldn't kill the observer; the next
+                        // change — or the scheduled worker — repaints anyway.
+                        DiagLog.w(TAG, "Widget refresh after settings change failed", t)
+                    }
+                }
         }
         applicationScope.launch {
             try {

--- a/app/src/main/kotlin/app/clothescast/ui/nav/ClothesCastNavHost.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/nav/ClothesCastNavHost.kt
@@ -54,7 +54,6 @@ import app.clothescast.ui.settings.SmartHomePage
 import app.clothescast.ui.settings.VoicePage
 import app.clothescast.ui.today.TodayScreen
 import app.clothescast.ui.today.TodayViewModel
-import app.clothescast.widget.updateAllClothesCastWidgets
 import app.clothescast.work.FetchAndNotifyWorker
 import kotlinx.coroutines.flow.first
 import kotlinx.serialization.ExperimentalSerializationApi
@@ -325,9 +324,6 @@ private fun todayViewModelFactory(app: ClothesCastApplication) =
         insightCache = app.insightCache,
         workManager = WorkManager.getInstance(app),
         settingsRepository = app.settingsRepository,
-        refreshOutfitWidget = {
-            updateAllClothesCastWidgets(app)
-        },
         deriveInsight = app.deriveInsight,
         calendarEventReader = app.calendarEventReader,
         geminiKeyConfigured = app.secureKeyStore.geminiKeyConfiguredFlow,
@@ -353,15 +349,6 @@ private fun settingsViewModelFactory(app: ClothesCastApplication) =
         },
         refreshLocationCache = {
             FetchAndNotifyWorker.enqueueLocationCacheRefresh(app)
-        },
-        refreshOutfitWidget = {
-            // No cache work needed — the cache holds the raw ForecastSnapshot,
-            // and every consumer (Today screen, Format settings preview, cast,
-            // MQTT) re-derives off the current prefs reactively. The widgets
-            // don't subscribe to the prefs flow themselves, so a settings write
-            // that changes what they render (outfit icon, or the chart's
-            // temperature unit) needs an explicit nudge to repaint the launcher.
-            updateAllClothesCastWidgets(app)
         },
         workManager = WorkManager.getInstance(app),
         insightCache = app.insightCache,

--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsViewModel.kt
@@ -93,17 +93,6 @@ class SettingsViewModel(
      */
     private val voiceEnumerationDispatcher: CoroutineDispatcher = Dispatchers.IO,
     /**
-     * Pokes the home-screen widget after a settings change so the launcher
-     * icon catches up in the same frame as the Today screen. The cache no
-     * longer needs a recompute — the snapshot it holds is settings-
-     * independent and the widget re-derives at every `provideGlance()` —
-     * but the widget doesn't observe the settings flow itself, so a `+1°`
-     * tap that flips the icon tier needs this nudge to repaint the launcher.
-     * Defaulted to a no-op for pure-VM tests; the Activity wires the real
-     * `OutfitWidget().updateAll(...)` call.
-     */
-    private val refreshOutfitWidget: suspend () -> Unit = {},
-    /**
      * Pushes the chosen [Region] into the platform locale machinery
      * (Locale.setDefault + LocaleManager / attachBaseContext cache) so the
      * whole UI re-renders in the chosen language. Defaulted to a no-op so
@@ -511,16 +500,10 @@ class SettingsViewModel(
         viewModelScope.launch { settingsRepository.setTonightDeliveryMode(mode) }
     }
 
-    // Display settings below all poke refreshOutfitWidget() after the write.
-    // The home-screen widgets render from a one-shot prefs snapshot and don't
-    // subscribe to the prefs flow (unlike the Today screen), so they only
-    // repaint when updateAllClothesCastWidgets() is called or at the next
-    // scheduled refresh. The ConditionsWidget reads temperatureUnit /
-    // windSpeedUnit; the FeelsLikeWidget reads temperatureUnit / timeFormat /
-    // colorPalette / themeMode; region changes the AUTO-resolved units. Without
-    // the nudge the launcher shows the old value until the next worker run.
-    // (Same contract the outfit-color setters below follow; see the
-    // refreshOutfitWidget note in ClothesCastNavHost.)
+    // Widgets repaint reactively: ClothesCastApplication observes the
+    // widget-relevant slice of preferences (see WidgetInputs) and calls
+    // updateAllClothesCastWidgets on any change, so these setters just write
+    // and don't poke the launcher themselves.
     fun setRegion(region: Region) {
         // Apply the locale up front so the UI recreates immediately; the
         // DataStore write happens in the background. The Application's
@@ -529,55 +512,48 @@ class SettingsViewModel(
         applyAppLocale(region)
         viewModelScope.launch {
             settingsRepository.setRegion(region)
-            refreshOutfitWidget()
         }
     }
 
     fun setTemperatureUnitSetting(setting: TemperatureUnitSetting) {
         viewModelScope.launch {
             settingsRepository.setTemperatureUnitSetting(setting)
-            refreshOutfitWidget()
         }
     }
 
     fun setWindSpeedUnitSetting(setting: WindSpeedUnitSetting) {
         viewModelScope.launch {
             settingsRepository.setWindSpeedUnitSetting(setting)
-            refreshOutfitWidget()
         }
     }
 
     fun setTimeFormatSetting(setting: TimeFormatSetting) {
         viewModelScope.launch {
             settingsRepository.setTimeFormatSetting(setting)
-            refreshOutfitWidget()
         }
     }
 
     fun setThemeMode(mode: ThemeMode) {
         viewModelScope.launch {
             settingsRepository.setThemeMode(mode)
-            refreshOutfitWidget()
         }
     }
 
     fun setColorPalette(palette: ColorPalette) {
         viewModelScope.launch {
             settingsRepository.setColorPalette(palette)
-            refreshOutfitWidget()
         }
     }
 
     /**
      * Sets the user's fill-colour override for the [top] icon (or clears it
-     * with `argb = null`). Re-renders the cached outfit + widget so the
-     * Today screen and any home-screen widget pick up the new colour in
-     * the same frame as the picker dismisses.
+     * with `argb = null`). The Today screen re-renders reactively off the
+     * prefs flow; the home-screen widget repaints via the preferences observer
+     * in ClothesCastApplication (see WidgetInputs).
      */
     fun setOutfitTopColor(top: OutfitSuggestion.Top, argb: Long?) {
         viewModelScope.launch {
             settingsRepository.setOutfitTopColor(top, argb)
-            refreshOutfitWidget()
         }
     }
 
@@ -585,7 +561,6 @@ class SettingsViewModel(
     fun setOutfitBottomColor(bottom: OutfitSuggestion.Bottom, argb: Long?) {
         viewModelScope.launch {
             settingsRepository.setOutfitBottomColor(bottom, argb)
-            refreshOutfitWidget()
         }
     }
 
@@ -593,7 +568,6 @@ class SettingsViewModel(
     fun setOutfitHandsColor(hands: OutfitSuggestion.Hands, argb: Long?) {
         viewModelScope.launch {
             settingsRepository.setOutfitHandsColor(hands, argb)
-            refreshOutfitWidget()
         }
     }
 
@@ -601,7 +575,6 @@ class SettingsViewModel(
     fun setOutfitCarriedColor(carried: OutfitSuggestion.Carried, argb: Long?) {
         viewModelScope.launch {
             settingsRepository.setOutfitCarriedColor(carried, argb)
-            refreshOutfitWidget()
         }
     }
 
@@ -609,7 +582,6 @@ class SettingsViewModel(
     fun setOutfitOuterColor(outer: OutfitSuggestion.Outer, argb: Long?) {
         viewModelScope.launch {
             settingsRepository.setOutfitOuterColor(outer, argb)
-            refreshOutfitWidget()
         }
     }
 
@@ -657,7 +629,6 @@ class SettingsViewModel(
     fun addClothesRule(rule: ClothesRule) {
         viewModelScope.launch {
             settingsRepository.setClothesRules(_state.value.clothesRules + rule)
-            refreshOutfitWidget()
         }
     }
 
@@ -666,7 +637,6 @@ class SettingsViewModel(
             val current = _state.value.clothesRules
             if (index !in current.indices) return@launch
             settingsRepository.setClothesRules(current.toMutableList().apply { this[index] = rule })
-            refreshOutfitWidget()
         }
     }
 
@@ -675,7 +645,6 @@ class SettingsViewModel(
             val current = _state.value.clothesRules
             if (index !in current.indices) return@launch
             settingsRepository.setClothesRules(current.toMutableList().apply { removeAt(index) })
-            refreshOutfitWidget()
         }
     }
 
@@ -697,14 +666,12 @@ class SettingsViewModel(
     fun setDefaultBottom(bottom: OutfitSuggestion.Bottom) {
         viewModelScope.launch {
             settingsRepository.setDefaultBottom(bottom)
-            refreshOutfitWidget()
         }
     }
 
     fun setDefaultTop(top: OutfitSuggestion.Top) {
         viewModelScope.launch {
             settingsRepository.setDefaultTop(top)
-            refreshOutfitWidget()
         }
     }
 
@@ -1238,7 +1205,6 @@ class SettingsViewModel(
         private val voiceEnumerator: TtsVoiceEnumerator,
         private val applyAppLocale: (Region) -> Unit,
         private val refreshLocationCache: () -> Unit,
-        private val refreshOutfitWidget: suspend () -> Unit,
         private val workManager: WorkManager? = null,
         private val mqttPublisher: MqttPublisher? = null,
         private val fullPublish: (suspend () -> MqttPublishOutcome)? = null,
@@ -1262,7 +1228,6 @@ class SettingsViewModel(
                 cancelAlarm = cancelAlarm,
                 geocodingClient = geocodingClient,
                 voiceEnumerator = voiceEnumerator,
-                refreshOutfitWidget = refreshOutfitWidget,
                 applyAppLocale = applyAppLocale,
                 refreshLocationCache = refreshLocationCache,
                 workManager = workManager,

--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayViewModel.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayViewModel.kt
@@ -468,13 +468,6 @@ class TodayViewModel(
      */
     private val deriveInsight: DeriveInsight = DeriveInsight(),
     /**
-     * Pushes the home-screen widget after a clothes-rule nudge so the icon
-     * out on the launcher refreshes in the same frame as the Today screen.
-     * Defaulted to a no-op so pure-VM tests don't need an Android Context;
-     * the Activity wires `OutfitWidget().updateAll(applicationContext)`.
-     */
-    private val refreshOutfitWidget: suspend () -> Unit = {},
-    /**
      * Source of "today" for the holiday resolver. Held as a [Clock] (not
      * `() -> LocalDate`) so tests can pin a specific instant while production
      * uses the system zone. Defaulted to system clock so callers that don't
@@ -944,7 +937,6 @@ class TodayViewModel(
         private val insightCache: InsightCache,
         private val workManager: WorkManager,
         private val settingsRepository: SettingsRepository,
-        private val refreshOutfitWidget: suspend () -> Unit,
         private val deriveInsight: DeriveInsight = DeriveInsight(),
         private val calendarEventReader: CalendarEventReader? = null,
         private val geminiKeyConfigured: Flow<Boolean> = flowOf(false),
@@ -959,7 +951,6 @@ class TodayViewModel(
                 insightCache = insightCache,
                 workManager = workManager,
                 settingsRepository = settingsRepository,
-                refreshOutfitWidget = refreshOutfitWidget,
                 deriveInsight = deriveInsight,
                 calendarEventReader = calendarEventReader,
                 geminiKeyConfigured = geminiKeyConfigured,

--- a/app/src/main/kotlin/app/clothescast/widget/WidgetRefresh.kt
+++ b/app/src/main/kotlin/app/clothescast/widget/WidgetRefresh.kt
@@ -1,0 +1,70 @@
+package app.clothescast.widget
+
+import app.clothescast.core.domain.model.ClothesRule
+import app.clothescast.core.domain.model.ColorPalette
+import app.clothescast.core.domain.model.OutfitSuggestion
+import app.clothescast.core.domain.model.Region
+import app.clothescast.core.domain.model.TemperatureUnit
+import app.clothescast.core.domain.model.ThemeMode
+import app.clothescast.core.domain.model.TimeFormat
+import app.clothescast.core.domain.model.UserPreferences
+import app.clothescast.core.domain.model.WindSpeedUnit
+
+/**
+ * The slice of [UserPreferences] that changes what a placed home-screen widget
+ * draws. Glance widgets render from a one-shot snapshot and don't observe the
+ * preferences flow (unlike the Today screen), so something has to call
+ * [updateAllClothesCastWidgets] when one of these fields changes. Rather than
+ * making every settings setter remember to poke the launcher,
+ * `ClothesCastApplication` watches `preferences.map { it.toWidgetInputs() }`
+ * with `distinctUntilChanged` and repaints on any change.
+ *
+ * Keep this in sync with what the widgets actually read:
+ *  - [ConditionsWidget]: [region] (the locale formatter), [temperatureUnit],
+ *    [windSpeedUnit].
+ *  - [FeelsLikeWidget]: [temperatureUnit], [timeFormat], [colorPalette],
+ *    [themeMode].
+ *  - The outfit icon ([OutfitWidget]): [clothesRules], [defaultTop] /
+ *    [defaultBottom], and the per-tier colour overrides.
+ *
+ * Deliberately excludes the schedule: which period the widget shows is derived
+ * from the clock at render time, and a schedule edit doesn't repaint the
+ * launcher today — only the next scheduled run picks it up. Adding a field the
+ * widgets don't render just causes needless repaints; omitting one the widgets
+ * do render reintroduces the stale-widget bug, so treat this list as the
+ * contract.
+ */
+data class WidgetInputs(
+    val region: Region,
+    val temperatureUnit: TemperatureUnit,
+    val windSpeedUnit: WindSpeedUnit,
+    val timeFormat: TimeFormat,
+    val colorPalette: ColorPalette,
+    val themeMode: ThemeMode,
+    val clothesRules: List<ClothesRule>,
+    val defaultTop: OutfitSuggestion.Top,
+    val defaultBottom: OutfitSuggestion.Bottom,
+    val outfitTopColors: Map<OutfitSuggestion.Top, Long>,
+    val outfitBottomColors: Map<OutfitSuggestion.Bottom, Long>,
+    val outfitHandsColors: Map<OutfitSuggestion.Hands, Long>,
+    val outfitCarriedColors: Map<OutfitSuggestion.Carried, Long>,
+    val outfitOuterColors: Map<OutfitSuggestion.Outer, Long>,
+)
+
+/** Projects the widget-relevant fields out of the full preferences. */
+fun UserPreferences.toWidgetInputs(): WidgetInputs = WidgetInputs(
+    region = region,
+    temperatureUnit = temperatureUnit,
+    windSpeedUnit = windSpeedUnit,
+    timeFormat = timeFormat,
+    colorPalette = colorPalette,
+    themeMode = themeMode,
+    clothesRules = clothesRules,
+    defaultTop = defaultTop,
+    defaultBottom = defaultBottom,
+    outfitTopColors = outfitTopColors,
+    outfitBottomColors = outfitBottomColors,
+    outfitHandsColors = outfitHandsColors,
+    outfitCarriedColors = outfitCarriedColors,
+    outfitOuterColors = outfitOuterColors,
+)

--- a/app/src/test/kotlin/app/clothescast/ui/settings/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/app/clothescast/ui/settings/SettingsViewModelTest.kt
@@ -414,89 +414,9 @@ class SettingsViewModelTest {
         refreshCount shouldBe 1
     }
 
-    @Test
-    fun `clothes-rule edits and setDefaultBottom kick the cached-outfit refresh`() = runTest {
-        // The Activity wires this lambda to OutfitWidget().updateAll()
-        // pair so the home-screen icon flips immediately on every clothes-rule
-        // change. Without the refresh, settings writes would only land on the
-        // Today screen at the next worker run — the bug Codex flagged on PR
-        // #419.
-        var refreshCount = 0
-        val refreshSubject = track(
-            SettingsViewModel(
-                settingsRepository = settingsRepository,
-                keyStore = keyStore,
-                rearmAlarm = { _, _ -> },
-                cancelAlarm = { _ -> },
-                geocodingClient = OpenMeteoGeocodingClient(
-                    HttpClient(MockEngine { respond("""{"results":[]}""") }) {
-                        install(ContentNegotiation) { json(KotlinxJson { ignoreUnknownKeys = true }) }
-                    },
-                ),
-                voiceEnumerator = EmptyVoiceEnumerator,
-                voiceEnumerationDispatcher = dispatcher,
-                refreshOutfitWidget = { refreshCount++ },
-            ),
-        )
-
-        refreshSubject.addClothesRule(ClothesRule(Garment.HOODIE, ClothesRule.TemperatureBelow(0.0)))
-        refreshSubject.state.first { it.clothesRules.any { rule -> rule.item == Garment.HOODIE } }
-        refreshCount shouldBe 1
-
-        refreshSubject.replaceClothesRule(0, ClothesRule(Garment.PUFFER, ClothesRule.TemperatureBelow(0.0)))
-        refreshSubject.state.first { it.clothesRules.first().item == Garment.PUFFER }
-        refreshCount shouldBe 2
-
-        refreshSubject.deleteClothesRule(0)
-        refreshSubject.state.first { it.clothesRules.none { rule -> rule.item == Garment.PUFFER } }
-        refreshCount shouldBe 3
-
-        refreshSubject.setDefaultBottom(OutfitSuggestion.Bottom.JEANS)
-        refreshSubject.state.first { it.defaultBottom == OutfitSuggestion.Bottom.JEANS }
-        refreshCount shouldBe 4
-
-        // clothesMentionMode and deltaThresholdC are prose-only — the Today
-        // screen / Format settings preview / cast / MQTT re-derive from the
-        // cached snapshot reactively against the prefs flow, so no widget
-        // poke is needed (the widget renders just the outfit icon, which
-        // these two settings don't touch).
-        refreshSubject.setClothesMentionMode(ClothesMentionMode.NEVER)
-        refreshSubject.state.first { it.clothesMentionMode == ClothesMentionMode.NEVER }
-        refreshCount shouldBe 4
-
-        refreshSubject.setDeltaThresholdC(8.0)
-        refreshSubject.state.first { it.deltaThresholdC == 8.0 }
-        refreshCount shouldBe 4
-
-        // Display settings that change what a home-screen widget renders must
-        // poke it too — the widgets don't subscribe to the prefs flow.
-        // ConditionsWidget reads temperatureUnit / windSpeedUnit; FeelsLikeWidget
-        // reads temperatureUnit / timeFormat / colorPalette / themeMode; region
-        // changes the AUTO-resolved units. (Codex flag on PR #1072.)
-        refreshSubject.setWindSpeedUnitSetting(WindSpeedUnitSetting.KNOTS)
-        refreshSubject.state.first { it.windSpeedUnitSetting == WindSpeedUnitSetting.KNOTS }
-        refreshCount shouldBe 5
-
-        refreshSubject.setTemperatureUnitSetting(TemperatureUnitSetting.FAHRENHEIT)
-        refreshSubject.state.first { it.temperatureUnitSetting == TemperatureUnitSetting.FAHRENHEIT }
-        refreshCount shouldBe 6
-
-        refreshSubject.setTimeFormatSetting(TimeFormatSetting.TWELVE_HOUR)
-        refreshSubject.state.first { it.timeFormatSetting == TimeFormatSetting.TWELVE_HOUR }
-        refreshCount shouldBe 7
-
-        refreshSubject.setColorPalette(ColorPalette.ACCESSIBLE)
-        refreshSubject.state.first { it.colorPalette == ColorPalette.ACCESSIBLE }
-        refreshCount shouldBe 8
-
-        refreshSubject.setThemeMode(ThemeMode.DARK)
-        refreshSubject.state.first { it.themeMode == ThemeMode.DARK }
-        refreshCount shouldBe 9
-
-        refreshSubject.setRegion(Region.EN_US)
-        refreshSubject.state.first { it.region == Region.EN_US }
-        refreshCount shouldBe 10
-    }
+    // Widget repaint is no longer pushed from each setter — ClothesCastApplication
+    // observes the widget-relevant slice of preferences and repaints on change.
+    // WidgetInputsTest guards which fields belong in that slice.
 
     @Test
     fun `setTemperatureUnitSetting and setWindSpeedUnitSetting persist independently`() = runTest {

--- a/app/src/test/kotlin/app/clothescast/widget/WidgetInputsTest.kt
+++ b/app/src/test/kotlin/app/clothescast/widget/WidgetInputsTest.kt
@@ -1,0 +1,83 @@
+package app.clothescast.widget
+
+import app.clothescast.core.domain.model.ClothesMentionMode
+import app.clothescast.core.domain.model.ClothesRule
+import app.clothescast.core.domain.model.ColorPalette
+import app.clothescast.core.domain.model.DeliveryMode
+import app.clothescast.core.domain.model.Garment
+import app.clothescast.core.domain.model.OutfitSuggestion
+import app.clothescast.core.domain.model.Region
+import app.clothescast.core.domain.model.Schedule
+import app.clothescast.core.domain.model.TemperatureUnit
+import app.clothescast.core.domain.model.ThemeMode
+import app.clothescast.core.domain.model.TimeFormat
+import app.clothescast.core.domain.model.UserPreferences
+import app.clothescast.core.domain.model.WindSpeedUnit
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import java.time.LocalTime
+import java.time.ZoneId
+import org.junit.jupiter.api.Test
+
+/**
+ * Guards the contract that [UserPreferences.toWidgetInputs] projects exactly the
+ * fields the home-screen widgets render — no more, no less. Under-projecting
+ * reintroduces the stale-widget bug (a setting changes but the launcher doesn't
+ * repaint); over-projecting causes needless repaints on unrelated edits.
+ */
+class WidgetInputsTest {
+    private val base = UserPreferences(
+        schedule = Schedule(time = LocalTime.of(7, 0), days = Schedule.EVERY_DAY, zoneId = ZoneId.of("UTC")),
+        deliveryMode = DeliveryMode.NOTIFICATION_AND_TTS,
+        temperatureUnit = TemperatureUnit.CELSIUS,
+        windSpeedUnit = WindSpeedUnit.KMH,
+        clothesRules = emptyList(),
+    )
+
+    @Test
+    fun `fields the widgets render flip the projection`() {
+        val baseInputs = base.toWidgetInputs()
+        baseInputs shouldNotBe base.copy(region = Region.EN_US).toWidgetInputs()
+        baseInputs shouldNotBe base.copy(temperatureUnit = TemperatureUnit.FAHRENHEIT).toWidgetInputs()
+        baseInputs shouldNotBe base.copy(windSpeedUnit = WindSpeedUnit.KNOTS).toWidgetInputs()
+        baseInputs shouldNotBe base.copy(timeFormat = TimeFormat.TWELVE_HOUR).toWidgetInputs()
+        baseInputs shouldNotBe base.copy(colorPalette = ColorPalette.ACCESSIBLE).toWidgetInputs()
+        baseInputs shouldNotBe base.copy(themeMode = ThemeMode.DARK).toWidgetInputs()
+        baseInputs shouldNotBe base.copy(
+            clothesRules = listOf(ClothesRule(Garment.HOODIE, ClothesRule.TemperatureBelow(0.0))),
+        ).toWidgetInputs()
+        baseInputs shouldNotBe base.copy(defaultTop = OutfitSuggestion.Top.POLO).toWidgetInputs()
+        baseInputs shouldNotBe base.copy(defaultBottom = OutfitSuggestion.Bottom.SHORTS).toWidgetInputs()
+        baseInputs shouldNotBe base.copy(
+            outfitTopColors = mapOf(OutfitSuggestion.Top.TSHIRT to 0xFF00FF00L),
+        ).toWidgetInputs()
+        baseInputs shouldNotBe base.copy(
+            outfitBottomColors = mapOf(OutfitSuggestion.Bottom.LONG_PANTS to 1L),
+        ).toWidgetInputs()
+        baseInputs shouldNotBe base.copy(
+            outfitHandsColors = mapOf(OutfitSuggestion.Hands.GLOVES to 1L),
+        ).toWidgetInputs()
+        baseInputs shouldNotBe base.copy(
+            outfitCarriedColors = mapOf(OutfitSuggestion.Carried.UMBRELLA to 1L),
+        ).toWidgetInputs()
+        baseInputs shouldNotBe base.copy(
+            outfitOuterColors = mapOf(OutfitSuggestion.Outer.RAIN_JACKET to 1L),
+        ).toWidgetInputs()
+    }
+
+    @Test
+    fun `settings the widgets don't render leave the projection unchanged`() {
+        val baseInputs = base.toWidgetInputs()
+        // A few representative non-widget settings — these must not trigger a repaint.
+        baseInputs shouldBe base.copy(geminiVoice = "Kore").toWidgetInputs()
+        baseInputs shouldBe base.copy(mqttHost = "example.com").toWidgetInputs()
+        baseInputs shouldBe base.copy(telemetryEnabled = false).toWidgetInputs()
+        baseInputs shouldBe base.copy(clothesMentionMode = ClothesMentionMode.NEVER).toWidgetInputs()
+        baseInputs shouldBe base.copy(deltaThresholdC = 8.0).toWidgetInputs()
+        // Schedule is deliberately excluded — which period the widget shows is
+        // clock-driven at render, and a schedule edit doesn't repaint today.
+        baseInputs shouldBe base.copy(
+            schedule = Schedule(time = LocalTime.of(9, 0), days = Schedule.EVERY_DAY, zoneId = ZoneId.of("UTC")),
+        ).toWidgetInputs()
+    }
+}


### PR DESCRIPTION
## What

Replaces the scattered per-setter widget pokes with **one reactive observer**. `ClothesCastApplication` now watches the widget-relevant slice of preferences and repaints every placed widget whenever it changes — so no settings setter has to remember to do it.

This is the refactor we discussed after #1076: the per-setter `refreshOutfitWidget()` push worked but was a "remember to poke" smell — it had been forgotten twice (wind in #1072, then the other display settings in #1076).

## Why an observer (and why it's still a "push")

Glance widgets aren't live observers — they render from a one-shot snapshot and the process can be killed afterward, so *something* must call `updateAllClothesCastWidgets()` when a setting they render changes. Instead of N setters each remembering to call it, a single process-scoped collector does:

```kotlin
settingsRepository.preferences
    .map { it.toWidgetInputs() }
    .distinctUntilChanged()
    .drop(1)               // skip the value present at process start
    .collect { updateAllClothesCastWidgets(this@ClothesCastApplication) }
```

Settings only change while the app is foregrounded, so a process-scoped collector reliably catches every edit. It also covers non-UI writers (migrations, deep links) for free.

## Single source of truth

`WidgetInputs` (in the widget package, next to the widgets) projects exactly the fields the widgets render:
- **ConditionsWidget**: region (locale formatter), temperatureUnit, windSpeedUnit
- **FeelsLikeWidget**: temperatureUnit, timeFormat, colorPalette, themeMode
- **outfit icon**: clothesRules, defaultTop/Bottom, the five outfit-color maps

`distinctUntilChanged` on this projection means unrelated edits (TTS voice, MQTT host, calendar toggles) don't cause needless repaints. Schedule is deliberately excluded — which period the widget shows is clock-driven at render and didn't repaint before either.

## Removed
- `refreshOutfitWidget` from `SettingsViewModel` (16 call sites + the param + factory wiring).
- The same hook on `TodayViewModel` — it was wired through the factory but **never actually called** (dead plumbing).
- Both `refreshOutfitWidget = { updateAllClothesCastWidgets(app) }` factory lambdas in `ClothesCastNavHost` (and the now-unused import).

## Test plan
- `:core:*:test`, `:app:testDebugUnitTest`, `:app:assembleDebug` — green.
- New `WidgetInputsTest` pins the projection: asserts each widget-rendered field flips `WidgetInputs` and that representative non-widget settings (voice, MQTT, telemetry, prose-only formats, schedule) leave it unchanged — so a future widget-affecting setting can't silently fall out of the refresh set.
- Replaced the old per-setter refresh-count test (the behavior it guarded now lives in the observer + `WidgetInputs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VPGYFfoGeqjGoyppxaeuWb)_