### PR TITLE
Speak the birthday greeting when a day has more than one celebration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -280,6 +280,19 @@ new rule the first time something bites you, not the third.
   unterminated through to EOF. Compiler reports "Unclosed comment" at the
   end of the file, far from the actual cause. Avoid literal `/*` in doc
   text: write `dir/` or `<path>.png` instead of `dir/*.png`.
+- **Kotlin's `lowercase()` / `uppercase()` are already locale-invariant —
+  don't "fix" them to `Locale.ROOT`.** Unlike Java's `String.toLowerCase()`,
+  the no-argument Kotlin stdlib overloads fold with the invariant locale, so
+  they are *not* subject to the Turkish dotless-ı trap. `code.lowercase()`
+  on an ISO country code is correct as written; rewriting it to
+  `code.lowercase(Locale.ROOT)` is a pure no-op. The locale-sensitive form is
+  the explicit `lowercase(locale)` overload — that one is only for
+  user-visible text (see `InsightFormatter.decapitalize`). Some sites do pass
+  `Locale.ROOT` explicitly; that's documentation, not a behavior difference.
+  This has been mistakenly "fixed" before — verify with a test under
+  `Locale.setDefault(Locale.forLanguageTag("tr-TR"))` before touching any of
+  it. (The default locale *does* matter for `String.format` / `"%d".format(x)`
+  without a `Locale` argument — that one is a real trap.)
 - **Compose `@Preview`s in tests.** Snapshot tests live in `app/src/test`
   (Roborazzi/Robolectric). Preview wrappers live in `app/src/main/.../*Previews.kt`
   with `internal` visibility so they're reachable from tests in the same

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -129,11 +129,20 @@ The source code is at <https://github.com/mikelward/clothescast>.
 - **Why:** To theme today's outfit on holidays your curated catalog
   doesn't cover (Diwali, Eid, Lunar New Year, etc.) and on detected
   birthdays — a celebratory palette + a banner naming the day.
-- **Where it goes:** Nowhere off-device. Detected event titles
-  (including contact names on birthday events) are shown only in the
-  themed banner on your screen — they are **never** read aloud through
-  online TTS, **never** sent to Gemini, and **never** written to
-  Firebase Analytics or Crashlytics.
+- **Where it goes:** Detected event titles — including contact names on
+  birthday events — stay on your device. They are shown only in the themed
+  banner on your screen: **never** read aloud through online TTS, **never**
+  sent to Gemini, and **never** written to Firebase Analytics or
+  Crashlytics.
+
+  One narrow exception, and only if you use the online (Gemini) voice: on a
+  day with a detected birthday, the spoken forecast opens with a generic
+  "Happy birthday" — a fixed phrase from the app's own translations, with
+  no name, no title, and no time. So the request carries the fact that
+  *some* birthday falls today; it carries nothing about whose, or what the
+  event was called. Detected public holidays from your calendar get no
+  greeting at all — those titles are never spoken. On the device voice
+  nothing leaves the phone either way.
 - **Permission:** Both toggles require `READ_CALENDAR`, prompted by
   the toggle itself. Revoking permission later from system Settings
   doesn't auto-flip the toggle off; the reader simply returns no events
@@ -443,9 +452,11 @@ What's **not** sent — these are hard limits, not "best-effort":
 
 - **No calendar event data.** Not titles, not times, not locations, not
   attendees, not whether you have any events at all. The calendar-sourced
-  holiday/birthday classifications described above stay on-device — the
-  themed banner is rendered locally and never read aloud through online
-  TTS, never sent to Gemini, and never written to Firebase.
+  holiday/birthday titles described above stay on-device — the themed
+  banner is rendered locally, never read aloud through online TTS, never
+  sent to Gemini, and never written to Firebase. (The generic "Happy
+  birthday" greeting noted in that section does reach Gemini on the online
+  voice; it never reaches Firebase.)
 - **No user names**, account identifiers, email addresses, or contact
   info. This explicitly includes contact names that may appear on
   birthday-themed banners on the Today screen.

--- a/app/src/main/kotlin/app/clothescast/tts/HolidayGreeting.kt
+++ b/app/src/main/kotlin/app/clothescast/tts/HolidayGreeting.kt
@@ -20,9 +20,10 @@ import java.util.Locale
  * the device boundary into TTS (the prose is sent to Gemini over the BYOK key —
  * see PRIVACY.md). So birthdays collapse to a generic "Happy birthday!" that
  * drops the name the banner shows, calendar public holidays are skipped
- * entirely, and composed multi-celebration banners speak only their catalog
- * pieces. Returns null when there's nothing safe to greet, leaving the plain
- * forecast unchanged.
+ * entirely, and composed multi-celebration banners speak their catalog pieces
+ * plus that same generic birthday stand-in — never a calendar title. Returns
+ * null when there's nothing safe to greet, leaving the plain forecast
+ * unchanged.
  */
 internal fun holidayTtsGreeting(
     context: Context,
@@ -39,14 +40,30 @@ internal fun holidayTtsGreeting(
         !segments.isNullOrEmpty() -> {
             val and = localized.getString(R.string.holiday_banner_and)
             segments
-                // Skip synthetic literal segments (calendar titles); speak only
-                // the catalog/Funny pieces, which resolve from string resources.
                 .mapNotNull { segment ->
                     val key = segment.textKeyByCountry[country.uppercase()] ?: segment.textKey
+                    // Catalog / Funny pieces resolve from string resources.
+                    // A literal segment is a calendar-sourced title and must
+                    // not be spoken — but a birthday still has a safe generic
+                    // stand-in that names nobody, the same one a lone birthday
+                    // theme speaks below. Without it a day whose only
+                    // celebrations are birthdays (two people sharing a date, or
+                    // a birthday alongside a calendar public holiday) fell
+                    // through to an empty list and spoke no greeting at all.
+                    // Calendar public holidays have no safe stand-in, so they
+                    // stay skipped.
                     key?.let { localized.resolveStringByName(it) }
+                        ?: R.string.tts_greeting_birthday
+                            .takeIf { segment.holidayId == HolidayId.BIRTHDAY }
+                            ?.let { localized.getString(it) }
                 }
+                .map { it.trim() }
+                .filter { it.isNotEmpty() }
+                // Two people sharing a birthday contribute one greeting, not
+                // "Happy birthday and Happy birthday".
+                .distinct()
                 .takeIf { it.isNotEmpty() }
-                ?.joinToString(separator = " $and ")
+                ?.joinGreetings(and)
         }
         theme.isSynthetic ->
             if (theme.id == HolidayId.BIRTHDAY) {
@@ -66,6 +83,26 @@ internal fun holidayTtsGreeting(
 }
 
 private val TERMINAL_PUNCTUATION = setOf('.', '!', '?')
+
+/**
+ * Joins the day's greeting pieces with [and] — except after a piece that
+ * already closed its own sentence, which starts a new one instead.
+ *
+ * Several banner strings ship their punctuation as part of the copy
+ * ("¡Feliz Cinco de Mayo!", "Ahoy, matey!"), so gluing the next piece on with
+ * "and" reads as one broken sentence: "¡Feliz Cinco de Mayo! and Happy
+ * birthday!". Stripping the trailing "!" instead would orphan the opening "¡"
+ * that Spanish pairs it with, so the fix is a sentence break, not a trim —
+ * "¡Feliz Cinco de Mayo! Happy birthday!".
+ *
+ * Receiver must be non-empty and carry no blank entries; the caller filters.
+ * The terminal punctuation on the *final* piece is left to
+ * [holidayTtsGreeting], which adds one when the copy doesn't bring its own.
+ */
+private fun List<String>.joinGreetings(and: String): String =
+    reduce { sentence, piece ->
+        if (sentence.last() in TERMINAL_PUNCTUATION) "$sentence $piece" else "$sentence $and $piece"
+    }
 
 // getIdentifier is required: the string name is computed at runtime (holiday
 // key), so a compile-time R.string reference isn't possible.

--- a/app/src/test/kotlin/app/clothescast/tts/InsightTtsUtteranceTest.kt
+++ b/app/src/test/kotlin/app/clothescast/tts/InsightTtsUtteranceTest.kt
@@ -3,7 +3,9 @@ package app.clothescast.tts
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import app.clothescast.core.domain.model.BandClause
+import app.clothescast.core.domain.model.CalendarEvent
 import app.clothescast.core.domain.model.ClothesClause
+import app.clothescast.core.domain.model.EventKind
 import app.clothescast.core.domain.model.FestiveThemes
 import app.clothescast.core.domain.model.ForecastPeriod
 import app.clothescast.core.domain.model.HolidayCatalog
@@ -13,10 +15,13 @@ import app.clothescast.core.domain.model.RangeFormat
 import app.clothescast.core.domain.model.Region
 import app.clothescast.core.domain.model.TemperatureBand
 import app.clothescast.core.domain.model.VoiceLocale
+import app.clothescast.core.domain.usecase.ThemeForToday
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldNotContain
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.time.LocalDate
+import java.time.Month
 import java.util.Locale
 
 @RunWith(AndroidJUnit4::class)
@@ -129,6 +134,96 @@ class InsightTtsUtteranceTest {
     }
 
     @Test
+    fun `two birthdays on one day still speak a single generic greeting`() {
+        // The composed banner reads "Alice's birthday and Bob's birthday", but
+        // both segments are calendar titles that can't be spoken — the greeting
+        // used to collapse to nothing, so a day with two birthdays was quieter
+        // than a day with one.
+        val utterance = insightTtsUtterance(
+            context = context,
+            summary = sampleSummary,
+            region = Region.EN_GB,
+            voiceLocale = VoiceLocale.SYSTEM,
+            fallbackLocale = Locale.US,
+            holidayTheme = composedTheme(
+                LocalDate.of(2026, Month.MAY, 18),
+                birthday("Alice's birthday"),
+                birthday("Bob's birthday"),
+            ),
+        )
+
+        utterance.text shouldBe "Happy birthday! Today, it will be 8° to 15°. Wear a jumper and jacket."
+        utterance.text shouldNotContain "Alice"
+        utterance.text shouldNotContain "Bob"
+    }
+
+    @Test
+    fun `a birthday sharing a catalog holiday is greeted alongside it`() {
+        val utterance = insightTtsUtterance(
+            context = context,
+            summary = sampleSummary,
+            region = Region.EN_GB,
+            voiceLocale = VoiceLocale.SYSTEM,
+            fallbackLocale = Locale.US,
+            holidayTheme = composedTheme(
+                LocalDate.of(2026, Month.DECEMBER, 25),
+                birthday("Alice's birthday"),
+            ),
+        )
+
+        utterance.text shouldBe
+            "Merry Christmas and Happy birthday! Today, it will be 8° to 15°. Wear a jumper and jacket."
+        utterance.text shouldNotContain "Alice"
+    }
+
+    @Test
+    fun `a greeting that brings its own punctuation starts a new sentence`() {
+        // "¡Feliz Cinco de Mayo!" closes its own sentence, so joining the
+        // birthday on with "and" would read as one broken sentence. Trimming
+        // the "!" isn't the answer either — it would orphan the opening "¡".
+        val utterance = insightTtsUtterance(
+            context = context,
+            summary = sampleSummary,
+            region = Region.EN_GB,
+            voiceLocale = VoiceLocale.SYSTEM,
+            fallbackLocale = Locale.US,
+            holidayTheme = composedTheme(
+                LocalDate.of(2026, Month.MAY, 5),
+                birthday("Alice's birthday"),
+            ),
+        )
+
+        utterance.text shouldBe
+            "¡Feliz Cinco de Mayo! Happy birthday! Today, it will be 8° to 15°. Wear a jumper and jacket."
+    }
+
+    @Test
+    fun `a calendar public holiday sharing a birthday keeps its title off-device`() {
+        val utterance = insightTtsUtterance(
+            context = context,
+            summary = sampleSummary,
+            region = Region.EN_GB,
+            voiceLocale = VoiceLocale.SYSTEM,
+            fallbackLocale = Locale.US,
+            holidayTheme = composedTheme(
+                LocalDate.of(2026, Month.MAY, 18),
+                CalendarEvent(
+                    title = "Diwali",
+                    start = LocalDate.of(2026, Month.MAY, 18).atStartOfDay(),
+                    end = LocalDate.of(2026, Month.MAY, 18).atStartOfDay(),
+                    allDay = true,
+                    kind = EventKind.PUBLIC_HOLIDAY,
+                ),
+                birthday("Alice's birthday"),
+            ),
+        )
+
+        utterance.text shouldBe "Happy birthday! Today, it will be 8° to 15°. Wear a jumper and jacket."
+        utterance.text shouldNotContain "Diwali"
+        utterance.text shouldNotContain "Alice"
+    }
+
+    @Test
     fun `nothing-to-say insight stays silent rather than speaking a placeholder`() {
         // RangeFormat.NONE drops the band; with no other clause the spoken
         // briefing is empty (the display card shows "Today, it will be the same
@@ -169,6 +264,25 @@ class InsightTtsUtteranceTest {
     private companion object {
         val christmas = HolidayCatalog.all.first { it.second.id == HolidayId.CHRISTMAS_DAY }.second
         val remembranceDay = HolidayCatalog.all.first { it.second.id == HolidayId.REMEMBRANCE_DAY }.second
+
+        fun birthday(title: String) = CalendarEvent(
+            title = title,
+            start = LocalDate.of(2026, Month.MAY, 18).atStartOfDay(),
+            end = LocalDate.of(2026, Month.MAY, 18).atStartOfDay(),
+            allDay = true,
+            kind = EventKind.BIRTHDAY,
+        )
+
+        /** The multi-celebration theme `ThemeForToday` composes for [date]. */
+        fun composedTheme(date: LocalDate, vararg events: CalendarEvent) =
+            ThemeForToday().resolve(
+                date = date,
+                overrides = emptyMap(),
+                enabledCountries = HolidayCatalog.allCountries,
+                events = events.toList(),
+                themeFromCalendarHolidays = true,
+                themeFromCalendarBirthdays = true,
+            )
 
         val sampleSummary = InsightSummary(
             period = ForecastPeriod.TODAY,

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/model/HolidayTheme.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/model/HolidayTheme.kt
@@ -459,6 +459,17 @@ data class BannerSegment(
     val textKey: String? = null,
     val textKeyByCountry: Map<String, String> = emptyMap(),
     val literalText: String? = null,
+    /**
+     * Which celebration contributed this piece. The banner doesn't need it —
+     * it renders [literalText] / [textKey] directly — but the spoken greeting
+     * does: a [literalText] segment is a calendar-sourced title that must
+     * never cross the device boundary, so speech has to decide *per kind*
+     * whether a safe generic stand-in exists (it does for a birthday, it
+     * doesn't for a calendar public holiday). Without this, a composed theme
+     * that is nothing but birthdays speaks no greeting at all, while a lone
+     * birthday speaks "Happy birthday!".
+     */
+    val holidayId: HolidayId? = null,
 )
 
 /**

--- a/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/ThemeForToday.kt
+++ b/core/domain/src/main/kotlin/app/clothescast/core/domain/usecase/ThemeForToday.kt
@@ -104,13 +104,17 @@ class ThemeForToday(
         val segments = contributors.map { theme ->
             when {
                 theme.displayTitleOverride != null ->
-                    BannerSegment(literalText = theme.displayTitleOverride)
+                    BannerSegment(literalText = theme.displayTitleOverride, holidayId = theme.id)
                 theme.isFunny ->
-                    BannerSegment(textKey = theme.bannerJoinKey ?: theme.bannerTextKey)
+                    BannerSegment(
+                        textKey = theme.bannerJoinKey ?: theme.bannerTextKey,
+                        holidayId = theme.id,
+                    )
                 else ->
                     BannerSegment(
                         textKey = theme.bannerTextKey,
                         textKeyByCountry = theme.bannerTextKeyByCountry,
+                        holidayId = theme.id,
                     )
             }
         }

--- a/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/ThemeForTodayTest.kt
+++ b/core/domain/src/test/kotlin/app/clothescast/core/domain/usecase/ThemeForTodayTest.kt
@@ -462,6 +462,30 @@ class ThemeForTodayTest {
     }
 
     @Test
+    fun `composed banner segments carry the contributing holiday id`() {
+        // The spoken greeting needs to tell a birthday's literal segment (which
+        // has a safe generic stand-in) from a calendar public holiday's (which
+        // doesn't), so every segment names its contributor.
+        val theme = subject.resolve(
+            date = christmas,
+            overrides = noOverrides,
+            enabledCountries = allCountries,
+            events = listOf(birthday("Alice's birthday"), birthday("Bob's birthday")),
+            themeFromCalendarHolidays = false,
+            themeFromCalendarBirthdays = true,
+        )
+        theme.shouldNotBeNull()
+        val segments = theme.bannerSegments.shouldNotBeNull()
+        segments.map { it.holidayId } shouldBe listOf(
+            HolidayId.CHRISTMAS_DAY,
+            HolidayId.BIRTHDAY,
+            HolidayId.BIRTHDAY,
+        )
+        // The literal calendar titles still ride on the segments for the banner.
+        segments.map { it.literalText } shouldBe listOf(null, "Alice's birthday", "Bob's birthday")
+    }
+
+    @Test
     fun `NORMAL kind events are ignored`() {
         val normalEvent = CalendarEvent(
             title = "Standup",


### PR DESCRIPTION
## The bug

When several celebrations land on the same date, `ThemeForToday` composes an ephemeral theme whose banner is a list of `BannerSegment`s rather than a single text key. `holidayTtsGreeting` walked those segments and kept only the ones that resolved to a string resource, dropping every `literalText` segment — correct for privacy, since a calendar-sourced title must never reach Gemini TTS.

But that dropped **birthdays** too, even though a birthday has a safe generic stand-in (`tts_greeting_birthday` → "Happy birthday") that names nobody, and a *lone* birthday theme already speaks it. Concretely:

| Day | Banner | Spoken greeting (before) |
| --- | --- | --- |
| one birthday | "Alice's birthday" | "Happy birthday!" |
| **two birthdays** | "Alice's birthday and Bob's birthday" | **(silence)** |
| **birthday + calendar public holiday** | "Diwali and Alice's birthday" | **(silence)** |
| **birthday + catalog holiday** | "Merry Christmas and Alice's birthday" | "Merry Christmas!" |

So a day with *more* to celebrate was quieter than a day with less — and two people sharing a birthday lost the greeting entirely.

## The fix

`BannerSegment` now carries the contributing `HolidayId`, so speech can decide *per kind* whether a safe generic stand-in exists:

- birthday segments substitute the same generic string the single-birthday path already uses;
- repeats collapse, so two birthdays greet once rather than "Happy birthday and Happy birthday";
- calendar public holidays have no safe stand-in and stay skipped, exactly as before.

The banner is untouched — `TodayScreen` renders `literalText` / `textKey` directly and ignores the new field.

### Punctuation in the join (from review)

Six banner strings ship their punctuation as part of the copy — `¡Feliz Cinco de Mayo!`, `Ahoy, matey!`, `¡Viva México!`, and three more — so gluing the next piece on with "and" read as one broken sentence. Trimming the trailing `!` would orphan the `¡` that Spanish pairs it with, so a piece that already terminated now starts a new sentence instead:

```
¡Feliz Cinco de Mayo! Happy birthday! Today, it will be 8° to 15°. …
```

Unterminated pieces still join with "and" (`Merry Christmas and Happy birthday!`), and the final piece's punctuation is still `holidayTtsGreeting`'s job. This one predates the PR — two punctuated catalog pieces on one date already hit it — but a birthday sharing Cinco de Mayo makes it considerably more likely.

## Privacy — the off-device payload does change

For **Gemini TTS users only** (Device TTS synthesises locally and sends nothing over the network). On the days in the table above, the utterance submitted to Gemini now carries the localized generic birthday greeting where it previously carried nothing, or only the other celebration's copy.

That string is a static string resource: **no calendar title, no name, no event time.** What is newly inferable from a Gemini request log is the bare fact that the user has a birthday in their calendar today on a multi-celebration day — a signal the single-birthday path already sent, now no longer suppressed by an unrelated second celebration.

So the marginal disclosure is one bit ("some birthday exists today"), on days that previously happened to suppress it, to an endpoint that already receives that bit whenever a birthday is the day's only celebration. Stated plainly so the trade is the maintainer's call; an earlier revision of this description said "no change to what leaves the device", which was a true-but-narrow claim about PII and is corrected here.

The tests assert the calendar titles themselves ("Alice", "Bob", "Diwali") stay off the utterance.

### PRIVACY.md correction

Chasing the above turned up an existing overreach in the user-facing policy. The calendar-theming section led with **"Where it goes: Nowhere off-device"** — already too broad *before* this change, since a lone birthday has always put the generic greeting into the Gemini request. The claim about event *titles* was and remains true, so that bullet now says so precisely and names the one narrow exception, instead of implying nothing calendar-derived ever leaves the phone. The Firebase bullet got the same treatment (titles stay local; the generic greeting reaches Gemini but never Firebase).

Note this makes the PR ship a changelog bullet under the repo's PRIVACY.md-is-not-docs rule — intended, since it's a user-visible policy clarification.

## Test plan

`./gradlew :core:domain:test :core:data:test :app:testDebugUnitTest` and `./gradlew :app:assembleDebug` — all green locally. No UI change, and CI confirms 265 snapshots unchanged.

New coverage:
- `ThemeForTodayTest` — composed segments carry their contributing holiday id, and the literal calendar titles still ride along for the banner.
- `InsightTtsUtteranceTest` — two birthdays, birthday + catalog holiday, birthday + calendar public holiday, and the self-punctuating join. Each fails against the previous logic and passes with the fix (verified by reverting `HolidayGreeting.kt` alone).

## Known gap, not fixed here

`TodayScreen` joins the same segments with the same "and" for the visible banner, so `¡Feliz Cinco de Mayo! and Alice's birthday` still renders on screen. Different surface with different constraints (it legitimately shows the calendar title), and pre-existing — flagged for a follow-up rather than widened into this PR.

## Also in this branch

`internal:` commit adding a Kotlin gotcha to `AGENTS.md`: Kotlin's no-arg `String.lowercase()` / `uppercase()` are already locale-invariant (unlike Java's `toLowerCase()`), so they're not subject to the Turkish dotless-ı trap and adding `Locale.ROOT` to them is a no-op. Written down because it's been chased more than once; the note points at `String.format` without a `Locale` as the case that genuinely *is* default-locale sensitive.