### PR TITLE
Fix home-screen widgets stuck showing no forecast

### DIFF
--- a/app/src/main/kotlin/app/clothescast/MainActivity.kt
+++ b/app/src/main/kotlin/app/clothescast/MainActivity.kt
@@ -188,23 +188,28 @@ class MainActivity : ComponentActivity() {
 
     override fun onStart() {
         super.onStart()
-        // Opportunistic refresh: when the user opens the app to a cached
-        // insight that's gone stale (>= SILENT_REFRESH_MIN_AGE since the
-        // last fetch), kick a silent background fetch so the screen
-        // re-renders off fresh data without waiting for the next scheduled
-        // alarm. The worker picks the period itself based on the user's
-        // schedule + wall-clock time (see [FetchAndNotifyWorker.currentPeriodForSchedule]),
-        // so a cache stuck in the wrong window after a missed alarm gets
-        // corrected on the next open. KEEP-deduped on the worker side, so
-        // the per-recreate onStart fires (config changes, returning from a
-        // permission dialog) coalesce into the one in-flight run.
+        // Opportunistic refresh: when the user opens the app to an empty cache
+        // or a cached insight that's gone stale (>= SILENT_REFRESH_MIN_AGE since
+        // the last fetch), kick a silent background fetch so the screen (and any
+        // home-screen widget) re-renders off fresh data without waiting for the
+        // next scheduled alarm. The empty-cache case matters now that onboarding
+        // is gone and both delivery slots are opt-in — otherwise a fresh install
+        // that never enabled notifications would sit on "No forecast yet" until
+        // the user found the manual Refresh. The worker picks the period itself
+        // based on the user's schedule + wall-clock time (see
+        // [FetchAndNotifyWorker.currentPeriodForSchedule]), so a cache stuck in
+        // the wrong window after a missed alarm gets corrected on the next open.
+        // REPLACE-deduped on the worker side, so the per-recreate onStart fires
+        // (config changes, returning from a permission dialog) coalesce into a
+        // single trailing run and can't be swallowed by an earlier one stuck in
+        // retry-backoff.
         val app = application as ClothesCastApplication
         lifecycleScope.launch {
             val snapshot = runCatching { app.insightCache.thisPeriod.first() }
                 .getOrElse {
                     DiagLog.w(TAG, "App-open freshness check failed; skipping silent refresh.", it)
                     return@launch
-                } ?: return@launch
+                }
             if (!FetchAndNotifyWorker.shouldSilentlyRefresh(snapshot, Instant.now())) return@launch
             FetchAndNotifyWorker.enqueueSilentRefresh(applicationContext)
         }

--- a/app/src/main/kotlin/app/clothescast/widget/WidgetInsightLoader.kt
+++ b/app/src/main/kotlin/app/clothescast/widget/WidgetInsightLoader.kt
@@ -45,7 +45,14 @@ internal suspend fun loadCurrentInsight(context: Context): Pair<Insight, UserPre
         .onFailure { DiagLog.w(TAG, "Widget: reading cached snapshot failed", it) }
         .getOrNull()
     if (snapshot == null) {
-        DiagLog.i(TAG, "Widget: no cached forecast yet — showing empty state")
+        // Nothing cached yet — a freshly placed widget on a fresh install, or a
+        // cache that never filled because both delivery slots are opt-in and the
+        // user hasn't opened the app / tapped Refresh. Show the empty state, but
+        // kick a silent refresh so the widget self-heals once the fetch lands
+        // (the worker's cache write fires updateAll). Deduped REPLACE, so repeat
+        // repaints coalesce onto one in-flight run.
+        DiagLog.i(TAG, "Widget: no cached forecast yet — showing empty state and kicking a silent refresh")
+        FetchAndNotifyWorker.enqueueSilentRefresh(context)
         return null
     }
     val insight = runCatching { app.deriveInsight(snapshot, prefs).insight }

--- a/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
@@ -2030,8 +2030,11 @@ class FetchAndNotifyWorker(
         const val UNIQUE_WORK_NAME_LOCATION_CACHE = "location_cache_refresh"
         // Distinct queue from the alarm-driven daily / tonight runs so a
         // silent app-open refresh in flight doesn't get cancelled by an
-        // alarm fire (and vice versa). KEEP-deduped so config-change
-        // re-triggers on app open coalesce into the one in-flight worker.
+        // alarm fire (and vice versa). REPLACE-deduped within the queue so a
+        // fresh app-open / widget self-heal kick supersedes any earlier silent
+        // refresh — including one stuck in retry-backoff after a transient
+        // failure, which KEEP would let swallow every later kick (the widget
+        // then stays on its empty state and re-opening the app can't fix it).
         const val UNIQUE_WORK_NAME_SILENT = "silent_insight_refresh"
         // Distinct queue from the daily / tonight runs so an offline Play
         // tap sitting in the queue can't block the morning alarm: alarm
@@ -2401,12 +2404,25 @@ class FetchAndNotifyWorker(
         }
 
         /**
-         * Opportunistic refresh fired on app open when the cached insight is
-         * older than [SILENT_REFRESH_MIN_AGE]. Runs the full fetch + cache
-         * pipeline but skips notification, TTS, MQTT, and cast — the Today
-         * screen re-renders silently when the new snapshot lands in
-         * [InsightCache.thisPeriod]. KEEP so config-change retriggers on the
-         * same app-open coalesce into the one in-flight run.
+         * Opportunistic refresh fired on app open (and by a home-screen widget
+         * that has nothing current to show) when the cache is empty or its
+         * snapshot is older than [SILENT_REFRESH_MIN_AGE]. Runs the full fetch +
+         * cache pipeline but skips notification, TTS, MQTT, and cast — the Today
+         * screen and widgets re-render silently when the new snapshot lands in
+         * [InsightCache.thisPeriod].
+         *
+         * REPLACE, not KEEP: the newest kick always wins. A prior silent refresh
+         * that returned [Result.retry] (e.g. a transient device-location read)
+         * sits ENQUEUED through WorkManager's exponential backoff, and under KEEP
+         * every later kick — the user re-opening the app to fix a blank widget
+         * included — would be dropped until that backoff run finally completed,
+         * so the widget stayed stuck on its empty state. REPLACE cancels the
+         * stuck run and starts a fresh attempt immediately (the same reason the
+         * alarm / manual-Refresh queue uses REPLACE — see [enqueueOneShot]).
+         * Kicks are event-paced (app open, widget repaint), not a tight loop, so
+         * cancel-and-restart doesn't thrash; a burst from one `updateAll` still
+         * collapses to a single trailing run. The queue is still distinct from
+         * the alarm / play queues, so this only supersedes other silent runs.
          *
          * The period is resolved inside the worker via [currentPeriodForSchedule]
          * so we refresh whichever window the user is *currently* in — not
@@ -2432,21 +2448,27 @@ class FetchAndNotifyWorker(
             WorkManager.getInstance(context)
                 .enqueueUniqueWork(
                     UNIQUE_WORK_NAME_SILENT,
-                    ExistingWorkPolicy.KEEP,
+                    ExistingWorkPolicy.REPLACE,
                     request,
                 )
         }
 
         /**
-         * App-open freshness predicate: true when [snapshot] is non-null and
-         * its [ForecastSnapshot.generatedAt] is at least [SILENT_REFRESH_MIN_AGE]
-         * before [now]. Null snapshot returns false — the app hasn't
-         * successfully fetched yet, so there's nothing user-visible to
-         * silently replace (the alarm or onboarding flow drives the first
-         * fetch).
+         * App-open freshness predicate: true when there's nothing cached yet, or
+         * the cached [snapshot]'s [ForecastSnapshot.generatedAt] is at least
+         * [SILENT_REFRESH_MIN_AGE] before [now].
+         *
+         * Null snapshot returns *true* — the app has no forecast to show, so an
+         * open should populate one. (This used to fail closed, deferring the
+         * first fetch to onboarding or a scheduled alarm; onboarding has since
+         * been removed and both delivery slots are opt-in, so nothing else
+         * drives that first fetch — a fresh install with a widget placed but
+         * notifications off would otherwise never fill the cache just by opening
+         * the app.) A brand-new snapshot (under the threshold) still stays put so
+         * routine re-opens don't burn Open-Meteo calls.
          */
         fun shouldSilentlyRefresh(snapshot: ForecastSnapshot?, now: Instant): Boolean {
-            if (snapshot == null) return false
+            if (snapshot == null) return true
             return Duration.between(snapshot.generatedAt, now) >= SILENT_REFRESH_MIN_AGE
         }
 

--- a/app/src/test/kotlin/app/clothescast/work/FetchAndNotifyWorkerTest.kt
+++ b/app/src/test/kotlin/app/clothescast/work/FetchAndNotifyWorkerTest.kt
@@ -4,8 +4,12 @@ import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.work.Configuration
+import androidx.work.Constraints
 import androidx.work.Data
+import androidx.work.ExistingWorkPolicy
 import androidx.work.ListenableWorker.Result
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import androidx.work.testing.SynchronousExecutor
@@ -357,6 +361,33 @@ class FetchAndNotifyWorkerTest {
 
         workInfosFor(FetchAndNotifyWorker.UNIQUE_WORK_NAME_SILENT).map { it.state } shouldContainExactlyInAnyOrder
             listOf(WorkInfo.State.ENQUEUED)
+    }
+
+    @Test
+    fun `enqueueSilentRefresh supersedes an in-flight silent refresh instead of coalescing into it`() {
+        // Convergence guarantee: a fresh app-open / widget self-heal kick must
+        // REPLACE any earlier silent refresh, including one WorkManager is
+        // holding ENQUEUED through retry-backoff after a transient failure.
+        // Under the old KEEP policy that stuck run swallowed every later kick,
+        // so re-opening the app couldn't clear a blank widget. Stand in an
+        // earlier run (kept ENQUEUED by the CONNECTED constraint) and assert the
+        // next enqueue cancels it rather than being dropped.
+        val stuck = OneTimeWorkRequestBuilder<FetchAndNotifyWorker>()
+            .setConstraints(Constraints.Builder().setRequiredNetworkType(NetworkType.CONNECTED).build())
+            .setInputData(workDataOf(FetchAndNotifyWorker.KEY_SILENT_REFRESH to true))
+            .build()
+        WorkManager.getInstance(context).enqueueUniqueWork(
+            FetchAndNotifyWorker.UNIQUE_WORK_NAME_SILENT,
+            ExistingWorkPolicy.REPLACE,
+            stuck,
+        )
+
+        FetchAndNotifyWorker.enqueueSilentRefresh(context)
+
+        WorkManager.getInstance(context).getWorkInfoById(stuck.id).get()!!.state shouldBe WorkInfo.State.CANCELLED
+        workInfosFor(FetchAndNotifyWorker.UNIQUE_WORK_NAME_SILENT).count {
+            it.state == WorkInfo.State.ENQUEUED
+        } shouldBe 1
     }
 
     @Test

--- a/app/src/test/kotlin/app/clothescast/work/SilentRefreshFreshnessTest.kt
+++ b/app/src/test/kotlin/app/clothescast/work/SilentRefreshFreshnessTest.kt
@@ -25,11 +25,12 @@ import java.time.ZoneId
 
 /**
  * Drives the app-open opportunistic-refresh decision used by
- * [app.clothescast.MainActivity.onStart]. The predicate has to fail closed in
- * the no-cache case (nothing to silently replace) and only kick a fresh fetch
- * once the stored snapshot's age has crossed the documented threshold —
- * otherwise routine app re-opens would burn Open-Meteo calls (and the
- * Gemini-keyed TTS budget on a forced-refresh equivalent).
+ * [app.clothescast.MainActivity.onStart]. The predicate kicks a fetch when
+ * there's nothing cached yet (a fresh install with notifications opt-out would
+ * otherwise never fill the cache just by opening the app) and once a stored
+ * snapshot's age has crossed the documented threshold — but leaves a
+ * still-fresh snapshot put, so routine app re-opens don't burn Open-Meteo calls
+ * (and the Gemini-keyed TTS budget on a forced-refresh equivalent).
  */
 class SilentRefreshFreshnessTest {
     private val now = Instant.parse("2026-04-25T09:00:00Z")
@@ -61,8 +62,10 @@ class SilentRefreshFreshnessTest {
     )
 
     @Test
-    fun `null snapshot does not trigger a silent refresh`() {
-        FetchAndNotifyWorker.shouldSilentlyRefresh(snapshot = null, now = now) shouldBe false
+    fun `null snapshot triggers a silent refresh to populate the empty cache`() {
+        // Onboarding is gone and both delivery slots are opt-in, so opening the
+        // app (or placing a widget) is the only thing that fills a fresh cache.
+        FetchAndNotifyWorker.shouldSilentlyRefresh(snapshot = null, now = now) shouldBe true
     }
 
     @Test


### PR DESCRIPTION
## What & why

The outfit and conditions widgets showed **"No outfit yet" / "No forecast yet"** while the app itself displayed the correct current-period forecast, and re-opening the app (or tapping the widget) didn't clear it.

Both widgets share `loadCurrentInsight`, which shows the empty state and relies on a background *silent refresh* to self-heal. Three gaps let that empty state get **stuck**:

1. **Stuck-run swallow (the "opening doesn't fix it" case).** The silent-refresh queue used `ExistingWorkPolicy.KEEP`. Once a silent refresh returned `Result.retry()` (e.g. a transient device-location read) it sat ENQUEUED through WorkManager's exponential backoff, and under KEEP **every later kick — including re-opening the app to fix a blank widget — was dropped** until that backoff run finished. The widget then stayed blank indefinitely.
2. **Empty cache never refreshed on app open.** `shouldSilentlyRefresh` returned `false` for a null snapshot, deferring the first fetch to onboarding or a scheduled alarm. Onboarding was removed and both delivery slots are now opt-in, so **nothing drove that first fetch** — a fresh install with a widget placed but notifications off never filled the cache just by opening the app.
3. **Empty cache never refreshed on widget placement.** A widget rendering against a null cache just showed the empty state without kicking anything.

## The fix

- **Silent-refresh queue: `KEEP` → `REPLACE`** so the newest app-open / widget kick supersedes a stuck run and converges (the same reasoning the alarm / manual-Refresh queue already uses). Kicks are event-paced, so cancel-and-restart doesn't thrash and a burst from one `updateAll` still collapses to a single trailing run. The queue stays distinct from the alarm / play queues, so this only supersedes other *silent* runs.
- **App open refreshes an empty cache** — `shouldSilentlyRefresh(null)` now returns `true`, and `MainActivity.onStart` no longer bails before the check.
- **Widget placement/render on an empty cache** kicks a silent refresh, so a freshly placed widget self-heals once the fetch lands (the worker's cache write fires `updateAll`).

The feels-like **chart** widgets deliberately keep blanking on a genuinely stale snapshot (their date axis is misleading when stale, per the commit that introduced the gate). This change only affects *when and how reliably* the self-heal fetch fires — not the stale-vs-blank decision.

## Privacy

No change to what crosses the device boundary. Same Open-Meteo / location refresh path as before; this only changes the WorkManager dedup policy and adds two triggers for the *existing* silent refresh. No new payloads, no new fields.

## Test plan

- `SilentRefreshFreshnessTest` — a null cache now triggers a refresh (was: stays put); freshness-threshold cases unchanged.
- `FetchAndNotifyWorkerTest` — new case asserts a fresh `enqueueSilentRefresh` **cancels** an in-flight silent run (REPLACE) rather than being coalesced away (KEEP).
- **Sandbox caveat:** `:app:testDebugUnitTest` / `:app:assembleDebug` could not run locally — the pinned Gradle 9.4.1 distribution download is blocked by the egress policy (403 via github.com), same gap noted on recent PRs, and AGP requires Gradle 9.x. All changed code is in `:app`, so **CI is the validation surface** for the build and these tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01M1EAFtjcqb6Uo1NwY9p8BQ)_