### PR TITLE
Keep home-screen widgets refreshing when scheduled casts are off

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -135,6 +135,18 @@
             </intent-filter>
         </receiver>
 
+        <!-- Widget-only refresh chain: while any ClothesCast widget is placed,
+             fires at the schedule boundary times regardless of the delivery
+             toggles and enqueues a silent cache refresh so placed widgets keep
+             tracking the current window. See WidgetRefreshReceiver. -->
+        <receiver
+            android:name=".alarm.WidgetRefreshReceiver"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="app.clothescast.alarm.WIDGET_REFRESH" />
+            </intent-filter>
+        </receiver>
+
         <!-- Owns the "Preparing your ClothesCast" / "Delivering your ClothesCast"
              foreground-service notification across an alarm-triggered delivery.
              Started from AlarmReceiver via startForegroundService inside the

--- a/app/src/main/kotlin/app/clothescast/ClothesCastApplication.kt
+++ b/app/src/main/kotlin/app/clothescast/ClothesCastApplication.kt
@@ -5,6 +5,7 @@ import android.app.Application
 import android.content.Context
 import android.os.Bundle
 import app.clothescast.alarm.DailyAlarmScheduler
+import app.clothescast.alarm.reconcileWidgetRefreshChain
 import app.clothescast.calendar.CalendarContractEventReader
 import app.clothescast.cast.CastInsightController
 import app.clothescast.cast.CastRouteDiscovery
@@ -63,6 +64,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import java.lang.ref.WeakReference
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.distinctUntilChangedBy
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
@@ -477,6 +479,30 @@ class ClothesCastApplication : Application() {
                 }
         }
         applicationScope.launch {
+            // Re-arm the widget-only refresh chain when a schedule boundary
+            // time changes. WidgetInputs deliberately excludes the schedule (a
+            // schedule edit doesn't repaint the launcher), so the repaint
+            // observer above never sees it — but the chain's armed alarm would
+            // otherwise sit on the *old* boundary until its next fire, and
+            // with delivery disabled a widget could miss the newly configured
+            // boundary entirely. Same process-scoped pattern as above:
+            // schedule edits only happen while the app is foregrounded.
+            settingsRepository.preferences
+                .distinctUntilChangedBy { it.schedule.time to it.tonightSchedule.time }
+                .drop(1)
+                .collect { prefs ->
+                    try {
+                        reconcileWidgetRefreshChain(this@ClothesCastApplication, prefs)
+                    } catch (c: CancellationException) {
+                        throw c
+                    } catch (t: Throwable) {
+                        // Non-fatal: the chain re-arms itself from fresh prefs
+                        // on its next fire, render, or app start anyway.
+                        DiagLog.w(TAG, "Widget refresh chain re-arm after schedule change failed", t)
+                    }
+                }
+        }
+        applicationScope.launch {
             try {
                 val prefs = settingsRepository.preferences.first()
                 // Reconcile Locale.setDefault (process-scoped, lost on cold
@@ -494,6 +520,10 @@ class ClothesCastApplication : Application() {
                 } else {
                     dailyAlarmScheduler.cancel(ForecastPeriod.TONIGHT)
                 }
+                // The widget-only refresh chain rides the same schedule times
+                // but is gated on widgets being placed, not on the delivery
+                // toggles — see WidgetRefreshScheduler.
+                reconcileWidgetRefreshChain(this@ClothesCastApplication, prefs)
             } catch (t: Throwable) {
                 DiagLog.e(TAG, "Initial alarm scheduling failed", t)
             }

--- a/app/src/main/kotlin/app/clothescast/alarm/ScheduleRefreshReceiver.kt
+++ b/app/src/main/kotlin/app/clothescast/alarm/ScheduleRefreshReceiver.kt
@@ -47,6 +47,10 @@ class ScheduleRefreshReceiver : BroadcastReceiver() {
                 } else {
                     scheduler.cancel(ForecastPeriod.TONIGHT)
                 }
+                // Boot / update / clock changes wipe the widget-only refresh
+                // chain too; re-arm it while any widget is placed so widgets
+                // keep refreshing even with both delivery slots disabled.
+                reconcileWidgetRefreshChain(context.applicationContext, prefs)
             } catch (t: Throwable) {
                 DiagLog.e(TAG, "Re-arm failed", t)
             } finally {

--- a/app/src/main/kotlin/app/clothescast/alarm/WidgetRefreshReceiver.kt
+++ b/app/src/main/kotlin/app/clothescast/alarm/WidgetRefreshReceiver.kt
@@ -1,0 +1,105 @@
+package app.clothescast.alarm
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import app.clothescast.ClothesCastApplication
+import app.clothescast.core.domain.model.ForecastPeriod
+import app.clothescast.core.domain.model.Schedule
+import app.clothescast.diag.DiagLog
+import app.clothescast.widget.hasPlacedClothesCastWidgets
+import app.clothescast.work.FetchAndNotifyWorker
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import java.time.LocalDateTime
+
+/**
+ * Fires when the widget-only refresh alarm goes off (see
+ * [WidgetRefreshScheduler]). At each schedule boundary while any ClothesCast
+ * widget is placed:
+ *
+ *  1. No widgets left → do nothing and don't re-arm; the chain ends here.
+ *  2. The boundary's delivery alarm would fire anyway (slot enabled and today
+ *     in its day set) → skip the enqueue — the delivery run refreshes the
+ *     cache and repaints the widgets itself — but still re-arm.
+ *  3. Otherwise → enqueue a silent refresh (fetch + cache + widget repaint,
+ *     no notification / TTS / MQTT / cast) and re-arm for the next boundary.
+ *
+ * The silent run derives its period from wall-clock time inside the worker
+ * ([FetchAndNotifyWorker.currentPeriodForSchedule]), which at a boundary fire
+ * is exactly the window that just opened.
+ */
+class WidgetRefreshReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action != ACTION_FIRE) return
+        DiagLog.i(TAG, "WidgetRefreshReceiver fired")
+
+        val pending = goAsync()
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        scope.launch {
+            val appCtx = context.applicationContext
+            try {
+                if (!hasPlacedClothesCastWidgets(appCtx)) {
+                    DiagLog.i(TAG, "No ClothesCast widgets placed; ending the widget-refresh chain.")
+                    return@launch
+                }
+                val app = appCtx as ClothesCastApplication
+                val prefs = app.settingsRepository.preferences.first()
+                if (deliveryCoversWidgetRefresh(
+                        dailyEnabled = prefs.dailyEnabled,
+                        tonightEnabled = prefs.tonightEnabled,
+                        morning = prefs.schedule,
+                        tonight = prefs.tonightSchedule,
+                        now = LocalDateTime.now(),
+                    )
+                ) {
+                    DiagLog.i(TAG, "Delivery alarm covers this boundary; skipping the widget-only refresh.")
+                } else {
+                    FetchAndNotifyWorker.enqueueSilentRefresh(appCtx, alarmFiredAtMs = System.currentTimeMillis())
+                }
+                WidgetRefreshScheduler(appCtx).schedule(prefs.schedule, prefs.tonightSchedule)
+            } catch (t: Throwable) {
+                DiagLog.e(TAG, "Widget-refresh fire failed", t)
+                // Widgets are (probably) still placed, so a one-off failure —
+                // typically the prefs read — shouldn't end the chain: refresh
+                // and re-arm on the default schedule times so the next fire
+                // gets another chance to read the real ones.
+                runCatching {
+                    FetchAndNotifyWorker.enqueueSilentRefresh(appCtx, alarmFiredAtMs = System.currentTimeMillis())
+                    WidgetRefreshScheduler(appCtx).schedule(Schedule.default(), Schedule.defaultTonight())
+                }.onFailure { DiagLog.e(TAG, "Widget-refresh fallback re-arm failed", it) }
+            } finally {
+                pending.finish()
+                scope.cancel()
+            }
+        }
+    }
+
+    companion object {
+        const val ACTION_FIRE = "app.clothescast.alarm.WIDGET_REFRESH"
+        private const val TAG = "WidgetRefreshReceiver"
+    }
+}
+
+/**
+ * True when the window boundary being crossed at [now] is already covered by
+ * an armed delivery alarm — the slot is enabled *and* today is in its
+ * day-of-week set — so the widget chain should defer to the delivery run
+ * rather than double-fetching alongside it. Pure and time-injected for tests.
+ */
+internal fun deliveryCoversWidgetRefresh(
+    dailyEnabled: Boolean,
+    tonightEnabled: Boolean,
+    morning: Schedule,
+    tonight: Schedule,
+    now: LocalDateTime,
+): Boolean = when (
+    FetchAndNotifyWorker.currentPeriodForSchedule(morning.time, tonight.time, now.toLocalTime())
+) {
+    ForecastPeriod.TODAY -> dailyEnabled && now.dayOfWeek in morning.days
+    ForecastPeriod.TONIGHT -> tonightEnabled && now.dayOfWeek in tonight.days
+}

--- a/app/src/main/kotlin/app/clothescast/alarm/WidgetRefreshScheduler.kt
+++ b/app/src/main/kotlin/app/clothescast/alarm/WidgetRefreshScheduler.kt
@@ -1,0 +1,122 @@
+package app.clothescast.alarm
+
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import androidx.core.content.getSystemService
+import app.clothescast.core.domain.model.Schedule
+import app.clothescast.core.domain.model.UserPreferences
+import app.clothescast.diag.DiagLog
+import app.clothescast.widget.hasPlacedClothesCastWidgets
+import java.time.Clock
+import java.time.Instant
+import java.time.LocalTime
+import java.time.ZoneId
+
+/**
+ * Arms the widget-only refresh chain: a single self-re-arming alarm that fires
+ * at the next schedule boundary (the morning or the tonight wall-clock time,
+ * whichever comes first, every day) while at least one ClothesCast widget is
+ * placed. [WidgetRefreshReceiver] handles the fire — it enqueues a *silent*
+ * cache refresh (no notification / TTS / MQTT / cast) and re-arms.
+ *
+ * This chain exists because the delivery alarms are gated on the enable
+ * toggles (and on each schedule's day-of-week set): with a slot disabled — or
+ * on a day outside its day set — nothing else ever fetches in the background,
+ * so a placed widget would cross a window boundary with a stale cache and sit
+ * on its empty state until the user happened to open the app. The enable
+ * toggles gate scheduled *delivery*, not refresh; this chain is the refresh
+ * half of that contract for the launcher surface.
+ *
+ * Unlike [DailyAlarmScheduler] this uses `setAndAllowWhileIdle` (inexact but
+ * doze-tolerant) rather than an exact alarm: nobody is waiting to *hear* the
+ * result, so a few minutes of batching drift is fine and cheaper than burning
+ * the exact-alarm budget twice a day.
+ */
+class WidgetRefreshScheduler(
+    private val context: Context,
+    private val clock: Clock = Clock.systemUTC(),
+) {
+    /**
+     * Arms (or re-arms) the chain for the next boundary after now. Boundary
+     * times come from the two schedules; day-of-week sets are deliberately
+     * ignored — the widget's current window flips at these times every day,
+     * whether or not a cast is scheduled to go out.
+     */
+    fun schedule(morning: Schedule, tonight: Schedule) {
+        val alarmManager = context.getSystemService<AlarmManager>() ?: run {
+            DiagLog.w(TAG, "AlarmManager unavailable; widget-refresh alarm not scheduled")
+            return
+        }
+        val triggerAt = nextWidgetRefreshAfter(clock.instant(), morning.time, tonight.time, morning.zoneId)
+        alarmManager.setAndAllowWhileIdle(
+            AlarmManager.RTC_WAKEUP,
+            triggerAt.toEpochMilli(),
+            pendingIntent(context),
+        )
+        DiagLog.i(TAG, "Widget-refresh alarm armed for $triggerAt")
+    }
+
+    fun cancel() {
+        val alarmManager = context.getSystemService<AlarmManager>() ?: return
+        alarmManager.cancel(pendingIntent(context))
+    }
+
+    companion object {
+        private const val TAG = "WidgetRefreshScheduler"
+        private const val REQUEST_CODE = 0xADA3
+
+        internal fun pendingIntent(context: Context): PendingIntent {
+            val intent = Intent(context, WidgetRefreshReceiver::class.java)
+                .setAction(WidgetRefreshReceiver.ACTION_FIRE)
+            return PendingIntent.getBroadcast(
+                context,
+                REQUEST_CODE,
+                intent,
+                PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+            )
+        }
+    }
+}
+
+/**
+ * The next instant strictly after [now] at which either boundary time occurs
+ * in [zone] — today's remaining boundary if one is still ahead, else the
+ * earliest one tomorrow. Mirrors [Schedule.nextOccurrenceAfter] but daily
+ * (no day-of-week filter) and across both times at once.
+ */
+internal fun nextWidgetRefreshAfter(
+    now: Instant,
+    morningTime: LocalTime,
+    tonightTime: LocalTime,
+    zone: ZoneId,
+): Instant {
+    val zoned = now.atZone(zone)
+    return sequence {
+        for (offset in 0L..1L) {
+            yield(zoned.plusDays(offset).with(morningTime).toInstant())
+            yield(zoned.plusDays(offset).with(tonightTime).toInstant())
+        }
+    }.filter { it.isAfter(now) }.min()
+}
+
+/**
+ * One entry point for keeping the chain consistent with reality: armed while
+ * any ClothesCast widget is placed, cancelled otherwise. Called from every
+ * widget render (the one signal that a widget actually exists — this is what
+ * starts the chain when the first widget is placed), from app start, from
+ * [ScheduleRefreshReceiver] (boot / app update / clock changes wipe alarms),
+ * and from `ClothesCastApplication`'s schedule-time observer (an edit to
+ * either boundary time re-arms the chain immediately instead of leaving the
+ * old boundary armed until its next fire). The chain's own fire also stops
+ * re-arming once no widgets remain.
+ */
+internal fun reconcileWidgetRefreshChain(context: Context, prefs: UserPreferences) {
+    val scheduler = WidgetRefreshScheduler(context)
+    if (hasPlacedClothesCastWidgets(context)) {
+        scheduler.schedule(prefs.schedule, prefs.tonightSchedule)
+    } else {
+        scheduler.cancel()
+    }
+}

--- a/app/src/main/kotlin/app/clothescast/widget/WidgetInsightLoader.kt
+++ b/app/src/main/kotlin/app/clothescast/widget/WidgetInsightLoader.kt
@@ -2,6 +2,7 @@ package app.clothescast.widget
 
 import android.content.Context
 import app.clothescast.ClothesCastApplication
+import app.clothescast.alarm.reconcileWidgetRefreshChain
 import app.clothescast.core.domain.model.ForecastPeriod
 import app.clothescast.core.domain.model.Insight
 import app.clothescast.core.domain.model.UserPreferences
@@ -43,6 +44,14 @@ internal suspend fun loadCurrentInsight(context: Context): Pair<Insight, UserPre
     val prefs = runCatching { app.settingsRepository.preferences.first() }
         .onFailure { DiagLog.w(TAG, "Widget: reading preferences failed", it) }
         .getOrNull() ?: return null
+    // A render is the one signal that a widget is actually placed, so each one
+    // (re)arms the widget-only refresh chain for the next schedule boundary.
+    // Idempotent — boundary times are absolute, so repeated arms collapse onto
+    // the same trigger. This is what keeps a placed widget refreshing when
+    // scheduled delivery is disabled (the delivery alarms are then cancelled
+    // and nothing else fetches in the background); see WidgetRefreshReceiver.
+    runCatching { reconcileWidgetRefreshChain(context, prefs) }
+        .onFailure { DiagLog.w(TAG, "Widget: arming the refresh chain failed", it) }
     val snapshot = runCatching { app.insightCache.thisPeriod.first() }
         .onFailure { DiagLog.w(TAG, "Widget: reading cached snapshot failed", it) }
         .getOrNull()

--- a/app/src/main/kotlin/app/clothescast/widget/WidgetRefresh.kt
+++ b/app/src/main/kotlin/app/clothescast/widget/WidgetRefresh.kt
@@ -1,5 +1,8 @@
 package app.clothescast.widget
 
+import android.appwidget.AppWidgetManager
+import android.content.ComponentName
+import android.content.Context
 import app.clothescast.core.domain.model.ClothesRule
 import app.clothescast.core.domain.model.ColorPalette
 import app.clothescast.core.domain.model.OutfitSuggestion
@@ -50,6 +53,22 @@ data class WidgetInputs(
     val outfitCarriedColors: Map<OutfitSuggestion.Carried, Long>,
     val outfitOuterColors: Map<OutfitSuggestion.Outer, Long>,
 )
+
+/**
+ * True when at least one ClothesCast widget (any of the four providers) is
+ * currently placed on a launcher. Gates the widget-only refresh alarm chain
+ * (see [app.clothescast.alarm.WidgetRefreshScheduler]): armed while this is
+ * true, cancelled once the last widget is removed.
+ */
+internal fun hasPlacedClothesCastWidgets(context: Context): Boolean {
+    val manager = AppWidgetManager.getInstance(context) ?: return false
+    return listOf(
+        OutfitWidgetReceiver::class.java,
+        FeelsLikeWidgetReceiver::class.java,
+        SevenDayFeelsLikeWidgetReceiver::class.java,
+        ConditionsWidgetReceiver::class.java,
+    ).any { manager.getAppWidgetIds(ComponentName(context, it)).isNotEmpty() }
+}
 
 /** Projects the widget-relevant fields out of the full preferences. */
 fun UserPreferences.toWidgetInputs(): WidgetInputs = WidgetInputs(

--- a/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
+++ b/app/src/main/kotlin/app/clothescast/work/FetchAndNotifyWorker.kt
@@ -1810,6 +1810,10 @@ class FetchAndNotifyWorker(
     private suspend fun promoteToPlaybackServiceIfNeeded(prefs: UserPreferences) {
         val alarmTriggered = inputData.getLong(KEY_ALARM_FIRED_AT_MS, 0L) != 0L
         if (!alarmTriggered) return
+        // Widget-chain silent refreshes carry an alarm timestamp (for the
+        // fetch jitter) but never speak — promoting would post a surprise
+        // "Preparing" notification for a run whose whole contract is silence.
+        if (inputData.getBoolean(KEY_SILENT_REFRESH, false)) return
         // ScheduledDeliveryService is the primary FGS owner for alarm-driven
         // runs. While it's holding id 1005, we skip our own setForeground —
         // a second call would clobber its notification and race the type
@@ -2427,8 +2431,15 @@ class FetchAndNotifyWorker(
          * whichever window a previously cached snapshot happens to label
          * itself as. This corrects the slot when an alarm was missed and the
          * cache crossed a period boundary while stale.
+         *
+         * [alarmFiredAtMs] is non-zero only for the widget-refresh alarm chain
+         * ([app.clothescast.alarm.WidgetRefreshReceiver]): those fires land at
+         * the same wall-clock minute across every device sharing a schedule
+         * time, so they opt into the same anti-thundering-herd fetch jitter
+         * the delivery alarms use (see [fresh]). Event-paced kicks (app open,
+         * widget repaint) leave it 0 and fetch immediately.
          */
-        fun enqueueSilentRefresh(context: Context) {
+        fun enqueueSilentRefresh(context: Context, alarmFiredAtMs: Long = 0L) {
             val constraints = Constraints.Builder()
                 .setRequiredNetworkType(NetworkType.CONNECTED)
                 .build()
@@ -2439,6 +2450,7 @@ class FetchAndNotifyWorker(
                 .setInputData(
                     workDataOf(
                         KEY_SILENT_REFRESH to true,
+                        KEY_ALARM_FIRED_AT_MS to alarmFiredAtMs,
                     )
                 )
                 .build()

--- a/app/src/test/kotlin/app/clothescast/alarm/WidgetRefreshReceiverTest.kt
+++ b/app/src/test/kotlin/app/clothescast/alarm/WidgetRefreshReceiverTest.kt
@@ -1,0 +1,171 @@
+package app.clothescast.alarm
+
+import android.app.AlarmManager
+import android.appwidget.AppWidgetManager
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+import androidx.core.content.getSystemService
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.work.Configuration
+import androidx.work.WorkManager
+import app.clothescast.ClothesCastApplication
+import app.clothescast.core.domain.model.ForecastPeriod
+import app.clothescast.widget.OutfitWidgetReceiver
+import app.clothescast.work.FetchAndNotifyWorker
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.runBlocking
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+/**
+ * Receiver coverage for the widget-only refresh chain:
+ *  - no widgets placed → the fire is a no-op and the chain ends (no re-arm);
+ *  - widgets placed with both delivery slots disabled → a silent refresh is
+ *    enqueued and the chain re-arms;
+ *  - widgets placed with delivery covering the boundary → no double-fetch,
+ *    but the chain still re-arms.
+ *
+ * The boundary / day-set decision logic itself is pure and covered by
+ * [WidgetRefreshSchedulerTest].
+ */
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [33])
+class WidgetRefreshReceiverTest {
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val app = context.applicationContext as ClothesCastApplication
+    private val alarmManager: AlarmManager = context.getSystemService()!!
+    private val workManager: WorkManager by lazy {
+        if (!WorkManager.isInitialized()) {
+            WorkManager.initialize(
+                context,
+                Configuration.Builder()
+                    .setMinimumLoggingLevel(Log.WARN)
+                    .setExecutor(Executors.newSingleThreadExecutor())
+                    .setTaskExecutor(Executors.newSingleThreadExecutor())
+                    .build(),
+            )
+        }
+        WorkManager.getInstance(context)
+    }
+
+    @Before
+    fun resetState() {
+        // ClothesCastApplication.onCreate reconciles the delivery alarms and
+        // the widget chain on a background coroutine; with default prefs (both
+        // slots off) and no widgets bound yet, that pass *cancels* all three.
+        // Plant sentinels and wait for the pass to clear them so a late cancel
+        // can't wipe the alarm the receiver-under-test arms (same pattern as
+        // ScheduleRefreshReceiverTest).
+        val sentinels = listOf(
+            DailyAlarmScheduler.pendingIntent(context, ForecastPeriod.TODAY),
+            DailyAlarmScheduler.pendingIntent(context, ForecastPeriod.TONIGHT),
+            WidgetRefreshScheduler.pendingIntent(context),
+        )
+        sentinels.forEach { alarmManager.setExact(AlarmManager.RTC, Long.MAX_VALUE, it) }
+        val deadline = System.currentTimeMillis() + 5_000
+        while (System.currentTimeMillis() < deadline &&
+            shadowOf(alarmManager).scheduledAlarms.isNotEmpty()
+        ) {
+            Thread.sleep(25)
+        }
+        sentinels.forEach { alarmManager.cancel(it) }
+
+        runBlocking {
+            app.settingsRepository.setDailyEnabled(false)
+            app.settingsRepository.setTonightEnabled(false)
+        }
+        // WorkManager's static instance (and its DB) survives across test
+        // methods in this class, so a previous test's silent-refresh record
+        // would still satisfy getWorkInfosForUniqueWork here. Cancel leaves a
+        // CANCELLED record behind — prune finished work too so each test
+        // starts from an empty queue and "isNotEmpty" can only mean "this
+        // test enqueued".
+        workManager.cancelUniqueWork(FetchAndNotifyWorker.UNIQUE_WORK_NAME_SILENT)
+            .result.get(5, TimeUnit.SECONDS)
+        workManager.pruneWork().result.get(5, TimeUnit.SECONDS)
+    }
+
+    @Test
+    fun `fire with no widgets placed ends the chain without refreshing`() {
+        fire()
+
+        // No positive completion signal exists on this path — give the
+        // receiver's coroutine time to finish before asserting the negatives.
+        Thread.sleep(500)
+        shadowOf(alarmManager).scheduledAlarms shouldBe emptyList()
+        workManager.getWorkInfosForUniqueWork(FetchAndNotifyWorker.UNIQUE_WORK_NAME_SILENT)
+            .get(5, TimeUnit.SECONDS)
+            .none { !it.state.isFinished } shouldBe true
+    }
+
+    @Test
+    fun `fire with a widget placed and delivery disabled enqueues a silent refresh and re-arms`() {
+        placeOutfitWidget()
+
+        fire()
+
+        waitForWidgetRefreshAlarm()
+        // Re-arm happens after the enqueue, so once the alarm is visible the
+        // silent queue's state is settled.
+        workManager.getWorkInfosForUniqueWork(FetchAndNotifyWorker.UNIQUE_WORK_NAME_SILENT)
+            .get(5, TimeUnit.SECONDS)
+            .isNotEmpty() shouldBe true
+    }
+
+    @Test
+    fun `fire with delivery covering the boundary re-arms without double-fetching`() {
+        placeOutfitWidget()
+        runBlocking {
+            // Both slots enabled on the default every-day schedules — whichever
+            // window the test's wall clock lands in, delivery covers it.
+            app.settingsRepository.setDailyEnabled(true)
+            app.settingsRepository.setTonightEnabled(true)
+        }
+
+        fire()
+
+        waitForWidgetRefreshAlarm()
+        // The queue was pruned in @Before, and this run's worker (had one been
+        // enqueued) could by now be in any state — so assert no record exists
+        // at all, finished or not.
+        workManager.getWorkInfosForUniqueWork(FetchAndNotifyWorker.UNIQUE_WORK_NAME_SILENT)
+            .get(5, TimeUnit.SECONDS)
+            .isEmpty() shouldBe true
+    }
+
+    private fun fire() {
+        WidgetRefreshReceiver().onReceive(
+            context,
+            Intent(WidgetRefreshReceiver.ACTION_FIRE).setPackage(context.packageName),
+        )
+    }
+
+    private fun placeOutfitWidget() {
+        val appWidgetManager = AppWidgetManager.getInstance(context)
+        shadowOf(appWidgetManager).setAllowedToBindAppWidgets(true)
+        appWidgetManager.bindAppWidgetIdIfAllowed(
+            42,
+            ComponentName(context, OutfitWidgetReceiver::class.java),
+        )
+    }
+
+    private fun waitForWidgetRefreshAlarm() {
+        val deadline = System.currentTimeMillis() + 5_000
+        while (System.currentTimeMillis() < deadline) {
+            val armed = shadowOf(alarmManager).scheduledAlarms.any {
+                shadowOf(it.operation).savedIntent.action == WidgetRefreshReceiver.ACTION_FIRE
+            }
+            if (armed) return
+            Thread.sleep(25)
+        }
+        error("Widget-refresh alarm was not re-armed within 5s")
+    }
+}

--- a/app/src/test/kotlin/app/clothescast/alarm/WidgetRefreshSchedulerTest.kt
+++ b/app/src/test/kotlin/app/clothescast/alarm/WidgetRefreshSchedulerTest.kt
@@ -1,0 +1,134 @@
+package app.clothescast.alarm
+
+import app.clothescast.core.domain.model.Schedule
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.DayOfWeek
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.ZoneId
+
+/**
+ * Pure-logic coverage for the widget-only refresh chain: [nextWidgetRefreshAfter]
+ * (which schedule boundary the chain arms for next — daily, ignoring day-of-week
+ * sets) and [deliveryCoversWidgetRefresh] (when a boundary fire defers to the
+ * delivery alarm instead of double-fetching alongside it). The alarm plumbing is
+ * covered by [WidgetRefreshReceiverTest]. Default 07:00 / 19:00 cutoffs match
+ * the app's default morning / tonight schedule.
+ */
+class WidgetRefreshSchedulerTest {
+
+    private val zone: ZoneId = ZoneId.of("Europe/London")
+    private val morningTime: LocalTime = LocalTime.of(7, 0)
+    private val tonightTime: LocalTime = LocalTime.of(19, 0)
+
+    private fun at(hour: Int, minute: Int, day: Int = 18): Instant =
+        LocalDateTime.of(2026, 6, day, hour, minute).atZone(zone).toInstant()
+
+    @Test
+    fun `before the morning boundary arms for this morning`() {
+        assertEquals(at(7, 0), nextWidgetRefreshAfter(at(5, 59), morningTime, tonightTime, zone))
+    }
+
+    @Test
+    fun `between the boundaries arms for tonight`() {
+        assertEquals(at(19, 0), nextWidgetRefreshAfter(at(12, 30), morningTime, tonightTime, zone))
+    }
+
+    @Test
+    fun `after the tonight boundary arms for tomorrow morning`() {
+        assertEquals(at(7, 0, day = 19), nextWidgetRefreshAfter(at(22, 15), morningTime, tonightTime, zone))
+    }
+
+    @Test
+    fun `exactly at a boundary arms strictly after it`() {
+        // A fire lands at (or just after) its own boundary; re-arming must pick
+        // the *next* one, not re-arm the instant that just fired.
+        assertEquals(at(19, 0), nextWidgetRefreshAfter(at(7, 0), morningTime, tonightTime, zone))
+    }
+
+    @Test
+    fun `crossed schedule still yields the earliest upcoming boundary`() {
+        // Degenerate config (tonight earlier than morning) — the chain doesn't
+        // care which window is which, only when the next flip happens.
+        val next = nextWidgetRefreshAfter(at(5, 0), LocalTime.of(21, 0), LocalTime.of(6, 0), zone)
+        assertEquals(at(6, 0), next)
+    }
+
+    private fun schedule(time: LocalTime, days: Set<DayOfWeek> = Schedule.EVERY_DAY) =
+        Schedule(time = time, days = days, zoneId = zone)
+
+    // 2026-06-18 is a Thursday.
+    private val thursdayMorningFire: LocalDateTime = LocalDateTime.of(2026, 6, 18, 7, 0)
+    private val thursdayTonightFire: LocalDateTime = LocalDateTime.of(2026, 6, 18, 19, 1)
+
+    @Test
+    fun `disabled slots never cover a boundary`() {
+        assertFalse(
+            deliveryCoversWidgetRefresh(
+                dailyEnabled = false,
+                tonightEnabled = false,
+                morning = schedule(morningTime),
+                tonight = schedule(tonightTime),
+                now = thursdayMorningFire,
+            ),
+        )
+    }
+
+    @Test
+    fun `enabled daily slot covers the morning boundary on an active day`() {
+        assertTrue(
+            deliveryCoversWidgetRefresh(
+                dailyEnabled = true,
+                tonightEnabled = false,
+                morning = schedule(morningTime),
+                tonight = schedule(tonightTime),
+                now = thursdayMorningFire,
+            ),
+        )
+    }
+
+    @Test
+    fun `enabled daily slot does not cover the morning boundary outside its day set`() {
+        // Weekend-only morning cast: Thursday's boundary isn't delivery-covered,
+        // so the widget chain must refresh it itself.
+        assertFalse(
+            deliveryCoversWidgetRefresh(
+                dailyEnabled = true,
+                tonightEnabled = false,
+                morning = schedule(morningTime, days = setOf(DayOfWeek.SATURDAY, DayOfWeek.SUNDAY)),
+                tonight = schedule(tonightTime),
+                now = thursdayMorningFire,
+            ),
+        )
+    }
+
+    @Test
+    fun `the daily toggle does not cover the tonight boundary`() {
+        assertFalse(
+            deliveryCoversWidgetRefresh(
+                dailyEnabled = true,
+                tonightEnabled = false,
+                morning = schedule(morningTime),
+                tonight = schedule(tonightTime),
+                now = thursdayTonightFire,
+            ),
+        )
+    }
+
+    @Test
+    fun `enabled tonight slot covers the tonight boundary on an active day`() {
+        assertTrue(
+            deliveryCoversWidgetRefresh(
+                dailyEnabled = false,
+                tonightEnabled = true,
+                morning = schedule(morningTime),
+                tonight = schedule(tonightTime),
+                now = thursdayTonightFire,
+            ),
+        )
+    }
+}

--- a/docs/schedule-lifecycle.md
+++ b/docs/schedule-lifecycle.md
@@ -240,6 +240,24 @@ on any of the other owner-gate fallbacks above.
 - **Silent refresh** (app-open opportunistic, manual Refresh).
   `KEY_SILENT_REFRESH=true` means no notification / TTS / MQTT / cast at all.
   No FGS needed; the Worker runs at normal priority.
+- **Widget-only refresh chain** (`WidgetRefreshScheduler` /
+  `WidgetRefreshReceiver`). While any ClothesCast widget is placed, a
+  self-re-arming inexact alarm (`setAndAllowWhileIdle`, request code
+  `0xADA3`) fires at both schedule boundary times every day — ignoring the
+  enable toggles *and* the schedules' day-of-week sets — and enqueues a
+  silent refresh so the widgets keep tracking the current window. The
+  toggles gate scheduled *delivery*, not refresh: without this chain,
+  disabling both slots cancels every delivery alarm and a placed widget
+  starves (stuck on "No forecast yet" until an app open). A fire whose
+  boundary the delivery alarm already covers (slot enabled and today in its
+  day set) skips the enqueue instead of double-fetching. The chain is armed
+  from every widget render (which is what starts it when the first widget
+  is placed), reconciled on app start, by `ScheduleRefreshReceiver`, and by
+  `ClothesCastApplication`'s schedule-time observer when a boundary time is
+  edited, and ends itself when a fire finds no widgets left. These runs carry
+  `KEY_ALARM_FIRED_AT_MS` purely for the anti-thundering-herd fetch jitter;
+  `promoteToPlaybackServiceIfNeeded` explicitly skips silent runs so they
+  never surface an FGS notification.
 - **Location-cache refresh** (device-location toggle on). Network-only side
   effect, no delivery pipeline.
 

--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -21,7 +21,8 @@ after each cache write / relevant settings change (no per-widget polling):
 
 There's no per-widget polling (`updatePeriodMillis=0`), so the cache only moves
 when the fetch worker writes it: on a scheduled morning/tonight alarm, on
-app-open, or on a manual refresh. With scheduled delivery off, a user who hasn't
+app-open, on a manual refresh, or on a widget-only refresh alarm (below). With
+scheduled delivery off and nothing else driving a fetch, a user who hasn't
 opened the app since yesterday would otherwise see *yesterday's* forecast
 plotted as today's — the per-period feels-like chart plots hour-of-day points
 for the snapshot's own date, so a day-old snapshot draws a previous day's curve
@@ -50,6 +51,27 @@ runs), in the device's wall clock:
   refresh would write the *upcoming* night instead. Keeping the last render until
   the morning cutoff makes the daytime window reachable beats both blanking and
   churning toward a future-night snapshot.
+
+### Widget-only refresh chain
+
+The `REFRESH` self-heal above only runs when something *renders* the widget —
+and with both delivery slots disabled every delivery alarm is cancelled, so
+nothing repaints the launcher and a widget that went empty stayed empty until
+the user opened the app (the "No forecast yet in the morning" report). The
+enable toggles gate scheduled *delivery*, not refresh, so
+`WidgetRefreshScheduler` keeps a separate self-re-arming inexact alarm going
+while any ClothesCast widget is placed: it fires at both schedule boundary
+times every day (ignoring the toggles and the schedules' day-of-week sets —
+the widget's window flips at those times regardless), and
+`WidgetRefreshReceiver` enqueues a silent refresh whose cache write repaints
+the widgets. Fires that coincide with an armed delivery alarm defer to it
+instead of double-fetching. The chain is armed from every widget render via
+`reconcileWidgetRefreshChain` (placement's first render starts it), re-armed on
+app start, by `ScheduleRefreshReceiver` after boot / update / clock changes,
+and by `ClothesCastApplication`'s schedule-time observer when either boundary
+time is edited, and ends itself when a fire finds no widgets left. See
+`docs/schedule-lifecycle.md` for how these silent runs differ from delivery
+runs.
 
 A leading age check is the loop-breaker: the worker stamps `forDate` from the
 *forecast location's* zone but picks the period from the *device* clock, so for


### PR DESCRIPTION
## Problem

Widget stuck on "No outfit yet" / "No forecast yet" again — this time with both delivery schedules disabled.

The enable toggles are meant to gate scheduled *delivery*, not refresh, but disabling a slot also cancels its alarm (SettingsViewModel on toggle-off, AlarmReceiver on a stale fire, app start and ScheduleRefreshReceiver on reconcile). With both slots off, **nothing ever fetches in the background**: the cache only moves on app open, and the widgets only repaint when the fetch worker's cache write calls `updateAll()`. So a placed widget crosses a window boundary with a stale cache, its freshness gate blanks it to the empty state, kicks a silent refresh that can be deferred by doze/no-network — and then nothing ever retries, because the retry only happens on a render and nothing renders it.

## Fix — a widget-only refresh chain

While any ClothesCast widget is placed, a self-re-arming inexact alarm (`setAndAllowWhileIdle`, request code `0xADA3`) fires at both schedule boundary times every day — ignoring the enable toggles **and** the schedules' day-of-week sets, since the widget's current window flips at those times regardless — and enqueues a silent refresh (fetch + cache + widget repaint; no notification, TTS, MQTT, or cast).

- **Defers to delivery:** a fire whose boundary an armed delivery alarm already covers (slot enabled and today in its day set) skips the enqueue instead of double-fetching, but still re-arms.
- **Lifecycle:** armed from every widget render via `reconcileWidgetRefreshChain` (placement's first render starts it); reconciled on app start, by `ScheduleRefreshReceiver` after boot / update / timezone / clock changes, and by a schedule-time preferences observer in `ClothesCastApplication` so editing a boundary time re-arms the chain immediately (addresses Codex's review comment) instead of leaving the old boundary armed until its next fire; ends itself when a fire finds no widgets left.
- **Worker:** `enqueueSilentRefresh` takes an optional `alarmFiredAtMs` so boundary-aligned fires join the same anti-thundering-herd fetch jitter as delivery alarms; `promoteToPlaybackServiceIfNeeded` now explicitly skips silent runs so an alarm-stamped silent refresh can never post a playback foreground notification.
- Inexact alarm rather than exact: nobody is waiting to *hear* the result, so batching drift is fine and cheaper than burning exact-alarm budget twice a day.

Also fixes the sibling gap where an *enabled* schedule with a restricted day set (e.g. weekdays-only) left widgets stale on the excluded days.

Docs: `docs/widgets.md` (freshness section) and `docs/schedule-lifecycle.md` (silent-run inventory) updated.

## Privacy

No change to what leaves the device — the silent refresh is the same Open-Meteo forecast fetch the app already performs, just on a schedule-boundary cadence while widgets are placed.

## Test plan

- `WidgetRefreshSchedulerTest` (pure): next-boundary computation (before/between/after boundaries, strictly-after semantics, degenerate crossed schedule) and the delivery-coverage decision (toggles × day sets × window).
- `WidgetRefreshReceiverTest` (Robolectric): no widgets → chain ends with no enqueue; widgets + delivery disabled → silent refresh enqueued and chain re-armed; widgets + delivery covering → re-arms without double-fetching. The suite prunes WorkManager's cross-test static state in `@Before` so queue assertions only see work the test itself enqueued (the first CI run's single failure).
- Existing alarm/widget/work suites unchanged; CI as the authoritative surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012yrhdTFxL9r8JTRA6F4BPQ