### PR TITLE
Keep the day's earlier hours in Google's cached forecast

### DIFF
--- a/app/src/main/kotlin/app/clothescast/data/GoogleForecastCache.kt
+++ b/app/src/main/kotlin/app/clothescast/data/GoogleForecastCache.kt
@@ -68,12 +68,8 @@ class GoogleForecastCache(
         maxAge: Duration = defaultTtl,
     ): List<PerModelHour>? {
         val raw = readRaw() ?: return null
-        val entry = try {
-            json.decodeFromString<Entry>(raw)
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: Exception) {
-            DiagLog.w(TAG, "Google forecast cache decode failed; dropping the entry", e)
+        val entry = decode(raw) ?: run {
+            // Corrupt entry — drop it so the next fetch re-populates.
             clear()
             return null
         }
@@ -93,16 +89,30 @@ class GoogleForecastCache(
      * Stores [hours] as the extended series for [location], stamped now. A
      * persistence failure is logged and swallowed — the caller already has the
      * series in hand for this fetch, and the next foreground walk re-stamps it.
+     *
+     * Google's hourly endpoint only serves from the current hour forward, so a
+     * fresh walk carries nothing for the part of *today* that has already
+     * elapsed. Writing just that from-now series would discard the morning the
+     * previous walk had captured, front-truncating Google's contribution to the
+     * current day's window — which then gets it dropped from the cross-model
+     * confidence comparison (see
+     * [app.clothescast.core.domain.usecase.confidenceInput], which excludes a
+     * model that doesn't reach the window's first hour). So carry the prior
+     * entry's already-elapsed same-day hours forward and merge the fresh series
+     * over them, keeping the cached series spanning the whole period. The fresh
+     * forecast always wins from its first hour on; only strictly-earlier hours
+     * of the same local day are retained.
      */
     suspend fun put(location: Location, apiKeyFingerprint: Int?, hours: List<PerModelHour>) {
         if (hours.isEmpty()) return
         val key = keyOf(location)
+        val merged = mergeRetainingEarlierToday(key, apiKeyFingerprint, hours)
         val entry = Entry(
             latBucket = key.first,
             lonBucket = key.second,
             apiKeyFingerprint = apiKeyFingerprint,
             fetchedAtMs = clock.instant().toEpochMilli(),
-            hours = hours.map { it.toDto() },
+            hours = merged.map { it.toDto() },
         )
         val encoded = try {
             json.encodeToString(entry)
@@ -119,6 +129,56 @@ class GoogleForecastCache(
         } catch (e: Exception) {
             DiagLog.w(TAG, "Google forecast cache write failed", e)
         }
+    }
+
+    /**
+     * Merges [fresh] over the prior cached entry, carrying forward only the
+     * already-elapsed hours of the current local day so the stored series still
+     * spans the whole period (see [put]). Returns [fresh] unchanged when there's
+     * no usable prior entry, it's for a different location / key, or it holds no
+     * earlier same-day hour to keep.
+     *
+     * "Current day" is read off the fresh series' own earliest timestamp (which
+     * is ~now in the location's local wall-clock) rather than [clock], so it
+     * needs no timezone of the location: only prior hours sharing that local
+     * date and falling strictly before the fresh series begin are retained.
+     * Retaining from a prior entry of *any* age is deliberate — the prior walk's
+     * forecast for this morning is the only Google data we'll ever have for
+     * hours Google no longer returns, and it's exactly the morning the day's
+     * low is read from. The fresh series owns every hour from its first onward,
+     * so nothing stale survives into the future.
+     */
+    private suspend fun mergeRetainingEarlierToday(
+        key: Pair<Long, Long>,
+        apiKeyFingerprint: Int?,
+        fresh: List<PerModelHour>,
+    ): List<PerModelHour> {
+        val newFirst = fresh.minByOrNull { it.time }?.time ?: return fresh
+        val prior = readRaw()?.let { decode(it) } ?: return fresh
+        // Only carry hours from an entry for the same location + key; a
+        // different bucket or a swapped key is unrelated data.
+        if (prior.apiKeyFingerprint != apiKeyFingerprint ||
+            prior.latBucket != key.first ||
+            prior.lonBucket != key.second
+        ) {
+            return fresh
+        }
+        val today = newFirst.toLocalDate()
+        val retained = prior.hours
+            .mapNotNull { it.toDomain() }
+            .filter { it.time.toLocalDate() == today && it.time.isBefore(newFirst) }
+        return if (retained.isEmpty()) fresh else (retained + fresh).sortedBy { it.time }
+    }
+
+    /**
+     * Decodes a stored [Entry], or null on a malformed payload (logged, no
+     * side effects — callers decide whether to clear). Not suspend: pure JSON.
+     */
+    private fun decode(raw: String): Entry? = try {
+        json.decodeFromString<Entry>(raw)
+    } catch (e: Exception) {
+        DiagLog.w(TAG, "Google forecast cache decode failed", e)
+        null
     }
 
     private suspend fun readRaw(): String? = try {

--- a/app/src/test/kotlin/app/clothescast/data/GoogleForecastCacheTest.kt
+++ b/app/src/test/kotlin/app/clothescast/data/GoogleForecastCacheTest.kt
@@ -133,4 +133,69 @@ class GoogleForecastCacheTest {
 
         cacheAt(t0.plus(Duration.ofHours(1))).fresh(london, keyA) shouldBe null
     }
+
+    // --- merge: retain the current day's already-elapsed hours on re-put ---
+
+    /** Minimal hour on 2026-06-[day] at [hour]:00, just enough to round-trip. */
+    private fun hr(day: Int, hour: Int, temp: Double = 15.0) = PerModelHour(
+        time = LocalDateTime.of(2026, 6, day, hour, 0),
+        apparentTemperatureC = temp,
+        temperatureC = temp + 1.0,
+        precipitationProbabilityPct = null,
+    )
+
+    @Test
+    fun `put carries earlier same-day hours forward instead of overwriting them`() = runTest {
+        // A morning walk captures 06:00–09:00 today.
+        val morning = listOf(hr(30, 6), hr(30, 7), hr(30, 8), hr(30, 9))
+        cacheAt(t0).put(london, keyA, morning)
+
+        // A later walk returns only from 10:00 onward, as Google's endpoint does.
+        val fromTen = listOf(hr(30, 10), hr(30, 11), hr(30, 12))
+        cacheAt(t0.plus(Duration.ofHours(4))).put(london, keyA, fromTen)
+
+        // The stored series still spans 06:00–12:00 rather than starting at 10:00.
+        cacheAt(t0.plus(Duration.ofHours(5))).fresh(london, keyA) shouldBe (morning + fromTen)
+    }
+
+    @Test
+    fun `a stale prior entry still backfills today's already-elapsed hours`() = runTest {
+        // Yesterday evening's walk forecast into today, including this morning.
+        // It's now older than the TTL, but its morning hours are the only Google
+        // data we'll have for hours Google no longer returns.
+        val priorWalk = listOf(hr(29, 21), hr(30, 6), hr(30, 7), hr(30, 8), hr(30, 9), hr(30, 10))
+        cacheAt(t0.minus(Duration.ofHours(13))).put(london, keyA, priorWalk)
+
+        // Today's first walk only reaches back to 10:00, with a fresher value there.
+        val todayWalk = listOf(hr(30, 10, temp = 20.0), hr(30, 11), hr(30, 12))
+        cacheAt(t0.plus(Duration.ofHours(4))).put(london, keyA, todayWalk)
+
+        // Morning (06–09) from the prior walk; today's walk owns 10:00 onward
+        // (its fresher 10:00 wins), and yesterday's 21:00 is not carried.
+        cacheAt(t0.plus(Duration.ofHours(5))).fresh(london, keyA) shouldBe
+            (listOf(hr(30, 6), hr(30, 7), hr(30, 8), hr(30, 9)) + todayWalk)
+    }
+
+    @Test
+    fun `put does not carry forward hours from an earlier day`() = runTest {
+        val yesterday = listOf(hr(29, 18), hr(29, 20), hr(29, 22))
+        cacheAt(t0.minus(Duration.ofHours(12))).put(london, keyA, yesterday)
+
+        val today = listOf(hr(30, 10), hr(30, 11))
+        cacheAt(t0.plus(Duration.ofHours(4))).put(london, keyA, today)
+
+        cacheAt(t0.plus(Duration.ofHours(5))).fresh(london, keyA) shouldBe today
+    }
+
+    @Test
+    fun `put does not carry forward hours fetched under a different key`() = runTest {
+        val morning = listOf(hr(30, 6), hr(30, 7))
+        cacheAt(t0).put(london, keyA, morning)
+
+        // The user swapped keys; keyB's entry must not inherit keyA's morning.
+        val fromTen = listOf(hr(30, 10), hr(30, 11))
+        cacheAt(t0.plus(Duration.ofHours(4))).put(london, keyB, fromTen)
+
+        cacheAt(t0.plus(Duration.ofHours(5))).fresh(london, keyB) shouldBe fromTen
+    }
 }


### PR DESCRIPTION
## What

`GoogleForecastCache.put` now merges a fresh walk over the prior cached entry instead of overwriting it, carrying forward the already-elapsed hours of the current local day so the cached series keeps spanning the whole period.

## Why

Google's `hours:lookup` endpoint only returns from the current hour forward, so a fresh full-horizon walk has no data for the part of today that has already elapsed. `put` used to overwrite the cache with exactly that from-now series, discarding the morning the previous walk had captured.

On a midday cache miss that front-truncated Google's contribution to the current day's window — and `DeriveInsight.confidenceInput` drops any model that doesn't reach the window's first hour, so Google sat out today's cross-model confidence comparison entirely, and its chart line started midday.

## How

- On `put`, retain only the prior entry's hours that fall on the same local day as the fresh series' first hour and strictly before it (matched by location + key fingerprint). The fresh forecast owns every hour from its first onward, so nothing stale survives into the future.
- "Current day" is read off the fresh series' own earliest local timestamp, so no location timezone is needed.
- The prior entry is read regardless of its age: that earlier walk's forecast for this morning is the only Google data we'll ever have for hours Google no longer serves, and it's exactly where the day's low is read from.
- `confidenceInput`'s drop-Google branch stays as the fallback for the first-ever fetch of a day, when there's no prior entry to backfill from.
- Factored the entry decode into a shared helper (`fresh` still clears a corrupt entry; the merge path just skips backfill).

## Privacy

No change to what crosses the device boundary — the same forecast numbers already cached are retained, just not thrown away when a later walk can't re-cover the morning. Same coarse (~1 km) location bucket and key fingerprint, no PII, no API key.

## Test plan

- `./gradlew :app:testDebugUnitTest --tests "*GoogleForecastCacheTest*"` ✅ — added coverage for same-day retention, stale-prior backfill with the fresh value winning on overlap, no cross-day carryover, and no carryover across a swapped key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HPyGMPZBPUigvWZydyKnDY)_