### PR TITLE
Home button jumps to the current period from other pages

### DIFF
--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
@@ -44,6 +44,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Settings
@@ -230,6 +231,25 @@ fun TodayScreen(
             TopAppBar(
                 title = { Text(stringResource(titleRes)) },
                 actions = {
+                    // On any period page past the current window (Tomorrow, Next
+                    // 7 days, Following 7 days) offer a one-tap jump back to page
+                    // 0 — the stepwise left chevron / system back only walk back a
+                    // single page at a time. Hidden on page 0, where there's
+                    // nowhere to go home to.
+                    if (pagerState.currentPage != 0) {
+                        IconButton(
+                            onClick = {
+                                coroutineScope.launch {
+                                    pagerState.animateScrollToPage(0)
+                                }
+                            },
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.Home,
+                                contentDescription = stringResource(R.string.today_go_home),
+                            )
+                        }
+                    }
                     // While anything's active on the alarm or replay queues we
                     // disable Refresh and (during the fetch phase) swap the icon
                     // for a spinner. The work makes a billed Gemini insight call

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,6 +12,7 @@
 
     <string name="today_title">Today</string>
     <string name="today_open_settings">Open Settings</string>
+    <string name="today_go_home">Go to current period</string>
     <string name="today_more_options">More options</string>
     <string name="today_report_a_bug">Report a bug</string>
     <string name="today_refresh">Refresh</string>


### PR DESCRIPTION
## What

Adds a **Home** action to the Today app bar that appears on any period page past the current window (Tomorrow / Next 7 days / Following 7 days) and jumps the pager straight back to page 0 (the current period).

- Rendered as the **leftmost of the right-aligned action icons** — before Refresh — in `TodayScreen`'s `TopAppBar`, using `Icons.Default.Home`.
- Hidden on page 0 (`pagerState.currentPage != 0`), where there's nowhere to go home to — mirroring the enable condition on the existing `BackHandler`.
- On tap it `coroutineScope.launch { pagerState.animateScrollToPage(0) }`, the same pattern the `BackHandler` and on-screen chevrons already use. Unlike the left chevron / system back (which step back one page at a time), this is a single jump to the current period.

## Why

The only way back to the current period was the stepwise left chevron / system back — one page per tap. From Following 7 days that's three taps. A dedicated Home control makes it one.

## Changes

- `app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt` — new `Home` import; Home `IconButton` as the first app-bar action, gated on `currentPage != 0`.
- `app/src/main/res/values/strings.xml` — new `today_go_home` content-description string ("Go to current period"). Translations are handled by the separate localization process.

## Privacy

No change to what crosses the device boundary — pure in-app navigation.

## Test plan

- Local `:app:assembleDebug` could **not** be run in this sandbox: the Gradle 9.4.1 wrapper distribution download is blocked by egress policy (403 from github.com, where `services.gradle.org` redirects), so the outer Android build can't bootstrap here. Relying on CI (`JVM unit tests` + `Android debug build`) for `:app` validation.
- Manual verification to do on device: on Today (page 0) the Home icon is absent; swipe to Tomorrow / Next 7 days / Following 7 days and confirm Home appears leftmost of the right-aligned icons and returns to page 0 in one tap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01A9RxX5krsFMGm9qNH4Du8C)_