### PR TITLE
Fix the bug hunt's five remaining findings

### DIFF
--- a/app/src/main/kotlin/app/clothescast/alarm/ScheduledDeliveryService.kt
+++ b/app/src/main/kotlin/app/clothescast/alarm/ScheduledDeliveryService.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import java.util.UUID
 
@@ -211,17 +212,27 @@ class ScheduledDeliveryService : Service() {
      * guard, the stale watcher would `stopForeground(REMOVE)` on the
      * *new* run's notification and leave its scheduled TTS without the
      * FGS it relies on.
+     *
+     * The check and the stop it guards run as one main-thread block: the
+     * shepherd swap in [onStartCommand] also runs on main, so the two can't
+     * interleave — a guard evaluated on `Dispatchers.Default` could pass and
+     * *then* lose the CPU to a swap, letting the stale watcher strip the new
+     * run's FGS anyway (the check-then-act gap the guard alone left open).
+     * A watcher cancelled by the swap before this block is dispatched never
+     * runs it at all — `withContext` aborts on the cancelled job.
      */
-    private fun teardown(workId: UUID) {
-        if (foregroundWorkId == workId) {
-            stopForeground(STOP_FOREGROUND_REMOVE)
-            foregroundWorkId = null
-            // Bare stopSelf (no startId) so any startIds the overlap-rejection
-            // branch left dangling don't keep the service alive past the
-            // shepherded run.
-            stopSelf()
-        } else {
-            DiagLog.i(TAG, "Skipping teardown for workId=$workId; current foregroundWorkId=$foregroundWorkId")
+    private suspend fun teardown(workId: UUID) {
+        withContext(Dispatchers.Main.immediate) {
+            if (foregroundWorkId == workId) {
+                stopForeground(STOP_FOREGROUND_REMOVE)
+                foregroundWorkId = null
+                // Bare stopSelf (no startId) so any startIds the overlap-rejection
+                // branch left dangling don't keep the service alive past the
+                // shepherded run.
+                stopSelf()
+            } else {
+                DiagLog.i(TAG, "Skipping teardown for workId=$workId; current foregroundWorkId=$foregroundWorkId")
+            }
         }
     }
 

--- a/app/src/main/kotlin/app/clothescast/cast/CastInsightController.kt
+++ b/app/src/main/kotlin/app/clothescast/cast/CastInsightController.kt
@@ -322,16 +322,32 @@ class CastInsightController(
             // thread on network I/O.
             val resolved = withContext(Dispatchers.Main.immediate) {
                 val route = findRoute(routeId, discoveryTimeoutMs)
-                    ?: return@withContext null
+                    ?: return@withContext RouteResolution.NotFound
                 val session = ensureSession(route, sessionTimeoutMs)
-                val client = session.remoteMediaClient ?: return@withContext null
-                ResolvedRoute(client, classifyRoute(route))
+                val client = session.remoteMediaClient
+                    ?: return@withContext RouteResolution.NoRemoteMediaClient
+                RouteResolution.Ready(ResolvedRoute(client, classifyRoute(route)))
             }
-            if (resolved == null) {
-                DiagLog.w(TAG, "Cast route $routeId not discovered within ${discoveryTimeoutMs}ms; skipping cast.")
-                return CastWorkerOutcome.SkippedNoRoute
+            val ready = when (resolved) {
+                RouteResolution.NotFound -> {
+                    DiagLog.w(TAG, "Cast route $routeId not discovered within ${discoveryTimeoutMs}ms; skipping cast.")
+                    return CastWorkerOutcome.SkippedNoRoute
+                }
+                // Distinct from NotFound: the session *started* — the device
+                // was reachable and is now sitting on the receiver splash —
+                // but exposed no RemoteMediaClient to load into. Reporting
+                // it as SkippedNoRoute pointed the Settings status row at
+                // the network when the problem is the playback layer
+                // (matches castToSavedRoute's NoRemoteMediaClient failure).
+                RouteResolution.NoRemoteMediaClient -> {
+                    DiagLog.w(TAG, "Cast route $routeId session started but exposed no RemoteMediaClient.")
+                    return CastWorkerOutcome.Failed(
+                        CastFailure.NoRemoteMediaClient.message ?: "Smart device did not accept playback",
+                    )
+                }
+                is RouteResolution.Ready -> resolved.route
             }
-            val client = resolved.client
+            val client = ready.client
             val host = resolveLanIp(context)
                 ?: run {
                     DiagLog.w(TAG, "No LAN IPv4 on the phone; cannot host cast media.")
@@ -341,7 +357,7 @@ class CastInsightController(
             // origin + bytes so a bug report can correlate the worker's
             // publish with later route-handler entries without leaking
             // the secret that gates the buffer.
-            val request = when (mediaPlanFor(resolved.deviceClass, hasRealAudio = hasRealAudio)) {
+            val request = when (mediaPlanFor(ready.deviceClass, hasRealAudio = hasRealAudio)) {
                 CastMediaPlan.SkipNoAudio -> {
                     // Audio-only device with no spoken forecast: a silent
                     // track would just be dead air on a speaker. Skip the
@@ -754,4 +770,17 @@ class CastInsightController(
         val client: RemoteMediaClient,
         val deviceClass: CastDeviceClass,
     )
+
+    /**
+     * Outcome of the main-thread route/session/client resolution in
+     * [castWithPreparedMedia]. Two distinct failure shapes so the caller
+     * can report "device not reachable" (route never discovered) apart
+     * from "device reachable but playback unavailable" (session started,
+     * no [RemoteMediaClient]).
+     */
+    private sealed interface RouteResolution {
+        data object NotFound : RouteResolution
+        data object NoRemoteMediaClient : RouteResolution
+        data class Ready(val route: ResolvedRoute) : RouteResolution
+    }
 }

--- a/app/src/main/kotlin/app/clothescast/cast/CastMediaServer.kt
+++ b/app/src/main/kotlin/app/clothescast/cast/CastMediaServer.kt
@@ -1,5 +1,6 @@
 package app.clothescast.cast
 
+import app.clothescast.diag.DiagLog
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.call
@@ -11,8 +12,8 @@ import io.ktor.server.response.respondBytes
 import io.ktor.server.routing.get
 import io.ktor.server.routing.routing
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeoutOrNull
-import java.net.ServerSocket
 import java.security.SecureRandom
 import kotlin.concurrent.thread
 
@@ -157,7 +158,10 @@ class CastMediaServer {
         // server on a fresh port without waiting for this one.
         if (srv != null) {
             thread(name = "CastMediaServer.stop", isDaemon = true) {
-                srv.stop(gracePeriodMillis = 0, timeoutMillis = 500)
+                // An uncaught throw on a bare thread kills the process on
+                // Android; a failed engine shutdown isn't worth that.
+                runCatching { srv.stop(gracePeriodMillis = 0, timeoutMillis = 500) }
+                    .onFailure { DiagLog.w(TAG, "Cast media server engine shutdown failed", it) }
             }
         }
     }
@@ -167,8 +171,7 @@ class CastMediaServer {
     internal fun port(): Int = port
 
     private fun start() {
-        port = ServerSocket(0).use { it.localPort }
-        val srv = embeddedServer(CIO, port = port) {
+        val srv = embeddedServer(CIO, port = 0) {
             routing {
                 // Wildcard filename so the same route serves whichever
                 // suffix the active [CastMediaKind] minted (insight.mp4 /
@@ -195,6 +198,14 @@ class CastMediaServer {
             }
         }
         srv.start(wait = false)
+        // Bind port 0 and read the kernel-assigned port back, rather than
+        // probing a free port with a throwaway ServerSocket and re-binding
+        // it — any other socket on the device could claim the probed port
+        // in that window and fail the publish. resolvedConnectors suspends
+        // until the engine is actually bound; [publish] is documented
+        // off-main (see Threading above), so the brief blocking wait here
+        // replaces the equally blocking probe bind it removes.
+        port = runBlocking { srv.engine.resolvedConnectors().first().port }
         server = srv
     }
 
@@ -217,6 +228,8 @@ class CastMediaServer {
     data class MediaUrl(val url: String)
 
     companion object {
+        private const val TAG = "CastMediaServer"
+
         // 128 bits of entropy in the URL path. Enough that scanning the
         // open ephemeral port for the buffer is computationally hopeless
         // even on a fast LAN; same order as a UUID4.

--- a/app/src/main/kotlin/app/clothescast/cast/CastMediaServer.kt
+++ b/app/src/main/kotlin/app/clothescast/cast/CastMediaServer.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.withTimeoutOrNull
 import java.net.ServerSocket
 import java.security.SecureRandom
+import kotlin.concurrent.thread
 
 /**
  * Tiny HTTP server that exposes one media buffer to a Cast receiver on
@@ -139,7 +140,7 @@ class CastMediaServer {
     /** Stops the server, if running, and clears the buffered media + the path token. */
     @Synchronized
     fun stop() {
-        server?.stop(gracePeriodMillis = 0, timeoutMillis = 500)
+        val srv = server
         server = null
         buffer = null
         pathToken = ""
@@ -147,6 +148,18 @@ class CastMediaServer {
         // Drop the reference so any in-flight [awaitFetch] times out
         // rather than waiting forever after the session ends.
         fetched = null
+        // Engine shutdown blocks the calling thread for up to its timeout,
+        // and stop() arrives on the main thread (the Cast session listener's
+        // onSessionEnded) — a 500 ms stall there is dropped frames right as
+        // the user disconnects. Hand the engine to a background thread; the
+        // token and buffer are already cleared above, so a request slipping
+        // in while it winds down 404s, and a re-publish starts a fresh
+        // server on a fresh port without waiting for this one.
+        if (srv != null) {
+            thread(name = "CastMediaServer.stop", isDaemon = true) {
+                srv.stop(gracePeriodMillis = 0, timeoutMillis = 500)
+            }
+        }
     }
 
     /** Currently-bound port, or 0 if the server isn't running. Test hook. */

--- a/app/src/main/kotlin/app/clothescast/pairing/PairingServer.kt
+++ b/app/src/main/kotlin/app/clothescast/pairing/PairingServer.kt
@@ -1,5 +1,6 @@
 package app.clothescast.pairing
 
+import android.util.Log
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.call
@@ -12,7 +13,8 @@ import io.ktor.server.response.respondText
 import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import io.ktor.server.routing.routing
-import java.net.ServerSocket
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import java.security.SecureRandom
 import kotlin.concurrent.thread
 
@@ -56,10 +58,14 @@ class PairingServer(
     /**
      * Starts the HTTP server on an available local port and returns that port.
      * Must be called at most once. The server runs until [stop] is called.
+     *
+     * Suspends until the engine is bound: the port comes from binding port 0
+     * and reading the kernel's assignment back (no probe-then-rebind race),
+     * and the bind itself runs off the caller's thread — the pairing
+     * ViewModel calls this from the main dispatcher.
      */
-    fun start(): Int {
-        val port = findFreePort()
-        val srv = embeddedServer(CIO, port = port) {
+    suspend fun start(): Int {
+        val srv = embeddedServer(CIO, port = 0) {
             routing {
                 get("/pair/$token") {
                     if (!active) {
@@ -103,9 +109,19 @@ class PairingServer(
                 }
             }
         }
-        srv.start(wait = false)
+        // Register the engine before the first suspension point, and shut it
+        // down on any failure *or cancellation* below — the pairing screen
+        // can be dismissed while the caller is still suspended in here, and
+        // an engine that started but was never handed back would keep the
+        // LAN pairing endpoint (and its token) alive with no remaining owner.
         server = srv
-        return port
+        try {
+            withContext(Dispatchers.IO) { srv.start(wait = false) }
+            return srv.engine.resolvedConnectors().first().port
+        } catch (t: Throwable) {
+            stop()
+            throw t
+        }
     }
 
     /** Stops the server. Safe to call even if [start] was never called or already stopped. */
@@ -123,7 +139,11 @@ class PairingServer(
         // thread; the [active] gate above already closed the routes.
         if (srv != null) {
             thread(name = "PairingServer.stop", isDaemon = true) {
-                srv.stop(gracePeriodMillis = 0, timeoutMillis = 500)
+                // An uncaught throw on a bare thread kills the process on
+                // Android; a failed engine shutdown isn't worth that — log
+                // and let the daemon thread die.
+                runCatching { srv.stop(gracePeriodMillis = 0, timeoutMillis = 500) }
+                    .onFailure { Log.w(TAG, "Pairing server engine shutdown failed", it) }
             }
         }
     }
@@ -176,13 +196,12 @@ class PairingServer(
 </html>"""
 
     companion object {
+        private const val TAG = "PairingServer"
+
         private fun generateToken(): String {
             val bytes = ByteArray(6)
             SecureRandom().nextBytes(bytes)
             return bytes.joinToString("") { "%02x".format(it) }
         }
-
-        private fun findFreePort(): Int =
-            ServerSocket(0).use { it.localPort }
     }
 }

--- a/app/src/main/kotlin/app/clothescast/pairing/PairingServer.kt
+++ b/app/src/main/kotlin/app/clothescast/pairing/PairingServer.kt
@@ -1,17 +1,20 @@
 package app.clothescast.pairing
 
 import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.call
 import io.ktor.server.cio.CIO
 import io.ktor.server.engine.EmbeddedServer
 import io.ktor.server.engine.embeddedServer
 import io.ktor.server.request.receiveParameters
+import io.ktor.server.response.respond
 import io.ktor.server.response.respondText
 import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import io.ktor.server.routing.routing
 import java.net.ServerSocket
 import java.security.SecureRandom
+import kotlin.concurrent.thread
 
 /**
  * Minimal HTTP server that brokers the phone→TV API key transfer.
@@ -42,6 +45,14 @@ class PairingServer(
 
     private var server: EmbeddedServer<*, *>? = null
 
+    // Revoked synchronously by [stop], before the engine wind-down is handed
+    // to its background thread. The routes authorize on `token && active`
+    // rather than the token alone, so a submission landing in the wind-down
+    // window — or after a failed engine shutdown left the socket open —
+    // can't invoke [onKeyReceived] once pairing has been closed.
+    @Volatile
+    private var active = true
+
     /**
      * Starts the HTTP server on an available local port and returns that port.
      * Must be called at most once. The server runs until [stop] is called.
@@ -51,9 +62,17 @@ class PairingServer(
         val srv = embeddedServer(CIO, port = port) {
             routing {
                 get("/pair/$token") {
+                    if (!active) {
+                        call.respond(HttpStatusCode.NotFound)
+                        return@get
+                    }
                     call.respondText(htmlForm(), ContentType.Text.Html)
                 }
                 post("/pair/$token") {
+                    if (!active) {
+                        call.respond(HttpStatusCode.NotFound)
+                        return@post
+                    }
                     val params = call.receiveParameters()
                     val key = params["gemini_key"]?.trim()
                     if (key.isNullOrEmpty()) {
@@ -62,10 +81,25 @@ class PairingServer(
                     }
                     // Serialize concurrent POSTs so callback invocations don't
                     // interleave; last submission wins (see the class doc).
-                    synchronized(this@PairingServer) {
-                        onKeyReceived(key)
+                    // Re-check [active] under the lock: a stop() landing after
+                    // the gate above (while receiveParameters was suspended)
+                    // must not have its revocation overtaken by an in-flight
+                    // submission — and when the revocation wins, answer 404
+                    // like the gate does, not a success page claiming a key
+                    // that was deliberately never stored was "sent".
+                    val accepted = synchronized(this@PairingServer) {
+                        if (active) {
+                            onKeyReceived(key)
+                            true
+                        } else {
+                            false
+                        }
                     }
-                    call.respondText(htmlSuccess(), ContentType.Text.Html)
+                    if (accepted) {
+                        call.respondText(htmlSuccess(), ContentType.Text.Html)
+                    } else {
+                        call.respond(HttpStatusCode.NotFound)
+                    }
                 }
             }
         }
@@ -76,8 +110,22 @@ class PairingServer(
 
     /** Stops the server. Safe to call even if [start] was never called or already stopped. */
     fun stop() {
-        server?.stop(gracePeriodMillis = 0, timeoutMillis = 500)
+        // Revoke the token gate first, so no submission arriving after this
+        // point can reach [onKeyReceived] — regardless of how long the
+        // engine's asynchronous wind-down below takes (or whether it fails).
+        active = false
+        val srv = server
         server = null
+        // Engine shutdown blocks the calling thread for up to its timeout,
+        // and stop() arrives on the main thread (the pairing ViewModel's
+        // onCleared / timeout path) — a 500 ms stall there is visible jank
+        // as the user leaves the screen. Hand the engine to a background
+        // thread; the [active] gate above already closed the routes.
+        if (srv != null) {
+            thread(name = "PairingServer.stop", isDaemon = true) {
+                srv.stop(gracePeriodMillis = 0, timeoutMillis = 500)
+            }
+        }
     }
 
     private fun htmlForm(error: Boolean = false): String = buildString {

--- a/app/src/main/kotlin/app/clothescast/ui/pairing/PairingViewModel.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/pairing/PairingViewModel.kt
@@ -15,6 +15,7 @@ import app.clothescast.data.SettingsRepository
 import app.clothescast.pairing.PairingServer
 import com.google.zxing.BarcodeFormat
 import com.google.zxing.qrcode.QRCodeWriter
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -65,6 +66,7 @@ class PairingViewModel(
     val state: StateFlow<PairingState> = _state.asStateFlow()
 
     private var server: PairingServer? = null
+    private var startJob: Job? = null
     private var timeoutJob: Job? = null
 
     init {
@@ -77,7 +79,13 @@ class PairingViewModel(
     }
 
     private fun startPairing() {
-        viewModelScope.launch {
+        // Tracked so [stopServer] can cancel a start still suspended in
+        // srv.start(): at that point [server] is unassigned, so without the
+        // job cancel a retry would race the pending launch — the old
+        // coroutine could resume later, publish a stale QR and timeout job,
+        // and leave one of the two servers running with a live token.
+        // PairingServer.start cleans its own engine up on cancellation.
+        startJob = viewModelScope.launch {
             val ip = LanAddress.resolve(appContext)
             if (ip == null) {
                 Log.w(TAG, "No LAN-routable IPv4 on the active network; cannot pair.")
@@ -96,6 +104,12 @@ class PairingViewModel(
             }
             val port = try {
                 srv.start()
+            } catch (ce: CancellationException) {
+                // start() suspends now, so the screen being dismissed can
+                // cancel us mid-bind — the server cleans itself up on that
+                // path; swallowing the cancellation here would keep this
+                // dead coroutine running. Rethrow, don't report Error.
+                throw ce
             } catch (e: Exception) {
                 Log.e(TAG, "PairingServer failed to start", e)
                 _state.value = PairingState.Error
@@ -118,6 +132,11 @@ class PairingViewModel(
     }
 
     private fun stopServer() {
+        // No-op when called from within the (completed) start coroutine's
+        // own timeout path; load-bearing when retry / onCleared arrive while
+        // the start is still suspended and [server] is unassigned.
+        startJob?.cancel()
+        startJob = null
         timeoutJob?.cancel()
         timeoutJob = null
         server?.stop()

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/ConsensusBlend.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/ConsensusBlend.kt
@@ -4,8 +4,8 @@ package app.clothescast.core.domain.model
  * Blends per-hour values from the consulted models — including Open-Meteo's
  * `best_match` overlay — into a single [HourlyForecast] series, replacing
  * the corresponding [bestMatch] entry with the arithmetic mean across
- * models. Covers temperature, feels-like, precipitation probability, wind
- * speed, UV index, and the weather condition. Used to drive the chart's
+ * models. Covers temperature, feels-like, precipitation probability, rain
+ * amount, wind speed, UV index, and the weather condition. Used to drive the chart's
  * "Combined" main line and — crucially — the clothes-rule + insight-prose
  * pipeline and the conditions strip, so on days when best_match diverges
  * from the consulted ECMWF / GFS / ICON consensus (the rain case the user
@@ -95,10 +95,20 @@ fun blendConsensusHourly(
             val blendedWind = if (windCandidates.isEmpty()) hour.windSpeedKmh else windCandidates.average()
             val uvCandidates = candidates.mapNotNull { it.uvIndex }
             val blendedUv = if (uvCandidates.isEmpty()) hour.uvIndex else uvCandidates.average()
+            // Rain amount blends like the rest: skip models that didn't
+            // report it, fall back to best_match when none did. Keeping
+            // best_match's raw mm here while the synthesized path below
+            // averages the models produced a series whose hour-to-hour shape
+            // reflected best_match's *coverage*, not the weather — 0 mm on a
+            // covered hour next to 2 mm on a synthesized one when the models
+            // agreed on 2 mm all along.
+            val mmCandidates = candidates.mapNotNull { it.precipitationMm }
+            val blendedMm = if (mmCandidates.isEmpty()) hour.precipitationMm else mmCandidates.average()
             hour.copy(
                 temperatureC = candidates.map { it.temperatureC }.average(),
                 feelsLikeC = candidates.map { it.apparentTemperatureC }.average(),
                 precipitationProbabilityPct = blendedPrecip,
+                precipitationMm = blendedMm,
                 windSpeedKmh = blendedWind,
                 uvIndex = blendedUv,
                 condition = consensusCondition(
@@ -205,6 +215,11 @@ fun DailyForecast.withAggregatesFrom(blendedHourly: List<HourlyForecast>): Daily
         feelsLikeMaxC = blendedHourly.maxOf { it.feelsLikeC },
         precipitationProbabilityMaxPct = blendedHourly
             .maxOfOrNull { it.precipitationProbabilityPct } ?: precipitationProbabilityMaxPct,
+        // Sum of the blended per-hour amounts, so the daily total agrees with
+        // the hourly series the chart draws (both now carry the cross-model
+        // mean; previously this stayed best_match's total while the hourly
+        // series blended, and the two could tell different stories).
+        precipitationMmTotal = blendedHourly.sumOf { it.precipitationMm },
         // Take the condition from the peak-precip hour of the blended series
         // (mirroring DailyForecast.slicedForToday), so a day the consensus
         // turns wet carries a precipitating daily condition. Without this the
@@ -217,7 +232,5 @@ fun DailyForecast.withAggregatesFrom(blendedHourly: List<HourlyForecast>): Daily
             ?.condition
             ?.takeIf { it != WeatherCondition.UNKNOWN }
             ?: condition,
-        // precipitationMmTotal stays from best_match — the per-model fetcher
-        // doesn't carry a hourly mm series, only probability percent.
     )
 }

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/model/ConsensusBlendTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/model/ConsensusBlendTest.kt
@@ -21,6 +21,7 @@ class ConsensusBlendTest {
         temp: Double,
         feels: Double = temp - 1.0,
         precip: Double = 0.0,
+        mm: Double = 0.0,
         wind: Double? = null,
         uv: Double? = null,
         condition: WeatherCondition = WeatherCondition.CLEAR,
@@ -29,6 +30,7 @@ class ConsensusBlendTest {
         temperatureC = temp,
         feelsLikeC = feels,
         precipitationProbabilityPct = precip,
+        precipitationMm = mm,
         windSpeedKmh = wind,
         uvIndex = uv,
         condition = condition,
@@ -39,6 +41,7 @@ class ConsensusBlendTest {
         apparent: Double,
         air: Double,
         precip: Double? = 0.0,
+        mm: Double? = null,
         wind: Double? = null,
         uv: Double? = null,
         condition: WeatherCondition? = null,
@@ -48,6 +51,7 @@ class ConsensusBlendTest {
         apparentTemperatureC = apparent,
         temperatureC = air,
         precipitationProbabilityPct = precip,
+        precipitationMm = mm,
         windSpeedKmh = wind,
         uvIndex = uv,
         condition = condition,
@@ -248,6 +252,44 @@ class ConsensusBlendTest {
     }
 
     @Test
+    fun `rain amount blends on hours best-match covers, like the synthesized path`() {
+        // best_match says 0 mm at noon while the consulted models agree on
+        // 2 mm. Keeping best_match's raw amount on covered hours (while
+        // synthesized hours average the models) made the series' shape
+        // reflect best_match's coverage, not the weather — the blend must
+        // treat both paths the same.
+        val best = listOf(hour(12, temp = 10.0, feels = 9.0, mm = 0.0))
+        val perModel = PerModelHourly(
+            byModel = mapOf(
+                "gfs_seamless" to listOf(perModel(12, apparent = 11.0, air = 12.0, mm = 2.0)),
+                "icon_seamless" to listOf(perModel(12, apparent = 13.0, air = 14.0, mm = 2.0)),
+            ),
+        )
+
+        val blended = blendConsensusHourly(today, best, perModel).shouldNotBeNull()
+
+        blended[0].precipitationMm shouldBe (2.0 plusOrMinus 0.0001)
+    }
+
+    @Test
+    fun `rain amount falls back to best-match when no candidate reported it`() {
+        // Models reported the hour but neither carried an mm series (Open-
+        // Meteo omits it for some models) — keep best_match's own amount
+        // rather than zeroing a wet hour.
+        val best = listOf(hour(12, temp = 10.0, feels = 9.0, mm = 1.5))
+        val perModel = PerModelHourly(
+            byModel = mapOf(
+                "gfs_seamless" to listOf(perModel(12, apparent = 11.0, air = 12.0, mm = null)),
+                "icon_seamless" to listOf(perModel(12, apparent = 13.0, air = 14.0, mm = null)),
+            ),
+        )
+
+        val blended = blendConsensusHourly(today, best, perModel).shouldNotBeNull()
+
+        blended[0].precipitationMm shouldBe (1.5 plusOrMinus 0.0001)
+    }
+
+    @Test
     fun `wind and uv are averaged across the candidates that reported them`() {
         // A model whose per-model entry carries null wind / UV (older cached
         // payloads; model runs that omit the field) sits the hour out — here
@@ -414,9 +456,9 @@ class ConsensusBlendTest {
             condition = WeatherCondition.CLEAR,
         )
         val blended = listOf(
-            hour(12, temp = 12.0, feels = 10.0, precip = 80.0),
-            hour(15, temp = 14.0, feels = 12.0, precip = 90.0),
-            hour(18, temp = 10.0, feels = 8.0, precip = 60.0),
+            hour(12, temp = 12.0, feels = 10.0, precip = 80.0, mm = 0.2),
+            hour(15, temp = 14.0, feels = 12.0, precip = 90.0, mm = 0.5),
+            hour(18, temp = 10.0, feels = 8.0, precip = 60.0, mm = 0.2),
         )
 
         val out = daily.withAggregatesFrom(blended)
@@ -429,9 +471,10 @@ class ConsensusBlendTest {
         // umbrella rule keys off this, so without recomputation the chart
         // would show "100% rain" while the umbrella stayed unrecommended.
         out.precipitationProbabilityMaxPct shouldBe (90.0 plusOrMinus 0.0001)
-        // Precip mm stays from best_match (no consensus available). Condition is
-        // recomputed from the peak-precip hour, which is CLEAR here too.
-        out.precipitationMmTotal shouldBe daily.precipitationMmTotal
+        // The daily rain total is the sum of the blended per-hour amounts,
+        // keeping it in step with the hourly series the chart draws.
+        // Condition is recomputed from the peak-precip hour, CLEAR here too.
+        out.precipitationMmTotal shouldBe (0.9 plusOrMinus 0.0001)
         out.condition shouldBe WeatherCondition.CLEAR
     }
 


### PR DESCRIPTION
## Scope

Follow-up to #1089: fixes the five findings that PR listed under "verified but not fixed", one commit per fix.

1. **Consensus rain amounts** (`ConsensusBlend`) — hours best_match covered kept its raw `precipitationMm` while hours it missed got the cross-model mean, so the "Combined" series could sawtooth along coverage boundaries (0 mm → 2 mm when the models agreed on 2 mm all along). Covered hours now blend mm with the same skip-nulls / fall-back rules as probability, wind, and UV, and `withAggregatesFrom` recomputes the daily rain total as the sum of the blended hours (its "no hourly mm series" comment had been stale since the per-model precipitation series landed). New `ConsensusBlendTest` cases cover both paths.
2. **Main-thread jank on server shutdown** (`CastMediaServer`, `PairingServer`) — both `stop()`s ran Ktor's blocking `stop(0, 500)` on the main thread (Cast `onSessionEnded`; pairing `onCleared`/timeout), freezing the UI up to half a second. Engine shutdown now happens on a short-lived background thread; caller-visible state clears synchronously — the cast server drops its buffer and path token, and (per Codex review) the pairing server revokes an `active` gate its routes check alongside the token, so no key submission can land after `stop()` however long the wind-down takes or even if it fails, and a submission that loses the revocation race gets a 404 rather than a false success page. Both shutdown threads swallow-and-log so a failed engine stop can't kill the process from a bare thread.
3. **Port grab-and-rebind race** (`CastMediaServer`, `PairingServer`) — both probed a free port with a throwaway `ServerSocket` and re-bound it in Ktor, a window where any other socket could steal the port and fail the publish/pairing. Ktor now binds port 0 and the kernel-assigned port is read back from the resolved connector. `PairingServer.start` becomes suspend with the bind on `Dispatchers.IO` (its caller is on the main dispatcher). Per Codex review: the server registers itself before the first suspension point and shuts down on failure or cancellation, the ViewModel rethrows `CancellationException`, and the ViewModel tracks the start coroutine so retry / screen-exit arriving mid-bind cancels the pending start instead of racing it.
4. **Cast misdiagnosis** (`CastInsightController.castWithPreparedMedia`) — a session that started but exposed no `RemoteMediaClient` was reported as `SkippedNoRoute` ("Smart device not reachable"), pointing the Settings status row at the network when the device was reachable and the playback layer was the problem. Now reports the same "did not accept playback" failure the "Cast now" path uses.
5. **Teardown TOCTOU** (`ScheduledDeliveryService`) — the owner-id guard ran on a background dispatcher while `onStartCommand`'s shepherd swap runs on main, so a stale watcher could pass the check, lose the CPU to a swap, and strip the new run's FGS anyway (silencing its TTS on Android 15+, which needs the mediaPlayback FGS for audio focus). The check-and-stop now runs as one main-thread block, serialized against the swap.

## Privacy

No change to what leaves the device.

## Test plan

- `:core:domain:test` + `:core:data:test` pass locally, including new `ConsensusBlendTest` cases for blended rain amounts (covered-hour blend, no-candidate fallback, summed daily total).
- The `ScheduledDeliveryServiceTest` suite is dispatch-only (never drives teardown) and `CastMediaServerTest` asserts field state, not socket closure, so the async-stop and main-thread-teardown changes don't disturb them.
- `:app` tests can't run in this sandbox (Gradle 9.4.1 distribution download is blocked by the network policy — same gap as #1089); CI validates the app module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014sBeUUKTGQA9H7v8VhhpVY