### PR TITLE
Cache Google's 10-day forecast and refresh it about twice a day

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ClothesCastApplication.kt
+++ b/app/src/main/kotlin/app/clothescast/ClothesCastApplication.kt
@@ -18,6 +18,8 @@ import app.clothescast.core.data.weather.GoogleWeatherModelClient
 import app.clothescast.core.data.weather.OpenMeteoClient
 import app.clothescast.core.domain.model.ForecastModel
 import app.clothescast.core.domain.model.ForecastPeriod
+import app.clothescast.core.domain.model.Location
+import app.clothescast.core.domain.model.PerModelHour
 import app.clothescast.core.domain.model.defaultsFor
 import app.clothescast.core.domain.repository.CachingWeatherRepository
 import app.clothescast.core.domain.repository.CalendarEventReader
@@ -27,6 +29,7 @@ import app.clothescast.core.domain.usecase.GenerateDailyInsight
 import app.clothescast.data.AppCheckGeminiCallPlanner
 import app.clothescast.data.DailyHistoryStore
 import app.clothescast.data.provideAppCheckProviderFactory
+import app.clothescast.data.GoogleForecastCache
 import app.clothescast.data.InsightCache
 import app.clothescast.data.SecureKeyStore
 import app.clothescast.data.SettingsRepository
@@ -81,6 +84,9 @@ class ClothesCastApplication : Application() {
     val settingsRepository: SettingsRepository by lazy { SettingsRepository.create(this) }
     val deriveInsight: DeriveInsight by lazy { DeriveInsight() }
     val insightCache: InsightCache by lazy { InsightCache.create(this, deriveInsight) }
+    // Caches the extended (10-day) Google forecast so its ~10-page walk happens
+    // at most a couple of times a day; see [fetchGoogleSeries].
+    val googleForecastCache: GoogleForecastCache by lazy { GoogleForecastCache.create(this) }
     val dailyHistoryStore: DailyHistoryStore by lazy { DailyHistoryStore.create(this) }
     val locationResolver: LocationResolver by lazy { LocationResolver(this) }
     val reverseGeocoder: ReverseGeocoder by lazy { ReverseGeocoder(this) }
@@ -278,15 +284,18 @@ class ClothesCastApplication : Application() {
                     if (!googleSelected) {
                         null
                     } else {
-                        val key = try {
-                            secureKeyStore.getGoogleApiKey()
+                        // Read the key and its fingerprint from one snapshot so a
+                        // key edit racing this fetch can't cache the old key's
+                        // series under the new key's fingerprint.
+                        val (key, fingerprint) = try {
+                            secureKeyStore.getGoogleApiKeyWithFingerprint()
                         } catch (ce: CancellationException) {
                             throw ce
                         } catch (e: Exception) {
                             DiagLog.w("GoogleWeather", "Google API key unavailable; skipping Google", e)
-                            null
+                            null to null
                         }
-                        key?.takeIf { it.isNotBlank() }?.let { googleWeatherClient.fetchHourly(location, it) }
+                        key?.takeIf { it.isNotBlank() }?.let { fetchGoogleSeries(location, it, fingerprint) }
                     }
                 },
             ),
@@ -307,6 +316,10 @@ class ClothesCastApplication : Application() {
                 // keep including (or excluding) Google until expiry, and swapping
                 // a key that 403'd the Weather API for a working one wouldn't
                 // take effect on a manual refresh.
+                // Google now always contributes the same extended (10-day) series
+                // — gated only by GoogleForecastCache's TTL, not by who's fetching
+                // — so the bundle's Google depth no longer varies with the caller
+                // and the freshness key only needs the model set + key fingerprint.
                 models to secureKeyStore.googleApiKeyFingerprint()
             },
         )
@@ -340,6 +353,46 @@ class ClothesCastApplication : Application() {
 
     /** The Activity currently in the resumed state, or null when none is. */
     fun currentResumedActivity(): Activity? = resumedActivity?.get()
+
+    /**
+     * Resolves the Google forecaster's contribution to one consensus blend.
+     *
+     * The full 10-day walk ([GoogleWeatherModelClient.EXTENDED_HOURS]) is
+     * expensive (~10 paginated, billed calls), so it's rate-limited behind
+     * [GoogleForecastCache] (a ~12 h TTL) rather than gated per caller: a fresh
+     * cached series serves *every* refresh path — app opens and background
+     * refreshes (scheduled alarms, widget self-heals) alike — and a cache miss
+     * walks the horizon once and persists it. Net effect: the walk runs at most
+     * ~twice a day, and every surface that needs the week-ahead — the Today
+     * screen's week pages, the home-screen 7-day widget (rendered in the
+     * background), the evening tomorrow pre-render — gets Google's vote, not just
+     * surfaces the user happens to have open.
+     *
+     * Returns null (Google sits out of the blend) on any fetch failure, exactly
+     * as before — best-effort, never fails the surrounding forecast.
+     */
+    private suspend fun fetchGoogleSeries(
+        location: Location,
+        apiKey: String,
+        fingerprint: Int?,
+    ): List<PerModelHour>? {
+        // [fingerprint] is read atomically with [apiKey] by the caller and keys
+        // the cache the same way the outer freshness key does, so a swap to a key
+        // that 403s the Weather API drops the old key's series rather than serving
+        // it for the rest of the TTL.
+        googleForecastCache.fresh(location, fingerprint)?.let { return it }
+
+        return googleWeatherClient.fetchHourly(location, apiKey)?.also { series ->
+            // Persist only a (near-)complete walk — a transient mid-walk page
+            // failure truncates the result to a near-length series, and freezing
+            // that into the 12 h cache would keep week-ahead Google missing for the
+            // whole TTL. The partial still feeds *this* blend; the next refresh
+            // retries the full walk.
+            if (series.size >= MIN_CACHEABLE_EXTENDED_HOURS) {
+                googleForecastCache.put(location, fingerprint, series)
+            }
+        }
+    }
 
     override fun attachBaseContext(base: Context) {
         // Re-apply the persisted per-app locale before the framework caches a
@@ -480,5 +533,15 @@ class ClothesCastApplication : Application() {
 
     companion object {
         private const val TAG = "ClothesCastApplication"
+
+        // Only freeze a (near-)complete extended walk into GoogleForecastCache.
+        // requestAllPages returns the pages gathered so far if a page fails
+        // partway (PR #1084), so a transient mid-walk failure yields a
+        // near-length series; caching that would keep week-ahead Google missing
+        // for the whole 12 h TTL. 7 days clears a healthy 10-day walk (and a walk
+        // that lost only its last page or two) while rejecting an early
+        // truncation. A genuine sub-7-day success just re-walks on the next
+        // refresh — safe.
+        private const val MIN_CACHEABLE_EXTENDED_HOURS = 168
     }
 }

--- a/app/src/main/kotlin/app/clothescast/data/GoogleForecastCache.kt
+++ b/app/src/main/kotlin/app/clothescast/data/GoogleForecastCache.kt
@@ -1,0 +1,223 @@
+package app.clothescast.data
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import app.clothescast.core.domain.model.Location
+import app.clothescast.core.domain.model.PerModelHour
+import app.clothescast.core.domain.model.WeatherCondition
+import app.clothescast.diag.DiagLog
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.first
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import kotlin.math.roundToLong
+
+/**
+ * Persists the most recent *extended* (10-day) Google forecast series for one
+ * location so the expensive multi-page walk runs at most a couple of times a
+ * day rather than on every forecast refresh.
+ *
+ * Why this exists: the Google forecaster's full horizon
+ * ([app.clothescast.core.data.weather.GoogleWeatherModelClient.EXTENDED_HOURS])
+ * costs ~10 paginated, billed Google API calls. We only want to pay that when
+ * the user opens the app, then reuse the result — for both later app opens and
+ * the cheap background refreshes — until it goes stale ([defaultTtl], "once or
+ * twice a day"). [ClothesCastApplication] reads [fresh] first and only walks the
+ * full horizon (then [put]s it) on a foreground miss.
+ *
+ * Single entry, keyed by location rounded to ~1 km — the same grid
+ * [app.clothescast.core.domain.repository.CachingWeatherRepository] uses, so the
+ * two caches move together — and by the Google key's fingerprint, so swapping a
+ * working key for one that 403s the Weather API drops the stale series instead
+ * of keeping Google in the blend for the rest of the TTL. Persisted across
+ * process death via DataStore; a deserialization failure drops the entry and
+ * re-fetches, the same posture as [InsightCache].
+ *
+ * Privacy: stores only the forecast numbers Google returns for the location,
+ * keyed by a coarse (~1 km) lat/lon bucket and a non-reversible 32-bit hash of
+ * the key's ciphertext (the same [SecureKeyStore.googleApiKeyFingerprint] the
+ * outer cache uses — not the key itself, and no decrypt). No PII, no API key.
+ */
+class GoogleForecastCache(
+    private val dataStore: DataStore<Preferences>,
+    private val clock: Clock = Clock.systemUTC(),
+    private val json: Json = Json { ignoreUnknownKeys = true },
+    private val locationGridDegrees: Double = 0.01,
+) {
+    /**
+     * The cached extended series if one is stored for [location] (same ~1 km
+     * grid cell), was fetched with the same key ([apiKeyFingerprint]), and is
+     * younger than [maxAge], else null. Returns null — never throws — on a decode
+     * failure, dropping the corrupt entry so the caller re-fetches.
+     */
+    suspend fun fresh(
+        location: Location,
+        apiKeyFingerprint: Int?,
+        maxAge: Duration = defaultTtl,
+    ): List<PerModelHour>? {
+        val raw = readRaw() ?: return null
+        val entry = try {
+            json.decodeFromString<Entry>(raw)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            DiagLog.w(TAG, "Google forecast cache decode failed; dropping the entry", e)
+            clear()
+            return null
+        }
+        // Key change (e.g. a working key swapped for one that 403s) → treat the
+        // old key's series as stale so Google re-fetches under the current key.
+        if (entry.apiKeyFingerprint != apiKeyFingerprint) return null
+        val key = keyOf(location)
+        if (entry.latBucket != key.first || entry.lonBucket != key.second) return null
+        val age = Duration.between(Instant.ofEpochMilli(entry.fetchedAtMs), clock.instant())
+        // A negative age (clock moved backwards / stored on a different device
+        // time) is treated as fresh — the data is still the latest we fetched.
+        if (age >= maxAge) return null
+        return entry.hours.mapNotNull { it.toDomain() }.ifEmpty { null }
+    }
+
+    /**
+     * Stores [hours] as the extended series for [location], stamped now. A
+     * persistence failure is logged and swallowed — the caller already has the
+     * series in hand for this fetch, and the next foreground walk re-stamps it.
+     */
+    suspend fun put(location: Location, apiKeyFingerprint: Int?, hours: List<PerModelHour>) {
+        if (hours.isEmpty()) return
+        val key = keyOf(location)
+        val entry = Entry(
+            latBucket = key.first,
+            lonBucket = key.second,
+            apiKeyFingerprint = apiKeyFingerprint,
+            fetchedAtMs = clock.instant().toEpochMilli(),
+            hours = hours.map { it.toDto() },
+        )
+        val encoded = try {
+            json.encodeToString(entry)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            DiagLog.w(TAG, "Google forecast cache encode failed; not persisting", e)
+            return
+        }
+        try {
+            dataStore.edit { it[ENTRY_KEY] = encoded }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            DiagLog.w(TAG, "Google forecast cache write failed", e)
+        }
+    }
+
+    private suspend fun readRaw(): String? = try {
+        dataStore.data.first()[ENTRY_KEY]
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        DiagLog.w(TAG, "Google forecast cache read failed", e)
+        null
+    }
+
+    private suspend fun clear() {
+        try {
+            dataStore.edit { it.remove(ENTRY_KEY) }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            DiagLog.w(TAG, "Google forecast cache clear failed", e)
+        }
+    }
+
+    private fun keyOf(location: Location): Pair<Long, Long> =
+        (location.latitude / locationGridDegrees).roundToLong() to
+            (location.longitude / locationGridDegrees).roundToLong()
+
+    @Serializable
+    private data class Entry(
+        val latBucket: Long,
+        val lonBucket: Long,
+        // Fingerprint of the Google key that fetched this series; null only on
+        // legacy entries written before keying was added (treated as a miss
+        // against any real fingerprint, so they re-fetch).
+        val apiKeyFingerprint: Int? = null,
+        val fetchedAtMs: Long,
+        val hours: List<HourDto>,
+    )
+
+    // Mirrors InsightCache.PerModelHourDto's date split (epoch-day + second-of-day)
+    // so a midnight-crossing series round-trips with each hour's own date intact.
+    // Only the fields Google populates are carried; the rest default absent.
+    @Serializable
+    private data class HourDto(
+        val dateEpochDays: Long,
+        val secondOfDay: Int,
+        val apparentTemperatureC: Double,
+        val temperatureC: Double,
+        val precipitationProbabilityPct: Double? = null,
+        val precipitationMm: Double? = null,
+        val windSpeedKmh: Double? = null,
+        val relativeHumidityPct: Double? = null,
+        val cloudCoverPct: Double? = null,
+        val uvIndex: Double? = null,
+        val conditionName: String? = null,
+    ) {
+        fun toDomain(): PerModelHour = PerModelHour(
+            time = LocalDateTime.of(
+                LocalDate.ofEpochDay(dateEpochDays),
+                LocalTime.ofSecondOfDay(secondOfDay.toLong()),
+            ),
+            apparentTemperatureC = apparentTemperatureC,
+            temperatureC = temperatureC,
+            precipitationProbabilityPct = precipitationProbabilityPct,
+            precipitationMm = precipitationMm,
+            windSpeedKmh = windSpeedKmh,
+            relativeHumidityPct = relativeHumidityPct,
+            cloudCoverPct = cloudCoverPct,
+            uvIndex = uvIndex,
+            condition = conditionName?.let {
+                runCatching { WeatherCondition.valueOf(it) }.getOrNull()
+            },
+        )
+    }
+
+    private fun PerModelHour.toDto(): HourDto = HourDto(
+        dateEpochDays = time.toLocalDate().toEpochDay(),
+        secondOfDay = time.toLocalTime().toSecondOfDay(),
+        apparentTemperatureC = apparentTemperatureC,
+        temperatureC = temperatureC,
+        precipitationProbabilityPct = precipitationProbabilityPct,
+        precipitationMm = precipitationMm,
+        windSpeedKmh = windSpeedKmh,
+        relativeHumidityPct = relativeHumidityPct,
+        cloudCoverPct = cloudCoverPct,
+        uvIndex = uvIndex,
+        conditionName = condition?.name,
+    )
+
+    companion object {
+        // "Once or twice a day": reuse the extended walk's result for 12 h, so a
+        // normal day of app opens triggers at most two full-horizon Google pulls.
+        val defaultTtl: Duration = Duration.ofHours(12)
+
+        private const val TAG = "GoogleForecast"
+        private val ENTRY_KEY = stringPreferencesKey("extended_series_v1")
+
+        fun create(context: Context): GoogleForecastCache =
+            GoogleForecastCache(context.googleForecastDataStore)
+    }
+}
+
+private val Context.googleForecastDataStore: DataStore<Preferences> by
+    preferencesDataStore(name = "google_forecast_cache")

--- a/app/src/main/kotlin/app/clothescast/data/SecureKeyStore.kt
+++ b/app/src/main/kotlin/app/clothescast/data/SecureKeyStore.kt
@@ -9,6 +9,7 @@ import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import app.clothescast.core.data.insight.InvalidApiKeyException
 import app.clothescast.core.data.insight.MissingApiKeyException
+import app.clothescast.diag.DiagLog
 import com.google.crypto.tink.Aead
 import com.google.crypto.tink.KeyTemplates
 import com.google.crypto.tink.aead.AeadConfig
@@ -124,6 +125,35 @@ class SecureKeyStore(
      */
     suspend fun googleApiKeyFingerprint(): Int? =
         dataStore.data.map { it[GOOGLE_PREF_KEY] }.first()?.hashCode()
+
+    /**
+     * The Google key plaintext and its [googleApiKeyFingerprint] read from a
+     * single DataStore snapshot. A caller that needs both — the weather blend,
+     * which fetches with the key and then caches the result under the fingerprint
+     * — must read them atomically: two separate reads can straddle a key edit and
+     * cache the *old* key's series under the *new* key's fingerprint, defeating
+     * the swap-invalidation the fingerprint exists for. Returns `(null, null)`
+     * when unset or after a decrypt failure clears a corrupt value, mirroring
+     * [getGoogleApiKey]. The fingerprint matches [googleApiKeyFingerprint] (same
+     * ciphertext hash), so the inner and outer caches key on the same value.
+     */
+    suspend fun getGoogleApiKeyWithFingerprint(): Pair<String?, Int?> {
+        val ciphertextB64 = dataStore.data.map { it[GOOGLE_PREF_KEY] }.first() ?: return null to null
+        val fingerprint = ciphertextB64.hashCode()
+        return try {
+            val ciphertext = Base64.getDecoder().decode(ciphertextB64)
+            aead.decrypt(ciphertext, GOOGLE_AAD).toString(Charsets.UTF_8) to fingerprint
+        } catch (e: Exception) {
+            // Corrupt ciphertext / unrecoverable Keystore state — log why Google
+            // is about to drop out of the blend (no diag trace otherwise), then
+            // drop the bad value so the next attempt starts clean, mirroring
+            // [read]. Returns nulls rather than rethrowing: the forecast path
+            // treats a missing Google key as "Google sits out", not an error.
+            DiagLog.w("SecureKeyStore", "Google key decrypt failed; clearing the corrupt value", e)
+            dataStore.edit { it.remove(GOOGLE_PREF_KEY) }
+            null to null
+        }
+    }
 
     /**
      * Reactive view of "is a Gemini key currently stored." Used by the Today screen's

--- a/app/src/test/kotlin/app/clothescast/data/GoogleForecastCacheTest.kt
+++ b/app/src/test/kotlin/app/clothescast/data/GoogleForecastCacheTest.kt
@@ -1,0 +1,136 @@
+package app.clothescast.data
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import app.clothescast.core.domain.model.Location
+import app.clothescast.core.domain.model.PerModelHour
+import app.clothescast.core.domain.model.WeatherCondition
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.nio.file.Path
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class GoogleForecastCacheTest {
+    @TempDir lateinit var tempDir: Path
+
+    private lateinit var dataStore: DataStore<Preferences>
+
+    private val london = Location(latitude = 51.5074, longitude = -0.1278, displayName = "London")
+    private val t0 = Instant.parse("2026-06-30T06:00:00Z")
+
+    private val series = listOf(
+        PerModelHour(
+            time = LocalDateTime.of(2026, 6, 30, 7, 0),
+            apparentTemperatureC = 16.0,
+            temperatureC = 17.5,
+            precipitationProbabilityPct = 40.0,
+            precipitationMm = 0.8,
+            windSpeedKmh = 12.0,
+            relativeHumidityPct = 70.0,
+            cloudCoverPct = 80.0,
+            uvIndex = 2.0,
+            condition = WeatherCondition.RAIN,
+        ),
+        // A next-day pre-dawn hour: exercises the per-entry date round-trip.
+        PerModelHour(
+            time = LocalDateTime.of(2026, 7, 1, 2, 0),
+            apparentTemperatureC = 11.0,
+            temperatureC = 12.0,
+            precipitationProbabilityPct = null,
+            condition = WeatherCondition.CLOUDY,
+        ),
+    )
+
+    @BeforeEach
+    fun setUp() {
+        dataStore = PreferenceDataStoreFactory.create(
+            produceFile = { File(tempDir.toFile(), "google_forecast.preferences_pb") },
+        )
+    }
+
+    private fun cacheAt(instant: Instant) =
+        GoogleForecastCache(dataStore, clock = Clock.fixed(instant, ZoneOffset.UTC))
+
+    // Fingerprint of the key that fetched the series; varied per test.
+    private val keyA = 111
+    private val keyB = 222
+
+    @Test
+    fun `fresh is null when nothing stored`() = runTest {
+        cacheAt(t0).fresh(london, keyA) shouldBe null
+    }
+
+    @Test
+    fun `put then fresh round-trips the series`() = runTest {
+        cacheAt(t0).put(london, keyA, series)
+
+        cacheAt(t0.plus(Duration.ofHours(1))).fresh(london, keyA) shouldBe series
+    }
+
+    @Test
+    fun `fresh returns the series right up to the TTL boundary`() = runTest {
+        cacheAt(t0).put(london, keyA, series)
+
+        // 11 h old, inside the 12 h default window.
+        cacheAt(t0.plus(Duration.ofHours(11))).fresh(london, keyA) shouldBe series
+    }
+
+    @Test
+    fun `fresh is null once the entry is older than the TTL`() = runTest {
+        cacheAt(t0).put(london, keyA, series)
+
+        cacheAt(t0.plus(Duration.ofHours(13))).fresh(london, keyA) shouldBe null
+    }
+
+    @Test
+    fun `fresh honors a caller-supplied max age`() = runTest {
+        cacheAt(t0).put(london, keyA, series)
+
+        cacheAt(t0.plus(Duration.ofHours(2))).fresh(london, keyA, maxAge = Duration.ofHours(1)) shouldBe null
+    }
+
+    @Test
+    fun `small GPS jitter within the grid cell still hits`() = runTest {
+        cacheAt(t0).put(london, keyA, series)
+
+        // ~hundreds of metres — same ~1 km bucket.
+        val jittered = london.copy(latitude = 51.5079, longitude = -0.1281)
+        cacheAt(t0.plus(Duration.ofHours(1))).fresh(jittered, keyA) shouldBe series
+    }
+
+    @Test
+    fun `a real move to a different cell misses`() = runTest {
+        cacheAt(t0).put(london, keyA, series)
+
+        val paris = Location(latitude = 48.8566, longitude = 2.3522, displayName = "Paris")
+        cacheAt(t0.plus(Duration.ofHours(1))).fresh(paris, keyA) shouldBe null
+    }
+
+    @Test
+    fun `a different key fingerprint misses so a swapped key re-fetches`() = runTest {
+        // Series fetched with key A; the user has since swapped to key B (which
+        // may 403). Reusing A's series would keep Google in the blend for a key
+        // that can't authorize Weather, so this must miss.
+        cacheAt(t0).put(london, keyA, series)
+
+        cacheAt(t0.plus(Duration.ofHours(1))).fresh(london, keyB) shouldBe null
+    }
+
+    @Test
+    fun `putting an empty series stores nothing`() = runTest {
+        cacheAt(t0).put(london, keyA, emptyList())
+
+        cacheAt(t0.plus(Duration.ofHours(1))).fresh(london, keyA) shouldBe null
+    }
+}

--- a/app/src/test/kotlin/app/clothescast/data/SecureKeyStoreTest.kt
+++ b/app/src/test/kotlin/app/clothescast/data/SecureKeyStoreTest.kt
@@ -133,6 +133,32 @@ class SecureKeyStoreTest {
     }
 
     @Test
+    fun `getGoogleApiKeyWithFingerprint reads key and matching fingerprint atomically`() = runTest {
+        // Unset → both null.
+        subject.getGoogleApiKeyWithFingerprint() shouldBe (null to null)
+
+        subject.setGoogleApiKey("AIzaGoogle")
+        val (key, fingerprint) = subject.getGoogleApiKeyWithFingerprint()
+        key shouldBe "AIzaGoogle"
+        // Same fingerprint the standalone accessor (and the outer cache) computes.
+        fingerprint shouldBe subject.googleApiKeyFingerprint()
+        fingerprint shouldNotBe null
+
+        subject.clearGoogleApiKey()
+        subject.getGoogleApiKeyWithFingerprint() shouldBe (null to null)
+    }
+
+    @Test
+    fun `getGoogleApiKeyWithFingerprint drops and clears an undecryptable key`() = runTest {
+        val failing = SecureKeyStore(aead = DecryptFailsFakeAead, dataStore = dataStore)
+        failing.setGoogleApiKey("AIzaGoogleCorrupt")
+
+        // Decrypt fails → returns nulls (Google sits out) and clears the bad value.
+        failing.getGoogleApiKeyWithFingerprint() shouldBe (null to null)
+        failing.googleApiKeyConfiguredFlow.first() shouldBe false
+    }
+
+    @Test
     fun `set replaces the previous key`() = runTest {
         subject.set("first")
         subject.set("second")

--- a/core/data/src/main/kotlin/app/clothescast/core/data/weather/GoogleWeatherModelClient.kt
+++ b/core/data/src/main/kotlin/app/clothescast/core/data/weather/GoogleWeatherModelClient.kt
@@ -74,21 +74,31 @@ sealed interface GoogleWeatherProbe {
  * blend proceeds on the Open-Meteo models alone. The fetch never fails the
  * surrounding forecast.
  *
- * [fetchHourly] walks Google's pagination to cover the full [FORECAST_HOURS]-hour
+ * [fetchHourly] walks Google's pagination across the full [EXTENDED_HOURS]-hour
  * (10-day) horizon — Google caps each page at [PAGE_SIZE] hours and hands back a
  * `nextPageToken`, so the series is assembled across up to [MAX_PAGES] round-trips,
- * matching the Open-Meteo models' forward reach so Google votes in the consensus on
- * every day rather than just today + tomorrow. A page that fails partway keeps the
- * hours already gathered (so a late network blip still contributes the near days)
- * rather than dropping Google entirely. [probe], the cold connectivity check, stays
- * a single round-trip — it only needs to know the key reaches the API and returns
- * usable hours, not the whole horizon.
+ * matching the Open-Meteo models' forward reach so Google votes in the consensus
+ * on every day rather than just today + tomorrow. The walk is expensive, so the
+ * :app layer rate-limits it behind `GoogleForecastCache` (a ~12 h TTL) rather than
+ * gating it per caller. A page that fails partway keeps the hours already gathered
+ * (so a late network blip still contributes the near days) rather than dropping
+ * Google entirely. [probe], the cold connectivity check, stays a single round-trip
+ * ([NEAR_HOURS]) — it only needs to know the key reaches the API and returns usable
+ * hours, not the whole horizon.
  */
 class GoogleWeatherModelClient(
     private val httpClient: HttpClient,
     private val logger: ConfidenceFetchLogger = NoOpConfidenceFetchLogger,
     private val apiCallLogger: ApiCallLogger = NoOpApiCallLogger,
 ) {
+    /**
+     * Fetches the full [EXTENDED_HOURS]-hour (10-day) Google forecast, walking
+     * pagination as needed (~10 round-trips). The expensive walk is rate-limited
+     * by the :app layer's `GoogleForecastCache` (a ~12 h TTL), so it runs at most
+     * a couple of times a day regardless of how often the forecast refreshes —
+     * which is why every caller can ask for the whole horizon here without a
+     * cheaper "near" variant.
+     */
     suspend fun fetchHourly(location: Location, apiKey: String): List<PerModelHour>? {
         if (apiKey.isBlank()) return null
         val hours = try {
@@ -123,7 +133,7 @@ class GoogleWeatherModelClient(
         val response = try {
             // Single page is enough for a connectivity check — no need to walk
             // the full horizon just to learn the key reaches the API.
-            request(location, apiKey, pageToken = null)
+            request(location, apiKey, maxHours = NEAR_HOURS, pageToken = null)
         } catch (ce: CancellationException) {
             throw ce
         } catch (t: Throwable) {
@@ -148,25 +158,28 @@ class GoogleWeatherModelClient(
     }
 
     /**
-     * Walks Google's pagination to gather up to [FORECAST_HOURS] hours, following
+     * Walks Google's pagination to gather up to [EXTENDED_HOURS] hours, following
      * each page's `nextPageToken` until it runs dry, the hour budget is met, or
      * [MAX_PAGES] is hit (a backstop so a misbehaving token can't loop forever).
      *
-     * The first page's failure propagates so the caller's catch can classify it
-     * (the probe's 403 handling, fetchHourly's drop-to-null). A *later* page's
-     * failure is caught and the walk stops with what it already has — a network
-     * blip on page 7 shouldn't throw away the six days already in hand.
+     * The first page's failure propagates so [fetchHourly]'s catch can drop
+     * Google to null. A *later* page's failure is caught and the walk stops with
+     * what it already has — a network blip on page 7 shouldn't throw away the six
+     * days already in hand.
      */
-    private suspend fun requestAllPages(location: Location, apiKey: String): List<GoogleForecastHour> {
+    private suspend fun requestAllPages(
+        location: Location,
+        apiKey: String,
+    ): List<GoogleForecastHour> {
         val all = mutableListOf<GoogleForecastHour>()
         var pageToken: String? = null
         var pages = 0
         do {
             val response = if (all.isEmpty()) {
-                request(location, apiKey, pageToken)
+                request(location, apiKey, EXTENDED_HOURS, pageToken)
             } else {
                 try {
-                    request(location, apiKey, pageToken)
+                    request(location, apiKey, EXTENDED_HOURS, pageToken)
                 } catch (ce: CancellationException) {
                     throw ce
                 } catch (t: Throwable) {
@@ -177,13 +190,14 @@ class GoogleWeatherModelClient(
             all += response.forecastHours
             pages++
             pageToken = response.nextPageToken?.takeIf { it.isNotBlank() }
-        } while (pageToken != null && all.size < FORECAST_HOURS && pages < MAX_PAGES)
+        } while (pageToken != null && all.size < EXTENDED_HOURS && pages < MAX_PAGES)
         return all
     }
 
     private suspend fun request(
         location: Location,
         apiKey: String,
+        maxHours: Int,
         pageToken: String?,
     ): GoogleHourlyResponse =
         apiCallLogger.instrument(ApiEndpoints.GOOGLE_WEATHER) {
@@ -206,9 +220,9 @@ class GoogleWeatherModelClient(
                 header("X-Goog-Api-Key", apiKey)
                 parameter("location.latitude", location.latitude)
                 parameter("location.longitude", location.longitude)
-                parameter("hours", FORECAST_HOURS)
+                parameter("hours", maxHours)
                 // Google caps the hourly page at PAGE_SIZE; the rest of the
-                // FORECAST_HOURS window arrives via nextPageToken (see
+                // requested window arrives via nextPageToken (see
                 // [requestAllPages]).
                 parameter("pageSize", PAGE_SIZE)
                 // METRIC so temperatures come back in °C and wind in km/h, the
@@ -254,17 +268,21 @@ class GoogleWeatherModelClient(
     companion object {
         // The full horizon Google's hourly endpoint serves — 240 hours / 10 days
         // — so Google reaches as far forward as the Open-Meteo models and votes in
-        // the consensus on every day, not just today + tomorrow.
-        private const val FORECAST_HOURS = 240
+        // the consensus on every day, not just today + tomorrow. The forecast path
+        // ([fetchHourly]) always walks this; the :app cache rate-limits it.
+        const val EXTENDED_HOURS = 240
 
-        // Google caps each hourly page at 24 hours; the rest of FORECAST_HOURS
+        // A single 24-hour page — all [probe] needs to confirm the key reaches the
+        // Weather API and returns usable hours, without walking the full horizon.
+        const val NEAR_HOURS = 24
+
+        // Google caps each hourly page at 24 hours; the rest of the horizon
         // arrives by following nextPageToken (see [requestAllPages]).
         private const val PAGE_SIZE = 24
 
-        // Backstop on the pagination walk: ceil(FORECAST_HOURS / PAGE_SIZE) pages
-        // cover the whole horizon, with no extra round-trips beyond that even if
-        // Google keeps handing back a token.
-        private const val MAX_PAGES = FORECAST_HOURS / PAGE_SIZE
+        // ceil(EXTENDED_HOURS / PAGE_SIZE) pages cover the whole horizon — a
+        // backstop so a misbehaving token can't loop forever.
+        private const val MAX_PAGES = EXTENDED_HOURS / PAGE_SIZE
     }
 }
 

--- a/core/data/src/test/kotlin/app/clothescast/core/data/weather/GoogleWeatherModelClientTest.kt
+++ b/core/data/src/test/kotlin/app/clothescast/core/data/weather/GoogleWeatherModelClientTest.kt
@@ -227,12 +227,14 @@ class GoogleWeatherModelClientTest {
     }
 
     @Test
-    fun `probe stays a single round-trip even when more pages are available`() = runTest {
+    fun `probe stays a single round-trip on the near window even when more pages are available`() = runTest {
         val captured = mutableListOf<HttpRequestData>()
         pagingClient(pages = listOf(page(hour = 11, nextPageToken = "p2"), page(hour = 12)), captured = captured)
             .probe(london, "AIza-test-key") shouldBe GoogleWeatherProbe.Reachable(hours = 1)
 
+        // One page only, asking Google for just the 24-hour connectivity window.
         captured.size shouldBe 1
+        captured.single().url.parameters["hours"] shouldBe "24"
     }
 
     @Test


### PR DESCRIPTION
## What & why

Follow-up to the 10-day Google pagination (#1084). That change made *every* forecast refresh walk Google's full horizon — ~10 paginated, billed API calls. Background refreshes (the scheduled morning/evening notifications, widget self-heals) hit that path too, so a background day could fire dozens of Google calls.

This rate-limits the walk with a cache instead of repeating it every refresh, so the full horizon is fetched at most ~twice a day while every surface that needs the week-ahead still gets Google's vote.

## Changes

- **`GoogleForecastCache`** (new, `:app`): persists the extended series for one location (~1 km grid, matching `CachingWeatherRepository`) across process death via DataStore, 12 h TTL ("once or twice a day"). Every refresh path — app opens and background refreshes alike — shares one cached series; a cache miss walks the horizon once and persists it. The entry is keyed by location **and the Google key's fingerprint**, so swapping a working key for one that 403s drops the stale series. Only a **(near-)complete walk** is persisted (≥ 7 days) — `requestAllPages` returns a partial series on a mid-walk page failure, and freezing that near-length result would keep week-ahead Google missing for the whole TTL.
- **`fetchGoogleSeries`** in `ClothesCastApplication`: serve the fresh cached series if present (keyed by location + key fingerprint); otherwise walk the full horizon once and persist it. No foreground/background branching — the cache TTL is the sole rate limiter.
- **`GoogleWeatherModelClient`**: `fetchHourly` always walks the full `EXTENDED_HOURS` (240) horizon (the depth param is gone); `probe` still hits a single `NEAR_HOURS` (24) page for its connectivity check.

## Why cache-gated, not app-open-gated

An earlier revision gated the expensive walk to "app is foregrounded." But the home-screen **`SevenDayFeelsLikeWidget`** renders a 7-day chart (today + `upcomingDays.take(6)`) in the background, and the **evening tomorrow pre-render** (`dayOffset=1`) needs tomorrow's daytime — both render multi-day data without the app open. Foreground-gating would leave Google off their days 2–10 for anyone who rarely opens the app. Gating purely by the 12 h cache TTL bounds cost the same way while feeding those surfaces, and it's simpler — it removes the near/extended split and the foreground edge cases entirely.

## Behavior notes

- The walk runs at most ~twice a day (12 h TTL), regardless of how many refreshes fire.
- Replacing the Google key invalidates both the inner extended cache and the outer bundle cache (shared fingerprint), so a key that can no longer authorize Weather drops Google immediately rather than after the TTL.
- A partial walk still feeds the current blend but isn't persisted, so the next refresh retries the full walk.

## Privacy

This only **reduces** what leaves the device — far fewer Google calls; no change to what any single request carries. The new cache stores forecast numbers keyed by a coarse (~1 km) lat/lon bucket and a non-reversible 32-bit hash of the key's ciphertext (the same fingerprint the outer cache already uses — not the key itself, no decrypt). No PII, no API key — the same on-device data category `InsightCache` already persists.

## Test plan

- New `GoogleForecastCacheTest`: round-trip, TTL boundary / expiry, caller-supplied max age, GPS-jitter hit vs real-move miss, key-fingerprint mismatch miss, empty-series no-op.
- `GoogleWeatherModelClientTest`: follows `nextPageToken` across pages, stops at the page cap, keeps partial hours on a late-page failure, drops Google on a first-page failure; `probe` stays a single 24-hour round-trip.
- `./gradlew :core:domain:test :core:data:test :app:testDebugUnitTest` — green.
- `./gradlew :app:assembleDebug` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)