### PR TITLE
ci: move every action off deprecated Node 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           # `app/build.gradle.kts` derives `versionCode` from
           # `git rev-list --count HEAD`. Shallow clones return 1 every time,
@@ -74,7 +74,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref || github.ref }}
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 21
@@ -83,16 +83,16 @@ jobs:
         # AGP must be loadable for Gradle to configure :app, even when only
         # running :core:* tasks. Pre-installing platform 36 + build-tools 36.0.0
         # avoids on-demand downloads at configure time.
-        # Pinned to a specific commit SHA (rather than the floating @v3 tag)
+        # Pinned to a specific commit SHA (rather than the floating @v4 tag)
         # so a compromised upstream release can't silently swap in malicious
         # code on our next CI run — same discipline as the FAD / Play upload
-        # actions below. SHA is android-actions/setup-android v3.2.2.
-        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3.2.2
+        # actions below. SHA is android-actions/setup-android v4.0.1.
+        uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4.0.1
         with:
           packages: 'platforms;android-36 build-tools;36.0.0 platform-tools'
 
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v5
         with:
           cache-read-only: ${{ github.ref != 'refs/heads/main' }}
 
@@ -159,7 +159,7 @@ jobs:
         # Skipped on cancellation so a manually-cancelled run doesn't wipe the
         # comment from a still-real failure.
         if: ${{ !cancelled() && github.event_name == 'pull_request' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const marker = '<!-- ci-jvm-tests -->';
@@ -179,7 +179,7 @@ jobs:
 
       - name: Post tail of gradle log on failure
         if: failure() && github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');
@@ -206,7 +206,7 @@ jobs:
 
       - name: Upload test reports
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-reports
           path: |
@@ -319,7 +319,7 @@ jobs:
           success() &&
           github.event_name == 'pull_request' &&
           github.event.pull_request.head.repo.full_name == github.repository
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');
@@ -462,7 +462,7 @@ jobs:
         # so reviewers on a fork PR (where the commit-back step is skipped
         # for lack of token write access) can still download and eyeball them.
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ui-preview-snapshots
           path: app/snapshots/
@@ -491,25 +491,25 @@ jobs:
     # each of which `if:`-gates secret access to push/dispatch on main).
     if: github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/main'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           # See unit-tests job above — versionCode comes from rev-list --count.
           fetch-depth: 0
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 21
 
       - name: Set up Android SDK
         # SHA-pinned — see rationale on the unit-tests job's copy of this step.
-        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3.2.2
+        uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4.0.1
         with:
           packages: 'platforms;android-36 build-tools;36.0.0 platform-tools'
 
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v5
         with:
           cache-read-only: ${{ github.ref != 'refs/heads/main' }}
 
@@ -625,7 +625,7 @@ jobs:
         # Up here, before the release-AAB steps, so a bundleRelease failure
         # doesn't gate this artifact behind a now-failed `success()`.
         if: success()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: app-debug-apk
           path: app/build/outputs/apk/debug/*.apk
@@ -1086,7 +1086,7 @@ jobs:
         # even after the auto-upload step below so the AAB is recoverable if the
         # Play upload fails (or for ad-hoc browser uploads to other tracks).
         if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main' && success()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: app-release-aab
           path: app/build/outputs/bundle/release/app-release.aab
@@ -1119,7 +1119,7 @@ jobs:
         # Same rationale as the JVM job — drops stale failure comments on a
         # clean re-run so the PR doesn't accumulate.
         if: ${{ !cancelled() && github.event_name == 'pull_request' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const marker = '<!-- ci-android-build -->';
@@ -1139,7 +1139,7 @@ jobs:
 
       - name: Post tail of gradle log on failure
         if: failure() && github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');
@@ -1165,7 +1165,7 @@ jobs:
 
       - name: Upload build log
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: android-build-log
           path: /tmp/android-build.log


### PR DESCRIPTION
## What

GitHub Actions runners now force Node-20 actions onto Node 24 and annotate every run with a deprecation warning. simmo surfaced it first, but this repo was the worst affected of the three: **six** actions still declared `runs.using: node20`. All six move to their first (or current) node24 release.

| Action | From | To | Runtime |
| --- | --- | --- | --- |
| `actions/checkout` | `@v4` | `@v5` | node24 |
| `actions/setup-java` | `@v4` | `@v5` | node24 |
| `gradle/actions/setup-gradle` | `@v4` | `@v5` | node24 |
| `actions/github-script` | `@v7` | `@v8` | node24 |
| `actions/upload-artifact` | `@v4` | `@v7` | node24 |
| `android-actions/setup-android` | `v3.2.2` | `v4.0.1` (`40fd30fb…`) | node24 |

Each step keeps its existing pinning style — the two `setup-android` steps stay SHA-pinned with the security rationale intact (comment updated to name v4.0.1), everything else stays on floating major tags.

## Version choices — not simply "latest" everywhere

Two of these deliberately stop short of the newest major:

- **`github-script` stops at v8.** v8 is node24 with no other breaking change. **v9 migrated the action to ESM, which removes `require` from the inline `script:` body** — and three of the six script steps here open with `const fs = require('fs')` to read a captured build log (`/tmp/jvm-tests.log`, `app/snapshots`, `/tmp/android-build.log`). v9 would break those at runtime while looking fine in review. v8 is the right target until those scripts are rewritten to use `import`.
- **`checkout` stops at v5.0.1**, matching the sibling repos rather than jumping to v6/v7. Both jobs check out with `fetch-depth: 0` because `versionCode` derives from `git rev-list --count`, and CI pushes `ci: regenerate UI snapshots` commits back to PR branches — so credential-persistence and fetch behavior here is load-bearing. v5 clears Node 20 while keeping both identical.
- **`upload-artifact` goes to v7.0.1** because `v5.x` is still node20 (checked against each tag's `action.yml`, not release-note prose) — v6 was the first release that actually clears the warning. v7 adds one new *optional* input, `archive`, defaulting to `true`, which is the pre-existing zip behavior, so `ui-preview-snapshots` and the APK/AAB artifacts download unchanged.

## One behavior change worth naming

**`setup-android` v4.0.0 raised its default `cmdline-tools-version` to 20.0.** Both jobs pass only `packages:` and take that default, so the SDK is now provisioned with a newer `sdkmanager`. This should be an improvement for `platforms;android-36 build-tools;36.0.0` — newer cmdline-tools know about newer platforms — and JDK 21 is well above its floor. But it's the one bump here that changes more than a Node runtime, so it deserves a real look at the CI logs for the "Set up Android SDK" step rather than just a green check.

The `packages` input itself is unchanged in v4.

## Compatibility

- Input surfaces are **identical** between old and new majors for every input this workflow passes (`fetch-depth`, `distribution`, `java-version`, `cache-read-only`, `script`, `name`/`path`/`if-no-files-found`/`retention-days`, `packages`). Verified by diffing `action.yml` input keys at each pair of tags.
- v6-era releases raised the minimum Actions runner to 2.327.1. Both jobs run on `ubuntu-latest`, so GitHub keeps the runner current.
- No `download-artifact` anywhere in the repo, so there's no upload/download version pairing to keep in step.
- The two remaining third-party actions were already clear: `r0adkll/upload-google-play` declares node24, and `wzieba/Firebase-Distribution-Github-Action` is a Docker action.

## Test plan

- Workflow YAML re-parses cleanly; every `uses:` in the file was resolved to its `action.yml` and confirmed `node24` or `docker`.
- No app or `:core:*` code touched, so no test, lint or snapshot impact — no snapshot drift expected and no image diffs to review.
- What to actually check on this run: CI green, **the Node 20 deprecation annotation gone from the run summary**, the "Set up Android SDK" step succeeding under cmdline-tools 20.0, and the six `github-script` steps still posting their PR comments (that's the `require('fs')` path exercised for real).
- The Play/Firebase upload steps only run on a push to `main`, so the `app-release-aab` upload on the `main` path isn't exercised here — it uses the same pin and inputs as the two that are.

Nothing about what leaves the device changes here; this is CI plumbing only.

Note: the same fix is going up in parallel on the sibling repos, which share this pipeline — both simmo and typelauncher needed only the single `upload-artifact` bump.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TKQbwrhnfYampcWVi2t8Jz)_