### PR TITLE
Adopt the v2 Compose test rule in WorkStatusBannerTest

### DIFF
--- a/app/src/test/kotlin/app/clothescast/ui/today/WorkStatusBannerTest.kt
+++ b/app/src/test/kotlin/app/clothescast/ui/today/WorkStatusBannerTest.kt
@@ -2,7 +2,7 @@ package app.clothescast.ui.today
 
 import androidx.activity.ComponentActivity
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4


### PR DESCRIPTION
## What

A single-file trial of the `createComposeRule` / `createAndroidComposeRule` → **v2** migration that was flagged out-of-scope during the production deprecation cleanup (#1099).

`WorkStatusBannerTest` now uses `androidx.compose.ui.test.junit4.v2.createAndroidComposeRule` instead of the deprecated `…junit4.createAndroidComposeRule`.

## Why this is the right trial

The v2 rule swaps the test coroutine dispatcher from `UnconfinedTestDispatcher` (immediate execution) to `StandardTestDispatcher` (queued) — the reason the deprecation warns that "tests relying on immediate execution may require explicit synchronization." `WorkStatusBannerTest` is an **interaction** test (it clicks a Show/Hide details toggle and asserts visibility), so it actually exercises the dispatcher rather than just static composition.

Result: the v2 rule is a **drop-in import swap** — identical reified generic and return type — and all three toggle tests pass unchanged, because the `performClick` / `assertIsDisplayed` / `assertDoesNotExist` assertions already sync to idle. No explicit synchronization needed.

## Testing

- `./gradlew :app:testDebugUnitTest --tests "app.clothescast.ui.today.WorkStatusBannerTest"` — green.

## Next

If CI here confirms it, the same import swap fans out to the remaining `createComposeRule` / `createAndroidComposeRule` sites (a handful in this repo, ~46 in typelauncher). The snapshot (Roborazzi) tests are the ones to watch when scaling — they're more sensitive to dispatcher timing than this interaction test — so the fan-out stays a separate, per-file-verified pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UeZwg5QTBw1YN74sdjzoWn

---
_Generated by [Claude Code](https://claude.ai/code/session_01UeZwg5QTBw1YN74sdjzoWn)_