### PR TITLE
ci: auto-post snapshot image diffs as a PR comment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -361,6 +361,102 @@ jobs:
               });
             }
 
+      - name: Post snapshot image diffs as a PR comment
+        # The GitHub mobile app shows "Binary files not rendered" for any
+        # binary diff, so PNG changes in the Files tab — including the
+        # snapshot-regen bot's commits — are invisible from a phone. This
+        # step upserts a single marker-tagged PR comment embedding every
+        # added / changed / removed snapshot inline, with image URLs pinned
+        # to commit SHAs (before → the PR merge-base, after → the branch
+        # head incl. any regen commit just pushed above). Markdown-embedded
+        # images render fine in the mobile app even though file diffs don't.
+        #
+        # Upsert (PATCH the existing marker comment) rather than re-post so
+        # repeated pushes don't pile up comments; when a later push reverts
+        # every snapshot change, the stale comment is rewritten to say so
+        # instead of being left describing a diff that no longer exists.
+        # Automates the hand-posted comments AGENTS.md used to prescribe,
+        # which historically suffered typo'd / stale-SHA image URLs.
+        #
+        # Same-repo PRs only: forks don't get token write access to post
+        # comments (the ui-preview-snapshots artifact below is the fallback
+        # there). Diff is taken against the merge-base so snapshots
+        # committed earlier on the branch (e.g. recorded locally) show up
+        # too, not just this run's regen.
+        if: >-
+          success() &&
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          marker='<!-- ui-snapshot-diffs -->'
+          base_sha=$(git merge-base HEAD "origin/${GITHUB_BASE_REF}")
+          head_sha=$(git rev-parse HEAD)
+
+          # --no-renames keeps statuses to a single-path A/M/D shape (a
+          # rename would otherwise emit R100 with two tab-separated paths).
+          mapfile -t entries < <(git diff --name-status --no-renames \
+            "$base_sha" HEAD -- app/snapshots/ | grep -E '^[AMD]' || true)
+
+          existing=$(gh api \
+            "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments?per_page=100" \
+            --jq "[.[] | select((.user.type == \"Bot\") and ((.body // \"\") | contains(\"$marker\")))][0].id // empty")
+
+          if [ ${#entries[@]} -eq 0 ]; then
+            if [ -n "$existing" ]; then
+              # A previous push changed snapshots and a later one reverted
+              # them — rewrite the comment so it doesn't lie.
+              revert_body="$marker"$'\n'"**UI snapshot diffs:** all snapshot changes reverted — no differences vs merge-base as of \`${head_sha:0:7}\`."
+              gh api -X PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${existing}" \
+                -f body="$revert_body" > /dev/null
+              echo "No snapshot changes; updated stale diff comment ${existing}."
+            else
+              echo "No added/changed/removed snapshots vs merge-base; skipping comment."
+            fi
+            exit 0
+          fi
+
+          raw="https://raw.githubusercontent.com/${GITHUB_REPOSITORY}"
+          body="$marker"$'\n'"## UI snapshot diffs"$'\n\n'
+          body+="Auto-posted by CI. After images pinned to \`${head_sha:0:7}\`, before images to the merge-base \`${base_sha:0:7}\`."$'\n'
+          count=0
+          for entry in "${entries[@]}"; do
+            status="${entry%%$'\t'*}"
+            path="${entry#*$'\t'}"
+            name=$(basename "$path")
+            count=$((count+1))
+            # GitHub caps comment bodies at 65536 chars; 20 entries of
+            # URL-heavy markdown stays comfortably under it.
+            if [ "$count" -gt 20 ]; then
+              body+=$'\n'"_…truncated: more than 20 snapshot changes; see the \`ui-preview-snapshots\` artifact or browse \`app/snapshots/\` at \`${head_sha:0:7}\`._"
+              break
+            fi
+            case "$status" in
+              A)
+                body+=$'\n'"**Added — \`${name}\`**"$'\n\n'"<img src=\"${raw}/${head_sha}/${path}\" width=\"320\">"$'\n'
+                ;;
+              D)
+                body+=$'\n'"**Removed — \`${name}\`** (was)"$'\n\n'"<img src=\"${raw}/${base_sha}/${path}\" width=\"320\">"$'\n'
+                ;;
+              *)
+                body+=$'\n'"**Changed — \`${name}\`**"$'\n\n'"| Before | After |"$'\n'"| --- | --- |"$'\n'"| <img src=\"${raw}/${base_sha}/${path}\" width=\"320\"> | <img src=\"${raw}/${head_sha}/${path}\" width=\"320\"> |"$'\n'
+                ;;
+            esac
+          done
+
+          if [ -n "$existing" ]; then
+            gh api -X PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${existing}" \
+              -f body="$body" > /dev/null
+            echo "Updated snapshot-diff comment ${existing}."
+          else
+            gh api -X POST "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+              -f body="$body" > /dev/null
+            echo "Posted new snapshot-diff comment."
+          fi
+
       - name: Upload UI preview snapshots (fallback for fork PRs)
         # Same PNGs as the in-repo commit above, kept as a workflow artifact
         # so reviewers on a fork PR (where the commit-back step is skipped

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -216,20 +216,22 @@ new rule the first time something bites you, not the third.
   pushed SHA so a stale review of a superseded commit isn't conflated with
   the current state. The user uses this to know when the automated pass
   is done vs. still pending.
-- **Post a PR comment with image diffs inline whenever snapshots change.**
+- **CI posts snapshot image diffs as a PR comment — don't hand-post.**
   The GitHub mobile app shows "Binary files not rendered" for any binary
   diff (added or modified), so PNG changes in the Files tab — including
   the bot's `ci: regenerate UI snapshots` commits — are invisible from
-  the user's phone, and long-press doesn't expose an "Open in Browser"
-  escape hatch on those links. After each regen commit (or any push that
-  touches `app/snapshots/`), post one PR comment embedding each affected
-  image as `![label](https://github.com/<owner>/<repo>/raw/<sha>/<path>.png)`.
-  For modified files include both the previous and new versions labelled
-  by SHA so the user can flip between them; for added files just the new
-  one. Markdown-embedded images render fine in the mobile app even though
-  file diffs don't. One comment per regen is enough — don't re-post if a
-  later regen reverts the same bytes (the existing thread already shows
-  both states).
+  the user's phone. The "Post snapshot image diffs as a PR comment" step
+  in `ci.yml` handles this: on every same-repo PR run it diffs
+  `app/snapshots/` against the merge-base and upserts a single
+  `<!-- ui-snapshot-diffs -->`-marked comment embedding each affected
+  image, SHA-pinned, with before/after side by side for modified files
+  (markdown-embedded images render fine in the mobile app even though
+  file diffs don't). Hand-posted comments are retired — they historically
+  suffered typo'd / stale-SHA image URLs. Only fork PRs (where CI can't
+  comment) still warrant a manual comment, in the same format:
+  `![label](https://github.com/<owner>/<repo>/raw/<sha>/<path>.png)`,
+  before + after labelled by SHA for modified files, just the new image
+  for added ones.
 - **Report Android versionCode after every merge to `main`.** When a PR
   merges, fetch `main` and run `git rev-list --count origin/main` to get
   the versionCode (`app/build.gradle.kts` derives it from this count).


### PR DESCRIPTION
## Scope

Adds a "Post snapshot image diffs as a PR comment" step to the `unit-tests` CI job, mirroring the automation from typelauncher PR #549. On every same-repo PR run (after the snapshot-regen commit step, so it sees the freshly pushed PNGs) it:

- Diffs `app/snapshots/` against the PR merge-base (`--no-renames`, so statuses stay single-path A/M/D). This picks up snapshots committed anywhere on the branch, not just this run's regen.
- Builds one comment embedding every affected PNG inline, SHA-pinned via `raw.githubusercontent.com`: **Added** → new image at the head SHA; **Changed** → before/after table (merge-base vs head); **Removed** → the old image at the merge-base SHA.
- Caps at 20 images and points to the `ui-preview-snapshots` artifact beyond that, keeping the body under GitHub's 65,536-char comment limit.
- **Upserts** a single `<!-- ui-snapshot-diffs -->`-marked comment (PATCH if present, POST otherwise) so repeated pushes don't pile up comments. If a later push reverts every snapshot change, the stale comment is rewritten to say so instead of describing a diff that no longer exists.
- Same-repo PRs only — forks have no token write access; the existing artifact upload remains the fallback there.

## Rationale

The GitHub mobile app shows "Binary files not rendered" for PNG diffs in the Files tab, so the snapshot-regen bot's changes are invisible from a phone. Markdown-embedded images render fine, so AGENTS.md prescribed hand-posting a comment with SHA-pinned image links after every regen — but hand-posted comments historically suffered typo'd / stale-SHA URLs. CI builds the URLs from `git rev-parse` / `git merge-base` directly, so they can't drift. AGENTS.md is updated to retire the hand-posting rule (kept only for fork PRs, where CI can't comment).

No new permissions needed: the `unit-tests` job already has `pull-requests: write`.

## Test plan

- `ci.yml` parses (PyYAML) and the step's script passes `bash -n`.
- The body-generation logic was dry-run locally with simulated A/M/D entries; markdown output renders added, before/after, and removed sections with correctly pinned URLs.
- Real end-to-end validation needs a PR that actually changes a snapshot — the step is exercised (and expected to no-op with "No added/changed/removed snapshots") on this PR's own CI run, since it touches no PNGs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GKkq3s5wgaLPCr1EpNfyfu

---
_Generated by [Claude Code](https://claude.ai/code/session_01GKkq3s5wgaLPCr1EpNfyfu)_