### PR TITLE
Replace deprecated Android and library API usages

### DIFF
--- a/app/src/main/kotlin/app/clothescast/cast/CastDeviceClass.kt
+++ b/app/src/main/kotlin/app/clothescast/cast/CastDeviceClass.kt
@@ -48,6 +48,12 @@ internal fun classifyRoute(route: MediaRouter.RouteInfo): CastDeviceClass {
  * [CastDevice] is attached — covers Cast speaker groups
  * ([MediaRouter.RouteInfo.DEVICE_TYPE_GROUP]) and bare speakers.
  */
+// DEVICE_TYPE_SPEAKER is deprecated in favor of the split
+// builtin/remote-speaker constants, but a route can still report the old
+// value, so it's kept alongside DEVICE_TYPE_REMOTE_SPEAKER to preserve the
+// audio-only classification. The deprecation is suppressed rather than the
+// constant dropped.
+@Suppress("DEPRECATION")
 private val AUDIO_ONLY_DEVICE_TYPES = setOf(
     MediaRouter.RouteInfo.DEVICE_TYPE_SPEAKER,
     MediaRouter.RouteInfo.DEVICE_TYPE_REMOTE_SPEAKER,

--- a/app/src/main/kotlin/app/clothescast/data/SecureKeyStore.kt
+++ b/app/src/main/kotlin/app/clothescast/data/SecureKeyStore.kt
@@ -12,6 +12,7 @@ import app.clothescast.core.data.insight.MissingApiKeyException
 import app.clothescast.diag.DiagLog
 import com.google.crypto.tink.Aead
 import com.google.crypto.tink.KeyTemplates
+import com.google.crypto.tink.RegistryConfiguration
 import com.google.crypto.tink.aead.AeadConfig
 import com.google.crypto.tink.integration.android.AndroidKeysetManager
 import kotlinx.coroutines.flow.Flow
@@ -267,7 +268,7 @@ class SecureKeyStore(
                 .withMasterKeyUri(MASTER_KEY_URI)
                 .build()
                 .keysetHandle
-                .getPrimitive(Aead::class.java)
+                .getPrimitive(RegistryConfiguration.get(), Aead::class.java)
             return SecureKeyStore(aead, context.secureKeyDataStore)
         }
     }

--- a/app/src/main/kotlin/app/clothescast/location/LocationResolver.kt
+++ b/app/src/main/kotlin/app/clothescast/location/LocationResolver.kt
@@ -182,6 +182,7 @@ class LocationResolver(
                     }
                 }
                 @Deprecated("Required override; never called on API 33+ but keep for older devices.")
+                @Suppress("OVERRIDE_DEPRECATION")
                 override fun onStatusChanged(p: String?, status: Int, extras: android.os.Bundle?) {}
                 override fun onProviderEnabled(p: String) {}
             }

--- a/app/src/main/kotlin/app/clothescast/tts/AndroidTtsSpeaker.kt
+++ b/app/src/main/kotlin/app/clothescast/tts/AndroidTtsSpeaker.kt
@@ -84,6 +84,7 @@ class AndroidTtsSpeaker(
                     "Required override; modern TTS engines call onError(id, errorCode) instead.",
                     ReplaceWith("onError(id, TextToSpeech.ERROR)"),
                 )
+                @Suppress("OVERRIDE_DEPRECATION")
                 override fun onError(id: String?) {
                     onError(id, TextToSpeech.ERROR)
                 }

--- a/app/src/main/kotlin/app/clothescast/ui/settings/ClothesSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/ClothesSettings.kt
@@ -26,6 +26,7 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuAnchorType
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.HorizontalDivider
@@ -1289,7 +1290,7 @@ private fun GarmentDropdown(
             trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
             modifier = Modifier
                 .fillMaxWidth()
-                .menuAnchor(),
+                .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable),
         )
         ExposedDropdownMenu(
             expanded = expanded,

--- a/app/src/main/kotlin/app/clothescast/ui/settings/HolidaySettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/HolidaySettings.kt
@@ -852,6 +852,10 @@ private fun resolveHolidayString(name: String): String? {
  * missing and finally to the raw code so the row is always readable.
  */
 @android.annotation.SuppressLint("DiscouragedApi")
+// Locale.of (the non-deprecated replacement for the two-arg Locale constructor)
+// needs API 34; minSdk is 31 with no core-library desugaring, so the deprecated
+// constructor stays and the deprecation is suppressed.
+@Suppress("DEPRECATION")
 private fun resolveCountryDisplayName(
     context: android.content.Context,
     uiLocale: Locale,

--- a/app/src/main/kotlin/app/clothescast/ui/settings/LocationSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/LocationSettings.kt
@@ -36,7 +36,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.Lifecycle

--- a/app/src/main/kotlin/app/clothescast/ui/settings/NotificationPermissionBanner.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/NotificationPermissionBanner.kt
@@ -19,7 +19,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.Lifecycle

--- a/app/src/main/kotlin/app/clothescast/ui/settings/ScheduleSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/ScheduleSettings.kt
@@ -45,7 +45,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp

--- a/app/src/main/kotlin/app/clothescast/ui/today/ForecastChart.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/ForecastChart.kt
@@ -35,7 +35,7 @@ import com.patrykandpatrick.vico.compose.cartesian.axis.VerticalAxis
 import com.patrykandpatrick.vico.compose.cartesian.data.CartesianChartModelProducer
 import com.patrykandpatrick.vico.compose.cartesian.data.CartesianLayerRangeProvider
 import com.patrykandpatrick.vico.compose.cartesian.data.CartesianValueFormatter
-import com.patrykandpatrick.vico.compose.cartesian.data.lineSeries
+import com.patrykandpatrick.vico.compose.cartesian.data.lineModel
 import com.patrykandpatrick.vico.compose.cartesian.layer.LineCartesianLayer
 import com.patrykandpatrick.vico.compose.common.data.ExtraStore
 import kotlin.math.ceil
@@ -180,7 +180,7 @@ fun ForecastChart(
     // even when [overlays] hasn't changed.
     LaunchedEffect(hourly, temperatureUnit, showFeelsLike, overlays, showModelSpread, indexByTime) {
         producer.runTransaction {
-            lineSeries {
+            lineModel {
                 // Main blended line first so it occupies series index 0 in
                 // both single and per-model views — keeps Vico's identity-
                 // by-index animation stable when the spread toggles, so the
@@ -374,7 +374,7 @@ internal fun rememberOnSurfaceAxisLabel() =
 // main line (e.g. the wind diagnostic chart, where there's no single-model
 // blended series to pair the overlays with) — in that case only the per-model
 // lines are returned and they start at index 0. LineProvider.series matches
-// lines to series by index, so this ordering must mirror the lineSeries
+// lines to series by index, so this ordering must mirror the lineModel
 // builder in the caller.
 @Composable
 internal fun rememberPinnedLineProvider(

--- a/app/src/main/kotlin/app/clothescast/ui/today/LastCrashBanner.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/LastCrashBanner.kt
@@ -21,7 +21,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
-import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.Lifecycle

--- a/app/src/main/kotlin/app/clothescast/ui/today/PerModelDiagnosticCard.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/PerModelDiagnosticCard.kt
@@ -31,7 +31,7 @@ import com.patrykandpatrick.vico.compose.cartesian.axis.VerticalAxis
 import com.patrykandpatrick.vico.compose.cartesian.data.CartesianChartModelProducer
 import com.patrykandpatrick.vico.compose.cartesian.data.CartesianLayerRangeProvider
 import com.patrykandpatrick.vico.compose.cartesian.data.CartesianValueFormatter
-import com.patrykandpatrick.vico.compose.cartesian.data.lineSeries
+import com.patrykandpatrick.vico.compose.cartesian.data.lineModel
 import com.patrykandpatrick.vico.compose.common.data.ExtraStore
 import java.time.LocalDate
 import kotlin.math.ceil
@@ -198,7 +198,7 @@ private fun PerModelDiagnosticChart(
     val producer = remember { CartesianChartModelProducer() }
     LaunchedEffect(seriesByModel, overlayModels, mainLine) {
         producer.runTransaction {
-            lineSeries {
+            lineModel {
                 // Main consensus line first so it stays at series index 0
                 // whether or not the overlay is on — see [ForecastChart] for
                 // the rationale (Vico animates by index, so pinning the main

--- a/app/src/main/kotlin/app/clothescast/ui/today/PrecipitationAmountChart.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/PrecipitationAmountChart.kt
@@ -25,7 +25,7 @@ import com.patrykandpatrick.vico.compose.cartesian.axis.VerticalAxis
 import com.patrykandpatrick.vico.compose.cartesian.data.CartesianChartModelProducer
 import com.patrykandpatrick.vico.compose.cartesian.data.CartesianLayerRangeProvider
 import com.patrykandpatrick.vico.compose.cartesian.data.CartesianValueFormatter
-import com.patrykandpatrick.vico.compose.cartesian.data.lineSeries
+import com.patrykandpatrick.vico.compose.cartesian.data.lineModel
 import com.patrykandpatrick.vico.compose.common.data.ExtraStore
 import kotlin.math.max
 import kotlin.math.roundToInt
@@ -79,7 +79,7 @@ fun PrecipitationAmountChart(
     val producer = remember { CartesianChartModelProducer() }
     LaunchedEffect(hourly, overlays, showModelSpread, indexByTime) {
         producer.runTransaction {
-            lineSeries {
+            lineModel {
                 series(mainLine)
                 visibleModels.forEach { modelId ->
                     overlays.getValue(modelId).let { entries ->

--- a/app/src/main/kotlin/app/clothescast/ui/today/PrecipitationChart.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/PrecipitationChart.kt
@@ -24,7 +24,7 @@ import com.patrykandpatrick.vico.compose.cartesian.axis.VerticalAxis
 import com.patrykandpatrick.vico.compose.cartesian.data.CartesianChartModelProducer
 import com.patrykandpatrick.vico.compose.cartesian.data.CartesianLayerRangeProvider
 import com.patrykandpatrick.vico.compose.cartesian.data.CartesianValueFormatter
-import com.patrykandpatrick.vico.compose.cartesian.data.lineSeries
+import com.patrykandpatrick.vico.compose.cartesian.data.lineModel
 import com.patrykandpatrick.vico.compose.common.data.ExtraStore
 import kotlin.math.roundToInt
 
@@ -85,7 +85,7 @@ fun PrecipitationChart(
     // even when [overlays] hasn't changed.
     LaunchedEffect(hourly, overlays, showModelSpread, indexByTime) {
         producer.runTransaction {
-            lineSeries {
+            lineModel {
                 // Main blended line first so it stays at series index 0 in
                 // both single and per-model views — see [ForecastChart] for
                 // the rationale (keeps Vico's by-index animation stable so

--- a/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/TodayScreen.kt
@@ -92,7 +92,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.text.style.TextAlign

--- a/app/src/main/kotlin/app/clothescast/ui/today/UpdateAvailableBanner.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/UpdateAvailableBanner.kt
@@ -24,7 +24,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
-import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.Lifecycle


### PR DESCRIPTION
## What

Resolves the deprecation warnings in the **production** sources so `compileDebugKotlin` is warning-clean. All changes are behavior-preserving — no user-visible change.

| Site | Deprecation | Fix |
|------|-------------|-----|
| 7 UI files | `androidx.compose.ui.platform.LocalLifecycleOwner` | Import the `androidx.lifecycle.compose` replacement (same value). |
| 4 chart files | Vico `Transaction.lineSeries { }` | Rename to `lineModel { }` (identical signature). |
| `ClothesSettings.kt` | `Modifier.menuAnchor()` no-arg | `menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable)` (read-only field). |
| `SecureKeyStore.kt` | `KeysetHandle.getPrimitive(Class)` | `getPrimitive(RegistryConfiguration.get(), Aead::class.java)` — the registry-backed configuration matches the old implicit-registry lookup. No change to what's stored or what leaves the device. |
| `CastDeviceClass.kt` | `MediaRouter.RouteInfo.DEVICE_TYPE_SPEAKER` | Kept in the audio-only set (a route can still report it) with the deprecation suppressed. |
| `HolidaySettings.kt` | `Locale(String, String)` | Suppressed — `Locale.of` needs API 34; minSdk is 31 with no core-library desugaring. |
| `LocationResolver.kt`, `AndroidTtsSpeaker.kt` | override of deprecated `onStatusChanged` / `onError(String)` | Required framework overrides; suppressed with `OVERRIDE_DEPRECATION`. |

## Testing

- `./gradlew compileDebugKotlin --rerun-tasks` — clean, zero deprecation warnings in production sources.
- `./gradlew :core:domain:test :core:data:test :app:testDebugUnitTest` — green.

## Privacy

No change to what crosses the device boundary. The Tink change swaps the primitive-retrieval configuration only; the keyset, encryption, and stored API-key handling are unchanged.

## Out of scope

Test-source deprecations remain — chiefly the `createAndroidComposeRule` → v2 migration (6 sites) that swaps the test dispatcher from `Unconfined` to `StandardTestDispatcher`, plus a few Robolectric shadow deprecations. These need a separate, test-verified pass since the dispatcher change can destabilize the snapshot suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UeZwg5QTBw1YN74sdjzoWn

---
_Generated by [Claude Code](https://claude.ai/code/session_01UeZwg5QTBw1YN74sdjzoWn)_