### PR TITLE
Eleven bug fixes from a full-codebase bug hunt

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -156,10 +156,13 @@
             android:name=".notification.NotificationDismissReceiver"
             android:exported="false" />
 
-        <!-- System broadcasts that should re-arm the daily alarm. All four
+        <!-- System broadcasts that should re-arm the daily alarm. All five
              actions are protected system broadcasts, which the OS delivers
              to unexported receivers — exported="false" just keeps other
-             apps from poking the receiver directly. -->
+             apps from poking the receiver directly. TIME_SET matters because
+             alarms are armed as absolute RTC epoch millis: correcting a wrong
+             clock shifts the armed instant relative to the intended wall-clock
+             time, so the fire time must be recomputed from the fixed clock. -->
         <receiver
             android:name=".alarm.ScheduleRefreshReceiver"
             android:exported="false">
@@ -167,6 +170,7 @@
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
                 <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
                 <action android:name="android.intent.action.TIMEZONE_CHANGED" />
+                <action android:name="android.intent.action.TIME_SET" />
                 <action android:name="android.intent.action.LOCALE_CHANGED" />
             </intent-filter>
         </receiver>

--- a/app/src/main/kotlin/app/clothescast/ClothesCastApplication.kt
+++ b/app/src/main/kotlin/app/clothescast/ClothesCastApplication.kt
@@ -203,7 +203,6 @@ class ClothesCastApplication : Application() {
                 context = this,
                 castContext = it,
                 ttsClient = geminiTtsClient,
-                applicationScope = applicationScope,
             )
         }
     }

--- a/app/src/main/kotlin/app/clothescast/alarm/AlarmReceiver.kt
+++ b/app/src/main/kotlin/app/clothescast/alarm/AlarmReceiver.kt
@@ -7,6 +7,7 @@ import androidx.core.content.ContextCompat
 import app.clothescast.diag.DiagLog
 import app.clothescast.ClothesCastApplication
 import app.clothescast.core.domain.model.ForecastPeriod
+import app.clothescast.core.domain.model.Schedule
 import app.clothescast.core.domain.model.UserPreferences
 import app.clothescast.core.domain.model.playsSpeech
 import app.clothescast.core.domain.model.postsNotification
@@ -66,8 +67,10 @@ class AlarmReceiver : BroadcastReceiver() {
             val appCtx = context.applicationContext
             val app = appCtx as ClothesCastApplication
             val scheduler = DailyAlarmScheduler(appCtx)
+            var readPrefs: UserPreferences? = null
             try {
                 val prefs = app.settingsRepository.preferences.first()
+                readPrefs = prefs
                 if (period == ForecastPeriod.TODAY && !prefs.dailyEnabled) {
                     // Mirror of the tonight branch below: the user disabled the
                     // daily ClothesCast after this alarm was already armed.
@@ -107,17 +110,33 @@ class AlarmReceiver : BroadcastReceiver() {
                 }
                 scheduler.schedule(schedule, period)
             } catch (t: Throwable) {
-                DiagLog.e(TAG, "Re-arm failed for $period", t)
+                DiagLog.e(TAG, "Alarm handling failed for $period", t)
                 // Best-effort: still enqueue the worker even if pref read failed,
                 // so the user gets *something* if it's the morning slot.
                 if (period == ForecastPeriod.TODAY) {
-                    FetchAndNotifyWorker.enqueueOneShot(
-                        appCtx,
-                        period = period,
-                        alarmScheduledAtMs = scheduledAtMs,
-                        alarmFiredAtMs = firedAtMs,
-                    )
+                    runCatching {
+                        FetchAndNotifyWorker.enqueueOneShot(
+                            appCtx,
+                            period = period,
+                            alarmScheduledAtMs = scheduledAtMs,
+                            alarmFiredAtMs = firedAtMs,
+                        )
+                    }.onFailure { DiagLog.e(TAG, "Fallback worker enqueue failed for $period", it) }
                 }
+                // Keep the self-perpetuating alarm chain alive: each fire arms
+                // the next, so a single transient failure (a DataStore read
+                // hiccup, an AlarmManager refusal) would otherwise silently end
+                // every future delivery until the next app open / reboot /
+                // update. Use the read prefs' schedule when we got that far,
+                // else the slot's default time; if the slot was actually
+                // disabled, the next fire reads prefs and cancels itself.
+                runCatching {
+                    val schedule = when (period) {
+                        ForecastPeriod.TODAY -> readPrefs?.schedule ?: Schedule.default()
+                        ForecastPeriod.TONIGHT -> readPrefs?.tonightSchedule ?: Schedule.defaultTonight()
+                    }
+                    scheduler.schedule(schedule, period)
+                }.onFailure { DiagLog.e(TAG, "Fallback re-arm failed for $period", it) }
             } finally {
                 pending.finish()
                 scope.cancel()
@@ -157,11 +176,9 @@ class AlarmReceiver : BroadcastReceiver() {
 
     /**
      * Starts the Service with the specific [workId] to watch, and the
-     * pre-resolved mode flags. Catches both the exception path
-     * (`ForegroundServiceStartNotAllowedException` and friends) and the
-     * silent-null return — `startForegroundService` returns the
-     * `ComponentName` of the started service, or null when the system
-     * couldn't resolve it.
+     * pre-resolved mode flags. Best-effort: a refusal
+     * (`ForegroundServiceStartNotAllowedException` and friends) is logged
+     * and the worker-only path covers the delivery.
      */
     private fun tryStartService(
         context: Context,
@@ -189,14 +206,10 @@ class AlarmReceiver : BroadcastReceiver() {
             playsSpeech = deliveryMode.playsSpeech,
             deliveringWantsForeground = deliveringWantsForeground,
         )
-        val result = runCatching { ContextCompat.startForegroundService(context, intent) }
+        runCatching { ContextCompat.startForegroundService(context, intent) }
             .onFailure { t ->
                 DiagLog.w(TAG, "startForegroundService for $period refused; falling back to worker-only path", t)
             }
-            .getOrNull()
-        if (result == null) {
-            DiagLog.w(TAG, "startForegroundService for $period returned null (system declined); falling back to worker-only path")
-        }
     }
 
     companion object {

--- a/app/src/main/kotlin/app/clothescast/alarm/ScheduleRefreshReceiver.kt
+++ b/app/src/main/kotlin/app/clothescast/alarm/ScheduleRefreshReceiver.kt
@@ -19,6 +19,8 @@ import kotlinx.coroutines.launch
  *  - device boot (alarms are wiped)
  *  - app update (Android also wipes alarms)
  *  - timezone change (the user travelled across zones)
+ *  - clock change (a manual or carrier correction moves the wall clock, so the
+ *    armed RTC instant no longer matches the scheduled wall-clock time)
  *  - locale change (the next insight should be generated in the new language)
  *
  * The schedules' `zoneId` is re-resolved from `ZoneId.systemDefault()` at read time, so

--- a/app/src/main/kotlin/app/clothescast/calendar/CalendarContractEventReader.kt
+++ b/app/src/main/kotlin/app/clothescast/calendar/CalendarContractEventReader.kt
@@ -59,12 +59,15 @@ class CalendarContractEventReader(
         val overrides = calendarOverridesProvider()
         return withContext(Dispatchers.IO) {
             coRunCatching {
-                // Drop all-day rows whose UTC date isn't today: in zones east of
-                // UTC, yesterday's all-day event overlaps the start of today's
-                // local-day window and would otherwise bleed in. Timed rows are
-                // kept as-is — the Instances window already scoped them.
+                // Drop all-day rows whose UTC span doesn't cover today: in zones
+                // east of UTC, yesterday's all-day event overlaps the start of
+                // today's local-day window and would otherwise bleed in. Checked
+                // against the row's full [date, endDateExclusive) span — not just
+                // its first day — so a multi-day all-day event still counts on
+                // days two onward. Timed rows are kept as-is — the Instances
+                // window already scoped them.
                 query(date, date.plusDays(1), zoneId, overrides = overrides)
-                    .filterNot { it.event.allDay && it.date != date }
+                    .filterNot { it.event.allDay && (date < it.date || date >= it.endDateExclusive) }
                     .map { it.event }
             }
                 .onFailure { DiagLog.w(TAG, "Calendar query failed; degrading to no events.", it) }
@@ -110,8 +113,17 @@ class CalendarContractEventReader(
         }
     }
 
-    /** A classified event paired with the local date it falls on. */
-    private data class DatedEvent(val date: LocalDate, val event: CalendarEvent)
+    /**
+     * A classified event paired with the local date it falls on (its first
+     * day, for a multi-day all-day event) and the exclusive end of its
+     * date span. Timed rows always span a single date; all-day rows carry
+     * their real UTC span so [eventsForDay] can match days after the first.
+     */
+    private data class DatedEvent(
+        val date: LocalDate,
+        val event: CalendarEvent,
+        val endDateExclusive: LocalDate = date.plusDays(1),
+    )
 
     @SuppressLint("MissingPermission")
     private fun query(
@@ -159,6 +171,7 @@ class CalendarContractEventReader(
         // kind before deciding whether the FREE filter applies.
         data class Row(
             val date: LocalDate,
+            val endDateExclusive: LocalDate,
             val title: String,
             val start: LocalDateTime,
             val end: LocalDateTime,
@@ -232,8 +245,18 @@ class CalendarContractEventReader(
                     val zonedEnd = Instant.ofEpochMilli(end).atZone(zoneId).toLocalDateTime()
                     Triple(zonedBegin.toLocalDate(), zonedBegin, zonedEnd)
                 }
+                // A multi-day all-day event is one Instances row whose END is
+                // the UTC midnight after its last day; carry that span so the
+                // single-day read can match days after the first. Clamped to
+                // at least one day against a malformed END at-or-before BEGIN.
+                val endDateExclusive = if (allDay) {
+                    Instant.ofEpochMilli(end).atZone(ZoneOffset.UTC).toLocalDate()
+                        .coerceAtLeast(date.plusDays(1))
+                } else {
+                    date.plusDays(1)
+                }
 
-                rows += Row(date, title, start, finish, location, allDay, calendarId, eventType, availability)
+                rows += Row(date, endDateExclusive, title, start, finish, location, allDay, calendarId, eventType, availability)
                 if (calendarId >= 0) calendarIds += calendarId
             }
         }
@@ -268,6 +291,7 @@ class CalendarContractEventReader(
             classificationTally[key] = (classificationTally[key] ?: 0) + 1
             DatedEvent(
                 date = row.date,
+                endDateExclusive = row.endDateExclusive,
                 event = CalendarEvent(
                     title = row.title,
                     start = row.start,

--- a/app/src/main/kotlin/app/clothescast/calendar/HolidayThemeResolver.kt
+++ b/app/src/main/kotlin/app/clothescast/calendar/HolidayThemeResolver.kt
@@ -5,6 +5,7 @@ import app.clothescast.core.domain.model.HolidayTheme
 import app.clothescast.core.domain.model.UserPreferences
 import app.clothescast.core.domain.repository.CalendarEventReader
 import app.clothescast.core.domain.usecase.ThemeForToday
+import app.clothescast.core.domain.util.coRunCatching
 import app.clothescast.tts.toJavaLocale
 import java.time.LocalDate
 import java.util.Locale
@@ -18,8 +19,9 @@ import java.util.Locale
  * to the user's default outfit colours.
  *
  * Calendar events are only read when the user has opted into
- * calendar-sourced theming; the read is wrapped in [runCatching] so a
- * missing READ_CALENDAR permission silently falls through to "no events".
+ * calendar-sourced theming; the read is wrapped in [coRunCatching] so a
+ * missing READ_CALENDAR permission silently falls through to "no events"
+ * while a caller cancellation still unwinds instead of being swallowed.
  *
  * [today] defaults to the user's wall-clock date but is injectable so
  * tests can pin a specific calendar date (avoids flake when the test
@@ -32,7 +34,7 @@ suspend fun resolveHolidayTheme(
 ): HolidayTheme? {
     val needEvents = prefs.calendarHolidayThemingActive || prefs.calendarBirthdayThemingActive
     val events = if (needEvents) {
-        runCatching {
+        coRunCatching {
             calendarEventReader.eventsForDay(today, prefs.schedule.zoneId)
         }.getOrDefault(emptyList())
     } else {

--- a/app/src/main/kotlin/app/clothescast/cast/CastInsightController.kt
+++ b/app/src/main/kotlin/app/clothescast/cast/CastInsightController.kt
@@ -20,13 +20,10 @@ import com.google.android.gms.cast.framework.CastSession
 import com.google.android.gms.cast.framework.SessionManager
 import com.google.android.gms.cast.framework.SessionManagerListener
 import com.google.android.gms.cast.framework.media.RemoteMediaClient
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
@@ -46,16 +43,14 @@ import kotlin.coroutines.resumeWithException
  * [SessionManagerListener] just stops the media server when the
  * receiver disconnects, so we're not leaving an open port behind.
  *
- * The "select a route then cast" orchestration lives in the caller —
- * the controller assumes a session is already active when [cast] is
- * called, and returns a [CastResult] describing why a cast was skipped
- * otherwise.
+ * The "select a route then cast" orchestration lives in
+ * [castToSavedRoute] (throws [CastFailure] describing why a cast was
+ * skipped) and [castWithPreparedMedia] (returns a [CastWorkerOutcome]).
  */
 class CastInsightController(
     private val context: Context,
     private val castContext: CastContext,
     private val ttsClient: GeminiTtsClient,
-    private val applicationScope: CoroutineScope,
     private val resolveLanIp: (Context) -> String? = LanAddress::resolve,
     private val server: CastMediaServer = CastMediaServer(),
 ) {
@@ -94,64 +89,6 @@ class CastInsightController(
         server.stop()
         bound = false
     }
-
-    /**
-     * Casts the given insight to the currently-connected smart display, if
-     * any. Returns [CastAttempt] describing the outcome of the pre-flight
-     * checks; the [CastAttempt.job] is the synth + publish + load coroutine,
-     * non-null only when [CastResult.Loaded] was returned.
-     */
-    fun cast(
-        prose: String,
-        locale: Locale,
-        voiceName: String,
-        style: TtsStyle,
-        outfitPng: ByteArray,
-        title: String,
-        subtitle: String?,
-    ): CastAttempt {
-        val session = sessionManager.currentCastSession
-        if (session == null || !session.isConnected) {
-            return CastAttempt(CastResult.NoActiveSession, job = null)
-        }
-        val client = session.remoteMediaClient
-            ?: return CastAttempt(CastResult.NoRemoteMediaClient, job = null)
-        val host = resolveLanIp(context)
-            ?: return CastAttempt(CastResult.NoLanAddress, job = null)
-
-        val job = applicationScope.launch {
-            try {
-                val pcm = ttsClient.synthesize(
-                    text = prose,
-                    voiceName = voiceName,
-                    locale = locale,
-                    style = style,
-                )
-                val wav = WavEncoder.encode(padPcmToMinimumDuration(pcm))
-                val mp4 = withContext(Dispatchers.Default) { Mp4Encoder.encode(outfitPng, wav) }
-                val urls = server.publish(host = host, media = mp4, kind = CastMediaKind.MP4)
-                client.load(
-                    MediaLoadRequestData.Builder()
-                        .setMediaInfo(buildMediaInfo(urls.url, title, subtitle))
-                        .build(),
-                )
-            } catch (t: Throwable) {
-                DiagLog.e(TAG, "Cast publish failed", t)
-                server.stop()
-                throw t
-            }
-        }
-        return CastAttempt(CastResult.Loaded, job = job)
-    }
-
-    sealed interface CastResult {
-        data object Loaded : CastResult
-        data object NoActiveSession : CastResult
-        data object NoRemoteMediaClient : CastResult
-        data object NoLanAddress : CastResult
-    }
-
-    data class CastAttempt(val result: CastResult, val job: Job?)
 
     /**
      * Selects the user's saved Cast route (by [routeId]), waits for the

--- a/app/src/main/kotlin/app/clothescast/cast/CastTestDispatch.kt
+++ b/app/src/main/kotlin/app/clothescast/cast/CastTestDispatch.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
 import java.time.LocalDate
+import java.time.ZoneId
 
 /**
  * Outcome of a "Cast now" test: carries the same (error, publishedAt,
@@ -85,7 +86,9 @@ internal suspend fun castCurrentInsight(
         prefs.periodPreamble,
         prefs.wearPreamble,
     )
-    val isFutureDay = insight.forDate.isAfter(LocalDate.now())
+    // Compared in the forecast location's zone (see InsightCard) — the
+    // device's own date mislabels the current day when the two differ.
+    val isFutureDay = insight.forDate.isAfter(LocalDate.now(insight.forecastZone ?: ZoneId.systemDefault()))
     val prose = formatter.format(insight.summary, isFutureDay = isFutureDay)
     val info = outfitCardInfoLines(
         context = context,

--- a/app/src/main/kotlin/app/clothescast/diag/BugReport.kt
+++ b/app/src/main/kotlin/app/clothescast/diag/BugReport.kt
@@ -31,6 +31,7 @@ import app.clothescast.core.domain.model.Region
 import app.clothescast.core.domain.model.TemperatureUnit
 import app.clothescast.core.domain.model.UserPreferences
 import app.clothescast.core.domain.model.symbol
+import app.clothescast.core.domain.util.coRunCatching
 import app.clothescast.data.SettingsRepository
 import app.clothescast.insight.InsightFormatter
 import kotlinx.coroutines.flow.first
@@ -87,30 +88,33 @@ object BugReport {
     }
 
     private suspend fun buildPayload(context: Context, app: ClothesCastApplication): String {
-        val prefs = runCatching { app.settingsRepository.preferences.first() }.getOrNull()
-        val geminiKeyConfigured = runCatching {
+        // coRunCatching, not runCatching: these reads suspend, and the stdlib
+        // form would swallow a cancellation of the sharing coroutine and keep
+        // building (and then sharing) a gutted report from a cancelled scope.
+        val prefs = coRunCatching { app.settingsRepository.preferences.first() }.getOrNull()
+        val geminiKeyConfigured = coRunCatching {
             app.secureKeyStore.geminiKeyConfiguredFlow.first()
         }.getOrDefault(false)
-        val mqttPasswordConfigured = runCatching {
+        val mqttPasswordConfigured = coRunCatching {
             app.secureKeyStore.mqttPasswordConfiguredFlow.first()
         }.getOrDefault(false)
-        val mqttPublishStatus = runCatching {
+        val mqttPublishStatus = coRunCatching {
             app.settingsRepository.mqttPublishStatus.first()
         }.getOrNull()
-        val castStatus = runCatching {
+        val castStatus = coRunCatching {
             app.settingsRepository.castStatus.first()
         }.getOrNull()
-        val thisSnapshot = runCatching {
+        val thisSnapshot = coRunCatching {
             app.insightCache.thisPeriod.first()
         }.getOrNull()
-        val nextSnapshot = runCatching {
+        val nextSnapshot = coRunCatching {
             app.insightCache.nextPeriod.first()
         }.getOrNull()
         val thisPeriod = if (thisSnapshot != null && prefs != null) {
-            runCatching { app.deriveInsight(thisSnapshot, prefs).insight }.getOrNull()
+            coRunCatching { app.deriveInsight(thisSnapshot, prefs).insight }.getOrNull()
         } else null
         val nextPeriod = if (nextSnapshot != null && prefs != null) {
-            runCatching { app.deriveInsight(nextSnapshot, prefs).insight }.getOrNull()
+            coRunCatching { app.deriveInsight(nextSnapshot, prefs).insight }.getOrNull()
         } else null
         val crash = DiagLog.readPersistedCrash()
         val recent = DiagLog.snapshot().takeLast(MAX_LOG_LINES)
@@ -400,7 +404,7 @@ object BugReport {
     }
 
     private suspend fun captureAndPersistScreenshot(activity: Activity): Uri? {
-        val bitmap = runCatching { captureWindow(activity) }.getOrNull() ?: return null
+        val bitmap = coRunCatching { captureWindow(activity) }.getOrNull() ?: return null
         return runCatching {
             val dir = File(activity.cacheDir, "bug-reports").apply { mkdirs() }
             // Wipe older screenshots — keep only the freshest one to avoid cache bloat.

--- a/app/src/main/kotlin/app/clothescast/discovery/NsdHomeAssistantDiscovery.kt
+++ b/app/src/main/kotlin/app/clothescast/discovery/NsdHomeAssistantDiscovery.kt
@@ -3,10 +3,12 @@ package app.clothescast.discovery
 import android.content.Context
 import android.net.nsd.NsdManager
 import android.net.nsd.NsdServiceInfo
+import android.os.Build
 import app.clothescast.diag.DiagLog
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
+import java.net.Inet4Address
 import java.net.Inet6Address
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.AtomicBoolean
@@ -189,7 +191,23 @@ internal class NsdHomeAssistantDiscovery(context: Context) : HomeAssistantDiscov
         }
 
         private fun hostStringOf(info: NsdServiceInfo): String? {
-            val address = info.host ?: return null
+            val candidates = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                info.hostAddresses
+            } else {
+                @Suppress("DEPRECATION") // Single-address `host` is the only pre-34 API.
+                listOfNotNull(info.host)
+            }
+            // Prefer an IPv4 address: services often advertise both A and AAAA
+            // records and Android's resolver can surface the IPv6 one first —
+            // frequently a link-local `fe80::…`, which is unroutable once the
+            // zone index below is stripped, so the prefilled host could never
+            // connect even though the broker is reachable over IPv4. Failing
+            // that, prefer a routable (non-link-local) IPv6 before falling
+            // back to whatever was reported.
+            val address = candidates.firstOrNull { it is Inet4Address }
+                ?: candidates.firstOrNull { !it.isLinkLocalAddress }
+                ?: candidates.firstOrNull()
+                ?: return null
             // Strip the IPv6 zone index (`fe80::1%wlan0`) — useless once written
             // back as a plain string and broker libraries reject it.
             val raw = address.hostAddress ?: return null

--- a/app/src/main/kotlin/app/clothescast/insight/ClothesPhraser.kt
+++ b/app/src/main/kotlin/app/clothescast/insight/ClothesPhraser.kt
@@ -80,9 +80,14 @@ internal class EnglishClothesPhraser(private val resources: Resources) : Clothes
         val lastIdx = translated.lastIndex
         val rendered = translated.mapIndexed { i, item ->
             val articleHere = when {
-                // Suppressed when the caller drops the leading article (wear
-                // preamble); the Oxford-comma trailing article still applies.
-                i == firstArticleIdx -> leadingArticle
+                // Suppressed only when the article is genuinely *leading* —
+                // i.e. the first item takes one, so dropping "Wear" leaves
+                // "A sweater and jacket" → "Sweater and jacket". A first
+                // article-taking item further down the list ("shorts and a
+                // t-shirt") isn't adjacent to the removed preamble and keeps
+                // its article; the Oxford-comma trailing article likewise
+                // still applies.
+                i == firstArticleIdx -> leadingArticle || i > 0
                 translated.size >= 3 && i == lastIdx && takesArticle(item) -> true
                 else -> false
             }

--- a/app/src/main/kotlin/app/clothescast/ui/nav/ClothesCastNavHost.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/nav/ClothesCastNavHost.kt
@@ -160,6 +160,7 @@ fun ClothesCastNavHost(
         composable<PairingRoute> {
             val pairing: PairingViewModel = viewModel(
                 factory = PairingViewModel.Factory(
+                    appContext = app,
                     secureKeyStore = app.secureKeyStore,
                     settingsRepository = app.settingsRepository,
                 ),

--- a/app/src/main/kotlin/app/clothescast/ui/pairing/PairingViewModel.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/pairing/PairingViewModel.kt
@@ -1,5 +1,6 @@
 package app.clothescast.ui.pairing
 
+import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.Color
 import android.util.Log
@@ -7,6 +8,7 @@ import androidx.core.graphics.createBitmap
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
+import app.clothescast.cast.LanAddress
 import app.clothescast.core.domain.model.TtsEngine
 import app.clothescast.data.SecureKeyStore
 import app.clothescast.data.SettingsRepository
@@ -19,8 +21,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
-import java.net.Inet4Address
-import java.net.NetworkInterface
 
 /** How long the pairing server stays open before it times out. */
 private const val PAIRING_TIMEOUT_MS = 5 * 60 * 1_000L
@@ -46,7 +46,9 @@ sealed interface PairingState {
  * Drives the phone-pairing screen.
  *
  * On creation it:
- *   1. Discovers the device's LAN IPv4 address.
+ *   1. Discovers the device's LAN IPv4 address via [LanAddress] — the
+ *      active network's site-local address, never a VPN / cellular /
+ *      loopback interface the phone's browser couldn't reach.
  *   2. Starts [PairingServer] on a random local port.
  *   3. Generates a QR code encoding `http://<ip>:<port>/pair/<token>`.
  *   4. Exposes [state] so the UI can render the QR code or react to success / timeout.
@@ -54,6 +56,7 @@ sealed interface PairingState {
  * The server is stopped and cleaned up in [onCleared] or when [retry] restarts it.
  */
 class PairingViewModel(
+    private val appContext: Context,
     private val secureKeyStore: SecureKeyStore,
     private val settingsRepository: SettingsRepository,
 ) : ViewModel() {
@@ -75,8 +78,9 @@ class PairingViewModel(
 
     private fun startPairing() {
         viewModelScope.launch {
-            val ip = getLocalIpAddress()
+            val ip = LanAddress.resolve(appContext)
             if (ip == null) {
+                Log.w(TAG, "No LAN-routable IPv4 on the active network; cannot pair.")
                 _state.value = PairingState.Error
                 return@launch
             }
@@ -126,6 +130,7 @@ class PairingViewModel(
     }
 
     class Factory(
+        private val appContext: Context,
         private val secureKeyStore: SecureKeyStore,
         private val settingsRepository: SettingsRepository,
     ) : ViewModelProvider.Factory {
@@ -134,7 +139,7 @@ class PairingViewModel(
             require(modelClass.isAssignableFrom(PairingViewModel::class.java)) {
                 "Unknown ViewModel: ${modelClass.name}"
             }
-            return PairingViewModel(secureKeyStore, settingsRepository) as T
+            return PairingViewModel(appContext, secureKeyStore, settingsRepository) as T
         }
     }
 
@@ -142,13 +147,6 @@ class PairingViewModel(
         private const val TAG = "PairingViewModel"
     }
 }
-
-private fun getLocalIpAddress(): String? =
-    NetworkInterface.getNetworkInterfaces()
-        ?.asSequence()
-        ?.flatMap { it.inetAddresses.asSequence() }
-        ?.firstOrNull { !it.isLoopbackAddress && it is Inet4Address }
-        ?.hostAddress
 
 private fun generateQrBitmap(content: String): Bitmap {
     val bits = QRCodeWriter().encode(content, BarcodeFormat.QR_CODE, QR_SIZE_PX, QR_SIZE_PX)

--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
@@ -2529,8 +2529,10 @@ internal fun InsightCard(
     // Page 2 caches tomorrow's daytime insight after the evening worker run;
     // surface it as "Tomorrow" rather than "Today" so the heading matches the
     // prose lead-in below. The ongoing overnight (post-midnight tail) is flagged
-    // on the insight itself — "Overnight", not "Tonight".
-    val isFutureDay = insight.forDate.isAfter(LocalDate.now())
+    // on the insight itself — "Overnight", not "Tonight". Compared in the
+    // forecast location's zone — `forDate` is that zone's date, so a device
+    // in a different timezone would otherwise mislabel the current day.
+    val isFutureDay = insight.forDate.isAfter(LocalDate.now(insight.forecastZone ?: ZoneId.systemDefault()))
     val periodLabel = stringResource(
         when (insight.period) {
             ForecastPeriod.TODAY ->

--- a/app/src/main/kotlin/app/clothescast/widget/FeelsLikeWidget.kt
+++ b/app/src/main/kotlin/app/clothescast/widget/FeelsLikeWidget.kt
@@ -252,8 +252,9 @@ private suspend fun buildChartBitmap(context: Context, id: GlanceId, weekly: Boo
 
 // Derives the off-screen bitmap size from the widget's actual cell, so the chart
 // scales with the space the user gave it. The launcher reports the cell extent
-// (in dp) via the AppWidget options bundle: for the visible orientation that's
-// MAX width × MIN height — the other pair describes the *rotated* extent. We
+// (in dp) via the AppWidget options bundle: the portrait cell is MIN width ×
+// MAX height and the landscape cell is MAX width × MIN height (the AppWidget
+// contract — portrait launchers are taller and narrower). We
 // render at the cell's own aspect (clamped to
 // [MIN_ASPECT_RATIO]..[MAX_ASPECT_RATIO]) so ContentScale.Fit fills the cell on
 // a wide placement instead of leaving side gaps, while keeping the chart
@@ -271,12 +272,12 @@ private fun chartRenderSizePx(context: Context, id: GlanceId): Pair<Int, Int> {
 
     val portrait = context.resources.configuration.orientation == Configuration.ORIENTATION_PORTRAIT
     val widthDp = options.getInt(
-        if (portrait) AppWidgetManager.OPTION_APPWIDGET_MAX_WIDTH
-        else AppWidgetManager.OPTION_APPWIDGET_MIN_WIDTH,
+        if (portrait) AppWidgetManager.OPTION_APPWIDGET_MIN_WIDTH
+        else AppWidgetManager.OPTION_APPWIDGET_MAX_WIDTH,
     )
     val heightDp = options.getInt(
-        if (portrait) AppWidgetManager.OPTION_APPWIDGET_MIN_HEIGHT
-        else AppWidgetManager.OPTION_APPWIDGET_MAX_HEIGHT,
+        if (portrait) AppWidgetManager.OPTION_APPWIDGET_MAX_HEIGHT
+        else AppWidgetManager.OPTION_APPWIDGET_MIN_HEIGHT,
     )
     if (widthDp <= 0 || heightDp <= 0) return fallback
 

--- a/app/src/test/kotlin/app/clothescast/alarm/AlarmReceiverErrorHandlingTest.kt
+++ b/app/src/test/kotlin/app/clothescast/alarm/AlarmReceiverErrorHandlingTest.kt
@@ -40,8 +40,12 @@ import java.util.concurrent.TimeUnit
  *  - on TODAY the best-effort fallback inside the catch still enqueues the
  *    worker so the morning insight runs even when prefs blew up (the whole
  *    reason the fallback exists);
- *  - on TONIGHT the receiver bails silently — no fallback enqueue, per the
- *    "only the morning slot gets the fallback" comment in [AlarmReceiver].
+ *  - on TONIGHT no fallback worker is enqueued, per the "only the morning
+ *    slot gets the fallback" comment in [AlarmReceiver];
+ *  - on BOTH slots the catch re-arms the alarm (with the slot's default
+ *    schedule, since prefs never materialized) — the chain is
+ *    self-perpetuating, so a transient failure that skipped the re-arm would
+ *    silently end every future delivery until the next app open / reboot.
  */
 @RunWith(AndroidJUnit4::class)
 @Config(sdk = [33])
@@ -85,9 +89,13 @@ class AlarmReceiverErrorHandlingTest {
         waitForAlarms(2)
         alarmManager.cancel(DailyAlarmScheduler.pendingIntent(context, ForecastPeriod.TODAY))
         alarmManager.cancel(DailyAlarmScheduler.pendingIntent(context, ForecastPeriod.TONIGHT))
-        // The startup pass also enqueues no worker, so the WorkManager queue is
-        // empty here — assertions on the unique-work lists start from a clean
-        // slate without needing an explicit cancel.
+        // WorkManager's instance is a process-wide static that survives
+        // Robolectric's per-test application reset, so unique work enqueued by
+        // an earlier test in this class leaks into the next one (JUnit 4's
+        // hash-based method order decides which runs first). Cancel it so the
+        // non-finished-work assertions below start from a clean slate in
+        // either order.
+        workManager.cancelUniqueWork(FetchAndNotifyWorker.UNIQUE_WORK_NAME).result.get()
 
         collectLatch = CountDownLatch(1)
         originalDelegate = swapRepository(throwingRepository(collectLatch))
@@ -101,7 +109,7 @@ class AlarmReceiverErrorHandlingTest {
     }
 
     @Test
-    fun `TODAY fire falls back to worker enqueue when preferences read fails`() {
+    fun `TODAY fire falls back to worker enqueue and re-arm when preferences read fails`() {
         AlarmReceiver().onReceive(
             context,
             Intent(AlarmReceiver.ACTION_FIRE).setPackage(context.packageName),
@@ -113,26 +121,29 @@ class AlarmReceiverErrorHandlingTest {
         collectLatch.shouldHaveTickedDown()
         val infos = waitForWork(FetchAndNotifyWorker.UNIQUE_WORK_NAME, expected = 1)
         infos shouldHaveAtLeastSize 1
+        // The catch also keeps the self-perpetuating chain alive by re-arming
+        // with the slot's default schedule.
+        waitForAlarms(1)
+        shadowOf(alarmManager).scheduledAlarms shouldHaveAtLeastSize 1
     }
 
     @Test
-    fun `TONIGHT fire does not enqueue a worker when preferences read fails`() {
+    fun `TONIGHT fire re-arms the alarm but enqueues no worker when preferences read fails`() {
         AlarmReceiver().onReceive(
             context,
             Intent(AlarmReceiver.ACTION_FIRE_TONIGHT).setPackage(context.packageName),
         )
 
         collectLatch.shouldHaveTickedDown()
-        // Give the goAsync coroutine time to walk out of the catch and finish.
-        // The catch for TONIGHT does nothing observable, so we can't poll for a
-        // positive signal — wait a beat, then assert nothing was enqueued.
-        Thread.sleep(500)
-        workManager.getWorkInfosForUniqueWork(FetchAndNotifyWorker.UNIQUE_WORK_NAME)
-            .get()
-            .shouldBeEmpty()
-        // The alarm was also never re-armed (scheduler.schedule lives inside
-        // the failing try block), so the alarm slot stays clear too.
-        shadowOf(alarmManager).scheduledAlarms.shouldBeEmpty()
+        // The catch's last observable act is the fallback re-arm; once the
+        // alarm lands, the coroutine has walked past the (TODAY-only) worker
+        // fallback, so the queue's emptiness is a settled fact, not a race.
+        waitForAlarms(1)
+        shadowOf(alarmManager).scheduledAlarms shouldHaveAtLeastSize 1
+        // Non-finished only: the @Before cancel leaves earlier tests' leaked
+        // work in CANCELLED state, which still shows up in the unique-work
+        // list. Only a live enqueue from *this* fire would appear here.
+        activeWork(FetchAndNotifyWorker.UNIQUE_WORK_NAME).shouldBeEmpty()
     }
 
     private fun throwingRepository(latch: CountDownLatch): SettingsRepository {
@@ -185,10 +196,15 @@ class AlarmReceiverErrorHandlingTest {
     private fun waitForWork(workName: String, expected: Int): List<WorkInfo> {
         val deadline = System.currentTimeMillis() + 5_000
         while (System.currentTimeMillis() < deadline) {
-            val infos = workManager.getWorkInfosForUniqueWork(workName).get()
+            val infos = activeWork(workName)
             if (infos.size >= expected) return infos
             Thread.sleep(25)
         }
-        return workManager.getWorkInfosForUniqueWork(workName).get()
+        return activeWork(workName)
     }
+
+    // The unique-work list filtered to live entries — CANCELLED leftovers from
+    // the @Before cleanup (or a REPLACE) don't count as an enqueue.
+    private fun activeWork(workName: String): List<WorkInfo> =
+        workManager.getWorkInfosForUniqueWork(workName).get().filterNot { it.state.isFinished }
 }

--- a/app/src/test/kotlin/app/clothescast/insight/InsightFormatterTest.kt
+++ b/app/src/test/kotlin/app/clothescast/insight/InsightFormatterTest.kt
@@ -239,6 +239,30 @@ class InsightFormatterTest {
     }
 
     @Test
+    fun `wear preamble Never keeps a mid-list article after a plural first item`() {
+        // Only the *leading* article sits next to the dropped "Wear", so a
+        // first article-taking item deeper in the list keeps its article:
+        // "Wear shorts and a t-shirt." → "Shorts and a t-shirt.", never the
+        // ungrammatical "Shorts and t-shirt."
+        val wearNever =
+            InsightFormatter.forContext(context, Locale.ENGLISH, wearPreamble = PreambleVisibility.NEVER)
+        wearNever.format(summary(clothes = ClothesClause(listOf("shorts", "t-shirt")))) shouldBe
+            "Today, it will be 21°. Shorts and a t-shirt."
+    }
+
+    @Test
+    fun `wear preamble Never keeps the trailing Oxford article after a plural first item`() {
+        // The Oxford-last article never abuts the dropped preamble, so it
+        // survives even when it belongs to the list's first article-taking
+        // item: "Wear shorts, gloves, and a scarf." → "Shorts, gloves, and a
+        // scarf."
+        val wearNever =
+            InsightFormatter.forContext(context, Locale.ENGLISH, wearPreamble = PreambleVisibility.NEVER)
+        wearNever.format(summary(clothes = ClothesClause(listOf("shorts", "gloves", "scarf")))) shouldBe
+            "Today, it will be 21°. Shorts, gloves, and a scarf."
+    }
+
+    @Test
     fun `wear preamble Speech-only drops Wear on the visual surface`() {
         val wearSpeechOnly =
             InsightFormatter.forContext(context, Locale.ENGLISH, wearPreamble = PreambleVisibility.SPEECH_ONLY)

--- a/core/data/src/main/kotlin/app/clothescast/core/data/tts/GeminiTtsClient.kt
+++ b/core/data/src/main/kotlin/app/clothescast/core/data/tts/GeminiTtsClient.kt
@@ -244,11 +244,28 @@ internal fun directiveFor(style: TtsStyle, locale: Locale?): String {
  * is acceptable.
  */
 internal fun geminiLanguageDirectiveFor(locale: Locale): String? {
+    val language = modernLanguageCode(locale.language)
     val country = locale.country
     if (country.isNotEmpty()) {
-        LANGUAGE_DIRECTIVES["${locale.language}-$country"]?.let { return it }
+        LANGUAGE_DIRECTIVES["$language-$country"]?.let { return it }
     }
-    return LANGUAGE_DIRECTIVES[locale.language]
+    return LANGUAGE_DIRECTIVES[language]
+}
+
+/**
+ * On Android, [Locale.getLanguage] returns the *legacy* ISO-639 codes for a
+ * handful of languages ("iw" for Hebrew, "in" for Indonesian, "ji" for
+ * Yiddish) — even when the locale was built from a modern BCP-47 tag like
+ * "he-IL". (JVMs since JDK 17 default to the modern codes, so unit tests
+ * can't reproduce the device behavior — hence this string-level seam.) The
+ * directive tables key on the modern codes, so normalize before lookup or
+ * Hebrew/Indonesian voices silently lose their language steering.
+ */
+internal fun modernLanguageCode(language: String): String = when (language) {
+    "iw" -> "he"
+    "in" -> "id"
+    "ji" -> "yi"
+    else -> language
 }
 
 private val LANGUAGE_DIRECTIVES: Map<String, String> = mapOf(
@@ -326,11 +343,12 @@ private val LANGUAGE_DIRECTIVES: Map<String, String> = mapOf(
  * [ACCENT_DIRECTIVES].
  */
 internal fun geminiAccentDirectiveFor(locale: Locale): String? {
+    val language = modernLanguageCode(locale.language)
     val country = locale.country
     if (country.isNotEmpty()) {
-        ACCENT_DIRECTIVES["${locale.language}-$country"]?.let { return it }
+        ACCENT_DIRECTIVES["$language-$country"]?.let { return it }
     }
-    return ACCENT_DIRECTIVES[locale.language]
+    return ACCENT_DIRECTIVES[language]
 }
 
 // Each entry names the language and (where meaningful) a regional variety.

--- a/core/data/src/main/kotlin/app/clothescast/core/data/weather/MultiModelConfidenceFetcher.kt
+++ b/core/data/src/main/kotlin/app/clothescast/core/data/weather/MultiModelConfidenceFetcher.kt
@@ -238,9 +238,10 @@ internal class MultiModelConfidenceFetcher(
 
     private fun computeConfidence(daily: JsonObject, models: List<String>): ConfidenceInfo? {
         val todayIndex = todayDailyIndex(daily)
+        val soleModel = models.size == 1
         val results = buildList {
             for (model in models) {
-                when (val outcome = readModelDaily(daily, model, todayIndex)) {
+                when (val outcome = readModelDaily(daily, model, todayIndex, soleModel)) {
                     is ReadOutcome.Usable -> add(model to outcome.values)
                     is ReadOutcome.Dropped ->
                         logger.log("model $model dropped: ${outcome.reason}")
@@ -260,25 +261,30 @@ internal class MultiModelConfidenceFetcher(
     private fun parseHourly(hourly: JsonObject?, models: List<String>): PerModelHourly? {
         val obj = hourly ?: return null
         val times = (obj["time"] as? JsonArray) ?: return null
+        // Open-Meteo only suffixes variables with the model id when two or
+        // more models are requested; a single-entry `models=` list comes back
+        // with plain names (`temperature_2m`, not `temperature_2m_<model>`).
+        // See [seriesFor].
+        val soleModel = models.size == 1
         val byModel = buildMap<String, List<PerModelHour>> {
             for (model in models) {
-                val apparentTemps = obj["apparent_temperature_$model"] as? JsonArray
-                val airTemps = obj["temperature_2m_$model"] as? JsonArray
-                val precips = obj["precipitation_probability_$model"] as? JsonArray
-                val precipMm = obj["precipitation_$model"] as? JsonArray
-                val winds = obj["wind_speed_10m_$model"] as? JsonArray
-                val humidities = obj["relative_humidity_2m_$model"] as? JsonArray
+                val apparentTemps = seriesFor(obj, "apparent_temperature", model, soleModel)
+                val airTemps = seriesFor(obj, "temperature_2m", model, soleModel)
+                val precips = seriesFor(obj, "precipitation_probability", model, soleModel)
+                val precipMm = seriesFor(obj, "precipitation", model, soleModel)
+                val winds = seriesFor(obj, "wind_speed_10m", model, soleModel)
+                val humidities = seriesFor(obj, "relative_humidity_2m", model, soleModel)
                 // We request cloud_cover_low but keep the domain field named
                 // `cloudCoverPct` — the value is still a percent, just for the
                 // low deck. See [PerModelHour.cloudCoverPct] for the rationale.
-                val clouds = obj["cloud_cover_low_$model"] as? JsonArray
-                val solar = obj["shortwave_radiation_$model"] as? JsonArray
-                val sunshine = obj["sunshine_duration_$model"] as? JsonArray
+                val clouds = seriesFor(obj, "cloud_cover_low", model, soleModel)
+                val solar = seriesFor(obj, "shortwave_radiation", model, soleModel)
+                val sunshine = seriesFor(obj, "sunshine_duration", model, soleModel)
                 // UV index per-model: Open-Meteo exposes `uv_index_$model` on
                 // most models. When a particular model omits it the field is
                 // simply absent for that model and the UV card hides its line.
-                val uv = obj["uv_index_$model"] as? JsonArray
-                val weatherCodes = obj["weather_code_$model"] as? JsonArray
+                val uv = seriesFor(obj, "uv_index", model, soleModel)
+                val weatherCodes = seriesFor(obj, "weather_code", model, soleModel)
                 // Hard requirement: temperature_2m. Without it the chart has
                 // nothing to plot for this model and the consensus blend
                 // can't average it in. Open-Meteo silently omits per-model
@@ -400,14 +406,38 @@ internal class MultiModelConfidenceFetcher(
         return if (times.size >= 2) 1 else 0
     }
 
-    private fun readModelDaily(daily: JsonObject, model: String, todayIndex: Int): ReadOutcome {
-        val tempMax = numberAt(daily["apparent_temperature_max_$model"] as? JsonArray, todayIndex)?.toDouble()
+    /**
+     * The per-model series for [field], honoring Open-Meteo's suffix rule:
+     * with two or more `models=` entries every variable is suffixed with the
+     * model id (`temperature_2m_gfs_seamless`), but a single-model request
+     * comes back with plain, unsuffixed names. Without the fallback a
+     * one-model fetch — reachable when the picker's selection filters down
+     * to a single Open-Meteo id, or when the invalid-model prune-and-retry
+     * leaves one survivor — parses to nothing and silently drops the whole
+     * per-model feature.
+     */
+    private fun seriesFor(
+        obj: JsonObject,
+        field: String,
+        model: String,
+        soleModel: Boolean,
+    ): JsonArray? =
+        (obj["${field}_$model"] as? JsonArray)
+            ?: if (soleModel) obj[field] as? JsonArray else null
+
+    private fun readModelDaily(
+        daily: JsonObject,
+        model: String,
+        todayIndex: Int,
+        soleModel: Boolean,
+    ): ReadOutcome {
+        val tempMax = numberAt(seriesFor(daily, "apparent_temperature_max", model, soleModel), todayIndex)?.toDouble()
         // Soft field: the daily low feeds the low-disagreement half of the
         // temp spread, but a model that reports a high without a low still
         // contributes its high. When missing it simply drops out of the
         // low-spread calculation (see [compute]) rather than dropping the
         // whole model.
-        val tempMin = numberAt(daily["apparent_temperature_min_$model"] as? JsonArray, todayIndex)?.toDouble()
+        val tempMin = numberAt(seriesFor(daily, "apparent_temperature_min", model, soleModel), todayIndex)?.toDouble()
         // Soft field: Open-Meteo omits daily precipitation_probability_max for
         // several models (verified 2026-06-09 against the live API — among
         // DEFAULT_MODELS, ecmwf_aifs025_single returns null at all three of
@@ -420,7 +450,7 @@ internal class MultiModelConfidenceFetcher(
         // path's soft precip handling and the daily-low handling above.
         // apparent_temperature_max stays the only hard requirement: without it
         // the model has no temperature vote to cast.
-        val precipMax = numberAt(daily["precipitation_probability_max_$model"] as? JsonArray, todayIndex)?.toDouble()
+        val precipMax = numberAt(seriesFor(daily, "precipitation_probability_max", model, soleModel), todayIndex)?.toDouble()
         if (precipMax == null) {
             logger.log("model $model daily: precipitation_probability_max missing, precip-spread will skip this model")
         }

--- a/core/data/src/test/kotlin/app/clothescast/core/data/tts/GeminiTtsClientTest.kt
+++ b/core/data/src/test/kotlin/app/clothescast/core/data/tts/GeminiTtsClientTest.kt
@@ -754,6 +754,29 @@ class GeminiTtsClientTest {
         shouldThrow<GeminiTtsEmptyResponseException> { client.synthesize(text = "hi") }
     }
 
+    @Test
+    fun `legacy ISO-639 language codes map to the directive tables' modern keys`() {
+        // Android's Locale.getLanguage() reports "iw" / "in" / "ji" for
+        // Hebrew / Indonesian / Yiddish — even for a locale built from the
+        // modern tag "he-IL" — while JVMs since JDK 17 report the modern
+        // codes, so this can only be covered at the string seam. Without the
+        // normalization, the on-device lookup misses the "he" / "id" entries
+        // and Hebrew / Indonesian voices lose their language steering.
+        modernLanguageCode("iw") shouldBe "he"
+        modernLanguageCode("in") shouldBe "id"
+        modernLanguageCode("ji") shouldBe "yi"
+        modernLanguageCode("he") shouldBe "he"
+        modernLanguageCode("en") shouldBe "en"
+    }
+
+    @Test
+    fun `Hebrew and Indonesian voice locales resolve their directives`() {
+        geminiAccentDirectiveFor(Locale.forLanguageTag("he-IL")) shouldBe
+            "קרא/י את הטקסט הבא בעברית."
+        geminiLanguageDirectiveFor(Locale.forLanguageTag("he-IL")) shouldBe "Speak in Hebrew."
+        geminiLanguageDirectiveFor(Locale.forLanguageTag("id-ID")) shouldBe "Speak in Indonesian."
+    }
+
     private companion object {
         // 0xDE 0xAD 0xBE 0xEF base64-encoded.
         const val SUCCESS_BODY = """

--- a/core/data/src/test/kotlin/app/clothescast/core/data/weather/MultiModelConfidenceFetcherTest.kt
+++ b/core/data/src/test/kotlin/app/clothescast/core/data/weather/MultiModelConfidenceFetcherTest.kt
@@ -248,6 +248,41 @@ class MultiModelConfidenceFetcherTest {
     }
 
     @Test
+    fun `single-model request parses Open-Meteo's unsuffixed response`() = runTest {
+        // Open-Meteo only suffixes variables with the model id when two or
+        // more models are requested; a lone `models=` entry answers with
+        // plain names (`temperature_2m`, `apparent_temperature_max`). This is
+        // reachable via the Forecasters picker (a selection whose only other
+        // entry is Google, which isn't an Open-Meteo id) and via the
+        // invalid-model prune-and-retry leaving one survivor — in both cases
+        // the suffixed-only parser silently dropped the entire per-model
+        // feature even though the server returned usable data.
+        val data = fetcherWith(SINGLE_MODEL_UNSUFFIXED).fetch(london, listOf("ecmwf_ifs025"))
+            .shouldNotBeNull()
+
+        // One model can't measure cross-model spread, so no confidence…
+        data.confidence.shouldBeNull()
+        // …but its hourly series still feeds the charts and the blend.
+        val hourly = data.hourly.shouldNotBeNull()
+        val ecmwf = hourly.byModel.getValue("ecmwf_ifs025")
+        ecmwf.size shouldBe 2
+        ecmwf[0].time shouldBe LocalDateTime.parse("2026-05-12T00:00")
+        ecmwf[0].apparentTemperatureC shouldBe (12.0 plusOrMinus 0.0001)
+        ecmwf[0].temperatureC shouldBe (14.0 plusOrMinus 0.0001)
+        ecmwf[0].precipitationProbabilityPct shouldBe (10.0 plusOrMinus 0.0001)
+    }
+
+    @Test
+    fun `multi-model request ignores unsuffixed fields rather than misattributing them`() = runTest {
+        // The unsuffixed fallback is scoped to single-model requests: a
+        // two-model response only ever carries suffixed series, and a stray
+        // unsuffixed field must not be parsed as belonging to every model.
+        fetcherWith(SINGLE_MODEL_UNSUFFIXED)
+            .fetch(london, listOf("ecmwf_ifs025", "gfs_seamless"))
+            .shouldBeNull()
+    }
+
+    @Test
     fun `diagnostic fields stay null when the response omits them`() = runTest {
         // Backwards-compat: the temp / precip overlay still works on responses
         // that don't include wind / humidity / cloud (legacy fixtures, or a
@@ -602,6 +637,26 @@ class MultiModelConfidenceFetcherTest {
                 "precipitation_probability_max_ecmwf_ifs025": [10],
                 "precipitation_probability_max_gfs_seamless": [15],
                 "precipitation_probability_max_icon_seamless": [20]
+              }
+            }
+        """.trimIndent()
+
+        // The suffix-free shape Open-Meteo returns for a single-entry
+        // `models=` list (verified against the live API): every daily and
+        // hourly variable appears under its plain name, no model suffix.
+        private val SINGLE_MODEL_UNSUFFIXED = """
+            {
+              "daily": {
+                "time": ["2026-05-12"],
+                "apparent_temperature_max": [21.0],
+                "apparent_temperature_min": [12.0],
+                "precipitation_probability_max": [10]
+              },
+              "hourly": {
+                "time": ["2026-05-12T00:00", "2026-05-12T01:00"],
+                "apparent_temperature": [12.0, 11.5],
+                "temperature_2m": [14.0, 13.5],
+                "precipitation_probability": [10, 15]
               }
             }
         """.trimIndent()

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/DeriveInsight.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/DeriveInsight.kt
@@ -491,7 +491,11 @@ class DeriveInsight(
  * `tomorrowHourly` fields drop to empty — we don't have day-after-tomorrow
  * data, so a hypothetical tonight-period generation off the shifted bundle
  * would lose its overnight wrap; that's why the public `dayOffset=1` path is
- * gated to TODAY-period only.
+ * gated to TODAY-period only. [ForecastBundle.upcomingDays] leads with the
+ * promoted day (it duplicates `tomorrow` at index 0), so the shift drops it —
+ * otherwise the derived insight's `upcomingDays[0]` would equal its own
+ * `forDate`, violating that field's "days after" contract and double-plotting
+ * the day on any week series built as `currentDay + upcomingDays`.
  */
 internal fun ForecastBundle.shiftedToTomorrow(): ForecastBundle? {
     val tmrw = tomorrow ?: return null
@@ -500,6 +504,7 @@ internal fun ForecastBundle.shiftedToTomorrow(): ForecastBundle? {
         yesterday = today,
         tomorrow = null,
         tomorrowHourly = emptyList(),
+        upcomingDays = upcomingDays.dropWhile { !it.date.isAfter(tmrw.date) },
     )
 }
 

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsightTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsightTest.kt
@@ -489,6 +489,34 @@ class GenerateDailyInsightTest {
     }
 
     @Test
+    fun `tomorrow pre-render (dayOffset 1) keeps upcomingDays after the promoted day`() = runTest {
+        // The evening worker's "next" pre-render shifts the bundle so tomorrow
+        // becomes today. upcomingDays duplicates tomorrow at index 0 (the
+        // bundle's convention), so the shift must drop it — otherwise the
+        // derived insight's upcomingDays[0] equals its own forDate, violating
+        // Insight.upcomingDays' "days after forDate" contract and
+        // double-plotting the day on any week series built as
+        // currentDay + upcomingDays.
+        val tomorrowDay = today.copy(date = today.date.plusDays(1))
+        val dayAfter = today.copy(date = today.date.plusDays(2))
+        val weather = FakeWeatherRepository(
+            ForecastBundle(
+                today = today,
+                yesterday = yesterday,
+                tomorrow = tomorrowDay,
+                upcomingDays = listOf(tomorrowDay, dayAfter),
+            ),
+        )
+        val subject = GenerateDailyInsight(weather, clock = clock)
+
+        val result = subject(london, prefs, ForecastPeriod.TODAY, dayOffset = 1).insight
+
+        result.forDate shouldBe tomorrowDay.date
+        result.currentDay?.date shouldBe tomorrowDay.date
+        result.upcomingDays.map { it.date } shouldContainExactly listOf(dayAfter.date)
+    }
+
+    @Test
     fun `the coming night (TONIGHT, not overnight) is dated today`() = runTest {
         val weather = FakeWeatherRepository(
             ForecastBundle(


### PR DESCRIPTION
## Scope

A systematic bug hunt across all three modules (`:core:domain`, `:core:data`, `:app`), one commit per fix so each lands as its own changelog bullet. Every finding was traced through the code with a concrete failure scenario before fixing; the highest-severity one was verified against the live Open-Meteo API.

### Fixes

1. **Single-forecaster responses parsed to nothing** (`MultiModelConfidenceFetcher`) — Open-Meteo only suffixes variables with the model id when ≥2 models are requested. A one-model request (reachable via a {Google, one-other} Forecasters selection, or the invalid-model prune-and-retry leaving one survivor) silently dropped every per-model chart line and the model's consensus vote. Verified against the live API.
2. **Hebrew/Indonesian TTS lost language steering** (`GeminiTtsClient`) — Android's `Locale.getLanguage()` returns legacy codes (`iw`, `in`); the directive tables key on modern codes. JDK 17+ returns modern codes, so JVM tests couldn't catch it.
3. **Wear-preamble-off dropped the wrong article** (`ClothesPhraser`) — "Shorts and t-shirt." instead of "Shorts and a t-shirt."; also killed the protected Oxford-last article.
4. **Multi-day all-day calendar events vanished after day one** (`CalendarContractEventReader`) — all-day rows were dated solely by their begin instant, so the east-of-UTC bleed filter discarded days 2+.
5. **"Today"/"Tomorrow" mislabeled across time zones** (`TodayScreen`, `CastTestDispatch`) — compared forecast-zone `forDate` against device-zone `now()`.
6. **Widget charts rendered at the rotated cell's aspect** (`FeelsLikeWidget`) — the AppWidget options orientation pairs were read backwards (portrait is minWidth × maxHeight).
7. **One transient error killed the alarm chain forever** (`AlarmReceiver`) — the error path never re-armed (and the tonight slot got nothing); also added `ACTION_TIME_SET` to `ScheduleRefreshReceiver` so clock corrections recompute the RTC fire time, and removed a dead null-check log. `AlarmReceiverErrorHandlingTest` is updated to the new contract: on a failed prefs read both slots re-arm (with the slot's default schedule) and the worker fallback stays TODAY-only.
8. **Pairing QR / device-scan addresses could be unreachable** (`PairingViewModel`, `NsdHomeAssistantDiscovery`) — pairing now uses `LanAddress.resolve` (site-local IPv4 on the active network) instead of the first non-loopback IPv4 of any interface; mDNS results prefer IPv4 over a link-local AAAA whose zone strip made it unroutable.
9. **Pre-rendered tomorrow insight duplicated its own day in `upcomingDays`** (`DeriveInsight.shiftedToTomorrow`) — latent contract violation; the shift now drops the promoted day.
10. **Cancellation swallowed by stdlib `runCatching` around suspends** (`HolidayThemeResolver`, `BugReport`) — swapped to the repo's `coRunCatching` so cancelled scopes unwind instead of publishing stale/gutted results.
11. **Removed the dead `CastInsightController.cast()` entry point** — uncalled, and if ever called it would `load()` off the main thread and rethrow into an unsupervised scope (process crash on any TTS/network failure).

### Verified but not fixed (intentionally left for follow-up)

- `ScheduledDeliveryService.teardown` has a milliseconds-wide TOCTOU against `onStartCommand`'s shepherd swap (could strip the FGS from an overlapping run). Real but rare; fixing it properly needs an atomicity rework.
- `CastMediaServer` / `PairingServer` pick a free port by probe-then-bind (TOCTOU); binding port 0 in Ktor and reading the resolved connector would close it.
- `EmbeddedServer.stop(0, 500)` runs on the main thread on session end / screen close (≤500 ms jank).
- `castWithPreparedMedia` reports a null `remoteMediaClient` as "route not found" (misdiagnosis in the status row).
- `ConsensusBlend` keeps best_match's raw `precipitationMm` on covered hours but averages models on synthesized hours (hour-to-hour inconsistency; the justifying comment is stale).

## Privacy

Commit 2 adds the static language-directive sentence to Hebrew/Indonesian Gemini TTS prompts (other locales already send it). Fixed prompt text only — no change to what user data leaves the device.

## Test plan

- `:core:domain:test` + `:core:data:test` pass locally (747 tests, 0 failures) including new regression tests for the single-model parse, the legacy-locale mapping, and the `shiftedToTomorrow` contract.
- New `InsightFormatterTest` cases cover both bare-article scenarios; `AlarmReceiverErrorHandlingTest` updated to assert the error-path re-arm (the first CI run caught it asserting the old drop-the-chain behavior).
- `:app:testDebugUnitTest` / `:app:assembleDebug` could **not** run in this sandbox: the network policy denies the Gradle 9.4.1 distribution download (GitHub releases and `downloads.gradle.org` both refuse CONNECT; only Gradle 8.14.3 is installed, and AGP 9.2.1 requires ≥9.4.1). Google Maven itself is reachable — the gap is the Gradle distribution host, worth adding to the sandbox allowlist. CI is the validation surface for the `:app` module on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014sBeUUKTGQA9H7v8VhhpVY