### PR TITLE
docs: agent rules — asking questions, drive to merge, git worktree

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,13 @@ new rule the first time something bites you, not the third.
   turn — ask the most important one, wait for the answer, then ask the
   next if you still need it. A wall of bundled questions is harder to
   answer than a short back-and-forth.
+- **Ask in chat, never with `AskUserQuestion`.** That's Claude Code's
+  multiple-choice question prompt, and it's broken in the Claude mobile
+  app — a question asked through it may be unanswerable. Plain chat also
+  keeps the question, its context, and the answer in one readable thread.
+- **After asking, stop and wait for the answer.** Don't proceed on an
+  assumed answer, pick a "recommended" option yourself, or keep working on
+  the part the question affects.
 - **Don't interrupt.** Never fire off a question while the user is still
   typing. Let them finish; a half-typed message isn't an invitation to
   jump in.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,9 @@ new rule the first time something bites you, not the third.
 
 - **Linear history.** Never merge — rebase. The repo's PRs land as a linear
   chain on `main`. A merge commit in a PR is a sign something went wrong.
+- **Use `git worktree` when it's available.** Give each branch its own
+  worktree instead of switching branches in place, so work in progress on one
+  branch isn't disturbed by work on another.
 - **Clean up unmerged commits before pushing for review.** Anything still
   on a feature branch (not yet merged to `main`) is scratch space — amend,
   squash, reorder, split, drop, rebase onto a different base as needed.
@@ -180,6 +183,10 @@ new rule the first time something bites you, not the third.
 
 - Use the `mcp__github__*` MCP tools for *all* GitHub operations. The `gh`
   CLI is **not** available in this sandbox.
+- **"Drive to merge"** is shorthand for the whole loop: open the PR, send it
+  for Codex review, address every review comment — fix it if you agree, reply
+  on the thread saying why if you don't — and merge once CI is green and Codex
+  has left its thumbs up.
 - Open PRs as **ready for review** (non-draft) immediately — don't wait for
   CI to go green or for an eyeball pass before marking them ready.
 - **Keep PR title and body in sync with the branch on every push.** A PR's


### PR DESCRIPTION
Records three working-practice rules in the agent guide.

**Asking questions** (*Talking to the user*). Never ask via the `AskUserQuestion` tool — it's broken in the Claude mobile app, so a question asked through it can be impossible to answer. Ask in plain chat, then stop and wait for the answer rather than assuming one or picking a "recommended" option.

**"Drive to merge"** (*GitHub*). Defines the shorthand: open the PR, send it for Codex review, address every review comment — fix it if you agree, reply on the thread saying why if you don't — and merge once CI is green and Codex has left its thumbs up.

**`git worktree`** (*Commits and PRs*). Use it when available, so parallel branches don't fight over one working tree.

Docs-only; the `docs:` subject prefixes keep both commits out of the Play "What's new".

The same three rules are going into the agent guides of the other repos in this set, so the guidance is identical everywhere.