### PR TITLE
Fix nine bugs found in a codebase-wide bug hunt

### DIFF
--- a/app/src/main/kotlin/app/clothescast/cast/CastInsightController.kt
+++ b/app/src/main/kotlin/app/clothescast/cast/CastInsightController.kt
@@ -11,6 +11,7 @@ import app.clothescast.core.domain.model.TtsStyle
 import app.clothescast.diag.DiagLog
 import app.clothescast.net.NetworkErrorKind
 import app.clothescast.net.classifyNetworkError
+import app.clothescast.tts.prepareForTts
 import com.google.android.gms.cast.CastMediaControlIntent
 import com.google.android.gms.cast.MediaInfo
 import com.google.android.gms.cast.MediaLoadRequestData
@@ -139,8 +140,13 @@ class CastInsightController(
         // Other synth failures (network, etc.) still surface as a cast error
         // so the user knows audio genuinely broke.
         val pcm = try {
+            // Same spoken-text transform every other speech path applies
+            // (AndroidTtsSpeaker, GeminiTtsSpeaker — see the TtsSpeaker
+            // contract): brand pronounced as two syllables, English degree
+            // glyphs spelled out. Without it the "Cast now" audio diverges
+            // from the scheduled cast it exists to preview.
             ttsClient.synthesize(
-                text = prose,
+                text = prepareForTts(prose, locale),
                 voiceName = voiceName,
                 locale = locale,
                 style = style,

--- a/app/src/main/kotlin/app/clothescast/data/InsightCache.kt
+++ b/app/src/main/kotlin/app/clothescast/data/InsightCache.kt
@@ -176,6 +176,16 @@ class InsightCache(
         today: LocalDate,
         period: ForecastPeriod,
         prefs: UserPreferences,
+        // The caller's window flavor for TONIGHT: true in the post-midnight
+        // tail (the ongoing overnight), false for the coming night. A date +
+        // period match alone can't tell the two apart — both anchor
+        // bundle.today.date on the real current day — and they describe
+        // different nights: a pre-dawn silent refresh leaves an
+        // overnight=true snapshot in THIS_PERIOD, and without this check the
+        // same evening's tonight alarm would dedup against it and redeliver
+        // the night that ended this morning instead of fetching the coming
+        // one.
+        overnight: Boolean = false,
         // Forwarded to [DeriveInsight] so cache-hit deliveries (debug-tap
         // redelivery later in the day, alarm re-fires) emit the same
         // `delta:` diagnostic line a fresh fetch would. The 300-line
@@ -185,7 +195,12 @@ class InsightCache(
         diagLog: (String) -> Unit = {},
     ): DailyInsightResult? {
         val snapshot = thisPeriod.first() ?: return null
-        if (snapshot.bundle.today.date != today || snapshot.period != period) return null
+        if (snapshot.bundle.today.date != today ||
+            snapshot.period != period ||
+            snapshot.overnight != overnight
+        ) {
+            return null
+        }
         return deriveInsight(snapshot, prefs, diagLog = diagLog)
     }
 

--- a/app/src/main/kotlin/app/clothescast/mqtt/MqttPublisher.kt
+++ b/app/src/main/kotlin/app/clothescast/mqtt/MqttPublisher.kt
@@ -858,11 +858,17 @@ class MqttPublisher(
             )
         }
 
+        // ASCII [a-z0-9] only — not isLetterOrDigit, which is Unicode-aware.
+        // The suffix lands in Home Assistant discovery topic segments and
+        // default_entity_id, both of which HA validates as slugs; a base
+        // topic like `wetter/küche` would otherwise pass `ü` through and HA
+        // would reject every discovery config (publishes "succeed", no
+        // entities ever appear).
         private fun discoveryIdSuffix(baseTopic: String): String =
             baseTopic.trim().trim('/')
                 .ifBlank { UserPreferences.DEFAULT_MQTT_TOPIC }
                 .lowercase()
-                .map { if (it.isLetterOrDigit()) it else '_' }
+                .map { if (it in 'a'..'z' || it in '0'..'9') it else '_' }
                 .joinToString("")
                 .replace(Regex("_+"), "_")
                 .trim('_')

--- a/app/src/main/kotlin/app/clothescast/notification/NotificationChannelRegistrar.kt
+++ b/app/src/main/kotlin/app/clothescast/notification/NotificationChannelRegistrar.kt
@@ -31,13 +31,13 @@ internal const val CHANNEL_PLAYBACK = "playback_v2"
 private const val CHANNEL_WEATHER_ALERTS_RETIRED = "weather_alerts_v1"
 // Pre-collapse forecast channels. The three of them — morning (HIGH), evening-
 // with-events (DEFAULT), evening-empty (LOW silent) — were replaced by the
-// single DEFAULT-importance CHANNEL_SCHEDULED_INSIGHT above. The
-// notifyOnlyOnEvents preference now drives "post or don't post" at the worker
-// level, not channel routing, so the silent channel no longer makes sense:
-// the user picked "only on events", so an empty evening should produce no
-// notification, not a quiet one. And both periods at the same DEFAULT
-// importance keeps a night-worker primary tonight slot just as loud as a
-// day-worker primary morning slot.
+// single CHANNEL_SCHEDULED_INSIGHT above (now LOW/silent — see the v1
+// retirement below). The notifyOnlyOnEvents preference now drives "post or
+// don't post" at the worker level, not channel routing, so the silent channel
+// no longer makes sense: the user picked "only on events", so an empty
+// evening should produce no notification, not a quiet one. And both periods
+// at the same importance keeps a night-worker primary tonight slot reading
+// exactly like a day-worker primary morning slot.
 private const val CHANNEL_DAILY_INSIGHT_RETIRED_V1 = "daily_insight_v1"
 // Brief interim ID introduced and immediately collapsed into
 // CHANNEL_SCHEDULED_INSIGHT — retire it too in case any dev / TestFlight build
@@ -80,8 +80,8 @@ object NotificationChannelRegistrar {
         // settings forever.
         //
         // The collapse from three forecast channels into one is a fresh
-        // start: we create the new channel at DEFAULT regardless of what
-        // the user did to the old ones. Trying to migrate the prior opt-out
+        // start: we create the new channel at its own importance (LOW,
+        // below) regardless of what the user did to the old ones. Trying to migrate the prior opt-out
         // state has no clean answer when three channels with different
         // user preferences fold into one — and surprise-muting a user who
         // only silenced (say) the empty-evening silent channel would

--- a/app/src/main/kotlin/app/clothescast/pairing/PairingServer.kt
+++ b/app/src/main/kotlin/app/clothescast/pairing/PairingServer.kt
@@ -129,7 +129,16 @@ class PairingServer(
         // Revoke the token gate first, so no submission arriving after this
         // point can reach [onKeyReceived] — regardless of how long the
         // engine's asynchronous wind-down below takes (or whether it fails).
-        active = false
+        // The revocation takes the same monitor the POST handler holds while
+        // re-checking [active] and invoking the callback: without it, a
+        // submission that passed its re-check could still be running
+        // [onKeyReceived] as stop() returns, and the caller would tear down
+        // pairing state a beat before a key it never expected gets stored.
+        // Under the lock, an in-flight accepted callback finishes before
+        // stop() returns, and any later submission sees active == false.
+        synchronized(this) {
+            active = false
+        }
         val srv = server
         server = null
         // Engine shutdown blocks the calling thread for up to its timeout,

--- a/app/src/main/kotlin/app/clothescast/ui/garment/GarmentRender.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/garment/GarmentRender.kt
@@ -1133,11 +1133,14 @@ private data class ConditionsStripCacheKey(
 )
 
 // Small bound: a placed conditions widget hits a handful of distinct
-// (size, theme, label) tuples across a refresh cycle. Mirrors [bitmapCache].
-private val conditionsStripCache = object : LinkedHashMap<ConditionsStripCacheKey, Bitmap>(16, 0.75f, true) {
-    override fun removeEldestEntry(eldest: Map.Entry<ConditionsStripCacheKey, Bitmap>): Boolean = size > MAX
-    private val MAX = 16
-}
+// (size, theme, label) tuples across a refresh cycle. Mirrors [bitmapCache],
+// including the synchronized wrapper — see the note there.
+private val conditionsStripCache: MutableMap<ConditionsStripCacheKey, Bitmap> = java.util.Collections.synchronizedMap(
+    object : LinkedHashMap<ConditionsStripCacheKey, Bitmap>(16, 0.75f, true) {
+        override fun removeEldestEntry(eldest: Map.Entry<ConditionsStripCacheKey, Bitmap>): Boolean = size > MAX
+        private val MAX = 16
+    },
+)
 
 // Geometry of the conditions strip, expressed as fractions of the render
 // height so the layout scales cleanly with the widget cell.
@@ -1271,11 +1274,20 @@ private const val INFO_BOTTOM_PAD = 60
  * a couple of size variants, so a small bound covers the realistic working
  * set without holding onto stale bitmaps after a colour change. Customising
  * a colour invalidates only that garment's entry (different cache key).
+ *
+ * Synchronized because the renderers run on several threads at once — the
+ * main thread (Today screen, MQTT publish), WorkManager workers (the
+ * notification's large icon), and Glance widget composition — and an
+ * access-ordered LinkedHashMap structurally mutates its linked list on every
+ * get(), so even concurrent reads corrupt it. Worst case under the lock is a
+ * duplicate render when two threads miss the same key, which is harmless.
  */
-private val bitmapCache = object : LinkedHashMap<BitmapCacheKey, Bitmap>(16, 0.75f, true) {
-    override fun removeEldestEntry(eldest: Map.Entry<BitmapCacheKey, Bitmap>): Boolean = size > MAX
-    private val MAX = 32
-}
+private val bitmapCache: MutableMap<BitmapCacheKey, Bitmap> = java.util.Collections.synchronizedMap(
+    object : LinkedHashMap<BitmapCacheKey, Bitmap>(16, 0.75f, true) {
+        override fun removeEldestEntry(eldest: Map.Entry<BitmapCacheKey, Bitmap>): Boolean = size > MAX
+        private val MAX = 32
+    },
+)
 
 /**
  * Builds the original-ARGB → new-ARGB substitution map for one garment.

--- a/app/src/main/kotlin/app/clothescast/ui/pairing/PairingScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/pairing/PairingScreen.kt
@@ -36,6 +36,7 @@ import kotlinx.coroutines.delay
  * by scanning a QR code.
  *
  * States:
+ *  - **Starting**: server bind in flight (first frames / after retry); plain progress.
  *  - **Waiting**: shows QR code + "scan with your phone" instructions.
  *  - **Received**: shows a brief success message, then calls [onSuccess] after a short delay.
  *  - **Timeout**: the 5-minute window expired; offers retry or cancel.
@@ -58,6 +59,7 @@ fun PairingScreen(
             contentAlignment = Alignment.Center,
         ) {
             when (val s = state) {
+                PairingState.Starting -> CircularProgressIndicator()
                 is PairingState.Waiting -> WaitingContent(
                     state = s,
                     onCancel = onCancel,

--- a/app/src/main/kotlin/app/clothescast/ui/pairing/PairingViewModel.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/pairing/PairingViewModel.kt
@@ -30,6 +30,15 @@ private const val PAIRING_TIMEOUT_MS = 5 * 60 * 1_000L
 private const val QR_SIZE_PX = 512
 
 sealed interface PairingState {
+    /**
+     * The LAN-address lookup and server bind are still in flight — the
+     * screen's first frames, and again briefly after a retry. Rendered as
+     * plain progress; without this state the screen initialized to [Error]
+     * and flashed "couldn't start" (with a live Retry button that could
+     * spawn a competing second start) for the duration of every bind.
+     */
+    data object Starting : PairingState
+
     /** Server is running and waiting for the phone to POST the key. */
     data class Waiting(val qrBitmap: Bitmap, val url: String) : PairingState
 
@@ -62,7 +71,7 @@ class PairingViewModel(
     private val settingsRepository: SettingsRepository,
 ) : ViewModel() {
 
-    private val _state = MutableStateFlow<PairingState>(PairingState.Error)
+    private val _state = MutableStateFlow<PairingState>(PairingState.Starting)
     val state: StateFlow<PairingState> = _state.asStateFlow()
 
     private var server: PairingServer? = null
@@ -79,6 +88,10 @@ class PairingViewModel(
     }
 
     private fun startPairing() {
+        // Retry arrives from the Timeout / Error screens — flip back to
+        // progress so the stale terminal UI (and its Retry button) doesn't
+        // linger while the new server binds.
+        _state.value = PairingState.Starting
         // Tracked so [stopServer] can cancel a start still suspended in
         // srv.start(): at that point [server] is unassigned, so without the
         // job cancel a retry would race the pending launch — the old

--- a/app/src/main/kotlin/app/clothescast/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/SettingsViewModel.kt
@@ -692,9 +692,17 @@ class SettingsViewModel(
         viewModelScope.launch { settingsRepository.setHolidayCountryOverride(code, override) }
     }
 
+    // The list setters below read-modify-write against _state, so they update
+    // _state synchronously (before the suspending DataStore write) the way
+    // [setDeviceVoice] does. Without that, a second edit landing before the
+    // first write's preferences-flow round trip reads the stale list and
+    // silently reverts the first edit — two quick rule edits or drag-reorders
+    // are enough. The DataStore emission that follows is idempotent.
     fun addClothesRule(rule: ClothesRule) {
         viewModelScope.launch {
-            settingsRepository.setClothesRules(_state.value.clothesRules + rule)
+            val updated = _state.value.clothesRules + rule
+            _state.update { it.copy(clothesRules = updated) }
+            settingsRepository.setClothesRules(updated)
         }
     }
 
@@ -702,7 +710,9 @@ class SettingsViewModel(
         viewModelScope.launch {
             val current = _state.value.clothesRules
             if (index !in current.indices) return@launch
-            settingsRepository.setClothesRules(current.toMutableList().apply { this[index] = rule })
+            val updated = current.toMutableList().apply { this[index] = rule }
+            _state.update { it.copy(clothesRules = updated) }
+            settingsRepository.setClothesRules(updated)
         }
     }
 
@@ -710,7 +720,9 @@ class SettingsViewModel(
         viewModelScope.launch {
             val current = _state.value.clothesRules
             if (index !in current.indices) return@launch
-            settingsRepository.setClothesRules(current.toMutableList().apply { removeAt(index) })
+            val updated = current.toMutableList().apply { removeAt(index) }
+            _state.update { it.copy(clothesRules = updated) }
+            settingsRepository.setClothesRules(updated)
         }
     }
 
@@ -725,6 +737,7 @@ class SettingsViewModel(
             val current = _state.value.homeSectionOrder
             if (from !in current.indices || to !in current.indices || from == to) return@launch
             val reordered = current.toMutableList().apply { add(to, removeAt(from)) }
+            _state.update { it.copy(homeSectionOrder = reordered) }
             settingsRepository.setHomeSectionOrder(reordered)
         }
     }

--- a/app/src/main/kotlin/app/clothescast/ui/today/PerModelDiagnosticCard.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/PerModelDiagnosticCard.kt
@@ -277,9 +277,10 @@ private fun PerModelDiagnosticChart(
         }
     }
 
-    // The line provider matches lines to series by index: overlay lines
-    // first (keyed by [overlayModels] order), then the main consensus line
-    // on top. Pass the theme primary as [mainLineColor] so the consensus
+    // The line provider matches lines to series by index: the main
+    // consensus line first (series index 0 — matching the emission order in
+    // the transaction above), then the overlay lines in [overlayModels]
+    // order. Pass the theme primary as [mainLineColor] so the consensus
     // line matches the temp / precip cards' "main line is theme primary"
     // convention.
     val lineProvider = rememberPinnedLineProvider(overlayModels, mainLineColor)

--- a/app/src/main/kotlin/app/clothescast/widget/WidgetInsightLoader.kt
+++ b/app/src/main/kotlin/app/clothescast/widget/WidgetInsightLoader.kt
@@ -33,8 +33,10 @@ import java.time.ZoneId
  * Rather than confidently render stale data, a widget whose snapshot has elapsed
  * shows its empty state, and we kick a silent refresh on the way out so it
  * self-heals: the worker's cache write fires `updateAll()`, which re-renders the
- * widget off the fresh snapshot. The refresh is enqueued unique+KEEP, so the
- * widgets sharing this loader coalesce onto one in-flight run.
+ * widget off the fresh snapshot. The refresh lands on the unique silent-refresh
+ * queue with REPLACE (see [FetchAndNotifyWorker.enqueueSilentRefresh]), so a
+ * burst of widget repaints collapses to a single trailing run rather than
+ * stacking requests.
  */
 internal suspend fun loadCurrentInsight(context: Context): Pair<Insight, UserPreferences>? {
     val app = context.applicationContext as ClothesCastApplication
@@ -64,7 +66,7 @@ internal suspend fun loadCurrentInsight(context: Context): Pair<Insight, UserPre
             DiagLog.i(
                 TAG,
                 "Widget: cached ${insight.period} insight for ${insight.forDate} isn't the current " +
-                    "window, but a silent refresh can't reach it (post-midnight overnight window) — " +
+                    "window, but a dayOffset=0 refresh couldn't reach that window either — " +
                     "keeping the last-known render rather than churning",
             )
         WidgetCacheAction.REFRESH -> {
@@ -93,13 +95,13 @@ internal enum class WidgetCacheAction {
     REFRESH,
 
     /**
-     * Stale, but a `dayOffset = 0` silent refresh can't reach the current window
-     * — render the last-known snapshot and *don't* kick one. The only such case
-     * is the ongoing overnight window in the post-midnight tail: it's dated
-     * yesterday and would need a `dayOffset = -1` the worker doesn't support, so
-     * a refresh would write the *upcoming* night instead. Keeping the last-known
-     * render until the morning cutoff makes the daytime window reachable again
-     * beats both blanking and churning toward a future-night snapshot.
+     * Stale, but a `dayOffset = 0` silent refresh (which targets the window
+     * dated *today*) couldn't replace it — render the last-known snapshot and
+     * *don't* kick one. Defensive backstop: since the overnight window became
+     * today-anchored ("Show Overnight and Today before dawn"), the current
+     * window's date always equals the device date, so this normally can't
+     * fire; if it somehow does, keeping the last render beats churning toward
+     * a window the refresh can't produce.
      */
     KEEP,
 }
@@ -124,16 +126,16 @@ internal enum class WidgetCacheAction {
  *    can disagree with what a refresh just wrote. Accepting any snapshot younger
  *    than [FetchAndNotifyWorker.SILENT_REFRESH_MIN_AGE] ([RENDER]) guarantees a
  *    freshly written one ends the staleness instead of feeding refresh→reject→…
- *  - **Unreachable window ([KEEP]).** A `dayOffset = 0` refresh can only produce
- *    the window dated *today*; the ongoing overnight window post-midnight is
- *    dated yesterday, so a refresh can't reach it and would write the upcoming
- *    night. We render the last-known snapshot without refreshing until the
- *    morning cutoff.
+ *  - **Unreachable window ([KEEP]).** Defensive backstop: a `dayOffset = 0`
+ *    refresh targets the window dated *today*, so if the current window's date
+ *    ever trailed the device date the refresh couldn't reach it. Not a live
+ *    case since the overnight window became today-anchored (see the note above
+ *    the branch); if it recurs, keeping the last-known render beats churning.
  *
  * In the common case — device location, so forecast zone == device zone — forDate
- * and the device date never diverge, the age gate is moot, and the only [KEEP]
- * is the genuine post-midnight overnight window. The forecast zone still governs
- * only where the chart's "now" line falls, not which cast is current.
+ * and the device date never diverge and the age gate is moot. The forecast zone
+ * still governs only where the chart's "now" line falls, not which cast is
+ * current.
  */
 internal fun widgetCacheAction(
     insight: Insight,

--- a/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
@@ -16,7 +16,6 @@ import androidx.work.ExistingWorkPolicy
 import androidx.work.ForegroundInfo
 import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequestBuilder
-import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import androidx.work.WorkerParameters
 import androidx.work.workDataOf
@@ -64,7 +63,6 @@ import app.clothescast.tts.InsightTtsUtterance
 import app.clothescast.tts.insightTtsUtterance
 import app.clothescast.tts.resolveHolidayVoice
 import app.clothescast.tts.withSpeechAudioFocus
-import app.clothescast.ui.today.WorkInfoLite
 import app.clothescast.ui.today.toLite
 import app.clothescast.R
 import app.clothescast.ui.garment.outfitCardInfoLines
@@ -2036,13 +2034,13 @@ class FetchAndNotifyWorker(
         // failure, which KEEP would let swallow every later kick (the widget
         // then stays on its empty state and re-opening the app can't fix it).
         const val UNIQUE_WORK_NAME_SILENT = "silent_insight_refresh"
-        // Distinct queue from the daily / tonight runs so an offline Play
-        // tap sitting in the queue can't block the morning alarm: alarm
-        // enqueues use ExistingWorkPolicy.KEEP and would otherwise be
-        // dropped in favour of the pending play, leaving the user
-        // listening to yesterday's cached insight at 7am instead of the
-        // fresh forecast. Race vs. concurrent plays is handled in the
-        // UI gate — see TodayState.anyWorkActive.
+        // Distinct queue from the daily / tonight runs so a Play tap and
+        // the alarms can't cancel each other: every enqueue uses
+        // ExistingWorkPolicy.REPLACE, so on a shared queue whichever lands
+        // second would silently wipe the other — a 7am alarm cancelling an
+        // offline Play still waiting on connectivity, or a Play tap
+        // cancelling an in-flight scheduled delivery. Race vs. concurrent
+        // plays is handled in the UI gate — see TodayState.anyWorkActive.
         const val UNIQUE_WORK_NAME_PLAY = "insight_play"
 
         // Foreground-service notification ID for the playback service. Distinct
@@ -2579,28 +2577,3 @@ class FetchAndNotifyWorker(
     }
 }
 
-/**
- * True when [infos] (one observed queue's WorkManager history) shows a *stale*
- * no-location failure: nothing currently active, and the most-recent terminal
- * run is a [FetchAndNotifyWorker.REASON_NO_LOCATION] failure. Mirrors
- * [app.clothescast.ui.today.selectStatus]'s "latest terminal by completed-at,
- * active runs win" rule so the cache-only recovery clears exactly the failure
- * the Today banner would otherwise surface.
- *
- * Top-level + [WorkInfoLite]-based (rather than a private method querying
- * WorkManager) so it's directly unit-testable — same pattern as `selectStatus`.
- */
-internal fun staleNoLocationFailure(infos: List<WorkInfoLite>): Boolean {
-    val active = infos.any {
-        it.state == WorkInfo.State.ENQUEUED ||
-            it.state == WorkInfo.State.RUNNING ||
-            it.state == WorkInfo.State.BLOCKED
-    }
-    if (active) return false
-    val latest = infos
-        .filter { it.state == WorkInfo.State.SUCCEEDED || it.state == WorkInfo.State.FAILED }
-        .maxByOrNull { it.outputData.getLong(FetchAndNotifyWorker.KEY_COMPLETED_AT, 0L) }
-        ?: return false
-    return latest.state == WorkInfo.State.FAILED &&
-        latest.outputData.getString(FetchAndNotifyWorker.KEY_REASON) == FetchAndNotifyWorker.REASON_NO_LOCATION
-}

--- a/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
@@ -347,7 +347,7 @@ class FetchAndNotifyWorker(
             null
         } else {
             runCatching {
-                app.insightCache.deliveredForToday(today, period, prefs, diagLog = { DiagLog.i(TAG, it) })
+                app.insightCache.deliveredForToday(today, period, prefs, overnight = overnight, diagLog = { DiagLog.i(TAG, it) })
             }.getOrNull()
         }
         if (cached != null) {

--- a/app/src/test/kotlin/app/clothescast/data/InsightCacheTest.kt
+++ b/app/src/test/kotlin/app/clothescast/data/InsightCacheTest.kt
@@ -607,6 +607,35 @@ class InsightCacheTest {
     }
 
     @Test
+    fun `deliveredForToday returns null on an overnight mismatch`() = runTest {
+        // A pre-dawn silent refresh leaves an ongoing-overnight snapshot in
+        // THIS_PERIOD: period=TONIGHT, overnight=true, dated the real current
+        // day. The same evening's tonight alarm (overnight=false — the coming
+        // night) must not dedup against it, or it would redeliver the night
+        // that ended this morning instead of fetching the coming one.
+        subject.store(
+            InsightCache.Slot.THIS_PERIOD,
+            sample.copy(period = ForecastPeriod.TONIGHT, overnight = true),
+        )
+
+        subject.deliveredForToday(today, ForecastPeriod.TONIGHT, basePrefs, overnight = false) shouldBe null
+    }
+
+    @Test
+    fun `deliveredForToday matches an overnight snapshot for an overnight run`() = runTest {
+        // The mirror case: a post-midnight tonight alarm (a night-owl
+        // schedule) runs in the same ongoing-overnight window the cached
+        // snapshot was captured in — that's a legitimate same-night dedup.
+        subject.store(
+            InsightCache.Slot.THIS_PERIOD,
+            sample.copy(period = ForecastPeriod.TONIGHT, overnight = true),
+        )
+
+        val result = subject.deliveredForToday(today, ForecastPeriod.TONIGHT, basePrefs, overnight = true)
+        result?.insight?.period shouldBe ForecastPeriod.TONIGHT
+    }
+
+    @Test
     fun `deliveredForToday ignores the NEXT_PERIOD slot`() = runTest {
         // The morning alarm shouldn't dedup against yesterday-evening's
         // pre-cached tomorrow-daytime snapshot in NEXT_PERIOD; otherwise it

--- a/app/src/test/kotlin/app/clothescast/mqtt/MqttPublisherTest.kt
+++ b/app/src/test/kotlin/app/clothescast/mqtt/MqttPublisherTest.kt
@@ -743,6 +743,23 @@ class MqttPublisherTest {
     }
 
     @Test
+    fun `Home Assistant discovery ids fold non-ASCII letters to underscores`() {
+        // HA validates discovery topic segments and default_entity_id as
+        // slugs ([a-z0-9_]); a Unicode-aware sanitizer would pass `ü`
+        // through and HA would reject every discovery config while the
+        // forecast publishes themselves kept succeeding.
+        val entries = MqttPublisher.homeAssistantDiscoveryEntries("wetter/küche")
+
+        entries.map { it.configTopic } shouldContainAll listOf(
+            "homeassistant/sensor/clothescast_wetter_k_che_day/config",
+        )
+        val day = Json.parseToJsonElement(
+            entries.first { it.configTopic == "homeassistant/sensor/clothescast_wetter_k_che_day/config" }.payload,
+        ).jsonObject
+        day["default_entity_id"]!!.jsonPrimitive.content shouldBe "sensor.clothescast_wetter_k_che_day"
+    }
+
+    @Test
     fun `Home Assistant discovery failure does not block forecast publish outcome`() = runTest {
         val captured = mutableListOf<PublishCall>()
         val subject = MqttPublisher(

--- a/app/src/test/kotlin/app/clothescast/work/FetchAndNotifyWorkerTest.kt
+++ b/app/src/test/kotlin/app/clothescast/work/FetchAndNotifyWorkerTest.kt
@@ -5,7 +5,6 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.work.Configuration
 import androidx.work.Constraints
-import androidx.work.Data
 import androidx.work.ExistingWorkPolicy
 import androidx.work.ListenableWorker.Result
 import androidx.work.NetworkType
@@ -24,7 +23,6 @@ import app.clothescast.core.domain.model.Location
 import app.clothescast.core.domain.model.WeatherCondition
 import app.clothescast.core.domain.repository.ForecastBundle
 import app.clothescast.data.InsightCache
-import app.clothescast.ui.today.WorkInfoLite
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.longs.shouldBeGreaterThan
@@ -265,51 +263,6 @@ class FetchAndNotifyWorkerTest {
         }
     }
 
-    // --- staleNoLocationFailure (cross-queue recovery predicate) --------
-
-    @Test
-    fun `staleNoLocationFailure is false for an empty history`() {
-        staleNoLocationFailure(emptyList()) shouldBe false
-    }
-
-    @Test
-    fun `staleNoLocationFailure is true when the latest terminal is a no-location failure`() {
-        staleNoLocationFailure(
-            listOf(lite(WorkInfo.State.FAILED, completedAt = 100, reason = FetchAndNotifyWorker.REASON_NO_LOCATION)),
-        ) shouldBe true
-    }
-
-    @Test
-    fun `staleNoLocationFailure ignores the failure while a run is active`() {
-        // A pending / running recovery on the queue means the failure isn't
-        // stale — it's about to be superseded — so don't kick another.
-        staleNoLocationFailure(
-            listOf(
-                lite(WorkInfo.State.FAILED, completedAt = 100, reason = FetchAndNotifyWorker.REASON_NO_LOCATION),
-                lite(WorkInfo.State.ENQUEUED),
-            ),
-        ) shouldBe false
-    }
-
-    @Test
-    fun `staleNoLocationFailure is false when a newer success supersedes the failure`() {
-        staleNoLocationFailure(
-            listOf(
-                lite(WorkInfo.State.FAILED, completedAt = 100, reason = FetchAndNotifyWorker.REASON_NO_LOCATION),
-                lite(WorkInfo.State.SUCCEEDED, completedAt = 200),
-            ),
-        ) shouldBe false
-    }
-
-    @Test
-    fun `staleNoLocationFailure is false for a failure with a different reason`() {
-        // A network / HTTP failure isn't cleared by saving a location, so it's
-        // not ours to supersede from the cache-only path.
-        staleNoLocationFailure(
-            listOf(lite(WorkInfo.State.FAILED, completedAt = 100, reason = FetchAndNotifyWorker.REASON_UNHANDLED)),
-        ) shouldBe false
-    }
-
     @Test
     fun `tonight-disabled success result carries a completed_at stamp`() {
         runBlocking {
@@ -491,19 +444,6 @@ class FetchAndNotifyWorkerTest {
         // overnight flag), so the cache matches on today's date.
         target(ForecastPeriod.TODAY, LocalTime.of(2, 0)) shouldBe date
         target(ForecastPeriod.TONIGHT, LocalTime.of(2, 0)) shouldBe date
-    }
-
-    // Minimal WorkInfoLite for the staleNoLocationFailure pure-function tests.
-    private fun lite(
-        state: WorkInfo.State,
-        completedAt: Long = 0L,
-        reason: String? = null,
-    ): WorkInfoLite {
-        val data = Data.Builder()
-            .putLong(FetchAndNotifyWorker.KEY_COMPLETED_AT, completedAt)
-            .apply { if (reason != null) putString(FetchAndNotifyWorker.KEY_REASON, reason) }
-            .build()
-        return WorkInfoLite(state = state, runAttemptCount = 1, outputData = data)
     }
 
     private fun workInfosFor(name: String): List<WorkInfo> =

--- a/core/data/src/main/kotlin/app/clothescast/core/data/weather/GoogleWeatherModelClient.kt
+++ b/core/data/src/main/kotlin/app/clothescast/core/data/weather/GoogleWeatherModelClient.kt
@@ -206,9 +206,11 @@ class GoogleWeatherModelClient(
                 url {
                     protocol = URLProtocol.HTTPS
                     host = GOOGLE_WEATHER_HOST
-                    // Pass already-encoded segments so the `:lookup` colon
-                    // survives — encoding it (via plain `path(...)`) to %3A
-                    // would make Google 404 the request.
+                    // `hours:lookup` must keep its literal colon. Plain
+                    // `path(...)` would too — Ktor's segment encoder
+                    // preserves ':' (GeminiTtsClient relies on that for
+                    // `<model>:generateContent`) — so pre-encoded segments
+                    // here are explicitness, not a workaround.
                     encodedPathSegments = listOf("v1", "forecast", "hours:lookup")
                 }
                 // Send the key as a header, NOT a `key=` query param: on an HTTP

--- a/core/data/src/main/kotlin/app/clothescast/core/data/weather/MultiModelConfidenceFetcher.kt
+++ b/core/data/src/main/kotlin/app/clothescast/core/data/weather/MultiModelConfidenceFetcher.kt
@@ -531,10 +531,13 @@ internal class MultiModelConfidenceFetcher(
         // Open-Meteo's status for an invalid/withdrawn `models=` entry.
         private const val HTTP_BAD_REQUEST = 400
 
-        // Hard cap on prune-and-retry rounds. Each round drops at least one
-        // model, so the loop already terminates on its own; this is a
-        // belt-and-suspenders bound against a pathological model list (and
-        // keeps a worst case of a handful of requests, not an unbounded storm).
+        // Backstop bound on the fetch loop. `attempts` counts every request
+        // (transient retries included, so those spend from the same budget),
+        // and the prune path gives up once a request lands beyond this count
+        // — worst case one more request than the constant, still a handful.
+        // Each prune round also drops at least one model, so the loop
+        // terminates on its own; this is belt-and-suspenders against a
+        // pathological model list, not the primary bound.
         private const val MAX_FETCH_ATTEMPTS = 6
 
         // Transient-network retry budget. A socket timeout on this best-effort

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/ConsensusBlend.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/ConsensusBlend.kt
@@ -60,7 +60,14 @@ fun blendConsensusHourly(
     // calendar day before looking up consensus candidates.
     val byHour = mutableMapOf<java.time.LocalDateTime, MutableList<PerModelHour>>()
     for (entries in models.values) {
-        for (entry in entries) {
+        // On the DST fall-back day Open-Meteo's local-time array repeats a
+        // wall-clock hour, so one model can carry two physical entries at the
+        // same LocalDateTime. Collapse those to one averaged entry per model
+        // first — otherwise that model votes twice in the hour's cross-model
+        // mean (and a lone model's duplicated pair would even clear the
+        // ≥2-candidates bar by itself). Mirrors the per-model pre-pass
+        // [consensusPerModelAverage] documents for the same day.
+        for (entry in collapseDuplicateHours(entries)) {
             byHour.getOrPut(entry.time) { mutableListOf() }.add(entry)
         }
     }
@@ -155,6 +162,40 @@ fun blendConsensusHourly(
     // Stable sort keeps a DST fall-back day's duplicated wall-clock hour as
     // two adjacent entries in their original order.
     return (replaced + synthesized).sortedBy { it.time }
+}
+
+/**
+ * One entry per wall-clock timestamp for a single model's series. The DST
+ * fall-back day's repeated hour is averaged into a single entry: numeric
+ * fields skip nulls (a null pair stays null rather than becoming a synthetic
+ * zero), the condition takes the more severe of the pair — the same tiebreak
+ * posture as [consensusCondition]. On the 364 other days this is an identity
+ * pass-through.
+ */
+private fun collapseDuplicateHours(entries: List<PerModelHour>): List<PerModelHour> {
+    if (entries.distinctBy { it.time }.size == entries.size) return entries
+    return entries.groupBy { it.time }.map { (_, dupes) ->
+        if (dupes.size == 1) dupes.first() else dupes.averagedIntoOne()
+    }
+}
+
+private fun List<PerModelHour>.averagedIntoOne(): PerModelHour {
+    fun avgOrNull(select: (PerModelHour) -> Double?): Double? =
+        mapNotNull(select).takeIf { it.isNotEmpty() }?.average()
+    return PerModelHour(
+        time = first().time,
+        apparentTemperatureC = map { it.apparentTemperatureC }.average(),
+        temperatureC = map { it.temperatureC }.average(),
+        precipitationProbabilityPct = avgOrNull { it.precipitationProbabilityPct },
+        precipitationMm = avgOrNull { it.precipitationMm },
+        windSpeedKmh = avgOrNull { it.windSpeedKmh },
+        relativeHumidityPct = avgOrNull { it.relativeHumidityPct },
+        cloudCoverPct = avgOrNull { it.cloudCoverPct },
+        shortwaveRadiationWm2 = avgOrNull { it.shortwaveRadiationWm2 },
+        sunshineDurationSec = avgOrNull { it.sunshineDurationSec },
+        uvIndex = avgOrNull { it.uvIndex },
+        condition = mapNotNull { it.condition }.maxByOrNull { it.severityRank() },
+    )
 }
 
 /**

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/repository/CachingWeatherRepository.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/repository/CachingWeatherRepository.kt
@@ -27,10 +27,9 @@ import kotlin.math.roundToLong
  */
 class CachingWeatherRepository(
     private val delegate: WeatherRepository,
-    // Default to the device's local zone so the date-rollover check below
-    // compares against the same wall-clock day the user — and the insight
-    // worker, which stamps `Insight.forDate` from the device's local date —
-    // is looking at.
+    // The date-rollover check reads the current date in the cached bundle's
+    // own forecast zone via clock.instant(); the clock's zone only matters
+    // as the fallback for legacy bundles that don't carry a zone.
     private val clock: Clock = Clock.systemDefaultZone(),
     private val ttl: Duration = Duration.ofHours(1),
     private val locationGridDegrees: Double = 0.01,
@@ -77,18 +76,29 @@ class CachingWeatherRepository(
         val key = keyOf(location)
         val freshnessKey = freshnessKeyProvider(location)
         val now = clock.instant()
-        val today = LocalDate.now(clock)
         val cached = entry
-        // Date check uses `isBefore` rather than `==` because Open-Meteo
-        // returns dates in the forecast location's local zone (timezone=auto).
-        // When the device zone is east of the location's zone, the cached
-        // bundle's today.date can sit one day ahead of the device's local
-        // date without being stale — only invalidate when it lags behind.
+        // Open-Meteo returns dates in the forecast location's local zone
+        // (timezone=auto), so "the bundle no longer describes today" is
+        // judged against the *location's* current date, not the device's.
+        // Comparing against the device date breaks whenever the two zones
+        // straddle midnight: a device east of the location rolls its date
+        // hours earlier, and every refetch returns the same location-local
+        // date — still "stale" — so the cache would be defeated (and
+        // Open-Meteo hammered) for the rest of the device's day. Bundles
+        // without a zone (legacy fixtures) fall back to the device date.
+        // `isBefore` rather than `==` so a bundle dated ahead (device west
+        // of the location) still hits.
+        val bundleStale = cached != null && run {
+            val todayAtLocation = cached.bundle.forecastZone
+                ?.let { now.atZone(it).toLocalDate() }
+                ?: LocalDate.now(clock)
+            cached.bundle.today.date.isBefore(todayAtLocation)
+        }
         if (
             cached != null &&
             cached.key == key &&
             cached.freshnessKey == freshnessKey &&
-            !cached.bundle.today.date.isBefore(today) &&
+            !bundleStale &&
             Duration.between(cached.fetchedAt, now) < ttl
         ) {
             return@withLock cached.bundle

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/HolidayResolver.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/HolidayResolver.kt
@@ -88,11 +88,12 @@ class HolidayResolver(
      * catalog has no opinion *they* could act on, and the calendar
      * fallback fires correctly.
      *
-     * Per-holiday overrides aren't checked here: an ON override falls
-     * out of [resolve] before this is called, so we only reach the
-     * fallback when resolve returned null. An OFF override on a holiday
-     * whose country *is* enabled still suppresses the fallback — the
-     * user's explicit opt-out beats a calendar event with the same date.
+     * Per-holiday overrides aren't checked here: [ThemeForToday] only
+     * consults this when [resolveAll] produced no primary, so an ON
+     * override (which always fires) never reaches this fallback. An OFF
+     * override on a holiday whose country *is* enabled still suppresses
+     * the fallback — the user's explicit opt-out beats a calendar event
+     * with the same date.
      *
      * Funny-bucket entries never count as a match: a joke observance
      * (Talk Like a Pirate Day, Towel Day) can share a date with a real

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/ThemeForToday.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/ThemeForToday.kt
@@ -53,7 +53,16 @@ class ThemeForToday(
         // A remembrance day mutes every playful clause for the day.
         val funnies = if (primaries.any { it.solemn }) emptyList() else catalogMatches.filter { it.isFunny }
 
+        // A curated primary that already fired suppresses the calendar
+        // fallback outright — without this, a holiday force-ON'd from
+        // outside the enabled countries (which hasCatalogMatch's country
+        // gate can't see) would double up with the synced calendar's event
+        // for the same day ("Happy Australia Day and Australia Day").
+        // hasCatalogMatch still handles the no-primary cases: an
+        // OFF-overridden holiday whose country is enabled keeps suppressing
+        // the fallback (explicit opt-out beats the calendar event).
         val calendarHolidays = if (themeFromCalendarHolidays &&
+            primaries.isEmpty() &&
             !holidayResolver.hasCatalogMatch(date, enabledCountries)
         ) {
             events.firstOrNull { it.kind == EventKind.PUBLIC_HOLIDAY }

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/model/ConsensusBlendTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/model/ConsensusBlendTest.kt
@@ -354,6 +354,55 @@ class ConsensusBlendTest {
     }
 
     @Test
+    fun `a model reporting the DST fall-back hour twice votes once in the mean`() {
+        // On the fall-back day Open-Meteo's local-time array repeats an hour,
+        // so a model's series carries two physical entries at the same
+        // LocalDateTime. The pair must collapse to one vote per model —
+        // otherwise the duplicated model is double-weighted against a model
+        // that reported the hour once (the double-voting policy
+        // consensusPerModelAverage already documents and guards).
+        val best = listOf(hour(1, temp = 12.0))
+        val perModel = PerModelHourly(
+            byModel = mapOf(
+                // Both physical 01:00s at 10° → one collapsed 10° vote.
+                "gfs_seamless" to listOf(
+                    perModel(1, apparent = 9.0, air = 10.0),
+                    perModel(1, apparent = 9.0, air = 10.0),
+                ),
+                "ecmwf_ifs04" to listOf(perModel(1, apparent = 15.0, air = 16.0)),
+            ),
+        )
+
+        val blended = blendConsensusHourly(today, best, perModel)
+
+        blended.shouldNotBeNull()
+        // Equal-weight mean (10+16)/2 = 13, not the double-vote (10+10+16)/3 = 12.
+        blended.single().temperatureC shouldBe (13.0 plusOrMinus 1e-9)
+        blended.single().feelsLikeC shouldBe (12.0 plusOrMinus 1e-9)
+    }
+
+    @Test
+    fun `a lone model's duplicated fall-back hour is not a consensus`() {
+        // One model reporting the repeated hour twice is still one model —
+        // its duplicate pair must not clear the two-candidates bar and
+        // overwrite best_match with a single-source "consensus".
+        val best = listOf(hour(1, temp = 12.0))
+        val perModel = PerModelHourly(
+            byModel = mapOf(
+                "gfs_seamless" to listOf(
+                    perModel(1, apparent = 9.0, air = 10.0),
+                    perModel(1, apparent = 9.0, air = 10.0),
+                ),
+                // Second model exists but covers a different hour, so the
+                // blend has no ≥2-model hour and returns null overall.
+                "ecmwf_ifs04" to listOf(perModel(5, apparent = 15.0, air = 16.0)),
+            ),
+        )
+
+        blendConsensusHourly(today, best, perModel).shouldBeNull()
+    }
+
+    @Test
     fun `condition is aggregated modally across models`() {
         // best_match says CLEAR but two of three consulted models say RAIN —
         // mode wins. This is the case the modal aggregation was added to

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/repository/CachingWeatherRepositoryTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/repository/CachingWeatherRepositoryTest.kt
@@ -150,6 +150,56 @@ class CachingWeatherRepositoryTest {
     }
 
     @Test
+    fun `bundle dated behind a device east of the location still hits cache`() = runTest {
+        // Device in Sydney (UTC+10), saved location London (UTC+1): from
+        // Sydney's midnight until London's, the device date runs a day ahead
+        // of the bundle's location-local today.date. The bundle still
+        // describes London's current day, so the cache must hit — judging it
+        // by the device date would refetch on every call for hours (each
+        // refetch returns the same London-dated bundle, still "stale").
+        val londonBundle = ForecastBundle(
+            today = today,
+            yesterday = yesterday,
+            forecastZone = java.time.ZoneId.of("Europe/London"),
+        )
+        val delegate = CountingRepository(response = { londonBundle })
+        // 2026-04-25T20:00Z = Apr 26 in Sydney, still Apr 25 in London.
+        val clock = object : Clock() {
+            override fun instant(): Instant = Instant.parse("2026-04-25T20:00:00Z")
+            override fun getZone() = java.time.ZoneId.of("Australia/Sydney")
+            override fun withZone(zone: java.time.ZoneId): Clock = this
+        }
+        val subject = CachingWeatherRepository(delegate, clock = clock)
+
+        subject.fetchForecast(london)
+        subject.fetchForecast(london)
+
+        delegate.callCount.get() shouldBe 1
+    }
+
+    @Test
+    fun `cache invalidated when the date rolls over in the forecast zone`() = runTest {
+        // The mirror of the case above: once the *location's* date rolls
+        // past the bundle's today.date, the bundle describes yesterday and
+        // must refetch even inside the TTL — regardless of the device zone.
+        val londonBundle = ForecastBundle(
+            today = today,
+            yesterday = yesterday,
+            forecastZone = java.time.ZoneId.of("Europe/London"),
+        )
+        val delegate = CountingRepository(response = { londonBundle })
+        // Bundle's today.date is 2026-04-25; London rolls to Apr 26 at 23:00Z.
+        val clock = MutableClock(Instant.parse("2026-04-25T22:50:00Z"))
+        val subject = CachingWeatherRepository(delegate, clock = clock)
+
+        subject.fetchForecast(london)
+        clock.advance(Duration.ofMinutes(15))
+        subject.fetchForecast(london)
+
+        delegate.callCount.get() shouldBe 2
+    }
+
+    @Test
     fun `cache invalidated when local date rolls over even within TTL`() = runTest {
         val delegate = CountingRepository(response = ::bundle)
         // Fixture bundle's today.date = 2026-04-25. Start the clock at

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/ThemeForTodayTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/ThemeForTodayTest.kt
@@ -56,6 +56,28 @@ class ThemeForTodayTest {
     }
 
     @Test
+    fun `user-on override outside the enabled countries suppresses calendar fallback`() {
+        // An Australian living in the US force-ONs Christmas... any holiday
+        // outside their enabled countries. hasCatalogMatch's country gate
+        // can't see the override, but the ON-overridden primary fires via
+        // resolveAll — the synced calendar's event for the same holiday must
+        // not join as a second contributor ("Happy Christmas and Christmas
+        // Day"). The curated theme alone carries the day.
+        val theme = subject.resolve(
+            date = christmas,
+            overrides = mapOf(HolidayId.CHRISTMAS_DAY to HolidayOverride.ON),
+            enabledCountries = emptySet(),
+            events = listOf(publicHoliday("Christmas Day")),
+            themeFromCalendarHolidays = true,
+            themeFromCalendarBirthdays = true,
+        )
+        theme.shouldNotBeNull()
+        theme.id shouldBe HolidayId.CHRISTMAS_DAY
+        // Single contributor → standalone banner, no composed segments.
+        theme.bannerSegments.shouldBeNull()
+    }
+
+    @Test
     fun `country-bucket-off lets calendar fallback fire`() {
         // The user disabled the Global bucket (so curated Christmas doesn't
         // fire via its bucket) but didn't explicitly opt out of Christmas —


### PR DESCRIPTION
## Summary

A systematic bug hunt across all three modules (five parallel review passes over `:core:domain`, `:core:data`, UI, background infra, and cast/TTS/network, each finding verified against the code before fixing). Nine behavioral fixes plus one `internal:` cleanup commit, one commit per fix:

### Correctness fixes

- **Forecast cache defeated across time zones** (`CachingWeatherRepository`): the date-rollover check compared the bundle's *location-local* date against the *device-local* date, so a device east of its saved city (e.g. Australia + a European city) invalidated the cache on every fetch for hours each day and hammered Open-Meteo with identical requests. Staleness is now judged in the bundle's own `forecastZone`. The old comment's east/west reasoning was also inverted.
- **Tonight alarm replaying the finished overnight forecast** (`InsightCache.deliveredForToday`): the same-day dedup matched date + period only, so on a tonight-only schedule a pre-dawn silent refresh's ongoing-overnight snapshot satisfied the evening alarm's dedup and the 7pm delivery redelivered the night that ended that morning. The dedup now also matches the snapshot's `overnight` flag against the run's window flavor.
- **Bitmap-cache data race** (`GarmentRender`): both render caches were unsynchronized access-ordered `LinkedHashMap`s (structural mutation on every `get()`), shared between the main thread, WorkManager workers, and Glance widget composition — intermittent corruption/CME/ANR risk. Now wrapped in `Collections.synchronizedMap`, matching `OutfitVector`'s posture.
- **"Cast now" speech skipped `prepareForTts`** (`CastInsightController`): the test cast spoke raw `°` glyphs and collapsed the brand to "ClotheCast", diverging from the scheduled cast it previews.
- **DST fall-back double-vote** (`blendConsensusHourly`): a model reporting both physical occurrences of the repeated hour voted twice in that hour's cross-model mean (and a lone model's duplicate pair could pass the ≥2-candidate bar alone). Per-model duplicates now collapse to one averaged vote, mirroring `consensusPerModelAverage`.
- **Duplicate holiday banner** (`ThemeForToday`): a holiday force-ONed from outside the enabled countries fired as a curated primary *and* let the synced calendar's event for the same day join ("Happy Australia Day and Australia Day"). The calendar fallback now requires that no curated primary fired — restoring the invariant `hasCatalogMatch`'s KDoc already claimed.
- **Pairing races** (`PairingServer` / `PairingViewModel`): `stop()` revoked the token gate without the monitor the POST handler holds, so a racing submission could persist a key *after* stop returned; and the screen's state initialized to `Error`, flashing "couldn't start" (with a live Retry that could spawn a second server) during every bind. Revocation now takes the lock; a new `Starting` state renders progress.
- **Home Assistant discovery broken by accented topics** (`MqttPublisher`): the ID sanitizer was Unicode-aware, so a base topic like `wetter/küche` produced non-slug discovery topics/entity IDs that HA rejects — publishes "succeeded" while no entities ever appeared. Sanitizer is now ASCII-only.
- **Lost updates in settings list edits** (`SettingsViewModel`): rule add/replace/delete and home-section reorder did read-modify-write against `_state`, which only refreshes via the DataStore round trip — two quick edits inside that window silently reverted the first. They now update `_state` synchronously first, like `setDeviceVoice`.

### Internal

- `internal:` commit fixing six verified code-vs-comment contradictions (Ktor colon encoding, retry-budget accounting, REPLACE-vs-KEEP queue comments ×2, channel importance, chart line order) and removing the dead `staleNoLocationFailure` helper + its tests (unreferenced; its KDoc described wiring that doesn't exist).

Nothing in this PR changes what leaves the device: no new network calls, no new data in TTS/MQTT/Firebase payloads (the MQTT fix only re-folds discovery IDs that HA previously rejected).

## Test plan

- New regression tests for the cache time-zone cases (device-east hit, forecast-zone rollover), the overnight dedup mismatch/match, the DST single-vote + lone-model cases, the ON-override banner suppression, and the non-ASCII discovery IDs.
- `:core:domain:test` and `:core:data:test` pass locally (inner build; Gradle 9.4.1 distribution downloads are blocked in this sandbox, so ran with system Gradle 8.14.3).
- `:app:testDebugUnitTest` / `:app:assembleDebug` could **not** be run locally for the same reason — CI is the validation surface for the app-module changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K5Gk5Knm7N9Kqb3kFTi7FX

---
_Generated by [Claude Code](https://claude.ai/code/session_01K5Gk5Knm7N9Kqb3kFTi7FX)_