### PR TITLE
Fix seventeen bugs found in a full-codebase bug hunt

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -609,6 +609,12 @@ dependencies {
     // Cast media-hosting endpoint (the receiver fetches PNG + WAV from a
     // tiny LAN server on the phone — Cast doesn't accept sender-pushed bytes).
     implementation(libs.ktor.server.cio)
+    // Range-request (206) and HEAD support for the Cast media server —
+    // Cast receivers probe MP4s with Range GETs (the MediaMuxer moov atom
+    // sits after mdat, so players seek to the tail before the first frame)
+    // and Google's media-server requirements mandate range support.
+    implementation(libs.ktor.server.partial.content)
+    implementation(libs.ktor.server.auto.head.response)
 
     // Google Cast — adds the route discovery / session APIs (via
     // androidx.mediarouter) and RemoteMediaClient. Initialised lazily in

--- a/app/src/main/kotlin/app/clothescast/cast/CastInsightController.kt
+++ b/app/src/main/kotlin/app/clothescast/cast/CastInsightController.kt
@@ -152,7 +152,13 @@ class CastInsightController(
             CastMediaPlan.SkipNoAudio -> throw CastFailure.NoAudioForSpeaker
             CastMediaPlan.Wav -> {
                 val wav = WavEncoder.encode(pcm!!)
-                val urls = server.publish(host = host, media = wav, kind = CastMediaKind.WAV)
+                // This path enters from viewModelScope (Settings "Cast now"),
+                // i.e. on Main — publish binds a socket and blocks on the CIO
+                // engine start, so hop it off the UI thread (matching the
+                // Threading contract documented on [CastMediaServer]).
+                val urls = withContext(Dispatchers.IO) {
+                    server.publish(host = host, media = wav, kind = CastMediaKind.WAV)
+                }
                 DiagLog.i(
                     TAG,
                     "Cast test: hosting ${wav.size}B wav on http://$host:${server.port()}/<token>/insight.wav " +
@@ -170,7 +176,10 @@ class CastInsightController(
                     silentWavStub
                 }
                 val mp4 = withContext(Dispatchers.Default) { Mp4Encoder.encode(outfitPng, wav) }
-                val urls = server.publish(host = host, media = mp4, kind = CastMediaKind.MP4)
+                // Off-main for the socket bind — see the WAV branch above.
+                val urls = withContext(Dispatchers.IO) {
+                    server.publish(host = host, media = mp4, kind = CastMediaKind.MP4)
+                }
                 DiagLog.i(
                     TAG,
                     "Cast test: hosting ${mp4.size}B mp4 on http://$host:${server.port()}/<token>/insight.mp4 " +
@@ -713,7 +722,20 @@ class CastInsightController(
          */
         internal fun padWavToMinimumDuration(wav: ByteArray): ByteArray {
             val info = Mp4Encoder.WavInfo.parse(wav)
-            val minBytes = info.sampleRate * MIN_CAST_DURATION_SECONDS * 2 * info.channels
+            // WavEncoder writes a mono header unconditionally, so re-encoding
+            // a multi-channel payload here would relabel stereo as mono —
+            // half-speed playback with corrupted interleave. No producer
+            // sends stereo today (Gemini TTS is mono); if one ever does,
+            // skip the padding rather than corrupt the audio.
+            if (info.channels != 1) {
+                DiagLog.w(
+                    TAG,
+                    "Skipping minimum-duration pad for ${info.channels}-channel WAV; " +
+                        "WavEncoder only writes mono headers.",
+                )
+                return wav
+            }
+            val minBytes = info.sampleRate * MIN_CAST_DURATION_SECONDS * 2
             if (info.pcm.size >= minBytes) return wav
             val padded = ByteArray(minBytes)
             info.pcm.copyInto(padded)

--- a/app/src/main/kotlin/app/clothescast/cast/CastMediaServer.kt
+++ b/app/src/main/kotlin/app/clothescast/cast/CastMediaServer.kt
@@ -2,15 +2,20 @@ package app.clothescast.cast
 
 import app.clothescast.diag.DiagLog
 import io.ktor.http.ContentType
+import io.ktor.http.HttpMethod
 import io.ktor.http.HttpStatusCode
+import io.ktor.http.content.OutgoingContent
 import io.ktor.server.application.call
+import io.ktor.server.application.install
 import io.ktor.server.cio.CIO
 import io.ktor.server.engine.EmbeddedServer
 import io.ktor.server.engine.embeddedServer
+import io.ktor.server.plugins.autohead.AutoHeadResponse
+import io.ktor.server.plugins.partialcontent.PartialContent
 import io.ktor.server.response.respond
-import io.ktor.server.response.respondBytes
 import io.ktor.server.routing.get
 import io.ktor.server.routing.routing
+import io.ktor.utils.io.ByteReadChannel
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeoutOrNull
@@ -172,6 +177,16 @@ class CastMediaServer {
 
     private fun start() {
         val srv = embeddedServer(CIO, port = 0) {
+            // Cast receivers probe MP4s with Range GETs — MediaMuxer writes
+            // the moov atom after mdat (no faststart), so the player seeks
+            // to the file tail before the first frame. Without 206 support
+            // every probe gets the whole body from byte 0: buffering the
+            // full resource at best, a failed load on stricter receiver
+            // firmware at worst. PartialContent turns the channel-backed
+            // response below into a range-aware one; AutoHeadResponse
+            // answers the HEAD some players lead with (it 404'd before).
+            install(PartialContent)
+            install(AutoHeadResponse)
             routing {
                 // Wildcard filename so the same route serves whichever
                 // suffix the active [CastMediaKind] minted (insight.mp4 /
@@ -182,15 +197,32 @@ class CastMediaServer {
                     val buf = buffer
                     val incoming = call.parameters["token"]
                     // Capture the active buffer kind + fetch deferred at
-                    // match time rather than re-reading post-respondBytes —
+                    // match time rather than re-reading post-respond —
                     // a concurrent publish would otherwise serve the new
                     // content type or redirect the signal onto the new
                     // awaiter instead of the one whose URL was just served.
                     val capturedKind = kind
                     val capturedFetched = fetched
                     if (buf != null && tokenMatches(incoming)) {
-                        call.respondBytes(buf, capturedKind.contentType)
-                        capturedFetched?.complete(Unit)
+                        // ReadChannelContent, not respondBytes: PartialContent
+                        // only rewrites channel-backed content into 206s —
+                        // a plain ByteArrayContent bypasses it and every
+                        // Range probe would get the whole body as a 200.
+                        call.respond(MediaBufferContent(buf, capturedKind.contentType))
+                        // Only a real GET confirms the fetch: AutoHeadResponse
+                        // routes HEAD probes through this handler with the
+                        // body discarded, and a HEAD moves no media bytes —
+                        // completing the deferred on one would fake the
+                        // "bytes actually crossed the LAN" signal awaitFetch
+                        // exists to provide. (A Range GET still counts; bytes
+                        // flow on it.) Read the raw method off request.local:
+                        // AutoHeadResponse rewrites the origin method to GET
+                        // before the handler runs (that's how the get() route
+                        // matches at all), so request.httpMethod reads GET
+                        // even for a HEAD probe — verified against Ktor 3.5.
+                        if (call.request.local.method == HttpMethod.Get) {
+                            capturedFetched?.complete(Unit)
+                        }
                     } else {
                         call.respond(HttpStatusCode.NotFound)
                     }
@@ -226,6 +258,21 @@ class CastMediaServer {
     }
 
     data class MediaUrl(val url: String)
+
+    /**
+     * Channel-backed wrapper for the in-memory media buffer. Exists so
+     * [PartialContent] can slice it: the plugin only rewrites
+     * [OutgoingContent.ReadChannelContent] responses into 206s (its
+     * range-cut path goes through [readFrom]), so a `respondBytes`
+     * ByteArrayContent would silently opt the serve out of range support.
+     */
+    private class MediaBufferContent(
+        private val bytes: ByteArray,
+        override val contentType: ContentType,
+    ) : OutgoingContent.ReadChannelContent() {
+        override val contentLength: Long = bytes.size.toLong()
+        override fun readFrom(): ByteReadChannel = ByteReadChannel(bytes)
+    }
 
     companion object {
         private const val TAG = "CastMediaServer"

--- a/app/src/main/kotlin/app/clothescast/data/GoogleForecastCache.kt
+++ b/app/src/main/kotlin/app/clothescast/data/GoogleForecastCache.kt
@@ -106,28 +106,31 @@ class GoogleForecastCache(
     suspend fun put(location: Location, apiKeyFingerprint: Int?, hours: List<PerModelHour>) {
         if (hours.isEmpty()) return
         val key = keyOf(location)
-        val merged = mergeRetainingEarlierToday(key, apiKeyFingerprint, hours)
-        val entry = Entry(
-            latBucket = key.first,
-            lonBucket = key.second,
-            apiKeyFingerprint = apiKeyFingerprint,
-            fetchedAtMs = clock.instant().toEpochMilli(),
-            hours = merged.map { it.toDto() },
-        )
-        val encoded = try {
-            json.encodeToString(entry)
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: Exception) {
-            DiagLog.w(TAG, "Google forecast cache encode failed; not persisting", e)
-            return
-        }
         try {
-            dataStore.edit { it[ENTRY_KEY] = encoded }
+            // Read-merge-write inside one edit transaction (the same shape
+            // DailyHistoryStore.put uses): merging from a separate read lets
+            // two near-simultaneous puts (foreground walk + background
+            // refresh) both merge against the same prior entry and the
+            // second write silently drop the first's retained morning hours
+            // — exactly the front-truncation the merge exists to prevent.
+            dataStore.edit { prefs ->
+                val merged = mergeRetainingEarlierToday(prefs[ENTRY_KEY], key, apiKeyFingerprint, hours)
+                val entry = Entry(
+                    latBucket = key.first,
+                    lonBucket = key.second,
+                    apiKeyFingerprint = apiKeyFingerprint,
+                    fetchedAtMs = clock.instant().toEpochMilli(),
+                    hours = merged.map { it.toDto() },
+                )
+                prefs[ENTRY_KEY] = json.encodeToString(entry)
+            }
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
-            DiagLog.w(TAG, "Google forecast cache write failed", e)
+            // Covers both a serialization failure and a DataStore write
+            // failure; the caller already holds the series for this fetch,
+            // and the next foreground walk re-stamps it.
+            DiagLog.w(TAG, "Google forecast cache write failed; not persisting", e)
         }
     }
 
@@ -148,13 +151,14 @@ class GoogleForecastCache(
      * low is read from. The fresh series owns every hour from its first onward,
      * so nothing stale survives into the future.
      */
-    private suspend fun mergeRetainingEarlierToday(
+    private fun mergeRetainingEarlierToday(
+        priorRaw: String?,
         key: Pair<Long, Long>,
         apiKeyFingerprint: Int?,
         fresh: List<PerModelHour>,
     ): List<PerModelHour> {
         val newFirst = fresh.minByOrNull { it.time }?.time ?: return fresh
-        val prior = readRaw()?.let { decode(it) } ?: return fresh
+        val prior = priorRaw?.let { decode(it) } ?: return fresh
         // Only carry hours from an entry for the same location + key; a
         // different bucket or a swapped key is unrelated data.
         if (prior.apiKeyFingerprint != apiKeyFingerprint ||

--- a/app/src/main/kotlin/app/clothescast/data/SettingsRepository.kt
+++ b/app/src/main/kotlin/app/clothescast/data/SettingsRepository.kt
@@ -1584,8 +1584,9 @@ class SettingsRepository(
         // Master switch for scheduled casting + per-period cast toggles +
         // the "smart display speaks, mute the phone" suppression. Stored
         // separately from CAST_ROUTE_ID so the user's picked display
-        // survives an off / on flip; default true on first read
-        // (mirrors the data-class defaults).
+        // survives an off / on flip; absent key reads as OFF — casting is
+        // opt-in (see castEnabledOptInMigration, which preserved the old
+        // default-on only for installs that predate the flip).
         private val CAST_ENABLED = booleanPreferencesKey("cast_enabled")
         private val CAST_MORNING = booleanPreferencesKey("cast_morning")
         private val CAST_TONIGHT = booleanPreferencesKey("cast_tonight")

--- a/app/src/main/kotlin/app/clothescast/tts/AndroidTtsEngine.kt
+++ b/app/src/main/kotlin/app/clothescast/tts/AndroidTtsEngine.kt
@@ -38,26 +38,36 @@ internal suspend fun initAndroidTtsEngine(context: Context): TextToSpeech =
             initOneAttempt(context, null)
         }
 
-private suspend fun initOneAttempt(context: Context, enginePackage: String?): TextToSpeech =
+private suspend fun initOneAttempt(context: Context, enginePackage: String?): TextToSpeech {
+    // The listener resumes with Unit and the engine is returned from the
+    // local below, NOT captured in a var the listener dereferences: onInit
+    // arrives on the main thread while the constructor returns on this
+    // (worker) thread, and a plain captured var has no happens-before edge
+    // between that write and the callback's read — the listener could
+    // observe null and NPE inside a main-thread callback, crashing the
+    // process instead of failing one TTS attempt. Reading the local after
+    // the suspension is safe: the assignment happens in this coroutine
+    // before it suspends, and coroutine resumption establishes the edge.
+    lateinit var engine: TextToSpeech
     suspendCancellableCoroutine { cont ->
-        var engineRef: TextToSpeech? = null
         val listener = TextToSpeech.OnInitListener { status ->
             if (status == TextToSpeech.SUCCESS) {
-                cont.resume(engineRef!!)
+                cont.resume(Unit)
             } else {
                 cont.resumeWithException(
                     IllegalStateException("TTS engine init failed (status=$status)"),
                 )
             }
         }
-        val engine = if (enginePackage != null) {
+        engine = if (enginePackage != null) {
             TextToSpeech(context, listener, enginePackage)
         } else {
             TextToSpeech(context, listener)
         }
-        engineRef = engine
         cont.invokeOnCancellation { runCatching { engine.shutdown() } }
     }
+    return engine
+}
 
 /**
  * Auto-picks the highest-quality voice for [locale] from [voices], or `null`

--- a/app/src/main/kotlin/app/clothescast/tts/PcmAudioPlayer.kt
+++ b/app/src/main/kotlin/app/clothescast/tts/PcmAudioPlayer.kt
@@ -7,6 +7,7 @@ import app.clothescast.diag.DiagLog
 import app.clothescast.core.data.tts.PcmAudio
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withTimeoutOrNull
 import kotlin.coroutines.coroutineContext
 import kotlin.coroutines.resume
 
@@ -24,6 +25,12 @@ import kotlin.coroutines.resume
 internal object PcmAudioPlayer {
 
     private const val TAG = "PcmAudioPlayer"
+
+    // Headroom past the clip's nominal duration before giving up on the
+    // end-of-playback marker — covers the buffered tail plus scheduling
+    // jitter on slow devices without meaningfully delaying a genuinely
+    // missing marker.
+    private const val MARKER_TIMEOUT_MARGIN_MS = 2_000L
 
     suspend fun play(audio: PcmAudio) {
         val pcm = audio.bytes
@@ -95,7 +102,26 @@ internal object PcmAudioPlayer {
                 }
                 offset += written
             }
-            awaitMarker(track, totalFrames)
+            // Bound the wait: AudioTrack's end-of-buffer marker is flaky on
+            // some devices (an underrun that stops the head *at* rather than
+            // past the marker, or a dropped callback on the stop transition
+            // never fires onMarkerReached). Un-bounded, that suspends this
+            // coroutine forever — pinning the delivery worker until
+            // WorkManager kills it, or hanging the Settings voice preview.
+            // The full clip length plus a generous margin can only trip when
+            // the marker genuinely went missing: by this point every byte is
+            // queued, so at most one buffer of audio remains.
+            val clipMillis = totalFrames * 1000L / audio.sampleRate
+            val completed = withTimeoutOrNull(clipMillis + MARKER_TIMEOUT_MARGIN_MS) {
+                awaitMarker(track, totalFrames)
+            }
+            if (completed == null) {
+                DiagLog.w(
+                    TAG,
+                    "End-of-playback marker never fired for $totalFrames frames " +
+                        "(~${clipMillis}ms); releasing the track anyway.",
+                )
+            }
         } finally {
             runCatching { track.stop() }
             track.release()

--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsState.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsState.kt
@@ -47,12 +47,12 @@ import java.util.Locale
 data class SettingsState(
     val scheduleTime: LocalTime = LocalTime.of(7, 0),
     val scheduleDays: Set<DayOfWeek> = Schedule.EVERY_DAY,
-    // On by default to mirror the repository (see UserPreferences.dailyEnabled,
-    // where an absent key resolves to enabled): the morning cast ships on out of
-    // the box, so the first render before DataStore emits must not show the
-    // switch off, or the user could leave Schedule believing the morning cast is
-    // off while the app has already scheduled it.
-    val dailyEnabled: Boolean = true,
+    // Off by default to mirror the repository (see UserPreferences.dailyEnabled,
+    // where an absent key resolves to disabled — both scheduled slots are
+    // opt-in now): the first render before DataStore emits must not show the
+    // switch on, or a fresh install's Schedule page would flash the morning
+    // cast as already scheduled when nothing is.
+    val dailyEnabled: Boolean = false,
     val tonightTime: LocalTime = LocalTime.of(19, 0),
     val tonightDays: Set<DayOfWeek> = Schedule.EVERY_DAY,
     val tonightEnabled: Boolean = false,

--- a/app/src/main/kotlin/app/clothescast/ui/today/ForecastChart.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/ForecastChart.kt
@@ -153,15 +153,15 @@ fun ForecastChart(
     // hour offset. See [hourlyTimestampIndices].
     val indexByTime = remember(hourly, startDate) { hourlyTimestampIndices(hourly, startDate) }
     val overlays = perModelHourly?.byModel.orEmpty()
+    // Only models with at least one point inside this chart's window.
+    // [rememberPinnedLineProvider] assigns line colors by position in
+    // this list against the series emitted below, so the two must stay
+    // in lockstep — emitting fewer series than entries here would shift
+    // every later model onto the wrong color. Shared with the cards'
+    // legends via [visibleSpreadModelIds] so the legend lists exactly
+    // the plotted models.
     val visibleModels = if (showModelSpread) {
-        // Only models with at least one point inside this chart's window.
-        // [rememberPinnedLineProvider] assigns line colors by position in
-        // this list against the series emitted below, so the two must stay
-        // in lockstep — emitting fewer series than entries here would shift
-        // every later model onto the wrong color.
-        MODEL_DRAW_ORDER.filter { modelId ->
-            overlays[modelId].orEmpty().any { it.time in indexByTime }
-        }
+        visibleSpreadModelIds(perModelHourly, indexByTime)
     } else {
         emptyList()
     }

--- a/app/src/main/kotlin/app/clothescast/ui/today/PrecipitationAmountChart.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/PrecipitationAmountChart.kt
@@ -64,12 +64,9 @@ fun PrecipitationAmountChart(
     // Only models with ≥1 plottable point (non-null mm, inside this chart's
     // window): the pinned line provider assigns colors by position in this
     // list against the series emitted below, so the two must stay in lockstep.
+    // Shared with the card's legend via [visibleSpreadModelIds].
     val visibleModels = if (showModelSpread) {
-        MODEL_DRAW_ORDER.filter { modelId ->
-            overlays[modelId].orEmpty().any {
-                it.precipitationMm != null && it.time in indexByTime
-            }
-        }
+        visibleSpreadModelIds(perModelHourly, indexByTime) { it.precipitationMm != null }
     } else {
         emptyList()
     }
@@ -216,7 +213,12 @@ internal const val PRECIPITATION_AMOUNT_MIN_SPAN_MM: Double = 5.0
 /**
  * Per-hour main-line series for the precipitation-amount chart and its
  * scrub readout — cross-model mean of `precipitationMm` across whichever
- * consulted models reported at each hour. Falls back to the best-match
+ * models reported at each hour, best_match (Auto) included as an
+ * equal-weight vote, matching the domain consensus blend's posture (see
+ * [app.clothescast.core.domain.model.blendConsensusHourly]). Note the
+ * min–max range band deliberately excludes best_match
+ * (see [perModelEnvelope]), so when Auto is an outlier this mean can sit
+ * outside the shaded band. Falls back to the best-match
  * line ([HourlyForecast.precipitationMm]) at hours where no per-model
  * reported, so the main line stays continuous over the full window and
  * aligns with the readout's hour-by-hour indexing.

--- a/app/src/main/kotlin/app/clothescast/ui/today/PrecipitationChart.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/PrecipitationChart.kt
@@ -71,11 +71,7 @@ fun PrecipitationChart(
     // color. The model still appears on the temperature chart via
     // [ForecastChart], which only needs air-temp.
     val visibleModels = if (showModelSpread) {
-        MODEL_DRAW_ORDER.filter { modelId ->
-            overlays[modelId].orEmpty().any {
-                it.precipitationProbabilityPct != null && it.time in indexByTime
-            }
-        }
+        visibleSpreadModelIds(perModelHourly, indexByTime) { it.precipitationProbabilityPct != null }
     } else {
         emptyList()
     }

--- a/app/src/main/kotlin/app/clothescast/ui/today/RangeBand.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/RangeBand.kt
@@ -58,6 +58,27 @@ internal fun hourlyTimestampIndices(
 }
 
 /**
+ * Model ids with at least one entry inside the chart window ([indexByTime])
+ * carrying a value [hasValue] accepts — the per-model visibility filter the
+ * charts apply when emitting series, shared with the cards' legends so a
+ * legend can never list a model whose line isn't actually plotted (e.g. a
+ * series that stops before the window's post-midnight hours, or a model
+ * Open-Meteo omits the metric for). Charts additionally rely on this list's
+ * order matching the emitted series order (pinned line providers assign
+ * colors by position), so both must come from this one function.
+ */
+internal fun visibleSpreadModelIds(
+    perModelHourly: PerModelHourly?,
+    indexByTime: Map<LocalDateTime, Int>,
+    hasValue: (PerModelHour) -> Boolean = { true },
+): List<String> {
+    val overlays = perModelHourly?.byModel.orEmpty()
+    return MODEL_DRAW_ORDER.filter { modelId ->
+        overlays[modelId].orEmpty().any { it.time in indexByTime && hasValue(it) }
+    }
+}
+
+/**
  * Per-hour min and max of [picker] across the consulted models — the envelope
  * the [rememberRangeBandDecoration] band fills. Returned as `(hourIndex, value)`
  * lists at the series' original indices, computed only where at least two models

--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
@@ -2801,8 +2801,13 @@ internal fun ForecastCard(
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                     if (perModelHourly != null) {
+                        // Same in-window filter [ForecastChart] applies —
+                        // see [visibleSpreadModelIds].
+                        val indexByTime = remember(hourly, startDate) {
+                            hourlyTimestampIndices(hourly, startDate)
+                        }
                         ModelSpreadLegend(
-                            visibleModelIds = if (showModelSpread) MODEL_DRAW_ORDER.filter { it in perModelHourly.byModel } else emptyList(),
+                            visibleModelIds = if (showModelSpread) visibleSpreadModelIds(perModelHourly, indexByTime) else emptyList(),
                             mainLine = MainLineLegend(
                                 color = AppTheme.mainLineColor,
                                 label = stringResource(R.string.today_chart_main_line_label),
@@ -2863,8 +2868,13 @@ internal fun AirTemperatureCard(
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
                 if (perModelHourly != null) {
+                    // Same in-window filter [ForecastChart] applies —
+                    // see [visibleSpreadModelIds].
+                    val indexByTime = remember(hourly, startDate) {
+                        hourlyTimestampIndices(hourly, startDate)
+                    }
                     ModelSpreadLegend(
-                        visibleModelIds = if (showModelSpread) MODEL_DRAW_ORDER.filter { it in perModelHourly.byModel } else emptyList(),
+                        visibleModelIds = if (showModelSpread) visibleSpreadModelIds(perModelHourly, indexByTime) else emptyList(),
                         mainLine = MainLineLegend(
                             color = AppTheme.mainLineColor,
                             label = stringResource(R.string.today_chart_main_line_label),
@@ -3378,18 +3388,16 @@ internal fun PrecipitationCard(
                     showModelSpread = showModelSpread,
                 )
                 if (perModelHourly != null) {
-                    // Mirror the chart's per-model visibility filter (see
-                    // [PrecipitationChart]) — list only the models that
-                    // actually have a probability line plotted, not every
-                    // model in byModel. Open-Meteo omits
-                    // `precipitation_probability_<model>` for some models
-                    // (UKMO, JMA, …) even though they report temperature and
-                    // precipitation_mm, so a bare `it in byModel` filter shows
-                    // a legend chip with no corresponding line on the chart.
+                    // Same visibility filter the chart applies (see
+                    // [PrecipitationChart] / [visibleSpreadModelIds]) — a
+                    // model without a probability line plotted inside this
+                    // window must not get a legend chip.
+                    val indexByTime = remember(hourly, startDate) {
+                        hourlyTimestampIndices(hourly, startDate)
+                    }
                     val visibleIds = if (showModelSpread) {
-                        MODEL_DRAW_ORDER.filter { modelId ->
-                            perModelHourly.byModel[modelId]
-                                ?.any { it.precipitationProbabilityPct != null } == true
+                        visibleSpreadModelIds(perModelHourly, indexByTime) {
+                            it.precipitationProbabilityPct != null
                         }
                     } else emptyList()
                     ModelSpreadLegend(
@@ -3511,15 +3519,14 @@ internal fun PrecipitationAmountCard(
                     showModelSpread = showModelSpread,
                 )
                 if (perModelHourly != null) {
-                    // Mirror the chart's per-model visibility filter — list
-                    // only the models that actually have a precipitation_mm
-                    // line plotted, not every model in byModel. Without
-                    // this filter, models whose Open-Meteo response omitted
-                    // `precipitation_<model>` (UKMO, JMA, …) show up as
-                    // legend chips with no corresponding line on the chart.
+                    // Same visibility filter the chart applies (see
+                    // [PrecipitationAmountChart] / [visibleSpreadModelIds]) —
+                    // a model without a precipitation_mm line plotted inside
+                    // this window must not get a legend chip. Reads the
+                    // card-level [indexByTime] the chart's inputs share.
                     val visibleIds = if (showModelSpread) {
-                        MODEL_DRAW_ORDER.filter { modelId ->
-                            perModelHourly.byModel[modelId]?.any { it.precipitationMm != null } == true
+                        visibleSpreadModelIds(perModelHourly, indexByTime) {
+                            it.precipitationMm != null
                         }
                     } else emptyList()
                     ModelSpreadLegend(

--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayViewModel.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayViewModel.kt
@@ -202,9 +202,11 @@ data class TodayState(
     val schedulePromoCardVisible: Boolean = false,
     /**
      * Whether the "Preview your daily ClothesCast now" promo card is eligible —
-     * true iff the user hasn't dismissed it AND at least one cast slot is
-     * enabled (the morning slot is on by default, so this normally holds). It
-     * points at the top-bar play button so the user can hear a cast on demand.
+     * true iff the user hasn't dismissed it AND at least one schedule slot
+     * ([UserPreferences.dailyEnabled] / [UserPreferences.tonightEnabled]) is
+     * enabled. Both slots are opt-in, so this card follows the schedule promo:
+     * once the user sets up a schedule, it points at the top-bar play button
+     * so they learn they can also hear a cast on demand.
      */
     val playPromoCardVisible: Boolean = false,
     /**
@@ -747,7 +749,8 @@ class TodayViewModel(
                 !prefs.calendarBirthdayThemingActive,
             clothesPromoCardVisible = !prefs.clothesPromoCardDismissed &&
                 prefs.clothesRules == ClothesRule.DEFAULTS,
-            schedulePromoCardVisible = !prefs.scheduleCardDismissed,
+            schedulePromoCardVisible = !prefs.scheduleCardDismissed &&
+                !prefs.dailyEnabled && !prefs.tonightEnabled,
             playPromoCardVisible = !prefs.playCardDismissed &&
                 (prefs.dailyEnabled || prefs.tonightEnabled),
             // Stand the "try high-quality voices" promo down while the limit

--- a/app/src/main/kotlin/app/clothescast/widget/ConditionsWidget.kt
+++ b/app/src/main/kotlin/app/clothescast/widget/ConditionsWidget.kt
@@ -29,6 +29,7 @@ import androidx.glance.text.Text
 import androidx.glance.text.TextStyle
 import androidx.glance.unit.ColorProvider
 import app.clothescast.R
+import app.clothescast.diag.DiagLog
 import app.clothescast.insight.InsightFormatter
 import app.clothescast.ui.garment.OutfitCardInfoLines
 import app.clothescast.ui.garment.STRIP_SURFACE_DARK_ARGB
@@ -55,6 +56,10 @@ import app.clothescast.ui.garment.renderConditionsStripBitmap
  */
 class ConditionsWidget : GlanceAppWidget() {
 
+    private companion object {
+        const val TAG = "ConditionsWidget"
+    }
+
     override val sizeMode: SizeMode = SizeMode.Exact
 
     override suspend fun provideGlance(context: Context, id: GlanceId) {
@@ -80,6 +85,11 @@ class ConditionsWidget : GlanceAppWidget() {
                     temperatureUnit = prefs.temperatureUnit,
                     windSpeedUnit = prefs.windSpeedUnit,
                 )
+            }.onFailure {
+                // A formatter / strip-math failure blanks the widget to its
+                // empty state; without a log that's indistinguishable from
+                // "no data yet" when chasing a blank-widget report.
+                DiagLog.w(TAG, "Conditions strip computation failed; showing empty state", it)
             }.getOrNull()
         } else {
             null

--- a/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
@@ -382,20 +382,35 @@ class FetchAndNotifyWorker(
                     // than push a stale bundle to the day/night topic.
                     // `today` is the base date deliveredForToday() just confirmed
                     // THIS_PERIOD is for, so the expected next-window date is it
-                    // (day run) or the day after (night run -> tomorrow's day).
-                    // Also require the cached sibling to be for *this run's*
-                    // location: a refresh can update THIS_PERIOD to a new city
-                    // while a failed generatePairedInsight() leaves a same-date
-                    // sibling for the old one, which we must not publish.
+                    // (day run) or the day after (night run -> tomorrow's day)
+                    // — EXCEPT the post-midnight overnight, whose sibling is
+                    // *today's* daytime (generatePairedInsight pairs
+                    // primaryOvernight with TODAY at dayOffset 0), not
+                    // tomorrow's. Also require the cached sibling to be for
+                    // *this run's* location: a refresh can update THIS_PERIOD
+                    // to a new city while a failed generatePairedInsight()
+                    // leaves a same-date sibling for the old one, which we
+                    // must not publish.
                     val expectedPeriod = period.opposite()
-                    val expectedDate = today.plusDays(if (period == ForecastPeriod.TONIGHT) 1L else 0L)
+                    val expectedDate = today.plusDays(
+                        if (period == ForecastPeriod.TONIGHT && !overnight) 1L else 0L,
+                    )
                     val nextSnapshot = runCatching { app.insightCache.nextPeriod.first() }
                         .onFailure { t -> if (t is CancellationException) throw t }
                         .getOrNull()
+                    // Proximity, not data-class equality: resolveLocation()
+                    // builds a fresh Location every run (new GPS fix a few
+                    // meters off, re-geocoded display fields), so exact
+                    // equality almost never holds for device-location users
+                    // even when they haven't moved — which silently skipped
+                    // every next-window publish. Same "same place" radius the
+                    // label-reuse path uses.
+                    val sameLocation = nextSnapshot?.location
+                        ?.isWithin(REUSE_LABEL_RADIUS_METERS, of = location) == true
                     if (nextSnapshot != null &&
                         nextSnapshot.period == expectedPeriod &&
                         nextSnapshot.bundle.today.date == expectedDate &&
-                        nextSnapshot.location == location
+                        sameLocation
                     ) {
                         publishNextWindowFromSnapshot(nextSnapshot, prefs)
                     } else {
@@ -455,10 +470,23 @@ class FetchAndNotifyWorker(
         // without a fetch. A snapshot for the wrong day — e.g. this morning's
         // already-delivered daytime cast when the user wants tomorrow's daily —
         // is skipped and falls through to a fresh fetch.
-        val cached = listOfNotNull(
-            app.insightCache.thisPeriod.first(),
-            app.insightCache.nextPeriod.first(),
-        ).firstOrNull { it.period == requestedPeriod && it.bundle.today.date == targetDate }
+        // A corrupted cache (DataStore IO error, snapshot that no longer
+        // deserializes) degrades to a miss — Play falls through to the fresh
+        // fetch below — rather than throwing out of the worker: an unhandled
+        // throw here becomes an unstamped Result.failure (no KEY_REASON, no
+        // KEY_COMPLETED_AT), which both surfaces a refresh-failure banner the
+        // Play contract says it never should and mis-sorts against other
+        // terminal work in TodayViewModel.selectStatus.
+        val cached = runCatching {
+            listOfNotNull(
+                app.insightCache.thisPeriod.first(),
+                app.insightCache.nextPeriod.first(),
+            ).firstOrNull { it.period == requestedPeriod && it.bundle.today.date == targetDate }
+        }.getOrElse {
+            if (it is CancellationException) throw it
+            DiagLog.e(TAG, "Play cache read failed; treating as a miss.", it)
+            null
+        }
 
         if (cached != null) {
             // Cache hit replays without fetching; signal "fetch is done"
@@ -467,9 +495,19 @@ class FetchAndNotifyWorker(
             // delivery via TodayState.anyWorkActive, which keys off
             // WorkInfo.state directly.)
             markFetchComplete()
-            val insight = app.deriveInsight(cached, prefs, diagLog = { DiagLog.i(TAG, it) }).insight
-            val prose = formatProse(insight, prefs)
-            return deliverBestEffort(insight, prefs, prose, "Replayed", forceNotifyAndSpeak)
+            return try {
+                val insight = app.deriveInsight(cached, prefs, diagLog = { DiagLog.i(TAG, it) }).insight
+                val prose = formatProse(insight, prefs)
+                deliverBestEffort(insight, prefs, prose, "Replayed", forceNotifyAndSpeak)
+            } catch (ce: CancellationException) {
+                throw ce
+            } catch (t: Throwable) {
+                // Same best-effort posture as deliverBestEffort: a replay
+                // that fails to derive shouldn't surface as a refresh
+                // failure — whatever's on screen is still valid.
+                DiagLog.e(TAG, "Play replay derivation failed.", t)
+                Result.success(workDataOf(KEY_SKIP_TELEMETRY to true))
+            }
         }
 
         // Cache miss — fetch fresh for the requested period.
@@ -973,7 +1011,13 @@ class FetchAndNotifyWorker(
         return try {
             manager.isProviderEnabled(LocationManager.NETWORK_PROVIDER) ||
                 manager.isProviderEnabled(LocationManager.PASSIVE_PROVIDER)
-        } catch (_: Throwable) {
+        } catch (e: Exception) {
+            // Some OEM builds throw from isProviderEnabled. Returning false
+            // reclassifies a transient device-location failure as permanent
+            // misconfiguration (REASON_NO_LOCATION failure instead of a
+            // retry), so leave a trace for when that misdiagnosis is being
+            // chased in the field.
+            DiagLog.w(TAG, "isProviderEnabled threw; treating location services as off", e)
             false
         }
     }

--- a/app/src/test/kotlin/app/clothescast/calendar/HolidayThemeResolverTest.kt
+++ b/app/src/test/kotlin/app/clothescast/calendar/HolidayThemeResolverTest.kt
@@ -50,7 +50,7 @@ class HolidayThemeResolverTest {
     private val nonHolidayDate: LocalDate = LocalDate.of(2026, 8, 11)
 
     @Test
-    fun `birthday event resolves to a synthetic birthday theme`() = runBlocking {
+    fun `birthday event resolves to a synthetic birthday theme`() = runBlocking<Unit> {
         val prefs = basePrefs.copy(themeFromCalendarBirthdays = true)
         val reader = object : CalendarEventReader {
             override suspend fun eventsForDay(date: LocalDate, zoneId: ZoneId): List<CalendarEvent> =

--- a/app/src/test/kotlin/app/clothescast/cast/CastMediaServerTest.kt
+++ b/app/src/test/kotlin/app/clothescast/cast/CastMediaServerTest.kt
@@ -86,7 +86,7 @@ class CastMediaServerTest {
     }
 
     @Test
-    fun `awaitFetch returns true once a receiver GETs the active URL`() = runBlocking {
+    fun `awaitFetch returns true once a receiver GETs the active URL`() = runBlocking<Unit> {
         val urls = server.publish(host = "127.0.0.1", media = byteArrayOf(1, 2, 3))
 
         // Await before the GET — the deferred must not be pre-completed.
@@ -113,7 +113,7 @@ class CastMediaServerTest {
     }
 
     @Test
-    fun `awaitFetch is not satisfied by a wrong-token request`() = runBlocking {
+    fun `awaitFetch is not satisfied by a wrong-token request`() = runBlocking<Unit> {
         val urls = server.publish(host = "127.0.0.1", media = byteArrayOf(7))
         val origin = URL(urls.url).let { "http://${it.host}:${it.port}" }
 
@@ -125,7 +125,7 @@ class CastMediaServerTest {
     }
 
     @Test
-    fun `awaitFetch returns true after a republish once the new URL is GET'd`() = runBlocking {
+    fun `awaitFetch returns true after a republish once the new URL is GET'd`() = runBlocking<Unit> {
         server.publish(host = "127.0.0.1", media = "first".toByteArray())
         // No GET on the first URL — its deferred never completes.
 
@@ -146,6 +146,47 @@ class CastMediaServerTest {
 
         server.stop()
         server.port() shouldBe 0
+    }
+
+    @Test
+    fun `range requests are answered with 206 and the requested slice`() {
+        // Cast receivers probe the MP4 tail for the moov atom (MediaMuxer
+        // writes it after mdat) with a Range GET; the server must answer
+        // 206 with just the slice, not the whole body from byte 0.
+        val mp4 = byteArrayOf(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
+        val urls = server.publish(host = "127.0.0.1", media = mp4)
+
+        // Warm up the accept loop through the retrying helper first.
+        fetch(urls.url).status shouldBe 200
+
+        val conn = URL(urls.url).openConnection() as HttpURLConnection
+        conn.setRequestProperty("Range", "bytes=6-")
+        try {
+            conn.responseCode shouldBe 206
+            conn.inputStream.use { it.readBytes() } shouldBe byteArrayOf(6, 7, 8, 9)
+        } finally {
+            conn.disconnect()
+        }
+    }
+
+    @Test
+    fun `HEAD is answered without confirming the fetch`() = runBlocking<Unit> {
+        // Some players lead with a HEAD probe. It must succeed (it 404'd
+        // before AutoHeadResponse) but must NOT complete the fetch
+        // confirmation — no media bytes crossed the LAN yet.
+        val urls = server.publish(host = "127.0.0.1", media = byteArrayOf(1, 2, 3))
+        fetch(urls.url).status shouldBe 200 // warm-up GET on the old token…
+        val fresh = server.publish(host = "127.0.0.1", media = byteArrayOf(1, 2, 3))
+
+        val conn = URL(fresh.url).openConnection() as HttpURLConnection
+        conn.requestMethod = "HEAD"
+        try {
+            conn.responseCode shouldBe 200
+        } finally {
+            conn.disconnect()
+        }
+
+        server.awaitFetch(timeoutMs = 100) shouldBe false
     }
 
     private data class Response(val status: Int, val contentType: String?, val body: ByteArray)

--- a/core/data/src/main/kotlin/app/clothescast/core/data/tts/GeminiTtsClient.kt
+++ b/core/data/src/main/kotlin/app/clothescast/core/data/tts/GeminiTtsClient.kt
@@ -279,6 +279,7 @@ private val LANGUAGE_DIRECTIVES: Map<String, String> = mapOf(
     "fr" to "Speak in French.",
     "fr-CA" to "Speak in Canadian French.",
     "it" to "Speak in Italian.",
+    "es" to "Speak in Spanish.",
     "es-ES" to "Speak in Spanish.",
     "es-MX" to "Speak in Mexican Spanish.",
     "ca" to "Speak in Catalan.",
@@ -378,9 +379,17 @@ private val ACCENT_DIRECTIVES: Map<String, String> = mapOf(
     "de" to "Sprich auf Deutsch in einem hochdeutschen Akzent.",
     "de-AT" to "Sprich auf Deutsch mit einem österreichischen Akzent.",
     "de-CH" to "Sprich auf Deutsch mit einem deutschschweizerischen Akzent.",
+    // Language-only fallback for bare `fr` (an app locale) and any fr-*
+    // variant not enumerated (fr-CH, fr-BE, …); France and Québec keep
+    // their own regional entries below.
+    "fr" to "Parle en français.",
     "fr-FR" to "Parle en français de France avec un accent parisien.",
     "fr-CA" to "Parle en français québécois avec un accent canadien-français.",
     "it" to "Parla in italiano.",
+    // Language-only fallback for bare `es` (an app locale) and any es-*
+    // variant not enumerated (es-AR, es-US, …); Spain and Mexico keep
+    // their own regional entries below.
+    "es" to "Habla en español.",
     "es-ES" to "Habla en español de España con un acento castellano.",
     "es-MX" to "Habla en español mexicano con un acento neutro.",
     "ca" to "Parla en català.",

--- a/core/data/src/main/kotlin/app/clothescast/core/data/weather/OpenMeteoClient.kt
+++ b/core/data/src/main/kotlin/app/clothescast/core/data/weather/OpenMeteoClient.kt
@@ -157,8 +157,7 @@ class OpenMeteoClient(
         // best_match stays a real vote in the consensus blend on both sides of
         // the midnight boundary.
         val tomorrowDate = bundle.today.date.plusDays(1)
-        val bestMatchPerModel =
-            response.hourly.asBestMatchPerModelHours(firstForecastDate = bundle.today.date)
+        val bestMatchPerModel = response.hourly.asBestMatchPerModelHours()
 
         // Fold best_match and (when the user enabled it) Google into the
         // per-model map. Google is stored alongside the Open-Meteo source models
@@ -220,13 +219,17 @@ class OpenMeteoClient(
     // without temperature_2m is dropped (no synthetic 0 °C vote), apparent
     // falls back to air, and the precipitation fields stay null when absent so
     // precip-specific aggregates skip them instead of counting a fake dry hour.
-    private fun HourlyData.asBestMatchPerModelHours(firstForecastDate: LocalDate): List<PerModelHour> =
+    private fun HourlyData.asBestMatchPerModelHours(): List<PerModelHour> =
         buildList {
             for (i in time.indices) {
                 val ts = runCatching { LocalDateTime.parse(time[i]) }.getOrNull() ?: continue
-                // Yesterday is historical with no side-band per-model coverage;
-                // start best_match's series where the consulted models start.
-                if (ts.toLocalDate() < firstForecastDate) continue
+                // Yesterday's hours stay in: both this call and the side-band
+                // confidence call fetch past_days=1, so the consulted models'
+                // series reach back to yesterday 00:00 — filtering best_match
+                // to today made the "Auto" line alone start at midnight on the
+                // Overnight chart's pre-midnight hours. Day-keyed consumers
+                // (the consensus blend) never look yesterday up, so the extra
+                // entries are inert outside the charts.
                 val air = temperature.getOrNull(i) ?: continue
                 add(
                     PerModelHour(

--- a/core/data/src/main/kotlin/app/clothescast/core/data/weather/OpenMeteoMapper.kt
+++ b/core/data/src/main/kotlin/app/clothescast/core/data/weather/OpenMeteoMapper.kt
@@ -109,7 +109,13 @@ internal object OpenMeteoMapper {
     private fun HourlyData.forDate(date: LocalDate): List<HourlyForecast> {
         val out = ArrayList<HourlyForecast>(24)
         for (i in time.indices) {
-            val ts = LocalDateTime.parse(time[i])
+            // Skip an unparseable timestamp instead of throwing: one mangled
+            // entry (truncated by a proxy, upstream glitch) must degrade to a
+            // dropped hour — the same policy the other two parsers of this
+            // stream apply (OpenMeteoClient.asBestMatchPerModelHours,
+            // MultiModelConfidenceFetcher.parseHour) — not void the whole
+            // 14-day payload.
+            val ts = runCatching { LocalDateTime.parse(time[i]) }.getOrNull() ?: continue
             if (ts.toLocalDate() != date) continue
             // An hour without temperature_2m (horizon edge of the 14-day
             // window, an upstream run still warming up) is dropped, not

--- a/core/data/src/test/kotlin/app/clothescast/core/data/tts/GeminiTtsClientTest.kt
+++ b/core/data/src/test/kotlin/app/clothescast/core/data/tts/GeminiTtsClientTest.kt
@@ -249,6 +249,52 @@ class GeminiTtsClientTest {
     }
 
     @Test
+    fun `request body includes a french directive for non-enumerated fr variants`() = runTest {
+        // Bare `fr` is a declared app locale and fr-CH / fr-BE resolve through
+        // the language-only fallback — without a bare `fr` key those devices
+        // got no French steering at all while France and Québec did.
+        var capturedBody: String? = null
+        val client = GeminiTtsClient(
+            httpClient = mockClient(SUCCESS_BODY) {
+                capturedBody = (it.body as io.ktor.http.content.OutgoingContent.ByteArrayContent)
+                    .bytes()
+                    .toString(Charsets.UTF_8)
+            },
+            callPlanner = directPlanner("test-key"),
+        )
+
+        client.synthesize(text = "bonjour", locale = Locale.forLanguageTag("fr-CH"))
+
+        val body = checkNotNull(capturedBody)
+        body.shouldContain("Parle en français.")
+        // The regional entries stay reserved for their own tags.
+        body.shouldNotContain("parisien")
+        body.shouldNotContain("québécois")
+    }
+
+    @Test
+    fun `request body includes a spanish directive for non-enumerated es variants`() = runTest {
+        // Same fallback shape as `fr`: bare `es` is a declared app locale and
+        // es-AR / es-US resolve through the language-only key.
+        var capturedBody: String? = null
+        val client = GeminiTtsClient(
+            httpClient = mockClient(SUCCESS_BODY) {
+                capturedBody = (it.body as io.ktor.http.content.OutgoingContent.ByteArrayContent)
+                    .bytes()
+                    .toString(Charsets.UTF_8)
+            },
+            callPlanner = directPlanner("test-key"),
+        )
+
+        client.synthesize(text = "hola", locale = Locale.forLanguageTag("es-AR"))
+
+        val body = checkNotNull(capturedBody)
+        body.shouldContain("Habla en español.")
+        body.shouldNotContain("castellano")
+        body.shouldNotContain("mexicano")
+    }
+
+    @Test
     fun `request body includes an austrian accent directive for de-AT locale`() = runTest {
         var capturedBody: String? = null
         val client = GeminiTtsClient(

--- a/core/data/src/test/kotlin/app/clothescast/core/data/weather/OpenMeteoClientTest.kt
+++ b/core/data/src/test/kotlin/app/clothescast/core/data/weather/OpenMeteoClientTest.kt
@@ -196,6 +196,74 @@ class OpenMeteoClientTest {
     }
 
     @Test
+    fun `best_match per-model series keeps yesterday's hours for the overnight chart`() = runTest {
+        // Both the primary call and the confidence side-band fetch past_days=1,
+        // so the consulted models' series reach back to yesterday evening for
+        // the Overnight chart's pre-midnight hours. best_match must too — a
+        // today-only filter made the "Auto" line alone start at midnight.
+        val primaryJson = """
+            {
+              "timezone": "Europe/London",
+              "daily": {
+                "time": ["2026-04-24", "2026-04-25"],
+                "temperature_2m_min": [12.0, 16.0],
+                "temperature_2m_max": [18.0, 24.0],
+                "apparent_temperature_min": [10.0, 15.0],
+                "apparent_temperature_max": [17.0, 23.0],
+                "precipitation_probability_max": [5, 60],
+                "precipitation_sum": [0.0, 4.5],
+                "weather_code": [2, 63]
+              },
+              "hourly": {
+                "time": ["2026-04-24T21:00", "2026-04-25T12:00"],
+                "temperature_2m": [14.0, 20.0],
+                "apparent_temperature": [13.0, 20.0],
+                "precipitation_probability": [10, 40],
+                "weather_code": [2, 2],
+                "wind_speed_10m": [8.0, 10.0],
+                "uv_index": [0.0, 4.0]
+              }
+            }
+        """.trimIndent()
+        val confidenceJson = """
+            {
+              "daily": {"time": ["2026-04-25"]},
+              "hourly": {
+                "time": ["2026-04-24T21:00", "2026-04-25T12:00"],
+                "temperature_2m_gfs_seamless": [15.0, 21.0],
+                "apparent_temperature_gfs_seamless": [15.0, 21.0],
+                "temperature_2m_icon_seamless": [13.0, 23.0],
+                "apparent_temperature_icon_seamless": [13.0, 23.0]
+              }
+            }
+        """.trimIndent()
+        val engine = MockEngine { request ->
+            val isPrimary = request.url.parameters["models"] == null
+            respond(
+                content = if (isPrimary) primaryJson else confidenceJson,
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+        val client = OpenMeteoClient(
+            HttpClient(engine) {
+                install(ContentNegotiation) {
+                    json(Json { ignoreUnknownKeys = true })
+                }
+            },
+        )
+
+        val bundle = client.fetchForecast(london)
+
+        val bestMatch = checkNotNull(bundle.perModelHourly)
+            .byModel.getValue(PerModelHourly.BEST_MATCH_MODEL_ID)
+        bestMatch.map { it.time } shouldBe listOf(
+            java.time.LocalDateTime.parse("2026-04-24T21:00"),
+            java.time.LocalDateTime.parse("2026-04-25T12:00"),
+        )
+    }
+
+    @Test
     fun `google is treated as just another model - votes in the blend and lands in the stored per-model map`() = runTest {
         // Same two-model side-band (GFS + ICON) and best_match primary as the
         // synthetic-zero test above. At 12:00 best_match=20, GFS=21, ICON=23.

--- a/core/data/src/test/kotlin/app/clothescast/core/data/weather/OpenMeteoMapperTest.kt
+++ b/core/data/src/test/kotlin/app/clothescast/core/data/weather/OpenMeteoMapperTest.kt
@@ -417,6 +417,39 @@ class OpenMeteoMapperTest {
     }
 
     @Test
+    fun `a malformed hourly timestamp drops that hour, not the whole payload`() {
+        // One mangled entry (proxy truncation, upstream glitch) must degrade
+        // to a dropped hour — the policy the sibling parsers already apply —
+        // instead of a DateTimeParseException voiding the whole forecast.
+        val mangled = OpenMeteoResponse(
+            timezone = "UTC",
+            daily = DailyData(
+                time = listOf("2026-04-24", "2026-04-25"),
+                temperatureMin = listOf(12.0, 16.0),
+                temperatureMax = listOf(18.0, 24.0),
+                feelsLikeMin = listOf(10.0, 15.0),
+                feelsLikeMax = listOf(17.0, 23.0),
+                precipitationProbabilityMax = listOf(5, 60),
+                precipitationSum = listOf(0.0, 4.5),
+                weatherCode = listOf(2, 63),
+            ),
+            hourly = HourlyData(
+                time = listOf("2026-04-25T09:00", "2026-04-2", ""),
+                temperature = listOf(18.0, 19.0, 20.0),
+                feelsLike = listOf(17.0, 18.0, 19.0),
+                precipitationProbability = listOf(20, 20, 20),
+                weatherCode = listOf(63, 63, 63),
+            ),
+        )
+
+        val today = OpenMeteoMapper.toBundle(mangled).today
+
+        val survivor = today.hourly.single()
+        survivor.time shouldBe LocalTime.of(9, 0)
+        survivor.temperatureC shouldBe 18.0
+    }
+
+    @Test
     fun `rejects responses missing two daily entries`() {
         val short = OpenMeteoResponse(
             timezone = "UTC",

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/InsightSummary.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/InsightSummary.kt
@@ -216,7 +216,8 @@ data class CalendarExtrasClause(val item: String)
  * formatter renders "Tonight, rain at 9pm." (or "Tonight, chance of rain at
  * 9pm." when [likelihood] is POSSIBLE).
  *
- * When the evening forecast slice has rain ≥ 20%, [rainTime] carries the peak
+ * When the evening forecast slice has rain ≥ 10% (the POSSIBLE bar — see
+ * [PrecipLikelihood]), [rainTime] carries the peak
  * hour and the formatter folds it into the same sentence ("Tonight, rain at
  * 9pm, bring a jacket.") — keeps the morning insight's mention of evening rain
  * tied to the evening event, rather than emitting a second precip clause that

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Units.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/Units.kt
@@ -61,7 +61,11 @@ fun WindSpeedUnit.symbol(): String = when (this) {
  *  branch so the chart subtitles read tight.
  */
 fun TimeFormat.formatHourMinute(time: LocalTime, locale: Locale): String = when (this) {
-    TimeFormat.TWENTY_FOUR_HOUR -> "%02d:%02d".format(time.hour, time.minute)
+    // Format against the passed locale, not the JVM default: the localeless
+    // String.format overload localizes %d digits via Locale.getDefault(FORMAT),
+    // so a device set to e.g. Persian would leak its digit shapes into a
+    // reading the caller explicitly asked for in another locale.
+    TimeFormat.TWENTY_FOUR_HOUR -> "%02d:%02d".format(locale, time.hour, time.minute)
     TimeFormat.TWELVE_HOUR -> formatTwelveHour(time, locale, includeMinutes = true)
 }
 
@@ -73,7 +77,8 @@ fun TimeFormat.formatHourMinute(time: LocalTime, locale: Locale): String = when 
  * the subtitle tight under narrow charts.
  */
 fun TimeFormat.formatTopOfHour(time: LocalTime, locale: Locale): String = when (this) {
-    TimeFormat.TWENTY_FOUR_HOUR -> "%02d:%02d".format(time.hour, time.minute)
+    // Localeless format leaks default-locale digits — see [formatHourMinute].
+    TimeFormat.TWENTY_FOUR_HOUR -> "%02d:%02d".format(locale, time.hour, time.minute)
     TimeFormat.TWELVE_HOUR -> formatTwelveHour(time, locale, includeMinutes = false)
 }
 
@@ -82,7 +87,8 @@ private fun formatTwelveHour(time: LocalTime, locale: Locale, includeMinutes: Bo
         val hour12 = ((time.hour + 11) % 12) + 1
         val suffix = if (time.hour < 12) "am" else "pm"
         return if (includeMinutes && time.minute != 0) {
-            "%d:%02d%s".format(hour12, time.minute, suffix)
+            // Locale-pinned like the 24h branch — see [formatHourMinute].
+            "%d:%02d%s".format(locale, hour12, time.minute, suffix)
         } else {
             "$hour12$suffix"
         }

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/DeriveInsight.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/DeriveInsight.kt
@@ -626,8 +626,18 @@ internal fun DailyForecast.slicedForTonight(
     morningEnd: LocalTime,
     tomorrowHourly: List<HourlyForecast>,
 ): DailyForecast {
-    val tonightHours = hourly.filter { it.time >= tonightStart }
-    val tomorrowMorning = if (tonightStart.isBefore(morningEnd)) {
+    // An after-midnight tonight time (tonightStart < morningEnd) puts the
+    // whole window before the same day's morning — [00:30, 07:00) — so it
+    // must also truncate at morningEnd, or a night-owl's "Tonight" would
+    // aggregate every hour through the following afternoon (a 28° daytime
+    // high reading as a hot night, suppressing the jacket the pre-dawn
+    // hours warrant). The wrapped shape [19:00, 07:00) reaches into
+    // tomorrowHourly instead.
+    val sameDayWindow = tonightStart.isBefore(morningEnd)
+    val tonightHours = hourly.filter {
+        it.time >= tonightStart && (!sameDayWindow || it.time < morningEnd)
+    }
+    val tomorrowMorning = if (sameDayWindow) {
         emptyList()
     } else {
         tomorrowHourly.filter { it.time < morningEnd }

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/DeriveInsight.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/DeriveInsight.kt
@@ -129,6 +129,19 @@ class DeriveInsight(
             }
             ?: periodView.deltaYesterday
 
+        // The IF_CHANGED clothes gate compares today's items against
+        // yesterday's, so yesterday's outfit has to be evaluated against the
+        // same corrected day the delta clause reads — re-running the rules on
+        // the hindcast would reintroduce exactly the wrong-yesterday the
+        // historic record exists to bypass (a hindcast that missed a warm day
+        // "fires" a sweater the user was never told about, and today's real
+        // sweater is then suppressed as unchanged).
+        val yesterdayTriggeredItems = if (deltaYesterdayForRender === periodView.deltaYesterday) {
+            periodView.yesterdayTriggeredItems
+        } else {
+            evaluateClothesRules(deltaYesterdayForRender, rules, defaultTop, defaultBottom).items
+        }
+
         val summary = renderInsightSummary(
             today = periodView.forecast,
             yesterday = deltaYesterdayForRender,
@@ -140,7 +153,7 @@ class DeriveInsight(
             deltaThresholdC = prefs.deltaThresholdC,
             deltaFormat = prefs.deltaFormat,
             clothesMentionMode = prefs.clothesMentionMode,
-            yesterdayTriggeredItems = periodView.yesterdayTriggeredItems,
+            yesterdayTriggeredItems = yesterdayTriggeredItems,
             todayRuleItems = Garment.layerReduce(periodView.triggeredOutfit.rules).map { it.item.itemKey },
             tonightStart = tonightStart,
             diagLog = diagLog,

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/HolidayResolver.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/HolidayResolver.kt
@@ -5,6 +5,7 @@ import app.clothescast.core.domain.model.HolidayDate
 import app.clothescast.core.domain.model.HolidayId
 import app.clothescast.core.domain.model.HolidayOverride
 import app.clothescast.core.domain.model.HolidayTheme
+import app.clothescast.core.domain.model.isFunny
 import java.time.LocalDate
 
 /**
@@ -92,9 +93,18 @@ class HolidayResolver(
      * fallback when resolve returned null. An OFF override on a holiday
      * whose country *is* enabled still suppresses the fallback — the
      * user's explicit opt-out beats a calendar event with the same date.
+     *
+     * Funny-bucket entries never count as a match: a joke observance
+     * (Talk Like a Pirate Day, Towel Day) can share a date with a real
+     * public holiday in *some* country's calendar, and it isn't a
+     * duplicate of it — the composed banner is built to join the two
+     * ("Happy bank holiday and don't forget your towel"), so the joke
+     * must not silence the calendar holiday.
      */
     fun hasCatalogMatch(date: LocalDate, enabledCountries: Set<String>): Boolean =
         catalog.any { (predicate, theme) ->
-            predicate.matches(date) && theme.countries.any { it in enabledCountries }
+            !theme.isFunny &&
+                predicate.matches(date) &&
+                theme.countries.any { it in enabledCountries }
         }
 }

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/model/UnitsTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/model/UnitsTest.kt
@@ -110,6 +110,23 @@ class UnitsTest {
     }
 
     @Test
+    fun `clock digits follow the passed locale, not the JVM default`() {
+        // A device default with non-ASCII digit shapes (Persian) must not
+        // leak into a reading the caller asked for in an explicit locale —
+        // the localeless String.format overload localizes %d through
+        // Locale.getDefault(FORMAT), which is exactly the leak this pins.
+        val saved = Locale.getDefault(Locale.Category.FORMAT)
+        try {
+            Locale.setDefault(Locale.Category.FORMAT, Locale.forLanguageTag("fa-IR"))
+            TimeFormat.TWENTY_FOUR_HOUR.formatHourMinute(LocalTime.of(14, 0), Locale.US) shouldBe "14:00"
+            TimeFormat.TWENTY_FOUR_HOUR.formatTopOfHour(LocalTime.of(9, 0), Locale.UK) shouldBe "09:00"
+            TimeFormat.TWELVE_HOUR.formatHourMinute(LocalTime.of(19, 5), Locale.US) shouldBe "7:05pm"
+        } finally {
+            Locale.setDefault(Locale.Category.FORMAT, saved)
+        }
+    }
+
+    @Test
     fun `pattern scanner ignores 12h field characters inside single-quoted literals`() {
         // fr_CA: "HH 'h' mm" — the quoted 'h' is the French separator, not an
         // hour field. Misclassifying it as 12h flips the Auto picker to AM/PM

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/DeriveInsightHistoricYesterdayTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/DeriveInsightHistoricYesterdayTest.kt
@@ -1,7 +1,9 @@
 package app.clothescast.core.domain.usecase
 
 import app.clothescast.core.domain.model.CalendarEvent
+import app.clothescast.core.domain.model.ClothesMentionMode
 import app.clothescast.core.domain.model.ClothesRule
+import app.clothescast.core.domain.model.Garment
 import app.clothescast.core.domain.model.DailyForecast
 import app.clothescast.core.domain.model.DailyHistoryEntry
 import app.clothescast.core.domain.model.DeliveryMode
@@ -118,6 +120,36 @@ class DeriveInsightHistoricYesterdayTest {
         result.insight.summary.delta.shouldNotBeNull()
         result.insight.summary.delta!!.degrees shouldBe 4
         result.insight.summary.delta!!.direction shouldBe DeltaClause.Direction.WARMER
+    }
+
+    @Test
+    fun `IF_CHANGED compares against the historic yesterday, not the hindcast`() {
+        // Sweater below 16° feels-like. Today (12..22) fires it. The bogus
+        // hindcast (14..18) would also fire it — making today read as
+        // "unchanged" and suppressing the clothes clause. But the day we
+        // actually delivered was warm (18..28): the user was told the t-shirt
+        // baseline, so today's sweater IS a change and must be named.
+        val sweaterRule = ClothesRule(
+            item = Garment.SWEATER,
+            condition = ClothesRule.TemperatureBelow(16.0),
+        )
+        val ifChangedPrefs = prefs.copy(
+            clothesRules = listOf(sweaterRule),
+            clothesMentionMode = ClothesMentionMode.IF_CHANGED,
+        )
+        val warmDelivered = DailyHistoryEntry(
+            date = LocalDate.of(2026, 5, 23),
+            feelsLikeMinC = 18.0,
+            feelsLikeMaxC = 28.0,
+        )
+
+        val withOverride = DeriveInsight()(snapshot(warmDelivered), ifChangedPrefs)
+        val withoutOverride = DeriveInsight()(snapshot(historic = null), ifChangedPrefs)
+
+        // Hindcast comparison: sweater "fired" yesterday too → suppressed.
+        withoutOverride.insight.summary.clothes.shouldBeNull()
+        // Historic comparison: yesterday was the baseline outfit → named.
+        withOverride.insight.summary.clothes.shouldNotBeNull()
     }
 
     @Test

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsightTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/GenerateDailyInsightTest.kt
@@ -1827,6 +1827,42 @@ class GenerateDailyInsightTest {
     }
 
     @Test
+    fun `tonight window set after midnight stays bounded by the morning`() = runTest {
+        // A night-owl tonight time of 00:30 puts the whole window on the same
+        // calendar day — [00:30, 07:00) — so the slice must stop at the
+        // morning boundary instead of running through tomorrow afternoon
+        // (which would let a warm daytime high masquerade as the night's max
+        // and suppress the jacket the pre-dawn hours warrant).
+        val todayHourly = listOf(
+            HourlyForecast(LocalTime.of(1, 0), 8.0, 6.0, 5.0, WeatherCondition.CLEAR),
+            HourlyForecast(LocalTime.of(4, 0), 6.0, 4.0, 5.0, WeatherCondition.CLEAR),
+            // Past the default 07:00 morning end — tomorrow's daytime, not tonight.
+            HourlyForecast(LocalTime.of(12, 0), 24.0, 24.0, 5.0, WeatherCondition.CLEAR),
+            HourlyForecast(LocalTime.of(15, 0), 28.0, 28.0, 5.0, WeatherCondition.CLEAR),
+        )
+        val todayWithHourly = today.copy(hourly = todayHourly)
+        val weather = FakeWeatherRepository(ForecastBundle(todayWithHourly, yesterday))
+        val subject = GenerateDailyInsight(weather, clock = clock)
+        val nightOwlPrefs = prefs.copy(
+            tonightSchedule = Schedule(
+                time = LocalTime.of(0, 30),
+                days = Schedule.EVERY_DAY,
+                zoneId = ZoneOffset.UTC,
+            ),
+        )
+
+        val result = subject(london, nightOwlPrefs, ForecastPeriod.TONIGHT)
+
+        result.insight.hourly.map { it.time } shouldBe listOf(
+            LocalTime.of(1, 0),
+            LocalTime.of(4, 0),
+        )
+        // Aggregates come from the pre-dawn hours only — a cold night, not
+        // the following afternoon's 28°.
+        result.insight.summary.band.high shouldBe TemperatureBand.COLD
+    }
+
+    @Test
     fun `today period populates nextOutfit from the overnight slice when hourly carries tonight hours`() = runTest {
         val todayHourly = listOf(
             HourlyForecast(LocalTime.of(8, 0), 22.0, 22.0, 5.0, WeatherCondition.CLEAR),

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/RenderInsightSummaryTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/RenderInsightSummaryTest.kt
@@ -307,7 +307,7 @@ class RenderInsightSummaryTest {
     }
 
     @Test
-    fun `precip clause emits with peak hour and condition when chance is at least 30 percent`() {
+    fun `precip clause emits with peak hour and condition when chance clears the rain bar`() {
         val today = mildToday.copy(
             precipitationProbabilityMaxPct = 60.0,
             condition = WeatherCondition.RAIN,

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/ThemeForTodayTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/ThemeForTodayTest.kt
@@ -284,6 +284,32 @@ class ThemeForTodayTest {
     }
 
     @Test
+    fun `funny-only curated date doesn't suppress a real calendar holiday`() {
+        // 2026-05-25's only catalog entry for this user is Towel Day (the
+        // FUNNY bucket) — their own country has no curated entry that day,
+        // but their holiday calendar carries a real public holiday. A joke
+        // observance isn't a duplicate of a national holiday, so the
+        // calendar fallback must fire and join the Towel Day clause
+        // instead of being silenced by it.
+        val theme = subject.resolve(
+            date = LocalDate.of(2026, Month.MAY, 25),
+            overrides = noOverrides,
+            enabledCountries = setOf(HolidayCatalog.FUNNY),
+            events = listOf(publicHoliday("National Day")),
+            themeFromCalendarHolidays = true,
+            themeFromCalendarBirthdays = false,
+        )
+        theme.shouldNotBeNull()
+        // Colours come from the Funny theme; banner leads with the real
+        // holiday and ends with the funny join clause.
+        theme.id shouldBe HolidayId.TOWEL_DAY
+        val segments = theme.bannerSegments
+        segments.shouldNotBeNull()
+        segments[0].literalText shouldBe "National Day"
+        segments[1].textKey shouldBe "holiday_banner_join_towel_day"
+    }
+
+    @Test
     fun `solemn day suppresses the Towel Day clause on a collision`() {
         // Same date, but a US user: Memorial Day is solemn, so Towel Day is
         // dropped entirely — no playful clause beside "Honoring our fallen".

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -130,6 +130,8 @@ ktor-client-logging = { group = "io.ktor", name = "ktor-client-logging", version
 ktor-client-mock = { group = "io.ktor", name = "ktor-client-mock", version.ref = "ktor" }
 ktor-serialization-kotlinx-json = { group = "io.ktor", name = "ktor-serialization-kotlinx-json", version.ref = "ktor" }
 ktor-server-cio = { group = "io.ktor", name = "ktor-server-cio", version.ref = "ktor" }
+ktor-server-partial-content = { group = "io.ktor", name = "ktor-server-partial-content", version.ref = "ktor" }
+ktor-server-auto-head-response = { group = "io.ktor", name = "ktor-server-auto-head-response", version.ref = "ktor" }
 zxing-core = { group = "com.google.zxing", name = "core", version.ref = "zxing" }
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "serialization" }
 


### PR DESCRIPTION
## Scope

A systematic bug hunt across all three modules (five parallel review passes: domain, data, UI/viewmodels, networking/cast/TTS, alarms/work/widgets), with every finding verified against the code before fixing. 16 commits, each a self-contained fix with tests where the surface is unit-testable.

## Fixes

**Insight / domain correctness**
- **Joke days no longer silence real holidays** — `hasCatalogMatch` counted FUNNY-bucket entries as an eligible catalog opinion, so a calendar public holiday on Talk Like a Pirate Day / Towel Day was dropped instead of joining the banner. GLOBAL entries still dedupe (a Google "Christmas Day" event must not double curated Christmas).
- **`IF_CHANGED` clothes mention compared against the wrong yesterday** — it evaluated yesterday's outfit from the Open-Meteo hindcast, bypassing the historic-yesterday correction the delta clause already uses; a missed-warm-day hindcast suppressed today's genuine outfit change as "unchanged".
- **After-midnight tonight schedules got a day-long "night"** — `slicedForTonight` never truncated the same-day window at the morning boundary, so a 00:30 tonight time aggregated the whole following afternoon into "Tonight" (28° daytime high read as a hot night, jacket suppressed).
- **Clock digits followed the device default locale, not the passed one** — `%d` via localeless `String.format` leaked e.g. Persian digit shapes into English-formatted times.

**Data layer**
- **The "Auto" line now spans the Overnight chart** — best_match's per-model series was filtered to start at today while every consulted model reaches back to yesterday evening (both calls fetch `past_days=1`); the filter predates the past_days fix and its justifying comment was no longer true.
- **One malformed hourly timestamp no longer voids the whole 14-day forecast** — the mapper now drops the bad hour, matching the two sibling parsers' policy.
- **Bare `fr`/`es` TTS directives added** — devices set to fr, fr-CH, fr-BE, es, es-AR, es-US got no language steering in the forecaster style while fr-FR/fr-CA/es-ES/es-MX did; both directive tables now have the language-only fallbacks every comparable language already had.

**UI state**
- **Schedule page first-frame showed the morning switch ON** — `SettingsState.dailyEnabled` still defaulted to true from before the opt-in migration.
- **The schedule promo card now hides once a slot is enabled** — the implementation checked only the dismissal flag, contradicting its own KDoc and the banner-stack contract; the play-promo KDoc's stale "morning slot is on by default" premise is also corrected.
- **Legend chips only appear for models actually drawn** — the legends mirrored only half of the charts' visibility filter (missing the in-window check); charts and legends now share one helper (`visibleSpreadModelIds`) so they can't drift.

**Cast / TTS runtime**
- **Range + HEAD support on the cast media server** (`PartialContent` / `AutoHeadResponse`, two new Ktor artifacts) — receivers probe the MP4 tail for the moov atom (MediaMuxer writes it after mdat), and without 206s every probe re-downloaded the file from byte 0: slow starts at best, failed loads on stricter firmware at worst (matches the "load accepted but never plays" bucket). The buffer is served as `ReadChannelContent` because `PartialContent` only range-slices channel-backed content — a plain `respondBytes` opts out silently (the first CI run caught exactly that). HEAD probes deliberately don't complete the fetch confirmation — no media bytes cross on them.
- **"Cast now" no longer blocks the main thread** on the server's socket bind.
- **The minimum-duration WAV pad refuses non-mono input** instead of silently re-wrapping stereo in a mono header (half-speed, corrupted interleave) — a landmine today, since all current producers are mono.
- **Bounded the AudioTrack end-of-playback wait** — the marker is a known-flaky Android spot, and an unbounded wait pinned the delivery worker until WorkManager's kill (or hung the voice preview).
- **Fixed an unsynchronized cross-thread read in TTS engine init** that could NPE inside a main-thread callback and crash the process.

**Background work / caches**
- **Overnight redeliveries no longer skip the sibling MQTT publish** — the cache-hit guard expected the tonight sibling on tomorrow's date, but the post-midnight overnight pairs with *today's* daytime.
- **Device-location users no longer silently skip every next-window publish** — the sibling guard used `Location` data-class equality, which a GPS fix a few meters off always fails; now a 25 km same-place proximity check (the label-reuse radius).
- **Play button can't surface a false refresh error** — the play path's cache read + derive ran outside any try, so a corrupted DataStore escaped as an unstamped worker failure; it now degrades to a fresh fetch / logged no-op per the Play contract.
- **Google forecast cache merge is transactional** — read-merge-write in one `edit` so overlapping refreshes can't drop the retained morning hours.

**Tests that never ran**
- **Five existing tests were being silently skipped by JUnit** — their `runBlocking` bodies end in a value-returning kotest `shouldBe`, so the `@Test` method returns Boolean and JUnit 5 refuses to execute it (a discovery-log warning nobody sees). Four `CastMediaServerTest` fetch-confirmation tests and `HolidayThemeResolverTest`'s birthday test now pin `runBlocking<Unit>` and actually run.
- Two silent exception swallows (OEM `isProviderEnabled` throw, conditions-widget render failure) now log per the repo's error-handling rules; a few stale comments and a misnamed test corrected.

## Verified findings deliberately NOT fixed (for your call)

- **The "Average" line can render outside the min–max band** when the Auto pick is an outlier: the band deliberately excludes best_match (`TODO(range-band)` defers including it) while the mean includes it, matching the domain blend's equal-weight posture. Both sides are internally consistent; picking one is the open product decision the TODO reserves, so this PR only documents the tension in `consensusRainfallMainLine`'s KDoc. Recommendation: include Auto in the band — it guarantees the mean stays inside and matches what's drawn.
- **Notification id 1005 FGS race** — `ScheduledDeliveryService` and WorkManager's `SystemForegroundService` can both claim id 1005 when the worker dispatches before `enterForeground` stamps the work id (the promote gate is check-once); the loser can strip the other's mandatory FGS notification mid-run. Likely the "notification disappears" symptom `logActiveAppNotifications` chases. Needs an on-device-verified redesign (distinct ids, or gating the worker's promote on a state that can't race), not a blind patch.
- **Replace-shepherd stranding** — in `ScheduledDeliveryService`'s different-workId branch, a `startForeground` failure after the old watcher is cancelled leaves the stale FGS notification with no watcher and no timeout. Narrow input; same on-device caveat.
- **GLOBAL-bucket date collisions** still suppress calendar holidays (e.g. Reformationstag under catalog Halloween) — inherent to date-keyed dedupe; fixing it risks the Christmas double-up the dedupe exists for.

## Privacy

No change to what leaves the device. The TTS directive additions alter only the fixed instruction prefix sent to Gemini (BYOK) for locales that already sent the prose; MQTT/cast fixes change *when* existing payloads publish, not their contents; the new HEAD/Range handling serves the same token-gated LAN media.

## Test plan

- `:core:domain:test` + `:core:data:test` pass locally (inner build) with new regression tests for the holiday join, IF_CHANGED historic comparison, after-midnight tonight window, locale digits, Auto-line yesterday coverage, malformed-timestamp tolerance, and fr/es directives.
- `CastMediaServerTest` gains Range-206 and HEAD-without-fetch-confirmation tests; the first CI run's failure (200 instead of 206) exposed the `ByteArrayContent` bypass and is fixed by the `ReadChannelContent` wrapper.
- **Sandbox caveat:** the outer Gradle 9.4.1 distribution download is blocked by the sandbox egress policy (it redirects to github.com release assets → 403), and AGP 9.2.1 needs Gradle 9.x, so `:app:testDebugUnitTest` / `:app:assembleDebug` did **not** run locally — core suites ran on the pre-installed Gradle 8.14.3 via the inner build. CI is the validation surface for `:app` (worker, cast, UI, widget changes). Flagging per AGENTS.md: the allowlist covers Google Maven but not the Gradle distribution mirror on github.com.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PVwyr1MBxVrtmxkM4nwKSy