### PR TITLE
Finish the v2 Compose test rule migration

### DIFF
--- a/app/src/test/kotlin/app/clothescast/ui/nav/NavGraphComposeTest.kt
+++ b/app/src/test/kotlin/app/clothescast/ui/nav/NavGraphComposeTest.kt
@@ -1,7 +1,7 @@
 package app.clothescast.ui.nav
 
 import androidx.activity.ComponentActivity
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable

--- a/app/src/test/kotlin/app/clothescast/ui/today/PreviewSnapshots.kt
+++ b/app/src/test/kotlin/app/clothescast/ui/today/PreviewSnapshots.kt
@@ -5,7 +5,7 @@ import android.graphics.BitmapFactory
 import androidx.activity.ComponentActivity
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.test.isDialog
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
 import androidx.compose.ui.test.onRoot
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import app.clothescast.notification.NotificationIconSweaterPreview

--- a/app/src/test/kotlin/app/clothescast/ui/today/SettingsClothesFullSnapshot.kt
+++ b/app/src/test/kotlin/app/clothescast/ui/today/SettingsClothesFullSnapshot.kt
@@ -1,7 +1,7 @@
 package app.clothescast.ui.today
 
 import androidx.activity.ComponentActivity
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
 import androidx.compose.ui.test.onRoot
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import app.clothescast.ui.settings.SettingsClothesPreview

--- a/app/src/test/kotlin/app/clothescast/ui/today/SettingsVoiceGeminiNoKeySharedFullSnapshot.kt
+++ b/app/src/test/kotlin/app/clothescast/ui/today/SettingsVoiceGeminiNoKeySharedFullSnapshot.kt
@@ -1,7 +1,7 @@
 package app.clothescast.ui.today
 
 import androidx.activity.ComponentActivity
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
 import androidx.compose.ui.test.onRoot
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import app.clothescast.ui.settings.SettingsVoiceGeminiNoKeySharedPreview


### PR DESCRIPTION
## What

Completes the `createAndroidComposeRule` → **v2** migration that #1100 started. Swaps the remaining **four** clothescast test files off the deprecated `androidx.compose.ui.test.junit4.createAndroidComposeRule` onto `…junit4.v2.createAndroidComposeRule`:

- `NavGraphComposeTest` — interaction test
- `PreviewSnapshots`, `SettingsClothesFullSnapshot`, `SettingsVoiceGeminiNoKeySharedFullSnapshot` — Roborazzi snapshot tests

After this, no clothescast test uses the deprecated rule.

## Why it's safe (incl. the snapshot tests)

The v2 rule swaps the test coroutine dispatcher from `UnconfinedTestDispatcher` (immediate) to `StandardTestDispatcher` (queued) — the reason the deprecation warns about tests that rely on immediate execution. The three snapshot tests are the timing-sensitive case (async content settling before `captureRoboImage`), so I verified the render is unchanged rather than assuming:

- `./gradlew :app:testDebugUnitTest` — **BUILD SUCCESSFUL** (full suite; mixed v1/v2 across the module is fine).
- The test task records under `roborazzi.test.record=true`; after the run, **every PNG under `app/snapshots/` is byte-identical** (`git status` on the snapshot dir is empty). Byte-identical re-records ⇒ identical pixels ⇒ the queued dispatcher does not change what these tests capture.

## Notes

- Test-only change (`test:`-prefixed → filtered from the changelog); nothing ships in the APK.
- typelauncher's ~46 remaining sites are the next PR, using this same verified recipe (record → assert snapshots byte-identical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UeZwg5QTBw1YN74sdjzoWn

---
_Generated by [Claude Code](https://claude.ai/code/session_01UeZwg5QTBw1YN74sdjzoWn)_