### PR TITLE
Fix two Google-forecaster edge cases from PR #1078 review

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ClothesCastApplication.kt
+++ b/app/src/main/kotlin/app/clothescast/ClothesCastApplication.kt
@@ -300,11 +300,13 @@ class ClothesCastApplication : Application() {
             freshnessKeyProvider = { location ->
                 val prefs = settingsRepository.preferences.first()
                 val models = prefs.forecastModels ?: ForecastModel.defaultsFor(location)
-                // Fold in whether Google is contributing (a Gemini key is
-                // configured) so toggling the key on/off invalidates the cache
+                // Fold in the Gemini key's fingerprint (null when unset) so
+                // adding, clearing, OR replacing the key invalidates the cache
                 // instead of waiting out the 1 h TTL — otherwise the blend would
-                // keep including (or excluding) Google until expiry.
-                models to secureKeyStore.geminiKeyConfiguredFlow.first()
+                // keep including (or excluding) Google until expiry, and swapping
+                // a key that 403'd Google for a working one wouldn't take effect
+                // on a manual refresh. Subsumes the old "configured" boolean.
+                models to secureKeyStore.geminiKeyFingerprint()
             },
         )
     }

--- a/app/src/main/kotlin/app/clothescast/data/SecureKeyStore.kt
+++ b/app/src/main/kotlin/app/clothescast/data/SecureKeyStore.kt
@@ -90,6 +90,20 @@ class SecureKeyStore(
         .distinctUntilChanged()
 
     /**
+     * In-memory fingerprint of the stored Gemini key ciphertext, or null when no
+     * key is stored. Changes whenever the key is set, replaced, or cleared — Tink
+     * re-encrypts with a fresh nonce on every save, so even re-saving the same
+     * key yields a new fingerprint. Used as a cache discriminator (see
+     * [app.clothescast.ClothesCastApplication]'s weather-cache freshness key) so
+     * replacing the key busts a stale forecast bundle — e.g. swapping a key that
+     * 403'd Google Weather for a working one refreshes immediately instead of
+     * waiting out the TTL. Reads only the ciphertext's hash, never the plaintext,
+     * and performs no decrypt.
+     */
+    suspend fun geminiKeyFingerprint(): Int? =
+        dataStore.data.map { it[GEMINI_PREF_KEY] }.first()?.hashCode()
+
+    /**
      * True after a stored Gemini key failed to decrypt and was cleared. Stays
      * true until the user re-enters or explicitly clears the key so retries
      * keep the BYOK privacy boundary instead of falling through to the shared

--- a/app/src/test/kotlin/app/clothescast/data/SecureKeyStoreTest.kt
+++ b/app/src/test/kotlin/app/clothescast/data/SecureKeyStoreTest.kt
@@ -10,6 +10,7 @@ import app.clothescast.core.data.insight.MissingApiKeyException
 import com.google.crypto.tink.Aead
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
@@ -70,6 +71,23 @@ class SecureKeyStoreTest {
         subject.clear()
 
         shouldThrow<MissingApiKeyException> { subject.get() }
+    }
+
+    @Test
+    fun `geminiKeyFingerprint is null unset, set after a key, changes on replace, and clears`() = runTest {
+        subject.geminiKeyFingerprint() shouldBe null
+
+        subject.set("AIzaKeyOne")
+        val first = subject.geminiKeyFingerprint()
+        first shouldNotBe null
+
+        // Replacing with a different key must change the fingerprint so the
+        // forecast cache busts (e.g. swapping a 403'ing key for a working one).
+        subject.set("AIzaKeyTwo")
+        subject.geminiKeyFingerprint() shouldNotBe first
+
+        subject.clear()
+        subject.geminiKeyFingerprint() shouldBe null
     }
 
     @Test

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/DeriveInsight.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/DeriveInsight.kt
@@ -11,6 +11,7 @@ import app.clothescast.core.domain.model.HourlyForecast
 import app.clothescast.core.domain.model.Insight
 import app.clothescast.core.domain.model.InsightSummary
 import app.clothescast.core.domain.model.OutfitSuggestion
+import app.clothescast.core.domain.model.ForecastModel
 import app.clothescast.core.domain.model.PerModelHourly
 import app.clothescast.core.domain.model.PrecipLikelihood
 import app.clothescast.core.domain.model.TriggeredOutfit
@@ -158,7 +159,7 @@ class DeriveInsight(
             confidence = if (bundle.perModelHourly == null) {
                 bundle.confidence
             } else {
-                periodView.perModelForRender?.let { ConfidenceInfo.computeFrom(it) }
+                periodView.confidencePerModel?.let { ConfidenceInfo.computeFrom(it) }
             },
             perModelHourly = periodView.perModelForRender,
             // Derive the displayed icon from the *same* TriggeredOutfit that
@@ -242,14 +243,21 @@ class DeriveInsight(
         // blended-consensus probability already on the sliced forecast, so no
         // per-model enrichment is needed.
         val nextForecast = rawNextForecast
-        val perModelForRender = bundle.perModelHourly?.slicedTo(
-            when (period) {
-                ForecastPeriod.TODAY -> todayWindow(periodForecast.hourly, bundle.today.date)
-                // The night window is dated off its base day (yesterday for the
-                // ongoing overnight, today for the coming night).
-                ForecastPeriod.TONIGHT -> tonightWindow(periodForecast.hourly, nightBase.date, tonightStart)
-            },
-        )
+        val window = when (period) {
+            ForecastPeriod.TODAY -> todayWindow(periodForecast.hourly, bundle.today.date)
+            // The night window is dated off its base day (yesterday for the
+            // ongoing overnight, today for the coming night).
+            ForecastPeriod.TONIGHT -> tonightWindow(periodForecast.hourly, nightBase.date, tonightStart)
+        }
+        val perModelForRender = bundle.perModelHourly?.slicedTo(window)
+        // The day-level confidence compares each model's min/max over the
+        // window, so a model that only covers part of it skews the spread.
+        // Google's forecast starts at the current hour, so a midday refresh
+        // leaves its sliced series front-truncated (missing the morning) — drop
+        // it from the confidence input unless it actually covers the window
+        // start. It still draws on the chart ([perModelForRender]) and still
+        // votes in the per-hour consensus blend.
+        val confidencePerModel = perModelForRender?.confidenceInput(window)
         // The rule engine reads the blended-consensus chance of rain already on
         // the sliced forecast (precipitationProbabilityMaxPct), so the umbrella /
         // rain-jacket rules fire off the same number the prose and strip use — no
@@ -272,6 +280,7 @@ class DeriveInsight(
             triggeredOutfit = triggeredOutfit,
             events = filterEventsForPeriod(events, period, nightBase.date, morningStart, tonightStart),
             perModelForRender = perModelForRender,
+            confidencePerModel = confidencePerModel,
             deltaToday = deltaToday,
             deltaYesterday = deltaYesterday,
             yesterdayTriggeredItems = yesterdayTriggeredItems,
@@ -462,6 +471,7 @@ class DeriveInsight(
         val triggeredOutfit: TriggeredOutfit,
         val events: List<CalendarEvent>,
         val perModelForRender: PerModelHourly?,
+        val confidencePerModel: PerModelHourly?,
         val deltaToday: DailyForecast,
         val deltaYesterday: DailyForecast,
         val yesterdayTriggeredItems: List<String>,
@@ -512,6 +522,39 @@ internal fun PerModelHourly.slicedTo(window: List<LocalDateTime>): PerModelHourl
         .mapValues { (_, entries) -> entries.filter { it.time in windowSet } }
         .filterValues { it.isNotEmpty() }
     return if (filtered.isEmpty()) null else PerModelHourly(filtered)
+}
+
+/**
+ * The subset of [this] to feed day-level confidence ([ConfidenceInfo.computeFrom]).
+ *
+ * Confidence compares each model's daily high/low over [window], so a model
+ * that only covers part of the window biases the spread. Google's forecast
+ * starts at the current hour, so on a midday refresh its sliced series is
+ * front-truncated relative to the Open-Meteo models that span the whole day —
+ * its partial min/max would inject a coverage-driven (not real) disagreement
+ * and wrongly downgrade the chip. So drop Google from the confidence input
+ * unless it actually covers the window's first hour. Google still draws on the
+ * chart (the full [slicedTo] series) and still votes in the per-hour consensus
+ * blend; only the day-extreme comparison excludes it when its coverage doesn't
+ * reach the window start. Open-Meteo models (which carry the whole day via
+ * `past_days`) are unaffected.
+ *
+ * Guard: Google is only dropped when at least two *other* consulted models
+ * remain. For a Google + one-Open-Meteo selection (which the picker allows),
+ * removing front-truncated Google would leave a single consulted model and
+ * [ConfidenceInfo.computeFrom] — which excludes `best_match` and needs two —
+ * would return null, hiding the chip entirely. Google's slightly partial
+ * contribution is better than no chip, so in that case it's kept.
+ */
+internal fun PerModelHourly.confidenceInput(window: List<LocalDateTime>): PerModelHourly {
+    val googleId = ForecastModel.GOOGLE_WEATHER.openMeteoId
+    if (byModel[googleId] == null) return this
+    val start = window.minOrNull() ?: return this
+    if (byModel.getValue(googleId).any { it.time == start }) return this
+    val otherConsulted = byModel.keys.count {
+        it != googleId && it != PerModelHourly.BEST_MATCH_MODEL_ID
+    }
+    return if (otherConsulted >= 2) PerModelHourly(byModel - googleId) else this
 }
 
 internal fun todayWindow(windowHourly: List<HourlyForecast>, todayDate: LocalDate): List<LocalDateTime> =

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/ConfidenceInputTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/ConfidenceInputTest.kt
@@ -1,0 +1,77 @@
+package app.clothescast.core.domain.usecase
+
+import app.clothescast.core.domain.model.ForecastModel
+import app.clothescast.core.domain.model.PerModelHour
+import app.clothescast.core.domain.model.PerModelHourly
+import io.kotest.matchers.maps.shouldContainKey
+import io.kotest.matchers.maps.shouldNotContainKey
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+
+class ConfidenceInputTest {
+    private val date = LocalDate.of(2026, 6, 29)
+    private val window = listOf(10, 11, 12).map { LocalDateTime.of(date, LocalTime.of(it, 0)) }
+    private val google = ForecastModel.GOOGLE_WEATHER.openMeteoId
+
+    private fun hour(h: Int, t: Double) = PerModelHour(
+        time = LocalDateTime.of(date, LocalTime.of(h, 0)),
+        apparentTemperatureC = t,
+        temperatureC = t,
+        precipitationProbabilityPct = null,
+    )
+
+    @Test
+    fun `google missing the window start is dropped when two other models remain`() {
+        val series = PerModelHourly(
+            mapOf(
+                "ecmwf_ifs025" to listOf(hour(10, 12.0), hour(11, 14.0), hour(12, 16.0)),
+                "gfs_seamless" to listOf(hour(10, 11.0), hour(11, 13.0), hour(12, 15.0)),
+                // Front-truncated: starts at 11:00, missing the 10:00 window start.
+                google to listOf(hour(11, 20.0), hour(12, 22.0)),
+            ),
+        )
+        val result = series.confidenceInput(window)
+        result.byModel shouldNotContainKey google
+        result.byModel shouldContainKey "ecmwf_ifs025"
+    }
+
+    @Test
+    fun `google covering the window start is kept`() {
+        val series = PerModelHourly(
+            mapOf(
+                "ecmwf_ifs025" to listOf(hour(10, 12.0), hour(11, 14.0)),
+                google to listOf(hour(10, 20.0), hour(11, 22.0)),
+            ),
+        )
+        series.confidenceInput(window).byModel shouldContainKey google
+    }
+
+    @Test
+    fun `front-truncated google is kept when it is the only second consulted model`() {
+        // Google + one Open-Meteo: dropping front-truncated Google would leave a
+        // single consulted model and computeFrom would return null (no chip), so
+        // Google is kept despite its partial coverage.
+        val series = PerModelHourly(
+            mapOf(
+                PerModelHourly.BEST_MATCH_MODEL_ID to listOf(hour(10, 11.0), hour(11, 13.0)),
+                "ecmwf_ifs025" to listOf(hour(10, 12.0), hour(11, 14.0)),
+                google to listOf(hour(11, 20.0)), // missing the 10:00 window start
+            ),
+        )
+        series.confidenceInput(window).byModel shouldContainKey google
+    }
+
+    @Test
+    fun `with no google the series is unchanged`() {
+        val series = PerModelHourly(
+            mapOf(
+                "ecmwf_ifs025" to listOf(hour(11, 14.0)),
+                "gfs_seamless" to listOf(hour(11, 15.0)),
+            ),
+        )
+        series.confidenceInput(window).byModel.keys shouldBe setOf("ecmwf_ifs025", "gfs_seamless")
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to the merged #1078, addressing the two P2 review comments that landed just before merge.

### 1. Forecast confidence no longer skewed by Google's partial coverage

Google's Weather forecast starts at the current hour, so on a midday refresh its sliced series is front-truncated vs the Open-Meteo models that span the whole day. `ConfidenceInfo.computeFrom` compares each model's daily high/low over the window, so Google's partial min/max injected a coverage-driven (not real) spread that could wrongly downgrade the confidence chip.

`DeriveInsight` now feeds confidence a coverage-filtered series (`PerModelHourly.confidenceInput`): **Google is dropped from the day-level comparison unless it covers the window's first hour.** It still draws on the chart and votes in the per-hour consensus blend — only the day-extreme comparison excludes it when its coverage doesn't reach the window start. Open-Meteo models (full-day via `past_days`) are unaffected, so behaviour without the Google forecaster is unchanged.

### 2. Replacing the Gemini key now busts the forecast cache

The cache freshness key used a `configured` boolean, so replacing one key with another left it unchanged and a manual refresh served the stale bundle for up to the 1 h TTL — e.g. swapping a key that 403'd Google Weather for a working one wouldn't take effect until expiry.

`SecureKeyStore.geminiKeyFingerprint()` now exposes a hash of the stored ciphertext (no decrypt, never the plaintext), and the cache freshness key uses it instead of the boolean, so **adding, clearing, or replacing the key all bust the cache immediately.** Subsumes the previous flag.

## Test plan

- New `ConfidenceInputTest` (Google dropped when front-truncated, kept when it covers the start, no-op without Google) and a `SecureKeyStore.geminiKeyFingerprint` test (null unset → set → changes on replace → null on clear).
- `:core:domain:test`, `:core:data:test`, `:app:testDebugUnitTest`, `:app:assembleDebug` all pass; no snapshot changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UjbadRz8dPLcyFa33LSyFk)_