### PR TITLE
Stretch the Google forecaster across the full 10-day forecast

### DIFF
--- a/core/data/src/main/kotlin/app/clothescast/core/data/weather/GoogleWeatherModelClient.kt
+++ b/core/data/src/main/kotlin/app/clothescast/core/data/weather/GoogleWeatherModelClient.kt
@@ -74,11 +74,15 @@ sealed interface GoogleWeatherProbe {
  * blend proceeds on the Open-Meteo models alone. The fetch never fails the
  * surrounding forecast.
  *
- * One page of [FORECAST_HOURS] hours (the current hour forward) is requested in
- * a single call — that covers today + tonight + early tomorrow, the window the
- * outfit / tonight insight / conditions strip actually lean on. Extending
- * Google's reach across the full 10-day horizon (which Google paginates) is a
- * possible follow-up; this keeps it to one round-trip.
+ * [fetchHourly] walks Google's pagination to cover the full [FORECAST_HOURS]-hour
+ * (10-day) horizon — Google caps each page at [PAGE_SIZE] hours and hands back a
+ * `nextPageToken`, so the series is assembled across up to [MAX_PAGES] round-trips,
+ * matching the Open-Meteo models' forward reach so Google votes in the consensus on
+ * every day rather than just today + tomorrow. A page that fails partway keeps the
+ * hours already gathered (so a late network blip still contributes the near days)
+ * rather than dropping Google entirely. [probe], the cold connectivity check, stays
+ * a single round-trip — it only needs to know the key reaches the API and returns
+ * usable hours, not the whole horizon.
  */
 class GoogleWeatherModelClient(
     private val httpClient: HttpClient,
@@ -87,8 +91,8 @@ class GoogleWeatherModelClient(
 ) {
     suspend fun fetchHourly(location: Location, apiKey: String): List<PerModelHour>? {
         if (apiKey.isBlank()) return null
-        val response = try {
-            request(location, apiKey)
+        val hours = try {
+            requestAllPages(location, apiKey)
         } catch (ce: CancellationException) {
             // Narrow the catch and rethrow cancellation so a cancelled fetch
             // doesn't get masked as "Google unavailable" and break structured
@@ -98,7 +102,7 @@ class GoogleWeatherModelClient(
             logger.log("Google Weather fetch failed; dropping Google from the blend", t)
             return null
         }
-        return parse(response)
+        return parse(hours)
     }
 
     /**
@@ -117,7 +121,9 @@ class GoogleWeatherModelClient(
     suspend fun probe(location: Location, apiKey: String): GoogleWeatherProbe {
         if (apiKey.isBlank()) return GoogleWeatherProbe.NoKey
         val response = try {
-            request(location, apiKey)
+            // Single page is enough for a connectivity check — no need to walk
+            // the full horizon just to learn the key reaches the API.
+            request(location, apiKey, pageToken = null)
         } catch (ce: CancellationException) {
             throw ce
         } catch (t: Throwable) {
@@ -134,14 +140,52 @@ class GoogleWeatherModelClient(
                 GoogleWeatherProbe.Failed(status)
             }
         }
-        val hours = parse(response)?.size ?: 0
+        val hours = parse(response.forecastHours)?.size ?: 0
         // A 200 with no usable hours is treated as a failure: the key reached the
         // API but there's nothing to fold into the blend, so "Google is
         // contributing" would be a lie. Rare for a valid key, but honest.
         return if (hours > 0) GoogleWeatherProbe.Reachable(hours) else GoogleWeatherProbe.Failed(null)
     }
 
-    private suspend fun request(location: Location, apiKey: String): GoogleHourlyResponse =
+    /**
+     * Walks Google's pagination to gather up to [FORECAST_HOURS] hours, following
+     * each page's `nextPageToken` until it runs dry, the hour budget is met, or
+     * [MAX_PAGES] is hit (a backstop so a misbehaving token can't loop forever).
+     *
+     * The first page's failure propagates so the caller's catch can classify it
+     * (the probe's 403 handling, fetchHourly's drop-to-null). A *later* page's
+     * failure is caught and the walk stops with what it already has — a network
+     * blip on page 7 shouldn't throw away the six days already in hand.
+     */
+    private suspend fun requestAllPages(location: Location, apiKey: String): List<GoogleForecastHour> {
+        val all = mutableListOf<GoogleForecastHour>()
+        var pageToken: String? = null
+        var pages = 0
+        do {
+            val response = if (all.isEmpty()) {
+                request(location, apiKey, pageToken)
+            } else {
+                try {
+                    request(location, apiKey, pageToken)
+                } catch (ce: CancellationException) {
+                    throw ce
+                } catch (t: Throwable) {
+                    logger.log("Google Weather page ${pages + 1} failed; keeping ${all.size} hours gathered so far", t)
+                    break
+                }
+            }
+            all += response.forecastHours
+            pages++
+            pageToken = response.nextPageToken?.takeIf { it.isNotBlank() }
+        } while (pageToken != null && all.size < FORECAST_HOURS && pages < MAX_PAGES)
+        return all
+    }
+
+    private suspend fun request(
+        location: Location,
+        apiKey: String,
+        pageToken: String?,
+    ): GoogleHourlyResponse =
         apiCallLogger.instrument(ApiEndpoints.GOOGLE_WEATHER) {
             httpClient.get {
                 expectSuccess = true
@@ -163,17 +207,20 @@ class GoogleWeatherModelClient(
                 parameter("location.latitude", location.latitude)
                 parameter("location.longitude", location.longitude)
                 parameter("hours", FORECAST_HOURS)
-                // One page covering the whole window — Google paginates hourly
-                // results and defaults to a smaller page; ask for the lot at once.
-                parameter("pageSize", FORECAST_HOURS)
+                // Google caps the hourly page at PAGE_SIZE; the rest of the
+                // FORECAST_HOURS window arrives via nextPageToken (see
+                // [requestAllPages]).
+                parameter("pageSize", PAGE_SIZE)
                 // METRIC so temperatures come back in °C and wind in km/h, the
                 // units PerModelHour / the domain already speak — no conversion.
                 parameter("unitsSystem", "METRIC")
+                // Subsequent pages: hand back the token from the prior page.
+                if (pageToken != null) parameter("pageToken", pageToken)
             }.body()
         }
 
-    private fun parse(response: GoogleHourlyResponse): List<PerModelHour>? {
-        val hours = response.forecastHours.mapNotNull { hour ->
+    private fun parse(forecastHours: List<GoogleForecastHour>): List<PerModelHour>? {
+        val hours = forecastHours.mapNotNull { hour ->
             val time = hour.displayDateTime?.toLocalDateTime() ?: return@mapNotNull null
             // Air temperature is the hard requirement, mirroring the Open-Meteo
             // per-model parse: without it there's nothing to average into the
@@ -205,17 +252,26 @@ class GoogleWeatherModelClient(
     }
 
     companion object {
-        // One page of hourly forecast. Covers today + tonight + early tomorrow
-        // in a single round-trip — the window the outfit / tonight insight lean
-        // on. Google's hourly endpoint serves up to 240 hours via pagination;
-        // reaching further is a follow-up.
-        private const val FORECAST_HOURS = 24
+        // The full horizon Google's hourly endpoint serves — 240 hours / 10 days
+        // — so Google reaches as far forward as the Open-Meteo models and votes in
+        // the consensus on every day, not just today + tomorrow.
+        private const val FORECAST_HOURS = 240
+
+        // Google caps each hourly page at 24 hours; the rest of FORECAST_HOURS
+        // arrives by following nextPageToken (see [requestAllPages]).
+        private const val PAGE_SIZE = 24
+
+        // Backstop on the pagination walk: ceil(FORECAST_HOURS / PAGE_SIZE) pages
+        // cover the whole horizon, with no extra round-trips beyond that even if
+        // Google keeps handing back a token.
+        private const val MAX_PAGES = FORECAST_HOURS / PAGE_SIZE
     }
 }
 
 @Serializable
 private data class GoogleHourlyResponse(
     val forecastHours: List<GoogleForecastHour> = emptyList(),
+    val nextPageToken: String? = null,
 )
 
 @Serializable

--- a/core/data/src/test/kotlin/app/clothescast/core/data/weather/GoogleWeatherModelClientTest.kt
+++ b/core/data/src/test/kotlin/app/clothescast/core/data/weather/GoogleWeatherModelClientTest.kt
@@ -45,8 +45,7 @@ class GoogleWeatherModelClientTest {
               "wind": {"speed":{"value":12.0}}
             }
           ],
-          "timeZone": {"id":"Europe/London"},
-          "nextPageToken": "abc"
+          "timeZone": {"id":"Europe/London"}
         }
     """.trimIndent()
 
@@ -65,6 +64,50 @@ class GoogleWeatherModelClientTest {
                 )
             } else {
                 respondError(status)
+            }
+        }
+        val http = HttpClient(engine) {
+            install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
+        }
+        return GoogleWeatherModelClient(http)
+    }
+
+    /** A single forecast page carrying one hour at [hour] and an optional [nextPageToken]. */
+    private fun page(hour: Int, nextPageToken: String? = null): String {
+        val token = nextPageToken?.let { ""","nextPageToken":"$it"""" } ?: ""
+        return """
+            {
+              "forecastHours": [
+                {
+                  "displayDateTime": {"year":2026,"month":6,"day":29,"hours":$hour,"minutes":0},
+                  "temperature": {"degrees":15.0}
+                }
+              ]$token
+            }
+        """.trimIndent()
+    }
+
+    /**
+     * Serves [pages] in order, one per request (capturing each request), then —
+     * once the list is exhausted — replays the last page forever. Replaying a page
+     * that still carries a token lets a test exercise the MAX_PAGES backstop.
+     */
+    private fun pagingClient(
+        pages: List<String>,
+        captured: MutableList<HttpRequestData> = mutableListOf(),
+        failOnRequest: Int? = null,
+    ): GoogleWeatherModelClient {
+        val engine = MockEngine { request ->
+            val index = captured.size
+            captured.add(request)
+            if (failOnRequest != null && index + 1 == failOnRequest) {
+                respondError(HttpStatusCode.InternalServerError)
+            } else {
+                respond(
+                    content = ByteReadChannel(pages[index.coerceAtMost(pages.lastIndex)]),
+                    status = HttpStatusCode.OK,
+                    headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                )
             }
         }
         val http = HttpClient(engine) {
@@ -120,6 +163,76 @@ class GoogleWeatherModelClientTest {
         params["location.latitude"] shouldBe "51.5074"
         params["location.longitude"] shouldBe "-0.1278"
         params["unitsSystem"] shouldBe "METRIC"
+        // The full 10-day horizon, fetched 24 hours at a time via pagination.
+        params["hours"] shouldBe "240"
+        params["pageSize"] shouldBe "24"
+        // No token on the first page.
+        params["pageToken"].shouldBeNull()
+    }
+
+    @Test
+    fun `follows nextPageToken across pages and concatenates the hours`() = runTest {
+        val captured = mutableListOf<HttpRequestData>()
+        val result = checkNotNull(
+            pagingClient(
+                pages = listOf(page(hour = 11, nextPageToken = "p2"), page(hour = 12, nextPageToken = "p3"), page(hour = 13)),
+                captured = captured,
+            ).fetchHourly(london, "AIza-test-key"),
+        )
+
+        // One PerModelHour per page, in order.
+        result.map { it.time.hour } shouldBe listOf(11, 12, 13)
+        // Stopped after the tokenless third page — exactly three round-trips.
+        captured.size shouldBe 3
+        // Each follow-up page carried the prior page's token; the first carried none.
+        captured.map { it.url.parameters["pageToken"] } shouldBe listOf(null, "p2", "p3")
+    }
+
+    @Test
+    fun `a page failing partway keeps the hours already gathered`() = runTest {
+        val captured = mutableListOf<HttpRequestData>()
+        // Page 1 succeeds and points at page 2; page 2 errors.
+        val result = checkNotNull(
+            pagingClient(
+                pages = listOf(page(hour = 11, nextPageToken = "p2"), page(hour = 12)),
+                captured = captured,
+                failOnRequest = 2,
+            ).fetchHourly(london, "AIza-test-key"),
+        )
+
+        result.map { it.time.hour } shouldBe listOf(11)
+        captured.size shouldBe 2
+    }
+
+    @Test
+    fun `the first page failing drops Google entirely`() = runTest {
+        // No partial result to keep — a page-one failure is the fetch failing.
+        pagingClient(pages = listOf(page(hour = 11)), failOnRequest = 1)
+            .fetchHourly(london, "AIza-test-key")
+            .shouldBeNull()
+    }
+
+    @Test
+    fun `pagination stops at the page cap even when Google keeps handing back a token`() = runTest {
+        val captured = mutableListOf<HttpRequestData>()
+        // Every page carries a token, so only the MAX_PAGES backstop ends the walk.
+        val result = checkNotNull(
+            pagingClient(pages = listOf(page(hour = 11, nextPageToken = "loop")), captured = captured)
+                .fetchHourly(london, "AIza-test-key"),
+        )
+
+        // 240 hours / 24 per page = 10 pages, and no more.
+        captured.size shouldBe 10
+        result.size shouldBe 10
+    }
+
+    @Test
+    fun `probe stays a single round-trip even when more pages are available`() = runTest {
+        val captured = mutableListOf<HttpRequestData>()
+        pagingClient(pages = listOf(page(hour = 11, nextPageToken = "p2"), page(hour = 12)), captured = captured)
+            .probe(london, "AIza-test-key") shouldBe GoogleWeatherProbe.Reachable(hours = 1)
+
+        captured.size shouldBe 1
     }
 
     @Test


### PR DESCRIPTION
## What & why

The Google forecaster was only contributing to the consensus blend for ~today + tomorrow, even though Google's hourly endpoint serves a full 10-day horizon. `GoogleWeatherModelClient` fetched a single page of 24 hours and never followed Google's pagination, so Google dropped out of the blend across the rest of the week.

Google's `hours:lookup` endpoint caps each page at 24 hours and hands back a `nextPageToken` for the rest. This PR walks that pagination.

## Changes

- `fetchHourly` now follows `nextPageToken` up to `FORECAST_HOURS` (240h / 10 days), 24 hours per page, with a `MAX_PAGES` backstop so a misbehaving token can't loop forever.
- Added `nextPageToken` to the response DTO (it was previously discarded as an unknown key).
- A page that fails partway through keeps the hours already gathered — a late network blip still contributes the near days. A **first**-page failure still drops Google entirely, preserving the existing 403→null contract.
- `probe` (the Forecasters settings connectivity check) deliberately stays a single round-trip — it only needs to confirm the key reaches the API and returns usable hours.

This matches Google's forward reach to the Open-Meteo models (`forecast_days=14`), so Google now votes in the consensus on every forecast day rather than just the first.

## Privacy

No change to what leaves the device — the same latitude/longitude is sent to `weather.googleapis.com` as before, just followed across more pages (up to ~10 requests instead of one) when the user has enabled the Google forecaster. The API key continues to ride the `X-Goog-Api-Key` header, never a URL query param.

## Test plan

- New tests in `GoogleWeatherModelClientTest`: follows `nextPageToken` across pages and concatenates hours; keeps gathered hours when a later page fails; drops Google when the first page fails; stops at the `MAX_PAGES` cap when a token loops; `probe` stays a single round-trip. Existing param test now asserts `hours=240` / `pageSize=24` / no first-page `pageToken`.
- `./gradlew :core:domain:test :core:data:test :app:testDebugUnitTest` — green.
- `./gradlew :app:assembleDebug` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Le3TPJ1CHT78NPYoRrXNuT)_