### PR TITLE
Fix bug report sharing: screenshots, size, failures, cancellation

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -139,6 +139,21 @@ I put on before I leave?" instead of a full weather-office report.
 - **On-device sensitive state:** Gemini and MQTT passwords are encrypted at rest;
   diagnostic logs and crash payloads can contain rendered insight prose and stay
   local unless the user shares a report or telemetry sends its trimmed payload.
+- **Bug reports are built and shared only on an explicit tap**, via the system
+  share sheet, with the text copied to the clipboard as a fallback; nothing is
+  transmitted automatically. The payload is size-bounded per section — settings,
+  the previous run's crash, the recent log — so no one section can crowd the
+  others out and the whole report still fits a Binder transaction with room to
+  spare (it crosses once into the clipboard and again in the share intent, and an
+  over-large payload fails *both* silently). If collecting the full report fails,
+  a minimal one still ships carrying the in-memory log, rather than the tap
+  crashing the app. **Both delivery routes failing is told to the user**, since a
+  tap that reaches neither the sheet nor the clipboard otherwise looks like it did
+  nothing. A share is **not tied to the screen it was started from** — it runs to
+  completion on the process-lifetime scope, so opening the sheet (or navigating
+  away) can't cancel it mid-collect. The post-crash banner dismisses itself only
+  once a report the user can still get at has been retained; a share that reached
+  nobody leaves the banner up for a retry.
 - **Runtime permissions:** coarse / background location, notifications,
   calendar, and exact-alarm-related platform capabilities must have explicit UX
   and fallbacks.

--- a/app/src/main/kotlin/app/clothescast/diag/BugReport.kt
+++ b/app/src/main/kotlin/app/clothescast/diag/BugReport.kt
@@ -75,6 +75,48 @@ object BugReport {
     private const val MAX_LOG_LINES = 100
 
     /**
+     * The ceiling a whole shared report stays under.
+     *
+     * The line cap above keeps the caption friendly for messenger targets; this
+     * is the hard failure it doesn't cover. Strings parcel as UTF-16, so N
+     * characters cost 2N bytes on the wire, and the payload crosses Binder twice
+     * — into the clipboard, then again in the chooser's `ACTION_SEND` extra. The
+     * per-process Binder buffer is ~1 MB **shared** across every in-flight
+     * transaction, so an unbounded report (a long clothes-rule list, a fat crash
+     * trace) could throw `TransactionTooLargeException` at both ends — and since
+     * both are best-effort, the tap would then do nothing whatsoever: no chooser,
+     * nothing on the clipboard. The three section budgets below add up to 60,000;
+     * the slack covers headers and the one over-budget line each bounded section
+     * may keep.
+     */
+    internal const val MAX_SHARE_PAYLOAD_CHARS = 64_000
+
+    /**
+     * Ceiling for the structured section (build, device, settings, ClothesCasts),
+     * bounded separately from the log so a long clothes-rule list can't crowd the
+     * log out. It degrades most gracefully — a settings dump reads fine
+     * truncated, a truncated log tail loses events.
+     */
+    private const val MAX_STRUCTURED_CHARS = 24_000
+
+    /** Ceiling for the previous run's crash section. */
+    private const val MAX_CRASH_PAYLOAD_CHARS = 16_000
+
+    /**
+     * Of that, the slice reserved for the crash itself (timestamp, exception,
+     * stack) before the recent-log half of the file gets the rest. A capped
+     * 12-frame trace with a cause chain fits comfortably; anything larger is a
+     * pathological trace worth clipping.
+     */
+    private const val MAX_CRASH_STACK_CHARS = 6_000
+
+    /** Cap for an exception message quoted into the collection-failure fallback. */
+    private const val MAX_FAILURE_MESSAGE_CHARS = 300
+
+    /** Ceiling for the recent-log section, on top of the [MAX_LOG_LINES] cap. */
+    private const val MAX_LOG_PAYLOAD_CHARS = 20_000
+
+    /**
      * Captures the screen, builds the text payload, copies the text to the
      * clipboard, and fires the share-sheet chooser. When [includeScreenshot] is
      * true (the default) the current window is grabbed and attached as a PNG so
@@ -121,10 +163,10 @@ object BugReport {
             coRunCatching { app.deriveInsight(nextSnapshot, prefs).insight }.getOrNull()
         } else null
         val crash = DiagLog.readPersistedCrash()
-        val recent = DiagLog.snapshot().takeLast(MAX_LOG_LINES)
+        val recent = DiagLog.snapshot()
         val now = TIMESTAMP_FORMAT.format(Instant.now())
 
-        return buildString {
+        val head = buildString {
             appendLine("ClothesCast bug report")
             appendLine("Captured: $now")
             appendLine()
@@ -157,17 +199,84 @@ object BugReport {
             val wearPreamble = prefs?.wearPreamble ?: PreambleVisibility.ALWAYS
             appendInsight("This period", thisPeriod, thisSnapshot, prefs, context, region, tempUnit, rangeFormat, clothesFormat, bottomsFormat, accessoriesFormat, periodPreamble, wearPreamble)
             appendInsight("Next period", nextPeriod, nextSnapshot, prefs, context, region, tempUnit, rangeFormat, clothesFormat, bottomsFormat, accessoriesFormat, periodPreamble, wearPreamble)
-            if (!crash.isNullOrBlank()) {
+        }
+        return assemble(head, crash, recent)
+    }
+
+    /**
+     * Joins the three sections with each one bounded on its own, so no single
+     * section can crowd the others out or push the whole report past what the
+     * share can carry.
+     *
+     * Prefix-truncating the assembled report would drop the log — appended last —
+     * exactly when a long settings dump or a fat crash trace is what pushed it
+     * over, losing the diagnostic the report exists for. Visible for tests.
+     */
+    internal fun assemble(head: String, crash: String?, recent: List<String>): String {
+        val boundedHead = if (head.length > MAX_STRUCTURED_CHARS) {
+            head.take(MAX_STRUCTURED_CHARS) + "\n…(details truncated to keep the report shareable)\n"
+        } else {
+            head
+        }
+        val crashSection = if (crash.isNullOrBlank()) {
+            ""
+        } else {
+            buildString {
                 appendLine("--- Last crash (from previous run) ---")
-                appendLine(crash.trim())
+                appendLine(boundCrash(crash.trim()))
                 appendLine()
             }
-            appendLine("--- Recent log (newest last, ${recent.size} of max $MAX_LOG_LINES) ---")
-            if (recent.isEmpty()) {
-                appendLine("(no captured log lines)")
-            } else {
-                recent.forEach { appendLine(it) }
-            }
+        }
+        return boundedHead + crashSection + renderRecentLog(recent)
+    }
+
+    /**
+     * Bounds `last-crash.txt` while keeping **both** halves that matter.
+     *
+     * The file is written head-first — timestamp, exception, stack — and then
+     * appends the recent log around the crash ([DiagLog.writeCrashLog]). So
+     * neither end can be dropped wholesale: a head-only cut loses the events
+     * leading up to the crash, and a tail-only cut loses the crash itself, which
+     * is the thing a post-crash report exists to carry. The stack half gets a
+     * reserved slice off the front; whatever it doesn't use goes to the newest
+     * log lines. Visible for tests.
+     */
+    internal fun boundCrash(crash: String): String {
+        val marker = "--- recent log ---"
+        val split = crash.indexOf(marker)
+        if (split < 0) {
+            // Not the shape we wrote (an older build, or a partial file): keep
+            // the newest lines, which is the safer default for a log-like blob.
+            return boundedLogTail(crash.split("\n"), MAX_CRASH_PAYLOAD_CHARS).joinToString("\n")
+        }
+        val stack = crash.take(split + marker.length)
+        val log = crash.substring(split + marker.length).removePrefix("\n")
+        val boundedStack = if (stack.length > MAX_CRASH_STACK_CHARS) {
+            stack.take(MAX_CRASH_STACK_CHARS) + "\n…(stack truncated)\n$marker"
+        } else {
+            stack
+        }
+        val remaining = MAX_CRASH_PAYLOAD_CHARS - boundedStack.length
+        if (remaining <= 0) return boundedStack
+        return boundedStack + "\n" + boundedLogTail(log.split("\n"), remaining).joinToString("\n")
+    }
+
+    /**
+     * The "Recent log" section — the newest [MAX_LOG_LINES] lines, further
+     * bounded by [MAX_LOG_PAYLOAD_CHARS] so a handful of fat entries can't blow
+     * the budget on line count alone. Shared with the collection-failure
+     * fallback, which needs it most.
+     */
+    private fun renderRecentLog(recent: List<String>): String = buildString {
+        val byLine = recent.takeLast(MAX_LOG_LINES)
+        val kept = boundedLogTail(byLine, MAX_LOG_PAYLOAD_CHARS)
+        val dropped = recent.size - kept.size
+        appendLine("--- Recent log (newest last, ${kept.size} of ${recent.size} shown, max $MAX_LOG_LINES) ---")
+        if (recent.isEmpty()) {
+            appendLine("(no captured log lines)")
+        } else {
+            if (dropped > 0) appendLine("($dropped older line(s) omitted to keep the report shareable)")
+            kept.forEach { appendLine(it) }
         }
     }
 
@@ -408,6 +517,11 @@ object BugReport {
     }
 
     private suspend fun captureAndPersistScreenshot(activity: Activity): Uri? {
+        // The share can outlive the screen that started it (it runs on the
+        // application scope). A destroyed window has nothing worth capturing and
+        // PixelCopy against its stale token fails anyway — go straight to a
+        // text-only report instead of spending a 10-30 MB buffer finding out.
+        if (activity.isFinishing || activity.isDestroyed) return null
         val bitmap = coRunCatching { captureWindow(activity) }.getOrNull() ?: return null
         // Compressing a full-window PNG and pruning previous files would block the
         // main thread long enough to jank the share-sheet open, so persist on
@@ -541,7 +655,18 @@ object BugReport {
         if (screenshotUri != null) {
             chooser.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
         }
-        return runCatching { activity.startActivity(chooser); true }
+        // The share runs on the application scope, so it can outlive the screen
+        // that started it. Starting an activity from a torn-down one targets a
+        // dead token, so launch from the application context with NEW_TASK
+        // instead — the chooser still opens, which is the whole point of not
+        // tying the share to the screen.
+        val launchContext: Context = if (activity.isFinishing || activity.isDestroyed) {
+            chooser.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            activity.applicationContext
+        } else {
+            activity
+        }
+        return runCatching { launchContext.startActivity(chooser); true }
             .onFailure { DiagLog.w("BugReport", "share intent failed", it) }
             .getOrDefault(false)
     }
@@ -575,22 +700,35 @@ private const val SCREENSHOT_KEEP_PREVIOUS = 2
 
 /**
  * The newest lines of [lines] (oldest-first) whose combined length fits
- * [budgetChars], returned oldest-first; at least the single newest line is kept
- * even if it alone exceeds the budget. Keeps the freshest context — a crash
+ * [budgetChars], returned oldest-first. Keeps the freshest context — a crash
  * entry and the events around it sit at the *end* of a log, so a head-first
  * truncation would drop exactly what the reader needs.
+ *
+ * A single newest line that alone exceeds the budget is kept **clamped to it**
+ * rather than whole: returning nothing would drop the freshest context
+ * entirely, but returning it whole would blow the very ceiling this exists to
+ * enforce. `last-crash.txt` is the case that can reach that size — it is
+ * written in one go and `cacheDir` survives app upgrades, so a file from an
+ * older build is read back into the report unchanged.
  */
 internal fun boundedLogTail(lines: List<String>, budgetChars: Int): List<String> {
     val kept = ArrayDeque<String>()
     var used = 0
     for (line in lines.asReversed()) {
         val cost = line.length + 1 // + the newline appendLine adds
-        if (used + cost > budgetChars && kept.isNotEmpty()) break
+        if (used + cost > budgetChars) {
+            if (kept.isNotEmpty()) break
+            kept.addFirst(line.take((budgetChars - LOG_TRUNCATION_MARKER.length).coerceAtLeast(0)) + LOG_TRUNCATION_MARKER)
+            break
+        }
         kept.addFirst(line)
         used += cost
     }
     return kept
 }
+
+/** Marks a log line cut short so a reader can tell it was clamped, not written that way. */
+private const val LOG_TRUNCATION_MARKER = "…(truncated)"
 
 /** Walks the [ContextWrapper] chain to find the host [Activity], or returns null. */
 fun Context.findActivity(): Activity? {

--- a/app/src/main/kotlin/app/clothescast/diag/BugReport.kt
+++ b/app/src/main/kotlin/app/clothescast/diag/BugReport.kt
@@ -627,7 +627,13 @@ object BugReport {
         // PixelCopy against its stale token fails anyway — go straight to a
         // text-only report instead of spending a 10-30 MB buffer finding out.
         if (activity.isFinishing || activity.isDestroyed) return null
-        val bitmap = coRunCatching { captureWindow(activity) }.getOrNull() ?: return null
+        // Logged, not silently dropped: a throw before PixelCopy's own guard —
+        // allocating the bitmap, reading the decor view — would otherwise turn
+        // into a text-only report with nothing in the log to say why the
+        // screenshot is missing. coRunCatching, so cancellation still propagates.
+        val bitmap = coRunCatching { captureWindow(activity) }
+            .onFailure { DiagLog.w("BugReport", "window capture failed", it) }
+            .getOrNull() ?: return null
         // Compressing a full-window PNG and pruning previous files would block the
         // main thread long enough to jank the share-sheet open, so persist on
         // Dispatchers.IO.

--- a/app/src/main/kotlin/app/clothescast/diag/BugReport.kt
+++ b/app/src/main/kotlin/app/clothescast/diag/BugReport.kt
@@ -15,10 +15,12 @@ import android.os.Looper
 import android.view.PixelCopy
 import android.view.View
 import android.view.Window
+import android.widget.Toast
 import androidx.core.content.FileProvider
 import androidx.core.graphics.createBitmap
 import app.clothescast.BuildConfig
 import app.clothescast.ClothesCastApplication
+import app.clothescast.R
 import app.clothescast.core.domain.model.AccessoriesFormat
 import app.clothescast.core.domain.model.BottomsFormat
 import app.clothescast.core.domain.model.ClothesFormat
@@ -124,13 +126,116 @@ object BugReport {
      * capture fails) the report shares text-only. The text payload is capped to
      * [MAX_LOG_LINES] log lines so the `EXTRA_TEXT` caption stays under the
      * length limits image-share targets impose.
+     *
+     * Returns whether the report was *retained* somewhere the user can still get
+     * it — i.e. the clipboard copy landed. `ACTION_SEND` gives no delivery or
+     * selection callback, so a launched chooser is no proof the report was sent
+     * (the user can back out of the sheet); the clipboard copy is the durable
+     * fallback that survives that. The post-crash banner gates its
+     * acknowledgement on this, so a share that reached nobody leaves the banner
+     * up for a retry instead of quietly dismissing it.
+     *
+     * [mainDispatcher], [payloadCollect], [screenshotCapture], [clipboardWrite],
+     * and [chooserLaunch] are injectable test seams (production uses the
+     * defaults): each delivery route can fail on its own, and both the return
+     * value and the failure notice are behavior a test must be able to drive
+     * every way, without a real window, `ClipboardManager`, or share target.
      */
-    suspend fun share(activity: Activity, includeScreenshot: Boolean = true) {
-        val app = activity.application as ClothesCastApplication
-        val text = buildPayload(activity, app)
-        val screenshotUri: Uri? = if (includeScreenshot) captureAndPersistScreenshot(activity) else null
-        copyToClipboard(activity, text)
-        startShare(activity, text, screenshotUri)
+    suspend fun share(
+        activity: Activity,
+        includeScreenshot: Boolean = true,
+        mainDispatcher: CoroutineDispatcher = Dispatchers.Main,
+        payloadCollect: suspend (Context, ClothesCastApplication) -> String = ::buildPayload,
+        screenshotCapture: suspend (Activity) -> Uri? = ::captureAndPersistScreenshot,
+        clipboardWrite: (Context, String) -> Boolean = ::copyToClipboard,
+        chooserLaunch: (Activity, String, Uri?) -> Boolean = ::startShare,
+    ): Boolean {
+        val app = activity.application as? ClothesCastApplication
+        val text = try {
+            // Off the main thread: the payload reads preferences, the insight
+            // cache, and the crash file from disk, and share() is launched from a
+            // UI tap — blocking there janks the frame the share sheet animates in
+            // over.
+            withContext(Dispatchers.IO) {
+                if (app == null) error("no ClothesCastApplication") else payloadCollect(activity, app)
+            }
+        } catch (c: CancellationException) {
+            throw c
+        } catch (t: Throwable) {
+            // A report is most useful after something has already gone wrong.
+            // Never turn a failure while inspecting that state into another
+            // crash: this runs from a tap, where an escaping throwable takes the
+            // app down. Retain a small shareable diagnostic instead.
+            DiagLog.w("BugReport", "payload collection failed", t)
+            buildFallbackPayload(t)
+        }
+        // The capture draws the live window via PixelCopy and the clipboard /
+        // chooser hand-off touches the Activity, so all three are pinned to the
+        // main thread — the payload build above hopped to IO and its continuation
+        // must not leave this on a worker thread.
+        return withContext(mainDispatcher) {
+            val screenshotUri: Uri? = if (includeScreenshot) screenshotCapture(activity) else null
+            // Guarded: both are injectable seams, and share() runs in a caller's
+            // coroutine scope where an escaping throwable would take the app down
+            // with it — the one thing a bug-report path must never do.
+            // Each logs what it caught: these guards also cover the work *around*
+            // the inner logged ones (building the chooser intent, resolving the
+            // clipboard service), so without this the user could see only the
+            // generic toast while the log said nothing about why.
+            val copied = runCatching { clipboardWrite(activity, text) }
+                .onFailure { DiagLog.w("BugReport", "clipboard hand-off threw", it) }
+                .getOrDefault(false)
+            val launched = runCatching { chooserLaunch(activity, text, screenshotUri) }
+                .onFailure { DiagLog.w("BugReport", "chooser hand-off threw", it) }
+                .getOrDefault(false)
+            // Neither route landed: the tap would otherwise do nothing visible at
+            // all — no chooser, nothing on the clipboard — and the user would
+            // retry into the same silence. Say so instead.
+            if (!copied && !launched) notifyShareFailed(activity)
+            copied
+        }
+    }
+
+    /**
+     * The report to fall back on when collecting the real one threw. Deliberately
+     * tiny and dependency-free — it reads nothing off disk, because a disk read
+     * is what most plausibly just failed — but it still carries the in-memory log
+     * tail, which is the diagnostic the report exists for. Without it the
+     * fallback would be four lines that say nothing about what went wrong, on the
+     * one path that only runs when something already has.
+     */
+    private fun buildFallbackPayload(failure: Throwable): String = buildString {
+        appendLine("ClothesCast bug report")
+        appendLine("Version: ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})")
+        appendLine("Android: ${Build.VERSION.RELEASE} (SDK ${Build.VERSION.SDK_INT})")
+        // The message is clipped: an exception can carry a whole response body
+        // or a serialized value, and an unbounded fallback would blow the very
+        // ceiling this path exists to stay under — on the one path that runs
+        // when the normal report couldn't even be built.
+        val why = failure.message?.take(MAX_FAILURE_MESSAGE_CHARS)
+        appendLine("Report collection failed: ${failure.javaClass.name}" + (why?.let { ": $it" } ?: ""))
+        // If reading the log fails too — plausible, since the same storage
+        // problem could be behind both — say so in the report. Falling through
+        // to the empty-log sentinel would tell the reader "nothing was logged"
+        // when the truth is "the log couldn't be read," and lose the second
+        // failure entirely.
+        val recent = runCatching { DiagLog.snapshot() }
+            .onFailure {
+                DiagLog.w("BugReport", "log snapshot failed while building the fallback report", it)
+                appendLine("Recent log unavailable: ${it.javaClass.name}")
+            }
+            .getOrDefault(emptyList())
+        append(renderRecentLog(recent))
+    }
+
+    /** Tells the user a share reached neither the chooser nor the clipboard. */
+    private fun notifyShareFailed(context: Context) {
+        // Logged, not swallowed: this is the last user-visible fallback after
+        // both delivery routes already failed, so if it throws too the tap does
+        // nothing at all — and the log is then the only place that can say why.
+        runCatching {
+            Toast.makeText(context, R.string.bug_report_share_failed, Toast.LENGTH_LONG).show()
+        }.onFailure { DiagLog.w("BugReport", "share-failed notice could not be shown", it) }
     }
 
     private suspend fun buildPayload(context: Context, app: ClothesCastApplication): String {

--- a/app/src/main/kotlin/app/clothescast/diag/BugReport.kt
+++ b/app/src/main/kotlin/app/clothescast/diag/BugReport.kt
@@ -34,8 +34,12 @@ import app.clothescast.core.domain.model.symbol
 import app.clothescast.core.domain.util.coRunCatching
 import app.clothescast.data.SettingsRepository
 import app.clothescast.insight.InsightFormatter
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
 import java.io.File
 import java.io.FileOutputStream
 import java.time.Duration
@@ -405,20 +409,60 @@ object BugReport {
 
     private suspend fun captureAndPersistScreenshot(activity: Activity): Uri? {
         val bitmap = coRunCatching { captureWindow(activity) }.getOrNull() ?: return null
-        return runCatching {
-            val dir = File(activity.cacheDir, "bug-reports").apply { mkdirs() }
-            // Wipe older screenshots — keep only the freshest one to avoid cache bloat.
-            dir.listFiles()?.forEach { it.delete() }
-            val file = File(dir, "screenshot-${System.currentTimeMillis()}.png")
-            FileOutputStream(file).use { out ->
-                bitmap.compress(Bitmap.CompressFormat.PNG, 100, out)
+        // Compressing a full-window PNG and pruning previous files would block the
+        // main thread long enough to jank the share-sheet open, so persist on
+        // Dispatchers.IO.
+        return try {
+            withContext(Dispatchers.IO) {
+                coRunCatching {
+                    val dir = File(activity.cacheDir, SCREENSHOT_DIR_NAME).apply { mkdirs() }
+                    // Prune old captures but keep the most recent couple: a
+                    // FileProvider URI from an earlier share may still be held by
+                    // its target (an unsent email draft, a messaging app that
+                    // reads attachments lazily), and deleting every file here
+                    // retroactively broke that grant — the attachment failed with
+                    // FileNotFoundException when the target finally read it.
+                    prunePersistedScreenshots(dir, keepNewest = SCREENSHOT_KEEP_PREVIOUS)
+                    val file = File(dir, "screenshot-${System.currentTimeMillis()}.png")
+                    FileOutputStream(file).use { out ->
+                        bitmap.compress(Bitmap.CompressFormat.PNG, 100, out)
+                    }
+                    FileProvider.getUriForFile(
+                        activity,
+                        activity.packageName + FILE_PROVIDER_AUTHORITY_SUFFIX,
+                        file,
+                    )
+                }.onFailure { DiagLog.w("BugReport", "screenshot persist failed", it) }.getOrNull()
             }
-            FileProvider.getUriForFile(
-                activity,
-                activity.packageName + FILE_PROVIDER_AUTHORITY_SUFFIX,
-                file,
-            )
-        }.onFailure { DiagLog.w("BugReport", "screenshot persist failed", it) }.getOrNull()
+        } finally {
+            // Only the PNG on disk outlives this call; free the full-window
+            // ARGB_8888 buffer (10-30 MB on current phones) now instead of
+            // waiting for GC. Safe even on cancellation: withContext waits for
+            // its block, so the compress has finished with the bitmap by the time
+            // we get here.
+            bitmap.recycle()
+        }
+    }
+
+    /**
+     * Deletes all but the [keepNewest] most recent `screenshot-*.png` captures in
+     * [dir], newest judged by the millis embedded in the filename (falling back
+     * to `lastModified` for a name that doesn't parse). Called before each new
+     * capture is written, so the directory holds at most [keepNewest] + 1 files —
+     * bounded growth without invalidating the URI a previous share target may
+     * still hold. Visible for tests.
+     */
+    internal fun prunePersistedScreenshots(dir: File, keepNewest: Int) {
+        val captures = dir.listFiles { file ->
+            file.isFile && file.name.startsWith("screenshot-") && file.name.endsWith(".png")
+        } ?: return
+        captures
+            .sortedByDescending { file ->
+                file.name.removePrefix("screenshot-").removeSuffix(".png").toLongOrNull()
+                    ?: file.lastModified()
+            }
+            .drop(keepNewest)
+            .forEach { it.delete() }
     }
 
     private suspend fun captureWindow(activity: Activity): Bitmap? {
@@ -426,23 +470,44 @@ object BugReport {
         val view: View = window.decorView
         if (view.width <= 0 || view.height <= 0) return null
         val bitmap = createBitmap(view.width, view.height)
-        return suspendCancellableCoroutine { cont ->
-            val location = IntArray(2)
-            view.getLocationInWindow(location)
-            val rect = Rect(
-                location[0],
-                location[1],
-                location[0] + view.width,
-                location[1] + view.height,
-            )
-            try {
-                requestPixelCopy(window, rect, bitmap) { ok ->
-                    cont.resume(if (ok) bitmap else null)
+        val location = IntArray(2)
+        view.getLocationInWindow(location)
+        val rect = Rect(
+            location[0],
+            location[1],
+            location[0] + view.width,
+            location[1] + view.height,
+        )
+        return awaitPixelCopyInto(bitmap) { onResult -> requestPixelCopy(window, rect, bitmap, onResult) }
+    }
+
+    /**
+     * Suspends until [request] reports whether the copy into [bitmap] landed,
+     * returning the bitmap on success and null on failure. The bitmap is a
+     * full-window ARGB_8888 buffer (10-30 MB on current phones), so every path
+     * that does not hand it to the caller recycles it: a failed copy, a
+     * synchronous throw from [request], and a caller cancelled before the result
+     * arrived. In the cancelled case the recycle happens in the (now ignored)
+     * result callback rather than eagerly at cancellation time, because PixelCopy
+     * may still be writing into the buffer until then. Visible for tests.
+     */
+    internal suspend fun awaitPixelCopyInto(
+        bitmap: Bitmap,
+        request: (onResult: (Boolean) -> Unit) -> Unit,
+    ): Bitmap? = suspendCancellableCoroutine { cont ->
+        try {
+            request { ok ->
+                if (ok) {
+                    cont.resume(bitmap) { _, _, _ -> bitmap.recycle() }
+                } else {
+                    bitmap.recycle()
+                    cont.resume(null)
                 }
-            } catch (t: Throwable) {
-                DiagLog.w("BugReport", "PixelCopy.request threw", t)
-                cont.resume(null)
             }
+        } catch (t: Throwable) {
+            DiagLog.w("BugReport", "PixelCopy.request threw", t)
+            bitmap.recycle()
+            cont.resume(null)
         }
     }
 
@@ -458,7 +523,8 @@ object BugReport {
         }, handler)
     }
 
-    private fun startShare(activity: Activity, text: String, screenshotUri: Uri?) {
+    /** Returns whether the chooser actually launched. */
+    private fun startShare(activity: Activity, text: String, screenshotUri: Uri?): Boolean {
         val send = Intent(Intent.ACTION_SEND).apply {
             putExtra(Intent.EXTRA_SUBJECT, "ClothesCast bug report — ${BuildConfig.VERSION_NAME}")
             putExtra(Intent.EXTRA_TEXT, text)
@@ -475,16 +541,55 @@ object BugReport {
         if (screenshotUri != null) {
             chooser.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
         }
-        runCatching { activity.startActivity(chooser) }
+        return runCatching { activity.startActivity(chooser); true }
             .onFailure { DiagLog.w("BugReport", "share intent failed", it) }
+            .getOrDefault(false)
     }
 
-    private fun copyToClipboard(context: Context, text: String) {
+    /**
+     * Returns whether the report actually landed on the clipboard — the durable
+     * retained delivery [share] reports back to its caller.
+     */
+    private fun copyToClipboard(context: Context, text: String): Boolean =
         runCatching {
-            val cm = context.getSystemService(ClipboardManager::class.java) ?: return
-            cm.setPrimaryClip(ClipData.newPlainText("ClothesCast bug report", text))
+            val cm = context.getSystemService(ClipboardManager::class.java)
+            if (cm == null) {
+                false
+            } else {
+                cm.setPrimaryClip(ClipData.newPlainText("ClothesCast bug report", text))
+                true
+            }
         }.onFailure { DiagLog.w("BugReport", "clipboard copy failed", it) }
+            .getOrDefault(false)
+}
+
+/** Cache subdirectory holding the captures attached to bug reports. */
+private const val SCREENSHOT_DIR_NAME = "bug-reports"
+
+/**
+ * How many previous captures survive a new one. Two covers the realistic window
+ * (the share the user just sent plus one before it) at ~a few MB of cache;
+ * anything older has no live URI grant worth preserving.
+ */
+private const val SCREENSHOT_KEEP_PREVIOUS = 2
+
+/**
+ * The newest lines of [lines] (oldest-first) whose combined length fits
+ * [budgetChars], returned oldest-first; at least the single newest line is kept
+ * even if it alone exceeds the budget. Keeps the freshest context — a crash
+ * entry and the events around it sit at the *end* of a log, so a head-first
+ * truncation would drop exactly what the reader needs.
+ */
+internal fun boundedLogTail(lines: List<String>, budgetChars: Int): List<String> {
+    val kept = ArrayDeque<String>()
+    var used = 0
+    for (line in lines.asReversed()) {
+        val cost = line.length + 1 // + the newline appendLine adds
+        if (used + cost > budgetChars && kept.isNotEmpty()) break
+        kept.addFirst(line)
+        used += cost
     }
+    return kept
 }
 
 /** Walks the [ContextWrapper] chain to find the host [Activity], or returns null. */

--- a/app/src/main/kotlin/app/clothescast/ui/BugReportOverflowMenu.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/BugReportOverflowMenu.kt
@@ -85,9 +85,16 @@ internal fun BugReportOverflowMenu(
                 val act = activity
                 val repo = app?.settingsRepository
                 if (act != null && repo != null) {
+                    // Split by what each branch owns. The consent read stays on
+                    // the composition, because its only outcome is composition
+                    // state — a dialog that a torn-down screen can't show
+                    // anyway. The share hops to the application scope, because
+                    // it must outlive the screen: the menu closes on tap and the
+                    // sheet takes the foreground while the hand-off is still
+                    // suspended.
                     coroutineScope.launch {
                         if (repo.bugReportConsentAcknowledged.first()) {
-                            BugReport.share(act)
+                            app.applicationScope.launch { BugReport.share(act) }
                         } else {
                             consentVisible = true
                         }
@@ -115,7 +122,13 @@ internal fun BugReportOverflowMenu(
                 consentVisible = false
                 val act = activity
                 if (act != null) {
-                    coroutineScope.launch {
+                    // Application scope for the whole sequence, for the same
+                    // reason as above — and here it matters twice: the dialog is
+                    // dismissed on this tap, so a composition-scoped coroutine
+                    // could be cancelled during the "don't show again" write and
+                    // never launch the share the user just confirmed.
+                    val scope = app?.applicationScope ?: coroutineScope
+                    scope.launch {
                         if (dontShowAgain) {
                             app?.settingsRepository?.setBugReportConsentAcknowledged(true)
                         }

--- a/app/src/main/kotlin/app/clothescast/ui/settings/AboutSettings.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/settings/AboutSettings.kt
@@ -76,7 +76,11 @@ private fun AboutCard() {
 
     val launchBugReport: () -> Unit = launchBugReport@{
         val act = activity ?: return@launchBugReport
-        coroutineScope.launch { BugReport.share(act) }
+        // On the application scope: the share sheet taking the foreground (or the
+        // user navigating away while the payload is still being built) tears this
+        // screen down, and a composition-scoped share would be cancelled partway
+        // through — the report would silently never arrive.
+        app.applicationScope.launch { BugReport.share(act) }
     }
 
     SectionCard(title = stringResource(R.string.settings_about_title)) {

--- a/app/src/main/kotlin/app/clothescast/ui/today/LastCrashBanner.kt
+++ b/app/src/main/kotlin/app/clothescast/ui/today/LastCrashBanner.kt
@@ -86,11 +86,20 @@ internal fun LastCrashBanner(modifier: Modifier = Modifier) {
 
     val shareCrashReport: () -> Unit = shareCrashReport@{
         val act = activity ?: return@shareCrashReport
-        coroutineScope.launch {
+        // On the application scope, not the composition's: the banner hides the
+        // moment the crash is acknowledged and the share sheet takes the
+        // foreground, either of which tears this composable down — and a
+        // composition-scoped share would be cancelled partway through, so the
+        // report the user asked for silently never arrived.
+        app.applicationScope.launch {
             // No screenshot: the crash is from a previous run, so the screen
             // visible now would be misleading attached to that report.
-            BugReport.share(act, includeScreenshot = false)
-            DiagLog.acknowledgePersistedCrash()
+            val retained = BugReport.share(act, includeScreenshot = false)
+            // Acknowledge only a report the user can still get at (the clipboard
+            // copy landed). If neither route landed, the banner stays up for a
+            // retry rather than quietly dismissing itself over a share that
+            // reached nobody.
+            if (retained) DiagLog.acknowledgePersistedCrash()
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1206,6 +1206,10 @@
     <string name="bug_report_consent_dont_show_again">Don\'t show this again</string>
     <string name="bug_report_consent_continue">Continue</string>
     <string name="bug_report_consent_cancel">Cancel</string>
+    <!-- Shown when a share reached neither a share target nor the clipboard, so
+         the tap would otherwise look like it did nothing at all. -->
+    <!-- TODO: translate -->
+    <string name="bug_report_share_failed" tools:ignore="MissingTranslation">Couldn\'t share the bug report</string>
 
     <!--
     Insight prose templates rendered by InsightFormatter. Each clause is its own

--- a/app/src/test/kotlin/app/clothescast/diag/BugReportBoundsTest.kt
+++ b/app/src/test/kotlin/app/clothescast/diag/BugReportBoundsTest.kt
@@ -1,0 +1,112 @@
+package app.clothescast.diag
+
+import io.kotest.matchers.comparables.shouldBeLessThanOrEqualTo
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import org.junit.jupiter.api.Test
+
+/**
+ * The assembled report has to survive the trip to a share target. It crosses
+ * Binder twice (clipboard, then the chooser's `ACTION_SEND` extra) against a
+ * ~1 MB per-process buffer shared with every other in-flight transaction, and
+ * both hand-offs are best-effort — so an oversized report used to make the tap
+ * do nothing at all. Each section is bounded on its own, and the newest lines
+ * are the ones kept: a crash entry and the events around it sit at the *end* of
+ * a log.
+ */
+class BugReportBoundsTest {
+
+    @Test
+    fun `a huge settings section still leaves room for the log`() {
+        val head = "--- Settings ---\n" + (0 until 4_000).joinToString("\n") { "Clothes rule $it: " + "x".repeat(40) }
+
+        val report = BugReport.assemble(head, crash = null, recent = listOf("the newest event"))
+
+        report shouldContain "details truncated"
+        report shouldContain "the newest event"
+        report.length shouldBeLessThanOrEqualTo BugReport.MAX_SHARE_PAYLOAD_CHARS
+    }
+
+    @Test
+    fun `an oversized crash section keeps both the crash and the newest log lines`() {
+        // last-crash.txt is written head-first (timestamp, exception, stack) and
+        // then appends the log around the crash, so neither end can be dropped
+        // wholesale: a tail-only cut loses the crash the report exists to carry.
+        val crash = "=== 2026-01-01 ===\nUncaught exception on thread \"main\"\n" +
+            (0 until 2_000).joinToString("\n") { "\tat frame-$it " + "x".repeat(60) } +
+            "\n--- recent log ---\n" +
+            (0 until 2_000).joinToString("\n") { "log-$it " + "x".repeat(60) } +
+            "\nthe last line before the crash"
+
+        val report = BugReport.assemble("head\n", crash, recent = emptyList())
+
+        report shouldContain "Uncaught exception on thread"
+        report shouldContain "\tat frame-0 "
+        report shouldContain "the last line before the crash"
+        report shouldNotContain "log-0 "
+        report.length shouldBeLessThanOrEqualTo BugReport.MAX_SHARE_PAYLOAD_CHARS
+    }
+
+    @Test
+    fun `a crash file of an unrecognized shape keeps its newest lines`() {
+        // An older build's file, or a partial write: no "recent log" marker to
+        // split on, so fall back to keeping the freshest end.
+        val crash = (0 until 2_000).joinToString("\n") { "line-$it " + "x".repeat(60) } + "\nthe newest line"
+
+        val report = BugReport.assemble("head\n", crash, recent = emptyList())
+
+        report shouldContain "the newest line"
+        report shouldNotContain "line-0 "
+        report.length shouldBeLessThanOrEqualTo BugReport.MAX_SHARE_PAYLOAD_CHARS
+    }
+
+    @Test
+    fun `an oversized log keeps its newest lines and says what it dropped`() {
+        val recent = (0 until 300).map { "line-$it " + "x".repeat(600) } + "the newest event"
+
+        val report = BugReport.assemble("head\n", crash = null, recent = recent)
+
+        report shouldContain "the newest event"
+        report shouldNotContain "line-0 "
+        report shouldContain "older line(s) omitted"
+        report.length shouldBeLessThanOrEqualTo BugReport.MAX_SHARE_PAYLOAD_CHARS
+    }
+
+    @Test
+    fun `every section at its largest still fits`() {
+        val report = BugReport.assemble(
+            head = "x".repeat(200_000),
+            crash = (0 until 2_000).joinToString("\n") { "frame-$it " + "x".repeat(60) },
+            recent = (0 until 300).map { "line-$it " + "x".repeat(600) },
+        )
+
+        report.length shouldBeLessThanOrEqualTo BugReport.MAX_SHARE_PAYLOAD_CHARS
+    }
+
+    @Test
+    fun `an empty log is called out rather than left blank`() {
+        BugReport.assemble("head\n", crash = null, recent = emptyList()) shouldContain
+            "(no captured log lines)"
+    }
+
+    @Test
+    fun `boundedLogTail clamps a newest line that alone overflows the budget`() {
+        // Keeping it whole would blow the very ceiling this enforces; dropping
+        // it would lose the freshest context. Clamp and mark it.
+        val kept = boundedLogTail(listOf("old", "x".repeat(500)), budgetChars = 40).single()
+
+        kept.length shouldBe 40
+        kept.endsWith("…(truncated)") shouldBe true
+    }
+
+    @Test
+    fun `a single oversized crash line is clamped, not passed through`() {
+        // `cacheDir` survives app upgrades, so last-crash.txt from an older
+        // build can hold one arbitrarily long line and is read back unchanged.
+        val report = BugReport.assemble("head\n", crash = "x".repeat(500_000), recent = emptyList())
+
+        report shouldContain "…(truncated)"
+        report.length shouldBeLessThanOrEqualTo BugReport.MAX_SHARE_PAYLOAD_CHARS
+    }
+}

--- a/app/src/test/kotlin/app/clothescast/diag/BugReportScreenshotPruneTest.kt
+++ b/app/src/test/kotlin/app/clothescast/diag/BugReportScreenshotPruneTest.kt
@@ -1,0 +1,61 @@
+package app.clothescast.diag
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+
+/**
+ * Covers the bug-report screenshot cache pruning. Each new capture prunes the
+ * directory but must keep the most recent previous captures: a FileProvider URI
+ * from an earlier share can still be held by its target (an unsent email draft,
+ * a lazily-reading messaging app), and the old delete-everything sweep broke
+ * that grant retroactively — the attachment failed with FileNotFoundException
+ * when the target finally read it.
+ */
+class BugReportScreenshotPruneTest {
+
+    @Test
+    fun `prune keeps the newest captures and deletes older ones`(@TempDir tmp: Path) {
+        val dir = tmp.toFile()
+        val oldest = dir.resolve("screenshot-1000.png").apply { writeBytes(byteArrayOf(1)) }
+        val middle = dir.resolve("screenshot-2000.png").apply { writeBytes(byteArrayOf(2)) }
+        val newest = dir.resolve("screenshot-3000.png").apply { writeBytes(byteArrayOf(3)) }
+
+        BugReport.prunePersistedScreenshots(dir, keepNewest = 2)
+
+        newest.exists() shouldBe true
+        middle.exists() shouldBe true
+        oldest.exists() shouldBe false
+    }
+
+    @Test
+    fun `the just-shared screenshot survives the next capture cycle`(@TempDir tmp: Path) {
+        // Regression scenario: share bug report A, then trigger bug report B.
+        // B's pre-write prune must leave A's file (and therefore A's shared URI)
+        // intact instead of deleting every file in the directory.
+        val dir = tmp.toFile()
+        val reportA = dir.resolve("screenshot-1000.png").apply { writeBytes(byteArrayOf(1)) }
+
+        BugReport.prunePersistedScreenshots(dir, keepNewest = 2)
+        val reportB = dir.resolve("screenshot-2000.png").apply { writeBytes(byteArrayOf(2)) }
+
+        reportA.exists() shouldBe true
+        reportB.exists() shouldBe true
+    }
+
+    @Test
+    fun `prune ignores unrelated files`(@TempDir tmp: Path) {
+        val dir = tmp.toFile()
+        val unrelated = dir.resolve("notes.txt").apply { writeBytes(byteArrayOf(9)) }
+        repeat(5) { index ->
+            dir.resolve("screenshot-${1000 + index}.png").writeBytes(byteArrayOf(index.toByte()))
+        }
+
+        BugReport.prunePersistedScreenshots(dir, keepNewest = 2)
+
+        unrelated.exists() shouldBe true
+        dir.listFiles().orEmpty().map { it.name }.filter { it.startsWith("screenshot-") }.sorted() shouldBe
+            listOf("screenshot-1003.png", "screenshot-1004.png")
+    }
+}

--- a/app/src/test/kotlin/app/clothescast/diag/BugReportScreenshotRecycleTest.kt
+++ b/app/src/test/kotlin/app/clothescast/diag/BugReportScreenshotRecycleTest.kt
@@ -1,0 +1,88 @@
+package app.clothescast.diag
+
+import android.graphics.Bitmap
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+/**
+ * Covers the bug-report screenshot buffer cleanup. The capture allocates a
+ * full-window ARGB_8888 bitmap (10-30 MB on current phones), and the original
+ * code dropped it unrecycled whenever PixelCopy failed or the caller was
+ * cancelled mid-capture — transient memory pressure that lingered until the
+ * next GC. Every path that doesn't hand the bitmap to the caller must recycle
+ * it; the one path that does must hand it over live.
+ */
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [35])
+class BugReportScreenshotRecycleTest {
+    private fun newBitmap(): Bitmap = Bitmap.createBitmap(2, 2, Bitmap.Config.ARGB_8888)
+
+    @Test
+    fun successfulCopyReturnsTheBitmapUnrecycled(): Unit = runBlocking {
+        val bitmap = newBitmap()
+
+        val result = BugReport.awaitPixelCopyInto(bitmap) { onResult -> onResult(true) }
+
+        (result === bitmap) shouldBe true
+        bitmap.isRecycled shouldBe false
+    }
+
+    @Test
+    fun failedCopyRecyclesTheBitmap(): Unit = runBlocking {
+        val bitmap = newBitmap()
+
+        val result = BugReport.awaitPixelCopyInto(bitmap) { onResult -> onResult(false) }
+
+        result.shouldBeNull()
+        bitmap.isRecycled shouldBe true
+    }
+
+    @Test
+    fun synchronousRequestFailureRecyclesTheBitmap(): Unit = runBlocking {
+        val bitmap = newBitmap()
+
+        val result = BugReport.awaitPixelCopyInto(bitmap) { throw IllegalStateException("boom") }
+
+        result.shouldBeNull()
+        bitmap.isRecycled shouldBe true
+    }
+
+    @Test
+    fun cancellationBeforeTheResultRecyclesTheBitmapWhenTheCopyLands(): Unit = runBlocking {
+        val bitmap = newBitmap()
+        var deliverResult: ((Boolean) -> Unit)? = null
+        val job = launch(start = CoroutineStart.UNDISPATCHED) {
+            BugReport.awaitPixelCopyInto(bitmap) { onResult -> deliverResult = onResult }
+        }
+        job.cancelAndJoin()
+
+        // PixelCopy may still be writing into the buffer until its callback
+        // fires, so cancellation alone must not recycle...
+        bitmap.isRecycled shouldBe false
+
+        // ...but once the (now unwanted) result lands, the buffer is freed.
+        deliverResult!!(true)
+        bitmap.isRecycled shouldBe true
+    }
+
+    @Test
+    fun cancellationBeforeAFailedResultRecyclesTheBitmap(): Unit = runBlocking {
+        val bitmap = newBitmap()
+        var deliverResult: ((Boolean) -> Unit)? = null
+        val job = launch(start = CoroutineStart.UNDISPATCHED) {
+            BugReport.awaitPixelCopyInto(bitmap) { onResult -> deliverResult = onResult }
+        }
+        job.cancelAndJoin()
+
+        deliverResult!!(false)
+        bitmap.isRecycled shouldBe true
+    }
+}

--- a/app/src/test/kotlin/app/clothescast/diag/BugReportShareTest.kt
+++ b/app/src/test/kotlin/app/clothescast/diag/BugReportShareTest.kt
@@ -11,6 +11,7 @@ import org.junit.After
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Robolectric
+import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
 import org.robolectric.shadows.ShadowToast
 
@@ -115,6 +116,26 @@ class BugReportShareTest {
         )
 
         retained shouldBe false
+        ShadowToast.getLatestToast() shouldBe null
+    }
+
+    @Test
+    fun `a share that outlives its screen still opens the chooser`(): Unit = runBlocking {
+        // The share runs on the application scope, so the Activity that started
+        // it can be gone by the time the chooser launches. Starting from a
+        // torn-down Activity targets a dead token, so it falls back to the
+        // application context — the report still reaches the sheet.
+        activity.finish()
+
+        BugReport.share(
+            activity,
+            includeScreenshot = false,
+            mainDispatcher = Dispatchers.Unconfined,
+            payloadCollect = { _, _ -> "report" },
+            clipboardWrite = { _, _ -> false },
+        )
+
+        shadowOf(activity.application).nextStartedActivity.shouldNotBeNull()
         ShadowToast.getLatestToast() shouldBe null
     }
 

--- a/app/src/test/kotlin/app/clothescast/diag/BugReportShareTest.kt
+++ b/app/src/test/kotlin/app/clothescast/diag/BugReportShareTest.kt
@@ -1,0 +1,139 @@
+package app.clothescast.diag
+
+import androidx.activity.ComponentActivity
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowToast
+
+/**
+ * [BugReport.share] must never turn a failure while collecting the report into
+ * another crash — the report is most useful right after something has already
+ * gone wrong — must say so when neither delivery route landed, and must report
+ * back whether anything was actually retained, because the post-crash banner
+ * dismisses itself on that answer. The payload build, the screenshot capture,
+ * the clipboard write, the chooser launch, and the main-thread hop are all
+ * injected, so every outcome is drivable without a real window,
+ * `ClipboardManager`, or share target.
+ */
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [35])
+class BugReportShareTest {
+
+    private val activity: ComponentActivity =
+        Robolectric.buildActivity(ComponentActivity::class.java).setup().get()
+
+    @After
+    fun tearDown() {
+        ShadowToast.reset()
+    }
+
+    @Test
+    fun `a failed payload collection still shares a report carrying the recent log`(): Unit = runBlocking {
+        DiagLog.i("BugReportShareTest", "a marker line")
+        var shared: String? = null
+
+        BugReport.share(
+            activity,
+            includeScreenshot = false,
+            mainDispatcher = Dispatchers.Unconfined,
+            payloadCollect = { _, _ -> error("preferences unreadable") },
+            clipboardWrite = { _, text -> shared = text; true },
+            chooserLaunch = { _, _, _ -> true },
+        )
+
+        shared.shouldNotBeNull()
+        shared!! shouldContain "Report collection failed"
+        shared!! shouldContain "--- Recent log"
+    }
+
+    @Test
+    fun `a collection failure does not escape into the caller's scope`(): Unit = runBlocking {
+        // The share runs from a tap; an escaping throwable would take the app
+        // down — the one thing a bug-report path must never do.
+        val retained = BugReport.share(
+            activity,
+            includeScreenshot = false,
+            mainDispatcher = Dispatchers.Unconfined,
+            payloadCollect = { _, _ -> throw OutOfMemoryError("simulated") },
+            clipboardWrite = { _, _ -> true },
+            chooserLaunch = { _, _, _ -> true },
+        )
+
+        retained shouldBe true
+    }
+
+    @Test
+    fun `neither route landing tells the user and reports nothing retained`(): Unit = runBlocking {
+        val retained = BugReport.share(
+            activity,
+            includeScreenshot = false,
+            mainDispatcher = Dispatchers.Unconfined,
+            payloadCollect = { _, _ -> "report" },
+            clipboardWrite = { _, _ -> false },
+            chooserLaunch = { _, _, _ -> false },
+        )
+
+        retained shouldBe false
+        ShadowToast.getLatestToast().shouldNotBeNull()
+    }
+
+    @Test
+    fun `a throwing clipboard or chooser is survivable and still reported`(): Unit = runBlocking {
+        val retained = BugReport.share(
+            activity,
+            includeScreenshot = false,
+            mainDispatcher = Dispatchers.Unconfined,
+            payloadCollect = { _, _ -> "report" },
+            clipboardWrite = { _, _ -> throw SecurityException("no clipboard access") },
+            chooserLaunch = { _, _, _ -> throw IllegalStateException("no share target") },
+        )
+
+        retained shouldBe false
+        ShadowToast.getLatestToast().shouldNotBeNull()
+    }
+
+    @Test
+    fun `an opened chooser without a clipboard copy is not a retained report`(): Unit = runBlocking {
+        // The sheet can still be backed out of, and ACTION_SEND gives no
+        // delivery callback — so the crash banner must stay up for a retry.
+        val retained = BugReport.share(
+            activity,
+            includeScreenshot = false,
+            mainDispatcher = Dispatchers.Unconfined,
+            payloadCollect = { _, _ -> "report" },
+            clipboardWrite = { _, _ -> false },
+            chooserLaunch = { _, _, _ -> true },
+        )
+
+        retained shouldBe false
+        ShadowToast.getLatestToast() shouldBe null
+    }
+
+    @Test
+    fun `a text-only share never captures a screenshot`(): Unit = runBlocking {
+        var captured = false
+
+        BugReport.share(
+            activity,
+            includeScreenshot = false,
+            mainDispatcher = Dispatchers.Unconfined,
+            payloadCollect = { _, _ -> "report" },
+            screenshotCapture = { captured = true; null },
+            clipboardWrite = { _, _ -> true },
+            chooserLaunch = { _, _, _ -> true },
+        )
+
+        // The post-crash banner shares text-only: the screen visible now is from
+        // a different run than the crash.
+        captured shouldBe false
+    }
+}


### PR DESCRIPTION
Cross-pollination pass across the three apps: fixes that already landed in Type Launcher's and Simmo's bug-report paths, applied here. Each is a real failure mode in this repo, not a cosmetic sync.

## `Keep a shared bug report's screenshot from disappearing`
Each capture wiped the whole `bug-reports` cache directory before writing its PNG. A FileProvider URI from an earlier share can still be held by its target — an unsent email draft, a messaging app that reads attachments lazily — so the sweep broke that grant retroactively and the attachment failed with `FileNotFoundException` when the target finally read it. Pruning now keeps the two most recent captures.

Two more in the same path: the full-window ARGB_8888 buffer (10-30 MB) was stranded unrecycled whenever PixelCopy failed, its request threw, or the caller was cancelled mid-capture; and PNG compression plus the prune ran on the main thread, long enough to jank the sheet animating in. Both fixed (persist on `Dispatchers.IO`, and `CancellationException` re-thrown instead of swallowed, per AGENTS' error-handling rule).

## `Keep bug reports small enough for the share sheet to take`
Only the log line count was capped; the settings dump and the previous run's crash file rode along unbounded. The text crosses Binder twice (clipboard, then the chooser's `ACTION_SEND` extra) against a ~1 MB per-process buffer, and strings parcel as UTF-16 — and since both hand-offs are best-effort, an over-large report made the tap do nothing at all. Each section is now bounded (settings 24k, crash 16k, log 20k), and the crash and log sections keep their **newest** lines, since a crash entry sits at the end of a log. A single line that alone exceeds its budget is clamped rather than passed through — `cacheDir` survives app upgrades, so `last-crash.txt` from an older build can hold one arbitrarily long line.

## `Say when a bug report can't be built or shared`
A throw while collecting the payload escaped into the caller's scope — a tap — and took the app down. (The per-read `coRunCatching` calls covered the suspend reads, but not the crash-file read, the prose render, or the assembly around them.) It now falls back to a minimal report that still carries the in-memory log. And a tap reaching neither the sheet nor the clipboard looked identical to one that did nothing; it now says so. `share()` also returns whether anything was retained, and the payload build moves off the main thread.

## `Finish sharing a bug report after leaving the screen`
The share ran on the composition scope from all three entry points (overflow menu, About, crash banner), and each leaves composition as the share starts. Since the hand-off suspends, the app could cancel its own share partway through. It now runs on `applicationScope`. Because that means the coroutine can outlive the Activity, the window-bound work degrades instead of targeting a dead token: a finishing/destroyed Activity skips the capture, and the chooser launches from the application context with `NEW_TASK`.

The crash banner also acknowledged the crash unconditionally, so a share that reached nobody still dismissed the banner. It now acknowledges only a retained report.

## Privacy
No change to what leaves the device. The report's contents are unchanged except for being bounded — sections are truncated, never added to — and it still only leaves on an explicit tap through the share sheet. The new Toast contains no user data.

## Test plan
- `BugReportScreenshotPruneTest` — the just-shared capture survives the next capture cycle; unrelated files aren't touched.
- `BugReportScreenshotRecycleTest` — every non-hand-off path recycles the buffer, including a result delivered after cancellation.
- `BugReportBoundsTest` — oversized settings / crash / log sections each stay under the ceiling and keep their newest lines; a single oversized line is clamped.
- `BugReportShareTest` — collection throws, clipboard fails, chooser fails, both fail, one lands, share outlives its screen, text-only.
- `./gradlew :core:domain:test :core:data:test :app:testDebugUnitTest :app:assembleDebug` green locally.
- `:app:lintDebug` fails, but on 43 **pre-existing** errors (`NonObservableLocale` in `TodayPreviews.kt`, older untranslated strings, a mediarouter restricted API) — none in the files this touches, and CI doesn't run lint.
- Not verified on a device: the real share-sheet hand-off, the FileProvider grant, and the Toast still want an eyeball on hardware.

## Strings
One new base string (`bug_report_share_failed`, "Couldn't share the bug report"), English-only with `tools:ignore="MissingTranslation"` and a `TODO: translate` comment. Wording matches what Simmo already ships for the same case.

## Related PRs in this cross-pollination pass
https://github.com/mikelward/clothescast/pull/1103
https://github.com/mikelward/typelauncher/pull/594
https://github.com/mikelward/simmo/pull/109