### PR TITLE
test: fix silent-refresh REPLACE assertion that NPE'd on a deleted WorkInfo

### DIFF
--- a/app/src/test/kotlin/app/clothescast/work/FetchAndNotifyWorkerTest.kt
+++ b/app/src/test/kotlin/app/clothescast/work/FetchAndNotifyWorkerTest.kt
@@ -384,10 +384,15 @@ class FetchAndNotifyWorkerTest {
 
         FetchAndNotifyWorker.enqueueSilentRefresh(context)
 
-        WorkManager.getInstance(context).getWorkInfoById(stuck.id).get()!!.state shouldBe WorkInfo.State.CANCELLED
-        workInfosFor(FetchAndNotifyWorker.UNIQUE_WORK_NAME_SILENT).count {
-            it.state == WorkInfo.State.ENQUEUED
-        } shouldBe 1
+        // REPLACE deletes the superseded request outright (so querying it by id
+        // can come back null), so assert on the queue instead: exactly one run
+        // is ENQUEUED and it is no longer the earlier `stuck` request. Under the
+        // old KEEP the second enqueue would have been dropped and `stuck` would
+        // still be the one ENQUEUED.
+        val enqueued = workInfosFor(FetchAndNotifyWorker.UNIQUE_WORK_NAME_SILENT)
+            .filter { it.state == WorkInfo.State.ENQUEUED }
+        enqueued shouldHaveSize 1
+        (enqueued.single().id == stuck.id) shouldBe false
     }
 
     @Test


### PR DESCRIPTION
## What & why

Follow-up to #1093 (merged). That PR's regression test — `enqueueSilentRefresh supersedes an in-flight silent refresh instead of coalescing into it` — **failed on `main`** with a `NullPointerException` at `FetchAndNotifyWorkerTest.kt:387`:

```
FetchAndNotifyWorkerTest > enqueueSilentRefresh supersedes an in-flight silent refresh
  instead of coalescing into it FAILED
    java.lang.NullPointerException
        at ...FetchAndNotifyWorkerTest.kt:387
```

The test asserted the superseded run reached `WorkInfo.State.CANCELLED` via `getWorkInfoById(stuck.id)`. But `ExistingWorkPolicy.REPLACE` **deletes** the old request outright rather than keeping it as a cancelled row, so `getWorkInfoById` returned `null` and the `!!`-deref threw.

## The fix

Assert on the queue instead of the deleted request: after the second enqueue, exactly one run is `ENQUEUED` and its id is no longer the earlier request's. That still fails under the old `KEEP` policy (where the second enqueue is dropped and the first stays `ENQUEUED`), so it keeps its regression value — while surviving `REPLACE`'s delete-the-old behavior.

**Test-only.** The production `KEEP → REPLACE` change from #1093 is unchanged; this only corrects how the test observes it.

## Privacy

No change to what crosses the device boundary — test source only.

## Test plan

- `FetchAndNotifyWorkerTest` — the `supersedes an in-flight silent refresh` case now asserts via `getWorkInfosForUniqueWork` (one `ENQUEUED`, id ≠ the superseded request) instead of dereferencing a deleted `WorkInfo`.
- **Sandbox caveat:** `:app:testDebugUnitTest` can't run locally (Gradle 9.4.1 distribution blocked by egress policy; AGP needs Gradle 9.x) — CI is the validation surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01M1EAFtjcqb6Uo1NwY9p8BQ)_